### PR TITLE
ci: scope workflow token permissions for CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:
@@ -239,6 +242,9 @@ jobs:
   lesson-schema-drift:
     name: Lesson Schema Drift
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -269,6 +275,9 @@ jobs:
   test:
     name: Test (pytest)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: [changes, lint]
     # Per Gemini cross-review on #1644: top-level `if:` MUST NOT exclude
     # lint=failure cases — Test (pytest) is a required status check; if the
@@ -386,6 +395,9 @@ jobs:
   frontend:
     name: Frontend (build + vitest)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:

--- a/.github/workflows/rules-deployment-check.yml
+++ b/.github/workflows/rules-deployment-check.yml
@@ -1,5 +1,8 @@
 name: Rules Deployment Check
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -1,5 +1,8 @@
 name: Validate YAML Files
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:
@@ -17,6 +20,9 @@ jobs:
   validate-activities:
     name: Activities & Vocab
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,6 +112,9 @@ jobs:
   validate-plans:
     name: Curriculum Plans
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Add explicit workflow-level permissions: contents read to CI, YAML validation, and rules deployment workflows.
- Add job-level actions write only for jobs that use dependency caching or upload artifacts.
- Addresses the low-risk CodeQL actions/missing-workflow-permissions alert slice in .github/workflows/ci.yml, .github/workflows/validate-yaml.yml, and .github/workflows/rules-deployment-check.yml.

## Verification
- .venv/bin/python YAML parse/assert check for the three touched workflows.
- git diff --check for the touched workflow files.
- Gemini review initially requested changes because cache/artifact jobs need actions scope; amended commit c21bb8ac1a adds job-level actions write only for those jobs.

## Notes
- Secret scanning API still reports secret scanning is disabled on this repository as of this check; I will retry after GitHub propagates the setting.
- This PR intentionally does not attempt to fix the remaining Python/JS CodeQL alerts; those need separate scoped PRs.