### PR TITLE
feat(ab): read-only sandbox for discussion adapter invocations (#1702)

### DIFF
--- a/docs/architecture/2026-05-06-ab-discuss-fs-sandbox-audit.md
+++ b/docs/architecture/2026-05-06-ab-discuss-fs-sandbox-audit.md
@@ -1,0 +1,51 @@
+# `ab discuss` Filesystem Sandbox Audit
+
+**Issue:** #1702
+**Date:** 2026-05-06
+**Scope:** `scripts/agent_runtime/adapters/{gemini,claude,codex}.py`
+as invoked by `ab discuss` and channel deliveries.
+
+## Finding
+
+Before this change, `ab discuss` requested `mode="read-only"`, but the
+three adapters did not provide equivalent filesystem protection:
+
+- `CodexAdapter` mapped read-only to `codex exec -s read-only`, which is
+  an explicit Codex sandbox.
+- `GeminiAdapter` treated read-only as the Gemini CLI default. The CLI
+  supports `--approval-mode plan` for read-only planning, but the adapter
+  only used `--approval-mode=yolo` for write modes and did not force plan
+  mode for discussion.
+- `ClaudeAdapter` documented that read-only and workspace-write used the
+  same Claude Code invocation unless the caller supplied restrictive tool
+  config. Claude Code now exposes `--permission-mode plan` and tool-set
+  restriction flags that were not used for discussion calls.
+
+`ab post` itself stores a message and delivery rows; the actual agent
+execution happens later in the inbox worker. Delivery mode defaults to
+read-only, and the inbox worker now applies the same discussion read-only
+tool config to those default deliveries. Explicit write-capable modes
+remain available for messages that are intentionally execution requests.
+
+## Policy
+
+Discussion is read-only. Agents may inspect and recommend; they must not
+create, edit, delete, stage, commit, or push files. Write-capable work
+belongs in an explicit execution path such as `delegate.py dispatch`.
+
+## Implementation
+
+`ab discuss` now marks runtime calls with discussion read-only tool config.
+Adapters honor that signal and the `AB_DISCUSS_READONLY=1` environment
+flag:
+
+- Codex rejects non-read-only discussion invocations and propagates the
+  environment flag to the child process.
+- Gemini rejects non-read-only discussion invocations and adds
+  `--approval-mode plan`.
+- Claude rejects non-read-only discussion invocations and adds
+  `--permission-mode plan --tools Read,Grep,Glob,LS`.
+
+The bridge also snapshots git state before each discussion round and checks
+it after all participants return. If the snapshot changed, the bridge posts
+a warning into the thread, rejects that round's replies, and exits non-zero.

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -41,6 +41,30 @@ captures, at post-time:
 A **reply** is just a new post with `parent_id` set. Replies inherit
 the thread_id and get `round_index = parent.round_index + 1`.
 
+## Discussion vs execution
+
+`ab discuss` is deliberation, not implementation. The bridge invokes
+participants in read-only mode, passes the `AB_DISCUSS_READONLY=1`
+contract through the adapter layer, and fails the round if the git
+working tree changes while participants are running. A failed round
+posts a loud system warning into the thread before returning non-zero.
+
+`ab post` creates channel messages and delivery rows. Its default
+delivery mode is read-only, and the inbox worker applies the same
+discussion read-only adapter contract to those default deliveries. Use
+write-capable modes only when the post is explicitly an execution
+request. Implementation work that needs file edits, commits, pushes, or
+a PR should normally go through `delegate.py dispatch` or
+`ab dispatch-fix`, not through discussion.
+
+Current adapter policy for discussion calls:
+
+- Codex: `read-only` maps to `codex exec -s read-only`.
+- Gemini: discussion calls add `--approval-mode plan`; plain read-only
+  CLI defaults were not enough in trusted workspaces.
+- Claude: discussion calls add `--permission-mode plan` and restrict
+  built-in tools to read/list/search tools.
+
 ## CLI quick reference
 
 ```bash
@@ -89,7 +113,7 @@ delegate worker.
 ## When to use channels vs `ask-*`
 
 | Situation | Use |
-|---|---|
+| --- | --- |
 | One-off question, no history needed | `ask-claude/gemini/codex` |
 | Sustained discussion on a topic | `ab post` to a channel |
 | Need a 2-3 agent debate on a design | `ab discuss` |
@@ -143,15 +167,15 @@ of project rules each time.
 **Measured brief sizes (chars sent from claude → gemini, excluding
 the ~10KB project-rules wrapper the legacy bridge prepends):**
 
-| Review round          | Task ID                        | Brief size |
-|-----------------------|--------------------------------|-----------:|
-| B.3 r1 (initial)      | `bridge-b3-review`             |  6,621     |
-| B.3 r2 (3 new blockers) | `bridge-b3-review-r2`        |  5,304     |
-| B.3 r3 (backslash bug)| `bridge-b3-review-r3`          |  2,683     |
-| B.3 r4 (CLEAN)        | `bridge-b3-review-r4`          |  2,121     |
-| B.4 r1 (4 blockers)   | `bridge-b4-review`             |  4,827     |
-| B.4 r2 (MINOR)        | `bridge-b4-review-r2`          |  3,915     |
-| **Total**             |                                | **25,471** |
+| Review round            | Task ID               | Brief size |
+| ----------------------- | --------------------- | ---------: |
+| B.3 r1 (initial)        | `bridge-b3-review`    |      6,621 |
+| B.3 r2 (3 new blockers) | `bridge-b3-review-r2` |      5,304 |
+| B.3 r3 (backslash bug)  | `bridge-b3-review-r3` |      2,683 |
+| B.3 r4 (CLEAN)          | `bridge-b3-review-r4` |      2,121 |
+| B.4 r1 (4 blockers)     | `bridge-b4-review`    |      4,827 |
+| B.4 r2 (MINOR)          | `bridge-b4-review-r2` |      3,915 |
+| **Total**               |                       | **25,471** |
 
 Every brief in that table would have been ~12KB larger had I
 followed the old convention (manually re-pasting the rules/history
@@ -298,15 +322,17 @@ Example launchd `.plist` (`docs/examples/learn-ukrainian.codex-inbox.plist`):
 
 Example systemd units (documented only, not tested here):
 
-> # ~/.config/systemd/user/learn-ukrainian-codex-inbox.path
-> [Path]
-> PathChanged=%h/projects/learn-ukrainian/.agent/wake/codex
->
-> # ~/.config/systemd/user/learn-ukrainian-codex-inbox.service
-> [Service]
-> Type=oneshot
-> WorkingDirectory=%h/projects/learn-ukrainian
-> ExecStart=%h/projects/learn-ukrainian/.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox run codex --until-idle
+```ini
+# ~/.config/systemd/user/learn-ukrainian-codex-inbox.path
+[Path]
+PathChanged=%h/projects/learn-ukrainian/.agent/wake/codex
+
+# ~/.config/systemd/user/learn-ukrainian-codex-inbox.service
+[Service]
+Type=oneshot
+WorkingDirectory=%h/projects/learn-ukrainian
+ExecStart=%h/projects/learn-ukrainian/.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox run codex --until-idle
+```
 
 If you do not want OS-level watchers, use the manual fallback:
 

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -80,6 +80,15 @@ _SESSION_ID_RE = re.compile(r"session[_-]?id[:=]\s*([0-9a-f-]{8,})", re.IGNORECA
 _EFFORT_MIN_VERSION = (2, 1, 98)
 _MIN_SUPPORTED_CLI_VERSION = (2, 1, 116)
 _POSTMORTEM_URL = "https://www.anthropic.com/engineering/april-23-postmortem"
+_DISCUSS_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
+
+
+def _discussion_readonly_requested(tool_config: dict | None) -> bool:
+    """Return True when the caller is an ab discuss read-only invocation."""
+    return bool(
+        os.environ.get("AB_DISCUSS_READONLY") == "1"
+        or (tool_config or {}).get(_DISCUSS_READONLY_TOOL_CONFIG_KEY)
+    )
 
 
 @cache
@@ -155,6 +164,9 @@ class ClaudeAdapter:
         are rejected outright due to the 2026-04-23 postmortem gate.
         """
         tc: dict[str, Any] = tool_config or {}
+        discussion_readonly = _discussion_readonly_requested(tool_config)
+        if discussion_readonly and mode != "read-only":
+            raise ValueError("AB_DISCUSS_READONLY requires mode='read-only'")
 
         # Command prefix — match start-claude.sh:120's invariant: prefer
         # ``npx @anthropic-ai/claude-code@latest`` so dispatched runs ride
@@ -250,6 +262,12 @@ class ClaudeAdapter:
         # Output format
         cmd.extend(["--output-format", tc.get("output_format", "text")])
 
+        if discussion_readonly:
+            cmd.extend([
+                "--permission-mode", "plan",
+                "--tools", "Read,Grep,Glob,LS",
+            ])
+
         # Mode-specific flags
         if mode == "danger":
             cmd.append("--dangerously-skip-permissions")
@@ -276,7 +294,7 @@ class ClaudeAdapter:
             cwd=cwd,
             stdin_payload="",  # Claude -p takes prompt as positional arg, not stdin
             output_file=None,
-            env_overrides={},
+            env_overrides={"AB_DISCUSS_READONLY": "1"} if discussion_readonly else {},
             liveness_paths=self._resolve_liveness_paths(cwd),
         )
 

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -27,6 +27,7 @@ Issue: #1184
 from __future__ import annotations
 
 import json as _json
+import os
 import re
 import shutil
 import tempfile
@@ -58,6 +59,15 @@ _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 # the post-prompt portion for rate-limit pattern matching. MULTILINE
 # so ^/$ match at each line boundary.
 _CODEX_DIVIDER_LINE_RE = re.compile(r"^-{3,}\s*$", re.MULTILINE)
+_DISCUSS_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
+
+
+def _discussion_readonly_requested(tool_config: dict | None) -> bool:
+    """Return True when the caller is an ab discuss read-only invocation."""
+    return bool(
+        os.environ.get("AB_DISCUSS_READONLY") == "1"
+        or (tool_config or {}).get(_DISCUSS_READONLY_TOOL_CONFIG_KEY)
+    )
 
 
 def _strip_codex_prompt_echo(stderr: str) -> str:
@@ -156,6 +166,10 @@ class CodexAdapter:
         # Codex 2026-04-10 audit.
         self._reset_per_invocation_state()
 
+        discussion_readonly = _discussion_readonly_requested(tool_config)
+        if discussion_readonly and mode != "read-only":
+            raise ValueError("AB_DISCUSS_READONLY requires mode='read-only'")
+
         # Resolve binary. shutil.which handles PATH lookup; fall back to
         # bare "codex" if not on PATH so subprocess.Popen can report the
         # error clearly.
@@ -199,7 +213,7 @@ class CodexAdapter:
             cwd=cwd,
             stdin_payload=prompt,
             output_file=output_path,
-            env_overrides={},
+            env_overrides={"AB_DISCUSS_READONLY": "1"} if discussion_readonly else {},
             liveness_paths=(output_path,),
         )
 

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -59,6 +59,15 @@ _TRANSIENT_ERROR_RE = re.compile("|".join(_TRANSIENT_ERROR_PATTERNS), re.IGNOREC
 _AUTH_MODE_VALUES = frozenset({"auto", "subscription", "api"})
 _INLINE_PROMPT_LIMIT_CHARS = 100_000
 _PROMPT_FILE_PREFIX = "learn-ukrainian-gemini-prompt-"
+_DISCUSS_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
+
+
+def _discussion_readonly_requested(tool_config: dict | None) -> bool:
+    """Return True when the caller is an ab discuss read-only invocation."""
+    return bool(
+        os.environ.get("AB_DISCUSS_READONLY") == "1"
+        or (tool_config or {}).get(_DISCUSS_READONLY_TOOL_CONFIG_KEY)
+    )
 
 
 def has_gemini_oauth_credentials(home: Path | None = None) -> bool:
@@ -179,6 +188,10 @@ class GeminiAdapter:
         passed inline; prompts over 100K chars use the verified ``-p @PATH``
         file-reference form, with runner cleanup after the subprocess exits.
         """
+        discussion_readonly = _discussion_readonly_requested(tool_config)
+        if discussion_readonly and mode != "read-only":
+            raise ValueError("AB_DISCUSS_READONLY requires mode='read-only'")
+
         if effort is not None:
             _logger.debug(
                 "gemini effort %r not yet wired through CLI — "
@@ -191,6 +204,12 @@ class GeminiAdapter:
             gemini_bin,
             "-m", model or self.default_model,
         ]
+
+        # Approval mode: discussion calls force Gemini's plan mode because
+        # the historical read-only default still exposed edit-capable tools
+        # in trusted workspaces (#1702).
+        if discussion_readonly:
+            cmd.extend(["--approval-mode", "plan"])
 
         # Approval mode: read-only is the default; yolo for write modes.
         # "danger" is treated identically to "workspace-write" because
@@ -259,7 +278,7 @@ class GeminiAdapter:
             cwd=cwd,
             stdin_payload=prompt,
             output_file=None,  # Gemini writes to stdout only.
-            env_overrides={},
+            env_overrides={"AB_DISCUSS_READONLY": "1"} if discussion_readonly else {},
             env_unsets=env_unsets,
             liveness_paths=(),  # stdout streamer is not actually sufficient —
             # see liveness_signal_paths() docstring — but we compute the

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -47,6 +47,7 @@ from typing import Any
 
 from . import _channels
 from ._channels_watch import watch_channel_events
+from ._config import REPO_ROOT
 
 _PREFLIGHT_FILE_PATH_RE = re.compile(r"[\w/-]+\.py\b")
 _PREFLIGHT_MULTI_STEP_RE = re.compile(
@@ -55,6 +56,7 @@ _PREFLIGHT_MULTI_STEP_RE = re.compile(
 )
 _ALLOWED_DEADLINE_SECONDS = (300, 600, 900, 1200, 1800, 2400, 3000)
 _GEMINI_AUTH_CHOICES = ["auto", "subscription", "api-key", "api"]
+_DISCUSSION_READONLY_TOOL_CONFIG = {"discussion_readonly": True}
 
 
 def _deadline_seconds_arg(raw_value: str) -> int:
@@ -70,6 +72,46 @@ def _deadline_seconds_arg(raw_value: str) -> int:
             + ", ".join(str(value) for value in _ALLOWED_DEADLINE_SECONDS)
         )
     return seconds
+
+
+def _git_output(args: list[str]) -> str:
+    """Run a read-only git command against the bridge repo."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            },
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout
+
+
+def _discussion_worktree_snapshot() -> tuple[str, str, str]:
+    """Capture enough git state to detect mutations during a discuss round."""
+    return (
+        _git_output(["status", "--short"]),
+        _git_output(["diff", "--no-ext-diff"]),
+        _git_output(["diff", "--cached", "--no-ext-diff"]),
+    )
+
+
+def _discussion_worktree_changed(before: tuple[str, str, str]) -> tuple[bool, str]:
+    after = _discussion_worktree_snapshot()
+    if after == before:
+        return False, ""
+    status = after[0].strip()
+    if not status:
+        status = "(git diff changed but status output is empty)"
+    return True, status
 
 
 def _post_preflight_warning(*, body: str, mode: str) -> str | None:
@@ -1103,7 +1145,11 @@ def _handle_discuss(args) -> int:
                 agent_name,
                 prompt_text,
                 mode="read-only",
+                cwd=REPO_ROOT,
                 task_id=f"discuss-{correlation_id[:8]}-r{round_idx}-{agent_name}",
+                # TODO(#1701): keep this flag in the sanitized child-env
+                # allowlist when the runner switches to build_agent_env().
+                tool_config=_DISCUSSION_READONLY_TOOL_CONFIG,
                 entrypoint="delegate",
                 hard_timeout=900,
             )
@@ -1163,6 +1209,8 @@ def _handle_discuss(args) -> int:
                 f"same root question in parallel right now — you have NOT "
                 f"seen their replies. Produce your independent first take.\n\n"
                 f"- Be concise but substantive. Cite file:line when relevant.\n"
+                f"- Deliberation is read-only: do not create, modify, delete, "
+                f"stage, commit, or push files.\n"
                 f"- Quote authoritative sources (VESUM, Правопис 2019, etc.) "
                 f"with specific entries; do not paraphrase from memory.\n"
                 f"- End your response with one of:\n"
@@ -1185,6 +1233,8 @@ def _handle_discuss(args) -> int:
                 f"above (they are posted as replies to the root). Compare "
                 f"them to your own prior position and decide.\n\n"
                 f"- Be concise but substantive. Cite file:line when relevant.\n"
+                f"- Deliberation is read-only: do not create, modify, delete, "
+                f"stage, commit, or push files.\n"
                 f"- Push back on any other agent's claim you disagree with — "
                 f"name the agent, quote the claim, give the counter-evidence.\n"
                 f"- End your response with one of:\n"
@@ -1228,6 +1278,7 @@ def _handle_discuss(args) -> int:
         # exits promptly instead of blocking on in-flight invocations
         # (which could be hold for up to hard_timeout=900 seconds).
         responses: dict[str, tuple[str, bool]] = {}
+        pre_round_worktree = _discussion_worktree_snapshot()
         pool = ThreadPoolExecutor(max_workers=len(with_agents))
         try:
             futures = {
@@ -1253,6 +1304,39 @@ def _handle_discuss(args) -> int:
             # cancel_futures is Py3.9+. Tasks already running cannot
             # be cancelled mid-flight, but queued ones will be.
             pool.shutdown(wait=False, cancel_futures=True)
+
+        changed, status_text = _discussion_worktree_changed(pre_round_worktree)
+        if changed:
+            warning = (
+                "🚨 DISCUSSION READ-ONLY VIOLATION\n\n"
+                f"`ab discuss` round {round_idx} changed the git working tree. "
+                "Discussion rounds are analysis-only; filesystem writes must go "
+                "through an explicit execution path such as `delegate.py dispatch`.\n\n"
+                "Current `git status --short`:\n\n"
+                "```text\n"
+                f"{status_text}\n"
+                "```\n\n"
+                "The round is failed and agent replies from this round were not "
+                "accepted."
+            )
+            try:
+                _channels.post(
+                    args.channel,
+                    "user",
+                    warning,
+                    to_agents=None,
+                    parent_id=root_id,
+                    correlation_id=correlation_id,
+                    kind="system",
+                    auto_snapshot=False,
+                )
+            except ValueError as e:
+                print(
+                    f"⚠️  failed to store read-only violation warning: {e}",
+                    file=sys.stderr,
+                )
+            print(warning, file=sys.stderr)
+            return 1
 
         # ── post each response as a reply to root ─────────────────
         # auto_snapshot=False here — the root message captured the

--- a/scripts/ai_agent_bridge/_inbox.py
+++ b/scripts/ai_agent_bridge/_inbox.py
@@ -112,11 +112,24 @@ _DEFAULT_GLOBAL_RETRY_SECONDS = 120
 _HEARTBEAT_INTERVAL_SECONDS = 60
 _MIN_HARD_TIMEOUT_SECONDS = 60
 _MAX_HARD_TIMEOUT_SECONDS = 3600
+_DISCUSSION_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
 _SESSION_COLUMNS = {
     "claude": "claude_session_id",
     "gemini": "gemini_session_id",
     "codex": "codex_session_id",
 }
+
+
+def _with_discussion_readonly_tool_config(
+    tool_config: dict | None,
+    *,
+    mode: str,
+) -> dict | None:
+    if mode != "read-only":
+        return tool_config
+    merged = dict(tool_config or {})
+    merged[_DISCUSSION_READONLY_TOOL_CONFIG_KEY] = True
+    return merged
 
 
 @dataclass(frozen=True)
@@ -698,6 +711,7 @@ def _invoke_thread(
     session_to_store: str | None = None
     tool_config: dict[str, object] | None = None
     requested_model = _resolve_model(claimed)
+    mode = _resolve_mode(claimed)
     if agent == "gemini" and requested_model is None:
         requested_model = PRO_MODEL
 
@@ -750,12 +764,15 @@ def _invoke_thread(
             result = runtime_invoke(
                 agent,
                 prompt,
-                mode=_resolve_mode(claimed),
+                mode=mode,
                 cwd=REPO_ROOT,
                 model=requested_model,
                 task_id=task_id,
                 session_id=session_id if agent == "claude" else None,
-                tool_config=tool_config,
+                tool_config=_with_discussion_readonly_tool_config(
+                    tool_config,
+                    mode=mode,
+                ),
                 entrypoint="bridge",
                 hard_timeout=hard_timeout,
                 stall_timeout=_DEFAULT_STALL_TIMEOUT_SECONDS,
@@ -784,6 +801,10 @@ def _invoke_gemini_thread_with_fallback(
     mode = _resolve_mode(claimed)
     effective_requested_model = requested_model or PRO_MODEL
     current_model = effective_requested_model
+    tool_config = _with_discussion_readonly_tool_config(
+        {"auth_mode": auth_mode} if auth_mode else None,
+        mode=mode,
+    )
 
     while True:
         try:
@@ -795,7 +816,7 @@ def _invoke_gemini_thread_with_fallback(
                 model=current_model,
                 task_id=task_id,
                 session_id=None,
-                tool_config={"auth_mode": auth_mode} if auth_mode else None,
+                tool_config=tool_config,
                 entrypoint="bridge",
                 hard_timeout=hard_timeout,
                 stall_timeout=_DEFAULT_STALL_TIMEOUT_SECONDS,

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -308,6 +308,23 @@ def test_codex_adapter_build_invocation_read_only(tmp_path):
     assert plan.output_file in plan.liveness_paths
 
 
+def test_codex_adapter_discussion_readonly_sets_env(tmp_path):
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="test-task",
+        session_id=None,
+        tool_config={"discussion_readonly": True},
+    )
+
+    assert "-s" in plan.cmd
+    assert "read-only" in plan.cmd
+    assert plan.env_overrides == {"AB_DISCUSS_READONLY": "1"}
+
+
 def test_codex_adapter_build_invocation_ignores_session_id(tmp_path):
     """Defensive: Codex adapter MUST ignore session_id even when passed."""
     adapter = CodexAdapter()
@@ -1967,6 +1984,23 @@ def test_gemini_adapter_read_only_no_yolo(tmp_path):
     assert plan.liveness_paths == ()
 
 
+def test_gemini_adapter_discussion_readonly_forces_plan_mode(tmp_path):
+    adapter = GeminiAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={"discussion_readonly": True},
+    )
+
+    assert plan.cmd[plan.cmd.index("--approval-mode") + 1] == "plan"
+    assert "--approval-mode=yolo" not in plan.cmd
+    assert plan.env_overrides == {"AB_DISCUSS_READONLY": "1"}
+
+
 def test_gemini_adapter_workspace_write_yolo(tmp_path):
     adapter = GeminiAdapter()
     plan = adapter.build_invocation(
@@ -2442,6 +2476,25 @@ def test_claude_adapter_basic_stateless(tmp_path):
     assert "--session-id" not in plan.cmd
     assert "--output-format" in plan.cmd
     assert plan.stdin_payload == ""  # Claude -p takes prompt as positional
+
+
+def test_claude_adapter_discussion_readonly_uses_plan_tools(tmp_path):
+    adapter = ClaudeAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={"discussion_readonly": True},
+    )
+
+    assert "--permission-mode" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--permission-mode") + 1] == "plan"
+    assert "--tools" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--tools") + 1] == "Read,Grep,Glob,LS"
+    assert plan.env_overrides == {"AB_DISCUSS_READONLY": "1"}
 
 
 def test_claude_adapter_resume_existing_session(tmp_path):

--- a/tests/test_bridge_inbox.py
+++ b/tests/test_bridge_inbox.py
@@ -114,6 +114,8 @@ def test_run_inbox_single_thread_single_delivery(mock_invoke):
     assert summary.deliveries_delivered == 1
     assert summary.replies_posted == 1
     assert mock_invoke.call_count == 1
+    assert mock_invoke.call_args.kwargs["mode"] == "read-only"
+    assert mock_invoke.call_args.kwargs["tool_config"]["discussion_readonly"] is True
     delivered = _delivery_rows(str(thread[0]["message_id"]))[0]
     assert delivered["status"] == "delivered"
     messages = _channels.read("topic", thread_id=str(thread[0]["thread_id"]))
@@ -318,7 +320,10 @@ def test_run_inbox_gemini_passes_auth_mode_to_runtime(mock_invoke):
     summary = _inbox.run_inbox("gemini", gemini_auth_mode="subscription")
 
     assert summary.deliveries_delivered == 1
-    assert mock_invoke.call_args.kwargs["tool_config"] == {"auth_mode": "subscription"}
+    assert mock_invoke.call_args.kwargs["tool_config"] == {
+        "auth_mode": "subscription",
+        "discussion_readonly": True,
+    }
 
 
 @patch("ai_agent_bridge._inbox.runtime_invoke")

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import sqlite3
+import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -255,6 +257,90 @@ def test_discuss_replies_create_delivered_reply_deliveries(mock_invoke, monkeypa
     }
     assert all(row["delivered_at"] is not None for row in reply_deliveries)
     assert all(row["parent_id"] is not None for row in reply_deliveries)
+
+
+@patch("agent_runtime.runner.invoke")
+def test_discuss_fails_and_warns_when_agent_writes_worktree(
+    mock_invoke,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    monkeypatch.setattr(_channels_cli, "REPO_ROOT", tmp_path)
+    git_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    subprocess.run(
+        ["git", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        env=git_env,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        env=git_env,
+    )
+    (tmp_path / "README.md").write_text("clean\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, env=git_env)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+
+    def _write_attempt(agent: str, *_args, **kwargs) -> Result:
+        assert kwargs["mode"] == "read-only"
+        assert kwargs["tool_config"] == {"discussion_readonly": True}
+        (tmp_path / "unauthorized.txt").write_text("write attempt\n", encoding="utf-8")
+        return Result(
+            ok=True,
+            agent=agent,
+            model="test-model",
+            mode="read-only",
+            response=f"{agent} reply [AGREE]",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    mock_invoke.side_effect = _write_attempt
+
+    exit_code = _run_cli(
+        ["discuss", "shared", "topic", "--with", "claude", "--max-rounds", "1"]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "DISCUSSION READ-ONLY VIOLATION" in captured.err
+    assert "unauthorized.txt" in captured.err
+
+    messages = _channels.read("shared", tail=10)
+    assert any("DISCUSSION READ-ONLY VIOLATION" in msg["body"] for msg in messages)
+    assert not any(msg["from_agent"] == "claude" for msg in messages)
+    rev_count = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=git_env,
+    ).stdout.strip()
+    assert rev_count == "1"
 
 
 def test_inbox_show_with_pending_and_failed(capsys):


### PR DESCRIPTION
## Summary

- add `AB_DISCUSS_READONLY`/tool-config handling in Codex, Gemini, and Claude adapters
- force Gemini plan mode and Claude plan/read tools for discussion/default read-only channel deliveries
- add an `ab discuss` git-state guard that rejects a round and posts a warning if agents mutate the worktree
- document the adapter audit and the Discussion vs execution contract

## Tests

- `.venv/bin/python -m pytest tests/test_bridge_inbox_cli.py tests/test_bridge_inbox.py tests/test_agent_runtime.py`
- `.venv/bin/python -m ruff check scripts/ai_agent_bridge/_inbox.py scripts/ai_agent_bridge/_channels_cli.py scripts/agent_runtime/adapters/codex.py scripts/agent_runtime/adapters/gemini.py scripts/agent_runtime/adapters/claude.py tests/test_agent_runtime.py tests/test_bridge_inbox_cli.py tests/test_bridge_inbox.py`
- `markdownlint-cli2 docs/best-practices/agent-bridge.md docs/architecture/2026-05-06-ab-discuss-fs-sandbox-audit.md`
- `git diff --check`

Issue audit comment posted: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/1702#issuecomment-4389028450
