### PR TITLE
Fix python_qg Codex runtime registry name

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -75,6 +75,18 @@ _SHIMS_DIR = Path(__file__).resolve().parent / "shims"
 _ADAPTER_CACHE: dict[str, AgentAdapter] = {}
 
 
+def _validate_agent_name(agent_name: str) -> None:
+    """Reject legacy public labels before registry lookup."""
+    if agent_name.endswith("-tools") and agent_name not in AGENTS:
+        bare_name = agent_name.removesuffix("-tools")
+        if bare_name in AGENTS:
+            raise ValueError(
+                "agent_runtime registry uses bare names — pass "
+                f"{bare_name!r} not {agent_name!r}; use tool_config to "
+                "indicate tools-enabled"
+            )
+
+
 def _is_agent_runtime_shim(path: str | None) -> bool:
     if not path:
         return False
@@ -932,6 +944,7 @@ def invoke(
         AgentTimeoutError: Wall-clock runtime exceeded hard_timeout.
     """
     # ---------- 1. Resolve adapter ----------
+    _validate_agent_name(agent_name)
     adapter = _load_adapter(agent_name)
 
     # ---------- 2. Validate mode ----------

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -2364,13 +2364,15 @@ def _apply_reviewer_correction(
             runtime_invoke = invoker
 
         result = runtime_invoke(
-            "codex-tools",
+            "codex",
             prompt,
             mode="read-only",
             cwd=module_dir,
+            model=REVIEWER_DEFAULTS["codex-tools"]["model"],
             task_id=f"linear-python-qg-{gate}-fix",
             entrypoint="runtime",
-            tool_config={"output_format": "text"},
+            effort=REVIEWER_DEFAULTS["codex-tools"]["effort"],
+            tool_config=_runtime_tool_config("codex-tools"),
         )
         response = str(getattr(result, "response", "") or "")
     else:

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -112,6 +112,7 @@ from agent_runtime.runner import (
     _is_temp_file,
     _kill_process_tree,
     _load_adapter,
+    _validate_agent_name,
     invoke,
 )
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
@@ -184,6 +185,33 @@ def test_load_adapter_codex():
 def test_load_adapter_unknown_raises():
     with pytest.raises(AgentUnavailableError, match="not in the registry"):
         _load_adapter("nonexistent")
+
+
+@pytest.mark.parametrize(
+    "agent_name,bare_name",
+    [
+        ("codex-tools", "codex"),
+        ("claude-tools", "claude"),
+        ("gemini-tools", "gemini"),
+    ],
+)
+def test_validate_agent_name_rejects_tools_suffix(agent_name, bare_name):
+    with pytest.raises(ValueError) as excinfo:
+        _validate_agent_name(agent_name)
+
+    message = str(excinfo.value)
+    assert "agent_runtime registry uses bare names" in message
+    assert f"pass {bare_name!r} not {agent_name!r}" in message
+    assert "use tool_config to indicate tools-enabled" in message
+
+
+def test_validate_agent_name_allows_bare_registry_name():
+    _validate_agent_name("codex")
+
+
+def test_invoke_rejects_tools_suffix_before_adapter_load():
+    with pytest.raises(ValueError, match="pass 'codex' not 'codex-tools'"):
+        invoke("codex-tools", "hello", mode="read-only")
 
 
 def test_load_adapter_grok_stub_unavailable():


### PR DESCRIPTION
## Summary
- Change the python_qg ADR-008 correction call from `codex-tools` to bare `codex`.
- Preserve tools-enabled semantics through `_runtime_tool_config("codex-tools")`, including the Codex `sources` MCP config, plus explicit `gpt-5.5` / `high` parity with reviewer defaults.
- Add a runner boundary check that rejects accidental `*-tools` runtime agent names with a clear bare-name/tool_config error.
- Add regression tests for the `*-tools` rejection path and bare-name allow path.

## Audited runtime call sites
- `scripts/build/linear_pipeline.py:1472`, `:1843`: public `*-tools` writer/reviewer choices are normalized with `split("-", 1)[0]`; OK.
- `scripts/build/linear_pipeline.py:2366`: was literal `codex-tools`; fixed to `codex` plus `tool_config`.
- `scripts/build/v7_build.py:124`: reviewer smoke call derives `agent_name = reviewer.split("-", 1)[0]`; OK.
- `scripts/build/dispatch.py:475`: literal `claude`; OK.
- `scripts/build/dispatch.py:594`, `:702`: `runtime_agent_name` is assigned only `codex`, `gemini`, or `gemma-local`; OK.
- `scripts/ai_agent_bridge/_claude.py:135`: literal `claude`; OK.
- `scripts/ai_agent_bridge/_gemini.py:354`: literal `gemini`; OK.
- `scripts/ai_agent_bridge/_inbox.py:750`, `:790`: bridge agent names are bare names / literal `gemini`; OK.
- `scripts/ai_agent_bridge/_channels_cli.py:1102`: channel agents use bare bridge agent names; OK.
- `scripts/batch_gemini_runner/execution.py:199`, `:531`: literal `gemini`; OK.
- `scripts/delegate.py:628`: delegate agent argument is expected to be a registered runtime agent name; OK.
- `scripts/wiki/review.py`: agent argument path uses runtime registry names; OK.

## Smoke
Command:
```bash
../../../../.venv/bin/python scripts/build/v7_build.py a1 my-morning --writer gemini-tools --out /tmp/v7-smoke-1712 --telemetry-out /tmp/v7-smoke-1712.jsonl
```

Result: reached and completed `python_qg` without the previous `Available: [...]` registry error, then failed the content gate after ADR-008 correction because the Gemini writer output was too short.

- Wall time: 390s
- python_qg duration: 94.73s
- QG failure: `word_count` failed after correction; `python_qg.json` reported 592 words vs target 1200.
- Last event emitted:
```json
{"event": "module_failed", "ts": "2026-05-05T18:57:48.803273+00:00", "level": "a1", "slug": "my-morning", "phase": "python_qg", "reason": "Python QG failed after ADR-008 correction paths"}
```

## Tests
- `../../../../.venv/bin/ruff check scripts/build/ scripts/agent_runtime/ tests/`
- `../../../../.venv/bin/pytest tests/test_agent_runtime.py tests/test_linear_pipeline_telemetry.py -v` - 125 passed
- Commit hook also ran affected pytest: 121 passed

## Cross-family review
Claude reviewed the staged diff under `issue-1712-review`; feedback was applied. Commit includes:
`Reviewed-By: claude-opus-4-7 (issue-1712-review)`
