### PR TITLE
docs: improve help for agent-facing CLIs (#1379)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -6,6 +6,10 @@ Current operational reference for repo-local scripts and agent workflows.
 - Validation pipeline after content exists: `npm run audit`, `npm run pipeline`, `npm run generate:json`
 - This document intentionally omits retired pipelines and legacy script paths
 
+Before guessing CLI flags, run the tool's `--help`. The repo standard lives in
+`claude_extensions/rules/cli-help-standard.md`, and touched CLIs are expected to
+meet it so agents can use them without source-diving.
+
 ---
 
 ## Startup Wrappers

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -327,7 +327,27 @@ def _handle_codex_usage(args) -> None:
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
-    parser = argparse.ArgumentParser(description="AI Agent Bridge - Claude/Gemini/Codex Communication")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bridge CLI for Claude, Gemini, and Codex message passing.\n"
+            "Use it for brokered multi-agent communication; do not use it as a substitute for direct local shell commands."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for gemini\n"
+            "  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex - --task-id review-123 < prompt.md\n"
+            "  .venv/bin/python scripts/ai_agent_bridge/__main__.py process-codex 4812 --new-session\n\n"
+            "Outputs:\n"
+            "  Reads and writes broker messages, may invoke agent CLIs, and can post follow-up data to GitHub.\n\n"
+            "Exit codes:\n"
+            "  0 on successful command completion; non-zero on CLI misuse, broker failures, or agent invocation failures.\n\n"
+            "Related:\n"
+            "  Broker DB: batch_state/agent_comms.db\n"
+            "  Runtime: scripts/agent_runtime/\n"
+            "  Issue: #1379\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # inbox

--- a/scripts/audit/audit_module.py
+++ b/scripts/audit/audit_module.py
@@ -100,18 +100,34 @@ def auto_fix_yaml_violations(file_path: str) -> tuple[int, list[str]]:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Audit curriculum module files for quality and standards."
+        description=(
+            "Audit curriculum modules for content, YAML, review, and gate compliance.\n"
+            "Use it on built module markdown; do not use it for wiki articles or raw plans."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a1/01-hello.md\n"
+            "  .venv/bin/python scripts/audit_module.py --fix curriculum/l2-uk-en/a2/03-genitive.md\n\n"
+            "Outputs:\n"
+            "  Prints audit findings to stdout and may rewrite YAML / IPA issues when --fix is set.\n\n"
+            "Exit codes:\n"
+            "  0 when every audited module passes; 1 when any module fails or CLI usage is invalid.\n\n"
+            "Related:\n"
+            "  Implementation: scripts/audit/audit_module.py\n"
+            "  Issue: #1379\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("files", nargs="*", help="Module file(s) to audit")
+    parser.add_argument("files", nargs="*", help="Module markdown file(s) to audit, e.g. curriculum/l2-uk-en/a1/01-hello.md.")
     parser.add_argument(
         "--fix",
         action="store_true",
-        help="Automatically fix YAML schema violations"
+        help="Automatically fix YAML schema violations and rerun the audit."
     )
     parser.add_argument(
         "--naturalness",
         action="store_true",
-        help="Auto-check naturalness via Gemini if PENDING"
+        help="Auto-check naturalness via Gemini when the audit would otherwise leave it PENDING."
     )
     parser.add_argument(
         "--skip-activities",
@@ -132,8 +148,7 @@ if __name__ == "__main__":
         os.environ['AUDIT_AUTO_NATURALNESS'] = '1'
 
     if not args.files:
-        print("Usage: python3 scripts/audit_module.py <file.md> [file2.md ...] [--fix]")
-        sys.exit(1)
+        parser.error("at least one module file is required")
 
     any_failure = False
     for file_path in args.files:

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -10146,9 +10146,28 @@ def main():
     if isinstance(sys.stdout, io.TextIOWrapper):
         sys.stdout.reconfigure(line_buffering=True)
 
-    parser = argparse.ArgumentParser(description="V6 Pipeline Build")
-    parser.add_argument("level", help="Level (e.g., a1)")
-    parser.add_argument("module", type=int, help="Module number (or start of range with --range)")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build curriculum modules through the v6 pipeline.\n"
+            "Use it for end-to-end module orchestration; do not use it for isolated wiki/article maintenance."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/build/v6_build.py a1 7\n"
+            "  .venv/bin/python scripts/build/v6_build.py a2 3 --step review --reviewer codex\n"
+            "  .venv/bin/python scripts/build/v6_build.py b1 1 --range 4 --resume\n\n"
+            "Outputs:\n"
+            "  Writes module markdown, sidecars, orchestration state, review/audit artifacts, and published outputs.\n\n"
+            "Exit codes:\n"
+            "  0 on successful build; non-zero on CLI misuse or any failed phase.\n\n"
+            "Related:\n"
+            "  Docs: docs/SCRIPTS.md\n"
+            "  Issue: #1379\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("level", help="Curriculum level, e.g. a1, a2, or b1.")
+    parser.add_argument("module", type=int, help="Module number, or range start when used with --range.")
     parser.add_argument("--range", type=int, default=None, metavar="END",
                         help="Build modules from MODULE to END (inclusive). E.g., a1 7 --range 14")
     parser.add_argument("--writer", choices=["gemini", "gemini-tools", "claude", "claude-tools", "codex", "codex-tools"], default="gemini-tools",
@@ -10156,7 +10175,8 @@ def main():
     parser.add_argument("--reviewer", choices=["gemini", "gemini-tools", "claude", "claude-tools", "codex", "codex-tools"], default=None,
                         help="Override reviewer. Default: cross-agent (opposite of writer)")
     parser.add_argument("--step", choices=["check", "research", "pre-verify", "skeleton", "write", "exercises", "activities", "repair", "verify-exercises", "annotate", "enrich", "verify", "review", "review-style", "publish", "audit", "all"],
-                        default="all")
+                        default="all",
+                        help="Stop after this phase or run the full pipeline (default: all).")
     skeleton_group = parser.add_mutually_exclusive_group()
     skeleton_group.add_argument("--skeleton", action="store_true", default=None,
                                 help="Force skeleton step (default: always on)")

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -782,19 +782,41 @@ def cmd_worker(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="delegate.py",
-        description="Async task dispatch over agent_runtime (#1184)",
+        description=(
+            "Dispatch async agent_runtime tasks and monitor their lifecycle.\n"
+            "Use it for long-running background agent work; do not use it for one-shot local invocations."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id review-123 --prompt-file prompt.md --mode workspace-write --cwd .\n"
+            "  .venv/bin/python scripts/delegate.py wait review-123 --timeout 600\n"
+            "  .venv/bin/python scripts/delegate.py list --status running\n\n"
+            "Outputs:\n"
+            "  Persists task state under batch_state/tasks/ and streams worker output to task-owned logs.\n\n"
+            "Exit codes:\n"
+            "  0 on successful command completion; non-zero on CLI misuse or worker/task failures.\n\n"
+            "Related:\n"
+            "  Runtime: scripts/agent_runtime/\n"
+            "  Rule: claude_extensions/rules/delegate-must-use-worktree.md\n"
+            "  Issue: #1379\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sub = p.add_subparsers(dest="command", required=True)
 
     # dispatch
     d = sub.add_parser("dispatch", help="Fire a task, return immediately")
-    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude"])
-    d.add_argument("--task-id", required=True)
-    d.add_argument("--prompt", help="Prompt text, or '-' for stdin")
-    d.add_argument("--prompt-file", help="Read prompt from this file")
+    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude"],
+                   help="Agent to run for the task: codex, gemini, or claude.")
+    d.add_argument("--task-id", required=True,
+                   help="Stable task identifier used for state/log files, e.g. review-123.")
+    d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")
+    d.add_argument("--prompt-file", help="Read the prompt body from this file path.")
     d.add_argument("--mode", default="read-only",
-                   choices=["read-only", "workspace-write", "danger"])
-    d.add_argument("--model", default=None)
+                   choices=["read-only", "workspace-write", "danger"],
+                   help="Runtime mode (default: read-only). Use danger only with --worktree.")
+    d.add_argument("--model", default=None,
+                   help="Optional model override, e.g. gpt-5.4 or gemini-3.1-pro-preview.")
     d.add_argument("--cwd", default=None,
                    help="Working directory for the worker (default: repo root)")
     d.add_argument(
@@ -808,12 +830,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     # status
     s = sub.add_parser("status", help="Check task status (fast, no block)")
-    s.add_argument("task_id")
+    s.add_argument("task_id", help="Task ID to inspect, e.g. review-123.")
     s.set_defaults(func=cmd_status)
 
     # wait
     w = sub.add_parser("wait", help="Block until task reaches terminal state")
-    w.add_argument("task_id")
+    w.add_argument("task_id", help="Task ID to wait for, e.g. review-123.")
     w.add_argument("--timeout", type=float, default=0,
                    help="Max wait seconds (0 = forever)")
     w.add_argument("--poll-interval", type=float, default=2.0,
@@ -822,14 +844,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     # cancel
     c = sub.add_parser("cancel", help="SIGTERM the worker")
-    c.add_argument("task_id")
+    c.add_argument("task_id", help="Task ID to cancel, e.g. review-123.")
     c.set_defaults(func=cmd_cancel)
 
     # list
     l = sub.add_parser("list", help="List tasks (with optional status filter)")
     l.add_argument("--status", default=None,
                    choices=["spawning", "running", "done", "failed",
-                            "rate_limited", "crashed", "cancelled"])
+                            "rate_limited", "crashed", "cancelled"],
+                   help="Optional status filter, e.g. running or failed.")
     l.set_defaults(func=cmd_list)
 
     # _worker (hidden — internal)

--- a/scripts/wiki/check_language_ratio.py
+++ b/scripts/wiki/check_language_ratio.py
@@ -131,9 +131,25 @@ def check_file(path: Path, threshold: float, verbose: bool = False) -> int:
 
 def main() -> int:
     ap = argparse.ArgumentParser(
-        description="Check wiki prose is Ukrainian-canonical (Cyrillic ratio guard)."
+        description=(
+            "Check wiki prose is Ukrainian-canonical with a Cyrillic-ratio guard.\n"
+            "Use it on compiled wiki markdown; do not use it for lesson/module files."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/wiki/check_language_ratio.py wiki/pedagogy/a1/hello.md\n"
+            "  .venv/bin/python scripts/wiki/check_language_ratio.py --threshold 0.95 wiki/periods/*.md\n\n"
+            "Outputs:\n"
+            "  Prints per-file PASS/FAIL lines and optional heading stats.\n\n"
+            "Exit codes:\n"
+            "  0 if all files pass; 1 if any file fails the threshold or cannot be read.\n\n"
+            "Related:\n"
+            "  Wiki compiler: scripts/wiki/compile.py\n"
+            "  Issue: #1379\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    ap.add_argument("files", nargs="+", type=Path, help="Wiki markdown file(s) to check.")
+    ap.add_argument("files", nargs="+", type=Path, help="Wiki markdown file(s) to check, e.g. wiki/pedagogy/a1/hello.md.")
     ap.add_argument(
         "--threshold",
         type=float,
@@ -141,7 +157,7 @@ def main() -> int:
         help="Minimum Cyrillic ratio in body prose (default 0.85 for pedagogy wikis; "
         "raise to 0.95 for academic seminar wikis).",
     )
-    ap.add_argument("--verbose", "-v", action="store_true", help="Also print heading-language stats.")
+    ap.add_argument("--verbose", "-v", action="store_true", help="Also print heading-language stats (default: off).")
     args = ap.parse_args()
 
     worst_exit = 0

--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -1362,13 +1362,29 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
             "Wiki knowledge base compiler. Compiles curated articles from textbook "
-            "sources and RAG data using Gemini. Articles are used as context for "
-            "module content generation.\n\n"
+            "sources and RAG data using Gemini.\n"
+            "Use it for wiki article compile/review/index workflows; do not use it "
+            "for module generation itself.\n\n"
             "Prompt per track type:\n"
             "  A1:         Pedagogical briefs (methodology, phonetics, vocab boundaries)\n"
             "  A2-B2:      Grammar briefs (paradigms, frequency, L2 errors)\n"
             "  C1-C2:      Academic briefs (scholarly register, stylistics)\n"
             "  Seminars:   Knowledge articles (primary sources, historiography)"
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/wiki/compile.py --track a2 --slug genitive-intro --dry-run\n"
+            "  .venv/bin/python scripts/wiki/compile.py --track a2 --all --limit 5 --review\n"
+            "  .venv/bin/python scripts/wiki/compile.py --track folk --review-only\n\n"
+            "Outputs:\n"
+            "  Writes wiki/<domain>/<slug>.md plus sibling .sources.yaml registries,\n"
+            "  updates wiki/index.md, and appends build events under wiki/.state/.\n\n"
+            "Exit codes:\n"
+            "  0 on success; 1 on invalid CLI usage or single-slug compile failure.\n\n"
+            "Related:\n"
+            "  Prompts: scripts/wiki/prompts/\n"
+            "  Design: docs/design/dimensional-review.md\n"
+            "  Issue: #1379\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1383,19 +1399,19 @@ def main() -> None:
     # Track selection
     parser.add_argument("--track", choices=ALL_TRACKS,
                         help="Track to compile (a1-c2 for core, folk/hist/etc for seminars)")
-    parser.add_argument("--slug", help="Specific module slug to compile")
+    parser.add_argument("--slug", help="Specific module slug to compile, e.g. genitive-intro")
     parser.add_argument("--all", action="store_true", dest="compile_all",
-                        help="Compile all modules in the track")
+                        help="Compile every discovery slug in the selected --track")
     parser.add_argument("--list", action="store_true",
-                        help="List available modules for a track")
+                        help="List available module slugs for the selected --track")
 
     # Options
     parser.add_argument("--limit", type=int,
-                        help="Max articles to compile (with --all)")
+                        help="Max articles to compile with --all, e.g. --limit 20")
     parser.add_argument("--force", action="store_true",
-                        help="Recompile even if already done")
+                        help="Recompile even if article + valid sidecar already exist")
     parser.add_argument("--dry-run", action="store_true",
-                        help="Print prompt without calling Gemini")
+                        help="Print the assembled prompt without calling Gemini")
     parser.add_argument("--review", action="store_true",
                         help="Review articles after compilation (legacy single-call)")
     parser.add_argument("--review-only", action="store_true",

--- a/scripts/wiki/ukrainian_wiki_corpus.py
+++ b/scripts/wiki/ukrainian_wiki_corpus.py
@@ -963,20 +963,43 @@ def ingest_articles(
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Ingest compiled wiki markdown into the ukrainian_wiki corpus.")
-    parser.add_argument("article", type=Path, help="Path to a compiled wiki markdown article or a directory of articles")
-    parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH, help="Override sources.db path")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ingest compiled wiki markdown into the ukrainian_wiki retrieval corpus.\n"
+            "Use it after wiki compilation; do not use it on raw discovery or lesson markdown."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/wiki/ingest_ukrainian_wiki.py wiki/pedagogy/a1/hello.md\n"
+            "  .venv/bin/python scripts/wiki/ingest_ukrainian_wiki.py wiki/pedagogy/a1 --report-path data/corpus_audit/a1-report.md\n\n"
+            "Outputs:\n"
+            "  Inserts passages into data/sources.db, updates the embedding manifest, and writes a markdown ingest report.\n\n"
+            "Exit codes:\n"
+            "  0 when all requested articles ingest cleanly; 1 when any article fails.\n\n"
+            "Related:\n"
+            "  Wrapper: scripts/wiki/ingest_ukrainian_wiki.py\n"
+            "  Issue: #1379\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("article", type=Path, help="Compiled wiki markdown path or a directory of compiled articles.")
+    parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH, help=f"Override sources DB path (default: {DEFAULT_DB_PATH}).")
     parser.add_argument(
         "--manifest-db",
         type=Path,
         default=DEFAULT_MANIFEST_DB,
-        help="Override embeddings manifest path",
+        help=f"Override embedding manifest DB path (default: {DEFAULT_MANIFEST_DB}).",
     )
-    parser.add_argument("--report-path", type=Path, default=DEFAULT_REPORT_PATH)
-    parser.add_argument("--min-words", type=int, default=DEFAULT_MIN_WORDS)
-    parser.add_argument("--max-chars", type=int, default=DEFAULT_MAX_CHARS)
-    parser.add_argument("--min-chunk-chars", type=int, default=DEFAULT_CHUNK_MIN_CHARS)
-    parser.add_argument("--min-vesum-coverage", type=float, default=DEFAULT_VESUM_MIN_COVERAGE)
+    parser.add_argument("--report-path", type=Path, default=DEFAULT_REPORT_PATH,
+                        help=f"Markdown report output path (default: {DEFAULT_REPORT_PATH}).")
+    parser.add_argument("--min-words", type=int, default=DEFAULT_MIN_WORDS,
+                        help=f"Reject passages below this word count (default: {DEFAULT_MIN_WORDS}).")
+    parser.add_argument("--max-chars", type=int, default=DEFAULT_MAX_CHARS,
+                        help=f"Maximum characters per passage chunk before splitting (default: {DEFAULT_MAX_CHARS}).")
+    parser.add_argument("--min-chunk-chars", type=int, default=DEFAULT_CHUNK_MIN_CHARS,
+                        help=f"Minimum characters for a kept chunk after splitting (default: {DEFAULT_CHUNK_MIN_CHARS}).")
+    parser.add_argument("--min-vesum-coverage", type=float, default=DEFAULT_VESUM_MIN_COVERAGE,
+                        help=f"Minimum Vesum/Pravopys coverage ratio for single-article ingest (default: {DEFAULT_VESUM_MIN_COVERAGE}).")
     return parser
 
 


### PR DESCRIPTION
## Summary
- upgrade help text for the current agent-facing CLI entrypoints (compile, delegate, v6_build, wiki ingest/check, audit, bridge)
- add examples, outputs, exit-code guidance, and clearer argument help where agents were likely to guess flags
- update docs/SCRIPTS.md to point contributors at the cli-help standard before inventing flags

## Notes
- The issue body listed some stale wrapper paths; this PR updates the current parser owners instead.
- `scripts/ai_agent_bridge/monitor_client.py` is a library module, not a supported standalone CLI.

## Testing
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py tests/test_wiki_compiler.py -q
- rendered --help for: scripts/wiki/compile.py, scripts/wiki/check_language_ratio.py, scripts/delegate.py, scripts/build/v6_build.py, scripts/wiki/ingest_ukrainian_wiki.py, scripts/audit_module.py, scripts/ai_agent_bridge/__main__.py
