### PR TITLE
fix(api): declare AccessFormatter class for uvicorn access log

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -35,6 +35,18 @@ still authoritative. A ready-to-use helper lives at
 
 ---
 
+### Custom log formatters
+
+Access log formats that reference uvicorn-only fields like
+`%(client_addr)s`, `%(request_line)s`, or `%(status_code)s` must declare
+`"()": "uvicorn.logging.AccessFormatter"` in `scripts/api/logging.json`.
+Python's default `logging.Formatter` does not populate those fields and
+will raise during response logging. See uvicorn's
+[`AccessFormatter`](https://github.com/encode/uvicorn/blob/master/uvicorn/logging.py)
+implementation for the field mapping.
+
+---
+
 ### One-shot orient (unchanged, still useful)
 
 ```bash

--- a/tests/api/test_logging_config.py
+++ b/tests/api/test_logging_config.py
@@ -1,0 +1,50 @@
+import json
+import logging
+import logging.config
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LOGGING_CONFIG = PROJECT_ROOT / "scripts" / "api" / "logging.json"
+
+
+def _load_logging_config() -> None:
+    with LOGGING_CONFIG.open() as handle:
+        logging.config.dictConfig(json.load(handle))
+
+
+def test_access_formatter_handles_uvicorn_access_record() -> None:
+    _load_logging_config()
+    formatter = logging.getLogger("uvicorn.access").handlers[0].formatter
+
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:1234", "GET", "/x", "1.1", 200),
+        exc_info=None,
+    )
+
+    formatted = formatter.format(record)
+
+    assert '127.0.0.1:1234 "GET /x HTTP/1.1" 200 OK' in formatted
+
+
+def test_default_formatter_handles_standard_info_record() -> None:
+    _load_logging_config()
+    formatter = logging.getLogger("uvicorn").handlers[0].formatter
+
+    record = logging.LogRecord(
+        name="uvicorn",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="server started",
+        args=(),
+        exc_info=None,
+    )
+
+    formatted = formatter.format(record)
+
+    assert "[INFO] uvicorn: server started" in formatted


### PR DESCRIPTION
## Summary

The Monitor API access formatter referenced uvicorn-specific named fields (`%(client_addr)s`, `%(request_line)s`, `%(status_code)s`) while relying on Python's default formatter behavior. Uvicorn emits access records as positional args, so the default formatter cannot populate those named fields and raises `KeyError` during response logging, which can corrupt the response send path and surface to clients as connection resets.

## Why this fix is correct

`uvicorn.logging.AccessFormatter` is the formatter that maps uvicorn's access-log positional args (`client_addr`, method, path, HTTP version, status code) into the named `LogRecord` fields used by the configured format string. The existing one-line config fix on main correctly declares that formatter class and disables colors for stable file output.

## Related sweep

- Verified `scripts/api/logging.json` has only `default` and `access` formatters.
- Verified `default` uses only standard `LogRecord` fields.
- Verified `access` uses uvicorn-only fields and declares `uvicorn.logging.AccessFormatter`.
- Grepped logging config field references with `%(...)s`; no other logging config files or formatter field consumers were found in `scripts/api/`.
- Reviewed `scripts/api/main.py` and API logging usage; no `logging.config.dictConfig`, custom formatter subclass, or logger calls using named-field format strings as positional args were found. `_signal_log.py` uses ordinary positional `%s/%d` message interpolation.

## Test plan

- `.venv/bin/pytest tests/api/test_logging_config.py -v` -> 2 passed.
- `.venv/bin/ruff check scripts/api/ tests/api/` -> all checks passed.
- Commit pre-commit hook reran ruff and affected pytest file -> passed.
- Smoke test output captured at `/tmp/codex-api-smoke.log`.
- Smoke endpoints all returned 200: `/api/state/manifest`, `/api/orient`, `/api/comms/inbox?agent=claude`, `/api/state/summary`, `/api/runtime/auth`.
- Log check after the smoke start marker and through SIGTERM shutdown found no `Traceback`, `KeyError`, or `Formatting field not found`.

Reference: infrastructure for EPIC #1550.
