### PR TITLE
fix(ruth.yaml): correct YAML parse error so plan-review audit can run (#1771)

### DIFF
--- a/curriculum/l2-uk-en/plans/ruth.yaml
+++ b/curriculum/l2-uk-en/plans/ruth.yaml
@@ -18,7 +18,9 @@ immersion: "100% Ukrainian"
 
 key_concepts:
   - term: "Руська мова"
-    description: "The administrative and literary language of Ukrainian lands in the GDL and Polish-Lithuanian Commonwealth"
+    description: >-
+      The administrative and literary language of Ukrainian lands in the GDL
+      and Polish-Lithuanian Commonwealth
   - term: "Проста мова"
     description: '"Simple/vernacular language" — the written form closer to actual spoken Ukrainian'
   - term: "Диглосія"
@@ -110,6 +112,36 @@ phases:
       - name: "Твори Григорія Сковороди"
         note: "Philosophy"
 
+  - id: 5
+    name_uk: "«Мовна ідентичність» — Народна мова та граматична традиція"
+    name_en: "Linguistic Identity — Vernacular Traditions & Grammars"
+    modules: 105-116
+    focus:
+      - "Early printing (Fedorovych Bukvar, 1574)"
+      - "Lexicography as identity (Zyzaniy, Berynda, Synonyma)"
+      - "Grammar in exile (Uzhevych in Paris)"
+      - "Vernacular literature (interludes, baroque poetry, fables)"
+      - "Practical registers (letter-writing, medical manuals)"
+      - "Administrative charters (XIV-XVI century)"
+    rationale: >-
+      These texts document Ukrainian linguistic SELF-AWARENESS — not literature
+      about identity but the infrastructure of identity: dictionaries, grammars,
+      primers, and everyday writing.
+    source_issue: "#673"
+    primary_sources:
+      - name: "Буквар Федоровича (1574)"
+        url: "http://litopys.org.ua/fedorovych/bf.htm"
+      - name: "Лексис Зизанія (1596)"
+        url: "http://litopys.org.ua/zyzlex/zyz.htm"
+      - name: "Лексикон Беринди (1627)"
+        url: "http://litopys.org.ua/berlex/be.htm"
+      - name: "Граматика Ужевича"
+        url: "http://litopys.org.ua/uzhgram/uz.htm"
+      - name: "Українські інтермедії"
+        url: "http://litopys.org.ua/ukrinter/int.htm"
+      - name: "Грамоти XIV ст."
+        url: "http://litopys.org.ua/gramxiv/grb.htm"
+
 timeline_key_texts:
   - year: 1529
     text: "Перший Литовський статут"
@@ -179,33 +211,6 @@ linguistic_evolution:
     high: "Church Slavonic (religious texts)"
     middle: "Chancery Ruthenian (legal documents)"
     low: "Prosta Mova (vernacular literature)"
-
-  - id: 5
-    name_uk: "«Мовна ідентичність» — Народна мова та граматична традиція"
-    name_en: "Linguistic Identity — Vernacular Traditions & Grammars"
-    modules: 105-116
-    focus:
-      - "Early printing (Fedorovych Bukvar, 1574)"
-      - "Lexicography as identity (Zyzaniy, Berynda, Synonyma)"
-      - "Grammar in exile (Uzhevych in Paris)"
-      - "Vernacular literature (interludes, baroque poetry, fables)"
-      - "Practical registers (letter-writing, medical manuals)"
-      - "Administrative charters (XIV-XVI century)"
-    rationale: "These texts document Ukrainian linguistic SELF-AWARENESS — not literature about identity but the infrastructure of identity: dictionaries, grammars, primers, and everyday writing."
-    source_issue: "#673"
-    primary_sources:
-      - name: "Буквар Федоровича (1574)"
-        url: "http://litopys.org.ua/fedorovych/bf.htm"
-      - name: "Лексис Зизанія (1596)"
-        url: "http://litopys.org.ua/zyzlex/zyz.htm"
-      - name: "Лексикон Беринди (1627)"
-        url: "http://litopys.org.ua/berlex/be.htm"
-      - name: "Граматика Ужевича"
-        url: "http://litopys.org.ua/uzhgram/uz.htm"
-      - name: "Українські інтермедії"
-        url: "http://litopys.org.ua/ukrinter/int.htm"
-      - name: "Грамоти XIV ст."
-        url: "http://litopys.org.ua/gramxiv/grb.htm"
 
 activity_types:
   # See ISSUE-502-activity-spec.yaml for full schemas


### PR DESCRIPTION
## Summary

Closes #1771. Fixes the YAML parse error in \`curriculum/l2-uk-en/plans/ruth.yaml\` that was blocking the plan-review audit (PR #1769 / #1765).

## Changes

Moved the misplaced phase 5 block from under \`linguistic_evolution\` into the top-level \`phases\` list. Folded two long scalars so yamllint passes.

## Validation

- \`python -c 'import yaml; yaml.safe_load(open("curriculum/l2-uk-en/plans/ruth.yaml"))'\` passes
- \`yamllint curriculum/l2-uk-en/plans/ruth.yaml\` passes
- \`git diff --check\` passes

## Note (separate follow-up)

Running \`check_plan.py curriculum/l2-uk-en/plans/ruth.yaml\` now reaches the script but exits with \`No modules found for level curriculum/l2-uk-en/plans/ruth.yaml\`. This is a deeper schema mismatch — \`check_plan.py\` expects a level slug + module-plan schema, but \`ruth.yaml\` is a TRACK-level plan with its own schema (\`phases\`, \`linguistic_evolution\`, etc.). Filing as a separate issue so this PR stays focused.

Closes #1771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)