### PR TITLE
docs(deliberation): high-risk-track false-consensus override (#1639)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,8 @@ You will sometimes be invoked via `ab discuss` for design / framing / pedagogy /
 
 **When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card.** It means user input is needed. Don't try to resolve it on your side; the orchestrator routes it to inline chat / `docs/decisions/pending/` / GH issue depending on user availability.
 
+**High-risk-track override:** On sensitive tracks (HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
+
 **Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** If you're starting work in a worktree and that directory has files, surface them in your initial response and check the field before assuming a decision blocks your work.
 
 Full protocol: `docs/best-practices/agent-cooperation.md` "Multi-Agent Deliberation" section.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -123,6 +123,8 @@ You will sometimes be invoked via `ab discuss` for design / framing / pedagogy /
 
 **When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card** routed to inline chat / `docs/decisions/pending/` / GH issue. Don't try to resolve it on Gemini's side.
 
+**High-risk-track override:** On sensitive tracks (HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
+
 **Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** Surface them before any new work that could invalidate them, and check the field before assuming a decision blocks your work.
 
 Full protocol: `docs/best-practices/agent-cooperation.md` "Multi-Agent Deliberation" section.

--- a/docs/agent-channels/shared/context.md
+++ b/docs/agent-channels/shared/context.md
@@ -62,6 +62,8 @@ adversarial review between agents.
 
 **When the orchestrator (usually Claude) detects real disagreement OR multi-option output**, they emit a structured **Decision Card** (template in `docs/best-practices/agent-cooperation.md`) and route it to: inline chat (user online) / `docs/decisions/pending/{date}-{slug}.md` (user AFK) / GH issue with `decision-pending` label (multi-week call). User decides → orchestrator executes → file moves to canonical `docs/decisions/{date}-{slug}.md`.
 
+**High-risk-track override:** On sensitive tracks (HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is a signal to check, not proceed, due to shared training-data biases. The orchestrator must force-emit a Decision Card anyway or inject a domain-specific bias checklist into the prompt (see full protocol docs).
+
 **Pending decisions are BLOCKING only for the scope declared in their `Scope` field.** If `docs/decisions/pending/` is non-empty, surface it first and check the field before assuming a decision blocks your work.
 
 Full protocol: [`docs/best-practices/agent-cooperation.md`](../../best-practices/agent-cooperation.md) "Multi-Agent Deliberation" section.

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -205,7 +205,20 @@ Most `ab discuss` runs converge with `[AGREE]` — orchestrator just executes th
 **Orchestrator recommendation:** A — {1-3 line rationale weighing the votes against project priors}
 
 **Awaiting:** user override (`go with B because…`) or `go` to proceed with the recommendation
-```
+
+### High-risk-track override (false-consensus failsafe)
+
+When all participating agents share the same underlying bias on a topic (e.g., Russian-imperial framing on Ukrainian topics, Western centrism on decolonization), an `[AGREE]` consensus is NOT a green light. It is exactly when the Decision Card mechanism is most needed and most likely to be bypassed.
+
+For high-risk tracks — **HIST, BIO, ISTORIO, LIT, OES, RUTH** (all decolonization-sensitive seminar tracks where Russian/Soviet-imperial framings are most ingrained in training data) — the orchestrator MUST apply at least one of the following failsafe mechanisms:
+
+- **Mechanism A (Force-emit Decision Card on `[AGREE]`):** If `ab discuss` runs on a topic touching any high-risk track and converges with `[AGREE]`, the orchestrator emits a Decision Card anyway. The question is framed as "agents converged on X — but consensus on this track is suspect; user should sanity-check." The user can quickly approve or override.
+- **Mechanism B (Inject domain-specific bias checklist):** For high-risk tracks, the `ab discuss` prompt is augmented with a short bias checklist explicitly provoking adversarial review on known bias vectors.
+  - *Example for HIST:* "Did you check the proposed framing against canonical decolonized sources? Bulgakov-as-Ukrainian, Gogol-as-Ukrainian, Akhmatova-as-Ukrainian, etc., are the 'Kyiv-born equals Ukrainian writer' trap — flag if you see it. Did you check whether the historical actor is being framed in Russian-imperial categories versus Ukrainian native categories?"
+
+**Recommendation:** Prefer **Mechanism B** (proactive — catches bias during discussion) for any new `ab discuss` on high-risk tracks. Fall back to **Mechanism A** (reactive — emit card on consensus) when no domain-specific checklist exists yet for that track.
+
+**Pattern:** Consensus on high-risk tracks is a SIGNAL TO CHECK, not a signal to proceed.
 
 ### Where Decision Cards land
 
@@ -216,6 +229,8 @@ Three locations depending on user availability:
 | User online, mid-session | Inline in chat reply | Immediate visibility, user can `go` in next message |
 | User AFK, no live session | `docs/decisions/pending/{YYYY-MM-DD}-{slug}.md` | Durable, scannable on return; cold-start protocol checks this dir |
 | Multi-week architectural call | New GH issue with `decision-pending` label + Decision Card as body | Long-lived discussion needs an issue thread, not a markdown file |
+
+Note: High-risk-track Decision Cards (the ones force-emitted by Mechanism A) should ALWAYS be routed inline-or-pending, never silently auto-resolved, even when the user appears online.
 
 Every Decision Card MUST include a `Scope` field. The scope declares exactly which tracks, issues, and paths are blocked by the pending decision and which work can continue independently. If a Decision Card omits scope, agents must use the conservative interpretation that it blocks everything — precisely the failure mode this field is meant to avoid.
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -205,6 +205,7 @@ Most `ab discuss` runs converge with `[AGREE]` — orchestrator just executes th
 **Orchestrator recommendation:** A — {1-3 line rationale weighing the votes against project priors}
 
 **Awaiting:** user override (`go with B because…`) or `go` to proceed with the recommendation
+```
 
 ### High-risk-track override (false-consensus failsafe)
 


### PR DESCRIPTION
## Summary
- New subsection "High-risk-track override (false-consensus failsafe)" in agent-cooperation.md
- Defines failure mode + high-risk track list (HIST/BIO/ISTORIO/LIT/OES/RUTH)
- Defines two failsafe mechanisms (force-emit on [AGREE] / inject bias checklist)
- Mirrors brief mention into AGENTS.md, GEMINI.md, shared/context.md
- Includes initial HIST bias-checklist sample

## Why
Per Gemini's own pushback in the 2026-05-02 onboarding round: [AGREE] consensus is structurally weakest exactly when correlated training-data biases are strongest. Adopted with user agreement (#1639).

## Test plan
- [ ] Visual check that override rule renders correctly
- [ ] All 4 canonical reference files updated consistently
- [ ] Cross-review by Codex (who has the parallel scope-field PR merged) for protocol-coherence
- [ ] Bias checklist examples verified against project canon (memory/MEMORY.md fact corrections)

Refs: #1639