### PR TITLE
fix(wiki): resolve source attribution from sources.db (#1434)

### DIFF
--- a/scripts/wiki/compiler.py
+++ b/scripts/wiki/compiler.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from ai_llm.fallback import CallResult, call_gemini_with_fallback, visible_sleep
 
 from .config import GEMINI_MODEL, PROMPTS_DIR, TRACK_DOMAINS, WIKI_DIR
+from .source_attribution import resolve_chunk_attribution
 from .sources_schema import (
+    WikiSourceEntry,
     WikiSourcesRegistry,
     assign_source_ids,
     extract_short_citation_ids,
@@ -214,15 +216,12 @@ def _inject_generated_by_model(article_text: str, *, model_used: str | None) -> 
     model = _normalize_generated_by_model(model_used)
     body = match.group("body").strip()
     lines = [line.rstrip() for line in body.splitlines()]
+    lines = [line for line in lines if not line.strip().startswith("generated_by_model:")]
     updated: list[str] = []
     inserted = False
 
     for line in lines:
         stripped = line.strip()
-        if stripped.startswith("generated_by_model:"):
-            updated.append(f"generated_by_model: {model}")
-            inserted = True
-            continue
         updated.append(line)
         if stripped.startswith("compiled:"):
             updated.append(f"generated_by_model: {model}")
@@ -314,16 +313,25 @@ def _build_sources_registry(
     S1/S6/S8 that never end up in the YAML. (Surfaced 2026-04-18 when
     the 45k→60k cap bump changed the chunk selection.)
     """
-    source_files: list[str] = []
+    attributed_sources: list[dict[str, object]] = []
     seen: set[str] = set()
     for source in sources:
-        chunk_id = normalize_source_filename(str(source.get("chunk_id", "")))
-        if not chunk_id or chunk_id in seen:
+        corpus = str(source.get("corpus") or source.get("source_type") or "").strip()
+        chunk_id = str(
+            source.get("chunk_id")
+            or source.get("title")
+            or source.get("parent_key")
+            or source.get("source_file")
+            or ""
+        ).strip()
+        attribution = resolve_chunk_attribution(chunk_id, corpus)
+        file_name = normalize_source_filename(str(attribution.get("file", "")))
+        if not file_name or file_name in seen:
             continue
-        source_files.append(chunk_id)
-        seen.add(chunk_id)
+        attributed_sources.append({**attribution, "file": file_name})
+        seen.add(file_name)
 
-    if not source_files:
+    if not attributed_sources:
         return None
 
     registry_path = registry_path_for(article_path)
@@ -332,7 +340,32 @@ def _build_sources_registry(
         if force
         else load_sources_registry(registry_path)
     )
-    registry = assign_source_ids(source_files, existing=existing_registry)
+    assigned_registry = assign_source_ids(
+        [str(source["file"]) for source in attributed_sources],
+        existing=existing_registry,
+    )
+    assigned_by_file = assigned_registry.by_file()
+    registry = WikiSourcesRegistry(
+        sources=[
+            WikiSourceEntry(
+                id=assigned_by_file[str(source["file"])].id,
+                file=str(source["file"]),
+                type=str(source.get("type") or "unknown"),
+                title=_optional_text(source.get("title")),
+                url=_optional_text(source.get("url")),
+                domain=_optional_text(source.get("domain")),
+                video_id=_optional_text(source.get("video_id")),
+                ts_start=_optional_int(source.get("ts_start")),
+                ts_end=_optional_int(source.get("ts_end")),
+                page=_optional_int(source.get("page")),
+                grade=_optional_int(source.get("grade")),
+                author=_optional_text(source.get("author")),
+                section_path=_optional_text(source.get("section_path")),
+                preserved_from_meta=assigned_by_file[str(source["file"])].preserved_from_meta,
+            )
+            for source in attributed_sources
+        ]
+    )
     cited_ids = set(extract_short_citation_ids(article_text))
     if cited_ids:
         registry = WikiSourcesRegistry(
@@ -450,6 +483,20 @@ def _clean_chunk_text(chunk: dict) -> str:
     cleaned = "\n".join(lines).strip()
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     return cleaned
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _recover_from_session(before_ts: float, prompt_fingerprint: str = "") -> str | None:

--- a/scripts/wiki/source_attribution.py
+++ b/scripts/wiki/source_attribution.py
@@ -1,0 +1,296 @@
+"""Resolve stable source attribution metadata for compiled wiki citations."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+from .config import PROJECT_ROOT
+from .sources_schema import _infer_source_type, normalize_source_filename
+
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+
+_CHUNK_SUFFIX_RE = re.compile(r"(_[cs]\d+)$", re.IGNORECASE)
+_TRAILING_DIGITS_RE = re.compile(r"(\d+)$")
+_NON_SLUG_RE = re.compile(r"[^0-9A-Za-zА-Яа-яІіЇїЄєҐґ_-]+")
+_CORPUS_ALIASES = {
+    "textbook_sections": "textbook_sections",
+    "textbooks": "textbooks",
+    "textbook": "textbooks",
+    "modern_literary": "literary_texts",
+    "archaic_literary": "literary_texts",
+    "literary_texts": "literary_texts",
+    "literary": "literary_texts",
+    "external": "external_articles",
+    "external_articles": "external_articles",
+    "external_article": "external_articles",
+    "wikipedia": "wikipedia",
+    "wiki": "wikipedia",
+    "ukrainian_wiki": "ukrainian_wiki",
+}
+
+
+def resolve_chunk_attribution(chunk_id: str, corpus: str) -> dict:
+    """Return rich source attribution for a retrieved corpus row."""
+    raw_chunk_id = str(chunk_id or "").strip()
+    raw_corpus = str(corpus or "").strip()
+    normalized_corpus = _CORPUS_ALIASES.get(raw_corpus, raw_corpus)
+
+    if not raw_chunk_id:
+        return {
+            "file": "unknown",
+            "type": "unknown",
+            "title": "Unknown source",
+        }
+
+    try:
+        with sqlite3.connect(str(DEFAULT_DB_PATH)) as conn:
+            conn.row_factory = sqlite3.Row
+            if normalized_corpus == "textbook_sections":
+                attribution = _resolve_textbook_section(conn, raw_chunk_id)
+            elif normalized_corpus == "textbooks":
+                attribution = _resolve_textbook_chunk(conn, raw_chunk_id)
+            elif normalized_corpus == "literary_texts":
+                attribution = _resolve_literary_chunk(conn, raw_chunk_id)
+            elif normalized_corpus == "external_articles":
+                attribution = _resolve_external_chunk(conn, raw_chunk_id)
+            elif normalized_corpus == "wikipedia":
+                attribution = _resolve_wikipedia_chunk(conn, raw_chunk_id)
+            elif normalized_corpus == "ukrainian_wiki":
+                attribution = _resolve_ukrainian_wiki_chunk(conn, raw_chunk_id)
+            else:
+                attribution = None
+    except sqlite3.Error:
+        attribution = None
+
+    if attribution is not None:
+        return attribution
+
+    normalized_file = normalize_source_filename(raw_chunk_id)
+    return {
+        "file": normalized_file,
+        "type": _infer_source_type(normalized_file),
+        "title": raw_chunk_id,
+    }
+
+
+def _resolve_textbook_section(conn: sqlite3.Connection, chunk_id: str) -> dict | None:
+    section_id = _parse_section_id(chunk_id)
+    if section_id is None:
+        return None
+
+    row = conn.execute(
+        """
+        SELECT section_id, source_file, grade, section_title, page_start
+        FROM textbook_sections
+        WHERE section_id = ?
+        """,
+        (section_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    return {
+        "file": f"{normalize_source_filename(str(row['source_file'] or ''))}_s{section_id:04d}",
+        "type": "textbook",
+        "title": str(row["section_title"] or ""),
+        "grade": _maybe_int(row["grade"]),
+        "page": _maybe_int(row["page_start"]),
+    }
+
+
+def _resolve_textbook_chunk(conn: sqlite3.Connection, chunk_id: str) -> dict | None:
+    row = conn.execute(
+        """
+        SELECT id, chunk_id, title, source_file, grade, author
+        FROM textbooks
+        WHERE chunk_id = ?
+        LIMIT 1
+        """,
+        (chunk_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    return {
+        "file": _build_chunk_file(
+            str(row["source_file"] or ""),
+            str(row["chunk_id"] or ""),
+            row["id"],
+        ),
+        "type": "textbook",
+        "title": str(row["title"] or ""),
+        "grade": _maybe_int(row["grade"]),
+        "author": _maybe_text(row["author"]),
+    }
+
+
+def _resolve_literary_chunk(conn: sqlite3.Connection, chunk_id: str) -> dict | None:
+    row = conn.execute(
+        """
+        SELECT id, chunk_id, title, source_file, author, work
+        FROM literary_texts
+        WHERE chunk_id = ?
+        LIMIT 1
+        """,
+        (chunk_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    return {
+        "file": _build_chunk_file(
+            str(row["source_file"] or ""),
+            str(row["chunk_id"] or ""),
+            row["id"],
+        ),
+        "type": "literary",
+        "title": str(row["work"] or row["title"] or ""),
+        "author": _maybe_text(row["author"]),
+    }
+
+
+def _resolve_external_chunk(conn: sqlite3.Connection, chunk_id: str) -> dict | None:
+    row = conn.execute(
+        """
+        SELECT
+            id,
+            chunk_id,
+            url,
+            title,
+            source_file,
+            domain,
+            video_id,
+            chunk_start_ts,
+            chunk_end_ts
+        FROM external_articles
+        WHERE chunk_id = ?
+        LIMIT 1
+        """,
+        (chunk_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    ts_start = _maybe_int(row["chunk_start_ts"])
+    url = _maybe_text(row["url"])
+    resolved_url = _with_ts_suffix(url, ts_start) if url else None
+    domain = _maybe_text(row["domain"])
+    file_value = resolved_url or _external_fallback_file(domain, row["id"], row["source_file"])
+    return {
+        "file": file_value,
+        "type": "external",
+        "title": str(row["title"] or ""),
+        "url": resolved_url or url,
+        "domain": domain,
+        "video_id": _maybe_text(row["video_id"]),
+        "ts_start": ts_start,
+        "ts_end": _maybe_int(row["chunk_end_ts"]),
+    }
+
+
+def _resolve_wikipedia_chunk(conn: sqlite3.Connection, chunk_id: str) -> dict | None:
+    row = conn.execute(
+        """
+        SELECT title, url
+        FROM wikipedia
+        WHERE title = ?
+        LIMIT 1
+        """,
+        (chunk_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    title = str(row["title"] or "")
+    return {
+        "file": f"wikipedia/{title}",
+        "type": "wikipedia",
+        "title": title,
+        "url": _maybe_text(row["url"]),
+    }
+
+
+def _resolve_ukrainian_wiki_chunk(conn: sqlite3.Connection, chunk_id: str) -> dict | None:
+    row = conn.execute(
+        """
+        SELECT article_slug, article_title, section_path
+        FROM ukrainian_wiki
+        WHERE passage_id = ?
+        LIMIT 1
+        """,
+        (chunk_id,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    article_slug = str(row["article_slug"] or "")
+    section_path = str(row["section_path"] or "")
+    section_suffix = _slugify(section_path) or "root"
+    return {
+        "file": f"ukrainian_wiki/{article_slug}_{section_suffix}",
+        "type": "ukrainian_wiki",
+        "title": str(row["article_title"] or ""),
+        "section_path": section_path or None,
+    }
+
+
+def _parse_section_id(chunk_id: str) -> int | None:
+    candidate = str(chunk_id or "").strip()
+    if candidate.startswith(("S", "s")):
+        candidate = candidate[1:]
+    try:
+        return int(candidate)
+    except ValueError:
+        return None
+
+
+def _build_chunk_file(source_file: str, chunk_id: str, row_id: object) -> str:
+    source_slug = normalize_source_filename(source_file)
+    suffix_match = _CHUNK_SUFFIX_RE.search(chunk_id)
+    if suffix_match:
+        return f"{source_slug}{suffix_match.group(1).lower()}"
+
+    trailing_digits = _TRAILING_DIGITS_RE.search(chunk_id)
+    if trailing_digits:
+        return f"{source_slug}_c{int(trailing_digits.group(1)):04d}"
+
+    if row_id is not None:
+        return f"{source_slug}_c{int(row_id):04d}"
+    return source_slug
+
+
+def _with_ts_suffix(url: str | None, ts_start: int | None) -> str | None:
+    if not url:
+        return None
+    if ts_start is None:
+        return url
+    separator = "&" if "?" in url else "?"
+    return f"{url}{separator}t={ts_start}s"
+
+
+def _external_fallback_file(domain: str | None, row_id: object, source_file: object) -> str:
+    base = _slugify(domain or str(source_file or "")) or "external"
+    suffix = f"{int(row_id):04d}" if row_id is not None else "unknown"
+    return f"{base}_{suffix}"
+
+
+def _slugify(value: str) -> str:
+    slug = _NON_SLUG_RE.sub("-", str(value or "").strip())
+    slug = re.sub(r"-{2,}", "-", slug).strip("-_")
+    return slug
+
+
+def _maybe_int(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None

--- a/scripts/wiki/sources_schema.py
+++ b/scripts/wiki/sources_schema.py
@@ -15,7 +15,7 @@ sources:
 from __future__ import annotations
 
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import yaml
@@ -26,8 +26,10 @@ SOURCE_TYPES = {
     "literary",
     "pravopys",
     "textbook",
+    "ukrainian_wiki",
     "unknown",
     "wiki",
+    "wikipedia",
 }
 _ID_RE = re.compile(r"^S([1-9]\d*)$")
 _SHORT_CITATION_BODY_RE = re.compile(r"\[([^\[\]]+)\]")
@@ -41,6 +43,16 @@ class WikiSourceEntry:
     id: str
     file: str
     type: str
+    title: str | None = None
+    url: str | None = None
+    domain: str | None = None
+    video_id: str | None = None
+    ts_start: int | None = None
+    ts_end: int | None = None
+    page: int | None = None
+    grade: int | None = None
+    author: str | None = None
+    section_path: str | None = None
     preserved_from_meta: bool = False
 
     def __post_init__(self) -> None:
@@ -56,11 +68,26 @@ class WikiSourceEntry:
         return int(self.id[1:])
 
     def to_dict(self) -> dict:
-        data = {
+        data: dict[str, object] = {
             "id": self.id,
             "file": self.file,
             "type": self.type,
         }
+        for field_name in (
+            "title",
+            "url",
+            "domain",
+            "video_id",
+            "ts_start",
+            "ts_end",
+            "page",
+            "grade",
+            "author",
+            "section_path",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                data[field_name] = value
         if self.preserved_from_meta:
             data["preserved_from_meta"] = True
         return data
@@ -99,6 +126,16 @@ def load_sources_registry(path: Path) -> WikiSourcesRegistry:
             id=str(item["id"]),
             file=normalize_source_filename(str(item["file"])),
             type=str(item.get("type") or _infer_source_type(str(item["file"]))),
+            title=_optional_str(item.get("title")),
+            url=_optional_str(item.get("url")),
+            domain=_optional_str(item.get("domain")),
+            video_id=_optional_str(item.get("video_id")),
+            ts_start=_optional_int(item.get("ts_start")),
+            ts_end=_optional_int(item.get("ts_end")),
+            page=_optional_int(item.get("page")),
+            grade=_optional_int(item.get("grade")),
+            author=_optional_str(item.get("author")),
+            section_path=_optional_str(item.get("section_path")),
             preserved_from_meta=bool(item.get("preserved_from_meta", False)),
         )
         for item in raw_sources
@@ -159,8 +196,8 @@ def assign_source_ids(
             continue
         if file_name in seen_now or entry.preserved_from_meta:
             ordered.append(
-                WikiSourceEntry(
-                    id=entry.id,
+                replace(
+                    entry,
                     file=file_name,
                     type=entry.type or _infer_source_type(file_name),
                     preserved_from_meta=entry.preserved_from_meta or file_name in preserved_from_meta,
@@ -176,8 +213,8 @@ def assign_source_ids(
         existing_entry = existing_by_file.get(file_name)
         if existing_entry is not None:
             ordered.append(
-                WikiSourceEntry(
-                    id=existing_entry.id,
+                replace(
+                    existing_entry,
                     file=file_name,
                     type=existing_entry.type or _infer_source_type(file_name),
                     preserved_from_meta=existing_entry.preserved_from_meta or file_name in preserved_from_meta,
@@ -253,8 +290,10 @@ def _infer_source_type(filename: str) -> str:
         return "unknown"
     if _TEXTBOOK_RE.match(lower):
         return "textbook"
-    if lower.startswith(("ext-wikipedia-", "wikipedia-", "wiki-")) or "wikipedia" in lower:
-        return "wiki"
+    if lower.startswith("ukrainian_wiki/") or lower.startswith("ukrainian-wiki/"):
+        return "ukrainian_wiki"
+    if lower.startswith(("ext-wikipedia-", "wikipedia-", "wikipedia/")) or "wikipedia" in lower:
+        return "wikipedia"
     if any(token in lower for token in ("pravopys", "orthograph")):
         return "pravopys"
     if lower.startswith("ext-") or lower.startswith("http://") or lower.startswith("https://"):
@@ -281,3 +320,17 @@ def _infer_source_type(filename: str) -> str:
 
 def _sort_sources(sources: list[WikiSourceEntry]) -> list[WikiSourceEntry]:
     return sorted(sources, key=lambda entry: entry.ordinal)
+
+
+def _optional_str(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -1,6 +1,7 @@
 """Tests for wiki compiler — prompt building, source formatting, index generation."""
 
 import os
+import sqlite3
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -9,6 +10,112 @@ import pytest
 
 _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(_project_root, "scripts"))
+
+
+@pytest.fixture
+def attribution_db(tmp_path, monkeypatch):
+    from wiki import source_attribution
+
+    db_path = tmp_path / "sources.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE textbook_sections (
+            section_id INTEGER PRIMARY KEY,
+            source_file TEXT NOT NULL,
+            grade INTEGER NOT NULL,
+            section_title TEXT NOT NULL,
+            page_start INTEGER
+        );
+
+        CREATE TABLE literary_texts (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            author TEXT DEFAULT '',
+            work TEXT DEFAULT ''
+        );
+
+        CREATE TABLE external_articles (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            url TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            domain TEXT DEFAULT '',
+            video_id TEXT DEFAULT '',
+            chunk_start_ts INTEGER,
+            chunk_end_ts INTEGER
+        );
+
+        CREATE TABLE wikipedia (
+            id INTEGER PRIMARY KEY,
+            title TEXT NOT NULL,
+            url TEXT NOT NULL DEFAULT ''
+        );
+
+        CREATE TABLE ukrainian_wiki (
+            id INTEGER PRIMARY KEY,
+            passage_id TEXT NOT NULL UNIQUE,
+            article_slug TEXT NOT NULL,
+            article_title TEXT NOT NULL DEFAULT '',
+            section_path TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO textbook_sections(section_id, source_file, grade, section_title, page_start) VALUES (?, ?, ?, ?, ?)",
+        [
+            (1, "11-klas-ukrmova-avramenko-2019", 11, "Topic 1", 101),
+            (2, "11-klas-ukrmova-avramenko-2019", 11, "Topic 2", 102),
+            (3, "11-klas-ukrmova-avramenko-2019", 11, "Topic 3", 103),
+            (4, "11-klas-ukrmova-avramenko-2019", 11, "Topic 4", 104),
+            (5, "11-klas-ukrmova-avramenko-2019", 11, "Topic 5", 105),
+            (77, "11-klas-ukrmova-avramenko-2019", 11, "Complex syntax", 123),
+        ],
+    )
+    conn.execute(
+        """
+        INSERT INTO literary_texts(id, chunk_id, title, source_file, author, work)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (12, "4f2a9abc_c0012", "Енеїда, уривок", "eneida", "Іван Котляревський", "Енеїда"),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_articles(
+            id, chunk_id, url, title, source_file, domain, video_id, chunk_start_ts, chunk_end_ts
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            1,
+            "ext-ulp-yt-001",
+            "https://www.youtube.com/watch?v=abc123",
+            "Podcast episode",
+            "ulp_youtube",
+            "youtube.com",
+            "abc123",
+            15,
+            29,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO wikipedia(id, title, url) VALUES (?, ?, ?)",
+        (1, "Українська мова", "https://uk.wikipedia.org/wiki/%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%B0_%D0%BC%D0%BE%D0%B2%D0%B0"),
+    )
+    conn.execute(
+        """
+        INSERT INTO ukrainian_wiki(id, passage_id, article_slug, article_title, section_path)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (1, "uw-1", "academic-writing", "Academic Writing", "Style / Evidence"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(source_attribution, "DEFAULT_DB_PATH", db_path)
+    return db_path
 
 
 # ── Tests: _format_sources ───────────────────────────────────────
@@ -374,6 +481,118 @@ class TestCompileArticleSkipLogic:
         assert "generated_by_model: gemini-3-flash-preview" in written
         mark_compiled.assert_called_once()
         assert mark_compiled.call_args.kwargs["model"] == "gemini-3-flash-preview"
+
+    def test_compile_builds_rich_sources_registry_without_unknown_types(self, tmp_path, attribution_db):
+        from wiki.compiler import compile_article
+        from wiki.sources_schema import load_sources_registry
+
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        (prompts_dir / "compile_article.md").write_text(
+            "Prompt: {topic} {slug} {domain} {tracks} {sources} {source_ids} {date}"
+        )
+        wiki_dir = tmp_path / "wiki"
+
+        with patch("wiki.compiler.PROMPTS_DIR", prompts_dir), \
+             patch("wiki.compiler.WIKI_DIR", wiki_dir), \
+             patch("wiki.compiler.is_compiled", return_value=False), \
+             patch("wiki.compiler.mark_compiled"), \
+             patch(
+                 "wiki.compiler._call_gemini",
+                 return_value="# Title\n\nOne [S1]. Two [S2]. Three [S3]. Four [S4]. Five [S5].\n",
+             ):
+            result = compile_article(
+                topic="Test",
+                slug="test",
+                domain="grammar/b2",
+                sources=[
+                    {"chunk_id": "S77", "text": "text", "corpus": "textbook_sections"},
+                    {"chunk_id": "4f2a9abc_c0012", "text": "text", "corpus": "modern_literary"},
+                    {"chunk_id": "ext-ulp-yt-001", "text": "text", "corpus": "external"},
+                    {"title": "Українська мова", "text": "text", "corpus": "wikipedia", "source_type": "wikipedia"},
+                    {"chunk_id": "uw-1", "text": "text", "corpus": "ukrainian_wiki"},
+                ],
+            )
+
+        registry = load_sources_registry(result.with_suffix(".sources.yaml"))
+        assert [entry.type for entry in registry.sources] == [
+            "textbook",
+            "literary",
+            "external",
+            "wikipedia",
+            "ukrainian_wiki",
+        ]
+        assert all(entry.type != "unknown" for entry in registry.sources)
+        assert [entry.file for entry in registry.sources] == [
+            "11-klas-ukrmova-avramenko-2019_s0077",
+            "eneida_c0012",
+            "https://www.youtube.com/watch?v=abc123&t=15s",
+            "wikipedia/Українська мова",
+            "ukrainian_wiki/academic-writing_Style-Evidence",
+        ]
+        assert registry.sources[2].url == "https://www.youtube.com/watch?v=abc123&t=15s"
+        assert registry.sources[2].video_id == "abc123"
+        assert registry.sources[4].section_path == "Style / Evidence"
+
+    def test_compile_preserves_s1_to_s5_textbook_section_attribution(self, tmp_path, attribution_db):
+        from wiki.compiler import compile_article
+        from wiki.sources_schema import load_sources_registry
+
+        prompts_dir = tmp_path / "prompts"
+        prompts_dir.mkdir()
+        (prompts_dir / "compile_article.md").write_text(
+            "Prompt: {topic} {slug} {domain} {tracks} {sources} {source_ids} {date}"
+        )
+        wiki_dir = tmp_path / "wiki"
+
+        with patch("wiki.compiler.PROMPTS_DIR", prompts_dir), \
+             patch("wiki.compiler.WIKI_DIR", wiki_dir), \
+             patch("wiki.compiler.is_compiled", return_value=False), \
+             patch("wiki.compiler.mark_compiled"), \
+             patch(
+                 "wiki.compiler._call_gemini",
+                 return_value="# Title\n\n[S1][S2][S3][S4][S5]\n",
+             ):
+            result = compile_article(
+                topic="Test",
+                slug="textbook-only",
+                domain="grammar/b2",
+                sources=[
+                    {"chunk_id": "S1", "text": "text", "corpus": "textbook_sections"},
+                    {"chunk_id": "S2", "text": "text", "corpus": "textbook_sections"},
+                    {"chunk_id": "S3", "text": "text", "corpus": "textbook_sections"},
+                    {"chunk_id": "S4", "text": "text", "corpus": "textbook_sections"},
+                    {"chunk_id": "S5", "text": "text", "corpus": "textbook_sections"},
+                ],
+            )
+
+        registry = load_sources_registry(result.with_suffix(".sources.yaml"))
+        assert [entry.id for entry in registry.sources] == ["S1", "S2", "S3", "S4", "S5"]
+        assert [entry.file for entry in registry.sources] == [
+            "11-klas-ukrmova-avramenko-2019_s0001",
+            "11-klas-ukrmova-avramenko-2019_s0002",
+            "11-klas-ukrmova-avramenko-2019_s0003",
+            "11-klas-ukrmova-avramenko-2019_s0004",
+            "11-klas-ukrmova-avramenko-2019_s0005",
+        ]
+        assert all(entry.type == "textbook" for entry in registry.sources)
+
+    def test_inject_generated_by_model_dedupes_existing_line(self):
+        from wiki.compiler import _inject_generated_by_model
+
+        article = (
+            "# Demo\n\n"
+            "<!-- wiki-meta\n"
+            "slug: demo\n"
+            "compiled: 2026-04-23\n"
+            "generated_by_model: unknown\n"
+            "-->\n"
+        )
+
+        updated = _inject_generated_by_model(article, model_used="gemini-3.1-pro-preview")
+
+        assert updated.count("generated_by_model:") == 1
+        assert "generated_by_model: gemini-3.1-pro-preview" in updated
 
 
 class TestCompileCommand:

--- a/tests/test_wiki_source_attribution.py
+++ b/tests/test_wiki_source_attribution.py
@@ -1,0 +1,253 @@
+"""Tests for corpus-aware wiki source attribution."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+
+import pytest
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_project_root, "scripts"))
+
+
+@pytest.fixture
+def attribution_db(tmp_path, monkeypatch):
+    from wiki import source_attribution
+
+    db_path = tmp_path / "sources.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE textbook_sections (
+            section_id INTEGER PRIMARY KEY,
+            source_file TEXT NOT NULL,
+            grade INTEGER NOT NULL,
+            section_title TEXT NOT NULL,
+            page_start INTEGER
+        );
+
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT ''
+        );
+
+        CREATE TABLE literary_texts (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            author TEXT DEFAULT '',
+            work TEXT DEFAULT ''
+        );
+
+        CREATE TABLE external_articles (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            url TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            domain TEXT DEFAULT '',
+            video_id TEXT DEFAULT '',
+            chunk_start_ts INTEGER,
+            chunk_end_ts INTEGER
+        );
+
+        CREATE TABLE wikipedia (
+            id INTEGER PRIMARY KEY,
+            title TEXT NOT NULL,
+            url TEXT NOT NULL DEFAULT ''
+        );
+
+        CREATE TABLE ukrainian_wiki (
+            id INTEGER PRIMARY KEY,
+            passage_id TEXT NOT NULL UNIQUE,
+            article_slug TEXT NOT NULL,
+            article_title TEXT NOT NULL DEFAULT '',
+            section_path TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO textbook_sections(section_id, source_file, grade, section_title, page_start) VALUES (?, ?, ?, ?, ?)",
+        [
+            (77, "11-klas-ukrmova-avramenko-2019", 11, "Складне речення", 123),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO textbooks(id, chunk_id, title, source_file, grade, author) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (402, "raw-402", "Складнопідрядні речення", "11-klas-ukrmova-avramenko-2019", "11", "Авраменко"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO literary_texts(id, chunk_id, title, source_file, author, work) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (12, "4f2a9abc_c0012", "Енеїда, уривок", "eneida", "Іван Котляревський", "Енеїда"),
+        ],
+    )
+    conn.executemany(
+        """
+        INSERT INTO external_articles(
+            id, chunk_id, url, title, source_file, domain, video_id, chunk_start_ts, chunk_end_ts
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                1,
+                "ext-ulp-yt-001",
+                "https://www.youtube.com/watch?v=abc123",
+                "Podcast episode",
+                "ulp_youtube",
+                "youtube.com",
+                "abc123",
+                15,
+                29,
+            ),
+            (
+                2,
+                "ext-blog-001",
+                "https://example.com/article",
+                "Article",
+                "ulp_blogs",
+                "example.com",
+                "",
+                None,
+                None,
+            ),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO wikipedia(id, title, url) VALUES (?, ?, ?)",
+        (1, "Українська мова", "https://uk.wikipedia.org/wiki/%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%B0_%D0%BC%D0%BE%D0%B2%D0%B0"),
+    )
+    conn.execute(
+        """
+        INSERT INTO ukrainian_wiki(id, passage_id, article_slug, article_title, section_path)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (1, "uw-1", "academic-writing", "Academic Writing", "Style / Evidence"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(source_attribution, "DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+def test_resolve_chunk_attribution_for_textbook_sections(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("S77", "textbook_sections")
+
+    assert result == {
+        "file": "11-klas-ukrmova-avramenko-2019_s0077",
+        "type": "textbook",
+        "title": "Складне речення",
+        "grade": 11,
+        "page": 123,
+    }
+
+
+def test_resolve_chunk_attribution_for_textbooks(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("raw-402", "textbooks")
+
+    assert result == {
+        "file": "11-klas-ukrmova-avramenko-2019_c0402",
+        "type": "textbook",
+        "title": "Складнопідрядні речення",
+        "grade": 11,
+        "author": "Авраменко",
+    }
+
+
+def test_resolve_chunk_attribution_for_literary_texts(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("4f2a9abc_c0012", "modern_literary")
+
+    assert result == {
+        "file": "eneida_c0012",
+        "type": "literary",
+        "title": "Енеїда",
+        "author": "Іван Котляревський",
+    }
+
+
+def test_resolve_chunk_attribution_for_external_video(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("ext-ulp-yt-001", "external_articles")
+
+    assert result == {
+        "file": "https://www.youtube.com/watch?v=abc123&t=15s",
+        "type": "external",
+        "title": "Podcast episode",
+        "url": "https://www.youtube.com/watch?v=abc123&t=15s",
+        "domain": "youtube.com",
+        "video_id": "abc123",
+        "ts_start": 15,
+        "ts_end": 29,
+    }
+
+
+def test_resolve_chunk_attribution_for_external_article_without_video(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("ext-blog-001", "external")
+
+    assert result == {
+        "file": "https://example.com/article",
+        "type": "external",
+        "title": "Article",
+        "url": "https://example.com/article",
+        "domain": "example.com",
+        "video_id": None,
+        "ts_start": None,
+        "ts_end": None,
+    }
+
+
+def test_resolve_chunk_attribution_for_wikipedia(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("Українська мова", "wikipedia")
+
+    assert result == {
+        "file": "wikipedia/Українська мова",
+        "type": "wikipedia",
+        "title": "Українська мова",
+        "url": "https://uk.wikipedia.org/wiki/%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%B0_%D0%BC%D0%BE%D0%B2%D0%B0",
+    }
+
+
+def test_resolve_chunk_attribution_for_ukrainian_wiki(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("uw-1", "ukrainian_wiki")
+
+    assert result == {
+        "file": "ukrainian_wiki/academic-writing_Style-Evidence",
+        "type": "ukrainian_wiki",
+        "title": "Academic Writing",
+        "section_path": "Style / Evidence",
+    }
+
+
+def test_resolve_chunk_attribution_falls_back_to_inferred_type_for_filename_shaped_ids(attribution_db) -> None:
+    from wiki.source_attribution import resolve_chunk_attribution
+
+    result = resolve_chunk_attribution("11-klas-ukrmova-avramenko-2019_s0077", "")
+
+    assert result == {
+        "file": "11-klas-ukrmova-avramenko-2019_s0077",
+        "type": "textbook",
+        "title": "11-klas-ukrmova-avramenko-2019_s0077",
+    }

--- a/tests/test_wiki_sources_schema.py
+++ b/tests/test_wiki_sources_schema.py
@@ -44,7 +44,8 @@ def test_assign_source_ids_is_stable_across_reruns() -> None:
         ("11-klas-ukrmova-avramenko-2019_s0075", "textbook"),
         ("11-клас-istoriya-ukr-galimov-2024_s0238", "textbook"),
         ("ext-ulp_youtube-19", "external"),
-        ("ext-wikipedia-kyiv", "wiki"),
+        ("ext-wikipedia-kyiv", "wikipedia"),
+        ("ukrainian_wiki/academic-writing_root", "ukrainian_wiki"),
         ("pravopys-2019-paragraph-42", "pravopys"),
         ("sum11-слово", "dictionary"),
         ("feaa5fa7_c3124", "literary"),
@@ -110,8 +111,13 @@ def test_registry_round_trip(tmp_path: Path) -> None:
             WikiSourceEntry(id="S1", file="11-klas-istoriya-ukr-galimov-2024_s0238", type="textbook"),
             WikiSourceEntry(
                 id="S2",
-                file="ext-ulp_youtube-19",
+                file="https://www.youtube.com/watch?v=abc123&t=15s",
                 type="external",
+                title="Podcast episode",
+                url="https://www.youtube.com/watch?v=abc123&t=15s",
+                video_id="abc123",
+                ts_start=15,
+                ts_end=29,
                 preserved_from_meta=True,
             ),
         ]
@@ -122,6 +128,10 @@ def test_registry_round_trip(tmp_path: Path) -> None:
 
     assert [(entry.id, entry.file, entry.type, entry.preserved_from_meta) for entry in loaded.sources] == [
         ("S1", "11-klas-istoriya-ukr-galimov-2024_s0238", "textbook", False),
-        ("S2", "ext-ulp_youtube-19", "external", True),
+        ("S2", "https://www.youtube.com/watch?v=abc123&t=15s", "external", True),
     ]
+    assert loaded.sources[1].title == "Podcast episode"
+    assert loaded.sources[1].video_id == "abc123"
+    assert loaded.sources[1].ts_start == 15
+    assert loaded.sources[1].ts_end == 29
     assert path.read_text(encoding="utf-8").startswith("# Source registry for wiki/periods/afhanistan.md")


### PR DESCRIPTION
## Summary

Closes the `type: unknown` + bare chunk ID leak in wiki `sources.yaml`. Unblocks the wiki-compile pipeline + #1435 backfill.

- New `scripts/wiki/source_attribution.py` — looks each chunk ID up in `data/sources.db`, returns rich metadata (title, page, grade, author, url+ts).
- `WikiSourceEntry` extended with optional rich-metadata fields, YAML round-trips stay backward compatible.
- `compile.py` routes through the new resolver; `generated_by_model` emitted exactly once.

## Canonical AC — verified

User's canonical AC:

```
.venv/bin/python scripts/wiki/compile.py --track b2 --slug academic-writing --force
```

Resulting `wiki/grammar/b2/academic-writing.sources.yaml`:
- 0 `type: unknown` entries
- 0 bare `file: S<N>` entries  
- All entries carry real corpus paths, types, titles, grades, authors
- `generated_by_model` appears exactly once

## Test plan

- [x] `pytest tests/test_wiki_source_attribution.py` — green (8 tests)
- [x] `pytest tests/test_wiki_sources_schema.py` — green (14 tests)
- [x] `pytest tests/test_wiki_compiler.py` — green (44 tests)
- [x] Live smoke: `compile.py --track b2 --slug academic-writing --force` — clean
- [ ] User merges only after spot-checking the generated sources.yaml from the branch

## Authoring note

Code authored by Codex (dispatch `codex-1434-compiler-attribution`). The dispatch stopped before committing/pushing — I finalized the delivery here so the pipeline can unblock. #1435 (backfill across ~227 existing wikis) depends on this landing first.

Do NOT auto-merge.