### PR TITLE
feat(retrieval): scenario-aware section excerpt selection (#1282)

### DIFF
--- a/scripts/build/phases/plan_contract.py
+++ b/scripts/build/phases/plan_contract.py
@@ -169,6 +169,7 @@ def build_contract(
     return contract, {
         "sections": compression["section_excerpts"],
         "factual_anchors": compression["factual_anchors"],
+        "selection_trace": compression.get("selection_trace", {}),
     }
 
 

--- a/scripts/build/phases/wiki_compressor.py
+++ b/scripts/build/phases/wiki_compressor.py
@@ -45,6 +45,29 @@ _STOPWORDS = {
     "has",
 }
 
+# Split article bodies on any level-2-or-deeper markdown heading.
+# Pedagogy wiki articles under `wiki/pedagogy/**` use `## Section` as their
+# primary structure (Методичний підхід, Послідовність введення, Приклади з
+# підручників, …). The previous `###+` pattern missed these H2s and collapsed
+# each article into one ~13KB "Overview" block — the trim-to-520-chars step
+# then only surfaced the generic pedagogical intro, never the concrete
+# dialogue/example sections a writer actually needs (see #1282).
+_HEADING_RE = re.compile(r"^##+\s+")
+
+# Section-name cues that indicate dialogue/role-play content. Used to append
+# the full scenario situation text to a dialogue section's ranking query
+# (stronger signal than the general scenario-token bonus).
+_DIALOGUE_SECTION_KEYWORDS = {
+    "dialogues",
+    "dialogue",
+    "діалоги",
+    "діалог",
+    "service",
+    "exchange",
+    "розмова",
+    "розмови",
+}
+
 
 def _tokenize(text: str) -> set[str]:
     normalized = unicodedata.normalize("NFKD", text or "")
@@ -104,9 +127,9 @@ def _split_article_blocks(path: str, body: str) -> list[dict]:
         })
 
     for line in lines:
-        if re.match(r"^###+?\s+", line):
+        if _HEADING_RE.match(line):
             flush()
-            heading = re.sub(r"^###+\s+", "", line).strip() or "Overview"
+            heading = re.sub(r"^##+\s+", "", line).strip() or "Overview"
             chunk = []
             continue
         chunk.append(line)
@@ -157,25 +180,80 @@ def _anchor_claim(excerpt: str) -> str:
     return parts[0].strip() if parts else excerpt.strip()
 
 
+def _build_scenario_tokens(plan: dict) -> set[str]:
+    """Return the set of scenario-context tokens derived from the plan.
+
+    Combines plan-level identity fields (``title``, ``subtitle``,
+    ``objectives``) with the full dialogue-situation context. The result is
+    used as a module-wide "what is this module actually about" signal so
+    ranking can promote blocks that describe the real scenario — not just
+    the per-section query tokens (#1282).
+    """
+    parts: list[str] = [
+        str(plan.get("title") or ""),
+        str(plan.get("subtitle") or ""),
+    ]
+    parts.extend(str(item) for item in (plan.get("objectives") or []))
+    for situation in (plan.get("dialogue_situations") or []):
+        parts.append(str(situation.get("setting", "")))
+        parts.append(str(situation.get("motivation", "")))
+        parts.extend(str(s) for s in (situation.get("speakers") or []))
+    return _tokenize(" ".join(parts))
+
+
+def _scenario_article_bonus(block_path: str, plan: dict) -> int:
+    """Return a bonus for blocks whose article path matches the plan slug.
+
+    Plans like ``at-the-cafe`` typically ship alongside a wiki article at
+    ``wiki/pedagogy/a1/at-the-cafe.md``. When that article is present in the
+    knowledge packet, its path contains the slug verbatim and we promote its
+    blocks so scenario-specific material outranks token-dense generic
+    articles (e.g. ``i-eat-i-drink.md`` matching cafe dialogues on shared
+    vocabulary like "їсти" / "пити") — the core #1282 problem.
+
+    Deliberately conservative: only a slug-substring match fires. We do not
+    score path-token overlap against arbitrary plan text, because that would
+    re-introduce the generic-wins-on-coincidence failure mode.
+    """
+    slug = str(plan.get("slug") or "").strip().lower()
+    if not slug or len(slug) < 3:
+        return 0
+    return 3 if slug in block_path.lower() else 0
+
+
 def compress_wiki_packet(
     plan: dict,
     wiki_packet: str,
     *,
     items_per_section: int = 2,
+    trace_size: int = 5,
 ) -> dict:
-    """Map wiki facts to plan sections and extract prompt-sized excerpts."""
+    """Map wiki facts to plan sections and extract prompt-sized excerpts.
+
+    Returns a dict with:
+      - ``section_excerpts``: picked top-``items_per_section`` excerpts per
+        section (fed into writer prompts).
+      - ``anchors_by_section`` / ``factual_anchors``: first-sentence anchors
+        used by the contract.
+      - ``selection_trace``: deterministic top-``trace_size`` candidate list
+        per section with full score breakdowns (query / scenario / article
+        bonuses and matched terms). Saved in ``wiki-excerpts.yaml`` for
+        inspectability (#1282 AC-3) without entering the writer prompt.
+    """
     sections = plan.get("content_outline") or []
     articles = _parse_wiki_articles(wiki_packet)
     result = {
         "section_excerpts": {},
         "anchors_by_section": defaultdict(list),
         "factual_anchors": [],
+        "selection_trace": {},
     }
 
     if not sections or not articles:
         return result
 
     all_blocks = [block for article in articles for block in article["blocks"]]
+    scenario_tokens = _build_scenario_tokens(plan)
     situation_text = " ".join(
         " ".join(
             [
@@ -186,7 +264,7 @@ def compress_wiki_packet(
         )
         for item in (plan.get("dialogue_situations") or [])
     )
-    dialogue_keywords = {"dialogues", "dialogue", "діалоги", "діалог", "service", "exchange"}
+
     for section in sections:
         name = str(section.get("section", "")).strip()
         if not name:
@@ -196,46 +274,72 @@ def compress_wiki_packet(
             + [str(point) for point in (section.get("points") or [])[:5]]
         )
         section_tokens = _tokenize(" ".join(query_parts))
-        if section_tokens & dialogue_keywords and situation_text:
+        if section_tokens & _DIALOGUE_SECTION_KEYWORDS and situation_text:
             query_parts.append(situation_text)
-        query = " ".join(query_parts)
-        query_tokens = _tokenize(query)
-        ranked: list[tuple[int, list[str], dict]] = []
+        query_tokens = _tokenize(" ".join(query_parts))
+
+        ranked: list[dict] = []
         for block in all_blocks:
-            score, overlap = _score_block(block, query_tokens)
-            if score > 0:
-                ranked.append((score, overlap, block))
-        ranked.sort(key=lambda item: (-item[0], item[2]["citation"]))
+            query_score, overlap = _score_block(block, query_tokens)
+            scenario_overlap = sorted(scenario_tokens & block["tokens"])
+            # Cap the scenario bonus so it enriches without dominating
+            # a well-matched per-section query on short sections.
+            scenario_score = min(len(scenario_overlap), 4)
+            article_score = _scenario_article_bonus(block["path"], plan)
+            total = query_score + scenario_score + article_score
+            if total > 0:
+                ranked.append({
+                    "block": block,
+                    "total": total,
+                    "query_score": query_score,
+                    "scenario_score": scenario_score,
+                    "article_score": article_score,
+                    "matched_terms": overlap,
+                    "scenario_terms": scenario_overlap[:6],
+                })
+        ranked.sort(key=lambda entry: (-entry["total"], entry["block"]["citation"]))
 
         seen_citations: set[str] = set()
         section_items: list[dict] = []
-        for score, overlap, block in ranked:
+        trace_entries: list[dict] = []
+        for entry in ranked:
+            block = entry["block"]
             citation = block["citation"]
             if citation in seen_citations:
                 continue
             seen_citations.add(citation)
-            excerpt = _trim_excerpt(block["text"])
-            item = {
+            breakdown = {
+                "query": entry["query_score"],
+                "scenario": entry["scenario_score"],
+                "article": entry["article_score"],
+            }
+            trace_entry = {
                 "citation": citation,
                 "source_path": block["path"],
                 "source_heading": block["heading"],
-                "matched_terms": overlap,
-                "score": score,
-                "excerpt": excerpt,
+                "score": entry["total"],
+                "score_breakdown": breakdown,
+                "matched_terms": entry["matched_terms"],
+                "scenario_terms": entry["scenario_terms"],
             }
-            section_items.append(item)
-            anchor = {
-                "section": name,
-                "claim": _anchor_claim(excerpt),
-                "citation": citation,
-                "matched_terms": overlap[:4],
-            }
-            result["anchors_by_section"][name].append(anchor)
-            result["factual_anchors"].append(anchor)
-            if len(section_items) >= items_per_section:
+            trace_entries.append(trace_entry)
+            if len(section_items) < items_per_section:
+                excerpt = _trim_excerpt(block["text"])
+                item = dict(trace_entry, excerpt=excerpt)
+                section_items.append(item)
+                anchor = {
+                    "section": name,
+                    "claim": _anchor_claim(excerpt),
+                    "citation": citation,
+                    "matched_terms": entry["matched_terms"][:4],
+                }
+                result["anchors_by_section"][name].append(anchor)
+                result["factual_anchors"].append(anchor)
+            if len(trace_entries) >= trace_size and len(section_items) >= items_per_section:
                 break
 
         result["section_excerpts"][name] = section_items
+        result["selection_trace"][name] = trace_entries
 
     result["anchors_by_section"] = dict(result["anchors_by_section"])
     return result

--- a/scripts/build/phases/wiki_compressor.py
+++ b/scripts/build/phases/wiki_compressor.py
@@ -281,22 +281,29 @@ def compress_wiki_packet(
         ranked: list[dict] = []
         for block in all_blocks:
             query_score, overlap = _score_block(block, query_tokens)
+            # Require at least one per-section query-token overlap before
+            # the scenario/article bonuses apply. Without this floor, a
+            # scenario-article block with zero section-relevance would beat
+            # a moderately-relevant generic block in a multi-section module
+            # (e.g. a grammar section inside a scenario module), starving
+            # the writer of actually-relevant generic context.
+            if query_score == 0:
+                continue
             scenario_overlap = sorted(scenario_tokens & block["tokens"])
             # Cap the scenario bonus so it enriches without dominating
             # a well-matched per-section query on short sections.
             scenario_score = min(len(scenario_overlap), 4)
             article_score = _scenario_article_bonus(block["path"], plan)
             total = query_score + scenario_score + article_score
-            if total > 0:
-                ranked.append({
-                    "block": block,
-                    "total": total,
-                    "query_score": query_score,
-                    "scenario_score": scenario_score,
-                    "article_score": article_score,
-                    "matched_terms": overlap,
-                    "scenario_terms": scenario_overlap[:6],
-                })
+            ranked.append({
+                "block": block,
+                "total": total,
+                "query_score": query_score,
+                "scenario_score": scenario_score,
+                "article_score": article_score,
+                "matched_terms": overlap,
+                "scenario_terms": scenario_overlap[:6],
+            })
         ranked.sort(key=lambda entry: (-entry["total"], entry["block"]["citation"]))
 
         seen_citations: set[str] = set()

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -3177,11 +3177,17 @@ def _format_contract_prompt_artifacts(
     section_map = excerpts.get("sections") or {}
     excerpt_payload: dict
     if section_title is None:
-        excerpt_payload = (
-            {"sections": section_map}
-            if mode == "write"
-            else excerpts
-        )
+        if mode == "write":
+            excerpt_payload = {"sections": section_map}
+        else:
+            # selection_trace is persisted to wiki-excerpts.yaml for
+            # inspectability (#1282 AC-3) but is not prompt material —
+            # strip it so it doesn't bloat the writer/review context.
+            excerpt_payload = {
+                key: value
+                for key, value in excerpts.items()
+                if key != "selection_trace"
+            }
     else:
         excerpt_payload = {
             "section": section_title,

--- a/tests/test_plan_contract.py
+++ b/tests/test_plan_contract.py
@@ -115,3 +115,161 @@ def test_wiki_compressor_uses_dialogue_situations_for_dialogue_sections() -> Non
 
     assert excerpts
     assert excerpts[0]["source_path"] == "pedagogy/a1/at-the-cafe.md"
+
+
+# #1282 — scenario-aware excerpt selection.
+#
+# The fixture below simulates the real failure mode the issue reported: a
+# scenario-specific wiki article (``at-the-cafe.md``) coexisting with a
+# generic, token-dense article (``i-eat-i-drink.md``) that could win on raw
+# overlap. Exercises (1) ##-heading split, (2) scenario-token + article-path
+# bonus, (3) determinism across repeated runs, (4) selection-trace shape.
+
+
+_CAFE_PLAN = {
+    "slug": "at-the-cafe",
+    "title": "У кафе",
+    "subtitle": "У кафе — замовлення, оплата та культура кафе",
+    "objectives": [
+        "Замовляти їжу та напої в українському кафе",
+        "Розуміти українську культуру кафе",
+    ],
+    "content_outline": [
+        {
+            "section": "Діалоги",
+            "words": 300,
+            "points": [
+                "Діалог 1 — Замовлення в кафе. — Добрий день! Ось меню.",
+                "Діалог 2 — Оплата рахунку. Можна карткою?",
+            ],
+        },
+        {
+            "section": "Як замовити",
+            "words": 300,
+            "points": ["Мені каву, будь ласка. Можна воду?"],
+        },
+    ],
+    "dialogue_situations": [
+        {
+            "setting": "Замовлення в кафе — кава, чай, тістечко, меню, рахунок",
+            "speakers": ["Клієнт", "Офіціантка"],
+            "motivation": "Замовлення та оплата в українському кафе",
+        }
+    ],
+    "activity_hints": [{"id": "quiz", "type": "quiz", "focus": "x"}],
+    "word_target": 1200,
+}
+
+
+_CAFE_PACKET = (
+    # A realistic generic article — food/drink verbs and vocabulary, but no
+    # cafe-specific ordering / payment vocabulary. This is the kind of
+    # article that coexists in the same knowledge packet as the scenario
+    # one and that the ranker must not over-promote on shared food tokens.
+    "### Вікі: pedagogy/a1/i-eat-i-drink.md\n\n"
+    "## Методичний підхід\n\n"
+    "Дієслова їсти і пити на рівні A1. Базова харчова лексика: хліб, "
+    "молоко, сік, чай, кава, вода. Відмінювання теперішнього часу. "
+    "Формування простих речень про харчування вдома.\n\n"
+    "## Приклади\n\n"
+    "Я їм хліб. Я п'ю молоко. Ти їси суп. Він п'є чай вранці.\n\n"
+    # The scenario-specific article — shares some food tokens with the
+    # generic one (кава, чай, вода) but owns the cafe-situation vocabulary.
+    "### Вікі: pedagogy/a1/at-the-cafe.md\n\n"
+    "## Методичний підхід\n\n"
+    "Сценарій кафе — основа комунікативного навчання A1. Ввічливе "
+    "замовлення, оплата рахунку, культура чайових у кафе.\n\n"
+    "## Приклади з підручників\n\n"
+    "Добрий день, ось меню. Мені каву, будь ласка. Можна рахунок, будь "
+    "ласка? Так, звичайно. З вас 250 гривень. Оплата карткою чи "
+    "готівкою?\n"
+)
+
+
+def test_wiki_compressor_promotes_scenario_article_over_generic_token_winner() -> None:
+    """#1282 AC-1/AC-2: scenario-specific article wins over a generic
+    article with higher raw token overlap.
+
+    ``i-eat-i-drink.md`` is padded with cafe-adjacent tokens on purpose so
+    the pre-fix ranker would score it competitively; the fix must still pick
+    ``at-the-cafe.md`` thanks to the plan-slug article bonus."""
+    compression = compress_wiki_packet(_CAFE_PLAN, _CAFE_PACKET)
+    dialog_items = compression["section_excerpts"]["Діалоги"]
+    assert dialog_items, "Діалоги section must have picks"
+    assert dialog_items[0]["source_path"] == "pedagogy/a1/at-the-cafe.md"
+    assert dialog_items[0]["score_breakdown"]["article"] == 3
+    assert dialog_items[0]["score_breakdown"]["scenario"] >= 1
+
+
+def test_wiki_compressor_splits_on_h2_headings() -> None:
+    """#1282 root cause: pedagogy articles use ``##`` headings, so block
+    splitting must fire on ``##`` not only ``###``. Otherwise each article
+    collapses to a single giant "Overview" block that truncates away the
+    concrete example sections writers rely on."""
+    compression = compress_wiki_packet(_CAFE_PLAN, _CAFE_PACKET)
+    trace = compression["selection_trace"]["Діалоги"]
+    headings = {entry["source_heading"] for entry in trace}
+    # Both ##-headed sub-sections of at-the-cafe.md must be addressable as
+    # separate blocks; the generic-article sub-sections too.
+    assert "Приклади з підручників" in headings
+    assert "Методичний підхід" in headings
+
+
+def test_wiki_compressor_is_deterministic() -> None:
+    """#1282 AC-3: repeated runs on the same inputs must produce byte-for-byte
+    identical section picks and selection traces."""
+    r1 = compress_wiki_packet(_CAFE_PLAN, _CAFE_PACKET)
+    r2 = compress_wiki_packet(_CAFE_PLAN, _CAFE_PACKET)
+    assert r1["section_excerpts"] == r2["section_excerpts"]
+    assert r1["selection_trace"] == r2["selection_trace"]
+
+
+def test_wiki_compressor_selection_trace_ranked_and_inspectable() -> None:
+    """#1282 AC-3: the selection trace persists the ranked candidate list
+    with per-dimension score breakdowns so the choice is auditable."""
+    compression = compress_wiki_packet(_CAFE_PLAN, _CAFE_PACKET)
+    trace = compression["selection_trace"]["Діалоги"]
+    assert len(trace) >= 2
+    # Ranked descending by total score (ties broken by citation).
+    scores = [entry["score"] for entry in trace]
+    assert scores == sorted(scores, reverse=True)
+    for entry in trace:
+        breakdown = entry["score_breakdown"]
+        assert set(breakdown.keys()) == {"query", "scenario", "article"}
+        assert entry["score"] == breakdown["query"] + breakdown["scenario"] + breakdown["article"]
+
+
+def test_wiki_compressor_fallback_when_no_scenario_article_present() -> None:
+    """When the packet has no article matching the plan slug, ranking falls
+    back to query + capped scenario overlap — the generic article still
+    surfaces something useful instead of crashing or returning empty.
+
+    Guards against over-fitting to the cafe case (an explicit Gemini
+    adversarial-review concern)."""
+    packet = (
+        "### Вікі: pedagogy/a1/i-eat-i-drink.md\n\n"
+        "## Overview\n\n"
+        "Я їм хліб. Я п'ю чай. Кава, чай, вода, сік. Замовлення, меню, "
+        "будь ласка.\n"
+    )
+    compression = compress_wiki_packet(_CAFE_PLAN, packet)
+    dialog_items = compression["section_excerpts"]["Діалоги"]
+    assert dialog_items, "Must still pick a fallback even without scenario article"
+    assert dialog_items[0]["source_path"] == "pedagogy/a1/i-eat-i-drink.md"
+    assert dialog_items[0]["score_breakdown"]["article"] == 0
+
+
+def test_build_contract_persists_selection_trace_in_artifact() -> None:
+    """#1282 AC-3: the wiki-excerpts.yaml artifact must carry the trace so
+    reviewers can inspect why each section got its picks."""
+    packet = _CAFE_PACKET
+    _, excerpts = build_contract(
+        _CAFE_PLAN,
+        packet,
+        level="a1",
+        slug="at-the-cafe",
+        module_num=38,
+    )
+    assert "selection_trace" in excerpts
+    assert excerpts["selection_trace"]["Діалоги"]
+    assert excerpts["sections"]["Діалоги"][0]["source_path"] == "pedagogy/a1/at-the-cafe.md"

--- a/tests/test_plan_contract.py
+++ b/tests/test_plan_contract.py
@@ -259,6 +259,76 @@ def test_wiki_compressor_fallback_when_no_scenario_article_present() -> None:
     assert dialog_items[0]["score_breakdown"]["article"] == 0
 
 
+def test_wiki_compressor_generic_article_wins_for_non_scenario_section() -> None:
+    """#1282 Gemini adversarial-review finding: a scenario-specific article
+    must not monopolise every section of a multi-section module. When a
+    section (e.g. a grammar breakdown) has zero query overlap with the
+    scenario article's blocks, the generic article's relevant block must
+    win — otherwise the article-path + scenario bonuses starve the writer
+    of the actually-relevant generic context.
+
+    Regression for the ``query_score == 0 → skip`` relevance floor."""
+    plan = {
+        "slug": "at-the-cafe",
+        "title": "У кафе",
+        "subtitle": "Сценарій замовлення у кафе",
+        "objectives": ["Замовляти їжу у кафе"],
+        "content_outline": [
+            {
+                "section": "Діалоги",
+                "words": 300,
+                "points": ["Замовлення в кафе — кава, меню, рахунок."],
+            },
+            {
+                "section": "Знахідний відмінок",
+                "words": 300,
+                "points": [
+                    "Знахідний відмінок іменника чоловічого роду: живі "
+                    "істоти отримують закінчення -а, -я; неживі — нульове.",
+                ],
+            },
+        ],
+        "dialogue_situations": [
+            {
+                "setting": "Замовлення у кафе — кава, меню, рахунок",
+                "speakers": ["Клієнт", "Офіціантка"],
+                "motivation": "Ввічливе замовлення",
+            }
+        ],
+        "activity_hints": [{"id": "quiz", "type": "quiz", "focus": "x"}],
+        "word_target": 600,
+    }
+    packet = (
+        # Scenario-specific article but its only block is pure cafe
+        # dialogue — zero content about the accusative case.
+        "### Вікі: pedagogy/a1/at-the-cafe.md\n\n"
+        "## Приклади з підручників\n\n"
+        "Мені каву, будь ласка. Можна меню? Рахунок, будь ласка.\n\n"
+        # Generic grammar article — carries the tokens the grammar section
+        # actually asks about.
+        "### Вікі: grammar/accusative-case.md\n\n"
+        "## Закінчення\n\n"
+        "Знахідний відмінок іменника чоловічого роду: живі істоти "
+        "отримують закінчення -а, -я; неживі зберігають нульове "
+        "закінчення.\n"
+    )
+    compression = compress_wiki_packet(plan, packet)
+
+    dialog_picks = compression["section_excerpts"]["Діалоги"]
+    assert dialog_picks, "Scenario-aligned section must have picks"
+    assert dialog_picks[0]["source_path"] == "pedagogy/a1/at-the-cafe.md"
+
+    grammar_picks = compression["section_excerpts"]["Знахідний відмінок"]
+    assert grammar_picks, "Grammar section must surface the grammar article"
+    assert grammar_picks[0]["source_path"] == "grammar/accusative-case.md"
+    # And the scenario article must not appear at all for the grammar
+    # section, since its one block has zero query overlap there.
+    assert not any(
+        item["source_path"] == "pedagogy/a1/at-the-cafe.md"
+        for item in grammar_picks
+    )
+
+
 def test_build_contract_persists_selection_trace_in_artifact() -> None:
     """#1282 AC-3: the wiki-excerpts.yaml artifact must carry the trace so
     reviewers can inspect why each section got its picks."""


### PR DESCRIPTION
## Summary
Improves wiki excerpt selection for sections whose plan/scenario clearly maps to a specific wiki article (e.g., A1/M18 Dialogues → `at-the-cafe.md`). Selection stays deterministic + inspectable.

**Root causes fixed:**

1. **H2 split** — `_split_article_blocks` only split on `###+` headings, but pedagogy wikis (`wiki/pedagogy/**`) use `##` as their primary structure (Методичний підхід, Послідовність введення, Приклади з підручників, …). Each article collapsed to one ~13KB "Overview" block that trim-to-520-chars then surfaced as generic meta-narration — never the concrete dialogue/example content the writer needs.
2. **Generic wins on shared vocab** — ranking was pure per-section token overlap, so a generic article with high raw overlap on shared vocabulary (їсти/пити, будь ласка) could outrank a scenario-specific article even when the plan slug clearly matched one article's path.
3. **No selection trace** — reviewers couldn't see why a given excerpt was chosen.

**Fix:**
- Split on `##+` headings; add scenario-token bonus (capped at 4) from plan `title`/`subtitle`/`objectives`/`dialogue_situations` and a +3 bonus when the block's article path contains `plan.slug` verbatim.
- Require `query_score > 0` floor so scenario/article bonuses never promote a block with zero per-section relevance (Gemini blocker finding).
- Emit `selection_trace` per section with per-dimension `score_breakdown` {query, scenario, article} + matched/scenario terms. Persisted to `wiki-excerpts.yaml` for inspectability; stripped from writer prompts to avoid bloat.
- Deterministic sort: `(-total, citation)` plus `sorted()` on set intersections.

**Acceptance criteria:**
- AC-1: scenario/setting cues from plan now feed excerpt ranking ✓
- AC-2: A1/M18 Dialogues now surfaces at-the-cafe.md blocks (Словниковий мінімум / Послідовність введення / Приклади з підручників) — verified on real packet, see PR description comments ✓
- AC-3: determinism preserved (regression test); orchestration artifact captures full selection trace ✓
- AC-4: 7 regression tests — scenario promotion, H2 split, determinism, trace shape, no-scenario fallback, multi-section fallback, artifact persistence ✓
- AC-5: Gemini adversarial review (2 findings addressed: blocker `query_score>0` floor + major multi-section test gap) ✓

Closes #1282.

## Test plan
- [ ] `.venv/bin/pytest tests/test_plan_contract.py tests/test_v6_contract_flow.py tests/test_build_knowledge_packet.py -v` — all green (72 pass locally)
- [ ] Manual: rebuild A1/M18 packet, inspect `wiki-excerpts.yaml` — café content (Словниковий мінімум / Приклади з підручників) present in Dialogues section, `selection_trace` populated
- [ ] Manual: rebuild a non-scenario-matching slug (e.g. a grammar module), confirm fallback to generic excerpts works and no leaked scenario-article blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)