### PR TITLE
fix(prompts): add HARD STOP rule to prevent meta-summary after artifacts (post-bakeoff fix)

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -257,3 +257,13 @@ like `correct_order`, indices are zero-based.
 ## Knowledge Packet
 
 {KNOWLEDGE_PACKET}
+
+## HARD STOP RULE
+
+After emitting all required `<plan_reasoning>` blocks, the 4 artifact fences
+(`module.md`, `activities.yaml`, `vocabulary.yaml`, `resources.yaml`), and the
+`<end_gate>` block, STOP. Do not write a summary, status report, completion
+confirmation, or any meta-commentary about what you did. The 4 fences are the
+deliverable. Anything after the `<end_gate>` block will be discarded by the
+parser. If you feel the urge to write "Module drafted under..." or "All forms
+verified...", DON'T. The verification is in the `<end_gate>` block, not in prose.

--- a/tests/test_writer_prompt_structured_cot.py
+++ b/tests/test_writer_prompt_structured_cot.py
@@ -58,6 +58,19 @@ def test_writer_prompt_locks_structured_end_gate_nodes() -> None:
         assert node in prompt
 
 
+def test_writer_prompt_has_hard_stop_rule_after_artifacts() -> None:
+    prompt = _writer_template()
+
+    assert "## HARD STOP RULE" in prompt
+    assert "After emitting all required `<plan_reasoning>` blocks" in prompt
+    assert "the 4 artifact fences" in prompt
+    assert "Do not write a summary, status report, completion" in prompt
+    assert "confirmation, or any meta-commentary about what you did" in prompt
+    assert "Anything after the `<end_gate>` block will be discarded by the" in prompt
+    assert "parser. If you feel the urge to write" in prompt
+    assert "The verification is in the `<end_gate>` block, not in prose" in prompt
+
+
 def test_plan_reasoning_parser_preserves_nested_xml_body() -> None:
     output = """<plan_reasoning section="intro">
 <word_budget>80 words.</word_budget>


### PR DESCRIPTION
## Summary

Bakeoff at \`audit/bakeoff-2026-05-07/\` failed because Claude wrote a 474-byte meta-summary ("Module a1-020 drafted under Phase 4 protocol... Four \`<plan_reasoning>\` blocks, four artifact fences, and one \`<end_gate>\` block emitted...") **instead of** the 4 required artifact fences. Trace-capture worked perfectly (9 tool calls, 5 verify_words, 0 theatre). The prompt was the issue.

The new structured CoT scaffolding from #1772 (Edits 1, 4, 5, 6) added so much output structure that the writer drifted into meta-reporting after the artifact fences. This locks down output discipline.

## Changes

- \`scripts/build/phases/linear-write.md\` — appended final \`## HARD STOP RULE\` section. Forbids summaries, status reports, completion confirmations, or any meta-commentary after \`<end_gate>\`. Explicit "DON'T write 'Module drafted under...' or 'All forms verified...'".
- \`tests/test_writer_prompt_structured_cot.py\` — regression coverage asserting the HARD STOP RULE section exists.

## Validation

- \`pytest tests/test_writer_prompt_structured_cot.py -v\` → 8 passed
- V7 dry-run smoke clean
- \`git diff --check\` clean

## Next step after merge

Re-fire the bakeoff with explicit \`--silence-timeout 3600\` (1h, vs the 30min default) since the bakeoff's serial 3-writer execution legitimately has long silent stretches between writers. Last attempt died at 1801s because Gemini's slow startup + Claude's failure cascade exceeded the 1800s default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)