### PR TITLE
fix(security): resolve 12 CodeQL warnings — URL substring + bad-tag-filter (batch C)

### DIFF
--- a/scripts/audit/audit_external_resources.py
+++ b/scripts/audit/audit_external_resources.py
@@ -159,7 +159,8 @@ def main():
 
     for i, url in enumerate(sorted(unique_urls), 1):
         parsed = urlparse(url)
-        is_youtube = parsed.netloc.endswith("youtube.com") or parsed.netloc == "youtu.be"
+        netloc_lower = parsed.netloc.lower()
+        is_youtube = netloc_lower in {"youtube.com", "www.youtube.com"} or netloc_lower.endswith(".youtube.com") or netloc_lower == "youtu.be"
         if args.skip_youtube and is_youtube:
             continue
 

--- a/scripts/audit/checks/contract_compliance.py
+++ b/scripts/audit/checks/contract_compliance.py
@@ -78,7 +78,7 @@ def _parse_sections(content: str) -> list[dict]:
             "title": match.group(1).strip(),
             "normalized_title": _normalize_section_title(match.group(1)),
             "body": body,
-            "word_count": len(re.sub(r"<!--.*?-->", "", body).split()),
+            "word_count": len(re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL).split()),
         })
     return sections
 

--- a/scripts/build/phases/honesty_annotator.py
+++ b/scripts/build/phases/honesty_annotator.py
@@ -11,7 +11,7 @@ _LINGUISTIC_UNIT_RE = re.compile(
     r"sound\w*|letter\w*|vowel\w*|consonant\w*|phoneme\w*|syllable\w*|case\w*|gender\w*)\b",
     re.IGNORECASE,
 )
-_COMMENT_ONLY_RE = re.compile(r"^\s*<!--.*-->\s*$")
+_COMMENT_ONLY_RE = re.compile(r"^\s*<!--.*?-->\s*$", flags=re.DOTALL)
 _SENTENCE_TERMINATOR_RE = re.compile(r"[.!?]\s+")
 
 

--- a/scripts/build/phases/wiki_compressor.py
+++ b/scripts/build/phases/wiki_compressor.py
@@ -104,7 +104,7 @@ def _tokenize(text: str) -> set[str]:
 
 
 def _clean_inline_markup(text: str) -> str:
-    text = re.sub(r"<!--.*?-->", "", text)
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
     text = re.sub(r"`([^`]+)`", r"\1", text)
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
     return re.sub(r"\s+", " ", text).strip()

--- a/scripts/content/video_discovery_helpers.py
+++ b/scripts/content/video_discovery_helpers.py
@@ -383,7 +383,8 @@ def _search_blog_dbs(level, topic_title, keywords, results, seen_urls, load_blog
         # 9fe99a00a7 dropped the default during an unrelated URL→domain refactor,
         # causing UnboundLocalError in CI for every non-dobraforma article.
         source = article.get("source", "ukrainianlessons.com")
-        if "dobraforma" in domain or "opentext.ku.edu" in domain:
+        domain_lower = domain.lower()
+        if "dobraforma" in domain_lower or domain_lower in {"opentext.ku.edu", "www.opentext.ku.edu"} or domain_lower.endswith(".opentext.ku.edu"):
             source = "dobraforma"
 
         entry: dict[str, Any] = {

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -789,18 +789,17 @@ def _extract_pravopys_text(html: str) -> str:
     The site doesn't use consistent CSS classes. We strip navigation,
     scripts, and styles, then extract the remaining body text.
     """
-    # Remove non-content elements
-    text = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL)
-    text = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL)
-    text = re.sub(r"<nav[^>]*>.*?</nav>", "", text, flags=re.DOTALL)
-    text = re.sub(r"<header[^>]*>.*?</header>", "", text, flags=re.DOTALL)
-    text = re.sub(r"<footer[^>]*>.*?</footer>", "", text, flags=re.DOTALL)
-    # Convert block elements to newlines
-    text = re.sub(r"<(?:p|li|h[1-6]|div|br)[^>]*>", "\n", text)
-    # Convert HTML entities
-    text = text.replace("&nbsp;", " ").replace("&#x301;", "\u0301")
-    # Strip remaining tags
-    text = re.sub(r"<[^>]+>", "", text)
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup(html, "html.parser")
+    for elem in soup(["script", "style", "nav", "header", "footer"]):
+        elem.decompose()
+
+    text = soup.get_text(separator="\n")
+    # BeautifulSoup unescapes standard entities.
+    text = text.replace("\xa0", " ")
+    # Just in case &#x301; didn't unescape:
+    text = text.replace("&#x301;", "\u0301")
+
     text = re.sub(r"\n{3,}", "\n\n", text)
     # Find where the rule content starts (§ or first Cyrillic block)
     match = re.search(r"§\s*\d|(?:Апостроф|Велика|Подвоєння|М.який|Чергування)", text)

--- a/scripts/wiki/migrate_external_chunks.py
+++ b/scripts/wiki/migrate_external_chunks.py
@@ -300,7 +300,8 @@ def chunk_text(
 def extract_video_id(url: str) -> str:
     """Extract a stable video/article identifier from a URL."""
     parsed = urlparse(url)
-    if "youtube.com" in parsed.netloc:
+    netloc_lower = parsed.netloc.lower()
+    if netloc_lower in {"youtube.com", "www.youtube.com"} or netloc_lower.endswith(".youtube.com"):
         values = parse_qs(parsed.query).get("v")
         if values:
             return values[0]

--- a/scripts/wiki/migrate_sources.py
+++ b/scripts/wiki/migrate_sources.py
@@ -684,6 +684,16 @@ def _is_citation_only_body(body: str, files: list[str]) -> bool:
     return not scrubbed.strip()
 
 
+def _has_wikipedia_domain(normalized: str) -> bool:
+    from urllib.parse import urlparse
+    if "http" in normalized:
+        try:
+            netloc = urlparse(normalized).netloc.lower()
+            return netloc == "wikipedia.org" or netloc.endswith(".wikipedia.org")
+        except Exception:
+            pass
+    return False
+
 def _looks_like_source_label(token: str) -> bool:
     normalized = normalize_source_filename(token)
     if not normalized:
@@ -695,7 +705,7 @@ def _looks_like_source_label(token: str) -> bool:
         or _HASH_SOURCE_RE.fullmatch(normalized)
         or normalized.startswith(("Wikipedia:", "wikipedia:", "За ", "Із ", "From "))
         or "/wiki/" in normalized
-        or "wikipedia.org" in normalized
+        or _has_wikipedia_domain(normalized)
         or "-" in normalized
         or "_" in normalized
         or bool(_PERSON_SOURCE_RE.fullmatch(normalized))

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -337,7 +337,10 @@ class TestEnrichIntegration:
         urok_tab = result.split("<!-- TAB:Словник -->")[0]
         assert "YouTubeVideo" not in urok_tab
         # References
-        assert "ukrainianlessons.com" in result
+        import re
+        from urllib.parse import urlparse
+        urls = re.findall(r'https?://[^\s)"]+', result)
+        assert any(urlparse(u).netloc in {"ukrainianlessons.com", "www.ukrainianlessons.com"} for u in urls)
         # All 4 tabs
         assert "<!-- TAB:Урок -->" in result
         assert "<!-- TAB:Словник -->" in result

--- a/tests/test_publish_step.py
+++ b/tests/test_publish_step.py
@@ -252,7 +252,10 @@ class TestBuildResourcesTabFull:
              patch("build.enrich._PROJECT_ROOT", tmp_path):
             result = _build_resources_tab_full("a1", "test-mod")
             assert "ULP Episode 1" in result
-            assert "https://example.com" in result
+            import re
+            from urllib.parse import urlparse
+            urls = re.findall(r'https?://[^\s)"]+', result)
+            assert any(urlparse(u).netloc == "example.com" for u in urls)
 
     def test_no_plan_falls_back(self, tmp_path):
         """Shows the localized placeholder when no resources exist."""

--- a/tests/test_stress_annotation.py
+++ b/tests/test_stress_annotation.py
@@ -91,11 +91,12 @@ class TestBuildSkipMask:
         assert text[start:end] == "```some code```"
 
     def test_url_detected(self):
+        from urllib.parse import urlparse
         text = "see https://example.com/path for info"
         ranges = _build_skip_mask(text)
         assert len(ranges) >= 1
         covered = text[ranges[0][0]:ranges[0][1]]
-        assert "https://example.com" in covered
+        assert urlparse(covered).netloc == "example.com"
 
     def test_inline_code_detected(self):
         text = "Use `код` here"

--- a/tests/test_video_discovery.py
+++ b/tests/test_video_discovery.py
@@ -389,7 +389,10 @@ class TestFormatBlogDiscovery:
              "relevance_score": 0.8, "topics": ["grammar"]},
         ])
         assert "Test" in result
-        assert "https://x.com" in result
+        import re
+        from urllib.parse import urlparse
+        urls = re.findall(r'https?://[^\s)"]+', result)
+        assert any(urlparse(u).netloc == "x.com" for u in urls)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves Batch C of CodeQL warnings:

- 8 `py/incomplete-url-substring-sanitization`: switched to `urlparse()` with anchored netloc check
- 4 `py/bad-tag-filter`: switched to BeautifulSoup parser for HTML, and fixed regex matching for markdown comments by adding `re.DOTALL`.