### PR TITLE
feat(writer-prompt): vocab-YAML coverage + звук/літера discipline

### DIFF
--- a/scripts/build/phases/v6-write.md
+++ b/scripts/build/phases/v6-write.md
@@ -1,4 +1,4 @@
-<!-- version: 2.2.0 | updated: 2026-04-24 | GH #1529 A — promote VERIFY to Rule #2 + worked examples + drop self-audit block -->
+<!-- version: 2.3.0 | updated: 2026-04-24 | GH #1529 follow-up — словник YAML coverage contract (required-terms guarantee) + звук/літера phonetics discipline section -->
 # V6 Writing Prompt — Module Content Generation
 
 ## Shared Contract (read first — supersedes rule text below on conflict)
@@ -331,6 +331,30 @@ Each section should follow the word budget specified. The total must reach {WORD
 - **Zero paronyms**: тактична≠тактовна, ефектний≠ефективний — use the right word, not a similar-sounding one
 - **Natural Ukrainian**: Write how a Ukrainian teacher would explain this to a student. Not robotic, not textbook-dry, not overly casual.
 
+### Phonetics discipline: звук vs літера
+
+Ukrainian phonetics requires strict separation between sound (звук) and
+letter (літера). Never conflate them in explanatory prose. Canonical
+errors that trigger Factual review findings:
+
+WRONG: "Ь пом'якшує літеру перед собою" / "Ь softens the letter before it"
+RIGHT: "Ь пом'якшує попередній приголосний звук" / "Ь softens the preceding
+consonant sound"
+
+WRONG: "літера А — голосна" / "letter А is a vowel"
+RIGHT: "літера А позначає голосний звук [а]" / "letter А represents the
+vowel sound [а]"
+
+WRONG: "звук Я" / "sound Я" (Я is a LETTER that represents two sounds [й]+[а])
+RIGHT: "літера Я" or "the sound sequence [й]+[а] that the letter Я
+represents"
+
+When writing phonetics modules (focus: phonetics OR phonetics-adjacent
+topics like alphabet, sounds-letters, pronunciation): apply this
+distinction in every sentence that references either concept. The
+module is teaching this distinction to the learner — the prose MUST
+model it.
+
 ### Canonical Anchors (decolonization-critical — contract §7a)
 
 Block below lists Ukrainian facts with state/dictionary authority where LLM drift
@@ -464,6 +488,21 @@ Every heading from "Section Structure" above MUST appear as an `## H2` in your o
 You MUST use **every word** from the list below at least once in the prose, in a natural sentence with bold + English translation. Abstract grammatical metalanguage (видова пара, дієвідміна, особове закінчення, прагматика, діагностика, дієвідмінювання, зворотний, двовидовий, одновидовий, неозначено-кількісний, etc.) is the most frequently dropped category — actively find homes for those words even if it means adding a sentence that defines them.
 
 {VOCABULARY_CHECKLIST}
+
+### Словник YAML coverage contract (required)
+
+Every entry in `plan.vocabulary_hints.required` MUST appear in your generated
+словник YAML. Match by normalized form (ignore stress marks, case,
+trailing punctuation) but you are responsible for producing the entry —
+NOT assuming the reviewer will patch omissions. If you cannot confidently
+produce an entry (e.g. missing translation or example), emit it with a
+placeholder marked `<!-- VERIFY: словник entry needs human sourcing -->`
+rather than omitting.
+
+This is not a suggestion. The pipeline runs a deterministic
+`--step vocab-check` before review, and missing `required` terms block
+convergence at `plan_revision_request` terminal. Your job is to prevent
+that.
 
 ### Forbidden words (never produce)
 

--- a/scripts/build/phases/v6-write.md
+++ b/scripts/build/phases/v6-write.md
@@ -1,4 +1,4 @@
-<!-- version: 2.3.0 | updated: 2026-04-24 | GH #1529 follow-up — словник YAML coverage contract (required-terms guarantee) + звук/літера phonetics discipline section -->
+<!-- version: 2.3.1 | updated: 2026-04-24 | #1538 review: Я positional rule (й+а vs palatalization) + VERIFY-in-YAML must be inside a field value -->
 # V6 Writing Prompt — Module Content Generation
 
 ## Shared Contract (read first — supersedes rule text below on conflict)
@@ -345,9 +345,14 @@ WRONG: "літера А — голосна" / "letter А is a vowel"
 RIGHT: "літера А позначає голосний звук [а]" / "letter А represents the
 vowel sound [а]"
 
-WRONG: "звук Я" / "sound Я" (Я is a LETTER that represents two sounds [й]+[а])
-RIGHT: "літера Я" or "the sound sequence [й]+[а] that the letter Я
-represents"
+WRONG: "звук Я" / "sound Я" (Я is a LETTER, not a sound; it represents
+either [й]+[а] or [а] + softness of the preceding consonant depending
+on position)
+RIGHT: "літера Я" and, when teaching what it represents, state the
+positional rule: Я = [й]+[а] at the start of a word, after a vowel, or
+after an apostrophe / ь; Я = [а] + softness of the preceding consonant
+elsewhere (after a consonant). The same rule applies to Ю, Є, Ї
+(Ї is always [й]+[і] — it has no palatalizing form).
 
 When writing phonetics modules (focus: phonetics OR phonetics-adjacent
 topics like alphabet, sounds-letters, pronunciation): apply this
@@ -495,9 +500,19 @@ Every entry in `plan.vocabulary_hints.required` MUST appear in your generated
 словник YAML. Match by normalized form (ignore stress marks, case,
 trailing punctuation) but you are responsible for producing the entry —
 NOT assuming the reviewer will patch omissions. If you cannot confidently
-produce an entry (e.g. missing translation or example), emit it with a
-placeholder marked `<!-- VERIFY: словник entry needs human sourcing -->`
-rather than omitting.
+produce an entry (e.g. missing translation or example), emit the entry
+with a placeholder VERIFY marker **inside a YAML field value** (never
+as a standalone line — YAML uses `#` for comments and will strip or
+choke on a stray `<!--`). Example:
+
+```yaml
+- term: доброго ранку
+  translation: "<!-- VERIFY: словник entry needs human sourcing -->"
+  example: "<!-- VERIFY: словник entry needs human sourcing -->"
+```
+
+This keeps the entry valid YAML, satisfies the `vocab-check` coverage
+gate, and leaves a human-reviewable TODO flag.
 
 This is not a suggestion. The pipeline runs a deterministic
 `--step vocab-check` before review, and missing `required` terms block


### PR DESCRIPTION
## Summary

Two targeted rules added to `scripts/build/phases/v6-write.md` (v2.2.0 → v2.3.0). Prompt-side belt-and-suspenders to a parallel Codex deterministic `vocab-check` validator — the validator is the hard gate; this lowers how often it has to fire.

### Rule 1 — Словник YAML coverage contract

Inserted in the MANDATORY FINAL CHECKLIST, after the existing `Required vocabulary (every word must appear)` block.

Every entry in `plan.vocabulary_hints.required` MUST appear in the generated словник YAML, matched by normalized form (stress-mark / case / trailing-punct insensitive). If the writer cannot confidently produce an entry, it emits a placeholder `<!-- VERIFY: словник entry needs human sourcing -->` rather than silently omitting.

**Empirical driver:** a1/1 `sounds-letters-and-hello` build terminated at `plan_revision_request` (2026-04-24 PM) — словник missed 3 required greeting chunks (`Доброго ранку`, `Добрий вечір`, `До побачення`) present in the plan. The reviewer caught it, but only after a wasted 9-dim review cycle.

### Rule 2 — Phonetics discipline: звук vs літера

Inserted as a new H3 right after `### Ukrainian Language Quality`, before `### Canonical Anchors`.

Strict separation between sound (`звук`) and letter (`літера`) in explanatory prose. Three WRONG/RIGHT pairs cover the canonical confusion vectors:
- `Ь softens the letter` (wrong) vs `Ь softens the preceding consonant sound` (right)
- `літера А is a vowel` (wrong) vs `літера А represents vowel sound [а]` (right)
- `звук Я` (wrong — Я is a letter representing `[й]+[а]`) vs `літера Я` (right)

The rule fires conditionally on phonetics-focused modules (alphabet, sounds-letters, pronunciation) — the teaching prose MUST model the distinction the module is teaching.

**Empirical driver:** a1/1 Factual dim scored 7.0 with the finding *"softens the літера (letter) before it"* — a conceptual error in the module literally titled `Звуки, літери та привіт`.

### Placement hygiene

- VERIFY rule (Rule #2 in Hard Rules, promoted by PR #1533 Phase A) placement is untouched.
- Version header bumped `2.2.0 → 2.3.0` with a one-line changelog note.

## Test plan

- [x] `pytest tests/test_plan_adherence_prompt_policy.py tests/test_honesty_annotator.py` — 26 passed
- [ ] Pilot on ≥3 seeded phonetics-adjacent modules (a1/1, a1/2, a1/special-signs) per the prompt-ablation discipline rule before any bulk run. The writer prompt change is the trigger; ablation is tracked in the parallel vocab-check validator PR.

## Out of scope

- Validator implementation — parallel Codex PR.
- Reviewer changes — separate parallel Claude PR.
- Wholesale writer-prompt rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)