### PR TITLE
ci(test): always run Test (pytest) job, conditionally skip on docs-only (#1641)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,22 +21,12 @@ on:
       - 'docs/lesson-contract.md'
       - 'docs/lesson-schema.yaml'
       - 'starlight/**'
+  # CI/docs-only required-check note:
+  # Keep PRs unfiltered so the required `Test (pytest)` check is always emitted.
+  # Docs-only PRs otherwise leave branch protection stuck on "expected" (#1641).
+  # Earlier path widenings only fixed individual recurrences (#1544, #1546);
+  # the `Test (pytest)` job below now does the path filtering internally.
   pull_request:
-    paths:
-      - '.github/workflows/ci.yml'
-      - 'requirements*.txt'
-      - 'requirements.lock'
-      - 'scripts/**/*.py'
-      - 'tests/**/*.py'
-      - 'pyproject.toml'
-      # See note on `push:` above — widened 2026-04-24 (#1546).
-      - 'claude_extensions/**'
-      - 'gemini_extensions/**'
-      - 'scripts/build/phases/**/*.md'
-      - 'scripts/build/contracts/**/*.md'
-      - 'docs/lesson-contract.md'
-      - 'docs/lesson-schema.yaml'
-      - 'starlight/**'
   workflow_dispatch:
 
 jobs:
@@ -245,12 +235,64 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for code-relevant changes
+        id: code-changes
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "Running pytest for ${{ github.event_name }}."
+            exit 0
+          fi
+
+          if [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git merge-base origin/main "$head_sha")"
+          fi
+
+          mapfile -t changed_files < <(git diff --name-only "$base_sha" "$head_sha")
+
+          code_changed=false
+          for file in "${changed_files[@]}"; do
+            if [[ "$file" == ".github/workflows/ci.yml" \
+              || "$file" =~ ^requirements.*\.txt$ \
+              || "$file" == "requirements.lock" \
+              || "$file" == "pyproject.toml" \
+              || "$file" =~ ^scripts/.*\.py$ \
+              || "$file" =~ ^tests/.*\.py$ \
+              || "$file" =~ ^claude_extensions/ \
+              || "$file" =~ ^gemini_extensions/ \
+              || "$file" =~ ^scripts/build/phases/.*\.md$ \
+              || "$file" =~ ^scripts/build/contracts/.*\.md$ \
+              || "$file" == "docs/lesson-contract.md" \
+              || "$file" == "docs/lesson-schema.yaml" \
+              || "$file" =~ ^starlight/ ]]; then
+              code_changed=true
+              break
+            fi
+          done
+
+          echo "code=$code_changed" >> "$GITHUB_OUTPUT"
+          if [[ "$code_changed" == "true" ]]; then
+            echo "Code-relevant changes detected; pytest will run."
+          else
+            echo "No code-relevant changes detected; pytest will be skipped successfully."
+          fi
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: steps.code-changes.outputs.code == 'true'
         with:
           python-version: '3.12'
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: steps.code-changes.outputs.code == 'true'
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt', 'requirements-lock.txt', 'pyproject.toml') }}
@@ -258,6 +300,7 @@ jobs:
             pip-${{ runner.os }}-
 
       - name: Install dependencies
+        if: steps.code-changes.outputs.code == 'true'
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
@@ -268,7 +311,7 @@ jobs:
             torch==2.11.0 torchvision==0.26.0
 
       - name: Run tests
-        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+        if: steps.code-changes.outputs.code == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main')
         run: |
           common_args=(
             tests/
@@ -295,7 +338,7 @@ jobs:
           .venv/bin/python -m pytest "${common_args[@]}"
 
       - name: Run tests with coverage
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.code-changes.outputs.code == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           # Gradual path: 30 (2025) → 35 (now, 2026-04) → 50 (mid-2026) → 80 on
           # critical paths (dispatch, activity_repair, audit/core). Measured
@@ -337,7 +380,7 @@ jobs:
           .venv/bin/python -m pytest "${common_args[@]}" "${coverage_args[@]}"
 
       - name: Upload coverage
-        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: always() && steps.code-changes.outputs.code == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report

--- a/docs/best-practices/ci-health.md
+++ b/docs/best-practices/ci-health.md
@@ -11,6 +11,7 @@ Scope of the 2026-04-22 repair pass:
 - `CI / Quality Gates (radon)`: evaluate only changed `scripts/**/*.py` files so historic complexity debt on untouched files does not block unrelated PRs.
 - `CI / No new root scripts`: diff only true `scripts/*.py` root files, not nested `scripts/**`.
 - `CI / Test (pytest)`: create a repo-local `.venv` in CI, install from `requirements-lock.txt`, force CPU `torch` wheels on GitHub-hosted Linux, and exclude non-hermetic integration files that require local corpora, generated review/orchestration artifacts, or sidecar tooling (`vesum.db`, `pdfinfo`, `codex`, `embed-venv`) that the runner does not provide.
+- `CI / Test (pytest)`: always emit the required PR check, but skip pytest successfully when only docs-only paths changed.
 
 Verification notes:
 


### PR DESCRIPTION
## Summary
- Removes path-filter gating on the `Test (pytest)` job
- Adds a "code-changes" filter step inside the job
- pytest runs when code-relevant paths changed; skips with success when only docs changed
- Required check `Test (pytest)` always reports success → no more --admin merges on docs PRs

## Why
Hit twice on 2026-05-02 (#1640, #1642). Both required `--admin` flag despite all real CI green. Prior path-widening fixes (#1544, #1546) only addressed specific recurrences. Structural fix per #1641.

## Implementation choice
Option A. GitHub path filters are workflow-level, so this PR removes the PR-level `paths:` gate and moves the code-relevant filter into the required `Test (pytest)` job. I used local `git diff` matching instead of a community action to keep the required check self-contained.

## Test plan
- [x] CI passes on the initial workflow-yaml commit; `Test (pytest)` ran full pytest and passed
- [x] Docs-only follow-up commit on this branch still triggered CI and `Test (pytest)` passed
- [x] Local classifier check returns `false` for README/docs-only paths and `true` for the code-relevant path set
- [ ] Cross-review by Gemini for any GitHub Actions edge cases

Note: the same-PR docs-only follow-up commit correctly did **not** exercise the skip branch, because this PR's cumulative diff still includes `.github/workflows/ci.yml`. Keeping the filter based on the whole PR diff prevents a later docs-only commit from masking an earlier failing code change. A PR whose entire diff is docs-only will take the skip-success path.

Closes #1641