### PR TITLE
perf(ci): parallel pytest + pip cache + skip PR coverage (#1479)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
     paths:
+      - '.github/workflows/ci.yml'
+      - 'requirements*.txt'
+      - 'requirements.lock'
       - 'scripts/**/*.py'
       - 'tests/**/*.py'
       - 'pyproject.toml'
@@ -12,6 +15,9 @@ on:
       - 'starlight/**'
   pull_request:
     paths:
+      - '.github/workflows/ci.yml'
+      - 'requirements*.txt'
+      - 'requirements.lock'
       - 'scripts/**/*.py'
       - 'tests/**/*.py'
       - 'pyproject.toml'
@@ -203,8 +209,13 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: requirements-lock.txt
+
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt', 'requirements-lock.txt', 'pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -216,7 +227,35 @@ jobs:
             --index-url https://download.pytorch.org/whl/cpu \
             torch==2.11.0 torchvision==0.26.0
 
+      - name: Run tests
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+        run: |
+          common_args=(
+            tests/
+            -n auto
+            -v
+            --tb=short
+            -k "not slow and not website"
+            --ignore=tests/test_rag.py
+            --ignore=tests/test_a1_review_scores.py
+            --ignore=tests/test_agent_runtime.py
+            --ignore=tests/test_channels_registry.py
+            --ignore=tests/test_convergence_loop.py
+            --ignore=tests/test_morphological_validator.py
+            --ignore=tests/test_plan_hash.py
+            --ignore=tests/test_scrape_diasporiana.py
+            --ignore=tests/test_v6_plan_hash_drift.py
+            --ignore=tests/test_vocab_gen.py
+            --ignore=tests/test_wiki_channels.py
+            --ignore=tests/test_wiki_enrichment.py
+            --ignore=tests/wiki/test_grade_filter.py
+            --ignore=tests/wiki/test_mlx_fault_injection.py
+            --ignore=tests/wiki/test_t1_t2_pipeline.py
+          )
+          .venv/bin/python -m pytest "${common_args[@]}"
+
       - name: Run tests with coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           # Gradual path: 30 (2025) → 35 (now, 2026-04) → 50 (mid-2026) → 80 on
           # critical paths (dispatch, activity_repair, audit/core). Measured
@@ -227,31 +266,38 @@ jobs:
           # Keep the required PR gate hermetic: these ignored files depend on
           # local corpora, generated review/orchestration artifacts, or sidecar
           # binaries/CLIs that are not provisioned on GitHub-hosted runners.
-          .venv/bin/python -m pytest tests/ \
-            --cov=scripts \
-            --cov-report=term-missing \
-            --cov-report=xml:coverage.xml \
-            --cov-fail-under=35 \
-            -v --tb=short \
-            -k "not slow and not website" \
-            --ignore=tests/test_rag.py \
-            --ignore=tests/test_a1_review_scores.py \
-            --ignore=tests/test_agent_runtime.py \
-            --ignore=tests/test_channels_registry.py \
-            --ignore=tests/test_convergence_loop.py \
-            --ignore=tests/test_morphological_validator.py \
-            --ignore=tests/test_plan_hash.py \
-            --ignore=tests/test_scrape_diasporiana.py \
-            --ignore=tests/test_v6_plan_hash_drift.py \
-            --ignore=tests/test_vocab_gen.py \
-            --ignore=tests/test_wiki_channels.py \
-            --ignore=tests/test_wiki_enrichment.py \
-            --ignore=tests/wiki/test_grade_filter.py \
-            --ignore=tests/wiki/test_mlx_fault_injection.py \
+          common_args=(
+            tests/
+            -n auto
+            -v
+            --tb=short
+            -k "not slow and not website"
+            --ignore=tests/test_rag.py
+            --ignore=tests/test_a1_review_scores.py
+            --ignore=tests/test_agent_runtime.py
+            --ignore=tests/test_channels_registry.py
+            --ignore=tests/test_convergence_loop.py
+            --ignore=tests/test_morphological_validator.py
+            --ignore=tests/test_plan_hash.py
+            --ignore=tests/test_scrape_diasporiana.py
+            --ignore=tests/test_v6_plan_hash_drift.py
+            --ignore=tests/test_vocab_gen.py
+            --ignore=tests/test_wiki_channels.py
+            --ignore=tests/test_wiki_enrichment.py
+            --ignore=tests/wiki/test_grade_filter.py
+            --ignore=tests/wiki/test_mlx_fault_injection.py
             --ignore=tests/wiki/test_t1_t2_pipeline.py
+          )
+          coverage_args=(
+            --cov=scripts
+            --cov-report=term-missing
+            --cov-report=xml:coverage.xml
+            --cov-fail-under=35
+          )
+          .venv/bin/python -m pytest "${common_args[@]}" "${coverage_args[@]}"
 
       - name: Upload coverage
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -37,6 +37,7 @@ docopt==0.6.2
 ecdsa==0.19.1
 einops==0.8.2
 emoji==2.15.0
+execnet==2.1.2
 fastapi==0.128.0
 filelock==3.24.3
 filetype==1.2.0
@@ -141,6 +142,7 @@ pypdfium2==4.30.0
 pyproject_hooks==1.2.0
 pytest==9.0.2
 pytest-cov==7.1.0
+pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
 python-discovery==1.1.0
 python-docx==1.2.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -37,6 +37,7 @@ docopt==0.6.2
 ecdsa==0.19.1
 einops==0.8.2
 emoji==2.15.0
+execnet==2.1.2
 fastapi==0.128.0
 filelock==3.24.3
 filetype==1.2.0
@@ -135,6 +136,7 @@ pypdfium2==4.30.0
 pyproject_hooks==1.2.0
 pytest==9.0.2
 pytest-cov==7.0.0
+pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
 python-discovery==1.1.0
 python-docx==1.2.0


### PR DESCRIPTION
## Summary

This speeds up the required `Test (pytest)` job by parallelizing pytest, skipping coverage on PR events, and adding an explicit pip cache step.

## Changes

- add `pytest-xdist` plus its `execnet` dependency to the pinned CI lockfiles and run pytest with `-n auto`
- replace the implicit setup-python pip cache with an explicit `actions/cache@v4` step keyed on Python dependency inputs
- split PR vs `push`-to-`main` pytest execution so coverage and artifact upload only run on `main`
- expand the CI path filters to include workflow and requirements changes so CI actually runs for this PR shape

## Verification

- baseline from #1479: current `main` `Test (pytest)` wall time is about `9-10m`
- PR cold run: `Test (pytest)` job completed in `4m51s` (`2m01s` install + `2m27s` tests) on https://github.com/learn-ukrainian/learn-ukrainian.github.io/actions/runs/24855499450/job/72767202930
- PR warm rerun: `Test (pytest)` job completed in `4m39s` (`1m40s` install + `2m28s` tests) on https://github.com/learn-ukrainian/learn-ukrainian.github.io/actions/runs/24855499450/job/72768116207
- explicit pip cache hit confirmed in the warm rerun log: `Cache restored from key: pip-Linux-03cb391c8de8b8735f7ce12a15730c5eb8f5efeed75e70122f414e240e0bd7df`
- PR run skipped coverage as intended: `Run tests with coverage` and `Upload coverage` were both skipped on the pull request run
- local CI-shaped `pytest -n auto` dry-run: `128.93s` wall time; no xdist-only shared-state failures surfaced

Closes #1479.