### PR TITLE
fix(qg): VESUM gate skips errorWord/error fields in error-correction activities (#1623)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -255,10 +255,10 @@ _SENTENCE_SPLIT_RE = re.compile(
     re.MULTILINE,
 )
 
-# Activity field whose value is intentionally misspelled — students correct it.
-# Excluded from VESUM lookup.
+# Activity fields whose values are intentionally misspelled — students correct
+# them. Excluded from VESUM lookup only for error-correction activities.
 _ERROR_CORRECTION_TYPE = "error-correction"
-_ERROR_CORRECTION_INTENTIONAL_FIELD = "error"
+_ERROR_CORRECTION_INTENTIONAL_FIELDS = frozenset({"error", "errorWord", "error_word"})
 
 # String fields whose values are user-facing prose (subject to AI-slop checks).
 # YAML structural keys like `correction:` and `correctAnswer:` are deliberately
@@ -1111,9 +1111,9 @@ def _vesum_gate(
     1. **Phonetic transcriptions and inline code** — `[с':а]`, `[ц':а]`, and
        backticked fragments like `` `вмиваєс':а` `` are metalinguistic notation
        (parts of words, IPA-ish symbols), not VESUM lemmas.
-    2. **Intentional misspellings in `error-correction` activities** — the
-       `error:` field of an `error-correction` activity contains the typo the
-       student must fix (e.g. `прокидаєштся`). Verifying it would always fail.
+    2. **Intentional misspellings in `error-correction` activities** —
+       `error:`, `errorWord:`, and `error_word:` fields contain the typo the
+       student must fix (e.g. `прокидаєштся`). Verifying them would always fail.
     3. **Sentence-initial capitalization** — VESUM is case-sensitive, so
        `Спочатку` (capitalized first word) returns no matches even though
        `спочатку` does. Lookup is performed in lowercase; the report keeps
@@ -1199,8 +1199,9 @@ def _walk_artifact_strings(
 
     - `skip_subtree_keys`: dict keys whose entire VALUE subtree (string OR
       nested dict/list) should be excluded. Used to drop intentional
-      misspellings stored under `error:` in `error-correction` activities,
-      so a future schema like `error: { text: "...", note: "..." }` would
+      misspellings stored under fields like `error:` or `errorWord:` in
+      `error-correction` activities, so a future schema like
+      `error: { text: "...", note: "..." }` would
       still be entirely excluded — not just the top-level string.
     - `keep(parent_key, string_value)`: leaf-level predicate, called for
       every string leaf NOT skipped by the subtree filter. Returns the
@@ -1276,13 +1277,14 @@ def _build_vesum_text(
 def _activity_vesum_text(activity: dict[str, Any]) -> str:
     """Walk an activity's string values, excluding intentional-error fields.
 
-    For `error-correction` activities, the `error:` field holds the typo the
-    student must fix; verifying it against VESUM would always fail. The skip
-    is at the dict (subtree) level so even a future nested shape like
-    `error: { text: "...", note: "..." }` would be entirely excluded.
+    For `error-correction` activities, fields like `error:` and `errorWord:`
+    hold the typo the student must fix; verifying them against VESUM would
+    always fail. The skip is at the dict (subtree) level so even a future
+    nested shape like `error: { text: "...", note: "..." }` would be entirely
+    excluded.
     """
     if activity.get("type") == _ERROR_CORRECTION_TYPE:
-        skip_subtree = frozenset({_ERROR_CORRECTION_INTENTIONAL_FIELD})
+        skip_subtree = _ERROR_CORRECTION_INTENTIONAL_FIELDS
     else:
         skip_subtree = frozenset()
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -764,6 +764,139 @@ def test_vesum_gate_skips_error_field_of_error_correction_activity(
     assert "прокидаєшся" in forwarded
 
 
+def test_vesum_gate_skips_error_word_field_of_error_correction_activity(
+    tmp_path: Path,
+) -> None:
+    """`errorWord` stores a deliberate typo and must not fail VESUM."""
+    module_dir, plan_path, _ = _passing_qg_fixture(tmp_path)
+    _write_yaml(
+        module_dir / "activities.yaml",
+        [
+            {
+                "id": "act-1",
+                "type": "error-correction",
+                "title": "Знайдіть помилку",
+                "items": [
+                    {
+                        "sentence": "Він ____ щодня.",
+                        "errorWord": "вмиваєця",
+                        "correctForm": "вмивається",
+                        "explanation": "Потрібна форма -ться.",
+                    },
+                    {
+                        "sentence": "Ти ____ швидко.",
+                        "error_word": "одягаєся",
+                        "correctForm": "одягаєшся",
+                        "explanation": "Потрібна форма -шся.",
+                    }
+                ],
+            }
+        ],
+    )
+
+    received: list[list[str]] = []
+
+    def fake_verify(words: list[str]) -> dict[str, list[dict]]:
+        received.append(list(words))
+        deliberate_errors = {"вмиваєця", "одягаєся"}
+        return {
+            word: []
+            if word in deliberate_errors
+            else [{"lemma": word, "pos": "x", "tags": ""}]
+            for word in words
+        }
+
+    report = linear_pipeline.run_python_qg(
+        module_dir, plan_path, verify_words_fn=fake_verify
+    )
+
+    assert report["gates"]["vesum_verified"]["passed"] is True
+    forwarded = received[0]
+    assert "вмиваєця" not in forwarded
+    assert "одягаєся" not in forwarded
+    assert "вмивається" in forwarded
+    assert "одягаєшся" in forwarded
+
+
+def test_vesum_gate_still_checks_correct_form_in_error_correction_activity(
+    tmp_path: Path,
+) -> None:
+    """`correctForm` is the learner's answer and must stay VESUM-verified."""
+    module_dir, plan_path, _ = _passing_qg_fixture(tmp_path)
+    _write_yaml(
+        module_dir / "activities.yaml",
+        [
+            {
+                "id": "act-1",
+                "type": "error-correction",
+                "title": "Знайдіть помилку",
+                "items": [
+                    {
+                        "sentence": "Він ____ щодня.",
+                        "errorWord": "вмиваєця",
+                        "correctForm": "вмиваєцявигадка",
+                        "explanation": "Потрібна форма -ться.",
+                    }
+                ],
+            }
+        ],
+    )
+
+    def fake_verify(words: list[str]) -> dict[str, list[dict]]:
+        return {
+            word: []
+            if word == "вмиваєцявигадка"
+            else [{"lemma": word, "pos": "x", "tags": ""}]
+            for word in words
+        }
+
+    report = linear_pipeline.run_python_qg(
+        module_dir, plan_path, verify_words_fn=fake_verify
+    )
+
+    gate = report["gates"]["vesum_verified"]
+    assert gate["passed"] is False
+    assert gate["missing"] == ["вмиваєцявигадка"]
+
+
+def test_vesum_gate_checks_error_word_outside_error_correction_activity(
+    tmp_path: Path,
+) -> None:
+    """The deliberate-error skip is scoped to error-correction activities."""
+    module_dir, plan_path, _ = _passing_qg_fixture(tmp_path)
+    _write_yaml(
+        module_dir / "activities.yaml",
+        [
+            {
+                "id": "act-1",
+                "type": "fill-in",
+                "title": "Додайте -ся",
+                "items": [
+                    {
+                        "sentence": "Він вмивається щодня.",
+                        "answer": "ся",
+                        "errorWord": "вмиваєця",
+                    }
+                ],
+            }
+        ],
+    )
+
+    def fake_verify(words: list[str]) -> dict[str, list[dict]]:
+        return {
+            word: [] if word == "вмиваєця" else [{"lemma": word, "pos": "x", "tags": ""}]
+            for word in words
+        }
+
+    report = linear_pipeline.run_python_qg(
+        module_dir, plan_path, verify_words_fn=fake_verify
+    )
+
+    gate = report["gates"]["vesum_verified"]
+    assert gate["passed"] is False
+    assert gate["missing"] == ["вмиваєця"]
+
+
 def test_vesum_gate_preserves_markdown_link_text(tmp_path: Path) -> None:
     """Markdown link text `[слово](url)` must reach VESUM, not be stripped.
 


### PR DESCRIPTION
## Summary

`run_python_qg`'s `vesum_verified` gate already skipped the legacy `error:` subtree for `error-correction` activities, but still VESUM-checked deliberate typo fields such as `errorWord` and `error_word`. This PR extends that activity-aware skip to those deliberate-error fields while leaving `correctForm` and all other activity text verified.

## Issue #1623 ACs

- Skips `errorWord`, `error_word`, and `error` values only when the enclosing activity has `type == \"error-correction\"`.
- Keeps `correctForm` VESUM-verified.
- Confirms typo fields that are not in VESUM do not fail the gate in error-correction activities.
- Confirms an invalid `correctForm` still fails the gate.
- Confirms non-error-correction activities still verify Ukrainian text in the same fields, so this is not a blanket activity skip.

## Tests Added

- `test_vesum_gate_skips_error_word_field_of_error_correction_activity`
- `test_vesum_gate_still_checks_correct_form_in_error_correction_activity`
- `test_vesum_gate_checks_error_word_outside_error_correction_activity`

## Verification

- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/build/` - passed
- `.venv/bin/pytest tests/build/test_linear_pipeline.py` - 49 passed
- Commit hook reran ruff + affected pytest file - passed

Closes #1623