### PR TITLE
Integrate МійКлас grammar index into V6 build pipeline

### DIFF
--- a/data/miyklas/grammar_index.yaml
+++ b/data/miyklas/grammar_index.yaml
@@ -1,0 +1,649 @@
+# МійКлас (miyklas.com.ua) Ukrainian grammar theory — Grades 5-11, NUS aligned.
+#
+# Hand-curated topic→URL mapping for the V6 build pipeline.
+# URLs verified 2026-03-27 via WebFetch.
+#
+# Usage:
+#   - RESEARCH step: fetch theory page content for knowledge packet
+#   - ENRICH step: inject matching URLs into Ресурсі tab
+#
+# Matching: plan YAML `grammar` and `focus` fields are compared against
+# each entry's `tags` list using keyword overlap scoring.
+#
+# Issue: #1040
+
+version: "1.0"
+source: miyklas.com.ua
+updated: "2026-03-27"
+base_url: https://miyklas.com.ua
+
+topics:
+  # ── Grade 5: Phonetics ────────────────────────────────────────────
+  - title: "Голосні й приголосні звуки"
+    tags: [звуки, голосні, приголосні, фонетика, phonetics, vowels, consonants, sounds]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/golosni-i-prigolosni-zvuki-40864
+    grade: 5
+    category: phonetics
+
+  - title: "Приголосні м'які й тверді, дзвінкі й глухі"
+    tags: [м'які, тверді, дзвінкі, глухі, приголосні, consonants, soft, hard, voiced, voiceless]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/prigolosni-m-iaki-i-tverdi-dzvinki-i-glukhi-vimova-prigolosnikh-g-i-g-40885
+    grade: 5
+    category: phonetics
+
+  - title: "Алфавіт (абетка, азбука)"
+    tags: [алфавіт, абетка, літери, букви, alphabet, letters]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/poznachennia-zvukiv-movlennia-na-pismi-alfavit-abetka-azbuka-41217
+    grade: 5
+    category: phonetics
+
+  - title: "Співвідношення звуків і букв"
+    tags: [звуки, букви, співвідношення, letters, sounds, mapping]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/spivvidnoshennia-zvukiv-i-bukv-41281
+    grade: 5
+    category: phonetics
+
+  - title: "Склад. Основні правила переносу"
+    tags: [склад, перенос, syllable, hyphenation]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/sklad-osnovni-pravila-perenosu-41850
+    grade: 5
+    category: phonetics
+
+  - title: "Наголос"
+    tags: [наголос, stress, accent, ударение]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/nagolos-41958
+    grade: 5
+    category: phonetics
+
+  - title: "Ненаголошені голосні [е], [и], [о] в коренях слів"
+    tags: [ненаголошені, голосні, корінь, unstressed, vowels, root]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/vimova-nagoloshenikh-i-nenagoloshenikh-golosnikh-nenagolosheni-golosni-e-_-42492
+    grade: 5
+    category: phonetics
+
+  - title: "Уподібнення приголосних звуків"
+    tags: [уподібнення, приголосні, assimilation, consonants]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/vimova-prigolosnikh-zvukiv-upodibnennia-prigolosnikh-zvukiv-42793
+    grade: 5
+    category: phonetics
+
+  - title: "Спрощення в групах приголосних"
+    tags: [спрощення, приголосні, simplification, consonant clusters]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/sproshchennia-v-grupakh-prigolosnikh-41974
+    grade: 5
+    category: phonetics
+
+  - title: "Чергування голосних у коренях слів"
+    tags: [чергування, голосні, корінь, alternation, vowels]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/cherguvannia-golosnikh-u-koreniakh-sliv-43524
+    grade: 5
+    category: phonetics
+
+  - title: "Зміни приголосних при словотворенні й формотворенні"
+    tags: [зміни, приголосні, словотворення, consonant changes, word formation]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/zmini-prigolosnikh-pri-slovotvorenni-i-formotvorenni-44357
+    grade: 5
+    category: phonetics
+
+  - title: "Чергування у–в, і–й, з–із–зі (правила милозвучності)"
+    tags: [чергування, милозвучність, euphony, у, в, і, й]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612
+    grade: 5
+    category: phonetics
+
+  - title: "Правила вживання знака м'якшення"
+    tags: [м'який знак, знак м'якшення, soft sign, ь]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/pravila-vzhivannia-znaka-m-iakshennia-39904
+    grade: 5
+    category: phonetics
+
+  - title: "Правила вживання апострофа"
+    tags: [апостроф, apostrophe]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/pravila-vzhivannia-apostrofa-39782
+    grade: 5
+    category: phonetics
+
+  - title: "Подвоєння букв. Подовження приголосних"
+    tags: [подвоєння, подовження, приголосні, doubling, lengthening]
+    url: /p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/podvoyennia-bukv-na-poznachennia-zbigu-odnakovikh-prigolosnikh-podovzhen_-441891
+    grade: 5
+    category: phonetics
+
+  # ── Grade 5: Lexicology ───────────────────────────────────────────
+  - title: "Лексичне значення слова. Однозначні й багатозначні слова"
+    tags: [лексика, значення, однозначні, багатозначні, lexicology, meaning, polysemy]
+    url: /p/ukrainska-mova/5-klas/leksikologiia-40143/leksichne-znachennia-slova-odnoznachni-i-bagatoznachni-slova-40128
+    grade: 5
+    category: lexicology
+
+  - title: "Синоніми. Синонімічний ряд"
+    tags: [синоніми, synonyms]
+    url: /p/ukrainska-mova/5-klas/leksikologiia-40143/sinonimi-sinonimichnii-riad-rol-sinonimiv-u-movlenni-slovnik-sinonimiv-40151
+    grade: 5
+    category: lexicology
+
+  - title: "Антоніми"
+    tags: [антоніми, antonyms]
+    url: /p/ukrainska-mova/5-klas/leksikologiia-40143/antonimi-antonimi-v-prisliv-iakh-i-prikazkakh-40142
+    grade: 5
+    category: lexicology
+
+  # ── Grade 5: Word structure ───────────────────────────────────────
+  - title: "Основа слова і закінчення"
+    tags: [основа, закінчення, будова слова, stem, ending, word structure]
+    url: /p/ukrainska-mova/5-klas/budova-slova-40702/osnova-slova-i-zakinchennia-40400
+    grade: 5
+    category: word_formation
+
+  - title: "Префікс"
+    tags: [префікс, prefix]
+    url: /p/ukrainska-mova/5-klas/budova-slova-40702/prefiks-prefiksi-iaki-nadaiut-slovam-emotciinogo-zabarvlennia-ta-virazno_-436960
+    grade: 5
+    category: word_formation
+
+  - title: "Суфікс"
+    tags: [суфікс, suffix]
+    url: /p/ukrainska-mova/5-klas/budova-slova-40702/sufiks-sufiksi-iaki-nadaiut-slovam-emotciinogo-zabarvlennia-ta-viraznosti-438165
+    grade: 5
+    category: word_formation
+
+  # ── Grade 5: Syntax ───────────────────────────────────────────────
+  - title: "Словосполучення"
+    tags: [словосполучення, phrase, word combination]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/slovospoluchennia-39535
+    grade: 5
+    category: syntax
+
+  - title: "Речення, його граматична основа (підмет і присудок)"
+    tags: [речення, підмет, присудок, sentence, subject, predicate]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/rechennia-iogo-gramatichna-osnova-pidmet-i-prisudok-39372
+    grade: 5
+    category: syntax
+
+  - title: "Речення з однорідними членами"
+    tags: [однорідні, члени, речення, homogeneous, sentence members]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/rechennia-z-odnoridnimi-chlenami-koma-mizh-odnoridnimi-chlenami-rechennia-39061
+    grade: 5
+    category: syntax
+
+  - title: "Звертання"
+    tags: [звертання, vocative, address]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/zvertannia-neposhireni-i-poshireni-zvertannia-rozdilovi-znaki-pri-zvertan_-38855
+    grade: 5
+    category: syntax
+
+  - title: "Складні речення з безсполучниковим і сполучниковим зв'язком"
+    tags: [складне речення, сполучник, безсполучникове, complex sentence, conjunction]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/skladni-rechennia-z-bezspoluchnikovim-i-spoluchnikovim-zv-iazkom-38302
+    grade: 5
+    category: syntax
+
+  - title: "Пряма мова"
+    tags: [пряма мова, direct speech]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/priama-mova-37998
+    grade: 5
+    category: syntax
+
+  - title: "Діалог"
+    tags: [діалог, dialog, dialogue]
+    url: /p/ukrainska-mova/5-klas/vidomosti-z-sintaksisu-i-punktuatciyi-14562/dialog-37999
+    grade: 5
+    category: syntax
+
+  # ── Grade 6: Noun (іменник) ───────────────────────────────────────
+  - title: "Іменник як частина мови"
+    tags: [іменник, noun, частина мови]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/imennik-iak-chastina-movi-41979
+    grade: 6
+    category: morphology
+
+  - title: "Рід іменників"
+    tags: [рід, іменник, gender, noun, чоловічий, жіночий, середній, masculine, feminine, neuter]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/rid-imennikiv-42978
+    grade: 6
+    category: morphology
+
+  - title: "Число іменників"
+    tags: [число, іменник, number, noun, однина, множина, singular, plural]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/chislo-imennikiv-43147
+    grade: 6
+    category: morphology
+
+  - title: "Відмінки іменників"
+    tags: [відмінок, відмінки, іменник, case, noun, називний, родовий, давальний, знахідний, орудний, місцевий, кличний]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/vidminki-imennikiv-45178
+    grade: 6
+    category: morphology
+
+  - title: "Поділ іменників на відміни та групи"
+    tags: [відміна, іменник, declension, noun]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/podil-imennikiv-na-vidmini-ta-grupi-45179
+    grade: 6
+    category: morphology
+
+  - title: "Відмінювання іменників І відміни"
+    tags: [відмінювання, іменник, перша відміна, declension, first]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/vidminiuvannia-imennikiv-i-vidmini-45547
+    grade: 6
+    category: morphology
+
+  - title: "Відмінювання іменників ІІ відміни"
+    tags: [відмінювання, іменник, друга відміна, declension, second]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/vidminiuvannia-imennikiv-ii-vidmini-45548
+    grade: 6
+    category: morphology
+
+  - title: "Відмінювання іменників ІІІ відміни"
+    tags: [відмінювання, іменник, третя відміна, declension, third]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/vidminiuvannia-imennikiv-iii-vidmini-46486
+    grade: 6
+    category: morphology
+
+  - title: "Кличний відмінок"
+    tags: [кличний, відмінок, іменник, vocative case, noun]
+    url: /p/ukrainska-mova/6-klas/imennik-43064/osoblivosti-napisannia-imennikiv-u-klichnomu-vidminku-464889
+    grade: 6
+    category: morphology
+
+  # ── Grade 6: Adjective (прикметник) ───────────────────────────────
+  - title: "Прикметник як частина мови"
+    tags: [прикметник, adjective, частина мови]
+    url: /p/ukrainska-mova/6-klas/prikmetnik-47431/prikmetnik-iak-chastina-movi-46716
+    grade: 6
+    category: morphology
+
+  - title: "Групи прикметників за значенням"
+    tags: [прикметник, якісні, відносні, присвійні, adjective, qualitative, relative, possessive]
+    url: /p/ukrainska-mova/6-klas/prikmetnik-47431/grupi-prikmetnikiv-za-znachenniam-46717
+    grade: 6
+    category: morphology
+
+  - title: "Ступені порівняння якісних прикметників"
+    tags: [прикметник, ступені порівняння, вищий, найвищий, comparison, adjective, comparative, superlative]
+    url: /p/ukrainska-mova/6-klas/prikmetnik-47431/stupeni-porivniannia-iakisnikh-prikmetnikiv-46718
+    grade: 6
+    category: morphology
+
+  - title: "Відмінювання прикметників"
+    tags: [прикметник, відмінювання, adjective, declension]
+    url: /p/ukrainska-mova/6-klas/prikmetnik-47431/vidminiuvannia-prikmetnikiv-47111
+    grade: 6
+    category: morphology
+
+  # ── Grade 6: Numeral (числівник) ──────────────────────────────────
+  - title: "Числівник як частина мови"
+    tags: [числівник, numeral, number words]
+    url: /p/ukrainska-mova/6-klas/chislivnik-14257/chislivnik-iak-chastina-movi-37269
+    grade: 6
+    category: morphology
+
+  - title: "Відмінювання та правопис числівників"
+    tags: [числівник, відмінювання, numeral, declension]
+    url: /p/ukrainska-mova/6-klas/chislivnik-14257/vidminiuvannia-ta-pravopis-chislivnikiv-37361
+    grade: 6
+    category: morphology
+
+  # ── Grade 6: Pronoun (займенник) ──────────────────────────────────
+  - title: "Займенник як частина мови"
+    tags: [займенник, pronoun]
+    url: /p/ukrainska-mova/6-klas/zaimennik-51336/zaimennik-iak-chastina-movi-pravilne-nagoloshuvannia-zaimennikovikh-form-51337
+    grade: 6
+    category: morphology
+
+  - title: "Розряди займенників за значенням"
+    tags: [займенник, розряди, pronoun, types, особові, вказівні, присвійні]
+    url: /p/ukrainska-mova/6-klas/zaimennik-51336/rozriadi-zaimennikiv-za-znachenniam-zaimenniki-iak-zasib-zv-iazku-rechen_-467947
+    grade: 6
+    category: morphology
+
+  - title: "Відмінювання особових і зворотного займенників"
+    tags: [займенник, особовий, зворотний, pronoun, personal, reflexive, declension]
+    url: /p/ukrainska-mova/6-klas/zaimennik-51336/vidminiuvannia-osobovikh-i-zvorotnogo-zaimennikiv-etiketni-funktciyi-zaim_-51338
+    grade: 6
+    category: morphology
+
+  # ── Grade 6: Phraseology ──────────────────────────────────────────
+  - title: "Поняття про фразеологізм"
+    tags: [фразеологізм, idiom, phraseology, фразеологія]
+    url: /p/ukrainska-mova/6-klas/frazeologiia-40687/poniattia-pro-frazeologizm-iogo-leksichne-znachennia-40609
+    grade: 6
+    category: lexicology
+
+  # ── Grade 7: Verb (дієслово) ──────────────────────────────────────
+  - title: "Дієслово: загальне значення, морфологічні ознаки"
+    tags: [дієслово, verb, морфологія, частина мови]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/diyeslovo-zagalne-znachennia-morfologichni-oznaki-sintaksichna-rol-38752
+    grade: 7
+    category: morphology
+
+  - title: "Неозначена форма дієслова (інфінітив)"
+    tags: [дієслово, інфінітив, infinitive, verb]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/neoznachena-forma-diyeslova-infinitiv-468289
+    grade: 7
+    category: morphology
+
+  - title: "Вид дієслова"
+    tags: [дієслово, вид, доконаний, недоконаний, aspect, verb, perfective, imperfective]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/vid-diyeslova-468379
+    grade: 7
+    category: morphology
+
+  - title: "Часи дієслів. Теперішній час"
+    tags: [дієслово, час, теперішній, tense, verb, present]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/chasi-diyesliv-teperishnii-chas-39373
+    grade: 7
+    category: morphology
+
+  - title: "Минулий час дієслів"
+    tags: [дієслово, минулий час, past tense, verb]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/minulii-chas-diyesliv-468469
+    grade: 7
+    category: morphology
+
+  - title: "Майбутній час дієслів"
+    tags: [дієслово, майбутній час, future tense, verb]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/maibutnii-chas-diyesliv-468490
+    grade: 7
+    category: morphology
+
+  - title: "І і ІІ дієвідміни. Дієвідмінювання дієслів"
+    tags: [дієслово, дієвідміна, conjugation, verb, перша, друга]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/i-i-ii-diyevidmini-diyevidminiuvannia-diyesliv-39539
+    grade: 7
+    category: morphology
+
+  - title: "Способи дієслів"
+    tags: [дієслово, спосіб, наказовий, умовний, mood, verb, imperative, conditional]
+    url: /p/ukrainska-mova/7-klas/diyeslovo-14736/sposobi-diyesliv-39998
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Participle (дієприкметник) ───────────────────────────
+  - title: "Дієприкметник як особлива форма дієслова"
+    tags: [дієприкметник, participle]
+    url: /p/ukrainska-mova/7-klas/diyeprikmetnik-43446/diyeprikmetnik-iak-osobliva-forma-diyeslova-41607
+    grade: 7
+    category: morphology
+
+  - title: "Дієприкметниковий зворот"
+    tags: [дієприкметниковий зворот, participial phrase]
+    url: /p/ukrainska-mova/7-klas/diyeprikmetnik-43446/diyeprikmetnikovii-zvorot-41608
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Gerund (дієприслівник) ───────────────────────────────
+  - title: "Дієприслівник як особлива форма дієслова"
+    tags: [дієприслівник, gerund, adverbial participle]
+    url: /p/ukrainska-mova/7-klas/diyeprislivnik-46606/diyeprislivnik-iak-osobliva-forma-diyeslova-45549
+    grade: 7
+    category: morphology
+
+  - title: "Дієприслівниковий зворот"
+    tags: [дієприслівниковий зворот, gerund phrase]
+    url: /p/ukrainska-mova/7-klas/diyeprislivnik-46606/diyeprislivnikovii-zvorot-46390
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Adverb (прислівник) ──────────────────────────────────
+  - title: "Прислівник як самостійна частина мови"
+    tags: [прислівник, adverb]
+    url: /p/ukrainska-mova/7-klas/prislivnik-45318/prislivnik-iak-samostiina-chastina-movi-44965
+    grade: 7
+    category: morphology
+
+  - title: "Ступені порівняння прислівників"
+    tags: [прислівник, ступені порівняння, adverb, comparison]
+    url: /p/ukrainska-mova/7-klas/prislivnik-45318/stupeni-porivniannia-prislivnikiv-45180
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Preposition (прийменник) ─────────────────────────────
+  - title: "Прийменник як службова частина мови"
+    tags: [прийменник, preposition]
+    url: /p/ukrainska-mova/7-klas/priimennik-48228/priimennik-iak-sluzhbova-chastina-movi-nepokhidni-i-pokhidni-priimenniki-48229
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Conjunction (сполучник) ──────────────────────────────
+  - title: "Сполучник як службова частина мови"
+    tags: [сполучник, conjunction, сурядний, підрядний]
+    url: /p/ukrainska-mova/7-klas/spoluchnik-313253/spoluchnik-iak-sluzhbova-chastina-movi-51548
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Particle (частка) ────────────────────────────────────
+  - title: "Загальна характеристика часток"
+    tags: [частка, particle]
+    url: /p/ukrainska-mova/7-klas/chastka-37195/zagalna-kharakteristika-chastok-37204
+    grade: 7
+    category: morphology
+
+  # ── Grade 7: Interjection (вигук) ─────────────────────────────────
+  - title: "Вигук як особлива частина мови"
+    tags: [вигук, interjection]
+    url: /p/ukrainska-mova/7-klas/viguk-38501/viguk-iak-osobliva-chastina-movi-grupi-vigukiv-za-znachenniam-38502
+    grade: 7
+    category: morphology
+
+  # ── Grade 8: Syntax — simple sentence ─────────────────────────────
+  - title: "Словосполучення і речення як одиниці синтаксису"
+    tags: [словосполучення, речення, синтаксис, syntax, phrase, sentence]
+    url: /p/ukrainska-mova/8-klas/slovospoluchennia-i-rechennia-39534/slovospoluchennia-i-rechennia-iak-odinitci-sintaksisu-39377
+    grade: 8
+    category: syntax
+
+  - title: "Підмет. Способи вираження підмета"
+    tags: [підмет, subject, речення, sentence]
+    url: /p/ukrainska-mova/8-klas/proste-rechennia-478879/pidmet-sposobi-virazhennia-pidmeta-40644
+    grade: 8
+    category: syntax
+
+  - title: "Присудок. Способи вираження простого присудка"
+    tags: [присудок, predicate, речення, sentence]
+    url: /p/ukrainska-mova/8-klas/proste-rechennia-478879/prisudok-sposobi-virazhennia-prostogo-prisudka-41667
+    grade: 8
+    category: syntax
+
+  - title: "Тире між підметом і присудком"
+    tags: [тире, підмет, присудок, dash, subject, predicate]
+    url: /p/ukrainska-mova/8-klas/proste-rechennia-478879/tire-mizh-pidmetom-i-prisudkom-42427
+    grade: 8
+    category: syntax
+
+  - title: "Означення"
+    tags: [означення, attribute, другорядні члени, secondary members]
+    url: /p/ukrainska-mova/8-klas/drugoriadni-chleni-rechennia-128066/oznachennia-50366
+    grade: 8
+    category: syntax
+
+  - title: "Додаток"
+    tags: [додаток, object, другорядні члени]
+    url: /p/ukrainska-mova/8-klas/drugoriadni-chleni-rechennia-128066/dodatok-51332
+    grade: 8
+    category: syntax
+
+  - title: "Обставина"
+    tags: [обставина, adverbial modifier, другорядні члени]
+    url: /p/ukrainska-mova/8-klas/drugoriadni-chleni-rechennia-128066/obstavina-51537
+    grade: 8
+    category: syntax
+
+  - title: "Односкладні речення"
+    tags: [односкладне, речення, one-part sentence, означено-особове, безособове]
+    url: /p/ukrainska-mova/8-klas/proste-odnoskladne-rechennia-nepovni-rechennia-135802/vidi-odnoskladnikh-rechen-oznacheno-osobovi-rechennia-135804
+    grade: 8
+    category: syntax
+
+  - title: "Безособові речення"
+    tags: [безособове, речення, impersonal sentence]
+    url: /p/ukrainska-mova/8-klas/proste-odnoskladne-rechennia-nepovni-rechennia-135802/bezosobovi-rechennia-226235
+    grade: 8
+    category: syntax
+
+  - title: "Однорідні члени речення"
+    tags: [однорідні, члени, речення, homogeneous members]
+    url: /p/ukrainska-mova/8-klas/proste-uskladnene-rechennia-46607/odnoridni-chleni-rechennia-46502
+    grade: 8
+    category: syntax
+
+  - title: "Відокремлені означення"
+    tags: [відокремлення, означення, detached attributes, apposition]
+    url: /p/ukrainska-mova/8-klas/rechennia-z-vidokremlenimi-chlenami-37190/vidokremleni-oznachennia-rozdilovi-znaki-v-rechenniakh-iz-vidokremlenimi_-483598
+    grade: 8
+    category: syntax
+
+  # ── Grade 9: Complex sentences ────────────────────────────────────
+  - title: "Поняття про складне речення"
+    tags: [складне речення, complex sentence]
+    url: /p/ukrainska-mova/9-klas/skladne-rechennia-39193/poniattia-pro-skladne-rechennia-37207
+    grade: 9
+    category: syntax
+
+  - title: "Складносурядне речення"
+    tags: [складносурядне, речення, compound sentence]
+    url: /p/ukrainska-mova/9-klas/skladnosuriadne-rechennia-39586/poniattia-pro-skladnosuriadne-rechennia-39513
+    grade: 9
+    category: syntax
+
+  - title: "Складнопідрядне речення"
+    tags: [складнопідрядне, речення, complex subordinate sentence]
+    url: /p/ukrainska-mova/9-klas/skladnopidriadne-rechennia-43534/poniattia-pro-skladnopidriadne-rechennia-41448
+    grade: 9
+    category: syntax
+
+  - title: "СПР з підрядними означальними"
+    tags: [складнопідрядне, означальне, relative clause, subordinate, attributive]
+    url: /p/ukrainska-mova/9-klas/skladnopidriadne-rechennia-43534/spr-z-pidriadnimi-oznachalnimi-42437
+    grade: 9
+    category: syntax
+
+  - title: "СПР з підрядними обставинними умови, мети, причини"
+    tags: [складнопідрядне, обставинне, умова, мета, причина, condition, purpose, cause, subordinate]
+    url: /p/ukrainska-mova/9-klas/skladnopidriadne-rechennia-43534/spr-z-pidriadnimi-obstavinnimi-umovi-meti-prichini-naslidkovimi-i-dopusto_-45320
+    grade: 9
+    category: syntax
+
+  - title: "Безсполучникове складне речення"
+    tags: [безсполучникове, складне речення, asyndetic, compound]
+    url: /p/ukrainska-mova/9-klas/bezspoluchnikove-skladne-rechennia-46707/poniattia-pro-bsr-rozdilovi-znaki-v-bsr-46385
+    grade: 9
+    category: syntax
+
+  # ── Grade 10: Orthoepy ────────────────────────────────────────────
+  - title: "Милозвучність. Чергування у//в, і//й, з//із//зі"
+    tags: [милозвучність, чергування, euphony, у, в, і, й]
+    url: /p/ukrainska-mova/10-klas/orfoepichna-norma-329328/poniattia-milozvuchnosti-cherguvannia-u-v-i-i-z-iz-zi-iak-zasib-milozvuc_-329327
+    grade: 10
+    category: phonetics
+
+  - title: "Основні правила вимови голосних звуків"
+    tags: [вимова, голосні, pronunciation, vowels]
+    url: /p/ukrainska-mova/10-klas/orfoepichna-norma-329328/osnovni-pravila-vimovi-golosnikh-zvukiv-332127
+    grade: 10
+    category: phonetics
+
+  - title: "Основні правила вимови приголосних звуків"
+    tags: [вимова, приголосні, pronunciation, consonants]
+    url: /p/ukrainska-mova/10-klas/orfoepichna-norma-329328/osnovni-pravila-vimovi-prigolosnikh-zvukiv-334761
+    grade: 10
+    category: phonetics
+
+  - title: "Наголос. Основні правила наголошування слів"
+    tags: [наголос, наголошування, stress, accent]
+    url: /p/ukrainska-mova/10-klas/orfoepichna-norma-329328/nagolos-osnovni-pravila-nagoloshuvannia-sliv-normativnii-nagolos-344850
+    grade: 10
+    category: phonetics
+
+  # ── Grade 10: Orthography ─────────────────────────────────────────
+  - title: "Чергування голосних"
+    tags: [чергування, голосні, alternation, vowels]
+    url: /p/ukrainska-mova/10-klas/orfografichna-norma-352880/cherguvannia-golosnikh-360923
+    grade: 10
+    category: phonetics
+
+  - title: "Чергування приголосних в українській мові"
+    tags: [чергування, приголосні, alternation, consonants]
+    url: /p/ukrainska-mova/10-klas/orfografichna-norma-352880/cherguvannia-prigolosnikh-v-ukrayinskii-movi-361758
+    grade: 10
+    category: phonetics
+
+  - title: "Подвоєння та подовження приголосних"
+    tags: [подвоєння, подовження, приголосні, doubling, lengthening, consonants]
+    url: /p/ukrainska-mova/10-klas/orfografichna-norma-352880/podvoyennia-ta-podovzhennia-prigolosnikh-364217
+    grade: 10
+    category: phonetics
+
+  - title: "Апостроф"
+    tags: [апостроф, apostrophe]
+    url: /p/ukrainska-mova/10-klas/orfografichna-norma-352880/apostrof-355181
+    grade: 10
+    category: phonetics
+
+  # ── Grade 10: Morphological norm ──────────────────────────────────
+  - title: "Іменник. Рід іменників. Паралельні родові форми"
+    tags: [іменник, рід, noun, gender, morphological norm]
+    url: /p/ukrainska-mova/10-klas/morfologichna-norma-373940/imennik-rid-imennikiv-paralelni-rodovi-formi-imennika-374830
+    grade: 10
+    category: morphology
+
+  - title: "Складні випадки відмінювання іменників"
+    tags: [іменник, відмінювання, noun, declension, advanced]
+    url: /p/ukrainska-mova/10-klas/morfologichna-norma-373940/skladni-vipadki-vidminiuvannia-imennikiv-zakinchennia-imennikiv-i-vidmin_-378953
+    grade: 10
+    category: morphology
+
+  - title: "Особливості кличного відмінка"
+    tags: [кличний, відмінок, vocative case]
+    url: /p/ukrainska-mova/10-klas/morfologichna-norma-373940/osoblivosti-klichnogo-vidminka-379283
+    grade: 10
+    category: morphology
+
+  # ── Grade 11: Morphological norm ──────────────────────────────────
+  - title: "Прикметник. Ступені порівняння"
+    tags: [прикметник, ступені порівняння, adjective, comparison, вищий, найвищий]
+    url: /p/ukrainska-mova/11-klas/morfologichna-norma-379685/vishchii-i-naivishchii-stupeni-porivniannia-prikmetnikiv-379713
+    grade: 11
+    category: morphology
+
+  - title: "Числівник. Складні випадки узгодження й відмінювання"
+    tags: [числівник, узгодження, відмінювання, numeral, agreement]
+    url: /p/ukrainska-mova/11-klas/morfologichna-norma-379685/chislivnik-skladni-vipadki-uzgodzhennia-i-vidminiuvannia-chislivnika-379884
+    grade: 11
+    category: morphology
+
+  - title: "Дієслово, дієслівні форми. Дієвідміни. Наказовий спосіб"
+    tags: [дієслово, дієвідміна, наказовий, verb, conjugation, imperative]
+    url: /p/ukrainska-mova/11-klas/morfologichna-norma-379685/diyeslovo-diyeslivni-formi-diyevidmini-diyesliv-nakazovii-sposib-380008
+    grade: 11
+    category: morphology
+
+  - title: "Активні й пасивні дієприкметники"
+    tags: [дієприкметник, активний, пасивний, participle, active, passive]
+    url: /p/ukrainska-mova/11-klas/morfologichna-norma-379685/aktivni-i-pasivni-diyeprikmetniki-380066
+    grade: 11
+    category: morphology
+
+  # ── Grade 11: Syntactic norm ──────────────────────────────────────
+  - title: "Синтаксична норма. Складні випадки синтаксичного узгодження"
+    tags: [синтаксична норма, узгодження, syntax, agreement]
+    url: /p/ukrainska-mova/11-klas/sintaksichna-norma-380223/poniattia-sintaksichnoyi-normi-sintaksichna-pomilka-skladni-vipadki-sint_-380224
+    grade: 11
+    category: syntax
+
+  - title: "Уживання прийменників В і НА з географічними назвами"
+    tags: [прийменник, в, на, geographic, preposition usage]
+    url: /p/ukrainska-mova/11-klas/sintaksichna-norma-380223/uzhivannia-priimennikiv-v-i-na-z-geografichnimi-nazvami-i-prostorovimi-i_-380264
+    grade: 11
+    category: syntax
+
+  - title: "Пасивні конструкції з дієсловами на -ся"
+    tags: [пасивний, конструкція, -ся, passive voice, reflexive]
+    url: /p/ukrainska-mova/11-klas/sintaksichna-norma-380223/pasivni-konstruktciyi-z-diyeslovami-na-sia-381629
+    grade: 11
+    category: syntax
+
+  - title: "Правила побудови складних речень"
+    tags: [складне речення, побудова, complex sentence, construction]
+    url: /p/ukrainska-mova/11-klas/sintaksichna-norma-380223/pravila-pobudovi-skladnikh-rechen-384176
+    grade: 11
+    category: syntax

--- a/docs/resources/trusted_sources.yaml
+++ b/docs/resources/trusted_sources.yaml
@@ -105,6 +105,19 @@ sources:
     query_function: e2u_translate, e2u_reverse
     mcp_tool: query_e2u
 
+  - id: miyklas
+    name: МійКлас Ukrainian grammar
+    type: reference
+    url: https://miyklas.com.ua
+    description: >
+      Ukrainian grammar theory pages for Grades 5-11, NUS aligned.
+      Covers phonetics, morphology, syntax, word formation.
+      Theory pages readable via WebFetch without auth.
+      Exercise content behind Мій+ premium — not needed (we generate own exercises).
+    coverage: Grammar rules, phonetics, morphology, syntax (Grades 5-11)
+    index: data/miyklas/grammar_index.yaml
+    query_function: miyklas_match
+
   # ── Reference sources ─────────────────────────────────────────
   - id: pravopys
     name: Ukrainian Pravopys (2019)

--- a/scripts/build/enrich.py
+++ b/scripts/build/enrich.py
@@ -251,7 +251,15 @@ def _build_resources(plan: dict, slug: str = "") -> str:
     refs = plan.get("references", [])
     ext_resources = _load_external_resources(slug, plan) if slug else []
 
-    if not refs and not ext_resources:
+    # МійКлас grammar references (#1040) — auto-matched by plan grammar/focus
+    miyklas_entries: list[dict] = []
+    try:
+        from build.miyklas import build_miyklas_resource_entries
+        miyklas_entries = build_miyklas_resource_entries(plan)
+    except Exception as e:
+        print(f"  ⚠️  МійКлас resource entries skipped: {e}")
+
+    if not refs and not ext_resources and not miyklas_entries:
         return ""
 
     lines = []
@@ -270,6 +278,13 @@ def _build_resources(plan: dict, slug: str = "") -> str:
                 lines.append(f"- {title}")
             if notes:
                 lines.append(f"  _{notes}_")
+        lines.append("")
+
+    if miyklas_entries:
+        lines.append("**Граматика — Grammar (МійКлас)**")
+        lines.append("")
+        for entry in miyklas_entries:
+            lines.append(f"- [{entry['title']}]({entry['url']}) ({entry['source']})")
         lines.append("")
 
     # External curated resources (ULP blog, Dobra Forma, Talk Ukrainian, etc.)

--- a/scripts/build/miyklas.py
+++ b/scripts/build/miyklas.py
@@ -1,0 +1,214 @@
+"""МійКлас (miyklas.com.ua) integration for V6 build pipeline.
+
+Provides two capabilities:
+1. RESEARCH: fetch theory page content for knowledge packet enrichment
+2. ENRICH: inject matching МійКлас URLs into Ресурсі tab
+
+Matching logic: plan YAML `grammar` and `focus` fields are tokenized and
+compared against each index entry's `tags` list via keyword overlap scoring.
+No per-module manual mapping needed — works for any A1-C1 module.
+
+Issue: #1040
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_INDEX_PATH = _PROJECT_ROOT / "data" / "miyklas" / "grammar_index.yaml"
+_BASE_URL = "https://miyklas.com.ua"
+
+# Pre-compiled: strip parenthetical English, punctuation, quotes
+_RE_PAREN = re.compile(r"\([^)]*\)")
+_RE_NON_ALPHA = re.compile(r"[^\w\s]", re.UNICODE)
+
+# CEFR level → approximate Ukrainian school grade mapping
+# Used to boost matches from the appropriate difficulty band
+_LEVEL_GRADE_MAP: dict[str, tuple[int, int]] = {
+    "a1": (5, 6),
+    "a2": (5, 7),
+    "b1": (6, 8),
+    "b2": (8, 10),
+    "c1": (9, 11),
+    "c2": (10, 11),
+}
+
+# Focus field → category mapping for additional filtering
+_FOCUS_CATEGORY: dict[str, str | None] = {
+    "phonetics": "phonetics",
+    "grammar": None,  # grammar is too broad — match all categories
+    "vocabulary": "lexicology",
+    "communication": None,
+    "review": None,
+}
+
+
+@lru_cache(maxsize=1)
+def _load_index() -> list[dict]:
+    """Load and cache the МійКлас grammar index YAML."""
+    if not _INDEX_PATH.exists():
+        return []
+    try:
+        data = yaml.safe_load(_INDEX_PATH.read_text("utf-8"))
+        return data.get("topics", [])
+    except Exception:
+        return []
+
+
+def _tokenize(text: str) -> set[str]:
+    """Normalize text into a set of lowercase keyword tokens.
+
+    Strips English parentheticals, punctuation, and short tokens.
+    """
+    text = _RE_PAREN.sub("", text)
+    text = _RE_NON_ALPHA.sub(" ", text.lower())
+    return {t for t in text.split() if len(t) > 2}
+
+
+def _extract_plan_keywords(plan: dict) -> set[str]:
+    """Extract searchable keywords from plan grammar and focus fields.
+
+    Sources:
+    - plan.grammar: list of grammar topic strings
+    - plan.focus: single focus keyword
+    - plan.content_outline[].section: section titles (Ukrainian part only)
+    """
+    tokens: set[str] = set()
+
+    # Grammar items (primary matching source)
+    for item in plan.get("grammar", []):
+        if isinstance(item, str):
+            tokens |= _tokenize(item)
+
+    # Focus field
+    focus = plan.get("focus", "")
+    if focus:
+        tokens |= _tokenize(focus)
+
+    # Section titles from content_outline (strip English parentheticals)
+    for section in plan.get("content_outline", []):
+        title = section.get("section", "")
+        if title:
+            # Keep only the Ukrainian part (before parenthesis)
+            uk_part = _RE_PAREN.sub("", title).strip()
+            tokens |= _tokenize(uk_part)
+
+    return tokens
+
+
+def find_matching_topics(plan: dict, max_results: int = 5) -> list[dict]:
+    """Find МійКлас topics that match a plan's grammar content.
+
+    Scoring:
+    - Base score = number of tag tokens that overlap with plan keywords
+    - Grade proximity bonus: +1 if within the CEFR→grade band
+    - Category bonus: +1 if focus field maps to the topic's category
+    - Minimum threshold: score >= 2 (avoids noise from single-word matches)
+
+    Returns list of dicts with keys: title, url, grade, category, score.
+    """
+    index = _load_index()
+    if not index:
+        return []
+
+    plan_keywords = _extract_plan_keywords(plan)
+    if not plan_keywords:
+        return []
+
+    level = plan.get("level", "").lower()
+    grade_lo, grade_hi = _LEVEL_GRADE_MAP.get(level, (5, 11))
+    focus = plan.get("focus", "")
+    focus_category = _FOCUS_CATEGORY.get(focus)
+
+    scored: list[tuple[float, dict]] = []
+
+    for entry in index:
+        entry_tags = {t.lower() for t in entry.get("tags", [])}
+        overlap = plan_keywords & entry_tags
+        if not overlap:
+            continue
+
+        score = len(overlap)
+
+        # Grade proximity bonus
+        entry_grade = entry.get("grade", 0)
+        if grade_lo <= entry_grade <= grade_hi:
+            score += 1
+
+        # Category alignment bonus
+        if focus_category and entry.get("category") == focus_category:
+            score += 1
+
+        if score < 2:
+            continue
+
+        url_path = entry.get("url", "")
+        full_url = f"{_BASE_URL}{url_path}" if url_path.startswith("/") else url_path
+
+        scored.append((score, {
+            "title": entry.get("title", ""),
+            "url": full_url,
+            "grade": entry_grade,
+            "category": entry.get("category", ""),
+            "score": score,
+        }))
+
+    # Sort by score descending, then by grade ascending (foundational first)
+    scored.sort(key=lambda x: (-x[0], x[1].get("grade", 99)))
+    return [item for _, item in scored[:max_results]]
+
+
+def build_miyklas_resource_entries(plan: dict) -> list[dict]:
+    """Build resource entries for the ENRICH step's Ресурсі tab.
+
+    Returns a list of dicts compatible with _build_resources() format:
+    [{title, url, source, type}]
+    """
+    matches = find_matching_topics(plan, max_results=3)
+    return [
+        {
+            "title": f"МійКлас: {m['title']}",
+            "url": m["url"],
+            "source": "miyklas.com.ua",
+            "type": "articles",
+        }
+        for m in matches
+    ]
+
+
+def build_miyklas_knowledge_section(plan: dict) -> str:
+    """Build a knowledge packet section with МійКлас theory references.
+
+    For the RESEARCH step — adds matched topics as pointers
+    (not full page content, which is fetched on-demand by the writer).
+
+    Returns markdown string, or empty string if no matches.
+    """
+    matches = find_matching_topics(plan, max_results=5)
+    if not matches:
+        return ""
+
+    lines = [
+        "",
+        "---",
+        "",
+        "## МійКлас Grammar References",
+        "",
+        "*Matched Ukrainian school grammar theory pages from miyklas.com.ua (Grades 5-11, NUS aligned).*",
+        "*Use WebFetch to retrieve full theory content for any topic below.*",
+        "",
+    ]
+
+    for m in matches:
+        lines.append(
+            f"- **{m['title']}** (Grade {m['grade']}, {m['category']}) — "
+            f"[МійКлас]({m['url']})"
+        )
+
+    lines.append("")
+    return "\n".join(lines)

--- a/scripts/build/research/build_knowledge_packet.py
+++ b/scripts/build/research/build_knowledge_packet.py
@@ -263,7 +263,22 @@ def build_packet(plan_path: Path) -> str:
         f"{total_hits} textbook excerpts from RAG.*\n"
     )
 
-    return header + "\n\n".join(section_packets) + "\n" + "\n".join(ref_lines) + footer
+    # МійКлас grammar references (#1040)
+    miyklas_section = ""
+    try:
+        from build.miyklas import build_miyklas_knowledge_section
+        miyklas_section = build_miyklas_knowledge_section(plan)
+    except Exception as e:
+        print(f"  ⚠️  МійКлас integration skipped: {e}")
+
+    return (
+        header
+        + "\n\n".join(section_packets)
+        + "\n"
+        + "\n".join(ref_lines)
+        + miyklas_section
+        + footer
+    )
 
 
 # CLI for testing

--- a/tests/test_build_knowledge_packet.py
+++ b/tests/test_build_knowledge_packet.py
@@ -199,3 +199,153 @@ def test_build_packet_no_rag(tmp_path):
     assert "# Knowledge Packet: Test Module" in result
     # No Cyrillic in points → no queries → "No search queries extracted"
     assert "0 textbook excerpts" in result
+
+
+# --- МійКлас integration tests (#1040) ---
+
+
+_FAKE_MIYKLAS_INDEX = [
+    {
+        "title": "Голосні й приголосні звуки",
+        "tags": ["звуки", "голосні", "приголосні", "фонетика"],
+        "url": "/p/ukrainska-mova/5-klas/fonetika/golosni",
+        "grade": 5,
+        "category": "phonetics",
+    },
+]
+
+
+def test_build_packet_includes_miyklas_section(tmp_path):
+    """build_packet appends МійКлас section when grammar matches."""
+    plan = {
+        "module": "a1-001",
+        "level": "A1",
+        "sequence": 1,
+        "slug": "test-phonetics",
+        "title": "Test Phonetics Module",
+        "grammar": ["Голосні і приголосні звуки"],
+        "focus": "phonetics",
+        "content_outline": [
+            {
+                "section": "Звуки (Sounds)",
+                "words": 300,
+                "points": ["Голосні та приголосні звуки української мови."],
+            },
+        ],
+        "references": [],
+    }
+
+    plan_path = tmp_path / "test-phonetics.yaml"
+    plan_path.write_text(yaml.dump(plan, allow_unicode=True), "utf-8")
+
+    with (
+        patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
+        patch("build.miyklas._load_index", return_value=list(_FAKE_MIYKLAS_INDEX)),
+    ):
+        result = build_packet(plan_path)
+
+    assert "МійКлас Grammar References" in result
+    assert "Голосні й приголосні звуки" in result
+    assert "miyklas.com.ua" in result
+
+
+def test_build_packet_no_miyklas_when_no_grammar_match(tmp_path):
+    """build_packet omits МійКлас section when no grammar overlap."""
+    plan = {
+        "module": "a1-001",
+        "level": "A1",
+        "sequence": 1,
+        "slug": "test-greetings",
+        "title": "Test Greetings Module",
+        "content_outline": [
+            {
+                "section": "Привітання (Greetings)",
+                "words": 300,
+                "points": ["Привіт, як справи?"],
+            },
+        ],
+        "references": [],
+    }
+
+    plan_path = tmp_path / "test-greetings.yaml"
+    plan_path.write_text(yaml.dump(plan, allow_unicode=True), "utf-8")
+
+    with (
+        patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
+        patch("build.miyklas._load_index", return_value=list(_FAKE_MIYKLAS_INDEX)),
+    ):
+        result = build_packet(plan_path)
+
+    assert "МійКлас Grammar References" not in result
+
+
+def test_build_packet_miyklas_failure_graceful(tmp_path):
+    """build_packet continues even if miyklas module raises."""
+    plan = {
+        "module": "a1-001",
+        "level": "A1",
+        "sequence": 1,
+        "slug": "test-fallback",
+        "title": "Test Fallback",
+        "grammar": ["Голосні звуки"],
+        "content_outline": [
+            {
+                "section": "Звуки (Sounds)",
+                "words": 300,
+                "points": ["Голосні звуки в українській."],
+            },
+        ],
+        "references": [],
+    }
+
+    plan_path = tmp_path / "test-fallback.yaml"
+    plan_path.write_text(yaml.dump(plan, allow_unicode=True), "utf-8")
+
+    def _failing_miyklas(*args, **kwargs):
+        raise RuntimeError("МійКлас unavailable")
+
+    with (
+        patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
+        patch("build.miyklas.build_miyklas_knowledge_section", side_effect=_failing_miyklas),
+    ):
+        result = build_packet(plan_path)
+
+    # Should still produce a valid packet without МійКлас
+    assert "# Knowledge Packet: Test Fallback" in result
+    assert "МійКлас" not in result
+
+
+def test_build_packet_miyklas_section_before_footer(tmp_path):
+    """МійКлас section appears between refs and footer."""
+    plan = {
+        "module": "a1-001",
+        "level": "A1",
+        "sequence": 1,
+        "slug": "test-order",
+        "title": "Test Order",
+        "grammar": ["Голосні і приголосні звуки"],
+        "content_outline": [
+            {
+                "section": "Звуки (Sounds)",
+                "words": 300,
+                "points": ["Голосні та приголосні звуки."],
+            },
+        ],
+        "references": [
+            {"title": "Ref Grade 1, p.10", "notes": "test ref"},
+        ],
+    }
+
+    plan_path = tmp_path / "test-order.yaml"
+    plan_path.write_text(yaml.dump(plan, allow_unicode=True), "utf-8")
+
+    with (
+        patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
+        patch("build.miyklas._load_index", return_value=list(_FAKE_MIYKLAS_INDEX)),
+    ):
+        result = build_packet(plan_path)
+
+    # МійКлас appears after references section and before footer
+    miyklas_pos = result.index("МійКлас Grammar References")
+    footer_pos = result.index("Knowledge Packet generated")
+    assert miyklas_pos < footer_pos

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -340,3 +340,104 @@ class TestEnrichIntegration:
         assert "<!-- TAB:Словник -->" in result
         assert "<!-- TAB:Зошит -->" in result
         assert "<!-- TAB:Ресурси -->" in result
+
+
+# ---------------------------------------------------------------------------
+# МійКлас integration in _build_resources (#1040)
+# ---------------------------------------------------------------------------
+
+
+class TestMiyklasResourceIntegration:
+    """Tests for МійКлас grammar entries injected into _build_resources()."""
+
+    _FAKE_INDEX = [
+        {
+            "title": "Голосні й приголосні звуки",
+            "tags": ["звуки", "голосні", "приголосні", "фонетика"],
+            "url": "/p/ukrainska-mova/5-klas/fonetika/golosni",
+            "grade": 5,
+            "category": "phonetics",
+        },
+    ]
+
+    def _patch_index(self):
+        from unittest.mock import patch
+        return patch(
+            "build.miyklas._load_index",
+            return_value=list(self._FAKE_INDEX),
+        )
+
+    def test_miyklas_section_appears_in_resources(self):
+        """When plan grammar matches, МійКлас section appears in output."""
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        with self._patch_index():
+            result = _build_resources(plan)
+        assert "Граматика — Grammar (МійКлас)" in result
+        assert "miyklas.com.ua" in result
+
+    def test_miyklas_links_have_correct_format(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        with self._patch_index():
+            result = _build_resources(plan)
+        # Format: - [title](url) (source)
+        assert "[МійКлас: Голосні й приголосні звуки](" in result
+        assert "(miyklas.com.ua)" in result
+
+    def test_miyklas_alone_produces_output(self):
+        """Even with no refs/ext_resources, miyklas entries alone produce output."""
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+            # No "references" key — only miyklas matches
+        }
+        with self._patch_index():
+            result = _build_resources(plan)
+        assert result != ""
+        assert "МійКлас" in result
+
+    def test_miyklas_combined_with_refs(self):
+        """МійКлас entries appear alongside regular references."""
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+            "references": [
+                {"title": "Test Reference", "url": "https://example.com"},
+            ],
+        }
+        with self._patch_index():
+            result = _build_resources(plan)
+        assert "Джерела — References" in result
+        assert "Граматика — Grammar (МійКлас)" in result
+
+    def test_miyklas_failure_does_not_break_resources(self):
+        """If miyklas raises, _build_resources still works (try/except guards it)."""
+        from unittest.mock import patch
+        plan = {
+            "references": [
+                {"title": "Fallback ref", "url": "https://example.com"},
+            ],
+        }
+        with patch(
+            "build.miyklas.build_miyklas_resource_entries",
+            side_effect=RuntimeError("index unavailable"),
+        ):
+            result = _build_resources(plan)
+        # Regular refs still present
+        assert "Fallback ref" in result
+
+    def test_no_grammar_no_miyklas_section(self):
+        """Plan without grammar field produces no МійКлас section."""
+        plan = {
+            "references": [
+                {"title": "Only ref", "url": "https://example.com"},
+            ],
+        }
+        with self._patch_index():
+            result = _build_resources(plan)
+        assert "МійКлас" not in result

--- a/tests/test_miyklas.py
+++ b/tests/test_miyklas.py
@@ -1,0 +1,482 @@
+"""Tests for scripts/build/miyklas.py — МійКлас grammar integration (#1040).
+
+Covers: _tokenize, _extract_plan_keywords, find_matching_topics,
+        build_miyklas_resource_entries, build_miyklas_knowledge_section.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from build.miyklas import (
+    _extract_plan_keywords,
+    _tokenize,
+    build_miyklas_knowledge_section,
+    build_miyklas_resource_entries,
+    find_matching_topics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic index entries used across tests
+# ---------------------------------------------------------------------------
+
+_FAKE_INDEX = [
+    {
+        "title": "Голосні й приголосні звуки",
+        "tags": ["звуки", "голосні", "приголосні", "фонетика", "phonetics", "vowels", "consonants", "sounds"],
+        "url": "/p/ukrainska-mova/5-klas/fonetika/golosni-i-prigolosni-zvuki",
+        "grade": 5,
+        "category": "phonetics",
+    },
+    {
+        "title": "Наголос",
+        "tags": ["наголос", "stress", "accent"],
+        "url": "/p/ukrainska-mova/5-klas/fonetika/nagolos",
+        "grade": 5,
+        "category": "phonetics",
+    },
+    {
+        "title": "Іменник як частина мови",
+        "tags": ["іменник", "частини", "мови", "noun", "morphology"],
+        "url": "/p/ukrainska-mova/6-klas/morfologiia/imennyk",
+        "grade": 6,
+        "category": "morphology",
+    },
+    {
+        "title": "Дієслово: час і спосіб",
+        "tags": ["дієслово", "час", "спосіб", "verb", "tense", "mood"],
+        "url": "/p/ukrainska-mova/7-klas/morfologiia/diieslovo",
+        "grade": 7,
+        "category": "morphology",
+    },
+    {
+        "title": "Складне речення",
+        "tags": ["складне", "речення", "syntax", "sentence"],
+        "url": "/p/ukrainska-mova/9-klas/syntaksys/skladne-rechennia",
+        "grade": 9,
+        "category": "syntax",
+    },
+]
+
+
+def _mock_load_index() -> list[dict]:
+    return list(_FAKE_INDEX)
+
+
+# ---------------------------------------------------------------------------
+# _tokenize — text normalization
+# ---------------------------------------------------------------------------
+
+
+class TestTokenize:
+    def test_basic_ukrainian(self):
+        tokens = _tokenize("Голосні й приголосні звуки")
+        assert "голосні" in tokens
+        assert "приголосні" in tokens
+        assert "звуки" in tokens
+
+    def test_strips_english_parenthetical(self):
+        tokens = _tokenize("Іменник (Nouns)")
+        assert "іменник" in tokens
+        # The parenthetical content is removed
+        assert "nouns" not in tokens
+
+    def test_strips_punctuation(self):
+        tokens = _tokenize("м'які, тверді — дзвінкі!")
+        assert "м'які" not in tokens  # apostrophe stripped → мякі
+        assert "тверді" in tokens
+        assert "дзвінкі" in tokens
+
+    def test_short_tokens_excluded(self):
+        """Tokens with 2 or fewer characters are discarded."""
+        tokens = _tokenize("а в і це слово")
+        assert "а" not in tokens
+        assert "в" not in tokens
+        assert "і" not in tokens
+        assert "це" not in tokens
+        assert "слово" in tokens
+
+    def test_empty_string(self):
+        assert _tokenize("") == set()
+
+    def test_all_short_tokens(self):
+        assert _tokenize("а б в") == set()
+
+    def test_mixed_languages(self):
+        tokens = _tokenize("nouns іменник")
+        assert "nouns" in tokens
+        assert "іменник" in tokens
+
+    def test_nested_parentheses(self):
+        tokens = _tokenize("Тема (Topic (extra))")
+        # After regex strips parenthetical, "тема" remains
+        assert "тема" in tokens
+
+    def test_lowercased(self):
+        tokens = _tokenize("ЗВУКИ Фонетика")
+        assert "звуки" in tokens
+        assert "фонетика" in tokens
+
+
+# ---------------------------------------------------------------------------
+# _extract_plan_keywords — keyword extraction from plan dict
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPlanKeywords:
+    def test_grammar_field(self):
+        plan = {"grammar": ["Голосні і приголосні звуки", "Наголос"]}
+        kw = _extract_plan_keywords(plan)
+        assert "голосні" in kw
+        assert "приголосні" in kw
+        assert "звуки" in kw
+        assert "наголос" in kw
+
+    def test_focus_field(self):
+        plan = {"focus": "phonetics"}
+        kw = _extract_plan_keywords(plan)
+        assert "phonetics" in kw
+
+    def test_content_outline_sections(self):
+        plan = {
+            "content_outline": [
+                {"section": "Іменник (Nouns)", "words": 300, "points": []},
+            ]
+        }
+        kw = _extract_plan_keywords(plan)
+        assert "іменник" in kw
+        # English parenthetical stripped
+        assert "nouns" not in kw
+
+    def test_empty_plan(self):
+        assert _extract_plan_keywords({}) == set()
+
+    def test_non_string_grammar_items_ignored(self):
+        plan = {"grammar": [42, None, "Наголос"]}
+        kw = _extract_plan_keywords(plan)
+        assert "наголос" in kw
+
+    def test_combined_sources(self):
+        plan = {
+            "grammar": ["Дієслово"],
+            "focus": "morphology",
+            "content_outline": [
+                {"section": "Час і спосіб дієслова (Verb tense and mood)"},
+            ],
+        }
+        kw = _extract_plan_keywords(plan)
+        assert "дієслово" in kw
+        assert "morphology" in kw
+        assert "спосіб" in kw
+
+
+# ---------------------------------------------------------------------------
+# find_matching_topics — scoring + filtering
+# ---------------------------------------------------------------------------
+
+
+class TestFindMatchingTopics:
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_basic_match(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        results = find_matching_topics(plan)
+        assert len(results) >= 1
+        assert results[0]["title"] == "Голосні й приголосні звуки"
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_grade_proximity_bonus(self):
+        """A1 maps to grades 5-6; grade-5 entry should get bonus."""
+        plan = {
+            "grammar": ["Голосні звуки"],
+            "level": "a1",
+        }
+        results = find_matching_topics(plan)
+        for r in results:
+            if r["grade"] == 5:
+                # Score includes grade bonus
+                assert r["score"] >= 2
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_category_bonus(self):
+        """Focus=phonetics should boost phonetics-category entries."""
+        plan = {
+            "grammar": ["звуки"],
+            "focus": "phonetics",
+            "level": "a1",
+        }
+        results = find_matching_topics(plan)
+        phonetics_scores = [r["score"] for r in results if r["category"] == "phonetics"]
+        assert len(phonetics_scores) >= 1
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_minimum_threshold_filters_noise(self):
+        """Single-word overlap with score < 2 is excluded."""
+        plan = {
+            "grammar": ["sentence"],  # only overlaps with "sentence" tag in index
+            "level": "c1",
+        }
+        results = find_matching_topics(plan)
+        # "sentence" alone = 1 overlap; grade 9 matches c1 band (9-11) → +1 = score 2
+        # So it might still pass threshold if grade matches; verify no false positives
+        for r in results:
+            assert r["score"] >= 2
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_max_results_limit(self):
+        plan = {
+            "grammar": ["звуки", "голосні", "приголосні", "фонетика"],
+            "level": "a1",
+        }
+        results = find_matching_topics(plan, max_results=2)
+        assert len(results) <= 2
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_empty_plan_returns_empty(self):
+        results = find_matching_topics({})
+        assert results == []
+
+    @patch("build.miyklas._load_index", return_value=[])
+    def test_empty_index_returns_empty(self, _mock):
+        plan = {"grammar": ["Голосні звуки"]}
+        results = find_matching_topics(plan)
+        assert results == []
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_no_overlap_returns_empty(self):
+        plan = {"grammar": ["xyznonexistent"]}
+        results = find_matching_topics(plan)
+        assert results == []
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_results_sorted_by_score_desc(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки", "фонетика"],
+            "focus": "phonetics",
+            "level": "a1",
+        }
+        results = find_matching_topics(plan)
+        if len(results) >= 2:
+            scores = [r["score"] for r in results]
+            assert scores == sorted(scores, reverse=True)
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_url_gets_base_prefix(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        results = find_matching_topics(plan)
+        assert len(results) >= 1
+        assert results[0]["url"].startswith("https://miyklas.com.ua/")
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_unknown_level_uses_full_range(self):
+        """Unknown CEFR level defaults to (5, 11) range."""
+        plan = {
+            "grammar": ["Голосні звуки"],
+            "level": "x9",  # not in _LEVEL_GRADE_MAP
+        }
+        results = find_matching_topics(plan)
+        # Should still work, just no grade bonus for entries outside default
+        assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# build_miyklas_resource_entries — resource tab entries
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResourceEntries:
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_returns_list_of_dicts(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        entries = build_miyklas_resource_entries(plan)
+        assert isinstance(entries, list)
+        if entries:
+            entry = entries[0]
+            assert "title" in entry
+            assert "url" in entry
+            assert "source" in entry
+            assert "type" in entry
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_title_prefixed_with_miyklas(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        entries = build_miyklas_resource_entries(plan)
+        assert len(entries) >= 1
+        assert entries[0]["title"].startswith("МійКлас: ")
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_source_is_domain(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        entries = build_miyklas_resource_entries(plan)
+        for e in entries:
+            assert e["source"] == "miyklas.com.ua"
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_type_is_articles(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        entries = build_miyklas_resource_entries(plan)
+        for e in entries:
+            assert e["type"] == "articles"
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_max_3_entries(self):
+        plan = {
+            "grammar": ["звуки", "голосні", "приголосні", "фонетика", "наголос"],
+            "level": "a1",
+        }
+        entries = build_miyklas_resource_entries(plan)
+        assert len(entries) <= 3
+
+    @patch("build.miyklas._load_index", return_value=[])
+    def test_no_index_returns_empty(self, _mock):
+        plan = {"grammar": ["Голосні звуки"]}
+        entries = build_miyklas_resource_entries(plan)
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# build_miyklas_knowledge_section — knowledge packet markdown
+# ---------------------------------------------------------------------------
+
+
+class TestBuildKnowledgeSection:
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_returns_markdown_with_header(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        assert "## МійКлас Grammar References" in section
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_contains_matched_topic_titles(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        assert "Голосні й приголосні звуки" in section
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_contains_miyklas_links(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        assert "[МійКлас](" in section
+        assert "miyklas.com.ua" in section
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_contains_grade_info(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        assert "Grade 5" in section
+
+    @patch("build.miyklas._load_index", return_value=[])
+    def test_empty_index_returns_empty_string(self, _mock):
+        plan = {"grammar": ["Голосні звуки"]}
+        section = build_miyklas_knowledge_section(plan)
+        assert section == ""
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_no_matches_returns_empty_string(self):
+        plan = {"grammar": ["xyznonexistent"]}
+        section = build_miyklas_knowledge_section(plan)
+        assert section == ""
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_max_5_entries(self):
+        plan = {
+            "grammar": ["звуки", "голосні", "приголосні", "фонетика", "наголос", "іменник", "дієслово"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        # Count bullet points
+        bullets = [line for line in section.split("\n") if line.startswith("- **")]
+        assert len(bullets) <= 5
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_has_webfetch_instruction(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        assert "WebFetch" in section
+
+    @patch("build.miyklas._load_index", _mock_load_index)
+    def test_starts_with_separator(self):
+        plan = {
+            "grammar": ["Голосні і приголосні звуки"],
+            "level": "a1",
+        }
+        section = build_miyklas_knowledge_section(plan)
+        assert "---" in section
+
+
+# ---------------------------------------------------------------------------
+# _load_index — file loading edge cases (tested via find_matching_topics)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIndex:
+    def test_nonexistent_index_returns_empty(self, tmp_path):
+        """When the index file doesn't exist, _load_index returns []."""
+        with patch("build.miyklas._INDEX_PATH", tmp_path / "nonexistent.yaml"):
+            # Clear the lru_cache before testing
+            from build.miyklas import _load_index
+            _load_index.cache_clear()
+            result = _load_index()
+            assert result == []
+            _load_index.cache_clear()
+
+    def test_malformed_yaml_returns_empty(self, tmp_path):
+        """Malformed YAML file gracefully returns []."""
+        bad_file = tmp_path / "bad.yaml"
+        bad_file.write_text(": : : invalid yaml [[[", "utf-8")
+        with patch("build.miyklas._INDEX_PATH", bad_file):
+            from build.miyklas import _load_index
+            _load_index.cache_clear()
+            result = _load_index()
+            assert result == []
+            _load_index.cache_clear()
+
+    def test_yaml_without_topics_key_returns_empty(self, tmp_path):
+        """YAML file that lacks 'topics' key returns []."""
+        no_topics = tmp_path / "no_topics.yaml"
+        no_topics.write_text("version: '1.0'\nsource: test\n", "utf-8")
+        with patch("build.miyklas._INDEX_PATH", no_topics):
+            from build.miyklas import _load_index
+            _load_index.cache_clear()
+            result = _load_index()
+            assert result == []
+            _load_index.cache_clear()


### PR DESCRIPTION
## Summary

This PR adds МійКлас (miyklas.com.ua) as a new trusted grammar source for the V6 build pipeline, enabling automatic matching of Ukrainian school grammar theory pages (Grades 5–11, NUS aligned) to module plans during both RESEARCH and ENRICH steps.

## Changes

The core of this change lives in `scripts/build/miyklas.py`, a new module that owns the matching logic end-to-end. `find_matching_topics()` tokenizes a plan's `grammar` and `focus` fields, then scores each entry in `data/miyklas/grammar_index.yaml` (649-line hand-curated topic→URL mapping) by keyword overlap against the entry's `tags` list. The scorer applies a grade-proximity bonus using a CEFR→Ukrainian-school-grade mapping (`_LEVEL_GRADE_MAP`) and a category alignment bonus when the plan focus maps cleanly to a grammar category, with a minimum threshold of 2 to suppress noise from single-token coincidences. Two public functions consume the scored results: `build_miyklas_resource_entries()` produces structured dicts for the Ресурсі tab, and `build_miyklas_knowledge_section()` emits a markdown section of topic pointers for the knowledge packet.

The two integration points are minimal. In `scripts/build/enrich.py`, `_build_resources()` now calls `build_miyklas_resource_entries(plan)` and renders a dedicated "Граматика — Grammar (МійКлас)" block in the resources output — the import is wrapped in a try/except so a missing index file degrades gracefully rather than blowing up the build. In `scripts/build/research/build_knowledge_packet.py`, `build_packet()` appends the МійКлас knowledge section after the RAG reference lines, again with a guarded import. This design keeps МійКлас completely optional: if the index YAML is absent or the import fails, both pipelines continue producing output identical to before. The index file itself and a new entry in `docs/resources/trusted_sources.yaml` round out the data layer.

## Testing

All three test files (`tests/test_miyklas.py`, `tests/test_enrich.py`, `tests/test_build_knowledge_packet.py`) were run locally with pytest and pass cleanly. `test_miyklas.py` (482 lines) covers `_tokenize`, `_extract_plan_keywords`, `find_matching_topics` with grade and category bonuses, `build_miyklas_resource_entries`, and `build_miyklas_knowledge_section` using a synthetic index fixture to avoid hitting the real YAML. `test_enrich.py` and `test_build_knowledge_packet.py` verify that the МійКлас integration points produce expected output when the module is importable and degrade without error when it is not. The website build (`npm run build:starlight`) completes without errors against the current curriculum content.

## Related Issues

Closes https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/1040