### PR TITLE
fix(codex): mirror start-codex.sh flags so workspace-write writers can use MCP + add --search to launcher

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -794,12 +794,36 @@ class CodexAdapter:
     def _mode_flags(mode: str) -> list[str]:
         """Map runtime mode → codex exec sandbox flags.
 
+        Mirrors ``start-codex.sh`` (the canonical interactive launcher) for
+        any non-read-only mode. The launcher unconditionally passes
+        ``--dangerously-bypass-approvals-and-sandbox`` AND
+        ``--enable multi_agent`` for every interactive Codex session on
+        this project; the same flags are required for headless writers
+        because Codex's ``--full-auto`` (the previous workspace-write
+        mapping) silently blocks localhost MCP server connections,
+        leaving writers unable to call ``verify_words``, ``search_text``,
+        and other MCP-backed tools. Empirically verified 2026-05-08:
+        codex with ``--full-auto`` returned
+        "Tool unavailable: ``mcp__sources__verify_words`` is not
+        available in this session"; the same prompt with the bypass
+        flag set called the tool successfully.
+
+        The runtime ``mode`` parameter is still retained for gating in
+        higher layers; at the codex CLI level workspace-write and danger
+        produce the same flag set because Codex has no distinct
+        "workspace-write + MCP-allowed" mode. This is the cost of
+        Codex's coarser sandbox model; worktree isolation is the actual
+        security boundary for headless dispatches.
+
         Matches the mapping in _codex.py::_codex_bridge_flags and
         dispatch.py::_codex_dispatch_flags for consistency during migration.
         """
-        if mode == "danger":
-            return ["--dangerously-bypass-approvals-and-sandbox"]
-        if mode == "workspace-write":
-            return ["--full-auto"]
-        # "read-only" default
-        return ["-s", "read-only"]
+        if mode == "read-only":
+            return ["-s", "read-only"]
+        # workspace-write and danger both need the bypass flag for MCP
+        # access. multi_agent is on by default to match start-codex.sh.
+        return [
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--enable",
+            "multi_agent",
+        ]

--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -87,13 +87,27 @@ def _codex_dispatch_mode(agent: str) -> str:
 
 
 def _codex_dispatch_flags(agent: str) -> list[str]:
-    """Translate Codex dispatch mode to CLI flags."""
+    """Translate Codex dispatch mode to CLI flags.
+
+    Mirrors ``start-codex.sh`` for any non-read-only mode. ``--full-auto``
+    (the previous workspace-write mapping) is undocumented in
+    ``codex exec --help`` and silently blocks localhost MCP server
+    connections — verified empirically 2026-05-08, see commit
+    ``fix(codex-adapter): mirror start-codex.sh flags`` for the modern
+    agent_runtime adapter mirror of this same fix. This legacy V6
+    dispatch path is fixed in parity so v6 re-runs do not surface the
+    same MCP-blocked-Codex bug.
+    """
     mode = _codex_dispatch_mode(agent)
-    if mode == "danger":
-        return ["--dangerously-bypass-approvals-and-sandbox"]
-    if mode == "workspace-write":
-        return ["--full-auto"]
-    return ["-s", "read-only"]
+    if mode == "read-only" or mode == "safe":
+        return ["-s", "read-only"]
+    # workspace-write and danger both need the bypass flag for MCP access.
+    # multi_agent matches start-codex.sh defaults.
+    return [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--enable",
+        "multi_agent",
+    ]
 
 
 def _codex_runtime_mode(agent: str) -> str:

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -913,8 +913,12 @@ def _build_tool_instructions(writer: str) -> str:
 
     For Codex writers, loads shell-command tool instructions from
     scripts/tools/codex_tool_instructions.md instead of MCP tool references.
-    Codex runs via `codex exec --full-auto` and can execute arbitrary Python
-    via subprocess, so it gets direct shell commands instead of MCP JSON-RPC.
+    Codex runs via `codex exec` with the project's standard sandbox-bypass
+    flags (mirrors start-codex.sh) and can execute arbitrary Python via
+    subprocess, so it gets direct shell commands instead of MCP JSON-RPC.
+    The previous comment said `--full-auto`; that flag is undocumented in
+    `codex exec --help` and was found 2026-05-08 to silently block
+    localhost MCP server connections.
     Issue: #1194
     """
     # Codex uses shell commands, not MCP — load from dedicated markdown file
@@ -4899,9 +4903,13 @@ def step_write(level: str, module_num: int, slug: str,
             mcp_tools=use_tools, allowed_tools=CLAUDE_WRITER_TOOLS if use_tools else None,
         )
     elif writer in ("codex", "codex-tools"):
-        # Codex uses workspace-write sandbox (--full-auto) so it can run
-        # the shell-command verification tools injected into the prompt.
-        # No MCP tools — Codex verifies via subprocess Python calls.
+        # Codex runs with the project's standard sandbox-bypass flags
+        # (mirrors start-codex.sh) so it can run the shell-command
+        # verification tools injected into the prompt and reach the
+        # localhost sources MCP server when allowed. The legacy comment
+        # said `--full-auto`; that flag silently blocks localhost MCP
+        # (verified 2026-05-08). No MCP tools used here — Codex verifies
+        # via subprocess Python calls.
         # Issue: #1194
         ok, raw = dispatch_agent(
             prompt, agent="codex-tools" if use_tools else "codex", phase="write",

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR"
 CODEX_TARGET="${CODEX_TARGET:-worktree}"
 CODEX_ARGS=()
-CODEX_FLAGS=(--dangerously-bypass-approvals-and-sandbox)
+CODEX_FLAGS=(--dangerously-bypass-approvals-and-sandbox --search)
 
 if [ "${CODEX_ENABLE_MULTI_AGENT:-1}" != "0" ]; then
     CODEX_FLAGS+=(--enable multi_agent)
@@ -33,6 +33,7 @@ Learn Ukrainian Codex launcher:
  - runs Codex in .worktrees/codex-interactive by default
  - use --main only when intentionally running in the primary checkout
  - always adds --dangerously-bypass-approvals-and-sandbox
+ - always adds --search (live web search; user-policy 2026-05-08)
  - enables Codex multi-agent support by default
  - set CODEX_ENABLE_MULTI_AGENT=0 to disable multi-agent support
  - forwards all other arguments to codex unchanged

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -274,13 +274,37 @@ def test_codex_adapter_mode_flags_read_only():
 
 
 def test_codex_adapter_mode_flags_workspace_write():
-    assert CodexAdapter._mode_flags("workspace-write") == ["--full-auto"]
+    # Mirrors start-codex.sh — --full-auto silently blocked localhost MCP
+    # server connections, leaving writers unable to call verify_words etc.
+    # (verified empirically 2026-05-08). workspace-write now uses the same
+    # flags as the interactive launcher.
+    assert CodexAdapter._mode_flags("workspace-write") == [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--enable",
+        "multi_agent",
+    ]
 
 
 def test_codex_adapter_mode_flags_danger():
+    # workspace-write and danger map to the same flags at the codex CLI
+    # layer because Codex has no "workspace-write + MCP-allowed" mode.
+    # The runtime mode parameter still differentiates them in higher layers.
     assert CodexAdapter._mode_flags("danger") == [
-        "--dangerously-bypass-approvals-and-sandbox"
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--enable",
+        "multi_agent",
     ]
+
+
+def test_codex_adapter_mode_flags_workspace_write_and_danger_are_equivalent():
+    """Codex CLI has no distinct workspace-write + MCP-allowed mode.
+
+    Regression for 2026-05-08 finding: --full-auto blocks localhost MCP.
+    If a future Codex CLI version adds a real workspace-write mode that
+    permits MCP, this test should be updated and the two flag sets can
+    diverge.
+    """
+    assert CodexAdapter._mode_flags("workspace-write") == CodexAdapter._mode_flags("danger")
 
 
 def test_codex_adapter_build_invocation_read_only(tmp_path):
@@ -354,7 +378,10 @@ def test_codex_adapter_build_invocation_workspace_write(tmp_path):
         session_id=None,
         tool_config=None,
     )
-    assert "--full-auto" in plan.cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" in plan.cmd
+    assert "--enable" in plan.cmd
+    assert "multi_agent" in plan.cmd
+    assert "--full-auto" not in plan.cmd  # legacy flag must not regress
     assert "gpt-5.5-mini" in plan.cmd  # model override honored
 
 


### PR DESCRIPTION
## Summary

Three commits, all on the same root cause: pipeline-Codex was configured differently from interactive-Codex (`start-codex.sh`), causing the bakeoff-2026-05-07-retry result of 0 real tool calls + 2 theatre violations on the codex-tools writer.

| Commit | Scope |
|---|---|
| `bfd30710e6` | `agent_runtime` adapter — workspace-write maps to launcher flags so MCP works |
| `f721c2c322` | Legacy V6 path parity (`dispatch.py` + stale `v6_build.py` comments) |
| `1ba8ad6b3c` | Add `--search` to `start-codex.sh` per user-policy 2026-05-08 |

## Root cause (verified empirically 2026-05-08)

`--full-auto` (the previous workspace-write mapping) is undocumented in `codex exec --help` and silently blocks localhost MCP server connections. Direct test:

```
codex exec --full-auto -m gpt-5.5 'Use mcp__sources__verify_words to verify "снідати"'
→ "Tool unavailable: mcp__sources__verify_words is not available in this session"
```

After the fix:

```
codex exec --dangerously-bypass-approvals-and-sandbox --enable multi_agent ...
→ "Batch verification: 1 words / Found: 1/1 / **снідати** — FOUND (1 match): снідати(verb)"
```

This explains the bakeoff Codex result. The bakeoff signal on Codex writer-discipline is **invalid** until re-run with this fix.

## What this changes

`scripts/agent_runtime/adapters/codex.py:_mode_flags`:
- `read-only` → unchanged (`-s read-only`)
- `workspace-write` → was `["--full-auto"]`, now `["--dangerously-bypass-approvals-and-sandbox", "--enable", "multi_agent"]` (mirrors `start-codex.sh:20-23`)
- `danger` → was just the bypass flag, now also `--enable multi_agent` for parity

`scripts/build/dispatch.py:_codex_dispatch_flags` (LEGACY V6, dead code per audit but kept consistent):
- Same mapping change as the modern adapter

`scripts/build/v6_build.py` (LEGACY):
- Two stale comments referencing `--full-auto` updated.

`start-codex.sh:20`:
- `--search` added to default `CODEX_FLAGS` per user policy.

## Codex audit (where else does this live)

| Location | Status |
|---|---|
| `start-codex.sh` (canonical reference) | ✅ now has all three: bypass + multi_agent + search |
| `scripts/agent_runtime/adapters/codex.py` | ✅ mirrors launcher (no --search, see limitation below) |
| `scripts/ai_agent_bridge/_codex.py` | ✅ no direct flag construction — routes through fixed adapter |
| `scripts/build/dispatch.py` | ✅ parity fix applied (dead code but consistent) |
| `scripts/build/v6_build.py` | ✅ comments updated |

## Important limitation

`--search` is a top-level `codex` flag — `codex exec --search` returns `error: unexpected argument '--search' found`. The headless agent_runtime adapter cannot enable web_search via `--search`, and the deprecated/removed `web_search_*` features mean there is currently no `codex exec` equivalent. Headless writers and dispatches will not have web search until Codex CLI restores a stable feature flag for the exec path. This is a Codex CLI limitation, not a project bug.

## Test plan

- [x] `pytest tests/test_agent_runtime.py` — 125/125 pass (added one new regression test asserting workspace-write == danger flag-equivalence as a regression sentinel for the --full-auto reintroduction)
- [x] `ruff check` clean on all changed files
- [x] Empirical: codex with workspace-write + MCP config now returns real VESUM lookup instead of "Tool unavailable"
- [x] `bash -n start-codex.sh` — syntax OK
- [ ] CI green
- [ ] Manual smoke (post-merge): re-fire bakeoff codex-tools writer alone — expect non-zero `tool_calls_total` in `audit/bakeoff-*/gpt55.write.jsonl`

## Pre-existing test note

`tests/test_dispatch.py::TestDispatchAgent::test_gemini_dispatch` fails locally when `GEMINI_API_KEY` is set in the env (test expects auth_mode=`subscription`, gets `api`). Pre-existing on main, not introduced by this PR. Pre-commit hook ran with `GEMINI_API_KEY=` unset to avoid the false positive on the `dispatch.py` change that triggers affected-file test discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)