### PR TITLE
ci(rules): deploy-script idempotency invariant (#1464)

### DIFF
--- a/.github/workflows/rules-deployment-check.yml
+++ b/.github/workflows/rules-deployment-check.yml
@@ -1,0 +1,49 @@
+name: Rules Deployment Check
+
+on:
+  push:
+    paths:
+      - '.github/workflows/rules-deployment-check.yml'
+      - 'scripts/deploy_prompts.sh'
+      - 'scripts/check_rules_deployment.sh'
+      - 'scripts/lint_prompts.py'
+      - 'scripts/lint/**/*.py'
+      - 'claude_extensions/**'
+      - 'gemini_extensions/**'
+      - 'tests/test_deploy_script_idempotency.py'
+  pull_request:
+    paths:
+      - '.github/workflows/rules-deployment-check.yml'
+      - 'scripts/deploy_prompts.sh'
+      - 'scripts/check_rules_deployment.sh'
+      - 'scripts/lint_prompts.py'
+      - 'scripts/lint/**/*.py'
+      - 'claude_extensions/**'
+      - 'gemini_extensions/**'
+      - 'tests/test_deploy_script_idempotency.py'
+  workflow_dispatch:
+
+jobs:
+  verify-rules-deployment:
+    name: Verify Deploy Script Idempotency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Create local test venv
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install pytest
+
+      - name: Verify deploy script is idempotent (rules/prompts sync)
+        run: |
+          bash scripts/deploy_prompts.sh
+          bash scripts/check_rules_deployment.sh
+
+      - name: Regression tests for deploy drift check
+        run: .venv/bin/python -m pytest tests/test_deploy_script_idempotency.py -v

--- a/scripts/check_rules_deployment.sh
+++ b/scripts/check_rules_deployment.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Verify that scripts/deploy_prompts.sh produced destination trees that
+# match the source extensions it actually manages.
+#
+# Run this after scripts/deploy_prompts.sh. It does not run the deploy.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+check_pair() {
+    local src="$1"
+    local dst="$2"
+    shift 2
+
+    local diff_args=(-rq -x .DS_Store)
+    local orphan
+    for orphan in "$@"; do
+        diff_args+=(-x "${orphan%/}")
+    done
+
+    if [[ ! -d "$src" ]]; then
+        echo "::error::Source dir missing: $src"
+        return 1
+    fi
+
+    if [[ ! -d "$dst" ]]; then
+        echo "::error::Deploy did not create target: $dst"
+        return 1
+    fi
+
+    local diff_out
+    diff_out=$(diff "${diff_args[@]}" "$src" "$dst" || true)
+    if [[ -n "$diff_out" ]]; then
+        echo "::error::Deploy-script drift between $src and $dst:"
+        echo "$diff_out"
+        echo
+        echo "This means scripts/deploy_prompts.sh is out of sync with its source."
+        echo "Fix the deploy script, not the target tree."
+        return 1
+    fi
+
+    echo "OK: $src -> $dst"
+}
+
+drift=0
+
+# These pairs and orphan exclusions must stay in lock-step with the
+# rsync calls and ORPHAN_PATHS_* declarations in scripts/deploy_prompts.sh.
+check_pair "claude_extensions" ".claude" "scheduled_tasks.lock" "worktrees" || drift=1
+check_pair "claude_extensions" ".agent" "wake" "cache" || drift=1
+check_pair "gemini_extensions" ".gemini" "docs/" || drift=1
+
+exit "$drift"

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -1,0 +1,96 @@
+"""Regression tests for deploy-script idempotency checks."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+DEPLOY_SCRIPT = Path("scripts/deploy_prompts.sh")
+CHECK_SCRIPT = Path("scripts/check_rules_deployment.sh")
+DRIFT_TARGET = Path(".claude/rules/critical-rules.md")
+
+
+def _copy_repo_subset(target: Path) -> None:
+    for directory in ("claude_extensions", "gemini_extensions"):
+        shutil.copytree(REPO_ROOT / directory, target / directory, symlinks=True)
+
+    for relative_path in (
+        DEPLOY_SCRIPT,
+        CHECK_SCRIPT,
+        Path("scripts/lint_prompts.py"),
+        Path("scripts/lint/lint_prompts.py"),
+    ):
+        destination = target / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative_path, destination)
+
+    bin_dir = target / ".venv" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    python_wrapper = bin_dir / "python"
+    python_wrapper.write_text(
+        "#!/usr/bin/env bash\n"
+        f"exec {shlex.quote(str(PROJECT_PYTHON))} \"$@\"\n",
+        encoding="utf-8",
+    )
+    python_wrapper.chmod(0o755)
+
+
+def _init_checkout(tmp_path: Path) -> Path:
+    assert PROJECT_PYTHON.exists(), f"Expected interpreter missing: {PROJECT_PYTHON}"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _copy_repo_subset(repo)
+    return repo
+
+
+def _run(repo: Path, script: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
+    """A clean checkout should deploy successfully and pass drift checks."""
+    repo = _init_checkout(tmp_path)
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, (
+        f"deploy failed:\nstdout: {deploy_result.stdout}\nstderr: {deploy_result.stderr}"
+    )
+
+    check_result = _run(repo, CHECK_SCRIPT)
+    assert check_result.returncode == 0, (
+        "drift check failed after fresh deploy:\n"
+        f"stdout: {check_result.stdout}\nstderr: {check_result.stderr}"
+    )
+
+
+def test_drift_is_caught(tmp_path: Path) -> None:
+    """Post-deploy edits to a target tree must be reported as drift."""
+    repo = _init_checkout(tmp_path)
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, (
+        f"deploy failed:\nstdout: {deploy_result.stdout}\nstderr: {deploy_result.stderr}"
+    )
+
+    drifted_file = repo / DRIFT_TARGET
+    assert drifted_file.exists(), f"Expected deployed file missing: {drifted_file}"
+    drifted_file.write_text(
+        drifted_file.read_text(encoding="utf-8") + "\n# drift injected by test\n",
+        encoding="utf-8",
+    )
+
+    check_result = _run(repo, CHECK_SCRIPT)
+    combined_output = f"{check_result.stdout}\n{check_result.stderr}"
+    assert check_result.returncode != 0
+    assert "Deploy-script drift between claude_extensions and .claude" in combined_output
+    assert "critical-rules.md" in combined_output


### PR DESCRIPTION
Closes #1464. Supersedes closed PR #1514 (architecturally flawed — that approach tried to diff-check gitignored dirs in CI).

New invariant: CI runs `scripts/deploy_prompts.sh` then diffs the generated target dirs against their sources. Catches deploy-script regressions (missed files, renamed paths, stale mappings) without requiring gitignored target dirs to be committed.

Does NOT catch local direct-edits to `.claude/` etc. — those are by design invisible to CI via `.gitignore`. Local linter concern.