### PR TITLE
feat(pre-commit): plan immutability enforcement (#1463)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,9 +198,6 @@ data/corpus_audit/*
 !data/corpus_audit/draft_tickets/*.md
 
 
-# Plan backup files from scripts/tools/update_plan_activities.py (#1148)
-curriculum/l2-uk-en/plans/*/*.yaml.bak
-
 .gemini/
 
 # SQLite WAL/SHM sidecars — same exclusion as the .db files themselves.
@@ -209,4 +206,3 @@ data/*.db-wal
 
 # Alona's teaching material (large, local-only, IP-sensitive)
 data/alona-lessons/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@
 # more expensive than catching a ruff error on save.
 #
 # Reference issue: #1081
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
 repos:
 
   # --- Ruff: the primary linter (same rules as CI) ---
@@ -69,17 +73,33 @@ repos:
     hooks:
       # Prevent accidentally adding .yaml.bak / .yaml.orig files that
       # our update_plan_activities.py / other tools create as safety
-      # backups. They're already in .gitignore but pre-commit is the
-      # second line of defence.
+      # backups. Versioned curriculum plan snapshots are the exception:
+      # they are required by the plan immutability rule.
       - id: no-yaml-backups
         name: block .yaml.bak / .yaml.orig files
         entry: >-
           bash -c 'files=$(git diff --cached --name-only --diff-filter=A |
-          grep -E "\.(yaml|yml)\.(bak|orig)$" || true); if [ -n "$files" ]; then
-          echo "ERROR: Do not commit plan backup files:"; echo "$files"; exit 1; fi'
+          grep -E "\.(yaml|yml)\.(bak|orig)$" |
+          grep -Ev "^curriculum/[^/]+/plans/.+\.yaml\.bak$" || true); if [ -n "$files" ]; then
+          echo "ERROR: Do not commit non-plan backup files:"; echo "$files"; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]
+
+      # Plans are immutable once committed. Any staged edit must ship
+      # with a bumped `version` field and a sibling `.bak` snapshot of
+      # the previous content. Run this in the commit-msg stage so the
+      # pipeline's escape-hatch tag is available.
+      - id: check-plan-immutability
+        name: enforce plan version bump + .bak
+        entry: >-
+          bash -c 'python=".venv/bin/python"; if [ ! -x "$python" ]; then
+          common_dir=$(git rev-parse --git-common-dir); python="$(cd "$common_dir/.." &&
+          pwd)/.venv/bin/python"; fi; exec "$python"
+          scripts/pre_commit/check_plan_immutability.py "$@"' --
+        language: system
+        always_run: true
+        stages: [commit-msg]
 
       # Block bare `python3`/`python` in shell scripts we add.
       # The project's venv is always at .venv/bin/python — use that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ After that, every `git commit` runs:
 - `ruff check` on changed `scripts/` files (blocks bad imports, multi-statement lines, etc.)
 - `gitleaks` secret scan on staged changes
 - YAML syntax check + large-file / merge-conflict detection
-- Block `.yaml.bak` / `.yaml.orig` accidental commits
+- Block accidental `.yaml.bak` / `.yaml.orig` commits, except versioned plan snapshots under `curriculum/*/plans/**`
 - Block bare `python` / `python3` in new shell scripts
 
 Run manually across the whole repo:

--- a/scripts/pre_commit/check_plan_immutability.py
+++ b/scripts/pre_commit/check_plan_immutability.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Block staged plan edits that skip versioning or backup snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+PLAN_PATH_RE = re.compile(r"^curriculum/[^/]+/plans/.+\.yaml$")
+AUTO_FIX_TAG = "[auto-fix-plan-vocab]"
+
+
+def _run_git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a git command from the target repository."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result
+
+
+def _repo_root() -> Path:
+    """Resolve the repository root from the current working directory."""
+    result = _run_git(Path.cwd(), "rev-parse", "--show-toplevel")
+    return Path(result.stdout.strip())
+
+
+def _staged_files(repo_root: Path) -> list[str]:
+    """Return staged file paths relative to the repository root."""
+    result = _run_git(repo_root, "diff", "--cached", "--name-only", "--diff-filter=AM")
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _is_plan_path(path: str) -> bool:
+    """True when the staged path is a curriculum plan YAML file."""
+    return bool(PLAN_PATH_RE.match(path))
+
+
+def _git_blob_exists(repo_root: Path, spec: str) -> bool:
+    """Return whether a git object spec resolves successfully."""
+    result = subprocess.run(
+        ["git", "cat-file", "-e", spec],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _read_git_blob(repo_root: Path, spec: str) -> str:
+    """Read text content from a git object spec."""
+    result = _run_git(repo_root, "show", spec)
+    return result.stdout
+
+
+def _read_commit_message(repo_root: Path, commit_msg_file: str | None) -> str:
+    """Read the in-flight commit message when it is available."""
+    if commit_msg_file:
+        path = Path(commit_msg_file)
+    else:
+        result = _run_git(repo_root, "rev-parse", "--git-path", "COMMIT_EDITMSG")
+        path = repo_root / result.stdout.strip()
+
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_version(content: str, label: str) -> str:
+    """Extract the plan version from YAML content."""
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{label}: failed to parse YAML: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"{label}: expected a YAML mapping at the document root")
+
+    version = data.get("version")
+    if version is None or str(version).strip() == "":
+        raise ValueError(f"{label}: missing version field")
+
+    return str(version).strip()
+
+
+def _collect_errors(repo_root: Path) -> list[str]:
+    """Validate staged plan edits against the immutability rule."""
+    staged = _staged_files(repo_root)
+    staged_set = set(staged)
+    errors: list[str] = []
+
+    for plan_path in staged:
+        if not _is_plan_path(plan_path):
+            continue
+
+        head_spec = f"HEAD:{plan_path}"
+        if not _git_blob_exists(repo_root, head_spec):
+            # New plans have no previous version to compare against.
+            continue
+
+        try:
+            old_version = _parse_version(_read_git_blob(repo_root, head_spec), plan_path)
+            new_version = _parse_version(_read_git_blob(repo_root, f":{plan_path}"), plan_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+
+        if old_version == new_version:
+            errors.append(f"{plan_path}: version not bumped (still {old_version})")
+
+        bak_path = f"{plan_path}.bak"
+        if bak_path not in staged_set:
+            errors.append(f"{plan_path}: missing {bak_path} backup in same commit")
+            continue
+
+        try:
+            bak_version = _parse_version(_read_git_blob(repo_root, f":{bak_path}"), bak_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+
+        if bak_version != old_version:
+            errors.append(
+                f"{bak_path}: should contain old version {old_version}, found {bak_version}"
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(
+        description="Enforce version bumps and backups for staged curriculum plan edits."
+    )
+    parser.add_argument(
+        "commit_msg_file",
+        nargs="?",
+        help="Path to COMMIT_EDITMSG from the commit-msg hook stage.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = _repo_root()
+    if AUTO_FIX_TAG in _read_commit_message(repo_root, args.commit_msg_file):
+        return 0
+
+    errors = _collect_errors(repo_root)
+    if not errors:
+        return 0
+
+    print(
+        "Plans are versioned - any change needs a bumped version and a `.bak` of the previous.",
+        file=sys.stderr,
+    )
+    print(
+        f"Exception: pipeline auto-fix commits use `{AUTO_FIX_TAG}` tag.",
+        file=sys.stderr,
+    )
+    print(
+        "See: claude_extensions/rules/non-negotiable-rules.md §7",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_plan_immutability_hook.py
+++ b/tests/test_plan_immutability_hook.py
@@ -1,0 +1,143 @@
+"""Tests for the staged plan immutability hook."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "pre_commit" / "check_plan_immutability.py"
+PLAN_PATH = Path("curriculum/l2-uk-en/plans/a1/test-plan.yaml")
+
+
+def _clean_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=check,
+        capture_output=True,
+        env=_clean_env(),
+        text=True,
+    )
+
+
+def _project_python() -> Path:
+    common_dir = _git(REPO_ROOT, "rev-parse", "--git-common-dir").stdout.strip()
+    return Path(common_dir).parent / ".venv" / "bin" / "python"
+
+
+def _write_plan(path: Path, version: str, title: str) -> str:
+    content = yaml.safe_dump(
+        {
+            "module": 1,
+            "slug": "test-plan",
+            "version": version,
+            "level": "a1",
+            "sequence": 1,
+            "title": title,
+            "word_target": 1200,
+            "phase": "A1.1",
+            "content_outline": [
+                {"section": "Intro", "words": 900},
+                {"section": "Summary", "words": 300},
+            ],
+        },
+        allow_unicode=True,
+        sort_keys=False,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return content
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+
+    plan_file = repo / PLAN_PATH
+    _write_plan(plan_file, "1.0", "Base plan")
+    _git(repo, "add", str(PLAN_PATH))
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _run_hook(repo: Path, commit_message: str) -> subprocess.CompletedProcess[str]:
+    commit_msg_file = repo / ".git" / "COMMIT_EDITMSG"
+    commit_msg_file.write_text(commit_message, encoding="utf-8")
+    return subprocess.run(
+        [str(_project_python()), str(HOOK_SCRIPT), str(commit_msg_file)],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        env=_clean_env(),
+        text=True,
+    )
+
+
+def test_plan_edit_with_bumped_version_and_bak_passes(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    plan_file = repo / PLAN_PATH
+    old_content = plan_file.read_text(encoding="utf-8")
+
+    _write_plan(plan_file, "1.1", "Updated plan")
+    (repo / f"{PLAN_PATH}.bak").write_text(old_content, encoding="utf-8")
+
+    _git(repo, "add", str(PLAN_PATH), f"{PLAN_PATH}.bak")
+    result = _run_hook(repo, "feat: update plan\n")
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_plan_edit_without_version_bump_fails(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    plan_file = repo / PLAN_PATH
+    old_content = plan_file.read_text(encoding="utf-8")
+
+    _write_plan(plan_file, "1.0", "Updated plan")
+    (repo / f"{PLAN_PATH}.bak").write_text(old_content, encoding="utf-8")
+
+    _git(repo, "add", str(PLAN_PATH), f"{PLAN_PATH}.bak")
+    result = _run_hook(repo, "feat: mutate plan\n")
+
+    assert result.returncode == 1
+    assert "version not bumped" in result.stderr
+
+
+def test_plan_edit_without_bak_fails(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    plan_file = repo / PLAN_PATH
+
+    _write_plan(plan_file, "1.1", "Updated plan")
+
+    _git(repo, "add", str(PLAN_PATH))
+    result = _run_hook(repo, "feat: mutate plan\n")
+
+    assert result.returncode == 1
+    assert "missing" in result.stderr
+    assert ".bak" in result.stderr
+
+
+def test_autofix_commit_tag_bypasses_hook(tmp_path: Path):
+    repo = _init_repo(tmp_path)
+    plan_file = repo / PLAN_PATH
+
+    _write_plan(plan_file, "1.0", "Updated plan")
+    _git(repo, "add", str(PLAN_PATH))
+    result = _run_hook(repo, "chore: pipeline repair [auto-fix-plan-vocab]\n")
+
+    assert result.returncode == 0
+    assert result.stderr == ""

--- a/tests/test_plan_immutability_hook.py
+++ b/tests/test_plan_immutability_hook.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -31,9 +32,15 @@ def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProc
     )
 
 
-def _project_python() -> Path:
-    common_dir = _git(REPO_ROOT, "rev-parse", "--git-common-dir").stdout.strip()
-    return Path(common_dir).parent / ".venv" / "bin" / "python"
+def _project_python() -> str:
+    """Return the Python interpreter that should invoke the hook.
+
+    Tests must run both locally (where ``.venv/bin/python`` exists) and on
+    CI (which uses the actions/setup-python runner — no ``.venv``). Using
+    ``sys.executable`` picks up whichever Python is running pytest, so
+    both environments work without special-casing.
+    """
+    return sys.executable
 
 
 def _write_plan(path: Path, version: str, title: str) -> str:
@@ -78,7 +85,7 @@ def _run_hook(repo: Path, commit_message: str) -> subprocess.CompletedProcess[st
     commit_msg_file = repo / ".git" / "COMMIT_EDITMSG"
     commit_msg_file.write_text(commit_message, encoding="utf-8")
     return subprocess.run(
-        [str(_project_python()), str(HOOK_SCRIPT), str(commit_msg_file)],
+        [_project_python(), str(HOOK_SCRIPT), str(commit_msg_file)],
         cwd=repo,
         check=False,
         capture_output=True,


### PR DESCRIPTION
## Summary
- add a staged-plan immutability hook under `scripts/pre_commit/check_plan_immutability.py`
- wire it into the existing `.pre-commit-config.yaml` via `commit-msg`, including the `[auto-fix-plan-vocab]` escape hatch and worktree-safe `.venv` resolution
- allow versioned plan `.bak` snapshots while keeping other backup-file commits blocked, and document the exception in `CONTRIBUTING.md`

## Test Plan
- [x] Plan edited + version bumped + `.bak` staged passes
- [x] Plan edited without version bump fails with `version not bumped`
- [x] Plan edited with version bump but no `.bak` fails with missing-backup stderr
- [x] Plan edited without bump is allowed when commit message includes `[auto-fix-plan-vocab]`

Closes #1463. Part of EPIC #1451 Phase 4.
