### PR TITLE
fix(build): preserve Cyrillic й/ї through NFKD in wiki_compressor tokenizer (unblocks Opus contract compliance)

### DIFF
--- a/scripts/build/phases/wiki_compressor.py
+++ b/scripts/build/phases/wiki_compressor.py
@@ -69,9 +69,30 @@ _DIALOGUE_SECTION_KEYWORDS = {
 }
 
 
+#: Combining marks that form part of Cyrillic letters (NOT stress marks).
+#: Under NFKD decomposition:
+#:   й (U+0439) → и (U+0438) + U+0306 combining short-stroke
+#:   ї (U+0457) → і (U+0456) + U+0308 combining diaeresis
+#:   Й (U+0419) → И (U+0418) + U+0306
+#:   Ї (U+0407) → І (U+0406) + U+0308
+#: If we drop these combiners the tokens get CORRUPTED: "білий" → "білии",
+#: "країна" → "краина", "жовтий" → "жовтии". The contract-compliance
+#: check then fails because the registered anchor term ("білий") never
+#: matches the tokenizer-normalized form. Preserve these combiners, then
+#: recompose via NFC so the Cyrillic letter comes back as a single
+#: codepoint. Other combiners (e.g. acute stress U+0301 on vowels) are
+#: still stripped — that's the intent of normalization for matching.
+_CYRILLIC_LETTER_COMBINERS: frozenset[str] = frozenset({"̆", "̈"})
+
+
 def _tokenize(text: str) -> set[str]:
     normalized = unicodedata.normalize("NFKD", text or "")
-    text = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    kept: list[str] = []
+    for ch in normalized:
+        if unicodedata.combining(ch) and ch not in _CYRILLIC_LETTER_COMBINERS:
+            continue
+        kept.append(ch)
+    text = unicodedata.normalize("NFC", "".join(kept))
     text = re.sub(r"[-_/.:]+", " ", text)
     return {
         token.lower()

--- a/tests/test_wiki_compressor_tokenize.py
+++ b/tests/test_wiki_compressor_tokenize.py
@@ -1,0 +1,111 @@
+"""Regression tests for scripts/build/phases/wiki_compressor.py::_tokenize.
+
+Ensures Ukrainian-specific Cyrillic letters (й, ї, Й, Ї) survive NFKD
+normalization cleanly. Before this fix, _tokenize was silently
+corrupting every token containing й or ї into forms that don't exist
+in Ukrainian (білий → білии, країна → краина, жовтий → жовтии), which
+broke contract-compliance matching — Opus would correctly write
+`білий` in a module, but the contract-compliance check required the
+tokenizer-corrupted form `білии`, so compliance always failed.
+
+Scope: reduces the surface to the tokenizer itself. A later PR should
+add a higher-level contract-compliance regression test that builds a
+real plan + content pair and verifies TEACHING_BEATS / FACTUAL_ANCHOR
+don't fire on correctly-spelled Ukrainian vocabulary.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from build.phases.wiki_compressor import _tokenize
+
+
+class TestTokenizePreservesCyrillicLetters:
+    """The bug: й/ї decompose under NFKD into base + combining mark.
+    The old tokenizer stripped all combining marks, corrupting the letter.
+    """
+
+    def test_preserves_й_lowercase(self):
+        tokens = _tokenize("білий")
+        assert "білий" in tokens
+        assert "білии" not in tokens  # the buggy output we're preventing
+
+    def test_preserves_ї(self):
+        tokens = _tokenize("країна")
+        assert "країна" in tokens
+        assert "краина" not in tokens
+
+    def test_preserves_Й_uppercase(self):
+        # Uppercase Й (U+0419) is also a separate codepoint that decomposes.
+        # Since the tokenizer lowercases, assertion is on the lowercase form.
+        tokens = _tokenize("ЙОРКШИР")
+        assert "йоркшир" in tokens
+
+    def test_preserves_mix_across_multiple_tokens(self):
+        text = "білий жовтий блакитний тризуб Україна"
+        tokens = _tokenize(text)
+        assert "білий" in tokens
+        assert "жовтий" in tokens
+        assert "блакитний" in tokens
+        assert "україна" in tokens
+
+    def test_canonical_flag_terms_survive(self):
+        """Direct regression for the #1431 / a1/colors failure mode:
+        the wiki compressor extracted `білии`/`жовтии`/`блакитнии` as
+        factual anchors, no writer could possibly produce those (since
+        they're not Ukrainian), compliance always failed."""
+        # Simulate what the wiki body would say.
+        article = "Наш прапор синьо-жовтий. Базові кольори: білий, чорний, червоний, жовтий, зелений, синій, блакитний."
+        tokens = _tokenize(article)
+        # Every real anchor the writer will output.
+        for expected in ("білий", "чорний", "червоний", "жовтий", "зелений", "синій", "блакитний"):
+            assert expected in tokens, f"Ukrainian adjective {expected!r} corrupted during tokenize: got {sorted(tokens)}"
+
+
+class TestTokenizeStripsStressMarks:
+    """NFKD + combining-strip was the original intent for stress removal
+    in Ukrainian textbook content where acute marks flag stress. Those
+    marks must still be stripped; only the Cyrillic-LETTER combiners
+    (short-stroke U+0306, diaeresis U+0308) need to survive.
+    """
+
+    def test_strips_acute_stress_mark_on_vowel(self):
+        # "ка́ртопля" — cyrillic а + combining acute U+0301
+        text = "ка́ртопля"
+        tokens = _tokenize(text)
+        assert "картопля" in tokens
+
+    def test_strips_acute_on_multiple_words(self):
+        text = "ка́ва мо́локо хлíб"
+        tokens = _tokenize(text)
+        assert "кава" in tokens
+        assert "молоко" in tokens
+
+
+class TestTokenizeStopwordsAndLength:
+    """Behaviour not related to the bug — sanity that pre-existing
+    filters still work after the tokenizer change."""
+
+    def test_drops_short_tokens(self):
+        tokens = _tokenize("до на за при і та")
+        # All these are < 4 chars → get dropped by the `len > 2` filter.
+        # "при" is 3 chars (length > 2), so it stays unless it's a stopword.
+        assert "до" not in tokens
+        assert "на" not in tokens
+        assert "за" not in tokens
+
+    def test_lowercases(self):
+        tokens = _tokenize("Україна БІЛИЙ жовтий")
+        for t in tokens:
+            assert t == t.lower()
+
+
+class TestTokenizeIdempotent:
+    def test_tokenize_twice_gives_same_result(self):
+        text = "білий жовтий блакитний"
+        t1 = _tokenize(text)
+        t2 = _tokenize(text)
+        assert t1 == t2


### PR DESCRIPTION
## TL;DR

**This is the root cause of the a1/colors Opus contract-compliance failures we saw all afternoon.** A silent Unicode-normalization bug in `wiki_compressor._tokenize` has been corrupting every Ukrainian token ending in й/ї since whenever NFKD was introduced.

## The bug

`_tokenize` uses `unicodedata.normalize("NFKD", ...)` then drops all `unicodedata.combining()` characters. Under NFKD:

- **й** (U+0439) → **и** (U+0438) + U+0306 (combining short-stroke)
- **ї** (U+0457) → **і** (U+0456) + U+0308 (combining diaeresis)

Stripping all combining marks turns **й into и** and **ї into і**:

| Correct Ukrainian | Tokenizer output |
|---|---|
| `білий` | `білии` |
| `жовтий` | `жовтии` |
| `блакитний` | `блакитнии` |
| `країна` | `краина` |

`wiki_compressor.py` puts these corrupted tokens into plan `factual_anchors`. `scripts/audit/checks/contract_compliance.py` then demands those corrupted spellings appear literally in the module body. But `білии` isn't Ukrainian — only `білий` is. **No writer could ever satisfy the contract.**

This is why today's Opus a1/colors rebuild looped on `Contract compliance FAILED — 5-7 violation(s)`:

```
FACTUAL_ANCHOR ERROR: Section 'Кольори' misses factual anchor terms ['білии']
FACTUAL_ANCHOR ERROR: Section 'Кольори' misses factual anchor terms ['жовтии', 'зелении']
FACTUAL_ANCHOR ERROR: Section 'Синій ≠ блакитний' misses factual anchor terms ['блакитнии']
```

Opus was writing `білий`/`жовтий`/`зелений` correctly. Compliance demanded `білии`/`жовтии`/`зелении`. Impossible.

## The fix

Preserve the two combining marks that form part of Cyrillic letters (U+0306, U+0308), then recompose via NFC so й/ї come back as single codepoints. Other combiners (acute stress U+0301 on Cyrillic vowels, diacritics on Latin, etc.) still get stripped — that's the intent of normalization for matching.

```python
_CYRILLIC_LETTER_COMBINERS: frozenset[str] = frozenset({"̆", "̈"})

def _tokenize(text: str) -> set[str]:
    normalized = unicodedata.normalize("NFKD", text or "")
    kept = [ch for ch in normalized
            if not unicodedata.combining(ch)
            or ch in _CYRILLIC_LETTER_COMBINERS]
    text = unicodedata.normalize("NFC", "".join(kept))
    ...
```

## Tests

10 new tests in `tests/test_wiki_compressor_tokenize.py`:

- й/ї/Й preservation (lowercase + uppercase + mixed)
- Direct regression for a1/colors flag-terms corruption
- Acute stress mark stripping still works (Cyrillic а + U+0301 → а)
- Pre-existing stopword + length + lowercasing filters unchanged
- Idempotency

## Blast radius

Every A1/A2/B1/B2/HIST/etc. module ever built through this tokenizer. Some effects:

1. **Gemini got blamed** for contract-compliance failures that were actually impossible-to-satisfy requirements produced by this tokenizer.
2. **Every `plan-contract.yaml` on disk** has corrupted factual_anchors. Quick scan:
   ```
   grep -rE "білии|жовтии|блакитнии|краина|країн[^аеиіоуяюєї]" curriculum/l2-uk-en/*/orchestration/*/
   ```
3. **Some writer outputs may have been coerced** into producing misspellings to satisfy the check (rare, but worth auditing).

## Follow-up (not this PR)

Re-extract factual_anchors for already-built modules. Either one-shot backfill script or just let the pipeline naturally refresh contracts on next build.

## Test plan

- [x] 10/10 new tokenizer tests pass
- [x] Ruff + pre-commit hooks pass
- [ ] After merge: re-run a1/colors build with `--writer claude-tools` and confirm FACTUAL_ANCHOR violations no longer reference Cyrillic-corrupted terms

Do NOT auto-merge — user merges.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>