### PR TITLE
fix(bakeoff): resume checks terminal success event (#1707)

### DIFF
--- a/scripts/audit/bakeoff_run.py
+++ b/scripts/audit/bakeoff_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import shutil
 import subprocess
 import sys
@@ -83,8 +84,30 @@ def _short_name(writer: str) -> str:
     return bakeoff_aggregate.normalize_agent(writer)
 
 
-def _nonempty(path: Path) -> bool:
-    return path.exists() and path.stat().st_size > 0
+def _jsonl_has_event(path: Path, event: str) -> bool:
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if payload.get("event") == event:
+            return True
+    return False
+
+
+def _writer_complete(path: Path) -> bool:
+    return _jsonl_has_event(path, "phase_writer_summary")
+
+
+def _review_complete(path: Path) -> bool:
+    return _jsonl_has_event(path, "phase_review_summary")
+
+
+def _truncate_telemetry(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
 
 
 def _display_path(path: Path) -> str:
@@ -196,8 +219,9 @@ def _run_writer(
     short = _short_name(writer)
     telemetry = bakeoff_dir / f"{short}.write.jsonl"
     out_dir = bakeoff_dir / short
-    if resume and _nonempty(telemetry):
+    if resume and _writer_complete(telemetry):
         return StepResult(label=f"write {writer}", ok=True, skipped=True)
+    _truncate_telemetry(telemetry)
 
     result = _run_or_report(
         f"write {writer}",
@@ -236,7 +260,7 @@ def _run_review(
     writer_short = _short_name(writer)
     reviewer_short = _short_name(reviewer)
     target = bakeoff_dir / f"{writer_short}-{reviewer_short}.review.jsonl"
-    if resume and _nonempty(target):
+    if resume and _review_complete(target):
         return StepResult(
             label=f"review {writer}->{reviewer}",
             ok=True,
@@ -247,6 +271,7 @@ def _run_review(
         detail = f"missing writer markdown for review: {content}"
         print(f"error: {detail}", file=sys.stderr)
         return StepResult(label=f"review {writer}->{reviewer}", ok=False, detail=detail)
+    _truncate_telemetry(target)
 
     return _run_or_report(
         f"review {writer}->{reviewer}",
@@ -379,7 +404,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help=(
             "Skip already-complete writer/review JSONL outputs when present "
-            "and non-empty (default: false)."
+            "and marked by a terminal success event (default: false)."
         ),
     )
     parser.add_argument(

--- a/tests/test_bakeoff_run.py
+++ b/tests/test_bakeoff_run.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 from scripts.audit import bakeoff_run
@@ -28,17 +29,13 @@ def _fake_runner(calls: list[list[str]], slug: str = "my-morning"):
                 "---\nlevel: A1\nslug: my-morning\n---\n\n# Мій ранок\n",
                 encoding="utf-8",
             )
-            telemetry.write_text(
-                json.dumps({"event": "phase_writer_summary"}) + "\n",
-                encoding="utf-8",
-            )
+            with telemetry.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"event": "phase_writer_summary"}) + "\n")
         elif script == "v7_review.py":
             telemetry = Path(command[command.index("--telemetry-out") + 1])
             telemetry.parent.mkdir(parents=True, exist_ok=True)
-            telemetry.write_text(
-                json.dumps({"event": "phase_review_summary"}) + "\n",
-                encoding="utf-8",
-            )
+            with telemetry.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"event": "phase_review_summary"}) + "\n")
         elif script == "bakeoff_aggregate.py":
             bakeoff_dir = Path(command[command.index("--bakeoff-dir") + 1])
             (bakeoff_dir / "REPORT.md").write_text("# Report\n", encoding="utf-8")
@@ -112,14 +109,27 @@ def test_bakeoff_run_invokes_write_and_review_steps_in_order(
     assert calls[4][calls[4].index("--reviewer") + 1] == "gemini-tools"
 
 
-def test_bakeoff_run_resume_skips_complete_writer(
+@pytest.mark.parametrize(
+    ("initial_jsonl", "expected_gemini_rerun"),
+    [
+        (json.dumps({"event": "phase_writer_summary"}) + "\n", False),
+        (json.dumps({"event": "module_start"}) + "\n", True),
+        (None, True),
+        ("", True),
+    ],
+)
+def test_bakeoff_run_resume_writer_requires_terminal_event(
     tmp_path: Path,
     monkeypatch,
+    initial_jsonl: str | None,
+    expected_gemini_rerun: bool,
 ) -> None:
     calls: list[list[str]] = []
     bakeoff_dir = tmp_path / "bakeoff"
     bakeoff_dir.mkdir()
-    (bakeoff_dir / "gemini.write.jsonl").write_text('{"event":"done"}\n', "utf-8")
+    telemetry = bakeoff_dir / "gemini.write.jsonl"
+    if initial_jsonl is not None:
+        telemetry.write_text(initial_jsonl, encoding="utf-8")
     monkeypatch.setattr(bakeoff_run, "run_command", _fake_runner(calls))
 
     exit_code = bakeoff_run.main(
@@ -145,7 +155,73 @@ def test_bakeoff_run_resume_skips_complete_writer(
     ]
 
     assert exit_code == 0
-    assert full_build_writers == ["claude-tools"]
+    assert ("gemini-tools" in full_build_writers) is expected_gemini_rerun
+    assert "claude-tools" in full_build_writers
+    if expected_gemini_rerun:
+        assert telemetry.read_text(encoding="utf-8") == (
+            json.dumps({"event": "phase_writer_summary"}) + "\n"
+        )
+    else:
+        assert full_build_writers == ["claude-tools"]
+
+
+@pytest.mark.parametrize(
+    ("initial_jsonl", "expected_gemini_claude_rerun"),
+    [
+        (json.dumps({"event": "phase_review_summary"}) + "\n", False),
+        (json.dumps({"event": "module_start"}) + "\n", True),
+        (None, True),
+        ("", True),
+    ],
+)
+def test_bakeoff_run_resume_review_requires_terminal_event(
+    tmp_path: Path,
+    monkeypatch,
+    initial_jsonl: str | None,
+    expected_gemini_claude_rerun: bool,
+) -> None:
+    calls: list[list[str]] = []
+    bakeoff_dir = tmp_path / "bakeoff"
+    bakeoff_dir.mkdir()
+    (bakeoff_dir / "gemini.md").write_text("# Gemini module\n", encoding="utf-8")
+    (bakeoff_dir / "claude.md").write_text("# Claude module\n", encoding="utf-8")
+    telemetry = bakeoff_dir / "gemini-claude.review.jsonl"
+    if initial_jsonl is not None:
+        telemetry.write_text(initial_jsonl, encoding="utf-8")
+    monkeypatch.setattr(bakeoff_run, "run_command", _fake_runner(calls))
+
+    exit_code = bakeoff_run.main(
+        [
+            "--bakeoff-dir",
+            str(bakeoff_dir),
+            "--level",
+            "a1",
+            "--slug",
+            "my-morning",
+            "--writers",
+            "gemini-tools,claude-tools",
+            "--resume",
+            "--reviewers-only",
+            "--skip-aggregate",
+        ]
+    )
+
+    review_pairs = [
+        (
+            Path(call[call.index("--content") + 1]).name,
+            call[call.index("--reviewer") + 1],
+        )
+        for call in calls
+        if Path(call[1]).name == "v7_review.py"
+    ]
+
+    assert exit_code == 0
+    assert (("gemini.md", "claude-tools") in review_pairs) is expected_gemini_claude_rerun
+    assert ("claude.md", "gemini-tools") in review_pairs
+    if expected_gemini_claude_rerun:
+        assert telemetry.read_text(encoding="utf-8") == (
+            json.dumps({"event": "phase_review_summary"}) + "\n"
+        )
 
 
 def test_bakeoff_run_preflight_missing_plan_exits_1(


### PR DESCRIPTION
Summary:
- Change bakeoff --resume to skip writer/review steps only when the matching terminal success event is present.
- Truncate telemetry JSONL before rerunning non-skipped writer/review steps so partial append-mode logs do not survive.
- Add parametrized writer and review resume tests for complete, partial, missing, and empty JSONL cases.

Validation:
- .venv/bin/ruff check scripts/audit/bakeoff_run.py tests/test_bakeoff_run.py
- .venv/bin/python -m pytest tests/test_bakeoff_run.py