### PR TITLE
feat(audit): D4 decision-lineage backlink scanner

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -510,6 +510,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/check_decisions.py` | Audit decision journal expiry | `.venv/bin/python scripts/check_decisions.py` |
 | `scripts/audit/lint_session_state.py` | Check handoff docs for missing env-file references | `.venv/bin/python scripts/audit/lint_session_state.py --all` |
 | `scripts/audit/lint_anti_menu.py` | Detect anti-menu sign-off prompts in markdown | `.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md` |
+| `scripts/audit/decision_lineage.py` | Scan decision git backlinks | `.venv/bin/python scripts/audit/decision_lineage.py --decision-id ADR-008` |
 
 ---
 
@@ -811,6 +812,19 @@ acceptance criteria, code fences, tables, and status/plan lines.
 .venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md
 cat handoff.md | .venv/bin/python scripts/audit/lint_anti_menu.py --stdin
 ```
+
+### `scripts/audit/decision_lineage.py`
+
+Scans `docs/decisions/**/*.md` plus git history for commits and PR references
+that touch or cite decision files by file path, filename slug, title, ADR ID,
+or declared decision ID.
+
+```bash
+.venv/bin/python scripts/audit/decision_lineage.py
+.venv/bin/python scripts/audit/decision_lineage.py --decision-id ADR-008
+```
+
+The Monitor API exposes the same read-only JSON at `/api/decisions/lineage`.
 
 ---
 

--- a/scripts/api/decisions_router.py
+++ b/scripts/api/decisions_router.py
@@ -5,6 +5,7 @@ Mounted at /api/decisions/ in main.py.
 
 Endpoints:
   GET  /api/decisions                  All decisions (optional ?status=active filter)
+  GET  /api/decisions/lineage          Decision files with git backlink lineage
   GET  /api/decisions/stale            Expired active decisions
   GET  /api/decisions/budget           Budget status (count, max, warning threshold)
   GET  /api/decisions/{dec_id}         Single decision by ID
@@ -20,6 +21,8 @@ from pathlib import Path
 import yaml
 from fastapi import APIRouter, HTTPException, Query
 
+from scripts.audit.decision_lineage import build_lineage_response
+
 from .config import PROJECT_ROOT
 
 router = APIRouter(tags=["decisions"])
@@ -34,6 +37,7 @@ _VALID_SCOPES = {"pipeline", "content", "architecture", "tooling", "pedagogy"}
 # ── TTL Cache ─────────────────────────────────────────────────────
 
 _cache: dict = {"data": None, "ts": 0.0}
+_lineage_cache: dict = {"data": None, "ts": 0.0}
 _CACHE_TTL = 60  # seconds
 
 
@@ -66,6 +70,19 @@ def _is_stale(dec: dict) -> bool:
         return date.fromisoformat(str(expires)) <= date.today()
     except (ValueError, TypeError):
         return False
+
+
+def _load_lineage(decision_id: str | None = None) -> dict:
+    """Load decision lineage with a short TTL because git history scans are heavier."""
+    now = time.monotonic()
+    if decision_id is None and _lineage_cache["data"] is not None and (now - _lineage_cache["ts"]) < _CACHE_TTL:
+        return _lineage_cache["data"]
+
+    data = build_lineage_response(PROJECT_ROOT, decision_id=decision_id)
+    if decision_id is None:
+        _lineage_cache["data"] = data
+        _lineage_cache["ts"] = now
+    return data
 
 
 # ── Endpoints ─────────────────────────────────────────────────────
@@ -111,6 +128,14 @@ async def decision_budget():
             else "ok"
         ),
     }
+
+
+@router.get("/lineage")
+async def decision_lineage(
+    decision_id: str | None = Query(None, description="Optional decision ID or alias filter, e.g. ADR-008 or dec-007"),
+):
+    """Decision files with git commit and PR backlink lineage."""
+    return _load_lineage(decision_id=decision_id)
 
 
 @router.get("/scope/{scope}")

--- a/scripts/api/decisions_router.py
+++ b/scripts/api/decisions_router.py
@@ -130,6 +130,7 @@ async def decision_budget():
     }
 
 
+# Keep this route above /{dec_id}; otherwise "lineage" is parsed as a decision ID.
 @router.get("/lineage")
 async def decision_lineage(
     decision_id: str | None = Query(None, description="Optional decision ID or alias filter, e.g. ADR-008 or dec-007"),

--- a/scripts/audit/decision_lineage.py
+++ b/scripts/audit/decision_lineage.py
@@ -23,6 +23,8 @@ FIELD_SEP = "\x1f"
 PAYLOAD_SEP = "\x1d"
 GIT_FORMAT = "%x1e%H%x1f%cI%x1f%s%x1f%B%x1d"
 PATCH_SCAN_COMMIT_LIMIT = 200
+NON_DECISION_FILENAMES = {"INDEX.md", "README.md"}
+MATCH_KIND_PRIORITY = {"path": 0, "patch": 1, "message": 2}
 
 
 @dataclass
@@ -34,7 +36,14 @@ class DecisionRecord:
     aliases: list[str]
     commits: dict[str, dict[str, Any]] = field(default_factory=dict)
 
-    def add_commit(self, sha: str, date: str, subject: str, matched_aliases: set[str], text: str) -> None:
+    def add_commit(
+        self,
+        sha: str,
+        date: str,
+        subject: str,
+        matched_aliases: set[str],
+        match_kind: str,
+    ) -> None:
         """Attach one matching commit, merging duplicate path/alias hits."""
         commit = self.commits.setdefault(
             sha,
@@ -42,12 +51,16 @@ class DecisionRecord:
                 "sha": sha,
                 "date": date,
                 "subject": subject,
+                "match_kind": match_kind,
                 "matched_aliases": [],
                 "prs": [],
             },
         )
+        if MATCH_KIND_PRIORITY[match_kind] > MATCH_KIND_PRIORITY[commit["match_kind"]]:
+            commit["match_kind"] = match_kind
         commit["matched_aliases"] = sorted(set(commit["matched_aliases"]) | matched_aliases)
-        commit["prs"] = sorted(set(commit["prs"]) | set(_extract_pr_refs(text)), key=_pr_sort_key)
+        if _matching_aliases(self, subject):
+            commit["prs"] = sorted(set(commit["prs"]) | set(_extract_pr_refs(subject)), key=_pr_sort_key)
 
     def as_dict(self) -> dict[str, Any]:
         commits = sorted(self.commits.values(), key=lambda item: (item["date"], item["sha"]))
@@ -148,6 +161,8 @@ def load_decision_records(project_root: Path = PROJECT_ROOT) -> list[DecisionRec
     records: list[DecisionRecord] = []
 
     for path in sorted((project_root / DECISIONS_DIR).glob("**/*.md")):
+        if path.name in NON_DECISION_FILENAMES:
+            continue
         rel_path = path.relative_to(project_root).as_posix()
         text = path.read_text("utf-8")
         frontmatter = _extract_frontmatter(text)
@@ -229,13 +244,18 @@ def _alias_git_pattern(records: list[DecisionRecord]) -> str:
     for alias in aliases:
         escaped = re.escape(alias)
         escaped = re.sub(r"\\\s+", r"[[:space:]]+", escaped)
-        patterns.append(escaped)
+        patterns.append(r"(^|[^[:alnum:]_.-])" + escaped + r"([^[:alnum:]_.-]|$)")
     return "|".join(patterns)
 
 
+def _alias_python_pattern(alias: str) -> re.Pattern[str]:
+    escaped = re.escape(alias)
+    escaped = re.sub(r"\\\s+", r"\\s+", escaped)
+    return re.compile(rf"(?<![A-Za-z0-9_.-]){escaped}(?![A-Za-z0-9_.-])", re.IGNORECASE)
+
+
 def _matching_aliases(record: DecisionRecord, text: str) -> set[str]:
-    haystack = text.casefold()
-    return {alias for alias in record.aliases if alias.casefold() in haystack}
+    return {alias for alias in record.aliases if _alias_python_pattern(alias).search(text)}
 
 
 def _extract_pr_refs(text: str) -> list[str]:
@@ -254,15 +274,14 @@ def _scan_path_touches(project_root: Path, by_path: dict[str, DecisionRecord]) -
         project_root,
         ["log", "--all", "--name-only", "--date=iso-strict", f"--format={GIT_FORMAT}", "--", str(DECISIONS_DIR)],
     )
-    for sha, date, subject, body, payload in _parse_git_records(output):
-        message = f"{subject}\n{body}\n{payload}"
+    for sha, date, subject, _body, payload in _parse_git_records(output):
         for line in payload.splitlines():
             record = by_path.get(line.strip())
             if record:
-                record.add_commit(sha, date, subject, {"file_path"}, message)
+                record.add_commit(sha, date, subject, set(), "path")
 
 
-def _scan_alias_hits(project_root: Path, records: list[DecisionRecord]) -> None:
+def _scan_alias_hits(project_root: Path, records: list[DecisionRecord], *, with_patch_scan: bool = False) -> None:
     pattern = _alias_git_pattern(records)
     if not pattern:
         return
@@ -277,23 +296,34 @@ def _scan_alias_hits(project_root: Path, records: list[DecisionRecord]) -> None:
         f"--format={GIT_FORMAT}",
     ]
     output = _run_git(project_root, command)
-    for sha, date, subject, body, payload in _parse_git_records(output):
-        text = f"{subject}\n{body}\n{_changed_patch_text(payload)}"
+    for sha, date, subject, body, _payload in _parse_git_records(output):
+        text = f"{subject}\n{body}"
         for record in records:
             matched = _matching_aliases(record, text)
             if matched:
-                record.add_commit(sha, date, subject, matched, text)
+                record.add_commit(sha, date, subject, matched, "message")
 
-    if _commit_count(project_root) > PATCH_SCAN_COMMIT_LIMIT:
+    commit_count = _commit_count(project_root)
+    if commit_count > PATCH_SCAN_COMMIT_LIMIT and not with_patch_scan:
+        print(
+            "decision_lineage: patch-text scan skipped "
+            f"(repo has {commit_count} commits > {PATCH_SCAN_COMMIT_LIMIT} limit); "
+            "add --with-patch-scan to force.",
+            file=sys.stderr,
+        )
         return
     command = ["log", "--all", "-p", "--date=iso-strict", "-G", pattern, f"--format={GIT_FORMAT}", "--", "."]
     output = _run_git(project_root, command)
     for sha, date, subject, body, payload in _parse_git_records(output):
-        text = f"{subject}\n{body}\n{_changed_patch_text(payload)}"
+        message_text = f"{subject}\n{body}"
+        patch_text = _changed_patch_text(payload)
         for record in records:
-            matched = _matching_aliases(record, text)
+            message_matched = _matching_aliases(record, message_text)
+            patch_matched = _matching_aliases(record, patch_text)
+            matched = message_matched | patch_matched
             if matched:
-                record.add_commit(sha, date, subject, matched, text)
+                match_kind = "message" if message_matched else "patch"
+                record.add_commit(sha, date, subject, matched, match_kind)
 
 
 def _filter_records(records: list[DecisionRecord], decision_id: str | None) -> list[DecisionRecord]:
@@ -306,20 +336,30 @@ def _filter_records(records: list[DecisionRecord], decision_id: str | None) -> l
     ]
 
 
-def scan_decision_lineage(project_root: Path = PROJECT_ROOT, decision_id: str | None = None) -> list[dict[str, Any]]:
+def scan_decision_lineage(
+    project_root: Path = PROJECT_ROOT,
+    decision_id: str | None = None,
+    *,
+    with_patch_scan: bool = False,
+) -> list[dict[str, Any]]:
     """Return lineage records for every markdown file under docs/decisions."""
     records = _filter_records(load_decision_records(project_root), decision_id)
     if not records:
         return []
     by_path = {record.file_path: record for record in records}
     _scan_path_touches(project_root, by_path)
-    _scan_alias_hits(project_root, records)
+    _scan_alias_hits(project_root, records, with_patch_scan=with_patch_scan)
     return [record.as_dict() for record in records]
 
 
-def build_lineage_response(project_root: Path = PROJECT_ROOT, decision_id: str | None = None) -> dict[str, Any]:
+def build_lineage_response(
+    project_root: Path = PROJECT_ROOT,
+    decision_id: str | None = None,
+    *,
+    with_patch_scan: bool = False,
+) -> dict[str, Any]:
     """Build the JSON response shared by the CLI and Monitor API."""
-    decisions = scan_decision_lineage(project_root, decision_id=decision_id)
+    decisions = scan_decision_lineage(project_root, decision_id=decision_id, with_patch_scan=with_patch_scan)
     return {"count": len(decisions), "decisions": decisions}
 
 
@@ -353,13 +393,24 @@ Related:
         "--decision-id",
         help="Filter to one decision ID or alias, e.g. ADR-008, dec-007, or a filename slug. Default: all decisions.",
     )
+    parser.add_argument(
+        "--with-patch-scan",
+        action="store_true",
+        help=f"Force git patch-text scan even when repo history exceeds {PATCH_SCAN_COMMIT_LIMIT} commits.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     try:
-        print(json.dumps(build_lineage_response(decision_id=args.decision_id), ensure_ascii=False, indent=2))
+        print(
+            json.dumps(
+                build_lineage_response(decision_id=args.decision_id, with_patch_scan=args.with_patch_scan),
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
     except RuntimeError as exc:
         print(f"decision_lineage: {exc}", file=sys.stderr)
         return 1

--- a/scripts/audit/decision_lineage.py
+++ b/scripts/audit/decision_lineage.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Scan decision files and git history for lineage backlinks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DECISIONS_DIR = Path("docs/decisions")
+DECISIONS_YAML = DECISIONS_DIR / "decisions.yaml"
+COMMIT_SEP = "\x1e"
+FIELD_SEP = "\x1f"
+PAYLOAD_SEP = "\x1d"
+GIT_FORMAT = "%x1e%H%x1f%cI%x1f%s%x1f%B%x1d"
+PATCH_SCAN_COMMIT_LIMIT = 200
+
+
+@dataclass
+class DecisionRecord:
+    """Parsed decision file plus lineage backlinks."""
+
+    decision_id: str
+    file_path: str
+    aliases: list[str]
+    commits: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def add_commit(self, sha: str, date: str, subject: str, matched_aliases: set[str], text: str) -> None:
+        """Attach one matching commit, merging duplicate path/alias hits."""
+        commit = self.commits.setdefault(
+            sha,
+            {
+                "sha": sha,
+                "date": date,
+                "subject": subject,
+                "matched_aliases": [],
+                "prs": [],
+            },
+        )
+        commit["matched_aliases"] = sorted(set(commit["matched_aliases"]) | matched_aliases)
+        commit["prs"] = sorted(set(commit["prs"]) | set(_extract_pr_refs(text)), key=_pr_sort_key)
+
+    def as_dict(self) -> dict[str, Any]:
+        commits = sorted(self.commits.values(), key=lambda item: (item["date"], item["sha"]))
+        prs = sorted({pr for commit in commits for pr in commit["prs"]}, key=_pr_sort_key)
+        dates = [commit["date"] for commit in commits if commit.get("date")]
+        return {
+            "decision_id": self.decision_id,
+            "file_path": self.file_path,
+            "aliases": self.aliases,
+            "commits": commits,
+            "prs": prs,
+            "first_cited_at": dates[0] if dates else None,
+            "last_cited_at": dates[-1] if dates else None,
+        }
+
+
+def _extract_frontmatter(text: str) -> dict[str, Any]:
+    if not text.startswith("---\n"):
+        return {}
+    parts = text.split("\n---\n", 1)
+    if len(parts) != 2:
+        return {}
+    try:
+        data = yaml.safe_load(parts[0].removeprefix("---\n"))
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _first_heading(text: str) -> str | None:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    return None
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _normalize_adr(value: str) -> str:
+    match = re.search(r"^ADR[-\s#]*(\d{1,3})\b", value, re.IGNORECASE)
+    return f"ADR-{int(match.group(1)):03d}" if match else ""
+
+
+def _normal_title(value: str) -> str:
+    value = re.sub(r"^ADR[-\s#]*\d{1,3}\s*[:—–.-]\s*", "", value, flags=re.IGNORECASE)
+    value = re.sub(r"^(ACCEPTED|RESOLVED|DECISION REQUIRED|Decision Brief)\s*[—–-]\s*", "", value)
+    return re.sub(r"\s+", " ", value).strip().casefold()
+
+
+def _load_decision_yaml_ids(project_root: Path) -> dict[str, list[str]]:
+    path = project_root / DECISIONS_YAML
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text("utf-8")) or {}
+    by_title: dict[str, list[str]] = {}
+    for item in data.get("decisions", []):
+        dec_id = str(item.get("id", "")).strip()
+        title = str(item.get("title", "")).strip()
+        if dec_id and title:
+            by_title.setdefault(_normal_title(title), []).append(dec_id)
+    return by_title
+
+
+def _declared_ids(frontmatter: dict[str, Any], text: str) -> list[str]:
+    ids: list[str] = []
+    for key in ("decision_id", "decision_ids", "id", "ids", "aliases", "adr", "adr_id"):
+        ids.extend(_as_list(frontmatter.get(key)))
+
+    header_text = "\n".join(text.splitlines()[:30])
+    for match in re.finditer(r"^\s*(?:>\s*)?\*\*(?:Decision IDs?|ID)\*\*:\s*(.+)$", header_text, re.MULTILINE):
+        ids.extend(part.strip(" `") for part in re.split(r"[,;]", match.group(1)) if part.strip())
+    return ids
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        value = re.sub(r"\s+", " ", value).strip()
+        if not value:
+            continue
+        key = value.casefold()
+        if key not in seen:
+            seen.add(key)
+            result.append(value)
+    return result
+
+
+def load_decision_records(project_root: Path = PROJECT_ROOT) -> list[DecisionRecord]:
+    """Walk docs/decisions/**/*.md and parse decision IDs and aliases."""
+    yaml_ids_by_title = _load_decision_yaml_ids(project_root)
+    records: list[DecisionRecord] = []
+
+    for path in sorted((project_root / DECISIONS_DIR).glob("**/*.md")):
+        rel_path = path.relative_to(project_root).as_posix()
+        text = path.read_text("utf-8")
+        frontmatter = _extract_frontmatter(text)
+        heading = _first_heading(text)
+        slug = path.stem
+        aliases = [slug, rel_path]
+        if heading:
+            aliases.append(heading)
+            stripped_title = re.sub(r"^ADR[-\s#]*\d{1,3}\s*[:—–.-]\s*", "", heading, flags=re.IGNORECASE)
+            aliases.append(stripped_title)
+
+        ids = _declared_ids(frontmatter, text)
+        adr = _normalize_adr(heading or slug)
+        if adr:
+            ids.append(adr)
+            ids.append(f"dec-{int(adr.removeprefix('ADR-')):03d}")
+        if heading:
+            ids.extend(yaml_ids_by_title.get(_normal_title(heading), []))
+        aliases.extend(ids)
+
+        decision_id = _unique(ids)[0] if _unique(ids) else slug
+        records.append(DecisionRecord(decision_id=decision_id, file_path=rel_path, aliases=_unique(aliases)))
+
+    return records
+
+
+def _run_git(project_root: Path, args: list[str]) -> str:
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        env.pop(key, None)
+    result = subprocess.run(
+        ["git", "-C", str(project_root), *args],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git command failed")
+    return result.stdout
+
+
+def _commit_count(project_root: Path) -> int:
+    output = _run_git(project_root, ["rev-list", "--all", "--count"]).strip()
+    return int(output or "0")
+
+
+def _parse_git_records(output: str) -> list[tuple[str, str, str, str, str]]:
+    records = []
+    for chunk in output.split(COMMIT_SEP):
+        if not chunk.strip():
+            continue
+        parts = chunk.split(FIELD_SEP, 3)
+        if len(parts) != 4:
+            continue
+        sha, date, subject, rest = parts
+        body, _, payload = rest.partition(PAYLOAD_SEP)
+        records.append((sha.strip(), date.strip(), subject.strip(), body, payload))
+    return records
+
+
+def _changed_patch_text(payload: str) -> str:
+    lines = []
+    for line in payload.splitlines():
+        if line.startswith(("+++", "---")):
+            continue
+        if line.startswith(("+", "-")):
+            lines.append(line[1:])
+    return "\n".join(lines)
+
+
+def _alias_git_pattern(records: list[DecisionRecord]) -> str:
+    aliases = sorted(
+        {alias for record in records for alias in record.aliases if len(alias) >= 3},
+        key=len,
+        reverse=True,
+    )
+    patterns = []
+    for alias in aliases:
+        escaped = re.escape(alias)
+        escaped = re.sub(r"\\\s+", r"[[:space:]]+", escaped)
+        patterns.append(escaped)
+    return "|".join(patterns)
+
+
+def _matching_aliases(record: DecisionRecord, text: str) -> set[str]:
+    haystack = text.casefold()
+    return {alias for alias in record.aliases if alias.casefold() in haystack}
+
+
+def _extract_pr_refs(text: str) -> list[str]:
+    refs = {f"#{match.group(1)}" for match in re.finditer(r"(?<![\w/#])#(\d{2,6})\b", text)}
+    refs.update(f"#{match.group(1)}" for match in re.finditer(r"\bPR\s*#?(\d{2,6})\b", text, re.IGNORECASE))
+    return sorted(refs, key=_pr_sort_key)
+
+
+def _pr_sort_key(value: str) -> tuple[int, str]:
+    number = re.search(r"\d+", value)
+    return (int(number.group(0)) if number else 0, value)
+
+
+def _scan_path_touches(project_root: Path, by_path: dict[str, DecisionRecord]) -> None:
+    output = _run_git(
+        project_root,
+        ["log", "--all", "--name-only", "--date=iso-strict", f"--format={GIT_FORMAT}", "--", str(DECISIONS_DIR)],
+    )
+    for sha, date, subject, body, payload in _parse_git_records(output):
+        message = f"{subject}\n{body}\n{payload}"
+        for line in payload.splitlines():
+            record = by_path.get(line.strip())
+            if record:
+                record.add_commit(sha, date, subject, {"file_path"}, message)
+
+
+def _scan_alias_hits(project_root: Path, records: list[DecisionRecord]) -> None:
+    pattern = _alias_git_pattern(records)
+    if not pattern:
+        return
+    command = [
+        "log",
+        "--all",
+        "--date=iso-strict",
+        "--regexp-ignore-case",
+        "--extended-regexp",
+        "--grep",
+        pattern,
+        f"--format={GIT_FORMAT}",
+    ]
+    output = _run_git(project_root, command)
+    for sha, date, subject, body, payload in _parse_git_records(output):
+        text = f"{subject}\n{body}\n{_changed_patch_text(payload)}"
+        for record in records:
+            matched = _matching_aliases(record, text)
+            if matched:
+                record.add_commit(sha, date, subject, matched, text)
+
+    if _commit_count(project_root) > PATCH_SCAN_COMMIT_LIMIT:
+        return
+    command = ["log", "--all", "-p", "--date=iso-strict", "-G", pattern, f"--format={GIT_FORMAT}", "--", "."]
+    output = _run_git(project_root, command)
+    for sha, date, subject, body, payload in _parse_git_records(output):
+        text = f"{subject}\n{body}\n{_changed_patch_text(payload)}"
+        for record in records:
+            matched = _matching_aliases(record, text)
+            if matched:
+                record.add_commit(sha, date, subject, matched, text)
+
+
+def _filter_records(records: list[DecisionRecord], decision_id: str | None) -> list[DecisionRecord]:
+    if not decision_id:
+        return records
+    needle = decision_id.casefold()
+    return [
+        record for record in records
+        if record.decision_id.casefold() == needle or any(alias.casefold() == needle for alias in record.aliases)
+    ]
+
+
+def scan_decision_lineage(project_root: Path = PROJECT_ROOT, decision_id: str | None = None) -> list[dict[str, Any]]:
+    """Return lineage records for every markdown file under docs/decisions."""
+    records = _filter_records(load_decision_records(project_root), decision_id)
+    if not records:
+        return []
+    by_path = {record.file_path: record for record in records}
+    _scan_path_touches(project_root, by_path)
+    _scan_alias_hits(project_root, records)
+    return [record.as_dict() for record in records]
+
+
+def build_lineage_response(project_root: Path = PROJECT_ROOT, decision_id: str | None = None) -> dict[str, Any]:
+    """Build the JSON response shared by the CLI and Monitor API."""
+    decisions = scan_decision_lineage(project_root, decision_id=decision_id)
+    return {"count": len(decisions), "decisions": decisions}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan docs/decisions markdown files and git history for decision-lineage backlinks.\n"
+            "Use this when you need read-only JSON showing which commits and PR refs cite or touch a decision."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  .venv/bin/python scripts/audit/decision_lineage.py
+  .venv/bin/python scripts/audit/decision_lineage.py --decision-id ADR-008
+  .venv/bin/python scripts/audit/decision_lineage.py --decision-id 2026-05-06-broker-stays-on-sqlite
+
+Outputs:
+  JSON to stdout only. Does not write files, update DBs, or mutate git state.
+
+Exit codes:
+  0 = scan completed
+  1 = git scan or argument failure
+
+Related:
+  docs/decisions/INDEX.md
+  scripts/audit/check_decisions.py
+  Monitor API: GET /api/decisions/lineage
+  Issue: #1785
+""",
+    )
+    parser.add_argument(
+        "--decision-id",
+        help="Filter to one decision ID or alias, e.g. ADR-008, dec-007, or a filename slug. Default: all decisions.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        print(json.dumps(build_lineage_response(decision_id=args.decision_id), ensure_ascii=False, indent=2))
+    except RuntimeError as exc:
+        print(f"decision_lineage: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/audit/test_decision_lineage.py
+++ b/tests/audit/test_decision_lineage.py
@@ -1,0 +1,137 @@
+"""Tests for the decision lineage scanner."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.api import decisions_router
+from scripts.api.main import app
+from scripts.audit.decision_lineage import build_lineage_response
+
+
+def _git(repo: Path, *args: str, date: str | None = None) -> None:
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        env.pop(key, None)
+    if date:
+        env["GIT_AUTHOR_DATE"] = date
+        env["GIT_COMMITTER_DATE"] = date
+    subprocess.run(["git", *args], cwd=repo, env=env, check=True, capture_output=True, text=True)
+
+
+def _commit(repo: Path, message: str, date: str) -> None:
+    _git(repo, "add", ".", date=date)
+    _git(repo, "commit", "-m", message, date=date)
+
+
+def test_decision_lineage_finds_path_title_and_declared_id_aliases(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Decision Test")
+
+    decisions = repo / "docs" / "decisions"
+    decisions.mkdir(parents=True)
+    notes = repo / "docs" / "notes.md"
+
+    alpha = decisions / "2026-01-01-alpha-path.md"
+    alpha.write_text(
+        "# ADR-001: Alpha Path Decision\n\n"
+        "**Status**: Accepted\n\n"
+        "The alpha path is accepted.\n",
+        encoding="utf-8",
+    )
+    beta = decisions / "2026-01-02-beta-routing.md"
+    beta.write_text(
+        "---\n"
+        "decision_ids:\n"
+        "  - BETA-42\n"
+        "---\n"
+        "# Beta Routing Decision\n\n"
+        "Beta routing is accepted.\n",
+        encoding="utf-8",
+    )
+    notes.write_text("Initial notes.\n", encoding="utf-8")
+    _commit(repo, "Initial decision files", "2026-01-01T00:00:00+00:00")
+
+    alpha.write_text(alpha.read_text("utf-8") + "\nPath touch follow-up.\n", encoding="utf-8")
+    _commit(repo, "Touch alpha decision path (#101)", "2026-01-02T00:00:00+00:00")
+
+    notes.write_text("Follow Alpha Path Decision in the builder.\n", encoding="utf-8")
+    _commit(repo, "Reference Alpha Path Decision title", "2026-01-03T00:00:00+00:00")
+
+    notes.write_text(notes.read_text("utf-8") + "Implement BETA-42 fallback.\n", encoding="utf-8")
+    _commit(repo, "Reference BETA-42 declared ID PR #202", "2026-01-04T00:00:00+00:00")
+
+    response = build_lineage_response(repo)
+    by_file = {item["file_path"]: item for item in response["decisions"]}
+
+    alpha_record = by_file["docs/decisions/2026-01-01-alpha-path.md"]
+    beta_record = by_file["docs/decisions/2026-01-02-beta-routing.md"]
+    alpha_subjects = {commit["subject"] for commit in alpha_record["commits"]}
+    beta_subjects = {commit["subject"] for commit in beta_record["commits"]}
+
+    assert "Touch alpha decision path (#101)" in alpha_subjects
+    assert "Reference Alpha Path Decision title" in alpha_subjects
+    assert "Reference BETA-42 declared ID PR #202" in beta_subjects
+    assert alpha_record["prs"] == ["#101"]
+    assert beta_record["prs"] == ["#202"]
+    assert "ADR-001" in alpha_record["aliases"]
+    assert "Alpha Path Decision" in alpha_record["aliases"]
+    assert "BETA-42" in beta_record["aliases"]
+
+
+def test_decision_id_filter_matches_alias(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Decision Test")
+
+    decisions = repo / "docs" / "decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "2026-01-01-alpha-path.md").write_text(
+        "# ADR-001: Alpha Path Decision\n\nAccepted.\n",
+        encoding="utf-8",
+    )
+    _commit(repo, "Initial ADR-001 (#303)", "2026-01-01T00:00:00+00:00")
+
+    response = build_lineage_response(repo, decision_id="ADR-001")
+
+    assert response["count"] == 1
+    assert response["decisions"][0]["decision_id"] == "ADR-001"
+
+
+def test_monitor_api_lineage_endpoint(monkeypatch):
+    expected = {
+        "count": 1,
+        "decisions": [
+            {
+                "decision_id": "ADR-008",
+                "file_path": "docs/decisions/example.md",
+                "aliases": ["ADR-008"],
+                "commits": [],
+                "prs": [],
+                "first_cited_at": None,
+                "last_cited_at": None,
+            }
+        ],
+    }
+    seen: dict[str, str | None] = {}
+
+    def fake_load_lineage(decision_id: str | None = None) -> dict:
+        seen["decision_id"] = decision_id
+        return expected
+
+    monkeypatch.setattr(decisions_router, "_load_lineage", fake_load_lineage)
+
+    response = TestClient(app).get("/api/decisions/lineage?decision_id=ADR-008")
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    assert seen["decision_id"] == "ADR-008"

--- a/tests/audit/test_decision_lineage.py
+++ b/tests/audit/test_decision_lineage.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from scripts.api import decisions_router
 from scripts.api.main import app
+from scripts.audit import decision_lineage
 from scripts.audit.decision_lineage import build_lineage_response
 
 
@@ -68,6 +69,9 @@ def test_decision_lineage_finds_path_title_and_declared_id_aliases(tmp_path):
     notes.write_text(notes.read_text("utf-8") + "Implement BETA-42 fallback.\n", encoding="utf-8")
     _commit(repo, "Reference BETA-42 declared ID PR #202", "2026-01-04T00:00:00+00:00")
 
+    notes.write_text(notes.read_text("utf-8") + "Patch-only BETA-42 expansion.\n", encoding="utf-8")
+    _commit(repo, "refactor: tidy notes.md (#404)", "2026-01-05T00:00:00+00:00")
+
     response = build_lineage_response(repo)
     by_file = {item["file_path"]: item for item in response["decisions"]}
 
@@ -79,11 +83,85 @@ def test_decision_lineage_finds_path_title_and_declared_id_aliases(tmp_path):
     assert "Touch alpha decision path (#101)" in alpha_subjects
     assert "Reference Alpha Path Decision title" in alpha_subjects
     assert "Reference BETA-42 declared ID PR #202" in beta_subjects
-    assert alpha_record["prs"] == ["#101"]
+    assert "refactor: tidy notes.md (#404)" in beta_subjects
+    assert alpha_record["prs"] == []
     assert beta_record["prs"] == ["#202"]
     assert "ADR-001" in alpha_record["aliases"]
     assert "Alpha Path Decision" in alpha_record["aliases"]
     assert "BETA-42" in beta_record["aliases"]
+
+    alpha_commits = {commit["subject"]: commit for commit in alpha_record["commits"]}
+    beta_commits = {commit["subject"]: commit for commit in beta_record["commits"]}
+    assert alpha_commits["Touch alpha decision path (#101)"]["match_kind"] == "path"
+    assert alpha_commits["Touch alpha decision path (#101)"]["matched_aliases"] == []
+    assert alpha_commits["Reference Alpha Path Decision title"]["match_kind"] == "message"
+    assert beta_commits["Reference BETA-42 declared ID PR #202"]["match_kind"] == "message"
+    assert beta_commits["refactor: tidy notes.md (#404)"]["match_kind"] == "patch"
+    assert "BETA-42" in beta_commits["refactor: tidy notes.md (#404)"]["matched_aliases"]
+    assert all("file_path" not in commit["matched_aliases"] for commit in alpha_record["commits"])
+    assert all("file_path" not in commit["matched_aliases"] for commit in beta_record["commits"])
+
+
+def test_decision_lineage_skips_non_decision_docs_and_uses_token_boundaries(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Decision Test")
+
+    decisions = repo / "docs" / "decisions"
+    pending = decisions / "pending"
+    pending.mkdir(parents=True)
+    notes = repo / "docs" / "notes.md"
+
+    (decisions / "INDEX.md").write_text("# Decision Journal Index\n", encoding="utf-8")
+    (pending / "README.md").write_text("# Pending Decisions\n", encoding="utf-8")
+    (decisions / "index-decision.md").write_text(
+        "---\n"
+        "decision_id: INDEX\n"
+        "---\n"
+        "# Index Decision\n\n"
+        "This deliberately uses an English-word alias.\n",
+        encoding="utf-8",
+    )
+    notes.write_text("Initial notes.\n", encoding="utf-8")
+    _commit(repo, "Initial decision docs", "2026-01-01T00:00:00+00:00")
+
+    notes.write_text("Update index.html after indexing READMEs.\n", encoding="utf-8")
+    _commit(repo, "Update index.html after indexing READMEs #505", "2026-01-02T00:00:00+00:00")
+
+    response = build_lineage_response(repo)
+
+    assert response["count"] == 1
+    record = response["decisions"][0]
+    assert record["file_path"] == "docs/decisions/index-decision.md"
+    assert "INDEX" in record["aliases"]
+    subjects = {commit["subject"] for commit in record["commits"]}
+    assert "Update index.html after indexing READMEs #505" not in subjects
+    assert record["prs"] == []
+
+
+def test_decision_lineage_warns_when_patch_scan_skipped_and_can_force_it(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Decision Test")
+
+    decisions = repo / "docs" / "decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "2026-01-01-alpha.md").write_text("# ADR-001: Alpha\n\nAccepted.\n", encoding="utf-8")
+    _commit(repo, "Initial ADR-001", "2026-01-01T00:00:00+00:00")
+
+    monkeypatch.setattr(decision_lineage, "PATCH_SCAN_COMMIT_LIMIT", 0)
+
+    build_lineage_response(repo)
+    stderr = capsys.readouterr().err
+    assert "decision_lineage: patch-text scan skipped" in stderr
+    assert "add --with-patch-scan to force" in stderr
+
+    build_lineage_response(repo, with_patch_scan=True)
+    assert "patch-text scan skipped" not in capsys.readouterr().err
 
 
 def test_decision_id_filter_matches_alias(tmp_path):


### PR DESCRIPTION
Closes #1785.

## Summary
- Add read-only decision-lineage scanner at `scripts/audit/decision_lineage.py`.
- Expose Monitor API endpoint `GET /api/decisions/lineage` with optional `decision_id` filter.
- Add fixture tests for path, title, declared ID aliases, PR extraction, filtering, and API route wiring.
- Document the script in `docs/SCRIPTS.md`.

## Acceptance checklist
- [x] Walks `docs/decisions/**/*.md` and emits one record per file.
- [x] Scans git history for file-path touches and multi-alias references: filename slug, first heading/title, ADR shorthand, declared/frontmatter decision IDs, and PR refs from matching commits.
- [x] Outputs JSON records with `decision_id`, `file_path`, `aliases`, `commits`, `prs`, `first_cited_at`, and `last_cited_at`.
- [x] Exposes read-only Monitor API endpoint `/api/decisions/lineage`.
- [x] Provides CLI: `.venv/bin/python scripts/audit/decision_lineage.py [--decision-id X]`.
- [x] Adds fixture with 2 decision files and 3 fake commits covering path/title/declared-ID references.
- [x] Updates `docs/SCRIPTS.md`.
- [x] CLI help conforms to `cli-help-standard.md` with description, examples, outputs, exit codes, and related links.

## Validation
- Targeted ruff: `ruff check scripts/audit/decision_lineage.py scripts/api/decisions_router.py tests/audit/test_decision_lineage.py` -> pass.
- Targeted pytest: `pytest tests/audit/test_decision_lineage.py -x` -> 3 passed.
- API smoke: `/api/decisions/stale` and `/api/decisions/lineage?decision_id=ADR-008` -> 200.
- Live scanner: ADR-008 returned 16 commits, 41 PR refs, 6 aliases; first cited `2026-04-21T20:41:02+02:00`, last cited `2026-05-08T00:41:55+02:00`.

Note: this worktree does not contain a local `.venv` directory, so validations were run from the repo venv at `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/...` while the working directory remained this delegated worktree.