### PR TITLE
fix(python_qg): citations_resolve loads plan_references as allowlist with author+grade+page matching (#1723)

### DIFF
--- a/scripts/build/citation_matcher.py
+++ b/scripts/build/citation_matcher.py
@@ -1,0 +1,111 @@
+"""Structured textbook citation matching for Python QG."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+_CYRILLIC_TO_LATIN = str.maketrans(
+    {
+        "а": "a",
+        "б": "b",
+        "в": "v",
+        "г": "h",
+        "ґ": "g",
+        "д": "d",
+        "е": "e",
+        "є": "ie",
+        "ж": "zh",
+        "з": "z",
+        "и": "y",
+        "і": "i",
+        "ї": "i",
+        "й": "i",
+        "к": "k",
+        "л": "l",
+        "м": "m",
+        "н": "n",
+        "о": "o",
+        "п": "p",
+        "р": "r",
+        "с": "s",
+        "т": "t",
+        "у": "u",
+        "ф": "f",
+        "х": "kh",
+        "ц": "ts",
+        "ч": "ch",
+        "ш": "sh",
+        "щ": "shch",
+        "ь": "",
+        "ю": "iu",
+        "я": "ia",
+        "ы": "y",
+        "э": "e",
+        "ъ": "",
+    }
+)
+
+_PAGE_RE = re.compile(
+    r"(?i)(?:\bp\.?\s*|\bpage\s+|[сc]\.?\s*|\bстор\.?\s*|"
+    r"\bсторінка\s+)(\d+)\b"
+)
+
+
+@dataclass(frozen=True)
+class CitationKey:
+    author: str
+    grade: int
+    page: int
+
+
+def normalize_citation_ref(value: Any) -> str:
+    normalized = re.sub(r"\s+", " ", str(value or "")).strip()
+    return re.sub(r"\bp\.\s+(\d+)\b", r"p.\1", normalized)
+
+
+def extract_plan_reference_titles(plan: Mapping[str, Any]) -> list[Any]:
+    references = plan.get("references")
+    if references is None:
+        references = plan.get("plan_references", [])
+    if not isinstance(references, list):
+        return []
+    return [
+        ref["title"] for ref in references if isinstance(ref, Mapping) and ref.get("title")
+    ]
+
+
+def extract_citation_key(value: Any) -> CitationKey | None:
+    text = str(value or "")
+    # The first capitalized token is intentionally a narrow author heuristic:
+    # title-first citations fail closed instead of laundering unknown sources.
+    author_match = re.search(r"\b[А-ЯҐЄІЇA-Z][А-ЯҐЄІЇа-яґєіїA-Za-z'’-]*\b", text)
+    if author_match is None:
+        return None
+
+    grade_match = re.search(
+        r"(?i)(?:\b(?:grade|clas|class|klas)\s*(1[01]|[1-9])\b|"
+        r"\b(1[01]|[1-9])\s*(?:клас|grade|clas|class|klas)\b)",
+        text,
+    )
+    if grade_match is None:
+        return None
+
+    page_matches = list(_PAGE_RE.finditer(text))
+    if len(page_matches) != 1:
+        return None
+    page_match = page_matches[0]
+    if text[page_match.end() : page_match.end() + 1] in {"-", "–", "—"}:
+        return None
+
+    author = fold_citation_author(author_match.group(0))
+    if not author:
+        return None
+    grade = int(next(group for group in grade_match.groups() if group is not None))
+    return CitationKey(author=author, grade=grade, page=int(page_match.group(1)))
+
+
+def fold_citation_author(author: str) -> str:
+    return re.sub(r"[^a-z]", "", author.casefold().translate(_CYRILLIC_TO_LATIN))

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -25,6 +25,11 @@ SCRIPTS_DIR = PROJECT_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
+from scripts.build.citation_matcher import (
+    extract_citation_key,
+    extract_plan_reference_titles,
+    normalize_citation_ref,
+)
 from scripts.build.prompt_builder import DOWNSTREAM_TOKENS, TOKEN_RE, render_prompt
 from scripts.common.thresholds import QG_DIMS, aggregate_review
 from scripts.config import get_immersion_policy, get_immersion_range, get_immersion_rule
@@ -3652,19 +3657,27 @@ def _formatting_standards_gate(text: str) -> dict[str, Any]:
 
 
 def _normalize_citation_ref(value: Any) -> str:
-    normalized = re.sub(r"\s+", " ", str(value or "")).strip()
-    return re.sub(r"\bp\.\s+(\d+)\b", r"p.\1", normalized)
+    return normalize_citation_ref(value)
 
 
 def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> dict[str, Any]:
-    plan_titles = {
-        _normalize_citation_ref(ref["title"]) for ref in plan.get("references", [])
+    plan_reference_titles = extract_plan_reference_titles(plan)
+    plan_titles = {_normalize_citation_ref(title) for title in plan_reference_titles}
+    plan_keys = {
+        key
+        for title in plan_reference_titles
+        if (key := extract_citation_key(title)) is not None
     }
     unknown = []
     for resource in resources:
         source_ref = str(resource.get("source_ref") or resource.get("title") or "")
         normalized_ref = _normalize_citation_ref(source_ref)
-        if normalized_ref not in plan_titles and resource.get("packet_chunk_id") is None:
+        source_key = extract_citation_key(source_ref)
+        if (
+            normalized_ref not in plan_titles
+            and source_key not in plan_keys
+            and resource.get("packet_chunk_id") is None
+        ):
             unknown.append(source_ref)
     return {"passed": not unknown, "unknown": unknown}
 

--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.build import linear_pipeline
+
+
+def _result(source_ref: str, title: str = "Караман Grade 10, p.176") -> dict[str, Any]:
+    return linear_pipeline._citation_gate(
+        [{"source_ref": source_ref}],
+        {"references": [{"title": title}]},
+    )
+
+
+def test_plan_compact_form_matches_writer_expanded() -> None:
+    result = _result("Караман, Українська мова, 10 клас, с. 176")
+
+    assert result["passed"] is True
+    assert result["unknown"] == []
+
+
+def test_grade_word_order_tolerated() -> None:
+    assert _result("Караман, 10 клас, с. 176")["passed"] is True
+    assert _result("Караман, Grade 10, p.176")["passed"] is True
+
+
+def test_page_label_variants() -> None:
+    assert _result("Караман, 10 клас, p.176")["passed"] is True
+    assert _result("Караман, 10 клас, с. 176")["passed"] is True
+    assert _result("Караман, 10 клас, стор. 176")["passed"] is True
+
+
+def test_latin_mixed_author_matches_plan_reference() -> None:
+    assert _result("Karaman Ukrainian language, Grade 10, p.176")["passed"] is True
+    assert _result("Kараман Ukrainian language, Grade 10, p.176")["passed"] is True
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        "Кaraman",
+        "Kаraman",
+        "Karаman",
+        "Karamаn",
+        "Караman",
+    ],
+)
+def test_cyrillic_latin_lookalike_author_forms_match(author: str) -> None:
+    assert _result(f"{author}, Grade 10, p.176")["passed"] is True
+
+
+def test_unknown_citation_still_rejected() -> None:
+    result = _result("Tolstoy, War and Peace, p.500")
+
+    assert result["passed"] is False
+    assert result["unknown"] == ["Tolstoy, War and Peace, p.500"]
+
+
+def test_partial_match_does_not_pass() -> None:
+    wrong_grade = _result("Караман, Українська мова, 9 клас, с. 176")
+    wrong_page = _result("Караман, Українська мова, 10 клас, с. 999")
+
+    assert wrong_grade["passed"] is False
+    assert wrong_grade["unknown"] == ["Караман, Українська мова, 9 клас, с. 176"]
+    assert wrong_page["passed"] is False
+    assert wrong_page["unknown"] == ["Караман, Українська мова, 10 клас, с. 999"]
+
+
+def test_page_range_and_second_page_label_do_not_pass() -> None:
+    page_range = _result("Караман, Українська мова, 10 клас, с. 176-178")
+    second_page = _result("Караман, Українська мова, 10 клас, с. 176, p.999")
+
+    assert page_range["passed"] is False
+    assert page_range["unknown"] == ["Караман, Українська мова, 10 клас, с. 176-178"]
+    assert second_page["passed"] is False
+    assert second_page["unknown"] == ["Караман, Українська мова, 10 клас, с. 176, p.999"]
+
+
+def test_unparseable_near_match_does_not_pass() -> None:
+    result = _result("Караман")
+
+    assert result["passed"] is False
+    assert result["unknown"] == ["Караман"]
+
+
+def test_plan_references_field_is_supported() -> None:
+    result = linear_pipeline._citation_gate(
+        [{"source_ref": "Караман, Українська мова, 10 клас, с. 176"}],
+        {"plan_references": [{"title": "Караман Grade 10, p.176"}]},
+    )
+
+    assert result["passed"] is True
+
+
+def test_my_morning_module_passes_citations_resolve() -> None:
+    plan_path = linear_pipeline.PROJECT_ROOT / "curriculum/l2-uk-en/plans/a1/my-morning.yaml"
+    plan = yaml.safe_load(plan_path.read_text("utf-8"))
+    result = linear_pipeline._citation_gate(
+        [
+            {"source_ref": "Караман, Українська мова, 10 клас, с. 176"},
+            {"source_ref": "Кравцова, Українська мова, 4 клас, с. 113"},
+            {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 162"},
+        ],
+        plan,
+    )
+
+    assert result["passed"] is True
+    assert result["unknown"] == []


### PR DESCRIPTION
## Summary
- Load plan references into citations_resolve via references/plan_references titles.
- Add structured author+grade+page matching across compact and expanded citation forms.
- Reject partial matches, page ranges, repeated page labels, unknown refs, and unparseable near-matches.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_citation_resolve.py -v
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_citation_resolve.py tests/test_citation_whitespace.py -v
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/
- git diff --check
- Direct my-morning citation set: {'passed': True, 'unknown': []}

## Review
- Claude adversarial review completed via ask-claude task 1723-review.
- Applied feedback for page-range/repeated-page rejection, mixed-script author tests, unparseable near-match tests, and heuristic documentation.

No auto-merge.