### PR TITLE
feat(thresholds): per-level per-dim LLM QG floors (#1586)

### DIFF
--- a/docs/decisions/2026-04-26-llm-qg-per-dim-thresholds.md
+++ b/docs/decisions/2026-04-26-llm-qg-per-dim-thresholds.md
@@ -1,0 +1,205 @@
+# 2026-04-26 — LLM QG per-level per-dimension thresholds
+
+> **Status**: DRAFT — pending 3-agent review (`ab discuss architecture --with codex,gemini`)
+> **Issue**: #1586 (`reboot-blocker`)
+> **Authority chain**: `docs/north-star.md` SHIPPABLE §7 → `docs/best-practices/strict-reviewer-persona.md` → this decision → `scripts/common/thresholds.py`
+> **Supersedes**: nothing. Companions: ADR-007 (no LLM rewrite), `module-contract.md` §8 (per-dim reviewer scope)
+> **Expiry**: revisit when Phase 4 exemplar lands (ACs in #1577) — empirical floor calibration may shift
+
+## Binding constraint (North Star §7, paraphrased)
+
+> LLM QG passes only when **Pedagogical, Naturalness, Decolonization, Engagement, Tone** each ≥ the per-level floor in `LEVEL_THRESHOLDS`. **No weighted average. One failing dim fails the module.**
+
+This document specifies the schema + aggregator semantics that satisfy this constraint and supplies the per-level per-dim default floors.
+
+## What's broken today
+
+`scripts/common/thresholds.py` provides:
+
+| Constant | Scope | Value |
+|---|---|---|
+| `REVIEW_PASS_FLOOR` | global, level-agnostic | 8.0 |
+| `REVIEW_REJECT_FLOOR` | global, level-agnostic | 6.0 |
+| `LevelThresholds.naturalness_min` | per-level, single dim | A1/A2/B1=9.0, B2+=8.0 |
+
+The Phase 4 LLM QG contract requires per-level floors for **all 5 dims**, not just naturalness. The current schema can't express that without ad-hoc parallel constants. `scripts/build/v6_build.py:1854-1858` already enforces a single global `REVIEW_TARGET_SCORE` per-dim floor (`dim_floor_fail` predicate); the aggregator is already MIN (`min(raw_scores)`, line 1844). The change is in the **floor lookup**, not the aggregator shape.
+
+## Schema (proposed)
+
+```python
+# scripts/common/thresholds.py — additions
+
+QG_DIMS: tuple[str, ...] = (
+    "pedagogical",
+    "naturalness",
+    "decolonization",
+    "engagement",
+    "tone",
+)
+"""The 5 LLM QG dimensions per North Star §7. Tests assert this tuple
+matches the per-dim reviewer prompt set under
+``scripts/build/phases/v6-review/`` (post-retirement of legacy 9-dim)."""
+
+
+@dataclass(frozen=True, slots=True)
+class DimensionFloor:
+    """Per-dimension PASS and REJECT floors for one (level, dim) pair."""
+    pass_floor: float   # score >= pass_floor → dim PASSes
+    reject_floor: float # score < reject_floor → module REJECT-eligible
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.reject_floor <= self.pass_floor <= 10.0):
+            raise ValueError(
+                f"DimensionFloor invariant: 0 ≤ reject ({self.reject_floor}) "
+                f"≤ pass ({self.pass_floor}) ≤ 10"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class LevelThresholds:
+    target_words: int
+    review_floors: Mapping[str, DimensionFloor]
+    """Per-LLM-QG-dim floors. Keys must be QG_DIMS."""
+
+    @property
+    def naturalness_min(self) -> float:
+        """Backward-compat alias. New code uses review_floors['naturalness']."""
+        return self.review_floors["naturalness"].pass_floor
+
+    def __post_init__(self) -> None:
+        missing = set(QG_DIMS) - set(self.review_floors.keys())
+        extra = set(self.review_floors.keys()) - set(QG_DIMS)
+        if missing or extra:
+            raise ValueError(
+                f"review_floors must cover exactly QG_DIMS. "
+                f"missing={missing} extra={extra}"
+            )
+```
+
+## Per-level per-dim default floors
+
+Rationale: A1/A2/B1 are stricter than B2+ because thin source material at lower CEFR levels makes awkwardness easier to miss; this matches the existing `naturalness_min` pattern. **Decolonization is held high regardless of level** — it's identity-critical and not a complexity-tradeoff. **Pedagogical and Naturalness track Decolonization at lower levels** because a beginner module that fails either of those is unshippable. **Engagement and Tone hold steady at 8.0** — these are quality-stretch dims that tolerate B-grade and still ship.
+
+| Level | pedagogical | naturalness | decolonization | engagement | tone |
+|---|---|---|---|---|---|
+| A1   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 |
+| A2   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 |
+| B1   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 |
+| B2   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 |
+| C1   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 |
+| C2   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 |
+
+REJECT floor: **6.0 across all (level, dim)** — matches the current `REVIEW_REJECT_FLOOR` global. Below 6 means the module is structurally broken and needs a re-plan, not a fix-loop. (User policy 2026-04-23 in strict-reviewer-persona.md.)
+
+These are **defaults, not commitments** — each is overridable per-level via `_LEVEL_THRESHOLDS` and per-variant via the existing `scripts/audit/config.LEVEL_CONFIG` override path.
+
+## Aggregator (single-source-of-truth helper)
+
+```python
+# scripts/common/thresholds.py — additions
+
+@dataclass(frozen=True, slots=True)
+class ReviewVerdict:
+    verdict: Literal["PASS", "REVISE", "REJECT"]
+    failing_dims: tuple[str, ...]   # below pass_floor (subset of rejected_dims ∪ revising)
+    rejected_dims: tuple[str, ...]  # below reject_floor
+    min_score: float
+    min_dim: str
+
+
+def aggregate_review(
+    scores: Mapping[str, float],
+    level_code: str | None,
+) -> ReviewVerdict:
+    """MIN aggregator. PASS iff every QG dim ≥ pass_floor.
+    REJECT if any QG dim < reject_floor. Otherwise REVISE."""
+    floors = get_level_thresholds(level_code).review_floors
+
+    # Restrict to QG dims actually scored; warn (in caller) if any QG dim missing.
+    scored_qg = {dim: score for dim, score in scores.items() if dim in floors}
+    if not scored_qg:
+        raise ValueError(f"No QG dims found in scores: {sorted(scores)}")
+
+    failing = tuple(
+        dim for dim, score in scored_qg.items()
+        if score < floors[dim].pass_floor
+    )
+    rejected = tuple(
+        dim for dim, score in scored_qg.items()
+        if score < floors[dim].reject_floor
+    )
+    min_dim = min(scored_qg, key=scored_qg.__getitem__)
+    min_score = scored_qg[min_dim]
+
+    if rejected:
+        verdict = "REJECT"
+    elif failing:
+        verdict = "REVISE"
+    else:
+        verdict = "PASS"
+
+    return ReviewVerdict(
+        verdict=verdict,
+        failing_dims=failing,
+        rejected_dims=rejected,
+        min_score=min_score,
+        min_dim=min_dim,
+    )
+```
+
+## Migration path
+
+| Caller | Today | After #1586 |
+|---|---|---|
+| Phase 4 LLM QG (new, #1577 Phase 4) | does not exist | uses `aggregate_review(scores, level)` end-to-end |
+| `scripts/build/v6_build.py` (legacy V6 reviewer) | uses `REVIEW_TARGET_SCORE` global | **leave as-is** — V6 is being retired by Phase 4. Migration would be wasted work. Mark with comment referencing this ADR. |
+| `scripts/wiki/review.py`, `scripts/wiki/compile.py`, `scripts/wiki/rebuild.py` | uses `REVIEW_PASS_FLOOR` global as single overall-score threshold | **leave as-is** — wiki review is single-score, not per-dim. Single-score wiki review is conceptually different from module per-dim QG. Document in module docstring. |
+| `scripts/audit/checks/review_gaming.py` (mean-based heuristic) | uses `REVIEW_PASS_FLOOR` for v6 anti-gaming check | **leave as-is** — also v6-specific. Mark with comment. |
+| `scripts/audit/checks/review_validation.py` (`_V6_REVIEW_MIN_SCORE`) | already isolated | already correct |
+| `scripts/scoring/sampling.py` (`NATURALNESS_THRESHOLD`) | aliases `REVIEW_PASS_FLOOR` | migrate to `get_level_thresholds(level).review_floors["naturalness"].pass_floor` (per-level) |
+| `scripts/api/module_dashboard.py` | uses global as single-score gate | migrate to per-level if dashboard knows the level; otherwise keep as worst-case fallback with comment |
+
+**Net change**: new schema lands, Phase 4 uses it. V6 stays on the global until V6 is retired (post-Phase-4 fan-out). No big-bang migration.
+
+## Tests required
+
+1. `tests/test_thresholds_per_dim.py`:
+   - `LevelThresholds` `__post_init__` rejects missing or extra dim keys
+   - `DimensionFloor` rejects `reject > pass`
+   - `aggregate_review` PASS path: all dims at/above pass_floor → PASS, no failing/rejected
+   - `aggregate_review` REVISE path: one dim between reject_floor and pass_floor → REVISE, that dim in failing_dims
+   - `aggregate_review` REJECT path: one dim below reject_floor → REJECT regardless of other dims
+   - `aggregate_review` extra-dim (legacy v6 dim like "language") tolerated, but only QG dims considered for verdict
+   - `aggregate_review` empty / missing-QG-dim raises ValueError
+   - per-level default floor table values match this doc's table
+2. `tests/test_threshold_source_of_truth.py` (extend existing):
+   - assert no NEW module-level threshold constants outside `scripts/common/thresholds.py`
+   - assert no caller imports `REVIEW_PASS_FLOOR` for **new** purposes (hard list of legacy callers; new imports fail)
+3. `tests/test_review_floors_table_sync.py` (new):
+   - assert per-level dim floors exactly match this doc's table — this doc is the source of truth, code must agree
+
+## Out of scope for #1586
+
+- Retiring V6 9-dim reviewer (Phase 4 implementation, separate)
+- Per-dim reviewer prompt files in `scripts/build/phases/v6-review/` — those are Phase 4 work
+- Wiki review per-dim migration — single-score wiki review is conceptually fine
+- The actual Phase 4 LLM QG runner — separate brief, separate dispatch
+
+## Implementation brief outline (for Codex dispatch after this design lands)
+
+1. Worktree: `.worktrees/codex-1586-llm-qg-thresholds`
+2. Files:
+   - `scripts/common/thresholds.py` — add `QG_DIMS`, `DimensionFloor`, `ReviewVerdict`, `aggregate_review`; extend `LevelThresholds.review_floors`; add `__post_init__` invariants
+   - `scripts/audit/config.py` — keep `naturalness_min_score` derivation (uses backward-compat alias on `LevelThresholds`)
+   - `scripts/scoring/sampling.py` — accept `level_code` parameter; thread through to per-level lookup
+   - `scripts/api/module_dashboard.py` — same
+   - `tests/test_thresholds_per_dim.py` — new
+   - `tests/test_threshold_source_of_truth.py` — extend
+   - `tests/test_review_floors_table_sync.py` — new
+3. Run `.venv/bin/ruff check` per edit, `.venv/bin/pytest tests/test_thresholds_per_dim.py tests/test_threshold_source_of_truth.py tests/test_review_floors_table_sync.py tests/test_thresholds_consumers.py -x` per phase
+4. Single PR titled `feat(thresholds): per-level per-dim LLM QG floors (#1586)`
+5. Mandatory worktree per `.claude/rules/delegate-must-use-worktree.md`
+
+## Decision-doc invariant (per `docs/decisions/INDEX.md`)
+
+This file MUST be referenced from `scripts/common/thresholds.py` module docstring after merge so the chain (north-star.md § SHIPPABLE 7 → this doc → code) is traversable from any of its three nodes.

--- a/scripts/api/module_dashboard.py
+++ b/scripts/api/module_dashboard.py
@@ -24,7 +24,7 @@ CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from audit.status_cache import get_source_paths, read_status
-from common.thresholds import REVIEW_PASS_FLOOR
+from common.thresholds import get_level_thresholds
 
 
 def _load_curriculum_order(level: str) -> list[str]:
@@ -97,6 +97,12 @@ def _get_blocking_issues(status: dict) -> list[str]:
     return issues
 
 
+def _review_pass_floor(level: str) -> float:
+    """Single-score dashboard fallback: require the strictest dim floor."""
+    floors = get_level_thresholds(level).review_floors.values()
+    return max(floor.pass_floor for floor in floors)
+
+
 def dashboard(level: str, failing_only: bool = False, first_n: int = 0) -> int:
     """Print the module health dashboard. Returns exit code."""
     slugs = _load_curriculum_order(level)
@@ -123,14 +129,15 @@ def dashboard(level: str, failing_only: bool = False, first_n: int = 0) -> int:
             audit_status = "NO DATA"
             blocking = []
 
-        # A module is only shippable if audit PASS + review ≥ REVIEW_PASS_FLOOR
+        review_pass_floor = _review_pass_floor(level)
+        # Legacy review scores are MIN aggregates, so use the strictest dim floor.
         review_num = None
         if review_score and review_score not in ("PASS", "FAIL"):
             with contextlib.suppress(ValueError):
                 review_num = float(review_score)
 
-        if review_num is not None and review_num < REVIEW_PASS_FLOOR:
-            blocking.append(f"review: {review_num}/10 (need ≥{int(REVIEW_PASS_FLOOR)})")
+        if review_num is not None and review_num < review_pass_floor:
+            blocking.append(f"review: {review_num}/10 (need ≥{review_pass_floor:g})")
         elif review_score is None or review_score == "-":
             blocking.append("review: not completed")
 

--- a/scripts/common/thresholds.py
+++ b/scripts/common/thresholds.py
@@ -7,12 +7,16 @@ semantics, immutable values.
 Every threshold-typed module-level constant outside this file is a
 regression and will be caught by ``tests/test_threshold_source_of_truth.py``.
 
-Why not per-level for reviewer floors?
-    Reviewer personas evaluate a dimension on its own merits — a "6/10
-    factual accuracy" is weak regardless of the target CEFR level. The
-    audit-side naturalness gate *is* level-varying (stricter at A1/A2/B1
-    because thin source material needs extra polish); that lives in
-    :data:`LEVEL_THRESHOLDS`.
+Decision chain:
+    ``docs/north-star.md`` SHIPPABLE §7 →
+    ``docs/decisions/2026-04-26-llm-qg-per-dim-thresholds.md`` →
+    this module.
+
+Why both global and per-level reviewer floors?
+    Phase 4 LLM QG uses per-level per-dim floors in
+    :data:`LEVEL_THRESHOLDS` and :func:`aggregate_review`. Legacy V6 and
+    wiki single-score review still use the global ``REVIEW_*`` constants
+    until those surfaces are retired or deliberately migrated.
 
 Why not per-level for style-review thresholds either?
     Same reason. The style reviewer evaluates pragmatic authenticity,
@@ -29,6 +33,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import Literal
 
 # ---------------------------------------------------------------------------
 # Review pipeline floors — global (level-agnostic)
@@ -40,6 +45,15 @@ REVISE verdict in the general reviewer (see scripts/build/v6_build.py)."""
 
 REVIEW_REJECT_FLOOR: float = 6.0
 """Hard reject floor. Dim scores below this fail review unconditionally."""
+
+QG_DIMS: tuple[str, ...] = (
+    "pedagogical",
+    "naturalness",
+    "decolonization",
+    "engagement",
+    "tone",
+)
+"""The 5 LLM QG dimensions per North Star §7."""
 
 STYLE_REVIEW_TARGET: float = 9.0
 """Style-reviewer verdict target. Stricter than the general reviewer
@@ -56,6 +70,24 @@ STYLE_REVIEW_DIMENSION_FLOOR: float = 8.5
 
 
 @dataclass(frozen=True, slots=True)
+class DimensionFloor:
+    """Per-dimension PASS and REJECT floors for one (level, dim) pair."""
+
+    pass_floor: float
+    """Score must be at or above this floor for the dimension to PASS."""
+
+    reject_floor: float
+    """Score below this floor makes the module REJECT-eligible."""
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.reject_floor <= self.pass_floor <= 10.0):
+            raise ValueError(
+                f"DimensionFloor invariant: 0 ≤ reject ({self.reject_floor}) "
+                f"≤ pass ({self.pass_floor}) ≤ 10"
+            )
+
+
+@dataclass(frozen=True, slots=True)
 class LevelThresholds:
     """Immutable per-level thresholds.
 
@@ -68,25 +100,137 @@ class LevelThresholds:
     target_words: int
     """Minimum total words per module (audit gate + writer word budget)."""
 
-    naturalness_min: float
-    """Audit gate for the ``naturalness`` review dimension. Stricter at
-    A1/A2/B1 where source material is thin and awkward phrasing is easy
-    to miss; relaxed to 8.0 at B2+ where complexity naturally increases."""
+    review_floors: Mapping[str, DimensionFloor]
+    """Per-LLM-QG-dim floors. Keys must be exactly ``QG_DIMS``."""
+
+    @property
+    def naturalness_min(self) -> float:
+        """Backward-compat alias. New code uses review_floors['naturalness']."""
+        return self.review_floors["naturalness"].pass_floor
+
+    def __post_init__(self) -> None:
+        missing = set(QG_DIMS) - set(self.review_floors.keys())
+        extra = set(self.review_floors.keys()) - set(QG_DIMS)
+        if missing or extra:
+            raise ValueError(
+                "review_floors must cover exactly QG_DIMS. "
+                f"missing={missing} extra={extra}"
+            )
+        object.__setattr__(
+            self,
+            "review_floors",
+            MappingProxyType(dict(self.review_floors)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewVerdict:
+    """Aggregate LLM QG verdict and the dimensions that drove it."""
+
+    verdict: Literal["PASS", "REVISE", "REJECT"]
+    failing_dims: tuple[str, ...]
+    rejected_dims: tuple[str, ...]
+    min_score: float
+    min_dim: str
+
+
+def _make_review_floors(
+    *,
+    pedagogical: float,
+    naturalness: float,
+    decolonization: float,
+    engagement: float,
+    tone: float,
+) -> Mapping[str, DimensionFloor]:
+    pass_floors = {
+        "pedagogical": pedagogical,
+        "naturalness": naturalness,
+        "decolonization": decolonization,
+        "engagement": engagement,
+        "tone": tone,
+    }
+    return MappingProxyType({
+        dim: DimensionFloor(pass_floor=pass_floor, reject_floor=REVIEW_REJECT_FLOOR)
+        for dim, pass_floor in pass_floors.items()
+    })
 
 
 _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
-    "A1": LevelThresholds(target_words=1200, naturalness_min=9.0),
-    "A2": LevelThresholds(target_words=2000, naturalness_min=9.0),
-    "B1": LevelThresholds(target_words=4000, naturalness_min=9.0),
-    "B2": LevelThresholds(target_words=4000, naturalness_min=8.0),
-    "C1": LevelThresholds(target_words=4000, naturalness_min=8.0),
-    "C2": LevelThresholds(target_words=5000, naturalness_min=8.0),
+    "A1": LevelThresholds(
+        target_words=1200,
+        review_floors=_make_review_floors(
+            pedagogical=9.0,
+            naturalness=9.0,
+            decolonization=9.0,
+            engagement=8.0,
+            tone=8.0,
+        ),
+    ),
+    "A2": LevelThresholds(
+        target_words=2000,
+        review_floors=_make_review_floors(
+            pedagogical=9.0,
+            naturalness=9.0,
+            decolonization=9.0,
+            engagement=8.0,
+            tone=8.0,
+        ),
+    ),
+    "B1": LevelThresholds(
+        target_words=4000,
+        review_floors=_make_review_floors(
+            pedagogical=9.0,
+            naturalness=9.0,
+            decolonization=9.0,
+            engagement=8.0,
+            tone=8.0,
+        ),
+    ),
+    "B2": LevelThresholds(
+        target_words=4000,
+        review_floors=_make_review_floors(
+            pedagogical=8.0,
+            naturalness=8.0,
+            decolonization=9.0,
+            engagement=8.0,
+            tone=8.0,
+        ),
+    ),
+    "C1": LevelThresholds(
+        target_words=4000,
+        review_floors=_make_review_floors(
+            pedagogical=8.0,
+            naturalness=8.0,
+            decolonization=9.0,
+            engagement=8.0,
+            tone=8.0,
+        ),
+    ),
+    "C2": LevelThresholds(
+        target_words=5000,
+        review_floors=_make_review_floors(
+            pedagogical=8.0,
+            naturalness=8.0,
+            decolonization=9.0,
+            engagement=8.0,
+            tone=8.0,
+        ),
+    ),
 }
 
 LEVEL_THRESHOLDS: Mapping[str, LevelThresholds] = MappingProxyType(_LEVEL_THRESHOLDS)
 """Read-only view of per-level family thresholds."""
 
-_DEFAULT_THRESHOLDS = LevelThresholds(target_words=4000, naturalness_min=8.0)
+_DEFAULT_THRESHOLDS = LevelThresholds(
+    target_words=4000,
+    review_floors=_make_review_floors(
+        pedagogical=8.0,
+        naturalness=8.0,
+        decolonization=9.0,
+        engagement=8.0,
+        tone=8.0,
+    ),
+)
 """Fallback for unknown level codes. Matches the audit-side ``default``
 row historically used in ``AUDIT_THRESHOLDS['naturalness_min_score']``."""
 
@@ -107,6 +251,49 @@ def get_level_thresholds(level_code: str | None) -> LevelThresholds:
 def get_naturalness_min(level_code: str | None) -> float:
     """Shortcut — per-level audit naturalness gate."""
     return get_level_thresholds(level_code).naturalness_min
+
+
+def aggregate_review(
+    scores: Mapping[str, float],
+    level_code: str | None,
+) -> ReviewVerdict:
+    """MIN aggregator for Phase 4 LLM QG.
+
+    PASS iff every scored QG dim is at or above its per-level pass floor.
+    REJECT if any scored QG dim is below its reject floor. Otherwise REVISE.
+    """
+    floors = get_level_thresholds(level_code).review_floors
+    scored_qg = {dim: score for dim, score in scores.items() if dim in floors}
+    if not scored_qg:
+        raise ValueError(f"No QG dims found in scores: {sorted(scores)}")
+
+    failing = tuple(
+        dim
+        for dim, score in scored_qg.items()
+        if score < floors[dim].pass_floor
+    )
+    rejected = tuple(
+        dim
+        for dim, score in scored_qg.items()
+        if score < floors[dim].reject_floor
+    )
+    min_dim = min(scored_qg, key=scored_qg.__getitem__)
+    min_score = scored_qg[min_dim]
+
+    if rejected:
+        verdict: Literal["PASS", "REVISE", "REJECT"] = "REJECT"
+    elif failing:
+        verdict = "REVISE"
+    else:
+        verdict = "PASS"
+
+    return ReviewVerdict(
+        verdict=verdict,
+        failing_dims=failing,
+        rejected_dims=rejected,
+        min_score=min_score,
+        min_dim=min_dim,
+    )
 
 
 def get_target_words(level_code: str | None) -> int:

--- a/scripts/scoring/sampling.py
+++ b/scripts/scoring/sampling.py
@@ -15,20 +15,27 @@ from typing import Any
 # Ensure scripts/ is importable (matches the pattern used elsewhere in audit/).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from common.thresholds import REVIEW_PASS_FLOOR
+from common.thresholds import get_level_thresholds
 
 # Constants
 SENSITIVE_TAGS = {
     'politics', 'war', 'religion', 'history', 'ideology', 'gender',
     'controversial', 'policy', 'identity'
 }
-# Modules scoring below the reviewer pass floor get Tier 2 (LLM-verified).
-# Shares the constant with the review pipeline so the risk-escalation
-# threshold tracks any future shift in reviewer calibration.
-NATURALNESS_THRESHOLD = REVIEW_PASS_FLOOR
+# Default fallback for callers that do not yet pass a level code.
+NATURALNESS_THRESHOLD = get_level_thresholds(None).review_floors["naturalness"].pass_floor
 SAMPLE_RATE = 0.20  # 20% sampling for Tier 3
 
-def determine_tier(module_data: dict[str, Any]) -> str:
+
+def get_naturalness_threshold(level_code: str | None = None) -> float:
+    """Return the per-level naturalness floor for sampling escalation."""
+    return get_level_thresholds(level_code).review_floors["naturalness"].pass_floor
+
+
+def determine_tier(
+    module_data: dict[str, Any],
+    level_code: str | None = None,
+) -> str:
     """
     Determine the implied validation tier based on module characteristics.
     Does NOT return the stored tier, but calculates what it *should* be
@@ -40,7 +47,8 @@ def determine_tier(module_data: dict[str, Any]) -> str:
     if isinstance(naturalness, dict):
         score = naturalness.get('score', 10)
 
-    if score < NATURALNESS_THRESHOLD:
+    resolved_level = level_code or module_data.get("level_code") or module_data.get("level")
+    if score < get_naturalness_threshold(resolved_level):
         return 'llm-verified'
 
     # Check sensitive tags

--- a/tests/test_review_floors_table_sync.py
+++ b/tests/test_review_floors_table_sync.py
@@ -1,0 +1,57 @@
+"""Decision doc and code must agree on LLM QG review floors."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from common.thresholds import LEVEL_THRESHOLDS, QG_DIMS, REVIEW_REJECT_FLOOR
+
+DOC_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "decisions"
+    / "2026-04-26-llm-qg-per-dim-thresholds.md"
+)
+
+
+def _parse_doc_floor_table() -> dict[str, dict[str, float]]:
+    text = DOC_PATH.read_text("utf-8")
+    pattern = re.compile(
+        r"^\|\s*(A1|A2|B1|B2|C1|C2)\s*"
+        r"\|\s*(\d+\.\d)\s*"
+        r"\|\s*(\d+\.\d)\s*"
+        r"\|\s*(\d+\.\d)\s*"
+        r"\|\s*(\d+\.\d)\s*"
+        r"\|\s*(\d+\.\d)\s*\|$",
+        re.MULTILINE,
+    )
+    rows = {}
+    for match in pattern.finditer(text):
+        level, *values = match.groups()
+        rows[level] = dict(zip(QG_DIMS, [float(value) for value in values], strict=True))
+    return rows
+
+
+def test_review_floor_code_matches_decision_doc_table() -> None:
+    doc_table = _parse_doc_floor_table()
+
+    assert set(doc_table) == set(LEVEL_THRESHOLDS)
+    for level, expected in doc_table.items():
+        actual = {
+            dim: LEVEL_THRESHOLDS[level].review_floors[dim].pass_floor
+            for dim in QG_DIMS
+        }
+        assert actual == expected
+
+
+def test_all_review_reject_floors_match_decision_doc_constant() -> None:
+    text = DOC_PATH.read_text("utf-8")
+    assert "REJECT floor: **6.0 across all (level, dim)**" in text
+
+    for thresholds in LEVEL_THRESHOLDS.values():
+        for floor in thresholds.review_floors.values():
+            assert floor.reject_floor == REVIEW_REJECT_FLOOR

--- a/tests/test_threshold_source_of_truth.py
+++ b/tests/test_threshold_source_of_truth.py
@@ -89,6 +89,18 @@ _FLOAT_LITERAL_ALLOWLIST: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("build/v6_build.py", re.compile(r"review_threshold \(default 9\.0\)")),
 )
 
+# REVIEW_PASS_FLOOR remains valid only for legacy V6, wiki single-score
+# review, and dashboard surfaces that still consume legacy single scores.
+_REVIEW_PASS_FLOOR_IMPORT_ALLOWLIST: frozenset[str] = frozenset({
+    "audit/checks/review_gaming.py",
+    "audit/checks/review_validation.py",
+    "build/v6_build.py",
+    "wiki/review.py",
+    "api/dashboard_helpers.py",
+    "api/dashboard_router.py",
+    "api/state_compute.py",
+})
+
 # Files excluded from the scan entirely (archived / generated / legacy).
 _EXCLUDED_DIRS: tuple[str, ...] = (
     "__pycache__",
@@ -158,6 +170,39 @@ def test_no_canonical_name_redeclared_outside_thresholds() -> None:
 
     assert not offenders, (
         "Canonical threshold names must live only in scripts/common/thresholds.py.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_review_pass_floor_imports_are_legacy_allowlisted() -> None:
+    """New module QG callers must use per-level per-dim review_floors.
+
+    ``REVIEW_PASS_FLOOR`` is retained for legacy V6 and single-score wiki /
+    dashboard review. A new import of the global floor is a schema regression.
+    """
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        if path.resolve() == SOURCE_OF_TRUTH.resolve():
+            continue
+        rel = path.relative_to(SCRIPTS_ROOT).as_posix()
+        try:
+            tree = ast.parse(path.read_text("utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module not in {"common.thresholds", "scripts.common.thresholds"}:
+                continue
+            if (
+                any(alias.name == "REVIEW_PASS_FLOOR" for alias in node.names)
+                and rel not in _REVIEW_PASS_FLOOR_IMPORT_ALLOWLIST
+            ):
+                offenders.append(f"{rel}:{node.lineno} imports REVIEW_PASS_FLOOR")
+
+    assert not offenders, (
+        "New callers must use LevelThresholds.review_floors or aggregate_review(); "
+        "REVIEW_PASS_FLOOR imports are legacy-only.\n"
         + "\n".join(offenders)
     )
 

--- a/tests/test_thresholds_per_dim.py
+++ b/tests/test_thresholds_per_dim.py
@@ -1,0 +1,189 @@
+"""Per-level per-dimension LLM QG threshold schema tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from common.thresholds import (
+    LEVEL_THRESHOLDS,
+    QG_DIMS,
+    REVIEW_REJECT_FLOOR,
+    DimensionFloor,
+    LevelThresholds,
+    aggregate_review,
+)
+
+EXPECTED_PASS_FLOORS = {
+    "A1": {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+    },
+    "A2": {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+    },
+    "B1": {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+    },
+    "B2": {
+        "pedagogical": 8.0,
+        "naturalness": 8.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+    },
+    "C1": {
+        "pedagogical": 8.0,
+        "naturalness": 8.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+    },
+    "C2": {
+        "pedagogical": 8.0,
+        "naturalness": 8.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+    },
+}
+
+
+def _valid_floors() -> dict[str, DimensionFloor]:
+    return {
+        dim: DimensionFloor(pass_floor=8.0, reject_floor=REVIEW_REJECT_FLOOR)
+        for dim in QG_DIMS
+    }
+
+
+def test_level_thresholds_rejects_missing_dim_keys() -> None:
+    floors = _valid_floors()
+    floors.pop("tone")
+
+    with pytest.raises(ValueError, match="review_floors must cover exactly QG_DIMS"):
+        LevelThresholds(target_words=1200, review_floors=floors)
+
+
+def test_level_thresholds_rejects_extra_dim_keys() -> None:
+    floors = _valid_floors()
+    floors["language"] = DimensionFloor(pass_floor=8.0, reject_floor=REVIEW_REJECT_FLOOR)
+
+    with pytest.raises(ValueError, match="review_floors must cover exactly QG_DIMS"):
+        LevelThresholds(target_words=1200, review_floors=floors)
+
+
+def test_dimension_floor_rejects_reject_above_pass() -> None:
+    with pytest.raises(ValueError, match="DimensionFloor invariant"):
+        DimensionFloor(pass_floor=6.0, reject_floor=7.0)
+
+
+def test_aggregate_review_passes_when_all_dims_clear_pass_floors() -> None:
+    verdict = aggregate_review(
+        {
+            "pedagogical": 9.0,
+            "naturalness": 9.0,
+            "decolonization": 9.0,
+            "engagement": 8.0,
+            "tone": 8.0,
+        },
+        "A1",
+    )
+
+    assert verdict.verdict == "PASS"
+    assert verdict.failing_dims == ()
+    assert verdict.rejected_dims == ()
+    assert verdict.min_score == 8.0
+    assert verdict.min_dim == "engagement"
+
+
+def test_aggregate_review_revises_when_one_dim_between_reject_and_pass() -> None:
+    verdict = aggregate_review(
+        {
+            "pedagogical": 9.0,
+            "naturalness": 8.5,
+            "decolonization": 9.0,
+            "engagement": 8.0,
+            "tone": 8.0,
+        },
+        "A1",
+    )
+
+    assert verdict.verdict == "REVISE"
+    assert verdict.failing_dims == ("naturalness",)
+    assert verdict.rejected_dims == ()
+    assert verdict.min_score == 8.0
+    assert verdict.min_dim == "engagement"
+
+
+def test_aggregate_review_rejects_when_any_dim_below_reject_floor() -> None:
+    verdict = aggregate_review(
+        {
+            "pedagogical": 10.0,
+            "naturalness": 10.0,
+            "decolonization": 5.9,
+            "engagement": 10.0,
+            "tone": 10.0,
+        },
+        "B2",
+    )
+
+    assert verdict.verdict == "REJECT"
+    assert verdict.failing_dims == ("decolonization",)
+    assert verdict.rejected_dims == ("decolonization",)
+    assert verdict.min_score == 5.9
+    assert verdict.min_dim == "decolonization"
+
+
+def test_aggregate_review_tolerates_extra_legacy_dims() -> None:
+    verdict = aggregate_review(
+        {
+            "pedagogical": 8.0,
+            "naturalness": 8.0,
+            "decolonization": 9.0,
+            "engagement": 8.0,
+            "tone": 8.0,
+            "language": 0.0,
+        },
+        "B2",
+    )
+
+    assert verdict.verdict == "PASS"
+    assert verdict.failing_dims == ()
+    assert verdict.rejected_dims == ()
+    assert verdict.min_score == 8.0
+    assert verdict.min_dim == "pedagogical"
+
+
+@pytest.mark.parametrize("scores", [{}, {"language": 10.0}])
+def test_aggregate_review_raises_when_no_qg_dims_are_scored(
+    scores: dict[str, float],
+) -> None:
+    with pytest.raises(ValueError, match="No QG dims found in scores"):
+        aggregate_review(scores, "A1")
+
+
+def test_per_level_default_floor_table_matches_design() -> None:
+    assert set(LEVEL_THRESHOLDS) == set(EXPECTED_PASS_FLOORS)
+    for level, expected in EXPECTED_PASS_FLOORS.items():
+        thresholds = LEVEL_THRESHOLDS[level]
+        assert set(thresholds.review_floors) == set(QG_DIMS)
+        for dim, pass_floor in expected.items():
+            floor = thresholds.review_floors[dim]
+            assert floor.pass_floor == pass_floor
+            assert floor.reject_floor == REVIEW_REJECT_FLOOR
+        assert thresholds.naturalness_min == expected["naturalness"]


### PR DESCRIPTION
## Summary

- Extends \`scripts/common/thresholds.py\` with per-level per-dim LLM QG floors and a MIN aggregator (\`aggregate_review\`)
- Lands the design at \`docs/decisions/2026-04-26-llm-qg-per-dim-thresholds.md\`
- Adds \`tests/test_thresholds_per_dim.py\` (schema + aggregator) and \`tests/test_review_floors_table_sync.py\` (code-vs-doc sync)
- Phase 4 (EPIC #1577) blocker — the new LLM QG runner uses this schema

## Test plan

- [x] Unit tests for schema invariants (DimensionFloor / LevelThresholds)
- [x] Aggregator PASS / REVISE / REJECT paths
- [x] Per-level default floor table matches design doc
- [x] Existing threshold tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)