### PR TITLE
docs(adr): ADR-007 ACCEPTED — close superseded issues + decision-journal alignment

### DIFF
--- a/.claude/phases/gemini/beginner-full-rag.md
+++ b/.claude/phases/gemini/beginner-full-rag.md
@@ -41,10 +41,13 @@ Your content will be scored on these 7 dimensions (see GEMINI.md for details):
 
 | Tool | When | Example |
 |------|------|---------|
+| `search_sources` | Preferred unified retrieval across textbooks, literary, Wikipedia, external, and ukrainian_wiki | `search_sources("{TOPIC_KEYWORDS}", track="a1")` |
 | `search_text` | Find textbook pedagogy | `search_text("{TOPIC_KEYWORDS}", grade={TEXTBOOK_GRADE})` |
 | `verify_words` | Check words exist in VESUM | `verify_words(["книга", "великий"])` |
 | `verify_lemma` | Get inflected forms | `verify_lemma("книга")` |
 | `query_pravopys` | Spelling/grammar rules | `query_pravopys("апостроф")` |
+
+Use `search_text` only when you explicitly want textbook-only scoping.
 
 ### What the Learner Already Knows
 

--- a/.claude/phases/gemini/phase-A-core.md
+++ b/.claude/phases/gemini/phase-A-core.md
@@ -41,10 +41,13 @@ Research **{TOPIC_TITLE}** for the **{LEVEL}** core track. Core tracks need ligh
 
 | Tool | When to use |
 |------|-------------|
+| `search_sources` | Preferred unified retrieval across textbooks, literary, Wikipedia, external, and ukrainian_wiki |
 | `search_text` | Find how this topic is taught in Ukrainian textbooks |
 | `verify_words` | Check vocabulary exists in VESUM dictionary |
 | `query_grac` mode=`frequency` | Get word frequency data |
 | `query_wikipedia` mode=`summary` | Quick fact-check for cultural hooks |
+
+Use `search_text` only when you explicitly need textbook-only scoping.
 
 ### Research Requirements
 

--- a/.claude/phases/gemini/phase-D1-structured-review.md
+++ b/.claude/phases/gemini/phase-D1-structured-review.md
@@ -115,16 +115,17 @@ You have access to RAG tools for linguistic verification. **Use them actively** 
 
 ### Textbook Cross-Reference
 
+- **`mcp__sources__search_sources`**: **PREFERRED** unified source search across textbooks, literary works, Wikipedia, external articles, and the ukrainian_wiki pedagogy corpus. Use this as the default cross-check for grammar claims and pedagogy.
 - **`mcp__sources__search_text`**: Search Ukrainian school textbooks (1.2K+ chunks) for grammar explanations, vocabulary usage, and pedagogical approaches. Use this to verify grammar rules stated in the content.
 - **`mcp__sources__search_images`**: Search textbook illustrations for visual aids that could enhance the content.
 - **`mcp__sources__search_literary`**: Search primary literary sources for quote verification.
 
-**When to cross-reference**: (a) Grammar rule claims — verify they match textbook explanations, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — check if textbooks use similar patterns.
+**When to cross-reference**: (a) Grammar rule claims — start with `mcp__sources__search_sources`, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — compare against authentic Ukrainian-source usage. Use `mcp__sources__search_text` only when you need textbook-only scoping.
 
 ### Verification Protocol
 
 1. For each word flagged ❌ in pre-scan: call `mcp__sources__verify_word` to confirm/dismiss
-2. For grammar explanations: call `mcp__sources__search_text` with the grammar topic to verify accuracy
+2. For grammar explanations: call `mcp__sources__search_sources` first; fall back to `mcp__sources__search_text` only if you need textbook-only scope
 3. For suspicious Russianisms: call `mcp__sources__verify_word` on the suspect word AND its Ukrainian alternative
 4. Report your RAG findings in the review — cite tool results as evidence
 

--- a/.claude/phases/gemini/research-core.md
+++ b/.claude/phases/gemini/research-core.md
@@ -41,10 +41,13 @@ Research **{TOPIC_TITLE}** for the **{LEVEL}** core track. Core tracks need ligh
 
 | Tool | When to use |
 |------|-------------|
+| `search_sources` | Preferred unified retrieval across textbooks, literary, Wikipedia, external, and ukrainian_wiki |
 | `search_text` | Find how this topic is taught in Ukrainian textbooks |
 | `verify_words` | Check vocabulary exists in VESUM dictionary |
 | `query_grac` mode=`frequency` | Get word frequency data |
 | `query_wikipedia` mode=`summary` | Quick fact-check for cultural hooks |
+
+Use `search_text` only when you explicitly need textbook-only scoping.
 
 ### Research Requirements
 

--- a/.claude/phases/gemini/review-structured.md
+++ b/.claude/phases/gemini/review-structured.md
@@ -118,16 +118,17 @@ You have access to RAG tools for linguistic verification. **Use them actively** 
 
 ### Textbook Cross-Reference
 
+- **`mcp__sources__search_sources`**: **PREFERRED** unified source search across textbooks, literary works, Wikipedia, external articles, and the ukrainian_wiki pedagogy corpus. Use this as the default cross-check for grammar claims and pedagogy.
 - **`mcp__sources__search_text`**: Search Ukrainian school textbooks (1.2K+ chunks) for grammar explanations, vocabulary usage, and pedagogical approaches. Use this to verify grammar rules stated in the content.
 - **`mcp__sources__search_images`**: Search textbook illustrations for visual aids that could enhance the content.
 - **`mcp__sources__search_literary`**: Search primary literary sources for quote verification.
 
-**When to cross-reference**: (a) Grammar rule claims — verify they match textbook explanations, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — check if textbooks use similar patterns.
+**When to cross-reference**: (a) Grammar rule claims — start with `mcp__sources__search_sources`, (b) cultural claims in callout boxes, (c) example sentences that seem unnatural — compare against authentic Ukrainian-source usage. Use `mcp__sources__search_text` only when you need textbook-only scoping.
 
 ### Verification Protocol
 
 1. For each word flagged ❌ in pre-scan: call `mcp__sources__verify_word` to confirm/dismiss
-2. For grammar explanations: call `mcp__sources__search_text` with the grammar topic to verify accuracy
+2. For grammar explanations: call `mcp__sources__search_sources` first; fall back to `mcp__sources__search_text` only if you need textbook-only scope
 3. For suspicious Russianisms: call `mcp__sources__verify_word` on the suspect word AND its Ukrainian alternative
 4. Report your RAG findings in the review — cite tool results as evidence
 

--- a/claude_extensions/rules/pipeline.md
+++ b/claude_extensions/rules/pipeline.md
@@ -16,8 +16,7 @@ paths:
 - **v5, v4, and v3 are RETIRED.** Do not use `build_module_v5.py` or `build_module.py`.
 - **Writer default (on `main` since 5e2afbd092, 2026-04-23):** `claude-tools` (Opus). Gemini remains available via `--writer gemini-tools` for research + exercises. Post-#1431 v2: `claude-tools` chosen for module writing while residual writer-quality gaps on colors are being closed (#1449 → EPIC #1451).
 - **Codex** is the primary pipeline reviewer (cross-agent, max 2 fix attempts). Claude reserved for dimensions requiring cultural/creative nuance.
-- **Reviewer-as-fixer**: reviewer outputs `<fixes>` find/replace pairs, pipeline applies deterministically.
-  > ⚠️ **Live contradiction (tracked as #1456):** `scripts/build/convergence_loop.py:595-607` still has `section_rewrite` / `full_rewrite` / `writer_swap` strategies despite the no-rewrite decision. Kill-or-revert pending — do not add new rewrite strategies until Phase 2-C of EPIC #1451 resolves.
+- **Reviewer-as-fixer**: reviewer outputs `<fixes>` find/replace pairs, pipeline applies deterministically. No LLM regeneration during review — enforced by ADR-007 / dec-007 and the structural invariant test `tests/test_no_rewrite_contract.py`.
 - **Writer-driven словнік**: writer generates vocabulary with contextual translations
 - **Plans**: DRAFT → REVIEWED → LOCKED lifecycle. Review plan before content build.
 - Model defaults: Claude writer `claude-opus-4-7` @ xhigh | Gemini `gemini-3.1-pro-preview` | Codex reviewer via `codex-tools`

--- a/docs/decisions/2026-04-23-rewrite-strategies-kill-or-revert.md
+++ b/docs/decisions/2026-04-23-rewrite-strategies-kill-or-revert.md
@@ -1,6 +1,6 @@
 # ADR-007: Kill the rewrite strategies — enforce reviewer-as-fixer parity
 
-**Status**: APPROVED 2026-04-23 by Krisztian K. (Y/Y/Y on Open Questions). Flips to ACCEPTED when P2-A (#1454) merges and PR-E lands per the Migration Plan gating.
+**Status**: ACCEPTED 2026-04-24 (flipped after P2-A #1454 + PR-A #1500, PR-B #1499, PR-C #1506, PR-D #1509, PR-F #1508 all merged).
 **Date**: 2026-04-23
 **Deciders**: Engineering (Krisztian K. — signed off 2026-04-23)
 **Related**: EPIC #1451 (Phase 2-C), closer #1456, pipeline rule `claude_extensions/rules/pipeline.md`, decision `dec-001` (reviewer-as-fixer, active since 2026-03-24)

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -11,3 +11,4 @@ Staleness check: `.venv/bin/python scripts/check_decisions.py`
 | dec-003 | 2026-04-03 | 2026-07-03 | pipeline | active | Cap review fix rounds at 4 with degradation detection |
 | dec-004 | 2026-03-28 | 2026-06-28 | architecture | active | Bare slug filenames, no number prefixes |
 | dec-005 | 2026-04-03 | 2026-07-03 | tooling | active | Keep gemini-cli, fix dispatch retry logic |
+| dec-007 | 2026-04-24 | 2027-04-23 | pipeline | active | Enforce dec-001 at code level — no LLM regeneration during review (ADR-007) |

--- a/docs/decisions/decisions.yaml
+++ b/docs/decisions/decisions.yaml
@@ -116,3 +116,34 @@ decisions:
         rejected_because: "Requires API key, lower rate limits than Pro subscription"
     superseded_by: null
     depends_on: []
+
+  - id: dec-007
+    status: active
+    date: "2026-04-24"
+    expires: "2027-04-23"
+    scope: pipeline
+    title: "Enforce dec-001 at code level — no LLM regeneration during review"
+    reasoning: >
+      ADR-007 enforces dec-001 at the code level. All in-loop rewrite
+      mechanisms removed: tier strategies (section_rewrite, full_rewrite,
+      writer_swap), the reviewer-emitted <rewrite-block> protocol, the
+      WORD_BUDGET auto-heal, and ~400 LOC of rewrite-block infrastructure.
+      Convergence ladder collapses to two strategies — patch and
+      plan_revision_request terminal. Empirical re-validation: a1/colors
+      smoke (2026-04-23) reproduced the 9.6→8.4 degradation pattern that
+      drove dec-001, with full_rewrite reintroducing the same flag-color
+      hallucination the <fixes> block had already corrected. Longer expiry
+      (12 months) because the underlying policy has been re-validated twice
+      on independent evidence; reintroducing rewrites requires NEW empirical
+      evidence that FROM-SCRATCH rewrites do not degrade content.
+    evidence: "ADR-007 (docs/decisions/2026-04-23-rewrite-strategies-kill-or-revert.md), PR-A #1500, PR-B #1499, PR-C #1506, PR-D #1509, PR-F #1508, closer #1456, a1/colors smoke 2026-04-23"
+    alternatives:
+      - option: "REVERT — accept rewrites with documented constraints"
+        rejected_because: "No new empirical data in favour; 9.6→8.4 degradation re-demonstrated on a1/colors 2026-04-23"
+      - option: "Keep section_rewrite only (kill full_rewrite + writer_swap)"
+        rejected_because: "Same LLM-regeneration class; partial kill leaves drift surface intact"
+      - option: "Stub the rewrite tiers instead of deleting"
+        rejected_because: "Stubs invite revival; structural invariant test (PR-F #1508) needs hard absence"
+    superseded_by: null
+    depends_on:
+      - dec-001


### PR DESCRIPTION
## Summary

Final PR in the ADR-007 migration plan. All dependencies have merged (P2-A #1454; PR-A #1500, PR-B #1499, PR-C #1506, PR-D #1509, PR-F #1508). ADR-007 flips APPROVED → ACCEPTED (2026-04-24).

## Changes

- **ADR-007 status → ACCEPTED**, with merge-gating PRs listed inline (`docs/decisions/2026-04-23-rewrite-strategies-kill-or-revert.md`).
- **`decisions.yaml`** gains `dec-007` (depends_on `dec-001`; 12-month expiry per ADR §Expiry; alternatives recorded for the rejected REVERT path, partial-kill path, and stub-instead-of-delete path).
- **`INDEX.md`** lists `dec-007`.
- **`claude_extensions/rules/pipeline.md`** — "Live contradiction" warning retired. Replaced with the positive enforcement statement: *"No LLM regeneration during review — enforced by ADR-007 / dec-007 and the structural invariant test `tests/test_no_rewrite_contract.py`."*
- Rules redeployed to `.claude/` via `npm run claude:deploy`.

### Side effect (deploy drift)

The `npm run claude:deploy` run also synced `.claude/phases/gemini/*.md` updates that had been merged into `claude_extensions/` via #1411 (unified `search_sources` tool) but never deployed to `.claude/`. Five files picked up the `search_sources` mention in their RAG-tool tables. Unrelated to ADR-007 in intent; included because deploy-as-sync naturally surfaces drift, and leaving it for the next deploy would just push the same cleanup into someone else's diff.

## Closes

- #1456 — ADR-007 closer
- #1268 — *obsolete* (per-call Gemini budget cap for section rewrites moot; section rewrites removed)
- #1277 — *obsolete* (rewrite-block prompt slimming + prompt-audit guards moot for rewrite prompts; prompt-audit pattern preserved architecturally)
- #1288 — *rejected* (WORD_BUDGET auto-heal contradicted dec-001; failures now surface as terminals or `<fixes>` `insert_after:` repairs)
- #1322 — *partially shipped, now tightened* (convergent pipeline ships without the three rewrite tiers; terminals + `stuck-modules.yaml` retained)

## Test plan

- [x] `.venv/bin/python scripts/check_decisions.py` — clean (6 active, 6 total, no stale)
- [x] `.venv/bin/ruff check scripts/` — All checks passed
- [x] `.venv/bin/python -m pytest tests/test_no_rewrite_contract.py tests/test_convergence_loop.py` — 31 passed
- [x] `grep -RE 'Live contradiction' claude_extensions/ .claude/` — zero matches outside the ADR's own historical-context quote
- [ ] Supersede comments posted on #1268/#1277/#1288/#1322 immediately after PR opens, then issues closed

Refs #1451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)