### PR TITLE
feat(honesty-annotator): deterministic VERIFY injection (#1529 P2)

### DIFF
--- a/scripts/build/phases/honesty_annotator.py
+++ b/scripts/build/phases/honesty_annotator.py
@@ -1,0 +1,90 @@
+"""Deterministic VERIFY marker insertion for precise prose claims."""
+
+from __future__ import annotations
+
+import re
+
+_PERCENT_RE = re.compile(r"\b\d+(?:[–\-]\d+)?\s*%")
+_LINGUISTIC_UNIT_RE = re.compile(
+    r"\b\d+\s+"
+    r"(?:звук\w*|літер\w*|голосн\w*|приголосн\w*|буков\w*|склад\w*|відмін\w*|"
+    r"sound\w*|letter\w*|vowel\w*|consonant\w*|phoneme\w*|syllable\w*|case\w*|gender\w*)\b",
+    re.IGNORECASE,
+)
+_COMMENT_ONLY_RE = re.compile(r"^\s*<!--.*-->\s*$")
+
+
+def _line_body_and_ending(line: str) -> tuple[str, str]:
+    if line.endswith("\r\n"):
+        return line[:-2], "\r\n"
+    if line.endswith(("\n", "\r")):
+        return line[:-1], line[-1]
+    return line, ""
+
+
+def _is_structural_line(line_body: str) -> bool:
+    stripped = line_body.strip()
+    if not stripped:
+        return True
+    lstripped = line_body.lstrip()
+    return (
+        lstripped.startswith("#")
+        or lstripped.startswith(":::")
+        or _COMMENT_ONLY_RE.fullmatch(line_body) is not None
+    )
+
+
+def _distinct_matches(line_body: str) -> list[str]:
+    found = []
+    for pattern in (_PERCENT_RE, _LINGUISTIC_UNIT_RE):
+        found.extend((match.start(), match.group(0)) for match in pattern.finditer(line_body))
+
+    matches: list[str] = []
+    seen: set[str] = set()
+    for _, value in sorted(found, key=lambda item: item[0]):
+        if value in seen:
+            continue
+        seen.add(value)
+        matches.append(value)
+    return matches
+
+
+def _marker_for(matches: list[str]) -> str:
+    preview = "; ".join(matches[:3])[:80]
+    return f" <!-- VERIFY: precise claim ({preview}) -->"
+
+
+def annotate_content(content: str) -> tuple[str, list[dict]]:
+    """Return content with VERIFY markers appended to precise-claim prose lines."""
+    annotated_lines: list[str] = []
+    annotation_log: list[dict] = []
+    in_fence = False
+
+    for line_num, line in enumerate(content.splitlines(keepends=True), start=1):
+        line_body, line_ending = _line_body_and_ending(line)
+        if line_body.lstrip().startswith("```"):
+            in_fence = not in_fence
+            annotated_lines.append(line)
+            continue
+
+        if in_fence or _is_structural_line(line_body) or "<!-- VERIFY" in line_body:
+            annotated_lines.append(line)
+            continue
+
+        matches = _distinct_matches(line_body)
+        if not matches:
+            annotated_lines.append(line)
+            continue
+
+        marker = _marker_for(matches)
+        annotated_lines.append(f"{line_body}{marker}{line_ending}")
+        annotation_log.append(
+            {
+                "line_num": line_num,
+                "line": line_body,
+                "matches": matches,
+                "marker": marker,
+            }
+        )
+
+    return "".join(annotated_lines), annotation_log

--- a/scripts/build/plan_tracking.py
+++ b/scripts/build/plan_tracking.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-PLAN_HASH_PHASES = ("skeleton", "write", "exercises", "annotate", "verify")
+PLAN_HASH_PHASES = ("skeleton", "write", "honesty-annotate", "exercises", "annotate", "verify")
 PLAN_DRIFT_GUARD_STEPS = {"review", "publish", "audit"}
 _PHASE_SATISFIED_STATUSES = {"complete", "skipped"}
 _PHASE_TS_FUDGE_SECONDS = 1.0

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -1288,7 +1288,7 @@ def _normalize_v6_phase_status(result: object, *, phase: str) -> V6_PHASE_STATUS
 # stable public name. They must stay in sync (which is free — they're
 # the same list object).
 _ALL_PHASES = [
-    "check", "research", "skeleton", "pre-verify", "write",
+    "check", "research", "skeleton", "pre-verify", "write", "honesty-annotate",
     "exercises", "activities", "repair", "verify-exercises", "annotate",
     "vocab", "enrich", "verify", "review", "review-style", "stress", "publish", "audit",
 ]
@@ -1297,6 +1297,7 @@ _PHASE_SATISFIED_STATUSES = {"complete", "skipped"}
 _PLAN_HASH_STALE_PHASES = tuple(phase for phase in PLAN_HASH_PHASES if phase in {
     "skeleton",
     "write",
+    "honesty-annotate",
     "exercises",
     "annotate",
     "verify",
@@ -1308,7 +1309,7 @@ _PLAN_HASH_DRIFT_REASON = (
 )
 _PLAN_HASH_WARN_MESSAGE = (
     "WARN: Plan version changed since write phase — marking "
-    "skeleton/write/exercises/annotate/verify as stale"
+    "skeleton/write/honesty-annotate/exercises/annotate/verify as stale"
 )
 _PLAN_HASH_ABORT_MESSAGE = (
     "Plan changed since last write — re-run from skeleton to rebuild with updated plan"
@@ -1324,6 +1325,7 @@ PHASE_LABELS: dict[str, str] = {
     "skeleton": "Skeleton",
     "pre-verify": "Pre-verify",
     "write": "Write content",
+    "honesty-annotate": "Honesty annotate",
     "exercises": "Exercises",
     "activities": "Activities",
     "repair": "Repair",
@@ -6317,6 +6319,34 @@ def step_annotate(content_path: Path) -> V6_PHASE_STATUS:
         return "degraded"
 
 
+def step_honesty_annotate(content_path: Path, level: str, slug: str, orch_dir: Path) -> bool:
+    """Step 5a: Insert deterministic VERIFY markers for precise claims."""
+    _log(f"\n{'='*60}")
+    _log("  Step 5a: HONESTY ANNOTATE — VERIFY markers")
+    _log(f"{'='*60}")
+
+    if not content_path or not content_path.exists():
+        _log("  ❌ No content file")
+        return False
+
+    try:
+        from build.phases.honesty_annotator import annotate_content
+
+        content = content_path.read_text("utf-8")
+        annotated_content, annotation_log = annotate_content(content)
+        content_path.write_text(annotated_content, "utf-8")
+        orch_dir.mkdir(parents=True, exist_ok=True)
+        (orch_dir / "honesty-annotations.json").write_text(
+            json.dumps(annotation_log, indent=2, ensure_ascii=False) + "\n",
+            "utf-8",
+        )
+        _log(f"  ✅ Added VERIFY markers to {len(annotation_log)} line(s)")
+        return True
+    except Exception as e:
+        _log(f"  ❌ Honesty annotation failed: {e}")
+        return False
+
+
 def step_vocab(content_path: Path, level: str, module_num: int,
                slug: str, writer: str = "claude") -> Path | None:
     """Step 5c: Generate vocabulary YAML from the module content.
@@ -9212,6 +9242,9 @@ def _rerun_write_after_plan_patch(
     if content_path is not None:
         _post_process_content(content_path)
         _save_v6_state(level, slug, "write")
+        orch_dir = CURRICULUM_ROOT / level / "orchestration" / slug
+        if step_honesty_annotate(content_path, level, slug, orch_dir):
+            _save_v6_state(level, slug, "honesty-annotate")
         _save_v6_state(level, slug, "annotate")
     return content_path
 
@@ -9403,6 +9436,11 @@ def _refresh_post_patch_sidecars(
     """Refresh content-derived sidecars after any prose regeneration."""
     _log("\n♻️ Refreshing full sidecar chain after prose regeneration")
     _post_process_content(content_path)
+    orch_dir = CURRICULUM_ROOT / level / "orchestration" / slug
+    if step_honesty_annotate(content_path, level, slug, orch_dir):
+        _save_v6_state(level, slug, "honesty-annotate")
+    else:
+        return False
     if _should_skip_annotate(level):
         _save_v6_state(level, slug, "annotate", status="skipped")
     else:
@@ -10245,7 +10283,7 @@ def main():
                         help="Default: claude-tools (2026-04-23: switched from gemini-tools after #1431 v2 showed Gemini factual-hallucination on decolonization-critical facts — e.g. writing «блакитний» instead of «синій» for the Ukrainian flag. Opus has stronger factual adherence + less Russian-imperial training-data contamination. *-tools = with verification access during writing via MCP/shell)")
     parser.add_argument("--reviewer", choices=["gemini", "gemini-tools", "claude", "claude-tools", "codex", "codex-tools"], default=None,
                         help="Override reviewer. Default: cross-agent (opposite of writer)")
-    parser.add_argument("--step", choices=["check", "research", "pre-verify", "skeleton", "write", "exercises", "activities", "repair", "verify-exercises", "annotate", "enrich", "verify", "review", "review-style", "publish", "audit", "all"],
+    parser.add_argument("--step", choices=["check", "research", "pre-verify", "skeleton", "write", "honesty-annotate", "exercises", "activities", "repair", "verify-exercises", "annotate", "enrich", "verify", "review", "review-style", "publish", "audit", "all"],
                         default="all",
                         help="Stop after this phase or run the full pipeline (default: all).")
     skeleton_group = parser.add_mutually_exclusive_group()
@@ -10720,6 +10758,25 @@ def main():
             _emit_phase_done("write", _phase_start)
         elif content_path is None:
             content_path = CURRICULUM_ROOT / args.level / f"{slug}.md"
+
+        # Step 5a: HONESTY ANNOTATE — deterministic VERIFY markers
+        if steps in ("all", "honesty-annotate") and "honesty-annotate" not in completed_phases:
+            if not content_path or not content_path.exists():
+                _log("\n❌ Build FAILED — no content file exists (write step failed)")
+                _emit_module_failed(
+                    "honesty-annotate",
+                    "Build FAILED — no content file exists (write step failed)",
+                )
+                sys.exit(1)
+            _phase_start = time.monotonic()
+            orch_dir = CURRICULUM_ROOT / args.level / "orchestration" / slug
+            honesty_ok = step_honesty_annotate(content_path, args.level, slug, orch_dir)
+            honesty_status: V6_PHASE_STATUS = "complete" if honesty_ok else "failed"
+            _save_v6_state(args.level, slug, "honesty-annotate", status=honesty_status)
+            _emit_phase_done("honesty-annotate", _phase_start, status=honesty_status)
+            if not honesty_ok:
+                _emit_module_failed("honesty-annotate", "Build FAILED at Step 5a (honesty annotate)")
+                sys.exit(1)
 
         # Step 5b: EXERCISES — legacy fallback (skip in full pipeline, ACTIVITIES replaces it)
         if steps == "exercises" and "exercises" not in completed_phases:

--- a/scripts/migrate/migrate_v6_plan_hashes.py
+++ b/scripts/migrate/migrate_v6_plan_hashes.py
@@ -32,6 +32,7 @@ from build.plan_tracking import (
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 PHASE_ORDER = [
     "check", "research", "skeleton", "pre-verify", "write",
+    "honesty-annotate",
     "exercises", "activities", "repair", "verify-exercises", "annotate",
     "vocab", "enrich", "verify", "review", "stress", "publish", "audit",
 ]

--- a/tests/test_honesty_annotator.py
+++ b/tests/test_honesty_annotator.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+from build.phases.honesty_annotator import annotate_content
+from build.v6_build import step_honesty_annotate
+
+
+def _annotated_line(text: str) -> str:
+    annotated, log = annotate_content(text)
+    assert len(log) == 1
+    return annotated
+
+
+def test_percent_pattern_is_annotated() -> None:
+    annotated = _annotated_line("Ukrainian is 42% vowelic.")
+    assert annotated == "Ukrainian is 42% vowelic. <!-- VERIFY: precise claim (42%) -->"
+
+
+def test_range_percent_is_annotated() -> None:
+    annotated = _annotated_line("42–46% of spoken Ukrainian is vowels.")
+    assert annotated == "42–46% of spoken Ukrainian is vowels. <!-- VERIFY: precise claim (42–46%) -->"
+
+
+def test_ukrainian_linguistic_units_are_annotated() -> None:
+    annotated, log = annotate_content("Ukrainian has 33 літер і 38 звуків.")
+    assert " <!-- VERIFY: precise claim (33 літер; 38 звуків) -->" in annotated
+    assert log[0]["matches"] == ["33 літер", "38 звуків"]
+
+
+def test_english_linguistic_units_are_annotated() -> None:
+    annotated, log = annotate_content("Ukrainian has 33 letters but 38 sounds.")
+    assert " <!-- VERIFY: precise claim (33 letters; 38 sounds) -->" in annotated
+    assert log[0]["matches"] == ["33 letters", "38 sounds"]
+
+
+def test_plain_prose_is_unchanged() -> None:
+    content = "Ukrainian is a beautiful language."
+    assert annotate_content(content) == (content, [])
+
+
+def test_already_marked_line_is_unchanged() -> None:
+    content = "42% vowelic <!-- VERIFY: existing marker -->"
+    assert annotate_content(content) == (content, [])
+
+
+def test_code_fence_is_skipped() -> None:
+    content = "```python\ncount = 42%\n```\n"
+    assert annotate_content(content) == (content, [])
+
+
+def test_heading_is_skipped() -> None:
+    content = "## 33 letters"
+    assert annotate_content(content) == (content, [])
+
+
+def test_admonition_markers_are_skipped() -> None:
+    content = ":::tip\n:::\n"
+    assert annotate_content(content) == (content, [])
+
+
+def test_html_comment_only_line_is_skipped() -> None:
+    content = "<!-- some note -->"
+    assert annotate_content(content) == (content, [])
+
+
+def test_idempotency() -> None:
+    content = "- Ukrainian has 33 letters.\n42–46% of spoken Ukrainian is vowels.\n"
+    once, _ = annotate_content(content)
+    twice, _ = annotate_content(once)
+    assert twice == once
+
+
+def test_list_item_is_annotated() -> None:
+    annotated = _annotated_line("- 6 vowels total")
+    assert annotated == "- 6 vowels total <!-- VERIFY: precise claim (6 vowels) -->"
+
+
+def test_blockquote_is_annotated() -> None:
+    annotated = _annotated_line("> Ukrainian has 33 letters")
+    assert annotated == "> Ukrainian has 33 letters <!-- VERIFY: precise claim (33 letters) -->"
+
+
+def test_mixed_content_appends_exactly_three_markers() -> None:
+    content = "\n".join(
+        [
+            "# Heading with 33 letters",
+            "",
+            "Plain intro.",
+            "Ukrainian has 33 letters.",
+            ":::tip",
+            "The tip body has vowels.",
+            ":::",
+            "```python",
+            "ratio = '42%'",
+            "```",
+            "<!-- 38 sounds note -->",
+            "> Ukrainian has 38 sounds.",
+            "No precise claim here.",
+            "- The alphabet has 10 vowels.",
+            "## Another heading 42%",
+            "",
+            "Closing sentence.",
+            "Already 42% marked <!-- VERIFY: existing -->",
+            ":::note",
+            ":::",
+        ]
+    )
+    annotated, log = annotate_content(content)
+    assert annotated.count("<!-- VERIFY: precise claim") == 3
+    assert len(log) == 3
+
+
+def test_current_sounds_letters_fixture_would_gain_markers() -> None:
+    fixture = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "a1" / "sounds-letters-and-hello.md"
+    content = fixture.read_text("utf-8")
+    annotated, log = annotate_content(content)
+    assert annotated != content
+    assert annotated.count("<!-- VERIFY: precise claim") >= 4
+    assert len(log) >= 4
+
+
+def test_step_honesty_annotate_writes_content_and_log(tmp_path: Path) -> None:
+    content_path = tmp_path / "a1" / "fixture.md"
+    content_path.parent.mkdir(parents=True)
+    content_path.write_text("Ukrainian has 33 letters.\nPlain line.\n", "utf-8")
+    orch_dir = tmp_path / "a1" / "orchestration" / "fixture"
+
+    assert step_honesty_annotate(content_path, "a1", "fixture", orch_dir) is True
+
+    annotated = content_path.read_text("utf-8")
+    assert "Ukrainian has 33 letters. <!-- VERIFY: precise claim (33 letters) -->" in annotated
+
+    log_path = orch_dir / "honesty-annotations.json"
+    assert log_path.exists()
+    payload = json.loads(log_path.read_text("utf-8"))
+    assert payload[0]["line_num"] == 1
+    assert payload[0]["line"] == "Ukrainian has 33 letters."
+    assert payload[0]["matches"] == ["33 letters"]
+    assert payload[0]["marker"] == " <!-- VERIFY: precise claim (33 letters) -->"

--- a/tests/test_migrate_plan_hashes.py
+++ b/tests/test_migrate_plan_hashes.py
@@ -83,7 +83,7 @@ def test_dry_run_does_not_write(tmp_path: Path, monkeypatch, capsys) -> None:
     assert state_path.read_text("utf-8") == original
     output = capsys.readouterr().out
     assert "DRY RUN a1/demo" in output
-    assert "updated 5 phase records" in output
+    assert "updated 6 phase records" in output
 
 
 def test_migration_populates_missing_hashes(tmp_path: Path, monkeypatch) -> None:
@@ -98,7 +98,7 @@ def test_migration_populates_missing_hashes(tmp_path: Path, monkeypatch) -> None
     result = migrate.migrate_state_file(state_path)
 
     assert result is not None
-    assert result.updated_phase_records == 5
+    assert result.updated_phase_records == 6
     assert result.stale_phase_records == 0
 
     current_hash = migrate.plan_hash(plan_path)

--- a/tests/test_migrate_v6_plan_hashes.py
+++ b/tests/test_migrate_v6_plan_hashes.py
@@ -64,7 +64,7 @@ def test_migration_backfills_plan_hashes_and_marks_stale_when_plan_is_newer(
     result = migrate_plan_hashes.migrate_state_file(state_path, apply=True)
 
     assert result is not None
-    assert result["backfilled_phases"] == 5
+    assert result["backfilled_phases"] == 6
     assert result["stale_modules"] == 1
     updated = json.loads(state_path.read_text("utf-8"))
     assert updated["phases"]["skeleton"]["plan_hash"]

--- a/tests/test_v6_plan_hash_drift.py
+++ b/tests/test_v6_plan_hash_drift.py
@@ -68,7 +68,7 @@ def _write_state(curriculum_root: Path, slug: str, *, tracked_hash: str) -> None
         phase: {"status": "complete", "ts": "2026-04-10T00:00:00+00:00"}
         for phase in v6_build._ALL_PHASES
     }
-    for phase in ("skeleton", "write", "exercises", "annotate", "verify"):
+    for phase in ("skeleton", "write", "honesty-annotate", "exercises", "annotate", "verify"):
         phases[phase]["plan_hash"] = tracked_hash
 
     orch_dir = curriculum_root / "b1" / "orchestration" / slug
@@ -157,6 +157,7 @@ def test_resume_plan_detects_plan_hash_drift_and_invalidates_from_earliest_write
         "skeleton",
         "pre-verify",
         "write",
+        "honesty-annotate",
         "exercises",
         "activities",
         "repair",
@@ -190,6 +191,7 @@ def test_resume_publish_expands_to_full_pipeline_when_writer_phase_is_stale(
     state_path = curriculum_root / "b1" / "orchestration" / slug / "state.json"
     state = json.loads(state_path.read_text("utf-8"))
     state["phases"]["write"]["plan_hash"] = "older-hash"
+    state["phases"]["honesty-annotate"]["plan_hash"] = "older-hash"
     state["phases"]["exercises"]["plan_hash"] = "older-hash"
     state["phases"]["annotate"]["plan_hash"] = "older-hash"
     state["phases"]["verify"]["plan_hash"] = "older-hash"


### PR DESCRIPTION
## Summary

Adds a deterministic `honesty-annotate` pipeline phase after `write` and before `exercises` so precise claims get `<!-- VERIFY: ... -->` markers before downstream generation/review. References #1529.

## Pattern Set

- Percentages: `\b\d+(?:[–\-]\d+)?\s*%`
- Linguistic-unit counts: digit + Ukrainian/English unit stems for sounds, letters, vowels, consonants, phonemes, syllables, cases, and genders.

## Integration Point

- New `scripts/build/phases/honesty_annotator.py` public API: `annotate_content(content)`.
- New `step_honesty_annotate(...)` in `scripts/build/v6_build.py`.
- New `_ALL_PHASES` / CLI `--step` phase: `honesty-annotate`, positioned immediately after `write` and before `exercises`.
- Persists raw annotation log entries to `orchestration/{slug}/honesty-annotations.json`.
- Adds `honesty-annotate` to plan-hash tracked phases so plan drift invalidates this writer-derived content mutation.

## Test Coverage

1. Percent pattern appends a marker.
2. Range percent appends a marker.
3. Ukrainian linguistic units append a marker.
4. English linguistic units append a marker.
5. Plain prose is unchanged.
6. Already marked lines are unchanged.
7. Code fences are skipped.
8. Headings are skipped.
9. Admonition marker lines are skipped.
10. Stand-alone HTML comments are skipped.
11. Idempotency on double-apply.
12. List items are annotated.
13. Blockquotes are annotated.
14. Mixed 20-line content appends exactly 3 markers.
15. Current `a1/sounds-letters-and-hello.md` fixture would gain at least 4 markers.

Also adds an integration test for `step_honesty_annotate` writing content and `honesty-annotations.json` with the expected log-entry schema.

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/phases/honesty_annotator.py tests/test_honesty_annotator.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_honesty_annotator.py tests/test_v6_contract_flow.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_v6_plan_hash_drift.py -q`