### PR TITLE
fix(delegate): bump --silence-timeout default 600s → 1800s (#1758)

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -110,6 +110,28 @@ Both wrappers support `--dry-run`, which writes the prompt and a
 `batch_state/tasks/<task-id>.json` preview without launching the
 delegate worker.
 
+## Silence-timeout vs hard-timeout
+
+`delegate.py dispatch` has two watchdogs with different jobs.
+`--hard-timeout` is the absolute wall-clock fallback for the worker.
+`--silence-timeout` is narrower: it kills the agent CLI when no stdout
+line arrives within the configured window, then marks the task
+`status="timeout"`.
+
+The default silence timeout is 1800 seconds. This is intentionally
+longer than the old 600-second watchdog because substantive Codex
+dispatches can be quiet for more than 10 minutes during thinking
+phases, multi-file refactors, or long test runs. The #1725
+`1725-verbatim-quoting` dispatch was killed after 12 minutes of stdout
+silence with most work already complete and the last phase still
+salvageable; that is the failure mode this default avoids.
+
+Use `--silence-timeout 600` when you want the tighter 10-minute
+operator watchdog. OAuth or CLI hangs should still show up within
+minutes, while the hard timeout remains the final wall-clock cap.
+Use `--silence-timeout 0` only when stdout silence is expected and the
+hard timeout alone is acceptable.
+
 ## When to use channels vs `ask-*`
 
 | Situation | Use |

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -155,7 +155,7 @@ def _inject_gh_token_for_agent(worker_env: dict[str, str], agent: str) -> None:
 
 
 DEFAULT_HARD_TIMEOUT_S = 7200
-DEFAULT_SILENCE_TIMEOUT_S = 600
+DEFAULT_SILENCE_TIMEOUT_S = 1800
 
 
 def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
@@ -1369,7 +1369,8 @@ def build_parser() -> argparse.ArgumentParser:
             "  Persists task state under batch_state/tasks/ and streams worker output to task-owned logs.\n\n"
             "Timeouts:\n"
             "  --hard-timeout is the absolute wall-clock fallback for the worker.\n"
-            "  --silence-timeout kills the agent CLI earlier when no stdout line arrives within the window; 0 disables it.\n\n"
+            "  --silence-timeout kills the agent CLI earlier when no stdout line arrives within the window.\n"
+            "    Default is 1800s to tolerate long Codex thinking/test phases; pass 600 for a tighter watchdog; 0 disables it.\n\n"
             "Exit codes:\n"
             "  0 on successful command completion; non-zero on CLI misuse or worker/task failures.\n\n"
             "Related:\n"
@@ -1382,7 +1383,14 @@ def build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="command", required=True)
 
     # dispatch
-    d = sub.add_parser("dispatch", help="Fire a task, return immediately")
+    def _dispatch_help_formatter(prog: str) -> argparse.HelpFormatter:
+        return argparse.HelpFormatter(prog, max_help_position=36, width=120)
+
+    d = sub.add_parser(
+        "dispatch",
+        help="Fire a task, return immediately",
+        formatter_class=_dispatch_help_formatter,
+    )
     d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude"],
                    help="Agent to run for the task: codex, gemini, or claude.")
     d.add_argument("--task-id", required=True,
@@ -1447,18 +1455,22 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Absolute wall-clock seconds for the worker before the runtime "
             f"hard-kills it (default: {DEFAULT_HARD_TIMEOUT_S}). "
-            "This is a fallback; --silence-timeout catches stdout-silent hangs sooner."
+            "--silence-timeout defaults to 1800s and catches stdout-silent "
+            "hangs sooner."
         ),
     )
     d.add_argument(
         "--silence-timeout",
         type=int,
+        metavar="SECS",
         default=DEFAULT_SILENCE_TIMEOUT_S,
         help=(
             "Seconds without a subprocess stdout line before killing the agent "
             "CLI and marking the task status='timeout' "
-            f"(default: {DEFAULT_SILENCE_TIMEOUT_S}; 0 disables). "
-            "--hard-timeout still applies as the absolute wall-clock fallback."
+            f"(default: {DEFAULT_SILENCE_TIMEOUT_S}s; 0 disables). "
+            "The default tolerates long Codex thinking/test phases; pass 600 "
+            "for a tighter watchdog. --hard-timeout still applies as the "
+            "absolute wall-clock fallback."
         ),
     )
     d.set_defaults(func=cmd_dispatch)

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -98,6 +98,36 @@ def test_dispatch_parser_timeout_defaults():
     ])
 
     assert args.hard_timeout == 7200
+    assert args.silence_timeout == 1800
+
+
+def test_silence_timeout_default_is_1800():
+    args = delegate.build_parser().parse_args([
+        "dispatch",
+        "--agent",
+        "codex",
+        "--task-id",
+        "defaults",
+        "--prompt",
+        "hi",
+    ])
+
+    assert args.silence_timeout == 1800
+
+
+def test_explicit_silence_timeout_override_still_works():
+    args = delegate.build_parser().parse_args([
+        "dispatch",
+        "--agent",
+        "codex",
+        "--task-id",
+        "override",
+        "--prompt",
+        "hi",
+        "--silence-timeout",
+        "600",
+    ])
+
     assert args.silence_timeout == 600
 
 
@@ -111,6 +141,8 @@ def test_dispatch_help_documents_timeout_interaction(capsys):
     assert exc_info.value.code == 0
     assert "--hard-timeout" in captured.out
     assert "--silence-timeout" in captured.out
+    assert "1800s" in captured.out
+    assert "pass 600" in captured.out
     assert "fallback" in captured.out
     assert "0 disables" in captured.out
 


### PR DESCRIPTION
## Summary

Closes #1758. Default `--silence-timeout` raised from 600s (10 min) to 1800s (30 min). Operators who need a tighter watchdog can pass `--silence-timeout 600` explicitly.

## Why

The 600s default fired false positives on substantive Codex dispatches:
- `1725-verbatim-quoting` (yesterday) — killed at 12 min with 2/3 phases committed and 1 phase 170 lines dirty
- `1761-trace-capture` (today, ~9:00 CEST) — killed at 600s with 11 files of trace-capture plumbing in flight (saved by orchestrator via worktree resume to `1761-trace-capture-resume` with explicit `--silence-timeout 1800`)

Substantive Codex tasks have multi-minute thinking phases and long test runs that produce 10+ minutes of stdout silence as **normal** behavior. 1800s still catches genuine OAuth hangs (those manifest in minutes-not-hours) but tolerates real work.

## Changes

- `scripts/delegate.py` — argparse default raised + `--help` text rewritten to document the trade-off and explicit override
- `tests/test_delegate.py` — regressions: default-is-1800 + explicit-override-still-works
- `docs/best-practices/agent-bridge.md` — new "Silence-timeout vs hard-timeout" section with #1725 incident as evidence

## Validation

- `pytest tests/ -k "silence_timeout or delegate" -v` → **88 passed**
- `delegate.py dispatch --help` shows `1800s` as the default
- `ruff check scripts/delegate.py` clean

Closes #1758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)