### PR TITLE
fix(gemini): route batch_gemini_runner through adapter for env-strip + ladder (#1406)

### DIFF
--- a/scripts/batch_gemini_runner/constants.py
+++ b/scripts/batch_gemini_runner/constants.py
@@ -1,12 +1,8 @@
 """Shared constants for the batch Gemini runner package."""
 
 import logging
-import shutil
 
 from batch_gemini_config import PROJECT_ROOT
-
-# Gemini binary location
-GEMINI_BIN = shutil.which("gemini") or "/opt/homebrew/bin/gemini"
 
 # Paths
 AUDIT_SCRIPT = PROJECT_ROOT / "scripts" / "audit_module.sh"

--- a/scripts/batch_gemini_runner/execution.py
+++ b/scripts/batch_gemini_runner/execution.py
@@ -10,6 +10,13 @@ import time
 from datetime import datetime
 
 import yaml
+from agent_runtime.adapters.gemini import resolve_gemini_auth_mode
+from agent_runtime.errors import (
+    AgentTimeoutError,
+    AgentUnavailableError,
+    RateLimitedError,
+)
+from agent_runtime.runner import invoke as runtime_invoke
 from batch_gemini_config import PROJECT_ROOT
 from batch_utils import ErrorCategory, ExponentialBackoff, classify_error
 from gemini_output import (
@@ -23,7 +30,6 @@ from slug_utils import to_bare_slug
 
 from .constants import (
     AUDIT_SCRIPT,
-    GEMINI_BIN,
     MAX_RETRIES,
     QUOTA_MAX_RETRIES,
     QUOTA_RETRY_WAIT_SECONDS,
@@ -185,50 +191,28 @@ def call_gemini(prompt_file, track, slug="unknown", phase="unknown", retry=0):
     # Read the prompt file and pass content via -p
     prompt_content = prompt_file.read_text(encoding="utf-8")
 
-    cmd = [GEMINI_BIN, "-p", prompt_content, "-o", "json"]
     start_time = time.monotonic()
     try:
-        res = subprocess.run(
-            cmd,
-            capture_output=True,
-            timeout=TIMEOUT_SECONDS,
-            cwd=str(PROJECT_ROOT),
+        # Load-bearing: route through the shared runtime so batch_gemini_runner
+        # inherits the Gemini fallback ladder's per-rung env stripping,
+        # 429 auto-fallover across model/auth rungs, and API cooldown awareness.
+        result = runtime_invoke(
+            "gemini",
+            prompt_content,
+            mode="read-only",
+            cwd=PROJECT_ROOT,
+            task_id=_runtime_task_id(track, slug, phase, retry),
+            tool_config={"auth_mode": resolve_gemini_auth_mode()},
+            entrypoint="dispatch",
+            hard_timeout=TIMEOUT_SECONDS,
         )
-        elapsed_ms = int((time.monotonic() - start_time) * 1000)
-
-        # Decode with error handling (Gemini output can be truncated mid-character)
-        res.stdout = res.stdout.decode("utf-8", errors="replace") if isinstance(res.stdout, bytes) else res.stdout
-        res.stderr = res.stderr.decode("utf-8", errors="replace") if isinstance(res.stderr, bytes) else res.stderr
-
-        # Parse JSON output -- extract response text and stats
-        stdout_text = ""
-        gemini_json = {}
-        if res.returncode == 0 and res.stdout.strip():
-            try:
-                gemini_json = json.loads(res.stdout)
-                stdout_text = gemini_json.get("response", "")
-                # Log API usage
-                _log_api_usage(track, slug, phase, retry, gemini_json, elapsed_ms)
-            except json.JSONDecodeError:
-                # Fallback: treat as plain text (non-JSON mode)
-                stdout_text = res.stdout
-
-        return {
-            "returncode": res.returncode,
-            "stdout": stdout_text,
-            "stderr": res.stderr,
-            "gemini_json": gemini_json,
-            "elapsed_ms": elapsed_ms,
-        }
-    except subprocess.TimeoutExpired:
-        elapsed_ms = int((time.monotonic() - start_time) * 1000)
-        return {
-            "returncode": -1,
-            "stdout": "",
-            "stderr": f"Timeout expired ({TIMEOUT_SECONDS}s)",
-            "gemini_json": {},
-            "elapsed_ms": elapsed_ms,
-        }
+        return _runtime_result_to_legacy_payload(
+            result, track=track, slug=slug, phase=phase, retry=retry,
+        )
+    except AgentTimeoutError:
+        return _timeout_payload(start_time, TIMEOUT_SECONDS)
+    except (AgentUnavailableError, RateLimitedError) as exc:
+        return _runtime_error_payload(exc, start_time)
 
 
 def apply_output(phase, output, paths):
@@ -393,12 +377,9 @@ def handle_quota_error(runner, slug, phase, stderr):
         )
         time.sleep(wait)
 
-        # Quick test: try a minimal gemini call to check if capacity is back
-        test_result = subprocess.run(
-            [GEMINI_BIN, "-p", "Say OK", "-o", "text"],
-            capture_output=True, text=True, timeout=30,
-        )
-        if test_result.returncode == 0:
+        # Probe the current account through the runtime so auth-mode
+        # resolution and env stripping match the real batch call path.
+        if _gemini_capacity_probe(runner.track, slug, phase):
             log.info(f"  Capacity restored for {current}. Resuming.")
             return True
 
@@ -426,11 +407,7 @@ def handle_quota_error(runner, slug, phase, stderr):
         log.info(f"  Trying account: {next_account}")
         if _switch_gemini_account(next_account):
             # Test the new account
-            test_result = subprocess.run(
-                [GEMINI_BIN, "-p", "Say OK", "-o", "text"],
-                capture_output=True, text=True, timeout=30,
-            )
-            if test_result.returncode == 0:
+            if _gemini_capacity_probe(runner.track, slug, phase):
                 log.info(f"  Account {next_account} works. Resuming batch.")
                 return True
             else:
@@ -458,3 +435,114 @@ def _append_log(log_path, message):
     """Append a timestamped message to a log file."""
     with open(log_path, "a", encoding="utf-8") as f:
         f.write(f"\n[{datetime.now().isoformat()}] {message}\n")
+
+
+def _runtime_task_id(track, slug, phase, retry, purpose="call"):
+    """Build a stable task identifier for runtime usage records."""
+    return f"batch-gemini-runner:{purpose}:{track}:{slug}:{phase}:retry-{retry}"
+
+
+def _timeout_payload(start_time, timeout_seconds):
+    """Preserve the legacy timeout return shape from direct subprocess.run."""
+    elapsed_ms = int((time.monotonic() - start_time) * 1000)
+    return {
+        "returncode": -1,
+        "stdout": "",
+        "stderr": f"Timeout expired ({timeout_seconds}s)",
+        "gemini_json": {},
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def _runtime_error_payload(exc, start_time):
+    """Map runtime exceptions onto the legacy non-zero subprocess payload."""
+    elapsed_ms = int((time.monotonic() - start_time) * 1000)
+    stderr = exc.reason or str(exc) if isinstance(exc, RateLimitedError) else str(exc)
+    return {
+        "returncode": 1,
+        "stdout": "",
+        "stderr": stderr,
+        "gemini_json": {},
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def _parse_gemini_runtime_response(raw_response):
+    """Parse runtime Gemini output, preserving the legacy JSON contract when possible."""
+    if not raw_response.strip():
+        return "", {}
+    try:
+        payload = json.loads(raw_response)
+    except json.JSONDecodeError:
+        return raw_response, {}
+    if isinstance(payload, dict):
+        return payload.get("response", raw_response), payload
+    return raw_response, {}
+
+
+def _build_runtime_usage_payload(result, gemini_json, elapsed_ms):
+    """Backfill the legacy batch usage logger from runtime results.
+
+    Exact token counters are only available when the runtime response is a
+    Gemini `-o json` payload. Otherwise we still preserve model + latency
+    continuity for the batch usage ledger without inventing token splits.
+    """
+    if gemini_json:
+        return gemini_json
+    return {
+        "response": result.response,
+        "stats": {
+            "models": {
+                result.model: {
+                    "api": {
+                        "totalLatencyMs": elapsed_ms,
+                    },
+                },
+            },
+        },
+    }
+
+
+def _runtime_result_to_legacy_payload(result, *, track, slug, phase, retry, log_usage=True):
+    """Translate runtime Result into the historical batch_gemini_runner dict."""
+    elapsed_ms = int(result.duration_s * 1000)
+    stdout_text, gemini_json = _parse_gemini_runtime_response(result.response or "")
+    if result.ok and log_usage:
+        _log_api_usage(
+            track,
+            slug,
+            phase,
+            retry,
+            _build_runtime_usage_payload(result, gemini_json, elapsed_ms),
+            elapsed_ms,
+        )
+    return {
+        "returncode": result.returncode if result.returncode is not None else (0 if result.ok else 1),
+        "stdout": stdout_text,
+        "stderr": result.stderr_excerpt or "",
+        "gemini_json": gemini_json,
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def _gemini_capacity_probe(track, slug, phase):
+    """Probe the current Gemini subscription account through the runtime."""
+    try:
+        result = runtime_invoke(
+            "gemini",
+            "Say OK",
+            mode="read-only",
+            cwd=PROJECT_ROOT,
+            task_id=_runtime_task_id(track, slug, phase, 0, purpose="probe"),
+            tool_config={"auth_mode": "subscription"},
+            entrypoint="dispatch",
+            hard_timeout=30,
+        )
+        payload = _runtime_result_to_legacy_payload(
+            result, track=track, slug=slug, phase=phase, retry=0, log_usage=False,
+        )
+        return payload["returncode"] == 0
+    except AgentTimeoutError:
+        return False
+    except (AgentUnavailableError, RateLimitedError):
+        return False

--- a/tests/test_batch_gemini_runner_env.py
+++ b/tests/test_batch_gemini_runner_env.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.errors import AgentTimeoutError
+from agent_runtime.result import Result
+from agent_runtime.watchdog import WatchdogState
+from batch_gemini_runner.constants import TIMEOUT_SECONDS
+from batch_gemini_runner.execution import call_gemini
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.buffer = ""
+
+    def write(self, text: str) -> int:
+        self.buffer += text
+        return len(text)
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeProc:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.stdin = _FakeStdin()
+        self.pid = 4321
+
+    def poll(self) -> int:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        _ = timeout
+        return self.returncode
+
+
+class _PopenCapture:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return _FakeProc(self.returncode)
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime_state():
+    from agent_runtime import runner as runner_mod
+
+    runner_mod._ADAPTER_CACHE.clear()
+    yield
+    runner_mod._ADAPTER_CACHE.clear()
+
+
+def _make_prompt_file(tmp_path: Path, text: str = "Say hello") -> Path:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text(text, encoding="utf-8")
+    return prompt_file
+
+
+def _invoke_with_captured_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    oauth_creds: bool,
+    auth_mode: str | None = None,
+) -> tuple[dict[str, object], _PopenCapture]:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GEMINI_API_KEY", "test-api-key")
+    if auth_mode is None:
+        monkeypatch.delenv("GEMINI_AUTH_MODE", raising=False)
+    else:
+        monkeypatch.setenv("GEMINI_AUTH_MODE", auth_mode)
+
+    gemini_dir = tmp_path / ".gemini"
+    gemini_dir.mkdir(exist_ok=True)
+    oauth_file = gemini_dir / "oauth_creds.json"
+    if oauth_creds:
+        oauth_file.write_text("{}", encoding="utf-8")
+    else:
+        oauth_file.unlink(missing_ok=True)
+
+    payload = json.dumps({"response": "hello from gemini", "stats": {"models": {}}})
+    popen_capture = _PopenCapture(returncode=0)
+    watchdog_state = WatchdogState(
+        start_time=0.0,
+        last_activity=0.0,
+        stdout_lines=[payload],
+        stderr_lines=[],
+    )
+
+    with patch("agent_runtime.runner.has_headroom", return_value=(True, "")), patch(
+        "agent_runtime.runner.write_record",
+    ), patch(
+        "agent_runtime.runner.subprocess.Popen", popen_capture,
+    ), patch(
+        "agent_runtime.runner.start_watchdog", return_value=(watchdog_state, []),
+    ), patch(
+        "agent_runtime.runner.stop_watchdog",
+    ), patch(
+        "agent_runtime.adapters.gemini.Path.home", return_value=tmp_path,
+    ), patch(
+        "batch_gemini_runner.execution._log_api_usage",
+    ):
+        result = call_gemini(_make_prompt_file(tmp_path), "bio", slug="demo", phase=2, retry=0)
+
+    return result, popen_capture
+
+
+def test_env_stripped_when_oauth_present(tmp_path, monkeypatch):
+    _result, popen_capture = _invoke_with_captured_env(
+        tmp_path, monkeypatch, oauth_creds=True,
+    )
+
+    env = popen_capture.calls[0]["kwargs"]["env"]
+    assert "GEMINI_API_KEY" not in env
+    assert "GOOGLE_API_KEY" not in env
+    assert "GOOGLE_GENERATIVE_AI_API_KEY" not in env
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in env
+
+
+def test_env_kept_when_oauth_absent(tmp_path, monkeypatch):
+    _result, popen_capture = _invoke_with_captured_env(
+        tmp_path, monkeypatch, oauth_creds=False,
+    )
+
+    env = popen_capture.calls[0]["kwargs"]["env"]
+    assert env["GEMINI_API_KEY"] == "test-api-key"
+
+
+def test_explicit_subscription_mode_strips(tmp_path, monkeypatch):
+    _result, popen_capture = _invoke_with_captured_env(
+        tmp_path, monkeypatch, oauth_creds=False, auth_mode="subscription",
+    )
+
+    env = popen_capture.calls[0]["kwargs"]["env"]
+    assert "GEMINI_API_KEY" not in env
+
+
+def test_return_shape_preserved(tmp_path):
+    prompt_file = _make_prompt_file(tmp_path)
+    payload = {
+        "response": "structured text",
+        "stats": {
+            "models": {
+                "gemini-3.1-pro-preview": {
+                    "tokens": {
+                        "input": 10,
+                        "candidates": 4,
+                        "cached": 0,
+                    },
+                },
+            },
+        },
+    }
+    runtime_result = Result(
+        ok=True,
+        agent="gemini",
+        model="gemini-3.1-pro-preview",
+        mode="read-only",
+        response=json.dumps(payload),
+        stderr_excerpt="runtime stderr",
+        duration_s=0.25,
+        session_id=None,
+        rate_limited=False,
+        stalled=False,
+        returncode=0,
+        usage_record={},
+    )
+
+    with patch(
+        "batch_gemini_runner.execution.runtime_invoke",
+        return_value=runtime_result,
+    ), patch(
+        "batch_gemini_runner.execution._log_api_usage",
+    ) as mock_log_usage:
+        result = call_gemini(prompt_file, "bio", slug="demo", phase=2, retry=1)
+
+    assert set(result.keys()) == {
+        "returncode",
+        "stdout",
+        "stderr",
+        "gemini_json",
+        "elapsed_ms",
+    }
+    assert result["returncode"] == 0
+    assert result["stdout"] == "structured text"
+    assert result["stderr"] == "runtime stderr"
+    assert result["gemini_json"] == payload
+    assert result["elapsed_ms"] == 250
+    mock_log_usage.assert_called_once()
+
+
+def test_timeout_returns_existing_shape(tmp_path):
+    prompt_file = _make_prompt_file(tmp_path)
+
+    with patch(
+        "batch_gemini_runner.execution.runtime_invoke",
+        side_effect=AgentTimeoutError("gemini", TIMEOUT_SECONDS),
+    ):
+        result = call_gemini(prompt_file, "bio", slug="demo", phase=2, retry=0)
+
+    assert result["returncode"] == -1
+    assert "Timeout expired" in result["stderr"]
+    assert result["stdout"] == ""
+    assert result["gemini_json"] == {}


### PR DESCRIPTION
## Decision

I took the unify route, not the deprecation route.

`v6_build.py` is clearly the more active path (`git log --since="6 months ago" --oneline -- scripts/build/v6_build.py | wc -l` returned `243`, versus `4` commits touching `scripts/batch_gemini_runner/execution.py` / `scripts/batch/batch_dispatcher*.py`), and there are no current docs references to the v5 dispatcher path. But the v5 surface is still live enough that deprecating it would be a behavior change, not a cleanup: `scripts/api/main.py` still points at `scripts/batch_dispatcher.py`, `tests/test_batch_fix_mode.py` imports `scripts.batch_gemini_runner`, `tests/test_coverage_batch_agent.py` still exercises `batch_dispatcher`, and `scripts/batch/batch_dispatcher.py --help` plus `scan --include-tracks bio` both still booted in this worktree.

Because of that, the safer fix for #1406 is to unify the remaining legacy Gemini subprocess path with `agent_runtime.runner.invoke()` instead of marking the whole v5 path deprecated. I also confirmed that the "second raw Gemini call" in the stale line reference is the capacity probe in `handle_quota_error()`, not `run_audit()`.

## What Changed

- Routed `scripts/batch_gemini_runner/execution.py::call_gemini()` through `agent_runtime.runner.invoke()`.
- Pinned the runtime `tool_config.auth_mode` from `resolve_gemini_auth_mode()` so batch now gets the same auth-mode resolution as the adapter path:
  - OAuth creds present + auto mode => `subscription` => Gemini API env vars stripped
  - no OAuth creds + auto mode => `api` => API key kept for legitimate fallback
  - explicit `GEMINI_AUTH_MODE=subscription` still strips regardless of OAuth file presence
- Preserved the legacy `call_gemini()` dict contract:
  - `returncode`
  - `stdout`
  - `stderr`
  - `gemini_json`
  - `elapsed_ms`
- Preserved legacy timeout semantics by mapping `AgentTimeoutError` back to the existing `{"returncode": -1, "stderr": "Timeout expired (...)", ...}` payload.
- Replaced the direct Gemini capacity probes in `handle_quota_error()` with runtime-based probes so they no longer inherit `GEMINI_API_KEY` accidentally.
- Added `tests/test_batch_gemini_runner_env.py` covering env stripping, fallback retention, explicit subscription mode, return-shape preservation, and timeout mapping.
- Removed the now-dead `GEMINI_BIN` constant after adversarial review flagged it.

## Verification

- `../../.venv/bin/python -m pytest tests/test_batch_gemini_runner_env.py`
- `../../.venv/bin/python scripts/batch/batch_dispatcher.py --help`
- `../../.venv/bin/python scripts/batch/batch_dispatcher.py scan --include-tracks bio`
- `../../.venv/bin/python -m py_compile scripts/batch_gemini_runner/constants.py scripts/batch_gemini_runner/execution.py tests/test_batch_gemini_runner_env.py`
- pre-commit hook on commit: `ruff check` + affected-file pytest passed

## Adversarial Review

Ran:

```bash
../../.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-claude \
  "Adversarial review: routing batch_gemini_runner.execution through agent_runtime.invoke (#1406). Read the diff. Look for: (1) call-shape regression — any dict key in the return value of call_gemini that disappeared, (2) JSON-output parsing change losing fields downstream code depends on, (3) timeout semantics mismatch (subprocess.TimeoutExpired vs AgentTimeoutError), (4) ladder behavior swallowing errors the old direct-subprocess raised, (5) deprecation banners on dead code missing." \
  --task-id 1406-review
```

Claude's bridge response was partially truncated by a rate-limit wrapper, but it did contain one actionable finding: `GEMINI_BIN` was dead after this refactor. I removed it in `scripts/batch_gemini_runner/constants.py`.

No rejected feedback.

Closes #1406.
