### PR TITLE
feat(ab-discuss): tier-2 warm-cache via bridge entrypoint + per-agent session_id (#1782)

### DIFF
--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -42,6 +42,7 @@ import shlex
 import subprocess
 import sys
 import time
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -1058,6 +1059,7 @@ def _handle_discuss(args) -> int:
             AgentUnavailableError,
             RateLimitedError,
         )
+        from agent_runtime.registry import get_agent_entry
         from agent_runtime.runner import invoke as runtime_invoke
     except ImportError as e:
         print(f"❌ agent_runtime unavailable: {e}", file=sys.stderr)
@@ -1130,6 +1132,8 @@ def _handle_discuss(args) -> int:
     print(f"   root message: {root_id[:12]} / thread {correlation_id[:12]}")
     print()
 
+    discussion_session_ids: dict[str, str] = {}
+
     def _invoke_one(
         agent_name: str, prompt_text: str, round_idx: int
     ) -> tuple[str, str, bool]:
@@ -1141,6 +1145,23 @@ def _handle_discuss(args) -> int:
         and the dashboard couldn't tell them apart.
         """
         try:
+            resume_policy = get_agent_entry(agent_name).get("resume_policy", "never")
+        except KeyError:
+            resume_policy = "never"
+
+        session_id_to_pass: str | None = None
+        is_new_session = False
+        if resume_policy == "bridge_only":
+            if agent_name not in discussion_session_ids:
+                discussion_session_ids[agent_name] = str(uuid.uuid4())
+                is_new_session = True
+            session_id_to_pass = discussion_session_ids[agent_name]
+
+        tool_config = dict(_DISCUSSION_READONLY_TOOL_CONFIG)
+        if is_new_session:
+            tool_config["is_new_session"] = True
+
+        try:
             result = runtime_invoke(
                 agent_name,
                 prompt_text,
@@ -1149,8 +1170,9 @@ def _handle_discuss(args) -> int:
                 task_id=f"discuss-{correlation_id[:8]}-r{round_idx}-{agent_name}",
                 # TODO(#1701): keep this flag in the sanitized child-env
                 # allowlist when the runner switches to build_agent_env().
-                tool_config=_DISCUSSION_READONLY_TOOL_CONFIG,
-                entrypoint="delegate",
+                tool_config=tool_config,
+                entrypoint="bridge",
+                session_id=session_id_to_pass,
                 hard_timeout=900,
             )
         except RateLimitedError as exc:

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -301,7 +301,11 @@ def test_discuss_fails_and_warns_when_agent_writes_worktree(
 
     def _write_attempt(agent: str, *_args, **kwargs) -> Result:
         assert kwargs["mode"] == "read-only"
-        assert kwargs["tool_config"] == {"discussion_readonly": True}
+        # tool_config now also carries `is_new_session: True` on round 1 for
+        # resumable agents (#1782 tier-2 warm-cache fix). Test the load-bearing
+        # contract — that discuss participants run in read-only — not the
+        # exact dict shape.
+        assert kwargs["tool_config"].get("discussion_readonly") is True
         (tmp_path / "unauthorized.txt").write_text("write attempt\n", encoding="utf-8")
         return Result(
             ok=True,

--- a/tests/test_channels_discuss_resume.py
+++ b/tests/test_channels_discuss_resume.py
@@ -1,0 +1,133 @@
+"""Tier 2 warm-cache fix for ab discuss - closes #1782 sub-task 1."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _channels, _cli, _db
+
+
+@pytest.fixture(autouse=True)
+def isolate_db(tmp_path):
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
+        "ai_agent_bridge._db.DB_PATH", db_file
+    ):
+        _db.init_db()
+        yield db_file
+
+
+def _run_cli(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["ab", *argv]):
+        try:
+            _cli.main()
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+    return 0
+
+
+def _successful_result(agent: str) -> MagicMock:
+    result = MagicMock()
+    result.ok = True
+    result.response = f"[reply from {agent}] [AGREE]"
+    return result
+
+
+def test_discuss_passes_session_id_for_resumable_agents(monkeypatch):
+    """Claude + Gemini get a session_id; Codex does not (registry policy)."""
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    captured_invokes = []
+
+    def fake_runtime_invoke(agent, _prompt, **kwargs):
+        captured_invokes.append((agent, kwargs))
+        return _successful_result(agent)
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_runtime_invoke)
+
+    exit_code = _run_cli(
+        [
+            "discuss",
+            "shared",
+            "topic",
+            "--with",
+            "claude,gemini,codex",
+            "--max-rounds",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+    by_agent = {agent: [] for agent in ("claude", "gemini", "codex")}
+    for agent, kwargs in captured_invokes:
+        by_agent[agent].append(kwargs)
+
+    assert all(len(calls) == 2 for calls in by_agent.values())
+    for agent in ("claude", "gemini"):
+        first, second = by_agent[agent]
+        assert first["session_id"] is not None
+        assert second["session_id"] == first["session_id"]
+        assert first["tool_config"]["is_new_session"] is True
+        assert "is_new_session" not in second["tool_config"]
+
+    for call in by_agent["codex"]:
+        assert call["session_id"] is None
+        assert "is_new_session" not in call["tool_config"]
+
+    assert all(kwargs["entrypoint"] == "bridge" for _, kwargs in captured_invokes)
+
+
+def test_discuss_entrypoint_is_bridge_not_delegate(monkeypatch):
+    """The entrypoint switch is the load-bearing change for the resume policy gate."""
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    captured_entrypoints = []
+
+    def fake_runtime_invoke(agent, _prompt, **kwargs):
+        captured_entrypoints.append(kwargs["entrypoint"])
+        return _successful_result(agent)
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_runtime_invoke)
+
+    exit_code = _run_cli(
+        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "2"]
+    )
+
+    assert exit_code == 0
+    assert captured_entrypoints
+    assert set(captured_entrypoints) == {"bridge"}
+
+
+def test_discuss_unknown_agent_defaults_to_no_resume(monkeypatch):
+    """Agents not in registry get resume_policy='never' equivalent - no session_id."""
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    monkeypatch.setattr(_channels, "VALID_AGENTS", (*_channels.VALID_AGENTS, "mystery"))
+    monkeypatch.setattr(
+        _channels,
+        "VALID_POST_AGENTS",
+        (*_channels.VALID_POST_AGENTS, "mystery"),
+    )
+    captured_invokes = []
+
+    def fake_runtime_invoke(agent, _prompt, **kwargs):
+        captured_invokes.append((agent, kwargs))
+        return _successful_result(agent)
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_runtime_invoke)
+
+    exit_code = _run_cli(
+        ["discuss", "shared", "topic", "--with", "mystery", "--max-rounds", "1"]
+    )
+
+    assert exit_code == 0
+    assert len(captured_invokes) == 1
+    assert captured_invokes[0][0] == "mystery"
+    assert captured_invokes[0][1]["session_id"] is None
+    assert captured_invokes[0][1]["entrypoint"] == "bridge"


### PR DESCRIPTION
## Summary

- Switch `ab discuss` from `entrypoint="delegate"` to `"bridge"` in `_channels_cli.py:1153`
- Add per-(agent, correlation_id) `session_id` store; round 1 generates fresh UUID with `is_new_session=True`, round 2+ reuses for `--resume`
- Gate session_id on `agent_runtime.registry.get_agent_entry(agent).resume_policy == "bridge_only"` — Claude/Gemini opt-in, Codex stays fresh
- Add `tests/test_channels_discuss_resume.py` with 3 regression tests

## Why

`ab discuss` was paying full Anthropic prompt-cache creation cost on every round for every participant. `ab ask-claude` already uses session_id (`_claude.py:117-123`) but `ab discuss` did not. Asymmetric.

The constraint Codex caught in the architectural review: `runner.py:288-324` enforces `resume_policy` per-agent + per-entrypoint. Codex CLI is `policy="never"`; Claude and Gemini are `policy="bridge_only"`. Naive "thread session_id through" would crash because `ab discuss` uses `entrypoint="delegate"`. Hence the entrypoint switch + per-agent gate.

Closes sub-task 1 of #1782 (persistent agent listeners umbrella). Tier 3 (full daemon listeners) deferred until pending Multi-UI ADR ACCEPTED.

## Test plan

- [x] \`pytest tests/test_channels_discuss_resume.py -v\` — 3 tests pass
- [x] \`ruff check\` clean
- [x] Pre-commit hooks pass
- [ ] CI green
- [ ] Manual smoke (post-merge): \`ab discuss architecture "test brief" --with claude,gemini,codex --max-rounds 2\` → check Anthropic API logs for cache hit on round-2 Claude call
- [ ] Round-2 root-truncation bug expected to be fixed as side effect (warm cache → root preserved)

🤖 Generated with [Codex via delegate.py dispatch]

Co-Authored-By: Codex (gpt-5.5)