### PR TITLE
feat(statusline): show effort.level and thinking.enabled (#1542)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ on:
       - 'scripts/**/*.py'
       - 'tests/**/*.py'
       - 'pyproject.toml'
-      - 'claude_extensions/phases/**/*.md'
-      - 'claude_extensions/skills/**/*.md'
-      - 'gemini_extensions/skills/**/*.md'
+      # Widened from per-subdir globs (phases, skills) to the whole tree so
+      # changes to hooks, statusline, rules, commands, etc. also trigger CI
+      # and satisfy the required `Test (pytest)` branch-protection check.
+      # Prior recurrence: #1544 widened for scripts/build/phases/**/*.md,
+      # #1546 widened for claude_extensions/** after statusline PR blocked.
+      - 'claude_extensions/**'
+      - 'gemini_extensions/**'
       - 'scripts/build/phases/**/*.md'
       - 'scripts/build/contracts/**/*.md'
       - 'starlight/**'
@@ -23,9 +27,9 @@ on:
       - 'scripts/**/*.py'
       - 'tests/**/*.py'
       - 'pyproject.toml'
-      - 'claude_extensions/phases/**/*.md'
-      - 'claude_extensions/skills/**/*.md'
-      - 'gemini_extensions/skills/**/*.md'
+      # See note on `push:` above — widened 2026-04-24 (#1546).
+      - 'claude_extensions/**'
+      - 'gemini_extensions/**'
       - 'scripts/build/phases/**/*.md'
       - 'scripts/build/contracts/**/*.md'
       - 'starlight/**'

--- a/claude_extensions/statusline/statusline.sh
+++ b/claude_extensions/statusline/statusline.sh
@@ -2,7 +2,8 @@
 # Claude Code statusline — learn-ukrainian project.
 #
 # Reads Claude Code status JSON from stdin and renders:
-#   [MODEL] cwd-basename [wt:worktree-name] (branch*) [ctx: N%] [5h: N%] [7d: N%]
+#   [MODEL] cwd-basename [wt:worktree-name] (branch*) [ctx: N%]
+#   [effort: level] [think] [5h: N%] [7d: N%]
 #
 # Segments:
 #   [MODEL]        .model.display_name, omitted if missing
@@ -12,6 +13,10 @@
 #   [ctx: N%]      .context_window.used_percentage — color-coded:
 #                    green <50, yellow 50–79, red 80+. Omitted until the
 #                    first API call populates the field.
+#   [effort: ...]  .effort.level — low/medium default, high/xhigh bold,
+#                    max red. Omitted for pre-2.1.119 clients.
+#   [think]        .thinking.enabled — emitted only when true. Omitted for
+#                    pre-2.1.119 clients.
 #   [5h: N%]       .rate_limits.five_hour.used_percentage — subscription
 #                    budget. Only shown when elevated (60%+ yellow, 80%+ red).
 #                    Stays silent while healthy — no noise in normal use.
@@ -28,6 +33,8 @@
 # Graceful degradation:
 #   - If `jq` is not installed, script exits silently (empty status line).
 #   - Any missing / null JSON field is dropped from output silently.
+#   - Claude Code <2.1.119 does not provide effort/thinking fields; those
+#     segments are omitted silently.
 #   - If any git op fails, branch segment is omitted.
 #
 # Design notes:
@@ -44,7 +51,7 @@ set -u
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-input=$(cat)
+input=$(</dev/stdin)
 # printf '%s' "$input" > /tmp/.statusline-input.json  # debug
 
 json_get() {
@@ -89,6 +96,22 @@ if [ -n "$ctx_pct" ]; then
   fi
 fi
 
+# Effort level
+effort_seg=""
+effort_level=$(json_get '.effort.level')
+if [ -n "$effort_level" ]; then
+  case "$effort_level" in
+    high|xhigh) effort_seg="\033[1m[effort: ${effort_level}]\033[0m" ;;
+    max)        effort_seg="\033[31m[effort: ${effort_level}]\033[0m" ;;
+    *)          effort_seg="[effort: ${effort_level}]" ;;
+  esac
+fi
+
+# Thinking mode
+thinking_seg=""
+thinking_enabled=$(json_get '.thinking.enabled')
+[ "$thinking_enabled" = "true" ] && thinking_seg="[think]"
+
 # Rate-limit segment helper — only surface when elevated (60%+).
 # Accepts a label (e.g. "5h", "7d") and a jq path, returns coloured
 # segment on stdout or empty string.
@@ -113,6 +136,8 @@ parts+=("$cwd_name")
 [ -n "$wt_seg" ]     && parts+=("$wt_seg")
 [ -n "$branch_seg" ] && parts+=("$branch_seg")
 [ -n "$ctx_seg" ]    && parts+=("$ctx_seg")
+[ -n "$effort_seg" ] && parts+=("$effort_seg")
+[ -n "$thinking_seg" ] && parts+=("$thinking_seg")
 [ -n "$rl5h_seg" ]   && parts+=("$rl5h_seg")
 [ -n "$rl7d_seg" ]   && parts+=("$rl7d_seg")
 


### PR DESCRIPTION
## Summary
- Adds `[effort: <level>]` and `[think]` segments to the statusline
- Colouring: low/medium default, high/xhigh bold, max red
- Thinking segment emitted only when `.thinking.enabled=true`
- Graceful degradation on CC <2.1.119 (missing fields → segments omitted)

## Test plan (manual, bash-only — no pytest target for statusline.sh)

- [x] `bash -n` — no syntax errors
- [x] Mock JSON with fields → segments render
- [x] Mock JSON without fields → segments omitted, exit 0
- [x] PATH without jq → exit 0 silently

Sample outputs:

Mock JSON with fields (`cat -v`):
```text
[Opus 4.7] tmp ^[[32m[ctx: 42%]^[[0m ^[[1m[effort: xhigh]^[[0m [think]
```

Mock JSON without fields (`cat -v`):
```text
[Opus 4.7] tmp ^[[32m[ctx: 42%]^[[0m
```

PATH without jq (`PATH=/bin /bin/bash claude_extensions/statusline/statusline.sh < /dev/null | cat -v`):
```text

```

Note: on this macOS worktree, `/usr/bin/jq` exists, so `PATH=/bin` was used to make the missing-jq check actually exercise the no-jq branch.

Closes #1542.