### PR TITLE
docs(adr): multi-UI participation ADR round-3 — addresses Codex self-review (#1731 Part B)

### DIFF
--- a/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
+++ b/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
@@ -28,9 +28,9 @@ Patching `ab discuss` ad hoc would silently change the contract for writer-lock 
 
 ## Scope
 
-In scope: participant identity across multiple surfaces, surface capability profiles, discussion discovery, claim/lease/fallback semantics, default user-as-context behavior, explicit user quorum mode, localhost identity assumptions, loopback-binding preflight, idempotent claim retries, atomic round-message validation, dynamic join rules, monotonic event replay, fallback identity, multimodal message attachments, pilot bakeoff design, and the implementation epic split.
+In scope: participant identity across multiple surfaces, surface capability profiles, discussion discovery, claim/lease/fallback semantics, default user-as-context behavior, explicit user quorum mode, localhost identity assumptions, loopback-binding preflight, idempotent claim and post retries, atomic round-message validation, dynamic join rules, monotonic event replay, fallback identity, multimodal message attachments, pilot bakeoff design, and the implementation epic split.
 
-Out of scope: remote/cloud auth, multi-user broker federation, voice/video, global task pickup outside discussion threads, final channels.html polish, blob retention/pruning, artifact promotion into curriculum assets, and Desktop vendor preference if both Claude Desktop and Codex Desktop are available.
+Out of scope: remote/cloud auth, multi-user broker federation, live voice/video calls, global task pickup outside discussion threads, final channels.html polish, blob retention/pruning, artifact promotion into curriculum assets, and Desktop vendor preference if both Claude Desktop and Codex Desktop are available.
 
 Implementation should not start until Gemini review and user signoff. The pilot bakeoff should run before the architecture makes Desktop mandatory for graphics-rich module work.
 
@@ -59,12 +59,14 @@ This is what lets the project later ask whether Desktop actually improved graphi
 
 `ui_surface` is a routing signal, not just display metadata.
 
-| `ui_surface` | Input capabilities | Output capabilities | Runtime affordances | Assign these tasks |
+| Capability dimension | `cli` | `desktop` | `web` | `headless` |
 | --- | --- | --- | --- | --- |
-| `cli` | text stdin, repo files, shell tools | text, file edits, command output | deterministic subprocess, easy logs, low friction | bug fixes, code review, docs edits, text-only module drafts |
-| `desktop` | text, image attach, file drop, screenshots, local context | text, file edits through tools, image generation where available, Artifacts-style render | human-in-loop, visual inspection, multimodal context | graphics-rich modules, image-backed pedagogy, paradigm-table design, register blocks with photos |
-| `web` | text, browser state, iframe messages, uploaded files where enabled | rich rendering, browser DOM changes, iframe-postMessage integration | browser APIs, live preview, visual QA | channels.html participation, rendered lesson review, browser debugging |
-| `headless` | scripted inputs, scheduled files, API payloads | scripted messages, reports, machine-readable logs | no human-in-loop, repeatable automation | nightly checks, status summaries, deterministic validation |
+| Text and files | text stdin, repo files, shell tools | text, file drop, screenshots, local context | text, browser state, iframe messages, uploaded files where enabled | scripted inputs, scheduled files, API payloads |
+| Visual I/O | none except repo files and textual descriptions | image attach, screenshots, visual inspection, image generation where available, Artifacts-style render | rich rendering, browser DOM changes, live preview, visual QA | none except scripted files |
+| Audio I/O | none by default; TTS only through an explicit subprocess/tool bridge | audio input/output through mic/speakers plus audio file attach | WebAudio API playback only | none |
+| Output capabilities | text, file edits, command output | text, file edits through tools, image/audio attachments where available | rich rendering, browser DOM changes, iframe-postMessage integration | scripted messages, reports, machine-readable logs |
+| Runtime affordances | deterministic subprocess, easy logs, low friction | human-in-loop, visual inspection, multimodal context | browser APIs, live preview, visual QA | no human-in-loop, repeatable automation |
+| Assign these tasks | bug fixes, code review, docs edits, text-only module drafts | graphics-rich modules, image-backed pedagogy, pronunciation/audio-paired lessons, paradigm-table design, register blocks with photos | channels.html participation, rendered lesson review, browser debugging, attachment playback QA | nightly checks, status summaries, deterministic validation |
 
 Initial allowed values are `cli`, `desktop`, `web`, and `headless`. Do not add `mobile` until there is a concrete client.
 
@@ -72,6 +74,7 @@ Rationale:
 
 - `claude:cli` and `claude:desktop` can both satisfy a Claude family slot.
 - Only Desktop should satisfy an assignment requiring multimodal output.
+- Pronunciation lessons and audio-paired Ohoiko sub-sections such as `N.1`, `N.2`, and similar listening prompts require first-class audio capability tracking, not prose placeholders.
 - Surface routing makes the user's content-production hypothesis testable.
 
 Tradeoffs:
@@ -104,7 +107,24 @@ A participant is represented by three first-class columns:
 
 Initial `agent_family` values are `claude`, `codex`, `gemini`, and `user`. Initial `ui_surface` values are `cli`, `desktop`, `web`, and `headless`.
 
-`instance_id` is an ephemeral UUID for one process, browser tab, desktop session, or headless worker run.
+`instance_id` is a UUID for one local client identity. It is generated on first run, then persisted locally per `(agent_family, ui_surface)` so brief restarts recover the same identity instead of creating a conflicting same-surface claimant.
+
+Recommended local storage path:
+
+```text
+~/.config/learn-ukrainian/agent-bridge/instance.json
+```
+
+Example persisted shape:
+
+```json
+{
+  "codex:desktop": "8f91c2e0-4c2d-4a74-8e13-2f68f5a70b3b",
+  "claude:desktop": "a6b9d0f7-7ab0-40b2-8b54-9f7b5fbbe807"
+}
+```
+
+Headless workers may still generate a fresh UUID per run. Browser tabs should use local storage when available and fall back to session storage only if persistence is unavailable.
 
 `participant_id` may exist only as a generated display/key convenience:
 
@@ -134,6 +154,7 @@ Tuple-in-text is not first-class schema. Quorum checks need `agent_family`; capa
 - Backfill needs a legacy mapping rule.
 - UI code needs to display `participant_id` while filtering by individual columns.
 - More indexes are needed, likely on `(channel, thread_id, agent_family)`, `(channel, thread_id, ui_surface)`, and `(channel, thread_id, agent_family, ui_surface, instance_id)`.
+- Clients need small local stable-storage handling and should tolerate missing or corrupt `instance.json` by generating a new UUID.
 
 ### Alternatives considered
 
@@ -141,6 +162,7 @@ Tuple-in-text is not first-class schema. Quorum checks need `agent_family`; capa
 - Distinct families such as `claude-desktop`. Rejected because Desktop and CLI should satisfy the same Claude family slot.
 - Keep only `from_agent` plus `client_app`. Rejected because telemetry is not identity.
 - Participant registry table only. Deferred; message rows still need denormalized identity for historical audit.
+- Purely ephemeral `instance_id` only. Rejected because closing and reopening a Desktop app would strand its active lease until expiry.
 
 ---
 
@@ -156,7 +178,7 @@ GET /api/comms/channels/{channel}/events?since={event_id}
 
 Required semantics: every event has monotonic `event_id`; clients may pass `since`; SSE clients may reconnect with `Last-Event-ID`; server replays events where `event_id > since`; if neither `since` nor `Last-Event-ID` is provided, start at now unless explicit replay mode is requested; keepalive comments emit every 30 seconds; idle connections close server-side after a bounded timeout.
 
-Minimum event types are `discussion_started`, `message_appended`, `claim_created`, `claim_extended`, `claim_released`, `claim_expired`, `discussion_aborted`, `attachment_added`, and `discussion_completed`.
+Minimum event types are `discussion_started`, `message_appended`, `claim_created`, `claim_extended`, `claim_released`, `claim_expired`, `claim_seized`, `discussion_aborted`, `attachment_added`, and `discussion_completed`.
 
 The existing pull/inbox route remains a fallback:
 
@@ -218,15 +240,36 @@ Reserve `participant_scope=participant` as a future escape hatch for assignments
 
 Claims return `claim_id`, holder identity, `round_index`, scope, lease kind, and visible `expires_at`. Conflicts return the current holder and `expires_at`.
 
+Normal brief restarts should recover the same `instance_id` through the Q1 local persistence rule. If persistence failed or the old app instance is dead, a same-surface replacement can seize a stale active lease.
+
+Lease takeover endpoint:
+
+```text
+POST /api/comms/channels/{channel}/threads/{thread_id}/claims/{claim_id}/seize
+```
+
+The broker may accept seize only when all conditions hold:
+
+- requester has the same `(agent_family, ui_surface)` as the active holder
+- requester presents a different `instance_id`
+- active holder has missed two keepalives
+- claim has not already been consumed by a posted round reply
+- requested `round_index` still matches the active round
+
+On success, the broker updates the claim holder to the new `instance_id`, extends the lease using the holder type's normal lease duration, emits `claim_seized`, and records previous holder identity in the event payload. On failure, return the current holder and `expires_at` like a claim conflict.
+
 ### Rationale
 
 Family-scoped claims preserve the current `--with claude,codex,gemini` contract while allowing Desktop tag-in. The required slot is "Codex", not "this exact Codex CLI subprocess." First-claim-wins prevents duplicate expensive replies.
+
+The persisted `instance_id` rule prevents accidental restart lock-outs in the common case. The seize endpoint covers the recovery case where the persisted ID is missing, corrupt, or unavailable but the old holder has stopped keepaliving.
 
 ### Tradeoffs
 
 - Same-family surfaces must coordinate through the claim table.
 - Capability requirements need validation in addition to family matching.
 - Participant-scoped behavior is deferred.
+- Seize requires keepalive accounting, such as `last_keepalive_at` and missed-keepalive count, instead of expiry timestamp alone.
 - Claims add API and DB complexity.
 
 ### Alternatives considered
@@ -355,13 +398,13 @@ A flat 90-second expiry is too brittle for human/UI work. Desktop users may insp
 
 ---
 
-## Q7. How are claim retries made idempotent?
+## Q7. How are claim and post retries made idempotent?
 
 ### Proposal
 
 Claim creation requires an `idempotency_key`. Store each request keyed by at least `(thread_id, idempotency_key)` with canonical request hash, response status, response body, claim ID, and created timestamp.
 
-Semantics:
+Claim semantics:
 
 - same key plus same request returns the original response
 - same key plus different request returns `409 idempotency_key_reuse`
@@ -371,21 +414,60 @@ Semantics:
 
 Compatibility rule: old local CLI callers that omit `idempotency_key` may receive a server-generated key for that request, but new clients must send one.
 
+Message posting also requires an idempotency key for:
+
+```text
+POST /api/comms/channels/{name}/post
+POST /api/comms/channels/{name}/threads/{thread_id}/post
+```
+
+Any thread-reply variant must follow the same rule. The client supplies a UUID4 `idempotency_key` for the logical post attempt and reuses it on retries, including retries after a timeout during a large multimodal upload.
+
+Post idempotency is keyed by `(participant_id, idempotency_key)` within a five-minute window. The broker stores canonical body hash, attachment manifest hash, response status, `message_id`, and `expires_at`.
+
+Conflict semantics:
+
+- first request inserts the idempotency row and then creates the message in the same transaction
+- same key plus same body hash before expiry returns `200` with the existing `message_id`
+- same key plus different body hash before expiry returns `409 idempotency_key_reuse`
+- same key after expiry is rejected with `409 idempotency_key_expired` unless the client starts a new logical post with a fresh key
+
+Implementation shape:
+
+```sql
+CREATE TABLE post_idempotency (
+  participant_id TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  body_hash TEXT NOT NULL,
+  attachment_manifest_hash TEXT,
+  message_id TEXT,
+  response_status INTEGER NOT NULL,
+  response_body TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (participant_id, idempotency_key)
+);
+```
+
+The post transaction uses `INSERT ... ON CONFLICT(participant_id, idempotency_key) DO NOTHING`, then selects the existing row on conflict. If the stored hashes match and `expires_at` is still in the future, return the stored `message_id`; if hashes differ, return `409`.
+
 ### Rationale
 
-Desktop and web clients reconnect. HTTP clients retry. Without idempotency, a retry can create ambiguous holder state or a misleading conflict. The broker must distinguish duplicate success, actual race, and client token reuse bug.
+Desktop and web clients reconnect. HTTP clients retry. Without idempotency, a claim retry can create ambiguous holder state or a misleading conflict, and a post retry can double-post the same multimodal round reply after a timeout. The broker must distinguish duplicate success, actual race, and client token reuse bug.
 
 ### Tradeoffs
 
 - Adds a table or equivalent persisted request log.
 - Clients must persist a token across reconnects.
 - Server needs canonical request hashing.
+- Large multimodal posts need attachment-manifest hashing in addition to body hashing.
 - Old clients need temporary compatibility.
 
 ### Alternatives considered
 
 - Rely on unique claim constraints only. Rejected because retries can look like conflicts.
 - Use `claim_id` as idempotency key. Rejected because the client does not have it before creation.
+- Rely on duplicate-round-reply validation for posts. Rejected because it cannot distinguish retry of the same accepted post from a second logical post that should be rejected differently.
 - Ignore retries because localhost is reliable. Rejected because browser refreshes and Desktop reconnects are normal.
 
 ---
@@ -490,7 +572,7 @@ CREATE TABLE channel_events (
 );
 ```
 
-Events include `discussion_started`, `message_appended`, `claim_created`, `claim_extended`, `claim_released`, `claim_expired`, `discussion_aborted`, `attachment_added`, and `discussion_completed`.
+Events include `discussion_started`, `message_appended`, `claim_created`, `claim_extended`, `claim_released`, `claim_expired`, `claim_seized`, `discussion_aborted`, `attachment_added`, and `discussion_completed`.
 
 Ordering rule: `event_id` is global across the local broker. Clients may filter by channel but retain the global ID. Replay returns `event_id > since`. Timestamps are metadata, not sequence.
 
@@ -576,7 +658,7 @@ CREATE TABLE message_attachments (
   attachment_id TEXT PRIMARY KEY,
   message_id TEXT NOT NULL,
   attachment_type TEXT NOT NULL,
-  blob_sha256 TEXT NOT NULL,
+  blob_hash TEXT NOT NULL,
   blob_ext TEXT NOT NULL,
   mime_type TEXT NOT NULL,
   byte_size INTEGER NOT NULL,
@@ -584,11 +666,12 @@ CREATE TABLE message_attachments (
   caption TEXT,
   source_participant_id TEXT NOT NULL,
   created_at TEXT NOT NULL,
+  UNIQUE(blob_hash),
   FOREIGN KEY(message_id) REFERENCES channel_messages(message_id)
 );
 ```
 
-Initial `attachment_type` values are `image`, `document`, `artifact`, and `data`.
+Initial `attachment_type` values are `image` and `audio`.
 
 Blob storage decision for localhost:
 
@@ -596,7 +679,18 @@ Blob storage decision for localhost:
 - path: `.ab/channels/blobs/{sha256}.{ext}`
 - keep metadata in SQLite
 - verify hash before linking
+- insert blob metadata with `INSERT OR IGNORE` semantics so identical uploads dedupe to one row
 - do not use S3-style storage for the local prototype
+
+If the implementation later normalizes blobs into a separate `channel_blobs` table, move the `UNIQUE(blob_hash)` constraint and `INSERT OR IGNORE` behavior to that table while keeping `message_attachments.blob_hash` as the content-addressed reference.
+
+`blob_ext` validation is strict:
+
+- allowed extensions: `png`, `jpg`, `jpeg`, `webp`, `svg`, `mp3`, `wav`, `ogg`, and `m4a`
+- reject anything containing `/`, `\`, or `..`
+- reject executable or active-content extensions, including `.exe`, `.sh`, `.html`, and `.svg-with-script`
+- treat SVG as static image content only; SVG with script or external active references is rejected
+- MIME sniffing must agree with the extension before the blob is linked
 
 Markdown image refs in message bodies use:
 
@@ -604,12 +698,18 @@ Markdown image refs in message bodies use:
 ![Color-coded possessive pronoun paradigm](attachment://{attachment_id})
 ```
 
+Audio refs use the same attachment URI and are rendered by the channel UI as playback controls:
+
+```markdown
+[Listen to the possessive-pronoun prompt](attachment://{attachment_id})
+```
+
 The channel renderer resolves `attachment://...` against the blob store. Export may rewrite refs to relative file paths.
 
 MCP tool surface:
 
 ```text
-mcp__channels__attach(message_id, file_path, alt_text?, caption?)
+mcp__channels__attach(message_id, file_path, attachment_type, alt_text?, caption?)
 ```
 
 If atomic message plus attachment creation is needed, use a draft flow: begin message, attach to draft, then post draft. A simpler first slice may post then immediately attach, but message state must show incomplete/broken attachments visibly.
@@ -617,13 +717,16 @@ If atomic message plus attachment creation is needed, use a draft flow: begin me
 Recommended limits:
 
 - image max size: 10 MB
-- document max size: 25 MB
+- audio max size: 50 MB
 - max attachments per message: 10
 - alt text required for images
+- pronunciation lessons and audio-paired Ohoiko sub-sections require real `audio` attachments when the task asks for audio scaffolding
+
+These limits are localhost defaults and may be tuned through explicit broker configuration.
 
 ### Rationale
 
-The content-production hypothesis depends on graphical output. A text-only channel cannot test it. Attachments must be persisted, content-addressed, referenced from markdown, rendered in channels.html, exportable, and attributable.
+The content-production hypothesis depends on graphical and pronunciation-linked output. A text-only channel cannot test it. Attachments must be persisted, content-addressed, referenced from markdown, rendered in channels.html, exportable, and attributable.
 
 Filesystem blob storage is the right localhost default because it is inspectable, cheap, and credential-free.
 
@@ -633,6 +736,7 @@ Filesystem blob storage is the right localhost default because it is inspectable
 - Upload needs size and type limits.
 - Rendering must avoid silent broken refs.
 - Alt text is extra required metadata.
+- Audio adds larger local files and playback QA.
 - Draft flow is more robust but more work.
 
 ### Alternatives considered
@@ -681,6 +785,7 @@ Writer A:
 - Codex CLI text-only
 - no image generation
 - no file attach
+- no audio file attach
 - no live visual artifact surface
 
 Writer B:
@@ -688,9 +793,12 @@ Writer B:
 - Claude Code Desktop or Codex Desktop, whichever the user can run
 - multimodal input allowed
 - image generation allowed where the tool surface supports it
+- audio file attach allowed where the tool surface supports it
 - Artifacts/live-preview rendering allowed
 
 If neither Desktop variant is available, the bakeoff is blocked.
+
+This is a manual, human-driven proof of hypothesis and must not depend on new channel infrastructure. Use existing tools: Codex CLI for Writer A, Claude Desktop or Codex Desktop for Writer B, and manual attachment of the Ohoiko reference image or produced artifacts where the surface permits it. The runner records artifact hashes in a simple local manifest for scoring.
 
 ### Measurement
 
@@ -699,7 +807,7 @@ Score seven binary anchors:
 | Anchor | Present? | Evidence |
 | --- | --- | --- |
 | Header structure | yes/no | line refs or artifact refs |
-| Audio scaffolding | yes/no | line refs |
+| Audio scaffolding | yes/no | audio attachment manifest refs |
 | Inductive opening | yes/no | line refs |
 | Concept block | yes/no | line refs |
 | Color-coded paradigm | yes/no | line refs or attachment refs |
@@ -708,24 +816,31 @@ Score seven binary anchors:
 
 Evidence must cite generated output, not the private notes. Score is `anchors_present / 7`.
 
+Scorer rules for multimodal anchors:
+
+- Image attachments count only if they have alt text and a content-hash entry in the blob store or pre-implementation artifact manifest.
+- Audio scaffolding counts only if an actual audio file is present in the channel attachment manifest or pre-implementation artifact manifest. Text placeholders such as `[audio TBD]` do not count.
+- Markdown placeholders such as `![photo](path-tbd)` do not count.
+- A markdown table may show the paradigm text, but it does not satisfy the color-coded paradigm anchor unless the output includes a true gender-coded color visual through a rendered artifact or image attachment.
+
 ### Acceptance gate
 
-Let `CLI_SCORE=N` and `DESKTOP_SCORE=D`.
+Let `CLI_NON_MM` be CLI's count across non-multimodal anchors and `DESKTOP_NON_MM` be Desktop's count across the same non-multimodal anchors.
 
-Desktop locks in graphics-rich routing only if:
+Multimodal-only anchors are:
 
-```text
-D >= N + 2
-```
+- Audio scaffolding (#2), counted only when an actual audio file is attached.
+- Color-coded paradigm (#5), counted only for a true gender-coded color visual.
+- Photo-anchored register block (#6), counted only for a real image/photo attachment with alt text and content hash.
 
-Examples:
+Desktop locks in graphics-rich routing only if it satisfies both conditions:
 
-- CLI 4/7, Desktop 6/7: Desktop advantage accepted.
-- CLI 5/7, Desktop 6/7: insufficient advantage.
-- CLI 6/7, Desktop 7/7: insufficient advantage.
-- CLI 3/7, Desktop 6/7: Desktop advantage accepted.
+- Desktop hits all three multimodal-only anchors.
+- `DESKTOP_NON_MM >= CLI_NON_MM`.
 
-If Desktop does not beat CLI by at least two anchors, ship CLI-first channel participation and keep attachment support optional/deferred. If Desktop wins by at least two anchors, implement surface capability routing, include attachment handling in the first multi-UI epic, and allow module-writing dispatch to require Desktop for graphics-rich modules.
+CLI is structurally barred from the audio anchor in this bakeoff because Writer A has no audio file attach path. CLI is also barred from the color-coded paradigm anchor unless it can produce a rendered inline image or equivalent visual artifact, which Writer A explicitly cannot use here. This makes the gate about what Desktop can do that CLI cannot, rather than a flat two-anchor arithmetic threshold.
+
+If Desktop fails any multimodal-only anchor, or falls behind CLI on non-multimodal anchors, abort Desktop-required routing and revisit the architecture before code lands. If Desktop passes, implement surface capability routing, include attachment handling in the first multi-UI epic, and allow module-writing dispatch to require Desktop for graphics-rich modules.
 
 ### Follow-up issue shape
 
@@ -743,15 +858,15 @@ Outputs:
 - module markdown per writer
 - artifact directory per writer
 - checklist report with 7 binary anchors
-- summary comparing CLI_SCORE and DESKTOP_SCORE
+- summary comparing multimodal-only anchor pass/fail and non-multimodal anchor counts
 
 Gate:
-- Desktop must score at least CLI_SCORE + 2 anchors to make Desktop-required routing mandatory for graphics-rich modules.
+- Desktop must hit all three multimodal-only anchors and must not trail CLI on non-multimodal anchors.
 ```
 
 ### Rationale
 
-The architecture should follow evidence. The seven-anchor checklist turns the user's hypothesis into a dispatchable test. It is pragmatic rather than statistically complete, but strong enough to decide whether Desktop-required routing belongs in the first implementation.
+The architecture should follow evidence. The seven-anchor checklist turns the user's hypothesis into a dispatchable test. The gate is intentionally multimodal-specific so a strong text-only CLI answer cannot mathematically eliminate Desktop before Desktop's unique audio and visual capabilities are evaluated.
 
 ### Tradeoffs
 
@@ -771,23 +886,33 @@ The architecture should follow evidence. The seven-anchor checklist turns the us
 
 ## Implementation epic
 
-After acceptance, split implementation into six strands. Each strand should carry focused tests; generated status, audit, and review artifacts must stay out of code PR diffs.
+Run Strand 0 before any implementation code lands. If Strand 0 fails the acceptance gate, abort and revisit the architecture before implementing Strands 1-6.
+
+After Strand 0 passes and the ADR is accepted, split implementation into six code strands. Each strand should carry focused tests; generated status, audit, and review artifacts must stay out of code PR diffs.
+
+### Strand 0: pre-implementation pilot bakeoff
+
+Scope: run the manual possessive-pronoun bakeoff using existing tools, dispatch the CLI writer, document Desktop writer instructions, collect outputs, record artifact hashes in a local manifest, score seven anchors, and apply the multimodal-specific acceptance gate.
+
+Questions covered: content-production hypothesis, capability-profile routing, and Q12 implementation priority.
+
+Test focus: missing private notes fail clearly, all seven anchors report, scorer rules reject placeholders, Desktop accepted/rejected is explicit, and generated artifacts stay out of PR diffs.
 
 ### Strand 1: schema and claim mechanism
 
-Scope: add first-class participant identity columns, preserve legacy `from_agent`, add claims table, add claim-request idempotency table, add lease fields, add claim create/keepalive/release/expire paths, and add loopback preflight if missing.
+Scope: add first-class participant identity columns, preserve legacy `from_agent`, add claims table, add claim and post idempotency tables, add lease fields, add claim create/keepalive/release/expire/seize paths, add persisted `instance_id` client handling, and add loopback preflight if missing.
 
 Questions covered: Q1, Q3, Q5, Q6, Q7.
 
-Test focus: legacy hydration, same-family claim conflicts, idempotent retry, key reuse failure, expired-claim rejection, keepalive extension, manual release, and loopback binding.
+Test focus: legacy hydration, same-family claim conflicts, idempotent claim and post retry, key reuse failure, expired-claim rejection, keepalive extension, lease seizure after two missed keepalives, manual release, and loopback binding.
 
-### Strand 2: SSE, replay semantics, and MCP shim
+### Strand 2: SSE event stream and replay semantics
 
-Scope: add `channel_events`, emit monotonic events for state changes, add replayable SSE endpoint, support `since`, support `Last-Event-ID`, keep pull endpoint as fallback, and add MCP resource registration for channel events.
+Scope: add `channel_events`, emit monotonic events for state changes, add replayable SSE endpoint, support `since`, support `Last-Event-ID`, and keep pull endpoint as fallback.
 
 Questions covered: Q2, Q10.
 
-Test focus: monotonic event IDs, replay after `since`, `Last-Event-ID` resume, claim/message event order, and MCP readable resource URI.
+Test focus: monotonic event IDs, replay after `since`, `Last-Event-ID` resume, claim/message/seize event order, and attachment event order.
 
 ### Strand 3: discuss orchestrator updates
 
@@ -803,23 +928,23 @@ Scope: add `mcp__channels__list`, `mcp__channels__observe`, `mcp__channels__clai
 
 Questions covered: Q2, Q3, Q6, Q12.
 
-Test focus: Desktop can list, observe through resource reads, claim, post, release, attach an image with alt text, and receive rejection for missing or unsupported files.
+Test focus: Desktop can list, observe through resource reads, claim, post with idempotency, release, attach an image with alt text, attach an audio file, and receive rejection for missing or unsupported files.
 
 ### Strand 5: multimodal artifact handling
 
-Scope: add `message_attachments`, add filesystem blob store, validate sha256 and MIME, support `attachment://{attachment_id}` markdown refs, render attachments in channels.html, export attachments for transcript review, and require alt text for images.
+Scope: add `message_attachments`, add filesystem blob store, validate sha256, MIME, extension allowlist, dedupe identical uploads, support `attachment://{attachment_id}` markdown refs, render image and audio attachments, export attachments for transcript review, and require alt text for images.
 
 Questions covered: Q12, Q8, Q11.
 
-Test focus: attachment-message links, blob hash verification, visibly broken missing blobs, image alt-text rejection, markdown image-ref resolution, and storage constrained under `.ab/channels/blobs`.
+Test focus: attachment-message links, blob hash verification, duplicate upload dedupe, unsafe extension rejection, visibly broken missing blobs, image alt-text rejection, audio size limit, markdown attachment-ref resolution, and storage constrained under `.ab/channels/blobs`.
 
-### Strand 6: pilot bakeoff dispatch and checklist tooling
+### Strand 6: channels.html UI updates
 
-Scope: add bakeoff preflight for the private notes path, dispatch CLI writer, document Desktop writer instructions, collect outputs, score seven anchors, produce comparison report, and apply the acceptance gate.
+Scope: update channels.html for claim status, visible expiry, seized-claim events, attachment rendering, audio playback controls, participant capability badges, and required-vs-actual participant display.
 
-Questions covered: content-production hypothesis, capability-profile routing, and Q12 implementation priority.
+Questions covered: Q1, Q2, Q3, Q6, Q10, Q11, Q12.
 
-Test focus: missing private notes fail clearly, all seven anchors report, score calculation is deterministic, Desktop accepted/rejected is explicit, and generated artifacts stay out of PR diffs.
+Test focus: claim state display, replayed event display, image alt text rendering, audio playback rendering, capability badge accuracy, and fallback identity visibility.
 
 ---
 
@@ -846,19 +971,19 @@ Deferred follow-up ADRs may be needed for remote auth, retention and pruning, cr
 
 Please review this as an architecture gate, not implementation code.
 
-1. Q1 schema: Are three first-class columns enough, or do we need a participant registry table in the first implementation?
+1. Q1 schema: Are three first-class columns plus local `instance_id` persistence enough, or do we need a participant registry table in the first implementation?
 2. Q2 discovery: Is replayable SSE plus MCP readable resource the right split, or should MCP expose a blocking subscription tool?
-3. Q3 claim scope: Is `participant_scope=family` the correct default, with participant scope reserved as an escape hatch?
+3. Q3 claim scope: Is `participant_scope=family` the correct default, and is same-surface lease seizure after two missed keepalives sufficient for restart recovery?
 4. Q4 user semantics: Does default context mode plus explicit `--with user` quorum mode preserve the current discussion contract?
 5. Q5 localhost auth: Is loopback-binding preflight sufficient for the first local prototype, or is token auth mandatory before remote support?
 6. Q6 leases: Are 90 seconds for automated holders and 5 minutes for human/UI holders the right starting values?
-7. Q7 idempotency: Is request-key idempotency on claim creation enough, or do post endpoints also need explicit client tokens in the first implementation?
+7. Q7 idempotency: Are explicit client tokens for both claim creation and message posting specified tightly enough?
 8. Q8 atomic validation: Are the listed post-time invariants complete?
 9. Q9 dynamic joins: Should late same-family surfaces be eligible claimants by default, or should every late participant be observer-only first?
 10. Q10 event IDs: Is a global broker event sequence preferable to per-channel event sequences?
 11. Q11 fallback identity: Is required-vs-actual identity sufficient for audit and bakeoff analysis?
-12. Q12 attachments: Is filesystem blob storage under `.ab/channels/blobs` the right localhost default, and should image alt text be mandatory at attach time?
-13. Pilot bakeoff: Is the `Desktop >= CLI + 2 anchors` gate strong enough to justify Desktop-required routing for graphics-rich modules?
-14. Epic split: Is the six-strand split ordered correctly, or should the bakeoff run before any schema work?
+12. Q12 attachments: Is filesystem blob storage under `.ab/channels/blobs` the right localhost default, with image/audio types, dedupe, extension sanitization, and image alt text required at attach time?
+13. Pilot bakeoff: Is the multimodal-specific gate strong enough to justify Desktop-required routing for graphics-rich modules?
+14. Epic split: Is Strand 0 correctly placed as a manual pre-implementation gate before schema work?
 
 Use `[AGREE]` for sections you accept, or `[REVISE Qn: reason]` for sections that need changes before user signoff.

--- a/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
+++ b/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
@@ -1,270 +1,864 @@
-# DECISION REQUIRED — Multi-UI agent participation in `ab discuss` / channels.html
+# DECISION REQUIRED - Multi-UI content-producing participants in `ab discuss` / channels.html
 
-**Status:** PROPOSED (awaiting cross-agent review by Gemini + Codex, then user signoff)
+**Status:** PROPOSED (awaiting Gemini cross-review and user signoff)
 **Surfaced:** 2026-05-06 morning, while running the writer-lock 3-way discussion
-**Source:** GH issue #1731 Part B
-**Predecessor ADRs:** None — this is the first ADR on multi-UI participation. Touches the `ab` channel-bridge contract from #1190.
+**Source:** GH issue #1731 Part B; revised after Codex REJECT review on PR #1732
+**Scope:** Agent bridge channel participation, round claims, multimodal channel messages, and pilot bakeoff dispatch
+**Predecessor ADRs:** None. This is the first ADR on multi-UI participation. It touches the `ab` channel-bridge contract from #1190.
 
 ---
 
-## Why this needs an ADR (not just a PR)
+## Why this needs an ADR
 
-`ab discuss` today is a **closed-loop, single-orchestrator** protocol. The agent that calls `ab discuss --with claude,gemini,codex` is a process that:
+`ab discuss` today is a closed-loop, single-orchestrator protocol. The caller runs `ab discuss --with claude,gemini,codex`, spawns each named agent through `scripts/agent_runtime/adapters/*.py`, reads stdout, posts the result to a channel, threads replies through `parent_id`, aggregates `[AGREE]`, and returns a transcript.
 
-1. Spawns each named agent as a subprocess (one per round, per agent) via `scripts/agent_runtime/adapters/*.py`.
-2. Reads each subprocess's stdout, posts the result to the channel, threads via `parent_id`.
-3. Aggregates `[AGREE]` markers; short-circuits when all participants agree, or runs to `--max-rounds`.
-4. Returns the transcript to the caller.
+That closed loop currently gives us three implicit guarantees:
 
-Three properties hold today only because of this closed-loop assumption:
+- **Identity is fixed at dispatch.** The `--with` list is the participant list.
+- **Time is owned by the orchestrator.** A round ends when subprocess replies return.
+- **State is one transcript.** The orchestrator is the only writer of round replies.
 
-- **Identity** is fixed at dispatch. `--with claude,gemini,codex` is the participant list; nothing else can join.
-- **Time** is owned by the orchestrator. A round is "Gemini's reply has returned from `gemini -p ...`" — there's no clock outside the subprocess.
-- **State** is a single transcript. The orchestrator is the only writer of `parent_id` chains; there is no claim/lock for "who responds next."
+The user's original ask was that Claude Code, Claude Desktop, Codex CLI, Codex UI, and the user can all participate. The newer, load-bearing framing is broader: "atm cli agents can use the discussion channel, but it would be nice if codex desktop and claude code desktop could also use them, they are another cli agent just ui, and i have a suspicion that better to create the lesson, to add graphical content."
 
-The user's ask — "Claude Code, Claude Desktop, Codex CLI, Codex UI, AND user can all participate" — breaks ALL THREE properties:
+This reframes the ADR from chat participation to **content-producing participants**. Desktop and web surfaces may create better lesson artifacts because they can attach files, inspect images, generate images, render Artifacts-style previews, or use browser APIs. The channel protocol must preserve which family answered, which surface answered, which instance answered, and which artifacts were produced.
 
-1. Claude Desktop is a separate process. It does not know `ab discuss` was invoked unless it polls or subscribes. → identity becomes dynamic.
-2. Claude Desktop's reply latency is unbounded (user might walk away). → time can no longer be owned by the orchestrator.
-3. If two Claude instances see the same channel post, both could reply. → state needs arbitration.
-
-Patching `ab discuss` ad hoc would silently change the contract for every existing caller (the writer-lock discussion, every channel review, every pipeline review). That's the rule-violation we want to avoid. Hence: ADR first.
+Patching `ab discuss` ad hoc would silently change the contract for writer-lock discussions, channel reviews, pipeline reviews, and future bakeoffs. This ADR defines the contract before implementation.
 
 ---
 
-## Scope of THIS ADR
+## Scope
 
-**In scope:** the participation/identity/round-semantics contract for an `ab discuss`-style multi-agent thread that can include Claude Code (CLI), Claude Desktop, Codex CLI, Codex UI, Gemini CLI, and human user.
+In scope: participant identity across multiple surfaces, surface capability profiles, discussion discovery, claim/lease/fallback semantics, default user-as-context behavior, explicit user quorum mode, localhost identity assumptions, loopback-binding preflight, idempotent claim retries, atomic round-message validation, dynamic join rules, monotonic event replay, fallback identity, multimodal message attachments, pilot bakeoff design, and the implementation epic split.
 
-**Out of scope** (explicitly deferred to follow-up issues, even if the design touches them):
+Out of scope: remote/cloud auth, multi-user broker federation, voice/video, global task pickup outside discussion threads, final channels.html polish, blob retention/pruning, artifact promotion into curriculum assets, and Desktop vendor preference if both Claude Desktop and Codex Desktop are available.
 
-- Real-time UI niceties (typing indicators, presence beyond "live now") — `playgrounds/channels.html` already has the basics, more polish is Part A territory.
-- Authentication of remote/3rd-party agents — this ADR assumes all participants run on `localhost` and trust the `ab` broker DB; remote/cloud agents are a separate ADR.
-- Action arbitration for non-discussion work (e.g. who picks up a `gh issue` to fix) — this ADR scopes "task pickup" to discussion-internal turn-taking only. Cross-channel work-claiming gets its own ADR if/when needed.
-- Voice / video / image sharing in channels — text only.
+Implementation should not start until Gemini review and user signoff. The pilot bakeoff should run before the architecture makes Desktop mandatory for graphics-rich module work.
 
 ---
 
-## Six architectural questions (from #1731 Part B)
+## Content-production reframe
 
-The questions below are quoted from the issue. Each gets a proposed answer with rationale and a tradeoffs subsection. The whole ADR is gated on user + Gemini + Codex agreement (or counter-proposal) on each.
+The prior ADR treated "participant" as chat identity. The revised contract treats a participant as a possible producer of curriculum content and artifacts. A Codex CLI reply and a Codex Desktop reply may satisfy the same `codex` quorum slot, but they do not have the same production capabilities.
 
-### Q1. What is a 'participant'?
+Task routing examples:
 
-> "Currently `ab discuss --with claude,gemini,codex` lists *agents* invoked via the runtime adapter. If Claude Desktop is a participant, is it 'claude' (same agent name) or 'claude-desktop' (distinct)? What about user — is that a participant or an external observer?"
+- Bug-fix dispatch can use CLI.
+- Text-only docs or module prose can use CLI.
+- A module needing a color-coded paradigm table may require Desktop.
+- A module needing generated or attached images may require Desktop.
+- Rendered lesson review may require Web.
+- Nightly deterministic checks may require Headless.
 
-#### Proposal
+The transcript must preserve this distinction. If Desktop was required and CLI fallback answered, the audit trail should show both the required family/surface and the actual participant. If an image was produced, the message should have a persisted attachment row, not an inline prose placeholder.
 
-A **participant** is the tuple `(agent_family, ui_surface, instance_id)`.
-
-- `agent_family`: `claude` | `gemini` | `codex` | `user` — the model/identity class.
-- `ui_surface`: `cli` | `desktop` | `web` | `mobile` | `headless` — the runtime context.
-- `instance_id`: ephemeral UUID for THIS process/session (so two Claude Desktop windows on the same machine don't collide).
-
-Wire format in DB: `agent_id = "{family}:{surface}:{instance_id_short}"`, e.g. `claude:cli:abc123`.
-
-The legacy `from_agent` column stays as `agent_family` (so old queries keep working). New column `participant_id` carries the full tuple. The `ab channel post` API accepts either; the broker normalizes.
-
-**User is a participant.** Family `user`, surface depends on where they post (web for channels.html, cli for `ab post`, desktop later). Treating user as first-class — vs "external observer" — is what makes "user posts mid-discussion" work without a special case.
-
-#### Why this shape (not just a flat string)
-
-Three needs the flat string can't satisfy without re-parsing:
-
-1. **Round arbitration** asks "has every required agent_family replied this round?" That's a family-level question (we don't care if it was `claude:cli` or `claude:desktop`, just that `claude` answered). Family is a first-class column.
-2. **Failure recovery** asks "did the SAME instance that started round N also produce reply N?" That's an instance-level question. Instance_id is a first-class column.
-3. **UI rendering** asks "show the current participants by surface so user knows which window to look at." Surface is a first-class column.
-
-#### Tradeoffs
-
-- **Cost:** schema migration on `channel_messages` (add `participant_id` text col, indexed). Backwards-compat-safe (`from_agent` stays).
-- **Risk:** instance_id collisions across reboots — solved by UUID4 on every process start. instance_id never persists.
-- **Alternative considered (rejected):** "claude-desktop" as a distinct agent_family. Rejected because round-quorum logic ("does Claude agree?") wants the family to be invariant across surfaces — otherwise a `[AGREE]` from `claude-desktop` doesn't satisfy a quorum that listed `claude`.
+This is what lets the project later ask whether Desktop actually improved graphics-rich module quality, which artifacts were produced by which surface, and which assignments silently degraded to text-only.
 
 ---
 
-### Q2. Discovery: how does Claude Desktop know a discussion is happening?
+## Capability profile per surface
 
-> "Polling? Push notification? An MCP server the desktop subscribes to? The desktop is a separate process that doesn't know `ab discuss` was invoked."
+`ui_surface` is a routing signal, not just display metadata.
 
-#### Proposal
+| `ui_surface` | Input capabilities | Output capabilities | Runtime affordances | Assign these tasks |
+| --- | --- | --- | --- | --- |
+| `cli` | text stdin, repo files, shell tools | text, file edits, command output | deterministic subprocess, easy logs, low friction | bug fixes, code review, docs edits, text-only module drafts |
+| `desktop` | text, image attach, file drop, screenshots, local context | text, file edits through tools, image generation where available, Artifacts-style render | human-in-loop, visual inspection, multimodal context | graphics-rich modules, image-backed pedagogy, paradigm-table design, register blocks with photos |
+| `web` | text, browser state, iframe messages, uploaded files where enabled | rich rendering, browser DOM changes, iframe-postMessage integration | browser APIs, live preview, visual QA | channels.html participation, rendered lesson review, browser debugging |
+| `headless` | scripted inputs, scheduled files, API payloads | scripted messages, reports, machine-readable logs | no human-in-loop, repeatable automation | nightly checks, status summaries, deterministic validation |
 
-**Three-tier discovery, layered:**
+Initial allowed values are `cli`, `desktop`, `web`, and `headless`. Do not add `mobile` until there is a concrete client.
 
-1. **Push (preferred):** Server-Sent Events stream at `GET /api/comms/channels/{name}/events` — open connection, receive `message_appended` and `discussion_started` events as they happen. Already runnable via `curl -N`; trivial to wire from any UI surface.
-2. **Pull (fallback):** `GET /api/comms/inbox?agent={family}&since={ts}` — already exists; works for any client that prefers polling. Recommended interval: 5s (matches channels.html auto-refresh; no point going faster than human read speed).
-3. **MCP tool (Claude Desktop / Claude Code specifically):** `mcp__channels__subscribe(channel)` thin wrapper over the SSE endpoint. Returns a resource the model can read on each turn. Lets Claude Desktop "see" channel activity without writing browser-automation code.
+Rationale:
 
-`ab discuss` itself emits a `discussion_started` event with `{thread_id, channel, participants_invited, max_rounds, initiator}` so subscribers know a structured discussion is open vs an ad-hoc thread.
+- `claude:cli` and `claude:desktop` can both satisfy a Claude family slot.
+- Only Desktop should satisfy an assignment requiring multimodal output.
+- Surface routing makes the user's content-production hypothesis testable.
 
-#### Why all three (not just one)
+Tradeoffs:
 
-Different surfaces have different cost profiles:
+- More schema and orchestration complexity.
+- Some tasks need capability requirements in addition to family requirements.
+- First implementation can enforce only coarse surface requirements in the claim layer.
 
-- **CLI / shell agents** can hold an SSE connection cheaply; push is right.
-- **Stateless adapters** (e.g. a one-shot `gemini -p ...` invocation) can't hold a connection across calls; they need pull.
-- **Claude Desktop / Code** through MCP is the cleanest — the model sees subscription as a tool, not infrastructure.
+Alternative considered:
 
-Layering doesn't add server complexity: the SSE endpoint and inbox endpoint share the same DB query; MCP is a thin shim over SSE.
-
-#### Tradeoffs
-
-- **Cost:** new SSE endpoint (~150 LOC FastAPI), new MCP tool (~80 LOC). Pull endpoint already exists.
-- **Risk:** SSE connection leaks if a client crashes — mitigated by a 60s server-side keepalive ping; idle connections auto-close after 10 min.
-- **Alternative considered (rejected):** WebSocket. Rejected because SSE is sufficient (server→client only; we don't need bidirectional), simpler to debug (just `curl -N`), and survives proxies that strip WS headers.
+- Keep all surfaces under flat `from_agent`. Rejected because it cannot distinguish "Claude answered" from "Claude Desktop produced an image-backed answer."
 
 ---
 
-### Q3. Action arbitration: who picks up tasks?
+## Architectural questions
 
-> "If the channel says 'someone please review module X', what stops 3 agents from picking it up simultaneously? Need a claim mechanism (DB-level lock or first-poster-wins)."
+Each question below includes proposal, rationale, tradeoffs, and alternatives considered. Q1-Q6 preserve and revise the original ADR questions. Q7-Q12 add the missing architectural questions from Codex review and the content-production reframe.
 
-#### Proposal (scoped to in-discussion turn-taking — see "out of scope" above for cross-channel claim)
+---
 
-For an active `ab discuss` thread, **the orchestrator owns the turn schedule**, exactly as today. Discovery tells Desktop/UI/etc. "a discussion is happening" but they don't auto-respond — they observe.
+## Q1. What is a participant?
 
-A non-orchestrator participant **must explicitly claim a turn** to contribute. Claim mechanism:
+### Proposal
 
-```
-POST /api/comms/channels/{name}/threads/{tid}/claim
-  body: {participant_id, round_index}
-  → 200 {claim_id, expires_at}  on success
-  → 409 {current_holder, expires_at}  on conflict
+A participant is represented by three first-class columns:
+
+- `agent_family`
+- `ui_surface`
+- `instance_id`
+
+Initial `agent_family` values are `claude`, `codex`, `gemini`, and `user`. Initial `ui_surface` values are `cli`, `desktop`, `web`, and `headless`.
+
+`instance_id` is an ephemeral UUID for one process, browser tab, desktop session, or headless worker run.
+
+`participant_id` may exist only as a generated display/key convenience:
+
+```text
+{agent_family}:{ui_surface}:{instance_id_short}
 ```
 
-Claims are scoped to `(thread_id, round_index, agent_family)`. Two `claude:*` instances cannot both claim round 3 of thread T — first-poster-wins. Claims expire after 90s if no message follows; another instance can re-claim.
+Example:
 
-The orchestrator's existing subprocess-spawn path **also goes through claim** (no special path), so the contract is uniform: "to post a round-N reply, you hold the claim."
+```text
+codex:desktop:8f91c2
+```
 
-#### Why claim per `(thread, round, family)` not per `(thread, round, instance)`
+It must not be the only stored identity. The canonical data model is the three separate columns. If SQLite generated columns are awkward, store `participant_id` as denormalized display text while keeping the three identity columns authoritative.
 
-Family-scoped claim is what makes "Claude Desktop joins instead of Claude Code for round 3" work. The orchestrator says "we need a claude reply in round 3"; whichever claude-instance holds the claim first delivers it. That's the user's mental model: "I'm tagging in for Claude this round."
+The legacy `from_agent` column remains during migration. Old rows hydrate as `agent_family=from_agent`, `ui_surface=cli`, and `instance_id=legacy`.
 
-Instance-scoped would force a deterministic spawner per instance — back to the closed-loop world.
+The user is a participant with `agent_family=user`. User surface depends on entry point: channels.html is `web`, `ab post` is `cli`, and future Desktop integration is `desktop`.
 
-#### Tradeoffs
+### Rationale
 
-- **Cost:** new `claims` table (`thread_id, round_index, agent_family, holder_participant_id, claimed_at, expires_at`); `~80 LOC` for the endpoint + claim-expiry sweep.
-- **Risk:** claim deadlock if the holder never delivers — solved by 90s expiry + re-claim. Keepalive every 30s extends.
-- **Risk:** claim livelock if 5 Claude instances all retry on 409 — solved by exponential backoff + jitter; documented in client lib.
-- **Alternative considered (rejected):** "first-message-wins" with no claim. Rejected because two slow agents racing each other waste tokens producing replies that get rejected. Pre-claim is cheap.
+Tuple-in-text is not first-class schema. Quorum checks need `agent_family`; capability routing needs `ui_surface`; lease renewal needs `instance_id`; UI display can use `participant_id`. Encoding everything in one string makes serious queries depend on parsing conventions and weak indexing.
 
----
+### Tradeoffs
 
-### Q4. Round semantics with mixed participants
+- Migration touches existing `channel_messages` queries.
+- Backfill needs a legacy mapping rule.
+- UI code needs to display `participant_id` while filtering by individual columns.
+- More indexes are needed, likely on `(channel, thread_id, agent_family)`, `(channel, thread_id, ui_surface)`, and `(channel, thread_id, agent_family, ui_surface, instance_id)`.
 
-> "If user posts mid-round, does that count as a round-N reply? Does `[AGREE]` from user terminate the discussion? Or is user input always 'context for next round'?"
+### Alternatives considered
 
-#### Proposal
-
-**User posts are always round-N+1 context, never count as round-N replies, and `[AGREE]` from user is treated as a HARD STOP (not consensus).**
-
-Concretely:
-
-- A user post during round N (i.e. while ≥1 agent_family hasn't yet posted round N) does NOT satisfy that family's round-N obligation.
-- The user post's body IS injected into the round-N+1 prompt for every agent (verbatim, prefixed with `[USER (mid-discussion)]:`), so the next round can react to it.
-- `[AGREE]` from a user post terminates the discussion immediately — but it's recorded as `kind: "user_terminate"` in the DB, not aggregated into the consensus quorum. Discussion outcome = "ended by user," not "converged."
-- `[OBJECT]` (new marker) from user resets convergence; if all agents had said `[AGREE]`, an `[OBJECT]` from user forces a round N+1 with the objection as injected context.
-
-#### Why user posts aren't replies
-
-Two reasons:
-
-1. **Quorum integrity.** The discussion contract is "agents converge on a recommendation." Counting user as a vote conflates "agents agree" with "agents agree AND user happens to also agree" — fundamentally different signals. The user is the consumer of the recommendation, not a producer of it.
-2. **Steering value.** If user posts ARE replies, the user can short-circuit a useful debate by `[AGREE]`-ing with whoever they liked best. We want the user to be able to steer ("I think X is missing, address it") without ending the deliberation.
-
-#### Tradeoffs
-
-- **Cost:** ~30 LOC in the discuss orchestrator to inject user posts into the next round's prompt. Schema is unchanged (already has `kind`, `from_agent`).
-- **Risk:** user spam mid-discussion (10 posts in a row) bloats the next round's prompt. Mitigation: cap the injected user-context block at 2000 chars, oldest-first truncate.
-- **Alternative considered (rejected):** "user posts ARE first-class replies, just from agent_family=user." Rejected because the round-N quorum was specified as "all agents in `--with`" — and `user` isn't in `--with` by default. Adding user to `--with` opens the abuse vectors above.
+- Flat `participant_id` only. Rejected because it repeats the parsing problem.
+- Distinct families such as `claude-desktop`. Rejected because Desktop and CLI should satisfy the same Claude family slot.
+- Keep only `from_agent` plus `client_app`. Rejected because telemetry is not identity.
+- Participant registry table only. Deferred; message rows still need denormalized identity for historical audit.
 
 ---
 
-### Q5. Identity / auth
+## Q2. How does a UI surface discover a discussion?
 
-> "Claude Code, Claude Desktop, Codex CLI, Codex UI — do they share auth tokens? Do they post as distinct identities or as the same 'claude'/'codex'?"
+### Proposal
 
-#### Proposal (localhost-only — remote auth deferred)
+Use replayable SSE as the primary discovery channel:
 
-- All participants run on `localhost`. No auth for now beyond "the broker DB is owned by user `krisztiankoos`."
-- A participant **identifies itself** to the broker via `participant_id` (Q1's tuple). The broker does not verify — it's an honour system on localhost.
-- A participant **identifies its origin** via a `client_app` field (`claude-cli/2.1.131`, `claude-desktop/0.x`, `codex-cli/y.y`, etc.) for telemetry and debugging.
-- Distinct surfaces post under distinct `participant_id`s but share the same `agent_family` for quorum (Q1).
+```text
+GET /api/comms/channels/{channel}/events?since={event_id}
+```
 
-If we later need remote agents or shared multi-user installs, this gets revisited as a separate auth ADR. The localhost-only assumption is explicitly recorded so we don't accidentally expose `:8765` to the network without revisiting.
+Required semantics: every event has monotonic `event_id`; clients may pass `since`; SSE clients may reconnect with `Last-Event-ID`; server replays events where `event_id > since`; if neither `since` nor `Last-Event-ID` is provided, start at now unless explicit replay mode is requested; keepalive comments emit every 30 seconds; idle connections close server-side after a bounded timeout.
 
-#### Why no token auth now
+Minimum event types are `discussion_started`, `message_appended`, `claim_created`, `claim_extended`, `claim_released`, `claim_expired`, `discussion_aborted`, `attachment_added`, and `discussion_completed`.
 
-Adding auth before we have a working multi-UI prototype is premature optimization. The broker DB is already user-readable only (file mode 0600 in `.ab/broker.db`); an attacker on the same machine has bigger problems. When we go remote, JWT or mutual TLS goes here.
+The existing pull/inbox route remains a fallback:
 
-#### Tradeoffs
+```text
+GET /api/comms/inbox?agent_family={family}&since={event_id}
+```
 
-- **Risk:** any local process can post as anyone. Acceptable on a single-user dev machine; documented in `docs/best-practices/agent-bridge.md`.
-- **Risk:** `:8765` is bound to `0.0.0.0` not `127.0.0.1`? Verify and tighten (separate fix).
+MCP decision:
 
----
+- Do not make `mcp__channels__subscribe` a long-running blocking tool call.
+- Implement subscribe as MCP resource registration.
+- Return a readable resource URI such as `channels://{channel}/events?since={event_id}`.
+- Use separate MCP tools for claim, post, keepalive, release, and attach.
 
-### Q6. Failure semantics
+### Rationale
 
-> "If Claude Desktop drops mid-round (user closed the app), does the discussion wait or short-circuit?"
+SSE is the smallest push primitive that fits server-to-client channel updates. Replay matters because Desktop, browser, and CLI clients disconnect and reconnect. `event_id`, `since`, and `Last-Event-ID` prevent clients from guessing whether they missed a claim, message, or abort. MCP resource reads fit Desktop model turns better than an indefinitely open tool call.
 
-#### Proposal
+### Tradeoffs
 
-- A claim expires 90s after issue if no message follows (Q3). If the discussion's `--max-rounds` budget is `M` and we're in round `R`, the orchestrator waits at most `90s × (M − R + 1)` for any pending claim, then either:
-  - re-prompts the SAME agent_family (subprocess-spawn path) if `--auto-fallback=true` (default in `ab discuss`),
-  - or aborts the discussion with `kind: "discussion_aborted"` and `reason: "claim_expired"` if `--auto-fallback=false`.
-- Auto-fallback uses the legacy `agent_runtime` adapter, so a discussion that started with Claude Desktop participating can degrade to Claude CLI without losing thread continuity.
-- Aborts are first-class events; the channel sees `discussion_aborted` so observers don't think it converged.
+- Requires an event log or derivable replay stream.
+- Clients must persist last seen `event_id`.
+- MCP resource reads are less real-time than a held socket, but more robust for model-driven Desktop turns.
+- Replay retention and pruning remain future policy.
 
-#### Why 90s + auto-fallback (not infinite wait)
+### Alternatives considered
 
-Infinite wait makes the channel unusable: a stuck discussion blocks `[AGREE]`-aggregation forever and channels.html's "Discussion live" strip never resolves. 90s is enough for a typical Desktop reply (Anthropic SDK p99 < 30s) plus user think-time; longer human deliberations can be done as multi-thread "post-then-respond" without round semantics.
-
-Auto-fallback to subprocess-spawn preserves the closed-loop as the safety net. We only LOSE the closed-loop when a multi-UI participant successfully claims and replies — exactly the path we want to support.
-
-#### Tradeoffs
-
-- **Cost:** ~60 LOC for claim-expiry sweep + fallback path in `_channels.py`.
-- **Risk:** flaky network on Desktop side causes false fallbacks. Mitigation: keepalive every 30s extends claim; stable connections never expire.
-- **Alternative considered (rejected):** "wait forever, user kicks the discussion manually." Rejected because UX suffers and the "Discussion live" strip becomes a forever-live ghost.
+- Polling only. Rejected as primary path; acceptable fallback.
+- WebSocket. Rejected for first implementation because bidirectional sockets are unnecessary.
+- Blocking MCP subscribe. Rejected because cancellation and model-turn semantics are unclear.
+- channels.html as source of truth. Rejected; broker DB and API remain canonical.
 
 ---
 
-## What this ADR explicitly does NOT decide
+## Q3. Who can claim a turn?
 
-These are downstream questions for follow-up ADRs once the contract above is accepted:
+### Proposal
 
-- **MCP tool surface for Claude Desktop / Code.** `mcp__channels__subscribe` is sketched in Q2 but the full tool family (post, claim, observe, list) needs its own design.
-- **Codex UI integration mechanism.** Codex UI is a web app; whether it polls SSE or uses an iframe-postMessage bridge to channels.html is undecided. Both work; pick after MCP tools land.
-- **Cross-channel task pickup** ("someone fix #1234"). Out of scope — see top of doc.
-- **Persistence beyond `.ab/broker.db`.** Single-DB single-user is fine for now; multi-user / replicated broker is a separate ADR.
+An active discussion round is claim-gated. A participant must hold a valid claim before posting a round reply.
+
+Endpoint:
+
+```text
+POST /api/comms/channels/{channel}/threads/{thread_id}/claims
+```
+
+Request fields:
+
+- `agent_family`
+- `ui_surface`
+- `instance_id`
+- `round_index`
+- `participant_scope`
+- `idempotency_key`
+
+Default claim scope is `participant_scope=family`. This means only one participant per `agent_family` can hold the round slot, while any surface of that family may claim it if capability requirements allow.
+
+Reserve `participant_scope=participant` as a future escape hatch for assignments that truly require one exact `(agent_family, ui_surface, instance_id)`. Do not implement it in the first slice unless a concrete test requires it.
+
+Claims return `claim_id`, holder identity, `round_index`, scope, lease kind, and visible `expires_at`. Conflicts return the current holder and `expires_at`.
+
+### Rationale
+
+Family-scoped claims preserve the current `--with claude,codex,gemini` contract while allowing Desktop tag-in. The required slot is "Codex", not "this exact Codex CLI subprocess." First-claim-wins prevents duplicate expensive replies.
+
+### Tradeoffs
+
+- Same-family surfaces must coordinate through the claim table.
+- Capability requirements need validation in addition to family matching.
+- Participant-scoped behavior is deferred.
+- Claims add API and DB complexity.
+
+### Alternatives considered
+
+- First-message-wins, no claim. Rejected because competing agents waste tokens and produce rejected replies.
+- Instance-scoped claims only. Rejected as the default because it blocks tag-in.
+- Orchestrator-only posting. Rejected because Desktop/Web could not produce channel content.
+- One global claim per thread. Rejected because it serializes all families.
 
 ---
 
-## Implementation epic (only after ACCEPTED)
+## Q4. How do user posts interact with round quorum?
 
-If/when this ADR flips PROPOSED → ACCEPTED, the implementation splits into 4 strands, each filable as its own issue:
+### Proposal
 
-1. **Schema + claim mechanism** (Q1, Q3): `participant_id` column, `claims` table, claim/release endpoints, expiry sweep. ~250 LOC + tests.
-2. **SSE event stream** (Q2): `/api/comms/channels/{name}/events` + `discussion_started`/`message_appended` events. ~150 LOC + tests.
-3. **Discuss orchestrator updates** (Q3, Q4, Q6): claim integration, user-post injection, fallback path. ~200 LOC + tests in `scripts/ai_agent_bridge/_channels.py`.
-4. **MCP tool family** (Q2 follow-up, separate ADR): `mcp__channels__*` tools for Claude surfaces.
+Default mode: user posts are context, do not satisfy agent-family quorum slots, `[AGREE]` from the user ends the discussion as user termination rather than agent consensus, and `[OBJECT]` clears convergence and forces another round if budget allows.
 
-**channels.html** updates (UI rendering of multi-UI participants, claim status indicator, user-post-as-context visual treatment) layer on top once strands 1+2 land.
+User context injection: user posts during round N are injected into round N+1 prompts, prefixed with `[USER_CONTEXT]`, capped by character budget, and visibly marked if truncated.
+
+Explicit quorum mode: `ab discuss --with user` makes `agent_family=user` a required quorum slot. A user post can satisfy the current `user` slot, never a non-user slot, and the transcript records `quorum_role=required_participant`.
+
+For a user post to satisfy the current user slot, the discussion must include `--with user`, the post must reference the active `thread_id`, the post must have the current `round_index`, and the user must hold or be granted the `user` claim.
+
+### Rationale
+
+Default behavior preserves the existing agent-deliberation contract: users steer, object, or terminate, but are not silently counted as model-family consensus. Explicit `--with user` handles real cases where user participation is required, such as sensitive framing choices, private reference input, or approval of a multimodal-to-text fallback.
+
+### Tradeoffs
+
+- Two user modes are more complex than one.
+- UI must show whether user input is context or quorum.
+- Prompt injection must avoid bloat.
+- Claim validation must handle `agent_family=user`.
+
+### Alternatives considered
+
+- User is always context. Rejected as too rigid.
+- User is always a quorum participant. Rejected because it changes existing semantics.
+- User `[AGREE]` counts toward agent consensus. Rejected because consumer signoff is not cross-agent convergence.
+- User posts are ignored until discussion ends. Rejected because it loses steering value.
 
 ---
 
-## Review questions for Gemini + Codex
+## Q5. What identity and auth model is acceptable on localhost?
 
-When this ADR fires for cross-agent review, please critique specifically:
+### Proposal
 
-1. **Q1 schema migration:** is `participant_id` as a tuple-encoded string the right wire format, or should it be 3 separate columns? My choice is single-column for migration simplicity; counter-argue if you see a problem.
-2. **Q2 push-vs-pull:** is layering all three (SSE + inbox-poll + MCP shim) over-engineering? Could we ship pull-only and add SSE later, or is push fundamental to the user-experience?
-3. **Q3 claim scope:** family-scoped vs instance-scoped claim. I argued family-scoped enables the "tag in" use case. Counter-cases?
-4. **Q4 user-as-context:** is "user posts are NEVER replies, always context" too rigid? Steel-man the case for letting user be a first-class quorum participant when they explicitly join `--with`.
-5. **Q5 localhost auth:** is "no auth on localhost, document the assumption" sufficient, or should we ship a token even now?
-6. **Q6 90s claim expiry:** too short (Desktop with slow LLM) or too long (channels.html UI feels frozen)? Propose alternative if you can defend it.
-7. **Anything missing.** Are there architectural questions I didn't raise that you'd want answered before implementation?
+Initial implementation is localhost-only. Participants self-identify with `agent_family`, `ui_surface`, `instance_id`, and `client_app`. Examples include `codex-cli/5.x`, `codex-desktop/unknown`, `claude-code/2.x`, `claude-desktop/unknown`, `channels-html/local`, and `ab-headless/1`.
 
-Use `[AGREE]` to signal acceptance per question, or `[REVISE Q3: <reason>]` to push back on a specific section. The aggregator will collate.
+The broker does not authenticate participants in the first implementation.
+
+Loopback binding is a pre-implementation gate. Before any multi-UI endpoint ships, tests or startup checks must verify:
+
+- API binds to `127.0.0.1` or `::1`
+- API does not bind to `0.0.0.0` by default
+- docs do not instruct remote exposure
+- channel URLs use relative paths or loopback localhost
+- no container-only `/app/...` paths are introduced
+
+If the server currently binds broadly, fix that before implementing the rest of this ADR.
+
+### Rationale
+
+The broker is a single-user local development tool. Tokens are premature for the first prototype, but unauthenticated claim/post endpoints are acceptable only if the service is truly loopback-bound. Treating loopback binding as a later fix is too risky.
+
+### Tradeoffs
+
+- Any local process owned by the user can impersonate an agent.
+- Future remote support will need a separate auth ADR.
+- The preflight may block implementation if current binding is unsafe.
+
+### Alternatives considered
+
+- Token auth now. Deferred until remote or multi-user support.
+- No auth and no bind check. Rejected because `:8765` could be exposed accidentally.
+- Browser same-origin only. Rejected because CLI and Desktop integrations are not browser-only.
+- Per-agent shared secrets in repo config. Rejected for first implementation.
+
+---
+
+## Q6. What happens when a claim holder disappears?
+
+### Proposal
+
+Use stateful claims with leases, keepalives, visible expiry, manual release, and fallback.
+
+| Holder type | Initial lease | Keepalive interval | Extension | Use case |
+| --- | ---: | ---: | ---: | --- |
+| automated/headless/CLI subprocess | 90 seconds | 30 seconds | now + 90 seconds | spawned agents and scripted workers |
+| human/UI/Desktop/Web | 5 minutes | 30 seconds | now + 5 minutes | Desktop, browser, user-in-loop work |
+
+Every claim response and claim event includes `expires_at`. Clients must display or log it.
+
+Endpoints:
+
+```text
+POST /api/comms/channels/{channel}/threads/{thread_id}/claims/{claim_id}/keepalive
+POST /api/comms/channels/{channel}/threads/{thread_id}/claims/{claim_id}/release
+```
+
+Expired claims emit `claim_expired`. Expired holders cannot post round replies. Another participant may claim after expiry. The orchestrator may auto-fallback if configured.
+
+Fallback policy:
+
+- `--auto-fallback=true` remains default for CLI-safe tasks
+- multimodal-required tasks must not silently fallback to CLI
+- if fallback loses a required capability, abort unless degradation was explicitly allowed
+
+### Rationale
+
+A flat 90-second expiry is too brittle for human/UI work. Desktop users may inspect images, drag in files, or wait for generation. Infinite waits are also unacceptable. Leases make waiting explicit, keepalives keep active claims alive, and manual release avoids waiting out accidental claims.
+
+### Tradeoffs
+
+- Two lease classes add policy complexity.
+- Long UI leases can make a discussion feel stuck.
+- Keepalives require client implementation.
+- Fallback must understand capability requirements.
+
+### Alternatives considered
+
+- Fixed 90 seconds for all holders. Rejected because legitimate UI work expires.
+- Fixed five minutes for all holders. Rejected because automated failures become slow.
+- Wait forever. Rejected because it can deadlock the discussion.
+- No manual release. Rejected because accidental claims become expensive.
+
+---
+
+## Q7. How are claim retries made idempotent?
+
+### Proposal
+
+Claim creation requires an `idempotency_key`. Store each request keyed by at least `(thread_id, idempotency_key)` with canonical request hash, response status, response body, claim ID, and created timestamp.
+
+Semantics:
+
+- same key plus same request returns the original response
+- same key plus different request returns `409 idempotency_key_reuse`
+- reconnects and HTTP retries reuse the same key
+- clients generate a new key only for a new logical claim attempt
+- retention lasts at least as long as the discussion plus event replay retention
+
+Compatibility rule: old local CLI callers that omit `idempotency_key` may receive a server-generated key for that request, but new clients must send one.
+
+### Rationale
+
+Desktop and web clients reconnect. HTTP clients retry. Without idempotency, a retry can create ambiguous holder state or a misleading conflict. The broker must distinguish duplicate success, actual race, and client token reuse bug.
+
+### Tradeoffs
+
+- Adds a table or equivalent persisted request log.
+- Clients must persist a token across reconnects.
+- Server needs canonical request hashing.
+- Old clients need temporary compatibility.
+
+### Alternatives considered
+
+- Rely on unique claim constraints only. Rejected because retries can look like conflicts.
+- Use `claim_id` as idempotency key. Rejected because the client does not have it before creation.
+- Ignore retries because localhost is reliable. Rejected because browser refreshes and Desktop reconnects are normal.
+
+---
+
+## Q8. How is posting a round reply validated atomically?
+
+### Proposal
+
+Posting a round reply must be a single DB transaction. The transaction validates:
+
+- `claim_id` exists
+- claim is not expired
+- holder identity matches `agent_family`, `ui_surface`, and `instance_id`
+- `round_index` matches the active round
+- `agent_family` is required or allowed for the discussion
+- `participant_scope` rules are satisfied
+- parent/thread lineage is valid
+- no accepted reply already satisfies the same family slot for that round
+- surface capability requirements are met
+- attachment references exist and belong to the message draft or upload session
+
+Only after validation passes may the broker insert the message row, attachment rows, events, and claim-consumed/released state.
+
+Structured errors should include `claim_missing`, `claim_expired`, `claim_holder_mismatch`, `round_mismatch`, `family_not_required`, `duplicate_round_reply`, `invalid_parent`, `capability_missing`, and `attachment_missing`.
+
+### Rationale
+
+Claims matter only if posting enforces them. Without atomic validation, CLI could post into a slot claimed by Desktop, or a stale UI could post round 1 after round 2 started. Parent lineage alone does not prove claim ownership.
+
+### Tradeoffs
+
+- Post endpoint becomes stricter.
+- Older clients may fail until updated.
+- Race-condition tests are required.
+- Attachment upload may need draft/session state.
+
+### Alternatives considered
+
+- Validate in orchestrator only. Rejected because Desktop/Web can post outside that process.
+- Accept all messages and filter later. Rejected because it corrupts transcript audit.
+- Use `parent_id` only as guard. Rejected because it does not prove holder identity.
+
+---
+
+## Q9. Can participants join after `discussion_started`?
+
+### Proposal
+
+Dynamic join is allowed but constrained. Participant states are:
+
+- `observer`
+- `eligible_claimant`
+- `quorum_member`
+
+Default after `discussion_started`:
+
+- a new surface for an already-required `agent_family` may become an `eligible_claimant`
+- a new `agent_family` becomes `observer`
+- the user becomes context participant unless `--with user` was specified
+
+A late joiner can claim only when its family is already required, the family slot is unclaimed or expired, surface/capability requirements are satisfied, and the discussion is still active.
+
+A late joiner cannot become a new quorum member unless a user or orchestrator explicitly amends the discussion, emits `discussion_quorum_changed`, and all existing participants see that event before the next round. Do not implement quorum expansion in the first slice.
+
+### Rationale
+
+The user wants Desktop tag-in by another surface of the same family. That should work. Adding a new family midstream changes consensus meaning and must be explicit.
+
+### Tradeoffs
+
+- Late tag-in must be visible in UI.
+- Blocking new quorum members reduces flexibility but keeps consensus stable.
+- Future quorum changes need another implementation slice.
+
+### Alternatives considered
+
+- No dynamic joins. Rejected because it blocks Desktop tag-in.
+- Any late participant becomes quorum member. Rejected because it changes consensus silently.
+- Late joiners can post only context. Rejected as the sole mode because it does not solve claim handoff.
+
+---
+
+## Q10. How are events ordered and replayed?
+
+### Proposal
+
+Add a monotonic channel event sequence. Every state-changing broker action writes one event row with a strictly increasing `event_id`.
+
+Minimum event shape:
+
+```sql
+CREATE TABLE channel_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  channel TEXT NOT NULL,
+  thread_id TEXT,
+  event_type TEXT NOT NULL,
+  message_id TEXT,
+  claim_id TEXT,
+  attachment_id TEXT,
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+```
+
+Events include `discussion_started`, `message_appended`, `claim_created`, `claim_extended`, `claim_released`, `claim_expired`, `discussion_aborted`, `attachment_added`, and `discussion_completed`.
+
+Ordering rule: `event_id` is global across the local broker. Clients may filter by channel but retain the global ID. Replay returns `event_id > since`. Timestamps are metadata, not sequence.
+
+### Rationale
+
+SSE without monotonic event IDs is underspecified. Clients need to know whether a claim expired before a message, whether an abort preceded a late post, and where to resume after reconnect. SQLite autoincrement event IDs are simple and deterministic.
+
+### Tradeoffs
+
+- Adds an event log table.
+- Every state-changing endpoint must write events.
+- Tests must assert event ordering.
+- Pruning policy is deferred.
+
+### Alternatives considered
+
+- Use `created_at` timestamps. Rejected because timestamps are not unique and can be skewed.
+- Per-channel sequence numbers. Rejected for first implementation; global sequence is simpler for multi-channel clients.
+- Derive events from message rows only. Rejected because claims, expiries, aborts, and attachments are not all messages.
+
+---
+
+## Q11. How is fallback identity recorded?
+
+### Proposal
+
+Transcript rows for round replies must record required identity and actual identity:
+
+- `required_agent_family`
+- `required_ui_surface` nullable
+- `required_capability_profile` nullable
+- `actual_agent_family`
+- `actual_ui_surface`
+- `actual_instance_id`
+- `actual_participant_id`
+- `fallback_from_participant_id` nullable
+- `fallback_reason` nullable
+
+If fallback loses a required capability, the message must not be accepted unless degradation was explicitly allowed. Allowed degradation records `capability_degraded=true`, who allowed it, and the degradation reason.
+
+Example:
+
+```json
+{
+  "required_agent_family": "codex",
+  "required_ui_surface": "desktop",
+  "required_capability_profile": "multimodal_output",
+  "actual_agent_family": "codex",
+  "actual_ui_surface": "cli",
+  "actual_participant_id": "codex:cli:2c991a",
+  "fallback_from_participant_id": "codex:desktop:8f91c2",
+  "fallback_reason": "lease_expired"
+}
+```
+
+### Rationale
+
+If Desktop was required because the task needed graphical content, CLI fallback is not equivalent. The transcript must show that. This also supports later analysis of Desktop-created modules, CLI-created modules, fallback modules, and graphics-rich tasks degraded to text-only.
+
+### Tradeoffs
+
+- More message metadata.
+- UI rendering must preserve audit without clutter.
+- Some rows have nullable fields.
+- Capability checks must exist before fallback can be safe.
+
+### Alternatives considered
+
+- Overwrite holder with fallback participant. Rejected because it erases fallback.
+- Record fallback only as prose in message body. Rejected because it is not queryable.
+- Forbid fallback always. Rejected because CLI fallback remains useful for text-only discussions.
+
+---
+
+## Q12. How are graphical and multimodal artifacts produced, attached, and persisted?
+
+### Proposal
+
+Add first-class message attachments.
+
+```sql
+CREATE TABLE message_attachments (
+  attachment_id TEXT PRIMARY KEY,
+  message_id TEXT NOT NULL,
+  attachment_type TEXT NOT NULL,
+  blob_sha256 TEXT NOT NULL,
+  blob_ext TEXT NOT NULL,
+  mime_type TEXT NOT NULL,
+  byte_size INTEGER NOT NULL,
+  alt_text TEXT,
+  caption TEXT,
+  source_participant_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(message_id) REFERENCES channel_messages(message_id)
+);
+```
+
+Initial `attachment_type` values are `image`, `document`, `artifact`, and `data`.
+
+Blob storage decision for localhost:
+
+- store blobs on filesystem
+- path: `.ab/channels/blobs/{sha256}.{ext}`
+- keep metadata in SQLite
+- verify hash before linking
+- do not use S3-style storage for the local prototype
+
+Markdown image refs in message bodies use:
+
+```markdown
+![Color-coded possessive pronoun paradigm](attachment://{attachment_id})
+```
+
+The channel renderer resolves `attachment://...` against the blob store. Export may rewrite refs to relative file paths.
+
+MCP tool surface:
+
+```text
+mcp__channels__attach(message_id, file_path, alt_text?, caption?)
+```
+
+If atomic message plus attachment creation is needed, use a draft flow: begin message, attach to draft, then post draft. A simpler first slice may post then immediately attach, but message state must show incomplete/broken attachments visibly.
+
+Recommended limits:
+
+- image max size: 10 MB
+- document max size: 25 MB
+- max attachments per message: 10
+- alt text required for images
+
+### Rationale
+
+The content-production hypothesis depends on graphical output. A text-only channel cannot test it. Attachments must be persisted, content-addressed, referenced from markdown, rendered in channels.html, exportable, and attributable.
+
+Filesystem blob storage is the right localhost default because it is inspectable, cheap, and credential-free.
+
+### Tradeoffs
+
+- Blob cleanup becomes a maintenance concern.
+- Upload needs size and type limits.
+- Rendering must avoid silent broken refs.
+- Alt text is extra required metadata.
+- Draft flow is more robust but more work.
+
+### Alternatives considered
+
+- Inline base64 images in message body. Rejected because it bloats DB rows and transcripts.
+- S3-style storage now. Rejected because it adds credentials and network failure modes.
+- Commit generated images directly to repo paths. Rejected as the channel default; promotion can be separate.
+- Text-only placeholder descriptions. Rejected because it cannot test graphical pedagogy.
+
+---
+
+## Empirical hypothesis: pilot bakeoff before implementation
+
+### Hypothesis
+
+Desktop or UI surfaces may produce better graphics-rich lesson content than CLI surfaces because they can use multimodal input/output and live rendering. This is plausible but not proven. Run a small bakeoff before making Desktop mandatory for graphics-rich routing.
+
+### Input
+
+Use:
+
+```text
+docs/references/private/ohoiko-june-a1-book/notes/page-068-module-24-possessive-pronouns.md
+```
+
+The file is gitignored and may not exist in all worktrees. The bakeoff runner must fail clearly if it is absent; it must not fabricate the reference.
+
+The brief identifies seven pedagogical anchors from that note:
+
+1. Header structure.
+2. Audio scaffolding.
+3. Inductive opening.
+4. Concept block.
+5. Color-coded paradigm.
+6. Photo-anchored register block.
+7. Q -> A scaffold.
+
+### Task
+
+Produce one A1 module on possessive pronouns matching the pedagogical layout described in the notes. Output must include module markdown, supporting visual artifacts where used, alt text for every visual artifact, and a short design note explaining how each anchor was attempted. Do not copy copyrighted source text; use the notes only as structural/pedagogical observation.
+
+### Writers
+
+Writer A:
+
+- Codex CLI text-only
+- no image generation
+- no file attach
+- no live visual artifact surface
+
+Writer B:
+
+- Claude Code Desktop or Codex Desktop, whichever the user can run
+- multimodal input allowed
+- image generation allowed where the tool surface supports it
+- Artifacts/live-preview rendering allowed
+
+If neither Desktop variant is available, the bakeoff is blocked.
+
+### Measurement
+
+Score seven binary anchors:
+
+| Anchor | Present? | Evidence |
+| --- | --- | --- |
+| Header structure | yes/no | line refs or artifact refs |
+| Audio scaffolding | yes/no | line refs |
+| Inductive opening | yes/no | line refs |
+| Concept block | yes/no | line refs |
+| Color-coded paradigm | yes/no | line refs or attachment refs |
+| Photo-anchored register block | yes/no | line refs or attachment refs |
+| Q -> A scaffold | yes/no | line refs |
+
+Evidence must cite generated output, not the private notes. Score is `anchors_present / 7`.
+
+### Acceptance gate
+
+Let `CLI_SCORE=N` and `DESKTOP_SCORE=D`.
+
+Desktop locks in graphics-rich routing only if:
+
+```text
+D >= N + 2
+```
+
+Examples:
+
+- CLI 4/7, Desktop 6/7: Desktop advantage accepted.
+- CLI 5/7, Desktop 6/7: insufficient advantage.
+- CLI 6/7, Desktop 7/7: insufficient advantage.
+- CLI 3/7, Desktop 6/7: Desktop advantage accepted.
+
+If Desktop does not beat CLI by at least two anchors, ship CLI-first channel participation and keep attachment support optional/deferred. If Desktop wins by at least two anchors, implement surface capability routing, include attachment handling in the first multi-UI epic, and allow module-writing dispatch to require Desktop for graphics-rich modules.
+
+### Follow-up issue shape
+
+```text
+Title: Run possessive-pronoun multimodal bakeoff for #1731 Part B
+
+Inputs:
+- docs/references/private/ohoiko-june-a1-book/notes/page-068-module-24-possessive-pronouns.md
+
+Writers:
+- Codex CLI text-only
+- Claude Code Desktop or Codex Desktop multimodal
+
+Outputs:
+- module markdown per writer
+- artifact directory per writer
+- checklist report with 7 binary anchors
+- summary comparing CLI_SCORE and DESKTOP_SCORE
+
+Gate:
+- Desktop must score at least CLI_SCORE + 2 anchors to make Desktop-required routing mandatory for graphics-rich modules.
+```
+
+### Rationale
+
+The architecture should follow evidence. The seven-anchor checklist turns the user's hypothesis into a dispatchable test. It is pragmatic rather than statistically complete, but strong enough to decide whether Desktop-required routing belongs in the first implementation.
+
+### Tradeoffs
+
+- A single bakeoff is not statistically strong.
+- The private reference limits reproducibility.
+- Desktop availability depends on user setup.
+- Binary anchors may miss qualitative differences, so reviewers may add notes, but the gate remains binary.
+
+### Alternatives considered
+
+- Implement Desktop routing immediately. Rejected because it assumes the hypothesis.
+- Require a large bakeoff suite first. Rejected because it is too slow for this ADR.
+- Use subjective holistic review only. Rejected because it is hard to turn into an implementation gate.
+- Skip image artifacts. Rejected because graphical output is the hypothesis.
+
+---
+
+## Implementation epic
+
+After acceptance, split implementation into six strands. Each strand should carry focused tests; generated status, audit, and review artifacts must stay out of code PR diffs.
+
+### Strand 1: schema and claim mechanism
+
+Scope: add first-class participant identity columns, preserve legacy `from_agent`, add claims table, add claim-request idempotency table, add lease fields, add claim create/keepalive/release/expire paths, and add loopback preflight if missing.
+
+Questions covered: Q1, Q3, Q5, Q6, Q7.
+
+Test focus: legacy hydration, same-family claim conflicts, idempotent retry, key reuse failure, expired-claim rejection, keepalive extension, manual release, and loopback binding.
+
+### Strand 2: SSE, replay semantics, and MCP shim
+
+Scope: add `channel_events`, emit monotonic events for state changes, add replayable SSE endpoint, support `since`, support `Last-Event-ID`, keep pull endpoint as fallback, and add MCP resource registration for channel events.
+
+Questions covered: Q2, Q10.
+
+Test focus: monotonic event IDs, replay after `since`, `Last-Event-ID` resume, claim/message event order, and MCP readable resource URI.
+
+### Strand 3: discuss orchestrator updates
+
+Scope: route subprocess replies through claims, inject user context into next-round prompts, support `--with user`, handle `[AGREE]` and `[OBJECT]`, enforce fallback policy, record fallback identity, and prevent silent capability degradation.
+
+Questions covered: Q3, Q4, Q6, Q8, Q9, Q11.
+
+Test focus: default user context, explicit user quorum, user stop/object markers, required-vs-actual fallback recording, and multimodal-required fallback abort unless degradation is allowed.
+
+### Strand 4: MCP tool family
+
+Scope: add `mcp__channels__list`, `mcp__channels__observe`, `mcp__channels__claim`, `mcp__channels__keepalive`, `mcp__channels__release`, `mcp__channels__post`, and `mcp__channels__attach`.
+
+Questions covered: Q2, Q3, Q6, Q12.
+
+Test focus: Desktop can list, observe through resource reads, claim, post, release, attach an image with alt text, and receive rejection for missing or unsupported files.
+
+### Strand 5: multimodal artifact handling
+
+Scope: add `message_attachments`, add filesystem blob store, validate sha256 and MIME, support `attachment://{attachment_id}` markdown refs, render attachments in channels.html, export attachments for transcript review, and require alt text for images.
+
+Questions covered: Q12, Q8, Q11.
+
+Test focus: attachment-message links, blob hash verification, visibly broken missing blobs, image alt-text rejection, markdown image-ref resolution, and storage constrained under `.ab/channels/blobs`.
+
+### Strand 6: pilot bakeoff dispatch and checklist tooling
+
+Scope: add bakeoff preflight for the private notes path, dispatch CLI writer, document Desktop writer instructions, collect outputs, score seven anchors, produce comparison report, and apply the acceptance gate.
+
+Questions covered: content-production hypothesis, capability-profile routing, and Q12 implementation priority.
+
+Test focus: missing private notes fail clearly, all seven anchors report, score calculation is deterministic, Desktop accepted/rejected is explicit, and generated artifacts stay out of PR diffs.
+
+---
+
+## What this ADR explicitly does not decide
+
+This ADR does not decide:
+
+- remote agent authentication
+- cloud-hosted channels
+- whether Desktop output should be trusted without code review
+- final UX design for channels.html
+- long-term blob retention
+- promotion workflow from channel blob to curriculum asset
+- whether every graphics-rich module must use generated images
+- exact Desktop vendor priority if both Claude Desktop and Codex Desktop are available
+- global task-claiming outside discussion threads
+- mobile participation
+
+Deferred follow-up ADRs may be needed for remote auth, retention and pruning, cross-channel task pickup, artifact promotion into curriculum assets, and a persistent participant registry.
+
+---
+
+## Review questions for Gemini
+
+Please review this as an architecture gate, not implementation code.
+
+1. Q1 schema: Are three first-class columns enough, or do we need a participant registry table in the first implementation?
+2. Q2 discovery: Is replayable SSE plus MCP readable resource the right split, or should MCP expose a blocking subscription tool?
+3. Q3 claim scope: Is `participant_scope=family` the correct default, with participant scope reserved as an escape hatch?
+4. Q4 user semantics: Does default context mode plus explicit `--with user` quorum mode preserve the current discussion contract?
+5. Q5 localhost auth: Is loopback-binding preflight sufficient for the first local prototype, or is token auth mandatory before remote support?
+6. Q6 leases: Are 90 seconds for automated holders and 5 minutes for human/UI holders the right starting values?
+7. Q7 idempotency: Is request-key idempotency on claim creation enough, or do post endpoints also need explicit client tokens in the first implementation?
+8. Q8 atomic validation: Are the listed post-time invariants complete?
+9. Q9 dynamic joins: Should late same-family surfaces be eligible claimants by default, or should every late participant be observer-only first?
+10. Q10 event IDs: Is a global broker event sequence preferable to per-channel event sequences?
+11. Q11 fallback identity: Is required-vs-actual identity sufficient for audit and bakeoff analysis?
+12. Q12 attachments: Is filesystem blob storage under `.ab/channels/blobs` the right localhost default, and should image alt text be mandatory at attach time?
+13. Pilot bakeoff: Is the `Desktop >= CLI + 2 anchors` gate strong enough to justify Desktop-required routing for graphics-rich modules?
+14. Epic split: Is the six-strand split ordered correctly, or should the bakeoff run before any schema work?
+
+Use `[AGREE]` for sections you accept, or `[REVISE Qn: reason]` for sections that need changes before user signoff.

--- a/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
+++ b/docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md
@@ -1,6 +1,6 @@
 # DECISION REQUIRED - Multi-UI content-producing participants in `ab discuss` / channels.html
 
-**Status:** PROPOSED (awaiting Gemini cross-review and user signoff)
+**Status:** PROPOSED (awaiting reviewer cross-review and user signoff)
 **Surfaced:** 2026-05-06 morning, while running the writer-lock 3-way discussion
 **Source:** GH issue #1731 Part B; revised after Codex REJECT review on PR #1732
 **Scope:** Agent bridge channel participation, round claims, multimodal channel messages, and pilot bakeoff dispatch
@@ -32,7 +32,7 @@ In scope: participant identity across multiple surfaces, surface capability prof
 
 Out of scope: remote/cloud auth, multi-user broker federation, live voice/video calls, global task pickup outside discussion threads, final channels.html polish, blob retention/pruning, artifact promotion into curriculum assets, and Desktop vendor preference if both Claude Desktop and Codex Desktop are available.
 
-Implementation should not start until Gemini review and user signoff. The pilot bakeoff should run before the architecture makes Desktop mandatory for graphics-rich module work.
+Implementation should not start until reviewer cross-review and user signoff. The pilot bakeoff should run before the architecture makes Desktop mandatory for graphics-rich module work.
 
 ---
 
@@ -99,15 +99,18 @@ Each question below includes proposal, rationale, tradeoffs, and alternatives co
 
 ### Proposal
 
-A participant is represented by three first-class columns:
+A participant is represented by four first-class columns:
 
 - `agent_family`
 - `ui_surface`
+- `client_id`
 - `instance_id`
 
 Initial `agent_family` values are `claude`, `codex`, `gemini`, and `user`. Initial `ui_surface` values are `cli`, `desktop`, `web`, and `headless`.
 
-`instance_id` is a UUID for one local client identity. It is generated on first run, then persisted locally per `(agent_family, ui_surface)` so brief restarts recover the same identity instead of creating a conflicting same-surface claimant.
+`client_id` is the stable local client identity. It is generated on first run, then persisted locally per `(agent_family, ui_surface)` so brief restarts recover the same client for idempotency, deduplication, and lease-recovery decisions.
+
+`instance_id` is the live surface-session identity. It is generated when a process, window, browser tab, or headless run starts, and it must include session entropy such as a random UUID, PID plus process start-time hash, or equivalent session-scoped random value. It is not reused merely because the same user opens a second Desktop window. Two Codex Desktop windows on the same machine may share `client_id`, but they must have different `instance_id` values.
 
 Recommended local storage path:
 
@@ -119,14 +122,18 @@ Example persisted shape:
 
 ```json
 {
-  "codex:desktop": "8f91c2e0-4c2d-4a74-8e13-2f68f5a70b3b",
-  "claude:desktop": "a6b9d0f7-7ab0-40b2-8b54-9f7b5fbbe807"
+  "codex:desktop": {
+    "client_id": "8f91c2e0-4c2d-4a74-8e13-2f68f5a70b3b"
+  },
+  "claude:desktop": {
+    "client_id": "a6b9d0f7-7ab0-40b2-8b54-9f7b5fbbe807"
+  }
 }
 ```
 
-Headless workers may still generate a fresh UUID per run. Browser tabs should use local storage when available and fall back to session storage only if persistence is unavailable.
+Headless workers may still generate a fresh `client_id` and `instance_id` per run. Browser tabs should use local storage for `client_id` when available and session storage or in-memory state for the per-tab `instance_id`.
 
-`participant_id` may exist only as a generated display/key convenience:
+`participant_id` may exist only as a generated display convenience:
 
 ```text
 {agent_family}:{ui_surface}:{instance_id_short}
@@ -138,23 +145,23 @@ Example:
 codex:desktop:8f91c2
 ```
 
-It must not be the only stored identity. The canonical data model is the three separate columns. If SQLite generated columns are awkward, store `participant_id` as denormalized display text while keeping the three identity columns authoritative.
+It must not be the only stored identity and must not key idempotency, deduplication, or lease management. Short display IDs may collide, and a UI may let a user rename the visible participant label later. The canonical data model is the four separate columns. If SQLite generated columns are awkward, store `participant_id` as denormalized display text while keeping the four identity columns authoritative.
 
-The legacy `from_agent` column remains during migration. Old rows hydrate as `agent_family=from_agent`, `ui_surface=cli`, and `instance_id=legacy`.
+The legacy `from_agent` column remains during migration. Old rows hydrate as `agent_family=from_agent`, `ui_surface=cli`, `client_id=legacy`, and `instance_id=legacy`.
 
 The user is a participant with `agent_family=user`. User surface depends on entry point: channels.html is `web`, `ab post` is `cli`, and future Desktop integration is `desktop`.
 
 ### Rationale
 
-Tuple-in-text is not first-class schema. Quorum checks need `agent_family`; capability routing needs `ui_surface`; lease renewal needs `instance_id`; UI display can use `participant_id`. Encoding everything in one string makes serious queries depend on parsing conventions and weak indexing.
+Tuple-in-text is not first-class schema. Quorum checks need `agent_family`; capability routing needs `ui_surface`; idempotency and dedupe need `client_id`; live claim ownership needs `instance_id`; UI display can use `participant_id`. Encoding everything in one string makes serious queries depend on parsing conventions and weak indexing.
 
 ### Tradeoffs
 
 - Migration touches existing `channel_messages` queries.
 - Backfill needs a legacy mapping rule.
 - UI code needs to display `participant_id` while filtering by individual columns.
-- More indexes are needed, likely on `(channel, thread_id, agent_family)`, `(channel, thread_id, ui_surface)`, and `(channel, thread_id, agent_family, ui_surface, instance_id)`.
-- Clients need small local stable-storage handling and should tolerate missing or corrupt `instance.json` by generating a new UUID.
+- More indexes are needed, likely on `(channel, thread_id, agent_family)`, `(channel, thread_id, ui_surface)`, `(channel, thread_id, client_id)`, and `(channel, thread_id, agent_family, ui_surface, client_id, instance_id)`.
+- Clients need small local stable-storage handling and should tolerate missing or corrupt `instance.json` by generating a new `client_id`.
 
 ### Alternatives considered
 
@@ -162,7 +169,8 @@ Tuple-in-text is not first-class schema. Quorum checks need `agent_family`; capa
 - Distinct families such as `claude-desktop`. Rejected because Desktop and CLI should satisfy the same Claude family slot.
 - Keep only `from_agent` plus `client_app`. Rejected because telemetry is not identity.
 - Participant registry table only. Deferred; message rows still need denormalized identity for historical audit.
-- Purely ephemeral `instance_id` only. Rejected because closing and reopening a Desktop app would strand its active lease until expiry.
+- Persisted `instance_id` only. Rejected because two live Desktop windows from the same user would share a lease holder identity and collide.
+- Purely ephemeral identity only. Rejected because closing and reopening a Desktop app would strand its active lease until expiry and break retry deduplication.
 
 ---
 
@@ -229,6 +237,7 @@ Request fields:
 
 - `agent_family`
 - `ui_surface`
+- `client_id`
 - `instance_id`
 - `round_index`
 - `participant_scope`
@@ -236,11 +245,11 @@ Request fields:
 
 Default claim scope is `participant_scope=family`. This means only one participant per `agent_family` can hold the round slot, while any surface of that family may claim it if capability requirements allow.
 
-Reserve `participant_scope=participant` as a future escape hatch for assignments that truly require one exact `(agent_family, ui_surface, instance_id)`. Do not implement it in the first slice unless a concrete test requires it.
+Reserve `participant_scope=participant` as a future escape hatch for assignments that truly require one exact `(agent_family, ui_surface, client_id, instance_id)`. Do not implement it in the first slice unless a concrete test requires it.
 
 Claims return `claim_id`, holder identity, `round_index`, scope, lease kind, and visible `expires_at`. Conflicts return the current holder and `expires_at`.
 
-Normal brief restarts should recover the same `instance_id` through the Q1 local persistence rule. If persistence failed or the old app instance is dead, a same-surface replacement can seize a stale active lease.
+Normal brief restarts should recover the same `client_id` through the Q1 local persistence rule and present a new live `instance_id`. If the old app instance is dead, a same-client same-surface replacement can seize a stale active lease after missed keepalives.
 
 Lease takeover endpoint:
 
@@ -250,19 +259,19 @@ POST /api/comms/channels/{channel}/threads/{thread_id}/claims/{claim_id}/seize
 
 The broker may accept seize only when all conditions hold:
 
-- requester has the same `(agent_family, ui_surface)` as the active holder
+- requester has the same `(agent_family, ui_surface, client_id)` as the active holder
 - requester presents a different `instance_id`
 - active holder has missed two keepalives
 - claim has not already been consumed by a posted round reply
 - requested `round_index` still matches the active round
 
-On success, the broker updates the claim holder to the new `instance_id`, extends the lease using the holder type's normal lease duration, emits `claim_seized`, and records previous holder identity in the event payload. On failure, return the current holder and `expires_at` like a claim conflict.
+On success, the broker updates the claim holder to the new `instance_id`, keeps the same `client_id`, extends the lease using the holder type's normal lease duration, emits `claim_seized`, and records previous holder identity in the event payload. On failure, return the current holder and `expires_at` like a claim conflict.
 
 ### Rationale
 
 Family-scoped claims preserve the current `--with claude,codex,gemini` contract while allowing Desktop tag-in. The required slot is "Codex", not "this exact Codex CLI subprocess." First-claim-wins prevents duplicate expensive replies.
 
-The persisted `instance_id` rule prevents accidental restart lock-outs in the common case. The seize endpoint covers the recovery case where the persisted ID is missing, corrupt, or unavailable but the old holder has stopped keepaliving.
+The persisted `client_id` rule prevents accidental restart lock-outs in the common case. The per-session `instance_id` rule prevents simultaneous windows from sharing one live holder identity. The seize endpoint covers the recovery case where the old holder has stopped keepaliving.
 
 ### Tradeoffs
 
@@ -317,7 +326,7 @@ Default behavior preserves the existing agent-deliberation contract: users steer
 
 ### Proposal
 
-Initial implementation is localhost-only. Participants self-identify with `agent_family`, `ui_surface`, `instance_id`, and `client_app`. Examples include `codex-cli/5.x`, `codex-desktop/unknown`, `claude-code/2.x`, `claude-desktop/unknown`, `channels-html/local`, and `ab-headless/1`.
+Initial implementation is localhost-only. Participants self-identify with `agent_family`, `ui_surface`, `client_id`, `instance_id`, and `client_app`. Examples include `codex-cli/5.x`, `codex-desktop/unknown`, `claude-code/2.x`, `claude-desktop/unknown`, `channels-html/local`, and `ab-headless/1`.
 
 The broker does not authenticate participants in the first implementation.
 
@@ -402,7 +411,7 @@ A flat 90-second expiry is too brittle for human/UI work. Desktop users may insp
 
 ### Proposal
 
-Claim creation requires an `idempotency_key`. Store each request keyed by at least `(thread_id, idempotency_key)` with canonical request hash, response status, response body, claim ID, and created timestamp.
+Claim creation requires an `idempotency_key`. Store each request keyed by `(client_id, idempotency_key)` with `thread_id`, canonical request hash, response status, response body, claim ID, and created timestamp. `client_id` is the stable retry identity from Q1; `participant_id` is display-only and must not be used for idempotency.
 
 Claim semantics:
 
@@ -423,7 +432,7 @@ POST /api/comms/channels/{name}/threads/{thread_id}/post
 
 Any thread-reply variant must follow the same rule. The client supplies a UUID4 `idempotency_key` for the logical post attempt and reuses it on retries, including retries after a timeout during a large multimodal upload.
 
-Post idempotency is keyed by `(participant_id, idempotency_key)` within a five-minute window. The broker stores canonical body hash, attachment manifest hash, response status, `message_id`, and `expires_at`.
+Post idempotency is keyed by `(client_id, idempotency_key)` within a five-minute window. The broker stores canonical body hash, attachment manifest hash, response status, `message_id`, and `expires_at`.
 
 Conflict semantics:
 
@@ -436,7 +445,7 @@ Implementation shape:
 
 ```sql
 CREATE TABLE post_idempotency (
-  participant_id TEXT NOT NULL,
+  client_id TEXT NOT NULL,
   idempotency_key TEXT NOT NULL,
   body_hash TEXT NOT NULL,
   attachment_manifest_hash TEXT,
@@ -445,11 +454,11 @@ CREATE TABLE post_idempotency (
   response_body TEXT NOT NULL,
   expires_at TEXT NOT NULL,
   created_at TEXT NOT NULL,
-  PRIMARY KEY (participant_id, idempotency_key)
+  PRIMARY KEY (client_id, idempotency_key)
 );
 ```
 
-The post transaction uses `INSERT ... ON CONFLICT(participant_id, idempotency_key) DO NOTHING`, then selects the existing row on conflict. If the stored hashes match and `expires_at` is still in the future, return the stored `message_id`; if hashes differ, return `409`.
+The post transaction uses `INSERT ... ON CONFLICT(client_id, idempotency_key) DO NOTHING`, then selects the existing row on conflict. If the stored hashes match and `expires_at` is still in the future, return the stored `message_id`; if hashes differ, return `409`.
 
 ### Rationale
 
@@ -480,7 +489,7 @@ Posting a round reply must be a single DB transaction. The transaction validates
 
 - `claim_id` exists
 - claim is not expired
-- holder identity matches `agent_family`, `ui_surface`, and `instance_id`
+- holder identity matches `agent_family`, `ui_surface`, `client_id`, and `instance_id`
 - `round_index` matches the active round
 - `agent_family` is required or allowed for the discussion
 - `participant_scope` rules are satisfied
@@ -651,38 +660,47 @@ If Desktop was required because the task needed graphical content, CLI fallback 
 
 ### Proposal
 
-Add first-class message attachments.
+Add first-class message attachments backed by a separate content-addressable blob store.
 
 ```sql
-CREATE TABLE message_attachments (
-  attachment_id TEXT PRIMARY KEY,
-  message_id TEXT NOT NULL,
-  attachment_type TEXT NOT NULL,
-  blob_hash TEXT NOT NULL,
+CREATE TABLE blobs (
+  hash TEXT PRIMARY KEY,
   blob_ext TEXT NOT NULL,
   mime_type TEXT NOT NULL,
   byte_size INTEGER NOT NULL,
+  storage_path TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE message_attachments (
+  message_id TEXT NOT NULL,
+  attachment_id TEXT NOT NULL,
+  attachment_type TEXT NOT NULL,
+  blob_hash TEXT NOT NULL REFERENCES blobs(hash),
   alt_text TEXT,
   caption TEXT,
-  source_participant_id TEXT NOT NULL,
+  source_client_id TEXT NOT NULL,
+  source_instance_id TEXT NOT NULL,
+  provenance_mode TEXT NOT NULL,
+  source_attachment_id TEXT,
   created_at TEXT NOT NULL,
-  UNIQUE(blob_hash),
+  PRIMARY KEY(message_id, attachment_id),
   FOREIGN KEY(message_id) REFERENCES channel_messages(message_id)
 );
 ```
 
 Initial `attachment_type` values are `image` and `audio`.
 
+The same blob may be attached to multiple messages. `blobs.hash` is the dedupe boundary; `message_attachments` is the relation between a message-local attachment ID and a stored blob. Reattaching the same image or audio file to a second message inserts or reuses one `blobs` row and inserts a new `message_attachments` row.
+
 Blob storage decision for localhost:
 
 - store blobs on filesystem
 - path: `.ab/channels/blobs/{sha256}.{ext}`
-- keep metadata in SQLite
+- keep blob metadata in SQLite
 - verify hash before linking
 - insert blob metadata with `INSERT OR IGNORE` semantics so identical uploads dedupe to one row
 - do not use S3-style storage for the local prototype
-
-If the implementation later normalizes blobs into a separate `channel_blobs` table, move the `UNIQUE(blob_hash)` constraint and `INSERT OR IGNORE` behavior to that table while keeping `message_attachments.blob_hash` as the content-addressed reference.
 
 `blob_ext` validation is strict:
 
@@ -706,13 +724,16 @@ Audio refs use the same attachment URI and are rendered by the channel UI as pla
 
 The channel renderer resolves `attachment://...` against the blob store. Export may rewrite refs to relative file paths.
 
-MCP tool surface:
+Atomic post surface:
 
 ```text
-mcp__channels__attach(message_id, file_path, attachment_type, alt_text?, caption?)
+POST /api/comms/channels/{name}/messages-with-attachments
+mcp__channels__post_with_attachments(thread_id, body, attachments[], idempotency_key, claim_id?)
 ```
 
-If atomic message plus attachment creation is needed, use a draft flow: begin message, attach to draft, then post draft. A simpler first slice may post then immediately attach, but message state must show incomplete/broken attachments visibly.
+The endpoint stages the message row, blob metadata, copied blob files, attachment rows, event rows, and idempotency row in one logical transaction. It returns `{message_id, attachment_ids}` only after all required attachments are stored, hashed, MIME-validated, linked, and visible to the renderer. If any attachment fails validation or storage, the endpoint rolls back the message, attachment links, events, and idempotency response.
+
+Round replies that require multimodal anchors must use this atomic endpoint. A separate attach-to-existing-message operation may exist only for non-round notes or administrative repair, and it must not be allowed to satisfy a multimodal-required round reply after the message has already been scored.
 
 Recommended limits:
 
@@ -884,6 +905,115 @@ The architecture should follow evidence. The seven-anchor checklist turns the us
 
 ---
 
+## Round-3 Codex self-review resolutions
+
+Round 3 resolves six design problems found after the round-2 review. These sections supersede any earlier wording in Q1, Q7, Q12, and the Strand 0 gate when there is tension.
+
+### R3.1 `instance_id` must be per live surface session
+
+Resolution: Q1 now splits persisted `client_id` from session-scoped `instance_id`. `client_id` persists per `(agent_family, ui_surface)` and is used for retry identity, deduplication, and lease-recovery decisions. `instance_id` is generated for each live process, window, browser tab, or headless run and must include session entropy.
+
+Reasoning: round 2 over-corrected restart recovery by persisting `instance_id`. That would make two Codex Desktop windows from the same user share a holder identity and collide in claim, keepalive, and fallback audit logic. The new model keeps restart recovery through `client_id` while preserving per-window distinction through `instance_id`.
+
+Cross-references: Q1 defines both IDs. Q3 claim seize requires the same `(agent_family, ui_surface, client_id)` and a different `instance_id`. Q8 validates both IDs at post time.
+
+### R3.2 `client_id` is canonical for idempotency; `participant_id` is display-only
+
+Resolution: Q1 now treats `participant_id` as a display convenience that may collide and must not key broker correctness. Q7 keys claim and post idempotency on `(client_id, idempotency_key)`.
+
+Reasoning: round 2 made `participant_id` non-canonical in Q1 but still used it as the idempotency key in Q7. That was a contradiction. Idempotency, deduplication, and lease management need a stable machine identity; display labels are for UI and transcript readability.
+
+Cross-references: Q1 defines `client_id` and `participant_id`. Q7 defines the idempotency table. Q11 may still show `actual_participant_id` in transcript payloads, but that field is audit display, not broker identity.
+
+### R3.3 Blob storage is separate from message attachment links
+
+Resolution: Q12 now defines `blobs(hash)` as the content-addressable store and `message_attachments(message_id, attachment_id)` as the relation from messages to blobs. The same blob hash may appear in multiple attachment rows.
+
+Reasoning: round 2 put `UNIQUE(blob_hash)` directly on `message_attachments`, which would reject a legitimate second message that attaches the same image or audio file. Deduplication belongs in the blob table; attachment identity belongs in the message relation.
+
+Cross-references: Q12 schema and Strand 5 test focus now require duplicate upload dedupe without blocking same-blob reuse across messages.
+
+### R3.4 Multimodal-required round replies must post atomically with attachments
+
+Resolution: Q12 now requires a single `POST /api/comms/channels/{name}/messages-with-attachments` flow for multimodal-required round replies. The endpoint returns `{message_id, attachment_ids}` only after message and attachment rows are both committed, or rolls back all of them.
+
+Reasoning: "post then attach" creates a scoring race. An evaluator could observe the text message before the image or audio upload finishes and fail the message against a multimodal anchor even though the agent intended to attach the file. Atomic creation makes the scored message state match the participant's submitted state.
+
+Cross-references: Q7 includes attachment manifest hashing in post idempotency. Q8 validates attachment references before accepting a round reply. Q12 defines the atomic endpoint.
+
+### R3.5 Strand 0 non-multimodal anchors need explicit scoring
+
+Resolution: the Strand 0 scoring appendix below defines per-anchor criteria for the four non-multimodal anchors: header structure, inductive opening, concept block, and Q -> A scaffold. The Desktop gate remains `DESKTOP_NON_MM >= CLI_NON_MM`, but each non-multimodal anchor now has concrete pass/fail criteria and evidence requirements.
+
+Reasoning: round 2 defined the multimodal-only gate tightly but left the text/pedagogy anchors underspecified. That could let reviewers disagree about whether Desktop "fell behind CLI" without a shared rubric.
+
+Cross-references: Strand 0 measurement keeps the seven binary anchors. The appendix defines the non-multimodal side of the same scoring sheet.
+
+### R3.6 Audio workflows are distinct: generate, attach, preserve
+
+Resolution: the audio workflow appendix below separates three flows: generating new audio, attaching a pre-existing audio file, and preserving an audio attachment posted by another participant. The broker records provenance for all three but does not itself need to synthesize audio in the first implementation.
+
+Reasoning: adding `attachment_type=audio` did not specify whether the agent creates audio, uploads an existing file, or carries forward another participant's file. Those flows have different provenance, security, licensing, and scoring implications.
+
+Cross-references: Q12 records `attachment_type`, `provenance_mode`, `source_client_id`, `source_instance_id`, and optional `source_attachment_id`. Strand 0 and Strand 5 use the appendix rules.
+
+---
+
+## Appendix: Strand 0 non-multimodal scoring rubric
+
+This appendix scores the four non-multimodal anchors used by `CLI_NON_MM` and `DESKTOP_NON_MM`. Each anchor is binary. Award `1` only when the submitted output contains the required evidence; otherwise award `0`.
+
+### Judge protocol
+
+Use the generated module markdown and any declared artifacts only. Do not score from private notes, hidden prompts, or the writer's design note unless the produced lesson itself contains the feature. Record line references for markdown evidence and artifact references for rendered evidence. If a scorer cannot point to evidence, the anchor fails.
+
+Two reviewers may score independently when time allows. If they disagree, they compare evidence references only, not model reputations or preferred style. If disagreement remains, use the stricter score and add a note explaining the ambiguity.
+
+### Anchor criteria
+
+| Non-multimodal anchor | Pass criteria | Fails when |
+| --- | --- | --- |
+| Header structure | The module has a clear title, level/module framing, and learner-facing section headings that match the lesson flow. | The output is an unstructured essay, lacks a title, or uses headings that do not organize the lesson. |
+| Inductive opening | The lesson starts from examples, noticing, contrast, or a short learner task before giving the rule. | It begins with only an abstract grammar rule or a meta explanation of what the writer intends. |
+| Concept block | The lesson includes a concise learner-facing explanation of possessive-pronoun meaning/use with examples tied to the target Ukrainian forms. | It only lists forms, gives an inaccurate explanation, or leaves the rule implicit. |
+| Q -> A scaffold | The lesson includes a question-to-answer pattern or guided transformation that shows how a learner moves from prompt to possessive-pronoun answer. | It has isolated examples with no prompt/response relation, or the scaffold is described but not actually provided. |
+
+### Tie-break rules
+
+Equivalent Ukrainian/English wording can pass when it satisfies the learner function. Extra polish, length, or richer prose does not earn extra credit. Minor formatting defects do not fail an anchor if the evidence is still clear. Any placeholder such as `TODO`, `[fill later]`, `image TBD`, or `audio TBD` fails the affected anchor.
+
+The Desktop acceptance gate compares only the count of these four anchors after scoring. Desktop passes the non-multimodal side when `DESKTOP_NON_MM >= CLI_NON_MM`; it does not need to beat CLI on text anchors, but it must not trail.
+
+---
+
+## Appendix: Audio workflow
+
+Audio support covers three different workflows. All three use `attachment_type=audio`, but they require different provenance.
+
+### Generate new audio
+
+An agent generates audio when it uses TTS, file synthesis, a local recording tool, or a Desktop audio-generation capability to create a new file for the reply. The broker stores the resulting file as a blob and records `provenance_mode=generated`.
+
+Required provenance: source text or prompt summary, generator/tool name when available, voice or model identifier when available, source client identity, file hash, MIME type, byte size, and any licensing constraint known to the client. The first implementation may accept generated audio only from clients that explicitly advertise audio-generation capability.
+
+### Attach pre-existing audio
+
+An agent attaches audio when it uploads or references an existing local file, course asset, or pre-implementation bakeoff artifact. The broker copies the file into `.ab/channels/blobs`, verifies its hash and MIME type, inserts or reuses the `blobs` row, and records `provenance_mode=attached`.
+
+Required provenance: source client identity, original filename or asset reference when safe to record, content hash, MIME type, byte size, and a client assertion that the file is allowed for local evaluation. This is the default flow for Strand 0 and for pronunciation/audio-paired lesson drafts before a dedicated generation tool is approved.
+
+### Preserve another participant's audio
+
+An agent preserves audio when it cites or carries forward an audio attachment that another participant already posted. The broker creates a new `message_attachments` row pointing to the existing `blob_hash`, records `provenance_mode=preserved`, and stores `source_attachment_id` for the original attachment. It must not rewrite provenance to make the preserving participant look like the creator.
+
+Required provenance: preserving client identity, original `message_id`, original `attachment_id`, original blob hash, and the original source participant fields. Preserve is the preferred flow for review, summary, and follow-up messages that need to keep an audio anchor visible without duplicating files.
+
+### Recommendation by strand
+
+Strand 0 may use generated audio only if the selected Desktop writer already has an explicit generation path; otherwise it should attach a pre-existing audio file and record its hash in the local manifest. Strand 4 should expose attach and atomic post-with-attachments first. Strand 5 should implement blob reuse and preserve semantics with tests. Broker-side audio generation is deferred; the broker records generated provenance but does not synthesize files itself.
+
+---
+
 ## Implementation epic
 
 Run Strand 0 before any implementation code lands. If Strand 0 fails the acceptance gate, abort and revisit the architecture before implementing Strands 1-6.
@@ -900,7 +1030,7 @@ Test focus: missing private notes fail clearly, all seven anchors report, scorer
 
 ### Strand 1: schema and claim mechanism
 
-Scope: add first-class participant identity columns, preserve legacy `from_agent`, add claims table, add claim and post idempotency tables, add lease fields, add claim create/keepalive/release/expire/seize paths, add persisted `instance_id` client handling, and add loopback preflight if missing.
+Scope: add first-class participant identity columns, preserve legacy `from_agent`, add claims table, add claim and post idempotency tables, add lease fields, add claim create/keepalive/release/expire/seize paths, add persisted `client_id` handling, add per-session `instance_id` handling, and add loopback preflight if missing.
 
 Questions covered: Q1, Q3, Q5, Q6, Q7.
 
@@ -924,19 +1054,19 @@ Test focus: default user context, explicit user quorum, user stop/object markers
 
 ### Strand 4: MCP tool family
 
-Scope: add `mcp__channels__list`, `mcp__channels__observe`, `mcp__channels__claim`, `mcp__channels__keepalive`, `mcp__channels__release`, `mcp__channels__post`, and `mcp__channels__attach`.
+Scope: add `mcp__channels__list`, `mcp__channels__observe`, `mcp__channels__claim`, `mcp__channels__keepalive`, `mcp__channels__release`, `mcp__channels__post`, `mcp__channels__post_with_attachments`, and limited `mcp__channels__attach` for non-round repair/admin use.
 
 Questions covered: Q2, Q3, Q6, Q12.
 
-Test focus: Desktop can list, observe through resource reads, claim, post with idempotency, release, attach an image with alt text, attach an audio file, and receive rejection for missing or unsupported files.
+Test focus: Desktop can list, observe through resource reads, claim, post with idempotency, release, atomically post a message with image/audio attachments, and receive rejection for missing or unsupported files.
 
 ### Strand 5: multimodal artifact handling
 
-Scope: add `message_attachments`, add filesystem blob store, validate sha256, MIME, extension allowlist, dedupe identical uploads, support `attachment://{attachment_id}` markdown refs, render image and audio attachments, export attachments for transcript review, and require alt text for images.
+Scope: add `blobs`, add `message_attachments`, add filesystem blob store, validate sha256, MIME, extension allowlist, dedupe identical uploads in `blobs`, allow the same blob to attach to multiple messages, support `attachment://{attachment_id}` markdown refs, render image and audio attachments, export attachments for transcript review, preserve existing audio attachments by reference, and require alt text for images.
 
 Questions covered: Q12, Q8, Q11.
 
-Test focus: attachment-message links, blob hash verification, duplicate upload dedupe, unsafe extension rejection, visibly broken missing blobs, image alt-text rejection, audio size limit, markdown attachment-ref resolution, and storage constrained under `.ab/channels/blobs`.
+Test focus: attachment-message links, blob hash verification, duplicate upload dedupe, same-blob reuse across messages, atomic rollback when an attachment fails, unsafe extension rejection, visibly broken missing blobs, image alt-text rejection, audio size limit, markdown attachment-ref resolution, preserved-audio provenance, and storage constrained under `.ab/channels/blobs`.
 
 ### Strand 6: channels.html UI updates
 
@@ -967,11 +1097,11 @@ Deferred follow-up ADRs may be needed for remote auth, retention and pruning, cr
 
 ---
 
-## Review questions for Gemini
+## Review questions for reviewers
 
 Please review this as an architecture gate, not implementation code.
 
-1. Q1 schema: Are three first-class columns plus local `instance_id` persistence enough, or do we need a participant registry table in the first implementation?
+1. Q1 schema: Are four first-class columns plus local `client_id` persistence and per-session `instance_id` enough, or do we need a participant registry table in the first implementation?
 2. Q2 discovery: Is replayable SSE plus MCP readable resource the right split, or should MCP expose a blocking subscription tool?
 3. Q3 claim scope: Is `participant_scope=family` the correct default, and is same-surface lease seizure after two missed keepalives sufficient for restart recovery?
 4. Q4 user semantics: Does default context mode plus explicit `--with user` quorum mode preserve the current discussion contract?
@@ -982,7 +1112,7 @@ Please review this as an architecture gate, not implementation code.
 9. Q9 dynamic joins: Should late same-family surfaces be eligible claimants by default, or should every late participant be observer-only first?
 10. Q10 event IDs: Is a global broker event sequence preferable to per-channel event sequences?
 11. Q11 fallback identity: Is required-vs-actual identity sufficient for audit and bakeoff analysis?
-12. Q12 attachments: Is filesystem blob storage under `.ab/channels/blobs` the right localhost default, with image/audio types, dedupe, extension sanitization, and image alt text required at attach time?
+12. Q12 attachments: Is filesystem blob storage under `.ab/channels/blobs` the right localhost default, with separate `blobs` and `message_attachments` tables, atomic message-with-attachments posting, image/audio types, dedupe, extension sanitization, and image alt text required at attach time?
 13. Pilot bakeoff: Is the multimodal-specific gate strong enough to justify Desktop-required routing for graphics-rich modules?
 14. Epic split: Is Strand 0 correctly placed as a manual pre-implementation gate before schema work?
 


### PR DESCRIPTION
## Summary

Supersedes PR #1735 with round-3 fixes for Codex self-review findings on the multi-UI participation ADR.

## Round-3 deltas

| Finding | Round-3 resolution |
| --- | --- |
| `instance_id` persistence over-corrected | Split stable persisted `client_id` from per-session `instance_id` with surface-session entropy, so simultaneous Desktop windows do not collide. |
| Q1/Q7 `participant_id` contradiction | Made `participant_id` display-only and keyed claim/post idempotency on `(client_id, idempotency_key)`. |
| Q12 same blob across messages blocked | Split `blobs(hash)` content storage from `message_attachments(message_id, attachment_id)` links so one blob can be reused across messages. |
| Post-then-attach scoring race | Added atomic `messages-with-attachments` / `post_with_attachments` flow that commits message and attachments together or rolls back both. |
| Strand 0 non-multimodal rubric vague | Added an appendix with binary scoring criteria, judge protocol, and tie-break rules for header, inductive opening, concept block, and Q -> A scaffold. |
| Audio capability vague | Added an audio appendix separating generate, attach, and preserve workflows with provenance and strand recommendations. |

## Round-2 already covered

- First-class multi-surface participant identity and capability profiles.
- Claim/lease/fallback semantics, dynamic joins, replayable events, and atomic round-message validation.
- Multimodal attachment direction, pilot bakeoff design, and implementation epic split.
- Multimodal-specific Strand 0 acceptance gate requiring Desktop to hit all three multimodal-only anchors and not trail CLI on non-multimodal anchors.

## Still open

- Reviewer cross-review and user signoff on the ADR.
- Actual implementation of the ADR strands after signoff.
- Running Strand 0 before implementation makes Desktop routing mandatory for graphics-rich work.
- PR #1735 should be closed as superseded after this PR lands.

## Validation

- `npx --no-install markdownlint-cli2 docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md`
- `git diff --check`