### PR TITLE
fix(test): align test_discuss_replies with round-1 short-circuit block

### DIFF
--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -226,16 +226,26 @@ def test_discuss_replies_create_delivered_reply_deliveries(mock_invoke, monkeypa
 
     mock_invoke.side_effect = _discuss_result
 
+    # Round 1 cannot short-circuit (per `_channels_cli.py:1290-1304` — round 1
+    # is parallel fan-out, agents haven't seen each other's replies yet, so
+    # [AGREE] in round 1 means "I'm done with my answer" not cross-agent
+    # assent). Convergence requires ≥ round 2, so use --max-rounds 2 here.
+    # Pre-protocol-fix this test passed with --max-rounds 1; updated 2026-05-05
+    # to match the round-1 short-circuit block (commit 872d8791).
     exit_code = _run_cli(
-        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "1"]
+        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "2"]
     )
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "✅ converged at round 1" in captured.out
+    assert "✅ converged at round 2" in captured.out
 
+    # Each round produces N*(N-1) reply deliveries (each agent's reply is
+    # delivered to every OTHER agent). With 2 agents × 2 rounds = 4 deliveries.
     reply_deliveries = _reply_deliveries()
-    assert len(reply_deliveries) == 2
+    assert len(reply_deliveries) == 4
+    # Set collapses duplicates across rounds — still just 2 distinct
+    # (from, to, status) tuples for the 2-agent case.
     assert {
         (row["from_agent"], row["to_agent"], row["status"])
         for row in reply_deliveries


### PR DESCRIPTION
## Summary

Pre-existing main breakage. The deliberation-protocol fix (commit \`872d8791\` from 2026-05-05) added a hard block on round-1 convergence in \`scripts/ai_agent_bridge/_channels_cli.py:1290-1304\`. Round 1 is parallel fan-out — agents haven't seen each other's replies yet, so [AGREE] in round 1 is "I'm done with my answer" not cross-agent assent. Convergence requires ≥ round 2.

The test \`test_discuss_replies_create_delivered_reply_deliveries\` was written for the pre-fix protocol with \`--max-rounds 1\` and expected "✅ converged at round 1". With the new protocol, max-rounds=1 can never converge.

This split-out PR fixes only that test. Originally bundled into PR #1686 (claude CLI dispatch fix), but Codex's adversarial review flagged the bundling as an AGENTS.md:22 + 121-130 violation (one PR = one concern). Splitting per Codex's recommendation.

## Changes

- \`tests/test_bridge_inbox_cli.py\`: \`--max-rounds 1\` → \`--max-rounds 2\`
- Expected output: "✅ converged at round 2"
- Expected reply deliveries count: 2 → 4 (each round produces N×(N-1) deliveries; 2 agents × 2 rounds = 4)
- The \`(from, to, status)\` set assertion still holds — set collapses duplicates across rounds
- Added explanatory comment with cross-reference to \`_channels_cli.py:1290-1304\`

## Test plan

- [x] \`pytest tests/test_bridge_inbox_cli.py::test_discuss_replies_create_delivered_reply_deliveries\` passes
- [x] All 19 tests in \`tests/test_bridge_inbox_cli.py\` pass
- [ ] CI green

🤖 Split out from PR #1686 per Codex adversarial review on 2026-05-05.