### PR TITLE
fix: postmortem 2026-04-23 must-change items (#1472)

### DIFF
--- a/claude_extensions/settings.json
+++ b/claude_extensions/settings.json
@@ -730,7 +730,7 @@
   "agent": "curriculum-maintainer",
   "acceptEdits": true,
   "yolo": true,
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "env": {
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"
   }

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -48,6 +48,8 @@ import logging
 import os
 import re
 import shutil
+import subprocess
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -75,13 +77,51 @@ _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 # to stdout; the caller passes them IN via tool_config. Parser kept for
 # forward compat.)
 _SESSION_ID_RE = re.compile(r"session[_-]?id[:=]\s*([0-9a-f-]{8,})", re.IGNORECASE)
+_EFFORT_MIN_VERSION = (2, 1, 98)
+_MIN_SUPPORTED_CLI_VERSION = (2, 1, 116)
+_POSTMORTEM_URL = "https://www.anthropic.com/engineering/april-23-postmortem"
+
+
+@cache
+def _probe_claude_cli_version(cmd_prefix: tuple[str, ...]) -> tuple[int, int, int] | None:
+    """Probe ``claude --version`` once per binary prefix for this process."""
+    try:
+        from utils.claude_version import _parse_claude_semver
+    except ImportError:
+        return None
+
+    try:
+        result = subprocess.run(
+            [*cmd_prefix, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    combined = f"{result.stdout or ''}\n{result.stderr or ''}".strip()
+    return _parse_claude_semver(combined)
+
+
+def _ensure_supported_claude_cli_version(cmd_prefix: tuple[str, ...]) -> tuple[int, int, int] | None:
+    """Reject Claude CLI versions with the 2026-04-23 postmortem regressions."""
+    version = _probe_claude_cli_version(cmd_prefix)
+    if version is not None and version < _MIN_SUPPORTED_CLI_VERSION:
+        raise RuntimeError(
+            "Claude CLI < 2.1.116 inherits known quality regressions fixed "
+            f"on 2026-04-23 (see {_POSTMORTEM_URL}). Upgrade with: "
+            "npm install -g @anthropic-ai/claude-cli@latest"
+        )
+    return version
 
 
 class ClaudeAdapter:
     """Adapter for ``npx @anthropic-ai/claude-code@latest`` print mode."""
 
     name: str = "claude"
-    default_model: str = "claude-opus-4-6"
+    default_model: str = "claude-opus-4-7"
     supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
 
     def build_invocation(
@@ -111,8 +151,8 @@ class ClaudeAdapter:
         ``effort``: optional reasoning-level string. When non-None and the
         probed Claude binary supports ``--effort`` (CC 2.1.98+), the flag
         is appended as ``--effort <level>``. Otherwise we log a warning
-        and proceed without the flag so older CLIs don't hard-fail. See
-        ``utils.claude_version.supports_effort`` and issue #1396.
+        and proceed without the flag. Claude CLI versions below 2.1.116
+        are rejected outright due to the 2026-04-23 postmortem gate.
         """
         tc: dict[str, Any] = tool_config or {}
 
@@ -122,10 +162,13 @@ class ClaudeAdapter:
         # override by passing ``tool_config={"cmd_prefix": [...]}``.
         cmd_prefix = tc.get("cmd_prefix")
         if cmd_prefix:
-            cmd: list[str] = list(cmd_prefix)
+            cmd = [cmd_prefix] if isinstance(cmd_prefix, str) else list(cmd_prefix)
         else:
             claude_bin = shutil.which("claude")
             cmd = [claude_bin] if claude_bin else ["npx", "@anthropic-ai/claude-code@latest"]
+
+        probe_prefix = tuple(cmd)
+        cli_version = _ensure_supported_claude_cli_version(probe_prefix)
 
         cmd.extend(["-p", prompt])
 
@@ -154,25 +197,14 @@ class ClaudeAdapter:
 
         # Effort (reasoning level) — version-gated. See #1396.
         if effort is not None:
-            probe_prefix_for_effort: tuple[str, ...]
-            if cmd_prefix:
-                probe_prefix_for_effort = tuple(cmd_prefix)
-            elif shutil.which("claude"):
-                probe_prefix_for_effort = (cmd[0],)
-            else:
-                probe_prefix_for_effort = ("npx", "@anthropic-ai/claude-code@latest")
-            try:
-                from utils.claude_version import supports_effort
-                effort_supported = supports_effort(probe_prefix_for_effort)
-            except ImportError:
-                effort_supported = False
+            effort_supported = bool(cli_version and cli_version >= _EFFORT_MIN_VERSION)
             if effort_supported:
                 cmd.extend(["--effort", effort])
             else:
                 _logger.warning(
                     "Claude CLI at %s does not support --effort; "
                     "ignoring effort=%r and using CLI default (#1396)",
-                    probe_prefix_for_effort,
+                    probe_prefix,
                     effort,
                 )
 
@@ -193,18 +225,8 @@ class ClaudeAdapter:
             cmd.extend(["--mcp-config", str(mcp_config_path), "--allowedTools", allowed_tools])
 
         # Cache-warmth optimization (CC 2.1.98+)
-        try:
-            from utils.claude_version import supports_exclude_dynamic_system_prompt_sections
-            # Probe the prefix we're about to run (matches the actual binary)
-            probe_prefix = tuple(cmd[:1]) if len(cmd) >= 1 else tuple(cmd[:2] or ["claude"])
-            if cmd_prefix:
-                probe_prefix = tuple(cmd_prefix)
-            elif not shutil.which("claude"):
-                probe_prefix = ("npx", "@anthropic-ai/claude-code@latest")
-            if supports_exclude_dynamic_system_prompt_sections(probe_prefix):
-                cmd.append("--exclude-dynamic-system-prompt-sections")
-        except ImportError:
-            pass  # Graceful degradation if helper unavailable
+        if cli_version and cli_version >= _EFFORT_MIN_VERSION:
+            cmd.append("--exclude-dynamic-system-prompt-sections")
 
         return InvocationPlan(
             cmd=cmd,

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -197,7 +197,15 @@ class ClaudeAdapter:
 
         # Effort (reasoning level) — version-gated. See #1396.
         if effort is not None:
-            effort_supported = bool(cli_version and cli_version >= _EFFORT_MIN_VERSION)
+            # Use the `utils.claude_version.supports_effort` helper so tests
+            # can patch the decision at a single point. Inline version
+            # comparison bypassed the helper and left CI runs (no Claude CLI
+            # installed → cli_version=None) silently dropping --effort even
+            # though the test patched supports_effort=True. Root cause of the
+            # test_claude_adapter_emits_effort_when_supported CI failure on
+            # PR #1474.
+            from utils.claude_version import supports_effort
+            effort_supported = supports_effort(probe_prefix)
             if effort_supported:
                 cmd.extend(["--effort", effort])
             else:

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -50,7 +50,7 @@ AGENTS: dict[str, AgentEntry] = {
     },
     "claude": {
         "adapter": "scripts.agent_runtime.adapters.claude:ClaudeAdapter",
-        "default_model": "claude-opus-4-6",
+        "default_model": "claude-opus-4-7",
         "cost_tier": "high",
         "capabilities": frozenset({
             "architecture",

--- a/scripts/batch/batch_gemini_config.py
+++ b/scripts/batch/batch_gemini_config.py
@@ -81,7 +81,7 @@ CASCADE_PER_CALL_MAX_S = 600
 # Use Opus ONLY where deep reasoning is critical (seminar content, final review).
 # Ref: Anthropic guidance (Lydia Hallie, 2026-04-03)
 CLAUDE_SONNET = "claude-sonnet-4-6"
-CLAUDE_OPUS   = "claude-opus-4-6"
+CLAUDE_OPUS   = "claude-opus-4-7"
 
 CLAUDE_MODEL_CORE_RESEARCH      = CLAUDE_SONNET  # Research — RAG search + summarization
 CLAUDE_MODEL_CORE_CONTENT       = CLAUDE_OPUS    # Content — writing quality needs Opus

--- a/scripts/build/build_module_direct.py
+++ b/scripts/build/build_module_direct.py
@@ -461,7 +461,7 @@ def phase_review(ctx: DirectModuleContext) -> bool:
         str(SCRIPTS_DIR / "ai_agent_bridge/__main__.py"), "ask-gemini",
         "-",
         "--task-id", task_id,
-        "--model", "claude-opus-4-6",
+        "--model", "claude-opus-4-7",
         "--stdout-only",
     ]
 

--- a/scripts/build/build_module_v5.py
+++ b/scripts/build/build_module_v5.py
@@ -158,7 +158,7 @@ def preflight(args: argparse.Namespace) -> ModuleContext:
 
     # Per-phase Claude model
     _is_seminar = ctx.track in SEMINAR_TRACKS or ctx.track in PRO_TRACKS
-    _default_gen_model = "claude-opus-4-6" if _is_seminar else CLAUDE_MODEL_ACTIVITIES
+    _default_gen_model = "claude-opus-4-7" if _is_seminar else CLAUDE_MODEL_ACTIVITIES
     ctx.claude_model_A = getattr(args, "claude_model_A", None) or _default_gen_model  # type: ignore[attr-defined]
     ctx.claude_model_B = getattr(args, "claude_model_B", None) or CLAUDE_MODEL_CONTENT  # type: ignore[attr-defined]
     ctx.claude_model_C = getattr(args, "claude_model_C", None) or _default_gen_model  # type: ignore[attr-defined]
@@ -524,11 +524,11 @@ def main() -> int:
     parser.add_argument("--claude-model-A", type=str, default=None, dest="claude_model_A",
                         help="Claude model for research")
     parser.add_argument("--claude-model-B", type=str, default=None, dest="claude_model_B",
-                        help="Claude model for content (default: claude-opus-4-6)")
+                        help="Claude model for content (default: claude-opus-4-7)")
     parser.add_argument("--claude-model-C", type=str, default=None, dest="claude_model_C",
                         help="Claude model for activities")
     parser.add_argument("--claude-model-D", type=str, default=None, dest="claude_model_D",
-                        help="Claude model for review (default: claude-opus-4-6)")
+                        help="Claude model for review (default: claude-opus-4-7)")
 
     # Tuning
     parser.add_argument("--stop-before", type=str, default=None, dest="stop_before",

--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -251,6 +251,7 @@ def _save_dispatch_log(
     agent: str,
     *,
     model: str | None = None,
+    effort: str | None = None,
     prompt_chars: int = 0,
     response_chars: int = 0,
     stderr: str = "",
@@ -283,6 +284,7 @@ def _save_dispatch_log(
         "phase": phase,
         "agent": agent,
         "model": model,
+        "effort": effort,
         "ok": ok,
         "returncode": returncode,
         "prompt_chars": prompt_chars,
@@ -368,9 +370,8 @@ def dispatch_agent(
     Returns:
         (success, stdout_text)
 
-    Migration note: Codex and Gemini branches are routed through
-    ``scripts.agent_runtime.runner.invoke()`` (Phase 3 of #1184).
-    Claude branch remains on the legacy subprocess path until Phase 5.
+    Migration note: Codex, Gemini, and Claude are all routed through
+    ``scripts.agent_runtime.runner.invoke()``.
     """
     is_gemini = agent.startswith("gemini")
     is_gemma_local = agent.startswith("gemma-local")
@@ -467,6 +468,7 @@ def _dispatch_claude_via_runtime(
         else None
     )
 
+    claude_effort = "xhigh"
     t0 = time.monotonic()
     call_start = datetime.now().astimezone()
     try:
@@ -483,6 +485,7 @@ def _dispatch_claude_via_runtime(
             tool_config=tool_config,
             entrypoint="dispatch",
             hard_timeout=timeout,
+            effort=claude_effort,  # postmortem 2026-04-23: pin explicitly, never inherit default
             # Stall budget is generous: Gemini/Claude CAN reasonably go
             # silent for 5+ minutes during long reasoning bursts (especially
             # skeleton + review phases). 600s = 10 min. The liveness-file
@@ -497,6 +500,7 @@ def _dispatch_claude_via_runtime(
         _save_dispatch_log(
             orch_dir, phase, agent_label,
             model=model,
+            effort=claude_effort,
             prompt_chars=len(prompt),
             response_chars=len(result.response),
             stderr=result.stderr_excerpt or "",
@@ -514,6 +518,7 @@ def _dispatch_claude_via_runtime(
         _save_dispatch_log(
             orch_dir, phase, agent_label,
             model=model,
+            effort=claude_effort,
             prompt_chars=len(prompt), response_chars=0,
             stderr=f"RateLimitedError: {exc}", returncode=None,
             duration_s=elapsed, ok=False, prompt=prompt,
@@ -525,6 +530,7 @@ def _dispatch_claude_via_runtime(
         _save_dispatch_log(
             orch_dir, phase, agent_label,
             model=model,
+            effort=claude_effort,
             prompt_chars=len(prompt), response_chars=0,
             stderr=f"{type(exc).__name__}: {exc}", returncode=None,
             duration_s=elapsed, ok=False, prompt=prompt,

--- a/scripts/build/pipeline_v5.py
+++ b/scripts/build/pipeline_v5.py
@@ -955,7 +955,7 @@ def _rescore_post_fix(ctx: ModuleContext) -> None:
 
         ok, raw = dispatch_claude_phase(
             prompt_path, "Post-fix scoring",
-            model="claude-opus-4-6", timeout=300,
+            model="claude-opus-4-7", timeout=300,
         )
         prompt_path.unlink(missing_ok=True)
 
@@ -981,7 +981,7 @@ def _rescore_post_fix(ctx: ModuleContext) -> None:
         review_text = review_path.read_text("utf-8")
         post_fix_section = (
             f"\n\n---\n\n## Post-Fix Re-Score (automated)\n\n"
-            f"**Scored by:** claude-opus-4-6 (on fixed content)\n"
+            f"**Scored by:** claude-opus-4-7 (on fixed content)\n"
             f"**Overall Score:** {overall}/10\n"
             f"**Verdict:** {verdict}\n\n"
             f"| Dimension | Score |\n|-----------|-------|\n"

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -815,7 +815,7 @@ class StyleReviewLoopRunResult:
 
 CLAUDE_FAMILY = ModelFamily(
     name="claude",
-    thinking="claude-opus-4-6",
+    thinking="claude-opus-4-7",
     fast="claude-sonnet-4-6",
     tool_prefix="mcp__rag__",
 )

--- a/scripts/pipeline/dispatch.py
+++ b/scripts/pipeline/dispatch.py
@@ -289,7 +289,7 @@ def _get_claude_bin() -> str:
 def dispatch_claude_phase(
     prompt_file: Path,
     phase_label: str,
-    model: str = "claude-opus-4-6",
+    model: str = "claude-opus-4-7",
     timeout: int = 600,
     allow_tools: list[str] | None = None,
 ) -> tuple[bool, str]:
@@ -301,6 +301,7 @@ def dispatch_claude_phase(
     prompt = prompt.replace("You are Gemini", "You are Claude")
 
     cmd = [_get_claude_bin(), "--model", model, "-p", "--output-format", "text"]
+    cmd.extend(["--effort", "xhigh"])  # postmortem 2026-04-23: pin explicitly, never inherit default
     if supports_exclude_dynamic_system_prompt_sections((_get_claude_bin(),)):
         cmd.append("--exclude-dynamic-system-prompt-sections")
     if allow_tools:

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -74,6 +74,22 @@ def _clear_state():
     _reset_rate_limit_cache_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _stub_claude_cli_version_gate(monkeypatch, request):
+    """Keep Claude adapter tests deterministic unless a test probes the gate."""
+    from agent_runtime.adapters import claude as claude_adapter_mod
+
+    claude_adapter_mod._probe_claude_cli_version.cache_clear()
+    if request.node.name != "test_claude_adapter_rejects_old_cli_version":
+        monkeypatch.setattr(
+            claude_adapter_mod,
+            "_ensure_supported_claude_cli_version",
+            lambda _cmd_prefix: (2, 1, 116),
+        )
+    yield
+    claude_adapter_mod._probe_claude_cli_version.cache_clear()
+
+
 # ---------------------------------------------------------------------------
 # Registry + adapter loading
 # ---------------------------------------------------------------------------
@@ -2310,6 +2326,7 @@ def test_gemini_liveness_paths_missing_dir_returns_empty(tmp_path, monkeypatch):
 def test_claude_adapter_attributes():
     adapter = ClaudeAdapter()
     assert adapter.name == "claude"
+    assert adapter.default_model == "claude-opus-4-7"
     assert adapter.supported_modes == frozenset({"read-only", "workspace-write", "danger"})
 
 
@@ -2446,6 +2463,33 @@ def test_claude_adapter_no_bare_when_session_id_passed(tmp_path, monkeypatch):
     )
     assert "--bare" not in plan.cmd
     assert "--resume" in plan.cmd
+
+
+def test_claude_adapter_rejects_old_cli_version(tmp_path):
+    from agent_runtime.adapters import claude as claude_adapter_mod
+
+    claude_adapter_mod._probe_claude_cli_version.cache_clear()
+    adapter = ClaudeAdapter()
+    with patch(
+        "agent_runtime.adapters.claude.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["claude", "--version"],
+            returncode=0,
+            stdout="2.1.115\n",
+            stderr="",
+        ),
+    ):
+        with pytest.raises(RuntimeError, match=r"Claude CLI < 2\.1\.116"):
+            adapter.build_invocation(
+                prompt="hello",
+                mode="read-only",
+                cwd=tmp_path,
+                model=None,
+                task_id=None,
+                session_id=None,
+                tool_config={"cmd_prefix": ["claude"]},
+            )
+    claude_adapter_mod._probe_claude_cli_version.cache_clear()
 
 
 def test_claude_parse_response_success():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -99,8 +99,9 @@ class TestSaveDispatchLog:
     def test_meta_json_structure(self, tmp_path):
         orch_dir = tmp_path / "orch"
         _save_dispatch_log(
-            orch_dir, "review", "claude-tools (claude-opus-4-6)",
-            model="claude-opus-4-6",
+            orch_dir, "review", "claude-tools (claude-opus-4-7)",
+            model="claude-opus-4-7",
+            effort="xhigh",
             prompt_chars=2000, response_chars=3000,
             returncode=0, duration_s=120.5, ok=True,
         )
@@ -108,8 +109,9 @@ class TestSaveDispatchLog:
         data = json.loads(meta_file.read_text())
 
         assert data["phase"] == "review"
-        assert data["agent"] == "claude-tools (claude-opus-4-6)"
-        assert data["model"] == "claude-opus-4-6"
+        assert data["agent"] == "claude-tools (claude-opus-4-7)"
+        assert data["model"] == "claude-opus-4-7"
+        assert data["effort"] == "xhigh"
         assert data["ok"] is True
         assert data["returncode"] == 0
         assert data["prompt_chars"] == 2000
@@ -374,7 +376,7 @@ class TestDispatchAgent:
         travels via tool_config dict, not argv assertions."""
         from agent_runtime.result import Result
         mock_invoke.return_value = Result(
-            ok=True, agent="claude", model="claude-opus-4-6", mode="read-only",
+            ok=True, agent="claude", model="claude-opus-4-7", mode="read-only",
             response="content here", stderr_excerpt=None, duration_s=1.0,
             session_id=None, rate_limited=False, stalled=False,
             returncode=0, usage_record={},
@@ -383,7 +385,7 @@ class TestDispatchAgent:
             "test prompt", agent="claude-tools", phase="review",
             orch_dir=tmp_path, timeout=600,
             mcp_tools=True, allowed_tools=CLAUDE_REVIEWER_TOOLS,
-            model="claude-opus-4-6",
+            model="claude-opus-4-7",
         )
         assert ok is True
         # MCP tool config must have been passed through tool_config
@@ -392,6 +394,7 @@ class TestDispatchAgent:
         assert "mcp_config_path" in kwargs["tool_config"]
         assert kwargs["tool_config"]["allowed_tools"] == CLAUDE_REVIEWER_TOOLS
         assert kwargs["entrypoint"] == "dispatch"
+        assert kwargs["effort"] == "xhigh"
 
     @patch.dict("os.environ", {}, clear=True)
     @patch("agent_runtime.runner.invoke")


### PR DESCRIPTION
## Summary

Addresses the 4 must-change items from the Anthropic 2026-04-23 postmortem impact report (`docs/reports/2026-04-23-anthropic-postmortem-impact.md`). Prevents the silent-default inheritance path that would mask a future similar regression.

- Pin `--effort xhigh` in `_dispatch_claude_via_runtime` — no more silent CLI-default
- Bump `CLAUDE_OPUS` default to `claude-opus-4-7` (user-approved, was `4-6` which was most-affected)
- Flip `claude_extensions/settings.json` effortLevel to `xhigh` + deployed to `.claude/` and `.agent/` (`diff` confirms parity)
- Add cached Claude CLI ≥ 2.1.116 version gate at runtime init
- Extend dispatch telemetry to record `effort` next to `agent`/`model`/`duration_s`

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_agent_runtime.py tests/test_dispatch.py tests/test_v6_build_events.py` — green
- `ruff check` — clean on all touched files
- `diff claude_extensions/settings.json .claude/settings.json` → no output
- `diff claude_extensions/settings.json .agent/settings.json` → no output

Closes #1472.

## Refs

- Postmortem: https://www.anthropic.com/engineering/april-23-postmortem
- Impact report: `docs/reports/2026-04-23-anthropic-postmortem-impact.md`
- User approval of 4-7 switch: 2026-04-23 PM session
- EPIC: #1451

🤖 Dispatched to Codex, PR body by Claude.