### PR TITLE
fix(review): honesty rubric — credit writer-emitted VERIFY markers

### DIFF
--- a/scripts/build/phases/v6-review/v6-review-honesty.md
+++ b/scripts/build/phases/v6-review/v6-review-honesty.md
@@ -1,4 +1,4 @@
-<!-- version: 1.2.0 | updated: 2026-04-24 | GH #1529 A — reconcile VERIFY scope with writer Rule #2; drop flat 5.0 hard-cap -->
+<!-- version: 1.3.0 | updated: 2026-04-24 | GH #1529 post-Phase-A — credit writer-emitted markers: vicinity rule + marker-format nitpicks out of scope + worked examples -->
 # V6 Per-Dimension Review — Honesty
 
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
@@ -16,7 +16,14 @@ A `<!-- VERIFY: {claim} -->` marker anchored to a specific claim is a POSITIVE s
 
 A marker is **NOT required** for soft-hedged wording ("usually", "typically", "most often", "common", "in most cases") or for claims already qualified in the immediate context. Do not penalize soft-hedged prose for lacking markers — that is not the failure mode. **Marker spam on soft prose IS a defect** (low-signal hedging) — penalize it the same way you penalize missing markers on precise claims.
 
-**Quality of the marker text matters.** A bare `<!-- VERIFY -->` or a marker that repeats the claim without pointing at a source is low-signal. A marker that names the claim and, where possible, the source it should be checked against is the ideal.
+**Marker sufficiency — the presence rule (authoritative).** A VERIFY marker attached to a precise claim **satisfies** the claim for Honesty purposes. You MUST NOT emit a Honesty finding against any claim that already carries a marker — presence is enough. Generic markers like `<!-- VERIFY: historical date for restoration of Ґ; check Ukrainian orthography/alphabet source -->` are fully acceptable. Marker-format nitpicks — "marker does not cite a specific packet section", "marker is too generic", "marker should name the source", "marker should include [format detail]" — are **out of scope** for this dimension. The ONLY insufficient marker shape is the **bare** form `<!-- VERIFY -->` with no claim description at all. Writers are encouraged to name the source they want checked, but the reviewer's job is to confirm the claim is flagged, not to grade the flag's wording.
+
+**Vicinity — where a marker "counts" for a claim.** A marker counts as attached to a claim when it appears:
+
+- on the **same line** as the claim (identical markdown line), **OR**
+- anywhere in the **same paragraph** as the claim (contiguous block of prose, ending at the next blank line).
+
+You MUST NOT emit a finding that says "claim X is missing a marker" when a marker is present within that vicinity. This rule matches both the writer prompt (Rule #2 worked examples place the marker on the same line) and the deterministic annotator (`honesty_annotator.py` skips any line that already contains `<!-- VERIFY`). If the reviewer uses a stricter vicinity than the writer+annotator, you WILL double-count already-marked claims — that is the exact miscalibration this rule closes.
 
 You are the **HONESTY** reviewer for a Ukrainian language module. Review only whether the writer stayed honest about uncertainty and avoided invented examples or unsupported certainty. Do not score language quality, pedagogy, or dialogue except where they expose fabrication.
 
@@ -66,15 +73,59 @@ REJECT, even if the writer thinks it's right.
 
 ## Dimension rubric
 
-Score **Honesty** from 1.0 to 10.0. Count **precise claims** (the four categories in §5 above) and check whether each is either (a) already grounded in the knowledge packet / plan, or (b) carries a VERIFY marker that names the claim and the source to check.
+Score **Honesty** from 1.0 to 10.0. Count **precise claims** (the four categories in §5 above) and check whether each is either (a) already grounded in the knowledge packet / plan, or (b) carries a VERIFY marker within the vicinity defined in §5 (same line or same paragraph). Marker presence is sufficient — do NOT require the marker to name a specific packet section or source.
 
-- **PASS (≥ 8.0)**: Every precise claim is either grounded or marked. Markers, when present, reference a specific source. Soft-hedged prose is unmarked (correctly). No fabrication.
-- **REVISE (5.0 – 7.9)**: Some precise claims are missing markers, OR some markers are present but decorative (do not name the source, or are bare `<!-- VERIFY -->`). No fabrication.
+- **PASS (≥ 8.0)**: Every precise claim is either grounded or marked (with any non-bare marker in vicinity). Soft-hedged prose is unmarked (correctly). No fabrication.
+- **REVISE (5.0 – 7.9)**: Some precise claims are missing markers (no marker in vicinity — see the presence + vicinity rules above), OR one or more markers are the **bare** `<!-- VERIFY -->` form with no claim description at all. No fabrication. Markers that name the claim but do NOT cite a specific source are fully acceptable and do not trigger REVISE — do not penalize marker format.
 - **REJECT (< 5.0)**: Fabrication (invented example, false citation, invented form that cannot be verified). Also REJECT when three or more precise claims exist and the module has zero VERIFY markers — that is hidden uncertainty, not absence of uncertainty.
 
 **Scoping rule — zero-marker modules are NOT automatically failed.** If the module contains no precise claims in the §5 categories (e.g., an A1 introduction module that stays on soft-hedged pedagogical prose throughout), zero markers is CORRECT and the module scores against the rest of the rubric normally. Only count the zero-marker penalty against **precise claims** in the prose.
 
 **Marker spam is a defect.** If the module has more than a small number of VERIFY markers on soft-hedged prose (not on precise claims), cap the score at REVISE (≤ 7.9) and write a finding explaining which markers are low-signal.
+
+## Worked examples — reviewer behavior (authoritative)
+
+Study the RIGHT column. Do not repeat the WRONG column. These are verbatim patterns observed in past Honesty reviews on a1/1 that this rubric rejects.
+
+**Example 1 — historical-date claim with a same-line marker**
+
+Module prose (single line):
+> `Ґ was restored to the alphabet in 1990.` <!-- VERIFY: historical date for restoration of Ґ; check Ukrainian orthography/alphabet source -->
+
+- **WRONG:** Emit `[HONESTY] Історична дата подана як упевнене твердження без VERIFY-маркера.` The reviewer reads the assertive prose and does not register the marker on the same line.
+- **RIGHT:** Marker is present on the same line; the presence + vicinity rules are satisfied. **Emit no Honesty finding for this claim.**
+
+**Example 2 — precise-count claim with a generic same-line marker**
+
+Module prose (single line):
+> `nine consonants each have a hard and a soft version` <!-- VERIFY: precise count of hard/soft consonant pairs; check Ukrainian phonetics source -->
+
+- **WRONG:** Emit `[HONESTY] Точна кількість приголосних пар не має маркера й не встановлена прямо в наданому knowledge packet.` — the reviewer demands the marker cite the packet section directly.
+- **RIGHT:** A marker naming the claim ("precise count of hard/soft consonant pairs") and gesturing at a source category ("Ukrainian phonetics source") is sufficient. Marker-format nitpicks are out of scope. **Emit no Honesty finding for this claim.**
+
+**Example 3 — marker-format nitpick on a correctly-placed marker**
+
+Module prose:
+> `Ukrainian has 33 letters and 38 sounds.` <!-- VERIFY: precise claim (33 letters; 38 sounds) -->
+
+- **WRONG:** Emit `[HONESTY] Маркери правильно позначають точні твердження, але не вказують [format detail].` — the reviewer acknowledges the marker is correctly placed but fails the module on a format preference.
+- **RIGHT:** If you find yourself writing a finding that begins "Маркери правильно позначають..." or "markers correctly flag...", STOP. The finding is admitting the claim is satisfied. **Do not emit it.**
+
+**Example 4 — genuinely unmarked precise claim (existing behavior, preserved)**
+
+Module prose (no marker on line, no marker anywhere in the paragraph):
+> `Register mismatch is normal in Ukrainian classrooms.`
+
+- **WRONG:** Skip the finding because the prose sounds confident-but-pedagogical.
+- **RIGHT:** This is an unsourced sociolinguistic generalization with no VERIFY marker in vicinity. **Emit a Honesty finding** and propose a VERIFY marker in `<fixes>`. The presence + vicinity rules tighten acceptance of marked claims; they do NOT weaken enforcement on unmarked ones.
+
+**Example 5 — bare marker (sole remaining marker-format defect, preserved)**
+
+Module prose:
+> `Ukrainian has 33 letters but 38 sounds.` <!-- VERIFY -->
+
+- **WRONG:** Treat the bare marker as sufficient because a marker is present.
+- **RIGHT:** A bare `<!-- VERIFY -->` with no claim text is the ONLY insufficient marker shape. **Emit a finding** asking the writer to name the claim (the source-name is optional, not required).
 
 ## Output contract
 

--- a/tests/test_honesty_reviewer_prompt.py
+++ b/tests/test_honesty_reviewer_prompt.py
@@ -1,0 +1,213 @@
+"""Policy-pinning tests for the Honesty reviewer prompt.
+
+The `v6-review-honesty.md` prompt encodes rules that the reviewer uses
+to judge whether a writer-emitted `<!-- VERIFY -->` marker satisfies a
+precise claim. Before #1529 post-Phase-A tightening the rubric let the
+reviewer double-count already-marked claims and nitpick marker format
+(observed on a1/1 rebuild 2026-04-24 — three false-positive Honesty
+findings on claims that DID carry markers).
+
+These tests guard against two regression classes:
+
+  1. Re-tightening the "source must be named" preference into a gate
+     (would re-create the marker-format nitpick finding class).
+  2. Deleting or shortening the same-line / same-paragraph vicinity
+     rule (would re-create the missing-marker finding on claims that
+     already carry a marker).
+
+The tests are intentionally phrasing-flexible (substring checks, not
+exact-string matches) so minor wording edits stay green as long as the
+operative rules are preserved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_PROMPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "build"
+    / "phases"
+    / "v6-review"
+    / "v6-review-honesty.md"
+)
+
+
+@pytest.fixture(scope="module")
+def prompt_text() -> str:
+    return _PROMPT_PATH.read_text(encoding="utf-8")
+
+
+# ── Version tag hygiene ─────────────────────────────────────────────
+
+
+def test_prompt_exists(prompt_text: str) -> None:
+    assert prompt_text.strip(), f"Prompt file is empty: {_PROMPT_PATH}"
+
+
+def test_prompt_has_version_tag(prompt_text: str) -> None:
+    """Every reviewer prompt starts with a semver-style version comment."""
+    first_line = prompt_text.splitlines()[0]
+    assert first_line.startswith("<!-- version:"), (
+        f"Prompt must start with a `<!-- version: X.Y.Z | ... -->` tag; "
+        f"got {first_line!r}"
+    )
+
+
+# ── Presence rule — marker presence satisfies a claim ──────────────
+
+
+def test_prompt_states_presence_rule(prompt_text: str) -> None:
+    """The rubric must tell the reviewer that a marker's presence
+    satisfies a claim. Without this, the reviewer re-creates the
+    double-counting finding class observed on a1/1 (marker on line,
+    reviewer emits missing-marker finding anyway)."""
+    lowered = prompt_text.lower()
+    assert "presence" in lowered and "satisfies" in lowered, (
+        "Rubric must state the presence rule — a VERIFY marker's "
+        "presence must explicitly satisfy a precise claim. Expected "
+        "both 'presence' and 'satisfies' to appear together."
+    )
+
+
+def test_prompt_forbids_missing_marker_finding_when_marker_present(
+    prompt_text: str,
+) -> None:
+    """Stronger guard — the prompt must explicitly tell the reviewer
+    NOT to emit a missing-marker finding when a marker is already
+    attached. Positive 'presence satisfies' language alone can be read
+    ambiguously; the prohibition must be explicit."""
+    lowered = prompt_text.lower()
+    forbidden_phrases = (
+        "must not emit a finding",
+        "must not emit a honesty finding",
+        "do not emit a finding",
+    )
+    assert any(phrase in lowered for phrase in forbidden_phrases), (
+        "Rubric must contain an explicit 'do not emit a finding when "
+        "a marker is present' instruction. Expected one of "
+        f"{forbidden_phrases!r}."
+    )
+
+
+# ── Vicinity rule — same line or same paragraph ───────────────────
+
+
+def test_prompt_defines_marker_vicinity(prompt_text: str) -> None:
+    """The rubric must define the vicinity in which a marker counts
+    for a claim. Without an explicit definition the reviewer picks a
+    stricter vicinity than the writer+annotator and double-counts."""
+    lowered = prompt_text.lower()
+    assert "same line" in lowered, (
+        "Rubric must define vicinity as including 'same line'."
+    )
+    assert "same paragraph" in lowered, (
+        "Rubric must define vicinity as including 'same paragraph'."
+    )
+
+
+# ── Marker-format nitpicks — out of scope ─────────────────────────
+
+
+def test_prompt_excludes_marker_format_nitpicks(prompt_text: str) -> None:
+    """The rubric must explicitly put marker-format nitpicks out of
+    scope. Without this, the reviewer re-creates findings like
+    'marker does not cite a specific packet section' (observed on
+    a1/1 Finding #3)."""
+    lowered = prompt_text.lower()
+    assert "out of scope" in lowered, (
+        "Rubric must state that marker-format nitpicks are 'out of "
+        "scope' for Honesty. Expected the exact phrase 'out of scope'."
+    )
+
+
+def test_prompt_accepts_generic_markers(prompt_text: str) -> None:
+    """Generic markers (that name the claim but not a specific packet
+    section) must be accepted. The only insufficient marker shape is
+    the bare `<!-- VERIFY -->`."""
+    lowered = prompt_text.lower()
+    assert "generic" in lowered, (
+        "Rubric must mention that generic markers are acceptable."
+    )
+    # The word "bare" should appear in the context of the sole
+    # insufficient marker shape.
+    assert "bare" in lowered, (
+        "Rubric must identify the bare `<!-- VERIFY -->` as the sole "
+        "insufficient marker shape."
+    )
+
+
+# ── Worked examples — WRONG vs RIGHT ──────────────────────────────
+
+
+def test_prompt_contains_worked_examples_section(prompt_text: str) -> None:
+    """The rubric must include a worked-examples section. This is a
+    high-leverage calibration surface for reviewer prompts — the
+    brief explicitly requires it."""
+    lowered = prompt_text.lower()
+    assert "worked example" in lowered, (
+        "Rubric must include a 'Worked examples' section heading. "
+        "Reviewers are calibrated by concrete WRONG/RIGHT patterns, "
+        "not by prose rules alone."
+    )
+
+
+def test_prompt_has_wrong_right_pattern(prompt_text: str) -> None:
+    """Worked examples must be structured as WRONG/RIGHT pairs.
+    Unlabelled examples leave the reviewer to infer the correct
+    behavior, which is the failure mode this section closes."""
+    # The bolded markdown labels used in the rubric.
+    assert "**WRONG:**" in prompt_text, (
+        "Worked examples must label WRONG behavior explicitly."
+    )
+    assert "**RIGHT:**" in prompt_text, (
+        "Worked examples must label RIGHT behavior explicitly."
+    )
+
+
+def test_prompt_covers_restoration_of_g_example(prompt_text: str) -> None:
+    """The rubric must include the Ґ-restoration worked example from
+    the brief — it's the canonical case of the miscalibration this
+    fix closes (Finding #1 on a1/1 sounds-letters-and-hello)."""
+    assert "restoration of Ґ" in prompt_text, (
+        "Worked examples must include the Ґ-restoration case — it is "
+        "the canonical past-failure pattern this rubric fix addresses."
+    )
+
+
+# ── Preserved behavior — unmarked claims still enforced ────────────
+
+
+def test_prompt_preserves_unmarked_claim_enforcement(prompt_text: str) -> None:
+    """The tightening must NOT weaken enforcement on genuinely
+    unmarked precise claims. The brief explicitly requires this."""
+    # Look for any of the phrases that preserve the enforcement intent.
+    preserved_phrases = (
+        "do not weaken enforcement",
+        "do not weaken",
+        "does not weaken",
+        "not weakening",
+        "preserved behavior",
+        "preserved behaviour",
+        "preserved)",
+    )
+    lowered = prompt_text.lower()
+    assert any(phrase in lowered for phrase in preserved_phrases), (
+        "Rubric must state that the presence + vicinity rules tighten "
+        "acceptance of MARKED claims without weakening enforcement on "
+        f"UNMARKED ones. Expected one of {preserved_phrases!r}."
+    )
+
+
+def test_prompt_keeps_reject_rule_for_zero_markers(prompt_text: str) -> None:
+    """Zero-marker modules with 3+ precise claims must still REJECT.
+    If this test fires, the tightening has over-softened the rubric."""
+    lowered = prompt_text.lower()
+    assert "three or more precise claims" in lowered or "zero verify markers" in lowered, (
+        "Rubric must preserve the 'REJECT when 3+ precise claims and "
+        "zero markers' rule. If this fires, the hidden-uncertainty "
+        "guard has been removed."
+    )


### PR DESCRIPTION
## Summary

Phase A (#1533) aligned the writer prompt, annotator, and reviewer's VERIFY scope. The a1/1 rebuild on 2026-04-24 confirmed the pipeline works (6 writer markers, 0 annotator additions, Honesty 5.0 → 7.0) but surfaced a remaining reviewer-side miscalibration: the rubric flagged three claims as missing-marker even though the writer had emitted a marker on the same line.

**Empirical data from a1/1 rebuild (`sounds-letters-and-hello-review-honesty-r1.yaml`):**

1. `Ґ was restored to the alphabet in 1990.` flagged as missing VERIFY — but the writer DID emit `<!-- VERIFY: historical date for restoration of Ґ; check Ukrainian orthography/alphabet source -->` on the same line.
2. `nine consonants each have a hard and a soft version` flagged as missing marker — but the writer DID emit `<!-- VERIFY: precise count of hard/soft consonant pairs; check Ukrainian phonetics source -->`.
3. Reviewer acknowledged markers were correctly placed, then failed the module on marker format ("не вказують [format detail]").

This PR closes the miscalibration.

## Changes

### `scripts/build/phases/v6-review/v6-review-honesty.md` (v1.2.0 → v1.3.0)

- **Presence rule** (authoritative): marker presence alone satisfies a precise claim. Reviewer MUST NOT emit a missing-marker finding when a marker is already attached.
- **Vicinity rule**: a marker counts as attached when it is on the **same line** as the claim OR anywhere in the **same paragraph**. Matches `honesty_annotator.py` line-level dedup (line 110: skip line if `<!-- VERIFY` present anywhere on it) and the writer's worked examples in `v6-write.md` (markers placed on same line).
- **Marker-format nitpicks out of scope**: generic markers like `<!-- VERIFY: historical date for restoration of Ґ; check Ukrainian orthography/alphabet source -->` are fully acceptable. Findings like "marker does not cite a specific packet section" / "marker is too generic" / "marker should include [format detail]" are **banned**. Only the bare `<!-- VERIFY -->` (no claim text) remains insufficient.
- **Five worked examples** (WRONG vs RIGHT) covering the three a1/1 false-positive patterns + genuinely-unmarked-claim + bare-marker preserved cases.
- **PASS / REVISE bullets** rewritten to match the presence + vicinity rules (removed "markers reference a specific source" preference from PASS; removed "do not name the source" penalty from REVISE).
- Enforcement on genuinely unmarked claims is **preserved** — the fix stops double-counting marked claims, not weakens unmarked-claim detection.

### `tests/test_honesty_reviewer_prompt.py` (new, 12 tests)

Modeled on `tests/test_plan_adherence_prompt_policy.py`. Pins:
- Version tag hygiene
- Presence rule phrasing (`presence` + `satisfies`)
- Explicit prohibition phrasing (`must not emit a finding` when marker present)
- Vicinity definition (`same line` + `same paragraph`)
- Marker-format nitpicks out of scope (`out of scope` + `generic` + `bare`)
- Worked-examples section present with `**WRONG:**` / `**RIGHT:**` labels
- Canonical Ґ-restoration example present
- Preserved enforcement on unmarked claims
- Preserved REJECT rule for 3+-precise-claims / 0-markers

## Version note

The brief requested v2.3.0, but that version was from `v6-write.md`'s header. The Honesty reviewer rubric has always been on 1.x (pre-Phase-A was 1.1.0, Phase A bumped to 1.2.0). This PR bumps 1.2.0 → 1.3.0 to preserve semver continuity on this specific file.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_honesty_annotator.py tests/test_plan_adherence_prompt_policy.py tests/test_honesty_reviewer_prompt.py` → 38 passed
- [x] `ruff check` on edited files — all green
- [x] Pre-commit hook passes
- [ ] Rebuild a1/1 and observe that the three previously-flagged claims no longer trigger Honesty findings (post-merge verification — out of scope for this PR since user runs builds)
- [ ] Rebuild a module with a genuinely unmarked precise claim and confirm Honesty still fires (regression check, post-merge)

## Out of scope

- Writer prompt changes (separate PR running in parallel per brief)
- Reviewer concurrency (#1534, already shipped)
- Other review dimensions (Factual, Plan Adherence) — this PR touches only Honesty
- Wholesale rubric rewrite — targeted additions only

Do **not** enable auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)