### PR TITLE
fix(mcp): strip codex -c `type` field + positive runtime gate (#1812)

### DIFF
--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -9,6 +9,15 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_MCP_CONFIG_PATH = _REPO_ROOT / ".mcp.json"
 _RESOLUTION_STATUSES = {"ok", "config_missing", "config_empty", "servers_not_found"}
+_CODEX_MCP_SERVER_FIELDS = frozenset(
+    {
+        "url",
+        "command",
+        "args",
+        "env",
+        "bearer_token_env_var",
+    }
+)
 
 
 def _canonical_agent_name(agent: str) -> str | None:
@@ -25,6 +34,18 @@ def _canonical_agent_name(agent: str) -> str | None:
 def _resolved_mcp_config_path(mcp_config_path: Path | None) -> Path:
     """Return the configured `.mcp.json` path, defaulting to repo root."""
     return (mcp_config_path or _DEFAULT_MCP_CONFIG_PATH).resolve()
+
+
+def _codex_sanitize_server_config(server_config: dict) -> dict:
+    """Drop fields codex CLI's mcp_servers schema does not recognize.
+
+    `.mcp.json` includes Claude-format fields, notably `type` such as
+    `type="streamable-http"`. Codex CLI auto-detects HTTP transport from the
+    URL scheme and does not have `type` in its `mcp_servers.<name>.*` schema;
+    passing the unknown field silently breaks server registration on the codex
+    side and leaves the model with no MCP tools.
+    """
+    return {k: v for k, v in server_config.items() if k in _CODEX_MCP_SERVER_FIELDS}
 
 
 @lru_cache(maxsize=1)
@@ -75,9 +96,15 @@ def _codex_mcp_servers(
 
     if not requested:
         if usable_servers:
-            return usable_servers, diagnostics(
-                resolved_servers=list(usable_servers),
-                resolution_status="ok",
+            return (
+                {
+                    name: _codex_sanitize_server_config(cfg)
+                    for name, cfg in usable_servers.items()
+                },
+                diagnostics(
+                    resolved_servers=list(usable_servers),
+                    resolution_status="ok",
+                ),
             )
         return None, diagnostics(
             resolution_status="servers_not_found",
@@ -85,7 +112,7 @@ def _codex_mcp_servers(
         )
 
     selected = {
-        server_name: usable_servers[server_name]
+        server_name: _codex_sanitize_server_config(usable_servers[server_name])
         for server_name in requested
         if server_name in usable_servers
     }

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1661,6 +1661,28 @@ def emit_writer_response_telemetry(
     return summary
 
 
+def _enforce_tools_writer_runtime_gate(
+    *,
+    writer: str,
+    module: str,
+    phase_writer_summary: Mapping[str, Any],
+) -> None:
+    """Fail when a tools writer resolved MCP config but never invoked a tool."""
+    if not writer.endswith("-tools"):
+        return
+    if phase_writer_summary["tool_calls_total"] != 0:
+        return
+    raise LinearPipelineError(
+        "MCP_TOOLS_NEVER_INVOKED: "
+        f"writer={writer!r} module={module!r} expected='>=1 mcp__sources__* call "
+        "from a -tools writer' got=0. Pre-flight "
+        "mcp_config_resolved.resolution_status='ok' only verifies config string "
+        "resolution. The model must actually invoke at least one MCP tool. If "
+        "this fires, check the rollout JSONL for catalog-visibility errors "
+        "(e.g., 'tools are not exposed in this session')."
+    )
+
+
 def writer_context(plan: Mapping[str, Any], plan_content: str, knowledge_packet: str) -> dict[str, str]:
     level = str(plan["level"])
     sequence = int(plan["sequence"])
@@ -1882,13 +1904,18 @@ def invoke_writer(
             encoding="utf-8",
         )
     if module_ref and section_names:
-        emit_writer_response_telemetry(
+        phase_writer_summary = emit_writer_response_telemetry(
             response_text,
             writer=writer,
             module=module_ref,
             sections=section_names,
             tool_calls=tool_calls,
             event_sink=event_sink,
+        )
+        _enforce_tools_writer_runtime_gate(
+            writer=writer,
+            module=module_ref,
+            phase_writer_summary=phase_writer_summary,
         )
     return response_text
 

--- a/tests/test_agent_runtime_tool_config.py
+++ b/tests/test_agent_runtime_tool_config.py
@@ -9,7 +9,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from agent_runtime.tool_config import _load_mcp_config, build_mcp_tool_config
+from agent_runtime.tool_config import (
+    _codex_sanitize_server_config,
+    _load_mcp_config,
+    build_mcp_tool_config,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -63,9 +67,10 @@ def test_build_mcp_tool_config_gemini_without_servers_returns_none() -> None:
     assert diagnostics["resolution_status"] == "config_empty"
 
 
-def test_build_mcp_tool_config_codex_with_mcp_servers(
+def test_codex_tool_config_strips_claude_format_type_field(
     tmp_path: Path,
 ) -> None:
+    """codex CLI doesn't recognize `type` - it must be stripped (#1812)."""
     config_path = tmp_path / ".mcp.json"
     config_path.write_text(
         json.dumps(
@@ -91,15 +96,47 @@ def test_build_mcp_tool_config_codex_with_mcp_servers(
         mcp_config_path=config_path,
     )
 
-    assert tool_config == {
-        "mcp_servers": {
-            "sources": {
-                "type": "streamable-http",
-                "url": "http://127.0.0.1:8766/mcp",
-            },
-        }
-    }
+    assert tool_config is not None
+    assert "mcp_servers" in tool_config
+    sources_cfg = tool_config["mcp_servers"]["sources"]
+    assert sources_cfg["url"] == "http://127.0.0.1:8766/mcp"
+    assert "type" not in sources_cfg, (
+        "codex tool_config must not include the Claude-format `type` field; "
+        f"got {sources_cfg!r}. See #1812."
+    )
     assert diagnostics["resolution_status"] == "ok"
+
+
+def test_codex_sanitize_server_config_drops_unknown_fields() -> None:
+    raw = {
+        "url": "http://127.0.0.1:8766/mcp",
+        "type": "streamable-http",
+        "transport": "http",
+        "headers": {"X-Foo": "bar"},
+    }
+
+    sanitized = _codex_sanitize_server_config(raw)
+
+    assert sanitized == {"url": "http://127.0.0.1:8766/mcp"}
+
+
+def test_codex_sanitize_server_config_preserves_codex_fields() -> None:
+    raw = {
+        "command": "/usr/local/bin/some-mcp",
+        "args": ["--port", "9000"],
+        "env": {"FOO": "bar"},
+        "bearer_token_env_var": "MY_TOKEN",
+        "type": "stdio",
+    }
+
+    sanitized = _codex_sanitize_server_config(raw)
+
+    assert sanitized == {
+        "command": "/usr/local/bin/some-mcp",
+        "args": ["--port", "9000"],
+        "env": {"FOO": "bar"},
+        "bearer_token_env_var": "MY_TOKEN",
+    }
 
 
 def test_build_mcp_tool_config_codex_without_mcp_servers_key_returns_none(

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -53,7 +53,6 @@ def test_build_mcp_tool_config_diagnostics_ok(tmp_path: Path) -> None:
     assert config == {
         "mcp_servers": {
             "sources": {
-                "type": "streamable-http",
                 "url": "http://127.0.0.1:8766/mcp",
             }
         }

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -84,7 +84,9 @@ def test_v7_writer_choices_resolve_to_runtime_adapters(
     assert calls[0][2]["effort"] == linear_pipeline.WRITER_DEFAULTS[writer]["effort"]
     assert calls[0][2]["tool_config"]["output_format"] == "stream-json"
     if writer == "codex-tools":
-        assert calls[0][2]["tool_config"]["mcp_servers"]["sources"]["url"].endswith("/mcp")
+        sources_cfg = calls[0][2]["tool_config"]["mcp_servers"]["sources"]
+        assert sources_cfg["url"].endswith("/mcp")
+        assert "type" not in sources_cfg
     elif writer == "claude-tools":
         assert calls[0][2]["tool_config"]["mcp_config_path"] == str(
             (tmp_path / ".mcp.json").resolve()
@@ -171,6 +173,44 @@ def test_v7_writer_trace_capture_clears_tool_theatre(
     assert summary["tool_calls_total"] == 1
     assert summary["verify_words_calls"] == 1
     assert summary["tool_theatre_violations"] == []
+
+
+def test_positive_runtime_gate_fires_when_tools_writer_makes_zero_mcp_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v7 must fail loud when a -tools writer produces 0 MCP calls (#1812)."""
+    _seed_sources_mcp_config(tmp_path, monkeypatch)
+    events: list[dict[str, Any]] = []
+
+    def fake_invoker(_agent: str, _prompt: str, **_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(response="writer output", tool_calls=[])
+
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="MCP_TOOLS_NEVER_INVOKED",
+    ):
+        linear_pipeline.invoke_writer(
+            "Write the module.",
+            writer="codex-tools",
+            cwd=tmp_path,
+            invoker=fake_invoker,
+            module="a1/1",
+            sections=["vocab"],
+            event_sink=lambda event, **fields: events.append({"event": event, **fields}),
+        )
+
+    summary = next(event for event in events if event["event"] == "phase_writer_summary")
+    assert summary["tool_calls_total"] == 0
+
+
+def test_positive_runtime_gate_does_not_fire_for_non_tools_writer() -> None:
+    """Gate must only apply to *-tools writers, not legacy claude/gemini."""
+    linear_pipeline._enforce_tools_writer_runtime_gate(
+        writer="claude",
+        module="a1/1",
+        phase_writer_summary={"tool_calls_total": 0},
+    )
 
 
 def test_v7_build_writer_timeout_kills_silent_subprocess(


### PR DESCRIPTION
## Summary

Codex CLI does not recognize `type` in its `mcp_servers.<name>.*` schema. v7 was emitting `-c mcp_servers.sources.type="streamable-http"` which silently broke server registration on the codex side and left the model with NO MCP tools in its catalog. The model substituted `exec_command` shell-grep (39-59 calls per writer run) producing fake `<verification_trace>` citations that pipeline mistook for "writer-prompt theatre."

**Direct evidence** (bakeoff rollout line 10 of both 2026-05-08 codex sessions): the model itself articulated *"requested mcp__sources__... tools 'are not exposed in this session'"*.

Both Claude (inline) and Codex (headless via `ab ask-codex`) independently reviewed and converged on this root cause — see `audit/codex-tools-review-2026-05-08/REPORT.md` (commit `fc38467c4b`).

## Changes

- `scripts/agent_runtime/tool_config.py` — `_codex_sanitize_server_config` drops fields outside `{url, command, args, env, bearer_token_env_var}`. Wired into `_codex_mcp_servers` for both the explicit-request and no-request branches.
- `scripts/build/linear_pipeline.py` — positive runtime gate: `MCP_TOOLS_NEVER_INVOKED` raised when a `*-tools` writer produces 0 `mcp__sources__*` calls. Pre-flight `mcp_config_resolved` now known to be insufficient (verifies config string resolution, not runtime tool injection).
- Tests: 4 new + 1 existing flipped + 1 observability test updated for new payload shape.

## Test plan

- [x] `ruff check` passes
- [x] `pytest tests/test_agent_runtime_tool_config.py tests/test_v7_writer_dispatch.py tests/test_mcp_init_observability.py` — 34 passed
- [x] Smoke test (Codex's reproducer): `codex exec` with v7-shaped flags called `mcp__sources__verify_words` for `кіт` and returned a real result (`lemma кіт, noun`)
- [ ] **Human follow-up: re-fire 3-way bakeoff** (`v7_build.py a1 my-morning --writer codex-tools`) — expect `tool_calls_total > 0` for codex-tools post-merge; currently always 0

## Refutes / confirms

- **Refutes** "agents in sandbox" hypothesis: `turn_context` in rollout shows `sandbox_policy: danger-full-access`, `permission_profile: disabled`. Sandbox is NOT the blocker.
- **Refutes** "not using the wiki" at the input layer: `knowledge_packet.md` byte-identical (41,374 bytes, identical SHA256) across all 3 writers.
- **Confirms** "model can't see / doesn't know about our tools": direct rollout-text quote above.

Closes #1812.

Refs: `audit/codex-tools-review-2026-05-08/REPORT.md`, #1810, #1798, #1790, #1811.

## Note for reviewer

Codex (the writer) hit `HTTP 401: Bad credentials` on `gh` from inside the dispatch subprocess and could not create this PR itself. Branch is correctly pushed; PR opened by orchestrator (Claude). Worth a follow-up issue: dispatch subprocess gh-auth env propagation (separate from #1811 deploy invariants).