### PR TITLE
test(delegate): isolate test_dispatch_creates_worktree from real .worktrees/ dir (#1682)

### DIFF
--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -683,10 +683,11 @@ def _make_run_stub(
     return calls, fake_run
 
 
-def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, capsys):
+def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
     import argparse
 
     recorded_prompt: dict[str, str] = {}
+    worktree_path = tmp_path / ".worktrees" / "codex-1383"
 
     class _FakeStdin:
         def write(self, data):
@@ -712,7 +713,7 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, monkeypatch, ca
         mode="danger",
         model=None,
         cwd=None,
-        worktree=".worktrees/codex-1383",
+        worktree=str(worktree_path),
         base="main",
         hard_timeout=3600,
     )


### PR DESCRIPTION
## Summary

Fixes `tests/test_delegate.py::test_dispatch_creates_worktree_and_records_it` flaking on machines where `.worktrees/codex-1383/` exists on disk.

## Approach

Option A: `delegate.py` already accepts an explicit worktree path through `args.worktree`, and `_normalize_worktree_path` supports absolute paths. The test now passes a `tmp_path` worktree path with the same `.worktrees/codex-1383` suffix, so it exercises the same dispatch behavior without consulting the real repo-local `.worktrees/` directory.

## Verification

- Reproduced the original failure with `mkdir -p .worktrees/codex-1383/data` before run
- Verified the fixed test passes with that stale directory present
- Fix passes 3 consecutive runs
- Full `tests/test_delegate.py` suite green
- ruff clean

Closes #1682.
