### PR TITLE
fix(unicode): preserve й/ї during normalization (#1487)

### DIFF
--- a/scripts/audit/checks/grammar.py
+++ b/scripts/audit/checks/grammar.py
@@ -6,8 +6,9 @@ and case government rules based on CEFR level.
 """
 
 import re
-import unicodedata
 from typing import Any
+
+from common.text_utils import strip_ukrainian_stress
 
 from ..cleaners import extract_ukrainian_sentences
 from ..config import (
@@ -34,7 +35,7 @@ def _resolve_constraints(level_code: str) -> dict[str, Any]:
 
 def _strip_stress(s: str) -> str:
     """Strip combining acute accent (U+0301) — stress marks break \\w regex matching."""
-    return unicodedata.normalize('NFD', s).replace('\u0301', '')
+    return strip_ukrainian_stress(s)
 
 
 def is_fixed_phrase(match: str, text: str, phrase_set: set) -> bool:
@@ -281,4 +282,3 @@ def check_case_government(content: str, level_code: str) -> list[dict]:
                 })
 
     return violations
-

--- a/scripts/audit/checks/plan_adherence.py
+++ b/scripts/audit/checks/plan_adherence.py
@@ -15,11 +15,11 @@ Issue: #849
 from __future__ import annotations
 
 import re
-import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
+from common.text_utils import strip_ukrainian_stress
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -54,7 +54,7 @@ class PlanAdherenceResult:
 
 def _strip_stress(text: str) -> str:
     """Remove combining acute accents (stress marks) from text."""
-    return unicodedata.normalize("NFD", text).replace("\u0301", "")
+    return strip_ukrainian_stress(text)
 
 
 def _load_plan(plan_path: Path) -> dict | None:

--- a/scripts/common/text_utils.py
+++ b/scripts/common/text_utils.py
@@ -1,0 +1,14 @@
+"""Shared Unicode text helpers for Ukrainian-processing pipelines."""
+
+from __future__ import annotations
+
+import unicodedata
+
+_UKRAINIAN_STRESS_MARK = "\u0301"
+
+
+def strip_ukrainian_stress(text: str) -> str:
+    """Remove Ukrainian acute stress marks without corrupting й/ї."""
+    decomposed = unicodedata.normalize("NFD", text)
+    without_stress = decomposed.replace(_UKRAINIAN_STRESS_MARK, "")
+    return unicodedata.normalize("NFC", without_stress)

--- a/scripts/rag/rag_batch_verify.py
+++ b/scripts/rag/rag_batch_verify.py
@@ -19,11 +19,11 @@ import argparse
 import json
 import re
 import sys
-import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
+from common.text_utils import strip_ukrainian_stress
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -35,15 +35,6 @@ PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 
-# ---------------------------------------------------------------------------
-# Stress-mark stripping
-# ---------------------------------------------------------------------------
-# Combining diacritical marks used for stress in Ukrainian text
-_COMBINING_MARKS = {
-    "\u0301",  # combining acute accent (most common stress mark)
-    "\u0300",  # combining grave accent
-    "\u030B",  # combining double acute
-}
 _APOSTROPHE_TRANSLATION = str.maketrans({
     "\u2019": "'",
     "\u2018": "'",
@@ -54,14 +45,8 @@ _TRAILING_JOINERS = "-'\u2019\u2018\u02BCʼ`"
 
 
 def strip_stress(text: str) -> str:
-    """Remove combining accent marks from Ukrainian text.
-
-    Normalizes to NFD, strips combining marks used for stress,
-    then re-normalizes to NFC.
-    """
-    nfd = unicodedata.normalize("NFD", text)
-    cleaned = "".join(ch for ch in nfd if ch not in _COMBINING_MARKS)
-    return unicodedata.normalize("NFC", cleaned)
+    """Remove Ukrainian acute stress marks without corrupting й/ї."""
+    return strip_ukrainian_stress(text)
 
 
 def normalize_apostrophes(text: str) -> str:
@@ -74,7 +59,7 @@ def normalize_apostrophes(text: str) -> str:
 # ---------------------------------------------------------------------------
 # Require at least 2 characters to avoid single-letter noise (abbreviations, etc.)
 _UKRAINIAN_WORD_RE = re.compile(
-    r"[а-яіїєґА-ЯІЇЄҐ][а-яіїєґА-ЯІЇЄҐ'\u2019\u2018ʼ\u0027\u02BC-]+"
+    r"[а-яіїєґА-ЯІЇЄҐ][а-яіїєґА-ЯІЇЄҐ'\u2019\u2018ʼ\u0027\u02BC-\u0301]+"
 )
 
 
@@ -84,19 +69,13 @@ def tokenize_all_ukrainian(text: str) -> list[tuple[str, str]]:
     Returns: [(original_form, clean_form), ...]
     where clean_form has stress marks stripped and is lowercased.
 
-    Strips combining diacritics BEFORE regex matching so that stress-marked
-    words like зва́ти are captured as single tokens (not split into зва + ти).
-
     Does NOT filter stop words.
     Preserves original casing for proper noun detection in report.
     """
-    # Strip stress marks before tokenization to avoid word-splitting
-    stripped_text = strip_stress(text)
-
     tokens = []
-    for match in _UKRAINIAN_WORD_RE.finditer(stripped_text):
+    for match in _UKRAINIAN_WORD_RE.finditer(text):
         original = match.group()
-        clean = normalize_apostrophes(original.lower())
+        clean = normalize_apostrophes(strip_stress(original).lower())
         # Strip trailing hyphens/apostrophes that regex may capture
         clean = clean.rstrip(_TRAILING_JOINERS)
         original = original.rstrip(_TRAILING_JOINERS)

--- a/scripts/wiki/context.py
+++ b/scripts/wiki/context.py
@@ -5,8 +5,9 @@ context for injection into build prompts (all tracks — core and seminar).
 """
 
 import re
-import unicodedata
 from pathlib import Path
+
+from common.text_utils import strip_ukrainian_stress
 
 from .config import TRACK_DOMAINS, WIKI_DIR
 from .sources_schema import load_sources_registry, registry_path_for
@@ -154,8 +155,7 @@ def get_wiki_context(
 
 
 def _normalize_text(text: str) -> str:
-    normalized = unicodedata.normalize("NFKD", text or "")
-    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    stripped = strip_ukrainian_stress(text or "")
     return re.sub(r"[-_/.:]+", " ", stripped)
 
 

--- a/tests/test_cyrillic_roundtrip_invariant.py
+++ b/tests/test_cyrillic_roundtrip_invariant.py
@@ -117,19 +117,19 @@ INVENTORY = {
         "coverage": "roundtrip",
         "path": "scripts/wiki/context.py",
         "needle": "def _normalize_text(",
-        "notes": "Identity-safe on clean lowercase words; currently xfailed for #1487.",
+        "notes": "Identity-safe on clean lowercase words after the #1487 NFC recompose fix.",
     },
     "audit.checks.plan_adherence._strip_stress": {
         "coverage": "roundtrip",
         "path": "scripts/audit/checks/plan_adherence.py",
         "needle": "def _strip_stress(",
-        "notes": "Should be identity on non-stressed text; currently xfailed for #1487.",
+        "notes": "Identity-safe on non-stressed text after the #1487 NFC recompose fix.",
     },
     "audit.checks.grammar._strip_stress": {
         "coverage": "roundtrip",
         "path": "scripts/audit/checks/grammar.py",
         "needle": "def _strip_stress(",
-        "notes": "Should be identity on non-stressed text; currently xfailed for #1487.",
+        "notes": "Identity-safe on non-stressed text after the #1487 NFC recompose fix.",
     },
     "audit.check_plan._dialogue_tokens": {
         "coverage": "exempt",
@@ -291,15 +291,6 @@ ROUND_TRIPPERS = [
 ]
 
 KNOWN_XFAILS = {
-    ("wiki.context._normalize_text", "iotation_y_short_word"): FOLLOWUP_ISSUE,
-    ("wiki.context._normalize_text", "iotation_yi_words"): FOLLOWUP_ISSUE,
-    ("audit.checks.plan_adherence._strip_stress", "iotation_y_short_word"): FOLLOWUP_ISSUE,
-    ("audit.checks.plan_adherence._strip_stress", "iotation_yi_words"): FOLLOWUP_ISSUE,
-    ("audit.checks.plan_adherence._strip_stress", "iotation_phrase_ascii"): FOLLOWUP_ISSUE,
-    ("audit.checks.grammar._strip_stress", "iotation_y_short_word"): FOLLOWUP_ISSUE,
-    ("audit.checks.grammar._strip_stress", "iotation_yi_words"): FOLLOWUP_ISSUE,
-    ("audit.checks.grammar._strip_stress", "iotation_phrase_ascii"): FOLLOWUP_ISSUE,
-    ("rag.rag_batch_verify.tokenize_all_ukrainian", "stress_acute"): FOLLOWUP_ISSUE,
 }
 
 

--- a/tests/test_unicode_normalization_roundtrip.py
+++ b/tests/test_unicode_normalization_roundtrip.py
@@ -1,0 +1,57 @@
+"""Round-trip invariants for Ukrainian text-processing helpers (#1487).
+
+NFKD / NFD normalization without NFC recompose corrupts й (U+0438 U+0306)
+and ї (U+0456 U+0308) — see issue #1487 for the full postmortem.
+"""
+
+from __future__ import annotations
+
+import sys
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+
+@pytest.mark.parametrize("word", ["мій", "їжа", "йому", "її", "мої", "українська"])
+def test_wiki_context_normalize_preserves_cyrillic(word: str) -> None:
+    from wiki.context import _normalize_text
+
+    result = _normalize_text(word)
+    assert "и" + chr(0x306) not in result
+    assert "і" + chr(0x308) not in result
+    for bad_form in ("міи", "іжа", "иому"):
+        assert bad_form not in result, f"Cyrillic corruption: {word!r} -> {result!r}"
+
+
+@pytest.mark.parametrize("word", ["мій", "їжа", "йому", "мо\u0301й"])
+def test_plan_adherence_strip_stress_roundtrip(word: str) -> None:
+    from audit.checks.plan_adherence import _strip_stress
+
+    result = _strip_stress(word)
+    assert "\u0301" not in result
+    assert result == unicodedata.normalize("NFC", result)
+
+
+@pytest.mark.parametrize("word", ["мій", "їжа", "йому"])
+def test_grammar_strip_stress_roundtrip(word: str) -> None:
+    from audit.checks.grammar import _strip_stress
+
+    result = _strip_stress(word)
+    assert "\u0301" not in result
+    assert result == unicodedata.normalize("NFC", result)
+
+
+def test_tokenize_all_ukrainian_preserves_original_bytes() -> None:
+    from rag.rag_batch_verify import tokenize_all_ukrainian
+
+    text = "бу\u0301кви мій її"
+    tokens = tokenize_all_ukrainian(text)
+
+    for original, _clean in tokens:
+        assert original in text, (
+            f"Token original {original!r} not a substring of input; "
+            f"stressed bytes were lost during tokenization."
+        )


### PR DESCRIPTION
Closes #1487.

## Summary
- add a shared Ukrainian stress-strip helper that uses `NFD -> remove U+0301 -> NFC`
- update wiki/audit/RAG helpers to preserve composed `й` and `ї` instead of stripping all combining marks
- keep `tokenize_all_ukrainian()` original tokens as raw input substrings while deriving clean forms separately
- add focused Unicode round-trip regression tests and remove the stale xfails from the Cyrillic invariant suite

## Verification
- `../../../../.venv/bin/ruff check scripts/ tests/`
- `../../../../.venv/bin/pytest tests/test_unicode_normalization_roundtrip.py tests/test_cyrillic_roundtrip_invariant.py tests/test_rag_formula_filter.py -v`
- `../../../../.venv/bin/pytest tests/ -x` *(stops on pre-existing baseline failure in `tests/test_a1_review_scores.py::TestA1ReviewScores::test_all_modules_have_orchestration_dirs` because `curriculum/l2-uk-en/a1/orchestration/sounds-letters-and-hello` is absent on both this branch and `origin/main`)*