### PR TITLE
feat(runtime): CompositeProbe + signal primitives for liveness (#1520 P1)

### DIFF
--- a/scripts/agent_runtime/livenessprobe.py
+++ b/scripts/agent_runtime/livenessprobe.py
@@ -1,0 +1,144 @@
+"""Pure liveness probe primitives for agent-runtime subprocess monitoring.
+
+This module intentionally has no integration points yet. Phase 2 wires these
+primitives into watchdog.py; Phase 1 keeps them independently unit-testable.
+"""
+from __future__ import annotations
+
+import glob
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+import psutil
+
+
+class Signal(Protocol):
+    """A probe signal returns True if it observes liveness, False if not."""
+
+    def evaluate(self) -> bool: ...
+
+
+def _newest_path(pattern: str) -> Path | None:
+    """Return the newest matching path, or None when no file exists."""
+    matches = [Path(match) for match in glob.glob(pattern) if Path(match).exists()]
+    if not matches:
+        return None
+    return max(matches, key=lambda path: path.stat().st_mtime)
+
+
+@dataclass
+class FileMTimeSignal:
+    """Positive if the target file's mtime is within max_age_s of now.
+
+    For glob patterns (e.g. rollout-*.jsonl), pick the newest match.
+    Absent file -> False.
+    """
+
+    path: str
+    max_age_s: int
+    # Deviation from the sketch: injectable clock keeps tests deterministic
+    # without monkeypatching module globals.
+    now_provider: Callable[[], float] = field(default=time.time, repr=False, compare=False)
+
+    def evaluate(self) -> bool:
+        target = _newest_path(self.path)
+        if target is None:
+            return False
+        return (self.now_provider() - target.stat().st_mtime) <= self.max_age_s
+
+
+@dataclass
+class FileSizeGrowthSignal:
+    """Positive if the target file has grown by >= min_bytes since the last call.
+
+    First call is always True (baselining). Absent file -> False.
+    State lives on the instance so CompositeProbe can reuse it across cycles.
+    """
+
+    path: str
+    min_bytes: int
+    _last_size: int | None = field(default=None, init=False, repr=False)
+
+    def evaluate(self) -> bool:
+        target = Path(self.path)
+        if not target.exists():
+            self._last_size = None
+            return False
+
+        current_size = target.stat().st_size
+        if self._last_size is None:
+            self._last_size = current_size
+            return True
+
+        grew_by = current_size - self._last_size
+        self._last_size = current_size
+        return grew_by >= self.min_bytes
+
+
+@dataclass
+class ProcCpuSignal:
+    """Positive if the given PID shows >= min_percent CPU over sample_window_s."""
+
+    pid: int
+    min_percent: float
+    sample_window_s: float = 1.0
+
+    def evaluate(self) -> bool:
+        try:
+            process = psutil.Process(self.pid)
+            return process.cpu_percent(interval=self.sample_window_s) >= self.min_percent
+        except psutil.Error:
+            return False
+
+
+@dataclass
+class StdoutStreamedSignal:
+    """Positive if stdout received any byte within max_age_s seconds."""
+
+    last_write_time_provider: Callable[[], float | None]
+    max_age_s: int
+    # Deviation from the sketch: injectable clock keeps tests deterministic
+    # without monkeypatching module globals.
+    now_provider: Callable[[], float] = field(default=time.time, repr=False, compare=False)
+
+    def evaluate(self) -> bool:
+        last_write_time = self.last_write_time_provider()
+        if last_write_time is None:
+            return False
+        return (self.now_provider() - last_write_time) <= self.max_age_s
+
+
+@dataclass
+class CompositeProbe:
+    """ANY-mode composition with failure threshold."""
+
+    signals: list[Signal]
+    failure_threshold: int = 3
+    period_s: int = 30
+    initial_delay_s: int = 90
+    _failure_count: int = 0
+    _started_at: float | None = None
+
+    def evaluate_once(self) -> bool:
+        """Return True if ANY signal reports alive."""
+        return any(signal.evaluate() for signal in self.signals)
+
+    def report(self, alive_this_cycle: bool) -> None:
+        """Advance or reset the failure counter."""
+        if alive_this_cycle:
+            self._failure_count = 0
+        else:
+            self._failure_count += 1
+
+    def should_kill(self) -> bool:
+        """Return True when consecutive failures reached the threshold."""
+        return self._failure_count >= self.failure_threshold
+
+    def in_initial_grace(self, now: float) -> bool:
+        """True if evaluation should be deferred while startup finishes."""
+        if self._started_at is None:
+            return False
+        return (now - self._started_at) < self.initial_delay_s

--- a/tests/test_livenessprobe.py
+++ b/tests/test_livenessprobe.py
@@ -1,0 +1,247 @@
+"""Unit tests for agent_runtime.livenessprobe primitives.
+
+Issue: #1520 Phase 1
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from scripts.agent_runtime.livenessprobe import (
+    CompositeProbe,
+    FileMTimeSignal,
+    FileSizeGrowthSignal,
+    ProcCpuSignal,
+    StdoutStreamedSignal,
+)
+
+
+class StaticSignal:
+    def __init__(self, value: bool) -> None:
+        self.value = value
+
+    def evaluate(self) -> bool:
+        return self.value
+
+
+def _stop_process(proc: subprocess.Popen[str]) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=3)
+
+
+def test_file_mtime_signal_returns_true_for_recent_file(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    target.write_text("event\n")
+    os.utime(target, (100.0, 100.0))
+
+    signal = FileMTimeSignal(str(target), max_age_s=10, now_provider=lambda: 105.0)
+
+    assert signal.evaluate() is True
+
+
+def test_file_mtime_signal_returns_false_for_stale_file(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    target.write_text("event\n")
+    os.utime(target, (100.0, 100.0))
+
+    signal = FileMTimeSignal(str(target), max_age_s=10, now_provider=lambda: 111.0)
+
+    assert signal.evaluate() is False
+
+
+def test_file_mtime_signal_returns_false_for_absent_file(tmp_path):
+    signal = FileMTimeSignal(str(tmp_path / "missing.jsonl"), max_age_s=10, now_provider=lambda: 100.0)
+
+    assert signal.evaluate() is False
+
+
+def test_file_mtime_signal_respects_glob_and_picks_newest_match(tmp_path):
+    old = tmp_path / "rollout-old.jsonl"
+    new = tmp_path / "rollout-new.jsonl"
+    old.write_text("old\n")
+    new.write_text("new\n")
+    os.utime(old, (100.0, 100.0))
+    os.utime(new, (200.0, 200.0))
+
+    signal = FileMTimeSignal(str(tmp_path / "rollout-*.jsonl"), max_age_s=10, now_provider=lambda: 205.0)
+
+    assert signal.evaluate() is True
+
+
+def test_file_size_growth_signal_first_call_returns_true_and_baselines(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    target.write_text("abc")
+    signal = FileSizeGrowthSignal(str(target), min_bytes=2)
+
+    assert signal.evaluate() is True
+
+
+def test_file_size_growth_signal_returns_true_when_growth_reaches_min_bytes(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    target.write_text("abc")
+    signal = FileSizeGrowthSignal(str(target), min_bytes=2)
+
+    assert signal.evaluate() is True
+    target.write_text("abcde")
+
+    assert signal.evaluate() is True
+
+
+def test_file_size_growth_signal_returns_false_when_growth_is_too_small(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    target.write_text("abc")
+    signal = FileSizeGrowthSignal(str(target), min_bytes=3)
+
+    assert signal.evaluate() is True
+    target.write_text("abcd")
+
+    assert signal.evaluate() is False
+
+
+def test_file_size_growth_signal_returns_false_for_absent_file(tmp_path):
+    signal = FileSizeGrowthSignal(str(tmp_path / "missing.jsonl"), min_bytes=1)
+
+    assert signal.evaluate() is False
+
+
+def test_file_size_growth_signal_resets_after_absent_file(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    signal = FileSizeGrowthSignal(str(target), min_bytes=1)
+
+    assert signal.evaluate() is False
+    target.write_text("abc")
+
+    assert signal.evaluate() is True
+
+
+def test_file_size_growth_signal_resets_on_file_truncation(tmp_path):
+    target = tmp_path / "rollout.jsonl"
+    target.write_text("abcdef")
+    signal = FileSizeGrowthSignal(str(target), min_bytes=2)
+
+    assert signal.evaluate() is True
+    target.write_text("abc")
+    assert signal.evaluate() is False
+    target.write_text("abcde")
+
+    assert signal.evaluate() is True
+
+
+def test_proc_cpu_signal_returns_true_for_cpu_spinning_subprocess():
+    proc = subprocess.Popen(
+        ["/bin/sh", "-c", "while :; do :; done"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        signal = ProcCpuSignal(proc.pid, min_percent=1.0, sample_window_s=0.2)
+
+        assert signal.evaluate() is True
+    finally:
+        _stop_process(proc)
+
+
+def test_proc_cpu_signal_returns_false_for_sleeping_subprocess():
+    proc = subprocess.Popen(
+        ["/bin/sleep", "10"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        signal = ProcCpuSignal(proc.pid, min_percent=1.0, sample_window_s=0.2)
+
+        assert signal.evaluate() is False
+    finally:
+        _stop_process(proc)
+
+
+def test_proc_cpu_signal_returns_false_for_missing_pid():
+    signal = ProcCpuSignal(999_999_999, min_percent=1.0, sample_window_s=0.01)
+
+    assert signal.evaluate() is False
+
+
+def test_stdout_streamed_signal_returns_true_when_last_write_is_recent():
+    signal = StdoutStreamedSignal(lambda: 95.0, max_age_s=10, now_provider=lambda: 100.0)
+
+    assert signal.evaluate() is True
+
+
+def test_stdout_streamed_signal_returns_false_when_last_write_is_stale():
+    signal = StdoutStreamedSignal(lambda: 80.0, max_age_s=10, now_provider=lambda: 100.0)
+
+    assert signal.evaluate() is False
+
+
+def test_stdout_streamed_signal_returns_false_when_last_write_is_none():
+    signal = StdoutStreamedSignal(lambda: None, max_age_s=10, now_provider=lambda: 100.0)
+
+    assert signal.evaluate() is False
+
+
+def test_composite_probe_evaluate_once_returns_true_with_any_positive_signal():
+    probe = CompositeProbe(signals=[StaticSignal(False), StaticSignal(True), StaticSignal(False)])
+
+    assert probe.evaluate_once() is True
+
+
+def test_composite_probe_evaluate_once_returns_false_with_all_negative_signals():
+    probe = CompositeProbe(signals=[StaticSignal(False), StaticSignal(False)])
+
+    assert probe.evaluate_once() is False
+
+
+def test_composite_probe_report_true_resets_counter():
+    probe = CompositeProbe(signals=[])
+    probe.report(False)
+    probe.report(False)
+
+    probe.report(True)
+
+    assert probe._failure_count == 0
+
+
+def test_composite_probe_report_false_increments_counter():
+    probe = CompositeProbe(signals=[])
+
+    probe.report(False)
+    probe.report(False)
+
+    assert probe._failure_count == 2
+
+
+def test_composite_probe_should_kill_fires_at_exactly_failure_threshold():
+    probe = CompositeProbe(signals=[], failure_threshold=2)
+
+    probe.report(False)
+    assert probe.should_kill() is False
+    probe.report(False)
+
+    assert probe.should_kill() is True
+
+
+@pytest.mark.parametrize(
+    ("started_at", "now", "expected"),
+    [
+        (None, 100.0, False),
+        (100.0, 189.9, True),
+        (100.0, 190.0, False),
+    ],
+)
+def test_composite_probe_in_initial_grace_correctly_gates_on_started_at(
+    started_at: float | None,
+    now: float,
+    expected: bool,
+):
+    probe = CompositeProbe(signals=[], initial_delay_s=90)
+    probe._started_at = started_at
+
+    assert probe.in_initial_grace(now) is expected


### PR DESCRIPTION
## Summary

Phase 1 substrate for #1520:
- Adds `scripts/agent_runtime/livenessprobe.py`
- Adds `FileMTimeSignal`, `FileSizeGrowthSignal`, `ProcCpuSignal`, `StdoutStreamedSignal`
- Adds `CompositeProbe` with ANY-mode evaluation and failure threshold handling
- Adds focused unit tests with 100% statement coverage for the new module

I did NOT touch watchdog.py or runner.py.

## Verification

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_livenessprobe.py -v`

24 passed:
- PASS tests/test_livenessprobe.py::test_file_mtime_signal_returns_true_for_recent_file
- PASS tests/test_livenessprobe.py::test_file_mtime_signal_returns_false_for_stale_file
- PASS tests/test_livenessprobe.py::test_file_mtime_signal_returns_false_for_absent_file
- PASS tests/test_livenessprobe.py::test_file_mtime_signal_respects_glob_and_picks_newest_match
- PASS tests/test_livenessprobe.py::test_file_size_growth_signal_first_call_returns_true_and_baselines
- PASS tests/test_livenessprobe.py::test_file_size_growth_signal_returns_true_when_growth_reaches_min_bytes
- PASS tests/test_livenessprobe.py::test_file_size_growth_signal_returns_false_when_growth_is_too_small
- PASS tests/test_livenessprobe.py::test_file_size_growth_signal_returns_false_for_absent_file
- PASS tests/test_livenessprobe.py::test_file_size_growth_signal_resets_after_absent_file
- PASS tests/test_livenessprobe.py::test_file_size_growth_signal_resets_on_file_truncation
- PASS tests/test_livenessprobe.py::test_proc_cpu_signal_returns_true_for_cpu_spinning_subprocess
- PASS tests/test_livenessprobe.py::test_proc_cpu_signal_returns_false_for_sleeping_subprocess
- PASS tests/test_livenessprobe.py::test_proc_cpu_signal_returns_false_for_missing_pid
- PASS tests/test_livenessprobe.py::test_stdout_streamed_signal_returns_true_when_last_write_is_recent
- PASS tests/test_livenessprobe.py::test_stdout_streamed_signal_returns_false_when_last_write_is_stale
- PASS tests/test_livenessprobe.py::test_stdout_streamed_signal_returns_false_when_last_write_is_none
- PASS tests/test_livenessprobe.py::test_composite_probe_evaluate_once_returns_true_with_any_positive_signal
- PASS tests/test_livenessprobe.py::test_composite_probe_evaluate_once_returns_false_with_all_negative_signals
- PASS tests/test_livenessprobe.py::test_composite_probe_report_true_resets_counter
- PASS tests/test_livenessprobe.py::test_composite_probe_report_false_increments_counter
- PASS tests/test_livenessprobe.py::test_composite_probe_should_kill_fires_at_exactly_failure_threshold
- PASS tests/test_livenessprobe.py::test_composite_probe_in_initial_grace_correctly_gates_on_started_at[None-100.0-False]
- PASS tests/test_livenessprobe.py::test_composite_probe_in_initial_grace_correctly_gates_on_started_at[100.0-189.9-True]
- PASS tests/test_livenessprobe.py::test_composite_probe_in_initial_grace_correctly_gates_on_started_at[100.0-190.0-False]

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/agent_runtime/livenessprobe.py tests/test_livenessprobe.py`

All checks passed.

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_livenessprobe.py --cov=scripts.agent_runtime.livenessprobe --cov-report=term-missing`

24 passed, `scripts/agent_runtime/livenessprobe.py` 100% statement coverage.

Note: this worktree did not have `.venv/bin/pytest` or `.venv/bin/ruff`, so the same shared project venv was invoked by absolute path with the command working directory set to this worktree.
