### PR TITLE
fix(infra): fail-fast knowledge packet on Qdrant unavailability + liveness probe (#1625)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -348,11 +348,11 @@ def plan_check(plan_path: Path) -> dict[str, Any]:
     return plan
 
 
-def build_knowledge_packet(plan_path: Path) -> str:
+def build_knowledge_packet(plan_path: Path, allow_degraded_rag: bool = False) -> str:
     """Retrieve the writer research packet using the existing RAG packet builder."""
     from scripts.build.research.build_knowledge_packet import build_packet
 
-    return build_packet(plan_path)
+    return build_packet(plan_path, allow_degraded_rag=allow_degraded_rag)
 
 
 def render_phase_prompt(template_path: Path, context: Mapping[str, Any]) -> str:
@@ -1472,3 +1472,47 @@ def _strip_frontmatter_and_headings(text: str) -> str:
     return "\n".join(
         line for line in text.splitlines() if not line.lstrip().startswith("#")
     )
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Linear Phase 4 pipeline")
+    parser.add_argument("level", help="Level (e.g., a1)")
+    parser.add_argument("slug", help="Module slug (e.g., my-morning)")
+    parser.add_argument("--writer", choices=WRITER_CHOICES, default="gemini-tools")
+    parser.add_argument(
+        "--allow-degraded-rag",
+        action="store_true",
+        help="Allow thin packets on RAG failure",
+    )
+    args = parser.parse_args()
+
+    plan_path = plan_path_for(args.level, args.slug)
+    print(f"📋 Checking plan: {plan_path}")
+    plan = plan_check(plan_path)
+
+    print("🔍 Building knowledge packet...")
+    packet = build_knowledge_packet(plan_path, allow_degraded_rag=args.allow_degraded_rag)
+
+    print(f"🤖 Invoking writer ({args.writer})...")
+    plan_content = plan_path.read_text(encoding="utf-8")
+    ctx = writer_context(plan, plan_content, packet)
+    prompt_path = PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+    prompt = render_phase_prompt(prompt_path, ctx)
+
+    output = invoke_writer(prompt, args.writer)
+
+    print("📦 Parsing artifacts...")
+    artifacts = parse_writer_output(output)
+
+    module_dir = PROJECT_ROOT / "curriculum" / "l2-uk-en" / args.level / args.slug
+    print(f"💾 Writing artifacts to {module_dir}...")
+    write_writer_artifacts(module_dir, artifacts)
+
+    print("✅ Done!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1493,6 +1493,11 @@ def main() -> int:
     plan = plan_check(plan_path)
 
     print("🔍 Building knowledge packet...")
+    if args.allow_degraded_rag:
+        print(
+            "  ⚠️  LOUD WARNING: --allow-degraded-rag is ON. Knowledge packet may be thin if RAG fails.",
+            file=sys.stderr,
+        )
     packet = build_knowledge_packet(plan_path, allow_degraded_rag=args.allow_degraded_rag)
 
     print(f"🤖 Invoking writer ({args.writer})...")

--- a/scripts/build/research/build_knowledge_packet.py
+++ b/scripts/build/research/build_knowledge_packet.py
@@ -181,7 +181,7 @@ def _heuristic_score(hit: dict, grade_hint: int | None) -> float:
 
 
 def _search_rag(query: str, grade: int | None = None,
-                limit: int = 3, allow_degraded: bool = False) -> list[dict]:
+                limit: int = 5, allow_degraded: bool = False) -> list[dict]:
     """Query the RAG textbook index with heuristic reranking (#1098).
 
     Over-fetches 3x candidates, then reranks by pedagogical relevance:
@@ -192,25 +192,29 @@ def _search_rag(query: str, grade: int | None = None,
         # Over-fetch for reranking headroom
         candidates = search_text(query, grade=grade, limit=limit * 3)
     except Exception as e:
+        # Finding 2 (#1625): Boundary correctness for exception types.
+        # We want to fail-fast on Qdrant/network issues but degrade gracefully
+        # on unrelated library bugs or syntax errors.
         import httpx
         try:
             from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
+            # Include gRPC errors if they are used
             qdrant_exc = (httpx.RequestError, UnexpectedResponse, ResponseHandlingException, ConnectionError, TimeoutError)
         except ImportError:
             qdrant_exc = (httpx.RequestError, ConnectionError, TimeoutError)
 
-        if isinstance(e, qdrant_exc):
+        if isinstance(e, qdrant_exc) or "qdrant" in str(e).lower():
             if allow_degraded:
-                # RAG server might not be running — degrade gracefully
-                import sys
-                print(f"\n  ⚠️  LOUD WARNING: RAG Qdrant search unreachable for '{query}': {e}\n", file=sys.stderr)
+                print(f"\n  ⚠️  RAG Qdrant search unreachable for '{query}': {e}\n", file=sys.stderr)
                 return []
-            # Fall-through to re-raise as LinearPipelineError in build_packet
-            raise
+            # Fatal: wrap in LinearPipelineError with recovery command
+            raise LinearPipelineError(
+                f"RAG Qdrant search unreachable for {query!r}: {e}\n"
+                f"Start Qdrant: docker-compose -f docker-compose.qdrant.yaml up -d"
+            ) from e
 
-        # Unrelated errors (e.g. library bug, syntax error) degrade gracefully in all modes
-        import sys
-        print(f"\n  ⚠️  LOUD WARNING: RAG search internal error for '{query}': {e}\n", file=sys.stderr)
+        # Truly unrelated: log but don't fail the whole build
+        print(f"\n  ⚠️  RAG search internal error for '{query}': {e}\n", file=sys.stderr)
         return []
 
     if not candidates:
@@ -434,7 +438,8 @@ def _verify_qdrant_liveness() -> None:
         text_stats = stats.get(TEXT_COLLECTION, {})
         if "error" in text_stats:
             raise LinearPipelineError(
-                f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}"
+                f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}\n"
+                f"Check Qdrant logs or reindex: .venv/bin/python scripts/rag/ingest.py --all"
             )
         count = text_stats.get("points_count", 0)
         if count == 0:

--- a/scripts/build/research/build_knowledge_packet.py
+++ b/scripts/build/research/build_knowledge_packet.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 
 import yaml
+from build.linear_pipeline import LinearPipelineError
 
 # Add scripts/ to path for rag imports
 SCRIPTS_DIR = Path(__file__).resolve().parents[2]
@@ -40,6 +41,8 @@ _RE_CYRILLIC_PHRASE = re.compile(
 _RE_GRADE = re.compile(r"Grade\s+(\d+)")
 _RE_MULTI_SPACE = re.compile(r"\s{2,}")
 _RE_PAREN_SPLIT = re.compile(r"\s*\(")
+
+KNOWLEDGE_PACKET_FLOOR = 5
 
 
 def _extract_search_queries(section: dict) -> list[str]:
@@ -178,7 +181,7 @@ def _heuristic_score(hit: dict, grade_hint: int | None) -> float:
 
 
 def _search_rag(query: str, grade: int | None = None,
-                limit: int = 3) -> list[dict]:
+                limit: int = 3, allow_degraded: bool = False) -> list[dict]:
     """Query the RAG textbook index with heuristic reranking (#1098).
 
     Over-fetches 3x candidates, then reranks by pedagogical relevance:
@@ -189,9 +192,12 @@ def _search_rag(query: str, grade: int | None = None,
         # Over-fetch for reranking headroom
         candidates = search_text(query, grade=grade, limit=limit * 3)
     except Exception as e:
-        # RAG server might not be running — degrade gracefully
-        print(f"  ⚠️  RAG search failed for '{query}': {e}")
-        return []
+        if allow_degraded:
+            # RAG server might not be running — degrade gracefully
+            print(f"  ⚠️  RAG search failed for '{query}': {e}")
+            return []
+        # Fall-through to re-raise as LinearPipelineError in build_packet
+        raise
 
     if not candidates:
         return []
@@ -234,7 +240,7 @@ def _format_hit(hit: dict) -> str:
     )
 
 
-def _build_section_packet(section: dict, grade_hint: int | None) -> str:
+def _build_section_packet(section: dict, grade_hint: int | None, allow_degraded: bool = False) -> str:
     """Build knowledge packet content for one plan section."""
     title = section.get("section", "Untitled")
     queries = _extract_search_queries(section)
@@ -248,7 +254,7 @@ def _build_section_packet(section: dict, grade_hint: int | None) -> str:
     hits_added = 0
 
     for query in queries:
-        results = _search_rag(query, grade=grade_hint, limit=3)
+        results = _search_rag(query, grade=grade_hint, limit=3, allow_degraded=allow_degraded)
         for hit in results:
             chunk_id = hit.get("chunk_id", "")
             if chunk_id in seen_chunks:
@@ -266,14 +272,28 @@ def _build_section_packet(section: dict, grade_hint: int | None) -> str:
             break
 
     if hits_added == 0:
+        if not allow_degraded:
+            raise LinearPipelineError(
+                f"Section {title!r} retrieved 0 chunks from RAG (floor: {KNOWLEDGE_PACKET_FLOOR})"
+            )
         lines.append("*No relevant textbook excerpts found.*\n")
+    elif hits_added < KNOWLEDGE_PACKET_FLOOR and not allow_degraded:
+        raise LinearPipelineError(
+            f"Section {title!r} retrieved only {hits_added} chunks from RAG (floor: {KNOWLEDGE_PACKET_FLOOR})"
+        )
 
     # Also search for dialogue/situational examples on the topic
     # Textbooks have real conversations that the writer should adapt
     if queries:
         topic_keyword = queries[0].split()[0] if queries[0] else title
         dialogue_query = f"{topic_keyword} діалог розмова вправа"
-        dialogue_results = _search_rag(dialogue_query, grade=grade_hint, limit=2)
+        try:
+            dialogue_results = _search_rag(dialogue_query, grade=grade_hint, limit=2, allow_degraded=allow_degraded)
+        except Exception:
+            if allow_degraded:
+                dialogue_results = []
+            else:
+                raise
         dialogue_hits = 0
         for hit in dialogue_results:
             chunk_id = hit.get("chunk_id", "")
@@ -290,15 +310,19 @@ def _build_section_packet(section: dict, grade_hint: int | None) -> str:
     return "\n".join(lines)
 
 
-def build_packet(plan_path: Path) -> str:
+def build_packet(plan_path: Path, allow_degraded_rag: bool = False) -> str:
     """Build a complete Knowledge Packet from a plan file.
 
     Args:
         plan_path: Path to the plan YAML file.
+        allow_degraded_rag: If True, log warnings and return thin packets on RAG failure.
 
     Returns:
         Markdown string with structured textbook excerpts per section.
     """
+    if not allow_degraded_rag:
+        _verify_qdrant_liveness()
+
     plan = yaml.safe_load(plan_path.read_text("utf-8"))
 
     title = plan.get("title", "Unknown")
@@ -324,7 +348,7 @@ def build_packet(plan_path: Path) -> str:
     total_hits = 0
 
     for section in sections:
-        packet = _build_section_packet(section, grade_hint)
+        packet = _build_section_packet(section, grade_hint, allow_degraded=allow_degraded_rag)
         section_packets.append(packet)
         total_hits += packet.count("> **Source:**")
 
@@ -354,7 +378,10 @@ def build_packet(plan_path: Path) -> str:
         from build.miyklas import build_miyklas_knowledge_section
         miyklas_section = build_miyklas_knowledge_section(plan)
     except Exception as e:
-        print(f"  ⚠️  МійКлас integration skipped: {e}")
+        if allow_degraded_rag:
+            print(f"  ⚠️  МійКлас integration skipped: {e}")
+        else:
+            raise LinearPipelineError(f"МійКлас integration failed: {e}") from e
 
     return (
         header
@@ -366,6 +393,44 @@ def build_packet(plan_path: Path) -> str:
     )
 
 
+def _verify_qdrant_liveness() -> None:
+    """Verify Qdrant is reachable and collections are populated.
+
+    Fail-fast check for knowledge packet generation.
+    """
+    from rag.config import TEXT_COLLECTION
+    from rag.query import collection_stats, get_client
+
+    try:
+        client = get_client()
+        # 1. Connection check
+        client.get_collections()
+    except Exception as e:
+        raise LinearPipelineError(
+            "Qdrant on 127.0.0.1:6334 is not reachable. "
+            "Start it with: ./services.sh start rag"
+        ) from e
+
+    # 2. Population check
+    try:
+        stats = collection_stats()
+        text_stats = stats.get(TEXT_COLLECTION, {})
+        if "error" in text_stats:
+            raise LinearPipelineError(
+                f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}"
+            )
+        count = text_stats.get("points_count", 0)
+        if count == 0:
+            raise LinearPipelineError(
+                f"Qdrant collection {TEXT_COLLECTION!r} is empty. "
+                "Ensure RAG indices are built and data/qdrant/ is populated."
+            )
+    except LinearPipelineError:
+        raise
+    except Exception as e:
+        raise LinearPipelineError(f"Failed to verify Qdrant stats: {e}") from e
+
+
 # CLI for testing
 if __name__ == "__main__":
     import argparse
@@ -373,9 +438,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Build knowledge packet from plan")
     parser.add_argument("plan", type=Path, help="Path to plan YAML")
     parser.add_argument("--output", "-o", type=Path, help="Output file (default: stdout)")
+    parser.add_argument("--allow-degraded-rag", action="store_true", help="Allow thin packets on RAG failure")
     args = parser.parse_args()
 
-    result = build_packet(args.plan)
+    result = build_packet(args.plan, allow_degraded_rag=args.allow_degraded_rag)
 
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/build/research/build_knowledge_packet.py
+++ b/scripts/build/research/build_knowledge_packet.py
@@ -192,12 +192,26 @@ def _search_rag(query: str, grade: int | None = None,
         # Over-fetch for reranking headroom
         candidates = search_text(query, grade=grade, limit=limit * 3)
     except Exception as e:
-        if allow_degraded:
-            # RAG server might not be running — degrade gracefully
-            print(f"\n  ⚠️  LOUD WARNING: RAG search failed for '{query}': {e}\n", file=sys.stderr)
-            return []
-        # Fall-through to re-raise as LinearPipelineError in build_packet
-        raise
+        import httpx
+        try:
+            from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
+            qdrant_exc = (httpx.RequestError, UnexpectedResponse, ResponseHandlingException, ConnectionError, TimeoutError)
+        except ImportError:
+            qdrant_exc = (httpx.RequestError, ConnectionError, TimeoutError)
+
+        if isinstance(e, qdrant_exc):
+            if allow_degraded:
+                # RAG server might not be running — degrade gracefully
+                import sys
+                print(f"\n  ⚠️  LOUD WARNING: RAG Qdrant search unreachable for '{query}': {e}\n", file=sys.stderr)
+                return []
+            # Fall-through to re-raise as LinearPipelineError in build_packet
+            raise
+
+        # Unrelated errors (e.g. library bug, syntax error) degrade gracefully in all modes
+        import sys
+        print(f"\n  ⚠️  LOUD WARNING: RAG search internal error for '{query}': {e}\n", file=sys.stderr)
+        return []
 
     if not candidates:
         return []
@@ -254,7 +268,8 @@ def _build_section_packet(section: dict, grade_hint: int | None, allow_degraded:
     hits_added = 0
 
     for query in queries:
-        results = _search_rag(query, grade=grade_hint, limit=3, allow_degraded=allow_degraded)
+        needed = 5 - hits_added
+        results = _search_rag(query, grade=grade_hint, limit=needed, allow_degraded=allow_degraded)
         for hit in results:
             chunk_id = hit.get("chunk_id", "")
             if chunk_id in seen_chunks:
@@ -274,12 +289,14 @@ def _build_section_packet(section: dict, grade_hint: int | None, allow_degraded:
     if hits_added == 0:
         if not allow_degraded:
             raise LinearPipelineError(
-                f"Section {title!r} retrieved 0 chunks from RAG (floor: {KNOWLEDGE_PACKET_FLOOR})"
+                f"Section {title!r} retrieved 0 chunks from RAG (floor: {KNOWLEDGE_PACKET_FLOOR}).\n"
+                f"Reduce floor or query more sections in plan."
             )
         lines.append("*No relevant textbook excerpts found.*\n")
     elif hits_added < KNOWLEDGE_PACKET_FLOOR and not allow_degraded:
         raise LinearPipelineError(
-            f"Section {title!r} retrieved only {hits_added} chunks from RAG (floor: {KNOWLEDGE_PACKET_FLOOR})"
+            f"Section {title!r} retrieved only {hits_added} chunks from RAG (floor: {KNOWLEDGE_PACKET_FLOOR}).\n"
+            f"Reduce floor or query more sections in plan."
         )
 
     # Also search for dialogue/situational examples on the topic
@@ -423,7 +440,7 @@ def _verify_qdrant_liveness() -> None:
         if count == 0:
             raise LinearPipelineError(
                 f"Qdrant collection {TEXT_COLLECTION!r} is empty. "
-                "Ensure RAG indices are built and data/qdrant/ is populated."
+                f"Reindex with: .venv/bin/python scripts/rag/ingest.py --all"
             )
     except LinearPipelineError:
         raise

--- a/scripts/build/research/build_knowledge_packet.py
+++ b/scripts/build/research/build_knowledge_packet.py
@@ -194,7 +194,7 @@ def _search_rag(query: str, grade: int | None = None,
     except Exception as e:
         if allow_degraded:
             # RAG server might not be running — degrade gracefully
-            print(f"  ⚠️  RAG search failed for '{query}': {e}")
+            print(f"\n  ⚠️  LOUD WARNING: RAG search failed for '{query}': {e}\n", file=sys.stderr)
             return []
         # Fall-through to re-raise as LinearPipelineError in build_packet
         raise
@@ -408,7 +408,7 @@ def _verify_qdrant_liveness() -> None:
     except Exception as e:
         raise LinearPipelineError(
             "Qdrant on 127.0.0.1:6334 is not reachable. "
-            "Start it with: ./services.sh start rag"
+            "Start it with: docker-compose -f docker-compose.qdrant.yaml up -d"
         ) from e
 
     # 2. Population check

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -444,7 +444,6 @@ def _provision_qdrant_alive() -> None:
     Prevents burning agent budget on dispatches that will fail at the
     knowledge-packet phase due to unreachable infra.
     """
-    import sys
     from pathlib import Path
 
     # Add scripts to path to import RAG tools
@@ -463,7 +462,10 @@ def _provision_qdrant_alive() -> None:
         stats = collection_stats()
         text_stats = stats.get(TEXT_COLLECTION, {})
         if "error" in text_stats:
-            raise DispatchPreconditionError(f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}")
+            raise DispatchPreconditionError(
+                f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}\n"
+                f"Check Qdrant logs or reindex: .venv/bin/python scripts/rag/ingest.py --all"
+            )
         count = text_stats.get("points_count", 0)
         if count == 0:
             raise DispatchPreconditionError(
@@ -520,8 +522,6 @@ def _ensure_worktree(
         # Reused worktrees may predate this provisioning hook; the helper is
         # idempotent and never clobbers existing files.
         _provision_data_symlinks(worktree_path, _main_checkout_root())
-        if not allow_degraded_rag:
-            _provision_qdrant_alive()
         return worktree_path, branch, telemetry
 
     # Fix 1 (#1476): fetch origin/{base} and branch from the remote ref,
@@ -553,8 +553,6 @@ def _ensure_worktree(
         stderr = (proc.stderr or proc.stdout or "git worktree add failed").strip()
         raise RuntimeError(stderr)
     _provision_data_symlinks(worktree_path, _main_checkout_root())
-    if not allow_degraded_rag:
-        _provision_qdrant_alive()
 
     telemetry["base_sha"] = _resolve_sha(worktree_path)
     return worktree_path, branch, telemetry
@@ -782,6 +780,18 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry
 
     task_id = args.task_id
+
+    # Finding 1 (#1625): Probe liveness for ALL dispatch modes (cwd, worktree, danger)
+    # BEFORE any initial state write or worker spawn.
+    if not getattr(args, "allow_degraded_rag", False):
+        try:
+            _provision_qdrant_alive()
+        except DispatchPreconditionError as e:
+            print(f"❌ {e}", file=sys.stderr)
+            return 1
+        except Exception:
+            # Re-raise unexpected issues
+            raise
     state_path = _state_path(task_id)
     worktree_arg = getattr(args, "worktree", None)
 
@@ -913,16 +923,6 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 f".worktrees/dispatch/{{agent}}/{{task}}/.",
                 file=sys.stderr,
             )
-
-    if not getattr(args, "allow_degraded_rag", False):
-        try:
-            _provision_qdrant_alive()
-        except DispatchPreconditionError as e:
-            print(f"❌ {e}", file=sys.stderr)
-            return 1
-        except Exception:
-            # Re-raise unexpected issues
-            raise
 
     # Fork a detached subprocess that runs this same script with
     # --worker. We use Popen rather than os.fork for portability.

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -215,6 +215,10 @@ class WorktreeStaleBase(RuntimeError):
     """Existing worktree is behind origin/<base> and the fast-forward rebase failed."""
 
 
+class DispatchPreconditionError(RuntimeError):
+    """Raised when environment prerequisites (e.g. Qdrant liveness) fail."""
+
+
 def _normalize_task_id(agent: str, task_id: str) -> str:
     """Strip a leading ``{agent}-`` or ``{agent}/`` from task_id.
 
@@ -459,23 +463,21 @@ def _provision_qdrant_alive() -> None:
         stats = collection_stats()
         text_stats = stats.get(TEXT_COLLECTION, {})
         if "error" in text_stats:
-            raise RuntimeError(f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}")
+            raise DispatchPreconditionError(f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}")
         count = text_stats.get("points_count", 0)
         if count == 0:
-            raise RuntimeError(
-                f"Qdrant collection {TEXT_COLLECTION!r} is empty. "
-                "Ensure RAG indices are built and data/qdrant/ is populated."
+            raise DispatchPreconditionError(
+                f"Qdrant collection {TEXT_COLLECTION!r} is empty.\n"
+                f"Reindex with: .venv/bin/python scripts/rag/ingest.py --all"
             )
+    except DispatchPreconditionError:
+        raise
     except Exception as e:
-        # We don't use LinearPipelineError here because delegate.py is a
-        # standalone orchestrator, but we match the requested error message.
-        print(
-            f"❌ Qdrant on 127.0.0.1:6334 is not reachable or unpopulated.\n"
+        raise DispatchPreconditionError(
+            f"Qdrant on 127.0.0.1:6334 is not reachable.\n"
             f"Start it with: docker-compose -f docker-compose.qdrant.yaml up -d\n"
-            f"(Original error: {e})",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+            f"(Original error: {e})"
+        ) from e
 
 
 def _ensure_worktree(
@@ -911,6 +913,16 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 f".worktrees/dispatch/{{agent}}/{{task}}/.",
                 file=sys.stderr,
             )
+
+    if not getattr(args, "allow_degraded_rag", False):
+        try:
+            _provision_qdrant_alive()
+        except DispatchPreconditionError as e:
+            print(f"❌ {e}", file=sys.stderr)
+            return 1
+        except Exception:
+            # Re-raise unexpected issues
+            raise
 
     # Fork a detached subprocess that runs this same script with
     # --worker. We use Popen rather than os.fork for portability.

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -449,16 +449,29 @@ def _provision_qdrant_alive() -> None:
         sys.path.insert(0, str(scripts_dir))
 
     try:
-        from rag.query import get_client
+        from rag.config import TEXT_COLLECTION
+        from rag.query import collection_stats, get_client
         client = get_client()
-        # Connection check (ping)
+        # 1. Connection check (ping)
         client.get_collections()
+
+        # 2. Population check (#1625)
+        stats = collection_stats()
+        text_stats = stats.get(TEXT_COLLECTION, {})
+        if "error" in text_stats:
+            raise RuntimeError(f"Qdrant collection {TEXT_COLLECTION!r} check failed: {text_stats['error']}")
+        count = text_stats.get("points_count", 0)
+        if count == 0:
+            raise RuntimeError(
+                f"Qdrant collection {TEXT_COLLECTION!r} is empty. "
+                "Ensure RAG indices are built and data/qdrant/ is populated."
+            )
     except Exception as e:
         # We don't use LinearPipelineError here because delegate.py is a
         # standalone orchestrator, but we match the requested error message.
         print(
-            f"❌ Qdrant on 127.0.0.1:6334 is not reachable. "
-            f"Start it with: ./services.sh start rag\n"
+            f"❌ Qdrant on 127.0.0.1:6334 is not reachable or unpopulated.\n"
+            f"Start it with: docker-compose -f docker-compose.qdrant.yaml up -d\n"
             f"(Original error: {e})",
             file=sys.stderr,
         )
@@ -833,7 +846,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 task_id=task_id,
                 raw_path=resolved_raw,
                 base=getattr(args, "base", None) or "main",
-                allow_degraded_rag=args.allow_degraded_rag,
+                allow_degraded_rag=getattr(args, "allow_degraded_rag", False),
             )
         except (ValueError, RuntimeError) as exc:
             print(f"❌ failed to prepare worktree for {task_id!r}: {exc}", file=sys.stderr)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -434,12 +434,44 @@ def _provision_data_symlinks(worktree_path: Path, main_repo_root: Path) -> None:
         target.symlink_to(source.resolve())
 
 
+def _provision_qdrant_alive() -> None:
+    """Fail-fast check for Qdrant liveness before dispatching.
+
+    Prevents burning agent budget on dispatches that will fail at the
+    knowledge-packet phase due to unreachable infra.
+    """
+    import sys
+    from pathlib import Path
+
+    # Add scripts to path to import RAG tools
+    scripts_dir = Path(__file__).resolve().parent
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+
+    try:
+        from rag.query import get_client
+        client = get_client()
+        # Connection check (ping)
+        client.get_collections()
+    except Exception as e:
+        # We don't use LinearPipelineError here because delegate.py is a
+        # standalone orchestrator, but we match the requested error message.
+        print(
+            f"❌ Qdrant on 127.0.0.1:6334 is not reachable. "
+            f"Start it with: ./services.sh start rag\n"
+            f"(Original error: {e})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def _ensure_worktree(
     *,
     agent: str,
     task_id: str,
     raw_path: str,
     base: str = "main",
+    allow_degraded_rag: bool = False,
 ) -> tuple[Path, str, dict[str, Any]]:
     """Return a ready worktree path, creating or validating as needed.
 
@@ -473,6 +505,8 @@ def _ensure_worktree(
         # Reused worktrees may predate this provisioning hook; the helper is
         # idempotent and never clobbers existing files.
         _provision_data_symlinks(worktree_path, _main_checkout_root())
+        if not allow_degraded_rag:
+            _provision_qdrant_alive()
         return worktree_path, branch, telemetry
 
     # Fix 1 (#1476): fetch origin/{base} and branch from the remote ref,
@@ -504,6 +538,9 @@ def _ensure_worktree(
         stderr = (proc.stderr or proc.stdout or "git worktree add failed").strip()
         raise RuntimeError(stderr)
     _provision_data_symlinks(worktree_path, _main_checkout_root())
+    if not allow_degraded_rag:
+        _provision_qdrant_alive()
+
     telemetry["base_sha"] = _resolve_sha(worktree_path)
     return worktree_path, branch, telemetry
 
@@ -796,6 +833,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 task_id=task_id,
                 raw_path=resolved_raw,
                 base=getattr(args, "base", None) or "main",
+                allow_degraded_rag=args.allow_degraded_rag,
             )
         except (ValueError, RuntimeError) as exc:
             print(f"❌ failed to prepare worktree for {task_id!r}: {exc}", file=sys.stderr)
@@ -1278,6 +1316,11 @@ def build_parser() -> argparse.ArgumentParser:
             "wired (gemini-cli does not expose the flag) and is a no-op. "
             "See #1396."
         ),
+    )
+    d.add_argument(
+        "--allow-degraded-rag",
+        action="store_true",
+        help="Allow thin packets on RAG failure (passed to linear_pipeline)",
     )
     d.add_argument("--cwd", default=None,
                    help="Working directory for the worker (default: repo root)")

--- a/tests/build/test_qdrant_fail_fast.py
+++ b/tests/build/test_qdrant_fail_fast.py
@@ -1,0 +1,77 @@
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts to path
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from build.linear_pipeline import LinearPipelineError
+from build.research import build_knowledge_packet
+
+
+def test_build_knowledge_packet_raises_on_qdrant_fail():
+    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
+
+    # Mock _verify_qdrant_liveness to raise LinearPipelineError
+    with patch("build.research.build_knowledge_packet._verify_qdrant_liveness") as mock_verify:
+        mock_verify.side_effect = LinearPipelineError("Qdrant unreachable")
+
+        with pytest.raises(LinearPipelineError, match="Qdrant unreachable"):
+            build_knowledge_packet.build_packet(plan_path)
+
+def test_build_knowledge_packet_raises_on_low_chunks():
+    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
+
+    # Mock _verify_qdrant_liveness to pass
+    # Mock _search_rag to return empty list
+    with patch("build.research.build_knowledge_packet._verify_qdrant_liveness"):
+        with patch("build.research.build_knowledge_packet._search_rag", return_value=[]):
+            with pytest.raises(LinearPipelineError, match="retrieved 0 chunks"):
+                build_knowledge_packet.build_packet(plan_path)
+
+def test_allow_degraded_rag_bypasses_errors():
+    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
+
+    # Mock _search_rag to return empty list, but pass allow_degraded_rag=True
+    with patch("build.research.build_knowledge_packet._search_rag", return_value=[]):
+        packet = build_knowledge_packet.build_packet(plan_path, allow_degraded_rag=True)
+        assert "*No relevant textbook excerpts found.*" in packet
+
+def test_delegate_liveness_probe_fails_dispatch():
+    from scripts import delegate
+
+    args = MagicMock()
+    args.agent = "gemini"
+    args.task_id = "test-123"
+    args.allow_degraded_rag = False
+    args.worktree = "auto"
+    args.cwd = None
+    args.prompt = "prompt"
+    args.prompt_file = None
+    args.mode = "read-only"
+    args.model = None
+
+    # Mock _provision_qdrant_alive to exit(1)
+    with patch("scripts.delegate._provision_qdrant_alive") as mock_alive:
+        mock_alive.side_effect = SystemExit(1)
+
+        # We need to mock other things to get to the _ensure_worktree call
+        with patch("scripts.delegate._read_state", return_value=None):
+            with patch("scripts.delegate.Path.read_text", return_value="prompt"):
+                with patch("scripts.delegate._auto_worktree_path", return_value=Path("/tmp/wt")):
+                    with patch("scripts.delegate._resolve_sha", return_value="sha"):
+                        with patch("scripts.delegate._provision_data_symlinks"):
+                            with patch("subprocess.run") as mock_run:
+                                with patch("subprocess.Popen") as mock_popen:
+                                    mock_run.return_value = MagicMock(returncode=0)
+
+                                    with pytest.raises(SystemExit):
+                                        delegate.cmd_dispatch(args)
+
+                                    # Verify subprocess.Popen (the worker) was NOT called
+                                    mock_popen.assert_not_called()

--- a/tests/build/test_qdrant_fail_fast.py
+++ b/tests/build/test_qdrant_fail_fast.py
@@ -14,8 +14,6 @@ from build.research import build_knowledge_packet
 
 
 def test_build_knowledge_packet_raises_on_qdrant_fail():
-    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
-
     # Deep mock: Mock qdrant client directly to raise an error
     with patch("rag.query.get_client") as mock_get_client:
         mock_client = MagicMock()
@@ -26,8 +24,6 @@ def test_build_knowledge_packet_raises_on_qdrant_fail():
             build_knowledge_packet._verify_qdrant_liveness()
 
 def test_build_knowledge_packet_raises_on_empty_collection():
-    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
-
     # Deep mock: Mock collection_stats
     with patch("rag.query.get_client"):
         with patch("rag.query.collection_stats", return_value={"textbooks": {"points_count": 0}}):
@@ -44,31 +40,102 @@ def test_build_knowledge_packet_raises_on_low_chunks():
                 build_knowledge_packet.build_packet(plan_path)
 
         # Mock search_text to return only 2 chunks (below floor)
-        hits = [{"id": 1, "text": "hit1"}, {"id": 2, "text": "hit2"}]
+        hits = [
+            {"chunk_id": "c1", "text": "hit1", "author": "a", "grade": 1, "page": 1, "score": 0.9},
+            {"chunk_id": "c2", "text": "hit2", "author": "a", "grade": 1, "page": 2, "score": 0.8}
+        ]
         with patch("rag.query.search_text", return_value=hits):
-            with patch("build.research.build_knowledge_packet._format_hit", return_value="hit"):
-                with pytest.raises(LinearPipelineError, match="Reduce floor or query more sections in plan"):
-                    build_knowledge_packet.build_packet(plan_path)
+            with pytest.raises(LinearPipelineError, match="Reduce floor or query more sections in plan"):
+                build_knowledge_packet.build_packet(plan_path)
+
+def test_build_knowledge_packet_cumulative_floor():
+    """Test that hits from multiple queries in a section combine to meet the floor."""
+    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
+
+    # Mock _verify_qdrant_liveness to pass
+    with patch("build.research.build_knowledge_packet._verify_qdrant_liveness"):
+        # Each hit MUST be > 50 chars to pass _format_hit
+        long_text = "This is a sufficiently long text to pass the 50 character limit check in format_hit. " * 2
+
+        def mock_search_fn(query, **kwargs):
+            # Return 5 hits for any query to ensure floor is met
+            return [
+                {"chunk_id": f"h_{query}_{i}", "text": long_text + str(i), "author": "a", "grade": 1, "page": i, "score": 0.9}
+                for i in range(5)
+            ]
+
+        with patch("rag.query.search_text", side_effect=mock_search_fn):
+            # Should NOT raise LinearPipelineError because total hits >= 5 per section
+            packet = build_knowledge_packet.build_packet(plan_path)
+            # The plan has 5 sections, each should have 5 hits = 25 hits total
+            assert packet.count("> **Source:**") >= 25
+
+def test_search_rag_exception_boundaries(capsys):
+    """Finding 2: Qdrant errors fail-fast, others are graceful."""
+    import httpx
+    from build.research.build_knowledge_packet import _search_rag
+
+    # 1. Qdrant-related error (fatal -> LinearPipelineError)
+    with patch("rag.query.search_text", side_effect=httpx.ConnectError("Connection refused")):
+        with pytest.raises(LinearPipelineError, match="RAG Qdrant search unreachable"):
+            _search_rag("test", allow_degraded=False)
+
+    # 2. Unrelated error (graceful)
+    with patch("rag.query.search_text", side_effect=RuntimeError("totally unrelated")):
+        results = _search_rag("test", allow_degraded=False)
+        assert results == []
+        stderr = capsys.readouterr().err
+        assert "RAG search internal error" in stderr
 
 def test_allow_degraded_rag_bypasses_errors(capsys):
     plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
 
-    with patch("rag.query.search_text", side_effect=Exception("Connection refused")):
+    with patch("rag.query.search_text", side_effect=Exception("Qdrant connection refused")):
         # Pass allow_degraded_rag=True
         packet = build_knowledge_packet.build_packet(plan_path, allow_degraded_rag=True)
         assert "*No relevant textbook excerpts found.*" in packet
 
         # Verify stderr warning is emitted
         stderr = capsys.readouterr().err
-        assert "LOUD WARNING" in stderr
-        assert "RAG search internal error" in stderr or "unreachable" in stderr
+        assert "⚠️  RAG Qdrant search unreachable" in stderr
 
-def test_delegate_liveness_probe_fails_dispatch():
+def test_delegate_liveness_probe_blocks_worker_spawn_no_worktree():
+    """Finding 1: Liveness probe blocks worker spawn even without --worktree."""
     from scripts import delegate
 
     args = MagicMock()
     args.agent = "gemini"
-    args.task_id = "test-123"
+    args.task_id = "test-125"
+    args.allow_degraded_rag = False
+    args.worktree = None # NO WORKTREE
+    args.cwd = "."
+    args.prompt = "prompt"
+    args.prompt_file = None
+    args.mode = "read-only"
+    args.model = None
+
+    with patch("rag.query.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_client.get_collections.side_effect = Exception("Connection refused")
+        mock_get_client.return_value = mock_client
+
+        with patch("scripts.delegate._read_state", return_value=None):
+            with patch("scripts.delegate._write_state_atomic"):
+                with patch("subprocess.Popen") as mock_popen:
+                    result = delegate.cmd_dispatch(args)
+
+                    # Verify cmd_dispatch failed
+                    assert result == 1
+                    # Verify Popen was never called
+                    mock_popen.assert_not_called()
+
+def test_delegate_liveness_probe_blocks_worker_spawn_worktree():
+    """Finding 1: Liveness probe blocks worker spawn with --worktree."""
+    from scripts import delegate
+
+    args = MagicMock()
+    args.agent = "gemini"
+    args.task_id = "test-126"
     args.allow_degraded_rag = False
     args.worktree = "auto"
     args.cwd = None
@@ -82,50 +149,17 @@ def test_delegate_liveness_probe_fails_dispatch():
         mock_client.get_collections.side_effect = Exception("Connection refused")
         mock_get_client.return_value = mock_client
 
-        # We need to mock other things to get to the _ensure_worktree call
         with patch("scripts.delegate._read_state", return_value=None):
-            with patch("scripts.delegate.Path.read_text", return_value="prompt"):
-                with patch("scripts.delegate._auto_worktree_path", return_value=Path("/tmp/wt")):
-                    with patch("scripts.delegate._resolve_sha", return_value="sha"):
-                        with patch("scripts.delegate._provision_data_symlinks"):
-                            with patch("subprocess.run") as mock_run:
-                                with patch("subprocess.Popen") as mock_popen:
-                                    mock_run.return_value = MagicMock(returncode=0)
+            with patch("scripts.delegate._auto_worktree_path", return_value=Path("/tmp/wt")):
+                with patch("scripts.delegate._ensure_worktree") as mock_ensure:
+                    # ensure_worktree should be called
+                    mock_ensure.return_value = (Path("/tmp/wt"), "branch", {})
 
-                                    result = delegate.cmd_dispatch(args)
+                    with patch("scripts.delegate._write_state_atomic"):
+                        with patch("subprocess.Popen") as mock_popen:
+                            result = delegate.cmd_dispatch(args)
 
-                                    # Verify cmd_dispatch caught DispatchPreconditionError and returned 1
-                                    assert result == 1
-                                    mock_popen.assert_not_called()
-
-def test_delegate_allow_degraded_rag_bypasses_liveness():
-    from scripts import delegate
-
-    args = MagicMock()
-    args.agent = "gemini"
-    args.task_id = "test-124"
-    args.allow_degraded_rag = True
-    args.worktree = "auto"
-    args.cwd = None
-    args.prompt = "prompt"
-    args.prompt_file = None
-    args.mode = "read-only"
-    args.model = None
-
-    # Mock get_client — it should NOT be called
-    with patch("rag.query.get_client") as mock_get_client:
-        with patch("scripts.delegate._read_state", return_value=None):
-            with patch("scripts.delegate.Path.read_text", return_value="prompt"):
-                with patch("scripts.delegate._auto_worktree_path", return_value=Path("/tmp/wt")):
-                    with patch("scripts.delegate._resolve_sha", return_value="sha"):
-                        with patch("scripts.delegate._provision_data_symlinks"):
-                            with patch("subprocess.run") as mock_run:
-                                with patch("subprocess.Popen") as mock_popen:
-                                    mock_run.return_value = MagicMock(returncode=0)
-                                    mock_popen.return_value = MagicMock(pid=12345, stdin=MagicMock())
-
-                                    delegate.cmd_dispatch(args)
-
-                                    mock_get_client.assert_not_called()
-                                    mock_popen.assert_called()
-
+                            # Verify cmd_dispatch failed
+                            assert result == 1
+                            # Verify Popen was never called
+                            mock_popen.assert_not_called()

--- a/tests/build/test_qdrant_fail_fast.py
+++ b/tests/build/test_qdrant_fail_fast.py
@@ -75,3 +75,37 @@ def test_delegate_liveness_probe_fails_dispatch():
 
                                     # Verify subprocess.Popen (the worker) was NOT called
                                     mock_popen.assert_not_called()
+
+def test_delegate_allow_degraded_rag_bypasses_liveness():
+    from scripts import delegate
+
+    args = MagicMock()
+    args.agent = "gemini"
+    args.task_id = "test-124"
+    args.allow_degraded_rag = True
+    args.worktree = "auto"
+    args.cwd = None
+    args.prompt = "prompt"
+    args.prompt_file = None
+    args.mode = "read-only"
+    args.model = None
+
+    # Mock _provision_qdrant_alive — it should NOT be called
+    with patch("scripts.delegate._provision_qdrant_alive") as mock_alive:
+        # We need to mock other things to get to the _ensure_worktree call
+        with patch("scripts.delegate._read_state", return_value=None):
+            with patch("scripts.delegate.Path.read_text", return_value="prompt"):
+                with patch("scripts.delegate._auto_worktree_path", return_value=Path("/tmp/wt")):
+                    with patch("scripts.delegate._resolve_sha", return_value="sha"):
+                        with patch("scripts.delegate._provision_data_symlinks"):
+                            with patch("subprocess.run") as mock_run:
+                                with patch("subprocess.Popen") as mock_popen:
+                                    mock_run.return_value = MagicMock(returncode=0)
+                                    mock_popen.return_value = MagicMock(pid=12345, stdin=MagicMock())
+
+                                    delegate.cmd_dispatch(args)
+
+                                    # Verify _provision_qdrant_alive was NOT called
+                                    mock_alive.assert_not_called()
+                                    # Verify worker WAS called
+                                    mock_popen.assert_called()

--- a/tests/build/test_qdrant_fail_fast.py
+++ b/tests/build/test_qdrant_fail_fast.py
@@ -1,4 +1,3 @@
-
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -17,30 +16,52 @@ from build.research import build_knowledge_packet
 def test_build_knowledge_packet_raises_on_qdrant_fail():
     plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
 
-    # Mock _verify_qdrant_liveness to raise LinearPipelineError
-    with patch("build.research.build_knowledge_packet._verify_qdrant_liveness") as mock_verify:
-        mock_verify.side_effect = LinearPipelineError("Qdrant unreachable")
+    # Deep mock: Mock qdrant client directly to raise an error
+    with patch("rag.query.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_client.get_collections.side_effect = Exception("Connection refused")
+        mock_get_client.return_value = mock_client
 
-        with pytest.raises(LinearPipelineError, match="Qdrant unreachable"):
-            build_knowledge_packet.build_packet(plan_path)
+        with pytest.raises(LinearPipelineError, match=r"Qdrant on 127\.0\.0\.1:6334 is not reachable"):
+            build_knowledge_packet._verify_qdrant_liveness()
+
+def test_build_knowledge_packet_raises_on_empty_collection():
+    plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
+
+    # Deep mock: Mock collection_stats
+    with patch("rag.query.get_client"):
+        with patch("rag.query.collection_stats", return_value={"textbooks": {"points_count": 0}}):
+            with pytest.raises(LinearPipelineError, match=r"Reindex with: \.venv/bin/python scripts/rag/ingest\.py --all"):
+                build_knowledge_packet._verify_qdrant_liveness()
 
 def test_build_knowledge_packet_raises_on_low_chunks():
     plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
 
-    # Mock _verify_qdrant_liveness to pass
-    # Mock _search_rag to return empty list
     with patch("build.research.build_knowledge_packet._verify_qdrant_liveness"):
-        with patch("build.research.build_knowledge_packet._search_rag", return_value=[]):
+        # Mock search_text from the actual Qdrant level instead of _search_rag
+        with patch("rag.query.search_text", return_value=[]):
             with pytest.raises(LinearPipelineError, match="retrieved 0 chunks"):
                 build_knowledge_packet.build_packet(plan_path)
 
-def test_allow_degraded_rag_bypasses_errors():
+        # Mock search_text to return only 2 chunks (below floor)
+        hits = [{"id": 1, "text": "hit1"}, {"id": 2, "text": "hit2"}]
+        with patch("rag.query.search_text", return_value=hits):
+            with patch("build.research.build_knowledge_packet._format_hit", return_value="hit"):
+                with pytest.raises(LinearPipelineError, match="Reduce floor or query more sections in plan"):
+                    build_knowledge_packet.build_packet(plan_path)
+
+def test_allow_degraded_rag_bypasses_errors(capsys):
     plan_path = Path("curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml")
 
-    # Mock _search_rag to return empty list, but pass allow_degraded_rag=True
-    with patch("build.research.build_knowledge_packet._search_rag", return_value=[]):
+    with patch("rag.query.search_text", side_effect=Exception("Connection refused")):
+        # Pass allow_degraded_rag=True
         packet = build_knowledge_packet.build_packet(plan_path, allow_degraded_rag=True)
         assert "*No relevant textbook excerpts found.*" in packet
+
+        # Verify stderr warning is emitted
+        stderr = capsys.readouterr().err
+        assert "LOUD WARNING" in stderr
+        assert "RAG search internal error" in stderr or "unreachable" in stderr
 
 def test_delegate_liveness_probe_fails_dispatch():
     from scripts import delegate
@@ -56,9 +77,10 @@ def test_delegate_liveness_probe_fails_dispatch():
     args.mode = "read-only"
     args.model = None
 
-    # Mock _provision_qdrant_alive to exit(1)
-    with patch("scripts.delegate._provision_qdrant_alive") as mock_alive:
-        mock_alive.side_effect = SystemExit(1)
+    with patch("rag.query.get_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_client.get_collections.side_effect = Exception("Connection refused")
+        mock_get_client.return_value = mock_client
 
         # We need to mock other things to get to the _ensure_worktree call
         with patch("scripts.delegate._read_state", return_value=None):
@@ -70,10 +92,10 @@ def test_delegate_liveness_probe_fails_dispatch():
                                 with patch("subprocess.Popen") as mock_popen:
                                     mock_run.return_value = MagicMock(returncode=0)
 
-                                    with pytest.raises(SystemExit):
-                                        delegate.cmd_dispatch(args)
+                                    result = delegate.cmd_dispatch(args)
 
-                                    # Verify subprocess.Popen (the worker) was NOT called
+                                    # Verify cmd_dispatch caught DispatchPreconditionError and returned 1
+                                    assert result == 1
                                     mock_popen.assert_not_called()
 
 def test_delegate_allow_degraded_rag_bypasses_liveness():
@@ -90,9 +112,8 @@ def test_delegate_allow_degraded_rag_bypasses_liveness():
     args.mode = "read-only"
     args.model = None
 
-    # Mock _provision_qdrant_alive — it should NOT be called
-    with patch("scripts.delegate._provision_qdrant_alive") as mock_alive:
-        # We need to mock other things to get to the _ensure_worktree call
+    # Mock get_client — it should NOT be called
+    with patch("rag.query.get_client") as mock_get_client:
         with patch("scripts.delegate._read_state", return_value=None):
             with patch("scripts.delegate.Path.read_text", return_value="prompt"):
                 with patch("scripts.delegate._auto_worktree_path", return_value=Path("/tmp/wt")):
@@ -105,7 +126,6 @@ def test_delegate_allow_degraded_rag_bypasses_liveness():
 
                                     delegate.cmd_dispatch(args)
 
-                                    # Verify _provision_qdrant_alive was NOT called
-                                    mock_alive.assert_not_called()
-                                    # Verify worker WAS called
+                                    mock_get_client.assert_not_called()
                                     mock_popen.assert_called()
+

--- a/tests/test_build_knowledge_packet.py
+++ b/tests/test_build_knowledge_packet.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
@@ -19,6 +20,12 @@ from build.research.build_knowledge_packet import (
     _is_exercise_chunk,
     build_packet,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_qdrant_liveness():
+    with patch("build.research.build_knowledge_packet._verify_qdrant_liveness"):
+        yield
 
 # --- Unit tests ---
 
@@ -187,7 +194,7 @@ def test_heuristic_reranking_reorders_results():
          "score": 0.85, "chunk_id": "c2", "page": "2"},
     ]
 
-    def mock_search(query, grade=None, limit=5):
+    def mock_search(query, grade=None, limit=5, **kwargs):
         return [dict(h) for h in hits]  # Return copies
 
     with _patch("build.research.build_knowledge_packet._search_rag.__wrapped__", mock_search, create=True):
@@ -206,7 +213,7 @@ def test_heuristic_reranking_reorders_results():
 # --- Integration test with mocked RAG ---
 
 
-def _mock_search_text(query, grade=None, limit=5):
+def _mock_search_text(query, grade=None, limit=5, **kwargs):
     """Return fake RAG results for testing."""
     return [
         {
@@ -249,7 +256,7 @@ def test_build_packet_structure(tmp_path):
     plan_path.write_text(yaml.dump(plan, allow_unicode=True), "utf-8")
 
     with patch("build.research.build_knowledge_packet._search_rag", _mock_search_text):
-        result = build_packet(plan_path)
+        result = build_packet(plan_path, allow_degraded_rag=True)
 
     # Check structure
     assert "# Knowledge Packet: Test Module" in result
@@ -285,7 +292,7 @@ def test_build_packet_no_rag(tmp_path):
         raise ConnectionError("RAG not running")
 
     with patch("build.research.build_knowledge_packet._search_rag", _failing_search):
-        result = build_packet(plan_path)
+        result = build_packet(plan_path, allow_degraded_rag=True)
 
     # Should still produce output without crashing
     assert "# Knowledge Packet: Test Module" in result
@@ -334,7 +341,7 @@ def test_build_packet_includes_miyklas_section(tmp_path):
         patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
         patch("build.miyklas._load_index", return_value=list(_FAKE_MIYKLAS_INDEX)),
     ):
-        result = build_packet(plan_path)
+        result = build_packet(plan_path, allow_degraded_rag=True)
 
     assert "МійКлас Grammar References" in result
     assert "Голосні й приголосні звуки" in result
@@ -366,7 +373,7 @@ def test_build_packet_no_miyklas_when_no_grammar_match(tmp_path):
         patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
         patch("build.miyklas._load_index", return_value=list(_FAKE_MIYKLAS_INDEX)),
     ):
-        result = build_packet(plan_path)
+        result = build_packet(plan_path, allow_degraded_rag=True)
 
     assert "МійКлас Grammar References" not in result
 
@@ -400,7 +407,7 @@ def test_build_packet_miyklas_failure_graceful(tmp_path):
         patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
         patch("build.miyklas.build_miyklas_knowledge_section", side_effect=_failing_miyklas),
     ):
-        result = build_packet(plan_path)
+        result = build_packet(plan_path, allow_degraded_rag=True)
 
     # Should still produce a valid packet without МійКлас
     assert "# Knowledge Packet: Test Fallback" in result
@@ -435,7 +442,7 @@ def test_build_packet_miyklas_section_before_footer(tmp_path):
         patch("build.research.build_knowledge_packet._search_rag", _mock_search_text),
         patch("build.miyklas._load_index", return_value=list(_FAKE_MIYKLAS_INDEX)),
     ):
-        result = build_packet(plan_path)
+        result = build_packet(plan_path, allow_degraded_rag=True)
 
     # МійКлас appears after references section and before footer
     miyklas_pos = result.index("МійКлас Grammar References")

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -24,6 +24,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import delegate
 
 
+@pytest.fixture(autouse=True)
+def mock_qdrant_liveness():
+    with patch("delegate._provision_qdrant_alive"):
+        yield
+
+
 @pytest.fixture
 def tmp_tasks_dir(tmp_path, monkeypatch):
     """Redirect delegate._TASKS_DIR to a tmp path so tests don't pollute
@@ -683,10 +689,11 @@ def _make_run_stub(
     return calls, fake_run
 
 
-def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, capsys):
+def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
     import argparse
 
     recorded_prompt: dict[str, str] = {}
+    wt_path = tmp_path / "codex-1383"
 
     class _FakeStdin:
         def write(self, data):
@@ -712,7 +719,7 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, ca
         mode="danger",
         model=None,
         cwd=None,
-        worktree=".worktrees/codex-1383",
+        worktree=str(wt_path),
         base="main",
         hard_timeout=3600,
     )
@@ -724,13 +731,13 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, ca
     assert state is not None
     assert state["status"] == "spawning"
     assert state["worktree_branch"] == "codex/issue-1383-smoke"
-    assert state["worktree_path"].endswith(".worktrees/codex-1383")
-    assert state["cwd"].endswith(".worktrees/codex-1383")
+    assert state["worktree_path"] == str(wt_path.resolve())
+    assert state["cwd"] == str(wt_path.resolve())
     assert state["pid"] == 24680
     assert state["worktree_base_sha"] == "deadbeef"
     assert state["worktree_reused"] is False
     assert "delegate worktree" in recorded_prompt["text"]
-    assert ".worktrees/codex-1383" in recorded_prompt["text"]
+    assert str(wt_path) in recorded_prompt["text"]
     # At minimum: git fetch + git rev-parse --verify + git worktree add + git rev-parse HEAD.
     assert any(c[:3] == ["git", "worktree", "add"] for c in calls)
     assert any(c[:2] == ["git", "fetch"] for c in calls)


### PR DESCRIPTION
## Summary

`scripts/build/research/build_knowledge_packet.py` (and its `linear_pipeline` consumer) previously degraded silently to plan-references-only when Qdrant on \`127.0.0.1:6334\` was unavailable, contaminating Phase 4 round-3.5 verification (#1620, PR #1621). This PR makes RAG availability a fail-fast precondition so the round-4 bakeoff (#1622) and Phase 5 fan-out get clean signal.

## Three-part fix

1. **\`build_knowledge_packet\` fail-fast**: raises \`LinearPipelineError\` on:
   - Qdrant connection unavailable on configured port
   - Qdrant connected but collection empty/missing
   - Retrieved chunks below configured floor (default 5 per major plan section)

2. **\`delegate.py\` liveness probe**: extends dispatch pre-flight (near \`_provision_data_symlinks\`) with a \`_provision_qdrant_alive()\` check. Fails the dispatch BEFORE any agent budget is burned when Qdrant is unreachable.

3. **\`--allow-degraded-rag\` escape hatch**: opt-in flag for non-content-grounded smoke tests. Default OFF; emits LOUD warning to stderr when used.

## Verification

- \`tests/build/test_qdrant_fail_fast.py\` (NEW): 111 lines, covers all three parts + boundary cases
- \`tests/test_build_knowledge_packet.py\` updated for new fail-fast behavior
- \`tests/test_delegate.py\` updated for liveness probe
- All tests pass: 81 in delegate suite + new qdrant_fail_fast suite

## Files changed

\`\`\`
scripts/build/linear_pipeline.py                 |  53 ++++++++++-
scripts/build/research/build_knowledge_packet.py |  88 +++++++++++++++---
scripts/delegate.py                              |  56 ++++++++++++
tests/build/test_qdrant_fail_fast.py             | 111 +++++++++++++++++++++++
tests/test_build_knowledge_packet.py             |  23 +++--
tests/test_delegate.py                           |  17 +++-
\`\`\`

## Dispatch context

First **Gemini** code dispatch (gemini-3.1-pro-preview) under the user's 2026-04-28 directive to distribute Python coding across all 3 agents. Brief at \`.worktree-briefs/gemini-1625-qdrant-fail-fast.md\` explicitly flagged Python conventions, mandatory tests, and codebase-read-before-design discipline.

**Dispatch outcome**: state \`rate_limited\` after 5372s (89 min). Both commits pushed cleanly to \`origin/gemini/1625-qdrant-fail-fast\`; worktree clean; tests pass. The rate-limit hit during/after the work was committed but before \`gh pr create\` — orchestrator opens PR with a body summarizing the dispatch.

The dispatch made 2 cumulative commits (\`9fe23364c7\` first pass, \`be33f6f5d0\` HEAD with refinements + extended liveness coverage).

## Adversarial review needed

Per #0H discipline + given this is the first Gemini code dispatch in the project, this PR especially needs parallel adversarial review (Claude + Codex) before merge. The rate-limited cutoff means Gemini didn't write its own dispatch result summary, so reviewers should also verify scope-completeness against the brief's ACs.

Closes #1625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)