### PR TITLE
fix(convergence): apply reviewer <fixes> before tier-5 escalation (#1526 item 2)

### DIFF
--- a/scripts/build/convergence_loop.py
+++ b/scripts/build/convergence_loop.py
@@ -242,30 +242,37 @@ def _fix_anchor_text(fix: dict[str, Any]) -> str:
     return ""
 
 
-def _best_match_invalid_fix(
-    finding: dict[str, Any],
-    invalid_fixes: Sequence[dict[str, Any]],
+def _best_match_finding_for_fix(
+    fix: dict[str, Any],
+    candidate_findings: Sequence[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """Heuristically pair a ghost finding with the invalid fix it most likely refers to.
+    """Heuristically pair an invalid fix with the non-plan finding it most
+    likely refers to. Iterating fixes first (GH #1526 item 2 ghost
+    collection) — after the patchability predicate was loosened in
+    item 2, non-plan findings no longer carry a per-finding ``anchor_missing``
+    status in the partial-valid case, so the ghost collector has to start
+    from invalid fixes rather than from findings.
 
-    Reviewer output format does not link findings to ``<fixes>`` entries by ID,
-    so we match by substring: if the invalid fix's anchor text appears in the
-    finding's ``fix`` or ``issue`` prose, assume they are paired. Falls back to
-    the first invalid fix when no content overlap is found, so the bundle still
-    attaches a concrete ``raw_fix`` for audit.
+    Reviewer output does not link fixes to findings by ID, so match by
+    substring: the invalid fix's anchor text (or issue wording overlap) is
+    checked against the finding's ``fix`` / ``issue`` prose. Falls back to
+    the first candidate finding when no content overlap is found, so every
+    invalid fix still produces a ghost entry for audit.
     """
-    if not invalid_fixes:
+    if not candidate_findings:
         return None
-    fix_text = str(finding.get("fix") or "").lower()
-    issue_text = str(finding.get("issue") or "").lower()
-    for fix in invalid_fixes:
-        anchor = _fix_anchor_text(fix).lower()
-        if not anchor:
-            continue
-        probe = anchor[:60]
-        if probe and (probe in fix_text or probe in issue_text):
-            return fix
-    return invalid_fixes[0]
+    anchor = _fix_anchor_text(fix).lower()
+    if not anchor:
+        return candidate_findings[0]
+    probe = anchor[:60]
+    if not probe:
+        return candidate_findings[0]
+    for finding in candidate_findings:
+        fix_text = str(finding.get("fix") or "").lower()
+        issue_text = str(finding.get("issue") or "").lower()
+        if probe in fix_text or probe in issue_text:
+            return finding
+    return candidate_findings[0]
 
 
 def collect_reviewer_ghost_findings(
@@ -276,9 +283,16 @@ def collect_reviewer_ghost_findings(
 ) -> tuple[dict[str, Any], ...]:
     """Build the ghost-finding tuple for an observation.
 
-    A ghost finding is a reviewer-emitted finding whose patchability status
-    resolves to :data:`REVIEWER_GHOST_PATCHABILITY_STATUS` — i.e. the anchor
-    text the reviewer "quoted" cannot be located in current module content.
+    A ghost finding represents a reviewer-emitted ``<fixes>`` entry whose
+    anchor text cannot be located in current module content. Under the
+    GH #1526 item 2 loosening, the patchability status on a non-plan
+    finding is ``batch_patch_ok`` even when SOME sibling fixes are
+    invalid — so we can't filter findings by ``patchability ==
+    anchor_missing`` the way the pre-#1526 code did. Instead we iterate
+    over the invalid fixes themselves and match each back to a non-plan
+    finding via substring heuristic. This means every invalid fix
+    produces a ghost entry for audit regardless of whether the
+    observation routed to patch or plan_revision.
 
     Each returned dict preserves the normalized finding fields and adds three
     bundle-writer affordances:
@@ -302,18 +316,25 @@ def collect_reviewer_ghost_findings(
         if normalized is not None
         else _normalize_observation(observation, growth_log_path=growth_log_path)
     )
+    non_plan_findings = tuple(
+        item
+        for item in findings
+        if item.get("patchability") != "plan_level_hardstop"
+    )
+    if not non_plan_findings:
+        return ()
     ghosts: list[dict[str, Any]] = []
-    for item in findings:
-        if item.get("patchability") != REVIEWER_GHOST_PATCHABILITY_STATUS:
+    for invalid_fix in invalid_fixes:
+        matched_finding = _best_match_finding_for_fix(invalid_fix, non_plan_findings)
+        if matched_finding is None:
             continue
-        matched_fix = _best_match_invalid_fix(item, invalid_fixes)
-        anchor = _fix_anchor_text(matched_fix) if matched_fix else ""
+        anchor = _fix_anchor_text(invalid_fix)
         ghosts.append(
             {
-                **item,
+                **matched_finding,
                 "reviewer_find_anchor": anchor,
                 "anchor_validation": REVIEWER_GHOST_PATCHABILITY_STATUS,
-                "raw_fix": dict(matched_fix) if matched_fix else {},
+                "raw_fix": dict(invalid_fix),
             }
         )
     return tuple(ghosts)
@@ -378,6 +399,26 @@ def prioritize_findings(
     return _normalize_observation(observation, growth_log_path=growth_log_path)
 
 
+def _has_applicable_review_fix(observation: ReviewObservation) -> bool:
+    """True iff the reviewer emitted at least one fix with a valid anchor.
+
+    GH #1526 item 2: the old ``topologies == {"local_to_prose"}`` gate in
+    ``select_strategy`` used set-equality, so any non-prose topology in the
+    batch (e.g. Plan-Adherence with a ``cross_section`` location string)
+    collapsed the whole observation to ``plan_revision_request`` even when
+    the reviewer's ``<fixes>`` block had clean find/replace pairs for the
+    non-plan findings. This helper checks the ground truth: does the
+    reviewer's own batch have anchor-valid fixes we can apply?
+    """
+    if not observation.parsed_fixes or observation.module_content is None:
+        return False
+    valid, _invalid = validate_fix_anchors(
+        observation.parsed_fixes,
+        observation.module_content,
+    )
+    return bool(valid)
+
+
 def select_strategy(
     *,
     observation: ReviewObservation,
@@ -393,14 +434,38 @@ def select_strategy(
         )
 
     topologies = {item["topology"] for item in prioritized_findings}
+    has_plan_level = any(
+        item.get("plan_level") or item.get("topology") == "plan_level"
+        for item in prioritized_findings
+    )
     candidate_tier = 5
     candidate_strategy: TierName = "plan_revision_request"
     candidate_reason = "findings require human plan revision"
 
-    if observation.patch_available and topologies == {"local_to_prose"}:
+    # GH #1526 item 2: apply the patch tier whenever the reviewer emitted
+    # deterministic fixes with valid anchors AND no finding is plan-level,
+    # regardless of whether cross_section / plan-adherence topologies appear
+    # in the sibling set. The old ``topologies == {"local_to_prose"}``
+    # equality gate routed honest patch-able batches to
+    # plan_revision_request whenever one sibling finding had a cross-section
+    # location, black-holing the reviewer's <fixes>. Empirical trigger:
+    # a1/sounds-letters-and-hello 2026-04-24 — 24 findings, 0 plan_level,
+    # 5 Factual fixes with byte-exact anchors, zero applied.
+    if observation.patch_available and not has_plan_level and (
+        topologies == {"local_to_prose"} or _has_applicable_review_fix(observation)
+    ):
         candidate_tier = 1
         candidate_strategy = "patch"
-        candidate_reason = "all findings are local prose edits and reviewer emitted deterministic fixes"
+        if topologies == {"local_to_prose"}:
+            candidate_reason = (
+                "all findings are local prose edits and reviewer emitted "
+                "deterministic fixes"
+            )
+        else:
+            candidate_reason = (
+                "reviewer emitted at least one deterministic fix with a valid "
+                "anchor and no finding is plan-level"
+            )
 
     signals = _stall_signals(previous_round, {
         "strategy": previous_round.get("strategy") if previous_round else "write",

--- a/scripts/build/patchability.py
+++ b/scripts/build/patchability.py
@@ -12,9 +12,13 @@ finding against its "own" fix. Reviewer output does not link findings to
 specific fixes (no `fix_for_finding id=...` contract today); every fix is
 anonymous within the block. Consequence:
 
-- ``batch_patch_ok`` means "every fix in the reviewer's `<fixes>` block has
-  an anchor present in current content", NOT "this finding has a
-  corresponding fix that applies cleanly".
+- ``batch_patch_ok`` means "at least one fix in the reviewer's `<fixes>`
+  block has an anchor present in current content", NOT "this finding has a
+  corresponding fix that applies cleanly". See GH #1526 item 2 — the
+  predicate was loosened from "all anchors valid" to "at least one anchor
+  valid" on 2026-04-24 after a1/sounds-letters-and-hello R1 proved that
+  batch-atomic invalidation was black-holing legitimate fixes whenever any
+  sibling fix had a hallucinated anchor.
 - If the reviewer emits 2 fixes for 3 findings, all 3 non-plan findings
   share the ``batch_patch_ok`` status. The apply step
   (``_apply_review_fixes``) applies only the 2 matching fixes; the third
@@ -47,10 +51,13 @@ findings that point at ``INJECT_ACTIVITY`` markers — the classifier defaults t
 A finding is "batch-patchable" iff ALL three hold:
 
 1. ``parsed_fixes`` is non-empty (reviewer actually emitted ``<fixes>``)
-2. **Every** fix's anchor (``find`` or ``insert_after``) string is present in
-   the current module content. Not a subset — every one. A partial-anchor set
-   means the reviewer saw a stale version of the text, so the fixes are not
-   trustworthy as a batch.
+2. **At least one** fix's anchor (``find`` or ``insert_after``) string is
+   present in the current module content. Partial-anchor sets are accepted:
+   the valid fixes apply via ``_apply_review_fixes``, the invalid ones get
+   skipped and logged to the ghost bundle (``anchor_validation.invalid`` and
+   ``reviewer_ghost_findings``) for audit. ``anchor_missing`` is reserved
+   for the fully-hallucinated case (zero valid anchors) — reviewer saw a
+   completely stale version, nothing to trust.
 3. The finding itself is NOT ``plan_level`` (``finding_normalizer`` already
    labels plan-contradiction / vocab-density / pedagogical-sequence /
    scenario-grammar-misalignment at the source). Plan-level findings keep the
@@ -85,9 +92,9 @@ PatchabilityStatus = Literal[
     # derived from OBSERVATION-level validation of the whole ``<fixes>``
     # block, not from per-finding matching. See module docstring "Scope"
     # section. GH #1526 item 1 renamed from ``patch_ok`` on 2026-04-24.
-    "batch_patch_ok",      # all 3 predicate parts hold — override to local_to_prose
+    "batch_patch_ok",      # at least one fix has valid anchor — override to local_to_prose
     "no_fixes",            # reviewer emitted no <fixes> block at all
-    "anchor_missing",      # at least one fix has find-string NOT present in content
+    "anchor_missing",      # ALL fix anchors absent from content (fully hallucinated batch)
     "plan_level_hardstop", # finding.plan_level is True — ADR-007 plan-revision path
     "not_evaluated",       # caller did not supply content/fixes — legacy code path
 ]
@@ -242,10 +249,26 @@ def classify_patchability(
             "no_fixes",
             "reviewer emitted no <fixes> block — nothing to patch",
         )
-    if anchor_validation.invalid > 0:
+    # GH #1526 item 2: loosened from batch-atomic to at-least-one-valid. A
+    # partial-valid batch still routes to patch — the valid fixes apply, the
+    # invalid ones get skipped (and surface via the reviewer-ghost bundle).
+    # ``anchor_missing`` is reserved for the fully-hallucinated case where
+    # the reviewer saw a completely stale module; nothing in the batch is
+    # trustworthy and we escalate to plan_revision_request.
+    if anchor_validation.valid == 0:
         return (
             "anchor_missing",
-            f"{anchor_validation.invalid} of {anchor_validation.total} fix anchors not present in content (could be stale review, normalization asymmetry, or reviewer-side anchor bug)",
+            f"all {anchor_validation.invalid} fix anchors absent from content "
+            f"(fully hallucinated batch — could be stale review, normalization asymmetry, "
+            f"or reviewer-side anchor bug)",
+        )
+    if anchor_validation.invalid > 0:
+        return (
+            "batch_patch_ok",
+            f"{anchor_validation.valid} of {anchor_validation.total} fix anchors validated "
+            f"against current content; {anchor_validation.invalid} invalid anchor(s) will be "
+            f"logged as ghost warnings (batch-level: does NOT prove 1:1 mapping to this "
+            f"finding; see GH #1526)",
         )
     return (
         "batch_patch_ok",

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -5651,11 +5651,22 @@ def _build_review_aggregate_payload(
     results: list[PerDimensionReviewResult],
     content_filename: str,
 ) -> dict:
-    """Build the aggregate YAML payload for a review round."""
+    """Build the aggregate YAML payload for a review round.
+
+    GH #1526 item 2: the payload field used to be called ``fixes_applied`` but
+    was populated from ``result.fixes`` — the reviewer's PROPOSED fixes, before
+    any apply-step ran. This was a lie: aggregate YAMLs would report
+    ``fixes_applied.count=5`` while the real apply loop landed zero patches
+    (convergence_loop escalated to plan_revision_request before
+    ``_apply_review_fixes`` fired). Renamed to ``fixes_available`` (truth:
+    these are the fixes the reviewer emitted; applying them is a downstream
+    step). The new ``fixes_applied`` field is populated post-apply by
+    ``_update_aggregate_with_applied_fixes`` and starts empty here.
+    """
     scores = []
     dim_scores = {}
     findings = []
-    fixes_applied = []
+    fixes_available = []
     for spec in REVIEW_DIMENSIONS:
         result = next(item for item in results if item.dimension_id == spec["id"])
         dim_scores[result.dimension_id] = round(result.score, 1)
@@ -5670,7 +5681,7 @@ def _build_review_aggregate_payload(
         )
         findings.extend(dict(item) for item in result.findings)
         if result.fixes:
-            fixes_applied.append(
+            fixes_available.append(
                 {
                     "dim": result.dimension_id,
                     "count": len(result.fixes),
@@ -5689,9 +5700,61 @@ def _build_review_aggregate_payload(
         "dim_scores": dim_scores,
         "scores": scores,
         "findings": _dedupe_yaml_items(findings),
-        "fixes_applied": fixes_applied,
+        "fixes_available": fixes_available,
+        "fixes_applied": [],
         "passed": verdict == "PASS",
     }
+
+
+def _update_aggregate_with_applied_fixes(
+    *,
+    level: str,
+    slug: str,
+    round_num: int | None,
+    applied_count: int,
+    content_filename: str,
+) -> None:
+    """Write the actual apply-count back into the aggregate YAML post-apply.
+
+    GH #1526 item 2: the aggregate YAML's ``fixes_applied`` field used to be
+    populated (pre-apply) from the reviewer's proposed fix count — a lie,
+    since the apply step could skip every fix (invalid anchors) or be bypassed
+    entirely (convergence escalated to plan_revision_request before
+    ``_apply_review_fixes`` ran). Now the aggregate writer emits
+    ``fixes_applied: []`` at review time; after the apply step runs, this
+    helper rewrites the file with the real landed count. ``fixes_available``
+    keeps the proposed count for auditability.
+
+    ``round_num=None`` means "latest round" — we glob the versioned aggregates
+    to find it, matching how ``step_review`` tracks rounds.
+    """
+    review_dir = CURRICULUM_ROOT / level / "review"
+    if not review_dir.exists():
+        return
+    if round_num is None:
+        candidates = list(review_dir.glob(f"{slug}-review-aggregate-r*.yaml"))
+        if not candidates:
+            return
+        round_num = max(_versioned_round_number(p) for p in candidates)
+    versioned_path = review_dir / f"{slug}-review-aggregate-r{round_num}.yaml"
+    if not versioned_path.exists():
+        return
+    try:
+        payload = yaml.safe_load(versioned_path.read_text("utf-8"))
+    except yaml.YAMLError:
+        return
+    if not isinstance(payload, dict):
+        return
+    payload["fixes_applied"] = [
+        {
+            "count": applied_count,
+            "files": [content_filename],
+        }
+    ]
+    dumped = yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+    versioned_path.write_text(dumped, "utf-8")
+    # Keep the unversioned alias in sync.
+    (review_dir / f"{slug}-review-aggregate.yaml").write_text(dumped, "utf-8")
 
 
 def _determine_reviewer(
@@ -8898,6 +8961,18 @@ def _run_convergence_loop(
             level=level,
             slug=slug,
         )
+        # GH #1526 item 2: write the real apply count back into the aggregate
+        # YAML so ``fixes_applied`` matches what actually landed, not what the
+        # reviewer proposed (``fixes_available``). Zero-count case still
+        # overwrites so audit trail reads "apply fired, nothing landed"
+        # instead of the default empty list (apply never ran).
+        _update_aggregate_with_applied_fixes(
+            level=level,
+            slug=slug,
+            round_num=None,
+            applied_count=count,
+            content_filename=content_path.name,
+        )
         return ConvergenceMutationSummary(
             changed=applied,
             mutation_count=count,
@@ -8999,6 +9074,17 @@ def _run_review_heal_loop(
             content_path,
             level=level,
             slug=slug,
+        )
+        # GH #1526 item 2: record the honest apply count in the aggregate YAML
+        # (``fixes_applied``). ``fixes_available`` already carries the
+        # reviewer's proposed count; this step closes the gap between proposed
+        # and landed so downstream readers can tell them apart.
+        _update_aggregate_with_applied_fixes(
+            level=level,
+            slug=slug,
+            round_num=round_index,
+            applied_count=fix_count,
+            content_filename=content_path.name,
         )
         if fixes_applied:
             _log(f"\n🔧 Applied {fix_count} deterministic fix(es) from R{round_index}")

--- a/tests/test_convergence_loop.py
+++ b/tests/test_convergence_loop.py
@@ -531,3 +531,188 @@ def test_budget_exhausted_payload_has_no_exception_for_reviewer_disagreement(
     assert result.terminal == "budget_exhausted"
     assert "exception" not in budget_payload
     assert len(budget_payload["history"]) == 1 + harness.context().max_escalations
+
+
+# ---------- GH #1526 item 2 regression: apply fixes before tier-5 escalation ----------
+
+
+def test_mixed_topology_with_valid_fixes_routes_to_patch_not_plan_revision() -> None:
+    """GH #1526 item 2 regression: the pre-fix ``select_strategy`` gated the
+    patch tier on ``topologies == {"local_to_prose"}`` — set equality, so any
+    sibling finding with a non-prose classifier topology (e.g. Plan Adherence
+    with a cross-section location) collapsed the WHOLE observation to tier-5
+    ``plan_revision_request`` even though the reviewer emitted anchor-valid
+    ``<fixes>`` for the non-plan findings. Empirical trigger:
+    a1/sounds-letters-and-hello 2026-04-24 — 24 findings across 8 dims, zero
+    plan_level, 5 Factual fixes with byte-exact anchors, zero applied.
+
+    The test replays that scenario: partial-valid batch (so the patchability
+    override used to collapse to ``anchor_missing`` under old batch-atomic
+    semantics; findings kept their raw classifier topologies; mixed-topology
+    set tripped the equality gate). With the item 2 loosening, partial-valid
+    batches are ``batch_patch_ok`` and override to ``local_to_prose``, and
+    the ``_has_applicable_review_fix`` belt-and-suspenders predicate covers
+    any residual cases. Result: ``tier=1, strategy="patch"``.
+    """
+    from build.convergence_loop import select_strategy
+
+    # Partial-valid batch: valid anchors for 2 non-plan findings + 1
+    # hallucinated anchor. Under old logic this marked EVERY finding
+    # ``anchor_missing`` (batch-atomic), which suppressed the override and
+    # left classifier topologies in place — the bug trigger.
+    module_content = (
+        "Ukrainian has 32 consonant sounds drawn from 22 **літер** (letters).\n"
+        "Take these openers and farewells as indivisible chunks.\n"
+        "<!-- INJECT_ACTIVITY: quiz-sounds-vs-letters -->\n"
+    )
+    parsed_fixes = (
+        {
+            "find": "Ukrainian has 32 consonant sounds drawn from 22 **літер** (letters).",
+            "replace": "Ukrainian has 32 consonant sounds drawn from 22 consonant **літери** (letters).",
+        },
+        {
+            "find": "<!-- INJECT_ACTIVITY: quiz-sounds-vs-letters -->",
+            "replace": "",
+        },
+        # Hallucinated anchor — reviewer quoted text that is not present.
+        {
+            "find": "этот текст отсутствует в модуле",
+            "replace": "irrelevant",
+        },
+    )
+    # Mixed classifier topologies: one local-to-prose (has "paragraph"),
+    # one activity_order (which the classifier does NOT map to
+    # local_to_prose by default).
+    observation = ReviewObservation(
+        passed=False,
+        score=5.8,
+        review_text="(synthetic)",
+        findings=(
+            _finding(
+                dimension="Factual Accuracy",
+                severity="major",
+                location="## Intro / paragraph 1",
+                issue="Mislabels the consonant-sound count.",
+                fix="Correct the inventory claim.",
+            ),
+            _finding(
+                dimension="Completeness",
+                severity="major",
+                location="INJECT_ACTIVITY marker block",
+                issue="Activity marker order diverges from the contract.",
+                fix="Reorder the activity markers.",
+            ),
+        ),
+        dim_floor_dimensions=(),
+        content_hash="hash-mixed-topo",
+        patch_available=True,
+        parsed_fixes=parsed_fixes,
+        module_content=module_content,
+        reviewer="claude",
+        writer_model_version="gemini-3.1-pro-preview",
+        reviewer_model_version="claude-opus-4-6",
+    )
+    prioritized = prioritize_findings(observation, growth_log_path=None)
+
+    # Precondition: no plan_level findings.
+    assert not any(item.get("plan_level") for item in prioritized)
+
+    decision = select_strategy(
+        observation=observation,
+        prioritized_findings=prioritized,
+        previous_round=None,
+    )
+
+    assert decision.strategy == "patch", (
+        f"mixed-topology observation with partial-valid reviewer fixes must "
+        f"route to patch tier; got strategy={decision.strategy!r} "
+        f"(reason: {decision.reason})"
+    )
+    assert decision.tier == 1
+
+
+def test_plan_level_finding_still_escalates_even_with_valid_fixes() -> None:
+    """Safety rail: a single plan_level finding in the batch forces
+    ``plan_revision_request`` regardless of how many fix anchors validate.
+    ADR-007 keeps the plan-edit path authoritative for genuine plan defects.
+    """
+    from build.convergence_loop import select_strategy
+
+    module_content = "Ukrainian is a separate language with its own history."
+    parsed_fixes = (
+        {
+            "find": "Ukrainian is a separate language with its own history.",
+            "replace": "Ukrainian is a living language with its own literary canon.",
+        },
+    )
+    observation = ReviewObservation(
+        passed=False,
+        score=5.0,
+        review_text="(synthetic)",
+        findings=(
+            _finding(
+                dimension="Plan Adherence",
+                severity="major",
+                location="## whole module",
+                issue="Vocabulary density is too dense for the level contract.",
+                fix="Reduce the vocabulary density per plan.",
+            ),
+        ),
+        dim_floor_dimensions=(),
+        content_hash="hash-plan-level",
+        patch_available=True,
+        parsed_fixes=parsed_fixes,
+        module_content=module_content,
+        reviewer="claude",
+        writer_model_version="gemini-3.1-pro-preview",
+        reviewer_model_version="claude-opus-4-6",
+    )
+    prioritized = prioritize_findings(observation, growth_log_path=None)
+    assert any(item.get("plan_level") for item in prioritized)
+
+    decision = select_strategy(
+        observation=observation,
+        prioritized_findings=prioritized,
+        previous_round=None,
+    )
+    assert decision.strategy == "plan_revision_request"
+    assert decision.tier == 5
+
+
+def test_has_applicable_review_fix_detects_partial_valid_batch() -> None:
+    """GH #1526 item 2 helper: ``_has_applicable_review_fix`` returns True
+    whenever the observation carries ≥1 anchor-valid fix — matching the
+    loosened batch semantics in patchability.py. Partial-valid batches
+    (some invalid anchors in the batch) still return True.
+    """
+    from build.convergence_loop import _has_applicable_review_fix
+
+    content = "the valid anchor lives here"
+    observation_valid = ReviewObservation(
+        passed=False, score=5.0, review_text="",
+        findings=(), dim_floor_dimensions=(), content_hash="h1",
+        patch_available=True,
+        parsed_fixes=(
+            {"find": "the valid anchor", "replace": "replacement"},
+            {"find": "nonexistent anchor", "replace": "x"},  # invalid sibling
+        ),
+        module_content=content,
+    )
+    assert _has_applicable_review_fix(observation_valid) is True
+
+    observation_all_invalid = ReviewObservation(
+        passed=False, score=5.0, review_text="",
+        findings=(), dim_floor_dimensions=(), content_hash="h2",
+        patch_available=True,
+        parsed_fixes=({"find": "ghost anchor", "replace": "x"},),
+        module_content=content,
+    )
+    assert _has_applicable_review_fix(observation_all_invalid) is False
+
+    observation_legacy = ReviewObservation(
+        passed=False, score=5.0, review_text="",
+        findings=(), dim_floor_dimensions=(), content_hash="h3",
+        patch_available=False,
+        # parsed_fixes + module_content default to None — legacy caller path
+    )
+    assert _has_applicable_review_fix(observation_legacy) is False

--- a/tests/test_patchability.py
+++ b/tests/test_patchability.py
@@ -1,4 +1,4 @@
-"""Tests for the validated-patchability predicate (GH #1525 P0).
+"""Tests for the validated-patchability predicate (GH #1525 P0, GH #1526 item 2).
 
 Invariants:
 1. Plan-level findings ALWAYS return ``plan_level_hardstop`` regardless of fixes
@@ -6,10 +6,13 @@ Invariants:
    plan defects.
 2. Legacy callers (no fixes, no content) get ``not_evaluated`` — old heuristic
    path stays intact.
-3. ``batch_patch_ok`` fires only when ALL fixes have anchors present in content.
-   A partial set is ``anchor_missing`` (reviewer saw stale text → don't trust
-   the batch). The status is OBSERVATION-SCOPED (GH #1526 item 1) — it
-   describes the ``<fixes>`` block as a whole, not the individual finding.
+3. ``batch_patch_ok`` fires when AT LEAST ONE fix has a valid anchor (GH #1526
+   item 2 loosening). A partial-valid set used to return ``anchor_missing``
+   — the batch-atomic behavior was black-holing legitimate fixes whenever one
+   unrelated fix had a bad anchor. ``anchor_missing`` is now reserved for the
+   fully-hallucinated case (zero valid anchors). The status is
+   OBSERVATION-SCOPED (GH #1526 item 1) — it describes the ``<fixes>`` block
+   as a whole, not the individual finding.
 4. ``compute_anchor_validation`` runs ONCE per observation; ``classify_patchability``
    consumes the result per finding without rescanning.
 5. Golden fixture derived from a1/sounds-letters-and-hello R1 (the module
@@ -135,10 +138,13 @@ def test_no_fixes_when_reviewer_emitted_empty_block() -> None:
     assert "nothing to patch" in reason
 
 
-# ---------- anchor_missing: stale reviewer text ----------
+# ---------- partial-valid batches still route to patch (GH #1526 item 2) ----------
 
 
-def test_anchor_missing_when_any_fix_anchor_absent() -> None:
+def test_partial_valid_batch_routes_to_patch_ok() -> None:
+    """GH #1526 item 2: at-least-one-valid-anchor flips status to
+    ``batch_patch_ok``. Old batch-atomic semantics returned ``anchor_missing``
+    here, which black-holed the valid fix into plan_revision_request."""
     finding = {"plan_level": False, "error_class": "notation_error"}
     content = "real module content is here"
     fixes = [
@@ -147,9 +153,12 @@ def test_anchor_missing_when_any_fix_anchor_absent() -> None:
     ]
     validation = compute_anchor_validation(fixes, content)
     status, reason = classify_patchability(finding, anchor_validation=validation)
-    assert status == "anchor_missing"
+    assert status == "batch_patch_ok"
     assert "1 of 2" in reason
-    assert "not present in content" in reason
+    assert "invalid anchor" in reason  # the warning note
+
+
+# ---------- anchor_missing: fully hallucinated batch ----------
 
 
 def test_anchor_missing_when_all_fix_anchors_absent() -> None:
@@ -159,7 +168,7 @@ def test_anchor_missing_when_all_fix_anchors_absent() -> None:
     validation = compute_anchor_validation(fixes, content)
     status, reason = classify_patchability(finding, anchor_validation=validation)
     assert status == "anchor_missing"
-    assert "2 of 2" in reason
+    assert "2 fix anchors absent" in reason
 
 
 # ---------- batch_patch_ok: the unlock condition ----------

--- a/tests/test_reviewer_ghost_normalization.py
+++ b/tests/test_reviewer_ghost_normalization.py
@@ -68,16 +68,21 @@ def _observation(
 
 def test_ghost_tagging_separates_ghost_from_hardstop_finding() -> None:
     """Observation with one plan-level finding (hardstop) and one non-plan
-    finding whose fix anchor is missing → only the non-plan finding is a
-    ghost; the plan-level finding keeps its ``plan_level_hardstop`` route
-    and is NOT copied into the ghost tuple. Original ``findings`` list is
-    left unchanged (reviewer emitted both; audit keeps them visible).
+    finding in a partial-valid batch → the non-plan finding routes to
+    ``batch_patch_ok`` (GH #1526 item 2: ≥1 valid anchor unblocks the
+    patch tier), the plan-level finding keeps ``plan_level_hardstop``, and
+    the invalid fix still surfaces as a ghost (so the audit trail captures
+    the reviewer hallucination even though the routing no longer blocks
+    on it). Original ``findings`` list is left unchanged (reviewer emitted
+    both; audit keeps them visible).
     """
     content = "Module prose that contains **мама** → [– • – •] — two sounds."
     # One plan-level finding (vocab_density) + one non-plan (notation_error).
-    # The <fixes> block has one valid anchor + one hallucinated anchor. Under
-    # current batch-level predicate: non-plan finding → anchor_missing (ghost);
-    # plan-level finding → plan_level_hardstop (not ghost).
+    # The <fixes> block has one valid anchor + one hallucinated anchor.
+    # GH #1526 item 2: non-plan finding → batch_patch_ok (partial-valid
+    # batches route to patch); plan-level finding → plan_level_hardstop.
+    # The ghost bundle still captures the invalid fix by iterating invalid
+    # fixes rather than filtering findings.
     findings = (
         _finding(
             dimension="Plan Adherence",
@@ -110,16 +115,18 @@ def test_ghost_tagging_separates_ghost_from_hardstop_finding() -> None:
 
     prioritized = prioritize_findings(observation, growth_log_path=None)
     statuses = {item["dimension"]: item["patchability"] for item in prioritized}
-    # Non-plan → anchor_missing (ghost). Plan-level → plan_level_hardstop.
-    assert statuses["factual_accuracy"] == REVIEWER_GHOST_PATCHABILITY_STATUS
+    # Non-plan → batch_patch_ok (≥1 valid anchor). Plan-level → plan_level_hardstop.
+    assert statuses["factual_accuracy"] == "batch_patch_ok"
     assert statuses["plan_adherence"] == "plan_level_hardstop"
 
     ghosts = collect_reviewer_ghost_findings(observation)
     assert len(ghosts) == 1
     ghost = ghosts[0]
+    # Ghost collection matches the invalid fix back to the non-plan finding —
+    # the plan-level finding is excluded (it has its own hardstop route).
     assert ghost["dimension"] == "factual_accuracy"
     assert ghost["anchor_validation"] == REVIEWER_GHOST_PATCHABILITY_STATUS
-    # reviewer_find_anchor matches one of the invalid fixes' find text.
+    # reviewer_find_anchor matches the invalid fix's find text.
     assert "мама" in ghost["reviewer_find_anchor"]
     assert "two [а] sounds" in ghost["reviewer_find_anchor"]
     # raw_fix is the full invalid fix dict.

--- a/tests/test_v6_review_per_dim.py
+++ b/tests/test_v6_review_per_dim.py
@@ -195,7 +195,10 @@ def test_step_review_fans_out_aggregates_min_and_collects_all_fixes(
     assert aggregate["verdict_score"] == 6.5
     assert aggregate["weighted_average"] > aggregate["verdict_score"]
     assert aggregate["dim_scores"]["language"] == 6.5
-    assert len(aggregate["fixes_applied"]) == 2
+    # GH #1526 item 2: proposed fixes now live under ``fixes_available``;
+    # ``fixes_applied`` starts empty and is populated by the post-apply step.
+    assert len(aggregate["fixes_available"]) == 2
+    assert aggregate["fixes_applied"] == []
 
     for spec in v6_build.REVIEW_DIMENSIONS:
         assert (review_dir / f"{slug}-review-{spec['id']}.yaml").exists()
@@ -249,3 +252,128 @@ def test_review_validation_prefers_aggregate_verdict_score(tmp_path: Path) -> No
     )
     violations = review_validation.check_v6_review_validity(str(module_file), "A1", "sample")
     assert not any(item["type"] == "STRUCTURED_REVIEW_BELOW_THRESHOLD" for item in violations)
+
+
+# ---------- GH #1526 item 2: fixes_applied honesty ----------
+
+
+def _per_dim_result(
+    *,
+    dim_id: str,
+    dim_name: str,
+    score: float,
+    fixes: list[dict] | None = None,
+    findings: list[dict] | None = None,
+) -> v6_build.PerDimensionReviewResult:
+    return v6_build.PerDimensionReviewResult(
+        dimension_id=dim_id,
+        dimension_name=dim_name,
+        score=score,
+        verdict="PASS" if score >= 8.0 else "REVISE",
+        evidence="synthetic evidence",
+        review_text=f"score: {score:.1f}/10\nverdict: {'PASS' if score >= 8.0 else 'REVISE'}",
+        findings=tuple(findings or ()),
+        fixes=tuple(fixes or ()),
+    )
+
+
+def test_aggregate_payload_starts_with_empty_fixes_applied_and_populates_available() -> None:
+    """Regression guard: the aggregate-YAML builder must NOT populate
+    ``fixes_applied`` from the reviewer's proposed fix count. Before GH #1526
+    item 2 the payload field ``fixes_applied`` carried proposed counts, which
+    was a lie because the apply step may not run (convergence escalated to
+    plan_revision_request before ``_apply_review_fixes`` fired) or every fix
+    may be skipped (bad anchors). Now:
+
+      * ``fixes_available`` holds the reviewer's proposed fix counts (truth:
+        these were emitted by the reviewer; applying is a separate step).
+      * ``fixes_applied`` starts as ``[]`` and is populated post-apply by
+        ``_update_aggregate_with_applied_fixes``.
+    """
+    results = [
+        _per_dim_result(
+            dim_id=spec["id"],
+            dim_name=spec["label"],
+            score=9.0 if spec["id"] != "factual" else 6.5,
+            fixes=(
+                [{"find": "x", "replace": "y"}] * 5
+                if spec["id"] == "factual"
+                else []
+            ),
+        )
+        for spec in v6_build.REVIEW_DIMENSIONS
+    ]
+    payload = v6_build._build_review_aggregate_payload(
+        slug="sample",
+        round_num=1,
+        verdict="REVISE",
+        verdict_score=6.5,
+        weighted_average=8.5,
+        results=results,
+        content_filename="sample.md",
+    )
+    # Proposed fixes → fixes_available, not fixes_applied.
+    assert payload["fixes_applied"] == []
+    assert len(payload["fixes_available"]) == 1
+    assert payload["fixes_available"][0]["dim"] == "factual"
+    assert payload["fixes_available"][0]["count"] == 5
+
+
+def test_update_aggregate_with_applied_fixes_rewrites_count_post_apply(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The post-apply helper rewrites ``fixes_applied`` with the real landed
+    count — independent of how many fixes the reviewer proposed in
+    ``fixes_available``. Covers the a1/1 2026-04-24 empirical case:
+    5 proposed, 0 landed (because convergence escalated before apply).
+    """
+    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    level = "a1"
+    slug = "sample"
+    review_dir = curriculum_root / level / "review"
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    initial_payload = {
+        "slug": slug,
+        "round": 1,
+        "verdict": "REVISE",
+        "verdict_score": 6.5,
+        "weighted_average": 8.5,
+        "scores": [],
+        "findings": [],
+        "fixes_available": [{"dim": "factual", "count": 5, "files": ["sample.md"]}],
+        "fixes_applied": [],
+        "passed": False,
+    }
+    dumped = yaml.safe_dump(initial_payload, sort_keys=False, allow_unicode=True)
+    (review_dir / f"{slug}-review-aggregate-r1.yaml").write_text(dumped, "utf-8")
+    (review_dir / f"{slug}-review-aggregate.yaml").write_text(dumped, "utf-8")
+
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+
+    # Case 1: apply landed zero fixes (the a1/1 empirical case).
+    v6_build._update_aggregate_with_applied_fixes(
+        level=level,
+        slug=slug,
+        round_num=1,
+        applied_count=0,
+        content_filename="sample.md",
+    )
+    after_zero = yaml.safe_load((review_dir / f"{slug}-review-aggregate-r1.yaml").read_text("utf-8"))
+    assert after_zero["fixes_applied"] == [{"count": 0, "files": ["sample.md"]}]
+    # fixes_available unchanged — reviewer's proposal count is preserved.
+    assert after_zero["fixes_available"] == [{"dim": "factual", "count": 5, "files": ["sample.md"]}]
+
+    # Case 2: apply landed 3 fixes — honest count lands in fixes_applied.
+    v6_build._update_aggregate_with_applied_fixes(
+        level=level,
+        slug=slug,
+        round_num=1,
+        applied_count=3,
+        content_filename="sample.md",
+    )
+    after_three = yaml.safe_load((review_dir / f"{slug}-review-aggregate-r1.yaml").read_text("utf-8"))
+    assert after_three["fixes_applied"] == [{"count": 3, "files": ["sample.md"]}]
+    # Unversioned alias stays in sync.
+    unversioned = yaml.safe_load((review_dir / f"{slug}-review-aggregate.yaml").read_text("utf-8"))
+    assert unversioned["fixes_applied"] == [{"count": 3, "files": ["sample.md"]}]


### PR DESCRIPTION
## Summary

- Convergence loop was escalating to `plan_revision_request` without ever applying reviewer-emitted deterministic fixes.
- Two joined defects in `scripts/build/convergence_loop.py` + `scripts/build/patchability.py`; a third cosmetic lie in `scripts/build/v6_build.py` (`fixes_applied` aggregate field).
- Empirical trigger: a1/sounds-letters-and-hello 2026-04-24 rebuild — 24 findings across 8 dims, 0 `plan_level=True`, 5 Factual fixes with byte-exact anchors in the module, zero landed.

## The bugs

### 1. Tier-5 escalation ran BEFORE fixes were applied

`convergence_loop.select_strategy` gated the patch tier on exact-set equality:

```python
if observation.patch_available and topologies == {"local_to_prose"}:
```

Any sibling finding with a non-prose classifier topology (e.g. Plan Adherence with a cross-section location) collapsed the whole observation to `plan_revision_request` at tier 5 even when the reviewer emitted anchor-valid `<fixes>` for the non-plan findings. The `_apply_review_fixes` call downstream (`v6_build.py:_patch_round`) never ran because the strategy returned early at `convergence_loop.py:717`.

**Fix:** accept the patch tier when the reviewer emitted ≥1 anchor-valid fix AND no finding is plan-level, regardless of whether non-prose topologies appear in the set. New helper `_has_applicable_review_fix(observation)` consults `validate_fix_anchors` directly — belt-and-suspenders alongside the existing `batch_patch_ok` topology override.

### 2. Batch-atomic anchor validation

`patchability.classify_patchability` treated the `<fixes>` block as atomic:

```python
if anchor_validation.invalid > 0:
    return "anchor_missing", ...
```

One invalid anchor anywhere in the batch marked every non-plan finding `anchor_missing`, suppressing the `batch_patch_ok` topology override and leaving mixed classifier topologies in place — which then tripped bug 1.

**Fix:** loosened to `batch_patch_ok` whenever ≥1 anchor validates. `anchor_missing` is now reserved for the fully-hallucinated case (`valid == 0 AND invalid > 0`). Invalid anchors in partial-valid batches surface via the reviewer-ghost bundle for audit rather than aborting routing.

Ghost collection (`collect_reviewer_ghost_findings`) restructured to iterate over invalid fixes and match each to a non-plan finding via substring heuristic — the old finding-first filter (`patchability == anchor_missing`) no longer works now that partial-valid findings route to `batch_patch_ok`.

### 3. `fixes_applied` aggregate field was a lie

`_build_review_aggregate_payload` populated `fixes_applied` from the reviewer's proposed fix count at review-write time — before the apply step ran (or didn't). On the a1/1 build, the aggregate claimed `fixes_applied.factual.count=5` while zero fixes landed.

**Fix:**
- Renamed to `fixes_available` (truth: these are proposed by the reviewer).
- New `fixes_applied: []` field starts empty.
- New helper `_update_aggregate_with_applied_fixes` rewrites the field after `_apply_review_fixes` runs in both `_patch_round` (convergence path) and `_run_review_heal_loop` (legacy heal path).

## Empirical evidence (from the a1/1 rebuild 2026-04-24 ~23:37 UTC)

- All 5 Factual reviewer `find` strings present byte-exact in `curriculum/l2-uk-en/a1/sounds-letters-and-hello.md`
- Zero of the 5 corresponding `replace` strings present
- `fixes_applied.factual.count=5` claimed in the aggregate YAML
- Terminal: `plan_revision_request` at tier 5, attempt 1, on a review that had 24 findings and zero `plan_level=True`

## Cross-agent consensus

Diagnoses from Codex (bridge msg #447) and Gemini (bridge msg #446) both converge on defect 1. Codex's recommended patch is adopted (with light cleanup), and Gemini's simpler `plan_defect not in topologies` variant was considered but superseded by the explicit `has_plan_level` gate that reads more directly.

## Test plan

- [x] `.venv/bin/ruff check scripts/build/convergence_loop.py scripts/build/patchability.py scripts/build/v6_build.py` — clean
- [x] `.venv/bin/pytest tests/test_convergence_loop.py tests/test_patchability.py tests/test_reviewer_ghost_normalization.py tests/test_v6_review_per_dim.py` — 41 passed
- [x] Pre-commit hooks ran ruff + pytest and both passed
- [x] Full-repo sweep outside modified files: no new failures introduced (50 pre-existing failures are in unrelated modules — morphological_validator, wiki pipeline, agent_runtime, etc.)

### New regression tests

`tests/test_convergence_loop.py`:
- `test_mixed_topology_with_valid_fixes_routes_to_patch_not_plan_revision` — replays the a1/1 scenario (partial-valid batch, mixed topologies, 0 plan_level) → asserts `tier=1, strategy="patch"`.
- `test_plan_level_finding_still_escalates_even_with_valid_fixes` — safety rail: plan-level findings still hardstop to `plan_revision_request` even with clean fix anchors.
- `test_has_applicable_review_fix_detects_partial_valid_batch` — helper contract: True for partial-valid, False for all-invalid or legacy observations.

`tests/test_v6_review_per_dim.py`:
- `test_aggregate_payload_starts_with_empty_fixes_applied_and_populates_available` — pins the `fixes_available` / `fixes_applied` split at payload construction.
- `test_update_aggregate_with_applied_fixes_rewrites_count_post_apply` — pins the post-apply rewrite path for both 0-landed (the a1/1 case) and N-landed cases.

## Explicitly NOT touched

- `scripts/pipeline/vocab_coverage_validator.py` (#1536) — different system
- Writer prompts (`v6-write.md`)
- Reviewer prompts
- `curriculum/l2-uk-en/a1/sounds-letters-and-hello.md` — user manually patched

## References

- #1526 item 2 (this PR)
- #1525 P0 (validated-patchability predicate — item 1 prior)
- #1529 P3 (reviewer-ghost bundle — ghost collection restructured here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)