### PR TITLE
feat(validator): vocab-YAML coverage pre-review gate

### DIFF
--- a/curriculum/l2-uk-en/a1/vocabulary/sounds-letters-and-hello.yaml
+++ b/curriculum/l2-uk-en/a1/vocabulary/sounds-letters-and-hello.yaml
@@ -154,6 +154,27 @@ vocabulary:
   pos: ''
   gender: ''
   verified: true
+- word: Доброго ранку!
+  definition: ввічливе ранкове вітання
+  expression: true
+  additional: true
+  pos: ''
+  gender: ''
+  verified: true
+- word: Добрий вечір!
+  definition: ввічливе вечірнє вітання
+  expression: true
+  additional: true
+  pos: ''
+  gender: ''
+  verified: true
+- word: До побачення!
+  definition: прощальна фраза при завершенні зустрічі або розмови
+  expression: true
+  additional: true
+  pos: ''
+  gender: ''
+  verified: true
 - word: А у тебе?
   definition: зустрічне неформальне запитання для підтримання розмови
   expression: true

--- a/scripts/build/phases/vocab_coverage.py
+++ b/scripts/build/phases/vocab_coverage.py
@@ -1,0 +1,145 @@
+"""Vocabulary sidecar coverage checks for plan-required terms."""
+
+from __future__ import annotations
+
+import sqlite3
+import unicodedata
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+VESUM_DB_PATH = PROJECT_ROOT / "data" / "vesum.db"
+_TRAILING_PUNCTUATION = "?!."
+
+
+@dataclass(frozen=True)
+class VocabCoverageResult:
+    passed: bool
+    missing_terms: tuple[str, ...]
+    present_mapping: dict[str, str]
+
+
+def _strip_stress_marks(value: str) -> str:
+    decomposed = unicodedata.normalize("NFD", value).replace("\u0301", "")
+    return unicodedata.normalize("NFC", decomposed)
+
+
+def _normalize_term(value: str) -> str:
+    return _strip_stress_marks(value).lower().strip().rstrip(_TRAILING_PUNCTUATION).strip()
+
+
+def _extract_ukrainian_term(hint: str) -> str:
+    return str(hint).split(" (", maxsplit=1)[0].strip()
+
+
+def _load_required_terms(plan_path: Path) -> tuple[str, ...]:
+    payload = yaml.safe_load(plan_path.read_text("utf-8")) or {}
+    vocabulary_hints = payload.get("vocabulary_hints") or {}
+    required = vocabulary_hints.get("required") or []
+    return tuple(
+        term
+        for item in required
+        if (term := _extract_ukrainian_term(str(item)))
+    )
+
+
+def _load_vocab_words(vocab_yaml_path: Path) -> tuple[str, ...]:
+    payload = yaml.safe_load(vocab_yaml_path.read_text("utf-8")) or {}
+    entries = payload.get("vocabulary") if isinstance(payload, dict) else payload
+    if not isinstance(entries, list):
+        return ()
+
+    words: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        word = entry.get("word")
+        if isinstance(word, str) and word.strip():
+            words.append(word.strip())
+    return tuple(words)
+
+
+def _vesum_lemma_lookup(term: str, db_path: Path = VESUM_DB_PATH) -> str | None:
+    if not db_path.exists() or db_path.stat().st_size == 0:
+        return None
+
+    normalized = _normalize_term(term)
+    if not normalized:
+        return None
+
+    try:
+        with sqlite3.connect(str(db_path)) as db:
+            # Current contract for this validator: data/vesum.db exposes
+            # vesum(form, lemma). Older local imports used forms(word_form, lemma),
+            # so keep that fallback to avoid making the validator environment-fragile.
+            for query in (
+                "SELECT lemma FROM vesum WHERE form = ? LIMIT 1",
+                "SELECT lemma FROM forms WHERE word_form = ? LIMIT 1",
+                "SELECT lemma FROM forms WHERE lemma = ? LIMIT 1",
+            ):
+                try:
+                    row = db.execute(query, (normalized,)).fetchone()
+                except sqlite3.OperationalError:
+                    continue
+                if row and row[0]:
+                    return _normalize_term(str(row[0]))
+    except sqlite3.Error:
+        return None
+    return None
+
+
+@lru_cache(maxsize=4096)
+def _lemma_key(term: str) -> str | None:
+    normalized = _normalize_term(term)
+    if not normalized:
+        return None
+
+    direct = _vesum_lemma_lookup(normalized)
+    if direct:
+        return direct
+
+    tokens = normalized.split()
+    if len(tokens) <= 1:
+        return None
+
+    lemmas = [_vesum_lemma_lookup(token) for token in tokens]
+    if all(lemmas):
+        return " ".join(str(lemma) for lemma in lemmas)
+    return None
+
+
+def _terms_match(plan_term: str, vocab_word: str) -> bool:
+    if _normalize_term(plan_term) == _normalize_term(vocab_word):
+        return True
+
+    plan_lemma = _lemma_key(plan_term)
+    vocab_lemma = _lemma_key(vocab_word)
+    return bool(plan_lemma and vocab_lemma and plan_lemma == vocab_lemma)
+
+
+def check_vocab_coverage(
+    plan_path: Path,
+    vocab_yaml_path: Path,
+) -> VocabCoverageResult:
+    """Check that every plan-required vocabulary term is present in словник YAML."""
+    required_terms = _load_required_terms(plan_path)
+    vocab_words = _load_vocab_words(vocab_yaml_path)
+
+    missing: list[str] = []
+    present_mapping: dict[str, str] = {}
+
+    for term in required_terms:
+        matched_word = next((word for word in vocab_words if _terms_match(term, word)), None)
+        if matched_word is None:
+            missing.append(term)
+        else:
+            present_mapping[term] = matched_word
+
+    return VocabCoverageResult(
+        passed=not missing,
+        missing_terms=tuple(missing),
+        present_mapping=present_mapping,
+    )

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -1368,6 +1368,7 @@ PHASE_LABELS: dict[str, str] = {
     "verify-exercises": "Verify exercises",
     "annotate": "Annotate",
     "vocab": "Vocabulary",
+    "vocab-check": "Vocabulary coverage check",
     "enrich": "Enrich",
     "verify": "Verify content",
     "review": "Review",
@@ -6486,6 +6487,59 @@ def step_vocab(content_path: Path, level: str, module_num: int,
     return vocab_path
 
 
+def step_vocab_coverage(level: str, module_num: int, slug: str) -> bool:
+    """Validate required plan vocabulary coverage in the generated словник YAML."""
+    _log(f"\n{'='*60}")
+    _log("  Step 5c-check: VOCAB-CHECK — Required plan terms in словник")
+    _log(f"{'='*60}")
+
+    from build.phases.vocab_coverage import check_vocab_coverage
+
+    plan_path = _plan_path(level, slug)
+    vocab_path = CURRICULUM_ROOT / level / "vocabulary" / f"{slug}.yaml"
+    if plan_path is None or not plan_path.exists():
+        raise FileNotFoundError(f"Plan not found: {plan_path}")
+    if not vocab_path.exists():
+        raise FileNotFoundError(f"Vocabulary YAML not found: {vocab_path}")
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+    if result.passed:
+        _log(f"  ✅ Vocabulary coverage passed ({len(result.present_mapping)} required term(s))")
+        return True
+
+    finding = {
+        "dimension": "Plan Adherence",
+        "severity": "critical",
+        "location": "vocabulary YAML",
+        "issue": (
+            "missing required vocabulary terms from plan.vocabulary_hints.required: "
+            + ", ".join(result.missing_terms)
+        ),
+        "fix": (
+            "Regenerate the module so every required-vocabulary term from the plan "
+            "appears in the vocabulary YAML."
+        ),
+        "missing_terms": list(result.missing_terms),
+        "present_mapping": result.present_mapping,
+    }
+    orch_dir = CURRICULUM_ROOT / level / "orchestration" / slug
+    orch_dir.mkdir(parents=True, exist_ok=True)
+    finding_path = orch_dir / "vocab-coverage-findings.yaml"
+    finding_path.write_text(
+        yaml.safe_dump(
+            {"phase": "vocab-check", "findings": [finding]},
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        "utf-8",
+    )
+
+    _log("  ❌ Vocabulary coverage failed")
+    _log(f"     Missing terms: {', '.join(result.missing_terms)}")
+    _log(f"     Structured finding: {finding_path}")
+    return False
+
+
 def _extract_verify_flags(content: str) -> list[dict]:
     """Extract <!-- VERIFY: ... --> flags from writer content.
 
@@ -10298,21 +10352,27 @@ def main():
 
     parser = argparse.ArgumentParser(
         description=(
-            "Build curriculum modules through the v6 pipeline.\n"
-            "Use it for end-to-end module orchestration; do not use it for isolated wiki/article maintenance."
+            "Validate every plan.vocabulary_hints.required term is present in the generated словник YAML.\n"
+            "Also builds curriculum modules through the v6 pipeline for end-to-end module orchestration."
         ),
         epilog=(
             "Examples:\n"
             "  .venv/bin/python scripts/build/v6_build.py a1 7\n"
+            "  .venv/bin/python scripts/build/v6_build.py a1 1 --step vocab-check\n"
             "  .venv/bin/python scripts/build/v6_build.py a2 3 --step review --reviewer codex\n"
             "  .venv/bin/python scripts/build/v6_build.py b1 1 --range 4 --resume\n\n"
             "Outputs:\n"
             "  Writes module markdown, sidecars, orchestration state, review/audit artifacts, and published outputs.\n\n"
             "Exit codes:\n"
-            "  0 on successful build; non-zero on CLI misuse or any failed phase.\n\n"
+            "  0 on successful build/check.\n"
+            "  1 on missing vocabulary terms or any failed phase.\n"
+            "  2 on pipeline error for --step vocab-check.\n\n"
             "Related:\n"
             "  Docs: docs/SCRIPTS.md\n"
             "  Issue: #1379\n"
+            "  Plan contract: scripts/build/contracts/module-contract.md\n"
+            "  Postmortem: #1529\n"
+            "  PR: vocab-YAML coverage pre-review gate\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -10324,7 +10384,7 @@ def main():
                         help="Default: claude-tools (2026-04-23: switched from gemini-tools after #1431 v2 showed Gemini factual-hallucination on decolonization-critical facts — e.g. writing «блакитний» instead of «синій» for the Ukrainian flag. Opus has stronger factual adherence + less Russian-imperial training-data contamination. *-tools = with verification access during writing via MCP/shell)")
     parser.add_argument("--reviewer", choices=["gemini", "gemini-tools", "claude", "claude-tools", "codex", "codex-tools"], default=None,
                         help="Override reviewer. Default: cross-agent (opposite of writer)")
-    parser.add_argument("--step", choices=["check", "research", "pre-verify", "skeleton", "write", "honesty-annotate", "exercises", "activities", "repair", "verify-exercises", "annotate", "enrich", "verify", "review", "review-style", "publish", "audit", "all"],
+    parser.add_argument("--step", choices=["check", "research", "pre-verify", "skeleton", "write", "honesty-annotate", "exercises", "activities", "repair", "verify-exercises", "annotate", "vocab-check", "enrich", "verify", "review", "review-style", "publish", "audit", "all"],
                         default="all",
                         help="Stop after this phase or run the full pipeline (default: all).")
     skeleton_group = parser.add_mutually_exclusive_group()
@@ -10616,7 +10676,7 @@ def main():
                 return False
 
         # Pre-flight: check MCP server is running (VESUM, dictionaries, textbooks via SQLite)
-        if "tools" in args.writer:
+        if "tools" in args.writer and steps != "vocab-check":
             import urllib.request
             try:
                 resp = urllib.request.urlopen("http://127.0.0.1:8766/health", timeout=3)
@@ -10821,6 +10881,21 @@ def main():
             _emit_phase_done("write", _phase_start)
         elif content_path is None:
             content_path = CURRICULUM_ROOT / args.level / f"{slug}.md"
+
+        if steps == "vocab-check":
+            _phase_start = time.monotonic()
+            try:
+                vocab_check_ok = step_vocab_coverage(args.level, args.module, slug)
+            except Exception as exc:
+                _log(f"\n❌ Vocab coverage pipeline error: {exc}")
+                _emit_module_failed("vocab-check", f"pipeline error: {exc}")
+                sys.exit(2)
+            if not vocab_check_ok:
+                _emit_phase_done("vocab-check", _phase_start, status="failed")
+                _emit_module_failed("vocab-check", "missing required vocabulary terms")
+                sys.exit(1)
+            _emit_phase_done("vocab-check", _phase_start)
+            return True
 
         # Step 5a: HONESTY ANNOTATE — deterministic VERIFY markers
         if steps in ("all", "honesty-annotate") and "honesty-annotate" not in completed_phases:

--- a/tests/test_vocab_coverage.py
+++ b/tests/test_vocab_coverage.py
@@ -1,0 +1,162 @@
+"""Tests for plan-required vocabulary coverage validation."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+vocab_coverage = import_module("build.phases.vocab_coverage")
+_extract_ukrainian_term = vocab_coverage._extract_ukrainian_term
+check_vocab_coverage = vocab_coverage.check_vocab_coverage
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_plan(tmp_path: Path, required: list[str]) -> Path:
+    path = tmp_path / "plan.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"vocabulary_hints": {"required": required, "recommended": []}},
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        "utf-8",
+    )
+    return path
+
+
+def _write_vocab(tmp_path: Path, words: list[str]) -> Path:
+    path = tmp_path / "vocab.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"vocabulary": [{"word": word} for word in words]},
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        "utf-8",
+    )
+    return path
+
+
+def _vesum_has_sound_lemma() -> bool:
+    db_path = vocab_coverage.VESUM_DB_PATH
+    if not db_path.exists() or db_path.stat().st_size == 0:
+        return False
+    try:
+        with sqlite3.connect(str(db_path)) as db:
+            for query in (
+                "SELECT lemma FROM vesum WHERE form = ? LIMIT 1",
+                "SELECT lemma FROM forms WHERE word_form = ? LIMIT 1",
+            ):
+                try:
+                    singular = db.execute(query, ("звук",)).fetchone()
+                    plural = db.execute(query, ("звуки",)).fetchone()
+                except sqlite3.OperationalError:
+                    continue
+                if singular and plural and singular[0] == plural[0]:
+                    return True
+    except sqlite3.Error:
+        return False
+    return False
+
+
+def test_all_required_present_passes(tmp_path: Path) -> None:
+    plan_path = _write_plan(tmp_path, ["звук (sound)", "привіт (hi)"])
+    vocab_path = _write_vocab(tmp_path, ["звук", "привіт"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is True
+    assert result.missing_terms == ()
+    assert result.present_mapping == {"звук": "звук", "привіт": "привіт"}
+
+
+def test_missing_term_fails(tmp_path: Path) -> None:
+    plan_path = _write_plan(tmp_path, ["молоко (milk)"])
+    vocab_path = _write_vocab(tmp_path, ["вода"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is False
+    assert result.missing_terms == ("молоко",)
+
+
+def test_stress_marks_ignored(tmp_path: Path) -> None:
+    plan_path = _write_plan(tmp_path, ["привіт (hi)"])
+    vocab_path = _write_vocab(tmp_path, ["приві\u0301т"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is True
+    assert result.missing_terms == ()
+
+
+def test_capitalization_ignored(tmp_path: Path) -> None:
+    plan_path = _write_plan(tmp_path, ["як справи (how are you)"])
+    vocab_path = _write_vocab(tmp_path, ["Як справи?"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is True
+    assert result.missing_terms == ()
+
+
+def test_punctuation_ignored(tmp_path: Path) -> None:
+    plan_path = _write_plan(tmp_path, ["До побачення (Goodbye)"])
+    vocab_path = _write_vocab(tmp_path, ["До побачення!"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is True
+    assert result.missing_terms == ()
+
+
+def test_inflection_via_vesum_lemma(tmp_path: Path) -> None:
+    if not _vesum_has_sound_lemma():
+        pytest.skip("VESUM DB with звук/звуки lemma data is not available")
+
+    plan_path = _write_plan(tmp_path, ["звук (sound)"])
+    vocab_path = _write_vocab(tmp_path, ["звуки"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is True
+    assert result.missing_terms == ()
+
+
+def test_distinct_terms_do_not_match(tmp_path: Path) -> None:
+    plan_path = _write_plan(tmp_path, ["звук (sound)"])
+    vocab_path = _write_vocab(tmp_path, ["звичайний"])
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is False
+    assert result.missing_terms == ("звук",)
+
+
+def test_ukrainian_term_extraction() -> None:
+    assert _extract_ukrainian_term("Добрий день (Good day — formal)") == "Добрий день"
+
+
+def test_a1_1_sounds_letters_golden() -> None:
+    plan_path = (
+        PROJECT_ROOT
+        / "curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml"
+    )
+    vocab_path = (
+        PROJECT_ROOT
+        / "curriculum/l2-uk-en/a1/vocabulary/sounds-letters-and-hello.yaml"
+    )
+
+    result = check_vocab_coverage(plan_path, vocab_path)
+
+    assert result.passed is True
+    assert result.missing_terms == ()


### PR DESCRIPTION
## Summary
- Add scripts/build/phases/vocab_coverage.py to compare plan.vocabulary_hints.required against generated vocabulary YAML words.
- Normalize stress marks, case, and trailing punctuation, with VESUM lemma matching when the local SQLite data is available.
- Add --step vocab-check as an explicit CLI surface without adding it to the default _ALL_PHASES flow yet.
- Emit a structured Plan Adherence finding with the exact missing required terms before expensive review phases.
- Update the A1/M01 vocabulary sidecar with the missing required greeting chunks so the golden fixture satisfies the locked plan contract.

## Failure mode
A1/M01 hit plan_revision_request because required plan vocabulary was absent from the словник YAML. The convergence loop could not repair that through prose find/replace, so the same finding persisted until content_hash_repeat. This validator fails loudly with the precise missing-term list before dispatching to per-dimension review.

## Validation
- .venv/bin/python -m pytest tests/test_vocab_coverage.py -v
- .venv/bin/ruff check scripts/build/phases/vocab_coverage.py scripts/build/v6_build.py tests/test_vocab_coverage.py
- .venv/bin/python -m pytest tests/test_v6_plan_hash_drift.py tests/test_convergence_loop.py
- .venv/bin/python scripts/build/v6_build.py a1 1 --step vocab-check --writer claude

Auto-merge not enabled.