### PR TITLE
feat(governance): postmortem validator + INDEX automation (#1522)

### DIFF
--- a/claude_extensions/hooks/session-setup.sh
+++ b/claude_extensions/hooks/session-setup.sh
@@ -127,6 +127,15 @@ if [ -f "$PROJECT_DIR/.venv/bin/python" ] && [ -f "$PROJECT_DIR/scripts/audit/ch
   fi
 fi
 
+# 10c. Check postmortem hygiene (sister to decisions + ADRs). Process:
+# docs/best-practices/postmortem-management.md.
+if [ -f "$PROJECT_DIR/.venv/bin/python" ] && [ -f "$PROJECT_DIR/scripts/audit/check_postmortems.py" ]; then
+  POSTMORTEM_REPORT=$("$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/scripts/audit/check_postmortems.py" --quiet 2>/dev/null)
+  if [ -n "$POSTMORTEM_REPORT" ]; then
+    ISSUES+=("Postmortem hygiene: $POSTMORTEM_REPORT — see docs/best-practices/postmortem-management.md")
+  fi
+fi
+
 # 11. Open GH issues summary
 if command -v gh >/dev/null 2>&1; then
   OPEN_ISSUES=$(gh issue list --state open --json number,title,labels --limit 10 2>/dev/null)

--- a/docs/best-practices/postmortem-management.md
+++ b/docs/best-practices/postmortem-management.md
@@ -1,0 +1,241 @@
+# Postmortem Management
+
+Sister doc to [`adr-management.md`](adr-management.md) and
+[`decision-journal.md`](decision-journal.md). Decisions record temporary policy.
+ADRs record durable architecture. Postmortems record bugs that taught us
+something expensive enough that the next engineer should not rediscover it.
+
+## The split
+
+| Question | Where it goes |
+|---|---|
+| "What is our current policy on X?" — might change in 90 days | **Decision** in `docs/decisions/decisions.yaml` |
+| "Why does the code look this way?" — permanent structural choice | **ADR** in `docs/architecture/adr/` |
+| "Why did this specific bug happen and how do we stop a repeat?" | **Postmortem** in `docs/bug-autopsies/` |
+
+If you are deciding what to do next, write a decision. If you are explaining a
+structural choice, write an ADR. If production or the build pipeline already
+failed and you found the class of failure, write a postmortem.
+
+## When to write a postmortem
+
+Write a postmortem when the bug is likely to recur or when the debugging path
+was expensive enough to preserve.
+
+Strong signals:
+
+- The bug was architectural: cache invalidation, prompt contract drift,
+  review/build loop behavior, indexing, persistence, or orchestration state.
+- The bug broke production output, publishing, review gates, CI, or the local
+  development loop.
+- The same category has already happened once before.
+- The fix required more than 30 minutes of diagnosis.
+- The root cause was not obvious from the final code diff.
+- The prevention belongs in a test, hook, invariant, or written process.
+
+Do not write a postmortem for:
+
+- Typos.
+- One-line syntax errors.
+- Formatting-only fixes.
+- Broken local commands where the only lesson is "run the right command."
+- Flaky model output that has no actionable prevention.
+- Trivial dependency bumps with no system lesson.
+
+The threshold is not blame and not drama. The threshold is whether the record
+will save a future engineer from repeating the same investigation.
+
+## Required fields
+
+Every new postmortem must include these four fields:
+
+- **Symptom** — what broke, from the user's or operator's point of view.
+- **Root cause** — the underlying bug, design flaw, missing invariant, or
+  mismatch that made the symptom possible.
+- **Prevention** — what stops this category from recurring.
+- **Links** — at minimum the GitHub issue and the commit SHA that shipped the
+  fix.
+
+Historical files in `docs/bug-autopsies/` use a few older variants such as
+`What Broke`, `Why`, `Files Changed`, and `See also`. The checker accepts those
+so we do not spend a PR doing mechanical backfill. New files should use the
+template below.
+
+## Template
+
+```markdown
+# Bug Autopsy: {short title}
+
+## Symptom
+
+What broke? Write this in observable terms:
+
+- What did the user, builder, reviewer, or CI job see?
+- Which command, issue, module, or workflow exposed it?
+- What made the failure confusing or expensive?
+
+## Root cause
+
+Why did it happen?
+
+- Name the code path, prompt, config, or process that caused it.
+- Distinguish the trigger from the underlying design flaw.
+- Include file paths and function names when they matter.
+
+## Fix
+
+What changed?
+
+- Summarize the implementation.
+- Link the test, hook, or invariant added with the fix.
+- Call out anything intentionally left out of scope.
+
+## Prevention
+
+What stops this class of bug from coming back?
+
+- A regression test.
+- A pre-commit or SessionStart check.
+- A schema or manifest invariant.
+- A documented operating rule only when automation is not practical.
+
+## Links
+
+- Issue: #{issue-number}
+- Fix: {commit-sha}
+- PR: #{pr-number}
+```
+
+One page is better than five. A postmortem should preserve the debug lesson,
+not replay the entire debugging session.
+
+## Lifecycle
+
+```
+[ bug diagnosed ] ──► [ write postmortem ] ──► [ reference from fix commit ]
+                                                   │
+                                                   └──► [ INDEX.md updated ]
+```
+
+### Written
+
+Write the postmortem while the failure is still fresh. The useful details are
+the first ones to disappear: exact symptom wording, misleading hypotheses,
+hidden assumptions, and the concrete invariant that would have caught it.
+
+The postmortem can be committed with the fix when the prevention is clear. If
+the bug is still under investigation, write a draft in the PR body or issue
+first, then land the durable version when the fix ships.
+
+### Referenced
+
+The fix commit or PR should reference the postmortem. That gives future readers
+two paths:
+
+- From code to context: the commit explains why the invariant exists.
+- From context to code: the postmortem links to the shipped fix.
+
+Do not rely on chat history as the only explanation. Chat is useful during the
+incident and poor as an archive.
+
+### Closed
+
+A postmortem is closed when:
+
+- The fix has shipped.
+- The prevention exists or the postmortem explicitly explains why prevention is
+  procedural.
+- The `docs/bug-autopsies/INDEX.md` entry exists.
+- `scripts/audit/check_postmortems.py` passes.
+
+The index is regenerated by the checker. Do not hand-sort the table.
+
+## Index
+
+`docs/bug-autopsies/INDEX.md` is the quick lookup surface. It is intentionally
+short: date, issue, category, summary. The detail belongs in the individual
+postmortem file.
+
+The checker owns the content between:
+
+```markdown
+<!-- INDEX-START -->
+...
+<!-- INDEX-END -->
+```
+
+Everything outside those sentinels is hand-written context and must be
+preserved verbatim. If the checker changes prose outside the sentinel block,
+that is a bug in the checker.
+
+## Automation
+
+Script: `scripts/audit/check_postmortems.py`.
+
+Default mode validates all `docs/bug-autopsies/*.md` files except `INDEX.md`.
+If validation passes, it regenerates the index table. Validation failures exit
+with code `1`.
+
+### `--quiet`
+
+SessionStart uses quiet mode:
+
+```bash
+.venv/bin/python -m scripts.audit.check_postmortems --quiet
+```
+
+Quiet mode prints nothing on success. On failure it prints only the specific
+errors, one per line, so the hook can surface the problem without dumping a
+full report into every session.
+
+### `--regenerate-index`
+
+Use this when you want to refresh `INDEX.md` even while a draft postmortem is
+still missing required fields:
+
+```bash
+.venv/bin/python -m scripts.audit.check_postmortems --regenerate-index
+```
+
+The exit code still reflects validation status. Regeneration is not a way to
+hide an incomplete postmortem.
+
+## SessionStart integration
+
+`claude_extensions/hooks/session-setup.sh` runs the checker alongside decision
+and ADR hygiene checks:
+
+- Decisions first.
+- ADRs second.
+- Postmortems third.
+
+Clean postmortems are silent. Missing required fields are surfaced as session
+issues with a pointer back to this policy.
+
+## Anti-patterns
+
+- **Blame assignment** — The postmortem is about the system property that let
+  the bug happen. "Agent did something dumb" is not a root cause.
+- **"Shouldn't have done that" lectures** — Prevention must be concrete. Add a
+  test, hook, schema check, or documented threshold.
+- **Missing prevention** — A postmortem without prevention is just a story.
+- **Confusing trigger with root cause** — "PR #123 changed X" may be the
+  trigger. The root cause is the missing invariant that allowed X to break Y.
+- **Hand-editing the index table** — Run the checker and review the generated
+  diff.
+- **Writing a postmortem for every bug** — This creates noise. Use the threshold.
+- **Burying links in prose** — Put issue and commit links in `## Links` so the
+  checker and future readers can find them.
+
+## Rule of thumb
+
+If the fix taught you a reusable debugging lesson, write the postmortem. If the
+only lesson is "be more careful," do not write one until you can name the
+mechanism that would have made care unnecessary.
+
+---
+
+*Codified 2026-04-24 after postmortem governance was identified as the missing
+third automation surface. Accompanying automation:
+`scripts/audit/check_postmortems.py`. Wired into SessionStart via
+`claude_extensions/hooks/session-setup.sh`.*

--- a/docs/bug-autopsies/INDEX.md
+++ b/docs/bug-autopsies/INDEX.md
@@ -2,6 +2,7 @@
 
 One-liner per bug. Grep for symptoms or categories to find relevant detail files.
 
+<!-- INDEX-START -->
 | Date | Issue | Category | Summary |
 |------|-------|----------|---------|
 | 2026-04-05 | #1150 | score-parsing | Wiki review loop stuck at 8/10 — regex `(\d+)` can't match decimal scores like `8.8/10` |
@@ -12,3 +13,4 @@ One-liner per bug. Grep for symptoms or categories to find relevant detail files
 | 2026-04-23 | EPIC | alignment-contracts | Sidecar cache reuse without hash check (`v6_build.py:3207`) — stale contract.yaml/wiki-excerpts.yaml silently consumed after plan/template/tokenizer change |
 | 2026-04-23 | EPIC | alignment-contracts | `module_memory` sources_hash updated silently — corpus/rule changes land but old learned constraints persist (`module_memory.py:293-316`) |
 | 2026-04-23 | EPIC | alignment-contracts | Rule-after-incident governance pattern — rules added post-incident are advisory, not CI-enforced; live contradiction between "no-rewrite" decision and `convergence_loop.py` rewrite strategies |
+<!-- INDEX-END -->

--- a/scripts/audit/check_postmortems.py
+++ b/scripts/audit/check_postmortems.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Validate bug postmortems and keep their index current.
+
+Postmortems live at ``docs/bug-autopsies/``. This script validates the
+minimum fields that make an autopsy useful and regenerates the INDEX.md
+table between sentinel markers.
+
+Usage:
+    .venv/bin/python -m scripts.audit.check_postmortems
+    .venv/bin/python -m scripts.audit.check_postmortems --quiet
+    .venv/bin/python -m scripts.audit.check_postmortems --regenerate-index
+
+Exit codes:
+    0 = clean
+    1 = validation errors
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+POSTMORTEM_DIR = PROJECT_ROOT / "docs" / "bug-autopsies"
+INDEX_PATH = POSTMORTEM_DIR / "INDEX.md"
+
+INDEX_START = "<!-- INDEX-START -->"
+INDEX_END = "<!-- INDEX-END -->"
+TABLE_HEADER = "| Date | Issue | Category | Summary |\n|------|-------|----------|---------|"
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+TITLE_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+DATE_LINE_RE = re.compile(r"^\*\*Date:\*\*\s*(.+?)\s*$", re.MULTILINE)
+ISSUE_LINE_RE = re.compile(r"^\*\*Issue:\*\*\s*(.+?)\s*$", re.MULTILINE)
+ISSUE_REF_RE = re.compile(r"(?:#\d+|github\.com/[^/\s]+/[^/\s]+/issues/\d+)")
+COMMIT_REF_RE = re.compile(r"(?:\b[0-9a-f]{7,40}\b|github\.com/[^/\s]+/[^/\s]+/commit/[0-9a-f]+)")
+
+
+@dataclass(frozen=True)
+class IndexRow:
+    """One row in docs/bug-autopsies/INDEX.md."""
+
+    date: str
+    issue: str
+    category: str
+    summary: str
+
+    @classmethod
+    def from_markdown_row(cls, line: str) -> IndexRow | None:
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != 4:
+            return None
+        if cells[0] in {"Date", "------"}:
+            return None
+        return cls(date=cells[0], issue=cells[1], category=cells[2], summary=cells[3])
+
+    def to_markdown(self) -> str:
+        return f"| {self.date} | {self.issue} | {self.category} | {self.summary} |"
+
+
+@dataclass(frozen=True)
+class PostmortemRecord:
+    """One parsed postmortem file."""
+
+    path: Path
+    slug: str
+    title: str
+    date: str
+    issue: str
+    summary: str
+    content: str
+
+
+@dataclass
+class CheckResult:
+    """Aggregated postmortem validation findings."""
+
+    errors: list[str] = field(default_factory=list)
+    records: list[PostmortemRecord] = field(default_factory=list)
+    index_changed: bool = False
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if self.errors else 0
+
+
+def _postmortem_dir(project_root: Path) -> Path:
+    return project_root / "docs" / "bug-autopsies"
+
+
+def _index_path(project_root: Path) -> Path:
+    return _postmortem_dir(project_root) / "INDEX.md"
+
+
+def _relative(path: Path, project_root: Path) -> str:
+    try:
+        return path.relative_to(project_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _strip_title_prefix(title: str) -> str:
+    title = title.strip()
+    title = re.sub(r"^Bug Autopsy\s*[:—-]\s*", "", title)
+    title = re.sub(r"^\d{4}-\d{2}-\d{2}\s*[:—-]\s*", "", title)
+    return title.strip()
+
+
+def _first_title(content: str, fallback: str) -> str:
+    match = TITLE_RE.search(content)
+    if not match:
+        return fallback
+    return _strip_title_prefix(match.group(1))
+
+
+def _date_from(path: Path, content: str) -> str:
+    date_match = DATE_LINE_RE.search(content)
+    if date_match:
+        return date_match.group(1).strip()
+
+    filename_match = re.search(r"\d{4}-\d{2}-\d{2}", path.name)
+    if filename_match:
+        return filename_match.group(0)
+
+    title_match = re.search(r"\d{4}-\d{2}-\d{2}", content[:300])
+    if title_match:
+        return title_match.group(0)
+
+    return "—"
+
+
+def _issue_from(content: str) -> str:
+    issue_line = ISSUE_LINE_RE.search(content)
+    if issue_line:
+        return issue_line.group(1).strip()
+
+    issue_ref = re.search(r"#\d+", content[:800])
+    if issue_ref:
+        return issue_ref.group(0)
+
+    return "—"
+
+
+def _summary_from(title: str, content: str) -> str:
+    symptom_line = re.search(r"^\*\*Symptom:\*\*\s*(.+?)\s*$", content, re.MULTILINE)
+    if symptom_line:
+        return symptom_line.group(1).strip()
+    return title
+
+
+def _load_postmortems(project_root: Path) -> list[PostmortemRecord]:
+    postmortem_dir = _postmortem_dir(project_root)
+    if not postmortem_dir.exists():
+        return []
+
+    records: list[PostmortemRecord] = []
+    for path in sorted(postmortem_dir.glob("*.md")):
+        if path.name == "INDEX.md":
+            continue
+        content = path.read_text("utf-8")
+        title = _first_title(content, path.stem)
+        records.append(
+            PostmortemRecord(
+                path=path,
+                slug=path.stem,
+                title=title,
+                date=_date_from(path, content),
+                issue=_issue_from(content),
+                summary=_summary_from(title, content),
+                content=content,
+            )
+        )
+    return records
+
+
+def _has_heading(content: str, accepted: tuple[str, ...]) -> bool:
+    accepted_normalized = {item.lower() for item in accepted}
+    for _, heading in HEADING_RE.findall(content):
+        normalized = heading.strip().lower()
+        normalized = re.sub(r"\s+", " ", normalized)
+        if normalized in accepted_normalized:
+            return True
+    return False
+
+
+def _has_bold_sentence_label(content: str, accepted: tuple[str, ...]) -> bool:
+    for label in accepted:
+        if re.search(rf"^\*\*{re.escape(label)}[.:]\*\*", content, re.MULTILINE | re.IGNORECASE):
+            return True
+    return False
+
+
+def _has_symptom(record: PostmortemRecord) -> bool:
+    content = record.content
+    return (
+        _has_heading(content, ("Symptom", "Symptoms", "What Broke", "What broke"))
+        or _has_bold_sentence_label(content, ("Symptom", "What broke"))
+    )
+
+
+def _has_root_cause(record: PostmortemRecord) -> bool:
+    content = record.content
+    return (
+        _has_heading(
+            content,
+            (
+                "Root cause",
+                "Root causes",
+                "Root Causes (3 separate bugs)",
+                "Why",
+                "Why — Three Interacting Bugs",
+            ),
+        )
+        or _has_bold_sentence_label(content, ("Root cause", "Root causes", "Why"))
+    )
+
+
+def _has_prevention(record: PostmortemRecord) -> bool:
+    content = record.content
+    return (
+        _has_heading(content, ("Prevention", "Pinning test"))
+        or _has_bold_sentence_label(content, ("Prevention",))
+    )
+
+
+def _links_section(content: str) -> str | None:
+    link_heading = re.search(r"^##\s+Links\s*$", content, re.MULTILINE | re.IGNORECASE)
+    if not link_heading:
+        return None
+
+    following_heading = re.search(
+        r"^##\s+",
+        content[link_heading.end() :],
+        re.MULTILINE,
+    )
+    if following_heading:
+        return content[link_heading.end() : link_heading.end() + following_heading.start()]
+    return content[link_heading.end() :]
+
+
+def _has_links(record: PostmortemRecord) -> bool:
+    content = record.content
+    if _links_section(content) is not None:
+        return True
+
+    # Historical autopsies predate a strict Links section. Accept the link
+    # surfaces they already use so this automation does not force a backfill.
+    return (
+        bool(ISSUE_LINE_RE.search(content))
+        or bool(ISSUE_REF_RE.search(content[:1000]))
+        or _has_heading(content, ("Files Changed", "See also"))
+        or "Origin: [" in content
+    )
+
+
+def _check_required_fields(record: PostmortemRecord, project_root: Path) -> list[str]:
+    missing = []
+    if not _has_symptom(record):
+        missing.append("Symptom")
+    if not _has_root_cause(record):
+        missing.append("Root cause")
+    if not _has_prevention(record):
+        missing.append("Prevention")
+    if not _has_links(record):
+        missing.append("Links")
+
+    errors = [
+        f"{_relative(record.path, project_root)} — missing required field: {field}"
+        for field in missing
+    ]
+
+    links = _links_section(record.content)
+    if links is not None:
+        if not ISSUE_REF_RE.search(links):
+            errors.append(
+                f"{_relative(record.path, project_root)} — Links section present but no GH issue ref"
+            )
+        if not COMMIT_REF_RE.search(links):
+            errors.append(
+                f"{_relative(record.path, project_root)} — Links section present but no commit SHA"
+            )
+
+    return errors
+
+
+def _parse_existing_rows(index_text: str) -> list[IndexRow]:
+    rows = []
+    for line in index_text.splitlines():
+        if not line.startswith("|"):
+            continue
+        row = IndexRow.from_markdown_row(line)
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
+def _generated_row(record: PostmortemRecord) -> IndexRow:
+    return IndexRow(
+        date=record.date,
+        issue=record.issue,
+        category=record.slug,
+        summary=record.summary,
+    )
+
+
+def _index_rows(records: list[PostmortemRecord], index_text: str) -> list[IndexRow]:
+    existing_rows = _parse_existing_rows(index_text)
+    if not existing_rows:
+        return sorted(
+            (_generated_row(record) for record in records),
+            key=lambda row: (row.category.lower(), row.date, row.summary.lower()),
+        )
+
+    # Preserve historical rows exactly. Existing index categories sometimes
+    # describe the failure class rather than the filename slug, and multi-bug
+    # files intentionally have multiple rows. Use the table as curated data,
+    # then append generated rows only for genuinely new files.
+    rows = list(existing_rows)
+    covered_categories = {row.category for row in rows}
+    covered_issues = {row.issue for row in rows if row.issue != "—"}
+    for record in records:
+        if record.slug not in covered_categories and record.issue not in covered_issues:
+            rows.append(_generated_row(record))
+
+    return rows
+
+
+def _build_index_block(rows: list[IndexRow]) -> str:
+    table = "\n".join([TABLE_HEADER, *(row.to_markdown() for row in rows)])
+    return f"{INDEX_START}\n{table}\n{INDEX_END}"
+
+
+def _legacy_table_bounds(index_text: str) -> tuple[int, int] | None:
+    header_match = re.search(
+        r"^\| Date \| Issue \| Category \| Summary \|\n"
+        r"^\|[- |]+\|\n",
+        index_text,
+        re.MULTILINE,
+    )
+    if not header_match:
+        return None
+
+    end = header_match.end()
+    while True:
+        next_newline = index_text.find("\n", end)
+        if next_newline == -1:
+            return header_match.start(), len(index_text)
+        next_line_start = next_newline + 1
+        if not index_text[next_line_start:].startswith("|"):
+            return header_match.start(), next_newline
+        end = next_line_start
+
+
+def regenerate_index(project_root: Path = PROJECT_ROOT) -> bool:
+    """Regenerate INDEX.md in place. Returns True if the file changed."""
+    index_path = _index_path(project_root)
+    if not index_path.exists():
+        return False
+
+    index_text = index_path.read_text("utf-8")
+    records = _load_postmortems(project_root)
+    new_block = _build_index_block(_index_rows(records, index_text))
+
+    start = index_text.find(INDEX_START)
+    end = index_text.find(INDEX_END)
+    if start >= 0 and end >= 0:
+        new_text = index_text[:start] + new_block + index_text[end + len(INDEX_END) :]
+    else:
+        legacy_bounds = _legacy_table_bounds(index_text)
+        if legacy_bounds is None:
+            separator = "\n\n" if not index_text.endswith("\n\n") else ""
+            new_text = f"{index_text}{separator}{new_block}\n"
+        else:
+            legacy_start, legacy_end = legacy_bounds
+            new_text = index_text[:legacy_start] + new_block + index_text[legacy_end:]
+
+    if new_text == index_text:
+        return False
+    index_path.write_text(new_text, "utf-8")
+    return True
+
+
+def run_check(
+    *,
+    project_root: Path = PROJECT_ROOT,
+    regenerate: bool = True,
+    regenerate_on_failure: bool = False,
+) -> CheckResult:
+    """Validate postmortems and optionally regenerate the index."""
+    result = CheckResult(records=_load_postmortems(project_root))
+    postmortem_dir = _postmortem_dir(project_root)
+
+    if not postmortem_dir.exists():
+        result.errors.append(f"{_relative(postmortem_dir, project_root)} — directory missing")
+        return result
+
+    for record in result.records:
+        result.errors.extend(_check_required_fields(record, project_root))
+
+    if regenerate and (regenerate_on_failure or not result.errors):
+        result.index_changed = regenerate_index(project_root)
+
+    return result
+
+
+def _print_errors(errors: list[str]) -> None:
+    for error in errors:
+        print(f"❌ {error}")
+
+
+def main(argv: list[str] | None = None, *, project_root: Path = PROJECT_ROOT) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate docs/bug-autopsies/ postmortems and regenerate INDEX.md.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Modes:\n"
+            "  default              validate + regenerate INDEX.md when validation passes\n"
+            "  --quiet              print only errors; stdout is empty on success\n"
+            "  --regenerate-index   regenerate INDEX.md even if validation fails\n"
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Print only errors; silent on success for SessionStart hooks",
+    )
+    parser.add_argument(
+        "--regenerate-index",
+        action="store_true",
+        help="Regenerate INDEX.md even if validation fails",
+    )
+    args = parser.parse_args(argv)
+
+    result = run_check(
+        project_root=project_root,
+        regenerate=(not args.quiet or args.regenerate_index),
+        regenerate_on_failure=args.regenerate_index,
+    )
+
+    if args.quiet:
+        _print_errors(result.errors)
+        return result.exit_code
+
+    _print_errors(result.errors)
+    if result.index_changed:
+        print(f"✅ regenerated {_relative(_index_path(project_root), project_root)}")
+    print(f"✅ {len(result.records)} postmortems validated")
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_postmortems.py
+++ b/tests/test_check_postmortems.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit import check_postmortems
+
+VALID_ENTRY = """# Bug Autopsy: Cache Invalidation Failure
+
+## Symptom
+Users saw stale generated lessons after changing the source plan.
+
+## Root cause
+The cache key omitted the source plan hash.
+
+## Prevention
+The cache manifest now includes the source plan hash and a regression test.
+
+## Links
+- Issue: #1522
+- Fix: abc1234
+"""
+
+
+def _write_tree(tmp_path: Path, entries: dict[str, str], index: str | None = None) -> None:
+    autopsies = tmp_path / "docs" / "bug-autopsies"
+    autopsies.mkdir(parents=True)
+    for filename, content in entries.items():
+        (autopsies / filename).write_text(content, "utf-8")
+    (autopsies / "INDEX.md").write_text(
+        index
+        or """# Bug Autopsy Index
+
+One-liner per bug.
+
+<!-- INDEX-START -->
+| Date | Issue | Category | Summary |
+|------|-------|----------|---------|
+<!-- INDEX-END -->
+""",
+        "utf-8",
+    )
+
+
+def test_validates_valid_entry(tmp_path: Path, capsys) -> None:
+    _write_tree(tmp_path, {"cache-invalidation.md": VALID_ENTRY})
+
+    exit_code = check_postmortems.main([], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "✅ 1 postmortems validated" in captured.out
+
+
+def test_flags_missing_symptom(tmp_path: Path, capsys) -> None:
+    _write_tree(
+        tmp_path,
+        {"cache-invalidation.md": VALID_ENTRY.replace("## Symptom\n", "")},
+    )
+
+    exit_code = check_postmortems.main(["--regenerate-index"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert (
+        "❌ docs/bug-autopsies/cache-invalidation.md — missing required field: Symptom"
+        in captured.out
+    )
+
+
+def test_flags_missing_prevention(tmp_path: Path, capsys) -> None:
+    _write_tree(
+        tmp_path,
+        {"cache-invalidation.md": VALID_ENTRY.replace("## Prevention\n", "")},
+    )
+
+    exit_code = check_postmortems.main(["--regenerate-index"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert (
+        "❌ docs/bug-autopsies/cache-invalidation.md — missing required field: Prevention"
+        in captured.out
+    )
+
+
+def test_flags_missing_links(tmp_path: Path, capsys) -> None:
+    _write_tree(
+        tmp_path,
+        {
+            "cache-invalidation.md": VALID_ENTRY.replace(
+                "## Links\n- Issue: #1522\n- Fix: abc1234\n",
+                "",
+            )
+        },
+    )
+
+    exit_code = check_postmortems.main(["--regenerate-index"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert (
+        "❌ docs/bug-autopsies/cache-invalidation.md — missing required field: Links"
+        in captured.out
+    )
+
+
+def test_quiet_mode_silent_on_success(tmp_path: Path, capsys) -> None:
+    _write_tree(tmp_path, {"cache-invalidation.md": VALID_ENTRY})
+
+    exit_code = check_postmortems.main(["--quiet"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == ""
+
+
+def test_quiet_mode_reports_failures(tmp_path: Path, capsys) -> None:
+    _write_tree(
+        tmp_path,
+        {"cache-invalidation.md": VALID_ENTRY.replace("## Symptom\n", "")},
+    )
+
+    exit_code = check_postmortems.main(["--quiet"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "missing required field: Symptom" in captured.out
+
+
+def test_index_regeneration_preserves_outer_content(tmp_path: Path) -> None:
+    index = """# Bug Autopsy Index
+
+Intro stays.
+
+<!-- INDEX-START -->
+stale content
+<!-- INDEX-END -->
+
+Trailing note stays.
+"""
+    _write_tree(tmp_path, {"cache-invalidation.md": VALID_ENTRY}, index=index)
+
+    check_postmortems.main([], project_root=tmp_path)
+
+    regenerated = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
+    assert regenerated.startswith("# Bug Autopsy Index\n\nIntro stays.\n\n")
+    assert regenerated.endswith("\n\nTrailing note stays.\n")
+    assert "| cache-invalidation | Cache Invalidation Failure |" in regenerated
+
+
+def test_index_regeneration_idempotent(tmp_path: Path) -> None:
+    _write_tree(tmp_path, {"cache-invalidation.md": VALID_ENTRY})
+
+    check_postmortems.main([], project_root=tmp_path)
+    first = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
+    check_postmortems.main([], project_root=tmp_path)
+    second = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
+
+    assert second == first
+
+
+def test_index_regeneration_preserves_sort_order(tmp_path: Path) -> None:
+    _write_tree(
+        tmp_path,
+        {
+            "zulu-cache.md": VALID_ENTRY.replace(
+                "Cache Invalidation Failure",
+                "Zulu Cache Failure",
+            ),
+            "alpha-cache.md": VALID_ENTRY.replace(
+                "Cache Invalidation Failure",
+                "Alpha Cache Failure",
+            ),
+        },
+    )
+
+    check_postmortems.main([], project_root=tmp_path)
+
+    regenerated = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
+    assert regenerated.index("| alpha-cache |") < regenerated.index("| zulu-cache |")


### PR DESCRIPTION
## Summary
- `scripts/audit/check_postmortems.py` — validator + sentinel-driven INDEX.md regeneration (mirrors `check_adrs.py` / `check_decisions.py` pattern)
- `docs/best-practices/postmortem-management.md` — policy: when to write, template, lifecycle, anti-patterns
- SessionStart hook wiring: adds `check_postmortems.py --quiet` alongside the two existing checks
- `docs/bug-autopsies/INDEX.md` — adds the `INDEX-START` / `INDEX-END` sentinels while preserving existing rows
- Pytest coverage: 9 tests

## Test plan
- [x] `.venv/bin/pytest tests/test_check_postmortems.py -v` — 9 passed
- [x] `.venv/bin/ruff check scripts/audit/check_postmortems.py tests/test_check_postmortems.py` — clean
- [x] Dry run: `.venv/bin/python -m scripts.audit.check_postmortems` — validates current docs/bug-autopsies/ without false positives, regenerates INDEX.md idempotently
- [x] `diff -u /tmp/check_postmortems_INDEX.md.bak docs/bug-autopsies/INDEX.md` after two consecutive regenerations — empty
- [x] `bash -n claude_extensions/hooks/session-setup.sh` — clean

Out of scope: auto-generating postmortems from PR labels, `/api/orient` integration.

Closes #1522.