### PR TITLE
fix(comms): pagination + broker indexes + retention CLI + main-page nav (#1736)

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -163,6 +163,40 @@ Served by `scripts/api/main.py` at `http://localhost:8765`. The
 browser POST endpoint is `/api/comms/channels/{name}/post` — user-only,
 gated by localhost binding. Agents still post via CLI.
 
+`playgrounds/comms.html` is the legacy operational dashboard for live
+activity, DM-style broker messages, zombie detection, and batch progress.
+Its hot message endpoints are bounded by server-side `limit` defaults
+and keyset cursors; keep client polling paced so heavy views refresh no
+more often than every 30 seconds.
+
+## Broker storage hygiene
+
+SQLite remains the broker store for the localhost-only bridge. The
+performance bottleneck in the comms dashboard was unindexed scans plus
+unbounded result sets, not the engine. Keep the broker in WAL mode so
+readers can continue while a writer commits:
+
+```bash
+sqlite3 .mcp/servers/message-broker/messages.db 'PRAGMA journal_mode'
+```
+
+Expected output is `wal`. Bridge connections also use
+`PRAGMA busy_timeout=5000`, `PRAGMA cache_size=-20000` (about 20 MB),
+and `PRAGMA temp_store=MEMORY` for local dashboard queries.
+
+Run retention explicitly; the API server must not delete broker history
+on startup:
+
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py cleanup --older-than 30d --dry-run
+.venv/bin/python scripts/ai_agent_bridge/__main__.py cleanup --older-than 30d
+```
+
+Recommended schedule: run the dry-run weekly, then run the cleanup if
+the counts look reasonable. Cleanup deletes acknowledged legacy
+messages and terminal channel deliveries/messages older than the
+threshold, then runs `VACUUM` to reclaim disk space.
+
 ## API endpoints (for scripts + dashboards)
 
 Read-only:

--- a/docs/decisions/2026-05-06-broker-stays-on-sqlite.md
+++ b/docs/decisions/2026-05-06-broker-stays-on-sqlite.md
@@ -1,0 +1,16 @@
+# Broker Stays On SQLite
+
+**Date:** 2026-05-06
+**Status:** Accepted
+**Scope:** agent-bridge broker storage
+
+SQLite stays as broker storage. The performance bottleneck on
+`comms.html` was unindexed scans plus unbounded result sets, not the
+storage engine.
+
+The broker is a single-user localhost service, with no current
+multi-host or multi-user requirement. WAL mode handles concurrent local
+readers, and operational backup remains a normal file copy.
+
+Revisit this if multi-host or multi-user broker use emerges, in line
+with ADR #1731 Part B's current localhost-only scope.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -12,3 +12,4 @@ Staleness check: `.venv/bin/python scripts/check_decisions.py`
 | dec-004 | 2026-03-28 | 2026-06-28 | architecture | active | Bare slug filenames, no number prefixes |
 | dec-005 | 2026-04-03 | 2026-07-03 | tooling | active | Keep gemini-cli, fix dispatch retry logic |
 | dec-007 | 2026-04-24 | 2027-04-23 | pipeline | active | Enforce dec-001 at code level — no LLM regeneration during review (ADR-007) |
+| 2026-05-06 | 2026-05-06 | 2027-05-06 | agent-bridge | active | Broker stays on SQLite; fix unbounded scans first |

--- a/playgrounds/channels.html
+++ b/playgrounds/channels.html
@@ -15,8 +15,12 @@
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
 
 /* Top bar */
-.top-bar { display: flex; align-items: center; justify-content: space-between; padding: 16px 24px; border-bottom: 1px solid var(--border); background: var(--bg2); flex-shrink: 0; }
+.top-bar { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 16px 24px; border-bottom: 1px solid var(--border); background: var(--bg2); flex-shrink: 0; }
+.top-left { display: flex; align-items: center; gap: 14px; min-width: 0; }
 .top-bar h1 { font-size: 18px; font-weight: 600; }
+.top-bar a { color: var(--text2); text-decoration: none; font-size: 13px; }
+.top-bar a:hover { color: var(--text); }
+.home-link { color: var(--blue) !important; font-weight: 600; white-space: nowrap; }
 .banner { display: none; background: var(--red); color: white; padding: 8px 24px; font-size: 13px; text-align: center; }
 
 /* Main layout */
@@ -134,7 +138,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 <div id="error-banner" class="banner"></div>
 
 <div class="top-bar">
-  <h1>Agent Channels <span style="font-weight:400;color:var(--text3);font-size:14px;margin-left:8px;">#1190</span></h1>
+  <div class="top-left">
+    <a class="home-link" href="/index.html">&larr; Home</a>
+    <h1>Agent Channels <span style="font-weight:400;color:var(--text3);font-size:14px;margin-left:8px;">#1190</span></h1>
+  </div>
   <div style="font-size:12px;color:var(--text3);" id="refresh-status">Auto-refresh active</div>
 </div>
 

--- a/playgrounds/comms.html
+++ b/playgrounds/comms.html
@@ -14,10 +14,12 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; padding: 24px; }
 
-.top-bar { display: flex; align-items: center; justify-content: space-between; margin-bottom: 24px; }
+.top-bar { display: flex; align-items: center; justify-content: space-between; margin-bottom: 24px; gap: 16px; }
+.top-left { display: flex; align-items: center; gap: 14px; min-width: 0; }
 .top-bar h1 { font-size: 24px; font-weight: 700; }
 .top-bar a { color: var(--text2); text-decoration: none; font-size: 13px; }
 .top-bar a:hover { color: var(--text); }
+.home-link { color: var(--blue) !important; font-weight: 600; white-space: nowrap; }
 .top-bar .refresh-info { font-size: 12px; color: var(--text3); }
 
 /* Health summary bar */
@@ -181,11 +183,13 @@ a.gh-issue:hover { text-decoration: underline; }
 <body>
 
 <div class="top-bar">
-  <h1>Agent Comms</h1>
+  <div class="top-left">
+    <a class="home-link" href="/index.html">&larr; Home</a>
+    <h1>Agent Comms</h1>
+  </div>
   <div style="display:flex;align-items:center;gap:16px;">
     <span class="refresh-info" id="refresh-info">Loading...</span>
     <div style="display:flex;gap:12px;font-size:13px;">
-      <a href="/">Home</a>
       <a href="/channels.html" style="color:var(--green);font-weight:600;">Channels ↗</a>
       <a href="/audit-dashboard.html">Audit</a>
       <a href="/progress.html">Progress</a>
@@ -289,6 +293,12 @@ a.gh-issue:hover { text-decoration: underline; }
 </div>
 
 <script>
+const MESSAGE_LIMIT = 50;
+const CONVERSATION_LIMIT = 100;
+const DISPATCH_LIMIT = 30;
+const FULL_REFRESH_MS = 30000;
+const HEALTH_REFRESH_MS = 15000;
+
 // ========= DETAIL PANEL =========
 function openDetail(html) {
   document.getElementById('detail-content').innerHTML = html;
@@ -324,7 +334,8 @@ function escapeHtmlAttribute(value) {
 
 async function showConversation(taskId) {
   if (!taskId) return;
-  const res = await fetch(`/api/comms/conversation/${encodeURIComponent(taskId)}`);
+  const params = new URLSearchParams({ limit: String(CONVERSATION_LIMIT) });
+  const res = await fetch(`/api/comms/conversation/${encodeURIComponent(taskId)}?${params}`);
   const data = await res.json();
   const parsed = parseTaskId(taskId);
 
@@ -408,7 +419,8 @@ function showBuildDetail(track, slug, phase, status, taskId) {
   openDetail(html);
   // If there's a task_id, also load the conversation thread
   if (taskId) {
-    fetch(`/api/comms/conversation/${encodeURIComponent(taskId)}`)
+    const params = new URLSearchParams({ limit: String(CONVERSATION_LIMIT) });
+    fetch(`/api/comms/conversation/${encodeURIComponent(taskId)}?${params}`)
       .then(r => r.json())
       .then(data => {
         if (data.messages && data.messages.length > 0) {
@@ -472,7 +484,11 @@ function phaseLabel(phase) {
 // ========= LIVE ACTIVITY =========
 async function loadLiveActivity() {
   try {
-    const res = await fetch('/api/comms/live-activity?minutes=30');
+    const params = new URLSearchParams({
+      minutes: '30',
+      limit: String(DISPATCH_LIMIT),
+    });
+    const res = await fetch(`/api/comms/live-activity?${params}`);
     const data = await res.json();
 
     // Building Now — modules with recently updated state
@@ -735,7 +751,8 @@ async function sendMessage() {
 // ========= MESSAGES =========
 async function loadMessages() {
   try {
-    const res = await fetch('/api/comms/messages?limit=50');
+    const params = new URLSearchParams({ limit: String(MESSAGE_LIMIT) });
+    const res = await fetch(`/api/comms/messages?${params}`);
     const data = await res.json();
 
     document.getElementById('msg-tbody').innerHTML = data.messages.map(m => {
@@ -847,6 +864,14 @@ async function refreshAll() {
   ]);
 }
 
+async function refreshHealthOnly() {
+  try {
+    await fetch('/api/comms/health');
+  } catch(e) {
+    console.error('Health refresh failed:', e);
+  }
+}
+
 document.getElementById('feed-building').addEventListener('click', onBuildRowClick);
 document.getElementById('feed-completions').addEventListener('click', onConversationRowClick);
 document.getElementById('feed-dispatches').addEventListener('click', onConversationRowClick);
@@ -854,7 +879,8 @@ document.getElementById('zombie-list').addEventListener('click', onConversationR
 document.getElementById('msg-tbody').addEventListener('click', onConversationRowClick);
 
 refreshAll();
-setInterval(refreshAll, 15000); // refresh every 15s for live feel
+setInterval(refreshHealthOnly, HEALTH_REFRESH_MS);
+setInterval(refreshAll, FULL_REFRESH_MS);
 </script>
 </body>
 </html>

--- a/playgrounds/index.html
+++ b/playgrounds/index.html
@@ -63,8 +63,14 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
   <a class="card comms" href="/channels.html">
     <div class="icon">&#128172;</div>
     <h2>Agent Channels</h2>
-    <p>Slack-style multi-agent discussions on shared / pipeline / content / architecture / reviews channels. Read + post.</p>
+    <p>Topic-scoped multi-agent discussions on shared / pipeline / content / architecture / reviews channels. Read + post.</p>
     <div class="card-stat" id="comms-stat"></div>
+  </a>
+  <a class="card comms" href="/comms.html" style="border-left-color: var(--blue);">
+    <div class="icon">&#128242;</div>
+    <h2>Agent Comms</h2>
+    <p>Live activity feed, DM-style agent messages, zombie monitor, batch progress.</p>
+    <div class="card-stat" id="agent-comms-stat"></div>
   </a>
   <a class="card audit" href="/audit-dashboard.html">
     <div class="icon">&#9745;</div>
@@ -238,6 +244,8 @@ async function loadStats() {
     const running = tracks.filter(t => t.health === 'healthy').length;
     const stalled = tracks.filter(t => t.health === 'stalled').length;
     document.getElementById('comms-stat').textContent =
+      `${comms.running_processes} processes · ${running} healthy · ${stalled} stalled`;
+    document.getElementById('agent-comms-stat').textContent =
       `${comms.running_processes} processes · ${running} healthy · ${stalled} stalled`;
   } catch(e) {}
 

--- a/scripts/ai_agent_bridge/_broker.py
+++ b/scripts/ai_agent_bridge/_broker.py
@@ -4,7 +4,7 @@ import json
 import os
 import sqlite3
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from ._config import DB_PATH, PID_DIR, REPO_ROOT
@@ -137,8 +137,30 @@ def _remove_pid_file(agent: str, task_id: str):
     pid_file.unlink(missing_ok=True)
 
 
-def broker_cleanup(max_age_hours: int = 24, dry_run: bool = False):
-    """Clean up stuck broker state: stale PIDs, ancient unacked messages, orphaned locks."""
+def _parse_age_window(value: str) -> timedelta:
+    """Parse compact age windows such as 30d, 12h, or 90m."""
+    raw = value.strip().lower()
+    if len(raw) < 2:
+        raise ValueError("age must look like 30d, 12h, or 90m")
+    amount = int(raw[:-1])
+    unit = raw[-1]
+    if amount < 1:
+        raise ValueError("age amount must be positive")
+    if unit == "d":
+        return timedelta(days=amount)
+    if unit == "h":
+        return timedelta(hours=amount)
+    if unit == "m":
+        return timedelta(minutes=amount)
+    raise ValueError("age unit must be one of d, h, or m")
+
+
+def broker_cleanup(
+    max_age_hours: int = 24,
+    dry_run: bool = False,
+    older_than: str = "30d",
+):
+    """Clean stuck broker state and apply explicit message retention."""
     action = "Would clean" if dry_run else "Cleaning"
     cleaned = 0
 
@@ -148,12 +170,132 @@ def broker_cleanup(max_age_hours: int = 24, dry_run: bool = False):
     # 2. Force-ack ancient unacknowledged messages
     cleaned += _cleanup_ancient_messages(action, max_age_hours, dry_run)
 
-    # 3. Summary
+    # 3. Delete old acknowledged/terminal broker rows.
+    cleaned += broker_retention_cleanup(older_than=older_than, dry_run=dry_run)
+
+    # 4. Summary
     mode = " (DRY RUN)" if dry_run else ""
     if cleaned == 0:
         print(f"✅ Broker is clean — nothing to do{mode}")
     else:
         print(f"\n🧹 {cleaned} items cleaned{mode}")
+
+
+def broker_retention_cleanup(older_than: str = "30d", dry_run: bool = False) -> int:
+    """Delete acknowledged/terminal broker rows older than the retention window."""
+    if not DB_PATH.exists():
+        return 0
+
+    cutoff = datetime.now(UTC) - _parse_age_window(older_than)
+    cutoff_iso = cutoff.isoformat()
+    db = sqlite3.connect(str(DB_PATH))
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA busy_timeout=5000")
+    db.execute("PRAGMA foreign_keys=ON")
+
+    counts = _retention_counts(db, cutoff_iso)
+    total = sum(counts.values())
+    mode = "Would delete" if dry_run else "Deleting"
+    print(
+        f"  {mode} retention rows older than {older_than}: "
+        f"{counts['messages']} messages, "
+        f"{counts['deliveries']} deliveries, "
+        f"{counts['channel_messages']} channel_messages"
+    )
+
+    if dry_run or total == 0:
+        db.close()
+        return total
+
+    try:
+        if _table_exists(db, "messages"):
+            db.execute(
+                """
+                DELETE FROM messages
+                WHERE acknowledged = 1 AND timestamp < ?
+                """,
+                (cutoff_iso,),
+            )
+        if _table_exists(db, "deliveries") and _table_exists(db, "channel_messages"):
+            db.execute(
+                """
+                DELETE FROM deliveries
+                WHERE status IN ('delivered', 'failed')
+                  AND message_id IN (
+                      SELECT message_id FROM channel_messages WHERE created_at < ?
+                  )
+                """,
+                (cutoff_iso,),
+            )
+            while True:
+                cur = db.execute(
+                    """
+                    DELETE FROM channel_messages
+                    WHERE created_at < ?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM deliveries d
+                          WHERE d.message_id = channel_messages.message_id
+                      )
+                      AND NOT EXISTS (
+                          SELECT 1 FROM channel_messages child
+                          WHERE child.parent_id = channel_messages.message_id
+                      )
+                    """,
+                    (cutoff_iso,),
+                )
+                if cur.rowcount == 0:
+                    break
+        db.commit()
+        db.execute("VACUUM")
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+    return total
+
+
+def _retention_counts(db: sqlite3.Connection, cutoff_iso: str) -> dict[str, int]:
+    """Return retention delete counts for legacy and channel tables."""
+    counts = {"messages": 0, "deliveries": 0, "channel_messages": 0}
+    if _table_exists(db, "messages"):
+        counts["messages"] = db.execute(
+            "SELECT COUNT(*) FROM messages WHERE acknowledged = 1 AND timestamp < ?",
+            (cutoff_iso,),
+        ).fetchone()[0]
+    if _table_exists(db, "deliveries") and _table_exists(db, "channel_messages"):
+        counts["deliveries"] = db.execute(
+            """
+            SELECT COUNT(*)
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            WHERE d.status IN ('delivered', 'failed')
+              AND cm.created_at < ?
+            """,
+            (cutoff_iso,),
+        ).fetchone()[0]
+        counts["channel_messages"] = db.execute(
+            """
+            SELECT COUNT(*)
+            FROM channel_messages cm
+            WHERE cm.created_at < ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM deliveries d
+                  WHERE d.message_id = cm.message_id
+                    AND d.status NOT IN ('delivered', 'failed')
+              )
+            """,
+            (cutoff_iso,),
+        ).fetchone()[0]
+    return counts
+
+
+def _table_exists(db: sqlite3.Connection, table: str) -> bool:
+    row = db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return row is not None
 
 
 def _cleanup_stale_pids(action: str, max_age_hours: int, dry_run: bool) -> int:

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -543,8 +543,13 @@ def _build_parser() -> argparse.ArgumentParser:
     check_model_parser.add_argument("model", help="Model name")
 
     # cleanup
-    cleanup_parser = subparsers.add_parser("cleanup", help="Clean stuck broker state")
-    cleanup_parser.add_argument("--max-age", type=int, default=24, help="Force-ack messages older than N hours")
+    cleanup_parser = subparsers.add_parser("cleanup", help="Clean stuck broker state and old acknowledged rows")
+    cleanup_parser.add_argument("--max-age", type=int, default=24, help="Force-ack stuck messages older than N hours")
+    cleanup_parser.add_argument(
+        "--older-than",
+        default="30d",
+        help="Delete acknowledged/terminal broker rows older than this age (default: 30d)",
+    )
     cleanup_parser.add_argument("--dry-run", action="store_true", help="Report what would be cleaned")
 
     # status
@@ -610,7 +615,7 @@ def _dispatch_command(args):
         ok = check_model(args.model, force=True)
         sys.exit(0 if ok else 1)
     elif args.command == "cleanup":
-        broker_cleanup(args.max_age, args.dry_run)
+        broker_cleanup(args.max_age, args.dry_run, args.older_than)
     elif args.command == "status":
         bridge_status()
     elif args.command == "interactive":

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -18,6 +18,8 @@ in the B.1 design round (task bridge-b1-schema-design, 2026-04-11).
 
 import sqlite3
 from datetime import UTC, datetime
+from importlib import util as importlib_util
+from pathlib import Path
 
 from ._config import DB_PATH
 
@@ -171,7 +173,57 @@ def _tune_connection(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA cache_size=-20000")
+    conn.execute("PRAGMA temp_store=MEMORY")
     conn.row_factory = sqlite3.Row
+
+
+def _apply_broker_index_migration(conn: sqlite3.Connection) -> None:
+    """Apply the standalone broker-index migration from scripts/migrations."""
+    existing_indexes = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()
+    }
+    existing_tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    required_by_table = {
+        "messages": {
+            "idx_messages_to_agent_created",
+            "idx_messages_from_agent_created",
+            "idx_messages_task_id",
+        },
+        "channel_messages": {
+            "idx_channel_messages_channel_created",
+            "idx_channel_messages_thread_id",
+        },
+        "deliveries": {"idx_deliveries_to_agent_status"},
+    }
+    if all(
+        required_by_table[table].issubset(existing_indexes)
+        for table in required_by_table
+        if table in existing_tables
+    ):
+        return
+
+    migration_path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "2026-05-06-broker-indexes.py"
+    )
+    if not migration_path.exists():
+        return
+    spec = importlib_util.spec_from_file_location("broker_indexes_20260506", migration_path)
+    if spec is None or spec.loader is None:
+        return
+    module = importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.apply(conn)
 
 
 def init_db():
@@ -181,6 +233,7 @@ def init_db():
     _tune_connection(conn)
     conn.executescript(_LEGACY_SCHEMA)
     conn.executescript(_CHANNELS_SCHEMA)
+    _apply_broker_index_migration(conn)
     conn.commit()
     return conn
 
@@ -319,6 +372,7 @@ def get_db():
                         """
                     )
 
+        _apply_broker_index_migration(conn)
         conn.commit()
     except Exception:
         conn.rollback()

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -24,6 +24,7 @@ import sqlite3
 import time
 import uuid
 from datetime import UTC, datetime
+from importlib import util as importlib_util
 
 logger = logging.getLogger(__name__)
 
@@ -59,12 +60,43 @@ def _read_tail_text(path, max_bytes: int = BATCH_LOG_TAIL_BYTES) -> tuple[str, b
         return handle.read().decode("utf-8", errors="replace"), True
 
 
+def _tune_db_connection(conn: sqlite3.Connection, *, writable: bool) -> None:
+    """Apply broker read/write PRAGMAs for API connections."""
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA cache_size=-20000")
+    conn.execute("PRAGMA temp_store=MEMORY")
+    if writable:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+    conn.row_factory = sqlite3.Row
+
+
+def ensure_broker_db_ready() -> None:
+    """Run idempotent broker startup tuning and migrations."""
+    if not MESSAGE_DB.exists():
+        return
+
+    conn = sqlite3.connect(str(MESSAGE_DB))
+    try:
+        _tune_db_connection(conn, writable=True)
+        migration_path = PROJECT_ROOT / "scripts" / "migrations" / "2026-05-06-broker-indexes.py"
+        if migration_path.exists():
+            spec = importlib_util.spec_from_file_location("broker_indexes_20260506", migration_path)
+            if spec is not None and spec.loader is not None:
+                module = importlib_util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                module.apply(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _get_db() -> sqlite3.Connection | None:
     """Get read-only broker DB connection. Returns None if DB missing."""
     if not MESSAGE_DB.exists():
         return None
     conn = connect_sqlite(f"file:{MESSAGE_DB}?mode=ro", uri=True)
-    conn.row_factory = sqlite3.Row
+    _tune_db_connection(conn, writable=False)
     return conn
 
 
@@ -73,7 +105,7 @@ def _get_rw_db() -> sqlite3.Connection | None:
     if not MESSAGE_DB.exists():
         return None
     conn = connect_sqlite(str(MESSAGE_DB))
-    conn.row_factory = sqlite3.Row
+    _tune_db_connection(conn, writable=True)
     return conn
 
 
@@ -99,8 +131,10 @@ async def list_messages(
     task_id: str | None = Query(None),
     msg_type: str | None = Query(None),
     unacked_only: bool = Query(False),
-    limit: int = Query(100, ge=1, le=1000),
+    limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
+    since: str | None = Query(None, description="Only messages with timestamp > this ISO-8601 value"),
+    cursor: int | None = Query(None, ge=1, description="Keyset cursor: return messages older than this id"),
 ):
     """**Deprecated (#1190 B.5).** All broker messages with optional filters.
 
@@ -126,21 +160,35 @@ async def list_messages(
         params.append(msg_type)
     if unacked_only:
         conditions.append("acknowledged = 0")
+    if since:
+        conditions.append("timestamp > ?")
+        params.append(since)
+    if cursor is not None:
+        conditions.append("id < ?")
+        params.append(cursor)
 
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
     total = conn.execute(f"SELECT COUNT(*) FROM messages {where}", params).fetchone()[0]
+    page_params = [*params, limit]
+    if cursor is None:
+        page_params.append(offset)
+        page_clause = "LIMIT ? OFFSET ?"
+    else:
+        page_clause = "LIMIT ?"
     rows = conn.execute(
         f"SELECT id, task_id, from_llm, to_llm, message_type, "
         f"substr(content, 1, 300) as preview, length(content) as content_len, "
         f"timestamp, acknowledged "
-        f"FROM messages {where} ORDER BY id DESC LIMIT ? OFFSET ?",
-        [*params, limit, offset],
+        f"FROM messages {where} ORDER BY id DESC {page_clause}",
+        page_params,
     ).fetchall()
     conn.close()
 
     return {
         "total": total,
+        "limit": limit,
+        "next_cursor": rows[-1]["id"] if len(rows) == limit else None,
         "messages": [dict(r) for r in rows],
     }
 
@@ -176,7 +224,12 @@ async def list_conversations(limit: int = Query(50, ge=1, le=200)):
 
 
 @router.get("/conversation/{task_id}", deprecated=True)
-async def get_conversation(task_id: str):
+async def get_conversation(
+    task_id: str,
+    limit: int = Query(100, ge=1, le=500),
+    since: str | None = Query(None, description="Only messages with timestamp > this ISO-8601 value"),
+    cursor: int | None = Query(None, ge=1, description="Keyset cursor: return messages older than this id"),
+):
     """**Deprecated (#1190 B.5).** Full broker thread for one task_id.
 
     Use /api/comms/channels/{name}/threads/{thread_id} for
@@ -186,17 +239,47 @@ async def get_conversation(task_id: str):
     if not conn:
         return {"messages": []}
 
-    rows = conn.execute("""
+    conditions = ["task_id = ?"]
+    params: list = [task_id]
+    if since:
+        conditions.append("timestamp > ?")
+        params.append(since)
+    if cursor is not None:
+        conditions.append("id < ?")
+        params.append(cursor)
+
+    where = " AND ".join(conditions)
+    total = conn.execute(
+        f"SELECT COUNT(*) FROM messages WHERE {where}",
+        params,
+    ).fetchone()[0]
+    rows = conn.execute(
+        f"""
         SELECT id, task_id, from_llm, to_llm, message_type,
-               substr(content, 1, 500) as preview, length(content) as content_len,
-               data, timestamp, acknowledged
-        FROM messages
-        WHERE task_id = ?
+               preview, content_len, data, timestamp, acknowledged
+        FROM (
+            SELECT id, task_id, from_llm, to_llm, message_type,
+                   substr(content, 1, 500) as preview, length(content) as content_len,
+                   data, timestamp, acknowledged
+            FROM messages
+            WHERE {where}
+            ORDER BY id DESC
+            LIMIT ?
+        )
         ORDER BY id ASC
-    """, (task_id,)).fetchall()
+        """,
+        [*params, limit],
+    ).fetchall()
     conn.close()
 
-    return {"task_id": task_id, "count": len(rows), "messages": [dict(r) for r in rows]}
+    return {
+        "task_id": task_id,
+        "count": len(rows),
+        "total": total,
+        "limit": limit,
+        "next_cursor": rows[0]["id"] if len(rows) == limit else None,
+        "messages": [dict(r) for r in rows],
+    }
 
 
 # ==================== ACTIVE PROCESSES ====================
@@ -806,6 +889,9 @@ def _scan_recent_completions(minutes: int = 60) -> list[dict]:
 async def live_activity(
     response: Response,
     minutes: int = Query(15, ge=1, le=120),
+    limit: int = Query(30, ge=1, le=500, description="Maximum recent broker dispatches"),
+    since: str | None = Query(None, description="Only dispatches with timestamp > this ISO-8601 value"),
+    cursor: int | None = Query(None, ge=1, description="Keyset cursor: return dispatches older than this id"),
 ):
     """What's being built RIGHT NOW — module-level live feed.
 
@@ -839,14 +925,25 @@ async def live_activity(
     # Also get recent broker messages for the dispatch feed
     conn = _get_db()
     dispatches = []
+    rows = []
     if conn:
-        rows = conn.execute("""
+        conditions = []
+        params: list = []
+        if since:
+            conditions.append("timestamp > ?")
+            params.append(since)
+        if cursor is not None:
+            conditions.append("id < ?")
+            params.append(cursor)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        rows = conn.execute(f"""
             SELECT id, task_id, from_llm, to_llm, message_type,
                    substr(content, 1, 200) as preview, timestamp
             FROM messages
+            {where}
             ORDER BY id DESC
-            LIMIT 30
-        """).fetchall()
+            LIMIT ?
+        """, [*params, limit]).fetchall()
         conn.close()
         now_ts = datetime.now(UTC)
         for r in rows:
@@ -870,6 +967,8 @@ async def live_activity(
         "in_progress": acts,
         "recent_completions": completions[:30],
         "recent_dispatches": dispatches,
+        "dispatch_limit": limit,
+        "dispatch_next_cursor": rows[-1]["id"] if len(rows) == limit else None,
     }
 
 

--- a/scripts/api/config.py
+++ b/scripts/api/config.py
@@ -1,5 +1,6 @@
 """Configuration for the playground API."""
 
+import os
 from pathlib import Path
 
 # Project root
@@ -9,7 +10,12 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 
 # Message broker database
-MESSAGE_DB = PROJECT_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"
+MESSAGE_DB = Path(
+    os.environ.get(
+        "AB_DB_PATH",
+        str(PROJECT_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"),
+    )
+)
 
 # Playgrounds directory (for static file serving)
 PLAYGROUNDS_DIR = PROJECT_ROOT / "playgrounds"

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -40,6 +40,7 @@ from .agent_router import router as agent_router
 from .artifacts_router import router as artifacts_router
 from .blue_router import router as blue_router
 from .build_events_router import router as build_events_router
+from .comms_router import ensure_broker_db_ready
 from .comms_router import router as comms_router
 from .config import (
     BATCH_STATE_DIR,
@@ -82,6 +83,7 @@ async def _lifespan(_app: FastAPI):
     See scripts/api/_signal_log.py for the wrapper rationale.
     """
     install_signal_logging()
+    ensure_broker_db_ready()
     yield
 
 

--- a/scripts/migrations/2026-05-06-broker-indexes.py
+++ b/scripts/migrations/2026-05-06-broker-indexes.py
@@ -1,0 +1,101 @@
+"""Add broker indexes for bounded comms dashboard reads.
+
+The original issue text used the logical names ``to_agent``/``from_agent``
+and ``created_at`` for the legacy message bus. The live legacy table in
+this repo is named ``messages`` and uses ``to_llm``/``from_llm`` plus
+``timestamp``. Channel tables already use ``created_at``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB = PROJECT_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def apply(conn: sqlite3.Connection) -> None:
+    """Apply the broker index migration idempotently."""
+    if _table_exists(conn, "messages"):
+        columns = _table_columns(conn, "messages")
+        if {"to_llm", "timestamp"}.issubset(columns):
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_messages_to_agent_created
+                ON messages(to_llm, timestamp DESC)
+                """
+            )
+        if {"from_llm", "timestamp"}.issubset(columns):
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_messages_from_agent_created
+                ON messages(from_llm, timestamp DESC)
+                """
+            )
+        if "task_id" in columns:
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_messages_task_id
+                ON messages(task_id)
+                """
+            )
+
+    if _table_exists(conn, "channel_messages"):
+        columns = _table_columns(conn, "channel_messages")
+        if {"channel", "created_at"}.issubset(columns):
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_channel_messages_channel_created
+                ON channel_messages(channel, created_at DESC)
+                """
+            )
+        if {"thread_id", "channel", "round_index", "created_at"}.issubset(columns):
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_channel_messages_thread_id
+                ON channel_messages(thread_id, channel, round_index, created_at)
+                """
+            )
+
+    if _table_exists(conn, "deliveries"):
+        columns = _table_columns(conn, "deliveries")
+        if {"to_agent", "status"}.issubset(columns):
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_deliveries_to_agent_status
+                ON deliveries(to_agent, status)
+                """
+            )
+
+    conn.commit()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Add broker indexes for comms hot paths.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    args = parser.parse_args()
+
+    if not args.db.exists():
+        raise SystemExit(f"Broker DB not found: {args.db}")
+
+    with sqlite3.connect(str(args.db)) as conn:
+        apply(conn)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_coverage_api_routers.py
+++ b/tests/test_coverage_api_routers.py
@@ -220,6 +220,21 @@ class TestCommsMessages:
         assert len(r.json()["messages"]) == 3
         assert r.json()["total"] == 10
 
+    def test_messages_cursor_and_since(self, comms_client, broker_db):
+        old_ts = "2026-01-01T00:00:00+00:00"
+        new_ts = "2026-01-02T00:00:00+00:00"
+        _insert_messages(broker_db, [
+            {"content": "old", "timestamp": old_ts},
+            {"content": "new", "timestamp": new_ts},
+        ])
+        r = comms_client.get(
+            "/api/comms/messages",
+            params={"limit": 10, "cursor": 2, "since": "2026-01-01T12:00:00+00:00"},
+        )
+        data = r.json()
+        assert data["messages"] == []
+        assert data["next_cursor"] is None
+
     def test_messages_combined_filters(self, comms_client, broker_db):
         _insert_messages(broker_db, [
             {"from_llm": "claude", "task_id": "t1", "message_type": "error", "acknowledged": 0},
@@ -277,6 +292,23 @@ class TestCommsConversationDetail:
         data = r.json()
         assert data["task_id"] == "task-X"
         assert data["count"] == 2
+
+    def test_conversation_detail_limited_with_cursor(self, comms_client, broker_db):
+        _insert_messages(broker_db, [
+            {"task_id": "task-X", "content": f"msg{i}"}
+            for i in range(5)
+        ])
+        r = comms_client.get("/api/comms/conversation/task-X", params={"limit": 2})
+        data = r.json()
+        assert data["count"] == 2
+        assert data["total"] == 5
+        assert data["next_cursor"] == 4
+
+        r2 = comms_client.get(
+            "/api/comms/conversation/task-X",
+            params={"limit": 2, "cursor": data["next_cursor"]},
+        )
+        assert [m["id"] for m in r2.json()["messages"]] == [2, 3]
 
     def test_conversation_detail_no_db(self, comms_client, mock_project_root):
         db_path = mock_project_root / ".mcp" / "servers" / "message-broker" / "messages.db"
@@ -696,6 +728,13 @@ class TestCommsLiveActivity:
         _insert_messages(broker_db, [{"content": "dispatch test"}])
         r = comms_client.get("/api/comms/live-activity")
         assert len(r.json()["recent_dispatches"]) >= 1
+
+    def test_live_activity_dispatch_limit(self, comms_client, broker_db):
+        _insert_messages(broker_db, [{"content": f"dispatch-{i}"} for i in range(3)])
+        r = comms_client.get("/api/comms/live-activity", params={"limit": 2})
+        data = r.json()
+        assert len(data["recent_dispatches"]) == 2
+        assert data["dispatch_next_cursor"] is not None
 
 
 # ===========================================================================

--- a/tests/test_coverage_bridge_audit.py
+++ b/tests/test_coverage_bridge_audit.py
@@ -333,6 +333,71 @@ class TestBroker:
         assert row[0] == 0
         conn.close()
 
+    def test_broker_retention_cleanup_deletes_acknowledged_rows(self, tmp_path):
+        from scripts.ai_agent_bridge._broker import broker_retention_cleanup
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY, task_id TEXT, from_llm TEXT, to_llm TEXT,
+                timestamp TEXT, acknowledged INTEGER DEFAULT 0
+            );
+            CREATE TABLE channel_messages (
+                message_id TEXT PRIMARY KEY, created_at TEXT, parent_id TEXT
+            );
+            CREATE TABLE deliveries (
+                delivery_id TEXT PRIMARY KEY, message_id TEXT, status TEXT
+            );
+        """)
+        old_ts = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+        conn.execute(
+            "INSERT INTO messages (id, task_id, from_llm, to_llm, timestamp, acknowledged) VALUES (?, ?, ?, ?, ?, 1)",
+            (1, "task-1", "claude", "gemini", old_ts),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, task_id, from_llm, to_llm, timestamp, acknowledged) VALUES (?, ?, ?, ?, ?, 0)",
+            (2, "task-2", "claude", "gemini", old_ts),
+        )
+        conn.execute(
+            "INSERT INTO channel_messages (message_id, created_at, parent_id) VALUES (?, ?, NULL)",
+            ("m1", old_ts),
+        )
+        conn.execute(
+            "INSERT INTO deliveries (delivery_id, message_id, status) VALUES (?, ?, ?)",
+            ("d1", "m1", "delivered"),
+        )
+        conn.commit()
+        conn.close()
+        with patch("scripts.ai_agent_bridge._broker.DB_PATH", db_path):
+            result = broker_retention_cleanup("30d", False)
+        assert result == 3
+        conn = sqlite3.connect(str(db_path))
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM channel_messages").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM deliveries").fetchone()[0] == 0
+        conn.close()
+
+    def test_broker_retention_cleanup_dry_run(self, tmp_path):
+        from scripts.ai_agent_bridge._broker import broker_retention_cleanup
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""CREATE TABLE messages (
+            id INTEGER PRIMARY KEY, timestamp TEXT, acknowledged INTEGER DEFAULT 0
+        )""")
+        old_ts = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+        conn.execute(
+            "INSERT INTO messages (id, timestamp, acknowledged) VALUES (?, ?, 1)",
+            (1, old_ts),
+        )
+        conn.commit()
+        conn.close()
+        with patch("scripts.ai_agent_bridge._broker.DB_PATH", db_path):
+            result = broker_retention_cleanup("30d", True)
+        assert result == 1
+        conn = sqlite3.connect(str(db_path))
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 1
+        conn.close()
+
     def test_bridge_status_no_pid_dir(self, tmp_path, capsys):
         from scripts.ai_agent_bridge._broker import bridge_status
         with patch("scripts.ai_agent_bridge._broker.PID_DIR", tmp_path / "nope"):


### PR DESCRIPTION
## Summary

Fixes #1736.

- Bounds legacy comms hot paths with server-enforced limits, keyset cursors, optional `since`, and client polling limits.
- Adds idempotent broker index migration plus API/bridge startup application and SQLite PRAGMA tuning.
- Adds explicit `ab cleanup --older-than 30d [--dry-run]` broker retention cleanup; documents weekly operator workflow and WAL expectations.
- Splits `Agent Channels` and `Agent Comms` on the playground index and adds matching Home links to both dashboards.
- Records the storage decision: SQLite remains the right localhost broker store; the observed bottleneck was unindexed scans plus unbounded result sets.

## Commit / AC mapping

- `fix(comms): bound broker dashboard queries`
  - AC1: identified slow/unbounded `/api/comms/messages`, `/api/comms/conversation/{task_id}`, `/api/comms/live-activity` legacy message reads.
  - AC4/AC6/AC7: adds bounded query params, idempotent startup migration, EXPLAIN-backed indexes, WAL/cache/temp PRAGMAs.
- `feat(ab): add broker retention cleanup`
  - AC5/AC8: explicit retention CLI, docs, and SQLite decision record.
- `fix(playgrounds): split comms nav cards`
  - AC2/AC3: main-page cards and top-left Home links; comms polling uses bounded endpoint params and 30s full refresh.

## Investigation evidence

- Live local broker volume was small, not tens of thousands: `messages=550`, `channel_messages=428`, `deliveries=314`.
- WAL was already active on the live broker DB: `PRAGMA journal_mode` => `wal`.
- Baseline EXPLAIN showed scans on legacy message hot paths:
  - `/api/comms/messages`: `SCAN messages`
  - `/api/comms/messages?agent=...`: `SCAN messages`
  - `/api/comms/conversation/{task_id}`: `SCAN messages`
  - `/api/comms/live-activity`: `SCAN messages`
- After migration, EXPLAIN uses the new indexes:
  - agent filtered messages: `SEARCH messages USING INDEX idx_messages_from_agent_created` / `idx_messages_to_agent_created`
  - conversation: `SEARCH messages USING INDEX idx_messages_task_id`
  - channel messages: `SEARCH channel_messages USING INDEX idx_channel_messages_channel_created`
  - thread: `SEARCH channel_messages USING INDEX idx_channel_messages_thread_id`
  - deliveries: `SEARCH d USING INDEX idx_deliveries_to_agent_status`

## Validation

- `git diff --check origin/main...HEAD`
- Pre-submit hygiene: `.python-version`, `.yamllint`, `.markdownlint.json` unchanged; no status/audit/review artifacts; no `sys.executable` added in changed code/tests; 15 files in PR diff.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m ruff check ...` passed.
- Targeted pytest passed: 46 passed for comms API pagination + broker cleanup tests.
- Commit hooks passed affected-file tests: 157 API tests and 193 bridge-audit tests on staged commits.
- Migration idempotency verified by running the migration twice against a copied broker DB; no duplicate index errors.
- Worktree API smoke on `127.0.0.1:8767` with copied broker DB:
  - `/api/comms/health`: 0.006s initial response.
  - `/api/comms/messages?limit=50`, `/api/comms/live-activity?minutes=30&limit=30`, `/api/comms/conversation/...?...limit=100`, `/api/comms/batch-progress`, `/api/comms/zombies`, `/api/comms/stats` all returned 200.
  - With `comms.html` open and polling for 5 minutes: 60 health samples, 0 failures, max 0.004752s, avg 0.002453s.

## Full pytest note

I ran the full suite once. It did not pass in this delegated worktree: 7007 passed, 214 skipped, 11 xfailed, 28 failed. The failures were outside this change set and were environment/data/auth related, including missing worktree `.venv/bin/python`, missing fixture JSONL/registry data, HuggingFace 401s for `BAAI/bge-m3`, and missing `embed-venv/bin/python`.
