### PR TITLE
fix(alignment-manifest): exclude FTS5 shadow tables from sources_hash (#1517)

### DIFF
--- a/scripts/build/alignment_manifest.py
+++ b/scripts/build/alignment_manifest.py
@@ -249,6 +249,28 @@ def _canonical_plan_hash(level: str, slug: str) -> str:
     return _sha256_bytes(canonical_yaml.encode("utf-8"))
 
 
+# FTS5 creates these shadow tables for every virtual table `<name>`:
+#   <name>_data, <name>_idx, <name>_content, <name>_docsize, <name>_config
+# They must be excluded from the manifest for TWO reasons (#1517):
+#   1. Correctness: `_idx` and `_config` are declared WITHOUT ROWID, so
+#      `SELECT MAX(rowid)` raises "no such column: rowid" and crashes every
+#      build. The shadow tables pass the `PRAGMA index_list` filter below
+#      because their PRIMARY KEYs register as implicit indexes.
+#   2. Stability: segids, pgnos, and serialized segment blobs inside the
+#      shadow tables are SQLite-internal bookkeeping that differs across
+#      identical content rebuilds (after VACUUM, `INSERT … INTO …('optimize')`,
+#      or re-ingest). Hashing them would produce a non-deterministic manifest.
+# The virtual table itself (e.g. `literary_fts`) answers the rowid query
+# correctly and IS included — its rowid tracks content identity.
+_FTS5_SHADOW_SUFFIXES: tuple[str, ...] = (
+    "_data",
+    "_idx",
+    "_content",
+    "_docsize",
+    "_config",
+)
+
+
 def _sqlite_indexed_table_names(connection: sqlite3.Connection) -> tuple[str, ...]:
     rows = connection.execute(
         """
@@ -258,18 +280,37 @@ def _sqlite_indexed_table_names(connection: sqlite3.Connection) -> tuple[str, ..
           AND name NOT LIKE 'sqlite_%'
         """
     ).fetchall()
-    names: list[str] = []
+
+    # Pass 1: identify virtual tables so we can recognize their shadows.
+    virtual_table_names: set[str] = set()
     for name, sql in rows:
-        table_name = str(name)
         table_sql = str(sql or "")
-        has_explicit_index = bool(
-            connection.execute(f'PRAGMA index_list("{table_name}")').fetchall()
-        )
         # Substring `"VIRTUAL TABLE"` would false-positive on a table
         # named e.g. `my_virtual_table_data`. Match the DDL prefix instead.
         # Flagged by gemini-review on PR #1468.
+        if table_sql.upper().lstrip().startswith("CREATE VIRTUAL TABLE"):
+            virtual_table_names.add(str(name))
+
+    shadow_names: set[str] = {
+        f"{vt}{suffix}"
+        for vt in virtual_table_names
+        for suffix in _FTS5_SHADOW_SUFFIXES
+    }
+
+    # Pass 2: keep virtual tables and any regular table with an explicit
+    # index, BUT subtract FTS5 shadows — see the block comment above for
+    # why we must exclude them even though they pass the index filter.
+    names: list[str] = []
+    for name, sql in rows:
+        table_name = str(name)
+        if table_name in shadow_names:
+            continue
+        table_sql = str(sql or "")
         is_virtual_table = table_sql.upper().lstrip().startswith("CREATE VIRTUAL TABLE")
-        if has_explicit_index or is_virtual_table:
+        has_explicit_index = bool(
+            connection.execute(f'PRAGMA index_list("{table_name}")').fetchall()
+        )
+        if is_virtual_table or has_explicit_index:
             names.append(table_name)
     return tuple(sorted(names))
 

--- a/tests/test_alignment_manifest.py
+++ b/tests/test_alignment_manifest.py
@@ -267,3 +267,98 @@ def test_validate_reports_specific_mismatch(manifest_fixture: dict[str, Path]) -
         False,
         ("plan_hash",),
     )
+
+
+# --- Regression coverage for #1517: FTS5 shadow tables ----------------------
+#
+# Before the fix, `_sources_hash` crashed on any real `sources.db` because
+# SQLite FTS5 virtual tables create 5 shadow tables (`_data`, `_idx`,
+# `_content`, `_docsize`, `_config`) — two of which are declared
+# `WITHOUT ROWID` and therefore can't answer `SELECT MAX(rowid)`. The
+# shadow tables also carry non-deterministic internal state (segids, pgnos)
+# that would make the hash flaky even if the rowid query succeeded. These
+# tests freeze that contract: shadows out, the virtual table in.
+
+
+def _build_sources_db_with_fts5(path: Path) -> None:
+    """Materialize a DB that reproduces the failure mode of the real
+    sources.db — a content-backed FTS5 virtual table with the full set of
+    shadow tables SQLite auto-creates."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "CREATE TABLE source_chunks (id INTEGER PRIMARY KEY, body TEXT NOT NULL)"
+        )
+        connection.execute(
+            "CREATE INDEX idx_source_chunks_body ON source_chunks(body)"
+        )
+        connection.execute(
+            "CREATE VIRTUAL TABLE source_chunks_fts USING fts5(body, "
+            "content='source_chunks', content_rowid='id')"
+        )
+        connection.execute(
+            "INSERT INTO source_chunks(body) VALUES (?)",
+            ("first row",),
+        )
+        connection.execute(
+            "INSERT INTO source_chunks_fts(rowid, body) "
+            "SELECT id, body FROM source_chunks"
+        )
+        connection.commit()
+
+
+def test_fts5_shadow_tables_excluded_from_name_enumeration(tmp_path: Path) -> None:
+    """_sqlite_indexed_table_names keeps the virtual table and drops all
+    five FTS5 shadow tables (prevents the `no such column: rowid` crash
+    and guards against hashing non-deterministic segment state)."""
+    db_path = tmp_path / "sources.db"
+    _build_sources_db_with_fts5(db_path)
+
+    with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:
+        names = alignment_manifest._sqlite_indexed_table_names(connection)
+
+    assert "source_chunks" in names
+    assert "source_chunks_fts" in names
+    for suffix in ("_data", "_idx", "_content", "_docsize", "_config"):
+        assert f"source_chunks_fts{suffix}" not in names, (
+            f"FTS5 shadow table source_chunks_fts{suffix} must be excluded"
+        )
+
+
+def test_sources_hash_runs_clean_against_fts5_db(
+    manifest_fixture: dict[str, Path],
+) -> None:
+    """Full end-to-end: a DB that includes an FTS5 virtual table must not
+    crash `_sources_hash`. Prior to #1517 this raised
+    `sqlite3.OperationalError: no such column: rowid`."""
+    # Replace the plain fixture DB with one that exercises FTS5 shadows.
+    sources_db_path = manifest_fixture["sources_db_path"]
+    sources_db_path.unlink()
+    _build_sources_db_with_fts5(sources_db_path)
+
+    # Must not raise. Must return a valid sha256 hex digest.
+    digest = alignment_manifest._sources_hash()
+    assert isinstance(digest, str)
+    assert len(digest) == 64
+    int(digest, 16)  # raises ValueError if not hex
+
+
+def test_fts5_sources_hash_is_stable_across_rebuilds(tmp_path: Path, monkeypatch) -> None:
+    """Two independently-built DBs containing identical FTS5 content must
+    yield identical `_sources_hash` values. This would fail before #1517
+    because `*_data` / `*_idx` shadow tables carry segment IDs that differ
+    across separate `INSERT INTO fts(body)` operations."""
+    db_a = tmp_path / "a" / "sources.db"
+    db_b = tmp_path / "b" / "sources.db"
+    _build_sources_db_with_fts5(db_a)
+    _build_sources_db_with_fts5(db_b)
+
+    monkeypatch.setattr(alignment_manifest, "SOURCES_DB_PATH", db_a)
+    hash_a = alignment_manifest._sources_hash()
+    monkeypatch.setattr(alignment_manifest, "SOURCES_DB_PATH", db_b)
+    hash_b = alignment_manifest._sources_hash()
+
+    assert hash_a == hash_b, (
+        "Identical FTS5 content produced different manifest hashes — "
+        "shadow-table segment state is leaking into the hash."
+    )


### PR DESCRIPTION
## What broke

User fired the `a1/colors` pilot. It crashed at Step 2 CHECK while saving state:

```
sqlite3.OperationalError: no such column: rowid
  File "scripts/build/alignment_manifest.py", line 278, in _sqlite_table_snapshot
    row_count, max_rowid = connection.execute(
        f'SELECT COUNT(*), MAX(rowid) FROM "{table_name}"'
    ).fetchone()
```

Every build hits this path via `compose_manifest` → `_sources_hash` → `_sqlite_table_snapshot` on every `_save_v6_state`. Total blast radius: all builds against `sources.db` blocked.

## Root cause

`_sqlite_indexed_table_names` accepted any table with `PRAGMA index_list` rows OR a `CREATE VIRTUAL TABLE` DDL. SQLite's FTS5 virtual tables spawn 5 shadow tables each:

```
<name>_data, <name>_idx, <name>_content, <name>_docsize, <name>_config
```

All 5 carry PRIMARY KEYs, so they pass the index filter. Two of them are declared `WITHOUT ROWID`:

```sql
CREATE TABLE 'literary_fts_config'(k PRIMARY KEY, v) WITHOUT ROWID
CREATE TABLE 'literary_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID
```

`SELECT MAX(rowid)` against a `WITHOUT ROWID` table raises `no such column: rowid`.

10 failing tables in real `sources.db`:
`external_fts_config`, `external_fts_idx`, `literary_fts_config`, `literary_fts_idx`, `textbooks_fts_config`, `textbooks_fts_idx`, `ukrainian_wiki_fts_config`, `ukrainian_wiki_fts_idx`, `wikipedia_fts_config`, `wikipedia_fts_idx`.

## Fix

Two-pass enumeration in `_sqlite_indexed_table_names`:

1. First pass collects virtual-table names so shadows can be recognized.
2. Shadow set computed as `{vt + suffix}` for all FTS5 shadow suffixes.
3. Second pass keeps virtual tables + regular tables with indexes, minus the shadow set.

## Semantic correctness

Even if the shadow tables responded to `MAX(rowid)`, **including them would be wrong**. Their `segid` / `pgno` / serialized segment blobs are SQLite-internal bookkeeping that varies across identical content rebuilds (VACUUM, FTS5 optimize, re-ingest). Hashing them would make the manifest non-deterministic — exactly the opposite of the alignment-manifest contract's purpose.

So exclusion is the **correct** answer, not a workaround.

## Regression coverage

Three new tests in `tests/test_alignment_manifest.py`:

- `test_fts5_shadow_tables_excluded_from_name_enumeration` — direct unit test on the enumeration function
- `test_sources_hash_runs_clean_against_fts5_db` — end-to-end smoke that would have caught the rowid crash
- `test_fts5_sources_hash_is_stable_across_rebuilds` — guards against the segment-state-leak failure mode (two fresh DBs, identical content → identical hash)

## Why the original test suite missed this

Existing fixtures built a plain `CREATE TABLE ... ; CREATE INDEX ...` — no FTS5 virtual tables, no shadows. New `_build_sources_db_with_fts5` helper uses `CREATE VIRTUAL TABLE … USING fts5(…, content='source_chunks', content_rowid='id')` to match the real `sources.db` shape.

## Verification

```
13 manifest tests pass
68 tests pass across manifest + v6 contract suite
_sources_hash() produces clean 64-char sha256 against real data/sources.db
```

## Closes

- #1517