### PR TITLE
refactor(contract): ADR-007 PR-C — kill WORD_BUDGET auto-heal

### DIFF
--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -8859,86 +8859,6 @@ def _contract_budget_for_section(contract: dict, section_name: str) -> tuple[str
     return resolved_name, budget
 
 
-def _apply_contract_word_budget_rewrites(
-    content_path: Path,
-    *,
-    level: str,
-    module_num: int,
-    slug: str,
-    writer: str,
-    contract: dict,
-    contract_violations: list[dict],
-) -> tuple[bool, int]:
-    """Auto-heal pure WORD_BUDGET blockers with targeted section rewrites."""
-    blocking = [
-        violation
-        for violation in contract_violations
-        if str(violation.get("severity") or "").upper() == "ERROR"
-    ]
-    if not blocking:
-        return False, 0
-
-    blocking_types = {str(violation.get("type") or "").strip() for violation in blocking}
-    if blocking_types != {"WORD_BUDGET"}:
-        return False, 0
-
-    spans = _section_spans(content_path.read_text("utf-8"))
-    applied = 0
-    seen_sections: set[str] = set()
-
-    for violation in blocking:
-        section_name = str(violation.get("section") or "").strip()
-        if not section_name or section_name in seen_sections:
-            continue
-
-        resolved_title = _resolve_section_title(section_name, spans)
-        if resolved_title is None:
-            continue
-        section_span = next(
-            (span for span in spans if span["title"] == resolved_title),
-            None,
-        )
-        if section_span is None:
-            continue
-
-        budget_entry = _contract_budget_for_section(contract, resolved_title)
-        if budget_entry is None:
-            continue
-        _, budget = budget_entry
-        min_words = int(budget.get("min") or 0)
-        target_words = int(budget.get("target") or min_words or 0)
-        current_words = _section_body_word_count(section_span)
-        if min_words <= 0 or current_words >= min_words:
-            continue
-
-        deficit = min_words - current_words
-        directive = "\n".join(
-            [
-                "Contract repair: this section is below its required word minimum.",
-                "- Issue type: WORD_BUDGET",
-                f"- Current section words: {current_words}",
-                f"- Contract minimum: {min_words}",
-                f"- Contract target: {target_words}",
-                f"- Add at least {deficit} words of concrete learner-facing content.",
-                "- Expand the section with natural Ukrainian teaching prose, examples, or dialogue turns that fit the existing lesson.",
-                "- Do not add filler, meta-commentary, or generic padding.",
-            ]
-        )
-        if _rewrite_block_section(
-            content_path,
-            level=level,
-            module_num=module_num,
-            slug=slug,
-            writer=writer,
-            section_name=resolved_title,
-            directive=directive,
-        ):
-            applied += 1
-            seen_sections.add(section_name)
-
-    return applied > 0, applied
-
-
 def _atomic_write_text(path: Path, body: str) -> None:
     """Write *body* to *path* atomically via ``os.replace``.
 
@@ -9362,25 +9282,6 @@ def _run_review_heal_loop(
             content_path.read_text("utf-8"),
             contract,
         )
-        word_budget_rewrite_applied, word_budget_rewrite_count = _apply_contract_word_budget_rewrites(
-            content_path,
-            level=level,
-            module_num=module_num,
-            slug=slug,
-            writer=writer,
-            contract=contract,
-            contract_violations=final_contract_violations,
-        )
-        if word_budget_rewrite_applied:
-            _log(
-                f"\n📏 Applied {word_budget_rewrite_count} contract word-budget rewrite(s) "
-                f"from R{round_index}"
-            )
-            step_verify(content_path, level, module_num)
-            final_contract_violations = check_contract_compliance(
-                content_path.read_text("utf-8"),
-                contract,
-            )
         _save_contract_compliance(
             level,
             slug,
@@ -9498,9 +9399,7 @@ def _run_review_heal_loop(
         # resolved the reviewer's complaints. If the confirmation review
         # passes, the plateau becomes a pass; otherwise the plateau still
         # fires, but at least on honest data.
-        mutated_this_round = (
-            fixes_applied or rewrite_applied or word_budget_rewrite_applied
-        )
+        mutated_this_round = fixes_applied or rewrite_applied
         if decision.outcome == "plateau" and mutated_this_round:
             _log(
                 f"\n🔁 Running post-mutation confirmation review on R{round_index}'s "

--- a/tests/test_v6_contract_flow.py
+++ b/tests/test_v6_contract_flow.py
@@ -155,94 +155,6 @@ def test_apply_review_rewrite_blocks_rewrites_only_target_section(tmp_path: Path
     assert "Old practice." not in updated
 
 
-def test_apply_contract_word_budget_rewrites_targets_only_budget_blockers(
-    tmp_path: Path, monkeypatch
-) -> None:
-    level = "a1"
-    slug = "word-budget-autoheal"
-    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
-    content_path = curriculum_root / level / f"{slug}.md"
-    content_path.parent.mkdir(parents=True, exist_ok=True)
-    content_path.write_text(
-        "## Intro\nОдне коротке речення.\n\n"
-        "## Practice\nТут уже достатньо слів для перевірки.\n",
-        "utf-8",
-    )
-
-    calls: list[tuple[str, str]] = []
-
-    def fake_rewrite(*args, **kwargs):
-        calls.append((kwargs["section_name"], kwargs["directive"]))
-        return True
-
-    monkeypatch.setattr(v6_build, "_rewrite_block_section", fake_rewrite)
-
-    ok, count = v6_build._apply_contract_word_budget_rewrites(
-        content_path,
-        level=level,
-        module_num=1,
-        slug=slug,
-        writer="gemini",
-        contract={
-            "section_word_budgets": {
-                "Intro": {"target": 100, "min": 90, "max": 110},
-                "Practice": {"target": 100, "min": 90, "max": 110},
-            }
-        },
-        contract_violations=[
-            {
-                "type": "WORD_BUDGET",
-                "severity": "ERROR",
-                "section": "Intro",
-                "message": "Section 'Intro' has 10 words; contract minimum is 90",
-            }
-        ],
-    )
-
-    assert ok is True
-    assert count == 1
-    assert calls[0][0] == "Intro"
-    assert "Issue type: WORD_BUDGET" in calls[0][1]
-    assert "Contract minimum: 90" in calls[0][1]
-    assert "Contract target: 100" in calls[0][1]
-    assert "Add at least" in calls[0][1]
-
-
-def test_apply_contract_word_budget_rewrites_skips_mixed_violation_sets(
-    tmp_path: Path, monkeypatch
-) -> None:
-    content_path = tmp_path / "module.md"
-    content_path.write_text("## Intro\nКороткий текст.\n", "utf-8")
-
-    monkeypatch.setattr(v6_build, "_rewrite_block_section", lambda *args, **kwargs: True)
-
-    ok, count = v6_build._apply_contract_word_budget_rewrites(
-        content_path,
-        level="a1",
-        module_num=1,
-        slug="mixed-violations",
-        writer="gemini",
-        contract={"section_word_budgets": {"Intro": {"target": 100, "min": 90, "max": 110}}},
-        contract_violations=[
-            {
-                "type": "WORD_BUDGET",
-                "severity": "ERROR",
-                "section": "Intro",
-                "message": "Section 'Intro' has 10 words; contract minimum is 90",
-            },
-            {
-                "type": "ACTIVITY_MISSING",
-                "severity": "ERROR",
-                "section": "Intro",
-                "message": "Missing required activity marker.",
-            },
-        ],
-    )
-
-    assert ok is False
-    assert count == 0
-
-
 def test_rewrite_block_section_emits_slim_prompt_manifest(tmp_path: Path, monkeypatch) -> None:
     level = "a1"
     slug = "rewrite-prompt-audit"
@@ -666,9 +578,19 @@ def test_main_clears_stale_terminal_after_review_pass(
     assert (orch_dir / "plan_revision_request.yaml").exists() is False
 
 
-def test_run_review_heal_loop_triggers_word_budget_autoheal(tmp_path: Path, monkeypatch) -> None:
+def test_run_review_heal_loop_word_budget_error_no_longer_triggers_autoheal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """ADR-007 PR-C: WORD_BUDGET ERROR no longer auto-heals via section regeneration.
+
+    With the M5 auto-heal removed, an unrepairable WORD_BUDGET ERROR must
+    surface as ``contract_blocking`` on the round state and prevent the
+    loop from declaring ``pass``. The reviewer's ``insert_after:`` repair
+    path is the only remaining mechanism; if the reviewer emits none, the
+    round stays blocked and the loop plateaus (downstream → terminal).
+    """
     level = "a1"
-    slug = "review-word-budget"
+    slug = "review-word-budget-no-heal"
     curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
     content_path = curriculum_root / level / f"{slug}.md"
     content_path.parent.mkdir(parents=True, exist_ok=True)
@@ -681,66 +603,42 @@ def test_run_review_heal_loop_triggers_word_budget_autoheal(tmp_path: Path, monk
     packet_path.write_text("packet", "utf-8")
 
     monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    # Every round: reviewer reports PASS (score 9.3) but contract-compliance
+    # still emits a WORD_BUDGET ERROR. Before PR-C the heal would mutate
+    # the content and the follow-up round cleared; now the violation sticks
+    # and ``contract_blocking`` keeps the loop from returning outcome=pass.
     review_rounds = iter(
         [
-            (False, 9.1, "## Verdict: REVISE\n<fixes></fixes>\n"),
+            (True, 9.3, "## Verdict: PASS\n"),
             (True, 9.3, "## Verdict: PASS\n"),
         ]
     )
-
     monkeypatch.setattr(v6_build, "step_review", lambda *args, **kwargs: next(review_rounds))
     monkeypatch.setattr(v6_build, "_apply_review_fixes", lambda *args, **kwargs: (False, 0))
     monkeypatch.setattr(v6_build, "_apply_review_rewrite_blocks", lambda *args, **kwargs: (False, 0))
-
-    verify_calls = {"count": 0}
-
-    def fake_verify(*args, **kwargs):
-        verify_calls["count"] += 1
-        return "complete"
-
-    monkeypatch.setattr(v6_build, "step_verify", fake_verify)
+    monkeypatch.setattr(v6_build, "step_verify", lambda *args, **kwargs: "complete")
     monkeypatch.setattr(
         v6_build,
         "_ensure_contract_artifacts",
         lambda *args, **kwargs: (
-            {
-                "section_word_budgets": {
-                    "Intro": {"target": 100, "min": 90, "max": 110},
-                    "Practice": {"target": 100, "min": 90, "max": 110},
-                }
-            },
+            {"section_word_budgets": {"Intro": {"target": 100, "min": 90, "max": 110}}},
             {},
         ),
     )
-
-    review_passes = iter(
-        [
-            [
-                {
-                    "type": "WORD_BUDGET",
-                    "severity": "ERROR",
-                    "section": "Intro",
-                    "message": "Section 'Intro' has 10 words; contract minimum is 90",
-                }
-            ],
-            [],
-            [],
-        ]
-    )
-
+    word_budget_violation = {
+        "type": "WORD_BUDGET",
+        "severity": "ERROR",
+        "section": "Intro",
+        "message": "Section 'Intro' has 10 words; contract minimum is 90",
+    }
     monkeypatch.setattr(
         "audit.checks.contract_compliance.check_contract_compliance",
-        lambda *args, **kwargs: next(review_passes),
+        lambda *args, **kwargs: [word_budget_violation],
     )
-
-    autoheal_calls: list[dict] = []
-
-    def fake_word_budget_autoheal(*args, **kwargs):
-        autoheal_calls.append(kwargs)
-        return (len(autoheal_calls) == 1), (1 if len(autoheal_calls) == 1 else 0)
-
-    monkeypatch.setattr(v6_build, "_apply_contract_word_budget_rewrites", fake_word_budget_autoheal)
     monkeypatch.setattr(v6_build, "_save_contract_compliance", lambda *args, **kwargs: None)
+
+    # Make sure even dead-code lookups can't silently resurrect the heal path.
+    assert not hasattr(v6_build, "_apply_contract_word_budget_rewrites")
 
     result = v6_build._run_review_heal_loop(
         content_path,
@@ -752,11 +650,12 @@ def test_run_review_heal_loop_triggers_word_budget_autoheal(tmp_path: Path, monk
         max_rounds=2,
     )
 
-    assert result.outcome == "pass"
-    assert len(autoheal_calls) >= 1
-    assert autoheal_calls[0]["writer"] == "gemini"
-    assert autoheal_calls[0]["contract_violations"][0]["type"] == "WORD_BUDGET"
-    assert verify_calls["count"] == 1
+    # Without the heal, contract_blocking remains True and the loop exits
+    # as plateau (max_rounds hit with non-passing state). A downstream
+    # terminal emitter would then write plan_revision_request.yaml.
+    assert result.outcome == "plateau"
+    assert result.rounds[-1].contract_blocking is True
+    assert result.rounds[-1].contract_violations[0]["type"] == "WORD_BUDGET"
 
 
 _HEAL_LOOP_DIMENSIONS = (
@@ -822,11 +721,6 @@ def _setup_heal_loop_fixture(tmp_path: Path, monkeypatch, slug: str) -> Path:
     monkeypatch.setattr(
         "audit.checks.contract_compliance.check_contract_compliance",
         lambda *args, **kwargs: [],
-    )
-    monkeypatch.setattr(
-        v6_build,
-        "_apply_contract_word_budget_rewrites",
-        lambda *args, **kwargs: (False, 0),
     )
     monkeypatch.setattr(v6_build, "_save_contract_compliance", lambda *args, **kwargs: None)
     return content_path
@@ -1172,49 +1066,6 @@ def test_review_loop_confirmation_triggers_on_two_small_deltas_plateau(
 
     assert result.outcome == "pass"
     assert result.rounds[-1].score == 9.7
-
-
-def test_review_loop_confirmation_triggers_on_word_budget_rewrite_only(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """Bug #1316 Bug B — word_budget_rewrite alone must trigger confirmation.
-
-    The three mutation paths are independent: main fixes, rewrite blocks,
-    and word-budget rewrites. A round where ONLY the word-budget rewrite
-    applied still changes content and still invalidates the pre-fix
-    review score, so confirmation must run.
-    """
-    content_path = _setup_heal_loop_fixture(tmp_path, monkeypatch, slug="conf-word-budget")
-
-    review_rounds = iter(
-        [
-            (False, 9.0, "## Verdict: REVISE\n"),
-            (False, 9.1, "## Verdict: REVISE\n"),
-            (True, 9.5, _fake_review_text(10, "PASS")),  # confirmation
-        ]
-    )
-    monkeypatch.setattr(v6_build, "step_review", lambda *args, **kwargs: next(review_rounds))
-    monkeypatch.setattr(v6_build, "_apply_review_fixes", lambda *args, **kwargs: (False, 0))
-    monkeypatch.setattr(v6_build, "_apply_review_rewrite_blocks", lambda *args, **kwargs: (False, 0))
-    # Only word-budget rewrite applies a mutation.
-    monkeypatch.setattr(
-        v6_build,
-        "_apply_contract_word_budget_rewrites",
-        lambda *args, **kwargs: (True, 1),
-    )
-
-    result = v6_build._run_review_heal_loop(
-        content_path,
-        level="a1",
-        module_num=1,
-        slug="conf-word-budget",
-        writer="gemini",
-        reviewer_override="codex-tools",
-        max_rounds=2,
-    )
-
-    assert result.outcome == "pass"
-    assert result.rounds[-1].score == 9.5
 
 
 def test_review_loop_confirmation_pass_blocked_by_contract_errors(

--- a/tests/test_v6_review_regression_guard.py
+++ b/tests/test_v6_review_regression_guard.py
@@ -7,9 +7,9 @@ The tests exercise ``_run_review_heal_loop`` with the heavy pieces
 monkeypatched out:
 
 * ``step_review`` → a scripted sequence of (passed, score, text)
-* ``_apply_review_fixes`` / ``_apply_review_rewrite_blocks`` /
-  ``_apply_contract_word_budget_rewrites`` → no-ops that mutate
-  the content file when a test wants to simulate a bad round
+* ``_apply_review_fixes`` / ``_apply_review_rewrite_blocks`` → no-ops
+  that mutate the content file when a test wants to simulate a bad
+  round
 * ``step_verify`` → no-op
 * ``check_contract_compliance`` → returns no violations
 
@@ -66,10 +66,6 @@ def _patch_noop_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub the heavy parts of the heal loop that aren't under test."""
     monkeypatch.setattr(
         v6_build, "_apply_review_rewrite_blocks",
-        lambda *a, **kw: (False, 0),
-    )
-    monkeypatch.setattr(
-        v6_build, "_apply_contract_word_budget_rewrites",
         lambda *a, **kw: (False, 0),
     )
     monkeypatch.setattr(v6_build, "step_verify", lambda *a, **kw: None)


### PR DESCRIPTION
## Summary

ADR-007 Phase-C KILL (mechanism M5). Unrepairable WORD_BUDGET ERROR becomes a `plan_revision_request` terminal instead of triggering auto-heal section regeneration.

## Context

Per user sign-off on ADR-007 Open Question 2 (Y): accept terminal outcome. A chronic section undershoot means the plan or the writer prompt is under-specified — not something to paper over with auto-regeneration.

## Deletion scope

- `_apply_contract_word_budget_rewrites` — the function that took a pure-WORD_BUDGET contract-violation set, built a targeted expansion directive, and called `_rewrite_block_section` to regenerate the undersized section.
- Its invoker inside `_run_review_heal_loop` (the post-fix/post-rewrite leg that re-ran the contract check and kicked off word-budget mutation).
- The `word_budget_rewrite_applied` leg of the `mutated_this_round` gate (confirmation-review trigger now just `fixes_applied or rewrite_applied`).

## Repair path (unchanged)

The `<fixes>` `insert_after:` mechanism (see `v6_build.py:8238-8270`, `phases/v6-review.md:167`) remains the reviewer's tool for repairing WORD_BUDGET shortfalls: the reviewer emits an anchor + text payload, `_apply_review_fixes` inserts it deterministically. If the reviewer can emit an `insert_after:` entry that grows the section enough, the module converges via the normal review-finding path. Otherwise the loop plateaus with `contract_blocking=True` on the final round, and the downstream terminal emitter writes `plan_revision_request.yaml`.

Note: `_run_review_heal_loop` itself is dead-for-production (replaced by `_run_convergence_loop` since the ADR-007 spec). The live convergence loop already routes WORD_BUDGET violations through the standard tier-selected repair path (see `convergence_loop.py` and `_CONTRACT_VIOLATION_TO_FINDING` in `v6_build.py:9687` — Plan Adherence / critical). The deletion removes the last piece of heal-tier machinery from the legacy loop so tests can't keep it alive.

## Test plan

- [x] Deleted heal-path unit tests (`test_apply_contract_word_budget_rewrites_targets_only_budget_blockers`, `test_apply_contract_word_budget_rewrites_skips_mixed_violation_sets`)
- [x] Deleted `test_review_loop_confirmation_triggers_on_word_budget_rewrite_only` — its scenario (only word-budget mutation applied) is now impossible; confirmation-review coverage for the surviving two mutation paths is already tested elsewhere
- [x] Retargeted `test_run_review_heal_loop_triggers_word_budget_autoheal` → `test_run_review_heal_loop_word_budget_error_no_longer_triggers_autoheal`: asserts the loop plateaus with `contract_blocking=True` when a WORD_BUDGET ERROR persists and the reviewer emits no `insert_after:` repair — the terminal-path precondition
- [x] Dropped the `_apply_contract_word_budget_rewrites` monkeypatch from `_setup_heal_loop_fixture` and from `test_v6_review_regression_guard.py` `_patch_noop_side_effects`
- [x] Grep invariant: `rg '_apply_contract_word_budget_rewrites|word_budget_rewrite_applied|word_budget_heal|word_budget_autoheal' scripts/build/ tests/` → zero residue (the only remaining hit is the `assert not hasattr` invariant in the new terminal test)
- [x] ruff clean on `scripts/build/` + `tests/`
- [x] Targeted pytest: `tests/test_v6_contract_flow.py` + `tests/test_v6_review_regression_guard.py` — 42/42 passing
- [x] Wider review/contract/convergence/v6 sweep — 697/697 passing (the 2 pre-existing failures on this tree — `test_plan_hash.py::test_resume_reruns_stale_phase` and `test_a1_review_scores.py::test_all_modules_have_orchestration_dirs` — reproduce on clean `origin/main`, unrelated to this change)

Refs #1456. Supersedes #1288. Part of #1451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)