### PR TITLE
fix(delegate): correct rate-limit misclassification on completed dispatches (#1404)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1009,6 +1009,10 @@ Newest usage records from today's runtime logs, newest first.
 ### `GET /api/delegate/tasks?status=&limit=50`
 
 List delegate task state files with derived age and zombie detection.
+Delegate task status only becomes `rate_limited` when the runtime adapter sees
+an actual provider rate-limit failure signal; for Claude's text-mode runtime
+that means a failed call with a rate-limit phrase on `stderr`, not a successful
+response whose body happens to mention rate limits.
 
 ```json
 {

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -238,12 +238,19 @@ class ClaudeAdapter:
         _ = plan
         _ = call_start_time
 
-        # Rate-limit detection across both streams
-        combined = f"{stdout}\n{stderr}"
-        rate_limited = bool(_RATE_LIMIT_RE.search(combined))
+        # Claude Code 2.1.117 does not document a dedicated rate-limit exit
+        # code in `claude --help`, and this runtime currently requests plain
+        # text (`--output-format text`), not machine-readable JSON. The safest
+        # remaining signal is a rate-limit phrase on stderr from a failed or
+        # empty-response call. We intentionally ignore stdout here: successful
+        # Claude responses can legitimately discuss "rate limited" without the
+        # task being blocked.
+        usable_response = bool(stdout.strip())
+        failed_call = returncode != 0 or not usable_response
+        rate_limited = failed_call and bool(_RATE_LIMIT_RE.search(stderr or ""))
 
         # Success classification
-        ok = returncode == 0 and bool(stdout.strip()) and not rate_limited
+        ok = returncode == 0 and usable_response and not rate_limited
         response = stdout.strip() if ok else ""
 
         # Stderr excerpt on failure

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -235,6 +235,22 @@ def _worker_sigterm_handler(_signum, _frame):
     raise KeyboardInterrupt("SIGTERM received; unwinding for cleanup")
 
 
+def _classify_final_status(
+    *,
+    cancelled: bool,
+    rate_limited: bool,
+    ok_outcome: bool,
+) -> str:
+    """Map worker outcome flags to the persisted delegate task status."""
+    if cancelled:
+        return "cancelled"
+    if rate_limited:
+        return "rate_limited"
+    if ok_outcome:
+        return "done"
+    return "failed"
+
+
 def _run_worker(
     task_id: str,
     agent: str,
@@ -337,15 +353,11 @@ def _run_worker(
         except OSError:
             result_file = None
 
-    # Classify final status
-    if cancelled:
-        final_status = "cancelled"
-    elif rate_limited:
-        final_status = "rate_limited"
-    elif ok_outcome:
-        final_status = "done"
-    else:
-        final_status = "failed"
+    final_status = _classify_final_status(
+        cancelled=cancelled,
+        rate_limited=rate_limited,
+        ok_outcome=ok_outcome,
+    )
 
     final_state = _read_state(state_path) or {}
     final_state.update({

--- a/scripts/maintenance/reclassify_dispatch_status.py
+++ b/scripts/maintenance/reclassify_dispatch_status.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+"""Reclassify persisted delegate task states after runtime classifier fixes.
+
+Walks ``batch_state/tasks/*.json`` and revisits any task currently marked
+``rate_limited`` using the current adapter parsing logic plus whatever saved
+signals we still have in the task file / usage logs.
+
+Issue: #1404
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import delegate
+from agent_runtime.runner import _load_adapter
+
+DEFAULT_TASKS_DIR = REPO_ROOT / "batch_state" / "tasks"
+DEFAULT_USAGE_DIR = REPO_ROOT / "batch_state" / "api_usage"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _backup_task_file(path: Path) -> Path:
+    backup_path = path.with_suffix(f"{path.suffix}.bak")
+    if not backup_path.exists():
+        shutil.copy2(path, backup_path)
+    return backup_path
+
+
+def _load_usage_by_task_id(usage_dir: Path) -> dict[str, dict[str, Any]]:
+    """Return the newest usage record we have for each task_id."""
+    records: dict[str, dict[str, Any]] = {}
+    if not usage_dir.exists():
+        return records
+
+    for path in sorted(usage_dir.glob("usage_*.jsonl")):
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            task_id = record.get("task_id")
+            ts = record.get("ts")
+            if not task_id or not ts:
+                continue
+            existing = records.get(task_id)
+            if existing is None or ts >= existing.get("ts", ""):
+                records[task_id] = record
+    return records
+
+
+def _reconstruct_streams(
+    *,
+    task_state: dict[str, Any],
+    usage_record: dict[str, Any] | None,
+) -> tuple[str, str, int | None, Path | None]:
+    """Best-effort recovery of the raw signals the adapter classified.
+
+    The #1404 historical false positive lost its true stdout because delegate
+    caught ``RateLimitedError`` and only persisted the synthesized excerpt. For
+    Claude with ``returncode == 0``, that usage ``stderr_excerpt`` is actually
+    the original stdout body, so we feed it back as stdout for reclassification.
+    """
+    result_file: Path | None = None
+    result_file_raw = task_state.get("result_file")
+    if result_file_raw:
+        candidate = Path(result_file_raw)
+        if candidate.exists():
+            result_file = candidate
+
+    returncode = task_state.get("returncode")
+    if returncode is None and usage_record is not None:
+        returncode = usage_record.get("returncode")
+
+    stdout = result_file.read_text().strip() if result_file is not None else ""
+    stderr = ""
+
+    agent = task_state.get("agent")
+    usage_excerpt = (usage_record or {}).get("stderr_excerpt") or ""
+    task_excerpt = task_state.get("stderr_excerpt") or ""
+
+    if agent == "claude" and returncode == 0 and usage_excerpt and not stdout:
+        stdout = usage_excerpt
+    else:
+        stderr = usage_excerpt or task_excerpt
+
+    return stdout, stderr, returncode, result_file
+
+
+def _reclassify_task(
+    task_path: Path,
+    *,
+    usage_by_task_id: dict[str, dict[str, Any]],
+    dry_run: bool,
+) -> tuple[str, str, str] | None:
+    task_state = _read_json(task_path)
+    if task_state.get("status") != "rate_limited":
+        return None
+
+    task_id = task_state.get("task_id", task_path.stem)
+    agent = task_state.get("agent")
+    if not agent:
+        return "skipped", task_id, "missing agent"
+
+    usage_record = usage_by_task_id.get(task_id)
+    stdout, stderr, returncode, result_file = _reconstruct_streams(
+        task_state=task_state,
+        usage_record=usage_record,
+    )
+    if returncode is None and not stdout and not stderr:
+        return "skipped", task_id, "missing saved stderr/stdout/returncode"
+
+    adapter = _load_adapter(agent)
+    parse = adapter.parse_response(
+        stdout=stdout,
+        stderr=stderr,
+        returncode=returncode if returncode is not None else 1,
+        output_file=result_file,
+    )
+    new_status = delegate._classify_final_status(
+        cancelled=False,
+        rate_limited=parse.rate_limited,
+        ok_outcome=parse.ok,
+    )
+    if new_status == task_state["status"]:
+        return None
+    if new_status != "done":
+        return "skipped", task_id, f"reclassified to {new_status}, left unchanged"
+
+    previous_status = task_state["status"]
+    if dry_run:
+        return "changed", task_id, f"{previous_status} -> {new_status} (dry-run)"
+
+    backup_path = _backup_task_file(task_path)
+    task_state["status"] = new_status
+    _write_json(task_path, task_state)
+    return "changed", task_id, f"{previous_status} -> {new_status} (backup: {backup_path.name})"
+
+
+def reclassify_rate_limited_tasks(
+    *,
+    tasks_dir: Path = DEFAULT_TASKS_DIR,
+    usage_dir: Path = DEFAULT_USAGE_DIR,
+    dry_run: bool = False,
+) -> dict[str, list[tuple[str, str]]]:
+    usage_by_task_id = _load_usage_by_task_id(usage_dir)
+    changes: list[tuple[str, str]] = []
+    skipped: list[tuple[str, str]] = []
+    if not tasks_dir.exists():
+        return {"changed": changes, "skipped": skipped}
+
+    for task_path in sorted(tasks_dir.glob("*.json")):
+        outcome = _reclassify_task(
+            task_path,
+            usage_by_task_id=usage_by_task_id,
+            dry_run=dry_run,
+        )
+        if outcome is None:
+            continue
+        kind, task_id, detail = outcome
+        if kind == "changed":
+            changes.append((task_id, detail))
+        else:
+            skipped.append((task_id, detail))
+    return {"changed": changes, "skipped": skipped}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=DEFAULT_TASKS_DIR,
+        help="Directory containing delegate task JSON state files.",
+    )
+    parser.add_argument(
+        "--usage-dir",
+        type=Path,
+        default=DEFAULT_USAGE_DIR,
+        help="Directory containing runtime usage JSONL logs.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report proposed task-state changes without rewriting JSON files.",
+    )
+    args = parser.parse_args()
+
+    usage_by_task_id = _load_usage_by_task_id(args.usage_dir)
+    changed: list[tuple[str, str]] = []
+    skipped: list[tuple[str, str]] = []
+    if args.tasks_dir.exists():
+        for task_path in sorted(args.tasks_dir.glob("*.json")):
+            outcome = _reclassify_task(
+                task_path,
+                usage_by_task_id=usage_by_task_id,
+                dry_run=args.dry_run,
+            )
+            if outcome is None:
+                continue
+            kind, task_id, detail = outcome
+            if kind == "changed":
+                changed.append((task_id, detail))
+            else:
+                skipped.append((task_id, detail))
+
+    for task_id, detail in changed:
+        print(f"{task_id}: {detail}")
+    for task_id, detail in skipped:
+        print(f"{task_id}: skipped ({detail})")
+
+    if not changed and not skipped:
+        print("No task states changed.")
+        return 0
+    if args.dry_run:
+        print(f"Dry run only. Proposed changes: {len(changed)}")
+        return 0
+
+    if changed:
+        print(f"Changed: {len(changed)}")
+    if skipped:
+        print(f"Skipped: {len(skipped)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_runtime_rate_limit.py
+++ b/tests/test_agent_runtime_rate_limit.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.adapters.claude import ClaudeAdapter
+from maintenance.reclassify_dispatch_status import reclassify_rate_limited_tasks
+
+
+def test_claude_success_text_with_rate_limited_phrase_is_not_rate_limited():
+    adapter = ClaudeAdapter()
+
+    result = adapter.parse_response(
+        stdout="Done.\nThe previous soft warning said rate limited, but the task completed.",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.rate_limited is False
+    assert result.ok is True
+
+
+def test_claude_stderr_rate_limit_failure_is_still_rate_limited():
+    adapter = ClaudeAdapter()
+
+    result = adapter.parse_response(
+        stdout="",
+        stderr="Error: rate limit reached, try again later.",
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.rate_limited is True
+    assert result.ok is False
+
+
+def test_claude_empty_stdout_with_stderr_rate_limit_stays_rate_limited():
+    adapter = ClaudeAdapter()
+
+    result = adapter.parse_response(
+        stdout="",
+        stderr="Warning: rate limit reached before any response was returned.",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.rate_limited is True
+    assert result.ok is False
+
+
+def test_claude_failed_stdout_rate_limit_phrase_without_stderr_is_not_rate_limited():
+    adapter = ClaudeAdapter()
+
+    result = adapter.parse_response(
+        stdout="Error: rate limit reached.",
+        stderr="",
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.rate_limited is False
+    assert result.ok is False
+
+
+def test_reclassify_script_flips_historical_claude_false_positive(tmp_path):
+    tasks_dir = tmp_path / "batch_state" / "tasks"
+    usage_dir = tmp_path / "batch_state" / "api_usage"
+    tasks_dir.mkdir(parents=True)
+    usage_dir.mkdir(parents=True)
+
+    task_path = tasks_dir / "claude-1370-writer-harden.json"
+    task_path.write_text(json.dumps({
+        "task_id": "claude-1370-writer-harden",
+        "agent": "claude",
+        "status": "rate_limited",
+        "stderr_excerpt": "claude/claude-opus-4-7 rate limited: Done.",
+        "returncode": None,
+        "result_file": None,
+    }))
+    (usage_dir / "usage_claude-delegate_2026-04-22.jsonl").write_text(
+        json.dumps({
+            "ts": "2026-04-22T12:52:00.090793+00:00",
+            "agent": "claude",
+            "entrypoint": "delegate",
+            "task_id": "claude-1370-writer-harden",
+            "model": "claude-opus-4-7",
+            "returncode": 0,
+            "outcome": "rate_limited",
+            "rate_limited": True,
+            "stderr_excerpt": (
+                "Done.\n\n**Delivered:** soft warning said rate limited, "
+                "but work finished."
+            ),
+        }) + "\n"
+    )
+
+    changes = reclassify_rate_limited_tasks(tasks_dir=tasks_dir, usage_dir=usage_dir)
+
+    assert changes["changed"] == [
+        (
+            "claude-1370-writer-harden",
+            "rate_limited -> done (backup: claude-1370-writer-harden.json.bak)",
+        )
+    ]
+    assert changes["skipped"] == []
+    updated = json.loads(task_path.read_text())
+    assert updated["status"] == "done"
+    assert updated["stderr_excerpt"] == "claude/claude-opus-4-7 rate limited: Done."
+    assert (tasks_dir / "claude-1370-writer-harden.json.bak").exists()

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -72,6 +72,14 @@ def test_read_state_corrupted_json(tmp_tasks_dir):
     assert delegate._read_state(path) is None
 
 
+def test_classify_final_status_prioritizes_cancelled_over_other_flags():
+    assert delegate._classify_final_status(
+        cancelled=True,
+        rate_limited=True,
+        ok_outcome=True,
+    ) == "cancelled"
+
+
 # ---------------------------------------------------------------------------
 # PID liveness probe
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- restrict Claude delegate rate-limit classification to failed-or-empty responses with a stderr rate-limit signal, so successful stdout mentioning rate limits no longer flips tasks to `rate_limited`
- add targeted regression tests plus a shared delegate status classifier helper
- add `scripts/maintenance/reclassify_dispatch_status.py` with dry-run, backup, and skip logging to re-evaluate saved `rate_limited` task states
- document the delegate rate-limit rule in `docs/MONITOR-API.md`

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_agent_runtime_rate_limit.py tests/test_agent_runtime.py -k "claude_parse_response or reclassify or rate_limit"`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_delegate.py -k "state_path or status_detects_zombie or wait_returns_immediately_when_already_done"`
- pre-commit on commit: `ruff check` + affected-file pytest (`35 passed`)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/maintenance/reclassify_dispatch_status.py --tasks-dir /Users/krisztiankoos/projects/learn-ukrainian/batch_state/tasks --usage-dir /Users/krisztiankoos/projects/learn-ukrainian/batch_state/api_usage`
- adversarial review via `scripts/ai_agent_bridge/__main__.py ask-claude ... --task-id 1404-review` and follow-up `1404-review-r2` (no remaining blockers)

## Notes
- The historical task `/Users/krisztiankoos/projects/learn-ukrainian/batch_state/tasks/claude-1370-writer-harden.json` now reports `status: done`.
- `batch_state/` is gitignored, so the runtime-state reclassification was executed against the saved operational files but does not appear in the tracked diff.