### PR TITLE
feat(prompts): mandate end_gate block + module-only correction contract (#1720 strands 2+3)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1623,6 +1623,44 @@ def parse_writer_output(output: str) -> dict[str, str]:
     return parse_writer_output_strict_json(output)
 
 
+# Match a single fenced block whose info string identifies module.md, in any
+# of the writer's known fence-info conventions:
+#   ```markdown file=module.md
+#   ```markdown module.md
+#   ```module.md
+# The body capture stops at the next ``` fence terminator. Whitespace before
+# the trailing fence is allowed but content lines are preserved verbatim.
+_MODULE_ONLY_FENCE_RE = re.compile(
+    r"```\s*(?:markdown(?:\s+(?:file=)?module\.md)?|(?:file=)?module\.md)\s*\n"
+    r"(?P<body>.*?)\n```",
+    re.DOTALL,
+)
+
+
+def parse_writer_correction_module_only(response: str) -> str | None:
+    """Extract the patched module.md from a single-fence correction response.
+
+    The patch-bounded writer-correction prompt (`linear-writer-correction.md`)
+    instructs the writer to return EXACTLY one fenced block labeled
+    `module.md`. This parser accepts that format. Returns the module.md body
+    (with one trailing newline) when the response contains exactly one such
+    block, or None if the response has zero or multiple matching blocks.
+
+    Used by `_apply_writer_correction` for gates that only modify module.md
+    (everything in WRITER_CORRECTION_GATES except `strict_json_parse`, which
+    needs all four artifacts re-emitted).
+    """
+    if not isinstance(response, str):
+        return None
+    matches = list(_MODULE_ONLY_FENCE_RE.finditer(response))
+    if len(matches) != 1:
+        return None
+    body = matches[0].group("body").strip()
+    if not body:
+        return None
+    return body + "\n"
+
+
 def write_writer_artifacts(module_dir: Path, artifacts: Mapping[str, str]) -> None:
     """Write parsed writer artifacts after validating their basic shapes."""
     missing = [name for name in WRITER_ARTIFACTS if name not in artifacts]
@@ -2354,18 +2392,29 @@ def _apply_writer_correction(
         response = writer_corrector(context)
     if isinstance(response, Mapping):
         write_writer_artifacts(module_dir, response)
-    elif isinstance(response, str) and all(name in response for name in WRITER_ARTIFACTS):
-        write_writer_artifacts(module_dir, parse_writer_output_strict_json(response))
-    else:
-        emit_event(
-            "writer_correction_unparseable",
-            **_correction_event_fields(
-                gate=gate,
-                module_dir=module_dir,
-                plan_path=plan_path,
-            ),
-            response_preview=_correction_preview(response),
-        )
+        return
+    if isinstance(response, str):
+        # Strict-JSON-parse failures need all 4 artifact blocks back since the
+        # original parse was the failure mode itself. Other gates (word_count,
+        # plan_sections, formatting_standards, mdx_render) are module.md-only
+        # patches per the linear-writer-correction.md output contract.
+        if all(name in response for name in WRITER_ARTIFACTS):
+            write_writer_artifacts(module_dir, parse_writer_output_strict_json(response))
+            return
+        if gate != "strict_json_parse":
+            patched = parse_writer_correction_module_only(response)
+            if patched is not None:
+                (module_dir / "module.md").write_text(patched, encoding="utf-8")
+                return
+    emit_event(
+        "writer_correction_unparseable",
+        **_correction_event_fields(
+            gate=gate,
+            module_dir=module_dir,
+            plan_path=plan_path,
+        ),
+        response_preview=_correction_preview(response),
+    )
 
 
 def _apply_reviewer_correction(

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1628,10 +1628,12 @@ def parse_writer_output(output: str) -> dict[str, str]:
 #   ```markdown file=module.md
 #   ```markdown module.md
 #   ```module.md
-# The body capture stops at the next ``` fence terminator. Whitespace before
-# the trailing fence is allowed but content lines are preserved verbatim.
+#   ```file=module.md
+# The module.md label is REQUIRED — a bare ``` markdown ``` fence does not
+# qualify because the gate is "this is the patched module.md", not "any
+# markdown content". The body capture stops at the next ``` fence terminator.
 _MODULE_ONLY_FENCE_RE = re.compile(
-    r"```\s*(?:markdown(?:\s+(?:file=)?module\.md)?|(?:file=)?module\.md)\s*\n"
+    r"```\s*(?:markdown\s+(?:file=)?module\.md|(?:file=)?module\.md)\s*\n"
     r"(?P<body>.*?)\n```",
     re.DOTALL,
 )

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1623,19 +1623,13 @@ def parse_writer_output(output: str) -> dict[str, str]:
     return parse_writer_output_strict_json(output)
 
 
-# Match a single fenced block whose info string identifies module.md, in any
-# of the writer's known fence-info conventions:
-#   ```markdown file=module.md
-#   ```markdown module.md
-#   ```module.md
-#   ```file=module.md
-# The module.md label is REQUIRED — a bare ``` markdown ``` fence does not
-# qualify because the gate is "this is the patched module.md", not "any
-# markdown content". The body capture stops at the next ``` fence terminator.
-_MODULE_ONLY_FENCE_RE = re.compile(
-    r"```\s*(?:markdown\s+(?:file=)?module\.md|(?:file=)?module\.md)\s*\n"
-    r"(?P<body>.*?)\n```",
-    re.DOTALL,
+# Recognized info strings that identify a fence as the patched module.md.
+# Accepted: ``` ```markdown file=module.md```, ``` ```markdown module.md```,
+#           ``` ```module.md```, ``` ```file=module.md```.
+# The module.md label is REQUIRED — a bare ``` ```markdown``` fence does not
+# qualify because the gate semantics is "this is the patched module.md".
+_MODULE_FENCE_INFO_RE = re.compile(
+    r"\A\s*(?:markdown\s+(?:file=)?module\.md|(?:file=)?module\.md)\s*\Z",
 )
 
 
@@ -1644,20 +1638,41 @@ def parse_writer_correction_module_only(response: str) -> str | None:
 
     The patch-bounded writer-correction prompt (`linear-writer-correction.md`)
     instructs the writer to return EXACTLY one fenced block labeled
-    `module.md`. This parser accepts that format. Returns the module.md body
-    (with one trailing newline) when the response contains exactly one such
-    block, or None if the response has zero or multiple matching blocks.
+    `module.md`, with no leading or trailing prose. This parser accepts that
+    contract and rejects everything else:
 
-    Used by `_apply_writer_correction` for gates that only modify module.md
-    (everything in WRITER_CORRECTION_GATES except `strict_json_parse`, which
-    needs all four artifacts re-emitted).
+    - leading prose before the fence
+    - trailing prose after the fence
+    - multiple fenced blocks (e.g., a strict-json 4-block writer response
+      that incidentally contains a module.md fence)
+    - bare ``` ```markdown``` fences without the module.md label
+    - empty fence body
+
+    Returns the module.md body (with one trailing newline) on the contract
+    match, else None. Used by `_apply_writer_correction` for gates that only
+    modify module.md (everything in WRITER_CORRECTION_GATES except
+    `strict_json_parse`, which needs all four artifacts re-emitted).
     """
     if not isinstance(response, str):
         return None
-    matches = list(_MODULE_ONLY_FENCE_RE.finditer(response))
-    if len(matches) != 1:
+    stripped = response.strip()
+    # Hard guards: the entire response must be one triple-fence block.
+    if not (stripped.startswith("```") and stripped.endswith("```")):
         return None
-    body = matches[0].group("body").strip()
+    # Splitting on the triple-backtick delimiter gives exactly 3 parts when
+    # the response is one fence: ["", fence_content, ""]. More parts → there
+    # are extra fences (i.e., 4-block writer output) or stray ``` characters,
+    # which violates the contract.
+    parts = stripped.split("```")
+    if len(parts) != 3 or parts[0] != "" or parts[2] != "":
+        return None
+    fence_content = parts[1]
+    info_line, sep, body = fence_content.partition("\n")
+    if sep == "":  # No body delimiter — fence is malformed
+        return None
+    if not _MODULE_FENCE_INFO_RE.fullmatch(info_line):
+        return None
+    body = body.strip()
     if not body:
         return None
     return body + "\n"

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -62,7 +62,23 @@ For slovnyk.me rows, use only canonical `dictionary_slug` values defined by `scr
    presence. OMIT or rewrite anything unverifiable. Shipping unverified
    output for the reviewer to catch is itself a protocol violation.
 
-Return the visible `<plan_reasoning>` blocks first, then exactly these four fenced blocks, in this exact order. Do not add any other prose before, between, or after them.
+   You MUST record this scan as a visible `<end_gate>...</end_gate>` block
+   AFTER the four artifact fences. Required format:
+
+   ```
+   <end_gate>
+   actions: [rescanned_words, rescanned_sources, removed_unverified]
+   removed_count: N
+   summary: brief description of what was rescanned and what was removed.
+   </end_gate>
+   ```
+
+   Drop any action key that did not apply; `actions: []` is allowed when
+   the rescan removed nothing. Pipeline detects `gate_present=true` only
+   when this block exists. A missing block records `gate_present=false`,
+   and the writer is treated as having skipped the protocol.
+
+Return the visible `<plan_reasoning>` blocks first, then exactly these four fenced blocks in the order below, then the `<end_gate>` block. Do not add any other prose anywhere.
 
 ```markdown file=module.md
 ...

--- a/scripts/build/phases/linear-writer-correction.md
+++ b/scripts/build/phases/linear-writer-correction.md
@@ -1,18 +1,37 @@
 # ADR-008 Writer Correction
 
-You are correcting one failed deterministic Python QG gate.
+You are correcting one failed deterministic Python QG gate. Apply the smallest
+patch that clears the gate.
 
-Hard constraint: modify in place via append/insert, never re-author or regenerate.
+## Output contract — non-negotiable
 
-Forbidden phrases for this task:
-- regenerate
-- rewrite
-- produce again
-- start over
+Return **exactly one** fenced markdown block, formatted as:
 
-Do not use any forbidden phrase as an instruction or strategy. Do not discard
-the previously-passing prose. Keep the current structure and patch only the
-specific failed gate described below.
+```` markdown
+```markdown file=module.md
+... full patched module.md content ...
+```
+````
+
+That is the entire response. Do **not** include any of the following:
+- progress notes ("Done.", "Word count went from X → Y")
+- summaries of changes
+- explanatory prose before, between, or after the fenced block
+- the `activities.yaml`, `vocabulary.yaml`, or `resources.yaml` artifacts
+  (they are not being patched in this correction pass — leave them untouched
+  on disk)
+
+Any response that is not exactly one `markdown file=module.md` fenced block
+will be rejected as `writer_correction_unparseable` and the module will fail.
+
+## Hard constraint — patch-bounded
+
+Modify in place via append/insert. Never re-author or regenerate.
+
+Forbidden phrases as instructions or strategy: "regenerate", "rewrite",
+"produce again", "start over". Do not discard the previously-passing prose.
+Keep the current structure and patch only the specific failed gate described
+below.
 
 ## Gate Feedback
 
@@ -24,6 +43,8 @@ specific failed gate described below.
 
 The following prose passed other gates before this correction. Preserve it
 verbatim except for the smallest append/insert needed for the failed gate.
+Return the FULL patched module.md (the unchanged prose plus your minimal
+patch) inside the single fenced block above.
 
 ```markdown
 {MODULE_CONTENT}

--- a/tests/test_prompt_cot_tier1_scaffolding.py
+++ b/tests/test_prompt_cot_tier1_scaffolding.py
@@ -158,6 +158,24 @@ def test_writer_prompt_has_no_unresolved_placeholders(level: str, slug: str) -> 
 
 
 @pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+def test_writer_prompt_mandates_end_gate_block(level: str, slug: str) -> None:
+    """#1720 strand 2 — writer prompt must mandate emitting an
+    <end_gate>...</end_gate> block AFTER the four artifact fences. Pipeline
+    parser at linear_pipeline.py:_extract_writer_gate searches the output
+    for this block; missing block → gate_present=false."""
+    rendered = _writer_prompt(level, slug)
+    # The literal block tags must appear in the prompt's example.
+    assert "<end_gate>" in rendered and "</end_gate>" in rendered, (
+        f"Writer end_gate block mandate missing for {level}/{slug}"
+    )
+    # The action keys the parser recognizes must be in the example block.
+    for key in ("rescanned_words", "rescanned_sources", "removed_unverified"):
+        assert key in rendered, (
+            f"Writer end_gate action key {key!r} missing for {level}/{slug}"
+        )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
 @pytest.mark.parametrize("dim", QG_DIMS)
 def test_reviewer_prompt_has_cot_block(level: str, slug: str, dim: str) -> None:
     rendered = _reviewer_prompt(level, slug, dim)

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -32,3 +32,126 @@ def test_writer_correction_unparseable_response_emits_diagnostic(tmp_path: Path)
     assert [event["event"] for event in events] == ["writer_correction_unparseable"]
     assert events[0]["gate"] == "word_count"
     assert events[0]["response_preview"] == "I fixed the prose but emitted no artifacts."
+
+
+def test_parse_writer_correction_module_only_extracts_single_block() -> None:
+    """The patch-bounded correction parser accepts the contract format
+    (one fenced ``markdown file=module.md`` block, no other prose)."""
+    response = (
+        "```markdown file=module.md\n"
+        "## Morning\n\n"
+        "Patched prose with the missing 50 words appended.\n"
+        "```\n"
+    )
+    body = linear_pipeline.parse_writer_correction_module_only(response)
+    assert body is not None
+    assert body.startswith("## Morning")
+    assert "Patched prose" in body
+    assert body.endswith("\n")
+
+
+def test_parse_writer_correction_module_only_accepts_short_form_label() -> None:
+    """The parser also accepts ``markdown module.md`` and ``module.md``
+    fence-info conventions — writers vary on this minor formatting."""
+    response_short = "```markdown module.md\nbody1\n```"
+    response_bare = "```module.md\nbody2\n```"
+    assert linear_pipeline.parse_writer_correction_module_only(response_short) == "body1\n"
+    assert linear_pipeline.parse_writer_correction_module_only(response_bare) == "body2\n"
+
+
+def test_parse_writer_correction_module_only_rejects_zero_or_multi_blocks() -> None:
+    """No fenced block, or multiple fenced blocks, returns None — the
+    pipeline falls through to writer_correction_unparseable."""
+    assert linear_pipeline.parse_writer_correction_module_only("just prose") is None
+    multi = (
+        "```markdown file=module.md\nfirst\n```\n\n"
+        "```markdown file=module.md\nsecond\n```\n"
+    )
+    assert linear_pipeline.parse_writer_correction_module_only(multi) is None
+
+
+def test_parse_writer_correction_module_only_rejects_empty_body() -> None:
+    """A fenced block with no content is unparseable — writer is patching
+    nothing, which violates the patch-bounded contract."""
+    response = "```markdown file=module.md\n\n```"
+    assert linear_pipeline.parse_writer_correction_module_only(response) is None
+
+
+def test_writer_correction_module_only_writes_patched_module(tmp_path: Path) -> None:
+    """End-to-end: a contract-shaped response patches module.md and emits
+    no `writer_correction_unparseable` event."""
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(
+        "## Morning\n\nOriginal prose.\n", encoding="utf-8"
+    )
+    telemetry = tmp_path / "events.jsonl"
+    patched_response = (
+        "```markdown file=module.md\n"
+        "## Morning\n\n"
+        "Original prose. Patched insert: добрий ранок!\n"
+        "```\n"
+    )
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline._apply_writer_correction(
+            "word_count",
+            {"passed": False, "minimum": 100, "actual": 20},
+            qg_report={"gates": {}},
+            module_dir=module_dir,
+            plan_path=tmp_path / "plan.yaml",
+            writer_corrector=lambda _context: patched_response,
+            writer="codex-tools",
+            invoker=None,
+        )
+
+    # No diagnostic — the contract response parsed cleanly.
+    events = (
+        _events(telemetry)
+        if telemetry.exists() and telemetry.stat().st_size > 0
+        else []
+    )
+    assert events == [], (
+        f"Expected no events, got: {[e['event'] for e in events]}"
+    )
+    # module.md was patched with the new prose.
+    assert (module_dir / "module.md").read_text("utf-8") == (
+        "## Morning\n\nOriginal prose. Patched insert: добрий ранок!\n"
+    )
+
+
+def test_writer_correction_strict_json_parse_gate_still_requires_full_artifacts(
+    tmp_path: Path,
+) -> None:
+    """The strict_json_parse gate is the ONE writer-correction gate where
+    the response must include all 4 artifact blocks — single-block response
+    is unparseable for that gate because the original failure mode WAS the
+    parse, so all artifacts need to be re-emitted."""
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(
+        "## Morning\n\nOriginal prose.\n", encoding="utf-8"
+    )
+    telemetry = tmp_path / "events.jsonl"
+    # A response that would parse as module-only but fails the
+    # strict_json_parse contract because activities/vocabulary/resources
+    # are absent.
+    module_only_response = (
+        "```markdown file=module.md\n## Morning\n\nPatched.\n```\n"
+    )
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        linear_pipeline._apply_writer_correction(
+            "strict_json_parse",
+            {"passed": False, "reason": "missing artifact"},
+            qg_report={"gates": {}},
+            module_dir=module_dir,
+            plan_path=tmp_path / "plan.yaml",
+            writer_corrector=lambda _context: module_only_response,
+            writer="codex-tools",
+            invoker=None,
+        )
+
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == ["writer_correction_unparseable"]
+    assert events[0]["gate"] == "strict_json_parse"

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -85,6 +85,44 @@ def test_parse_writer_correction_module_only_rejects_bare_markdown_fence() -> No
     assert linear_pipeline.parse_writer_correction_module_only(response) is None
 
 
+def test_parse_writer_correction_module_only_rejects_full_4_block_response() -> None:
+    """A realistic 4-block writer response that happens to contain a
+    module.md fence MUST NOT parse as module-only. The contract is "the
+    entire response is a single fence" — extra fences disqualify it.
+
+    Caught upstream too: ``_apply_writer_correction`` checks
+    ``all(name in response for name in WRITER_ARTIFACTS)`` before reaching
+    the module-only path. But the parser itself must also reject this
+    case so it can be safely called out of context.
+    """
+    full_response = (
+        "```markdown file=module.md\n## Morning\nProse.\n```\n\n"
+        "```json file=activities.yaml\n[]\n```\n\n"
+        "```json file=vocabulary.yaml\n[]\n```\n\n"
+        "```json file=resources.yaml\n[]\n```\n"
+    )
+    assert linear_pipeline.parse_writer_correction_module_only(full_response) is None
+
+
+def test_parse_writer_correction_module_only_rejects_leading_prose() -> None:
+    """Any prose before the fence disqualifies the response — the contract
+    says "that is the entire response"."""
+    response = (
+        "Done. Here is the patched module:\n\n"
+        "```markdown file=module.md\nbody\n```\n"
+    )
+    assert linear_pipeline.parse_writer_correction_module_only(response) is None
+
+
+def test_parse_writer_correction_module_only_rejects_trailing_prose() -> None:
+    """Any prose after the fence disqualifies the response."""
+    response = (
+        "```markdown file=module.md\nbody\n```\n\n"
+        "Word count went from 996 → 1325.\n"
+    )
+    assert linear_pipeline.parse_writer_correction_module_only(response) is None
+
+
 def test_writer_correction_module_only_writes_patched_module(tmp_path: Path) -> None:
     """End-to-end: a contract-shaped response patches module.md and emits
     no `writer_correction_unparseable` event."""

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -77,6 +77,14 @@ def test_parse_writer_correction_module_only_rejects_empty_body() -> None:
     assert linear_pipeline.parse_writer_correction_module_only(response) is None
 
 
+def test_parse_writer_correction_module_only_rejects_bare_markdown_fence() -> None:
+    """A bare ``markdown`` fence (without module.md label) does NOT qualify.
+    The gate semantics is "this is the patched module.md" — bare markdown
+    might be a knowledge_packet, a draft excerpt, or unrelated content."""
+    response = "```markdown\nsome unrelated markdown content\n```"
+    assert linear_pipeline.parse_writer_correction_module_only(response) is None
+
+
 def test_writer_correction_module_only_writes_patched_module(tmp_path: Path) -> None:
     """End-to-end: a contract-shaped response patches module.md and emits
     no `writer_correction_unparseable` event."""


### PR DESCRIPTION
## Summary

Implements **strands 2 and 3** of the 3-strand follow-up identified in #1720 from the 2026-05-06 bakeoff. Strand 1 (tool-theatre telemetry detection) is left for a follow-up — it requires telemetry-parser changes to cross-reference `<plan_reasoning verification>` tool citations against actual `function_call` events, which is a larger surface.

### Strand 2 — `<end_gate>` block mandate

The bakeoff showed all 3 writers had `gate_present=false`. Root cause: `_extract_writer_gate` (linear_pipeline.py:1132) ALREADY supports parsing an `<end_gate>...</end_gate>` block; the writer prompt just didn't tell the writer to emit one. Pure prompt-contract fix.

### Strand 3 — patch-bounded writer-correction output contract

The bakeoff showed all 3 writers' correction-pass responses emitted `writer_correction_unparseable` for `word_count`, `plan_sections`, `vesum_verified`. Root cause: the correction prompt told the writer "modify in place via append/insert" but the parser expected all 4 artifact blocks back. Mismatched contract → conversational prose responses.

Two-sided fix:
- Prompt: explicit single-fence `markdown file=module.md` contract, forbidden phrases ("progress notes", "summaries", etc.)
- Parser: new `parse_writer_correction_module_only()` accepts the contract format. Reserved 4-block requirement for `strict_json_parse` only (where the original parse WAS the failure mode).

YAML artifacts stay untouched on disk during module-only corrections — matches ADR-008 intent + saves ~5x prompt tokens.

## Test plan

- [x] `pytest tests/test_prompt_template_render.py tests/test_prompt_cot_tier1_scaffolding.py tests/test_writer_correction_no_op_diagnostic.py tests/test_no_rewrite_contract.py` — 129 passed locally
- [x] New test: `test_writer_prompt_mandates_end_gate_block` — locks in strand 2 prompt contract
- [x] 6 new tests in `test_writer_correction_no_op_diagnostic.py` — cover positive path (single-block parse + writes module.md), negative paths (zero/multi/empty blocks), and the `strict_json_parse` gate exemption
- [x] `test_writer_correction_unparseable_response_emits_diagnostic` (existing) still passes — backward-compat preserved
- [x] `test_no_rewrite_contract.py` (ADR-007 invariant test) still passes — module-only correction is patch-bounded, not regen
- [ ] **Re-run bakeoff** after merge. Acceptance per #1720: `tool_calls_total > 0` (strand 1, NOT yet fixed — this PR doesn't address), `gate_present=true` (strand 2 ✓), at least 1 writer publishes (strand 3 ✓), at least 1 review runs (depends on strand 3 unblocking publication)

## Files changed

- `scripts/build/phases/linear-write.md` — strand 2 prompt mandate
- `scripts/build/phases/linear-writer-correction.md` — strand 3 prompt rewrite
- `scripts/build/linear_pipeline.py` — strand 3 parser + dispatch
- `tests/test_prompt_cot_tier1_scaffolding.py` — strand 2 lock-in
- `tests/test_writer_correction_no_op_diagnostic.py` — strand 3 lock-in (6 new tests)

## Closes / refs

- Refs #1720 (strands 2 + 3; strand 1 stays open)
- Refs #1577 / EPIC reboot pipeline
- Predecessor: #1719 (V7 prompt strengthening — Q4 visible CoT win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)