### PR TITLE
fix(wiki): disambiguate chunk-ID label — strip S-prefix to stop citation leakage (#1450 Fix 2a) (#1459)

### DIFF
--- a/scripts/wiki/compiler.py
+++ b/scripts/wiki/compiler.py
@@ -297,9 +297,16 @@ def _format_sources(sources: list[dict]) -> str:
         header = " | ".join(header_parts) if header_parts else f"Source {i}"
         chunk_id = chunk.get("chunk_id", "")
         text = _clean_chunk_text(chunk)
+        # Strip the textbook S-prefix so the internal chunk reference cannot
+        # be mistaken for the [S1]..[SN] source citation format in prose.
+        display_ref = (
+            chunk_id.removeprefix("S")
+            if str(chunk.get("source_type")) == "textbook"
+            else chunk_id
+        )
 
         parts.append(f"### Source {i}: {header}\n"
-                     f"Chunk ID: `{chunk_id}`\n\n"
+                     f"(internal ref: `{display_ref}` — cite this source as `[S{i}]`)\n\n"
                      f"{text}")
 
     return "\n\n---\n\n".join(parts)

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -173,6 +173,23 @@ class TestFormatSources:
         assert "Grade 7" in result
         assert "Section: Unit 5" in result
 
+    def test_disambiguates_textbook_chunk_id_from_source_citation(self):
+        from wiki.compiler import _format_sources
+
+        sources = [
+            {
+                "chunk_id": "S3931",
+                "source_type": "textbook",
+                "text": "Grammar text.",
+                "grade": 7,
+                "section_title": "Unit 5",
+            },
+        ]
+        result = _format_sources(sources)
+        assert "internal ref: `3931`" in result
+        assert "cite this source as `[S1]`" in result
+        assert "Chunk ID: `S3931`" not in result
+
     def test_empty_sources(self):
         from wiki.compiler import _format_sources
 


### PR DESCRIPTION
## Summary
- strip the leading `S` from textbook chunk IDs when rendering internal refs in `compiler._format_sources`
- replace the ambiguous `Chunk ID:` label with an explicit `(internal ref: ... — cite this source as [S{i}])` prompt line
- add a regression test covering textbook `S3931` formatting and the absence of the old leaked label

## Verification
- `.venv/bin/pytest tests/test_wiki_compiler.py` ✅
- full suite via `.venv/bin/pytest` blocked by unrelated existing failures:
  - `tests/test_a1_review_scores.py::TestA1ReviewScores::test_all_modules_have_orchestration_dirs`
  - `tests/test_agent_runtime.py::test_invoke_danger_respects_agent_allow_merge_opt_in`
- live smoke via `.venv/bin/python scripts/wiki/compile.py --track a1 --slug where-is-it --force` blocked twice by unrelated SQLite retrieval failure in `scripts/wiki/sources_db.py` (`SystemError: <sqlite3.Connection object ...> returned NULL without setting an exception`)

Closes #1459.