### PR TITLE
feat(build): alignment manifest hash contract (#1452 P1-A of #1451)

### DIFF
--- a/scripts/build/alignment_manifest.py
+++ b/scripts/build/alignment_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import copy
+import functools
 import hashlib
 import json
 import re
@@ -48,7 +49,35 @@ def _load_v6_build_constant(name: str) -> Any:
     raise RuntimeError(f"Could not load {name} from {V6_BUILD_PATH}")
 
 
-REVIEW_TARGET_SCORE = float(_load_v6_build_constant("REVIEW_TARGET_SCORE"))
+@functools.lru_cache(maxsize=1)
+def _review_target_score() -> float:
+    """Lazy accessor for REVIEW_TARGET_SCORE.
+
+    Loading at import time was brittle: it ran AST parsing on
+    `v6_build.py` on every import of this module, which broke tests
+    that monkeypatch `PROJECT_ROOT` (the constant was already
+    evaluated against the real path before the fixture ran) and failed
+    with `FileNotFoundError` whenever this module was imported outside
+    a full checkout. Flagged by gemini-review on PR #1468.
+    """
+    return float(_load_v6_build_constant("REVIEW_TARGET_SCORE"))
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 module-level lazy attribute.
+
+    Preserves the `alignment_manifest.REVIEW_TARGET_SCORE` access
+    shape used by `tests/test_alignment_manifest.py::manifest_fixture`
+    (which monkeypatches this value to test threshold-change
+    invalidation). First real access triggers `_review_target_score()`
+    and caches the result as a real module attribute, so subsequent
+    accesses — including `monkeypatch.setattr` — see a normal attribute.
+    """
+    if name == "REVIEW_TARGET_SCORE":
+        value = _review_target_score()
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'alignment_manifest' has no attribute {name!r}")
 
 
 def _sha256_bytes(payload: bytes) -> str:
@@ -75,7 +104,11 @@ def _freeze(value: Any) -> Any:
 
 
 def _plan_path(level: str, slug: str) -> Path:
-    return CURRICULUM_ROOT / "plans" / level / f"{slug}.yaml"
+    # Curriculum plan directories are lowercase on disk (a1, b2-pro, hist, …).
+    # Canonicalize `level` so callers can pass "A1" or "B2-Pro" without
+    # breaking on case-sensitive filesystems. Flagged by gemini-review on
+    # PR #1468.
+    return CURRICULUM_ROOT / "plans" / level.lower() / f"{slug}.yaml"
 
 
 def _canonical_plan_hash(level: str, slug: str) -> str:
@@ -100,7 +133,10 @@ def _sqlite_indexed_table_names(connection: sqlite3.Connection) -> tuple[str, ..
         has_explicit_index = bool(
             connection.execute(f'PRAGMA index_list("{table_name}")').fetchall()
         )
-        is_virtual_table = "VIRTUAL TABLE" in table_sql.upper()
+        # Substring `"VIRTUAL TABLE"` would false-positive on a table
+        # named e.g. `my_virtual_table_data`. Match the DDL prefix instead.
+        # Flagged by gemini-review on PR #1468.
+        is_virtual_table = table_sql.upper().lstrip().startswith("CREATE VIRTUAL TABLE")
         if has_explicit_index or is_virtual_table:
             names.append(table_name)
     return tuple(sorted(names))
@@ -121,7 +157,11 @@ def _sources_hash() -> str:
     if not SOURCES_DB_PATH.exists():
         return _sha256_bytes(_stable_json_bytes(()))
 
-    with sqlite3.connect(f"file:{SOURCES_DB_PATH}?mode=ro", uri=True) as connection:
+    # `Path.as_uri()` produces a cross-platform-safe `file://…` URI;
+    # raw f-string interpolation leaks backslashes on Windows. Flagged
+    # by gemini-review on PR #1468.
+    db_uri = f"{SOURCES_DB_PATH.as_uri()}?mode=ro"
+    with sqlite3.connect(db_uri, uri=True) as connection:
         manifest_rows = tuple(
             _sqlite_table_snapshot(connection, table_name)
             for table_name in _sqlite_indexed_table_names(connection)
@@ -183,6 +223,9 @@ def _threshold_snapshot(level: str) -> dict[str, Any]:
     level_key = _resolve_level_config_key(level)
     return {
         "level_config": _freeze(audit_config.LEVEL_CONFIG[level_key]),
+        # Access the module attribute (not the `_review_target_score()`
+        # function directly) so tests can `monkeypatch.setattr` the
+        # value. See `__getattr__` / `_review_target_score` docstrings.
         "review_target_score": REVIEW_TARGET_SCORE,
     }
 

--- a/scripts/build/alignment_manifest.py
+++ b/scripts/build/alignment_manifest.py
@@ -1,0 +1,269 @@
+"""Alignment manifest helpers for cache invalidation across build sidecars."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+import re
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from build.phases import wiki_compressor
+
+from audit import config as audit_config
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
+SOURCES_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+CANONICAL_ANCHORS_PATH = PROJECT_ROOT / "data" / "canonical_anchors.yaml"
+DECISIONS_PATH = PROJECT_ROOT / "docs" / "decisions" / "decisions.yaml"
+PHASE_TEMPLATES_ROOT = PROJECT_ROOT / "scripts" / "build" / "phases"
+CLAUDE_PHASES_ROOT = PROJECT_ROOT / ".claude" / "phases" / "claude"
+GEMINI_PHASES_ROOT = PROJECT_ROOT / ".gemini" / "phases" / "gemini"
+V6_BUILD_PATH = PROJECT_ROOT / "scripts" / "build" / "v6_build.py"
+
+_ACTIVE_DECISION_SCOPES = {"pipeline", "architecture"}
+_TEMPLATE_KEY_RE = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _load_v6_build_constant(name: str) -> Any:
+    module = ast.parse(V6_BUILD_PATH.read_text("utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            targets = [target for target in node.targets if isinstance(target, ast.Name)]
+            if any(target.id == name for target in targets):
+                return ast.literal_eval(node.value)
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value is not None
+        ):
+            return ast.literal_eval(node.value)
+    raise RuntimeError(f"Could not load {name} from {V6_BUILD_PATH}")
+
+
+REVIEW_TARGET_SCORE = float(_load_v6_build_constant("REVIEW_TARGET_SCORE"))
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _stable_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple((key, _freeze(value[key])) for key in sorted(value))
+    if isinstance(value, set):
+        return tuple(sorted(_freeze(item) for item in value))
+    if isinstance(value, list | tuple):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _plan_path(level: str, slug: str) -> Path:
+    return CURRICULUM_ROOT / "plans" / level / f"{slug}.yaml"
+
+
+def _canonical_plan_hash(level: str, slug: str) -> str:
+    plan_data = yaml.safe_load(_plan_path(level, slug).read_text("utf-8"))
+    canonical_yaml = yaml.safe_dump(plan_data, sort_keys=True, allow_unicode=True)
+    return _sha256_bytes(canonical_yaml.encode("utf-8"))
+
+
+def _sqlite_indexed_table_names(connection: sqlite3.Connection) -> tuple[str, ...]:
+    rows = connection.execute(
+        """
+        SELECT name, COALESCE(sql, '')
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+        """
+    ).fetchall()
+    names: list[str] = []
+    for name, sql in rows:
+        table_name = str(name)
+        table_sql = str(sql or "")
+        has_explicit_index = bool(
+            connection.execute(f'PRAGMA index_list("{table_name}")').fetchall()
+        )
+        is_virtual_table = "VIRTUAL TABLE" in table_sql.upper()
+        if has_explicit_index or is_virtual_table:
+            names.append(table_name)
+    return tuple(sorted(names))
+
+
+def _sqlite_table_snapshot(connection: sqlite3.Connection, table_name: str) -> dict[str, Any]:
+    row_count, max_rowid = connection.execute(
+        f'SELECT COUNT(*), MAX(rowid) FROM "{table_name}"'
+    ).fetchone()
+    return {
+        "table_name": table_name,
+        "row_count": int(row_count or 0),
+        "max_rowid": None if max_rowid is None else int(max_rowid),
+    }
+
+
+def _sources_hash() -> str:
+    if not SOURCES_DB_PATH.exists():
+        return _sha256_bytes(_stable_json_bytes(()))
+
+    with sqlite3.connect(f"file:{SOURCES_DB_PATH}?mode=ro", uri=True) as connection:
+        manifest_rows = tuple(
+            _sqlite_table_snapshot(connection, table_name)
+            for table_name in _sqlite_indexed_table_names(connection)
+        )
+    return _sha256_bytes(_stable_json_bytes(manifest_rows))
+
+
+def _template_key(prefix: str, relative_path: Path) -> str:
+    stem = str(relative_path.with_suffix("")).replace("\\", "/")
+    key = _TEMPLATE_KEY_RE.sub("_", stem).strip("_").lower()
+    return f"{prefix}__{key}" if prefix else key
+
+
+def _template_hashes_from_root(
+    root: Path,
+    *,
+    prefix: str,
+    include_all_files: bool,
+) -> dict[str, str]:
+    if not root.exists():
+        return {}
+
+    hashes: dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        if not include_all_files and path.suffix != ".md":
+            continue
+        relative_path = path.relative_to(root)
+        hashes[_template_key(prefix, relative_path)] = _sha256_bytes(path.read_bytes())
+    return hashes
+
+
+def _template_hashes() -> dict[str, str]:
+    template_hashes: dict[str, str] = {}
+    template_hashes.update(
+        _template_hashes_from_root(CLAUDE_PHASES_ROOT, prefix="claude", include_all_files=True)
+    )
+    template_hashes.update(
+        _template_hashes_from_root(GEMINI_PHASES_ROOT, prefix="gemini", include_all_files=True)
+    )
+    template_hashes.update(
+        _template_hashes_from_root(PHASE_TEMPLATES_ROOT, prefix="", include_all_files=False)
+    )
+    return dict(sorted(template_hashes.items()))
+
+
+def _canonical_anchor_hash() -> str:
+    return _sha256_bytes(CANONICAL_ANCHORS_PATH.read_bytes())
+
+
+def _resolve_level_config_key(level: str) -> str:
+    candidates = (level, level.upper(), level.lower(), level.capitalize())
+    for candidate in candidates:
+        if candidate in audit_config.LEVEL_CONFIG:
+            return candidate
+    raise KeyError(f"No LEVEL_CONFIG entry for {level!r}")
+
+
+def _threshold_snapshot(level: str) -> dict[str, Any]:
+    level_key = _resolve_level_config_key(level)
+    return {
+        "level_config": _freeze(audit_config.LEVEL_CONFIG[level_key]),
+        "review_target_score": REVIEW_TARGET_SCORE,
+    }
+
+
+def _decisions_subset() -> list[tuple[str, str]]:
+    if not DECISIONS_PATH.exists():
+        return []
+
+    payload = yaml.safe_load(DECISIONS_PATH.read_text("utf-8")) or {}
+    decisions = payload.get("decisions") or []
+    subset = [
+        (str(decision["id"]), str(decision["status"]))
+        for decision in decisions
+        if decision.get("status") == "active"
+        and decision.get("scope") in _ACTIVE_DECISION_SCOPES
+    ]
+    return sorted(subset)
+
+
+def compose_manifest(*, level: str, slug: str) -> dict:
+    """Build the full manifest dict (callers can inspect fields or the hash)."""
+    return {
+        "plan_hash": _canonical_plan_hash(level, slug),
+        "sources_hash": _sources_hash(),
+        "template_hashes": _template_hashes(),
+        "canonical_anchor_hash": _canonical_anchor_hash(),
+        "tokenizer_version": wiki_compressor.TOKENIZER_VERSION,
+        "threshold_snapshot": _threshold_snapshot(level),
+        "decisions_subset": _decisions_subset(),
+    }
+
+
+def manifest_hash(manifest: dict) -> str:
+    """Return the SHA-256 hex digest of the canonicalized manifest."""
+    return _sha256_bytes(_stable_json_bytes(manifest))
+
+
+def stamp_artifact(artifact: dict, manifest: dict) -> dict:
+    """Return artifact with `alignment_manifest` block injected (non-destructive)."""
+    stamped = copy.deepcopy(artifact)
+    stamped["alignment_manifest"] = {
+        "composite_hash": manifest_hash(manifest),
+        "composed_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "components": copy.deepcopy(manifest),
+    }
+    return stamped
+
+
+def _diff_component(prefix: str, current_value: Any, stamped_value: Any) -> tuple[str, ...]:
+    if isinstance(current_value, dict) and isinstance(stamped_value, dict):
+        reasons: list[str] = []
+        for key in sorted(set(current_value) | set(stamped_value)):
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if key not in current_value or key not in stamped_value:
+                reasons.append(child_prefix)
+                continue
+            reasons.extend(_diff_component(child_prefix, current_value[key], stamped_value[key]))
+        return tuple(reasons)
+    if current_value != stamped_value:
+        return (prefix,)
+    return ()
+
+
+def validate_stamped_artifact(
+    artifact: dict,
+    current_manifest: dict,
+) -> tuple[bool, tuple[str, ...]]:
+    """Return (is_fresh, mismatch_reasons)."""
+    stamped_manifest = artifact.get("alignment_manifest")
+    if not isinstance(stamped_manifest, dict):
+        return False, ("alignment_manifest",)
+
+    stamped_components = stamped_manifest.get("components")
+    if not isinstance(stamped_components, dict):
+        return False, ("alignment_manifest",)
+
+    mismatch_reasons = _diff_component("", current_manifest, stamped_components)
+    if mismatch_reasons:
+        return False, mismatch_reasons
+
+    if stamped_manifest.get("composite_hash") != manifest_hash(current_manifest):
+        return False, ("composite_hash",)
+
+    return True, ()

--- a/scripts/build/phases/wiki_compressor.py
+++ b/scripts/build/phases/wiki_compressor.py
@@ -6,6 +6,8 @@ import re
 import unicodedata
 from collections import defaultdict
 
+TOKENIZER_VERSION = "2026-04-23"
+
 _TOKEN_RE = re.compile(r"[A-Za-zА-Яа-яІіЇїЄєҐґ'][A-Za-zА-Яа-яІіЇїЄєҐґ'’-]{1,}")
 _STOPWORDS = {
     "але",

--- a/tests/test_alignment_manifest.py
+++ b/tests/test_alignment_manifest.py
@@ -1,0 +1,269 @@
+"""Tests for the alignment manifest contract."""
+
+from __future__ import annotations
+
+import copy
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from build import alignment_manifest
+from build.phases import wiki_compressor
+
+from audit import config as audit_config
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+        "utf-8",
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, "utf-8")
+
+
+def _build_sources_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "CREATE TABLE source_chunks (id INTEGER PRIMARY KEY, body TEXT NOT NULL)"
+        )
+        connection.execute(
+            "CREATE INDEX idx_source_chunks_body ON source_chunks(body)"
+        )
+        connection.execute(
+            "INSERT INTO source_chunks(body) VALUES (?)",
+            ("first row",),
+        )
+        connection.commit()
+
+
+@pytest.fixture
+def manifest_fixture(tmp_path: Path, monkeypatch) -> dict[str, Path]:
+    repo_root = tmp_path
+    curriculum_root = repo_root / "curriculum" / "l2-uk-en"
+    plan_path = curriculum_root / "plans" / "a1" / "demo.yaml"
+    sources_db_path = repo_root / "data" / "sources.db"
+    canonical_anchors_path = repo_root / "data" / "canonical_anchors.yaml"
+    decisions_path = repo_root / "docs" / "decisions" / "decisions.yaml"
+    phase_template_path = repo_root / "scripts" / "build" / "phases" / "v6-write.md"
+
+    _write_yaml(
+        plan_path,
+        {
+            "slug": "demo",
+            "level": "A1",
+            "title": "Alignment demo",
+            "word_target": 1200,
+            "objectives": ["Test the manifest contract."],
+        },
+    )
+    _build_sources_db(sources_db_path)
+    _write_text(canonical_anchors_path, "anchors:\n  - id: flag\n")
+    _write_yaml(
+        decisions_path,
+        {
+            "decisions": [
+                {"id": "dec-001", "status": "active", "scope": "pipeline"},
+                {"id": "dec-002", "status": "active", "scope": "architecture"},
+                {"id": "dec-003", "status": "active", "scope": "content"},
+            ]
+        },
+    )
+    _write_text(phase_template_path, "# Writer prompt\n\nOriginal template.\n")
+    _write_text(
+        repo_root / ".claude" / "phases" / "claude" / "writer.md",
+        "Claude prompt.\n",
+    )
+    _write_text(
+        repo_root / ".gemini" / "phases" / "gemini" / "review.md",
+        "Gemini prompt.\n",
+    )
+
+    monkeypatch.setattr(alignment_manifest, "PROJECT_ROOT", repo_root)
+    monkeypatch.setattr(alignment_manifest, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(alignment_manifest, "SOURCES_DB_PATH", sources_db_path)
+    monkeypatch.setattr(alignment_manifest, "CANONICAL_ANCHORS_PATH", canonical_anchors_path)
+    monkeypatch.setattr(alignment_manifest, "DECISIONS_PATH", decisions_path)
+    monkeypatch.setattr(
+        alignment_manifest,
+        "PHASE_TEMPLATES_ROOT",
+        repo_root / "scripts" / "build" / "phases",
+    )
+    monkeypatch.setattr(
+        alignment_manifest,
+        "CLAUDE_PHASES_ROOT",
+        repo_root / ".claude" / "phases" / "claude",
+    )
+    monkeypatch.setattr(
+        alignment_manifest,
+        "GEMINI_PHASES_ROOT",
+        repo_root / ".gemini" / "phases" / "gemini",
+    )
+    monkeypatch.setattr(alignment_manifest, "REVIEW_TARGET_SCORE", 8.0)
+    monkeypatch.setattr(audit_config, "LEVEL_CONFIG", copy.deepcopy(audit_config.LEVEL_CONFIG))
+
+    return {
+        "plan_path": plan_path,
+        "sources_db_path": sources_db_path,
+        "canonical_anchors_path": canonical_anchors_path,
+        "decisions_path": decisions_path,
+        "phase_template_path": phase_template_path,
+    }
+
+
+def _compose() -> dict:
+    return alignment_manifest.compose_manifest(level="a1", slug="demo")
+
+
+def test_manifest_is_deterministic(manifest_fixture: dict[str, Path]) -> None:
+    first = _compose()
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(first) == alignment_manifest.manifest_hash(second)
+
+
+def test_plan_change_invalidates_manifest(manifest_fixture: dict[str, Path]) -> None:
+    first = _compose()
+
+    _write_yaml(
+        manifest_fixture["plan_path"],
+        {
+            "slug": "demo",
+            "level": "A1",
+            "title": "Alignment demo updated",
+            "word_target": 1200,
+            "objectives": ["Test the manifest contract."],
+        },
+    )
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_sources_db_change_invalidates_manifest(manifest_fixture: dict[str, Path]) -> None:
+    first = _compose()
+
+    with sqlite3.connect(manifest_fixture["sources_db_path"]) as connection:
+        connection.execute(
+            "INSERT INTO source_chunks(body) VALUES (?)",
+            ("second row",),
+        )
+        connection.commit()
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_template_change_invalidates_manifest(manifest_fixture: dict[str, Path]) -> None:
+    first = _compose()
+
+    _write_text(
+        manifest_fixture["phase_template_path"],
+        "# Writer prompt\n\nUpdated template.\n",
+    )
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_canonical_anchor_change_invalidates_manifest(manifest_fixture: dict[str, Path]) -> None:
+    first = _compose()
+
+    _write_text(
+        manifest_fixture["canonical_anchors_path"],
+        "anchors:\n  - id: flag\n  - id: anthem\n",
+    )
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_tokenizer_version_bump_invalidates_manifest(
+    manifest_fixture: dict[str, Path],
+    monkeypatch,
+) -> None:
+    first = _compose()
+
+    monkeypatch.setattr(wiki_compressor, "TOKENIZER_VERSION", "2026-04-24")
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_threshold_change_invalidates_manifest(
+    manifest_fixture: dict[str, Path],
+    monkeypatch,
+) -> None:
+    first = _compose()
+
+    monkeypatch.setattr(alignment_manifest, "REVIEW_TARGET_SCORE", 8.5)
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_decision_status_change_invalidates_manifest(manifest_fixture: dict[str, Path]) -> None:
+    first = _compose()
+
+    _write_yaml(
+        manifest_fixture["decisions_path"],
+        {
+            "decisions": [
+                {"id": "dec-001", "status": "superseded", "scope": "pipeline"},
+                {"id": "dec-002", "status": "active", "scope": "architecture"},
+                {"id": "dec-003", "status": "active", "scope": "content"},
+            ]
+        },
+    )
+
+    second = _compose()
+
+    assert alignment_manifest.manifest_hash(second) != alignment_manifest.manifest_hash(first)
+
+
+def test_stamp_roundtrip(manifest_fixture: dict[str, Path]) -> None:
+    manifest = _compose()
+    artifact = {"slug": "demo", "status": "complete"}
+
+    stamped = alignment_manifest.stamp_artifact(artifact, manifest)
+
+    assert alignment_manifest.validate_stamped_artifact(stamped, manifest) == (True, ())
+    assert artifact == {"slug": "demo", "status": "complete"}
+
+
+def test_validate_reports_specific_mismatch(manifest_fixture: dict[str, Path]) -> None:
+    manifest = _compose()
+    stamped = alignment_manifest.stamp_artifact({"slug": "demo"}, manifest)
+
+    _write_yaml(
+        manifest_fixture["plan_path"],
+        {
+            "slug": "demo",
+            "level": "A1",
+            "title": "Changed after stamp",
+            "word_target": 1200,
+            "objectives": ["Test the manifest contract."],
+        },
+    )
+    current_manifest = _compose()
+
+    assert alignment_manifest.validate_stamped_artifact(stamped, current_manifest) == (
+        False,
+        ("plan_hash",),
+    )


### PR DESCRIPTION
## Summary
- add `scripts/build/alignment_manifest.py` to compose deterministic alignment manifests, hash them, stamp artifacts, and validate stamped sidecars with field-level mismatch reasons
- hash the requested upstream inputs: canonicalized plan YAML, cheap `sources.db` table snapshots, prompt templates, canonical anchors, tokenizer version, thresholds, and active pipeline/architecture decisions
- add focused unit coverage for every invalidation path and stamp/validate roundtrips, and add `TOKENIZER_VERSION` to `wiki_compressor.py`

## Testing
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_alignment_manifest.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_wiki_compressor_tokenize.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_alignment_manifest.py tests/test_wiki_compressor_tokenize.py -q`
