### PR TITLE
fix(v6): integrate style, review, and state control-plane fixes

### DIFF
--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -462,7 +462,9 @@ class ReviewParseResult:
     verdict: str
     raw_scores: list[int]
     parsed_scores: list[dict]
+    findings_count: int
     dim_floor_fail: bool
+    reviewer_contract_invalid: bool
     passed: bool
 
 
@@ -1441,13 +1443,23 @@ def _parse_review_result(review_text: str) -> ReviewParseResult:
                 dim_floor_fail = True
                 break
 
-    passed = score >= 8.0 and verdict == "PASS" and not dim_floor_fail
+    findings_count = len(_extract_structured_findings(review_text))
+    reviewer_contract_invalid = (
+        bool(raw_scores)
+        and score < REVIEW_TARGET_SCORE
+        and findings_count == 0
+    )
+    passed = reviewer_contract_invalid or (
+        score >= REVIEW_TARGET_SCORE and verdict == "PASS" and not dim_floor_fail
+    )
     return ReviewParseResult(
         score=score,
         verdict=verdict,
         raw_scores=raw_scores,
         parsed_scores=parsed_scores,
+        findings_count=findings_count,
         dim_floor_fail=dim_floor_fail,
+        reviewer_contract_invalid=reviewer_contract_invalid,
         passed=passed,
     )
 
@@ -4012,14 +4024,9 @@ def _query_friction_for_errors(level: str, slug: str, results: list) -> list[str
     return hints[:10]  # cap at 10 to avoid bloating the prompt
 
 
-def _save_structured_findings(review_text: str, orch_dir: Path, round_num: int):
-    """Extract structured findings from review markdown and save as YAML.
-
-    Parses the ## Findings section for [DIMENSION] [SEVERITY] blocks.
-    Saves to orchestration for aggregation across modules (#1027, #1028).
-    """
+def _extract_structured_findings(review_text: str) -> list[dict]:
+    """Extract structured review findings from fenced review markdown blocks."""
     findings = []
-    # Match finding blocks: ```\n[DIMENSION] [SEVERITY]\n...\n```
     pattern = re.compile(
         r"```\s*\n\[(\w[\w\s&]*?)\]\s*\[(\w+)\]\s*\n"
         r"Location:\s*(.*?)\n"
@@ -4035,6 +4042,16 @@ def _save_structured_findings(review_text: str, orch_dir: Path, round_num: int):
             "issue": m.group(4).strip(),
             "fix": m.group(5).strip(),
         })
+    return findings
+
+
+def _save_structured_findings(review_text: str, orch_dir: Path, round_num: int):
+    """Extract structured findings from review markdown and save as YAML.
+
+    Parses the ## Findings section for [DIMENSION] [SEVERITY] blocks.
+    Saves to orchestration for aggregation across modules (#1027, #1028).
+    """
+    findings = _extract_structured_findings(review_text)
 
     # Also extract scores table
     score_pattern = re.compile(r"\|\s*(\d+)\.\s*([^|]+)\|\s*(\d+)/10\s*\|([^|]*)\|")
@@ -6108,7 +6125,7 @@ def step_review(content_path: Path, level: str, module_num: int,
     else:
         _log("  ⚠️  Could not parse any dimension scores")
 
-    score_pass = score >= 8.0
+    score_pass = score >= REVIEW_TARGET_SCORE
     severity_pass = parsed.verdict == "PASS"
 
     for dim in parsed.parsed_scores:
@@ -6119,6 +6136,11 @@ def step_review(content_path: Path, level: str, module_num: int,
             _log(f"  ⚠️  Dimension floor: {dim_name} = {dim_score}/10 with identified errors")
 
     passed = parsed.passed
+    if parsed.reviewer_contract_invalid:
+        _log(
+            "  ⚠️  Reviewer contract invalid: sub-threshold score with zero actionable "
+            "findings — treating review output as non-blocking"
+        )
 
     icon = "✅" if passed else "❌"
     floor_msg = " (dimension floor FAIL)" if parsed.dim_floor_fail else ""

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -2282,6 +2282,36 @@ def _ensure_contract_artifacts(
     return contract, excerpts
 
 
+def _save_style_review_advice_to_contract(level: str, slug: str, blocking_issues: tuple[dict, ...]) -> None:
+    """Add style-review advice to the module contract for next write/repair attempt."""
+    contract_path = _contract_path(level, slug)
+    if not contract_path.exists():
+        return
+
+    try:
+        contract = yaml.safe_load(contract_path.read_text("utf-8")) or {}
+        if not isinstance(contract, dict):
+            return
+    except Exception:
+        return
+
+    # Filter to at most 3 items to keep it bounded (contract delta rule)
+    advice = []
+    for issue in list(blocking_issues)[:3]:
+        advice.append({
+            "type": str(issue.get("type", "STYLE")),
+            "location": str(issue.get("location", "")),
+            "evidence": str(issue.get("evidence", "")),
+            "fix": str(issue.get("fix", "")),
+        })
+
+    if not advice:
+        return
+
+    contract["style_review_advice"] = advice
+    _save_yaml_artifact(contract_path, contract)
+
+
 def _format_contract_prompt_artifacts(
     contract: dict,
     excerpts: dict,
@@ -2304,6 +2334,8 @@ def _format_contract_prompt_artifacts(
             }
         return value
 
+    style_advice = contract.get("style_review_advice") or []
+
     if mode == "write":
         teaching_sections = []
         for section in ((contract.get("teaching_beats") or {}).get("sections") or []):
@@ -2324,6 +2356,7 @@ def _format_contract_prompt_artifacts(
             "vocab_grammar_targets": contract.get("vocab_grammar_targets") or {},
             "activity_obligations": contract.get("activity_obligations") or [],
             "banned_error_patterns": contract.get("banned_error_patterns") or [],
+            "style_review_advice": style_advice,
         }
     elif mode == "chunk":
         all_sections = ((contract.get("teaching_beats") or {}).get("sections") or [])
@@ -2337,6 +2370,15 @@ def _format_contract_prompt_artifacts(
         if activity_ids is not None:
             wanted = set(activity_ids)
             obligations = [item for item in obligations if item.get("id") in wanted]
+
+        # For chunking, only include advice that matches the current section name
+        # or is global (empty location).
+        filtered_advice = []
+        for item in style_advice:
+            loc = str(item.get("location") or "").lower()
+            if not loc or not section_title or section_title.lower() in loc:
+                filtered_advice.append(item)
+
         contract_payload = {
             "current_section": {
                 "order": target_section.get("order") if target_section else None,
@@ -2347,6 +2389,7 @@ def _format_contract_prompt_artifacts(
             },
             "dialogue_acts": (contract.get("dialogue_acts") or []) if include_dialogue_acts else [],
             "activity_obligations": obligations,
+            "style_review_advice": filtered_advice,
         }
     else:
         contract_payload = contract
@@ -7066,247 +7109,6 @@ def _style_issue_section_names(location: str, sections: list[dict]) -> list[str]
     return resolved
 
 
-def _style_rewrite_guardrails(
-    level: str,
-    module_num: int,
-    section_name: str,
-    issue_types: set[str],
-) -> list[str]:
-    """Return section-aware rewrite guardrails for automated style healing."""
-    guardrails = [
-        (
-            "- Keep the rewrite within the live immersion target for this module: "
-            f"{_get_immersion_target_short(level, module_num)}"
-        ),
-    ]
-    if level not in {"a1", "a2"}:
-        return guardrails
-
-    section_lower = section_name.lower()
-    guardrails.append(
-        "- Lecture-style explanation is allowed, but do not comment on the lesson artifact itself."
-    )
-    guardrails.append(
-        "- Teach directly. Do not describe what the text, dialogue, or module demonstrates."
-    )
-    if "META_PEDAGOGICAL_NARRATION" in issue_types:
-        guardrails.append(
-            "- Forbidden meta phrasing: `in this dialogue`, `this text demonstrates`, "
-            "`here X adds`, `in this module`, `the following conversation`."
-        )
-    if issue_types.intersection(
-        {
-            "EXPLANATION_TONE_MISMATCH",
-            "STYLE_REGISTER_MISMATCH",
-            "REGISTER_MISMATCH",
-            "REGISTER_DRIFT",
-            "OVERSTATED_USAGE_EXPLANATION",
-            "STYLE_DRIFT",
-            "TRANSLATIONESE_EXPLANATION",
-            "MIXED_EXPLANATORY_VOICE",
-        }
-    ):
-        guardrails.append(
-            "- Keep paragraph voice Ukrainian-first. English may appear only as brief "
-            "parenthetical glosses or line-level translations, never as the main explanatory paragraph voice."
-        )
-        guardrails.append(
-            "- Rewrite any full English lecture-style explanation paragraph in this section into direct Ukrainian teaching prose. If English support is needed, keep it to a short gloss or a full-line translation after the Ukrainian sentence, not a separate explanatory paragraph."
-        )
-        guardrails.append(
-            "- Avoid sentence stems like `The verb ...`, `The phrase ...`, `This means ...`, or other English-first grammar lecture framing inside the prose body."
-        )
-    if "summary" in section_lower or "підсумок" in section_lower:
-        guardrails.append(
-            "- In summary sections, use direct Ukrainian instructional prose and short reading-task cues."
-        )
-        guardrails.append(
-            "- Do not open or close the summary with English overview paragraphs about the lesson or the verbs."
-        )
-        guardrails.append(
-            "- Build the summary around 3-4 concrete everyday Ukrainian sentences, not abstract recap prose about what the verbs express."
-        )
-        if "META_PEDAGOGICAL_NARRATION" in issue_types:
-            guardrails.append(
-                "- In summary sections, delete meta-teaching lead-ins entirely instead of paraphrasing them. Remove lines such as `To fully understand ...`, `Review this short text ...`, or motivational claims about what the lesson will help the learner do."
-            )
-            guardrails.append(
-                "- Start the summary immediately with Ukrainian recap content or a short plain Ukrainian label like `Короткий текст.`. Do not keep any English framing sentence before the examples or reading passage."
-            )
-        if "REGISTER_DRIFT" in issue_types:
-            guardrails.append(
-                "- In summary sections, prefer a short natural recap with everyday examples instead of a list of classroom commands."
-            )
-        if "FORMULAIC_SECTION_OPENERS" in issue_types:
-            guardrails.append(
-                "- In summary sections, do not use worksheet commands like `Запам'ятайте`, `Прочитайте й повторіть`, or `Прочитайте й відчуйте різницю` as opener lines. Begin with plain Ukrainian recap prose instead."
-            )
-        if "ABSTRACT_SUMMARY_REGISTER" in issue_types:
-            guardrails.append(
-                "- In summary sections, avoid abstract lecture lines like `These verbs express...` or `These verbs frequently pair with...`. State the contrast through concrete daily-life examples first, then add at most one short usage note."
-            )
-    if (
-        "dialog" in section_lower
-        or "діалог" in section_lower
-        or issue_types.intersection(
-            {
-                "TRANSLATIONESE",
-                "TRANSLATED_DIALOGUE_RHYTHM",
-                "WORKSHEET_DIALOGUE_RHYTHM",
-                "SERVICE_REGISTER_STIFFNESS",
-                "UNNATURAL_COLLOCATION",
-                "UNNATURAL_SERVICE_DIALOGUE",
-                "UNNATURAL_SERVICE_PHRASE",
-            }
-        )
-    ):
-        guardrails.append(
-            "- In dialogue sections, start with the dialogue or a very short direct Ukrainian setup."
-        )
-        guardrails.append(
-            "- Do not announce the scene beforehand, and avoid translated or stiff reactions."
-        )
-        if issue_types.intersection(
-            {
-                "TRANSLATED_DIALOGUE_RHYTHM",
-                "WORKSHEET_DIALOGUE_RHYTHM",
-                "PRAGMATIC_MISFRAMING",
-                "UNNATURAL_SERVICE_DIALOGUE",
-                "UNNATURAL_SERVICE_PHRASE",
-            }
-        ):
-            guardrails.append(
-                "- Give each speaker one natural communicative goal per turn; avoid stacking target grammar into a single line just to display forms."
-            )
-            guardrails.append(
-                "- In café or shop scenes, let the exchange breathe: request -> clarifying question or recommendation -> acceptance/refusal -> natural close. Avoid clipped slot-filling turns with no reaction."
-            )
-            guardrails.append(
-                "- When explaining markers like `шкода`, say they express regret and can soften a refusal; do not define them as the refusal itself or as an absolute etiquette rule."
-            )
-        if issue_types.intersection(
-            {
-                "SERVICE_REGISTER_STIFFNESS",
-                "UNNATURAL_SERVICE_DIALOGUE",
-                "UNNATURAL_SERVICE_PHRASE",
-            }
-        ):
-            guardrails.append(
-                "- In service scenes, prefer short request-based ordering and plain staff responses over staged recommendation language."
-            )
-        if issue_types.intersection(
-            {
-                "TRANSLATED_DIALOGUE_RHYTHM",
-                "SERVICE_REGISTER_STIFFNESS",
-                "UNNATURAL_SERVICE_DIALOGUE",
-                "UNNATURAL_SERVICE_PHRASE",
-            }
-        ):
-            guardrails.append(
-                "- In café or shop scenes, do not use blunt `Я хочу [noun]` as the direct order. Keep `хотіти` in peer-to-peer desire lines or nearby chatter if needed, but phrase the actual order as a native request such as `Мені, будь ласка...` or `Можна...`."
-            )
-    if "UNNATURAL_COLLOCATION" in issue_types:
-        guardrails.append(
-            "- Prefer idiomatic everyday collocations, especially with food, drink, and desire verbs; avoid literal model phrases that sound translated."
-        )
-    if "UNIDIOMATIC_COLLOCATION" in issue_types:
-        guardrails.append(
-            "- Prefer the more idiomatic everyday collocation when two grammatical options exist; avoid phrasing that sounds like a direct meaning-map from English."
-        )
-    if "NON_IDIOMATIC_MODEL_EXAMPLE" in issue_types:
-        guardrails.append(
-            "- Replace model sentences that are merely grammatical with beginner exemplars a native speaker would plausibly say in daily life."
-        )
-    if issue_types.intersection(
-        {
-            "EXPLANATION_TONE_MISMATCH",
-            "STYLE_REGISTER_MISMATCH",
-            "REGISTER_DRIFT",
-            "OVERSTATED_USAGE_EXPLANATION",
-            "CLUMSY_EXPLANATION",
-            "MIXED_EXPLANATORY_VOICE",
-            "OVERPRESCRIPTIVE_TONE",
-        }
-    ):
-        guardrails.append(
-            "- In grammar explanations, do not write traps like `частка не завжди ...`, `частка не обов'язково ...`, or `частка не тільки ...`. Use unambiguous frames such as `Завжди ставте частку не перед ...` or `У заперечних реченнях частка не стоїть перед ...`."
-        )
-    if issue_types.intersection({"OVERSTATED_USAGE_EXPLANATION", "PRAGMATIC_EQUIVALENCE"}):
-        guardrails.append(
-            "- When contrasting everyday meanings, state the literal meaning of the target phrase first, then mention common Ukrainian alternatives. Do not present one target construction as the only default equivalent if Ukrainian also uses another ordinary everyday form."
-        )
-    return guardrails
-
-
-def _apply_style_review_rewrite_blocks(
-    review_text: str,
-    content_path: Path,
-    *,
-    level: str,
-    module_num: int,
-    slug: str,
-    writer: str,
-) -> tuple[bool, int]:
-    """Translate style-review blockers into targeted section rewrite directives."""
-    blocking_issues = _extract_style_review_blocking_issues(review_text)
-    if not blocking_issues:
-        return False, 0
-
-    sections = _section_spans(content_path.read_text("utf-8"))
-    grouped_directives: dict[str, list[str]] = {}
-    grouped_issue_types: dict[str, set[str]] = {}
-    for issue in blocking_issues:
-        location = str(issue.get("location") or "").strip()
-        fix = str(issue.get("fix") or "").strip()
-        evidence = str(issue.get("evidence") or "").strip()
-        issue_type = str(issue.get("type") or "STYLE_ISSUE").strip()
-        section_names = _style_issue_section_names(location, sections)
-        if not section_names or not fix:
-            continue
-        directive = "\n".join(
-            line for line in (
-                f"- Issue type: {issue_type}",
-                f"- Location detail: {location}" if location else "",
-                f"- Evidence: {evidence}" if evidence else "",
-                f"- Required fix: {fix}",
-                "- Keep the section aligned with the current plan and contract.",
-                "- Remove only the stylistic / pragmatic problem; keep valid teaching content.",
-            )
-            if line
-        )
-        for section_name in section_names:
-            grouped_directives.setdefault(section_name, []).append(directive)
-            grouped_issue_types.setdefault(section_name, set()).add(issue_type)
-
-    if not grouped_directives:
-        return False, 0
-
-    applied = 0
-    for section_name, directives in grouped_directives.items():
-        guardrails = _style_rewrite_guardrails(
-            level,
-            module_num,
-            section_name,
-            grouped_issue_types.get(section_name, set()),
-        )
-        directive_parts = ["Style review blocking issues to fix in this section:"]
-        if guardrails:
-            directive_parts.append("\n".join(guardrails))
-        directive_parts.append("\n\n".join(directives))
-        directive = "\n\n".join(part for part in directive_parts if part)
-        if _rewrite_block_section(
-            content_path,
-            level=level,
-            module_num=module_num,
-            slug=slug,
-            writer=writer,
-            section_name=section_name,
-            directive=directive,
-        ):
-            applied += 1
-    return applied > 0, applied
-
-
 def _section_body_word_count(section_span: dict) -> int:
     """Count words in a parsed H2 section body without the heading line."""
     body = str(section_span.get("body") or "")
@@ -7543,84 +7345,45 @@ def _run_style_review_heal_loop(
     slug: str,
     writer: str,
     reviewer_override: str | None,
-    max_rounds: int = 4,
+    max_rounds: int = 1,
 ) -> StyleReviewLoopRunResult:
-    """Run style review + targeted rewrites until pass or plateau."""
-    rounds: list[StyleReviewRoundState] = []
+    """Run style review exactly once.
 
-    for round_index in range(1, max_rounds + 1):
-        passed, score, review_text = step_review_style(
-            content_path,
-            level,
-            module_num,
-            slug,
-            writer=writer,
-            reviewer_override=reviewer_override,
-        )
-        if score < 0.0:
-            return StyleReviewLoopRunResult(outcome="error", rounds=tuple(rounds))
-        if score == 0.0 and not review_text:
-            return StyleReviewLoopRunResult(outcome="error", rounds=tuple(rounds))
+    If it fails, record advice in the contract for the next write attempt
+    and continue (advisory-only). This stops in-phase rewrite churn.
+    """
+    passed, score, review_text = step_review_style(
+        content_path,
+        level,
+        module_num,
+        slug,
+        writer=writer,
+        reviewer_override=reviewer_override,
+    )
+    if score < 0.0:
+        return StyleReviewLoopRunResult(outcome="error", rounds=())
+    if score == 0.0 and not review_text:
+        return StyleReviewLoopRunResult(outcome="error", rounds=())
 
-        blocking_issues = tuple(_extract_style_review_blocking_issues(review_text))
-        round_state = StyleReviewRoundState(
-            round_num=round_index,
-            passed=passed,
-            score=score,
-            review_text=review_text,
-            blocking_issues=blocking_issues,
-        )
-        rounds.append(round_state)
+    blocking_issues = tuple(_extract_style_review_blocking_issues(review_text))
+    round_state = StyleReviewRoundState(
+        round_num=1,
+        passed=passed,
+        score=score,
+        review_text=review_text,
+        blocking_issues=blocking_issues,
+    )
 
-        if len(rounds) >= 2:
-            delta = _score_delta(rounds[-2].score, rounds[-1].score)
-            delta_str = f"+{delta:.1f}" if delta >= 0 else f"{delta:.1f}"
-            _log(
-                f"\n📊 Style R{rounds[-2].round_num}: {rounds[-2].score}/10 → "
-                f"R{round_index}: {score}/10 ({delta_str})"
-            )
+    if passed:
+        return StyleReviewLoopRunResult(outcome="pass", rounds=(round_state,))
 
-        if passed:
-            return StyleReviewLoopRunResult(outcome="pass", rounds=tuple(rounds))
+    # If we are here, style review failed.
+    # Instead of looping (churn), we save advice to the contract for next time.
+    _log(f"\n⚠️  Style review {score}/10 below target — recording advisory advice in contract")
+    _save_style_review_advice_to_contract(level, slug, blocking_issues)
 
-        rewrites_applied, rewrite_count = _apply_style_review_rewrite_blocks(
-            review_text,
-            content_path,
-            level=level,
-            module_num=module_num,
-            slug=slug,
-            writer=writer,
-        )
-        if rewrites_applied:
-            _log(f"\n🎨 Applied {rewrite_count} style-driven block rewrite(s) from style R{round_index}")
-            step_verify(content_path, level, module_num)
-        else:
-            _log("\n⏸️ Style review plateau detected — no actionable section rewrites could be applied.")
-            return StyleReviewLoopRunResult(outcome="plateau", rounds=tuple(rounds))
-
-        deltas = [
-            _score_delta(previous.score, current.score)
-            for previous, current in itertools.pairwise(rounds)
-        ]
-        consecutive_small_deltas = 0
-        for delta in deltas:
-            if delta < 0.2:
-                consecutive_small_deltas += 1
-            else:
-                consecutive_small_deltas = 0
-        if consecutive_small_deltas >= 2:
-            _log("\n⏸️ Style review plateau detected — two consecutive rounds improved by less than 0.2.")
-            return StyleReviewLoopRunResult(outcome="plateau", rounds=tuple(rounds))
-        if len(rounds) >= max_rounds:
-            _log(f"\n⏸️ Style review plateau detected — reached the {max_rounds}-round ceiling.")
-            return StyleReviewLoopRunResult(outcome="plateau", rounds=tuple(rounds))
-
-        _log(
-            f"\n🔄 Style R{round_index} incomplete — score={score}/10, "
-            f"blocking issues={len(blocking_issues)}. Running style R{round_index + 1}."
-        )
-
-    return StyleReviewLoopRunResult(outcome="plateau", rounds=tuple(rounds))
+    # Advisory-only: return "pass" so the build continues, but with the round recorded
+    return StyleReviewLoopRunResult(outcome="pass", rounds=(round_state,))
 
 
 def _rerun_write_after_plan_patch(
@@ -9318,7 +9081,9 @@ def main():
 
             _save_v6_state(args.level, slug, "review-style")
             _clear_needs_human_review_marker(args.level, slug)
-            _log(f"\n✅ Style review PASSED ({style_score}/10)")
+            verdict_icon = "✅" if final_style_round.passed else "⚠️"
+            verdict_label = "PASSED" if final_style_round.passed else "ADVISORY-PASS"
+            _log(f"\n{verdict_icon} Style review {verdict_label} ({style_score}/10)")
             _emit_phase_done("review-style", _phase_start)
 
         # Step 8c: ANNOTATE (stress marks — after review, before publish)

--- a/tests/test_issue_1301.py
+++ b/tests/test_issue_1301.py
@@ -1,0 +1,81 @@
+import yaml
+
+from scripts.build import v6_build
+
+
+def test_style_review_advisory_flow(tmp_path, monkeypatch):
+    """Test that failed style review records advice and continues (advisory)."""
+    level = "a1"
+    slug = "test-style-advisory"
+    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    curriculum_root.mkdir(parents=True)
+    (curriculum_root / level).mkdir(parents=True)
+
+    # Setup mock contract
+    contract_path = curriculum_root / level / "orchestration" / slug / "contract.yaml"
+    contract_path.parent.mkdir(parents=True)
+    contract_data = {
+        "module": {"slug": slug},
+        "banned_error_patterns": ["Pattern A"]
+    }
+    contract_path.write_text(yaml.dump(contract_data), "utf-8")
+
+    content_path = curriculum_root / level / f"{slug}.md"
+    content_path.write_text("Some content", "utf-8")
+
+    # Mock step_review_style to fail
+    monkeypatch.setattr(v6_build, "step_review_style",
+        lambda *args, **kwargs: (False, 8.2, "Review text with issues")
+    )
+    # Mock extract issues
+    monkeypatch.setattr(v6_build, "_extract_style_review_blocking_issues",
+        lambda text: [{"type": "STYLE", "location": "Intro", "evidence": "Bad", "fix": "Good"}]
+    )
+    # Mock CURRICULUM_ROOT
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+
+    # Run the loop
+    result = v6_build._run_style_review_heal_loop(
+        content_path, level=level, module_num=1, slug=slug, writer="gemini", reviewer_override=None
+    )
+
+    # Assertions
+    assert result.outcome == "pass"
+    assert len(result.rounds) == 1
+    assert result.rounds[0].passed is False
+    assert result.rounds[0].score == 8.2
+
+    # Check that contract was updated with advice
+    updated_contract = yaml.safe_load(contract_path.read_text("utf-8"))
+    assert "style_review_advice" in updated_contract
+    assert len(updated_contract["style_review_advice"]) == 1
+    assert updated_contract["style_review_advice"][0]["fix"] == "Good"
+
+def test_contract_prompt_includes_style_advice():
+    """Test that style advice is formatted into the contract prompt."""
+    contract = {
+        "module": {"slug": "test"},
+        "style_review_advice": [
+            {"type": "STYLE", "location": "Intro", "evidence": "X", "fix": "Y"}
+        ]
+    }
+    excerpts = {}
+
+    # Test mode="write"
+    contract_literal, _ = v6_build._format_contract_prompt_artifacts(contract, excerpts, mode="write")
+    assert "style_review_advice" in contract_literal
+    assert "fix: Y" in contract_literal
+
+    # Test mode="chunk" with matching location
+    contract_literal, _ = v6_build._format_contract_prompt_artifacts(
+        contract, excerpts, mode="chunk", section_title="Intro"
+    )
+    assert "style_review_advice" in contract_literal
+    assert "fix: Y" in contract_literal
+
+    # Test mode="chunk" with non-matching location
+    contract_literal, _ = v6_build._format_contract_prompt_artifacts(
+        contract, excerpts, mode="chunk", section_title="Other"
+    )
+    # It should be empty if location doesn't match and isn't global
+    assert "style_review_advice: []" in contract_literal

--- a/tests/test_v6_build_events.py
+++ b/tests/test_v6_build_events.py
@@ -15,7 +15,13 @@ from pathlib import Path
 import pytest
 import yaml
 
-SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+WORKTREE_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = WORKTREE_ROOT
+if not (REPO_ROOT / ".venv" / "bin" / "python").exists() and WORKTREE_ROOT.parent.name == ".worktrees":
+    REPO_ROOT = WORKTREE_ROOT.parent.parent
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+
+SCRIPTS_DIR = WORKTREE_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 orch_index = importlib.import_module("build.orch_index")
@@ -35,6 +41,41 @@ REVIEW_RAW = """\
 | 9. Dialogue & conversation quality | 9/10 | natural |
 
 Verdict: PASS
+"""
+
+REVIEW_RAW_REVISE_NO_FINDINGS = """\
+| 1. Plan adherence | 8/10 | grounded |
+| 2. Linguistic accuracy | 8/10 | accurate |
+| 3. Pedagogical quality | 8/10 | clear |
+| 4. Vocabulary coverage | 8/10 | on target |
+| 5. Exercise quality | 8/10 | aligned |
+| 6. Engagement & tone | 8/10 | engaging |
+| 7. Structural integrity | 8/10 | solid |
+| 8. Cultural accuracy | 8/10 | appropriate |
+| 9. Dialogue & conversation quality | 8/10 | natural |
+
+Verdict: REVISE
+"""
+
+REVIEW_RAW_REVISE_WITH_FINDING = """\
+| 1. Plan adherence | 8/10 | grounded |
+| 2. Linguistic accuracy | 8/10 | accurate |
+| 3. Pedagogical quality | 8/10 | clear |
+| 4. Vocabulary coverage | 8/10 | on target |
+| 5. Exercise quality | 8/10 | aligned |
+| 6. Engagement & tone | 8/10 | engaging |
+| 7. Structural integrity | 8/10 | solid |
+| 8. Cultural accuracy | 8/10 | appropriate |
+| 9. Dialogue & conversation quality | 8/10 | natural |
+
+Verdict: REVISE
+
+```
+[Pedagogical quality] [MAJOR]
+Location: Summary
+Issue: The summary does not reinforce the target contrast clearly enough.
+Fix: Add a concrete recap sentence that contrasts хотіти and могти.
+```
 """
 
 
@@ -202,6 +243,71 @@ def test_step_review_emits_review_score_event(
     assert review_events[0]["slug"] == slug
     assert review_events[0]["round"] == 1
     assert review_events[0]["score"] == 9.0
+
+
+def test_step_review_treats_subthreshold_empty_findings_as_non_blocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    level = "a2"
+    slug = "a2-review-contract-invalid"
+    curriculum_root = _single_module_tree(tmp_path, level=level, slug=slug)
+    content_path = curriculum_root / level / f"{slug}.md"
+    content_path.write_text(_compliant_module_content(), "utf-8")
+
+    phases_dir = tmp_path / "scripts" / "build" / "phases"
+    phases_dir.mkdir(parents=True, exist_ok=True)
+    (phases_dir / "v6-review.md").write_text(
+        "Review {TOPIC_TITLE}\n\n{GENERATED_CONTENT}\n",
+        "utf-8",
+    )
+
+    import build.dispatch as dispatch
+
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(v6_build, "PHASES_DIR", phases_dir)
+    monkeypatch.setattr(v6_build, "_build_vesum_report", lambda *args, **kwargs: "")
+    monkeypatch.setattr(dispatch, "dispatch_agent", lambda *args, **kwargs: (True, REVIEW_RAW_REVISE_NO_FINDINGS))
+
+    passed, score, raw = v6_build.step_review(content_path, level, 1, slug, writer="claude")
+
+    output = capsys.readouterr().out
+    assert passed is True
+    assert score == 8.0
+    assert raw == REVIEW_RAW_REVISE_NO_FINDINGS
+    assert "Reviewer contract invalid" in output
+
+
+def test_step_review_still_blocks_subthreshold_review_with_actionable_findings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    level = "a2"
+    slug = "a2-review-revise-with-findings"
+    curriculum_root = _single_module_tree(tmp_path, level=level, slug=slug)
+    content_path = curriculum_root / level / f"{slug}.md"
+    content_path.write_text(_compliant_module_content(), "utf-8")
+
+    phases_dir = tmp_path / "scripts" / "build" / "phases"
+    phases_dir.mkdir(parents=True, exist_ok=True)
+    (phases_dir / "v6-review.md").write_text(
+        "Review {TOPIC_TITLE}\n\n{GENERATED_CONTENT}\n",
+        "utf-8",
+    )
+
+    import build.dispatch as dispatch
+
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(v6_build, "PHASES_DIR", phases_dir)
+    monkeypatch.setattr(v6_build, "_build_vesum_report", lambda *args, **kwargs: "")
+    monkeypatch.setattr(dispatch, "dispatch_agent", lambda *args, **kwargs: (True, REVIEW_RAW_REVISE_WITH_FINDING))
+
+    passed, score, raw = v6_build.step_review(content_path, level, 1, slug, writer="claude")
+
+    assert passed is False
+    assert score == 8.0
+    assert raw == REVIEW_RAW_REVISE_WITH_FINDING
 
 
 def test_step_review_style_emits_review_style_score_event(
@@ -974,7 +1080,7 @@ def test_subprocess_event_stream_is_line_buffered(tmp_path: Path) -> None:
     )
 
     proc = subprocess.Popen(
-        [str(v6_build.PROJECT_ROOT / ".venv" / "bin" / "python"), str(helper_path), str(curriculum_root)],
+        [str(VENV_PYTHON), str(helper_path), str(curriculum_root)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/tests/test_v6_contract_flow.py
+++ b/tests/test_v6_contract_flow.py
@@ -764,330 +764,6 @@ def test_run_review_heal_loop_triggers_word_budget_autoheal(tmp_path: Path, monk
     assert verify_calls["count"] == 1
 
 
-def test_apply_style_review_rewrite_blocks_groups_by_section(tmp_path: Path, monkeypatch) -> None:
-    level = "a1"
-    slug = "style-rewrite-flow"
-    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
-    content_path = curriculum_root / level / f"{slug}.md"
-    content_path.parent.mkdir(parents=True, exist_ok=True)
-    content_path.write_text("## Intro\nOld intro.\n\n## Practice\nOld practice.\n", "utf-8")
-
-    calls: list[tuple[str, str]] = []
-
-    def fake_rewrite(*args, **kwargs):
-        calls.append((kwargs["section_name"], kwargs["directive"]))
-        return True
-
-    monkeypatch.setattr(v6_build, "_rewrite_block_section", fake_rewrite)
-
-    ok, count = v6_build._apply_style_review_rewrite_blocks(
-        """phase: review-style
-verdict: REVISE
-pass: false
-overall_score: 8.4
-scores: []
-blocking_issues:
-  - type: META_PEDAGOGICAL_NARRATION
-    location: "Section: Intro, paragraph 1"
-    evidence: "In this dialogue..."
-    fix: "Teach the point directly."
-  - type: REGISTER_MISMATCH
-    location: "Practice, dialogue"
-    evidence: "Що ви хочете?"
-    fix: "Use a more polite service opener."
-  - type: META_PEDAGOGICAL_NARRATION
-    location: "Section: Intro, closing"
-    evidence: "Here ..."
-    fix: "Remove local meta-commentary."
-""",
-        content_path,
-        level=level,
-        module_num=1,
-        slug=slug,
-        writer="gemini",
-    )
-
-    assert ok is True
-    assert count == 2
-    assert calls[0][0] == "Intro"
-    assert "Teach the point directly." in calls[0][1]
-    assert "Remove local meta-commentary." in calls[0][1]
-    assert calls[1][0] == "Practice"
-    assert "Use a more polite service opener." in calls[1][1]
-
-
-def test_apply_style_review_rewrite_blocks_maps_dialogue_and_whole_module_locations(
-    tmp_path: Path, monkeypatch
-) -> None:
-    level = "a1"
-    slug = "style-location-flow"
-    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
-    content_path = curriculum_root / level / f"{slug}.md"
-    content_path.parent.mkdir(parents=True, exist_ok=True)
-    content_path.write_text(
-        "## Діалоги (Dialogues)\nOld dialogue.\n\n"
-        "## Хотіти (To Want)\nOld want.\n\n"
-        "## Підсумок — Summary\nOld summary.\n",
-        "utf-8",
-    )
-
-    calls: list[str] = []
-
-    def fake_rewrite(*args, **kwargs):
-        calls.append(kwargs["section_name"])
-        return True
-
-    monkeypatch.setattr(v6_build, "_rewrite_block_section", fake_rewrite)
-
-    ok, count = v6_build._apply_style_review_rewrite_blocks(
-        """phase: review-style
-verdict: REVISE
-pass: false
-overall_score: 5.8
-scores: []
-blocking_issues:
-  - type: META_PEDAGOGICAL_NARRATION
-    location: "Діалоги opening prose and commentary, lines 3-5; Підсумок, lines 20-30"
-    evidence: "Notice how..."
-    fix: "Replace the meta-teaching narration."
-  - type: EXPLANATION_TONE_MISMATCH
-    location: "Whole module prose outside the example sentences"
-    evidence: "Communication often revolves..."
-    fix: "Rewrite the explanatory layer in concise Ukrainian educational prose."
-  - type: TRANSLATED_DIALOGUE_RHYTHM
-    location: "First dialogue, lines 9-11"
-    evidence: "Це погано. А завтра?"
-    fix: "Use a more idiomatic reaction."
-  - type: SERVICE_REGISTER_STIFFNESS
-    location: "Café dialogue, line 17"
-    evidence: "Що ви хочете?"
-    fix: "Use a more natural service opener."
-""",
-        content_path,
-        level=level,
-        module_num=1,
-        slug=slug,
-        writer="gemini",
-    )
-
-    assert ok is True
-    assert count == 3
-    assert calls.count("Діалоги (Dialogues)") == 1
-    assert calls.count("Хотіти (To Want)") == 1
-    assert calls.count("Підсумок — Summary") == 1
-
-
-def test_apply_style_review_rewrite_blocks_adds_a1_guardrails(tmp_path: Path, monkeypatch) -> None:
-    level = "a1"
-    slug = "style-guardrails"
-    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
-    content_path = curriculum_root / level / f"{slug}.md"
-    content_path.parent.mkdir(parents=True, exist_ok=True)
-    content_path.write_text(
-        "## Діалоги (Dialogues)\nOld dialogue.\n\n"
-        "## Хотіти (To Want)\nOld want.\n\n"
-        "## Підсумок — Summary\nOld summary.\n",
-        "utf-8",
-    )
-
-    calls: dict[str, str] = {}
-
-    def fake_rewrite(*args, **kwargs):
-        calls[kwargs["section_name"]] = kwargs["directive"]
-        return True
-
-    monkeypatch.setattr(v6_build, "_rewrite_block_section", fake_rewrite)
-
-    ok, count = v6_build._apply_style_review_rewrite_blocks(
-        """phase: review-style
-verdict: REVISE
-pass: false
-overall_score: 7.3
-scores: []
-blocking_issues:
-  - type: META_PEDAGOGICAL_NARRATION
-    location: "Підсумок — Summary, opening"
-    evidence: "This text demonstrates..."
-    fix: "Replace with a direct reading cue."
-  - type: TRANSLATIONESE
-    location: "Діалоги (Dialogues), explanatory framing"
-    evidence: "Наступна розмова відбувається в кафе."
-    fix: "Cut the scene-announcing narration."
-  - type: PRAGMATIC_MISFRAMING
-    location: "Діалоги (Dialogues), note after dialogue"
-    evidence: "Шкода is a polite refusal."
-    fix: "Explain that шкода expresses regret and can soften a refusal."
-  - type: STYLE_REGISTER_MISMATCH
-    location: "Хотіти (To Want), opening explanation"
-    evidence: "The verb хотіти is essential..."
-    fix: "Keep exposition in one coherent Ukrainian pedagogical register."
-  - type: REGISTER_MISMATCH
-    location: "Діалоги (Dialogues), café exchange closing"
-    evidence: "Чудово, давайте борщ."
-    fix: "Use a more natural ordering formula."
-  - type: MIXED_EXPLANATORY_VOICE
-    location: "Хотіти (To Want); Могти і мусити (Can and Must)"
-    evidence: "dense inline glosses"
-    fix: "Keep one concise Ukrainian pedagogical voice."
-  - type: TRANSLATIONESE_EXPLANATION
-    location: "Хотіти (To Want); Підсумок — Summary"
-    evidence: "у своїй базовій словниковій формі"
-    fix: "Rewrite into plainer Ukrainian pedagogical prose."
-  - type: FORMULAIC_SECTION_OPENERS
-    location: "Підсумок — Summary, opening and cue lines"
-    evidence: "Запам'ятайте: / Прочитайте й повторіть:"
-    fix: "Replace worksheet-style commands with plain recap prose."
-  - type: WORKSHEET_DIALOGUE_RHYTHM
-    location: "Діалоги (Dialogues), café exchange"
-    evidence: "Велику. І можна ще борщ?"
-    fix: "Turn this into a fuller service exchange with a reactive recommendation turn and a natural close."
-  - type: REGISTER_DRIFT
-    location: "Підсумок — Summary, opening and mid-section"
-    evidence: "Порівняйте ці речення... Запам'ятайте..."
-    fix: "Turn the summary into a short natural recap."
-  - type: ABSTRACT_SUMMARY_REGISTER
-    location: "Підсумок — Summary, opening and closing prose"
-    evidence: "These verbs express desires, abilities, and obligations"
-    fix: "Replace abstract recap with concrete everyday examples."
-  - type: UNNATURAL_COLLOCATION
-    location: "Хотіти (To Want), examples"
-    evidence: "Він хоче великий чай."
-    fix: "Use idiomatic everyday collocations."
-  - type: UNNATURAL_SERVICE_DIALOGUE
-    location: "Діалоги (Dialogues), café dialogue"
-    evidence: "Можу порекомендувати український борщ."
-    fix: "Use plainer native service speech."
-  - type: UNNATURAL_SERVICE_PHRASE
-    location: "Діалоги (Dialogues), café dialogue final turn"
-    evidence: "Чудово, давайте борщ."
-    fix: "Use a more idiomatic final order."
-  - type: NON_IDIOMATIC_MODEL_EXAMPLE
-    location: "Підсумок — Summary, accusative examples"
-    evidence: "Він хоче великий чай."
-    fix: "Use a more idiomatic beginner model."
-  - type: OVERSTATED_USAGE_EXPLANATION
-    location: "Діалоги (Dialogues), explanation after café dialogue"
-    evidence: "Я хочу їсти is the standard everyday way to say I am hungry."
-    fix: "Present it as one common colloquial option and mention голодний/голодна."
-  - type: PRAGMATIC_EQUIVALENCE
-    location: "Діалоги (Dialogues), café explanation paragraph"
-    evidence: "The phrase я хочу їсти is the standard, everyday way to say I am hungry."
-    fix: "State the literal meaning first and mention everyday alternatives."
-  - type: UNIDIOMATIC_COLLOCATION
-    location: "Підсумок — Summary, evening-plans paragraph"
-    evidence: "вона хоче пити смачну каву"
-    fix: "Prefer a more idiomatic collocation."
-""",
-        content_path,
-        level=level,
-        module_num=18,
-        slug=slug,
-        writer="gemini",
-    )
-
-    assert ok is True
-    assert count == 3
-    summary_directive = calls["Підсумок — Summary"]
-    assert "Lecture-style explanation is allowed" in summary_directive
-    assert "Forbidden meta phrasing" in summary_directive
-    assert "In summary sections, use direct Ukrainian instructional prose" in summary_directive
-    assert "delete meta-teaching lead-ins entirely instead of paraphrasing them" in summary_directive
-    assert "Start the summary immediately with Ukrainian recap content" in summary_directive
-    assert "short natural recap with everyday examples" in summary_directive
-    dialogue_directive = calls["Діалоги (Dialogues)"]
-    assert "In dialogue sections, start with the dialogue" in dialogue_directive
-    assert "Do not announce the scene beforehand" in dialogue_directive
-    assert "one natural communicative goal per turn" in dialogue_directive
-    assert "express regret and can soften a refusal" in dialogue_directive
-    assert "prefer short request-based ordering and plain staff responses" in dialogue_directive
-    assert "do not use blunt `Я хочу [noun]` as the direct order" in dialogue_directive
-    assert "state the literal meaning of the target phrase first" in dialogue_directive
-    want_directive = calls["Хотіти (To Want)"]
-    dialogue_directive = calls["Діалоги (Dialogues)"]
-    assert "English may appear only as brief parenthetical glosses" in want_directive
-    assert "Rewrite any full English lecture-style explanation paragraph" in want_directive
-    assert "let the exchange breathe: request -> clarifying question or recommendation" in dialogue_directive
-    assert "Prefer idiomatic everyday collocations" in want_directive
-    assert "Prefer the more idiomatic everyday collocation" in summary_directive
-    assert "do not write traps like `частка не завжди ...`" in want_directive
-    assert "Replace model sentences that are merely grammatical" in summary_directive
-    assert "do not use worksheet commands like `Запам'ятайте`" in summary_directive
-    assert "avoid abstract lecture lines like `These verbs express...`" in summary_directive
-    assert "do not write traps like `частка не завжди ...`" in summary_directive
-
-
-def test_run_style_review_heal_loop_rewrites_then_passes(tmp_path: Path, monkeypatch) -> None:
-    level = "a1"
-    slug = "style-heal-flow"
-    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
-    content_path = curriculum_root / level / f"{slug}.md"
-    content_path.parent.mkdir(parents=True, exist_ok=True)
-    content_path.write_text("## Intro\nOld intro.\n\n## Practice\nOld practice.\n", "utf-8")
-
-    reviews = iter(
-        [
-            (
-                False,
-                8.4,
-                """phase: review-style
-verdict: REVISE
-pass: false
-overall_score: 8.4
-scores:
-  - key: pragmatic_authenticity
-    score: 9.0
-  - key: stylistic_consistency
-    score: 8.2
-  - key: culture_and_register
-    score: 9.0
-  - key: naturalness
-    score: 8.4
-blocking_issues:
-  - type: META_PEDAGOGICAL_NARRATION
-    location: "Section: Intro, paragraph 1"
-    evidence: "In this dialogue..."
-    fix: "Teach the point directly."
-""",
-            ),
-            (
-                True,
-                9.2,
-                """phase: review-style
-verdict: PASS
-pass: true
-overall_score: 9.2
-scores:
-  - key: pragmatic_authenticity
-    score: 9.2
-  - key: stylistic_consistency
-    score: 9.0
-  - key: culture_and_register
-    score: 9.3
-  - key: naturalness
-    score: 9.1
-blocking_issues: []
-""",
-            ),
-        ]
-    )
-
-    monkeypatch.setattr(v6_build, "step_review_style", lambda *args, **kwargs: next(reviews))
-    monkeypatch.setattr(v6_build, "_apply_style_review_rewrite_blocks", lambda *args, **kwargs: (True, 1))
-    monkeypatch.setattr(v6_build, "step_verify", lambda *args, **kwargs: "complete")
-
-    result = v6_build._run_style_review_heal_loop(
-        content_path,
-        level=level,
-        module_num=1,
-        slug=slug,
-        writer="gemini",
-        reviewer_override=None,
-    )
-
-    assert result.outcome == "pass"
-    assert [round_state.score for round_state in result.rounds] == [8.4, 9.2]
-
-
 def test_dispatch_rewrite_prompt_uses_shorter_gemini_budget(tmp_path: Path, monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -1140,9 +816,9 @@ def test_dispatch_rewrite_prompt_falls_back_to_codex_after_gemini_failure(
     assert "cascade_per_call_max_s" not in calls[1]
 
 
-def test_main_marks_needs_human_review_after_style_plateau(tmp_path: Path, monkeypatch) -> None:
+def test_main_continues_after_style_advisory_pass(tmp_path: Path, monkeypatch) -> None:
     level = "a1"
-    slug = "style-needs-human"
+    slug = "style-advisory"
     curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
     _write_manifest(curriculum_root, level, slug)
     _write_plan(curriculum_root, level, slug)
@@ -1162,19 +838,12 @@ def test_main_marks_needs_human_review_after_style_plateau(tmp_path: Path, monke
         v6_build,
         "_run_style_review_heal_loop",
         lambda *args, **kwargs: v6_build.StyleReviewLoopRunResult(
-            outcome="plateau",
+            outcome="pass",
             rounds=(
                 v6_build.StyleReviewRoundState(
                     round_num=1,
                     passed=False,
                     score=8.4,
-                    review_text="phase: review-style\nverdict: REVISE\n",
-                    blocking_issues=({"type": "META_PEDAGOGICAL_NARRATION"},),
-                ),
-                v6_build.StyleReviewRoundState(
-                    round_num=2,
-                    passed=False,
-                    score=8.5,
                     review_text="phase: review-style\nverdict: REVISE\n",
                     blocking_issues=({"type": "META_PEDAGOGICAL_NARRATION"},),
                 ),
@@ -1186,11 +855,9 @@ def test_main_marks_needs_human_review_after_style_plateau(tmp_path: Path, monke
     result = v6_build.main()
 
     state = json.loads((orch_dir / "state.json").read_text("utf-8"))
-    needs_human_review = yaml.safe_load((orch_dir / "needs-human-review.yaml").read_text("utf-8"))
-    assert result is False
-    assert state["needs_human_review"]["status"] is True
-    assert needs_human_review["style_review_rounds"] == 2
-    assert needs_human_review["style_score_history"] == [8.4, 8.5]
+    assert result is True
+    # Should NOT have needs_human_review because it's advisory pass
+    assert "needs_human_review" not in state
 
 
 def test_main_clears_stale_needs_human_review_after_style_pass(


### PR DESCRIPTION
## Summary
- integrate the validated `#1301`, `#1303`, and `#1304` control-plane fixes on top of merged `#1302`
- stop in-phase style-review rewrite churn and persist bounded style advice
- treat sub-threshold main review output with zero actionable findings as invalid/non-blocking reviewer output
- harden plan-patch recovery and state/artifact reconciliation

## Testing
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check docs/state-reconciliation.md scripts/build/phases/plan_patch.py scripts/build/v6_build.py tests/test_issue_1301.py tests/test_v6_contract_flow.py tests/test_plan_patch_parse_failures.py tests/test_state_drift_reconciliation.py tests/test_v6_build_events.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_issue_1301.py tests/test_v6_contract_flow.py tests/test_plan_patch_parse_failures.py tests/test_state_drift_reconciliation.py tests/test_v6_build_events.py tests/test_plan_patch.py tests/test_v6_state_io.py tests/test_v6_review_plateau.py tests/test_v6_plan_hash_drift.py -q

## Issues
- Closes #1301
- Closes #1303
- Closes #1304