### PR TITLE
refactor(thresholds): unify threshold source of truth (#1454)

### DIFF
--- a/scripts/api/dashboard_helpers.py
+++ b/scripts/api/dashboard_helpers.py
@@ -18,6 +18,7 @@ from .config import CURRICULUM_ROOT, LEVELS, SEMINAR_TRACK_IDS
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from audit.status_cache import get_source_paths, read_status
+from common.thresholds import REVIEW_PASS_FLOOR
 from research_quality import assess_research_compat, find_research_path, get_rubric
 
 from .review_parsing import extract_plan_verdict, extract_review_score, extract_review_verdict
@@ -187,9 +188,9 @@ def build_module_info(track_dir, plans_dir, track_id, slug, idx) -> dict:
         except Exception:
             pass
 
-    # Shippable = audit PASS + review >= 8.0
+    # Shippable = audit PASS + review >= REVIEW_PASS_FLOOR
     r_score = review_info["review_score"]
-    is_shippable = overall_status == "pass" and r_score is not None and r_score >= 8.0
+    is_shippable = overall_status == "pass" and r_score is not None and r_score >= REVIEW_PASS_FLOOR
 
     return {
         "slug": slug, "num": num, "pipeline_version": pipeline_version,

--- a/scripts/api/dashboard_router.py
+++ b/scripts/api/dashboard_router.py
@@ -12,6 +12,10 @@ from pathlib import Path
 import yaml
 from fastapi import APIRouter, HTTPException
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from common.thresholds import REVIEW_PASS_FLOOR
+
 from .config import CURRICULUM_ROOT, LEVELS
 from .dashboard_comms import (
     collect_stuck_tasks,
@@ -222,11 +226,11 @@ async def module_detail(track_id: str, slug: str):
     result["review_verdict"] = review_info["review_verdict"]
     result["plan_review_verdict"] = review_info["plan_review_verdict"]
 
-    # Shippable = audit pass + review >= 8.0 (#971)
+    # Shippable = audit pass + review >= REVIEW_PASS_FLOOR (#971)
     audit_status = result.get("status", {})
     overall = audit_status.get("overall", {}).get("status") if isinstance(audit_status, dict) else None
     r_score = review_info["review_score"]
-    result["shippable"] = overall == "pass" and r_score is not None and r_score >= 8.0
+    result["shippable"] = overall == "pass" and r_score is not None and r_score >= REVIEW_PASS_FLOOR
 
     # Friction from friction.yaml (#970)
     orch_dir = track_dir / "orchestration" / slug

--- a/scripts/api/module_dashboard.py
+++ b/scripts/api/module_dashboard.py
@@ -24,6 +24,7 @@ CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from audit.status_cache import get_source_paths, read_status
+from common.thresholds import REVIEW_PASS_FLOOR
 
 
 def _load_curriculum_order(level: str) -> list[str]:
@@ -122,14 +123,14 @@ def dashboard(level: str, failing_only: bool = False, first_n: int = 0) -> int:
             audit_status = "NO DATA"
             blocking = []
 
-        # A module is only shippable if audit PASS + review ≥ 8.0
+        # A module is only shippable if audit PASS + review ≥ REVIEW_PASS_FLOOR
         review_num = None
         if review_score and review_score not in ("PASS", "FAIL"):
             with contextlib.suppress(ValueError):
                 review_num = float(review_score)
 
-        if review_num is not None and review_num < 8.0:
-            blocking.append(f"review: {review_num}/10 (need ≥8)")
+        if review_num is not None and review_num < REVIEW_PASS_FLOOR:
+            blocking.append(f"review: {review_num}/10 (need ≥{int(REVIEW_PASS_FLOOR)})")
         elif review_score is None or review_score == "-":
             blocking.append("review: not completed")
 

--- a/scripts/api/state_compute.py
+++ b/scripts/api/state_compute.py
@@ -6,8 +6,13 @@ pipeline version phase resolution, and legacy research/content checks.
 
 import contextlib
 import re
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from common.thresholds import REVIEW_PASS_FLOOR
 
 from .config import CURRICULUM_ROOT
 from .state_helpers import (
@@ -179,10 +184,10 @@ def _get_review_score(track_dir: Path, slug: str) -> dict:
 
 
 def _compute_shippable(audit_status: str, review_score: float | None) -> bool:
-    """Module is shippable if audit PASS + review >= 8.0."""
+    """Module is shippable if audit PASS + review >= REVIEW_PASS_FLOOR."""
     if audit_status != "pass":
         return False
-    return not (review_score is None or review_score < 8.0)
+    return not (review_score is None or review_score < REVIEW_PASS_FLOOR)
 
 
 def _get_stress_issues(orch_dir: Path) -> dict:

--- a/scripts/audit/checks/review_gaming.py
+++ b/scripts/audit/checks/review_gaming.py
@@ -27,6 +27,7 @@ from pathlib import Path
 # Ensure scripts/ is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
+from common.thresholds import REVIEW_PASS_FLOOR
 from slug_utils import review_path as _review_path
 from slug_utils import to_bare_slug
 
@@ -105,8 +106,8 @@ def check_score_uniformity(review_content: str) -> list[dict]:
     """
     Flag reviews where all dimension scores are uniformly high.
 
-    If stdev < 0.5 AND mean >= 8.0, the reviewer likely isn't evaluating
-    each dimension independently.
+    If stdev < 0.5 AND mean >= REVIEW_PASS_FLOOR, the reviewer likely
+    isn't evaluating each dimension independently.
 
     Severity: warning only (genuinely good modules can have uniform scores).
     """
@@ -119,7 +120,7 @@ def check_score_uniformity(review_content: str) -> list[dict]:
     mean = statistics.mean(scores)
     stdev = statistics.stdev(scores) if len(scores) > 1 else 0.0
 
-    if stdev < 0.5 and mean >= 8.0:
+    if stdev < 0.5 and mean >= REVIEW_PASS_FLOOR:
         violations.append({
             'type': 'UNIFORM_HIGH_SCORES',
             'severity': 'warning',

--- a/scripts/audit/checks/review_validation.py
+++ b/scripts/audit/checks/review_validation.py
@@ -29,6 +29,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 from audit.config import get_naturalness_min_score
+from common.thresholds import REVIEW_PASS_FLOOR, STYLE_REVIEW_DIMENSION_FLOOR
 from slug_utils import review_path as _review_path
 from slug_utils import to_bare_slug
 
@@ -528,8 +529,8 @@ def _check_praise_only_citations(content: str, citations: list[str], fix_prompt:
     }]
 
 
-_STYLE_REVIEW_DIMENSION_FLOOR = 8.5
-_V6_REVIEW_MIN_SCORE = 8.0
+_STYLE_REVIEW_DIMENSION_FLOOR = STYLE_REVIEW_DIMENSION_FLOOR
+_V6_REVIEW_MIN_SCORE = REVIEW_PASS_FLOOR
 _STYLE_REVIEW_DIMENSIONS = {
     'pragmatic_authenticity': 'Pragmatic authenticity',
     'stylistic_consistency': 'Stylistic consistency',

--- a/scripts/audit/config.py
+++ b/scripts/audit/config.py
@@ -5,6 +5,7 @@ Contains grammar constraints, case patterns, level configurations,
 and activity requirements for each CEFR level.
 """
 
+from common.thresholds import LEVEL_THRESHOLDS, get_naturalness_min
 from config import get_immersion_range as shared_get_immersion_range
 
 # Proper names and abbreviations whitelisted from VESUM verification.
@@ -40,19 +41,17 @@ PROPER_NAME_WHITELIST: set[str] = {
 # Syllable fragments (ка, ра, ль, нь, шч) in phonetics modules are not words.
 VESUM_MIN_WORD_LENGTH = 3
 
-# Gate thresholds — centralized so they're easy to find and adjust.
-# All per-level thresholds are in LEVEL_CONFIG below.
-# These are gate-evaluation constants used across gates.py.
+# Gate thresholds — audit-side knobs.
+# Per-level review floors live in scripts/common/thresholds.LEVEL_THRESHOLDS
+# (single source of truth). The ``naturalness_min_score`` sub-dict below is a
+# read-only view derived from there so existing AUDIT_THRESHOLDS[...] call
+# sites keep working without duplicating numbers.
 AUDIT_THRESHOLDS = {
     "word_count_fail_pct": 12,            # FAIL if more than this % below target
     "immersion_tolerance_pct": 3,        # ±% tolerance before FAIL
-    "naturalness_min_score": {           # Minimum review score for PASS by level family
-        "A1": 9.0,
-        "A2": 9.0,
-        "B1": 9.0,
-        "B2": 8.0,
-        "C1": 8.0,
-        "default": 8.0,
+    "naturalness_min_score": {
+        **{level: thr.naturalness_min for level, thr in LEVEL_THRESHOLDS.items()},
+        "default": get_naturalness_min(None),
     },
     "severity_update": 40,               # Severity score boundary: PASS → UPDATE
     "severity_rewrite": 75,              # Severity score boundary: UPDATE → REWRITE
@@ -61,11 +60,7 @@ AUDIT_THRESHOLDS = {
 
 def get_naturalness_min_score(level_code: str | None) -> float:
     """Return the review-score threshold for the given level family."""
-    thresholds = AUDIT_THRESHOLDS["naturalness_min_score"]
-    if not level_code:
-        return thresholds["default"]
-    level_prefix = level_code.upper().split("-", 1)[0]
-    return thresholds.get(level_prefix, thresholds["default"])
+    return get_naturalness_min(level_code)
 
 # Grammar constraints by level (what's ALLOWED at each level)
 GRAMMAR_CONSTRAINTS = {
@@ -633,7 +628,9 @@ EXCLUDE_KEYWORDS = ["activities", "activity", "production", "vocabulary", "check
 # Level-specific configuration
 LEVEL_CONFIG = {
     'A1': {
-        'target_words': 1200,  # Mar 2026: lowered from 2000 — A1 teaches letters/basics, activities do the heavy lifting
+        # Family target sourced from scripts/common/thresholds.LEVEL_THRESHOLDS (1200).
+        # Mar 2026: lowered from 2000 — A1 teaches letters/basics, activities do the heavy lifting.
+        'target_words': LEVEL_THRESHOLDS['A1'].target_words,
         'min_activities': 0,   # Mar 2026: dropped — quality over quantity, LLM decides count (#969)
         'min_items_per_activity': 6,  # Standard: 6 items minimum per activity
         'min_types_unique': 0,  # Mar 2026: dropped with min_activities
@@ -644,7 +641,9 @@ LEVEL_CONFIG = {
         'priority_types': {'fill-in', 'match-up', 'anagram', 'unjumble', 'quiz', 'watch-and-repeat', 'classify', 'image-to-letter'}
     },
     'A2': {
-        'target_words': 2000,  # Mar 2026: lowered from 3000 — prose should be concise at A2
+        # Family target sourced from scripts/common/thresholds.LEVEL_THRESHOLDS (2000).
+        # Mar 2026: lowered from 3000 — prose should be concise at A2.
+        'target_words': LEVEL_THRESHOLDS['A2'].target_words,
         'min_activities': 0,   # Mar 2026: dropped — quality over quantity, LLM decides count (#969)
         'min_items_per_activity': 8,  # Feb 2026: relaxed from 12 — was stricter than B1-grammar (6)
         'min_types_unique': 0,  # Mar 2026: dropped with min_activities
@@ -732,7 +731,9 @@ LEVEL_CONFIG = {
         'priority_types': {'reading', 'match-up', 'mark-the-words', 'translate', 'quiz'}  # Added reading
     },
     'B1': {
-        'target_words': 4000,  # Feb 2026: raised to 4000 minimum for all B1+
+        # Family target sourced from scripts/common/thresholds.LEVEL_THRESHOLDS (4000).
+        # Feb 2026: raised to 4000 minimum for all B1+.
+        'target_words': LEVEL_THRESHOLDS['B1'].target_words,
         'min_activities': 0,  # Mar 2026: dropped — plan activity_hints guide count (#969)
         'min_items_per_activity': 12,  # Reduced from 14 (Jan 2026)
         'min_types_unique': 4,
@@ -815,7 +816,9 @@ LEVEL_CONFIG = {
         'priority_types': {'reading', 'match-up', 'mark-the-words', 'translate', 'quiz'}  # Added reading
     },
     'B2': {
-        'target_words': 4000,  # Feb 2026: raised to 4000 minimum for all B1+
+        # Family target sourced from scripts/common/thresholds.LEVEL_THRESHOLDS (4000).
+        # Feb 2026: raised to 4000 minimum for all B1+.
+        'target_words': LEVEL_THRESHOLDS['B2'].target_words,
         'min_activities': 0,  # Mar 2026: dropped — plan activity_hints guide count (#969)
         'min_items_per_activity': 14,  # Reduced from 16 (Jan 2026)
         'min_types_unique': 4,
@@ -925,7 +928,9 @@ LEVEL_CONFIG = {
         'essay_max_words': 300
     },
     'C1': {
-        'target_words': 4000,  # Feb 2026: raised to 4000 minimum for all B1+
+        # Family target sourced from scripts/common/thresholds.LEVEL_THRESHOLDS (4000).
+        # Feb 2026: raised to 4000 minimum for all B1+.
+        'target_words': LEVEL_THRESHOLDS['C1'].target_words,
         'min_activities': 0,  # Mar 2026: dropped — plan guides count (#969)
         'min_items_per_activity': 12,
         'min_types_unique': 4,
@@ -1067,7 +1072,9 @@ LEVEL_CONFIG = {
     },
     'C2': {
         # C2 Track: Seminar style - production-focused
-        'target_words': 5000,  # Feb 2026: seminars raised to 5000 minimum
+        # Family target sourced from scripts/common/thresholds.LEVEL_THRESHOLDS (5000).
+        # Feb 2026: seminars raised to 5000 minimum.
+        'target_words': LEVEL_THRESHOLDS['C2'].target_words,
         'min_activities': 0,  # Mar 2026: dropped — plan guides count (#969)
         'max_activities': 9,
         'min_items_per_activity': 1,

--- a/scripts/batch/batch_fix_review.py
+++ b/scripts/batch/batch_fix_review.py
@@ -24,6 +24,9 @@ import tempfile
 import time
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from common.thresholds import STYLE_REVIEW_TARGET
 from slug_utils import review_path as _review_path
 from slug_utils import status_path as _status_path
 from slug_utils import to_bare_slug
@@ -31,7 +34,8 @@ from slug_utils import to_bare_slug
 REPO = Path(__file__).parent.parent.parent
 VENV_PYTHON = REPO / ".venv" / "bin" / "python"
 MAX_RETRIES = 3
-PASS_THRESHOLD = 9.0
+# Batch fix loop targets the style-reviewer PASS score (9.0).
+PASS_THRESHOLD = STYLE_REVIEW_TARGET
 SUSPICIOUS_JUMP = 3.5  # Flag if score jumps more than this in one fix
 GEMINI_TIMEOUT = 600  # 10 minutes
 

--- a/scripts/build/alignment_manifest.py
+++ b/scripts/build/alignment_manifest.py
@@ -149,18 +149,39 @@ def _load_v6_build_constant(name: str) -> Any:
 
     v6_build_path = _module_attr("V6_BUILD_PATH")
     module = ast.parse(v6_build_path.read_text("utf-8"))
+    # Index top-level assigns so we can resolve Name aliases (e.g.
+    # ``REVIEW_TARGET_SCORE = REVIEW_PASS_FLOOR``) without importing
+    # v6_build. Maps target-name → (RHS AST node).
+    top_level_values: dict[str, Any] = {}
     for node in module.body:
         if isinstance(node, ast.Assign):
-            targets = [target for target in node.targets if isinstance(target, ast.Name)]
-            if any(target.id == name for target in targets):
-                return ast.literal_eval(node.value)
-        if (
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    top_level_values[target.id] = node.value
+        elif (
             isinstance(node, ast.AnnAssign)
             and isinstance(node.target, ast.Name)
-            and node.target.id == name
             and node.value is not None
         ):
-            return ast.literal_eval(node.value)
+            top_level_values[node.target.id] = node.value
+
+    def _resolve_node(value_node: ast.AST, seen: set[str]) -> Any:
+        if isinstance(value_node, ast.Name):
+            if value_node.id in seen:
+                raise RuntimeError(
+                    f"Cycle resolving {name} in {v6_build_path}: {' -> '.join(seen)}"
+                )
+            seen.add(value_node.id)
+            if value_node.id in top_level_values:
+                return _resolve_node(top_level_values[value_node.id], seen)
+            # Imported name — try the common.thresholds source of truth.
+            from common import thresholds as _thresholds
+            if hasattr(_thresholds, value_node.id):
+                return getattr(_thresholds, value_node.id)
+        return ast.literal_eval(value_node)
+
+    if name in top_level_values:
+        return _resolve_node(top_level_values[name], set())
     raise RuntimeError(f"Could not load {name} from {v6_build_path}")
 
 

--- a/scripts/build/phases/plan_patch.py
+++ b/scripts/build/phases/plan_patch.py
@@ -20,6 +20,7 @@ import yaml
 from batch_gemini_config import PRO_MODEL
 from build.io_utils import write_text_atomic
 from build.v6_build import _format_prompt_literal_block, _strip_prompt_control_tags
+from common.thresholds import STYLE_REVIEW_TARGET
 from gemini_output import extract_delimited
 from tools.plan_autofix import _bump_version
 
@@ -93,7 +94,7 @@ def load_structured_review_rounds(orch_dir: Path) -> list[dict]:
 def extract_plateau_complaints(
     structured_rounds: list[dict],
     *,
-    review_target_score: float = 9.0,
+    review_target_score: float = STYLE_REVIEW_TARGET,
     max_items: int = 6,
     contract: dict | None = None,
 ) -> list[dict]:

--- a/scripts/build/pipeline_v5.py
+++ b/scripts/build/pipeline_v5.py
@@ -36,7 +36,6 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 # ---------------------------------------------------------------------------
 # Imports from pipeline_lib (shared utilities — never duplicated)
 # ---------------------------------------------------------------------------
-
 import pipeline_lib
 from batch_gemini_config import (
     CLAUDE_MODEL_CORE_ACTIVITIES,
@@ -49,6 +48,7 @@ from batch_gemini_config import (
     PROJECT_ROOT,
     SEMINAR_TRACKS,
 )
+from common.thresholds import STYLE_REVIEW_TARGET
 from pipeline_lib import (
     ModuleContext,
     _dispatch_prompt,
@@ -3925,7 +3925,7 @@ def phase_review_gemini(ctx: ModuleContext, state: dict) -> bool:
         # Check if all review issues were resolved by inline fixes (#975)
         _review_score = merged.scores.get("overall", 10)
         _n_issues = len(merged.issues or [])
-        if n_fixes >= _n_issues or _review_score >= 9.0:
+        if n_fixes >= _n_issues or _review_score >= STYLE_REVIEW_TARGET:
             # All issues fixed or score high enough — done
             _post_fix_passed, _post_fix_output = run_verify(ctx.paths["md"])
             log(f"  review-gemini: PASS (inline fixes resolved review issues — {n_fixes} fix(es), post-fix audit: {'PASS' if _post_fix_passed else 'FAIL'})")

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -103,6 +103,12 @@ from build.plan_tracking import (
     plan_path_for,
 )
 from build.track_constraints import build_writer_constraints_section
+from common.thresholds import (
+    REVIEW_PASS_FLOOR,
+    REVIEW_REJECT_FLOOR,
+    STYLE_REVIEW_DIMENSION_FLOOR,
+    STYLE_REVIEW_TARGET,
+)
 
 _LEGACY_PLAN_HASH_DRIFT_DETECTOR = detect_plan_hash_drift
 
@@ -110,10 +116,10 @@ logger = logging.getLogger(__name__)
 
 # Rate limit backoff — shared by all retry loops
 _RATE_LIMIT_BACKOFF_S = 300  # 5 min — long enough for Gemini quota to recover
-REVIEW_TARGET_SCORE = 8.0
-REVIEW_REJECT_SCORE = 6.0
-STYLE_REVIEW_TARGET_SCORE = 9.0
-STYLE_REVIEW_DIMENSION_FLOOR = 8.5
+# Legacy aliases. Canonical names + values live in scripts/common/thresholds.py.
+REVIEW_TARGET_SCORE = REVIEW_PASS_FLOOR
+REVIEW_REJECT_SCORE = REVIEW_REJECT_FLOOR
+STYLE_REVIEW_TARGET_SCORE = STYLE_REVIEW_TARGET
 REWRITE_BLOCK_TIMEOUT_S = 420
 REWRITE_BLOCK_GEMINI_CALL_CAP_S = 120
 REWRITE_BLOCK_PROMPT_MAX_CHARS = 18_000

--- a/scripts/common/__init__.py
+++ b/scripts/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities used across build, audit, and tooling pipelines."""

--- a/scripts/common/thresholds.py
+++ b/scripts/common/thresholds.py
@@ -1,0 +1,116 @@
+"""Single source of truth for pipeline thresholds.
+
+Consolidates reviewer floors, style-review gates, and per-level word /
+naturalness thresholds so drift is impossible: one file, explicit
+semantics, immutable values.
+
+Every threshold-typed module-level constant outside this file is a
+regression and will be caught by ``tests/test_threshold_source_of_truth.py``.
+
+Why not per-level for reviewer floors?
+    Reviewer personas evaluate a dimension on its own merits — a "6/10
+    factual accuracy" is weak regardless of the target CEFR level. The
+    audit-side naturalness gate *is* level-varying (stricter at A1/A2/B1
+    because thin source material needs extra polish); that lives in
+    :data:`LEVEL_THRESHOLDS`.
+
+Why not per-level for style-review thresholds either?
+    Same reason. The style reviewer evaluates pragmatic authenticity,
+    stylistic consistency, culture + register, and naturalness against
+    absolute targets.
+
+Plan-level ``word_target`` overrides the level default at generation
+time (see ``scripts/pipeline/core.py``). That's a per-module attribute,
+not a threshold — keep it in plan YAML, not here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+# ---------------------------------------------------------------------------
+# Review pipeline floors — global (level-agnostic)
+# ---------------------------------------------------------------------------
+
+REVIEW_PASS_FLOOR: float = 8.0
+"""Per-dimension reviewer PASS floor. Dim scores below this trigger a
+REVISE verdict in the general reviewer (see scripts/build/v6_build.py)."""
+
+REVIEW_REJECT_FLOOR: float = 6.0
+"""Hard reject floor. Dim scores below this fail review unconditionally."""
+
+STYLE_REVIEW_TARGET: float = 9.0
+"""Style-reviewer verdict target. Stricter than the general reviewer
+because pragmatic authenticity / stylistic consistency / culture-register /
+naturalness are language-native dimensions where "just ok" is not
+shippable."""
+
+STYLE_REVIEW_DIMENSION_FLOOR: float = 8.5
+"""Per-dimension floor for the style reviewer."""
+
+# ---------------------------------------------------------------------------
+# Per-level thresholds — families (A1..C2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LevelThresholds:
+    """Immutable per-level thresholds.
+
+    Variant configs (A1-checkpoint, A2-grammar, B2-biography, seminar
+    tracks, ...) may legitimately override these family baselines. When
+    they do, the override lives in ``scripts/audit/config.LEVEL_CONFIG``
+    and the reason belongs in a comment there, not here.
+    """
+
+    target_words: int
+    """Minimum total words per module (audit gate + writer word budget)."""
+
+    naturalness_min: float
+    """Audit gate for the ``naturalness`` review dimension. Stricter at
+    A1/A2/B1 where source material is thin and awkward phrasing is easy
+    to miss; relaxed to 8.0 at B2+ where complexity naturally increases."""
+
+
+_LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
+    "A1": LevelThresholds(target_words=1200, naturalness_min=9.0),
+    "A2": LevelThresholds(target_words=2000, naturalness_min=9.0),
+    "B1": LevelThresholds(target_words=4000, naturalness_min=9.0),
+    "B2": LevelThresholds(target_words=4000, naturalness_min=8.0),
+    "C1": LevelThresholds(target_words=4000, naturalness_min=8.0),
+    "C2": LevelThresholds(target_words=5000, naturalness_min=8.0),
+}
+
+LEVEL_THRESHOLDS: Mapping[str, LevelThresholds] = MappingProxyType(_LEVEL_THRESHOLDS)
+"""Read-only view of per-level family thresholds."""
+
+_DEFAULT_THRESHOLDS = LevelThresholds(target_words=4000, naturalness_min=8.0)
+"""Fallback for unknown level codes. Matches the audit-side ``default``
+row historically used in ``AUDIT_THRESHOLDS['naturalness_min_score']``."""
+
+
+def get_level_thresholds(level_code: str | None) -> LevelThresholds:
+    """Resolve thresholds for a level family.
+
+    Accepts both bare families (``"A1"``, ``"b2"``) and variant codes
+    (``"A1-checkpoint"``, ``"B2-grammar"``) — maps to the family prefix.
+    Unknown codes fall back to ``_DEFAULT_THRESHOLDS``.
+    """
+    if not level_code:
+        return _DEFAULT_THRESHOLDS
+    prefix = level_code.upper().split("-", 1)[0]
+    return LEVEL_THRESHOLDS.get(prefix, _DEFAULT_THRESHOLDS)
+
+
+def get_naturalness_min(level_code: str | None) -> float:
+    """Shortcut — per-level audit naturalness gate."""
+    return get_level_thresholds(level_code).naturalness_min
+
+
+def get_target_words(level_code: str | None) -> int:
+    """Shortcut — per-level family word target. Variant overrides live in
+    ``scripts/audit/config.LEVEL_CONFIG``; callers that respect those
+    should use ``scripts.audit.config.get_word_target`` instead."""
+    return get_level_thresholds(level_code).target_words

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -19,37 +19,31 @@ TRACK_CONFIG: dict[str, dict[str, Any]] = {
     # --- Core Tracks (Beginner/Intermediate) ---
     "a1": {
         "model": FLASH_MODEL,
-        "word_floor": 2000,
         "persona": "The Helpful Neighbor",
         "immersion_range": [0.10, 0.50],
     },
     "a2": {
         "model": FLASH_MODEL,
-        "word_floor": 2500,
         "persona": "The Cultural Guide",
         "immersion_range": [0.50, 0.90],
     },
     "b1": {
         "model": FLASH_MODEL,
-        "word_floor": 3000,
         "persona": "The Storyteller",
         "immersion_range": [0.85, 1.0],
     },
     "b2": {
         "model": FLASH_MODEL,
-        "word_floor": 3500,
         "persona": "The Urbanist",
         "immersion_range": [0.95, 1.0],
     },
     "c1": {
         "model": PRO_MODEL,
-        "word_floor": 4000,
         "persona": "The Analyst",
         "immersion_range": [1.0, 1.0],
     },
     "c2": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Connoisseur",
         "immersion_range": [1.0, 1.0],
     },
@@ -57,25 +51,21 @@ TRACK_CONFIG: dict[str, dict[str, Any]] = {
     # --- Seminar Tracks (Advanced/Scholar) ---
     "hist": {
         "model": PRO_MODEL,
-        "word_floor": 4000,
         "persona": "The Decolonizer",
         "immersion_range": [0.95, 1.0],
     },
     "istorio": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Sensory Historian",
         "immersion_range": [1.0, 1.0],
     },
     "bio": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Humanist Biographer",
         "immersion_range": [1.0, 1.0],
     },
     "lit": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Stylistic Critic",
         "immersion_range": [1.0, 1.0],
     },
@@ -83,55 +73,46 @@ TRACK_CONFIG: dict[str, dict[str, Any]] = {
     # --- Specialized Literature Tracks ---
     "lit-war": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Trauma Analyst",
         "immersion_range": [1.0, 1.0],
     },
     "lit-essay": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Intellectual Historian",
         "immersion_range": [1.0, 1.0],
     },
     "lit-fantastika": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The World-Builder",
         "immersion_range": [1.0, 1.0],
     },
     "lit-hist-fic": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Historical Narratologist",
         "immersion_range": [1.0, 1.0],
     },
     "lit-humor": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Irony Analyst",
         "immersion_range": [1.0, 1.0],
     },
     "lit-youth": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Childhood Scholar",
         "immersion_range": [1.0, 1.0],
     },
     "lit-doc": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Witness Documentarian",
         "immersion_range": [1.0, 1.0],
     },
     "lit-drama": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Avant-Garde Playwright",
         "immersion_range": [1.0, 1.0],
     },
     "lit-crimea": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Crimean Narratologist",
         "immersion_range": [1.0, 1.0],
     },
@@ -139,25 +120,21 @@ TRACK_CONFIG: dict[str, dict[str, Any]] = {
     # --- Scholar Tracks (Ancient/Professional) ---
     "ruth": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Baroque Scholar",
         "immersion_range": [0.97, 1.0],
     },
     "oes": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Paleographer",
         "immersion_range": [0.97, 1.0],
     },
     "b2-pro": {
         "model": PRO_MODEL,
-        "word_floor": 4000,
         "persona": "The Professional Coach",
         "immersion_range": [0.95, 1.0],
     },
     "c1-pro": {
         "model": PRO_MODEL,
-        "word_floor": 5000,
         "persona": "The Corporate Strategist",
         "immersion_range": [1.0, 1.0],
     },
@@ -492,7 +469,6 @@ def get_config(track: str) -> dict[str, Any]:
     """Retrieves config for a specific track, falling back to default core config."""
     return TRACK_CONFIG.get(track, {
         "model": FLASH_MODEL,
-        "word_floor": 2500,
         "persona": "The Helpful Neighbor",
         "immersion_range": [0.5, 1.0],
     })

--- a/scripts/scoring/sampling.py
+++ b/scripts/scoring/sampling.py
@@ -8,14 +8,24 @@ Implements the sampling strategy:
 """
 
 import hashlib
+import sys
+from pathlib import Path
 from typing import Any
+
+# Ensure scripts/ is importable (matches the pattern used elsewhere in audit/).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from common.thresholds import REVIEW_PASS_FLOOR
 
 # Constants
 SENSITIVE_TAGS = {
     'politics', 'war', 'religion', 'history', 'ideology', 'gender',
     'controversial', 'policy', 'identity'
 }
-NATURALNESS_THRESHOLD = 8.0  # Modules below this score get Tier 2
+# Modules scoring below the reviewer pass floor get Tier 2 (LLM-verified).
+# Shares the constant with the review pipeline so the risk-escalation
+# threshold tracks any future shift in reviewer calibration.
+NATURALNESS_THRESHOLD = REVIEW_PASS_FLOOR
 SAMPLE_RATE = 0.20  # 20% sampling for Tier 3
 
 def determine_tier(module_data: dict[str, Any]) -> str:

--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -75,6 +75,7 @@ def _ts() -> str:
     """Compact HH:MM:SS timestamp for log lines."""
     return datetime.now().strftime("%H:%M:%S")
 
+from common.thresholds import REVIEW_PASS_FLOOR
 from wiki.compiler import compile_article, update_index
 from wiki.config import ALL_TRACKS, CURRICULUM_DIR, TRACK_DOMAINS, WIKI_DIR
 from wiki.context import strip_meta
@@ -787,19 +788,16 @@ def _review_article(article_path: Path, track: str, slug: str) -> None:
     log_event(track, slug, "review_round", round=1,
               score=score, **{k: v for k, v in scores.items() if k != "overall"})
 
-    # Pass criteria: every individual dimension ≥ 8.0 AND overall ≥ 8.0.
-    # The per-dimension floor catches the "one bad dimension hidden by a
-    # strong total" failure mode (Codex's A1 macro-report finding).
-    # Overall ≥ 8.0 is a lower bound — if every dim is ≥ 8.0 the overall
-    # is always ≥ 8.0 by construction, so the overall gate mostly guards
-    # against parse failures where the reviewer reports a sub-8 overall
-    # while emitting inflated dim scores. Matches the project's documented
-    # 8.0 minimum pass (docs/.../non-negotiable-rules.md §2).
-    DIMENSION_FLOOR = 8.0
-    OVERALL_PASS = 8.0
+    # Pass criteria: every individual dimension ≥ REVIEW_PASS_FLOOR AND
+    # overall ≥ REVIEW_PASS_FLOOR. The per-dimension floor catches the
+    # "one bad dimension hidden by a strong total" failure mode (Codex's
+    # A1 macro-report finding). Overall is a lower bound — if every dim
+    # is ≥ floor, overall is always ≥ floor by construction; the overall
+    # gate mostly guards against parse failures where the reviewer
+    # reports a sub-floor overall while emitting inflated dim scores.
     DIMENSIONS = ("factual", "language", "decolonization", "completeness", "actionable")
-    failing_dims = [d for d in DIMENSIONS if scores.get(d, 0) < DIMENSION_FLOOR]
-    overall_ok = score >= OVERALL_PASS
+    failing_dims = [d for d in DIMENSIONS if scores.get(d, 0) < REVIEW_PASS_FLOOR]
+    overall_ok = score >= REVIEW_PASS_FLOOR
 
     if overall_ok and not failing_dims:
         log_event(track, slug, "review_pass", score=score, rounds=1)
@@ -810,9 +808,9 @@ def _review_article(article_path: Path, track: str, slug: str) -> None:
     # Build failure reason for logs + user visibility.
     fail_reasons = []
     if not overall_ok:
-        fail_reasons.append(f"overall {score} < {OVERALL_PASS}")
+        fail_reasons.append(f"overall {score} < {REVIEW_PASS_FLOOR}")
     for d in failing_dims:
-        fail_reasons.append(f"{d} {scores.get(d, 0)} < {DIMENSION_FLOOR}")
+        fail_reasons.append(f"{d} {scores.get(d, 0)} < {REVIEW_PASS_FLOOR}")
     fail_reason = "; ".join(fail_reasons)
 
     review_summary = _extract_review_summary(review_text)

--- a/tests/test_threshold_source_of_truth.py
+++ b/tests/test_threshold_source_of_truth.py
@@ -1,0 +1,257 @@
+"""CI invariant — thresholds live in exactly one file.
+
+Guards against drift by rejecting:
+  1. Module-level re-declarations of any canonical threshold name.
+  2. Float literals (8.0 / 9.0 / 8.5 / 6.0) used in threshold-adjacent
+     contexts anywhere in ``scripts/`` outside the source-of-truth module.
+
+Related incident: ISTORIO 3500 vs 4000 drift (Jan 2026), recorded in
+``claude_extensions/rules/non-negotiable-rules.md`` §1. EPIC #1451 P2-A.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from common.thresholds import (
+    REVIEW_PASS_FLOOR,
+    REVIEW_REJECT_FLOOR,
+    STYLE_REVIEW_DIMENSION_FLOOR,
+    STYLE_REVIEW_TARGET,
+)
+
+SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+SOURCE_OF_TRUTH = SCRIPTS_ROOT / "common" / "thresholds.py"
+
+# Canonical names that must never be redeclared outside the source-of-truth.
+# The values are the source-of-truth values — any other file claiming to
+# own these names (at module scope) is a regression.
+_CANONICAL_NAMES: frozenset[str] = frozenset({
+    "REVIEW_PASS_FLOOR",
+    "REVIEW_REJECT_FLOOR",
+    "STYLE_REVIEW_TARGET",
+    "STYLE_REVIEW_DIMENSION_FLOOR",
+    "LEVEL_THRESHOLDS",
+})
+
+# Float literals that are threshold-valued. 5.0 / 7.0 are common but not
+# pipeline thresholds; we deliberately do not list them.
+_THRESHOLD_VALUES: frozenset[float] = frozenset({
+    REVIEW_PASS_FLOOR,
+    REVIEW_REJECT_FLOOR,
+    STYLE_REVIEW_TARGET,
+    STYLE_REVIEW_DIMENSION_FLOOR,
+})
+
+# Words that make a nearby float literal "look like" a threshold. If none
+# of these appear within 3 lines of the literal, we don't flag — an 8.0
+# in a test-weight matrix is fine.
+_THRESHOLD_CONTEXT_WORDS: tuple[str, ...] = (
+    "threshold", "floor", "target", "min_score", "minscore",
+    "pass_floor", "reject_floor", "revise", "review_score",
+    "review_target", "review_pass", "style_review",
+    "naturalness_min", "naturalness_threshold",
+)
+
+# Precise per-line allow-list for legitimate non-threshold float literals
+# that happen to look like thresholds. Each entry is (relative_posix_path,
+# line_number) — keep this short; prefer migrating over extending.
+_FLOAT_LITERAL_ALLOWLIST: frozenset[tuple[str, int]] = frozenset({
+    # scoring/report.py display heuristic: "show criteria below 9" —
+    # not a pipeline pass/fail threshold, belongs to a separate scoring
+    # domain.
+    ("scoring/report.py", 205),
+    ("scoring/report.py", 400),
+    # review_validation.py gaming-detection heuristic: if ALL dims scored
+    # ≥9 without substantive issues → suspicious. Independent of
+    # STYLE_REVIEW_TARGET (they share the number by coincidence).
+    ("audit/checks/review_validation.py", 487),
+    # scoring/caps.py max_score= entries: these CAP a track's score at a
+    # value when a content-quality metric fails (e.g., zero [!quote]
+    # blocks → cap at 6.0). They are cap values, not pipeline
+    # pass/fail gates, and the specific numbers encode per-criterion
+    # penalties chosen for the scoring rubric.
+    ("scoring/caps.py", 61),
+    ("scoring/caps.py", 105),
+    # v6_build.py docstring in a long help message — mentions the default
+    # --review-threshold CLI default (9.0). The actual CLI default is
+    # wired via argparse reading REVIEW_TARGET_SCORE, not this literal.
+    ("build/v6_build.py", 2767),
+})
+
+# Files excluded from the scan entirely (archived / generated / legacy).
+_EXCLUDED_DIRS: tuple[str, ...] = (
+    "__pycache__",
+    "oneoff",
+    "legacy/",
+    "agent_runtime/_archive",
+)
+
+
+def _iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for path in SCRIPTS_ROOT.rglob("*.py"):
+        rel = path.relative_to(SCRIPTS_ROOT).as_posix()
+        if any(excl in rel for excl in _EXCLUDED_DIRS):
+            continue
+        files.append(path)
+    return files
+
+
+def _module_level_name_assignments(tree: ast.Module) -> list[tuple[str, int]]:
+    """Return (name, lineno) pairs for module-level ``NAME = ...`` assigns.
+
+    Skips nested functions/classes — only top-level assignments count as
+    "this module claims to own this constant."
+    """
+    results: list[tuple[str, int]] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    results.append((target.id, node.lineno))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            results.append((node.target.id, node.lineno))
+    return results
+
+
+def test_no_canonical_name_redeclared_outside_thresholds() -> None:
+    """No file other than thresholds.py defines the canonical names.
+
+    An ``import`` of the name is fine (that's the whole point). Only
+    local re-assignments at module scope are flagged.
+    """
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        if path.resolve() == SOURCE_OF_TRUTH.resolve():
+            continue
+        try:
+            tree = ast.parse(path.read_text("utf-8"))
+        except SyntaxError:
+            continue
+        for name, lineno in _module_level_name_assignments(tree):
+            if name in _CANONICAL_NAMES:
+                rel = path.relative_to(SCRIPTS_ROOT).as_posix()
+                offenders.append(f"{rel}:{lineno} redeclares {name!r}")
+
+    assert not offenders, (
+        "Canonical threshold names must live only in scripts/common/thresholds.py.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_no_duplicate_target_words_module_level() -> None:
+    """No module-level ``target_words = <int>`` literal outside thresholds.py.
+
+    Dict-entry ``'target_words': 1200`` inside ``LEVEL_CONFIG`` is fine —
+    those are per-variant overrides, not module-level constants. This
+    catches the ISTORIO-class drift: a bare ``target_words = 3500`` next
+    to a separate ``target_words = 4000`` in another file.
+    """
+    pattern = re.compile(r"^(?:target_words|naturalness_threshold|word_floor)\s*=\s*\d", re.MULTILINE)
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        if path.resolve() == SOURCE_OF_TRUTH.resolve():
+            continue
+        for match in pattern.finditer(path.read_text("utf-8")):
+            lineno = path.read_text("utf-8")[: match.start()].count("\n") + 1
+            rel = path.relative_to(SCRIPTS_ROOT).as_posix()
+            offenders.append(f"{rel}:{lineno} — {match.group(0).strip()}")
+
+    assert not offenders, (
+        "Module-level threshold names are reserved for scripts/common/thresholds.py.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_no_threshold_float_literals_in_threshold_context() -> None:
+    """Flag ``8.0 / 8.5 / 9.0 / 6.0`` near threshold-adjacent words.
+
+    The ± 3-line window catches common patterns (``if score < 8.0:``,
+    ``threshold = 8.0``) without false-positiving on unrelated uses
+    (e.g., a version string or a percentage). Per-line allow-list
+    carries the few legitimate exceptions.
+    """
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        if path.resolve() == SOURCE_OF_TRUTH.resolve():
+            continue
+        rel = path.relative_to(SCRIPTS_ROOT).as_posix()
+        lines = path.read_text("utf-8").splitlines()
+        for idx, line in enumerate(lines, start=1):
+            if (rel, idx) in _FLOAT_LITERAL_ALLOWLIST:
+                continue
+            # Quick literal presence filter.
+            stripped = line.split("#", 1)[0]  # strip line comments
+            has_literal = any(
+                re.search(rf"(?<!\d)\b{re.escape(f'{value:.1f}')}\b", stripped)
+                for value in _THRESHOLD_VALUES
+            )
+            if not has_literal:
+                continue
+            # Context window: ± 3 lines. Include the line itself.
+            lo, hi = max(0, idx - 4), min(len(lines), idx + 3)
+            window = " ".join(lines[lo:hi]).lower()
+            if any(word in window for word in _THRESHOLD_CONTEXT_WORDS):
+                offenders.append(f"{rel}:{idx} — {line.strip()}")
+
+    assert not offenders, (
+        "Float literals that look like pipeline thresholds were found "
+        "outside scripts/common/thresholds.py:\n"
+        + "\n".join(offenders)
+        + "\n\nFix: import REVIEW_PASS_FLOOR / STYLE_REVIEW_TARGET / etc. "
+        "from scripts.common.thresholds, or — if the value is genuinely "
+        "unrelated — add (path, lineno) to _FLOAT_LITERAL_ALLOWLIST with a "
+        "one-line justification."
+    )
+
+
+def test_audit_config_naturalness_matches_thresholds() -> None:
+    """``AUDIT_THRESHOLDS['naturalness_min_score']`` stays in sync with
+    ``LEVEL_THRESHOLDS`` — not because a test asserts equality once,
+    but because the dict is built from LEVEL_THRESHOLDS at import time.
+    Regression guard.
+    """
+    from audit.config import AUDIT_THRESHOLDS
+    from common.thresholds import LEVEL_THRESHOLDS
+
+    mins = AUDIT_THRESHOLDS["naturalness_min_score"]
+    for level, thresholds in LEVEL_THRESHOLDS.items():
+        assert mins[level] == thresholds.naturalness_min, (
+            f"{level} audit naturalness drift: "
+            f"AUDIT_THRESHOLDS={mins[level]} vs LEVEL_THRESHOLDS={thresholds.naturalness_min}"
+        )
+    assert "default" in mins, "AUDIT_THRESHOLDS must keep a 'default' fallback."
+
+
+def test_level_config_family_target_words_match_thresholds() -> None:
+    """Family entries (A1..C2) in ``LEVEL_CONFIG`` read from
+    ``LEVEL_THRESHOLDS`` — guards against someone hardcoding a number
+    back into the LEVEL_CONFIG dict literal.
+    """
+    from audit.config import LEVEL_CONFIG
+    from common.thresholds import LEVEL_THRESHOLDS
+
+    for level, thresholds in LEVEL_THRESHOLDS.items():
+        cfg = LEVEL_CONFIG.get(level)
+        assert cfg is not None, f"LEVEL_CONFIG missing family {level!r}"
+        assert cfg["target_words"] == thresholds.target_words, (
+            f"{level} LEVEL_CONFIG target_words={cfg['target_words']} "
+            f"drifted from LEVEL_THRESHOLDS.target_words={thresholds.target_words}"
+        )
+
+
+def test_config_py_has_no_word_floor() -> None:
+    """Legacy dead field — must stay removed. scripts/config.py
+    TRACK_CONFIG used to carry ``word_floor`` that no caller read."""
+    config_py = (SCRIPTS_ROOT / "config.py").read_text("utf-8")
+    assert "word_floor" not in config_py, (
+        "scripts/config.py TRACK_CONFIG.word_floor was removed as dead "
+        "code that contradicted scripts/audit/config.py word targets. "
+        "Do not revive it — use scripts.common.thresholds.LEVEL_THRESHOLDS."
+    )

--- a/tests/test_thresholds_consumers.py
+++ b/tests/test_thresholds_consumers.py
@@ -1,0 +1,155 @@
+"""Per-consumer tests — every migrated consumer reads thresholds from
+``scripts/common/thresholds`` and exposes values consistent with the
+single source of truth.
+
+These tests would catch a silent regression where a consumer still imports
+the name but re-binds it to a different number, or where an alias drifts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from common.thresholds import (
+    LEVEL_THRESHOLDS,
+    REVIEW_PASS_FLOOR,
+    REVIEW_REJECT_FLOOR,
+    STYLE_REVIEW_DIMENSION_FLOOR,
+    STYLE_REVIEW_TARGET,
+    LevelThresholds,
+    get_level_thresholds,
+    get_naturalness_min,
+    get_target_words,
+)
+
+# ---------------------------------------------------------------------------
+# thresholds.py — shape and invariants
+# ---------------------------------------------------------------------------
+
+class TestThresholdsModule:
+    def test_canonical_values_present(self) -> None:
+        assert REVIEW_PASS_FLOOR == 8.0
+        assert REVIEW_REJECT_FLOOR == 6.0
+        assert STYLE_REVIEW_TARGET == 9.0
+        assert STYLE_REVIEW_DIMENSION_FLOOR == 8.5
+
+    def test_level_thresholds_covers_all_families(self) -> None:
+        expected = {"A1", "A2", "B1", "B2", "C1", "C2"}
+        assert set(LEVEL_THRESHOLDS) == expected
+
+    def test_level_thresholds_is_immutable_mapping(self) -> None:
+        with pytest.raises(TypeError):
+            LEVEL_THRESHOLDS["A1"] = LevelThresholds(target_words=1, naturalness_min=1.0)  # type: ignore[index]
+
+    def test_level_thresholds_dataclass_is_frozen(self) -> None:
+        with pytest.raises(AttributeError):
+            LEVEL_THRESHOLDS["A1"].target_words = 9999  # type: ignore[misc]
+
+    def test_get_level_thresholds_accepts_variants(self) -> None:
+        assert get_level_thresholds("A1") == LEVEL_THRESHOLDS["A1"]
+        assert get_level_thresholds("A1-checkpoint") == LEVEL_THRESHOLDS["A1"]
+        assert get_level_thresholds("B2-grammar") == LEVEL_THRESHOLDS["B2"]
+        assert get_level_thresholds("c2-literary") == LEVEL_THRESHOLDS["C2"]
+
+    def test_get_level_thresholds_unknown_falls_back_to_default(self) -> None:
+        unknown = get_level_thresholds("ZZ")
+        assert unknown.naturalness_min == 8.0
+        assert unknown.target_words == 4000
+
+    def test_get_level_thresholds_none_returns_default(self) -> None:
+        assert get_level_thresholds(None).naturalness_min == 8.0
+
+    def test_shortcut_functions_match_full_resolver(self) -> None:
+        for code in ("A1", "B2-grammar", "C2-literary", None, "ZZ"):
+            resolved = get_level_thresholds(code)
+            assert get_naturalness_min(code) == resolved.naturalness_min
+            assert get_target_words(code) == resolved.target_words
+
+
+# ---------------------------------------------------------------------------
+# v6_build.py — legacy aliases carry canonical values
+# ---------------------------------------------------------------------------
+
+class TestV6BuildAliases:
+    def test_review_target_score_alias(self) -> None:
+        from build import v6_build
+        assert v6_build.REVIEW_TARGET_SCORE == REVIEW_PASS_FLOOR
+
+    def test_review_reject_score_alias(self) -> None:
+        from build import v6_build
+        assert v6_build.REVIEW_REJECT_SCORE == REVIEW_REJECT_FLOOR
+
+    def test_style_review_target_score_alias(self) -> None:
+        from build import v6_build
+        assert v6_build.STYLE_REVIEW_TARGET_SCORE == STYLE_REVIEW_TARGET
+
+    def test_style_review_dimension_floor_matches(self) -> None:
+        from build import v6_build
+        assert v6_build.STYLE_REVIEW_DIMENSION_FLOOR == STYLE_REVIEW_DIMENSION_FLOOR
+
+
+# ---------------------------------------------------------------------------
+# audit/config.py — AUDIT_THRESHOLDS + LEVEL_CONFIG derive from thresholds
+# ---------------------------------------------------------------------------
+
+class TestAuditConfig:
+    def test_audit_thresholds_naturalness_matches_thresholds_table(self) -> None:
+        from audit.config import AUDIT_THRESHOLDS
+        mins = AUDIT_THRESHOLDS["naturalness_min_score"]
+        for level, entry in LEVEL_THRESHOLDS.items():
+            assert mins[level] == entry.naturalness_min
+        assert mins["default"] == get_naturalness_min(None)
+
+    def test_get_naturalness_min_score_family_prefix(self) -> None:
+        from audit.config import get_naturalness_min_score
+        assert get_naturalness_min_score("A1") == LEVEL_THRESHOLDS["A1"].naturalness_min
+        assert get_naturalness_min_score("A1-checkpoint") == LEVEL_THRESHOLDS["A1"].naturalness_min
+        assert get_naturalness_min_score("b2-grammar") == LEVEL_THRESHOLDS["B2"].naturalness_min
+
+    def test_level_config_family_target_words(self) -> None:
+        from audit.config import LEVEL_CONFIG
+        for level, entry in LEVEL_THRESHOLDS.items():
+            assert LEVEL_CONFIG[level]["target_words"] == entry.target_words
+
+    def test_get_word_target_honors_variants_and_family_default(self) -> None:
+        from audit.config import get_word_target
+        # Family entry (no focus): reads LEVEL_THRESHOLDS.A1.
+        assert get_word_target("A1") == LEVEL_THRESHOLDS["A1"].target_words
+        # Variant: A1-checkpoint has a smaller override (1000) documented
+        # inline in LEVEL_CONFIG — not pulled into the common table.
+        assert get_word_target("A1", module_focus="checkpoint") == 1000
+
+
+# ---------------------------------------------------------------------------
+# Other migrated consumers
+# ---------------------------------------------------------------------------
+
+class TestOtherConsumers:
+    def test_review_validation_constants(self) -> None:
+        from audit.checks import review_validation
+        assert review_validation._V6_REVIEW_MIN_SCORE == REVIEW_PASS_FLOOR
+        assert review_validation._STYLE_REVIEW_DIMENSION_FLOOR == STYLE_REVIEW_DIMENSION_FLOOR
+
+    def test_scoring_sampling_naturalness_threshold(self) -> None:
+        from scoring import sampling
+        assert sampling.NATURALNESS_THRESHOLD == REVIEW_PASS_FLOOR
+
+    def test_batch_fix_review_pass_threshold(self) -> None:
+        from batch import batch_fix_review
+        assert batch_fix_review.PASS_THRESHOLD == STYLE_REVIEW_TARGET
+
+
+# ---------------------------------------------------------------------------
+# scripts/config.py — dead field stays dead
+# ---------------------------------------------------------------------------
+
+class TestConfigLegacyDeadFields:
+    def test_track_config_has_no_word_floor(self) -> None:
+        import config as scripts_config  # scripts/config.py via sys.path
+        for track, entry in scripts_config.TRACK_CONFIG.items():
+            assert "word_floor" not in entry, f"{track} still carries dead word_floor"


### PR DESCRIPTION
## Summary

EPIC #1451 P2-A. Single source of truth for reviewer floors, style-review targets, audit naturalness gates, and per-level word targets.

- Kills the `word_floor` dead field in `scripts/config.py` TRACK_CONFIG that duplicated — with **different numbers** — the `target_words` in `scripts/audit/config.py` LEVEL_CONFIG (same drift class as ISTORIO 3500-vs-4000).
- Hoists the four reviewer constants out of `scripts/build/v6_build.py` into `scripts/common/thresholds.py`. Legacy names kept as aliases so the 20+ call sites stay put.
- Adds a CI invariant that fails if any threshold literal leaks outside the source-of-truth module.

## Landscape audit (before this PR)

| File:Line | Name | Value | Semantic group | Post-PR status |
|---|---|---|---|---|
| `scripts/build/v6_build.py:113` | `REVIEW_TARGET_SCORE` | `8.0` | per-dim reviewer PASS floor | imported from `common.thresholds.REVIEW_PASS_FLOOR` |
| `scripts/build/v6_build.py:114` | `REVIEW_REJECT_SCORE` | `6.0` | reviewer hard REJECT | imported from `REVIEW_REJECT_FLOOR` |
| `scripts/build/v6_build.py:115` | `STYLE_REVIEW_TARGET_SCORE` | `9.0` | style-reviewer verdict target | imported from `STYLE_REVIEW_TARGET` |
| `scripts/build/v6_build.py:116` | `STYLE_REVIEW_DIMENSION_FLOOR` | `8.5` | style-reviewer per-dim floor | imported from `STYLE_REVIEW_DIMENSION_FLOOR` |
| `scripts/audit/checks/review_validation.py:531-532` | `_STYLE_REVIEW_DIMENSION_FLOOR` / `_V6_REVIEW_MIN_SCORE` | `8.5` / `8.0` | duplicated of above | now reference common imports |
| `scripts/audit/checks/review_gaming.py:122` | `mean >= 8.0` | `8.0` | gaming heuristic | `>= REVIEW_PASS_FLOOR` |
| `scripts/audit/config.py:46-59` | `AUDIT_THRESHOLDS.naturalness_min_score` | per-level `8.0/9.0` | audit gate per level | derived from `LEVEL_THRESHOLDS` |
| `scripts/audit/config.py LEVEL_CONFIG` A1..C2 | `target_words` | 1200..5000 | per-level writer budget + audit gate | family entries read from `LEVEL_THRESHOLDS`; variant entries keep explicit overrides |
| `scripts/config.py TRACK_CONFIG.word_floor` | `word_floor` | A1:2000, A2:2500, B1:3000, B2:3500, C1:4000, C2:5000 | **dead field** — no reader, different values than LEVEL_CONFIG | **deleted** |
| `scripts/scoring/sampling.py:18` | `NATURALNESS_THRESHOLD` | `8.0` | risk-tier escalation gate | imported |
| `scripts/batch/batch_fix_review.py:34` | `PASS_THRESHOLD` | `9.0` | batch fix loop target | imported from `STYLE_REVIEW_TARGET` |
| `scripts/build/pipeline_v5.py:3928` | `_review_score >= 9.0` | `9.0` | review pass shortcut | `>= STYLE_REVIEW_TARGET` |
| `scripts/build/phases/plan_patch.py:96` | `review_target_score: float = 9.0` | `9.0` | plateau extractor default | `= STYLE_REVIEW_TARGET` |
| `scripts/wiki/compile.py:798-799` | `DIMENSION_FLOOR` / `OVERALL_PASS` | `8.0` | wiki review pass gate | imported |
| `scripts/api/{state_compute,dashboard_router,module_dashboard,dashboard_helpers}.py` | `review_score >= 8.0` / `< 8.0` | `8.0` | shippable heuristic | imported |

## Design decisions (judgment calls)

1. **Reviewer floors stay GLOBAL, not per-level.** Reviewer personas evaluate dimensions on their own merits — a 6/10 factual accuracy is weak regardless of CEFR target. The audit-side naturalness gate *is* level-varying (stricter at A1/A2/B1 because source material is thin); that lives on `LevelThresholds.naturalness_min`.
2. **`MODULE_REVIEW_TARGET` kept at 8.0 globally.** Same reasoning — the reviewer score is an absolute-merit call.
3. **Plan `word_target` is a per-module attribute, not a threshold.** `scripts/pipeline/core.py:2051` already replaces the family default with the plan's override when present. Kept as plan YAML attribute — not pulled into `thresholds.py`.
4. **LEVEL_CONFIG variant entries keep their explicit overrides.** `A1-checkpoint` at 1000 words, `A2-grammar` at 2000, `B2-biography` at 4000 etc. are legitimate per-variant tuning, not drift. Only the family entries (A1..C2) are wired to `LEVEL_THRESHOLDS`.
5. **Legacy aliases in v6_build.py.** Kept `REVIEW_TARGET_SCORE` etc. as `= REVIEW_PASS_FLOOR` to avoid churning 20+ call sites + 6 test monkeypatches. `alignment_manifest._load_v6_build_constant` hardened to resolve Name-alias RHSs so the AST fallback path stays functional.
6. **CI invariant allow-list, kept SHORT.** Four entries, each with a one-line justification: `scoring/report.py` display heuristic (×2), `review_validation.py` gaming heuristic (9.0 means "suspiciously perfect" — different semantic from STYLE_REVIEW_TARGET), `scoring/caps.py` cap values (not pass/fail gates), and `v6_build.py` docstring.

## Test plan

- [x] `.venv/bin/ruff check scripts/ tests/` clean
- [x] `tests/test_threshold_source_of_truth.py` — 6 invariant tests pass (detect canonical-name redeclaration, module-level threshold literals, threshold-valued floats in threshold context, AUDIT_THRESHOLDS/LEVEL_THRESHOLDS sync, LEVEL_CONFIG family/LEVEL_THRESHOLDS sync, word_floor deletion stays deleted)
- [x] `tests/test_thresholds_consumers.py` — 20 consumer tests pass (thresholds module shape + immutability + fallback, v6_build aliases, audit.config derivation, review_validation / sampling / batch_fix_review / TRACK_CONFIG coupling)
- [x] `tests/test_alignment_manifest.py` — 10 tests pass (AST fallback still resolves after alias change)
- [x] `tests/test_pipeline_v5.py` / `tests/test_plan_patch.py` / `tests/test_module_dashboard.py` / threshold-adjacent tests — all green
- [x] Full non-integration pytest suite: **5995 passed**. The 43 failures are pre-existing on `origin/main` (verified via `git stash`) — env-specific missing VESUM DB / `.venv` / data fixtures in the worktree, not caused by this PR.

## Unblocks

- EPIC #1451 Phase 5 (colors rebuild) gate #3 of 4
- ADR-007 PR-E (decision-journal flip to ACCEPTED)

Closes #1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)