### PR TITLE
feat(ab): add dispatch-fix + review-deep wrappers

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -61,6 +61,31 @@ ab post pipeline "reply" --parent MESSAGE_ID
 ab discuss architecture "should we refactor X?" --with claude,gemini,codex --max-rounds 2
 ```
 
+## Dispatch wrappers
+
+Use these wrappers when the task needs the project-standard model/mode
+assignment enforced by tooling instead of memory.
+
+`ab dispatch-fix <issue-or-task-id> [--brief-file PATH]` dispatches a
+Codex worktree implementation run for "fix this and ship a PR" tasks.
+It hardcodes `delegate.py dispatch --agent codex --mode danger
+--worktree --base origin/main --effort high`, and every generated
+brief includes the commit, push, and PR checklist. If `--brief-file`
+is omitted, the wrapper builds `/tmp/dispatch-fix-<task-id>.md` from
+`gh issue view <issue> --json title,body`.
+
+`ab review-deep <PR-or-path> [--effort xhigh]` dispatches an
+adversarial Claude review run. It hardcodes `--agent claude --mode
+read-only --model claude-opus-4-7 --effort xhigh` unless an explicit
+effort override is passed, then builds a review prompt from either
+`gh pr view` plus `gh pr diff` or the target file/directory contents.
+Use it for blocking logic/security/test review, not for stylistic
+preferences.
+
+Both wrappers support `--dry-run`, which writes the prompt and a
+`batch_state/tasks/<task-id>.json` preview without launching the
+delegate worker.
+
 ## When to use channels vs `ask-*`
 
 | Situation | Use |

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -19,6 +19,12 @@ from ._codex import (
 )
 from ._config import GEMINI_DEFAULT_MODEL
 from ._db import get_db
+from ._dispatch_wrappers import (
+    MANDATORY_COMMIT_PUSH_PR_CHECKLIST,
+    REVIEW_DEEP_INSTRUCTIONS,
+    handle_dispatch_fix,
+    handle_review_deep,
+)
 from ._gemini import ask_gemini, converse_gemini, process_and_respond
 from ._messaging import (
     acknowledge,
@@ -538,6 +544,71 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON instead of text",
     )
 
+    dispatch_fix_parser = subparsers.add_parser(
+        "dispatch-fix",
+        help="Dispatch a Codex worktree fix run with commit/push/PR guardrails",
+        description=(
+            "Dispatch a Codex worktree run using the hardcoded model assignment "
+            "for code changes: Codex, danger mode, worktree, origin/main base, "
+            "high effort."
+        ),
+        epilog=(
+            "Example:\n"
+            "  ab dispatch-fix 1701 --dry-run\n\n"
+            "Mandatory checklist appended to dispatch-fix briefs:\n"
+            f"{MANDATORY_COMMIT_PUSH_PR_CHECKLIST}"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    dispatch_fix_parser.add_argument(
+        "task_id",
+        metavar="issue-or-task-id",
+        help="GitHub issue number or stable task ID to use for delegate.py --task-id.",
+    )
+    dispatch_fix_parser.add_argument(
+        "--brief-file",
+        help="Use an existing brief file instead of generating one from gh issue view.",
+    )
+    dispatch_fix_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write the prompt/state preview and print the delegate.py command without dispatching.",
+    )
+
+    review_deep_parser = subparsers.add_parser(
+        "review-deep",
+        help="Dispatch an adversarial Claude Opus read-only review run",
+        description=(
+            "Dispatch an adversarial Claude review using the hardcoded model "
+            "assignment for deep design/code review: read-only Opus 4.7, xhigh "
+            "effort by default."
+        ),
+        epilog=(
+            "Example:\n"
+            "  ab review-deep 1740 --dry-run\n"
+            "  ab review-deep scripts/ai_agent_bridge --effort high --dry-run\n\n"
+            "Prompt wrapper:\n"
+            f"{REVIEW_DEEP_INSTRUCTIONS}"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    review_deep_parser.add_argument(
+        "target",
+        metavar="PR-or-path",
+        help="PR number, #PR, file path, or directory path to review.",
+    )
+    review_deep_parser.add_argument(
+        "--effort",
+        default="xhigh",
+        choices=["low", "medium", "high", "xhigh", "max"],
+        help="Claude effort level (default: xhigh).",
+    )
+    review_deep_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write the prompt/state preview and print the delegate.py command without dispatching.",
+    )
+
     # check-model
     check_model_parser = subparsers.add_parser("check-model", help="Check if a Gemini model is available")
     check_model_parser.add_argument("model", help="Model name")
@@ -606,6 +677,10 @@ def _dispatch_command(args):
         process_all_codex(args.new_session)
     elif args.command == "codex-usage":
         _handle_codex_usage(args)
+    elif args.command == "dispatch-fix":
+        sys.exit(handle_dispatch_fix(args))
+    elif args.command == "review-deep":
+        sys.exit(handle_review_deep(args))
     elif args.command == "check-model":
         ok = check_model(args.model, force=True)
         sys.exit(0 if ok else 1)

--- a/scripts/ai_agent_bridge/_dispatch_wrappers.py
+++ b/scripts/ai_agent_bridge/_dispatch_wrappers.py
@@ -1,0 +1,258 @@
+"""Hardcoded delegate.py wrapper commands for recurring agent dispatches."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYTHON = ".venv/bin/python"
+
+MANDATORY_COMMIT_PUSH_PR_CHECKLIST = """## MANDATORY checklist — do NOT skip these (the dispatch will be marked failed if you do)
+
+1. `git add` your work (specific files, not `git add -A`)
+2. `git commit -m "..."` — commit hooks will run ruff + targeted pytest
+3. `git push -u origin <branch-name>`
+4. `gh pr create --title "..." --body "..."` — return the URL in your final response
+5. Worktree at `.worktrees/dispatch/codex/<task-id>/`. NEVER branch in the main checkout.
+
+If you finish writing code but skip steps 2-4, the work is lost. Don't make that mistake.
+"""
+
+REVIEW_DEEP_INSTRUCTIONS = (
+    "Adversarial review. Find logical bugs, security issues, contradictions, "
+    "missing tests, dead code, performance footguns. Cite file:line. Be terse "
+    "but complete. Do NOT propose stylistic preferences. Output: structured "
+    "`## Findings` markdown."
+)
+
+
+def _safe_path_component(raw: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip(".-")
+    return safe or "task"
+
+
+def _is_pr_number(target: str) -> bool:
+    return target.lstrip("#").isdigit()
+
+
+def _task_state_path(task_id: str) -> Path:
+    tasks_dir = REPO_ROOT / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    safe = task_id.replace("/", "_").replace("\\", "_")
+    return tasks_dir / f"{safe}.json"
+
+
+def _run_json_command(cmd: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout or "{}")
+
+
+def _run_text_command(cmd: list[str]) -> str:
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def _write_dispatch_fix_auto_brief(task_id: str) -> Path:
+    issue = _run_json_command(["gh", "issue", "view", task_id, "--json", "title,body"])
+    title = str(issue.get("title") or "").strip()
+    body = str(issue.get("body") or "").strip()
+    prompt = (
+        f"# Dispatch fix: {task_id}\n\n"
+        f"## GitHub issue {task_id}: {title}\n\n"
+        f"{body}\n\n"
+        f"{MANDATORY_COMMIT_PUSH_PR_CHECKLIST}"
+    )
+    brief_path = Path("/tmp") / f"dispatch-fix-{_safe_path_component(task_id)}.md"
+    brief_path.write_text(prompt, encoding="utf-8")
+    return brief_path
+
+
+def _dispatch_fix_prompt_file(task_id: str, brief_file: str | None) -> Path:
+    if brief_file:
+        path = Path(brief_file).expanduser()
+        prompt = path.read_text(encoding="utf-8")
+        if MANDATORY_COMMIT_PUSH_PR_CHECKLIST not in prompt:
+            prompt = f"{prompt.rstrip()}\n\n{MANDATORY_COMMIT_PUSH_PR_CHECKLIST}"
+        brief_path = Path("/tmp") / f"dispatch-fix-{_safe_path_component(task_id)}.md"
+        brief_path.write_text(prompt, encoding="utf-8")
+        return brief_path
+    return _write_dispatch_fix_auto_brief(task_id)
+
+
+def build_dispatch_fix_command(task_id: str, prompt_file: Path) -> list[str]:
+    return [
+        PYTHON,
+        "scripts/delegate.py",
+        "dispatch",
+        "--agent",
+        "codex",
+        "--mode",
+        "danger",
+        "--worktree",
+        "--base",
+        "origin/main",
+        "--task-id",
+        task_id,
+        "--effort",
+        "high",
+        "--prompt-file",
+        str(prompt_file),
+    ]
+
+
+def _serialize_files(files: Any) -> str:
+    if not files:
+        return "(none)"
+    if not isinstance(files, list):
+        return json.dumps(files, indent=2, sort_keys=True)
+    lines = []
+    for item in files:
+        if isinstance(item, dict):
+            path = item.get("path") or item.get("filename") or item.get("name") or str(item)
+            additions = item.get("additions")
+            deletions = item.get("deletions")
+            if additions is not None and deletions is not None:
+                lines.append(f"- {path} (+{additions}/-{deletions})")
+            else:
+                lines.append(f"- {path}")
+        else:
+            lines.append(f"- {item}")
+    return "\n".join(lines)
+
+
+def _write_review_deep_pr_prompt(pr_number: str) -> Path:
+    pr = _run_json_command(["gh", "pr", "view", pr_number, "--json", "title,body,files"])
+    diff = _run_text_command(["gh", "pr", "diff", pr_number])
+    title = str(pr.get("title") or "").strip()
+    body = str(pr.get("body") or "").strip()
+    files = _serialize_files(pr.get("files"))
+    prompt = (
+        f"{REVIEW_DEEP_INSTRUCTIONS}\n\n"
+        f"## PR #{pr_number}: {title}\n\n"
+        f"### Body\n\n{body}\n\n"
+        f"### Files\n\n{files}\n\n"
+        f"### Diff\n\n```diff\n{diff}\n```\n"
+    )
+    prompt_path = Path("/tmp") / f"review-deep-pr-{_safe_path_component(pr_number)}.md"
+    prompt_path.write_text(prompt, encoding="utf-8")
+    return prompt_path
+
+
+def _read_review_path(target: Path) -> str:
+    if target.is_file():
+        return target.read_text(encoding="utf-8", errors="replace")
+    chunks = []
+    for path in sorted(p for p in target.rglob("*") if p.is_file()):
+        if ".git" in path.parts or "__pycache__" in path.parts:
+            continue
+        rel = path.relative_to(target)
+        content = path.read_text(encoding="utf-8", errors="replace")
+        chunks.append(f"### {rel}\n\n```text\n{content}\n```")
+    return "\n\n".join(chunks)
+
+
+def _write_review_deep_path_prompt(target: str) -> Path:
+    path = Path(target).expanduser()
+    if not path.exists():
+        raise SystemExit(f"review-deep target is not a PR number or existing path: {target}")
+    resolved = path.resolve()
+    content = _read_review_path(resolved)
+    prompt = (
+        f"{REVIEW_DEEP_INSTRUCTIONS}\n\n"
+        f"## Path target\n\n{resolved}\n\n"
+        f"## Contents\n\n{content}\n"
+    )
+    prompt_path = Path("/tmp") / f"review-deep-path-{_safe_path_component(target)}.md"
+    prompt_path.write_text(prompt, encoding="utf-8")
+    return prompt_path
+
+
+def _review_task_id(target: str) -> str:
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    return f"review-{_safe_path_component(target)}-{timestamp}"
+
+
+def _review_prompt_file(target: str) -> Path:
+    if _is_pr_number(target):
+        return _write_review_deep_pr_prompt(target.lstrip("#"))
+    return _write_review_deep_path_prompt(target)
+
+
+def build_review_deep_command(target: str, prompt_file: Path, effort: str) -> list[str]:
+    return [
+        PYTHON,
+        "scripts/delegate.py",
+        "dispatch",
+        "--agent",
+        "claude",
+        "--mode",
+        "read-only",
+        "--model",
+        "claude-opus-4-7",
+        "--effort",
+        effort,
+        "--task-id",
+        _review_task_id(target),
+        "--prompt-file",
+        str(prompt_file),
+    ]
+
+
+def _write_dry_run_state(task_id: str, command: list[str], prompt_file: Path) -> None:
+    prompt = prompt_file.read_text(encoding="utf-8")
+    state = {
+        "task_id": task_id,
+        "agent": command[command.index("--agent") + 1],
+        "model": command[command.index("--model") + 1] if "--model" in command else None,
+        "effort": command[command.index("--effort") + 1] if "--effort" in command else None,
+        "mode": command[command.index("--mode") + 1],
+        "status": "dry-run",
+        "prompt_file": str(prompt_file),
+        "prompt_chars": len(prompt),
+        "command": command,
+        "started_at": datetime.now(UTC).isoformat(),
+        "finished_at": datetime.now(UTC).isoformat(),
+        "returncode": 0,
+    }
+    _task_state_path(task_id).write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def _run_dispatch(command: list[str], dry_run: bool, prompt_file: Path) -> int:
+    task_id = command[command.index("--task-id") + 1]
+    if dry_run:
+        _write_dry_run_state(task_id, command, prompt_file)
+        print("DRY RUN: " + " ".join(command))
+        print(f"Prompt file: {prompt_file}")
+        print(f"State file: {_task_state_path(task_id)}")
+        return 0
+    proc = subprocess.run(command, cwd=REPO_ROOT)
+    return int(proc.returncode)
+
+
+def handle_dispatch_fix(args: Any) -> int:
+    prompt_file = _dispatch_fix_prompt_file(args.task_id, args.brief_file)
+    command = build_dispatch_fix_command(args.task_id, prompt_file)
+    return _run_dispatch(command, args.dry_run, prompt_file)
+
+
+def handle_review_deep(args: Any) -> int:
+    prompt_file = _review_prompt_file(args.target)
+    command = build_review_deep_command(args.target, prompt_file, args.effort)
+    return _run_dispatch(command, args.dry_run, prompt_file)

--- a/tests/test_ab_dispatch_wrappers.py
+++ b/tests/test_ab_dispatch_wrappers.py
@@ -1,0 +1,152 @@
+"""Tests for hardcoded ab dispatch wrapper commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _dispatch_wrappers as wrappers
+
+
+def _option(command: list[str], name: str) -> str:
+    return command[command.index(name) + 1]
+
+
+def _patch_state_dir(monkeypatch, tmp_path: Path) -> Path:
+    state_dir = tmp_path / "states"
+    state_dir.mkdir()
+
+    def state_path(task_id: str) -> Path:
+        return state_dir / f"{task_id}.json"
+
+    monkeypatch.setattr(wrappers, "_task_state_path", state_path)
+    return state_dir
+
+
+def test_dispatch_fix_with_explicit_brief_file_appends_checklist_and_dispatches(monkeypatch, tmp_path):
+    brief = tmp_path / "brief.md"
+    brief.write_text("# Fix this\n\nExisting acceptance criteria.\n", encoding="utf-8")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+
+    rc = wrappers.handle_dispatch_fix(
+        argparse.Namespace(task_id="1741", brief_file=str(brief), dry_run=False)
+    )
+
+    assert rc == 0
+    command = calls[0][0]
+    assert command[:3] == [".venv/bin/python", "scripts/delegate.py", "dispatch"]
+    assert _option(command, "--agent") == "codex"
+    assert _option(command, "--mode") == "danger"
+    assert "--worktree" in command
+    assert _option(command, "--base") == "origin/main"
+    assert _option(command, "--task-id") == "1741"
+    assert _option(command, "--effort") == "high"
+    prompt = Path(_option(command, "--prompt-file")).read_text(encoding="utf-8")
+    assert "Existing acceptance criteria." in prompt
+    assert wrappers.MANDATORY_COMMIT_PUSH_PR_CHECKLIST in prompt
+
+
+def test_dispatch_fix_with_auto_brief_uses_issue_body_and_dry_run_state(monkeypatch, tmp_path):
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == ["gh", "issue", "view", "1701", "--json", "title,body"]
+        payload = {"title": "Security issue", "body": "Acceptance criteria from issue."}
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+
+    rc = wrappers.handle_dispatch_fix(
+        argparse.Namespace(task_id="1701", brief_file=None, dry_run=True)
+    )
+
+    assert rc == 0
+    state = json.loads((state_dir / "1701.json").read_text(encoding="utf-8"))
+    command = state["command"]
+    assert state["status"] == "dry-run"
+    assert state["agent"] == "codex"
+    assert state["mode"] == "danger"
+    assert state["model"] is None
+    assert state["effort"] == "high"
+    assert _option(command, "--task-id") == "1701"
+    prompt = Path(state["prompt_file"]).read_text(encoding="utf-8")
+    assert "Security issue" in prompt
+    assert "Acceptance criteria from issue." in prompt
+    assert wrappers.MANDATORY_COMMIT_PUSH_PR_CHECKLIST in prompt
+
+
+def test_review_deep_for_pr_target_generates_prompt_and_dry_run_state(monkeypatch, tmp_path):
+    state_dir = _patch_state_dir(monkeypatch, tmp_path)
+
+    def fake_run(command, **kwargs):
+        if command == ["gh", "pr", "view", "1740", "--json", "title,body,files"]:
+            payload = {
+                "title": "Wrapper PR",
+                "body": "Review this behavior.",
+                "files": [{"path": "scripts/ai_agent_bridge/_cli.py", "additions": 10, "deletions": 2}],
+            }
+            return subprocess.CompletedProcess(command, 0, stdout=json.dumps(payload))
+        if command == ["gh", "pr", "diff", "1740"]:
+            return subprocess.CompletedProcess(command, 0, stdout="diff --git a/file b/file\n+change\n")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+
+    rc = wrappers.handle_review_deep(
+        argparse.Namespace(target="1740", effort="xhigh", dry_run=True)
+    )
+
+    assert rc == 0
+    state_path = next(state_dir.glob("review-1740-*.json"))
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    command = state["command"]
+    assert state["agent"] == "claude"
+    assert state["mode"] == "read-only"
+    assert state["model"] == "claude-opus-4-7"
+    assert state["effort"] == "xhigh"
+    assert _option(command, "--agent") == "claude"
+    assert _option(command, "--model") == "claude-opus-4-7"
+    assert _option(command, "--effort") == "xhigh"
+    assert _option(command, "--task-id").startswith("review-1740-")
+    prompt = Path(state["prompt_file"]).read_text(encoding="utf-8")
+    assert wrappers.REVIEW_DEEP_INSTRUCTIONS in prompt
+    assert "Review this behavior." in prompt
+    assert "diff --git" in prompt
+
+
+def test_review_deep_for_path_target_generates_prompt_and_dispatches(monkeypatch, tmp_path):
+    target = tmp_path / "target.py"
+    target.write_text("def broken():\n    return missing_name\n", encoding="utf-8")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+
+    rc = wrappers.handle_review_deep(
+        argparse.Namespace(target=str(target), effort="high", dry_run=False)
+    )
+
+    assert rc == 0
+    command = calls[0][0]
+    assert _option(command, "--agent") == "claude"
+    assert _option(command, "--mode") == "read-only"
+    assert _option(command, "--model") == "claude-opus-4-7"
+    assert _option(command, "--effort") == "high"
+    assert _option(command, "--task-id").startswith("review-")
+    prompt = Path(_option(command, "--prompt-file")).read_text(encoding="utf-8")
+    assert wrappers.REVIEW_DEEP_INSTRUCTIONS in prompt
+    assert "def broken()" in prompt


### PR DESCRIPTION
## Summary
- add `ab dispatch-fix` to generate guarded Codex fix briefs and dispatch through `delegate.py` with codex/danger/worktree/high hardcoded
- add `ab review-deep` to generate adversarial Claude review prompts from PRs or paths and dispatch read-only Opus 4.7/xhigh by default
- add focused wrapper unit tests and document wrapper usage in `docs/best-practices/agent-bridge.md`

Closes #1741.

## Validation
- `.venv/bin/ruff check scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_dispatch_wrappers.py tests/test_ab_dispatch_wrappers.py`
- `.venv/bin/python -m pytest tests/test_ab_dispatch_wrappers.py tests/test_codex_bridge.py tests/test_bridge_inbox_cli.py`
- `ab dispatch-fix --help` and `ab review-deep --help`
- `ab dispatch-fix 1701 --dry-run` generated `/tmp/dispatch-fix-1701.md` and `batch_state/tasks/1701.json`
- `ab review-deep 1740 --dry-run` generated `/tmp/review-deep-pr-1740.md` and a dry-run state JSON
- commit hook: ruff + affected pytest passed

## Full pytest note
`.venv/bin/python -m pytest` completed with 12 failures unrelated to this change: expired Hugging Face token for BAAI/bge-m3 and timm/SigLIP tokenizer fetches, missing `embed-venv/bin/python`, missing `data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl`, empty external source registry file set in this worktree, and a pre-existing Gemini adapter assertion in `tests/test_agent_runtime.py::test_gemini_adapter_read_only_no_yolo`.