### PR TITLE
feat(guardrail): handoff verifier flags missing env-file references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,3 +136,11 @@ repos:
         language: system
         files: ^docs/dispatch-briefs/.*\.md$
         stages: [pre-commit]
+
+      - id: lint-session-state
+        name: lint session-state env references
+        entry: .venv/bin/python scripts/audit/lint_session_state.py --all
+        language: system
+        pass_filenames: false
+        files: ^docs/session-state/.*\.md$
+        stages: [pre-commit]

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -508,6 +508,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/assess_research.py` | Assess and upgrade research | `.venv/bin/python scripts/assess_research.py hist --upgrade` |
 | `scripts/consultation_cli.py` | Review consultation proposals | `.venv/bin/python scripts/consultation_cli.py list` |
 | `scripts/check_decisions.py` | Audit decision journal expiry | `.venv/bin/python scripts/check_decisions.py` |
+| `scripts/audit/lint_session_state.py` | Check handoff docs for missing env-file references | `.venv/bin/python scripts/audit/lint_session_state.py --all` |
 
 ---
 
@@ -786,6 +787,19 @@ Scans `docs/decisions/decisions.yaml` for expired or near-expiry decisions.
 ```
 
 This is also called by `session-setup.sh`.
+
+### `lint_session_state.py`
+
+Scans `docs/session-state/*.md` for references to env/config files that do not exist locally.
+
+```bash
+.venv/bin/python scripts/audit/lint_session_state.py --all
+.venv/bin/python scripts/audit/lint_session_state.py --file docs/session-state/current.md
+```
+
+Known user-scoped paths that are expected but not committed live in
+`scripts/audit/known_user_paths.yaml`. This check is also wired into pre-commit
+for `docs/session-state/*.md`.
 
 ---
 

--- a/scripts/audit/known_user_paths.yaml
+++ b/scripts/audit/known_user_paths.yaml
@@ -1,0 +1,3 @@
+paths:
+  - ~/.codex/config.toml
+  - ~/.gemini/settings.json

--- a/scripts/audit/lint_session_state.py
+++ b/scripts/audit/lint_session_state.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Lint session handoffs for environmental file references that do not exist."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SESSION_STATE_DIR = PROJECT_ROOT / "docs" / "session-state"
+ALLOWLIST_FILE = Path(__file__).with_name("known_user_paths.yaml")
+
+PATH_PATTERN = re.compile(
+    r"(?<![\w/.-])("
+    r"~/\.claude/settings\.json|"
+    r"~/\.codex/config\.toml|"
+    r"~/\.gemini/settings\.json|"
+    r"~/\.bash_secrets|"
+    r"~/\.zprofile|"
+    r"~/\.bashrc|"
+    r"~/\.profile|"
+    r"~/\.zshrc|"
+    r"\.env\.local|"
+    r"\.envrc|"
+    r"\.env"
+    r")(?![\w/.-])"
+)
+FENCE_PATTERN = re.compile(r"^\s*(```|~~~)(.*)$")
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line_number: int
+    reference: str
+
+
+def load_allowlist(path: Path | None = None) -> set[str]:
+    path = path or ALLOWLIST_FILE
+    if not path.exists():
+        return set()
+    data = yaml.safe_load(path.read_text("utf-8")) or {}
+    return {str(item) for item in data.get("paths", [])}
+
+
+def session_state_files() -> list[Path]:
+    return sorted(SESSION_STATE_DIR.glob("*.md"))
+
+
+def project_scoped_roots(project_root: Path) -> list[Path]:
+    roots = [project_root]
+    git_marker = project_root / ".git"
+    if not git_marker.is_file():
+        return roots
+
+    prefix = "gitdir:"
+    gitdir_line = git_marker.read_text("utf-8").strip()
+    if not gitdir_line.startswith(prefix):
+        return roots
+
+    gitdir = Path(gitdir_line[len(prefix) :].strip())
+    if not gitdir.is_absolute():
+        gitdir = project_root / gitdir
+
+    for parent in (gitdir, *gitdir.parents):
+        if parent.name == ".git":
+            primary_checkout = parent.parent
+            if primary_checkout not in roots:
+                roots.append(primary_checkout)
+            break
+    return roots
+
+
+def reference_exists(reference: str, *, project_root: Path, home: Path) -> bool:
+    if reference.startswith("~/"):
+        return (home / reference[2:]).exists()
+    return any((root / reference).exists() for root in project_scoped_roots(project_root))
+
+
+def illustrative_fence_lines(lines: list[str]) -> set[int]:
+    skip_lines: set[int] = set()
+    open_fence: tuple[str, int, bool] | None = None
+    block_body: list[str] = []
+
+    for index, line in enumerate(lines, start=1):
+        match = FENCE_PATTERN.match(line)
+        if match and open_fence is None:
+            marker, info = match.groups()
+            illustrative = "example" in info.lower() or "illustrative" in info.lower()
+            open_fence = (marker, index, illustrative)
+            block_body = []
+            continue
+
+        if match and open_fence is not None and match.group(1) == open_fence[0]:
+            _, start_line, illustrative = open_fence
+            body_marks_example = any(
+                body_line.strip().lower().startswith(("# example", "# illustrative"))
+                for body_line in block_body
+            )
+            if illustrative or body_marks_example:
+                skip_lines.update(range(start_line, index + 1))
+            open_fence = None
+            block_body = []
+            continue
+
+        if open_fence is not None:
+            block_body.append(line)
+
+    return skip_lines
+
+
+def lint_file(
+    path: Path,
+    *,
+    allowlist: set[str],
+    project_root: Path | None = None,
+    home: Path | None = None,
+) -> list[Violation]:
+    project_root = project_root or PROJECT_ROOT
+    home = home or Path.home()
+    lines = path.read_text("utf-8").splitlines()
+    skip_lines = illustrative_fence_lines(lines)
+    violations: list[Violation] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        if line_number in skip_lines:
+            continue
+        for match in PATH_PATTERN.finditer(line):
+            reference = match.group(1)
+            if reference in allowlist:
+                continue
+            if not reference_exists(reference, project_root=project_root, home=home):
+                violations.append(Violation(path, line_number, reference))
+
+    return violations
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Lint docs/session-state handoffs for referenced env/config files "
+            "that do not exist.\n"
+            "Use before committing handoff docs; do not use for general markdown linting."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/audit/lint_session_state.py --all\n"
+            "  .venv/bin/python scripts/audit/lint_session_state.py "
+            "--file docs/session-state/current.md\n\n"
+            "Outputs: Prints path:line diagnostics to stdout. Writes no files.\n\n"
+            "Exit codes: 0 clean, 1 missing referenced env/config files, 2 CLI usage error.\n\n"
+            "Related: scripts/audit/known_user_paths.yaml, issue #1787."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--file",
+        type=Path,
+        help="Session-state markdown file to lint, e.g. docs/session-state/current.md",
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Lint every docs/session-state/*.md file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    paths = session_state_files() if args.all else [args.file]
+    allowlist = load_allowlist()
+
+    violations: list[Violation] = []
+    for path in paths:
+        if not path.exists():
+            print(f"{path}: file does not exist", file=sys.stderr)
+            return 1
+        violations.extend(lint_file(path, allowlist=allowlist))
+
+    for violation in violations:
+        print(
+            f"{violation.path}:{violation.line_number}: referenced env file "
+            f"'{violation.reference}' does not exist"
+        )
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/audit/test_lint_session_state.py
+++ b/tests/audit/test_lint_session_state.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import lint_session_state
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, "utf-8")
+    return path
+
+
+def _isolate_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(lint_session_state, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(lint_session_state, "ALLOWLIST_FILE", tmp_path / "known_user_paths.yaml")
+    monkeypatch.setattr(lint_session_state.Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+
+def test_missing_bash_secrets_exits_one_and_names_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _isolate_cli(monkeypatch, tmp_path)
+    handoff = _write(tmp_path / "handoff.md", "Token was loaded from `~/.bash_secrets`.\n")
+
+    exit_code = lint_session_state.main(["--file", str(handoff)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert str(handoff) in output
+    assert "~/.bash_secrets" in output
+
+
+def test_existing_project_envrc_is_clean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cli(monkeypatch, tmp_path)
+    handoff = _write(tmp_path / "handoff.md", "GH_TOKEN lives in `.envrc`.\n")
+    _write(tmp_path / ".envrc", "export GH_TOKEN=test\n")
+
+    assert lint_session_state.main(["--file", str(handoff)]) == 0
+
+
+def test_allowlisted_codex_config_is_clean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cli(monkeypatch, tmp_path)
+    handoff = _write(tmp_path / "handoff.md", "Codex config: `~/.codex/config.toml`.\n")
+    _write(tmp_path / "known_user_paths.yaml", "paths:\n  - ~/.codex/config.toml\n")
+
+    assert lint_session_state.main(["--file", str(handoff)]) == 0
+
+
+def test_illustrative_code_block_is_not_flagged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cli(monkeypatch, tmp_path)
+    handoff = _write(
+        tmp_path / "handoff.md",
+        """Example only:
+
+```bash
+# example
+source ~/.bash_secrets
+source ~/.notreal
+```
+""",
+    )
+
+    assert lint_session_state.main(["--file", str(handoff)]) == 0


### PR DESCRIPTION
## Acceptance checklist
- [x] Added `scripts/audit/lint_session_state.py` with `--file PATH` / `--all` CLI and help text aligned with `cli-help-standard.md`.
- [x] Detects named env/config path references and checks project-scoped paths against the worktree plus primary checkout, and user-scoped paths against `$HOME`.
- [x] Skips illustrative fenced code blocks.
- [x] Added `scripts/audit/known_user_paths.yaml` seeded with `~/.codex/config.toml` and `~/.gemini/settings.json`.
- [x] Added tests in `tests/audit/test_lint_session_state.py`.
- [x] Added pre-commit hook scoped to `docs/session-state/*.md`.
- [x] Updated `docs/SCRIPTS.md`.

## Test plan
- [x] `.venv/bin/pytest tests/audit/test_lint_session_state.py -x`
- [x] `.venv/bin/ruff check scripts/audit/lint_session_state.py tests/audit/test_lint_session_state.py`
- [x] `.venv/bin/python scripts/audit/lint_session_state.py --all`
- [x] `.venv/bin/pre-commit run lint-session-state --all-files`
- [x] `git diff --check`

Full `.venv/bin/ruff check` was also attempted and currently fails on pre-existing unrelated files under `docs/reports/` and `plans/`; touched-file ruff and commit-time affected-file ruff are clean.

Validation pass results: 35 references found, 2 allowlisted, 0 real issues fixed.