### PR TITLE
feat(prompts): tool-theatre detection — cross-check plan_reasoning citations vs trace (#1720 strand 1)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -194,6 +194,7 @@ TELEMETRY_MAX_QUOTES = 5
 TELEMETRY_MAX_QUOTE_CHARS = 240
 TELEMETRY_MAX_MAPPING_CHARS = 500
 TELEMETRY_MAX_FAILED_WORDS = 5
+TELEMETRY_MAX_THEATRE_VIOLATIONS = 25
 CORRECTION_PREVIEW_CHARS = 200
 _TELEMETRY_EVENT_SINK: Callable[..., None] | None = None
 
@@ -1221,8 +1222,12 @@ _PLAN_REASONING_BLOCK_RE = re.compile(
     r"<plan_reasoning\b[^>]*>(.*?)</plan_reasoning>",
     re.DOTALL | re.IGNORECASE,
 )
+_PLAN_REASONING_ELEMENT_RE = re.compile(
+    r"<plan_reasoning\b(?P<attrs>[^>]*)>(?P<body>.*?)</plan_reasoning>",
+    re.DOTALL | re.IGNORECASE,
+)
 _TOOL_CITATION_RE = re.compile(
-    r"`(?P<name>(?:mcp__sources__|search_|verify_|check_|query_|translate_)\w+)`"
+    r"`?(?P<name>(?:mcp__sources__|search_|verify_|check_|query_|translate_)\w+)`?"
 )
 
 
@@ -1240,12 +1245,36 @@ def _tool_name_from_call(call: Any) -> str:
     )
 
 
+def _markdown_fence_spans(text: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    start: int | None = None
+    for match in re.finditer(r"^```", text, flags=re.MULTILINE):
+        if start is None:
+            start = match.start()
+        else:
+            spans.append((start, match.end()))
+            start = None
+    if start is not None:
+        spans.append((start, len(text)))
+    return spans
+
+
+def _position_in_spans(position: int, spans: list[tuple[int, int]]) -> bool:
+    return any(start <= position < end for start, end in spans)
+
+
 def _cited_plan_reasoning_tools(writer_output: str) -> set[str]:
-    return {
-        _normalize_tool_citation_name(match)
-        for block in _PLAN_REASONING_BLOCK_RE.findall(writer_output)
-        for match in _TOOL_CITATION_RE.findall(block)
-    }
+    cited: set[str] = set()
+    fenced_spans = _markdown_fence_spans(writer_output)
+    for match in _PLAN_REASONING_ELEMENT_RE.finditer(writer_output):
+        if _position_in_spans(match.start(), fenced_spans):
+            continue
+        searchable = f"{match.group('attrs')} {match.group('body')}"
+        cited.update(
+            _normalize_tool_citation_name(citation)
+            for citation in _TOOL_CITATION_RE.findall(searchable)
+        )
+    return cited
 
 
 def detect_tool_theatre(
@@ -1452,7 +1481,9 @@ def emit_writer_response_telemetry(
         "removed_via_gate": int(gate["removed_count"]),
     }
     theatre_violations = detect_tool_theatre(output, list(tool_calls or []))
-    summary["tool_theatre_violations"] = theatre_violations
+    capped_theatre_violations = theatre_violations[:TELEMETRY_MAX_THEATRE_VIOLATIONS]
+    summary["tool_theatre_violations"] = capped_theatre_violations
+    summary["tool_theatre_violation_count"] = len(theatre_violations)
     if theatre_violations:
         called_tools = {_tool_name_from_call(call) for call in tool_calls or []}
         called_tools.discard("")
@@ -1461,7 +1492,8 @@ def emit_writer_response_telemetry(
             "writer_tool_theatre",
             writer=writer,
             module=module,
-            violations=theatre_violations,
+            violations=capped_theatre_violations,
+            violation_count=len(theatre_violations),
             cited_count=len(_cited_plan_reasoning_tools(output)),
             called_count=len(called_tools),
         )

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -62,6 +62,7 @@ WRITER_ARTIFACTS = (
 )
 
 PYTHON_QG_GATE_ORDER = (
+    "tool_theatre",
     "word_count",
     "plan_sections",
     "formatting_standards",
@@ -80,6 +81,7 @@ PYTHON_QG_GATE_ORDER = (
 WRITER_CORRECTION_GATES = frozenset(
     {
         "strict_json_parse",
+        "tool_theatre",
         "word_count",
         "plan_sections",
         "formatting_standards",
@@ -167,8 +169,11 @@ WRITER_TOOL_NAMES = frozenset(
         "verify_lemma",
         "search_definitions",
         "search_definitions_slovnyk",
+        "search_esum",
         "search_grinchenko_1907",
+        "search_heritage",
         "search_literary",
+        "search_slovnyk_me",
         "search_style_guide",
         "search_idioms",
         "query_pravopys",
@@ -1212,6 +1217,51 @@ def _mapping_from_tool_call(call: Any) -> dict[str, Any]:
     return data
 
 
+_PLAN_REASONING_BLOCK_RE = re.compile(
+    r"<plan_reasoning\b[^>]*>(.*?)</plan_reasoning>",
+    re.DOTALL | re.IGNORECASE,
+)
+_TOOL_CITATION_RE = re.compile(
+    r"`(?P<name>(?:mcp__sources__|search_|verify_|check_|query_|translate_)\w+)`"
+)
+
+
+def _normalize_tool_citation_name(raw_tool: Any) -> str:
+    tool = str(raw_tool or "").strip()
+    if tool.startswith("mcp__sources__"):
+        tool = tool.removeprefix("mcp__sources__")
+    return tool
+
+
+def _tool_name_from_call(call: Any) -> str:
+    mapped = _mapping_from_tool_call(call)
+    return _normalize_tool_citation_name(
+        mapped.get("tool") or mapped.get("tool_name") or mapped.get("name")
+    )
+
+
+def _cited_plan_reasoning_tools(writer_output: str) -> set[str]:
+    return {
+        _normalize_tool_citation_name(match)
+        for block in _PLAN_REASONING_BLOCK_RE.findall(writer_output)
+        for match in _TOOL_CITATION_RE.findall(block)
+    }
+
+
+def detect_tool_theatre(
+    writer_output: str,
+    tool_calls: list[Mapping[str, Any]],
+) -> list[str]:
+    """Return cited plan-reasoning tool names absent from the actual trace."""
+    cited = _cited_plan_reasoning_tools(writer_output)
+    called = {_tool_name_from_call(call) for call in tool_calls}
+    called.discard("")
+
+    # Canonical-only: aliases/family maps do not count. The writer must cite
+    # the actual tool name it called so telemetry cannot be satisfied by prose.
+    return sorted(cited - called)
+
+
 def _runtime_tool_calls(result: Any) -> list[dict[str, Any]]:
     calls: list[dict[str, Any]] = []
     for attr in ("tool_calls", "mcp_tool_calls"):
@@ -1401,6 +1451,20 @@ def emit_writer_response_telemetry(
         "end_gate_fired": bool(gate["gate_present"]),
         "removed_via_gate": int(gate["removed_count"]),
     }
+    theatre_violations = detect_tool_theatre(output, list(tool_calls or []))
+    summary["tool_theatre_violations"] = theatre_violations
+    if theatre_violations:
+        called_tools = {_tool_name_from_call(call) for call in tool_calls or []}
+        called_tools.discard("")
+        _emit(
+            event_sink,
+            "writer_tool_theatre",
+            writer=writer,
+            module=module,
+            violations=theatre_violations,
+            cited_count=len(_cited_plan_reasoning_tools(output)),
+            called_count=len(called_tools),
+        )
     _emit(event_sink, "phase_writer_summary", writer=writer, module=module, **summary)
     return summary
 
@@ -2412,9 +2476,9 @@ def _apply_writer_correction(
         return
     if isinstance(response, str):
         # Strict-JSON-parse failures need all 4 artifact blocks back since the
-        # original parse was the failure mode itself. Other gates (word_count,
-        # plan_sections, formatting_standards, mdx_render) are module.md-only
-        # patches per the linear-writer-correction.md output contract.
+        # original parse was the failure mode itself. Other gates are
+        # module.md-only patches per the linear-writer-correction.md output
+        # contract.
         if all(name in response for name in WRITER_ARTIFACTS):
             write_writer_artifacts(module_dir, parse_writer_output_strict_json(response))
             return

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -61,6 +61,16 @@ For slovnyk.me rows, use only canonical `dictionary_slug` values defined by `scr
    ran, every cited source for grounding, every quote for literal corpus
    presence. OMIT or rewrite anything unverifiable. Shipping unverified
    output for the reviewer to catch is itself a protocol violation.
+   **Tool-citation honesty (mandatory).** Every tool name you cite inside
+   a `<plan_reasoning verification="...">` attribute or block body MUST
+   correspond to an actual tool call you made on this turn. The pipeline
+   cross-references citations against the trace and treats unmatched citations
+   as a hard fail (`tool_theatre`). Citing a tool you did not call to satisfy
+   the verification rubric — without doing the verification — is the canonical
+   theatre failure and will block publication. If you intend to cite
+   `search_heritage`, call `search_heritage`. If you intend to cite the
+   underlying `search_grinchenko_1907`, call that. Canonical names only —
+   no family aliases.
 
    You MUST record this scan as a visible `<end_gate>...</end_gate>` block
    AFTER the four artifact fences. Required format:

--- a/scripts/build/phases/linear-writer-correction.md
+++ b/scripts/build/phases/linear-writer-correction.md
@@ -39,6 +39,29 @@ below.
 {CORRECTION_SECTION}
 ```
 
+## When `gate = tool_theatre`
+
+Your previous turn cited tool names in `<plan_reasoning verification>` that
+you did not actually call. The unmatched citations are listed under
+`diagnostic.violations` in the gate feedback above.
+
+Pick exactly one path. Single fenced ```` ```markdown file=module.md ```` block
+as your entire response, no prose around it.
+
+1. **Call them now.** Make the tool calls you cited (each one), then re-emit
+   `module.md` with the actual tool results in the verification block. The
+   verification text should reference the result, not the tool name in isolation.
+2. **Remove the false citations.** Delete the unmatched tool names from the
+   verification blocks; replace each removed citation with the verbatim text
+   "verification not performed" so it's auditable.
+
+No third option. Citing the same tools again without calling them = same
+failure, same gate, exhausted retry.
+
+Verbatim citation rule: every tool name you cite in
+`<plan_reasoning verification>` must correspond to a tool call you actually
+made in this turn's trace.
+
 ## Previously-Passing Prose
 
 The following prose passed other gates before this correction. Preserve it

--- a/scripts/build/phases/linear-writer-correction.md
+++ b/scripts/build/phases/linear-writer-correction.md
@@ -56,7 +56,8 @@ as your entire response, no prose around it.
    "verification not performed" so it's auditable.
 
 No third option. Citing the same tools again without calling them = same
-failure, same gate, exhausted retry.
+failure, same gate, exhausted retry. Removing backticks while keeping the
+uncalled tool name in prose is still a citation and still fails.
 
 Verbatim citation rule: every tool name you cite in
 `<plan_reasoning verification>` must correspond to a tool call you actually

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -257,6 +257,18 @@ def _run(args: argparse.Namespace) -> int:
         _phase_done(phase, started_at, level=level, slug=slug)
 
         if args.dry_run:
+            sections = [
+                str(item.get("section"))
+                for item in plan.get("content_outline", [])
+                if isinstance(item, Mapping) and item.get("section")
+            ]
+            linear_pipeline.emit_writer_response_telemetry(
+                "",
+                writer=writer,
+                module=f"{level.lower()}/{int(plan['sequence'])}",
+                sections=sections,
+                tool_calls=[],
+            )
             emit_event(
                 "module_done",
                 level=level,

--- a/tests/test_prompt_cot_tier1_scaffolding.py
+++ b/tests/test_prompt_cot_tier1_scaffolding.py
@@ -176,6 +176,24 @@ def test_writer_prompt_mandates_end_gate_block(level: str, slug: str) -> None:
 
 
 @pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+def test_writer_prompt_mandates_tool_call_match(level: str, slug: str) -> None:
+    """#1720 strand 1 — visible tool citations must match real calls."""
+    rendered = _writer_prompt(level, slug)
+
+    for text in (
+        "Tool-citation honesty (mandatory)",
+        "Every tool name you cite inside",
+        "actual tool call you made on this turn",
+        "hard fail (`tool_theatre`)",
+        "Canonical names only",
+        "no family aliases",
+    ):
+        assert text in rendered, (
+            f"Writer tool-citation honesty rule missing {text!r} for {level}/{slug}"
+        )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
 @pytest.mark.parametrize("dim", QG_DIMS)
 def test_reviewer_prompt_has_cot_block(level: str, slug: str, dim: str) -> None:
     rendered = _reviewer_prompt(level, slug, dim)

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -51,6 +51,38 @@ def test_detect_tool_theatre_only_scans_plan_reasoning_blocks() -> None:
     assert linear_pipeline.detect_tool_theatre(writer_output, []) == []
 
 
+def test_detect_tool_theatre_scans_plan_reasoning_attributes() -> None:
+    writer_output = (
+        '<plan_reasoning section="intro" verification="checked with `verify_words`">'
+        "No citation in the body."
+        "</plan_reasoning>"
+    )
+
+    assert linear_pipeline.detect_tool_theatre(writer_output, []) == ["verify_words"]
+
+
+def test_detect_tool_theatre_scans_unbackticked_tool_names() -> None:
+    writer_output = (
+        '<plan_reasoning section="intro">'
+        "Verified using search_heritage."
+        "</plan_reasoning>"
+    )
+
+    assert linear_pipeline.detect_tool_theatre(writer_output, []) == [
+        "search_heritage"
+    ]
+
+
+def test_detect_tool_theatre_ignores_plan_reasoning_inside_fences() -> None:
+    writer_output = (
+        "```markdown file=module.md\n"
+        "<plan_reasoning section=\"example\">`search_heritage`</plan_reasoning>\n"
+        "```\n"
+    )
+
+    assert linear_pipeline.detect_tool_theatre(writer_output, []) == []
+
+
 def test_detect_tool_theatre_handles_multiple_blocks() -> None:
     writer_output = (
         '<plan_reasoning section="intro">`verify_words` checked.</plan_reasoning>\n'
@@ -102,10 +134,13 @@ def test_writer_summary_emits_tool_theatre_event(tmp_path: Path) -> None:
         event for event in events if event["event"] == "phase_writer_summary"
     )
     assert summary["tool_theatre_violations"] == ["search_heritage"]
+    assert summary["tool_theatre_violation_count"] == 1
     assert theatre_event["violations"] == ["search_heritage"]
+    assert theatre_event["violation_count"] == 1
     assert theatre_event["cited_count"] == 2
     assert theatre_event["called_count"] == 1
     assert summary_event["tool_theatre_violations"] == ["search_heritage"]
+    assert summary_event["tool_theatre_violation_count"] == 1
 
 
 def test_writer_correction_unparseable_response_emits_diagnostic(tmp_path: Path) -> None:

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -10,6 +10,104 @@ def _events(path: Path) -> list[dict[str, object]]:
     return [json.loads(line) for line in path.read_text("utf-8").splitlines()]
 
 
+def test_detect_tool_theatre_returns_unmatched_citations() -> None:
+    writer_output = (
+        '<plan_reasoning section="intro" verification="checked">'
+        "Verified lemmas with `verify_words`; heritage via `search_heritage`."
+        "</plan_reasoning>"
+    )
+
+    assert linear_pipeline.detect_tool_theatre(
+        writer_output,
+        [{"tool": "verify_words"}],
+    ) == ["search_heritage"]
+
+
+def test_detect_tool_theatre_normalizes_mcp_prefix() -> None:
+    writer_output = (
+        '<plan_reasoning section="intro">'
+        "Verified lemmas with `mcp__sources__verify_words`."
+        "</plan_reasoning>"
+    )
+
+    assert linear_pipeline.detect_tool_theatre(
+        writer_output,
+        [{"tool": "verify_words"}],
+    ) == []
+
+
+def test_detect_tool_theatre_empty_input() -> None:
+    assert linear_pipeline.detect_tool_theatre("", []) == []
+
+
+def test_detect_tool_theatre_only_scans_plan_reasoning_blocks() -> None:
+    writer_output = (
+        "```markdown file=module.md\n"
+        "This lesson mentions that `search_heritage` is the function name.\n"
+        "```\n\n"
+        '<plan_reasoning section="intro">No tool citation here.</plan_reasoning>'
+    )
+
+    assert linear_pipeline.detect_tool_theatre(writer_output, []) == []
+
+
+def test_detect_tool_theatre_handles_multiple_blocks() -> None:
+    writer_output = (
+        '<plan_reasoning section="intro">`verify_words` checked.</plan_reasoning>\n'
+        '<plan_reasoning section="heritage">`search_heritage` checked.</plan_reasoning>'
+    )
+
+    assert linear_pipeline.detect_tool_theatre(writer_output, []) == [
+        "search_heritage",
+        "verify_words",
+    ]
+
+
+def test_detect_tool_theatre_returns_all_citations_when_trace_empty() -> None:
+    writer_output = (
+        '<plan_reasoning section="intro">'
+        "`verify_words`, `search_heritage`, and `query_pravopys` checked."
+        "</plan_reasoning>"
+    )
+
+    assert linear_pipeline.detect_tool_theatre(writer_output, []) == [
+        "query_pravopys",
+        "search_heritage",
+        "verify_words",
+    ]
+
+
+def test_writer_summary_emits_tool_theatre_event(tmp_path: Path) -> None:
+    writer_output = (
+        '<plan_reasoning section="intro">'
+        "`verify_words` checked; `search_heritage` checked."
+        "</plan_reasoning>"
+    )
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        summary = linear_pipeline.emit_writer_response_telemetry(
+            writer_output,
+            writer="codex-tools",
+            module="a1/test",
+            sections=["intro"],
+            tool_calls=[{"tool": "verify_words"}],
+        )
+
+    events = _events(telemetry)
+    theatre_event = next(
+        event for event in events if event["event"] == "writer_tool_theatre"
+    )
+    summary_event = next(
+        event for event in events if event["event"] == "phase_writer_summary"
+    )
+    assert summary["tool_theatre_violations"] == ["search_heritage"]
+    assert theatre_event["violations"] == ["search_heritage"]
+    assert theatre_event["cited_count"] == 2
+    assert theatre_event["called_count"] == 1
+    assert summary_event["tool_theatre_violations"] == ["search_heritage"]
+
+
 def test_writer_correction_unparseable_response_emits_diagnostic(tmp_path: Path) -> None:
     module_dir = tmp_path / "module"
     module_dir.mkdir()
@@ -163,6 +261,56 @@ def test_writer_correction_module_only_writes_patched_module(tmp_path: Path) -> 
     # module.md was patched with the new prose.
     assert (module_dir / "module.md").read_text("utf-8") == (
         "## Morning\n\nOriginal prose. Patched insert: добрий ранок!\n"
+    )
+
+
+def test_writer_correction_handles_tool_theatre_gate(tmp_path: Path) -> None:
+    """The tool_theatre gate uses the module-only correction path."""
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(
+        "## Morning\n\nOriginal prose with `search_heritage` theatre.\n",
+        encoding="utf-8",
+    )
+    reports = [
+        {
+            "gates": {
+                "tool_theatre": {
+                    "passed": False,
+                    "violations": ["search_heritage"],
+                },
+                "passed": False,
+            }
+        },
+        {"gates": {"tool_theatre": {"passed": True}, "passed": True}},
+    ]
+    patched_response = (
+        "```markdown file=module.md\n"
+        "## Morning\n\n"
+        "Original prose with verification not performed theatre.\n"
+        "```\n"
+    )
+
+    def qg_runner() -> dict[str, object]:
+        return reports.pop(0)
+
+    def writer_corrector(
+        context: linear_pipeline.CorrectionContext,
+    ) -> str:
+        assert context.gate == "tool_theatre"
+        assert "search_heritage" in context.prompt
+        return patched_response
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        tmp_path / "plan.yaml",
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+    )
+
+    assert report["gates"]["passed"] is True
+    assert (module_dir / "module.md").read_text("utf-8") == (
+        "## Morning\n\nOriginal prose with verification not performed theatre.\n"
     )
 
 


### PR DESCRIPTION
## Summary

Closes the last open strand of #1720 — the bakeoff blocker.

- New `detect_tool_theatre()` in `linear_pipeline.py` cross-references tool names cited in `<plan_reasoning verification>` blocks against the actual writer turn trace.
- New `writer_tool_theatre` JSONL event surfaces violations to telemetry/aggregator.
- `tool_theatre` joins `WRITER_CORRECTION_GATES`, so the existing correction-pass loop (built in #1721) handles the failure with a single-fence module-only retry.
- Writer prompt mandates "tool-citation honesty" — citing a tool you did not call is a hard fail.
- Correction-pass prompt gives the writer a binary choice: call-the-cited-tools, or remove-the-false-citations.

## Test plan

- [x] `pytest tests/test_writer_correction_no_op_diagnostic.py` — new detection/correction cases pass.
- [x] `pytest tests/test_prompt_cot_tier1_scaffolding.py` — new prompt-rule test passes; mentally-deleting the rule fails the test.
- [x] `bakeoff_aggregate.py` runs without TypeError on the new fields.
- [x] `v7_build.py --dry-run` emits `phase_writer_summary` with `tool_theatre_violations` populated.

## Why this is the bakeoff blocker

Strands 2+3 (#1721) made writers emit `<end_gate>` and made the correction pass parseable. But all 3 writers in the 2026-05-06 bakeoff cited tools without calling them — `tool_calls_total = 0` across the board. Until that loop closes, the bakeoff cannot produce decision-grade signal for writer-selection per the agent-responsibilities ADR.

Reviewed-By: claude-opus-4-7 (1720-strand-1-review)