### PR TITLE
fix(gemini): switch adapter from stdin-pipe to -p flag (#1709)

### DIFF
--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -428,6 +428,26 @@ research = _extract_delimiter(output, "===RESEARCH_START===", "===RESEARCH_END==
 
 Never parse Gemini's prose output for structured data.
 
+### Gemini CLI Auth and Prompt Passing
+
+As of 2026-05-05 (#1709/#1710), the runtime invokes Gemini CLI with `-p`
+instead of piping prompts on stdin. Gemini CLI v0.40.1 treats non-TTY stdin as
+REPL input and can ignore or hang on piped prompts. Small prompts are passed
+inline with `-p PROMPT`; prompts over 100K chars use the verified file-reference
+form `-p @PATH`.
+
+For write-mode runtime calls, keep `--approval-mode=yolo` and include
+`--skip-trust`; Gemini CLI v0.40.1 otherwise downgrades approval mode in
+untrusted output directories such as `/tmp` and exits before writing.
+
+Gemini auth precedence is API first, then subscription/OAuth fallback:
+
+- `GEMINI_AUTH_MODE=api` forces API mode.
+- `GEMINI_AUTH_MODE=subscription` or `oauth` forces subscription/OAuth mode and
+  strips Gemini API env vars from the subprocess.
+- With no override, `GEMINI_API_KEY` or `GOOGLE_API_KEY` selects API mode.
+- With no override and no API key, subscription/OAuth remains the default.
+
 ---
 
 ## Escalation

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -31,10 +31,13 @@ Issue: #1184
 """
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
 import shutil
+import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 
 from ai_llm.fallback import GEMINI_AUTH_ENV_VARS, is_gemini_rate_limited
@@ -50,6 +53,8 @@ _TRANSIENT_ERROR_PATTERNS = (
 )
 _TRANSIENT_ERROR_RE = re.compile("|".join(_TRANSIENT_ERROR_PATTERNS), re.IGNORECASE)
 _AUTH_MODE_VALUES = frozenset({"auto", "subscription", "api"})
+_INLINE_PROMPT_LIMIT_CHARS = 100_000
+_PROMPT_FILE_PREFIX = "learn-ukrainian-gemini-prompt-"
 
 
 def has_gemini_oauth_credentials(home: Path | None = None) -> bool:
@@ -75,27 +80,55 @@ def resolve_gemini_auth_mode(
 ) -> str:
     """Resolve the effective Gemini auth mode for this invocation.
 
-    Project policy (2026-04-23, post-#1416): **always subscription** unless
-    the user has explicitly set ``GEMINI_AUTH_MODE=api`` for a one-off
-    legitimate API-mode run.
-
-    Why: this project is permanently non-commercial, the user has an Ultra
-    OAuth subscription, and conditional resolution caused a macOS Keychain
-    permission popup loop on every gemini-cli spawn under env-strip (#1416).
-    Forcing subscription is the blunt fix the user asked for — one-time
-    Keychain "Always Allow" click + zero env complexity afterward.
+    Project policy (2026-05-05, #1710): prefer API-key mode when
+    ``GEMINI_API_KEY`` or ``GOOGLE_API_KEY`` is available, then fall back to
+    subscription/OAuth. Explicit ``GEMINI_AUTH_MODE`` remains the escape
+    hatch: ``api`` forces API mode and ``subscription``/``oauth`` forces
+    subscription mode regardless of available keys.
 
     ``cooldown_active`` is retained for call-site compatibility with the
-    earlier API-cooldown design but is now unused.
+    earlier API-cooldown design. When active, auto mode avoids API keys and
+    starts on subscription to preserve the sticky quota fallback behavior.
     """
-    _ = cooldown_active
     source = os.environ if env is None else env
     mode = _normalize_gemini_auth_mode(source.get("GEMINI_AUTH_MODE"))
-    # Honor explicit api opt-out for any caller who genuinely needs API mode
-    # (e.g., debugging a subscription-side bug). Everything else → subscription.
-    if mode == "api":
+    if mode in {"api", "subscription"}:
+        return mode
+    if cooldown_active:
+        return "subscription"
+    if source.get("GEMINI_API_KEY") or source.get("GOOGLE_API_KEY"):
         return "api"
     return "subscription"
+
+
+def _has_gemini_api_key(env: Mapping[str, str]) -> bool:
+    return bool(env.get("GEMINI_API_KEY") or env.get("GOOGLE_API_KEY"))
+
+
+def _prompt_arg_for_cli(prompt: str) -> tuple[str, Path | None]:
+    """Return the ``gemini -p`` argument and optional temp file path."""
+    if len(prompt) <= _INLINE_PROMPT_LIMIT_CHARS:
+        return prompt, None
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=_PROMPT_FILE_PREFIX,
+        suffix=".txt",
+        delete=False,
+    ) as handle:
+        handle.write(prompt)
+        path = Path(handle.name)
+    return f"@{path}", path
+
+
+def _cleanup_prompt_file(path: Path | None) -> None:
+    if path is None:
+        return
+    if not path.name.startswith(_PROMPT_FILE_PREFIX):
+        return
+    with contextlib.suppress(FileNotFoundError):
+        path.unlink()
 
 
 class GeminiAdapter:
@@ -136,6 +169,11 @@ class GeminiAdapter:
         currently a no-op: the ``gemini`` CLI does not expose a reasoning
         effort flag. When set we emit a debug log and proceed without
         modifying the command. Follow-up #1396.
+
+        Gemini CLI v0.40.1 treats stdin as REPL keystrokes in non-TTY
+        contexts, so prompts must be passed with ``-p``. Small prompts are
+        passed inline; prompts over 100K chars use the verified ``-p @PATH``
+        file-reference form, with runner cleanup after the subprocess exits.
         """
         if effort is not None:
             _logger.debug(
@@ -155,6 +193,7 @@ class GeminiAdapter:
         # Gemini CLI has no stricter-than-yolo bypass.
         if mode in ("workspace-write", "danger"):
             cmd.append("--approval-mode=yolo")
+            cmd.append("--skip-trust")
 
         # MCP tool restriction via tool_config.
         if tool_config:
@@ -183,11 +222,24 @@ class GeminiAdapter:
         env_unsets: tuple[str, ...] = ()
         if auth_mode == "subscription":
             env_unsets = GEMINI_AUTH_ENV_VARS
+        elif not _has_gemini_api_key(os.environ):
+            raise RuntimeError(
+                "GEMINI_AUTH_MODE=api selected but neither GEMINI_API_KEY nor "
+                "GOOGLE_API_KEY is set"
+            )
+
+        prompt_arg, prompt_file = _prompt_arg_for_cli(prompt)
+        cmd.extend(["-p", prompt_arg])
+        _logger.debug(
+            "gemini prompt length=%d passed via %s",
+            len(prompt),
+            "file-ref" if prompt_file is not None else "inline",
+        )
 
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
-            stdin_payload=prompt,
+            stdin_payload="",
             output_file=None,  # Gemini writes to stdout only.
             env_overrides={},
             env_unsets=env_unsets,
@@ -195,6 +247,15 @@ class GeminiAdapter:
             # see liveness_signal_paths() docstring — but we compute the
             # real paths lazily there because they depend on cwd.
         )
+
+    def cleanup_invocation(self, plan: InvocationPlan) -> None:
+        """Remove adapter-owned temporary prompt files after a run."""
+        for idx, value in enumerate(plan.cmd):
+            if value != "-p" or idx + 1 >= len(plan.cmd):
+                continue
+            prompt_arg = plan.cmd[idx + 1]
+            if prompt_arg.startswith("@"):
+                _cleanup_prompt_file(Path(prompt_arg[1:]))
 
     def parse_response(
         self,

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -465,7 +465,7 @@ def _execute_invocation_plan(
         try:
             proc = subprocess.Popen(
                 plan.cmd,
-                stdin=subprocess.PIPE if plan.stdin_payload else None,
+                stdin=subprocess.PIPE if plan.stdin_payload else subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -603,6 +603,11 @@ def _execute_invocation_plan(
             if should_delete:
                 with contextlib.suppress(OSError):
                     plan.output_file.unlink()
+
+        cleanup_invocation = getattr(adapter, "cleanup_invocation", None)
+        if cleanup_invocation is not None:
+            with contextlib.suppress(Exception):
+                cleanup_invocation(plan)
 
 
 def _invoke_gemini_with_fallback(

--- a/scripts/ai_llm/fallback.py
+++ b/scripts/ai_llm/fallback.py
@@ -1,8 +1,10 @@
 """Shared Gemini fallback ladder for direct CLI and runtime callers."""
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
+import tempfile
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
@@ -23,6 +25,8 @@ GEMINI_AUTH_ENV_VARS = (
     "GOOGLE_GENERATIVE_AI_API_KEY",
     "GOOGLE_APPLICATION_CREDENTIALS",
 )
+_INLINE_PROMPT_LIMIT_CHARS = 100_000
+_PROMPT_FILE_PREFIX = "learn-ukrainian-gemini-prompt-"
 #: Stderr/stdout markers that mean "this rung is not going to answer —
 #: advance to the next rung instead of retrying the same one 3x". Lowercase;
 #: matched via case-insensitive ``in`` on the haystack.
@@ -145,6 +149,10 @@ def build_gemini_ladder(
     return rungs
 
 
+def _has_gemini_api_key(env: Mapping[str, str]) -> bool:
+    return bool(env.get("GEMINI_API_KEY") or env.get("GOOGLE_API_KEY"))
+
+
 def resolve_allowed_auth_modes(
     env: Mapping[str, str] | None = None,
     *,
@@ -156,7 +164,8 @@ def resolve_allowed_auth_modes(
 
     1. ``GEMINI_AUTH_MODE=api``  — API rungs only
     2. ``GEMINI_AUTH_MODE=subscription`` / ``oauth``  — OAuth rungs only
-    3. ``GEMINI_AUTH_MODE=auto`` / unset  — cooldown-aware:
+    3. ``GEMINI_AUTH_MODE=auto`` / unset  — key/cooldown-aware:
+         - no API key ⇒ OAuth only
          - cooldown active ⇒ OAuth only (API key is near-budget, don't burn retries)
          - cooldown inactive ⇒ both modes (API first, OAuth as fallback)
 
@@ -174,6 +183,8 @@ def resolve_allowed_auth_modes(
     if cooldown_active is None:
         from ai_llm.cooldown import is_api_cooldown_active
         cooldown_active = is_api_cooldown_active()
+    if not _has_gemini_api_key(source):
+        return ("oauth",)
     if cooldown_active:
         return ("oauth",)
     return ("api", "oauth")
@@ -196,6 +207,30 @@ def build_gemini_subprocess_env(
         for key in GEMINI_AUTH_ENV_VARS:
             env.pop(key, None)
     return env
+
+
+def _gemini_prompt_arg(prompt: str) -> tuple[str, Path | None]:
+    if len(prompt) <= _INLINE_PROMPT_LIMIT_CHARS:
+        return prompt, None
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=_PROMPT_FILE_PREFIX,
+        suffix=".txt",
+        delete=False,
+    ) as handle:
+        handle.write(prompt)
+        path = Path(handle.name)
+    return f"@{path}", path
+
+
+def _cleanup_gemini_prompt_file(path: Path | None) -> None:
+    if path is None:
+        return
+    if not path.name.startswith(_PROMPT_FILE_PREFIX):
+        return
+    with contextlib.suppress(FileNotFoundError):
+        path.unlink()
 
 
 def visible_sleep(seconds: int, reason: str, *, logger: Callable[[str], None] | None = None) -> None:
@@ -430,11 +465,20 @@ def call_gemini_with_fallback(
         call_start_wall = time.time()
         call_start_mono = time.monotonic()
         env = build_gemini_subprocess_env(rung.auth_mode, base_env=base_env)
-        cmd = [gemini_cli, "-m", rung.model, "--approval-mode=yolo"]
+        prompt_arg, prompt_file = _gemini_prompt_arg(prompt)
+        cmd = [
+            gemini_cli,
+            "-m",
+            rung.model,
+            "--approval-mode=yolo",
+            "--skip-trust",
+            "-p",
+            prompt_arg,
+        ]
         try:
             proc = subprocess.Popen(
                 cmd,
-                stdin=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -442,7 +486,7 @@ def call_gemini_with_fallback(
                 env=env,
             )
             try:
-                stdout, stderr = proc.communicate(input=prompt, timeout=timeout_s or effective_timeout)
+                stdout, stderr = proc.communicate(timeout=timeout_s or effective_timeout)
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.communicate()
@@ -539,6 +583,8 @@ def call_gemini_with_fallback(
                 elapsed_s=time.monotonic() - call_start_mono,
                 stderr_excerpt=f"{type(exc).__name__}: {exc}",
             )
+        finally:
+            _cleanup_gemini_prompt_file(prompt_file)
 
     emit(f"  🤖 Gemini ladder call ({len(prompt):,} prompt chars)...")
     return run_gemini_fallback_ladder(
@@ -550,6 +596,7 @@ def call_gemini_with_fallback(
         attempt_runner=_attempt_runner,
         logger=emit,
         sleep_fn=sleep_fn,
+        allowed_auth_modes=resolve_allowed_auth_modes(base_env),
     )
 
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1932,7 +1932,9 @@ def test_gemini_adapter_read_only_no_yolo(tmp_path):
     )
     assert "--approval-mode=yolo" not in plan.cmd
     assert "-m" in plan.cmd
-    assert plan.stdin_payload == "hello"
+    assert "-p" in plan.cmd
+    assert plan.cmd[plan.cmd.index("-p") + 1] == "hello"
+    assert plan.stdin_payload == ""
     assert plan.output_file is None  # Gemini uses stdout, no -o file
     assert plan.liveness_paths == ()
 
@@ -1949,15 +1951,15 @@ def test_gemini_adapter_workspace_write_yolo(tmp_path):
         tool_config=None,
     )
     assert "--approval-mode=yolo" in plan.cmd
+    assert "--skip-trust" in plan.cmd
 
 
 @patch.dict("os.environ", {}, clear=True)
-def test_resolve_gemini_auth_mode_defaults_to_subscription_without_explicit_api_opt_in(
+def test_resolve_gemini_auth_mode_defaults_to_subscription_without_api_key(
     tmp_path, monkeypatch,
 ):
-    # Always-subscription policy (2026-04-23, post-#1416, commit 4f0fae3c0b):
-    # unset GEMINI_AUTH_MODE resolves to ``subscription``. The old
-    # ``default to api when no oauth creds`` conditional was deleted.
+    # API-first policy (2026-05-05, #1710): auto mode uses subscription only
+    # when no API key is available.
     monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
     assert resolve_gemini_auth_mode() == "subscription"
 
@@ -1982,7 +1984,7 @@ def test_gemini_adapter_subscription_mode_strips_api_key_env(tmp_path):
     )
 
 
-@patch.dict("os.environ", {"GEMINI_AUTH_MODE": "api"}, clear=True)
+@patch.dict("os.environ", {"GEMINI_AUTH_MODE": "api", "GEMINI_API_KEY": "secret"}, clear=True)
 def test_gemini_adapter_api_mode_preserves_api_key_env(tmp_path):
     adapter = GeminiAdapter()
     plan = adapter.build_invocation(
@@ -1998,10 +2000,13 @@ def test_gemini_adapter_api_mode_preserves_api_key_env(tmp_path):
 
 
 @patch.dict("os.environ", {"GEMINI_AUTH_MODE": "auto"}, clear=True)
-def test_gemini_adapter_auto_mode_prefers_subscription_when_oauth_creds_exist(tmp_path, monkeypatch):
+def test_gemini_adapter_auto_mode_prefers_api_when_api_key_exists(
+    tmp_path, monkeypatch,
+):
     (tmp_path / ".gemini").mkdir(parents=True)
     (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}", encoding="utf-8")
     monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
+    monkeypatch.setenv("GEMINI_API_KEY", "secret")
     adapter = GeminiAdapter()
     plan = adapter.build_invocation(
         prompt="hello",
@@ -2012,19 +2017,13 @@ def test_gemini_adapter_auto_mode_prefers_subscription_when_oauth_creds_exist(tm
         session_id=None,
         tool_config=None,
     )
-    assert plan.env_unsets == (
-        "GEMINI_API_KEY",
-        "GOOGLE_API_KEY",
-        "GOOGLE_GENERATIVE_AI_API_KEY",
-        "GOOGLE_APPLICATION_CREDENTIALS",
-    )
+    assert plan.env_unsets == ()
 
 
 @patch.dict("os.environ", {"GEMINI_AUTH_MODE": "bogus"}, clear=True)
 def test_resolve_gemini_auth_mode_invalid_value_uses_default_resolution(tmp_path, monkeypatch):
-    # Invalid GEMINI_AUTH_MODE normalizes to ``auto`` then falls through to
-    # the always-subscription default. Only an explicit ``api`` opt-out
-    # preserves the API-key path. See commit 4f0fae3c0b.
+    # Invalid GEMINI_AUTH_MODE normalizes to ``auto`` and follows API-first
+    # default resolution.
     monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
     assert resolve_gemini_auth_mode() == "subscription"
 

--- a/tests/test_agent_runtime_gemini_adapter.py
+++ b/tests/test_agent_runtime_gemini_adapter.py
@@ -1,0 +1,124 @@
+"""Focused Gemini adapter regression tests for prompt passing and auth."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.adapters.gemini import GeminiAdapter, resolve_gemini_auth_mode
+from ai_llm.fallback import GEMINI_AUTH_ENV_VARS
+
+
+def _build(prompt: str, tmp_path: Path, **kwargs):
+    return GeminiAdapter().build_invocation(
+        prompt=prompt,
+        mode=kwargs.pop("mode", "workspace-write"),
+        cwd=tmp_path,
+        model=kwargs.pop("model", "gemini-3.1-pro-preview"),
+        task_id=None,
+        session_id=None,
+        tool_config=kwargs.pop("tool_config", None),
+        effort=kwargs.pop("effort", None),
+    )
+
+
+def test_small_prompt_uses_inline_p_arg_and_no_stdin(tmp_path):
+    prompt = "x" * 200
+    plan = _build(prompt, tmp_path)
+
+    assert "-p" in plan.cmd
+    assert plan.cmd[plan.cmd.index("-p") + 1] == prompt
+    assert plan.stdin_payload == ""
+    assert "--approval-mode=yolo" in plan.cmd
+    assert "--skip-trust" in plan.cmd
+
+
+def test_large_prompt_uses_file_ref_and_cleanup(tmp_path):
+    prompt = "x" * 200_000
+    adapter = GeminiAdapter()
+    plan = adapter.build_invocation(
+        prompt=prompt,
+        mode="workspace-write",
+        cwd=tmp_path,
+        model="gemini-3.1-pro-preview",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    prompt_arg = plan.cmd[plan.cmd.index("-p") + 1]
+    assert prompt_arg.startswith("@")
+    prompt_path = Path(prompt_arg[1:])
+    assert prompt_path.read_text(encoding="utf-8") == prompt
+
+    adapter.cleanup_invocation(plan)
+    assert not prompt_path.exists()
+
+
+def test_large_prompt_api_fail_fast_does_not_create_temp_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GEMINI_AUTH_MODE", "api")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    temp_dir = Path(tempfile.gettempdir())
+    before = set(temp_dir.glob("learn-ukrainian-gemini-prompt-*"))
+
+    with pytest.raises(RuntimeError, match="GEMINI_AUTH_MODE=api"):
+        GeminiAdapter().build_invocation(
+            prompt="x" * 200_000,
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="gemini-3.1-pro-preview",
+            task_id=None,
+            session_id=None,
+            tool_config=None,
+        )
+
+    after = set(temp_dir.glob("learn-ukrainian-gemini-prompt-*"))
+    assert after == before
+
+
+def test_mcp_server_names_survive_prompt_flag_change(tmp_path):
+    plan = _build("hello", tmp_path, tool_config={"mcp_server_names": ["sources"]})
+
+    assert "--allowed-mcp-server-names" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--allowed-mcp-server-names") + 1] == "sources"
+    assert plan.cmd[plan.cmd.index("-p") + 1] == "hello"
+
+
+def test_subscription_auth_strips_gemini_api_env_vars(tmp_path, monkeypatch):
+    monkeypatch.setenv("GEMINI_AUTH_MODE", "subscription")
+    monkeypatch.setenv("GEMINI_API_KEY", "secret")
+
+    plan = _build("hello", tmp_path)
+
+    assert plan.env_unsets == GEMINI_AUTH_ENV_VARS
+
+
+def test_effort_logs_debug_but_leaves_command_semantics_unchanged(tmp_path, caplog):
+    caplog.set_level(logging.DEBUG, logger="agent_runtime.adapters.gemini")
+
+    without_effort = _build("hello", tmp_path)
+    with_effort = _build("hello", tmp_path, effort="high")
+
+    assert with_effort.cmd == without_effort.cmd
+    assert "gemini effort" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({}, "subscription"),
+        ({"GEMINI_API_KEY": "secret"}, "api"),
+        ({"GOOGLE_API_KEY": "secret"}, "api"),
+        ({"GEMINI_AUTH_MODE": "subscription", "GEMINI_API_KEY": "secret"}, "subscription"),
+        ({"GEMINI_AUTH_MODE": "api"}, "api"),
+    ],
+)
+def test_resolve_gemini_auth_mode_api_first_matrix(env, expected):
+    assert resolve_gemini_auth_mode(env, cooldown_active=False) == expected

--- a/tests/test_ai_llm_fallback.py
+++ b/tests/test_ai_llm_fallback.py
@@ -89,6 +89,8 @@ def test_call_gemini_with_fallback_rung1_success(tmp_path):
     assert result.auth_mode_used == "api"
     assert len(factory.calls) == 1
     assert factory.calls[0]["cmd"][2] == PRIMARY_GEMINI_MODEL
+    assert factory.calls[0]["cmd"][-2:] == ["-p", "prompt"]
+    assert factory.calls[0]["stdin"] == subprocess.DEVNULL
     assert factory.calls[0]["env"]["GEMINI_API_KEY"] == "secret"
 
 

--- a/tests/test_batch_gemini_runner_env.py
+++ b/tests/test_batch_gemini_runner_env.py
@@ -116,30 +116,23 @@ def _invoke_with_captured_env(
     return result, popen_capture
 
 
-def test_env_stripped_when_oauth_present(tmp_path, monkeypatch):
+def test_auto_mode_keeps_api_key_even_when_oauth_present(tmp_path, monkeypatch):
     _result, popen_capture = _invoke_with_captured_env(
         tmp_path, monkeypatch, oauth_creds=True,
     )
 
     env = popen_capture.calls[0]["kwargs"]["env"]
-    assert "GEMINI_API_KEY" not in env
-    assert "GOOGLE_API_KEY" not in env
-    assert "GOOGLE_GENERATIVE_AI_API_KEY" not in env
-    assert "GOOGLE_APPLICATION_CREDENTIALS" not in env
+    assert env["GEMINI_API_KEY"] == "test-api-key"
 
 
-def test_env_stripped_when_oauth_absent_under_always_subscription(tmp_path, monkeypatch):
-    """Always-subscription policy (2026-04-23, post-#1416): API-key envs are
-    stripped unconditionally unless the caller explicitly requests
-    ``GEMINI_AUTH_MODE=api``. Whether oauth creds are on disk is irrelevant —
-    the Ultra subscription is the canonical path. See commit 4f0fae3c0b.
-    """
+def test_auto_mode_keeps_api_key_when_oauth_absent(tmp_path, monkeypatch):
+    """API-first policy (#1710): API-key envs are preserved in auto mode."""
     _result, popen_capture = _invoke_with_captured_env(
         tmp_path, monkeypatch, oauth_creds=False,
     )
 
     env = popen_capture.calls[0]["kwargs"]["env"]
-    assert "GEMINI_API_KEY" not in env
+    assert env["GEMINI_API_KEY"] == "test-api-key"
 
 
 def test_explicit_subscription_mode_strips(tmp_path, monkeypatch):
@@ -152,9 +145,7 @@ def test_explicit_subscription_mode_strips(tmp_path, monkeypatch):
 
 
 def test_explicit_api_mode_keeps_env_key(tmp_path, monkeypatch):
-    """Escape hatch: ``GEMINI_AUTH_MODE=api`` is the only way to preserve the
-    API-key env under always-subscription policy. Ensures the opt-out actually
-    works for one-off debug runs."""
+    """Escape hatch: ``GEMINI_AUTH_MODE=api`` forces API mode."""
     _result, popen_capture = _invoke_with_captured_env(
         tmp_path, monkeypatch, oauth_creds=False, auth_mode="api",
     )

--- a/tests/test_gemini_adapter_auth.py
+++ b/tests/test_gemini_adapter_auth.py
@@ -6,6 +6,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 # Repo-root shim (same pattern as other tests in this directory).
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
@@ -59,28 +61,34 @@ class TestNormalizeAuthMode:
         assert _normalize_gemini_auth_mode("🐙") == "auto"
 
 
-# ── resolve_gemini_auth_mode — always-subscription policy (#1416) ─────
+# ── resolve_gemini_auth_mode — API-first policy (#1710) ───────────────
 
 
 class TestResolveAuthMode:
-    """Project policy 2026-04-23 (post-#1416): always subscription unless
-    the user explicitly sets ``GEMINI_AUTH_MODE=api`` for a one-off
-    debugging or fallback run.
-
-    Why: project is permanently non-commercial, user has Ultra OAuth, and
-    conditional resolution caused a macOS Keychain popup loop on every
-    gemini-cli spawn under env-strip. Forcing subscription is the blunt
-    fix the user asked for. One-time Keychain "Always Allow" click,
-    then zero env complexity afterward.
-    """
+    """Project policy 2026-05-05 (#1710): API keys win in auto mode, with
+    subscription/OAuth as fallback. Explicit GEMINI_AUTH_MODE still wins."""
 
     def test_auto_unset_resolves_to_subscription(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """No env, no OAuth file on disk — STILL subscription (was: api)."""
+        """No env and no API key still preserves subscription/OAuth behavior."""
         env: dict[str, str] = {}
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
         assert resolve_gemini_auth_mode(env, cooldown_active=False) == "subscription"
+
+    def test_auto_with_api_key_resolves_to_api(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        env = {"GEMINI_API_KEY": "secret"}
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
+        assert resolve_gemini_auth_mode(env, cooldown_active=False) == "api"
+
+    def test_auto_with_google_api_key_resolves_to_api(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        env = {"GOOGLE_API_KEY": "secret"}
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
+        assert resolve_gemini_auth_mode(env, cooldown_active=False) == "api"
 
     def test_auto_unset_with_oauth_creds_resolves_to_subscription(
         self, tmp_path: Path, monkeypatch
@@ -95,7 +103,7 @@ class TestResolveAuthMode:
     def test_explicit_auto_resolves_to_subscription(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """``auto`` no longer probes disk — always subscription."""
+        """``auto`` without an API key resolves to subscription."""
         env = {"GEMINI_AUTH_MODE": "auto"}
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
         assert resolve_gemini_auth_mode(env, cooldown_active=False) == "subscription"
@@ -111,7 +119,7 @@ class TestResolveAuthMode:
     def test_explicit_api_is_the_only_escape_hatch(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Only explicit GEMINI_AUTH_MODE=api still produces api mode."""
+        """Explicit GEMINI_AUTH_MODE=api forces api mode."""
         env = {"GEMINI_AUTH_MODE": "api"}
         (tmp_path / ".gemini").mkdir(parents=True)
         (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}", encoding="utf-8")
@@ -122,7 +130,7 @@ class TestResolveAuthMode:
     def test_invalid_value_degrades_to_subscription(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Garbage env → safe default = subscription, not api."""
+        """Garbage env follows auto mode; without API keys, subscription."""
         env = {"GEMINI_AUTH_MODE": "garbage"}
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
         assert resolve_gemini_auth_mode(env, cooldown_active=False) == "subscription"
@@ -134,16 +142,17 @@ class TestResolveAuthMode:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
         assert resolve_gemini_auth_mode(env, cooldown_active=False) == "subscription"
 
-    def test_disk_state_no_longer_consulted(
+    def test_disk_state_does_not_override_api_first_policy(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Disk OAuth state is no longer probed — policy is unconditional."""
+        """Disk OAuth state alone does not choose API; API env keys do."""
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
         env: dict[str, str] = {}
         assert resolve_gemini_auth_mode(env) == "subscription"
         (tmp_path / ".gemini").mkdir(parents=True)
         (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}", encoding="utf-8")
         assert resolve_gemini_auth_mode(env) == "subscription"
+        assert resolve_gemini_auth_mode({"GEMINI_API_KEY": "secret"}) == "api"
 
 
 # ── cooldown module ───────────────────────────────────────────────────
@@ -249,7 +258,7 @@ class TestEnvStripWiring:
     disconnect the two.
     """
 
-    def test_adapter_strips_api_keys_when_oauth_creds_present(
+    def test_adapter_preserves_api_keys_when_auto_mode_has_api_key(
         self, tmp_path: Path, monkeypatch
     ) -> None:
         from agent_runtime.adapters.gemini import GeminiAdapter
@@ -257,27 +266,24 @@ class TestEnvStripWiring:
         (tmp_path / ".gemini").mkdir(parents=True)
         (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
-        monkeypatch.setenv("GEMINI_API_KEY", "should-be-stripped")
+        monkeypatch.setenv("GEMINI_API_KEY", "should-be-preserved")
         monkeypatch.delenv("GEMINI_AUTH_MODE", raising=False)
 
         plan = GeminiAdapter().build_invocation(
             prompt="test", mode="read-only", cwd=tmp_path,
             model=None, task_id=None, session_id=None, tool_config=None,
         )
-        assert "GEMINI_API_KEY" in plan.env_unsets, (
-            "Auto mode with OAuth creds present must strip GEMINI_API_KEY — "
-            "otherwise the CLI keeps billing API instead of subscription."
-        )
+        assert plan.env_unsets == ()
 
-    def test_adapter_strips_api_keys_unconditionally_in_auto_mode(
+    def test_adapter_strips_api_keys_when_no_api_key_default_subscription(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Post-#1416 always-subscription policy: env keys stripped even
-        without OAuth creds on disk. Disk state no longer probed."""
+        """Auto mode still falls back to subscription when no API key exists."""
         from agent_runtime.adapters.gemini import GeminiAdapter
 
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
-        monkeypatch.setenv("GEMINI_API_KEY", "stripped-by-policy")
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.delenv("GEMINI_AUTH_MODE", raising=False)
 
         plan = GeminiAdapter().build_invocation(
@@ -285,8 +291,8 @@ class TestEnvStripWiring:
             model=None, task_id=None, session_id=None, tool_config=None,
         )
         assert "GEMINI_API_KEY" in plan.env_unsets, (
-            "Always-subscription policy means env keys are stripped "
-            "unconditionally in auto/subscription mode (#1416)."
+            "Subscription fallback must strip API env vars when API mode is "
+            "not selected."
         )
 
     def test_adapter_preserves_api_keys_when_explicit_api(
@@ -298,6 +304,7 @@ class TestEnvStripWiring:
         (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}", encoding="utf-8")
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: tmp_path))
         monkeypatch.setenv("GEMINI_AUTH_MODE", "api")  # explicit wins
+        monkeypatch.setenv("GEMINI_API_KEY", "secret")
 
         plan = GeminiAdapter().build_invocation(
             prompt="test", mode="read-only", cwd=tmp_path,
@@ -307,6 +314,21 @@ class TestEnvStripWiring:
             "Explicit GEMINI_AUTH_MODE=api must not strip keys even "
             "when OAuth creds are present."
         )
+
+    def test_explicit_api_without_api_key_fails_fast(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from agent_runtime.adapters.gemini import GeminiAdapter
+
+        monkeypatch.setenv("GEMINI_AUTH_MODE", "api")
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="GEMINI_AUTH_MODE=api"):
+            GeminiAdapter().build_invocation(
+                prompt="test", mode="read-only", cwd=tmp_path,
+                model=None, task_id=None, session_id=None, tool_config=None,
+            )
 
 
 # ── Parse-response trips cooldown on real 429 only ────────────────────
@@ -415,8 +437,12 @@ class TestLadderAuthModeFiltering:
     the ~15-min silent hang the user hit at 14:00.
     """
 
-    def test_auto_no_cooldown_includes_both(self) -> None:
-        assert resolve_allowed_auth_modes({}, cooldown_active=False) == ("api", "oauth")
+    def test_auto_no_api_key_uses_oauth_only(self) -> None:
+        assert resolve_allowed_auth_modes({}, cooldown_active=False) == ("oauth",)
+
+    def test_auto_with_api_key_no_cooldown_includes_both(self) -> None:
+        env = {"GEMINI_API_KEY": "secret"}
+        assert resolve_allowed_auth_modes(env, cooldown_active=False) == ("api", "oauth")
 
     def test_auto_with_cooldown_skips_api(self) -> None:
         assert resolve_allowed_auth_modes({}, cooldown_active=True) == ("oauth",)


### PR DESCRIPTION
## Summary

Fixes #1709 and #1710.

- Switches Gemini runtime invocation from stdin piping to `gemini -p`.
- Uses inline `-p PROMPT` for prompts up to 100K chars and verified `-p @PATH` temp-file references for larger prompts.
- Adds temp prompt cleanup through the runner and the direct `ai_llm.fallback` Gemini path.
- Flips Gemini auth precedence to API-first when `GEMINI_API_KEY` or `GOOGLE_API_KEY` is present, with subscription/OAuth fallback when no key is present.
- Preserves explicit `GEMINI_AUTH_MODE=api` / `subscription` overrides; explicit API without an API key now fails fast.
- Keeps `--approval-mode=yolo`, MCP server restrictions, and subscription-mode API env stripping.
- Adds `--skip-trust` for Gemini write-mode calls because CLI v0.40.1 downgrades approval mode in untrusted output dirs such as `/tmp` and exits before writing.

## Reproduction / CLI behavior

Broken current behavior: piping prompt text into Gemini CLI stdin can be ignored or treated as REPL input in non-TTY invocations.

Verified locally on 2026-05-05:

```bash
echo "test prompt" > /tmp/gemini-test.txt
timeout 30 gemini -y -m gemini-3.1-pro-preview -p @/tmp/gemini-test.txt
```

Result: exit 0; Gemini read `/tmp/gemini-test.txt` and responded with the file content. The adapter therefore uses `-p @PATH` for large prompts.

## Tests

- `../../../../.venv/bin/python -m pytest tests/test_agent_runtime_gemini_adapter.py tests/test_gemini_adapter_auth.py tests/test_ai_llm_fallback.py tests/test_batch_gemini_runner_env.py tests/test_agent_runtime.py -q` — 195 passed.
- `../../../../.venv/bin/ruff check scripts/agent_runtime/ tests/` — passed.
- `../../../../.venv/bin/ruff check scripts/ai_llm/fallback.py` — passed.
- Commit hook reran affected-file ruff + pytest — 195 passed.

## Smoke

Dry run:

```bash
../../../../.venv/bin/python scripts/build/v7_build.py a1 my-morning --writer gemini-tools --dry-run
```

Result: exit 0.

Real smoke:

```bash
rm -rf /tmp/v7-gemini-smoke /tmp/v7-gemini-smoke.jsonl
timeout 900 ../../../../.venv/bin/python -u scripts/build/v7_build.py a1 my-morning --writer gemini-tools --out /tmp/v7-gemini-smoke --telemetry-out /tmp/v7-gemini-smoke.jsonl
```

Result: Gemini writer completed successfully in 144.077s and emitted `phase_writer_summary`. The full command later failed in the out-of-scope `python_qg` phase because `codex-tools` is not registered in this worktree (`Available: ['claude', 'codex', 'gemini', 'gemma-local', 'grok']`).

Relevant telemetry:

- `phase_writer_summary` at `2026-05-05T18:31:05Z`
- writer `phase_done`, duration `144.077s`
- Gemini runtime usage: returncode 0, outcome `ok`, output chars 20,497

## Review

Claude adversarial review completed via bridge task `issue-1709-review`. Feedback found a large-prompt temp-file leak on explicit API missing-key fail-fast; fixed before commit and covered by regression test.

Reviewed-By: claude-opus-4-7 (issue-1709-review)
