### PR TITLE
phase-3: lesson schema + prompt-template substitution (#1584)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
       - 'gemini_extensions/**'
       - 'scripts/build/phases/**/*.md'
       - 'scripts/build/contracts/**/*.md'
+      - 'docs/lesson-contract.md'
+      - 'docs/lesson-schema.yaml'
       - 'starlight/**'
   pull_request:
     paths:
@@ -32,6 +34,8 @@ on:
       - 'gemini_extensions/**'
       - 'scripts/build/phases/**/*.md'
       - 'scripts/build/contracts/**/*.md'
+      - 'docs/lesson-contract.md'
+      - 'docs/lesson-schema.yaml'
       - 'starlight/**'
   workflow_dispatch:
 
@@ -206,6 +210,34 @@ jobs:
             exit 1
           fi
           echo "✅ No new root-level scripts"
+
+  lesson-schema-drift:
+    name: Lesson Schema Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install schema dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install PyYAML
+          npm ci
+
+      - name: Regenerate lesson schema and check drift
+        run: |
+          .venv/bin/python scripts/build/generate_lesson_schema.py
+          git diff --exit-code docs/lesson-schema.yaml
 
   test:
     name: Test (pytest)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,3 +117,11 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+
+      - id: lesson-schema-drift
+        name: lesson schema drift gate
+        entry: bash -c '.venv/bin/python scripts/build/generate_lesson_schema.py && git diff --exit-code docs/lesson-schema.yaml'
+        language: system
+        pass_filenames: false
+        files: ^(starlight/src/components/.*\.(tsx|astro)|scripts/pipeline/config_tables\.py|docs/lesson-contract\.md)$
+        stages: [pre-commit]

--- a/docs/best-practices/lesson-schema.md
+++ b/docs/best-practices/lesson-schema.md
@@ -1,0 +1,24 @@
+# Lesson Schema Workflow
+
+`docs/lesson-schema.yaml` is generated. Do not hand-edit it.
+
+When you add or modify a Starlight lesson component:
+
+1. Update the component prop interface and its JSDoc schema tags.
+2. If the component is new, add it to `docs/lesson-contract.md` §3 with its tab and scope.
+3. If the change adds or removes an activity type, update `scripts/pipeline/config_tables.py` and the matrix in `docs/best-practices/activity-pedagogy.md`.
+4. Regenerate the schema:
+
+   ```bash
+   .venv/bin/python scripts/build/generate_lesson_schema.py
+   ```
+
+5. Review the `docs/lesson-schema.yaml` diff and commit the component/config/contract change together with the regenerated schema.
+6. Run the focused checks:
+
+   ```bash
+   .venv/bin/pytest tests/test_lesson_schema.py tests/test_prompt_substitution.py -v
+   .venv/bin/ruff check scripts/build/generate_lesson_schema.py scripts/build/prompt_builder.py tests/test_lesson_schema.py tests/test_prompt_substitution.py
+   ```
+
+The pre-commit hook and CI drift gate regenerate the schema and fail if the committed YAML differs.

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -1,0 +1,2050 @@
+schema_version: "1.0"
+generator_version: "1.0.0"
+generated_from:
+  components_dir: starlight/src/components/{*.tsx, *.astro}
+  components_sha256: 99c48b8fa082924310cdac58f2973805d521b6a734751daf610b0cf75cedfa2f
+  config_tables_sha256: 281df19989601f0312fb944fec0a8fb4ec3cb7275de338d8d158e042705a2c8a
+  lesson_contract_sha256: 89bd2db9731bdc5d811cd6b166d9e7d1e250e08f1e01a9120127593c78223727
+components:
+  Anagram:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: anagram
+    placement: workbook
+    props:
+      required: []
+      optional:
+      - name: items
+        type: AnagramItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      AnagramItem:
+      - name: scrambled
+        type: string
+        description: Scrambled value consumed by this component.
+        ukrainian_text: 'true'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+      - name: hint
+        type: string
+        description: Hint value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  AuthorialIntent:
+    tab: activities
+    level_scope:
+    - c2
+    - bio
+    - lit
+    activity_type: authorial-intent
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: excerpt
+        type: string
+        description: Excerpt value consumed by this component.
+        ukrainian_text: 'true'
+      - name: questions
+        type: string[]
+        description: Array of questions rendered by the component.
+        ukrainian_text: 'true'
+      - name: modelAnswer
+        type: string
+        description: Model answer for review or self-check.
+        ukrainian_text: 'true'
+      optional:
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      title: Приклад
+      excerpt: Приклад
+      questions:
+      - Приклад
+      modelAnswer: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Classify:
+    tab: activities
+    level_scope: []
+    activity_type: classify
+    placement: n/a
+    props:
+      required:
+      - name: categories
+        type: ClassifyCategory[]
+        description: Categories value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      ClassifyCategory:
+      - name: label
+        type: string
+        description: Short label for a UI or source item.
+        ukrainian_text: 'true'
+      - name: symbolHint
+        type: string
+        description: Symbol Hint value consumed by this component.
+        ukrainian_text: 'true'
+      - name: items
+        type: string[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+    example:
+      categories:
+      - <ClassifyCategory>
+      title: Приклад
+      instruction: Приклад
+    deprecated: true
+    deprecation_reason: Deprecated; subsumed by group-sort.
+  Cloze:
+    tab: activities
+    level_scope:
+    - a2
+    - b1
+    - b2
+    - c1
+    - c2
+    - b2-pro
+    - c1-pro
+    activity_type: cloze
+    placement: workbook
+    props:
+      required: []
+      optional:
+      - name: passage
+        type: string
+        description: Passage value consumed by this component.
+        ukrainian_text: 'true'
+      - name: blanks
+        type: ClozeBlank[]
+        description: Blanks value consumed by this component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      ClozeBlank:
+      - name: index
+        type: number
+        description: Index value consumed by this component.
+        ukrainian_text: 'false'
+      - name: options
+        type: string[]
+        description: Answer options shown to the learner.
+        ukrainian_text: 'true'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  ComparativeStudy:
+    tab: activities
+    level_scope:
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: comparative-study
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: content
+        type: string
+        description: Content value consumed by this component.
+        ukrainian_text: 'true'
+      - name: task
+        type: string
+        description: Task value consumed by this component.
+        ukrainian_text: 'true'
+      - name: modelAnswer
+        type: string
+        description: Model answer for review or self-check.
+        ukrainian_text: 'true'
+      - name: itemsToCompare
+        type: string[]
+        description: Items To Compare value consumed by this component.
+        ukrainian_text: 'true'
+      - name: criteria
+        type: string[]
+        description: Criteria value consumed by this component.
+        ukrainian_text: 'true'
+      - name: prompt
+        type: string
+        description: Prompt shown to guide the learner response.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  CountSyllables:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: count-syllables
+    placement: both
+    props:
+      required:
+      - name: items
+        type: CountSyllablesItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: maxCount
+        type: number
+        description: Max Count value consumed by this component.
+        ukrainian_text: 'false'
+    nested_types:
+      CountSyllablesItem:
+      - name: word
+        type: string
+        description: Ukrainian word shown to the learner.
+        ukrainian_text: 'true'
+      - name: correct
+        type: number
+        description: Correct value consumed by this component.
+        ukrainian_text: 'false'
+      - name: translation
+        type: string
+        description: English translation or gloss.
+        ukrainian_text: 'true'
+    example:
+      items:
+      - <CountSyllablesItem>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  CriticalAnalysis:
+    tab: activities
+    level_scope:
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: critical-analysis
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: context
+        type: string
+        description: Context value consumed by this component.
+        ukrainian_text: 'true'
+      - name: question
+        type: string
+        description: Question value consumed by this component.
+        ukrainian_text: 'true'
+      - name: modelAnswer
+        type: string
+        description: Model answer for review or self-check.
+        ukrainian_text: 'true'
+      - name: targetText
+        type: string
+        description: Target Text value consumed by this component.
+        ukrainian_text: 'true'
+      - name: questions
+        type: string[]
+        description: Array of questions rendered by the component.
+        ukrainian_text: 'true'
+      - name: modelAnswers
+        type: string[]
+        description: Model answers for review or self-check.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Debate:
+    tab: activities
+    level_scope:
+    - c2
+    - lit
+    activity_type: debate
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: debateQuestion
+        type: string
+        description: Debate Question value consumed by this component.
+        ukrainian_text: 'true'
+      - name: positions
+        type: Position[]
+        description: Positions value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: historicalContext
+        type: string
+        description: Historical Context value consumed by this component.
+        ukrainian_text: 'true'
+      - name: analysisTasks
+        type: string[]
+        description: Analysis Tasks value consumed by this component.
+        ukrainian_text: 'true'
+      - name: modelAnalysis
+        type: string
+        description: Model Analysis value consumed by this component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      Position:
+      - name: name
+        type: string
+        description: Name value consumed by this component.
+        ukrainian_text: 'true'
+      - name: proponents
+        type: string
+        description: Proponents value consumed by this component.
+        ukrainian_text: 'true'
+      - name: argument
+        type: string
+        description: Argument value consumed by this component.
+        ukrainian_text: 'true'
+      - name: evidence
+        type: string[]
+        description: Evidence value consumed by this component.
+        ukrainian_text: 'true'
+      - name: weaknesses
+        type: string[]
+        description: Weaknesses value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      title: Приклад
+      debateQuestion: Приклад
+      positions:
+      - <Position>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  DialectComparison:
+    tab: activities
+    level_scope:
+    - ruth
+    activity_type: dialect-comparison
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: textA
+        type: string
+        description: Text A value consumed by this component.
+        ukrainian_text: maybe
+      - name: textB
+        type: string
+        description: Text B value consumed by this component.
+        ukrainian_text: maybe
+      - name: features
+        type: Feature[]
+        description: Features value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: labelA
+        type: string
+        description: Label A value consumed by this component.
+        ukrainian_text: 'false'
+      - name: labelB
+        type: string
+        description: Label B value consumed by this component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      Feature:
+      - name: featureName
+        type: string
+        description: Feature Name value consumed by this component.
+        ukrainian_text: 'true'
+      - name: valueA
+        type: string
+        description: Value A value consumed by this component.
+        ukrainian_text: 'true'
+      - name: valueB
+        type: string
+        description: Value B value consumed by this component.
+        ukrainian_text: 'true'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    example:
+      title: Приклад
+      textA: Приклад
+      textB: Приклад
+      features:
+      - <Feature>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  DialogueBox:
+    tab: lesson
+    level_scope: &id001
+    - a1
+    - a2
+    - b1
+    - b2
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: exchanges
+        type: DialogueExchange[]
+        description: Exchanges value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      DialogueExchange:
+      - name: speaker
+        type: string
+        description: Speaker value consumed by this component.
+        ukrainian_text: 'true'
+      - name: text
+        type: string
+        description: Text passage shown to the learner.
+        ukrainian_text: 'true'
+      - name: emoji
+        type: string
+        description: Emoji value consumed by this component.
+        ukrainian_text: 'false'
+    example:
+      exchanges:
+      - <DialogueExchange>
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  DivideWords:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: divide-words
+    placement: both
+    props:
+      required:
+      - name: items
+        type: DivideWordsItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+    nested_types:
+      DivideWordsItem:
+      - name: word
+        type: string
+        description: Ukrainian word shown to the learner.
+        ukrainian_text: 'true'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+      - name: hint
+        type: string
+        description: Hint value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      items:
+      - <DivideWordsItem>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  ErrorCorrection:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - c1
+    - c2
+    - b2-pro
+    - c1-pro
+    activity_type: error-correction
+    placement: both
+    props:
+      required: []
+      optional:
+      - name: items
+        type: ErrorCorrectionItemData[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      ErrorCorrectionItemData:
+      - name: sentence
+        type: string
+        description: Sentence shown to the learner.
+        ukrainian_text: 'true'
+      - name: errorWord
+        type: string | null
+        description: Error Word value consumed by this component.
+        ukrainian_text: 'true'
+      - name: correctForm
+        type: string
+        description: Correct Form value consumed by this component.
+        ukrainian_text: 'true'
+      - name: options
+        type: string[]
+        description: Answer options shown to the learner.
+        ukrainian_text: 'true'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  EssayResponse:
+    tab: activities
+    level_scope:
+    - b1
+    - b2
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: essay-response
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: prompt
+        type: string
+        description: Prompt shown to guide the learner response.
+        ukrainian_text: 'true'
+      optional:
+      - name: modelAnswer
+        type: string
+        description: Model answer for review or self-check.
+        ukrainian_text: 'true'
+      - name: rubric
+        type: string
+        description: Evaluation rubric for the response.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      title: Приклад
+      prompt: Приклад
+    deprecated: false
+    deprecation_reason: null
+  EtymologyTrace:
+    tab: activities
+    level_scope:
+    - c1
+    - c2
+    - oes
+    - ruth
+    activity_type: etymology-trace
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: items
+        type: EtymologyItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      EtymologyItem:
+      - name: word
+        type: string
+        description: Ukrainian word shown to the learner.
+        ukrainian_text: 'true'
+      - name: modern
+        type: string
+        description: Modern value consumed by this component.
+        ukrainian_text: 'true'
+      - name: evolution
+        type: string
+        description: Evolution value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      title: Приклад
+      items:
+      - <EtymologyItem>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  FillIn:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: fill-in
+    placement: both
+    props:
+      required:
+      - name: items
+        type: FillInItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      FillInItem:
+      - name: sentence
+        type: string
+        description: Sentence shown to the learner.
+        ukrainian_text: 'true'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+      - name: options
+        type: string[]
+        description: Answer options shown to the learner.
+        ukrainian_text: 'true'
+    example:
+      items:
+      - <FillInItem>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  FlashcardDeck:
+    tab: vocabulary
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: cards
+        type: FlashcardData[]
+        description: Cards value consumed by this component.
+        ukrainian_text: 'true'
+      optional: []
+    nested_types:
+      FlashcardData:
+      - name: front
+        type: string
+        description: Front value consumed by this component.
+        ukrainian_text: 'true'
+      - name: back
+        type: string
+        description: Back value consumed by this component.
+        ukrainian_text: 'true'
+      - name: subtitle
+        type: string
+        description: Subtitle value consumed by this component.
+        ukrainian_text: 'true'
+      - name: tag
+        type: string
+        description: Tag value consumed by this component.
+        ukrainian_text: 'true'
+      - name: tagColor
+        type: string
+        description: Tag Color value consumed by this component.
+        ukrainian_text: 'false'
+    example:
+      cards:
+      - <FlashcardData>
+    deprecated: false
+    deprecation_reason: null
+  GrammarIdentify:
+    tab: activities
+    level_scope:
+    - b1
+    - b2
+    - c1
+    - c2
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: grammar-identify
+    placement: both
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: items
+        type: GrammarItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      GrammarItem:
+      - name: text
+        type: string
+        description: Text passage shown to the learner.
+        ukrainian_text: 'true'
+      - name: form
+        type: string
+        description: Form value consumed by this component.
+        ukrainian_text: 'true'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+    example:
+      title: Приклад
+      items:
+      - <GrammarItem>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  GroupSort:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - b2-pro
+    activity_type: group-sort
+    placement: both
+    props:
+      required:
+      - name: groups
+        type: '{ [key: string]: string[] }'
+        description: Groups value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      groups: {}
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  HighlightMorphemes:
+    tab: activities
+    level_scope:
+    - b1
+    - b2
+    - c1
+    - c2
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: highlight-morphemes
+    placement: both
+    props:
+      required:
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      optional:
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      children: <p>Приклад вмісту.</p>
+    deprecated: false
+    deprecation_reason: null
+  ImageToLetter:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: image-to-letter
+    placement: inline
+    props:
+      required:
+      - name: items
+        type: ImageToLetterItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      ImageToLetterItem:
+      - name: emoji
+        type: string
+        description: Emoji value consumed by this component.
+        ukrainian_text: 'false'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+      - name: distractors
+        type: string[]
+        description: Distractors value consumed by this component.
+        ukrainian_text: 'false'
+      - name: note
+        type: string
+        description: Note value consumed by this component.
+        ukrainian_text: 'false'
+    example:
+      items:
+      - <ImageToLetterItem>
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  LetterGrid:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: letter-grid
+    placement: inline
+    props:
+      required:
+      - name: letters
+        type: LetterEntry[]
+        description: Letters value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+    nested_types:
+      LetterEntry:
+      - name: upper
+        type: string
+        description: Upper value consumed by this component.
+        ukrainian_text: 'true'
+      - name: lower
+        type: string
+        description: Lower value consumed by this component.
+        ukrainian_text: 'true'
+      - name: emoji
+        type: string
+        description: Emoji value consumed by this component.
+        ukrainian_text: 'false'
+      - name: key_word
+        type: string
+        description: Key word value consumed by this component.
+        ukrainian_text: 'true'
+      - name: note
+        type: string
+        description: Note value consumed by this component.
+        ukrainian_text: 'false'
+      - name: sound_type
+        type: string
+        description: Sound type value consumed by this component.
+        ukrainian_text: 'false'
+    example:
+      letters:
+      - <LetterEntry>
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  MarkTheWords:
+    tab: activities
+    level_scope:
+    - a2
+    - b1
+    - b2
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: mark-the-words
+    placement: both
+    props:
+      required:
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      optional:
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      children: <p>Приклад вмісту.</p>
+    deprecated: false
+    deprecation_reason: null
+  MatchUp:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - c1
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    activity_type: match-up
+    placement: both
+    props:
+      required:
+      - name: pairs
+        type: MatchPair[]
+        description: Pairs value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      MatchPair:
+      - name: left
+        type: string
+        description: Left value consumed by this component.
+        ukrainian_text: 'true'
+      - name: right
+        type: string
+        description: Right value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      pairs:
+      - <MatchPair>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  MythBuster:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: claim
+        type: string
+        description: Claim value consumed by this component.
+        ukrainian_text: 'true'
+      - name: truth
+        type: string
+        description: Truth value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: claimSource
+        type: string
+        description: Claim Source value consumed by this component.
+        ukrainian_text: 'false'
+      - name: truthSource
+        type: string
+        description: Truth Source value consumed by this component.
+        ukrainian_text: 'false'
+    nested_types: {}
+    example:
+      claim: Приклад
+      truth: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Observe:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    activity_type: observe
+    placement: both
+    props:
+      required: []
+      optional:
+      - name: examples
+        type: string[]
+        description: Examples value consumed by this component.
+        ukrainian_text: 'true'
+      - name: prompt
+        type: string
+        description: Prompt shown to guide the learner response.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example: {}
+    deprecated: false
+    deprecation_reason: null
+  OddOneOut:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    activity_type: odd-one-out
+    placement: both
+    props:
+      required:
+      - name: items
+        type: '{ /** * @schemaDescription Words shown to the learner. * @ukrainianText true */ words: string[]; /** * @schemaDescription Correct value consumed by this component. * @ukrainianText false */ correct: number; /** * @schemaDescription Feedback explanation shown after the learner answers. * @ukrainianText true */ explanation: string; }[]'
+        description: items prop.
+        ukrainian_text: 'false'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+    nested_types: {}
+    example:
+      items:
+      - {}
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Order:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    activity_type: order
+    placement: both
+    props:
+      required:
+      - name: items
+        type: string[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      - name: correct_order
+        type: number[]
+        description: Zero-based order indices for the correct sequence.
+        ukrainian_text: 'false'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      items:
+      - Приклад
+      correct_order:
+      - 1
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  PaleographyAnalysis:
+    tab: activities
+    level_scope:
+    - oes
+    - ruth
+    activity_type: paleography-analysis
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: imageUrl
+        type: string
+        description: Image Url value consumed by this component.
+        ukrainian_text: 'false'
+      - name: hotspots
+        type: Hotspot[]
+        description: Hotspots value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: options
+        type: string[]
+        description: Answer options shown to the learner.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      Hotspot:
+      - name: x
+        type: number
+        description: X value consumed by this component.
+        ukrainian_text: 'false'
+      - name: y
+        type: number
+        description: Y value consumed by this component.
+        ukrainian_text: 'false'
+      - name: label
+        type: string
+        description: Short label for a UI or source item.
+        ukrainian_text: 'true'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    example:
+      title: Приклад
+      imageUrl: Приклад
+      hotspots:
+      - <Hotspot>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  PhraseTable:
+    tab: vocabulary
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: groups
+        type: PhraseGroup[]
+        description: Groups value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      PhraseGroup:
+      - name: function
+        type: string
+        description: Function value consumed by this component.
+        ukrainian_text: 'true'
+      - name: phrases
+        type: Phrase[]
+        description: Phrases value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      groups:
+      - <PhraseGroup>
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  PickSyllables:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: pick-syllables
+    placement: both
+    props:
+      required:
+      - name: syllables
+        type: string[]
+        description: Syllables value consumed by this component.
+        ukrainian_text: 'true'
+      - name: correctIndices
+        type: number[]
+        description: Zero-based indices of all correct choices.
+        ukrainian_text: 'false'
+      - name: category
+        type: string
+        description: Category label used by the activity.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    nested_types: {}
+    example:
+      syllables:
+      - Приклад
+      correctIndices:
+      - 1
+      category: Приклад
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Quiz:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: quiz
+    placement: both
+    props:
+      required: []
+      optional:
+      - name: questions
+        type: QuizQuestionItem[]
+        description: Array of questions rendered by the component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      QuizQuestionItem:
+      - name: question
+        type: string
+        description: Question value consumed by this component.
+        ukrainian_text: 'true'
+      - name: options
+        type: '{ text: string; correct: boolean }[]'
+        description: Answer options shown to the learner.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  ReadingActivity:
+    tab: activities
+    level_scope:
+    - b2
+    - c1
+    - c2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - c1-pro
+    - oes
+    - ruth
+    activity_type: reading
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: tasks
+        type: string[]
+        description: Tasks value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: context
+        type: string
+        description: Context value consumed by this component.
+        ukrainian_text: 'true'
+      - name: text
+        type: string
+        description: Text passage shown to the learner.
+        ukrainian_text: 'true'
+      - name: source
+        type: string
+        description: Source value consumed by this component.
+        ukrainian_text: 'false'
+      - name: resource
+        type: '{ /** * @schemaDescription Type value consumed by this component. * @ukrainianText false */ type?: string; /** * @schemaDescription External URL for the embedded or linked resource. * @ukrainianText false */ url?: string; /** * @schemaDescription Display title shown above the component. * @ukrainianText true */ title?: string; }'
+        description: resource prop.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      title: Приклад
+      tasks:
+      - Приклад
+    deprecated: false
+    deprecation_reason: null
+  RuleBox:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      optional:
+      - name: icon
+        type: string
+        description: Icon value consumed by this component.
+        ukrainian_text: 'false'
+    nested_types: {}
+    example:
+      title: Приклад
+      children: <p>Приклад вмісту.</p>
+    deprecated: false
+    deprecation_reason: null
+  Select:
+    tab: activities
+    level_scope: []
+    activity_type: select
+    placement: n/a
+    props:
+      required: []
+      optional:
+      - name: questions
+        type: GeneratorSelectQuestion[]
+        description: Array of questions rendered by the component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      GeneratorSelectQuestion:
+      - name: question
+        type: string
+        description: Question value consumed by this component.
+        ukrainian_text: 'true'
+      - name: options
+        type: '{ text: string; correct: boolean }[]'
+        description: Answer options shown to the learner.
+        ukrainian_text: 'true'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: true
+    deprecation_reason: Deprecated; subsumed by mark-the-words.
+  SourceBox:
+    tab: resources
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'false'
+      - name: quote
+        type: string
+        description: Quoted source excerpt preserved in its source language.
+        ukrainian_text: maybe
+      - name: citation
+        type: string
+        description: Citation metadata preserved verbatim.
+        ukrainian_text: 'false'
+      optional:
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+    nested_types: {}
+    example:
+      title: Приклад
+      quote: Приклад
+      citation: Приклад
+    deprecated: false
+    deprecation_reason: null
+  SourceEvaluation:
+    tab: activities
+    level_scope:
+    - hist
+    - bio
+    - istorio
+    activity_type: source-evaluation
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: sourceText
+        type: string
+        description: Source Text value consumed by this component.
+        ukrainian_text: maybe
+      optional:
+      - name: sourceMetadata
+        type: SourceMetadata
+        description: Source Metadata value consumed by this component.
+        ukrainian_text: 'false'
+      - name: evaluationCriteria
+        type: string[]
+        description: Evaluation Criteria value consumed by this component.
+        ukrainian_text: 'true'
+      - name: guidingQuestions
+        type: string[]
+        description: Guiding Questions value consumed by this component.
+        ukrainian_text: 'true'
+      - name: modelEvaluation
+        type: string
+        description: Model Evaluation value consumed by this component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      SourceMetadata:
+      - name: author
+        type: string
+        description: Author value consumed by this component.
+        ukrainian_text: 'false'
+      - name: date
+        type: string
+        description: Date value consumed by this component.
+        ukrainian_text: 'false'
+      - name: type
+        type: string
+        description: Type value consumed by this component.
+        ukrainian_text: 'false'
+      - name: context
+        type: string
+        description: Context value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      title: Приклад
+      sourceText: Приклад
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Transcription:
+    tab: activities
+    level_scope:
+    - oes
+    - ruth
+    activity_type: transcription
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: original
+        type: string
+        description: Original value consumed by this component.
+        ukrainian_text: maybe
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: hints
+        type: string[]
+        description: Hints value consumed by this component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types: {}
+    example:
+      title: Приклад
+      original: Приклад
+      answer: Приклад
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Translate:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - c1
+    - b2-pro
+    - c1-pro
+    activity_type: translate
+    placement: workbook
+    props:
+      required: []
+      optional:
+      - name: questions
+        type: GeneratorTranslateQuestion[]
+        description: Array of questions rendered by the component.
+        ukrainian_text: 'true'
+      - name: direction
+        type: '''to-uk'' | ''to-en'''
+        description: Direction value consumed by this component.
+        ukrainian_text: 'false'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      GeneratorTranslateQuestion:
+      - name: source
+        type: string
+        description: Source value consumed by this component.
+        ukrainian_text: 'false'
+      - name: options
+        type: '{ text: string; correct: boolean }[]'
+        description: Answer options shown to the learner.
+        ukrainian_text: 'true'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  TranslationCritique:
+    tab: activities
+    level_scope:
+    - b2
+    - c1
+    - c2
+    - lit
+    - b2-pro
+    - c1-pro
+    activity_type: translation-critique
+    placement: workbook
+    props:
+      required:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: original
+        type: string
+        description: Original value consumed by this component.
+        ukrainian_text: maybe
+      - name: translations
+        type: Translation[]
+        description: Translations value consumed by this component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: focusPoints
+        type: string[]
+        description: Focus Points value consumed by this component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      Translation:
+      - name: translator
+        type: string
+        description: Translator value consumed by this component.
+        ukrainian_text: 'true'
+      - name: text
+        type: string
+        description: Text passage shown to the learner.
+        ukrainian_text: 'true'
+      - name: accuracyScore
+        type: number
+        description: Accuracy Score value consumed by this component.
+        ukrainian_text: 'false'
+      - name: notes
+        type: string
+        description: Notes value consumed by this component.
+        ukrainian_text: 'false'
+    example:
+      title: Приклад
+      original: Приклад
+      translations:
+      - <Translation>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  TrueFalse:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    - b2
+    - hist
+    - bio
+    - istorio
+    - lit
+    - b2-pro
+    - oes
+    - ruth
+    activity_type: true-false
+    placement: both
+    props:
+      required:
+      - name: items
+        type: TrueFalseItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      TrueFalseItem:
+      - name: statement
+        type: string
+        description: Statement the learner marks true or false.
+        ukrainian_text: 'true'
+      - name: isTrue
+        type: boolean
+        description: Is True value consumed by this component.
+        ukrainian_text: 'false'
+      - name: explanation
+        type: string
+        description: Feedback explanation shown after the learner answers.
+        ukrainian_text: 'true'
+    example:
+      items:
+      - <TrueFalseItem>
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  Unjumble:
+    tab: activities
+    level_scope:
+    - a1
+    - a2
+    - b1
+    activity_type: unjumble
+    placement: both
+    props:
+      required: []
+      optional:
+      - name: items
+        type: UnjumbleItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      - name: instruction
+        type: string
+        description: Instruction shown to the learner above the activity.
+        ukrainian_text: 'true'
+      - name: children
+        type: jsx
+        description: Nested MDX content rendered inside the component.
+        ukrainian_text: 'false'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      UnjumbleItem:
+      - name: words
+        type: string
+        description: Words shown to the learner.
+        ukrainian_text: 'true'
+      - name: jumbled
+        type: string
+        description: Jumbled value consumed by this component.
+        ukrainian_text: 'true'
+      - name: answer
+        type: string
+        description: Correct answer used for validation and feedback.
+        ukrainian_text: 'true'
+      - name: hint
+        type: string
+        description: Hint value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  VocabCard:
+    tab: vocabulary
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: words
+        type: VocabEntry[]
+        description: Words shown to the learner.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      VocabEntry:
+      - name: word
+        type: string
+        description: Ukrainian word shown to the learner.
+        ukrainian_text: 'true'
+      - name: emoji
+        type: string
+        description: Emoji value consumed by this component.
+        ukrainian_text: 'false'
+      - name: image_url
+        type: string | null
+        description: Image url value consumed by this component.
+        ukrainian_text: 'false'
+      - name: pronunciation_video
+        type: string
+        description: Pronunciation video value consumed by this component.
+        ukrainian_text: 'false'
+      - name: examples
+        type: string[]
+        description: Examples value consumed by this component.
+        ukrainian_text: 'true'
+      - name: category
+        type: string
+        description: Category label used by the activity.
+        ukrainian_text: 'true'
+      - name: question
+        type: string
+        description: Question value consumed by this component.
+        ukrainian_text: 'true'
+    example:
+      words:
+      - <VocabEntry>
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  WatchAndRepeat:
+    tab: activities
+    level_scope:
+    - a1
+    activity_type: watch-and-repeat
+    placement: inline
+    props:
+      required:
+      - name: items
+        type: WatchAndRepeatItem[]
+        description: Array of activity items rendered by the component.
+        ukrainian_text: 'true'
+      optional:
+      - name: title
+        type: string
+        description: Display title shown above the component.
+        ukrainian_text: 'true'
+      - name: isUkrainian
+        type: boolean
+        description: UI language flag for Ukrainian labels and feedback.
+        ukrainian_text: 'false'
+        default: false
+    nested_types:
+      WatchAndRepeatItem:
+      - name: video
+        type: string
+        description: Video value consumed by this component.
+        ukrainian_text: 'false'
+      - name: letter
+        type: string
+        description: Letter value consumed by this component.
+        ukrainian_text: 'false'
+      - name: word
+        type: string
+        description: Ukrainian word shown to the learner.
+        ukrainian_text: 'true'
+      - name: note
+        type: string
+        description: Note value consumed by this component.
+        ukrainian_text: 'false'
+    example:
+      items:
+      - <WatchAndRepeatItem>
+      title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  YouTubeVideo:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required: []
+      optional:
+      - name: url
+        type: string
+        description: External URL for the embedded or linked resource.
+        ukrainian_text: 'false'
+      - name: id
+        type: string
+        description: External media identifier.
+        ukrainian_text: 'false'
+      - name: label
+        type: string
+        description: Short label for a UI or source item.
+        ukrainian_text: 'true'
+    nested_types: {}
+    example: {}
+    deprecated: false
+    deprecation_reason: null

--- a/scripts/build/generate_lesson_schema.py
+++ b/scripts/build/generate_lesson_schema.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Generate docs/lesson-schema.yaml from Starlight component prop interfaces."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+COMPONENTS_DIR = PROJECT_ROOT / "starlight" / "src" / "components"
+OUTPUT_PATH = PROJECT_ROOT / "docs" / "lesson-schema.yaml"
+CONFIG_TABLES_PATH = PROJECT_ROOT / "scripts" / "pipeline" / "config_tables.py"
+LESSON_CONTRACT_PATH = PROJECT_ROOT / "docs" / "lesson-contract.md"
+EXTRACTOR_PATH = PROJECT_ROOT / "scripts" / "build" / "lesson_schema_extractor.mjs"
+GENERATOR_VERSION = "1.0.0"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+from pipeline.config_tables import (
+    ACTIVITY_CONFIGS,
+    INLINE_ONLY_TYPES,
+    WORKBOOK_ONLY_TYPES,
+)
+
+EXCLUSIONS = {
+    "utils",
+    "Footer",
+    "Head",
+    "Header",
+    "PageTitle",
+    "Sidebar",
+    "Home",
+    "LevelLanding",
+    "LiveStatus",
+    "ActivityHelp",
+    "ActivityPlaceholder",
+}
+
+PUBLIC_LEVELS = [
+    "a1",
+    "a2",
+    "b1",
+    "b2",
+    "c1",
+    "c2",
+    "hist",
+    "bio",
+    "istorio",
+    "lit",
+    "b2-pro",
+    "c1-pro",
+    "oes",
+    "ruth",
+]
+
+LEVEL_KEY_MAP = {
+    "a1": "a1",
+    "a2": "a2",
+    "b1-core": "b1",
+    "b2": "b2",
+    "c1-core": "c1",
+    "c2": "c2",
+    "hist": "hist",
+    "bio": "bio",
+    "istorio": "istorio",
+    "lit": "lit",
+    "b2-pro": "b2-pro",
+    "c1-pro": "c1-pro",
+    "oes": "oes",
+    "ruth": "ruth",
+}
+
+TAB_BY_COMPONENT = {
+    "RuleBox": "lesson",
+    "DialogueBox": "lesson",
+    "YouTubeVideo": "lesson",
+    "AuthorialIntent": "activities",
+    "MythBuster": "lesson",
+    "ComparativeStudy": "activities",
+    "CriticalAnalysis": "activities",
+    "DialectComparison": "activities",
+    "EtymologyTrace": "activities",
+    "PaleographyAnalysis": "activities",
+    "SourceEvaluation": "activities",
+    "TranslationCritique": "activities",
+    "FlashcardDeck": "vocabulary",
+    "VocabCard": "vocabulary",
+    "PhraseTable": "vocabulary",
+    "SourceBox": "resources",
+}
+
+ACTIVITY_TYPE_BY_COMPONENT = {
+    "Anagram": "anagram",
+    "AuthorialIntent": "authorial-intent",
+    "Classify": "classify",
+    "Cloze": "cloze",
+    "ComparativeStudy": "comparative-study",
+    "CountSyllables": "count-syllables",
+    "CriticalAnalysis": "critical-analysis",
+    "Debate": "debate",
+    "DialectComparison": "dialect-comparison",
+    "DivideWords": "divide-words",
+    "ErrorCorrection": "error-correction",
+    "EssayResponse": "essay-response",
+    "EtymologyTrace": "etymology-trace",
+    "FillIn": "fill-in",
+    "GrammarIdentify": "grammar-identify",
+    "GroupSort": "group-sort",
+    "HighlightMorphemes": "highlight-morphemes",
+    "ImageToLetter": "image-to-letter",
+    "LetterGrid": "letter-grid",
+    "MarkTheWords": "mark-the-words",
+    "MatchUp": "match-up",
+    "Observe": "observe",
+    "OddOneOut": "odd-one-out",
+    "Order": "order",
+    "PaleographyAnalysis": "paleography-analysis",
+    "PickSyllables": "pick-syllables",
+    "Quiz": "quiz",
+    "ReadingActivity": "reading",
+    "Select": "select",
+    "SourceEvaluation": "source-evaluation",
+    "Transcription": "transcription",
+    "Translate": "translate",
+    "TranslationCritique": "translation-critique",
+    "TrueFalse": "true-false",
+    "Unjumble": "unjumble",
+    "WatchAndRepeat": "watch-and-repeat",
+}
+
+PROPS_INTERFACE_OVERRIDES = {
+    "Observe": "ObserveBlockProps",
+    "ReadingActivity": "ReadingProps",
+}
+
+DEPRECATED = {
+    "Classify": "Deprecated; subsumed by group-sort.",
+    "Select": "Deprecated; subsumed by mark-the-words.",
+}
+
+
+def _split_types(value: str) -> set[str]:
+    return {item.strip() for item in value.split(",") if item.strip()}
+
+
+def discover_components(components_dir: Path) -> list[Path]:
+    files = [*components_dir.rglob("*.tsx"), *components_dir.rglob("*.astro")]
+    return sorted(path for path in files if path.stem not in EXCLUSIONS)
+
+
+def _hash_files(paths: list[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(paths):
+        digest.update(path.relative_to(PROJECT_ROOT).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _hash_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def extract_interfaces(paths: list[Path]) -> dict[str, dict[str, Any]]:
+    result = subprocess.run(
+        ["node", str(EXTRACTOR_PATH), *[str(path) for path in paths]],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {item["component"]: item for item in json.loads(result.stdout)}
+
+
+def choose_props_interface(component: str, interfaces: list[dict[str, Any]]) -> dict[str, Any]:
+    by_name = {interface["name"]: interface for interface in interfaces}
+    names = [
+        PROPS_INTERFACE_OVERRIDES.get(component, ""),
+        f"{component}Props",
+        f"{component}BlockProps",
+    ]
+    for name in names:
+        if name and name in by_name:
+            return by_name[name]
+    props_interfaces = [item for item in interfaces if item["name"].endswith("Props")]
+    if len(props_interfaces) == 1:
+        return props_interfaces[0]
+    raise RuntimeError(f"Could not identify props interface for {component}")
+
+
+def _type_name(type_text: str) -> str | None:
+    cleaned = type_text.replace("Array<", "").replace("[]>", "").replace("[]", "")
+    cleaned = cleaned.strip()
+    if cleaned.startswith("{") or "|" in cleaned or "<" in cleaned:
+        return None
+    return cleaned if cleaned[:1].isupper() else None
+
+
+def _normalize_type(type_text: str) -> str:
+    replacements = {
+        "React.ReactNode": "jsx",
+        "string": "string",
+        "number": "number",
+        "boolean": "boolean",
+    }
+    if type_text in replacements:
+        return replacements[type_text]
+    if type_text == "string[]":
+        return "string[]"
+    if type_text.startswith("Array<"):
+        inner = type_text.removeprefix("Array<").removesuffix(">")
+        return f"{_normalize_type(inner)}[]"
+    return type_text
+
+
+def _prop_record(prop: dict[str, Any]) -> dict[str, Any]:
+    tags = prop.get("tags", {})
+    record = {
+        "name": prop["name"],
+        "type": _normalize_type(prop["type"]),
+        "description": tags.get("schemaDescription") or f"{prop['name']} prop.",
+        "ukrainian_text": tags.get("ukrainianText", "false"),
+    }
+    if prop["optional"]:
+        default = _default_for(prop["name"])
+        if default is not None:
+            record["default"] = default
+    if "deprecated" in tags:
+        record["deprecated"] = True
+        record["deprecation_reason"] = tags["deprecated"]
+    return record
+
+
+def _default_for(name: str) -> Any:
+    if name == "isUkrainian":
+        return False
+    if name in {"children", "instruction", "title", "prompt", "explanation"}:
+        return None
+    return None
+
+
+def _nested_types(
+    main_interface: dict[str, Any],
+    interfaces: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    by_name = {item["name"]: item for item in interfaces}
+    names = set()
+    for prop in main_interface["props"]:
+        type_name = _type_name(prop["type"])
+        if type_name and type_name in by_name:
+            names.add(type_name)
+    nested = {}
+    for name in sorted(names):
+        nested[name] = [_prop_record(prop) for prop in by_name[name]["props"]]
+    return nested
+
+
+def _levels_for_activity(activity_type: str) -> list[str]:
+    levels: set[str] = set()
+    for key, config in ACTIVITY_CONFIGS.items():
+        public_key = LEVEL_KEY_MAP.get(key)
+        if public_key is None:
+            continue
+        allowed = (
+            _split_types(config.get("INLINE_ALLOWED_TYPES", ""))
+            | _split_types(config.get("WORKBOOK_ALLOWED_TYPES", ""))
+            | _split_types(config.get("ALLOWED_ACTIVITY_TYPES", ""))
+        )
+        if activity_type in allowed:
+            levels.add(public_key)
+    return [level for level in PUBLIC_LEVELS if level in levels]
+
+
+def _placement_for_activity(activity_type: str) -> str:
+    if activity_type in INLINE_ONLY_TYPES:
+        return "inline"
+    if activity_type in WORKBOOK_ONLY_TYPES:
+        return "workbook"
+    inline = False
+    workbook = False
+    for config in ACTIVITY_CONFIGS.values():
+        inline = inline or activity_type in _split_types(config.get("INLINE_ALLOWED_TYPES", ""))
+        workbook = workbook or activity_type in _split_types(config.get("WORKBOOK_ALLOWED_TYPES", ""))
+    if inline and workbook:
+        return "both"
+    if inline:
+        return "inline"
+    if workbook:
+        return "workbook"
+    return "n/a"
+
+
+def _example_value(type_text: str, prop_name: str) -> Any:
+    if type_text == "jsx":
+        return "<p>Приклад вмісту.</p>"
+    if type_text == "string":
+        return "Приклад"
+    if type_text == "number":
+        return 1
+    if type_text == "boolean":
+        return False
+    if type_text.endswith("[]"):
+        return [_example_value(type_text[:-2], prop_name)]
+    if type_text.startswith("{"):
+        return {}
+    return f"<{type_text}>"
+
+
+def _example(required: list[dict[str, Any]], optional: list[dict[str, Any]]) -> dict[str, Any]:
+    sample_props = required + [prop for prop in optional if prop["name"] in {"instruction", "title"}]
+    return {prop["name"]: _example_value(prop["type"], prop["name"]) for prop in sample_props}
+
+
+def build_schema(components_dir: Path) -> dict[str, Any]:
+    paths = discover_components(components_dir)
+    extracted = extract_interfaces(paths)
+    components: dict[str, Any] = {}
+    for path in paths:
+        component = path.stem
+        item = extracted[component]
+        main_interface = choose_props_interface(component, item["interfaces"])
+        required = [_prop_record(prop) for prop in main_interface["props"] if not prop["optional"]]
+        optional = [_prop_record(prop) for prop in main_interface["props"] if prop["optional"]]
+        activity_type = ACTIVITY_TYPE_BY_COMPONENT.get(component)
+        deprecated = component in DEPRECATED
+        components[component] = {
+            "tab": TAB_BY_COMPONENT.get(component, "activities" if activity_type else "lesson"),
+            "level_scope": _levels_for_activity(activity_type) if activity_type else PUBLIC_LEVELS,
+            "activity_type": activity_type,
+            "placement": _placement_for_activity(activity_type) if activity_type else "n/a",
+            "props": {
+                "required": required,
+                "optional": optional,
+            },
+            "nested_types": _nested_types(main_interface, item["interfaces"]),
+            "example": _example(required, optional),
+            "deprecated": deprecated,
+            "deprecation_reason": DEPRECATED.get(component) if deprecated else None,
+        }
+    return {
+        "schema_version": "1.0",
+        "generator_version": GENERATOR_VERSION,
+        "generated_from": {
+            "components_dir": "starlight/src/components/{*.tsx, *.astro}",
+            "components_sha256": _hash_files(paths),
+            "config_tables_sha256": _hash_file(CONFIG_TABLES_PATH),
+            "lesson_contract_sha256": _hash_file(LESSON_CONTRACT_PATH),
+        },
+        "components": dict(sorted(components.items())),
+    }
+
+
+def write_schema(schema: dict[str, Any], output: Path) -> None:
+    text = yaml.safe_dump(schema, sort_keys=False, allow_unicode=True, width=1000)
+    text = text.replace("schema_version: '1.0'\n", 'schema_version: "1.0"\n', 1)
+    text = text.replace("generator_version: 1.0.0\n", 'generator_version: "1.0.0"\n', 1)
+    output.write_text(text, encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    epilog = textwrap.dedent(
+        """\
+        Examples:
+          .venv/bin/python scripts/build/generate_lesson_schema.py
+          .venv/bin/python scripts/build/generate_lesson_schema.py --output /tmp/lesson-schema.yaml
+
+        Outputs:
+          Writes deterministic lesson component schema YAML to docs/lesson-schema.yaml by default.
+
+        Exit codes:
+          0  schema generated successfully
+          1  generation failed
+          2  invalid CLI usage
+
+        Related docs:
+          docs/lesson-schema-design.md
+          docs/lesson-contract.md
+          docs/best-practices/activity-pedagogy.md
+        """
+    )
+    parser = argparse.ArgumentParser(
+        description="Generate the lesson component schema YAML from Starlight prop interfaces.",
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--components-dir",
+        type=Path,
+        default=COMPONENTS_DIR,
+        help="Directory containing Starlight .tsx/.astro component files (default: starlight/src/components).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=OUTPUT_PATH,
+        help="YAML output path (default: docs/lesson-schema.yaml).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        schema = build_schema(args.components_dir)
+        write_schema(schema, args.output)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/lesson_schema_extractor.mjs
+++ b/scripts/build/lesson_schema_extractor.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import ts from "typescript";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+function tags(node) {
+  const out = {};
+  for (const tag of ts.getJSDocTags(node)) {
+    const name = tag.tagName.escapedText.toString();
+    out[name] = (tag.comment ?? "").toString().trim();
+  }
+  return out;
+}
+function cleanType(typeNode, source) {
+  if (!typeNode) return "unknown";
+  return typeNode.getText(source).replace(/\s+/g, " ").trim();
+}
+function readInterface(node, source) {
+  return {
+    name: node.name.escapedText.toString(),
+    tags: tags(node),
+    props: node.members
+      .filter((member) => ts.isPropertySignature(member))
+      .map((member) => ({
+        name: member.name.getText(source),
+        optional: Boolean(member.questionToken),
+        type: cleanType(member.type, source),
+        tags: tags(member),
+      })),
+  };
+}
+function extract(filePath) {
+  const text = readFileSync(filePath, "utf8");
+  const source = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const interfaces = [];
+  function visit(node) {
+    if (ts.isInterfaceDeclaration(node)) interfaces.push(readInterface(node, source));
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  return { path: filePath, component: basename(filePath).replace(/\.(tsx|astro)$/, ""), interfaces };
+}
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error("usage: lesson_schema_extractor.mjs <component.tsx> [...]");
+  process.exit(2);
+}
+process.stdout.write(JSON.stringify(files.map(extract), null, 2));

--- a/scripts/build/prompt_builder.py
+++ b/scripts/build/prompt_builder.py
@@ -1,0 +1,113 @@
+"""Render Phase 0 document placeholders inside prompt templates."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NORTH_STAR_PATH = PROJECT_ROOT / "docs" / "north-star.md"
+LESSON_CONTRACT_PATH = PROJECT_ROOT / "docs" / "lesson-contract.md"
+
+PLACEHOLDERS = {
+    "{NORTH_STAR}": NORTH_STAR_PATH,
+    "{LESSON_CONTRACT}": LESSON_CONTRACT_PATH,
+}
+
+DOWNSTREAM_TOKENS = frozenset(
+    {
+        "ACTIVITY_COUNT_TARGET",
+        "ALLOWED_ACTIVITY_TYPES",
+        "CANONICAL_ANCHORS",
+        "CANONICAL_ANCHORS_REVIEWER",
+        "CONTRACT_YAML",
+        "CORRECTION_SECTION",
+        "DIALOGUE_SITUATIONS",
+        "EXACT_SECTION_TITLES",
+        "FORBIDDEN_ACTIVITY_TYPES",
+        "GENERATED_CONTENT",
+        "GOLDEN_DIALOGUE_ANCHORS",
+        "GOLDEN_FRAGMENT",
+        "IMMERSION_RULE",
+        "IMMERSION_TARGET_SHORT",
+        "INJECTION_MARKERS",
+        "INLINE_ALLOWED_TYPES",
+        "INLINE_MAX",
+        "INLINE_MIN",
+        "INLINE_PRIORITY_TYPES",
+        "ITEMS_MIN",
+        "ITEM_MINIMUMS_TABLE",
+        "KNOWLEDGE_PACKET",
+        "LETTER_MODULE_ACTIVE",
+        "LEVEL",
+        "LEVEL_CONSTRAINTS",
+        "LEVEL_CONTEXT",
+        "MIN_TYPES_UNIQUE",
+        "MODULE_CONTENT",
+        "MODULE_NUM",
+        "MODULE_SLUG",
+        "PEDAGOGICAL_CONSTRAINTS",
+        "PEDAGOGY_PATTERNS",
+        "PHASE",
+        "PLAN_ACTIVITY_HINTS",
+        "PLAN_CONTENT",
+        "PLAN_VOCABULARY",
+        "PRE_VERIFIED_FACTS",
+        "PRIORITY_TYPES",
+        "PRONUNCIATION_VIDEOS",
+        "REQUIRED_TYPES",
+        "SECTION_QUERIES",
+        "SECTION_WIKI_EXCERPTS",
+        "SEMINAR_TYPE_REFERENCE",
+        "SKELETON_SECTION",
+        "SUMMARY_HEADING",
+        "TOOL_INSTRUCTIONS",
+        "TOPIC_TITLE",
+        "TOTAL_TARGET",
+        "UNGROUNDED_FEEDBACK",
+        "VOCABULARY_CHECKLIST",
+        "VOCABULARY_HINTS",
+        "VOCAB_COUNT_TARGET",
+        "WORD_CEILING",
+        "WORD_COUNT",
+        "WORD_OVERSHOOT",
+        "WORD_TARGET",
+        "WORKBOOK_ALLOWED_TYPES",
+        "WORKBOOK_MAX",
+        "WORKBOOK_MIN",
+        "WORKBOOK_PRIORITY_TYPES",
+        "WRITER_MODEL",
+    }
+)
+
+TOKEN_RE = re.compile(r"\{([A-Z][A-Z0-9_]*)\}")
+
+
+def render_prompt(template_path: Path) -> str:
+    """Render Phase 0 placeholders in a prompt template."""
+    text = template_path.read_text(encoding="utf-8")
+
+    for match in TOKEN_RE.finditer(text):
+        token = match.group(1)
+        if f"{{{token}}}" not in PLACEHOLDERS and token not in DOWNSTREAM_TOKENS:
+            raise RuntimeError(
+                f"Unknown placeholder-shaped token {{{token}}} in {template_path}. "
+                "If this is a new Phase-0 placeholder, register it in PLACEHOLDERS. "
+                "If it's a downstream .format() variable, register it in DOWNSTREAM_TOKENS. "
+                "If it's a literal brace string, escape it."
+            )
+
+    for placeholder, source in PLACEHOLDERS.items():
+        if not source.exists():
+            raise FileNotFoundError(f"Phase 0 source missing for {placeholder}: {source}")
+        source_text = source.read_text(encoding="utf-8")
+        for literal_placeholder in PLACEHOLDERS:
+            source_text = source_text.replace(literal_placeholder, literal_placeholder.strip("{}"))
+        text = text.replace(placeholder, source_text)
+
+    for placeholder in PLACEHOLDERS:
+        if placeholder in text:
+            raise RuntimeError(
+                f"Unfilled placeholder remains after substitution: {placeholder} in {template_path}"
+            )
+    return text

--- a/starlight/src/components/Anagram.tsx
+++ b/starlight/src/components/Anagram.tsx
@@ -17,9 +17,25 @@ function getLetterColor(letter: string, index: number): string {
 }
 
 interface AnagramQuestionProps {
+  /**
+   * @schemaDescription Scrambled value consumed by this component.
+   * @ukrainianText true
+   */
   scrambled: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Hint value consumed by this component.
+   * @ukrainianText true
+   */
   hint?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -200,15 +216,43 @@ export function AnagramQuestion({ scrambled, answer, hint, isUkrainian }: Anagra
 }
 
 interface AnagramItem {
+  /**
+   * @schemaDescription Scrambled value consumed by this component.
+   * @ukrainianText true
+   */
   scrambled: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Hint value consumed by this component.
+   * @ukrainianText true
+   */
   hint?: string;
 }
 
 interface AnagramProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items?: AnagramItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/AuthorialIntent.tsx
+++ b/starlight/src/components/AuthorialIntent.tsx
@@ -4,10 +4,30 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface AuthorialIntentProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Excerpt value consumed by this component.
+   * @ukrainianText true
+   */
   excerpt: string;
+  /**
+   * @schemaDescription Array of questions rendered by the component.
+   * @ukrainianText true
+   */
   questions: string[];
+  /**
+   * @schemaDescription Model answer for review or self-check.
+   * @ukrainianText true
+   */
   modelAnswer: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/Classify.tsx
+++ b/starlight/src/components/Classify.tsx
@@ -4,15 +4,46 @@ import directStyles from './Direct.module.css';
 import { shuffle } from './utils';
 
 interface ClassifyCategory {
+  /**
+   * @schemaDescription Short label for a UI or source item.
+   * @ukrainianText true
+   */
   label: string;
+  /**
+   * @schemaDescription Symbol Hint value consumed by this component.
+   * @ukrainianText true
+   */
   symbolHint?: string;
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: string[];
 }
 
+/**
+ * @deprecated Deprecated; subsumed by group-sort.
+ */
 interface ClassifyProps {
+  /**
+   * @schemaDescription Categories value consumed by this component.
+   * @ukrainianText true
+   */
   categories: ClassifyCategory[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/Cloze.tsx
+++ b/starlight/src/components/Cloze.tsx
@@ -4,14 +4,38 @@ import ActivityHelp from './ActivityHelp';
 import { shuffle } from './utils';
 
 interface ClozeBlank {
+  /**
+   * @schemaDescription Index value consumed by this component.
+   * @ukrainianText false
+   */
   index: number;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: string[];
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
 }
 
 interface ClozePassageProps {
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text: string;  // Text with [___:N] markers
+  /**
+   * @schemaDescription Blanks value consumed by this component.
+   * @ukrainianText true
+   */
   blanks: ClozeBlank[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -157,10 +181,30 @@ export function ClozePassage({ text, blanks, isUkrainian }: ClozePassageProps) {
 }
 
 interface ClozeProps {
+  /**
+   * @schemaDescription Passage value consumed by this component.
+   * @ukrainianText true
+   */
   passage?: string;  // MDX generator sends passage with embedded options
+  /**
+   * @schemaDescription Blanks value consumed by this component.
+   * @ukrainianText true
+   */
   blanks?: ClozeBlank[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/ComparativeStudy.tsx
+++ b/starlight/src/components/ComparativeStudy.tsx
@@ -4,14 +4,46 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface ComparativeStudyProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Content value consumed by this component.
+   * @ukrainianText true
+   */
   content?: string; // The comparison table or text (legacy)
+  /**
+   * @schemaDescription Task value consumed by this component.
+   * @ukrainianText true
+   */
   task?: string;
+  /**
+   * @schemaDescription Model answer for review or self-check.
+   * @ukrainianText true
+   */
   modelAnswer?: string;
   // Seminar mode fields
+  /**
+   * @schemaDescription Items To Compare value consumed by this component.
+   * @ukrainianText true
+   */
   itemsToCompare?: string[];
+  /**
+   * @schemaDescription Criteria value consumed by this component.
+   * @ukrainianText true
+   */
   criteria?: string[];
+  /**
+   * @schemaDescription Prompt shown to guide the learner response.
+   * @ukrainianText true
+   */
   prompt?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/CountSyllables.tsx
+++ b/starlight/src/components/CountSyllables.tsx
@@ -2,14 +2,38 @@ import React, { useState } from 'react';
 import styles from './Activities.module.css';
 
 interface CountSyllablesItem {
+  /**
+   * @schemaDescription Ukrainian word shown to the learner.
+   * @ukrainianText true
+   */
   word: string;
+  /**
+   * @schemaDescription Correct value consumed by this component.
+   * @ukrainianText false
+   */
   correct: number;
+  /**
+   * @schemaDescription English translation or gloss.
+   * @ukrainianText true
+   */
   translation?: string;
 }
 
 interface CountSyllablesProps {
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: CountSyllablesItem[];
+  /**
+   * @schemaDescription Max Count value consumed by this component.
+   * @ukrainianText false
+   */
   maxCount?: number;
 }
 

--- a/starlight/src/components/CriticalAnalysis.tsx
+++ b/starlight/src/components/CriticalAnalysis.tsx
@@ -4,14 +4,46 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface CriticalAnalysisProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Context value consumed by this component.
+   * @ukrainianText true
+   */
   context?: string;
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
   question?: string;
+  /**
+   * @schemaDescription Model answer for review or self-check.
+   * @ukrainianText true
+   */
   modelAnswer?: string;
   // Seminar mode fields
+  /**
+   * @schemaDescription Target Text value consumed by this component.
+   * @ukrainianText true
+   */
   targetText?: string;
+  /**
+   * @schemaDescription Array of questions rendered by the component.
+   * @ukrainianText true
+   */
   questions?: string[];
+  /**
+   * @schemaDescription Model answers for review or self-check.
+   * @ukrainianText true
+   */
   modelAnswers?: string[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/Debate.tsx
+++ b/starlight/src/components/Debate.tsx
@@ -4,21 +4,73 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface Position {
+  /**
+   * @schemaDescription Name value consumed by this component.
+   * @ukrainianText true
+   */
   name: string;
+  /**
+   * @schemaDescription Proponents value consumed by this component.
+   * @ukrainianText true
+   */
   proponents: string;
+  /**
+   * @schemaDescription Argument value consumed by this component.
+   * @ukrainianText true
+   */
   argument: string;
+  /**
+   * @schemaDescription Evidence value consumed by this component.
+   * @ukrainianText true
+   */
   evidence?: string[];
+  /**
+   * @schemaDescription Weaknesses value consumed by this component.
+   * @ukrainianText true
+   */
   weaknesses?: string[];
 }
 
 interface DebateProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Debate Question value consumed by this component.
+   * @ukrainianText true
+   */
   debateQuestion: string;
+  /**
+   * @schemaDescription Historical Context value consumed by this component.
+   * @ukrainianText true
+   */
   historicalContext?: string;
+  /**
+   * @schemaDescription Positions value consumed by this component.
+   * @ukrainianText true
+   */
   positions: Position[];
+  /**
+   * @schemaDescription Analysis Tasks value consumed by this component.
+   * @ukrainianText true
+   */
   analysisTasks?: string[];
+  /**
+   * @schemaDescription Model Analysis value consumed by this component.
+   * @ukrainianText true
+   */
   modelAnalysis?: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/DialectComparison.tsx
+++ b/starlight/src/components/DialectComparison.tsx
@@ -4,20 +4,68 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface Feature {
+  /**
+   * @schemaDescription Feature Name value consumed by this component.
+   * @ukrainianText true
+   */
   featureName: string;
+  /**
+   * @schemaDescription Value A value consumed by this component.
+   * @ukrainianText true
+   */
   valueA: string;
+  /**
+   * @schemaDescription Value B value consumed by this component.
+   * @ukrainianText true
+   */
   valueB: string;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation: string;
 }
 
 interface DialectComparisonProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Text A value consumed by this component.
+   * @ukrainianText maybe
+   */
   textA: string;
+  /**
+   * @schemaDescription Text B value consumed by this component.
+   * @ukrainianText maybe
+   */
   textB: string;
+  /**
+   * @schemaDescription Label A value consumed by this component.
+   * @ukrainianText false
+   */
   labelA?: string;
+  /**
+   * @schemaDescription Label B value consumed by this component.
+   * @ukrainianText false
+   */
   labelB?: string;
+  /**
+   * @schemaDescription Features value consumed by this component.
+   * @ukrainianText true
+   */
   features: Feature[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/DialogueBox.tsx
+++ b/starlight/src/components/DialogueBox.tsx
@@ -2,14 +2,38 @@ import React from 'react';
 import directStyles from './Direct.module.css';
 
 interface DialogueExchange {
+  /**
+   * @schemaDescription Speaker value consumed by this component.
+   * @ukrainianText true
+   */
   speaker: string;
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text: string;
+  /**
+   * @schemaDescription Emoji value consumed by this component.
+   * @ukrainianText false
+   */
   emoji?: string;
 }
 
 interface DialogueBoxProps {
+  /**
+   * @schemaDescription Exchanges value consumed by this component.
+   * @ukrainianText true
+   */
   exchanges: DialogueExchange[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/DivideWords.tsx
+++ b/starlight/src/components/DivideWords.tsx
@@ -2,13 +2,33 @@ import React, { useState } from 'react';
 import styles from './Activities.module.css';
 
 interface DivideWordsItem {
+  /**
+   * @schemaDescription Ukrainian word shown to the learner.
+   * @ukrainianText true
+   */
   word: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string; // correct division, e.g. "мо-ло-ко"
+  /**
+   * @schemaDescription Hint value consumed by this component.
+   * @ukrainianText true
+   */
   hint?: string;
 }
 
 interface DivideWordsProps {
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: DivideWordsItem[];
 }
 

--- a/starlight/src/components/ErrorCorrection.tsx
+++ b/starlight/src/components/ErrorCorrection.tsx
@@ -4,11 +4,35 @@ import ActivityHelp from './ActivityHelp';
 import { shuffle } from './utils';
 
 interface ErrorCorrectionItemProps {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
   sentence: string;
+  /**
+   * @schemaDescription Error Word value consumed by this component.
+   * @ukrainianText true
+   */
   errorWord: string | null;  // null = no error
+  /**
+   * @schemaDescription Correct Form value consumed by this component.
+   * @ukrainianText true
+   */
   correctForm: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: string[];
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -225,17 +249,53 @@ export function ErrorCorrectionItem({
 }
 
 interface ErrorCorrectionItemData {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
   sentence: string;
+  /**
+   * @schemaDescription Error Word value consumed by this component.
+   * @ukrainianText true
+   */
   errorWord: string | null;
+  /**
+   * @schemaDescription Correct Form value consumed by this component.
+   * @ukrainianText true
+   */
   correctForm: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: string[];
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation: string;
 }
 
 interface ErrorCorrectionProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items?: ErrorCorrectionItemData[];
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/EssayResponse.tsx
+++ b/starlight/src/components/EssayResponse.tsx
@@ -4,10 +4,30 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface EssayResponseProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Prompt shown to guide the learner response.
+   * @ukrainianText true
+   */
   prompt: string;
+  /**
+   * @schemaDescription Model answer for review or self-check.
+   * @ukrainianText true
+   */
   modelAnswer?: string;
+  /**
+   * @schemaDescription Evaluation rubric for the response.
+   * @ukrainianText true
+   */
   rubric?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/EtymologyTrace.tsx
+++ b/starlight/src/components/EtymologyTrace.tsx
@@ -4,15 +4,43 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface EtymologyItem {
+  /**
+   * @schemaDescription Ukrainian word shown to the learner.
+   * @ukrainianText true
+   */
   word: string;
+  /**
+   * @schemaDescription Modern value consumed by this component.
+   * @ukrainianText true
+   */
   modern: string;
+  /**
+   * @schemaDescription Evolution value consumed by this component.
+   * @ukrainianText true
+   */
   evolution: string;
 }
 
 interface EtymologyTraceProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: EtymologyItem[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/FillIn.tsx
+++ b/starlight/src/components/FillIn.tsx
@@ -16,8 +16,20 @@ function getChipColor(text: string, index: number): string {
 }
 
 interface FillInQuestionProps {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
   sentence: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options?: string[];
 }
 
@@ -133,14 +145,38 @@ export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestio
 }
 
 interface FillInItem {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
   sentence: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options?: string[];
 }
 
 interface FillInProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: FillInItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/FlashcardDeck.tsx
+++ b/starlight/src/components/FlashcardDeck.tsx
@@ -1,14 +1,38 @@
 import React, { useState } from 'react';
 
 interface FlashcardData {
+  /**
+   * @schemaDescription Front value consumed by this component.
+   * @ukrainianText true
+   */
   front: string;
+  /**
+   * @schemaDescription Back value consumed by this component.
+   * @ukrainianText true
+   */
   back: string;
+  /**
+   * @schemaDescription Subtitle value consumed by this component.
+   * @ukrainianText true
+   */
   subtitle?: string;
+  /**
+   * @schemaDescription Tag value consumed by this component.
+   * @ukrainianText true
+   */
   tag?: string;
+  /**
+   * @schemaDescription Tag Color value consumed by this component.
+   * @ukrainianText false
+   */
   tagColor?: string;
 }
 
 interface FlashcardDeckProps {
+  /**
+   * @schemaDescription Cards value consumed by this component.
+   * @ukrainianText true
+   */
   cards: FlashcardData[];
 }
 

--- a/starlight/src/components/GrammarIdentify.tsx
+++ b/starlight/src/components/GrammarIdentify.tsx
@@ -4,15 +4,43 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface GrammarItem {
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text: string;
+  /**
+   * @schemaDescription Form value consumed by this component.
+   * @ukrainianText true
+   */
   form: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
 }
 
 interface GrammarIdentifyProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: GrammarItem[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/GroupSort.tsx
+++ b/starlight/src/components/GroupSort.tsx
@@ -16,8 +16,20 @@ function getWordColor(word: string, index: number): string {
 }
 
 interface GroupSortProps {
+  /**
+   * @schemaDescription Groups value consumed by this component.
+   * @ukrainianText true
+   */
   groups: { [key: string]: string[] };
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/HighlightMorphemes.tsx
+++ b/starlight/src/components/HighlightMorphemes.tsx
@@ -3,15 +3,43 @@ import styles from './Activities.module.css';
 import ActivityHelp from './ActivityHelp';
 
 interface MorphemeItem {
+  /**
+   * @schemaDescription Ukrainian word shown to the learner.
+   * @ukrainianText true
+   */
   word: string;        // The full word: "прийшов"
+  /**
+   * @schemaDescription Morpheme value consumed by this component.
+   * @ukrainianText true
+   */
   morpheme: string;    // The part to highlight: "при"
+  /**
+   * @schemaDescription Type value consumed by this component.
+   * @ukrainianText false
+   */
   type?: 'prefix' | 'root' | 'suffix';  // Optional classification
 }
 
 interface HighlightMorphemesActivityProps {
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text: string;
+  /**
+   * @schemaDescription Morphemes value consumed by this component.
+   * @ukrainianText true
+   */
   morphemes: MorphemeItem[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -217,7 +245,15 @@ export function HighlightMorphemesActivity({
 }
 
 interface HighlightMorphemesProps {
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/ImageToLetter.tsx
+++ b/starlight/src/components/ImageToLetter.tsx
@@ -4,15 +4,43 @@ import directStyles from './Direct.module.css';
 import { shuffle } from './utils';
 
 interface ImageToLetterItem {
+  /**
+   * @schemaDescription Emoji value consumed by this component.
+   * @ukrainianText false
+   */
   emoji: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Distractors value consumed by this component.
+   * @ukrainianText false
+   */
   distractors: string[];
+  /**
+   * @schemaDescription Note value consumed by this component.
+   * @ukrainianText false
+   */
   note?: string;
 }
 
 interface ImageToLetterProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: ImageToLetterItem[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/LetterGrid.tsx
+++ b/starlight/src/components/LetterGrid.tsx
@@ -2,16 +2,48 @@ import React from 'react';
 import directStyles from './Direct.module.css';
 
 interface LetterEntry {
+  /**
+   * @schemaDescription Upper value consumed by this component.
+   * @ukrainianText true
+   */
   upper: string;
+  /**
+   * @schemaDescription Lower value consumed by this component.
+   * @ukrainianText true
+   */
   lower: string;
+  /**
+   * @schemaDescription Emoji value consumed by this component.
+   * @ukrainianText false
+   */
   emoji: string;
+  /**
+   * @schemaDescription Key word value consumed by this component.
+   * @ukrainianText true
+   */
   key_word: string;
+  /**
+   * @schemaDescription Note value consumed by this component.
+   * @ukrainianText false
+   */
   note?: string;
+  /**
+   * @schemaDescription Sound type value consumed by this component.
+   * @ukrainianText false
+   */
   sound_type?: string;
 }
 
 interface LetterGridProps {
+  /**
+   * @schemaDescription Letters value consumed by this component.
+   * @ukrainianText true
+   */
   letters: LetterEntry[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
 }
 

--- a/starlight/src/components/MarkTheWords.tsx
+++ b/starlight/src/components/MarkTheWords.tsx
@@ -3,9 +3,25 @@ import styles from './Activities.module.css';
 import ActivityHelp from './ActivityHelp';
 
 interface MarkTheWordsActivityProps {
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text: string;
+  /**
+   * @schemaDescription Correct Words value consumed by this component.
+   * @ukrainianText true
+   */
   correctWords: string[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -154,7 +170,15 @@ export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrain
 }
 
 interface MarkTheWordsProps {
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/MatchUp.tsx
+++ b/starlight/src/components/MatchUp.tsx
@@ -4,13 +4,33 @@ import { parseMarkdown, shuffle } from './utils';
 import ActivityHelp from './ActivityHelp';
 
 interface MatchPair {
+  /**
+   * @schemaDescription Left value consumed by this component.
+   * @ukrainianText true
+   */
   left: string;
+  /**
+   * @schemaDescription Right value consumed by this component.
+   * @ukrainianText true
+   */
   right: string;
 }
 
 interface MatchUpProps {
+  /**
+   * @schemaDescription Pairs value consumed by this component.
+   * @ukrainianText true
+   */
   pairs: MatchPair[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/MythBuster.tsx
+++ b/starlight/src/components/MythBuster.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
 
 interface MythBusterProps {
+  /**
+   * @schemaDescription Claim value consumed by this component.
+   * @ukrainianText true
+   */
   claim: string;
+  /**
+   * @schemaDescription Claim Source value consumed by this component.
+   * @ukrainianText false
+   */
   claimSource?: string;
+  /**
+   * @schemaDescription Truth value consumed by this component.
+   * @ukrainianText true
+   */
   truth: string;
+  /**
+   * @schemaDescription Truth Source value consumed by this component.
+   * @ukrainianText false
+   */
   truthSource?: string;
 }
 

--- a/starlight/src/components/Observe.tsx
+++ b/starlight/src/components/Observe.tsx
@@ -3,8 +3,20 @@ import styles from './Activities.module.css';
 import ActivityHelp from './ActivityHelp';
 
 interface ObserveProps {
+  /**
+   * @schemaDescription Examples value consumed by this component.
+   * @ukrainianText true
+   */
   examples: string[];
+  /**
+   * @schemaDescription Prompt shown to guide the learner response.
+   * @ukrainianText true
+   */
   prompt?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
 }
 
@@ -40,9 +52,25 @@ export function ObserveActivity({ examples, prompt = "What pattern do you notice
 }
 
 interface ObserveBlockProps {
+  /**
+   * @schemaDescription Examples value consumed by this component.
+   * @ukrainianText true
+   */
   examples?: string[];
+  /**
+   * @schemaDescription Prompt shown to guide the learner response.
+   * @ukrainianText true
+   */
   prompt?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/OddOneOut.tsx
+++ b/starlight/src/components/OddOneOut.tsx
@@ -2,10 +2,26 @@ import React, { useState } from 'react';
 import styles from './Activities.module.css';
 
 interface OddOneOutProps {
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
   items: {
+    /**
+     * @schemaDescription Words shown to the learner.
+     * @ukrainianText true
+     */
     words: string[];
+    /**
+     * @schemaDescription Correct value consumed by this component.
+     * @ukrainianText false
+     */
     correct: number;
+    /**
+     * @schemaDescription Feedback explanation shown after the learner answers.
+     * @ukrainianText true
+     */
     explanation: string;
   }[];
 }

--- a/starlight/src/components/Order.tsx
+++ b/starlight/src/components/Order.tsx
@@ -4,9 +4,25 @@ import ActivityHelp from './ActivityHelp';
 import { shuffleNotCorrect } from './utils';
 
 interface OrderProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: string[];
+  /**
+   * @schemaDescription Zero-based order indices for the correct sequence.
+   * @ukrainianText false
+   */
   correct_order: number[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/PaleographyAnalysis.tsx
+++ b/starlight/src/components/PaleographyAnalysis.tsx
@@ -4,18 +4,58 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface Hotspot {
+  /**
+   * @schemaDescription X value consumed by this component.
+   * @ukrainianText false
+   */
   x: number;
+  /**
+   * @schemaDescription Y value consumed by this component.
+   * @ukrainianText false
+   */
   y: number;
+  /**
+   * @schemaDescription Short label for a UI or source item.
+   * @ukrainianText true
+   */
   label: string;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation: string;
 }
 
 interface PaleographyAnalysisProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Image Url value consumed by this component.
+   * @ukrainianText false
+   */
   imageUrl: string;
+  /**
+   * @schemaDescription Hotspots value consumed by this component.
+   * @ukrainianText true
+   */
   hotspots: Hotspot[];
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText false
+   */
   options?: string[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/PhraseTable.tsx
+++ b/starlight/src/components/PhraseTable.tsx
@@ -2,19 +2,51 @@ import React from 'react';
 import directStyles from './Direct.module.css';
 
 interface Phrase {
+  /**
+   * @schemaDescription Phrase value consumed by this component.
+   * @ukrainianText true
+   */
   phrase: string;
+  /**
+   * @schemaDescription Context value consumed by this component.
+   * @ukrainianText true
+   */
   context?: string;
+  /**
+   * @schemaDescription Emoji value consumed by this component.
+   * @ukrainianText false
+   */
   emoji?: string;
 }
 
 interface PhraseGroup {
+  /**
+   * @schemaDescription Function value consumed by this component.
+   * @ukrainianText true
+   */
   function: string;
+  /**
+   * @schemaDescription Phrases value consumed by this component.
+   * @ukrainianText true
+   */
   phrases: Phrase[];
 }
 
 interface PhraseTableProps {
+  /**
+   * @schemaDescription Groups value consumed by this component.
+   * @ukrainianText true
+   */
   groups: PhraseGroup[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/PickSyllables.tsx
+++ b/starlight/src/components/PickSyllables.tsx
@@ -2,10 +2,30 @@ import React, { useState } from 'react';
 import styles from './Activities.module.css';
 
 interface PickSyllablesProps {
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Syllables value consumed by this component.
+   * @ukrainianText true
+   */
   syllables: string[];
+  /**
+   * @schemaDescription Zero-based indices of all correct choices.
+   * @ukrainianText false
+   */
   correctIndices: number[];
+  /**
+   * @schemaDescription Category label used by the activity.
+   * @ukrainianText true
+   */
   category: string; // e.g. "закриті" or "відкриті"
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
 }
 

--- a/starlight/src/components/Quiz.tsx
+++ b/starlight/src/components/Quiz.tsx
@@ -4,10 +4,30 @@ import { parseMarkdown, shuffle } from './utils';
 import ActivityHelp from './ActivityHelp';
 
 interface QuizQuestionProps {
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
   question: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: string[];
+  /**
+   * @schemaDescription Zero-based index of the correct option.
+   * @ukrainianText false
+   */
   correctIndex: number;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -71,14 +91,38 @@ export function QuizQuestion({ question, options, correctIndex, explanation, isU
 }
 
 interface QuizQuestionItem {
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
   question: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: Array<{ text: string; correct: boolean }>;
 }
 
 interface QuizProps {
+  /**
+   * @schemaDescription Array of questions rendered by the component.
+   * @ukrainianText true
+   */
   questions?: QuizQuestionItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/ReadingActivity.tsx
+++ b/starlight/src/components/ReadingActivity.tsx
@@ -4,16 +4,52 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface ReadingProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Context value consumed by this component.
+   * @ukrainianText true
+   */
   context?: string;
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text?: string;  // Seminar: inline primary source text
+  /**
+   * @schemaDescription Source value consumed by this component.
+   * @ukrainianText false
+   */
   source?: string;  // Seminar: attribution (e.g., 'Тарас Шевченко (1845)')
   resource?: {
+    /**
+     * @schemaDescription Type value consumed by this component.
+     * @ukrainianText false
+     */
     type?: string;
+    /**
+     * @schemaDescription External URL for the embedded or linked resource.
+     * @ukrainianText false
+     */
     url?: string;
+    /**
+     * @schemaDescription Display title shown above the component.
+     * @ukrainianText true
+     */
     title?: string;
   };
+  /**
+   * @schemaDescription Tasks value consumed by this component.
+   * @ukrainianText true
+   */
   tasks: string[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/RuleBox.tsx
+++ b/starlight/src/components/RuleBox.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
 interface RuleBoxProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Icon value consumed by this component.
+   * @ukrainianText false
+   */
   icon?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children: React.ReactNode;
 }
 

--- a/starlight/src/components/Select.tsx
+++ b/starlight/src/components/Select.tsx
@@ -4,10 +4,30 @@ import ActivityHelp from './ActivityHelp';
 import { shuffle } from './utils';
 
 interface SelectQuestionProps {
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
   question: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: string[];
+  /**
+   * @schemaDescription Correct answer strings for multi-select validation.
+   * @ukrainianText true
+   */
   correctAnswers: string[];
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -125,15 +145,46 @@ export function SelectQuestion({ question, options, correctAnswers, explanation,
 
 // Generator format question
 interface GeneratorSelectQuestion {
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
   question: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: Array<{ text: string; correct: boolean }>;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
 }
 
+/**
+ * @deprecated Deprecated; subsumed by mark-the-words.
+ */
 interface SelectProps {
+  /**
+   * @schemaDescription Array of questions rendered by the component.
+   * @ukrainianText true
+   */
   questions?: GeneratorSelectQuestion[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/SourceBox.tsx
+++ b/starlight/src/components/SourceBox.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
 
 interface SourceBoxProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText false
+   */
   title: string;
+  /**
+   * @schemaDescription Quoted source excerpt preserved in its source language.
+   * @ukrainianText maybe
+   */
   quote: string;
+  /**
+   * @schemaDescription Citation metadata preserved verbatim.
+   * @ukrainianText false
+   */
   citation: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
 }
 

--- a/starlight/src/components/SourceEvaluation.tsx
+++ b/starlight/src/components/SourceEvaluation.tsx
@@ -4,20 +4,68 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface SourceMetadata {
+  /**
+   * @schemaDescription Author value consumed by this component.
+   * @ukrainianText false
+   */
   author?: string;
+  /**
+   * @schemaDescription Date value consumed by this component.
+   * @ukrainianText false
+   */
   date?: string;
+  /**
+   * @schemaDescription Type value consumed by this component.
+   * @ukrainianText false
+   */
   type?: string;
+  /**
+   * @schemaDescription Context value consumed by this component.
+   * @ukrainianText true
+   */
   context?: string;
 }
 
 interface SourceEvaluationProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Source Text value consumed by this component.
+   * @ukrainianText maybe
+   */
   sourceText: string;
+  /**
+   * @schemaDescription Source Metadata value consumed by this component.
+   * @ukrainianText false
+   */
   sourceMetadata?: SourceMetadata;
+  /**
+   * @schemaDescription Evaluation Criteria value consumed by this component.
+   * @ukrainianText true
+   */
   evaluationCriteria?: string[];
+  /**
+   * @schemaDescription Guiding Questions value consumed by this component.
+   * @ukrainianText true
+   */
   guidingQuestions?: string[];
+  /**
+   * @schemaDescription Model Evaluation value consumed by this component.
+   * @ukrainianText true
+   */
   modelEvaluation?: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/Transcription.tsx
+++ b/starlight/src/components/Transcription.tsx
@@ -23,11 +23,35 @@ const HISTORICAL_CHARS = [
 ];
 
 interface TranscriptionProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Original value consumed by this component.
+   * @ukrainianText maybe
+   */
   original: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Hints value consumed by this component.
+   * @ukrainianText true
+   */
   hints?: string[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/Translate.tsx
+++ b/starlight/src/components/Translate.tsx
@@ -4,11 +4,35 @@ import ActivityHelp from './ActivityHelp';
 import { shuffle } from './utils';
 
 interface TranslateItemProps {
+  /**
+   * @schemaDescription Source value consumed by this component.
+   * @ukrainianText false
+   */
   source: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Alternatives value consumed by this component.
+   * @ukrainianText true
+   */
   alternatives?: string[];
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText false
+   */
   options?: string[];  // For selection-based (no free typing)
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -119,16 +143,48 @@ export function TranslateItem({
 
 // Generator format question
 interface GeneratorTranslateQuestion {
+  /**
+   * @schemaDescription Source value consumed by this component.
+   * @ukrainianText false
+   */
   source: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
   options: Array<{ text: string; correct: boolean }>;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
 }
 
 interface TranslateProps {
+  /**
+   * @schemaDescription Array of questions rendered by the component.
+   * @ukrainianText true
+   */
   questions?: GeneratorTranslateQuestion[];
+  /**
+   * @schemaDescription Direction value consumed by this component.
+   * @ukrainianText false
+   */
   direction?: 'to-uk' | 'to-en';
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/TranslationCritique.tsx
+++ b/starlight/src/components/TranslationCritique.tsx
@@ -4,18 +4,58 @@ import ActivityHelp from './ActivityHelp';
 import { parseMarkdown } from './utils';
 
 interface Translation {
+  /**
+   * @schemaDescription Translator value consumed by this component.
+   * @ukrainianText true
+   */
   translator: string;
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
   text: string;
+  /**
+   * @schemaDescription Accuracy Score value consumed by this component.
+   * @ukrainianText false
+   */
   accuracyScore: number;
+  /**
+   * @schemaDescription Notes value consumed by this component.
+   * @ukrainianText false
+   */
   notes: string;
 }
 
 interface TranslationCritiqueProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title: string;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Original value consumed by this component.
+   * @ukrainianText maybe
+   */
   original: string;
+  /**
+   * @schemaDescription Translations value consumed by this component.
+   * @ukrainianText true
+   */
   translations: Translation[];
+  /**
+   * @schemaDescription Focus Points value consumed by this component.
+   * @ukrainianText true
+   */
   focusPoints?: string[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/TrueFalse.tsx
+++ b/starlight/src/components/TrueFalse.tsx
@@ -4,9 +4,25 @@ import { parseMarkdown } from './utils';
 import ActivityHelp from './ActivityHelp';
 
 interface TrueFalseQuestionProps {
+  /**
+   * @schemaDescription Statement the learner marks true or false.
+   * @ukrainianText true
+   */
   statement: string;
+  /**
+   * @schemaDescription Is True value consumed by this component.
+   * @ukrainianText false
+   */
   isTrue: boolean;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -68,14 +84,38 @@ export function TrueFalseQuestion({ statement, isTrue, explanation, isUkrainian 
 }
 
 interface TrueFalseItem {
+  /**
+   * @schemaDescription Statement the learner marks true or false.
+   * @ukrainianText true
+   */
   statement: string;
+  /**
+   * @schemaDescription Is True value consumed by this component.
+   * @ukrainianText false
+   */
   isTrue: boolean;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
   explanation?: string;
 }
 
 interface TrueFalseProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: TrueFalseItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/Unjumble.tsx
+++ b/starlight/src/components/Unjumble.tsx
@@ -16,9 +16,25 @@ function getWordColor(word: string, index: number): string {
 }
 
 interface UnjumbleQuestionProps {
+  /**
+   * @schemaDescription Words shown to the learner.
+   * @ukrainianText true
+   */
   words: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Hint value consumed by this component.
+   * @ukrainianText true
+   */
   hint?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 
@@ -229,16 +245,48 @@ export function UnjumbleQuestion({ words, answer, hint, isUkrainian }: UnjumbleQ
 }
 
 interface UnjumbleItem {
+  /**
+   * @schemaDescription Words shown to the learner.
+   * @ukrainianText true
+   */
   words?: string;
+  /**
+   * @schemaDescription Jumbled value consumed by this component.
+   * @ukrainianText true
+   */
   jumbled?: string;  // Alternative field name from MDX generator
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
   answer: string;
+  /**
+   * @schemaDescription Hint value consumed by this component.
+   * @ukrainianText true
+   */
   hint?: string;
 }
 
 interface UnjumbleProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items?: UnjumbleItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
   instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
   children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/VocabCard.tsx
+++ b/starlight/src/components/VocabCard.tsx
@@ -2,18 +2,58 @@ import React, { useState } from 'react';
 import directStyles from './Direct.module.css';
 
 interface VocabEntry {
+  /**
+   * @schemaDescription Ukrainian word shown to the learner.
+   * @ukrainianText true
+   */
   word: string;
+  /**
+   * @schemaDescription Emoji value consumed by this component.
+   * @ukrainianText false
+   */
   emoji?: string;
+  /**
+   * @schemaDescription Image url value consumed by this component.
+   * @ukrainianText false
+   */
   image_url?: string | null;
+  /**
+   * @schemaDescription Pronunciation video value consumed by this component.
+   * @ukrainianText false
+   */
   pronunciation_video?: string;
+  /**
+   * @schemaDescription Examples value consumed by this component.
+   * @ukrainianText true
+   */
   examples: string[];
+  /**
+   * @schemaDescription Category label used by the activity.
+   * @ukrainianText true
+   */
   category?: string;
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
   question?: string;
 }
 
 interface VocabCardProps {
+  /**
+   * @schemaDescription Words shown to the learner.
+   * @ukrainianText true
+   */
   words: VocabEntry[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/WatchAndRepeat.tsx
+++ b/starlight/src/components/WatchAndRepeat.tsx
@@ -3,15 +3,43 @@ import styles from './Activities.module.css';
 import directStyles from './Direct.module.css';
 
 interface WatchAndRepeatItem {
+  /**
+   * @schemaDescription Video value consumed by this component.
+   * @ukrainianText false
+   */
   video: string;
+  /**
+   * @schemaDescription Letter value consumed by this component.
+   * @ukrainianText false
+   */
   letter?: string;
+  /**
+   * @schemaDescription Ukrainian word shown to the learner.
+   * @ukrainianText true
+   */
   word?: string;
+  /**
+   * @schemaDescription Note value consumed by this component.
+   * @ukrainianText false
+   */
   note?: string;
 }
 
 interface WatchAndRepeatProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
   items: WatchAndRepeatItem[];
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
   title?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
   isUkrainian?: boolean;
 }
 

--- a/starlight/src/components/YouTubeVideo.tsx
+++ b/starlight/src/components/YouTubeVideo.tsx
@@ -1,8 +1,20 @@
 import React, { useState } from 'react';
 
 interface YouTubeVideoProps {
+  /**
+   * @schemaDescription External URL for the embedded or linked resource.
+   * @ukrainianText false
+   */
   url?: string;
+  /**
+   * @schemaDescription External media identifier.
+   * @ukrainianText false
+   */
   id?: string;
+  /**
+   * @schemaDescription Short label for a UI or source item.
+   * @ukrainianText true
+   */
   label?: string;
 }
 

--- a/tests/test_lesson_schema.py
+++ b/tests/test_lesson_schema.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import yaml
+
+from scripts.build.generate_lesson_schema import (
+    ACTIVITY_TYPE_BY_COMPONENT,
+    LEVEL_KEY_MAP,
+    PUBLIC_LEVELS,
+    _split_types,
+)
+from scripts.pipeline.config_tables import ACTIVITY_CONFIGS
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = PROJECT_ROOT / "docs" / "lesson-schema.yaml"
+COMPONENTS_DIR = PROJECT_ROOT / "starlight" / "src" / "components"
+PEDAGOGY_PATH = PROJECT_ROOT / "docs" / "best-practices" / "activity-pedagogy.md"
+
+EXCLUSIONS = {
+    "utils",
+    "Footer",
+    "Head",
+    "Header",
+    "PageTitle",
+    "Sidebar",
+    "Home",
+    "LevelLanding",
+    "LiveStatus",
+    "ActivityHelp",
+    "ActivityPlaceholder",
+}
+
+
+def _schema() -> dict:
+    return yaml.safe_load(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_every_lesson_scope_component_has_schema() -> None:
+    schema = _schema()
+    declared = set(schema["components"].keys())
+    actual = set()
+    for ext in ("*.tsx", "*.astro"):
+        for path in COMPONENTS_DIR.rglob(ext):
+            if path.stem not in EXCLUSIONS:
+                actual.add(path.stem)
+    assert declared == actual, (
+        f"missing from schema: {actual - declared}; orphan in schema: {declared - actual}"
+    )
+
+
+def test_schema_loadable() -> None:
+    yaml.safe_load(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_activity_components_match_pedagogy_matrix() -> None:
+    assert "## 3. Full Allowlist Matrix" in PEDAGOGY_PATH.read_text(encoding="utf-8")
+    schema = _schema()
+    expected = _expected_level_scopes()
+
+    for component, activity_type in ACTIVITY_TYPE_BY_COMPONENT.items():
+        if component not in schema["components"]:
+            continue
+        assert schema["components"][component]["level_scope"] == expected.get(activity_type, [])
+
+
+def _expected_level_scopes() -> dict[str, list[str]]:
+    scopes: dict[str, set[str]] = {}
+    for config_key, config in ACTIVITY_CONFIGS.items():
+        public_key = LEVEL_KEY_MAP.get(config_key)
+        if public_key is None:
+            continue
+        allowed = (
+            _split_types(config.get("INLINE_ALLOWED_TYPES", ""))
+            | _split_types(config.get("WORKBOOK_ALLOWED_TYPES", ""))
+            | _split_types(config.get("ALLOWED_ACTIVITY_TYPES", ""))
+        )
+        for activity_type in allowed:
+            scopes.setdefault(activity_type, set()).add(public_key)
+    return {
+        activity_type: [level for level in PUBLIC_LEVELS if level in levels]
+        for activity_type, levels in scopes.items()
+    }

--- a/tests/test_prompt_substitution.py
+++ b/tests/test_prompt_substitution.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.build.prompt_builder import PLACEHOLDERS, render_prompt
+
+PROMPTS_DIR = Path(__file__).resolve().parents[1] / "scripts" / "build" / "phases"
+
+
+@pytest.mark.parametrize("template", sorted(PROMPTS_DIR.glob("v6-*.md")))
+def test_no_unfilled_placeholders(template: Path) -> None:
+    rendered = render_prompt(template)
+    for placeholder in PLACEHOLDERS:
+        assert placeholder not in rendered, (
+            f"Template {template.name} still has {placeholder} after render"
+        )
+
+
+def test_north_star_loaded() -> None:
+    rendered = render_prompt(PROMPTS_DIR / "v6-write.md")
+    assert "WHO — the learner" in rendered
+    assert "B1 onwards is uniformly 100 % Ukrainian" in rendered
+
+
+def test_lesson_contract_loaded() -> None:
+    rendered = render_prompt(PROMPTS_DIR / "v6-write.md")
+    assert "Tab 3 — Вправи" in rendered
+    assert "Deprecated; subsumed by `mark-the-words`" in rendered


### PR DESCRIPTION
## Summary
- Adds generated `docs/lesson-schema.yaml` from Starlight prop interfaces, config tables, and the lesson contract.
- Adds Phase 0 prompt-template substitution via `scripts/build/prompt_builder.py` with typo guarding for unknown placeholder-shaped tokens.
- Wires schema drift protection through pre-commit and CI, with contributor workflow docs and focused tests.

## Files changed
- Starlight component prop interfaces: JSDoc schema metadata across lesson-scope components.
- `scripts/build/generate_lesson_schema.py` and `scripts/build/lesson_schema_extractor.mjs`.
- `scripts/build/prompt_builder.py`.
- `docs/lesson-schema.yaml` and `docs/best-practices/lesson-schema.md`.
- `tests/test_lesson_schema.py` and `tests/test_prompt_substitution.py`.
- `.pre-commit-config.yaml` and `.github/workflows/ci.yml`.

## Verification checklist
- [x] `.venv/bin/pytest tests/test_lesson_schema.py tests/test_prompt_substitution.py -v`
- [x] `.venv/bin/ruff check scripts/build/generate_lesson_schema.py scripts/build/prompt_builder.py tests/test_lesson_schema.py tests/test_prompt_substitution.py`
- [x] `.venv/bin/python scripts/build/generate_lesson_schema.py --help`
- [x] `.venv/bin/python scripts/build/generate_lesson_schema.py`
- [x] `.venv/bin/python scripts/build/generate_lesson_schema.py && git diff --exit-code docs/lesson-schema.yaml`
- [x] substitution smoke for `scripts/build/phases/v6-write.md`
- [x] `git fetch origin main && git log --oneline HEAD..origin/main` empty after rebase

## Sub-issues filed
- None.

## CI status note
- CI is pending at PR creation. Local affected tests and drift checks pass after rebasing onto latest `origin/main`.

Closes #1584.