### PR TITLE
fix(ab-bridge): preserve discuss root and infer ask sender

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -62,8 +62,10 @@ Current adapter policy for discussion calls:
 - Codex: `read-only` maps to `codex exec -s read-only`.
 - Gemini: discussion calls add `--approval-mode plan`; plain read-only
   CLI defaults were not enough in trusted workspaces.
-- Claude: discussion calls add `--permission-mode plan` and restrict
-  built-in tools to read/list/search tools.
+- Claude: discussion calls restrict built-in tools to read/list/search
+  tools. They do not use Claude plan mode because discussion replies are
+  comments, not implementation plans; the restricted tool list plus the
+  bridge's git mutation guard enforce the read-only contract.
 
 ## CLI quick reference
 
@@ -261,8 +263,10 @@ to 40–60KB of copy-pasted transcript.
 one-time cost — the pinned `context.md` + the Monitor API snapshot
 are concatenated into the prompt even if the agent doesn't strictly
 need them. For drive-by one-shots, the legacy `ask-*` commands are
-still cheaper. Use channels when the conversation will have at
-least two turns.
+still cheaper. `ask-*` commands infer `--from` from wrapper environment
+such as `CLAUDE_AGENT_NAME`, `CODEX_SESSION`, or `GEMINI_SESSION`; pass
+`--from` explicitly when running them from a plain shell. Use channels
+when the conversation will have at least two turns.
 
 ## Web dashboard
 

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -273,10 +273,7 @@ class ClaudeAdapter:
         cmd.append("--verbose")
 
         if discussion_readonly:
-            cmd.extend([
-                "--permission-mode", "plan",
-                "--tools", "Read,Grep,Glob,LS",
-            ])
+            cmd.extend(["--tools", "Read,Grep,Glob,LS"])
 
         # Mode-specific flags
         if mode == "danger":

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -60,6 +60,21 @@ _GEMINI_AUTH_CHOICES = ["auto", "subscription", "api-key", "api"]
 _DISCUSSION_READONLY_TOOL_CONFIG = {"discussion_readonly": True}
 
 
+def _build_discuss_round_body(root_body: str, directive: str) -> str:
+    """Render the high-priority body for a discuss round prompt.
+
+    The root question is pinned outside channel history because history
+    truncation is allowed to drop old messages. In later rounds, verbose
+    replies can exceed the history budget before the root is rendered.
+    """
+    return (
+        "--- discussion root question (pinned) ---\n"
+        f"{root_body}\n\n"
+        "--- round directive ---\n"
+        f"{directive}"
+    )
+
+
 def _deadline_seconds_arg(raw_value: str) -> int:
     try:
         seconds = int(raw_value)
@@ -1279,7 +1294,7 @@ def _handle_discuss(args) -> int:
         try:
             prompt_obj = _channels.build_agent_prompt(
                 args.channel,
-                directive,
+                _build_discuss_round_body(body, directive),
                 history_tail=needed_history,
                 review=args.review,
             )

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -35,6 +36,46 @@ from ._messaging import (
     send_message,
 )
 from ._model import check_model
+
+_CALLER_IDENTITY_ENV_HINTS = (
+    "CLAUDE_AGENT_NAME",
+    "CODEX_SESSION",
+    "CLAUDE_PROJECT_DIR",
+    "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS",
+    "GEMINI_SESSION",
+)
+
+
+def _detect_caller_identity_from_env() -> str | None:
+    """Infer the sending agent for legacy ask-* commands from wrapper env."""
+    claude_name = os.environ.get("CLAUDE_AGENT_NAME")
+    if claude_name:
+        return claude_name.strip().lower()
+    if os.environ.get("CODEX_SESSION"):
+        return "codex"
+    if (
+        os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.environ.get("CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS")
+    ):
+        return "claude"
+    if os.environ.get("GEMINI_SESSION"):
+        return "gemini"
+    return None
+
+
+def _resolve_from_llm(args) -> str:
+    """Return explicit --from or fail loudly if caller identity is unknown."""
+    explicit = getattr(args, "from_llm", None)
+    if explicit:
+        return explicit
+    detected = _detect_caller_identity_from_env()
+    if detected:
+        return detected
+    hint_list = ", ".join(_CALLER_IDENTITY_ENV_HINTS)
+    raise SystemExit(
+        "Cannot infer sender for ask-* command. Pass --from explicitly or "
+        f"run under a known agent wrapper that sets one of: {hint_list}."
+    )
 
 
 def interactive_mode():
@@ -425,8 +466,8 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_claude_parser.add_argument("--data", help="Path to data file to attach")
     ask_claude_parser.add_argument("--new-session", dest="new_session", action="store_true",
                                    help="Force new session even if one exists")
-    ask_claude_parser.add_argument("--from", dest="from_llm", default="gemini",
-                                   help="Sender agent family (gemini, claude). Default: gemini")
+    ask_claude_parser.add_argument("--from", dest="from_llm",
+                                   help="Sender agent family. Default: inferred from environment")
     ask_claude_parser.add_argument("--from-model", dest="from_model",
                                    help="Exact sender model ID")
     ask_claude_parser.add_argument("--to-model", dest="to_model",
@@ -442,8 +483,8 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_codex_parser.add_argument("--data", help="Path to data file to attach")
     ask_codex_parser.add_argument("--new-session", dest="new_session", action="store_true",
                                   help="Force new session even if one exists")
-    ask_codex_parser.add_argument("--from", dest="from_llm", default="gemini",
-                                  help="Sender agent family (gemini, claude, codex). Default: gemini")
+    ask_codex_parser.add_argument("--from", dest="from_llm",
+                                  help="Sender agent family. Default: inferred from environment")
     ask_codex_parser.add_argument("--from-model", dest="from_model",
                                   help="Exact sender model ID")
     ask_codex_parser.add_argument("--to-model", dest="to_model",
@@ -466,6 +507,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ask_gemini_parser.add_argument("--from-model", dest="from_model",
                                    help="Exact sender model ID")
+    ask_gemini_parser.add_argument("--from", dest="from_llm",
+                                   help="Sender agent family. Default: inferred from environment")
     ask_gemini_parser.add_argument("--async", dest="async_mode", action="store_true",
                                    help="Queue only, don't invoke Gemini CLI")
     ask_gemini_parser.add_argument("--stdout-only", dest="stdout_only", action="store_true",
@@ -711,8 +754,9 @@ def _handle_ask_claude(args):
     if args.data:
         data = Path(args.data).read_text()
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    from_llm = _resolve_from_llm(args)
     ask_claude(args.content, args.task_id, args.type, data,
-               args.new_session, args.from_llm, args.from_model, args.to_model,
+               args.new_session, from_llm, args.from_model, args.to_model,
                **kwargs)
 
 
@@ -727,8 +771,9 @@ def _handle_ask_codex(args):
             raise SystemExit("ask-codex --chain derives issue task IDs automatically; omit --task-id")
         try:
             kwargs = {"review": True} if getattr(args, "review", False) else {}
+            from_llm = _resolve_from_llm(args)
             ask_codex_chain(content, args.chain, args.type, data,
-                            args.new_session, args.from_llm, args.from_model,
+                            args.new_session, from_llm, args.from_model,
                             args.to_model, args.no_timeout, **kwargs)
         except ValueError as exc:
             raise SystemExit(str(exc)) from exc
@@ -736,8 +781,9 @@ def _handle_ask_codex(args):
     if not args.task_id:
         raise SystemExit("ask-codex requires --task-id unless --chain is used")
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    from_llm = _resolve_from_llm(args)
     ask_codex(content, args.task_id, args.type, data,
-              args.new_session, args.from_llm, args.from_model,
+              args.new_session, from_llm, args.from_model,
               args.to_model, args.no_timeout, **kwargs)
 
 
@@ -748,7 +794,9 @@ def _handle_ask_gemini(args):
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    from_llm = _resolve_from_llm(args)
     ask_gemini(content, args.task_id, args.type, data, args.model,
+               from_llm,
                getattr(args, 'from_model', None),
                getattr(args, 'async_mode', False),
                getattr(args, 'stdout_only', False),

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -82,12 +82,12 @@ def converse_gemini(content: str, task_id: str, model: str = "gemini-3.1-pro-pre
 
 def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query",
                data: str | None = None, model: str = GEMINI_DEFAULT_MODEL,
-               from_model: str | None = None, async_mode: bool = False,
-               stdout_only: bool = False, output_path: str | None = None,
-               extract_tags: list | None = None, skip_model_check: bool = False,
-               allow_write: bool = False, delimiters: str | None = None,
-               skip_github: bool = False, auth_mode: str | None = None,
-               review: bool = False):
+               from_llm: str | None = None, from_model: str | None = None,
+               async_mode: bool = False, stdout_only: bool = False,
+               output_path: str | None = None, extract_tags: list | None = None,
+               skip_model_check: bool = False, allow_write: bool = False,
+               delimiters: str | None = None, skip_github: bool = False,
+               auth_mode: str | None = None, review: bool = False):
     """Send message to Gemini AND optionally invoke Gemini to process it."""
     # Model cache management
     if skip_model_check and model in _MODEL_CACHE:
@@ -111,8 +111,8 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
     _warn_long_handoff(content, msg_type, task_id)
 
     # Send the message
-    msg_id = _send_gemini_message(content, task_id, msg_type, data, from_model, model,
-                                  stdout_only, output_path)
+    msg_id = _send_gemini_message(content, task_id, msg_type, data, from_llm,
+                                  from_model, model, stdout_only, output_path)
 
     # Invoke Gemini or queue
     if async_mode:
@@ -146,18 +146,34 @@ def _warn_long_handoff(content: str, msg_type: str, task_id: str | None):
         print()
 
 
-def _send_gemini_message(content, task_id, msg_type, data, from_model, model,
+def _send_gemini_message(content, task_id, msg_type, data, from_llm, from_model, model,
                          stdout_only, output_path):
     """Send the message and handle pre-acknowledgement."""
     if output_path:
-        msg_id = send_to_gemini(content, task_id, msg_type, data,
-                                from_model=from_model, to_model=model, quiet=stdout_only)
+        if from_llm:
+            msg_id = send_message(
+                content, task_id, msg_type, data, from_llm=from_llm,
+                to_llm="gemini", from_model=from_model, to_model=model,
+                quiet=stdout_only,
+            )
+        else:
+            msg_id = send_to_gemini(content, task_id, msg_type, data,
+                                    from_model=from_model, to_model=model,
+                                    quiet=stdout_only)
         acknowledge(msg_id, quiet=stdout_only)
         if not stdout_only:
             print("   Pre-acknowledged (file output mode — no broker traffic)")
     else:
-        msg_id = send_to_gemini(content, task_id, msg_type, data,
-                                from_model=from_model, to_model=model, quiet=stdout_only)
+        if from_llm:
+            msg_id = send_message(
+                content, task_id, msg_type, data, from_llm=from_llm,
+                to_llm="gemini", from_model=from_model, to_model=model,
+                quiet=stdout_only,
+            )
+        else:
+            msg_id = send_to_gemini(content, task_id, msg_type, data,
+                                    from_model=from_model, to_model=model,
+                                    quiet=stdout_only)
         if stdout_only:
             acknowledge(msg_id, quiet=stdout_only)
     return msg_id

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from agent_runtime.adapters.claude import ClaudeAdapter
+from ai_agent_bridge import _channels, _channels_cli, _cli, _db
+
+
+def _clear_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _cli._CALLER_IDENTITY_ENV_HINTS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_discuss_round_four_prompt_pins_root_after_history_truncation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
+    monkeypatch.setattr(
+        _channels,
+        "load_channel_context",
+        lambda channel: {"body": "", "revs": {}, "missing": []},
+    )
+
+    _channels.create_channel("architecture", exist_ok=False)
+    for index in range(205):
+        _channels.post(
+            "architecture",
+            "user",
+            f"prior message {index}",
+            auto_snapshot=False,
+            verify_citations=False,
+        )
+
+    prompts: list[str] = []
+
+    def fake_invoke(agent_name: str, prompt: str, **kwargs):
+        prompts.append(prompt)
+        return SimpleNamespace(
+            ok=True,
+            response=("x" * 6000) + "\n[DISAGREE]",
+            stderr_excerpt="",
+        )
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
+
+    root_body = "ROOT QUESTION: preserve this exact discussion brief."
+    args = SimpleNamespace(
+        channel="architecture",
+        body=root_body,
+        with_agents="codex",
+        max_rounds=4,
+        review=False,
+    )
+
+    assert _channels_cli._handle_discuss(args) == 0
+    assert len(prompts) == 4
+    assert "... [" in prompts[3]
+    assert root_body in prompts[3]
+
+
+def test_discuss_claude_subagent_uses_restricted_tools_without_plan_mode(
+    tmp_path: Path,
+) -> None:
+    plan = ClaudeAdapter().build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={"cmd_prefix": ["true"], "discussion_readonly": True},
+    )
+
+    assert "--permission-mode" not in plan.cmd
+    assert "--tools" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--tools") + 1] == "Read,Grep,Glob,LS"
+
+
+def test_ask_codex_without_from_fails_when_sender_cannot_be_inferred(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_identity_env(monkeypatch)
+    parser = _cli._build_parser()
+    args = parser.parse_args(["ask-codex", "hello", "--task-id", "task-1"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cli._dispatch_command(args)
+
+    assert "Cannot infer sender" in str(exc_info.value)
+
+
+def test_ask_codex_infers_from_claude_agent_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_identity_env(monkeypatch)
+    monkeypatch.setenv("CLAUDE_AGENT_NAME", "claude")
+    captured: dict[str, str | None] = {}
+
+    def fake_ask_codex(
+        content,
+        task_id,
+        msg_type,
+        data,
+        new_session,
+        from_llm,
+        from_model,
+        to_model,
+        no_timeout,
+        **kwargs,
+    ):
+        captured["from_llm"] = from_llm
+        return 123
+
+    monkeypatch.setattr(_cli, "ask_codex", fake_ask_codex)
+    parser = _cli._build_parser()
+    args = parser.parse_args(["ask-codex", "hello", "--task-id", "task-1"])
+
+    assert _cli._dispatch_command(args) is True
+    assert captured["from_llm"] == "claude"

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -2511,7 +2511,7 @@ def test_claude_adapter_basic_stateless(tmp_path):
     assert plan.stdin_payload == ""  # Claude -p takes prompt as positional
 
 
-def test_claude_adapter_discussion_readonly_uses_plan_tools(tmp_path):
+def test_claude_adapter_discussion_readonly_uses_restricted_tools_without_plan_mode(tmp_path):
     adapter = ClaudeAdapter()
     plan = adapter.build_invocation(
         prompt="hello",
@@ -2523,8 +2523,7 @@ def test_claude_adapter_discussion_readonly_uses_plan_tools(tmp_path):
         tool_config={"discussion_readonly": True},
     )
 
-    assert "--permission-mode" in plan.cmd
-    assert plan.cmd[plan.cmd.index("--permission-mode") + 1] == "plan"
+    assert "--permission-mode" not in plan.cmd
     assert "--tools" in plan.cmd
     assert plan.cmd[plan.cmd.index("--tools") + 1] == "Read,Grep,Glob,LS"
     assert plan.env_overrides == {"AB_DISCUSS_READONLY": "1"}

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -433,7 +433,7 @@ class TestSendGeminiMessage:
         f = self._import()
         with patch("ai_agent_bridge._gemini.send_to_gemini", return_value=10) as st, \
              patch("ai_agent_bridge._gemini.acknowledge") as ack:
-            result = f("content", "task-1", "query", None, None, "model", False, "/out")
+            result = f("content", "task-1", "query", None, None, None, "model", False, "/out")
             assert result == 10
             ack.assert_called_once()
 
@@ -441,7 +441,7 @@ class TestSendGeminiMessage:
         f = self._import()
         with patch("ai_agent_bridge._gemini.send_to_gemini", return_value=11), \
              patch("ai_agent_bridge._gemini.acknowledge") as ack:
-            result = f("content", "task-1", "query", None, None, "model", True, None)
+            result = f("content", "task-1", "query", None, None, None, "model", True, None)
             assert result == 11
             ack.assert_called_once()
 
@@ -449,7 +449,7 @@ class TestSendGeminiMessage:
         f = self._import()
         with patch("ai_agent_bridge._gemini.send_to_gemini", return_value=12), \
              patch("ai_agent_bridge._gemini.acknowledge") as ack:
-            result = f("content", "task-1", "query", None, None, "model", False, None)
+            result = f("content", "task-1", "query", None, None, None, "model", False, None)
             assert result == 12
             ack.assert_not_called()
 

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -190,6 +190,7 @@ def test_handle_ask_gemini_passes_auth_mode(monkeypatch):
         type = "query"
         data = None
         model = PRO_MODEL
+        from_llm = "claude"
         from_model = None
         async_mode = False
         stdout_only = False


### PR DESCRIPTION
## Summary

Closes #1786.

- Pins the original `ab discuss` root question into every round prompt outside truncatable channel history, so round 2+ and round 4 prompts always include the actual question even when older history is omitted.
- Fixes Claude discuss subagent spawning via Option A: discussion agents are commenting, not producing implementation plans, so Claude no longer runs with `--permission-mode plan`. It still gets the restricted `Read,Grep,Glob,LS` tool list and the bridge still fails the round if the worktree mutates.
- Changes legacy `ask-*` CLI sender defaults from hardcoded `gemini` to explicit caller detection from environment (`CLAUDE_AGENT_NAME`, `CODEX_SESSION`, Claude wrapper env, `GEMINI_SESSION`) and fails loudly when no identity can be inferred.
- Updates `docs/best-practices/agent-bridge.md` for the visible Claude discuss and `ask-* --from` behavior.

## B.2 Decision

Option A is the right fix. The adapter and docs showed Claude plan mode was intentional as a safety mechanism, but `ab discuss` participants are not being asked to draft or exit an implementation plan. The plan-mode workflow itself caused the missing-tool complaints (`Write` / `ExitPlanMode`). Keeping Claude out of plan mode while restricting built-in tools to read/list/search preserves the discussion contract without requiring plan-mode completion tools.

## Tests

- `.venv/bin/ruff check scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_gemini.py scripts/ai_agent_bridge/_channels_cli.py scripts/agent_runtime/adapters/claude.py tests/ai_agent_bridge/test_ab_discuss_bugs.py tests/test_agent_runtime.py tests/test_gemini_bridge.py`
- `.venv/bin/pytest tests/ai_agent_bridge/ -x`
- `.venv/bin/pytest tests/test_agent_runtime.py::test_claude_adapter_discussion_readonly_uses_restricted_tools_without_plan_mode tests/test_gemini_bridge.py::test_handle_ask_gemini_passes_auth_mode -q`
- Commit hook: ruff plus affected pytest suite, 132 passed

Note: full `.venv/bin/ruff check` still reports pre-existing unrelated issues in `docs/reports/*` and `plans/*`; this PR does not modify those files.
