### PR TITLE
docs(session): handoff after round 3.5 shipped

### DIFF
--- a/docs/session-state/2026-04-26-round-3.5-shipped.md
+++ b/docs/session-state/2026-04-26-round-3.5-shipped.md
@@ -1,0 +1,143 @@
+# Session Handoff — 2026-04-26 (Round 3.5 prompt-tighten shipped)
+
+> **Predecessor:** `2026-04-26-qg-bugfix-shipped.md` (round-3 QG bugfixes)
+> **Successor scope:** user re-runs A1/20 build → result gates round 4 bakeoff decision
+> **Mode:** Clean exit, ~225K context. No background tasks owed.
+
+---
+
+## TL;DR — what shipped
+
+```
+9294dedbbe  feat(phase-4): round 3.5 writer prompt + whitelist tighten (#1602) (#1603)
+```
+
+Single squash-merged PR. Two underlying commits (initial + revision pass after dual-agent review). Issue #1602 closed. Follow-up #1604 filed for the schema-generator root cause.
+
+---
+
+## What round 3.5 actually fixes
+
+The 3 real writer failures left after PRs #1598 + #1599 unmasked round-3 false positives:
+
+| Failure | Fix |
+|---|---|
+| Chatty English meta-narration → over-budget sections + 11.72% immersion | New "Tone and immersion" section in `linear-write.md` with 12+ explicit forbidden phrases ("Welcome to…", "Note that…", "Observe how…", …) + meta-rule against teacher-facing transition verbs |
+| Component-prop schema invisible to writer (`passage:` for fill-in, missing `correct_order`) | New `{COMPONENT_PROPS_SCHEMA}` token rendered from `docs/lesson-schema.yaml` per allowed activity type — same source-of-truth as `_component_prop_gate` validator. WARNING bullets emitted for unresolved allowed types (`phrase-table` is the one drift case in A1) |
+| `Караман`, `Ліна`, `Настя` not in `PROPER_NAME_WHITELIST` | Added all three + 13 declined-form variants |
+
+Plus 3 BLOCKERs surfaced by parallel Gemini + Codex review and fixed in the revision pass:
+- Invalid `fill-in` example in prompt skeleton (id/type/title only) contradicted new schema section → replaced with valid example, added test that runs example through `_component_prop_gate`.
+- `@functools.cache` on `_proper_name_whitelist_lc` was a test-isolation hazard → cache dropped (90-element set, microseconds), regression test guards against reintroduction.
+- `phrase-table` silent-drop in renderer → emits `# WARNING:` bullet with #1604 backref instead.
+
+Plus 4 SUGGESTIONs both reviewers raised (anti-meta phrases expanded, TSDoc strip in raw types, declined name forms, missing tests for new behaviors) — all addressed.
+
+---
+
+## Decision pending for next session
+
+**Did the tightened prompt fix Gemini's chatty meta-narration?**
+
+User runs A1/20 build via the linear pipeline:
+```bash
+.venv/bin/python -m scripts.build.linear_pipeline a1 my-morning --writer gemini-tools
+```
+(or the existing dispatch path — I haven't traced which entry point is canonical for round 3.5).
+
+Then inspect `curriculum/l2-uk-en/a1/my-morning/module.md` and `audit/a1/my-morning.json`:
+
+| If… | Then |
+|---|---|
+| Gemini complies with anti-meta directives, `plan_sections` green, `immersion.pct` ≥ 15%, `component_props` green, `vesum_verified` green | Round 3.5 is the canonical writer config. Proceed to Phase 5 fan-out. |
+| Gemini still produces meta-narration despite the explicit list | **Empirical bakeoff trigger.** Dispatch round 4: `claude-tools` writer on the same module, compare. ADR-007 §3 says the writer choice is "not yet decided — not a current blocker"; this becomes the moment to decide. |
+| Mixed result (some directives obeyed, some not) | Iterate one more prompt-tighten round (round 3.75) with whatever specific failure mode. Don't bakeoff yet. |
+
+Recommendation: I'd start with the Gemini run (cheap, fast), then decide based on actual artifacts rather than theory.
+
+---
+
+## How today's review sequence went (good template)
+
+Per the corrected workflow added 2026-04-26 (3-agent panel before merge):
+
+1. PR opened with self-described plan + ACs.
+2. **Parallel** dispatch: Gemini-3.1-pro-preview + Codex-gpt-5.5 with the same review prompt (`/tmp/pr-1603-review-prompt.md` — kept under `.worktree-briefs/` as evidence). Both finished in ~3-4 min wallclock.
+3. Cross-agent triage: 7 findings, agreement on 6, disagreement only on severity of one (Codex marked phrase-table BLOCKER, Gemini didn't surface it).
+4. Single revision commit addressing ALL findings, with new tests for each.
+5. PR comment posting the disposition table inline so reviewers can verify their findings landed.
+6. CI green → squash-merge → branch+worktree deleted.
+
+Total wallclock from PR open to merge: ~25 min (review + revision + CI). Cheaper than silent merge then bug-then-fix.
+
+---
+
+## Worktree state (cleaned)
+
+```
+/Users/krisztiankoos/projects/learn-ukrainian                                  [main, b532271f3d — user WIP, behind origin/main]
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/codex-interactive     (stale, detached HEAD — pre-existing)
+```
+
+Main checkout HEAD `b532271f3d` is intentionally behind `origin/main` (now `9294dedbbe`, 7 commits ahead) — that's the user's working tree with uncommitted edits from in-flight wiki rebuilds. Don't `git pull` from there.
+
+Round 3.5 worktree (`.worktrees/claude-1602-round-3.5-prompt-tighten`) and its branch removed post-merge.
+
+---
+
+## Open coding issues snapshot
+
+Same backlog as predecessor handoff plus #1604:
+
+- **#1604 (NEW)**: schema-generator drift — `PhraseTable` (and other vocabulary-tab activities) get `activity_type: null` in `lesson-schema.yaml`. Renderer warns; root cause needs the generator at `scripts/build/generate_lesson_schema.py` to assign `phrase-table` to PhraseTable. ACs include a unit test that asserts every type in any track's `*_ALLOWED_TYPES` resolves to a real schema entry.
+- All other issues (#1573, #1571, #1570, #1553, #1377, #1373, #1351, #1350, #1333, #1201) carried forward from predecessor — none Phase-4-blockers.
+
+---
+
+## Active background tasks at handoff time
+
+- **None of mine.** All my background watchers/dispatches completed and reported.
+- 4 user-launched Gemini wiki rebuilds may still be running. When `pgrep -f "compile.py.*--track"` is empty, follow `b7db136b1d` commit pattern.
+
+---
+
+## Cold-start protocol for successor
+
+```bash
+# 1. Verify state
+git -C /Users/krisztiankoos/projects/learn-ukrainian log --oneline origin/main -5
+# Expect: 9294dedbbe (round 3.5) → ab253e00f1 → ccfe0aaac0 → a6b9e7f417 → 3603f11774
+
+curl -s 'http://localhost:8765/api/comms/inbox?agent=claude'   # expect empty
+
+gh pr list --state open --limit 10   # expect no Phase 4 PRs
+
+# 2. Read the predecessor chain (3-5 most recent date-stamped handoffs)
+ls -lt docs/session-state/2026-04-26*.md | head -5
+
+# 3. If user has run the A1/20 re-test, inspect:
+cat curriculum/l2-uk-en/a1/my-morning/module.md  | head -40
+cat audit/a1/my-morning.json | jq '.gates'
+# Then decide round 3.5 success vs round 4 bakeoff per the table above.
+```
+
+---
+
+## Final stats for the session
+
+- **1 PR shipped** (#1603 round 3.5 prompt-tighten + revision pass)
+- **2 commits squash-merged into 1** (`9294dedbbe`)
+- **13 new regression tests** across the two pre-squash commits (8 initial + 5 in revision pass)
+- **5 source files touched**: `linear-write.md`, `linear_pipeline.py`, `prompt_builder.py`, `audit/config.py`, `test_linear_pipeline.py`
+- **2 issues**: #1602 closed, #1604 filed (follow-up for schema-generator drift)
+- **2 adversarial reviews** archived in bridge message store (IDs 478 Gemini, 479 Codex)
+- **0 open Phase 4 PRs** at handoff
+- **0 open coding issues blocked on me** at handoff
+
+---
+
+## Behavioral notes worth carrying forward
+
+1. **Parallel adversarial review at PR open is cheap and load-bearing.** ~3-4 min wallclock for two reviews; 7 findings caught that would have either shipped silently (TSDoc leak, cache hazard) or surfaced during build (invalid example, phrase-table drop).
+2. **Don't fail-loud when the failure mode is unrelated drift.** The phrase-table BLOCKER 2 was tempting to fix with `raise LinearPipelineError` — but that would have blocked round 3.5 dispatch on a separate generator-side bug. Skip-and-warn + follow-up issue is the right scope when the immediate goal is unblocking the next experiment.
+3. **Test sentinels need self-tests.** The JSX-object-literal test broke because `Ліна` got whitelisted; new sentinel `Маркіян` carries an `assert "Маркіян" not in PROPER_NAME_WHITELIST` so the next agent can't silently degrade it.

--- a/docs/session-state/current.md
+++ b/docs/session-state/current.md
@@ -8,7 +8,8 @@
 
 | Thread | Latest handoff | Owner |
 |---|---|---|
-| **EPIC #1577 reboot — Round 3 diagnostic shipped, decision pending (3.5 vs 4)** | **`docs/session-state/2026-04-26-qg-bugfix-shipped.md`** | **Claude late-evening (this session)** |
+| **EPIC #1577 reboot — Round 3.5 prompt-tighten shipped (#1603); decision pending on user re-run** | **`docs/session-state/2026-04-26-round-3.5-shipped.md`** | **Claude late-evening (this session)** |
+| Predecessor: Round 3 QG bugfixes shipped, decision pending (3.5 vs 4) | `docs/session-state/2026-04-26-qg-bugfix-shipped.md` | Claude late-evening |
 | Predecessor: Phase 4 round 3 dispatched (strict-JSON exemplar) | `docs/session-state/2026-04-26-evening-handoff.md` | Claude evening |
 | Predecessor: autonomous orchestration during user-away window | `docs/session-state/2026-04-26-autonomous-orchestration.md` | Claude midday |
 | Predecessor: overnight wiki rebuild + Phase 4 dispatch | `docs/session-state/2026-04-26-overnight-claude.md` | Claude overnight |
@@ -39,17 +40,22 @@
   standard rc file. Source it manually before `gh` calls.
 - **a1/1 working tree** has user's preserved manual patches. Do NOT
   clobber from any thread.
-- **Main is at `a6b9e7f417`** as of late-evening handoff (2026-04-26).
-  Two Phase 4 PRs merged this session: `3603f11774` (#1598 strict-JSON
-  contract) + `a6b9e7f417` (#1599 QG false-positive fixes).
-- **Phase 4 round 3 dispatch:** completed `worktree_dirty_on_exit:
-  true`. Diagnostic showed 4 of 5 RED gates were Python QG bugs
-  (now fixed). 3 real writer failures remain: chatty over-writing
-  (causes both `plan_sections` over-budget and `immersion 11.72%`),
-  schema-syntax gap (`act-my-morning-4/6/8`), and 3 proper-name
-  whitelist gaps (`Караман`/`Ліна`/`Настя`). **Next decision:**
-  round 3.5 prompt-tighten vs round 4 writer bakeoff. See
-  `2026-04-26-qg-bugfix-shipped.md` for context.
+- **Main is at `9294dedbbe`** as of late-evening handoff (2026-04-26).
+  Three Phase 4 PRs merged this round of sessions: `3603f11774` (#1598
+  strict-JSON), `a6b9e7f417` (#1599 QG false-positive fixes), and
+  `9294dedbbe` (#1603 round 3.5 prompt-tighten).
+- **Phase 4 round 3.5 SHIPPED:** writer prompt now includes anti-meta-
+  narration directives (12+ forbidden phrases), `{COMPONENT_PROPS_SCHEMA}`
+  rendered from `lesson-schema.yaml` per allowed activity type, and 3
+  whitelist additions + 13 declined-form variants. **Next decision:**
+  user runs A1/20 build → if Gemini complies, round 3.5 is canonical
+  config and Phase 5 fan-out begins; if it still produces meta-narration,
+  empirical bakeoff trigger for round 4 (claude-tools vs gemini-tools).
+  See `2026-04-26-round-3.5-shipped.md` for the decision table.
+- **#1604 (NEW)** filed as follow-up: `PhraseTable` (and other
+  vocabulary-tab activities) get `activity_type: null` in
+  `lesson-schema.yaml`. Renderer warns; root cause needs schema-generator
+  fix. Not Phase-4-blocking.
 - **Round-3 failed Gemini exemplar artifacts** preserved in repo
   stash@{0} and stash@{1} (duplicates). `git stash show -p stash@{0}`
   to inspect — needed for round 3.5 prompt-tightening evidence.


### PR DESCRIPTION
## Summary

Session handoff after round 3.5 (#1602 / PR #1603) merged.

- New handoff `docs/session-state/2026-04-26-round-3.5-shipped.md` (TL;DR, decision table for next session, behavioral notes)
- `current.md` index updated: round 3.5 row added, cross-thread notes rolled forward

## Test plan

- [x] No code changes; only `docs/session-state/`