### PR TITLE
feat(agent_runtime): scrub spawned-agent env (#1701)

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -87,6 +87,32 @@ agent.** Per channel conventions:
 This rule is non-negotiable. Bypassing it was the #1 reason review
 quality degraded on earlier commits.
 
+## Spawned-agent env hygiene
+
+The agent runtime does not pass the orchestrator's full `os.environ` to
+spawned CLIs. `scripts/agent_runtime/env_sanitize.py` builds a narrow
+environment for each process:
+
+- Common runtime variables survive only from the safe allowlist:
+  `PATH`, `HOME`, `TMPDIR`, `LANG`, `LC_*`, `AB_*`, and `LU_*`.
+- Variables with secret-shaped names are dropped, including names that
+  contain `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `PRIVATE`,
+  `CREDENTIAL`, `API_KEY`, `ACCESS_KEY`, `AUTH`, or `COOKIE`.
+- Variables with known secret-shaped values are dropped, including
+  GitHub, OpenAI-style `sk-`, Slack `xox-`, Hugging Face `hf_`, npm,
+  AWS access-key, and Google `AIza` patterns.
+- Provider credentials pass through only to that provider: Gemini sees
+  Gemini/Google keys, Claude sees Anthropic/Claude keys, and Codex sees
+  OpenAI/Codex keys. Cross-provider keys and `GITHUB_TOKEN` stay absent.
+- Gemini also receives `GEMINI_AUTH_MODE` because it is runtime mode
+  selection, not a credential; secret-shaped values are still rejected.
+
+Adapters should put per-call environment values in
+`InvocationPlan.env_overrides`; the runner applies overrides, sanitizes,
+then applies explicit `InvocationPlan.env_unsets`. The merge guard runs
+after sanitization so its `gh`/`git` shims still receive the final `PATH`
+and can stamp `AGENT_NO_MERGE`, `AGENT_REAL_GH`, and `AGENT_REAL_GIT`.
+
 ## Context file conventions
 
 `docs/agent-channels/{channel}/context.md` should contain:

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -1,0 +1,134 @@
+"""Sanitize environment variables for spawned agent CLI processes.
+
+Agent CLIs can run shell commands and inspect ``os.environ`` directly. The
+runtime should therefore pass only ordinary process context plus the credential
+for the provider being invoked, not the full orchestrator environment.
+"""
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+
+_SENSITIVE_NAME_RE = re.compile(
+    r"TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE|CREDENTIALS?|API_?KEY|"
+    r"ACCESS_?KEY|AUTH|COOKIE",
+    re.IGNORECASE,
+)
+
+_SENSITIVE_VALUE_RE = re.compile(
+    r"(?:"
+    r"github_pat_[A-Za-z0-9_]+|"
+    r"gh[pousr]_[A-Za-z0-9_]+|"
+    r"sk-[A-Za-z0-9_-]+|"
+    r"xox[baprs]-[A-Za-z0-9-]+|"
+    r"hf_[A-Za-z0-9_]+|"
+    r"npm_[A-Za-z0-9_]+|"
+    r"AKIA[A-Z0-9]{12,}|"
+    r"AIza[A-Za-z0-9_-]+"
+    r")"
+)
+
+_SAFE_NAME_ALLOWLIST = {
+    "AGENT_ALLOW_MERGE",
+    "AGENT_NO_MERGE",
+    "HOME",
+    "LANG",
+    "PATH",
+    "TMPDIR",
+}
+
+_SAFE_NAME_PREFIXES = (
+    "AB_",
+    "LC_",
+    "LU_",
+)
+
+_PROVIDER_SECRET_ALLOWLIST = {
+    "gemini": {
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+    },
+    "claude": {
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_API_KEY",
+    },
+    "codex": {
+        "CODEX_API_KEY",
+        "OPENAI_API_KEY",
+    },
+    "bridge": set(),
+}
+
+_PROVIDER_SAFE_NAME_ALLOWLIST = {
+    "gemini": {
+        "GEMINI_AUTH_MODE",
+    },
+}
+
+
+def _normalized_provider(provider: str) -> str:
+    """Map runtime provider names to sanitizer policy keys."""
+    return provider.removesuffix("-tools").lower()
+
+
+def _is_safe_name(name: str) -> bool:
+    upper = name.upper()
+    return upper in _SAFE_NAME_ALLOWLIST or upper.startswith(_SAFE_NAME_PREFIXES)
+
+
+def _is_provider_secret(name: str, provider: str) -> bool:
+    allowed = _PROVIDER_SECRET_ALLOWLIST.get(_normalized_provider(provider), set())
+    return name.upper() in allowed
+
+
+def _is_provider_safe_name(name: str, provider: str) -> bool:
+    allowed = _PROVIDER_SAFE_NAME_ALLOWLIST.get(_normalized_provider(provider), set())
+    return name.upper() in allowed
+
+
+def _looks_sensitive_name(name: str) -> bool:
+    return bool(_SENSITIVE_NAME_RE.search(name))
+
+
+def _looks_sensitive_value(value: str) -> bool:
+    return bool(_SENSITIVE_VALUE_RE.search(value))
+
+
+def build_agent_env(
+    *,
+    provider: str,
+    overrides: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a scrubbed env for a spawned agent CLI.
+
+    ``overrides`` are applied to the parent environment before sanitization so
+    adapter-supplied values are subject to the same policy as inherited values.
+    The runner applies explicit ``InvocationPlan.env_unsets`` after this call.
+    """
+    raw = dict(os.environ)
+    raw.update(overrides or {})
+
+    env: dict[str, str] = {}
+    for name, value in raw.items():
+        if _is_provider_secret(name, provider):
+            env[name] = value
+            continue
+
+        if _looks_sensitive_value(value):
+            continue
+        if _is_provider_safe_name(name, provider):
+            env[name] = value
+            continue
+        if _looks_sensitive_name(name):
+            continue
+        if _is_safe_name(name):
+            env[name] = value
+
+    if "PATH" not in env and "PATH" in raw and not _looks_sensitive_value(raw["PATH"]):
+        env["PATH"] = raw["PATH"]
+    if "HOME" not in env and "HOME" in raw and not _looks_sensitive_value(raw["HOME"]):
+        env["HOME"] = raw["HOME"]
+
+    return env

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -47,6 +47,7 @@ from ai_llm.fallback import (
 )
 
 from .adapters.base import AgentAdapter
+from .env_sanitize import build_agent_env
 from .errors import (
     AgentTimeoutError,
     AgentUnavailableError,
@@ -462,7 +463,7 @@ def _execute_invocation_plan(
     stall_timeout: int,
 ) -> _ExecutionOutcome:
     """Spawn one plan, run watchdog/parse flow, and return raw execution state."""
-    env = {**os.environ, **plan.env_overrides}
+    env = build_agent_env(provider=agent_name, overrides=plan.env_overrides)
     for key in plan.env_unsets:
         env.pop(key, None)
     env = _apply_merge_guard(mode=mode, env=env)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1961,8 +1961,8 @@ def test_gemini_adapter_read_only_no_yolo(tmp_path):
     assert "--approval-mode=yolo" not in plan.cmd
     assert "-m" in plan.cmd
     assert "-p" in plan.cmd
-    assert plan.cmd[plan.cmd.index("-p") + 1] == "hello"
-    assert plan.stdin_payload == ""
+    assert plan.cmd[plan.cmd.index("-p") + 1] == " "
+    assert plan.stdin_payload == "hello"
     assert plan.output_file is None  # Gemini uses stdout, no -o file
     assert plan.liveness_paths == ()
 

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.env_sanitize import build_agent_env
+from agent_runtime.result import ParseResult
+from agent_runtime.runner import _execute_invocation_plan
+
+
+def _resolve_test_python() -> str:
+    checkout_venv = Path(__file__).resolve().parent.parent / ".venv" / "bin" / "python"
+    if checkout_venv.exists():
+        return str(checkout_venv)
+
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=Path(__file__).resolve().parent,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if common_dir:
+            main_venv = (Path(common_dir) / ".." / ".venv" / "bin" / "python").resolve()
+            if main_venv.exists():
+                return str(main_venv)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    active_venv = os.environ.get("VIRTUAL_ENV")
+    if active_venv:
+        candidate = Path(active_venv) / "bin" / "python"
+        if candidate.exists():
+            return str(candidate)
+
+    raise RuntimeError("No project virtualenv Python found")
+
+
+_TEST_PYTHON = _resolve_test_python()
+
+
+def test_build_agent_env_passes_only_current_provider_credentials():
+    parent_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/Users/example",
+        "GEMINI_API_KEY": "gemini-key",
+        "GOOGLE_API_KEY": "google-key",
+        "ANTHROPIC_API_KEY": "sk-ant-fake",
+        "CLAUDE_API_KEY": "sk-claude-fake",
+        "OPENAI_API_KEY": "sk-openai-fake",
+        "CODEX_API_KEY": "codex-key",
+        "GITHUB_TOKEN": "ghp_fakegithubtoken",
+    }
+
+    with patch.dict("os.environ", parent_env, clear=True):
+        gemini_env = build_agent_env(provider="gemini", overrides={})
+        claude_env = build_agent_env(provider="claude", overrides={})
+        codex_env = build_agent_env(provider="codex", overrides={})
+        bridge_env = build_agent_env(provider="bridge", overrides={})
+
+    assert gemini_env["GEMINI_API_KEY"] == "gemini-key"
+    assert gemini_env["GOOGLE_API_KEY"] == "google-key"
+    assert "ANTHROPIC_API_KEY" not in gemini_env
+    assert "OPENAI_API_KEY" not in gemini_env
+
+    assert claude_env["ANTHROPIC_API_KEY"] == "sk-ant-fake"
+    assert claude_env["CLAUDE_API_KEY"] == "sk-claude-fake"
+    assert "GEMINI_API_KEY" not in claude_env
+    assert "OPENAI_API_KEY" not in claude_env
+
+    assert codex_env["OPENAI_API_KEY"] == "sk-openai-fake"
+    assert codex_env["CODEX_API_KEY"] == "codex-key"
+    assert "GEMINI_API_KEY" not in codex_env
+    assert "ANTHROPIC_API_KEY" not in codex_env
+
+    assert "GEMINI_API_KEY" not in bridge_env
+    assert "ANTHROPIC_API_KEY" not in bridge_env
+    assert "OPENAI_API_KEY" not in bridge_env
+    assert "GITHUB_TOKEN" not in bridge_env
+
+
+def test_build_agent_env_drops_sensitive_names():
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "CUSTOM_TOKEN": "benign",
+            "CUSTOMTOKEN": "benign",
+            "DB_PASSWORD": "benign",
+            "AWS_ACCESS_KEY_ID": "benign",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/creds.json",
+            "SESSION_COOKIE": "benign",
+            "AB_TRACE_ID": "safe",
+        },
+        clear=True,
+    ):
+        env = build_agent_env(provider="codex", overrides={})
+
+    assert env["AB_TRACE_ID"] == "safe"
+    assert "CUSTOM_TOKEN" not in env
+    assert "CUSTOMTOKEN" not in env
+    assert "DB_PASSWORD" not in env
+    assert "AWS_ACCESS_KEY_ID" not in env
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in env
+    assert "SESSION_COOKIE" not in env
+
+
+def test_build_agent_env_drops_sensitive_values():
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "AB_GITHUB_PAT": "github_pat_fakevalue",
+            "AB_GITHUB_CLASSIC": "ghp_fakevalue",
+            "AB_OPENAI_SHAPED": "sk-fakevalue",
+            "AB_SLACK_SHAPED": "xoxb-fake-value",
+            "AB_HF_SHAPED": "hf_fakevalue",
+            "AB_NPM_SHAPED": "npm_fakevalue",
+            "AB_AWS_SHAPED": "AKIAFAKEFAKEFAKE",
+            "AB_GOOGLE_SHAPED": "AIzaFakeValue",
+            "AB_SAFE_VALUE": "trace-123",
+        },
+        clear=True,
+    ):
+        env = build_agent_env(provider="codex", overrides={})
+
+    assert env["AB_SAFE_VALUE"] == "trace-123"
+    assert "AB_GITHUB_PAT" not in env
+    assert "AB_GITHUB_CLASSIC" not in env
+    assert "AB_OPENAI_SHAPED" not in env
+    assert "AB_SLACK_SHAPED" not in env
+    assert "AB_HF_SHAPED" not in env
+    assert "AB_NPM_SHAPED" not in env
+    assert "AB_AWS_SHAPED" not in env
+    assert "AB_GOOGLE_SHAPED" not in env
+
+
+def test_build_agent_env_preserves_safe_allowlist_and_applies_overrides_first():
+    with patch.dict(
+        "os.environ",
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/example",
+            "TMPDIR": "/tmp",
+            "LANG": "en_US.UTF-8",
+            "LC_ALL": "C",
+            "AB_REPO_ROOT": "/repo",
+            "LU_BYPASS_RATE_LIMIT": "1",
+            "UNRELATED": "drop-me",
+        },
+        clear=True,
+    ):
+        env = build_agent_env(
+            provider="gemini",
+            overrides={
+                "PATH": "/custom/bin",
+                "GEMINI_AUTH_MODE": "subscription",
+                "AB_BAD_OVERRIDE": "sk-override",
+                "GITHUB_TOKEN": "ghp_fakeoverride",
+            },
+        )
+
+    assert env["PATH"] == "/custom/bin"
+    assert env["HOME"] == "/Users/example"
+    assert env["TMPDIR"] == "/tmp"
+    assert env["LANG"] == "en_US.UTF-8"
+    assert env["LC_ALL"] == "C"
+    assert env["AB_REPO_ROOT"] == "/repo"
+    assert env["LU_BYPASS_RATE_LIMIT"] == "1"
+    assert env["GEMINI_AUTH_MODE"] == "subscription"
+    assert "AB_BAD_OVERRIDE" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "UNRELATED" not in env
+
+
+@dataclass
+class _SmokePlan:
+    cmd: list[str]
+    cwd: Path
+    stdin_payload: str = ""
+    output_file: Path | None = None
+    env_overrides: dict[str, str] = field(default_factory=dict)
+    env_unsets: tuple[str, ...] = ()
+    liveness_paths: tuple[Path, ...] = ()
+
+
+class _SmokeAdapter:
+    def liveness_signal_paths(self, _plan: _SmokePlan) -> tuple[Path, ...]:
+        return ()
+
+    def parse_response(self, *, stdout: str, **_kwargs: object) -> ParseResult:
+        return ParseResult(ok=True, response=stdout)
+
+
+def test_runner_smoke_spawns_each_provider_with_only_its_own_key(tmp_path):
+    keys = [
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_API_KEY",
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY",
+        "GITHUB_TOKEN",
+    ]
+    script = (
+        "import json, os; "
+        f"keys = {keys!r}; "
+        "print(json.dumps({k: os.environ[k] for k in keys if k in os.environ}, "
+        "sort_keys=True))"
+    )
+    parent_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(tmp_path),
+        "GEMINI_API_KEY": "gemini-key",
+        "GOOGLE_API_KEY": "google-key",
+        "ANTHROPIC_API_KEY": "sk-ant-fake",
+        "CLAUDE_API_KEY": "sk-claude-fake",
+        "OPENAI_API_KEY": "sk-openai-fake",
+        "CODEX_API_KEY": "codex-key",
+        "GITHUB_TOKEN": "ghp_fakegithubtoken",
+    }
+    expected = {
+        "gemini": {
+            "GEMINI_API_KEY": "gemini-key",
+            "GOOGLE_API_KEY": "google-key",
+        },
+        "claude": {
+            "ANTHROPIC_API_KEY": "sk-ant-fake",
+            "CLAUDE_API_KEY": "sk-claude-fake",
+        },
+        "codex": {
+            "OPENAI_API_KEY": "sk-openai-fake",
+            "CODEX_API_KEY": "codex-key",
+        },
+    }
+
+    with patch.dict("os.environ", parent_env, clear=True), patch(
+        "agent_runtime.runner._POLL_INTERVAL_S", 0.01,
+    ):
+        for provider, expected_env in expected.items():
+            plan = _SmokePlan(
+                cmd=[_TEST_PYTHON, "-c", script],
+                cwd=tmp_path,
+            )
+            outcome = _execute_invocation_plan(
+                agent_name=provider,
+                adapter=_SmokeAdapter(),
+                plan=plan,
+                prompt="env smoke",
+                mode="read-only",
+                cwd=tmp_path,
+                model="smoke-model",
+                task_id=f"{provider}-env-smoke",
+                session_id=None,
+                entrypoint="runtime-test",
+                hard_timeout=10,
+                stall_timeout=10,
+            )
+
+            assert outcome.parse.ok is True
+            assert json.loads(outcome.stdout_text) == expected_env


### PR DESCRIPTION
## Summary
- Add agent_runtime env sanitizer with safe allowlist, secret name/value drops, and per-provider credential pass-through.
- Wire runner subprocess env construction through the sanitizer before env_unsets and merge guard.
- Add sanitizer/unit smoke coverage and document spawned-agent env hygiene.

## Tests
- pre-commit hook: ruff check + pytest on affected files (126 passed)
- manual: git diff --check