### PR TITLE
fix(python_qg): vesum_verified treats -ся as postfix; allows proper-noun case forms (#1722)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -369,6 +369,9 @@ _BRACES_RE = re.compile(r"\{[А-ЯІЇЄҐа-яіїєґ'ʼ]{1,12}\}")
 _MORPHEME_FRAGMENT_RE = re.compile(
     r"(?<![А-ЯІЇЄҐа-яіїєґ'ʼA-Za-z0-9])-[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'ʼ]*"
 )
+_STANDALONE_POSTFIX_FRAGMENTS = frozenset(
+    {"ся", "сь", "тся", "тсь", "ться", "шся", "шсь", "чся", "чсь"}
+)
 
 # JSX self-closing or paired component blocks. Treated as one structural unit
 # in `_immersion_gate`'s long-sentence detection so prop arrays like
@@ -3369,8 +3372,7 @@ def _vesum_gate(
     surface_pairs = sorted(
         {
             (word, word.lower())
-            for raw in _UK_WORD_RE.findall(text)
-            for word in [raw.strip("-'ʼ")]
+            for word in _iter_vesum_word_surfaces(text)
             if len(word) >= VESUM_MIN_WORD_LENGTH
         }
     )
@@ -3392,6 +3394,24 @@ def _vesum_gate(
         return {"passed": False, "error": str(exc), "checked": len(unchecked_pairs)}
 
     missing_lc = {word for word, matches in verified.items() if not matches}
+    if missing_lc:
+        original_case_words = sorted(
+            {
+                surface
+                for surface, lower in unchecked_pairs
+                if lower in missing_lc and surface != lower
+            }
+        )
+        try:
+            original_case_verified = verify_words_fn(original_case_words)
+        except Exception as exc:
+            return {"passed": False, "error": str(exc), "checked": len(unchecked_pairs)}
+        resolved_lc = {
+            surface.lower()
+            for surface, matches in original_case_verified.items()
+            if matches
+        }
+        missing_lc -= resolved_lc
     missing = sorted(
         {surface for surface, lower in unchecked_pairs if lower in missing_lc}
     )
@@ -3402,6 +3422,38 @@ def _vesum_gate(
         "missing": missing[:100],
         "missing_count": len(missing),
     }
+
+
+def _iter_vesum_word_surfaces(text: str) -> list[str]:
+    """Extract Ukrainian surface forms that are meaningful VESUM candidates."""
+    words: list[str] = []
+    for match in _UK_WORD_RE.finditer(text):
+        if _touches_blank_marker(text, match.start(), match.end()):
+            continue
+        raw = match.group(0)
+        if _looks_like_elided_notation(text, match.start(), raw):
+            continue
+        word = raw.strip("-'ʼ")
+        if not word:
+            continue
+        if word.lower() in _STANDALONE_POSTFIX_FRAGMENTS:
+            continue
+        words.append(word)
+    return words
+
+
+def _touches_blank_marker(text: str, start: int, end: int) -> bool:
+    """Return true when a regex word is a stem fragment next to `__` blanks."""
+    return (start > 0 and text[start - 1] == "_") or (
+        end < len(text) and text[end] == "_"
+    )
+
+
+def _looks_like_elided_notation(text: str, start: int, raw: str) -> bool:
+    """Skip clipped pronunciation notes like `прокидаюс'`, not quoted words."""
+    return raw.endswith(("'", "ʼ")) and not (
+        start > 0 and text[start - 1] in {"'", "ʼ"}
+    )
 
 
 def _proper_name_whitelist_lc() -> frozenset[str]:

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import yaml
+
+from scripts.build.linear_pipeline import _iter_vesum_word_surfaces, _vesum_gate
+
+
+def test_reflexive_verb_not_split() -> None:
+    text = (
+        "вмиваюся прокидаєшся вмивається вмиваємося вмиваєтеся "
+        "вмиваються ся сь тся ться шся 'навчаюся' прокидаюс'"
+    )
+
+    tokens = _iter_vesum_word_surfaces(text)
+
+    assert tokens == [
+        "вмиваюся",
+        "прокидаєшся",
+        "вмивається",
+        "вмиваємося",
+        "вмиваєтеся",
+        "вмиваються",
+        "навчаюся",
+    ]
+    assert not {"шся", "тся", "ться"} & set(tokens)
+
+
+def test_compound_hyphen_word_not_split() -> None:
+    text = "синьо-жовтий англо-український"
+
+    tokens = _iter_vesum_word_surfaces(text)
+
+    assert tokens == ["синьо-жовтий", "англо-український"]
+
+
+def test_em_dash_splits_sentences() -> None:
+    text = "Привіт — як справи?"
+
+    tokens = _iter_vesum_word_surfaces(text)
+
+    assert tokens == ["Привіт", "як", "справи"]
+
+
+def test_proper_noun_genitive_resolves() -> None:
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        return {
+            word: (
+                [{"lemma": word}]
+                if word in {"вірш", "Білоуса", "Дмитра"}
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="Вірш Дмитра Білоуса.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is True
+    assert seen == [["білоуса", "вірш", "дмитра"], ["Білоуса", "Дмитра"]]
+
+
+def test_unknown_capitalized_name_stays_missing() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {word: [] for word in words}
+
+    gate = _vesum_gate(
+        module_text="Дрімлюша Драбадана тут немає.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["Драбадана", "Дрімлюша", "немає", "тут"]
+
+
+def test_my_morning_module_passes_vesum_gate() -> None:
+    module_text = """
+## Діалог
+— Коли ти прокидаєшся?
+— Я прокидаюся о сьомій і вмиваюся.
+
+У вправі є форма Дмитра Білоуса.
+"""
+    activities = yaml.safe_load(
+        """
+- id: a1-20-reflexive-postfix
+  type: fill-in
+  items:
+    - sentence: Я вмиваю__ о сьомій.
+      answer: ся
+      options: [ся, сь, тся]
+    - sentence: Він прокидаєть__ пізно.
+      answer: ся
+      options: [ся, сь, шся]
+    - sentence: Вона вмиваєть__ холодною водою.
+      answer: ся
+      options: [ся, сь, ться]
+"""
+    )
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        valid = {
+            "коли",
+            "ти",
+            "прокидаєшся",
+            "прокидаюся",
+            "сьомій",
+            "вмиваюся",
+            "вправі",
+            "він",
+            "вона",
+            "форма",
+            "діалог",
+            "пізно",
+            "холодною",
+            "водою",
+        }
+        original_case_valid = {"Білоуса", "Дмитра"}
+        return {
+            word: (
+                [{"lemma": word}]
+                if word in valid or word in original_case_valid
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text=module_text,
+        activities=activities,
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []


### PR DESCRIPTION
## Summary

The `vesum_verified` gate of `python_qg` was treating reflexive-postfix exercise fragments (`шся`, `тся`, `ться`) and blank-adjacent stems (`вмиваєть__`, `прокидаєть__`) as VESUM-checkable words. It also lowercased proper-noun case forms before lookup, so VESUM surface forms like `Білоуса` and `Дмитра` were missed.

This was the terminal failure for the 2026-05-06 bakeoff path on A1/20 `my-morning`.

- VESUM token extraction now skips blank-adjacent stems and standalone postfix fragments while preserving full reflexive forms such as `вмиваюся`, `прокидаєшся`, and `вмивається`.
- Compound hyphen-words such as `синьо-жовтий` remain single tokens; em-dashes still split text.
- Proper-noun case forms resolve by retrying missing capitalized surfaces against VESUM with original casing, so unknown fictional names still fail instead of being silently whitelisted.
- Claude adversarial review feedback was applied: straight-apostrophe quoted real words stay tokenized, while clipped pronunciation notation like `прокидаюс'` is skipped.

## Test plan

- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_vesum_verified_postfix.py -v` — 6 cases pass.
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_linear_pipeline_telemetry.py tests/test_vesum_verified_postfix.py -v` — 10 cases pass.
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_vesum_verified_postfix.py`.
- [x] `git diff --check origin/main..HEAD`.
- [x] Re-running `run_python_qg` on `/Users/krisztiankoos/projects/learn-ukrainian/audit/bakeoff-2026-05-05/claude/module.md` shows `vesum_verified: passed: true`, `missing: []`.

## Related

Closes #1722.
Companion to #1720 strand 1 — together these unblock the bakeoff.

Reviewed-By: claude-opus-4-7 (1722-review)