### PR TITLE
feat(observability): instrument MCP init in writer dispatch (#1798)

### DIFF
--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -453,6 +453,36 @@ Gemini auth precedence is API first, then subscription/OAuth fallback:
 
 ---
 
+## MCP Writer Observability
+
+Codex `*-tools` writer dispatch must fail before model invocation when MCP intent
+cannot be wired. The dispatch path emits:
+
+- `mcp_config_resolved`: emitted after resolving `.mcp.json` into runtime
+  `tool_config`. Check `requested_servers`, `resolved_servers`,
+  `resolution_status`, `missing_server_names`, and `config_path`.
+- `mcp_runtime_init`: emitted by the runner when Codex output shows MCP runtime
+  status. `status=ready` comes from `mcp: <server>/<tool> started` or
+  `(completed)`. `status=failed` comes from Codex `rmcp::transport::worker`
+  transport errors. `status=timeout` means no runtime init line appeared within
+  the init-observation window.
+
+If a writer label ends in `-tools`, requests MCP servers, and resolves none, the
+pipeline raises `LinearPipelineError` and refuses to dispatch tool-less. Codex
+legacy SSE endpoints (`type: sse` or URLs ending `/sse`) are treated as
+unresolved for this path; use the streamable HTTP `/mcp` endpoint.
+
+To debug "writer produced 0 tool calls", start with the writer JSONL:
+
+1. Find `mcp_config_resolved`. If `resolved_servers` is empty, fix `.mcp.json`
+   or the requested server name before rerunning the bakeoff.
+2. Find `mcp_runtime_init`. `failed` usually includes the Codex transport error
+   line; `timeout` means Codex never showed a server/tool init line.
+3. Only inspect prompt/tool-theatre telemetry after both config resolution and
+   runtime init show the expected `sources` server.
+
+---
+
 ## Escalation
 
 If Gemini is stuck (not completing a phase, silently failing):

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 import contextlib
 import importlib
 import os
+import re
 import shutil
 import signal
 import subprocess
 import time
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -71,6 +73,13 @@ from .watchdog import (
 # enough that we don't burn CPU in the wait loop.
 _POLL_INTERVAL_S = 1.0
 _SHIMS_DIR = Path(__file__).resolve().parent / "shims"
+_MCP_RUNTIME_INIT_TIMEOUT_S = 30.0
+_MCP_TOOL_EVENT_RE = re.compile(
+    r"\bmcp:\s+(?P<server>[A-Za-z0-9_.-]+)/(?P<tool>[A-Za-z0-9_.-]+)\s+"
+    r"(?:started|\(completed\))"
+)
+_MCP_TRANSPORT_FAILURE_RE = re.compile(r"ERROR\s+rmcp::transport::worker:")
+_MCP_FAILURE_URL_RE = re.compile(r"url \((?P<url>https?://[^)\s]+)\)")
 
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.
@@ -384,6 +393,161 @@ class _ExecutionOutcome:
     liveness_paths: tuple[Path, ...]
 
 
+@dataclass
+class _McpRuntimeObserver:
+    """Emit one MCP runtime-init status per configured Codex server."""
+
+    event_sink: Callable[..., None]
+    agent_name: str
+    task_id: str | None
+    configured_servers: set[str]
+    server_urls: dict[str, str]
+    start_time: float
+    timeout_s: float = _MCP_RUNTIME_INIT_TIMEOUT_S
+    ready_servers: set[str] = field(default_factory=set)
+    failed_servers: set[str] = field(default_factory=set)
+    timed_out_servers: set[str] = field(default_factory=set)
+
+    @classmethod
+    def from_tool_config(
+        cls,
+        *,
+        agent_name: str,
+        task_id: str | None,
+        tool_config: dict | None,
+        event_sink: Callable[..., None] | None,
+        start_time: float,
+    ) -> _McpRuntimeObserver | None:
+        if event_sink is None or agent_name != "codex":
+            return None
+        mcp_servers = (tool_config or {}).get("mcp_servers")
+        if not isinstance(mcp_servers, dict) or not mcp_servers:
+            return None
+        server_urls = {
+            name: str(config.get("url"))
+            for name, config in mcp_servers.items()
+            if isinstance(config, dict) and config.get("url")
+        }
+        return cls(
+            event_sink=event_sink,
+            agent_name=agent_name,
+            task_id=task_id,
+            configured_servers=set(mcp_servers),
+            server_urls=server_urls,
+            start_time=start_time,
+        )
+
+    def observe_lines(
+        self,
+        lines: list[str],
+        *,
+        start_index: int,
+        stream: str,
+    ) -> int:
+        for line in lines[start_index:]:
+            self.observe_line(line, stream=stream)
+        return len(lines)
+
+    def observe_line(self, line: str, *, stream: str) -> None:
+        tool_match = _MCP_TOOL_EVENT_RE.search(line)
+        if tool_match:
+            server = tool_match.group("server")
+            if server in self.configured_servers:
+                self._emit_ready(
+                    server,
+                    tool=tool_match.group("tool"),
+                    stream=stream,
+                    line=line,
+                )
+            return
+
+        failure_match = _MCP_TRANSPORT_FAILURE_RE.search(line)
+        if not failure_match:
+            return
+        url_match = _MCP_FAILURE_URL_RE.search(line)
+        servers = self._servers_for_failed_line(
+            url_match.group("url") if url_match else None
+        )
+        for server in servers:
+            self._emit_failed(server, stream=stream, line=line)
+
+    def maybe_emit_timeout(self, now: float) -> None:
+        if now - self.start_time < self.timeout_s:
+            return
+        unresolved = (
+            self.configured_servers
+            - self.ready_servers
+            - self.failed_servers
+            - self.timed_out_servers
+        )
+        for server in sorted(unresolved):
+            self.timed_out_servers.add(server)
+            self._emit(
+                server=server,
+                status="timeout",
+                stream=None,
+                line=(
+                    f"no mcp runtime init line observed within "
+                    f"{self.timeout_s:.0f}s"
+                ),
+            )
+
+    def _servers_for_failed_line(self, url: str | None) -> list[str]:
+        if url:
+            matched = [
+                server
+                for server, server_url in self.server_urls.items()
+                if server_url == url
+            ]
+            if matched:
+                return matched
+        unresolved = self.configured_servers - self.ready_servers - self.failed_servers
+        return sorted(unresolved) or ["unknown"]
+
+    def _emit_ready(
+        self,
+        server: str,
+        *,
+        tool: str,
+        stream: str,
+        line: str,
+    ) -> None:
+        if server in self.ready_servers:
+            return
+        self.ready_servers.add(server)
+        self._emit(server=server, status="ready", stream=stream, line=line, tool=tool)
+
+    def _emit_failed(self, server: str, *, stream: str, line: str) -> None:
+        if server in self.failed_servers:
+            return
+        self.failed_servers.add(server)
+        self._emit(server=server, status="failed", stream=stream, line=line)
+
+    def _emit(
+        self,
+        *,
+        server: str,
+        status: str,
+        stream: str | None,
+        line: str,
+        tool: str | None = None,
+    ) -> None:
+        fields: dict[str, Any] = {
+            "agent": self.agent_name,
+            "server": server,
+            "status": status,
+            "elapsed_s": round(time.monotonic() - self.start_time, 3),
+            "line": line.strip()[:500],
+        }
+        if self.task_id:
+            fields["task_id"] = self.task_id
+        if stream:
+            fields["stream"] = stream
+        if tool:
+            fields["tool"] = tool
+        self.event_sink("mcp_runtime_init", **fields)
+
+
 def _normalize_gemini_tool_auth_mode(raw: Any) -> str:
     """Mirror Gemini adapter auth-mode normalization for tool_config overrides."""
     value = str(raw or "auto").strip().lower()
@@ -462,6 +626,8 @@ def _execute_invocation_plan(
     entrypoint: str,
     hard_timeout: int,
     stall_timeout: int,
+    tool_config: dict | None = None,
+    event_sink: Callable[..., None] | None = None,
     stdout_silence_timeout: int | None = None,
 ) -> _ExecutionOutcome:
     """Spawn one plan, run watchdog/parse flow, and return raw execution state."""
@@ -526,10 +692,32 @@ def _execute_invocation_plan(
         if plan.output_file is not None and plan.output_file not in liveness_paths:
             liveness_paths = (*liveness_paths, plan.output_file)
         watchdog_state, watchdog_threads = start_watchdog(proc, list(liveness_paths))
+        mcp_observer = _McpRuntimeObserver.from_tool_config(
+            agent_name=agent_name,
+            task_id=task_id,
+            tool_config=tool_config,
+            event_sink=event_sink,
+            start_time=start_time,
+        )
+        observed_stdout_lines = 0
+        observed_stderr_lines = 0
 
         early_reap_check = getattr(adapter, "check_early_reap", None)
         kill_reason: str | None = None
         while True:
+            if mcp_observer is not None:
+                observed_stdout_lines = mcp_observer.observe_lines(
+                    watchdog_state.stdout_lines,
+                    start_index=observed_stdout_lines,
+                    stream="stdout",
+                )
+                observed_stderr_lines = mcp_observer.observe_lines(
+                    watchdog_state.stderr_lines,
+                    start_index=observed_stderr_lines,
+                    stream="stderr",
+                )
+                mcp_observer.maybe_emit_timeout(time.monotonic())
+
             returncode = proc.poll()
             if returncode is not None:
                 break
@@ -568,6 +756,19 @@ def _execute_invocation_plan(
         for thread in watchdog_threads:
             if "stdout" in thread.name or "stderr" in thread.name:
                 thread.join(timeout=5.0)
+
+        if mcp_observer is not None:
+            observed_stdout_lines = mcp_observer.observe_lines(
+                watchdog_state.stdout_lines,
+                start_index=observed_stdout_lines,
+                stream="stdout",
+            )
+            observed_stderr_lines = mcp_observer.observe_lines(
+                watchdog_state.stderr_lines,
+                start_index=observed_stderr_lines,
+                stream="stderr",
+            )
+            mcp_observer.maybe_emit_timeout(time.monotonic())
 
         stdout_text = "".join(watchdog_state.stdout_lines)
         stderr_text = "".join(watchdog_state.stderr_lines)
@@ -688,6 +889,7 @@ def _invoke_gemini_with_fallback(
             entrypoint=entrypoint,
             hard_timeout=timeout_s or hard_timeout,
             stall_timeout=stall_timeout,
+            tool_config=attempt_tool_config,
             stdout_silence_timeout=stdout_silence_timeout,
         )
         parse = execution.parse
@@ -933,6 +1135,7 @@ def invoke(
                                  # for the full design rationale.
     stall_timeout: int = 180,  # accepted but ignored; see docstring
     stdout_silence_timeout: int | None = None,
+    event_sink: Callable[..., None] | None = None,
     effort: str | None = None,
 ) -> Result:
     """Single entry point for all agent CLI invocations.
@@ -969,6 +1172,8 @@ def invoke(
         stdout_silence_timeout: Optional per-call stdout silence watchdog in
             seconds. Disabled by default. Use only for protocols where stdout
             bytes are the authoritative liveness signal.
+        event_sink: Optional ``event_sink(event_name, **fields)`` callback for
+            dispatch JSONL observability events.
         effort: Cross-agent reasoning/effort level. First-class peer of
             ``model`` (NOT stuffed into ``tool_config``). Accepted values:
             ``"low" | "medium" | "high" | "xhigh" | "max"``. When ``None``,
@@ -1088,6 +1293,8 @@ def invoke(
         entrypoint=entrypoint,
         hard_timeout=hard_timeout,
         stall_timeout=stall_timeout,
+        tool_config=tool_config,
+        event_sink=event_sink,
         stdout_silence_timeout=stdout_silence_timeout,
     )
     parse = execution.parse

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -8,6 +8,7 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_MCP_CONFIG_PATH = _REPO_ROOT / ".mcp.json"
+_RESOLUTION_STATUSES = {"ok", "config_missing", "config_empty", "servers_not_found"}
 
 
 def _canonical_agent_name(agent: str) -> str | None:
@@ -39,25 +40,97 @@ def _load_mcp_config(mcp_config_path: Path) -> dict[str, Any] | None:
 def _codex_mcp_servers(
     mcp_config_path: Path,
     requested_servers: list[str] | None,
-) -> dict[str, Any] | None:
-    """Return Codex's nested `mcp_servers` config, optionally filtered."""
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Return Codex's nested `mcp_servers` config plus resolution diagnostics."""
+    requested = list(requested_servers or [])
+
+    def diagnostics(
+        *,
+        resolved_servers: list[str] | None = None,
+        resolution_status: str,
+        missing_server_names: list[str] | None = None,
+    ) -> dict[str, Any]:
+        assert resolution_status in _RESOLUTION_STATUSES
+        return {
+            "requested_servers": requested,
+            "resolved_servers": resolved_servers or [],
+            "config_path": str(mcp_config_path),
+            "resolution_status": resolution_status,
+            "missing_server_names": missing_server_names or [],
+        }
+
     data = _load_mcp_config(mcp_config_path)
     if not data:
-        return None
+        return None, diagnostics(resolution_status="config_missing")
 
     servers = data.get("mcpServers")
     if not isinstance(servers, dict) or not servers:
-        return None
+        return None, diagnostics(resolution_status="config_empty")
 
-    if not requested_servers:
-        return servers
+    usable_servers = {
+        server_name: server_config
+        for server_name, server_config in servers.items()
+        if _codex_server_is_usable(server_config)
+    }
+
+    if not requested:
+        if usable_servers:
+            return usable_servers, diagnostics(
+                resolved_servers=list(usable_servers),
+                resolution_status="ok",
+            )
+        return None, diagnostics(
+            resolution_status="servers_not_found",
+            missing_server_names=list(servers),
+        )
 
     selected = {
-        server_name: servers[server_name]
-        for server_name in requested_servers
-        if server_name in servers
+        server_name: usable_servers[server_name]
+        for server_name in requested
+        if server_name in usable_servers
     }
-    return selected or None
+    missing = [server_name for server_name in requested if server_name not in selected]
+    if not selected:
+        return None, diagnostics(
+            resolution_status="servers_not_found",
+            missing_server_names=missing,
+        )
+    return selected, diagnostics(
+        resolved_servers=list(selected),
+        resolution_status="ok",
+        missing_server_names=missing,
+    )
+
+
+def _codex_server_is_usable(server_config: Any) -> bool:
+    """Reject known-stale Codex MCP endpoint shapes before dispatch."""
+    if not isinstance(server_config, dict):
+        return False
+    server_type = str(server_config.get("type") or "").strip().lower()
+    url = str(server_config.get("url") or "").strip()
+    if server_type == "sse":
+        return False
+    if url.rstrip("/").endswith("/sse"):
+        return False
+    return bool(url)
+
+
+def _basic_diagnostics(
+    *,
+    mcp_config_path: Path,
+    requested_servers: list[str] | None,
+    resolved_servers: list[str] | None,
+    resolution_status: str,
+    missing_server_names: list[str] | None = None,
+) -> dict[str, Any]:
+    assert resolution_status in _RESOLUTION_STATUSES
+    return {
+        "requested_servers": list(requested_servers or []),
+        "resolved_servers": list(resolved_servers or []),
+        "config_path": str(mcp_config_path),
+        "resolution_status": resolution_status,
+        "missing_server_names": list(missing_server_names or []),
+    }
 
 
 def build_mcp_tool_config(
@@ -66,30 +139,66 @@ def build_mcp_tool_config(
     mcp_servers: list[str] | None = None,
     allowed_tools: str | None = None,
     mcp_config_path: Path | None = None,
-) -> dict | None:
+) -> tuple[dict | None, dict[str, Any]]:
     """Build adapter-appropriate tool_config dict for MCP access.
 
-    Returns ``None`` when the requested agent cannot be configured for MCP.
-    Gemini also returns ``None`` when no server names are requested.
+    Returns ``(None, diagnostics)`` when the requested agent cannot be
+    configured for MCP. Gemini also returns ``None`` when no server names are
+    requested.
     """
+    resolved_config_path = _resolved_mcp_config_path(mcp_config_path)
     canonical_agent = _canonical_agent_name(agent)
     if canonical_agent is None:
-        return None
-
-    resolved_config_path = _resolved_mcp_config_path(mcp_config_path)
+        return None, _basic_diagnostics(
+            mcp_config_path=resolved_config_path,
+            requested_servers=mcp_servers,
+            resolved_servers=None,
+            resolution_status="servers_not_found",
+            missing_server_names=mcp_servers,
+        )
 
     if canonical_agent == "claude":
         if not allowed_tools or not resolved_config_path.exists():
-            return None
-        return {
-            "mcp_config_path": str(resolved_config_path),
-            "allowed_tools": allowed_tools,
-        }
+            return None, _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status=(
+                    "config_missing"
+                    if not resolved_config_path.exists()
+                    else "config_empty"
+                ),
+            )
+        return (
+            {
+                "mcp_config_path": str(resolved_config_path),
+                "allowed_tools": allowed_tools,
+            },
+            _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
 
     if canonical_agent == "gemini":
         if not mcp_servers:
-            return None
-        return {"mcp_server_names": mcp_servers}
+            return None, _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status="config_empty",
+            )
+        return (
+            {"mcp_server_names": mcp_servers},
+            _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
 
-    codex_servers = _codex_mcp_servers(resolved_config_path, mcp_servers)
-    return {"mcp_servers": codex_servers} if codex_servers else None
+    codex_servers, diagnostics = _codex_mcp_servers(resolved_config_path, mcp_servers)
+    return ({"mcp_servers": codex_servers} if codex_servers else None), diagnostics

--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -473,14 +473,13 @@ def _dispatch_claude_via_runtime(
     )
     from agent_runtime.runner import invoke as runtime_invoke
 
-    tool_config = (
-        build_mcp_tool_config(
+    if mcp_tools and allowed_tools:
+        tool_config, _diagnostics = build_mcp_tool_config(
             "claude",
             allowed_tools=allowed_tools,
         )
-        if mcp_tools and allowed_tools
-        else None
-    )
+    else:
+        tool_config = None
 
     claude_effort = "xhigh"
     t0 = time.monotonic()
@@ -587,11 +586,15 @@ def _dispatch_via_runtime(
     if is_gemini:
         # Gemini in the pipeline is always -y (write-enabled) — existing behavior.
         runtime_mode = "workspace-write"
-        tool_config = (
-            build_mcp_tool_config("gemini", mcp_servers=["rag"])
-            if mcp_tools
-            else None
-        )
+        if mcp_tools:
+            # TODO(#1803): rename "rag" → "sources"; see
+            # .claude/rules/mcp-sources-and-dictionaries.md.
+            tool_config, _diagnostics = build_mcp_tool_config(
+                "gemini",
+                mcp_servers=["rag"],
+            )
+        else:
+            tool_config = None
     elif runtime_agent_name == "gemma-local":
         runtime_mode = "workspace-write"
         tool_config = None

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1723,12 +1723,29 @@ def _render_component_props_schema(allowed_activity_types: str) -> str:
     return "\n".join(lines)
 
 
-def _runtime_tool_config(agent_label: str) -> dict[str, Any]:
+def _runtime_tool_config(
+    agent_label: str,
+    *,
+    event_sink: Callable[..., None] | None = None,
+) -> dict[str, Any]:
     tool_config: dict[str, Any] = {"output_format": "stream-json"}
     if agent_label == "codex-tools":
         from scripts.agent_runtime.tool_config import build_mcp_tool_config
 
-        codex_tools = build_mcp_tool_config("codex", mcp_servers=["sources"])
+        codex_tools, diagnostics = build_mcp_tool_config(
+            "codex",
+            mcp_servers=["sources"],
+        )
+        _emit(event_sink, "mcp_config_resolved", writer=agent_label, **diagnostics)
+        requested = diagnostics["requested_servers"]
+        resolved = diagnostics["resolved_servers"]
+        status = diagnostics["resolution_status"]
+        if agent_label.endswith("-tools") and requested and not resolved:
+            raise LinearPipelineError(
+                f"Writer {agent_label!r} requested MCP servers {requested!r} "
+                f"but resolver returned none ({status}). Refusing to dispatch "
+                "tool-less."
+            )
         if codex_tools:
             tool_config.update(codex_tools)
     assert tool_config.get("output_format") == "stream-json", (
@@ -1769,7 +1786,8 @@ def invoke_writer(
         task_id="phase-4-a1-20-writer",
         entrypoint="dispatch",
         effort=defaults["effort"],
-        tool_config=_runtime_tool_config(writer),
+        tool_config=_runtime_tool_config(writer, event_sink=event_sink),
+        event_sink=event_sink,
         stdout_silence_timeout=stdout_silence_timeout,
     )
     response = getattr(result, "response", None)
@@ -2218,7 +2236,8 @@ def invoke_reviewer_dim(
         task_id=f"phase-4-review-{dim}",
         entrypoint="dispatch",
         effort=defaults["effort"],
-        tool_config=_runtime_tool_config(reviewer),
+        tool_config=_runtime_tool_config(reviewer, event_sink=event_sink),
+        event_sink=event_sink,
         stdout_silence_timeout=stdout_silence_timeout,
     )
     response = getattr(result, "response", None)

--- a/scripts/wiki/review.py
+++ b/scripts/wiki/review.py
@@ -255,11 +255,12 @@ def _tool_config_for(agent: str, *, needs_mcp: bool) -> dict | None:
     if not needs_mcp:
         return None
 
-    return build_mcp_tool_config(
+    tool_config, _diagnostics = build_mcp_tool_config(
         agent,
         mcp_servers=["sources"],
         allowed_tools="mcp__sources__*" if agent == "claude" else None,
     )
+    return tool_config
 
 
 def _dim_needs_mcp(dim: str) -> bool:

--- a/tests/test_agent_runtime_tool_config.py
+++ b/tests/test_agent_runtime_tool_config.py
@@ -23,7 +23,7 @@ def test_build_mcp_tool_config_claude_with_present_config(tmp_path: Path) -> Non
     config_path = tmp_path / ".mcp.json"
     config_path.write_text("{}", encoding="utf-8")
 
-    tool_config = build_mcp_tool_config(
+    tool_config, diagnostics = build_mcp_tool_config(
         "claude",
         allowed_tools="mcp__sources__*",
         mcp_config_path=config_path,
@@ -33,30 +33,34 @@ def test_build_mcp_tool_config_claude_with_present_config(tmp_path: Path) -> Non
         "mcp_config_path": str(config_path.resolve()),
         "allowed_tools": "mcp__sources__*",
     }
+    assert diagnostics["resolution_status"] == "ok"
 
 
 def test_build_mcp_tool_config_claude_without_config_returns_none(
     tmp_path: Path,
 ) -> None:
-    tool_config = build_mcp_tool_config(
+    tool_config, diagnostics = build_mcp_tool_config(
         "claude",
         allowed_tools="mcp__sources__*",
         mcp_config_path=tmp_path / ".mcp.json",
     )
 
     assert tool_config is None
+    assert diagnostics["resolution_status"] == "config_missing"
 
 
 def test_build_mcp_tool_config_gemini_with_server_list() -> None:
-    tool_config = build_mcp_tool_config("gemini", mcp_servers=["sources"])
+    tool_config, diagnostics = build_mcp_tool_config("gemini", mcp_servers=["sources"])
 
     assert tool_config == {"mcp_server_names": ["sources"]}
+    assert diagnostics["resolution_status"] == "ok"
 
 
 def test_build_mcp_tool_config_gemini_without_servers_returns_none() -> None:
-    tool_config = build_mcp_tool_config("gemini")
+    tool_config, diagnostics = build_mcp_tool_config("gemini")
 
     assert tool_config is None
+    assert diagnostics["resolution_status"] == "config_empty"
 
 
 def test_build_mcp_tool_config_codex_with_mcp_servers(
@@ -67,15 +71,21 @@ def test_build_mcp_tool_config_codex_with_mcp_servers(
         json.dumps(
             {
                 "mcpServers": {
-                    "sources": {"type": "sse", "url": "http://127.0.0.1:8766/sse"},
-                    "other": {"type": "sse", "url": "http://127.0.0.1:9999/sse"},
+                    "sources": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:8766/mcp",
+                    },
+                    "other": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:9999/mcp",
+                    },
                 }
             }
         ),
         encoding="utf-8",
     )
 
-    tool_config = build_mcp_tool_config(
+    tool_config, diagnostics = build_mcp_tool_config(
         "codex",
         mcp_servers=["sources"],
         mcp_config_path=config_path,
@@ -83,9 +93,13 @@ def test_build_mcp_tool_config_codex_with_mcp_servers(
 
     assert tool_config == {
         "mcp_servers": {
-            "sources": {"type": "sse", "url": "http://127.0.0.1:8766/sse"},
+            "sources": {
+                "type": "streamable-http",
+                "url": "http://127.0.0.1:8766/mcp",
+            },
         }
     }
+    assert diagnostics["resolution_status"] == "ok"
 
 
 def test_build_mcp_tool_config_codex_without_mcp_servers_key_returns_none(
@@ -94,16 +108,20 @@ def test_build_mcp_tool_config_codex_without_mcp_servers_key_returns_none(
     config_path = tmp_path / ".mcp.json"
     config_path.write_text(json.dumps({"other": "value"}), encoding="utf-8")
 
-    tool_config = build_mcp_tool_config("codex", mcp_config_path=config_path)
+    tool_config, diagnostics = build_mcp_tool_config(
+        "codex",
+        mcp_config_path=config_path,
+    )
 
     assert tool_config is None
+    assert diagnostics["resolution_status"] == "config_empty"
 
 
 def test_build_mcp_tool_config_unknown_agent_returns_none(tmp_path: Path) -> None:
     config_path = tmp_path / ".mcp.json"
     config_path.write_text("{}", encoding="utf-8")
 
-    tool_config = build_mcp_tool_config(
+    tool_config, diagnostics = build_mcp_tool_config(
         "nonexistent",
         mcp_servers=["sources"],
         allowed_tools="mcp__sources__*",
@@ -111,3 +129,4 @@ def test_build_mcp_tool_config_unknown_agent_returns_none(tmp_path: Path) -> Non
     )
 
     assert tool_config is None
+    assert diagnostics["resolution_status"] == "servers_not_found"

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from scripts.agent_runtime import tool_config as tool_config_mod
+from scripts.agent_runtime.runner import _McpRuntimeObserver
+from scripts.build import linear_pipeline
+
+
+@pytest.fixture(autouse=True)
+def _clear_mcp_config_cache() -> None:
+    tool_config_mod._load_mcp_config.cache_clear()
+    yield
+    tool_config_mod._load_mcp_config.cache_clear()
+
+
+def _write_mcp_config(path: Path, data: dict[str, Any]) -> Path:
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _valid_sources_config(path: Path) -> Path:
+    return _write_mcp_config(
+        path,
+        {
+            "mcpServers": {
+                "sources": {
+                    "type": "streamable-http",
+                    "url": "http://127.0.0.1:8766/mcp",
+                }
+            }
+        },
+    )
+
+
+def test_build_mcp_tool_config_diagnostics_ok(tmp_path: Path) -> None:
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+
+    config, diagnostics = tool_config_mod.build_mcp_tool_config(
+        "codex",
+        mcp_servers=["sources"],
+        mcp_config_path=config_path,
+    )
+
+    assert config == {
+        "mcp_servers": {
+            "sources": {
+                "type": "streamable-http",
+                "url": "http://127.0.0.1:8766/mcp",
+            }
+        }
+    }
+    assert diagnostics == {
+        "requested_servers": ["sources"],
+        "resolved_servers": ["sources"],
+        "config_path": str(config_path.resolve()),
+        "resolution_status": "ok",
+        "missing_server_names": [],
+    }
+
+
+def test_build_mcp_tool_config_diagnostics_config_missing(tmp_path: Path) -> None:
+    config_path = tmp_path / ".mcp.json"
+
+    config, diagnostics = tool_config_mod.build_mcp_tool_config(
+        "codex",
+        mcp_servers=["sources"],
+        mcp_config_path=config_path,
+    )
+
+    assert config is None
+    assert diagnostics["resolution_status"] == "config_missing"
+    assert diagnostics["requested_servers"] == ["sources"]
+    assert diagnostics["resolved_servers"] == []
+
+
+def test_build_mcp_tool_config_diagnostics_config_empty(tmp_path: Path) -> None:
+    config_path = _write_mcp_config(tmp_path / ".mcp.json", {"mcpServers": {}})
+
+    config, diagnostics = tool_config_mod.build_mcp_tool_config(
+        "codex",
+        mcp_servers=["sources"],
+        mcp_config_path=config_path,
+    )
+
+    assert config is None
+    assert diagnostics["resolution_status"] == "config_empty"
+    assert diagnostics["requested_servers"] == ["sources"]
+    assert diagnostics["resolved_servers"] == []
+
+
+def test_build_mcp_tool_config_diagnostics_servers_not_found(tmp_path: Path) -> None:
+    config_path = _write_mcp_config(
+        tmp_path / ".mcp.json",
+        {
+            "mcpServers": {
+                "other": {
+                    "type": "streamable-http",
+                    "url": "http://127.0.0.1:9999/mcp",
+                }
+            }
+        },
+    )
+
+    config, diagnostics = tool_config_mod.build_mcp_tool_config(
+        "codex",
+        mcp_servers=["sources"],
+        mcp_config_path=config_path,
+    )
+
+    assert config is None
+    assert diagnostics["resolution_status"] == "servers_not_found"
+    assert diagnostics["missing_server_names"] == ["sources"]
+    assert diagnostics["resolved_servers"] == []
+
+
+def test_build_mcp_tool_config_rejects_legacy_sse_codex_endpoint(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_mcp_config(
+        tmp_path / ".mcp.json",
+        {
+            "mcpServers": {
+                "sources": {
+                    "type": "sse",
+                    "url": "http://127.0.0.1:8766/sse",
+                }
+            }
+        },
+    )
+
+    config, diagnostics = tool_config_mod.build_mcp_tool_config(
+        "codex",
+        mcp_servers=["sources"],
+        mcp_config_path=config_path,
+    )
+
+    assert config is None
+    assert diagnostics["resolution_status"] == "servers_not_found"
+    assert diagnostics["missing_server_names"] == ["sources"]
+
+
+def test_runtime_tool_config_raises_and_emits_resolution_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_mcp_config(tmp_path / ".mcp.json", {"mcpServers": {}})
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="tool-less"):
+        linear_pipeline._runtime_tool_config(
+            "codex-tools",
+            event_sink=lambda event, **fields: events.append((event, fields)),
+        )
+
+    assert events == [
+        (
+            "mcp_config_resolved",
+            {
+                "writer": "codex-tools",
+                "requested_servers": ["sources"],
+                "resolved_servers": [],
+                "config_path": str(config_path.resolve()),
+                "resolution_status": "config_empty",
+                "missing_server_names": [],
+            },
+        )
+    ]
+
+
+def test_runtime_tool_config_emits_resolution_event_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = linear_pipeline._runtime_tool_config(
+        "codex-tools",
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config["output_format"] == "stream-json"
+    assert config["mcp_servers"]["sources"]["url"].endswith("/mcp")
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["resolution_status"] == "ok"
+    assert events[0][1]["resolved_servers"] == ["sources"]
+
+
+def test_invoke_writer_refuses_tool_less_codex_before_invoker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_mcp_config(tmp_path / ".mcp.json", {"mcpServers": {}})
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    def fail_if_called(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("writer invoker should not run without MCP servers")
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="tool-less"):
+        linear_pipeline.invoke_writer(
+            "Write the module.",
+            "codex-tools",
+            cwd=tmp_path,
+            invoker=fail_if_called,
+            event_sink=lambda event, **fields: events.append((event, fields)),
+        )
+
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["resolution_status"] == "config_empty"
+
+
+def test_mcp_runtime_observer_emits_ready() -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    observer = _McpRuntimeObserver.from_tool_config(
+        agent_name="codex",
+        task_id="writer",
+        tool_config={
+            "mcp_servers": {
+                "sources": {"url": "http://127.0.0.1:8766/mcp"},
+            }
+        },
+        event_sink=lambda event, **fields: events.append((event, fields)),
+        start_time=time.monotonic(),
+    )
+    assert observer is not None
+
+    observer.observe_line("mcp: sources/verify_words started", stream="stdout")
+
+    assert events[0][0] == "mcp_runtime_init"
+    assert events[0][1]["server"] == "sources"
+    assert events[0][1]["status"] == "ready"
+    assert events[0][1]["tool"] == "verify_words"
+
+
+def test_mcp_runtime_observer_emits_failed_for_codex_rmcp_error() -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    observer = _McpRuntimeObserver.from_tool_config(
+        agent_name="codex",
+        task_id="writer",
+        tool_config={
+            "mcp_servers": {
+                "sources": {"url": "http://127.0.0.1:9999/sse"},
+            }
+        },
+        event_sink=lambda event, **fields: events.append((event, fields)),
+        start_time=time.monotonic(),
+    )
+    assert observer is not None
+
+    observer.observe_line(
+        "2026-05-08T11:37:32.975327Z ERROR rmcp::transport::worker: "
+        "worker quit with fatal: Transport channel closed, when "
+        'Client(HttpRequest(HttpRequest("http/request failed: error sending '
+        'request for url (http://127.0.0.1:9999/sse)")))',
+        stream="stderr",
+    )
+
+    assert events[0][0] == "mcp_runtime_init"
+    assert events[0][1]["server"] == "sources"
+    assert events[0][1]["status"] == "failed"
+
+
+def test_mcp_runtime_observer_emits_timeout() -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    observer = _McpRuntimeObserver.from_tool_config(
+        agent_name="codex",
+        task_id="writer",
+        tool_config={
+            "mcp_servers": {
+                "sources": {"url": "http://127.0.0.1:8766/mcp"},
+            }
+        },
+        event_sink=lambda event, **fields: events.append((event, fields)),
+        start_time=time.monotonic(),
+    )
+    assert observer is not None
+    observer.timeout_s = 0
+
+    observer.maybe_emit_timeout(time.monotonic())
+
+    assert events[0][0] == "mcp_runtime_init"
+    assert events[0][1]["server"] == "sources"
+    assert events[0][1]["status"] == "timeout"

--- a/tests/test_textbook_grounding_gate.py
+++ b/tests/test_textbook_grounding_gate.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from scripts.build import linear_pipeline
 
 FIXTURES = Path(__file__).parent / "fixtures" / "textbook_grounding"
@@ -46,6 +48,28 @@ def _write_tool_calls(module_dir: Path, calls: list[dict[str, Any]]) -> None:
         json.dumps(calls, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
+
+
+def _seed_mcp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seed a minimal MCP config so codex-tools pre-flight resolves."""
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "sources": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:8766/mcp",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    from scripts.agent_runtime import tool_config as tc_mod
+
+    monkeypatch.setattr(tc_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    tc_mod._load_mcp_config.cache_clear()
 
 
 def _search_call(title: str = "Караман Grade 10, p.176") -> dict[str, Any]:
@@ -139,7 +163,11 @@ def test_textbook_grounding_gate_reads_jsonl_writer_trace(tmp_path: Path) -> Non
     assert result["passed"] is True
 
 
-def test_invoke_writer_persists_tool_trace(tmp_path: Path) -> None:
+def test_invoke_writer_persists_tool_trace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_mcp_config(tmp_path, monkeypatch)
     trace_path = tmp_path / "writer_tool_calls.json"
 
     def invoker(_agent: str, _prompt: str, **_kwargs: Any) -> SimpleNamespace:
@@ -328,7 +356,11 @@ def test_empty_references_rejected_for_b1_plus(tmp_path: Path) -> None:
     assert result["reason"] == "missing_references"
 
 
-def test_invoke_writer_appends_tool_trace(tmp_path: Path) -> None:
+def test_invoke_writer_appends_tool_trace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_mcp_config(tmp_path, monkeypatch)
     trace_path = tmp_path / "writer_tool_calls.json"
 
     def invoker(_agent: str, _prompt: str, **_kwargs: Any) -> SimpleNamespace:

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+from scripts.agent_runtime import tool_config as tool_config_mod
 from scripts.agent_runtime.adapters.base import InvocationPlan
 from scripts.agent_runtime.registry import get_agent_entry
 from scripts.agent_runtime.result import ParseResult
@@ -27,6 +28,7 @@ from scripts.build import linear_pipeline, v7_build
 )
 def test_v7_writer_choices_resolve_to_runtime_adapters(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     writer: str,
     agent_name: str,
 ) -> None:
@@ -36,11 +38,30 @@ def test_v7_writer_choices_resolve_to_runtime_adapters(
         calls.append((agent, prompt, kwargs))
         return SimpleNamespace(response="writer output")
 
+    if writer == "codex-tools":
+        mcp_config_path = tmp_path / ".mcp.json"
+        mcp_config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "sources": {
+                            "type": "streamable-http",
+                            "url": "http://127.0.0.1:8766/mcp",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        tool_config_mod._load_mcp_config.cache_clear()
+        monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", mcp_config_path)
+
     response = linear_pipeline.invoke_writer(
         "Write the module.",
         writer=writer,
         cwd=tmp_path,
         invoker=fake_invoker,
+        event_sink=lambda _event, **_fields: None,
     )
 
     entry = get_agent_entry(agent_name)
@@ -58,7 +79,7 @@ def test_v7_writer_choices_resolve_to_runtime_adapters(
     assert calls[0][2]["effort"] == linear_pipeline.WRITER_DEFAULTS[writer]["effort"]
     assert calls[0][2]["tool_config"]["output_format"] == "stream-json"
     if writer == "codex-tools":
-        assert calls[0][2]["tool_config"]["mcp_servers"]["sources"]["url"].endswith("/sse")
+        assert calls[0][2]["tool_config"]["mcp_servers"]["sources"]["url"].endswith("/mcp")
     else:
         assert calls[0][2]["tool_config"] == {"output_format": "stream-json"}
 


### PR DESCRIPTION
## Summary

Implements #1798 MCP init observability for writer dispatch:

- `build_mcp_tool_config()` now returns `(config, diagnostics)` and reports `mcp_config_resolved` inputs/status.
- `linear_pipeline._runtime_tool_config()` emits `mcp_config_resolved` and raises `LinearPipelineError` before dispatch when `codex-tools` requests MCP but resolves no usable servers.
- `runner.invoke()` accepts an `event_sink` and emits `mcp_runtime_init` for Codex MCP ready, failed, and timeout observations.
- Adds focused tests in `tests/test_mcp_init_observability.py` and updates adjacent tool-config/writer-dispatch tests.
- Documents the events and 0-tool-call debugging flow in `docs/best-practices/agent-cooperation.md`.

Codex legacy SSE endpoints (`type: sse` or URL ending `/sse`) are treated as unresolved in the Codex writer dispatch resolver, so the current worktree `.mcp.json` fails fast instead of running a tool-less writer pass.

## Captured Codex failure pattern

Broken-MCP experiment used Codex v0.129.0 with `http://127.0.0.1:9999/sse`. The observed stderr pattern was:

```text
ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when Client(HttpRequest(HttpRequest("http/request failed: error sending request for url (http://127.0.0.1:9999/sse)")))
```

The runtime parser detects `rmcp::transport::worker` failures and maps the URL back to the configured server when available.

## Validation

- `.venv/bin/pytest tests/test_mcp_init_observability.py -v`
- `.venv/bin/pytest tests/test_agent_runtime_tool_config.py tests/test_v7_writer_dispatch.py -v`
- `.venv/bin/pytest tests/test_mcp_init_observability.py tests/test_agent_runtime_tool_config.py tests/test_v7_writer_dispatch.py -v`
- `.venv/bin/python scripts/audit/bakeoff_run.py --bakeoff-dir /tmp/bakeoff-smoke-1798 --level a1 --slug my-morning --writers codex-tools --writers-only 2>&1 | head -40`
- `.venv/bin/ruff check scripts/ tests/`
- `git diff --check`

Smoke result: failed fast at pre-flight with `Writer 'codex-tools' requested MCP servers ['sources'] but resolver returned none (servers_not_found). Refusing to dispatch tool-less.` and wrote `mcp_config_resolved` to `/tmp/bakeoff-smoke-1798/gpt55.write.jsonl`.

Closes #1798
