### PR TITLE
chore: commit 2026-04-23 session docs + colors smoke evidence

### DIFF
--- a/curriculum/l2-uk-en/a1/review/colors-review-actionable-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-actionable-r1.yaml
@@ -1,0 +1,280 @@
+slug: colors
+round: 1
+dimension: actionable
+name: Actionable
+score: 3.0
+verdict: REJECT
+evidence: '- Українською: "В українській мові для позначення "blue" ми активно вчимо
+  пару окремих слів..." English: The prose uses complex Ukrainian sentences for meta-explanation,
+  which an A1 learner cannot...'
+findings:
+- dimension: ACTIONABLE
+  severity: critical
+  location: Throughout the module (e.g., "Діалоги", "Кольори", "Синій ≠ блакитний",
+    and the end of the module)
+  issue: 'Українською: Автор скопіював інструкції з промпту (wiki excerpts та teaching
+    beats) безпосередньо в текст для студента, створивши складні україномовні речення
+    та суржик (напр., "This модуль taught узгодження кольорів using the adjective
+    правилами"). Крім того, в кінці модуля додано мета-коментар про баг у Python-скрипті.
+
+    English: The writer copy-pasted teaching beats and wiki excerpts directly into
+    the learner-facing text. This results in complex B2-level Ukrainian prose and
+    bizarre Surzhyk in an A1 module, violating the structural rule that explanations
+    must be in English. Additionally, the AI included meta-narration about a Python
+    bug at the end of the module.'
+  fix: Translate all pedagogical rationale into clear English prose, ensure Ukrainian
+    words are only used as bolded inline examples, and completely remove the meta-narration
+    about the Python bug.
+fixes:
+- find: Every color in Dialogue 1 arrives as a short відповідь (answer) to «Якого
+    кольору?» — без дієслова (without a verb), one adjective in the correct gender.
+    Білий з'являється у формі «білі лілії» — саме цей колір входить до першої послідовності
+    введення кольорів у підручниках, бо білий легко впізнати на предметах навколо.
+    Такі кольори, як білий і червоний, використовуються for впізнавання (recognition)
+    of everyday objects — the learner links word to thing immediately. This echoes
+    how Ukrainian textbooks introduce colors, за мотивами вірша про кольори from the
+    Большакова Grade 2 textbook.
+  replace: Every color in Dialogue 1 arrives as a short **відповідь** (answer) to
+    **«Якого кольору?»** — **без дієслова** (without a verb), just one adjective in
+    the correct gender. Colors like **білий** (white) and **червоний** (red) are used
+    for **впізнавання** (recognition) of everyday objects. For example, **білий**
+    appears as **«білі лілії»** (white lilies), making it easy to link the word to
+    the thing immediately.
+- find: '«червоний / червона / червоне / червоні» (red), «жовтий / жовта / жовте /
+    жовті» (yellow), «зелений / зелена / зелене / зелені» (green), «чорний / чорна
+    / чорне / чорні» (black), «білий / біла / біле / білі» (white), «сірий / сіра
+    / сіре / сірі» (gray).
+
+
+    Варто запам''ятати саме ці шість — вони покривають більшість побутових описів.
+    Білий, жовтий і зелений входять до першої послідовності введення кольорів у більшості
+    підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений
+    листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих
+    форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і
+    зелений — «жовтий м''яч» і «зелений листок».
+
+
+    Five more follow the same endings:'
+  replace: '**червоний / червона / червоне / червоні** (red), **жовтий / жовта / жовте
+    / жовті** (yellow), **зелений / зелена / зелене / зелені** (green), **чорний /
+    чорна / чорне / чорні** (black), **білий / біла / біле / білі** (white), **сірий
+    / сіра / сіре / сірі** (gray).
+
+
+    It is worth memorizing these six first, as they cover most everyday descriptions.
+    Common examples include **жовтий соняшник** (yellow sunflower), **зелений листок**
+    (green leaf), and **білий сніг** (white snow).
+
+
+    Five more follow the same endings:'
+- find: 'В українській мові для позначення "blue" ми активно вчимо пару окремих слів
+    — these are two separate base colors, not two shades of one word. Впізнавання
+    різниці між «синій» і «блакитний» is one of the first steps in thinking about
+    color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить
+    до послідовності введення кольорів нарівні з основними, бо це окремий базовий
+    колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the
+    sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне
+    небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag
+    is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below
+    is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий
+    часто зустрічаються поряд як приклади з підручників для тренування — наприклад,
+    «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.
+    If you encounter «голубий» outside this module, it is a dictionary-level synonym
+    for «блакитний» — passive recognition is enough at A1, not a third active color
+    to learn.'
+  replace: 'In Ukrainian, there are two separate base words for "blue," not just two
+    shades of one word. Recognizing the difference between **синій** and **блакитний**
+    is one of the first steps in thinking about color like a Ukrainian speaker.
+
+
+    - **Синій** means dark, deep blue — the color of the sea and ink: **синє море**
+    (dark blue sea), **синє чорнило** (dark blue ink).
+
+    - **Блакитний** means light, sky blue: **блакитне небо** (light blue sky), **блакитні
+    очі** (light blue eyes).
+
+
+    A stable reference pair to memorize: the Ukrainian flag is **синьо-жовтий** —
+    the dark stripe on top is **синій**, the bright stripe below is **жовтий**, and
+    a clear noon sky is **блакитне**. If you encounter **голубий** outside this module,
+    it is a synonym for **блакитний** — passive recognition is enough at A1.'
+- find: This модуль taught узгодження кольорів using the adjective правилами you learned
+    in Module 9.
+  replace: This module taught color agreement (**узгодження кольорів**) using the
+    adjective rules you learned in Module 9.
+- find: 'Перевірте себе — три завдання:
+
+
+    • Поставте 3 запитання «Якого кольору?» про речі у вашій кімнаті й дайте короткі
+    відповіді. Наприклад: «Якого кольору твій стіл? — Коричневий.»
+
+
+    • Опишіть 3 предмети з правильним узгодженням за родом: «Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»
+
+
+    • Скажіть природно: «У мене ___ очі. У мене ___ волосся.» Вибирайте з «карі /
+    блакитні» та «русяве / сиве / темне».
+
+
+    > Check yourself: (1) Ask three «Якого кольору?» questions about things in your
+    room and answer them. (2) Describe three objects with correct gender agreement.
+    (3) Describe your eyes and hair using the fixed collocations from Dialogue 2.'
+  replace: 'Check yourself with three tasks:
+
+
+    1. Ask three **«Якого кольору...?»** questions about things in your room and answer
+    them. For example: **«Якого кольору твій стіл? — Коричневий.»**
+
+    2. Describe three objects with correct gender agreement: **«Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»**
+
+    3. Describe your eyes and hair using the fixed collocations from Dialogue 2: **«У
+    мене ___ очі. У мене ___ волосся.»** Choose from **карі / блакитні** and **русяве
+    / сиве / темне**.'
+- find: '---
+
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:**
+
+    - Added `_strip_combining()` helper that applies the same NFKD + strip-combining
+    normalization
+
+    - Updated `_missing_terms()` to normalize both the text and the terms before matching
+
+    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit
+    function and end-to-end integration
+
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: ''
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: actionable\nname: Actionable\nscore:\
+  \ 3.0/10\nverdict: REJECT\n\n## Evidence\n- Українською: \"В українській мові для\
+  \ позначення \"blue\" ми активно вчимо пару окремих слів...\"\n  English: The prose\
+  \ uses complex Ukrainian sentences for meta-explanation, which an A1 learner cannot\
+  \ read.\n- Українською: \"Білий з'являється у формі «білі лілії» — саме цей колір\
+  \ входить до першої послідовності введення кольорів...\"\n  English: More advanced\
+  \ Ukrainian prose mixed into English paragraphs.\n- Українською: \"This модуль taught\
+  \ узгодження кольорів using the adjective правилами you learned in Module 9.\"\n\
+  \  English: Surzhyk/macaronic mixing of Ukrainian words into English grammar structures.\n\
+  - Українською: \"**Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`...**\"\
+  \n  English: AI meta-narration about a Python script bug included in the learner-facing\
+  \ module.\n\n## Findings\n[ACTIONABLE] [SEVERITY: critical]\nLocation: Throughout\
+  \ the module (e.g., \"Діалоги\", \"Кольори\", \"Синій ≠ блакитний\", and the end\
+  \ of the module)\nIssue: Українською: Автор скопіював інструкції з промпту (wiki\
+  \ excerpts та teaching beats) безпосередньо в текст для студента, створивши складні\
+  \ україномовні речення та суржик (напр., \"This модуль taught узгодження кольорів\
+  \ using the adjective правилами\"). Крім того, в кінці модуля додано мета-коментар\
+  \ про баг у Python-скрипті.\nEnglish: The writer copy-pasted teaching beats and\
+  \ wiki excerpts directly into the learner-facing text. This results in complex B2-level\
+  \ Ukrainian prose and bizarre Surzhyk in an A1 module, violating the structural\
+  \ rule that explanations must be in English. Additionally, the AI included meta-narration\
+  \ about a Python bug at the end of the module.\nFix: Translate all pedagogical rationale\
+  \ into clear English prose, ensure Ukrainian words are only used as bolded inline\
+  \ examples, and completely remove the meta-narration about the Python bug.\n\n##\
+  \ Verdict Reason\nThe module severely violates the A1 scaffolding rules by using\
+  \ complex Ukrainian sentences and macaronic Surzhyk for pedagogical explanations,\
+  \ making it unreadable for an A1 learner. Additionally, the inclusion of AI meta-narration\
+  \ about a Python script bug in the learner-facing text makes the module completely\
+  \ non-actionable as educational material.\n\n<fixes>\n- find: |-\n    Every color\
+  \ in Dialogue 1 arrives as a short відповідь (answer) to «Якого кольору?» — без\
+  \ дієслова (without a verb), one adjective in the correct gender. Білий з'являється\
+  \ у формі «білі лілії» — саме цей колір входить до першої послідовності введення\
+  \ кольорів у підручниках, бо білий легко впізнати на предметах навколо. Такі кольори,\
+  \ як білий і червоний, використовуються for впізнавання (recognition) of everyday\
+  \ objects — the learner links word to thing immediately. This echoes how Ukrainian\
+  \ textbooks introduce colors, за мотивами вірша про кольори from the Большакова\
+  \ Grade 2 textbook.\n  replace: |-\n    Every color in Dialogue 1 arrives as a short\
+  \ **відповідь** (answer) to **«Якого кольору?»** — **без дієслова** (without a verb),\
+  \ just one adjective in the correct gender. Colors like **білий** (white) and **червоний**\
+  \ (red) are used for **впізнавання** (recognition) of everyday objects. For example,\
+  \ **білий** appears as **«білі лілії»** (white lilies), making it easy to link the\
+  \ word to the thing immediately.\n- find: |-\n    «червоний / червона / червоне\
+  \ / червоні» (red), «жовтий / жовта / жовте / жовті» (yellow), «зелений / зелена\
+  \ / зелене / зелені» (green), «чорний / чорна / чорне / чорні» (black), «білий /\
+  \ біла / біле / білі» (white), «сірий / сіра / сіре / сірі» (gray).\n    \n    Варто\
+  \ запам'ятати саме ці шість — вони покривають більшість побутових описів. Білий,\
+  \ жовтий і зелений входять до першої послідовності введення кольорів у більшості\
+  \ підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений\
+  \ листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих\
+  \ форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і\
+  \ зелений — «жовтий м'яч» і «зелений листок».\n    \n    Five more follow the same\
+  \ endings:\n  replace: |-\n    **червоний / червона / червоне / червоні** (red),\
+  \ **жовтий / жовта / жовте / жовті** (yellow), **зелений / зелена / зелене / зелені**\
+  \ (green), **чорний / чорна / чорне / чорні** (black), **білий / біла / біле / білі**\
+  \ (white), **сірий / сіра / сіре / сірі** (gray).\n    \n    It is worth memorizing\
+  \ these six first, as they cover most everyday descriptions. Common examples include\
+  \ **жовтий соняшник** (yellow sunflower), **зелений листок** (green leaf), and **білий\
+  \ сніг** (white snow).\n    \n    Five more follow the same endings:\n- find: |-\n\
+  \    В українській мові для позначення \"blue\" ми активно вчимо пару окремих слів\
+  \ — these are two separate base colors, not two shades of one word. Впізнавання\
+  \ різниці між «синій» і «блакитний» is one of the first steps in thinking about\
+  \ color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить\
+  \ до послідовності введення кольорів нарівні з основними, бо це окремий базовий\
+  \ колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the\
+  \ sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне\
+  \ небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag\
+  \ is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below\
+  \ is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий\
+  \ часто зустрічаються поряд як приклади з підручників для тренування — наприклад,\
+  \ «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.\
+  \ If you encounter «голубий» outside this module, it is a dictionary-level synonym\
+  \ for «блакитний» — passive recognition is enough at A1, not a third active color\
+  \ to learn.\n  replace: |-\n    In Ukrainian, there are two separate base words\
+  \ for \"blue,\" not just two shades of one word. Recognizing the difference between\
+  \ **синій** and **блакитний** is one of the first steps in thinking about color\
+  \ like a Ukrainian speaker.\n    \n    - **Синій** means dark, deep blue — the color\
+  \ of the sea and ink: **синє море** (dark blue sea), **синє чорнило** (dark blue\
+  \ ink).\n    - **Блакитний** means light, sky blue: **блакитне небо** (light blue\
+  \ sky), **блакитні очі** (light blue eyes).\n    \n    A stable reference pair to\
+  \ memorize: the Ukrainian flag is **синьо-жовтий** — the dark stripe on top is **синій**,\
+  \ the bright stripe below is **жовтий**, and a clear noon sky is **блакитне**. If\
+  \ you encounter **голубий** outside this module, it is a synonym for **блакитний**\
+  \ — passive recognition is enough at A1.\n- find: |-\n    This модуль taught узгодження\
+  \ кольорів using the adjective правилами you learned in Module 9.\n  replace: |-\n\
+  \    This module taught color agreement (**узгодження кольорів**) using the adjective\
+  \ rules you learned in Module 9.\n- find: |-\n    Перевірте себе — три завдання:\n\
+  \    \n    • Поставте 3 запитання «Якого кольору?» про речі у вашій кімнаті й дайте\
+  \ короткі відповіді. Наприклад: «Якого кольору твій стіл? — Коричневий.»\n    \n\
+  \    • Опишіть 3 предмети з правильним узгодженням за родом: «Моя сумка ___на. Моє\
+  \ вікно ___не. Мій светр ___ній.»\n    \n    • Скажіть природно: «У мене ___ очі.\
+  \ У мене ___ волосся.» Вибирайте з «карі / блакитні» та «русяве / сиве / темне».\n\
+  \    \n    > Check yourself: (1) Ask three «Якого кольору?» questions about things\
+  \ in your room and answer them. (2) Describe three objects with correct gender agreement.\
+  \ (3) Describe your eyes and hair using the fixed collocations from Dialogue 2.\n\
+  \  replace: |-\n    Check yourself with three tasks:\n    \n    1. Ask three **«Якого\
+  \ кольору...?»** questions about things in your room and answer them. For example:\
+  \ **«Якого кольору твій стіл? — Коричневий.»**\n    2. Describe three objects with\
+  \ correct gender agreement: **«Моя сумка ___на. Моє вікно ___не. Мій светр ___ній.»**\n\
+  \    3. Describe your eyes and hair using the fixed collocations from Dialogue 2:\
+  \ **«У мене ___ очі. У мене ___ волосся.»** Choose from **карі / блакитні** and\
+  \ **русяве / сиве / темне**.\n- find: |-\n    ---\n    \n    **Important: The errors\
+  \ were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,\
+  \ not problems with the draft.** The draft is unchanged because the content was\
+  \ already correct.\n    \n    **Root cause:** The `wiki_compressor._tokenize()`\
+  \ function applies NFKD normalization + combining-mark stripping, which converts\
+  \ Ukrainian \"й\" (U+0439 = и + combining breve) → \"и\" (U+0438). So \"білий\"\
+  \ becomes \"білии\" in the anchor terms. But `_missing_terms()` in the compliance\
+  \ checker did raw substring matching without the same normalization — it looked\
+  \ for \"білии\" in text containing \"білий\" and never found it.\n    \n    **Fix\
+  \ applied to `scripts/audit/checks/contract_compliance.py`:**\n    - Added `_strip_combining()`\
+  \ helper that applies the same NFKD + strip-combining normalization\n    - Updated\
+  \ `_missing_terms()` to normalize both the text and the terms before matching\n\
+  \    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit\
+  \ function and end-to-end integration\n    \n    This was a systemic bug — every\
+  \ Ukrainian word ending in \"й\" would fail as a factual anchor term. The fix resolves\
+  \ this for all modules, not just colors.\n  replace: \"\"\n</fixes>\n```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-actionable.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-actionable.yaml
@@ -1,0 +1,280 @@
+slug: colors
+round: 1
+dimension: actionable
+name: Actionable
+score: 3.0
+verdict: REJECT
+evidence: '- Українською: "В українській мові для позначення "blue" ми активно вчимо
+  пару окремих слів..." English: The prose uses complex Ukrainian sentences for meta-explanation,
+  which an A1 learner cannot...'
+findings:
+- dimension: ACTIONABLE
+  severity: critical
+  location: Throughout the module (e.g., "Діалоги", "Кольори", "Синій ≠ блакитний",
+    and the end of the module)
+  issue: 'Українською: Автор скопіював інструкції з промпту (wiki excerpts та teaching
+    beats) безпосередньо в текст для студента, створивши складні україномовні речення
+    та суржик (напр., "This модуль taught узгодження кольорів using the adjective
+    правилами"). Крім того, в кінці модуля додано мета-коментар про баг у Python-скрипті.
+
+    English: The writer copy-pasted teaching beats and wiki excerpts directly into
+    the learner-facing text. This results in complex B2-level Ukrainian prose and
+    bizarre Surzhyk in an A1 module, violating the structural rule that explanations
+    must be in English. Additionally, the AI included meta-narration about a Python
+    bug at the end of the module.'
+  fix: Translate all pedagogical rationale into clear English prose, ensure Ukrainian
+    words are only used as bolded inline examples, and completely remove the meta-narration
+    about the Python bug.
+fixes:
+- find: Every color in Dialogue 1 arrives as a short відповідь (answer) to «Якого
+    кольору?» — без дієслова (without a verb), one adjective in the correct gender.
+    Білий з'являється у формі «білі лілії» — саме цей колір входить до першої послідовності
+    введення кольорів у підручниках, бо білий легко впізнати на предметах навколо.
+    Такі кольори, як білий і червоний, використовуються for впізнавання (recognition)
+    of everyday objects — the learner links word to thing immediately. This echoes
+    how Ukrainian textbooks introduce colors, за мотивами вірша про кольори from the
+    Большакова Grade 2 textbook.
+  replace: Every color in Dialogue 1 arrives as a short **відповідь** (answer) to
+    **«Якого кольору?»** — **без дієслова** (without a verb), just one adjective in
+    the correct gender. Colors like **білий** (white) and **червоний** (red) are used
+    for **впізнавання** (recognition) of everyday objects. For example, **білий**
+    appears as **«білі лілії»** (white lilies), making it easy to link the word to
+    the thing immediately.
+- find: '«червоний / червона / червоне / червоні» (red), «жовтий / жовта / жовте /
+    жовті» (yellow), «зелений / зелена / зелене / зелені» (green), «чорний / чорна
+    / чорне / чорні» (black), «білий / біла / біле / білі» (white), «сірий / сіра
+    / сіре / сірі» (gray).
+
+
+    Варто запам''ятати саме ці шість — вони покривають більшість побутових описів.
+    Білий, жовтий і зелений входять до першої послідовності введення кольорів у більшості
+    підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений
+    листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих
+    форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і
+    зелений — «жовтий м''яч» і «зелений листок».
+
+
+    Five more follow the same endings:'
+  replace: '**червоний / червона / червоне / червоні** (red), **жовтий / жовта / жовте
+    / жовті** (yellow), **зелений / зелена / зелене / зелені** (green), **чорний /
+    чорна / чорне / чорні** (black), **білий / біла / біле / білі** (white), **сірий
+    / сіра / сіре / сірі** (gray).
+
+
+    It is worth memorizing these six first, as they cover most everyday descriptions.
+    Common examples include **жовтий соняшник** (yellow sunflower), **зелений листок**
+    (green leaf), and **білий сніг** (white snow).
+
+
+    Five more follow the same endings:'
+- find: 'В українській мові для позначення "blue" ми активно вчимо пару окремих слів
+    — these are two separate base colors, not two shades of one word. Впізнавання
+    різниці між «синій» і «блакитний» is one of the first steps in thinking about
+    color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить
+    до послідовності введення кольорів нарівні з основними, бо це окремий базовий
+    колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the
+    sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне
+    небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag
+    is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below
+    is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий
+    часто зустрічаються поряд як приклади з підручників для тренування — наприклад,
+    «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.
+    If you encounter «голубий» outside this module, it is a dictionary-level synonym
+    for «блакитний» — passive recognition is enough at A1, not a third active color
+    to learn.'
+  replace: 'In Ukrainian, there are two separate base words for "blue," not just two
+    shades of one word. Recognizing the difference between **синій** and **блакитний**
+    is one of the first steps in thinking about color like a Ukrainian speaker.
+
+
+    - **Синій** means dark, deep blue — the color of the sea and ink: **синє море**
+    (dark blue sea), **синє чорнило** (dark blue ink).
+
+    - **Блакитний** means light, sky blue: **блакитне небо** (light blue sky), **блакитні
+    очі** (light blue eyes).
+
+
+    A stable reference pair to memorize: the Ukrainian flag is **синьо-жовтий** —
+    the dark stripe on top is **синій**, the bright stripe below is **жовтий**, and
+    a clear noon sky is **блакитне**. If you encounter **голубий** outside this module,
+    it is a synonym for **блакитний** — passive recognition is enough at A1.'
+- find: This модуль taught узгодження кольорів using the adjective правилами you learned
+    in Module 9.
+  replace: This module taught color agreement (**узгодження кольорів**) using the
+    adjective rules you learned in Module 9.
+- find: 'Перевірте себе — три завдання:
+
+
+    • Поставте 3 запитання «Якого кольору?» про речі у вашій кімнаті й дайте короткі
+    відповіді. Наприклад: «Якого кольору твій стіл? — Коричневий.»
+
+
+    • Опишіть 3 предмети з правильним узгодженням за родом: «Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»
+
+
+    • Скажіть природно: «У мене ___ очі. У мене ___ волосся.» Вибирайте з «карі /
+    блакитні» та «русяве / сиве / темне».
+
+
+    > Check yourself: (1) Ask three «Якого кольору?» questions about things in your
+    room and answer them. (2) Describe three objects with correct gender agreement.
+    (3) Describe your eyes and hair using the fixed collocations from Dialogue 2.'
+  replace: 'Check yourself with three tasks:
+
+
+    1. Ask three **«Якого кольору...?»** questions about things in your room and answer
+    them. For example: **«Якого кольору твій стіл? — Коричневий.»**
+
+    2. Describe three objects with correct gender agreement: **«Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»**
+
+    3. Describe your eyes and hair using the fixed collocations from Dialogue 2: **«У
+    мене ___ очі. У мене ___ волосся.»** Choose from **карі / блакитні** and **русяве
+    / сиве / темне**.'
+- find: '---
+
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:**
+
+    - Added `_strip_combining()` helper that applies the same NFKD + strip-combining
+    normalization
+
+    - Updated `_missing_terms()` to normalize both the text and the terms before matching
+
+    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit
+    function and end-to-end integration
+
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: ''
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: actionable\nname: Actionable\nscore:\
+  \ 3.0/10\nverdict: REJECT\n\n## Evidence\n- Українською: \"В українській мові для\
+  \ позначення \"blue\" ми активно вчимо пару окремих слів...\"\n  English: The prose\
+  \ uses complex Ukrainian sentences for meta-explanation, which an A1 learner cannot\
+  \ read.\n- Українською: \"Білий з'являється у формі «білі лілії» — саме цей колір\
+  \ входить до першої послідовності введення кольорів...\"\n  English: More advanced\
+  \ Ukrainian prose mixed into English paragraphs.\n- Українською: \"This модуль taught\
+  \ узгодження кольорів using the adjective правилами you learned in Module 9.\"\n\
+  \  English: Surzhyk/macaronic mixing of Ukrainian words into English grammar structures.\n\
+  - Українською: \"**Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`...**\"\
+  \n  English: AI meta-narration about a Python script bug included in the learner-facing\
+  \ module.\n\n## Findings\n[ACTIONABLE] [SEVERITY: critical]\nLocation: Throughout\
+  \ the module (e.g., \"Діалоги\", \"Кольори\", \"Синій ≠ блакитний\", and the end\
+  \ of the module)\nIssue: Українською: Автор скопіював інструкції з промпту (wiki\
+  \ excerpts та teaching beats) безпосередньо в текст для студента, створивши складні\
+  \ україномовні речення та суржик (напр., \"This модуль taught узгодження кольорів\
+  \ using the adjective правилами\"). Крім того, в кінці модуля додано мета-коментар\
+  \ про баг у Python-скрипті.\nEnglish: The writer copy-pasted teaching beats and\
+  \ wiki excerpts directly into the learner-facing text. This results in complex B2-level\
+  \ Ukrainian prose and bizarre Surzhyk in an A1 module, violating the structural\
+  \ rule that explanations must be in English. Additionally, the AI included meta-narration\
+  \ about a Python bug at the end of the module.\nFix: Translate all pedagogical rationale\
+  \ into clear English prose, ensure Ukrainian words are only used as bolded inline\
+  \ examples, and completely remove the meta-narration about the Python bug.\n\n##\
+  \ Verdict Reason\nThe module severely violates the A1 scaffolding rules by using\
+  \ complex Ukrainian sentences and macaronic Surzhyk for pedagogical explanations,\
+  \ making it unreadable for an A1 learner. Additionally, the inclusion of AI meta-narration\
+  \ about a Python script bug in the learner-facing text makes the module completely\
+  \ non-actionable as educational material.\n\n<fixes>\n- find: |-\n    Every color\
+  \ in Dialogue 1 arrives as a short відповідь (answer) to «Якого кольору?» — без\
+  \ дієслова (without a verb), one adjective in the correct gender. Білий з'являється\
+  \ у формі «білі лілії» — саме цей колір входить до першої послідовності введення\
+  \ кольорів у підручниках, бо білий легко впізнати на предметах навколо. Такі кольори,\
+  \ як білий і червоний, використовуються for впізнавання (recognition) of everyday\
+  \ objects — the learner links word to thing immediately. This echoes how Ukrainian\
+  \ textbooks introduce colors, за мотивами вірша про кольори from the Большакова\
+  \ Grade 2 textbook.\n  replace: |-\n    Every color in Dialogue 1 arrives as a short\
+  \ **відповідь** (answer) to **«Якого кольору?»** — **без дієслова** (without a verb),\
+  \ just one adjective in the correct gender. Colors like **білий** (white) and **червоний**\
+  \ (red) are used for **впізнавання** (recognition) of everyday objects. For example,\
+  \ **білий** appears as **«білі лілії»** (white lilies), making it easy to link the\
+  \ word to the thing immediately.\n- find: |-\n    «червоний / червона / червоне\
+  \ / червоні» (red), «жовтий / жовта / жовте / жовті» (yellow), «зелений / зелена\
+  \ / зелене / зелені» (green), «чорний / чорна / чорне / чорні» (black), «білий /\
+  \ біла / біле / білі» (white), «сірий / сіра / сіре / сірі» (gray).\n    \n    Варто\
+  \ запам'ятати саме ці шість — вони покривають більшість побутових описів. Білий,\
+  \ жовтий і зелений входять до першої послідовності введення кольорів у більшості\
+  \ підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений\
+  \ листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих\
+  \ форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і\
+  \ зелений — «жовтий м'яч» і «зелений листок».\n    \n    Five more follow the same\
+  \ endings:\n  replace: |-\n    **червоний / червона / червоне / червоні** (red),\
+  \ **жовтий / жовта / жовте / жовті** (yellow), **зелений / зелена / зелене / зелені**\
+  \ (green), **чорний / чорна / чорне / чорні** (black), **білий / біла / біле / білі**\
+  \ (white), **сірий / сіра / сіре / сірі** (gray).\n    \n    It is worth memorizing\
+  \ these six first, as they cover most everyday descriptions. Common examples include\
+  \ **жовтий соняшник** (yellow sunflower), **зелений листок** (green leaf), and **білий\
+  \ сніг** (white snow).\n    \n    Five more follow the same endings:\n- find: |-\n\
+  \    В українській мові для позначення \"blue\" ми активно вчимо пару окремих слів\
+  \ — these are two separate base colors, not two shades of one word. Впізнавання\
+  \ різниці між «синій» і «блакитний» is one of the first steps in thinking about\
+  \ color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить\
+  \ до послідовності введення кольорів нарівні з основними, бо це окремий базовий\
+  \ колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the\
+  \ sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне\
+  \ небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag\
+  \ is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below\
+  \ is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий\
+  \ часто зустрічаються поряд як приклади з підручників для тренування — наприклад,\
+  \ «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.\
+  \ If you encounter «голубий» outside this module, it is a dictionary-level synonym\
+  \ for «блакитний» — passive recognition is enough at A1, not a third active color\
+  \ to learn.\n  replace: |-\n    In Ukrainian, there are two separate base words\
+  \ for \"blue,\" not just two shades of one word. Recognizing the difference between\
+  \ **синій** and **блакитний** is one of the first steps in thinking about color\
+  \ like a Ukrainian speaker.\n    \n    - **Синій** means dark, deep blue — the color\
+  \ of the sea and ink: **синє море** (dark blue sea), **синє чорнило** (dark blue\
+  \ ink).\n    - **Блакитний** means light, sky blue: **блакитне небо** (light blue\
+  \ sky), **блакитні очі** (light blue eyes).\n    \n    A stable reference pair to\
+  \ memorize: the Ukrainian flag is **синьо-жовтий** — the dark stripe on top is **синій**,\
+  \ the bright stripe below is **жовтий**, and a clear noon sky is **блакитне**. If\
+  \ you encounter **голубий** outside this module, it is a synonym for **блакитний**\
+  \ — passive recognition is enough at A1.\n- find: |-\n    This модуль taught узгодження\
+  \ кольорів using the adjective правилами you learned in Module 9.\n  replace: |-\n\
+  \    This module taught color agreement (**узгодження кольорів**) using the adjective\
+  \ rules you learned in Module 9.\n- find: |-\n    Перевірте себе — три завдання:\n\
+  \    \n    • Поставте 3 запитання «Якого кольору?» про речі у вашій кімнаті й дайте\
+  \ короткі відповіді. Наприклад: «Якого кольору твій стіл? — Коричневий.»\n    \n\
+  \    • Опишіть 3 предмети з правильним узгодженням за родом: «Моя сумка ___на. Моє\
+  \ вікно ___не. Мій светр ___ній.»\n    \n    • Скажіть природно: «У мене ___ очі.\
+  \ У мене ___ волосся.» Вибирайте з «карі / блакитні» та «русяве / сиве / темне».\n\
+  \    \n    > Check yourself: (1) Ask three «Якого кольору?» questions about things\
+  \ in your room and answer them. (2) Describe three objects with correct gender agreement.\
+  \ (3) Describe your eyes and hair using the fixed collocations from Dialogue 2.\n\
+  \  replace: |-\n    Check yourself with three tasks:\n    \n    1. Ask three **«Якого\
+  \ кольору...?»** questions about things in your room and answer them. For example:\
+  \ **«Якого кольору твій стіл? — Коричневий.»**\n    2. Describe three objects with\
+  \ correct gender agreement: **«Моя сумка ___на. Моє вікно ___не. Мій светр ___ній.»**\n\
+  \    3. Describe your eyes and hair using the fixed collocations from Dialogue 2:\
+  \ **«У мене ___ очі. У мене ___ волосся.»** Choose from **карі / блакитні** and\
+  \ **русяве / сиве / темне**.\n- find: |-\n    ---\n    \n    **Important: The errors\
+  \ were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,\
+  \ not problems with the draft.** The draft is unchanged because the content was\
+  \ already correct.\n    \n    **Root cause:** The `wiki_compressor._tokenize()`\
+  \ function applies NFKD normalization + combining-mark stripping, which converts\
+  \ Ukrainian \"й\" (U+0439 = и + combining breve) → \"и\" (U+0438). So \"білий\"\
+  \ becomes \"білии\" in the anchor terms. But `_missing_terms()` in the compliance\
+  \ checker did raw substring matching without the same normalization — it looked\
+  \ for \"білии\" in text containing \"білий\" and never found it.\n    \n    **Fix\
+  \ applied to `scripts/audit/checks/contract_compliance.py`:**\n    - Added `_strip_combining()`\
+  \ helper that applies the same NFKD + strip-combining normalization\n    - Updated\
+  \ `_missing_terms()` to normalize both the text and the terms before matching\n\
+  \    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit\
+  \ function and end-to-end integration\n    \n    This was a systemic bug — every\
+  \ Ukrainian word ending in \"й\" would fail as a factual anchor term. The fix resolves\
+  \ this for all modules, not just colors.\n  replace: \"\"\n</fixes>\n```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-aggregate-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-aggregate-r1.yaml
@@ -1,0 +1,220 @@
+slug: colors
+round: 1
+review_mode: per-dimension-min
+verdict: REJECT
+verdict_score: 3.0
+overall_score: 3.0
+weighted_average: 7.4
+dim_scores:
+  factual: 8.0
+  language: 10.0
+  decolonization: 10.0
+  completeness: 9.0
+  actionable: 3.0
+  naturalness: 4.0
+  plan_adherence: 8.5
+  honesty: 4.0
+  dialogue: 10.0
+scores:
+- dimension: 1
+  key: factual
+  name: Factual
+  score: 8.0
+  evidence: '- Українською: "білии" (found inside the English bug report at the end
+    of the module) English: The module ends with a Python bug report explaining script
+    normalization ("білий" -> "білии") instead...'
+- dimension: 2
+  key: language
+  name: Language
+  score: 10.0
+  evidence: '- Українською: **«Якого вони кольору?»**, **«Червоні.»**, **«Синя.»**,
+    **«Сіре.»** English: Correct use of the "What color?" formula and precise gender/number
+    agreement in short answers. - Українсь...'
+- dimension: 3
+  key: decolonization
+  name: Decolonization
+  score: 10.0
+  evidence: '- Українською: В українській мові для позначення "blue" ми активно вчимо
+    пару окремих слів — these are two separate base colors, not two shades of one
+    word. English: Effectively contrasts Ukrainian...'
+- dimension: 4
+  key: completeness
+  name: Completeness
+  score: 9.0
+  evidence: '- Українською: Прапор України — синьо-жовтий (Кравцова, 2 клас, с. 22:
+    Синє — небо, жовте — жито). English: Contract explicitly requires citing Kravtsova''s
+    Grade 2 textbook for the blue-yellow flag...'
+- dimension: 5
+  key: actionable
+  name: Actionable
+  score: 3.0
+  evidence: '- Українською: "В українській мові для позначення "blue" ми активно вчимо
+    пару окремих слів..." English: The prose uses complex Ukrainian sentences for
+    meta-explanation, which an A1 learner cannot...'
+- dimension: 6
+  key: naturalness
+  name: Naturalness
+  score: 4.0
+  evidence: '- Українською: `Такі кольори, як білий і червоний, використовуються for
+    впізнавання (recognition) of everyday objects — the learner links word to thing
+    immediately. This echoes how Ukrainian textbo...'
+- dimension: 7
+  key: plan_adherence
+  name: Plan Adherence
+  score: 8.5
+  evidence: '- Українською: «Діалог 1 — Вибір букета на квітковому ринку (за мотивами
+    вірша про кольори з підручника Большакової для 2 класу, с. 38)» English: Section
+    1 correctly follows the pedagogy source and...'
+- dimension: 8
+  key: honesty
+  name: Honesty
+  score: 4.0
+  evidence: '- Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме
+    через жовтий і зелений — «жовтий м''яч» і «зелений листок». English: The writer
+    makes a highly specific, confident claim attri...'
+- dimension: 9
+  key: dialogue
+  name: Dialogue
+  score: 10.0
+  evidence: '- Українською: «— **Наталка:** Добрий день! *(Good day!)* / — **Продавець:**
+    Добрий день! Будь ласка, дивіться. *(Good day! Please, look around.)*» English:
+    Includes natural turn-taking and common...'
+findings:
+- dimension: FACTUAL
+  severity: major
+  location: End of the module (Підсумок)
+  issue: 'Українською: Текст містить технічний звіт про помилку в скрипті Python замість
+    навчального матеріалу.
+
+    English: The draft includes raw LLM meta-narration and a bug report about a Python
+    script at the end of the content. This is a fabrication of curriculum content
+    and violates the ban on meta-narration.'
+  fix: Remove the bug report section entirely.
+- dimension: COMPLETENESS
+  severity: minor
+  location: Section "Синій ≠ блакитний"
+  issue: 'Українською: Пропущено педагогічну опору з підручника Кравцової для 2 класу:
+    "Синє — небо, жовте — жито", що була чітко вказана в контракті.
+
+    English: The specific textbook citation (Kravtsova, Grade 2) and the corresponding
+    quote for the flag colors are missing.'
+  fix: Add the Kravtsova textbook reference and quote to the explanation of the Ukrainian
+    flag colors.
+- dimension: ACTIONABLE
+  severity: critical
+  location: Throughout the module (e.g., "Діалоги", "Кольори", "Синій ≠ блакитний",
+    and the end of the module)
+  issue: 'Українською: Автор скопіював інструкції з промпту (wiki excerpts та teaching
+    beats) безпосередньо в текст для студента, створивши складні україномовні речення
+    та суржик (напр., "This модуль taught узгодження кольорів using the adjective
+    правилами"). Крім того, в кінці модуля додано мета-коментар про баг у Python-скрипті.
+
+    English: The writer copy-pasted teaching beats and wiki excerpts directly into
+    the learner-facing text. This results in complex B2-level Ukrainian prose and
+    bizarre Surzhyk in an A1 module, violating the structural rule that explanations
+    must be in English. Additionally, the AI included meta-narration about a Python
+    bug at the end of the module.'
+  fix: Translate all pedagogical rationale into clear English prose, ensure Ukrainian
+    words are only used as bolded inline examples, and completely remove the meta-narration
+    about the Python bug.
+- dimension: NATURALNESS
+  severity: critical
+  location: Section "Діалоги" and throughout the module
+  issue: 'Українською: Автор штучно змішує англійську й українську мови у реченнях
+    (напр. "a вибір букета на квітковому ринку", "використовуються for впізнавання")
+    та вдається до мета-розповідей про українські підручники.
+
+    English: The prose forces required contract terms into unnatural "code-switching"
+    sentences rather than correctly bolding them inline with English glosses.'
+  fix: Rewrite the explanations to be in natural English, using bolding for the Ukrainian
+    terms, and drop the meta-narration completely.
+- dimension: NATURALNESS
+  severity: critical
+  location: End of file
+  issue: 'Українською: Модуль містить згенерований ШІ звіт про виправлення помилок
+    у скриптах `contract_compliance.py`.
+
+    English: AI-generated boilerplate explaining bug fixes in Python scripts leaked
+    into the learning material.'
+  fix: Delete the bug report entirely.
+- dimension: PLAN_ADHERENCE
+  severity: major
+  location: End of module text (after Section 4)
+  issue: 'Українською: Модуль містить технічний звіт про помилки лінтера («Important:
+    The errors were false positives...») безпосередньо в тексті уроку.
+
+    English: The module includes a technical report about linter bugs and normalization
+    issues ("Root cause: The wiki_compressor._tokenize()...") inside the educational
+    content. This violates the "Banned Error Patterns: Meta-narration" rule.'
+  fix: 'Remove all text following the end of Section 4 (the part starting with "**Important:
+    The errors were false positives...**").'
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Відсутній обов''язковий термін «Діалог». Замість нього використано
+    англійське «Dialogue 1».
+
+    English: Missing required term "Діалог". The writer used the English heading "Dialogue
+    1" instead.'
+  fix: Replace "Dialogue 1" with "Діалог 1" and "Dialogue 2" with "Діалог 2".
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Невідповідність сценарію. План секції 1 вимагає «Опис кімнати»
+    (стіл, крісло), але текст описує «Вибір вбрання» (сукня, светр).
+
+    English: Scenario mismatch. Section 1 teaching beats required a room description
+    (table, chair), but the dialogue describes choosing clothes (dress, sweater).
+    Note: This matches the `dialogue_acts` specification in the contract, but creates
+    a discrepancy with the `teaching_beats`.'
+  fix: None required (prioritizing `dialogue_acts` adherence), but worth noting for
+    consistency.
+- dimension: HONESTY
+  severity: critical
+  location: Кольори
+  issue: 'Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через
+    жовтий і зелений — «жовтий м''яч» і «зелений листок».
+
+    English: The writer fabricated a specific textbook citation and examples. Grade
+    2 textbooks do not teach "тверда група" (this grammatical concept is taught in
+    later grades), and the specific examples "жовтий м''яч" and "зелений листок" as
+    illustrations of the hard group in Vashulenko Grade 2 are invented and unsupported
+    by the provided knowledge packet.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+- dimension: HONESTY
+  severity: major
+  location: Синій ≠ блакитний
+  issue: 'Українською: У підручниках блакитний і жовтий часто зустрічаються поряд
+    як приклади з підручників для тренування — наприклад, «блакитне небо» та «жовтий
+    соняшник» — саме для вправ на розрізнення кольорів.
+
+    English: The writer invented a claim about specific textbook exercises targeting
+    color differentiation between blue and yellow. The wiki excerpts do not support
+    this.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+fixes_applied:
+- dim: factual
+  count: 1
+  files:
+  - colors.md
+- dim: completeness
+  count: 1
+  files:
+  - colors.md
+- dim: actionable
+  count: 6
+  files:
+  - colors.md
+- dim: naturalness
+  count: 9
+  files:
+  - colors.md
+- dim: plan_adherence
+  count: 3
+  files:
+  - colors.md
+- dim: honesty
+  count: 2
+  files:
+  - colors.md
+passed: false

--- a/curriculum/l2-uk-en/a1/review/colors-review-aggregate.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-aggregate.yaml
@@ -1,0 +1,220 @@
+slug: colors
+round: 1
+review_mode: per-dimension-min
+verdict: REJECT
+verdict_score: 3.0
+overall_score: 3.0
+weighted_average: 7.4
+dim_scores:
+  factual: 8.0
+  language: 10.0
+  decolonization: 10.0
+  completeness: 9.0
+  actionable: 3.0
+  naturalness: 4.0
+  plan_adherence: 8.5
+  honesty: 4.0
+  dialogue: 10.0
+scores:
+- dimension: 1
+  key: factual
+  name: Factual
+  score: 8.0
+  evidence: '- Українською: "білии" (found inside the English bug report at the end
+    of the module) English: The module ends with a Python bug report explaining script
+    normalization ("білий" -> "білии") instead...'
+- dimension: 2
+  key: language
+  name: Language
+  score: 10.0
+  evidence: '- Українською: **«Якого вони кольору?»**, **«Червоні.»**, **«Синя.»**,
+    **«Сіре.»** English: Correct use of the "What color?" formula and precise gender/number
+    agreement in short answers. - Українсь...'
+- dimension: 3
+  key: decolonization
+  name: Decolonization
+  score: 10.0
+  evidence: '- Українською: В українській мові для позначення "blue" ми активно вчимо
+    пару окремих слів — these are two separate base colors, not two shades of one
+    word. English: Effectively contrasts Ukrainian...'
+- dimension: 4
+  key: completeness
+  name: Completeness
+  score: 9.0
+  evidence: '- Українською: Прапор України — синьо-жовтий (Кравцова, 2 клас, с. 22:
+    Синє — небо, жовте — жито). English: Contract explicitly requires citing Kravtsova''s
+    Grade 2 textbook for the blue-yellow flag...'
+- dimension: 5
+  key: actionable
+  name: Actionable
+  score: 3.0
+  evidence: '- Українською: "В українській мові для позначення "blue" ми активно вчимо
+    пару окремих слів..." English: The prose uses complex Ukrainian sentences for
+    meta-explanation, which an A1 learner cannot...'
+- dimension: 6
+  key: naturalness
+  name: Naturalness
+  score: 4.0
+  evidence: '- Українською: `Такі кольори, як білий і червоний, використовуються for
+    впізнавання (recognition) of everyday objects — the learner links word to thing
+    immediately. This echoes how Ukrainian textbo...'
+- dimension: 7
+  key: plan_adherence
+  name: Plan Adherence
+  score: 8.5
+  evidence: '- Українською: «Діалог 1 — Вибір букета на квітковому ринку (за мотивами
+    вірша про кольори з підручника Большакової для 2 класу, с. 38)» English: Section
+    1 correctly follows the pedagogy source and...'
+- dimension: 8
+  key: honesty
+  name: Honesty
+  score: 4.0
+  evidence: '- Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме
+    через жовтий і зелений — «жовтий м''яч» і «зелений листок». English: The writer
+    makes a highly specific, confident claim attri...'
+- dimension: 9
+  key: dialogue
+  name: Dialogue
+  score: 10.0
+  evidence: '- Українською: «— **Наталка:** Добрий день! *(Good day!)* / — **Продавець:**
+    Добрий день! Будь ласка, дивіться. *(Good day! Please, look around.)*» English:
+    Includes natural turn-taking and common...'
+findings:
+- dimension: FACTUAL
+  severity: major
+  location: End of the module (Підсумок)
+  issue: 'Українською: Текст містить технічний звіт про помилку в скрипті Python замість
+    навчального матеріалу.
+
+    English: The draft includes raw LLM meta-narration and a bug report about a Python
+    script at the end of the content. This is a fabrication of curriculum content
+    and violates the ban on meta-narration.'
+  fix: Remove the bug report section entirely.
+- dimension: COMPLETENESS
+  severity: minor
+  location: Section "Синій ≠ блакитний"
+  issue: 'Українською: Пропущено педагогічну опору з підручника Кравцової для 2 класу:
+    "Синє — небо, жовте — жито", що була чітко вказана в контракті.
+
+    English: The specific textbook citation (Kravtsova, Grade 2) and the corresponding
+    quote for the flag colors are missing.'
+  fix: Add the Kravtsova textbook reference and quote to the explanation of the Ukrainian
+    flag colors.
+- dimension: ACTIONABLE
+  severity: critical
+  location: Throughout the module (e.g., "Діалоги", "Кольори", "Синій ≠ блакитний",
+    and the end of the module)
+  issue: 'Українською: Автор скопіював інструкції з промпту (wiki excerpts та teaching
+    beats) безпосередньо в текст для студента, створивши складні україномовні речення
+    та суржик (напр., "This модуль taught узгодження кольорів using the adjective
+    правилами"). Крім того, в кінці модуля додано мета-коментар про баг у Python-скрипті.
+
+    English: The writer copy-pasted teaching beats and wiki excerpts directly into
+    the learner-facing text. This results in complex B2-level Ukrainian prose and
+    bizarre Surzhyk in an A1 module, violating the structural rule that explanations
+    must be in English. Additionally, the AI included meta-narration about a Python
+    bug at the end of the module.'
+  fix: Translate all pedagogical rationale into clear English prose, ensure Ukrainian
+    words are only used as bolded inline examples, and completely remove the meta-narration
+    about the Python bug.
+- dimension: NATURALNESS
+  severity: critical
+  location: Section "Діалоги" and throughout the module
+  issue: 'Українською: Автор штучно змішує англійську й українську мови у реченнях
+    (напр. "a вибір букета на квітковому ринку", "використовуються for впізнавання")
+    та вдається до мета-розповідей про українські підручники.
+
+    English: The prose forces required contract terms into unnatural "code-switching"
+    sentences rather than correctly bolding them inline with English glosses.'
+  fix: Rewrite the explanations to be in natural English, using bolding for the Ukrainian
+    terms, and drop the meta-narration completely.
+- dimension: NATURALNESS
+  severity: critical
+  location: End of file
+  issue: 'Українською: Модуль містить згенерований ШІ звіт про виправлення помилок
+    у скриптах `contract_compliance.py`.
+
+    English: AI-generated boilerplate explaining bug fixes in Python scripts leaked
+    into the learning material.'
+  fix: Delete the bug report entirely.
+- dimension: PLAN_ADHERENCE
+  severity: major
+  location: End of module text (after Section 4)
+  issue: 'Українською: Модуль містить технічний звіт про помилки лінтера («Important:
+    The errors were false positives...») безпосередньо в тексті уроку.
+
+    English: The module includes a technical report about linter bugs and normalization
+    issues ("Root cause: The wiki_compressor._tokenize()...") inside the educational
+    content. This violates the "Banned Error Patterns: Meta-narration" rule.'
+  fix: 'Remove all text following the end of Section 4 (the part starting with "**Important:
+    The errors were false positives...**").'
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Відсутній обов''язковий термін «Діалог». Замість нього використано
+    англійське «Dialogue 1».
+
+    English: Missing required term "Діалог". The writer used the English heading "Dialogue
+    1" instead.'
+  fix: Replace "Dialogue 1" with "Діалог 1" and "Dialogue 2" with "Діалог 2".
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Невідповідність сценарію. План секції 1 вимагає «Опис кімнати»
+    (стіл, крісло), але текст описує «Вибір вбрання» (сукня, светр).
+
+    English: Scenario mismatch. Section 1 teaching beats required a room description
+    (table, chair), but the dialogue describes choosing clothes (dress, sweater).
+    Note: This matches the `dialogue_acts` specification in the contract, but creates
+    a discrepancy with the `teaching_beats`.'
+  fix: None required (prioritizing `dialogue_acts` adherence), but worth noting for
+    consistency.
+- dimension: HONESTY
+  severity: critical
+  location: Кольори
+  issue: 'Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через
+    жовтий і зелений — «жовтий м''яч» і «зелений листок».
+
+    English: The writer fabricated a specific textbook citation and examples. Grade
+    2 textbooks do not teach "тверда група" (this grammatical concept is taught in
+    later grades), and the specific examples "жовтий м''яч" and "зелений листок" as
+    illustrations of the hard group in Vashulenko Grade 2 are invented and unsupported
+    by the provided knowledge packet.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+- dimension: HONESTY
+  severity: major
+  location: Синій ≠ блакитний
+  issue: 'Українською: У підручниках блакитний і жовтий часто зустрічаються поряд
+    як приклади з підручників для тренування — наприклад, «блакитне небо» та «жовтий
+    соняшник» — саме для вправ на розрізнення кольорів.
+
+    English: The writer invented a claim about specific textbook exercises targeting
+    color differentiation between blue and yellow. The wiki excerpts do not support
+    this.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+fixes_applied:
+- dim: factual
+  count: 1
+  files:
+  - colors.md
+- dim: completeness
+  count: 1
+  files:
+  - colors.md
+- dim: actionable
+  count: 6
+  files:
+  - colors.md
+- dim: naturalness
+  count: 9
+  files:
+  - colors.md
+- dim: plan_adherence
+  count: 3
+  files:
+  - colors.md
+- dim: honesty
+  count: 2
+  files:
+  - colors.md
+passed: false

--- a/curriculum/l2-uk-en/a1/review/colors-review-completeness-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-completeness-r1.yaml
@@ -1,0 +1,51 @@
+slug: colors
+round: 1
+dimension: completeness
+name: Completeness
+score: 9.0
+verdict: REVISE
+evidence: '- Українською: Прапор України — синьо-жовтий (Кравцова, 2 клас, с. 22:
+  Синє — небо, жовте — жито). English: Contract explicitly requires citing Kravtsova''s
+  Grade 2 textbook for the blue-yellow flag...'
+findings:
+- dimension: COMPLETENESS
+  severity: minor
+  location: Section "Синій ≠ блакитний"
+  issue: 'Українською: Пропущено педагогічну опору з підручника Кравцової для 2 класу:
+    "Синє — небо, жовте — жито", що була чітко вказана в контракті.
+
+    English: The specific textbook citation (Kravtsova, Grade 2) and the corresponding
+    quote for the flag colors are missing.'
+  fix: Add the Kravtsova textbook reference and quote to the explanation of the Ukrainian
+    flag colors.
+fixes:
+- insert_after: 'A stable reference pair to memorize: the Ukrainian flag is «синьо-жовтий»
+    — the dark stripe on top is «синій», the bright stripe below is «жовтий», and
+    a clear noon sky is «блакитне».'
+  text: ' As noted in textbook materials (Кравцова, Grade 2, p. 22), the flag represents
+    the landscape: **«Синє — небо, жовте — жито»** (*Blue is the sky, yellow is the
+    wheat*).'
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: completeness\nname: Completeness\nscore:\
+  \ 9.0/10\nverdict: REVISE\n\n## Evidence\n- Українською: Прапор України — синьо-жовтий\
+  \ (Кравцова, 2 клас, с. 22: Синє — небо, жовте — жито).\n  English: Contract explicitly\
+  \ requires citing Kravtsova's Grade 2 textbook for the blue-yellow flag metaphor.\n\
+  - Українською: A stable reference pair to memorize: the Ukrainian flag is «синьо-жовтий»\
+  \ — the dark stripe on top is «синій», the bright stripe below is «жовтий», and\
+  \ a clear noon sky is «блакитне».\n  English: The generated text mentions the flag\
+  \ but omits the specific textbook citation and the poetic metaphor \"Синє — небо,\
+  \ жовте — жито\".\n\n## Findings\n[COMPLETENESS] [SEVERITY: minor]\nLocation: Section\
+  \ \"Синій ≠ блакитний\"\nIssue: Українською: Пропущено педагогічну опору з підручника\
+  \ Кравцової для 2 класу: \"Синє — небо, жовте — жито\", що була чітко вказана в\
+  \ контракті.\nEnglish: The specific textbook citation (Kravtsova, Grade 2) and the\
+  \ corresponding quote for the flag colors are missing.\nFix: Add the Kravtsova textbook\
+  \ reference and quote to the explanation of the Ukrainian flag colors.\n\n## Verdict\
+  \ Reason\nThe module is nearly perfectly complete, fulfilling all complex dialogue\
+  \ requirements, group sorting, and nuance distinctions. However, it missed one specific\
+  \ textbook citation (\"Кравцова, 2 клас, с. 22: Синє — небо, жовте — жито\") required\
+  \ by the section 3 teaching beat.\n\n<fixes>\n- insert_after: \"A stable reference\
+  \ pair to memorize: the Ukrainian flag is «синьо-жовтий» — the dark stripe on top\
+  \ is «синій», the bright stripe below is «жовтий», and a clear noon sky is «блакитне».\"\
+  \n  text: \" As noted in textbook materials (Кравцова, Grade 2, p. 22), the flag\
+  \ represents the landscape: **«Синє — небо, жовте — жито»** (*Blue is the sky, yellow\
+  \ is the wheat*).\"\n</fixes>\n```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-completeness.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-completeness.yaml
@@ -1,0 +1,51 @@
+slug: colors
+round: 1
+dimension: completeness
+name: Completeness
+score: 9.0
+verdict: REVISE
+evidence: '- Українською: Прапор України — синьо-жовтий (Кравцова, 2 клас, с. 22:
+  Синє — небо, жовте — жито). English: Contract explicitly requires citing Kravtsova''s
+  Grade 2 textbook for the blue-yellow flag...'
+findings:
+- dimension: COMPLETENESS
+  severity: minor
+  location: Section "Синій ≠ блакитний"
+  issue: 'Українською: Пропущено педагогічну опору з підручника Кравцової для 2 класу:
+    "Синє — небо, жовте — жито", що була чітко вказана в контракті.
+
+    English: The specific textbook citation (Kravtsova, Grade 2) and the corresponding
+    quote for the flag colors are missing.'
+  fix: Add the Kravtsova textbook reference and quote to the explanation of the Ukrainian
+    flag colors.
+fixes:
+- insert_after: 'A stable reference pair to memorize: the Ukrainian flag is «синьо-жовтий»
+    — the dark stripe on top is «синій», the bright stripe below is «жовтий», and
+    a clear noon sky is «блакитне».'
+  text: ' As noted in textbook materials (Кравцова, Grade 2, p. 22), the flag represents
+    the landscape: **«Синє — небо, жовте — жито»** (*Blue is the sky, yellow is the
+    wheat*).'
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: completeness\nname: Completeness\nscore:\
+  \ 9.0/10\nverdict: REVISE\n\n## Evidence\n- Українською: Прапор України — синьо-жовтий\
+  \ (Кравцова, 2 клас, с. 22: Синє — небо, жовте — жито).\n  English: Contract explicitly\
+  \ requires citing Kravtsova's Grade 2 textbook for the blue-yellow flag metaphor.\n\
+  - Українською: A stable reference pair to memorize: the Ukrainian flag is «синьо-жовтий»\
+  \ — the dark stripe on top is «синій», the bright stripe below is «жовтий», and\
+  \ a clear noon sky is «блакитне».\n  English: The generated text mentions the flag\
+  \ but omits the specific textbook citation and the poetic metaphor \"Синє — небо,\
+  \ жовте — жито\".\n\n## Findings\n[COMPLETENESS] [SEVERITY: minor]\nLocation: Section\
+  \ \"Синій ≠ блакитний\"\nIssue: Українською: Пропущено педагогічну опору з підручника\
+  \ Кравцової для 2 класу: \"Синє — небо, жовте — жито\", що була чітко вказана в\
+  \ контракті.\nEnglish: The specific textbook citation (Kravtsova, Grade 2) and the\
+  \ corresponding quote for the flag colors are missing.\nFix: Add the Kravtsova textbook\
+  \ reference and quote to the explanation of the Ukrainian flag colors.\n\n## Verdict\
+  \ Reason\nThe module is nearly perfectly complete, fulfilling all complex dialogue\
+  \ requirements, group sorting, and nuance distinctions. However, it missed one specific\
+  \ textbook citation (\"Кравцова, 2 клас, с. 22: Синє — небо, жовте — жито\") required\
+  \ by the section 3 teaching beat.\n\n<fixes>\n- insert_after: \"A stable reference\
+  \ pair to memorize: the Ukrainian flag is «синьо-жовтий» — the dark stripe on top\
+  \ is «синій», the bright stripe below is «жовтий», and a clear noon sky is «блакитне».\"\
+  \n  text: \" As noted in textbook materials (Кравцова, Grade 2, p. 22), the flag\
+  \ represents the landscape: **«Синє — небо, жовте — жито»** (*Blue is the sky, yellow\
+  \ is the wheat*).\"\n</fixes>\n```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-decolonization-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-decolonization-r1.yaml
@@ -1,0 +1,30 @@
+slug: colors
+round: 1
+dimension: decolonization
+name: Decolonization
+score: 10.0
+verdict: PASS
+evidence: '- Українською: В українській мові для позначення "blue" ми активно вчимо
+  пару окремих слів — these are two separate base colors, not two shades of one word.
+  English: Effectively contrasts Ukrainian...'
+findings: []
+fixes: []
+rewrite_blocks: []
+review_text: "## Dimension\nid: decolonization\nname: Decolonization\nscore: 10.0/10\n\
+  verdict: PASS\n\n## Evidence\n- Українською: В українській мові для позначення \"\
+  blue\" ми активно вчимо пару окремих слів — these are two separate base colors,\
+  \ not two shades of one word.\n  English: Effectively contrasts Ukrainian directly\
+  \ with English (\"blue\") instead of mediating through Russian, establishing Ukrainian\
+  \ on its own terms.\n- Українською: Ukrainian does not transfer standard color adjectives\
+  \ onto people's features the way English does. You say «карі очі» (brown eyes),\
+  \ not *«коричневі очі»\n  English: Provides authentic Ukrainian collocations by\
+  \ contrasting them with English L1 transfer errors, without using Russian equivalents.\n\
+  - Українською: The Ukrainian flag is «синьо-жовтий» — the dark stripe on top is\
+  \ «синій», the bright stripe below is «жовтий», and a clear noon sky is «блакитне».\n\
+  \  English: Uses a culturally resonant, sovereign anchor (the Ukrainian flag) to\
+  \ teach the distinction between синій and блакитний.\n\n## Findings\nNone.\n\n##\
+  \ Verdict Reason\nThe module perfectly executes a decolonized, Ukrainian-first framing.\
+  \ It teaches the distinction between «синій» and «блакитний», as well as appearance\
+  \ collocations («карі очі», «русяве волосся»), by directly contrasting them with\
+  \ the learner's L1 (English) and using Ukrainian cultural anchors (the flag, authentic\
+  \ school textbooks), completely avoiding any Russian-mediated explanations."

--- a/curriculum/l2-uk-en/a1/review/colors-review-decolonization.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-decolonization.yaml
@@ -1,0 +1,30 @@
+slug: colors
+round: 1
+dimension: decolonization
+name: Decolonization
+score: 10.0
+verdict: PASS
+evidence: '- Українською: В українській мові для позначення "blue" ми активно вчимо
+  пару окремих слів — these are two separate base colors, not two shades of one word.
+  English: Effectively contrasts Ukrainian...'
+findings: []
+fixes: []
+rewrite_blocks: []
+review_text: "## Dimension\nid: decolonization\nname: Decolonization\nscore: 10.0/10\n\
+  verdict: PASS\n\n## Evidence\n- Українською: В українській мові для позначення \"\
+  blue\" ми активно вчимо пару окремих слів — these are two separate base colors,\
+  \ not two shades of one word.\n  English: Effectively contrasts Ukrainian directly\
+  \ with English (\"blue\") instead of mediating through Russian, establishing Ukrainian\
+  \ on its own terms.\n- Українською: Ukrainian does not transfer standard color adjectives\
+  \ onto people's features the way English does. You say «карі очі» (brown eyes),\
+  \ not *«коричневі очі»\n  English: Provides authentic Ukrainian collocations by\
+  \ contrasting them with English L1 transfer errors, without using Russian equivalents.\n\
+  - Українською: The Ukrainian flag is «синьо-жовтий» — the dark stripe on top is\
+  \ «синій», the bright stripe below is «жовтий», and a clear noon sky is «блакитне».\n\
+  \  English: Uses a culturally resonant, sovereign anchor (the Ukrainian flag) to\
+  \ teach the distinction between синій and блакитний.\n\n## Findings\nNone.\n\n##\
+  \ Verdict Reason\nThe module perfectly executes a decolonized, Ukrainian-first framing.\
+  \ It teaches the distinction between «синій» and «блакитний», as well as appearance\
+  \ collocations («карі очі», «русяве волосся»), by directly contrasting them with\
+  \ the learner's L1 (English) and using Ukrainian cultural anchors (the flag, authentic\
+  \ school textbooks), completely avoiding any Russian-mediated explanations."

--- a/curriculum/l2-uk-en/a1/review/colors-review-dialogue-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-dialogue-r1.yaml
@@ -1,0 +1,27 @@
+slug: colors
+round: 1
+dimension: dialogue
+name: Dialogue
+score: 10.0
+verdict: PASS
+evidence: '- Українською: «— **Наталка:** Добрий день! *(Good day!)* / — **Продавець:**
+  Добрий день! Будь ласка, дивіться. *(Good day! Please, look around.)*» English:
+  Includes natural turn-taking and common...'
+findings: []
+fixes: []
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: dialogue\nname: Dialogue\nscore: 10.0/10\n\
+  verdict: PASS\n\n## Evidence\n- Українською: «— **Наталка:** Добрий день! *(Good\
+  \ day!)* / — **Продавець:** Добрий день! Будь ласка, дивіться. *(Good day! Please,\
+  \ look around.)*»\n  English: Includes natural turn-taking and common conversational\
+  \ phrasing.\n- Українською: «— **Ліза:** Подивися в шафу. Ось чорна сукня. / — **Дмитро:**\
+  \ Гарна! А якого кольору цей светр?»\n  English: Transitions the drill-like color\
+  \ questions into a functional, situational scenario matching the contract's required\
+  \ settings.\n- Українською: «— **Ліза:** У неї карі очі й русяве волосся.»\n  English:\
+  \ Perfectly integrates the required fixed collocations for physical descriptions\
+  \ into the dialogue flow.\n\n## Findings\nNone.\n\n## Verdict Reason\nThe dialogues\
+  \ excellently fulfill the module contract. They feature named speakers, integrate\
+  \ required grammatical functions (`Якого кольору?`, noun-adjective gender agreement,\
+  \ appearance collocations), and incorporate authentic turn-taking phrases (Добрий\
+  \ день, будь ласка, дякую, гарного дня) without degrading into a sterile drill format.\n\
+  ```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-dialogue.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-dialogue.yaml
@@ -1,0 +1,27 @@
+slug: colors
+round: 1
+dimension: dialogue
+name: Dialogue
+score: 10.0
+verdict: PASS
+evidence: '- Українською: «— **Наталка:** Добрий день! *(Good day!)* / — **Продавець:**
+  Добрий день! Будь ласка, дивіться. *(Good day! Please, look around.)*» English:
+  Includes natural turn-taking and common...'
+findings: []
+fixes: []
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: dialogue\nname: Dialogue\nscore: 10.0/10\n\
+  verdict: PASS\n\n## Evidence\n- Українською: «— **Наталка:** Добрий день! *(Good\
+  \ day!)* / — **Продавець:** Добрий день! Будь ласка, дивіться. *(Good day! Please,\
+  \ look around.)*»\n  English: Includes natural turn-taking and common conversational\
+  \ phrasing.\n- Українською: «— **Ліза:** Подивися в шафу. Ось чорна сукня. / — **Дмитро:**\
+  \ Гарна! А якого кольору цей светр?»\n  English: Transitions the drill-like color\
+  \ questions into a functional, situational scenario matching the contract's required\
+  \ settings.\n- Українською: «— **Ліза:** У неї карі очі й русяве волосся.»\n  English:\
+  \ Perfectly integrates the required fixed collocations for physical descriptions\
+  \ into the dialogue flow.\n\n## Findings\nNone.\n\n## Verdict Reason\nThe dialogues\
+  \ excellently fulfill the module contract. They feature named speakers, integrate\
+  \ required grammatical functions (`Якого кольору?`, noun-adjective gender agreement,\
+  \ appearance collocations), and incorporate authentic turn-taking phrases (Добрий\
+  \ день, будь ласка, дякую, гарного дня) without degrading into a sterile drill format.\n\
+  ```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-factual-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-factual-r1.yaml
@@ -1,0 +1,92 @@
+slug: colors
+round: 1
+dimension: factual
+name: Factual
+score: 8.0
+verdict: REVISE
+evidence: '- Українською: "білии" (found inside the English bug report at the end
+  of the module) English: The module ends with a Python bug report explaining script
+  normalization ("білий" -> "білии") instead...'
+findings:
+- dimension: FACTUAL
+  severity: major
+  location: End of the module (Підсумок)
+  issue: 'Українською: Текст містить технічний звіт про помилку в скрипті Python замість
+    навчального матеріалу.
+
+    English: The draft includes raw LLM meta-narration and a bug report about a Python
+    script at the end of the content. This is a fabrication of curriculum content
+    and violates the ban on meta-narration.'
+  fix: Remove the bug report section entirely.
+fixes:
+- find: 'You can now ask «Якого кольору?» about any object, give a gender-matched
+    answer, choose «синій» or «блакитний» with confidence, and use the appearance
+    collocations as ready-made chunks.
+
+
+    ---
+
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:**
+
+    - Added `_strip_combining()` helper that applies the same NFKD + strip-combining
+    normalization
+
+    - Updated `_missing_terms()` to normalize both the text and the terms before matching
+
+    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit
+    function and end-to-end integration
+
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: You can now ask «Якого кольору?» about any object, give a gender-matched
+    answer, choose «синій» or «блакитний» with confidence, and use the appearance
+    collocations as ready-made chunks.
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: factual\nname: Factual\nscore: 8.0/10\n\
+  verdict: REVISE\n\n## Evidence\n- Українською: \"білии\" (found inside the English\
+  \ bug report at the end of the module)\n  English: The module ends with a Python\
+  \ bug report explaining script normalization (\"білий\" -> \"білии\") instead of\
+  \ curriculum content.\n\n## Findings\n[FACTUAL] [SEVERITY: major]\nLocation: End\
+  \ of the module (Підсумок)\nIssue: Українською: Текст містить технічний звіт про\
+  \ помилку в скрипті Python замість навчального матеріалу.\nEnglish: The draft includes\
+  \ raw LLM meta-narration and a bug report about a Python script at the end of the\
+  \ content. This is a fabrication of curriculum content and violates the ban on meta-narration.\n\
+  Fix: Remove the bug report section entirely.\n\n## Verdict Reason\nThe linguistic\
+  \ facts about colors, hard/soft groups, and collocations are completely accurate\
+  \ and align well with the contract. However, the inclusion of an LLM bug report\
+  \ about a Python script at the end of the module is a major factual fabrication\
+  \ of curriculum content that must be removed.\n\n<fixes>\n- find: \"You can now\
+  \ ask «Якого кольору?» about any object, give a gender-matched answer, choose «синій»\
+  \ or «блакитний» with confidence, and use the appearance collocations as ready-made\
+  \ chunks.\\n\\n---\\n\\n**Important: The errors were false positives from a bug\
+  \ in `scripts/audit/checks/contract_compliance.py`, not problems with the draft.**\
+  \ The draft is unchanged because the content was already correct.\\n\\n**Root cause:**\
+  \ The `wiki_compressor._tokenize()` function applies NFKD normalization + combining-mark\
+  \ stripping, which converts Ukrainian \\\"й\\\" (U+0439 = и + combining breve) →\
+  \ \\\"и\\\" (U+0438). So \\\"білий\\\" becomes \\\"білии\\\" in the anchor terms.\
+  \ But `_missing_terms()` in the compliance checker did raw substring matching without\
+  \ the same normalization — it looked for \\\"білии\\\" in text containing \\\"білий\\\
+  \" and never found it.\\n\\n**Fix applied to `scripts/audit/checks/contract_compliance.py`:**\\\
+  n- Added `_strip_combining()` helper that applies the same NFKD + strip-combining\
+  \ normalization\\n- Updated `_missing_terms()` to normalize both the text and the\
+  \ terms before matching\\n- Added 2 tests to `tests/test_contract_compliance.py`\
+  \ covering both the unit function and end-to-end integration\\n\\nThis was a systemic\
+  \ bug — every Ukrainian word ending in \\\"й\\\" would fail as a factual anchor\
+  \ term. The fix resolves this for all modules, not just colors.\"\n  replace: \"\
+  You can now ask «Якого кольору?» about any object, give a gender-matched answer,\
+  \ choose «синій» or «блакитний» with confidence, and use the appearance collocations\
+  \ as ready-made chunks.\"\n</fixes>\n```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-factual.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-factual.yaml
@@ -1,0 +1,92 @@
+slug: colors
+round: 1
+dimension: factual
+name: Factual
+score: 8.0
+verdict: REVISE
+evidence: '- Українською: "білии" (found inside the English bug report at the end
+  of the module) English: The module ends with a Python bug report explaining script
+  normalization ("білий" -> "білии") instead...'
+findings:
+- dimension: FACTUAL
+  severity: major
+  location: End of the module (Підсумок)
+  issue: 'Українською: Текст містить технічний звіт про помилку в скрипті Python замість
+    навчального матеріалу.
+
+    English: The draft includes raw LLM meta-narration and a bug report about a Python
+    script at the end of the content. This is a fabrication of curriculum content
+    and violates the ban on meta-narration.'
+  fix: Remove the bug report section entirely.
+fixes:
+- find: 'You can now ask «Якого кольору?» about any object, give a gender-matched
+    answer, choose «синій» or «блакитний» with confidence, and use the appearance
+    collocations as ready-made chunks.
+
+
+    ---
+
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:**
+
+    - Added `_strip_combining()` helper that applies the same NFKD + strip-combining
+    normalization
+
+    - Updated `_missing_terms()` to normalize both the text and the terms before matching
+
+    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit
+    function and end-to-end integration
+
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: You can now ask «Якого кольору?» about any object, give a gender-matched
+    answer, choose «синій» or «блакитний» with confidence, and use the appearance
+    collocations as ready-made chunks.
+rewrite_blocks: []
+review_text: "```markdown\n## Dimension\nid: factual\nname: Factual\nscore: 8.0/10\n\
+  verdict: REVISE\n\n## Evidence\n- Українською: \"білии\" (found inside the English\
+  \ bug report at the end of the module)\n  English: The module ends with a Python\
+  \ bug report explaining script normalization (\"білий\" -> \"білии\") instead of\
+  \ curriculum content.\n\n## Findings\n[FACTUAL] [SEVERITY: major]\nLocation: End\
+  \ of the module (Підсумок)\nIssue: Українською: Текст містить технічний звіт про\
+  \ помилку в скрипті Python замість навчального матеріалу.\nEnglish: The draft includes\
+  \ raw LLM meta-narration and a bug report about a Python script at the end of the\
+  \ content. This is a fabrication of curriculum content and violates the ban on meta-narration.\n\
+  Fix: Remove the bug report section entirely.\n\n## Verdict Reason\nThe linguistic\
+  \ facts about colors, hard/soft groups, and collocations are completely accurate\
+  \ and align well with the contract. However, the inclusion of an LLM bug report\
+  \ about a Python script at the end of the module is a major factual fabrication\
+  \ of curriculum content that must be removed.\n\n<fixes>\n- find: \"You can now\
+  \ ask «Якого кольору?» about any object, give a gender-matched answer, choose «синій»\
+  \ or «блакитний» with confidence, and use the appearance collocations as ready-made\
+  \ chunks.\\n\\n---\\n\\n**Important: The errors were false positives from a bug\
+  \ in `scripts/audit/checks/contract_compliance.py`, not problems with the draft.**\
+  \ The draft is unchanged because the content was already correct.\\n\\n**Root cause:**\
+  \ The `wiki_compressor._tokenize()` function applies NFKD normalization + combining-mark\
+  \ stripping, which converts Ukrainian \\\"й\\\" (U+0439 = и + combining breve) →\
+  \ \\\"и\\\" (U+0438). So \\\"білий\\\" becomes \\\"білии\\\" in the anchor terms.\
+  \ But `_missing_terms()` in the compliance checker did raw substring matching without\
+  \ the same normalization — it looked for \\\"білии\\\" in text containing \\\"білий\\\
+  \" and never found it.\\n\\n**Fix applied to `scripts/audit/checks/contract_compliance.py`:**\\\
+  n- Added `_strip_combining()` helper that applies the same NFKD + strip-combining\
+  \ normalization\\n- Updated `_missing_terms()` to normalize both the text and the\
+  \ terms before matching\\n- Added 2 tests to `tests/test_contract_compliance.py`\
+  \ covering both the unit function and end-to-end integration\\n\\nThis was a systemic\
+  \ bug — every Ukrainian word ending in \\\"й\\\" would fail as a factual anchor\
+  \ term. The fix resolves this for all modules, not just colors.\"\n  replace: \"\
+  You can now ask «Якого кольору?» about any object, give a gender-matched answer,\
+  \ choose «синій» or «блакитний» with confidence, and use the appearance collocations\
+  \ as ready-made chunks.\"\n</fixes>\n```"

--- a/curriculum/l2-uk-en/a1/review/colors-review-honesty-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-honesty-r1.yaml
@@ -1,0 +1,92 @@
+slug: colors
+round: 1
+dimension: honesty
+name: Honesty
+score: 4.0
+verdict: REJECT
+evidence: '- Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме
+  через жовтий і зелений — «жовтий м''яч» і «зелений листок». English: The writer
+  makes a highly specific, confident claim attri...'
+findings:
+- dimension: HONESTY
+  severity: critical
+  location: Кольори
+  issue: 'Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через
+    жовтий і зелений — «жовтий м''яч» і «зелений листок».
+
+    English: The writer fabricated a specific textbook citation and examples. Grade
+    2 textbooks do not teach "тверда група" (this grammatical concept is taught in
+    later grades), and the specific examples "жовтий м''яч" and "зелений листок" as
+    illustrations of the hard group in Vashulenko Grade 2 are invented and unsupported
+    by the provided knowledge packet.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+- dimension: HONESTY
+  severity: major
+  location: Синій ≠ блакитний
+  issue: 'Українською: У підручниках блакитний і жовтий часто зустрічаються поряд
+    як приклади з підручників для тренування — наприклад, «блакитне небо» та «жовтий
+    соняшник» — саме для вправ на розрізнення кольорів.
+
+    English: The writer invented a claim about specific textbook exercises targeting
+    color differentiation between blue and yellow. The wiki excerpts do not support
+    this.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+fixes:
+- find: У підручниках «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші
+    приклади з підручників для тренування цих форм. Наприклад, Вашуленко (Клас 2)
+    ілюструє тверду групу саме через жовтий і зелений — «жовтий м'яч» і «зелений листок».
+  replace: 'У підручниках «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші
+    приклади з підручників для тренування цих форм. Наприклад, Вашуленко (Клас 2)
+    ілюструє тверду групу саме через жовтий і зелений — «жовтий м''яч» і «зелений
+    листок». <!-- VERIFY: Чи дійсно Вашуленко (Клас 2) ілюструє тверду групу саме
+    через ці приклади? -->'
+- find: У підручниках блакитний і жовтий часто зустрічаються поряд як приклади з підручників
+    для тренування — наприклад, «блакитне небо» та «жовтий соняшник» — саме для вправ
+    на розрізнення кольорів.
+  replace: 'У підручниках блакитний і жовтий часто зустрічаються поряд як приклади
+    з підручників для тренування — наприклад, «блакитне небо» та «жовтий соняшник»
+    — саме для вправ на розрізнення кольорів. <!-- VERIFY: Чи є це цілеспрямованими
+    вправами на розрізнення кольорів? -->'
+rewrite_blocks: []
+review_text: "## Dimension\nid: honesty\nname: Honesty\nscore: 4.0/10\nverdict: REJECT\n\
+  \n## Evidence\n- Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу\
+  \ саме через жовтий і зелений — «жовтий м'яч» і «зелений листок».\n  English: The\
+  \ writer makes a highly specific, confident claim attributing the teaching of \"\
+  hard group\" adjectives with exact examples to a Grade 2 textbook, which is a fabrication\
+  \ not supported by the plan or excerpts.\n- Українською: У підручниках блакитний\
+  \ і жовтий часто зустрічаються поряд як приклади з підручників для тренування —\
+  \ наприклад, «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення\
+  \ кольорів.\n  English: The writer fabricates a pedagogical claim about specific\
+  \ exercises in textbooks targeting the differentiation between blue and yellow.\n\
+  \n## Findings\n[HONESTY] [SEVERITY: critical]\nLocation: Кольори\nIssue: Українською:\
+  \ Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і зелений\
+  \ — «жовтий м'яч» і «зелений листок».\nEnglish: The writer fabricated a specific\
+  \ textbook citation and examples. Grade 2 textbooks do not teach \"тверда група\"\
+  \ (this grammatical concept is taught in later grades), and the specific examples\
+  \ \"жовтий м'яч\" and \"зелений листок\" as illustrations of the hard group in Vashulenko\
+  \ Grade 2 are invented and unsupported by the provided knowledge packet.\nFix: Add\
+  \ a VERIFY marker to flag the unsupported claim.\n\n[HONESTY] [SEVERITY: major]\n\
+  Location: Синій ≠ блакитний\nIssue: Українською: У підручниках блакитний і жовтий\
+  \ часто зустрічаються поряд як приклади з підручників для тренування — наприклад,\
+  \ «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.\n\
+  English: The writer invented a claim about specific textbook exercises targeting\
+  \ color differentiation between blue and yellow. The wiki excerpts do not support\
+  \ this.\nFix: Add a VERIFY marker to flag the unsupported claim.\n\n## Verdict Reason\n\
+  The module contains invented, highly specific factual claims about textbook contents\
+  \ and exercises (such as attributing the grammatical concept of \"тверда група\"\
+  \ and specific examples to a Grade 2 textbook) without using `<!-- VERIFY -->` markers.\
+  \ According to the rubric, unsupported factual certainty without `<!-- VERIFY -->`\
+  \ results in a REJECT with a maximum score of 5.0.\n\n<fixes>\n- find: \"У підручниках\
+  \ «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші приклади з підручників\
+  \ для тренування цих форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме\
+  \ через жовтий і зелений — «жовтий м'яч» і «зелений листок».\"\n  replace: \"У підручниках\
+  \ «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші приклади з підручників\
+  \ для тренування цих форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме\
+  \ через жовтий і зелений — «жовтий м'яч» і «зелений листок». <!-- VERIFY: Чи дійсно\
+  \ Вашуленко (Клас 2) ілюструє тверду групу саме через ці приклади? -->\"\n- find:\
+  \ \"У підручниках блакитний і жовтий часто зустрічаються поряд як приклади з підручників\
+  \ для тренування — наприклад, «блакитне небо» та «жовтий соняшник» — саме для вправ\
+  \ на розрізнення кольорів.\"\n  replace: \"У підручниках блакитний і жовтий часто\
+  \ зустрічаються поряд як приклади з підручників для тренування — наприклад, «блакитне\
+  \ небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів. <!-- VERIFY:\
+  \ Чи є це цілеспрямованими вправами на розрізнення кольорів? -->\"\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-honesty.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-honesty.yaml
@@ -1,0 +1,92 @@
+slug: colors
+round: 1
+dimension: honesty
+name: Honesty
+score: 4.0
+verdict: REJECT
+evidence: '- Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме
+  через жовтий і зелений — «жовтий м''яч» і «зелений листок». English: The writer
+  makes a highly specific, confident claim attri...'
+findings:
+- dimension: HONESTY
+  severity: critical
+  location: Кольори
+  issue: 'Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через
+    жовтий і зелений — «жовтий м''яч» і «зелений листок».
+
+    English: The writer fabricated a specific textbook citation and examples. Grade
+    2 textbooks do not teach "тверда група" (this grammatical concept is taught in
+    later grades), and the specific examples "жовтий м''яч" and "зелений листок" as
+    illustrations of the hard group in Vashulenko Grade 2 are invented and unsupported
+    by the provided knowledge packet.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+- dimension: HONESTY
+  severity: major
+  location: Синій ≠ блакитний
+  issue: 'Українською: У підручниках блакитний і жовтий часто зустрічаються поряд
+    як приклади з підручників для тренування — наприклад, «блакитне небо» та «жовтий
+    соняшник» — саме для вправ на розрізнення кольорів.
+
+    English: The writer invented a claim about specific textbook exercises targeting
+    color differentiation between blue and yellow. The wiki excerpts do not support
+    this.'
+  fix: Add a VERIFY marker to flag the unsupported claim.
+fixes:
+- find: У підручниках «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші
+    приклади з підручників для тренування цих форм. Наприклад, Вашуленко (Клас 2)
+    ілюструє тверду групу саме через жовтий і зелений — «жовтий м'яч» і «зелений листок».
+  replace: 'У підручниках «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші
+    приклади з підручників для тренування цих форм. Наприклад, Вашуленко (Клас 2)
+    ілюструє тверду групу саме через жовтий і зелений — «жовтий м''яч» і «зелений
+    листок». <!-- VERIFY: Чи дійсно Вашуленко (Клас 2) ілюструє тверду групу саме
+    через ці приклади? -->'
+- find: У підручниках блакитний і жовтий часто зустрічаються поряд як приклади з підручників
+    для тренування — наприклад, «блакитне небо» та «жовтий соняшник» — саме для вправ
+    на розрізнення кольорів.
+  replace: 'У підручниках блакитний і жовтий часто зустрічаються поряд як приклади
+    з підручників для тренування — наприклад, «блакитне небо» та «жовтий соняшник»
+    — саме для вправ на розрізнення кольорів. <!-- VERIFY: Чи є це цілеспрямованими
+    вправами на розрізнення кольорів? -->'
+rewrite_blocks: []
+review_text: "## Dimension\nid: honesty\nname: Honesty\nscore: 4.0/10\nverdict: REJECT\n\
+  \n## Evidence\n- Українською: Наприклад, Вашуленко (Клас 2) ілюструє тверду групу\
+  \ саме через жовтий і зелений — «жовтий м'яч» і «зелений листок».\n  English: The\
+  \ writer makes a highly specific, confident claim attributing the teaching of \"\
+  hard group\" adjectives with exact examples to a Grade 2 textbook, which is a fabrication\
+  \ not supported by the plan or excerpts.\n- Українською: У підручниках блакитний\
+  \ і жовтий часто зустрічаються поряд як приклади з підручників для тренування —\
+  \ наприклад, «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення\
+  \ кольорів.\n  English: The writer fabricates a pedagogical claim about specific\
+  \ exercises in textbooks targeting the differentiation between blue and yellow.\n\
+  \n## Findings\n[HONESTY] [SEVERITY: critical]\nLocation: Кольори\nIssue: Українською:\
+  \ Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і зелений\
+  \ — «жовтий м'яч» і «зелений листок».\nEnglish: The writer fabricated a specific\
+  \ textbook citation and examples. Grade 2 textbooks do not teach \"тверда група\"\
+  \ (this grammatical concept is taught in later grades), and the specific examples\
+  \ \"жовтий м'яч\" and \"зелений листок\" as illustrations of the hard group in Vashulenko\
+  \ Grade 2 are invented and unsupported by the provided knowledge packet.\nFix: Add\
+  \ a VERIFY marker to flag the unsupported claim.\n\n[HONESTY] [SEVERITY: major]\n\
+  Location: Синій ≠ блакитний\nIssue: Українською: У підручниках блакитний і жовтий\
+  \ часто зустрічаються поряд як приклади з підручників для тренування — наприклад,\
+  \ «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.\n\
+  English: The writer invented a claim about specific textbook exercises targeting\
+  \ color differentiation between blue and yellow. The wiki excerpts do not support\
+  \ this.\nFix: Add a VERIFY marker to flag the unsupported claim.\n\n## Verdict Reason\n\
+  The module contains invented, highly specific factual claims about textbook contents\
+  \ and exercises (such as attributing the grammatical concept of \"тверда група\"\
+  \ and specific examples to a Grade 2 textbook) without using `<!-- VERIFY -->` markers.\
+  \ According to the rubric, unsupported factual certainty without `<!-- VERIFY -->`\
+  \ results in a REJECT with a maximum score of 5.0.\n\n<fixes>\n- find: \"У підручниках\
+  \ «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші приклади з підручників\
+  \ для тренування цих форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме\
+  \ через жовтий і зелений — «жовтий м'яч» і «зелений листок».\"\n  replace: \"У підручниках\
+  \ «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші приклади з підручників\
+  \ для тренування цих форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме\
+  \ через жовтий і зелений — «жовтий м'яч» і «зелений листок». <!-- VERIFY: Чи дійсно\
+  \ Вашуленко (Клас 2) ілюструє тверду групу саме через ці приклади? -->\"\n- find:\
+  \ \"У підручниках блакитний і жовтий часто зустрічаються поряд як приклади з підручників\
+  \ для тренування — наприклад, «блакитне небо» та «жовтий соняшник» — саме для вправ\
+  \ на розрізнення кольорів.\"\n  replace: \"У підручниках блакитний і жовтий часто\
+  \ зустрічаються поряд як приклади з підручників для тренування — наприклад, «блакитне\
+  \ небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів. <!-- VERIFY:\
+  \ Чи є це цілеспрямованими вправами на розрізнення кольорів? -->\"\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-language-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-language-r1.yaml
@@ -1,0 +1,31 @@
+slug: colors
+round: 1
+dimension: language
+name: Language
+score: 10.0
+verdict: PASS
+evidence: '- Українською: **«Якого вони кольору?»**, **«Червоні.»**, **«Синя.»**,
+  **«Сіре.»** English: Correct use of the "What color?" formula and precise gender/number
+  agreement in short answers. - Українсь...'
+findings: []
+fixes: []
+rewrite_blocks: []
+review_text: "## Dimension\nid: language\nname: Language\nscore: 10.0/10\nverdict:\
+  \ PASS\n\n## Evidence\n- Українською: **«Якого вони кольору?»**, **«Червоні.»**,\
+  \ **«Синя.»**, **«Сіре.»**\n  English: Correct use of the \"What color?\" formula\
+  \ and precise gender/number agreement in short answers.\n- Українською: **«карі\
+  \ очі»**, **«русяве волосся»**, **«сиве волосся»**\n  English: Authentic Ukrainian\
+  \ collocations for physical appearance, correctly avoiding literal color translations\
+  \ (like *коричневі очі).\n- Українською: **«синій»** (soft group) vs **«червоний»**\
+  \ (hard group).\n  English: Accurately teaches the soft-stem declension pattern\
+  \ for \"синій\" (синя, синє, сині) as the sole common exception in the basic color\
+  \ palette.\n- Українською: **«синій»** vs **«блакитний»**\n  English: Correct linguistic\
+  \ distinction between dark blue and light blue as two distinct base colors in the\
+  \ Ukrainian worldview.\n\n## Findings\nNone.\n\n## Verdict Reason\nThe Ukrainian\
+  \ content is linguistically flawless and fully idiomatic. All adjective agreements\
+  \ across gender and number are correct, and the module successfully implements the\
+  \ soft-stem paradigm for \"синій\". The inclusion of fixed collocations for physical\
+  \ appearance (карі очі, русяве волосся) demonstrates a high level of idiomatic accuracy\
+  \ and adherence to decolonization standards (avoiding calques from English). The\
+  \ text is free of Russianisms, Surzhyk, and paronym errors. Scaffolding is applied\
+  \ correctly for the A1 level.\n\n<fixes>\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-language.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-language.yaml
@@ -1,0 +1,31 @@
+slug: colors
+round: 1
+dimension: language
+name: Language
+score: 10.0
+verdict: PASS
+evidence: '- Українською: **«Якого вони кольору?»**, **«Червоні.»**, **«Синя.»**,
+  **«Сіре.»** English: Correct use of the "What color?" formula and precise gender/number
+  agreement in short answers. - Українсь...'
+findings: []
+fixes: []
+rewrite_blocks: []
+review_text: "## Dimension\nid: language\nname: Language\nscore: 10.0/10\nverdict:\
+  \ PASS\n\n## Evidence\n- Українською: **«Якого вони кольору?»**, **«Червоні.»**,\
+  \ **«Синя.»**, **«Сіре.»**\n  English: Correct use of the \"What color?\" formula\
+  \ and precise gender/number agreement in short answers.\n- Українською: **«карі\
+  \ очі»**, **«русяве волосся»**, **«сиве волосся»**\n  English: Authentic Ukrainian\
+  \ collocations for physical appearance, correctly avoiding literal color translations\
+  \ (like *коричневі очі).\n- Українською: **«синій»** (soft group) vs **«червоний»**\
+  \ (hard group).\n  English: Accurately teaches the soft-stem declension pattern\
+  \ for \"синій\" (синя, синє, сині) as the sole common exception in the basic color\
+  \ palette.\n- Українською: **«синій»** vs **«блакитний»**\n  English: Correct linguistic\
+  \ distinction between dark blue and light blue as two distinct base colors in the\
+  \ Ukrainian worldview.\n\n## Findings\nNone.\n\n## Verdict Reason\nThe Ukrainian\
+  \ content is linguistically flawless and fully idiomatic. All adjective agreements\
+  \ across gender and number are correct, and the module successfully implements the\
+  \ soft-stem paradigm for \"синій\". The inclusion of fixed collocations for physical\
+  \ appearance (карі очі, русяве волосся) demonstrates a high level of idiomatic accuracy\
+  \ and adherence to decolonization standards (avoiding calques from English). The\
+  \ text is free of Russianisms, Surzhyk, and paronym errors. Scaffolding is applied\
+  \ correctly for the A1 level.\n\n<fixes>\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-naturalness-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-naturalness-r1.yaml
@@ -1,0 +1,308 @@
+slug: colors
+round: 1
+dimension: naturalness
+name: Naturalness
+score: 4.0
+verdict: REVISE
+evidence: '- Українською: `Такі кольори, як білий і червоний, використовуються for
+  впізнавання (recognition) of everyday objects — the learner links word to thing
+  immediately. This echoes how Ukrainian textbo...'
+findings:
+- dimension: NATURALNESS
+  severity: critical
+  location: Section "Діалоги" and throughout the module
+  issue: 'Українською: Автор штучно змішує англійську й українську мови у реченнях
+    (напр. "a вибір букета на квітковому ринку", "використовуються for впізнавання")
+    та вдається до мета-розповідей про українські підручники.
+
+    English: The prose forces required contract terms into unnatural "code-switching"
+    sentences rather than correctly bolding them inline with English glosses.'
+  fix: Rewrite the explanations to be in natural English, using bolding for the Ukrainian
+    terms, and drop the meta-narration completely.
+- dimension: NATURALNESS
+  severity: critical
+  location: End of file
+  issue: 'Українською: Модуль містить згенерований ШІ звіт про виправлення помилок
+    у скриптах `contract_compliance.py`.
+
+    English: AI-generated boilerplate explaining bug fixes in Python scripts leaked
+    into the learning material.'
+  fix: Delete the bug report entirely.
+fixes:
+- find: 'A sunny morning at an open flower market. Наталка needs bouquets — a вибір
+    букета на квітковому ринку. Her key question: «Якого кольору?»'
+  replace: A sunny morning at an open flower market. This **Діалог** features the
+    **вибір букета на квітковому ринку** (choosing a bouquet at a flower market),
+    a classic scenario **за мотивами вірша про** (based on a poem about) colors. Наталка's
+    key question is **«Якого кольору?»** (What color?).
+- find: Every color in Dialogue 1 arrives as a short відповідь (answer) to «Якого
+    кольору?» — без дієслова (without a verb), one adjective in the correct gender.
+    Білий з'являється у формі «білі лілії» — саме цей колір входить до першої послідовності
+    введення кольорів у підручниках, бо білий легко впізнати на предметах навколо.
+    Такі кольори, як білий і червоний, використовуються for впізнавання (recognition)
+    of everyday objects — the learner links word to thing immediately. This echoes
+    how Ukrainian textbooks introduce colors, за мотивами вірша про кольори from the
+    Большакова Grade 2 textbook.
+  replace: Every color arrives as a short **відповідь** (answer) to **«Якого кольору?»**
+    — **без** дієслова (without a verb), using one adjective in the correct gender.
+    Colors like **білий** (white) and **червоний** (red) **використовуються** (are
+    used) for **впізнавання** (recognition) of everyday objects. Notice the form **«білі
+    лілії»** (white lilies).
+- find: 'Both dialogues used color adjectives naturally — «червоні троянди», «синя
+    ваза», «сіре пальто». Now let''s organize what you heard. Ukrainian has twelve
+    базових кольорів, поділених на дві групи за типами прикметників.
+
+
+    **Тверда група (hard group).** Eleven colors belong here. Their masculine ending
+    is **-ий** — такий самий pattern as «великий» from Module 9.'
+  replace: 'Both dialogues used color adjectives naturally — **«червоні троянди»**,
+    **«синя ваза»**, **«сіре пальто»**. Now let''s organize what you heard. Ukrainian
+    has twelve **базових кольорів** (basic colors), **поділених** (divided) into two
+    groups by **типами прикметників** (types of adjectives).
+
+
+    **Тверда група** (Hard group). Eleven colors belong here. Their masculine ending
+    is **-ий** — **такий** (such) a similar pattern as **«великий»** from Module 9.'
+- find: Варто запам'ятати саме ці шість — вони покривають більшість побутових описів.
+    Білий, жовтий і зелений входять до першої послідовності введення кольорів у більшості
+    підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений
+    листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих
+    форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і
+    зелений — «жовтий м'яч» і «зелений листок».
+  replace: '**Варто** (It is worth) memorizing these six — they cover most everyday
+    descriptions. We start with **білий** (white), **жовтий** (yellow), and **зелений**
+    (green). Common examples include **«жовтий соняшник»** (yellow sunflower), **«зелений
+    листок»** (green leaf), and **«білий сніг»** (white snow).'
+- find: 'Now for the question from both dialogues: «Якого кольору...?» (What color
+    is...?). The відповідь (answer) is simply the adjective in the correct gender
+    — no verb needed. Four model exchanges show the pattern:'
+  replace: 'Now for the question from both dialogues: **«Якого кольору...?»** (What
+    color is...?). The **відповідь** (answer) is simply the adjective in the correct
+    gender — no verb needed. Four model exchanges show the pattern:'
+- find: 'В українській мові для позначення "blue" ми активно вчимо пару окремих слів
+    — these are two separate base colors, not two shades of one word. Впізнавання
+    різниці між «синій» і «блакитний» is one of the first steps in thinking about
+    color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить
+    до послідовності введення кольорів нарівні з основними, бо це окремий базовий
+    колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the
+    sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне
+    небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag
+    is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below
+    is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий
+    часто зустрічаються поряд як приклади з підручників для тренування — наприклад,
+    «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.
+    If you encounter «голубий» outside this module, it is a dictionary-level synonym
+    for «блакитний» — passive recognition is enough at A1, not a third active color
+    to learn.'
+  replace: 'In **українській мові** (the Ukrainian language), **для** (for) the color
+    "blue", we **активно вчимо** (actively learn) a **пару** (pair) of separate base
+    words, not two shades. **Впізнавання** (Recognizing) the difference between them
+    is essential. **Варто** (It is worth) mastering this immediately. **«Синій»**
+    means dark, deep blue — the color of the sea and ink: **«синє море»**, **«синє
+    чорнило»**. **«Блакитний»** means light, sky blue: **«блакитне небо»**, **«блакитні
+    очі»**. A stable reference pair: the Ukrainian flag is **«синьо-жовтий»** — the
+    dark stripe on top is **«синій»**, the bright stripe below is **«жовтий»**. If
+    you encounter **«голубий»**, it is a dictionary synonym for **«блакитний»** —
+    passive recognition is enough at A1.'
+- find: 'This модуль taught узгодження кольорів using the adjective правилами you
+    learned in Module 9. The тверда група covers every basic color except one: «червоний
+    стіл» (m, -ий), «червона книга» (f, -а), «червоне вікно» (n, -е), «червоні квіти»
+    (pl, -і).'
+  replace: 'This **модуль** (module) taught **узгодження кольорів** (agreement of
+    colors) using the adjective **правилами** (rules) you learned in Module 9. The
+    **тверда група** (hard group) covers every basic color except one: **«червоний
+    стіл»** (m, -ий), **«червона книга»** (f, -а), **«червоне вікно»** (n, -е), **«червоні
+    квіти»** (pl, -і).'
+- find: 'Перевірте себе — три завдання:
+
+
+    • Поставте 3 запитання «Якого кольору?» про речі у вашій кімнаті й дайте короткі
+    відповіді. Наприклад: «Якого кольору твій стіл? — Коричневий.»
+
+
+    • Опишіть 3 предмети з правильним узгодженням за родом: «Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»
+
+
+    • Скажіть природно: «У мене ___ очі. У мене ___ волосся.» Вибирайте з «карі /
+    блакитні» та «русяве / сиве / темне».
+
+
+    > Check yourself: (1) Ask three «Якого кольору?» questions about things in your
+    room and answer them. (2) Describe three objects with correct gender agreement.
+    (3) Describe your eyes and hair using the fixed collocations from Dialogue 2.'
+  replace: 'As the **автора** (author) of your own sentences, check yourself with
+    three tasks:
+
+
+    1. Ask three **запитання** (questions) with **«Якого кольору?»** about things
+    in your room and **дайте** (give) short answers. Example: **«Якого кольору твій
+    стіл? — Коричневий.»**
+
+    2. Describe three objects with correct gender agreement: **«Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»**
+
+    3. Describe your eyes and hair using the fixed collocations: **«У мене карі очі.
+    У мене сиве волосся.»**'
+- find: '---
+
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:**
+
+    - Added `_strip_combining()` helper that applies the same NFKD + strip-combining
+    normalization
+
+    - Updated `_missing_terms()` to normalize both the text and the terms before matching
+
+    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit
+    function and end-to-end integration
+
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: ''
+rewrite_blocks: []
+review_text: "## Dimension\nid: naturalness\nname: Naturalness\nscore: 4.0/10\nverdict:\
+  \ REVISE\n\n## Evidence\n- Українською: `Такі кольори, як білий і червоний, використовуються\
+  \ for впізнавання (recognition) of everyday objects — the learner links word to\
+  \ thing immediately. This echoes how Ukrainian textbooks introduce colors, за мотивами\
+  \ вірша про кольори from the Большакова Grade 2 textbook.`\n  English: Severe mixing\
+  \ of English and Ukrainian text inside sentences, violating the A1 structural rule,\
+  \ accompanied by meta-narration about textbooks.\n- Українською: `У підручниках\
+  \ «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші приклади з підручників\
+  \ для тренування цих форм.`\n  English: Unnatural meta-narration directed at the\
+  \ reviewer, instead of teaching the learner.\n- Українською: `**Important: The errors\
+  \ were false positives from a bug in scripts/audit/checks/contract_compliance.py...**`\n\
+  \  English: System hallucination where the LLM addresses internal CI script errors\
+  \ inside the student-facing module text.\n\n## Findings\n[NATURALNESS] [SEVERITY:\
+  \ critical]\nLocation: Section \"Діалоги\" and throughout the module\nIssue: Українською:\
+  \ Автор штучно змішує англійську й українську мови у реченнях (напр. \"a вибір букета\
+  \ на квітковому ринку\", \"використовуються for впізнавання\") та вдається до мета-розповідей\
+  \ про українські підручники.\nEnglish: The prose forces required contract terms\
+  \ into unnatural \"code-switching\" sentences rather than correctly bolding them\
+  \ inline with English glosses.\nFix: Rewrite the explanations to be in natural English,\
+  \ using bolding for the Ukrainian terms, and drop the meta-narration completely.\n\
+  \n[NATURALNESS] [SEVERITY: critical]\nLocation: End of file\nIssue: Українською:\
+  \ Модуль містить згенерований ШІ звіт про виправлення помилок у скриптах `contract_compliance.py`.\n\
+  English: AI-generated boilerplate explaining bug fixes in Python scripts leaked\
+  \ into the learning material.\nFix: Delete the bug report entirely.\n\n## Verdict\
+  \ Reason\nThe module fails the structural constraints of the A1 level band by randomly\
+  \ weaving Ukrainian phrasing into English syntax and speaking directly to the system\
+  \ (\"УВАГА до автора\", \"bug in scripts...\"). This breaks the pedagogical voice\
+  \ entirely and introduces severe robotic traits, capping the score at 4.0.\n\n<fixes>\n\
+  - find: \"A sunny morning at an open flower market. Наталка needs bouquets — a вибір\
+  \ букета на квітковому ринку. Her key question: «Якого кольору?»\"\n  replace: \"\
+  A sunny morning at an open flower market. This **Діалог** features the **вибір букета\
+  \ на квітковому ринку** (choosing a bouquet at a flower market), a classic scenario\
+  \ **за мотивами вірша про** (based on a poem about) colors. Наталка's key question\
+  \ is **«Якого кольору?»** (What color?).\"\n- find: \"Every color in Dialogue 1\
+  \ arrives as a short відповідь (answer) to «Якого кольору?» — без дієслова (without\
+  \ a verb), one adjective in the correct gender. Білий з'являється у формі «білі\
+  \ лілії» — саме цей колір входить до першої послідовності введення кольорів у підручниках,\
+  \ бо білий легко впізнати на предметах навколо. Такі кольори, як білий і червоний,\
+  \ використовуються for впізнавання (recognition) of everyday objects — the learner\
+  \ links word to thing immediately. This echoes how Ukrainian textbooks introduce\
+  \ colors, за мотивами вірша про кольори from the Большакова Grade 2 textbook.\"\n\
+  \  replace: \"Every color arrives as a short **відповідь** (answer) to **«Якого\
+  \ кольору?»** — **без** дієслова (without a verb), using one adjective in the correct\
+  \ gender. Colors like **білий** (white) and **червоний** (red) **використовуються**\
+  \ (are used) for **впізнавання** (recognition) of everyday objects. Notice the form\
+  \ **«білі лілії»** (white lilies).\"\n- find: \"Both dialogues used color adjectives\
+  \ naturally — «червоні троянди», «синя ваза», «сіре пальто». Now let's organize\
+  \ what you heard. Ukrainian has twelve базових кольорів, поділених на дві групи\
+  \ за типами прикметників.\\n\\n**Тверда група (hard group).** Eleven colors belong\
+  \ here. Their masculine ending is **-ий** — такий самий pattern as «великий» from\
+  \ Module 9.\"\n  replace: \"Both dialogues used color adjectives naturally — **«червоні\
+  \ троянди»**, **«синя ваза»**, **«сіре пальто»**. Now let's organize what you heard.\
+  \ Ukrainian has twelve **базових кольорів** (basic colors), **поділених** (divided)\
+  \ into two groups by **типами прикметників** (types of adjectives).\\n\\n**Тверда\
+  \ група** (Hard group). Eleven colors belong here. Their masculine ending is **-ий**\
+  \ — **такий** (such) a similar pattern as **«великий»** from Module 9.\"\n- find:\
+  \ \"Варто запам'ятати саме ці шість — вони покривають більшість побутових описів.\
+  \ Білий, жовтий і зелений входять до першої послідовності введення кольорів у більшості\
+  \ підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений\
+  \ листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих\
+  \ форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і\
+  \ зелений — «жовтий м'яч» і «зелений листок».\"\n  replace: \"**Варто** (It is worth)\
+  \ memorizing these six — they cover most everyday descriptions. We start with **білий**\
+  \ (white), **жовтий** (yellow), and **зелений** (green). Common examples include\
+  \ **«жовтий соняшник»** (yellow sunflower), **«зелений листок»** (green leaf), and\
+  \ **«білий сніг»** (white snow).\"\n- find: \"Now for the question from both dialogues:\
+  \ «Якого кольору...?» (What color is...?). The відповідь (answer) is simply the\
+  \ adjective in the correct gender — no verb needed. Four model exchanges show the\
+  \ pattern:\"\n  replace: \"Now for the question from both dialogues: **«Якого кольору...?»**\
+  \ (What color is...?). The **відповідь** (answer) is simply the adjective in the\
+  \ correct gender — no verb needed. Four model exchanges show the pattern:\"\n- find:\
+  \ \"В українській мові для позначення \\\"blue\\\" ми активно вчимо пару окремих\
+  \ слів — these are two separate base colors, not two shades of one word. Впізнавання\
+  \ різниці між «синій» і «блакитний» is one of the first steps in thinking about\
+  \ color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить\
+  \ до послідовності введення кольорів нарівні з основними, бо це окремий базовий\
+  \ колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the\
+  \ sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне\
+  \ небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag\
+  \ is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below\
+  \ is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий\
+  \ часто зустрічаються поряд як приклади з підручників для тренування — наприклад,\
+  \ «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.\
+  \ If you encounter «голубий» outside this module, it is a dictionary-level synonym\
+  \ for «блакитний» — passive recognition is enough at A1, not a third active color\
+  \ to learn.\"\n  replace: \"In **українській мові** (the Ukrainian language), **для**\
+  \ (for) the color \\\"blue\\\", we **активно вчимо** (actively learn) a **пару**\
+  \ (pair) of separate base words, not two shades. **Впізнавання** (Recognizing) the\
+  \ difference between them is essential. **Варто** (It is worth) mastering this immediately.\
+  \ **«Синій»** means dark, deep blue — the color of the sea and ink: **«синє море»**,\
+  \ **«синє чорнило»**. **«Блакитний»** means light, sky blue: **«блакитне небо»**,\
+  \ **«блакитні очі»**. A stable reference pair: the Ukrainian flag is **«синьо-жовтий»**\
+  \ — the dark stripe on top is **«синій»**, the bright stripe below is **«жовтий»**.\
+  \ If you encounter **«голубий»**, it is a dictionary synonym for **«блакитний»**\
+  \ — passive recognition is enough at A1.\"\n- find: \"This модуль taught узгодження\
+  \ кольорів using the adjective правилами you learned in Module 9. The тверда група\
+  \ covers every basic color except one: «червоний стіл» (m, -ий), «червона книга»\
+  \ (f, -а), «червоне вікно» (n, -е), «червоні квіти» (pl, -і).\"\n  replace: \"This\
+  \ **модуль** (module) taught **узгодження кольорів** (agreement of colors) using\
+  \ the adjective **правилами** (rules) you learned in Module 9. The **тверда група**\
+  \ (hard group) covers every basic color except one: **«червоний стіл»** (m, -ий),\
+  \ **«червона книга»** (f, -а), **«червоне вікно»** (n, -е), **«червоні квіти»**\
+  \ (pl, -і).\"\n- find: \"Перевірте себе — три завдання:\\n\\n• Поставте 3 запитання\
+  \ «Якого кольору?» про речі у вашій кімнаті й дайте короткі відповіді. Наприклад:\
+  \ «Якого кольору твій стіл? — Коричневий.»\\n\\n• Опишіть 3 предмети з правильним\
+  \ узгодженням за родом: «Моя сумка ___на. Моє вікно ___не. Мій светр ___ній.»\\\
+  n\\n• Скажіть природно: «У мене ___ очі. У мене ___ волосся.» Вибирайте з «карі\
+  \ / блакитні» та «русяве / сиве / темне».\\n\\n> Check yourself: (1) Ask three «Якого\
+  \ кольору?» questions about things in your room and answer them. (2) Describe three\
+  \ objects with correct gender agreement. (3) Describe your eyes and hair using the\
+  \ fixed collocations from Dialogue 2.\"\n  replace: \"As the **автора** (author)\
+  \ of your own sentences, check yourself with three tasks:\\n\\n1. Ask three **запитання**\
+  \ (questions) with **«Якого кольору?»** about things in your room and **дайте**\
+  \ (give) short answers. Example: **«Якого кольору твій стіл? — Коричневий.»**\\\
+  n2. Describe three objects with correct gender agreement: **«Моя сумка ___на. Моє\
+  \ вікно ___не. Мій светр ___ній.»**\\n3. Describe your eyes and hair using the fixed\
+  \ collocations: **«У мене карі очі. У мене сиве волосся.»**\"\n- find: \"---\\n\\\
+  n**Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,\
+  \ not problems with the draft.** The draft is unchanged because the content was\
+  \ already correct.\\n\\n**Root cause:** The `wiki_compressor._tokenize()` function\
+  \ applies NFKD normalization + combining-mark stripping, which converts Ukrainian\
+  \ \\\"й\\\" (U+0439 = и + combining breve) → \\\"и\\\" (U+0438). So \\\"білий\\\"\
+  \ becomes \\\"білии\\\" in the anchor terms. But `_missing_terms()` in the compliance\
+  \ checker did raw substring matching without the same normalization — it looked\
+  \ for \\\"білии\\\" in text containing \\\"білий\\\" and never found it.\\n\\n**Fix\
+  \ applied to `scripts/audit/checks/contract_compliance.py`:**\\n- Added `_strip_combining()`\
+  \ helper that applies the same NFKD + strip-combining normalization\\n- Updated\
+  \ `_missing_terms()` to normalize both the text and the terms before matching\\\
+  n- Added 2 tests to `tests/test_contract_compliance.py` covering both the unit function\
+  \ and end-to-end integration\\n\\nThis was a systemic bug — every Ukrainian word\
+  \ ending in \\\"й\\\" would fail as a factual anchor term. The fix resolves this\
+  \ for all modules, not just colors.\"\n  replace: \"\"\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-naturalness.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-naturalness.yaml
@@ -1,0 +1,308 @@
+slug: colors
+round: 1
+dimension: naturalness
+name: Naturalness
+score: 4.0
+verdict: REVISE
+evidence: '- Українською: `Такі кольори, як білий і червоний, використовуються for
+  впізнавання (recognition) of everyday objects — the learner links word to thing
+  immediately. This echoes how Ukrainian textbo...'
+findings:
+- dimension: NATURALNESS
+  severity: critical
+  location: Section "Діалоги" and throughout the module
+  issue: 'Українською: Автор штучно змішує англійську й українську мови у реченнях
+    (напр. "a вибір букета на квітковому ринку", "використовуються for впізнавання")
+    та вдається до мета-розповідей про українські підручники.
+
+    English: The prose forces required contract terms into unnatural "code-switching"
+    sentences rather than correctly bolding them inline with English glosses.'
+  fix: Rewrite the explanations to be in natural English, using bolding for the Ukrainian
+    terms, and drop the meta-narration completely.
+- dimension: NATURALNESS
+  severity: critical
+  location: End of file
+  issue: 'Українською: Модуль містить згенерований ШІ звіт про виправлення помилок
+    у скриптах `contract_compliance.py`.
+
+    English: AI-generated boilerplate explaining bug fixes in Python scripts leaked
+    into the learning material.'
+  fix: Delete the bug report entirely.
+fixes:
+- find: 'A sunny morning at an open flower market. Наталка needs bouquets — a вибір
+    букета на квітковому ринку. Her key question: «Якого кольору?»'
+  replace: A sunny morning at an open flower market. This **Діалог** features the
+    **вибір букета на квітковому ринку** (choosing a bouquet at a flower market),
+    a classic scenario **за мотивами вірша про** (based on a poem about) colors. Наталка's
+    key question is **«Якого кольору?»** (What color?).
+- find: Every color in Dialogue 1 arrives as a short відповідь (answer) to «Якого
+    кольору?» — без дієслова (without a verb), one adjective in the correct gender.
+    Білий з'являється у формі «білі лілії» — саме цей колір входить до першої послідовності
+    введення кольорів у підручниках, бо білий легко впізнати на предметах навколо.
+    Такі кольори, як білий і червоний, використовуються for впізнавання (recognition)
+    of everyday objects — the learner links word to thing immediately. This echoes
+    how Ukrainian textbooks introduce colors, за мотивами вірша про кольори from the
+    Большакова Grade 2 textbook.
+  replace: Every color arrives as a short **відповідь** (answer) to **«Якого кольору?»**
+    — **без** дієслова (without a verb), using one adjective in the correct gender.
+    Colors like **білий** (white) and **червоний** (red) **використовуються** (are
+    used) for **впізнавання** (recognition) of everyday objects. Notice the form **«білі
+    лілії»** (white lilies).
+- find: 'Both dialogues used color adjectives naturally — «червоні троянди», «синя
+    ваза», «сіре пальто». Now let''s organize what you heard. Ukrainian has twelve
+    базових кольорів, поділених на дві групи за типами прикметників.
+
+
+    **Тверда група (hard group).** Eleven colors belong here. Their masculine ending
+    is **-ий** — такий самий pattern as «великий» from Module 9.'
+  replace: 'Both dialogues used color adjectives naturally — **«червоні троянди»**,
+    **«синя ваза»**, **«сіре пальто»**. Now let''s organize what you heard. Ukrainian
+    has twelve **базових кольорів** (basic colors), **поділених** (divided) into two
+    groups by **типами прикметників** (types of adjectives).
+
+
+    **Тверда група** (Hard group). Eleven colors belong here. Their masculine ending
+    is **-ий** — **такий** (such) a similar pattern as **«великий»** from Module 9.'
+- find: Варто запам'ятати саме ці шість — вони покривають більшість побутових описів.
+    Білий, жовтий і зелений входять до першої послідовності введення кольорів у більшості
+    підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений
+    листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих
+    форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і
+    зелений — «жовтий м'яч» і «зелений листок».
+  replace: '**Варто** (It is worth) memorizing these six — they cover most everyday
+    descriptions. We start with **білий** (white), **жовтий** (yellow), and **зелений**
+    (green). Common examples include **«жовтий соняшник»** (yellow sunflower), **«зелений
+    листок»** (green leaf), and **«білий сніг»** (white snow).'
+- find: 'Now for the question from both dialogues: «Якого кольору...?» (What color
+    is...?). The відповідь (answer) is simply the adjective in the correct gender
+    — no verb needed. Four model exchanges show the pattern:'
+  replace: 'Now for the question from both dialogues: **«Якого кольору...?»** (What
+    color is...?). The **відповідь** (answer) is simply the adjective in the correct
+    gender — no verb needed. Four model exchanges show the pattern:'
+- find: 'В українській мові для позначення "blue" ми активно вчимо пару окремих слів
+    — these are two separate base colors, not two shades of one word. Впізнавання
+    різниці між «синій» і «блакитний» is one of the first steps in thinking about
+    color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить
+    до послідовності введення кольорів нарівні з основними, бо це окремий базовий
+    колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the
+    sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне
+    небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag
+    is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below
+    is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий
+    часто зустрічаються поряд як приклади з підручників для тренування — наприклад,
+    «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.
+    If you encounter «голубий» outside this module, it is a dictionary-level synonym
+    for «блакитний» — passive recognition is enough at A1, not a third active color
+    to learn.'
+  replace: 'In **українській мові** (the Ukrainian language), **для** (for) the color
+    "blue", we **активно вчимо** (actively learn) a **пару** (pair) of separate base
+    words, not two shades. **Впізнавання** (Recognizing) the difference between them
+    is essential. **Варто** (It is worth) mastering this immediately. **«Синій»**
+    means dark, deep blue — the color of the sea and ink: **«синє море»**, **«синє
+    чорнило»**. **«Блакитний»** means light, sky blue: **«блакитне небо»**, **«блакитні
+    очі»**. A stable reference pair: the Ukrainian flag is **«синьо-жовтий»** — the
+    dark stripe on top is **«синій»**, the bright stripe below is **«жовтий»**. If
+    you encounter **«голубий»**, it is a dictionary synonym for **«блакитний»** —
+    passive recognition is enough at A1.'
+- find: 'This модуль taught узгодження кольорів using the adjective правилами you
+    learned in Module 9. The тверда група covers every basic color except one: «червоний
+    стіл» (m, -ий), «червона книга» (f, -а), «червоне вікно» (n, -е), «червоні квіти»
+    (pl, -і).'
+  replace: 'This **модуль** (module) taught **узгодження кольорів** (agreement of
+    colors) using the adjective **правилами** (rules) you learned in Module 9. The
+    **тверда група** (hard group) covers every basic color except one: **«червоний
+    стіл»** (m, -ий), **«червона книга»** (f, -а), **«червоне вікно»** (n, -е), **«червоні
+    квіти»** (pl, -і).'
+- find: 'Перевірте себе — три завдання:
+
+
+    • Поставте 3 запитання «Якого кольору?» про речі у вашій кімнаті й дайте короткі
+    відповіді. Наприклад: «Якого кольору твій стіл? — Коричневий.»
+
+
+    • Опишіть 3 предмети з правильним узгодженням за родом: «Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»
+
+
+    • Скажіть природно: «У мене ___ очі. У мене ___ волосся.» Вибирайте з «карі /
+    блакитні» та «русяве / сиве / темне».
+
+
+    > Check yourself: (1) Ask three «Якого кольору?» questions about things in your
+    room and answer them. (2) Describe three objects with correct gender agreement.
+    (3) Describe your eyes and hair using the fixed collocations from Dialogue 2.'
+  replace: 'As the **автора** (author) of your own sentences, check yourself with
+    three tasks:
+
+
+    1. Ask three **запитання** (questions) with **«Якого кольору?»** about things
+    in your room and **дайте** (give) short answers. Example: **«Якого кольору твій
+    стіл? — Коричневий.»**
+
+    2. Describe three objects with correct gender agreement: **«Моя сумка ___на. Моє
+    вікно ___не. Мій светр ___ній.»**
+
+    3. Describe your eyes and hair using the fixed collocations: **«У мене карі очі.
+    У мене сиве волосся.»**'
+- find: '---
+
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:**
+
+    - Added `_strip_combining()` helper that applies the same NFKD + strip-combining
+    normalization
+
+    - Updated `_missing_terms()` to normalize both the text and the terms before matching
+
+    - Added 2 tests to `tests/test_contract_compliance.py` covering both the unit
+    function and end-to-end integration
+
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: ''
+rewrite_blocks: []
+review_text: "## Dimension\nid: naturalness\nname: Naturalness\nscore: 4.0/10\nverdict:\
+  \ REVISE\n\n## Evidence\n- Українською: `Такі кольори, як білий і червоний, використовуються\
+  \ for впізнавання (recognition) of everyday objects — the learner links word to\
+  \ thing immediately. This echoes how Ukrainian textbooks introduce colors, за мотивами\
+  \ вірша про кольори from the Большакова Grade 2 textbook.`\n  English: Severe mixing\
+  \ of English and Ukrainian text inside sentences, violating the A1 structural rule,\
+  \ accompanied by meta-narration about textbooks.\n- Українською: `У підручниках\
+  \ «жовтий соняшник», «зелений листок» і «білий сніг» — найчастіші приклади з підручників\
+  \ для тренування цих форм.`\n  English: Unnatural meta-narration directed at the\
+  \ reviewer, instead of teaching the learner.\n- Українською: `**Important: The errors\
+  \ were false positives from a bug in scripts/audit/checks/contract_compliance.py...**`\n\
+  \  English: System hallucination where the LLM addresses internal CI script errors\
+  \ inside the student-facing module text.\n\n## Findings\n[NATURALNESS] [SEVERITY:\
+  \ critical]\nLocation: Section \"Діалоги\" and throughout the module\nIssue: Українською:\
+  \ Автор штучно змішує англійську й українську мови у реченнях (напр. \"a вибір букета\
+  \ на квітковому ринку\", \"використовуються for впізнавання\") та вдається до мета-розповідей\
+  \ про українські підручники.\nEnglish: The prose forces required contract terms\
+  \ into unnatural \"code-switching\" sentences rather than correctly bolding them\
+  \ inline with English glosses.\nFix: Rewrite the explanations to be in natural English,\
+  \ using bolding for the Ukrainian terms, and drop the meta-narration completely.\n\
+  \n[NATURALNESS] [SEVERITY: critical]\nLocation: End of file\nIssue: Українською:\
+  \ Модуль містить згенерований ШІ звіт про виправлення помилок у скриптах `contract_compliance.py`.\n\
+  English: AI-generated boilerplate explaining bug fixes in Python scripts leaked\
+  \ into the learning material.\nFix: Delete the bug report entirely.\n\n## Verdict\
+  \ Reason\nThe module fails the structural constraints of the A1 level band by randomly\
+  \ weaving Ukrainian phrasing into English syntax and speaking directly to the system\
+  \ (\"УВАГА до автора\", \"bug in scripts...\"). This breaks the pedagogical voice\
+  \ entirely and introduces severe robotic traits, capping the score at 4.0.\n\n<fixes>\n\
+  - find: \"A sunny morning at an open flower market. Наталка needs bouquets — a вибір\
+  \ букета на квітковому ринку. Her key question: «Якого кольору?»\"\n  replace: \"\
+  A sunny morning at an open flower market. This **Діалог** features the **вибір букета\
+  \ на квітковому ринку** (choosing a bouquet at a flower market), a classic scenario\
+  \ **за мотивами вірша про** (based on a poem about) colors. Наталка's key question\
+  \ is **«Якого кольору?»** (What color?).\"\n- find: \"Every color in Dialogue 1\
+  \ arrives as a short відповідь (answer) to «Якого кольору?» — без дієслова (without\
+  \ a verb), one adjective in the correct gender. Білий з'являється у формі «білі\
+  \ лілії» — саме цей колір входить до першої послідовності введення кольорів у підручниках,\
+  \ бо білий легко впізнати на предметах навколо. Такі кольори, як білий і червоний,\
+  \ використовуються for впізнавання (recognition) of everyday objects — the learner\
+  \ links word to thing immediately. This echoes how Ukrainian textbooks introduce\
+  \ colors, за мотивами вірша про кольори from the Большакова Grade 2 textbook.\"\n\
+  \  replace: \"Every color arrives as a short **відповідь** (answer) to **«Якого\
+  \ кольору?»** — **без** дієслова (without a verb), using one adjective in the correct\
+  \ gender. Colors like **білий** (white) and **червоний** (red) **використовуються**\
+  \ (are used) for **впізнавання** (recognition) of everyday objects. Notice the form\
+  \ **«білі лілії»** (white lilies).\"\n- find: \"Both dialogues used color adjectives\
+  \ naturally — «червоні троянди», «синя ваза», «сіре пальто». Now let's organize\
+  \ what you heard. Ukrainian has twelve базових кольорів, поділених на дві групи\
+  \ за типами прикметників.\\n\\n**Тверда група (hard group).** Eleven colors belong\
+  \ here. Their masculine ending is **-ий** — такий самий pattern as «великий» from\
+  \ Module 9.\"\n  replace: \"Both dialogues used color adjectives naturally — **«червоні\
+  \ троянди»**, **«синя ваза»**, **«сіре пальто»**. Now let's organize what you heard.\
+  \ Ukrainian has twelve **базових кольорів** (basic colors), **поділених** (divided)\
+  \ into two groups by **типами прикметників** (types of adjectives).\\n\\n**Тверда\
+  \ група** (Hard group). Eleven colors belong here. Their masculine ending is **-ий**\
+  \ — **такий** (such) a similar pattern as **«великий»** from Module 9.\"\n- find:\
+  \ \"Варто запам'ятати саме ці шість — вони покривають більшість побутових описів.\
+  \ Білий, жовтий і зелений входять до першої послідовності введення кольорів у більшості\
+  \ підручників, тому ми починаємо з них. У підручниках «жовтий соняшник», «зелений\
+  \ листок» і «білий сніг» — найчастіші приклади з підручників для тренування цих\
+  \ форм. Наприклад, Вашуленко (Клас 2) ілюструє тверду групу саме через жовтий і\
+  \ зелений — «жовтий м'яч» і «зелений листок».\"\n  replace: \"**Варто** (It is worth)\
+  \ memorizing these six — they cover most everyday descriptions. We start with **білий**\
+  \ (white), **жовтий** (yellow), and **зелений** (green). Common examples include\
+  \ **«жовтий соняшник»** (yellow sunflower), **«зелений листок»** (green leaf), and\
+  \ **«білий сніг»** (white snow).\"\n- find: \"Now for the question from both dialogues:\
+  \ «Якого кольору...?» (What color is...?). The відповідь (answer) is simply the\
+  \ adjective in the correct gender — no verb needed. Four model exchanges show the\
+  \ pattern:\"\n  replace: \"Now for the question from both dialogues: **«Якого кольору...?»**\
+  \ (What color is...?). The **відповідь** (answer) is simply the adjective in the\
+  \ correct gender — no verb needed. Four model exchanges show the pattern:\"\n- find:\
+  \ \"В українській мові для позначення \\\"blue\\\" ми активно вчимо пару окремих\
+  \ слів — these are two separate base colors, not two shades of one word. Впізнавання\
+  \ різниці між «синій» і «блакитний» is one of the first steps in thinking about\
+  \ color like a Ukrainian speaker. Варто засвоїти цю різницю одразу — блакитний входить\
+  \ до послідовності введення кольорів нарівні з основними, бо це окремий базовий\
+  \ колір, а не відтінок синього. «Синій» means dark, deep blue — the color of the\
+  \ sea and ink: «синє море», «синє чорнило». «Блакитний» means light, sky blue: «блакитне\
+  \ небо», «блакитні очі». A stable reference pair to memorize: the Ukrainian flag\
+  \ is «синьо-жовтий» — the dark stripe on top is «синій», the bright stripe below\
+  \ is «жовтий», and a clear noon sky is «блакитне». У підручниках блакитний і жовтий\
+  \ часто зустрічаються поряд як приклади з підручників для тренування — наприклад,\
+  \ «блакитне небо» та «жовтий соняшник» — саме для вправ на розрізнення кольорів.\
+  \ If you encounter «голубий» outside this module, it is a dictionary-level synonym\
+  \ for «блакитний» — passive recognition is enough at A1, not a third active color\
+  \ to learn.\"\n  replace: \"In **українській мові** (the Ukrainian language), **для**\
+  \ (for) the color \\\"blue\\\", we **активно вчимо** (actively learn) a **пару**\
+  \ (pair) of separate base words, not two shades. **Впізнавання** (Recognizing) the\
+  \ difference between them is essential. **Варто** (It is worth) mastering this immediately.\
+  \ **«Синій»** means dark, deep blue — the color of the sea and ink: **«синє море»**,\
+  \ **«синє чорнило»**. **«Блакитний»** means light, sky blue: **«блакитне небо»**,\
+  \ **«блакитні очі»**. A stable reference pair: the Ukrainian flag is **«синьо-жовтий»**\
+  \ — the dark stripe on top is **«синій»**, the bright stripe below is **«жовтий»**.\
+  \ If you encounter **«голубий»**, it is a dictionary synonym for **«блакитний»**\
+  \ — passive recognition is enough at A1.\"\n- find: \"This модуль taught узгодження\
+  \ кольорів using the adjective правилами you learned in Module 9. The тверда група\
+  \ covers every basic color except one: «червоний стіл» (m, -ий), «червона книга»\
+  \ (f, -а), «червоне вікно» (n, -е), «червоні квіти» (pl, -і).\"\n  replace: \"This\
+  \ **модуль** (module) taught **узгодження кольорів** (agreement of colors) using\
+  \ the adjective **правилами** (rules) you learned in Module 9. The **тверда група**\
+  \ (hard group) covers every basic color except one: **«червоний стіл»** (m, -ий),\
+  \ **«червона книга»** (f, -а), **«червоне вікно»** (n, -е), **«червоні квіти»**\
+  \ (pl, -і).\"\n- find: \"Перевірте себе — три завдання:\\n\\n• Поставте 3 запитання\
+  \ «Якого кольору?» про речі у вашій кімнаті й дайте короткі відповіді. Наприклад:\
+  \ «Якого кольору твій стіл? — Коричневий.»\\n\\n• Опишіть 3 предмети з правильним\
+  \ узгодженням за родом: «Моя сумка ___на. Моє вікно ___не. Мій светр ___ній.»\\\
+  n\\n• Скажіть природно: «У мене ___ очі. У мене ___ волосся.» Вибирайте з «карі\
+  \ / блакитні» та «русяве / сиве / темне».\\n\\n> Check yourself: (1) Ask three «Якого\
+  \ кольору?» questions about things in your room and answer them. (2) Describe three\
+  \ objects with correct gender agreement. (3) Describe your eyes and hair using the\
+  \ fixed collocations from Dialogue 2.\"\n  replace: \"As the **автора** (author)\
+  \ of your own sentences, check yourself with three tasks:\\n\\n1. Ask three **запитання**\
+  \ (questions) with **«Якого кольору?»** about things in your room and **дайте**\
+  \ (give) short answers. Example: **«Якого кольору твій стіл? — Коричневий.»**\\\
+  n2. Describe three objects with correct gender agreement: **«Моя сумка ___на. Моє\
+  \ вікно ___не. Мій светр ___ній.»**\\n3. Describe your eyes and hair using the fixed\
+  \ collocations: **«У мене карі очі. У мене сиве волосся.»**\"\n- find: \"---\\n\\\
+  n**Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,\
+  \ not problems with the draft.** The draft is unchanged because the content was\
+  \ already correct.\\n\\n**Root cause:** The `wiki_compressor._tokenize()` function\
+  \ applies NFKD normalization + combining-mark stripping, which converts Ukrainian\
+  \ \\\"й\\\" (U+0439 = и + combining breve) → \\\"и\\\" (U+0438). So \\\"білий\\\"\
+  \ becomes \\\"білии\\\" in the anchor terms. But `_missing_terms()` in the compliance\
+  \ checker did raw substring matching without the same normalization — it looked\
+  \ for \\\"білии\\\" in text containing \\\"білий\\\" and never found it.\\n\\n**Fix\
+  \ applied to `scripts/audit/checks/contract_compliance.py`:**\\n- Added `_strip_combining()`\
+  \ helper that applies the same NFKD + strip-combining normalization\\n- Updated\
+  \ `_missing_terms()` to normalize both the text and the terms before matching\\\
+  n- Added 2 tests to `tests/test_contract_compliance.py` covering both the unit function\
+  \ and end-to-end integration\\n\\nThis was a systemic bug — every Ukrainian word\
+  \ ending in \\\"й\\\" would fail as a factual anchor term. The fix resolves this\
+  \ for all modules, not just colors.\"\n  replace: \"\"\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-plan_adherence-r1.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-plan_adherence-r1.yaml
@@ -1,0 +1,117 @@
+slug: colors
+round: 1
+dimension: plan_adherence
+name: Plan Adherence
+score: 8.5
+verdict: REVISE
+evidence: '- Українською: «Діалог 1 — Вибір букета на квітковому ринку (за мотивами
+  вірша про кольори з підручника Большакової для 2 класу, с. 38)» English: Section
+  1 correctly follows the pedagogy source and...'
+findings:
+- dimension: PLAN_ADHERENCE
+  severity: major
+  location: End of module text (after Section 4)
+  issue: 'Українською: Модуль містить технічний звіт про помилки лінтера («Important:
+    The errors were false positives...») безпосередньо в тексті уроку.
+
+    English: The module includes a technical report about linter bugs and normalization
+    issues ("Root cause: The wiki_compressor._tokenize()...") inside the educational
+    content. This violates the "Banned Error Patterns: Meta-narration" rule.'
+  fix: 'Remove all text following the end of Section 4 (the part starting with "**Important:
+    The errors were false positives...**").'
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Відсутній обов''язковий термін «Діалог». Замість нього використано
+    англійське «Dialogue 1».
+
+    English: Missing required term "Діалог". The writer used the English heading "Dialogue
+    1" instead.'
+  fix: Replace "Dialogue 1" with "Діалог 1" and "Dialogue 2" with "Діалог 2".
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Невідповідність сценарію. План секції 1 вимагає «Опис кімнати»
+    (стіл, крісло), але текст описує «Вибір вбрання» (сукня, светр).
+
+    English: Scenario mismatch. Section 1 teaching beats required a room description
+    (table, chair), but the dialogue describes choosing clothes (dress, sweater).
+    Note: This matches the `dialogue_acts` specification in the contract, but creates
+    a discrepancy with the `teaching_beats`.'
+  fix: None required (prioritizing `dialogue_acts` adherence), but worth noting for
+    consistency.
+fixes:
+- find: Dialogue 1
+  replace: Діалог 1
+- find: Dialogue 2
+  replace: Діалог 2
+- find: '---
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:** - Added `_strip_combining()`
+    helper that applies the same NFKD + strip-combining normalization - Updated `_missing_terms()`
+    to normalize both the text and the terms before matching - Added 2 tests to `tests/test_contract_compliance.py`
+    covering both the unit function and end-to-end integration
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: ''
+rewrite_blocks: []
+review_text: "## Dimension\nid: plan_adherence\nname: Plan Adherence\nscore: 8.5/10\n\
+  verdict: REVISE\n\n## Evidence\n- Українською: «Діалог 1 — Вибір букета на квітковому\
+  \ ринку (за мотивами вірша про кольори з підручника Большакової для 2 класу, с.\
+  \ 38)»\n  English: Section 1 correctly follows the pedagogy source and scenario\
+  \ for the flower market.\n- Українською: «українській мові для позначення 'blue'\
+  \ ми активно вчимо пару окремих слів — синій і блакитний»\n  English: Section 3\
+  \ implements the mandatory \"blue vs light blue\" distinction.\n- Українською: «карі\
+  \ очі й русяве волосся»\n  English: The module correctly provides fixed collocations\
+  \ for appearance as chunks.\n\n## Findings\n[PLAN_ADHERENCE] [SEVERITY: major]\n\
+  Location: End of module text (after Section 4)\nIssue: Українською: Модуль містить\
+  \ технічний звіт про помилки лінтера («Important: The errors were false positives...»)\
+  \ безпосередньо в тексті уроку.\nEnglish: The module includes a technical report\
+  \ about linter bugs and normalization issues (\"Root cause: The wiki_compressor._tokenize()...\"\
+  ) inside the educational content. This violates the \"Banned Error Patterns: Meta-narration\"\
+  \ rule.\nFix: Remove all text following the end of Section 4 (the part starting\
+  \ with \"**Important: The errors were false positives...**\").\n\n[PLAN_ADHERENCE]\
+  \ [SEVERITY: minor]\nLocation: Section 1 (Діалоги)\nIssue: Українською: Відсутній\
+  \ обов'язковий термін «Діалог». Замість нього використано англійське «Dialogue 1».\n\
+  English: Missing required term \"Діалог\". The writer used the English heading \"\
+  Dialogue 1\" instead.\nFix: Replace \"Dialogue 1\" with \"Діалог 1\" and \"Dialogue\
+  \ 2\" with \"Діалог 2\".\n\n[PLAN_ADHERENCE] [SEVERITY: minor]\nLocation: Section\
+  \ 1 (Діалоги)\nIssue: Українською: Невідповідність сценарію. План секції 1 вимагає\
+  \ «Опис кімнати» (стіл, крісло), але текст описує «Вибір вбрання» (сукня, светр).\n\
+  English: Scenario mismatch. Section 1 teaching beats required a room description\
+  \ (table, chair), but the dialogue describes choosing clothes (dress, sweater).\
+  \ Note: This matches the `dialogue_acts` specification in the contract, but creates\
+  \ a discrepancy with the `teaching_beats`.\nFix: None required (prioritizing `dialogue_acts`\
+  \ adherence), but worth noting for consistency.\n\n## Verdict Reason\nThe module\
+  \ is exceptionally strong in covering the 12-color target and correctly distinguishing\
+  \ between the hard and soft stems (синій). It accurately implements all appearance\
+  \ collocations and complex color rules (темно-/світло-). However, it contains significant\
+  \ meta-narration in the form of a technical bug report included in the lesson text,\
+  \ and misses the simple required term \"Діалог\".\n\n<fixes>\n- find: \"Dialogue\
+  \ 1\"\n  replace: \"Діалог 1\"\n- find: \"Dialogue 2\"\n  replace: \"Діалог 2\"\n\
+  - find: \"---\n\n**Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,\
+  \ not problems with the draft.** The draft is unchanged because the content was\
+  \ already correct.\n\n**Root cause:** The `wiki_compressor._tokenize()` function\
+  \ applies NFKD normalization + combining-mark stripping, which converts Ukrainian\
+  \ \\\"й\\\" (U+0439 = и + combining breve) → \\\"и\\\" (U+0438). So \\\"білий\\\"\
+  \ becomes \\\"білии\\\" in the anchor terms. But `_missing_terms()` in the compliance\
+  \ checker did raw substring matching without the same normalization — it looked\
+  \ for \\\"білии\\\" in text containing \\\"білий\\\" and never found it.\n\n**Fix\
+  \ applied to `scripts/audit/checks/contract_compliance.py`:**\n- Added `_strip_combining()`\
+  \ helper that applies the same NFKD + strip-combining normalization\n- Updated `_missing_terms()`\
+  \ to normalize both the text and the terms before matching\n- Added 2 tests to `tests/test_contract_compliance.py`\
+  \ covering both the unit function and end-to-end integration\n\nThis was a systemic\
+  \ bug — every Ukrainian word ending in \\\"й\\\" would fail as a factual anchor\
+  \ term. The fix resolves this for all modules, not just colors.\"\n  replace: \"\
+  \"\n</fixes>"

--- a/curriculum/l2-uk-en/a1/review/colors-review-plan_adherence.yaml
+++ b/curriculum/l2-uk-en/a1/review/colors-review-plan_adherence.yaml
@@ -1,0 +1,117 @@
+slug: colors
+round: 1
+dimension: plan_adherence
+name: Plan Adherence
+score: 8.5
+verdict: REVISE
+evidence: '- Українською: «Діалог 1 — Вибір букета на квітковому ринку (за мотивами
+  вірша про кольори з підручника Большакової для 2 класу, с. 38)» English: Section
+  1 correctly follows the pedagogy source and...'
+findings:
+- dimension: PLAN_ADHERENCE
+  severity: major
+  location: End of module text (after Section 4)
+  issue: 'Українською: Модуль містить технічний звіт про помилки лінтера («Important:
+    The errors were false positives...») безпосередньо в тексті уроку.
+
+    English: The module includes a technical report about linter bugs and normalization
+    issues ("Root cause: The wiki_compressor._tokenize()...") inside the educational
+    content. This violates the "Banned Error Patterns: Meta-narration" rule.'
+  fix: 'Remove all text following the end of Section 4 (the part starting with "**Important:
+    The errors were false positives...**").'
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Відсутній обов''язковий термін «Діалог». Замість нього використано
+    англійське «Dialogue 1».
+
+    English: Missing required term "Діалог". The writer used the English heading "Dialogue
+    1" instead.'
+  fix: Replace "Dialogue 1" with "Діалог 1" and "Dialogue 2" with "Діалог 2".
+- dimension: PLAN_ADHERENCE
+  severity: minor
+  location: Section 1 (Діалоги)
+  issue: 'Українською: Невідповідність сценарію. План секції 1 вимагає «Опис кімнати»
+    (стіл, крісло), але текст описує «Вибір вбрання» (сукня, светр).
+
+    English: Scenario mismatch. Section 1 teaching beats required a room description
+    (table, chair), but the dialogue describes choosing clothes (dress, sweater).
+    Note: This matches the `dialogue_acts` specification in the contract, but creates
+    a discrepancy with the `teaching_beats`.'
+  fix: None required (prioritizing `dialogue_acts` adherence), but worth noting for
+    consistency.
+fixes:
+- find: Dialogue 1
+  replace: Діалог 1
+- find: Dialogue 2
+  replace: Діалог 2
+- find: '---
+
+    **Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,
+    not problems with the draft.** The draft is unchanged because the content was
+    already correct.
+
+    **Root cause:** The `wiki_compressor._tokenize()` function applies NFKD normalization
+    + combining-mark stripping, which converts Ukrainian "й" (U+0439 = и + combining
+    breve) → "и" (U+0438). So "білий" becomes "білии" in the anchor terms. But `_missing_terms()`
+    in the compliance checker did raw substring matching without the same normalization
+    — it looked for "білии" in text containing "білий" and never found it.
+
+    **Fix applied to `scripts/audit/checks/contract_compliance.py`:** - Added `_strip_combining()`
+    helper that applies the same NFKD + strip-combining normalization - Updated `_missing_terms()`
+    to normalize both the text and the terms before matching - Added 2 tests to `tests/test_contract_compliance.py`
+    covering both the unit function and end-to-end integration
+
+    This was a systemic bug — every Ukrainian word ending in "й" would fail as a factual
+    anchor term. The fix resolves this for all modules, not just colors.'
+  replace: ''
+rewrite_blocks: []
+review_text: "## Dimension\nid: plan_adherence\nname: Plan Adherence\nscore: 8.5/10\n\
+  verdict: REVISE\n\n## Evidence\n- Українською: «Діалог 1 — Вибір букета на квітковому\
+  \ ринку (за мотивами вірша про кольори з підручника Большакової для 2 класу, с.\
+  \ 38)»\n  English: Section 1 correctly follows the pedagogy source and scenario\
+  \ for the flower market.\n- Українською: «українській мові для позначення 'blue'\
+  \ ми активно вчимо пару окремих слів — синій і блакитний»\n  English: Section 3\
+  \ implements the mandatory \"blue vs light blue\" distinction.\n- Українською: «карі\
+  \ очі й русяве волосся»\n  English: The module correctly provides fixed collocations\
+  \ for appearance as chunks.\n\n## Findings\n[PLAN_ADHERENCE] [SEVERITY: major]\n\
+  Location: End of module text (after Section 4)\nIssue: Українською: Модуль містить\
+  \ технічний звіт про помилки лінтера («Important: The errors were false positives...»)\
+  \ безпосередньо в тексті уроку.\nEnglish: The module includes a technical report\
+  \ about linter bugs and normalization issues (\"Root cause: The wiki_compressor._tokenize()...\"\
+  ) inside the educational content. This violates the \"Banned Error Patterns: Meta-narration\"\
+  \ rule.\nFix: Remove all text following the end of Section 4 (the part starting\
+  \ with \"**Important: The errors were false positives...**\").\n\n[PLAN_ADHERENCE]\
+  \ [SEVERITY: minor]\nLocation: Section 1 (Діалоги)\nIssue: Українською: Відсутній\
+  \ обов'язковий термін «Діалог». Замість нього використано англійське «Dialogue 1».\n\
+  English: Missing required term \"Діалог\". The writer used the English heading \"\
+  Dialogue 1\" instead.\nFix: Replace \"Dialogue 1\" with \"Діалог 1\" and \"Dialogue\
+  \ 2\" with \"Діалог 2\".\n\n[PLAN_ADHERENCE] [SEVERITY: minor]\nLocation: Section\
+  \ 1 (Діалоги)\nIssue: Українською: Невідповідність сценарію. План секції 1 вимагає\
+  \ «Опис кімнати» (стіл, крісло), але текст описує «Вибір вбрання» (сукня, светр).\n\
+  English: Scenario mismatch. Section 1 teaching beats required a room description\
+  \ (table, chair), but the dialogue describes choosing clothes (dress, sweater).\
+  \ Note: This matches the `dialogue_acts` specification in the contract, but creates\
+  \ a discrepancy with the `teaching_beats`.\nFix: None required (prioritizing `dialogue_acts`\
+  \ adherence), but worth noting for consistency.\n\n## Verdict Reason\nThe module\
+  \ is exceptionally strong in covering the 12-color target and correctly distinguishing\
+  \ between the hard and soft stems (синій). It accurately implements all appearance\
+  \ collocations and complex color rules (темно-/світло-). However, it contains significant\
+  \ meta-narration in the form of a technical bug report included in the lesson text,\
+  \ and misses the simple required term \"Діалог\".\n\n<fixes>\n- find: \"Dialogue\
+  \ 1\"\n  replace: \"Діалог 1\"\n- find: \"Dialogue 2\"\n  replace: \"Діалог 2\"\n\
+  - find: \"---\n\n**Important: The errors were false positives from a bug in `scripts/audit/checks/contract_compliance.py`,\
+  \ not problems with the draft.** The draft is unchanged because the content was\
+  \ already correct.\n\n**Root cause:** The `wiki_compressor._tokenize()` function\
+  \ applies NFKD normalization + combining-mark stripping, which converts Ukrainian\
+  \ \\\"й\\\" (U+0439 = и + combining breve) → \\\"и\\\" (U+0438). So \\\"білий\\\"\
+  \ becomes \\\"білии\\\" in the anchor terms. But `_missing_terms()` in the compliance\
+  \ checker did raw substring matching without the same normalization — it looked\
+  \ for \\\"білии\\\" in text containing \\\"білий\\\" and never found it.\n\n**Fix\
+  \ applied to `scripts/audit/checks/contract_compliance.py`:**\n- Added `_strip_combining()`\
+  \ helper that applies the same NFKD + strip-combining normalization\n- Updated `_missing_terms()`\
+  \ to normalize both the text and the terms before matching\n- Added 2 tests to `tests/test_contract_compliance.py`\
+  \ covering both the unit function and end-to-end integration\n\nThis was a systemic\
+  \ bug — every Ukrainian word ending in \\\"й\\\" would fail as a factual anchor\
+  \ term. The fix resolves this for all modules, not just colors.\"\n  replace: \"\
+  \"\n</fixes>"

--- a/docs/reports/2026-04-23-anthropic-postmortem-impact.md
+++ b/docs/reports/2026-04-23-anthropic-postmortem-impact.md
@@ -1,0 +1,125 @@
+# Anthropic April 23 Postmortem — Impact on `learn-ukrainian` Pipeline
+
+**Author:** curriculum-maintainer (Opus research session)
+**Source:** https://www.anthropic.com/engineering/april-23-postmortem
+**Scope:** read-only research; no code changes in this session
+
+---
+
+## 1. What the postmortem actually says
+
+Anthropic's April 23 postmortem covers **three independent quality regressions** in Claude Code, the Claude Agent SDK, and Claude Cowork between early March and April 20. The raw Anthropic API was **not** affected — the postmortem is explicit: *"The API was not impacted."* That distinction matters for us: every one of our pipeline paths goes through the Claude Code CLI (`npx @anthropic-ai/claude-code@latest -p`), so we sit squarely in the affected blast radius.
+
+The three issues:
+
+- **Issue #1 — reasoning-effort default silently dropped (Mar 4 – Apr 7)**, affecting Sonnet 4.6 and Opus 4.6. Anthropic flipped the default reasoning effort from `high` to `medium` because *"in our internal evals and testing, medium effort achieved slightly lower intelligence with significantly less latency for the majority of tasks."* Customers rejected the trade-off. Reverted on April 7; Opus 4.7 now defaults to `xhigh`.
+- **Issue #2 — prompt-cache "clear thinking" bug (Mar 26 – Apr 10)**, affecting Sonnet 4.6 and Opus 4.6. Intent: *"if a session has been idle for more than an hour, we could reduce users' cost of resuming that session by clearing old thinking sections."* Actual behavior: the `clear_thinking_20251015` API header with `keep:1` flag *"executed on every turn thereafter, not once."* Result: *"each request for the rest of that process told the API to keep only the most recent block of reasoning and discard everything before it."* Symptoms: forgetfulness, repetition, odd tool choices, faster usage-limit drain (cache misses). Fixed in v2.1.101.
+- **Issue #3 — length-limit system prompt (Apr 16 – Apr 20)**, affecting Sonnet 4.6, Opus 4.6, **and Opus 4.7**. Anthropic added the line *"Length limits: keep text between tool calls to ≤25 words. Keep final responses to ≤100 words unless the task requires more detail."* to the Claude Code system prompt. Ablation showed *"a 3% drop for both Opus 4.6 and 4.7."* Reverted in v2.1.116.
+
+Residual behavior change shipping as a result: **Opus 4.7 default effort is now `xhigh`** (not `high`), and **Sonnet 4.6+ default is `high`**. Usage limits were reset for all subscribers on April 23. Anthropic also notes *"Two unrelated experiments made it challenging for us to reproduce the issue at first"* — i.e. the regression took weeks to triage because two changes interacted.
+
+---
+
+## 2. Our exposure during the incident window
+
+Every Claude call in this repo flows through `scripts/agent_runtime/adapters/claude.py`, which exec's `npx @anthropic-ai/claude-code@latest` (or a local `claude` binary) in `-p` print mode. Three call paths:
+
+| Path | File | Session? | Effort flag? | Affected by |
+|---|---|---|---|---|
+| Pipeline writer/reviewer | `scripts/build/dispatch.py:_dispatch_claude_via_runtime` | **No** (`session_id=None`, fresh per call) | **No** (`effort` not passed) | #1 (Mar 4 – Apr 7), #3 (Apr 16 – Apr 20) |
+| Inter-agent bridge | `scripts/ai_agent_bridge/_claude.py:_run_claude_sync_via_runtime` | **Yes** (`--resume` for cache warmth) | **No** | #1, **#2 worst-case**, #3 |
+| `delegate.py` headless dispatches | `scripts/delegate.py` | No (worktree-scoped, fresh) | Optional `--effort` arg | #1, #3 |
+| Interactive session (this one) | `claude_extensions/settings.json` `effortLevel: "high"` | n/a | Hardcoded `high` (not `xhigh`) | #1, #3 |
+
+Concrete consequences:
+
+**a. Five-week window of degraded writer/reviewer reasoning (Mar 4 – Apr 7).** `dispatch.py` builds the Claude invocation with `model=CLAUDE_MODEL_CORE_CONTENT` (which resolves to `claude-opus-4-6` per `scripts/batch/batch_gemini_config.py:84`) and **never sets `effort`**. The adapter only forwards `--effort` when the caller passes it — so during the incident our writer/reviewer phases inherited Anthropic's silently-flipped `medium` default. Every module built in that window — and every reviewer pass — ran below the intended reasoning floor. This is consistent with otherwise inexplicable score variability we saw in late March.
+
+**b. Bridge sessions hit Issue #2 directly.** `_run_claude_sync_via_runtime` deliberately uses `--resume <uuid>` to keep the prompt cache warm across turns (project policy in `agent-runtime-guide.md`: *"Cache economics — 95% of our tokens are cache reads. Dropping resume here would reproduce the 2026-03-21 cost fiasco"*). That is exactly the surface area Issue #2 corrupted — a session idle >1h would, on every subsequent turn, discard prior reasoning blocks. Symptoms in the postmortem (*forgetfulness, repetition, odd tool choices*) match anecdotes from `ab discuss` and `ab channel` long threads in early April.
+
+**c. Pipeline calls were partially insulated from Issue #2** because `dispatch.py` passes `session_id=None` (each pipeline call is fresh, no `--resume`). The cache-clearing bug needed a session that had thinking history to clear. So core builds were less hit than bridge conversations.
+
+**d. April 16–20 length-limit instruction affected ALL three paths** including Opus 4.7. The instruction lived in Claude Code's *internal* system prompt; our `--bare` flag (auto-enabled when stateless + `ANTHROPIC_API_KEY` set, per `claude.py:139`) skips hooks/LSP/plugins but does **not**, per the CLI docs, strip Claude Code's own system prompt. So we ate the 3% drop on writer + reviewer + bridge during that window.
+
+**e. Silent masking in our retry logic.** `_RATE_LIMIT_PATTERNS` in both `dispatch.py` and `claude.py` only catches stderr containing `429`, `rate limit`, `quota exceeded`, etc. The cache-clearing bug emitted **no error signal** — degraded outputs returned `returncode=0` with `result.ok=True`. Our pipeline happily wrote them to disk and ran the reviewer (also degraded) over them. There is no fingerprint in our telemetry that would let us identify which artifacts were produced under the bug.
+
+---
+
+## 3. Required changes (priority-ranked)
+
+### Must change before next build run
+
+| # | What | Why | Effort | Owner | Blocker? |
+|---|---|---|---|---|---|
+| 1 | **Pin `effort="xhigh"` explicitly in `_dispatch_claude_via_runtime`** for writer/reviewer calls. Add a parameter `effort: str | None` to `dispatch_agent` that defaults to `"xhigh"` for `claude-tools` writer and `"high"` for cheaper reviewer modes. Pass it through to `runtime_invoke(..., effort=effort)`. The runtime + adapter already support it (`adapters/claude.py:97-177` is wired and version-gated via `utils.claude_version.supports_effort`). | Prevents recurrence of Issue #1 (silent default flip). Quote: *"Default reasoning effort changed from `high` to `medium` to reduce latency."* Our pipeline must never inherit a default we don't control. | S | claude/codex | **YES** — every build until this lands could re-degrade if Anthropic flips defaults again |
+| 2 | **Bump `CLAUDE_OPUS = "claude-opus-4-7"`** in `scripts/batch/batch_gemini_config.py:84`, and the corresponding `default_model` in `scripts/agent_runtime/adapters/claude.py:84` and `scripts/agent_runtime/registry.py:53`. Add `claude-sonnet-4-6` → `claude-sonnet-4-7` if/when available. The pipeline rule (`.claude/rules/pipeline.md`) already documents `claude-opus-4-7 @ xhigh` as the default — config has not caught up. | Opus 4-6 is the model the postmortem says was hit by all three issues; Opus 4-7 was hit only by Issue #3 (now fixed). MEMORY.md says *"use `xhigh` where we previously used `high`"* — implies 4-7. | S | claude | **YES** — drift between rule docs and config is a known landmine (#1456 supersede pattern) |
+| 3 | **Update `.claude/settings.json` (and `claude_extensions/settings.json`) `effortLevel: "high"` → `"xhigh"`.** | MEMORY.md explicitly states *"Anthropic notes Opus 4.7 at `high` is weaker than prior versions, so use `xhigh` where we previously used `high`."* Settings.json never followed. Today's session is running at `high` while reviewing this very postmortem. | S | claude | **YES** — affects every interactive curriculum-maintainer session |
+| 4 | **Add a Claude CLI minimum-version gate** in `agent_runtime/runner.py` that raises `AgentUnavailableError` if `--version` < `2.1.116`. Reuse `utils.claude_version` infrastructure that already probes the binary; add a new `supports_postmortem_fixes()` helper with `_MIN_VERSION = (2, 1, 116)`. Block pipeline + bridge if violated; warn on `delegate.py`. | The version that closed all three bugs. Running an older CLI silently regresses us. Quote: *"April 20 (v2.1.116): Reverted system prompt instruction."* | S | claude | **YES** — five minutes of work, prevents stale-binary regression |
+
+### Should change this week
+
+| # | What | Why | Effort | Owner |
+|---|---|---|---|---|
+| 5 | **Telemetry: log `effort`, `model`, `claude_cli_version` per call** in `agent_runtime/usage.py` JSONL records and `build_stats.jsonl`. Today we record `agent`, `model`, `duration_s`, `tokens` — not `effort`, not CLI version. | Anthropic took weeks to triage their own bug because *"two unrelated experiments made it challenging for us to reproduce."* If we hit a quality regression, we cannot today say "all degraded modules were built with effort=medium under CLI 2.1.103." We need per-call provenance. | M | codex |
+| 6 | **Add a stderr/stdout sanity check that flags anomalously short Claude responses** (e.g. <500 chars from a writer phase whose prompt asks for ≥4000-word output). Today we record `response_chars` in `_save_dispatch_log` but don't act on it. A length-limit-style regression in the future would manifest as truncated outputs. | Direct prevention against Issue #3 recurrence. The postmortem's instruction reduced response length AND reduced intelligence — we should fail fast on the length signal. | S | codex |
+| 7 | **Tag modules built between 2026-03-04 and 2026-04-20 in `status/{slug}.json`** with an `incident_window: true` flag and a one-line note pointing to this report. | A1 has 31 audit-passing + 40 reviewed modules per the Monitor API; many were built during the window. The next batch-review pass should know which to re-score under stricter conditions. Doesn't force a re-run — just makes the metadata honest. | S | claude |
+| 8 | **Bridge: drop `--resume` if the prior session's last activity is >55 minutes old** (just under the 1h trigger Anthropic cited). Mint a fresh session instead, re-prepend the channel `context.md`. Cost: one cache miss; benefit: avoids the exact Issue #2 trigger if it recurs. | Quote: *"if a session has been idle for more than an hour, we could reduce users' cost of resuming that session by clearing old thinking sections."* Even though Anthropic fixed the *bug* implementation, the *feature* is still alive — and idle-session resumption is the trigger. Forcing a fresh session at the cliff edge sidesteps the entire failure class. | M | claude |
+
+### Nice to have
+
+| # | What | Why | Effort | Owner |
+|---|---|---|---|---|
+| 9 | Document a "model & CLI pin" decision in `docs/decisions/` with a 6-month expiry. Forces a recurring re-evaluation of which Anthropic defaults we trust. | Decision-journal hygiene. Today there is no record of *why* we use 4-6 vs 4-7. | S | claude |
+| 10 | Add a `npm run claude:doctor` script that prints CLI version, configured `effortLevel`, and a green/yellow/red verdict against this report's recommendations. | Operator UX. New contributors should see "your CLI is 2.1.103 — too old, please upgrade" without reading 2000 words of postmortem. | M | codex |
+| 11 | Update `docs/SCRIPTS.md` and `docs/agent-runtime-guide.md` with an explicit "the `effort` parameter is REQUIRED, not optional" section. Today the guide treats it as one of many kwargs. | Onboarding correctness. Issue #1 will reappear in some other form; our defense is "we always pin effort, period." | S | human |
+
+---
+
+## 4. Behaviors we should ADOPT from the postmortem
+
+1. **Ablation testing for any system-prompt or template change.** Anthropic measured *"a 3% drop for both Opus 4.6 and 4.7"* from a one-line instruction. Our `colors` rebuild diagnostic (#1449) traced multi-point dim drops to a single `_extract_terms` heuristic — same pattern. Whenever we touch a phase template or a writer/reviewer prompt, run before/after on a held-out module and measure the dim deltas. Add this to the existing `prompt-template-review` skill workflow.
+
+2. **Pin everything; treat upstream defaults as breaking changes.** The lesson Anthropic learned the expensive way is "users had calibrated expectations against `high`; flipping to `medium` violated those expectations even though it was technically a 'small' regression." Our equivalent: never inherit `--effort`, never inherit `--model`, never inherit `--output-format`. Always pass them explicitly, even when they match today's default.
+
+3. **Per-call provenance in telemetry.** The postmortem's reproduction difficulty came down to "we couldn't tell which calls had which behavior." Our `batch_state/api_usage/*.jsonl` records should include `effort`, `model`, `cli_version`, `--bare?`, `--resume?` so that any future regression can be A/B-attributed against an exact configuration.
+
+4. **Acknowledge that "low-cost optimizations" mutate cache semantics.** Anthropic's `clear_thinking_20251015` was a cost-optimization that turned into a quality bug. Our equivalent risk surface: `--exclude-dynamic-system-prompt-sections` (CC 2.1.98+, which we enable via version gate). Worth a brief audit to confirm it doesn't silently strip something we depend on. Tracked in section 6 below.
+
+---
+
+## 5. Behaviors we should NOT adopt
+
+- **The `clear_thinking_20251015` API header itself.** That is internal Anthropic protocol used by Claude Code to talk to its backend. We are downstream of Claude Code; we do not — and should not — inject API headers into the conversation. Don't try to "manage" the cache from our side beyond what `--bare` / `--resume` already give us.
+- **Anthropic's internal "two-week eval cycle"** before reverting Issue #1. We are smaller, faster, and our user is one person who can make a unilateral call within hours. We should not adopt a heavy formal eval gate before reverting our own bad changes.
+- **The length-limit system instruction itself**, even paraphrased. Our writer prompts already have *minimum* word targets (1200 / 2000 / 4000 / 5000 per CEFR level). Adding "keep responses brief" anywhere in the writer/reviewer chain would be the exact antipattern the postmortem flagged. Existing project rule (NON-NEGOTIABLE-RULES.md #1) already enforces this; nothing to add.
+- **Verbatim copy of Anthropic's "ablation = subtract one line and re-eval" workflow** as a hard gate. We should adopt the *spirit* (measure before/after) but not the *cost* (Anthropic ablated against an internal eval suite we don't have). Our equivalent is the strict-reviewer multi-dim score on a held-out module, which is cheaper.
+
+---
+
+## 6. Open questions for Krisztian
+
+1. **Switch default `CLAUDE_OPUS` from `claude-opus-4-6` to `claude-opus-4-7`?** The postmortem confirms 4-7 is the path forward and was hit only by Issue #3 (now fixed). Effort-cost increases (xhigh > high), but quality is non-negotiable per project policy. Recommended: yes. Need your sign-off because it affects per-build quota burn.
+
+2. **Re-review or re-build modules created Mar 4 – Apr 20?** Tagging them (Required Change #7) is cheap; actually re-running them is expensive. The 31 A1 audit-passing modules + 40 reviewed are the immediate question. Do we treat this window as a "trust but verify" tier (re-review only, no rebuild) or as a "rebuild from scratch" tier?
+
+3. **Audit `--exclude-dynamic-system-prompt-sections` for our use case?** It's enabled today (CC 2.1.98+ gate). Anthropic's track record on cache-related optimizations is now explicitly mixed (Issue #2). Should I dispatch a Codex investigation to confirm it doesn't silently strip something we depend on (e.g. project-scoped CLAUDE.md sections)?
+
+---
+
+## Appendix — files touched (read-only)
+
+```
+scripts/agent_runtime/adapters/claude.py        (read)
+scripts/agent_runtime/runner.py                 (grep)
+scripts/utils/claude_version.py                 (read)
+scripts/build/dispatch.py                       (read 1-120, 350-650)
+scripts/build/v6_build.py                       (grep)
+scripts/ai_agent_bridge/_claude.py              (read)
+scripts/batch/batch_gemini_config.py            (grep)
+.claude/settings.json                           (read)
+claude_extensions/settings.json                 (read)
+docs/agent-runtime-guide.md                     (read)
+docs/session-state/2026-04-23-late-evening-handoff.md  (read)
+```
+
+No source code modified. No commits. No worktree. Active Codex dispatches on EPIC #1451 Phase 1 (worktrees `codex-1452-alignment-manifest`, `codex-1453-sidecar-freshness`) untouched.

--- a/docs/session-state/2026-04-23-afternoon-discipline-handoff.md
+++ b/docs/session-state/2026-04-23-afternoon-discipline-handoff.md
@@ -1,0 +1,168 @@
+# Session Handoff — 2026-04-23 afternoon (wiki + module writer discipline)
+
+> User was away ~2 hours; I built a working solution for "correct wiki
+> writing prompt for Gemini with Codex" + "proper module writing and
+> reviewing prompt" as asked, tested + committed + pushed + opened PR.
+
+## What you come back to — **6 PRs waiting for your merge**
+
+| # | Title | Status |
+|---|---|---|
+| **1447** | **feat(discipline): canonical-anchor registry + citation-bound prompts for module and wiki writers** | THE wiki+module discipline PR. **Single-commit, 143 tests green.** Read its body carefully. |
+| 1446 | feat(quality): review-and-lock how-many wiki + plan | Scale-lock batch |
+| 1445 | Backfill wiki source attribution metadata (#1435) | Codex delivered its own PR this time (good) |
+| 1444 | feat(quality): review-and-lock what-is-it-like wiki + plan | Scale-lock batch |
+| 1443 | feat(quality): review-and-lock things-have-gender wiki + plan | Scale-lock batch |
+| 1442 | fix(wiki): strip Gemini MCP warning + collapse duplicate generated_by_model | Landed on main by me (Codex didn't push) |
+
+**Merge order recommendation** when you return:
+1. **#1447 first** (wiki+module discipline — every subsequent wiki compile benefits)
+2. #1442 (cosmetic MCP warning strip — also benefits compiles)
+3. #1445 (backfill — after #1447 the discipline is in place so backfill writes clean metadata)
+4. #1443 / #1444 / #1446 (scale-locks — independent, any order)
+
+## Main work delivered — PR #1447 (the big one)
+
+Fixes both failure classes surfaced today:
+
+- **«блакитний» for flag** (a1/colors #1431 v2 smoke) — decolonization-critical
+  factual hallucination
+- **`[S6]`/`[S7]` phantom citations** (b2/academic-writing) — writer invents
+  citation IDs past actual retrieval count
+
+Both are LLM-drift-back-to-pre-training-mid-output failures. Prompt discipline
+(80% fix) + mechanical post-pass validator (remaining 20%) plugs the gap.
+
+**What landed:**
+- `data/canonical_anchors.yaml` — 18 shared anchors (flag, trident, anthem,
+  capital, currency, papa/тато, «фамілія», Kiev/Kyiv, Holodomor dates, current
+  president/PM, literary canon safe vs excluded, etc.)
+- `scripts/wiki/discipline.py` — mechanical validators + strip/flag repair +
+  prompt block renderers (Ukrainian writer / English reviewer)
+- **All 4 wiki writer prompts** get `{citation_discipline}` +
+  `{canonical_anchors}` — the writer is now told explicitly "only cite [S1]..[SN]"
+  and given the canonical-anchor table
+- Wiki compile pipeline auto-repairs after write (strips phantom citations,
+  flags forbidden anchor phrases with `<!-- VERIFY -->`)
+- **Module contract §7a** — full canonical-anchors contract
+- Module writer prompt + Factual/Honesty/Language reviewer prompts inject the
+  anchor block
+- 47 new tests (40 discipline + 7 pin)
+
+**Important caveats (documented in the PR body):**
+- Does NOT turn on fix-loop wiki review — still shadow mode. Separate PR worth
+  doing next.
+- Does NOT repair already-compiled wikis — that's #1445 (now unblocked).
+- Does NOT verify live MCP-retrieved chunks — deeper RAG integration, another
+  PR.
+
+## Other delivered this session
+
+- **#1439 merged** — #1434 compiler attribution fix (B2 wiki compile now
+  possible). You merged it when I asked.
+- **#1442** — compile-strip-mcp Codex delivery finalized by me (Codex pattern:
+  completed work but didn't commit).
+- **Default writer switched on main** — `claude-tools` (Opus). Commit
+  `5e2afbd092`. Any new A1 module build = Opus writer + Codex reviewer.
+
+## Running dispatches
+
+- `scale-how-many-review-and-lock` (Claude) — likely finishing; PR #1446
+  already exists, may have been opened mid-run
+- **All other dispatches completed and have open PRs** above
+
+Monitor `bx9efxhre` still armed on stale task list. Can be safely stopped.
+
+## a1/colors Opus rebuild — **stopped failing, not on disk anymore**
+
+I fired `v6_build.py a1 10 --writer claude-tools` earlier at user's direction
+("yes rerun it"). Opus started writing, but hit the `Contract compliance
+FAILED` event repeatedly (5–7 violations each round). Dispatch appears to
+have terminated. Module state is pre-verify complete, no `colors.md` written
+yet on main. Needs a fresh rebuild once PR #1447 lands so the writer prompt
+includes the canonical anchors.
+
+**Cause of Opus failure (speculative — need to inspect the contract-compliance
+report):** likely that Opus is hitting a rule the Gemini-tuned contract writer
+didn't enforce (e.g., word-budget overflow handling, section coverage). This
+is a separate issue from the discipline PR — worth a focused look tomorrow.
+
+## A1 lock progress
+
+- **14/55 locked** after this afternoon's merges
+- 3 more in PR queue (things-have-gender, what-is-it-like, how-many) →
+  17/55 once you merge #1443 / #1444 / #1446
+
+Next slugs in sequence order if you want to keep the scale-lock train moving:
+`this-and-that`, `many-things`, `i-have-i-dont-have`, `i-want-i-can`, ...
+
+## Open architectural questions for you
+
+1. **Pipeline module writer is now Opus by default** but `colors` failed
+   contract-compliance 5+ times on it. Before scaling module builds, worth
+   understanding whether the contract rules are Gemini-shaped (over-specified
+   for Opus) or whether Opus is genuinely failing real requirements. Read
+   `curriculum/l2-uk-en/a1/orchestration/colors/contract-compliance-write-r*.yaml`.
+
+2. **Wiki dim-review is still shadow mode** — with the discipline PR landed,
+   the next leverage point is turning on the real fix-loop (4 dims,
+   2 rounds). PR-sized work, maybe 1h.
+
+3. **#1286 review transport** worktree still has uncommitted code (partial fix
+   — AC 4-5 unmet). Worth deciding: commit partial, or wait for Codex 0.122.0
+   upstream fix.
+
+## What I'd recommend you do first on return
+
+1. **Merge #1447** (the discipline PR). That unblocks everything wiki-side.
+2. **Re-fire a1/colors build** with Opus writer to validate the new writer
+   prompt actually reduces the «блакитний» class of hallucination.
+3. **Merge the 5 other open PRs** in the order above.
+4. **Then** kick off B2 wiki compile batch if you want the backlog to move:
+   `compile.py --track b2 --all --force`. Post-#1447 articles will emit
+   `discipline_pass` / `discipline_repair` events per compile.
+
+## Services + environment (unchanged from morning handoff)
+
+- api:8765, sources MCP:8766, starlight:4321 — all healthy
+- `GEMINI_AUTH_MODE=subscription` still set in user shell
+- Gemini ladder: flash → 3.1-pro optimistic → 2.5-pro emergency (my mid-day
+  edit + revert landed it back at 3.1-pro → flash → 2.5-pro per your
+  correction)
+
+---
+
+## LATE FIND (post-handoff) — PR #1448 tokenizer bug
+
+While investigating why a1/colors Opus rebuild kept failing contract
+compliance, I traced it to a **Unicode normalization bug in
+`scripts/build/phases/wiki_compressor.py::_tokenize`**. NFKD decomposes
+`й` → `и + U+0306` and `ї` → `і + U+0308`; stripping ALL combining marks
+turned every Ukrainian token ending in й/ї into a non-word:
+
+- `білий` → `білии`
+- `жовтий` → `жовтии`
+- `блакитний` → `блакитнии`
+- `країна` → `краина`
+
+These corrupted tokens were written to plan `factual_anchors`,
+contract-compliance then demanded them literally, and Opus (writing
+correct Ukrainian) could never satisfy the check.
+
+**Fixed in PR #1448.** 10 new tests. The fix preserves U+0306/U+0308
+then recomposes via NFC. Separate PR from #1447 for clean blast-radius
+narrative.
+
+**Merge priority updated:**
+
+1. **#1448** (tokenizer bug — unblocks every future module build)
+2. **#1447** (wiki+module writer discipline)
+3. #1442 (compile-strip MCP warning)
+4. #1445 (attribution backfill)
+5. #1443 / #1444 / #1446 (scale-locks)
+
+After merging #1448, the a1/colors rebuild with `--writer claude-tools`
+should stop looping on impossible anchor matches and actually complete.
+Worth re-firing as the real v2 smoke test — if it passes, the AI-only
+pipeline viability question flips YES under (Opus writer + Codex
+reviewer + canonical anchors + clean tokenizer).

--- a/docs/session-state/2026-04-23-session-handoff-full.md
+++ b/docs/session-state/2026-04-23-session-handoff-full.md
@@ -1,0 +1,234 @@
+# Session Handoff — 2026-04-23 (full afternoon)
+
+> Built the wiki + module writer-discipline infrastructure you asked
+> for, found a critical tokenizer bug while testing, ran the first
+> real Opus writer smoke on a1/colors (6 dims pass, 3 fail for real),
+> and dispatched two focused Opus diagnostics on the failing dims.
+>
+> You return to: 7 open PRs queued for merge + 2 Opus diagnostics
+> running + a clear merge order + clear next move.
+
+---
+
+## 7 open PRs, merge in this exact order
+
+| # | Title | Why this order |
+|---|---|---|
+| **1448** | fix(build): preserve Cyrillic й/ї through NFKD in wiki_compressor tokenizer | **MUST land first.** Silent Unicode bug turning `білий→білии`, `жовтий→жовтии`, `країна→краина` in every plan's `factual_anchors`. Explains why Opus contract compliance kept failing 5×. Every future module build depends on this being right. |
+| **1447** | feat(discipline): canonical-anchor registry + citation-bound prompts | Shared registry + writer prompt discipline + mechanical validator + module contract §7a. Both wiki and module writers benefit. 143 tests green. |
+| **1442** | fix(wiki): strip Gemini MCP warning + idempotent generated_by_model | Cosmetic clean-up for compile logs; also collapses duplicate `generated_by_model:` entries. Small. |
+| **1445** | Backfill wiki source attribution metadata (#1435) | Rewrites ~227 existing `*.sources.yaml` with real attribution via the #1434 resolver. Land AFTER #1447 so any backfilled wikis land clean. |
+| **1443** | feat(quality): review-and-lock `things-have-gender` | Scale-lock batch (Claude Opus xhigh, 9/9/9/9/9) |
+| **1444** | feat(quality): review-and-lock `what-is-it-like` | Scale-lock batch |
+| **1446** | feat(quality): review-and-lock `how-many` | Scale-lock batch |
+
+**Also previously merged this session**: #1437 (special-signs lock),
+#1438 (checkpoint-first-contact lock), #1439 (#1434 compiler
+attribution), #1440 (#1431 v2 shared contract architectural fix),
+#1441 (#1403 auto-merge prevention).
+
+**On `main` directly**: writer default switched from `gemini-tools` →
+`claude-tools` (commit `5e2afbd092`). Any fresh A1 module build uses
+Opus writer + Codex reviewer.
+
+---
+
+## a1/colors Opus rebuild — the real #1431 viability smoke
+
+Fired earlier today as `v6_build.py a1 10 --writer claude-tools`.
+Completed through review. R1 aggregate:
+
+| Dim | Gemini v2 R2 | **Opus R1** | Δ |
+|---|---:|---:|---|
+| Factual | 5.0 | **8.0** | +3.0 ✅ |
+| Language | 7.4 | **10.0** | +2.6 🔥 |
+| Decolonization | 7.4 | **10.0** | +2.6 🔥 |
+| Completeness | 8.8 | 9.0 | +0.2 |
+| Plan Adherence | 7.4 | 8.5 | +1.1 ✅ |
+| Dialogue | 6.4 | 10.0 | +3.6 🔥 |
+| Actionable | 7.6 | **3.0** | **-4.6 ❌** |
+| Naturalness | 4.9 | **4.0** | -0.9 ❌ |
+| Honesty | 5.0 | **4.0** | -1.0 ❌ |
+
+MIN = 3.0 → REJECT. **BUT six dims passed, and the Factual/Language/
+Decolonization/Dialogue improvements are dramatic.** The «блакитний»-
+for-flag class of hallucination is **gone** with Opus.
+
+The three failing dims are *real writer-quality issues*, not bug
+artifacts:
+
+- **Actionable 3.0** — Opus produced code-switched pseudo-Ukrainian
+  English like `"This модуль taught узгодження кольорів using the
+  adjective правилами"`. Writer instructions leaked into student
+  prose.
+- **Naturalness 4.0** — Same code-switching: `"a вибір букета на
+  квітковому ринку"` forces Ukrainian nouns into English syntax
+  instead of bolded inline examples. v2 Gemini also failed this dim
+  (4.9) — pattern survives writer change.
+- **Honesty 4.0** — Opus **fabricated specific textbook citations**
+  ("Vashulenko Class 2 illustrates hard group with жовтий м'яч and
+  зелений листок" — that textbook doesn't teach the concept at that
+  grade and doesn't use those examples). Pre-training-leak into
+  corpus-grounded claims.
+
+---
+
+## Running now — 2 Opus diagnostics (90-min each)
+
+Both dispatched via `delegate.py`. Results land as PRs.
+
+### `claude-1449-colors-dim-diagnostics`
+
+Diagnoses root cause of the 3 failing module dims (Actionable,
+Naturalness, Honesty). Attribution among: **better plan / better
+wiki / better prompt / better corpus / additive writer rule**.
+
+Brief: `.worktree-briefs/claude-1449-colors-dim-diagnostics.md`
+Report will land at:
+`docs/reports/2026-04-23-a1-colors-opus-r1-dim-diagnosis.md`
+
+Told to IGNORE failures that are artifacts of #1447 / #1448 (the
+bug-report-meta-commentary inside the module), focus on what fails
+even with those merged.
+
+### `claude-1450-gemini-wiki-writer-diagnostic`
+
+Diagnoses what Gemini needs to write wiki sources correctly. Core
+failure evidence: invented `[S6]`/`[S7]`/`[S8]` citations in
+`b2/academic-writing.sources.yaml` (we verified `S2318`, `S746`,
+`S276` exist nowhere in sources.db). Pattern applies across many
+wikis.
+
+Deliberately NOT self-review: Opus diagnoses Gemini's output because
+different priors = different blind spots.
+
+Report will land at:
+`docs/reports/2026-04-23-gemini-wiki-writer-diagnosis.md`
+
+Both diagnostics are **diagnostic-only** — no code/prompt/plan
+changes land from them. They produce reports + ready-to-dispatch
+follow-up briefs. You approve before implementation.
+
+Monitor `bncr8m659` armed on both task IDs.
+
+---
+
+## Key findings today (for future you)
+
+1. **Opus writer DOES fix the factual-hallucination class** (flag
+   colors, Russianisms, decolonization framing) — Factual went
+   5.0→8.0, Decolonization 7.4→10.0, Language 7.4→10.0.
+
+2. **The remaining failure classes are different under Opus than
+   under Gemini**: Gemini failed on parametric fact leaks; Opus
+   fails on scaffolding-voice mixing (code-switching English+
+   Ukrainian) and on fabricated specific citations.
+
+3. **Infrastructure bugs were masking the real writer-quality
+   signal.** #1448 (tokenizer) meant contract-compliance demanded
+   impossible-to-satisfy Ukrainian forms and Opus kept trying for 5
+   rounds before giving up + writing a meta-commentary bug report
+   inside the module (!). That bug report then polluted the Honesty
+   dim score.
+
+4. **MIN≥8 rule is the right gate.** Six dims at 8+ and three at 3-4
+   is not "passing with caveats" — it's a real failure that needs
+   real fixes (or we mint a polished Potemkin module).
+
+---
+
+## What to do first when you return
+
+In order:
+
+1. **Read PR #1448 body first** — understand the tokenizer bug;
+   merge it.
+2. **Merge PR #1447** — canonical anchors + discipline.
+3. **Merge PR #1442** — compile-strip cosmetic.
+4. **Check status of the two diagnostic dispatches**. If they've
+   finished, you'll have 2 more PRs open with the diagnosis reports.
+   Read them before merging anything else.
+5. **Re-fire a1/colors build** after #1447 + #1448 merge:
+
+   ```
+   rm -rf curriculum/l2-uk-en/a1/orchestration/colors
+   rm curriculum/l2-uk-en/a1/colors.md
+   rm curriculum/l2-uk-en/a1/review/colors-*
+   .venv/bin/python scripts/build/v6_build.py a1 10 --writer claude-tools
+   ```
+
+   This is the REAL #1431 viability smoke — Opus writer + Codex
+   reviewer + canonical anchors + clean tokenizer + citation
+   discipline. Expected to cross MIN≥8 if the three failing dims
+   were genuinely artifact-dominated, or to cleanly reveal what
+   still breaks if they weren't.
+
+6. **Act on the two diagnostic reports** — each will include a
+   dispatch-ready follow-up brief. Approve or refine and fire.
+
+7. **Merge the scale-lock PRs** (#1443 / #1444 / #1446 / #1445) in
+   any order. They're independent.
+
+---
+
+## State of the pipeline
+
+- **A1 locks**: 14/55 on main; 17/55 once you merge the 3 scale-lock
+  PRs. ~38 A1 slugs left to lock. Next slugs in sequence:
+  `this-and-that`, `many-things`, `i-have-i-dont-have`, `i-want-i-can`.
+- **A1 modules**: 1 built end-to-end through v6 pipeline (colors,
+  which is our current REJECT). 0 passing MIN≥8. 40 legacy `.md`
+  files exist but predate current pipeline.
+- **Wiki compile**: B2 batch partially started (1 article compiled,
+  pending discipline rollout). Once #1447 + #1448 merge, safe to
+  kick off the full B2 batch (113 slugs).
+
+---
+
+## Services + environment
+
+All healthy:
+- api:8765 — monitor API
+- sources MCP:8766 — writer's retrieval tool
+- starlight:4321 — user-facing render of compiled wikis
+
+Shell state:
+- `GEMINI_AUTH_MODE=subscription` set
+- `GEMINI_API_KEY` unset (subscription mode)
+
+Gemini ladder (unchanged from pre-session):
+- rung 1: gemini-3.1-pro-preview (primary)
+- rung 2: gemini-3-flash-preview (fallback when 3.1-pro rate-limits)
+- rung 3: gemini-2.5-pro (emergency)
+
+---
+
+## Open architectural threads — pick up when you have time
+
+1. **Wiki dim-review is still in shadow mode** (`scripts/wiki/
+   review.py`). With #1447 landed, the next leverage is turning
+   fix-loop ON with a hard-gate. ~1h of work.
+2. **#1286 review transport** — worktree has uncommitted Codex work.
+   Partial fix (transport hardening works, live `task_complete`
+   still broken by upstream Codex 0.122.0). Decide: commit partial
+   or wait for upstream.
+3. **Codex dispatch pattern** — 3 of 4 Codex dispatches this
+   session stopped after writing code + passing tests but did NOT
+   commit/push/PR. I had to finalize 2 of them (#1434, #1403). The
+   dispatch brief template needs a "your work is NOT done until git
+   commit + push + gh pr create" section. I've added this language
+   to the most recent briefs; should promote into the dispatch
+   template.
+
+---
+
+## Critical rules observed this session
+
+- No auto-merge ever (INCIDENT #1403). User merged #1439 when asked;
+  then "you merge you idiot" was explicit user override on the
+  previous session's PRs.
+- Writer default on main switched to claude-tools per #1431 v2
+  finding. Rollback = 1-line edit if needed.
+- Action bias stayed strong — no option menus, one decisive
+  recommendation per question.
+- Subagent/dispatch cap held (max 2 Claude + 2 Codex in flight).


### PR DESCRIPTION
## Summary

Git hygiene pass during 2026-04-23 evening session. Two additive commits:

### Commit 1 — 2026-04-23 session documentation
Three markdown files produced during today's sessions that never got committed:

- `docs/reports/2026-04-23-anthropic-postmortem-impact.md` (17 KB) — Opus research report on how the April 23 Anthropic postmortem affects our pipeline. Informed the #1472 postmortem-must-change PR.
- `docs/session-state/2026-04-23-afternoon-discipline-handoff.md` — mid-afternoon handoff (wiki + module writer discipline).
- `docs/session-state/2026-04-23-session-handoff-full.md` — full afternoon handoff (wiki infrastructure + tokenizer bug discovery + first Opus writer smoke).

Committing makes the session-state chain navigable for cold-starts (per memory rule #0C).

### Commit 2 — Per-dim review evidence for a1/colors smoke
20 YAML files (10 dims × current + r1) under `curriculum/l2-uk-en/a1/review/colors-review-*.yaml`. Per-dim reviewer output from the abandoned 2026-04-23 colors smoke — follows the existing convention (`around/colors/days/euphony/food/...` are already committed). These artifacts back the #1449 diagnostic + today's "colors NOT ready to fire" finding.

## Hygiene context

This PR is part of an end-of-session cleanup pass that also:

- Removed 46 abandoned colors-smoke artifacts from `curriculum/l2-uk-en/a1/orchestration/colors/` and `curriculum/l2-uk-en/a1/build-errors/` (not in this PR — already nuked via \`git clean\`).
- Pruned 32 stale remote branches (merged PRs whose branches remained on origin).
- Pruned 22 stale local branches whose PRs had been squash-merged.
- Remaining work-tree noise: wiki/b1 motion-\* (tracked mods) + wiki/b2/ (untracked 144-file content batch) — **preserved, flagged to user for decision**.

## Test plan

- [x] All 23 files are pure documentation/evidence additions — no code surface
- [x] Follows existing convention for \`curriculum/l2-uk-en/a1/review/\` directory
- [x] No secrets or binary blobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)