### PR TITLE
feat(api): /api/git/hygiene endpoint — classify dirty working-tree state (#1519)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1450,6 +1450,69 @@ never 500.
 }
 ```
 
+### Git hygiene — `GET /api/git/hygiene`
+
+Classifies current working-tree dirty files into actionable cleanup
+buckets. Exemption paths are loaded from
+`docs/best-practices/git-hygiene.md`; exempt files do not count toward
+`dirty_total`.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/git/hygiene` | Dirty-file taxonomy, remediation hints, and hygiene health |
+
+```bash
+curl -s http://localhost:8765/api/git/hygiene | python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+  "generated_at": "2026-04-24T06:50:00Z",
+  "dirty_total": 6,
+  "exempt": {"wiki": 1, "draft_tickets": 1, "gitignored": 0, "other": 0, "total": 2},
+  "buckets": {
+    "stale_behind_main": {"count": 1, "files": ["stale.py"]},
+    "real_wip": {"count": 1, "files": ["wip.py"]},
+    "untracked_unexempted": {"count": 1, "files": ["scratch/todo.txt"]},
+    "intentional_deletions": {
+      "count": 3,
+      "files": ["feature/remove/a.txt", "feature/remove/b.txt", "feature/remove/c.txt"],
+      "pattern": "feature/remove/*"
+    }
+  },
+  "suggestions": [
+    {
+      "action": "restore_to_head",
+      "rationale": "pre-merge content; main moved past these files",
+      "files": ["stale.py"],
+      "command": "git checkout HEAD -- stale.py"
+    },
+    {
+      "action": "stash_wip",
+      "rationale": "local definitions or decorators need a stash or commit, not restore",
+      "files": ["wip.py"],
+      "command": "git stash push -m git-hygiene-wip -- wip.py"
+    },
+    {
+      "action": "gitignore_pattern",
+      "pattern": "scratch/",
+      "rationale": "untracked files are neither ignored nor policy-exempt",
+      "files": ["scratch/todo.txt"]
+    },
+    {
+      "action": "commit_deletions",
+      "rationale": "coherent deletion cluster with no modified or untracked files in the same subtree",
+      "pattern": "feature/remove/*",
+      "files": ["feature/remove/a.txt", "feature/remove/b.txt", "feature/remove/c.txt"]
+    }
+  ],
+  "health": "dirty",
+  "performance_ms": 42.5
+}
+```
+
 ### Force-preview — `GET /api/artifacts/{track}/{slug}/force-preview`
 
 Exact list of files `v6_build.py {track} {num} --force` would delete,

--- a/scripts/api/git_hygiene_router.py
+++ b/scripts/api/git_hygiene_router.py
@@ -1,0 +1,448 @@
+"""Git hygiene endpoint for classifying dirty working-tree state (#1519).
+
+Mounted at /api/git in main.py.
+
+Endpoints:
+    GET /api/git/hygiene      Dirty-file taxonomy with remediation hints
+
+Performance benchmark: ``tests/test_git_hygiene_endpoint.py`` creates a
+fixture repository with 1000 non-exempt untracked files and asserts
+``compute_git_hygiene(...).performance_ms < 500``. The implementation
+keeps the common large-dirty-tree path cheap by batching ``git
+check-ignore`` and only running per-file ``git diff`` / ``git log`` for
+modified tracked files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import os
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+from .config import PROJECT_ROOT
+
+router = APIRouter(tags=["git"])
+
+POLICY_DOC = PROJECT_ROOT / "docs" / "best-practices" / "git-hygiene.md"
+FALLBACK_EXEMPTION_PATTERNS = (
+    "wiki/**",
+    "data/corpus_audit/draft_tickets/*.md",
+)
+
+BUCKET_NAMES = (
+    "stale_behind_main",
+    "real_wip",
+    "untracked_unexempted",
+    "intentional_deletions",
+)
+
+_GIT_TIMEOUT_S = 2.0
+_GIT_ENV_KEYS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_COMMON_DIR")
+
+
+def _git_invocation(args: list[str], cwd: Path) -> list[str]:
+    git_path = cwd / ".git"
+    if git_path.is_file():
+        line = git_path.read_text(encoding="utf-8").strip()
+        if line.startswith("gitdir:"):
+            raw_git_dir = Path(line.removeprefix("gitdir:").strip())
+            git_dir = raw_git_dir if raw_git_dir.is_absolute() else cwd / raw_git_dir
+            return ["git", f"--git-dir={git_dir}", f"--work-tree={cwd}", *args]
+    if git_path.is_dir():
+        return ["git", f"--git-dir={git_path}", f"--work-tree={cwd}", *args]
+    return ["git", *args]
+
+
+@dataclass(frozen=True)
+class StatusEntry:
+    xy: str
+    path: str
+
+    @property
+    def is_untracked(self) -> bool:
+        return self.xy == "??"
+
+    @property
+    def is_deleted(self) -> bool:
+        return "D" in self.xy
+
+    @property
+    def is_modified(self) -> bool:
+        return self.xy != "??" and "M" in self.xy
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: Path,
+    input_text: str | None = None,
+    timeout_s: float = _GIT_TIMEOUT_S,
+) -> tuple[int, str, str]:
+    try:
+        env = os.environ.copy()
+        for key in _GIT_ENV_KEYS:
+            env.pop(key, None)
+        proc = subprocess.run(
+            _git_invocation(args, cwd),
+            cwd=cwd,
+            env=env,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as exc:
+        return 124, "", f"TimeoutExpired after {exc.timeout}s"
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        return 127, "", f"{type(exc).__name__}: {exc}"
+
+
+def _isoformat_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_status(stdout: str) -> list[StatusEntry]:
+    entries: list[StatusEntry] = []
+    for line in stdout.splitlines():
+        if len(line) < 4:
+            continue
+        xy = line[:2]
+        path = line[3:]
+        if " -> " in path:
+            path = path.rsplit(" -> ", 1)[1]
+        entries.append(StatusEntry(xy=xy, path=path.strip()))
+    return entries
+
+
+def _extract_policy_exemptions(policy_doc: Path = POLICY_DOC) -> list[str]:
+    """Load exemption paths from the policy doc, with an explicit fallback.
+
+    The policy's "Exemption paths" section is the source of truth for
+    human-facing rules. We parse backticked path patterns from that
+    section so the endpoint does not silently drift from the documented
+    exemptions.
+    """
+    patterns: list[str] = []
+    try:
+        lines = policy_doc.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return list(FALLBACK_EXEMPTION_PATTERNS)
+
+    in_section = False
+    for line in lines:
+        if line.startswith("## "):
+            in_section = line.strip() == "## Exemption paths"
+            continue
+        if not in_section or not line.lstrip().startswith("- "):
+            continue
+
+        parts = line.split("`")
+        for idx in range(1, len(parts), 2):
+            candidate = parts[idx].strip()
+            if candidate:
+                patterns.append(candidate)
+
+    return sorted(set(patterns or FALLBACK_EXEMPTION_PATTERNS))
+
+
+def _matches_pattern(path: str, pattern: str) -> bool:
+    normalized = path.strip("/")
+    normalized_pattern = pattern.strip()
+    if not normalized_pattern:
+        return False
+
+    if normalized_pattern.endswith("/"):
+        return normalized.startswith(normalized_pattern.strip("/") + "/")
+    if normalized_pattern.endswith("/**"):
+        prefix = normalized_pattern[:-3].strip("/")
+        return normalized == prefix or normalized.startswith(prefix + "/")
+    if fnmatch.fnmatchcase(normalized, normalized_pattern.strip("/")):
+        return True
+
+    # The policy documents draft tickets as ``*.md`` because that is
+    # today's file type, but the exemption is operationally the draft
+    # ticket directory.
+    if normalized_pattern.endswith("/*.md"):
+        prefix = normalized_pattern[:-5].strip("/")
+        return normalized.startswith(prefix + "/")
+    return False
+
+
+def _exemption_key(path: str, patterns: list[str], ignored: set[str]) -> str | None:
+    if path in ignored:
+        return "gitignored"
+    for pattern in patterns:
+        if _matches_pattern(path, pattern):
+            if path == "wiki" or path.startswith("wiki/"):
+                return "wiki"
+            if path.startswith("data/corpus_audit/draft_tickets/"):
+                return "draft_tickets"
+            return "other"
+    return None
+
+
+def _check_ignored(paths: list[str], cwd: Path) -> set[str]:
+    if not paths:
+        return set()
+    code, stdout, _stderr = _run_git(
+        ["check-ignore", "--stdin"],
+        cwd=cwd,
+        input_text="\n".join(paths) + "\n",
+    )
+    if code not in {0, 1}:
+        return set()
+    return {line.strip() for line in stdout.splitlines() if line.strip()}
+
+
+def _git_diff(path: str, cwd: Path) -> str:
+    code, stdout, _stderr = _run_git(["diff", "HEAD", "--", path], cwd=cwd)
+    return stdout if code == 0 else ""
+
+
+def _recent_commits(path: str, cwd: Path) -> list[str]:
+    code, stdout, _stderr = _run_git(
+        ["log", "--format=%H", "HEAD~20..HEAD", "--", path],
+        cwd=cwd,
+    )
+    if code != 0:
+        code, stdout, _stderr = _run_git(["log", "--format=%H", "-20", "--", path], cwd=cwd)
+    if code != 0:
+        return []
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+def _diff_added_definition(diff: str) -> bool:
+    for line in diff.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        stripped = line[1:].lstrip()
+        if stripped.startswith(("def ", "class ", "@")):
+            return True
+    return False
+
+
+def _changed_lines(diff: str, prefix: str) -> set[str]:
+    header = prefix * 3
+    return {
+        line[1:].strip()
+        for line in diff.splitlines()
+        if line.startswith(prefix) and not line.startswith(header) and line[1:].strip()
+    }
+
+
+def _commit_patch(commit: str, path: str, cwd: Path) -> str:
+    code, stdout, _stderr = _run_git(
+        ["show", "--format=", "--unified=0", commit, "--", path],
+        cwd=cwd,
+    )
+    return stdout if code == 0 else ""
+
+
+def _is_stale_behind_main(path: str, diff: str, commits: list[str], cwd: Path) -> bool:
+    if not commits:
+        return False
+
+    working_additions = _changed_lines(diff, "+")
+    working_removals = _changed_lines(diff, "-")
+    if not working_removals:
+        return False
+
+    for commit in commits[:5]:
+        patch = _commit_patch(commit, path, cwd)
+        commit_added = _changed_lines(patch, "+")
+        commit_removed = _changed_lines(patch, "-")
+        if working_additions & commit_removed and working_removals & commit_added:
+            return True
+
+    return False
+
+
+def _same_subtree(path: str, directory: str) -> bool:
+    return path == directory or path.startswith(directory.rstrip("/") + "/")
+
+
+def _intentional_deletion_files(
+    deleted: list[str],
+    modified_or_untracked: set[str],
+) -> tuple[list[str], str | None]:
+    by_dir: dict[str, list[str]] = {}
+    for path in deleted:
+        directory = str(Path(path).parent).replace("\\", "/")
+        if directory == ".":
+            continue
+        by_dir.setdefault(directory, []).append(path)
+
+    chosen: list[str] = []
+    patterns: list[str] = []
+    used: set[str] = set()
+    for directory, files in sorted(by_dir.items(), key=lambda item: (-len(item[1]), item[0])):
+        if len(files) < 3:
+            continue
+        if any(_same_subtree(path, directory) for path in modified_or_untracked):
+            continue
+        fresh = [path for path in sorted(files) if path not in used]
+        if not fresh:
+            continue
+        chosen.extend(fresh)
+        used.update(fresh)
+        patterns.append(f"{directory}/*")
+
+    if not chosen:
+        return [], None
+    return chosen, ", ".join(patterns)
+
+
+def _bucket(count_files: list[str], **extra: Any) -> dict[str, Any]:
+    bucket: dict[str, Any] = {
+        "count": len(count_files),
+        "files": sorted(count_files),
+    }
+    bucket.update(extra)
+    return bucket
+
+
+def _suggestions(buckets: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+
+    stale_files = buckets["stale_behind_main"]["files"]
+    if stale_files:
+        quoted = " ".join(shlex.quote(path) for path in stale_files)
+        suggestions.append({
+            "action": "restore_to_head",
+            "rationale": "pre-merge content; main moved past these files",
+            "files": stale_files,
+            "command": f"git checkout HEAD -- {quoted}",
+        })
+
+    wip_files = buckets["real_wip"]["files"]
+    if wip_files:
+        quoted = " ".join(shlex.quote(path) for path in wip_files)
+        suggestions.append({
+            "action": "stash_wip",
+            "rationale": "local definitions or decorators need a stash or commit, not restore",
+            "files": wip_files,
+            "command": f"git stash push -m git-hygiene-wip -- {quoted}",
+        })
+
+    untracked_files = buckets["untracked_unexempted"]["files"]
+    if untracked_files:
+        first = untracked_files[0]
+        pattern = f"{first.split('/', 1)[0]}/" if "/" in first else first
+        suggestions.append({
+            "action": "gitignore_pattern",
+            "pattern": pattern,
+            "rationale": "untracked files are neither ignored nor policy-exempt",
+            "files": untracked_files,
+        })
+
+    deletion_pattern = buckets["intentional_deletions"].get("pattern")
+    if deletion_pattern:
+        suggestions.append({
+            "action": "commit_deletions",
+            "rationale": "coherent deletion cluster with no modified or untracked files in the same subtree",
+            "pattern": deletion_pattern,
+            "files": buckets["intentional_deletions"]["files"],
+        })
+
+    return suggestions
+
+
+def compute_git_hygiene(project_root: Path | None = None) -> dict[str, Any]:
+    if project_root is None:
+        project_root = PROJECT_ROOT
+
+    started = time.perf_counter()
+    generated_at = _isoformat_z(datetime.now(UTC))
+    policy_doc = project_root / "docs" / "best-practices" / "git-hygiene.md"
+    exemption_patterns = _extract_policy_exemptions(policy_doc)
+
+    code, stdout, stderr = _run_git(
+        ["status", "--short", "--porcelain=v1", "--untracked-files=all"],
+        cwd=project_root,
+    )
+    if code != 0:
+        return {
+            "generated_at": generated_at,
+            "dirty_total": 0,
+            "exempt": {"wiki": 0, "draft_tickets": 0, "gitignored": 0, "other": 0, "total": 0},
+            "buckets": {name: _bucket([]) for name in BUCKET_NAMES},
+            "suggestions": [],
+            "health": "blocked_imports",
+            "error": stderr.strip() or "git status failed",
+            "performance_ms": round((time.perf_counter() - started) * 1000, 2),
+        }
+
+    entries = _parse_status(stdout)
+    untracked_paths = [entry.path for entry in entries if entry.is_untracked]
+    ignored_paths = _check_ignored(untracked_paths, project_root)
+
+    exempt = {"wiki": 0, "draft_tickets": 0, "gitignored": 0, "other": 0, "total": 0}
+    non_exempt_entries: list[StatusEntry] = []
+    for entry in entries:
+        key = _exemption_key(entry.path, exemption_patterns, ignored_paths)
+        if key is not None:
+            exempt[key] += 1
+            exempt["total"] += 1
+            continue
+        non_exempt_entries.append(entry)
+
+    stale: list[str] = []
+    real_wip: list[str] = []
+    modified_or_untracked = {
+        entry.path for entry in non_exempt_entries if entry.is_modified or entry.is_untracked
+    }
+
+    for entry in non_exempt_entries:
+        if not entry.is_modified:
+            continue
+        diff = _git_diff(entry.path, project_root)
+        commits = _recent_commits(entry.path, project_root)
+        if _is_stale_behind_main(entry.path, diff, commits, project_root):
+            stale.append(entry.path)
+        elif _diff_added_definition(diff) and not commits:
+            real_wip.append(entry.path)
+
+    untracked = [entry.path for entry in non_exempt_entries if entry.is_untracked]
+    deleted = [entry.path for entry in non_exempt_entries if entry.is_deleted]
+    intentional_deletions, deletion_pattern = _intentional_deletion_files(
+        deleted,
+        modified_or_untracked,
+    )
+
+    buckets = {
+        "stale_behind_main": _bucket(stale),
+        "real_wip": _bucket(real_wip),
+        "untracked_unexempted": _bucket(untracked),
+        "intentional_deletions": _bucket(intentional_deletions, pattern=deletion_pattern),
+    }
+
+    dirty_total = len(non_exempt_entries)
+    blocked_imports = any(entry.is_deleted and entry.path.endswith(".py") for entry in non_exempt_entries)
+    health = "clean" if dirty_total == 0 else "blocked_imports" if blocked_imports else "dirty"
+
+    return {
+        "generated_at": generated_at,
+        "dirty_total": dirty_total,
+        "exempt": exempt,
+        "buckets": buckets,
+        "suggestions": _suggestions(buckets),
+        "health": health,
+        "performance_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+@router.get("/hygiene")
+async def git_hygiene():
+    """Classify current working-tree drift into actionable buckets."""
+    return await asyncio.to_thread(compute_git_hygiene)

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -49,6 +49,7 @@ from .cost_router import router as cost_router
 from .dashboard_router import router as dashboard_router
 from .decisions_router import router as decisions_router
 from .delegate_router import router as delegate_router
+from .git_hygiene_router import router as git_hygiene_router
 from .gold_router import router as gold_router
 from .images_router import router as images_router
 from .issues_router import router as issues_router
@@ -110,6 +111,7 @@ app.include_router(cost_router, prefix="/api/analytics/cost")
 app.include_router(dashboard_router, prefix="/api/dashboard")
 app.include_router(decisions_router, prefix="/api/decisions", tags=["decisions"])
 app.include_router(delegate_router, prefix="/api/delegate")
+app.include_router(git_hygiene_router, prefix="/api/git", tags=["git"])
 app.include_router(gold_router, prefix="/api/gold")
 app.include_router(build_events_router, prefix="/api/build/events")
 app.include_router(images_router, prefix="/api/images")

--- a/tests/test_git_hygiene_endpoint.py
+++ b/tests/test_git_hygiene_endpoint.py
@@ -1,0 +1,172 @@
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.api import git_hygiene_router
+from scripts.api.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        env.pop(key, None)
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        env=env,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "codex@example.invalid")
+    _git(repo, "config", "user.name", "Codex Test")
+    _write(
+        repo / "docs" / "best-practices" / "git-hygiene.md",
+        """# Git Hygiene
+
+## Exemption paths
+
+- `wiki/**` - wiki builder output
+- `data/corpus_audit/draft_tickets/*.md` - draft tickets
+
+## Other section
+""",
+    )
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+
+
+def _dirty_repo_with_all_buckets(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    _write(repo / "stale.py", "def old_name():\n    return 'old'\n")
+    _write(repo / "wip.py", "def stable():\n    return 'stable'\n")
+    for name in ("a.txt", "b.txt", "c.txt"):
+        _write(repo / "feature" / "remove" / name, f"{name}\n")
+    _commit_all(repo, "initial")
+
+    for idx in range(20):
+        _write(repo / "fillers" / f"{idx:02d}.txt", f"{idx}\n")
+        _commit_all(repo, f"filler {idx}")
+
+    _write(repo / "stale.py", "def new_name():\n    return 'new'\n")
+    _commit_all(repo, "update stale file")
+
+    _write(repo / "stale.py", "def old_name():\n    return 'old'\n")
+    _write(repo / "wip.py", "def stable():\n    return 'stable'\n\n\ndef local_wip():\n    return 'wip'\n")
+    for name in ("a.txt", "b.txt", "c.txt"):
+        (repo / "feature" / "remove" / name).unlink()
+    _write(repo / "scratch" / "todo.txt", "local note\n")
+    _write(repo / "wiki" / "draft.md", "wiki output\n")
+    _write(repo / "data" / "corpus_audit" / "draft_tickets" / "ticket.md", "draft\n")
+
+    return repo
+
+
+def test_hygiene_classifies_each_dirty_bucket(tmp_path: Path) -> None:
+    repo = _dirty_repo_with_all_buckets(tmp_path)
+
+    result = git_hygiene_router.compute_git_hygiene(repo)
+
+    assert result["health"] == "dirty"
+    assert result["dirty_total"] == 6
+    assert result["exempt"]["wiki"] == 1
+    assert result["exempt"]["draft_tickets"] == 1
+    assert result["exempt"]["total"] == 2
+    assert result["buckets"]["stale_behind_main"]["files"] == ["stale.py"]
+    assert result["buckets"]["real_wip"]["files"] == ["wip.py"]
+    assert result["buckets"]["untracked_unexempted"]["files"] == ["scratch/todo.txt"]
+    assert result["buckets"]["intentional_deletions"]["count"] == 3
+    assert result["buckets"]["intentional_deletions"]["pattern"] == "feature/remove/*"
+    assert {item["action"] for item in result["suggestions"]} == {
+        "restore_to_head",
+        "stash_wip",
+        "gitignore_pattern",
+        "commit_deletions",
+    }
+
+
+def test_hygiene_endpoint_is_registered_and_uses_project_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _dirty_repo_with_all_buckets(tmp_path)
+    monkeypatch.setattr(git_hygiene_router, "PROJECT_ROOT", repo)
+
+    response = client.get("/api/git/hygiene")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["health"] == "dirty"
+    assert body["buckets"]["real_wip"]["files"] == ["wip.py"]
+
+
+def test_hygiene_is_clean_when_all_dirty_files_are_exempt(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write(repo / "README.md", "clean base\n")
+    _commit_all(repo, "initial")
+    _write(repo / "wiki" / "draft.md", "wiki output\n")
+    _write(repo / "data" / "corpus_audit" / "draft_tickets" / "ticket.md", "draft\n")
+
+    result = git_hygiene_router.compute_git_hygiene(repo)
+
+    assert result["health"] == "clean"
+    assert result["dirty_total"] == 0
+    assert result["exempt"]["total"] == 2
+    assert all(bucket["count"] == 0 for bucket in result["buckets"].values())
+
+
+def test_hygiene_marks_deleted_python_as_blocked_imports(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write(repo / "scripts" / "common" / "text_utils.py", "def normalize():\n    return None\n")
+    _commit_all(repo, "initial")
+    (repo / "scripts" / "common" / "text_utils.py").unlink()
+
+    result = git_hygiene_router.compute_git_hygiene(repo)
+
+    assert result["health"] == "blocked_imports"
+    assert result["dirty_total"] == 1
+
+
+def test_hygiene_1000_untracked_files_stays_under_500ms(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write(repo / "README.md", "clean base\n")
+    _commit_all(repo, "initial")
+
+    for idx in range(1000):
+        _write(repo / "scratch" / f"{idx:04d}.txt", f"{idx}\n")
+
+    started = time.perf_counter()
+    result = git_hygiene_router.compute_git_hygiene(repo)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+
+    assert result["dirty_total"] == 1000
+    assert result["buckets"]["untracked_unexempted"]["count"] == 1000
+    assert result["performance_ms"] < 500
+    assert elapsed_ms < 500


### PR DESCRIPTION
## Summary

Adds a read-only Monitor API endpoint at `GET /api/git/hygiene` that classifies current working-tree drift into the four #1519 buckets: `stale_behind_main`, `real_wip`, `untracked_unexempted`, and `intentional_deletions`.

The implementation loads exemption patterns from `docs/best-practices/git-hygiene.md`, batches `git check-ignore --stdin` for untracked files, cross-checks modified files with recent git history, and returns remediation suggestions mapped to `restore_to_head`, `stash_wip`, `gitignore_pattern`, and `commit_deletions`.

## Test Coverage

- `tests/test_git_hygiene_endpoint.py::test_hygiene_classifies_each_dirty_bucket` covers all 4 classification buckets plus suggestions.
- `tests/test_git_hygiene_endpoint.py::test_hygiene_endpoint_is_registered_and_uses_project_root` covers route registration at `/api/git/hygiene`.
- `tests/test_git_hygiene_endpoint.py::test_hygiene_is_clean_when_all_dirty_files_are_exempt` covers `wiki/**` and `data/corpus_audit/draft_tickets/*.md` exclusion from `dirty_total` and `health: clean`.
- `tests/test_git_hygiene_endpoint.py::test_hygiene_marks_deleted_python_as_blocked_imports` covers `health: blocked_imports`.
- `tests/test_git_hygiene_endpoint.py::test_hygiene_1000_untracked_files_stays_under_500ms` covers the <=500ms response budget for 1000 dirty entries.

## Acceptance Criteria Evidence

- Endpoint registered + reachable: `scripts/api/main.py:52`, `scripts/api/main.py:113`; smoke-tested `curl http://127.0.0.1:8765/api/git/hygiene` => HTTP 200, `health: clean`.
- All 4 buckets populated correctly: `tests/test_git_hygiene_endpoint.py:86`.
- Response time <500ms: benchmark documented in `scripts/api/git_hygiene_router.py:8`; asserted in `tests/test_git_hygiene_endpoint.py:155`.
- Exemptions honored: policy loading in `scripts/api/git_hygiene_router.py:128`; tested in `tests/test_git_hygiene_endpoint.py:124`.
- `health` returns `clean` / `dirty` / `blocked_imports`: computed in `scripts/api/git_hygiene_router.py:432`; tests at `tests/test_git_hygiene_endpoint.py:86`, `tests/test_git_hygiene_endpoint.py:124`, and `tests/test_git_hygiene_endpoint.py:141`.
- Documented in `docs/MONITOR-API.md:1453`.

## Verification

- `.venv/bin/pytest tests/test_git_hygiene_endpoint.py -v` => 5 passed
- `.venv/bin/ruff check scripts/api/git_hygiene_router.py tests/test_git_hygiene_endpoint.py` => passed
- Additional hook coverage: ruff and affected pytest passed during commit.

Closes #1519