### PR TITLE
fix(writer): 5 prompt rules for prose quality (#1550 U2)

### DIFF
--- a/scripts/build/phases/v6-write.md
+++ b/scripts/build/phases/v6-write.md
@@ -104,7 +104,15 @@ Then begin writing the module content. Follow your own pacing plan — each sect
    The convergence loop treats `<section_overflow>` as a plan-revision signal (plan-authoring bug, not writer bug) and will not fail the module for it. Silent deferral IS a failure — Section 2 promising 12 colors and delivering 6 (Round-1 `a1/colors` defect) is exactly the pattern to avoid.
 
    **Dialogue retrieval mandate (contract §3).** When a section's contract includes a dialogue (section is `Діалоги` / `Dialogues`, or the plan has a `dialogue_acts` entry for that section), BEFORE drafting Ukrainian dialogue you MUST call `mcp__sources__search_sources` with a Ukrainian query biased toward the scenario. Example query shape: `"діалог на ринку квіти кольори"` for a flower-market scene. Take the top 2–3 hits from `textbook_sections` or `ukrainian_wiki` as anchors — match their register, re-use common turn-taking phrases (Добрий день, Дякую, Будь ласка, Скажіть, будь ласка, …). If the search returns zero usable hits, emit a `<!-- VERIFY: dialogue not corpus-grounded, search returned no A1 matches -->` marker on the dialogue block. Invented Ukrainian dialogue without corpus anchoring is the Round-1 Dialogue-dim failure (stilted `Я думаю, цей білий светр і коричневі черевики.`).
-4. **NO IPA, NO Latin transliteration** — never write [mɑmɑ], (khlib), or phonetic brackets. Describe sounds by comparison: "Х sounds like «ch» in Scottish «loch»."
+4. **NO Latin IPA, NO Latin transliteration** — never write [mɑmɑ], (khlib), or Latin phonetic brackets. Describe sounds by comparison: "Х sounds like «ch» in Scottish «loch»."
+
+   <phonetic-notation>
+   Use ONLY Cyrillic phonetic notation in square brackets:
+       [а] [о] [у] [е] [и] [і] [й]
+   NEVER use Latin IPA (e.g., [y], [ɪ], [ʊ], [j]). The learner does
+   not know IPA at A1; Latin in a Ukrainian text is confusing noise.
+   Counter-example: WRONG `и pronounced [y]`. RIGHT `и звучить як [и]`.
+   </phonetic-notation>
 5. **You are a warm, encouraging teacher.** Write with the voice of a calm classroom teacher explaining something interesting. Good phrasing is content-anchored: ask a direct question ("What happens when ___?"), point at an example ("Look at ___"), invite attention ("Notice ___"). Those slots take a specific Ukrainian word, sound, or pattern, not a generic noun.
 
    **Contract §4 allow-list (standard textbook-teacher register — these ARE acceptable when anchored to a specific teaching point):** "You have learned...", "Now it's time to...", "Let's review...", "In this module...", "By the end...", "Here's how to...", "Try this now...", "Notice that...", "Look at...", "Read aloud...". The reviewer will NOT penalize these when they introduce a specific Ukrainian word, sound, or pattern.
@@ -118,8 +126,6 @@ Then begin writing the module content. Follow your own pacing plan — each sect
 9. **Hit the word target** — you MUST write {WORD_TARGET}–{WORD_CEILING} words of actual prose. To reach this target, deeply expand explanations, provide 3+ examples per concept, and, only if the contract has non-empty dialogue_acts, include rich multi-turn dialogues. Short modules fail review. Never pad with filler.
 10. **NO archaic, obsolete, or rare words** — use only modern standard Ukrainian. Do not use words marked as archaic (застаріле) or dialectal in dictionaries. Example: use «кін» not «кон», use «пом'якшені» not «м'якшені». When in doubt, choose the common modern form. Your pre-training contains Russian-influenced archaic forms — verify unfamiliar words.
 11. **EVERY module MUST end with `## {SUMMARY_HEADING}`** — this is the last H2 section before the file ends. It contains a self-check recap. If you forget this section, the audit REJECTS the module and you waste a retry. Write it LAST, after all other sections.
-
-**Note:** Do NOT add stress marks (´) to any Ukrainian word — a deterministic tool handles this after you write.
 
 ## Exercise Placement — Markers Only
 
@@ -415,11 +421,43 @@ VESUM (does word exist?) → Правопис 2019 (spelling) → Горох (st
 - Every paragraph: ONE clear point, logical flow to the next
 - Vary sentence length (short for emphasis, medium for explanation, long for examples)
 - Use callout boxes (:::tip, :::caution, :::note) — at least 3 per module (mnemonics, common mistakes, cultural notes). Space them throughout the module, not clustered.
-- **Dialogue formatting** — use blockquote `>` with speaker names in bold. Each turn on its own line. At A1 level, add English translation in italics after each line so learners understand what is being said. At A2, translate only new vocabulary. At B1+, no dialogue translations. Example:
+- **Dialogue formatting** — use blockquote `>` with speaker names in bold. Each turn on its own line. At A1 level, add English translation in italics after each line so learners understand what is being said. At A2, translate only new vocabulary. At B1+, no dialogue translations.
 
-> **Оленка:** Привіт! Як справи? *(Hi! How are you?)*
-> **Тарас:** Добре, дякую! А у тебе? *(Good, thanks! And you?)*
-> **Оленка:** Теж добре! *(Also good!)*
+  <speaker-labels>
+  When the plan's `dialogue` block names speakers (e.g., Марко, Софія),
+  format every turn as:
+
+      **Марко:** «Привіт!»
+      **Софія:** «Привіт! Як тебе звати?»
+
+  Use bold name + colon + Ukrainian guillemets («…»). Do NOT use
+  em-dashes (— Привіт!) when the plan names speakers — em-dashes lose
+  speaker identity in the rendered MDX. Em-dashes are only acceptable
+  for un-named speakers.
+  </speaker-labels>
+
+  <dialogue-not-lecture>
+  Dialogue is what people SAY to each other. NEVER embed grammar
+  explanations inside quotation marks.
+
+  ANTIPATTERN (forbidden):
+      Софія: «"Рада"? Я кажу "рада", бо я дівчина.»
+  This reads as a grammar lecture posing as conversation. The learner
+  notices it as fake.
+
+  CORRECT pattern: dialogue first, explanation in a separate prose
+  paragraph AFTER the dialogue:
+      Софія: «Рада познайомитися!»
+
+      Note: Софія says «рада» (feminine form) because she is a girl;
+      Марко would say «радий» (masculine).
+  </dialogue-not-lecture>
+
+  Example:
+
+> **Оленка:** «Привіт! Як справи?» *(Hi! How are you?)*
+> **Тарас:** «Добре, дякую! А у тебе?» *(Good, thanks! And you?)*
+> **Оленка:** «Теж добре!» *(Also good!)*
 
 Without speaker names, the reader cannot tell who is speaking. NEVER use anonymous em dashes (`— text`). After each dialogue, briefly explain the key phrases and patterns the learner just saw.
 - **Dialogues must sound like real people talking.** Test: would two Ukrainians actually say this to each other? If the dialogue sounds like a textbook drill ("Це кінь? — Так, це кінь."), rewrite it. Good dialogues have context, reactions, and personality:
@@ -471,6 +509,24 @@ Available videos (for reference only — ENRICH handles placement):
 {GOLDEN_FRAGMENT}
 
 ## Output Format
+
+<no-meta-language>
+The prose is FINAL output for the learner. NEVER include drafting
+or instructional meta-language directed at yourself or a future
+editor. Banned phrases (non-exhaustive):
+- "Use the Ukrainian sound symbols here"
+- "Insert example", "Add table", "List the words"
+- "Apply the rule", "Generate dialogue", "Continue with..."
+- Bracketed editor notes like [TODO], [example], [insert]
+If you would write any of those, write the actual content instead.
+</no-meta-language>
+
+<no-stress-marks>
+Do NOT add stress marks (U+0301 combining acute) to any word.
+Stress is added by a deterministic annotator AFTER your output is
+reviewed. If you include stress marks, the reviewer will see them
+and the pipeline will reject the output as out-of-contract.
+</no-stress-marks>
 
 Write in Markdown. Use:
 - `## Section Title` for main sections

--- a/tests/build/test_v6_write_prompt.py
+++ b/tests/build/test_v6_write_prompt.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+PROMPT_PATH = Path("scripts/build/phases/v6-write.md")
+
+REQUIRED_BLOCKS = (
+    "phonetic-notation",
+    "no-meta-language",
+    "speaker-labels",
+    "dialogue-not-lecture",
+    "no-stress-marks",
+)
+
+
+def test_v6_write_prompt_contains_quality_rule_blocks():
+    prompt = PROMPT_PATH.read_text(encoding="utf-8")
+
+    for block in REQUIRED_BLOCKS:
+        assert prompt.count(f"<{block}>") == 1
+        assert prompt.count(f"</{block}>") == 1


### PR DESCRIPTION
## Rule blocks added

1. Cyrillic-only phonetic notation (no Latin IPA)
2. No drafting-leak meta-language in prose
3. Speaker labels mandatory when plan names speakers
4. Dialogue is conversation, not grammar lecture (concrete antipattern)
5. Writer must not add stress marks (defensive reminder)

Rule 4 antipattern included in the prompt:

    Софія: «"Рада"? Я кажу "рада", бо я дівчина.»

## Evidence

- Added unit test: tests/build/test_v6_write_prompt.py
- Test asserts all 5 named blocks appear exactly once in scripts/build/phases/v6-write.md
- Ran: .venv/bin/ruff check tests/build/ via the repository venv at /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff from the delegated worktree
- Ran: .venv/bin/python -m pytest tests/build/test_v6_write_prompt.py via the repository venv from the delegated worktree

Refs #1550