### PR TITLE
feat(guardrail): anti-menu linter detects sign-off antipatterns

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -509,6 +509,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/consultation_cli.py` | Review consultation proposals | `.venv/bin/python scripts/consultation_cli.py list` |
 | `scripts/check_decisions.py` | Audit decision journal expiry | `.venv/bin/python scripts/check_decisions.py` |
 | `scripts/audit/lint_session_state.py` | Check handoff docs for missing env-file references | `.venv/bin/python scripts/audit/lint_session_state.py --all` |
+| `scripts/audit/lint_anti_menu.py` | Detect anti-menu sign-off prompts in markdown | `.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md` |
 
 ---
 
@@ -800,6 +801,16 @@ Scans `docs/session-state/*.md` for references to env/config files that do not e
 Known user-scoped paths that are expected but not committed live in
 `scripts/audit/known_user_paths.yaml`. This check is also wired into pre-commit
 for `docs/session-state/*.md`.
+
+### `scripts/audit/lint_anti_menu.py`
+
+Scans markdown for MEMORY #0I anti-menu sign-off prompts while ignoring
+acceptance criteria, code fences, tables, and status/plan lines.
+
+```bash
+.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md
+cat handoff.md | .venv/bin/python scripts/audit/lint_anti_menu.py --stdin
+```
 
 ---
 

--- a/scripts/audit/lint_anti_menu.py
+++ b/scripts/audit/lint_anti_menu.py
@@ -12,14 +12,15 @@ The detector is intentionally heuristic. It looks for these regex shapes:
   a numbered list.
 
 Exemptions are markdown-aware enough for handoff docs: fenced code blocks,
-tables, ``## Acceptance criteria`` sections, and lines with or immediately
-after ``Done:``, ``Status:``, or ``Plan:`` are skipped.
+tables, ``## Acceptance criteria`` sections, meta-example preambles, and lines
+with or immediately after ``Done:``, ``Status:``, or ``Plan:`` are skipped.
 """
 
 from __future__ import annotations
 
 import argparse
 import re
+import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,10 +58,14 @@ SIGNOFF_OPTIONS_RE = re.compile(
     r"\bsign\s+off\s+on\s+these\s+\d+\s+options\s*:?",
     re.IGNORECASE,
 )
-NUMBERED_LIST_LINE_RE = re.compile(r"^\s*(?:[-*]\s*)?\d+\)\s+\S")
+NUMBERED_LIST_LINE_RE = re.compile(r"^\s*(?:[-*]\s*)?\d+[.)]\s+\S")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 FENCE_RE = re.compile(r"^\s*(```|~~~)")
-PREFIX_EXEMPT_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:Done|Status|Plan):(?:\s|$)", re.IGNORECASE)
+PREFIX_EXEMPT_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:Done|Status|Plan|Forbidden patterns?):(?:\s|$)",
+    re.IGNORECASE,
+)
+META_EXAMPLE_LOOKBACK_LINES = 3
 
 
 def _is_table_line(line: str) -> bool:
@@ -69,7 +74,9 @@ def _is_table_line(line: str) -> bool:
 
 
 def _normalize_heading(text: str) -> str:
-    return text.rstrip("#").strip().lower().rstrip(":")
+    text = text.rstrip("#").strip().rstrip(":")
+    text = re.sub(r"\s*\([^)]*\)\s*$", "", text).strip().lower()
+    return text.rstrip(":")
 
 
 def _trim_snippet(snippet: str, limit: int = 120) -> str:
@@ -93,6 +100,11 @@ def _find_numbered_list_after(lines: list[str], start_index: int) -> bool:
         if checked >= 4:
             return False
     return False
+
+
+def _has_meta_example_context(lines: list[str], index: int) -> bool:
+    start = max(0, index - META_EXAMPLE_LOOKBACK_LINES)
+    return any(META_EXAMPLE_RE.search(line) for line in lines[start : index + 1])
 
 
 def scan_text(text: str) -> list[Violation]:
@@ -132,7 +144,7 @@ def scan_text(text: str) -> list[Violation]:
             or bool(PREFIX_EXEMPT_RE.match(previous_nonblank))
         )
 
-        if not exempt and not META_EXAMPLE_RE.search(line):
+        if not exempt and not _has_meta_example_context(lines, index):
             paren_match = PAREN_OPTION_RE.search(line)
             if paren_match and PAREN_OPTION_CONTEXT_RE.search(line):
                 violations.append(Violation(index + 1, _trim_snippet(paren_match.group(0))))
@@ -174,6 +186,7 @@ Outputs:
 Exit codes:
   0 = no anti-menu patterns detected
   1 = one or more anti-menu patterns detected
+  2 = input file is not valid UTF-8
 
 Related:
   MEMORY.md rule #0I; issue #1787 sub-task 1.4.
@@ -192,13 +205,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.stdin:
-        import sys
-
         label = "<stdin>"
         text = sys.stdin.read()
     else:
         label = str(args.text)
-        text = args.text.read_text(encoding="utf-8")
+        try:
+            text = args.text.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            print(f"{label}: not utf-8", file=sys.stderr)
+            return 2
 
     violations = scan_text(text)
     for violation in violations:

--- a/scripts/audit/lint_anti_menu.py
+++ b/scripts/audit/lint_anti_menu.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Detect MEMORY #0I anti-menu sign-off prompts in markdown.
+
+The detector is intentionally heuristic. It looks for these regex shapes:
+
+- Inline parenthesized choice labels with chooser context: ``(a) ... vs ... (b)``
+  or ``(a) ... or ... (b)`` near ``do we``, ``decision``, ``sign off``, etc.
+- Direct user-delegation questions: ``Want me to A, B, or C?`` and
+  ``Should I/we do X or Y?``.
+- Inline numbered chooser menus: ``1) Do X 2) Do Y 3) Do Z -- which?``.
+- Sign-off preambles: ``Sign off on these N options:`` followed shortly by
+  a numbered list.
+
+Exemptions are markdown-aware enough for handoff docs: fenced code blocks,
+tables, ``## Acceptance criteria`` sections, and lines with or immediately
+after ``Done:``, ``Status:``, or ``Plan:`` are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One anti-menu match in a scanned document."""
+
+    line_number: int
+    snippet: str
+
+
+PAREN_OPTION_RE = re.compile(
+    r"\([a-z]\)[^\n]{0,120}\b(?:vs\.?|or)\b[^\n]{0,120}\([a-z]\)",
+    re.IGNORECASE,
+)
+PAREN_OPTION_CONTEXT_RE = re.compile(
+    r"\b(?:decision|do we|should i|should we|want me|approve|approval|sign off|choose)\b",
+    re.IGNORECASE,
+)
+META_EXAMPLE_RE = re.compile(
+    r"\b(?:forbid|forbids|forbidden|not acceptable|do not propose|no menus?|anti-menu|anti-pattern|wrong pattern)\b",
+    re.IGNORECASE,
+)
+DIRECT_QUESTION_RE = re.compile(
+    r"\b(?:do you want me to|want me to|should i|should we)\b[^\n?]{0,180}\bor\b[^\n?]{0,100}\?",
+    re.IGNORECASE,
+)
+INLINE_NUMBERED_MENU_RE = re.compile(
+    r"(?:^|\s)1\)\s+\S[^\n]{0,100}(?:^|\s)2\)\s+\S[^\n]{0,160}\b(?:which|pick|choose|sign off)\b[^\n?]*\?",
+    re.IGNORECASE,
+)
+SIGNOFF_OPTIONS_RE = re.compile(
+    r"\bsign\s+off\s+on\s+these\s+\d+\s+options\s*:?",
+    re.IGNORECASE,
+)
+NUMBERED_LIST_LINE_RE = re.compile(r"^\s*(?:[-*]\s*)?\d+\)\s+\S")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+PREFIX_EXEMPT_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:Done|Status|Plan):(?:\s|$)", re.IGNORECASE)
+
+
+def _is_table_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("|") and stripped.endswith("|") and stripped.count("|") >= 2
+
+
+def _normalize_heading(text: str) -> str:
+    return text.rstrip("#").strip().lower().rstrip(":")
+
+
+def _trim_snippet(snippet: str, limit: int = 120) -> str:
+    collapsed = " ".join(snippet.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[: limit - 3]}..."
+
+
+def _find_numbered_list_after(lines: list[str], start_index: int) -> bool:
+    checked = 0
+    for line in lines[start_index + 1 : start_index + 7]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            return False
+        checked += 1
+        if NUMBERED_LIST_LINE_RE.search(line):
+            return True
+        if checked >= 4:
+            return False
+    return False
+
+
+def scan_text(text: str) -> list[Violation]:
+    """Return anti-menu violations in markdown text."""
+
+    violations: list[Violation] = []
+    lines = text.splitlines()
+    in_fence = False
+    in_acceptance_criteria = False
+    acceptance_heading_level: int | None = None
+    previous_nonblank = ""
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            previous_nonblank = stripped or previous_nonblank
+            continue
+
+        heading = HEADING_RE.match(stripped)
+        if heading:
+            level = len(heading.group(1))
+            heading_text = _normalize_heading(heading.group(2))
+            if in_acceptance_criteria and acceptance_heading_level is not None and level <= acceptance_heading_level:
+                in_acceptance_criteria = False
+                acceptance_heading_level = None
+            if heading_text == "acceptance criteria":
+                in_acceptance_criteria = True
+                acceptance_heading_level = level
+
+        exempt = (
+            in_fence
+            or in_acceptance_criteria
+            or _is_table_line(line)
+            or bool(PREFIX_EXEMPT_RE.match(line))
+            or bool(PREFIX_EXEMPT_RE.match(previous_nonblank))
+        )
+
+        if not exempt and not META_EXAMPLE_RE.search(line):
+            paren_match = PAREN_OPTION_RE.search(line)
+            if paren_match and PAREN_OPTION_CONTEXT_RE.search(line):
+                violations.append(Violation(index + 1, _trim_snippet(paren_match.group(0))))
+                continue
+
+            for pattern in (DIRECT_QUESTION_RE, INLINE_NUMBERED_MENU_RE):
+                match = pattern.search(line)
+                if match:
+                    violations.append(Violation(index + 1, _trim_snippet(match.group(0))))
+                    break
+            else:
+                signoff_match = SIGNOFF_OPTIONS_RE.search(line)
+                if signoff_match and _find_numbered_list_after(lines, index):
+                    violations.append(Violation(index + 1, _trim_snippet(signoff_match.group(0))))
+
+        if stripped:
+            previous_nonblank = stripped
+
+    return violations
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect MEMORY #0I anti-menu sign-off prompts in markdown.\n"
+            "Use before committing handoffs or dispatch briefs; do not use as a general markdown style linter."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  .venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md
+  cat handoff.md | .venv/bin/python scripts/audit/lint_anti_menu.py --stdin
+
+Outputs:
+  Prints one line per violation as: path:line: anti-menu pattern detected — '<matched-snippet>'
+  Writes no files and has no side effects.
+
+Exit codes:
+  0 = no anti-menu patterns detected
+  1 = one or more anti-menu patterns detected
+
+Related:
+  MEMORY.md rule #0I; issue #1787 sub-task 1.4.
+""",
+    )
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--text", type=Path, help="Markdown file to scan, e.g. docs/session-state/current.md")
+    input_group.add_argument("--stdin", action="store_true", help="Read markdown text from stdin instead of a file")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.stdin:
+        import sys
+
+        label = "<stdin>"
+        text = sys.stdin.read()
+    else:
+        label = str(args.text)
+        text = args.text.read_text(encoding="utf-8")
+
+    violations = scan_text(text)
+    for violation in violations:
+        print(f"{label}:{violation.line_number}: anti-menu pattern detected — '{violation.snippet}'")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_lint_anti_menu.py
+++ b/tests/audit/test_lint_anti_menu.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path("scripts/audit/lint_anti_menu.py")
+PYTHON = Path(".venv/bin/python")
+
+
+def run_linter(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(PYTHON), str(SCRIPT), "--text", str(path)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def write_fixture(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "fixture.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_parenthesized_signoff_menu_triggers(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        "Decision: do we (a) merge the PR now or (b) wait for another review?\n",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 1
+    assert "anti-menu pattern detected" in result.stdout
+    assert "(a) merge the PR now or (b)" in result.stdout
+
+
+def test_inline_numbered_which_menu_triggers(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        "1) Keep current prompt 2) Switch output filter 3) Wait for review -- which?\n",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 1
+    assert "1) Keep current prompt" in result.stdout
+    assert "which?" in result.stdout
+
+
+def test_signoff_options_menu_triggers(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """Sign off on these 3 options:
+1) Ship the guardrail
+2) Wait for another review
+3) Defer the issue
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 1
+    assert "Sign off on these 3 options" in result.stdout
+
+
+def test_acceptance_criteria_numbered_list_does_not_trigger(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """## Acceptance criteria
+
+1) Detect direct sign-off menus
+2) Ignore status reports
+3) Exit non-zero on violations
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_adr_options_inside_code_fence_do_not_trigger(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """# ADR sketch
+
+```md
+Should I adopt Option A or Option B?
+Sign off on these 2 options:
+1) Option A
+2) Option B
+```
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_status_prefixed_list_does_not_trigger(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        "Status: 1) implemented 2) tested 3) documented -- which landed today?\n",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_real_shaped_handoff_does_not_trigger(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """# Session Handoff -- 2026-05-08
+
+> Mode: autonomous code guardrail dispatch.
+> Scope: audit script, tests, docs entry.
+
+## TL;DR
+
+One guardrail is ready for implementation. The worktree is isolated and the
+main checkout stays on main. The pending Multi-UI decision does not block this
+audit-only change.
+
+## Merged today
+
+| PR | What | Status |
+|---|---|---|
+| #1781 | Prompt hard stop | merged |
+| #1783 | Warm cache | merged |
+| #1784 | Codex launcher parity | merged |
+
+## Open work
+
+| Priority | Task | Next action |
+|---|---|---|
+| 1 | Anti-menu linter | implement script |
+| 2 | Handoff verifier | file follow-up |
+| 3 | python_qg failure | investigate separately |
+
+## Plan
+
+Plan:
+1) Read the rule and recent handoffs.
+2) Implement the scanner.
+3) Run targeted tests.
+4) Validate against session-state docs.
+
+## Validation commands
+
+```bash
+.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md
+.venv/bin/python -m pytest tests/audit/test_lint_anti_menu.py -x
+```
+
+## Status
+
+Done: scoped the change to three files.
+Status: validation remains before opening the PR.
+
+## Acceptance criteria
+
+1) Script exits 0 on clean markdown.
+2) Script exits 1 on sign-off menu prompts.
+3) Docs entry lists the command.
+
+## Notes
+
+ADR option enumerations remain valid inside decision documents. This guardrail
+targets handoff-style requests that ask the user to pick from a menu instead of
+making a concrete recommendation.
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_stdin_uses_stdin_label_and_informative_snippet() -> None:
+    result = subprocess.run(
+        [str(PYTHON), str(SCRIPT), "--stdin"],
+        capture_output=True,
+        check=False,
+        input="Should I merge this now or wait for another review?\n",
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "<stdin>:1: anti-menu pattern detected —" in result.stdout
+    assert "Should I merge this now or wait" in result.stdout

--- a/tests/audit/test_lint_anti_menu.py
+++ b/tests/audit/test_lint_anti_menu.py
@@ -64,6 +64,22 @@ def test_signoff_options_menu_triggers(tmp_path: Path) -> None:
     assert "Sign off on these 3 options" in result.stdout
 
 
+def test_signoff_options_period_numbered_list_triggers(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """Sign off on these 3 options:
+1. Ship the guardrail
+2. Wait for another review
+3. Defer the issue
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 1
+    assert "Sign off on these 3 options" in result.stdout
+
+
 def test_acceptance_criteria_numbered_list_does_not_trigger(tmp_path: Path) -> None:
     path = write_fixture(
         tmp_path,
@@ -72,6 +88,37 @@ def test_acceptance_criteria_numbered_list_does_not_trigger(tmp_path: Path) -> N
 1) Detect direct sign-off menus
 2) Ignore status reports
 3) Exit non-zero on violations
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_parenthesized_acceptance_criteria_heading_does_not_trigger(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """## Acceptance criteria (numbered, all required)
+
+1) Want me to merge now, rerun tests, or wait for another review?
+""",
+    )
+
+    result = run_linter(path)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_forbidden_patterns_preamble_exempts_following_examples(tmp_path: Path) -> None:
+    path = write_fixture(
+        tmp_path,
+        """Forbidden patterns:
+
+- Should I merge this now or wait for another review?
+- Want me to rerun tests or open the PR?
 """,
     )
 
@@ -195,3 +242,14 @@ def test_stdin_uses_stdin_label_and_informative_snippet() -> None:
     assert result.returncode == 1
     assert "<stdin>:1: anti-menu pattern detected —" in result.stdout
     assert "Should I merge this now or wait" in result.stdout
+
+
+def test_non_utf8_input_exits_2(tmp_path: Path) -> None:
+    path = tmp_path / "fixture.md"
+    path.write_bytes(b"\xff")
+
+    result = run_linter(path)
+
+    assert result.returncode == 2
+    assert f"{path}: not utf-8" in result.stderr
+    assert result.stdout == ""


### PR DESCRIPTION
## Summary

Adds a markdown anti-menu linter for MEMORY #0I sign-off antipatterns, with targeted regex shapes, markdown-aware exemptions, tests, and a docs/SCRIPTS.md entry.

## Acceptance criteria

- [x] New `scripts/audit/lint_anti_menu.py` CLI supports `--text PATH` and `--stdin`
- [x] Regex-based detection for parenthesized sign-off choices, direct delegation questions, inline numbered chooser menus, and sign-off option preambles
- [x] Allowlist covers Acceptance criteria sections, fenced code blocks, tables, and Done:/Status:/Plan: lines
- [x] Per-violation output uses `path:line: anti-menu pattern detected — '<matched-snippet>'`
- [x] Exits 0 when clean and 1 on violations
- [x] CLI help includes description, argument help, examples, output, exit codes, and related issue
- [x] Tests cover 3 triggering fixture shapes, 3 non-triggering fixture shapes, a real-shaped handoff, stdin, and informative snippets
- [x] Regex shapes documented in the module docstring
- [x] `docs/SCRIPTS.md` updated

## Test plan

- [x] `.venv/bin/ruff check scripts/audit/lint_anti_menu.py tests/audit/test_lint_anti_menu.py`
- [x] `.venv/bin/pytest tests/audit/test_lint_anti_menu.py -x`
- [x] `.venv/bin/python scripts/audit/lint_anti_menu.py --help`
- [x] Validation pass over `docs/session-state/*.md`: 1/85 files flagged; reviewed as a true historical sign-off menu, not a false positive

False positive rate on newest 20 `docs/session-state/` handoff docs: 0% (0/20).