### PR TITLE
ci(rules): invariant — claude_extensions/ must match .claude/ (#1464)

### DIFF
--- a/.claude/rules/activity-yaml.md
+++ b/.claude/rules/activity-yaml.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "curriculum/**/*.yaml"
+  - "curriculum/**/*.yml"
+  - "scripts/yaml_activities.py"
+  - "scripts/generate_mdx/**"
+---
+
+# Activity YAML Rules
+
+<critical>
+
+Bare list at root (NOT `activities:` wrapper). Full schema: [`vocabulary-activity-standards.md`](docs/best-practices/vocabulary-activity-standards.md) and `docs/ACTIVITY-YAML-REFERENCE.md`
+
+```yaml
+# CORRECT                    # WRONG
+- type: quiz                 activities:
+  title: ...                   - type: quiz
+```
+
+</critical>

--- a/.claude/rules/cli-help-standard.md
+++ b/.claude/rules/cli-help-standard.md
@@ -1,0 +1,53 @@
+# CLI `--help` Standard
+
+<critical>
+
+Every CLI script in this repo must emit enough from `--help` that an agent
+can use it correctly **without reading the source**. This is load-bearing:
+agents waste real time guessing flag names. See #1379 for the backstory.
+
+## When you write a NEW CLI
+
+Your `argparse.ArgumentParser` must include all of:
+
+1. **`description=`** — two lines:
+   - What the tool does (one sentence)
+   - When to use it (and when NOT to use it)
+
+2. **Every `add_argument()` has a meaningful `help=`**, including:
+   - What the arg is / does
+   - Default value for optional flags
+   - Example value or expected format
+
+3. **`epilog=`** (with `formatter_class=argparse.RawDescriptionHelpFormatter`):
+   - 1–3 concrete `.venv/bin/python scripts/…` usage examples for the common cases
+   - `Outputs:` — files written, DB updates, side effects
+   - `Exit codes:` — what 0 and ≥1 mean
+   - `Related:` — the template/prompt it uses, prod version, relevant doc, EPIC/issue
+
+## When you TOUCH an existing CLI
+
+Boy Scout rule — if you're editing the script for any reason and its
+`--help` doesn't meet this standard, bring it up to standard in the same
+commit. Don't leave it worse than you found it.
+
+## Reference implementation
+
+`scripts/build/pilot_uk_lesson.py` — mirror this pattern.
+
+Run: `.venv/bin/python scripts/build/pilot_uk_lesson.py --help`
+
+## Why this matters
+
+When docs/SCRIPTS.md doesn't cover a flag you need, `--help` is the
+source of truth. If `--help` is also thin, the agent guesses, guesses
+wrong, wastes a dispatch budget, and has to retry. Seen it enough times
+to make it a rule instead of a convention.
+
+## What does NOT need this standard
+
+- Library modules (not invoked as CLI)
+- MCP tools / MCP server commands (different interface)
+- External wrappers we don't own (gemini, codex, gh)
+
+</critical>

--- a/.claude/rules/critical-rules.md
+++ b/.claude/rules/critical-rules.md
@@ -1,0 +1,31 @@
+# Critical Rules
+
+<critical>
+
+### 1. Work in `claude_extensions/` First
+**NEVER** edit `.claude/`, `.agent/`, `.gemini/` directly. Edit in `claude_extensions/`, run `npm run claude:deploy` to sync.
+
+### 2. Use Python venv
+**ALWAYS** `.venv/bin/python`, **NEVER** `python3` or `python` directly.
+- pyenv Python 3.12.8 with `--enable-loadable-sqlite-extensions`
+- Recreate: `rm -rf .venv && ~/.pyenv/versions/3.12.8/bin/python -m venv .venv`
+
+### 3. Language Settings
+**English**: all technical work. **Ukrainian**: curriculum content only.
+
+### 4. External LLM Access
+Use `gemini-cli` (Google AI Pro subscription). No direct API keys.
+
+### 5. Word Targets Are Minimums
+**NEVER** reduce content or change `word_target` to match short content. Expand the content instead.
+
+### 6. GitHub Issues as Persistent Memory
+Every change tracked via GH issues. Before work: find/create issue. After: update/close. Reference in commits. Full protocol: [`issue-tracking.md`](docs/best-practices/issue-tracking.md)
+
+### 7. Intellectual Independence
+**The user explicitly wants pushback. Do not rubber-stamp ideas.**
+- Challenge bad ideas directly — don't silently comply then fix later
+- Think independently — consider second-order effects and alternatives before agreeing
+- Propose the better approach when you disagree, not just a veto
+
+</critical>

--- a/.claude/rules/delegate-must-use-worktree.md
+++ b/.claude/rules/delegate-must-use-worktree.md
@@ -1,0 +1,92 @@
+# Delegated Work MUST Use Git Worktree
+
+<critical>
+
+When you dispatch work to Codex, Gemini, or any other agent via
+`scripts/delegate.py dispatch` (or any equivalent), the agent MUST work
+in a git worktree — **not** a feature branch in the main checkout.
+
+## Why this matters
+
+`critical-rules.md` says: *"All work on `main`. Use `git worktree` for
+isolation."* If delegated work creates a feature branch inside the main
+checkout directory (`git checkout -b ...`), it:
+
+- Switches HEAD of the main checkout off `main`, silently
+- Mixes delegated work with any uncommitted work the user has
+- Breaks scripts that expect `main` to be current
+- Violates the "all on main" convention
+
+This happened on 2026-04-21. I wrote a Codex brief saying *"Commit as a
+feature branch + single PR if possible"* without specifying WHERE.
+Codex ran `git checkout -b feature/gemini-fallback-ladder` inside the
+main checkout. Cleanup was awkward (user had running scripts, couldn't
+switch HEAD). The rule exists so this never happens again.
+
+## MANDATORY in every dispatch brief
+
+Every Codex / Gemini dispatch prompt MUST include wording equivalent to:
+
+```
+## Worktree instructions (mandatory)
+
+Work in a git worktree at `.worktrees/<task-name>`. Do NOT create a
+feature branch in the main checkout. Concrete setup:
+
+    git worktree add -b <task-branch-name> .worktrees/<task-name>
+    cd .worktrees/<task-name>
+    # do work, commit, push
+
+    # For dispatches that warrant peak Opus 4.7 reasoning:
+    #   .venv/bin/python scripts/delegate.py dispatch \
+    #       --agent claude --effort xhigh --model claude-opus-4-7 \
+    #       --task-id <task-name> --worktree .worktrees/<task-name> \
+    #       --mode danger --prompt-file brief.md
+    # Accepted --effort levels: low | medium | high | xhigh | max
+    # (Omit --effort to use the agent's own CLI/config default.)
+
+The main checkout (wherever the user is working) stays untouched on
+`main`. After the PR merges, the worktree is cleaned up by the user
+or the next agent session:
+
+    git worktree remove .worktrees/<task-name>
+    git branch -d <task-branch-name>
+
+If the work truly cannot be done in a worktree (extremely rare —
+usually only repo-wide mass migrations), STOP and ask for approval
+before creating any branch.
+```
+
+Use descriptive names: `codex-<issue-number>-<short-topic>`,
+`gemini-<issue-number>-<topic>`. Not generic names like `feature/*`.
+
+## Post-merge cleanup
+
+When a worktree's PR merges to main, the worktree and its branch MUST be
+deleted. This is NOT optional — stale worktrees accumulate and pollute
+`git worktree list`.
+
+Check with:
+
+    git worktree list
+
+Remove with:
+
+    git worktree remove .worktrees/<name>
+    git branch -d <branch>
+
+## When YOU (not a delegated agent) need isolation
+
+Same rule — use a worktree. Don't branch in the main checkout.
+
+    git worktree add -b claude-<issue>-<topic> .worktrees/claude-<issue>-<topic>
+    cd .worktrees/claude-<issue>-<topic>
+
+## Enforcement
+
+The rule lives in both `claude_extensions/rules/` (this file) and will
+fire on every session start. If you dispatch without the worktree
+instruction, you're violating a critical rule — reread it and rewrite
+the brief.
+
+</critical>

--- a/.claude/rules/mcp-sources-and-dictionaries.md
+++ b/.claude/rules/mcp-sources-and-dictionaries.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "scripts/**"
+  - "curriculum/**"
+  - "data/**"
+---
+
+# MCP Sources Tools
+
+> The project's MCP server at port 8766 is called **`sources`** — it serves
+> SQLite FTS5 indices over textbooks, literary works, dictionaries, VESUM,
+> and Wikipedia. Historically called the "RAG server" — the current
+> implementation is not vector-based retrieval, so the name was misleading
+> and was retired. All tool prefixes are now `mcp__sources__*`. The old
+> prefix `mcp__rag__*` may still appear in archived orchestration prompts
+> but is no longer the canonical name.
+
+## Core tools (always use)
+- `mcp__sources__verify_word` / `mcp__sources__verify_words` / `mcp__sources__verify_lemma` — VESUM morphological dictionary (409K lemmas, 6.7M forms)
+- `mcp__sources__search_sources` — **PREFERRED unified entry point** across textbooks, literary corpora, Wikipedia, external articles, and `ukrainian_wiki`
+- `mcp__sources__search_text` — textbook content search (23K chunks, Grades 1-11)
+- `mcp__sources__search_images` — textbook image search (14K images)
+- `mcp__sources__search_literary` — primary literary sources (125K chunks — chronicles, poetry, legal texts)
+- `mcp__sources__query_pravopys` — Ukrainian orthography rules (Правопис 2019)
+- `mcp__sources__query_wikipedia` — Ukrainian Wikipedia
+
+> Start with `mcp__sources__search_sources` for general retrieval. Keep `mcp__sources__search_text` for explicit textbook-only scoping when you do not want literary, Wikipedia, external, or `ukrainian_wiki` results mixed in.
+
+## Dictionary tools (for quality and vocabulary)
+- `mcp__sources__search_style_guide` — Антоненко-Давидович (279 entries) — **calques and Russianisms**. HIGH PRIORITY.
+- `mcp__sources__query_cefr_level` — PULS CEFR vocabulary (5.9K words, A1-C1) — check level-appropriateness
+- `mcp__sources__search_definitions` — СУМ-11 (127K entries) — Ukrainian explanatory dictionary
+- `mcp__sources__search_etymology` — Грінченко (67K entries) — historical dictionary, etymology
+- `mcp__sources__search_idioms` — Фразеологічний (25K entries) — Ukrainian idioms and expressions
+- `mcp__sources__search_synonyms` — Ukrajinet WordNet (122K synsets) — synonyms, antonyms
+- `mcp__sources__translate_en_uk` — Балла EN→UK (79K entries) — English→Ukrainian translations
+
+## Dictionaries (local, in sources.db or SQLite)
+
+| Dictionary | Entries | Type | Collection/File |
+|-----------|---------|------|-----------------|
+| **VESUM** | 409K lemmas, 6.7M forms | Morphological (POS, gender, inflections) | `data/vesum.db` (SQLite) |
+| **СУМ-11** | 127K | Ukrainian explanatory (definitions, citations) | `data/sources.db` FTS5 |
+| **Грінченко** | 67K | Historical Ukrainian (1907, etymology) | `data/sources.db` FTS5 |
+| **Балла EN→UK** | 79K | English→Ukrainian translations | `data/sources.db` FTS5 |
+| **Антоненко-Давидович** | 279 | Style guide (calques, Russianisms) | `data/sources.db` FTS5 |
+| **Фразеологічний** | 25K | Ukrainian idioms and expressions | `data/sources.db` FTS5 |
+| **Stress dictionary** | 2.7M forms | Word stress for annotation | via `ukrainian-word-stress` |
+
+Source: [bakustarver/ukr-dictionaries-list-opensource](https://github.com/bakustarver/ukr-dictionaries-list-opensource) (СУМ-11, Балла, Фразеологічний)

--- a/.claude/rules/non-negotiable-rules.md
+++ b/.claude/rules/non-negotiable-rules.md
@@ -1,0 +1,186 @@
+# NON-NEGOTIABLE RULES
+
+All rules are hard requirements. Partial compliance = failure.
+
+<critical>
+
+## Quick Reference
+
+| When... | Do this |
+|---|---|
+| Building content | Check `config.py` target_words FIRST — never hardcode from memory |
+| Module under word target | Expand content to meet target. Never lower the target |
+| Audit gate shows ❌ | Fix it. ALL gates must be GREEN or the module fails |
+| Fixing a module | Reviewer provides `<fixes>` — apply deterministically (rule 4) |
+| Reviewing content | Cite SPECIFIC examples from the text, or the review is invalid (rule 6) |
+| Plan can't be met | STOP building. Report to user. Propose new plan version (rule 7) |
+| Review verdict REVISE | Reviewer outputs `<fixes>` find/replace pairs → pipeline applies them (rule 4) |
+| Creating JSONL/data | Add ingestion flag + update tracking doc in SAME commit (rule 11) |
+
+</critical>
+
+---
+
+## 1. Word Count Targets (Source of Truth: `config.py`)
+
+<critical>
+
+Expand content to meet targets. Never lower targets to match content.
+
+**Always read config.py** before generating content_outline or word budgets: `.venv/bin/python -c "import sys; sys.path.insert(0,'scripts'); from audit.config import LEVEL_CONFIG; print(LEVEL_CONFIG['{LEVEL}']['target_words'])"`
+
+**Word targets:** A1=1200, A1-cp=1000, A2=2000, A2-cp=1500, B1/B1-cp/B2/B2-cp/B2-cap/C1/C1-cp/C2-cp=4000, C2=5000, HIST/ISTORIO/BIO/LIT/OES/RUTH=5000. If stale, re-read `scripts/audit/config.py`.
+
+**Lesson learned:** Jan 2026 — 270 ISTORIO plans generated at 3500 instead of 4000 because agent hardcoded from memory instead of reading config.py.
+
+</critical>
+
+---
+
+## 2. Audit Gates — ALL Must Pass
+
+ALL gates must be GREEN (✅) or the module FAILS.
+
+| Gate | Requirement |
+|---|---|
+| Words | ≥ target from config.py |
+| Activities | ≥ minimum count for level |
+| Unique_types | Sufficient variety |
+| Vocab | ≥ minimum vocabulary for level |
+| Naturalness | ≥ 8/10 |
+
+Fix every failing gate. No exceptions, no "good enough."
+
+---
+
+## 3. Section-Level Word Targets (Flexible Guidance)
+
+Section targets are guidance, not hard limits.
+
+**Hard requirements:**
+1. **Total word count** ≥ `word_target`
+2. Each section within **±10% tolerance** of its target
+
+**Flexible:** Redistribute words between sections freely. One section 20% over is fine if no section is >10% under.
+
+**Priority:** Total word count first → fix sections >10% under → don't worry about over-target sections.
+
+---
+
+## 4. Review + Fix Loop (V6 Pipeline)
+
+V6 uses **reviewer-as-fixer**: Gemini reviews, finds issues, outputs `<fixes>` with exact find/replace pairs. Pipeline applies them deterministically — no LLM regeneration, no rewriting from scratch.
+
+**Flow:**
+1. Writer generates content → ENRICH adds tabs/словнік → REVIEW
+2. If REVISE: reviewer outputs `<fixes>` → pipeline applies find/replace → re-ENRICH → re-REVIEW
+3. Max 2 fix rounds. Score should go UP (9.0→9.4→9.7), never down.
+4. If still failing after 2 rounds → problem is in the PROMPT or PLAN, not the content.
+
+**Critical:** Reviewer sees PROSE ONLY (enrichment stripped before review). Deterministic word count injected into review prompt. Reviewer must NOT estimate word count — use the injected number.
+
+**Never rewrite from scratch.** Gemini proved: "FROM SCRATCH" rewrites degrade content (9.6→9.2→8.4). PATCH fixes only what's broken.
+
+---
+
+## 5. Quality Standards
+
+| Requirement | Threshold |
+|---|---|
+| Review score | 9+/10 target (8+ minimum PASS) |
+| **MIN-score gate** | **`min(dim_scores)` ≥ 8 to PASS, not weighted average.** A single failing dim fails the module. <8 → REVISE; <6 → REJECT. See `docs/best-practices/strict-reviewer-persona.md`. (Threshold dropped from 9 to 8 by user 2026-04-23.) |
+| Russian ghost words | Zero (кот → кіт, хорошо → добре) |
+| Dialogues | Natural situations from textbooks — not invented. Someone searches for keys, not interrogation. |
+| Vocabulary | All words VESUM-verified. Writer generates словнік YAML with contextual translations. |
+| Plans | Must have `references` (textbook + ULP links). No plan ships without references. |
+| Stress marks | Added by deterministic annotator AFTER review, not by writer. |
+
+Rewrite any text that fails naturalness. No robotic or disconnected prose.
+
+**Reviewer architecture (load-bearing, user-stated 2026-04-23):** Each review dimension runs as an INDEPENDENT model call with its own strict persona — no single-pass multi-dim bundling. Aggregator takes MIN, not weighted average. Persona reference: `docs/best-practices/strict-reviewer-persona.md`. **Do NOT design new review prompts that bundle dims into one pass with a weighted average — that pattern is rejected.**
+
+---
+
+## 6. LLM Self-Validation — Cite Evidence or It's Invalid
+
+Reviews must cite SPECIFIC examples from the actual content.
+
+**FAKE:** `✅ PASS | High-style analytical register with historical terms.` — no evidence, invalid.
+**HONEST:** `✅ PASS | Case endings correct ("Данилом Галицьким" — instrumental). Aspects: "зумів об'єднати" (pf), "прагнула" (impf). No Russianisms.` — cites real examples.
+
+Every review must: read content first, verify grammar with examples, list vocabulary found, check facts with evidence. No evidence = failed review.
+
+---
+
+## 7. Plan Versioning (Architecture v2.1)
+
+Plans in `plans/` are the source of truth. They require user approval to change.
+
+> `plans/{level}/{slug}.yaml` → VERSIONED (immutable without approval)
+
+**When build can't meet plan:** STOP → report "Plan requires X but Y isn't achievable because Z" → propose new plan version → user approves → backup old plan as `.bak` → write new version with bumped `version` field.
+
+**Never** silently modify plan files, lower word_target to match output, or skip the backup step.
+
+**Exception**: The pipeline may auto-fix plan `vocabulary_hints` entries that fail VESUM verification. Changes are version-bumped and logged in `plan_fixes`. Content outline, objectives, and word targets remain immutable.
+
+---
+
+## 8. Batch Fixes Within Module
+
+When fixing a module, diagnose ALL issues first, fix ALL at once, verify ONCE.
+
+**Wrong** (O(3N) tokens):
+```
+Read → Fix A → Audit → Read → Fix B → Audit → Read → Fix C → Audit
+```
+
+**Correct** (O(3) tokens):
+```
+1. DIAGNOSE: Read review findings + audit results
+2. EXECUTE: Apply ALL fixes in ONE pass
+3. VERIFY: Re-enrich + re-review ONCE
+```
+
+---
+
+## 9. Activities Test LANGUAGE, Not Content
+
+Activities practice Ukrainian language skills, not subject knowledge.
+
+### 9a. Content-heavy modules (HIST, BIO, ISTORIO, LIT, RUTH, OES)
+
+**Golden Rule:** Can the learner answer without reading the Ukrainian text? If YES → rewrite it.
+
+| Pattern | Verdict |
+|---|---|
+| "У якому році..." (dates) | ❌ Tests content recall |
+| "Хто був..." (names) | ❌ Tests content recall |
+| "Згідно з текстом, як автор..." | ✅ Tests comprehension |
+| "У тексті модуля автор характеризує..." | ✅ Tests comprehension |
+
+### 9b. ZNO-format activities (EXEMPT from 9a)
+
+ZNO activities test language mechanics directly — наголос, фонетика, орфографія, морфологія. These are standalone language skill tests exempt from 9a.
+
+---
+
+## 10. Complete The Work — No Tech Debt
+
+Every operation must be finished end-to-end in the same commit:
+
+| When you... | You MUST also... |
+|---|---|
+| Create JSONL data | Add ingestion flag to script + update `DICTIONARY-PIPELINE-STATUS.md` |
+| Write plans | Add references (textbook + ULP links) to every plan |
+| Build a module | Verify MDX renders correctly (not empty, has all tabs) |
+| Fix a bug | Write a test that catches the same bug |
+| Close a GH issue | Verify ALL acceptance criteria, not just "most" |
+
+"For now", "batch job for later", "flag for human" = failure. If it needs doing, do it NOW.
+
+---
+
+## Enforcement
+
+Negotiating requirements down, skipping audit gates, producing under-length modules, shipping without references, leaving incomplete work, or giving up before PASS = task failure.

--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "scripts/build/**"
+  - "scripts/pipeline/**"
+  - "scripts/audit/**"
+  - "scripts/validate/**"
+  - "curriculum/**/orchestration/**"
+---
+
+# Pipeline Architecture
+
+<critical>
+
+**Pipeline V6** (`scripts/build/v6_build.py`) — the ONLY pipeline:
+- check → research → skeleton → write → exercises → annotate → enrich → verify → review → publish
+- **v5, v4, and v3 are RETIRED.** Do not use `build_module_v5.py` or `build_module.py`.
+- **Writer default (on `main` since 5e2afbd092, 2026-04-23):** `claude-tools` (Opus). Gemini remains available via `--writer gemini-tools` for research + exercises. Post-#1431 v2: `claude-tools` chosen for module writing while residual writer-quality gaps on colors are being closed (#1449 → EPIC #1451).
+- **Codex** is the primary pipeline reviewer (cross-agent, max 2 fix attempts). Claude reserved for dimensions requiring cultural/creative nuance.
+- **Reviewer-as-fixer**: reviewer outputs `<fixes>` find/replace pairs, pipeline applies deterministically. No LLM regeneration during review — enforced by ADR-007 / dec-007 and the structural invariant test `tests/test_no_rewrite_contract.py`.
+- **Writer-driven словнік**: writer generates vocabulary with contextual translations
+- **Plans**: DRAFT → REVIEWED → LOCKED lifecycle. Review plan before content build.
+- Model defaults: Claude writer `claude-opus-4-7` @ xhigh | Gemini `gemini-3.1-pro-preview` | Codex reviewer via `codex-tools`
+- Build: `.venv/bin/python scripts/build/v6_build.py {level} {num} [--step {step}] [--writer {gemini|claude|gemini-tools|claude-tools}]`
+- Writer modes: `gemini-tools` / `claude-tools` have MCP access (VESUM/RAG) during writing
+
+**An LLM must NEVER review its own work.** Gemini builds → Claude reviews. Enforced by `SELF_REVIEW_DETECTED` audit gate.
+
+</critical>

--- a/.claude/rules/ukrainian-linguistics.md
+++ b/.claude/rules/ukrainian-linguistics.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "curriculum/**"
+  - "orchestration/**"
+  - "docs/l2-*/**"
+  - "plans/**"
+---
+
+# Ukrainian Linguistic Principles
+
+When working with Ukrainian text (plans, content, reviews, code comments), follow these rules:
+
+1. **Admit uncertainty, never invent.** If unsure about a Ukrainian word, stress, or grammatical form — flag it with `<!-- VERIFY -->` and check VESUM/goroh.pp.ua. Never guess. Your pre-training is contaminated by Russian.
+2. **Four separate checks:** Russianisms (кон→кін), Surzhyk (шо→що), Calques (приймати душ→брати душ), Paronyms (тактична≠тактовна). These are four different problems — catch them all.
+3. **Authority hierarchy (check in this order):** VESUM (forms — does this word exist?) → Правопис 2019 (spelling) → Горох (stress + frequency) → Антоненко-Давидович (style — natural or calque?) → Грінченко (etymology).
+4. **Think in Ukrainian categories:** звук/літера, голосний/приголосний, відмінок, наголос — not English translations.
+5. **Online fallbacks (if RAG/tools unavailable):** VESUM: vesum.com.ua | Правопис: 2019.pravopys.net | Горох: goroh.pp.ua | Антоненко-Давидович: ukrlib.com.ua/books/printit.php?tid=4002 | Грінченко: hrinchenko.com | Словник.ua: slovnyk.me

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,160 @@
+# How We Work (Mandatory Workflow)
+
+<critical>
+
+## Cold-start sequence (do this first every session)
+
+Use the Monitor API instead of reading files. One-shot bootstrap:
+
+```python
+# Python one-liner equivalent — see scripts/monitor_client.py
+from ai_agent_bridge.monitor_client import MonitorClient
+boot = MonitorClient().bootstrap()
+# boot["rules"].body    — condensed rules markdown
+# boot["session"].body  — condensed session summary
+```
+
+Shell equivalent:
+
+```bash
+curl -s http://localhost:8765/api/state/manifest         # ~1 KB index
+curl -s http://localhost:8765/api/rules?format=markdown  # only if hash changed
+curl -s http://localhost:8765/api/session/current        # only if hash changed
+curl -s http://localhost:8765/api/orient                 # always-fresh, has meta
+curl -s 'http://localhost:8765/api/comms/inbox?agent=claude'  # unread messages
+```
+
+**Do NOT read `CLAUDE.md`, `claude_extensions/rules/*.md`, or
+`docs/session-state/current.md` directly on cold start.** Those are
+the source of truth the endpoints above serve. Reading them separately
+costs 5+ tool calls and ignores the hash-based cache. If an endpoint
+is unreachable (API server down), THEN fall back to files.
+
+After a write that needs to be immediately visible (just-committed
+change, just-filed issue), pass `?fresh=true` to `/api/orient`.
+
+## Scoped queries — call the API instead of filesystem spelunking
+
+When you need deterministic answers about a specific module / range /
+worktree, use these endpoints instead of grepping `orchestration/`,
+`status/`, or `review/` directly. They are the source of truth for
+agent-side reasoning.
+
+| Question | Endpoint |
+|---|---|
+| What's module `{slug}` doing right now? | `GET /api/state/module/{track}/slug/{slug}` |
+| Give me the dashboard for modules N..M on {track} | `GET /api/state/range/{track}?start=N&end=M` |
+| Which files would `--force` delete for this module? | `GET /api/artifacts/{track}/{slug}/force-preview` |
+| Classify every file tied to this module (source/generated/published/stale) | `GET /api/artifacts/{track}/{slug}/files` |
+| Latest main + style reviews + "reviewer gaming" flag | `GET /api/artifacts/{track}/{slug}/review-snapshot` |
+| Does state.json agree with audit / reviews / published MDX? | `GET /api/artifacts/{track}/{slug}/drift` |
+| Can I ship this module? (every gate green) | `GET /api/artifacts/{track}/{slug}` |
+| Aggregate list of ship-ready modules | `GET /api/artifacts/ship-ready[?track=...]` |
+| Is the public site actually reachable? | `GET /api/site/health` |
+| Recent GH Pages deployments | `GET /api/site/deployments` |
+| Which worktrees exist and which branches are they on? | `GET /api/worktrees` |
+| Open issues grouped by category, with supersede hints | `GET /api/issues/map` |
+| Per-agent auth mode (Gemini subscription vs API) | `GET /api/runtime/auth` |
+
+**Rule of thumb:** if you're about to run `ls`, `cat`, `grep`, or
+`find` against `curriculum/` / `orchestration/` / `review/` /
+`status/` / `.git/worktrees/` — check the table above first. A
+single API call almost always returns the structured answer you
+were trying to reconstruct.
+
+**Full reference:** [`docs/MONITOR-API.md`](../../docs/MONITOR-API.md).
+
+---
+
+## Mandatory task workflow
+
+Every task follows this workflow. No exceptions for non-trivial changes.
+
+1. **Create GH issue** — describe the problem, draft a plan
+2. **Adversarial review of plan** — send to Gemini, incorporate feedback
+3. **Finalize ACs** — update issue with concrete acceptance criteria
+4. **Implement** — work through ACs one by one
+5. **Verify all ACs** — every AC checked and documented on the issue
+6. **Adversarial review of implementation** — send code to Gemini, fix findings
+7. **Close** — only when all ACs pass and review is clean
+
+**Goal-Driven Execution (step 4)**: Transform imperative tasks into verifiable goals. For multi-step work, state a plan with explicit verification at each step:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+Strong success criteria enable independent looping. Weak criteria ("make it work") require constant clarification.
+
+**Skip plan review** (step 2) only for trivial changes (< 50 lines, config/typo fixes).
+
+**Adversarial review command** (steps 2 & 6). Always use `--model gemini-3.1-pro-preview`. Document findings on the GH issue.
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini \
+  "Adversarial review for #NNN. Read {path}." \
+  --task-id issue-NNN --model gemini-3.1-pro-preview
+```
+
+## Channel bridge (#1190, shipped 2026-04-12)
+
+The agent bridge now supports **topic-scoped channels** — preferred
+for sustained multi-turn conversations because they eliminate the
+need to re-paste project context on every round.
+
+**Five seeded channels**: `shared`, `pipeline`, `content`,
+`architecture`, `reviews`. Every post auto-prepends:
+1. The channel's pinned `context.md` (via the include chain, so
+   `shared` is merged into everything)
+2. A Monitor API snapshot of volatile project state
+3. Recent channel history, character-budget truncated
+
+**Preferred for:** code reviews (multi-round), design debates,
+cross-agent discussions, anything that needs pinned context.
+**Not preferred for:** one-off drive-by questions — use `ask-*` for
+those.
+
+**Quick reference**:
+```bash
+# List / inspect
+ab channel list
+ab channel info pipeline
+ab channel tail reviews -n 20
+ab channel tail reviews --thread THREAD_ID
+
+# Post (short form — single recipient)
+ab p reviews gemini "quick question about module X"
+
+# Post (long form — multi-recipient, threading, parent/corr ids)
+ab post reviews "Review of #NNN" --to gemini,codex --parent MSG_ID
+
+# Multi-agent bounded discussion
+ab discuss architecture "Should we extract the V6 god object?" \
+    --with claude,gemini,codex --max-rounds 2
+```
+
+`ab discuss` runs rounds in parallel via ThreadPoolExecutor,
+short-circuits when all agents end their response with `[AGREE]`,
+and caps at 4 rounds. Default: 2 rounds, 1 agent. The transcript
+lands in `channel_messages` with proper `parent_id` threading so
+you can tail it later with `ab channel tail --thread`.
+
+**Web dashboard**: `http://localhost:8765/channels.html` (localhost
+only, read + post).
+
+**Full docs**: `docs/best-practices/agent-bridge.md`.
+
+The legacy `ask-gemini` / `ask-claude` / `ask-codex` commands are
+NOT deprecated — they stay alive for one-shot delegations. Use
+channels for anything that will have >1 turn.
+
+**Why**: GH issues are persistent memory. Without them, context is lost between sessions and work gets repeated or silently broken.
+
+**Issue discipline (coding issues)**:
+- **Never leave half-done.** If you open it, finish it. If you can't finish it now, document exactly where you stopped and what remains.
+- **Never close unless ALL acceptance criteria are verified.** Partial completion = still open.
+- **Aim to fully resolve and close.** Open issues are debt. Minimize them aggressively.
+- **The human manages content generation issues.** Claude owns coding/infrastructure issues. But proactively remind when it's time to start building a new track or batch — initiative is welcome.
+
+**Proactive issue hygiene**: At the start of each session, check open coding issues. Prioritize, resolve, close — don't let them go stale.
+
+</critical>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,13 @@ on:
       - 'requirements*.txt'
       - 'requirements.lock'
       - 'scripts/**/*.py'
+      - 'scripts/check_rules_deployment.sh'
       - 'tests/**/*.py'
       - 'pyproject.toml'
-      - 'claude_extensions/phases/**/*.md'
-      - 'claude_extensions/skills/**/*.md'
-      - 'gemini_extensions/skills/**/*.md'
+      - 'claude_extensions/rules/**'
+      - 'gemini_extensions/**'
+      - '.claude/rules/**'
+      - '.gemini/**'
       - 'starlight/**'
   pull_request:
     paths:
@@ -19,11 +21,13 @@ on:
       - 'requirements*.txt'
       - 'requirements.lock'
       - 'scripts/**/*.py'
+      - 'scripts/check_rules_deployment.sh'
       - 'tests/**/*.py'
       - 'pyproject.toml'
-      - 'claude_extensions/phases/**/*.md'
-      - 'claude_extensions/skills/**/*.md'
-      - 'gemini_extensions/skills/**/*.md'
+      - 'claude_extensions/rules/**'
+      - 'gemini_extensions/**'
+      - '.claude/rules/**'
+      - '.gemini/**'
       - 'starlight/**'
   workflow_dispatch:
 
@@ -139,6 +143,15 @@ jobs:
 
       - name: Lint prompt templates
         run: python scripts/lint/lint_prompts.py
+
+  rules-deployment-invariant:
+    name: Rules Deployment Invariant
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check deployed mirrors are in sync
+        run: bash scripts/check_rules_deployment.sh
 
   scripts-root-guard:
     name: No new root scripts

--- a/scripts/check_rules_deployment.sh
+++ b/scripts/check_rules_deployment.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+ORPHAN_PATHS_AGENT="wake cache"
+ORPHAN_PATHS_GEMINI="docs/"
+
+drift_found=false
+
+check_sync() {
+    local src="$1"
+    local dst="$2"
+    local label="$3"
+    local orphans="$4"
+    local source_hint="$5"
+
+    if [[ ! -d "$src" ]]; then
+        echo "::error::Missing source directory for $label: $src"
+        drift_found=true
+        return
+    fi
+
+    if [[ ! -d "$dst" ]]; then
+        echo "Skipping $label: destination $dst is not present in this checkout."
+        return
+    fi
+
+    local diff_args=(-rq --exclude='.DS_Store')
+    for p in $orphans; do
+        diff_args+=(--exclude="${p%/}")
+    done
+
+    local diff_out
+    diff_out=$(diff "${diff_args[@]}" "$src" "$dst" || true)
+    if [[ -z "$diff_out" ]]; then
+        echo "OK: $label"
+        return
+    fi
+
+    drift_found=true
+    echo "::error::Rules/prompts drift detected for $label. Run 'npm run claude:deploy' and commit the deployed mirror."
+    echo "Files out of sync:"
+    echo "$diff_out"
+    echo "Fix: edit the source in $source_hint, then run \`npm run claude:deploy\`,"
+    echo "commit both $source_hint and the deployed mirror."
+    echo "See: claude_extensions/rules/critical-rules.md §1."
+    echo ""
+}
+
+check_sync "claude_extensions/rules" ".claude/rules" "claude_extensions/rules -> .claude/rules" "" "claude_extensions/rules/"
+check_sync "claude_extensions/rules" ".agent/rules" "claude_extensions/rules -> .agent/rules" "$ORPHAN_PATHS_AGENT" "claude_extensions/rules/"
+check_sync "gemini_extensions" ".gemini" "gemini_extensions -> .gemini" "$ORPHAN_PATHS_GEMINI" "gemini_extensions/"
+
+if [[ "$drift_found" == true ]]; then
+    exit 1
+fi
+
+echo "All deployed prompt/rule mirrors are in sync."


### PR DESCRIPTION
Closes #1464. Part of EPIC #1451 Phase 4.

## Summary
- add `scripts/check_rules_deployment.sh` to fail CI when deployed rule/prompt mirrors drift from their sources
- run that invariant in the existing `ci.yml` workflow and trigger it on rule / mirror changes
- add the tracked `.claude/rules/` mirror so the invariant has a real committed target

## Test plan
- `bash scripts/check_rules_deployment.sh`
  - Expected: exit 0 on the clean branch
- Append `drift test` to `claude_extensions/rules/critical-rules.md`, run `bash scripts/check_rules_deployment.sh`, then remove the line
  - Expected: exit 1 with `Files claude_extensions/rules/critical-rules.md and .claude/rules/critical-rules.md differ`

## Notes
- `.agent/rules/` is skipped when that destination is absent in the checkout, matching the current repo state rather than inventing an untracked mirror.
- No auto-merge requested.