### PR TITLE
refactor(rag): split VESUM out of query.py + wire MCP into wiki packet (#1680)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -28,8 +28,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Add scripts/ to path so the rag package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2].parent / "scripts"))
+# Add repo root and scripts/ to path so both scripts.* and legacy top-level
+# packages are importable.
+PROJECT_ROOT = Path(__file__).resolve().parents[2].parent
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+for _path in (PROJECT_ROOT, SCRIPTS_DIR):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
 
 try:
     from mcp.server import Server
@@ -1054,7 +1059,7 @@ def _is_archaic(tags: str | None) -> bool:
 async def handle_check_modern_form(args: dict) -> list[TextContent]:
     word = args["word"]
 
-    from rag.query import verify_word
+    from scripts.verification.vesum import verify_word
     matches = await asyncio.to_thread(verify_word, word, None)
 
     if not matches:
@@ -1084,7 +1089,7 @@ async def handle_verify_word(args: dict) -> list[TextContent]:
     word = args["word"]
     pos_filter = args.get("pos_filter")
 
-    from rag.query import verify_word
+    from scripts.verification.vesum import verify_word
     matches = await asyncio.to_thread(verify_word, word, pos_filter)
 
     if not matches:
@@ -1103,7 +1108,7 @@ async def handle_verify_words(args: dict) -> list[TextContent]:
     words = args["words"]
     pos_filter = args.get("pos_filter")
 
-    from rag.query import verify_words
+    from scripts.verification.vesum import verify_words
     results = await asyncio.to_thread(verify_words, words, pos_filter)
 
     lines = [f"Batch verification: {len(words)} words\n"]
@@ -1124,7 +1129,7 @@ async def handle_verify_words(args: dict) -> list[TextContent]:
 async def handle_verify_lemma(args: dict) -> list[TextContent]:
     lemma = args["lemma"]
 
-    from rag.query import verify_lemma
+    from scripts.verification.vesum import verify_lemma
     forms = await asyncio.to_thread(verify_lemma, lemma)
 
     if not forms:

--- a/docs/phase-4-exemplar-report.md
+++ b/docs/phase-4-exemplar-report.md
@@ -79,9 +79,9 @@ teacher-facing English framing style.
 - The delegated worktree did not contain `.venv/`; a local ignored symlink to
   the main checkout venv was created so commands could use `.venv/bin/python`
   with Python 3.12.8.
-- Local Qdrant on `127.0.0.1:6334` was not running. The knowledge-packet builder
-  degraded by logging RAG connection failures and producing a packet with plan
-  references but no retrieved textbook excerpts.
+- Failure mode: writer cites a vocabulary item that fails MCP verification at
+  review-time. The wiki+MCP knowledge packet is supposed to surface this gap
+  during writing — see `Dictionary context` section in `build_knowledge_packet`.
 - The first Gemini response satisfied fenced-block structure but not the
   activity JSON schema, requiring the one allowed corrective redispatch.
 - The successful redispatch still missed core content gates: minimum word count,

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -464,7 +464,174 @@ def build_knowledge_packet(
     from scripts.build.phases.wiki_compressor import compress_wiki_packet
 
     compressed = compress_wiki_packet(plan_data, wiki_packet)
-    return _render_wiki_knowledge_packet(plan_data, wiki_packet, compressed)
+    dictionary_context = _build_dictionary_context(plan_data)
+    return _render_wiki_knowledge_packet(
+        plan_data,
+        wiki_packet,
+        compressed,
+        dictionary_context,
+    )
+
+
+def _extract_dictionary_lemmas(plan: Mapping[str, Any]) -> list[str]:
+    """Return required vocabulary lemmas for dictionary-context enrichment."""
+    candidates: list[Any] = []
+    required_vocab = plan.get("required_vocab")
+    if isinstance(required_vocab, list):
+        candidates = required_vocab
+    else:
+        vocab_hints = plan.get("vocabulary_hints")
+        if isinstance(vocab_hints, dict):
+            required = vocab_hints.get("required")
+            if isinstance(required, list) and required:
+                candidates = required
+            else:
+                for category in ("recommended", "sight_words"):
+                    items = vocab_hints.get(category)
+                    if isinstance(items, list):
+                        candidates.extend(items)
+        elif isinstance(vocab_hints, list):
+            candidates = vocab_hints
+
+    lemmas: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        lemma = _normalize_vocab_hint(item)
+        if lemma and lemma not in seen:
+            seen.add(lemma)
+            lemmas.append(lemma)
+    return lemmas
+
+
+def _normalize_vocab_hint(item: Any) -> str:
+    """Extract the Ukrainian lemma from a plan vocabulary hint item."""
+    if isinstance(item, Mapping):
+        raw = item.get("lemma") or item.get("word") or item.get("uk") or ""
+    elif isinstance(item, str):
+        raw = item
+    else:
+        return ""
+    text = str(raw).split("(", 1)[0].strip()
+    text = re.split(r"\s+[–—-]\s+", text, maxsplit=1)[0].strip()
+    return text.strip(" \t\r\n,;:.")
+
+
+def _build_dictionary_context(
+    plan: Mapping[str, Any],
+    *,
+    max_chars: int = 6000,
+    definition_chars: int = 200,
+) -> str:
+    """Build compact VESUM + dictionary context for plan vocabulary."""
+    lemmas = _extract_dictionary_lemmas(plan)
+    if not lemmas:
+        return ""
+
+    try:
+        from scripts.verification import vesum as vesum_lookup
+        from wiki import sources_db
+    except Exception as exc:
+        return (
+            "## Dictionary context\n\n"
+            f"*Dictionary context unavailable: {type(exc).__name__}: {exc}*"
+        )
+
+    try:
+        batch_matches = vesum_lookup.verify_words(lemmas)
+    except Exception:
+        batch_matches = {lemma: [] for lemma in lemmas}
+
+    lines = ["## Dictionary context", ""]
+    current_chars = sum(len(line) + 1 for line in lines)
+    for lemma in lemmas:
+        word_matches = batch_matches.get(lemma, [])
+        forms = _safe_lookup(vesum_lookup.verify_lemma, [], lemma)
+        definitions = _safe_lookup(sources_db.search_definitions, [], lemma, limit=1)
+        style_notes = _safe_lookup(sources_db.search_style_guide, [], lemma, limit=1)
+
+        pos = _dictionary_pos_label(word_matches, forms)
+        entry = [
+            f"- **{lemma}** [{pos}]",
+            f"  - VESUM: {_vesum_form_summary(lemma, word_matches, forms)}",
+        ]
+        definition = _dictionary_hit_text(definitions)
+        if definition:
+            entry.append(
+                f"  - Definition: {_truncate_prompt_text(definition, definition_chars)}"
+            )
+        else:
+            entry.append("  - Definition: Not found in SUM-11.")
+
+        style_note = _dictionary_hit_text(style_notes)
+        if style_note:
+            entry.append(
+                f"  - Style note: {_truncate_prompt_text(style_note, definition_chars)}"
+            )
+
+        entry_chars = sum(len(line) + 1 for line in entry)
+        if current_chars + entry_chars <= max_chars:
+            lines.extend(entry)
+            current_chars += entry_chars
+            continue
+
+        short_entry = f"- **{lemma}** [{pos}]"
+        if current_chars + len(short_entry) + 1 <= max_chars:
+            lines.append(short_entry)
+            current_chars += len(short_entry) + 1
+        else:
+            break
+
+    return "\n".join(lines).rstrip()
+
+
+def _safe_lookup(fn: Callable[..., Any], fallback: Any, *args: Any, **kwargs: Any) -> Any:
+    try:
+        return fn(*args, **kwargs)
+    except Exception:
+        return fallback
+
+
+def _dictionary_pos_label(word_matches: list[dict], forms: list[dict]) -> str:
+    values: list[str] = []
+    for item in [*word_matches, *forms]:
+        pos = str(item.get("pos") or "").strip()
+        if pos and pos not in values:
+            values.append(pos)
+    return ", ".join(values) if values else "unknown"
+
+
+def _vesum_form_summary(lemma: str, word_matches: list[dict], forms: list[dict]) -> str:
+    if word_matches:
+        match = word_matches[0]
+        tags = str(match.get("tags") or "").strip()
+        return f"{lemma}" + (f" (`{tags}`)" if tags else "")
+    if forms:
+        form = forms[0]
+        word_form = str(form.get("word_form") or lemma).strip()
+        tags = str(form.get("tags") or "").strip()
+        return f"{word_form}" + (f" (`{tags}`)" if tags else "")
+    return "Not found in VESUM."
+
+
+def _dictionary_hit_text(hits: Any) -> str:
+    if not isinstance(hits, list) or not hits:
+        return ""
+    first = hits[0]
+    if not isinstance(first, Mapping):
+        return str(first)
+    for key in ("definition", "definitions", "text", "note", "notes"):
+        value = first.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _truncate_prompt_text(text: str, max_chars: int) -> str:
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    if len(cleaned) <= max_chars:
+        return cleaned
+    trimmed = cleaned[:max_chars].rsplit(" ", 1)[0].rstrip(" ,;:")
+    return f"{trimmed}..."
 
 
 def _build_wiki_packet(level: str, slug: str) -> str:
@@ -558,6 +725,7 @@ def _render_wiki_knowledge_packet(
     plan: Mapping[str, Any],
     wiki_packet: str,
     compressed: Mapping[str, Any],
+    dictionary_context: str = "",
 ) -> str:
     """Render raw and compressed wiki context as the writer packet."""
     lines: list[str] = [
@@ -597,6 +765,9 @@ def _render_wiki_knowledge_packet(
                 f"({anchor['citation']})"
             )
         lines.append("")
+
+    if dictionary_context:
+        lines.extend([dictionary_context, ""])
 
     lines.extend(
         [
@@ -2072,7 +2243,7 @@ def _vesum_gate(
         if lower not in whitelist_lc
     ]
     if verify_words_fn is None:
-        from scripts.rag.query import verify_words as verify_words_fn
+        from scripts.verification.vesum import verify_words as verify_words_fn
 
     # VESUM is case-sensitive — lowercase before lookup so sentence-initial
     # words like "Спочатку" match the lemma "спочатку".

--- a/scripts/oneoff/check_words.py
+++ b/scripts/oneoff/check_words.py
@@ -1,21 +1,21 @@
 import subprocess
 
 words_m08 = [
-    "стіл", "книга", "вікно", "кімната", "ліжко", "стілець", 
-    "лампа", "телефон", "комп'ютер", "він", "вона", "воно", 
-    "зошит", "ручка", "сумка", "крісло", "дзеркало", "ключ", 
+    "стіл", "книга", "вікно", "кімната", "ліжко", "стілець",
+    "лампа", "телефон", "комп'ютер", "він", "вона", "воно",
+    "зошит", "ручка", "сумка", "крісло", "дзеркало", "ключ",
     "фото", "стіна"
 ]
 words_m09 = [
-    "який", "яка", "яке", "великий", "маленький", "новий", 
-    "старий", "гарний", "чистий", "дорогий", "дешевий", 
+    "який", "яка", "яке", "великий", "маленький", "новий",
+    "старий", "гарний", "чистий", "дорогий", "дешевий",
     "поганий", "брудний", "світлий", "темний", "а", "але", "рюкзак", "речі"
 ]
 
 print("=== M08 Words ===")
 for w in words_m08:
-    res = subprocess.run(["python", "scripts/rag/query.py", "word", w], capture_output=True, text=True)
-    if "✅" not in res.stdout:
+    res = subprocess.run([".venv/bin/python", "scripts/verification/vesum.py", "word", w], capture_output=True, text=True)
+    if "match(es)" not in res.stdout:
         print(f"FAILED: {w}")
     else:
         # Just check the first line or so to confirm it's found
@@ -23,8 +23,8 @@ for w in words_m08:
 
 print("=== M09 Words ===")
 for w in words_m09:
-    res = subprocess.run(["python", "scripts/rag/query.py", "word", w], capture_output=True, text=True)
-    if "✅" not in res.stdout:
+    res = subprocess.run([".venv/bin/python", "scripts/verification/vesum.py", "word", w], capture_output=True, text=True)
+    if "match(es)" not in res.stdout:
         print(f"FAILED: {w}")
     else:
         print(f"OK: {w} - {res.stdout.splitlines()[0] if res.stdout else 'no output'}")

--- a/scripts/oneoff/run_checks.py
+++ b/scripts/oneoff/run_checks.py
@@ -1,9 +1,11 @@
 import sys
 from pprint import pprint
+
 # Assuming scripts directory is in PYTHONPATH or we can just append it
 sys.path.append('.')
 
-from scripts.rag.query import search_text, verify_words
+from scripts.rag.query import search_text
+from scripts.verification.vesum import verify_words
 
 topics = [
     "чергування голосних і о е",
@@ -39,4 +41,3 @@ print("Invalid words:")
 for word in words_to_verify:
     if word not in res or not res[word]:
         print(f"NOT FOUND: {word}")
-

--- a/scripts/rag/query.py
+++ b/scripts/rag/query.py
@@ -34,7 +34,6 @@ from rag.config import (
     QDRANT_GRPC_PORT,
     QDRANT_HOST,
     TEXT_COLLECTION,
-    VESUM_DB_PATH,
 )
 
 # Module-level singletons (lazy-loaded)
@@ -42,7 +41,6 @@ _qdrant_client = None
 _text_encoder = None
 _image_encoder = None
 _cross_encoder = None
-_vesum_conn = None
 
 
 def get_client():
@@ -617,79 +615,6 @@ def collection_stats() -> dict:
     return stats
 
 
-def get_vesum_conn():
-    """Lazy-load SQLite connection to VESUM dictionary."""
-    global _vesum_conn
-    if _vesum_conn is None:
-        import sqlite3
-        if not VESUM_DB_PATH.exists():
-            raise FileNotFoundError(
-                f"VESUM database not found at {VESUM_DB_PATH}. "
-                "Run: .venv/bin/python scripts/rag/import_vesum.py"
-            )
-        _vesum_conn = sqlite3.connect(str(VESUM_DB_PATH), check_same_thread=False)
-        _vesum_conn.row_factory = sqlite3.Row
-    return _vesum_conn
-
-
-def verify_word(word: str, pos_filter: str | None = None) -> list[dict]:
-    """Check if a word form exists in VESUM.
-
-    Returns list of {lemma, pos, tags} matches. Empty list = not found.
-    """
-    conn = get_vesum_conn()
-    if pos_filter:
-        rows = conn.execute(
-            "SELECT lemma, pos, tags FROM forms WHERE word_form = ? AND pos = ?",
-            (word, pos_filter),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            "SELECT lemma, pos, tags FROM forms WHERE word_form = ?",
-            (word,),
-        ).fetchall()
-    return [{"lemma": r["lemma"], "pos": r["pos"], "tags": r["tags"]} for r in rows]
-
-
-def verify_words(words: list[str], pos_filter: str | None = None) -> dict[str, list[dict]]:
-    """Batch-verify multiple word forms against VESUM in a single query.
-
-    Returns dict mapping each word to its list of matches.
-    Words not found map to an empty list.
-    """
-    if not words:
-        return {}
-    conn = get_vesum_conn()
-    placeholders = ",".join("?" * len(words))
-    if pos_filter:
-        rows = conn.execute(
-            f"SELECT word_form, lemma, pos, tags FROM forms WHERE word_form IN ({placeholders}) AND pos = ?",
-            (*words, pos_filter),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            f"SELECT word_form, lemma, pos, tags FROM forms WHERE word_form IN ({placeholders})",
-            words,
-        ).fetchall()
-    result: dict[str, list[dict]] = {w: [] for w in words}
-    for r in rows:
-        result[r["word_form"]].append({"lemma": r["lemma"], "pos": r["pos"], "tags": r["tags"]})
-    return result
-
-
-def verify_lemma(lemma: str) -> list[dict]:
-    """Get all inflected forms of a lemma.
-
-    Returns list of {word_form, pos, tags} for every form.
-    """
-    conn = get_vesum_conn()
-    rows = conn.execute(
-        "SELECT word_form, pos, tags FROM forms WHERE lemma = ? ORDER BY pos, tags",
-        (lemma,),
-    ).fetchall()
-    return [{"word_form": r["word_form"], "pos": r["pos"], "tags": r["tags"]} for r in rows]
-
-
 def main():
     parser = argparse.ArgumentParser(description="Query the RAG pipeline")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -728,15 +653,6 @@ def main():
 
     # Stats
     subparsers.add_parser("stats", help="Collection statistics")
-
-    # VESUM word verification
-    word_parser = subparsers.add_parser("word", help="Verify a Ukrainian word form (VESUM)")
-    word_parser.add_argument("query", help="Word form to check")
-    word_parser.add_argument("--pos", type=str, help="Filter by POS (e.g., noun, verb, adj)")
-
-    # VESUM lemma lookup
-    lemma_parser = subparsers.add_parser("lemma", help="Get all forms of a lemma (VESUM)")
-    lemma_parser.add_argument("query", help="Lemma to look up")
 
     args = parser.parse_args()
 
@@ -809,24 +725,6 @@ def main():
     elif args.command == "stats":
         stats = collection_stats()
         print(json.dumps(stats, indent=2))
-
-    elif args.command == "word":
-        matches = verify_word(args.query, pos_filter=args.pos)
-        if not matches:
-            print(f"❌ '{args.query}' not found in VESUM")
-        else:
-            print(f"✅ '{args.query}' — {len(matches)} match(es):")
-            for m in matches:
-                print(f"  lemma={m['lemma']}  pos={m['pos']}  tags={m['tags']}")
-
-    elif args.command == "lemma":
-        forms = verify_lemma(args.query)
-        if not forms:
-            print(f"❌ Lemma '{args.query}' not found in VESUM")
-        else:
-            print(f"✅ '{args.query}' — {len(forms)} form(s):")
-            for f in forms:
-                print(f"  {f['word_form']:20s}  {f['tags']}")
 
 
 if __name__ == "__main__":

--- a/scripts/rag/rag_batch_verify.py
+++ b/scripts/rag/rag_batch_verify.py
@@ -273,7 +273,7 @@ def _extract_activity_words(data, words: dict[str, str]) -> None:
 # VESUM verification
 # ---------------------------------------------------------------------------
 
-from rag.query import get_vesum_conn
+from verification.vesum import get_vesum_conn
 
 
 def vesum_batch_lookup(words: list[str], batch_size: int = 500) -> dict[str, list[dict]]:

--- a/scripts/rag/verify_module_1_v6.py
+++ b/scripts/rag/verify_module_1_v6.py
@@ -6,8 +6,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
-from rag.query import search_dictionary, search_text, verify_words
+from rag.query import search_dictionary, search_text
 from rag.source_query import pravopys_lookup, r2u_translate
+from verification.vesum import verify_words
 
 
 def run_verification():

--- a/scripts/tools/codex_tool_instructions.md
+++ b/scripts/tools/codex_tool_instructions.md
@@ -11,7 +11,7 @@ Batch multiple verifications together to minimize round-trips.
 ```bash
 .venv/bin/python -c "
 import sys; sys.path.insert(0, 'scripts')
-from rag.query import verify_words
+from verification.vesum import verify_words
 results = verify_words(['слово1', 'слово2', 'слово3'])
 for w, matches in results.items():
     if matches:
@@ -26,7 +26,7 @@ for w, matches in results.items():
 ```bash
 .venv/bin/python -c "
 import sys; sys.path.insert(0, 'scripts')
-from rag.query import verify_word
+from verification.vesum import verify_word
 results = verify_word('WORD_HERE')
 if results:
     for m in results:
@@ -41,7 +41,7 @@ else:
 ```bash
 .venv/bin/python -c "
 import sys; sys.path.insert(0, 'scripts')
-from rag.query import verify_lemma
+from verification.vesum import verify_lemma
 forms = verify_lemma('LEMMA_HERE')
 for f in forms[:20]:
     print(f'{f[\"word_form\"]:20s} {f[\"pos\"]:8s} {f[\"tags\"]}')

--- a/scripts/verification/check_ru_morph.py
+++ b/scripts/verification/check_ru_morph.py
@@ -60,7 +60,7 @@ def is_russian_pattern(word: str, threshold: float = 0.7) -> dict:
 
     # Cross-check VESUM: if it's a real Ukrainian lemma, do not flag.
     # We use the existing verify_word from mcp sources/rag logic.
-    from scripts.rag.query import verify_word
+    from scripts.verification.vesum import verify_word
     try:
         vesum_results = verify_word(word)
         if vesum_results:

--- a/scripts/verification/vesum.py
+++ b/scripts/verification/vesum.py
@@ -1,0 +1,157 @@
+"""VESUM SQLite lookup helpers.
+
+This module owns the local VESUM morphological dictionary connection and the
+public verification API previously embedded in ``scripts.rag.query``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from scripts.rag.config import VESUM_DB_PATH
+
+_vesum_conn = None
+
+
+def get_vesum_conn():
+    """Lazy-load SQLite connection to VESUM dictionary."""
+    global _vesum_conn
+    if _vesum_conn is None:
+        import sqlite3
+
+        if not VESUM_DB_PATH.exists():
+            raise FileNotFoundError(
+                f"VESUM database not found at {VESUM_DB_PATH}. "
+                "Run: .venv/bin/python scripts/rag/import_vesum.py"
+            )
+        _vesum_conn = sqlite3.connect(str(VESUM_DB_PATH), check_same_thread=False)
+        _vesum_conn.row_factory = sqlite3.Row
+    return _vesum_conn
+
+
+def verify_word(word: str, pos_filter: str | None = None) -> list[dict]:
+    """Check if a word form exists in VESUM.
+
+    Returns list of {lemma, pos, tags} matches. Empty list = not found.
+    """
+    conn = get_vesum_conn()
+    if pos_filter:
+        rows = conn.execute(
+            "SELECT lemma, pos, tags FROM forms WHERE word_form = ? AND pos = ?",
+            (word, pos_filter),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT lemma, pos, tags FROM forms WHERE word_form = ?",
+            (word,),
+        ).fetchall()
+    return [{"lemma": r["lemma"], "pos": r["pos"], "tags": r["tags"]} for r in rows]
+
+
+def verify_words(words: list[str], pos_filter: str | None = None) -> dict[str, list[dict]]:
+    """Batch-verify multiple word forms against VESUM in a single query.
+
+    Returns dict mapping each word to its list of matches.
+    Words not found map to an empty list.
+    """
+    if not words:
+        return {}
+    conn = get_vesum_conn()
+    placeholders = ",".join("?" * len(words))
+    if pos_filter:
+        rows = conn.execute(
+            f"SELECT word_form, lemma, pos, tags FROM forms WHERE word_form IN ({placeholders}) AND pos = ?",
+            (*words, pos_filter),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            f"SELECT word_form, lemma, pos, tags FROM forms WHERE word_form IN ({placeholders})",
+            words,
+        ).fetchall()
+    result: dict[str, list[dict]] = {w: [] for w in words}
+    for r in rows:
+        result[r["word_form"]].append({"lemma": r["lemma"], "pos": r["pos"], "tags": r["tags"]})
+    return result
+
+
+def verify_lemma(lemma: str) -> list[dict]:
+    """Get all inflected forms of a lemma.
+
+    Returns list of {word_form, pos, tags} for every form.
+    """
+    conn = get_vesum_conn()
+    rows = conn.execute(
+        "SELECT word_form, pos, tags FROM forms WHERE lemma = ? ORDER BY pos, tags",
+        (lemma,),
+    ).fetchall()
+    return [{"word_form": r["word_form"], "pos": r["pos"], "tags": r["tags"]} for r in rows]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query the VESUM morphological dictionary")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    word_parser = subparsers.add_parser("word", help="Verify a Ukrainian word form")
+    word_parser.add_argument("query", help="Word form to check")
+    word_parser.add_argument("--pos", type=str, help="Filter by POS, e.g. noun, verb, adj")
+    word_parser.add_argument("--json", action="store_true", help="Print raw JSON")
+
+    words_parser = subparsers.add_parser("words", help="Batch-verify Ukrainian word forms")
+    words_parser.add_argument("query", nargs="+", help="Word forms to check")
+    words_parser.add_argument("--pos", type=str, help="Filter by POS, e.g. noun, verb, adj")
+    words_parser.add_argument("--json", action="store_true", help="Print raw JSON")
+
+    lemma_parser = subparsers.add_parser("lemma", help="Get all forms of a lemma")
+    lemma_parser.add_argument("query", help="Lemma to look up")
+    lemma_parser.add_argument("--json", action="store_true", help="Print raw JSON")
+
+    args = parser.parse_args()
+
+    if args.command == "word":
+        matches = verify_word(args.query, pos_filter=args.pos)
+        if args.json:
+            print(json.dumps(matches, ensure_ascii=False, indent=2))
+        elif not matches:
+            print(f"'{args.query}' not found in VESUM")
+        else:
+            print(f"'{args.query}' - {len(matches)} match(es):")
+            for match in matches:
+                print(
+                    f"  lemma={match['lemma']}  pos={match['pos']}  "
+                    f"tags={match['tags']}"
+                )
+    elif args.command == "words":
+        results = verify_words(args.query, pos_filter=args.pos)
+        if args.json:
+            print(json.dumps(results, ensure_ascii=False, indent=2))
+        else:
+            found = sum(1 for matches in results.values() if matches)
+            print(f"Found: {found}/{len(args.query)}")
+            for word in args.query:
+                matches = results.get(word, [])
+                status = "FOUND" if matches else "NOT FOUND"
+                print(f"{word}: {status}")
+    elif args.command == "lemma":
+        forms = verify_lemma(args.query)
+        if args.json:
+            print(json.dumps(forms, ensure_ascii=False, indent=2))
+        elif not forms:
+            print(f"Lemma '{args.query}' not found in VESUM")
+        else:
+            print(f"'{args.query}' - {len(forms)} form(s):")
+            for form in forms:
+                print(f"  {form['word_form']:20s}  {form['tags']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_ru_morph.py
+++ b/tests/test_check_ru_morph.py
@@ -17,7 +17,7 @@ def test_get_ru_confidence():
     conf, lemma = get_ru_confidence("привіт")
     assert conf < 0.5
 
-@patch("scripts.rag.query.verify_word")
+@patch("scripts.verification.vesum.verify_word")
 def test_smoke_cases(mock_verify_word):
     # VESUM mock for smoke cases
     def mock_vesum(word):

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -145,20 +145,20 @@ class TestVerifyWordHandler:
     """Test verify_word handler formatting."""
 
     def test_not_found(self, server_module):
-        with patch("rag.query.verify_word", return_value=[]):
+        with patch("scripts.verification.vesum.verify_word", return_value=[]):
             result = _run(server_module.handle_verify_word({"word": "взяйте"}))
             assert "NOT FOUND" in result[0].text
 
     def test_found(self, server_module):
         mock_matches = [{"lemma": "читати", "pos": "verb", "tags": "verb:imperf:impr:s:2"}]
-        with patch("rag.query.verify_word", return_value=mock_matches):
+        with patch("scripts.verification.vesum.verify_word", return_value=mock_matches):
             result = _run(server_module.handle_verify_word({"word": "читай"}))
             assert "читати" in result[0].text
             assert "verb" in result[0].text
             assert "1 match" in result[0].text
 
     def test_passes_pos_filter(self, server_module):
-        with patch("rag.query.verify_word", return_value=[]) as mock:
+        with patch("scripts.verification.vesum.verify_word", return_value=[]) as mock:
             _run(server_module.handle_verify_word({"word": "тест", "pos_filter": "noun"}))
             mock.assert_called_once_with("тест", "noun")
 
@@ -171,7 +171,7 @@ class TestVerifyWordsHandler:
             "стій": [{"lemma": "стояти", "pos": "verb", "tags": "verb:imperf:impr:s:2"}],
             "взяйте": [],
         }
-        with patch("rag.query.verify_words", return_value=mock_results):
+        with patch("scripts.verification.vesum.verify_words", return_value=mock_results):
             result = _run(server_module.handle_verify_words({"words": ["стій", "взяйте"]}))
             text = result[0].text
             assert "Found: 1/2" in text
@@ -232,7 +232,7 @@ class TestSSEStateless:
 
 class TestCheckRussianShadowHandler:
     def test_handle_check_russian_shadow(self, server_module):
-        with patch("scripts.rag.query.verify_word") as mock_verify_word:
+        with patch("scripts.verification.vesum.verify_word") as mock_verify_word:
             def mock_vesum(w):
                 if w in ["получити", "здача"]:
                     return []

--- a/tests/test_wiki_packet_dictionary_context.py
+++ b/tests/test_wiki_packet_dictionary_context.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from scripts.build import linear_pipeline
+
+
+def _fixture_plan() -> dict:
+    return {
+        "module": "a1-999",
+        "level": "A1",
+        "sequence": 999,
+        "slug": "dictionary-context",
+        "title": "Dictionary Context",
+        "subtitle": "Fixture plan",
+        "content_outline": [
+            {
+                "section": "Vocabulary",
+                "words": 120,
+                "points": ["Use the required vocabulary in short examples."],
+            }
+        ],
+        "word_target": 120,
+        "references": [{"title": "Fixture source"}],
+        "vocabulary_hints": {
+            "required": [
+                "мама (mom)",
+                "тато (dad)",
+                "йти (to go)",
+                "кава (coffee)",
+                {"word": "школа"},
+            ],
+        },
+    }
+
+
+def test_build_knowledge_packet_appends_dictionary_context(monkeypatch) -> None:
+    from scripts.verification import vesum
+    from wiki import sources_db
+
+    long_definition = " ".join(f"довге{i}" for i in range(80))
+    long_definition += " TAIL_SHOULD_NOT_APPEAR"
+
+    def fake_verify_words(words: list[str]) -> dict[str, list[dict]]:
+        return {
+            word: [
+                {
+                    "lemma": word,
+                    "pos": "verb" if word == "йти" else "noun",
+                    "tags": "verb:imperf:inf" if word == "йти" else "noun:anim",
+                }
+            ]
+            for word in words
+        }
+
+    def fake_verify_lemma(lemma: str) -> list[dict]:
+        return [
+            {
+                "word_form": lemma,
+                "pos": "verb" if lemma == "йти" else "noun",
+                "tags": "verb:imperf:inf" if lemma == "йти" else "noun:anim",
+            }
+        ]
+
+    def fake_search_definitions(lemma: str, limit: int = 1) -> list[dict]:
+        assert limit == 1
+        definition = long_definition if lemma == "кава" else f"{lemma}: short SUM-11 definition"
+        return [{"word": lemma, "definition": definition, "source": "СУМ-11"}]
+
+    def fake_search_style_guide(lemma: str, limit: int = 1) -> list[dict]:
+        assert limit == 1
+        if lemma == "йти":
+            return [{"word": lemma, "text": "Style guidance for йти."}]
+        return []
+
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_build_wiki_packet",
+        lambda level, slug: (
+            "### Вікі: pedagogy/a1/dictionary-context.md\n\n"
+            "## Overview\n"
+            "мама тато йти кава школа"
+        ),
+    )
+    monkeypatch.setattr(vesum, "verify_words", fake_verify_words)
+    monkeypatch.setattr(vesum, "verify_lemma", fake_verify_lemma)
+    monkeypatch.setattr(sources_db, "search_definitions", fake_search_definitions)
+    monkeypatch.setattr(sources_db, "search_style_guide", fake_search_style_guide)
+
+    packet = linear_pipeline.build_knowledge_packet(
+        level="a1",
+        slug="dictionary-context",
+        plan=_fixture_plan(),
+    )
+
+    assert "## Dictionary context" in packet
+    for lemma in ("мама", "тато", "йти", "кава", "школа"):
+        assert f"**{lemma}**" in packet
+    assert "- **йти** [verb]" in packet
+    assert "Style note: Style guidance for йти." in packet
+    assert "TAIL_SHOULD_NOT_APPEAR" not in packet
+    assert "Definition: довге0 довге1" in packet
+    assert "..." in packet


### PR DESCRIPTION
## Summary

Three residuals from #1631 closed in one PR (PR opened by orchestrator after Codex dispatch hit hard-timeout but commit was clean):

1. **VESUM split** — moved the VESUM SQLite API from `scripts/rag/query.py` to `scripts/verification/vesum.py`. The new module is colocated with `check_ru_morph.py` and other verification helpers. 8 consumer call sites updated across pipeline, MCP server, oneoff scripts, docs, and tests.

2. **Wiki packet enhancement** — `build_knowledge_packet` now appends a bounded `Dictionary context` section after wiki compression, with VESUM lemma/form data + top SUM-11 definition + style-guide note for each plan-vocab lemma. Definitions truncated to 200 chars; section capped at ~6000 chars.

3. **Doc fix** — `docs/phase-4-exemplar-report.md` failure-mode wording updated from "Qdrant fallback" to "wiki+MCP Dictionary context".

## Notes on `scripts/rag/query.py`

Did NOT delete the file because active Qdrant search consumers still import `search_text` / `search_literary` / `search_images` / `collection_stats` from it. VESUM references are gone from `query.py` though, so it's now Qdrant-only — separate cleanup issue should track full deletion once Qdrant path is retired.

## Verification

- New test `tests/test_wiki_packet_dictionary_context.py` (101 lines)
- Existing `tests/test_check_ru_morph.py` and `tests/test_mcp_sources_server.py` updated for the new VESUM module path
- Diff stats: 14 files changed, +470 / -136 LOC

## Provenance note

Codex hit `--hard-timeout 3600` (60 min) at the very end of the dispatch — commit `daddaa180d` was clean and complete, but `git push` + `gh pr create` didn't run. Orchestrator (Claude) is opening the PR after verifying the commit's diff matches the brief acceptance criteria. The work is Codex's; the orchestration mechanics are mine. Brief at `docs/dispatch-briefs/2026-05-05-1680-vesum-split-and-mcp-wiki-packet.md`.

Closes #1680.