### PR TITLE
fix(deploy): add .codex/ to deploy_prompts.sh sync chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ service-account*.json
 # AI assistant configs
 #.gemini/
 .claude/
+.codex/
 
 
 # Python

--- a/scripts/check_rules_deployment.sh
+++ b/scripts/check_rules_deployment.sh
@@ -18,6 +18,9 @@ check_pair() {
     local orphan
     for orphan in "$@"; do
         diff_args+=(-x "${orphan%/}")
+        if [[ "$orphan" == */* ]]; then
+            diff_args+=(-x "${orphan##*/}")
+        fi
     done
 
     if [[ ! -d "$src" ]]; then
@@ -50,6 +53,7 @@ drift=0
 # rsync calls and ORPHAN_PATHS_* declarations in scripts/deploy_prompts.sh.
 check_pair "claude_extensions" ".claude" "scheduled_tasks.lock" "worktrees" || drift=1
 check_pair "claude_extensions" ".agent" "wake" "cache" || drift=1
+check_pair "claude_extensions" ".codex" "agents/curriculum-maintainer.toml" "config.toml" "hooks.json" || drift=1
 check_pair "claude_extensions/skills" ".agents/skills" || drift=1
 check_pair "gemini_extensions" ".gemini" "docs/" || drift=1
 

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -43,6 +43,9 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees"
 #          Runtime-only; NOT source-tracked. rsync --delete must preserve both.
 ORPHAN_PATHS_AGENT="wake cache"
 ORPHAN_PATHS_AGENTS=""
+# agents/curriculum-maintainer.toml — Codex agent definition with no claude_extensions equivalent.
+# config.toml and hooks.json — Codex CLI configuration files managed directly by Codex.
+ORPHAN_PATHS_CODEX="agents/curriculum-maintainer.toml config.toml hooks.json"
 ORPHAN_PATHS_GEMINI="docs/"
 
 # Build rsync --exclude arguments from a space-separated path list.
@@ -91,6 +94,7 @@ orphan_fail=false
 check_orphans "claude_extensions" ".claude" "$ORPHAN_PATHS_CLAUDE" "claude_extensions → .claude" || orphan_fail=true
 check_orphans "claude_extensions" ".agent" "$ORPHAN_PATHS_AGENT" "claude_extensions → .agent" || orphan_fail=true
 check_orphans "claude_extensions/skills" ".agents/skills" "$ORPHAN_PATHS_AGENTS" "claude_extensions/skills → .agents/skills" || orphan_fail=true
+check_orphans "claude_extensions" ".codex" "$ORPHAN_PATHS_CODEX" "claude_extensions → .codex" || orphan_fail=true
 check_orphans "gemini_extensions" ".gemini" "$ORPHAN_PATHS_GEMINI" "gemini_extensions → .gemini" || orphan_fail=true
 if [[ "$orphan_fail" == true ]]; then
     echo ""
@@ -126,6 +130,9 @@ diff_dirs() {
     for p in $orphans; do
         # Strip trailing slash for diff --exclude
         diff_args+=(--exclude="${p%/}")
+        if [[ "$p" == */* ]]; then
+            diff_args+=(--exclude="${p##*/}")
+        fi
     done
     local diff_out
     diff_out=$(diff "${diff_args[@]}" "$src" "$dst" 2>/dev/null || true)
@@ -146,6 +153,7 @@ diff_dirs() {
 diff_dirs "claude_extensions" ".claude" "claude_extensions → .claude" "$ORPHAN_PATHS_CLAUDE"
 diff_dirs "claude_extensions" ".agent" "claude_extensions → .agent" "$ORPHAN_PATHS_AGENT"
 diff_dirs "claude_extensions/skills" ".agents/skills" "claude_extensions/skills → .agents/skills" "$ORPHAN_PATHS_AGENTS"
+diff_dirs "claude_extensions" ".codex" "claude_extensions → .codex" "$ORPHAN_PATHS_CODEX"
 diff_dirs "gemini_extensions" ".gemini" "gemini_extensions → .gemini" "$ORPHAN_PATHS_GEMINI"
 echo ""
 
@@ -165,6 +173,8 @@ echo "=== Syncing ==="
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CLAUDE") claude_extensions/ .claude/
 # shellcheck disable=SC2046
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_AGENT") claude_extensions/ .agent/
+# shellcheck disable=SC2046
+rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX") claude_extensions/ .codex/
 # shellcheck disable=SC2046
 # rsync needs the destination's parent dir to exist before it can create
 # `.agents/skills/`. On a clean checkout (e.g. the test fixture in

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -12,6 +12,7 @@ PROJECT_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 DEPLOY_SCRIPT = Path("scripts/deploy_prompts.sh")
 CHECK_SCRIPT = Path("scripts/check_rules_deployment.sh")
 DRIFT_TARGET = Path(".claude/rules/critical-rules.md")
+CODEX_HOOK_TARGET = Path(".codex/hooks/session-setup.sh")
 
 
 def _copy_repo_subset(target: Path) -> None:
@@ -58,6 +59,16 @@ def _run(repo: Path, script: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _run_command(repo: Path, command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
 def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
     """A clean checkout should deploy successfully and pass drift checks."""
     repo = _init_checkout(tmp_path)
@@ -72,6 +83,48 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         "drift check failed after fresh deploy:\n"
         f"stdout: {check_result.stdout}\nstderr: {check_result.stderr}"
     )
+    assert (repo / CODEX_HOOK_TARGET).exists()
+
+    codex_hooks_diff = _run_command(
+        repo,
+        ["diff", "-rq", "claude_extensions/hooks", ".codex/hooks"],
+    )
+    assert codex_hooks_diff.returncode == 0, (
+        "Codex hooks drift after fresh deploy:\n"
+        f"stdout: {codex_hooks_diff.stdout}\nstderr: {codex_hooks_diff.stderr}"
+    )
+
+
+def test_second_deploy_is_noop_for_codex_target(tmp_path: Path) -> None:
+    """Two consecutive deploys should leave the Codex target unchanged."""
+    repo = _init_checkout(tmp_path)
+
+    first_result = _run(repo, DEPLOY_SCRIPT)
+    assert first_result.returncode == 0, (
+        f"first deploy failed:\nstdout: {first_result.stdout}\nstderr: {first_result.stderr}"
+    )
+
+    second_result = _run(repo, DEPLOY_SCRIPT)
+    assert second_result.returncode == 0, (
+        f"second deploy failed:\nstdout: {second_result.stdout}\nstderr: {second_result.stderr}"
+    )
+    assert "claude_extensions → .codex: no changes" in second_result.stdout
+    assert "No changes to deploy." in second_result.stdout
+
+
+def test_codex_orphan_is_caught(tmp_path: Path) -> None:
+    """Undeclared destination-only Codex paths must abort the deploy."""
+    repo = _init_checkout(tmp_path)
+    orphan = repo / ".codex" / "stale-only.txt"
+    orphan.parent.mkdir(parents=True)
+    orphan.write_text("stale\n", encoding="utf-8")
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    combined_output = f"{deploy_result.stdout}\n{deploy_result.stderr}"
+
+    assert deploy_result.returncode != 0
+    assert "claude_extensions → .codex" in combined_output
+    assert "undeclared orphan 'stale-only.txt'" in combined_output
 
 
 def test_drift_is_caught(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `.codex/` to the `scripts/deploy_prompts.sh` sync chain.
- Declares Codex-only orphan paths: `agents/curriculum-maintainer.toml`, `config.toml`, and `hooks.json`.
- Extends preflight, deploy diff verification, and standalone drift checks for `.codex/`.
- Adds focused pytest coverage for `.codex/` sync, second-run idempotency, and orphan detection.
- Ignores `.codex/` like `.claude/`, `.agent/`, and `.gemini/` so local deploy output does not flood code diffs.

Closes #1815. Closes the upstream cause of #1811-class drift.

## Acceptance Criteria

- [x] `deploy_prompts.sh` adds an rsync chain `claude_extensions/ → .codex/`.
  - Evidence from diff: `rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX") claude_extensions/ .codex/`
- [x] `ORPHAN_PATHS_CODEX` declared for `.codex/` destination-only paths.
  - Evidence from diff: `ORPHAN_PATHS_CODEX="agents/curriculum-maintainer.toml config.toml hooks.json"`
- [x] Preflight `check_orphans` extended for `.codex/`.
  - Evidence from diff: `check_orphans "claude_extensions" ".codex" "$ORPHAN_PATHS_CODEX" "claude_extensions → .codex" || orphan_fail=true`
- [x] `diff_dirs` extended for `.codex/`.
  - Evidence from diff: `diff_dirs "claude_extensions" ".codex" "claude_extensions → .codex" "$ORPHAN_PATHS_CODEX"`
- [x] `tests/test_deploy_script_idempotency.py` covers `.codex/` target.
  - Evidence: new tests assert `.codex/hooks/session-setup.sh`, `diff -rq claude_extensions/hooks .codex/hooks`, second deploy no-op output, and `.codex` orphan failure.
- [x] After deploy, `diff -rq claude_extensions/hooks/ .codex/hooks/` returns no differences.
  - Evidence below.

## Verification Evidence

### `.codex/hooks/` exists in git

```text
$ git ls-files .codex/hooks/
.codex/hooks/auto-audit.sh
.codex/hooks/check-gemini-inbox.sh
.codex/hooks/context-monitor.sh
.codex/hooks/enforce-venv.sh
.codex/hooks/post-compact.sh
.codex/hooks/session-setup.sh
.codex/hooks/tool-timing.sh
```

### Deploy sync and hooks diff

```text
$ npm run claude:deploy && diff -rq claude_extensions/hooks/ .codex/hooks/
=== Preflight (orphan-path guard) ===
  ✅ All orphan paths are declared.
...
=== Deploy diff ===
  claude_extensions → .claude: no changes
  claude_extensions → .agent: no changes
  claude_extensions/skills → .agents/skills: no changes
  claude_extensions → .codex: no changes
  gemini_extensions → .gemini: no changes

No changes to deploy.
```

`diff -rq claude_extensions/hooks/ .codex/hooks/` produced no output.

### Idempotency

```text
$ npm run claude:deploy && npm run claude:deploy
=== Deploy diff ===
  claude_extensions → .claude: no changes
  claude_extensions → .agent: no changes
  claude_extensions/skills → .agents/skills: no changes
  claude_extensions → .codex: no changes
  gemini_extensions → .gemini: no changes

No changes to deploy.
...
=== Deploy diff ===
  claude_extensions → .claude: no changes
  claude_extensions → .agent: no changes
  claude_extensions/skills → .agents/skills: no changes
  claude_extensions → .codex: no changes
  gemini_extensions → .gemini: no changes

No changes to deploy.
```

### Tests

```text
$ .venv/bin/pytest tests/test_deploy_script_idempotency.py -q
4 passed in 1.86s
```

```text
$ .venv/bin/ruff check tests/test_deploy_script_idempotency.py
All checks passed!
```

```text
$ shellcheck scripts/deploy_prompts.sh
shellcheck unavailable
```

### Codex orphan preflight

```text
$ printf 'stale\n' > .codex/stale-preflight-proof.txt; npm run claude:deploy
=== Preflight (orphan-path guard) ===
  ⚠️  claude_extensions → .codex: undeclared orphan 'stale-preflight-proof.txt' in destination
     rsync --delete would wipe this. Either:
       1. Move it to the source extensions/ dir, OR
       2. Add it to ORPHAN_PATHS_* in this script

❌ Deploy aborted: undeclared orphan paths would be deleted.
```

The temporary stale file was removed after this check.

### Drift checker

```text
$ bash scripts/check_rules_deployment.sh
OK: claude_extensions -> .claude
OK: claude_extensions -> .agent
OK: claude_extensions -> .codex
OK: claude_extensions/skills -> .agents/skills
OK: gemini_extensions -> .gemini
```

### Pre-submit scope checks

```text
$ git diff -- .python-version .yamllint .markdownlint.json
# no output
```

```text
$ git diff --name-only
.gitignore
scripts/check_rules_deployment.sh
scripts/deploy_prompts.sh
tests/test_deploy_script_idempotency.py
```
