### PR TITLE
docs(adr): Decision Graph view ADR — round-3 revisions (PROPOSED, supersedes #1791)

### DIFF
--- a/docs/decisions/pending/2026-05-09-decision-graph-view.md
+++ b/docs/decisions/pending/2026-05-09-decision-graph-view.md
@@ -5,7 +5,7 @@
 **Authors:** Gemini (drafting), Codex (data collection), Claude (orchestration context)
 **Supersedes:** None
 **Scope:** Decision Graph view in channels.html — UI toggle, marker parser, matrix layout, drawer; not the underlying DB schema or `ab discuss` broker logic.
-**Blocks/Blocked-by:** Blocks Decision Graph UI implementation; independent of docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md. Integrates with D4 decision-lineage backlink scanner (#1785).
+**Blocks/Blocked-by:** Blocks Decision Graph UI implementation; ships today against the current `from_agent` schema and remains forward-compatible with docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md participant identity fields. Integrates with D4 decision-lineage backlink scanner (#1785).
 
 ---
 
@@ -38,9 +38,9 @@ This document formalizes the UX and architectural semantics for the Decision Gra
 The Decision Graph view will be implemented under the following paradigm:
 
 *   **Toggle-not-inversion:** Chat remains the primary view. The Decision Graph is a toggleable view that auto-engages under specific conditions.
-*   **Outline-first matrix layout:** The graph uses a dense matrix representation (rounds as rows, agent families as columns) displaying only markers and brief summaries to accommodate our large average message sizes.
+*   **Outline-first matrix layout:** The graph uses a dense matrix representation (rounds as rows, participants as columns) displaying only markers and brief summaries to accommodate our large average message sizes.
 *   **Side drawer UX:** Reading full message bodies relies on a pinnable side drawer to avoid disrupting the matrix context.
-*   **Explicit marker semantics:** Deliberation state is strictly derived from standard `[AGREE]`, `[OPTION]`, `[OBJECT]`, and `[DEFER]` markers.
+*   **Explicit marker semantics:** Deliberation state is strictly derived from standard `[AGREE]` and `[DISAGREE]` markers, with `[OPTION]`, `[OBJECT]`, and `[DEFER]` reserved for future or ADR-specific display.
 
 ---
 
@@ -48,8 +48,8 @@ The Decision Graph view will be implemented under the following paradigm:
 
 ### Proposal
 The Decision Graph view should auto-engage (switch automatically from the chat view) when a thread meets **both** of the following conditions:
-1.  **Participant-count threshold:** The thread contains messages from **≥2 distinct `agent_family` participants** (e.g., `claude` and `codex`).
-2.  **Marker-density threshold:** The thread contains **≥2 messages** carrying formal deliberation markers (`[AGREE]`, `[OPTION]`, `[OBJECT]`, `[DEFER]`).
+1.  **Participant-count threshold:** The thread contains messages from **≥2 distinct `from_agent` participants** in the current schema (e.g., `claude` and `codex`; user/human posts count as participants when they use the same channel-message path).
+2.  **Marker-density threshold:** The thread contains **≥2 messages** carrying formal deliberation markers (`[AGREE]`, `[DISAGREE]`, or future display markers `[OPTION]`, `[OBJECT]`, `[DEFER]`).
 
 The manual toggle to switch between Chat and Decision Graph views is **always available** on every thread, regardless of whether the auto-engage criteria are met.
 
@@ -63,7 +63,7 @@ Our channel statistics show that marker threads only dominate the `architecture`
 ### Proposal
 The Decision Graph will use an **outline-first matrix layout**:
 *   **Rows:** Rounds (1..N).
-*   **Columns:** `agent_family` (e.g., `claude`, `gemini`, `codex`, plus a `human` column for posts where `from_agent='human'`).
+*   **Columns:** current implementation keys columns by `from_agent` because `channel_messages` currently has `from_agent` but no `agent_family`/`participant_id` columns. After the Multi-UI ADR lands, columns should re-key to the exact participant identity, preferably `participant_id` or the tuple `(agent_family, ui_surface, instance_id_short)`, with labels such as `claude:cli` and `claude:desktop`.
 *   **Cell Content:** A marker chip (color-coded, e.g., Green for `[AGREE]`) + a first-line summary truncated to ~80 characters.
 *   **Empty Cells:** If an agent didn't respond in a specific round, the cell displays a visible empty state (e.g., a dashed outline or "No response").
 *   **Interaction:** Clicking a cell opens a side drawer with the full message body.
@@ -76,34 +76,37 @@ Codex's data shows average reply bodies are 2367 chars and max out at 8349 chars
 ## Q3. Marker parsing semantics
 
 ### Proposal
-*   **Target Markers:** `[AGREE]`, `[OPTION]`, `[OBJECT]`, `[DEFER]`.
+*   **Canonical Markers:** `[AGREE]` and `[DISAGREE]`. The broker prompt requires agents to end round replies with one of these markers, and convergence uses strict `[AGREE]` tail matching in `scripts/ai_agent_bridge/_channels_cli.py:1413`.
+*   **Future/ADR-specific Markers:** `[OPTION]`, `[OBJECT]`, and `[DEFER]` may be displayed when present, but they are not canonical broker markers today. Current live DB evidence shows `[OPTION]`, `[OBJECT]`, and `[DEFER]` are rare compared with `[DISAGREE]`; `[OBJECT]` is documented in the Multi-UI ADR as a user pushback marker.
 *   **Case Sensitivity:** Case-insensitive match (to accommodate human posts or agent casing drift).
-*   **Regex Matching:** Use a concrete regex boundary: `\[(AGREE(?:D)?|OPTION|OBJECT(?:[^\]]*)?|DEFER)(?:\b[^\]]*)?\]` (case-insensitive).
+*   **Regex Matching:** Use a concrete regex boundary for display extraction: `\[(AGREE|DISAGREE|OPTION|OBJECT(?:[^\]]*)?|DEFER)(?:\b[^\]]*)?\]` (case-insensitive). Do not match `[AGREED]`; live DB evidence shows zero occurrences and the broker checks `[AGREE]` literally.
     | Input | Captured | Maps to |
     |---|---|---|
     | `[AGREE]` | `AGREE` | `[AGREE]` |
-    | `[AGREED]` | `AGREED` | `[AGREE]` |
+    | `[DISAGREE]` | `DISAGREE` | `[DISAGREE]` |
     | `[OBJECT - missing context]` | `OBJECT - missing context` | `[OBJECT]` |
     | `[OPTION B]` | `OPTION` | `[OPTION]` |
-*   **Position Requirement:** Anywhere in the body. While agents typically place markers at the end, human participants or modified prompts might place them at the top.
-*   **Multiple Markers:** If a single message contains multiple markers (e.g., `[OPTION] ... [DEFER]`), **last-wins** logic is applied. The final marker in the text flow is considered the agent's concluding stance for that round.
+*   **Position Requirement:** Display extraction may find markers anywhere in the body, but convergence uses the broker-compatible rule: the latest round message must end with literal `[AGREE]` after `.strip()`.
+*   **Multiple Markers:** If a single message contains multiple markers, the final marker in text flow may be used for the display chip. Protocol convergence still follows strict tail-anchored `[AGREE]`, so a message such as `I don't [AGREE] with that. [DISAGREE]` is not converged.
 
 ### Rationale
-Strict regexes break easily when agents append reasoning inside the brackets. Case-insensitivity and "anywhere in body" rules ensure human participants don't have to fight a rigid parser. "Last-wins" matches standard LLM reasoning behavior, where the model deliberates and concludes at the end of its generation.
+Strict regexes break easily when agents append reasoning inside the brackets, so the display parser tolerates annotated future markers such as `[OBJECT - missing context]`. Convergence is stricter than display because the broker intentionally uses `text.strip().endswith("[AGREE]")` to avoid false positives when a message mentions `[AGREE]` while concluding with `[DISAGREE]`.
 
 ---
 
 ## Q4. Convergence detection
 
 ### Proposal
-A thread is converged when every distinct `agent_family` that has posted in the thread emits `[AGREE]` in the latest round. Earlier-round content does not factor in.
+A thread is converged when every distinct current-schema participant (`from_agent`) that has posted in the thread has a latest round-N message whose stripped body ends with literal `[AGREE]`. Earlier-round content does not factor in.
 
-Edge case (partial participation): if an agent posted earlier but is silent in the latest round, that agent is still considered "participating" — the thread is NOT converged until that agent re-posts with `[AGREE]` or another marker. To exit, an agent must explicitly emit `[DEFER]`.
+Edge case (partial participation): if an agent posted earlier but is silent in the latest round, that agent is still considered "participating" — the thread is NOT converged until that agent re-posts with `[AGREE]` at the tail or another marker. In the current broker, `[DISAGREE]` is the canonical non-converging marker; `[DEFER]` remains a future display marker unless a later broker change gives it protocol meaning.
 
 When convergence is detected, the UI should display a "closing-out indicator" (e.g., a banner at the bottom of the graph) and auto-suggest the creation of a Decision Card if one has not already been emitted.
 
+Exception: for threads tagged with a high-risk track (HIST, BIO, ISTORIO, LIT, OES, or RUTH), convergence triggers a forced Decision Card prompt rather than a soft auto-suggest, per `docs/best-practices/agent-cooperation.md:210-222` Mechanism A.
+
 ### Rationale
-If Claude, Gemini, and Codex all end round 2 with `[AGREE]`, the deliberation protocol considers the issue resolved. Stricter conditions (requiring an explicit `[OBJECT]` first) would arbitrarily keep immediate-consensus threads marked as "unresolved."
+If Claude, Gemini, and Codex all end round 2 with `[AGREE]`, the deliberation protocol considers the issue resolved. Stricter conditions (requiring an explicit `[OBJECT]` first) would arbitrarily keep immediate-consensus threads marked as "unresolved." The Decision Graph's closing-out indicator must treat the broker's strict `endswith("[AGREE]")` rule as authoritative for protocol convergence.
 
 ---
 
@@ -111,19 +114,19 @@ If Claude, Gemini, and Codex all end round 2 with `[AGREE]`, the deliberation pr
 
 ### Proposal
 *   **Format:** A pinnable side rail (drawer) that persists alongside the matrix graph. It does NOT use a modal that interrupts the page and blocks the graph.
-*   **Content:** Displays the full-thread transcript filtered to that specific `agent_family` up to that round, highlighting the specific single-message cell clicked.
+*   **Content:** Defaults to the same-round transcript across all agents plus the clicked participant's prior posts in earlier rounds, highlighting the specific single-message cell clicked. A per-agent filter toggle lets readers narrow the drawer when they want a single participant's history.
 *   **Rendering:** Uses the exact same Markdown rendering pipeline as the main `channels.html` view (including image attachments, code blocks, etc.).
 *   **Actions:** Includes standard "Quote", "Copy", and "Reply" actions within the drawer.
 
 ### Rationale
-A modal blocks the matrix, preventing the user from reading Codex's full argument while looking at Gemini's summary chip. A pinnable side rail allows side-by-side comparison. Showing the filtered thread context for that agent helps the user understand how that specific agent arrived at its conclusion over multiple rounds.
+A modal blocks the matrix, preventing the user from reading Codex's full argument while looking at Gemini's summary chip. A pinnable side rail allows side-by-side comparison. Showing same-round all-agent context preserves the antagonist/proponent relationship for objections, while the clicked participant's prior posts show how that participant arrived at its conclusion over multiple rounds.
 
 ---
 
 ## Q6. Decision provenance
 
 ### Proposal
-*   The Decision Graph will integrate directly with **D4** (decision-lineage backlink scanner, Epic #1785).
+*   The Decision Graph will integrate directly with **D4** (decision-lineage backlink scanner, #1785).
 *   When D4 detects that a thread's ID or URL has been cited in an ADR file (e.g., inside `docs/decisions/`), the Decision Graph UI will display a **"This thread became ADR-NNN"** badge at the top of the matrix.
 *   Clicking the badge links out to the compiled ADR Markdown file or its GitHub equivalent.
 
@@ -136,6 +139,8 @@ Deliberation is ephemeral; decisions are permanent. Linking the Decision Graph t
 
 *   **What changes:** The `channels.html` frontend, adding a toggle for graph view, implementing the marker parser, and building the matrix/drawer UI.
 *   **What doesn't change:** The underlying DB schema, the `ab discuss` Python broker logic, or the Multi-UI blob storage schema. D3 and D4 are strictly read-oriented presentation layers.
+*   **Identity migration:** Before Multi-UI lands, Decision Graph reads `from_agent` as the participant key. Once Multi-UI adds first-class identity, the view can re-key columns by `participant_id` or `(agent_family, ui_surface, instance_id_short)` without changing the current DB schema first.
+*   **Convergence authority:** The broker's strict `text.strip().endswith("[AGREE]")` check is authoritative for `ab discuss` short-circuit behavior. The Decision Graph may show display markers found elsewhere in the body, but it must not label a thread converged unless the latest round messages satisfy the broker-compatible tail rule.
 
 ---
 
@@ -149,11 +154,11 @@ Deliberation is ephemeral; decisions are permanent. Linking the Decision Graph t
 ## Open Questions for User
 
 1.  **D4 Integration Timing:** Should the Decision Graph UI ship with a placeholder for the ADR badge, or should it be held until D4 (#1785) is fully merged and its JSON API is available?
-2.  **Thread Filtering in Drawer:** Should the side drawer default to showing *only* the clicked message, or the clicked message *plus* its parent thread context?
+2.  **Thread Filtering in Drawer:** Resolved by Q5: default to same-round all-agents plus clicked participant prior posts, with a per-agent filter toggle.
 
 ---
 
 ## Supersedes/Refines
 
 *   **Refines:** `docs/best-practices/agent-cooperation.md` (Provides UI realization of the Deliberation Protocol).
-*   **Complements:** `docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md` (Multi-UI sets up the identity primitives; this ADR defines the visualization).
+*   **Complements:** `docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md` (Multi-UI sets up future identity primitives; this ADR defines the visualization and uses current `from_agent` until those primitives land).

--- a/docs/decisions/pending/2026-05-09-decision-graph-view.md
+++ b/docs/decisions/pending/2026-05-09-decision-graph-view.md
@@ -1,0 +1,152 @@
+# DECISION REQUIRED - Decision Graph View Paradigm and Layout
+
+**Status:** PROPOSED (awaiting user signoff to ACCEPTED)
+**Date:** 2026-05-09
+**Authors:** Gemini (drafting), Codex (data collection), Claude (orchestration context)
+**Supersedes:** None
+**Blocks/Blocked-by:** Blocks Decision Graph UI implementation; independent of Multi-UI ADR (ADR-008). Integrates with D4 decision-lineage backlink scanner (#1785).
+
+---
+
+## Context
+
+The kubedojo team (a sister project) recently compared their dashboard to ours and pitched inverting our `channels.html` UI from being **chat-primary** to being **Decision Graph-primary**, where chat would become a secondary toggle. They offered to upstream their D3 (Decision Graph) PR after implementing it in their own repository.
+
+A 3-way agent review (Codex + Gemini, 2026-05-07) was conducted to evaluate this paradigm shift. The review converged on adopting a **modified version** of their proposal. Specifically, Codex provided verifiable data from our `channel_messages` snapshot (2026-05-07) demonstrating channel marker-thread density:
+
+| Channel | Marker threads | Total threads | % |
+|---|---:|---:|---:|
+| `architecture` | 32 | 39 | 82% |
+| `pipeline` | 2 | 11 | 18% |
+| `reviews` | 19 | 83 | 23% |
+
+This data strongly confirms that for ~75-80% of our general channel traffic, a Decision Graph-primary view would be the wrong paradigm. Therefore, the Decision Graph must be implemented as a **toggle**, not as an inversion of the primary IA.
+
+Furthermore, Codex gathered data on round-reply body sizes in the `architecture` channel:
+- Average: 2367 chars
+- Maximum: 8349 chars
+
+A standard 3-column body-first grid would be completely unreadable with this volume of text. This justifies an outline-first matrix layout.
+
+This document formalizes the UX and architectural semantics for the Decision Graph view. It is a separate ADR from the pending Multi-UI channel participation ADR because it changes primary IA and marker semantics (meeting the threshold rule for a distinct ADR).
+
+---
+
+## Decision
+
+The Decision Graph view will be implemented under the following paradigm:
+
+*   **Toggle-not-inversion:** Chat remains the primary view. The Decision Graph is a toggleable view that auto-engages under specific conditions.
+*   **Outline-first matrix layout:** The graph uses a dense matrix representation (rounds as rows, agent families as columns) displaying only markers and brief summaries to accommodate our large average message sizes.
+*   **Side drawer UX:** Reading full message bodies relies on a pinnable side drawer to avoid disrupting the matrix context.
+*   **Explicit marker semantics:** Deliberation state is strictly derived from standard `[AGREE]`, `[OPTION]`, `[OBJECT]`, and `[DEFER]` markers.
+
+---
+
+## Q1. When does Decision Graph view auto-engage?
+
+### Proposal
+The Decision Graph view should auto-engage (switch automatically from the chat view) when a thread meets **both** of the following conditions:
+1.  **Participant-count threshold:** The thread contains messages from **≥2 distinct `agent_family` participants** (e.g., `claude` and `codex`).
+2.  **Marker-density threshold:** The thread contains **≥2 messages** carrying formal deliberation markers (`[AGREE]`, `[OPTION]`, `[OBJECT]`, `[DEFER]`).
+
+The manual toggle to switch between Chat and Decision Graph views is **always available** on every thread, regardless of whether the auto-engage criteria are met.
+
+### Rationale
+Our channel statistics show that marker threads only dominate the `architecture` channel (82%), while `reviews` (23%) and `pipeline` (18%) are predominantly standard chat or single-shot interactions. Auto-engaging requires sufficient signal (multiple agents + multiple markers) to ensure the graph view is only presented when actual deliberation is taking place. Relying on a manual toggle for edge cases provides an escape hatch without enforcing the wrong default paradigm on 80% of threads.
+
+---
+
+## Q2. Layout
+
+### Proposal
+The Decision Graph will use an **outline-first matrix layout**:
+*   **Rows:** Rounds (1..N).
+*   **Columns:** `agent_family` (e.g., `claude`, `gemini`, `codex`, plus a `human` column for posts where `from_agent='human'`).
+*   **Cell Content:** A marker chip (color-coded, e.g., Green for `[AGREE]`) + a first-line summary truncated to ~80 characters.
+*   **Empty Cells:** If an agent didn't respond in a specific round, the cell displays a visible empty state (e.g., a dashed outline or "No response").
+*   **Interaction:** Clicking a cell opens a side drawer with the full message body.
+
+### Rationale
+Codex's data shows average reply bodies are 2367 chars and max out at 8349 chars. A "body-first" grid (like a traditional Kanban board) would stretch rows to unreadable heights, destroying the visual comparison between agent responses in a given round. An outline matrix optimizes for horizontal scanning of consensus (e.g., seeing three green `[AGREE]` chips in Row 2 immediately signals convergence).
+
+---
+
+## Q3. Marker parsing semantics
+
+### Proposal
+*   **Target Markers:** `[AGREE]`, `[OPTION]`, `[OBJECT]`, `[DEFER]`.
+*   **Case Sensitivity:** Case-insensitive match (to accommodate human posts or agent casing drift).
+*   **Fuzzy Matching:** Match exact bases and safe adjacent variants using a regex boundary (e.g., matching `[AGREED]` or `[OBJECT - missing context]`).
+*   **Position Requirement:** Anywhere in the body. While agents typically place markers at the end, human participants or modified prompts might place them at the top.
+*   **Multiple Markers:** If a single message contains multiple markers (e.g., `[OPTION] ... [DEFER]`), **last-wins** logic is applied. The final marker in the text flow is considered the agent's concluding stance for that round.
+
+### Rationale
+Strict regexes break easily when agents append reasoning inside the brackets. Case-insensitivity and "anywhere in body" rules ensure human participants don't have to fight a rigid parser. "Last-wins" matches standard LLM reasoning behavior, where the model deliberates and concludes at the end of its generation.
+
+---
+
+## Q4. Convergence detection
+
+### Proposal
+A thread is considered "decided" (converged) when:
+*   All distinct participating `agent_family` instances in the thread have emitted an `[AGREE]` marker in the **latest round**.
+*   **Looser historical condition:** At least one round must have had an `[OPTION]` or `[OBJECT]` marker, OR it can be an immediate 1-round agreement. We define convergence strictly by the state of the *terminal* round.
+
+When convergence is detected, the UI should display a "closing-out indicator" (e.g., a banner at the bottom of the graph) and auto-suggest the creation of a Decision Card if one has not already been emitted.
+
+### Rationale
+If Claude, Gemini, and Codex all end round 2 with `[AGREE]`, the deliberation protocol considers the issue resolved. Stricter conditions (requiring an explicit `[OBJECT]` first) would arbitrarily keep immediate-consensus threads marked as "unresolved."
+
+---
+
+## Q5. Side drawer UX
+
+### Proposal
+*   **Format:** A pinnable side rail (drawer) that persists alongside the matrix graph. It does NOT use a modal that interrupts the page and blocks the graph.
+*   **Content:** Displays the full-thread transcript filtered to that specific `agent_family` up to that round, highlighting the specific single-message cell clicked.
+*   **Rendering:** Uses the exact same Markdown rendering pipeline as the main `channels.html` view (including image attachments, code blocks, etc.).
+*   **Actions:** Includes standard "Quote", "Copy", and "Reply" actions within the drawer.
+
+### Rationale
+A modal blocks the matrix, preventing the user from reading Codex's full argument while looking at Gemini's summary chip. A pinnable side rail allows side-by-side comparison. Showing the filtered thread context for that agent helps the user understand how that specific agent arrived at its conclusion over multiple rounds.
+
+---
+
+## Q6. Decision provenance
+
+### Proposal
+*   The Decision Graph will integrate directly with **D4** (decision-lineage backlink scanner, Epic #1785).
+*   When D4 detects that a thread's ID or URL has been cited in an ADR file (e.g., inside `docs/decisions/`), the Decision Graph UI will display a **"This thread became ADR-NNN"** badge at the top of the matrix.
+*   Clicking the badge links out to the compiled ADR Markdown file or its GitHub equivalent.
+
+### Rationale
+Deliberation is ephemeral; decisions are permanent. Linking the Decision Graph to the D4 lineage scanner bridges the gap between the `ab discuss` transcript and the final, accepted architectural rule. It fulfills the workflow rule where deliberation must result in referenceable documentation.
+
+---
+
+## Implementation Notes
+
+*   **What changes:** The `channels.html` frontend, adding a toggle for graph view, implementing the marker parser, and building the matrix/drawer UI.
+*   **What doesn't change:** The underlying DB schema, the `ab discuss` Python broker logic, or the Multi-UI blob storage schema. D3 and D4 are strictly read-oriented presentation layers.
+
+---
+
+## Cross-Agent Review
+
+*   **Codex (Green Team):** *(Pending review)*
+*   **Claude (Blue Team):** *(Pending review)*
+
+---
+
+## Open Questions for User
+
+1.  **D4 Integration Timing:** Should the Decision Graph UI ship with a placeholder for the ADR badge, or should it be held until D4 (#1785) is fully merged and its JSON API is available?
+2.  **Thread Filtering in Drawer:** Should the side drawer default to showing *only* the clicked message, or the clicked message *plus* its parent thread context?
+
+---
+
+## Supersedes/Refines
+
+*   **Refines:** `docs/best-practices/agent-cooperation.md` (Provides UI realization of the Deliberation Protocol).
+*   **Complements:** `docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md` (Multi-UI sets up the identity primitives; this ADR defines the visualization).

--- a/docs/decisions/pending/2026-05-09-decision-graph-view.md
+++ b/docs/decisions/pending/2026-05-09-decision-graph-view.md
@@ -76,7 +76,7 @@ Codex's data shows average reply bodies are 2367 chars and max out at 8349 chars
 ## Q3. Marker parsing semantics
 
 ### Proposal
-*   **Canonical Markers:** `[AGREE]` and `[DISAGREE]`. The broker prompt requires agents to end round replies with one of these markers, and convergence uses strict `[AGREE]` tail matching in `scripts/ai_agent_bridge/_channels_cli.py:1413`.
+*   **Canonical Markers:** `[AGREE]` and `[DISAGREE]`. The broker prompt requires agents to end round replies with one of these markers, and convergence uses strict `[AGREE]` tail matching in `scripts/ai_agent_bridge/_channels_cli.py::_handle_discuss` (the convergence check is `text.strip().endswith("[AGREE]")` -- grep that literal to find current line).
 *   **Future/ADR-specific Markers:** `[OPTION]`, `[OBJECT]`, and `[DEFER]` may be displayed when present, but they are not canonical broker markers today. Current live DB evidence shows `[OPTION]`, `[OBJECT]`, and `[DEFER]` are rare compared with `[DISAGREE]`; `[OBJECT]` is documented in the Multi-UI ADR as a user pushback marker.
 *   **Case Sensitivity:** Case-insensitive match (to accommodate human posts or agent casing drift).
 *   **Regex Matching:** Use a concrete regex boundary for display extraction: `\[(AGREE|DISAGREE|OPTION|OBJECT(?:[^\]]*)?|DEFER)(?:\b[^\]]*)?\]` (case-insensitive). Do not match `[AGREED]`; live DB evidence shows zero occurrences and the broker checks `[AGREE]` literally.

--- a/docs/decisions/pending/2026-05-09-decision-graph-view.md
+++ b/docs/decisions/pending/2026-05-09-decision-graph-view.md
@@ -4,7 +4,8 @@
 **Date:** 2026-05-09
 **Authors:** Gemini (drafting), Codex (data collection), Claude (orchestration context)
 **Supersedes:** None
-**Blocks/Blocked-by:** Blocks Decision Graph UI implementation; independent of Multi-UI ADR (ADR-008). Integrates with D4 decision-lineage backlink scanner (#1785).
+**Scope:** Decision Graph view in channels.html — UI toggle, marker parser, matrix layout, drawer; not the underlying DB schema or `ab discuss` broker logic.
+**Blocks/Blocked-by:** Blocks Decision Graph UI implementation; independent of docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md. Integrates with D4 decision-lineage backlink scanner (#1785).
 
 ---
 
@@ -26,7 +27,7 @@ Furthermore, Codex gathered data on round-reply body sizes in the `architecture`
 - Average: 2367 chars
 - Maximum: 8349 chars
 
-A standard 3-column body-first grid would be completely unreadable with this volume of text. This justifies an outline-first matrix layout.
+A standard 3-column body-first grid would be completely unreadable with this volume of text. The matrix layout is justified for high-density channels; lighter channels could fall back to body-first or use the same matrix as a uniform UX choice.
 
 This document formalizes the UX and architectural semantics for the Decision Graph view. It is a separate ADR from the pending Multi-UI channel participation ADR because it changes primary IA and marker semantics (meeting the threshold rule for a distinct ADR).
 
@@ -68,7 +69,7 @@ The Decision Graph will use an **outline-first matrix layout**:
 *   **Interaction:** Clicking a cell opens a side drawer with the full message body.
 
 ### Rationale
-Codex's data shows average reply bodies are 2367 chars and max out at 8349 chars. A "body-first" grid (like a traditional Kanban board) would stretch rows to unreadable heights, destroying the visual comparison between agent responses in a given round. An outline matrix optimizes for horizontal scanning of consensus (e.g., seeing three green `[AGREE]` chips in Row 2 immediately signals convergence).
+Codex's data shows average reply bodies are 2367 chars and max out at 8349 chars. A "body-first" grid (like a traditional Kanban board) would stretch rows to unreadable heights, destroying the visual comparison between agent responses in a given round. An outline matrix optimizes for horizontal scanning of consensus (e.g., seeing three green `[AGREE]` chips in Row 2 immediately signals convergence). The matrix layout is justified for high-density channels; lighter channels could fall back to body-first or use the same matrix as a uniform UX choice.
 
 ---
 
@@ -77,7 +78,13 @@ Codex's data shows average reply bodies are 2367 chars and max out at 8349 chars
 ### Proposal
 *   **Target Markers:** `[AGREE]`, `[OPTION]`, `[OBJECT]`, `[DEFER]`.
 *   **Case Sensitivity:** Case-insensitive match (to accommodate human posts or agent casing drift).
-*   **Fuzzy Matching:** Match exact bases and safe adjacent variants using a regex boundary (e.g., matching `[AGREED]` or `[OBJECT - missing context]`).
+*   **Regex Matching:** Use a concrete regex boundary: `\[(AGREE(?:D)?|OPTION|OBJECT(?:[^\]]*)?|DEFER)(?:\b[^\]]*)?\]` (case-insensitive).
+    | Input | Captured | Maps to |
+    |---|---|---|
+    | `[AGREE]` | `AGREE` | `[AGREE]` |
+    | `[AGREED]` | `AGREED` | `[AGREE]` |
+    | `[OBJECT - missing context]` | `OBJECT - missing context` | `[OBJECT]` |
+    | `[OPTION B]` | `OPTION` | `[OPTION]` |
 *   **Position Requirement:** Anywhere in the body. While agents typically place markers at the end, human participants or modified prompts might place them at the top.
 *   **Multiple Markers:** If a single message contains multiple markers (e.g., `[OPTION] ... [DEFER]`), **last-wins** logic is applied. The final marker in the text flow is considered the agent's concluding stance for that round.
 
@@ -89,9 +96,9 @@ Strict regexes break easily when agents append reasoning inside the brackets. Ca
 ## Q4. Convergence detection
 
 ### Proposal
-A thread is considered "decided" (converged) when:
-*   All distinct participating `agent_family` instances in the thread have emitted an `[AGREE]` marker in the **latest round**.
-*   **Looser historical condition:** At least one round must have had an `[OPTION]` or `[OBJECT]` marker, OR it can be an immediate 1-round agreement. We define convergence strictly by the state of the *terminal* round.
+A thread is converged when every distinct `agent_family` that has posted in the thread emits `[AGREE]` in the latest round. Earlier-round content does not factor in.
+
+Edge case (partial participation): if an agent posted earlier but is silent in the latest round, that agent is still considered "participating" — the thread is NOT converged until that agent re-posts with `[AGREE]` or another marker. To exit, an agent must explicitly emit `[DEFER]`.
 
 When convergence is detected, the UI should display a "closing-out indicator" (e.g., a banner at the bottom of the graph) and auto-suggest the creation of a Decision Card if one has not already been emitted.
 


### PR DESCRIPTION
Supersedes #1791. Applies Claude round-3 REVISE findings from `origin/main:audit/claude-review-1791-decision-graph-adr-2026-05-09/REVIEW.md` to the Decision Graph ADR.

## Deterministic evidence (#M-4)

Live marker prevalence:

```text
$ sqlite3 'file:/Users/krisztiankoos/projects/learn-ukrainian/.mcp/servers/message-broker/messages.db?mode=ro&immutable=1' "SELECT COUNT(*) FROM channel_messages WHERE body LIKE '%[DISAGREE]%'"
139

$ sqlite3 'file:/Users/krisztiankoos/projects/learn-ukrainian/.mcp/servers/message-broker/messages.db?mode=ro&immutable=1' "SELECT '[AGREE]', COUNT(*) FROM channel_messages WHERE body LIKE '%[AGREE]%' UNION ALL SELECT '[AGREED]', COUNT(*) FROM channel_messages WHERE body LIKE '%[AGREED]%' UNION ALL SELECT '[OPTION]', COUNT(*) FROM channel_messages WHERE body LIKE '%[OPTION]%' UNION ALL SELECT '[OBJECT]', COUNT(*) FROM channel_messages WHERE body LIKE '%[OBJECT]%' UNION ALL SELECT '[DEFER]', COUNT(*) FROM channel_messages WHERE body LIKE '%[DEFER]%' UNION ALL SELECT '[DISAGREE]', COUNT(*) FROM channel_messages WHERE body LIKE '%[DISAGREE]%'"
[AGREE]|207
[AGREED]|0
[OPTION]|1
[OBJECT]|2
[DEFER]|1
[DISAGREE]|139
```

The exact aggregate query from the dispatch brief returned:

```text
$ sqlite3 'file:/Users/krisztiankoos/projects/learn-ukrainian/.mcp/servers/message-broker/messages.db?mode=ro&immutable=1' "SELECT body LIKE '%[AGREE]%', COUNT(*) FROM channel_messages WHERE body LIKE '%[AGREE]%' OR body LIKE '%[DISAGREE]%' OR body LIKE '%[OPTION]%' OR body LIKE '%[OBJECT]%' OR body LIKE '%[DEFER]%'"
0|287
```

Broker source for strict tail matching:

```text
$ grep -nE "endswith.*\[AGREE\]|\.endswith\(.\[AGREE\]" scripts/ai_agent_bridge/_channels_cli.py
1413:            text.strip().endswith("[AGREE]") for (text, _) in responses.values()
1435:                if not t.strip().endswith("[AGREE]")
```

Post-edit ADR evidence:

```text
$ grep -nE "\[DISAGREE\]" docs/decisions/pending/2026-05-09-decision-graph-view.md
79:*   **Canonical Markers:** `[AGREE]` and `[DISAGREE]`. The broker prompt requires agents to end round replies with one of these markers, and convergence uses strict `[AGREE]` tail matching in `scripts/ai_agent_bridge/_channels_cli.py:1413`.
86:    | `[DISAGREE]` | `DISAGREE` | `[DISAGREE]` |
102:Edge case (partial participation): if an agent posted earlier but is silent in the latest round, that agent is still considered "participating" — the thread is NOT converged until that agent re-posts with `[AGREE]` at the tail or another marker. In the current broker, `[DISAGREE]` is the canonical non-converging marker; `[DEFER]` remains a future display marker unless a later broker change gives it protocol meaning.

$ grep -nE "agent_family|from_agent|participant_id" docs/decisions/pending/2026-05-09-decision-graph-view.md
51:1.  **Participant-count threshold:** The thread contains messages from **≥2 distinct `from_agent` participants** in the current schema (e.g., `claude` and `codex`; user/human posts count as participants when they use the same channel-message path).
66:*   **Columns:** current implementation keys columns by `from_agent` because `channel_messages` currently has `from_agent` but no `agent_family`/`participant_id` columns. After the Multi-UI ADR lands, columns should re-key to the exact participant identity, preferably `participant_id` or the tuple `(agent_family, ui_surface, instance_id_short)`, with labels such as `claude:cli` and `claude:desktop`.
100:A thread is converged when every distinct current-schema participant (`from_agent`) that has posted in the thread has a latest round-N message whose stripped body ends with literal `[AGREE]`. Earlier-round content does not factor in.
142:*   **Identity migration:** Before Multi-UI lands, Decision Graph reads `from_agent` as the participant key. Once Multi-UI adds first-class identity, the view can re-key columns by `participant_id` or `(agent_family, ui_surface, instance_id_short)` without changing the current DB schema first.
```

Pre-commit clean. This linked worktree has no local `.venv`, so this was run from the worktree using the project venv binary:

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pre-commit run --files docs/decisions/pending/2026-05-09-decision-graph-view.md
ruff (lint)..........................................(no files to check)Skipped
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
```

## Revisions applied

- [x] Revision 1 / IND-1 marker set: before, Q3 listed only `[AGREE]`, `[OPTION]`, `[OBJECT]`, `[DEFER]` and regex matched `[AGREED]`; after, `docs/decisions/pending/2026-05-09-decision-graph-view.md:79-86` makes `[AGREE]` + `[DISAGREE]` canonical, demotes `[OPTION]`/`[OBJECT]`/`[DEFER]` to future/ADR-specific display, and drops `AGREE(?:D)?`.
- [x] Revision 2 / IND-1 secondary convergence wording: before, Q3 said markers could appear anywhere with last-wins and Q4 used generic marker emission; after, lines 89-100 require latest round messages to end with literal `[AGREE]` after `.strip()`, aligned to `_channels_cli.py:1413`.
- [x] Revision 3 / IND-2 current schema dependency: before, frontmatter claimed independence while Q1/Q2/Q4/Q5 keyed on nonexistent `agent_family`; after, lines 8, 51, 66, 100, and 142 use current `from_agent` with forward compatibility for Multi-UI identity fields.
- [x] Revision 4 / G2 unique columns: before, Q2 collapsed columns by `agent_family`; after, line 66 documents `from_agent` for today and future `participant_id` or `(agent_family, ui_surface, instance_id_short)` for `claude:cli` + `claude:desktop` cases.
- [x] Revision 5 / G3 high-risk override: before, Q4 only soft auto-suggested a Decision Card; after, line 106 forces a Decision Card prompt on HIST/BIO/ISTORIO/LIT/OES/RUTH per `docs/best-practices/agent-cooperation.md:210-222` Mechanism A.
- [x] Revision 6 / G4 drawer context: before, Q5 filtered the drawer to a single `agent_family` and Open Question 2 deferred the context choice; after, lines 117, 122, and 157 default to same-round all-agents plus clicked participant prior posts with a per-agent filter toggle.

## Scope guard

```text
$ git show --stat --oneline --name-only HEAD
1116e3054c docs(adr): apply round-3 REVISE findings (#1791)
docs/decisions/pending/2026-05-09-decision-graph-view.md
```

No generated `status/*.json`, `audit/*-review.md`, `review/*-review.md`, linter config, or `.python-version` files are in this diff.

No auto-merge requested.