### PR TITLE
fix: skip wiki retrieval for completed articles (#1378)

### DIFF
--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -86,7 +86,12 @@ from wiki.sources import (
     list_discovery_slugs_readonly,
     list_literary_sources,
 )
-from wiki.sources_schema import registry_path_for
+from wiki.sources_schema import (
+    extract_short_citation_ids,
+    load_sources_registry,
+    registry_path_for,
+    validate_sources_registry,
+)
 from wiki.state import log_event, read_log
 
 # ── Domain mapping: how to group discovery slugs into wiki articles ──
@@ -310,16 +315,17 @@ def cmd_compile_one(track: str, slug: str, *, force: bool = False,
     """
     from wiki.state import is_compiled
 
-    print(f"\n🔨 Compiling: {track}/{slug}")
-
-    # Get domain mapping
-    t_stage = time.monotonic()
     domain = _get_domain(track, slug)
     article_key = f"{domain}/{slug}"
-    already_compiled = not force and not dry_run and is_compiled(article_key)
+    if not force and not dry_run and _compiled_article_is_ready(track, slug):
+        print(f"  ⏭️  Already compiled: {article_key}")
+        return True
+
+    print(f"\n🔨 Compiling: {track}/{slug}")
 
     # Gather sources — can stall on cloud-backed or slow filesystem paths.
     # Codex review 2026-04-21 flagged this as the #1 silent-hang suspect.
+    t_stage = time.monotonic()
     print(f"  📂 Gathering discovery sources... ({_ts()})", flush=True)
     sources_info = gather_discovery_sources(track, slug)
     print(f"    ✓ gather_discovery_sources in {time.monotonic() - t_stage:.1f}s", flush=True)
@@ -344,13 +350,13 @@ def cmd_compile_one(track: str, slug: str, *, force: bool = False,
         domain=domain,
         sources=all_chunks,
         track=track,
-        force=force,
+        force=force or is_compiled(article_key),
         dry_run=dry_run,
     )
     print(f"    ✓ compile_article in {time.monotonic() - t_stage:.1f}s", flush=True)
 
     if result:
-        if not already_compiled and not dry_run:
+        if not dry_run:
             t_stage = time.monotonic()
             print("  📑 Updating index + logging event...", flush=True)
             update_index()
@@ -369,6 +375,39 @@ def cmd_compile_one(track: str, slug: str, *, force: bool = False,
             print(f"    ✓ dim-review in {time.monotonic() - t_stage:.1f}s", flush=True)
         return True
     return dry_run  # dry_run returns None but isn't a failure
+
+
+def _compiled_article_is_ready(track: str, slug: str) -> bool:
+    """Return True when an article is fully compiled and safe to skip.
+
+    "Compiled" here means more than a progress-db row: the markdown must
+    exist, and if the article cites sources then its sibling
+    ``.sources.yaml`` must exist and validate cleanly.
+    """
+    from wiki.state import is_compiled
+
+    domain = _get_domain(track, slug)
+    article_key = f"{domain}/{slug}"
+    if not is_compiled(article_key):
+        return False
+
+    article_path = WIKI_DIR / domain / f"{slug}.md"
+    try:
+        article_text = article_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    registry_path = registry_path_for(article_path)
+    citation_ids = extract_short_citation_ids(article_text)
+    if not registry_path.exists():
+        return not citation_ids
+
+    try:
+        registry = load_sources_registry(registry_path)
+    except Exception:
+        return False
+
+    return not validate_sources_registry(article_text, registry)
 
 
 def _dim_review_article(article_path: Path, track: str, slug: str) -> None:
@@ -1174,6 +1213,13 @@ def cmd_compile_all(track: str, *, limit: int | None = None,
     for i, slug in enumerate(slugs, 1):
         slug_start = time.time()
         print(f"\n[{i}/{len(slugs)}] {slug}  ({_ts()})")
+        if not force and not dry_run and _compiled_article_is_ready(track, slug):
+            domain = _get_domain(track, slug)
+            skipped += 1
+            elapsed = time.time() - slug_start
+            print(f"  ⏭️  Already compiled: {domain}/{slug}")
+            print(f"  ⏭️  Skipped (already compiled) in {elapsed:.1f}s")
+            continue
         try:
             result = cmd_compile_one(
                 track, slug,

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -282,24 +282,75 @@ class TestCompileArticleSkipLogic:
 
 
 class TestCompileCommand:
+    def test_compiled_article_is_ready_with_valid_sources_sidecar(self, tmp_path):
+        from wiki.compile import _compiled_article_is_ready
+
+        wiki_dir = tmp_path / "wiki"
+        article_dir = wiki_dir / "pedagogy" / "a1"
+        article_dir.mkdir(parents=True)
+        (article_dir / "demo.md").write_text("# Demo\n\nSentence [S1].\n", encoding="utf-8")
+        (article_dir / "demo.sources.yaml").write_text(
+            "sources:\n"
+            "  - id: S1\n"
+            "    file: ext-demo-1\n"
+            "    type: external\n",
+            encoding="utf-8",
+        )
+
+        with patch("wiki.compile.WIKI_DIR", wiki_dir), \
+             patch("wiki.state.is_compiled", return_value=True), \
+             patch("wiki.compile._get_domain", return_value="pedagogy/a1"):
+            assert _compiled_article_is_ready("a1", "demo") is True
+
+    def test_compiled_article_is_not_ready_when_citations_lack_sidecar(self, tmp_path):
+        from wiki.compile import _compiled_article_is_ready
+
+        wiki_dir = tmp_path / "wiki"
+        article_dir = wiki_dir / "pedagogy" / "a1"
+        article_dir.mkdir(parents=True)
+        (article_dir / "demo.md").write_text("# Demo\n\nSentence [S1].\n", encoding="utf-8")
+
+        with patch("wiki.compile.WIKI_DIR", wiki_dir), \
+             patch("wiki.state.is_compiled", return_value=True), \
+             patch("wiki.compile._get_domain", return_value="pedagogy/a1"):
+            assert _compiled_article_is_ready("a1", "demo") is False
+
     def test_skip_does_not_log_compile_or_update_index(self):
         from wiki.compile import cmd_compile_one
 
-        article_path = os.path.join("wiki", "pedagogy", "a1", "demo.md")
-
         with patch("wiki.compile._get_domain", return_value="pedagogy/a1"), \
-             patch("wiki.compile.gather_discovery_sources", return_value={}), \
-             patch("wiki.compile.enrich_sources", return_value=[{"chunk_id": "c1", "text": "text"}]), \
-             patch("wiki.compile._slug_to_topic", return_value="Demo"), \
-             patch("wiki.compile.compile_article", return_value=Path(article_path)), \
+             patch("wiki.compile._compiled_article_is_ready", return_value=True), \
+             patch("wiki.compile.gather_discovery_sources") as gather_sources, \
+             patch("wiki.compile.enrich_sources") as enrich_sources, \
+             patch("wiki.compile.compile_article") as compile_article, \
              patch("wiki.compile.update_index") as update_index, \
-             patch("wiki.compile.log_event") as log_event, \
-             patch("wiki.state.is_compiled", return_value=True):
+             patch("wiki.compile.log_event") as log_event:
             ok = cmd_compile_one("a1", "demo")
 
         assert ok is True
+        gather_sources.assert_not_called()
+        enrich_sources.assert_not_called()
+        compile_article.assert_not_called()
         update_index.assert_not_called()
         log_event.assert_not_called()
+
+    def test_compile_all_skips_ready_articles_before_cmd_compile_one(self):
+        from wiki.compile import cmd_compile_all
+
+        with patch("wiki.compile.list_discovery_slugs", return_value=["done", "todo"]), \
+             patch("wiki.compile._compiled_article_is_ready", side_effect=[True, False]), \
+             patch("wiki.compile._get_domain", return_value="pedagogy/a1"), \
+             patch("wiki.compile.cmd_compile_one", return_value=True) as compile_one:
+            cmd_compile_all("a1")
+
+        compile_one.assert_called_once_with(
+            "a1",
+            "todo",
+            force=False,
+            dry_run=False,
+            review=False,
+            dim_review=False,
+        )
 
     def test_dim_review_flag_runs_shadow_review_and_writes_report(self):
         from wiki.compile import cmd_compile_one


### PR DESCRIPTION
## Summary
- move wiki skip detection ahead of source gathering and retrieval in both single-slug and batch flows
- only skip when the article is actually ready: markdown exists and any cited source registry validates cleanly
- force recompilation through the writer when a stale compiled row exists but the article is incomplete

## Testing
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_wiki_compiler.py -q