### PR TITLE
fix(retrieval): populate ukrainian_wiki dense embeddings + close ingest→encode gap

### DIFF
--- a/scripts/wiki/ukrainian_wiki_corpus.py
+++ b/scripts/wiki/ukrainian_wiki_corpus.py
@@ -10,6 +10,7 @@ import statistics
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from audit.checks.cross_file_integrity import extract_ukrainian_words
 from audit.checks.russicism_detection import check_russicisms
@@ -216,6 +217,31 @@ def migrate_ukrainian_wiki_corpus(
     finally:
         conn.close()
     ensure_ukrainian_wiki_manifest(manifest_db)
+
+
+def encode_ukrainian_wiki_corpus(
+    *,
+    db_path: Path = DEFAULT_DB_PATH,
+    manifest_db: Path = DEFAULT_MANIFEST_DB,
+    encoder: Any | None = None,
+    progress_callback: Any | None = None,
+) -> dict[str, Any]:
+    """Encode all ``ukrainian_wiki`` passages into the manifest-backed shard index.
+
+    Thin wrapper around :func:`wiki.dense_rerank.cold_encode_corpus` so that
+    ingestion callers do not have to import the heavier dense-rerank module to
+    close the ingest→encode loop. Tests inject ``encoder`` to bypass MLX.
+    """
+
+    from .dense_rerank import cold_encode_corpus
+
+    return cold_encode_corpus(
+        UKRAINIAN_WIKI_CORPUS,
+        db_path=db_path,
+        manifest_db=manifest_db,
+        encoder=encoder,
+        progress_callback=progress_callback,
+    )
 
 
 def _utc_now() -> str:
@@ -1000,6 +1026,15 @@ def _build_parser() -> argparse.ArgumentParser:
                         help=f"Minimum characters for a kept chunk after splitting (default: {DEFAULT_CHUNK_MIN_CHARS}).")
     parser.add_argument("--min-vesum-coverage", type=float, default=DEFAULT_VESUM_MIN_COVERAGE,
                         help=f"Minimum Vesum/Pravopys coverage ratio for single-article ingest (default: {DEFAULT_VESUM_MIN_COVERAGE}).")
+    parser.add_argument(
+        "--encode",
+        action="store_true",
+        help=(
+            "After ingestion, encode any new/changed passages into the dense "
+            "index (calls cold_encode_corpus). Required for search_sources "
+            "dense reranking to surface the ingested passages."
+        ),
+    )
     return parser
 
 
@@ -1024,6 +1059,11 @@ def main(argv: list[str] | None = None) -> int:
             "skipped_chunks": sum(result.skipped_chunks for result in results),
             "report_path": _relative_or_absolute(args.report_path),
         }
+        if args.encode:
+            summary["encode"] = encode_ukrainian_wiki_corpus(
+                db_path=args.db_path,
+                manifest_db=args.manifest_db,
+            )
         print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
         return 0 if summary["articles_failed"] == 0 else 1
 
@@ -1038,6 +1078,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     print(report.to_json())
     print(f"inserted_passages={inserted}")
+    if args.encode and report.passed:
+        encode_summary = encode_ukrainian_wiki_corpus(
+            db_path=args.db_path,
+            manifest_db=args.manifest_db,
+        )
+        print(f"encode={json.dumps(encode_summary, ensure_ascii=False, sort_keys=True)}")
     return 0 if report.passed else 1
 
 

--- a/tests/wiki/test_ukrainian_wiki_corpus.py
+++ b/tests/wiki/test_ukrainian_wiki_corpus.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
@@ -12,6 +14,43 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from wiki.embedding_manifest import EmbeddingManifest
 
 from wiki import dense_rerank, sources_db, ukrainian_wiki_corpus
+
+
+class _FakeTokenizer:
+    def encode(
+        self,
+        text: str,
+        add_special_tokens: bool = True,
+        truncation: bool = True,
+        max_length: int | None = None,
+    ) -> list[int]:
+        tokens = list(range(1, len(text.split()) + 1))
+        if max_length is not None:
+            limit = max_length - (2 if add_special_tokens else 0)
+            tokens = tokens[:limit]
+        if add_special_tokens:
+            return [0, *tokens, 1]
+        return tokens
+
+
+class _FakeEncoder:
+    def encode(self, texts: list[str], batch_size: int = 16, max_length: int = 512) -> np.ndarray:
+        vectors: list[np.ndarray] = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode("utf-8")).digest()
+            seed = np.frombuffer(digest * 64, dtype=np.uint8)[: dense_rerank.EMBEDDING_DIMS].astype(np.float32)
+            vector = seed / np.clip(np.linalg.norm(seed), 1e-12, None)
+            vectors.append(vector.astype(np.float16))
+        return np.stack(vectors, axis=0)
+
+
+def _install_fake_encoder(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_tokenizer = _FakeTokenizer()
+    fake_encoder = _FakeEncoder()
+    monkeypatch.setattr(dense_rerank, "_TOKENIZER", fake_tokenizer)
+    monkeypatch.setattr(dense_rerank, "_get_tokenizer", lambda: fake_tokenizer)
+    monkeypatch.setattr(dense_rerank, "_ENCODER", fake_encoder)
+    monkeypatch.setattr(dense_rerank, "_get_encoder", lambda: fake_encoder)
 
 
 def _article_with_registry(
@@ -443,3 +482,154 @@ def test_batch_ingest_directory_is_idempotent_and_writes_report(
     assert len(results) == 1
     assert results[0]["corpus"] == "ukrainian_wiki"
     assert results[0]["title"] == "Наголос"
+
+
+def test_encode_flag_populates_manifest_units_matching_search_unit_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the zero-embedding gap: ingest only fills SQLite,
+    so ``--encode`` (or ``encode_ukrainian_wiki_corpus``) must populate the
+    manifest with unit rows whose keys match the ``ukrainian_wiki:{passage_id}``
+    format that ``_search_ukrainian_wiki_candidates`` emits — otherwise the
+    dense reranker silently drops every ukrainian_wiki candidate to score 0
+    and they lose to every other corpus in the final sort.
+    """
+
+    article = _article_with_registry(
+        tmp_path,
+        slug="kolory",
+        text=(
+            "# Кольори\n\n"
+            "Кольори допомагають описувати предмети довкола нас [S1]. "
+            "Червоний, синій, жовтий і зелений — це базова лексика для A1.\n\n"
+            "Учень використовує ці слова, щоб говорити про одяг, природу "
+            "і прості сцени з повсякденного життя.\n"
+        ),
+    )
+    db_path = tmp_path / "sources.db"
+    manifest_path = tmp_path / "embeddings" / "manifest.db"
+
+    monkeypatch.setattr(
+        ukrainian_wiki_corpus,
+        "vesum_batch_lookup",
+        lambda words: {word: [{"word": word}] for word in words},
+    )
+    monkeypatch.setattr(ukrainian_wiki_corpus, "check_russicisms", lambda text, file_path="": [])
+    monkeypatch.setattr(ukrainian_wiki_corpus, "pravopys_lookup", lambda term: {"term": term})
+    monkeypatch.setattr(ukrainian_wiki_corpus, "search_style_guide", lambda term: [])
+    _install_fake_encoder(monkeypatch)
+
+    report, inserted = ukrainian_wiki_corpus.ingest_article(
+        article,
+        db_path=db_path,
+        manifest_db=manifest_path,
+        min_words=5,
+        max_chars=1000,
+        min_vesum_coverage=0.5,
+    )
+    assert report.passed is True
+    assert inserted >= 1
+
+    manifest = EmbeddingManifest(manifest_path)
+    try:
+        active_before = manifest.active_units_for_corpus("ukrainian_wiki")
+    finally:
+        manifest.close()
+    assert active_before == [], (
+        "ingest alone must not encode — encode step is explicit so MLX is not "
+        "triggered unintentionally"
+    )
+
+    encode_summary = ukrainian_wiki_corpus.encode_ukrainian_wiki_corpus(
+        db_path=db_path,
+        manifest_db=manifest_path,
+    )
+    assert encode_summary["status"] == "encoded"
+    assert encode_summary["encoded_units"] == inserted
+
+    passage_ids = _fetch_passage_ids(db_path)
+    manifest = EmbeddingManifest(manifest_path)
+    try:
+        active_after = manifest.active_units_for_corpus("ukrainian_wiki")
+    finally:
+        manifest.close()
+
+    assert len(active_after) == inserted
+    encoded_keys = {row.unit_key for row in active_after}
+    expected_keys = {f"ukrainian_wiki:{pid}" for pid in passage_ids}
+    assert encoded_keys == expected_keys, (
+        "unit_key format must match _search_ukrainian_wiki_candidates so the "
+        "dense reranker can look up vectors by unit_key"
+    )
+
+    second = ukrainian_wiki_corpus.encode_ukrainian_wiki_corpus(
+        db_path=db_path,
+        manifest_db=manifest_path,
+    )
+    assert second["status"] == "up_to_date"
+    assert second["encoded_units"] == 0
+
+
+def _fetch_passage_ids(db_path: Path) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return [row[0] for row in conn.execute("SELECT passage_id FROM ukrainian_wiki ORDER BY id")]
+    finally:
+        conn.close()
+
+
+def test_main_cli_encode_flag_wires_ingest_to_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--encode on the CLI must trigger encoding after a successful ingest."""
+
+    article = _article_with_registry(
+        tmp_path,
+        slug="simya",
+        text=(
+            "# Сім'я\n\n"
+            "Сім'я — це найближчі люди поряд з учнем [S1]. "
+            "Мама, тато, брат і сестра дають першу лексику для A1.\n\n"
+            "Учень описує свою родину простими реченнями.\n"
+        ),
+    )
+    db_path = tmp_path / "sources.db"
+    manifest_path = tmp_path / "embeddings" / "manifest.db"
+
+    monkeypatch.setattr(
+        ukrainian_wiki_corpus,
+        "vesum_batch_lookup",
+        lambda words: {word: [{"word": word}] for word in words},
+    )
+    monkeypatch.setattr(ukrainian_wiki_corpus, "check_russicisms", lambda text, file_path="": [])
+    monkeypatch.setattr(ukrainian_wiki_corpus, "pravopys_lookup", lambda term: {"term": term})
+    monkeypatch.setattr(ukrainian_wiki_corpus, "search_style_guide", lambda term: [])
+    _install_fake_encoder(monkeypatch)
+
+    exit_code = ukrainian_wiki_corpus.main(
+        [
+            str(article),
+            "--db-path",
+            str(db_path),
+            "--manifest-db",
+            str(manifest_path),
+            "--min-words",
+            "5",
+            "--max-chars",
+            "1000",
+            "--min-vesum-coverage",
+            "0.5",
+            "--encode",
+        ]
+    )
+    assert exit_code == 0
+
+    manifest = EmbeddingManifest(manifest_path)
+    try:
+        active = manifest.active_units_for_corpus("ukrainian_wiki")
+    finally:
+        manifest.close()
+    assert len(active) >= 1
+    assert all(row.unit_key.startswith("ukrainian_wiki:") for row in active)


### PR DESCRIPTION
## Problem

`search_sources()` returned **zero** `ukrainian_wiki` hits to writers even though the FTS5 table had 1424 rows. Every A1/A2 build since PR #1411 was effectively getting zero wiki grounding — matching the 'thin-corpus' problem the wiki build was supposed to fix. A.8 canary was cancelled twice awaiting per-dim reviewer; without this fix even a passing canary would have measured the wrong corpus.

**Root cause:** `ingest_ukrainian_wiki.py` only writes FTS rows + reserves a zero-row manifest shard via `reserve_corpus_shard`. Nothing ever called `cold_encode_corpus('ukrainian_wiki')`, so the manifest held 0 unit rows despite 1424 FTS rows. `rerank_candidates` (scripts/wiki/dense_rerank.py:484) then looks up each candidate's `unit_key` in an empty `unit_rows` map, assigns `dense_score=0.0`, and the final sort drops every ukrainian_wiki hit below non-zero hits from other corpora.

PR #1411 added the corpus to the search dispatch path but left the encode step out.

## Fix — data side (already run in this worktree)

`.venv/bin/python scripts/wiki/cold_encode.py --corpora ukrainian_wiki --resume`

- vacuumed the pre-existing zero-row reserved shard first so numbering starts at shard-000001
- produced `shard-000001.npy (1000, 1024) float16` + `shard-000002.npy (424, 1024) float16`
- manifest now has **1424 active units** with `unit_key = ukrainian_wiki:{passage_id}` — the exact format `_search_ukrainian_wiki_candidates` emits (`scripts/wiki/sources_db.py:603`)
- encoder: `bge-m3-mlx-fp16` (same as every other corpus), MAX_LENGTH=512, 57.7s total on-device

Embedding data is gitignored (`data/embeddings/`), so the artefacts are not in this PR — but the code changes below prevent silent regression.

## Fix — code side (so this can't silently regress)

- **`ukrainian_wiki_corpus.encode_ukrainian_wiki_corpus()`** — thin wrapper around `cold_encode_corpus`. Lazy-imports `dense_rerank` so the ingest script stays light when `--encode` is off.
- **`--encode` flag on `ingest_ukrainian_wiki.py`**, default OFF. When set, encode runs right after a successful ingest so the dense index can't lag the FTS table. Default-off preserves existing behaviour and keeps MLX out of unintended code paths.
- **Two regression tests** pin the invariant that caught this bug:
  1. ingest alone MUST NOT populate the manifest (separation of concerns)
  2. after `encode_ukrainian_wiki_corpus()`, every SQLite passage has a matching `ukrainian_wiki:{passage_id}` unit row in the manifest — the exact format dense rerank looks up

## Acceptance criteria (all met)

- [x] `data/embeddings/ukrainian_wiki/shard-*.npy` → `(1000, 1024)` + `(424, 1024)` = 1424 rows (split across 2 shards per `SEQUENTIAL_SHARD_LIMIT=1000`, consistent with other corpora)
- [x] `SELECT COUNT(*) FROM embedding_units WHERE corpus='ukrainian_wiki'` → **1424**
- [x] `search_sources('кольори ...', track='a1', limit=8)` → **5 ukrainian_wiki hits** in top 8 with dense_score 0.48–0.54
- [x] `search_sources('родина сім\\'я ...', track='a1', limit=8)` → **3 ukrainian_wiki hits** in top 8 from the my-family article
- [x] No regression on other corpora — `pytest tests/wiki/ tests/rag/ tests/test_build_sources_db_safety.py` → 90 passed, 1 skipped (was 88 passed before the new tests)
- [x] Commit body includes full verification output for steps 4 and 5

## Verification output

**Step 4 — `кольори basic Ukrainian vocabulary`, track=a1, limit=8:**
```
total: 8  by_corpus: {'ukrainian_wiki': 5, 'textbook_sections': 3}
  1. ukrainian_wiki       dense=0.5402  Педагогіка A1: Colors
  2. ukrainian_wiki       dense=0.5239  Педагогіка A1: Colors
  3. ukrainian_wiki       dense=0.52    Педагогіка A1: Colors
  4. ukrainian_wiki       dense=0.5086  Педагогіка A1: Colors
  5. textbook_sections    dense=0.4664  УМОВНІ ПОЗНАЧЕННЯ
  6. textbook_sections    dense=0.4598  Г. Напишіть твір-опис пам'ятки культури
  7. ukrainian_wiki       dense=0.4822  Педагогіка A1: Colors
  8. textbook_sections    dense=0.4311  СЛОВА, ЯКІ НАЗИВАЮТЬ ОЗНАКИ ПРЕДМЕТІВ
```

**Step 5 — `родина сім'я family`, track=a1, limit=8:**
```
total: 8  by_corpus: {'textbook_sections': 5, 'ukrainian_wiki': 3}
  1. textbook_sections    dense=0.4587  НАВЧАЮСЯ ВЖИВАТИ ІМЕННИКИ…
  2. ukrainian_wiki       dense=0.4726  Педагогіка A1: My Family
  3. ukrainian_wiki       dense=0.4622  Педагогіка A1: My Family
  4. textbook_sections    dense=0.4255  Катерина Перелісна. МАМИ Й ДОНІ
  5. textbook_sections    dense=0.4217  Відомості із синтаксису
  6. textbook_sections    dense=0.4134  Зачин
  7. textbook_sections    dense=0.4062  Іван Нечуй-Левицький
  8. ukrainian_wiki       dense=0.4261  Педагогіка A1: My Story
```

## Related

- **PR #1411** — added search dispatch for `ukrainian_wiki` but never populated embeddings
- **EPIC #1349** — Ukrainian wiki corpus
- **ADR-007** — no hard grade filter (explicitly not doing that here)

## Test plan

- [x] `.venv/bin/python -m pytest tests/wiki/test_ukrainian_wiki_corpus.py -q` — 11 passed
- [x] `.venv/bin/python -m pytest tests/wiki/ tests/rag/ tests/test_build_sources_db_safety.py -q` — 90 passed, 1 skipped
- [x] Manual: cold_encode.py writes correct shards + manifest rows (1424 units, 2 shards)
- [x] Manual: `search_sources` returns ukrainian_wiki hits for кольори + родина queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)