### PR TITLE
feat(prompts): Tier-1 verification discipline for V7 writer + reviewer (#1661, #1673)

### DIFF
--- a/docs/dispatch-briefs/2026-05-05-cot-tier1-pilot-guide.md
+++ b/docs/dispatch-briefs/2026-05-05-cot-tier1-pilot-guide.md
@@ -1,0 +1,148 @@
+# 2026-05-05 — CoT scaffolding + Tier-1 verification pilot guide (#1673 + #1661)
+
+This guide describes how to run the 3-module ablation pilot for the V7
+prompt-discipline diff that combines:
+
+- **#1673** — chain-of-thought reasoning checklist (writer + reviewer)
+- **#1661** — Tier-1 verification discipline (writer) and audit (reviewer)
+
+The diff itself is in PR (link in commit body). Until the pilot runs and
+the user signs off, the PR stays **DRAFT**. Per memory rule
+`PROMPT-ABLATION DISCIPLINE`, pipeline-prompt changes pilot on ≥ 3 seeded
+modules before any `--range` rollout.
+
+## What the prompts now require
+
+**Writer (`scripts/build/phases/linear-write.md`):**
+
+1. Reasoning checklist (CoT, 4 steps): word-budget per section, plan-vocab
+   terms, register check, teaching sequence.
+2. Tier-1 verification discipline (5 steps): VESUM word-verification,
+   modern Ukrainian default, source-citation discipline, quote-attribution
+   discipline, end-of-output gate.
+
+**Reviewer (`scripts/build/phases/linear-review-dim.md`):**
+
+1. Per-dim CoT (4 steps): list 3 verbatim quotes, map to rubric, aggregate
+   score, verdict.
+2. Tier-1 verification audit (5 items A–E): source-attribution audit,
+   quote verification, sovietization flag (decolonization / naturalness),
+   modern Ukrainian guard, reinforce rule #6.
+
+## Three modules to pilot
+
+Pick three seeded modules across levels so the pilot covers different
+content types (vocabulary lesson, grammar lesson, advanced/grammar).
+The `tests/test_prompt_cot_tier1_scaffolding.py` ablation already verifies
+these three plans render against the new templates with no template-token
+or placeholder failures, so the writer call will not crash on a malformed
+prompt:
+
+| Level | Slug | Plan | Notes |
+|-------|------|------|-------|
+| a1 | `my-morning` | `curriculum/l2-uk-en/plans/a1/my-morning.yaml` | A1 reflexive verbs, prior round-3.5 baseline exists |
+| a2 | `a2-bridge` | `curriculum/l2-uk-en/plans/a2/a2-bridge.yaml` | A2 review/bridge module |
+| b1 | `adjectives-comparative` | `curriculum/l2-uk-en/plans/b1/adjectives-comparative.yaml` | B1 grammar lesson |
+
+Substitute different slugs if any of these have un-shippable plans by the
+time the pilot runs — the only requirement is each plan passes
+`linear_pipeline.plan_check` AND has a prior baseline output for diffing.
+
+## Run the pilot
+
+For each module above, one at a time, run the V7 build with the writer
+backend you want to evaluate (default `claude-tools`):
+
+```bash
+.venv/bin/python scripts/build/v7_build.py a1 my-morning \
+    --writer claude-tools \
+    --out /tmp/v7-pilot/a1-my-morning
+```
+
+```bash
+.venv/bin/python scripts/build/v7_build.py a2 a2-bridge \
+    --writer claude-tools \
+    --out /tmp/v7-pilot/a2-a2-bridge
+```
+
+```bash
+.venv/bin/python scripts/build/v7_build.py b1 adjectives-comparative \
+    --writer claude-tools \
+    --out /tmp/v7-pilot/b1-adjectives-comparative
+```
+
+`--out` keeps the pilot artifacts out of `curriculum/` so they do not
+overwrite the live tree. The writer prompt, knowledge packet, generated
+artifacts, Python QG, and LLM QG report all land under that directory.
+
+> Per memory rule **BATCH COMMANDS — NEVER RUN, ONLY SUGGEST** the user
+> runs the builds — Claude does not. This guide is documentation. If
+> Claude is asked to run a single-module build for verification it is
+> still **one slug at a time**, never `--range`.
+
+For the `gemini-tools` cross-family run (recommended for the cross-review
+hook in the PR body):
+
+```bash
+.venv/bin/python scripts/build/v7_build.py a1 my-morning \
+    --writer gemini-tools \
+    --out /tmp/v7-pilot-gemini/a1-my-morning
+```
+
+## Compare and score
+
+For each pilot module:
+
+1. **Compare output.** If a `<slug>.bak.md` baseline exists in the live
+   curriculum tree, diff `module.md` from the pilot vs. the baseline.
+   The diff should show: more verified example words, fewer or no
+   ungroundable source citations, no fused literary quotes, and per-section
+   word counts matching the contract budgets the writer reasoned out
+   in step 1 of CoT.
+2. **Re-run the per-dim reviewer** on the pilot artifacts (already part of
+   `v7_build.py`'s LLM QG step). Compare per-dim scores and FLAG strings
+   against the pre-CoT/Tier-1 baseline. Expect (a) decolonization +
+   naturalness scores to either rise OR drop with FLAG strings naming the
+   specific failures, and (b) `evidence` fields to be verbatim quotes from
+   the actual artifacts (not paraphrased summaries) — that's the rule #6
+   reinforcement.
+3. **Capture findings.** Write a short pilot report under
+   `docs/reports/2026-05-05-cot-tier1-pilot-<slug>.md` with the
+   before/after diff and the per-dim score deltas.
+
+## User-facing checklist (to sign off the DRAFT PR)
+
+- [ ] Did fabricated source citations drop or surface as
+      `unverified citation` FLAG strings?
+- [ ] Did fused / non-existent literary quotes drop or surface as
+      `fabricated quote` FLAG strings?
+- [ ] Did per-section word counts hold within the ±10% contract budget
+      the CoT block forces the writer to commit to?
+- [ ] Did per-dim reviews cite specific verbatim quotes rather than
+      paraphrased summaries?
+- [ ] Did the writer leave `<!-- VERIFY: lemma "X" not in VESUM -->`
+      markers when it could not ground a candidate, instead of silently
+      substituting a confabulated alternative?
+- [ ] (Cross-family) Did Gemini-as-writer behave the same way the
+      Claude-as-writer pilot did, on the same slug?
+
+If all six check out across the three modules, the PR can leave DRAFT and
+go to merge review. If any of the six fail on ≥ 1 module, write the
+pilot report, add a follow-up issue (or amend this brief), and keep the
+PR DRAFT.
+
+## After the pilot — follow-up
+
+EPIC #1657 Phase 2 introduces single-call MCP primitives `verify_quote`,
+`verify_source_attribution`, `check_modern_form`. When that lands, the
+discipline blocks in this PR collapse from multi-tool composition to
+1-tool calls. That simplification PR should reference this one and remove
+the now-redundant tool-name lists from both prompts. Bounded throwaway
+risk on the prompt blocks: ~50 lines.
+
+## Related
+
+- Parent EPIC: #1657 — verification-layer architecture
+- Tier ordering: `docs/session-state/2026-05-04-tools-before-a1-20.md`
+- Сибір case study: search prior session handoffs for "fabricated citations"
+- Decision (writer-choice still open): `docs/decisions/2026-04-26-reboot-agent-responsibilities.md` §3

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -38,6 +38,50 @@ The JSON `evidence` field below MUST be one of the verbatim quotes from
 step 1, wrapped in escaped quotes. A summary or paraphrase in the evidence
 field is a reviewer-protocol failure.
 
+## Tier-1 verification audit (do this DURING evidence search — #1661)
+
+Сибір case study (May 2026): an unhardened reviewer let two fabricated
+citations and a fused Shevchenko line pass on the writer's first try.
+Run this audit on every quote / citation / claim in the Generated Content
+that touches dimension `{DIM}`. The audit feeds the evidence list above:
+unverified items become FLAG strings in your evidence and weigh the score
+down, not silent passes.
+
+A. **Source-attribution audit (all dims).** For every dictionary /
+   style-guide / author cited in the Generated Content, verify via the
+   matching MCP tool (`search_definitions` for СУМ-11,
+   `search_style_guide` for Антоненко-Давидович,
+   `search_grinchenko_1907` for Грінченко, `query_pravopys` for Правопис,
+   `search_esum` for ЕСУМ). No matching hit → FLAG `unverified citation`,
+   treat as score-against.
+
+B. **Quote verification (all dims).** For every authored quote attributed
+   to a literary source, run `mcp__sources__search_literary` for the exact
+   line. Line not found as a contiguous string → FLAG `fabricated quote`.
+   Two sources fused into one attributed line is the same failure.
+
+C. **Sovietization flag (decolonization, naturalness).** When the content
+   draws from `search_definitions` (СУМ-11) for politically loaded
+   headwords (`ленін*`, `більшовик*`, `радянськ*`, `соціалістичн*`,
+   `партійн*`, `національн*`, `школа`, `шлях`, `прапор`), apply
+   heightened scrutiny. The result row's `sovietization_risk` field
+   (0/1/2) is ground truth; until it is wired through the writer, fall
+   back to the keyword regex above. Soviet framing reproduced into the
+   module without paraphrase or correction → FLAG
+   `soviet-framed definition unsupervised`.
+
+D. **Modern Ukrainian guard (naturalness, decolonization).** Flag
+   historical / Old East Slavic / Russian-shadow / pre-Pravopys-2019
+   forms presented in the module as modern Ukrainian. VESUM
+   (`verify_word`, `check_modern_form`) is ground truth for what is
+   modern. Archaic form passed off as standard → FLAG
+   `archaic form as modern`.
+
+E. **Reinforce rule #6.** Every claim pairs (i) a verbatim quote from the
+   content and (ii) a specific MCP-grounded verification or an explicit
+   absence-of-verification flag. A `PASS` with no grounded evidence is a
+   reviewer-protocol failure.
+
 Return only JSON:
 
 ```json

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -30,10 +30,11 @@ mode that bit Phase 4 round 3.5.
    contract violation; a required term that appears only as a translation
    gloss without a Ukrainian sentence is also insufficient.
 
-3. **Register check.** Re-read the Immersion Rule above. State internally:
-   "I will produce ~{X}% Ukrainian and ~{100-X}% English in module.md." If
-   your draft starts drifting (English bridge sentences expanding, Ukrainian
-   examples shrinking), STOP and rebudget — do not push through.
+3. **Register check.** Re-read the Immersion Rule above. State internally,
+   filling in the percentages it sets: "I will produce ~X% Ukrainian and
+   ~(100−X)% English in module.md." If your draft starts drifting (English
+   bridge sentences expanding, Ukrainian examples shrinking), STOP and
+   rebudget — do not push through.
 
 4. **Teaching sequence.** Re-read the Knowledge Packet below. Each citation
    [S1], [S2], etc. is a fact you will teach or anchor on. Decide the
@@ -44,6 +45,45 @@ mode that bit Phase 4 round 3.5.
    marker.
 
 Only after this reasoning is complete, emit the four fenced blocks below.
+
+## Tier-1 verification discipline (do this WHILE drafting — #1661)
+
+Сибір case study (May 2026): an unhardened answer shipped two fabricated
+citations (a Грінченко example with no Грінченко entry behind it,
+an Антоненко-Давидович claim with no style-guide entry) and one fused
+Shevchenko line that does not exist as composed. These five checks block
+that failure class. Run each check while drafting, not as a separate pass.
+
+1. **Verify every example word in VESUM.** Every Ukrainian lemma listed as
+   an example, vocabulary entry, or grammar exemplar must confirm via
+   `mcp__sources__verify_words`. Failed verification → OMIT. Do NOT
+   silently substitute a confabulated alternative. If no good substitute,
+   leave the slot empty and emit `<!-- VERIFY: lemma "X" not in VESUM -->`.
+
+2. **Modern Ukrainian only.** Default to post-2019 Pravopys forms. No
+   Old East Slavic, Church Slavonic, Russian-shadow, or pre-Pravopys-2019
+   spellings unless the section is explicitly historical / etymological.
+   Doubt → `mcp__sources__check_modern_form`. Archaic-only → swap or omit.
+
+3. **Source-citation discipline.** Every dictionary / style-guide / author
+   citation MUST be groundable in MCP via the matching tool
+   (`search_definitions` for СУМ-11, `search_style_guide` for
+   Антоненко-Давидович, `search_grinchenko_1907` for Грінченко,
+   `query_pravopys` for Правопис, `search_esum` for ЕСУМ). Cannot ground
+   → do NOT cite. Say "modern Ukrainian standardized form" or rephrase
+   without attribution. Inventing a citation to look authoritative is a
+   hard fail.
+
+4. **Quote attribution discipline.** Every attributed quote must be a
+   contiguous string findable via `mcp__sources__search_literary`. Never
+   fuse two separate sources into one attributed line. Exact line not
+   found → drop the quote or paraphrase without attribution.
+
+5. **End-of-output gate.** Before emitting the four fenced blocks, scan
+   the draft once more: every example word against the verification you
+   ran, every cited source for grounding, every quote for literal corpus
+   presence. OMIT or rewrite anything unverifiable. Shipping unverified
+   output for the reviewer to catch is itself a protocol violation.
 
 Return only these four fenced blocks, in this exact order. Do not add prose
 before, between, or after the blocks.

--- a/tests/test_prompt_cot_tier1_scaffolding.py
+++ b/tests/test_prompt_cot_tier1_scaffolding.py
@@ -1,0 +1,197 @@
+"""Structural assertions for the V7 writer + reviewer prompts.
+
+Locks two coordinated prompt-discipline features:
+  - #1673 chain-of-thought reasoning checklist (4 numbered steps)
+  - #1661 Tier-1 verification discipline / audit (5 numbered/lettered items)
+
+Renders ``linear-write.md`` and ``linear-review-dim.md`` against three
+already-validated reference plans (a1/my-morning, b1/aspect-future-tense,
+a2/a2-bridge) and asserts the structural markers + verbatim discipline
+text are present and that no ``{TOKEN}`` placeholders survived rendering.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from scripts.build import linear_pipeline
+from scripts.common.thresholds import QG_DIMS
+
+REFERENCE_PLANS: tuple[tuple[str, str], ...] = (
+    ("a1", "my-morning"),
+    ("a2", "a2-bridge"),
+    ("b1", "adjectives-comparative"),
+)
+
+WRITER_TEMPLATE = (
+    linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+)
+REVIEWER_TEMPLATE = (
+    linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-review-dim.md"
+)
+
+WRITER_COT_HEADER = (
+    "## Reasoning checklist (do this BEFORE drafting — #1673)"
+)
+WRITER_TIER1_HEADER = (
+    "## Tier-1 verification discipline (do this WHILE drafting — #1661)"
+)
+REVIEWER_COT_HEADER = (
+    "## Reasoning checklist (do this BEFORE scoring — #1673)"
+)
+REVIEWER_TIER1_HEADER = (
+    "## Tier-1 verification audit (do this DURING evidence search — #1661)"
+)
+
+WRITER_TIER1_BULLETS = (
+    "Verify every example word in VESUM",
+    "Modern Ukrainian only",
+    "Source-citation discipline",
+    "Quote attribution discipline",
+    "End-of-output gate",
+)
+
+REVIEWER_TIER1_BULLETS = (
+    "Source-attribution audit (all dims)",
+    "Quote verification (all dims)",
+    "Sovietization flag (decolonization, naturalness)",
+    "Modern Ukrainian guard (naturalness, decolonization)",
+    "Reinforce rule #6",
+)
+
+# Plain ``{NAME}`` placeholders the renderer is supposed to substitute.
+# Anything matching this pattern after rendering is unresolved.
+PLACEHOLDER_RE = re.compile(r"\{([A-Z][A-Z0-9_]+)\}")
+
+
+def _writer_prompt(level: str, slug: str) -> str:
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.plan_check(plan_path)
+    plan_content = plan_path.read_text(encoding="utf-8")
+    context = linear_pipeline.writer_context(
+        plan, plan_content, "Knowledge packet stub for prompt-rendering ablation."
+    )
+    return linear_pipeline.render_phase_prompt(WRITER_TEMPLATE, context)
+
+
+def _reviewer_prompt(level: str, slug: str, dim: str) -> str:
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.plan_check(plan_path)
+    plan_content = plan_path.read_text(encoding="utf-8")
+    return linear_pipeline.render_review_prompt(
+        plan,
+        plan_content,
+        "Generated content stub for prompt-rendering ablation.",
+        dim,
+    )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+def test_writer_prompt_has_cot_block(level: str, slug: str) -> None:
+    rendered = _writer_prompt(level, slug)
+    assert rendered.count(WRITER_COT_HEADER) == 1, (
+        f"Writer CoT header missing or duplicated for {level}/{slug}"
+    )
+    for n in (1, 2, 3, 4):
+        assert f"\n{n}. **" in rendered, (
+            f"Writer CoT step {n} marker missing for {level}/{slug}"
+        )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+def test_writer_prompt_has_tier1_discipline(level: str, slug: str) -> None:
+    rendered = _writer_prompt(level, slug)
+    assert rendered.count(WRITER_TIER1_HEADER) == 1, (
+        f"Writer Tier-1 header missing or duplicated for {level}/{slug}"
+    )
+    for bullet in WRITER_TIER1_BULLETS:
+        assert bullet in rendered, (
+            f"Writer Tier-1 bullet missing: {bullet!r} for {level}/{slug}"
+        )
+    # MCP tool callouts must survive into the rendered prompt verbatim
+    # so the writer routes verification through MCP, not pre-training.
+    for tool in (
+        "mcp__sources__verify_words",
+        "mcp__sources__check_modern_form",
+        "mcp__sources__search_literary",
+        "search_definitions",
+        "search_style_guide",
+        "search_grinchenko_1907",
+        "query_pravopys",
+        "search_esum",
+    ):
+        assert tool in rendered, (
+            f"Writer Tier-1 MCP-tool reference missing: {tool!r} for {level}/{slug}"
+        )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+def test_writer_prompt_has_no_unresolved_placeholders(level: str, slug: str) -> None:
+    rendered = _writer_prompt(level, slug)
+    leftover = sorted(set(PLACEHOLDER_RE.findall(rendered)))
+    assert not leftover, f"Unresolved placeholders for {level}/{slug}: {leftover}"
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+@pytest.mark.parametrize("dim", QG_DIMS)
+def test_reviewer_prompt_has_cot_block(level: str, slug: str, dim: str) -> None:
+    rendered = _reviewer_prompt(level, slug, dim)
+    assert rendered.count(REVIEWER_COT_HEADER) == 1, (
+        f"Reviewer CoT header missing or duplicated for {level}/{slug} dim={dim}"
+    )
+    for n in (1, 2, 3, 4):
+        assert f"\n{n}. **" in rendered, (
+            f"Reviewer CoT step {n} marker missing for {level}/{slug} dim={dim}"
+        )
+    assert f"Assigned dimension: {dim}" in rendered, (
+        f"Assigned-dimension token did not interpolate for {level}/{slug} dim={dim}"
+    )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+@pytest.mark.parametrize("dim", QG_DIMS)
+def test_reviewer_prompt_has_tier1_audit(level: str, slug: str, dim: str) -> None:
+    rendered = _reviewer_prompt(level, slug, dim)
+    assert rendered.count(REVIEWER_TIER1_HEADER) == 1, (
+        f"Reviewer Tier-1 header missing or duplicated for {level}/{slug} dim={dim}"
+    )
+    for bullet in REVIEWER_TIER1_BULLETS:
+        assert bullet in rendered, (
+            f"Reviewer Tier-1 bullet missing: {bullet!r} for {level}/{slug} dim={dim}"
+        )
+    for flag in (
+        "unverified citation",
+        "fabricated quote",
+        "soviet-framed definition unsupervised",
+        "archaic form as modern",
+    ):
+        assert flag in rendered, (
+            f"Reviewer Tier-1 FLAG name missing: {flag!r} for {level}/{slug} dim={dim}"
+        )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+@pytest.mark.parametrize("dim", QG_DIMS)
+def test_reviewer_prompt_has_no_unresolved_placeholders(
+    level: str, slug: str, dim: str
+) -> None:
+    rendered = _reviewer_prompt(level, slug, dim)
+    leftover = sorted(set(PLACEHOLDER_RE.findall(rendered)))
+    assert not leftover, (
+        f"Unresolved placeholders for {level}/{slug} dim={dim}: {leftover}"
+    )
+
+
+def test_writer_and_reviewer_share_sibir_provenance() -> None:
+    writer = WRITER_TEMPLATE.read_text(encoding="utf-8")
+    reviewer = REVIEWER_TEMPLATE.read_text(encoding="utf-8")
+    # Both prompts cite the same case study so the discipline traces back to a
+    # named, reproducible failure rather than a vague "be careful" instruction.
+    assert "Сибір case study" in writer
+    assert "Сибір case study" in reviewer
+    assert "#1661" in writer
+    assert "#1661" in reviewer
+    assert "#1673" in writer
+    assert "#1673" in reviewer


### PR DESCRIPTION
## Summary

Adds **Tier-1 verification discipline (#1661)** on top of the existing
**chain-of-thought scaffolding (#1673)** in V7 writer + reviewer prompts.
Both issues touch `scripts/build/phases/linear-write.md` and
`scripts/build/phases/linear-review-dim.md`; merging them as one diff
avoids merge churn on identical regions.

The Сибір case study (May 2026) showed an unhardened answer shipped two
fabricated source citations (a Грінченко example with no Грінченко entry,
an Антоненко-Давидович claim with no style-guide entry) and a fused
Shevchenko line that does not exist as composed. This PR blocks that
failure class at both the writer and reviewer prompts.

Closes #1673 and #1661 once the pilot signs off.

## Diffs

### `scripts/build/phases/linear-write.md`

- New **Tier-1 verification discipline** block (5 numbered steps):
  - Verify every example word in VESUM (`mcp__sources__verify_words`).
    Failed → OMIT, do NOT substitute. Mark gaps with explicit
    `<!-- VERIFY: lemma "X" not in VESUM -->`.
  - Modern Ukrainian only — default to post-2019 Pravopys; doubt →
    `mcp__sources__check_modern_form`.
  - Source-citation discipline — every cited dictionary / style-guide /
    author MUST ground via the matching MCP tool; cannot ground → do NOT
    cite.
  - Quote-attribution discipline — every attributed quote must verify as
    a contiguous string via `mcp__sources__search_literary`; never fuse
    two separate sources into one attributed line.
  - End-of-output gate — final scan over example words, sources, and
    quotes before emitting the four fenced blocks.
- Fixed a pre-existing rendering bug in the #1673 CoT block: the
  register-check step had `~{X}%` / `~{100-X}%` literals that
  `scripts/build/prompt_builder.py`'s brace validator rejected. Rewrote
  as `~X%` / `~(100−X)%`. Confirmed via the existing failing test
  `test_render_phase_prompt_fills_registered_tokens` flipping to PASS.

### `scripts/build/phases/linear-review-dim.md`

- New **Tier-1 verification audit** block (5 lettered items):
  - A. Source-attribution audit (all dims) → FLAG `unverified citation`.
  - B. Quote verification (all dims) → FLAG `fabricated quote`.
  - C. Sovietization flag (decolonization, naturalness) → FLAG
       `soviet-framed definition unsupervised`.
  - D. Modern Ukrainian guard (naturalness, decolonization) → FLAG
       `archaic form as modern`.
  - E. Reinforce non-negotiable rule #6 — every claim pairs verbatim
       quote + MCP-grounded verification (or explicit absence-of-verification
       flag); a `PASS` with no grounded evidence is protocol-failure.

### Tests — `tests/test_prompt_cot_tier1_scaffolding.py` (new)

- Renders both prompts against 3 already-validated reference plans
  (`a1/my-morning`, `a2/a2-bridge`, `b1/adjectives-comparative`) crossed
  with all 5 QG dimensions for the reviewer.
- Asserts CoT structure (4 steps), Tier-1 structure (5 steps / 5 items),
  MCP tool callouts, FLAG strings, and Сибір/issue-ref provenance survive
  into rendered output.
- Asserts no `{TOKEN}` placeholders leak through unresolved, locking the
  `{X}` regression that was already on `main`.
- 55 cases, all green.

### Pilot guide — `docs/dispatch-briefs/2026-05-05-cot-tier1-pilot-guide.md` (new)

Documents the 3-module ablation pathway and the user-sign-off checklist
for taking this PR out of DRAFT. Per memory rule
`PROMPT-ABLATION DISCIPLINE`, pipeline-prompt changes pilot on ≥3 seeded
modules before any `--range` rollout.

## V6 currency check

V6 prompts (`scripts/build/phases/v6-write.md`, `v6-review.md`) are
loaded only by `scripts/build/v6_build.py`. Per the dispatch brief's V6
decision rule, V6 is treated as deprecated for new discipline and is
**NOT mirrored** here. Recommend opening a separate cleanup issue to
track V6 prompt drift once V6 is formally retired.

## Why ship now vs. wait for EPIC #1657 Phase 2

Phase 2 introduces single-call MCP primitives (`verify_quote`,
`verify_source_attribution`, `check_modern_form`) that simplify these
diffs from multi-tool composition to 1-tool calls. But:

- A1/20 build (POC step 3) currently runs against unhardened prompts;
  this PR unblocks the Checkpoint-A user eval against fewer
  avoidable-error-class outputs.
- The discipline added here still works after Phase 2 — Phase 2 just
  collapses 4-tool composition into 1-tool calls.
- Throwaway risk is bounded: ~50 lines of prompt logic that gets
  simplified later, not deleted.

## Why DRAFT

Pipeline-prompt changes pilot on ≥3 modules before bulk per
`PROMPT-ABLATION DISCIPLINE`. PR stays DRAFT until the pilot runs and
the user signs off via the checklist in the pilot guide.

## Cross-review request

cc the user — needs cross-family review (Codex or Gemini, opposite of
whoever drafted) on:

- Token efficiency — every block earns its tokens?
- Pedagogical soundness — does the CoT block actually force the right
  reasoning, or does it become ritual the writer reads-and-skips?
- Verification escapability — can a writer / reviewer route around the
  new discipline (e.g., paraphrase a fabricated quote so it is no longer
  "attributed")?

## Test plan

- [x] `pytest tests/test_prompt_cot_tier1_scaffolding.py` — 55 passed
- [x] `pytest tests/build/test_linear_pipeline.py` — 128 passed
      (includes the previously-failing `{X}` render test, now PASS)
- [x] `pytest tests/test_prompt_substitution.py tests/test_prompt_health.py tests/test_prompt_assembly.py` — clean
- [x] `ruff check tests/test_prompt_cot_tier1_scaffolding.py scripts/build/phases/` — clean
- [ ] User runs the 3-module pilot per
      `docs/dispatch-briefs/2026-05-05-cot-tier1-pilot-guide.md` and
      signs off the 6-item checklist
- [ ] Cross-family reviewer signs off on token-efficiency / pedagogical /
      escapability dimensions
- [ ] Follow-up issue tracks simplifying both diffs against EPIC #1657
      Phase 2 primitives once they land

🤖 Generated with [Claude Code](https://claude.com/claude-code)