### PR TITLE
feat(mcp): wire MCP for claude-tools + gemini-tools writer dispatch (#1809)

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "rag": {
-      "url": "http://127.0.0.1:8766/sse",
-      "type": "sse"
+    "sources": {
+      "url": "http://127.0.0.1:8766/mcp",
+      "type": "http"
     }
   }
 }

--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -587,11 +587,9 @@ def _dispatch_via_runtime(
         # Gemini in the pipeline is always -y (write-enabled) — existing behavior.
         runtime_mode = "workspace-write"
         if mcp_tools:
-            # TODO(#1803): rename "rag" → "sources"; see
-            # .claude/rules/mcp-sources-and-dictionaries.md.
             tool_config, _diagnostics = build_mcp_tool_config(
                 "gemini",
-                mcp_servers=["rag"],
+                mcp_servers=["sources"],
             )
         else:
             tool_config = None

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1729,30 +1729,94 @@ def _runtime_tool_config(
     event_sink: Callable[..., None] | None = None,
 ) -> dict[str, Any]:
     tool_config: dict[str, Any] = {"output_format": "stream-json"}
-    if agent_label == "codex-tools":
-        from scripts.agent_runtime.tool_config import build_mcp_tool_config
+    if not agent_label.endswith("-tools"):
+        return tool_config
 
-        codex_tools, diagnostics = build_mcp_tool_config(
-            "codex",
-            mcp_servers=["sources"],
+    from scripts.agent_runtime.tool_config import _load_mcp_config, build_mcp_tool_config
+
+    if agent_label == "codex-tools":
+        agent_kwargs = {
+            "mcp_servers": ["sources"],
+        }
+    elif agent_label == "claude-tools":
+        agent_kwargs = {
+            "mcp_servers": ["sources"],
+            "allowed_tools": "mcp__sources__*",
+        }
+    elif agent_label == "gemini-tools":
+        agent_kwargs = {
+            "mcp_servers": ["sources"],
+        }
+    else:
+        raise LinearPipelineError(
+            f"Unknown -tools writer {agent_label!r}; expected one of "
+            "codex-tools / claude-tools / gemini-tools."
         )
-        _emit(event_sink, "mcp_config_resolved", writer=agent_label, **diagnostics)
-        requested = diagnostics["requested_servers"]
-        resolved = diagnostics["resolved_servers"]
-        status = diagnostics["resolution_status"]
-        if agent_label.endswith("-tools") and requested and not resolved:
-            raise LinearPipelineError(
-                f"Writer {agent_label!r} requested MCP servers {requested!r} "
-                f"but resolver returned none ({status}). Refusing to dispatch "
-                "tool-less."
-            )
-        if codex_tools:
-            tool_config.update(codex_tools)
+
+    canonical_agent = agent_label.split("-", 1)[0]
+    mcp_dict, diagnostics = build_mcp_tool_config(canonical_agent, **agent_kwargs)
+    if canonical_agent in {"claude", "gemini"}:
+        diagnostics = _mcp_config_server_name_diagnostics(
+            diagnostics,
+            load_mcp_config=_load_mcp_config,
+        )
+    _emit(event_sink, "mcp_config_resolved", writer=agent_label, **diagnostics)
+
+    requested = diagnostics["requested_servers"]
+    resolved = diagnostics["resolved_servers"]
+    status = diagnostics["resolution_status"]
+    if requested and not resolved:
+        raise LinearPipelineError(
+            f"Writer {agent_label!r} requested MCP servers {requested!r} "
+            f"but resolver returned none ({status}). Refusing to dispatch "
+            "tool-less."
+        )
+    if mcp_dict:
+        tool_config.update(mcp_dict)
     assert tool_config.get("output_format") == "stream-json", (
         "tool-call writers must keep output_format='stream-json'; "
         f"got {tool_config.get('output_format')!r}"
     )
     return tool_config
+
+
+def _mcp_config_server_name_diagnostics(
+    diagnostics: dict[str, Any],
+    *,
+    load_mcp_config: Callable[[Path], dict[str, Any] | None],
+) -> dict[str, Any]:
+    """Validate non-Codex MCP server names against the canonical repo config."""
+    requested = list(diagnostics["requested_servers"])
+    if not requested:
+        return diagnostics
+
+    config_path = Path(diagnostics["config_path"])
+    data = load_mcp_config(config_path)
+    if not data:
+        return {
+            **diagnostics,
+            "resolved_servers": [],
+            "resolution_status": "config_missing",
+            "missing_server_names": requested,
+        }
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        return {
+            **diagnostics,
+            "resolved_servers": [],
+            "resolution_status": "config_empty",
+            "missing_server_names": requested,
+        }
+
+    resolved = [server_name for server_name in requested if server_name in servers]
+    missing = [server_name for server_name in requested if server_name not in servers]
+    return {
+        **diagnostics,
+        "resolved_servers": resolved,
+        "resolution_status": "ok" if resolved else "servers_not_found",
+        "missing_server_names": missing,
+    }
 
 
 def invoke_writer(

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -341,11 +341,11 @@ class TestDispatchAgent:
         assert first_call["model"] == "gemini-3.1-pro-preview"
         assert second_call["model"] == "gemini-3-flash-preview"
         assert first_call["tool_config"] == {
-            "mcp_server_names": ["rag"],
+            "mcp_server_names": ["sources"],
             "auth_mode": "subscription",
         }
         assert second_call["tool_config"] == {
-            "mcp_server_names": ["rag"],
+            "mcp_server_names": ["sources"],
             "auth_mode": "subscription",
         }
 

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -197,6 +197,97 @@ def test_runtime_tool_config_emits_resolution_event_success(
     assert events[0][1]["resolved_servers"] == ["sources"]
 
 
+def test_runtime_tool_config_claude_tools_emits_resolution_event_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = linear_pipeline._runtime_tool_config(
+        "claude-tools",
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config["output_format"] == "stream-json"
+    assert config["mcp_config_path"] == str(config_path.resolve())
+    assert config["allowed_tools"] == "mcp__sources__*"
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["writer"] == "claude-tools"
+    assert events[0][1]["resolution_status"] == "ok"
+    assert events[0][1]["resolved_servers"] == ["sources"]
+
+
+def test_runtime_tool_config_claude_tools_raises_when_unconfigured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_mcp_config(tmp_path / ".mcp.json", {"mcpServers": {}})
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="tool-less"):
+        linear_pipeline._runtime_tool_config(
+            "claude-tools",
+            event_sink=lambda event, **fields: events.append((event, fields)),
+        )
+
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["writer"] == "claude-tools"
+    assert events[0][1]["resolution_status"] == "config_empty"
+    assert events[0][1]["resolved_servers"] == []
+
+
+def test_runtime_tool_config_gemini_tools_emits_resolution_event_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = linear_pipeline._runtime_tool_config(
+        "gemini-tools",
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config["output_format"] == "stream-json"
+    assert config["mcp_server_names"] == ["sources"]
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["writer"] == "gemini-tools"
+    assert events[0][1]["resolution_status"] == "ok"
+    assert events[0][1]["resolved_servers"] == ["sources"]
+
+
+def test_runtime_tool_config_gemini_tools_raises_when_unconfigured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_mcp_config(tmp_path / ".mcp.json", {"mcpServers": {}})
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="tool-less"):
+        linear_pipeline._runtime_tool_config(
+            "gemini-tools",
+            event_sink=lambda event, **fields: events.append((event, fields)),
+        )
+
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["writer"] == "gemini-tools"
+    assert events[0][1]["resolution_status"] == "config_empty"
+    assert events[0][1]["resolved_servers"] == []
+
+
+def test_runtime_tool_config_unknown_tools_writer_raises() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="Unknown -tools writer",
+    ):
+        linear_pipeline._runtime_tool_config("phantom-tools")
+
+
 def test_invoke_writer_refuses_tool_less_codex_before_invoker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -18,6 +18,28 @@ from scripts.agent_runtime.telemetry import InvocationTelemetry
 from scripts.build import linear_pipeline, v7_build
 
 
+def _seed_sources_mcp_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mcp_config_path = tmp_path / ".mcp.json"
+    mcp_config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "sources": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:8766/mcp",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    tool_config_mod._load_mcp_config.cache_clear()
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", mcp_config_path)
+
+
 @pytest.mark.parametrize(
     ("writer", "agent_name"),
     [
@@ -33,28 +55,11 @@ def test_v7_writer_choices_resolve_to_runtime_adapters(
     agent_name: str,
 ) -> None:
     calls: list[tuple[str, str, dict[str, Any]]] = []
+    _seed_sources_mcp_config(tmp_path, monkeypatch)
 
     def fake_invoker(agent: str, prompt: str, **kwargs: Any) -> SimpleNamespace:
         calls.append((agent, prompt, kwargs))
         return SimpleNamespace(response="writer output")
-
-    if writer == "codex-tools":
-        mcp_config_path = tmp_path / ".mcp.json"
-        mcp_config_path.write_text(
-            json.dumps(
-                {
-                    "mcpServers": {
-                        "sources": {
-                            "type": "streamable-http",
-                            "url": "http://127.0.0.1:8766/mcp",
-                        }
-                    }
-                }
-            ),
-            encoding="utf-8",
-        )
-        tool_config_mod._load_mcp_config.cache_clear()
-        monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", mcp_config_path)
 
     response = linear_pipeline.invoke_writer(
         "Write the module.",
@@ -80,8 +85,13 @@ def test_v7_writer_choices_resolve_to_runtime_adapters(
     assert calls[0][2]["tool_config"]["output_format"] == "stream-json"
     if writer == "codex-tools":
         assert calls[0][2]["tool_config"]["mcp_servers"]["sources"]["url"].endswith("/mcp")
+    elif writer == "claude-tools":
+        assert calls[0][2]["tool_config"]["mcp_config_path"] == str(
+            (tmp_path / ".mcp.json").resolve()
+        )
+        assert calls[0][2]["tool_config"]["allowed_tools"] == "mcp__sources__*"
     else:
-        assert calls[0][2]["tool_config"] == {"output_format": "stream-json"}
+        assert calls[0][2]["tool_config"]["mcp_server_names"] == ["sources"]
 
 
 def test_v7_build_accepts_codex_alias() -> None:
@@ -119,7 +129,11 @@ def test_v7_build_dry_run_telemetry_out_writes_file_not_stdout(
     assert events[-1]["dry_run"] is True
 
 
-def test_v7_writer_trace_capture_clears_tool_theatre(tmp_path: Path) -> None:
+def test_v7_writer_trace_capture_clears_tool_theatre(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_sources_mcp_config(tmp_path, monkeypatch)
     telemetry = tmp_path / "trace.jsonl"
     writer_output = (
         '<plan_reasoning section="vocab">'


### PR DESCRIPTION
## Summary

Wires MCP resolution for all three writer dispatch labels: `codex-tools`, `claude-tools`, and `gemini-tools`.

- Refactors `linear_pipeline._runtime_tool_config` into one shared resolver/preflight path for `-tools` writers.
- Adds explicit unknown `-tools` writer rejection instead of silently dispatching without tools.
- Emits `mcp_config_resolved` for Claude, Gemini, and Codex writer dispatches.
- Renames Gemini dispatch/config server name from `rag` to `sources`.
- Updates smoke/observability tests for all three writer labels.

This is the gating fix for the user requirement that bakeoff comparisons are meaningless unless all writer families receive equivalent MCP wiring.

## Gemini Transport Experiment

Experiment log: `/tmp/gemini-mcp-experiment.log`.

Observed with Gemini CLI `0.41.2`:

- `type: "streamable-http"` against `http://127.0.0.1:8766/mcp` is rejected by Gemini CLI settings validation: valid enum values are `stdio`, `sse`, and `http`.
- `type: "sse"` against `http://127.0.0.1:8766/sse` did not successfully invoke `mcp__sources__verify_words`; the run timed out after reporting the tool was not found.
- `type: "http"` against `http://127.0.0.1:8766/mcp` is the transport spelling generated by `gemini mcp add sources http://127.0.0.1:8766/mcp --transport http --scope project --trust`:

```json
{
  "mcpServers": {
    "sources": {
      "url": "http://127.0.0.1:8766/mcp",
      "type": "http",
      "trust": true
    }
  }
}
```

The direct model invocation with `type: "http"` was blocked by transient Gemini service capacity/backend errors during the experiment, but the installed CLI accepts `http` and rejects `streamable-http`; SSE failed to invoke. This PR therefore uses `type: "http"` with the `/mcp` endpoint in `.gemini/settings.json`.

## Verification

- `.venv/bin/pytest tests/test_mcp_init_observability.py tests/test_v7_writer_dispatch.py tests/test_agent_runtime_tool_config.py tests/test_dispatch.py tests/test_textbook_grounding_gate.py -v` -> 71 passed
- `.venv/bin/python -c '<three-writer smoke>'` -> all three printed `ok status=ok resolved=['sources']`
- `.venv/bin/ruff check scripts/ tests/` -> passed
- Commit hook reran affected tests -> 50 passed

Closes #1803, #1804
Refs #1577
