### PR TITLE
feat(bridge): ab inbox ack CLI + drop sender self-fanout + ab discuss acks own deliveries (#1838)

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -121,6 +121,19 @@ Codex Desktop can also pull its pending inbox:
 ab inbox show codex-desktop
 ```
 
+### Explicit ack: `ab inbox ack <delivery_id>`
+
+When an external worker processes a delivery without going through
+`ab inbox run`, ack it explicitly:
+
+```bash
+ab inbox ack <delivery_id> [--error "processed by <thing>"]
+```
+
+Without an explicit ack, deliveries stay `pending` forever and the inbox
+warning recurs. `ab discuss` acks its own deliveries on round convergence
+automatically, so no manual intervention is needed for that path.
+
 Codex Desktop posts replies with its own sender identity:
 
 ```bash

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -975,7 +975,13 @@ def post(
         )
 
         delivery_ids = []
+        delivery_agents = []
         for agent in to_agents or []:
+            # Skip sender self-fanout: an agent does not need to "process"
+            # its own reply. Channel deliveries are for other subscribers.
+            if agent == from_agent:
+                continue
+            delivery_agents.append(agent)
             dlv_id = _new_id()
             delivery_ids.append(dlv_id)
             if pre_delivered:
@@ -1016,7 +1022,7 @@ def post(
         conn.commit()
 
         if not pre_delivered:
-            for agent in set(to_agents or []):
+            for agent in set(delivery_agents):
                 _touch_wake_file(agent)
 
         return {

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -21,6 +21,7 @@ ab p <channel> <agent> <body>                    # shorthand
 
 ab inbox run <agent> [--once] [--max-messages N] [--stop-after-seconds N] [--deadline SECONDS]
 ab inbox show <agent>
+ab inbox ack <delivery_id> [--error NOTE]
 ab reconcile [--dry-run]
 ab sync <agent> | ab sync --all
 
@@ -429,6 +430,26 @@ def register_channel_commands(subparsers: Any) -> None:
             choices=list(_channels.VALID_AGENTS),
             help="Agent inbox to inspect",
         )
+        inbox_ack = inbox_sub.add_parser(
+            "ack",
+            help=(
+                "Mark a delivery as delivered without spawning the agent "
+                "(manual operator drain or post-handling ack from automations / "
+                "external workers)"
+            ),
+        )
+        inbox_ack.add_argument(
+            "delivery_id",
+            help="Delivery ID to mark delivered (long form, from `ab inbox show <agent>`)",
+        )
+        inbox_ack.add_argument(
+            "--error",
+            default=None,
+            help=(
+                "Optional ack note recorded in deliveries.error "
+                "(e.g. 'processed by codex-desktop automation')"
+            ),
+        )
 
     # ── top-level: sync ───────────────────────────────────────────
     sync_parser = subparsers.add_parser(
@@ -532,6 +553,8 @@ def _dispatch_inbox_command(args) -> int:
         return _handle_inbox_run(args)
     if sub == "show":
         return _handle_inbox_show(args)
+    if sub == "ack":
+        return _handle_inbox_ack(args)
     print("unknown subcommand: inbox", file=sys.stderr)
     return 2
 
@@ -1070,6 +1093,39 @@ def _handle_inbox_show(args) -> int:
     return 0
 
 
+def _handle_inbox_ack(args) -> int:
+    """Explicit ack of one delivery for automations or manual operator drain."""
+    from ._db import get_db
+
+    conn = get_db()
+    try:
+        row = conn.execute(
+            """
+            SELECT delivery_id, status, to_agent, message_id
+            FROM deliveries
+            WHERE delivery_id = ?
+            """,
+            (args.delivery_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        print(f"❌ delivery_id {args.delivery_id!r} not found", file=sys.stderr)
+        return 1
+    if row["status"] == "delivered":
+        print(f"⚠️  delivery {args.delivery_id} is already 'delivered' (no-op)")
+        return 0
+
+    note = args.error or "explicitly acked via `ab inbox ack`"
+    _channels.mark_delivery(args.delivery_id, "delivered", error=note)
+    print(
+        f"✅ delivery {args.delivery_id} → delivered  "
+        f"(to={row['to_agent']}, message={row['message_id']})"
+    )
+    return 0
+
+
 def _handle_reconcile(args) -> int:
     from ._reconcile import reconcile_deliveries
 
@@ -1492,24 +1548,32 @@ def _handle_discuss(args) -> int:
         # fetches + context file reads + extra storage. The reply's
         # context is implicit from its parent_id anyway.
         for agent in with_agents:
-            text, ok = responses[agent]
-            reply_recipients = [name for name in with_agents if name != agent]
+            text, _ok = responses[agent]
             try:
-                _channels.post(
+                reply = _channels.post(
                     args.channel,
                     agent,
                     text,
-                    to_agents=reply_recipients,
+                    to_agents=with_agents,
                     parent_id=root_id,
                     correlation_id=correlation_id,
                     kind="reply",
                     auto_snapshot=False,
-                    pre_delivered=True,
                 )
             except ValueError as e:
                 print(
                     f"⚠️  failed to store {agent} response: {e}",
                     file=sys.stderr,
+                )
+                continue
+            for delivery_id in reply["delivery_ids"]:
+                _channels.mark_delivery(
+                    delivery_id,
+                    "delivered",
+                    error=(
+                        "acked by ab discuss orchestrator "
+                        f"(thread={correlation_id[:8]}, round={round_idx})"
+                    ),
                 )
 
         # ── convergence check ─────────────────────────────────────

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -174,6 +174,40 @@ def test_post_creates_delivery_row_per_recipient():
     assert all(d["status"] == "pending" for d in dlvs)
 
 
+def test_channel_post_does_not_fanout_to_sender():
+    """Posting to subscribers including self must not create self-deliveries."""
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic",
+        "gemini",
+        "hello",
+        to_agents=["gemini", "claude"],
+        auto_snapshot=False,
+    )
+
+    dlvs = _channels.deliveries_for_message(res["message_id"])
+    assert len(res["delivery_ids"]) == 1
+    assert {d["to_agent"] for d in dlvs} == {"claude"}
+    assert not any(d["to_agent"] == "gemini" for d in dlvs)
+
+
+def test_channel_post_still_fans_out_to_other_subscribers():
+    """Skipping self-fanout must preserve deliveries for every other target."""
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic",
+        "gemini",
+        "hello",
+        to_agents=["claude", "gemini", "codex"],
+        auto_snapshot=False,
+    )
+
+    dlvs = _channels.deliveries_for_message(res["message_id"])
+    assert len(res["delivery_ids"]) == 2
+    assert {d["to_agent"] for d in dlvs} == {"claude", "codex"}
+    assert all(d["status"] == "pending" for d in dlvs)
+
+
 def test_post_routes_to_desktop_agent_identity():
     """Desktop identities are first-class delivery targets for manual pull."""
     _channels.create_channel("topic")

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -153,6 +153,21 @@ def _oldest_pending_delivery_id(agent: str) -> str | None:
     return str(row["delivery_id"]) if row is not None else None
 
 
+def _delivery_detail(delivery_id: str) -> sqlite3.Row:
+    conn = _db.get_db()
+    try:
+        return conn.execute(
+            """
+            SELECT delivery_id, status, error, delivered_at
+            FROM deliveries
+            WHERE delivery_id = ?
+            """,
+            (delivery_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
 def _install_fake_inbox_module(monkeypatch, run_inbox) -> None:
     fake_inbox_module = ModuleType("ai_agent_bridge._inbox")
     fake_inbox_module.run_inbox = run_inbox
@@ -213,6 +228,57 @@ def test_inbox_show_accepts_codex_desktop(capsys):
     assert captured.err == ""
     assert "codex-desktop inbox:" in captured.out
     assert "pending:    0" in captured.out
+
+
+def test_inbox_ack_marks_delivery_delivered(capsys):
+    thread = _make_thread("claude", count=1)
+    delivery_id = _channels.deliveries_for_message(str(thread[0]["message_id"]))[0][
+        "delivery_id"
+    ]
+
+    exit_code = _run_cli(
+        [
+            "inbox",
+            "ack",
+            delivery_id,
+            "--error",
+            "processed by codex-desktop automation",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert f"✅ delivery {delivery_id} → delivered" in captured.out
+    detail = _delivery_detail(delivery_id)
+    assert detail["status"] == "delivered"
+    assert detail["error"] == "processed by codex-desktop automation"
+    assert detail["delivered_at"] is not None
+
+
+def test_inbox_ack_unknown_delivery_id_errors(capsys):
+    exit_code = _run_cli(["inbox", "ack", "missing-delivery-id"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "delivery_id 'missing-delivery-id' not found" in captured.err
+
+
+def test_inbox_ack_already_delivered_is_noop(capsys):
+    thread = _make_thread("claude", count=1)
+    delivery_id = _channels.deliveries_for_message(str(thread[0]["message_id"]))[0][
+        "delivery_id"
+    ]
+    assert _run_cli(["inbox", "ack", delivery_id]) == 0
+    capsys.readouterr()
+
+    exit_code = _run_cli(["inbox", "ack", delivery_id])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert f"delivery {delivery_id} is already 'delivered' (no-op)" in captured.out
 
 
 def test_post_from_codex_desktop_is_accepted(capsys):

--- a/tests/test_channels_discuss_resume.py
+++ b/tests/test_channels_discuss_resume.py
@@ -83,6 +83,55 @@ def test_discuss_passes_session_id_for_resumable_agents(monkeypatch):
     assert all(kwargs["entrypoint"] == "bridge" for _, kwargs in captured_invokes)
 
 
+def test_discuss_acks_its_own_deliveries_on_convergence(monkeypatch, capsys):
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+
+    def fake_runtime_invoke(agent, _prompt, **_kwargs):
+        return _successful_result(agent)
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_runtime_invoke)
+
+    exit_code = _run_cli(
+        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "2"]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "✅ converged at round 2" in captured.out
+
+    conn = _db.get_db()
+    try:
+        rows = conn.execute(
+            """
+            SELECT d.status, d.error, d.to_agent, cm.from_agent
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            WHERE cm.channel = 'shared'
+            ORDER BY cm.created_at ASC, d.delivery_id ASC
+            """
+        ).fetchall()
+        pending_count = conn.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            WHERE cm.channel = 'shared' AND d.status = 'pending'
+            """
+        ).fetchone()["count"]
+    finally:
+        conn.close()
+
+    assert pending_count == 0
+    assert len(rows) == 4
+    assert all(row["status"] == "delivered" for row in rows)
+    assert all(
+        row["error"].startswith("acked by ab discuss orchestrator")
+        for row in rows
+    )
+    assert not any(row["to_agent"] == row["from_agent"] for row in rows)
+
+
 def test_discuss_entrypoint_is_bridge_not_delegate(monkeypatch):
     """The entrypoint switch is the load-bearing change for the resume policy gate."""
     _channels.create_channel("shared")


### PR DESCRIPTION
## Summary

Three small changes that close out the inbox-pending-forever pattern that nags every `ab discuss` run + every Codex Desktop Automation run (per the new [Multi-UI ADR addendum](docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md#codex-desktop-automations--the-canonical-desktop-side-polling-primitive-2026-05-09-update)).

- **`ab inbox ack <delivery_id> [--error NOTE]`** — new CLI subcommand for explicit per-delivery ack. Used by external workers (Codex Desktop Automations, manual operator drain) that process a delivery without going through `ab inbox run`.
- **Drop sender self-fanout** in `_channels.post()` — agents no longer get a "process your own reply" delivery. That was 3-12 stale deliveries per `ab discuss` run, all noise.
- **`ab discuss` self-acks** the deliveries it creates on round convergence with an informative orchestrator note.

## Verification

- Targeted tests: `110 passed`
- Bridge suite subset: `123 passed, 1 skipped`
- Ruff: clean
- Live smoke: post-`ab discuss` `inbox show` returns `pending: 0` for `claude`, `codex`, `gemini`
- SQL smoke: `SELECT COUNT(*) FROM deliveries d JOIN channel_messages m ON d.message_id=m.message_id WHERE d.to_agent=m.from_agent` = 0 (self-fanout eliminated)

## Test plan

- [x] `.venv/bin/pytest tests/test_bridge_channels.py tests/test_bridge_inbox_cli.py tests/test_channels_discuss_resume.py -v`
- [x] `.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox ack --help`
- [x] Manual smoke: `ab inbox ack <pending-delivery-id>` marks it delivered + records the ack note in `deliveries.error`
- [x] Manual smoke: post → discuss → `inbox show` shows 0 pending for all participants

## Related

- Closes #1838
- Refs Multi-UI ADR (Codex Desktop Automations strand) — `docs/decisions/pending/2026-05-06-multi-ui-channel-participation.md`
- Unblocks autonomous Codex Desktop Automations: the polling automation can now `ab inbox ack <id>` cleanly after handling a brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)