### PR TITLE
feat(monitor-api): /api/git/cleanup endpoint (#1395)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1570,6 +1570,79 @@ Response:
 }
 ```
 
+### Git cleanup (`GET /api/git/cleanup`)
+
+Read-only git rot report for stale local branches and worktrees that are
+safe candidates for manual removal. The endpoint only classifies state;
+it never runs `git branch -d`, `git worktree remove`, `rm`, or any other
+destructive cleanup command.
+
+```bash
+curl -s http://localhost:8765/api/git/cleanup | python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+  "stale_branches": [
+    {
+      "name": "codex/1234-old-branch",
+      "upstream_gone": true,
+      "fully_merged_to_main": false,
+      "last_commit_sha": "abc1234",
+      "last_commit_date": "2026-04-12T14:22:00Z",
+      "committer": "Codex Worker"
+    }
+  ],
+  "removable_worktrees": [
+    {
+      "path": ".worktrees/dispatch/codex/foo",
+      "branch": "codex/foo",
+      "clean": true,
+      "upstream_gone": true,
+      "fully_merged_to_main": false,
+      "disk_bytes": 240000000,
+      "reason": "upstream gone, working tree clean"
+    }
+  ],
+  "protected_worktrees": [
+    {
+      "path": "/Users/you/projects/learn-ukrainian",
+      "branch": "main",
+      "reason": "primary checkout"
+    },
+    {
+      "path": ".worktrees/codex-interactive",
+      "branch": "(detached HEAD)",
+      "reason": "interactive session (contains 'interactive' in path)"
+    }
+  ],
+  "total_reclaimable_bytes": 1234567890,
+  "computed_at": "2026-04-25T00:15:30Z",
+  "performance_ms": 342.5
+}
+```
+
+Branch classification:
+
+- A local branch is stale when its upstream tracking branch is gone, or
+  when all commits are already present on `main`.
+- `main`, `origin/*`, and branches currently checked out in any worktree
+  are never returned in `stale_branches`.
+
+Worktree classification:
+
+- A worktree is removable only when its branch is merged to `main` or
+  has a gone upstream, `git status --porcelain` is empty in that
+  worktree, and no protection rule applies.
+- Protected worktrees are the primary checkout, paths containing
+  `interactive`, and active dispatch worktrees under
+  `.worktrees/dispatch/**` whose `batch_state/tasks/*.json` state has
+  `status: "running"`.
+- `disk_bytes` comes from portable `du -sk` output. If `du` cannot read
+  a worktree, `disk_bytes` is `null` and the total ignores that entry.
+
 ### Force-preview — `GET /api/artifacts/{track}/{slug}/force-preview`
 
 Exact list of files `v6_build.py {track} {num} --force` would delete,

--- a/scripts/api/git_hygiene_router.py
+++ b/scripts/api/git_hygiene_router.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import json
 import os
 import shlex
 import subprocess
@@ -27,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 from .config import PROJECT_ROOT
 
@@ -47,6 +49,34 @@ BUCKET_NAMES = (
 
 _GIT_TIMEOUT_S = 2.0
 _GIT_ENV_KEYS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_COMMON_DIR")
+
+
+class StaleBranch(BaseModel):
+    name: str
+    upstream_gone: bool
+    fully_merged_to_main: bool
+    last_commit_sha: str
+    last_commit_date: str
+    committer: str
+
+
+class Worktree(BaseModel):
+    path: str
+    branch: str
+    clean: bool | None = None
+    upstream_gone: bool | None = None
+    fully_merged_to_main: bool | None = None
+    disk_bytes: int | None = None
+    reason: str
+
+
+class CleanupReport(BaseModel):
+    stale_branches: list[StaleBranch]
+    removable_worktrees: list[Worktree]
+    protected_worktrees: list[Worktree]
+    total_reclaimable_bytes: int
+    computed_at: str
+    performance_ms: float
 
 
 def _git_invocation(args: list[str], cwd: Path) -> list[str]:
@@ -110,6 +140,261 @@ def _run_git(
 
 def _isoformat_z(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _list_local_branches(cwd: Path) -> list[dict[str, Any]]:
+    code, stdout, _stderr = _run_git(
+        [
+            "for-each-ref",
+            "--format=%(refname:short)%00%(upstream:short)%00%(upstream:track)"
+            "%00%(objectname:short)%00%(committerdate:unix)%00%(committername)",
+            "refs/heads",
+        ],
+        cwd=cwd,
+    )
+    if code != 0:
+        return []
+
+    branches: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        parts = line.split("\x00")
+        if len(parts) != 6:
+            continue
+        name, upstream, upstream_track, sha, timestamp, committer = parts
+        try:
+            committed_at = datetime.fromtimestamp(int(timestamp), UTC)
+            last_commit_date = _isoformat_z(committed_at)
+        except (OSError, ValueError):
+            last_commit_date = ""
+        branches.append({
+            "name": name,
+            "upstream_gone": bool(upstream and "gone" in upstream_track.lower()),
+            "last_commit_sha": sha,
+            "last_commit_date": last_commit_date,
+            "committer": committer,
+        })
+    return branches
+
+
+def _list_worktrees(cwd: Path) -> list[dict[str, Any]]:
+    code, stdout, _stderr = _run_git(["worktree", "list", "--porcelain"], cwd=cwd)
+    if code != 0:
+        return []
+
+    worktrees: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for line in stdout.splitlines():
+        if not line.strip():
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            current["path"] = value
+        elif key == "HEAD":
+            current["head"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key == "detached":
+            current["branch"] = "(detached HEAD)"
+            current["detached"] = True
+        elif key in {"locked", "prunable"}:
+            current[key] = value or True
+
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+def _is_branch_merged_to_main(branch: str, cwd: Path) -> bool:
+    code, stdout, _stderr = _run_git(["cherry", "main", branch], cwd=cwd)
+    if code == 0:
+        lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+        return all(line.startswith("-") for line in lines)
+
+    code, stdout, _stderr = _run_git(["branch", "--merged", "main", "--format=%(refname:short)"], cwd=cwd)
+    if code != 0:
+        return False
+    return branch in {line.strip() for line in stdout.splitlines() if line.strip()}
+
+
+def _is_worktree_clean(path: Path, cwd: Path) -> bool:
+    del cwd
+    code, stdout, _stderr = _run_git(["status", "--porcelain"], cwd=path)
+    return code == 0 and not stdout.strip()
+
+
+def _disk_bytes(path: Path) -> int | None:
+    try:
+        proc = subprocess.run(
+            ["du", "-sk", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    first = proc.stdout.split(maxsplit=1)[0] if proc.stdout.split() else ""
+    try:
+        return int(first) * 1024
+    except ValueError:
+        return None
+
+
+def _active_task_ids(project_root: Path | None = None) -> set[str]:
+    tasks_dir = (project_root or PROJECT_ROOT) / "batch_state" / "tasks"
+    active: set[str] = set()
+    try:
+        task_files = list(tasks_dir.glob("*.json"))
+    except OSError:
+        return active
+
+    for path in task_files:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if payload.get("status") != "running":
+            continue
+        active.add(path.stem)
+        task_id = payload.get("task_id")
+        if isinstance(task_id, str) and task_id:
+            active.add(task_id)
+    return active
+
+
+def _is_protected(
+    path: Path,
+    branch: str,
+    active_task_ids: set[str],
+    project_root: Path | None = None,
+) -> tuple[bool, str | None]:
+    root = project_root or PROJECT_ROOT
+    try:
+        if path.resolve() == root.resolve():
+            return True, "primary checkout"
+    except OSError:
+        pass
+
+    normalized = path.as_posix()
+    if "interactive" in normalized:
+        return True, "interactive session (contains 'interactive' in path)"
+
+    parts = path.parts
+    for idx in range(len(parts) - 2):
+        if parts[idx] == ".worktrees" and parts[idx + 1] == "dispatch":
+            task_id = parts[idx + 3] if len(parts) > idx + 3 else path.name
+            if task_id in active_task_ids or path.name in active_task_ids:
+                return True, "active dispatch (matches .worktrees/dispatch/**)"
+    return False, None
+
+
+def _display_worktree_path(path: Path, project_root: Path) -> str:
+    try:
+        if path.resolve() == project_root.resolve():
+            return str(path)
+    except OSError:
+        pass
+    try:
+        return path.relative_to(project_root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _worktree_reason(upstream_gone: bool, fully_merged_to_main: bool, clean: bool) -> str:
+    reasons: list[str] = []
+    if upstream_gone:
+        reasons.append("upstream gone")
+    if fully_merged_to_main:
+        reasons.append("fully merged to main")
+    if clean:
+        reasons.append("working tree clean")
+    return ", ".join(reasons)
+
+
+def compute_git_cleanup(project_root: Path | None = None) -> CleanupReport:
+    if project_root is None:
+        project_root = PROJECT_ROOT
+
+    started = time.perf_counter()
+    computed_at = _isoformat_z(datetime.now(UTC))
+    branches = _list_local_branches(project_root)
+    worktrees = _list_worktrees(project_root)
+    checked_out_branches = {
+        record["branch"]
+        for record in worktrees
+        if record.get("branch") and record.get("branch") != "(detached HEAD)"
+    }
+
+    branch_state: dict[str, dict[str, Any]] = {}
+    stale_branches: list[StaleBranch] = []
+    for branch in branches:
+        name = branch["name"]
+        fully_merged = _is_branch_merged_to_main(name, project_root)
+        state = {**branch, "fully_merged_to_main": fully_merged}
+        branch_state[name] = state
+
+        if name == "main" or name.startswith("origin/") or name in checked_out_branches:
+            continue
+        if branch["upstream_gone"] or fully_merged:
+            stale_branches.append(StaleBranch(**state))
+
+    active_task_ids = _active_task_ids(project_root)
+    removable_worktrees: list[Worktree] = []
+    protected_worktrees: list[Worktree] = []
+    for record in worktrees:
+        raw_path = record.get("path")
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        branch = record.get("branch") or "(detached HEAD)"
+        display_path = _display_worktree_path(path, project_root)
+
+        protected, reason = _is_protected(path, branch, active_task_ids, project_root)
+        if protected:
+            protected_worktrees.append(Worktree(path=display_path, branch=branch, reason=reason or "protected"))
+            continue
+
+        state = branch_state.get(branch)
+        if state is None:
+            continue
+        upstream_gone = bool(state["upstream_gone"])
+        fully_merged = bool(state["fully_merged_to_main"])
+        if not (upstream_gone or fully_merged):
+            continue
+        clean = _is_worktree_clean(path, project_root)
+        if not clean:
+            continue
+
+        disk_bytes = _disk_bytes(path)
+        removable_worktrees.append(
+            Worktree(
+                path=display_path,
+                branch=branch,
+                clean=clean,
+                upstream_gone=upstream_gone,
+                fully_merged_to_main=fully_merged,
+                disk_bytes=disk_bytes,
+                reason=_worktree_reason(upstream_gone, fully_merged, clean),
+            )
+        )
+
+    total_reclaimable_bytes = sum(
+        item.disk_bytes for item in removable_worktrees if item.disk_bytes is not None
+    )
+    return CleanupReport(
+        stale_branches=stale_branches,
+        removable_worktrees=removable_worktrees,
+        protected_worktrees=protected_worktrees,
+        total_reclaimable_bytes=total_reclaimable_bytes,
+        computed_at=computed_at,
+        performance_ms=round((time.perf_counter() - started) * 1000, 2),
+    )
 
 
 def _parse_status(stdout: str) -> list[StatusEntry]:
@@ -446,3 +731,9 @@ def compute_git_hygiene(project_root: Path | None = None) -> dict[str, Any]:
 async def git_hygiene():
     """Classify current working-tree drift into actionable buckets."""
     return await asyncio.to_thread(compute_git_hygiene)
+
+
+@router.get("/cleanup", response_model=CleanupReport, response_model_exclude_none=True)
+async def git_cleanup() -> CleanupReport:
+    """Classify stale branches and removable worktrees without changing git state."""
+    return await asyncio.to_thread(compute_git_cleanup)

--- a/tests/test_git_cleanup_router.py
+++ b/tests/test_git_cleanup_router.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.api import git_hygiene_router
+from scripts.api.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_COMMON_DIR"):
+        env.pop(key, None)
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        env=env,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+
+
+def _create_branch(repo: Path, branch: str, filename: str) -> None:
+    _git(repo, "checkout", "-b", branch, "main")
+    _write(repo / filename, f"{branch}\n")
+    _commit_all(repo, f"add {branch}")
+    _git(repo, "checkout", "main")
+
+
+def _create_merged_branch(repo: Path, branch: str, filename: str) -> None:
+    _create_branch(repo, branch, filename)
+    _git(repo, "cherry-pick", branch)
+
+
+def _create_upstream_gone_branch(repo: Path, branch: str, filename: str) -> None:
+    _create_branch(repo, branch, filename)
+    _git(repo, "checkout", branch)
+    _git(repo, "push", "-u", "origin", branch)
+    _git(repo, "checkout", "main")
+    _git(repo, "push", "origin", "--delete", branch)
+
+
+def _add_worktree(repo: Path, path: Path, branch: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(repo, "worktree", "add", str(path), branch)
+
+
+def _cleanup_fixture(tmp_path: Path, monkeypatch) -> Path:
+    repo = tmp_path / "repo"
+    remote = tmp_path / "origin.git"
+    repo.mkdir()
+    remote.mkdir()
+    _git(remote, "init", "--bare")
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "codex@example.invalid")
+    _git(repo, "config", "user.name", "Codex Test")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _write(repo / ".gitignore", ".worktrees/\nbatch_state/\n")
+    _write(repo / "README.md", "base\n")
+    _commit_all(repo, "initial")
+    _git(repo, "push", "-u", "origin", "main")
+
+    _create_upstream_gone_branch(repo, "codex/upstream-gone", "branches/upstream-gone.txt")
+    _create_merged_branch(repo, "codex/merged-stale", "branches/merged-stale.txt")
+
+    _create_merged_branch(repo, "codex/removable-merged", "branches/removable-merged.txt")
+    _add_worktree(repo, repo / ".worktrees" / "removable-merged", "codex/removable-merged")
+
+    _create_upstream_gone_branch(repo, "codex/dirty-gone", "branches/dirty-gone.txt")
+    _add_worktree(repo, repo / ".worktrees" / "dirty-gone", "codex/dirty-gone")
+    _write(repo / ".worktrees" / "dirty-gone" / "local.txt", "dirty\n")
+
+    _create_merged_branch(repo, "codex/interactive-merged", "branches/interactive-merged.txt")
+    _add_worktree(repo, repo / ".worktrees" / "codex-interactive", "codex/interactive-merged")
+
+    _create_merged_branch(repo, "codex/active-dispatch-merged", "branches/active-dispatch.txt")
+    _add_worktree(
+        repo,
+        repo / ".worktrees" / "dispatch" / "codex" / "1526-item2-anchor-parity",
+        "codex/active-dispatch-merged",
+    )
+    _write(
+        repo / "batch_state" / "tasks" / "1526-item2-anchor-parity.json",
+        json.dumps({"task_id": "1526-item2-anchor-parity", "status": "running"}),
+    )
+
+    monkeypatch.setattr(git_hygiene_router, "PROJECT_ROOT", repo)
+    return repo
+
+
+def _report(tmp_path: Path, monkeypatch):
+    repo = _cleanup_fixture(tmp_path, monkeypatch)
+    return git_hygiene_router.compute_git_cleanup(repo)
+
+
+def test_stale_branch_upstream_gone(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    stale = {branch.name: branch for branch in result.stale_branches}
+    assert stale["codex/upstream-gone"].upstream_gone is True
+
+
+def test_stale_branch_merged_to_main(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    stale = {branch.name: branch for branch in result.stale_branches}
+    assert stale["codex/merged-stale"].fully_merged_to_main is True
+
+
+def test_checked_out_branch_not_stale(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    stale_names = {branch.name for branch in result.stale_branches}
+    assert "codex/removable-merged" not in stale_names
+    assert "codex/dirty-gone" not in stale_names
+
+
+def test_main_never_stale(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    assert "main" not in {branch.name for branch in result.stale_branches}
+
+
+def test_clean_merged_worktree_is_removable(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    removable = {worktree.branch: worktree for worktree in result.removable_worktrees}
+    assert removable["codex/removable-merged"].clean is True
+    assert removable["codex/removable-merged"].fully_merged_to_main is True
+
+
+def test_dirty_worktree_not_removable(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    assert "codex/dirty-gone" not in {worktree.branch for worktree in result.removable_worktrees}
+
+
+def test_interactive_worktree_is_protected(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    protected = {worktree.branch: worktree for worktree in result.protected_worktrees}
+    assert protected["codex/interactive-merged"].reason == "interactive session (contains 'interactive' in path)"
+    assert "codex/interactive-merged" not in {worktree.branch for worktree in result.removable_worktrees}
+
+
+def test_active_dispatch_worktree_is_protected(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    protected = {worktree.branch: worktree for worktree in result.protected_worktrees}
+    assert protected["codex/active-dispatch-merged"].reason == "active dispatch (matches .worktrees/dispatch/**)"
+    assert "codex/active-dispatch-merged" not in {worktree.branch for worktree in result.removable_worktrees}
+
+
+def test_total_reclaimable_sums_correctly(tmp_path: Path, monkeypatch) -> None:
+    result = _report(tmp_path, monkeypatch)
+
+    expected = sum(
+        worktree.disk_bytes for worktree in result.removable_worktrees if worktree.disk_bytes is not None
+    )
+    assert result.total_reclaimable_bytes == expected
+
+
+def test_endpoint_performance_under_budget(tmp_path: Path, monkeypatch) -> None:
+    _cleanup_fixture(tmp_path, monkeypatch)
+
+    response = client.get("/api/git/cleanup")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {
+        "stale_branches",
+        "removable_worktrees",
+        "protected_worktrees",
+        "total_reclaimable_bytes",
+        "computed_at",
+        "performance_ms",
+    }
+    assert body["performance_ms"] < 500


### PR DESCRIPTION
## Summary
- New read-only endpoint `GET /api/git/cleanup` classifying stale branches + removable worktrees
- Protection rules: primary checkout, `*interactive*` worktrees, active-dispatch worktrees (via `batch_state/tasks/*.json status=running`)
- Extends existing `scripts/api/git_hygiene_router.py` — shares helpers, does NOT change `/api/git/hygiene`

## Test plan
- [x] `.venv/bin/pytest tests/test_git_cleanup_router.py -v` — 10 passed
- [x] `.venv/bin/ruff check` — clean
- [x] Smoke against live repo: `curl -s http://localhost:8765/api/git/cleanup | jq .performance_ms` — returns in <500ms on current state

Smoke output:
139.9

Closes #1395.