### PR TITLE
fix(trace-capture): prevent contaminated tool traces (#1768)

### DIFF
--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -22,8 +22,8 @@ to land because it has the most special-case logic:
   used by the pipeline reviewers to restrict which MCP tools are
   accessible. Critical for audit gate correctness.
 
-- **``--output-format text``**: Forces plain-text output for machine
-  parsing.
+- **``--output-format stream-json``**: Forces machine-readable output so
+  tool calls can be captured from the CLI trace.
 
 Mode handling:
 - ``read-only``: No sandbox flag (Claude Code has no explicit sandbox
@@ -263,9 +263,14 @@ class ClaudeAdapter:
 
         # Output format
         output_format = str(tc.get("output_format", "stream-json"))
+        if output_format != "stream-json":
+            raise ValueError(
+                "ClaudeAdapter requires tool_config output_format='stream-json' "
+                "so tool-call trace parsing fails closed instead of degrading "
+                f"to text output; got {output_format!r}"
+            )
         cmd.extend(["--output-format", output_format])
-        if output_format == "stream-json":
-            cmd.append("--verbose")
+        cmd.append("--verbose")
 
         if discussion_readonly:
             cmd.extend([
@@ -332,12 +337,10 @@ class ClaudeAdapter:
         effective_stdout = stream_response if events else stdout.strip()
 
         # Claude Code 2.1.117 does not document a dedicated rate-limit exit
-        # code in `claude --help`, and this runtime currently requests plain
-        # text (`--output-format text`), not machine-readable JSON. The safest
-        # remaining signal is a rate-limit phrase on stderr from a failed or
-        # empty-response call. We intentionally ignore stdout here: successful
-        # Claude responses can legitimately discuss "rate limited" without the
-        # task being blocked.
+        # code in `claude --help`. The safest remaining signal is a
+        # rate-limit phrase on stderr from a failed or empty-response call.
+        # We intentionally ignore stdout here: successful Claude responses can
+        # legitimately discuss "rate limited" without the task being blocked.
         usable_response = bool(effective_stdout)
         failed_call = returncode != 0 or not usable_response
         rate_limited = failed_call and bool(_RATE_LIMIT_RE.search(stderr or ""))

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -375,7 +375,7 @@ class CodexAdapter:
         if plan is not None:
             rollout_trace = self._read_latest_rollout_trace(plan)
         trace_events = parse_json_events(
-            "\n".join(part for part in (stdout, stderr, rollout_trace) if part),
+            rollout_trace,
             source="codex",
             logger=_logger,
         )

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -36,6 +36,7 @@ Issue: #1184
 from __future__ import annotations
 
 import contextlib
+import json as _json
 import logging
 import os
 import re
@@ -199,6 +200,7 @@ class GeminiAdapter:
                 "using adapter default (#1396 follow-up)",
                 effort,
             )
+        self._reset_per_invocation_state(plan_cwd=cwd)
         gemini_bin = shutil.which("gemini") or "gemini"
 
         cmd: list[str] = [
@@ -477,44 +479,14 @@ class GeminiAdapter:
         are swallowed — this is a last-resort fallback, not a primary
         code path.
         """
-        import json as _json
-        import time as _time
-
         try:
-            chats_dir = Path.home() / ".gemini" / "tmp" / plan.cwd.name / "chats"
-            if not chats_dir.exists():
-                return ""
-
-            candidates = sorted(
-                chats_dir.glob("session-*.json"),
-                key=lambda p: p.stat().st_mtime,
-                reverse=True,
+            session_file = self._select_session_for_plan(
+                plan, call_start_time=call_start_time,
             )
-            if not candidates:
+            if session_file is None:
                 return ""
 
-            # Pick the newest file whose mtime is after the call start.
-            # If call_start_time is unknown, trust the newest file.
-            newest: Path | None = None
-            if call_start_time is None:
-                newest = candidates[0]
-            else:
-                # Compare wall-clock (file mtime) to monotonic (call_start).
-                # Convert monotonic → wall by adding (time.time() - monotonic())
-                # at call time — but we don't have that delta. Approximation:
-                # any file modified in the last 2 hours of wall clock is
-                # acceptable if it's also the newest. This guards against
-                # picking a multi-day-old orphan file.
-                two_hours_ago = _time.time() - 2 * 3600
-                for c in candidates:
-                    if c.stat().st_mtime >= two_hours_ago:
-                        newest = c
-                        break
-
-            if newest is None:
-                return ""
-
-            data = _json.loads(newest.read_text("utf-8"))
+            data = _json.loads(session_file.read_text("utf-8"))
             messages = data.get("messages", [])
             if not isinstance(messages, list):
                 return ""
@@ -546,29 +518,128 @@ class GeminiAdapter:
             return ""
 
     def _read_latest_session_trace(self, plan: InvocationPlan) -> str:
-        """Read the newest Gemini session JSON for tool-call telemetry."""
-        import json as _json
-        import time as _time
-
+        """Read this invocation's Gemini session JSON for tool-call telemetry."""
         try:
-            chats_dir = Path.home() / ".gemini" / "tmp" / plan.cwd.name / "chats"
-            if not chats_dir.exists():
+            session_file = self._select_session_for_plan(plan, call_start_time=None)
+            if session_file is None:
                 return ""
-            candidates = sorted(
-                chats_dir.glob("session-*.json"),
-                key=lambda path: path.stat().st_mtime,
-                reverse=True,
+            data = _json.loads(
+                session_file.read_text(encoding="utf-8", errors="replace")
             )
-            if not candidates:
-                return ""
-            two_hours_ago = _time.time() - 2 * 3600
-            for candidate in candidates:
-                if candidate.stat().st_mtime >= two_hours_ago:
-                    data = _json.loads(candidate.read_text(encoding="utf-8", errors="replace"))
-                    return _json.dumps(data, ensure_ascii=False)
-            return ""
+            return _json.dumps(data, ensure_ascii=False)
         except Exception:
             return ""
+
+    def _reset_per_invocation_state(self, *, plan_cwd: Path) -> None:
+        """Snapshot pre-existing Gemini sessions before launching a call."""
+        self._session_snapshot = self._snapshot_preexisting_sessions(plan_cwd)
+        self._bound_session = None
+
+    def _snapshot_preexisting_sessions(self, cwd: Path) -> set[Path]:
+        chats_dir = Path.home() / ".gemini" / "tmp" / cwd.name / "chats"
+        try:
+            return set(chats_dir.glob("session-*.json"))
+        except OSError:
+            return set()
+
+    def _select_session_for_plan(
+        self,
+        plan: InvocationPlan,
+        *,
+        call_start_time: float | None = None,
+    ) -> Path | None:
+        """Return the Gemini session JSON scoped to this invocation, if any."""
+        import time as _time
+
+        snapshot: set[Path] = getattr(self, "_session_snapshot", None) or set()
+        bound: Path | None = getattr(self, "_bound_session", None)
+        if bound is not None and bound.exists() and self._session_matches_plan(bound, plan):
+            return bound
+
+        chats_dir = Path.home() / ".gemini" / "tmp" / plan.cwd.name / "chats"
+        try:
+            candidates = list(chats_dir.glob("session-*.json"))
+        except OSError:
+            return None
+
+        new_candidates = [path for path in candidates if path not in snapshot]
+        if not new_candidates and not snapshot:
+            # Direct unit tests may construct InvocationPlan by hand instead
+            # of calling build_invocation. Preserve that path while production
+            # calls use the snapshot to avoid stale-session contamination.
+            new_candidates = candidates
+        if not new_candidates:
+            return None
+
+        if call_start_time is not None:
+            two_hours_ago = _time.time() - 2 * 3600
+            new_candidates = [
+                path for path in new_candidates
+                if self._mtime(path) >= two_hours_ago
+            ]
+            if not new_candidates:
+                return None
+
+        for candidate in sorted(new_candidates, key=self._mtime, reverse=True):
+            if self._session_matches_plan(candidate, plan):
+                self._bound_session = candidate
+                return candidate
+        return None
+
+    @staticmethod
+    def _mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    def _session_matches_plan(self, session_path: Path, plan: InvocationPlan) -> bool:
+        """Return True when a Gemini session contains this invocation's prompt."""
+        expected = (plan.stdin_payload or "").rstrip()
+        if not expected:
+            return True
+
+        try:
+            data = _json.loads(session_path.read_text(encoding="utf-8", errors="replace"))
+            messages = data.get("messages", [])
+            if not isinstance(messages, list):
+                return False
+
+            user_texts: list[str] = []
+            for msg in messages:
+                if not isinstance(msg, dict) or msg.get("type") != "user":
+                    continue
+                content = msg.get("content")
+                if isinstance(content, str):
+                    user_texts.append(content)
+                elif isinstance(content, list):
+                    parts: list[str] = []
+                    for part in content:
+                        if isinstance(part, dict) and isinstance(part.get("text"), str):
+                            parts.append(part["text"])
+                    if parts:
+                        user_texts.append("\n".join(parts))
+
+            for text in user_texts:
+                normalized = text.rstrip()
+                if normalized == expected:
+                    return True
+                if self._prompt_fingerprint_matches(expected, normalized):
+                    return True
+            return False
+        except Exception:
+            return False
+
+    @staticmethod
+    def _prompt_fingerprint_matches(expected: str, observed: str) -> bool:
+        """Check stable first/last prompt fragments without storing new metadata."""
+        if len(expected) <= 400:
+            return expected in observed
+        # This is a fallback for session formats that wrap the prompt text.
+        # Snapshot filtering already removes pre-existing sessions; the
+        # first/last fragments are an extra guard against concurrent new
+        # sessions in the same repo, not the only binding signal.
+        return expected[:200] in observed and expected[-200:] in observed
 
     def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
         """Return filesystem paths the watchdog should poll for mtime bumps.

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1724,6 +1724,10 @@ def _runtime_tool_config(agent_label: str) -> dict[str, Any]:
         codex_tools = build_mcp_tool_config("codex", mcp_servers=["sources"])
         if codex_tools:
             tool_config.update(codex_tools)
+    assert tool_config.get("output_format") == "stream-json", (
+        "tool-call writers must keep output_format='stream-json'; "
+        f"got {tool_config.get('output_format')!r}"
+    )
     return tool_config
 
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1425,7 +1425,9 @@ def test_invoke_hard_timeout_recovers_from_session_file(tmp_path, monkeypatch):
     import json as _json
     from unittest.mock import MagicMock
 
-    # Set up a fake $HOME with a Gemini session file for the test project.
+    # Set up fake Gemini state for the test project. The session file is
+    # created by the mocked Popen below, after build_invocation snapshots
+    # pre-existing files.
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
@@ -1435,14 +1437,6 @@ def test_invoke_hard_timeout_recovers_from_session_file(tmp_path, monkeypatch):
 
     chats_dir = fake_home / ".gemini" / "tmp" / "learn-ukrainian" / "chats"
     chats_dir.mkdir(parents=True)
-    (chats_dir / "session-latest.json").write_text(_json.dumps({
-        "sessionId": "x",
-        "messages": [
-            {"type": "user", "content": [{"text": "write a module"}]},
-            {"type": "gemini",
-             "content": "### Skeleton\n\n## Section 1\n...full response..."},
-        ],
-    }), "utf-8")
 
     # Mock Popen so it never really spawns a subprocess. We simulate
     # a hang by NOT setting returncode on the first poll and then
@@ -1471,6 +1465,17 @@ def test_invoke_hard_timeout_recovers_from_session_file(tmp_path, monkeypatch):
 
     mock_kill_tree = MagicMock()
 
+    def _popen_after_session_start(*args, **kwargs):
+        (chats_dir / "session-latest.json").write_text(_json.dumps({
+            "sessionId": "x",
+            "messages": [
+                {"type": "user", "content": [{"text": "write a module"}]},
+                {"type": "gemini",
+                 "content": "### Skeleton\n\n## Section 1\n...full response..."},
+            ],
+        }), "utf-8")
+        return mock_proc
+
     # has_headroom mock: always OK.
     # should_kill mock: fire hard_timeout on every call.
     with patch(
@@ -1480,7 +1485,7 @@ def test_invoke_hard_timeout_recovers_from_session_file(tmp_path, monkeypatch):
         "agent_runtime.runner.write_record",
     ), patch(
         "agent_runtime.runner.subprocess.Popen",
-        return_value=mock_proc,
+        side_effect=_popen_after_session_start,
     ), patch(
         "agent_runtime.runner.should_kill",
         side_effect=lambda *a, **kw: "hard_timeout",
@@ -2285,10 +2290,21 @@ def test_gemini_parse_response_recovers_from_session_file(tmp_path, monkeypatch)
     project_cwd = tmp_path / "learn-ukrainian"
     project_cwd.mkdir()
 
-    # Create a realistic session file with a user message + two gemini
-    # messages (the second one being the final answer).
     chats_dir = fake_home / ".gemini" / "tmp" / "learn-ukrainian" / "chats"
     chats_dir.mkdir(parents=True)
+
+    plan = adapter.build_invocation(
+        prompt="write a sonnet",
+        mode="read-only",
+        cwd=project_cwd,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    # Create a realistic session file after build_invocation has snapshotted
+    # pre-existing files.
     session_data = {
         "sessionId": "abc-def",
         "startTime": "2026-04-10T20:00:00Z",
@@ -2301,16 +2317,6 @@ def test_gemini_parse_response_recovers_from_session_file(tmp_path, monkeypatch)
     }
     (chats_dir / "session-2026-04-10T20-00-abcdef.json").write_text(
         _json.dumps(session_data), "utf-8",
-    )
-
-    plan = adapter.build_invocation(
-        prompt="x",
-        mode="read-only",
-        cwd=project_cwd,
-        model=None,
-        task_id=None,
-        session_id=None,
-        tool_config=None,
     )
 
     # Simulate a hard-timeout kill: stdout empty, returncode -9 (SIGKILL).

--- a/tests/test_runner_tool_calls.py
+++ b/tests/test_runner_tool_calls.py
@@ -145,7 +145,7 @@ def test_gemini_adapter_parses_session_file_tool_calls(
     assert result.tool_calls[0]["arguments"] == {"words": ["ранок"]}
 
 
-def test_codex_adapter_parses_tool_calls(tmp_path: Path) -> None:
+def test_codex_adapter_ignores_stdout_tool_calls(tmp_path: Path) -> None:
     output_file = tmp_path / "codex-output.txt"
     output_file.write_text("Final answer.", encoding="utf-8")
     stdout = "\n".join([
@@ -163,14 +163,10 @@ def test_codex_adapter_parses_tool_calls(tmp_path: Path) -> None:
 
     assert result.ok is True
     assert result.session_id == "00000000-0000-0000-0000-000000000001"
-    assert [call["name"] for call in result.tool_calls] == [
-        "mcp__sources__verify_words",
-        "mcp__sources__search_heritage",
-    ]
-    assert result.tool_calls[0]["arguments"] == {"words": ["мати"]}
+    assert result.tool_calls == []
 
 
-def test_codex_adapter_parses_stderr_tool_calls(tmp_path: Path) -> None:
+def test_codex_adapter_ignores_stderr_tool_calls(tmp_path: Path) -> None:
     output_file = tmp_path / "codex-output.txt"
     output_file.write_text("Final answer.", encoding="utf-8")
 
@@ -182,8 +178,7 @@ def test_codex_adapter_parses_stderr_tool_calls(tmp_path: Path) -> None:
     )
 
     assert result.ok is True
-    assert result.tool_calls[0]["name"] == "mcp__sources__verify_words"
-    assert result.tool_calls[0]["arguments"] == {"words": ["ніч"]}
+    assert result.tool_calls == []
 
 
 def test_codex_adapter_parses_matching_rollout_tool_calls(
@@ -241,21 +236,42 @@ def test_tool_call_output_summary_truncation() -> None:
     assert summary.endswith("[...truncated]")
 
 
-def test_tool_call_arguments_are_bounded(tmp_path: Path) -> None:
+def test_tool_call_arguments_are_bounded(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    today = datetime.now(UTC)
+    rollout_dir = (
+        home
+        / ".codex"
+        / "sessions"
+        / f"{today.year:04d}"
+        / f"{today.month:02d}"
+        / f"{today.day:02d}"
+    )
+    rollout_dir.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
     output_file = tmp_path / "codex-output.txt"
     output_file.write_text("Final answer.", encoding="utf-8")
-    stdout = (
-        '{"type":"tool_call","name":"Write",'
-        '"arguments":{"file_path":"lesson.md","content":"'
-        + ("x" * 10_000)
-        + '"},"output":"ok"}'
+    prompt = "Write the module."
+    adapter = CodexAdapter()
+    adapter._reset_per_invocation_state()
+    rollout = rollout_dir / "rollout-test.jsonl"
+    rollout.write_text(
+        "\n".join([
+            '{"type":"event_msg","payload":{"type":"user_message","message":"Write the module."}}',
+            '{"type":"response_item","payload":{"type":"function_call","name":"Write",'
+            '"arguments":{"file_path":"lesson.md","content":"'
+            + ("x" * 10_000)
+            + '"},"call_id":"call-1"}}',
+        ]),
+        encoding="utf-8",
     )
 
-    result = CodexAdapter().parse_response(
-        stdout=stdout,
+    result = adapter.parse_response(
+        stdout="",
         stderr="",
         returncode=0,
         output_file=output_file,
+        plan=InvocationPlan(cmd=["codex"], cwd=tmp_path, stdin_payload=prompt),
     )
 
     assert result.ok is True

--- a/tests/test_trace_capture_no_contamination.py
+++ b/tests/test_trace_capture_no_contamination.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.adapters.claude import ClaudeAdapter
+from agent_runtime.adapters.codex import CodexAdapter
+from agent_runtime.adapters.gemini import GeminiAdapter
+
+
+def test_gemini_session_does_not_leak_across_invocations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "learn-ukrainian"
+    chats = home / ".gemini" / "tmp" / cwd.name / "chats"
+    chats.mkdir(parents=True)
+    cwd.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("GEMINI_AUTH_MODE", "subscription")
+
+    previous = chats / "session-previous.json"
+    previous.write_text(
+        json.dumps({
+            "messages": [
+                {"type": "user", "content": [{"text": "PREVIOUS PLAN"}]},
+                {
+                    "type": "tool_call",
+                    "name": "mcp__sources__stale",
+                    "arguments": {"query": "old"},
+                },
+                {"type": "gemini", "content": "Previous answer."},
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    prompt = "CURRENT PLAN: write this module."
+    adapter = GeminiAdapter()
+    plan = adapter.build_invocation(
+        prompt=prompt,
+        mode="read-only",
+        cwd=cwd,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    current = chats / "session-current.json"
+    current.write_text(
+        json.dumps({
+            "messages": [
+                {"type": "user", "content": [{"text": prompt}]},
+                {
+                    "type": "tool_call",
+                    "name": "mcp__sources__current",
+                    "arguments": {"query": "new"},
+                },
+                {"type": "gemini", "content": "Current answer."},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    newer_mtime = time.time() + 10
+    os.utime(previous, (newer_mtime, newer_mtime))
+
+    trace = adapter._read_latest_session_trace(plan)
+
+    assert "mcp__sources__current" in trace
+    assert "mcp__sources__stale" not in trace
+
+
+def test_codex_prompt_echo_does_not_appear_in_tool_calls(tmp_path: Path) -> None:
+    output_file = tmp_path / "codex-output.txt"
+    output_file.write_text("Final answer.", encoding="utf-8")
+    stderr = "\n".join([
+        "User prompt:",
+        '{"type":"tool_call","name":"mcp__sources__prompt_echo",'
+        '"arguments":{"query":"example from instructions"}}',
+    ])
+
+    result = CodexAdapter().parse_response(
+        stdout="",
+        stderr=stderr,
+        returncode=0,
+        output_file=output_file,
+    )
+
+    assert result.ok is True
+    assert result.tool_calls == []
+
+
+def test_claude_text_output_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="output_format='stream-json'"):
+        ClaudeAdapter().build_invocation(
+            prompt="hello",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={"cmd_prefix": ["true"], "output_format": "text"},
+        )
+
+
+def test_codex_rollout_trace_still_records_real_tool_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    today = datetime.now(UTC)
+    rollout_dir = (
+        home
+        / ".codex"
+        / "sessions"
+        / f"{today.year:04d}"
+        / f"{today.month:02d}"
+        / f"{today.day:02d}"
+    )
+    rollout_dir.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    output_file = tmp_path / "codex-output.txt"
+    output_file.write_text("Final answer.", encoding="utf-8")
+    prompt = "Write the module."
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt=prompt,
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    (rollout_dir / "rollout-current.jsonl").write_text(
+        "\n".join([
+            json.dumps({
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": prompt},
+            }),
+            json.dumps({
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "mcp__sources__verify_words",
+                    "arguments": {"words": ["день"]},
+                    "call_id": "call-1",
+                },
+            }),
+        ]),
+        encoding="utf-8",
+    )
+
+    result = adapter.parse_response(
+        stdout="",
+        stderr='{"type":"tool_call","name":"mcp__sources__prompt_echo"}',
+        returncode=0,
+        output_file=output_file,
+        plan=plan,
+    )
+
+    assert [call["name"] for call in result.tool_calls] == [
+        "mcp__sources__verify_words"
+    ]


### PR DESCRIPTION
## Summary

Closes #1768. Pre-bakeoff Claude Opus xhigh validation found 3 HIGH-RISK trace-capture bugs in #1761/#1767 that would systematically taint bakeoff signal in opposite directions on different writers. All 3 fixed.

## Fixes

1. **Gemini cross-contamination** — \`scripts/agent_runtime/adapters/gemini.py\` now snapshots pre-existing session files in \`build_invocation\` and ignores them during trace recovery. Picks newest non-snapshot file and validates against current prompt content (mirrors codex's \`_rollout_matches_plan\` pattern).

2. **Codex prompt-echo absorption** — \`scripts/agent_runtime/adapters/codex.py\` now reads tool calls ONLY from the bound rollout trace (the authoritative, prompt-echo-free source). Stdout/stderr no longer contribute to \`Result.tool_calls\`. Stderr/stdout still parsed for rate-limit detection.

3. **Claude format-fragility** — \`scripts/agent_runtime/adapters/claude.py\` rejects non-\`stream-json\` output format at invocation build time. Pipeline invariant check at \`linear_pipeline.py\` ensures the format isn't overridden by callers.

## Tests

\`tests/test_trace_capture_no_contamination.py\` (NEW) — regression tests for all 3 bugs:
- \`test_gemini_session_does_not_leak_across_invocations\`
- \`test_codex_prompt_echo_does_not_appear_in_tool_calls\`
- \`test_claude_text_output_fails_closed\`

## Validation

- New regression tests pass
- \`tests/test_runner_tool_calls.py\` + \`tests/test_detect_tool_theatre_integration.py\` regression
- \`193 passed\` broader adapter suite
- \`140 passed\` pre-commit
- V7 dry-run smoke clean
- Adversarial Claude review (\`1768-fix-review\`) — no BLOCK findings

\`Reviewed-By: claude-opus-4-7 (1768-fix-review)\` trailer in commit.

Closes #1768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)