### PR TITLE
fix(api): tactical stability pass — top-5 endpoints + smoke test + audit (#1737)

### DIFF
--- a/.mcp/servers/message-broker/server.py
+++ b/.mcp/servers/message-broker/server.py
@@ -79,6 +79,24 @@ async def init_db():
         await db.execute("""
             CREATE INDEX IF NOT EXISTS idx_task ON messages(task_id)
         """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_task_id ON messages(task_id, id)
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_acknowledged ON messages(acknowledged, id)
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_message_type ON messages(message_type, id)
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp)
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_from_llm ON messages(from_llm, id)
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_to_llm ON messages(to_llm, id)
+        """)
         # Migration: add claimed_by/claimed_at to existing tables
         with suppress(Exception):
             await db.execute("ALTER TABLE messages ADD COLUMN claimed_by TEXT")

--- a/docs/api-stability-audit-2026-05-06.md
+++ b/docs/api-stability-audit-2026-05-06.md
@@ -1,0 +1,149 @@
+# API Stability Audit - 2026-05-06
+
+Scope: all `playgrounds/*.html` dashboards. Measurements used 5 `curl` samples
+unless noted. Patched-code measurements used the worktree API on `127.0.0.1:8877`.
+Broker-backed comms measurements used the live local API on `127.0.0.1:8765`,
+because this worktree has an empty broker DB.
+
+## Ranked Stressors
+
+| Rank | Endpoint | Dashboard(s) | Before | After | Fix |
+| ---: | --- | --- | ---: | ---: | --- |
+| 1 | `/api/wiki/status` | `index.html`, `wiki.html` | timed out at 20 s on live single worker | p99 0.56-0.68 s cold, median <1 ms cached | Reused article index, stopped per-slug source gathering, added TTL cache |
+| 2 | `/api/dashboard/overview` | `index.html`, `audit-dashboard.html`, `curriculum-dashboard.html` | p99 7.9-8.6 s cold | p99 0.30 s cold, median 0.035 s | Switched overview to lightweight summary scan |
+| 3 | `/api/comms/batch-progress` | `index.html`, `comms.html` | median 0.47-0.51 s every poll | p99 0.045 s in patched code | Bounded log reads to 256 KiB tail, added 10 s TTL cache |
+| 4 | `/api/state/weak-points?limit=1` | `index.html` | p99 7.5-8.3 s cold | p99 0.098 s cold, median <1 ms cached | Avoided 1,776 plan YAML reads when `word_count == 0`, added TTL cache |
+| 5 | `/api/rag/search_text` | `image-explorer.html` | can stall single worker when Qdrant is down | fast 503 after socket probe | Added 250 ms Qdrant port check |
+
+## Server Findings
+
+- Middleware-level request concurrency limits: none found.
+- Uvicorn process model: `package.json` runs one default uvicorn worker. No
+  `--workers` or `--limit-concurrency` is configured.
+- Single-worker impact: reproduced. A wedged dashboard request caused `/api/health`
+  to time out until that request returned.
+- Live server process during audit: PID 54081, RSS about 54 MiB, open FDs about 78.
+- Existing broker indexes: channel tables were indexed, legacy `messages` was not.
+  Added idempotent `messages` indexes and applied them to the live local DB.
+
+## Endpoint Matrix
+
+`Pagination` means the endpoint has a caller-visible `limit`, `tail`, `page`, or
+equivalent bounded response control. `SQL/plan` is abbreviated to the dominant
+backend path.
+
+| Dashboard | Polling | Endpoint | Median / p99 latency | Median / p99 bytes | SQL / plan | Pagination |
+| --- | --- | --- | ---: | ---: | --- | --- |
+| `index.html` | none | `/api/dashboard/overview` | 0.035 / 0.301 s | 7,857 / 7,857 | filesystem status summary | no, cached |
+| `index.html` | none | `/api/state/pipeline-versions` | 0.0008 / 0.099 s | 1,253 / 1,253 | filesystem, cached | no |
+| `index.html` | none | `/api/consultation/metrics` | 0.0008 / 0.005 s | 349 / 349 | filesystem | no |
+| `index.html` | none | `/api/state/summary` | 0.0008 / 0.194 s | 4,128 / 4,128 | filesystem, cached | no |
+| `index.html` | none | `/api/comms/batch-progress` | 0.0007 / 0.044 s | 85 / 85 | bounded log tail + `ps` | bounded tail |
+| `index.html` | none | `/api/state/weak-points?limit=1` | 0.0007 / 0.098 s | 24 / 24 | filesystem audit/research scan | yes |
+| `index.html` | none | `/api/orient` | 0.0017 / 0.623 s | 10,693 / 10,701 | mixed cached collectors | no |
+| `index.html` | none | `/api/runtime/agents` | 0.0020 / 0.002 s | 583 / 583 | filesystem | no |
+| `index.html` | none | `/api/delegate/tasks?limit=100` | 0.0008 / 0.001 s | 22 / 22 | filesystem | yes |
+| `index.html` | none | `/api/build/events/active` | 0.0028 / 0.004 s | 13 / 13 | JSONL tail | bounded |
+| `index.html` | none | `/api/wiki/status` | 0.0008 / 0.559 s | 1,696 / 1,696 | filesystem + progress cache | no, cached |
+| `index.html` | none | `/api/analytics/cost` | 0.0042 / 0.005 s | 11,509 / 11,509 | dispatch meta glob | no |
+| `channels.html` | 5 s | `/api/comms/channels` | 0.0013 / 0.001 s live | 2,098 / 2,098 | `channel_messages` covering index | no |
+| `channels.html` | active channel load | `/api/comms/channels/{name}` | 0.001 s class | varies | indexed `channels.name`, channel count | no |
+| `channels.html` | active channel load | `/api/comms/channels/{name}/messages?tail=50` | 0.0012 / 0.001 s live for missing `general` | 39 / 39 | `idx_channel_messages_channel_time` | yes |
+| `channels.html` | active channel load | `/api/comms/channels/{name}/deliveries?status=pending&limit=20` | 0.001 s class | varies | `idx_channel_messages_channel_time` + `idx_deliveries_message` | yes |
+| `channels.html` | user action | `POST /api/comms/channels/{name}/post` | not benchmarked | n/a | indexed insert fanout | n/a |
+| `comms.html` | 15 s | `/api/comms/messages?limit=1&offset=0` | 0.003 s live | small | rowid scan in descending id order | yes |
+| `comms.html` | 15 s | `/api/comms/messages?limit=50` | 0.0029 / 0.031 s live | 23,910 / 23,910 | rowid scan, indexed filters if present | yes |
+| `comms.html` | 15 s | `/api/comms/live-activity?minutes=30` | 0.0032 / 0.0047 s live | 9,716 / 9,716 | filesystem recent-state scan + message tail | bounded |
+| `comms.html` | 15 s | `/api/comms/batch-progress` | 0.51 s live before patch | 5,460 / 5,460 | unbounded logs before patch | bounded tail after patch |
+| `comms.html` | 15 s | `/api/comms/zombies` | 0.005 / 0.009 s live | 280 / 280 | `idx_messages_acknowledged`, `message_type` | no, indexed |
+| `comms.html` | 15 s | `/api/comms/stats` | 0.0035 / 0.0036 s live | 233 / 233 | `messages` aggregate counts | no, indexed |
+| `comms.html` | 15 s | `/api/comms/health` | 0.0007 / 0.001 s | 113 / 113 | `idx_messages_acknowledged` | no |
+| `comms.html` | user action | `POST /api/comms/send` | not benchmarked | n/a | legacy message insert | n/a |
+| `comms.html` | user action | `POST /api/comms/acknowledge/{id}` | not benchmarked | n/a | primary-key update | n/a |
+| `admin.html` | health every 30 s | `/api/admin/health` | 0.0117 / 0.0145 s | 321 / 321 | filesystem + broker probe | no |
+| `admin.html` | on demand | `/api/admin/disk-usage` | 0.0019 / 0.0044 s | 1,545 / 1,545 | filesystem | no |
+| `admin.html` | on demand | `/api/admin/backup/list` | 0.0006 / 0.0009 s | 154 / 154 | filesystem | no |
+| `admin.html` | on demand | `/api/admin/maintenance/embedding-cache-stats` | 0.0006 / 0.0009 s | 54 / 54 | filesystem | no |
+| `admin.html` | on demand | `/api/admin/maintenance/annotation-stats` | 0.0005 / 0.0010 s | 47 / 47 | filesystem | no |
+| `admin.html` | on demand | `/api/admin/collections` | 0.0014 / 0.0018 s, 503 when Qdrant absent | 63 / 63 | Qdrant probe | no |
+| `admin.html` | user action | backup, vacuum, clean logs, verify collections | not benchmarked | n/a | mutating operations | n/a |
+| `audit-dashboard.html` | none | `/api/dashboard/overview` and dashboard detail endpoints | see overview / track rows | see rows | filesystem summary/detail | no |
+| `build-events.html` | 10 s | `/api/build/events/active` | 0.0028 / 0.004 s | 13 / 13 | build event JSONL | bounded |
+| `build-events.html` | 10 s | `/api/build/events/recent?limit=50&offset=0` | 0.0029 / 0.0036 s | 6,526 / 6,526 | build event JSONL | yes |
+| `consultation.html` | none | `/api/config` | not rebenchmarked; health smoke passed | small | static config | no |
+| `consultation.html` | on demand | `/api/consultation/metrics` | 0.0008 / 0.005 s | 349 / 349 | filesystem | no |
+| `cost.html` | none | `/api/analytics/cost` | 0.0042 / 0.005 s | 11,509 / 11,509 | dispatch meta glob | no |
+| `cost.html` | search | `/api/analytics/cost?track={track}` | same class | varies | filtered dispatch meta glob | no |
+| `cost.html` | search | `/api/analytics/cost/module/{level}/{slug}` | same class | varies | scoped dispatch meta glob | no |
+| `cost.html` | search | `/api/analytics/cost/phase/{name}` | same class | varies | filtered dispatch meta glob | no |
+| `curriculum-dashboard.html` | 30 s | `/api/dashboard/overview` | 0.035 / 0.301 s | 7,857 / 7,857 | lightweight filesystem summary | no, cached |
+| `delegate.html` | none | `/api/delegate/tasks?limit=100` | 0.0008 / 0.001 s | 22 / 22 | filesystem task dirs | yes |
+| `delegate.html` | detail click | `/api/delegate/tasks/{task_id}` | not benchmarked | n/a | filesystem detail | n/a |
+| `image-explorer.html` | none | `/api/rag/search_text?q=test&limit=5` | fast 503 after patch when Qdrant down | 503 body | Qdrant socket probe + query | yes |
+| `image-explorer.html` | none | `/api/rag/search_images`, `/api/rag/search_literary` | same class | varies | Qdrant socket probe + query | yes |
+| `images.html` | none | `/api/images/textbooks` | direct function 0.135 s cold | large catalog | PDF catalog scan | no, cached singleton |
+| `images.html` | none | `/api/images/annotations` | same index class | varies | JSONL index + pagination | yes |
+| `images.html` | none | `/api/images/stats` | same index class | small | JSONL index aggregate | no, cached singleton |
+| `orient.html` | 30 s | `/api/orient` | 0.0017 / 0.623 s | 10,693 / 10,701 | mixed collectors, per-section TTLs | no |
+| `progress.html` | none | `/api/state/pipeline/{track}` | not in broad matrix | varies | filesystem pipeline state | no, cached |
+| `progress.html` | none | `/api/state/summary` | 0.0008 / 0.194 s | 4,128 / 4,128 | filesystem summary | no, cached |
+| `progress.html` | none | `/api/state/pipeline-versions` | 0.0008 / 0.099 s | 1,253 / 1,253 | filesystem | no, cached |
+| `quality.html` | none | `/api/state/research-coverage` | health smoke passed | varies | filesystem research scan | no, cached |
+| `quality.html` | none | `/api/state/review-coverage` | health smoke passed | varies | filesystem review scan | no, cached |
+| `quality.html` | none | `/api/state/issues` | health smoke passed | varies | filesystem review/audit scan | no |
+| `quality.html` | none | `/api/state/weak-points?limit=500` | patched class | varies | filesystem audit/research scan | yes, cached |
+| `runtime.html` | 30 s | `/api/runtime/agents` | 0.0020 / 0.002 s | 583 / 583 | filesystem/process state | no |
+| `runtime.html` | 30 s | `/api/runtime/usage?days=7` | health smoke passed | varies | runtime logs | bounded by days |
+| `runtime.html` | 30 s | `/api/runtime/headroom?...` | per-agent fanout | varies | runtime config | no |
+| `runtime.html` | 30 s | `/api/runtime/recent?limit=50` | health smoke passed | varies | runtime logs | yes |
+| `track-health.html` | 30 s | `/api/state/build-status` | health smoke passed | varies | filesystem build status | no, cached |
+| `track-health.html` | 30 s | `/api/state/enrichment-status` | health smoke passed | varies | filesystem plan scan | no, cached |
+| `track-health.html` | 30 s | `/api/state/track-health/a1` | health smoke passed | varies | filesystem track scan | no, cached |
+| `track-health.html` | track click | `/api/state/module/a1/1` | health smoke passed | varies | filesystem module detail + comms preview | no |
+| `track-health.html` | track click | `/api/comms/by-module/a1/hello` | worktree DB empty; live class indexed poorly for leading wildcard | varies | `LIKE '%slug%'` scan | yes limit, cannot index leading wildcard |
+| `wiki.html` | 60 s | `/api/wiki/status` | 0.0008 / 0.559 s | 1,696 / 1,696 | filesystem + progress cache | no, cached |
+| `wiki.html` | 60 s | `/api/wiki/status/a1` | 0.0011 / 0.305 s | 5,369 / 5,369 | filesystem + progress cache | no, cached |
+| `wiki.html` | 60 s | `/api/wiki/quality-gate/a1` | health smoke passed | varies | filesystem markdown scan | no |
+| `wiki.html` | 60 s | `/api/wiki/build-log?limit=50` | health smoke passed | varies | log tail | yes |
+
+## SQL Query Plans
+
+Plans were run against the live broker DB after applying the new indexes.
+
+```text
+/api/comms/messages?limit=50
+SCAN messages
+
+/api/comms/zombies stale messages
+SEARCH messages USING INDEX idx_messages_acknowledged (acknowledged=?)
+
+/api/comms/by-module/{track}/{slug}
+SCAN messages
+Reason: task_id LIKE '%slug%' has a leading wildcard and cannot use the task index.
+
+/api/comms/channels
+SCAN channel_messages USING COVERING INDEX idx_channel_messages_channel_time
+
+/api/comms/channels/{name}/messages?tail=50
+SEARCH channel_messages USING INDEX idx_channel_messages_channel_time (channel=?)
+
+/api/comms/channels/{name}/deliveries?status=pending&limit=20
+SEARCH cm USING INDEX idx_channel_messages_channel_time (channel=?)
+SEARCH d USING INDEX idx_deliveries_message (message_id=?)
+```
+
+## Fixes Applied
+
+- `scripts/api/wiki_router.py`: cached aggregate and per-track status, reused a
+  single article candidate index per request, and used progress metadata for
+  `source_count` instead of gathering discovery sources for every slug.
+- `scripts/api/dashboard_router.py` and `scripts/api/dashboard_helpers.py`:
+  overview now uses lightweight summaries instead of full research scoring.
+- `scripts/api/comms_router.py`: `/api/comms/batch-progress` reads only the last
+  256 KiB of each current log and caches for 10 seconds.
+- `scripts/api/state_router.py`: `/api/state/weak-points` avoids plan YAML reads
+  when no word count exists and caches by query parameters for 60 seconds.
+- `scripts/api/rag_router.py`: Qdrant-backed search endpoints fail fast when the
+  local Qdrant port is closed.
+- `scripts/ai_agent_bridge/_db.py` and `.mcp/servers/message-broker/server.py`:
+  added idempotent indexes for legacy `messages` filters used by dashboards.

--- a/docs/best-practices/local-api-server.md
+++ b/docs/best-practices/local-api-server.md
@@ -1,0 +1,86 @@
+# Local API Server
+
+The playground API is a local development service, not a production web
+service. It still needs guardrails because the dashboards poll multiple heavy
+filesystem and SQLite endpoints from one browser session.
+
+## Current Process Model
+
+`package.json` currently starts uvicorn like this:
+
+```bash
+.venv/bin/python -m uvicorn scripts.api.main:app --host 0.0.0.0 --port 8765 --log-config scripts/api/logging.json
+```
+
+Findings from the 2026-05-06 stability audit:
+
+- Uvicorn runs with the default single worker.
+- No `--limit-concurrency` value is configured.
+- No FastAPI middleware-level request concurrency limit is installed.
+- `scripts/api/main.py` has a dedicated thread pool only for `/api/orient`
+  sync collectors. It does not limit whole-server request concurrency.
+- A single blocking request can stall `/api/health` in the current process
+  model.
+
+## Recommended Defaults
+
+Do not change the process model without user signoff. The recommended next
+configuration to test is:
+
+```bash
+.venv/bin/python -m uvicorn scripts.api.main:app \
+  --host 127.0.0.1 \
+  --port 8765 \
+  --workers 2 \
+  --limit-concurrency 32 \
+  --log-config scripts/api/logging.json
+```
+
+Rationale:
+
+- `--workers 2` keeps one dashboard request from monopolizing the only event
+  loop process.
+- `--limit-concurrency 32` prevents one browser or script from queueing
+  unlimited work.
+- `127.0.0.1` matches the localhost-only intent in `scripts/api/config.py`.
+  Current npm scripts bind to `0.0.0.0`; tighten that separately if remote LAN
+  access is not intentionally needed.
+
+Tradeoffs:
+
+- In-memory TTL caches become per-worker, so the first request to each worker
+  may pay a cold-cache cost.
+- Background mutable operations, especially admin maintenance endpoints, must be
+  reviewed before multi-worker is made default.
+- `--reload` and `--workers` should not be used together for the normal dev
+  workflow.
+
+## Endpoint Design Rules
+
+- Dashboard polling endpoints must be bounded by `limit`, `tail`, `page`, or a
+  short TTL cache.
+- SQLite tables used by polling paths need indexes matching their `WHERE` and
+  `ORDER BY` clauses.
+- Endpoints that depend on optional local services, such as Qdrant, must fail
+  fast when the service is down.
+- Filesystem scans that aggregate all tracks should use summary data when the
+  UI only needs counts.
+- Log readers should read bounded tails unless the endpoint is explicitly an
+  export operation.
+
+## Operational Checks
+
+Use these while exercising dashboards:
+
+```bash
+pid=$(pgrep -f 'uvicorn scripts.api.main:app' | head -1)
+ps -o rss= -p "$pid"
+lsof -p "$pid" | wc -l
+curl -s -w '%{time_total}\n' -o /dev/null http://127.0.0.1:8765/api/health
+```
+
+Healthy local expectations:
+
+- `/api/health` stays under 200 ms while dashboards are being opened.
+- RSS should stabilize after warm caches; it should not climb on every poll.
+- File descriptors should remain roughly flat after PDF and SQLite caches warm.

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -38,6 +38,19 @@ CREATE TABLE IF NOT EXISTS messages (
     status TEXT DEFAULT 'pending'
 );
 
+CREATE INDEX IF NOT EXISTS idx_messages_task_id
+    ON messages(task_id, id);
+CREATE INDEX IF NOT EXISTS idx_messages_acknowledged
+    ON messages(acknowledged, id);
+CREATE INDEX IF NOT EXISTS idx_messages_message_type
+    ON messages(message_type, id);
+CREATE INDEX IF NOT EXISTS idx_messages_timestamp
+    ON messages(timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_from_llm
+    ON messages(from_llm, id);
+CREATE INDEX IF NOT EXISTS idx_messages_to_llm
+    ON messages(to_llm, id);
+
 CREATE TABLE IF NOT EXISTS sessions (
     task_id TEXT PRIMARY KEY,
     claude_session_id TEXT,
@@ -172,6 +185,24 @@ def init_db():
     return conn
 
 
+def _ensure_legacy_indexes(conn: sqlite3.Connection) -> None:
+    """Create legacy message indexes needed by dashboard polling paths."""
+    conn.executescript("""
+    CREATE INDEX IF NOT EXISTS idx_messages_task_id
+        ON messages(task_id, id);
+    CREATE INDEX IF NOT EXISTS idx_messages_acknowledged
+        ON messages(acknowledged, id);
+    CREATE INDEX IF NOT EXISTS idx_messages_message_type
+        ON messages(message_type, id);
+    CREATE INDEX IF NOT EXISTS idx_messages_timestamp
+        ON messages(timestamp);
+    CREATE INDEX IF NOT EXISTS idx_messages_from_llm
+        ON messages(from_llm, id);
+    CREATE INDEX IF NOT EXISTS idx_messages_to_llm
+        ON messages(to_llm, id);
+    """)
+
+
 def get_db():
     """Get database connection with auto-migration (#604, #1190)."""
     if not DB_PATH.exists():
@@ -191,6 +222,7 @@ def get_db():
         elif "status" not in columns:
             print("🔧 Migrating database: adding 'status' column to 'messages' table")
             conn.execute("ALTER TABLE messages ADD COLUMN status TEXT DEFAULT 'pending'")
+        _ensure_legacy_indexes(conn)
 
         # --- Sessions table migration (#604) ---
         conn.execute("""

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -37,6 +37,7 @@ except ImportError:
 from pydantic import BaseModel
 
 from .config import CURRICULUM_ROOT, MESSAGE_DB, PROJECT_ROOT
+from .state_helpers import cache_get, cache_set
 
 router = APIRouter(tags=["comms"])
 
@@ -44,6 +45,17 @@ router = APIRouter(tags=["comms"])
 
 PID_DIR = PROJECT_ROOT / ".mcp" / "servers" / "message-broker" / "pids"
 LOG_DIR = PROJECT_ROOT / "logs" / "research-preseed"
+BATCH_LOG_TAIL_BYTES = 256 * 1024
+
+
+def _read_tail_text(path, max_bytes: int = BATCH_LOG_TAIL_BYTES) -> tuple[str, bool]:
+    """Read at most the tail of a log file for dashboard polling."""
+    size = path.stat().st_size
+    if size <= max_bytes:
+        return path.read_text(errors="replace"), False
+    with path.open("rb") as handle:
+        handle.seek(-max_bytes, os.SEEK_END)
+        return handle.read().decode("utf-8", errors="replace"), True
 
 
 def _get_db() -> sqlite3.Connection | None:
@@ -459,8 +471,9 @@ def _scan_preseed_logs() -> list[dict]:
         track = lf.name.replace(f"-{latest_ts}.log", "")
         stat = lf.stat()
 
-        # Parse log for progress
-        text = lf.read_text(errors="replace")
+        # Parse a bounded tail for progress. Full historical preseed logs
+        # can be multi-MB and this endpoint is polled by dashboards.
+        text, truncated = _read_tail_text(lf)
         passed = len(re.findall(r"VERDICT: PASS", text))
         failed = len(re.findall(r"VERDICT: FAIL|FAILED —|ERROR:", text))
 
@@ -488,6 +501,7 @@ def _scan_preseed_logs() -> list[dict]:
             "failed": failed,
             "complete": batch_complete,
             "last_line": last_line,
+            "truncated": truncated,
         })
 
     return sorted(results, key=lambda r: r["track"])
@@ -592,6 +606,11 @@ async def batch_progress():
     """
     import asyncio
 
+    cache_key = f"comms_batch_progress_{LOG_DIR}_{PID_DIR}"
+    cached = cache_get(cache_key, ttl=10.0)
+    if cached is not None:
+        return cached
+
     logs, processes = await asyncio.gather(
         asyncio.to_thread(_scan_preseed_logs),
         asyncio.to_thread(_check_build_processes),
@@ -632,11 +651,13 @@ async def batch_progress():
             "process": proc,
         }
 
-    return {
+    result = {
         "generated_at": datetime.now(UTC).isoformat(),
         "running_processes": len(processes),
         "tracks": track_progress,
     }
+    cache_set(cache_key, result)
+    return result
 
 
 @router.get("/batch-progress/{track}")

--- a/scripts/api/dashboard_helpers.py
+++ b/scripts/api/dashboard_helpers.py
@@ -326,7 +326,6 @@ def build_module_summary(track_dir: Path, plans_dir: Path, track_id: str, slug: 
     orch_dir = _safe_join(track_dir, "orchestration", slug)
     pipeline_version = detect_pipeline_version(orch_dir) if orch_dir and orch_dir.exists() else "unbuilt"
     review_info = extract_review_info(track_dir, slug)
-
     return {
         "slug": slug,
         "num": num,

--- a/scripts/api/dashboard_router.py
+++ b/scripts/api/dashboard_router.py
@@ -27,6 +27,7 @@ from .dashboard_comms import (
     read_dispatcher_state,
 )
 from .dashboard_helpers import (
+    compute_track_stats,
     default_research_info,
     extract_review_info,
     find_active_builds,
@@ -69,7 +70,8 @@ async def overview():
         if not track_modules:
             continue
 
-        track_data = scan_track_cached(track_id, level_cfg["path"], track_modules)
+        track_data = scan_track_summary_cached(track_id, level_cfg["path"], track_modules)
+        track_data["stats"] = compute_track_stats(track_data["modules"], track_id)
         s = track_data["stats"]
         pct = round(s["pass"] / track_data["module_count"] * 100) if track_data["module_count"] > 0 else 0
 

--- a/scripts/api/rag_router.py
+++ b/scripts/api/rag_router.py
@@ -5,6 +5,7 @@ and ports the browse logic from image_review_server.py.
 """
 
 import re
+import socket
 import sys
 
 from fastapi import APIRouter, Query
@@ -26,6 +27,10 @@ ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
 def _qdrant_available() -> bool:
     """Quick check if Qdrant is reachable."""
     try:
+        from rag.config import QDRANT_GRPC_PORT, QDRANT_HOST
+
+        with socket.create_connection((QDRANT_HOST, QDRANT_GRPC_PORT), timeout=0.25):
+            pass
         from rag.query import get_client
         get_client().get_collections()
         return True

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -199,6 +199,11 @@ async def weak_points(
     limit: int = Query(20, ge=1, le=500),
 ):
     """Modules with quality issues: failing audit, thin research, or low word count."""
+    cache_key = f"weak_points_{track or 'all'}_{min_score}_{limit}"
+    cached = cache_get(cache_key, ttl=60.0)
+    if cached is not None:
+        return cached
+
     def _compute():
         weak = []
         level_cfgs = [l for l in LEVELS if l["id"] == track] if track else LEVELS
@@ -221,7 +226,7 @@ async def weak_points(
 
                 word_count = audit.get("word_count", 0)
                 word_target = audit.get("word_target", 0)
-                if word_target == 0:
+                if word_target == 0 and word_count > 0:
                     word_target = get_word_target_from_plan(track_id, slug)
                 if word_target > 0 and word_count > 0 and word_count < word_target * 0.8:
                     issues.append(f"low_words_{word_count}/{word_target}")
@@ -240,7 +245,9 @@ async def weak_points(
         weak.sort(key=severity_key)
         return {"count": len(weak), "modules": weak[:limit]}
 
-    return await asyncio.to_thread(_compute)
+    result = await asyncio.to_thread(_compute)
+    cache_set(cache_key, result)
+    return result
 
 
 @router.get("/failing")

--- a/scripts/api/wiki_router.py
+++ b/scripts/api/wiki_router.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 
 from .config import CURRICULUM_ROOT, LEVELS
+from .state_helpers import cache_get, cache_set
 
 # scripts/wiki is not a package, so we add the scripts/ root to sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -113,8 +114,15 @@ def _matches_track_domain(track: str, rel_path: str) -> bool:
     return any(rel_path.startswith(f"{domain}/") for domain in domains)
 
 
-def _resolve_article(track: str, slug: str) -> dict[str, Any] | None:
-    candidates = _list_article_candidates().get(slug, [])
+def _resolve_article(
+    track: str,
+    slug: str,
+    candidates_by_slug: dict[str, list[dict[str, Any]]] | None = None,
+) -> dict[str, Any] | None:
+    article_candidates = (
+        _list_article_candidates() if candidates_by_slug is None else candidates_by_slug
+    )
+    candidates = article_candidates.get(slug, [])
     if not candidates:
         return None
 
@@ -154,14 +162,20 @@ def _source_count(track: str, slug: str) -> int:
     )
 
 
-def _track_status_rows(track: str) -> list[dict[str, Any]]:
+def _track_status_rows(
+    track: str,
+    candidates_by_slug: dict[str, list[dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
     _ensure_track_exists(track)
     slugs = _track_slugs(track)
+    article_candidates = (
+        _list_article_candidates() if candidates_by_slug is None else candidates_by_slug
+    )
     word_cache: dict[Path, dict[str, Any]] = {}
     rows = []
 
     for slug in slugs:
-        article = _resolve_article(track, slug)
+        article = _resolve_article(track, slug, article_candidates)
         article_path = _safe_join(wiki_config.WIKI_DIR, article["path"]) if article else None
         compiled = bool(article_path and article_path.exists())
         word_count = 0
@@ -174,7 +188,7 @@ def _track_status_rows(track: str) -> list[dict[str, Any]]:
             "compiled": compiled,
             "word_count": word_count,
             "compiled_at": article.get("compiled_at") if article else None,
-            "source_count": _source_count(track, slug),
+            "source_count": article.get("source_count") if article else 0,
         })
 
     return rows
@@ -183,14 +197,20 @@ def _track_status_rows(track: str) -> list[dict[str, Any]]:
 @router.get("/status")
 async def wiki_status():
     """Per-track wiki compilation status."""
-    wiki_state.get_status_summary()
+    known_tracks = _known_tracks()
+    cache_key = "wiki_status_" + ",".join(known_tracks)
+    cached = cache_get(cache_key, ttl=60.0)
+    if cached is not None:
+        return cached
+
+    article_candidates = _list_article_candidates()
     tracks = []
 
-    for track in _known_tracks():
+    for track in known_tracks:
         slugs = _track_slugs(track)
         if not slugs:
             continue
-        modules = _track_status_rows(track)
+        modules = _track_status_rows(track, article_candidates)
         total = len(modules)
         compiled = sum(1 for module in modules if module["compiled"])
         total_words = sum(module["word_count"] for module in modules)
@@ -202,13 +222,21 @@ async def wiki_status():
             "total_words": total_words,
         })
 
-    return {"tracks": tracks}
+    result = {"tracks": tracks}
+    cache_set(cache_key, result)
+    return result
 
 
 @router.get("/status/{track}")
 async def wiki_status_track(track: str):
     """Per-module wiki compilation status for one track."""
-    return _track_status_rows(track)
+    cache_key = f"wiki_status_track_{track}_{wiki_config.WIKI_DIR}"
+    cached = cache_get(cache_key, ttl=60.0)
+    if cached is not None:
+        return cached
+    result = _track_status_rows(track)
+    cache_set(cache_key, result)
+    return result
 
 
 @router.get("/article/{track}/{slug}")
@@ -219,7 +247,7 @@ async def wiki_article(track: str, slug: str):
         raise HTTPException(status_code=404, detail=f"Article not found: {track}/{slug}")
 
     article = _resolve_article(track, slug)
-    source_count = _source_count(track, slug)
+    source_count = article.get("source_count") if article else _source_count(track, slug)
 
     if not article:
         return {

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -1,0 +1,71 @@
+"""Smoke tests for playground dashboard API stability."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import scripts.api.comms_router as comms_router
+from scripts.ai_agent_bridge import _db
+from scripts.api.main import app
+
+
+def _init_broker_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(_db._LEGACY_SCHEMA)
+    conn.executescript(_db._CHANNELS_SCHEMA)
+    conn.execute(
+        """
+        INSERT INTO channels (name, created_at, description, include, subscribers)
+        VALUES ('general', '2026-05-06T00:00:00Z', 'General', '', 'claude,codex')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO messages (
+            task_id, from_llm, to_llm, message_type, content, timestamp, acknowledged, status
+        )
+        VALUES ('smoke-a1-hello', 'codex', 'claude', 'message', 'smoke', '2026-05-06T00:00:00Z', 0, 'pending')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch):
+    broker_db = tmp_path / "messages.db"
+    _init_broker_db(broker_db)
+    monkeypatch.setattr(comms_router, "MESSAGE_DB", broker_db)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    endpoints = [
+        "/api/dashboard/overview",
+        "/api/comms/channels",
+        "/api/comms/messages?limit=1&offset=0",
+        "/api/comms/batch-progress",
+        "/api/admin/health",
+        "/api/build/events/active",
+        "/api/consultation/metrics",
+        "/api/analytics/cost",
+        "/api/delegate/tasks?limit=100",
+        "/api/images/stats",
+        "/api/orient",
+        "/api/state/summary",
+        "/api/state/research-coverage",
+        "/api/runtime/agents",
+        "/api/state/track-health/a1",
+        "/api/wiki/status",
+    ]
+
+    for endpoint in endpoints:
+        response = client.get(endpoint)
+        assert response.status_code < 500, endpoint
+
+        start = time.perf_counter()
+        health = client.get("/api/health")
+        elapsed = time.perf_counter() - start
+        assert health.status_code == 200
+        assert elapsed < 0.2, f"/api/health took {elapsed:.3f}s after {endpoint}"


### PR DESCRIPTION
## Summary

First-pass output of dispatch `1737-api-stability` (Codex). Salvaged because the dispatch returned `done` without committing — known dispatch-checklist violation. Work is real; tests pass; ruff clean.

This PR ships the **tactical** scope of #1737: audit doc + top-5 stressing endpoints fixed + smoke test + hardening doc.

A **broader, structural** second pass is queued: `docs/dispatch-queue/2026-05-06-1737-followup-brief.md` — full router/playground inventory (KEEP/DEPRECATE/DELETE), structural crash-cause diagnosis, resilience layer (concurrency limits, request timeouts, slow-query log).

## What changed

**Top-5 endpoint fixes** (p99 before → after, from audit doc):

| Endpoint | Before | After | Fix |
|---|---|---|---|
| `/api/wiki/status` | 20s timeout | 0.56s cold / <1ms cached | Reused article index, dropped per-slug source gather, TTL cache |
| `/api/dashboard/overview` | 7.9s p99 cold | 0.30s p99 cold | Lightweight summary scan |
| `/api/comms/batch-progress` | 0.5s every poll | 0.04s p99 cached | Bounded log tail (256 KiB) + 10s TTL cache |
| `/api/state/weak-points` | 7.5s p99 cold | 0.10s p99 cold | Skip plan YAML reads when `word_count == 0` + cache |
| `/api/rag/search_text` | single-worker stall on Qdrant down | fast 503 | 250ms Qdrant port probe |

**Server findings** (audit doc):
- No middleware-level concurrency limits
- Uvicorn runs single default worker → one wedged request stalls `/api/health`
- Legacy `messages` table missing indexes (added idempotently to schema + applied to live local broker DB)

**New artifacts:**
- `docs/api-stability-audit-2026-05-06.md` — 149 lines, ranked stressors + endpoint × dashboard matrix + server findings
- `docs/best-practices/local-api-server.md` — 86 lines, hardening guide
- `tests/test_playground_api_stability.py` — 71 lines, smoke test

## Test plan

- [x] `ruff check` passes
- [x] `tests/test_playground_api_stability.py` passes (1 test, 2.27s)
- [x] Targeted API tests: 23 passed (per Codex run)
- [ ] CI green
- [ ] Spot-check the 5 fixed endpoints in a running API server
- [ ] Review audit doc — confirm measurements look sane

## Coordination

- #1736 (`codex/1736-comms-fix`) is in flight on the same broker DB. Both PRs add `CREATE INDEX IF NOT EXISTS` — additive merge, should not conflict.
- Second-pass dispatch (#1737 broader review) fires off `origin/main` after this merges. Brief is in `docs/dispatch-queue/2026-05-06-1737-followup-brief.md`.

## Attribution

Code authored by **Codex (gpt-5.5)** via `delegate.py dispatch` task `1737-api-stability` (started 11:02 UTC, finished 11:40 UTC, 38 min, returncode 0). Worktree was left dirty; salvage commit by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)