### PR TITLE
feat: --effort wiring for claude/codex dispatch (#1396)

### DIFF
--- a/claude_extensions/rules/delegate-must-use-worktree.md
+++ b/claude_extensions/rules/delegate-must-use-worktree.md
@@ -37,6 +37,14 @@ feature branch in the main checkout. Concrete setup:
     cd .worktrees/<task-name>
     # do work, commit, push
 
+    # For dispatches that warrant peak Opus 4.7 reasoning:
+    #   .venv/bin/python scripts/delegate.py dispatch \
+    #       --agent claude --effort xhigh --model claude-opus-4-7 \
+    #       --task-id <task-name> --worktree .worktrees/<task-name> \
+    #       --mode danger --prompt-file brief.md
+    # Accepted --effort levels: low | medium | high | xhigh | max
+    # (Omit --effort to use the agent's own CLI/config default.)
+
 The main checkout (wherever the user is working) stays untouched on
 `main`. After the PR merges, the worktree is cleaned up by the user
 or the next agent session:

--- a/scripts/agent_runtime/adapters/base.py
+++ b/scripts/agent_runtime/adapters/base.py
@@ -107,6 +107,7 @@ class AgentAdapter(Protocol):
         task_id: str | None,
         session_id: str | None,
         tool_config: dict | None,
+        effort: str | None = None,
     ) -> InvocationPlan:
         """Build the full InvocationPlan for spawning this agent.
 
@@ -124,6 +125,18 @@ class AgentAdapter(Protocol):
                 Gemini this carries MCP server names and allowed tools.
                 Structure is adapter-defined; keys the adapter doesn't
                 understand are silently ignored.
+            effort: Cross-agent reasoning/effort level. Peer of ``model``
+                in invocation semantics — NOT adapter-specific
+                tool_config. Accepted levels: ``"low" | "medium" | "high"
+                | "xhigh" | "max"``. When ``None``, each adapter falls
+                through to its own CLI / config default (Claude CLI
+                default, Codex's ``~/.codex/config.toml``, etc.). Each
+                adapter decides how to surface the level to its CLI:
+                Claude passes ``--effort <level>`` when the binary
+                supports it (CC 2.1.98+); Codex passes
+                ``-c model_reasoning_effort=<level>``; Gemini currently
+                no-ops with a debug log (see #1396). Adapters MUST NOT
+                hard-fail on an unsupported CLI — warn and proceed.
 
         Returns:
             InvocationPlan ready for subprocess.Popen.

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -44,6 +44,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
@@ -52,6 +53,8 @@ from typing import Any
 
 from ..result import ParseResult
 from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
 
 # Rate-limit patterns (Claude/Anthropic-specific + generic fallbacks)
 _RATE_LIMIT_PATTERNS = (
@@ -91,6 +94,7 @@ class ClaudeAdapter:
         task_id: str | None,
         session_id: str | None,
         tool_config: dict | None,
+        effort: str | None = None,
     ) -> InvocationPlan:
         """Build the Claude Code invocation.
 
@@ -103,6 +107,12 @@ class ClaudeAdapter:
             - ``output_format: str`` — defaults to "text"
             - ``use_bare: bool`` — explicit opt-out of --bare (default: auto-enable
               when no session + ANTHROPIC_API_KEY is set)
+
+        ``effort``: optional reasoning-level string. When non-None and the
+        probed Claude binary supports ``--effort`` (CC 2.1.98+), the flag
+        is appended as ``--effort <level>``. Otherwise we log a warning
+        and proceed without the flag so older CLIs don't hard-fail. See
+        ``utils.claude_version.supports_effort`` and issue #1396.
         """
         tc: dict[str, Any] = tool_config or {}
 
@@ -141,6 +151,30 @@ class ClaudeAdapter:
         # Model override
         if model:
             cmd.extend(["--model", model])
+
+        # Effort (reasoning level) — version-gated. See #1396.
+        if effort is not None:
+            probe_prefix_for_effort: tuple[str, ...]
+            if cmd_prefix:
+                probe_prefix_for_effort = tuple(cmd_prefix)
+            elif shutil.which("claude"):
+                probe_prefix_for_effort = (cmd[0],)
+            else:
+                probe_prefix_for_effort = ("npx", "@anthropic-ai/claude-code@latest")
+            try:
+                from utils.claude_version import supports_effort
+                effort_supported = supports_effort(probe_prefix_for_effort)
+            except ImportError:
+                effort_supported = False
+            if effort_supported:
+                cmd.extend(["--effort", effort])
+            else:
+                _logger.warning(
+                    "Claude CLI at %s does not support --effort; "
+                    "ignoring effort=%r and using CLI default (#1396)",
+                    probe_prefix_for_effort,
+                    effort,
+                )
 
         # Output format
         cmd.extend(["--output-format", tc.get("output_format", "text")])

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -128,6 +128,7 @@ class CodexAdapter:
         task_id: str | None,
         session_id: str | None,
         tool_config: dict | None,
+        effort: str | None = None,
     ) -> InvocationPlan:
         """Build the codex exec invocation.
 
@@ -137,6 +138,12 @@ class CodexAdapter:
             - ``{"mcp_servers": {"sources": {"url": "http://127.0.0.1:8766/sse"}}}``
               → ``-c 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"'``
             - Unknown top-level keys are ignored (forward-compatible).
+
+        ``effort``: when non-None, appended as
+        ``-c model_reasoning_effort=<level>`` so it overrides
+        ``~/.codex/config.toml`` for this invocation only. When None,
+        Codex falls through to the config default (currently ``high``).
+        See #1396.
         """
         # Defensively drop session_id — Codex is always fresh-session by
         # design (see class docstring). Local `_ =` rebind silences the
@@ -174,6 +181,9 @@ class CodexAdapter:
 
         cmd: list[str] = [codex_bin, "exec"]
         cmd.extend(self._tool_config_flags(tool_config))
+        if effort is not None:
+            # Per-invocation override of ~/.codex/config.toml (#1396).
+            cmd.extend(["-c", f"model_reasoning_effort={effort}"])
         cmd.extend([
             "--skip-git-repo-check",
             "-C", str(cwd),

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -31,6 +31,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
@@ -40,6 +41,8 @@ from ai_llm.fallback import GEMINI_AUTH_ENV_VARS, is_gemini_rate_limited
 
 from ..result import ParseResult
 from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
 
 _TRANSIENT_ERROR_PATTERNS = (
     r"No capacity available",
@@ -111,6 +114,7 @@ class GeminiAdapter:
         task_id: str | None,
         session_id: str | None,
         tool_config: dict | None,
+        effort: str | None = None,
     ) -> InvocationPlan:
         """Build the ``gemini`` CLI invocation.
 
@@ -123,7 +127,18 @@ class GeminiAdapter:
             - ``{"mcp_server_names": ["rag", "other"]}`` → appended as
               ``--allowed-mcp-server-names rag,other``
             - Any other keys are ignored (forward-compatible).
+
+        ``effort`` is accepted for uniformity with the other adapters but
+        currently a no-op: the ``gemini`` CLI does not expose a reasoning
+        effort flag. When set we emit a debug log and proceed without
+        modifying the command. Follow-up #1396.
         """
+        if effort is not None:
+            _logger.debug(
+                "gemini effort %r not yet wired through CLI — "
+                "using adapter default (#1396 follow-up)",
+                effort,
+            )
         gemini_bin = shutil.which("gemini") or "gemini"
 
         cmd: list[str] = [

--- a/scripts/agent_runtime/adapters/gemma_local.py
+++ b/scripts/agent_runtime/adapters/gemma_local.py
@@ -38,10 +38,12 @@ class GemmaLocalAdapter:
         task_id: str | None,
         session_id: str | None,
         tool_config: dict | None,
+        effort: str | None = None,
     ) -> InvocationPlan:
         _ = mode
         _ = task_id
         _ = session_id
+        _ = effort  # Gemma local lane has no effort knob; silently ignore.
         tc = tool_config or {}
         python_bin = Path(
             tc.get(

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -528,6 +528,7 @@ def _invoke_gemini_with_fallback(
     entrypoint: str,
     hard_timeout: int,
     stall_timeout: int,
+    effort: str | None = None,
 ) -> Result:
     """Run Gemini through the shared model/auth fallback ladder."""
 
@@ -545,6 +546,7 @@ def _invoke_gemini_with_fallback(
             task_id=task_id,
             session_id=session_id,
             tool_config=attempt_tool_config,
+            effort=effort,
         )
         execution = _execute_invocation_plan(
             agent_name=agent_name,
@@ -760,6 +762,7 @@ def invoke(
     entrypoint: str = "runtime",
     hard_timeout: int = 3600,
     stall_timeout: int = 180,  # accepted but ignored; see docstring
+    effort: str | None = None,
 ) -> Result:
     """Single entry point for all agent CLI invocations.
 
@@ -792,6 +795,12 @@ def invoke(
             successful long-running calls were killed as false-positive
             stalls. See watchdog.py::should_kill() docstring for the
             full incident chain. hard_timeout is the only safety net now.
+        effort: Cross-agent reasoning/effort level. First-class peer of
+            ``model`` (NOT stuffed into ``tool_config``). Accepted values:
+            ``"low" | "medium" | "high" | "xhigh" | "max"``. When ``None``,
+            each adapter's CLI / config default applies (Claude CLI
+            default; Codex's ``~/.codex/config.toml``; Gemini has no
+            equivalent yet). See #1396.
 
     Returns:
         Result with ok, response, timing, session_id, and the full usage
@@ -868,6 +877,7 @@ def invoke(
             entrypoint=entrypoint,
             hard_timeout=hard_timeout,
             stall_timeout=stall_timeout,
+            effort=effort,
         )
 
     # ---------- 6. Build invocation plan ----------
@@ -879,6 +889,7 @@ def invoke(
         task_id=task_id,
         session_id=session_id,
         tool_config=tool_config,
+        effort=effort,
     )
 
     execution = _execute_invocation_plan(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -243,6 +243,7 @@ def _run_worker(
     cwd_str: str,
     model: str | None,
     hard_timeout: int,
+    effort: str | None = None,
 ) -> int:
     """Worker main loop. Invokes the runtime, updates the state file.
 
@@ -297,6 +298,7 @@ def _run_worker(
             tool_config=None,
             entrypoint="delegate",
             hard_timeout=hard_timeout,
+            effort=effort,
         )
         ok_outcome = result.ok
         response = result.response
@@ -438,6 +440,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "task_id": task_id,
         "agent": args.agent,
         "model": args.model,
+        "effort": getattr(args, "effort", None),
         "mode": args.mode,
         "cwd": cwd,
         "worktree_path": str(worktree_path) if worktree_path else None,
@@ -480,6 +483,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     ]
     if args.model:
         cmd.extend(["--model", args.model])
+    effort = getattr(args, "effort", None)
+    if effort:
+        cmd.extend(["--effort", effort])
 
     # Pipe the prompt via stdin so it doesn't hit argv length limits.
     # start_new_session=True detaches from our process group — the
@@ -772,6 +778,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
         cwd_str=args.cwd,
         model=args.model,
         hard_timeout=args.hard_timeout,
+        effort=args.effort,
     )
 
 
@@ -817,6 +824,20 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Runtime mode (default: read-only). Use danger only with --worktree.")
     d.add_argument("--model", default=None,
                    help="Optional model override, e.g. gpt-5.4 or gemini-3.1-pro-preview.")
+    d.add_argument(
+        "--effort",
+        default=None,
+        choices=["low", "medium", "high", "xhigh", "max"],
+        help=(
+            "Optional reasoning / effort level. Accepted: low, medium, "
+            "high, xhigh, max. Omit to use the agent's own default: "
+            "Codex falls through to ~/.codex/config.toml (currently high); "
+            "Claude falls through to its CLI default (currently high for "
+            "Opus/Sonnet 4.6+ per CC 1.117); Gemini effort is not yet "
+            "wired (gemini-cli does not expose the flag) and is a no-op. "
+            "See #1396."
+        ),
+    )
     d.add_argument("--cwd", default=None,
                    help="Working directory for the worker (default: repo root)")
     d.add_argument(
@@ -862,6 +883,11 @@ def build_parser() -> argparse.ArgumentParser:
     wk.add_argument("--mode", required=True)
     wk.add_argument("--cwd", required=True)
     wk.add_argument("--model", default=None)
+    wk.add_argument(
+        "--effort",
+        default=None,
+        choices=["low", "medium", "high", "xhigh", "max"],
+    )
     wk.add_argument("--hard-timeout", type=int, default=3600)
     wk.set_defaults(func=cmd_worker)
 

--- a/scripts/utils/claude_version.py
+++ b/scripts/utils/claude_version.py
@@ -198,6 +198,25 @@ def supports_exclude_dynamic_system_prompt_sections(
     return ok
 
 
+def supports_effort(cmd_prefix: Sequence[str] | str) -> bool:
+    """Return True iff Claude Code at ``cmd_prefix`` supports ``--effort``.
+
+    ``--effort`` was available in Claude Code 2.1.98+ (verified against
+    2.1.117 ``--help`` output on 2026-04-22). Gates on the same minimum
+    version as ``--exclude-dynamic-system-prompt-sections`` for
+    simplicity; if this turns out to be wrong, split the constant.
+
+    Args:
+        cmd_prefix: Same semantics as
+            :func:`supports_exclude_dynamic_system_prompt_sections` —
+            the exact argv prefix to probe.
+
+    Returns:
+        True if the probed CLI is >= 2.1.98, else False.
+    """
+    return supports_exclude_dynamic_system_prompt_sections(cmd_prefix)
+
+
 def _reset_cache_for_tests() -> None:
     """Clear the cache. Tests only — do NOT call from production code."""
     with _CACHE_LOCK:

--- a/tests/test_agent_runtime_effort.py
+++ b/tests/test_agent_runtime_effort.py
@@ -416,3 +416,136 @@ def test_gemini_adapter_accepts_effort_without_crashing(tmp_path, caplog):
         f"expected a DEBUG log mentioning 'xhigh' and '#1396'; "
         f"records={[r.message for r in caplog.records]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: gemma-local adapter must accept effort without crashing
+# (Codex adversarial review 2026-04-22: gemma-local broke when every
+# non-Gemini adapter got effort forwarded.)
+# ---------------------------------------------------------------------------
+
+def test_gemma_local_adapter_accepts_effort_kwarg(tmp_path):
+    from agent_runtime.adapters.gemma_local import GemmaLocalAdapter
+
+    adapter = GemmaLocalAdapter()
+    # No exception on effort=... even though the CLI has no such knob.
+    plan = adapter.build_invocation(
+        prompt="hi",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+        effort="xhigh",
+    )
+    # And no '--effort' / 'xhigh' leaks into the Gemma argv.
+    assert "--effort" not in plan.cmd
+    assert "xhigh" not in plan.cmd
+
+
+# ---------------------------------------------------------------------------
+# Gemini fallback ladder path propagates effort on every rung
+# (Codex adversarial review 2026-04-22 finding #2.)
+# ---------------------------------------------------------------------------
+
+def test_gemini_fallback_ladder_forwards_effort_to_every_rung(tmp_path):
+    """When invoke() routes to _invoke_gemini_with_fallback, each rung's
+    attempt must call adapter.build_invocation with effort= propagated.
+    Drive two rungs by returning rate_limited on the first, success on
+    the second, and assert both build_invocation calls saw the kwarg."""
+    from agent_runtime import runner as runner_mod
+
+    spy_adapter = MagicMock()
+    spy_adapter.supported_modes = frozenset({"read-only", "workspace-write", "danger"})
+    spy_adapter.default_model = "gemini-3.1-pro-preview"
+
+    fake_plan = MagicMock()
+    fake_plan.cmd = ["/bin/true"]
+    fake_plan.cwd = tmp_path
+    fake_plan.stdin_payload = ""
+    fake_plan.env_overrides = {}
+    fake_plan.env_unsets = ()
+    fake_plan.output_file = None
+    fake_plan.liveness_paths = ()
+    spy_adapter.build_invocation.return_value = fake_plan
+    spy_adapter.liveness_signal_paths.return_value = ()
+
+    # Drive the ladder: rung 1 → rate_limited, rung 2 → success.
+    from ai_llm.fallback import CallResult
+    fake_call_result = CallResult(
+        response_text="pong",
+        model_used="gemini-3.1-pro-preview",
+        auth_mode_used="oauth",
+        elapsed_s=0.1,
+    )
+
+    with patch(
+        "agent_runtime.runner._load_adapter", return_value=spy_adapter,
+    ), patch(
+        "agent_runtime.runner.has_headroom", return_value=(True, ""),
+    ), patch(
+        "agent_runtime.runner.write_record",
+    ), patch(
+        "agent_runtime.runner.run_gemini_fallback_ladder",
+    ) as mock_ladder:
+        def _run_ladder(*, attempt_runner, **_kwargs):
+            # Invoke the runner's attempt callback twice with different rungs
+            # to prove effort gets forwarded on each call.
+            from ai_llm.fallback import GeminiRung
+            rung_a = GeminiRung(
+                index=0, total=2,
+                model="gemini-3.1-pro-preview", auth_mode="oauth",
+            )
+            rung_b = GeminiRung(
+                index=1, total=2,
+                model="gemini-3.1-flash-preview", auth_mode="api",
+            )
+            # The runner's _attempt_runner internally calls adapter.build_invocation.
+            # We patch _execute_invocation_plan to a no-op success so the runner
+            # returns an AttemptOutcome without running a real subprocess.
+            with patch(
+                "agent_runtime.runner._execute_invocation_plan",
+                return_value=MagicMock(
+                    parse=MagicMock(
+                        ok=True,
+                        response="pong",
+                        stderr_excerpt=None,
+                        rate_limited=False,
+                        session_id=None,
+                        tokens=None,
+                    ),
+                    duration_s=0.1,
+                    returncode=0,
+                    kill_reason=None,
+                    stdout_text="pong",
+                    stderr_text="",
+                    liveness_paths=(),
+                ),
+            ):
+                attempt_runner(rung_a, 0, 60)
+                attempt_runner(rung_b, 1, 60)
+            return fake_call_result
+
+        mock_ladder.side_effect = _run_ladder
+
+        runner_mod.invoke(
+            "gemini",
+            "hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="gemini-3.1-pro-preview",
+            effort="xhigh",
+            entrypoint="delegate",
+        )
+
+    # Both rung invocations must have forwarded effort="xhigh".
+    assert spy_adapter.build_invocation.call_count == 2, (
+        f"expected 2 build_invocation calls (one per rung); "
+        f"got {spy_adapter.build_invocation.call_count}"
+    )
+    for call in spy_adapter.build_invocation.call_args_list:
+        assert call.kwargs.get("effort") == "xhigh", (
+            f"every rung must propagate effort='xhigh'; "
+            f"kwargs={call.kwargs}"
+        )

--- a/tests/test_agent_runtime_effort.py
+++ b/tests/test_agent_runtime_effort.py
@@ -1,0 +1,418 @@
+"""Unit tests for #1396 — ``--effort`` wiring through delegate → runner → adapters.
+
+Covers:
+- ``delegate.py dispatch --effort xhigh`` argparse parses correctly.
+- ``_run_worker`` forwards ``effort`` to ``runtime.invoke``.
+- ``runner.invoke(effort=...)`` forwards to ``adapter.build_invocation(effort=...)``.
+- ClaudeAdapter emits ``--effort <level>`` when the CLI supports it, and
+  logs a warning + skips the flag when it does not.
+- CodexAdapter emits ``-c model_reasoning_effort=<level>``.
+- GeminiAdapter accepts ``effort`` without crashing, logs at DEBUG, and
+  does not mutate the command.
+
+Issue: #1396
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import delegate as delegate_mod
+from agent_runtime.adapters.claude import ClaudeAdapter
+from agent_runtime.adapters.codex import CodexAdapter
+from agent_runtime.adapters.gemini import GeminiAdapter
+from agent_runtime.usage import _reset_rate_limit_cache_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _isolate_usage_log(tmp_path):
+    """Never write to the real batch_state/api_usage/ log during tests."""
+    with patch("agent_runtime.usage._usage_dir", return_value=tmp_path / "api_usage"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    """Reset runtime in-process caches before every test."""
+    _reset_rate_limit_cache_for_tests()
+    from agent_runtime import runner
+
+    runner._ADAPTER_CACHE.clear()
+    yield
+    runner._ADAPTER_CACHE.clear()
+    _reset_rate_limit_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# AC5.1 — delegate.py dispatch --effort parses
+# ---------------------------------------------------------------------------
+
+def test_delegate_dispatch_parses_effort_flag():
+    """``dispatch --effort xhigh ...`` parses to ``args.effort == "xhigh"``."""
+    parser = delegate_mod.build_parser()
+    args = parser.parse_args([
+        "dispatch",
+        "--agent", "claude",
+        "--task-id", "t1",
+        "--prompt", "hi",
+        "--effort", "xhigh",
+    ])
+    assert args.effort == "xhigh"
+    assert args.agent == "claude"
+    assert args.task_id == "t1"
+
+
+def test_delegate_dispatch_effort_default_is_none():
+    """Omitting --effort leaves args.effort == None (falls through to CLI default)."""
+    parser = delegate_mod.build_parser()
+    args = parser.parse_args([
+        "dispatch",
+        "--agent", "claude",
+        "--task-id", "t1",
+        "--prompt", "hi",
+    ])
+    assert args.effort is None
+
+
+def test_delegate_dispatch_rejects_invalid_effort_level():
+    """Only the documented choices are accepted."""
+    parser = delegate_mod.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([
+            "dispatch",
+            "--agent", "claude",
+            "--task-id", "t1",
+            "--prompt", "hi",
+            "--effort", "ultra",
+        ])
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+def test_delegate_dispatch_accepts_all_documented_effort_levels(level):
+    parser = delegate_mod.build_parser()
+    args = parser.parse_args([
+        "dispatch",
+        "--agent", "claude",
+        "--task-id", f"t-{level}",
+        "--prompt", "hi",
+        "--effort", level,
+    ])
+    assert args.effort == level
+
+
+def test_delegate_worker_parser_accepts_effort():
+    """The internal `_worker` subcommand also accepts --effort so the parent
+    can propagate the value into the detached child's argv."""
+    parser = delegate_mod.build_parser()
+    args = parser.parse_args([
+        "_worker",
+        "--task-id", "t1",
+        "--agent", "claude",
+        "--mode", "read-only",
+        "--cwd", "/tmp",
+        "--effort", "xhigh",
+    ])
+    assert args.effort == "xhigh"
+
+
+# ---------------------------------------------------------------------------
+# AC5.2 — _run_worker forwards effort to runtime.invoke
+# ---------------------------------------------------------------------------
+
+def test_run_worker_forwards_effort_to_runtime_invoke(tmp_path):
+    """_run_worker must pass effort= straight through to runner.invoke."""
+    mock_result = MagicMock(
+        ok=True,
+        response="ok",
+        stderr_excerpt=None,
+        returncode=0,
+        rate_limited=False,
+    )
+    # The state file must exist so _run_worker's read returns a dict.
+    state_path = delegate_mod._state_path("t-effort")
+    delegate_mod._write_state_atomic(state_path, {"task_id": "t-effort"})
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result) as mock_invoke:
+        rc = delegate_mod._run_worker(
+            task_id="t-effort",
+            agent="claude",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model="claude-opus-4-7",
+            hard_timeout=60,
+            effort="xhigh",
+        )
+
+    assert rc == 0
+    assert mock_invoke.called, "runner.invoke should have been called"
+    kwargs = mock_invoke.call_args.kwargs
+    assert kwargs["effort"] == "xhigh", (
+        f"_run_worker must forward effort='xhigh'; kwargs={kwargs}"
+    )
+    assert kwargs["model"] == "claude-opus-4-7"
+    assert kwargs["entrypoint"] == "delegate"
+
+
+def test_run_worker_effort_none_forwards_none(tmp_path):
+    """Omitting effort (default None) propagates None — not a string."""
+    mock_result = MagicMock(
+        ok=True,
+        response="ok",
+        stderr_excerpt=None,
+        returncode=0,
+        rate_limited=False,
+    )
+    state_path = delegate_mod._state_path("t-none")
+    delegate_mod._write_state_atomic(state_path, {"task_id": "t-none"})
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result) as mock_invoke:
+        delegate_mod._run_worker(
+            task_id="t-none",
+            agent="claude",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+        )
+
+    assert mock_invoke.call_args.kwargs["effort"] is None
+
+
+# ---------------------------------------------------------------------------
+# AC5.3 — runner.invoke forwards effort to adapter.build_invocation
+# ---------------------------------------------------------------------------
+
+def test_runner_invoke_forwards_effort_to_adapter_build_invocation(tmp_path):
+    """runner.invoke(..., effort="xhigh") must pass effort="xhigh" into the
+    adapter's build_invocation call. Stub has_headroom + Popen so no real
+    process runs; assert the adapter spy captured effort."""
+    from agent_runtime import runner as runner_mod
+
+    spy_adapter = MagicMock()
+    spy_adapter.supported_modes = frozenset({"read-only", "workspace-write", "danger"})
+    spy_adapter.default_model = "claude-opus-4-7"
+    # Make build_invocation return an InvocationPlan-ish mock.
+    fake_plan = MagicMock()
+    fake_plan.cmd = ["/bin/true"]
+    fake_plan.cwd = tmp_path
+    fake_plan.stdin_payload = ""
+    fake_plan.env_overrides = {}
+    fake_plan.env_unsets = ()
+    fake_plan.output_file = None
+    fake_plan.liveness_paths = ()
+    spy_adapter.build_invocation.return_value = fake_plan
+    spy_adapter.liveness_signal_paths.return_value = ()
+    # parse_response returns an ok ParseResult-like object.
+    spy_parse = MagicMock(
+        ok=True,
+        response="ok",
+        stderr_excerpt=None,
+        rate_limited=False,
+        session_id=None,
+        tokens=None,
+    )
+    spy_adapter.parse_response.return_value = spy_parse
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = 0
+    fake_proc.returncode = 0
+    fake_proc.stdin = None
+
+    with patch(
+        "agent_runtime.runner._load_adapter", return_value=spy_adapter,
+    ), patch(
+        "agent_runtime.runner.has_headroom", return_value=(True, ""),
+    ), patch(
+        "agent_runtime.runner.write_record",
+    ), patch(
+        "agent_runtime.runner.subprocess.Popen", return_value=fake_proc,
+    ), patch(
+        "agent_runtime.runner.start_watchdog",
+        return_value=(MagicMock(stdout_lines=[], stderr_lines=[]), []),
+    ), patch(
+        "agent_runtime.runner.stop_watchdog",
+    ):
+        runner_mod.invoke(
+            "claude",
+            "hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="claude-opus-4-7",
+            effort="xhigh",
+            entrypoint="delegate",
+        )
+
+    assert spy_adapter.build_invocation.called
+    build_kwargs = spy_adapter.build_invocation.call_args.kwargs
+    assert build_kwargs["effort"] == "xhigh", (
+        f"runner.invoke must forward effort='xhigh' to adapter; "
+        f"kwargs={build_kwargs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5.4 — ClaudeAdapter emits --effort when supported
+# ---------------------------------------------------------------------------
+
+def test_claude_adapter_emits_effort_when_supported(tmp_path):
+    adapter = ClaudeAdapter()
+    with patch(
+        "utils.claude_version.supports_effort", return_value=True,
+    ), patch(
+        "utils.claude_version.supports_exclude_dynamic_system_prompt_sections",
+        return_value=False,  # keep the OTHER gated flag off so we isolate --effort
+    ):
+        plan = adapter.build_invocation(
+            prompt="hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="claude-opus-4-7",
+            task_id="t",
+            session_id=None,
+            tool_config=None,
+            effort="xhigh",
+        )
+    assert "--effort" in plan.cmd, f"plan.cmd={plan.cmd}"
+    i = plan.cmd.index("--effort")
+    assert plan.cmd[i + 1] == "xhigh", (
+        f"--effort must be followed by 'xhigh'; got {plan.cmd[i + 1]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5.5 — ClaudeAdapter skips + warns when unsupported
+# ---------------------------------------------------------------------------
+
+def test_claude_adapter_skips_effort_when_unsupported(tmp_path, caplog):
+    adapter = ClaudeAdapter()
+    with patch(
+        "utils.claude_version.supports_effort", return_value=False,
+    ), patch(
+        "utils.claude_version.supports_exclude_dynamic_system_prompt_sections",
+        return_value=False,
+    ), caplog.at_level(logging.WARNING, logger="agent_runtime.adapters.claude"):
+        plan = adapter.build_invocation(
+            prompt="hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="claude-opus-4-7",
+            task_id="t",
+            session_id=None,
+            tool_config=None,
+            effort="xhigh",
+        )
+    assert "--effort" not in plan.cmd, (
+        f"--effort must be omitted when the CLI does not support it; "
+        f"plan.cmd={plan.cmd}"
+    )
+    assert any(
+        "does not support --effort" in rec.message for rec in caplog.records
+    ), (
+        f"expected a WARNING log about effort being unsupported; "
+        f"records={[r.message for r in caplog.records]}"
+    )
+
+
+def test_claude_adapter_no_effort_arg_means_no_flag(tmp_path):
+    """Default (effort=None) must NOT emit --effort regardless of version."""
+    adapter = ClaudeAdapter()
+    with patch(
+        "utils.claude_version.supports_effort", return_value=True,
+    ):
+        plan = adapter.build_invocation(
+            prompt="hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="claude-opus-4-7",
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+    assert "--effort" not in plan.cmd
+
+
+# ---------------------------------------------------------------------------
+# AC5.6 — CodexAdapter emits -c model_reasoning_effort=<level>
+# ---------------------------------------------------------------------------
+
+def test_codex_adapter_emits_effort_as_config_override(tmp_path):
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hi",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="t",
+        session_id=None,
+        tool_config=None,
+        effort="xhigh",
+    )
+    # The argv must contain `-c model_reasoning_effort=xhigh` as adjacent tokens.
+    assert "-c" in plan.cmd
+    flag_pairs = [
+        (plan.cmd[i], plan.cmd[i + 1])
+        for i in range(len(plan.cmd) - 1)
+        if plan.cmd[i] == "-c"
+    ]
+    assert ("-c", "model_reasoning_effort=xhigh") in flag_pairs, (
+        f"expected ('-c', 'model_reasoning_effort=xhigh') in flag pairs; "
+        f"plan.cmd={plan.cmd}"
+    )
+
+
+def test_codex_adapter_no_effort_means_no_config_override(tmp_path):
+    """effort=None (default) must fall through to ~/.codex/config.toml —
+    no -c model_reasoning_effort=... override in the argv."""
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hi",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+    joined = " ".join(plan.cmd)
+    assert "model_reasoning_effort" not in joined, (
+        f"plan.cmd must not contain a model_reasoning_effort override when "
+        f"effort is unset; plan.cmd={plan.cmd}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5.7 — GeminiAdapter accepts effort, logs debug, no cmd mutation
+# ---------------------------------------------------------------------------
+
+def test_gemini_adapter_accepts_effort_without_crashing(tmp_path, caplog):
+    adapter = GeminiAdapter()
+    with caplog.at_level(logging.DEBUG, logger="agent_runtime.adapters.gemini"):
+        plan = adapter.build_invocation(
+            prompt="hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="gemini-3.1-pro-preview",
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+            effort="xhigh",
+        )
+    # No --effort in cmd (gemini-cli doesn't expose one).
+    assert "--effort" not in plan.cmd
+    assert "xhigh" not in plan.cmd
+    # And a DEBUG note referencing the follow-up issue was logged.
+    assert any(
+        "xhigh" in rec.message and "#1396" in rec.message
+        for rec in caplog.records
+    ), (
+        f"expected a DEBUG log mentioning 'xhigh' and '#1396'; "
+        f"records={[r.message for r in caplog.records]}"
+    )


### PR DESCRIPTION
## Summary

- Thread a first-class ``effort`` kwarg (peer of ``model``, NOT tool_config) through ``delegate.py dispatch`` → ``runner.invoke`` → ``AgentAdapter.build_invocation``.
- ClaudeAdapter emits ``--effort <level>`` when the binary supports it (CC 2.1.98+, verified via new ``supports_effort`` helper in ``utils.claude_version``); warns + proceeds when unsupported (no hard-fail).
- CodexAdapter appends ``-c model_reasoning_effort=<level>`` as a per-invocation override of ``~/.codex/config.toml``.
- GeminiAdapter accepts the kwarg for uniformity but no-ops with a DEBUG log referencing the follow-up issue, since gemini-cli has no equivalent flag.
- Persist ``effort`` in the task-state JSON for postmortems.
- 18 new unit tests (argparse, delegate→runner propagation, adapter argv construction, mocked version-probe for Claude).

Implements Codex-approved revised ACs on #1396. See comment thread on the issue.

## Test plan

- [x] ``.venv/bin/python -m pytest tests/test_agent_runtime_effort.py`` — 18 passed.
- [x] ``.venv/bin/python -m pytest tests/test_agent_runtime.py tests/test_claude_version.py tests/test_agent_runtime_tool_config.py tests/test_agent_runtime_json_parse.py`` — 144 passed, no regression.
- [x] ``ruff check`` on every touched file — clean.
- [x] ``delegate.py dispatch --help`` lists ``--effort`` with accepted values and per-agent fallback notes (AC6).
- [ ] Live smoke: ``scripts/delegate.py dispatch --agent claude --effort xhigh --model claude-opus-4-7 --prompt "echo hi" --hard-timeout 60`` (optional operator verification).

## Follow-ups

- Wire ``--effort`` for Gemini once gemini-cli exposes an equivalent flag. Follow-up issue will link back to #1396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)