### PR TITLE
fix(delegate): dispatch hardening — stale-base, reuse validation, branch naming, dispatch/ subtree (#1476)

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -133,6 +133,74 @@ points:
   and raises `RateLimitedError` before burning a quota slot on a
   known-rate-limited call.
 
+## Dispatch worktree layout (#1476)
+
+`delegate.py dispatch --worktree ...` creates the dispatched agent a
+private git worktree so its writes are isolated from the main checkout.
+Two layouts are currently supported:
+
+| Layout | Path | Status | Triggered by |
+|---|---|---|---|
+| **dispatch subtree** (new) | `.worktrees/dispatch/{agent}/{task}/` | **default** for new dispatches | `--worktree` (bare, no path) |
+| flat (legacy) | `.worktrees/{agent}-{task}/` | deprecated, still accepted | `--worktree <explicit-path>` under `.worktrees/` |
+| custom | anywhere you point it | accepted | `--worktree <explicit-path>` anywhere |
+
+`delegate.py list` and `delegate.py status` print a deprecation notice
+when they encounter a flat-layout worktree.
+
+Two non-dispatch worktrees live alongside these and are **out of scope**
+for delegate lifecycle — don't prune or rename:
+- `.worktrees/codex-interactive/` — the persistent interactive session
+  from `start-codex.sh` (detached HEAD, symlinks to `.venv`, `data/`,
+  `starlight/node_modules`).
+- Any operator-created `.worktrees/*` that predates the dispatch layout.
+
+### Stale-base safety (the actual #1476 bug)
+
+Before creating or reusing a worktree, `delegate.py` runs
+`git fetch origin <base>` and branches from `origin/<base>`, not local
+`<base>`. The local ref drifts the moment a PR merges while a dispatch
+is queued — the resulting worktree would miss any commits landed in the
+gap. This is what shipped PRs #1473 and #1474 against stale tips
+(2026-04-23).
+
+When a worktree is reused, it is validated:
+1. **Branch match** — must be on the expected derived branch
+   (`{agent}/{task_normalized}`). Mismatch → `WorktreeBranchMismatch`.
+2. **Clean tree** — no uncommitted changes. Dirty → `WorktreeDirty`.
+3. **Base freshness** — at most 0 commits behind `origin/<base>`; if
+   behind, attempt `git rebase origin/<base>` and raise
+   `WorktreeStaleBase` if that fails.
+
+Offline fallback: if `git fetch` fails (no network, no remote), delegate
+warns on stderr and branches from the local ref. Pin the `--base` flag
+to override the default `main`.
+
+### Branch-name normalization (Fix 2 of #1476)
+
+Task-ids that already include the agent name (our common convention:
+`codex-1472-foo`) don't produce doubled-prefix branch names. The
+normalizer strips a leading `{agent}-` or `{agent}/` before prefixing:
+
+| Agent | Task-id | Branch |
+|---|---|---|
+| codex | `codex-1472-foo` | `codex/1472-foo` |
+| codex | `codex/1472-foo` | `codex/1472-foo` |
+| codex | `1472-foo` | `codex/1472-foo` |
+| codex | `random-name` | `codex/random-name` (no strip — `random` ≠ `codex`) |
+| claude | `claude-bar` | `claude/bar` |
+
+### Dispatch telemetry (Fix 5 of #1476)
+
+The state file at `batch_state/tasks/<task-id>.json` now carries:
+- `worktree_path`, `worktree_branch`, `worktree_layout` (`flat` | `dispatch` | `external`)
+- `worktree_base`, `worktree_base_sha` — resolved at dispatch start
+- `worktree_rebased`, `worktree_reused` — reuse-path telemetry
+- `worktree_dirty_on_exit` — whether the agent left uncommitted changes
+
+`delegate.py list` surfaces `worktree_layout`; `delegate.py status`
+prints a deprecation notice for flat-layout tasks.
+
 ## Common mistakes
 
 - **Writing new subprocess logic outside the runtime.** If you're
@@ -182,7 +250,8 @@ Run them all: `.venv/bin/python -m pytest tests/test_agent_runtime.py tests/test
 
 ---
 
-*Last updated: 2026-04-10 (Phase 1 foundation complete). When behavior
-changes, update this guide in the same commit. This file is also
-auto-loaded into Gemini and Codex prompts via the bridge — keep it
-accurate.*
+*Last updated: 2026-04-23 (#1476 dispatch hardening: fetch-before-branch,
+reuse validation, branch normalization, dispatch/ subtree layout).
+When behavior changes, update this guide in the same commit. This file
+is also auto-loaded into Gemini and Codex prompts via the bridge — keep
+it accurate.*

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -161,13 +161,215 @@ def _normalize_worktree_path(raw_path: str) -> Path:
     return path.resolve()
 
 
+# ---------------------------------------------------------------------------
+# Worktree lifecycle — create, validate, reuse
+# ---------------------------------------------------------------------------
+#
+# The four failure classes below drove a design change from "silent-reuse
+# existing directory" to "validate before reuse, raise a specific error
+# otherwise." Silent reuse is how #1473 shipped a stub alignment_manifest.py
+# as a real PR: the dispatched worktree already existed on a stale branch
+# and delegate.py inherited that state. Each exception carries the exact
+# remediation command in its message so operators can unblock without
+# digging.
+
+class WorktreeBranchMismatch(RuntimeError):
+    """Existing worktree is on a branch other than the expected dispatch branch."""
+
+
+class WorktreeDirty(RuntimeError):
+    """Existing worktree has uncommitted changes; refuse to reuse."""
+
+
+class WorktreeStaleBase(RuntimeError):
+    """Existing worktree is behind origin/<base> and the fast-forward rebase failed."""
+
+
+def _normalize_task_id(agent: str, task_id: str) -> str:
+    """Strip a leading ``{agent}-`` or ``{agent}/`` from task_id.
+
+    Shared by :func:`_derive_worktree_branch` and :func:`_auto_worktree_path`
+    so the branch name and the dispatch/ subtree path land in sync even
+    when the caller accidentally prefixed the agent name (our own tools
+    often do — task-ids like ``codex-1472-foo`` are common).
+    """
+    for prefix in (f"{agent}-", f"{agent}/"):
+        if task_id.startswith(prefix):
+            return task_id[len(prefix):]
+    return task_id
+
+
 def _derive_worktree_branch(agent: str, task_id: str) -> str:
-    """Derive a git-safe branch name for a delegated worktree."""
-    safe_task = re.sub(r"[^A-Za-z0-9._/-]+", "-", task_id).strip("./-")
+    """Derive a git-safe branch name for a delegated worktree.
+
+    Normalizes task_id first so ``codex-1472-foo`` produces
+    ``codex/1472-foo`` rather than ``codex/codex-1472-foo``.
+    """
+    normalized = _normalize_task_id(agent, task_id)
+    safe_task = re.sub(r"[^A-Za-z0-9._/-]+", "-", normalized).strip("./-")
     safe_task = re.sub(r"/{2,}", "/", safe_task)
     if not safe_task:
         safe_task = "task"
     return f"{agent}/{safe_task}"
+
+
+def _auto_worktree_path(agent: str, task_id: str) -> Path:
+    """Default worktree path for a fresh dispatch: ``.worktrees/dispatch/{agent}/{task}/``."""
+    normalized = _normalize_task_id(agent, task_id)
+    # Slashes are fine in branch names but not in a single path component,
+    # so flatten them here (task_id ``foo/bar`` → path ``foo-bar``).
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", normalized).strip("./-") or "task"
+    return _REPO_ROOT / ".worktrees" / "dispatch" / agent / safe
+
+
+def _classify_worktree_layout(path: Path | str | None) -> str | None:
+    """Return "dispatch" (new subtree), "flat" (old), "external", or None."""
+    if path is None:
+        return None
+    p = Path(path)
+    try:
+        rel = p.resolve().relative_to(_REPO_ROOT)
+    except ValueError:
+        return "external"
+    parts = rel.parts
+    if parts and parts[0] == ".worktrees":
+        if len(parts) >= 4 and parts[1] == "dispatch":
+            return "dispatch"
+        if len(parts) >= 2:
+            return "flat"
+    return None
+
+
+def _fetch_base(base: str) -> bool:
+    """Fetch ``origin/{base}``. Returns True iff the remote ref is resolvable."""
+    proc = subprocess.run(
+        ["git", "fetch", "origin", base],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return False
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"origin/{base}"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return verify.returncode == 0
+
+
+def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
+    """Return the commit SHA at ``ref`` in ``path``, or None if unresolvable."""
+    proc = subprocess.run(
+        ["git", "rev-parse", ref],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    sha = (proc.stdout or "").strip()
+    return sha or None
+
+
+def _validate_existing_worktree(
+    *, path: Path, expected_branch: str, base: str,
+) -> bool:
+    """Validate a reused worktree. Returns True if a rebase occurred.
+
+    Raises :class:`WorktreeBranchMismatch`, :class:`WorktreeDirty`, or
+    :class:`WorktreeStaleBase` on the respective failure mode. The
+    checks skip silently when the path isn't a real git worktree (e.g.
+    a tmp_path fixture) — those cases either fail at the first real git
+    operation later or were never on the dispatch path to begin with.
+    """
+    # 1. Branch check.
+    branch_proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if branch_proc.returncode != 0:
+        # Not a git worktree (e.g. test tmp dir). Don't treat as an error —
+        # the caller may be a test fixture, and real dispatch paths will
+        # surface the issue on the next git op.
+        return False
+    actual_branch = (branch_proc.stdout or "").strip()
+    if actual_branch and actual_branch != expected_branch:
+        raise WorktreeBranchMismatch(
+            f"worktree at {path} is on branch {actual_branch!r}, expected "
+            f"{expected_branch!r}. Remove it and retry:\n"
+            f"    git worktree remove {path}"
+        )
+
+    # 2. Dirty check.
+    status_proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty_output = (status_proc.stdout or "").strip()
+    if dirty_output:
+        first_files = [line[3:] for line in dirty_output.splitlines()[:3]]
+        raise WorktreeDirty(
+            f"worktree at {path} has uncommitted changes "
+            f"(first {len(first_files)}): {first_files}. "
+            f"Commit, stash, or remove the worktree before reuse."
+        )
+
+    # 3. Stale-base check. Refresh origin/{base} first; ignore fetch failure
+    # (we'll use whatever ref is locally available and warn instead of hard-
+    # failing offline).
+    _fetch_base(base)
+    count_proc = subprocess.run(
+        ["git", "rev-list", "--count", f"HEAD..origin/{base}"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if count_proc.returncode != 0:
+        # origin/{base} unresolvable (offline / no remote). Nothing to do.
+        return False
+    try:
+        behind = int((count_proc.stdout or "0").strip())
+    except ValueError:
+        behind = 0
+    if behind == 0:
+        return False
+
+    print(
+        f"⚠️  worktree {path} is {behind} commit(s) behind origin/{base}; "
+        f"attempting fast-forward rebase",
+        file=sys.stderr,
+    )
+    rebase_proc = subprocess.run(
+        ["git", "rebase", f"origin/{base}"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if rebase_proc.returncode != 0:
+        # Clean up so the worktree isn't left mid-rebase.
+        subprocess.run(
+            ["git", "rebase", "--abort"],
+            cwd=path, capture_output=True, text=True, check=False,
+        )
+        raise WorktreeStaleBase(
+            f"worktree at {path} is {behind} commit(s) behind origin/{base} "
+            f"and rebase failed. Resolve manually or remove:\n"
+            f"    git worktree remove {path}"
+        )
+    return True
 
 
 def _ensure_worktree(
@@ -175,18 +377,59 @@ def _ensure_worktree(
     agent: str,
     task_id: str,
     raw_path: str,
-) -> tuple[Path, str]:
-    """Return a ready worktree path, creating it if needed."""
+    base: str = "main",
+) -> tuple[Path, str, dict[str, Any]]:
+    """Return a ready worktree path, creating or validating as needed.
+
+    The telemetry dict (third tuple element) carries:
+    - ``base_sha``: the SHA the worktree was branched from (or is currently
+      sitting on, if reused).
+    - ``rebased``: whether :func:`_validate_existing_worktree` advanced the
+      reused worktree.
+    - ``layout``: ``"dispatch"`` or ``"flat"``.
+    - ``reused``: whether the path already existed and was validated rather
+      than created.
+    """
     worktree_path = _normalize_worktree_path(raw_path)
     branch = _derive_worktree_branch(agent, task_id)
+    layout = _classify_worktree_layout(worktree_path)
+    telemetry: dict[str, Any] = {
+        "base_sha": None,
+        "rebased": False,
+        "layout": layout,
+        "reused": False,
+    }
 
     if worktree_path.exists():
         if not worktree_path.is_dir():
             raise ValueError(f"worktree path exists but is not a directory: {worktree_path}")
-        return worktree_path, branch
+        telemetry["reused"] = True
+        telemetry["rebased"] = _validate_existing_worktree(
+            path=worktree_path, expected_branch=branch, base=base,
+        )
+        telemetry["base_sha"] = _resolve_sha(worktree_path)
+        return worktree_path, branch, telemetry
+
+    # Fix 1 (#1476): fetch origin/{base} and branch from the remote ref,
+    # not the local one. Local `main` drifts the moment a PR merges while
+    # a dispatch is queued — this is the stale-base footgun Codex
+    # diagnosed in bridge msg #431 (2026-04-23).
+    if _fetch_base(base):
+        worktree_base_ref = f"origin/{base}"
+    else:
+        print(
+            f"⚠️  `git fetch origin {base}` failed or origin/{base} is "
+            f"unresolvable; falling back to local {base}. This worktree "
+            f"may be branched from a stale tip.",
+            file=sys.stderr,
+        )
+        worktree_base_ref = base
+
+    # Ensure parent dirs exist for the dispatch/ subtree layout.
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
     proc = subprocess.run(
-        ["git", "worktree", "add", "-b", branch, str(worktree_path), "main"],
+        ["git", "worktree", "add", "-b", branch, str(worktree_path), worktree_base_ref],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
@@ -195,7 +438,8 @@ def _ensure_worktree(
     if proc.returncode != 0:
         stderr = (proc.stderr or proc.stdout or "git worktree add failed").strip()
         raise RuntimeError(stderr)
-    return worktree_path, branch
+    telemetry["base_sha"] = _resolve_sha(worktree_path)
+    return worktree_path, branch, telemetry
 
 
 def _augment_prompt_with_worktree(prompt: str, worktree_path: Path | None) -> str:
@@ -361,6 +605,26 @@ def _run_worker(
     )
 
     final_state = _read_state(state_path) or {}
+
+    # Fix 5 (#1476 AC 5): dispatch-finish telemetry — record whether the
+    # worktree exited dirty so follow-up reviewers can see at a glance
+    # that the dispatched agent left uncommitted changes behind.
+    dirty_on_exit: bool | None = None
+    worktree_path = final_state.get("worktree_path")
+    if worktree_path:
+        try:
+            status_proc = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if status_proc.returncode == 0:
+                dirty_on_exit = bool((status_proc.stdout or "").strip())
+        except OSError:
+            dirty_on_exit = None
+
     final_state.update({
         "status": final_status,
         "finished_at": datetime.now(UTC).isoformat(),
@@ -369,6 +633,7 @@ def _run_worker(
         "result_file": result_file,
         "stderr_excerpt": stderr_excerpt,
         "returncode": returncode,
+        "worktree_dirty_on_exit": dirty_on_exit,
     })
     _write_state_atomic(state_path, final_state)
 
@@ -432,12 +697,22 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     worktree_path: Path | None = None
     worktree_branch: str | None = None
+    worktree_telemetry: dict[str, Any] = {}
     if worktree_arg:
+        # Fix 4 (#1476): the sentinel ``auto`` (from bare ``--worktree``)
+        # resolves to ``.worktrees/dispatch/{agent}/{task}/``. Explicit
+        # paths remain unchanged for back-compat with in-flight dispatches.
+        resolved_raw = (
+            str(_auto_worktree_path(args.agent, task_id))
+            if worktree_arg == "auto"
+            else worktree_arg
+        )
         try:
-            worktree_path, worktree_branch = _ensure_worktree(
+            worktree_path, worktree_branch, worktree_telemetry = _ensure_worktree(
                 agent=args.agent,
                 task_id=task_id,
-                raw_path=worktree_arg,
+                raw_path=resolved_raw,
+                base=getattr(args, "base", None) or "main",
             )
         except (ValueError, RuntimeError) as exc:
             print(f"❌ failed to prepare worktree for {task_id!r}: {exc}", file=sys.stderr)
@@ -449,6 +724,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # Write initial state BEFORE forking so a fast caller can see it.
     # pid is filled in by the worker once it starts; for now we record
     # the parent PID as a placeholder (overwritten by worker).
+    worktree_layout = worktree_telemetry.get("layout") if worktree_path else None
     initial_state = {
         "task_id": task_id,
         "agent": args.agent,
@@ -459,6 +735,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "cwd": cwd,
         "worktree_path": str(worktree_path) if worktree_path else None,
         "worktree_branch": worktree_branch,
+        "worktree_base_sha": worktree_telemetry.get("base_sha"),
+        "worktree_base": getattr(args, "base", None) or ("main" if worktree_path else None),
+        "worktree_rebased": bool(worktree_telemetry.get("rebased")),
+        "worktree_reused": bool(worktree_telemetry.get("reused")),
+        "worktree_layout": worktree_layout,
         "pid": None,  # worker fills this
         "status": "spawning",
         "started_at": datetime.now(UTC).isoformat(),
@@ -471,6 +752,25 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "returncode": None,
     }
     _write_state_atomic(state_path, initial_state)
+
+    # Fix 5 (#1476 AC 5) — dispatch-start telemetry.
+    if worktree_path:
+        print(
+            f"🌲 dispatch {task_id}: branch={worktree_branch} "
+            f"base_sha={worktree_telemetry.get('base_sha') or '?'} "
+            f"path={worktree_path} layout={worktree_layout}"
+            + (" [rebased]" if worktree_telemetry.get("rebased") else "")
+            + (" [reused]" if worktree_telemetry.get("reused") else ""),
+            file=sys.stderr,
+        )
+        if worktree_layout == "flat":
+            print(
+                f"⚠️  task {task_id!r} is using the DEPRECATED flat worktree "
+                f"layout ({worktree_path}). New dispatches should use "
+                f"`--worktree` (bare) to land in "
+                f".worktrees/dispatch/{{agent}}/{{task}}/.",
+                file=sys.stderr,
+            )
 
     # Fork a detached subprocess that runs this same script with
     # --worker. We use Popen rather than os.fork for portability.
@@ -627,6 +927,20 @@ def cmd_status(args: argparse.Namespace) -> int:
         except (ValueError, TypeError):
             pass
 
+    # Fix 4 (#1476): backfill worktree_layout for tasks persisted before
+    # the field existed, and warn about flat-layout worktrees.
+    if state.get("worktree_path") and not state.get("worktree_layout"):
+        state["worktree_layout"] = _classify_worktree_layout(
+            state.get("worktree_path"),
+        )
+    if state.get("worktree_layout") == "flat":
+        print(
+            f"⚠️  task {args.task_id!r} uses the DEPRECATED flat worktree "
+            f"layout ({state.get('worktree_path')}). New dispatches should "
+            f"use the `.worktrees/dispatch/{{agent}}/{{task}}/` subtree.",
+            file=sys.stderr,
+        )
+
     print(json.dumps(state, indent=2, default=str))
     return 0
 
@@ -754,6 +1068,7 @@ def cmd_cancel(args: argparse.Namespace) -> int:
 def cmd_list(args: argparse.Namespace) -> int:
     _TASKS_DIR.mkdir(parents=True, exist_ok=True)
     tasks: list[dict[str, Any]] = []
+    flat_tasks: list[str] = []
     for state_file in sorted(_TASKS_DIR.glob("*.json")):
         state = _read_state(state_file)
         if state is None:
@@ -765,6 +1080,13 @@ def cmd_list(args: argparse.Namespace) -> int:
                 state["status"] = "crashed"
         if args.status and state.get("status") != args.status:
             continue
+        # Fix 4 (#1476): classify worktree layout so operators can see at
+        # a glance which tasks are on the deprecated flat path.
+        layout = state.get("worktree_layout") or _classify_worktree_layout(
+            state.get("worktree_path"),
+        )
+        if layout == "flat":
+            flat_tasks.append(str(state.get("task_id")))
         tasks.append(
             {
                 "task_id": state.get("task_id"),
@@ -772,9 +1094,20 @@ def cmd_list(args: argparse.Namespace) -> int:
                 "status": state.get("status"),
                 "started_at": state.get("started_at"),
                 "duration_s": state.get("duration_s"),
+                "worktree_path": state.get("worktree_path"),
+                "worktree_layout": layout,
             }
         )
     print(json.dumps(tasks, indent=2, default=str))
+    if flat_tasks:
+        print(
+            f"⚠️  {len(flat_tasks)} task(s) use the DEPRECATED flat worktree "
+            f"layout: {flat_tasks[:5]}"
+            + (" …" if len(flat_tasks) > 5 else "")
+            + ". New dispatches should use "
+            "`.worktrees/dispatch/{agent}/{task}/`.",
+            file=sys.stderr,
+        )
     return 0
 
 
@@ -858,8 +1191,25 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Working directory for the worker (default: repo root)")
     d.add_argument(
         "--worktree",
+        nargs="?",
+        const="auto",
         default=None,
-        help="Run inside this git worktree (created on demand, required for --mode danger)",
+        help=(
+            "Run inside this git worktree (created on demand, required for "
+            "--mode danger). Pass `--worktree PATH` to use a specific path "
+            "(back-compat with existing `.worktrees/{agent}-{task}/` "
+            "layout), or `--worktree` alone to auto-derive the new default "
+            "`.worktrees/dispatch/{agent}/{task}/`."
+        ),
+    )
+    d.add_argument(
+        "--base",
+        default="main",
+        help=(
+            "Base branch to fetch and branch the worktree from "
+            "(default: main). The worktree is branched from "
+            "origin/{base}, not local {base}."
+        ),
     )
     d.add_argument(
         "--allow-merge",

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -548,6 +548,46 @@ def test_dispatch_rejects_danger_without_worktree(tmp_tasks_dir, capsys):
     assert "--worktree" in captured.err
 
 
+def _make_run_stub(
+    *,
+    rev_parse_verify_ok: bool = True,
+    rev_parse_head_sha: str = "abc1234",
+    status_porcelain: str = "",
+    rev_list_count: str = "0",
+    abbrev_ref: str = "",
+    rebase_ok: bool = True,
+):
+    """Helper: build a fake subprocess.run that understands the git commands
+    _ensure_worktree/_validate_existing_worktree issue. Returns ``(calls, fn)``.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"]:
+            if "--verify" in cmd:
+                rc = 0 if rev_parse_verify_ok else 1
+                out = rev_parse_head_sha if rc == 0 else ""
+                return subprocess.CompletedProcess(cmd, rc, out, "")
+            if "--abbrev-ref" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, abbrev_ref, "")
+            return subprocess.CompletedProcess(cmd, 0, rev_parse_head_sha, "")
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, status_porcelain, "")
+        if cmd[:2] == ["git", "rev-list"]:
+            return subprocess.CompletedProcess(cmd, 0, rev_list_count, "")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rebase"]:
+            rc = 0 if rebase_ok else 1
+            return subprocess.CompletedProcess(cmd, rc, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    return calls, fake_run
+
+
 def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, capsys):
     import argparse
 
@@ -564,12 +604,7 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, ca
         pid = 24680
         stdin = _FakeStdin()
 
-    calls: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        assert cmd[:5] == ["git", "worktree", "add", "-b", "codex/issue-1383-smoke"]
-        return subprocess.CompletedProcess(cmd, 0, "", "")
+    calls, fake_run = _make_run_stub(rev_parse_head_sha="deadbeef")
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
     monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _FakeProc())
@@ -583,6 +618,7 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, ca
         model=None,
         cwd=None,
         worktree=".worktrees/codex-1383",
+        base="main",
         hard_timeout=3600,
     )
 
@@ -596,9 +632,18 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, ca
     assert state["worktree_path"].endswith(".worktrees/codex-1383")
     assert state["cwd"].endswith(".worktrees/codex-1383")
     assert state["pid"] == 24680
+    assert state["worktree_base_sha"] == "deadbeef"
+    assert state["worktree_reused"] is False
     assert "delegate worktree" in recorded_prompt["text"]
     assert ".worktrees/codex-1383" in recorded_prompt["text"]
-    assert len(calls) == 1
+    # At minimum: git fetch + git rev-parse --verify + git worktree add + git rev-parse HEAD.
+    assert any(c[:3] == ["git", "worktree", "add"] for c in calls)
+    assert any(c[:2] == ["git", "fetch"] for c in calls)
+    # Fix 1: the worktree add MUST branch from origin/main, not local main.
+    add_cmd = next(c for c in calls if c[:3] == ["git", "worktree", "add"])
+    assert add_cmd[-1] == "origin/main", (
+        f"worktree must be created from origin/main, got base={add_cmd[-1]!r}"
+    )
     captured = capsys.readouterr()
     assert "issue-1383-smoke" in captured.out
 
@@ -666,6 +711,8 @@ def test_dispatch_allow_merge_opt_in_updates_worker_env(tmp_tasks_dir, monkeypat
         recorded["env"] = kwargs.get("env", {})
         return _FakeProc()
 
+    _, fake_run = _make_run_stub()
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
     monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
 
     args = argparse.Namespace(
@@ -677,6 +724,7 @@ def test_dispatch_allow_merge_opt_in_updates_worker_env(tmp_tasks_dir, monkeypat
         model=None,
         cwd=None,
         worktree=str(tmp_tasks_dir / "wt"),
+        base="main",
         hard_timeout=3600,
         allow_merge=True,
     )
@@ -708,11 +756,22 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
         pid = 13579
         stdin = _FakeStdin()
 
-    monkeypatch.setattr(
-        delegate.subprocess,
-        "run",
-        lambda *a, **k: pytest.fail("git worktree add should not run for an existing path"),
+    # Allow the validation calls (rev-parse, status, rev-list, fetch) to
+    # run but refuse `git worktree add` — that's what "without_git_add"
+    # is asserting. Validation returns "clean, matching, up-to-date" so
+    # the reuse path succeeds.
+    _, base_stub = _make_run_stub(
+        abbrev_ref="gemini/existing-worktree",
+        status_porcelain="",
+        rev_list_count="0",
     )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "add"]:
+            pytest.fail("git worktree add should not run for an existing path")
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
     monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _FakeProc())
 
     args = argparse.Namespace(
@@ -724,6 +783,7 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
         model=None,
         cwd=None,
         worktree=str(worktree),
+        base="main",
         hard_timeout=3600,
     )
 
@@ -733,6 +793,7 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
     state = delegate._read_state(delegate._state_path("existing-worktree"))
     assert state["worktree_path"] == str(worktree.resolve())
     assert state["cwd"] == str(worktree.resolve())
+    assert state["worktree_reused"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -773,3 +834,365 @@ def test_list_flips_dead_running_to_crashed(tmp_tasks_dir, capsys):
     tasks = json.loads(captured.out)
     assert len(tasks) == 1
     assert tasks[0]["status"] == "crashed"
+
+
+# ---------------------------------------------------------------------------
+# #1476 — Fix 1: fetch-before-branch (stale-base footgun)
+# ---------------------------------------------------------------------------
+
+def test_ensure_worktree_branches_from_origin_main(tmp_tasks_dir, tmp_path, monkeypatch):
+    """Fix 1 (#1476): _ensure_worktree must fetch origin and branch from
+    origin/main, not local main. This is the regression that caused #1473
+    and #1474 to ship against stale tips.
+    """
+    target = tmp_path / "fresh-worktree"
+
+    calls, fake_run = _make_run_stub(rev_parse_head_sha="sha-from-origin")
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    path, branch, telemetry = delegate._ensure_worktree(
+        agent="codex",
+        task_id="1476-branches-from-origin",
+        raw_path=str(target),
+        base="main",
+    )
+
+    assert path == target.resolve()
+    assert branch == "codex/1476-branches-from-origin"
+    # Fetch is called before the add.
+    fetch_calls = [c for c in calls if c[:2] == ["git", "fetch"]]
+    add_calls = [c for c in calls if c[:3] == ["git", "worktree", "add"]]
+    assert fetch_calls, "must fetch origin/main before branching"
+    assert fetch_calls[0] == ["git", "fetch", "origin", "main"]
+    assert add_calls, "must invoke git worktree add"
+    assert add_calls[0][-1] == "origin/main", (
+        "must branch from origin/main, not local main"
+    )
+    assert telemetry["base_sha"] == "sha-from-origin"
+    assert telemetry["reused"] is False
+
+
+def test_ensure_worktree_falls_back_when_fetch_fails(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
+    """Fix 1 (#1476): offline/no-remote scenarios fall back to local
+    base rather than hard-failing. A warning is logged on stderr.
+    """
+    target = tmp_path / "offline-worktree"
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "fatal: unable to access")
+        if cmd[:2] == ["git", "rev-parse"] and "--verify" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, "localsha", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    _, branch, _ = delegate._ensure_worktree(
+        agent="codex",
+        task_id="1476-offline",
+        raw_path=str(target),
+        base="main",
+    )
+    assert branch == "codex/1476-offline"
+    captured = capsys.readouterr()
+    assert (
+        ("fetch" in captured.err and "fallback" in captured.err.lower())
+        or "stale" in captured.err.lower()
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1476 — Fix 2: branch-name normalization
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "agent, task_id, expected_branch",
+    [
+        # The doubled-prefix bug from #1472: task_id starts with the agent name.
+        ("codex", "codex-1472-postmortem-must-change", "codex/1472-postmortem-must-change"),
+        # Slash-separator variant.
+        ("codex", "codex/1472-slash-variant", "codex/1472-slash-variant"),
+        # Already-clean task_id: no change expected.
+        ("codex", "1472-no-prefix", "codex/1472-no-prefix"),
+        # Non-codex agents.
+        ("claude", "claude-foo", "claude/foo"),
+        ("gemini", "gemini-bar", "gemini/bar"),
+        # Agent name is a substring, not a prefix — must NOT strip.
+        ("codex", "random-name", "codex/random-name"),
+        ("codex", "codexy-is-not-a-prefix", "codex/codexy-is-not-a-prefix"),
+    ],
+)
+def test_derive_branch_strips_agent_prefix(agent, task_id, expected_branch):
+    """Fix 2 (#1476): derived branch must never contain a doubled prefix
+    like `codex/codex-…`."""
+    assert delegate._derive_worktree_branch(agent, task_id) == expected_branch
+
+
+def test_derive_branch_never_doubles_prefix_across_agents():
+    """Fix 2 (#1476): for any agent × any reasonable task_id, the derived
+    branch must not start with `{agent}/{agent}-` or `{agent}/{agent}/`."""
+    for agent in ("codex", "claude", "gemini"):
+        for task_id in (
+            f"{agent}-123-foo",
+            f"{agent}/456-bar",
+            "789-no-prefix",
+            f"prefix-{agent}-mid",
+        ):
+            branch = delegate._derive_worktree_branch(agent, task_id)
+            assert not branch.startswith(f"{agent}/{agent}-"), (
+                f"doubled prefix for agent={agent} task={task_id}: {branch}"
+            )
+            assert not branch.startswith(f"{agent}/{agent}/"), (
+                f"doubled prefix for agent={agent} task={task_id}: {branch}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# #1476 — Fix 3: worktree-reuse validation
+# ---------------------------------------------------------------------------
+
+def test_ensure_worktree_reuse_dirty_raises(tmp_tasks_dir, tmp_path, monkeypatch):
+    """Fix 3 (#1476): a dirty existing worktree must raise WorktreeDirty
+    rather than being silently reused. Silent reuse is how #1473 shipped
+    a stub alignment_manifest.py to a PR."""
+    wt = tmp_path / "dirty-worktree"
+    wt.mkdir()
+
+    _, fake_run = _make_run_stub(
+        abbrev_ref="codex/1476-dirty-task",
+        status_porcelain=" M scripts/foo.py\n?? scripts/bar.py\n",
+    )
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeDirty, match="uncommitted"):
+        delegate._ensure_worktree(
+            agent="codex",
+            task_id="1476-dirty-task",
+            raw_path=str(wt),
+            base="main",
+        )
+
+
+def test_ensure_worktree_reuse_wrong_branch_raises(tmp_tasks_dir, tmp_path, monkeypatch):
+    """Fix 3 (#1476): an existing worktree on a different branch must
+    raise WorktreeBranchMismatch, with the expected remediation command
+    in the message."""
+    wt = tmp_path / "mismatched-worktree"
+    wt.mkdir()
+
+    _, fake_run = _make_run_stub(abbrev_ref="codex/some-other-branch")
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeBranchMismatch) as exc_info:
+        delegate._ensure_worktree(
+            agent="codex",
+            task_id="1476-mismatched",
+            raw_path=str(wt),
+            base="main",
+        )
+    assert "codex/some-other-branch" in str(exc_info.value)
+    assert "codex/1476-mismatched" in str(exc_info.value)
+    assert "git worktree remove" in str(exc_info.value)
+
+
+def test_ensure_worktree_reuse_stale_base_rebases(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
+    """Fix 3 (#1476): a clean worktree behind origin/main is automatically
+    rebased. The reuse path succeeds and telemetry records ``rebased=True``."""
+    wt = tmp_path / "stale-worktree"
+    wt.mkdir()
+
+    _, fake_run = _make_run_stub(
+        abbrev_ref="codex/1476-stale-task",
+        status_porcelain="",
+        rev_list_count="3",
+        rev_parse_head_sha="rebased-head-sha",
+        rebase_ok=True,
+    )
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    path, branch, telemetry = delegate._ensure_worktree(
+        agent="codex",
+        task_id="1476-stale-task",
+        raw_path=str(wt),
+        base="main",
+    )
+    assert path == wt.resolve()
+    assert branch == "codex/1476-stale-task"
+    assert telemetry["rebased"] is True
+    assert telemetry["reused"] is True
+    assert telemetry["base_sha"] == "rebased-head-sha"
+    captured = capsys.readouterr()
+    assert "behind origin/main" in captured.err
+
+
+def test_ensure_worktree_reuse_stale_base_rebase_fail_raises(tmp_tasks_dir, tmp_path, monkeypatch):
+    """Fix 3 (#1476): if the fast-forward rebase fails (e.g. conflicts),
+    _ensure_worktree must raise WorktreeStaleBase, aborting the rebase
+    so the worktree is left in a usable state."""
+    wt = tmp_path / "stale-conflict-worktree"
+    wt.mkdir()
+
+    abort_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:3] == ["git", "rev-parse", "--verify"]:
+            return subprocess.CompletedProcess(cmd, 0, "originsha", "")
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return subprocess.CompletedProcess(cmd, 0, "codex/1476-conflict-task", "")
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-list"]:
+            return subprocess.CompletedProcess(cmd, 0, "5", "")
+        if cmd[:2] == ["git", "rebase"]:
+            if cmd[-1] == "--abort":
+                abort_calls.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            return subprocess.CompletedProcess(cmd, 1, "", "CONFLICT")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeStaleBase, match="rebase failed"):
+        delegate._ensure_worktree(
+            agent="codex",
+            task_id="1476-conflict-task",
+            raw_path=str(wt),
+            base="main",
+        )
+    # Must abort so the worktree isn't left mid-rebase.
+    assert any(c[:2] == ["git", "rebase"] and "--abort" in c for c in abort_calls), (
+        "rebase must be aborted on failure"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1476 — Fix 4: dispatch/ subtree layout
+# ---------------------------------------------------------------------------
+
+def test_auto_worktree_path_is_dispatch_subtree():
+    """Fix 4 (#1476): the auto-derived default worktree path is under
+    .worktrees/dispatch/{agent}/{task_normalized}/."""
+    path = delegate._auto_worktree_path("codex", "codex-1476-delegate-hardening")
+    parts = path.parts[-4:]
+    assert parts == (".worktrees", "dispatch", "codex", "1476-delegate-hardening")
+
+
+def test_classify_worktree_layout_distinguishes_flat_and_dispatch(tmp_path):
+    """Fix 4 (#1476): layout classifier tells flat from dispatch paths,
+    so list/status can emit deprecation messages."""
+    repo = delegate._REPO_ROOT
+    assert delegate._classify_worktree_layout(
+        repo / ".worktrees" / "codex-1453-sidecar-freshness",
+    ) == "flat"
+    assert delegate._classify_worktree_layout(
+        repo / ".worktrees" / "dispatch" / "codex" / "1476",
+    ) == "dispatch"
+    assert delegate._classify_worktree_layout(None) is None
+    assert delegate._classify_worktree_layout(tmp_path / "anywhere-else") in (
+        "external", None,
+    )
+
+
+def test_new_dispatch_uses_dispatch_subtree(tmp_tasks_dir, monkeypatch, capsys):
+    """Fix 4 (#1476): a fresh dispatch with `--worktree` (bare — no path)
+    lands in `.worktrees/dispatch/{agent}/{task}/`, the new default."""
+    import argparse
+
+    class _FakeStdin:
+        def write(self, _data): pass
+        def close(self): pass
+
+    class _FakeProc:
+        pid = 54321
+        stdin = _FakeStdin()
+
+    _, fake_run = _make_run_stub()
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    args = argparse.Namespace(
+        agent="codex",
+        task_id="codex-1476-auto-path",
+        prompt="test",
+        prompt_file=None,
+        mode="danger",
+        model=None,
+        cwd=None,
+        worktree="auto",  # sentinel from bare `--worktree`
+        base="main",
+        hard_timeout=3600,
+        allow_merge=False,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("codex-1476-auto-path"))
+    assert state is not None
+    wt = Path(state["worktree_path"])
+    assert wt.parts[-4:] == (".worktrees", "dispatch", "codex", "1476-auto-path")
+    assert state["worktree_branch"] == "codex/1476-auto-path"
+    assert state["worktree_layout"] == "dispatch"
+
+
+def test_list_and_status_walk_both_layouts(tmp_tasks_dir, tmp_path, capsys, monkeypatch):
+    """Fix 4 (#1476): both the deprecated flat layout and the new dispatch
+    subtree layout must surface in `list`, and flat-layout tasks emit
+    a deprecation notice."""
+    repo = delegate._REPO_ROOT
+    flat_path = repo / ".worktrees" / "codex-1453-sidecar-freshness"
+    dispatch_path = repo / ".worktrees" / "dispatch" / "codex" / "1476-new"
+
+    delegate._write_state_atomic(delegate._state_path("flat-task"), {
+        "task_id": "flat-task",
+        "agent": "codex",
+        "status": "done",
+        "worktree_path": str(flat_path),
+    })
+    delegate._write_state_atomic(delegate._state_path("new-task"), {
+        "task_id": "new-task",
+        "agent": "codex",
+        "status": "done",
+        "worktree_path": str(dispatch_path),
+    })
+
+    import argparse
+    args = argparse.Namespace(status=None)
+    delegate.cmd_list(args)
+    captured = capsys.readouterr()
+    tasks = json.loads(captured.out)
+    task_map = {t["task_id"]: t for t in tasks}
+    assert "flat-task" in task_map
+    assert "new-task" in task_map
+    assert task_map["flat-task"]["worktree_layout"] == "flat"
+    assert task_map["new-task"]["worktree_layout"] == "dispatch"
+    # Deprecation notice surfaces on stderr for the flat-layout task.
+    assert "DEPRECATED" in captured.err or "deprecated" in captured.err.lower()
+    assert "flat-task" in captured.err
+
+
+def test_status_warns_on_flat_layout(tmp_tasks_dir, capsys):
+    """Fix 4 (#1476): `status` for a flat-layout task must print a
+    deprecation notice in addition to the JSON state."""
+    repo = delegate._REPO_ROOT
+    flat_path = repo / ".worktrees" / "codex-old-thing"
+    delegate._write_state_atomic(delegate._state_path("flat-status"), {
+        "task_id": "flat-status",
+        "agent": "codex",
+        "status": "done",
+        "worktree_path": str(flat_path),
+    })
+
+    import argparse
+    args = argparse.Namespace(task_id="flat-status")
+    delegate.cmd_status(args)
+    captured = capsys.readouterr()
+    state = json.loads(captured.out)
+    assert state["worktree_layout"] == "flat"
+    assert "flat" in captured.err.lower() or "deprecated" in captured.err.lower()


### PR DESCRIPTION
Closes #1476.

## Why

2026-04-23 PM shipped two PRs (#1473, #1474) against stale main tips because `scripts/delegate.py` branched dispatched worktrees from local `main` instead of `origin/main`. The diagnostic surfaced 3 other correctness/ergonomics bugs in the same area. This ships all 4 fixes in one commit.

## The four fixes

### Fix 1 — Fetch-before-branch (the real bug)

**Before**
```python
def _ensure_worktree(...):
    ...
    # No fetch. Branch is created from local `main` — drifts the moment
    # another PR merges while a dispatch is queued.
    subprocess.run(
        ["git", "worktree", "add", "-b", branch, str(path), "main"],
        ...
    )
```

**After**
```python
def _fetch_base(base: str) -> bool:
    """Fetch origin/<base>. Returns True iff the remote ref is resolvable."""
    subprocess.run(["git", "fetch", "origin", base], ...)
    subprocess.run(["git", "rev-parse", "--verify", f"origin/{base}"], ...)

def _ensure_worktree(..., base: str = "main"):
    if _fetch_base(base):
        worktree_base_ref = f"origin/{base}"
    else:
        # Offline fallback with a clear warning (don't hard-fail on CI
        # smoke runs without network).
        print(f"⚠️  git fetch origin {base} failed; falling back...", file=sys.stderr)
        worktree_base_ref = base
    subprocess.run(
        ["git", "worktree", "add", "-b", branch, str(path), worktree_base_ref],
        ...
    )
```

`--base` CLI flag added for future non-main dispatch.

### Fix 2 — Branch-name normalization

**Before**
```python
def _derive_worktree_branch(agent: str, task_id: str) -> str:
    safe_task = re.sub(r\"[^A-Za-z0-9._/-]+\", \"-\", task_id)...
    return f\"{agent}/{safe_task}\"
# task_id=\"codex-1472-foo\" → branch=\"codex/codex-1472-foo\" (doubled!)
```

**After**
```python
def _normalize_task_id(agent: str, task_id: str) -> str:
    for prefix in (f\"{agent}-\", f\"{agent}/\"):
        if task_id.startswith(prefix):
            return task_id[len(prefix):]
    return task_id

def _derive_worktree_branch(agent: str, task_id: str) -> str:
    normalized = _normalize_task_id(agent, task_id)
    ...
    return f\"{agent}/{normalized}\"
# task_id=\"codex-1472-foo\" → branch=\"codex/1472-foo\" ✓
```

Parameterized test covers `codex-1472-X`, `codex/1472-X`, `1472-X`, `claude-foo`, `gemini-bar`, and the \"substring ≠ prefix\" case (`codexy-…` not stripped).

### Fix 3 — Worktree-reuse validation

**Before**
```python
if worktree_path.exists():
    return worktree_path, branch  # silent reuse — how #1473 shipped a stub
```

**After**
```python
class WorktreeBranchMismatch(RuntimeError): ...
class WorktreeDirty(RuntimeError): ...
class WorktreeStaleBase(RuntimeError): ...

def _validate_existing_worktree(*, path, expected_branch, base) -> bool:
    # 1. Branch check → WorktreeBranchMismatch with remediation command.
    # 2. Clean check → WorktreeDirty with first 3 dirty files.
    # 3. Stale-base → attempt `git rebase origin/{base}`; on conflict,
    #    `git rebase --abort` + WorktreeStaleBase.
```

### Fix 4 — `.worktrees/dispatch/` subtree layout

**Before**
```
--worktree PATH  → required, no auto-derivation
```

**After**
```
--worktree              → auto-derive to .worktrees/dispatch/{agent}/{task}/
--worktree PATH         → explicit (back-compat with flat layout)
(omitted)               → no worktree (unchanged)
```

`delegate.py list` / `status` classify `worktree_layout` as
`dispatch` | `flat` | `external` and emit a deprecation notice for flat-layout tasks. In-flight flat-layout worktrees (#1453, #1286, #1472) keep working.

`.worktrees/codex-interactive` (from `start-codex.sh`) is documented as out-of-scope for delegate lifecycle.

## Telemetry (AC 5)

State file now records: `worktree_base`, `worktree_base_sha`, `worktree_rebased`, `worktree_reused`, `worktree_layout`, `worktree_dirty_on_exit`. Dispatch start logs resolved base SHA + branch + path + layout on stderr.

## Test plan
- [x] `tests/test_delegate.py` — 51 tests (was 32; +19 new), all green.
- [x] Agent runtime + effort + json-parse + rate-limit + tool-config: 200 green.
- [x] New tests cover: fetch-before-branch, offline fallback, branch normalization (parameterized + invariant), reuse-dirty, reuse-wrong-branch, reuse-stale-rebase, reuse-rebase-conflict-abort, auto-derive path, layout classifier, list walks both layouts, status flat-deprecation notice.
- [x] `ruff check scripts/delegate.py tests/test_delegate.py` — clean.
- [x] `git worktree list | grep codex-interactive` — untouched.
- [ ] Branch protection: `CI / Test (pytest)` must go green before merge.

Pre-existing failures unchanged: 2 Gemini dispatch tests (`test_gemini_dispatch`, `test_gemini_dispatch_rate_limit_falls_through_to_oauth`) fail on clean `origin/main` due to test-env rate-limit behavior; 1 curriculum path test fails because worktree `sparsePaths` excludes curriculum files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)