### PR TITLE
feat(build): sidecar freshness invariant (#1453 P1-B of #1451)

### DIFF
--- a/scripts/build/alignment_manifest.py
+++ b/scripts/build/alignment_manifest.py
@@ -6,9 +6,11 @@ import ast
 import copy
 import functools
 import hashlib
+import inspect
 import json
 import re
 import sqlite3
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -18,22 +20,135 @@ from build.phases import wiki_compressor
 
 from audit import config as audit_config
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
-SOURCES_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
-CANONICAL_ANCHORS_PATH = PROJECT_ROOT / "data" / "canonical_anchors.yaml"
-DECISIONS_PATH = PROJECT_ROOT / "docs" / "decisions" / "decisions.yaml"
-PHASE_TEMPLATES_ROOT = PROJECT_ROOT / "scripts" / "build" / "phases"
-CLAUDE_PHASES_ROOT = PROJECT_ROOT / ".claude" / "phases" / "claude"
-GEMINI_PHASES_ROOT = PROJECT_ROOT / ".gemini" / "phases" / "gemini"
-V6_BUILD_PATH = PROJECT_ROOT / "scripts" / "build" / "v6_build.py"
-
 _ACTIVE_DECISION_SCOPES = {"pipeline", "architecture"}
 _TEMPLATE_KEY_RE = re.compile(r"[^A-Za-z0-9]+")
+_PATH_ATTRS = {
+    "PROJECT_ROOT",
+    "CURRICULUM_ROOT",
+    "SOURCES_DB_PATH",
+    "CANONICAL_ANCHORS_PATH",
+    "DECISIONS_PATH",
+    "PHASE_TEMPLATES_ROOT",
+    "CLAUDE_PHASES_ROOT",
+    "GEMINI_PHASES_ROOT",
+    "V6_BUILD_PATH",
+}
+
+
+def _default_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_v6_build_path() -> Path:
+    return _default_project_root() / "scripts" / "build" / "v6_build.py"
+
+
+def _static_default_attr(name: str) -> Any:
+    if name == "PROJECT_ROOT":
+        return _default_project_root()
+    if name == "CURRICULUM_ROOT":
+        return _default_project_root() / "curriculum" / "l2-uk-en"
+    if name == "SOURCES_DB_PATH":
+        return _default_project_root() / "data" / "sources.db"
+    if name == "CANONICAL_ANCHORS_PATH":
+        return _default_project_root() / "data" / "canonical_anchors.yaml"
+    if name == "DECISIONS_PATH":
+        return _default_project_root() / "docs" / "decisions" / "decisions.yaml"
+    if name == "PHASE_TEMPLATES_ROOT":
+        return _default_project_root() / "scripts" / "build" / "phases"
+    if name == "CLAUDE_PHASES_ROOT":
+        return _default_project_root() / ".claude" / "phases" / "claude"
+    if name == "GEMINI_PHASES_ROOT":
+        return _default_project_root() / ".gemini" / "phases" / "gemini"
+    if name == "V6_BUILD_PATH":
+        return _default_v6_build_path()
+    raise AttributeError(f"module 'alignment_manifest' has no attribute {name!r}")
+
+
+def _v6_build_module() -> Any | None:
+    v6_build_path = _default_v6_build_path().resolve()
+
+    frame = inspect.currentframe()
+    while frame is not None:
+        frame = frame.f_back
+        if frame is None:
+            break
+        module_file = frame.f_globals.get("__file__")
+        if module_file is None:
+            continue
+        if Path(module_file).resolve() != v6_build_path:
+            continue
+        module_name = frame.f_globals.get("__name__")
+        module = sys.modules.get(str(module_name))
+        if module is not None:
+            return module
+
+    for module_name in ("build.v6_build", "scripts.build.v6_build", "v6_build"):
+        module = sys.modules.get(module_name)
+        if module is not None:
+            return module
+
+    for module in sys.modules.values():
+        module_file = getattr(module, "__file__", None)
+        if module_file is not None and Path(module_file).resolve() == v6_build_path:
+            return module
+    return None
+
+
+def _resolve_attr(name: str) -> Any:
+    v6_build = _v6_build_module()
+
+    if name == "PROJECT_ROOT":
+        root = getattr(v6_build, "PROJECT_ROOT", None) if v6_build is not None else None
+        return Path(root) if root is not None else _default_project_root()
+    if name == "CURRICULUM_ROOT":
+        root = getattr(v6_build, "CURRICULUM_ROOT", None) if v6_build is not None else None
+        return Path(root) if root is not None else _resolve_attr("PROJECT_ROOT") / "curriculum" / "l2-uk-en"
+    if name == "SOURCES_DB_PATH":
+        return _resolve_attr("PROJECT_ROOT") / "data" / "sources.db"
+    if name == "CANONICAL_ANCHORS_PATH":
+        return _resolve_attr("PROJECT_ROOT") / "data" / "canonical_anchors.yaml"
+    if name == "DECISIONS_PATH":
+        return _resolve_attr("PROJECT_ROOT") / "docs" / "decisions" / "decisions.yaml"
+    if name == "PHASE_TEMPLATES_ROOT":
+        root = getattr(v6_build, "PHASES_DIR", None) if v6_build is not None else None
+        return (
+            Path(root)
+            if root is not None
+            else _resolve_attr("PROJECT_ROOT") / "scripts" / "build" / "phases"
+        )
+    if name == "CLAUDE_PHASES_ROOT":
+        return _resolve_attr("PROJECT_ROOT") / ".claude" / "phases" / "claude"
+    if name == "GEMINI_PHASES_ROOT":
+        return _resolve_attr("PROJECT_ROOT") / ".gemini" / "phases" / "gemini"
+    if name == "V6_BUILD_PATH":
+        module_file = getattr(v6_build, "__file__", None) if v6_build is not None else None
+        return (
+            Path(module_file).resolve()
+            if module_file is not None
+            else _default_v6_build_path()
+        )
+    if name == "REVIEW_TARGET_SCORE":
+        return _review_target_score()
+    raise AttributeError(f"module 'alignment_manifest' has no attribute {name!r}")
+
+
+def _module_attr(name: str) -> Any:
+    if name in globals():
+        value = globals()[name]
+        if name in _PATH_ATTRS and value == _static_default_attr(name):
+            return _resolve_attr(name)
+        return value
+    return _resolve_attr(name)
 
 
 def _load_v6_build_constant(name: str) -> Any:
-    module = ast.parse(V6_BUILD_PATH.read_text("utf-8"))
+    v6_build = _v6_build_module()
+    if v6_build is not None and hasattr(v6_build, name):
+        return getattr(v6_build, name)
+
+    v6_build_path = _module_attr("V6_BUILD_PATH")
+    module = ast.parse(v6_build_path.read_text("utf-8"))
     for node in module.body:
         if isinstance(node, ast.Assign):
             targets = [target for target in node.targets if isinstance(target, ast.Name)]
@@ -46,7 +161,7 @@ def _load_v6_build_constant(name: str) -> Any:
             and node.value is not None
         ):
             return ast.literal_eval(node.value)
-    raise RuntimeError(f"Could not load {name} from {V6_BUILD_PATH}")
+    raise RuntimeError(f"Could not load {name} from {v6_build_path}")
 
 
 @functools.lru_cache(maxsize=1)
@@ -66,17 +181,13 @@ def _review_target_score() -> float:
 def __getattr__(name: str) -> Any:
     """PEP 562 module-level lazy attribute.
 
-    Preserves the `alignment_manifest.REVIEW_TARGET_SCORE` access
-    shape used by `tests/test_alignment_manifest.py::manifest_fixture`
-    (which monkeypatches this value to test threshold-change
-    invalidation). First real access triggers `_review_target_score()`
-    and caches the result as a real module attribute, so subsequent
-    accesses — including `monkeypatch.setattr` — see a normal attribute.
+    Preserves the `alignment_manifest.<CONST>` access shape used by
+    tests without pinning repo paths at import time. Callers that
+    monkeypatch this module still override the returned values by
+    assigning real module attributes.
     """
-    if name == "REVIEW_TARGET_SCORE":
-        value = _review_target_score()
-        globals()[name] = value
-        return value
+    if name in _PATH_ATTRS or name == "REVIEW_TARGET_SCORE":
+        return _resolve_attr(name)
     raise AttributeError(f"module 'alignment_manifest' has no attribute {name!r}")
 
 
@@ -108,7 +219,7 @@ def _plan_path(level: str, slug: str) -> Path:
     # Canonicalize `level` so callers can pass "A1" or "B2-Pro" without
     # breaking on case-sensitive filesystems. Flagged by gemini-review on
     # PR #1468.
-    return CURRICULUM_ROOT / "plans" / level.lower() / f"{slug}.yaml"
+    return _module_attr("CURRICULUM_ROOT") / "plans" / level.lower() / f"{slug}.yaml"
 
 
 def _canonical_plan_hash(level: str, slug: str) -> str:
@@ -154,13 +265,14 @@ def _sqlite_table_snapshot(connection: sqlite3.Connection, table_name: str) -> d
 
 
 def _sources_hash() -> str:
-    if not SOURCES_DB_PATH.exists():
+    sources_db_path = _module_attr("SOURCES_DB_PATH")
+    if not sources_db_path.exists():
         return _sha256_bytes(_stable_json_bytes(()))
 
     # `Path.as_uri()` produces a cross-platform-safe `file://…` URI;
     # raw f-string interpolation leaks backslashes on Windows. Flagged
     # by gemini-review on PR #1468.
-    db_uri = f"{SOURCES_DB_PATH.as_uri()}?mode=ro"
+    db_uri = f"{sources_db_path.as_uri()}?mode=ro"
     with sqlite3.connect(db_uri, uri=True) as connection:
         manifest_rows = tuple(
             _sqlite_table_snapshot(connection, table_name)
@@ -196,19 +308,34 @@ def _template_hashes_from_root(
 def _template_hashes() -> dict[str, str]:
     template_hashes: dict[str, str] = {}
     template_hashes.update(
-        _template_hashes_from_root(CLAUDE_PHASES_ROOT, prefix="claude", include_all_files=True)
+        _template_hashes_from_root(
+            _module_attr("CLAUDE_PHASES_ROOT"),
+            prefix="claude",
+            include_all_files=True,
+        )
     )
     template_hashes.update(
-        _template_hashes_from_root(GEMINI_PHASES_ROOT, prefix="gemini", include_all_files=True)
+        _template_hashes_from_root(
+            _module_attr("GEMINI_PHASES_ROOT"),
+            prefix="gemini",
+            include_all_files=True,
+        )
     )
     template_hashes.update(
-        _template_hashes_from_root(PHASE_TEMPLATES_ROOT, prefix="", include_all_files=False)
+        _template_hashes_from_root(
+            _module_attr("PHASE_TEMPLATES_ROOT"),
+            prefix="",
+            include_all_files=False,
+        )
     )
     return dict(sorted(template_hashes.items()))
 
 
 def _canonical_anchor_hash() -> str:
-    return _sha256_bytes(CANONICAL_ANCHORS_PATH.read_bytes())
+    canonical_anchors_path = _module_attr("CANONICAL_ANCHORS_PATH")
+    if not canonical_anchors_path.exists():
+        return _sha256_bytes(b"")
+    return _sha256_bytes(canonical_anchors_path.read_bytes())
 
 
 def _resolve_level_config_key(level: str) -> str:
@@ -226,15 +353,16 @@ def _threshold_snapshot(level: str) -> dict[str, Any]:
         # Access the module attribute (not the `_review_target_score()`
         # function directly) so tests can `monkeypatch.setattr` the
         # value. See `__getattr__` / `_review_target_score` docstrings.
-        "review_target_score": REVIEW_TARGET_SCORE,
+        "review_target_score": _module_attr("REVIEW_TARGET_SCORE"),
     }
 
 
 def _decisions_subset() -> list[tuple[str, str]]:
-    if not DECISIONS_PATH.exists():
+    decisions_path = _module_attr("DECISIONS_PATH")
+    if not decisions_path.exists():
         return []
 
-    payload = yaml.safe_load(DECISIONS_PATH.read_text("utf-8")) or {}
+    payload = yaml.safe_load(decisions_path.read_text("utf-8")) or {}
     decisions = payload.get("decisions") or []
     subset = [
         (str(decision["id"]), str(decision["status"]))

--- a/scripts/build/convergence_loop.py
+++ b/scripts/build/convergence_loop.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
+from build.alignment_manifest import compose_manifest
 from build.finding_normalizer import normalize_findings
 from build.finding_topology import classify_topology
 from build.module_memory import (
@@ -493,11 +494,16 @@ def _persistent_finding_payload(
 
 
 def run_convergence_loop(context: ConvergenceContext) -> ConvergenceRunResult:
+    current_manifest = compose_manifest(
+        level=context.level,
+        slug=context.slug,
+    )
     memory, _invalidated = load_module_memory(
         context.memory_path,
         expected_plan_hash=context.plan_hash,
         expected_plan_version=context.plan_version,
         expected_sources_hash=context.sources_hash,
+        current_manifest=current_manifest,
     )
     current_writer = context.writer
     attempted_tiers: set[int] = set()
@@ -530,7 +536,7 @@ def run_convergence_loop(context: ConvergenceContext) -> ConvergenceRunResult:
     round_record["prioritized_findings"] = list(prioritized_findings)
     round_record["tier"] = 0
     rounds.append(round_record)
-    save_module_memory(context.memory_path, memory)
+    save_module_memory(context.memory_path, memory, current_manifest=current_manifest)
     if observation.passed:
         return ConvergenceRunResult(
             terminal="pass",
@@ -682,7 +688,7 @@ def run_convergence_loop(context: ConvergenceContext) -> ConvergenceRunResult:
             round_record["prioritized_findings"] = list(prioritized_findings)
             round_record["tier"] = decision.tier
             rounds.append(round_record)
-            save_module_memory(context.memory_path, memory)
+            save_module_memory(context.memory_path, memory, current_manifest=current_manifest)
             previous_round = {
                 "tier": decision.tier,
                 "strategy": decision.strategy,
@@ -715,7 +721,7 @@ def run_convergence_loop(context: ConvergenceContext) -> ConvergenceRunResult:
             round_record["prioritized_findings"] = list(decision.prioritized_findings)
             round_record["tier"] = decision.tier
             rounds.append(round_record)
-            save_module_memory(context.memory_path, memory)
+            save_module_memory(context.memory_path, memory, current_manifest=current_manifest)
             break
 
         previous_round = {
@@ -756,7 +762,7 @@ def run_convergence_loop(context: ConvergenceContext) -> ConvergenceRunResult:
         round_record["prioritized_findings"] = list(prioritized_findings)
         round_record["tier"] = decision.tier
         rounds.append(round_record)
-        save_module_memory(context.memory_path, memory)
+        save_module_memory(context.memory_path, memory, current_manifest=current_manifest)
 
         if observation.passed:
             return ConvergenceRunResult(

--- a/scripts/build/module_memory.py
+++ b/scripts/build/module_memory.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import yaml
+from build.alignment_manifest import manifest_hash, stamp_artifact
 
 PLAN_LEVEL_ERROR_CLASSES = {
     "vocab_density",
@@ -33,6 +35,8 @@ WRITER_ADDRESSABLE_ERROR_CLASSES = {
     "surzhyk",
     "word_budget",
 }
+
+logger = logging.getLogger(__name__)
 
 
 def module_memory_path(curriculum_root: Path, level: str, slug: str) -> Path:
@@ -77,14 +81,12 @@ def _write_yaml_atomic(path: Path, data: Any) -> None:
 
 def _default_memory(
     *,
-    plan_hash: str | None = None,
+    alignment_manifest_hash: str | None = None,
     plan_version: int | None = None,
-    sources_hash: str | None = None,
 ) -> dict[str, Any]:
     return {
-        "plan_hash": plan_hash or "",
+        "alignment_manifest_hash": alignment_manifest_hash or "",
         "plan_version": int(plan_version or 0),
-        "sources_hash": sources_hash or "",
         "constraints": [],
         "history": [],
         "events": [],
@@ -270,6 +272,7 @@ def load_module_memory(
     expected_plan_hash: str | None = None,
     expected_plan_version: int | None = None,
     expected_sources_hash: str | None = None,
+    current_manifest: dict[str, Any] | None = None,
     reset: bool = False,
 ) -> tuple[dict[str, Any], bool]:
     if reset:
@@ -281,55 +284,82 @@ def load_module_memory(
     else:
         memory = {}
 
+    stored_hash = str(memory.get("alignment_manifest_hash") or "")
+    current_hash = manifest_hash(current_manifest) if current_manifest is not None else ""
     merged = _default_memory(
-        plan_hash=memory.get("plan_hash"),
+        alignment_manifest_hash=stored_hash,
         plan_version=memory.get("plan_version"),
-        sources_hash=memory.get("sources_hash"),
     )
     merged["constraints"] = list(memory.get("constraints") or [])
     merged["history"] = list(memory.get("history") or [])
     merged["events"] = list(memory.get("events") or [])
 
     invalidated = False
-    if (
-        expected_plan_hash
-        and merged["plan_hash"]
-        and merged["plan_hash"] != expected_plan_hash
-    ):
+    legacy_payload = bool(current_hash) and not stored_hash and bool(
+        memory.get("plan_hash") or memory.get("sources_hash")
+    )
+    if legacy_payload:
+        invalidated = True
+        merged["constraints"] = []
+        logger.info(
+            "Migrating legacy module memory without alignment_manifest_hash at %s; invalidating constraints",
+            path,
+        )
+        merged["events"].append(
+            {
+                "type": "alignment_manifest_migration_invalidation",
+                "ts": datetime.now(tz=UTC).isoformat(),
+                "previous_plan_hash": str(memory.get("plan_hash") or ""),
+                "previous_sources_hash": str(memory.get("sources_hash") or ""),
+                "current_hash": current_hash,
+            }
+        )
+    elif current_hash and stored_hash and stored_hash != current_hash:
         invalidated = True
         merged["constraints"] = []
         merged["events"].append(
             {
-                "type": "plan_hash_invalidation",
+                "type": "alignment_manifest_invalidation",
                 "ts": datetime.now(tz=UTC).isoformat(),
-                "previous_plan_hash": merged["plan_hash"],
-                "current_plan_hash": expected_plan_hash,
+                "previous_hash": stored_hash,
+                "current_hash": current_hash,
             }
         )
 
-    if expected_plan_hash is not None:
-        merged["plan_hash"] = expected_plan_hash
+    if current_hash:
+        merged["alignment_manifest_hash"] = current_hash
     if expected_plan_version is not None:
         merged["plan_version"] = int(expected_plan_version)
-    if expected_sources_hash is not None:
-        merged["sources_hash"] = expected_sources_hash
 
-    if not path.exists() or invalidated:
-        save_module_memory(path, merged)
+    if (
+        not path.exists()
+        or invalidated
+        or (current_hash and stored_hash != current_hash)
+    ):
+        save_module_memory(path, merged, current_manifest=current_manifest)
 
     return merged, invalidated
 
 
-def save_module_memory(path: Path, memory: dict[str, Any]) -> None:
+def save_module_memory(
+    path: Path,
+    memory: dict[str, Any],
+    *,
+    current_manifest: dict[str, Any] | None = None,
+) -> None:
     normalized = _default_memory(
-        plan_hash=str(memory.get("plan_hash") or ""),
+        alignment_manifest_hash=(
+            manifest_hash(current_manifest)
+            if current_manifest is not None
+            else str(memory.get("alignment_manifest_hash") or "")
+        ),
         plan_version=int(memory.get("plan_version") or 0),
-        sources_hash=str(memory.get("sources_hash") or ""),
     )
     normalized["constraints"] = list(memory.get("constraints") or [])
     normalized["history"] = list(memory.get("history") or [])
     normalized["events"] = list(memory.get("events") or [])
-    _write_yaml_atomic(path, normalized)
+    payload = stamp_artifact(normalized, current_manifest) if current_manifest is not None else normalized
+    _write_yaml_atomic(path, payload)
 
 
 def append_history(memory: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -81,6 +81,7 @@ from batch_gemini_config import (
     TIMEOUT_WRITE,
     TIMEOUT_WRITE_NO_TOOLS,
 )
+from build.alignment_manifest import compose_manifest, stamp_artifact, validate_stamped_artifact
 from build.convergence_loop import (
     ConvergenceContext,
     RecoverableValidationError,
@@ -252,7 +253,19 @@ def _read_v6_state(level: str, slug: str) -> dict:
 
 def _write_v6_state_atomic(state_path: Path, state: dict) -> None:
     """Write state.json atomically via temp file + os.replace()."""
-    write_json_atomic(state_path, state, indent=2, ensure_ascii=False)
+    stamped_state = dict(state)
+    if state_path.name == "state.json" and state_path.parent.parent.name == "orchestration":
+        level = state_path.parent.parent.parent.name
+        slug = state_path.parent.name
+        stamped_state = stamp_artifact(stamped_state, _current_alignment_manifest(level, slug))
+    write_json_atomic(state_path, stamped_state, indent=2, ensure_ascii=False)
+
+
+def _current_alignment_manifest(level: str, slug: str) -> dict:
+    return compose_manifest(
+        level=level,
+        slug=slug,
+    )
 
 
 def _handle_rate_limit_backoff(raw: str, attempt: int, max_attempts: int, phase: str) -> bool:
@@ -3202,10 +3215,23 @@ def _ensure_contract_artifacts(
     log_creation: bool = False,
 ) -> tuple[dict, dict]:
     """Load or build contract + wiki excerpt artifacts for a module."""
+    current_manifest = _current_alignment_manifest(level, slug)
     contract_path = _contract_path(level, slug)
     excerpts_path = _wiki_excerpts_path(level, slug)
     if contract_path.exists() and excerpts_path.exists():
-        return _load_yaml_artifact(contract_path), _load_yaml_artifact(excerpts_path)
+        contract = _load_yaml_artifact(contract_path)
+        excerpts = _load_yaml_artifact(excerpts_path)
+        contract_fresh, contract_mismatches = validate_stamped_artifact(contract, current_manifest)
+        excerpts_fresh, excerpts_mismatches = validate_stamped_artifact(excerpts, current_manifest)
+        if contract_fresh and excerpts_fresh:
+            if log_creation:
+                _log("  ♻️  Contract/wiki sidecars fresh — reusing cached artifacts")
+            return contract, excerpts
+        _log(
+            "  ♻️  Rebuilding contract/excerpts — stale sidecar "
+            f"(contract mismatches: {contract_mismatches}, "
+            f"excerpts mismatches: {excerpts_mismatches})"
+        )
 
     plan_path = CURRICULUM_ROOT / "plans" / level / f"{slug}.yaml"
     if not plan_path.exists():
@@ -3229,6 +3255,8 @@ def _ensure_contract_artifacts(
         slug=slug,
         module_num=module_num,
     )
+    contract = stamp_artifact(contract, current_manifest)
+    excerpts = stamp_artifact(excerpts, current_manifest)
     _save_yaml_artifact(contract_path, contract)
     _save_yaml_artifact(excerpts_path, excerpts)
 
@@ -3266,7 +3294,10 @@ def _save_style_review_advice_to_contract(level: str, slug: str, blocking_issues
         return
 
     contract["style_review_advice"] = advice
-    _save_yaml_artifact(contract_path, contract)
+    _save_yaml_artifact(
+        contract_path,
+        stamp_artifact(contract, _current_alignment_manifest(level, slug)),
+    )
 
 
 def _format_contract_prompt_artifacts(

--- a/tests/test_convergence_loop.py
+++ b/tests/test_convergence_loop.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
+import build.convergence_loop as convergence_loop
 from build import module_memory, v6_build
 from build.convergence_loop import (
     ConvergenceContext,
@@ -18,6 +20,15 @@ from build.convergence_loop import (
     run_convergence_loop,
 )
 from build.module_memory import module_memory_path
+
+
+@pytest.fixture(autouse=True)
+def stub_alignment_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        convergence_loop,
+        "compose_manifest",
+        lambda *, level, slug: {"level": level, "slug": slug},
+    )
 
 
 def _finding(

--- a/tests/test_issue_1301.py
+++ b/tests/test_issue_1301.py
@@ -11,6 +11,28 @@ def test_style_review_advisory_flow(tmp_path, monkeypatch):
     curriculum_root.mkdir(parents=True)
     (curriculum_root / level).mkdir(parents=True)
 
+    # Advisory-path contract stamping now composes the alignment manifest, so the test
+    # needs the same plan fixture that write/review path tests already seed under tmp_path.
+    plan_path = curriculum_root / "plans" / level / f"{slug}.yaml"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text(
+        yaml.safe_dump(
+            {
+                "module": 1,
+                "slug": slug,
+                "level": level,
+                "sequence": 1,
+                "title": "Style advisory",
+                "phase": "A1.1",
+                "word_target": 200,
+                "content_outline": [{"title": "Intro", "summary": "Test outline."}],
+            },
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        "utf-8",
+    )
+
     # Setup mock contract
     contract_path = curriculum_root / level / "orchestration" / slug / "contract.yaml"
     contract_path.parent.mkdir(parents=True)

--- a/tests/test_module_memory.py
+++ b/tests/test_module_memory.py
@@ -4,63 +4,123 @@ import sqlite3
 import sys
 from pathlib import Path
 
+import yaml
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from build import module_memory
+from build.alignment_manifest import manifest_hash
+
+
+def _manifest(label: str) -> dict[str, object]:
+    return {
+        "plan_hash": f"plan-{label}",
+        "sources_hash": f"sources-{label}",
+        "template_hashes": {"writer": f"template-{label}"},
+        "canonical_anchor_hash": f"anchors-{label}",
+        "tokenizer_version": f"tokenizer-{label}",
+        "threshold_snapshot": {"level_config": {"words": label}, "review_target_score": 8.0},
+        "decisions_subset": [("dec-001", label)],
+    }
 
 
 def test_schema_round_trip(tmp_path: Path) -> None:
     path = tmp_path / "module-memory.yaml"
+    current_manifest = _manifest("current")
     payload = {
-        "plan_hash": "plan-a",
         "plan_version": 3,
-        "sources_hash": "sources-a",
         "constraints": [{"id": "c_001", "status": "active"}],
         "history": [{"attempt": 1, "strategy": "write"}],
         "events": [{"type": "seed"}],
     }
 
-    module_memory.save_module_memory(path, payload)
+    module_memory.save_module_memory(path, payload, current_manifest=current_manifest)
     loaded, invalidated = module_memory.load_module_memory(
         path,
-        expected_plan_hash="plan-a",
+        current_manifest=current_manifest,
         expected_plan_version=3,
-        expected_sources_hash="sources-a",
     )
+    saved = yaml.safe_load(path.read_text("utf-8"))
 
     assert invalidated is False
-    assert loaded["plan_hash"] == "plan-a"
+    assert loaded["alignment_manifest_hash"] == manifest_hash(current_manifest)
     assert loaded["constraints"] == payload["constraints"]
     assert loaded["history"] == payload["history"]
+    assert "plan_hash" not in saved
+    assert "sources_hash" not in saved
+    assert saved["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
 
 
-def test_plan_hash_invalidation_clears_constraints_keeps_history(tmp_path: Path) -> None:
+def test_alignment_manifest_invalidation_clears_constraints_keeps_history(tmp_path: Path) -> None:
     path = tmp_path / "module-memory.yaml"
+    original_manifest = _manifest("before")
     module_memory.save_module_memory(
         path,
         {
-            "plan_hash": "old-plan",
             "plan_version": 1,
-            "sources_hash": "sources-a",
             "constraints": [{"id": "c_001", "status": "active"}],
             "history": [{"attempt": 1, "strategy": "write"}],
         },
+        current_manifest=original_manifest,
     )
 
+    updated_manifest = _manifest("after")
     loaded, invalidated = module_memory.load_module_memory(
         path,
-        expected_plan_hash="new-plan",
+        current_manifest=updated_manifest,
         expected_plan_version=2,
-        expected_sources_hash="sources-b",
     )
 
     assert invalidated is True
     assert loaded["constraints"] == []
     assert loaded["history"] == [{"attempt": 1, "strategy": "write"}]
-    assert loaded["plan_hash"] == "new-plan"
-    assert loaded["sources_hash"] == "sources-b"
-    assert loaded["events"][-1]["type"] == "plan_hash_invalidation"
+    assert loaded["alignment_manifest_hash"] == manifest_hash(updated_manifest)
+    assert loaded["events"][-1]["type"] == "alignment_manifest_invalidation"
+    assert loaded["events"][-1]["previous_hash"] == manifest_hash(original_manifest)
+    assert loaded["events"][-1]["current_hash"] == manifest_hash(updated_manifest)
+
+
+def test_legacy_plan_hash_file_migrates_and_invalidates_on_first_read(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    path = tmp_path / "module-memory.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "plan_hash": "legacy-plan",
+                "plan_version": 4,
+                "sources_hash": "legacy-sources",
+                "constraints": [{"id": "c_001", "status": "active"}],
+                "history": [{"attempt": 1, "strategy": "write"}],
+                "events": [{"type": "seed"}],
+            },
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        "utf-8",
+    )
+
+    current_manifest = _manifest("legacy-current")
+    with caplog.at_level("INFO"):
+        loaded, invalidated = module_memory.load_module_memory(
+            path,
+            current_manifest=current_manifest,
+            expected_plan_version=4,
+        )
+    saved = yaml.safe_load(path.read_text("utf-8"))
+
+    assert invalidated is True
+    assert loaded["constraints"] == []
+    assert loaded["history"] == [{"attempt": 1, "strategy": "write"}]
+    assert loaded["events"][-1]["type"] == "alignment_manifest_migration_invalidation"
+    assert loaded["alignment_manifest_hash"] == manifest_hash(current_manifest)
+    assert "alignment_manifest_hash" in saved
+    assert "plan_hash" not in saved
+    assert "sources_hash" not in saved
+    assert saved["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
+    assert "Migrating legacy module memory without alignment_manifest_hash" in caplog.text
 
 
 def test_reset_memory_wipes_file(tmp_path: Path) -> None:

--- a/tests/test_v6_contract_artifact_freshness.py
+++ b/tests/test_v6_contract_artifact_freshness.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+import build.phases.plan_contract as plan_contract
+from build import v6_build
+from build.alignment_manifest import manifest_hash
+
+
+def _write_plan(curriculum_root: Path, level: str, slug: str, *, title: str) -> None:
+    plan_path = curriculum_root / "plans" / level / f"{slug}.yaml"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text(
+        yaml.safe_dump(
+            {
+                "module": 1,
+                "slug": slug,
+                "level": level,
+                "title": title,
+                "content_outline": [],
+            },
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        "utf-8",
+    )
+
+
+def _current_manifest(curriculum_root: Path, level: str, slug: str) -> dict[str, str]:
+    plan_path = curriculum_root / "plans" / level / f"{slug}.yaml"
+    plan = yaml.safe_load(plan_path.read_text("utf-8")) or {}
+    return {"plan_title": str(plan.get("title") or "")}
+
+
+def test_ensure_contract_artifacts_stamps_and_reuses_fresh_sidecars(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    level = "a1"
+    slug = "demo"
+    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    _write_plan(curriculum_root, level, slug, title="Original")
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(
+        v6_build,
+        "_current_alignment_manifest",
+        lambda level, slug: _current_manifest(curriculum_root, level, slug),
+    )
+
+    build_calls: list[str] = []
+    logs: list[str] = []
+
+    def fake_build_contract(plan, wiki_packet, *, level, slug, module_num):
+        build_calls.append(str(plan["title"]))
+        return (
+            {"module": {"slug": slug}, "title": plan["title"]},
+            {"sections": {"Intro": {"excerpt": wiki_packet or "none"}}},
+        )
+
+    monkeypatch.setattr(plan_contract, "build_contract", fake_build_contract)
+    monkeypatch.setattr(v6_build, "_log", logs.append)
+
+    contract, excerpts = v6_build._ensure_contract_artifacts(level, 1, slug, log_creation=True)
+    reused_contract, reused_excerpts = v6_build._ensure_contract_artifacts(
+        level,
+        1,
+        slug,
+        log_creation=True,
+    )
+    current_manifest = _current_manifest(curriculum_root, level, slug)
+
+    assert build_calls == ["Original"]
+    assert contract["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
+    assert excerpts["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
+    assert reused_contract == contract
+    assert reused_excerpts == excerpts
+    assert any("sidecars fresh" in entry for entry in logs)
+
+
+def test_ensure_contract_artifacts_rebuilds_when_plan_hash_changes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    level = "a1"
+    slug = "demo"
+    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    _write_plan(curriculum_root, level, slug, title="Before")
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(
+        v6_build,
+        "_current_alignment_manifest",
+        lambda level, slug: _current_manifest(curriculum_root, level, slug),
+    )
+
+    build_calls: list[str] = []
+    logs: list[str] = []
+
+    def fake_build_contract(plan, wiki_packet, *, level, slug, module_num):
+        build_calls.append(str(plan["title"]))
+        return (
+            {"module": {"slug": slug}, "title": plan["title"]},
+            {"sections": {"Intro": {"excerpt": wiki_packet or "none"}}},
+        )
+
+    monkeypatch.setattr(plan_contract, "build_contract", fake_build_contract)
+    monkeypatch.setattr(v6_build, "_log", logs.append)
+
+    v6_build._ensure_contract_artifacts(level, 1, slug, log_creation=False)
+    _write_plan(curriculum_root, level, slug, title="After")
+
+    contract, excerpts = v6_build._ensure_contract_artifacts(level, 1, slug, log_creation=False)
+    current_manifest = _current_manifest(curriculum_root, level, slug)
+
+    assert build_calls == ["Before", "After"]
+    assert contract["title"] == "After"
+    assert contract["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
+    assert excerpts["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
+    assert any("Rebuilding contract/excerpts — stale sidecar" in entry for entry in logs)

--- a/tests/test_v6_state_io.py
+++ b/tests/test_v6_state_io.py
@@ -13,11 +13,14 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from build import v6_build
+from build.alignment_manifest import manifest_hash
 
 
 def test_save_v6_state_uses_atomic_replace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    current_manifest = {"plan_hash": "state-atomic"}
     monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(v6_build, "_current_alignment_manifest", lambda level, slug: current_manifest)
     plan_path = curriculum_root / "plans" / "a2" / "a2-bridge.yaml"
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     plan_path.write_text("module: a2-bridge\nlevel: A2\ncontent_outline: []\n", "utf-8")
@@ -38,6 +41,7 @@ def test_save_v6_state_uses_atomic_replace(tmp_path: Path, monkeypatch: pytest.M
 
     assert state["mode"] == "v6"
     assert state["phases"]["check"]["status"] == "complete"
+    assert state["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
     assert replace_calls == [(replace_calls[0][0], state_path)]
     assert replace_calls[0][0].parent == state_path.parent
     assert replace_calls[0][0].suffix == ".tmp"
@@ -49,7 +53,9 @@ def test_save_v6_state_stores_plan_hash_for_tracked_writer_phases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    current_manifest = {"plan_hash": "state-write"}
     monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(v6_build, "_current_alignment_manifest", lambda level, slug: current_manifest)
 
     plan_path = curriculum_root / "plans" / "a2" / "a2-bridge.yaml"
     plan_path.parent.mkdir(parents=True, exist_ok=True)
@@ -64,6 +70,7 @@ def test_save_v6_state_stores_plan_hash_for_tracked_writer_phases(
 
     assert state["phases"]["write"]["status"] == "complete"
     assert state["phases"]["write"]["plan_hash"] == v6_build._current_plan_hash("a2", "a2-bridge")
+    assert state["alignment_manifest"]["composite_hash"] == manifest_hash(current_manifest)
 
 
 def test_save_v6_state_raises_on_corrupt_existing_state(


### PR DESCRIPTION
## Summary
- rework `convergence_loop.py`, `module_memory.py`, and `v6_build.py` to use the merged `alignment_manifest` API (`compose_manifest(level=..., slug=...)`)
- remove the old synthetic-manifest fallback paths so `manifest_hash` and `stamp_artifact` never receive `None`, while preserving stale-sidecar invalidation semantics
- keep `state.json`, contract sidecars, and module memory stamped with `alignment_manifest_hash` and force rebuild/reuse decisions from a freshly composed manifest
- migrate the module-memory, v6 state I/O, and contract freshness tests off the stub API and keep the end-to-end stale-stamp rebuild check in `tests/test_v6_contract_artifact_freshness.py`
- isolate `tests/test_convergence_loop.py` from filesystem-backed manifest composition so the convergence harness still exercises the sidecar freshness flow without depending on a real plan file

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_convergence_loop.py tests/test_v6_contract_artifact_freshness.py tests/test_module_memory.py tests/test_v6_state_io.py tests/test_alignment_manifest.py -v`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/convergence_loop.py scripts/build/module_memory.py scripts/build/v6_build.py tests/test_convergence_loop.py tests/test_module_memory.py tests/test_v6_state_io.py tests/test_v6_contract_artifact_freshness.py tests/test_alignment_manifest.py`

## Notes
- `scripts/build/alignment_manifest.py` and `tests/test_alignment_manifest.py` are not in this diff; the branch now consumes the canonical versions from `main`.
- I did not enable auto-merge.