### PR TITLE
feat: tier-aware shared content rules + drop decodable vocabulary

### DIFF
--- a/claude_extensions/phases/gemini/_shared-content-rules-beginner.md
+++ b/claude_extensions/phases/gemini/_shared-content-rules-beginner.md
@@ -1,0 +1,37 @@
+## Language Quality Rules (Beginner Tier)
+
+### Russian Characters (HARD FAIL)
+
+**ы, э, ё, ъ** must NEVER appear in Ukrainian text. These are Russian-only characters.
+
+### Stress Mark Typography
+
+Use lowercase letters with a combining acute accent (´) on the stressed vowel:
+- Correct: ма́ма, анана́с, оса́, сосна́
+- Wrong: мА́ма, ананА́с, осА́, соснА́ (do NOT capitalize the stressed vowel)
+
+### IPA and Latin Transliteration (BANNED at ALL levels)
+
+Never include IPA symbols (ɑ, ɛ, ʃ, etc.) or bracketed pronunciation guides like `[ma-ma]`, `[a-na-nas]`, `[ˈmɑmɑ]`. The ONLY pronunciation aid is the stress mark (´) on the vowel.
+
+Latin transliterations are BANNED: never use kh, sh, ch, zh, ts, ya, yu, ye, shch.
+
+```markdown
+❌ WRONG: "мама [ˈmɑmɑ]" or "хліб (khlib)"
+✅ RIGHT: "**ма́ма** (mom)" or "**Х**, like the «ch» in Scottish «loch»"
+```
+
+### Typography
+
+- **ALWAYS** use Ukrainian angular quotes: «...» (never straight quotes "...")
+- Use ONLY vocabulary from the plan's `vocabulary_hints` — do NOT invent new terms
+
+### No Word Salad (HARD FAIL)
+
+Every paragraph must have ONE clear point and logical flow between sentences. Do NOT string together unrelated observations.
+
+### LLM Writing Patterns to Avoid
+
+1. **Grandiose openers** — don't inflate every topic
+2. **Stacked identical callouts** — same title max twice, vary types
+3. **"In this lesson, we will..."** — ALWAYS banned (formulaic opener)

--- a/claude_extensions/phases/gemini/_shared-content-rules-core.md
+++ b/claude_extensions/phases/gemini/_shared-content-rules-core.md
@@ -1,0 +1,100 @@
+## Language Quality Rules (Core Tier)
+
+### Russianisms (HARD FAIL if found)
+
+Scan your ENTIRE output for these. They cause automatic audit failure:
+
+| Russicism | Correct Ukrainian |
+|-----------|-------------------|
+| кушати | їсти |
+| приймати участь | брати участь |
+| получати | отримувати |
+| самий кращий | найкращий |
+| відноситися | стосуватися |
+| слідуючий | наступний |
+| любий (= будь-який) | будь-який |
+| на то, що | на те, що |
+| красивий | гарний |
+| прекрасне / прекрасний | чудовий / чудове |
+
+Also scan for Russian characters: **ы, э, ё, ъ** — these must NEVER appear in Ukrainian text.
+
+### English Calque Checklist
+
+As an English-dominant model, you may produce English-to-Ukrainian calques. Check and avoid:
+
+| English Pattern | WRONG Ukrainian | CORRECT Ukrainian |
+|---|---|---|
+| "will have" | буду мати | матиму |
+| "do work" | робити роботу | працювати |
+| "save money" | зберегти гроші | заощадити гроші |
+| "make a decision" | зробити рішення | прийняти рішення |
+| "take a photo" | брати фото | фотографувати / робити фото |
+| "have attention" | мати увагу | звертати увагу |
+| "give an answer" | давати відповідь | відповідати |
+| "make sense" | робити сенс | мати сенс |
+
+### Euphony / Милозвучність (WARNING if violated)
+
+Ukrainian prose must follow euphony rules:
+
+| Rule | Avoid (Bad) | Use (Good) |
+|------|-------------|------------|
+| і → й between vowels | вона і Олена | вона й Олена |
+| й → і after consonant | він й Олена | він і Олена |
+| у → в before vowel | у Одесі | в Одесі |
+| в → у before в, ф | в вікні | у вікні |
+| в → у before consonant cluster | в зграї | у зграї |
+| з → із/зі before з, с, ш, ч | з зброєю | із зброєю (або зі) |
+| Vary conjunctions | він і вона і Іван | він і вона та Іван |
+
+Key: й can ONLY follow a vowel. After a consonant, always use і — even before a vowel.
+
+### Stress Mark Typography
+
+Use lowercase letters with a combining acute accent (´) on the stressed vowel:
+- Correct: ма́ма, анана́с, оса́, сосна́
+- Wrong: мА́ма, ананА́с, осА́, соснА́ (do NOT capitalize the stressed vowel)
+
+### IPA and Latin Transliteration (BANNED at ALL levels)
+
+Never include IPA symbols (ɑ, ɛ, ʃ, etc.) or bracketed pronunciation guides like `[ma-ma]`, `[a-na-nas]`, `[ˈmɑmɑ]`. The ONLY pronunciation aid is the stress mark (´) on the vowel.
+
+Latin transliterations are BANNED: never use kh, sh, ch, zh, ts, ya, yu, ye, shch.
+
+```markdown
+❌ WRONG: "мама [ˈmɑmɑ]" or "хліб (khlib)"
+✅ RIGHT: "**ма́ма** (mom)" or "**Х**, like the «ch» in Scottish «loch»"
+```
+
+### Typography
+
+- **ALWAYS** use Ukrainian angular quotes: «...» (never straight quotes "...")
+
+### No Word Salad (HARD FAIL)
+
+Every paragraph must have ONE clear point and logical flow between sentences. Do NOT string together unrelated observations.
+
+### LLM Writing Patterns to Avoid
+
+1. **"Це не просто X, а Y"** — max ONE in entire module
+2. **Grandiose openers** — don't inflate every topic
+3. **Purple prose** — no "багатогранний діамант", "хірургічного аналізу"
+4. **Duplicate greetings** — "Ласкаво просимо" ONCE (intro only)
+5. **Stacked identical callouts** — same title max twice, vary types
+6. **"In this lesson, we will..."** — ALWAYS banned (formulaic opener)
+7. **Repetitive transitions** — "It's worth noting...", «Варто зазначити...», «Давайте розглянемо...» flagged at 2+ occurrences
+
+### Anti-Robotic Writing
+
+- No 3+ sentences starting with the same phrase
+- Vary sentence openers across sections
+- No mechanical transitions («Далі ми побачимо...», «Тепер розглянемо...»)
+- Each section should have its own narrative arc
+
+### Active Voice Preference
+
+Ukrainian strongly prefers active constructions. Use passive only when the agent is truly unknown.
+
+Avoid: «Це може бути використано...», «Правило застосовується...»
+Prefer: «Ви можете використати...», «Ми застосовуємо правило...»

--- a/claude_extensions/phases/gemini/beginner-content.md
+++ b/claude_extensions/phases/gemini/beginner-content.md
@@ -13,22 +13,11 @@
 |------|---------|
 | `{RESEARCH_PATH}` | Research notes |
 | `{PLAN_PATH}` | Content outline, section word allocations, vocabulary_hints |
-| `{PLAN_PATH}` | Objectives, vocabulary_hints |
 | `{QUICK_REF_PATH}` | Level constraints, immersion % |
 
 Read ALL files before writing.
 
-## Resource Discoveries
-
-{VIDEO_DISCOVERY}
-
-{PRONUNCIATION_VIDEOS}
-
-## Module Constraints (HARD FAIL if violated)
-
-{PEDAGOGICAL_CONSTRAINTS}
-
-{DECODABLE_VOCABULARY}
+## Target Vocabulary (MANDATORY)
 
 **Target vocabulary** (from the plan — you MUST teach and use these words heavily):
 
@@ -40,9 +29,17 @@ Read ALL files before writing.
 - Match the syntactic complexity, sentence length, and vocabulary level of the provided textbook excerpts. Do not exceed their lexical density.
 - When textbook excerpts contain vocabulary or grammar not yet taught at this level, simplify or provide an English gloss in parentheses.
 
-NOTE: The textbook examples below are provided as INSPIRATION for the pedagogical approach, NOT as content to copy. For modules M15+, focus on the communicative patterns, not the letter/syllable exercises.
+## Resource Discoveries
+
+{VIDEO_DISCOVERY}
+
+{PRONUNCIATION_VIDEOS}
 
 {TEXTBOOK_EXAMPLES}
+
+## Module Constraints (HARD FAIL if violated)
+
+{PEDAGOGICAL_CONSTRAINTS}
 
 {CHECKPOINT_GUIDANCE}
 
@@ -101,9 +98,7 @@ Keep paragraphs short (3-5 sentences). Do NOT use abstract Ukrainian grammar ter
 ### Audit Gates (your content will be checked for)
 
 - **Word count**: minimum {WORD_TARGET} words
-- **Russianisms**: banned (кушати, получати, etc.)
 - **Russian characters**: ы, э, ё, ъ must NEVER appear
-- **Euphony**: і/й, у/в alternation
 - **Engagement callouts**: {ENGAGEMENT_MIN}+
 - **IPA/phonetic brackets**: BANNED
 
@@ -111,15 +106,14 @@ Keep paragraphs short (3-5 sentences). Do NOT use abstract Ukrainian grammar ter
 
 ---
 
-## Pre-Submission Checks
+## Boundaries
 
-1. **Plan compliance**: Does every point in the content_outline have dedicated prose?
-2. **Word count**: Does the total meet {WORD_TARGET}?
-3. **Language scan**: No Russianisms, no Russian characters, no IPA, no Latin transliteration?
-4. **Decodable vocabulary**: Does every Ukrainian word use only the allowed letter set?
-5. **Target vocabulary**: Are all target vocabulary words used in the content?
-
-{SELF_AUDIT_SNIPPET}
+- Do NOT generate activities or vocabulary tables (separate phase)
+- Do NOT add vocabulary outside the plan's vocabulary_hints
+- **VOCABULARY COVERAGE RULE:** All words from `vocabulary_hints` in the plan MUST appear at least once in the module content. Vocabulary listed but never used in the prose is a validation failure.
+- Do NOT skip sections from the content_outline
+- Do NOT write fewer than {WORD_TARGET} words
+- Do NOT use straight quotes "..." — always «...»
 
 ---
 
@@ -162,6 +156,17 @@ Total: {total} words (target: {WORD_TARGET})
 ===WORD_COUNTS===
 ```
 
+## Pre-Submission Checks
+
+*Mentally verify these before writing your Friction Report:*
+
+1. **Plan compliance**: Does every point in the content_outline have dedicated prose?
+2. **Word count**: Does the total meet {WORD_TARGET}?
+3. **Language scan**: No Russian characters, no IPA, no Latin transliteration?
+4. **Target vocabulary**: Are all target vocabulary words used in the content?
+
+{SELF_AUDIT_SNIPPET}
+
 ## Friction Report (MANDATORY)
 
 ```
@@ -174,12 +179,3 @@ Total: {total} words (target: {WORD_TARGET})
 **Proposed Tooling Fix**: {if applicable, or "N/A"}
 ===FRICTION_END===
 ```
-
-## Boundaries
-
-- Do NOT generate activities or vocabulary tables (separate phase)
-- Do NOT add vocabulary outside the plan's vocabulary_hints
-- **VOCABULARY COVERAGE RULE:** All words from `vocabulary_hints` in the plan MUST appear at least once in the module content. Vocabulary listed but never used in the prose is a validation failure.
-- Do NOT skip sections from the content_outline
-- Do NOT write fewer than {WORD_TARGET} words
-- Do NOT use straight quotes "..." — always «...»

--- a/curriculum/l2-uk-en/plans/a1/the-ukrainian-alphabet.yaml
+++ b/curriculum/l2-uk-en/plans/a1/the-ukrainian-alphabet.yaml
@@ -9,7 +9,6 @@ focus: grammar
 pedagogy: PPP
 phase: A1.1 [First Contact]
 word_target: 1200
-decodable_letters: "А О У І М Н Т К С Л"
 objectives:
 - Learner sees the full 33-letter Ukrainian alphabet as a coherent system
 - "Learner understands letter ≠ sound (букви vs звуки)"

--- a/scripts/build/pipeline_v5.py
+++ b/scripts/build/pipeline_v5.py
@@ -1456,7 +1456,7 @@ def _build_fix_prompt(ctx: ModuleContext, audit_output: str, content_only: bool,
     Instead of dumping 60 lines of audit output, this extracts specific
     failures and produces exact instructions Gemini can act on.
     """
-    from pipeline_lib import get_decodable_vocabulary, get_pedagogical_constraints
+    from pipeline_lib import get_pedagogical_constraints
 
     det_issues = deterministic_issues or []
     gate_failures = _extract_gate_failures(audit_output)
@@ -1507,9 +1507,8 @@ def _build_fix_prompt(ctx: ModuleContext, audit_output: str, content_only: bool,
     if ped_constraints:
         ped_section = f"\n## Constraints (do NOT violate while fixing)\n\n{ped_constraints}\n"
 
-    # Decodable vocabulary (compact)
-    decodable = get_decodable_vocabulary(ctx.track, ctx.module_num, ctx.plan)
-    decodable_section = f"\n{decodable}\n" if decodable else ""
+    # Decodable vocabulary removed (#841) — plan vocabulary_hints is source of truth
+    decodable_section = ""
 
     # Lexical sandbox — compact lemma list so fix agent stays on-vocabulary
     sandbox_section = ""

--- a/scripts/pipeline_lib.py
+++ b/scripts/pipeline_lib.py
@@ -414,94 +414,8 @@ def get_pedagogical_constraints(track: str, module_num: int, plan: dict | None =
 
 
 # ---------------------------------------------------------------------------
-# Decodable vocabulary for early A1 (VESUM-verified, charset-validated)
+# Decodable vocabulary removed in #841 — plan's vocabulary_hints is source of truth.
 # ---------------------------------------------------------------------------
-
-# Decodable charsets for early A1 modules (M1-M3)
-def _build_charset_from_plan(plan: dict) -> str:
-    """Build charset string from plan's decodable_letters field.
-
-    Plan declares e.g. `decodable_letters: "А О У І М Н Т К С Л"`.
-    Returns both upper and lower case variants for charset filtering.
-    If no decodable_letters field, returns empty string (no restriction).
-    """
-    letters_str = plan.get("decodable_letters", "")
-    if not letters_str:
-        return ""
-    letters = [l.strip() for l in letters_str.split() if l.strip()]
-    charset = ""
-    for letter in letters:
-        charset += letter.upper() + letter.lower()
-    return charset
-
-
-def _charset_filter(words: list[str], allowed: str) -> list[str]:
-    """Return only words whose characters are all in the allowed charset."""
-    allowed_set = set(allowed)
-    return [w for w in words if all(c in allowed_set for c in w)]
-
-
-def get_decodable_vocabulary(track: str, module_num: int, plan: dict) -> str:
-    """Return decodable word list if the plan declares decodable_letters, else empty.
-
-    Plans that need strict letter-decodability declare:
-        decodable_letters: "А О У І М Н Т К С Л"
-
-    Vocabulary is extracted from the plan's vocabulary_hints and filtered against
-    that charset. Plans without decodable_letters get no restriction.
-    """
-    charset = _build_charset_from_plan(plan)
-    if not charset:
-        return ""
-
-    # Extract vocabulary from plan (source of truth)
-    plan_words = _extract_plan_vocabulary(plan)
-    decodable = _charset_filter(plan_words, charset)
-
-    if not decodable:
-        return ""
-
-    upper_letters = sorted(set(c for c in charset if c.isupper()))
-    letter_list = ", ".join(upper_letters)
-
-    lines = [
-        f"DECODABLE VOCABULARY (only letters: {letter_list}):",
-        "Use ONLY these words in reading drills and prose examples.",
-        "Any word with a letter outside this set will FAIL the decodability audit gate.",
-        "Sight words from the plan are exempt — they are recognized as whole shapes,",
-        "not decoded letter-by-letter. Label them clearly.",
-        "Video pronunciation examples are also exempt (heard, not read).",
-        "",
-        f"Available decodable words: {', '.join(decodable)}",
-        "",
-        "If you need a word not on this list, check that ALL its letters are in the",
-        "allowed set above. Words with unknown letters need English translation.",
-    ]
-    return "\n".join(lines)
-
-
-def _extract_plan_vocabulary(plan: dict) -> list[str]:
-    """Extract Ukrainian words from plan's vocabulary_hints (all categories)."""
-    raw_hints = plan.get("vocabulary_hints", [])
-    if isinstance(raw_hints, dict):
-        all_hints = []
-        for key in ("required", "recommended", "sight_words"):
-            all_hints.extend(raw_hints.get(key, []))
-    else:
-        all_hints = raw_hints
-
-    words = []
-    for hint in all_hints:
-        if isinstance(hint, str):
-            # Extract Ukrainian word from "слово (word) — description" format
-            word = hint.split("(")[0].strip().split("—")[0].strip()
-            if word:
-                words.append(word)
-        elif isinstance(hint, dict):
-            w = hint.get("word", hint.get("uk", ""))
-            if w:
-                words.append(w.strip())
-    return words
 
 
 # ---------------------------------------------------------------------------
@@ -2294,7 +2208,7 @@ def build_placeholders(ctx: ModuleContext) -> None:
         "IMMERSION_RULE": ctx.immersion_rule,
         "LEVEL_CONSTRAINTS": ctx.level_constraints,
         "PEDAGOGICAL_CONSTRAINTS": get_pedagogical_constraints(ctx.track, ctx.module_num, ctx.plan),
-        "DECODABLE_VOCABULARY": get_decodable_vocabulary(ctx.track, ctx.module_num, ctx.plan),
+        "DECODABLE_VOCABULARY": "",  # Decodable system removed (#841) — plan vocabulary_hints is source of truth
         "STRUCTURAL_RULES": get_structural_rules(ctx.track, ctx.module_num),
         "H3_WORD_RANGE": get_h3_word_range(ctx.track, ctx.module_num),
         "EXPANSION_METHOD": get_expansion_method(ctx.track, ctx.module_num),
@@ -2419,16 +2333,25 @@ def build_placeholders(ctx: ModuleContext) -> None:
     else:
         placeholders["PRONUNCIATION_VIDEOS"] = ""
 
-    # Shared rules (injected into tier-specific prompts via placeholders)
-    placeholders["SHARED_CONTENT_RULES"] = _read_phase_file("_shared-content-rules.md")
+    # Shared rules — tier-aware: beginner gets minimal rules, core/seminar get full set
+    tier = _get_prompt_tier(ctx.track, ctx.module_num)
+    # Core and seminar share the same rules (can diverge later by adding a seminar file)
+    rules_tier = "beginner" if tier == "beginner" else "core"
+    _shared_rules_file = f"_shared-content-rules-{rules_tier}.md"
+    placeholders["SHARED_CONTENT_RULES"] = _read_phase_file(_shared_rules_file)
     placeholders["SHARED_ACTIVITY_RULES"] = _read_phase_file("_shared-activity-rules.md")
-    # Resolve {CONTENT_PATH} inside the snippet so nested placeholders expand correctly.
-    # fill_template does a single pass; snippets included via {SELF_AUDIT_SNIPPET} would
-    # otherwise leave {CONTENT_PATH} unresolved in the final prompt.
-    _self_audit_raw = _read_phase_file("_shared-self-audit.md")
-    placeholders["SELF_AUDIT_SNIPPET"] = _self_audit_raw.replace(
-        "{CONTENT_PATH}", placeholders.get("CONTENT_PATH", "")
-    )
+    # Self-audit: beginner tier skips it (validate phase catches everything);
+    # core/seminar keep the full self-audit snippet.
+    if tier == "beginner":
+        placeholders["SELF_AUDIT_SNIPPET"] = ""
+    else:
+        # Resolve {CONTENT_PATH} inside the snippet so nested placeholders expand correctly.
+        # fill_template does a single pass; snippets included via {SELF_AUDIT_SNIPPET} would
+        # otherwise leave {CONTENT_PATH} unresolved in the final prompt.
+        _self_audit_raw = _read_phase_file("_shared-self-audit.md")
+        placeholders["SELF_AUDIT_SNIPPET"] = _self_audit_raw.replace(
+            "{CONTENT_PATH}", placeholders.get("CONTENT_PATH", "")
+        )
 
     # Lexical Sandbox removed in #820 — VESUM post-validation replaces it.
     # Placeholder kept as empty string so existing templates don't break.
@@ -2752,6 +2675,23 @@ def _prefetch_sources_for_phase_B(ctx: ModuleContext) -> str:
     return "\n\n".join(results[:8])  # Cap at 8 excerpts
 
 
+def _clean_textbook_text(text: str) -> str:
+    """Strip OCR artifacts from textbook text without destroying numbered lists.
+
+    Removes: stray brackets [], excessive blank lines, stray pipe characters.
+    Preserves: numbered lists (1. Foo), lettered sub-tasks (А. Б. В.).
+    """
+    # Remove stray brackets — preserve markdown links [text](url) and images ![alt](url)
+    text = re.sub(r'\[([^\]]*)\]\(([^)]*)\)', r'MDLINK\1MDURL\2MDEND', text)  # protect links
+    text = re.sub(r'[\[\]]', '', text)  # strip stray brackets
+    text = re.sub(r'MDLINK(.*?)MDURL(.*?)MDEND', r'[\1](\2)', text)  # restore links
+    # Collapse 3+ blank lines to 2
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    # Remove stray pipe chars at start/end of lines (OCR table artifacts)
+    text = re.sub(r'^\|?\s*\|\s*$', '', text, flags=re.MULTILINE)
+    return text.strip()
+
+
 def _prefetch_textbook_examples(ctx: ModuleContext) -> str:
     """Pre-fetch textbook/encyclopedia examples from RAG for content generation.
 
@@ -2813,7 +2753,7 @@ def _prefetch_textbook_examples(ctx: ModuleContext) -> str:
                     seen_chunks.add(cid)
                     source = hit.get("source", "")
                     section = hit.get("section", "")
-                    text = hit.get("text", "")[:500]
+                    text = _clean_textbook_text(hit.get("text", "")[:500])
                     results.append(
                         f"**{source}** — {section}:\n```\n{text}\n```"
                     )
@@ -2891,7 +2831,7 @@ def _prefetch_textbook_examples(ctx: ModuleContext) -> str:
                 author = hit.get("author", "")
                 hit_grade = hit.get("grade", "")
                 section = hit.get("section_title", hit.get("section", ""))
-                text = hit.get("text", "")[:500]
+                text = _clean_textbook_text(hit.get("text", "")[:500])
                 label = f"Grade {hit_grade}, {author}" if author else f"Grade {hit_grade}"
                 results.append(
                     f"**{label}** — {section}:\n```\n{text}\n```"
@@ -2900,7 +2840,12 @@ def _prefetch_textbook_examples(ctx: ModuleContext) -> str:
     if not results:
         return ""
 
-    return header + "\n\n".join(results[:6])
+    note = (
+        "\n\nNOTE: The textbook examples above are provided as INSPIRATION "
+        "for the pedagogical approach, NOT as content to copy. For modules M15+, "
+        "focus on the communicative patterns, not the letter/syllable exercises.\n"
+    )
+    return header + "\n\n".join(results[:6]) + note
 
 
 def _get_textbook_grade(ctx: ModuleContext) -> str:

--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -2,7 +2,7 @@
 
 Covers: _parse_section, _build_section_budget_table, _check_archive_fits_outline,
 get_level_constraints, get_activity_config, get_item_minimums_table,
-bilingualify_section_titles, get_pedagogical_constraints, get_decodable_vocabulary,
+bilingualify_section_titles, get_pedagogical_constraints,
 get_structural_rules, get_h3_word_range, get_expansion_method, get_track_skill,
 get_immersion_rule, get_level_label, track_to_level_focus, load_state,
 v5 phase terminology (no legacy Phase 2: labels), SELF_AUDIT_SNIPPET CONTENT_PATH resolution.
@@ -447,59 +447,74 @@ class TestGetPedagogicalConstraints:
         assert r1 != r15
 
 
+    # Decodable vocabulary tests removed in #841 — system was dropped.
+
+
 # ============================================================================
-# get_decodable_vocabulary
+# _get_prompt_tier — tier-aware shared rules (#841)
 # ============================================================================
 
-class TestGetDecodableVocabulary:
-    def test_non_a1_returns_empty(self):
-        from pipeline_lib import get_decodable_vocabulary
-        assert get_decodable_vocabulary("b1", 1, {}) == ""
+class TestGetPromptTier:
+    def test_a1_is_beginner(self):
+        from pipeline_lib import _get_prompt_tier
+        assert _get_prompt_tier("a1", 1) == "beginner"
+        assert _get_prompt_tier("a1", 14) == "beginner"
+        assert _get_prompt_tier("a1", 25) == "beginner"
 
-    def test_m4_plus_returns_empty(self):
-        from pipeline_lib import get_decodable_vocabulary
-        assert get_decodable_vocabulary("a1", 4, {}) == ""
+    def test_a2_early_is_beginner(self):
+        from pipeline_lib import _get_prompt_tier
+        assert _get_prompt_tier("a2", 1) == "beginner"
+        assert _get_prompt_tier("a2", 20) == "beginner"
 
-    def test_plan_with_decodable_letters(self):
-        """Plans with decodable_letters get charset-filtered vocabulary."""
-        from pipeline_lib import get_decodable_vocabulary
-        plan = {
-            "decodable_letters": "А О У І М Н Т К С Л",
-            "vocabulary_hints": {
-                "required": ["мама (mom) — decodable", "тато (dad) — decodable"],
-                "recommended": ["сон (dream) — decodable"],
-            },
-        }
-        result = get_decodable_vocabulary("a1", 1, plan)
-        assert "мама" in result
-        assert "тато" in result
-        assert "сон" in result
+    def test_a2_late_is_core(self):
+        from pipeline_lib import _get_prompt_tier
+        assert _get_prompt_tier("a2", 21) == "core"
+        assert _get_prompt_tier("a2", 50) == "core"
 
-    def test_plan_filters_non_decodable(self):
-        """Words with letters outside decodable_letters are excluded."""
-        from pipeline_lib import get_decodable_vocabulary
-        plan = {
-            "decodable_letters": "А О У І М Н Т К С Л",
-            "vocabulary_hints": {
-                "required": ["мама (mom) — decodable", "хліб (bread) — uses Х Б"],
-            },
-        }
-        result = get_decodable_vocabulary("a1", 1, plan)
-        assert "мама" in result
-        word_line = [l for l in result.splitlines() if l.startswith("Available")][0]
-        assert "хліб" not in word_line
+    def test_b1_is_core(self):
+        from pipeline_lib import _get_prompt_tier
+        assert _get_prompt_tier("b1", 1) == "core"
 
-    def test_plan_without_decodable_letters(self):
-        """Plans without decodable_letters get no restriction."""
-        from pipeline_lib import get_decodable_vocabulary
-        plan = {"vocabulary_hints": {"required": ["мама (mom)"]}}
-        assert get_decodable_vocabulary("a1", 1, plan) == ""
-        assert get_decodable_vocabulary("a1", 2, plan) == ""
-        assert get_decodable_vocabulary("b1", 1, plan) == ""
+    def test_hist_is_seminar(self):
+        from pipeline_lib import _get_prompt_tier
+        assert _get_prompt_tier("hist", 1) == "seminar"
 
-    def test_empty_plan(self):
-        from pipeline_lib import get_decodable_vocabulary
-        assert get_decodable_vocabulary("a1", 1, {}) == ""
+    def test_no_hardcoded_level_checks(self):
+        """Selection uses _get_prompt_tier, not hardcoded level/module checks."""
+        import inspect
+        from pipeline_lib import build_placeholders
+        source = inspect.getsource(build_placeholders)
+        # The tier selection for shared rules should use _get_prompt_tier, not
+        # direct string comparisons like 'ctx.track == "a1"'
+        assert "_get_prompt_tier" in source
+
+
+# ============================================================================
+# _clean_textbook_text (#841)
+# ============================================================================
+
+class TestCleanTextbookText:
+    def test_preserves_numbered_lists(self):
+        from pipeline_lib import _clean_textbook_text
+        text = "1. Вступ\n2. Основна частина\n3. Висновок"
+        assert _clean_textbook_text(text) == text
+
+    def test_collapses_excessive_blanks(self):
+        from pipeline_lib import _clean_textbook_text
+        text = "Line 1\n\n\n\n\nLine 2"
+        assert _clean_textbook_text(text) == "Line 1\n\nLine 2"
+
+    def test_removes_stray_brackets(self):
+        from pipeline_lib import _clean_textbook_text
+        text = "Some [stray text"
+        result = _clean_textbook_text(text)
+        assert "[" not in result
+
+    def test_preserves_markdown_links(self):
+        from pipeline_lib import _clean_textbook_text
+        text = "See [this link](http://example.com) for details"
+        result = _clean_textbook_text(text)
+        assert "[this link](http://example.com)" in result
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Closes #841. Splits the monolithic `_shared-content-rules.md` (109 lines injected into every prompt) into tier-aware files so beginner modules get minimal rules (~37 lines) while core/seminar get the full set (~100 lines). Also drops the overengineered decodable vocabulary system.

- **AC1**: Tier-aware shared rules — beginner (minimal) vs core (full Russianisms/euphony/anti-robotic). Core serves both core and seminar tiers.
- **AC2**: Tier-aware self-audit — beginner skips it (validate phase catches everything)
- **AC3**: Dropped decodable vocabulary system (`get_decodable_vocabulary`, `_build_charset_from_plan`, `_charset_filter`, `_extract_plan_vocabulary`). Removed `decodable_letters` from the-ukrainian-alphabet plan.
- **AC4**: `_clean_textbook_text()` strips OCR artifacts (stray brackets, excessive blanks, pipe chars) while preserving markdown links and numbered lists. NOTE text moved inside Python function.
- **AC5**: Beginner template reordered — vocabulary + videos in first 50 lines, constraints mid-section, shared rules + boundaries before output format
- **AC6**: `pytest tests/test_lint_prompts.py tests/test_pipeline_helpers.py` — 152 passed, 0 warnings
- **AC7**: Test builds per tier:
  | Tier | Module | Result |
  |------|--------|--------|
  | Beginner (A1 M1) | the-ukrainian-alphabet | **PASS** — 1596w, 100% VESUM |
  | Beginner (A1 M15) | the-living-verb-i | **PASS** — after fix loop |
  | Beginner (A2 M1) | the-dative-i-pronouns | FAIL — missing `## Summary` (structural, not template) |
  | Core (B1 M1) | how-to-talk-about-grammar | FAIL — under word count (pre-existing Gemini issue, core rules verified in prompt) |
  | Seminar (HIST M1) | trypillian-civilization | FAIL — under word count (seminar uses inline rules, not placeholder) |

## Reviews

- Gemini adversarial review (2 rounds on plan, 1 round on implementation): all findings addressed
- `/simplify` review: fixed bracket regex destroying markdown links, unified core/seminar duplicate, dedented orphaned comment

## Test plan

- [x] `pytest tests/test_lint_prompts.py` — 56 passed
- [x] `pytest tests/test_pipeline_helpers.py` — 96 passed
- [x] No hardcoded level/module checks in selection logic
- [x] Build a1 M1 with new template → PASS
- [x] Build a1 M15 with new template → PASS
- [x] Verify B1 prompt contains full Russianisms/Euphony rules
- [x] Verify seminar prompt unaffected (inline rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)