### PR TITLE
fix(prompts): escape literal {X} in linear-write.md + add render-guard test (#1705)

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -31,7 +31,7 @@ mode that bit Phase 4 round 3.5.
    gloss without a Ukrainian sentence is also insufficient.
 
 3. **Register check.** Re-read the Immersion Rule above. State internally:
-   "I will produce ~{X}% Ukrainian and ~{100-X}% English in module.md." If
+   "I will produce ~X% Ukrainian and ~(100-X)% English in module.md." If
    your draft starts drifting (English bridge sentences expanding, Ukrainian
    examples shrinking), STOP and rebudget — do not push through.
 

--- a/tests/test_prompt_template_render.py
+++ b/tests/test_prompt_template_render.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.build.prompt_builder import render_prompt
+
+PHASES_DIR = Path(__file__).resolve().parents[1] / "scripts" / "build" / "phases"
+
+
+@pytest.mark.parametrize("template_path", sorted(PHASES_DIR.rglob("*.md")))
+def test_phase_template_renders_without_unknown_tokens(template_path: Path) -> None:
+    render_prompt(template_path)


### PR DESCRIPTION
## Summary
- Reworded the linear writer immersion-register example so it uses plain math notation instead of placeholder-shaped brace literals.
- Added a pytest render guard that calls prompt_builder.render_prompt() for every Markdown phase template under scripts/build/phases/.

## Sibling Hunt Findings
- Fixed: scripts/build/phases/linear-write.md:34 had the unregistered literal {X}; the adjacent {100-X} was also reworded for clarity even though it did not match TOKEN_RE.
- No other unregistered {TOKEN}-shaped literals were found under scripts/build/phases/**/*.md after cross-checking against PLACEHOLDERS and DOWNSTREAM_TOKENS.

## Test Rationale
- The failure mode is render_prompt() raising RuntimeError before downstream replacement, so the test exercises that exact guard across every phase template from a clean repo context.

## Validation
- git log --oneline HEAD..origin/main returned empty before edits.
- .venv/bin/pytest tests/test_prompt_template_render.py -v: 28 passed.
- .venv/bin/python scripts/build/v7_build.py a1 my-morning --writer claude-tools --dry-run: module_done.
- .venv/bin/ruff check scripts/build/ tests/: passed.
- git diff --check: passed.
- Gemini review: clean, Reviewed-By trailer included on commit 1deca0ade7.

Fixes #1705