### PR TITLE
feat(v6): optimize write-chunk prompt layering and add prompt budget metadata

### DIFF
--- a/docs/prompt-budgets.md
+++ b/docs/prompt-budgets.md
@@ -1,0 +1,140 @@
+# V6 Writer Prompt Context Budgets
+
+> **Scope:** Documents the intended context budget and shape for each
+> v6 build phase that sends a prompt to an LLM writer.  Used by the
+> deterministic prompt audit (`_audit_chunk_prompt`,
+> `_audit_rewrite_block_prompt`) and by humans reviewing orchestration
+> artifacts.
+
+## Phase Overview
+
+| Phase | Budget | Primary Artifact | Scoped To |
+|---|---|---|---|
+| **research** | N/A (data assembly) | knowledge-packet.md | module |
+| **skeleton** | ≤40 000 chars | v6-skeleton-prompt.md | module |
+| **write-chunk** | ≤12 000 chars | v6-chunk-NN-prompt.md | section |
+| **rewrite-block** | ≤18 000 chars | rewrite-block prompt | section |
+
+---
+
+## research
+
+**Purpose:** Assemble a knowledge packet from wiki articles, discovery
+data, and plan references.
+
+**Context shape:**
+- Wiki context (primary — compiled from textbooks, literary texts,
+  Wikipedia).  Capped at ~30 000 chars in the packet itself.
+- Discovery data (RAG literary + textbook chunks from the discovery
+  phase).  Capped at 10 literary + 8 textbook chunks.
+- Plan references.
+
+**No LLM prompt** — this phase is deterministic data assembly.
+The output feeds into skeleton and write phases.
+
+---
+
+## skeleton
+
+**Purpose:** Generate a paragraph-level structural plan that constrains
+the writer to balanced sections.
+
+**Budget:** ≤40 000 chars (`SKELETON_PROMPT_MAX_CHARS`).
+
+**Context shape (components):**
+1. `template` — the `v6-skeleton.md` prompt template (~2 000 chars).
+2. `plan_content` — the full plan YAML wrapped in a literal block.
+3. `knowledge_packet` — the full knowledge packet (truncated at
+   30 000 chars if larger).
+
+**What is intentionally included:** The skeleton needs the broadest
+context because it must allocate word budgets across all sections and
+decide which teaching beats go where.
+
+**Machine-readable manifest:** `v6-skeleton-manifest.yaml` in the
+module's orchestration directory.
+
+---
+
+## write-chunk
+
+**Purpose:** Generate prose for ONE H2 section of a module.
+
+**Budget:** ≤12 000 chars (`CHUNK_PROMPT_MAX_CHARS`).
+
+**Context shape (components):**
+1. `persona` — writer identity (1-2 lines).
+2. `section_skeleton` — the skeleton body for this section only.
+3. `section_contract` — the contract slice for this section (current
+   section's teaching beats, required terms, scoped activity
+   obligations).
+4. `section_wiki_excerpts` — wiki excerpt items mapped to this section.
+5. `previous_sections_summary` — rolling summary of previously written
+   sections (max 500 words), included only from section 2 onward.
+6. `paragraph_language_rule` — compact immersion/monolingual rule.
+7. `section_rules` — level grammar envelope + activity markers.
+8. `dialogue_formatting` — blockquote formatting guide, included
+   **only** when the section contains dialogue content.
+9. `required_vocab_checklist` — per-section vocab focus or final
+   sweep-up, included only when vocabulary is defined.
+10. `forbidden_words` — hard-banned Russianisms (~300 chars, always
+    included).
+
+**What is intentionally excluded:**
+- Full write template (`v6-write.md`) — the chunk prompt is
+  self-contained; carrying the 8 000+ char template would exceed the
+  budget and repeat rules already distilled into compact helpers.
+- Full module contract — only the current section's slice is included.
+- Full knowledge packet — section-mapped excerpts replace it.
+- Dialogue formatting rules (when section has no dialogue content).
+
+**Machine-readable manifest:** `v6-chunk-NN-manifest.yaml` in the
+module's orchestration directory.
+
+---
+
+## rewrite-block
+
+**Purpose:** Surgically rewrite one H2 section to fix a specific
+review finding.
+
+**Budget:** ≤18 000 chars (`REWRITE_BLOCK_PROMPT_MAX_CHARS`).
+
+**Context shape (components):**
+1. `rewrite_directive` — the reviewer's specific fix instruction.
+2. `rewrite_guardrails` — heading preservation, marker preservation.
+3. `section_mapped_wiki_excerpts` — wiki excerpts for this section.
+4. `current_section` — the existing prose being rewritten.
+
+**What is intentionally excluded:**
+- Full module contract (`## Shared Module Contract`).
+- Other sections' context (`## Previous Sections For Continuity`).
+- Skeleton (`## Skeleton For This Section`).
+
+These exclusions are enforced by `REWRITE_BLOCK_FORBIDDEN_HEADINGS`
+and `_audit_rewrite_block_prompt`.
+
+**Machine-readable manifest:** saved alongside the rewrite prompt in
+the orchestration directory.
+
+---
+
+## Auditing Prompt Composition
+
+Each phase that emits a manifest can be audited deterministically:
+
+```python
+from build.v6_build import (
+    _audit_chunk_prompt,
+    _audit_rewrite_block_prompt,
+)
+
+# Load manifest from orchestration dir
+manifest = yaml.safe_load(path.read_text())
+failures = _audit_chunk_prompt(manifest)  # or _audit_rewrite_block_prompt
+assert failures == [], f"Prompt audit failed: {failures}"
+```
+
+The manifest YAML files are committed to orchestration directories
+alongside the prompt files, enabling CI-level verification that prompt
+composition stays within budget.

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -2673,6 +2673,18 @@ def step_skeleton(level: str, module_num: int, slug: str,
     prompt_path.write_text(prompt, "utf-8")
     _log(f"  Prompt saved → {prompt_path.name} ({len(prompt)} chars)")
 
+    # Emit prompt composition manifest
+    skeleton_manifest = _build_skeleton_prompt_manifest(
+        prompt=prompt,
+        plan_content=plan_content,
+        packet=packet,
+        word_target=word_target,
+    )
+    manifest_path = orch_dir / "v6-skeleton-manifest.yaml"
+    manifest_path.write_text(
+        yaml.safe_dump(skeleton_manifest, sort_keys=False, allow_unicode=True), "utf-8",
+    )
+
     # Dispatch to writer — skeleton is structure planning, fast model sufficient
     from build.dispatch import dispatch_agent as _dispatch
 
@@ -2919,9 +2931,17 @@ def _chunk_required_vocab_block(
     return f"## REQUIRED VOCABULARY CHECKLIST (#1189)\n\n{instruction}\n\n{checklist}"
 
 
+def _section_has_dialogue_content(section_body: str, section_name: str) -> bool:
+    """Return True when a skeleton section likely contains dialogue content."""
+    lower_name = section_name.lower()
+    if any(token in lower_name for token in ("dialogue", "діалог")):
+        return True
+    # Check skeleton body for dialogue markers (blockquote speaker turns)
+    return bool(re.search(r">\s*—?\s*\*\*\w+", section_body))
+
+
 def _build_chunk_prompt(
     *,
-    template: str,
     section: dict,
     section_index: int,
     total_sections: int,
@@ -2938,8 +2958,14 @@ def _build_chunk_prompt(
     """Build prompt for a single section chunk.
 
     Includes the section plan from skeleton, rolling summary of previous
-    sections, and the research packet. Uses a streamlined prompt that
-    focuses the writer on one section at a time.
+    sections, and the section-scoped contract + wiki excerpts.  Uses a
+    streamlined prompt that focuses the writer on one section at a time.
+
+    Context budget target: ≤12 000 chars.  The prompt carries ONLY
+    section-scoped artifacts (contract slice, wiki excerpt slice,
+    skeleton body) plus lightweight rule summaries.  Full-module context
+    (knowledge packet, full contract, write template) is intentionally
+    excluded — those belong to the skeleton and single-call write phases.
     """
     word_target = section["words"] or 300  # fallback if no budget in skeleton
     phase = plan.get("phase", "")
@@ -2996,39 +3022,142 @@ Continue naturally from where the previous section ended. Do not re-introduce co
 
 ---
 
-{{WIKI_CHUNK_CONTEXT}}
-
 {_chunk_paragraph_language_rule(level, module_num)}
 
 ---
 
 {_chunk_other_rules(level, module_num, section_activity_ids)}
+"""
 
-## Dialogue formatting
+    # Include dialogue formatting only when the section actually contains dialogue
+    has_dialogue = _section_has_dialogue_content(section["body"], section_name)
+    if has_dialogue:
+        section_prompt += """## Dialogue formatting
 
 - **Dialogue formatting (EXEMPT from the monolingual rule):** Use blockquote `>` with speaker names in bold. Each turn on its own `>` line. Per-turn inline English translations in `*(English)*` ARE allowed for dialogs. NO blank lines between turns. Example:
   > — **Оксана:** Привіт! *(Hi!)*
   > — **Степан:** Добрий день! *(Good day!)*
   > — **Оксана:** Як справи? *(How are you?)*
 
-{_chunk_required_vocab_block(
-    section_required_terms=section_required_terms,
-    all_required_words=all_required_words,
-    section_index=section_index,
-    total_sections=total_sections,
-)}
+"""
 
-{_CHUNK_FORBIDDEN_WORDS_BLOCK}
+    vocab_block = _chunk_required_vocab_block(
+        section_required_terms=section_required_terms,
+        all_required_words=all_required_words,
+        section_index=section_index,
+        total_sections=total_sections,
+    )
+    if vocab_block:
+        section_prompt += vocab_block + "\n\n"
+
+    section_prompt += f"""{_CHUNK_FORBIDDEN_WORDS_BLOCK}
 
 ## Output
 
 Write the section starting with the H2 heading **`## {section_name}`** (verbatim — do not paraphrase). Output ONLY the section content — no preamble, no summary, no notes.
 """
-    # Wiki context is now in the knowledge packet (step_research handles it).
-    # No separate chunk injection needed.
-    section_prompt = section_prompt.replace("{WIKI_CHUNK_CONTEXT}", "")
 
     return section_prompt
+
+
+# ---------------------------------------------------------------------------
+# Prompt composition metadata — chunk phase
+# ---------------------------------------------------------------------------
+
+CHUNK_PROMPT_MAX_CHARS = 12_000
+
+
+def _build_chunk_prompt_manifest(
+    *,
+    section_name: str,
+    section_index: int,
+    total_sections: int,
+    prompt: str,
+    contract_content: str,
+    section_excerpts: str,
+    previous_summary: str,
+    has_dialogue: bool,
+    has_vocab_checklist: bool,
+) -> dict:
+    """Build machine-readable prompt metadata for a write-chunk call.
+
+    Mirrors ``_rewrite_block_prompt_manifest`` so every prompt phase
+    can be audited with the same tooling.
+    """
+    components = ["persona", "section_skeleton", "section_contract", "section_wiki_excerpts"]
+    if previous_summary:
+        components.append("previous_sections_summary")
+    components.extend(["paragraph_language_rule", "section_rules"])
+    if has_dialogue:
+        components.append("dialogue_formatting")
+    if has_vocab_checklist:
+        components.append("required_vocab_checklist")
+    components.append("forbidden_words")
+
+    return {
+        "phase": "write-chunk",
+        "section": section_name,
+        "section_index": section_index,
+        "total_sections": total_sections,
+        "components": components,
+        "metrics": {
+            "prompt_chars": len(prompt),
+            "prompt_words": len(prompt.split()),
+            "contract_chars": len(contract_content),
+            "excerpt_chars": len(section_excerpts),
+            "previous_summary_chars": len(previous_summary),
+        },
+        "flags": {
+            "includes_dialogue_formatting": has_dialogue,
+            "includes_vocab_checklist": has_vocab_checklist,
+            "includes_previous_summary": bool(previous_summary),
+        },
+    }
+
+
+def _audit_chunk_prompt(manifest: dict) -> list[str]:
+    """Return deterministic audit failures for a write-chunk prompt manifest."""
+    failures: list[str] = []
+    metrics = manifest.get("metrics") or {}
+
+    prompt_chars = metrics.get("prompt_chars", 0)
+    if prompt_chars > CHUNK_PROMPT_MAX_CHARS:
+        failures.append(
+            f"prompt exceeds max chars ({prompt_chars} > {CHUNK_PROMPT_MAX_CHARS})"
+        )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Prompt composition metadata — skeleton phase
+# ---------------------------------------------------------------------------
+
+SKELETON_PROMPT_MAX_CHARS = 40_000
+
+
+def _build_skeleton_prompt_manifest(
+    *,
+    prompt: str,
+    plan_content: str,
+    packet: str,
+    word_target: int,
+) -> dict:
+    """Build machine-readable prompt metadata for the skeleton phase."""
+    return {
+        "phase": "skeleton",
+        "components": ["template", "plan_content", "knowledge_packet"],
+        "metrics": {
+            "prompt_chars": len(prompt),
+            "prompt_words": len(prompt.split()),
+            "plan_chars": len(plan_content),
+            "packet_chars": len(packet),
+        },
+        "flags": {
+            "packet_truncated": "truncated for context window" in packet,
+        },
+        "word_target": word_target,
+    }
 
 
 def step_write_chunked(
@@ -3064,12 +3193,6 @@ def step_write_chunked(
     contract, excerpts = _ensure_contract_artifacts(
         level, module_num, slug, packet_path, log_creation=False,
     )
-
-    # Load write template for reference (used to pull content rules)
-    is_seminar = _is_seminar_track(level)
-    template_name = "v6-write-seminar.md" if is_seminar else "v6-write.md"
-    template_path = PHASES_DIR / template_name
-    template = template_path.read_text("utf-8") if template_path.exists() else ""
 
     from build.dispatch import dispatch_agent as _dispatch
 
@@ -3111,8 +3234,8 @@ def step_write_chunked(
             activity_ids=section_activity_ids,
         )
 
+        section_required_terms = [str(t) for t in (target_section.get("required_terms") or [])]
         prompt = _build_chunk_prompt(
-            template=template,
             section=section,
             section_index=i,
             total_sections=len(sections),
@@ -3123,13 +3246,42 @@ def step_write_chunked(
             module_num=module_num,
             plan=plan,
             slug=slug,
-            section_required_terms=[str(t) for t in (target_section.get("required_terms") or [])],
+            section_required_terms=section_required_terms,
             all_required_words=all_required_words,
         )
 
         # Inject correction directive on first chunk only
         if correction_directive and i == 0:
             prompt = correction_directive + "\n\n" + prompt
+
+        # Build and save prompt composition manifest for deterministic audit
+        section_name_canon = _canonical_section_name(section["title"])
+        has_dialogue = _section_has_dialogue_content(section["body"], section_name_canon)
+        vocab_block = _chunk_required_vocab_block(
+            section_required_terms=section_required_terms,
+            all_required_words=all_required_words,
+            section_index=i,
+            total_sections=len(sections),
+        )
+        manifest = _build_chunk_prompt_manifest(
+            section_name=section_name_canon,
+            section_index=i,
+            total_sections=len(sections),
+            prompt=prompt,
+            contract_content=contract_content,
+            section_excerpts=section_excerpts,
+            previous_summary=previous_summary,
+            has_dialogue=has_dialogue,
+            has_vocab_checklist=bool(vocab_block),
+        )
+        manifest_path = orch_dir / f"v6-chunk-{i + 1:02d}-manifest.yaml"
+        manifest_path.write_text(
+            yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True), "utf-8",
+        )
+
+        audit_failures = _audit_chunk_prompt(manifest)
+        if audit_failures:
+            _log(f"  ⚠️  Chunk {i + 1} prompt audit: {'; '.join(audit_failures)}")
 
         # Save chunk prompt for inspection
         chunk_prompt_path = orch_dir / f"v6-chunk-{i + 1:02d}-prompt.md"

--- a/tests/test_prompt_budget.py
+++ b/tests/test_prompt_budget.py
@@ -1,0 +1,290 @@
+"""Deterministic tests for v6 prompt composition metadata (#1280).
+
+Tests the prompt manifest builders, audit functions, and context
+shaping logic introduced to enforce prompt budgets per phase.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+from build.v6_build import (
+    CHUNK_PROMPT_MAX_CHARS,
+    _audit_chunk_prompt,
+    _build_chunk_prompt,
+    _build_chunk_prompt_manifest,
+    _build_skeleton_prompt_manifest,
+    _section_has_dialogue_content,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_PLAN = {
+    "title": "Test Module",
+    "phase": "core",
+    "word_target": 2000,
+}
+
+MINIMAL_SECTION = {
+    "title": "## Test Section (~300 words total)",
+    "body": "## Test Section (~300 words total)\n\n- P1 (~150 words): Intro.\n- P2 (~150 words): Detail.",
+    "words": 300,
+}
+
+DIALOGUE_SECTION = {
+    "title": "## Діалог: У кав'ярні (~400 words total)",
+    "body": (
+        "## Діалог: У кав'ярні (~400 words total)\n\n"
+        "- P1 (~50 words): Scene-setting.\n"
+        "- Dialogue (~200 words): Ordering coffee.\n"
+        "> — **Оксана:** Добрий день!\n"
+        "> — **Бариста:** Вітаю!\n"
+        "- P2 (~150 words): Wrap-up."
+    ),
+    "words": 400,
+}
+
+
+# ---------------------------------------------------------------------------
+# _section_has_dialogue_content
+# ---------------------------------------------------------------------------
+
+class TestSectionHasDialogueContent:
+
+    def test_title_with_dialogue_keyword(self):
+        assert _section_has_dialogue_content("plain body", "Діалог: У кав'ярні") is True
+
+    def test_title_with_english_dialogue(self):
+        assert _section_has_dialogue_content("plain body", "Dialogues and Greetings") is True
+
+    def test_body_with_speaker_turn(self):
+        body = "> — **Оксана:** Привіт!\n> — **Тарас:** Добрий день!"
+        assert _section_has_dialogue_content(body, "Plain Title") is True
+
+    def test_no_dialogue_content(self):
+        assert _section_has_dialogue_content("Just normal prose.", "Grammar Rules") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_chunk_prompt — structure validation
+# ---------------------------------------------------------------------------
+
+class TestBuildChunkPrompt:
+
+    def _make_prompt(self, section=None, **overrides):
+        defaults = dict(
+            section=section or MINIMAL_SECTION,
+            section_index=0,
+            total_sections=4,
+            previous_summary="",
+            contract_content="current_section:\n  name: Test",
+            section_excerpts="section: Test\nitems: []",
+            level="a1",
+            module_num=5,
+            plan=MINIMAL_PLAN,
+            slug="test-module",
+            section_required_terms=["слово", "речення"],
+            all_required_words=["слово", "речення", "граматика"],
+        )
+        defaults.update(overrides)
+        return _build_chunk_prompt(**defaults)
+
+    def test_no_wiki_chunk_context_placeholder(self):
+        """Dead {WIKI_CHUNK_CONTEXT} placeholder must not appear."""
+        prompt = self._make_prompt()
+        assert "{WIKI_CHUNK_CONTEXT}" not in prompt
+
+    def test_contains_section_skeleton(self):
+        prompt = self._make_prompt()
+        assert "Section Skeleton" in prompt
+
+    def test_contains_forbidden_words(self):
+        prompt = self._make_prompt()
+        assert "FORBIDDEN WORDS" in prompt
+
+    def test_dialogue_formatting_excluded_for_plain_section(self):
+        prompt = self._make_prompt(section=MINIMAL_SECTION)
+        assert "Dialogue formatting" not in prompt
+
+    def test_dialogue_formatting_included_for_dialogue_section(self):
+        prompt = self._make_prompt(section=DIALOGUE_SECTION)
+        assert "Dialogue formatting" in prompt
+
+    def test_previous_summary_excluded_on_first_section(self):
+        prompt = self._make_prompt(previous_summary="")
+        assert "Previous Sections" not in prompt
+
+    def test_previous_summary_included_when_present(self):
+        prompt = self._make_prompt(previous_summary="Previous content here.")
+        assert "Previous Sections" in prompt
+
+    def test_vocab_checklist_included_when_terms_exist(self):
+        prompt = self._make_prompt(section_required_terms=["слово"])
+        assert "REQUIRED VOCABULARY CHECKLIST" in prompt
+
+    def test_vocab_checklist_excluded_when_no_terms(self):
+        prompt = self._make_prompt(
+            section_required_terms=[],
+            all_required_words=[],
+        )
+        assert "REQUIRED VOCABULARY CHECKLIST" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# _build_chunk_prompt_manifest
+# ---------------------------------------------------------------------------
+
+class TestBuildChunkPromptManifest:
+
+    def _make_manifest(self, **overrides):
+        defaults = dict(
+            section_name="Test Section",
+            section_index=1,
+            total_sections=4,
+            prompt="x" * 5000,
+            contract_content="contract text",
+            section_excerpts="excerpt text",
+            previous_summary="previous summary",
+            has_dialogue=False,
+            has_vocab_checklist=True,
+        )
+        defaults.update(overrides)
+        return _build_chunk_prompt_manifest(**defaults)
+
+    def test_phase_is_write_chunk(self):
+        m = self._make_manifest()
+        assert m["phase"] == "write-chunk"
+
+    def test_section_metadata(self):
+        m = self._make_manifest(section_name="Діалог", section_index=2, total_sections=5)
+        assert m["section"] == "Діалог"
+        assert m["section_index"] == 2
+        assert m["total_sections"] == 5
+
+    def test_metrics_present(self):
+        m = self._make_manifest()
+        assert "prompt_chars" in m["metrics"]
+        assert "prompt_words" in m["metrics"]
+        assert "contract_chars" in m["metrics"]
+        assert "excerpt_chars" in m["metrics"]
+        assert "previous_summary_chars" in m["metrics"]
+
+    def test_flags_reflect_dialogue(self):
+        m1 = self._make_manifest(has_dialogue=False)
+        assert m1["flags"]["includes_dialogue_formatting"] is False
+
+        m2 = self._make_manifest(has_dialogue=True)
+        assert m2["flags"]["includes_dialogue_formatting"] is True
+
+    def test_components_include_dialogue_when_flagged(self):
+        m = self._make_manifest(has_dialogue=True)
+        assert "dialogue_formatting" in m["components"]
+
+    def test_components_exclude_dialogue_when_not_flagged(self):
+        m = self._make_manifest(has_dialogue=False)
+        assert "dialogue_formatting" not in m["components"]
+
+    def test_components_include_vocab_when_flagged(self):
+        m = self._make_manifest(has_vocab_checklist=True)
+        assert "required_vocab_checklist" in m["components"]
+
+    def test_components_exclude_vocab_when_not_flagged(self):
+        m = self._make_manifest(has_vocab_checklist=False)
+        assert "required_vocab_checklist" not in m["components"]
+
+    def test_previous_summary_flag(self):
+        m1 = self._make_manifest(previous_summary="")
+        assert m1["flags"]["includes_previous_summary"] is False
+
+        m2 = self._make_manifest(previous_summary="content")
+        assert m2["flags"]["includes_previous_summary"] is True
+
+
+# ---------------------------------------------------------------------------
+# _audit_chunk_prompt
+# ---------------------------------------------------------------------------
+
+class TestAuditChunkPrompt:
+
+    def test_passes_under_budget(self):
+        manifest = {
+            "metrics": {"prompt_chars": CHUNK_PROMPT_MAX_CHARS - 1},
+        }
+        assert _audit_chunk_prompt(manifest) == []
+
+    def test_fails_over_budget(self):
+        manifest = {
+            "metrics": {"prompt_chars": CHUNK_PROMPT_MAX_CHARS + 1},
+        }
+        failures = _audit_chunk_prompt(manifest)
+        assert len(failures) == 1
+        assert "exceeds max chars" in failures[0]
+
+    def test_passes_exactly_at_budget(self):
+        manifest = {
+            "metrics": {"prompt_chars": CHUNK_PROMPT_MAX_CHARS},
+        }
+        assert _audit_chunk_prompt(manifest) == []
+
+
+# ---------------------------------------------------------------------------
+# _build_skeleton_prompt_manifest
+# ---------------------------------------------------------------------------
+
+class TestBuildSkeletonPromptManifest:
+
+    def test_phase_is_skeleton(self):
+        m = _build_skeleton_prompt_manifest(
+            prompt="p" * 100,
+            plan_content="plan",
+            packet="packet",
+            word_target=2000,
+        )
+        assert m["phase"] == "skeleton"
+
+    def test_metrics_present(self):
+        m = _build_skeleton_prompt_manifest(
+            prompt="p" * 500,
+            plan_content="plan" * 100,
+            packet="packet" * 200,
+            word_target=3000,
+        )
+        assert m["metrics"]["prompt_chars"] == 500
+        assert m["metrics"]["plan_chars"] == 400
+        assert m["metrics"]["packet_chars"] == 1200
+        assert m["word_target"] == 3000
+
+    def test_packet_truncated_flag(self):
+        m = _build_skeleton_prompt_manifest(
+            prompt="p",
+            plan_content="plan",
+            packet="some text... truncated for context window",
+            word_target=1000,
+        )
+        assert m["flags"]["packet_truncated"] is True
+
+    def test_packet_not_truncated_flag(self):
+        m = _build_skeleton_prompt_manifest(
+            prompt="p",
+            plan_content="plan",
+            packet="full packet content",
+            word_target=1000,
+        )
+        assert m["flags"]["packet_truncated"] is False
+
+    def test_components_list(self):
+        m = _build_skeleton_prompt_manifest(
+            prompt="p",
+            plan_content="plan",
+            packet="packet",
+            word_target=1000,
+        )
+        assert "template" in m["components"]
+        assert "plan_content" in m["components"]
+        assert "knowledge_packet" in m["components"]


### PR DESCRIPTION
## Summary

Closes #1280.

- **Strip redundant context from write-chunk prompts**: removed dead `template` parameter (loaded but never referenced), dead `{WIKI_CHUNK_CONTEXT}` placeholder (always empty), and made dialogue formatting conditional on section content.
- **Add machine-readable prompt composition manifests** (`v6-chunk-NN-manifest.yaml`, `v6-skeleton-manifest.yaml`) with deterministic audit functions (`_audit_chunk_prompt`, `_build_chunk_prompt_manifest`, `_build_skeleton_prompt_manifest`), mirroring the existing rewrite-block pattern.
- **Document intended context budget/shape** for all four writer phases (research, skeleton, write-chunk, rewrite-block) in `docs/prompt-budgets.md` with per-phase budget constants.
- **30 deterministic tests** covering prompt composition, manifest structure, audit logic, and conditional inclusion of dialogue/vocab blocks.

No manual lesson edits. Pipeline behavior only.

## Test plan

- [x] `ruff check` passes on touched files
- [x] `pytest tests/test_prompt_budget.py` — 30/30 pass
- [x] `pytest tests/test_chunked_write.py` — 20/20 pass (regression)
- [x] `pytest tests/test_v6_prompt_literals.py tests/test_v6_insert_after_fix.py tests/test_prompt_assembly.py tests/test_prompt_health.py` — 73/73 pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)