### PR TITLE
fix: replace sys.executable subprocess calls

### DIFF
--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -33,6 +33,8 @@ from ._db import get_db, get_session, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_claude_prompt
 
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+
 
 def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query",
                data: str | None = None, new_session: bool = False,
@@ -278,7 +280,7 @@ def _launch_claude_background(msg, message_id, new_session):
 
     try:
         bridge_cmd = [
-            sys.executable, str(Path(__file__).parent / "__main__.py"),
+            str(VENV_PYTHON), str(Path(__file__).parent / "__main__.py"),
             "process-claude", str(message_id),
             "--no-timeout"
         ]

--- a/scripts/audit/naturalness_check.py
+++ b/scripts/audit/naturalness_check.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import yaml
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
+VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
 if str(PROJECT_ROOT / "scripts") not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
@@ -101,7 +102,7 @@ def call_gemini(prompt: str, task_id: str) -> tuple[str, dict]:
     try:
         result = subprocess.run(
             [
-                sys.executable,
+                str(VENV_PYTHON),
                 str(PROJECT_ROOT / "scripts" / "ai_agent_bridge" / "__main__.py"),
                 "ask-gemini",
                 "-",  # read prompt from stdin
@@ -148,7 +149,7 @@ def call_claude_headless(prompt: str, task_id: str) -> tuple[str, dict]:
     try:
         result = subprocess.run(
             [
-                sys.executable,
+                str(VENV_PYTHON),
                 str(PROJECT_ROOT / "scripts" / "ai_agent_bridge" / "__main__.py"),
                 "ask-claude",
                 prompt,

--- a/scripts/batch/batch_fix_review.py
+++ b/scripts/batch/batch_fix_review.py
@@ -29,6 +29,7 @@ from slug_utils import status_path as _status_path
 from slug_utils import to_bare_slug
 
 REPO = Path(__file__).parent.parent.parent
+VENV_PYTHON = REPO / ".venv" / "bin" / "python"
 MAX_RETRIES = 3
 PASS_THRESHOLD = 9.0
 SUSPICIOUS_JUMP = 3.5  # Flag if score jumps more than this in one fix
@@ -267,7 +268,7 @@ def call_gemini(prompt_path: Path, task_id: str, model: str) -> Path:
     )
     result = subprocess.run(
         [
-            sys.executable, str(REPO / "scripts/ai_agent_bridge/__main__.py"),
+            str(VENV_PYTHON), str(REPO / "scripts/ai_agent_bridge/__main__.py"),
             "ask-gemini",
             "-",  # read prompt from stdin
             "--task-id", task_id,
@@ -290,7 +291,7 @@ def call_gemini_review(prompt_path: Path, task_id: str, model: str) -> Path:
     full_prompt = f"{prompt_content}\n\nWrap the ENTIRE review between ===REVIEW_START=== and ===REVIEW_END=== delimiters."
     result = subprocess.run(
         [
-            sys.executable, str(REPO / "scripts/ai_agent_bridge/__main__.py"),
+            str(VENV_PYTHON), str(REPO / "scripts/ai_agent_bridge/__main__.py"),
             "ask-gemini",
             "-",  # read prompt from stdin
             "--task-id", task_id,

--- a/scripts/batch/batch_research.py
+++ b/scripts/batch/batch_research.py
@@ -15,6 +15,7 @@ from batch_gemini_config import FLASH_MODEL
 from slug_utils import to_bare_slug
 
 REPO = Path(__file__).parent.parent.parent
+VENV_PYTHON = REPO / ".venv" / "bin" / "python"
 
 
 def find_module_files(level: str, num: int) -> dict | None:
@@ -226,7 +227,7 @@ def research_module(level: str, num: int, model: str, dry_run: bool = False) -> 
     try:
         result = subprocess.run(
             [
-                sys.executable, str(REPO / "scripts/ai_agent_bridge/__main__.py"),
+                str(VENV_PYTHON), str(REPO / "scripts/ai_agent_bridge/__main__.py"),
                 "ask-gemini", "-",
                 "--task-id", task_id,
                 "--output-path", output_path,

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -42,6 +42,8 @@ from yaml_activities import (
     ActivityParser,
 )
 
+VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
+
 
 def detect_pipeline_info(level_dir: Path, slug: str) -> tuple[str | None, str | None]:
     """Detect pipeline version and build status from orchestration dir.
@@ -578,7 +580,7 @@ def main():
         print('\n' + '=' * 50)
         print('Running MDX validation...\n')
         import subprocess
-        validate_args = [sys.executable, str(SCRIPT_DIR / 'validate_mdx.py'), lang_pair]
+        validate_args = [str(VENV_PYTHON), str(SCRIPT_DIR / 'validate_mdx.py'), lang_pair]
         if target_level:
             validate_args.append(target_level)
         if target_module:

--- a/scripts/rag/batch_scrape_izbornyk.py
+++ b/scripts/rag/batch_scrape_izbornyk.py
@@ -7,11 +7,12 @@ Scrapes texts organized into waves 5-10 by source page category.
 """
 
 import subprocess
-import sys
 import time
 from pathlib import Path
 
 BASE = "http://izbornyk.org.ua"
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
 
 # ══════════════════════════════════════════════════════════════════════
 # Wave 5: Old Ukrainian Literature (inoldlit.htm)
@@ -347,7 +348,7 @@ def scrape_text(text: dict, wave_num: int, dry_run: bool = False) -> int:
         return 0
 
     cmd = [
-        sys.executable, "scripts/rag/scrape_litopys.py",
+        str(VENV_PYTHON), str(PROJECT_ROOT / "scripts" / "rag" / "scrape_litopys.py"),
         "--url", text["url"],
         "--work", text["work"],
         "--author", text["author"],

--- a/scripts/tools/agent_watcher.py
+++ b/scripts/tools/agent_watcher.py
@@ -67,6 +67,7 @@ def _get_login_env() -> dict:
 LOGIN_ENV = _get_login_env()
 
 # Configuration
+VENV_PYTHON = Path(__file__).parent.parent.parent / ".venv" / "bin" / "python"
 DB_PATH = Path(__file__).parent.parent.parent / ".mcp/servers/message-broker/messages.db"
 PID_FILE = Path(__file__).parent.parent.parent / ".mcp/servers/message-broker/watcher.pid"
 LOG_FILE = Path(__file__).parent.parent.parent / ".mcp/servers/message-broker/watcher.log"
@@ -312,7 +313,7 @@ def trigger_agent(agent: str, message_id: int, task_id: str | None = None, from_
     try:
         bridge_cmd = agents[agent]["bridge_command"]
         cmd = [
-            sys.executable,
+            str(VENV_PYTHON),
             str(BRIDGE_SCRIPT),
             bridge_cmd,
             str(message_id)

--- a/tests/test_assess_research_coverage.py
+++ b/tests/test_assess_research_coverage.py
@@ -8,6 +8,9 @@ from unittest.mock import patch
 
 import pytest
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from assess_research import _coverage_for_track
@@ -73,8 +76,8 @@ class TestCoverageCliIntegration:
     def test_coverage_json_is_valid(self):
         """--coverage --json produces valid JSON with expected structure."""
         result = subprocess.run(
-            [sys.executable, "scripts/assess_research.py", "a1", "--coverage", "--json"],
-            capture_output=True, text=True, timeout=30,
+            [str(VENV_PYTHON), str(REPO_ROOT / "scripts/assess_research.py"), "a1", "--coverage", "--json"],
+            capture_output=True, text=True, timeout=30, cwd=REPO_ROOT,
         )
         assert result.returncode == 0
         data = json.loads(result.stdout)
@@ -93,16 +96,16 @@ class TestCoverageCliIntegration:
         particular coverage snapshot.
         """
         probe = subprocess.run(
-            [sys.executable, "scripts/assess_research.py", "a1", "--coverage", "--json"],
-            capture_output=True, text=True, timeout=30,
+            [str(VENV_PYTHON), str(REPO_ROOT / "scripts/assess_research.py"), "a1", "--coverage", "--json"],
+            capture_output=True, text=True, timeout=30, cwd=REPO_ROOT,
         )
         assert probe.returncode == 0
         data = json.loads(probe.stdout)
         expected_rc = 0 if not data.get("gaps") else 1
 
         strict = subprocess.run(
-            [sys.executable, "scripts/assess_research.py", "a1", "--coverage", "--strict"],
-            capture_output=True, text=True, timeout=30,
+            [str(VENV_PYTHON), str(REPO_ROOT / "scripts/assess_research.py"), "a1", "--coverage", "--strict"],
+            capture_output=True, text=True, timeout=30, cwd=REPO_ROOT,
         )
         assert strict.returncode == expected_rc, (
             f"--strict exited {strict.returncode} with "
@@ -112,8 +115,8 @@ class TestCoverageCliIntegration:
     def test_all_coverage_json(self):
         """--all --coverage --json produces valid JSON."""
         result = subprocess.run(
-            [sys.executable, "scripts/assess_research.py", "--all", "--coverage", "--json"],
-            capture_output=True, text=True, timeout=30,
+            [str(VENV_PYTHON), str(REPO_ROOT / "scripts/assess_research.py"), "--all", "--coverage", "--json"],
+            capture_output=True, text=True, timeout=30, cwd=REPO_ROOT,
         )
         assert result.returncode == 0
         data = json.loads(result.stdout)


### PR DESCRIPTION
## Summary
- replace remaining `sys.executable` subprocess invocations in touched runtime, batch, audit, MDX, and RAG scripts with the repo-local `.venv/bin/python`
- keep the interpreter contract explicit by adding local `VENV_PYTHON` path constants where needed
- update the assess-research CLI integration test to invoke the same `.venv/bin/python` path and repo-root script path

## Testing
- `.venv/bin/python -m pytest tests/test_assess_research_coverage.py`
- `.venv/bin/python -m compileall scripts/tools/agent_watcher.py scripts/ai_agent_bridge/_claude.py scripts/generate_mdx/core.py scripts/batch/batch_research.py scripts/batch/batch_fix_review.py scripts/audit/naturalness_check.py scripts/rag/batch_scrape_izbornyk.py`
- `rg -n "sys\.executable" scripts tests`