### PR TITLE
deps: refresh sentence-transformers to 5.4.1

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -162,7 +162,7 @@ ruff==0.15.5
 safetensors==0.7.0
 scikit-learn==1.8.0
 scipy==1.17.0
-sentence-transformers==5.2.2
+sentence-transformers==5.4.1
 sentencepiece==0.2.1
 setuptools==80.10.2
 shellingham==1.5.4


### PR DESCRIPTION
## Summary
- replace the stale Dependabot `sentence-transformers` bump with a fresh branch from current `main`
- update `requirements-lock.txt` from `sentence-transformers==5.2.2` to `sentence-transformers==5.4.1`
- keep the diff scoped to the single lock entry only

## Validation
- `.venv/bin/python -c "import sys; print(sys.version); import sentence_transformers; print(sentence_transformers.__version__)"`
- `.venv/bin/python -m pip install --dry-run sentence-transformers==5.4.1`

## Notes
- The dry run resolves cleanly against the repo's current `.venv` on Python `3.12.8`.
- This supersedes stale Dependabot PR #1358, which was opened on April 20, 2026 before the current `main` state.
