### PR TITLE
verify: a1/1 Phase A baseline (Claude writer / Codex reviewer) (#1550 U6A)

### DIFF
--- a/evidence/unit6-phaseA/SUMMARY.md
+++ b/evidence/unit6-phaseA/SUMMARY.md
@@ -1,0 +1,44 @@
+# Unit 6 Phase A - Baseline (Claude writer / Codex reviewer)
+
+- Outcome: FAIL
+- module_done emitted: no
+- MIN dim score: N/A (audit did not run)
+- Convergence rounds used: 0
+- Audit gates: failed: build stopped before audit
+- Build wall clock: <1m
+
+## Per-dim scores
+
+| Dim | Score | Verdict           |
+| --- | ---   | ---               |
+| N/A | N/A   | Audit did not run |
+
+## Notable findings
+
+The forced build was invoked with:
+
+```text
+.venv/bin/python -u scripts/build/v6_build.py a1 1 --force --writer claude-tools --reviewer codex-tools
+```
+
+It passed the plan check and generated the research packet, then stopped during
+Step 4 (`SKELETON`) before prose, activities, vocabulary, audit, or review were
+produced.
+
+Terminal failure:
+
+```text
+RuntimeError: Claude CLI < 2.1.116 inherits known quality regressions fixed on 2026-04-23 (see https://www.anthropic.com/engineering/april-23-postmortem). Upgrade with: npm install -g @anthropic-ai/claude-cli@latest
+```
+
+Preflight verification passed before the build:
+
+- `scripts/api/logging.json` uses `uvicorn.logging.AccessFormatter`.
+- `letter_module: true` is present for a1/1.
+- 33 alphabet letter entries are present in `vocabulary_hints.recommended`.
+- All five v6 write prompt blocks are present.
+- A1 `min_types_unique` is `4`.
+
+## Prose excerpt (first dialogue + first letter activity)
+
+Not available. The build stopped before lesson prose was produced.

--- a/evidence/unit6-phaseA/audit.json
+++ b/evidence/unit6-phaseA/audit.json
@@ -1,0 +1,5 @@
+{
+  "available": false,
+  "reason": "The forced a1/1 build stopped during Step 4 (SKELETON) before audit generation.",
+  "failure": "RuntimeError: Claude CLI < 2.1.116 inherits known quality regressions fixed on 2026-04-23; upgrade @anthropic-ai/claude-cli."
+}

--- a/evidence/unit6-phaseA/build.log
+++ b/evidence/unit6-phaseA/build.log
@@ -1,0 +1,54 @@
+{"event": "module_start", "ts": "2026-04-25T10:17:54.868738+00:00", "level": "a1", "slug": "sounds-letters-and-hello"}
+
+🔨 V6 Build: A1 M01 (sounds-letters-and-hello)
+   Writer: claude-tools
+   🔄 --force: resetting module to source of truth...
+  🧹 Cleaned 11 previous build artifact(s)
+  🧹 Removed published MDX: sounds-letters-and-hello.mdx
+   MCP server: ✅ running ({"status":"ok"})
+
+============================================================
+  Step 2: CHECK — Plan validation
+============================================================
+  ✅ Pre-build readiness gate passed
+  ✅ Plan check PASSED
+{"event": "phase_done", "ts": "2026-04-25T10:17:54.993992+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "check", "duration_s": 0.114, "ok": true, "status": "complete"}
+
+============================================================
+  Step 3: RESEARCH — Knowledge packet
+============================================================
+  📚 Wiki context loaded (99,514 chars)
+  ✅ Knowledge packet built (14761 words)
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/curriculum/l2-uk-en/a1/research/sounds-letters-and-hello-knowledge-packet.md
+{"event": "phase_done", "ts": "2026-04-25T10:17:55.059999+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "research", "duration_s": 0.066, "ok": true, "status": "complete"}
+
+============================================================
+  Step 4: SKELETON — Structure planning (claude-tools)
+============================================================
+  Prompt saved → v6-skeleton-prompt.md (52996 chars)
+  Dispatching to claude (claude-opus-4-7)...
+Traceback (most recent call last):
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/build/v6_build.py", line 11893, in <module>
+    raise SystemExit(0 if main() is not False else 1)
+                          ^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/build/v6_build.py", line 11067, in main
+    skeleton_text = step_skeleton(
+                    ^^^^^^^^^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/build/v6_build.py", line 3785, in step_skeleton
+    ok, raw = _dispatch(
+              ^^^^^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/build/dispatch.py", line 419, in dispatch_agent
+    return _dispatch_claude_via_runtime(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/build/dispatch.py", line 475, in _dispatch_claude_via_runtime
+    result = runtime_invoke(
+             ^^^^^^^^^^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/agent_runtime/runner.py", line 974, in invoke
+    plan = adapter.build_invocation(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/agent_runtime/adapters/claude.py", line 171, in build_invocation
+    cli_version = _ensure_supported_claude_cli_version(probe_prefix)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v2/scripts/agent_runtime/adapters/claude.py", line 112, in _ensure_supported_claude_cli_version
+    raise RuntimeError(
+RuntimeError: Claude CLI < 2.1.116 inherits known quality regressions fixed on 2026-04-23 (see https://www.anthropic.com/engineering/april-23-postmortem). Upgrade with: npm install -g @anthropic-ai/claude-cli@latest

--- a/evidence/unit6-phaseA/events.jsonl
+++ b/evidence/unit6-phaseA/events.jsonl
@@ -1,0 +1,3 @@
+{"event": "module_start", "ts": "2026-04-25T10:17:54.868738+00:00", "level": "a1", "slug": "sounds-letters-and-hello"}
+{"event": "phase_done", "ts": "2026-04-25T10:17:54.993992+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "check", "duration_s": 0.114, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T10:17:55.059999+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "research", "duration_s": 0.066, "ok": true, "status": "complete"}

--- a/evidence/unit6-phaseA/produced-module.md
+++ b/evidence/unit6-phaseA/produced-module.md
@@ -1,0 +1,10 @@
+# Not produced
+
+The forced a1/1 build stopped during Step 4 (`SKELETON`) before the lesson
+markdown was generated.
+
+Terminal failure:
+
+```text
+RuntimeError: Claude CLI < 2.1.116 inherits known quality regressions fixed on 2026-04-23 (see https://www.anthropic.com/engineering/april-23-postmortem). Upgrade with: npm install -g @anthropic-ai/claude-cli@latest
+```

--- a/evidence/unit6-phaseA/review-not-produced.md
+++ b/evidence/unit6-phaseA/review-not-produced.md
@@ -1,0 +1,4 @@
+# Not produced
+
+No review round was produced. The forced a1/1 build stopped during Step 4
+(`SKELETON`) before write, audit, or review phases ran.


### PR DESCRIPTION
# Unit 6 Phase A - Baseline (Claude writer / Codex reviewer)

- Outcome: FAIL
- module_done emitted: no
- MIN dim score: N/A (audit did not run)
- Convergence rounds used: 0
- Audit gates: failed: build stopped before audit
- Build wall clock: <1m

## Per-dim scores

| Dim | Score | Verdict           |
| --- | ---   | ---               |
| N/A | N/A   | Audit did not run |

## Notable findings

The forced build was invoked with:

```text
.venv/bin/python -u scripts/build/v6_build.py a1 1 --force --writer claude-tools --reviewer codex-tools
```

It passed the plan check and generated the research packet, then stopped during
Step 4 (`SKELETON`) before prose, activities, vocabulary, audit, or review were
produced.

Terminal failure:

```text
RuntimeError: Claude CLI < 2.1.116 inherits known quality regressions fixed on 2026-04-23 (see https://www.anthropic.com/engineering/april-23-postmortem). Upgrade with: npm install -g @anthropic-ai/claude-cli@latest
```

Preflight verification passed before the build:

- `scripts/api/logging.json` uses `uvicorn.logging.AccessFormatter`.
- `letter_module: true` is present for a1/1.
- 33 alphabet letter entries are present in `vocabulary_hints.recommended`.
- All five v6 write prompt blocks are present.
- A1 `min_types_unique` is `4`.

## Prose excerpt (first dialogue + first letter activity)

Not available. The build stopped before lesson prose was produced.
