### PR TITLE
feat(mcp): add unified search_sources tool — wire ukrainian_wiki corpus into v6 writer retrieval

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -14,7 +14,7 @@ The Python backing package is still `scripts/rag/` for backwards compat
 with imports; rename there is a follow-up.
 
 Tools:
-    - search_text, search_literary, search_external, search_images, get_chunk_context
+    - search_sources, search_text, search_literary, search_external, search_images, get_chunk_context
     - verify_word, verify_words, verify_lemma (VESUM)
     - query_wikipedia, query_pravopys, query_e2u, query_r2u, query_ulif
     - search_definitions, search_etymology, search_idioms, search_synonyms
@@ -48,6 +48,36 @@ server = Server("sources")
 async def list_tools() -> list[Tool]:
     """List available RAG tools."""
     return [
+        Tool(
+            name="search_sources",
+            description=(
+                "Unified Ukrainian source search across textbooks, literary corpora, "
+                "Wikipedia, external articles, AND the ukrainian_wiki corpus "
+                "(compiled Ukrainian textbook pedagogy). Use this for general retrieval "
+                "when you want all relevant Ukrainian-source content in one query. "
+                "Use the corpus-specific tools (search_text, search_literary, etc.) "
+                "only when you need to scope to a single source."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query in Ukrainian (e.g., 'голосні звуки', 'як утворюється минулий час')"
+                    },
+                    "track": {
+                        "type": "string",
+                        "description": "Optional curriculum track for retrieval prep and reranking (e.g., 'a1'). Defaults to empty string."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return (default 10, max 20)",
+                        "default": 10
+                    }
+                },
+                "required": ["query"]
+            },
+        ),
         Tool(
             name="search_text",
             description=(
@@ -618,6 +648,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     try:
         # Dispatch to handler
         _handlers = {
+            "search_sources": lambda: handle_search_sources(arguments),
             "search_text": lambda: handle_search_text(arguments),
             "search_images": lambda: handle_search_images(arguments),
             "search_literary": lambda: handle_search_literary(arguments),
@@ -682,6 +713,23 @@ async def handle_search_text(args: dict) -> list[TextContent]:
         lines.append("")
 
     return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_search_sources(args: dict) -> list[TextContent]:
+    query = args["query"]
+    # Empty-string track is intentional: `_prepare_query()` handles ad-hoc
+    # string queries without needing a concrete curriculum track.
+    track = str(args.get("track", "") or "")
+    limit = min(args.get("limit", 10), 20)
+
+    from wiki.sources_db import search_sources
+
+    hits = await asyncio.to_thread(search_sources, query, track=track, limit=limit)
+
+    if not hits:
+        return [TextContent(type="text", text="[]")]
+
+    return [TextContent(type="text", text=json.dumps(hits, ensure_ascii=False, indent=2))]
 
 
 async def handle_search_literary(args: dict) -> list[TextContent]:

--- a/claude_extensions/phases/gemini/beginner-full-rag.md
+++ b/claude_extensions/phases/gemini/beginner-full-rag.md
@@ -41,10 +41,13 @@ Your content will be scored on these 7 dimensions (see GEMINI.md for details):
 
 | Tool | When | Example |
 |------|------|---------|
+| `search_sources` | Preferred unified retrieval across textbooks, literary, Wikipedia, external, and ukrainian_wiki | `search_sources("{TOPIC_KEYWORDS}", track="a1")` |
 | `search_text` | Find textbook pedagogy | `search_text("{TOPIC_KEYWORDS}", grade={TEXTBOOK_GRADE})` |
 | `verify_words` | Check words exist in VESUM | `verify_words(["книга", "великий"])` |
 | `verify_lemma` | Get inflected forms | `verify_lemma("книга")` |
 | `query_pravopys` | Spelling/grammar rules | `query_pravopys("апостроф")` |
+
+Use `search_text` only when you explicitly want textbook-only scoping.
 
 ### What the Learner Already Knows
 

--- a/claude_extensions/phases/gemini/phase-A-core.md
+++ b/claude_extensions/phases/gemini/phase-A-core.md
@@ -41,10 +41,13 @@ Research **{TOPIC_TITLE}** for the **{LEVEL}** core track. Core tracks need ligh
 
 | Tool | When to use |
 |------|-------------|
+| `search_sources` | Preferred unified retrieval across textbooks, literary, Wikipedia, external, and ukrainian_wiki |
 | `search_text` | Find how this topic is taught in Ukrainian textbooks |
 | `verify_words` | Check vocabulary exists in VESUM dictionary |
 | `query_grac` mode=`frequency` | Get word frequency data |
 | `query_wikipedia` mode=`summary` | Quick fact-check for cultural hooks |
+
+Use `search_text` only when you explicitly need textbook-only scoping.
 
 ### Research Requirements
 

--- a/claude_extensions/phases/gemini/phase-D1-structured-review.md
+++ b/claude_extensions/phases/gemini/phase-D1-structured-review.md
@@ -115,16 +115,17 @@ You have access to RAG tools for linguistic verification. **Use them actively** 
 
 ### Textbook Cross-Reference
 
+- **`mcp__sources__search_sources`**: **PREFERRED** unified source search across textbooks, literary works, Wikipedia, external articles, and the ukrainian_wiki pedagogy corpus. Use this as the default cross-check for grammar claims and pedagogy.
 - **`mcp__sources__search_text`**: Search Ukrainian school textbooks (1.2K+ chunks) for grammar explanations, vocabulary usage, and pedagogical approaches. Use this to verify grammar rules stated in the content.
 - **`mcp__sources__search_images`**: Search textbook illustrations for visual aids that could enhance the content.
 - **`mcp__sources__search_literary`**: Search primary literary sources for quote verification.
 
-**When to cross-reference**: (a) Grammar rule claims — verify they match textbook explanations, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — check if textbooks use similar patterns.
+**When to cross-reference**: (a) Grammar rule claims — start with `mcp__sources__search_sources`, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — compare against authentic Ukrainian-source usage. Use `mcp__sources__search_text` only when you need textbook-only scoping.
 
 ### Verification Protocol
 
 1. For each word flagged ❌ in pre-scan: call `mcp__sources__verify_word` to confirm/dismiss
-2. For grammar explanations: call `mcp__sources__search_text` with the grammar topic to verify accuracy
+2. For grammar explanations: call `mcp__sources__search_sources` first; fall back to `mcp__sources__search_text` only if you need textbook-only scope
 3. For suspicious Russianisms: call `mcp__sources__verify_word` on the suspect word AND its Ukrainian alternative
 4. Report your RAG findings in the review — cite tool results as evidence
 

--- a/claude_extensions/phases/gemini/research-core.md
+++ b/claude_extensions/phases/gemini/research-core.md
@@ -41,10 +41,13 @@ Research **{TOPIC_TITLE}** for the **{LEVEL}** core track. Core tracks need ligh
 
 | Tool | When to use |
 |------|-------------|
+| `search_sources` | Preferred unified retrieval across textbooks, literary, Wikipedia, external, and ukrainian_wiki |
 | `search_text` | Find how this topic is taught in Ukrainian textbooks |
 | `verify_words` | Check vocabulary exists in VESUM dictionary |
 | `query_grac` mode=`frequency` | Get word frequency data |
 | `query_wikipedia` mode=`summary` | Quick fact-check for cultural hooks |
+
+Use `search_text` only when you explicitly need textbook-only scoping.
 
 ### Research Requirements
 

--- a/claude_extensions/phases/gemini/review-structured.md
+++ b/claude_extensions/phases/gemini/review-structured.md
@@ -118,16 +118,17 @@ You have access to RAG tools for linguistic verification. **Use them actively** 
 
 ### Textbook Cross-Reference
 
+- **`mcp__sources__search_sources`**: **PREFERRED** unified source search across textbooks, literary works, Wikipedia, external articles, and the ukrainian_wiki pedagogy corpus. Use this as the default cross-check for grammar claims and pedagogy.
 - **`mcp__sources__search_text`**: Search Ukrainian school textbooks (1.2K+ chunks) for grammar explanations, vocabulary usage, and pedagogical approaches. Use this to verify grammar rules stated in the content.
 - **`mcp__sources__search_images`**: Search textbook illustrations for visual aids that could enhance the content.
 - **`mcp__sources__search_literary`**: Search primary literary sources for quote verification.
 
-**When to cross-reference**: (a) Grammar rule claims — verify they match textbook explanations, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — check if textbooks use similar patterns.
+**When to cross-reference**: (a) Grammar rule claims — start with `mcp__sources__search_sources`, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — compare against authentic Ukrainian-source usage. Use `mcp__sources__search_text` only when you need textbook-only scoping.
 
 ### Verification Protocol
 
 1. For each word flagged ❌ in pre-scan: call `mcp__sources__verify_word` to confirm/dismiss
-2. For grammar explanations: call `mcp__sources__search_text` with the grammar topic to verify accuracy
+2. For grammar explanations: call `mcp__sources__search_sources` first; fall back to `mcp__sources__search_text` only if you need textbook-only scope
 3. For suspicious Russianisms: call `mcp__sources__verify_word` on the suspect word AND its Ukrainian alternative
 4. Report your RAG findings in the review — cite tool results as evidence
 

--- a/claude_extensions/phases/gemini/v6-write.md
+++ b/claude_extensions/phases/gemini/v6-write.md
@@ -125,6 +125,11 @@ Your prose should contain (after the relevant sections):
 {KNOWLEDGE_PACKET}
 </knowledge_packet>
 
+## MCP Retrieval Tools
+
+- `search_sources` — **PREFERRED** unified source search across textbooks, literary works, Wikipedia, external articles, AND the Ukrainian wiki pedagogy corpus (compiled from Ukrainian textbooks for Ukrainian learners). Use this as your default when you need supporting retrieval beyond the knowledge packet.
+- `search_text` — textbook-only search. Use this only when you explicitly need school textbook coverage without other corpora.
+
 ---
 
 ## Section Structure

--- a/claude_extensions/rules/mcp-sources-and-dictionaries.md
+++ b/claude_extensions/rules/mcp-sources-and-dictionaries.md
@@ -17,13 +17,14 @@ paths:
 
 ## Core tools (always use)
 - `mcp__sources__verify_word` / `mcp__sources__verify_words` / `mcp__sources__verify_lemma` — VESUM morphological dictionary (409K lemmas, 6.7M forms)
+- `mcp__sources__search_sources` — **PREFERRED unified entry point** across textbooks, literary corpora, Wikipedia, external articles, and `ukrainian_wiki`
 - `mcp__sources__search_text` — textbook content search (23K chunks, Grades 1-11)
 - `mcp__sources__search_images` — textbook image search (14K images)
 - `mcp__sources__search_literary` — primary literary sources (125K chunks — chronicles, poetry, legal texts)
 - `mcp__sources__query_pravopys` — Ukrainian orthography rules (Правопис 2019)
 - `mcp__sources__query_wikipedia` — Ukrainian Wikipedia
 
-> MCP `search_text` currently uses the legacy `search_textbooks` path. T1-T2 modules building via wiki compile use the new `search_sources(strategy='modern_dense_section')` path. Migration ticket TBD.
+> Start with `mcp__sources__search_sources` for general retrieval. Keep `mcp__sources__search_text` for explicit textbook-only scoping when you do not want literary, Wikipedia, external, or `ukrainian_wiki` results mixed in.
 
 ## Dictionary tools (for quality and vocabulary)
 - `mcp__sources__search_style_guide` — Антоненко-Давидович (279 entries) — **calques and Russianisms**. HIGH PRIORITY.

--- a/scripts/build/phases/v6-review.md
+++ b/scripts/build/phases/v6-review.md
@@ -93,7 +93,7 @@ Order violation or type mismatch = deduct in Dimension 5.
 
 ### PROOF OF ABSENCE — mandatory before claiming ANYTHING is missing
 
-**Before you claim a word, symbol, notation, or plan point is MISSING from the content, you MUST search for it.** Use your MCP tools (`verify_words`, `search_text`) or carefully re-read the specific section where it should appear.
+**Before you claim a word, symbol, notation, or plan point is MISSING from the content, you MUST search for it.** Use your MCP tools (`verify_words`, `search_sources`, `search_text`) or carefully re-read the specific section where it should appear. Prefer `search_sources`; keep `search_text` for textbook-only checks.
 
 Rules:
 - If you claim "[•] notation is missing" — you must have searched the content for `[•]` and confirmed 0 occurrences

--- a/scripts/tools/codex_tool_instructions.md
+++ b/scripts/tools/codex_tool_instructions.md
@@ -63,7 +63,26 @@ if not results:
 "
 ```
 
-### 5. Search textbook content (Ukrainian school textbooks, Grades 1-11)
+### 5. Search Ukrainian source content (preferred unified retrieval)
+
+```bash
+.venv/bin/python -c "
+import sys; sys.path.insert(0, 'scripts')
+from wiki.sources_db import search_sources
+results = search_sources('голосні звуки', track='a1', limit=5)
+for r in results:
+    corpus = r.get('corpus', '?')
+    title = r.get('title', r.get('section_title', ''))
+    text = (r.get('text') or r.get('full_text') or '')[:200]
+    print(f'[{corpus}] {title}')
+    print(f'  {text}')
+    print()
+"
+```
+
+Use `search_textbooks` only when you explicitly need textbook-only scoping.
+
+### 6. Search textbook content (Ukrainian school textbooks, Grades 1-11)
 
 ```bash
 .venv/bin/python -c "
@@ -81,7 +100,7 @@ for r in results:
 "
 ```
 
-### 6. Search style guide for calques/Russianisms (Антоненко-Давидович, 279 entries)
+### 7. Search style guide for calques/Russianisms (Антоненко-Давидович, 279 entries)
 
 ```bash
 .venv/bin/python -c "
@@ -97,7 +116,7 @@ if not results:
 "
 ```
 
-### 7. Look up word definition in СУМ-11 (Ukrainian explanatory dictionary, 127K entries)
+### 8. Look up word definition in СУМ-11 (Ukrainian explanatory dictionary, 127K entries)
 
 ```bash
 .venv/bin/python -c "
@@ -109,7 +128,7 @@ for r in results:
 "
 ```
 
-### 8. Search idioms (Фразеологічний словник, 25K entries)
+### 9. Search idioms (Фразеологічний словник, 25K entries)
 
 ```bash
 .venv/bin/python -c "
@@ -121,7 +140,7 @@ for r in results:
 "
 ```
 
-### 9. English-to-Ukrainian translation (Балла, 79K entries)
+### 10. English-to-Ukrainian translation (Балла, 79K entries)
 
 ```bash
 .venv/bin/python -c "
@@ -145,10 +164,9 @@ for r in results:
    is level-appropriate.
 4. **When unsure about a case ending or conjugation** — use `verify_lemma` (tool 3)
    to see the full paradigm.
-5. **When covering a grammar topic** — search textbooks (tool 5) to see how
-   Ukrainian school textbooks teach it.
-6. **When you need the precise Ukrainian meaning** — use СУМ-11 (tool 7).
-7. **When looking for natural Ukrainian expressions** — search idioms (tool 8).
+5. **When covering a grammar topic or looking for supporting pedagogy** — start with unified retrieval (tool 5), then use textbook-only search (tool 6) if you need school-textbook scope only.
+6. **When you need the precise Ukrainian meaning** — use СУМ-11 (tool 8).
+7. **When looking for natural Ukrainian expressions** — search idioms (tool 9).
 
 **Batching rule:** Collect all words you want to verify, then run ONE `verify_words`
 call instead of multiple `verify_word` calls. This is faster and uses fewer tokens.

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -46,7 +46,7 @@ class TestListTools:
         tool_names = {t.name for t in tools}
 
         expected = {
-            "search_text", "search_images", "search_literary", "search_external",
+            "search_sources", "search_text", "search_images", "search_literary", "search_external",
             "get_full_text", "get_chunk_context", "collection_stats",
             "verify_word", "verify_words", "verify_lemma",
             "query_wikipedia", "query_grac", "query_ulif",
@@ -103,6 +103,12 @@ class TestCallToolDispatch:
             _run(server_module.call_tool("verify_words", {"words": ["тест"]}))
             mock.assert_called_once_with({"words": ["тест"]})
 
+    def test_search_sources_dispatches(self, server_module):
+        with patch.object(server_module, "handle_search_sources", new_callable=AsyncMock) as mock:
+            mock.return_value = [MagicMock(text="ok")]
+            _run(server_module.call_tool("search_sources", {"query": "голосні звуки"}))
+            mock.assert_called_once_with({"query": "голосні звуки"})
+
     def test_handler_exception_returns_error_text(self, server_module):
         with patch.object(server_module, "handle_verify_word", new_callable=AsyncMock) as mock:
             mock.side_effect = RuntimeError("test error")
@@ -148,6 +154,40 @@ class TestVerifyWordsHandler:
             assert "Found: 1/2" in text
             assert "**стій** — FOUND" in text
             assert "**взяйте** — NOT FOUND" in text
+
+
+class TestSearchSourcesHandler:
+    """Test search_sources handler formatting."""
+
+    def test_empty_results(self, server_module):
+        with patch("wiki.sources_db.search_sources", return_value=[]):
+            result = _run(server_module.handle_search_sources({"query": "голосні звуки"}))
+            assert result[0].text == "[]"
+
+    def test_defaults_track_to_empty_string(self, server_module):
+        with patch("wiki.sources_db.search_sources", return_value=[]) as mock:
+            _run(server_module.handle_search_sources({"query": "голосні звуки"}))
+            mock.assert_called_once_with("голосні звуки", track="", limit=10)
+
+    def test_returns_json_payload(self, server_module):
+        mock_hits = [
+            {
+                "chunk_id": "ukwiki:test-1",
+                "corpus": "ukrainian_wiki",
+                "title": "Голосні звуки",
+                "text": "Голосні звуки творяться без перешкод.",
+                "final_score": 0.91,
+            }
+        ]
+        with patch("wiki.sources_db.search_sources", return_value=mock_hits) as mock:
+            result = _run(
+                server_module.handle_search_sources(
+                    {"query": "голосні звуки", "track": "a1", "limit": 5}
+                )
+            )
+            mock.assert_called_once_with("голосні звуки", track="a1", limit=5)
+            assert '"corpus": "ukrainian_wiki"' in result[0].text
+            assert '"chunk_id": "ukwiki:test-1"' in result[0].text
 
 
 class TestSSEStateless:


### PR DESCRIPTION
## Summary
Wires the `ukrainian_wiki` corpus (1424 chunks, compiled Ukrainian textbook pedagogy, ingested 2026-04-21) into v6 writer retrieval. Previously it was inert during module builds because the MCP server exposed only `search_text` (textbooks-only); this adds `search_sources` as the unified MCP entry point that includes `ukrainian_wiki` alongside textbooks, literary, Wikipedia, and external sources.

Refs EPIC #1365.

- AC-1: Added MCP tool `search_sources` in `.mcp/servers/sources/server.py` with additive dispatch/handler wiring; `search_text` behavior is unchanged
- AC-2: Updated active writer/research/review prompts so `search_sources` is the preferred default and `search_text` is explicitly textbook-only
- AC-3: Updated `claude_extensions/rules/mcp-sources-and-dictionaries.md` and `scripts/tools/codex_tool_instructions.md`
- AC-4: Sanity test passed against the populated project `sources.db` — the acceptance query returns `ukrainian_wiki` rows
- AC-5: Claude adversarial review completed; initial findings on the `v6-write` placeholder and optional-track semantics were addressed, and a follow-up pass reported no blocking issues

Backward-compatible: existing `search_text` callers see no behavior change.

## Test plan
- [x] Restarted the sources server from this worktree against the populated shared `sources.db` and verified `http://127.0.0.1:8766/health` returns `{"status":"ok"}`
- [x] `../../.venv/bin/python -m pytest tests/test_mcp_sources_server.py`
- [x] Direct Python sanity check for the acceptance query returns a `ukrainian_wiki` hit:

```bash
../../.venv/bin/python <<'PY'
import sys
from pathlib import Path
sys.path.insert(0, 'scripts')
from wiki import sources_db as sdb

sdb.SOURCES_DB_PATH = Path('/Users/krisztiankoos/projects/learn-ukrainian/data/sources.db')
sdb._conn = None
results = sdb.search_sources(query='голосні звуки', track='a1', limit=5)
print('count=', len(results))
print('corpora=', [row.get('corpus') for row in results])
uk_rows = [row for row in results if row.get('corpus') == 'ukrainian_wiki']
print('ukrainian_wiki_count=', len(uk_rows))
for row in uk_rows[:3]:
    print({
        'corpus': row.get('corpus'),
        'title': row.get('title'),
        'chunk_id': row.get('chunk_id'),
        'parent_key': row.get('parent_key'),
    })
PY
```

Sample output:

```text
count= 5
corpora= ['ukrainian_wiki', 'modern_literary', 'modern_literary', 'textbook_sections', 'textbook_sections']
ukrainian_wiki_count= 1
{'corpus': 'ukrainian_wiki', 'title': 'Граматика A2: Звуки і букви', 'chunk_id': 'metalanguage-phonetics:p8-8', 'parent_key': 'metalanguage-phonetics'}
```

- [ ] Smoke test: dispatch one A1 module rebuild via `v6_build.py` and confirm the writer calls `search_sources` during retrieval

## Notes
In this worktree, the tracked `data/sources.db` is not a populated build database, so the runtime sanity check and live-server restart were pointed at the populated shared project database for verification. No repository data files were modified for this.
