### PR TITLE
feat(delegate): inject GH_TOKEN for codex/claude/bridge dispatch subprocesses (#1751)

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -152,7 +152,12 @@ environment for each process:
   AWS access-key, and Google `AIza` patterns.
 - Provider credentials pass through only to that provider: Gemini sees
   Gemini/Google keys, Claude sees Anthropic/Claude keys, and Codex sees
-  OpenAI/Codex keys. Cross-provider keys and `GITHUB_TOKEN` stay absent.
+  OpenAI/Codex keys. Cross-provider keys stay absent. `GITHUB_TOKEN`
+  is never passed through directly; `delegate.py` resolves it once from
+  the environment or `~/.bash_secrets` and exposes it as `GH_TOKEN` only
+  for Codex, Claude, and bridge subprocesses so authenticated `gh`
+  commands work without sourcing shell secrets. Gemini subprocesses do
+  not receive `GH_TOKEN`.
 - Gemini also receives `GEMINI_AUTH_MODE` because it is runtime mode
   selection, not a credential; secret-shaped values are still rejected.
 

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -53,12 +53,16 @@ _PROVIDER_SECRET_ALLOWLIST = {
     "claude": {
         "ANTHROPIC_API_KEY",
         "CLAUDE_API_KEY",
+        "GH_TOKEN",
     },
     "codex": {
         "CODEX_API_KEY",
+        "GH_TOKEN",
         "OPENAI_API_KEY",
     },
-    "bridge": set(),
+    "bridge": {
+        "GH_TOKEN",
+    },
 }
 
 _PROVIDER_SAFE_NAME_ALLOWLIST = {

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -83,6 +83,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import signal
 import subprocess
 import sys
@@ -94,6 +95,63 @@ from typing import Any
 # Resolve repo root from this file's location so we work from any cwd.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
+_BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
+_GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}
+
+
+def _read_github_token_from_bash_secrets(path: Path | None = None) -> str | None:
+    """Read GITHUB_TOKEN from a shell env file without executing it."""
+    path = path or _BASH_SECRETS_PATH
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    for line in lines:
+        try:
+            parts = shlex.split(line, comments=True, posix=True)
+        except ValueError:
+            continue
+        if not parts:
+            continue
+        if parts[0] == "export":
+            parts = parts[1:]
+        for part in parts:
+            if part.startswith("GITHUB_TOKEN="):
+                value = part.split("=", 1)[1]
+                return value or None
+    return None
+
+
+def _resolve_github_token() -> str | None:
+    """Resolve the GitHub token used for GH_TOKEN pass-through."""
+    return (
+        os.environ.get("GITHUB_TOKEN")
+        or _read_github_token_from_bash_secrets()
+        or os.environ.get("GH_TOKEN")
+    )
+
+
+def _inject_gh_token_for_agent(worker_env: dict[str, str], agent: str) -> None:
+    """Expose GH_TOKEN only to agents allowed to run authenticated gh."""
+    worker_env.pop("GITHUB_TOKEN", None)
+    if agent not in _GH_TOKEN_AGENTS:
+        worker_env.pop("GH_TOKEN", None)
+        return
+
+    token = _resolve_github_token()
+    if token:
+        worker_env["GH_TOKEN"] = token
+        return
+
+    worker_env.pop("GH_TOKEN", None)
+    print(
+        f"⚠️  GITHUB_TOKEN not found in environment or {_BASH_SECRETS_PATH}; "
+        f"{agent} dispatch will not receive GH_TOKEN.",
+        file=sys.stderr,
+    )
 
 
 def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
@@ -903,6 +961,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # explicit rather than implicit. Callers that want to scrub
     # secrets from the worker's env can override this here.
     worker_env = os.environ.copy()
+    _inject_gh_token_for_agent(worker_env, args.agent)
     if getattr(args, "allow_merge", False):
         worker_env.pop("AGENT_NO_MERGE", None)
         worker_env["AGENT_ALLOW_MERGE"] = "1"

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -57,6 +57,7 @@ def test_build_agent_env_passes_only_current_provider_credentials():
         "OPENAI_API_KEY": "sk-openai-fake",
         "CODEX_API_KEY": "codex-key",
         "GITHUB_TOKEN": "ghp_fakegithubtoken",
+        "GH_TOKEN": "ghp_fakeghtoken",
     }
 
     with patch.dict("os.environ", parent_env, clear=True):
@@ -69,20 +70,24 @@ def test_build_agent_env_passes_only_current_provider_credentials():
     assert gemini_env["GOOGLE_API_KEY"] == "google-key"
     assert "ANTHROPIC_API_KEY" not in gemini_env
     assert "OPENAI_API_KEY" not in gemini_env
+    assert "GH_TOKEN" not in gemini_env
 
     assert claude_env["ANTHROPIC_API_KEY"] == "sk-ant-fake"
     assert claude_env["CLAUDE_API_KEY"] == "sk-claude-fake"
+    assert claude_env["GH_TOKEN"] == "ghp_fakeghtoken"
     assert "GEMINI_API_KEY" not in claude_env
     assert "OPENAI_API_KEY" not in claude_env
 
     assert codex_env["OPENAI_API_KEY"] == "sk-openai-fake"
     assert codex_env["CODEX_API_KEY"] == "codex-key"
+    assert codex_env["GH_TOKEN"] == "ghp_fakeghtoken"
     assert "GEMINI_API_KEY" not in codex_env
     assert "ANTHROPIC_API_KEY" not in codex_env
 
     assert "GEMINI_API_KEY" not in bridge_env
     assert "ANTHROPIC_API_KEY" not in bridge_env
     assert "OPENAI_API_KEY" not in bridge_env
+    assert bridge_env["GH_TOKEN"] == "ghp_fakeghtoken"
     assert "GITHUB_TOKEN" not in bridge_env
 
 
@@ -210,6 +215,7 @@ def test_runner_smoke_spawns_each_provider_with_only_its_own_key(tmp_path):
         "OPENAI_API_KEY",
         "CODEX_API_KEY",
         "GITHUB_TOKEN",
+        "GH_TOKEN",
     ]
     script = (
         "import json, os; "
@@ -227,6 +233,7 @@ def test_runner_smoke_spawns_each_provider_with_only_its_own_key(tmp_path):
         "OPENAI_API_KEY": "sk-openai-fake",
         "CODEX_API_KEY": "codex-key",
         "GITHUB_TOKEN": "ghp_fakegithubtoken",
+        "GH_TOKEN": "ghp_fakeghtoken",
     }
     expected = {
         "gemini": {
@@ -236,10 +243,12 @@ def test_runner_smoke_spawns_each_provider_with_only_its_own_key(tmp_path):
         "claude": {
             "ANTHROPIC_API_KEY": "sk-ant-fake",
             "CLAUDE_API_KEY": "sk-claude-fake",
+            "GH_TOKEN": "ghp_fakeghtoken",
         },
         "codex": {
             "OPENAI_API_KEY": "sk-openai-fake",
             "CODEX_API_KEY": "codex-key",
+            "GH_TOKEN": "ghp_fakeghtoken",
         },
     }
 
@@ -268,3 +277,81 @@ def test_runner_smoke_spawns_each_provider_with_only_its_own_key(tmp_path):
 
             assert outcome.parse.ok is True
             assert json.loads(outcome.stdout_text) == expected_env
+
+
+def test_runner_codex_subprocess_gets_gh_token_for_gh_auth_status(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = auth ] && [ \"$2\" = status ] && [ -n \"$GH_TOKEN\" ]; then\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n"
+    )
+    gh.chmod(0o755)
+    script = (
+        "import os, subprocess, sys; "
+        "assert os.environ.get('GH_TOKEN') == 'ghp_fakeghtoken'; "
+        "sys.exit(subprocess.run(['gh', 'auth', 'status']).returncode)"
+    )
+    parent_env = {
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "HOME": str(tmp_path),
+        "GH_TOKEN": "ghp_fakeghtoken",
+    }
+
+    with patch.dict("os.environ", parent_env, clear=True), patch(
+        "agent_runtime.runner._POLL_INTERVAL_S", 0.01,
+    ):
+        outcome = _execute_invocation_plan(
+            agent_name="codex",
+            adapter=_SmokeAdapter(),
+            plan=_SmokePlan(cmd=[_TEST_PYTHON, "-c", script], cwd=tmp_path),
+            prompt="gh auth smoke",
+            mode="read-only",
+            cwd=tmp_path,
+            model="smoke-model",
+            task_id="codex-gh-auth-smoke",
+            session_id=None,
+            entrypoint="runtime-test",
+            hard_timeout=10,
+            stall_timeout=10,
+        )
+
+    assert outcome.returncode == 0
+    assert outcome.parse.ok is True
+
+
+def test_runner_gemini_subprocess_does_not_get_gh_token(tmp_path):
+    script = (
+        "import os, sys; "
+        "sys.exit(0 if 'GH_TOKEN' not in os.environ else 1)"
+    )
+    parent_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(tmp_path),
+        "GH_TOKEN": "ghp_fakeghtoken",
+    }
+
+    with patch.dict("os.environ", parent_env, clear=True), patch(
+        "agent_runtime.runner._POLL_INTERVAL_S", 0.01,
+    ):
+        outcome = _execute_invocation_plan(
+            agent_name="gemini",
+            adapter=_SmokeAdapter(),
+            plan=_SmokePlan(cmd=[_TEST_PYTHON, "-c", script], cwd=tmp_path),
+            prompt="gh token absence smoke",
+            mode="read-only",
+            cwd=tmp_path,
+            model="smoke-model",
+            task_id="gemini-no-gh-token-smoke",
+            session_id=None,
+            entrypoint="runtime-test",
+            hard_timeout=10,
+            stall_timeout=10,
+        )
+
+    assert outcome.returncode == 0
+    assert outcome.parse.ok is True

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -835,6 +835,103 @@ def test_dispatch_allow_merge_opt_in_updates_worker_env(tmp_tasks_dir, monkeypat
     assert env["AGENT_ALLOW_MERGE"] == "1"
 
 
+def test_dispatch_codex_worker_env_maps_github_token_to_gh_token(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    import argparse
+
+    recorded: dict[str, object] = {}
+    secrets_path = tmp_path / ".bash_secrets"
+    secrets_path.write_text("export GITHUB_TOKEN=ghp_fromfile\n")
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 24680
+        stdin = _FakeStdin()
+
+    def fake_popen(*args, **kwargs):
+        recorded["env"] = kwargs.get("env", {})
+        return _FakeProc()
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(delegate, "_BASH_SECRETS_PATH", secrets_path)
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+
+    args = argparse.Namespace(
+        agent="codex",
+        task_id="codex-gh-token",
+        prompt="test",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=None,
+        hard_timeout=3600,
+        allow_merge=False,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    env = recorded["env"]
+    assert env["GH_TOKEN"] == "ghp_fromfile"
+    assert "GITHUB_TOKEN" not in env
+
+
+def test_dispatch_gemini_worker_env_strips_gh_token(
+    tmp_tasks_dir, monkeypatch,
+):
+    import argparse
+
+    recorded: dict[str, object] = {}
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 24680
+        stdin = _FakeStdin()
+
+    def fake_popen(*args, **kwargs):
+        recorded["env"] = kwargs.get("env", {})
+        return _FakeProc()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_parentgithub")
+    monkeypatch.setenv("GH_TOKEN", "ghp_parentgh")
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+
+    args = argparse.Namespace(
+        agent="gemini",
+        task_id="gemini-no-gh-token",
+        prompt="test",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=None,
+        hard_timeout=3600,
+        allow_merge=False,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    env = recorded["env"]
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+
+
 def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path, monkeypatch):
     import argparse
 


### PR DESCRIPTION
## Summary

Fixes #1751 — Codex/Claude/bridge dispatch subprocesses now inherit `GH_TOKEN` so `gh` commands work without per-brief `source ~/.bash_secrets` workarounds.

## Changes

- `delegate.py` maps `GITHUB_TOKEN` (from env or `~/.bash_secrets`) → `GH_TOKEN` for Codex/Claude/bridge only
- Gemini subprocess env strips both `GH_TOKEN` and `GITHUB_TOKEN` (security: GitHub creds don't reach Gemini's tool calls)
- `env_sanitize.py` allowlist updated: `GH_TOKEN` for codex/claude/bridge, NOT gemini
- Subprocess tests: Codex `gh auth status` works with mock `gh`; Gemini token absence verified

## Test plan

- [x] `pytest tests/test_agent_runtime_env_sanitize.py tests/test_delegate.py` — all pass
- [x] ruff clean
- [x] Commit hook (ruff + 62 tests)
- [x] `git diff --check`
- [ ] CI green

## Self-applying paradox

The Codex dispatch (`1751-dispatch-gh-auth`) that wrote this fix could not itself open the PR — its shell had no `GH_TOKEN`. Claude opened the PR inline. After this merges, the next dispatch will be able to `gh pr create` itself.

## Attribution

Code authored by Codex (gpt-5.5) via task `1751-dispatch-gh-auth`. PR created by Claude (process recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)