### PR TITLE
chore(mcp): remove search_etymology deprecation alias (#1679)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -17,7 +17,7 @@ Tools:
     - search_sources, search_text, search_literary, search_external, search_images, get_chunk_context
     - verify_word, verify_words, verify_lemma (VESUM)
     - query_wikipedia, query_pravopys, query_e2u, query_r2u, query_ulif
-    - search_definitions, search_etymology, search_esum, search_idioms, search_synonyms
+    - search_definitions, search_grinchenko_1907, search_esum, search_idioms, search_synonyms
     - search_style_guide (Антоненко-Давидович)
     - translate_en_uk (Балла)
 """
@@ -575,33 +575,20 @@ async def list_tools() -> list[Tool]:
             description=(
                 "Search Грінченко «Словарь української мови» (1907) — historical "
                 "Ukrainian lexicographic dictionary. Coverage: 67,275 of canonical "
-                "~67K entries (~100% indexed). **NOT etymology** despite the legacy "
-                "alias `search_etymology` — this is lexicographic (definitions + "
-                "usage citations), not diachronic word-origin analysis. True "
+                "~67K entries (~100% indexed). **NOT etymology** — this is "
+                "lexicographic (definitions + usage citations), not diachronic "
+                "word-origin analysis. True "
                 "etymology lives in `search_esum` (ЕСУМ, vol 1 А–Г live; vols 2-6 "
                 "pending #1662). **Systematic exclusion: proper nouns** — toponyms "
                 "(Київ, Львів, Дніпро, Сибір) and personal names (Шевченко) are NOT "
                 "covered. Use for pre-Soviet Ukrainian usage attestation: helps "
-                "verify a word is genuinely Ukrainian, not a Soviet-era import. "
-                "Renamed from `search_etymology` 2026-05-04 (#1658)."
+                "verify a word is genuinely Ukrainian, not a Soviet-era import."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Ukrainian word to look up historical form/usage"},
                     "limit": {"type": "integer", "description": "Max results (default 3)", "default": 3},
-                },
-                "required": ["query"]
-            },
-        ),
-        Tool(
-            name="search_etymology",
-            description="DEPRECATED alias for search_grinchenko_1907. Do not use. Will be removed in 30 days.",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "query": {"type": "string", "description": "Ukrainian word"},
-                    "limit": {"type": "integer", "description": "Max results", "default": 3},
                 },
                 "required": ["query"]
             },
@@ -654,7 +641,7 @@ async def list_tools() -> list[Tool]:
                 "Ukrainian lexicography. Quality audit pending under EPIC #1657 "
                 "Tier 3. Use for vocabulary variety and rough synonym/antonym "
                 "discovery, but **DO NOT cite as authoritative**: cross-validate "
-                "against `search_definitions` (СУМ-11) or `search_etymology` "
+                "against `search_definitions` (СУМ-11) or `search_grinchenko_1907` "
                 "(Грінченко) before treating a synonym as established Ukrainian. "
                 "The 3,360-synset version cited in older docs is the 2023 paper's "
                 "initial release; current production is the auto-MT-expanded set."
@@ -869,7 +856,6 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             "query_cefr_level": lambda: handle_dict_search(arguments, "puls_cefr", "PULS CEFR"),
             "search_definitions": lambda: handle_dict_search(arguments, "sum11", "СУМ-11"),
             "search_grinchenko_1907": lambda: handle_dict_search(arguments, "grinchenko_dict", "Грінченко"),
-            "search_etymology": lambda: handle_deprecated_search_etymology(arguments),
             "search_esum": lambda: handle_search_esum(arguments),
             "search_idioms": lambda: handle_dict_search(arguments, "frazeolohichnyi", "Фразеологічний"),
             "search_synonyms": lambda: handle_dict_search(arguments, "ukrajinet", "Ukrajinet WordNet"),
@@ -1556,16 +1542,6 @@ async def handle_query_pravopys(args: dict) -> list[TextContent]:
         result["text"][:3000],
     ]
     return [TextContent(type="text", text="\n".join(lines))]
-
-
-async def handle_deprecated_search_etymology(args: dict) -> list[TextContent]:
-    """Deprecated alias for search_grinchenko_1907."""
-    _log_tool_call("search_etymology", args, error="DEPRECATED: Use search_grinchenko_1907 instead.")
-    results = await handle_dict_search(args, "grinchenko_dict", "Грінченко")
-    if results and isinstance(results[0], TextContent):
-        warning = "⚠️ **DEPRECATION WARNING:** `search_etymology` is misnamed and deprecated. Use `search_grinchenko_1907` instead. Грінченко is a historical dictionary, NOT an etymological one.\n\n"
-        results[0].text = warning + results[0].text
-    return results
 
 
 async def handle_dict_search(args: dict, collection: str, label: str) -> list[TextContent]:

--- a/audit/mcp-coverage-audit-2026-05-04.md
+++ b/audit/mcp-coverage-audit-2026-05-04.md
@@ -32,7 +32,7 @@ SELECT word FROM sum11 WHERE word IN ('Київ','Львів','Україна','
 |---|---|---|---|---|---|
 | `search_style_guide` | Антоненко-Давидович «Як ми говоримо» | 279 | 600+ | ~46% | INCOMPLETE — issue #1663 tracks full ingest. Re-dispatch needed (segmenter broken on prior run). |
 | `search_definitions` | СУМ-11 (1970–1980) | 127,069 | ~127K | ~100% | Excludes proper nouns (toponyms, person names). 5.6% Sovietized (#1659 flagged). |
-| `search_etymology` | Грінченко (1907) | 67,275 | ~67K | ~100% | Excludes proper nouns. NOT etymology — lexicographic. Renamed `search_grinchenko_1907` in #1658. |
+| `search_grinchenko_1907` | Грінченко (1907) | 67,275 | ~67K | ~100% | Excludes proper nouns. NOT etymology — lexicographic. |
 | `search_esum` | ЕСУМ vol 1 (А–Г) | 1,923 | 6 vols | ~17% by volume, А–Г scope | PoC only. Vols 2-6 follow up. |
 | `search_idioms` | Фразеологічний | 24,683 | ~25K | ~99% | Single-source — cross-validate via `search_literary`. |
 | `search_synonyms` | Ukrajinet WordNet | 122,441 | 122K | 100% by count | **Quality caveat:** auto-MT from English WordNet, not curated. Audit pending #1657 Tier 3. |
@@ -75,7 +75,7 @@ that drops rows is caught before it ships.
 ## Action items shipped this PR
 
 1. Updated tool descriptions in `.mcp/servers/sources/server.py` for
-   `search_style_guide`, `search_definitions`, `search_etymology`,
+   `search_style_guide`, `search_definitions`, `search_grinchenko_1907`,
    `search_idioms`, `search_synonyms`, `translate_en_uk`,
    `query_cefr_level`. Each now states actual indexed count, canonical
    source size, coverage percent, and known systematic exclusions.

--- a/docs/best-practices/wiki-plan-review-and-lock.md
+++ b/docs/best-practices/wiki-plan-review-and-lock.md
@@ -60,7 +60,7 @@ Score each dimension 1–10. All five must be ≥9 to lock. The thresholds and r
    - **Правопис 2019** (MCP `query_pravopys`) — orthography edge cases
    - **Горох** / stress dictionary — pronunciation
    - **Антоненко-Давидович** (`data/sources.db` `style_guide` table, MCP `search_style_guide`) — is it a calque?
-   - **Грінченко** — historical / etymology
+   - **Грінченко** (MCP `search_grinchenko_1907`) — historical lexicographic evidence; use `search_esum` for true etymology
 4. **If a right-column Surzhyk replacement cannot be verified in at least VESUM + СУМ-11**, do NOT add it — flag with `<!-- VERIFY -->` instead. Hallucinated café vocab breaks the whole drill.
 5. **Emit a LOCKED review file** at `wiki/.reviews/pedagogy/{level}/{slug}-review-LOCKED.md` with:
    - Per-dimension scores with evidence

--- a/scripts/build/pipeline_v5.py
+++ b/scripts/build/pipeline_v5.py
@@ -80,6 +80,8 @@ from pipeline_lib import (
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
+
 MAX_AUDIT_FIX_ITERS_CORE = 3    # Mar 2026: raised from 2 — modules often need 3 passes
 MAX_AUDIT_FIX_ITERS_SEMINAR = 4  # Mar 2026: raised from 3
 MAX_REVIEW_FIX_ITERS = 3        # Mar 2026: raised from 2 — M05 needed 14+2 fixes in 2 iters, still had unresolved
@@ -2886,7 +2888,7 @@ def _validate_run_proofread(ctx: ModuleContext, screen: DScreenResult) -> DScree
     module_num = ctx.module_num if hasattr(ctx, "module_num") else 1
     log(f"  validate: Dispatching Gemini proofread+fix on {ctx.slug}...")
     proofread_cmd = [
-        sys.executable, str(SCRIPTS_DIR / "proofread.py"),
+        str(VENV_PYTHON), str(SCRIPTS_DIR / "proofread.py"),
         ctx.track, str(module_num), "--fix", "--no-mdx",
     ]
     try:
@@ -4070,7 +4072,7 @@ def phase_mdx(ctx: ModuleContext) -> bool:
 
     log("  mdx: Generating MDX...")
     result = subprocess.run(
-        [sys.executable, str(SCRIPTS_DIR / "generate_mdx.py"),
+        [str(VENV_PYTHON), str(SCRIPTS_DIR / "generate_mdx.py"),
          "l2-uk-en", ctx.track, str(ctx.module_num)],
         cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=600,
     )

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -53,7 +53,7 @@ class TestListTools:
             "query_wikipedia", "query_grac", "query_ulif",
             "query_r2u", "query_e2u", "query_sum20", "query_slovnyk_me",
             "query_pravopys", "query_cefr_level",
-            "search_style_guide", "search_definitions", "search_grinchenko_1907", "search_etymology",
+            "search_style_guide", "search_definitions", "search_grinchenko_1907",
             "search_idioms", "search_synonyms", "translate_en_uk",
             "search_esum", "check_russian_shadow",
         }
@@ -117,15 +117,6 @@ class TestCallToolDispatch:
             mock.return_value = [MagicMock(text="ok")]
             _run(server_module.call_tool("search_grinchenko_1907", {"query": "тест"}))
             mock.assert_called_once_with({"query": "тест"}, "grinchenko_dict", "Грінченко")
-
-    def test_search_etymology_deprecation_alias(self, server_module):
-        with patch.object(server_module, "handle_dict_search", new_callable=AsyncMock) as mock:
-            mock.return_value = [server_module.TextContent(type="text", text="ok")]
-            result = _run(server_module.call_tool("search_etymology", {"query": "тест"}))
-            mock.assert_called_once_with({"query": "тест"}, "grinchenko_dict", "Грінченко")
-            assert len(result) == 1
-            assert "DEPRECATION WARNING" in result[0].text
-            assert result[0].text.endswith("ok")
 
     def test_check_modern_form_dispatches(self, server_module):
         with patch.object(server_module, "handle_check_modern_form", new_callable=AsyncMock) as mock:

--- a/tests/test_sum11_sovietization_scan.py
+++ b/tests/test_sum11_sovietization_scan.py
@@ -22,6 +22,12 @@ MIGRATION_SQL = (
     / "migrations"
     / "2026-05-04-1659-sum11-sovietization-flag.sql"
 )
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+
+
+def _venv_python() -> Path:
+    assert VENV_PYTHON.exists(), "Expected repo venv at .venv/bin/python"
+    return VENV_PYTHON
 
 
 # Real-content samples lifted from a production DB scan on 2026-05-04.
@@ -175,14 +181,10 @@ def test_classify_entry_branches():
 
 def test_scan_produces_expected_distribution(seeded_db, tmp_path):
     report_path = tmp_path / "report.md"
-    venv_python = REPO_ROOT / ".venv" / "bin" / "python"
-    if not venv_python.exists():
-        # Fall back to whichever python is invoking pytest.
-        venv_python = Path(sys.executable)
 
     result = subprocess.run(
         [
-            str(venv_python),
+            str(_venv_python()),
             str(SCAN_SCRIPT),
             "--db",
             str(seeded_db),
@@ -235,13 +237,10 @@ def test_scan_produces_expected_distribution(seeded_db, tmp_path):
 
 def test_dry_run_does_not_modify_db(seeded_db, tmp_path):
     report_path = tmp_path / "dry_report.md"
-    venv_python = REPO_ROOT / ".venv" / "bin" / "python"
-    if not venv_python.exists():
-        venv_python = Path(sys.executable)
 
     result = subprocess.run(
         [
-            str(venv_python),
+            str(_venv_python()),
             str(SCAN_SCRIPT),
             "--db",
             str(seeded_db),
@@ -268,12 +267,9 @@ def test_dry_run_does_not_modify_db(seeded_db, tmp_path):
 def test_scan_is_idempotent(seeded_db, tmp_path):
     """Re-running the scan twice yields identical flag values."""
     report_path = tmp_path / "report.md"
-    venv_python = REPO_ROOT / ".venv" / "bin" / "python"
-    if not venv_python.exists():
-        venv_python = Path(sys.executable)
 
     cmd = [
-        str(venv_python),
+        str(_venv_python()),
         str(SCAN_SCRIPT),
         "--db",
         str(seeded_db),


### PR DESCRIPTION
## Summary

Removes the `search_etymology` deprecation alias from the MCP sources server. The canonical name is `search_grinchenko_1907`. The 30-day deprecation window opened with #1658/PR #1678 and expires early June 2026.

## What changed

- Deleted alias registration, dispatcher branch, and deprecated handler in `.mcp/servers/sources/server.py`
- Migrated remaining current references to `search_grinchenko_1907` in:
  - `audit/mcp-coverage-audit-2026-05-04.md`
  - `docs/best-practices/wiki-plan-review-and-lock.md`
- Deleted the alias-only MCP server test and kept canonical dispatch coverage in `tests/test_mcp_sources_server.py`
- Removed existing `sys.executable` subprocess fallbacks in `scripts/build/pipeline_v5.py` and `tests/test_sum11_sovietization_scan.py` for pre-submit compliance
- Prompt grep across `claude_extensions/rules/`, `scripts/build/phases/`, and `.agents/skills/` found no current `search_etymology` references

## Verification

- `git grep search_etymology` returns zero matches outside historical `docs/session-state/**` records
- `.venv/bin/python -m pytest tests/test_mcp_sources_server.py tests/test_sum11_sovietization_scan.py -x -q` passes
- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 .venv/bin/python -m pytest tests/ -x -q` passes: 6816 passed, 213 skipped, 11 xfailed
- `.venv/bin/ruff check scripts/` passes
- `.venv/bin/ruff check .mcp/servers/sources/server.py tests/test_mcp_sources_server.py tests/test_sum11_sovietization_scan.py` passes
- `git diff --check` clean
- No `.python-version`, `.yamllint`, `.markdownlint.json`, status JSON, or generated review/status artifacts in the diff
- `sys.executable` grep is clean across `scripts/`, `tests/`, `.mcp/`, `claude_extensions/`, and `.agents/`

Closes #1679.