### PR TITLE
feat(phase-4): parameterize linear_pipeline.py writer (#1577 ADR §1)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -40,6 +40,12 @@ PLAN_REQUIRED_KEYS = {
     "references",
 }
 
+WRITER_CHOICES = ("claude-tools", "gemini-tools")
+WRITER_DEFAULTS: dict[str, dict[str, str]] = {
+    "claude-tools": {"model": "claude-opus-4-7", "effort": "xhigh"},
+    "gemini-tools": {"model": "gemini-3.1-pro-preview", "effort": "high"},
+}
+
 QUALITY_FIELD_PATTERNS: dict[str, tuple[str, ...]] = {
     "russianisms_clean": (
         r"\bпожалуйста\b",
@@ -201,23 +207,30 @@ def writer_context(plan: Mapping[str, Any], plan_content: str, knowledge_packet:
 
 def invoke_writer(
     prompt: str,
+    writer: str,
     *,
     cwd: Path = PROJECT_ROOT,
     invoker: Callable[..., Any] | None = None,
 ) -> str:
-    """Call the configured Claude writer through the universal agent runtime."""
+    """Call the selected writer through the universal agent runtime."""
+    if writer not in WRITER_CHOICES:
+        raise LinearPipelineError(
+            f"Unknown writer {writer!r}; expected one of {WRITER_CHOICES}"
+        )
     if invoker is None:
         from scripts.agent_runtime.runner import invoke as invoker
 
+    defaults = WRITER_DEFAULTS[writer]
+    agent_name = writer.split("-", 1)[0]
     result = invoker(
-        "claude",
+        agent_name,
         prompt,
         mode="workspace-write",
         cwd=cwd,
-        model="claude-opus-4-7",
+        model=defaults["model"],
         task_id="phase-4-a1-20-writer",
         entrypoint="dispatch",
-        effort="xhigh",
+        effort=defaults["effort"],
         tool_config={"output_format": "text"},
     )
     response = getattr(result, "response", None)

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -76,6 +76,50 @@ def test_render_phase_prompt_fills_registered_tokens() -> None:
     assert "TARGET: 15-35% Ukrainian." in rendered
 
 
+@pytest.mark.parametrize(
+    ("writer", "agent_name"),
+    [
+        ("claude-tools", "claude"),
+        ("gemini-tools", "gemini"),
+    ],
+)
+def test_invoke_writer_routes_supported_writers(
+    tmp_path: Path,
+    writer: str,
+    agent_name: str,
+) -> None:
+    calls = []
+
+    class Result:
+        response = "writer output"
+
+    def fake_invoker(agent: str, prompt: str, **kwargs: object) -> Result:
+        calls.append((agent, prompt, kwargs))
+        return Result()
+
+    response = linear_pipeline.invoke_writer(
+        "Write the module.",
+        writer=writer,
+        cwd=tmp_path,
+        invoker=fake_invoker,
+    )
+
+    assert response == "writer output"
+    assert calls[0][0] == agent_name
+    assert calls[0][1] == "Write the module."
+    assert calls[0][2]["mode"] == "workspace-write"
+    assert calls[0][2]["cwd"] == tmp_path
+    assert calls[0][2]["entrypoint"] == "dispatch"
+    assert calls[0][2]["model"] == linear_pipeline.WRITER_DEFAULTS[writer]["model"]
+    assert calls[0][2]["effort"] == linear_pipeline.WRITER_DEFAULTS[writer]["effort"]
+    assert calls[0][2]["tool_config"] == {"output_format": "text"}
+
+
+def test_invoke_writer_rejects_unknown_writer(tmp_path: Path) -> None:
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="Unknown writer"):
+        linear_pipeline.invoke_writer("Write the module.", writer="bogus", cwd=tmp_path)
+
+
 def test_aggregate_llm_review_requires_exact_qg_dims() -> None:
     report = {
         dim: {


### PR DESCRIPTION
## Summary
- Implements ADR b532271f3d cleanup §1 by removing the hardcoded Phase 4 module writer from scripts/build/linear_pipeline.py.
- Adds selectable writer shorthands for claude-tools and gemini-tools while routing through the existing agent runtime adapter keys.
- Updates linear pipeline tests to verify both writer routes and invalid writer rejection.

## Stack
- Stacked on parent PR #1594 / branch codex/phase-4-a1-20-exemplar.
- Base is codex/phase-4-a1-20-exemplar, not main; after PR #1594 merges this PR can rebase onto main.

## Test plan
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/linear_pipeline.py tests/build/test_linear_pipeline.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/build/test_linear_pipeline.py tests/build/test_a1_20_exemplar.py tests/test_no_rewrite_contract.py tests/test_thresholds_per_dim.py -q