### PR TITLE
fix(gemini): flip auth-mode priority — API first, OAuth fallback (#1710)

### DIFF
--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -442,11 +442,14 @@ untrusted output directories such as `/tmp` and exits before writing.
 
 Gemini auth precedence is API first, then subscription/OAuth fallback:
 
-- `GEMINI_AUTH_MODE=api` forces API mode.
+- `GEMINI_AUTH_MODE=api` forces API mode and fails fast if no Gemini API key is
+  configured.
 - `GEMINI_AUTH_MODE=subscription` or `oauth` forces subscription/OAuth mode and
   strips Gemini API env vars from the subprocess.
 - With no override, `GEMINI_API_KEY` or `GOOGLE_API_KEY` selects API mode.
 - With no override and no API key, subscription/OAuth remains the default.
+- The fallback ladder starts on API rungs when API keys are available, then
+  transitions to subscription/OAuth rungs on rate limit or capacity failures.
 
 ---
 

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -13,6 +13,10 @@ flag requirements in the codebase:
 - Rate-limit detection: Gemini returns ``RESOURCE_EXHAUSTED``, ``quota
   exceeded``, and occasionally ``No capacity available`` depending on
   backend. Patterns match dispatch.py prior art.
+- Auth precedence: in auto mode, ``GEMINI_API_KEY`` / ``GOOGLE_API_KEY``
+  selects API-key auth first; otherwise the adapter falls back to
+  subscription/OAuth and strips Gemini API env vars from the subprocess.
+  Explicit ``GEMINI_AUTH_MODE=api`` or ``subscription`` still wins.
 - No session IDs. Gemini CLI doesn't expose them, so ``parse_response``
   returns ``session_id=None`` always. Resume policy is ``bridge_only``
   for cost economics, but session IDs come from the bridge's own SQLite

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1961,8 +1961,8 @@ def test_gemini_adapter_read_only_no_yolo(tmp_path):
     assert "--approval-mode=yolo" not in plan.cmd
     assert "-m" in plan.cmd
     assert "-p" in plan.cmd
-    assert plan.cmd[plan.cmd.index("-p") + 1] == "hello"
-    assert plan.stdin_payload == ""
+    assert plan.cmd[plan.cmd.index("-p") + 1] == " "
+    assert plan.stdin_payload == "hello"
     assert plan.output_file is None  # Gemini uses stdout, no -o file
     assert plan.liveness_paths == ()
 


### PR DESCRIPTION
## Summary
- Document Gemini API-first auth precedence and explicit override behavior in the adapter docstring and cooperation guide
- Clarify that forced API mode fails fast without a configured Gemini API key
- Keep runtime Gemini adapter tests aligned with the current stdin prompt transport while preserving the auth-mode coverage

## Tests
- .venv/bin/python -m pytest tests/test_agent_runtime.py tests/test_gemini_adapter_auth.py tests/test_agent_runtime_gemini_adapter.py tests/test_ai_llm_fallback.py -q
- .venv/bin/ruff check scripts/agent_runtime/adapters/gemini.py tests/test_agent_runtime.py tests/test_agent_runtime_gemini_adapter.py tests/test_gemini_adapter_auth.py tests/test_ai_llm_fallback.py

Closes #1710