### PR TITLE
chore(ops): CI red cleanup + --force audit from #1394

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Check for non-stub scripts in scripts/ root
         run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            base_sha="${{ github.event.before }}"
+          else
+            echo "ℹ️ Skipping root-script diff on ${{ github.event_name }}"
+            exit 0
+          fi
+
+          if [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git hash-object -t tree /dev/null)"
+          fi
+
+          if [[ -z "$base_sha" ]]; then
+            echo "::error::Unable to determine the comparison base for scripts/ root guard."
+            exit 1
+          fi
+
           # Allowed non-stub files at scripts/ root
           allowed="__init__.py|batch_gemini_runner.py|config.py|generate_mdx.py|manifest_direct.py|manifest_utils.py|paths.py|pipeline_lib.py|slug_utils.py|yaml_activities.py"
           violations=""
-          for f in scripts/*.py; do
+
+          mapfile -t candidates < <(
+            git diff --name-only --diff-filter=AR "$base_sha" "$GITHUB_SHA" -- 'scripts/*.py'
+          )
+
+          for f in "${candidates[@]}"; do
             [ ! -f "$f" ] && continue
             basename=$(basename "$f")
             # Skip allowed files

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -295,6 +295,7 @@ Never parse Gemini's prose output for structured data.
 ## Escalation
 
 If Gemini is stuck (not completing a phase, silently failing):
+<!-- TODO(#1394): classify --force usage -->
 ```bash
 .venv/bin/python scripts/build_module_v5.py {track} {num} --force-phase {research|content|activities|validate|review}
 ```

--- a/docs/best-practices/force-flag-audit-2026-04-22.md
+++ b/docs/best-practices/force-flag-audit-2026-04-22.md
@@ -1,0 +1,33 @@
+# `--force` Audit — 2026-04-22
+
+Scope:
+- `claude_extensions/rules/*.md`
+- `.claude/rules/*.md`
+- `docs/best-practices/*.md`
+- `.worktree-briefs/*.md`
+
+Notes:
+- `.claude/rules/` was not present in this worktree at audit time, so there were no mirror-only hits to classify there.
+- `.worktree-briefs/` contained no `--force` hits.
+- Total hits: 4
+
+## Classification Summary
+
+| Classification | Count |
+| --- | ---: |
+| LOAD-BEARING | 3 |
+| DROP | 0 |
+| FLAG_FOR_HUMAN | 1 |
+
+## Classified Hits
+
+| Path | Classification | Snippet | Rationale | Action |
+| --- | --- | --- | --- | --- |
+| `claude_extensions/rules/workflow.md` | LOAD-BEARING | `Which files would --force delete for this module?` | Refers to the real `force-preview` API endpoint that exists specifically to make forced rebuilds inspectable before execution. | Kept as-is. |
+| `docs/best-practices/agent-cooperation.md` | LOAD-BEARING | `Which files would --force delete?` | Same preview endpoint as the workflow rule; removing the term would hide the safety affordance that documents forced rebuild impact. | Kept as-is. |
+| `docs/best-practices/gitflow.md` | LOAD-BEARING | `git push --force` | This is a prohibited-command example in a danger list, not advice to run it. The exact flag spelling is necessary for the warning to be precise. | Kept as-is. |
+| `docs/best-practices/agent-cooperation.md` | FLAG_FOR_HUMAN | `scripts/build_module_v5.py ... --force-phase ...` | `--force-phase` is an escalation path, but whether it is a justified recovery tool or an unsafe copy-paste default is a product/process decision. | Added inline `TODO(#1394)` comment for owner review. |
+
+## Drop Cases
+
+No DROP cases were found in the audited paths, so no `--force` usage was removed from these docs/rules files.

--- a/scripts/wiki/strip_l2_framing.py
+++ b/scripts/wiki/strip_l2_framing.py
@@ -9,7 +9,6 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_REPORT_PATH = PROJECT_ROOT / "audit" / "phase-2c-wiki-strip" / "report.md"
 WIKI_META_START = "<!-- wiki-meta"


### PR DESCRIPTION
## Summary

Fixes two pre-existing red CI failures from the `main` run `24776953854` on 2026-04-22 and completes the deferred `--force` audit from #1394.

## CI fixes

- Lint (ruff): `scripts/wiki/strip_l2_framing.py` had one import-order lint failure. I applied the targeted import cleanup; local `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/ tests/` is clean.
- No new root scripts: the workflow was scanning every current `scripts/*.py` file and flagging long-standing root scripts as "new". I changed the guard to diff only added or renamed root scripts against the event base SHA. Tradeoff: this now enforces "no newly introduced root scripts" rather than retroactively policing historical ones, which matches the job name and removes the false positives on `main`.
- Secret Scanning (gitleaks): latest failure was license noise, not a leak. No workflow change in this PR.

## Gitleaks recommendation

- Recommended follow-up: replace the gitleaks job with a non-licensed scanner such as `trufflesecurity/trufflehog` if we want a free default.
- Alternative: keep gitleaks and add a `GITLEAKS_LICENSE` GitHub Secret.
- I did not remove the job in this PR.

## `--force` audit (#1394)

- Audit report: `docs/best-practices/force-flag-audit-2026-04-22.md`
- Classified 4 hits total: 3 LOAD-BEARING, 0 DROP, 1 FLAG_FOR_HUMAN.
- Added an inline `<!-- TODO(#1394): classify --force usage -->` beside the `--force-phase` escalation example in `docs/best-practices/agent-cooperation.md`.
- `.claude/rules/` was not present in this worktree, so the source-of-truth `claude_extensions/rules/` was audited directly and the mirror gap is documented in the report.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/ tests/`
- Exercised the root-scripts guard logic locally against the current diff
- `npx --yes markdownlint-cli2 docs/best-practices/force-flag-audit-2026-04-22.md`

## Claude review

- Headless Claude adversarial review marked the change mergeable.
- Non-blocking notes captured here:
  - the root-scripts guard is intentionally narrowed to newly introduced root scripts
  - `.claude/rules/` mirror was absent in this worktree, so that coverage gap is explicitly documented
