### PR TITLE
feat(delegate): default 2h hard_timeout + per-CLI silence detection (#1750)

### DIFF
--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -77,7 +77,9 @@ def _derived_task_status(task: dict[str, Any]) -> tuple[str, bool]:
 
 
 def list_delegate_tasks(
-    *, status: Literal["running", "done", "failed", "spawning", "all"] = "all", limit: int = 50
+    *,
+    status: Literal["running", "done", "failed", "timeout", "spawning", "all"] = "all",
+    limit: int = 50,
 ) -> dict[str, Any]:
     task_limit = min(max(1, int(limit)), 500)
     rows: list[dict[str, Any]] = []
@@ -145,7 +147,7 @@ def active_delegate_count() -> int:
 
 @router.get("/tasks")
 async def delegate_tasks(
-    status: Literal["running", "done", "failed", "spawning", "all"] = Query("all"),
+    status: Literal["running", "done", "failed", "timeout", "spawning", "all"] = Query("all"),
     limit: int = Query(50, ge=1, le=500),
 ):
     return await asyncio.to_thread(list_delegate_tasks, status=status, limit=limit)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -35,7 +35,7 @@ State files live at ``batch_state/tasks/<task-id>.json``. Format:
         "cli_version": str,
         "mode": str,
         "pid": int,
-        "status": "running" | "done" | "failed" | "rate_limited" | "crashed",
+        "status": "running" | "done" | "failed" | "timeout" | "rate_limited" | "crashed",
         "started_at": iso-8601 UTC,
         "finished_at": iso-8601 UTC | null,
         "duration_s": float | null,
@@ -154,6 +154,10 @@ def _inject_gh_token_for_agent(worker_env: dict[str, str], agent: str) -> None:
     )
 
 
+DEFAULT_HARD_TIMEOUT_S = 7200
+DEFAULT_SILENCE_TIMEOUT_S = 600
+
+
 def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
     """Return the primary checkout root that owns the shared .git dir."""
     git_path = repo_root / ".git"
@@ -213,6 +217,32 @@ def _write_state_atomic(path: Path, state: dict[str, Any]) -> None:
     tmp = path.with_suffix(f".json.tmp.{os.getpid()}")
     tmp.write_text(json.dumps(state, indent=2, default=str))
     os.replace(tmp, path)
+
+
+def _append_dispatch_event(event: str, **fields: Any) -> None:
+    """Append one delegate JSONL event without making telemetry fatal."""
+    payload = {
+        "ts": datetime.now(UTC).isoformat(),
+        "event": event,
+        **fields,
+    }
+    try:
+        _TASKS_DIR.mkdir(parents=True, exist_ok=True)
+        line = (json.dumps(payload, ensure_ascii=False, default=str) + "\n").encode("utf-8")
+        fd = os.open(
+            str(_TASKS_DIR / "dispatch_events.jsonl"),
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o644,
+        )
+        try:
+            os.write(fd, line)
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        print(
+            f"[delegate] WARNING: failed to write dispatch event: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
 
 
 def _read_state(path: Path) -> dict[str, Any] | None:
@@ -609,10 +639,13 @@ def _classify_final_status(
     cancelled: bool,
     rate_limited: bool,
     ok_outcome: bool,
+    timed_out: bool = False,
 ) -> str:
     """Map worker outcome flags to the persisted delegate task status."""
     if cancelled:
         return "cancelled"
+    if timed_out:
+        return "timeout"
     if rate_limited:
         return "rate_limited"
     if ok_outcome:
@@ -628,6 +661,7 @@ def _run_worker(
     cwd_str: str,
     model: str | None,
     hard_timeout: int,
+    silence_timeout: int = DEFAULT_SILENCE_TIMEOUT_S,
     effort: str | None = None,
 ) -> int:
     """Worker main loop. Invokes the runtime, updates the state file.
@@ -647,6 +681,7 @@ def _run_worker(
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
     from agent_runtime.errors import (
         AgentRuntimeError,
+        AgentStalledError,
         AgentTimeoutError,
         RateLimitedError,
     )
@@ -679,10 +714,12 @@ def _run_worker(
     response = ""
     returncode: int | None = None
     rate_limited = False
+    timed_out = False
     result = None
 
     cancelled = False
     try:
+        stdout_silence_timeout = silence_timeout if silence_timeout > 0 else None
         result = runtime_invoke(
             agent,
             prompt,
@@ -694,6 +731,7 @@ def _run_worker(
             tool_config=None,
             entrypoint="delegate",
             hard_timeout=hard_timeout,
+            stdout_silence_timeout=stdout_silence_timeout,
             effort=effort,
         )
         ok_outcome = result.ok
@@ -711,6 +749,11 @@ def _run_worker(
     except RateLimitedError as exc:
         rate_limited = True
         stderr_excerpt = str(exc)[:500]
+    except AgentStalledError as exc:
+        timed_out = True
+        stderr_excerpt = (
+            f"stdout_silence_timeout: {exc}"
+        )[:500]
     except AgentTimeoutError as exc:
         stderr_excerpt = f"hard_timeout: {exc}"[:500]
     except AgentRuntimeError as exc:
@@ -737,6 +780,7 @@ def _run_worker(
         cancelled=cancelled,
         rate_limited=rate_limited,
         ok_outcome=ok_outcome,
+        timed_out=timed_out,
     )
 
     final_state = _read_state(state_path) or {}
@@ -775,6 +819,22 @@ def _run_worker(
     })
     _write_state_atomic(state_path, final_state)
 
+    if timed_out:
+        _append_dispatch_event(
+            "dispatch_silence_timeout",
+            task_id=task_id,
+            agent=agent,
+            model=final_state.get("model"),
+            effort=final_state.get("effort"),
+            cwd=str(cwd),
+            pid=final_state.get("pid"),
+            status=final_status,
+            silence_timeout_s=silence_timeout,
+            hard_timeout_s=hard_timeout,
+            duration_s=round(duration_s, 3),
+            stderr_excerpt=stderr_excerpt,
+        )
+
     return 0 if ok_outcome else 1
 
 
@@ -790,6 +850,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     task_id = args.task_id
     state_path = _state_path(task_id)
     worktree_arg = getattr(args, "worktree", None)
+    silence_timeout = getattr(args, "silence_timeout", DEFAULT_SILENCE_TIMEOUT_S)
 
     if args.mode == "danger" and not worktree_arg:
         print(
@@ -887,6 +948,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "worktree_rebased": bool(worktree_telemetry.get("rebased")),
         "worktree_reused": bool(worktree_telemetry.get("reused")),
         "worktree_layout": worktree_layout,
+        "hard_timeout": args.hard_timeout,
+        "silence_timeout": silence_timeout,
         "pid": None,  # worker fills this
         "status": "spawning",
         "started_at": datetime.now(UTC).isoformat(),
@@ -936,6 +999,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "--mode", args.mode,
         "--cwd", cwd,
         "--hard-timeout", str(args.hard_timeout),
+        "--silence-timeout", str(silence_timeout),
     ]
     if args.model:
         cmd.extend(["--model", args.model])
@@ -1098,7 +1162,7 @@ def cmd_status(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 _TERMINAL_STATUSES = frozenset(
-    {"done", "failed", "rate_limited", "crashed", "cancelled"}
+    {"done", "failed", "timeout", "rate_limited", "crashed", "cancelled"}
 )
 
 
@@ -1132,6 +1196,8 @@ def cmd_wait(args: argparse.Namespace) -> int:
         if status in _TERMINAL_STATUSES:
             print(json.dumps(state, indent=2, default=str))
             # Exit code: 0 if done, 1 otherwise (failed/crashed/rate_limited)
+            if status == "timeout":
+                return 124
             return 0 if status == "done" else 1
 
         if deadline and time.monotonic() >= deadline:
@@ -1277,6 +1343,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
         cwd_str=args.cwd,
         model=args.model,
         hard_timeout=args.hard_timeout,
+        silence_timeout=args.silence_timeout,
         effort=args.effort,
     )
 
@@ -1300,6 +1367,9 @@ def build_parser() -> argparse.ArgumentParser:
             "  .venv/bin/python scripts/delegate.py list --status running\n\n"
             "Outputs:\n"
             "  Persists task state under batch_state/tasks/ and streams worker output to task-owned logs.\n\n"
+            "Timeouts:\n"
+            "  --hard-timeout is the absolute wall-clock fallback for the worker.\n"
+            "  --silence-timeout kills the agent CLI earlier when no stdout line arrives within the window; 0 disables it.\n\n"
             "Exit codes:\n"
             "  0 on successful command completion; non-zero on CLI misuse or worker/task failures.\n\n"
             "Related:\n"
@@ -1370,8 +1440,27 @@ def build_parser() -> argparse.ArgumentParser:
             "delegated subprocess. Default is off: AGENT_NO_MERGE=1 is set."
         ),
     )
-    d.add_argument("--hard-timeout", type=int, default=3600,
-                   help="Max wall-clock seconds for the worker (default: 3600)")
+    d.add_argument(
+        "--hard-timeout",
+        type=int,
+        default=DEFAULT_HARD_TIMEOUT_S,
+        help=(
+            "Absolute wall-clock seconds for the worker before the runtime "
+            f"hard-kills it (default: {DEFAULT_HARD_TIMEOUT_S}). "
+            "This is a fallback; --silence-timeout catches stdout-silent hangs sooner."
+        ),
+    )
+    d.add_argument(
+        "--silence-timeout",
+        type=int,
+        default=DEFAULT_SILENCE_TIMEOUT_S,
+        help=(
+            "Seconds without a subprocess stdout line before killing the agent "
+            "CLI and marking the task status='timeout' "
+            f"(default: {DEFAULT_SILENCE_TIMEOUT_S}; 0 disables). "
+            "--hard-timeout still applies as the absolute wall-clock fallback."
+        ),
+    )
     d.set_defaults(func=cmd_dispatch)
 
     # status
@@ -1397,7 +1486,7 @@ def build_parser() -> argparse.ArgumentParser:
     l = sub.add_parser("list", help="List tasks (with optional status filter)")
     l.add_argument("--status", default=None,
                    choices=["spawning", "running", "done", "failed",
-                            "rate_limited", "crashed", "cancelled"],
+                            "timeout", "rate_limited", "crashed", "cancelled"],
                    help="Optional status filter, e.g. running or failed.")
     l.set_defaults(func=cmd_list)
 
@@ -1413,7 +1502,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         choices=["low", "medium", "high", "xhigh", "max"],
     )
-    wk.add_argument("--hard-timeout", type=int, default=3600)
+    wk.add_argument("--hard-timeout", type=int, default=DEFAULT_HARD_TIMEOUT_S)
+    wk.add_argument("--silence-timeout", type=int, default=DEFAULT_SILENCE_TIMEOUT_S)
     wk.set_defaults(func=cmd_worker)
 
     return p

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -22,6 +24,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import delegate
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.result import ParseResult
+from agent_runtime.telemetry import InvocationTelemetry
 
 
 @pytest.fixture
@@ -77,7 +82,37 @@ def test_classify_final_status_prioritizes_cancelled_over_other_flags():
         cancelled=True,
         rate_limited=True,
         ok_outcome=True,
+        timed_out=True,
     ) == "cancelled"
+
+
+def test_dispatch_parser_timeout_defaults():
+    args = delegate.build_parser().parse_args([
+        "dispatch",
+        "--agent",
+        "codex",
+        "--task-id",
+        "defaults",
+        "--prompt",
+        "hi",
+    ])
+
+    assert args.hard_timeout == 7200
+    assert args.silence_timeout == 600
+
+
+def test_dispatch_help_documents_timeout_interaction(capsys):
+    parser = delegate.build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["dispatch", "--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "--hard-timeout" in captured.out
+    assert "--silence-timeout" in captured.out
+    assert "fallback" in captured.out
+    assert "0 disables" in captured.out
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +250,20 @@ def test_wait_returns_nonzero_on_failed(tmp_tasks_dir, capsys):
     )
     rc = delegate.cmd_wait(args)
     assert rc == 1  # nonzero for any non-done terminal status
+
+
+def test_wait_returns_124_on_task_timeout(tmp_tasks_dir, capsys):
+    path = delegate._state_path("wait-task-timeout")
+    delegate._write_state_atomic(path, {
+        "task_id": "wait-task-timeout",
+        "status": "timeout",
+    })
+    import argparse
+    args = argparse.Namespace(
+        task_id="wait-task-timeout", timeout=0, poll_interval=0.1,
+    )
+    rc = delegate.cmd_wait(args)
+    assert rc == 124
 
 
 def test_wait_timeout_returns_124(tmp_tasks_dir, capsys):
@@ -618,6 +667,160 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["model"] == "claude-opus-4-6"
     assert state["effort"] == "xhigh"
     assert state["cli_version"] == "2.1.89"
+
+
+def test_run_worker_silence_timeout_kills_silent_subprocess(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A stdout-silent CLI is SIGKILLed and persisted as status=timeout."""
+    from agent_runtime import runner as runtime_runner
+
+    state_path = delegate._state_path("silent-timeout")
+    returncode_file = tmp_path / "returncode.txt"
+    delegate._write_state_atomic(state_path, {"task_id": "silent-timeout"})
+
+    class SleepingAdapter:
+        name = "claude"
+        default_model = "fixture-model"
+        supported_modes = frozenset({"read-only"})
+
+        def build_invocation(self, **kwargs: Any) -> InvocationPlan:
+            return InvocationPlan(
+                cmd=["/bin/sh", "-c", "sleep 60"],
+                cwd=Path(kwargs["cwd"]),
+            )
+
+        def parse_response(self, *, returncode: int, **_kwargs: Any) -> ParseResult:
+            returncode_file.write_text(str(returncode), encoding="utf-8")
+            return ParseResult(ok=False, response="", stderr_excerpt="")
+
+        def liveness_signal_paths(self, _plan: InvocationPlan) -> tuple[Path, ...]:
+            return ()
+
+    monkeypatch.setattr(runtime_runner, "has_headroom", lambda *_args: (True, ""))
+    monkeypatch.setattr(runtime_runner, "write_record", lambda _record: None)
+    monkeypatch.setattr(
+        runtime_runner,
+        "resolve_invocation_telemetry",
+        lambda **_kwargs: InvocationTelemetry(
+            model="fixture-model",
+            effort="unknown",
+            cli_version="fixture",
+        ),
+    )
+    monkeypatch.setitem(runtime_runner._ADAPTER_CACHE, "claude", SleepingAdapter())
+
+    started = time.monotonic()
+    rc = delegate._run_worker(
+        task_id="silent-timeout",
+        agent="claude",
+        prompt="hi",
+        mode="read-only",
+        cwd_str=str(tmp_path),
+        model=None,
+        hard_timeout=30,
+        silence_timeout=1,
+        effort=None,
+    )
+    elapsed = time.monotonic() - started
+
+    state = delegate._read_state(state_path)
+    events = [
+        json.loads(line)
+        for line in (tmp_tasks_dir / "dispatch_events.jsonl").read_text().splitlines()
+    ]
+
+    assert rc == 1
+    assert elapsed < 6
+    assert int(returncode_file.read_text("utf-8")) == -signal.SIGKILL
+    assert state is not None
+    assert state["status"] == "timeout"
+    assert "stdout_silence_timeout" in (state["stderr_excerpt"] or "")
+    assert events[-1]["event"] == "dispatch_silence_timeout"
+    assert events[-1]["task_id"] == "silent-timeout"
+    assert events[-1]["status"] == "timeout"
+    assert events[-1]["silence_timeout_s"] == 1
+
+
+def test_run_worker_periodic_stdout_avoids_silence_timeout(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Scaled version of the 70-minute case: stdout before each silence window."""
+    from agent_runtime import runner as runtime_runner
+
+    state_path = delegate._state_path("periodic-stdout")
+    delegate._write_state_atomic(state_path, {"task_id": "periodic-stdout"})
+
+    class ChatteringAdapter:
+        name = "claude"
+        default_model = "fixture-model"
+        supported_modes = frozenset({"read-only"})
+
+        def build_invocation(self, **kwargs: Any) -> InvocationPlan:
+            script = (
+                "i=0; "
+                "while [ $i -lt 5 ]; do "
+                "echo tick-$i; "
+                "i=$((i + 1)); "
+                "sleep 0.2; "
+                "done"
+            )
+            return InvocationPlan(
+                cmd=["/bin/sh", "-c", script],
+                cwd=Path(kwargs["cwd"]),
+            )
+
+        def parse_response(
+            self,
+            *,
+            stdout: str,
+            returncode: int,
+            **_kwargs: Any,
+        ) -> ParseResult:
+            return ParseResult(
+                ok=returncode == 0,
+                response=stdout,
+                stderr_excerpt=None,
+            )
+
+        def liveness_signal_paths(self, _plan: InvocationPlan) -> tuple[Path, ...]:
+            return ()
+
+    monkeypatch.setattr(runtime_runner, "has_headroom", lambda *_args: (True, ""))
+    monkeypatch.setattr(runtime_runner, "write_record", lambda _record: None)
+    monkeypatch.setattr(
+        runtime_runner,
+        "resolve_invocation_telemetry",
+        lambda **_kwargs: InvocationTelemetry(
+            model="fixture-model",
+            effort="unknown",
+            cli_version="fixture",
+        ),
+    )
+    monkeypatch.setitem(runtime_runner._ADAPTER_CACHE, "claude", ChatteringAdapter())
+
+    rc = delegate._run_worker(
+        task_id="periodic-stdout",
+        agent="claude",
+        prompt="hi",
+        mode="read-only",
+        cwd_str=str(tmp_path),
+        model=None,
+        hard_timeout=10,
+        silence_timeout=1,
+        effort=None,
+    )
+
+    state = delegate._read_state(state_path)
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["response_chars"] > 0
+    assert not (tmp_tasks_dir / "dispatch_events.jsonl").exists()
 
 
 def test_dispatch_rejects_danger_without_worktree(tmp_tasks_dir, capsys):

--- a/tests/test_delegate_api.py
+++ b/tests/test_delegate_api.py
@@ -80,6 +80,21 @@ def test_tasks_status_filter(tmp_path, monkeypatch):
     assert data["tasks"][0]["status"] == "done"
 
 
+def test_tasks_timeout_status_is_distinct_from_failed(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+    _write_task(tasks_dir / "timeout.json", _task_payload("timeout", status="timeout"))
+    _write_task(tasks_dir / "failed.json", _task_payload("failed", status="failed"))
+
+    timeout_response = client.get("/api/delegate/tasks?status=timeout")
+    failed_response = client.get("/api/delegate/tasks?status=failed")
+
+    assert timeout_response.status_code == 200
+    assert failed_response.status_code == 200
+    assert [task["task_id"] for task in timeout_response.json()["tasks"]] == ["timeout"]
+    assert [task["task_id"] for task in failed_response.json()["tasks"]] == ["failed"]
+
+
 def test_task_detail_truncates_large_result(tmp_path, monkeypatch):
     tasks_dir = tmp_path / "tasks"
     monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)


### PR DESCRIPTION
## Summary

Fixes #1750. Two changes to `scripts/delegate.py`:

1. **Default `--hard-timeout` raised from 3600s → 7200s** (2 hours). Long ingestions and multi-step refactors don't fit in 1h.
2. **New `--silence-timeout SECONDS` flag** (default 600 = 10 min). Watchdog wraps subprocess stdout; if no line for `silence_timeout`, kills with SIGKILL, emits `dispatch_silence_timeout` JSONL event, status='timeout' (distinct from 'failed'). Hard timeout is now the fallback for "still emitting but stuck."

Reference impl: ported the per-writer-timeout pattern from `scripts/build/v7_build.py` (PR #1743).

## Test plan

- [x] `pytest tests/test_delegate.py tests/test_delegate_api.py tests/test_agent_runtime_effort.py` — 63 passed
- [x] ruff clean
- [x] Pre-commit hook clean
- [ ] CI green

## Self-applying paradox (again)

The Codex dispatch (`1750-delegate-timeout`) that wrote this fix could not itself open the PR — its shell still has no `GH_TOKEN`. After PR #1752 (#1751 — GH_TOKEN pass-through) merges, the next dispatch will be able to `gh pr create` itself. Claude opened this PR inline (process recovery).

## Attribution

Code authored by Codex (gpt-5.5) via task `1750-delegate-timeout`. PR created by Claude (process recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)