### PR TITLE
feat(bakeoff): V7 codex-tools writer + review-only + telemetry-out + harness (#1703)

### DIFF
--- a/docs/dispatch-briefs/2026-05-05-a1-20-bakeoff-with-new-prompts.md
+++ b/docs/dispatch-briefs/2026-05-05-a1-20-bakeoff-with-new-prompts.md
@@ -38,6 +38,13 @@ If PR #1696 has been merged to main by the time this runs: drop the worktree, ru
 - Plan: `curriculum/l2-uk-en/plans/a1/my-morning.yaml` (verify exists; if missing, the bakeoff is blocked on plan finalization first)
 - Wiki packet: `wiki/.../my-morning/*` (verify exists; if missing, blocked on wiki compile first)
 
+### Prerequisites
+
+- PR [#1704](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/1704) for #1703 is merged, or this bakeoff is run from its branch/worktree.
+- The harness entry point exists: `scripts/audit/bakeoff_run.py`.
+- The V7 review-only entry point exists: `scripts/build/v7_review.py`.
+- `scripts/build/v7_build.py` supports `--writer codex-tools` and `--telemetry-out`.
+
 ### Writers (3 candidates)
 
 | Writer | Model | Build flag | Tools |
@@ -65,43 +72,11 @@ This enforces no-self-review and surfaces inter-model bias (does Claude over-rat
 From the `claude/1673-1661-cot-tier1-prompts` worktree (or main once merged):
 
 ```bash
-# ── Phase 1: parallel writer runs ──
-
-# Writer A — Gemini
-.venv/bin/python scripts/build/v6_build.py a1 20 --step write --writer gemini-tools
-cp curriculum/l2-uk-en/a1/my-morning.md curriculum/l2-uk-en/a1/my-morning.gemini.md
-
-# Writer B — Claude
-.venv/bin/python scripts/build/v6_build.py a1 20 --step write --writer claude-tools
-cp curriculum/l2-uk-en/a1/my-morning.md curriculum/l2-uk-en/a1/my-morning.claude.md
-
-# Writer C — GPT-5.5
-.venv/bin/python scripts/build/v6_build.py a1 20 --step write --writer codex-tools
-cp curriculum/l2-uk-en/a1/my-morning.md curriculum/l2-uk-en/a1/my-morning.gpt55.md
-
-# ── Phase 2: capture each writer's reasoning trace + tool-call log ──
-
-# v6_build.py emits JSONL events; the relevant events for prompt-adherence audit:
-#   "writer_cot_start"  — CoT block was emitted (good)
-#   "writer_cot_skip"   — CoT block was bypassed (bad — prompt-adherence fail)
-#   "tool_call"         — every MCP call the writer made (verify_words, search_definitions, etc.)
-#
-# If those events do NOT exist yet (V6 telemetry didn't have them), Claude needs
-# to add them as part of the bakeoff harness — see "Implementation deltas" below.
-
-# ── Phase 3: cross-agent review (6 review runs) ──
-
-# Each review writes its scoring + cited-evidence to a JSONL:
-#   audit/bakeoff-2026-05-05/a1-20-{writer}-{reviewer}.review.jsonl
-
-for writer in gemini claude gpt55; do
-  for reviewer in $(echo "gemini claude gpt55" | tr ' ' '\n' | grep -v "$writer"); do
-    .venv/bin/python scripts/build/v6_build.py a1 20 --step review \
-      --content curriculum/l2-uk-en/a1/my-morning.${writer}.md \
-      --reviewer ${reviewer}-tools \
-      --output audit/bakeoff-2026-05-05/a1-20-${writer}-${reviewer}.review.jsonl
-  done
-done
+.venv/bin/python scripts/audit/bakeoff_run.py \
+  --bakeoff-dir audit/bakeoff-2026-05-05 \
+  --level a1 \
+  --slug my-morning \
+  --writers claude-tools,gemini-tools,codex-tools
 ```
 
 ---
@@ -158,17 +133,11 @@ Total prompt-adherence score per agent: sum of writer + reviewer sub-dim scores.
 
 ## Implementation deltas (Claude's prep work BEFORE user runs)
 
-The current `v6_build.py` may NOT emit the prompt-adherence events listed above. Claude needs to:
+PR #1699, PR #1700, and PR #1703 provide the telemetry, aggregation, and runnable V7 harness pieces. Claude needs to:
 
-1. **Verify** — read `scripts/build/v6_build.py` + `scripts/build/phases/*.py` and check whether the JSONL emitter has `writer_cot_start` / `tool_call` / `reviewer_dim_evidence` events.
+1. **Run `bakeoff_run.py` per below** — the harness pre-flights the plan/wiki packet, runs the writer dry-run spike, executes the configured writers, runs the six cross-reviews, and invokes `bakeoff_aggregate.py`.
 
-2. **Add if missing** — small instrumentation diff to the linear pipeline. Each agent's writer/reviewer wrapper emits these events as a side channel. Lands in the bakeoff branch (or main if cleaner).
-
-3. **Build aggregation script** — `scripts/audit/bakeoff_aggregate.py` reads the per-writer `.md` outputs + per-review `.jsonl` files and emits a comparison matrix. Output goes to `audit/bakeoff-2026-05-05/REPORT.md`.
-
-4. **Pre-flight check** — verify `curriculum/l2-uk-en/plans/a1/my-morning.yaml` exists and is finalized; verify wiki packet for module 20 is compiled and current. If either is missing, bakeoff is blocked on those — flag back to user before running.
-
-These prep tasks are sequential dependencies for the bakeoff to produce meaningful data. They're <1 day of Claude inline work or 1 codex dispatch.
+2. **Report harness failures honestly** — if pre-flight, a writer, a reviewer, or aggregation fails, use the harness summary and JSONL files as the source of truth before rerunning with `--resume`.
 
 ---
 

--- a/scripts/audit/bakeoff_run.py
+++ b/scripts/audit/bakeoff_run.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Run the V7 three-writer bakeoff and cross-review harness."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.agent_runtime.registry import get_agent_entry
+from scripts.build import linear_pipeline
+
+DEFAULT_WRITERS = "claude-tools,gemini-tools,codex-tools"
+PYTHON = Path(".venv/bin/python")
+V7_BUILD = Path("scripts/build/v7_build.py")
+V7_REVIEW = Path("scripts/build/v7_review.py")
+BAKEOFF_AGGREGATE_SCRIPT = Path("scripts/audit/bakeoff_aggregate.py")
+BAKEOFF_AGGREGATE = PROJECT_ROOT / BAKEOFF_AGGREGATE_SCRIPT
+
+WRITER_ALIASES = {
+    "claude": "claude-tools",
+    "gemini": "gemini-tools",
+    "codex": "codex-tools",
+    "gpt": "codex-tools",
+    "gpt55": "codex-tools",
+    "gpt-5.5": "codex-tools",
+    "openai": "codex-tools",
+}
+
+
+def _load_bakeoff_aggregate():
+    spec = importlib.util.spec_from_file_location("bakeoff_aggregate", BAKEOFF_AGGREGATE)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load {BAKEOFF_AGGREGATE}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bakeoff_aggregate = _load_bakeoff_aggregate()
+
+
+@dataclass(frozen=True, slots=True)
+class StepResult:
+    label: str
+    ok: bool
+    skipped: bool = False
+    detail: str = ""
+    returncode: int | None = None
+
+
+def _resolve_project_path(path: Path) -> Path:
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _normalize_writer(raw: str) -> str:
+    value = raw.strip().casefold().replace("_tools", "-tools")
+    return WRITER_ALIASES.get(value, value)
+
+
+def _parse_writers(raw: str) -> list[str]:
+    writers: list[str] = []
+    for part in raw.split(","):
+        if not part.strip():
+            continue
+        writer = _normalize_writer(part)
+        if writer not in writers:
+            writers.append(writer)
+    return writers
+
+
+def _short_name(writer: str) -> str:
+    return bakeoff_aggregate.normalize_agent(writer)
+
+
+def _nonempty(path: Path) -> bool:
+    return path.exists() and path.stat().st_size > 0
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _validate_writer(writer: str) -> str | None:
+    if writer not in linear_pipeline.WRITER_CHOICES:
+        return (
+            f"unknown writer {writer!r}; expected one of "
+            f"{', '.join(linear_pipeline.WRITER_CHOICES)}"
+        )
+    agent_name = writer.split("-", 1)[0]
+    try:
+        get_agent_entry(agent_name)
+    except KeyError:
+        return f"writer {writer!r} does not resolve in agent runtime registry"
+    return None
+
+
+def _preflight(level: str, slug: str, writers: Sequence[str]) -> list[str]:
+    errors: list[str] = []
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    if not plan_path.exists():
+        errors.append(f"missing plan: {_display_path(plan_path)}")
+    else:
+        try:
+            plan = linear_pipeline.load_plan(plan_path)
+            linear_pipeline.validate_plan(plan)
+        except Exception as exc:
+            errors.append(f"invalid plan {_display_path(plan_path)}: {exc}")
+
+    try:
+        article_paths = linear_pipeline._wiki_article_paths(level, slug)
+    except Exception as exc:
+        errors.append(f"could not inspect wiki packet for {level}/{slug}: {exc}")
+    else:
+        if not article_paths:
+            errors.append(f"missing wiki packet for {level}/{slug}")
+
+    for writer in writers:
+        error = _validate_writer(writer)
+        if error:
+            errors.append(error)
+    return errors
+
+
+def run_command(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_or_report(label: str, argv: Sequence[str]) -> StepResult:
+    result = run_command(argv)
+    if result.returncode == 0:
+        return StepResult(label=label, ok=True, returncode=result.returncode)
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    detail = stderr or stdout or f"exit {result.returncode}"
+    print(f"error: {label} failed: {detail}", file=sys.stderr)
+    return StepResult(label=label, ok=False, detail=detail, returncode=result.returncode)
+
+
+def _spike(level: str, slug: str, writer: str) -> StepResult:
+    return _run_or_report(
+        f"spike {writer}",
+        [
+            str(PYTHON),
+            str(V7_BUILD),
+            level,
+            slug,
+            "--writer",
+            writer,
+            "--dry-run",
+        ],
+    )
+
+
+def _copy_writer_markdown(out_dir: Path, bakeoff_dir: Path, slug: str, short: str) -> None:
+    candidates = [
+        out_dir / f"{slug}.md",
+        out_dir / f"{slug}.mdx",
+        out_dir / "module.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            shutil.copyfile(candidate, bakeoff_dir / f"{short}.md")
+            return
+    searched = ", ".join(path.name for path in candidates)
+    raise FileNotFoundError(f"no writer markdown found in {out_dir}; checked {searched}")
+
+
+def _run_writer(
+    *,
+    level: str,
+    slug: str,
+    writer: str,
+    bakeoff_dir: Path,
+    resume: bool,
+) -> StepResult:
+    short = _short_name(writer)
+    telemetry = bakeoff_dir / f"{short}.write.jsonl"
+    out_dir = bakeoff_dir / short
+    if resume and _nonempty(telemetry):
+        return StepResult(label=f"write {writer}", ok=True, skipped=True)
+
+    result = _run_or_report(
+        f"write {writer}",
+        [
+            str(PYTHON),
+            str(V7_BUILD),
+            level,
+            slug,
+            "--writer",
+            writer,
+            "--out",
+            str(out_dir),
+            "--telemetry-out",
+            str(telemetry),
+        ],
+    )
+    if not result.ok:
+        return result
+    try:
+        _copy_writer_markdown(out_dir, bakeoff_dir, slug, short)
+    except OSError as exc:
+        print(f"error: write {writer} copy failed: {exc}", file=sys.stderr)
+        return StepResult(label=f"write {writer}", ok=False, detail=str(exc))
+    return result
+
+
+def _run_review(
+    *,
+    level: str,
+    slug: str,
+    writer: str,
+    reviewer: str,
+    bakeoff_dir: Path,
+    resume: bool,
+) -> StepResult:
+    writer_short = _short_name(writer)
+    reviewer_short = _short_name(reviewer)
+    target = bakeoff_dir / f"{writer_short}-{reviewer_short}.review.jsonl"
+    if resume and _nonempty(target):
+        return StepResult(
+            label=f"review {writer}->{reviewer}",
+            ok=True,
+            skipped=True,
+        )
+    content = bakeoff_dir / f"{writer_short}.md"
+    if not content.exists():
+        detail = f"missing writer markdown for review: {content}"
+        print(f"error: {detail}", file=sys.stderr)
+        return StepResult(label=f"review {writer}->{reviewer}", ok=False, detail=detail)
+
+    return _run_or_report(
+        f"review {writer}->{reviewer}",
+        [
+            str(PYTHON),
+            str(V7_REVIEW),
+            level,
+            slug,
+            "--content",
+            str(content),
+            "--reviewer",
+            reviewer,
+            "--telemetry-out",
+            str(target),
+        ],
+    )
+
+
+def _run_aggregate(bakeoff_dir: Path, writers: Sequence[str]) -> StepResult:
+    writer_shorts = ",".join(_short_name(writer) for writer in writers)
+    return _run_or_report(
+        "aggregate",
+        [
+            str(PYTHON),
+            str(BAKEOFF_AGGREGATE_SCRIPT),
+            "--bakeoff-dir",
+            str(bakeoff_dir),
+            "--writers",
+            writer_shorts,
+        ],
+    )
+
+
+def _print_summary(
+    writer_results: Sequence[StepResult],
+    review_results: Sequence[StepResult],
+    aggregate_result: StepResult | None,
+) -> None:
+    print("Bakeoff summary")
+    print("Writers:")
+    if writer_results:
+        for result in writer_results:
+            state = "skipped" if result.skipped else ("pass" if result.ok else "fail")
+            print(f"  {result.label}: {state}")
+    else:
+        print("  skipped")
+    print("Reviews:")
+    if review_results:
+        for result in review_results:
+            state = "skipped" if result.skipped else ("pass" if result.ok else "fail")
+            print(f"  {result.label}: {state}")
+    else:
+        print("  skipped")
+    if aggregate_result is None:
+        print("Aggregate: skipped")
+    else:
+        state = "pass" if aggregate_result.ok else "fail"
+        print(f"Aggregate: {state} exit_code={aggregate_result.returncode}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        description=(
+            "Run V7 bakeoff writes, cross-reviews, and aggregation for one module.\n"
+            "Use for the A1/20 writer bakeoff; do not use it for V6 or bulk curriculum builds."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/audit/bakeoff_run.py \\\n"
+            "    --bakeoff-dir audit/bakeoff-2026-05-05 \\\n"
+            "    --level a1 --slug my-morning\n"
+            "  .venv/bin/python scripts/audit/bakeoff_run.py \\\n"
+            "    --bakeoff-dir audit/bakeoff-2026-05-05 \\\n"
+            "    --level a1 --slug my-morning \\\n"
+            "    --writers gemini-tools,codex-tools --writers-only\n"
+            "  .venv/bin/python scripts/audit/bakeoff_run.py \\\n"
+            "    --bakeoff-dir audit/bakeoff-2026-05-05 \\\n"
+            "    --level a1 --slug my-morning --resume --reviewers-only\n\n"
+            "Outputs:\n"
+            "  Writes <writer>.md, <writer>.write.jsonl, "
+            "<writer>-<reviewer>.review.jsonl, per-writer output directories, "
+            "and REPORT.md unless --skip-aggregate is set. No curriculum, "
+            "status, audit-review, or review-review files are modified.\n\n"
+            "Exit codes:\n"
+            "  0 when requested phases and aggregation all pass or are intentionally skipped.\n"
+            "  1 on pre-flight failure or any failed write, review, or aggregate step.\n"
+            "  2 on command-line usage errors from argparse.\n\n"
+            "Related:\n"
+            "  Builder: scripts/build/v7_build.py\n"
+            "  Review-only CLI: scripts/build/v7_review.py\n"
+            "  Aggregator: scripts/audit/bakeoff_aggregate.py\n"
+            "  Brief: docs/dispatch-briefs/2026-05-05-a1-20-bakeoff-with-new-prompts.md\n"
+            "  Issue: #1703"
+        ),
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    parser.add_argument(
+        "--bakeoff-dir",
+        required=True,
+        type=Path,
+        help=(
+            "Directory for bakeoff outputs; relative paths resolve from the "
+            "repository root. Example: audit/bakeoff-2026-05-05."
+        ),
+    )
+    parser.add_argument(
+        "--level",
+        required=True,
+        help="Curriculum level code to build and review; example: a1.",
+    )
+    parser.add_argument(
+        "--slug",
+        required=True,
+        help="Module slug matching the plan and wiki packet; example: my-morning.",
+    )
+    parser.add_argument(
+        "--writers",
+        default=DEFAULT_WRITERS,
+        help=(
+            "Comma-separated writer/reviewer backends in execution order. "
+            f"Default: {DEFAULT_WRITERS}."
+        ),
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Skip already-complete writer/review JSONL outputs when present "
+            "and non-empty (default: false)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-aggregate",
+        action="store_true",
+        help="Skip the final bakeoff_aggregate.py invocation (default: false).",
+    )
+    parser.add_argument(
+        "--writers-only",
+        action="store_true",
+        help="Run writer phases only and skip cross-reviews (default: false).",
+    )
+    parser.add_argument(
+        "--reviewers-only",
+        action="store_true",
+        help="Run cross-reviews only and skip writer phases (default: false).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.writers_only and args.reviewers_only:
+        print("error: --writers-only and --reviewers-only cannot be combined", file=sys.stderr)
+        return 1
+
+    level = args.level.lower()
+    slug = args.slug
+    writers = _parse_writers(args.writers)
+    if not writers:
+        print("error: --writers must name at least one writer", file=sys.stderr)
+        return 1
+
+    errors = _preflight(level, slug, writers)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    bakeoff_dir = _resolve_project_path(args.bakeoff_dir)
+    bakeoff_dir.mkdir(parents=True, exist_ok=True)
+
+    writer_results: list[StepResult] = []
+    review_results: list[StepResult] = []
+    aggregate_result: StepResult | None = None
+
+    if not args.reviewers_only:
+        spike = _spike(level, slug, writers[0])
+        if not spike.ok:
+            _print_summary([], [], None)
+            return 1
+
+        for writer in writers:
+            writer_results.append(
+                _run_writer(
+                    level=level,
+                    slug=slug,
+                    writer=writer,
+                    bakeoff_dir=bakeoff_dir,
+                    resume=args.resume,
+                )
+            )
+
+    if not args.writers_only:
+        for writer in writers:
+            for reviewer in writers:
+                if writer == reviewer:
+                    continue
+                review_results.append(
+                    _run_review(
+                        level=level,
+                        slug=slug,
+                        writer=writer,
+                        reviewer=reviewer,
+                        bakeoff_dir=bakeoff_dir,
+                        resume=args.resume,
+                    )
+                )
+
+    if not args.skip_aggregate:
+        aggregate_result = _run_aggregate(bakeoff_dir, writers)
+
+    _print_summary(writer_results, review_results, aggregate_result)
+    failures = [result for result in (*writer_results, *review_results) if not result.ok]
+    if aggregate_result is not None and not aggregate_result.ok:
+        failures.append(aggregate_result)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -12,6 +12,7 @@ import json
 import re
 import sys
 from collections.abc import Callable, Mapping
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -41,10 +42,11 @@ PLAN_REQUIRED_KEYS = {
     "references",
 }
 
-WRITER_CHOICES = ("claude-tools", "gemini-tools")
+WRITER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools")
 WRITER_DEFAULTS: dict[str, dict[str, str]] = {
     "claude-tools": {"model": "claude-opus-4-7", "effort": "xhigh"},
     "gemini-tools": {"model": "gemini-3.1-pro-preview", "effort": "high"},
+    "codex-tools": {"model": "gpt-5.5", "effort": "high"},
 }
 REVIEWER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools")
 REVIEWER_DEFAULTS: dict[str, dict[str, str]] = {
@@ -187,6 +189,7 @@ TELEMETRY_MAX_QUOTES = 5
 TELEMETRY_MAX_QUOTE_CHARS = 240
 TELEMETRY_MAX_MAPPING_CHARS = 500
 TELEMETRY_MAX_FAILED_WORDS = 5
+_TELEMETRY_EVENT_SINK: Callable[..., None] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -901,12 +904,50 @@ def render_phase_prompt(template_path: Path, context: Mapping[str, Any]) -> str:
 
 def emit_event(event: str, **fields: Any) -> None:
     """Emit one monitor-friendly JSONL event using the V6 event shape."""
+    if _TELEMETRY_EVENT_SINK is not None:
+        _TELEMETRY_EVENT_SINK(event, **fields)
+        return
     line = json.dumps(
         {"event": event, "ts": datetime.now(UTC).isoformat(), **fields},
         ensure_ascii=False,
         default=str,
     )
     print(line, flush=True)
+
+
+def _make_file_event_sink(path: Path) -> tuple[Callable[..., None], Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a", encoding="utf-8")
+
+    def sink(event: str, **fields: Any) -> None:
+        line = json.dumps(
+            {"event": event, "ts": datetime.now(UTC).isoformat(), **fields},
+            ensure_ascii=False,
+            default=str,
+        )
+        handle.write(f"{line}\n")
+        handle.flush()
+
+    return sink, handle
+
+
+@contextmanager
+def telemetry_event_sink(path: Path | None):
+    """Temporarily route JSONL telemetry to ``path`` in append mode."""
+    global _TELEMETRY_EVENT_SINK
+
+    previous = _TELEMETRY_EVENT_SINK
+    sink: Callable[..., None] | None = None
+    handle: Any = None
+    try:
+        if path is not None:
+            sink, handle = _make_file_event_sink(path)
+            _TELEMETRY_EVENT_SINK = sink
+        yield
+    finally:
+        _TELEMETRY_EVENT_SINK = previous
+        if handle is not None:
+            handle.close()
 
 
 def _emit(event_sink: Callable[..., None] | None, event: str, **fields: Any) -> None:
@@ -1397,6 +1438,17 @@ def _render_component_props_schema(allowed_activity_types: str) -> str:
     return "\n".join(lines)
 
 
+def _runtime_tool_config(agent_label: str) -> dict[str, Any]:
+    tool_config: dict[str, Any] = {"output_format": "text"}
+    if agent_label == "codex-tools":
+        from scripts.agent_runtime.tool_config import build_mcp_tool_config
+
+        codex_tools = build_mcp_tool_config("codex", mcp_servers=["sources"])
+        if codex_tools:
+            tool_config.update(codex_tools)
+    return tool_config
+
+
 def invoke_writer(
     prompt: str,
     writer: str,
@@ -1426,7 +1478,7 @@ def invoke_writer(
         task_id="phase-4-a1-20-writer",
         entrypoint="dispatch",
         effort=defaults["effort"],
-        tool_config={"output_format": "text"},
+        tool_config=_runtime_tool_config(writer),
     )
     response = getattr(result, "response", None)
     if not response:
@@ -1797,7 +1849,7 @@ def invoke_reviewer_dim(
         task_id=f"phase-4-review-{dim}",
         entrypoint="dispatch",
         effort=defaults["effort"],
-        tool_config={"output_format": "text"},
+        tool_config=_runtime_tool_config(reviewer),
     )
     response = getattr(result, "response", None)
     if not response:

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -4,11 +4,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 import time
 from collections.abc import Mapping
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -22,17 +20,13 @@ from scripts.common.thresholds import QG_DIMS
 WRITER_ALIASES = {
     "claude": "claude-tools",
     "gemini": "gemini-tools",
+    "codex": "codex-tools",
 }
 WRITER_CHOICES = (*linear_pipeline.WRITER_CHOICES, *WRITER_ALIASES)
 
 
 def emit_event(event: str, **fields: Any) -> None:
-    payload = {
-        "event": event,
-        "ts": datetime.now(UTC).isoformat(),
-        **fields,
-    }
-    print(json.dumps(payload, ensure_ascii=False, default=str), flush=True)
+    linear_pipeline.emit_event(event, **fields)
 
 
 def _default_module_dir(level: str, slug: str) -> Path:
@@ -42,6 +36,15 @@ def _default_module_dir(level: str, slug: str) -> Path:
 def _resolve_output_dir(raw: str | None, level: str, slug: str) -> Path:
     if raw is None:
         return _default_module_dir(level, slug)
+    path = Path(raw)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    return path
+
+
+def _resolve_project_path(raw: str | None) -> Path | None:
+    if raw is None:
+        return None
     path = Path(raw)
     if not path.is_absolute():
         path = PROJECT_ROOT / path
@@ -146,9 +149,10 @@ def build_parser() -> argparse.ArgumentParser:
             "Examples:\n"
             "  .venv/bin/python scripts/build/v7_build.py a1 my-morning --dry-run\n"
             "  .venv/bin/python scripts/build/v7_build.py a1 my-morning --writer gemini-tools\n"
+            "  .venv/bin/python scripts/build/v7_build.py a1 my-morning --writer codex-tools --telemetry-out audit/bakeoff-2026-05-05/gpt55.write.jsonl\n"
             "  .venv/bin/python scripts/build/v7_build.py b1-pro intro --out /tmp/v7-intro\n\n"
             "Outputs:\n"
-            "  Emits JSONL monitor events to stdout. Full builds write the writer "
+            "  Emits JSONL monitor events to stdout, or appends them to --telemetry-out. Full builds write the writer "
             "artifacts, knowledge_packet.md, writer_prompt.md, python_qg.json, "
             "llm_qg.json, and {slug}.mdx under --out or "
             "curriculum/l2-uk-en/{level}/{slug}/. Dry runs do not write files.\n\n"
@@ -184,8 +188,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="claude-tools",
         help=(
             "Writer backend for the one-shot V7 write phase "
-            "(default: claude-tools; claude/gemini aliases normalize to "
-            "claude-tools/gemini-tools)."
+            "(default: claude-tools; claude/gemini/codex aliases normalize to "
+            "claude-tools/gemini-tools/codex-tools)."
         ),
     )
     parser.add_argument(
@@ -206,11 +210,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "from the repository root."
         ),
     )
+    parser.add_argument(
+        "--telemetry-out",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Append JSONL monitor events to PATH instead of stdout. Relative "
+            "paths resolve from the repository root; default: stdout."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    telemetry_out = _resolve_project_path(args.telemetry_out)
+    with linear_pipeline.telemetry_event_sink(telemetry_out):
+        return _run(args)
+
+
+def _run(args: argparse.Namespace) -> int:
     level = args.level.lower()
     slug = args.slug
     writer = _normalize_writer(args.writer)

--- a/scripts/build/v7_review.py
+++ b/scripts/build/v7_review.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Review-only CLI for the V7 linear module pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.build import linear_pipeline
+from scripts.common.thresholds import QG_DIMS
+
+AGENT_ALIASES = {
+    "claude": "claude-tools",
+    "gemini": "gemini-tools",
+    "codex": "codex-tools",
+    "gpt": "codex-tools",
+    "gpt55": "codex-tools",
+    "gpt-5.5": "codex-tools",
+    "openai": "codex-tools",
+}
+REVIEWER_CHOICES = (*linear_pipeline.REVIEWER_CHOICES, *AGENT_ALIASES)
+FRONTMATTER_RE = re.compile(r"^---\s*\n(?P<body>.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
+
+
+def emit_event(event: str, **fields: Any) -> None:
+    linear_pipeline.emit_event(event, **fields)
+
+
+def _resolve_project_path(raw: str | None) -> Path | None:
+    if raw is None:
+        return None
+    path = Path(raw)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    return path
+
+
+def _normalize_agent(raw: str) -> str:
+    value = raw.strip().casefold().replace("_tools", "-tools")
+    return AGENT_ALIASES.get(value, value)
+
+
+def _writer_from_frontmatter(text: str) -> str | None:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+    try:
+        payload = yaml.safe_load(match.group("body"))
+    except yaml.YAMLError as exc:
+        raise linear_pipeline.LinearPipelineError(
+            f"Content front matter is invalid YAML: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        return None
+    writer = payload.get("writer")
+    if writer is None:
+        return None
+    return _normalize_agent(str(writer))
+
+
+def _writer_from_content_path(path: Path) -> str | None:
+    stem = path.stem.casefold()
+    if stem in {"claude", "gemini", "gpt55"}:
+        return _normalize_agent(stem)
+    return None
+
+
+def _phase_done(
+    phase: str,
+    started_at: float,
+    *,
+    level: str,
+    slug: str,
+    **fields: Any,
+) -> None:
+    emit_event(
+        "phase_done",
+        level=level,
+        slug=slug,
+        phase=phase,
+        duration_s=round(time.monotonic() - started_at, 3),
+        **fields,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        description=(
+            "Run only the V7 per-dimension LLM review for an existing lesson markdown file.\n"
+            "Use for bakeoff cross-review or reviewer reruns; do not use it to write or repair modules."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/build/v7_review.py a1 my-morning \\\n"
+            "    --content audit/bakeoff-2026-05-05/gemini.md \\\n"
+            "    --reviewer claude-tools\n"
+            "  .venv/bin/python scripts/build/v7_review.py a1 my-morning \\\n"
+            "    --content audit/bakeoff-2026-05-05/gpt55.md \\\n"
+            "    --reviewer gemini-tools \\\n"
+            "    --telemetry-out audit/bakeoff-2026-05-05/gpt55-gemini.review.jsonl\n\n"
+            "Outputs:\n"
+            "  Emits reviewer_dim_evidence and phase_review_summary JSONL to stdout, "
+            "or appends those events to --telemetry-out. No curriculum, status, "
+            "audit-review, or review-review files are modified.\n\n"
+            "Exit codes:\n"
+            "  0 when every configured LLM QG dimension is reviewed and aggregated.\n"
+            "  1 on missing plan, packet, content, self-review, reviewer, or parse failure.\n"
+            "  2 on command-line usage errors from argparse.\n\n"
+            "Related:\n"
+            "  Pipeline: scripts/build/linear_pipeline.py\n"
+            "  Reviewer prompt: scripts/build/phases/linear-review-dim.md\n"
+            "  Aggregator: scripts/audit/bakeoff_aggregate.py\n"
+            "  Issue: #1703"
+        ),
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    parser.add_argument(
+        "level",
+        help="Curriculum level code, for example a1, b1-pro, or hist.",
+    )
+    parser.add_argument(
+        "slug",
+        help="Module slug matching curriculum/l2-uk-en/plans/{level}/{slug}.yaml.",
+    )
+    parser.add_argument(
+        "--content",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Markdown or MDX lesson file to review. Relative paths resolve "
+            "from the repository root; example: audit/bakeoff-2026-05-05/gemini.md."
+        ),
+    )
+    parser.add_argument(
+        "--reviewer",
+        required=True,
+        choices=REVIEWER_CHOICES,
+        help=(
+            "Reviewer backend for every per-dimension LLM QG call; choices are "
+            "claude-tools, gemini-tools, codex-tools, plus short aliases."
+        ),
+    )
+    parser.add_argument(
+        "--telemetry-out",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Append JSONL review events to PATH instead of stdout. Relative "
+            "paths resolve from the repository root; default: stdout."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    telemetry_out = _resolve_project_path(args.telemetry_out)
+    with linear_pipeline.telemetry_event_sink(telemetry_out):
+        return _run(args)
+
+
+def _run(args: argparse.Namespace) -> int:
+    level = args.level.lower()
+    slug = args.slug
+    reviewer = _normalize_agent(args.reviewer)
+    content_path = _resolve_project_path(args.content)
+    assert content_path is not None
+    module_started_at = time.monotonic()
+    phase = "start"
+    module_ref = f"{level}/{slug}"
+    captured_events: list[dict[str, Any]] = []
+
+    def event_sink(event: str, **fields: Any) -> None:
+        captured_events.append({"event": event, **fields})
+        emit_event(event, **fields)
+
+    emit_event("module_start", level=level, slug=slug, reviewer=reviewer)
+
+    try:
+        phase = "plan"
+        started_at = time.monotonic()
+        plan_path = linear_pipeline.plan_path_for(level, slug)
+        plan_content = plan_path.read_text(encoding="utf-8")
+        plan = linear_pipeline.load_plan(plan_path)
+        linear_pipeline.validate_plan(plan)
+        _phase_done(phase, started_at, level=level, slug=slug)
+
+        phase = "knowledge_packet"
+        started_at = time.monotonic()
+        linear_pipeline.build_knowledge_packet(level=level, slug=slug, plan=plan)
+        _phase_done(phase, started_at, level=level, slug=slug)
+
+        phase = "content"
+        started_at = time.monotonic()
+        content = content_path.read_text(encoding="utf-8")
+        writer_under_review = (
+            _writer_from_frontmatter(content)
+            or _writer_from_content_path(content_path)
+            or "unknown"
+        )
+        if writer_under_review == reviewer:
+            raise linear_pipeline.LinearPipelineError(
+                f"Self-review refused: writer and reviewer are both {reviewer}"
+            )
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            content=content_path,
+            writer_under_review=writer_under_review,
+        )
+
+        phase = "review"
+        started_at = time.monotonic()
+        report: dict[str, dict[str, Any]] = {}
+        for dim in QG_DIMS:
+            prompt = linear_pipeline.render_review_prompt(
+                plan,
+                plan_content,
+                content,
+                dim,
+            )
+            response = linear_pipeline.invoke_reviewer_dim(
+                prompt,
+                reviewer,
+                dim=dim,
+                writer_under_review=writer_under_review,
+                cwd=content_path.parent,
+                module=module_ref,
+                event_sink=event_sink,
+            )
+            report[dim] = linear_pipeline.parse_review_response(response, dim)
+
+        audit_calls_total = sum(
+            1 for event in captured_events if event["event"] == "reviewer_audit_call"
+        )
+        flags_raised_total = sum(
+            len(event.get("flags_raised") or [])
+            for event in captured_events
+            if event["event"] == "reviewer_audit_call"
+        )
+        emitted_dims = {
+            event.get("dim")
+            for event in captured_events
+            if event["event"] == "reviewer_dim_evidence"
+        }
+        if emitted_dims != set(QG_DIMS):
+            missing = sorted(set(QG_DIMS) - emitted_dims)
+            raise linear_pipeline.LinearPipelineError(
+                f"Reviewer telemetry missing dim events: {missing}"
+            )
+        aggregate = linear_pipeline.aggregate_llm_review(
+            report,
+            str(plan["level"]),
+            reviewer=reviewer,
+            module=module_ref,
+            writer_under_review=writer_under_review,
+            audit_calls_total=audit_calls_total,
+            flags_raised_total=flags_raised_total,
+            event_sink=event_sink,
+        )
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            reviewer=reviewer,
+            verdict=aggregate["aggregate"]["verdict"],
+        )
+        emit_event(
+            "module_done",
+            level=level,
+            slug=slug,
+            reviewer=reviewer,
+            duration_s=round(time.monotonic() - module_started_at, 3),
+        )
+        return 0
+    except Exception as exc:
+        emit_event(
+            "module_failed",
+            level=level,
+            slug=slug,
+            reviewer=reviewer,
+            phase=phase,
+            reason=str(exc)[:500],
+        )
+        print(f"v7_review failed in phase {phase}: {exc}", file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bakeoff_run.py
+++ b/tests/test_bakeoff_run.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit import bakeoff_run
+
+
+def _completed(argv: list[str], returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(argv, returncode, stdout="", stderr="")
+
+
+def _fake_runner(calls: list[list[str]], slug: str = "my-morning"):
+    def run(argv: Any) -> subprocess.CompletedProcess[str]:
+        command = [str(part) for part in argv]
+        calls.append(command)
+        script = Path(command[1]).name
+        if script == "v7_build.py" and "--dry-run" not in command:
+            out_dir = Path(command[command.index("--out") + 1])
+            telemetry = Path(command[command.index("--telemetry-out") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            telemetry.parent.mkdir(parents=True, exist_ok=True)
+            (out_dir / f"{slug}.mdx").write_text(
+                "---\nlevel: A1\nslug: my-morning\n---\n\n# Мій ранок\n",
+                encoding="utf-8",
+            )
+            telemetry.write_text(
+                json.dumps({"event": "phase_writer_summary"}) + "\n",
+                encoding="utf-8",
+            )
+        elif script == "v7_review.py":
+            telemetry = Path(command[command.index("--telemetry-out") + 1])
+            telemetry.parent.mkdir(parents=True, exist_ok=True)
+            telemetry.write_text(
+                json.dumps({"event": "phase_review_summary"}) + "\n",
+                encoding="utf-8",
+            )
+        elif script == "bakeoff_aggregate.py":
+            bakeoff_dir = Path(command[command.index("--bakeoff-dir") + 1])
+            (bakeoff_dir / "REPORT.md").write_text("# Report\n", encoding="utf-8")
+        return _completed(command)
+
+    return run
+
+
+def _plan_payload() -> dict[str, object]:
+    return {
+        "module": "a1-020",
+        "level": "A1",
+        "sequence": 20,
+        "slug": "my-morning",
+        "title": "Мій ранок",
+        "subtitle": "Зворотні дієслова",
+        "word_target": 1200,
+        "content_outline": [
+            {
+                "section": "Діалоги",
+                "words": 1200,
+                "points": ["Introduce a morning dialogue."],
+            }
+        ],
+        "references": [{"title": "Fixture source"}],
+    }
+
+
+def test_bakeoff_run_invokes_write_and_review_steps_in_order(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+    bakeoff_dir = tmp_path / "bakeoff"
+    monkeypatch.setattr(bakeoff_run, "run_command", _fake_runner(calls))
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(bakeoff_dir),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools,claude-tools",
+            "--skip-aggregate",
+        ]
+    )
+
+    scripts = [Path(call[1]).name for call in calls]
+
+    assert exit_code == 0
+    assert scripts == [
+        "v7_build.py",
+        "v7_build.py",
+        "v7_build.py",
+        "v7_review.py",
+        "v7_review.py",
+    ]
+    assert "--dry-run" in calls[0]
+    assert calls[0][calls[0].index("--writer") + 1] == "gemini-tools"
+    assert calls[1][calls[1].index("--writer") + 1] == "gemini-tools"
+    assert calls[1][calls[1].index("--out") + 1] == str(bakeoff_dir / "gemini")
+    assert calls[1][calls[1].index("--telemetry-out") + 1] == str(
+        bakeoff_dir / "gemini.write.jsonl"
+    )
+    assert calls[3][calls[3].index("--content") + 1] == str(bakeoff_dir / "gemini.md")
+    assert calls[3][calls[3].index("--reviewer") + 1] == "claude-tools"
+    assert calls[4][calls[4].index("--content") + 1] == str(bakeoff_dir / "claude.md")
+    assert calls[4][calls[4].index("--reviewer") + 1] == "gemini-tools"
+
+
+def test_bakeoff_run_resume_skips_complete_writer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+    bakeoff_dir = tmp_path / "bakeoff"
+    bakeoff_dir.mkdir()
+    (bakeoff_dir / "gemini.write.jsonl").write_text('{"event":"done"}\n', "utf-8")
+    monkeypatch.setattr(bakeoff_run, "run_command", _fake_runner(calls))
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(bakeoff_dir),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools,claude-tools",
+            "--resume",
+            "--writers-only",
+            "--skip-aggregate",
+        ]
+    )
+
+    full_build_writers = [
+        call[call.index("--writer") + 1]
+        for call in calls
+        if Path(call[1]).name == "v7_build.py" and "--dry-run" not in call
+    ]
+
+    assert exit_code == 0
+    assert full_build_writers == ["claude-tools"]
+
+
+def test_bakeoff_run_preflight_missing_plan_exits_1(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        bakeoff_run.linear_pipeline,
+        "plan_path_for",
+        lambda _level, _slug: tmp_path / "missing.yaml",
+    )
+    monkeypatch.setattr(
+        bakeoff_run,
+        "run_command",
+        lambda _argv: (_ for _ in ()).throw(AssertionError("runner called")),
+    )
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(tmp_path / "bakeoff"),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "missing plan" in captured.err
+
+
+def test_bakeoff_run_preflight_missing_packet_exits_1(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(bakeoff_run.linear_pipeline, "_wiki_article_paths", lambda *_args: [])
+    monkeypatch.setattr(
+        bakeoff_run,
+        "run_command",
+        lambda _argv: (_ for _ in ()).throw(AssertionError("runner called")),
+    )
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(tmp_path / "bakeoff"),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "missing wiki packet" in captured.err
+
+
+def test_bakeoff_run_preflight_unknown_writer_exits_1(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        bakeoff_run,
+        "run_command",
+        lambda _argv: (_ for _ in ()).throw(AssertionError("runner called")),
+    )
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(tmp_path / "bakeoff"),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "bogus-tools",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "unknown writer" in captured.err
+
+
+def test_bakeoff_run_aggregate_gets_normalized_writer_list(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+    bakeoff_dir = tmp_path / "bakeoff"
+    monkeypatch.setattr(bakeoff_run, "run_command", _fake_runner(calls))
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(bakeoff_dir),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools,codex-tools,claude-tools",
+            "--writers-only",
+        ]
+    )
+
+    aggregate_call = next(call for call in calls if Path(call[1]).name == "bakeoff_aggregate.py")
+
+    assert exit_code == 0
+    assert aggregate_call[aggregate_call.index("--writers") + 1] == "gemini,gpt55,claude"
+
+
+def test_bakeoff_run_preflight_accepts_fixture_plan(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    plan_path = tmp_path / "my-morning.yaml"
+    plan_path.write_text(yaml.safe_dump(_plan_payload()), encoding="utf-8")
+    monkeypatch.setattr(
+        bakeoff_run.linear_pipeline,
+        "plan_path_for",
+        lambda _level, _slug: plan_path,
+    )
+    monkeypatch.setattr(
+        bakeoff_run.linear_pipeline,
+        "_wiki_article_paths",
+        lambda *_args: [tmp_path / "my-morning.md"],
+    )
+
+    assert bakeoff_run._preflight("a1", "my-morning", ["gemini-tools"]) == []

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+
+import pytest
 
 from scripts.build import linear_pipeline
 from scripts.common.thresholds import QG_DIMS
@@ -314,3 +317,22 @@ def test_telemetry_event_schema_is_bounded_and_flat() -> None:
         if event["event"] == "writer_cot_emit":
             assert event["block_chars"] < 1000
             assert set(event["fields_filled"]) <= set(linear_pipeline.PROMPT_ADHERENCE_FIELDS)
+
+
+def test_telemetry_event_sink_appends_jsonl(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline.emit_event("first", slug="x")
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline.emit_event("second", slug="x")
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in telemetry.read_text("utf-8").splitlines()]
+
+    assert captured.out == ""
+    assert [event["event"] for event in events] == ["first", "second"]
+    assert all(event["slug"] == "x" for event in events)

--- a/tests/test_v7_review.py
+++ b/tests/test_v7_review.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.build import linear_pipeline, v7_review
+from scripts.common.thresholds import QG_DIMS
+
+
+def _lesson(path: Path, *, writer: str = "gemini-tools") -> Path:
+    path.write_text(
+        f"""---
+level: A1
+slug: my-morning
+writer: {writer}
+---
+
+# Мій ранок
+
+\"Я прокидаюся о сьомій\" and then I make coffee.
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _review_response(dim: str) -> str:
+    return json.dumps(
+        {
+            "score": 8.5,
+            "evidence": f"\"{dim} quote one\"",
+            "evidence_quotes": [f"{dim} quote one", f"{dim} quote two"],
+            "rubric_mapping": f"{dim} maps to the fixture rubric.",
+            "verdict": "PASS",
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cheap_packet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        v7_review.linear_pipeline,
+        "build_knowledge_packet",
+        lambda **_kwargs: "knowledge packet",
+    )
+
+
+@pytest.fixture()
+def fake_reviewer(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def invoke(
+        prompt: str,
+        reviewer: str,
+        *,
+        dim: str,
+        writer_under_review: str,
+        module: str,
+        event_sink: Any,
+        **kwargs: Any,
+    ) -> str:
+        calls.append(
+            {
+                "prompt": prompt,
+                "reviewer": reviewer,
+                "dim": dim,
+                "writer_under_review": writer_under_review,
+                "module": module,
+                "kwargs": kwargs,
+            }
+        )
+        response = _review_response(dim)
+        linear_pipeline.parse_review_response(
+            response,
+            dim,
+            reviewer=reviewer,
+            module=module,
+            writer_under_review=writer_under_review,
+            event_sink=event_sink,
+        )
+        return response
+
+    monkeypatch.setattr(v7_review.linear_pipeline, "invoke_reviewer_dim", invoke)
+    return calls
+
+
+def _events_from_stdout(stdout: str) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+
+
+def test_v7_review_refuses_self_review(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    content = _lesson(tmp_path / "claude.md", writer="claude-tools")
+
+    exit_code = v7_review.main(
+        [
+            "a1",
+            "my-morning",
+            "--content",
+            str(content),
+            "--reviewer",
+            "claude-tools",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Self-review refused" in captured.err
+
+
+def test_v7_review_success_emits_all_dim_events(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    fake_reviewer: list[dict[str, Any]],
+) -> None:
+    content = _lesson(tmp_path / "gemini.md", writer="gemini-tools")
+
+    exit_code = v7_review.main(
+        [
+            "a1",
+            "my-morning",
+            "--content",
+            str(content),
+            "--reviewer",
+            "claude-tools",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    events = _events_from_stdout(captured.out)
+    dim_events = [event for event in events if event["event"] == "reviewer_dim_evidence"]
+    summaries = [event for event in events if event["event"] == "phase_review_summary"]
+
+    assert exit_code == 0
+    assert [call["dim"] for call in fake_reviewer] == list(QG_DIMS)
+    assert len(dim_events) == len(QG_DIMS)
+    assert {event["dim"] for event in dim_events} == set(QG_DIMS)
+    assert all(event["reviewer"] == "claude-tools" for event in dim_events)
+    assert all(event["writer_under_review"] == "gemini-tools" for event in dim_events)
+    assert summaries[0]["dims_scored"] == len(QG_DIMS)
+    assert summaries[0]["dims_with_evidence"] == len(QG_DIMS)
+
+
+def test_v7_review_telemetry_out_writes_file_not_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    fake_reviewer: list[dict[str, Any]],
+) -> None:
+    content = _lesson(tmp_path / "gpt55.md", writer="codex-tools")
+    telemetry = tmp_path / "review.jsonl"
+
+    exit_code = v7_review.main(
+        [
+            "a1",
+            "my-morning",
+            "--content",
+            str(content),
+            "--reviewer",
+            "gemini-tools",
+            "--telemetry-out",
+            str(telemetry),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in telemetry.read_text("utf-8").splitlines()]
+    dim_events = [event for event in events if event["event"] == "reviewer_dim_evidence"]
+
+    assert exit_code == 0
+    assert captured.out == ""
+    assert len(fake_reviewer) == len(QG_DIMS)
+    assert len(dim_events) == len(QG_DIMS)
+    assert events[-1]["event"] == "module_done"

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.agent_runtime.registry import get_agent_entry
+from scripts.build import linear_pipeline, v7_build
+
+
+@pytest.mark.parametrize(
+    ("writer", "agent_name"),
+    [
+        ("claude-tools", "claude"),
+        ("gemini-tools", "gemini"),
+        ("codex-tools", "codex"),
+    ],
+)
+def test_v7_writer_choices_resolve_to_runtime_adapters(
+    tmp_path: Path,
+    writer: str,
+    agent_name: str,
+) -> None:
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def fake_invoker(agent: str, prompt: str, **kwargs: Any) -> SimpleNamespace:
+        calls.append((agent, prompt, kwargs))
+        return SimpleNamespace(response="writer output")
+
+    response = linear_pipeline.invoke_writer(
+        "Write the module.",
+        writer=writer,
+        cwd=tmp_path,
+        invoker=fake_invoker,
+    )
+
+    entry = get_agent_entry(agent_name)
+    module_name, class_name = entry["adapter"].split(":", 1)
+    adapter_module = importlib.import_module(module_name)
+
+    assert response == "writer output"
+    assert getattr(adapter_module, class_name)
+    assert calls[0][0] == agent_name
+    assert calls[0][1] == "Write the module."
+    assert calls[0][2]["mode"] == "workspace-write"
+    assert calls[0][2]["cwd"] == tmp_path
+    assert calls[0][2]["entrypoint"] == "dispatch"
+    assert calls[0][2]["model"] == linear_pipeline.WRITER_DEFAULTS[writer]["model"]
+    assert calls[0][2]["effort"] == linear_pipeline.WRITER_DEFAULTS[writer]["effort"]
+    assert calls[0][2]["tool_config"]["output_format"] == "text"
+    if writer == "codex-tools":
+        assert calls[0][2]["tool_config"]["mcp_servers"]["sources"]["url"].endswith("/sse")
+    else:
+        assert calls[0][2]["tool_config"] == {"output_format": "text"}
+
+
+def test_v7_build_accepts_codex_alias() -> None:
+    assert "codex-tools" in v7_build.WRITER_CHOICES
+    assert "codex" in v7_build.WRITER_CHOICES
+    assert v7_build._normalize_writer("codex") == "codex-tools"
+
+
+def test_v7_build_dry_run_telemetry_out_writes_file_not_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    telemetry = tmp_path / "out.jsonl"
+
+    exit_code = v7_build.main(
+        [
+            "a1",
+            "my-morning",
+            "--writer",
+            "codex-tools",
+            "--dry-run",
+            "--telemetry-out",
+            str(telemetry),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in telemetry.read_text("utf-8").splitlines()]
+
+    assert exit_code == 0
+    assert captured.out == ""
+    assert events
+    assert {event["event"] for event in events} >= {"module_start", "phase_done", "module_done"}
+    assert events[-1]["event"] == "module_done"
+    assert events[-1]["dry_run"] is True


### PR DESCRIPTION
## Summary
- Adds `codex-tools` writer to V7 (`v7_build.py` + `linear_pipeline.WRITER_*`)
- New `scripts/build/v7_review.py` — review-only entry point with `--content`/`--reviewer`/`--telemetry-out`
- New `--telemetry-out PATH` flag on `v7_build.py` for file-sink JSONL
- New `scripts/audit/bakeoff_run.py` — Python orchestration harness for the 3-writer × 6-cross-review bakeoff
- Updates `docs/dispatch-briefs/2026-05-05-a1-20-bakeoff-with-new-prompts.md` to use the new harness

## Test plan
- [x] `pytest tests/test_v7_writer_dispatch.py tests/test_v7_review.py tests/test_bakeoff_run.py tests/test_linear_pipeline_telemetry.py -v` all green
- [x] `v7_build.py --writer codex-tools a1 my-morning --dry-run` exit 0
- [ ] `v7_review.py a1 my-morning --content fixtures/sample.md --reviewer claude-tools --telemetry-out /tmp/out.jsonl` produces a valid event stream (not run live; covered by `tests/test_v7_review.py` with a fake reviewer to avoid spending API budget)
- [ ] `bakeoff_run.py --bakeoff-dir /tmp/bk-test --level a1 --slug my-morning --writers gemini-tools,claude-tools --skip-aggregate` writes the expected file layout (not run live; covered by `tests/test_bakeoff_run.py` with a fake runner to avoid spending API budget)
- [x] `ruff check scripts/build/ scripts/audit/ tests/` clean
- [x] `bakeoff_run.py --bakeoff-dir /tmp/bakeoff-preflight-smoke --level a1 --slug my-morning --writers gemini-tools --reviewers-only --skip-aggregate` preflight smoke exits 0 without LLM calls

Closes #1703.