### PR TITLE
feat(writer-honesty): writer-prompt hardening + rubric alignment + annotator scoping (#1529 A)

### DIFF
--- a/scripts/build/phases/honesty_annotator.py
+++ b/scripts/build/phases/honesty_annotator.py
@@ -12,6 +12,7 @@ _LINGUISTIC_UNIT_RE = re.compile(
     re.IGNORECASE,
 )
 _COMMENT_ONLY_RE = re.compile(r"^\s*<!--.*-->\s*$")
+_SENTENCE_TERMINATOR_RE = re.compile(r"[.!?]\s+")
 
 
 def _line_body_and_ending(line: str) -> tuple[str, str]:
@@ -34,24 +35,63 @@ def _is_structural_line(line_body: str) -> bool:
     )
 
 
-def _distinct_matches(line_body: str) -> list[str]:
-    found = []
+def _distinct_matches(line_body: str) -> list[tuple[int, str]]:
+    """Return (position, matched_text) tuples for distinct precise-claim matches, sorted by position."""
+    found: list[tuple[int, str]] = []
     for pattern in (_PERCENT_RE, _LINGUISTIC_UNIT_RE):
         found.extend((match.start(), match.group(0)) for match in pattern.finditer(line_body))
 
-    matches: list[str] = []
+    results: list[tuple[int, str]] = []
     seen: set[str] = set()
-    for _, value in sorted(found, key=lambda item: item[0]):
+    for pos, value in sorted(found, key=lambda item: item[0]):
         if value in seen:
             continue
         seen.add(value)
-        matches.append(value)
-    return matches
+        results.append((pos, value))
+    return results
 
 
-def _marker_for(matches: list[str]) -> str:
-    preview = "; ".join(matches[:3])[:80]
+def _marker_for(match_values: list[str]) -> str:
+    preview = "; ".join(match_values[:3])[:80]
     return f" <!-- VERIFY: precise claim ({preview}) -->"
+
+
+def _sentence_spans(line_body: str) -> list[tuple[int, int]]:
+    """Return [start, end) spans for sentences within line_body.
+
+    A sentence ends at `[.!?]` followed by whitespace; `end` is the position
+    just after the terminator character (before the separating whitespace).
+    If no terminator is found the whole line is returned as a single span —
+    callers treat that as "fall back to end-of-line append."
+    """
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for match in _SENTENCE_TERMINATOR_RE.finditer(line_body):
+        terminator_end = match.start() + 1
+        spans.append((cursor, terminator_end))
+        cursor = match.end()
+    if cursor < len(line_body):
+        spans.append((cursor, len(line_body)))
+    if not spans:
+        spans.append((0, len(line_body)))
+    return spans
+
+
+def _inject_marker(line_body: str, marker: str, first_match_pos: int) -> str:
+    """Insert `marker` at the end of the sentence containing `first_match_pos`.
+
+    If the line has no sentence terminator, fall back to end-of-line append —
+    preserves the pre-sentence-scoping behavior for single-sentence lines.
+    """
+    spans = _sentence_spans(line_body)
+    if len(spans) == 1:
+        return f"{line_body}{marker}"
+    target_end = spans[-1][1]
+    for _, end in spans:
+        if first_match_pos < end:
+            target_end = end
+            break
+    return f"{line_body[:target_end]}{marker}{line_body[target_end:]}"
 
 
 def annotate_content(content: str) -> tuple[str, list[dict]]:
@@ -76,13 +116,16 @@ def annotate_content(content: str) -> tuple[str, list[dict]]:
             annotated_lines.append(line)
             continue
 
-        marker = _marker_for(matches)
-        annotated_lines.append(f"{line_body}{marker}{line_ending}")
+        match_values = [value for _, value in matches]
+        first_match_pos = matches[0][0]
+        marker = _marker_for(match_values)
+        new_line_body = _inject_marker(line_body, marker, first_match_pos)
+        annotated_lines.append(f"{new_line_body}{line_ending}")
         annotation_log.append(
             {
                 "line_num": line_num,
                 "line": line_body,
-                "matches": matches,
+                "matches": match_values,
                 "marker": marker,
             }
         )

--- a/scripts/build/phases/v6-review/v6-review-honesty.md
+++ b/scripts/build/phases/v6-review/v6-review-honesty.md
@@ -1,18 +1,22 @@
-<!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract -->
+<!-- version: 1.2.0 | updated: 2026-04-24 | GH #1529 A — reconcile VERIFY scope with writer Rule #2; drop flat 5.0 hard-cap -->
 # V6 Per-Dimension Review — Honesty
 
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Honesty** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Honesty ONLY by how well the module satisfies the contract's §5 (VERIFY markers as positive signal) clause. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.
 
-### Contract §5 — VERIFY is positive, not a defect
+### Contract §5 — what a VERIFY marker is, and what needs one
 
-A `<!-- VERIFY: {claim} -->` marker anchored to a specific claim is a POSITIVE signal — the writer flagged honest uncertainty rather than inventing. Score PASS-level (≥ 8) on any module with zero fabrication and one or more specific VERIFY markers where the plan/brief/pre-training genuinely disagree. Score <8 ONLY if:
+A `<!-- VERIFY: {claim} -->` marker anchored to a specific claim is a POSITIVE signal — the writer flagged honest uncertainty rather than inventing. The marker is **required** on any **precise, externally-verifiable claim** that a reader could check against a cited source. The writer prompt (Rule #2) scopes this to:
 
-- A specific factual claim is invented and cannot be verified; OR
-- Real plan-vs-authority ambiguity exists and the writer produced zero VERIFY markers (hidden uncertainty).
+- **Precise statistics** — percentages or specific counts of linguistic units (letters, sounds, phonemes, vowels, consonants, cases, genders, syllables, conjugation classes).
+- **Absolute quantifiers with scope-overreach risk** — "every / always / never / all / no exceptions" applied to a Ukrainian rule that the authorities treat as having standard exceptions or sociolinguistic variation.
+- **Historical dates** — year of a language reform, dictionary publication date, letter restoration / removal date, or similar datable events.
+- **Unsourced citations** — claims attributed to "Правопис 2019", "Антоненко-Давидович", a named textbook, or any authority, when the attribution is not already established in the knowledge packet.
 
-A large number of VERIFY markers without specific claims is scattered hedging — penalize that. A small number of specific VERIFY markers is ideal.
+A marker is **NOT required** for soft-hedged wording ("usually", "typically", "most often", "common", "in most cases") or for claims already qualified in the immediate context. Do not penalize soft-hedged prose for lacking markers — that is not the failure mode. **Marker spam on soft prose IS a defect** (low-signal hedging) — penalize it the same way you penalize missing markers on precise claims.
+
+**Quality of the marker text matters.** A bare `<!-- VERIFY -->` or a marker that repeats the claim without pointing at a source is low-signal. A marker that names the claim and, where possible, the source it should be checked against is the ideal.
 
 You are the **HONESTY** reviewer for a Ukrainian language module. Review only whether the writer stayed honest about uncertainty and avoided invented examples or unsupported certainty. Do not score language quality, pedagogy, or dialogue except where they expose fabrication.
 
@@ -62,14 +66,15 @@ REJECT, even if the writer thinks it's right.
 
 ## Dimension rubric
 
-Score **Honesty** from 1.0 to 10.0.
+Score **Honesty** from 1.0 to 10.0. Count **precise claims** (the four categories in §5 above) and check whether each is either (a) already grounded in the knowledge packet / plan, or (b) carries a VERIFY marker that names the claim and the source to check.
 
-- **10**: Claims are properly supported or explicitly marked uncertain.
-- **8-9.9**: Mostly honest, maybe one lightly overstated point.
-- **6-7.9**: Unsupported certainty or suspiciously invented examples.
-- **<6**: Fabrication or hidden uncertainty.
+- **PASS (≥ 8.0)**: Every precise claim is either grounded or marked. Markers, when present, reference a specific source. Soft-hedged prose is unmarked (correctly). No fabrication.
+- **REVISE (5.0 – 7.9)**: Some precise claims are missing markers, OR some markers are present but decorative (do not name the source, or are bare `<!-- VERIFY -->`). No fabrication.
+- **REJECT (< 5.0)**: Fabrication (invented example, false citation, invented form that cannot be verified). Also REJECT when three or more precise claims exist and the module has zero VERIFY markers — that is hidden uncertainty, not absence of uncertainty.
 
-**Hard cap:** Invented example or unsupported factual certainty without `<!-- VERIFY -->` = **max 5.0/10**.
+**Scoping rule — zero-marker modules are NOT automatically failed.** If the module contains no precise claims in the §5 categories (e.g., an A1 introduction module that stays on soft-hedged pedagogical prose throughout), zero markers is CORRECT and the module scores against the rest of the rubric normally. Only count the zero-marker penalty against **precise claims** in the prose.
+
+**Marker spam is a defect.** If the module has more than a small number of VERIFY markers on soft-hedged prose (not on precise claims), cap the score at REVISE (≤ 7.9) and write a finding explaining which markers are low-signal.
 
 ## Output contract
 

--- a/scripts/build/phases/v6-write.md
+++ b/scripts/build/phases/v6-write.md
@@ -1,4 +1,4 @@
-<!-- version: 2.1.0 | updated: 2026-04-23 | GH #1431 — shared contract reference -->
+<!-- version: 2.2.0 | updated: 2026-04-24 | GH #1529 A — promote VERIFY to Rule #2 + worked examples + drop self-audit block -->
 # V6 Writing Prompt — Module Content Generation
 
 ## Shared Contract (read first — supersedes rule text below on conflict)
@@ -57,10 +57,33 @@ Then begin writing the module content. Follow your own pacing plan — each sect
 
 ---
 
-## 9 Hard Rules
+## Hard Rules
 
 1. **IMMERSION TARGET: {IMMERSION_TARGET_SHORT}** — this is the percentage of Ukrainian text in your output. The audit will REJECT the module if immersion is outside this range. For A1 early modules, the learner cannot read Cyrillic — English must dominate. For A2+, Ukrainian must carry a significant share — add Ukrainian Reading Practice blocks, dialogues, and example paragraphs to reach the target. Too little Ukrainian fails audit just as much as too much.
-2. **EVERY contract item MUST appear in your output.** The shared contract lists required section beats, vocabulary, dialogue situations, activity obligations, and factual anchors. You MUST cover ALL of them — every textbook reference, every notation, every required example. If the contract says "Захарійчук Grade 1: [•] for vowels, [–] for consonants", you MUST include that notation. Skipping contract items is the #1 reason modules get rejected.
+2. **Mark precise claims with `<!-- VERIFY: {specific note} -->` while you draft.** This is the single most-skipped rule in builds through 2026-04. Emit these HTML-comment markers inline as you write — not as an after-thought, not in a post-draft audit. The marker does not break the learner's reading flow (it is an HTML comment), and it carries three distinct values: (a) honesty to the learner, who inherits any error you confidently assert; (b) a positive grading signal on the Honesty reviewer dimension; (c) a downstream verification path so later pipeline steps or human reviewers can check the flagged claim against named authorities.
+
+   **What requires a marker** (the reviewer treats these as precise, externally-verifiable claims):
+   - **Precise statistics** — any percentage or specific count of linguistic units (letters, sounds, phonemes, vowels, consonants, cases, genders, syllables, conjugation classes).
+   - **Absolute quantifiers with scope-overreach risk** — "every", "always", "never", "all", "no exceptions", applied to a Ukrainian grammar, spelling, or phonetic rule that the authorities treat as having standard exceptions or sociolinguistic variation.
+   - **Historical dates** — year of a reform, a dictionary's publication date, a letter's restoration or removal date, any datable language-policy event.
+   - **Unsourced citations** — claims attributed to "Правопис 2019", "Антоненко-Давидович", a named textbook, or any authority, when the attribution is not already established by the knowledge packet.
+
+   **What does NOT require a marker:** soft-hedged wording the module already uses ("usually", "typically", "most often", "common", "in most cases"), or claims already qualified in the immediate context. Do not scatter markers on soft prose — the reviewer penalizes low-signal hedging the same as missing markers.
+
+   **The marker text must be specific.** A bare `<!-- VERIFY -->` is low-signal. Name the claim, and where possible, the source you want checked.
+
+   WRONG:  Ukrainian has 33 letters but 38 sounds.
+   RIGHT:  Ukrainian has 33 letters but 38 sounds. <!-- VERIFY: counts from knowledge packet [S2] — 33 letters (fixed alphabet); 38 sounds (yotated Я/Ю/Є/Ї as digraph behavior) -->
+
+   WRONG:  Ukrainian is strikingly vocalic — 42% of speech is vowels.
+   RIGHT:  Ukrainian is vocalic — around 42% of speech is vowels. <!-- VERIFY: knowledge packet S6 cites 42-46% range for spoken Ukrainian; narrower claim needs external confirmation -->
+
+   WRONG:  Every unstressed Ukrainian vowel keeps its own quality.
+   RIGHT:  The unstressed [о] keeps its clean quality (не редукується до [а]). <!-- VERIFY: plan teaches this rule only for [о]; broader claim about all unstressed vowels overstates the source -->
+
+   When your pre-training disagrees with the plan YAML or wiki brief on a form, spelling, or rule — the brief wins, but you must surface the disagreement with a VERIFY marker so a reviewer can check. A deterministic post-write annotator will inject markers on precise-number claims you miss; your goal is to make that annotator a no-op by emitting the markers yourself.
+
+3. **EVERY contract item MUST appear in your output.** The shared contract lists required section beats, vocabulary, dialogue situations, activity obligations, and factual anchors. You MUST cover ALL of them — every textbook reference, every notation, every required example. If the contract says "Захарійчук Grade 1: [•] for vowels, [–] for consonants", you MUST include that notation. Skipping contract items is the #1 reason modules get rejected.
 
    **Section overflow protocol (contract §2).** Each section has a word budget (typically 270–330 words). If the contracted items for a section cannot fit at readable density, do NOT silently defer items to a later section. Cover every item AND emit a structured overflow block at the end of the section:
 
@@ -77,21 +100,20 @@ Then begin writing the module content. Follow your own pacing plan — each sect
    The convergence loop treats `<section_overflow>` as a plan-revision signal (plan-authoring bug, not writer bug) and will not fail the module for it. Silent deferral IS a failure — Section 2 promising 12 colors and delivering 6 (Round-1 `a1/colors` defect) is exactly the pattern to avoid.
 
    **Dialogue retrieval mandate (contract §3).** When a section's contract includes a dialogue (section is `Діалоги` / `Dialogues`, or the plan has a `dialogue_acts` entry for that section), BEFORE drafting Ukrainian dialogue you MUST call `mcp__sources__search_sources` with a Ukrainian query biased toward the scenario. Example query shape: `"діалог на ринку квіти кольори"` for a flower-market scene. Take the top 2–3 hits from `textbook_sections` or `ukrainian_wiki` as anchors — match their register, re-use common turn-taking phrases (Добрий день, Дякую, Будь ласка, Скажіть, будь ласка, …). If the search returns zero usable hits, emit a `<!-- VERIFY: dialogue not corpus-grounded, search returned no A1 matches -->` marker on the dialogue block. Invented Ukrainian dialogue without corpus anchoring is the Round-1 Dialogue-dim failure (stilted `Я думаю, цей білий светр і коричневі черевики.`).
-3. **NO IPA, NO Latin transliteration** — never write [mɑmɑ], (khlib), or phonetic brackets. Describe sounds by comparison: "Х sounds like «ch» in Scottish «loch»."
-4. **You are a warm, encouraging teacher.** Write with the voice of a calm classroom teacher explaining something interesting. Good phrasing is content-anchored: ask a direct question ("What happens when ___?"), point at an example ("Look at ___"), invite attention ("Notice ___"). Those slots take a specific Ukrainian word, sound, or pattern, not a generic noun.
+4. **NO IPA, NO Latin transliteration** — never write [mɑmɑ], (khlib), or phonetic brackets. Describe sounds by comparison: "Х sounds like «ch» in Scottish «loch»."
+5. **You are a warm, encouraging teacher.** Write with the voice of a calm classroom teacher explaining something interesting. Good phrasing is content-anchored: ask a direct question ("What happens when ___?"), point at an example ("Look at ___"), invite attention ("Notice ___"). Those slots take a specific Ukrainian word, sound, or pattern, not a generic noun.
 
    **Contract §4 allow-list (standard textbook-teacher register — these ARE acceptable when anchored to a specific teaching point):** "You have learned...", "Now it's time to...", "Let's review...", "In this module...", "By the end...", "Here's how to...", "Try this now...", "Notice that...", "Look at...", "Read aloud...". The reviewer will NOT penalize these when they introduce a specific Ukrainian word, sound, or pattern.
 
    **Contract §4 block-list (vacuous filler — always banned):** self-congratulatory framing ("Welcome to A2! Congratulations!", "Great job!", "You're doing amazing!"), gamified language ("You have unlocked...", "You now possess..."), empty transitions that do not introduce a specific teaching point ("In this section, we will explore [nothing specific]"), and padding sentences that carry no Ukrainian anchor ("This is a very important concept you will use frequently.").
 
    The distinguishing test: an opener is ALLOWED if the next clause teaches something specific to Ukrainian. It is BANNED if the next clause is empty framing with no Ukrainian anchor.
-5. **Ukrainian quotes: «...»** for Ukrainian text. Use regular quotes "..." for English metalanguage (e.g., "like the 'a' in 'father'").
-6. **Place exercise markers only** — do NOT write exercises directly. Place `<!-- INJECT_ACTIVITY: {exact_id_from_contract} -->` markers where exercises should appear. The `id` must match the shared contract's `activity_obligations` exactly. A separate pipeline step generates the actual exercises from the plan's activity_hints.
-7. **NO meta-commentary or vocabulary tables** — do NOT add "Content notes:", word count summaries, self-audit sections, or vocabulary/словник tables at the end. A downstream tool generates vocabulary tables automatically. Just write the module content and stop.
-8. **Hit the word target** — you MUST write {WORD_TARGET}–{WORD_CEILING} words of actual prose. To reach this target, deeply expand explanations, provide 3+ examples per concept, and, only if the contract has non-empty dialogue_acts, include rich multi-turn dialogues. Short modules fail review. Never pad with filler.
-9. **NO archaic, obsolete, or rare words** — use only modern standard Ukrainian. Do not use words marked as archaic (застаріле) or dialectal in dictionaries. Example: use «кін» not «кон», use «пом'якшені» not «м'якшені». When in doubt, choose the common modern form. Your pre-training contains Russian-influenced archaic forms — verify unfamiliar words.
-10. **EVERY module MUST end with `## {SUMMARY_HEADING}`** — this is the last H2 section before the file ends. It contains a self-check recap. If you forget this section, the audit REJECTS the module and you waste a retry. Write it LAST, after all other sections.
-11. **State rules honestly. Cite or hedge — never invent.** A grammar rule is "strict" ONLY when the plan YAML or a named Ukrainian authority (Правопис 2019, Антоненко-Давидович, VESUM, Захарійчук / Большакова / Авраменко textbooks) says so explicitly. Default language when a rule has exceptions or sociolinguistic variation: *common*, *typical*, *usually*, *most often*. When your pre-training and the wiki brief disagree, the brief wins — and if the brief's claim surprises you, flag it inline with `<!-- VERIFY: {word or claim} -->` rather than silently picking the version that "feels right." `<!-- VERIFY -->` is not a failure signal; it is the correct honest move, and reviewers score its presence positively on the honesty axis.
+6. **Ukrainian quotes: «...»** for Ukrainian text. Use regular quotes "..." for English metalanguage (e.g., "like the 'a' in 'father'").
+7. **Place exercise markers only** — do NOT write exercises directly. Place `<!-- INJECT_ACTIVITY: {exact_id_from_contract} -->` markers where exercises should appear. The `id` must match the shared contract's `activity_obligations` exactly. A separate pipeline step generates the actual exercises from the plan's activity_hints.
+8. **NO meta-commentary or vocabulary tables** — do NOT add "Content notes:", word count summaries, self-audit sections, or vocabulary/словник tables at the end. A downstream tool generates vocabulary tables automatically. Just write the module content and stop.
+9. **Hit the word target** — you MUST write {WORD_TARGET}–{WORD_CEILING} words of actual prose. To reach this target, deeply expand explanations, provide 3+ examples per concept, and, only if the contract has non-empty dialogue_acts, include rich multi-turn dialogues. Short modules fail review. Never pad with filler.
+10. **NO archaic, obsolete, or rare words** — use only modern standard Ukrainian. Do not use words marked as archaic (застаріле) or dialectal in dictionaries. Example: use «кін» not «кон», use «пом'якшені» not «м'якшені». When in doubt, choose the common modern form. Your pre-training contains Russian-influenced archaic forms — verify unfamiliar words.
+11. **EVERY module MUST end with `## {SUMMARY_HEADING}`** — this is the last H2 section before the file ends. It contains a self-check recap. If you forget this section, the audit REJECTS the module and you waste a retry. Write it LAST, after all other sections.
 
 **Note:** Do NOT add stress marks (´) to any Ukrainian word — a deterministic tool handles this after you write.
 
@@ -387,7 +409,6 @@ Without speaker names, the reader cannot tell who is speaking. NEVER use anonymo
 
   BAD: "The Ukrainian language has a wonderfully consistent and beautiful phonetic system."
   GOOD: "Ukrainian spelling is highly phonetic — what you see is what you hear."
-- **Never guess about Ukrainian.** If you are unsure about a word, grammatical form, or phonetic rule — flag it with `<!-- VERIFY: word/claim -->`. Never invent or describe vaguely to hide uncertainty.
 
 ### Forbidden Tropes (contract §4 block-list)
 
@@ -443,22 +464,6 @@ Every heading from "Section Structure" above MUST appear as an `## H2` in your o
 You MUST use **every word** from the list below at least once in the prose, in a natural sentence with bold + English translation. Abstract grammatical metalanguage (видова пара, дієвідміна, особове закінчення, прагматика, діагностика, дієвідмінювання, зворотний, двовидовий, одновидовий, неозначено-кількісний, etc.) is the most frequently dropped category — actively find homes for those words even if it means adding a sentence that defines them.
 
 {VOCABULARY_CHECKLIST}
-
-### Honesty pre-stop check (Rule #11, operational)
-
-This is a required check, not advice. Before you finish, walk through these three questions in order. If the answer to any is yes, you MUST have at least one `<!-- VERIFY: {specific claim} -->` marker in your prose at the relevant sentence. Zero VERIFY markers when real ambiguity exists is a review-fail signal on the honesty axis.
-
-1. **Does the plan YAML contradict itself, or cite conflicting textbook sources for the same point?** (E.g., `content_outline` says one thing about a rule while `references` says another; `grammar[N]` contradicts `grammar[M]` on a scope boundary.)
-2. **Does the plan state a rule as absolute where Правопис 2019 / Антоненко-Давидович / VESUM knows a standard exception?** (E.g., the plan formulates the apostrophe rule as "after б, п, в, м, ф, р before я, ю, є, ї" with no exceptions, but Правопис 2019 lists «свято», «цвях», «морквяний», «буряк» as standard no-apostrophe cases after labials.)
-3. **Does your pre-training strongly disagree with the plan or brief on a form, spelling, or rule?** The plan/brief wins — but you must surface the disagreement so a reviewer can check.
-
-**WRONG (no VERIFY marker; writer renders the simplified plan rule as absolute law, the reader inherits the error):**
-> Правило сформульоване чітко: **апостроф ставиться після Б, П, В, М, Ф, Р перед я, ю, є, ї.** Example words: **м'ясо**, **п'ять**, **об'єкт**.
-
-**RIGHT (VERIFY marker flags the scope gap without altering the plan's teaching pathway):**
-> Правило сформульоване чітко: **апостроф ставиться після Б, П, В, М, Ф, Р перед я, ю, є, ї.** Example words: **м'ясо**, **п'ять**, **об'єкт**. <!-- VERIFY: Правопис 2019 lists «свято», «цвях», «морквяний», «буряк» as standard no-apostrophe exceptions after labials even though they match the plan's labial+р+я pattern. A1 scope simplification or genuine plan gap? --> 
-
-The VERIFY marker does not interrupt the learner's reading flow — it is an HTML comment — but a reviewer grading honesty will see it and score positively. This is the explicit operational move rule #11 requires when plan-vs-authority disagreement is present.
 
 ### Forbidden words (never produce)
 

--- a/tests/test_honesty_annotator.py
+++ b/tests/test_honesty_annotator.py
@@ -116,6 +116,39 @@ def test_mixed_content_appends_exactly_three_markers() -> None:
     assert len(log) == 3
 
 
+def test_multi_sentence_line_marker_attaches_to_matching_first_sentence() -> None:
+    annotated, log = annotate_content(
+        "Ukrainian has 33 letters. Кави я люблю вранці."
+    )
+    assert annotated == (
+        "Ukrainian has 33 letters. <!-- VERIFY: precise claim (33 letters) --> "
+        "Кави я люблю вранці."
+    )
+    assert log[0]["matches"] == ["33 letters"]
+
+
+def test_multi_sentence_line_marker_attaches_to_matching_second_sentence() -> None:
+    annotated, log = annotate_content(
+        "Кави я люблю вранці. Ukrainian has 38 sounds."
+    )
+    assert annotated == (
+        "Кави я люблю вранці. Ukrainian has 38 sounds."
+        " <!-- VERIFY: precise claim (38 sounds) -->"
+    )
+    assert log[0]["matches"] == ["38 sounds"]
+
+
+def test_multi_sentence_line_marker_attaches_to_middle_sentence() -> None:
+    annotated, log = annotate_content(
+        "First sentence. Ukrainian has 42% vowels. Third sentence."
+    )
+    assert annotated == (
+        "First sentence. Ukrainian has 42% vowels."
+        " <!-- VERIFY: precise claim (42%) --> Third sentence."
+    )
+    assert log[0]["matches"] == ["42%"]
+
+
 def test_current_sounds_letters_fixture_would_gain_markers() -> None:
     fixture = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "a1" / "sounds-letters-and-hello.md"
     content = fixture.read_text("utf-8")


### PR DESCRIPTION
## Context

Empirical audit: **0 `<!-- VERIFY: ... -->` markers across 186 built modules** (a1 + a2 + b1 tracks). Writers systematically ignored buried Rule #11 + scattered mentions at lines 390/449 in `v6-write.md`. Honesty reviewer hard-capped at 5.0 when precise claims existed without markers → blocking a1/1 convergence. PR #1531 shipped the deterministic `honesty_annotator.py` as a post-write safety net; this PR moves from "annotator as band-aid" to "annotator as no-op behind a hardened writer prompt + aligned rubric."

Codex critique (bridge msg `437`, task `1529-writer-prompt-strategy`) pushed back on an earlier 3-step plan. All seven points incorporated: no self-audit / hidden-CoT block, annotator-as-enforcer reframe, rubric–writer scope reconciliation, marker-spam guard, over-hedging guard, incentive-inversion guard, and sentence-scoped marker placement.

## Deliverable 1 — `scripts/build/phases/v6-write.md`

- Promote the VERIFY instruction from buried **Rule #11** to **Rule #2**, right after `IMMERSION TARGET`.
- Rewrite with explicit categories — **what to mark** (precise statistics, absolute quantifiers with scope-overreach risk, historical dates, unsourced citations) and **what NOT to mark** (soft-hedged prose).
- Three concrete **WRONG → RIGHT** A1-level worked examples inline.
- Remove the `Honesty pre-stop check (Rule #11, operational)` self-audit subsection from the MANDATORY FINAL CHECKLIST (hidden-CoT failure mode per Codex).
- Remove the redundant "Never guess about Ukrainian" bullet — consolidated into Rule #2.
- Renumber rules 2-10 → 3-11; drop "9" from "## 9 Hard Rules" heading (list was already drifting to 11 items).

## Deliverable 2 — `scripts/build/phases/v6-review/v6-review-honesty.md`

- Reconcile the reviewer's §5 definition with the writer's Rule #2 scope. Previously drifted — writer said "precise statistics / absolute quantifiers / historical dates" while reviewer said "uncertainty / disagreement with source."
- Drop the flat **"hard cap 5.0 on zero markers"** rule — replace with a **precise-claim-scoped** penalty.
- New rubric: **PASS (≥8)** — every precise claim grounded or marked, marker text specific; **REVISE (5-7.9)** — precise claims missing markers OR markers are decorative/bare; **REJECT (<5)** — fabrication, OR ≥3 precise claims with zero markers.
- Explicit marker-spam cap: soft-prose markers cap score at REVISE.
- Explicit "zero-marker modules are not automatically failed" — soft-hedged introductions score against the rest of the rubric normally.

## Deliverable 3 — `scripts/build/phases/honesty_annotator.py`

Per Codex critique #7: current regex appended the marker at end of LINE, risking attachment to the wrong sentence on multi-sentence lines.

- Split line by `[.!?]\s+` sentence boundaries, locate the sentence containing the first regex match, insert the marker at that sentence's end.
- Fall back to end-of-line append when no sentence terminator is present (preserves prior behavior on single-sentence lines, headings-as-prose, blockquotes, bullet-only lines).
- Tests in `tests/test_honesty_annotator.py`: existing 16 tests still pass; 3 new multi-sentence tests (match in first / middle / second sentence) verify sentence-scoped placement.

## Non-goals (out of scope for this PR)

- No new LLM call / pipeline phase. A **semantic claim-audit** step — post-write LLM call returning structured JSON of risky claims, for dated historical assertions like "Ґ restored in 1990" that regex can't catch — is Phase B, tracked separately.
- `honesty_annotator.py` pattern set unchanged; only placement logic changed.
- No self-audit / checklist block added to the writer prompt (Codex #1).
- Other writer prompts untouched (`v6-write-uk.md`, `v6-write-seminar.md` are separate tracks).

## Verification

- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/phases/honesty_annotator.py tests/test_honesty_annotator.py` — clean.
- [x] `pytest tests/test_honesty_annotator.py tests/test_plan_adherence_prompt_policy.py -q` — 26 passed.
- [x] Pre-commit hook ran ruff + `pytest tests/test_honesty_annotator.py` — 19 passed.
- [x] `scripts/lint/lint_prompts.py` — clean (targets `gemini_extensions/skills/` and `claude_extensions/phases/`; the v6 build-phase prompts are not in scope but the linter runs clean on the repo).

## Success metric

Annotator-injected-marker count trending **down** as writers internalize Rule #2, but this PR does **NOT** gate on it. The annotator is now a safety net that correctly handles multi-sentence lines; the writer prompt is now the primary enforcement layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)