### PR TITLE
feat(v7): per-writer subprocess timeout (#1708)

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -48,6 +48,7 @@ from ai_llm.fallback import (
 
 from .adapters.base import AgentAdapter
 from .errors import (
+    AgentStalledError,
     AgentTimeoutError,
     AgentUnavailableError,
     RateLimitedError,
@@ -460,6 +461,7 @@ def _execute_invocation_plan(
     entrypoint: str,
     hard_timeout: int,
     stall_timeout: int,
+    stdout_silence_timeout: int | None = None,
 ) -> _ExecutionOutcome:
     """Spawn one plan, run watchdog/parse flow, and return raw execution state."""
     env = {**os.environ, **plan.env_overrides}
@@ -544,7 +546,12 @@ def _execute_invocation_plan(
                 except Exception:
                     pass
 
-            kill_reason = should_kill(watchdog_state, stall_timeout, hard_timeout)
+            kill_reason = should_kill(
+                watchdog_state,
+                stall_timeout,
+                hard_timeout,
+                stdout_silence_timeout=stdout_silence_timeout,
+            )
             if kill_reason is not None:
                 returncode = proc.poll()
                 if returncode is not None:
@@ -636,6 +643,7 @@ def _invoke_gemini_with_fallback(
     entrypoint: str,
     hard_timeout: int,
     stall_timeout: int,
+    stdout_silence_timeout: int | None = None,
     effort: str | None = None,
 ) -> Result:
     """Run Gemini through the shared model/auth fallback ladder."""
@@ -677,8 +685,35 @@ def _invoke_gemini_with_fallback(
             entrypoint=entrypoint,
             hard_timeout=timeout_s or hard_timeout,
             stall_timeout=stall_timeout,
+            stdout_silence_timeout=stdout_silence_timeout,
         )
         parse = execution.parse
+
+        if execution.kill_reason == "stdout_silence_timeout":
+            record = _build_usage_record(
+                agent=agent_name,
+                entrypoint=entrypoint,
+                model=last_telemetry.model if last_telemetry is not None else rung.model,
+                mode=mode,
+                task_id=task_id,
+                cwd=cwd,
+                session_id=session_id,
+                duration_s=execution.duration_s,
+                input_chars=len(prompt),
+                output_chars=len(execution.stdout_text),
+                returncode=execution.returncode,
+                outcome="stalled",
+                rate_limited=False,
+                stalled=True,
+                stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
+                tokens=None,
+            )
+            write_record(record)
+            raise AgentStalledError(
+                agent_name,
+                stdout_silence_timeout or stall_timeout,
+                execution.duration_s,
+            )
 
         if execution.kill_reason == "hard_timeout" and not parse.ok:
             return AttemptOutcome(
@@ -891,6 +926,7 @@ def invoke(
                                  # scripts/batch/batch_gemini_config.py
                                  # for the full design rationale.
     stall_timeout: int = 180,  # accepted but ignored; see docstring
+    stdout_silence_timeout: int | None = None,
     effort: str | None = None,
 ) -> Result:
     """Single entry point for all agent CLI invocations.
@@ -924,6 +960,9 @@ def invoke(
             successful long-running calls were killed as false-positive
             stalls. See watchdog.py::should_kill() docstring for the
             full incident chain. hard_timeout is the only safety net now.
+        stdout_silence_timeout: Optional per-call stdout silence watchdog in
+            seconds. Disabled by default. Use only for protocols where stdout
+            bytes are the authoritative liveness signal.
         effort: Cross-agent reasoning/effort level. First-class peer of
             ``model`` (NOT stuffed into ``tool_config``). Accepted values:
             ``"low" | "medium" | "high" | "xhigh" | "max"``. When ``None``,
@@ -1007,6 +1046,7 @@ def invoke(
             entrypoint=entrypoint,
             hard_timeout=hard_timeout,
             stall_timeout=stall_timeout,
+            stdout_silence_timeout=stdout_silence_timeout,
             effort=effort,
         )
 
@@ -1042,8 +1082,35 @@ def invoke(
         entrypoint=entrypoint,
         hard_timeout=hard_timeout,
         stall_timeout=stall_timeout,
+        stdout_silence_timeout=stdout_silence_timeout,
     )
     parse = execution.parse
+
+    if execution.kill_reason == "stdout_silence_timeout":
+        record = _build_usage_record(
+            agent=agent_name,
+            entrypoint=entrypoint,
+            model=effective_model,
+            mode=mode,
+            task_id=task_id,
+            cwd=effective_cwd,
+            session_id=session_id,
+            duration_s=execution.duration_s,
+            input_chars=len(prompt),
+            output_chars=len(execution.stdout_text),
+            returncode=execution.returncode,
+            outcome="stalled",
+            rate_limited=False,
+            stalled=True,
+            stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
+            tokens=None,
+        )
+        write_record(record)
+        raise AgentStalledError(
+            agent_name,
+            stdout_silence_timeout or stall_timeout,
+            execution.duration_s,
+        )
 
     if execution.kill_reason == "hard_timeout" and not parse.ok:
         record = _build_usage_record(

--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -18,9 +18,13 @@ string of production incidents. The module now does three things:
    bump broke a different mtime signal; see ``should_kill`` for
    the full story.
 
-3. **Hard-timeout kill** — the ONLY condition the watchdog kills on.
+3. **Hard-timeout kill** — the default kill condition.
    Triggers ``AgentTimeoutError`` when ``now - start_time >
    hard_timeout``. Default hard_timeout is 1h.
+
+Callers may opt in to a separate stdout-silence timeout for workflows where
+the stdout pipe is the protocol liveness signal. It remains disabled by
+default so normal agent dispatch keeps ADR-009's hard-timeout behavior.
 
 Issue: #1184
 """
@@ -58,6 +62,9 @@ class WatchdogState:
         start_time: monotonic timestamp when the subprocess was spawned.
         last_activity: monotonic timestamp of the most recent observed
             activity (stdout line or liveness file mtime bump).
+        last_stdout_activity: monotonic timestamp of the most recent stdout
+            line. Unlike ``last_activity``, stderr and liveness files never
+            update this field.
         stop: Set to True by the main thread when the watchdog should exit.
         stdout_lines: Accumulated stdout lines captured by the streamer.
             The runner reads this on normal termination to build the final
@@ -78,6 +85,7 @@ class WatchdogState:
     """
     start_time: float
     last_activity: float
+    last_stdout_activity: float = 0.0
     stop: bool = False
     stdout_lines: list[str] = field(default_factory=list)
     stderr_lines: list[str] = field(default_factory=list)
@@ -95,6 +103,7 @@ def _stdout_streamer(proc: subprocess.Popen, state: WatchdogState) -> None:
                 break
             state.stdout_lines.append(line)
             state.last_activity = time.monotonic()
+            state.last_stdout_activity = state.last_activity
     except (ValueError, OSError):
         # Pipe closed or subprocess killed. Normal shutdown path.
         pass
@@ -188,7 +197,7 @@ def start_watchdog(
         cleanly after the subprocess terminates.
     """
     now = time.monotonic()
-    state = WatchdogState(start_time=now, last_activity=now)
+    state = WatchdogState(start_time=now, last_activity=now, last_stdout_activity=now)
 
     threads: list[threading.Thread] = []
 
@@ -291,12 +300,20 @@ def stop_watchdog(
         t.join(timeout=timeout)
 
 
-def should_kill(state: WatchdogState, stall_timeout: int, hard_timeout: int) -> str | None:
+def should_kill(
+    state: WatchdogState,
+    stall_timeout: int,
+    hard_timeout: int,
+    *,
+    stdout_silence_timeout: int | None = None,
+) -> str | None:
     """Check if the subprocess should be killed. Returns the kill reason or None.
 
     Returns:
         None if the process should continue running.
         "hard_timeout" if total runtime exceeded hard_timeout.
+        "stdout_silence_timeout" if the caller explicitly enabled stdout
+        silence detection and no stdout line has arrived within that window.
 
     ``stall_timeout`` is accepted for backward compatibility with callers but
     is NOT used as a kill condition. Deleting stall detection from the kill
@@ -329,6 +346,12 @@ def should_kill(state: WatchdogState, stall_timeout: int, hard_timeout: int) -> 
     now = time.monotonic()
     if (now - state.start_time) > hard_timeout:
         return "hard_timeout"
+    if (
+        stdout_silence_timeout is not None
+        and stdout_silence_timeout > 0
+        and (now - state.last_stdout_activity) > stdout_silence_timeout
+    ):
+        return "stdout_silence_timeout"
     return None
 
 

--- a/scripts/audit/bakeoff_run.py
+++ b/scripts/audit/bakeoff_run.py
@@ -152,6 +152,8 @@ def _run_or_report(label: str, argv: Sequence[str]) -> StepResult:
     stderr = result.stderr.strip()
     stdout = result.stdout.strip()
     detail = stderr or stdout or f"exit {result.returncode}"
+    if result.returncode == 124:
+        detail = f"timeout: {detail}"
     print(f"error: {label} failed: {detail}", file=sys.stderr)
     return StepResult(label=label, ok=False, detail=detail, returncode=result.returncode)
 
@@ -443,8 +445,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             )
 
+    review_writers = writers
+    if writer_results:
+        successful_writer_labels = {
+            result.label.removeprefix("write ")
+            for result in writer_results
+            if result.ok
+        }
+        review_writers = [writer for writer in writers if writer in successful_writer_labels]
+
     if not args.writers_only:
-        for writer in writers:
+        for writer in review_writers:
             for reviewer in writers:
                 if writer == reviewer:
                     continue
@@ -459,8 +470,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     )
                 )
 
-    if not args.skip_aggregate:
-        aggregate_result = _run_aggregate(bakeoff_dir, writers)
+    if not args.skip_aggregate and review_writers:
+        aggregate_result = _run_aggregate(bakeoff_dir, review_writers)
 
     _print_summary(writer_results, review_results, aggregate_result)
     failures = [result for result in (*writer_results, *review_results) if not result.ok]

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1593,6 +1593,7 @@ def invoke_writer(
     module: str | None = None,
     sections: list[str] | None = None,
     event_sink: Callable[..., None] | None = None,
+    stdout_silence_timeout: int | None = None,
 ) -> str:
     """Call the selected writer through the universal agent runtime."""
     if writer not in WRITER_CHOICES:
@@ -1614,6 +1615,7 @@ def invoke_writer(
         entrypoint="dispatch",
         effort=defaults["effort"],
         tool_config=_runtime_tool_config(writer),
+        stdout_silence_timeout=stdout_silence_timeout,
     )
     response = getattr(result, "response", None)
     if not response:
@@ -2019,6 +2021,7 @@ def invoke_reviewer_dim(
     invoker: Callable[..., Any] | None = None,
     module: str | None = None,
     event_sink: Callable[..., None] | None = None,
+    stdout_silence_timeout: int | None = None,
 ) -> str:
     """Call one per-dimension reviewer and emit response/audit telemetry."""
     if reviewer not in REVIEWER_CHOICES:
@@ -2040,6 +2043,7 @@ def invoke_reviewer_dim(
         entrypoint="dispatch",
         effort=defaults["effort"],
         tool_config=_runtime_tool_config(reviewer),
+        stdout_silence_timeout=stdout_silence_timeout,
     )
     response = getattr(result, "response", None)
     if not response:

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import sys
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -14,9 +16,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.agent_runtime.errors import AgentStalledError
 from scripts.build import linear_pipeline
 from scripts.common.thresholds import QG_DIMS
 
+DEFAULT_WRITER_TIMEOUT_S = 1800
 WRITER_ALIASES = {
     "claude": "claude-tools",
     "gemini": "gemini-tools",
@@ -25,8 +29,26 @@ WRITER_ALIASES = {
 WRITER_CHOICES = (*linear_pipeline.WRITER_CHOICES, *WRITER_ALIASES)
 
 
+@dataclass(slots=True)
+class LastEventTracker:
+    event_type: str | None = None
+    event_ts: str | None = None
+
+    def emit(self, event: str, **fields: Any) -> None:
+        self.event_type = event
+        self.event_ts = datetime.now(UTC).isoformat()
+        emit_event(event, **fields)
+
+
 def emit_event(event: str, **fields: Any) -> None:
     linear_pipeline.emit_event(event, **fields)
+
+
+def _positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
 
 
 def _default_module_dir(level: str, slug: str) -> Path:
@@ -57,9 +79,10 @@ def _phase_done(
     *,
     level: str,
     slug: str,
+    event_sink: Callable[..., None] = emit_event,
     **fields: Any,
 ) -> None:
-    emit_event(
+    event_sink(
         "phase_done",
         level=level,
         slug=slug,
@@ -105,6 +128,7 @@ def _run_llm_qg(
     plan_content: str,
     module_dir: Path,
     writer: str,
+    stdout_silence_timeout: int | None = None,
 ) -> dict[str, Any]:
     from scripts.agent_runtime.runner import invoke
 
@@ -131,6 +155,7 @@ def _run_llm_qg(
             entrypoint="dispatch",
             effort=defaults["effort"],
             tool_config={"output_format": "text"},
+            stdout_silence_timeout=stdout_silence_timeout,
         )
         response = str(getattr(result, "response", "") or "")
         report[dim] = linear_pipeline.parse_review_response(response, dim)
@@ -160,6 +185,8 @@ def build_parser() -> argparse.ArgumentParser:
             "  0 on successful build or dry run.\n"
             "  1 on plan, packet, writer, QG, review, MDX, or filesystem failure.\n"
             "  2 on command-line usage errors from argparse.\n\n"
+            "  124 when a writer subprocess is killed after --writer-timeout "
+            "seconds of stdout silence.\n\n"
             "Related:\n"
             "  Pipeline: scripts/build/linear_pipeline.py\n"
             "  Writer prompt: scripts/build/phases/linear-write.md\n"
@@ -190,6 +217,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Writer backend for the one-shot V7 write phase "
             "(default: claude-tools; claude/gemini/codex aliases normalize to "
             "claude-tools/gemini-tools/codex-tools)."
+        ),
+    )
+    parser.add_argument(
+        "--writer-timeout",
+        metavar="SECONDS",
+        type=_positive_int,
+        default=DEFAULT_WRITER_TIMEOUT_S,
+        help=(
+            "Kill the writer subprocess and exit 124 if it produces no stdout "
+            f"for SECONDS (default: {DEFAULT_WRITER_TIMEOUT_S})."
         ),
     )
     parser.add_argument(
@@ -235,8 +272,10 @@ def _run(args: argparse.Namespace) -> int:
     writer = _normalize_writer(args.writer)
     module_started_at = time.monotonic()
     phase = "start"
+    timeout_agent = writer
+    tracker = LastEventTracker()
 
-    emit_event("module_start", level=level, slug=slug)
+    tracker.emit("module_start", level=level, slug=slug)
 
     try:
         phase = "plan"
@@ -245,7 +284,7 @@ def _run(args: argparse.Namespace) -> int:
         plan_content = plan_path.read_text(encoding="utf-8")
         plan = linear_pipeline.load_plan(plan_path)
         linear_pipeline.validate_plan(plan)
-        _phase_done(phase, started_at, level=level, slug=slug)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
 
         phase = "knowledge_packet"
         started_at = time.monotonic()
@@ -254,7 +293,7 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             plan=plan,
         )
-        _phase_done(phase, started_at, level=level, slug=slug)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
 
         if args.dry_run:
             sections = [
@@ -268,8 +307,9 @@ def _run(args: argparse.Namespace) -> int:
                 module=f"{level.lower()}/{int(plan['sequence'])}",
                 sections=sections,
                 tool_calls=[],
+                event_sink=tracker.emit,
             )
-            emit_event(
+            tracker.emit(
                 "module_done",
                 level=level,
                 slug=slug,
@@ -281,6 +321,7 @@ def _run(args: argparse.Namespace) -> int:
         module_dir = _resolve_output_dir(args.out, level, slug)
 
         phase = "writer"
+        timeout_agent = writer
         started_at = time.monotonic()
         module_dir.mkdir(parents=True, exist_ok=True)
         prompt = _writer_prompt(
@@ -292,6 +333,7 @@ def _run(args: argparse.Namespace) -> int:
             prompt,
             writer,
             cwd=module_dir,
+            stdout_silence_timeout=args.writer_timeout,
         )
         # Save raw writer output + prompt + knowledge packet BEFORE parse so any
         # parse failure is fully debuggable. Without this, a parse error like
@@ -309,7 +351,14 @@ def _run(args: argparse.Namespace) -> int:
         )
         artifacts = linear_pipeline.parse_writer_output(writer_output)
         linear_pipeline.write_writer_artifacts(module_dir, artifacts)
-        _phase_done(phase, started_at, level=level, slug=slug, writer=writer)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            writer=writer,
+            event_sink=tracker.emit,
+        )
 
         phase = "python_qg"
         started_at = time.monotonic()
@@ -319,7 +368,7 @@ def _run(args: argparse.Namespace) -> int:
             writer=writer,
         )
         linear_pipeline.write_json(module_dir / "python_qg.json", python_qg)
-        _phase_done(phase, started_at, level=level, slug=slug)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
         gates = python_qg.get("gates")
         if not isinstance(gates, Mapping) or gates.get("passed") is not True:
             raise linear_pipeline.LinearPipelineError(
@@ -327,23 +376,25 @@ def _run(args: argparse.Namespace) -> int:
             )
 
         phase = "llm_qg"
+        timeout_agent = _reviewer_for_writer(writer)
         started_at = time.monotonic()
         llm_qg = _run_llm_qg(
             plan=plan,
             plan_content=plan_content,
             module_dir=module_dir,
             writer=writer,
+            stdout_silence_timeout=args.writer_timeout,
         )
         linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)
         aggregate = llm_qg["aggregate"]
-        emit_event(
+        tracker.emit(
             "review_score",
             level=level,
             slug=slug,
             score=aggregate["min_score"],
             verdict=aggregate["verdict"],
         )
-        _phase_done(phase, started_at, level=level, slug=slug)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
         if aggregate["verdict"] != "PASS":
             raise linear_pipeline.LinearPipelineError(
                 f"LLM QG verdict was {aggregate['verdict']}"
@@ -353,17 +404,38 @@ def _run(args: argparse.Namespace) -> int:
         started_at = time.monotonic()
         mdx_path = module_dir / f"{slug}.mdx"
         linear_pipeline.assemble_mdx(module_dir, mdx_path, plan_path)
-        _phase_done(phase, started_at, level=level, slug=slug, output=mdx_path)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            output=mdx_path,
+            event_sink=tracker.emit,
+        )
 
-        emit_event(
+        tracker.emit(
             "module_done",
             level=level,
             slug=slug,
             duration_s=round(time.monotonic() - module_started_at, 3),
         )
         return 0
+    except AgentStalledError as exc:
+        tracker.emit(
+            "writer_timeout",
+            level=level,
+            slug=slug,
+            writer=timeout_agent,
+            phase=phase,
+            timeout_s=args.writer_timeout,
+            last_event_type=tracker.event_type,
+            last_event_ts=tracker.event_ts,
+            total_wall_time_s=round(time.monotonic() - module_started_at, 3),
+        )
+        print(f"v7_build timed out in phase {phase}: {exc}", file=sys.stderr, flush=True)
+        return 124
     except Exception as exc:
-        emit_event(
+        tracker.emit(
             "module_failed",
             level=level,
             slug=slug,

--- a/scripts/build/v7_review.py
+++ b/scripts/build/v7_review.py
@@ -7,6 +7,9 @@ import argparse
 import re
 import sys
 import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -16,9 +19,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.agent_runtime.errors import AgentStalledError
 from scripts.build import linear_pipeline
 from scripts.common.thresholds import QG_DIMS
 
+DEFAULT_WRITER_TIMEOUT_S = 1800
 AGENT_ALIASES = {
     "claude": "claude-tools",
     "gemini": "gemini-tools",
@@ -32,8 +37,26 @@ REVIEWER_CHOICES = (*linear_pipeline.REVIEWER_CHOICES, *AGENT_ALIASES)
 FRONTMATTER_RE = re.compile(r"^---\s*\n(?P<body>.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
 
 
+@dataclass(slots=True)
+class LastEventTracker:
+    event_type: str | None = None
+    event_ts: str | None = None
+
+    def emit(self, event: str, **fields: Any) -> None:
+        self.event_type = event
+        self.event_ts = datetime.now(UTC).isoformat()
+        emit_event(event, **fields)
+
+
 def emit_event(event: str, **fields: Any) -> None:
     linear_pipeline.emit_event(event, **fields)
+
+
+def _positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
 
 
 def _resolve_project_path(raw: str | None) -> Path | None:
@@ -81,9 +104,10 @@ def _phase_done(
     *,
     level: str,
     slug: str,
+    event_sink: Callable[..., None] = emit_event,
     **fields: Any,
 ) -> None:
-    emit_event(
+    event_sink(
         "phase_done",
         level=level,
         slug=slug,
@@ -117,6 +141,8 @@ def build_parser() -> argparse.ArgumentParser:
             "  0 when every configured LLM QG dimension is reviewed and aggregated.\n"
             "  1 on missing plan, packet, content, self-review, reviewer, or parse failure.\n"
             "  2 on command-line usage errors from argparse.\n\n"
+            "  124 when a reviewer subprocess is killed after --writer-timeout "
+            "seconds of stdout silence.\n\n"
             "Related:\n"
             "  Pipeline: scripts/build/linear_pipeline.py\n"
             "  Reviewer prompt: scripts/build/phases/linear-review-dim.md\n"
@@ -155,6 +181,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--writer-timeout",
+        metavar="SECONDS",
+        type=_positive_int,
+        default=DEFAULT_WRITER_TIMEOUT_S,
+        help=(
+            "Kill each reviewer subprocess and exit 124 if it produces no "
+            f"stdout for SECONDS (default: {DEFAULT_WRITER_TIMEOUT_S})."
+        ),
+    )
+    parser.add_argument(
         "--telemetry-out",
         metavar="PATH",
         default=None,
@@ -183,12 +219,13 @@ def _run(args: argparse.Namespace) -> int:
     phase = "start"
     module_ref = f"{level}/{slug}"
     captured_events: list[dict[str, Any]] = []
+    tracker = LastEventTracker()
 
     def event_sink(event: str, **fields: Any) -> None:
         captured_events.append({"event": event, **fields})
-        emit_event(event, **fields)
+        tracker.emit(event, **fields)
 
-    emit_event("module_start", level=level, slug=slug, reviewer=reviewer)
+    tracker.emit("module_start", level=level, slug=slug, reviewer=reviewer)
 
     try:
         phase = "plan"
@@ -197,12 +234,12 @@ def _run(args: argparse.Namespace) -> int:
         plan_content = plan_path.read_text(encoding="utf-8")
         plan = linear_pipeline.load_plan(plan_path)
         linear_pipeline.validate_plan(plan)
-        _phase_done(phase, started_at, level=level, slug=slug)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
 
         phase = "knowledge_packet"
         started_at = time.monotonic()
         linear_pipeline.build_knowledge_packet(level=level, slug=slug, plan=plan)
-        _phase_done(phase, started_at, level=level, slug=slug)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
 
         phase = "content"
         started_at = time.monotonic()
@@ -223,6 +260,7 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             content=content_path,
             writer_under_review=writer_under_review,
+            event_sink=tracker.emit,
         )
 
         phase = "review"
@@ -243,6 +281,7 @@ def _run(args: argparse.Namespace) -> int:
                 cwd=content_path.parent,
                 module=module_ref,
                 event_sink=event_sink,
+                stdout_silence_timeout=args.writer_timeout,
             )
             report[dim] = linear_pipeline.parse_review_response(response, dim)
 
@@ -281,8 +320,9 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             reviewer=reviewer,
             verdict=aggregate["aggregate"]["verdict"],
+            event_sink=tracker.emit,
         )
-        emit_event(
+        tracker.emit(
             "module_done",
             level=level,
             slug=slug,
@@ -290,8 +330,23 @@ def _run(args: argparse.Namespace) -> int:
             duration_s=round(time.monotonic() - module_started_at, 3),
         )
         return 0
+    except AgentStalledError as exc:
+        tracker.emit(
+            "writer_timeout",
+            level=level,
+            slug=slug,
+            writer=reviewer,
+            reviewer=reviewer,
+            phase=phase,
+            timeout_s=args.writer_timeout,
+            last_event_type=tracker.event_type,
+            last_event_ts=tracker.event_ts,
+            total_wall_time_s=round(time.monotonic() - module_started_at, 3),
+        )
+        print(f"v7_review timed out in phase {phase}: {exc}", file=sys.stderr, flush=True)
+        return 124
     except Exception as exc:
-        emit_event(
+        tracker.emit(
             "module_failed",
             level=level,
             slug=slug,

--- a/tests/test_bakeoff_run.py
+++ b/tests/test_bakeoff_run.py
@@ -148,6 +148,67 @@ def test_bakeoff_run_resume_skips_complete_writer(
     assert full_build_writers == ["claude-tools"]
 
 
+def test_bakeoff_run_writer_timeout_continues_next_writer(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    calls: list[list[str]] = []
+    bakeoff_dir = tmp_path / "bakeoff"
+
+    def run(argv: Any) -> subprocess.CompletedProcess[str]:
+        command = [str(part) for part in argv]
+        calls.append(command)
+        script = Path(command[1]).name
+        if script == "v7_build.py" and "--dry-run" not in command:
+            writer = command[command.index("--writer") + 1]
+            if writer == "gemini-tools":
+                return subprocess.CompletedProcess(
+                    command,
+                    124,
+                    stdout="",
+                    stderr="writer_timeout",
+                )
+            out_dir = Path(command[command.index("--out") + 1])
+            telemetry = Path(command[command.index("--telemetry-out") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            telemetry.parent.mkdir(parents=True, exist_ok=True)
+            (out_dir / "my-morning.mdx").write_text("# Мій ранок\n", encoding="utf-8")
+            telemetry.write_text(
+                json.dumps({"event": "phase_writer_summary"}) + "\n",
+                encoding="utf-8",
+            )
+        return _completed(command)
+
+    monkeypatch.setattr(bakeoff_run, "run_command", run)
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(bakeoff_dir),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools,claude-tools",
+            "--writers-only",
+            "--skip-aggregate",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    full_build_writers = [
+        call[call.index("--writer") + 1]
+        for call in calls
+        if Path(call[1]).name == "v7_build.py" and "--dry-run" not in call
+    ]
+
+    assert exit_code == 1
+    assert full_build_writers == ["gemini-tools", "claude-tools"]
+    assert "timeout: writer_timeout" in captured.err
+
+
 def test_bakeoff_run_preflight_missing_plan_exits_1(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_v7_review.py
+++ b/tests/test_v7_review.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from scripts.agent_runtime.errors import AgentStalledError
 from scripts.build import linear_pipeline, v7_review
 from scripts.common.thresholds import QG_DIMS
 
@@ -177,3 +178,43 @@ def test_v7_review_telemetry_out_writes_file_not_stdout(
     assert len(fake_reviewer) == len(QG_DIMS)
     assert len(dim_events) == len(QG_DIMS)
     assert events[-1]["event"] == "module_done"
+
+
+def test_v7_review_reviewer_timeout_emits_writer_timeout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = _lesson(tmp_path / "gemini.md", writer="gemini-tools")
+    telemetry = tmp_path / "review-timeout.jsonl"
+
+    def timeout_reviewer(*_args: Any, **_kwargs: Any) -> str:
+        raise AgentStalledError("claude", 1, 1.2)
+
+    monkeypatch.setattr(v7_review.linear_pipeline, "invoke_reviewer_dim", timeout_reviewer)
+
+    exit_code = v7_review.main(
+        [
+            "a1",
+            "my-morning",
+            "--content",
+            str(content),
+            "--reviewer",
+            "claude-tools",
+            "--writer-timeout",
+            "1",
+            "--telemetry-out",
+            str(telemetry),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in telemetry.read_text("utf-8").splitlines()]
+    timeout_event = next(event for event in events if event["event"] == "writer_timeout")
+
+    assert exit_code == 124
+    assert "timed out in phase review" in captured.err
+    assert timeout_event["writer"] == "claude-tools"
+    assert timeout_event["reviewer"] == "claude-tools"
+    assert timeout_event["last_event_type"] == "phase_done"
+    assert timeout_event["last_event_ts"]

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import importlib
 import json
+import signal
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from scripts.agent_runtime.adapters.base import InvocationPlan
 from scripts.agent_runtime.registry import get_agent_entry
+from scripts.agent_runtime.result import ParseResult
+from scripts.agent_runtime.telemetry import InvocationTelemetry
 from scripts.build import linear_pipeline, v7_build
 
 
@@ -91,3 +96,86 @@ def test_v7_build_dry_run_telemetry_out_writes_file_not_stdout(
     assert {event["event"] for event in events} >= {"module_start", "phase_done", "module_done"}
     assert events[-1]["event"] == "module_done"
     assert events[-1]["dry_run"] is True
+
+
+def test_v7_build_writer_timeout_kills_silent_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    telemetry = tmp_path / "timeout.jsonl"
+    out_dir = tmp_path / "out"
+    returncode_file = tmp_path / "returncode.txt"
+    from scripts.agent_runtime import runner as runtime_runner
+
+    class SleepingAdapter:
+        name = "claude"
+        default_model = "fixture-model"
+        supported_modes = frozenset({"workspace-write"})
+
+        def build_invocation(self, **kwargs: Any) -> InvocationPlan:
+            return InvocationPlan(
+                cmd=["/bin/sh", "-c", "sleep 60"],
+                cwd=Path(kwargs["cwd"]),
+            )
+
+        def parse_response(
+            self,
+            *,
+            stdout: str,
+            stderr: str,
+            returncode: int,
+            **_kwargs: Any,
+        ) -> ParseResult:
+            returncode_file.write_text(str(returncode), encoding="utf-8")
+            return ParseResult(ok=False, response="", stderr_excerpt=stderr or stdout)
+
+        def liveness_signal_paths(self, _plan: InvocationPlan) -> tuple[Path, ...]:
+            return ()
+
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "build_knowledge_packet",
+        lambda **_kwargs: "knowledge packet",
+    )
+    monkeypatch.setattr(runtime_runner, "has_headroom", lambda *_args: (True, ""))
+    monkeypatch.setattr(runtime_runner, "write_record", lambda _record: None)
+    monkeypatch.setattr(
+        runtime_runner,
+        "resolve_invocation_telemetry",
+        lambda **_kwargs: InvocationTelemetry(
+            model="fixture-model",
+            effort="unknown",
+            cli_version="fixture",
+        ),
+    )
+    monkeypatch.setitem(runtime_runner._ADAPTER_CACHE, "claude", SleepingAdapter())
+
+    started = time.monotonic()
+    exit_code = v7_build.main(
+        [
+            "a1",
+            "my-morning",
+            "--writer",
+            "claude-tools",
+            "--writer-timeout",
+            "1",
+            "--out",
+            str(out_dir),
+            "--telemetry-out",
+            str(telemetry),
+        ]
+    )
+    elapsed = time.monotonic() - started
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in telemetry.read_text("utf-8").splitlines()]
+    timeout_event = next(event for event in events if event["event"] == "writer_timeout")
+
+    assert exit_code == 124
+    assert elapsed < 6
+    assert int(returncode_file.read_text("utf-8")) == -signal.SIGKILL
+    assert "timed out in phase writer" in captured.err
+    assert timeout_event["writer"] == "claude-tools"
+    assert timeout_event["last_event_type"] == "phase_done"
+    assert timeout_event["last_event_ts"]
+    assert timeout_event["total_wall_time_s"] < 6


### PR DESCRIPTION
## Summary
- add opt-in stdout-silence watchdog support to agent runtime and wire it to V7 writer/reviewer calls via --writer-timeout (default 1800s)
- emit writer_timeout JSONL telemetry and return exit code 124 on silent subprocess kills
- teach bakeoff_run.py to classify exit 124 as timeout failure while continuing remaining writers/reviews

## Tests
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/agent_runtime/watchdog.py scripts/agent_runtime/runner.py scripts/build/linear_pipeline.py scripts/build/v7_build.py scripts/build/v7_review.py scripts/audit/bakeoff_run.py tests/test_v7_writer_dispatch.py tests/test_v7_review.py tests/test_bakeoff_run.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_v7_writer_dispatch.py tests/test_v7_review.py tests/test_bakeoff_run.py -q
- pre-commit hook: ruff + affected pytest files (18 passed)