### PR TITLE
fix(writer-prompt): kill "Section N:" primer — enforce verbatim Ukrainian H2 titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
       - 'claude_extensions/phases/**/*.md'
       - 'claude_extensions/skills/**/*.md'
       - 'gemini_extensions/skills/**/*.md'
+      - 'scripts/build/phases/**/*.md'
+      - 'scripts/build/contracts/**/*.md'
       - 'starlight/**'
   pull_request:
     paths:
@@ -24,6 +26,8 @@ on:
       - 'claude_extensions/phases/**/*.md'
       - 'claude_extensions/skills/**/*.md'
       - 'gemini_extensions/skills/**/*.md'
+      - 'scripts/build/phases/**/*.md'
+      - 'scripts/build/contracts/**/*.md'
       - 'starlight/**'
   workflow_dispatch:
 

--- a/scripts/build/phases/v6-write-seminar.md
+++ b/scripts/build/phases/v6-write-seminar.md
@@ -13,18 +13,22 @@ Write the full prose content for seminar module **{MODULE_NUM}: {TOPIC_TITLE}** 
 
 ## Step 1: Pacing Plan (output this FIRST)
 
-Before writing any content, output a `<pacing_plan>` block:
+Before writing any content, output a `<pacing_plan>` block.
+
+Use the exact Ukrainian section titles from the plan as the quoted labels — do **not** invent `Section 1`, `Section 2`, `Part N`, or any English/numeric prefix. The pacing plan is a scratchpad; the labels here must be verbatim the H2 headings you'll write below.
 
 ```
 <pacing_plan>
-Section 1 "Title": ~XXX words — [1-sentence content focus]
-Section 2 "Title": ~XXX words — [1-sentence content focus]
+"<verbatim-ukrainian-title-from-plan-1>": ~XXX words — [1-sentence content focus]
+"<verbatim-ukrainian-title-from-plan-2>": ~XXX words — [1-sentence content focus]
 ...
 Total: {WORD_TARGET}+ words
 </pacing_plan>
 ```
 
 Then begin writing. Follow your own pacing plan.
+
+**H2 heading rule (strict).** Every `## H2` in the module body MUST match the plan's section title verbatim — no `## Section 1: <title>`, no `## Part N: <title>`, no numbering, no English label. The contract checker compares H2 titles to plan titles by exact string match.
 
 ---
 

--- a/scripts/build/phases/v6-write.md
+++ b/scripts/build/phases/v6-write.md
@@ -1,4 +1,4 @@
-<!-- version: 2.3.1 | updated: 2026-04-24 | #1538 review: Я positional rule (й+а vs palatalization) + VERIFY-in-YAML must be inside a field value -->
+<!-- version: 2.4.0 | updated: 2026-04-24 | pacing-plan no longer primes "Section N:" labels — use verbatim Ukrainian plan titles; adds explicit H2 heading rule to kill SECTION_ORDER retries (observed on a1/1 2026-04-24 rebuild) -->
 # V6 Writing Prompt — Module Content Generation
 
 ## Shared Contract (read first — supersedes rule text below on conflict)
@@ -43,17 +43,21 @@ Write the full prose content for module **{MODULE_NUM}: {TOPIC_TITLE}** ({LEVEL}
 
 Before writing any content, output a `<pacing_plan>` block only if no Skeleton block appears later in this prompt. Evaluate each section from the plan and commit to a word budget. This prevents frontloading early sections and rushing later ones.
 
+Use the exact Ukrainian section titles from the plan as the quoted labels — do **not** invent `Section 1`, `Section 2`, `Part N`, or any English/numeric prefix. The pacing plan is a scratchpad; the labels you write here must be verbatim the H2 headings you'll write below.
+
 ```
 <pacing_plan>
-Section 1 "Title": ~XXX words — [1-sentence content focus]
-Section 2 "Title": ~XXX words — [1-sentence content focus]
+"<verbatim-ukrainian-title-from-plan-1>": ~XXX words — [1-sentence content focus]
+"<verbatim-ukrainian-title-from-plan-2>": ~XXX words — [1-sentence content focus]
 ...
-Summary: ~150 words
+"{SUMMARY_HEADING}": ~150 words
 Total: {WORD_TARGET}+ words
 </pacing_plan>
 ```
 
 Then begin writing the module content. Follow your own pacing plan — each section must hit its word budget (±10%). If a Skeleton block appears later in this prompt, do NOT output `<pacing_plan>` and start directly with the first H2 heading.
+
+**H2 heading rule (strict — enforced by deterministic contract check).** Every `## H2` in the module body MUST match the plan's section title verbatim. No `## Section 1: <title>`, no `## Part N: <title>`, no `## Step N: <title>`, no numbering, no English label — just `## <ukrainian title>`. The contract checker compares H2 titles to plan titles by exact string match. Any prefix or suffix fails `SECTION_ORDER` and cascades into `MISSING_SECTION` + `TEACHING_BEATS` violations. This is a frequent write-phase failure — emitting `## Section 1: Звуки і літери` instead of `## Звуки і літери` wastes 2–3 write retries per module.
 
 ---
 


### PR DESCRIPTION
## Summary

Small but impactful prompt-template fix. The pacing-plan example block in `v6-write.md` + `v6-write-seminar.md` used English scaffolding labels (`Section 1 "Title":`, `Section 2 "Title":`). Claude opus pattern-completes that into the module body H2s as `## Section 1: Звуки і літери` instead of `## Звуки і літери`, which trips the contract checker's exact-match `SECTION_ORDER` gate and cascades into `MISSING_SECTION` + `TEACHING_BEATS` failures.

## Empirical driver

Observed live on a1/1 rebuild, 2026-04-24 ~21:26 UTC, immediately after #1538 merged and the user re-ran with `--force --writer claude-tools --reviewer codex-tools`:

- Attempt 1: 8 violations (SECTION_ORDER + 4× MISSING_SECTION from `Section N:` prefix)
- Attempt 2: 10 violations (prefix removed, but TEACHING_BEATS + FACTUAL_ANCHOR misplaced because sections got reshuffled)
- Attempt 3: converged ✅

The convergence loop survives this, but wastes ~4 min/module on every build that trips it. Classic MEMORY #0F ("trace to pipeline code before designing prompt fixes") — this looked like a writer-quality issue, but the writer is following the primer the prompt itself handed it.

## Changes

1. **`scripts/build/phases/v6-write.md`** (v2.3.1 → v2.4.0):
   - Replaced `Section 1 "Title":` / `Section 2 "Title":` in pacing-plan example with `<verbatim-ukrainian-title-from-plan-N>` placeholders
   - Added explicit H2 heading rule immediately after the pacing plan, naming the anti-example (`## Section 1: Звуки і літери` vs `## Звуки і літери`) so the model has the wrong pattern right next to the correct instruction
2. **`scripts/build/phases/v6-write-seminar.md`**: same fix to the seminar variant

## Test plan

- [x] Lint (ruff, lint-prompts) pass
- [x] Existing `plan_contract` SECTION_ORDER + MISSING_SECTION gates remain the authoritative check — this PR removes the upstream primer that was tripping them, doesn't change the gates themselves
- [ ] Next a1 rebuild should converge on write attempt 1 (watch `module_failed` vs `module_done` events + write-attempt count)

## Related

- Empirical driver: a1/1 rebuild live-debug with user 2026-04-24
- Follow-up to #1538 (writer-prompt vocab+phonetics)
- Same class of bug as colors investigation (EPIC #1451 Phase 3 / PR #1449)

🤖 Generated with [Claude Code](https://claude.com/claude-code)