### PR TITLE
fix(bakeoff): silent no-op diagnostics + citation whitespace + Codex fence prompt

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -189,6 +189,7 @@ TELEMETRY_MAX_QUOTES = 5
 TELEMETRY_MAX_QUOTE_CHARS = 240
 TELEMETRY_MAX_MAPPING_CHARS = 500
 TELEMETRY_MAX_FAILED_WORDS = 5
+CORRECTION_PREVIEW_CHARS = 200
 _TELEMETRY_EVENT_SINK: Callable[..., None] | None = None
 
 
@@ -953,6 +954,34 @@ def telemetry_event_sink(path: Path | None):
 def _emit(event_sink: Callable[..., None] | None, event: str, **fields: Any) -> None:
     sink = event_sink or emit_event
     sink(event, **fields)
+
+
+def _correction_preview(text: Any, limit: int = CORRECTION_PREVIEW_CHARS) -> str:
+    return str(text or "")[:limit]
+
+
+def _module_ref_from_module_dir(module_dir: Path) -> str | None:
+    match = re.match(r"^(?P<sequence>\d+)-", module_dir.name)
+    if not match:
+        return None
+    return _module_ref(module_dir.parent.name, match.group("sequence"))
+
+
+def _correction_event_fields(
+    *,
+    gate: str,
+    module_dir: Path,
+    plan_path: Path,
+) -> dict[str, str]:
+    fields = {
+        "gate": gate,
+        "module_dir": str(module_dir),
+        "plan_path": str(plan_path),
+    }
+    module = _module_ref_from_module_dir(module_dir)
+    if module is not None:
+        fields["module"] = module
+    return fields
 
 
 def _module_ref(level: str | None, module_num: str | int | None) -> str | None:
@@ -2327,6 +2356,16 @@ def _apply_writer_correction(
         write_writer_artifacts(module_dir, response)
     elif isinstance(response, str) and all(name in response for name in WRITER_ARTIFACTS):
         write_writer_artifacts(module_dir, parse_writer_output_strict_json(response))
+    else:
+        emit_event(
+            "writer_correction_unparseable",
+            **_correction_event_fields(
+                gate=gate,
+                module_dir=module_dir,
+                plan_path=plan_path,
+            ),
+            response_preview=_correction_preview(response),
+        )
 
 
 def _apply_reviewer_correction(
@@ -2378,8 +2417,26 @@ def _apply_reviewer_correction(
     else:
         response = reviewer_corrector(context) or ""
     fixes = _parse_reviewer_fixes(response)
+    if not fixes:
+        emit_event(
+            "reviewer_fixes_unparseable",
+            **_correction_event_fields(
+                gate=gate,
+                module_dir=module_dir,
+                plan_path=plan_path,
+            ),
+            response_preview=_correction_preview(response),
+        )
+        return
+    updated = _apply_reviewer_fixes(
+        module_text,
+        fixes,
+        gate=gate,
+        module_dir=module_dir,
+        plan_path=plan_path,
+    )
     if fixes:
-        module_path.write_text(_apply_reviewer_fixes(module_text, fixes), encoding="utf-8")
+        module_path.write_text(updated, encoding="utf-8")
 
 
 def _apply_activity_id_inserts(module_path: Path, gate_report: Mapping[str, Any]) -> None:
@@ -2419,18 +2476,51 @@ def _parse_reviewer_fixes(review_text: str) -> list[dict[str, str]]:
     return fixes
 
 
-def _apply_reviewer_fixes(text: str, fixes: list[dict[str, str]]) -> str:
+def _apply_reviewer_fixes(
+    text: str,
+    fixes: list[dict[str, str]],
+    *,
+    gate: str | None = None,
+    module_dir: Path | None = None,
+    plan_path: Path | None = None,
+) -> str:
     updated = text
     for fix in fixes:
         if "insert_after" in fix and "text" in fix:
             anchor = fix["insert_after"]
             if anchor in updated:
                 updated = updated.replace(anchor, anchor + fix["text"], 1)
+            else:
+                emit_event(
+                    "reviewer_fixes_anchor_unmatched",
+                    **_correction_event_fields(
+                        gate=gate or "",
+                        module_dir=module_dir,
+                        plan_path=plan_path,
+                    )
+                    if module_dir is not None and plan_path is not None
+                    else {"gate": gate},
+                    anchor_preview=_correction_preview(anchor),
+                    text_preview=_correction_preview(fix["text"]),
+                )
             continue
         find = fix.get("find")
         replace = fix.get("replace")
         if find and replace is not None and find in updated:
             updated = updated.replace(find, replace, 1)
+        elif find:
+            emit_event(
+                "reviewer_fixes_anchor_unmatched",
+                **_correction_event_fields(
+                    gate=gate or "",
+                    module_dir=module_dir,
+                    plan_path=plan_path,
+                )
+                if module_dir is not None and plan_path is not None
+                else {"gate": gate},
+                anchor_preview=_correction_preview(find),
+                text_preview=_correction_preview(replace),
+            )
     return updated
 
 
@@ -3347,12 +3437,20 @@ def _formatting_standards_gate(text: str) -> dict[str, Any]:
     }
 
 
+def _normalize_citation_ref(value: Any) -> str:
+    normalized = re.sub(r"\s+", " ", str(value or "")).strip()
+    return re.sub(r"\bp\.\s+(\d+)\b", r"p.\1", normalized)
+
+
 def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> dict[str, Any]:
-    plan_titles = {str(ref["title"]) for ref in plan.get("references", [])}
+    plan_titles = {
+        _normalize_citation_ref(ref["title"]) for ref in plan.get("references", [])
+    }
     unknown = []
     for resource in resources:
         source_ref = str(resource.get("source_ref") or resource.get("title") or "")
-        if source_ref not in plan_titles and resource.get("packet_chunk_id") is None:
+        normalized_ref = _normalize_citation_ref(source_ref)
+        if normalized_ref not in plan_titles and resource.get("packet_chunk_id") is None:
             unknown.append(source_ref)
     return {"passed": not unknown, "unknown": unknown}
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -102,10 +102,11 @@ block per structured artifact. Do not include trailing commas. Do not include
 comments. Do not mix YAML or prose into JSON blocks. The pipeline uses
 `json.loads` and fails the build on any parse error.
 
-`module.md` itself stays Markdown. Only the three structured-data blocks move
-to JSON. The pipeline serializes those parsed JSON values to YAML for storage.
-Use `json` fences only for these three structured artifacts; do not fence prose
-inside `module.md`.
+Inside the `module.md` artifact, do NOT use triple backticks (```) for ANY
+purpose — no fenced code, no fenced quote, no fenced text. Use plain paragraphs,
+lists, or tables instead. Triple backticks inside the artifact will be parsed as
+a closing fence and break the artifact boundary. Single backticks for inline code
+spans (e.g., `verify_words`) are fine — only triple backticks are forbidden.
 
 ## Module Context
 

--- a/tests/test_citation_whitespace.py
+++ b/tests/test_citation_whitespace.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+
+def _result(source_ref: str, title: str = "Караман Grade 10, p.176") -> dict[str, Any]:
+    return linear_pipeline._citation_gate(
+        [{"source_ref": source_ref}],
+        {"references": [{"title": title}]},
+    )
+
+
+def test_citation_gate_normalizes_page_reference_whitespace() -> None:
+    assert _result("Караман Grade 10, p. 176")["passed"] is True
+    assert _result("Караман Grade 10, p.176")["passed"] is True
+    assert _result("Караман Grade 10, p.  176")["passed"] is True
+
+
+def test_citation_gate_normalizes_plan_page_reference_whitespace() -> None:
+    assert _result("Караман Grade 10, p.176", "Караман Grade 10, p. 176")[
+        "passed"
+    ] is True

--- a/tests/test_reviewer_correction_diagnostics.py
+++ b/tests/test_reviewer_correction_diagnostics.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.build import linear_pipeline
+
+
+def _events(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text("utf-8").splitlines()]
+
+
+def _module_dir(tmp_path: Path) -> Path:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(
+        "## Morning\n\nAnchor sentence.\n",
+        encoding="utf-8",
+    )
+    return module_dir
+
+
+def test_reviewer_correction_without_fixes_block_emits_diagnostic(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline._apply_reviewer_correction(
+            "russianisms_clean",
+            {"passed": False, "hits": ["bad form"]},
+            qg_report={"gates": {}},
+            module_dir=_module_dir(tmp_path),
+            plan_path=tmp_path / "plan.yaml",
+            candidates=(),
+            reviewer_corrector=lambda _context: "REVISE: please fix the issue.",
+            invoker=None,
+        )
+
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == ["reviewer_fixes_unparseable"]
+    assert events[0]["gate"] == "russianisms_clean"
+    assert events[0]["response_preview"] == "REVISE: please fix the issue."
+
+
+def test_reviewer_correction_unmatched_anchor_emits_diagnostic(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline._apply_reviewer_correction(
+            "russianisms_clean",
+            {"passed": False, "hits": ["bad form"]},
+            qg_report={"gates": {}},
+            module_dir=_module_dir(tmp_path),
+            plan_path=tmp_path / "plan.yaml",
+            candidates=(),
+            reviewer_corrector=lambda _context: (
+                "<fixes>\n"
+                "- find: Missing anchor\n"
+                "  replace: Replacement text\n"
+                "</fixes>"
+            ),
+            invoker=None,
+        )
+
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == [
+        "reviewer_fixes_anchor_unmatched"
+    ]
+    assert events[0]["gate"] == "russianisms_clean"
+    assert events[0]["anchor_preview"] == "Missing anchor"

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.build import linear_pipeline
+
+
+def _events(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text("utf-8").splitlines()]
+
+
+def test_writer_correction_unparseable_response_emits_diagnostic(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("## Morning\n\nTest module.\n", encoding="utf-8")
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline._apply_writer_correction(
+            "word_count",
+            {"passed": False, "minimum": 100, "actual": 20},
+            qg_report={"gates": {}},
+            module_dir=module_dir,
+            plan_path=tmp_path / "plan.yaml",
+            writer_corrector=lambda _context: "I fixed the prose but emitted no artifacts.",
+            writer="codex-tools",
+            invoker=None,
+        )
+
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == ["writer_correction_unparseable"]
+    assert events[0]["gate"] == "word_count"
+    assert events[0]["response_preview"] == "I fixed the prose but emitted no artifacts."


### PR DESCRIPTION
## Summary

Fixes five pipeline bugs surfaced by tonight's A1/20 bakeoff (`bakeoff-execute-danger`) per Codex msg 525 diagnosis.

- `writer_correction_unparseable` telemetry for writer-correction no-ops (`linear_pipeline.py:2326` area)
- `reviewer_fixes_unparseable` + `reviewer_fixes_anchor_unmatched` telemetry (`linear_pipeline.py:2394`, `:2422`)
- Citation whitespace normalization — `p. 176`/`p.176`/`p.  176` all match (`linear_pipeline.py:3350`)
- `linear-write.md:105` strengthened: no triple backticks anywhere inside `module.md`
- 3 new test files: `test_writer_correction_no_op_diagnostic.py`, `test_reviewer_correction_diagnostics.py`, `test_citation_whitespace.py`

## Validation

- ruff: pass
- focused pytest: 33 passed
- pre-commit: ruff + affected tests, 5 passed
- Claude adversarial review under `bakeoff-gate-fixes-review` — feedback applied

## Test plan

- [ ] CI green on this branch
- [ ] After merge, re-run A1/20 bakeoff (separately) — silent no-ops should now emit visible JSONL events for diagnosis

🤖 Generated by Codex dispatch under brief `docs/dispatch-briefs/2026-05-05-bakeoff-gate-fixes.md`