### PR TITLE
feat(mcp): slovnyk.me ingester + search_slovnyk_me + search_heritage tools (#1715)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -18,6 +18,7 @@ Tools:
     - verify_word, verify_words, verify_lemma (VESUM)
     - query_wikipedia, query_pravopys, query_e2u, query_r2u, query_ulif
     - search_definitions, search_grinchenko_1907, search_esum, search_idioms, search_synonyms
+    - search_slovnyk_me, search_heritage
     - search_style_guide (Антоненко-Давидович)
     - translate_en_uk (Балла)
 """
@@ -707,8 +708,9 @@ async def list_tools() -> list[Tool]:
                 "`search_definitions` returns `sovietization_risk > 0`, fall "
                 "back to `query_sum20`. Backed by slovnyk.me's clean per-word "
                 "URLs (replaces the broken sum20ua.com search-page parser). "
-                "License posture: per-query lookup with attribution is fair "
-                "use; bulk crawl is not. Issue: #1667."
+                "License posture: per-query lookup with attribution only; "
+                "no bulk crawl and no DB caching. Prefer official ULIF "
+                "routes for authoritative СУМ-20 when available. Issue: #1667."
             ),
             inputSchema={
                 "type": "object",
@@ -729,19 +731,20 @@ async def list_tools() -> list[Tool]:
                 "Available `dict` values:\n"
                 "- `newsum` — СУМ-20 (modern, 2010–) — DEFAULT for definitions\n"
                 "- `sum` — СУМ-11 (Sovietized, 1970–80) — fallback only\n"
-                "- `antonenko` — Antonenko-Davydovych «Як ми говоримо» — calques + Russianisms\n"
-                "- `karavansky` — Karavansky synonyms (#1664)\n"
-                "- `paronyms` — Ukrainian paronyms dictionary (#1666 alternate)\n"
+                "- `davydov` (`antonenko` alias) — Antonenko-Davydovych «Як ми говоримо»\n"
+                "- `synonyms_karavansky` (`karavansky` alias) — Karavansky synonyms\n"
+                "- `franko` — dictionary from Ivan Franko's works\n"
+                "- `slang_lviv` — Lviv regional lexicon\n"
+                "- `holoskevych` — Holoskevych 1929 orthographic dictionary\n"
                 "- `phraseology` — Фразеологічний словник\n"
                 "- `orthography` — Орфографічний словник\n"
                 "- `orthoepy` — Орфоепічний словник\n"
                 "- `vts` — Великий тлумачний словник сучасної мови (alternate modern)\n"
-                "- `ukrlit_ency` — Українська літературна енциклопедія\n"
-                "- `khreshchatyk_lessons` — «Уроки державної мови» (usage column)\n"
                 "- `foreign_melnychuk` — foreign-words dictionary (Мельничук)\n"
-                "- `ukr_rus` / `rus_ukr` / `eng_ukr` — bilinguals\n\n"
-                "License posture: slovnyk.me © notice with no explicit terms; "
-                "per-query lookup with attribution is fair use. Issue: #1667."
+                "- `ukrrus` / `rusukr` / `engukr` — bilinguals\n\n"
+                "License posture: slovnyk.me © notice plus third-party source "
+                "rights; per-query lookup with attribution only, no bulk crawl "
+                "and no DB caching. Issue: #1667."
             ),
             inputSchema={
                 "type": "object",
@@ -749,11 +752,70 @@ async def list_tools() -> list[Tool]:
                     "word": {"type": "string", "description": "Ukrainian word to look up"},
                     "dict": {
                         "type": "string",
-                        "description": "Dictionary slug (newsum, sum, antonenko, karavansky, paronyms, phraseology, orthography, orthoepy, vts, ukrlit_ency, khreshchatyk_lessons, foreign_melnychuk, ukr_rus, rus_ukr, eng_ukr)",
+                        "description": "Dictionary slug (newsum, sum, davydov, synonyms_karavansky, franko, slang_lviv, holoskevych, phraseology, orthography, orthoepy, vts, foreign_melnychuk, ukrrus, rusukr, engukr). Backward aliases antonenko, karavansky, ukr_rus, rus_ukr, eng_ukr are accepted.",
                         "default": "newsum",
                     },
                 },
                 "required": ["word"]
+            },
+        ),
+        Tool(
+            name="search_slovnyk_me",
+            description=(
+                "Search slovnyk.me as a single-source dictionary aggregator. "
+                "Uses curated rows in data/sources.db when present, with optional "
+                "live direct-entry fallback to /dict/{slug}/{word}. Does NOT crawl "
+                "slovnyk.me /search, /terms, or sitemap. Returns dictionary slug, "
+                "source URL, bounded text/snippet, `is_modern`, `is_dialect`, "
+                "`is_russianism`, `sovietization_risk`, and ranking score. Use this "
+                "when a prompt needs slovnyk.me specifically, especially СУМ-20 or "
+                "regional dictionaries. Dictionaries already indexed locally "
+                "(СУМ-11, Грінченко, Антоненко-Давидович, phraseology, EN→UK) "
+                "are blocked here; use their canonical tools. For heritage-defense "
+                "decisions, prefer `search_heritage`."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Ukrainian headword to look up"},
+                    "dictionaries": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional dictionary slugs. Default: curated modern + heritage set.",
+                    },
+                    "limit": {"type": "integer", "description": "Max results (default 5, max 20)", "default": 5},
+                    "live": {
+                        "type": "boolean",
+                        "description": "Allow live direct-entry fallback if local rows are absent. Default: true.",
+                        "default": True,
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="search_heritage",
+            description=(
+                "Canonical heritage-defense lookup for distinguishing authentic "
+                "Ukrainian archaisms, historisms, dialectisms, and inherited words "
+                "from Russianisms/surzhyk. Merges existing tools/sources: "
+                "Грінченко 1907, ЕСУМ, slovnyk.me modern/regional dictionaries, "
+                "and Антоненко-Давидович style warnings. Ranks pre-Soviet and "
+                "etymological attestations above modern-only rows, and demotes "
+                "style-guide Russianism warnings rather than dropping them."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Ukrainian headword to verify"},
+                    "limit": {"type": "integer", "description": "Max merged results (default 8, max 20)", "default": 8},
+                    "include_live_slovnyk": {
+                        "type": "boolean",
+                        "description": "Allow live slovnyk.me direct-entry fallback. Default: true.",
+                        "default": True,
+                    },
+                },
+                "required": ["query"],
             },
         ),
         Tool(
@@ -857,6 +919,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             "query_sum20": lambda: handle_query_sum20(arguments),
             "query_slovnyk_me": lambda: handle_query_slovnyk_me(arguments),
             "query_pravopys": lambda: handle_query_pravopys(arguments),
+            "search_slovnyk_me": lambda: handle_search_slovnyk_me(arguments),
+            "search_heritage": lambda: handle_search_heritage(arguments),
             "search_style_guide": lambda: handle_dict_search(arguments, "style_guide", "Антоненко-Давидович"),
             "query_cefr_level": lambda: handle_dict_search(arguments, "puls_cefr", "PULS CEFR"),
             "search_definitions": lambda: handle_dict_search(arguments, "sum11", "СУМ-11"),
@@ -1486,15 +1550,16 @@ async def handle_query_slovnyk_me(args: dict) -> list[TextContent]:
     """Live single-query lookup against slovnyk.me — multi-dictionary.
 
     Per-query live fetch with citation. NO bulk crawl, NO DB persist.
-    License posture: slovnyk.me © notice with no explicit terms;
-    per-query lookup with attribution is fair use. Issue: #1667.
+    License posture: slovnyk.me © notice plus third-party source rights;
+    per-query lookup with attribution only. Issue: #1667.
     """
     word = args["word"]
     dict_slug = args.get("dict", "newsum")
 
-    from rag.source_query import SLOVNYK_ME_DICTS, slovnyk_me_lookup
+    from rag.source_query import SLOVNYK_ME_DICTS, resolve_slovnyk_me_dict_slug, slovnyk_me_lookup
 
-    if dict_slug not in SLOVNYK_ME_DICTS:
+    canonical_slug = resolve_slovnyk_me_dict_slug(dict_slug)
+    if canonical_slug not in SLOVNYK_ME_DICTS:
         valid = ", ".join(sorted(SLOVNYK_ME_DICTS.keys()))
         return [TextContent(
             type="text",
@@ -1504,14 +1569,14 @@ async def handle_query_slovnyk_me(args: dict) -> list[TextContent]:
             ),
         )]
 
-    result = await asyncio.to_thread(slovnyk_me_lookup, word, dict_slug)
+    result = await asyncio.to_thread(slovnyk_me_lookup, word, canonical_slug)
 
     if not result:
         return [TextContent(
             type="text",
             text=(
-                f"No entry found for '{word}' in slovnyk.me/{dict_slug} "
-                f"({SLOVNYK_ME_DICTS[dict_slug]})."
+                f"No entry found for '{word}' in slovnyk.me/{canonical_slug} "
+                f"({SLOVNYK_ME_DICTS[canonical_slug]})."
             ),
         )]
 
@@ -1602,6 +1667,102 @@ async def handle_dict_search(args: dict, collection: str, label: str) -> list[Te
             lines.append(f"- **Text**: {text[:500]}")
         lines.append("")
 
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_search_slovnyk_me(args: dict) -> list[TextContent]:
+    """Search slovnyk.me curated rows plus optional live direct-entry fallback."""
+    query = args.get("query", args.get("word", ""))
+    dictionaries = args.get("dictionaries")
+    if dictionaries is not None and not isinstance(dictionaries, list):
+        dictionaries = [str(dictionaries)]
+    limit = min(args.get("limit", 5), 20)
+    live = bool(args.get("live", True))
+
+    from wiki import sources_db as sdb
+
+    hits = await asyncio.to_thread(
+        sdb.search_slovnyk_me,
+        query,
+        limit,
+        dictionaries,
+        live=live,
+    )
+    if not hits:
+        return [TextContent(type="text", text=f"No slovnyk.me results for: \"{query}\"")]
+
+    lines = [f"Found {len(hits)} slovnyk.me result(s) for: \"{query}\"\n"]
+    for i, hit in enumerate(hits, 1):
+        lines.append(f"### Result {i}")
+        lines.append(f"- **Headword**: {hit.get('word', '')}")
+        lines.append(f"- **Dictionary**: {hit.get('dictionary_label', hit.get('dictionary_slug', ''))}")
+        if hit.get("source_url"):
+            lines.append(f"- **URL**: {hit['source_url']}")
+        flags = []
+        if hit.get("is_modern"):
+            flags.append("modern")
+        if hit.get("is_dialect"):
+            flags.append("heritage/regional")
+        if hit.get("is_russianism"):
+            flags.append("possible Russianism/calque")
+        if flags:
+            lines.append(f"- **Flags**: {', '.join(flags)}")
+        risk = int(hit.get("sovietization_risk") or 0)
+        if risk > 0:
+            lines.append(
+                f"- **Sovietization risk**: {risk} "
+                f"({hit.get('sovietization_keywords', '') or 'keywords unknown'})"
+            )
+        snippet = str(hit.get("snippet") or hit.get("text") or "")
+        if snippet:
+            lines.append(f"- **Snippet**: {snippet[:700]}")
+        lines.append(f"- **Score**: {float(hit.get('score', 0.0)):.1f}")
+        lines.append("")
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_search_heritage(args: dict) -> list[TextContent]:
+    """Merge heritage-defense sources for a headword."""
+    query = args.get("query", args.get("word", ""))
+    limit = min(args.get("limit", 8), 20)
+    include_live_slovnyk = bool(args.get("include_live_slovnyk", True))
+
+    from wiki import sources_db as sdb
+
+    hits = await asyncio.to_thread(
+        sdb.search_heritage,
+        query,
+        limit,
+        include_live_slovnyk=include_live_slovnyk,
+    )
+    if not hits:
+        return [TextContent(type="text", text=f"No heritage evidence found for: \"{query}\"")]
+
+    lines = [f"Found {len(hits)} heritage evidence row(s) for: \"{query}\"\n"]
+    for i, hit in enumerate(hits, 1):
+        lines.append(f"### Evidence {i}")
+        lines.append(f"- **Source family**: {hit.get('source_family', '')}")
+        lines.append(f"- **Source**: {hit.get('source', '')}")
+        lines.append(f"- **Headword**: {hit.get('word', '')}")
+        lines.append(f"- **Classification**: {hit.get('classification', '')}")
+        lines.append(f"- **Authentic Ukrainian**: {bool(hit.get('is_authentic_ukrainian'))}")
+        lines.append(f"- **Russianism/calque warning**: {bool(hit.get('is_russianism'))}")
+        if hit.get("url"):
+            lines.append(f"- **URL**: {hit['url']}")
+        tags = hit.get("evidence_tags") or []
+        if tags:
+            lines.append(f"- **Evidence tags**: {', '.join(tags)}")
+        risk = int(hit.get("sovietization_risk") or 0)
+        if risk > 0:
+            lines.append(
+                f"- **Sovietization risk**: {risk} "
+                f"({hit.get('sovietization_keywords', '') or 'keywords unknown'})"
+            )
+        text = str(hit.get("text") or "")
+        if text:
+            lines.append(f"- **Text**: {text[:700]}")
+        lines.append(f"- **Score**: {float(hit.get('score', 0.0)):.1f}")
+        lines.append("")
     return [TextContent(type="text", text="\n".join(lines))]
 
 

--- a/claude_extensions/rules/mcp-sources-and-dictionaries.md
+++ b/claude_extensions/rules/mcp-sources-and-dictionaries.md
@@ -24,6 +24,7 @@ paths:
 - `mcp__sources__search_literary` — primary literary sources (125K chunks — chronicles, poetry, legal texts)
 - `mcp__sources__query_pravopys` — Ukrainian orthography rules (Правопис 2019)
 - `mcp__sources__query_wikipedia` — Ukrainian Wikipedia
+- `mcp__sources__search_heritage` — **canonical heritage-defense lookup** for verifying potential archaisms, historisms, dialectisms, and inherited Ukrainian words against Russianism/surzhyk false positives. Merges Грінченко, ЕСУМ, slovnyk.me, and Антоненко-Давидович evidence.
 
 > Start with `mcp__sources__search_sources` for general retrieval. Keep `mcp__sources__search_text` for explicit textbook-only scoping when you do not want literary, Wikipedia, external, or `ukrainian_wiki` results mixed in.
 
@@ -34,9 +35,33 @@ paths:
 - `mcp__sources__search_definitions` — СУМ-11 (127K entries) — Ukrainian explanatory dictionary. **⚠️ Partially Sovietized for ideological terms** — see "Sovietization caveat" below. Each result row carries `sovietization_risk` (0/1/2) and `sovietization_keywords`.
 - `mcp__sources__search_grinchenko_1907` — Грінченко (67K entries) — historical Ukrainian dictionary from 1907. Use for pre-Soviet usage attestation; **NOT for word origins/etymology** — that's a separate concern handled by `search_esum` below.
 - `mcp__sources__search_esum` — ЕСУМ etymological dictionary — canonical name for ЕСУМ. PoC scope: vol. 1 (А–Г) only; vols. 2–6 are follow-up (#1662). Falls back to a goroh.pp.ua hint if word not found.
+- `mcp__sources__search_slovnyk_me` — slovnyk.me single-source aggregator. Uses curated `sources.db` rows when present and optional live direct-entry `/dict/{slug}/{word}` fallback. Returns URL, dictionary slug, bounded snippet, `is_modern`, `is_dialect`, `is_russianism`, and `sovietization_risk`. Use when slovnyk.me specifically is required; prefer `search_heritage` for archaism-vs-Russianism decisions.
 - `mcp__sources__search_idioms` — Фразеологічний (25K entries) — Ukrainian idioms and expressions
 - `mcp__sources__search_synonyms` — Ukrajinet WordNet (122K synsets) — synonyms, antonyms. **⚠️ Synsets are largely auto-translated from Open English WordNet** per upstream README — quality audit pending (#1657 Tier 3).
 - `mcp__sources__translate_en_uk` — Балла EN→UK (79K entries) — English→Ukrainian translations. One-way only; UK→EN reverse not yet built.
+
+## Heritage defense
+
+Use `mcp__sources__search_heritage` when a word may be an authentic Ukrainian
+archaism, historism, dialectism, regionalism, or contact borrowing rather than a
+Russianism/surzhyk form.
+
+The merger is intentionally conservative:
+
+- Pre-Soviet Грінченко evidence ranks highest.
+- ЕСУМ etymology ranks next, especially with Proto-Slavic cognate markers.
+- slovnyk.me СУМ-20/regional dictionaries provide modern and regional
+  attestation without duplicating the existing Грінченко/ЕСУМ tables.
+- Антоненко-Давидович style-guide hits are included as warnings but demoted;
+  a warning does not erase stronger historical or etymological evidence.
+- slovnyk.me dictionaries that duplicate canonical local tools are blocked in
+  `search_slovnyk_me`: use `search_definitions`, `search_grinchenko_1907`,
+  `search_style_guide`, `search_idioms`, or `translate_en_uk` instead.
+
+For writer/reviewer prompts: call `search_heritage` before rejecting an
+unfamiliar Ukrainian-looking word as Russianism. The load-bearing example is
+`кобета`/`кобіта`: the tool surfaces Lviv/regional and СУМ-20 evidence and keeps
+`is_russianism=false`.
 
 ## Sovietization caveat (СУМ-11) — issue #1659
 
@@ -61,9 +86,14 @@ Every `search_definitions` result row carries:
 - Do NOT reproduce the definition verbatim.
 - Prefer Грінченко (`search_grinchenko_1907`) for the same headword if it has
   pre-Soviet coverage.
-- After СУМ-20 lands (#1667), prefer that for modern definitional baseline.
+- Prefer `search_heritage` for an evidence merge, or `search_slovnyk_me` /
+  slovnyk.me `newsum` (СУМ-20) for a modern definitional baseline.
 - If neither alternative is available, paraphrase neutrally and flag in
   reviewer evidence.
+
+СУМ-20 rows are cleaner on sampled neutral words, but not assumed categorically
+clean. `search_slovnyk_me` applies the same `sovietization_risk` /
+`sovietization_keywords` classifier to slovnyk.me rows.
 
 The scan is reproducible:
 `.venv/bin/python scripts/audit/sum11_sovietization_scan.py --db data/sources.db`.
@@ -77,6 +107,7 @@ Audit report at `audit/sum11_sovietization_scan_<DATE>.md`.
 | **СУМ-11** | 127K (7,152 flagged Sovietized — #1659) | Ukrainian explanatory (definitions, citations) | `data/sources.db` FTS5 |
 | **Грінченко** | 67K | Historical Ukrainian (1907, lexicographic) | `data/sources.db` FTS5 |
 | **ЕСУМ** | vol. 1 (А–Г) PoC | Etymological dictionary | `data/sources.db` FTS5 via `search_esum` |
+| **slovnyk.me** | bounded per-word rows + live direct lookup | Modern/regional dictionary aggregator; no bulk mirror | `data/sources.db` `slovnyk_me_entries` + live `/dict/{slug}/{word}` |
 | **Балла EN→UK** | 79K | English→Ukrainian translations | `data/sources.db` FTS5 |
 | **Антоненко-Давидович** | 279 | Style guide (calques, Russianisms) | `data/sources.db` FTS5 |
 | **Фразеологічний** | 25K | Ukrainian idioms and expressions | `data/sources.db` FTS5 |

--- a/docs/audits/slovnyk-me-ingestion-feasibility.md
+++ b/docs/audits/slovnyk-me-ingestion-feasibility.md
@@ -1,0 +1,117 @@
+# slovnyk.me ingestion feasibility
+
+**Issue:** #1715
+**Date:** 2026-05-05
+**Decision:** Do not bulk-ingest slovnyk.me full text. Implement bounded per-word
+URL-reference/snapshot ingestion plus live direct-entry lookup. Robots
+permission is treated only as crawl permission, not as a copyright license.
+
+## Checks performed
+
+- `https://slovnyk.me/robots.txt` allows `/dict/...` direct dictionary pages,
+  but disallows `/search`, `/terms`, and `/feedback`. The ingester and MCP
+  lookup use only `/dict/{slug}/{word}` and do not call `/search`. This is a
+  robots compliance finding, not a reuse-license finding.
+- `https://slovnyk.me/` lists the hosted dictionaries and exposes stable
+  dictionary slugs such as `newsum`, `sum`, `hrinchenko`, `holoskevych`,
+  `obsolete_words`, `bukovina`, `franko`, `slang_lviv`, `davydov`,
+  `synonyms_karavansky`, `phraseology`, `engukr`, `rusukr`, and `ukrrus`.
+- No public slovnyk.me data dump, API, or upstream GitHub repository was found
+  during web/GitHub search. The site publishes a gzip sitemap, but using that
+  as a crawl seed would amount to bulk mirroring and is out of scope.
+- The `/terms` path returns HTTP 200 to `HEAD`, but it is disallowed by
+  `robots.txt`, so I did not crawl or parse it.
+- ULIF/NAS Ukraine publicly warns that sites including `slovnyk.me` use
+  electronic versions of СУМ and СУМ-20 without authorization and that those
+  are not official academic editions. Technolex summarizes the same warning and
+  points to official `sum20ua.com` / `services.ulif.org.ua/expl` routes for
+  СУМ-20.
+
+## Ingestion decision
+
+Bulk text ingestion is rejected for this PR. The legal/source-integrity posture
+is stronger than a normal "no explicit terms" site: the official СУМ-20 owner
+has explicitly objected to redistributed copies on slovnyk.me. Non-commercial
+educational use does not automatically create a general redistribution license,
+and Ukrainian copyright exceptions are narrower than US-style fair use.
+
+Dictionary copyright posture is mixed:
+
+- `holoskevych` (1929) and some older author-work dictionaries are lower risk
+  / likely public-domain or public-domain-adjacent, but still cited.
+- `newsum` (СУМ-20, 2010–), `slang_lviv` (2009), and other modern dictionaries
+  remain copyright-sensitive.
+- Overlap dictionaries already available through canonical local tools are
+  blocked in the new slovnyk.me search/ingest path: `sum`, `hrinchenko`,
+  `davydov`, `phraseology`, and `engukr`.
+
+This PR therefore implements:
+
+- `scripts/ingest/slovnyk_me_ingest.py` for explicit per-word fetching only.
+- `slovnyk_me_entries` rows in `data/sources.db` with source URL, dictionary
+  slug, bounded snippet/text, modern/dialect/Russianism flags, and
+  `sovietization_risk`.
+- A conservative default storage cap of 200 text characters per fetched row.
+- No sitemap crawl, no `/search` crawl, no full-dictionary mirror.
+- MCP live fallback that fetches only direct `/dict/{slug}/{word}` pages for the
+  requested headword or a known spelling alias.
+
+## Dictionary scope
+
+Default `search_slovnyk_me` scope targets gaps instead of duplicating existing
+local tools:
+
+- `newsum` / `vts` for modern explanatory attestation.
+- `holoskevych`, `obsolete_words`, `bukovina`, `franko`, `slang_lviv` for
+  heritage, regional, historical, and dialect attestation.
+
+Existing local tools remain independent and are not reingested:
+
+- Грінченко 1907: `search_grinchenko_1907`
+- ЕСУМ vol. 1: `search_esum`
+- Балла EN to UK: `translate_en_uk`
+- Антоненко-Давидович partial index: `search_style_guide`
+
+The merger `search_heritage` calls those existing functions and merges their
+results with slovnyk.me rows. It does not copy existing Грінченко/ЕСУМ/Балла/
+Антоненко-Давидович data into the slovnyk.me table.
+
+## Sovietization scan on СУМ-20 sample
+
+The same `sovietization_risk` classifier used for СУМ-11 is applied to
+slovnyk.me rows, including СУМ-20 rows. A direct-entry spot check was run
+against `newsum` on 2026-05-05:
+
+| Word | Result |
+| --- | --- |
+| `блакитний` | risk 0 |
+| `кобіта` | risk 0 |
+| `гаразд` | risk 0 |
+| `ленінізм` | no СУМ-20 row found |
+| `більшовик` | risk 1, keyword `більшов` |
+| `радянський` | risk 1, keywords `радянськ`, `срср` |
+| `національний` | risk 0 |
+| `прапор` | risk 0 |
+| `школа` | risk 0 |
+| `центр` | risk 0 |
+| `шлях` | risk 0 |
+
+Conclusion: СУМ-20 is much cleaner than СУМ-11 on the sampled neutral words,
+but it is not treated as categorically clean. Ideological headwords can still
+carry Soviet-era markers, so rows preserve `sovietization_risk` and
+`sovietization_keywords` for reviewers.
+
+## Heritage-defense behavior
+
+`search_heritage` ranks evidence as follows:
+
+1. Грінченко 1907 exact/prefix rows: strong pre-Soviet Ukrainian attestation.
+2. ЕСУМ rows, with a bonus when Proto-Slavic markers appear.
+3. slovnyk.me regional/historical rows, then modern explanatory rows.
+4. Style-guide Russianism/calque warnings are included but demoted.
+
+This ranking is designed for writer/reviewer prompts: if a word appears in
+pre-Soviet, etymological, or regional Ukrainian sources, it should not be
+rejected merely because it looks unfamiliar or has Polish contact history. The
+`кобета` user-facing spelling is normalized to the attested `кобіта` row so the
+Lviv/regional evidence is surfaced and not classified as Russianism.

--- a/migrations/add_slovnyk_me_entries.sql
+++ b/migrations/add_slovnyk_me_entries.sql
@@ -1,0 +1,70 @@
+-- Migration: add curated slovnyk.me verification snapshots
+-- Issue: #1715
+--
+-- This table is intentionally a bounded per-word / URL-reference store, not
+-- a bulk mirror of slovnyk.me. See docs/audits/slovnyk-me-ingestion-feasibility.md.
+
+CREATE TABLE IF NOT EXISTS slovnyk_me_entries (
+    id INTEGER PRIMARY KEY,
+    query TEXT NOT NULL DEFAULT '',
+    word TEXT NOT NULL,
+    normalized_word TEXT NOT NULL DEFAULT '',
+    dictionary_slug TEXT NOT NULL,
+    dictionary_label TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL DEFAULT 'slovnyk_me',
+    source_url TEXT NOT NULL DEFAULT '',
+    title TEXT NOT NULL DEFAULT '',
+    snippet TEXT NOT NULL DEFAULT '',
+    text TEXT NOT NULL DEFAULT '',
+    is_modern INTEGER NOT NULL DEFAULT 0,
+    is_dialect INTEGER NOT NULL DEFAULT 0,
+    is_russianism INTEGER NOT NULL DEFAULT 0,
+    sovietization_risk INTEGER NOT NULL DEFAULT 0,
+    sovietization_keywords TEXT NOT NULL DEFAULT '',
+    fetched_at TEXT NOT NULL DEFAULT '',
+    UNIQUE(normalized_word, dictionary_slug, source_url)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS slovnyk_me_entries_fts USING fts5(
+    word,
+    title,
+    snippet,
+    text,
+    dictionary_label,
+    content='slovnyk_me_entries',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS slovnyk_me_entries_ai
+AFTER INSERT ON slovnyk_me_entries BEGIN
+    INSERT INTO slovnyk_me_entries_fts(rowid, word, title, snippet, text, dictionary_label)
+    VALUES (new.id, new.word, new.title, new.snippet, new.text, new.dictionary_label);
+END;
+
+CREATE TRIGGER IF NOT EXISTS slovnyk_me_entries_ad
+AFTER DELETE ON slovnyk_me_entries BEGIN
+    INSERT INTO slovnyk_me_entries_fts(
+        slovnyk_me_entries_fts, rowid, word, title, snippet, text, dictionary_label
+    )
+    VALUES ('delete', old.id, old.word, old.title, old.snippet, old.text, old.dictionary_label);
+END;
+
+CREATE TRIGGER IF NOT EXISTS slovnyk_me_entries_au
+AFTER UPDATE ON slovnyk_me_entries BEGIN
+    INSERT INTO slovnyk_me_entries_fts(
+        slovnyk_me_entries_fts, rowid, word, title, snippet, text, dictionary_label
+    )
+    VALUES ('delete', old.id, old.word, old.title, old.snippet, old.text, old.dictionary_label);
+    INSERT INTO slovnyk_me_entries_fts(rowid, word, title, snippet, text, dictionary_label)
+    VALUES (new.id, new.word, new.title, new.snippet, new.text, new.dictionary_label);
+END;
+
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_word
+    ON slovnyk_me_entries(normalized_word COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_dict
+    ON slovnyk_me_entries(dictionary_slug);
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_modern
+    ON slovnyk_me_entries(is_modern) WHERE is_modern = 1;
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_dialect
+    ON slovnyk_me_entries(is_dialect) WHERE is_dialect = 1;

--- a/scripts/ingest/slovnyk_me_ingest.py
+++ b/scripts/ingest/slovnyk_me_ingest.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Ingest bounded slovnyk.me per-word verification snapshots into sources.db."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from wiki.slovnyk_me import (
+    DEFAULT_SLOVNYK_ME_DICTS,
+    DEFAULT_USER_AGENT,
+    OVERLAP_BLOCKED_DICTS,
+    SLOVNYK_ME_DICTS,
+    db_row_values,
+    ensure_slovnyk_me_schema,
+    fetch_entries,
+    resolve_dict_slug,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_DB = REPO / "data" / "sources.db"
+DEFAULT_NOTES = REPO / "docs" / "audits" / "slovnyk-me-ingestion-feasibility.md"
+
+INSERT_SQL = """
+INSERT INTO slovnyk_me_entries (
+    query,
+    word,
+    normalized_word,
+    dictionary_slug,
+    dictionary_label,
+    source_type,
+    source_url,
+    title,
+    snippet,
+    text,
+    is_modern,
+    is_dialect,
+    is_russianism,
+    sovietization_risk,
+    sovietization_keywords,
+    fetched_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(normalized_word, dictionary_slug, source_url) DO UPDATE SET
+    query = excluded.query,
+    word = excluded.word,
+    dictionary_label = excluded.dictionary_label,
+    source_type = excluded.source_type,
+    title = excluded.title,
+    snippet = excluded.snippet,
+    text = excluded.text,
+    is_modern = excluded.is_modern,
+    is_dialect = excluded.is_dialect,
+    is_russianism = excluded.is_russianism,
+    sovietization_risk = excluded.sovietization_risk,
+    sovietization_keywords = excluded.sovietization_keywords,
+    fetched_at = excluded.fetched_at
+"""
+
+
+def _read_words(args: argparse.Namespace) -> list[str]:
+    words: list[str] = []
+    for word in args.words:
+        cleaned = word.strip()
+        if cleaned:
+            words.append(cleaned)
+    if args.words_file:
+        with args.words_file.open(encoding="utf-8") as fh:
+            for line in fh:
+                cleaned = line.strip()
+                if cleaned and not cleaned.startswith("#"):
+                    words.append(cleaned)
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for word in words:
+        lowered = word.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        deduped.append(word)
+    return deduped
+
+
+def ingest_words(
+    db_path: Path,
+    words: list[str],
+    *,
+    dictionaries: list[str],
+    dry_run: bool,
+    sleep_s: float,
+    user_agent: str,
+    max_text_chars: int,
+) -> int:
+    rows: list[dict] = []
+    for index, word in enumerate(words):
+        if index and sleep_s > 0:
+            time.sleep(sleep_s)
+        fetched = fetch_entries(
+            word,
+            dictionaries=dictionaries,
+            limit=len(dictionaries),
+            user_agent=user_agent,
+            max_text_chars=max_text_chars,
+        )
+        rows.extend(fetched)
+        print(f"{word}: {len(fetched)} slovnyk.me row(s)")
+
+    if dry_run:
+        print(f"[dry-run] would upsert {len(rows)} row(s) into {db_path}")
+        return len(rows)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        ensure_slovnyk_me_schema(conn)
+        with conn:
+            conn.executemany(INSERT_SQL, [db_row_values(row) for row in rows])
+        return len(rows)
+    finally:
+        conn.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    dict_list = ", ".join(DEFAULT_SLOVNYK_ME_DICTS)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch explicit slovnyk.me direct-entry pages and store bounded verification snapshots.\n"
+            "Use for a curated word list; do NOT use as a sitemap crawler or full-dictionary mirror."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""Examples:
+  .venv/bin/python scripts/ingest/slovnyk_me_ingest.py блакитний кобета гаразд
+  .venv/bin/python scripts/ingest/slovnyk_me_ingest.py --words-file data/slovnyk-me-seed.txt --dict newsum --dict slang_lviv
+  .venv/bin/python scripts/ingest/slovnyk_me_ingest.py --dry-run --dict newsum блакитний
+
+Outputs:
+  Creates/updates the slovnyk_me_entries table plus FTS5 index in data/sources.db by default.
+  Stores bounded snippets/text for explicit words only; no /search crawl and no sitemap ingest.
+
+Exit codes:
+  0 on successful ingest; 2 when no words are supplied; >=1 on network, SQLite, or argument errors.
+
+Related:
+  GitHub issue #1715; feasibility notes: {DEFAULT_NOTES}
+  Default dictionaries: {dict_list}
+""",
+    )
+    parser.add_argument(
+        "words",
+        nargs="*",
+        help="Explicit Ukrainian headwords to fetch, e.g. блакитний кобета гаразд.",
+    )
+    parser.add_argument(
+        "--words-file",
+        type=Path,
+        help="UTF-8 file with one headword per line; blank lines and # comments are ignored.",
+    )
+    parser.add_argument(
+        "--dict",
+        dest="dicts",
+        action="append",
+        choices=sorted(SLOVNYK_ME_DICTS),
+        help=(
+            "slovnyk.me dictionary slug to query; repeatable. "
+            f"Default: {dict_list}."
+        ),
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DEFAULT_DB,
+        help=f"SQLite sources.db path to update. Default: {DEFAULT_DB}",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and report rows but do not create or update the SQLite database.",
+    )
+    parser.add_argument(
+        "--sleep",
+        type=float,
+        default=0.75,
+        help="Seconds to pause between words for polite per-word fetching. Default: 0.75.",
+    )
+    parser.add_argument(
+        "--max-text-chars",
+        type=int,
+        default=200,
+        help="Maximum entry text characters stored per row. Default: 200.",
+    )
+    parser.add_argument(
+        "--user-agent",
+        default=DEFAULT_USER_AGENT,
+        help=f"HTTP User-Agent for direct-entry requests. Default: {DEFAULT_USER_AGENT}",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    words = _read_words(args)
+    if not words:
+        print("No words supplied. Pass positional words or --words-file.", file=sys.stderr)
+        return 2
+    dicts = args.dicts or list(DEFAULT_SLOVNYK_ME_DICTS)
+    for slug in dicts:
+        canonical = resolve_dict_slug(slug)
+        if canonical in OVERLAP_BLOCKED_DICTS:
+            print(
+                f"Skipping slovnyk.me/{canonical}: use canonical local tool "
+                f"`{OVERLAP_BLOCKED_DICTS[canonical]}` instead.",
+                file=sys.stderr,
+            )
+    loaded = ingest_words(
+        args.db,
+        words,
+        dictionaries=dicts,
+        dry_run=args.dry_run,
+        sleep_s=max(0.0, args.sleep),
+        user_agent=args.user_agent,
+        max_text_chars=max(1, args.max_text_chars),
+    )
+    print(f"Loaded {loaded} slovnyk.me row(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rag/source_query.py
+++ b/scripts/rag/source_query.py
@@ -33,6 +33,14 @@ from urllib.parse import quote
 
 import requests
 
+try:
+    from wiki import slovnyk_me as _slovnyk_me
+except ImportError:  # pragma: no cover - direct package import fallback
+    from scripts.wiki import slovnyk_me as _slovnyk_me
+
+SLOVNYK_ME_DICTS = _slovnyk_me.SLOVNYK_ME_DICTS
+resolve_slovnyk_me_dict_slug = _slovnyk_me.resolve_dict_slug
+
 # ── Shared config ────────────────────────────────────────────────
 
 REQUEST_TIMEOUT = 15
@@ -862,31 +870,11 @@ def pravopys_lookup(topic: str) -> dict[str, Any] | None:
 # ══════════════════════════════════════════════════════════════════
 # slovnyk.me — multi-dictionary aggregator with clean per-word URLs
 # Hosts СУМ-20, СУМ-11, Antonenko-Davydovych, Karavansky synonyms,
-# paronyms, phraseology, orthography, orthoepy, foreign-words
+# phraseology, orthography, orthoepy, foreign-words
 # (Мельничук), and Ukrainian↔Russian / Ukrainian↔Polish bilinguals.
 # ══════════════════════════════════════════════════════════════════
 
 SLOVNYK_ME_BASE = "https://slovnyk.me"
-
-# Dictionary slugs slovnyk.me uses in /dict/{slug}/{word} URLs.
-# Confirmed via WebFetch 2026-05-04 from slovnyk.me/dict/newsum and search results page.
-SLOVNYK_ME_DICTS: dict[str, str] = {
-    "newsum": "Словник української мови у 20 томах (2010–) — modern post-Soviet",
-    "sum": "Словник української мови в 11 томах (1970–80) — Sovietized",
-    "antonenko": "«Як ми говоримо» Антоненка-Давидовича — calques + Russianisms",
-    "karavansky": "Синоніми Караванського",
-    "paronyms": "Словник паронімів",
-    "phraseology": "Фразеологічний словник української мови",
-    "orthography": "Орфографічний словник української мови",
-    "orthoepy": "Орфоепічний словник",
-    "vts": "Великий тлумачний словник сучасної мови",
-    "ukrlit_ency": "Українська літературна енциклопедія",
-    "khreshchatyk_lessons": "«Уроки державної мови» з газети «Хрещатик»",
-    "foreign_melnychuk": "Словник іншомовних слів Мельничука",
-    "ukr_rus": "Українсько-російський словник",
-    "rus_ukr": "Російсько-український словник",
-    "eng_ukr": "Англо-український словник",
-}
 
 
 def slovnyk_me_lookup(word: str, dict_slug: str = "newsum") -> dict[str, Any] | None:
@@ -903,10 +891,11 @@ def slovnyk_me_lookup(word: str, dict_slug: str = "newsum") -> dict[str, Any] | 
 
     Issue: #1667 (SUM-20 modern definitional baseline).
     """
-    if dict_slug not in SLOVNYK_ME_DICTS:
+    canonical_slug = resolve_slovnyk_me_dict_slug(dict_slug)
+    if canonical_slug not in SLOVNYK_ME_DICTS:
         return None
 
-    url = f"{SLOVNYK_ME_BASE}/dict/{dict_slug}/{quote(word)}"
+    url = f"{SLOVNYK_ME_BASE}/dict/{canonical_slug}/{quote(word)}"
     try:
         r = _get(url, timeout=20)
         if r.status_code == 404:
@@ -943,8 +932,8 @@ def slovnyk_me_lookup(word: str, dict_slug: str = "newsum") -> dict[str, Any] | 
 
         return {
             "word": word,
-            "dict": dict_slug,
-            "dict_label": SLOVNYK_ME_DICTS[dict_slug],
+            "dict": canonical_slug,
+            "dict_label": SLOVNYK_ME_DICTS[canonical_slug],
             "url": url,
             "text": text,
         }

--- a/scripts/wiki/slovnyk_me.py
+++ b/scripts/wiki/slovnyk_me.py
@@ -1,0 +1,472 @@
+"""Helpers for bounded slovnyk.me dictionary lookups.
+
+The project deliberately does not bulk-crawl slovnyk.me. The helpers here
+support explicit per-word lookup plus a small SQLite table for curated
+verification snapshots / URL references.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import html
+import re
+import sqlite3
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+try:
+    from audit.sum11_sovietization_scan import classify_entry
+except ImportError:  # pragma: no cover - direct package import fallback
+    from scripts.audit.sum11_sovietization_scan import classify_entry
+
+SLOVNYK_ME_BASE = "https://slovnyk.me"
+DEFAULT_USER_AGENT = (
+    "learn-ukrainian-slovnyk-me/1.0 "
+    "(noncommercial educational verification; issue 1715)"
+)
+
+# Canonical slugs are taken from https://slovnyk.me/ direct dictionary links.
+SLOVNYK_ME_DICTS: dict[str, str] = {
+    "newsum": "Словник української мови у 20 томах (СУМ-20)",
+    "sum": "Словник української мови в 11 томах (СУМ-11)",
+    "vts": "Великий тлумачний словник сучасної української мови",
+    "hrinchenko": "Словник української мови Грінченка",
+    "holoskevych": "Правописний словник Голоскевича (1929)",
+    "obsolete_words": "Словник застарілих та маловживаних слів",
+    "bukovina": "Українська літературна мова на Буковині",
+    "franko": "Словник з творів Івана Франка",
+    "literary_encyclopedia": "Українська літературна енциклопедія",
+    "slang_lviv": "Лексикон львівський: поважно і на жарт",
+    "slang": "Словник жарґонної лексики української мови",
+    "slang_modern": "Словник сучасного українського сленгу",
+    "synonyms_karavansky": "Словник синонімів Караванського",
+    "synonyms": "Словник синонімів української мови",
+    "phraseology": "Фразеологічний словник української мови",
+    "davydov": "«Як ми говоримо» Антоненка-Давидовича",
+    "khreshchatyk": "«Уроки державної мови» з газети «Хрещатик»",
+    "linguistic_norm": "Літературне слововживання",
+    "voloschak": "Неправильно-правильно",
+    "orthography": "Орфографічний словник української мови",
+    "orthoepy": "Орфоепічний словник української мови",
+    "foreign_melnychuk": "Словник іншомовних слів Мельничука",
+    "polukr": "Польсько-український словник",
+    "ukrpol": "Українсько-польський словник",
+    "engukr": "Англо-український словник",
+    "ukreng": "Українсько-англійський словник",
+    "rusukr": "Російсько-український словник",
+    "ukrrus": "Українсько-російський словник",
+}
+
+SLOVNYK_ME_DICT_ALIASES: dict[str, str] = {
+    "antonenko": "davydov",
+    "karavansky": "synonyms_karavansky",
+    "ukrlit_ency": "literary_encyclopedia",
+    "khreshchatyk_lessons": "khreshchatyk",
+    "eng_ukr": "engukr",
+    "ukr_eng": "ukreng",
+    "rus_ukr": "rusukr",
+    "ukr_rus": "ukrrus",
+    "pol_ukr": "polukr",
+    "ukr_pol": "ukrpol",
+}
+
+DEFAULT_SLOVNYK_ME_DICTS: tuple[str, ...] = (
+    "newsum",
+    "vts",
+    "holoskevych",
+    "obsolete_words",
+    "bukovina",
+    "franko",
+    "slang_lviv",
+)
+HERITAGE_SLOVNYK_ME_DICTS: tuple[str, ...] = (
+    "newsum",
+    "holoskevych",
+    "obsolete_words",
+    "bukovina",
+    "franko",
+    "slang_lviv",
+)
+MODERN_DICTS: frozenset[str] = frozenset({"newsum", "vts"})
+DIALECT_OR_HERITAGE_DICTS: frozenset[str] = frozenset(
+    {"holoskevych", "obsolete_words", "bukovina", "franko", "slang_lviv", "slang", "slang_modern"}
+)
+RUSSIANISM_GUIDE_DICTS: frozenset[str] = frozenset({"davydov", "linguistic_norm", "voloschak"})
+OVERLAP_BLOCKED_DICTS: dict[str, str] = {
+    "sum": "search_definitions",
+    "hrinchenko": "search_grinchenko_1907",
+    "davydov": "search_style_guide",
+    "phraseology": "search_idioms",
+    "engukr": "translate_en_uk",
+}
+QUERY_ALIASES: dict[str, tuple[str, ...]] = {
+    # User-facing spelling from #1715. slovnyk.me / СУМ-20 and regional
+    # dictionaries index the Ukrainianized Polish loan as кобіта.
+    "кобета": ("кобіта",),
+}
+
+SLOVNYK_ME_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS slovnyk_me_entries (
+    id INTEGER PRIMARY KEY,
+    query TEXT NOT NULL DEFAULT '',
+    word TEXT NOT NULL,
+    normalized_word TEXT NOT NULL DEFAULT '',
+    dictionary_slug TEXT NOT NULL,
+    dictionary_label TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL DEFAULT 'slovnyk_me',
+    source_url TEXT NOT NULL DEFAULT '',
+    title TEXT NOT NULL DEFAULT '',
+    snippet TEXT NOT NULL DEFAULT '',
+    text TEXT NOT NULL DEFAULT '',
+    is_modern INTEGER NOT NULL DEFAULT 0,
+    is_dialect INTEGER NOT NULL DEFAULT 0,
+    is_russianism INTEGER NOT NULL DEFAULT 0,
+    sovietization_risk INTEGER NOT NULL DEFAULT 0,
+    sovietization_keywords TEXT NOT NULL DEFAULT '',
+    fetched_at TEXT NOT NULL DEFAULT '',
+    UNIQUE(normalized_word, dictionary_slug, source_url)
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS slovnyk_me_entries_fts USING fts5(
+    word,
+    title,
+    snippet,
+    text,
+    dictionary_label,
+    content='slovnyk_me_entries',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+CREATE TRIGGER IF NOT EXISTS slovnyk_me_entries_ai
+AFTER INSERT ON slovnyk_me_entries BEGIN
+    INSERT INTO slovnyk_me_entries_fts(rowid, word, title, snippet, text, dictionary_label)
+    VALUES (new.id, new.word, new.title, new.snippet, new.text, new.dictionary_label);
+END;
+CREATE TRIGGER IF NOT EXISTS slovnyk_me_entries_ad
+AFTER DELETE ON slovnyk_me_entries BEGIN
+    INSERT INTO slovnyk_me_entries_fts(
+        slovnyk_me_entries_fts, rowid, word, title, snippet, text, dictionary_label
+    )
+    VALUES ('delete', old.id, old.word, old.title, old.snippet, old.text, old.dictionary_label);
+END;
+CREATE TRIGGER IF NOT EXISTS slovnyk_me_entries_au
+AFTER UPDATE ON slovnyk_me_entries BEGIN
+    INSERT INTO slovnyk_me_entries_fts(
+        slovnyk_me_entries_fts, rowid, word, title, snippet, text, dictionary_label
+    )
+    VALUES ('delete', old.id, old.word, old.title, old.snippet, old.text, old.dictionary_label);
+    INSERT INTO slovnyk_me_entries_fts(rowid, word, title, snippet, text, dictionary_label)
+    VALUES (new.id, new.word, new.title, new.snippet, new.text, new.dictionary_label);
+END;
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_word
+    ON slovnyk_me_entries(normalized_word COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_dict
+    ON slovnyk_me_entries(dictionary_slug);
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_modern
+    ON slovnyk_me_entries(is_modern) WHERE is_modern = 1;
+CREATE INDEX IF NOT EXISTS idx_slovnyk_me_dialect
+    ON slovnyk_me_entries(is_dialect) WHERE is_dialect = 1;
+"""
+
+_BLOCK_TAGS = {"p", "li", "br", "div", "h1", "h2", "h3", "small"}
+_SPACE_RE = re.compile(r"\s+")
+_ACUTE_RE = re.compile("[\u0301\u0300]")
+
+
+class _SlovnykHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.title_parts: list[str] = []
+        self.section_parts: dict[str, list[str]] = {
+            "dictionary-acticle": [],
+            "dictionary-more": [],
+        }
+        self.h1_parts: list[str] = []
+        self.meta_description = ""
+        self.canonical_url = ""
+        self._in_title = False
+        self._in_h1 = False
+        self._in_article = False
+        self._active_section: str | None = None
+
+    def _should_collect(self) -> bool:
+        if self._active_section == "dictionary-acticle":
+            return self._in_article
+        return self._active_section in self.section_parts
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr = {key: value or "" for key, value in attrs}
+        if tag == "title":
+            self._in_title = True
+        if tag == "article" and self._active_section == "dictionary-acticle":
+            self._in_article = True
+        if tag == "h1" and self._active_section == "dictionary-acticle" and self._in_article:
+            self._in_h1 = True
+        if tag == "section" and attr.get("id") in self.section_parts:
+            self._active_section = attr["id"]
+        if tag in _BLOCK_TAGS and self._should_collect():
+            self.section_parts[self._active_section].append("\n")
+        if tag == "meta" and attr.get("name") == "description":
+            self.meta_description = attr.get("content", "")
+        if tag == "link" and attr.get("rel") == "canonical":
+            self.canonical_url = attr.get("href", "")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+        if tag == "h1":
+            self._in_h1 = False
+        if tag == "article" and self._active_section == "dictionary-acticle":
+            self._in_article = False
+        if tag == "section" and self._active_section:
+            self._active_section = None
+        if tag in _BLOCK_TAGS and self._should_collect():
+            self.section_parts[self._active_section].append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+        if self._should_collect():
+            self.section_parts[self._active_section].append(data)
+        if self._in_h1:
+            self.h1_parts.append(data)
+
+
+def ensure_slovnyk_me_schema(conn: sqlite3.Connection) -> None:
+    """Create the curated slovnyk.me table and FTS index if missing."""
+    conn.executescript(SLOVNYK_ME_SCHEMA_SQL)
+
+
+def normalize_word(word: str) -> str:
+    """Normalize a Ukrainian headword for lookup keys."""
+    normalized = html.unescape(str(word or "")).strip().lower()
+    normalized = _ACUTE_RE.sub("", normalized)
+    normalized = normalized.replace("’", "'").replace("`", "'")
+    return _SPACE_RE.sub(" ", normalized)
+
+
+def resolve_dict_slug(slug: str) -> str:
+    """Return the canonical slovnyk.me dictionary slug for a slug or alias."""
+    cleaned = str(slug or "").strip()
+    return SLOVNYK_ME_DICT_ALIASES.get(cleaned, cleaned)
+
+
+def overlap_block_reason(slug: str) -> str | None:
+    """Return the canonical local tool when a slovnyk.me dictionary overlaps."""
+    return OVERLAP_BLOCKED_DICTS.get(resolve_dict_slug(slug))
+
+
+def query_variants(query: str) -> list[str]:
+    """Return direct-entry lookup variants without using /search."""
+    normalized = normalize_word(query)
+    variants = [normalized]
+    for alias in QUERY_ALIASES.get(normalized, ()):
+        normalized_alias = normalize_word(alias)
+        if normalized_alias not in variants:
+            variants.append(normalized_alias)
+    return variants
+
+
+def _clean_text(value: str) -> str:
+    return _SPACE_RE.sub(" ", html.unescape(value)).strip()
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    cleaned = _clean_text(value)
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return cleaned[: max_chars - 1].rstrip() + "…"
+
+
+def _source_type(dict_slug: str, is_modern: bool, is_dialect: bool, is_russianism: bool) -> str:
+    if is_russianism:
+        return "usage_warning"
+    if is_dialect:
+        return "heritage_or_regional"
+    if is_modern:
+        return "modern_explanatory"
+    return "dictionary"
+
+
+def _classify_flags(dict_slug: str, text: str) -> tuple[bool, bool, bool, int, str]:
+    lower = text.lower()
+    is_modern = dict_slug in MODERN_DICTS
+    is_dialect = dict_slug in DIALECT_OR_HERITAGE_DICTS or any(
+        marker in lower
+        for marker in (" діал.", " зах.", " заст.", " маловжив", "регіон", "говір", "жарґ", "львів")
+    )
+    is_russianism = dict_slug in RUSSIANISM_GUIDE_DICTS and any(
+        marker in lower
+        for marker in ("росіянізм", "російськ", "кальк", "неправильно", "не слід", "краще")
+    )
+    risk, keywords = classify_entry("", text)
+    return is_modern, is_dialect, is_russianism, risk, ",".join(keywords)
+
+
+def parse_entry_html(
+    page_html: str,
+    *,
+    query: str,
+    word: str,
+    dict_slug: str,
+    url: str,
+    max_text_chars: int = 500,
+) -> dict[str, Any] | None:
+    """Parse one direct slovnyk.me dictionary page into a bounded row."""
+    parser = _SlovnykHTMLParser()
+    parser.feed(page_html)
+
+    section_text = _clean_text(" ".join(parser.section_parts["dictionary-acticle"]))
+    if not section_text:
+        return None
+
+    headword = _clean_text(" ".join(parser.h1_parts)) or normalize_word(word)
+    title = _clean_text(" ".join(parser.title_parts)) or headword
+    canonical_url = parser.canonical_url or url
+    text = _truncate(section_text, max_text_chars)
+    snippet = _truncate(parser.meta_description or section_text, min(max_text_chars, 500))
+    is_modern, is_dialect, is_russianism, risk, keywords = _classify_flags(dict_slug, text)
+
+    return {
+        "query": query,
+        "word": headword,
+        "normalized_word": normalize_word(headword),
+        "dictionary_slug": dict_slug,
+        "dictionary_label": SLOVNYK_ME_DICTS.get(dict_slug, dict_slug),
+        "source_type": _source_type(dict_slug, is_modern, is_dialect, is_russianism),
+        "source_url": canonical_url,
+        "title": title,
+        "snippet": snippet,
+        "text": text,
+        "is_modern": is_modern,
+        "is_dialect": is_dialect,
+        "is_russianism": is_russianism,
+        "sovietization_risk": risk,
+        "sovietization_keywords": keywords,
+        "fetched_at": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+    }
+
+
+def fetch_entry(
+    word: str,
+    dict_slug: str,
+    *,
+    query: str | None = None,
+    user_agent: str = DEFAULT_USER_AGENT,
+    timeout: int = 20,
+    max_text_chars: int = 500,
+) -> dict[str, Any] | None:
+    """Fetch one direct slovnyk.me dictionary entry.
+
+    This intentionally uses /dict/{slug}/{word}, not /search, because /search
+    is disallowed in robots.txt.
+    """
+    canonical_slug = resolve_dict_slug(dict_slug)
+    if canonical_slug not in SLOVNYK_ME_DICTS:
+        return None
+    if canonical_slug in OVERLAP_BLOCKED_DICTS:
+        return None
+    url = f"{SLOVNYK_ME_BASE}/dict/{canonical_slug}/{quote(word)}"
+    response = requests.get(url, timeout=timeout, headers={"User-Agent": user_agent})
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return parse_entry_html(
+        response.text,
+        query=query or word,
+        word=word,
+        dict_slug=canonical_slug,
+        url=url,
+        max_text_chars=max_text_chars,
+    )
+
+
+def fetch_entries(
+    query: str,
+    *,
+    dictionaries: list[str] | tuple[str, ...] | None = None,
+    limit: int = 10,
+    user_agent: str = DEFAULT_USER_AGENT,
+    timeout: int = 20,
+    max_text_chars: int = 500,
+) -> list[dict[str, Any]]:
+    """Fetch bounded direct-entry rows for a query across selected dictionaries."""
+    dicts = dictionaries or DEFAULT_SLOVNYK_ME_DICTS
+    variants = query_variants(query)
+    results: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for slug in dicts:
+        canonical_slug = resolve_dict_slug(slug)
+        if canonical_slug not in SLOVNYK_ME_DICTS:
+            continue
+        if canonical_slug in OVERLAP_BLOCKED_DICTS:
+            continue
+        for variant in variants:
+            try:
+                row = fetch_entry(
+                    variant,
+                    canonical_slug,
+                    query=query,
+                    user_agent=user_agent,
+                    timeout=timeout,
+                    max_text_chars=max_text_chars,
+                )
+            except requests.RequestException:
+                row = None
+            if not row:
+                continue
+            key = (row["dictionary_slug"], row["source_url"])
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(row)
+            break
+        if len(results) >= limit:
+            break
+
+    results.sort(key=lambda row: score_slovnyk_row(row, query), reverse=True)
+    return results[:limit]
+
+
+def score_slovnyk_row(row: dict[str, Any], query: str) -> float:
+    """Rank slovnyk.me rows for direct verification."""
+    normalized_query = normalize_word(query)
+    normalized_word = normalize_word(str(row.get("normalized_word") or row.get("word") or ""))
+    score = 40.0
+    if normalized_word == normalized_query or normalized_word in query_variants(normalized_query):
+        score += 35.0
+    elif normalized_word.startswith(normalized_query):
+        score += 20.0
+    if bool(row.get("is_modern")):
+        score += 15.0
+    if bool(row.get("is_dialect")):
+        score += 18.0
+    if bool(row.get("is_russianism")):
+        score -= 45.0
+    score -= 5.0 * int(row.get("sovietization_risk") or 0)
+    return score
+
+
+def db_row_values(row: dict[str, Any]) -> tuple[Any, ...]:
+    """Return insert values for slovnyk_me_entries."""
+    return (
+        row.get("query", ""),
+        row.get("word", ""),
+        row.get("normalized_word") or normalize_word(str(row.get("word", ""))),
+        row.get("dictionary_slug", ""),
+        row.get("dictionary_label", ""),
+        row.get("source_type", "slovnyk_me"),
+        row.get("source_url", ""),
+        row.get("title", ""),
+        row.get("snippet", ""),
+        row.get("text", ""),
+        int(bool(row.get("is_modern"))),
+        int(bool(row.get("is_dialect"))),
+        int(bool(row.get("is_russianism"))),
+        int(row.get("sovietization_risk") or 0),
+        row.get("sovietization_keywords", ""),
+        row.get("fetched_at", ""),
+    )

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -14,6 +14,8 @@ Indexed tables (dictionary headword lookup):
 - translate_en_uk() — Балла EN→UK
 - query_cefr_level() — PULS CEFR
 - search_style_guide() — Антоненко-Давидович
+- search_slovnyk_me() — curated slovnyk.me verification snapshots / live lookup
+- search_heritage() — merged Ukrainian heritage-defense lookup
 - lookup_by_url() — external article URL lookup
 """
 
@@ -24,6 +26,7 @@ from pathlib import Path
 
 import yaml
 
+from . import slovnyk_me
 from .channels import rank_external_hits
 from .chunking import chunk_text, policy_for
 from .dense_rerank import _get_tokenizer, rerank_candidates, rerank_sections
@@ -1456,6 +1459,292 @@ def query_cefr_level(word: str, limit: int = 5) -> list[dict]:
 def search_style_guide(word: str, limit: int = 5) -> list[dict]:
     """Look up calques/Russianisms in Антоненко-Давидович style guide."""
     return _dict_lookup("style_guide", word, limit)
+
+
+def _normalize_slovnyk_row(row: dict, query: str) -> dict:
+    row = dict(row)
+    row["is_modern"] = bool(row.get("is_modern"))
+    row["is_dialect"] = bool(row.get("is_dialect"))
+    row["is_russianism"] = bool(row.get("is_russianism"))
+    row["sovietization_risk"] = int(row.get("sovietization_risk") or 0)
+    row["score"] = float(row.get("score") or slovnyk_me.score_slovnyk_row(row, query))
+    row.setdefault("source", "slovnyk.me")
+    return row
+
+
+def _resolved_slovnyk_dicts(dictionaries: list[str] | tuple[str, ...] | None) -> list[str]:
+    if not dictionaries:
+        return []
+    resolved: list[str] = []
+    for slug in dictionaries:
+        canonical = slovnyk_me.resolve_dict_slug(slug)
+        if canonical in slovnyk_me.OVERLAP_BLOCKED_DICTS:
+            continue
+        if canonical not in resolved:
+            resolved.append(canonical)
+    return resolved
+
+
+def _search_slovnyk_me_db(
+    query: str,
+    *,
+    limit: int,
+    dictionaries: list[str] | tuple[str, ...] | None,
+) -> list[dict]:
+    try:
+        conn = _get_conn()
+    except FileNotFoundError:
+        return []
+    if not _table_columns("slovnyk_me_entries"):
+        return []
+
+    variants = slovnyk_me.query_variants(query)
+    normalized_variants = [slovnyk_me.normalize_word(variant) for variant in variants]
+    dicts = _resolved_slovnyk_dicts(dictionaries)
+
+    dict_filter = ""
+    dict_params: list[object] = []
+    if dicts:
+        dict_filter = f" AND dictionary_slug IN ({','.join('?' for _ in dicts)})"
+        dict_params = [*dicts]
+    elif dictionaries:
+        return []
+    else:
+        blocked = tuple(slovnyk_me.OVERLAP_BLOCKED_DICTS)
+        dict_filter = f" AND dictionary_slug NOT IN ({','.join('?' for _ in blocked)})"
+        dict_params = [*blocked]
+
+    seen_ids: set[int] = set()
+    rows: list[dict] = []
+
+    def add_fetched(fetched: list[sqlite3.Row]) -> None:
+        for fetched_row in fetched:
+            item = dict(fetched_row)
+            row_id = int(item["id"])
+            if row_id in seen_ids:
+                continue
+            seen_ids.add(row_id)
+            rows.append(_normalize_slovnyk_row(item, query))
+
+    placeholders = ",".join("?" for _ in normalized_variants)
+    exact = conn.execute(
+        f"""
+        SELECT *
+        FROM slovnyk_me_entries
+        WHERE normalized_word IN ({placeholders}){dict_filter}
+        LIMIT ?
+        """,
+        (*normalized_variants, *dict_params, limit),
+    ).fetchall()
+    add_fetched(exact)
+
+    if len(rows) < limit:
+        prefix_where = " OR ".join("normalized_word LIKE ?" for _ in normalized_variants)
+        prefix_params = [f"{variant}%" for variant in normalized_variants]
+        prefix = conn.execute(
+            f"""
+            SELECT *
+            FROM slovnyk_me_entries
+            WHERE ({prefix_where}){dict_filter}
+            LIMIT ?
+            """,
+            (*prefix_params, *dict_params, limit),
+        ).fetchall()
+        add_fetched(prefix)
+
+    if len(rows) < limit and _table_columns("slovnyk_me_entries_fts"):
+        fts_query = _escape_fts5_phrase(query)
+        if fts_query:
+            try:
+                fts = conn.execute(
+                    f"""
+                    SELECT e.*, bm25(slovnyk_me_entries_fts) AS fts_rank
+                    FROM slovnyk_me_entries_fts
+                    JOIN slovnyk_me_entries e ON e.id = slovnyk_me_entries_fts.rowid
+                    WHERE slovnyk_me_entries_fts MATCH ?{dict_filter}
+                    ORDER BY fts_rank
+                    LIMIT ?
+                    """,
+                    (fts_query, *dict_params, limit),
+                ).fetchall()
+                add_fetched(fts)
+            except sqlite3.OperationalError:
+                pass
+
+    rows.sort(key=lambda row: row["score"], reverse=True)
+    return rows[:limit]
+
+
+def search_slovnyk_me(
+    query: str,
+    limit: int = 10,
+    dictionaries: list[str] | tuple[str, ...] | None = None,
+    *,
+    live: bool = False,
+) -> list[dict]:
+    """Search curated slovnyk.me rows, optionally falling back to live direct pages.
+
+    `live=True` fetches only /dict/{slug}/{word} pages for the explicit query
+    and known variants. It does not call slovnyk.me /search and does not crawl
+    sitemaps.
+    """
+    limit = max(1, min(limit, 20))
+    rows = _search_slovnyk_me_db(query, limit=limit, dictionaries=dictionaries)
+    if len(rows) >= limit or not live:
+        return rows[:limit]
+
+    live_rows = [
+        _normalize_slovnyk_row(row, query)
+        for row in slovnyk_me.fetch_entries(
+            query,
+            dictionaries=dictionaries,
+            limit=limit - len(rows),
+        )
+    ]
+    seen = {
+        (row.get("dictionary_slug", ""), row.get("source_url", ""))
+        for row in rows
+    }
+    for row in live_rows:
+        key = (row.get("dictionary_slug", ""), row.get("source_url", ""))
+        if key not in seen:
+            seen.add(key)
+            rows.append(row)
+    rows.sort(key=lambda row: row["score"], reverse=True)
+    return rows[:limit]
+
+
+def _heritage_text(hit: dict) -> str:
+    return str(
+        hit.get("definition")
+        or hit.get("etymology_text")
+        or hit.get("snippet")
+        or hit.get("text")
+        or ""
+    )
+
+
+def search_heritage(
+    query: str,
+    limit: int = 10,
+    *,
+    include_live_slovnyk: bool = False,
+) -> list[dict]:
+    """Merge heritage-defense evidence for a Ukrainian headword.
+
+    Sources are deliberately kept separate: this calls the existing
+    Грінченко, ЕСУМ, slovnyk.me, and style-guide lookup functions rather
+    than re-ingesting those dictionaries into a combined table.
+    """
+    limit = max(1, min(limit, 20))
+    rows: list[dict] = []
+
+    for hit in search_grinchenko_1907(query, limit=5):
+        text = _heritage_text(hit)
+        rows.append({
+            "query": query,
+            "source_family": "grinchenko",
+            "source": hit.get("source", "Грінченко"),
+            "word": hit.get("word", ""),
+            "text": text,
+            "classification": "pre_soviet_ukrainian_attestation",
+            "is_authentic_ukrainian": True,
+            "is_russianism": False,
+            "is_modern": False,
+            "is_dialect": "діал" in text.lower(),
+            "sovietization_risk": 0,
+            "evidence_tags": ["pre_soviet", "lexicographic"],
+            "score": 96.0,
+        })
+
+    for hit in search_esum(query, limit=5):
+        text = _heritage_text(hit)
+        cognates = str(hit.get("cognates", ""))
+        tags = ["etymology"]
+        score = 92.0
+        if "псл" in text.lower() or "псл" in cognates.lower():
+            tags.append("proto_slavic")
+            score += 5.0
+        rows.append({
+            "query": query,
+            "source_family": "esum",
+            "source": hit.get("source", "ЕСУМ"),
+            "word": hit.get("lemma", ""),
+            "text": text,
+            "classification": "etymological_attestation",
+            "is_authentic_ukrainian": True,
+            "is_russianism": False,
+            "is_modern": False,
+            "is_dialect": False,
+            "sovietization_risk": 0,
+            "evidence_tags": tags,
+            "score": score,
+        })
+
+    for hit in search_slovnyk_me(
+        query,
+        limit=limit,
+        dictionaries=slovnyk_me.HERITAGE_SLOVNYK_ME_DICTS,
+        live=include_live_slovnyk,
+    ):
+        is_russianism = bool(hit.get("is_russianism"))
+        is_dialect = bool(hit.get("is_dialect"))
+        is_modern = bool(hit.get("is_modern"))
+        if is_russianism:
+            classification = "potential_russianism_or_calque"
+            score = 25.0
+        elif is_dialect:
+            classification = "regional_or_historical_ukrainian_attestation"
+            score = 88.0
+        elif is_modern:
+            classification = "modern_ukrainian_attestation"
+            score = 82.0
+        else:
+            classification = "dictionary_attestation"
+            score = 72.0
+        score -= 5.0 * int(hit.get("sovietization_risk") or 0)
+        rows.append({
+            "query": query,
+            "source_family": "slovnyk_me",
+            "source": hit.get("dictionary_label", "slovnyk.me"),
+            "word": hit.get("word", ""),
+            "text": _heritage_text(hit),
+            "url": hit.get("source_url", ""),
+            "classification": classification,
+            "is_authentic_ukrainian": not is_russianism,
+            "is_russianism": is_russianism,
+            "is_modern": is_modern,
+            "is_dialect": is_dialect,
+            "sovietization_risk": int(hit.get("sovietization_risk") or 0),
+            "sovietization_keywords": hit.get("sovietization_keywords", ""),
+            "evidence_tags": [tag for tag, present in {
+                "modern": is_modern,
+                "regional_or_historical": is_dialect,
+                "possible_russianism": is_russianism,
+                "slovnyk_me": True,
+            }.items() if present],
+            "score": score,
+        })
+
+    for hit in search_style_guide(query, limit=3):
+        rows.append({
+            "query": query,
+            "source_family": "style_guide",
+            "source": hit.get("source", "Антоненко-Давидович"),
+            "word": hit.get("word", ""),
+            "text": _heritage_text(hit),
+            "classification": "potential_russianism_or_calque",
+            "is_authentic_ukrainian": False,
+            "is_russianism": True,
+            "is_modern": False,
+            "is_dialect": False,
+            "sovietization_risk": 0,
+            "evidence_tags": ["style_warning", "possible_russianism"],
+            "score": 20.0,
+        })
+
+    rows.sort(key=lambda row: row["score"], reverse=True)
+    return rows[:limit]
 
 
 def lookup_by_url(url: str) -> dict | None:

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -55,7 +55,7 @@ class TestListTools:
             "query_pravopys", "query_cefr_level",
             "search_style_guide", "search_definitions", "search_grinchenko_1907",
             "search_idioms", "search_synonyms", "translate_en_uk",
-            "search_esum", "check_russian_shadow",
+            "search_esum", "search_slovnyk_me", "search_heritage", "check_russian_shadow",
         }
         missing = expected - tool_names
         extra = tool_names - expected
@@ -117,6 +117,18 @@ class TestCallToolDispatch:
             mock.return_value = [MagicMock(text="ok")]
             _run(server_module.call_tool("search_grinchenko_1907", {"query": "тест"}))
             mock.assert_called_once_with({"query": "тест"}, "grinchenko_dict", "Грінченко")
+
+    def test_search_slovnyk_me_dispatches(self, server_module):
+        with patch.object(server_module, "handle_search_slovnyk_me", new_callable=AsyncMock) as mock:
+            mock.return_value = [MagicMock(text="ok")]
+            _run(server_module.call_tool("search_slovnyk_me", {"query": "тест"}))
+            mock.assert_called_once_with({"query": "тест"})
+
+    def test_search_heritage_dispatches(self, server_module):
+        with patch.object(server_module, "handle_search_heritage", new_callable=AsyncMock) as mock:
+            mock.return_value = [MagicMock(text="ok")]
+            _run(server_module.call_tool("search_heritage", {"query": "тест"}))
+            mock.assert_called_once_with({"query": "тест"})
 
     def test_check_modern_form_dispatches(self, server_module):
         with patch.object(server_module, "handle_check_modern_form", new_callable=AsyncMock) as mock:

--- a/tests/test_slovnyk_me_tool.py
+++ b/tests/test_slovnyk_me_tool.py
@@ -1,0 +1,267 @@
+"""Smoke tests for #1715 slovnyk.me and heritage MCP backing functions."""
+
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+
+
+@pytest.fixture()
+def slovnyk_sources_db(tmp_path, monkeypatch):
+    from wiki.slovnyk_me import db_row_values, ensure_slovnyk_me_schema, normalize_word
+
+    from wiki import sources_db as sdb
+
+    db_path = tmp_path / "sources.db"
+    conn = sqlite3.connect(str(db_path))
+    ensure_slovnyk_me_schema(conn)
+    conn.executescript(
+        """
+        CREATE TABLE grinchenko (
+            id INTEGER PRIMARY KEY,
+            word TEXT NOT NULL,
+            definition TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        );
+        CREATE INDEX idx_grinchenko_word ON grinchenko(word COLLATE NOCASE);
+
+        CREATE TABLE style_guide (
+            id INTEGER PRIMARY KEY,
+            word TEXT NOT NULL,
+            section TEXT DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        );
+        CREATE INDEX idx_style_word ON style_guide(word COLLATE NOCASE);
+
+        CREATE TABLE esum_etymology_meta (
+            id INTEGER PRIMARY KEY,
+            lemma TEXT NOT NULL,
+            vol INTEGER NOT NULL,
+            page INTEGER NOT NULL,
+            entry_hash TEXT NOT NULL DEFAULT '',
+            etymology_text TEXT NOT NULL DEFAULT '',
+            cognates TEXT NOT NULL DEFAULT '',
+            source TEXT NOT NULL DEFAULT 'ЕСУМ'
+        );
+        CREATE VIRTUAL TABLE esum_etymology USING fts5(
+            lemma,
+            etymology_text,
+            cognates,
+            vol UNINDEXED,
+            page UNINDEXED,
+            content='esum_etymology_meta',
+            content_rowid='id',
+            tokenize='unicode61'
+        );
+        """
+    )
+
+    rows = [
+        {
+            "query": "блакитний",
+            "word": "блакитний",
+            "normalized_word": normalize_word("блакитний"),
+            "dictionary_slug": "newsum",
+            "dictionary_label": "Словник української мови у 20 томах (СУМ-20)",
+            "source_type": "modern_explanatory",
+            "source_url": "https://slovnyk.me/dict/newsum/блакитний",
+            "title": "блакитний — СУМ-20",
+            "snippet": "БЛАКИ́ТНИЙ, а, е. Небесно-голубого кольору; голубий.",
+            "text": "БЛАКИ́ТНИЙ, а, е. Небесно-голубого кольору; голубий.",
+            "is_modern": True,
+            "is_dialect": False,
+            "is_russianism": False,
+            "sovietization_risk": 0,
+            "sovietization_keywords": "",
+            "fetched_at": "2026-05-05T00:00:00+00:00",
+        },
+        {
+            "query": "кобета",
+            "word": "кобіта",
+            "normalized_word": normalize_word("кобіта"),
+            "dictionary_slug": "slang_lviv",
+            "dictionary_label": "Лексикон львівський: поважно і на жарт",
+            "source_type": "heritage_or_regional",
+            "source_url": "https://slovnyk.me/dict/slang_lviv/кобіта",
+            "title": "кобіта — Лексикон львівський",
+            "snippet": "кобі́та (кубі́та) жінка; дівчина (м, ср, ст).",
+            "text": "кобі́та (кубі́та) жінка; дівчина (м, ср, ст).",
+            "is_modern": False,
+            "is_dialect": True,
+            "is_russianism": False,
+            "sovietization_risk": 0,
+            "sovietization_keywords": "",
+            "fetched_at": "2026-05-05T00:00:00+00:00",
+        },
+        {
+            "query": "гаразд",
+            "word": "гаразд",
+            "normalized_word": normalize_word("гаразд"),
+            "dictionary_slug": "newsum",
+            "dictionary_label": "Словник української мови у 20 томах (СУМ-20)",
+            "source_type": "modern_explanatory",
+            "source_url": "https://slovnyk.me/dict/newsum/гаразд",
+            "title": "гаразд — СУМ-20",
+            "snippet": "ГАРА́ЗД. Уживається для вираження згоди; добре.",
+            "text": "ГАРА́ЗД. Уживається для вираження згоди; добре.",
+            "is_modern": True,
+            "is_dialect": False,
+            "is_russianism": False,
+            "sovietization_risk": 0,
+            "sovietization_keywords": "",
+            "fetched_at": "2026-05-05T00:00:00+00:00",
+        },
+        {
+            "query": "гаразд",
+            "word": "гаразд",
+            "normalized_word": normalize_word("гаразд"),
+            "dictionary_slug": "hrinchenko",
+            "dictionary_label": "Словник української мови Грінченка",
+            "source_type": "dictionary",
+            "source_url": "https://slovnyk.me/dict/hrinchenko/гаразд",
+            "title": "гаразд — Грінченко on slovnyk.me",
+            "snippet": "Duplicate copy that should be blocked by search_slovnyk_me.",
+            "text": "Duplicate copy that should be blocked by search_slovnyk_me.",
+            "is_modern": False,
+            "is_dialect": False,
+            "is_russianism": False,
+            "sovietization_risk": 0,
+            "sovietization_keywords": "",
+            "fetched_at": "2026-05-05T00:00:00+00:00",
+        },
+        {
+            "query": "радянський",
+            "word": "радянський",
+            "normalized_word": normalize_word("радянський"),
+            "dictionary_slug": "newsum",
+            "dictionary_label": "Словник української мови у 20 томах (СУМ-20)",
+            "source_type": "modern_explanatory",
+            "source_url": "https://slovnyk.me/dict/newsum/радянський",
+            "title": "радянський — СУМ-20",
+            "snippet": "РАДЯ́НСЬКИЙ. Стос. до рад, СРСР.",
+            "text": "РАДЯ́НСЬКИЙ. Стос. до рад, СРСР.",
+            "is_modern": True,
+            "is_dialect": False,
+            "is_russianism": False,
+            "sovietization_risk": 1,
+            "sovietization_keywords": "радянськ,срср",
+            "fetched_at": "2026-05-05T00:00:00+00:00",
+        },
+    ]
+    conn.executemany(
+        """
+        INSERT INTO slovnyk_me_entries (
+            query, word, normalized_word, dictionary_slug, dictionary_label,
+            source_type, source_url, title, snippet, text, is_modern,
+            is_dialect, is_russianism, sovietization_risk,
+            sovietization_keywords, fetched_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [db_row_values(row) for row in rows],
+    )
+    conn.execute(
+        "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
+        (
+            "гаразд I",
+            "Гаразд нар. 1) Ладно, хорошо. 2) Хорошо.",
+            "Грінченко",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO esum_etymology_meta
+            (lemma, vol, page, entry_hash, etymology_text, cognates, source)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "гаразд",
+            1,
+            470,
+            "garage-test",
+            "гаразд — псл. основа, споріднене з гараздувати.",
+            '["псл."]',
+            "ЕСУМ vol. 1",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO esum_etymology(rowid, lemma, etymology_text, cognates, vol, page)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            1,
+            "гаразд",
+            "гаразд — псл. основа, споріднене з гараздувати.",
+            '["псл."]',
+            1,
+            470,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(sdb, "SOURCES_DB_PATH", db_path)
+    monkeypatch.setattr(sdb, "_conn", None)
+    yield db_path
+    if sdb._conn is not None:
+        sdb._conn.close()
+        monkeypatch.setattr(sdb, "_conn", None)
+
+
+def test_search_slovnyk_me_blakytnyi_returns_modern_sum20_row(slovnyk_sources_db):
+    from wiki.sources_db import search_slovnyk_me
+
+    hits = search_slovnyk_me("блакитний", live=False)
+
+    assert hits
+    assert any(hit["dictionary_slug"] == "newsum" and hit["is_modern"] for hit in hits)
+
+
+def test_search_slovnyk_me_kobeta_returns_dialect_not_russianism(slovnyk_sources_db):
+    from wiki.sources_db import search_slovnyk_me
+
+    hits = search_slovnyk_me("кобета", live=False)
+
+    assert hits
+    assert any(hit["word"] == "кобіта" and hit["is_dialect"] for hit in hits)
+    assert not any(hit["is_russianism"] for hit in hits)
+
+
+def test_search_heritage_harazd_merges_grinchenko_slovnyk_and_esum(slovnyk_sources_db):
+    from wiki.sources_db import search_heritage
+
+    hits = search_heritage("гаразд", include_live_slovnyk=False)
+    families = {hit["source_family"] for hit in hits}
+
+    assert {"grinchenko", "slovnyk_me", "esum"}.issubset(families)
+    assert all(
+        hit["is_authentic_ukrainian"]
+        for hit in hits
+        if hit["source_family"] in {"grinchenko", "slovnyk_me", "esum"}
+    )
+
+
+def test_search_slovnyk_me_blocks_duplicate_local_dictionary_rows(slovnyk_sources_db):
+    from wiki.sources_db import search_slovnyk_me
+
+    assert search_slovnyk_me("гаразд", dictionaries=["hrinchenko"], live=False) == []
+
+    hits = search_slovnyk_me("гаразд", live=False)
+
+    assert hits
+    assert not any(hit["dictionary_slug"] == "hrinchenko" for hit in hits)
+
+
+def test_search_heritage_demotes_slovnyk_sovietization_risk(slovnyk_sources_db):
+    from wiki.sources_db import search_heritage
+
+    hits = search_heritage("радянський", include_live_slovnyk=False)
+    slovnyk_hit = next(hit for hit in hits if hit["source_family"] == "slovnyk_me")
+
+    assert slovnyk_hit["sovietization_risk"] == 1
+    assert slovnyk_hit["score"] == 77.0


### PR DESCRIPTION
## Summary
- Add a bounded slovnyk.me ingester and storage migration for `slovnyk_me_entries` in `data/sources.db`.
- Add MCP tools `search_slovnyk_me` and `search_heritage`, plus tests for the `блакитний`, `кобета`, and `гаразд` heritage-defense smoke cases.
- Document the slovnyk.me ingestion feasibility/legal posture and update MCP dictionary guidance for V7 writer/reviewer prompts.

## Strategic decisions
1. **Ingestion mechanism:** I rejected bulk full-text ingestion. `robots.txt` allows direct `/dict/...` pages but disallows `/search`, `/terms`, and `/feedback`; no public dump/API/upstream repo was found; and ULIF publicly warns that slovnyk.me uses SUM/SUM-20 without authorization. The implementation only supports explicit per-word bounded snapshots plus live direct-entry lookup with attribution. It does not crawl `/search`, `/terms`, the sitemap, or dictionary indexes.
2. **Dictionary scope:** Default slovnyk.me scope is gap-focused: `newsum`, `vts`, `holoskevych`, `obsolete_words`, `bukovina`, `franko`, and `slang_lviv`. Dictionaries already covered by existing tools are blocked from the new slovnyk.me ingest/search path: `sum`, `hrinchenko`, `davydov`, `phraseology`, and `engukr`. Existing `search_grinchenko_1907`, `search_esum`, `translate_en_uk`, and `search_style_guide` remain independent.
3. **MCP surface:** `search_slovnyk_me` is the single-source lookup against curated rows, with optional direct-entry live fallback. `search_heritage` is the canonical merger for prompts: it queries Grinchenko, ESUM, slovnyk.me rows, and the style guide, then ranks heritage evidence ahead of cautions. Grinchenko and ESUM score highest, slovnyk dialect/archaic rows rank above modern rows, Russianism cautions are demoted, and slovnyk rows subtract `5 * sovietization_risk`.
4. **SUM-20 Sovietization risk:** The same SUM-11 classifier is applied to slovnyk.me/SUM-20 rows instead of assuming SUM-20 is clean. A spot-check sample found risk 0 for `блакитний`, `кобіта`, `гаразд`, `національний`, `прапор`, `школа`, `центр`, and `шлях`; no SUM-20 row for `ленінізм`; and risk 1 for `більшовик` and `радянський`. Risk fields are stored and surfaced, not dropped.

## Claude review
Claude adversarial review ran as `1715-slovnyk-me-review`. Blocking feedback was applied:
- Demote slovnyk.me rows by `sovietization_risk` in `search_heritage` ranking.
- Add a blocklist to prevent duplicating dictionaries already indexed by existing tools.
- Tighten the legal wording to separate robots permission from copyright/licensing and lower stored text caps.

## Validation
- `.venv/bin/ruff check scripts/ingest/ .mcp/servers/sources/ scripts/wiki/sources_db.py scripts/wiki/slovnyk_me.py scripts/rag/source_query.py tests/`
- `.venv/bin/python -m pytest tests/test_slovnyk_me_tool.py -v`
- `.venv/bin/python -m pytest tests/test_mcp_sources_server.py -v`
- Commit hook affected tests: `tests/test_mcp_sources_server.py`, `tests/test_slovnyk_me_tool.py`, `tests/test_sources_db.py` — 49 passed
- `git diff --cached --check`
- Live dry-run: `.venv/bin/python scripts/ingest/slovnyk_me_ingest.py --dry-run --dict newsum --dict slang_lviv --dict hrinchenko блакитний кобета гаразд`

## Notes
- The dispatch brief named `.claude/rules/mcp-sources-and-dictionaries.md`, but this repository has the rule at `claude_extensions/rules/mcp-sources-and-dictionaries.md`; I updated that existing path.
- The dispatch brief named `scripts/sources/`, but this repository's MCP server lives under `.mcp/servers/sources/`; validation used that actual path.
