### PR TITLE
fix(activities): pass pre-validate findings to regeneration retry (#1550)

### DIFF
--- a/scripts/build/phases/v6-activities.md
+++ b/scripts/build/phases/v6-activities.md
@@ -92,6 +92,10 @@ These words are the module's vocabulary foundation. ALL exercise items must use 
 
 **Grounding rule:** Every Ukrainian word in your exercises must appear either in the prose content or in this vocabulary list. Do NOT invent new words the learner hasn't seen.
 
+<retry-feedback>
+{UNGROUNDED_FEEDBACK}
+</retry-feedback>
+
 <required-vocab-coverage>
 Every entry in the plan's `vocabulary_hints.required` list MUST appear in at least one activity. Coverage is mandatory at 100%.
 

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -6937,7 +6937,11 @@ def _activity_pre_validation_findings(
     return findings, payload
 
 
-def step_activity_pre_validate(content_path: Path, level: str, slug: str) -> bool:
+def step_activity_pre_validate(
+    content_path: Path,
+    level: str,
+    slug: str,
+) -> tuple[bool, dict[str, object] | None]:
     """Block review when generated activities are ungrounded or miss required vocab."""
     _log(f"\n{'='*60}")
     _log("  Step 5g: ACTIVITY PRE-VALIDATE — Grounding + required vocab")
@@ -6959,13 +6963,43 @@ def step_activity_pre_validate(content_path: Path, level: str, slug: str) -> boo
         for finding in findings:
             _log(f"    - {finding['issue']}")
         _log(f"  → {validation_path}")
-        return False
+        return False, payload or None
     if payload.get("skipped"):
         _log(f"  ⏭️  Activity pre-validation skipped: {payload['reason']}")
     else:
         _log("  ✅ Activity pre-validation passed")
     _log(f"  → {validation_path}")
-    return True
+    return True, payload
+
+
+def _format_activity_prevalidate_feedback(findings: dict[str, object] | None) -> str | None:
+    if not findings:
+        return None
+    ungrounded = [
+        str(u["word"])
+        for u in findings.get("ungrounded_answers", [])
+        if isinstance(u, dict) and u.get("word")
+    ]
+    missing_vocab = [str(w) for w in findings.get("required_vocab_missing", [])]
+    feedback_lines = []
+    if ungrounded:
+        feedback_lines.append(
+            "PRE-VALIDATE FAILED on these activity answers — they are "
+            "NOT in the prose or plan vocabulary, so the learner cannot "
+            "answer them:"
+        )
+        feedback_lines.extend(f"  - {word!r}" for word in ungrounded)
+        feedback_lines.append(
+            "DO NOT use those answers again. Replace with words that "
+            "actually appear in the prose, or drop the activity."
+        )
+    if missing_vocab:
+        feedback_lines.append(
+            "These required vocabulary items have NO activity coverage "
+            "and must each be tested by at least one activity:"
+        )
+        feedback_lines.extend(f"  - {word!r}" for word in missing_vocab)
+    return "\n".join(feedback_lines) if feedback_lines else None
 
 
 def _build_activity_level_context(level: str, module_num: int, plan: dict) -> str:
@@ -7177,6 +7211,7 @@ def _build_pedagogy_patterns(plan: dict, level: str) -> str:
 def step_activities(
     content_path: Path, level: str, module_num: int, slug: str,
     writer: str = "gemini-tools", max_retries: int = 4,
+    ungrounded_feedback: str | None = None,
 ) -> Path | None:
     """Step 5e: Generate structured activity YAML from plan + prose.
 
@@ -7328,6 +7363,7 @@ def step_activities(
         "{FORBIDDEN_ACTIVITY_TYPES}": forbidden_types,
         "{ALLOWED_ACTIVITY_TYPES}": allowed_types,
         "{REQUIRED_TYPES}": required_types,
+        "{UNGROUNDED_FEEDBACK}": ungrounded_feedback or "",
         # Backward compat
         "{ACTIVITY_COUNT_TARGET}": total_target,
         "{PRIORITY_TYPES}": activity_config.get("PRIORITY_TYPES", ""),
@@ -11315,18 +11351,30 @@ def main():
             and "activity-pre-validate" not in completed_phases
         ):
             _phase_start = time.monotonic()
-            prevalidate_ok = step_activity_pre_validate(content_path, args.level, slug)
+            prevalidate_ok, prevalidate_payload = step_activity_pre_validate(
+                content_path,
+                args.level,
+                slug,
+            )
             if not prevalidate_ok and steps in ("all", "activities", "repair"):
                 _log("  🔄 Activity pre-validation failed — regenerating activities once through tier-1 repair")
+                ungrounded_feedback = _format_activity_prevalidate_feedback(
+                    prevalidate_payload,
+                )
                 activity_path = step_activities(
                     content_path, args.level, args.module, slug,
                     writer=args.writer,
+                    ungrounded_feedback=ungrounded_feedback,
                 )
                 if activity_path:
                     _inject_abetka_activities(activity_path, args.level, slug)
                     repair_ok, _needs_regen = step_repair(args.level, args.module, slug)
                     if repair_ok:
-                        prevalidate_ok = step_activity_pre_validate(content_path, args.level, slug)
+                        prevalidate_ok, _prevalidate_payload = step_activity_pre_validate(
+                            content_path,
+                            args.level,
+                            slug,
+                        )
             if not prevalidate_ok:
                 _log("\n❌ Build FAILED at Step 5g (activity pre-validation)")
                 _save_v6_state(args.level, slug, "activity-pre-validate", status="failed")

--- a/tests/build/test_activity_retry_feedback.py
+++ b/tests/build/test_activity_retry_feedback.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+dispatch = importlib.import_module("build.dispatch")
+v6_build = importlib.import_module("build.v6_build")
+
+VALID_ACTIVITY_YAML = yaml.safe_dump(
+    {
+        "version": "1.0",
+        "module": "retry-feedback",
+        "level": "a1",
+        "inline": [{
+            "id": "quiz-intro",
+            "type": "quiz",
+            "instruction": "Оберіть",
+            "items": [{"question": "Це ____.", "options": ["кіт", "пес"], "correct": 0}],
+        }],
+        "workbook": [{
+            "id": "match-words",
+            "type": "match-up",
+            "instruction": "З'єднайте",
+            "pairs": [{"left": word, "right": "known"} for word in ["кіт", "пес"] * 3],
+        }],
+    },
+    allow_unicode=True,
+    sort_keys=False,
+) + "\n# " + ("padding " * 260)
+
+
+def _write_activity_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    level = "a1"
+    slug = "retry-feedback"
+    curriculum_root = tmp_path / "curriculum" / "l2-uk-en"
+    (curriculum_root / level / "orchestration" / slug).mkdir(parents=True)
+    (curriculum_root / "plans" / level).mkdir(parents=True)
+    (tmp_path / "schemas").mkdir()
+    phases_dir = tmp_path / "scripts" / "build" / "phases"
+    phases_dir.mkdir(parents=True)
+    (curriculum_root / "plans" / level / f"{slug}.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "title": "Retry Feedback",
+                "vocabulary_hints": {"required": ["кіт", "пес"]},
+            },
+            allow_unicode=True,
+        ),
+        "utf-8",
+    )
+    content_path = curriculum_root / level / f"{slug}.md"
+    content_path.write_text("## Intro\n\nкіт і пес\n\n<!-- INJECT_ACTIVITY: quiz-intro -->\n", "utf-8")
+    (phases_dir / "v6-activities.md").write_text(
+        "<retry-feedback>\n{UNGROUNDED_FEEDBACK}\n</retry-feedback>\n",
+        "utf-8",
+    )
+    shutil.copy(
+        Path(__file__).resolve().parents[2] / "schemas" / "activity-v2.schema.json",
+        tmp_path / "schemas" / "activity-v2.schema.json",
+    )
+    return curriculum_root, content_path, level, slug
+
+
+def _run_step_activities(tmp_path: Path, monkeypatch, feedback: str | None) -> str:
+    curriculum_root, content_path, level, slug = _write_activity_fixture(tmp_path)
+    captured: dict[str, str] = {}
+
+    def fake_dispatch(prompt: str, *args, **kwargs):
+        captured["prompt"] = prompt
+        return True, VALID_ACTIVITY_YAML
+
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(v6_build, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(v6_build, "PHASES_DIR", tmp_path / "scripts" / "build" / "phases")
+    monkeypatch.setattr(dispatch, "dispatch_agent", fake_dispatch)
+    output_path = v6_build.step_activities(
+        content_path,
+        level,
+        8,
+        slug,
+        writer="gemini-tools",
+        max_retries=0,
+        ungrounded_feedback=feedback,
+    )
+    assert output_path is not None
+    return captured["prompt"]
+
+
+def test_step_activities_omits_prevalidate_failure_on_first_pass(tmp_path, monkeypatch):
+    assert "PRE-VALIDATE FAILED" not in _run_step_activities(tmp_path, monkeypatch, None)
+
+
+def test_step_activities_includes_prevalidate_feedback_on_retry(tmp_path, monkeypatch):
+    assert "DO NOT use invented answers again." in _run_step_activities(
+        tmp_path,
+        monkeypatch,
+        "DO NOT use invented answers again.",
+    )
+
+
+def test_step_activity_pre_validate_returns_persisted_payload(tmp_path, monkeypatch):
+    curriculum_root, content_path, level, slug = _write_activity_fixture(tmp_path)
+    activities_dir = curriculum_root / level / "activities"
+    activities_dir.mkdir()
+    (activities_dir / f"{slug}.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": "1.0",
+                "module": slug,
+                "level": level,
+                "inline": [{
+                    "id": "quiz-intro",
+                    "type": "fill-in",
+                    "instruction": "Вставте слово",
+                    "items": [{"sentence": "Це ____.", "answer": "гриб"}],
+                }],
+                "workbook": [],
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        "utf-8",
+    )
+    monkeypatch.setattr(v6_build, "CURRICULUM_ROOT", curriculum_root)
+
+    ok, payload = v6_build.step_activity_pre_validate(content_path, level, slug)
+
+    validation_path = curriculum_root / level / "orchestration" / slug / "activity-pre-validation.json"
+    assert ok is False
+    assert payload == json.loads(validation_path.read_text("utf-8"))
+    assert payload["ungrounded_answers"][0]["word"] == "гриб"
+    assert payload["required_vocab_missing"] == ["кіт", "пес"]


### PR DESCRIPTION
## Trace
- `step_activity_pre_validate` calls `_activity_pre_validation_findings`, which already builds the structured payload written to `activity-pre-validation.json`: `ungrounded_answers` and `required_vocab_missing`.
- Before this change, `step_activity_pre_validate` returned only `bool`, so the Step 5g retry path in `scripts/build/v6_build.py` dropped that payload.
- The retry then called `step_activities(...)` fresh through tier-1 repair without telling the generator which answers failed grounding.

## Before
When pre-validation rejected invented activity answers, the build retried activity generation once, but the prompt had no failure context. The LLM could regenerate the same kind of ungrounded fill-ins because the rejected words were not surfaced.

## After
- `step_activity_pre_validate` returns `(ok, findings)`, where `findings` matches the persisted JSON payload.
- The Step 5g retry formats ungrounded answers and missing required vocab into a feedback block and passes it to `step_activities(ungrounded_feedback=...)`.
- `step_activities` substitutes `{UNGROUNDED_FEEDBACK}`; first pass is empty, retry includes the failure list.
- `v6-activities.md` now includes a benign `<retry-feedback>` block near the grounding rules.

## Tests
- `.venv/bin/ruff check scripts/build/ tests/build/`
- `.venv/bin/pytest tests/build/ tests/test_v6_build_events.py -v`

Refs #1550.