### PR TITLE
fix(v7): gemini-tools writer cwd=PROJECT_ROOT (#1809)

### DIFF
--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -329,10 +329,14 @@ def _run(args: argparse.Namespace) -> int:
             plan_content=plan_content,
             knowledge_packet=knowledge_packet,
         )
+        # gemini-tools must load .gemini/settings.json from repo root;
+        # module_dir cwd would leave its MCP catalog empty. See
+        # audit/gemini-tools-review-2026-05-09/REPORT.html E5/E6.
+        writer_cwd = PROJECT_ROOT if writer == "gemini-tools" else module_dir
         writer_output = linear_pipeline.invoke_writer(
             prompt,
             writer,
-            cwd=module_dir,
+            cwd=writer_cwd,
             tool_trace_path=module_dir / "writer_tool_calls.json",
             stdout_silence_timeout=args.writer_timeout,
         )

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -100,6 +101,64 @@ def test_v7_build_accepts_codex_alias() -> None:
     assert "codex-tools" in v7_build.WRITER_CHOICES
     assert "codex" in v7_build.WRITER_CHOICES
     assert v7_build._normalize_writer("codex") == "codex-tools"
+
+
+@pytest.mark.parametrize(
+    ("writer", "expected_cwd"),
+    [
+        ("gemini-tools", v7_build.PROJECT_ROOT),
+        ("claude-tools", None),
+        ("codex-tools", None),
+    ],
+)
+def test_v7_build_invokes_gemini_tools_from_project_root(
+    tmp_path: Path,
+    writer: str,
+    expected_cwd: Path | None,
+) -> None:
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("level: a1\nslug: my-morning\nsequence: 1\n", encoding="utf-8")
+    module_dir = tmp_path / "module"
+    plan = {
+        "level": "a1",
+        "slug": "my-morning",
+        "sequence": 1,
+        "content_outline": [],
+    }
+
+    with (
+        patch.object(v7_build.linear_pipeline, "plan_path_for", return_value=plan_path),
+        patch.object(v7_build.linear_pipeline, "load_plan", return_value=plan),
+        patch.object(v7_build.linear_pipeline, "validate_plan"),
+        patch.object(
+            v7_build.linear_pipeline,
+            "build_knowledge_packet",
+            return_value="knowledge packet",
+        ),
+        patch.object(v7_build, "_writer_prompt", return_value="writer prompt"),
+        patch.object(
+            v7_build.linear_pipeline,
+            "invoke_writer",
+            side_effect=linear_pipeline.LinearPipelineError("stop after writer invoke"),
+        ) as invoke_writer,
+    ):
+        exit_code = v7_build.main(
+            [
+                "a1",
+                "my-morning",
+                "--writer",
+                writer,
+                "--out",
+                str(module_dir),
+            ]
+        )
+
+    assert exit_code == 1
+    assert invoke_writer.call_count == 1
+    assert invoke_writer.call_args.kwargs["cwd"] == (expected_cwd or module_dir)
+    assert invoke_writer.call_args.kwargs["tool_trace_path"] == (
+        module_dir / "writer_tool_calls.json"
+    )
 
 
 def test_v7_build_dry_run_telemetry_out_writes_file_not_stdout(


### PR DESCRIPTION
## Summary
- Run only the v7 `gemini-tools` writer invocation from `PROJECT_ROOT` so Gemini CLI loads repo `.gemini/settings.json`.
- Keep all other writers on `module_dir` cwd and keep `writer_tool_calls.json` in the module artifact directory.
- Add a targeted regression test around the `invoke_writer(..., cwd=...)` contract.

## Audit
- Implements Option A from `audit/gemini-tools-review-2026-05-09/REPORT.html`, E5/E6.
- Issue: #1809.

## Smoke evidence
From repo root/worktree:

```
Configured MCP servers:

✓ sources: http://127.0.0.1:8766/mcp (http) - Connected
```

From `/tmp`:

```
Approval mode overridden to "default" because the current folder is not trusted.
No MCP servers configured.
```

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/v7_build.py tests/test_v7_writer_dispatch.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_v7_writer_dispatch.py -v`

Note: this worktree does not have a local `.venv`; the shared project venv is Python 3.12.8 and was used from inside the delegated worktree.
