### PR TITLE
fix(wiki): route textbook_sections through attribution — close #1434 (#1450 Fix 1)

### DIFF
--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -318,7 +318,11 @@ def _search_sections_fts5(
             "text": meta["full_text"],
             "chunk_id": f"S{meta['section_id']}",
             "corpus": "textbook_sections",
-            "unit_key": f"textbook_sections:S{meta['section_id']}",
+            # Do NOT set "unit_key" here — the dispatcher computes it
+            # downstream without the "S" prefix to match the embedding
+            # manifest's seeded keys (`textbook_sections:{id}`). Setting
+            # it here with the S-prefix would shadow the correct value
+            # and break dense rerank lookup. See #1466 regression fix.
             "title": meta["section_title"],
             "source_type": "textbook",
         })

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -317,6 +317,8 @@ def _search_sections_fts5(
             **ranked,
             "text": meta["full_text"],
             "chunk_id": f"S{meta['section_id']}",
+            "corpus": "textbook_sections",
+            "unit_key": f"textbook_sections:S{meta['section_id']}",
             "title": meta["section_title"],
             "source_type": "textbook",
         })

--- a/tests/test_wiki_sources_db.py
+++ b/tests/test_wiki_sources_db.py
@@ -162,7 +162,13 @@ def test_search_sections_fts5_emits_textbook_sections_corpus(textbook_sections_d
 
     assert results
     assert results[0].get("corpus") == "textbook_sections"
-    assert results[0].get("unit_key") == "textbook_sections:S101"
+    # NOTE: `unit_key` is intentionally NOT set by `_search_sections_fts5` —
+    # it is computed by the dispatcher (`_dispatch_corpus_search`) as
+    # `f"textbook_sections:{section_id}"` WITHOUT the "S" prefix, to match
+    # the format used when seeding the embedding manifest. Setting it here
+    # with an "S"-prefixed form would shadow the dispatcher's value and
+    # break dense rerank lookup (regression caught on #1466 CI).
+    assert results[0].get("unit_key") is None
 
 
 def test_search_sections_fts5_results_route_to_textbook_attribution(textbook_sections_db) -> None:

--- a/tests/test_wiki_sources_db.py
+++ b/tests/test_wiki_sources_db.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from wiki import source_attribution, sources_db
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0,
+            parent_section_id INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE textbooks_fts USING fts5(
+            title, text, content='textbooks', content_rowid='id', tokenize='unicode61'
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER textbooks_ai AFTER INSERT ON textbooks BEGIN
+            INSERT INTO textbooks_fts(rowid, title, text) VALUES (new.id, new.title, new.text);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE textbook_sections (
+            section_id INTEGER PRIMARY KEY,
+            source_file TEXT NOT NULL,
+            grade INTEGER NOT NULL,
+            section_title TEXT NOT NULL,
+            section_number TEXT,
+            page_start INTEGER,
+            page_end INTEGER,
+            chunk_count INTEGER NOT NULL,
+            full_text TEXT NOT NULL
+        )
+        """
+    )
+    return conn
+
+
+def _seed_search_db(conn: sqlite3.Connection) -> None:
+    conn.executemany(
+        """
+        INSERT INTO textbook_sections (
+            section_id, source_file, grade, section_title, section_number,
+            page_start, page_end, chunk_count, full_text
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                101,
+                "11-klas-ukrmova-avramenko-2019",
+                11,
+                "Апостроф і наголос",
+                "§ 1",
+                123,
+                124,
+                2,
+                "Апостроф і наголос. Чергування у-в і м'які приголосні.",
+            ),
+        ],
+    )
+    conn.executemany(
+        """
+        INSERT INTO textbooks (
+            id, chunk_id, title, text, source_file, grade, author, char_count, parent_section_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                1,
+                "11-klas-ukrmova-avramenko-2019_c0001",
+                "Сторінка 1",
+                "Апостроф і наголос у слові.",
+                "11-klas-ukrmova-avramenko-2019",
+                "11",
+                "Авраменко",
+                40,
+                101,
+            ),
+            (
+                2,
+                "11-klas-ukrmova-avramenko-2019_c0002",
+                "Сторінка 2",
+                "Чергування у-в і м'які приголосні.",
+                "11-klas-ukrmova-avramenko-2019",
+                "11",
+                "Авраменко",
+                38,
+                101,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def textbook_sections_db(tmp_path, monkeypatch):
+    conn = _make_conn()
+    _seed_search_db(conn)
+
+    db_path = tmp_path / "sources.db"
+    disk_conn = sqlite3.connect(str(db_path))
+    disk_conn.execute(
+        """
+        CREATE TABLE textbook_sections (
+            section_id INTEGER PRIMARY KEY,
+            source_file TEXT NOT NULL,
+            grade INTEGER NOT NULL,
+            section_title TEXT NOT NULL,
+            page_start INTEGER
+        )
+        """
+    )
+    disk_conn.execute(
+        """
+        INSERT INTO textbook_sections(section_id, source_file, grade, section_title, page_start)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (101, "11-klas-ukrmova-avramenko-2019", 11, "Апостроф і наголос", 123),
+    )
+    disk_conn.commit()
+    disk_conn.close()
+
+    monkeypatch.setattr(sources_db, "_get_conn", lambda: conn)
+    monkeypatch.setattr(source_attribution, "DEFAULT_DB_PATH", db_path)
+    yield conn
+    conn.close()
+
+
+def test_search_sections_fts5_emits_textbook_sections_corpus(textbook_sections_db) -> None:
+    results = sources_db._search_sections_fts5(
+        ['"апостроф і наголос"'],
+        {"апостроф", "наголос", "чергування"},
+        track="b1",
+        max_chunk_candidates=10,
+        max_sections=10,
+    )
+
+    assert results
+    assert results[0].get("corpus") == "textbook_sections"
+    assert results[0].get("unit_key") == "textbook_sections:S101"
+
+
+def test_search_sections_fts5_results_route_to_textbook_attribution(textbook_sections_db) -> None:
+    results = sources_db._search_sections_fts5(
+        ['"апостроф і наголос"'],
+        {"апостроф", "наголос", "чергування"},
+        track="b1",
+        max_chunk_candidates=10,
+        max_sections=10,
+    )
+
+    attribution = source_attribution.resolve_chunk_attribution(
+        results[0]["chunk_id"],
+        results[0]["corpus"],
+    )
+
+    assert attribution["type"] == "textbook"
+    assert re.fullmatch(r"^\d+-klas-.+_s\d+$", attribution["file"])


### PR DESCRIPTION
## Summary
- add the missing `corpus: textbook_sections` and `unit_key: textbook_sections:S####` fields to `_search_sections_fts5` results in `scripts/wiki/sources_db.py`
- add a focused regression test module covering the emitted `corpus`/`unit_key` contract and `resolve_chunk_attribution(chunk_id, corpus)` routing for textbook sections

## Context
Implements #1450 Fix 1 from `docs/reports/2026-04-23-gemini-wiki-writer-diagnosis.md` for the #1434 attribution misrouting root cause.

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_wiki_sources_db.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/wiki/test_search_sources.py tests/test_wiki_source_attribution.py`
- pre-commit affected-file pytest: `tests/test_sources_db.py tests/test_wiki_sources_db.py`

## Notes
- attempted full `pytest`, but the baseline worktree is not green due unrelated failures in `tests/rag/test_benchmark_harness.py`, `tests/test_a1_review_scores.py`, and `tests/test_agent_runtime.py`
- attempted the live `scripts/wiki/compile.py --track b1 --slug adjectives-comparative --force` verification, but the run stalled in the Gemini fallback subprocess and had to be interrupted before a new `.sources.yaml` could be emitted
