### PR TITLE
feat(mcp): add streamable HTTP transport for sources

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -24,6 +24,7 @@ Tools:
 """
 
 import asyncio
+import contextlib
 import json
 import sys
 from pathlib import Path
@@ -1803,23 +1804,35 @@ async def main_stdio():
         await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
-async def main_sse(host: str = "127.0.0.1", port: int = 8766):
-    """Run the MCP sources server as a standalone SSE daemon."""
-    import uvicorn
+def create_http_app():
+    """Create the standalone HTTP app with SSE and Streamable HTTP transports."""
+    import anyio
     from mcp.server.sse import SseServerTransport
+    from mcp.server.streamable_http import StreamableHTTPServerTransport
     from starlette.applications import Starlette
     from starlette.responses import Response
     from starlette.routing import Mount, Route
 
-    # Verify SQLite sources database exists
-    from wiki.sources_db import source_count
-    try:
-        total = source_count()
-        print(f"SQLite sources database: {total:,} entries ✅")
-    except FileNotFoundError:
-        print("⚠️  Sources database not found. Run: .venv/bin/python scripts/wiki/build_sources_db.py")
-
     sse = SseServerTransport("/messages/")
+
+    def _scope_with_default_accept(scope):
+        method = scope.get("method")
+        default_accept = b"text/event-stream" if method == "GET" else b"application/json"
+        headers = [
+            (name, value)
+            for name, value in scope["headers"]
+            if name.lower() != b"accept"
+        ]
+        accept_values = [
+            value.strip()
+            for name, value in scope["headers"]
+            if name.lower() == b"accept"
+            for value in value.split(b",")
+        ]
+        if not accept_values or accept_values == [b"*/*"]:
+            headers.append((b"accept", default_accept))
+            return {**scope, "headers": headers}
+        return scope
 
     async def handle_health(request):
         return Response('{"status":"ok"}', media_type="application/json")
@@ -1837,16 +1850,62 @@ async def main_sse(host: str = "127.0.0.1", port: int = 8766):
             pass
         return Response()
 
+    class StreamableHTTPEndpoint:
+        async def __call__(self, scope, receive, send):
+            http_transport = StreamableHTTPServerTransport(
+                mcp_session_id=None,
+                is_json_response_enabled=True,
+            )
+            scope = _scope_with_default_accept(scope)
+
+            async with http_transport.connect() as streams:
+                read_stream, write_stream = streams
+
+                async def run_streamable_http_server():
+                    with contextlib.suppress(Exception):
+                        await server.run(
+                            read_stream,
+                            write_stream,
+                            server.create_initialization_options(),
+                            stateless=True,
+                        )
+
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(run_streamable_http_server)
+                    await http_transport.handle_request(scope, receive, send)
+                    await http_transport.terminate()
+                    tg.cancel_scope.cancel()
+
     app = Starlette(
         routes=[
             Route("/health", endpoint=handle_health),
             Route("/sse", endpoint=handle_sse),
+            Route("/mcp", endpoint=StreamableHTTPEndpoint(), methods=["GET", "POST", "DELETE"]),
             Mount("/messages/", app=sse.handle_post_message),
         ],
     )
 
+    return app
+
+
+async def main_sse(host: str = "127.0.0.1", port: int = 8766):
+    """Run the MCP sources server as a standalone SSE daemon."""
+    import uvicorn
+
+    # Verify SQLite sources database exists
+    from wiki.sources_db import source_count
+    try:
+        total = source_count()
+        print(f"SQLite sources database: {total:,} entries ✅")
+    except FileNotFoundError:
+        print("⚠️  Sources database not found. Run: .venv/bin/python scripts/wiki/build_sources_db.py")
+
+    # create_http_app keeps server.run(..., stateless=True) for HTTP transports.
+    app = create_http_app()
+
     print(f"MCP Sources Server (SSE) running on http://{host}:{port}")
     print(f"  SSE endpoint: http://{host}:{port}/sse")
+    print(f"  Streamable HTTP endpoint: http://{host}:{port}/mcp")
     print(f"  Messages: http://{host}:{port}/messages/")
     sys.stdout.flush()
 

--- a/tests/test_mcp_sources_streamable_http.py
+++ b/tests/test_mcp_sources_streamable_http.py
@@ -1,0 +1,110 @@
+"""Streamable HTTP transport tests for the MCP sources server."""
+
+from __future__ import annotations
+
+import importlib.util
+import socket
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+
+SERVER_PATH = Path(__file__).resolve().parents[1] / ".mcp" / "servers" / "sources" / "server.py"
+
+
+def _load_sources_server():
+    spec = importlib.util.spec_from_file_location("mcp_sources_streamable_server", SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def sources_http_url():
+    module = _load_sources_server()
+    port = _free_port()
+    app = module.create_http_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+
+    thread.start()
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(f"{base_url}/health", timeout=0.5)
+            if response.status_code == 200:
+                break
+        except httpx.HTTPError:
+            time.sleep(0.05)
+    else:
+        server.should_exit = True
+        thread.join(timeout=5)
+        pytest.fail("MCP sources HTTP server did not start")
+
+    yield base_url
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_streamable_http_initialize_returns_capabilities(sources_http_url):
+    response = httpx.post(
+        f"{sources_http_url}/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0"},
+            },
+        },
+        timeout=5,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 1
+    assert "capabilities" in body["result"]
+
+
+def test_streamable_http_tools_list_contains_verify_words(sources_http_url):
+    response = httpx.post(
+        f"{sources_http_url}/mcp",
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        timeout=5,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    tool_names = {tool["name"] for tool in body["result"]["tools"]}
+    assert "verify_words" in tool_names
+
+
+def test_legacy_sse_endpoint_still_emits_message_endpoint(sources_http_url):
+    text = ""
+    timeout = httpx.Timeout(2.0, connect=2.0, read=2.0, write=2.0, pool=2.0)
+    with httpx.stream("GET", f"{sources_http_url}/sse", timeout=timeout) as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        for chunk in response.iter_text():
+            text += chunk
+            if "event: endpoint" in text and "data: /messages/?session_id=" in text:
+                break
+
+    assert "event: endpoint" in text
+    assert "data: /messages/?session_id=" in text


### PR DESCRIPTION
## Root cause

Codex v0.129 uses Streamable HTTP for URL-configured MCP servers. The local config pointed `sources` at `http://127.0.0.1:8766/sse`, but the sources server only exposed legacy SSE (`/sse` + `/messages/`). Codex POSTed `initialize` to `/sse`, got HTTP 405 Method Not Allowed, and the `mcp__sources__*` tools were unavailable.

Pre-fix reproduction in this worktree:

```text
rmcp::transport::worker: worker quit with fatal: Transport channel closed, when UnexpectedContentType(Some("text/plain; charset=utf-8; body: Method Not Allowed"))
I can’t call `mcp__sources__verify_words` because that MCP tool isn’t available in this session.
```

## Fix

- Added a `/mcp` Streamable HTTP endpoint to `.mcp/servers/sources/server.py` using `StreamableHTTPServerTransport` directly.
- Reuses the existing `server` instance and runs it with `stateless=True`, matching the SSE transport behavior.
- Preserves the existing `/sse`, `/messages/`, and `/health` routes for Claude Code backward compatibility.
- Updated startup output to advertise the new `/mcp` endpoint.
- Added `tests/test_mcp_sources_streamable_http.py` to boot the HTTP app under uvicorn and verify initialize, tools/list, and legacy SSE endpoint behavior.

## Acceptance checklist

- [x] `/mcp` endpoint added and accepts Streamable HTTP POST initialize requests.
- [x] Existing `/sse` + `/messages/` endpoints preserved.
- [x] `/health` endpoint preserved.
- [x] New Streamable HTTP test covers initialize reply and `tools/list` containing `verify_words`.
- [x] SSE smoke test confirms `event: endpoint` still emits `/messages/?session_id=...`.
- [x] Startup print advertises `/mcp`.
- [x] `ruff check` clean.
- [x] `.venv/bin/pytest tests/test_mcp_sources*.py -x` passes.
- [x] Live curl checks pass.
- [x] Codex CLI works when config URL is temporarily switched to `/mcp`.

## Verification

```bash
.venv/bin/ruff check .mcp/servers/sources/server.py tests/test_mcp_sources_streamable_http.py
# All checks passed!

.venv/bin/pytest tests/test_mcp_sources*.py -x
# 31 passed in 1.03s
```

Live `/mcp` initialize curl:

```text
> POST /mcp HTTP/1.1
> Host: 127.0.0.1:8766
> Accept: */*
> Content-Type: application/json
< HTTP/1.1 200 OK
< content-type: application/json
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"sources","version":"1.26.0"}}}
```

Live legacy `/sse` curl:

```text
> GET /sse HTTP/1.1
> Host: 127.0.0.1:8766
< HTTP/1.1 200 OK
< content-type: text/event-stream; charset=utf-8

event: endpoint
data: /messages/?session_id=322dd930732640f8981d8ecc109b2f88
```

Codex CLI verification after temporarily changing `~/.codex/config.toml` from `/sse` to `/mcp`:

```text
mcp: sources/verify_words started
mcp: sources/verify_words (completed)
`кіт` was found in VESUM.
Result: `кіт` → lemma `кіт`, POS `noun`.
```

`~/.codex/config.toml` was restored to the original `/sse` URL after this check.

## After merge

Switch the local Codex MCP config from:

```toml
url = "http://127.0.0.1:8766/sse"
```

to:

```toml
url = "http://127.0.0.1:8766/mcp"
```

Then restart the sources MCP server.
