### PR TITLE
refactor(patchability): clarify batch-level semantics (#1526 item 1)

### DIFF
--- a/scripts/build/convergence_loop.py
+++ b/scripts/build/convergence_loop.py
@@ -192,8 +192,17 @@ def _normalize_observation(
         # anchor_missing, no_fixes, and not_evaluated all leave the classifier's
         # output intact — preserves plan_revision_request routing for genuine
         # plan defects and for reviewer-side anchor bugs.
+        #
+        # NOTE (GH #1526 item 1): ``batch_patch_ok`` is an OBSERVATION-LEVEL
+        # signal — it proves every fix in the reviewer's <fixes> block has a
+        # valid anchor, not that THIS specific finding has a corresponding
+        # fix. We accept the batch-level signal as best-effort routing until
+        # per-finding patchability ships (reviewer emits
+        # ``<fix_for_finding id=...>``). The worst case — 2 fixes for 3
+        # findings — is caught by ``_stall_signals`` (top3_overlap /
+        # hard_floor_persisted) on the next round and escalates cleanly.
         effective_topology = classifier_topology
-        if patchability_status == "patch_ok" and classifier_topology != "local_to_prose":
+        if patchability_status == "batch_patch_ok" and classifier_topology != "local_to_prose":
             effective_topology = "local_to_prose"
         severity = "critical" if item["dimension"] in floor_dimensions else item["severity"]
         results.append(

--- a/scripts/build/patchability.py
+++ b/scripts/build/patchability.py
@@ -4,6 +4,32 @@ Introduced 2026-04-24 (GH #1525 P0) to replace fragile location-string heuristic
 in ``finding_topology.py`` as the ONLY signal that decides whether a reviewer
 finding can be patched deterministically.
 
+## Scope: this is a BATCH-LEVEL predicate (GH #1526 item 1)
+
+**Read this before adding a new caller.** The predicate operates at
+**observation level** — it validates a `<fixes>` block as a whole, not each
+finding against its "own" fix. Reviewer output does not link findings to
+specific fixes (no `fix_for_finding id=...` contract today); every fix is
+anonymous within the block. Consequence:
+
+- ``batch_patch_ok`` means "every fix in the reviewer's `<fixes>` block has
+  an anchor present in current content", NOT "this finding has a
+  corresponding fix that applies cleanly".
+- If the reviewer emits 2 fixes for 3 findings, all 3 non-plan findings
+  share the ``batch_patch_ok`` status. The apply step
+  (``_apply_review_fixes``) applies only the 2 matching fixes; the third
+  finding's content defect persists and gets re-flagged next round, where
+  the stall detector (``convergence_loop._stall_signals``) catches it
+  (``top3_overlap`` or ``hard_floor_persisted``) and escalates to
+  ``plan_revision_request``. So the asymmetry costs at most one extra
+  round; it never silently ships a defect.
+
+A per-finding upgrade — reviewer prompts emitting
+``<fix_for_finding id="...">`` blocks so the predicate can map 1:1 — is
+tracked in GH #1526 item 1 (Path A). Deferred until empirical evidence of
+false-positive patchability classification shows up in production; until
+then the batch-level semantic is the conservative right call.
+
 ## Why this exists
 
 ``convergence_loop.select_strategy`` gates the ``patch`` tier on
@@ -18,7 +44,7 @@ findings that point at ``INJECT_ACTIVITY`` markers — the classifier defaults t
 
 ## The predicate (3-part, deterministic)
 
-A finding is "validated patchable" iff ALL three hold:
+A finding is "batch-patchable" iff ALL three hold:
 
 1. ``parsed_fixes`` is non-empty (reviewer actually emitted ``<fixes>``)
 2. **Every** fix's anchor (``find`` or ``insert_after``) string is present in
@@ -43,6 +69,8 @@ LLM during review. We only fix the ROUTING around the existing deterministic
 applied instead of being black-holed because the location wording failed a
 fragile heuristic.
 
+This is also NOT a per-finding patchability check — see "Scope" above.
+
 Cross-agent consensus: architecture thread ``8aaa5760a2814e1192dac1b61b1b4098``.
 """
 
@@ -53,7 +81,11 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 PatchabilityStatus = Literal[
-    "patch_ok",            # all 3 predicate parts hold — override to local_to_prose
+    # NOTE: ``batch_patch_ok`` (not ``patch_ok``) because this status is
+    # derived from OBSERVATION-level validation of the whole ``<fixes>``
+    # block, not from per-finding matching. See module docstring "Scope"
+    # section. GH #1526 item 1 renamed from ``patch_ok`` on 2026-04-24.
+    "batch_patch_ok",      # all 3 predicate parts hold — override to local_to_prose
     "no_fixes",            # reviewer emitted no <fixes> block at all
     "anchor_missing",      # at least one fix has find-string NOT present in content
     "plan_level_hardstop", # finding.plan_level is True — ADR-007 plan-revision path
@@ -64,6 +96,12 @@ PatchabilityStatus = Literal[
 @dataclass(frozen=True)
 class AnchorValidation:
     """Observation-level result of validating every fix's anchor against content.
+
+    This dataclass, and the ``batch_patch_ok`` status derived from it, are
+    OBSERVATION-SCOPED — they describe the reviewer's ``<fixes>`` block as a
+    whole, not individual findings. Every non-plan finding in the same
+    observation shares the same ``AnchorValidation`` result. See the module
+    docstring "Scope" section (GH #1526 item 1) for why.
 
     Computed once per review round, then passed to ``classify_patchability``
     for each finding. Avoids the O(findings × fixes) substring scans that
@@ -97,9 +135,9 @@ def _has_valid_anchor(fix: dict[str, Any], content: str) -> bool:
     Dispatch order MUST mirror ``_apply_review_fixes`` at v6_build.py:8180 —
     apply checks ``insert_after`` FIRST and continues past ``find`` when both
     keys are present. A validator that checks ``find`` first would mark a
-    mixed-shape fix ``patch_ok`` on a valid ``find`` anchor while the apply
-    step uses a missing ``insert_after`` anchor and silently skips the fix
-    (false positive in the "validated patchability" contract).
+    mixed-shape fix ``batch_patch_ok`` on a valid ``find`` anchor while the
+    apply step uses a missing ``insert_after`` anchor and silently skips the
+    fix (false positive in the batch-patchability contract).
     """
     if "insert_after" in fix and "text" in fix:
         anchor = fix.get("insert_after")
@@ -167,8 +205,14 @@ def classify_patchability(
     the status to decide whether to override the topology classifier's output
     for this finding:
 
-    - ``patch_ok`` → override topology to ``local_to_prose``
+    - ``batch_patch_ok`` → override topology to ``local_to_prose``
     - everything else → leave topology as-is (classifier-determined)
+
+    The only per-finding signal consumed here is ``plan_level`` — plan-level
+    findings hardstop regardless of batch-level anchor validity. All other
+    findings share the status derived from the observation-level
+    ``AnchorValidation``; see the module docstring "Scope" section for why
+    this is batch-level and not per-finding.
 
     ``reason`` is a human-readable one-liner suitable for telemetry / JSONL
     event emission.
@@ -204,6 +248,7 @@ def classify_patchability(
             f"{anchor_validation.invalid} of {anchor_validation.total} fix anchors not present in content (could be stale review, normalization asymmetry, or reviewer-side anchor bug)",
         )
     return (
-        "patch_ok",
-        f"all {anchor_validation.valid} fix anchors validated against current content",
+        "batch_patch_ok",
+        f"all {anchor_validation.valid} fix anchors validated against current content "
+        f"(batch-level: does NOT prove 1:1 mapping to this finding; see GH #1526)",
     )

--- a/tests/test_patchability.py
+++ b/tests/test_patchability.py
@@ -6,14 +6,16 @@ Invariants:
    plan defects.
 2. Legacy callers (no fixes, no content) get ``not_evaluated`` — old heuristic
    path stays intact.
-3. ``patch_ok`` fires only when ALL fixes have anchors present in content.
+3. ``batch_patch_ok`` fires only when ALL fixes have anchors present in content.
    A partial set is ``anchor_missing`` (reviewer saw stale text → don't trust
-   the batch).
+   the batch). The status is OBSERVATION-SCOPED (GH #1526 item 1) — it
+   describes the ``<fixes>`` block as a whole, not the individual finding.
 4. ``compute_anchor_validation`` runs ONCE per observation; ``classify_patchability``
    consumes the result per finding without rescanning.
 5. Golden fixture derived from a1/sounds-letters-and-hello R1 (the module
    that surfaced this bug): all 9 findings across 3 failing dims must route
-   to ``patch_ok`` under the new predicate so the pipeline re-fire converges.
+   to ``batch_patch_ok`` under the new predicate so the pipeline re-fire
+   converges.
 """
 from __future__ import annotations
 
@@ -160,10 +162,10 @@ def test_anchor_missing_when_all_fix_anchors_absent() -> None:
     assert "2 of 2" in reason
 
 
-# ---------- patch_ok: the unlock condition ----------
+# ---------- batch_patch_ok: the unlock condition ----------
 
 
-def test_patch_ok_when_all_anchors_validate_and_not_plan_level() -> None:
+def test_batch_patch_ok_when_all_anchors_validate_and_not_plan_level() -> None:
     finding = {"plan_level": False, "error_class": "notation_error"}
     content = "Hear **він** (it) in **ґанок** (porch)."
     fixes = [
@@ -174,17 +176,20 @@ def test_patch_ok_when_all_anchors_validate_and_not_plan_level() -> None:
     ]
     validation = compute_anchor_validation(fixes, content)
     status, reason = classify_patchability(finding, anchor_validation=validation)
-    assert status == "patch_ok"
+    assert status == "batch_patch_ok"
     assert "1 fix anchors validated" in reason
+    # GH #1526 item 1: the reason must surface the batch-level caveat so
+    # readers don't misread ``batch_patch_ok`` as a per-finding guarantee.
+    assert "batch-level" in reason
 
 
-def test_patch_ok_with_insert_after_directive() -> None:
+def test_batch_patch_ok_with_insert_after_directive() -> None:
     finding = {"plan_level": False, "error_class": "word_budget"}
     content = "Section 1 content.\n\nSection 2 content."
     fixes = [{"insert_after": "Section 1 content.", "text": " Added sentence."}]
     validation = compute_anchor_validation(fixes, content)
     status, _ = classify_patchability(finding, anchor_validation=validation)
-    assert status == "patch_ok"
+    assert status == "batch_patch_ok"
 
 
 # ---------- dispatch-order parity with _apply_review_fixes ----------
@@ -197,8 +202,8 @@ def test_mixed_shape_fix_validates_insert_after_first() -> None:
     ``_apply_review_fixes`` (v6_build.py:8180) dispatches ``insert_after``
     BEFORE ``find``. If our validator checked ``find`` first, a fix with a
     valid ``find`` anchor but a missing ``insert_after`` anchor would be
-    marked ``patch_ok`` even though the apply step silently skips it — a
-    false positive in the "validated patchability" contract.
+    marked ``batch_patch_ok`` even though the apply step silently skips it
+    — a false positive in the batch-patchability contract.
     """
     content = "the find-anchor is present but insert_after is missing"
     mixed_fix = [
@@ -322,7 +327,7 @@ def test_legacy_observation_without_p0_fields_reports_not_evaluated() -> None:
 
 def test_pilot_sounds_letters_and_hello_r1_all_findings_route_to_patch() -> None:
     """Every real finding from a1/sounds-letters-and-hello R1 must route to
-    patch_ok under the new predicate.
+    batch_patch_ok under the new predicate.
 
     This module's R1 review emitted 9 concrete find/replace pairs across
     Honesty/Factual/Plan_Adherence. Under the old heuristic topology classifier,
@@ -395,7 +400,7 @@ def test_pilot_sounds_letters_and_hello_r1_all_findings_route_to_patch() -> None
     assert validation == AnchorValidation(evaluated=True, total=9, valid=9, invalid=0)
     for finding in findings:
         status, _ = classify_patchability(finding, anchor_validation=validation)
-        assert status == "patch_ok", (
-            f"Finding {finding} should route to patch_ok with all 9 anchor-valid "
+        assert status == "batch_patch_ok", (
+            f"Finding {finding} should route to batch_patch_ok with all 9 anchor-valid "
             f"fixes present in content; got {status!r}"
         )


### PR DESCRIPTION
## Decision summary

**Chose Path B (rename + doc clarification) over Path A (reviewer-template migration).**

- Path A requires changing all 9 per-dim reviewer prompt templates (`v6-review-{actionable,completeness,decolonization,dialogue,factual,honesty,language,naturalness,plan-adherence}.md`) to emit `<fix_for_finding id="...">` blocks, regenerating test fixtures, re-verifying each prompt across Opus/Sonnet/Haiku reliability, and updating `_parse_review_fixes` in `v6_build.py`. Large blast radius.
- No empirical false-positive patchability classification has been observed in production. The a1/1 terminal this week was `plan_revision_request` for a legitimately non-patchable finding class, not a "some fix applied" false positive.
- The worst pathological case under batch-level routing — reviewer emits 2 fixes for 3 findings — is caught by `convergence_loop._stall_signals` (`top3_overlap` / `hard_floor_persisted`) on the next round and escalates cleanly. Asymmetry costs at most one extra convergence round, never a silent ship.

**What changes:** `patch_ok` status → `batch_patch_ok`; expanded module docstring with a `## Scope` section that walks through the 2-for-3 case; inline consumer comment at `_normalize_observation` explaining the batch-level acceptance.

**What's deferred:** Path A. The gate for revisiting is empirical evidence of a false-positive batch_patch_ok classification in a production build trace.

## Steel-man of Path A

The predicate **can** mismatch: reviewer emits 2 fixes covering 2 of 3 findings, the third finding has no corresponding fix in the block. Under batch semantics all 3 findings get `batch_patch_ok` → topology override to `local_to_prose` → patch tier. The apply step then fixes 2, leaves the third defect unpatched. That is a semantic gap Codex flagged in round-1 finding 3. The steel case: per-finding routing would cut one wasted convergence round when this pattern occurs.

**Why Path B still wins:** the waste is bounded (one round, detected by the stall signals), and the cost of Path A is a prompt contract change + reliability verification across 9 templates. Shipping Path A now without empirical frequency data would be a speculative investment against a real cost; deferring until we can measure the false-positive rate is the conservative right call.

## Summary

- Module docstring in `scripts/build/patchability.py` now opens with a `## Scope` section that explicitly states the predicate is observation-level, names what `batch_patch_ok` does and doesn't prove, documents the 2-for-3 pathological case and the stall-signal backstop, and links to GH #1526 for the per-finding upgrade path.
- `PatchabilityStatus` literal `patch_ok` → `batch_patch_ok`. All call sites, tests, and audit-trail strings updated.
- `AnchorValidation` docstring reinforces that it (and the status derived from it) are OBSERVATION-SCOPED; every non-plan finding in the same observation shares the same result.
- `classify_patchability` docstring spells out that `plan_level` is the only per-finding signal consumed; the rest is batch-level.
- `batch_patch_ok` return message carries the batch-level caveat inline so telemetry readers see it at the call site: `"(batch-level: does NOT prove 1:1 mapping to this finding; see GH #1526)"`.
- `convergence_loop._normalize_observation` routing site (line 196) gains a multi-line comment explaining why the batch-level signal is accepted for routing and what catches the residual unfixed-finding case.
- Test names `test_patch_ok_*` → `test_batch_patch_ok_*`; assertions + docstrings + section headers updated. Added assertion that the new reason string surfaces the "batch-level" caveat.

## Blast radius

Fully contained. Grep confirms the literal string `patch_ok` is referenced only in:
- `scripts/build/patchability.py` (4 occurrences — all updated)
- `scripts/build/convergence_loop.py` (1 conditional — updated)
- `tests/test_patchability.py` (multiple assertions — all updated)

No API endpoint, dashboard field, CLI flag, or external script reads the literal status string. No session-state file pins on the exact value.

## Test plan

- [x] `pytest tests/test_patchability.py tests/test_reviewer_ghost_normalization.py tests/test_convergence_loop.py tests/test_reviewer_ghost_bundle.py` — 39 passed
- [x] `ruff check` on all touched files — clean
- [x] Pre-commit hook ran pytest on affected files during commit — 28 passed
- [x] Verified no API consumer, external script, or dashboard reads the literal `patch_ok` string before renaming

## Out of scope (deferred to follow-up issues)

- Item 2 of #1526 — anchor-matching parity between `_has_valid_anchor` (plain `str in content`) and `_apply_review_fixes` (4 match strategies including stress-mark-aware + whitespace-normalized). Deferred per the handoff + Codex neutral review this afternoon.
- Item 3 of #1526 — duplicate / overlapping anchor edge cases.
- Any convergence routing behavior changes beyond rename/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)