### PR TITLE
feat(bridge): add desktop agent identities

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -94,6 +94,44 @@ ab post pipeline "reply" --parent MESSAGE_ID
 ab discuss architecture "should we refactor X?" --with claude,gemini,codex --max-rounds 2
 ```
 
+## Desktop Participation
+
+Desktop participation is currently an MVP flat-string identity, not the
+full Multi-UI identity model. The bridge accepts `codex-desktop` and
+`claude-desktop` as post authors and delivery targets, but it does not
+spawn them as subprocesses. Their registry entries have
+`cli_available=False`, so Desktop participation is human-invoked from
+the Desktop session.
+
+Orchestrator dispatch to Codex Desktop:
+
+```bash
+ab post desktop-tasks "<brief>" --to codex-desktop --from-agent claude
+```
+
+Codex Desktop watches the task channel from its own session:
+
+```bash
+ab channel tail desktop-tasks --follow
+```
+
+Codex Desktop can also pull its pending inbox:
+
+```bash
+ab inbox show codex-desktop
+```
+
+Codex Desktop posts replies with its own sender identity:
+
+```bash
+ab post desktop-tasks "<status>" --from-agent codex-desktop
+```
+
+Limitation: this MVP stores a flat sender/recipient string. The pending
+Multi-UI ADR remains the future design for 4-tuple identity
+(`agent_family`, `ui_surface`, `client_id`, `instance_id`), claims,
+SSE replay, and attachments.
+
 ## Dispatch wrappers
 
 Use these wrappers when the task needs the project-standard model/mode

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -48,6 +48,19 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": True,
         "resume_policy": "never",
     },
+    "codex-desktop": {
+        "adapter": "scripts.agent_runtime.adapters.codex:CodexAdapter",
+        "default_model": "gpt-5.5",
+        "cost_tier": "high",
+        "capabilities": frozenset({
+            "frontend_design",
+            "ui_review",
+            "multimodal",
+            "visual_inspection",
+        }),
+        "cli_available": False,
+        "resume_policy": "never",
+    },
     "claude": {
         "adapter": "scripts.agent_runtime.adapters.claude:ClaudeAdapter",
         "default_model": "claude-opus-4-7",
@@ -60,6 +73,19 @@ AGENTS: dict[str, AgentEntry] = {
         }),
         "cli_available": True,
         "resume_policy": "bridge_only",
+    },
+    "claude-desktop": {
+        "adapter": "scripts.agent_runtime.adapters.claude:ClaudeAdapter",
+        "default_model": "claude-opus-4-7",
+        "cost_tier": "high",
+        "capabilities": frozenset({
+            "frontend_design",
+            "ui_review",
+            "multimodal",
+            "visual_inspection",
+        }),
+        "cli_available": False,
+        "resume_policy": "never",
     },
     "gemini": {
         "adapter": "scripts.agent_runtime.adapters.gemini:GeminiAdapter",

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -70,7 +70,13 @@ class StaleClaimError(Exception):
 
 # ── Constants ──────────────────────────────────────────────────────────
 
-VALID_AGENTS = ("claude", "gemini", "codex")
+VALID_AGENTS = (
+    "claude",
+    "gemini",
+    "codex",
+    "claude-desktop",
+    "codex-desktop",
+)
 VALID_POST_AGENTS = (*VALID_AGENTS, "user")
 VALID_RECIPIENT_AGENTS = VALID_AGENTS
 VALID_KINDS = ("post", "reply", "system", "fanout_start", "fanout_end")

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -60,6 +60,31 @@ _GEMINI_AUTH_CHOICES = ["auto", "subscription", "api-key", "api"]
 _DISCUSSION_READONLY_TOOL_CONFIG = {"discussion_readonly": True}
 
 
+def _cli_available_agent(agent: str) -> bool:
+    """Return whether the agent can be spawned by the local runtime."""
+    try:
+        from agent_runtime.registry import get_agent_entry
+    except ImportError:
+        return agent in {"claude", "codex", "gemini"}
+
+    try:
+        return bool(get_agent_entry(agent)["cli_available"])
+    except KeyError:
+        return False
+
+
+def _reject_non_cli_agent(agent: str, command: str) -> bool:
+    if _cli_available_agent(agent):
+        return False
+    print(
+        f"❌ {command} cannot spawn {agent!r}: registry has cli_available=False. "
+        "Use `ab inbox show` / `ab channel tail` from the Desktop session, "
+        "or post to its inbox with `ab post --to`.",
+        file=sys.stderr,
+    )
+    return True
+
+
 def _build_discuss_round_body(root_body: str, directive: str) -> str:
     """Render the high-priority body for a discuss round prompt.
 
@@ -242,6 +267,11 @@ def register_channel_commands(subparsers: Any) -> None:
     tail_parser.add_argument(
         "--json", action="store_true",
         help="Output as JSON instead of human-readable",
+    )
+    tail_parser.add_argument(
+        "--follow",
+        action="store_true",
+        help="Keep polling for newly appended channel messages",
     )
 
     # ab channel watch
@@ -834,6 +864,9 @@ def _handle_channel_tail(args) -> int:
     if _channels.get_channel(args.name) is None:
         print(f"❌ channel '{args.name}' does not exist", file=sys.stderr)
         return 1
+    if args.follow and args.json:
+        print("❌ --follow does not support --json output", file=sys.stderr)
+        return 2
 
     try:
         if args.thread:
@@ -851,10 +884,11 @@ def _handle_channel_tail(args) -> int:
         return 0
 
     print(f"=== {header} ===")
+    seen_ids = set()
     if not msgs:
         print("(no messages)")
-        return 0
     for m in msgs:
+        seen_ids.add(m["message_id"])
         ts = m["created_at"][:19]
         parent_str = f" ← {m['parent_id'][:8]}" if m["parent_id"] else ""
         print(
@@ -863,6 +897,31 @@ def _handle_channel_tail(args) -> int:
         )
         if len(m["body"]) > 200:
             print(f"   ... [{len(m['body']) - 200} more chars]")
+    if not args.follow:
+        return 0
+
+    try:
+        while True:
+            time.sleep(2)
+            if args.thread:
+                next_msgs = _channels.read(args.name, thread_id=args.thread)
+            else:
+                next_msgs = _channels.read(args.name, tail=args.limit)
+            for m in next_msgs:
+                if m["message_id"] in seen_ids:
+                    continue
+                seen_ids.add(m["message_id"])
+                ts = m["created_at"][:19]
+                parent_str = f" ← {m['parent_id'][:8]}" if m["parent_id"] else ""
+                print(
+                    f"[{ts}] {m['from_agent']}"
+                    f" (r{m['round_index']}{parent_str}): {m['body'][:200]}",
+                    flush=True,
+                )
+                if len(m["body"]) > 200:
+                    print(f"   ... [{len(m['body']) - 200} more chars]", flush=True)
+    except KeyboardInterrupt:
+        return 0
     return 0
 
 
@@ -958,6 +1017,9 @@ def _handle_inbox_run(args) -> int:
     """Handle `ab inbox run <agent>`."""
     from ._inbox import run_inbox
 
+    if _reject_non_cli_agent(args.agent, "ab inbox run"):
+        return 1
+
     until_idle = not args.once
     if args.until_idle:
         until_idle = True
@@ -1035,7 +1097,11 @@ def _handle_sync(args) -> int:
         print("❌ sync requires an agent or --all", file=sys.stderr)
         return 2
 
-    agents = list(_channels.VALID_AGENTS) if args.all else [args.agent]
+    agents = (
+        [agent for agent in _channels.VALID_AGENTS if _cli_available_agent(agent)]
+        if args.all
+        else [args.agent]
+    )
     worst_exit_code = 0
     for agent in agents:
         class _Args:
@@ -1115,6 +1181,16 @@ def _handle_discuss(args) -> int:
         print(
             f"❌ unknown agent(s): {', '.join(unknown)} "
             f"(valid: {', '.join(sorted(_channels.VALID_AGENTS))})",
+            file=sys.stderr,
+        )
+        return 1
+    non_cli_agents = [agent for agent in with_agents if not _cli_available_agent(agent)]
+    if non_cli_agents:
+        print(
+            "❌ ab discuss cannot spawn non-CLI participant(s): "
+            f"{', '.join(non_cli_agents)}. "
+            "Use channel posts/inbox show for Desktop participation until "
+            "the Multi-UI ADR lands.",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -163,12 +163,39 @@ def _stub_claude_cli_version_gate(monkeypatch, request):
 # Registry + adapter loading
 # ---------------------------------------------------------------------------
 
-def test_registry_has_four_agents():
-    assert set(AGENTS.keys()) == {"codex", "claude", "gemini", "gemma-local", "grok"}
+def test_registry_has_known_agents():
+    assert set(AGENTS.keys()) == {
+        "codex",
+        "codex-desktop",
+        "claude",
+        "claude-desktop",
+        "gemini",
+        "gemma-local",
+        "grok",
+    }
 
 
 def test_codex_entry_has_never_resume_policy():
     assert get_agent_entry("codex")["resume_policy"] == "never"
+
+
+def test_codex_desktop_entry_is_human_invoked():
+    entry = get_agent_entry("codex-desktop")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.codex:CodexAdapter"
+    assert entry["default_model"] == "gpt-5.5"
+    assert entry["cost_tier"] == "high"
+    assert entry["cli_available"] is False
+    assert entry["resume_policy"] == "never"
+    assert {"frontend_design", "ui_review", "multimodal", "visual_inspection"} <= entry[
+        "capabilities"
+    ]
+
+
+def test_claude_desktop_entry_is_human_invoked():
+    entry = get_agent_entry("claude-desktop")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.claude:ClaudeAdapter"
+    assert entry["cli_available"] is False
+    assert entry["resume_policy"] == "never"
 
 
 def test_claude_entry_has_bridge_only_resume_policy():

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -96,7 +96,7 @@ def test_create_channel_rejects_user_subscriber():
 
 def test_validate_recipient_agent_accepts_non_user_agents():
     """Delivery targets still accept the real agent inboxes."""
-    for agent in ("claude", "gemini", "codex"):
+    for agent in ("claude", "gemini", "codex", "claude-desktop", "codex-desktop"):
         _channels._validate_recipient_agent(agent)
 
 def test_create_channel_invalid_name_raises():
@@ -172,6 +172,23 @@ def test_post_creates_delivery_row_per_recipient():
     assert len(dlvs) == 2
     assert {d["to_agent"] for d in dlvs} == {"claude", "codex"}
     assert all(d["status"] == "pending" for d in dlvs)
+
+
+def test_post_routes_to_desktop_agent_identity():
+    """Desktop identities are first-class delivery targets for manual pull."""
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic",
+        "claude",
+        "desktop brief",
+        to_agents=["codex-desktop"],
+        auto_snapshot=False,
+    )
+
+    dlvs = _channels.deliveries_for_message(res["message_id"])
+    assert len(dlvs) == 1
+    assert dlvs[0]["to_agent"] == "codex-desktop"
+    assert dlvs[0]["status"] == "pending"
 
 
 def test_post_rejects_user_as_delivery_target():
@@ -1133,4 +1150,3 @@ class TestDeliveryLeasing:
         second = _channels.claim_next_delivery("claude", now=_iso_at(1))
         assert second is not None
         assert _delivery_row(delivery_id)["attempt_count"] == 2
-

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -205,6 +205,83 @@ def test_inbox_show_empty(capsys):
     assert "    (none)" in captured.out
 
 
+def test_inbox_show_accepts_codex_desktop(capsys):
+    exit_code = _run_cli(["inbox", "show", "codex-desktop"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "codex-desktop inbox:" in captured.out
+    assert "pending:    0" in captured.out
+
+
+def test_post_from_codex_desktop_is_accepted(capsys):
+    _channels.create_channel("topic")
+
+    exit_code = _run_cli(
+        [
+            "post",
+            "topic",
+            "desktop status",
+            "--from-agent",
+            "codex-desktop",
+            "--no-snapshot",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "✅ posted to #topic" in captured.out
+    assert _channels.read("topic")[0]["from_agent"] == "codex-desktop"
+
+
+def test_post_to_codex_desktop_routes_delivery(capsys):
+    _channels.create_channel("topic")
+
+    exit_code = _run_cli(
+        [
+            "post",
+            "topic",
+            "desktop brief",
+            "--to",
+            "codex-desktop",
+            "--from-agent",
+            "claude",
+            "--no-snapshot",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "→ codex-desktop  (1 deliveries)" in captured.out
+    delivery = _channels.deliveries_for_message(
+        _channels.read("topic")[0]["message_id"]
+    )[0]
+    assert delivery["to_agent"] == "codex-desktop"
+
+
+def test_post_from_existing_codex_path_still_works(capsys):
+    _channels.create_channel("topic")
+
+    exit_code = _run_cli(
+        [
+            "post",
+            "topic",
+            "codex status",
+            "--from-agent",
+            "codex",
+            "--no-snapshot",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert _channels.read("topic")[0]["from_agent"] == "codex"
+
+
 @patch("agent_runtime.runner.invoke")
 def test_discuss_replies_create_delivered_reply_deliveries(mock_invoke, monkeypatch, capsys):
     _channels.create_channel("shared")
@@ -414,6 +491,7 @@ def test_inbox_run_once_processes_one_thread(monkeypatch, capsys):
 def test_sync_all_iterates_known_agents(monkeypatch, capsys):
     for agent in _channels.VALID_AGENTS:
         _make_thread(agent, channel=f"{agent}-topic", count=1)
+    cli_agents = ["claude", "gemini", "codex"]
 
     calls: list[tuple[str, dict[str, object]]] = []
 
@@ -436,10 +514,19 @@ def test_sync_all_iterates_known_agents(monkeypatch, capsys):
     assert exit_code == 0
     captured = capsys.readouterr()
     assert captured.err == ""
-    assert [call[0] for call in calls] == list(_channels.VALID_AGENTS)
+    assert [call[0] for call in calls] == cli_agents
     assert captured.out.count("processed: 1 deliveries | 1 threads | 0 failed | duration:") == len(
-        _channels.VALID_AGENTS
+        cli_agents
     )
+
+
+def test_inbox_run_rejects_codex_desktop(capsys):
+    exit_code = _run_cli(["inbox", "run", "codex-desktop", "--once"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "cli_available=False" in captured.err
+    assert "ab inbox show" in captured.err
 
 
 def test_backlog_banner_triggers_for_old_pending_delivery(monkeypatch, capsys):

--- a/tests/test_channels_discuss_resume.py
+++ b/tests/test_channels_discuss_resume.py
@@ -114,6 +114,12 @@ def test_discuss_unknown_agent_defaults_to_no_resume(monkeypatch):
         "VALID_POST_AGENTS",
         (*_channels.VALID_POST_AGENTS, "mystery"),
     )
+    # Register `mystery` as cli_available so the new _reject_non_cli_agent gate
+    # in _channels_cli (added in this PR) passes. The assertion below still
+    # validates the resume-policy fallback for an agent without an explicit
+    # resume_policy entry.
+    from agent_runtime import registry as _registry
+    monkeypatch.setitem(_registry.AGENTS, "mystery", {"cli_available": True})
     captured_invokes = []
 
     def fake_runtime_invoke(agent, _prompt, **kwargs):


### PR DESCRIPTION
## Summary

Adds `codex-desktop` and `claude-desktop` as first-class flat-string identities for the channel bridge MVP described in `audit/codex-desktop-comms-research-2026-05-09/REPORT.html` § "What I'm executing next." This intentionally stays below the pending Multi-UI ADR: no schema migration, no 4-tuple identity, no claims/SSE/attachments work.

- Extends channel sender/recipient validation in `scripts/ai_agent_bridge/_channels.py`.
- Adds runtime registry entries with `cli_available=False` so Desktop identities are human-invoked, not subprocess-spawnable.
- Keeps `ab post --from-agent` / `--to` and `ab inbox show` accepting Desktop identities.
- Adds clear guards for subprocess paths (`ab inbox run`, `ab discuss`) when a Desktop identity is selected.
- Adds `ab channel tail --follow` for the documented Desktop subscription workflow.
- Documents the Desktop participation MVP in `docs/best-practices/agent-bridge.md`.

## Downstream constraint found

`VALID_AGENTS` also feeds subprocess-oriented paths (`ab inbox run`, `ab sync --all`, and `ab discuss --with`). Because Desktop entries are not spawnable, this PR handles that explicitly:

- `ab inbox run codex-desktop` now errors clearly with `cli_available=False` guidance.
- `ab discuss --with codex-desktop` errors clearly instead of reaching the runtime adapter.
- `ab sync --all` drains only CLI-available channel agents.
- `ab inbox show codex-desktop` remains read-only and allowed.

## Acceptance evidence

Note: in this noninteractive shell, `ab` resolves to `/usr/sbin/ab` (ApacheBench), so the evidence used a shell function wrapping the repo CLI:

```bash
VENV_PY="$(git rev-parse --git-common-dir)/../.venv/bin/python"
ab(){ "$VENV_PY" scripts/ai_agent_bridge/__main__.py "$@"; }
```

### Bridge accepts `codex-desktop` as `--from-agent`

Command:

```bash
AB_MONITOR_URL= ab post desktop-tasks-mvp-ac "from desktop" --from-agent codex-desktop --no-snapshot
```

Output:

```text
✅ posted to #desktop-tasks-mvp-ac
   message_id: 880a48029ffe48d8b34e6ece2377b9c3
   thread_id:  880a48029ffe48d8b34e6ece2377b9c3
```

### Bridge accepts `--to codex-desktop` for routing

Command:

```bash
AB_MONITOR_URL= ab post desktop-tasks-mvp-ac "to desktop" --to codex-desktop --from-agent claude --no-snapshot
```

Output:

```text
✅ posted to #desktop-tasks-mvp-ac
   message_id: 95b4a9cd2e454fdeb0c5f30931adaf62
   thread_id:  95b4a9cd2e454fdeb0c5f30931adaf62
   → codex-desktop  (1 deliveries)
```

### `ab inbox show codex-desktop` works

Command:

```bash
ab inbox show codex-desktop
```

Output:

```text
codex-desktop inbox:
  pending:    2 (oldest 0m ago)
  processing: 0
  failed (last 24h): 0
  oldest preview:
    [codex-desktop-mvp-test/bcca4] claude → "hi desktop"
```

### Registry has `codex-desktop` entry

Command:

```bash
grep -A16 '"codex-desktop"' scripts/agent_runtime/registry.py
```

Output:

```text
    "codex-desktop": {
        "adapter": "scripts.agent_runtime.adapters.codex:CodexAdapter",
        "default_model": "gpt-5.5",
        "cost_tier": "high",
        "capabilities": frozenset({
            "frontend_design",
            "ui_review",
            "multimodal",
            "visual_inspection",
        }),
        "cli_available": False,
        "resume_policy": "never",
    },
    "claude": {
        "adapter": "scripts.agent_runtime.adapters.claude:ClaudeAdapter",
        "default_model": "claude-opus-4-7",
        "cost_tier": "high",
```

### Existing `codex` from-agent path still works

Command:

```bash
VENV_PY="$(git rev-parse --git-common-dir)/../.venv/bin/python"; "$VENV_PY" -m pytest tests/test_bridge_inbox_cli.py::test_post_from_existing_codex_path_still_works -q
```

Output:

```text
collected 1 item

tests/test_bridge_inbox_cli.py .                                         [100%]

============================== 1 passed in 0.12s ===============================
```

### New/affected tests pass

Command:

```bash
VENV_PY="$(git rev-parse --git-common-dir)/../.venv/bin/python"; "$VENV_PY" -m pytest tests/test_bridge_inbox_cli.py tests/test_bridge_channels.py tests/test_agent_runtime.py -q
```

Output:

```text
============================= 228 passed in 26.80s =============================
```

Commit hook reran the affected tests as well:

```text
============================= 228 passed in 26.72s =============================
✅ pre-commit passed
```

### Ruff clean

Command:

```bash
VENV_PY="$(git rev-parse --git-common-dir)/../.venv/bin/python"; "$VENV_PY" -m ruff check scripts/ai_agent_bridge/_channels.py scripts/ai_agent_bridge/_channels_cli.py scripts/agent_runtime/registry.py tests/
```

Output:

```text
All checks passed!
```

### Diff hygiene

Commands:

```bash
git diff --check
git diff -- .python-version .yamllint .markdownlint.json
git diff --name-only | rg '(^|/)(status/.*\.json|audit/.*-review\.md|review/.*-review\.md|docs/.*-STATUS\.md)$' || true
rg -n "sys\.executable|@pytest\.mark\.skip" scripts/ai_agent_bridge/_channels.py scripts/ai_agent_bridge/_channels_cli.py scripts/agent_runtime/registry.py tests/test_bridge_inbox_cli.py tests/test_bridge_channels.py tests/test_agent_runtime.py
```

Output summary:

```text
git diff --check: clean
protected config diff: empty
generated artifact grep: empty
sys.executable / skipped-test grep: no matches
```

Pre-commit:

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

## Out of scope

Full Multi-UI ADR implementation remains out of scope: no `agent_family` / `ui_surface` / `client_id` / `instance_id` schema, no claim leases, no SSE replay API, and no attachment storage.
