### PR TITLE
fix(python_qg): immersion sentence splitter recognizes dialogue turns + table rows + bullets (#1724)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -406,13 +406,15 @@ _JSX_BLOCK_RE = re.compile(
 _JSX_STRING_VALUE_RE = re.compile(r'"([^"\n]*)"')
 
 # Sentence boundaries for the immersion gate's long-sentence check: end-of-
-# sentence punctuation (including Ukrainian `…`, `‼`, `⁇`, `⁈`, `⁉`) or a
-# markdown bullet/numbered-list marker (`* `, `- `, `1. `). The bullet-marker
-# alternations match start-of-string OR after a newline, so a list at the
-# very top of the body (e.g., immediately after frontmatter) is recognized
-# as a sentence boundary.
+# sentence punctuation (including Ukrainian `…`, `‼`, `⁇`, `⁈`, `⁉`) with
+# optional closing markdown/quote marks, markdown hard line breaks, plus
+# markdown structure that makes adjacent lines independent prose units.
+# The zero-width structural branch preserves line markers in the returned
+# chunks and requires re.MULTILINE so `^` anchors each line, including quoted
+# dialogue turns at the top of a body.
 _SENTENCE_SPLIT_RE = re.compile(
-    r"[.!?…‼⁇⁈⁉]+(?:\s+|$)|(?:\n|^)\s*[*\-]\s+|(?:\n|^)\s*\d+\.\s+",
+    r"[.!?…‼⁇⁈⁉]+(?:[*_~\"'»”)\]]{0,4})(?:\s+|$)| {2,}\n+|\n\s*\n+|"
+    r"(?=^[\s«“\"']*(?:[—–-]\s*(?:\*\*)?|\|\s*|[*-]\s+|\d+\.\s+|>\s*|#{1,6}\s+))",
     re.MULTILINE,
 )
 
@@ -3695,16 +3697,19 @@ def _immersion_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
     text inside JSX counts toward immersion, structural prop syntax doesn't.
 
     The long-sentence check splits on Ukrainian-aware sentence punctuation
-    (`. ! ? … ‼ ⁇ ⁈ ⁉`) and markdown list-item starts (`* `, `- `, `1. `,
-    including at start-of-string) so bullet items render as separate
-    sentences instead of one giant joined run.
+    (`. ! ? … ‼ ⁇ ⁈ ⁉`) and markdown structure starts: dialogue dashes,
+    table rows, bullets, numbered list items, blockquotes, and headers. This
+    keeps dialogue turns and table rows from being joined into one giant run.
     """
     level = str(plan["level"]).lower()
     sequence = int(plan["sequence"])
     min_pct, max_pct = get_immersion_range(level, sequence)
-    body = _strip_frontmatter_and_headings(_strip_comments(text))
+    comment_stripped = _strip_comments(text)
+    body = _strip_frontmatter_and_headings(comment_stripped)
+    sentence_body = _strip_frontmatter(comment_stripped)
 
     body_no_jsx = _JSX_BLOCK_RE.sub(" ", body)
+    sentence_body_no_jsx = _JSX_BLOCK_RE.sub(" ", sentence_body)
     jsx_string_props: list[str] = []
     for jsx_block in _JSX_BLOCK_RE.findall(body):
         jsx_string_props.extend(_JSX_STRING_VALUE_RE.findall(jsx_block))
@@ -3714,11 +3719,7 @@ def _immersion_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
     uk_tokens = [token for token in tokens if _UK_WORD_RE.search(token)]
     pct = round((len(uk_tokens) / len(tokens) * 100), 2) if tokens else 0.0
 
-    long_sentences = [
-        sentence.strip()
-        for sentence in _SENTENCE_SPLIT_RE.split(body_no_jsx)
-        if len(_UK_WORD_RE.findall(sentence)) > 10
-    ]
+    long_sentences = _long_ukrainian_sentences(sentence_body_no_jsx)
     return {
         "passed": min_pct <= pct <= max_pct and not long_sentences,
         "pct": pct,
@@ -3727,6 +3728,26 @@ def _immersion_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
         "policy": get_immersion_policy(level, sequence)["key"],
         "long_ukrainian_sentences": long_sentences[:20],
     }
+
+
+def _split_immersion_sentences(text: str) -> list[str]:
+    """Split prose for the immersion gate's Ukrainian sentence-length check."""
+    text = re.sub(r"(?m)^\s*#{1,6}\s+.*$", "\n", text)
+    sentences = []
+    for sentence in _SENTENCE_SPLIT_RE.split(text):
+        sentence = sentence.strip()
+        if sentence:
+            sentences.append(sentence)
+    return sentences
+
+
+def _long_ukrainian_sentences(text: str) -> list[str]:
+    text = _FENCED_CODE_RE.sub(" ", text)
+    return [
+        sentence
+        for sentence in _split_immersion_sentences(text)
+        if len(_UK_WORD_RE.findall(sentence)) > 10
+    ]
 
 
 def _inject_activity_gate(text: str, activities: list[dict[str, Any]]) -> dict[str, Any]:
@@ -3839,11 +3860,16 @@ def _strip_comments(text: str) -> str:
     return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
 
 
-def _strip_frontmatter_and_headings(text: str) -> str:
+def _strip_frontmatter(text: str) -> str:
     if text.startswith("---\n"):
         end = text.find("\n---", 4)
         if end >= 0:
             text = text[end + 4 :]
+    return text
+
+
+def _strip_frontmatter_and_headings(text: str) -> str:
+    text = _strip_frontmatter(text)
     return "\n".join(
         line for line in text.splitlines() if not line.lstrip().startswith("#")
     )

--- a/tests/test_immersion_splitter.py
+++ b/tests/test_immersion_splitter.py
@@ -1,0 +1,246 @@
+from pathlib import Path
+
+from scripts.build.linear_pipeline import (
+    _immersion_gate,
+    _long_ukrainian_sentences,
+    _split_immersion_sentences,
+)
+
+PLAN = {"level": "a1", "sequence": 15}
+
+
+def test_em_dash_line_start_is_sentence_boundary() -> None:
+    text = "Що ти робиш?\n— Вмиваюся.\n–Одягаюся.\n- Снідаю."
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == ["Що ти робиш", "— Вмиваюся", "–Одягаюся", "- Снідаю"]
+    assert _long_ukrainian_sentences(text) == []
+
+
+def test_markdown_table_rows_split() -> None:
+    text = """| Особа | Форма |
+|---|---|
+| я | прокидаюся вранці швидко спокійно вдома |
+| ти | вмиваєшся після сну повільно у ванній |
+| вона | снідає рано вдома з мамою |
+| ми | йдемо на роботу о восьмій |"""
+
+    sentences = _split_immersion_sentences(text)
+
+    assert len(sentences) >= 4
+    assert _long_ukrainian_sentences(text) == []
+
+
+def test_bullet_items_split() -> None:
+    text = """- Прокидаюся о сьомій
+- Вмиваюся швидко
+- Снідаю вдома"""
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == [
+        "- Прокидаюся о сьомій",
+        "- Вмиваюся швидко",
+        "- Снідаю вдома",
+    ]
+    assert _long_ukrainian_sentences(text) == []
+
+
+def test_blockquote_dialogue_split() -> None:
+    text = "> **Ліна:** Я прокидаюся о сьомій.\n> **Настя:** Я снідаю вдома."
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == ["> **Ліна:** Я прокидаюся о сьомій", "> **Настя:** Я снідаю вдома"]
+
+
+def test_closing_markdown_and_quotes_do_not_block_sentence_boundary() -> None:
+    text = "**«Спочатку я прокидаюся.»**  \n**«Потім вмиваюся.»**"
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == ["**«Спочатку я прокидаюся", "**«Потім вмиваюся"]
+
+
+def test_opening_quotes_before_dialogue_dash_split() -> None:
+    text = "«— Привіт»\n“— Як справи?”"
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == ["«— Привіт»", "“— Як справи"]
+
+
+def test_markdown_hard_break_splits_pattern_lines() -> None:
+    text = "**вмивати → я вмиваю → я вмиваюся**  \n**одягати → ти одягаєш → ти одягаєшся**"
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == [
+        "**вмивати → я вмиваю → я вмиваюся**",
+        "**одягати → ти одягаєш → ти одягаєшся**",
+    ]
+
+
+def test_markdown_header_terminates_prior_sentence() -> None:
+    text = """Прокидаюся вранці без крапки
+## Ранок і щоденні звички учня
+Снідаю вдома."""
+
+    sentences = _split_immersion_sentences(text)
+
+    assert sentences == ["Прокидаюся вранці без крапки", "Снідаю вдома"]
+
+
+def test_code_fence_excluded_or_split() -> None:
+    long_code = " ".join(
+        [
+            "прокидаюся",
+            "вмиваюся",
+            "одягаюся",
+            "снідаю",
+            "працюю",
+            "читаю",
+            "пишу",
+            "слухаю",
+            "повторюю",
+            "навчаюся",
+            "відпочиваю",
+        ]
+    )
+    text = f"```md\n{long_code}\n```"
+
+    assert _long_ukrainian_sentences(text) == []
+
+
+def test_real_long_sentence_still_caught() -> None:
+    long_sentence = " ".join(
+        [
+            "Український",
+            "студент",
+            "повільно",
+            "прокидається",
+            "вмивається",
+            "одягається",
+            "снідає",
+            "планує",
+            "повторює",
+            "записує",
+            "читає",
+            "слухає",
+            "практикує",
+            "розповідає",
+            "запитує",
+            "відповідає",
+            "працює",
+            "навчається",
+            "уважно",
+            "щодня",
+        ]
+    )
+
+    assert _long_ukrainian_sentences(long_sentence) == [long_sentence]
+
+
+def test_immersion_gate_fails_real_long_sentence() -> None:
+    english_scaffold = " ".join(
+        [
+            "English",
+            "scaffolding",
+            "keeps",
+            "the",
+            "ratio",
+            "inside",
+            "the",
+            "A1",
+            "range",
+            "while",
+            "the",
+            "Ukrainian",
+            "paragraph",
+            "below",
+            "remains",
+            "a",
+            "single",
+            "overlong",
+            "sentence",
+            "for",
+            "the",
+            "gate",
+            "to",
+            "catch",
+            "during",
+            "integration",
+            "testing",
+            "without",
+            "depending",
+            "on",
+            "external",
+            "fixtures",
+            "or",
+            "generated",
+            "status",
+            "files",
+            "from",
+            "the",
+            "build",
+            "pipeline",
+            "today",
+        ]
+    )
+    long_sentence = " ".join(
+        [
+            "Український",
+            "студент",
+            "повільно",
+            "прокидається",
+            "вмивається",
+            "одягається",
+            "снідає",
+            "планує",
+            "повторює",
+            "записує",
+            "читає",
+            "слухає",
+            "практикує",
+            "розповідає",
+            "запитує",
+            "відповідає",
+        ]
+    )
+
+    result = _immersion_gate(f"{english_scaffold}\n\n{long_sentence}", PLAN)
+
+    assert result["min_pct"] <= result["pct"] <= result["max_pct"]
+    assert result["passed"] is False
+    assert result["long_ukrainian_sentences"] == [long_sentence]
+
+
+def test_my_morning_immersion_passes() -> None:
+    fixture = Path("audit/bakeoff-2026-05-05/claude/module.md")
+    if fixture.exists():
+        text = fixture.read_text(encoding="utf-8")
+    else:
+        text = """English context keeps the A1 immersion ratio bounded for learners.
+This short grammar note explains the morning routine pattern in plain English.
+Learners read the examples, notice the endings, compare the forms, and then
+practice the dialogue aloud with a partner before writing their own version.
+The surrounding English is intentionally present because early A1 modules need
+clear scaffolding and should not become full immersion lessons yet.
+
+Що ти робиш потім?**
+— **Вмиваюся, одягаюся, снідаю.**
+— **А коли ти йдеш на роботу?**
+— **О восьмій
+
+| Особа | Форма |
+|---|---|
+| я | прокидаюся |
+| ти | прокидаєшся |
+| вона | прокидається |
+"""
+
+    result = _immersion_gate(text, PLAN)
+
+    assert result["min_pct"] <= result["pct"] <= result["max_pct"]
+    assert result["long_ukrainian_sentences"] == []


### PR DESCRIPTION
## Summary
- Teach the Python QG immersion long-sentence splitter to treat dialogue turns, markdown table rows, bullets, numbered list items, blockquotes, headers, markdown hard breaks, and quote-wrapped dash dialogue as structural boundaries.
- Keep the immersion percentage calculation on the existing heading-stripped text path while using the richer structural splitter only for long-sentence detection.
- Add focused regression coverage for dialogue dash variants, tables, bullets, blockquotes, code fences, quote/markdown punctuation, real long sentences, and the My Morning bakeoff fixture path.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_immersion_splitter.py -v
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_immersion_splitter.py
- git diff --check
- Bakeoff rerun via _immersion_gate for claude/gemini/gpt55: all now report long_count=0; Claude passes; Gemini fails only low pct; GPT-5.5 fails only high pct.

## Notes
- Full pytest was also run after the initial implementation: 6977 passed, 214 skipped, 11 xfailed, 27 failed. Failures were unrelated environment/repo-data issues: missing worktree .venv, missing data fixture files, expired Hugging Face token/model access, missing embed-venv, and existing repo-level checks.
- Full ruff check still fails on pre-existing unrelated files under docs/reports/ and plans/; scoped ruff for touched files passes.

Reviewed-By: claude-opus-4-7 (1724-review)