### PR TITLE
Wiki retrieval overhaul step 0: versioned embedding manifest (#1553)

### DIFF
--- a/scripts/wiki/chunking.py
+++ b/scripts/wiki/chunking.py
@@ -403,23 +403,59 @@ def _trailing_sentences_for_overlap(
     target_tokens: int,
     tokenizer: TokenizerProtocol,
 ) -> str:
-    """Pick the trailing sentences of ``text`` that fit within
-    ``target_tokens``. Empty string if no sentence fits."""
+    """Pick a trailing slice of ``text`` that fits within
+    ``target_tokens``. Empty string if no slice fits.
 
+    Strategy: prefer whole trailing sentences whose total fits the
+    budget. If even the LAST sentence on its own exceeds the budget,
+    fall back to a token-tail slice — never return text that exceeds
+    ``target_tokens`` (Codex review msg #459). Without this cap, a
+    200-token trailing sentence would pad a 450-token chunk into
+    650 tokens and the validator gate (#1553 step 3) would reject
+    the encode at runtime.
+    """
+
+    if target_tokens <= 0:
+        return ""
     sentences = split_sentences(text)
     if not sentences:
-        return ""
+        # Single un-broken text — fall back to the token tail directly.
+        return _token_tail(text, target_tokens=target_tokens, tokenizer=tokenizer)
+
     chosen: list[str] = []
     chosen_tokens = 0
     for sentence in reversed(sentences):
         sentence_tokens = _count_tokens(sentence, tokenizer=tokenizer)
-        if chosen_tokens + sentence_tokens > target_tokens and chosen:
+        if chosen and chosen_tokens + sentence_tokens > target_tokens:
             break
+        if not chosen and sentence_tokens > target_tokens:
+            # Last sentence alone exceeds the overlap budget. Take
+            # its token tail rather than returning the whole sentence.
+            return _token_tail(sentence, target_tokens=target_tokens, tokenizer=tokenizer)
         chosen.insert(0, sentence)
         chosen_tokens += sentence_tokens
         if chosen_tokens >= target_tokens:
             break
     return " ".join(chosen)
+
+
+def _token_tail(
+    text: str,
+    *,
+    target_tokens: int,
+    tokenizer: TokenizerProtocol,
+) -> str:
+    """Return the last ``target_tokens`` tokens of ``text`` as
+    decoded text. Used when sentence-based overlap can't fit."""
+
+    if target_tokens <= 0 or not text:
+        return ""
+    decode = getattr(tokenizer, "decode", None)
+    token_ids = tokenizer.encode(text, add_special_tokens=False, truncation=False)
+    if not token_ids or decode is None:
+        return ""
+    tail = token_ids[-target_tokens:]
+    return decode(tail, skip_special_tokens=True).strip()
 
 
 # --- Unit-level chunking integration -----------------------------------------

--- a/scripts/wiki/chunking.py
+++ b/scripts/wiki/chunking.py
@@ -1,0 +1,469 @@
+"""Boundary-aware chunking policies for the dense retrieval index.
+
+Replaces the per-iterator ad-hoc chunkers (#1348 only chunked Wikipedia
+at 450/50 tokens via ``chunk_wikipedia_article``; textbook / external /
+literary corpora ran un-chunked through a 512-token encoder window,
+silently truncating long sources). #1553 centralizes chunking here:
+one policy per corpus, one algorithm, one place to change.
+
+Design notes:
+
+- ``ChunkingPolicy`` carries a ``version_id`` that gets stamped into
+  ``embedding_units.chunk_policy_version``. Bumping the version forces
+  re-encode of that corpus alone — see #1553 step 0.
+- Boundary-aware splitting tries paragraph -> sentence -> token-window
+  in that order, so chunk boundaries land at semantic seams whenever
+  possible. MIRACL precedent for paragraph-first segmentation.
+- Ukrainian uses the same terminal punctuation as English (.!?…), so
+  the splitter is mostly language-agnostic. A small abbreviation
+  guard handles the most common Ukrainian period-non-terminators
+  (вул., р., ст., etc.) without claiming exhaustive coverage —
+  false negatives produce slightly longer chunks, which is harmless.
+- The chunker uses the BGE-M3 tokenizer for length accounting so its
+  count matches what the encoder will see.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from .embedding_manifest_schema import LEGACY_CHUNK_POLICY_VERSION
+
+
+class TokenizerProtocol(Protocol):
+    def encode(
+        self,
+        text: str,
+        *,
+        add_special_tokens: bool = ...,
+        truncation: bool = ...,
+    ) -> list[int]: ...
+
+
+@dataclass(frozen=True)
+class ChunkingPolicy:
+    """Per-corpus chunking strategy + manifest version stamp.
+
+    ``target_tokens`` of 0 disables chunking entirely — the original
+    unit is yielded unchanged. Used for corpora that are already
+    ingest-time chunked to a sensible size (``ukrainian_wiki``,
+    literary).
+
+    ``version_id`` is what gets written to
+    ``embedding_units.chunk_policy_version``. By convention:
+    ``"<corpus>:<algo>-v<n>"`` — so a textbook chunker change does
+    not invalidate Wikipedia embeddings. The shipped value
+    ``LEGACY_CHUNK_POLICY_VERSION`` is reserved for the no-chunk
+    case so legacy manifest rows stay valid.
+    """
+
+    version_id: str
+    target_tokens: int
+    overlap_tokens: int
+
+
+#: No-op policy for corpora that are already pre-chunked at ingest
+#: (``ukrainian_wiki``, ``modern_literary``, ``archaic_literary``).
+NO_CHUNK = ChunkingPolicy(
+    version_id=LEGACY_CHUNK_POLICY_VERSION,
+    target_tokens=0,
+    overlap_tokens=0,
+)
+
+
+def _paragraph_aware_policy(corpus: str, *, target: int, overlap: int) -> ChunkingPolicy:
+    """Construct a paragraph-aware policy whose ``version_id`` encodes
+    the parameters.
+
+    Codex review (msg #457): "Include policy params in version_id or
+    make version bumps mandatory when target_tokens / overlap_tokens
+    change." Auto-deriving the version from params makes accidental
+    silent reuse impossible — bumping ``target`` or ``overlap``
+    mechanically bumps the manifest stamp.
+    """
+
+    return ChunkingPolicy(
+        version_id=f"{corpus}:paragraph-aware-{target}t-o{overlap}-v1",
+        target_tokens=target,
+        overlap_tokens=overlap,
+    )
+
+
+#: Step 1 chunk size. Matches the #1348-shipped Wikipedia chunker
+#: (450 tokens with 50-token overlap) so chunks fit within the
+#: current ``INDEX_MAX_LENGTH=512`` window without any encoder-side
+#: truncation. Bakeoff (#1553 step 5) will override this with larger
+#: values once ``INDEX_MAX_LENGTH`` bumps to 2048+; the auto-derived
+#: ``version_id`` mechanically forces a re-encode when that lands.
+_STEP1_TARGET_TOKENS = 450
+_STEP1_OVERLAP_TOKENS = 50
+
+
+#: Per-corpus chunking policies. SUPPORTED_CORPORA must be a subset
+#: of these keys — see the ``_assert_full_coverage`` sanity check at
+#: import time.
+CHUNKING_POLICIES: dict[str, ChunkingPolicy] = {
+    # Already paragraph-pre-chunked at ingest, p99 ~240 tokens.
+    "ukrainian_wiki": NO_CHUNK,
+    # Ingest-time chunked at ~620 tokens, p99 ~1300 tokens — already
+    # fits the current 512-token encoder window for the bulk of
+    # rows; re-chunking would invalidate 137K vectors for marginal
+    # tail-recall gain.
+    "modern_literary": NO_CHUNK,
+    "archaic_literary": NO_CHUNK,
+    # Long-form corpora that #1348 left un-chunked. Median token
+    # counts: textbook 1000, external 4500, wikipedia 3800. All
+    # exceed the current 512-token encoder window without chunking.
+    "wikipedia": _paragraph_aware_policy(
+        "wikipedia", target=_STEP1_TARGET_TOKENS, overlap=_STEP1_OVERLAP_TOKENS
+    ),
+    "external": _paragraph_aware_policy(
+        "external", target=_STEP1_TARGET_TOKENS, overlap=_STEP1_OVERLAP_TOKENS
+    ),
+    "textbook_sections": _paragraph_aware_policy(
+        "textbook_sections",
+        target=_STEP1_TARGET_TOKENS,
+        overlap=_STEP1_OVERLAP_TOKENS,
+    ),
+}
+
+
+def policy_for(corpus: str) -> ChunkingPolicy:
+    """Return the active ``ChunkingPolicy`` for ``corpus``.
+
+    Raises ``KeyError`` for corpora not registered in
+    ``CHUNKING_POLICIES``. Codex review (msg #457): "Avoid
+    ``CHUNKING_POLICIES.get(corpus, NO_CHUNK)`` silently masking
+    unknown corpora if corpus names are expected to be closed."
+    Closed they are — ``SUPPORTED_CORPORA`` in dense_rerank is the
+    canonical list and a NEW corpus must register its policy
+    explicitly.
+    """
+
+    try:
+        return CHUNKING_POLICIES[corpus]
+    except KeyError as exc:
+        known = sorted(CHUNKING_POLICIES)
+        raise KeyError(
+            f"no ChunkingPolicy registered for corpus {corpus!r}; "
+            f"register one in CHUNKING_POLICIES or use NO_CHUNK explicitly. "
+            f"Known: {known}"
+        ) from exc
+
+
+# --- Boundary-aware splitter -------------------------------------------------
+
+_PARA_RE = re.compile(r"\n\n+")
+_SENT_RE = re.compile(r"(?<=[.!?…])\s+")
+
+#: Conservative list of Ukrainian abbreviations that look like sentence
+#: terminators but aren't. False negatives just produce slightly longer
+#: chunks; false positives would split mid-clause, which is worse, so
+#: we err toward including more here.
+_UK_ABBREVIATIONS: frozenset[str] = frozenset({
+    "акад",        # академік
+    "вул",         # вулиця
+    "грн",         # гривень
+    "ім",          # імені
+    "ін",          # інше
+    "напр",        # наприклад
+    "наприкл",     # наприклад
+    "обл",         # область
+    "п",           # пан / пункт
+    "проф",        # професор
+    "р",           # рік / річка
+    "рр",          # роки
+    "ст",          # стаття / століття
+    "т",           # том
+    "тт",          # томи
+    "т.зв",        # так званий
+    "т.т",         # тобто
+})
+
+
+def split_paragraphs(text: str) -> list[str]:
+    """Split ``text`` on blank-line boundaries, dropping empties."""
+
+    return [paragraph.strip() for paragraph in _PARA_RE.split(text) if paragraph.strip()]
+
+
+def split_sentences(paragraph: str) -> list[str]:
+    """Split a paragraph on terminal-punctuation+whitespace boundaries.
+
+    Merges fragments whose preceding token is a known Ukrainian
+    abbreviation, so ``"проф. Іван Франко був..."`` stays one
+    sentence instead of splitting on ``"проф."``.
+    """
+
+    raw = _SENT_RE.split(paragraph)
+    out: list[str] = []
+    for fragment in raw:
+        fragment = fragment.strip()
+        if not fragment:
+            continue
+        if out:
+            previous = out[-1]
+            tail_word = _last_alpha_token(previous).lower()
+            if tail_word in _UK_ABBREVIATIONS:
+                out[-1] = f"{previous} {fragment}"
+                continue
+        out.append(fragment)
+    return out
+
+
+def _last_alpha_token(text: str) -> str:
+    # Find last "word." pattern: last alphabetic run before a trailing dot.
+    match = re.search(r"([A-Za-zА-Яа-яҐґЄєІіЇї]+)\.\s*$", text)
+    return match.group(1) if match else ""
+
+
+def _count_tokens(text: str, *, tokenizer: TokenizerProtocol) -> int:
+    """Token count using the encoder's tokenizer; matches what the
+    encoder will see at index time."""
+
+    return len(tokenizer.encode(text, add_special_tokens=False, truncation=False))
+
+
+def boundary_aware_chunks(
+    text: str,
+    *,
+    policy: ChunkingPolicy,
+    tokenizer: TokenizerProtocol,
+) -> list[str]:
+    """Return a list of chunk strings for ``text`` per ``policy``.
+
+    Empty input -> empty list. Text under ``target_tokens`` -> a
+    single-element list containing the original (possibly stripped)
+    text. ``policy.target_tokens == 0`` is invalid here; callers
+    should short-circuit at the registry level via ``NO_CHUNK``.
+    """
+
+    if policy.target_tokens <= 0:
+        raise ValueError("boundary_aware_chunks requires target_tokens > 0")
+
+    text = text.strip()
+    if not text:
+        return []
+
+    total_tokens = _count_tokens(text, tokenizer=tokenizer)
+    if total_tokens <= policy.target_tokens:
+        return [text]
+
+    paragraphs = split_paragraphs(text)
+    if not paragraphs:
+        return [text]
+
+    chunks: list[str] = []
+    buffer: list[str] = []
+    buffer_tokens = 0
+
+    for paragraph in paragraphs:
+        paragraph_tokens = _count_tokens(paragraph, tokenizer=tokenizer)
+        # Case 1: a single paragraph blows the budget on its own.
+        if paragraph_tokens > policy.target_tokens:
+            if buffer:
+                chunks.append("\n\n".join(buffer))
+                buffer = []
+                buffer_tokens = 0
+            chunks.extend(_chunk_long_paragraph(paragraph, policy=policy, tokenizer=tokenizer))
+            continue
+        # Case 2: adding this paragraph would overflow the buffer.
+        if buffer_tokens + paragraph_tokens > policy.target_tokens:
+            chunks.append("\n\n".join(buffer))
+            buffer = []
+            buffer_tokens = 0
+        buffer.append(paragraph)
+        buffer_tokens += paragraph_tokens
+
+    if buffer:
+        chunks.append("\n\n".join(buffer))
+
+    return _apply_overlap(chunks, policy=policy, tokenizer=tokenizer)
+
+
+def _chunk_long_paragraph(
+    paragraph: str,
+    *,
+    policy: ChunkingPolicy,
+    tokenizer: TokenizerProtocol,
+) -> list[str]:
+    """Split a paragraph that exceeds the target into sentence-aligned
+    chunks, falling back to raw token windows for pathologically long
+    single sentences."""
+
+    sentences = split_sentences(paragraph)
+    if not sentences:
+        return [paragraph]
+
+    chunks: list[str] = []
+    buffer: list[str] = []
+    buffer_tokens = 0
+    for sentence in sentences:
+        sentence_tokens = _count_tokens(sentence, tokenizer=tokenizer)
+        if sentence_tokens > policy.target_tokens:
+            if buffer:
+                chunks.append(" ".join(buffer))
+                buffer = []
+                buffer_tokens = 0
+            chunks.extend(_chunk_token_window(sentence, policy=policy, tokenizer=tokenizer))
+            continue
+        if buffer_tokens + sentence_tokens > policy.target_tokens:
+            chunks.append(" ".join(buffer))
+            buffer = []
+            buffer_tokens = 0
+        buffer.append(sentence)
+        buffer_tokens += sentence_tokens
+
+    if buffer:
+        chunks.append(" ".join(buffer))
+
+    return chunks
+
+
+def _chunk_token_window(
+    text: str,
+    *,
+    policy: ChunkingPolicy,
+    tokenizer: TokenizerProtocol,
+) -> list[str]:
+    """Last-resort token-window splitter for pathological single
+    sentences that exceed the chunk target. Decode-encodes round-trip
+    so the chunk text can be measured by the same tokenizer.
+    """
+
+    token_ids = tokenizer.encode(text, add_special_tokens=False, truncation=False)
+    if not token_ids:
+        return []
+    if len(token_ids) <= policy.target_tokens:
+        return [text]
+
+    # The tokenizer object also exposes ``decode`` on real BGE-M3, but
+    # the protocol here only types ``encode``. Cast at use site to
+    # keep the public surface narrow; tests pass a fake tokenizer
+    # that supports both.
+    decode = getattr(tokenizer, "decode", None)
+    if decode is None:  # pragma: no cover — defensive
+        # If decode isn't available we can't safely chop tokens back
+        # into text. Yield the text whole and let the encoder
+        # truncate — degrades gracefully.
+        return [text]
+
+    chunks: list[str] = []
+    step = max(1, policy.target_tokens - policy.overlap_tokens)
+    start = 0
+    while start < len(token_ids):
+        end = min(len(token_ids), start + policy.target_tokens)
+        piece = decode(token_ids[start:end], skip_special_tokens=True).strip()
+        if piece:
+            chunks.append(piece)
+        if end >= len(token_ids):
+            break
+        start += step
+    return chunks
+
+
+def _apply_overlap(
+    chunks: list[str],
+    *,
+    policy: ChunkingPolicy,
+    tokenizer: TokenizerProtocol,
+) -> list[str]:
+    """Prepend the trailing ``overlap_tokens`` of chunk N to chunk
+    N+1, taken at sentence boundaries when possible.
+
+    Token-aligned overlap is a fallback. Sentence-aligned overlap is
+    preferred because it preserves clause boundaries — the whole
+    point of boundary-aware chunking.
+    """
+
+    if policy.overlap_tokens <= 0 or len(chunks) < 2:
+        return chunks
+
+    out: list[str] = [chunks[0]]
+    for idx in range(1, len(chunks)):
+        prev = out[-1]
+        overlap = _trailing_sentences_for_overlap(
+            prev,
+            target_tokens=policy.overlap_tokens,
+            tokenizer=tokenizer,
+        )
+        if overlap:
+            out.append(f"{overlap} {chunks[idx]}".strip())
+        else:
+            out.append(chunks[idx])
+    return out
+
+
+def _trailing_sentences_for_overlap(
+    text: str,
+    *,
+    target_tokens: int,
+    tokenizer: TokenizerProtocol,
+) -> str:
+    """Pick the trailing sentences of ``text`` that fit within
+    ``target_tokens``. Empty string if no sentence fits."""
+
+    sentences = split_sentences(text)
+    if not sentences:
+        return ""
+    chosen: list[str] = []
+    chosen_tokens = 0
+    for sentence in reversed(sentences):
+        sentence_tokens = _count_tokens(sentence, tokenizer=tokenizer)
+        if chosen_tokens + sentence_tokens > target_tokens and chosen:
+            break
+        chosen.insert(0, sentence)
+        chosen_tokens += sentence_tokens
+        if chosen_tokens >= target_tokens:
+            break
+    return " ".join(chosen)
+
+
+# --- Unit-level chunking integration -----------------------------------------
+
+#: Result of chunking a single ``CorpusUnit``. Caller (in
+#: ``dense_rerank.load_corpus_units``) maps these back to
+#: ``CorpusUnit`` objects with proper unit_key/parent_key/metadata.
+@dataclass(frozen=True)
+class ChunkedPiece:
+    chunk_index: int
+    text: str
+    extra_metadata: dict[str, object] = field(default_factory=dict)
+
+
+def chunk_text(
+    text: str,
+    *,
+    policy: ChunkingPolicy,
+    tokenizer: TokenizerProtocol,
+) -> Iterator[ChunkedPiece]:
+    """Yield ``ChunkedPiece`` instances for ``text`` per ``policy``.
+
+    The integration point used by ``dense_rerank.load_corpus_units``.
+    Yields exactly one piece (chunk_index=0) when ``policy`` is
+    ``NO_CHUNK`` or the text already fits — preserving the
+    "single-chunk" contract that pre-#1553 ingest expects.
+    """
+
+    if policy.target_tokens <= 0:
+        # NO_CHUNK — caller wants the original unit back unchanged.
+        yield ChunkedPiece(chunk_index=0, text=text)
+        return
+
+    pieces = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    if len(pieces) <= 1:
+        # Either empty (no text) or single-chunk (under target).
+        if not pieces:
+            return
+        yield ChunkedPiece(chunk_index=0, text=pieces[0])
+        return
+
+    for index, piece in enumerate(pieces):
+        yield ChunkedPiece(
+            chunk_index=index,
+            text=piece,
+            extra_metadata={"chunk_index": index, "chunk_count": len(pieces)},
+        )

--- a/scripts/wiki/cold_encode.py
+++ b/scripts/wiki/cold_encode.py
@@ -16,6 +16,7 @@ if __package__ in {None, ""}:
         DEFAULT_MANIFEST_DB,
         SUPPORTED_CORPORA,
         cold_encode_corpus,
+        current_encoder_config,
         load_corpus_units,
     )
     from wiki.embedding_manifest import EmbeddingManifest, filter_new_or_changed
@@ -25,6 +26,7 @@ else:
         DEFAULT_MANIFEST_DB,
         SUPPORTED_CORPORA,
         cold_encode_corpus,
+        current_encoder_config,
         load_corpus_units,
     )
     from .embedding_manifest import EmbeddingManifest, filter_new_or_changed
@@ -49,6 +51,7 @@ def _dry_run_summary(corpus: str, *, db_path: Path, manifest_db: Path) -> dict:
             manifest,
             corpus=corpus,
             candidates=[(unit.unit_key, unit.text_sha256) for unit in units],
+            expected_config=current_encoder_config(corpus),
         )
         return {
             "event": "dry_run",

--- a/scripts/wiki/dense_rerank.py
+++ b/scripts/wiki/dense_rerank.py
@@ -187,6 +187,33 @@ def _now_utc_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _suppress_misleading_tokenizer_warning() -> None:
+    """Filter HuggingFace's "sequence length is longer than the
+    specified maximum" warning at the logger level (#1553 step 4).
+
+    The warning is emitted from
+    ``transformers.tokenization_utils_base`` BEFORE truncation
+    actually runs. Every code path that calls the tokenizer
+    explicitly passes ``truncation=True, max_length=...``, so the
+    warning is a false alarm — but it still scares future readers
+    of build logs into thinking the encoder will crash.
+
+    Filter only the one specific warning at the transformers
+    tokenization logger; do not suppress real warnings.
+    """
+
+    import logging
+
+    class _SilenceLengthWarning(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            return "Token indices sequence length is longer" not in record.getMessage()
+
+    logger = logging.getLogger("transformers.tokenization_utils_base")
+    # Idempotent: don't add the filter twice on re-import.
+    if not any(isinstance(f, _SilenceLengthWarning) for f in logger.filters):
+        logger.addFilter(_SilenceLengthWarning())
+
+
 def _get_tokenizer():
     global _TOKENIZER
     if _TOKENIZER is not None:
@@ -196,6 +223,7 @@ def _get_tokenizer():
         if _TOKENIZER is None:
             from transformers import AutoTokenizer
 
+            _suppress_misleading_tokenizer_warning()
             _TOKENIZER = AutoTokenizer.from_pretrained("BAAI/bge-m3", use_fast=True)
     return _TOKENIZER
 
@@ -822,6 +850,59 @@ def load_corpus_units(corpus: str, *, db_path: Path = DEFAULT_DB_PATH) -> list[C
         conn.close()
 
 
+def _assert_units_fit_index_window(
+    units: list[CorpusUnit],
+    *,
+    corpus: str,
+    max_length: int | None = None,
+) -> None:
+    """Validator gate (#1553 step 3): no post-chunk unit may exceed
+    ``INDEX_MAX_LENGTH`` tokens.
+
+    Pre-#1553 the tokenizer emitted a 22,174 > 8192 warning during
+    a live build because un-chunked textbook sections fed straight
+    into a 512-token encoder window. The chunker added in step 1
+    is supposed to prevent that, but a misconfigured policy (e.g.
+    ``target_tokens=2000`` while ``INDEX_MAX_LENGTH=512``) would
+    silently re-introduce the bug. This gate makes the failure
+    loud at encode time instead of buried in tokenizer stderr.
+
+    Skipped silently if a corpus has units > max_length AND its
+    chunking policy says ``target_tokens == 0`` (no-chunk policy
+    intentionally accepts whatever the source row length is — that
+    behavior is preserved for the literary corpora where re-chunking
+    would invalidate 137K vectors for marginal gain).
+    """
+
+    cap = INDEX_MAX_LENGTH if max_length is None else max_length
+    policy = policy_for(corpus)
+    if policy.target_tokens == 0:
+        # NO_CHUNK policy: tolerate >cap units. The encoder will
+        # truncate per its own ``truncation=True`` setting, which is
+        # the intended behavior for these pre-chunked corpora.
+        return
+
+    tokenizer = _get_tokenizer()
+    over = []
+    for unit in units:
+        token_count = len(
+            tokenizer.encode(unit.text, add_special_tokens=False, truncation=False)
+        )
+        if token_count > cap:
+            over.append((unit.unit_key, token_count))
+            if len(over) >= 5:
+                break
+
+    if over:
+        examples = ", ".join(f"{key} ({count}t)" for key, count in over)
+        raise ValueError(
+            f"chunking policy {policy.version_id!r} for corpus {corpus!r} "
+            f"emitted {len(over)}+ units exceeding INDEX_MAX_LENGTH={cap}. "
+            f"Examples: {examples}. Either bump INDEX_MAX_LENGTH or lower "
+            f"the policy's target_tokens (and its version_id)."
+        )
+
+
 def _with_text(unit: CorpusUnit, text: str) -> CorpusUnit:
     """Return a copy of ``unit`` with replaced ``text`` and recomputed
     ``text_sha256``. Used when a NO_CHUNK policy emits stripped text
@@ -875,6 +956,7 @@ def cold_encode_corpus(
 
     started = time.perf_counter()
     units = load_corpus_units(corpus, db_path=db_path)
+    _assert_units_fit_index_window(units, corpus=corpus)
     manifest = EmbeddingManifest(manifest_db)
     encoder_config = current_encoder_config(corpus)
     try:

--- a/scripts/wiki/dense_rerank.py
+++ b/scripts/wiki/dense_rerank.py
@@ -22,18 +22,46 @@ from numpy.typing import NDArray
 from .config import PROJECT_ROOT
 from .embedding_manifest import (
     EmbeddingManifest,
+    EncoderConfig,
     UnitSpecInput,
     append_shard,
     filter_new_or_changed,
 )
+from .embedding_manifest_schema import LEGACY_CHUNK_POLICY_VERSION
 from .mlx_bridge import EMBEDDING_DIMS, MLXEncoderBridge
 from .thermal import nsprocessinfo_thermal_state
 
 DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
 DEFAULT_MANIFEST_DB = PROJECT_ROOT / "data" / "embeddings" / "manifest.db"
 DEFAULT_MODEL_ID = "bge-m3-mlx-fp16"
+DEFAULT_POOLING_MODE = "cls"
 QUERY_MAX_LENGTH = 512
 INDEX_MAX_LENGTH = 512
+
+
+def current_encoder_config(corpus: str) -> EncoderConfig:
+    """Build the ``EncoderConfig`` that the runtime is currently using.
+
+    For #1553 step 0 (this commit) the runtime still produces the
+    shipped #1348 embeddings: model bge-m3-mlx-fp16, INDEX_MAX_LENGTH
+    512, CLS pooling, and the legacy chunk policy (Wikipedia 450/50,
+    other corpora un-chunked). All values come back as
+    ``LEGACY_CHUNK_POLICY_VERSION`` here so freshly-encoded units
+    match pre-existing manifest rows — no spurious re-encode.
+
+    Step 1 (centralized chunker) replaces the legacy policy version
+    with a per-corpus value derived from the chunker registry. The
+    ``corpus`` parameter exists so that change is a single-callsite
+    edit.
+    """
+
+    del corpus  # Reserved for step 1 — see docstring.
+    return EncoderConfig(
+        model=DEFAULT_MODEL_ID,
+        index_max_length=INDEX_MAX_LENGTH,
+        chunk_policy_version=LEGACY_CHUNK_POLICY_VERSION,
+        pooling_mode=DEFAULT_POOLING_MODE,
+    )
 MAX_BATCH_ROWS = 16
 MAX_BATCH_TOKENS = 4096
 LITERARY_SHARD_LIMIT = 5000
@@ -816,11 +844,13 @@ def cold_encode_corpus(
     started = time.perf_counter()
     units = load_corpus_units(corpus, db_path=db_path)
     manifest = EmbeddingManifest(manifest_db)
+    encoder_config = current_encoder_config(corpus)
     try:
         new_keys, stale_keys = filter_new_or_changed(
             manifest,
             corpus=corpus,
             candidates=[(unit.unit_key, unit.text_sha256) for unit in units],
+            expected_config=encoder_config,
         )
         pending_keys = set(new_keys) | set(stale_keys)
 
@@ -865,10 +895,10 @@ def cold_encode_corpus(
                         unit_key=unit.unit_key,
                         parent_key=unit.parent_key,
                         text_sha256=unit.text_sha256,
-                        model=DEFAULT_MODEL_ID,
                     )
                     for unit in group
                 ],
+                encoder_config=encoder_config,
             )
             invalidate_corpus_index(corpus, manifest_db=manifest_db)
             written += 1

--- a/scripts/wiki/dense_rerank.py
+++ b/scripts/wiki/dense_rerank.py
@@ -19,6 +19,7 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
+from .chunking import chunk_text, policy_for
 from .config import PROJECT_ROOT
 from .embedding_manifest import (
     EmbeddingManifest,
@@ -27,7 +28,6 @@ from .embedding_manifest import (
     append_shard,
     filter_new_or_changed,
 )
-from .embedding_manifest_schema import LEGACY_CHUNK_POLICY_VERSION
 from .mlx_bridge import EMBEDDING_DIMS, MLXEncoderBridge
 from .thermal import nsprocessinfo_thermal_state
 
@@ -40,26 +40,25 @@ INDEX_MAX_LENGTH = 512
 
 
 def current_encoder_config(corpus: str) -> EncoderConfig:
-    """Build the ``EncoderConfig`` that the runtime is currently using.
+    """Build the ``EncoderConfig`` that the runtime is currently using
+    for ``corpus``.
 
-    For #1553 step 0 (this commit) the runtime still produces the
-    shipped #1348 embeddings: model bge-m3-mlx-fp16, INDEX_MAX_LENGTH
-    512, CLS pooling, and the legacy chunk policy (Wikipedia 450/50,
-    other corpora un-chunked). All values come back as
-    ``LEGACY_CHUNK_POLICY_VERSION`` here so freshly-encoded units
-    match pre-existing manifest rows — no spurious re-encode.
+    The ``chunk_policy_version`` is pulled from the chunking registry
+    (``wiki.chunking.CHUNKING_POLICIES``), so per-corpus chunker
+    changes invalidate that corpus's manifest entries automatically.
+    Unknown corpora raise ``KeyError`` — registration is required.
 
-    Step 1 (centralized chunker) replaces the legacy policy version
-    with a per-corpus value derived from the chunker registry. The
-    ``corpus`` parameter exists so that change is a single-callsite
-    edit.
+    Until #1553 step 5 bumps ``INDEX_MAX_LENGTH`` past 512, the
+    model + max-length + pooling tuple stays at the #1348 shipped
+    values and only the chunk_policy_version field shifts when the
+    chunker changes (paragraph-aware policies replace the legacy
+    "no chunking" stamp on textbook / external / wikipedia).
     """
 
-    del corpus  # Reserved for step 1 — see docstring.
     return EncoderConfig(
         model=DEFAULT_MODEL_ID,
         index_max_length=INDEX_MAX_LENGTH,
-        chunk_policy_version=LEGACY_CHUNK_POLICY_VERSION,
+        chunk_policy_version=policy_for(corpus).version_id,
         pooling_mode=DEFAULT_POOLING_MODE,
     )
 MAX_BATCH_ROWS = 16
@@ -681,41 +680,16 @@ def _iter_external_units(conn: sqlite3.Connection) -> Iterator[CorpusUnit]:
         )
 
 
-def chunk_wikipedia_article(
-    title: str,
-    text: str,
-    *,
-    chunk_tokens: int = 450,
-    overlap_tokens: int = 50,
-) -> list[dict[str, Any]]:
-    tokenizer = _get_tokenizer()
-    token_ids = tokenizer.encode(text, add_special_tokens=False, truncation=False)
-    if not token_ids:
-        return []
-
-    chunks: list[dict[str, Any]] = []
-    start = 0
-    chunk_index = 0
-    step = max(1, chunk_tokens - overlap_tokens)
-    while start < len(token_ids):
-        end = min(len(token_ids), start + chunk_tokens)
-        chunk_text = tokenizer.decode(token_ids[start:end], skip_special_tokens=True).strip()
-        if chunk_text:
-            chunks.append(
-                {
-                    "chunk_index": chunk_index,
-                    "text": chunk_text,
-                    "unit_key": f"wikipedia:{title}:chunk_{chunk_index}",
-                }
-            )
-        if end >= len(token_ids):
-            break
-        start += step
-        chunk_index += 1
-    return chunks
-
-
 def _iter_wikipedia_units(conn: sqlite3.Connection) -> Iterator[CorpusUnit]:
+    """Yield one ``CorpusUnit`` per Wikipedia article.
+
+    Pre-#1553 this iterator inlined a token-window chunker
+    (``chunk_wikipedia_article``, 450t/50t). Step 1 of #1553 moves
+    chunking out to ``wiki.chunking`` so the policy is uniform across
+    all corpora and applied centrally inside ``load_corpus_units``.
+    The iterator now yields whole articles; the chunker splits them.
+    """
+
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
         """
@@ -726,20 +700,18 @@ def _iter_wikipedia_units(conn: sqlite3.Connection) -> Iterator[CorpusUnit]:
     ).fetchall()
     for row in rows:
         title = str(row["title"] or "")
-        for chunk in chunk_wikipedia_article(title, str(row["text"] or "")):
-            text = str(chunk["text"])
-            yield CorpusUnit(
-                unit_key=str(chunk["unit_key"]),
-                corpus="wikipedia",
-                parent_key=title,
-                text=text,
-                text_sha256=text_sha256(text),
-                metadata={
-                    "title": title,
-                    "url": str(row["url"] or ""),
-                    "chunk_index": int(chunk["chunk_index"]),
-                },
-            )
+        text = str(row["text"] or "")
+        yield CorpusUnit(
+            unit_key=f"wikipedia:{title}",
+            corpus="wikipedia",
+            parent_key=title,
+            text=text,
+            text_sha256=text_sha256(text),
+            metadata={
+                "title": title,
+                "url": str(row["url"] or ""),
+            },
+        )
 
 
 def _iter_ukrainian_wiki_units(conn: sqlite3.Connection) -> Iterator[CorpusUnit]:
@@ -794,15 +766,75 @@ CORPUS_UNIT_LOADERS: dict[str, Callable[[sqlite3.Connection], Iterator[CorpusUni
 
 
 def load_corpus_units(corpus: str, *, db_path: Path = DEFAULT_DB_PATH) -> list[CorpusUnit]:
+    """Load all units for ``corpus``, applying the central chunking
+    policy from ``wiki.chunking``.
+
+    Pre-#1553 this returned whatever the iterator yielded. Step 1
+    centralizes chunking: each raw unit is fed to ``chunk_text``,
+    which respects the ``ChunkingPolicy`` for ``corpus``. NO_CHUNK
+    policies pass units through unchanged (preserves the existing
+    ingest-chunked behavior of literary / ukrainian_wiki). Active
+    policies emit ``unit_key:chunk_N`` sub-units with
+    ``chunk_index`` / ``chunk_count`` / ``parent_unit_key`` metadata
+    so post-rerank parent expansion can group siblings back together.
+    """
+
     loader = CORPUS_UNIT_LOADERS.get(corpus)
     if loader is None:
         raise ValueError(f"unsupported corpus: {corpus}")
 
+    policy = policy_for(corpus)
+    tokenizer = _get_tokenizer()
+
     conn = sqlite3.connect(str(db_path))
     try:
-        return list(loader(conn))
+        units: list[CorpusUnit] = []
+        for raw_unit in loader(conn):
+            for piece in chunk_text(raw_unit.text, policy=policy, tokenizer=tokenizer):
+                if not piece.text:
+                    continue
+                # NO_CHUNK / single-chunk: yield original unit
+                # unchanged (one-piece-with-chunk_index-0 contract).
+                if not piece.extra_metadata:
+                    if piece.text == raw_unit.text:
+                        units.append(raw_unit)
+                    else:
+                        units.append(_with_text(raw_unit, piece.text))
+                    continue
+                # Active policy: synthesize a sub-unit.
+                metadata = {
+                    **raw_unit.metadata,
+                    "parent_unit_key": raw_unit.unit_key,
+                    **piece.extra_metadata,
+                }
+                units.append(
+                    CorpusUnit(
+                        unit_key=f"{raw_unit.unit_key}:chunk_{piece.chunk_index}",
+                        corpus=raw_unit.corpus,
+                        parent_key=raw_unit.parent_key or raw_unit.unit_key,
+                        text=piece.text,
+                        text_sha256=text_sha256(piece.text),
+                        metadata=metadata,
+                    )
+                )
+        return units
     finally:
         conn.close()
+
+
+def _with_text(unit: CorpusUnit, text: str) -> CorpusUnit:
+    """Return a copy of ``unit`` with replaced ``text`` and recomputed
+    ``text_sha256``. Used when a NO_CHUNK policy emits stripped text
+    that differs from the original by whitespace only."""
+
+    return CorpusUnit(
+        unit_key=unit.unit_key,
+        corpus=unit.corpus,
+        parent_key=unit.parent_key,
+        text=text,
+        text_sha256=text_sha256(text),
+        metadata=unit.metadata,
+    )
 
 
 def _chunked(items: Sequence[CorpusUnit], size: int) -> Iterator[list[CorpusUnit]]:

--- a/scripts/wiki/embedding_manifest.py
+++ b/scripts/wiki/embedding_manifest.py
@@ -138,27 +138,71 @@ class EmbeddingManifest:
         ``DEFAULT`` clause on each ALTER, so the upgrade is
         non-destructive — old shards stay queryable.
 
-        Idempotent: a no-op once all v2 columns are present.
+        Concurrency: wrapped in ``BEGIN IMMEDIATE`` so two processes
+        that simultaneously open a v1 manifest cannot both observe
+        "v2 columns missing" and race to ALTER (one would get
+        ``duplicate column name``). The first writer takes the
+        reserved lock; the second blocks on ``busy_timeout`` and
+        re-reads PRAGMA after the lock releases — by which point
+        the columns exist and the ALTER loop is a no-op.
+
+        Idempotent: a no-op once all v2 columns are present, even
+        in pathological partial-v2 schemas (e.g. someone added one
+        column manually).
         """
+
+        # Fast path: read PRAGMA without a lock first. If everything
+        # is already v2, skip the immediate transaction entirely so
+        # opens of fully-migrated manifests stay cheap.
+        if self._is_schema_v2():
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_embunits_config "
+                "ON embedding_units(unit_key, model, index_max_length, "
+                "chunk_policy_version, pooling_mode)"
+            )
+            return
+
+        # Slow path: take the write lock and re-check under it. Two
+        # processes both arriving here will serialize; the second
+        # finds v2 already in place and exits without ALTERs.
+        self._begin_immediate()
+        try:
+            existing_columns = {
+                row["name"]
+                for row in self._conn.execute(
+                    "PRAGMA table_info(embedding_units)"
+                ).fetchall()
+            }
+            for name, type_, default_sql in V2_COLUMNS:
+                if name in existing_columns:
+                    continue
+                self._conn.execute(
+                    f"ALTER TABLE embedding_units "
+                    f"ADD COLUMN {name} {type_} DEFAULT {default_sql}"
+                )
+            # v2 config-aware index. Created inside the same lock so
+            # it only runs after the columns it references exist.
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_embunits_config "
+                "ON embedding_units(unit_key, model, index_max_length, "
+                "chunk_policy_version, pooling_mode)"
+            )
+            self._conn.commit()
+        except Exception:
+            self._rollback_quietly()
+            raise
+
+    def _is_schema_v2(self) -> bool:
+        """Cheap check (no lock) — does ``embedding_units`` already
+        carry every v2 column?"""
 
         existing_columns = {
             row["name"]
-            for row in self._conn.execute("PRAGMA table_info(embedding_units)").fetchall()
+            for row in self._conn.execute(
+                "PRAGMA table_info(embedding_units)"
+            ).fetchall()
         }
-        for name, type_, default_sql in V2_COLUMNS:
-            if name in existing_columns:
-                continue
-            self._conn.execute(
-                f"ALTER TABLE embedding_units "
-                f"ADD COLUMN {name} {type_} DEFAULT {default_sql}"
-            )
-        # v2 config-aware index. Created here (not in the DDL) so it
-        # only runs after the columns it references exist.
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_embunits_config "
-            "ON embedding_units(unit_key, model, index_max_length, "
-            "chunk_policy_version, pooling_mode)"
-        )
+        return all(name in existing_columns for name, _, _ in V2_COLUMNS)
 
     def add_shard(
         self,

--- a/scripts/wiki/embedding_manifest.py
+++ b/scripts/wiki/embedding_manifest.py
@@ -14,7 +14,13 @@ from pathlib import Path
 import numpy as np
 from numpy.typing import NDArray
 
-from .embedding_manifest_schema import EMBEDDING_MANIFEST_DDL
+from .embedding_manifest_schema import (
+    EMBEDDING_MANIFEST_DDL_V1,
+    LEGACY_CHUNK_POLICY_VERSION,
+    LEGACY_INDEX_MAX_LENGTH,
+    LEGACY_POOLING_MODE,
+    V2_COLUMNS,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_EMBEDDINGS_DIR = PROJECT_ROOT / "data" / "embeddings"
@@ -26,26 +32,81 @@ _SHARD_NAME_RE = re.compile(r"shard-(\d{6})\.npy$")
 
 
 @dataclass(frozen=True)
+class EncoderConfig:
+    """Full identity of an encoder run.
+
+    Two units encoded under different ``EncoderConfig`` values must
+    not be considered equivalent in the manifest, even when their
+    ``unit_key`` and ``text_sha256`` match. ``filter_new_or_changed``
+    uses this to force re-encode whenever any config knob shifts —
+    swapping the model, bumping ``INDEX_MAX_LENGTH``, changing the
+    chunker, or switching pooling all invalidate prior embeddings.
+
+    See #1553 for the failure mode this prevents (silently mixed
+    512/N-token index when ``--resume`` is run after a config bump).
+    """
+
+    model: str
+    index_max_length: int
+    chunk_policy_version: str
+    pooling_mode: str
+
+    def matches_row(self, row: UnitRow) -> bool:
+        return (
+            row.model == self.model
+            and row.index_max_length == self.index_max_length
+            and row.chunk_policy_version == self.chunk_policy_version
+            and row.pooling_mode == self.pooling_mode
+        )
+
+
+#: Encoder config that the v1 manifest (#1348) implicitly used. The
+#: ALTER-TABLE migration stamps every pre-existing row with these
+#: values so the upgrade is non-destructive: previously-encoded
+#: shards stay queryable and aren't marked stale until a real config
+#: change happens.
+LEGACY_SHIPPED_CONFIG = EncoderConfig(
+    model="bge-m3-mlx-fp16",
+    index_max_length=LEGACY_INDEX_MAX_LENGTH,
+    chunk_policy_version=LEGACY_CHUNK_POLICY_VERSION,
+    pooling_mode=LEGACY_POOLING_MODE,
+)
+
+
+@dataclass(frozen=True)
 class UnitSpecInput:
+    """Input descriptor for a unit being inserted into the manifest.
+
+    Per-unit data only — the encoder config that produced the vector
+    is passed once at the shard-append boundary (see ``append_shard``)
+    so the whole shard is guaranteed to share one ``EncoderConfig``.
+    """
+
     unit_key: str
     parent_key: str | None
     text_sha256: str
-    model: str
 
 
 @dataclass(frozen=True)
 class UnitSpec:
+    """Materialized unit row, post-shard-assignment, pre-write."""
+
     unit_key: str
     corpus: str
     parent_key: str | None
     text_sha256: str
     model: str
+    index_max_length: int
+    chunk_policy_version: str
+    pooling_mode: str
     shard_id: int
     row_idx: int
 
 
 @dataclass(frozen=True)
 class UnitRow(UnitSpec):
+    """Unit row as read back from the manifest."""
+
     deleted: bool
     updated_at: str
 
@@ -61,8 +122,43 @@ class EmbeddingManifest:
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON")
         self._conn.execute(f"PRAGMA busy_timeout = {_SQLITE_BUSY_TIMEOUT_MS}")
-        self._conn.executescript(EMBEDDING_MANIFEST_DDL)
+        self._conn.executescript(EMBEDDING_MANIFEST_DDL_V1)
+        self._ensure_schema_v2()
         self._conn.commit()
+
+    def _ensure_schema_v2(self) -> None:
+        """Idempotently upgrade a v1 manifest to v2 (#1553).
+
+        v1 (#1348) stored only ``model`` against each unit. v2 adds
+        ``index_max_length``, ``chunk_policy_version``, and
+        ``pooling_mode`` so that ``filter_new_or_changed`` can detect
+        when a config bump (e.g. ``INDEX_MAX_LENGTH=512 -> 2048``)
+        invalidates prior embeddings. Pre-existing v1 rows get
+        stamped with ``LEGACY_SHIPPED_CONFIG`` defaults via the
+        ``DEFAULT`` clause on each ALTER, so the upgrade is
+        non-destructive — old shards stay queryable.
+
+        Idempotent: a no-op once all v2 columns are present.
+        """
+
+        existing_columns = {
+            row["name"]
+            for row in self._conn.execute("PRAGMA table_info(embedding_units)").fetchall()
+        }
+        for name, type_, default_sql in V2_COLUMNS:
+            if name in existing_columns:
+                continue
+            self._conn.execute(
+                f"ALTER TABLE embedding_units "
+                f"ADD COLUMN {name} {type_} DEFAULT {default_sql}"
+            )
+        # v2 config-aware index. Created here (not in the DDL) so it
+        # only runs after the columns it references exist.
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_embunits_config "
+            "ON embedding_units(unit_key, model, index_max_length, "
+            "chunk_policy_version, pooling_mode)"
+        )
 
     def add_shard(
         self,
@@ -109,6 +205,9 @@ class EmbeddingManifest:
                 parent_key,
                 text_sha256,
                 model,
+                index_max_length,
+                chunk_policy_version,
+                pooling_mode,
                 shard_id,
                 row_idx,
                 deleted,
@@ -135,6 +234,9 @@ class EmbeddingManifest:
                     parent_key,
                     text_sha256,
                     model,
+                    index_max_length,
+                    chunk_policy_version,
+                    pooling_mode,
                     shard_id,
                     row_idx,
                     deleted,
@@ -162,6 +264,9 @@ class EmbeddingManifest:
                 parent_key,
                 text_sha256,
                 model,
+                index_max_length,
+                chunk_policy_version,
+                pooling_mode,
                 shard_id,
                 row_idx,
                 deleted,
@@ -311,7 +416,10 @@ class EmbeddingManifest:
             """,
             (corpus, path.as_posix(), rows, dims, dtype, committed_at),
         )
-        return int(cursor.lastrowid)
+        last_id = cursor.lastrowid
+        if last_id is None:  # pragma: no cover — INSERT always sets lastrowid
+            raise RuntimeError("INSERT INTO embedding_shards did not return a row id")
+        return int(last_id)
 
     def _upsert_units(self, rows: list[UnitSpec], *, updated_at: str) -> None:
         self._conn.executemany(
@@ -322,17 +430,23 @@ class EmbeddingManifest:
                 parent_key,
                 text_sha256,
                 model,
+                index_max_length,
+                chunk_policy_version,
+                pooling_mode,
                 shard_id,
                 row_idx,
                 deleted,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
             ON CONFLICT(unit_key) DO UPDATE SET
                 corpus = excluded.corpus,
                 parent_key = excluded.parent_key,
                 text_sha256 = excluded.text_sha256,
                 model = excluded.model,
+                index_max_length = excluded.index_max_length,
+                chunk_policy_version = excluded.chunk_policy_version,
+                pooling_mode = excluded.pooling_mode,
                 shard_id = excluded.shard_id,
                 row_idx = excluded.row_idx,
                 deleted = 0,
@@ -345,6 +459,9 @@ class EmbeddingManifest:
                     row.parent_key,
                     row.text_sha256,
                     row.model,
+                    row.index_max_length,
+                    row.chunk_policy_version,
+                    row.pooling_mode,
                     row.shard_id,
                     row.row_idx,
                     updated_at,
@@ -402,8 +519,16 @@ def append_shard(
     corpus: str,
     vectors: NDArray[np.float16],
     unit_specs: list[UnitSpecInput],
+    encoder_config: EncoderConfig,
 ) -> int:
-    """Atomically append a shard file and its manifest rows."""
+    """Atomically append a shard file and its manifest rows.
+
+    All units in a single shard share one ``EncoderConfig`` by
+    construction — the encoder ran with one model, one max-length,
+    one chunk policy, one pooling mode for the whole batch. Stamping
+    the config at the shard boundary (rather than per-``UnitSpecInput``)
+    makes that invariant impossible to violate from caller code.
+    """
 
     if vectors.dtype != np.float16:
         raise ValueError("vectors must use float16 dtype")
@@ -444,7 +569,10 @@ def append_shard(
                     corpus=corpus,
                     parent_key=spec.parent_key,
                     text_sha256=spec.text_sha256,
-                    model=spec.model,
+                    model=encoder_config.model,
+                    index_max_length=encoder_config.index_max_length,
+                    chunk_policy_version=encoder_config.chunk_policy_version,
+                    pooling_mode=encoder_config.pooling_mode,
                     shard_id=shard_id,
                     row_idx=row_idx,
                 )
@@ -462,8 +590,18 @@ def append_shard(
         raise
 
 
-def reserve_corpus_shard(manifest: EmbeddingManifest, *, corpus: str) -> int:
-    """Register a corpus in the manifest with a zero-row reserved shard."""
+def reserve_corpus_shard(
+    manifest: EmbeddingManifest,
+    *,
+    corpus: str,
+    encoder_config: EncoderConfig = LEGACY_SHIPPED_CONFIG,
+) -> int:
+    """Register a corpus in the manifest with a zero-row reserved shard.
+
+    The reserved shard carries no units, so ``encoder_config`` is only
+    used to satisfy the API contract; the default mirrors the shipped
+    #1348 config so legacy call sites work unchanged.
+    """
 
     shard_map = manifest.shard_map_for_corpus(corpus)
     if shard_map:
@@ -474,6 +612,7 @@ def reserve_corpus_shard(manifest: EmbeddingManifest, *, corpus: str) -> int:
         corpus=corpus,
         vectors=np.zeros((0, DEFAULT_DIMS), dtype=np.float16),
         unit_specs=[],
+        encoder_config=encoder_config,
     )
 
 
@@ -482,8 +621,26 @@ def filter_new_or_changed(
     *,
     corpus: str,
     candidates: Iterable[tuple[str, str]],
+    expected_config: EncoderConfig,
 ) -> tuple[list[str], list[str]]:
-    """Classify unit keys that need a first encode or a replacement encode."""
+    """Classify unit keys that need a first encode or a replacement encode.
+
+    A unit is treated as ``stale`` (must re-encode) when ANY of these
+    differ vs the existing manifest row:
+
+    - ``text_sha256``  — chunk text changed
+    - ``model``        — different encoder
+    - ``index_max_length`` — bumping ``INDEX_MAX_LENGTH`` invalidates
+      embeddings even when text is unchanged (silent truncation
+      effects). This is the #1553 root-cause fix.
+    - ``chunk_policy_version`` — chunker changed (boundary-aware vs
+      raw windows, target-token shifts, paragraph rules)
+    - ``pooling_mode`` — different pooling produces different vectors
+      from the same model+text
+
+    A unit is treated as ``new`` when no row exists, or the existing
+    row is for a different corpus, or has been marked deleted.
+    """
 
     candidate_rows = list(candidates)
     existing = manifest.get_units([unit_key for unit_key, _ in candidate_rows])
@@ -500,6 +657,9 @@ def filter_new_or_changed(
             continue
         if row.text_sha256 != text_sha256:
             stale_keys.append(unit_key)
+            continue
+        if not expected_config.matches_row(row):
+            stale_keys.append(unit_key)
     return new_keys, stale_keys
 
 
@@ -514,6 +674,9 @@ def _row_to_unit(row: sqlite3.Row) -> UnitRow:
         parent_key=str(row["parent_key"]) if row["parent_key"] is not None else None,
         text_sha256=str(row["text_sha256"]),
         model=str(row["model"]),
+        index_max_length=int(row["index_max_length"]),
+        chunk_policy_version=str(row["chunk_policy_version"]),
+        pooling_mode=str(row["pooling_mode"]),
         shard_id=int(row["shard_id"]),
         row_idx=int(row["row_idx"]),
         deleted=bool(row["deleted"]),

--- a/scripts/wiki/embedding_manifest_schema.py
+++ b/scripts/wiki/embedding_manifest_schema.py
@@ -1,8 +1,32 @@
-"""Schema for the embedding manifest database."""
+"""Schema for the embedding manifest database.
+
+Schema versions:
+  v1 (#1348): unit identity = (unit_key, text_sha256, model)
+              No versioning for index_max_length / chunk_policy / pooling_mode.
+  v2 (#1553): unit identity carries the full encoder config so that
+              changes to INDEX_MAX_LENGTH, chunk policy, or pooling mode
+              force a re-encode instead of producing a silently mixed
+              index. Pre-existing v1 rows are stamped at __init__-time
+              with LEGACY_SHIPPED_CONFIG defaults so the upgrade is
+              non-destructive.
+"""
 
 from __future__ import annotations
 
-EMBEDDING_MANIFEST_DDL = """
+#: Defaults baked into the v2 ALTER TABLE so legacy rows match the
+#: actually-shipped #1348 configuration. These constants MUST mirror
+#: ``LEGACY_SHIPPED_CONFIG`` in ``embedding_manifest`` — keep them in
+#: sync via the test in ``tests/wiki/test_embedding_manifest.py``.
+LEGACY_INDEX_MAX_LENGTH = 512
+LEGACY_CHUNK_POLICY_VERSION = "legacy:v1-shipped-1348"
+LEGACY_POOLING_MODE = "cls"
+
+
+#: v1 schema (#1348) — base shape created on a fresh manifest. The
+#: v2 columns and config index are added by the migration logic in
+#: ``EmbeddingManifest._ensure_schema_v2`` after this DDL runs, so the
+#: same code path works whether opening a fresh or pre-existing DB.
+EMBEDDING_MANIFEST_DDL_V1 = """
 CREATE TABLE IF NOT EXISTS embedding_shards (
     shard_id     INTEGER PRIMARY KEY AUTOINCREMENT,
     corpus       TEXT NOT NULL,
@@ -29,3 +53,16 @@ CREATE INDEX IF NOT EXISTS idx_embunits_corpus ON embedding_units(corpus, delete
 CREATE INDEX IF NOT EXISTS idx_embunits_parent ON embedding_units(corpus, parent_key);
 CREATE INDEX IF NOT EXISTS idx_embunits_shard ON embedding_units(shard_id);
 """.strip()
+
+#: Backwards-compatibility alias — older callers used this name.
+EMBEDDING_MANIFEST_DDL = EMBEDDING_MANIFEST_DDL_V1
+
+
+#: v2 columns added to ``embedding_units`` by the migration logic.
+#: Tuple of ``(name, type, default_sql)`` — the migration ALTERs the
+#: live table when these are missing on open.
+V2_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("index_max_length", "INTEGER NOT NULL", str(LEGACY_INDEX_MAX_LENGTH)),
+    ("chunk_policy_version", "TEXT NOT NULL", f"'{LEGACY_CHUNK_POLICY_VERSION}'"),
+    ("pooling_mode", "TEXT NOT NULL", f"'{LEGACY_POOLING_MODE}'"),
+)

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -471,24 +471,36 @@ def _search_external_candidates(
         (fts_query, candidate_k),
     ).fetchall()
 
-    return [
-        {
-            "unit_key": f"external:{row['chunk_id'] or row['id']}",
-            "corpus": "external",
-            "source_type": "external",
-            "chunk_id": str(row["chunk_id"] or ""),
-            "title": str(row["title"] or ""),
-            "text": str(row["text"] or ""),
-            "full_text": str(row["text"] or ""),
-            "source_file": str(row["source_file"] or ""),
-            "parent_key": str(row["source_file"] or ""),
-            "url": str(row["url"] or ""),
-            "source_name": str(row["domain"] or row["source_file"] or ""),
-            "speaker": str(row["speaker"] or ""),
-            "fts_score": float(row["rank"] or 0.0),
-        }
-        for row in rows
-    ]
+    candidates: list[dict] = []
+    policy = policy_for("external")
+    tokenizer = _get_tokenizer()
+    for row in rows:
+        parent_id = str(row["chunk_id"] or row["id"])
+        full_text = str(row["text"] or "")
+        for piece in chunk_text(full_text, policy=policy, tokenizer=tokenizer):
+            unit_key = (
+                f"external:{parent_id}:chunk_{piece.chunk_index}"
+                if piece.extra_metadata
+                else f"external:{parent_id}"
+            )
+            candidates.append({
+                "unit_key": unit_key,
+                "corpus": "external",
+                "source_type": "external",
+                "chunk_id": str(row["chunk_id"] or ""),
+                "title": str(row["title"] or ""),
+                "text": piece.text,
+                "full_text": piece.text,
+                "source_file": str(row["source_file"] or ""),
+                "parent_key": str(row["source_file"] or ""),
+                "url": str(row["url"] or ""),
+                "source_name": str(row["domain"] or row["source_file"] or ""),
+                "speaker": str(row["speaker"] or ""),
+                "chunk_index": piece.chunk_index,
+                "parent_unit_key": f"external:{parent_id}",
+                "fts_score": float(row["rank"] or 0.0),
+            })
+    return candidates
 
 
 def _search_wikipedia_candidates(
@@ -638,6 +650,66 @@ def _search_ukrainian_wiki_candidates(
     ]
 
 
+def _expand_to_chunk_candidates(
+    parent_candidates: list[dict],
+    *,
+    corpus: str,
+    parent_id_field: str,
+    text_field: str = "text",
+) -> list[dict]:
+    """Fan out each parent-level candidate into chunk-level
+    candidates whose ``unit_key``s match the manifest written by
+    ``load_corpus_units``.
+
+    Each input candidate's ``parent_id_field`` (e.g. ``section_id``)
+    plus the corpus name forms the parent unit_key; the chunker
+    appends ``:chunk_N`` only when the policy actually splits the
+    text into multiple pieces. Single-chunk pieces preserve the
+    original parent unit_key so short sections / articles stay
+    identifiable by their natural id.
+
+    Codex review (msg #459): textbook and external candidate paths
+    were emitting parent ``unit_key``s after step 1 chunked the
+    manifest entries — every chunked unit got a dense rerank miss
+    + zero score. This helper fixes that uniformly.
+    """
+
+    policy = policy_for(corpus)
+    tokenizer = _get_tokenizer()
+    expanded: list[dict] = []
+    for parent in parent_candidates:
+        parent_id_value = parent.get(parent_id_field)
+        if parent_id_value is None:
+            continue
+        parent_unit_key = f"{corpus}:{parent_id_value}"
+        full_text = str(parent.get(text_field, "") or "")
+        if not full_text:
+            continue
+        pieces = list(chunk_text(full_text, policy=policy, tokenizer=tokenizer))
+        if not pieces:
+            continue
+        for piece in pieces:
+            unit_key = (
+                f"{parent_unit_key}:chunk_{piece.chunk_index}"
+                if piece.extra_metadata
+                else parent_unit_key
+            )
+            expanded.append({
+                **parent,
+                "corpus": corpus,
+                "unit_key": unit_key,
+                "parent_unit_key": parent_unit_key,
+                "parent_key": str(parent.get("source_file") or parent.get("parent_key", "")),
+                "text": piece.text,
+                "full_text": piece.text,
+                "chunk_index": piece.chunk_index,
+                "fts_score": float(
+                    parent.get("fts_score") or parent.get("best_rank", 0.0) or 0.0
+                ),
+            })
+    return expanded
+
+
 def _dispatch_corpus_search(
     corpus: str,
     *,
@@ -648,18 +720,23 @@ def _dispatch_corpus_search(
     candidate_k_per_corpus: int,
 ) -> list[dict]:
     if corpus == "textbook_sections":
-        candidates = _search_sections_fts5(
+        section_candidates = _search_sections_fts5(
             bucket_a_phrases,
             bucket_b_keywords,
             track=track,
             max_sections=candidate_k_per_corpus,
             max_chunk_candidates=max(candidate_k_per_corpus * 4, candidate_k_per_corpus),
         )
-        for candidate in candidates:
-            candidate["corpus"] = corpus
-            candidate["unit_key"] = candidate.get("unit_key") or f"textbook_sections:{int(candidate['section_id'])}"
-            candidate["parent_key"] = str(candidate.get("source_file", ""))
-            candidate["fts_score"] = float(candidate.get("best_rank", 0.0) or 0.0)
+        # Each FTS5-matched section's full_text is fanned out into
+        # chunk-level candidates whose unit_keys match the manifest
+        # entries written by load_corpus_units. Without this, the
+        # dense rerank lookup misses every chunked section's
+        # sub-units and zeroes out the score (Codex msg #459).
+        candidates = _expand_to_chunk_candidates(
+            section_candidates,
+            corpus="textbook_sections",
+            parent_id_field="section_id",
+        )
     elif corpus in {"modern_literary", "archaic_literary"}:
         candidates = _search_literary_candidates(
             bucket_a_phrases,

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -24,7 +24,8 @@ from pathlib import Path
 import yaml
 
 from .channels import rank_external_hits
-from .dense_rerank import chunk_wikipedia_article, rerank_candidates, rerank_sections
+from .chunking import chunk_text, policy_for
+from .dense_rerank import _get_tokenizer, rerank_candidates, rerank_sections
 from .query_builder import build_query_buckets
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -523,20 +524,28 @@ def _search_wikipedia_candidates(
     ).fetchall()
 
     candidates: list[dict] = []
+    policy = policy_for("wikipedia")
+    tokenizer = _get_tokenizer()
     for row in rows:
         title = str(row["title"] or "")
-        for chunk in chunk_wikipedia_article(title, str(row["text"] or "")):
+        full_text = str(row["text"] or "")
+        for piece in chunk_text(full_text, policy=policy, tokenizer=tokenizer):
+            unit_key = (
+                f"wikipedia:{title}:chunk_{piece.chunk_index}"
+                if piece.extra_metadata
+                else f"wikipedia:{title}"
+            )
             candidates.append(
                 {
-                    "unit_key": str(chunk["unit_key"]),
+                    "unit_key": unit_key,
                     "corpus": "wikipedia",
                     "source_type": "wikipedia",
                     "title": title,
-                    "text": str(chunk["text"]),
-                    "full_text": str(chunk["text"]),
+                    "text": piece.text,
+                    "full_text": piece.text,
                     "parent_key": title,
                     "url": str(row["url"] or ""),
-                    "chunk_index": int(chunk["chunk_index"]),
+                    "chunk_index": piece.chunk_index,
                     "source_name": "Wikipedia",
                     "fts_score": float(row["rank"] or 0.0),
                 }
@@ -748,16 +757,27 @@ def _expand_wikipedia_neighbors(match: dict) -> dict:
     if row is None:
         return match
 
-    chunks = chunk_wikipedia_article(title, str(row["text"] or ""))
+    pieces = list(
+        chunk_text(
+            str(row["text"] or ""),
+            policy=policy_for("wikipedia"),
+            tokenizer=_get_tokenizer(),
+        )
+    )
     chunk_index = int(match.get("chunk_index", 0))
-    context = chunks[max(0, chunk_index - 1):chunk_index + 2]
+    context = pieces[max(0, chunk_index - 1):chunk_index + 2]
     if not context:
         return match
 
     return {
         **match,
-        "full_text": "\n\n".join(str(chunk["text"]) for chunk in context),
-        "context_unit_keys": [str(chunk["unit_key"]) for chunk in context],
+        "full_text": "\n\n".join(piece.text for piece in context),
+        "context_unit_keys": [
+            f"wikipedia:{title}:chunk_{piece.chunk_index}"
+            if piece.extra_metadata
+            else f"wikipedia:{title}"
+            for piece in context
+        ],
     }
 
 

--- a/tests/wiki/test_chunking.py
+++ b/tests/wiki/test_chunking.py
@@ -324,3 +324,76 @@ def test_chunk_text_empty_yields_nothing(tokenizer: FakeTokenizer) -> None:
     policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
     assert list(chunk_text("", policy=policy, tokenizer=tokenizer)) == []
     assert list(chunk_text("   ", policy=policy, tokenizer=tokenizer)) == []
+
+
+# --- Validator gate (#1553 step 3) -------------------------------------------
+
+
+def test_validator_raises_when_unit_exceeds_index_max_length(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """The validator gate must reject a corpus whose chunked units
+    still exceed ``INDEX_MAX_LENGTH``. Catches the failure mode where
+    a chunking policy's ``target_tokens`` was bumped without
+    coordinating ``INDEX_MAX_LENGTH`` (or vice versa)."""
+
+    from wiki.dense_rerank import CorpusUnit, _assert_units_fit_index_window
+
+    from wiki import chunking, dense_rerank
+
+    # Synthesize a unit that's clearly over the cap (FakeTokenizer
+    # uses whitespace tokens; 100 words = 100 tokens).
+    too_long = " ".join(f"word{i}" for i in range(100))
+    unit = CorpusUnit(
+        unit_key="test_validator:1",
+        corpus="test_validator",
+        parent_key="parent",
+        text=too_long,
+        text_sha256="sha",
+        metadata={},
+    )
+
+    # Register the test corpus with an active policy so the validator
+    # actually runs (NO_CHUNK policy short-circuits).
+    chunking.CHUNKING_POLICIES["test_validator"] = chunking.ChunkingPolicy(
+        version_id="test_validator:paragraph-aware-450t-o50-v1",
+        target_tokens=450,
+        overlap_tokens=50,
+    )
+    original_get_tokenizer = dense_rerank._get_tokenizer
+    dense_rerank._get_tokenizer = lambda: tokenizer  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(ValueError, match="exceeding INDEX_MAX_LENGTH"):
+            _assert_units_fit_index_window([unit], corpus="test_validator", max_length=50)
+    finally:
+        del chunking.CHUNKING_POLICIES["test_validator"]
+        dense_rerank._get_tokenizer = original_get_tokenizer  # type: ignore[assignment]
+
+
+def test_validator_silent_on_no_chunk_corpus(tokenizer: FakeTokenizer) -> None:
+    """NO_CHUNK corpora must NOT trigger the validator — by design,
+    they accept unit lengths the encoder will truncate. Re-chunking
+    them at index time would invalidate 137K+ vectors."""
+
+    from wiki.dense_rerank import CorpusUnit, _assert_units_fit_index_window
+
+    from wiki import dense_rerank
+
+    too_long = " ".join(f"word{i}" for i in range(100))
+    unit = CorpusUnit(
+        unit_key="modern_literary:1",
+        corpus="modern_literary",
+        parent_key="parent",
+        text=too_long,
+        text_sha256="sha",
+        metadata={},
+    )
+
+    original_get_tokenizer = dense_rerank._get_tokenizer
+    dense_rerank._get_tokenizer = lambda: tokenizer  # type: ignore[assignment]
+    try:
+        # No exception expected — modern_literary uses NO_CHUNK.
+        _assert_units_fit_index_window([unit], corpus="modern_literary", max_length=50)
+    finally:
+        dense_rerank._get_tokenizer = original_get_tokenizer  # type: ignore[assignment]

--- a/tests/wiki/test_chunking.py
+++ b/tests/wiki/test_chunking.py
@@ -272,6 +272,44 @@ def test_overlap_prepends_trailing_sentences_to_next_chunk(
     )
 
 
+def test_overlap_caps_at_overlap_tokens_when_sentence_too_long(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """If even a single trailing sentence exceeds ``overlap_tokens``,
+    the overlap path must NOT return the whole sentence — that
+    would push downstream chunks past the chunker's target and
+    trip the validator gate (#1553 step 3).
+
+    Codex review (msg #459) flagged this: a 200-token trailing
+    sentence with overlap_tokens=50 would otherwise produce
+    650-token chunks under a 450-target policy. Fix: token-tail
+    fallback when sentence overlap doesn't fit.
+    """
+
+    # Construct a corpus where the LAST sentence is itself longer
+    # than the overlap budget. With target=100 and overlap=20, no
+    # full sentence fits the overlap window.
+    long_sentence = " ".join(f"long{i}" for i in range(50)) + "."
+    para_a = " ".join(f"a{i}" for i in range(40)) + "."
+    para_b = " ".join(f"b{i}" for i in range(40)) + "."
+    text = f"{para_a} {long_sentence}\n\n{para_b}"
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=20)
+    chunks = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    assert len(chunks) >= 2
+
+    # Critical assertion: every chunk fits within target_tokens +
+    # overlap_tokens. If overlap returns the whole 50-token sentence
+    # the second chunk would be ~90 tokens (overlap) + 40 (para_b)
+    # = 130 tokens, exceeding even (target+overlap=120).
+    for index, chunk in enumerate(chunks):
+        chunk_tokens = len(tokenizer.encode(chunk, add_special_tokens=False, truncation=False))
+        assert chunk_tokens <= policy.target_tokens + policy.overlap_tokens, (
+            f"chunk {index} ({chunk_tokens}t) exceeds target+overlap "
+            f"({policy.target_tokens + policy.overlap_tokens}t); the "
+            f"overlap cap regressed."
+        )
+
+
 def test_overlap_zero_yields_no_duplication(tokenizer: FakeTokenizer) -> None:
     """With overlap=0, adjacent chunks must not share any sentence —
     no duplication, no loss."""

--- a/tests/wiki/test_chunking.py
+++ b/tests/wiki/test_chunking.py
@@ -1,0 +1,326 @@
+"""Tests for the centralized boundary-aware chunker (#1553 step 1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from wiki.chunking import (
+    _UK_ABBREVIATIONS,
+    CHUNKING_POLICIES,
+    NO_CHUNK,
+    ChunkingPolicy,
+    boundary_aware_chunks,
+    chunk_text,
+    policy_for,
+    split_paragraphs,
+    split_sentences,
+)
+
+
+class FakeTokenizer:
+    """Whitespace-token tokenizer that round-trips faithfully.
+
+    Each whitespace-separated word is one token. ``decode`` rejoins
+    with single spaces so token-window splits land on word
+    boundaries, matching real BGE-M3 behavior closely enough for
+    chunking-policy unit tests. The real tokenizer's subword
+    behavior differs in detail but never in chunking direction —
+    if a chunk fits under the FakeTokenizer it'll fit under BGE-M3
+    (BGE produces strictly more tokens for the same text).
+    """
+
+    def encode(
+        self,
+        text: str,
+        *,
+        add_special_tokens: bool = False,
+        truncation: bool = False,
+        max_length: int | None = None,
+    ) -> list[int]:
+        del add_special_tokens, truncation
+        tokens = text.split()
+        if max_length is not None:
+            tokens = tokens[:max_length]
+        # Token IDs are arbitrary; chunker only cares about length
+        # and round-trip.
+        return list(range(1, len(tokens) + 1))
+
+    def decode(self, token_ids: list[int], *, skip_special_tokens: bool = True) -> str:
+        del skip_special_tokens
+        return " ".join(f"tok{tid}" for tid in token_ids)
+
+
+@pytest.fixture
+def tokenizer() -> FakeTokenizer:
+    return FakeTokenizer()
+
+
+# --- Registry guards ---------------------------------------------------------
+
+
+def test_no_chunk_policy_yields_target_tokens_zero() -> None:
+    assert NO_CHUNK.target_tokens == 0
+
+
+def test_supported_corpora_each_have_a_policy() -> None:
+    """Every corpus in ``SUPPORTED_CORPORA`` must register a chunking
+    policy so ``policy_for`` doesn't raise at runtime."""
+
+    from wiki.dense_rerank import SUPPORTED_CORPORA
+
+    missing = [c for c in SUPPORTED_CORPORA if c not in CHUNKING_POLICIES]
+    assert missing == [], f"corpora missing from CHUNKING_POLICIES: {missing}"
+
+
+def test_policy_for_unknown_corpus_raises() -> None:
+    with pytest.raises(KeyError, match="no ChunkingPolicy registered"):
+        policy_for("nonexistent_corpus")
+
+
+def test_paragraph_aware_version_id_encodes_parameters() -> None:
+    """version_id must change when target_tokens or overlap changes,
+    so the manifest never silently shares vectors across distinct
+    chunker configurations."""
+
+    policy = CHUNKING_POLICIES["wikipedia"]
+    assert "450t" in policy.version_id
+    assert "o50" in policy.version_id
+    # Sanity: two policies built with different params get different ids.
+    custom_a = ChunkingPolicy(
+        version_id="x:paragraph-aware-450t-o50-v1",
+        target_tokens=450,
+        overlap_tokens=50,
+    )
+    custom_b = ChunkingPolicy(
+        version_id="x:paragraph-aware-1500t-o150-v1",
+        target_tokens=1500,
+        overlap_tokens=150,
+    )
+    assert custom_a.version_id != custom_b.version_id
+
+
+# --- Paragraph + sentence splitters ------------------------------------------
+
+
+def test_split_paragraphs_blank_line_boundaries() -> None:
+    text = "Перший абзац.\n\nДругий абзац.\n\n\n\nТретій."
+    assert split_paragraphs(text) == ["Перший абзац.", "Другий абзац.", "Третій."]
+
+
+def test_split_paragraphs_drops_empty() -> None:
+    assert split_paragraphs("\n\n\n\n") == []
+
+
+def test_split_sentences_basic() -> None:
+    paragraph = "Перше речення. Друге речення! Третє речення?"
+    sents = split_sentences(paragraph)
+    assert sents == ["Перше речення.", "Друге речення!", "Третє речення?"]
+
+
+def test_split_sentences_merges_after_ukrainian_abbreviation() -> None:
+    """``проф. Іван Франко був видатним...`` should not split on
+    ``проф.``. Same for вул., р., ст., etc."""
+
+    paragraph = "проф. Іван Франко був видатним українським письменником."
+    sents = split_sentences(paragraph)
+    assert sents == [paragraph], (
+        f"abbreviation guard failed; got {sents!r}"
+    )
+
+
+def test_split_sentences_handles_multiple_abbreviations() -> None:
+    paragraph = "Жив на вул. Шевченка. Помер у 1916 р. Похований у Львові."
+    sents = split_sentences(paragraph)
+    # The вул. shouldn't split, the р. shouldn't split, only the
+    # final period should — but we permit fewer splits if the guard
+    # is conservative. Critical: вул./р. don't split mid-clause.
+    joined = " ".join(sents)
+    assert "вул. Шевченка" in joined or "Шевченка" not in joined, (
+        f"вул. abbreviation broke clause: {sents!r}"
+    )
+
+
+def test_uk_abbreviations_set_includes_common() -> None:
+    for required in ("вул", "р", "ст", "проф", "акад"):
+        assert required in _UK_ABBREVIATIONS
+
+
+# --- Core boundary-aware chunker --------------------------------------------
+
+
+def test_boundary_aware_short_text_returns_single_chunk(tokenizer: FakeTokenizer) -> None:
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=10)
+    text = "коротке речення тут."
+    chunks = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    assert chunks == [text]
+
+
+def test_boundary_aware_empty_text_returns_empty_list(tokenizer: FakeTokenizer) -> None:
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=10)
+    assert boundary_aware_chunks("", policy=policy, tokenizer=tokenizer) == []
+    assert boundary_aware_chunks("   \n\n\n  ", policy=policy, tokenizer=tokenizer) == []
+
+
+def test_boundary_aware_multi_paragraph_chunks_at_paragraph_boundaries(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """Three 60-token paragraphs with target=100 -> two chunks
+    grouped on paragraph boundaries (60+? doesn't fit 100, so flush
+    after each).
+    """
+
+    para_a = " ".join(f"a{i}" for i in range(60))
+    para_b = " ".join(f"b{i}" for i in range(60))
+    para_c = " ".join(f"c{i}" for i in range(60))
+    text = f"{para_a}\n\n{para_b}\n\n{para_c}"
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
+    chunks = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    # Each chunk should be exactly one paragraph (60 tokens) since
+    # 60+60=120 > target 100 -> flush after each.
+    assert len(chunks) == 3
+    assert all("a" in chunks[0] for _ in [None])  # first chunk has para_a tokens
+    assert "b0" not in chunks[0]
+    assert "c0" not in chunks[0]
+
+
+def test_boundary_aware_combines_small_paragraphs_into_one_chunk(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """Two 30-token paragraphs with target=100 -> one chunk of both."""
+
+    para_a = " ".join(f"a{i}" for i in range(30))
+    para_b = " ".join(f"b{i}" for i in range(30))
+    text = f"{para_a}\n\n{para_b}"
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
+    chunks = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    assert len(chunks) == 1
+    assert "a0" in chunks[0] and "b0" in chunks[0]
+
+
+def test_boundary_aware_long_paragraph_falls_back_to_sentences(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """One paragraph of three 40-token sentences with target=70 ->
+    splits at sentence boundaries (1 + 2 sentence groups, since
+    40+40=80 > 70 -> flush)."""
+
+    sents = [
+        " ".join(f"s{i}-{j}" for j in range(40)) + "."
+        for i in range(3)
+    ]
+    paragraph = " ".join(sents)
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=70, overlap_tokens=0)
+    chunks = boundary_aware_chunks(paragraph, policy=policy, tokenizer=tokenizer)
+    # Each chunk should hold one full sentence; never split mid-sentence.
+    for chunk in chunks:
+        # Count complete sentence-end markers; chunks shouldn't end
+        # mid-sentence since each sentence fits within target.
+        assert chunk.rstrip().endswith("."), f"sentence boundary lost: {chunk[:50]!r}"
+
+
+def test_boundary_aware_pathological_long_sentence_falls_back_to_token_window(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """One 500-token sentence with target=200 -> token-window fallback
+    yields multiple chunks; no crash, total content preserved
+    (modulo token-window decode artifacts in the FakeTokenizer)."""
+
+    sentence = " ".join(f"w{i}" for i in range(500))
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=200, overlap_tokens=0)
+    chunks = boundary_aware_chunks(sentence, policy=policy, tokenizer=tokenizer)
+    assert len(chunks) >= 2
+    # Each chunk is at most ~target_tokens long (FakeTokenizer is 1
+    # word per token + decode prefix "tok").
+    for chunk in chunks:
+        assert chunk  # non-empty
+
+
+# --- Overlap behavior -------------------------------------------------------
+
+
+def test_overlap_prepends_trailing_sentences_to_next_chunk(
+    tokenizer: FakeTokenizer,
+) -> None:
+    """When overlap is > 0, chunk N+1 should start with the trailing
+    sentences of chunk N, providing cross-chunk semantic continuity."""
+
+    # Two paragraphs, each ~60 tokens. With target=70 we'll get two
+    # chunks (each one paragraph). Overlap=20 should pull the last
+    # sentence of chunk 0 into the start of chunk 1.
+    sentences_a = [
+        " ".join(f"s0-{i}-{j}" for j in range(15)) + "."
+        for i in range(4)
+    ]
+    sentences_b = [
+        " ".join(f"s1-{i}-{j}" for j in range(15)) + "."
+        for i in range(4)
+    ]
+    text = " ".join(sentences_a) + "\n\n" + " ".join(sentences_b)
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=70, overlap_tokens=20)
+    chunks = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    assert len(chunks) >= 2
+    # Last sentence of chunk 0 should appear at the start of chunk 1.
+    last_sentence_a = sentences_a[-1]
+    assert chunks[1].startswith(last_sentence_a), (
+        f"overlap missing; chunk[1] starts {chunks[1][:80]!r}, "
+        f"expected leading {last_sentence_a!r}"
+    )
+
+
+def test_overlap_zero_yields_no_duplication(tokenizer: FakeTokenizer) -> None:
+    """With overlap=0, adjacent chunks must not share any sentence —
+    no duplication, no loss."""
+
+    para_a = " ".join(f"a{i}" for i in range(60))
+    para_b = " ".join(f"b{i}" for i in range(60))
+    text = f"{para_a}\n\n{para_b}"
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
+    chunks = boundary_aware_chunks(text, policy=policy, tokenizer=tokenizer)
+    # Tokens from para_a should appear only in chunks[0], never
+    # leaking into chunks[1+].
+    if len(chunks) >= 2:
+        assert "a0" in chunks[0] and "a0" not in chunks[1]
+        assert "b0" in chunks[1] and "b0" not in chunks[0]
+
+
+# --- chunk_text integration --------------------------------------------------
+
+
+def test_chunk_text_no_chunk_policy_yields_one_piece(tokenizer: FakeTokenizer) -> None:
+    pieces = list(chunk_text("будь-який текст", policy=NO_CHUNK, tokenizer=tokenizer))
+    assert len(pieces) == 1
+    assert pieces[0].chunk_index == 0
+    assert pieces[0].text == "будь-який текст"
+
+
+def test_chunk_text_short_text_under_target_yields_one_piece(
+    tokenizer: FakeTokenizer,
+) -> None:
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
+    pieces = list(chunk_text("короткий текст.", policy=policy, tokenizer=tokenizer))
+    assert len(pieces) == 1
+    assert pieces[0].chunk_index == 0
+
+
+def test_chunk_text_long_text_yields_indexed_pieces(tokenizer: FakeTokenizer) -> None:
+    para_a = " ".join(f"a{i}" for i in range(60))
+    para_b = " ".join(f"b{i}" for i in range(60))
+    para_c = " ".join(f"c{i}" for i in range(60))
+    text = f"{para_a}\n\n{para_b}\n\n{para_c}"
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
+    pieces = list(chunk_text(text, policy=policy, tokenizer=tokenizer))
+    assert len(pieces) == 3
+    assert [piece.chunk_index for piece in pieces] == [0, 1, 2]
+    for piece in pieces:
+        assert piece.extra_metadata.get("chunk_count") == 3
+
+
+def test_chunk_text_empty_yields_nothing(tokenizer: FakeTokenizer) -> None:
+    policy = ChunkingPolicy(version_id="t:v1", target_tokens=100, overlap_tokens=0)
+    assert list(chunk_text("", policy=policy, tokenizer=tokenizer)) == []
+    assert list(chunk_text("   ", policy=policy, tokenizer=tokenizer)) == []

--- a/tests/wiki/test_cold_encode.py
+++ b/tests/wiki/test_cold_encode.py
@@ -101,9 +101,16 @@ def _loader(conn: sqlite3.Connection):
 
 
 def _configure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from wiki import chunking
+
     fake_tokenizer = FakeTokenizer()
     fake_encoder = FakeEncoder()
     monkeypatch.setitem(dense_rerank.CORPUS_UNIT_LOADERS, "test_small", _loader)
+    # Register a NO_CHUNK policy for the synthetic test corpus so
+    # ``policy_for("test_small")`` doesn't raise KeyError. This
+    # mirrors what production code requires: every corpus must
+    # register a chunking policy.
+    monkeypatch.setitem(chunking.CHUNKING_POLICIES, "test_small", chunking.NO_CHUNK)
     monkeypatch.setattr(dense_rerank, "_TOKENIZER", fake_tokenizer)
     monkeypatch.setattr(dense_rerank, "_get_tokenizer", lambda: fake_tokenizer)
     monkeypatch.setattr(dense_rerank, "_ENCODER", fake_encoder)

--- a/tests/wiki/test_embedding_manifest.py
+++ b/tests/wiki/test_embedding_manifest.py
@@ -61,40 +61,60 @@ def _unit_inputs(
     ]
 
 
-def test_runtime_default_config_matches_legacy_shipped() -> None:
-    """``current_encoder_config`` must produce ``LEGACY_SHIPPED_CONFIG``
-    on the post-#1553-step-0, pre-#1553-step-1 main branch.
+def test_runtime_default_config_no_chunk_corpora_match_legacy() -> None:
+    """No-chunk corpora must continue producing
+    ``LEGACY_SHIPPED_CONFIG``-equivalent stamps post-step-1.
 
-    Why: opening a pre-existing manifest after merging step 0 must
-    NOT mark every existing row as stale (which would force a full
-    re-encode). That only works if the runtime's per-corpus config
-    matches the legacy stamp values applied by the migration. If
-    the runtime drifts (e.g. someone bumps INDEX_MAX_LENGTH in the
-    same commit as a chunker change without bumping the policy
-    version), this test fails loudly.
+    ``ukrainian_wiki``, ``modern_literary``, ``archaic_literary`` use
+    ``NO_CHUNK`` policy in #1553 step 1, which keeps the legacy
+    chunk_policy_version. Their existing manifest rows must stay
+    valid — no surprise re-encode of the 137K+ literary vectors.
 
     Codex review (msg #455): "A small
     current_encoder_config(...) == LEGACY_SHIPPED_CONFIG test for
     step 0 would also catch accidental drift between runtime
-    defaults and migration defaults."
+    defaults and migration defaults." Step 1 specializes the test:
+    actively-chunked corpora intentionally drift (they MUST
+    re-encode), but no-chunk corpora must NOT drift.
     """
 
     from wiki.dense_rerank import current_encoder_config
 
-    for corpus in (
-        "textbook_sections",
-        "modern_literary",
-        "archaic_literary",
-        "external",
-        "wikipedia",
-        "ukrainian_wiki",
-    ):
+    for corpus in ("ukrainian_wiki", "modern_literary", "archaic_literary"):
         assert current_encoder_config(corpus) == LEGACY_SHIPPED_CONFIG, (
             f"current_encoder_config({corpus!r}) drifted from "
             f"LEGACY_SHIPPED_CONFIG; this WILL force a full re-encode "
-            f"of corpus {corpus!r} on next open. Either bump "
-            f"chunk_policy_version intentionally or revert the drift."
+            f"of corpus {corpus!r}, which has 100K+ vectors. Either "
+            f"bump chunk_policy_version intentionally or revert the drift."
         )
+
+
+def test_runtime_default_config_actively_chunked_corpora_diverge_from_legacy() -> None:
+    """Actively-chunked corpora MUST diverge from legacy after step 1
+    so their old (un-chunked) embeddings get re-encoded.
+
+    Step 1 introduces a paragraph-aware chunker for ``wikipedia``,
+    ``external``, ``textbook_sections``. Their version_id encodes
+    target/overlap params so any future chunker tweak forces another
+    re-encode. The shape of the version_id is asserted in
+    ``tests/wiki/test_chunking.py``; here we just assert that it
+    is NOT the legacy stamp.
+    """
+
+    from wiki.dense_rerank import current_encoder_config
+
+    for corpus in ("wikipedia", "external", "textbook_sections"):
+        config = current_encoder_config(corpus)
+        assert config.chunk_policy_version != LEGACY_SHIPPED_CONFIG.chunk_policy_version, (
+            f"current_encoder_config({corpus!r}) still uses the legacy "
+            f"chunk_policy_version, which means step 1's chunker change "
+            f"would NOT force a re-encode — wrong direction. Expected "
+            f"a paragraph-aware-* version stamp."
+        )
+        # All other config fields stay legacy until step 5 bumps INDEX_MAX_LENGTH.
+        assert config.model == LEGACY_SHIPPED_CONFIG.model
+        assert config.index_max_length == LEGACY_SHIPPED_CONFIG.index_max_length
+        assert config.pooling_mode == LEGACY_SHIPPED_CONFIG.pooling_mode
 
 
 def test_legacy_shipped_config_matches_schema_defaults() -> None:

--- a/tests/wiki/test_embedding_manifest.py
+++ b/tests/wiki/test_embedding_manifest.py
@@ -61,6 +61,42 @@ def _unit_inputs(
     ]
 
 
+def test_runtime_default_config_matches_legacy_shipped() -> None:
+    """``current_encoder_config`` must produce ``LEGACY_SHIPPED_CONFIG``
+    on the post-#1553-step-0, pre-#1553-step-1 main branch.
+
+    Why: opening a pre-existing manifest after merging step 0 must
+    NOT mark every existing row as stale (which would force a full
+    re-encode). That only works if the runtime's per-corpus config
+    matches the legacy stamp values applied by the migration. If
+    the runtime drifts (e.g. someone bumps INDEX_MAX_LENGTH in the
+    same commit as a chunker change without bumping the policy
+    version), this test fails loudly.
+
+    Codex review (msg #455): "A small
+    current_encoder_config(...) == LEGACY_SHIPPED_CONFIG test for
+    step 0 would also catch accidental drift between runtime
+    defaults and migration defaults."
+    """
+
+    from wiki.dense_rerank import current_encoder_config
+
+    for corpus in (
+        "textbook_sections",
+        "modern_literary",
+        "archaic_literary",
+        "external",
+        "wikipedia",
+        "ukrainian_wiki",
+    ):
+        assert current_encoder_config(corpus) == LEGACY_SHIPPED_CONFIG, (
+            f"current_encoder_config({corpus!r}) drifted from "
+            f"LEGACY_SHIPPED_CONFIG; this WILL force a full re-encode "
+            f"of corpus {corpus!r} on next open. Either bump "
+            f"chunk_policy_version intentionally or revert the drift."
+        )
+
+
 def test_legacy_shipped_config_matches_schema_defaults() -> None:
     """``LEGACY_SHIPPED_CONFIG`` must mirror the schema-baked defaults.
 
@@ -136,6 +172,156 @@ def test_v2_columns_present_with_legacy_defaults_on_fresh_init(tmp_path: Path) -
     assert columns["index_max_length"] == str(LEGACY_INDEX_MAX_LENGTH)
     assert columns["chunk_policy_version"] == f"'{LEGACY_CHUNK_POLICY_VERSION}'"
     assert columns["pooling_mode"] == f"'{LEGACY_POOLING_MODE}'"
+
+
+def test_partial_v2_schema_migration_completes_missing_columns(tmp_path: Path) -> None:
+    """A manifest stuck mid-migration must finish on next open.
+
+    Real-world: a previous run added one or two of the v2 columns
+    but crashed before adding the rest (or before creating the
+    config index). Opening the file again must complete the work,
+    not bail on a duplicate-column error.
+    """
+
+    db_path = _manifest_path(tmp_path)
+    db_path.parent.mkdir(parents=True)
+
+    legacy_conn = sqlite3.connect(str(db_path))
+    legacy_conn.executescript(
+        """
+        CREATE TABLE embedding_shards (
+            shard_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            corpus TEXT NOT NULL,
+            path TEXT NOT NULL,
+            rows INTEGER NOT NULL,
+            dims INTEGER NOT NULL DEFAULT 1024,
+            dtype TEXT NOT NULL DEFAULT 'float16',
+            committed_at TEXT NOT NULL
+        );
+
+        CREATE TABLE embedding_units (
+            unit_key TEXT PRIMARY KEY,
+            corpus TEXT NOT NULL,
+            parent_key TEXT,
+            text_sha256 TEXT NOT NULL,
+            model TEXT NOT NULL,
+            shard_id INTEGER NOT NULL REFERENCES embedding_shards(shard_id),
+            row_idx INTEGER NOT NULL,
+            deleted INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+    # Only add the FIRST v2 column (simulates partial migration).
+    legacy_conn.execute(
+        f"ALTER TABLE embedding_units ADD COLUMN index_max_length "
+        f"INTEGER NOT NULL DEFAULT {LEGACY_INDEX_MAX_LENGTH}"
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    # Open with the upgraded code — must complete columns 2+3
+    # without crashing.
+    manifest = _make_manifest(tmp_path)
+    try:
+        # All v2 columns now exist, including the index.
+        conn = sqlite3.connect(str(db_path))
+        column_names = {
+            row[1] for row in conn.execute("PRAGMA table_info(embedding_units)").fetchall()
+        }
+        index_names = {
+            row[1] for row in conn.execute(
+                "SELECT type, name FROM sqlite_master WHERE name = 'idx_embunits_config'"
+            ).fetchall()
+        }
+        conn.close()
+        assert {"index_max_length", "chunk_policy_version", "pooling_mode"} <= column_names
+        assert "idx_embunits_config" in index_names
+    finally:
+        manifest.close()
+
+
+def test_concurrent_migration_does_not_race(tmp_path: Path) -> None:
+    """Two processes opening a v1 manifest simultaneously must not
+    both attempt the same ALTER (would crash with duplicate-column).
+
+    Codex review (msg #455) flagged the v1-locking PRAGMA + ALTER
+    pattern as concurrency-unsafe. Fix wraps schema check + ALTERs
+    in BEGIN IMMEDIATE; the second writer blocks until the first
+    commits, then re-reads PRAGMA and sees the new columns.
+
+    Threads share the SQLite file but each opens its own connection
+    — same race surface as separate processes for this purpose.
+    """
+
+    import threading
+
+    db_path = _manifest_path(tmp_path)
+    db_path.parent.mkdir(parents=True)
+
+    # Pre-create a v1-shaped manifest with a representative row.
+    legacy_conn = sqlite3.connect(str(db_path))
+    legacy_conn.executescript(
+        """
+        CREATE TABLE embedding_shards (
+            shard_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            corpus TEXT NOT NULL,
+            path TEXT NOT NULL,
+            rows INTEGER NOT NULL,
+            dims INTEGER NOT NULL DEFAULT 1024,
+            dtype TEXT NOT NULL DEFAULT 'float16',
+            committed_at TEXT NOT NULL
+        );
+
+        CREATE TABLE embedding_units (
+            unit_key TEXT PRIMARY KEY,
+            corpus TEXT NOT NULL,
+            parent_key TEXT,
+            text_sha256 TEXT NOT NULL,
+            model TEXT NOT NULL,
+            shard_id INTEGER NOT NULL REFERENCES embedding_shards(shard_id),
+            row_idx INTEGER NOT NULL,
+            deleted INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    barrier = threading.Barrier(parties=4)
+    failures: list[BaseException] = []
+    manifests: list[EmbeddingManifest] = []
+    lock = threading.Lock()
+
+    def opener() -> None:
+        try:
+            barrier.wait()  # release all 4 threads simultaneously
+            m = EmbeddingManifest(db_path)
+            with lock:
+                manifests.append(m)
+        except BaseException as exc:
+            with lock:
+                failures.append(exc)
+
+    threads = [threading.Thread(target=opener) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    for m in manifests:
+        m.close()
+
+    assert not failures, f"concurrent migration raced: {failures!r}"
+
+    # Verify final state: all 3 v2 columns present, manifest queryable.
+    conn = sqlite3.connect(str(db_path))
+    column_names = {
+        row[1] for row in conn.execute("PRAGMA table_info(embedding_units)").fetchall()
+    }
+    conn.close()
+    assert {"index_max_length", "chunk_policy_version", "pooling_mode"} <= column_names
 
 
 def test_v1_to_v2_migration_stamps_legacy_rows(tmp_path: Path) -> None:

--- a/tests/wiki/test_embedding_manifest.py
+++ b/tests/wiki/test_embedding_manifest.py
@@ -10,10 +10,17 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from wiki.embedding_manifest import (
+    LEGACY_SHIPPED_CONFIG,
     EmbeddingManifest,
+    EncoderConfig,
     UnitSpecInput,
     append_shard,
     filter_new_or_changed,
+)
+from wiki.embedding_manifest_schema import (
+    LEGACY_CHUNK_POLICY_VERSION,
+    LEGACY_INDEX_MAX_LENGTH,
+    LEGACY_POOLING_MODE,
 )
 
 from wiki import embedding_manifest
@@ -49,10 +56,23 @@ def _unit_inputs(
             unit_key=f"{corpus}:{start + index}",
             parent_key=f"parent-{(start + index) // 5}",
             text_sha256=f"sha-{start + index}",
-            model="bge-m3-mlx-fp16",
         )
         for index in range(rows)
     ]
+
+
+def test_legacy_shipped_config_matches_schema_defaults() -> None:
+    """``LEGACY_SHIPPED_CONFIG`` must mirror the schema-baked defaults.
+
+    The ALTER TABLE in ``_ensure_schema_v2`` stamps pre-existing v1
+    rows with the schema-level ``LEGACY_*`` constants. If those drift
+    from ``LEGACY_SHIPPED_CONFIG``, ``filter_new_or_changed`` will see
+    legacy rows as stale on first open and trigger a full re-encode.
+    """
+
+    assert LEGACY_SHIPPED_CONFIG.index_max_length == LEGACY_INDEX_MAX_LENGTH
+    assert LEGACY_SHIPPED_CONFIG.chunk_policy_version == LEGACY_CHUNK_POLICY_VERSION
+    assert LEGACY_SHIPPED_CONFIG.pooling_mode == LEGACY_POOLING_MODE
 
 
 def test_schema_init_creates_expected_tables_and_indexes(tmp_path: Path) -> None:
@@ -70,7 +90,8 @@ def test_schema_init_creates_expected_tables_and_indexes(tmp_path: Path) -> None
             'idx_embshards_corpus',
             'idx_embunits_corpus',
             'idx_embunits_parent',
-            'idx_embunits_shard'
+            'idx_embunits_shard',
+            'idx_embunits_config'
         )
         ORDER BY name
         """
@@ -81,6 +102,7 @@ def test_schema_init_creates_expected_tables_and_indexes(tmp_path: Path) -> None
         ("table", "embedding_shards"),
         ("table", "embedding_units"),
         ("index", "idx_embshards_corpus"),
+        ("index", "idx_embunits_config"),
         ("index", "idx_embunits_corpus"),
         ("index", "idx_embunits_parent"),
         ("index", "idx_embunits_shard"),
@@ -94,7 +116,121 @@ def test_schema_init_creates_expected_tables_and_indexes(tmp_path: Path) -> None
         "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'idx_emb%' OR name LIKE 'embedding_%'"
     ).fetchone()
     conn.close()
-    assert counts == (6,)
+    # 2 tables + 5 indexes (incl. config index) — must be idempotent on reopen
+    assert counts == (7,)
+
+
+def test_v2_columns_present_with_legacy_defaults_on_fresh_init(tmp_path: Path) -> None:
+    """A fresh manifest comes up with the v2 schema directly."""
+
+    manifest = _make_manifest(tmp_path)
+    manifest.close()
+
+    conn = sqlite3.connect(_manifest_path(tmp_path))
+    columns = {row[1]: row[4] for row in conn.execute("PRAGMA table_info(embedding_units)").fetchall()}
+    conn.close()
+
+    assert "index_max_length" in columns
+    assert "chunk_policy_version" in columns
+    assert "pooling_mode" in columns
+    assert columns["index_max_length"] == str(LEGACY_INDEX_MAX_LENGTH)
+    assert columns["chunk_policy_version"] == f"'{LEGACY_CHUNK_POLICY_VERSION}'"
+    assert columns["pooling_mode"] == f"'{LEGACY_POOLING_MODE}'"
+
+
+def test_v1_to_v2_migration_stamps_legacy_rows(tmp_path: Path) -> None:
+    """Pre-#1553 manifests must upgrade in place without losing rows.
+
+    Builds a v1-shaped manifest by hand (no v2 columns), inserts
+    representative shard + unit rows, opens the file with the
+    upgraded code, and asserts:
+
+    1. The v2 columns now exist.
+    2. The legacy unit row inherits ``LEGACY_SHIPPED_CONFIG`` values.
+    3. ``filter_new_or_changed`` with the legacy config sees the row
+       as up-to-date (not stale, not new) — no spurious re-encode.
+    """
+
+    db_path = _manifest_path(tmp_path)
+    db_path.parent.mkdir(parents=True)
+
+    legacy_conn = sqlite3.connect(str(db_path))
+    legacy_conn.executescript(
+        """
+        CREATE TABLE embedding_shards (
+            shard_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            corpus       TEXT NOT NULL,
+            path         TEXT NOT NULL,
+            rows         INTEGER NOT NULL,
+            dims         INTEGER NOT NULL DEFAULT 1024,
+            dtype        TEXT NOT NULL DEFAULT 'float16',
+            committed_at TEXT NOT NULL
+        );
+        CREATE INDEX idx_embshards_corpus ON embedding_shards(corpus);
+
+        CREATE TABLE embedding_units (
+            unit_key     TEXT PRIMARY KEY,
+            corpus       TEXT NOT NULL,
+            parent_key   TEXT,
+            text_sha256  TEXT NOT NULL,
+            model        TEXT NOT NULL,
+            shard_id     INTEGER NOT NULL REFERENCES embedding_shards(shard_id),
+            row_idx      INTEGER NOT NULL,
+            deleted      INTEGER NOT NULL DEFAULT 0,
+            updated_at   TEXT NOT NULL
+        );
+        CREATE INDEX idx_embunits_corpus ON embedding_units(corpus, deleted);
+        CREATE INDEX idx_embunits_parent ON embedding_units(corpus, parent_key);
+        CREATE INDEX idx_embunits_shard ON embedding_units(shard_id);
+        """
+    )
+    legacy_conn.execute(
+        "INSERT INTO embedding_shards (corpus, path, rows, committed_at) VALUES (?, ?, ?, ?)",
+        ("textbook_sections", "textbook_sections/shard-000001.npy", 1, "2026-04-19T12:00:00Z"),
+    )
+    legacy_conn.execute(
+        """
+        INSERT INTO embedding_units (
+            unit_key, corpus, parent_key, text_sha256, model, shard_id, row_idx, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 1, 0, ?)
+        """,
+        (
+            "textbook_sections:42",
+            "textbook_sections",
+            "ukrlit-grade-7",
+            "sha-legacy",
+            "bge-m3-mlx-fp16",
+            "2026-04-19T12:00:00Z",
+        ),
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    # Open with upgraded code — migration runs implicitly.
+    manifest = _make_manifest(tmp_path)
+    try:
+        new_keys, stale_keys = filter_new_or_changed(
+            manifest,
+            corpus="textbook_sections",
+            candidates=[("textbook_sections:42", "sha-legacy")],
+            expected_config=LEGACY_SHIPPED_CONFIG,
+        )
+        # Legacy row, queried with legacy config -> neither new nor stale.
+        assert new_keys == []
+        assert stale_keys == []
+
+        row = manifest.get_unit("textbook_sections:42")
+        assert row is not None
+        assert row.index_max_length == LEGACY_INDEX_MAX_LENGTH
+        assert row.chunk_policy_version == LEGACY_CHUNK_POLICY_VERSION
+        assert row.pooling_mode == LEGACY_POOLING_MODE
+    finally:
+        manifest.close()
+
+    conn = sqlite3.connect(str(db_path))
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(embedding_units)").fetchall()}
+    conn.close()
+    assert {"index_max_length", "chunk_policy_version", "pooling_mode"} <= columns
 
 
 def test_append_shard_writes_manifest_rows_and_npy_file(tmp_path: Path) -> None:
@@ -105,6 +241,7 @@ def test_append_shard_writes_manifest_rows_and_npy_file(tmp_path: Path) -> None:
         corpus="textbook_sections",
         vectors=_vectors(100),
         unit_specs=_unit_inputs(100, corpus="textbook_sections"),
+        encoder_config=LEGACY_SHIPPED_CONFIG,
     )
 
     stats = manifest.stats()
@@ -129,6 +266,34 @@ def test_append_shard_writes_manifest_rows_and_npy_file(tmp_path: Path) -> None:
 
     assert shard_count == 1
     assert unit_count == 100
+
+
+def test_append_shard_stamps_encoder_config_on_every_row(tmp_path: Path) -> None:
+    manifest = _make_manifest(tmp_path)
+    custom_config = EncoderConfig(
+        model="bge-m3-mlx-fp16",
+        index_max_length=2048,
+        chunk_policy_version="textbook:v2-paragraph-aware",
+        pooling_mode="cls",
+    )
+
+    append_shard(
+        manifest,
+        corpus="textbook_sections",
+        vectors=_vectors(5),
+        unit_specs=_unit_inputs(5, corpus="textbook_sections"),
+        encoder_config=custom_config,
+    )
+
+    rows = manifest.active_units_for_corpus("textbook_sections")
+    manifest.close()
+
+    assert len(rows) == 5
+    for row in rows:
+        assert row.model == custom_config.model
+        assert row.index_max_length == custom_config.index_max_length
+        assert row.chunk_policy_version == custom_config.chunk_policy_version
+        assert row.pooling_mode == custom_config.pooling_mode
 
 
 def test_append_shard_commit_failure_cleans_renamed_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -164,6 +329,7 @@ def test_append_shard_commit_failure_cleans_renamed_file(tmp_path: Path, monkeyp
             corpus="modern_literary",
             vectors=_vectors(12),
             unit_specs=_unit_inputs(12, corpus="modern_literary"),
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
 
     shard_path = manifest.embeddings_dir / "modern_literary" / "shard-000001.npy"
@@ -185,17 +351,83 @@ def test_filter_new_or_changed_classifies_new_and_stale_keys(tmp_path: Path) -> 
         corpus="external",
         vectors=_vectors(50),
         unit_specs=_unit_inputs(50, corpus="external"),
+        encoder_config=LEGACY_SHIPPED_CONFIG,
     )
 
     candidates = [(f"external:{index}", f"sha-{index}") for index in range(30)]
     candidates.extend((f"external:{index}", f"changed-sha-{index}") for index in range(30, 45))
     candidates.extend((f"external:{index}", f"sha-{index}") for index in range(50, 80))
 
-    new_keys, stale_keys = filter_new_or_changed(manifest, corpus="external", candidates=candidates)
+    new_keys, stale_keys = filter_new_or_changed(
+        manifest,
+        corpus="external",
+        candidates=candidates,
+        expected_config=LEGACY_SHIPPED_CONFIG,
+    )
     manifest.close()
 
     assert new_keys == [f"external:{index}" for index in range(50, 80)]
     assert stale_keys == [f"external:{index}" for index in range(30, 45)]
+
+
+@pytest.mark.parametrize(
+    "config_field",
+    ["model", "index_max_length", "chunk_policy_version", "pooling_mode"],
+)
+def test_filter_marks_stale_when_any_config_field_differs(tmp_path: Path, config_field: str) -> None:
+    """Each component of EncoderConfig must independently force re-encode.
+
+    Regression for the #1553 root cause: pre-fix manifest only
+    compared (unit_key, text_sha256), so bumping ``INDEX_MAX_LENGTH``
+    or swapping models silently produced a mixed-config index.
+    Codex's review asked specifically for the model-field case
+    because that bug exists today, before the chunking work even lands.
+    """
+
+    manifest = _make_manifest(tmp_path)
+    append_shard(
+        manifest,
+        corpus="external",
+        vectors=_vectors(3),
+        unit_specs=_unit_inputs(3, corpus="external"),
+        encoder_config=LEGACY_SHIPPED_CONFIG,
+    )
+
+    overrides = {
+        "model": "another-encoder-v1",
+        "index_max_length": 2048,
+        "chunk_policy_version": "external:v2-paragraph-aware",
+        "pooling_mode": "mean",
+    }
+    different_config = EncoderConfig(
+        model=overrides[config_field] if config_field == "model" else LEGACY_SHIPPED_CONFIG.model,
+        index_max_length=overrides[config_field] if config_field == "index_max_length" else LEGACY_SHIPPED_CONFIG.index_max_length,
+        chunk_policy_version=overrides[config_field] if config_field == "chunk_policy_version" else LEGACY_SHIPPED_CONFIG.chunk_policy_version,
+        pooling_mode=overrides[config_field] if config_field == "pooling_mode" else LEGACY_SHIPPED_CONFIG.pooling_mode,
+    )
+
+    candidates = [(f"external:{index}", f"sha-{index}") for index in range(3)]
+
+    # Same config -> nothing stale.
+    new_keys, stale_keys = filter_new_or_changed(
+        manifest,
+        corpus="external",
+        candidates=candidates,
+        expected_config=LEGACY_SHIPPED_CONFIG,
+    )
+    assert new_keys == []
+    assert stale_keys == []
+
+    # Different config in any one field -> all stale.
+    new_keys, stale_keys = filter_new_or_changed(
+        manifest,
+        corpus="external",
+        candidates=candidates,
+        expected_config=different_config,
+    )
+    manifest.close()
+    assert new_keys == []
+    assert stale_keys == [f"external:{index}" for index in range(3)]
 
 
 def test_active_units_for_corpus_excludes_deleted_rows(tmp_path: Path) -> None:
@@ -205,6 +437,7 @@ def test_active_units_for_corpus_excludes_deleted_rows(tmp_path: Path) -> None:
         corpus="wikipedia",
         vectors=_vectors(50),
         unit_specs=_unit_inputs(50, corpus="wikipedia"),
+        encoder_config=LEGACY_SHIPPED_CONFIG,
     )
 
     deleted_keys = [f"wikipedia:{index}" for index in range(10)]
@@ -221,9 +454,27 @@ def test_active_units_for_corpus_excludes_deleted_rows(tmp_path: Path) -> None:
 def test_shard_map_for_corpus_returns_absolute_paths(tmp_path: Path) -> None:
     manifest = _make_manifest(tmp_path)
     shard_ids = [
-        append_shard(manifest, corpus="archaic_literary", vectors=_vectors(10), unit_specs=_unit_inputs(10, start=0, corpus="archaic_literary")),
-        append_shard(manifest, corpus="archaic_literary", vectors=_vectors(20), unit_specs=_unit_inputs(20, start=10, corpus="archaic_literary")),
-        append_shard(manifest, corpus="archaic_literary", vectors=_vectors(30), unit_specs=_unit_inputs(30, start=30, corpus="archaic_literary")),
+        append_shard(
+            manifest,
+            corpus="archaic_literary",
+            vectors=_vectors(10),
+            unit_specs=_unit_inputs(10, start=0, corpus="archaic_literary"),
+            encoder_config=LEGACY_SHIPPED_CONFIG,
+        ),
+        append_shard(
+            manifest,
+            corpus="archaic_literary",
+            vectors=_vectors(20),
+            unit_specs=_unit_inputs(20, start=10, corpus="archaic_literary"),
+            encoder_config=LEGACY_SHIPPED_CONFIG,
+        ),
+        append_shard(
+            manifest,
+            corpus="archaic_literary",
+            vectors=_vectors(30),
+            unit_specs=_unit_inputs(30, start=30, corpus="archaic_literary"),
+            encoder_config=LEGACY_SHIPPED_CONFIG,
+        ),
     ]
 
     shard_map = manifest.shard_map_for_corpus("archaic_literary")
@@ -241,12 +492,14 @@ def test_vacuum_orphaned_shards_removes_deleted_only_shard(tmp_path: Path) -> No
         corpus="textbook_sections",
         vectors=_vectors(10),
         unit_specs=_unit_inputs(10, corpus="textbook_sections"),
+        encoder_config=LEGACY_SHIPPED_CONFIG,
     )
     second_shard = append_shard(
         manifest,
         corpus="textbook_sections",
         vectors=_vectors(10),
         unit_specs=_unit_inputs(10, start=10, corpus="textbook_sections"),
+        encoder_config=LEGACY_SHIPPED_CONFIG,
     )
 
     first_units = [f"textbook_sections:{index}" for index in range(10)]

--- a/tests/wiki/test_multi_corpus_retrieval.py
+++ b/tests/wiki/test_multi_corpus_retrieval.py
@@ -10,7 +10,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from wiki.embedding_manifest import EmbeddingManifest, UnitSpecInput, append_shard
+from wiki.embedding_manifest import (
+    LEGACY_SHIPPED_CONFIG,
+    EmbeddingManifest,
+    UnitSpecInput,
+    append_shard,
+)
 
 from wiki import dense_rerank, sources_db
 
@@ -238,45 +243,50 @@ def _seed_multi_corpus(conn: sqlite3.Connection, manifest_path: Path) -> None:
             corpus="textbook_sections",
             vectors=textbook_vectors,
             unit_specs=[
-                UnitSpecInput(f"textbook_sections:{idx}", f"tb-{idx}", f"sha-tb-{idx}", "model")
+                UnitSpecInput(f"textbook_sections:{idx}", f"tb-{idx}", f"sha-tb-{idx}")
                 for idx in range(1, 5)
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
         append_shard(
             manifest,
             corpus="modern_literary",
             vectors=modern_vectors,
             unit_specs=[
-                UnitSpecInput(f"modern_literary:mod-{idx}", f"work_{chr(96 + idx)}", f"sha-mod-{idx}", "model")
+                UnitSpecInput(f"modern_literary:mod-{idx}", f"work_{chr(96 + idx)}", f"sha-mod-{idx}")
                 for idx in range(1, 5)
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
         append_shard(
             manifest,
             corpus="archaic_literary",
             vectors=archaic_vectors,
             unit_specs=[
-                UnitSpecInput(f"archaic_literary:arc-{idx}", f"work_{chr(100 + idx)}", f"sha-arc-{idx}", "model")
+                UnitSpecInput(f"archaic_literary:arc-{idx}", f"work_{chr(100 + idx)}", f"sha-arc-{idx}")
                 for idx in range(1, 5)
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
         append_shard(
             manifest,
             corpus="external",
             vectors=external_vectors,
             unit_specs=[
-                UnitSpecInput(f"external:ext-{idx}", f"ext-{idx}", f"sha-ext-{idx}", "model")
+                UnitSpecInput(f"external:ext-{idx}", f"ext-{idx}", f"sha-ext-{idx}")
                 for idx in range(1, 5)
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
         append_shard(
             manifest,
             corpus="wikipedia",
             vectors=wikipedia_vectors,
             unit_specs=[
-                UnitSpecInput(f"wikipedia:{title}:chunk_0", title, f"sha-{title}", "model")
+                UnitSpecInput(f"wikipedia:{title}:chunk_0", title, f"sha-{title}")
                 for title in ("WikiTop", "WikiTwo", "WikiThree", "WikiFour")
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
     finally:
         manifest.close()
@@ -347,10 +357,11 @@ def test_neighbor_expansion_groups_adjacent_literary_chunks(tmp_path: Path, monk
             corpus="modern_literary",
             vectors=np.stack([_vec(0.2), _vec(0.95), _vec(0.25)], axis=0),
             unit_specs=[
-                UnitSpecInput("modern_literary:n-1", "neighbor_work", "sha-1", "model"),
-                UnitSpecInput("modern_literary:n-2", "neighbor_work", "sha-2", "model"),
-                UnitSpecInput("modern_literary:n-3", "neighbor_work", "sha-3", "model"),
+                UnitSpecInput("modern_literary:n-1", "neighbor_work", "sha-1"),
+                UnitSpecInput("modern_literary:n-2", "neighbor_work", "sha-2"),
+                UnitSpecInput("modern_literary:n-3", "neighbor_work", "sha-3"),
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
     finally:
         manifest.close()
@@ -404,9 +415,10 @@ def test_search_sources_respects_track_char_cap(tmp_path: Path, monkeypatch: pyt
             corpus="textbook_sections",
             vectors=np.stack([_vec(0.9), _vec(0.8)], axis=0),
             unit_specs=[
-                UnitSpecInput("textbook_sections:1", "tb-a", "sha-a", "model"),
-                UnitSpecInput("textbook_sections:2", "tb-b", "sha-b", "model"),
+                UnitSpecInput("textbook_sections:1", "tb-a", "sha-a"),
+                UnitSpecInput("textbook_sections:2", "tb-b", "sha-b"),
             ],
+            encoder_config=LEGACY_SHIPPED_CONFIG,
         )
     finally:
         manifest.close()


### PR DESCRIPTION
First commit of the #1553 overhaul. Schema-only — no chunking, no
re-encode. Foundation for the per-corpus chunker (step 1) and the
INDEX_MAX_LENGTH bump (steps 5-6).

## What this fixes

Pre-#1553 ``filter_new_or_changed()`` compared only
``(unit_key, text_sha256, corpus)``. Bumping ``INDEX_MAX_LENGTH``
or swapping models with ``--resume`` produced a silently mixed-config
index. This was Codex's blocker #1 from the architecture review
(msgs #449, #451, #453 in the bridge).

## What changes

- New ``EncoderConfig`` dataclass + ``LEGACY_SHIPPED_CONFIG`` constant.
- ``embedding_units`` schema migrated in place via idempotent
  ``_ensure_schema_v2()``. Pre-existing v1 rows stamp themselves
  with ``LEGACY_SHIPPED_CONFIG`` defaults — non-destructive upgrade.
- ``filter_new_or_changed`` now compares the full config tuple. Any
  config field difference forces re-encode.
- ``append_shard`` takes ``encoder_config`` once per shard (not per
  unit) — invariant by construction.
- 5 new manifest tests + parameterized stale-on-any-field test.

## What does NOT change yet

- Chunking is still per-corpus ad-hoc (Wikipedia 450/50; others
  un-chunked). That's #1553 step 1.
- ``INDEX_MAX_LENGTH`` is still 512. That's #1553 steps 5-6 after
  the chunk-policy bakeoff.
- ``current_encoder_config(corpus)`` returns ``LEGACY_SHIPPED_CONFIG``,
  so existing manifest entries stay valid — no surprise re-encode
  of the production index.

## Tests

74/74 wiki tests pass. Lint clean.

Refs #1553