### PR TITLE
fix(ui): address monitor review findings

### DIFF
--- a/playgrounds/comms.html
+++ b/playgrounds/comms.html
@@ -200,6 +200,14 @@ a.gh-issue:hover { text-decoration: underline; }
   </div>
 </div>
 
+<nav class="ops-nav" aria-label="Operational dashboards">
+  <a href="/audit-dashboard.html">Audit</a>
+  <a href="/progress.html">Progress</a>
+  <a href="/curriculum-dashboard.html">Curriculum</a>
+  <a href="/quality.html">Quality</a>
+  <a href="/track-health.html">Health</a>
+</nav>
+
 <div class="health-bar" id="health-bar"></div>
 
 <div class="tabs">

--- a/playgrounds/monitor.css
+++ b/playgrounds/monitor.css
@@ -83,6 +83,28 @@ a { color: var(--accent); }
   color: var(--accent) !important;
 }
 
+.ops-nav {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: -10px 24px 18px;
+  font-size: 12px;
+}
+
+.ops-nav a {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text2);
+  padding: 5px 8px;
+  text-decoration: none;
+}
+
+.ops-nav a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .home-link {
   color: var(--accent) !important;
 }

--- a/playgrounds/orient.html
+++ b/playgrounds/orient.html
@@ -401,10 +401,15 @@ function startRefresh() {
 
 async function loadOrient() {
   try {
-    const [data, discussions] = await Promise.all([
+    const [orientResult, discussionsResult] = await Promise.allSettled([
       fetchJson('/api/orient'),
       fetchJson('/api/discussions/active')
     ]);
+    if (orientResult.status !== 'fulfilled') throw orientResult.reason;
+    const data = orientResult.value;
+    const discussions = discussionsResult.status === 'fulfilled'
+      ? discussionsResult.value
+      : { discussions: [], error: discussionsResult.reason && discussionsResult.reason.message ? discussionsResult.reason.message : String(discussionsResult.reason || 'Discussion lookup failed') };
     setPageBanner('');
     refreshHalted = false;
     renderGit(data.git || {});
@@ -413,6 +418,9 @@ async function loadOrient() {
     renderRuntime(data.runtime || {});
     renderDelegate(data.delegate || {});
     renderDiscussions(discussions || {});
+    if (discussions && discussions.error) {
+      document.getElementById('discussions-content').innerHTML = `<div class="empty">Discussion lookup unavailable: ${escapeHtml(discussions.error)}</div>`;
+    }
     renderWiki(data.wiki || {});
     renderHealth(data.health || {});
     renderSessionHints(Array.isArray(data.session_hints) ? data.session_hints : []);

--- a/playgrounds/runtime.html
+++ b/playgrounds/runtime.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Runtime - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -61,6 +62,7 @@ tr:last-child td { border-bottom: none; }
   .topbar { flex-wrap: wrap; }
 }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">
@@ -74,7 +76,13 @@ tr:last-child td { border-bottom: none; }
     <div>Auto-refresh every 30s</div>
     <div id="last-refresh">Waiting for data...</div>
   </div>
-  <a href="/">Home</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a class="active" href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="container">

--- a/scripts/api/discussions_router.py
+++ b/scripts/api/discussions_router.py
@@ -40,27 +40,27 @@ def _latest_agent_states(messages: list[sqlite3.Row], last_round: int) -> dict[s
         if round_index < last_round:
             states[agent] = "pending"
             continue
-        states[agent] = "agreed" if body.upper().endswith("[AGREE]") else "done"
+        states[agent] = "agreed" if body.endswith("[AGREE]") else "done"
     return states
 
 
 def _discussion_status(messages: list[sqlite3.Row], last_message_at: datetime, last_round: int) -> str:
-    bodies = "\n".join(str(row["body"] or "") for row in messages).upper()
-    if "[TIMEOUT]" in bodies:
+    if any(str(row["body"] or "").strip().endswith("[TIMEOUT]") for row in messages):
         return "timed_out"
     if datetime.now(UTC) - last_message_at > timedelta(minutes=30):
         return "timed_out"
     states = _latest_agent_states(messages, last_round)
-    if states and all(state == "agreed" for state in states.values()):
+    if last_round > 1 and states and all(state == "agreed" for state in states.values()):
         return "converged"
     return "running"
 
 
-def collect_active_discussions(limit: int = 25) -> dict[str, Any]:
+def collect_active_discussions(limit: int = 25, lookback_days: int = 7) -> dict[str, Any]:
     """Return recent ab-discuss-style threads grouped from channel messages."""
     if not MESSAGE_DB.exists():
         return {"discussions": [], "count": 0, "error": "Broker DB not found"}
 
+    cutoff = (datetime.now(UTC) - timedelta(days=lookback_days)).isoformat()
     conn = connect_sqlite(f"file:{MESSAGE_DB}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     try:
@@ -69,8 +69,10 @@ def collect_active_discussions(limit: int = 25) -> dict[str, Any]:
             SELECT message_id, channel, thread_id, round_index, from_agent, body, created_at
             FROM channel_messages
             WHERE thread_id IS NOT NULL AND thread_id != ''
+              AND created_at >= ?
             ORDER BY created_at ASC
-            """
+            """,
+            (cutoff,),
         ).fetchall()
     finally:
         conn.close()
@@ -109,9 +111,12 @@ def collect_active_discussions(limit: int = 25) -> dict[str, Any]:
 
 
 @router.get("/active")
-async def active_discussions(limit: int = Query(25, ge=1, le=100)):
+async def active_discussions(
+    limit: int = Query(25, ge=1, le=100),
+    lookback_days: int = Query(7, ge=1, le=30),
+):
     """Recent discussion threads with running/converged/timed_out status."""
     try:
-        return collect_active_discussions(limit=limit)
+        return collect_active_discussions(limit=limit, lookback_days=lookback_days)
     except sqlite3.Error as exc:
         return JSONResponse(status_code=500, content={"error": "broker_query_failed", "detail": str(exc)})

--- a/scripts/api/docs_router.py
+++ b/scripts/api/docs_router.py
@@ -261,5 +261,5 @@ async def serve_artifact(
     return FileResponse(
         full_path,
         media_type=_MIME_TYPES.get(full_path.suffix.lower(), "application/octet-stream"),
-        headers={"Cache-Control": "max-age=300"},
+        headers={"Cache-Control": "max-age=300, must-revalidate"},
     )

--- a/tests/test_discussions_router.py
+++ b/tests/test_discussions_router.py
@@ -37,7 +37,7 @@ def _insert_message(
             round_index,
             from_agent,
             body,
-            created_at.isoformat().replace("+00:00", "Z"),
+            created_at.isoformat(),
         ),
     )
 
@@ -57,10 +57,15 @@ def discussions_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestC
     _insert_message(conn, message_id="m1", thread_id="running", round_index=0, from_agent="user", body="Discuss", created_at=now - timedelta(minutes=4))
     _insert_message(conn, message_id="m2", thread_id="running", round_index=1, from_agent="codex", body="Still working", created_at=now - timedelta(minutes=2))
     _insert_message(conn, message_id="m3", thread_id="converged", round_index=0, from_agent="user", body="Discuss", created_at=now - timedelta(minutes=8))
-    _insert_message(conn, message_id="m4", thread_id="converged", round_index=1, from_agent="codex", body="Agree [AGREE]", created_at=now - timedelta(minutes=6))
-    _insert_message(conn, message_id="m5", thread_id="timed-out", round_index=0, from_agent="user", body="Discuss", created_at=now - timedelta(minutes=50))
-    _insert_message(conn, message_id="m6", thread_id="timed-out", round_index=1, from_agent="gemini", body="Delayed", created_at=now - timedelta(minutes=45))
-    _insert_message(conn, message_id="m7", thread_id="marker-timeout", round_index=1, from_agent="claude", body="[TIMEOUT]", created_at=now - timedelta(minutes=1))
+    _insert_message(conn, message_id="m4", thread_id="converged", round_index=1, from_agent="codex", body="Need another pass", created_at=now - timedelta(minutes=6))
+    _insert_message(conn, message_id="m5", thread_id="converged", round_index=2, from_agent="codex", body="Agree [AGREE]", created_at=now - timedelta(minutes=5))
+    _insert_message(conn, message_id="m6", thread_id="timed-out", round_index=0, from_agent="user", body="Discuss", created_at=now - timedelta(minutes=50))
+    _insert_message(conn, message_id="m7", thread_id="timed-out", round_index=1, from_agent="gemini", body="Delayed", created_at=now - timedelta(minutes=45))
+    _insert_message(conn, message_id="m8", thread_id="marker-timeout", round_index=1, from_agent="claude", body="[TIMEOUT]", created_at=now - timedelta(minutes=1))
+    _insert_message(conn, message_id="m9", thread_id="timeout-topic", round_index=1, from_agent="codex", body="We should discuss [TIMEOUT] markers without ending yet.", created_at=now - timedelta(minutes=1))
+    _insert_message(conn, message_id="m10", thread_id="old", round_index=1, from_agent="codex", body="Old thread", created_at=now - timedelta(days=10))
+    _insert_message(conn, message_id="m11", thread_id="round-one-agree", round_index=1, from_agent="claude", body="Parallel reply [AGREE]", created_at=now - timedelta(minutes=1))
+    _insert_message(conn, message_id="m12", thread_id="lowercase-agree", round_index=2, from_agent="claude", body="Parallel reply [agree]", created_at=now - timedelta(minutes=1))
     conn.commit()
     conn.close()
     monkeypatch.setattr(discussions_router, "MESSAGE_DB", db_path)
@@ -77,9 +82,28 @@ def test_active_discussions_classifies_running_converged_and_timed_out(discussio
     assert by_thread["converged"]["status"] == "converged"
     assert by_thread["timed-out"]["status"] == "timed_out"
     assert by_thread["marker-timeout"]["status"] == "timed_out"
+    assert by_thread["timeout-topic"]["status"] == "running"
+    assert by_thread["round-one-agree"]["status"] == "running"
+    assert by_thread["lowercase-agree"]["status"] == "running"
+    assert "old" not in by_thread
     assert by_thread["running"]["channel"] == "architecture"
     assert by_thread["running"]["last_round"] == 1
     assert by_thread["running"]["round_count"] == 1
+
+
+def test_active_discussions_limit_and_lookback(discussions_client: TestClient):
+    response = discussions_client.get("/api/discussions/active", params={"limit": 1, "lookback_days": 30})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert len(body["discussions"]) == 1
+
+
+def test_active_discussions_lookback_includes_older_threads(discussions_client: TestClient):
+    response = discussions_client.get("/api/discussions/active", params={"lookback_days": 15})
+    assert response.status_code == 200
+    by_thread = {item["thread_id"]: item for item in response.json()["discussions"]}
+    assert "old" in by_thread
 
 
 def test_active_discussions_negative_path_missing_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_docs_router.py
+++ b/tests/test_docs_router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from scripts.api import artifacts_router, docs_router
@@ -38,6 +38,7 @@ def docs_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app = FastAPI()
     app.include_router(artifacts_router.router, prefix="/api/artifacts")
     app.include_router(docs_router.router, prefix="/artifacts")
+    app.include_router(docs_router.router, prefix="/files")
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -46,7 +47,7 @@ def test_docs_router_serves_allowed_html_roots(docs_client: TestClient, root_key
     response = docs_client.get(f"/artifacts/{root_key}/REPORT.html")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
-    assert response.headers["cache-control"] == "max-age=300"
+    assert response.headers["cache-control"] == "max-age=300, must-revalidate"
 
 
 def test_docs_router_root_serves_browser_ui(docs_client: TestClient):
@@ -61,6 +62,12 @@ def test_docs_router_root_json_lists_roots(docs_client: TestClient):
     assert response.status_code == 200
     body = response.json()
     assert len(body["roots"]) == len(docs_router.ALLOWED_ROOTS)
+
+
+def test_docs_router_files_alias_stays_json(docs_client: TestClient):
+    response = docs_client.get("/files/?format=json")
+    assert response.status_code == 200
+    assert len(response.json()["roots"]) == len(docs_router.ALLOWED_ROOTS)
 
 
 def test_docs_router_directory_listing_json(docs_client: TestClient):
@@ -86,18 +93,18 @@ def test_docs_router_blocks_symlink_outside_root(docs_client: TestClient, tmp_pa
     outside.write_text("outside", encoding="utf-8")
     link = tmp_path / "audit" / "linked.html"
     link.symlink_to(outside)
-    assert docs_client.get("/artifacts/audit/linked.html").status_code in {403, 404}
+    assert docs_client.get("/artifacts/audit/linked.html").status_code == 403
 
 
 def test_docs_router_blocks_forbidden_extension(docs_client: TestClient, tmp_path: Path):
     (tmp_path / "audit" / "script.py").write_text("print('no')", encoding="utf-8")
-    assert docs_client.get("/artifacts/audit/script.py").status_code in {403, 404}
+    assert docs_client.get("/artifacts/audit/script.py").status_code == 403
 
 
 def test_docs_router_blocks_unapproved_root(docs_client: TestClient, tmp_path: Path):
     (tmp_path / "scripts" / "api").mkdir(parents=True)
     (tmp_path / "scripts" / "api" / "main.py").write_text("x = 1", encoding="utf-8")
-    assert docs_client.get("/artifacts/scripts/api/main.py").status_code in {403, 404}
+    assert docs_client.get("/artifacts/scripts/api/main.py").status_code == 403
 
 
 def test_docs_router_missing_file_404(docs_client: TestClient):
@@ -108,7 +115,17 @@ def test_docs_router_blocks_hidden_file(docs_client: TestClient, tmp_path: Path)
     hidden_dir = tmp_path / "audit" / ".git"
     hidden_dir.mkdir()
     (hidden_dir / "HEAD").write_text("ref: refs/heads/main", encoding="utf-8")
-    assert docs_client.get("/artifacts/audit/.git/HEAD").status_code in {403, 404}
+    assert docs_client.get("/artifacts/audit/.git/HEAD").status_code == 403
+
+
+def test_docs_router_assert_under_root_blocks_resolved_escape(tmp_path: Path):
+    root = tmp_path / "audit"
+    root.mkdir()
+    outside = tmp_path / "outside.html"
+    outside.write_text("outside", encoding="utf-8")
+    with pytest.raises(HTTPException) as exc_info:
+        docs_router._assert_under_root(outside, root)
+    assert exc_info.value.status_code == 403
 
 
 def test_html_artifact_listing_extracts_metadata_and_filters(docs_client: TestClient):

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -17,8 +17,36 @@ def test_orient_page_renders_active_discussions_widget():
     html = (ROOT / "playgrounds" / "orient.html").read_text(encoding="utf-8")
     assert "Active Discussions" in html
     assert "/api/discussions/active" in html
+    assert "Promise.allSettled" in html
+    assert "Discussion lookup unavailable" in html
     assert "renderDiscussions" in html
     assert "channels.html?channel=" in html
+
+
+def test_runtime_page_keeps_primary_monitor_nav():
+    html = (ROOT / "playgrounds" / "runtime.html").read_text(encoding="utf-8")
+    assert '<link rel="stylesheet" href="/monitor.css">' in html
+    assert '<a class="active" href="/runtime.html">Runtime</a>' in html
+    for href in [
+        "/orient.html",
+        "/channels.html",
+        "/comms.html",
+        "/artifacts/",
+        "/runtime.html",
+    ]:
+        assert f'href="{href}"' in html
+
+
+def test_comms_page_keeps_secondary_dashboard_links():
+    html = (ROOT / "playgrounds" / "comms.html").read_text(encoding="utf-8")
+    for href in [
+        "/audit-dashboard.html",
+        "/progress.html",
+        "/curriculum-dashboard.html",
+        "/quality.html",
+        "/track-health.html",
+    ]:
+        assert f'href="{href}"' in html
 
 
 def test_artifacts_page_uses_metadata_endpoint_and_filters():


### PR DESCRIPTION
## Summary
Follow-up to merged PR #1824. This applies and tightens the concrete monitor UI review fixes that were validated after #1824 had already merged:

- keep `orient.html` usable when `/api/discussions/active` fails by using `Promise.allSettled`
- restore the primary monitor nav on `runtime.html`
- preserve secondary operational dashboard links from `comms.html`
- bound `/api/discussions/active` scanning with `lookback_days`
- align dashboard discussion semantics with the bridge: exact `[AGREE]`, no round-1 convergence, exact terminal `[TIMEOUT]`
- add `must-revalidate` to served artifact cache headers
- strengthen regression coverage for `/files`, path safety, lookback inclusion, marker semantics, and restored UI navigation contracts

Gemini and Claude initially passed the narrower patch with follow-up notes; those notes are now folded into this branch.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_docs_router.py tests/test_discussions_router.py tests/test_monitor_ui_contracts.py tests/test_playground_api_stability.py -q` -> `34 passed in 4.39s`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/api/docs_router.py scripts/api/artifacts_router.py scripts/api/discussions_router.py tests/test_docs_router.py tests/test_discussions_router.py tests/test_monitor_ui_contracts.py tests/test_playground_api_stability.py` -> `All checks passed!`
- HTMLParser parsed `playgrounds/orient.html`, `playgrounds/comms.html`, and `playgrounds/runtime.html`
- `git diff --check` -> clean
- pre-submit guard: 9 files changed; no `.python-version`, `.yamllint`, `.markdownlint.json`, status JSON, generated review markdown, or `docs/*-STATUS.md` in this PR diff
