### PR TITLE
verify: a1/1 Phase A baseline (Claude writer / Codex reviewer) (#1550 U6A)

### DIFF
--- a/evidence/unit6-phaseA/SUMMARY.md
+++ b/evidence/unit6-phaseA/SUMMARY.md
@@ -1,0 +1,71 @@
+# Unit 6 Phase A — Baseline (Claude writer / Codex reviewer)
+
+- Outcome: FAIL
+- module_done emitted: no
+- MIN dim score: N/A (review not reached)
+- Convergence rounds used: 0
+- Audit gates: failed before audit: activity-pre-validate
+- Build wall clock: 46m20s
+
+## Per-dim scores
+
+Review did not run because the build failed in Step 5g before audit/review.
+
+| Dim | Score | Verdict |
+|---|---:|---|
+| factual | N/A | not reached |
+| language | N/A | not reached |
+| decolonization | N/A | not reached |
+| completeness | N/A | not reached |
+| actionable | N/A | not reached |
+| naturalness | N/A | not reached |
+| plan_adherence | N/A | not reached |
+| honesty | N/A | not reached |
+| dialogue | N/A | not reached |
+
+## Notable findings
+
+- Phase 1 + 2 preflight checks passed before the build.
+- Build ran with `--writer claude-tools --reviewer codex-tools`.
+- Write phase completed on attempt 2 after fixing the required `Підсумок` heading and contract anchor issues.
+- Activity generation required retries. The final terminal failure was activity pre-validation: answer words were not grounded in prose or plan vocabulary: `гриб`, `казка`, `лис`.
+- No audit status JSON or review round was produced because the build failed before audit/review.
+
+## Prose excerpt (first dialogue + first letter activity)
+
+First dialogue from `produced-module.md`:
+
+> **Вчитель:** Добрий день, діти!
+> *Teacher: Good day, children!*
+> **Учні:** Добрий день!
+> *Pupils: Good day!*
+> **Вчитель:** Як справи?
+> *Teacher: How are things?*
+> **Учні:** Добре!
+> *Pupils: Good!*
+> **Марко:** Привіт, Софіє!
+> *Marko: Hi, Sofiia!*
+> **Софія:** Привіт, Марку! Як справи?
+> *Sofiia: Hi, Marko! How are things?*
+> **Марко:** Чудово.
+> *Marko: Great.*
+
+First letter activity from `activities.yaml`:
+
+```yaml
+- type: letter-grid
+  instruction: Голосні — Vowels
+  letters:
+  - upper: А
+    lower: а
+    key_word: ананас
+    sound_type: vowel
+  - upper: О
+    lower: о
+    key_word: око
+    sound_type: vowel
+  - upper: У
+    lower: у
+    key_word: Україна
+    sound_type: vowel
+```

--- a/evidence/unit6-phaseA/activities.yaml
+++ b/evidence/unit6-phaseA/activities.yaml
@@ -1,0 +1,811 @@
+version: '1.0'
+module: sounds-letters-and-hello
+level: a1
+inline:
+- id: quiz-sounds-vs-letters
+  type: quiz
+  instruction: Choose the correct answer about Ukrainian sounds and letters.
+  items:
+  - question: What do we HEAR and PRONOUNCE in Ukrainian?
+    options:
+    - Sounds (звуки)
+    - Letters (літери)
+    - The alphabet (абетка)
+    - Syllables (склади)
+    correct: 0
+  - question: What do we SEE and WRITE in Ukrainian?
+    options:
+    - Sounds (звуки)
+    - Letters (літери)
+    - Words (слова)
+    - Sentences (речення)
+    correct: 1
+  - question: How many letters are in the Ukrainian alphabet (абетка)?
+    options:
+    - '26'
+    - '30'
+    - '33'
+    - '38'
+    correct: 2
+  - question: How many sounds does the Ukrainian language have in total?
+    options:
+    - '26'
+    - '33'
+    - '36'
+    - '38'
+    correct: 3
+  - question: Is it correct to say 'голосна літера' (vowel letter) in Ukrainian phonetics?
+    options:
+    - Yes — А, О, У are vowel letters
+    - Yes — any letter can be a vowel
+    - No — only SOUNDS can be vowels or consonants, not letters
+    - No — Ukrainian has no vowel category
+    correct: 2
+  - question: What does the letter Ь (м'який знак / soft sign) represent?
+    options:
+    - A vowel sound [і]
+    - A consonant sound [й]
+    - No sound at all — it softens the previous consonant
+    - Two sounds at once
+    correct: 2
+  title: Choose the correct answer about Ukrainian sounds and letters.
+- id: match-up-letters-to-sounds
+  type: match-up
+  instruction: 'Match each Ukrainian letter to the sound it represents — just as Ukrainian
+    first-graders learn: ''I see the letter (бачу) — I hear the sound (чую)'''
+  pairs:
+  - left: А
+    right: '[а]'
+  - left: О
+    right: '[о]'
+  - left: У
+    right: '[у]'
+  - left: М
+    right: '[м]'
+  - left: К
+    right: '[к]'
+  - left: Н
+    right: '[н]'
+  - left: С
+    right: '[с]'
+  - left: Л
+    right: '[л]'
+  title: Match each Ukrainian letter to the sound it represents — just as Ukrainian
+    first
+- id: fill-in-l2-pronunciation-errors
+  type: fill-in
+  instruction: Choose the correct Ukrainian word — these are common pronunciation
+    mistakes English speakers make.
+  items:
+  - sentence: Він купив ____ у лісі — великий і червоний.
+    answer: гриб
+    options:
+    - гриб
+    - грип
+  - sentence: Це ____ для дітей — з принцесою і драконом.
+    answer: казка
+    options:
+    - казка
+    - каска
+  - sentence: У лісі живе руда ____.
+    answer: лис
+    options:
+    - лис
+    - ліс
+  - sentence: На столі великий ____ з картону.
+    answer: дім
+    options:
+    - дим
+    - дім
+  - sentence: Діти п'ють ____ щоранку.
+    answer: молоко
+    options:
+    - молоко
+    - малако
+  - sentence: — ____ ____!
+    answer: Доброго ранку
+    options:
+    - Доброго ранку
+    - Добрий день
+    - Добрий вечір
+    - До побачення
+  title: Choose the correct Ukrainian word — these are common pronunciation mistakes
+    Engl
+- id: fill-in-greeting-dialogue
+  type: fill-in
+  instruction: Complete the dialogue — choose the correct word for each blank.
+  items:
+  - sentence: — ____! Як справи?
+    answer: Привіт
+    options:
+    - Привіт
+    - До побачення
+    - Добрий вечір
+    - Нормально
+  - sentence: — Як ____?
+    answer: справи
+    options:
+    - справи
+    - звати
+    - добре
+    - тебе
+  - sentence: — ____. А у тебе?
+    answer: Добре
+    options:
+    - Добре
+    - Привіт
+    - До побачення
+    - Доброго ранку
+  - sentence: — А у ____?
+    answer: тебе
+    options:
+    - тебе
+    - мене
+    - справи
+    - добре
+  - sentence: — ____!
+    answer: Чудово
+    options:
+    - Чудово
+    - Нормально
+    - До побачення
+    - Добрий вечір
+  - sentence: — ____, діти!
+    answer: Доброго ранку
+    options:
+    - Доброго ранку
+    - Добрий вечір
+    - До побачення
+    - Як справи
+  title: Complete the dialogue — choose the correct word for each blank.
+- id: quiz-milozvuchnist-and-nagolos
+  type: quiz
+  instruction: Choose the correct answer about Ukrainian sound harmony (милозвучність)
+    and word stress (наголос).
+  items:
+  - question: What is 'милозвучність' (sound harmony) in Ukrainian?
+    options:
+    - The number of vowels in a word
+    - The natural switching between у/в and і/й to avoid hard consonant clusters
+    - A rule about capital letters
+    - The official name of the Ukrainian alphabet
+    correct: 1
+  - question: Why does Ukrainian switch between 'у' and 'в' (e.g., 'у мене' vs 'в
+      Україні')?
+    options:
+    - They have different meanings
+    - Random speaker choice
+    - To create smooth sound flow — avoiding difficult consonant clusters
+    - One is formal, the other informal
+    correct: 2
+  - question: What is 'наголос' (stress) in Ukrainian?
+    options:
+    - The emphasis on one syllable in a word, making it stronger
+    - The soft sign (ь)
+    - A type of vowel sound
+    - The name for the consonant category
+    correct: 0
+  - question: Ukrainian stress can CHANGE the meaning of a word. Which example shows
+      this?
+    options:
+    - мама / мами (same word, different grammatical form)
+    - замок (lock) / замок (castle) — same spelling, different stress, different meaning
+    - добре / чудово (different words, similar meaning)
+    - привіт / до побачення (greeting vs farewell)
+    correct: 1
+  - question: The unstressed [о] in 'Доброго ранку' — what must you NOT do with it?
+    options:
+    - Stress it strongly
+    - Reduce it toward [а] — that sounds Russian, not Ukrainian
+    - Pronounce it at all
+    - Write it in a different position
+    correct: 1
+  - question: The final consonant in 'день' — what makes it special?
+    options:
+    - It is a vowel in disguise
+    - It is silent, like the 'k' in English 'knock'
+    - It is a soft [н′] — softened by the soft sign ь
+    - It is the hardest consonant in Ukrainian
+    correct: 2
+  title: Choose the correct answer about Ukrainian sound harmony (милозвучність) and
+    word
+- type: letter-grid
+  instruction: Голосні — Vowels
+  letters:
+  - upper: А
+    lower: а
+    emoji: 🍍
+    key_word: ананас
+    sound_type: vowel
+  - upper: О
+    lower: о
+    emoji: 👁️
+    key_word: око
+    sound_type: vowel
+  - upper: У
+    lower: у
+    emoji: 🇺🇦
+    key_word: Україна
+    sound_type: vowel
+  - upper: И
+    lower: и
+    emoji: 🐟
+    key_word: риба
+    sound_type: vowel
+  - upper: І
+    lower: і
+    emoji: 🦃
+    key_word: індик
+    sound_type: vowel
+  - upper: Е
+    lower: е
+    emoji: 📺
+    key_word: екран
+    sound_type: vowel
+  - upper: Я
+    lower: я
+    emoji: 🍎
+    key_word: яблуко
+    sound_type: vowel
+  - upper: Ю
+    lower: ю
+    emoji: 🧑
+    key_word: юнак
+    sound_type: vowel
+  - upper: Є
+    lower: є
+    emoji: 🦝
+    key_word: єнот
+    sound_type: vowel
+  - upper: Ї
+    lower: ї
+    emoji: 🦔
+    key_word: їжак
+    sound_type: vowel
+  id: letter-grid-7
+- type: letter-grid
+  instruction: Friendly letters
+  letters:
+  - upper: М
+    lower: м
+    emoji: 🥕
+    key_word: морква
+    sound_type: consonant
+  - upper: К
+    lower: к
+    emoji: 🐱
+    key_word: кіт
+    sound_type: consonant
+  - upper: Т
+    lower: т
+    emoji: 🐯
+    key_word: тигр
+    sound_type: consonant
+  id: letter-grid-8
+- type: letter-grid
+  instruction: False friends!
+  letters:
+  - upper: Н
+    lower: н
+    emoji: ✂️
+    key_word: ножиці
+    sound_type: consonant
+  - upper: С
+    lower: с
+    emoji: 👜
+    key_word: сумка
+    sound_type: consonant
+  - upper: Р
+    lower: р
+    emoji: 🚀
+    key_word: ракета
+    sound_type: consonant
+  - upper: В
+    lower: в
+    emoji: 🐺
+    key_word: вовк
+    sound_type: consonant
+  - upper: Х
+    lower: х
+    emoji: 🍞
+    key_word: хліб
+    sound_type: consonant
+  id: letter-grid-9
+- type: letter-grid
+  instruction: New shapes
+  letters:
+  - upper: Л
+    lower: л
+    emoji: ✈️
+    key_word: літак
+    sound_type: consonant
+  - upper: Б
+    lower: б
+    emoji: 🍌
+    key_word: банан
+    sound_type: consonant
+  - upper: Д
+    lower: д
+    emoji: 🏠
+    key_word: дім
+    sound_type: consonant
+  - upper: П
+    lower: п
+    emoji: 🕷️
+    key_word: павук
+    sound_type: consonant
+  - upper: Г
+    lower: г
+    emoji: ⛰️
+    key_word: гора
+    sound_type: consonant
+  - upper: Ґ
+    lower: ґ
+    emoji: 🚪
+    key_word: ґанок
+    sound_type: consonant
+  - upper: З
+    lower: з
+    emoji: 🦓
+    key_word: зебра
+    sound_type: consonant
+  - upper: Ж
+    lower: ж
+    emoji: 🪲
+    key_word: жук
+    sound_type: consonant
+  - upper: Ш
+    lower: ш
+    emoji: 🧢
+    key_word: шапка
+    sound_type: consonant
+  - upper: Й
+    lower: й
+    emoji: 🥛
+    key_word: йогурт
+    sound_type: consonant
+  - upper: Ч
+    lower: ч
+    emoji: 🐢
+    key_word: черепаха
+    sound_type: consonant
+  - upper: Щ
+    lower: щ
+    emoji: 🪥
+    key_word: щітка
+    sound_type: consonant
+  - upper: Ц
+    lower: ц
+    emoji: 🧅
+    key_word: цибуля
+    sound_type: consonant
+  - upper: Ф
+    lower: ф
+    emoji: 🦩
+    key_word: фламінго
+    sound_type: consonant
+  id: letter-grid-10
+- type: letter-grid
+  instruction: Special letters
+  letters:
+  - upper: Я
+    lower: я
+    emoji: 🍎
+    key_word: яблуко
+    sound_type: vowel
+  - upper: Ю
+    lower: ю
+    emoji: 🧑
+    key_word: юнак
+    sound_type: vowel
+  - upper: Є
+    lower: є
+    emoji: 🦝
+    key_word: єнот
+    sound_type: vowel
+  - upper: Ь
+    lower: ь
+    emoji: 🧂
+    key_word: сіль
+    sound_type: special
+  - upper: Ї
+    lower: ї
+    emoji: 🦔
+    key_word: їжак
+    sound_type: vowel
+  id: letter-grid-11
+- type: watch-and-repeat
+  instruction: 'Watch and repeat: А, М, Л, У, Н, С'
+  items:
+  - video: https://www.youtube.com/watch?v=hvB3VpcR3ZE
+    letter: А
+    word: ананас
+    note: У нас ананас.
+  - video: https://www.youtube.com/watch?v=Ez95H4ibuJo
+    letter: М
+    word: морква
+    note: Мама сама.
+  - video: https://www.youtube.com/watch?v=v6-3Xg52Buk
+    letter: Л
+    word: літак
+    note: Мала лама.
+  - video: https://www.youtube.com/watch?v=VB1O6PmtYRU
+    letter: У
+    word: Україна
+    note: У нас мул.
+  - video: https://www.youtube.com/watch?v=vNUfiKHPYaU
+    letter: Н
+    word: ножиці
+    note: У нас лан.
+  - video: https://www.youtube.com/watch?v=7UsFBgSL91E
+    letter: С
+    word: сумка
+    note: Сумна мама.
+  id: watch-and-repeat-12
+- type: watch-and-repeat
+  instruction: 'Watch and repeat: К, И, Р, Б, В, Д, І'
+  items:
+  - video: https://www.youtube.com/watch?v=J7sGEI4-xJo
+    letter: К
+    word: кіт
+    note: ''
+  - video: https://www.youtube.com/watch?v=W-1rCu0indE
+    letter: И
+    word: риба
+    note: ''
+  - video: https://www.youtube.com/watch?v=fMGsQ5KPQgg
+    letter: Р
+    word: ракета
+    note: ''
+  - video: https://www.youtube.com/watch?v=V1hxBE_JbGg
+    letter: Б
+    word: банан
+    note: ''
+  - video: https://www.youtube.com/watch?v=aFcvYfvQ2X4
+    letter: В
+    word: вовк
+    note: ''
+  - video: https://www.youtube.com/watch?v=g4Bh-lqzd48
+    letter: Д
+    word: дім
+    note: ''
+  - video: https://www.youtube.com/watch?v=Z9TH0H4ShGo
+    letter: І
+    word: індик
+    note: ''
+  id: watch-and-repeat-13
+- type: watch-and-repeat
+  instruction: 'Watch and repeat: П, Т, Г, Ґ, Е, З, Ж, Ш, Х'
+  items:
+  - video: https://www.youtube.com/watch?v=JksSjjxyW5Y
+    letter: П
+    word: павук
+    note: ''
+  - video: https://www.youtube.com/watch?v=m-jcLR_gK0k
+    letter: Т
+    word: тигр
+    note: ''
+  - video: https://www.youtube.com/watch?v=gVnclpSI0DU
+    letter: Г
+    word: гора
+    note: ''
+  - video: https://www.youtube.com/watch?v=gNjHqjTW9WQ
+    letter: Ґ
+    word: ґанок
+    note: ''
+  - video: https://www.youtube.com/watch?v=KFlsroBW0dk
+    letter: Е
+    word: екран
+    note: ''
+  - video: https://www.youtube.com/watch?v=BhASNxitC1A
+    letter: З
+    word: зебра
+    note: ''
+  - video: https://www.youtube.com/watch?v=dIrGVcqPwqM
+    letter: Ж
+    word: жук
+    note: ''
+  - video: https://www.youtube.com/watch?v=1D-6MIw3OXY
+    letter: Ш
+    word: шапка
+    note: ''
+  - video: https://www.youtube.com/watch?v=vpr58zJSJKc
+    letter: Х
+    word: хліб
+    note: ''
+  id: watch-and-repeat-14
+- type: watch-and-repeat
+  instruction: 'Watch and repeat: Й, Ч, Щ, Я, Ю, Є, Ь, Ї, Ц, Ф'
+  items:
+  - video: https://www.youtube.com/watch?v=aq0cjB90s3w
+    letter: Й
+    word: йогурт
+    note: ''
+  - video: https://www.youtube.com/watch?v=UsJkbdsY2RA
+    letter: Ч
+    word: черепаха
+    note: ''
+  - video: https://www.youtube.com/watch?v=QmBLieIuf6Q
+    letter: Щ
+    word: щітка
+    note: ''
+  - video: https://www.youtube.com/watch?v=yhSAf41LX8I
+    letter: Я
+    word: яблуко
+    note: ''
+  - video: https://www.youtube.com/watch?v=9JdIBYCTWGw
+    letter: Ю
+    word: юнак
+    note: ''
+  - video: https://www.youtube.com/watch?v=O0bwRyyBQSc
+    letter: Є
+    word: єнот
+    note: ''
+  - video: https://www.youtube.com/watch?v=cJlal8XKBxo
+    letter: Ь
+    word: сіль
+    note: ''
+  - video: https://www.youtube.com/watch?v=UcjdjQXhAY8
+    letter: Ї
+    word: їжак
+    note: ''
+  - video: https://www.youtube.com/watch?v=u44eCjR2Oz8
+    letter: Ц
+    word: цибуля
+    note: ''
+  - video: https://www.youtube.com/watch?v=haHRsFFZRQI
+    letter: Ф
+    word: фламінго
+    note: ''
+  id: watch-and-repeat-15
+workbook:
+- id: wb-match-up-greetings
+  type: match-up
+  instruction: Match each Ukrainian expression to its English meaning.
+  pairs:
+  - left: Привіт!
+    right: Hi! (informal)
+  - left: Добрий день!
+    right: Good day! / Hello! (formal)
+  - left: Доброго ранку!
+    right: Good morning!
+  - left: Добрий вечір!
+    right: Good evening!
+  - left: До побачення!
+    right: Goodbye!
+  - left: Як справи?
+    right: How are you? / How are things?
+  - left: Чудово!
+    right: Great! / Wonderful!
+  - left: Нормально.
+    right: Fine. / Okay.
+  title: Match each Ukrainian expression to its English meaning.
+- id: wb-group-sort-formal-informal
+  type: group-sort
+  instruction: Sort these expressions — formal (use with teachers and strangers) or
+    informal (use with friends and peers)?
+  groups:
+  - label: Formal (офіційне)
+    items:
+    - Добрий день!
+    - Доброго ранку!
+    - Добрий вечір!
+    - До побачення!
+    - На все добре!
+  - label: Informal (неофіційне)
+    items:
+    - Привіт!
+    - Як справи?
+    - Радий тебе бачити!
+    - Нормально.
+    - А у тебе?
+    - Рада тебе бачити!
+  title: Sort these expressions — formal (use with teachers and strangers) or informal
+    (u
+- id: wb-fill-in-key-facts
+  type: fill-in
+  instruction: Fill in the correct word to complete each statement.
+  items:
+  - sentence: Ukrainian has 33 ____ in its alphabet.
+    answer: літери
+    options:
+    - літери
+    - звуки
+    - слова
+    - склади
+  - sentence: Ukrainian has 38 ____ in total — more than the 33 letters.
+    answer: звуки
+    options:
+    - звуки
+    - літери
+    - слова
+    - абетки
+  - sentence: The letter Ь represents ____ sounds — it only softens the previous consonant.
+    answer: zero
+    options:
+    - zero
+    - one
+    - two
+    - three
+  - sentence: ____ sounds are made with voice only — you can sing them.
+    answer: Голосні
+    options:
+    - Голосні
+    - Приголосні
+    - М'які
+    - Тверді
+  - sentence: ____ sounds are made when lips, teeth, or tongue block the airflow.
+    answer: Приголосні
+    options:
+    - Приголосні
+    - Голосні
+    - Йотовані
+    - Тверді
+  - sentence: The word 'мама' contains ____ vowel sounds.
+    answer: '2'
+    options:
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+  title: Fill in the correct word to complete each statement.
+- id: wb-anagram-vocab
+  type: anagram
+  instruction: Rearrange the letters to spell the Ukrainian word.
+  items:
+  - letters:
+    - а
+    - м
+    - а
+    - м
+    answer: мама
+  - letters:
+    - а
+    - т
+    - т
+    - о
+    answer: тато
+  - letters:
+    - м
+    - і
+    - д
+    answer: дім
+  - letters:
+    - с
+    - о
+    - н
+    answer: сон
+  - letters:
+    - к
+    - о
+    - о
+    answer: око
+  - letters:
+    - к
+    - о
+    - м
+    - о
+    - л
+    - о
+    answer: молоко
+  title: Rearrange the letters to spell the Ukrainian word.
+- id: wb-true-false-phonetics
+  type: true-false
+  instruction: True or false? Read each statement and decide.
+  items:
+  - statement: In Ukrainian, a 'звук' (sound) and a 'літера' (letter) are the same
+      thing.
+    correct: false
+    explanation: They are different. Sounds (звуки) are what we hear and say; letters
+      (літери) are what we see and write.
+  - statement: Ukrainian has more sounds (38) than letters (33).
+    correct: true
+    explanation: Yes — letters Я, Ю, Є, Ї can each represent two sounds in certain
+      positions, and Ь represents no sound at all.
+  - statement: Only sounds — not letters — can be голосні (vowels) or приголосні (consonants).
+    correct: true
+    explanation: Correct. We say 'голосний звук' (vowel sound), not 'голосна літера'
+      (vowel letter).
+  - statement: The soft sign Ь represents a vowel sound similar to [і].
+    correct: false
+    explanation: Ь represents NO sound. Its only job is to soften the consonant before
+      it, as in 'день' where [н] becomes soft [н′].
+  - statement: 'Ukrainian has exactly six vowel sounds: [а], [о], [у], [е], [и], [і].'
+    correct: true
+    explanation: Exactly six vowel sounds, though there are ten vowel letters (the
+      six above plus the йотовані Я, Ю, Є, Ї).
+  - statement: In Ukrainian, the unstressed [о] in 'молоко' reduces toward [а], just
+      like in Russian.
+    correct: false
+    explanation: No — Ukrainian [о] stays full and round even when unstressed. 'Молоко'
+      stays [молоко], NOT [малако].
+  - statement: The greeting 'Привіт!' is correct to use with your Ukrainian teacher.
+    correct: false
+    explanation: Привіт is informal — for friends and peers. With teachers, use the
+      formal greeting 'Добрий день!'.
+  title: True or false? Read each statement and decide.
+- id: wb-count-syllables
+  type: count-syllables
+  instruction: How many syllables does each word have? (Count the vowel sounds — each
+    vowel sound = one syllable.)
+  items:
+  - word: мама
+    correct: 2
+    translation: mum
+  - word: молоко
+    correct: 3
+    translation: milk
+  - word: привіт
+    correct: 2
+    translation: hi
+  - word: яблуко
+    correct: 3
+    translation: apple
+  - word: день
+    correct: 1
+    translation: day
+  - word: тато
+    correct: 2
+    translation: father
+  - word: добре
+    correct: 2
+    translation: good / fine
+  - word: чудово
+    correct: 3
+    translation: great / wonderful
+  title: How many syllables does each word have? (Count the vowel sounds — each vowel
+    sou
+- id: wb-odd-one-out
+  type: odd-one-out
+  instruction: Which word or expression does not belong? Find the odd one out in each
+    group.
+  items:
+  - words:
+    - Привіт!
+    - Добрий день!
+    - Доброго ранку!
+    - Як справи?
+    correct: 3
+    explanation: '''Як справи?'' is a question (how are you?), not a greeting. The
+      other three are greetings.'
+  - words:
+    - '[а]'
+    - '[о]'
+    - '[у]'
+    - '[к]'
+    correct: 3
+    explanation: '[к] is a consonant sound (приголосний). The others — [а], [о], [у]
+      — are all vowel sounds (голосні).'
+  - words:
+    - мама
+    - тато
+    - молоко
+    - привіт
+    correct: 3
+    explanation: '''Привіт'' is a greeting. The other three are nouns naming people
+      or things.'
+  - words:
+    - Добре.
+    - Чудово.
+    - Нормально.
+    - До побачення!
+    correct: 3
+    explanation: '''До побачення!'' is a farewell. The other three are answers to
+      ''Як справи?'''
+  - words:
+    - '[м]'
+    - '[н]'
+    - '[к]'
+    - '[а]'
+    correct: 3
+    explanation: '[а] is a vowel sound (голосний). The others — [м], [н], [к] — are
+      all consonant sounds (приголосні).'
+  - words:
+    - день
+    - сон
+    - ніс
+    - мама
+    correct: 3
+    explanation: '''Мама'' has 2 syllables (2 vowel sounds). The others — день, сон,
+      ніс — each have only 1 syllable.'
+  title: Which word or expression does not belong? Find the odd one out in each group.

--- a/evidence/unit6-phaseA/activity-pre-validation.json
+++ b/evidence/unit6-phaseA/activity-pre-validation.json
@@ -1,0 +1,23 @@
+{
+  "ungrounded_answers": [
+    {
+      "word": "гриб",
+      "exercise_type": "fill-in",
+      "context": "гриб",
+      "role": "answer"
+    },
+    {
+      "word": "казка",
+      "exercise_type": "fill-in",
+      "context": "казка",
+      "role": "answer"
+    },
+    {
+      "word": "лис",
+      "exercise_type": "fill-in",
+      "context": "лис",
+      "role": "answer"
+    }
+  ],
+  "required_vocab_missing": []
+}

--- a/evidence/unit6-phaseA/audit-not-produced.txt
+++ b/evidence/unit6-phaseA/audit-not-produced.txt
@@ -1,0 +1,1 @@
+No audit status JSON was produced. The build failed at Step 5g (activity pre-validation) before audit.

--- a/evidence/unit6-phaseA/build.log
+++ b/evidence/unit6-phaseA/build.log
@@ -1,0 +1,213 @@
+{"event": "module_start", "ts": "2026-04-25T12:24:52.273585+00:00", "level": "a1", "slug": "sounds-letters-and-hello"}
+
+🔨 V6 Build: A1 M01 (sounds-letters-and-hello)
+   Writer: claude-tools
+   🔄 --force: resetting module to source of truth...
+  🧹 Cleaned 11 previous build artifact(s)
+  🧹 Removed published MDX: sounds-letters-and-hello.mdx
+   MCP server: ✅ running ({"status":"ok"})
+
+============================================================
+  Step 2: CHECK — Plan validation
+============================================================
+  ✅ Pre-build readiness gate passed
+  ✅ Plan check PASSED
+{"event": "phase_done", "ts": "2026-04-25T12:24:52.409539+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "check", "duration_s": 0.124, "ok": true, "status": "complete"}
+
+============================================================
+  Step 3: RESEARCH — Knowledge packet
+============================================================
+  📚 Wiki context loaded (99,514 chars)
+  ✅ Knowledge packet built (14761 words)
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/research/sounds-letters-and-hello-knowledge-packet.md
+{"event": "phase_done", "ts": "2026-04-25T12:24:52.481042+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "research", "duration_s": 0.071, "ok": true, "status": "complete"}
+
+============================================================
+  Step 4: SKELETON — Structure planning (claude-tools)
+============================================================
+  Prompt saved → v6-skeleton-prompt.md (52996 chars)
+  Dispatching to claude (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/01-skeleton-20260425-142723-032048-257482708-meta.json (151s)
+  ✅ Skeleton generated (1536 words)
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/orchestration/sounds-letters-and-hello/skeleton.md
+{"event": "phase_done", "ts": "2026-04-25T12:27:23.092688+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "skeleton", "duration_s": 150.628, "ok": true, "status": "complete"}
+
+  📐 Skeleton active (1536 words) — will constrain writer
+
+============================================================
+  Step 3b: PRE-VERIFY — Tool-forced fact checking (claude-tools)
+============================================================
+  Prompt saved → v6-pre-verify-prompt.md (8130 chars)
+  Dispatching to claude-tools (claude-sonnet-4-6)...
+  📋 Dispatch log → dispatch/00-pre-verify-20260425-142843-186457-412283166-meta.json (80s)
+  ✅ Pre-verification complete (3172 chars, 6 verification indicators)
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/orchestration/sounds-letters-and-hello/pre-verify-results.md
+{"event": "phase_done", "ts": "2026-04-25T12:28:43.219505+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "pre-verify", "duration_s": 80.127, "ok": true, "status": "complete"}
+
+============================================================
+  Step 4b: CONTRACT — Plan + wiki compression
+============================================================
+  ✅ Contract saved → contract.yaml
+  ✅ Wiki excerpts saved → wiki-excerpts.yaml
+
+  📝 Write attempt 1/5 (writer: claude-tools)
+
+============================================================
+  Step 5: WRITE — Content generation (claude-tools)
+============================================================
+  Chunking enabled: word_target=1200, sections=5
+  📦 CHUNKED generation — writing section-by-section
+  Skeleton has 5 sections:
+    1. Звуки і літери (~330 words total) (~330 words)
+    2. Голосні звуки (~275 words total) (~275 words)
+    3. Приголосні звуки (~275 words total) (~275 words)
+    4. Привіт! (~275 words total) (~275 words)
+    5. Summary (~165 words total) (~165 words)
+  ♻️  Rebuilding contract/excerpts — stale sidecar (contract mismatches: ('decisions_subset', 'threshold_snapshot.level_config'), excerpts mismatches: ('decisions_subset', 'threshold_snapshot.level_config'))
+
+  --- Chunk 1/5: Звуки і літери (~330 words total) ---
+  Dispatching to claude-tools (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/99-write-chunk-01-20260425-143018-532005-758351708-meta.json (95s)
+  ✅ Chunk 1: 364 words
+
+  --- Chunk 2/5: Голосні звуки (~275 words total) ---
+  ⚠️  Chunk 2 prompt audit: prompt exceeds max chars (13064 > 12000)
+  Dispatching to claude-tools (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/99-write-chunk-02-20260425-143213-641231-868186125-meta.json (115s)
+  ✅ Chunk 2: 317 words
+
+  --- Chunk 3/5: Приголосні звуки (~275 words total) ---
+  ⚠️  Chunk 3 prompt audit: prompt exceeds max chars (14968 > 12000)
+  Dispatching to claude-tools (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/99-write-chunk-03-20260425-143358-733156-960676500-meta.json (105s)
+  ✅ Chunk 3: 326 words
+
+  --- Chunk 4/5: Привіт! (~275 words total) ---
+  ⚠️  Chunk 4 prompt audit: prompt exceeds max chars (15729 > 12000)
+  Dispatching to claude-tools (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/99-write-chunk-04-20260425-143508-808588-036510333-meta.json (70s)
+  ✅ Chunk 4: 442 words
+
+  --- Chunk 5/5: Summary (~165 words total) ---
+  Dispatching to claude-tools (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/99-write-chunk-05-20260425-143523-834031-062023291-meta.json (15s)
+  ✅ Chunk 5: 196 words
+
+  ✅ Chunked write complete: 1645 words total (5 sections)
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/sounds-letters-and-hello.md
+  ♻️  Rebuilding contract/excerpts — stale sidecar (contract mismatches: ('decisions_subset', 'threshold_snapshot.level_config'), excerpts mismatches: ('decisions_subset', 'threshold_snapshot.level_config'))
+  ❌ Quick verify FAILED — 1 error(s), 0 warning(s)
+  ❌ [STRUCTURE] Missing section heading: 'Підсумок'
+  ❌ Contract compliance FAILED — 8 violation(s)
+    [SECTION_ORDER] Expected H2 order ['Звуки і літери', 'Голосні звуки', 'Приголосні звуки', 'Привіт!', 'Підсумок'], found ['Звуки і літери', 'Голосні звуки', 'Приголосні звуки', 'Привіт!', 'Summary']
+    [MISSING_SECTION] Missing required H2 section 'Підсумок'
+    [FACTUAL_ANCHOR] Section 'Звуки і літери' misses factual anchor terms ['від', 'відміну', 'відповідь'] from pedagogy/a1/sounds-letters-and-hello.md :: Послідовність введення
+    [FACTUAL_ANCHOR] Section 'Звуки і літери' misses factual anchor terms ['алфавіт', 'від', 'голосні', 'два'] from pedagogy/a1/checkpoint-first-contact.md :: Послідовність введення
+    [FACTUAL_ANCHOR] Section 'Голосні звуки' misses factual anchor terms ['без', 'вимовляються', 'голосних'] from pedagogy/a1/sounds-letters-and-hello.md :: Послідовність введення
+  🔍 Friction auto-query: 10 relevant hint(s) from past builds
+  🔄 Retrying with correction directive...
+
+  📝 Write attempt 2/5 (writer: claude-tools)
+
+============================================================
+  Step 5 (Fix): FIX OUTPUT — Holistic correction (claude-tools)
+============================================================
+  Dispatching to claude-tools (claude-opus-4-7)...
+  📋 Dispatch log → dispatch/99-write-fix-20260425-143738-509214-737916458-meta.json (135s)
+  ✅ Fixed content written (1685 words)
+  ♻️  Rebuilding contract/excerpts — stale sidecar (contract mismatches: ('decisions_subset', 'threshold_snapshot.level_config'), excerpts mismatches: ('decisions_subset', 'threshold_snapshot.level_config'))
+  ✅ Quick verify PASSED — all structural checks clean
+  ✅ Contract compliance PASSED
+  ✅ Quick verify PASSED on attempt 2
+{"event": "phase_done", "ts": "2026-04-25T12:37:38.666397+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "write", "duration_s": 535.37, "ok": true, "status": "complete"}
+
+============================================================
+  Step 5a: HONESTY ANNOTATE — VERIFY markers
+============================================================
+  ✅ Added VERIFY markers to 2 line(s)
+{"event": "phase_done", "ts": "2026-04-25T12:37:38.694117+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "honesty-annotate", "duration_s": 0.028, "ok": true, "status": "complete"}
+
+============================================================
+  Step 5b: EXERCISES — Skipped (ACTIVITIES step handles exercises)
+============================================================
+
+============================================================
+  Step 5e: ACTIVITIES — Structured YAML generation (claude-tools)
+============================================================
+  Prompt saved → v6-activities-prompt.md (49187 chars)
+
+  📝 Activity generation attempt 1/5
+  Dispatching to claude-tools (claude-sonnet-4-6)...
+  📋 Dispatch log → dispatch/02b-activities-20260425-144509-118447-349584458-meta.json (450s)
+  ❌ Response too short (1027 chars) — likely commentary, not YAML
+
+  📝 Activity generation attempt 2/5
+  Dispatching to claude-tools (claude-sonnet-4-6)...
+  📋 Dispatch log → dispatch/02b-activities-20260425-145203-837271-078802166-meta.json (415s)
+  🔧 Stripped 2 parenthetical hints from fill-in sentences
+  ✅ Activities generated: 6 inline + 7 workbook
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/activities/sounds-letters-and-hello.yaml
+  📝 Injected 5 letter-grid activities from abetka
+  📝 Injected watch-and-repeat: А, М, Л, У, Н, С (6 videos)
+  📝 Injected watch-and-repeat: К, И, Р, Б, В, Д, І (7 videos)
+  📝 Injected watch-and-repeat: П, Т, Г, Ґ, Е, З, Ж, Ш, Х (9 videos)
+  📝 Injected watch-and-repeat: Й, Ч, Щ, Я, Ю, Є, Ь, Ї, Ц, Ф (10 videos)
+{"event": "phase_done", "ts": "2026-04-25T12:52:04.044855+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "activities", "duration_s": 865.337, "ok": true, "status": "complete"}
+
+============================================================
+  Step 5f: REPAIR — Deterministic activity fixes (sounds-letters-and-hello)
+============================================================
+  🔧 Applied 9 fix(es):
+    • moved 9 INLINE-ONLY type(s) from workbook: letter-grid, watch-and-repeat
+  Final counts: 15 inline + 7 workbook
+  🔁 Activities changed — invalidating downstream phases (publish, audit) for --resume
+{"event": "phase_done", "ts": "2026-04-25T12:52:04.129063+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "repair", "duration_s": 0.084, "ok": true, "status": "complete"}
+
+============================================================
+  Step 5g: ACTIVITY PRE-VALIDATE — Grounding + required vocab
+============================================================
+  ❌ Activity pre-validation failed
+    - activity grounding failed before review: answer word(s) not grounded in prose or plan vocabulary: гриб, казка, лис
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/orchestration/sounds-letters-and-hello/activity-pre-validation.json
+  🔄 Activity pre-validation failed — regenerating activities once through tier-1 repair
+
+============================================================
+  Step 5e: ACTIVITIES — Structured YAML generation (claude-tools)
+============================================================
+  Prompt saved → v6-activities-prompt.md (49187 chars)
+
+  📝 Activity generation attempt 1/5
+  Dispatching to claude-tools (claude-sonnet-4-6)...
+  📋 Dispatch log → dispatch/02b-activities-20260425-150219-839009-086515250-meta.json (616s)
+  ❌ Response too short (1233 chars) — likely commentary, not YAML
+
+  📝 Activity generation attempt 2/5
+  Dispatching to claude-tools (claude-sonnet-4-6)...
+  📋 Dispatch log → dispatch/02b-activities-20260425-151110-687566-938407208-meta.json (531s)
+  🔧 Stripped 11 parenthetical hints from fill-in sentences
+  ✅ Activities generated: 6 inline + 7 workbook
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/activities/sounds-letters-and-hello.yaml
+  📝 Injected 5 letter-grid activities from abetka
+  📝 Injected watch-and-repeat: А, М, Л, У, Н, С (6 videos)
+  📝 Injected watch-and-repeat: К, И, Р, Б, В, Д, І (7 videos)
+  📝 Injected watch-and-repeat: П, Т, Г, Ґ, Е, З, Ж, Ш, Х (9 videos)
+  📝 Injected watch-and-repeat: Й, Ч, Щ, Я, Ю, Є, Ь, Ї, Ц, Ф (10 videos)
+
+============================================================
+  Step 5f: REPAIR — Deterministic activity fixes (sounds-letters-and-hello)
+============================================================
+  🔧 Applied 10 fix(es):
+    • moved 9 INLINE-ONLY type(s) from workbook: letter-grid, watch-and-repeat
+    • dropped 1 inline activities with disallowed types: group-sort
+  Final counts: 14 inline + 7 workbook
+
+============================================================
+  Step 5g: ACTIVITY PRE-VALIDATE — Grounding + required vocab
+============================================================
+  ❌ Activity pre-validation failed
+    - activity grounding failed before review: answer word(s) not grounded in prose or plan vocabulary: гриб, казка, лис
+  → /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/codex-1550-unit6-phaseA-baseline-v3/curriculum/l2-uk-en/a1/orchestration/sounds-letters-and-hello/activity-pre-validation.json
+
+❌ Build FAILED at Step 5g (activity pre-validation)
+{"event": "module_failed", "ts": "2026-04-25T13:11:11.179969+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "activity-pre-validate", "error": "Build FAILED at Step 5g (activity pre-validation)"}
+__WALL_CLOCK_SECONDS=2780

--- a/evidence/unit6-phaseA/events.jsonl
+++ b/evidence/unit6-phaseA/events.jsonl
@@ -1,0 +1,10 @@
+{"event": "module_start", "ts": "2026-04-25T12:24:52.273585+00:00", "level": "a1", "slug": "sounds-letters-and-hello"}
+{"event": "phase_done", "ts": "2026-04-25T12:24:52.409539+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "check", "duration_s": 0.124, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:24:52.481042+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "research", "duration_s": 0.071, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:27:23.092688+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "skeleton", "duration_s": 150.628, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:28:43.219505+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "pre-verify", "duration_s": 80.127, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:37:38.666397+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "write", "duration_s": 535.37, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:37:38.694117+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "honesty-annotate", "duration_s": 0.028, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:52:04.044855+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "activities", "duration_s": 865.337, "ok": true, "status": "complete"}
+{"event": "phase_done", "ts": "2026-04-25T12:52:04.129063+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "repair", "duration_s": 0.084, "ok": true, "status": "complete"}
+{"event": "module_failed", "ts": "2026-04-25T13:11:11.179969+00:00", "level": "a1", "slug": "sounds-letters-and-hello", "phase": "activity-pre-validate", "error": "Build FAILED at Step 5g (activity pre-validation)"}

--- a/evidence/unit6-phaseA/produced-module.md
+++ b/evidence/unit6-phaseA/produced-module.md
@@ -1,0 +1,136 @@
+## Звуки і літери
+
+Ukrainian schoolchildren learn one rule before any other in their phonetics lessons. Заболотний's grade-5 textbook (стор. 83) puts it this way: «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо» — sounds we hear and pronounce, letters we see and write. So a **«звук»** (sound) is what your mouth produces and your ear catches. A **«літера»** (letter) is the symbol you see on paper. They are not the same thing. Take the simple word **«мама»** (mum): the sounds you hear are [мама] — four sounds your voice produces. The letters you see are М-А-М-А — four marks on the page. Keep these two channels — mouth and hand, ear and eye — separate from day one. Ukrainian first-graders drill this distinction before they ever spell a full sentence.
+
+:::note
+Літвінова's grade-5 textbook (стор. 130) asks a trap question: «Чи можна говорити "голосна літера"?» — can we say "vowel letter"? The **відповідь** (answer) is no. Only a sound can be **«голосний»** (vowel) or **«приголосний»** (consonant); голосні і приголосні бувають лише звуками, не літерами. A letter is just the written symbol — it has no voice of its own.
+:::
+
+Here is where Ukrainian gets interesting. The alphabet has 33 letters, but the language has 38 sounds. <!-- VERIFY: precise claim (33 letters; 38 sounds) --> Why the mismatch? Three reasons, unpacked in later modules. First, the letters Я, Ю, Є, Ї can each stand for **два звуки** (two sounds) in certain positions — for example, **«яблуко»** (apple) is written with five letters but pronounced with six sounds. Second, the soft sign Ь stands for no sound at all; its only job is to soften the consonant before it, as in **«день»** (day). Third, the rest of the detail belongs to module 2. Hold the headline: 33 symbols on the page, 38 sounds in the mouth.
+
+The alphabet itself — the **«абетка»** (also called **«алфавіт»**) — is a fixed sequence of 33 letters, each with its own name. <!-- VERIFY: precise claim (33 letters; 38 sounds) --> **На відміну від** (in contrast to) English, where "knight" hides a silent K and a silent GH, Ukrainian orthography is overwhelmingly phonetic: what you see is, for the most part, what you say aloud. Master the 38 sounds and you can read almost any Ukrainian word — a head start English never gives its beginners.
+
+<!-- INJECT_ACTIVITY: quiz-sounds-vs-letters -->
+
+
+## Голосні звуки
+
+Ukrainian first-graders learn vowels through verse. Большакова's grade-1 textbook (1 клас, стор. 24) opens with this rhyme:
+
+> «Голосні почуєш в пісні, і у темному у лісі, і коли дивуєшся, і коли милуєшся.»
+
+> *Vowels you hear in song, in the dark forest, when you marvel, when you admire.*
+
+A **«голосний»** (vowel) sound is made by voice alone — голосні звуки **вимовляються без** перешкод (vowels are pronounced without obstruction); air flows through the mouth with no blockage from lips, teeth, or tongue. Try to sing [а]: you can hold the note as long as your breath lasts, or shout it across an open field. That sustained, singable quality is what marks a sound as a vowel.
+
+Ukrainian has six vowel **«звук»** (sound) units — [а], [о], [у], [е], [и], [і] — but ten vowel letters: А, О, У, Е, И, І, Я, Ю, Є, Ї. The four extras are called йотовані; in some positions they stand for two sounds — Module 2 covers the mechanic. For now, hold one rule: every Ukrainian word contains at least one vowel — без **голосних** не буває складу (without vowels there is no syllable). Pay attention to [и], which has no exact English match. The minimal pair **«дим»** (smoke) versus **«дім»** (house) trains the contrast: [и] is flat-mouthed and smiling; [і] is the same smile, tongue arched tighter.
+
+:::note
+Захарійчук's grade-1 textbook (1 клас, стор. 13) marks every vowel sound with a single dot — [•] — inside its sound models.
+:::
+
+Read these aloud:
+
+- **«мама»** (mum): мА-мА — two clean [а] beats.
+- **«молоко»** (milk): мО-лО-кО — three [о] sounds; stress lands on the last, but every [о] stays full and round. Ukrainian does not reduce unstressed [о] toward [а] as Russian does.
+- **«Уля»** (Ulya, a girl's name): У-ля — one [у] at the start.
+
+Anna Ohoiko's video series gives one clip per vowel letter — watch one a day, mimic aloud, and your ear locks onto all six.
+
+
+## Приголосні звуки
+
+Большакова's grade-1 textbook (1 клас, стор. 24) follows the vowel verse with this companion rhyme:
+
+> «Приголосні деренчать і тихенько шелестять, голосно свистять і шиплять.»
+> *Consonants rattle and softly rustle, loudly whistle and hiss.*
+
+A **«приголосний»** (consonant) **«звук»** (sound) is made by voice plus noise — or by noise alone. Your lips (**губи**), teeth, or tongue create an obstruction the air must push through. Try the kinesthetic test: attempt to sing a clean [к] or [п]. You cannot — the airflow is blocked. That blockage is what defines a consonant.
+
+Ukrainian has thirty-two consonant sounds drawn from twenty-two **«літера»** (letter) symbols. Why more sounds than letters? Many consonants come in pairs — one **«твердий»** (hard) and one **«м'який»** (soft). Pairs like [т]/[т′] and [н]/[н′] double the inventory. Захарійчук's grade-1 textbook (1 клас, стор. 15) marks hard sounds with [–] and soft sounds with [=]. This hard/soft contrast has no equivalent в **англійській** мові — it is a distinctly Slavic feature. The minimal pair **«стан»** (camp) versus **«стань»** (stand up) hinges on whether the final [н] is hard or soft; the soft sign Ь flips the switch.
+
+Four consonant letters demand special attention. First, Ґ versus Г: Ґ marks a hard plosive [g] as in English *go*, while Г marks a pharyngeal [ɦ] as in *behind* — both belong to Ukrainian, both equal. The letter Ґ returned to the alphabet in 1990 as a small step of decolonization. Second, Щ always equals two sounds, [шч] — **«борщ»** (borscht) is heard as [боршч]. Third, the soft sign — **м'який знак** Ь — carries no sound of its own; its job is to soften the consonant before it. Fourth, Й is always soft (**він завжди** м'який), the only letter in its class.
+
+:::note
+Anna Ohoiko's video series teaches consonants in frequency order — М, Н, С, К, Л, Р first; the rest follow.
+:::
+
+<!-- INJECT_ACTIVITY: match-up-letters-to-sounds -->
+
+<!-- INJECT_ACTIVITY: fill-in-l2-pronunciation-errors -->
+
+<!-- INJECT_ACTIVITY: group-sort-vowels-vs-consonants -->
+
+<!-- INJECT_ACTIVITY: letter-grid-full-alphabet -->
+
+<!-- INJECT_ACTIVITY: watch-and-repeat-ohoiko-videos -->
+
+
+## Привіт!
+
+Your first real conversation in Ukrainian opens with one word — **«Привіт!»** (hi) [приві́т] — anchored in Episode 1 of Anna Ohoiko's ULP series. Use it with friends, family, and peers. The state-exchange cycle follows: «Як справи?» (how are things?) — answered **«Добре.»** (good), **«Чудово.»** (great), or **«Нормально.»** (fine). The reciprocal here is **«А у тебе?»** (and you?) — correct because the elided full form is «у мене все добре».
+
+Listen to the first-day classroom greeting:
+
+> **Вчитель:** Добрий день, діти!
+> *Teacher: Good day, children!*
+> **Учні:** Добрий день!
+> *Pupils: Good day!*
+> **Вчитель:** Як справи?
+> *Teacher: How are things?*
+> **Учні:** Добре!
+> *Pupils: Good!*
+> **Марко:** Привіт, Софіє!
+> *Marko: Hi, Sofiia!*
+> **Софія:** Привіт, Марку! Як справи?
+> *Sofiia: Hi, Marko! How are things?*
+> **Марко:** Чудово.
+> *Marko: Great.*
+
+Every word is built from sounds and letters already taught. The class greets the teacher with formal «Добрий день!»; peers greet each other with informal «Привіт!».
+
+Hold the formal set as indivisible chunks (Wiki Крок 8): **«Добрий день!»** [до́брий де́нь] (good day), **«Доброго ранку!»** [до́брого ра́нку] (good morning), **«Добрий вечір!»** [до́брий ве́чір] (good evening), **«До побачення!»** [до поба́чення] (goodbye), **«На все добре!»** (all the best). Critical pronunciation flag: in «Доброго» the unstressed [о] stays clean — it does not reduce to [а]. The final «-нь» in «день» is soft [н′], softened by ь.
+
+:::note
+Anna Ohoiko's ULP Episode 1 walks through this whole greeting cycle at native pace. Watch once, mimic aloud, then return to the page.
+:::
+
+Now meet two pupils in the corridor:
+
+> **Марко:** Привіт!
+> *Marko: Hi!*
+> **Софія:** Привіт! Як тебе звати?
+> *Sofiia: Hi! What's your name?*
+> **Марко:** Мене звати Марко. А тебе?
+> *Marko: My name is Marko. And you?*
+> **Софія:** Мене звати Софія.
+> *Sofiia: My name is Sofiia.*
+> **Марко:** Радий тебе бачити!
+> *Marko (m.): Glad to see you!*
+> **Софія:** Рада тебе бачити!
+> *Sofiia (f.): Glad to see you!*
+
+The elliptical **«А тебе?»** (= «А тебе як звати?») is the contextually correct reciprocal here — not «А у тебе?», which belongs to the state-exchange cycle above.
+
+Two compact beats close the section. First, gender: a man says **«Радий»** and a woman says **«Рада»** — your first whisper of grammatical gender, treated fully in module 8. Second, read **«привіт»** by sound: П [п] — приголосний; р [р] — приголосний; и [и] — голосний; в [в] — приголосний; і [і] — голосний; т [т] — приголосний. Four приголосних, two голосних. Every sound type you have learned in this module appears in this single word.
+
+<!-- INJECT_ACTIVITY: fill-in-greeting-dialogue -->
+<!-- INJECT_ACTIVITY: quiz-milozvuchnist-and-nagolos -->
+
+
+## Підсумок
+
+You have walked from zero Cyrillic to a real first conversation. Lock the core in with self-check. Answer aloud before you peek.
+
+- **Скільки літер в українській абетці?** → 33.
+- **Скільки звуків в українській мові?** → 38.
+- **Чому кількість літер і звуків не збігається?** → Літери Я, Ю, Є, Ї можуть позначати по два звуки; знак Ь не позначає звуку взагалі — він лише пом'якшує попередній приголосний.
+- **Що таке голосний звук?** → A sound made with voice only, no obstruction in the mouth — you can sing it. Six total: [а], [о], [у], [е], [и], [і].
+- **Що таке приголосний звук?** → A sound made with noise — lips, teeth, or tongue create an obstruction. Thirty-two total.
+- **Чи можна сказати «голосна літера»?** → Ні. Голосними і приголосними бувають ЗВУКИ, а не літери. Letters only represent sounds.
+- **Що означає «Привіт»?** → Hi — informal, for friends, family, peers. Formal swap is **«Добрий день!»**.
+- **Як відповісти на «Як справи?»** → **«Добре.»** / **«Чудово.»** / **«Нормально.»** + **«А у тебе?»**
+
+:::tip
+Miss one? Scroll back to that section, re-read aloud, then return. Stuck on letter-vs-sound? Re-watch Anna Ohoiko's Episode 1.
+:::

--- a/evidence/unit6-phaseA/review-not-produced.txt
+++ b/evidence/unit6-phaseA/review-not-produced.txt
@@ -1,0 +1,1 @@
+No review round was produced. The build failed at Step 5g (activity pre-validation) before review/convergence.

--- a/evidence/unit6-phaseA/state.json
+++ b/evidence/unit6-phaseA/state.json
@@ -1,0 +1,156 @@
+{
+  "mode": "v6",
+  "track": "a1",
+  "slug": "sounds-letters-and-hello",
+  "phases": {
+    "check": {
+      "status": "complete",
+      "ts": "2026-04-25T12:24:52.378526+00:00"
+    },
+    "research": {
+      "status": "complete",
+      "ts": "2026-04-25T12:24:52.454034+00:00"
+    },
+    "skeleton": {
+      "status": "complete",
+      "ts": "2026-04-25T12:27:23.042500+00:00",
+      "plan_hash": "470e9c2d67c68dbbcbcf7ed0c114bb4d849b689406086f607952bcdd66420287"
+    },
+    "pre-verify": {
+      "status": "complete",
+      "ts": "2026-04-25T12:28:43.187762+00:00"
+    },
+    "write": {
+      "status": "complete",
+      "ts": "2026-04-25T12:37:38.639244+00:00",
+      "plan_hash": "470e9c2d67c68dbbcbcf7ed0c114bb4d849b689406086f607952bcdd66420287"
+    },
+    "honesty-annotate": {
+      "status": "complete",
+      "ts": "2026-04-25T12:37:38.668290+00:00",
+      "plan_hash": "470e9c2d67c68dbbcbcf7ed0c114bb4d849b689406086f607952bcdd66420287"
+    },
+    "exercises": {
+      "status": "complete",
+      "ts": "2026-04-25T12:37:38.694214+00:00",
+      "plan_hash": "470e9c2d67c68dbbcbcf7ed0c114bb4d849b689406086f607952bcdd66420287"
+    },
+    "activities": {
+      "status": "complete",
+      "ts": "2026-04-25T13:11:10.860510+00:00"
+    },
+    "repair": {
+      "status": "complete",
+      "ts": "2026-04-25T12:52:04.100282+00:00"
+    },
+    "activity-pre-validate": {
+      "status": "failed",
+      "ts": "2026-04-25T13:11:11.150692+00:00"
+    }
+  },
+  "alignment_manifest": {
+    "composite_hash": "13f43cec23f8d54a58f54892f082a2b74f8a2600291b7656a2ebd4e85e1fa79e",
+    "composed_at": "2026-04-25T13:11:11+00:00",
+    "components": {
+      "plan_hash": "ca304e2e99ceb5a3679ca69cdce16f965647ab14a4c0bafe0a1753ebdf1fedca",
+      "sources_hash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "template_hashes": {
+        "golden_dialogues_a1_a1_directions_transport": "5dde2e14c005c9f50edaf1b71bafd44a2bcd0351ee1c55880c1b48c3322eb0f6",
+        "golden_dialogues_a1_a1_routine_flatmate": "f7f22720f94164a0f3ddb8262f2f3da30a44ef65466ee76b796930644272e381",
+        "golden_dialogues_a1_a1_weather_smalltalk": "d905d1342463631a3eb42c986504d0f222fe8ad46230df6417137ac806056154",
+        "v6_activities": "d0e6bf4f327f48b81a87065d569f11de13e33d7291a14e2c61bfa5df928c44f1",
+        "v6_activities_uk": "518d176bd1ef1ea7bc8c5a322456d3c5aed4d328c1efd457f8d633cfc6a45fc9",
+        "v6_enrich_uk": "c71bffc54698578c7c0371e2aa06fd52cee13456a5af6e7cf06d0cac77605831",
+        "v6_pre_verify": "27b058ac95155acb35cc4942fa94ce85a465c25ef9b747f5fae87a95e54c844f",
+        "v6_review": "9b1cd02def0cbdee0417f2beca39b7180a50cf7975991a430106107e7b64af61",
+        "v6_review_style": "65cca846eca29249cbb51a6c7a054139d3e33d78e7a2f31914d7fb992ae0729b",
+        "v6_review_uk": "1fe49a22d3dbe266a7c007f3ea012d93e5747382f6f534ed617f1e8e3c32b56d",
+        "v6_review_v6_review_actionable": "4a755ba8cb83f231aee4daffc9888823a439bfdd786797dfba352ae550c969cd",
+        "v6_review_v6_review_completeness": "9cbb295303a217dfcf149043eec399ff3e8a16e0eceb177d9e50ad8caa51b4f6",
+        "v6_review_v6_review_decolonization": "7e79e96ef0c02743c97d978509f66b5d280086ca243fd9576bc58b01a1bef072",
+        "v6_review_v6_review_dialogue": "702f9bc7206d40e0de25cc508ceffffa5b83f5c10d7b754444b8ebc3b262fa8c",
+        "v6_review_v6_review_factual": "17a453bf93f7bcec5cbfbfdda2f38045ad19270f79f3ba9c6634a79df3467cc7",
+        "v6_review_v6_review_honesty": "5ea7fcb337d47c32f4ace64d7fdfba1121d9c64618c7847f47187be6d1366756",
+        "v6_review_v6_review_language": "b6821a6fa6066f000ddb5c78fb3346824ab0590d4da166345805622f7e5dd52a",
+        "v6_review_v6_review_naturalness": "c2f0df691d9419cee8deb680af757f5b9345b189a2c91b11d538f0192c7ec07e",
+        "v6_review_v6_review_plan_adherence": "f905078b74f55a81d5511a8ed499a3a2f8a032f88f398eb192050e0a8e1a7aa3",
+        "v6_skeleton": "e3e6d1258047f618e06eeeeea7c488cd003998f9f7842a4cf800efb4c11fee23",
+        "v6_vocab": "afe1725328a5fc592d725020b374bb13b26c99f40494fea0c4c683d6aef7ab0f",
+        "v6_vocab_uk": "b717ab72ab964ed81ab8b8a8bac15239c94bb1cfe5544d534352676cfe0640ea",
+        "v6_write": "790ee6a77abbdd6f889b3a1a6987a02fc67c31b13cc41f86616b5f121fb91319",
+        "v6_write_seminar": "df5885b7c704e1057d1c562645af0d95d102cd85a457ea90170afe48bc2231e5",
+        "v6_write_uk": "e9cd5597d331c249f33b6fcd93abf54df6ff3f29e1d0adef4b6f4c3d4915390f"
+      },
+      "canonical_anchor_hash": "58682461c8584cdb6190c1dae6fc6dbc166280d9ea4c768acbc2452e26a20229",
+      "tokenizer_version": "2026-04-23",
+      "threshold_snapshot": {
+        "level_config": [
+          [
+            "immersion_graduated",
+            true
+          ],
+          [
+            "min_activities",
+            1
+          ],
+          [
+            "min_engagement",
+            0
+          ],
+          [
+            "min_items_per_activity",
+            6
+          ],
+          [
+            "min_types_unique",
+            4
+          ],
+          [
+            "min_vocab",
+            1
+          ],
+          [
+            "priority_types",
+            [
+              "anagram",
+              "classify",
+              "fill-in",
+              "image-to-letter",
+              "match-up",
+              "quiz",
+              "unjumble",
+              "watch-and-repeat"
+            ]
+          ],
+          [
+            "target_words",
+            1200
+          ],
+          [
+            "transliteration_allowed",
+            true
+          ]
+        ],
+        "review_target_score": 8.0
+      },
+      "decisions_subset": [
+        [
+          "dec-001",
+          "active"
+        ],
+        [
+          "dec-003",
+          "active"
+        ],
+        [
+          "dec-004",
+          "active"
+        ],
+        [
+          "dec-007",
+          "active"
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Unit 6 Phase A — Baseline (Claude writer / Codex reviewer)

- Outcome: FAIL
- module_done emitted: no
- MIN dim score: N/A (review not reached)
- Convergence rounds used: 0
- Audit gates: failed before audit: activity-pre-validate
- Build wall clock: 46m20s

## Per-dim scores

Review did not run because the build failed in Step 5g before audit/review.

| Dim | Score | Verdict |
|---|---:|---|
| factual | N/A | not reached |
| language | N/A | not reached |
| decolonization | N/A | not reached |
| completeness | N/A | not reached |
| actionable | N/A | not reached |
| naturalness | N/A | not reached |
| plan_adherence | N/A | not reached |
| honesty | N/A | not reached |
| dialogue | N/A | not reached |

## Notable findings

- Phase 1 + 2 preflight checks passed before the build.
- Build ran with `--writer claude-tools --reviewer codex-tools`.
- Write phase completed on attempt 2 after fixing the required `Підсумок` heading and contract anchor issues.
- Activity generation required retries. The final terminal failure was activity pre-validation: answer words were not grounded in prose or plan vocabulary: `гриб`, `казка`, `лис`.
- No audit status JSON or review round was produced because the build failed before audit/review.

## Prose excerpt (first dialogue + first letter activity)

First dialogue from `produced-module.md`:

> **Вчитель:** Добрий день, діти!
> *Teacher: Good day, children!*
> **Учні:** Добрий день!
> *Pupils: Good day!*
> **Вчитель:** Як справи?
> *Teacher: How are things?*
> **Учні:** Добре!
> *Pupils: Good!*
> **Марко:** Привіт, Софіє!
> *Marko: Hi, Sofiia!*
> **Софія:** Привіт, Марку! Як справи?
> *Sofiia: Hi, Marko! How are things?*
> **Марко:** Чудово.
> *Marko: Great.*

First letter activity from `activities.yaml`:

```yaml
- type: letter-grid
  instruction: Голосні — Vowels
  letters:
  - upper: А
    lower: а
    key_word: ананас
    sound_type: vowel
  - upper: О
    lower: о
    key_word: око
    sound_type: vowel
  - upper: У
    lower: у
    key_word: Україна
    sound_type: vowel
```
