### PR TITLE
fix(reviewer): pre-strip stress + inject level context per dim (#1550 U1)

### DIFF
--- a/scripts/build/phases/v6-review/v6-review-actionable.md
+++ b/scripts/build/phases/v6-review/v6-review-actionable.md
@@ -1,6 +1,18 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract + level calibration -->
 # V6 Per-Dimension Review — Actionable
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Actionable** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Actionable ONLY by how well the content satisfies the contract's §1 (scaffolding) and §4 (pedagogical voice) clauses — the "concrete teaching, not abstract" axis. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.

--- a/scripts/build/phases/v6-review/v6-review-completeness.md
+++ b/scripts/build/phases/v6-review/v6-review-completeness.md
@@ -1,6 +1,18 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract -->
 # V6 Per-Dimension Review — Completeness
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Completeness** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Completeness ONLY by how well the content satisfies the contract's §2 (section contract covers list) clause. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows (a `<section_overflow>` block is a §2 positive signal, not a defect — handled by the Plan Adherence dim).

--- a/scripts/build/phases/v6-review/v6-review-decolonization.md
+++ b/scripts/build/phases/v6-review/v6-review-decolonization.md
@@ -1,6 +1,18 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract -->
 # V6 Per-Dimension Review — Decolonization
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Decolonization** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Decolonization ONLY by how well the module avoids Russian-centered framing and establishes Ukrainian cultural sovereignty. Do NOT import criteria from outside this contract. Do NOT penalize scaffolding-language choices (scaffolding is §1, handled by Naturalness/Actionable, not here).

--- a/scripts/build/phases/v6-review/v6-review-dialogue.md
+++ b/scripts/build/phases/v6-review/v6-review-dialogue.md
@@ -1,6 +1,29 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract + §3 corpus grounding -->
 # V6 Per-Dimension Review — Dialogue
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
+<pedagogical-stage>
+For {learner_level} M1–M3 (the first 3 modules of a CEFR level),
+score on PEDAGOGICAL FIT, not richness:
+- Greeting exchange + name introduction is the appropriate ceiling.
+- "Привіт! Я Марко. Як тебе звати?" is a 9/10 dialogue at this stage.
+- Do NOT penalize short turns, repeated patterns, or absence of
+  tense variation; the learner has not been taught those yet.
+For {learner_level} M4 and later, evaluate dialogue richness as
+normal.
+</pedagogical-stage>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Dialogue** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Dialogue ONLY by how well the dialogue content satisfies the contract's §3 clause (corpus-grounded when `dialogue_acts` present). Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.

--- a/scripts/build/phases/v6-review/v6-review-factual.md
+++ b/scripts/build/phases/v6-review/v6-review-factual.md
@@ -1,6 +1,30 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract -->
 # V6 Per-Dimension Review — Factual
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
+<factual-scope>
+Evaluate factual accuracy of CONTENT claims (history, biography,
+linguistics, cultural facts). Do NOT evaluate:
+- Stress marks (handled by deterministic annotator post-review)
+- Pronunciation IPA notation (Language dim)
+- Activity question wording (Actionable dim)
+Examples of valid Factual findings: "the year 988 should be 988
+AD"; "Lesya Ukrainka was born in 1871, not 1881". Examples of
+INVALID Factual findings: "missing stress on день"; "should be
+стіл not стол" (this is a Russianism — Language dim).
+</factual-scope>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Factual** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Factual ONLY by how well the Ukrainian factual claims match the plan YAML `factual_anchors` and authority-hierarchy sources. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows (VERIFY markers are a positive honesty signal — handled by the Honesty dim).

--- a/scripts/build/phases/v6-review/v6-review-honesty.md
+++ b/scripts/build/phases/v6-review/v6-review-honesty.md
@@ -1,6 +1,18 @@
 <!-- version: 1.3.0 | updated: 2026-04-24 | GH #1529 post-Phase-A — credit writer-emitted markers: vicinity rule + marker-format nitpicks out of scope + worked examples -->
 # V6 Per-Dimension Review — Honesty
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Honesty** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Honesty ONLY by how well the module satisfies the contract's §5 (VERIFY markers as positive signal) clause. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.

--- a/scripts/build/phases/v6-review/v6-review-language.md
+++ b/scripts/build/phases/v6-review/v6-review-language.md
@@ -1,6 +1,18 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract + level calibration -->
 # V6 Per-Dimension Review — Language
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Language** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Language ONLY by how well the Ukrainian in the module satisfies the contract's §7 (forbidden words) clause and the Ukrainian-linguistic-quality rules from the writer prompt (VESUM, Правопис 2019, Антоненко-Давидович). Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.

--- a/scripts/build/phases/v6-review/v6-review-naturalness.md
+++ b/scripts/build/phases/v6-review/v6-review-naturalness.md
@@ -1,6 +1,18 @@
 <!-- version: 1.1.0 | updated: 2026-04-23 | GH #1431 — shared contract + level calibration -->
 # V6 Per-Dimension Review — Naturalness
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Naturalness** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Naturalness ONLY by how well the content satisfies the contract's §1 (scaffolding roles) and §4 (pedagogical voice) clauses. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.

--- a/scripts/build/phases/v6-review/v6-review-plan-adherence.md
+++ b/scripts/build/phases/v6-review/v6-review-plan-adherence.md
@@ -1,6 +1,18 @@
 <!-- version: 1.2.0 | updated: 2026-04-24 | GH #1529 — section max is advisory, not binding -->
 # V6 Per-Dimension Review — Plan Adherence
 
+<module-context>
+Learner level: {learner_level}
+Module index: {module_index} of {module_total}
+</module-context>
+
+<stress-marks>
+The prose you receive has had stress marks (U+0301 combining acute)
+removed by the pipeline. Do NOT comment on missing stress marks.
+Stress is added by a deterministic annotator AFTER review.
+Any stress finding will be discarded.
+</stress-marks>
+
 ## Shared Contract (authoritative — supersedes rubric text on conflict)
 
 You are scoring the **Plan Adherence** dimension. The module must satisfy the contract at `scripts/build/contracts/module-contract.md` as specialized by the plan and the `{CONTRACT_YAML}` block below. Score Plan Adherence ONLY by how well the content satisfies the contract's §2 (section contract) and §6 (activity markers) clauses. Do NOT import criteria from outside this contract. Do NOT penalize behavior the contract explicitly allows.

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -105,6 +105,7 @@ from build.plan_tracking import (
     plan_path_for,
 )
 from build.track_constraints import build_writer_constraints_section
+from common.text_utils import strip_ukrainian_stress
 from common.thresholds import (
     REVIEW_PASS_FLOOR,
     REVIEW_REJECT_FLOOR,
@@ -5757,6 +5758,33 @@ def _update_aggregate_with_applied_fixes(
     (review_dir / f"{slug}-review-aggregate.yaml").write_text(dumped, "utf-8")
 
 
+def _resolve_module_total(level: str) -> int:
+    """Count modules for a level from the curriculum manifest.
+
+    Returns 0 if the manifest is missing or the level is absent. Used to
+    inject `{module_total}` into per-dim review prompts so the reviewer
+    knows whether a module sits in the early-stage band (M1-M3) where
+    pedagogical-fit calibration applies (#1550 U1).
+    """
+    manifest = CURRICULUM_ROOT / "curriculum.yaml"
+    if not manifest.exists():
+        return 0
+    data = yaml.safe_load(manifest.read_text("utf-8")) or {}
+    modules = data.get("levels", {}).get(level, {}).get("modules", [])
+    return len(modules) if isinstance(modules, list) else 0
+
+
+def _prepare_reviewer_prose(text: str) -> str:
+    """Strip Ukrainian stress marks (U+0301) from prose before reviewer dispatch.
+
+    The deterministic stress annotator runs AFTER review, so any stress
+    finding the reviewer raises is invalid by construction. Stripping at
+    the dispatcher boundary closes the loophole without touching the
+    canonical content file (#1550 U1).
+    """
+    return strip_ukrainian_stress(text)
+
+
 def _determine_reviewer(
     writer: str,
     reviewer_override: str | None,
@@ -7753,10 +7781,13 @@ def step_review(content_path: Path, level: str, module_num: int,
     else:
         writer_model = "Gemini"
 
+    reviewer_prose = _prepare_reviewer_prose(generated_content)
     generated_content_literal = _format_prompt_literal_block(
-        "Generated Module Content", generated_content, language="markdown",
+        "Generated Module Content", reviewer_prose, language="markdown",
     )
     from pipeline.config_tables import get_immersion_rule as _get_immersion_rule_for_review
+
+    module_total = _resolve_module_total(level)
 
     replacements = {
         "{MODULE_NUM}": str(module_num),
@@ -7772,6 +7803,9 @@ def step_review(content_path: Path, level: str, module_num: int,
         "{GENERATED_CONTENT}": generated_content_literal,
         "{IMMERSION_RULE}": _get_immersion_rule_for_review(level, module_num),
         "{IMMERSION_TARGET_SHORT}": _get_immersion_target_short(level, module_num),
+        "{learner_level}": level.upper(),
+        "{module_index}": str(module_num),
+        "{module_total}": str(module_total),
         **_build_canonical_anchors_replacements(),
     }
 

--- a/tests/build/test_reviewer_dispatcher.py
+++ b/tests/build/test_reviewer_dispatcher.py
@@ -1,0 +1,104 @@
+"""Tests for per-dim reviewer dispatcher hardening (#1550 unit 1).
+
+Two reviewer-side bugs surfaced on a1/1:
+1. Factual dim flagged stress marks added by the deterministic annotator
+   AFTER review — invalid findings dropped score 8.2.
+2. Dialogue dim held A1 M1-M3 to advanced-richness standards and scored
+   7.0 on appropriate beginner greetings — a calibration miss, not a
+   content failure.
+
+These tests pin the fix:
+- Stress marks (U+0301 combining acute) are stripped from reviewer prose
+  before placeholder substitution.
+- `{learner_level}`, `{module_index}`, `{module_total}` substitute in
+  every dim prompt template.
+- The Dialogue prompt carries a `<pedagogical-stage>` block that
+  references the level.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+WORKTREE_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS_DIR = WORKTREE_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+v6_build = importlib.import_module("build.v6_build")
+
+PROMPT_DIR = SCRIPTS_DIR / "build" / "phases" / "v6-review"
+
+STRESS = "́"
+
+
+def test_prepare_reviewer_prose_strips_combining_acute():
+    """Stress marks must be removed before the prose reaches the reviewer."""
+    raw = "Приві" + STRESS + "т! Я Ма" + STRESS + "рко."
+    cleaned = v6_build._prepare_reviewer_prose(raw)
+    assert STRESS not in cleaned
+    assert cleaned == "Привіт! Я Марко."
+
+
+def test_prepare_reviewer_prose_passthrough_when_no_stress():
+    """Plain Ukrainian without stress is returned unchanged."""
+    raw = "Як тебе звати?"
+    assert v6_build._prepare_reviewer_prose(raw) == raw
+
+
+def test_resolve_module_total_returns_positive_count_for_a1():
+    """Curriculum manifest is the source of truth for `{module_total}`."""
+    total = v6_build._resolve_module_total("a1")
+    assert total > 0
+
+
+def test_level_placeholders_substitute_into_dim_prompt():
+    """`{learner_level}`, `{module_index}`, `{module_total}` must be
+    substitutable across every dim template."""
+    replacements = {
+        "{learner_level}": "A1",
+        "{module_index}": "2",
+        "{module_total}": "55",
+    }
+    for path in sorted(PROMPT_DIR.glob("v6-review-*.md")):
+        text = path.read_text("utf-8")
+        for key in replacements:
+            assert key in text, f"missing placeholder {key} in {path.name}"
+        for key, value in replacements.items():
+            text = text.replace(key, value)
+        for key in replacements:
+            assert key not in text, f"residual placeholder {key} in {path.name}"
+        assert "Learner level: A1" in text, f"module-context not bound in {path.name}"
+        assert "Module index: 2 of 55" in text, f"module-context not bound in {path.name}"
+
+
+def test_dialogue_prompt_carries_pedagogical_stage_block():
+    """The dialogue dim alone gets the pedagogical-stage calibration block,
+    and the block resolves to the learner level after substitution."""
+    text = (PROMPT_DIR / "v6-review-dialogue.md").read_text("utf-8")
+    assert "<pedagogical-stage>" in text
+    assert "</pedagogical-stage>" in text
+    assert "M1–M3" in text
+    bound = text.replace("{learner_level}", "A1")
+    assert "For A1 M1–M3" in bound
+    assert "For A1 M4 and later" in bound
+
+
+def test_factual_prompt_carries_factual_scope_block():
+    """The factual dim alone gets the factual-scope block carving
+    stress / IPA / activity wording out of factual scope."""
+    text = (PROMPT_DIR / "v6-review-factual.md").read_text("utf-8")
+    assert "<factual-scope>" in text
+    assert "</factual-scope>" in text
+    assert "Stress marks" in text
+    assert "Pronunciation IPA notation (Language dim)" in text
+
+
+def test_all_dim_prompts_carry_stress_marks_block():
+    """The defensive stress-marks rule must be present in every dim prompt."""
+    for path in sorted(PROMPT_DIR.glob("v6-review-*.md")):
+        text = path.read_text("utf-8")
+        assert "<stress-marks>" in text, f"missing <stress-marks> in {path.name}"
+        assert "</stress-marks>" in text, f"missing </stress-marks> in {path.name}"
+        assert "U+0301" in text, f"missing U+0301 reference in {path.name}"


### PR DESCRIPTION
## Summary

Unit 1 of EPIC #1550 — reviewer-side calibration. Two failure classes
on a1/1 traced to reviewer behavior, not content:

1. **Factual dim flagged stress marks** that the deterministic stress
   annotator adds AFTER review. Three minor stress findings on a1/1
   were all invalid by construction; they dropped the dim from a clean
   PASS to 8.2 REVISE.
2. **Dialogue dim over-strict for A1 M1–M3.** Beginners only know
   greetings + names; the reviewer (Codex/gpt-5.5) was scoring rich-
   dialogue criteria and held \"Привіт! Я Марко. Як тебе звати?\" to
   7.0/10. This is a calibration miss, not a content failure.

Refs #1550

## Trace (per task 1)

The per-dim review flow lives in `step_review` (`scripts/build/v6_build.py:7715`):

1. Content is read from disk and stripped of vocab/lesson tabs.
2. A `replacements` dict is built (`{MODULE_NUM}`, `{TOPIC_TITLE}`, …).
3. For each spec in `REVIEW_DIMENSIONS` (line 169), the dim template is
   loaded from `scripts/build/phases/v6-review/v6-review-{id}.md`.
4. Placeholders are substituted, and the prompt is dispatched via
   `_dispatch_review_prompt` (line 5850 after the helpers added here).

This unit hooks two boundaries:
- The prose entering step 2's `{GENERATED_CONTENT}` is run through
  `_prepare_reviewer_prose()` (new) which calls
  `strip_ukrainian_stress` from `scripts/common/text_utils.py`.
- The replacements dict gains `{learner_level}`, `{module_index}`,
  `{module_total}` — the latter resolved from `curriculum.yaml` via
  `_resolve_module_total()` (new).

## Changes

- `scripts/build/v6_build.py` — two new helpers (`_resolve_module_total`,
  `_prepare_reviewer_prose`); `step_review` now strips stress and
  injects the three level-context placeholders.
- `scripts/build/phases/v6-review/*.md` — all 9 dim prompts gain the
  defensive `<stress-marks>` and `<module-context>` blocks.
- `scripts/build/phases/v6-review/v6-review-dialogue.md` — adds the
  `<pedagogical-stage>` block referencing `{learner_level}` so M1–M3
  is scored on pedagogical fit, not richness.
- `scripts/build/phases/v6-review/v6-review-factual.md` — adds the
  `<factual-scope>` block carving stress / IPA / activity-wording
  out of the Factual dim's scope.
- `tests/build/test_reviewer_dispatcher.py` — 7 tests covering
  stress-strip, module-total resolution, placeholder substitution
  across all 9 dim prompts, and presence of the pedagogical-stage,
  factual-scope, and stress-marks blocks.

## Test plan

- [x] `tests/build/test_reviewer_dispatcher.py` — 7 passing.
- [x] `ruff check scripts/build/v6_build.py tests/build/` — clean.
- [x] Pre-commit hook (ruff + pytest on affected files) — passing.
- [ ] **Owner verification:** re-run a1/1 review with
      `.venv/bin/python scripts/build/v6_build.py a1 1 --step review --resume --writer claude-tools --reviewer codex-tools`
      and confirm Dialogue ≥ 8.0 and Factual cites no stress findings.
      (Per project policy, builds are user-triggered only.)

## Out of scope

- Writer / activity prompts (Units 2–3).
- Convergence loop (#1545, merged).
- Scoring thresholds.

## Notes

Auto-merge is NOT enabled per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)