### PR TITLE
docs(deliberation): add Scope field to Decision Card template (#1639)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,6 @@ You will sometimes be invoked via `ab discuss` for design / framing / pedagogy /
 
 **When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card.** It means user input is needed. Don't try to resolve it on your side; the orchestrator routes it to inline chat / `docs/decisions/pending/` / GH issue depending on user availability.
 
-**Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING.** If you're starting work in a worktree and that directory has files, surface them in your initial response before doing anything that could invalidate them.
+**Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** If you're starting work in a worktree and that directory has files, surface them in your initial response and check the field before assuming a decision blocks your work.
 
 Full protocol: `docs/best-practices/agent-cooperation.md` "Multi-Agent Deliberation" section.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -123,6 +123,6 @@ You will sometimes be invoked via `ab discuss` for design / framing / pedagogy /
 
 **When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card** routed to inline chat / `docs/decisions/pending/` / GH issue. Don't try to resolve it on Gemini's side.
 
-**Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING.** Surface them before any new work that could invalidate them.
+**Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** Surface them before any new work that could invalidate them, and check the field before assuming a decision blocks your work.
 
 Full protocol: `docs/best-practices/agent-cooperation.md` "Multi-Agent Deliberation" section.

--- a/docs/agent-channels/shared/context.md
+++ b/docs/agent-channels/shared/context.md
@@ -62,7 +62,7 @@ adversarial review between agents.
 
 **When the orchestrator (usually Claude) detects real disagreement OR multi-option output**, they emit a structured **Decision Card** (template in `docs/best-practices/agent-cooperation.md`) and route it to: inline chat (user online) / `docs/decisions/pending/{date}-{slug}.md` (user AFK) / GH issue with `decision-pending` label (multi-week call). User decides → orchestrator executes → file moves to canonical `docs/decisions/{date}-{slug}.md`.
 
-**Pending decisions are BLOCKING.** If `docs/decisions/pending/` is non-empty, do not start new work that could invalidate a pending decision. Surface it first.
+**Pending decisions are BLOCKING only for the scope declared in their `Scope` field.** If `docs/decisions/pending/` is non-empty, surface it first and check the field before assuming a decision blocks your work.
 
 Full protocol: [`docs/best-practices/agent-cooperation.md`](../../best-practices/agent-cooperation.md) "Multi-Agent Deliberation" section.
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -196,6 +196,12 @@ Most `ab discuss` runs converge with `[AGREE]` — orchestrator just executes th
 
 **Real disagreement (not surface-level):** {what they actually differ on — the underlying assumption gap, not just which letter they picked}
 
+**Scope:** {what this pending decision blocks and what remains safe}
+  - Tracks/levels blocked: {e.g., a1 zero-onset modules; a2 unaffected}
+  - Issues blocked: {e.g., #1622 round-4 bakeoff downstream}
+  - Paths/dirs blocked: {e.g., scripts/build/v7_build.py changes}
+  - Safe to proceed: {e.g., dependabot triage, wiki cleanup, A2/B1/B2 module fixes, infrastructure}
+
 **Orchestrator recommendation:** A — {1-3 line rationale weighing the votes against project priors}
 
 **Awaiting:** user override (`go with B because…`) or `go` to proceed with the recommendation
@@ -210,6 +216,8 @@ Three locations depending on user availability:
 | User online, mid-session | Inline in chat reply | Immediate visibility, user can `go` in next message |
 | User AFK, no live session | `docs/decisions/pending/{YYYY-MM-DD}-{slug}.md` | Durable, scannable on return; cold-start protocol checks this dir |
 | Multi-week architectural call | New GH issue with `decision-pending` label + Decision Card as body | Long-lived discussion needs an issue thread, not a markdown file |
+
+Every Decision Card MUST include a `Scope` field. The scope declares exactly which tracks, issues, and paths are blocked by the pending decision and which work can continue independently. If a Decision Card omits scope, agents must use the conservative interpretation that it blocks everything — precisely the failure mode this field is meant to avoid.
 
 When the user decides:
 - `pending/` file → moves to `docs/decisions/{date}-{slug}.md` with the chosen option recorded + closed
@@ -246,7 +254,7 @@ curl -s "http://localhost:8765/api/comms/inbox?agent=claude"
 # 5. Are there pending decisions awaiting user input?
 ls docs/decisions/pending/ 2>/dev/null
 # If non-empty: read each, surface to user before any other work.
-# Pending decisions are blocking — don't start new work that may invalidate them.
+# Pending decisions block only their declared scope; check Scope before assuming work is blocked.
 ```
 
 Agents running Python should use the SDK instead — one call, caching

--- a/docs/decisions/pending/README.md
+++ b/docs/decisions/pending/README.md
@@ -7,7 +7,7 @@
 
 Decision Cards emitted by the orchestrator (Claude) **when the user is AFK** and a decision needs the user's input before work can proceed. Each file is a single Decision Card surfaced from a multi-agent `ab discuss` deliberation OR from any other point where the orchestrator has hit a real choice that's not its to make.
 
-This directory is **the canonical AFK queue.** Cold-start protocol scans it. Anything in here is BLOCKING — orchestrator must NOT start new work that could invalidate a pending decision.
+This directory is **the canonical AFK queue.** Cold-start protocol scans it. Anything in here is BLOCKING for its declared scope — orchestrator must NOT start new work that could invalidate a pending decision.
 
 ## File naming
 
@@ -26,6 +26,8 @@ Date = when the decision was surfaced, not when it'll be resolved.
 Each file contains exactly one Decision Card per the template in `agent-cooperation.md` ("Decision Card pattern" section). Don't bundle multiple decisions in one file — one card per file makes resolution atomic.
 
 ## When the user decides
+
+Pending decisions block only the work declared in their `Scope` field, not all repository work. Read the field before assuming a pending card blocks unrelated tracks, issues, or paths.
 
 The orchestrator (or the user directly):
 


### PR DESCRIPTION
## Summary
- Adds required `Scope:` field to Decision Card template
- Declares which tracks/issues/paths are blocked AND which are safe to proceed
- Mirrors update across `agent-cooperation.md`, `pending/README.md`, `AGENTS.md`, `GEMINI.md`, `shared/context.md`

## Why
Per Codex's own pushback in the 2026-05-02 onboarding round: without scope, "BLOCKING" can freeze unrelated work. Adopted with user agreement (#1639).

## Test plan
- [ ] Visual check that template renders with all 6 fields (question, agents, options, votes, disagreement, scope, recommendation, awaiting)
- [ ] All 5 canonical reference files updated consistently
- [ ] Cross-review by Gemini (who has parallel false-consensus PR pending) for protocol-coherence

Refs: #1639