### PR TITLE
fix(v6): harden plan-patch recovery and reconcile state drift

### DIFF
--- a/docs/state-reconciliation.md
+++ b/docs/state-reconciliation.md
@@ -1,0 +1,71 @@
+# State/Artifact Reconciliation — Operator Guide
+
+The v6 build pipeline maintains two sources of truth for each module:
+
+1. **`state.json`** — phase-level status in `curriculum/{level}/orchestration/{slug}/state.json`
+2. **Artifacts on disk** — the actual `.md` content files, review files, `needs-human-review.yaml`, etc.
+
+These can drift apart when builds fail mid-flight, plan patches modify the plan after phases have run, or file operations fail silently. The reconciliation system detects these contradictions at resume time and forces re-execution of affected phases.
+
+## How it works
+
+`reconcile_state_artifacts(level, slug)` runs at the start of `_build_resume_invalidation_plan` — i.e., every time `--resume` evaluates whether to skip or re-run a module. It returns a list of `StateArtifactContradiction` objects, each with a `kind` and `detail`.
+
+When contradictions are found:
+- Each is logged as a warning: `state drift [level/slug]: kind — detail`
+- Affected phases are invalidated (forced to re-run)
+- The resume plan reports `reason: "state/artifact drift detected: ..."`
+
+## Contradiction types
+
+| `kind` | What it means | Auto-fix |
+|--------|---------------|----------|
+| `needs_human_review_state_only` | `state.json` says the module needs human review, but the `needs-human-review.yaml` artifact is missing. The escalation context is lost. | No auto-fix. Investigate `state.json` to decide whether to clear the flag or recreate the artifact. |
+| `needs_human_review_artifact_only` | `needs-human-review.yaml` exists on disk but `state.json` doesn't have the `needs_human_review` flag. This can happen when state was cleared but file deletion failed. | No auto-fix. Either delete the stale artifact or re-set the state flag. |
+| `verify_stale_after_content_update` | State says `verify: failed` but the content `.md` file was modified after the verify timestamp. The failure may no longer apply. | `verify` phase is invalidated and will re-run. |
+| `review_complete_no_artifact` | State says `review: complete` but no review artifact (`.md` file) exists. The "pass" has no supporting evidence. | Review and downstream phases (`review-style`, `stress`, `publish`, `audit`) are invalidated. |
+| `failed_phase_plan_hash_drift` | A plan-hash-tracked phase (`skeleton`, `write`, `exercises`, `annotate`, `verify`) is `failed`, but the plan has since changed. The failure was against an old plan. | Phases from the earliest drifted one onward are invalidated. |
+
+## Manual investigation
+
+To check a specific module's state health:
+
+```bash
+# Read state.json
+cat curriculum/{level}/orchestration/{slug}/state.json | python -m json.tool
+
+# Check for needs-human-review artifact
+ls curriculum/{level}/orchestration/{slug}/needs-human-review.yaml
+
+# Check content mtime vs state timestamps
+stat curriculum/{level}/{slug}.md
+```
+
+To see contradictions without running a build:
+
+```python
+from build.v6_build import reconcile_state_artifacts
+contradictions = reconcile_state_artifacts("a1", "module-slug")
+for c in contradictions:
+    print(f"{c.kind}: {c.detail}")
+```
+
+## Plan-patch failure diagnostics
+
+When a plan-patch attempt fails to parse Gemini's response, a diagnostic artifact is saved to `curriculum/{level}/orchestration/{slug}/v6-plan-patch-diagnostic.yaml`. It contains:
+
+- `failure_reason` — one of: `empty_output`, `missing_delimiters`, `empty_payload_between_delimiters`, `yaml_parse_error: ...`, `unexpected_payload_type: ...`
+- `raw_output_length` — how many characters Gemini returned
+- `raw_output_preview` — first 500 characters of the response
+
+The full raw output is always saved to `v6-plan-patch-output.md` for investigation.
+
+### Failure reasons
+
+| Reason | Typical cause | Suggested action |
+|--------|---------------|------------------|
+| `empty_output` | Gemini returned nothing (timeout, quota) | Retry the build; check Gemini API status |
+| `missing_delimiters` | Gemini produced prose instead of structured output | Review the prompt in `v6-plan-patch-prompt.md`; the model may need stronger delimiter instructions |
+| `yaml_parse_error` | Delimiters present but content is not valid YAML | Usually a one-off — retry should work |
+| `unexpected_payload_type` | YAML parsed but was a list/string, not a mapping | Prompt issue — review template |
+| `empty_payload_between_delimiters` | Delimiters present but nothing between them | Usually a one-off — retry should work |

--- a/scripts/build/phases/plan_patch.py
+++ b/scripts/build/phases/plan_patch.py
@@ -331,19 +331,57 @@ def _dispatch_gemini_plan_patch(
     return True, response_text
 
 
-def parse_plan_patch_response(raw_output: str) -> dict | None:
-    """Parse the structured Gemini plan-patch payload."""
+@dataclass(frozen=True)
+class PlanPatchParseOutcome:
+    """Result of parsing plan-patch Gemini output, with explicit failure modes."""
+
+    data: dict | None
+    failure_reason: str | None
+
+    @property
+    def ok(self) -> bool:
+        return self.data is not None and self.failure_reason is None
+
+
+def parse_plan_patch_response(raw_output: str) -> PlanPatchParseOutcome:
+    """Parse the structured Gemini plan-patch payload.
+
+    Returns a ``PlanPatchParseOutcome`` with an explicit ``failure_reason``
+    when delimiters are missing, YAML is unparseable, or the payload shape
+    is unexpected.  The caller must inspect ``.ok`` before using ``.data``.
+    """
+    if not raw_output or not raw_output.strip():
+        return PlanPatchParseOutcome(data=None, failure_reason="empty_output")
+
     extracted = extract_delimited(raw_output, PLAN_PATCH_TAG)
     if extracted is None:
-        extracted = raw_output
+        return PlanPatchParseOutcome(
+            data=None,
+            failure_reason="missing_delimiters",
+        )
+
     cleaned = _strip_code_fence(extracted)
     if not cleaned:
-        return None
+        return PlanPatchParseOutcome(
+            data=None,
+            failure_reason="empty_payload_between_delimiters",
+        )
+
     try:
         data = yaml.safe_load(cleaned)
-    except yaml.YAMLError:
-        return None
-    return data if isinstance(data, dict) else None
+    except yaml.YAMLError as exc:
+        return PlanPatchParseOutcome(
+            data=None,
+            failure_reason=f"yaml_parse_error: {exc}",
+        )
+
+    if not isinstance(data, dict):
+        return PlanPatchParseOutcome(
+            data=None,
+            failure_reason=f"unexpected_payload_type: {type(data).__name__}",
+        )
+
+    return PlanPatchParseOutcome(data=data, failure_reason=None)
 
 
 def _parse_path(path: str) -> list[str | int]:
@@ -608,22 +646,37 @@ def run_plan_patch(
             complaint_summary=complaint_summary,
         )
 
-    response = parse_plan_patch_response(raw_output)
-    if response is None:
+    parse_outcome = parse_plan_patch_response(raw_output)
+    if not parse_outcome.ok:
+        # Save diagnostic artifact so operators can distinguish failure modes
+        diag_path = orch_dir / "v6-plan-patch-diagnostic.yaml"
+        write_text_atomic(
+            diag_path,
+            yaml.safe_dump(
+                {
+                    "failure_reason": parse_outcome.failure_reason,
+                    "raw_output_length": len(raw_output),
+                    "raw_output_preview": raw_output[:500] if raw_output else "",
+                },
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
         return PlanPatchResult(
             applied=False,
-            reason="Gemini returned no parseable plan-patch payload",
+            reason=f"plan-patch parse failed: {parse_outcome.failure_reason}",
             complaint_summary=complaint_summary,
         )
 
     parsed_path = orch_dir / "v6-plan-patch-response.yaml"
     write_text_atomic(
         parsed_path,
-        yaml.safe_dump(response, allow_unicode=True, sort_keys=False),
+        yaml.safe_dump(parse_outcome.data, allow_unicode=True, sort_keys=False),
         encoding="utf-8",
     )
     return apply_plan_patch_response(
         plan_path,
-        response,
+        parse_outcome.data,
         complaint_summary=complaint_summary,
     )

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -85,6 +85,7 @@ from build.plan_tracking import (
     current_plan_hash_for,
     detect_plan_hash_drift,
     ordered_phases_from,
+    parse_phase_timestamp,
     plan_path_for,
 )
 
@@ -113,6 +114,40 @@ STYLE_REVIEW_DIMENSION_LABELS = {
 }
 V6_PHASE_STATUS = Literal["complete", "skipped", "failed", "degraded", "stale"]
 _VALID_V6_PHASE_STATUSES = {"complete", "skipped", "failed", "degraded", "stale"}
+
+# --- dim_floor_fail keyword matching with negation awareness ---
+
+_DIM_FLOOR_ERROR_KEYWORDS = (
+    "error", "incorrect", "wrong", "mistake", "factual",
+    "помилк", "невірн", "хибн", "contradictory",
+)
+_DIM_FLOOR_NEGATION_PREFIXES = (
+    "no ", "not ", "without ", "free of ", "absent ",
+    "ні ", "без ", "жодн",
+)
+# Max characters before a keyword match to check for negation prefix
+_NEGATION_LOOKBACK = 12
+
+
+def _evidence_has_error_keyword(evidence: str) -> bool:
+    """Return True when evidence text contains an error keyword NOT preceded by negation.
+
+    Prevents false ``dim_floor_fail`` from phrases like "no incorrect forms found"
+    or "without errors".
+    """
+    lowered = evidence.lower()
+    for kw in _DIM_FLOOR_ERROR_KEYWORDS:
+        start = 0
+        while True:
+            idx = lowered.find(kw, start)
+            if idx == -1:
+                break
+            # Check the preceding context for negation prefixes
+            lookback = lowered[max(0, idx - _NEGATION_LOOKBACK):idx]
+            if not any(lookback.rstrip().endswith(neg.rstrip()) for neg in _DIM_FLOOR_NEGATION_PREFIXES):
+                return True
+            start = idx + len(kw)
+    return False
 
 
 class V6StateError(ValueError):
@@ -1095,8 +1130,119 @@ def _clear_needs_human_review_marker(level: str, slug: str) -> None:
             _write_v6_state_atomic(state_path, state)
 
     needs_review_path = CURRICULUM_ROOT / level / "orchestration" / slug / "needs-human-review.yaml"
-    if needs_review_path.exists():
-        needs_review_path.unlink()
+    try:
+        if needs_review_path.exists():
+            needs_review_path.unlink()
+    except OSError:
+        logger.warning(
+            "Could not delete %s — state cleared but artifact persists", needs_review_path
+        )
+
+
+@dataclass(frozen=True)
+class StateArtifactContradiction:
+    """One detected contradiction between state.json and on-disk artifacts."""
+
+    kind: str
+    detail: str
+
+
+def reconcile_state_artifacts(level: str, slug: str) -> list[StateArtifactContradiction]:
+    """Detect contradictions between state.json and on-disk artifacts.
+
+    Returns a list of contradictions found. An empty list means state and
+    artifacts are consistent. Operators should treat any non-empty result
+    as requiring investigation before trusting the module's status.
+
+    Checked invariants:
+
+    1. **needs_human_review consistency** — if state has ``needs_human_review``
+       set, the corresponding ``needs-human-review.yaml`` artifact must exist,
+       and vice versa.
+    2. **verify vs content mtime** — if state says ``verify: failed`` but the
+       content ``.md`` file was modified *after* the verify timestamp, the
+       verify result is stale.
+    3. **review phase vs artifact** — if state says ``review: complete`` but no
+       review artifact can be found, the state is unsupported by evidence.
+    4. **plan-hash drift on failed phases** — if a plan-hash-tracked phase is
+       ``failed`` but the plan hash has since changed, the failure may be stale.
+    """
+    state_path = _v6_state_path(level, slug)
+    if not state_path.exists():
+        return []
+
+    state = _read_v6_state(level, slug)
+    contradictions: list[StateArtifactContradiction] = []
+    orch_dir = CURRICULUM_ROOT / level / "orchestration" / slug
+    phases = state.get("phases", {})
+
+    # 1. needs_human_review consistency
+    needs_review_in_state = bool(state.get("needs_human_review", {}).get("status"))
+    needs_review_yaml = orch_dir / "needs-human-review.yaml"
+    needs_review_on_disk = needs_review_yaml.exists()
+
+    if needs_review_in_state and not needs_review_on_disk:
+        contradictions.append(StateArtifactContradiction(
+            kind="needs_human_review_state_only",
+            detail="state.json has needs_human_review=True but needs-human-review.yaml is missing",
+        ))
+    elif needs_review_on_disk and not needs_review_in_state:
+        contradictions.append(StateArtifactContradiction(
+            kind="needs_human_review_artifact_only",
+            detail="needs-human-review.yaml exists but state.json has no needs_human_review flag",
+        ))
+
+    # 2. verify vs content mtime
+    verify_info = phases.get("verify")
+    if isinstance(verify_info, dict) and verify_info.get("status") == "failed":
+        content_path = CURRICULUM_ROOT / level / f"{slug}.md"
+        if content_path.exists():
+            verify_ts = parse_phase_timestamp(verify_info.get("ts"))
+            if verify_ts is not None:
+                content_mtime = datetime.fromtimestamp(content_path.stat().st_mtime, tz=UTC)
+                if content_mtime > verify_ts:
+                    contradictions.append(StateArtifactContradiction(
+                        kind="verify_stale_after_content_update",
+                        detail=(
+                            f"state says verify=failed at {verify_ts.isoformat()} "
+                            f"but content was modified at {content_mtime.isoformat()}"
+                        ),
+                    ))
+
+    # 3. review phase vs artifact
+    review_info = phases.get("review")
+    if isinstance(review_info, dict) and review_info.get("status") == "complete":
+        review_dir = CURRICULUM_ROOT / level / "review"
+        review_path = review_dir / f"{slug}-review.md"
+        has_review = review_path.exists()
+        if not has_review and review_dir.exists():
+            has_review = bool(list(review_dir.glob(f"{slug}-review-r*.md")))
+        if not has_review:
+            contradictions.append(StateArtifactContradiction(
+                kind="review_complete_no_artifact",
+                detail="state says review=complete but no review artifact found",
+            ))
+
+    # 4. plan-hash drift on failed phases
+    current_hash = _current_plan_hash(level, slug)
+    if current_hash:
+        for phase_name in PLAN_HASH_PHASES:
+            phase_info = phases.get(phase_name)
+            if not isinstance(phase_info, dict):
+                continue
+            if phase_info.get("status") != "failed":
+                continue
+            saved_hash = phase_info.get("plan_hash")
+            if saved_hash and saved_hash != current_hash:
+                contradictions.append(StateArtifactContradiction(
+                    kind="failed_phase_plan_hash_drift",
+                    detail=(
+                        f"{phase_name}=failed was recorded against plan hash "
+                        f"{saved_hash[:12]}… but current plan hash is {current_hash[:12]}…"
+                    ),
+                ))
+
+    return contradictions
 
 
 def _invalidate_phases(level: str, slug: str, phases_to_clear: list[str]) -> None:
@@ -1288,14 +1434,10 @@ def _parse_review_result(review_text: str) -> ReviewParseResult:
 
     dim_floor_fail = False
     if parsed_scores:
-        error_keywords = (
-            "error", "incorrect", "wrong", "mistake", "factual",
-            "помилк", "невірн", "хибн", "contradictory",
-        )
         for dim in parsed_scores:
             dim_score = dim.get("score", 10)
-            evidence = dim.get("evidence", "").lower()
-            if dim_score < REVIEW_TARGET_SCORE and any(kw in evidence for kw in error_keywords):
+            evidence = dim.get("evidence", "")
+            if dim_score < REVIEW_TARGET_SCORE and _evidence_has_error_keyword(evidence):
                 dim_floor_fail = True
                 break
 
@@ -1510,6 +1652,42 @@ def _build_resume_invalidation_plan(
     raw_state = _read_v6_state(level, slug) if _v6_state_path(level, slug).exists() else {}
     if completed_phases is None:
         completed_phases = _load_completed_phases(level, slug)
+
+    # State/artifact reconciliation — flag contradictions before skip decisions
+    contradictions = reconcile_state_artifacts(level, slug)
+    if contradictions:
+        contradiction_kinds = {c.kind for c in contradictions}
+        for c in contradictions:
+            logger.warning("state drift [%s/%s]: %s — %s", level, slug, c.kind, c.detail)
+
+        # Determine which phases need invalidation based on contradiction types
+        drift_invalidation: set[str] = set()
+        if "verify_stale_after_content_update" in contradiction_kinds:
+            drift_invalidation.add("verify")
+        if "review_complete_no_artifact" in contradiction_kinds:
+            drift_invalidation.update({"review", "review-style", "stress", "publish", "audit"})
+        if any(c.kind == "failed_phase_plan_hash_drift" for c in contradictions):
+            # Re-run from earliest drifted phase
+            drifted = [
+                c.detail.split("=")[0] for c in contradictions
+                if c.kind == "failed_phase_plan_hash_drift"
+            ]
+            for phase_name in _ALL_PHASES:
+                if phase_name in drifted:
+                    drift_invalidation.update(
+                        ordered_phases_from(_ALL_PHASES, phase_name, raw_state.get("phases", {}))
+                    )
+                    break
+
+        if drift_invalidation:
+            base_invalidation = set(_resume_invalidation_plan_for_step(step, completed_phases))
+            base_invalidation.update(drift_invalidation)
+            reasons = ", ".join(sorted(contradiction_kinds))
+            return ResumeInvalidationPlan(
+                should_skip=False,
+                reason=f"state/artifact drift detected: {reasons}",
+                invalidate_phases=_ordered_invalidation_phases(base_invalidation, completed_phases),
+            )
 
     invalidation = set(_resume_invalidation_plan_for_step(step, completed_phases))
     audit_tail = {"audit", "publish"}
@@ -5892,12 +6070,8 @@ def step_review(content_path: Path, level: str, module_num: int,
 
     for dim in parsed.parsed_scores:
         dim_score = dim.get("score", 10)
-        evidence = dim.get("evidence", "").lower()
-        error_keywords = (
-            "error", "incorrect", "wrong", "mistake", "factual",
-            "помилк", "невірн", "хибн", "contradictory",
-        )
-        if dim_score < REVIEW_TARGET_SCORE and any(kw in evidence for kw in error_keywords):
+        evidence = dim.get("evidence", "")
+        if dim_score < REVIEW_TARGET_SCORE and _evidence_has_error_keyword(evidence):
             dim_name = dim.get("name", "?")
             _log(f"  ⚠️  Dimension floor: {dim_name} = {dim_score}/10 with identified errors")
 

--- a/tests/test_plan_patch_parse_failures.py
+++ b/tests/test_plan_patch_parse_failures.py
@@ -1,0 +1,156 @@
+"""Regression tests for plan-patch parse failure handling (#1304).
+
+Ensures that unparseable Gemini output produces explicit, deterministic
+failure reasons rather than silently falling back to treating the entire
+raw LLM response as YAML.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import yaml
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+plan_patch = importlib.import_module("build.phases.plan_patch")
+
+
+class TestParsePlanPatchResponse:
+    """parse_plan_patch_response must return structured failure reasons."""
+
+    def test_missing_delimiters_returns_explicit_failure(self) -> None:
+        raw = "Here is some prose from Gemini without any delimiters."
+        outcome = plan_patch.parse_plan_patch_response(raw)
+        assert not outcome.ok
+        assert outcome.failure_reason == "missing_delimiters"
+        assert outcome.data is None
+
+    def test_empty_output_returns_explicit_failure(self) -> None:
+        outcome = plan_patch.parse_plan_patch_response("")
+        assert not outcome.ok
+        assert outcome.failure_reason == "empty_output"
+
+    def test_whitespace_only_returns_empty_output(self) -> None:
+        outcome = plan_patch.parse_plan_patch_response("   \n\n  ")
+        assert not outcome.ok
+        assert outcome.failure_reason == "empty_output"
+
+    def test_valid_delimiters_with_valid_yaml_succeeds(self) -> None:
+        raw = (
+            "noise\n"
+            "===PLAN_PATCH_START===\n"
+            "decision: noop\n"
+            "complaint_summary: prose-only issue\n"
+            "===PLAN_PATCH_END===\n"
+            "more noise"
+        )
+        outcome = plan_patch.parse_plan_patch_response(raw)
+        assert outcome.ok
+        assert outcome.data["decision"] == "noop"
+        assert outcome.failure_reason is None
+
+    def test_valid_delimiters_with_invalid_yaml_returns_parse_error(self) -> None:
+        raw = (
+            "===PLAN_PATCH_START===\n"
+            "not: valid: yaml: [unclosed\n"
+            "===PLAN_PATCH_END===\n"
+        )
+        outcome = plan_patch.parse_plan_patch_response(raw)
+        assert not outcome.ok
+        assert outcome.failure_reason is not None
+        assert outcome.failure_reason.startswith("yaml_parse_error")
+
+    def test_valid_delimiters_with_non_dict_yaml_returns_type_error(self) -> None:
+        raw = (
+            "===PLAN_PATCH_START===\n"
+            "- just a list item\n"
+            "- another item\n"
+            "===PLAN_PATCH_END===\n"
+        )
+        outcome = plan_patch.parse_plan_patch_response(raw)
+        assert not outcome.ok
+        assert outcome.failure_reason is not None
+        assert "unexpected_payload_type" in outcome.failure_reason
+
+    def test_empty_content_between_delimiters(self) -> None:
+        raw = (
+            "===PLAN_PATCH_START===\n"
+            "\n"
+            "===PLAN_PATCH_END===\n"
+        )
+        outcome = plan_patch.parse_plan_patch_response(raw)
+        assert not outcome.ok
+        assert outcome.failure_reason == "empty_payload_between_delimiters"
+
+    def test_code_fence_stripping_within_delimiters(self) -> None:
+        raw = (
+            "===PLAN_PATCH_START===\n"
+            "```yaml\n"
+            "decision: patch\n"
+            "complaint_summary: test\n"
+            "changes: []\n"
+            "```\n"
+            "===PLAN_PATCH_END===\n"
+        )
+        outcome = plan_patch.parse_plan_patch_response(raw)
+        assert outcome.ok
+        assert outcome.data["decision"] == "patch"
+
+
+class TestRunPlanPatchDiagnosticArtifact:
+    """run_plan_patch must save diagnostic artifacts on parse failure."""
+
+    def test_diagnostic_artifact_written_on_missing_delimiters(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        plan_path = tmp_path / "plan.yaml"
+        plan_path.write_text("version: '1.0'\ntitle: Demo\n", "utf-8")
+        orch_dir = tmp_path / "orch"
+        orch_dir.mkdir()
+        (orch_dir / "review-structured-r1.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "round": 1,
+                    "scores": [
+                        {
+                            "dimension": 2,
+                            "name": "Linguistic accuracy",
+                            "score": 8,
+                            "evidence": "A few inflection errors remain.",
+                        }
+                    ],
+                    "findings": [],
+                },
+                sort_keys=False,
+            ),
+            "utf-8",
+        )
+
+        # Gemini returns prose without delimiters
+        monkeypatch.setattr(
+            plan_patch,
+            "_dispatch_gemini_plan_patch",
+            lambda *args, **kwargs: (True, "I think the plan is fine as-is."),
+        )
+
+        result = plan_patch.run_plan_patch(
+            level="a1",
+            slug="demo",
+            plan_path=plan_path,
+            orch_dir=orch_dir,
+            score_history=[8.3],
+            contract_violations=[],
+        )
+
+        assert result.applied is False
+        assert "missing_delimiters" in result.reason
+
+        diag_path = orch_dir / "v6-plan-patch-diagnostic.yaml"
+        assert diag_path.exists()
+        diag = yaml.safe_load(diag_path.read_text("utf-8"))
+        assert diag["failure_reason"] == "missing_delimiters"
+        assert diag["raw_output_length"] > 0

--- a/tests/test_state_drift_reconciliation.py
+++ b/tests/test_state_drift_reconciliation.py
@@ -1,0 +1,289 @@
+"""Regression tests for state/artifact drift detection and reconciliation (#1304).
+
+Tests:
+- _evidence_has_error_keyword negation awareness (dim_floor_fail false positives)
+- reconcile_state_artifacts contradiction detection
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from build import v6_build
+
+# ---------- _evidence_has_error_keyword tests ----------
+
+
+class TestEvidenceHasErrorKeyword:
+    """Negation-aware keyword matching prevents dim_floor_fail false positives."""
+
+    def test_plain_error_keyword_detected(self) -> None:
+        assert v6_build._evidence_has_error_keyword("Contains a factual error in section 3")
+
+    def test_negated_no_prefix_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("No incorrect forms found")
+
+    def test_negated_not_prefix_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("Grammar is not wrong in this section")
+
+    def test_negated_without_prefix_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("Text is without errors throughout")
+
+    def test_negated_free_of_prefix_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("Content is free of mistakes")
+
+    def test_negated_ukrainian_bez_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("Текст без помилок")
+
+    def test_negated_ukrainian_ni_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("Ні невірних форм")
+
+    def test_negated_absent_prefix_not_detected(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("Absent factual issues in the text")
+
+    def test_non_negated_keyword_still_detected_after_negated(self) -> None:
+        # "no errors" is negated, but "wrong translation" is not
+        assert v6_build._evidence_has_error_keyword(
+            "No errors in grammar but has a wrong translation in section 2"
+        )
+
+    def test_case_insensitive(self) -> None:
+        assert v6_build._evidence_has_error_keyword("Contains an ERROR in the vocabulary")
+
+    def test_empty_evidence(self) -> None:
+        assert not v6_build._evidence_has_error_keyword("")
+
+    def test_keyword_at_start_of_string(self) -> None:
+        assert v6_build._evidence_has_error_keyword("Incorrect declension used")
+
+    def test_multiple_negated_keywords_all_negated(self) -> None:
+        assert not v6_build._evidence_has_error_keyword(
+            "No incorrect forms, no wrong translations, without mistakes"
+        )
+
+    def test_ukrainian_помилк_detected_without_negation(self) -> None:
+        assert v6_build._evidence_has_error_keyword("Знайдено помилки в тексті")
+
+    def test_contradictory_detected(self) -> None:
+        assert v6_build._evidence_has_error_keyword("Contains contradictory statements")
+
+
+class TestDimFloorFailIntegration:
+    """_parse_review_result uses negation-aware matching."""
+
+    def _make_review_text(self, dim_score: int, evidence: str) -> str:
+        # Format must match the regex in _parse_review_result:
+        #   r"\|\s*(\d+)\.\s*([^|]+)\|\s*(\d+)/10\s*\|([^|]*)\|"
+        # Need all 9 dimensions for a valid weighted score >= 8.0
+        lines = [
+            "## Review\n",
+            "Verdict: PASS\n",
+            "| # | Dimension | Score | Evidence |",
+            "|---|-----------|-------|----------|",
+        ]
+        for i in range(1, 10):
+            if i == 2:  # Linguistic accuracy — our test dimension
+                lines.append(f"| {i}. Linguistic accuracy | {dim_score}/10 | {evidence} |")
+            else:
+                lines.append(f"| {i}. Dimension {i} | 10/10 | Excellent |")
+        return "\n".join(lines) + "\n"
+
+    def test_negated_evidence_does_not_trigger_dim_floor_fail(self) -> None:
+        review_text = self._make_review_text(8, "No incorrect forms found in the text")
+        parsed = v6_build._parse_review_result(review_text)
+        assert not parsed.dim_floor_fail
+        assert parsed.passed  # weighted score >= 8.0, verdict == PASS, no floor fail
+
+    def test_genuine_error_evidence_triggers_dim_floor_fail(self) -> None:
+        review_text = self._make_review_text(8, "Incorrect declension of іменник")
+        parsed = v6_build._parse_review_result(review_text)
+        assert parsed.dim_floor_fail
+        assert not parsed.passed
+
+
+# ---------- reconcile_state_artifacts tests ----------
+
+
+def _setup_module_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    level: str = "a1",
+    slug: str = "test-module",
+    state: dict | None = None,
+) -> tuple[Path, Path]:
+    """Create minimal curriculum structure and return (curriculum_root, orch_dir)."""
+    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+
+    orch_dir = curriculum_root / level / "orchestration" / slug
+    orch_dir.mkdir(parents=True, exist_ok=True)
+
+    if state is not None:
+        state_path = orch_dir / "state.json"
+        state_path.write_text(json.dumps(state), "utf-8")
+
+    return curriculum_root, orch_dir
+
+
+class TestReconcileStateArtifacts:
+    """reconcile_state_artifacts detects state/artifact contradictions."""
+
+    def test_no_state_file_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_module_state(tmp_path, monkeypatch)
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert contradictions == []
+
+    def test_consistent_state_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "phases": {
+                    "write": {"status": "complete", "ts": datetime.now(tz=UTC).isoformat()},
+                },
+            },
+        )
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert contradictions == []
+
+    def test_needs_human_review_state_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "needs_human_review": {"status": True, "ts": "2026-04-17T10:00:00+00:00"},
+                "phases": {},
+            },
+        )
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert len(contradictions) == 1
+        assert contradictions[0].kind == "needs_human_review_state_only"
+
+    def test_needs_human_review_artifact_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, orch_dir = _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "phases": {},
+            },
+        )
+        (orch_dir / "needs-human-review.yaml").write_text("slug: test-module\n", "utf-8")
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert len(contradictions) == 1
+        assert contradictions[0].kind == "needs_human_review_artifact_only"
+
+    def test_verify_stale_after_content_update(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        old_ts = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
+        curriculum_root, _orch_dir = _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "phases": {
+                    "verify": {"status": "failed", "ts": old_ts},
+                },
+            },
+        )
+        content_path = curriculum_root / "a1" / "test-module.md"
+        content_path.parent.mkdir(parents=True, exist_ok=True)
+        content_path.write_text("# Updated content\n", "utf-8")
+
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert any(c.kind == "verify_stale_after_content_update" for c in contradictions)
+
+    def test_review_complete_no_artifact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "phases": {
+                    "review": {
+                        "status": "complete",
+                        "ts": datetime.now(tz=UTC).isoformat(),
+                    },
+                },
+            },
+        )
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert any(c.kind == "review_complete_no_artifact" for c in contradictions)
+
+    def test_failed_phase_plan_hash_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        curriculum_root, _orch_dir = _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "phases": {
+                    "write": {
+                        "status": "failed",
+                        "ts": datetime.now(tz=UTC).isoformat(),
+                        "plan_hash": "old_hash_000000000000",
+                    },
+                },
+            },
+        )
+        # Create a plan so _current_plan_hash returns something different
+        plan_dir = curriculum_root / "plans" / "a1"
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        (plan_dir / "test-module.yaml").write_text("version: '2.0'\ntitle: Updated\n", "utf-8")
+
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        assert any(c.kind == "failed_phase_plan_hash_drift" for c in contradictions)
+
+    def test_no_contradiction_when_both_needs_review_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, orch_dir = _setup_module_state(
+            tmp_path,
+            monkeypatch,
+            state={
+                "mode": "v6",
+                "track": "a1",
+                "slug": "test-module",
+                "needs_human_review": {"status": True, "ts": "2026-04-17T10:00:00+00:00"},
+                "phases": {},
+            },
+        )
+        (orch_dir / "needs-human-review.yaml").write_text("slug: test-module\n", "utf-8")
+        contradictions = v6_build.reconcile_state_artifacts("a1", "test-module")
+        # Both present → consistent, no contradiction
+        assert not any(c.kind.startswith("needs_human_review") for c in contradictions)


### PR DESCRIPTION
## Summary

Closes #1304.

- **Deterministic plan-patch parse failures**: removed the fallback that treated entire raw Gemini output as YAML when `===PLAN_PATCH_START===`/`===PLAN_PATCH_END===` delimiters are missing. Parse failures now return an explicit `PlanPatchParseOutcome` with a typed `failure_reason` (`empty_output`, `missing_delimiters`, `yaml_parse_error`, `unexpected_payload_type`, `empty_payload_between_delimiters`). A diagnostic artifact (`v6-plan-patch-diagnostic.yaml`) is saved on every parse failure.
- **High-score review no longer enters fragile recovery**: added negation-aware keyword matching for `dim_floor_fail` — phrases like "no incorrect forms found" or "без помилок" no longer trigger false floor failures that send high-scoring modules into plan-patch recovery.
- **State/artifact reconciliation**: `reconcile_state_artifacts()` detects 4 types of contradictions between `state.json` and on-disk artifacts, wired into `_build_resume_invalidation_plan` to auto-invalidate affected phases at resume time. Fixed `_clear_needs_human_review_marker` to handle `OSError` on file deletion.
- **26 regression tests** covering all parse failure modes, negation-aware keyword matching, dim_floor_fail integration, and state/artifact contradiction detection.
- **Operator docs** at `docs/state-reconciliation.md`.

## Test plan

- [x] `ruff check` passes on all changed files
- [x] Pre-commit hooks pass (lint + pytest on affected files)
- [x] 51 targeted tests pass: `pytest tests/test_plan_patch_parse_failures.py tests/test_state_drift_reconciliation.py tests/test_plan_patch.py tests/test_v6_state_io.py tests/test_v6_review_plateau.py tests/test_v6_plan_hash_drift.py`
- [ ] Run proving set on A1/A2 modules to verify no regressions in review/plan-patch flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)