### PR TITLE
fix(v7_build): render authoring activity schema in writer prompt

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -691,94 +691,38 @@ def writer_context(plan: Mapping[str, Any], plan_content: str, knowledge_packet:
     }
 
 
-# Multi-line TSDoc comments embedded in raw type strings would leak into the
-# rendered writer prompt verbatim — `odd-one-out`'s `items` field, for example,
-# carries `{ /** * @schemaDescription Words... */ words: string[]; ... }[]`.
-# That burns tokens and confuses the writer with TypeScript syntax. Strip them
-# before rendering. Generator-side fix tracked in #1604.
-_TSDOC_BLOCK_RE = re.compile(r"/\*\*.*?\*/", re.DOTALL)
-
-
-def _strip_tsdoc(raw_type: str) -> str:
-    """Remove embedded TSDoc comment blocks and collapse runs of whitespace."""
-    cleaned = _TSDOC_BLOCK_RE.sub("", raw_type)
-    return " ".join(cleaned.split()).strip()
-
-
 def _render_component_props_schema(allowed_activity_types: str) -> str:
-    """Render compact required/optional prop spec per allowed activity type.
+    """Render compact authoring-field spec per allowed activity type.
 
-    Reads ``docs/lesson-schema.yaml`` and emits a writer-facing markdown list,
-    one bullet per allowed activity type, naming the required and optional
-    props plus the nested-item field names. Without this, the writer guesses
-    prop shapes — e.g. it produced ``passage:`` for ``fill-in`` (which the
-    schema says needs ``items: FillInItem[]``) and omitted ``correct_order``
-    on ``order`` activities. The component-prop QG gate then failed late with
-    cryptic errors. Surfacing the contract in the prompt is the cheapest fix
-    that matches what the gate actually checks (#1602, round 3.5).
-
-    The same ``docs/lesson-schema.yaml`` file is the source of truth for both
-    this prompt section and the ``_component_prop_gate`` validator, so the
-    writer can never see a stale contract.
-
-    Allowed types that have no resolvable schema entry (the
-    ``activity_type: null`` drift class — see #1604 for the ``phrase-table``
-    instance) are NOT silently dropped. They emit an explicit
-    ``# WARNING: <type> has no schema entry…`` line so the writer is told
-    not to use them. Failing loudly here would block round 3.5 dispatch on
-    an unrelated generator-side bug; warning + follow-up issue is the right
-    scope for this PR.
+    Historical name retained for prompt-token compatibility. The writer must
+    see the AUTHORING JSON/YAML shape consumed by ``scripts/yaml_activities.py``
+    and validated by ``_validate_writer_json_artifact`` — not React component
+    prop names from ``docs/lesson-schema.yaml``. Those views diverge for
+    adapter-style activities: quiz/select/translate authoring uses ``items``,
+    while React components may expose ``questions``. Showing component props in
+    this prompt caused Gemini to emit ``quiz: {questions: [...]}``, which the
+    strict writer parser correctly rejects.
     """
     allowed = {token.strip() for token in allowed_activity_types.split(",") if token.strip()}
-    schema = load_yaml(PROJECT_ROOT / "docs" / "lesson-schema.yaml")
-    components = schema.get("components", {}) or {}
-    by_type: dict[str, dict[str, Any]] = {}
-    for data in components.values():
-        if not isinstance(data, dict):
-            continue
-        activity_type = data.get("activity_type")
-        if activity_type in allowed:
-            by_type[activity_type] = data
-    unresolved = sorted(allowed - by_type.keys())
-
-    def _format_prop(prop: Mapping[str, Any], nested: Mapping[str, Any]) -> str:
-        name = prop.get("name", "?")
-        ptype = _strip_tsdoc(str(prop.get("type", "")))
-        # Resolve nested-item field names so the writer sees the inner shape
-        # of arrays like FillInItem[] without us having to repeat the whole
-        # schema. Falls back to the raw type string when there's no match.
-        item_type = ptype[:-2] if ptype.endswith("[]") else None
-        if item_type and item_type in nested:
-            fields = ", ".join(
-                str(field.get("name", "?"))
-                for field in nested[item_type]
-                if isinstance(field, dict)
-            )
-            return f"{name} ({ptype}: {fields})" if fields else f"{name} ({ptype})"
-        return f"{name} ({ptype})" if ptype else str(name)
-
+    authoring_by_type = _activity_type_field_whitelist()
     lines: list[str] = []
-    for activity_type in sorted(by_type):
-        data = by_type[activity_type]
-        props = data.get("props", {}) or {}
-        nested = data.get("nested_types", {}) or {}
-        required = [p for p in (props.get("required", []) or []) if isinstance(p, dict)]
-        optional = [p for p in (props.get("optional", []) or []) if isinstance(p, dict)]
-        req_str = ", ".join(_format_prop(p, nested) for p in required) if required else "—"
-        opt_str = ", ".join(_format_prop(p, nested) for p in optional) if optional else "—"
+    for activity_type in sorted(allowed):
+        fields = authoring_by_type.get(activity_type)
+        if fields is None:
+            lines.append(
+                f"- {activity_type}:  # WARNING: no authoring schema entry — "
+                "DO NOT USE this activity type until the schema is fixed "
+                "(see #1604 for schema drift)"
+            )
+            continue
+        content_fields = sorted(fields - _UNIVERSAL_AUTHORING_FIELDS)
+        optional_fields = sorted((fields & _UNIVERSAL_AUTHORING_FIELDS) - {"id", "type"})
+        required = ["id", "type", *content_fields]
         lines.append(f"- {activity_type}:")
-        lines.append(f"    required: {req_str}")
-        lines.append(f"    optional: {opt_str}")
-    for activity_type in unresolved:
-        # Visible to both the writer (via the prompt) and to anyone reading
-        # the rendered output. Keep the wording stable — tests grep for it.
-        lines.append(
-            f"- {activity_type}:  # WARNING: no schema entry in "
-            f"docs/lesson-schema.yaml — DO NOT USE this activity type "
-            f"(see #1604 for the schema-generator drift)"
-        )
+        lines.append(f"    required authoring fields: {', '.join(required)}")
+        lines.append(f"    optional authoring fields: {', '.join(optional_fields) or '—'}")
     if not lines:
-        return "(no allowed activity types resolved against lesson-schema.yaml)"
+        return "(no allowed activity types resolved against authoring schema)"
     return "\n".join(lines)
 
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -133,22 +133,23 @@ Activity count target: {ACTIVITY_COUNT_TARGET}
 
 Vocabulary count target: {VOCAB_COUNT_TARGET}
 
-## Activity Component Props (mandatory)
+## Activity Authoring Fields (mandatory)
 
-Each activity object in `activities.yaml` MUST carry the props for its
-declared `type` exactly as specified below. The build's `component_props`
-gate compares these against `docs/lesson-schema.yaml` and fails the build
-on any missing required prop. Do not invent prop names; do not borrow a
-prop name from a different activity type (for example, `fill-in` requires
-`items: FillInItem[]` — do not substitute `passage:`).
+Each activity object in `activities.yaml` MUST use the authoring field names
+listed below for its declared `type`. These are the JSON/YAML fields consumed
+by `scripts/yaml_activities.py` and checked by the writer parser. They are not
+React component prop names.
+
+Do not invent prop names. Do not borrow a prop name from a different activity
+type. In particular, for `quiz`, `select`, and `translate`, use the authoring
+field `items`; do NOT use the React/component prop name `questions`.
 
 ```
 {COMPONENT_PROPS_SCHEMA}
 ```
 
-For nested array item types (e.g. `FillInItem[]`), include the listed
-fields on every item. For numeric arrays like `correct_order: number[]`,
-indices are zero-based.
+For item-bearing types, include a non-empty `items` array. For numeric arrays
+like `correct_order`, indices are zero-based.
 
 ## Plan
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -237,6 +237,55 @@ def test_parse_writer_output_rejects_invalid_json() -> None:
         linear_pipeline.parse_writer_output_strict_json(output)
 
 
+def test_parse_writer_output_rejects_quiz_component_prop_questions() -> None:
+    """Writer artifacts must use authoring shape: quiz uses `items`.
+
+    The M20 POC failure came from a prompt contradiction: the writer saw React
+    component props and emitted `questions`, but the authoring parser consumes
+    `items`.
+    """
+    output = """```markdown file=module.md
+# Мій ранок
+```
+
+```json file=activities.yaml
+[
+  {
+    "id": "act-1",
+    "type": "quiz",
+    "instruction": "Оберіть правильну відповідь.",
+    "questions": [
+      {"question": "Я ____ о сьомій.", "options": ["прокидаюся", "йдеш"]}
+    ]
+  }
+]
+```
+
+```json file=vocabulary.yaml
+[
+  {
+    "lemma": "ранок",
+    "translation": "morning",
+    "pos": "noun",
+    "usage": "Мій ранок простий."
+  }
+]
+```
+
+```json file=resources.yaml
+[
+  {"title": "Караман Grade 10, p.176"}
+]
+```
+"""
+
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match=r"activities\.yaml schema validation failed.*unexpected fields.*questions",
+    ):
+        linear_pipeline.parse_writer_output_strict_json(output)
+
+
 def test_parse_writer_output_rejects_missing_artifact() -> None:
     output = """```markdown file=module.md
 # Мій ранок
@@ -1688,11 +1737,12 @@ def test_run_python_qg_passes_structural_fixture(tmp_path: Path) -> None:
 
 
 def test_render_component_props_schema_lists_required_and_optional() -> None:
-    """A1's allowed types must each get a `required:` and `optional:` line.
+    """A1's allowed types must each get authoring required/optional lines.
 
     Round-3 (#1577) failed because the writer guessed `passage:` for `fill-in`
-    and omitted `correct_order` on `order`. Surfacing the lesson-schema prop
-    contract in the writer prompt is the cheapest fix.
+    and omitted `correct_order` on `order`. The POC M20 failure then showed
+    that surfacing React component props misled Gemini into writing
+    `quiz.questions`. The prompt must show authoring fields instead.
     """
     allowed = "fill-in, order, match-up, quiz"
     rendered = linear_pipeline._render_component_props_schema(allowed)
@@ -1703,24 +1753,27 @@ def test_render_component_props_schema_lists_required_and_optional() -> None:
             f"Missing bullet for activity type {activity_type!r} in:\n{rendered}"
         )
 
-    # Required-prop names must appear verbatim — these are the exact keys the
-    # `_component_prop_gate` validator looks up.
+    # Required authoring field names must appear verbatim — these are the exact
+    # keys the writer parser accepts.
     assert "items" in rendered, "FillIn / Order / MatchUp `items` prop missing"
     assert "correct_order" in rendered, (
         "Order `correct_order` prop missing — was the original round-3 failure"
     )
+    quiz_block = rendered.split("- quiz:")[1].split("- ")[0]
+    assert "items" in quiz_block
+    assert "questions" not in quiz_block
 
     # Required and optional must be on different lines so the writer can tell
     # them apart.
-    assert "    required:" in rendered
-    assert "    optional:" in rendered
+    assert "    required authoring fields:" in rendered
+    assert "    optional authoring fields:" in rendered
 
 
 def test_render_component_props_schema_filters_to_allowed_types() -> None:
     """The schema renderer must NOT leak forbidden activity types.
 
     Forbidden types (e.g. `cloze`, `essay-response`, `paleography-analysis`)
-    have their own component-prop schemas in `lesson-schema.yaml`. If the
+    have their own authoring schemas. If the
     renderer doesn't filter, the writer would see them as 'available' and
     reach for them. The filter mirrors `ALLOWED_ACTIVITY_TYPES` exactly.
     """
@@ -1733,24 +1786,6 @@ def test_render_component_props_schema_filters_to_allowed_types() -> None:
     assert "- cloze:" not in rendered
     assert "- essay-response:" not in rendered
     assert "- paleography-analysis:" not in rendered
-
-
-def test_render_component_props_schema_resolves_nested_item_fields() -> None:
-    """Nested array item types like `FillInItem[]` must show their fields.
-
-    The writer needs to know that a `FillInItem` has `sentence`, `answer`,
-    `options` — not just that the prop is `items: FillInItem[]`. Otherwise
-    the prop shape is still ambiguous and we end up where round 3 ended.
-    """
-    rendered = linear_pipeline._render_component_props_schema("fill-in")
-
-    # The nested-type expansion must list the FillInItem fields after the
-    # array type annotation.
-    fill_in_block = rendered.split("- fill-in:")[1].split("- ")[0]
-    for field in ("sentence", "answer", "options"):
-        assert field in fill_in_block, (
-            f"FillInItem field {field!r} missing from rendered fill-in block:\n{fill_in_block}"
-        )
 
 
 def test_writer_context_populates_component_props_schema() -> None:
@@ -1771,7 +1806,7 @@ def test_writer_context_populates_component_props_schema() -> None:
     assert "COMPONENT_PROPS_SCHEMA" in context
     schema_text = context["COMPONENT_PROPS_SCHEMA"]
     assert "- fill-in:" in schema_text
-    assert "    required:" in schema_text
+    assert "    required authoring fields:" in schema_text
 
 
 def test_render_phase_prompt_resolves_component_props_schema() -> None:
@@ -1796,7 +1831,8 @@ def test_render_phase_prompt_resolves_component_props_schema() -> None:
     assert "{COMPONENT_PROPS_SCHEMA}" not in rendered
     # Concrete schema body landed in the prompt where the placeholder was.
     assert "- fill-in:" in rendered
-    assert "    required:" in rendered
+    assert "    required authoring fields:" in rendered
+    assert "quiz`, `select`, and `translate`, use the authoring" in rendered
 
 
 def test_linear_write_prompt_carries_anti_meta_narration_directive() -> None:
@@ -1913,7 +1949,7 @@ def test_render_component_props_schema_warns_on_unresolved_allowed_type() -> Non
     # Each unresolved type gets its own WARNING bullet.
     for unresolved in ("phrase-table", "banana-rama-not-a-real-type"):
         assert f"- {unresolved}:" in rendered
-        assert "# WARNING: no schema entry" in rendered, (
+        assert "# WARNING: no authoring schema entry" in rendered, (
             f"Unresolved type {unresolved!r} did not produce a WARNING line; "
             f"rendered output was:\n{rendered}"
         )
@@ -1923,42 +1959,24 @@ def test_render_component_props_schema_warns_on_unresolved_allowed_type() -> Non
     assert "#1604" in rendered
 
 
-def test_render_component_props_schema_strips_tsdoc_from_raw_types() -> None:
-    """Embedded `/** ... */` blocks must be stripped from raw type strings.
+def test_render_component_props_schema_uses_authoring_shape_not_ts_types() -> None:
+    """The writer prompt must expose authoring fields, not TypeScript props.
 
-    Adversarial review (Gemini + Codex on PR #1603): `odd-one-out`'s
-    `items` field has type `{ /** ... */ words: string[]; ... }[]` —
-    the JSDoc comments leak into the rendered prompt verbatim, burning
-    tokens and confusing the writer with TypeScript syntax. The renderer
-    runs `_strip_tsdoc` on every raw type before formatting.
+    The prompt used to render component prop types from lesson-schema.yaml.
+    That leaked TypeScript/JSDoc details and, worse, component-side names like
+    `questions` that are not valid authoring JSON. It now renders the compact
+    authoring whitelist.
     """
     rendered = linear_pipeline._render_component_props_schema("odd-one-out")
 
     odd_block = rendered.split("- odd-one-out:")[1].split("- ")[0]
-    # No raw TSDoc syntax should leak through.
     assert "/**" not in odd_block, (
         f"TSDoc block leaked into rendered odd-one-out output:\n{odd_block}"
     )
     assert "*/" not in odd_block
     assert "@schemaDescription" not in odd_block
     assert "@ukrainianText" not in odd_block
-    # The cleaned type signature should still mention the inner field names
-    # so the writer knows what to emit.
-    for field in ("words", "correct", "explanation"):
-        assert field in odd_block, (
-            f"Field {field!r} disappeared from cleaned odd-one-out type:\n{odd_block}"
-        )
-
-
-def test_strip_tsdoc_collapses_whitespace() -> None:
-    """`_strip_tsdoc` is the single point that handles raw-type cleanup."""
-    raw = "{ /** * @schemaDescription Foo. */ name: string; /** Bar */ age: number; }[]"
-
-    assert linear_pipeline._strip_tsdoc(raw) == "{ name: string; age: number; }[]"
-    # No-op on already-clean strings.
-    assert linear_pipeline._strip_tsdoc("string[]") == "string[]"
-    # Empty-string safety.
-    assert linear_pipeline._strip_tsdoc("") == ""
+    assert "required authoring fields: id, type, items" in odd_block
 
 
 def test_linear_write_prompt_skeleton_example_matches_schema() -> None:


### PR DESCRIPTION
## Summary
- Render writer-facing activity schema from authoring fields consumed by scripts/yaml_activities.py instead of React component props.
- Clarify the v7 writer prompt so quiz/select/translate use items, not questions.
- Add regression coverage for rejecting quiz.questions and for prompt schema rendering.

## Verification
- .venv/bin/pytest tests/build/ -x
- .venv/bin/ruff check scripts/build/
- pre-commit: ruff + affected tests
- Real M20 rerun passed the writer phase; next blocker is downstream python_qg plan_sections after ADR-008 correction.

## Review
- Gemini cross-review: no blockers, verdict [AGREE].

Generated M20 artifacts were cleaned and are not included.