### PR TITLE
test(auth): align 2 tests with always-subscription policy

### DIFF
--- a/tests/test_batch_gemini_runner_env.py
+++ b/tests/test_batch_gemini_runner_env.py
@@ -128,13 +128,18 @@ def test_env_stripped_when_oauth_present(tmp_path, monkeypatch):
     assert "GOOGLE_APPLICATION_CREDENTIALS" not in env
 
 
-def test_env_kept_when_oauth_absent(tmp_path, monkeypatch):
+def test_env_stripped_when_oauth_absent_under_always_subscription(tmp_path, monkeypatch):
+    """Always-subscription policy (2026-04-23, post-#1416): API-key envs are
+    stripped unconditionally unless the caller explicitly requests
+    ``GEMINI_AUTH_MODE=api``. Whether oauth creds are on disk is irrelevant —
+    the Ultra subscription is the canonical path. See commit 4f0fae3c0b.
+    """
     _result, popen_capture = _invoke_with_captured_env(
         tmp_path, monkeypatch, oauth_creds=False,
     )
 
     env = popen_capture.calls[0]["kwargs"]["env"]
-    assert env["GEMINI_API_KEY"] == "test-api-key"
+    assert "GEMINI_API_KEY" not in env
 
 
 def test_explicit_subscription_mode_strips(tmp_path, monkeypatch):
@@ -144,6 +149,18 @@ def test_explicit_subscription_mode_strips(tmp_path, monkeypatch):
 
     env = popen_capture.calls[0]["kwargs"]["env"]
     assert "GEMINI_API_KEY" not in env
+
+
+def test_explicit_api_mode_keeps_env_key(tmp_path, monkeypatch):
+    """Escape hatch: ``GEMINI_AUTH_MODE=api`` is the only way to preserve the
+    API-key env under always-subscription policy. Ensures the opt-out actually
+    works for one-off debug runs."""
+    _result, popen_capture = _invoke_with_captured_env(
+        tmp_path, monkeypatch, oauth_creds=False, auth_mode="api",
+    )
+
+    env = popen_capture.calls[0]["kwargs"]["env"]
+    assert env["GEMINI_API_KEY"] == "test-api-key"
 
 
 def test_return_shape_preserved(tmp_path):

--- a/tests/test_issues_auth_api.py
+++ b/tests/test_issues_auth_api.py
@@ -177,7 +177,10 @@ def test_runtime_auth_invalid_mode_uses_default_resolution(monkeypatch, tmp_path
     monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: fake_home))
 
     body = client.get("/api/runtime/auth").json()
-    assert body["gemini"]["auth_mode"] == "api"
+    # Always-subscription policy (2026-04-23, post-#1416): any mode other
+    # than an explicit ``api`` resolves to subscription, including invalid
+    # values. See ``resolve_gemini_auth_mode`` + commit 4f0fae3c0b.
+    assert body["gemini"]["auth_mode"] == "subscription"
     # Raw is NOT echoed — just flagged as invalid with a length.
     assert body["gemini"]["auth_mode_raw_valid"] is False
     assert body["gemini"]["auth_mode_raw_length"] == len("bogus-value")


### PR DESCRIPTION
## Summary
- Commit `4f0fae3c0b` (always-subscription policy) updated `tests/test_gemini_adapter_auth.py` but missed 2 other auth-related tests — they fail on main today.
- This PR realigns them with the new policy so the full suite is green.

## Changes
- `tests/test_issues_auth_api.py::test_runtime_auth_invalid_mode_uses_default_resolution` — assertion flipped from `"api"` → `"subscription"`. Under the always-subscription resolver, any non-`api` value (including invalid strings) resolves to `subscription`.
- `tests/test_batch_gemini_runner_env.py::test_env_kept_when_oauth_absent` — premise was "oauth absent ⇒ keep API key env as fallback", now obsolete. Renamed to `test_env_stripped_when_oauth_absent_under_always_subscription` with reversed assertion; added `test_explicit_api_mode_keeps_env_key` covering the `GEMINI_AUTH_MODE=api` escape hatch.

## Test plan
- [x] `tests/test_gemini_adapter_auth.py` + `tests/test_issues_auth_api.py` + `tests/test_batch_gemini_runner_env.py` — 68 passed locally
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)