### PR TITLE
channels.html UX overhaul (Part A) + multi-UI participation ADR (Part B) (#1731)

### DIFF
--- a/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
+++ b/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
@@ -1,0 +1,270 @@
+# DECISION REQUIRED — Multi-UI agent participation in `ab discuss` / channels.html
+
+**Status:** PROPOSED (awaiting cross-agent review by Gemini + Codex, then user signoff)
+**Surfaced:** 2026-05-06 morning, while running the writer-lock 3-way discussion
+**Source:** GH issue #1731 Part B
+**Predecessor ADRs:** None — this is the first ADR on multi-UI participation. Touches the `ab` channel-bridge contract from #1190.
+
+---
+
+## Why this needs an ADR (not just a PR)
+
+`ab discuss` today is a **closed-loop, single-orchestrator** protocol. The agent that calls `ab discuss --with claude,gemini,codex` is a process that:
+
+1. Spawns each named agent as a subprocess (one per round, per agent) via `scripts/agent_runtime/adapters/*.py`.
+2. Reads each subprocess's stdout, posts the result to the channel, threads via `parent_id`.
+3. Aggregates `[AGREE]` markers; short-circuits when all participants agree, or runs to `--max-rounds`.
+4. Returns the transcript to the caller.
+
+Three properties hold today only because of this closed-loop assumption:
+
+- **Identity** is fixed at dispatch. `--with claude,gemini,codex` is the participant list; nothing else can join.
+- **Time** is owned by the orchestrator. A round is "Gemini's reply has returned from `gemini -p ...`" — there's no clock outside the subprocess.
+- **State** is a single transcript. The orchestrator is the only writer of `parent_id` chains; there is no claim/lock for "who responds next."
+
+The user's ask — "Claude Code, Claude Desktop, Codex CLI, Codex UI, AND user can all participate" — breaks ALL THREE properties:
+
+1. Claude Desktop is a separate process. It does not know `ab discuss` was invoked unless it polls or subscribes. → identity becomes dynamic.
+2. Claude Desktop's reply latency is unbounded (user might walk away). → time can no longer be owned by the orchestrator.
+3. If two Claude instances see the same channel post, both could reply. → state needs arbitration.
+
+Patching `ab discuss` ad hoc would silently change the contract for every existing caller (the writer-lock discussion, every channel review, every pipeline review). That's the rule-violation we want to avoid. Hence: ADR first.
+
+---
+
+## Scope of THIS ADR
+
+**In scope:** the participation/identity/round-semantics contract for an `ab discuss`-style multi-agent thread that can include Claude Code (CLI), Claude Desktop, Codex CLI, Codex UI, Gemini CLI, and human user.
+
+**Out of scope** (explicitly deferred to follow-up issues, even if the design touches them):
+
+- Real-time UI niceties (typing indicators, presence beyond "live now") — `playgrounds/channels.html` already has the basics, more polish is Part A territory.
+- Authentication of remote/3rd-party agents — this ADR assumes all participants run on `localhost` and trust the `ab` broker DB; remote/cloud agents are a separate ADR.
+- Action arbitration for non-discussion work (e.g. who picks up a `gh issue` to fix) — this ADR scopes "task pickup" to discussion-internal turn-taking only. Cross-channel work-claiming gets its own ADR if/when needed.
+- Voice / video / image sharing in channels — text only.
+
+---
+
+## Six architectural questions (from #1731 Part B)
+
+The questions below are quoted from the issue. Each gets a proposed answer with rationale and a tradeoffs subsection. The whole ADR is gated on user + Gemini + Codex agreement (or counter-proposal) on each.
+
+### Q1. What is a 'participant'?
+
+> "Currently `ab discuss --with claude,gemini,codex` lists *agents* invoked via the runtime adapter. If Claude Desktop is a participant, is it 'claude' (same agent name) or 'claude-desktop' (distinct)? What about user — is that a participant or an external observer?"
+
+#### Proposal
+
+A **participant** is the tuple `(agent_family, ui_surface, instance_id)`.
+
+- `agent_family`: `claude` | `gemini` | `codex` | `user` — the model/identity class.
+- `ui_surface`: `cli` | `desktop` | `web` | `mobile` | `headless` — the runtime context.
+- `instance_id`: ephemeral UUID for THIS process/session (so two Claude Desktop windows on the same machine don't collide).
+
+Wire format in DB: `agent_id = "{family}:{surface}:{instance_id_short}"`, e.g. `claude:cli:abc123`.
+
+The legacy `from_agent` column stays as `agent_family` (so old queries keep working). New column `participant_id` carries the full tuple. The `ab channel post` API accepts either; the broker normalizes.
+
+**User is a participant.** Family `user`, surface depends on where they post (web for channels.html, cli for `ab post`, desktop later). Treating user as first-class — vs "external observer" — is what makes "user posts mid-discussion" work without a special case.
+
+#### Why this shape (not just a flat string)
+
+Three needs the flat string can't satisfy without re-parsing:
+
+1. **Round arbitration** asks "has every required agent_family replied this round?" That's a family-level question (we don't care if it was `claude:cli` or `claude:desktop`, just that `claude` answered). Family is a first-class column.
+2. **Failure recovery** asks "did the SAME instance that started round N also produce reply N?" That's an instance-level question. Instance_id is a first-class column.
+3. **UI rendering** asks "show the current participants by surface so user knows which window to look at." Surface is a first-class column.
+
+#### Tradeoffs
+
+- **Cost:** schema migration on `channel_messages` (add `participant_id` text col, indexed). Backwards-compat-safe (`from_agent` stays).
+- **Risk:** instance_id collisions across reboots — solved by UUID4 on every process start. instance_id never persists.
+- **Alternative considered (rejected):** "claude-desktop" as a distinct agent_family. Rejected because round-quorum logic ("does Claude agree?") wants the family to be invariant across surfaces — otherwise a `[AGREE]` from `claude-desktop` doesn't satisfy a quorum that listed `claude`.
+
+---
+
+### Q2. Discovery: how does Claude Desktop know a discussion is happening?
+
+> "Polling? Push notification? An MCP server the desktop subscribes to? The desktop is a separate process that doesn't know `ab discuss` was invoked."
+
+#### Proposal
+
+**Three-tier discovery, layered:**
+
+1. **Push (preferred):** Server-Sent Events stream at `GET /api/comms/channels/{name}/events` — open connection, receive `message_appended` and `discussion_started` events as they happen. Already runnable via `curl -N`; trivial to wire from any UI surface.
+2. **Pull (fallback):** `GET /api/comms/inbox?agent={family}&since={ts}` — already exists; works for any client that prefers polling. Recommended interval: 5s (matches channels.html auto-refresh; no point going faster than human read speed).
+3. **MCP tool (Claude Desktop / Claude Code specifically):** `mcp__channels__subscribe(channel)` thin wrapper over the SSE endpoint. Returns a resource the model can read on each turn. Lets Claude Desktop "see" channel activity without writing browser-automation code.
+
+`ab discuss` itself emits a `discussion_started` event with `{thread_id, channel, participants_invited, max_rounds, initiator}` so subscribers know a structured discussion is open vs an ad-hoc thread.
+
+#### Why all three (not just one)
+
+Different surfaces have different cost profiles:
+
+- **CLI / shell agents** can hold an SSE connection cheaply; push is right.
+- **Stateless adapters** (e.g. a one-shot `gemini -p ...` invocation) can't hold a connection across calls; they need pull.
+- **Claude Desktop / Code** through MCP is the cleanest — the model sees subscription as a tool, not infrastructure.
+
+Layering doesn't add server complexity: the SSE endpoint and inbox endpoint share the same DB query; MCP is a thin shim over SSE.
+
+#### Tradeoffs
+
+- **Cost:** new SSE endpoint (~150 LOC FastAPI), new MCP tool (~80 LOC). Pull endpoint already exists.
+- **Risk:** SSE connection leaks if a client crashes — mitigated by a 60s server-side keepalive ping; idle connections auto-close after 10 min.
+- **Alternative considered (rejected):** WebSocket. Rejected because SSE is sufficient (server→client only; we don't need bidirectional), simpler to debug (just `curl -N`), and survives proxies that strip WS headers.
+
+---
+
+### Q3. Action arbitration: who picks up tasks?
+
+> "If the channel says 'someone please review module X', what stops 3 agents from picking it up simultaneously? Need a claim mechanism (DB-level lock or first-poster-wins)."
+
+#### Proposal (scoped to in-discussion turn-taking — see "out of scope" above for cross-channel claim)
+
+For an active `ab discuss` thread, **the orchestrator owns the turn schedule**, exactly as today. Discovery tells Desktop/UI/etc. "a discussion is happening" but they don't auto-respond — they observe.
+
+A non-orchestrator participant **must explicitly claim a turn** to contribute. Claim mechanism:
+
+```
+POST /api/comms/channels/{name}/threads/{tid}/claim
+  body: {participant_id, round_index}
+  → 200 {claim_id, expires_at}  on success
+  → 409 {current_holder, expires_at}  on conflict
+```
+
+Claims are scoped to `(thread_id, round_index, agent_family)`. Two `claude:*` instances cannot both claim round 3 of thread T — first-poster-wins. Claims expire after 90s if no message follows; another instance can re-claim.
+
+The orchestrator's existing subprocess-spawn path **also goes through claim** (no special path), so the contract is uniform: "to post a round-N reply, you hold the claim."
+
+#### Why claim per `(thread, round, family)` not per `(thread, round, instance)`
+
+Family-scoped claim is what makes "Claude Desktop joins instead of Claude Code for round 3" work. The orchestrator says "we need a claude reply in round 3"; whichever claude-instance holds the claim first delivers it. That's the user's mental model: "I'm tagging in for Claude this round."
+
+Instance-scoped would force a deterministic spawner per instance — back to the closed-loop world.
+
+#### Tradeoffs
+
+- **Cost:** new `claims` table (`thread_id, round_index, agent_family, holder_participant_id, claimed_at, expires_at`); `~80 LOC` for the endpoint + claim-expiry sweep.
+- **Risk:** claim deadlock if the holder never delivers — solved by 90s expiry + re-claim. Keepalive every 30s extends.
+- **Risk:** claim livelock if 5 Claude instances all retry on 409 — solved by exponential backoff + jitter; documented in client lib.
+- **Alternative considered (rejected):** "first-message-wins" with no claim. Rejected because two slow agents racing each other waste tokens producing replies that get rejected. Pre-claim is cheap.
+
+---
+
+### Q4. Round semantics with mixed participants
+
+> "If user posts mid-round, does that count as a round-N reply? Does `[AGREE]` from user terminate the discussion? Or is user input always 'context for next round'?"
+
+#### Proposal
+
+**User posts are always round-N+1 context, never count as round-N replies, and `[AGREE]` from user is treated as a HARD STOP (not consensus).**
+
+Concretely:
+
+- A user post during round N (i.e. while ≥1 agent_family hasn't yet posted round N) does NOT satisfy that family's round-N obligation.
+- The user post's body IS injected into the round-N+1 prompt for every agent (verbatim, prefixed with `[USER (mid-discussion)]:`), so the next round can react to it.
+- `[AGREE]` from a user post terminates the discussion immediately — but it's recorded as `kind: "user_terminate"` in the DB, not aggregated into the consensus quorum. Discussion outcome = "ended by user," not "converged."
+- `[OBJECT]` (new marker) from user resets convergence; if all agents had said `[AGREE]`, an `[OBJECT]` from user forces a round N+1 with the objection as injected context.
+
+#### Why user posts aren't replies
+
+Two reasons:
+
+1. **Quorum integrity.** The discussion contract is "agents converge on a recommendation." Counting user as a vote conflates "agents agree" with "agents agree AND user happens to also agree" — fundamentally different signals. The user is the consumer of the recommendation, not a producer of it.
+2. **Steering value.** If user posts ARE replies, the user can short-circuit a useful debate by `[AGREE]`-ing with whoever they liked best. We want the user to be able to steer ("I think X is missing, address it") without ending the deliberation.
+
+#### Tradeoffs
+
+- **Cost:** ~30 LOC in the discuss orchestrator to inject user posts into the next round's prompt. Schema is unchanged (already has `kind`, `from_agent`).
+- **Risk:** user spam mid-discussion (10 posts in a row) bloats the next round's prompt. Mitigation: cap the injected user-context block at 2000 chars, oldest-first truncate.
+- **Alternative considered (rejected):** "user posts ARE first-class replies, just from agent_family=user." Rejected because the round-N quorum was specified as "all agents in `--with`" — and `user` isn't in `--with` by default. Adding user to `--with` opens the abuse vectors above.
+
+---
+
+### Q5. Identity / auth
+
+> "Claude Code, Claude Desktop, Codex CLI, Codex UI — do they share auth tokens? Do they post as distinct identities or as the same 'claude'/'codex'?"
+
+#### Proposal (localhost-only — remote auth deferred)
+
+- All participants run on `localhost`. No auth for now beyond "the broker DB is owned by user `krisztiankoos`."
+- A participant **identifies itself** to the broker via `participant_id` (Q1's tuple). The broker does not verify — it's an honour system on localhost.
+- A participant **identifies its origin** via a `client_app` field (`claude-cli/2.1.131`, `claude-desktop/0.x`, `codex-cli/y.y`, etc.) for telemetry and debugging.
+- Distinct surfaces post under distinct `participant_id`s but share the same `agent_family` for quorum (Q1).
+
+If we later need remote agents or shared multi-user installs, this gets revisited as a separate auth ADR. The localhost-only assumption is explicitly recorded so we don't accidentally expose `:8765` to the network without revisiting.
+
+#### Why no token auth now
+
+Adding auth before we have a working multi-UI prototype is premature optimization. The broker DB is already user-readable only (file mode 0600 in `.ab/broker.db`); an attacker on the same machine has bigger problems. When we go remote, JWT or mutual TLS goes here.
+
+#### Tradeoffs
+
+- **Risk:** any local process can post as anyone. Acceptable on a single-user dev machine; documented in `docs/best-practices/agent-bridge.md`.
+- **Risk:** `:8765` is bound to `0.0.0.0` not `127.0.0.1`? Verify and tighten (separate fix).
+
+---
+
+### Q6. Failure semantics
+
+> "If Claude Desktop drops mid-round (user closed the app), does the discussion wait or short-circuit?"
+
+#### Proposal
+
+- A claim expires 90s after issue if no message follows (Q3). If the discussion's `--max-rounds` budget is `M` and we're in round `R`, the orchestrator waits at most `90s × (M − R + 1)` for any pending claim, then either:
+  - re-prompts the SAME agent_family (subprocess-spawn path) if `--auto-fallback=true` (default in `ab discuss`),
+  - or aborts the discussion with `kind: "discussion_aborted"` and `reason: "claim_expired"` if `--auto-fallback=false`.
+- Auto-fallback uses the legacy `agent_runtime` adapter, so a discussion that started with Claude Desktop participating can degrade to Claude CLI without losing thread continuity.
+- Aborts are first-class events; the channel sees `discussion_aborted` so observers don't think it converged.
+
+#### Why 90s + auto-fallback (not infinite wait)
+
+Infinite wait makes the channel unusable: a stuck discussion blocks `[AGREE]`-aggregation forever and channels.html's "Discussion live" strip never resolves. 90s is enough for a typical Desktop reply (Anthropic SDK p99 < 30s) plus user think-time; longer human deliberations can be done as multi-thread "post-then-respond" without round semantics.
+
+Auto-fallback to subprocess-spawn preserves the closed-loop as the safety net. We only LOSE the closed-loop when a multi-UI participant successfully claims and replies — exactly the path we want to support.
+
+#### Tradeoffs
+
+- **Cost:** ~60 LOC for claim-expiry sweep + fallback path in `_channels.py`.
+- **Risk:** flaky network on Desktop side causes false fallbacks. Mitigation: keepalive every 30s extends claim; stable connections never expire.
+- **Alternative considered (rejected):** "wait forever, user kicks the discussion manually." Rejected because UX suffers and the "Discussion live" strip becomes a forever-live ghost.
+
+---
+
+## What this ADR explicitly does NOT decide
+
+These are downstream questions for follow-up ADRs once the contract above is accepted:
+
+- **MCP tool surface for Claude Desktop / Code.** `mcp__channels__subscribe` is sketched in Q2 but the full tool family (post, claim, observe, list) needs its own design.
+- **Codex UI integration mechanism.** Codex UI is a web app; whether it polls SSE or uses an iframe-postMessage bridge to channels.html is undecided. Both work; pick after MCP tools land.
+- **Cross-channel task pickup** ("someone fix #1234"). Out of scope — see top of doc.
+- **Persistence beyond `.ab/broker.db`.** Single-DB single-user is fine for now; multi-user / replicated broker is a separate ADR.
+
+---
+
+## Implementation epic (only after ACCEPTED)
+
+If/when this ADR flips PROPOSED → ACCEPTED, the implementation splits into 4 strands, each filable as its own issue:
+
+1. **Schema + claim mechanism** (Q1, Q3): `participant_id` column, `claims` table, claim/release endpoints, expiry sweep. ~250 LOC + tests.
+2. **SSE event stream** (Q2): `/api/comms/channels/{name}/events` + `discussion_started`/`message_appended` events. ~150 LOC + tests.
+3. **Discuss orchestrator updates** (Q3, Q4, Q6): claim integration, user-post injection, fallback path. ~200 LOC + tests in `scripts/ai_agent_bridge/_channels.py`.
+4. **MCP tool family** (Q2 follow-up, separate ADR): `mcp__channels__*` tools for Claude surfaces.
+
+**channels.html** updates (UI rendering of multi-UI participants, claim status indicator, user-post-as-context visual treatment) layer on top once strands 1+2 land.
+
+---
+
+## Review questions for Gemini + Codex
+
+When this ADR fires for cross-agent review, please critique specifically:
+
+1. **Q1 schema migration:** is `participant_id` as a tuple-encoded string the right wire format, or should it be 3 separate columns? My choice is single-column for migration simplicity; counter-argue if you see a problem.
+2. **Q2 push-vs-pull:** is layering all three (SSE + inbox-poll + MCP shim) over-engineering? Could we ship pull-only and add SSE later, or is push fundamental to the user-experience?
+3. **Q3 claim scope:** family-scoped vs instance-scoped claim. I argued family-scoped enables the "tag in" use case. Counter-cases?
+4. **Q4 user-as-context:** is "user posts are NEVER replies, always context" too rigid? Steel-man the case for letting user be a first-class quorum participant when they explicitly join `--with`.
+5. **Q5 localhost auth:** is "no auth on localhost, document the assumption" sufficient, or should we ship a token even now?
+6. **Q6 90s claim expiry:** too short (Desktop with slow LLM) or too long (channels.html UI feels frozen)? Propose alternative if you can defend it.
+7. **Anything missing.** Are there architectural questions I didn't raise that you'd want answered before implementation?
+
+Use `[AGREE]` to signal acceptance per question, or `[REVISE Q3: <reason>]` to push back on a specific section. The aggregator will collate.

--- a/playgrounds/channels.html
+++ b/playgrounds/channels.html
@@ -55,8 +55,6 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .msg-time { color: var(--text3); font-size: 11px; }
 .msg-round { font-size: 10px; background: var(--bg3); padding: 1px 6px; border-radius: 4px; color: var(--text2); font-weight: 600; }
 .msg-body { background: var(--bg2); border: 1px solid var(--border); padding: 10px 14px; border-radius: 8px; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-word; color: var(--text); line-height: 1.4; }
-.expand-link { color: var(--blue); cursor: pointer; font-size: 11px; margin-top: 4px; display: inline-block; }
-.expand-link:hover { text-decoration: underline; }
 
 .empty-state { text-align: center; padding: 40px 20px; color: var(--text3); font-size: 14px; }
 .empty-state code { background: var(--bg2); padding: 2px 6px; border-radius: 4px; color: var(--text); }
@@ -88,6 +86,47 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .delivery-item:last-child { border-bottom: none; }
 .d-status { color: var(--yellow); font-weight: 600; text-transform: uppercase; font-size: 10px; }
 .d-agent { color: var(--blue); font-weight: 600; }
+
+/* User-post visual treatment (#1731 pain #4) — orange accent so user
+   contributions stand out from agent posts. The `::before` injects a
+   👤 prefix only when the author class is `user`, so we don't have to
+   touch the per-message render path. */
+.message.from-user { border-left: 3px solid var(--orange); padding-left: 12px; margin-left: -15px; }
+.message.from-user .msg-body { background: rgba(240,136,62,0.06); border-color: rgba(240,136,62,0.4); }
+.msg-author.user { color: var(--orange); }
+.msg-author.user::before { content: "👤 "; }
+
+/* Thread filter bar (#1731 pain #3) — sits between channel header and
+   the messages area, hidden until the channel has at least 2 threads. */
+.thread-bar { padding: 8px 24px; border-bottom: 1px solid var(--border); background: var(--bg); display: none; align-items: center; gap: 12px; font-size: 12px; color: var(--text2); flex-shrink: 0; }
+.thread-bar.shown { display: flex; }
+.thread-bar select { background: var(--bg2); color: var(--text); border: 1px solid var(--border); padding: 4px 8px; border-radius: 4px; font-size: 12px; max-width: 480px; font-family: inherit; }
+.thread-bar select:focus { outline: none; border-color: var(--blue); }
+.thread-bar .thread-meta { color: var(--text3); font-size: 11px; }
+.thread-bar .clear-filter { color: var(--blue); cursor: pointer; font-size: 11px; }
+.thread-bar .clear-filter:hover { text-decoration: underline; }
+
+/* Live-discussion strip (#1731 pain #5) — green pulse + per-agent
+   state. Only visible when an `ab discuss` thread is live (most recent
+   activity in last 5 min AND has round_index > 0 messages). */
+.discussion-strip { padding: 10px 24px; background: rgba(63,185,80,0.08); border-bottom: 1px solid var(--green); display: none; align-items: center; gap: 16px; font-size: 12px; flex-shrink: 0; flex-wrap: wrap; }
+.discussion-strip.active { display: flex; }
+.discussion-strip .ds-pulse { width: 8px; height: 8px; background: var(--green); border-radius: 50%; animation: dsPulse 1.5s ease-in-out infinite; flex-shrink: 0; }
+@keyframes dsPulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.3; transform: scale(0.8); } }
+.discussion-strip .ds-label { font-weight: 600; color: var(--green); }
+.discussion-strip .ds-progress { color: var(--text2); }
+.discussion-strip .ds-participants { display: flex; gap: 6px; flex-wrap: wrap; }
+.discussion-strip .ds-participant { padding: 2px 8px; border-radius: 10px; font-size: 11px; background: var(--bg2); border: 1px solid var(--border); color: var(--text3); }
+.discussion-strip .ds-participant.done { color: var(--text); border-color: var(--text3); }
+.discussion-strip .ds-participant.agreed { color: var(--green); border-color: var(--green); background: rgba(63,185,80,0.15); font-weight: 600; }
+.discussion-strip .ds-jump { margin-left: auto; cursor: pointer; color: var(--blue); font-size: 11px; }
+.discussion-strip .ds-jump:hover { text-decoration: underline; }
+
+/* Make sure messages-area stays the only flex-grow child below the
+   header/strip/thread-bar stack. Without explicit flex shrink rules
+   on the strips, a multi-line participant list could nudge messages
+   off-screen on narrow viewports. */
+.messages-area { flex: 1 1 0; min-height: 0; }
 </style>
 </head>
 <body>
@@ -108,7 +147,23 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
     <div class="channel-header" id="channel-header">
       <!-- header content injected -->
     </div>
-    
+
+    <!-- Live-discussion strip (#1731 pain #5). Hidden by default; the
+         renderer flips `.active` when an `ab discuss` thread is live. -->
+    <div class="discussion-strip" id="discussion-strip"></div>
+
+    <!-- Thread filter (#1731 pain #3). Hidden when the channel has
+         only one thread; auto-shown when ≥2. Selecting a thread
+         filters the messages-area to that thread only. -->
+    <div class="thread-bar" id="thread-bar">
+      <span>Thread:</span>
+      <select id="thread-select">
+        <option value="">All threads</option>
+      </select>
+      <span class="thread-meta" id="thread-meta"></span>
+      <span class="clear-filter" id="thread-clear" style="display:none;" onclick="clearThreadFilter()">Show all</span>
+    </div>
+
     <div class="messages-area" id="messages-area">
       <!-- messages injected -->
     </div>
@@ -152,6 +207,16 @@ let currentMessages = [];
 // both channel-switch races AND same-channel overlap (auto-refresh
 // firing while a manual reload is in flight).
 let currentFetchId = 0;
+// Thread filter (#1731 pain #3). When set, only messages whose
+// thread_id matches are rendered. Cleared on channel switch.
+let activeThreadFilter = null;
+// IDs of messages currently in the DOM. Auto-refresh appends only
+// new IDs (delta-render) instead of repainting innerHTML, so user
+// state — long-message scroll position, expanded sections — survives
+// the 5-second tick. Cleared on channel switch / filter change.
+let renderedMsgIds = new Set();
+// "Discussion in progress" detection threshold (ms). Tunable.
+const DISCUSSION_FRESH_MS = 5 * 60 * 1000;
 
 const DOM = {
   sidebar: document.getElementById('sidebar'),
@@ -168,6 +233,12 @@ const DOM = {
   errorBanner: document.getElementById('error-banner'),
   parentIdContainer: document.getElementById('parent-id-container'),
   postParentId: document.getElementById('post-parent-id'),
+  // #1731 pain #3 + #5
+  threadBar: document.getElementById('thread-bar'),
+  threadSelect: document.getElementById('thread-select'),
+  threadMeta: document.getElementById('thread-meta'),
+  threadClear: document.getElementById('thread-clear'),
+  discussionStrip: document.getElementById('discussion-strip'),
 };
 
 async function api(path, options = {}) {
@@ -187,7 +258,11 @@ async function api(path, options = {}) {
 }
 
 function escapeHTML(str) {
-  return (str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  // Escape `'` too even though our templates use double-quoted attrs —
+  // future templating switch to single-quoted attrs (common in JS lit
+  // templates) would otherwise silently open an XSS surface. Caught
+  // by Gemini review of #1731 Part A.
+  return (str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 // Safe for interpolation inside a single-quoted JS string literal that
@@ -252,12 +327,25 @@ async function selectChannel(name) {
   if (activeChannel === name) return;
   activeChannel = name;
   renderSidebar();
-  
+
   DOM.mainEmpty.style.display = 'none';
   DOM.mainPanel.style.display = 'flex';
   DOM.messagesArea.innerHTML = '<div class="empty-state">Loading messages...</div>';
   clearReply();
-  
+  // Each channel switch is a clean slate — drop any thread filter
+  // from the prior channel and forget which DOM nodes we rendered,
+  // otherwise the delta-render in renderMessages would skip messages
+  // it already drew for a DIFFERENT channel. Also drop the cache
+  // signatures used by refreshThreadBar / refreshDiscussionStrip so
+  // a coincidentally-matching new-channel signature can't suppress
+  // the redraw.
+  activeThreadFilter = null;
+  renderedMsgIds = new Set();
+  _lastThreadBarSig = null;
+  _lastDiscussionStripSig = null;
+  DOM.threadSelect.value = '';
+  DOM.threadClear.style.display = 'none';
+
   await loadChannelDetail(name);
 }
 
@@ -376,15 +464,6 @@ window.toggleDeliveries = async function() {
   }
 };
 
-window.expandMessage = function(id) {
-  const msg = currentMessages.find(m => String(m.id) === String(id));
-  if (!msg) return;
-  const el = document.getElementById('msg-body-' + id);
-  el.textContent = msg.body;
-  const link = document.getElementById('expand-' + id);
-  if (link) link.style.display = 'none';
-};
-
 window.replyTo = function(id) {
   DOM.parentIdContainer.style.display = 'flex';
   DOM.postParentId.value = id;
@@ -396,6 +475,53 @@ window.clearReply = function() {
   DOM.postParentId.value = '';
 };
 
+// Render a single message (#1731 pain #2: full body, no 300-char
+// truncation; pain #4: from-user class for orange accent). Pure —
+// returns HTML string, no DOM mutation.
+function renderMessageHTML(m) {
+  const safeAuthor = escapeHTML(m.from_agent || 'unknown');
+  const safeAuthorCls = escapeHTML((m.from_agent || '').toLowerCase());
+  const safeIdHtml = escapeHTML(String(m.id || ''));
+  const safeIdJs = escapeJSAttrString(safeIdHtml);
+  const safeTime = escapeHTML(
+    m.timestamp
+      ? (() => {
+          const d = new Date(m.timestamp);
+          const date = d.toLocaleDateString('sv-SE');
+          const time = d.toLocaleTimeString([], { hour12: false });
+          return `${date} ${time}`;
+        })()
+      : ''
+  );
+  const roundHtml = m.round_index > 0
+    ? `<span class="msg-round">r${m.round_index | 0}</span>`
+    : '';
+  const threadHtml = m.thread_id
+    ? `<span class="msg-thread-id" title="thread_id">${escapeHTML(String(m.thread_id).substring(0,8))}</span>`
+    : '';
+  const isUser = (m.from_agent || '').toLowerCase() === 'user';
+  const userCls = isUser ? ' from-user' : '';
+  // Long agent rounds (~2500 chars) are the norm; truncating to 300
+  // chars (the old behaviour) hid the actual argument and was wiped
+  // by every auto-refresh tick. Render the body in full and let
+  // .messages-area scroll handle vertical real estate.
+  const safeBody = escapeHTML(m.body || '');
+  return `
+    <div class="message${userCls}" data-msg-id="${safeIdHtml}" data-thread-id="${escapeHTML(String(m.thread_id || ''))}">
+      <div class="msg-header">
+        <span class="msg-time">[${safeTime}]</span>
+        <span class="msg-author ${safeAuthorCls}">${safeAuthor}</span>
+        ${roundHtml}
+        ${threadHtml}
+        <span class="msg-reply" onclick="replyTo('${safeIdJs}')">Reply</span>
+      </div>
+      <div>
+        <div class="msg-body" id="msg-body-${safeIdHtml}">${safeBody}</div>
+      </div>
+    </div>
+  `;
+}
+
 function renderMessages(msgs, isBackground) {
   // API returns {message_id, created_at, ...}; normalize to {id, timestamp}
   // so downstream render helpers stay agnostic to the server schema.
@@ -404,60 +530,237 @@ function renderMessages(msgs, isBackground) {
     id: m.message_id || m.id,
     timestamp: m.created_at || m.timestamp,
   }));
-  if (currentMessages.length === 0) {
-    DOM.messagesArea.innerHTML = '<div class="empty-state">No messages in this channel yet.</div>';
+
+  // Group ONCE per tick (Gemini review fix #3). Both the thread bar
+  // and the discussion strip described the channel state, not the
+  // filtered view, and both were calling groupByThread independently
+  // — wasteful at scale. Single grouping, passed through.
+  const groups = groupByThread(currentMessages);
+  refreshThreadBar(currentMessages, groups);
+  refreshDiscussionStrip(currentMessages, groups);
+
+  const filtered = activeThreadFilter
+    ? currentMessages.filter(m => String(m.thread_id || '') === activeThreadFilter)
+    : currentMessages;
+
+  if (filtered.length === 0) {
+    DOM.messagesArea.innerHTML = activeThreadFilter
+      ? '<div class="empty-state">No messages in this thread.</div>'
+      : '<div class="empty-state">No messages in this channel yet.</div>';
+    renderedMsgIds = new Set();
     return;
   }
-  
-  const isAtBottom = DOM.messagesArea.scrollHeight - DOM.messagesArea.scrollTop <= DOM.messagesArea.clientHeight + 50;
-  
-  DOM.messagesArea.innerHTML = currentMessages.map(m => {
-    // Every sink gets HTML-escaped; anything that lands inside a JS
-    // string literal in an onclick attribute gets an additional pass
-    // to neutralise single-quote breakout.
-    const safeAuthor = escapeHTML(m.from_agent || 'unknown');
-    const safeAuthorCls = escapeHTML((m.from_agent || '').toLowerCase());
-    const safeIdHtml = escapeHTML(String(m.id || ''));
-    // Backslash escape FIRST — see escapeJSAttrString rationale.
-    const safeIdJs = escapeJSAttrString(safeIdHtml);
-    const safeTime = escapeHTML(
-      m.timestamp ? new Date(m.timestamp).toLocaleTimeString([], { hour12: false }) : ''
-    );
-    const roundHtml = m.round_index > 0
-      ? `<span class="msg-round">r${m.round_index | 0}</span>`
-      : '';
 
-    let bodyPreview = m.body || '';
-    let isTruncated = false;
-    if (bodyPreview.length > 300) {
-      bodyPreview = bodyPreview.substring(0, 300);
-      isTruncated = true;
+  const isAtBottom = DOM.messagesArea.scrollHeight - DOM.messagesArea.scrollTop <= DOM.messagesArea.clientHeight + 80;
+
+  if (!isBackground) {
+    // Fresh paint — channel switch, filter change, or first load.
+    // Wipe and re-render everything; reset the rendered-id ledger.
+    DOM.messagesArea.innerHTML = filtered.map(renderMessageHTML).join('');
+    renderedMsgIds = new Set(filtered.map(m => String(m.id)));
+  } else {
+    // Background tick (auto-refresh). Append-only: every existing
+    // .message DOM node stays put — preserving scroll position,
+    // text selection, and any in-flight UI (e.g. open dropdowns).
+    const newMsgs = filtered.filter(m => !renderedMsgIds.has(String(m.id)));
+    if (newMsgs.length > 0) {
+      DOM.messagesArea.insertAdjacentHTML('beforeend', newMsgs.map(renderMessageHTML).join(''));
+      newMsgs.forEach(m => renderedMsgIds.add(String(m.id)));
     }
+  }
 
-    const expandHtml = isTruncated
-      ? `<span class="expand-link" id="expand-${safeIdHtml}" onclick="expandMessage('${safeIdJs}')">[${(m.body.length - 300) | 0} more chars]</span>`
-      : '';
-
-    return `
-      <div class="message">
-        <div class="msg-header">
-          <span class="msg-time">[${safeTime}]</span>
-          <span class="msg-author ${safeAuthorCls}">${safeAuthor}</span>
-          ${roundHtml}
-          <span class="msg-reply" onclick="replyTo('${safeIdJs}')">Reply</span>
-        </div>
-        <div>
-          <div class="msg-body" id="msg-body-${safeIdHtml}">${escapeHTML(bodyPreview)}</div>
-          ${expandHtml}
-        </div>
-      </div>
-    `;
-  }).join('');
-  
   if (isAtBottom || !isBackground) {
     DOM.messagesArea.scrollTop = DOM.messagesArea.scrollHeight;
   }
 }
+
+// ---- Thread + discussion helpers (#1731 pain #3 + #5) ------------
+
+// Group messages by thread_id, returning [{thread_id, msgs[], lastTs,
+// rootBody}] sorted by most-recent activity first. Messages without a
+// thread_id are grouped as standalone (one-per-id) so the dropdown
+// surfaces them too rather than dropping them silently.
+function groupByThread(msgs) {
+  const byId = new Map();
+  for (const m of msgs) {
+    const tid = String(m.thread_id || m.id || '');
+    if (!byId.has(tid)) byId.set(tid, []);
+    byId.get(tid).push(m);
+  }
+  const groups = [];
+  for (const [tid, list] of byId) {
+    list.sort((a,b) => new Date(a.timestamp) - new Date(b.timestamp));
+    const lastTs = list.length ? new Date(list[list.length - 1].timestamp).getTime() : 0;
+    // Use the earliest message's body (round 0 / kind=post) as the
+    // thread label — that's the "subject line" of the discussion.
+    const root = list.find(m => m.round_index === 0 || m.kind === 'post') || list[0];
+    groups.push({
+      threadId: tid,
+      msgs: list,
+      lastTs,
+      rootBody: (root && root.body) ? root.body : '',
+      maxRound: list.reduce((mx, m) => Math.max(mx, m.round_index | 0), 0),
+      participants: Array.from(new Set(list.map(m => m.from_agent).filter(Boolean))),
+    });
+  }
+  groups.sort((a,b) => b.lastTs - a.lastTs);
+  return groups;
+}
+
+function threadLabel(group) {
+  const stub = (group.rootBody || '').replace(/\s+/g, ' ').trim().substring(0, 60);
+  const tidShort = group.threadId.substring(0, 8);
+  const round = group.maxRound > 0 ? ` · r${group.maxRound}` : '';
+  const parts = group.participants.length ? ` · ${group.participants.join(',')}` : '';
+  return `${tidShort}${round}${parts} — ${stub || '(no body)'}`;
+}
+
+// Cached signature of the last <option> set we built. Comparing this
+// to the freshly computed signature lets us skip the innerHTML rewrite
+// when the set of threads + their labels are unchanged — which is the
+// common case on a 5-second tick. Wiping a dropdown's innerHTML while
+// the user has it open will close the popup mid-click; Gemini review
+// fix #1.
+let _lastThreadBarSig = null;
+
+function refreshThreadBar(msgs, groups) {
+  // Hide bar entirely when there's only one (or zero) thread — no
+  // value in showing a dropdown with a single option, and the
+  // architecture channel routinely has 1 thread per topic.
+  if (groups.length < 2) {
+    DOM.threadBar.classList.remove('shown');
+    if (_lastThreadBarSig !== '__hidden__') {
+      DOM.threadSelect.innerHTML = '<option value="">All threads</option>';
+      _lastThreadBarSig = '__hidden__';
+    }
+    return;
+  }
+  DOM.threadBar.classList.add('shown');
+
+  // Build a signature from (threadId, label, count) so any meaningful
+  // change forces a rebuild but identical-state ticks are cheap.
+  const labels = groups.map(g => `${g.threadId}|${threadLabel(g)}`);
+  const sig = labels.join('§§') + '|n=' + groups.length;
+  if (sig !== _lastThreadBarSig) {
+    const prevValue = DOM.threadSelect.value;
+    const stillExists = groups.some(g => g.threadId === prevValue);
+    const opts = ['<option value="">All threads (' + groups.length + ')</option>'];
+    for (const g of groups) {
+      const safeId = escapeHTML(g.threadId);
+      const safeLabel = escapeHTML(threadLabel(g));
+      opts.push(`<option value="${safeId}">${safeLabel}</option>`);
+    }
+    DOM.threadSelect.innerHTML = opts.join('');
+    if (stillExists) DOM.threadSelect.value = prevValue;
+    _lastThreadBarSig = sig;
+  }
+
+  // Meta + clear-button visibility cheap to set; no caching needed.
+  DOM.threadMeta.textContent = `${groups.length} threads · ${msgs.length} msgs`;
+  DOM.threadClear.style.display = activeThreadFilter ? 'inline' : 'none';
+}
+
+// Detect a "currently live" `ab discuss` thread: any group whose
+// maxRound > 0 and whose most-recent message is within
+// DISCUSSION_FRESH_MS. If multiple match, pick the most recent.
+// Now takes pre-computed groups (Gemini review fix #3) instead of
+// re-grouping internally — saves a pass per refresh tick.
+function detectLiveDiscussion(groups) {
+  const now = Date.now();
+  const live = groups.filter(g => g.maxRound > 0 && (now - g.lastTs) < DISCUSSION_FRESH_MS);
+  return live.length ? live[0] : null;
+}
+
+// Cache the (thread_id, lastTs) signature so we skip the innerHTML
+// rewrite when nothing has changed. Gemini review fix #5 — DOM churn
+// on every 5s tick was small but unnecessary.
+let _lastDiscussionStripSig = null;
+
+function refreshDiscussionStrip(msgs, groups) {
+  const live = detectLiveDiscussion(groups);
+  if (!live) {
+    if (_lastDiscussionStripSig !== '__hidden__') {
+      DOM.discussionStrip.classList.remove('active');
+      DOM.discussionStrip.innerHTML = '';
+      _lastDiscussionStripSig = '__hidden__';
+    }
+    return;
+  }
+  // Per-participant state. For each agent that posted in this thread
+  // (round_index > 0), find their highest-round message; if its body
+  // contains [AGREE] (case-insensitive, end-anchored to avoid mid-
+  // message false positives like "I would [AGREE] in spirit but...")
+  // mark `agreed`, otherwise `done`. Anyone listed as a participant
+  // but whose latest round_index < live.maxRound is `pending`.
+  const roundMsgs = live.msgs.filter(m => (m.round_index | 0) > 0);
+  const participantsSet = new Set(roundMsgs.map(m => m.from_agent).filter(Boolean));
+  const participants = Array.from(participantsSet);
+  const stateByAgent = {};
+  for (const a of participants) {
+    const theirs = roundMsgs.filter(m => m.from_agent === a);
+    theirs.sort((x,y) => (y.round_index | 0) - (x.round_index | 0));
+    const latest = theirs[0];
+    if (!latest) { stateByAgent[a] = 'pending'; continue; }
+    // Case-insensitive end-anchor: tolerates `[Agree]`, `[agree]`,
+    // and `[AGREE]\n\n` while still rejecting mid-message hits.
+    // Gemini review fix #4.
+    const agreed = /\[AGREE\]\s*$/i.test((latest.body || '').trim());
+    if ((latest.round_index | 0) >= live.maxRound) {
+      stateByAgent[a] = agreed ? 'agreed' : 'done';
+    } else {
+      stateByAgent[a] = 'pending';
+    }
+  }
+  // Strip-skip signature: thread + maxRound + per-agent state. Any
+  // meaningful change forces a redraw; identical state is a no-op.
+  const sig = `${live.threadId}|r${live.maxRound}|${live.lastTs}|${
+    participants.sort().map(a => a + ':' + stateByAgent[a]).join(',')
+  }`;
+  if (sig === _lastDiscussionStripSig) return;
+  _lastDiscussionStripSig = sig;
+  const allAgreed = participants.length > 0
+    && participants.every(a => stateByAgent[a] === 'agreed');
+  const pulse = allAgreed
+    ? '<span class="ds-pulse" style="background:var(--green);animation:none;"></span>'
+    : '<span class="ds-pulse"></span>';
+  const label = allAgreed
+    ? `<span class="ds-label">Discussion converged</span>`
+    : `<span class="ds-label">Discussion live</span>`;
+  const progress = `<span class="ds-progress">round ${live.maxRound} · thread ${escapeHTML(live.threadId.substring(0,8))}</span>`;
+  const partsHtml = participants.map(a => {
+    const s = stateByAgent[a];
+    const safeA = escapeHTML(a);
+    const txt = s === 'agreed' ? `${safeA} ✓` : (s === 'done' ? `${safeA} ●` : `${safeA} ⏳`);
+    return `<span class="ds-participant ${s}">${txt}</span>`;
+  }).join('');
+  const safeTid = escapeJSAttrString(escapeHTML(live.threadId));
+  const jump = `<span class="ds-jump" onclick="selectThreadFilter('${safeTid}')">Pin to this thread →</span>`;
+  DOM.discussionStrip.innerHTML = `
+    ${pulse}
+    ${label}
+    ${progress}
+    <span class="ds-participants">${partsHtml}</span>
+    ${jump}
+  `;
+  DOM.discussionStrip.classList.add('active');
+}
+
+window.selectThreadFilter = function(threadId) {
+  activeThreadFilter = threadId || null;
+  DOM.threadSelect.value = threadId || '';
+  DOM.threadClear.style.display = activeThreadFilter ? 'inline' : 'none';
+  // Filter change = full repaint, not a delta — drop the rendered
+  // ledger so renderMessages won't skip messages it "already drew".
+  renderedMsgIds = new Set();
+  // currentMessages is already normalised (id/timestamp set); the
+  // re-spread inside renderMessages is idempotent so passing through
+  // works without a temp re-pack.
+  renderMessages(currentMessages, false);
+};
+
+window.clearThreadFilter = function() {
+  selectThreadFilter('');
+};
 
 // Post Form Handlers
 DOM.postBody.addEventListener('input', () => {
@@ -541,6 +844,13 @@ document.addEventListener('click', (e) => {
   if (panel && panel.classList.contains('open')) {
     panel.classList.remove('open');
   }
+});
+
+// Thread filter dropdown (#1731 pain #3) — change → set filter and
+// repaint. Wired here once at init; the dropdown's <option> children
+// are repopulated by refreshThreadBar on every render tick.
+DOM.threadSelect.addEventListener('change', (e) => {
+  selectThreadFilter(e.target.value);
 });
 
 // Init


### PR DESCRIPTION
Closes #1731 Part A. Files Part B as PROPOSED ADR for cross-agent review.

## Part A — Surgical UX overhaul (`playgrounds/channels.html`)

The dashboard had five blockers preventing it from being useful during live `ab discuss` deliberations:

| # | Pain | Fix |
|---|---|---|
| 1 | Auto-refresh wiped innerHTML every 5s, destroying scroll + expand state | Delta-render: rendered-id Set, only NEW messages appended via `insertAdjacentHTML`, existing nodes preserved |
| 2 | Message bodies truncated to 300 chars (discussion rounds run 1500-2500) | Removed truncation entirely; `.messages-area` handles vertical scroll |
| 3 | No thread filter — architecture channel routinely has 10+ threads | Auto-shown thread dropdown (hides for <2 threads) with root-excerpt + max-round + participant labels |
| 4 | User posts blended in with agent posts | Orange left-border + 👤 prefix + tinted body background |
| 5 | No live-discussion indicator | Green-pulse strip with per-agent state (done ●, agreed ✓, pending ⏳) + "Pin to this thread →" jump link |

### Verification

Inline browser check via claude-in-chrome MCP:
- 14 threads in architecture channel dropdown ✓
- 12 user posts with `rgb(240,136,62)` (--orange) border ✓
- Longest message renders 8422 chars in full ✓
- Scroll position preserved across forced background refresh ✓
- Synthetic fresh-data activates strip with correct done/agreed states ✓
- Thread filter narrows 50→7→0→50 across selection cycles ✓

### Adversarial review

Gemini (`gemini-3.1-pro-preview`) returned REVISE with five findings, all incorporated:
- `escapeHTML` now escapes `'` (XSS defense-in-depth)
- `groupByThread` runs once per tick, passed to both refreshers
- Thread-bar dropdown skips innerHTML rewrite when option set unchanged (no popup-collapse mid-click)
- Discussion strip skips innerHTML rewrite when state unchanged
- `[AGREE]` regex case-insensitive but still end-anchored (no mid-message false positives)

Boy-Scout cleanup: dead `window.expandMessage` + `.expand-link` CSS removed.

## Part B — Multi-UI participation ADR (PROPOSED)

`docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md` answers the six architectural questions from #1731 Part B with concrete proposals + tradeoffs:

1. **Participant** = `(agent_family, ui_surface, instance_id)` tuple, wire format `participant_id`.
2. **Discovery** — three-tier: SSE push, inbox-poll fallback, MCP tool shim for Claude surfaces.
3. **Arbitration** — claim per `(thread, round, agent_family)`, 90s expiry.
4. **Rounds** — user posts are NEVER replies, ALWAYS context; user `[AGREE]` is hard stop, not consensus.
5. **Auth** — localhost-only honour system; remote auth deferred.
6. **Failure** — 90s claim expiry + auto-fallback to legacy subprocess-spawn.

Closes with seven targeted review questions for Gemini + Codex.

**Per user mandate, zero Part B code ships until ACCEPTED.**

## Test plan

- [x] JS parses clean (`node --check` on extracted script block)
- [x] Browser smoke test (5 features verified via claude-in-chrome MCP)
- [x] Gemini adversarial review (REVISE → 5 fixes applied → re-verified)
- [ ] Codex adversarial review on Part B ADR (post-merge follow-up)
- [ ] User signoff to flip Part B from PROPOSED → ACCEPTED (post-merge follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)