### PR TITLE
fix(telemetry): GeminiAdapter parses toolCalls from session JSONL (#1819)

### DIFF
--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -331,11 +331,19 @@ class GeminiAdapter:
         session_trace = ""
         if plan is not None:
             session_trace = self._read_latest_session_trace(plan)
+        # Parse stdout/stderr (JSONL events) and session_trace (may be a
+        # multi-line single JSON document OR JSONL) separately, then merge.
+        # Concatenating breaks single-document parses for the legacy session
+        # format, which the existing fixtures still exercise.
         trace_events = parse_json_events(
-            "\n".join(part for part in (stdout, stderr, session_trace) if part),
+            "\n".join(part for part in (stdout, stderr) if part),
             source="gemini",
             logger=_logger,
         )
+        if session_trace:
+            trace_events.extend(
+                parse_json_events(session_trace, source="gemini-session", logger=_logger)
+            )
         tool_calls = normalize_tool_calls(trace_events)
 
         stdout_response = stdout.strip()

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -36,7 +36,6 @@ Issue: #1184
 from __future__ import annotations
 
 import contextlib
-import json as _json
 import logging
 import os
 import re
@@ -310,7 +309,7 @@ class GeminiAdapter:
         """Parse Gemini CLI output into a ParseResult.
 
         Primary source: stdout. Fallback source: the Gemini session file
-        under ``~/.gemini/tmp/<project>/chats/session-*.json``.
+        under ``~/.gemini/tmp/<project>/chats/session-*.json*``.
 
         Why the fallback exists (2026-04-10): the Gemini CLI block-buffers
         stdout when not connected to a TTY. On long calls (MCP tool use +
@@ -452,9 +451,10 @@ class GeminiAdapter:
         """Extract the assistant's response from the newest Gemini session file.
 
         Gemini CLI writes a file at ``~/.gemini/tmp/<cwd-basename>/chats/
-        session-YYYY-MM-DDTHH-MM-<short>.json`` for every exec. It creates
+        session-YYYY-MM-DDTHH-MM-<short>.json*`` for every exec. It creates
         a new file at call start and keeps updating it throughout the
-        run. The file structure is:
+        run. Older files are a single JSON object; current Gemini CLI
+        sessions are JSONL events. The single-object structure is:
 
             {
               "sessionId": "<uuid>",
@@ -486,47 +486,38 @@ class GeminiAdapter:
             if session_file is None:
                 return ""
 
-            data = _json.loads(session_file.read_text("utf-8"))
-            messages = data.get("messages", [])
-            if not isinstance(messages, list):
-                return ""
+            events = self._read_session_events(session_file)
 
             # Concatenate every gemini message's text content. Skip user
             # messages, skip info/system messages, skip tool-call
             # metadata. Content for gemini messages is a plain string
             # (verified against real session files on disk).
             parts: list[str] = []
-            for msg in messages:
-                if not isinstance(msg, dict):
-                    continue
+            for msg in self._iter_session_messages(events):
                 if msg.get("type") != "gemini":
                     continue
-                content = msg.get("content")
-                if isinstance(content, str) and content.strip():
+                content = self._message_text_content(msg)
+                if content.strip():
                     parts.append(content)
-                elif isinstance(content, list):
-                    # Defensive: some older Gemini CLI versions may use
-                    # list-of-parts format like user messages.
-                    for part in content:
-                        if isinstance(part, dict):
-                            text = part.get("text")
-                            if isinstance(text, str) and text.strip():
-                                parts.append(text)
 
             return "\n\n".join(parts).strip()
         except Exception:
             return ""
 
     def _read_latest_session_trace(self, plan: InvocationPlan) -> str:
-        """Read this invocation's Gemini session JSON for tool-call telemetry."""
+        """Read this invocation's Gemini session trace for tool-call telemetry.
+
+        Current Gemini CLI sessions are JSONL, not one JSON document:
+            {"type":"user","content":[{"text":"..."}]}
+            {"type":"gemini","toolCalls":[{"name":"list_directory","args":{...}}]}
+            {"type":"gemini","toolCalls":[{"name":"mcp__sources__verify_words",
+             "args":{"words":["кіт"]}}]}
+        """
         try:
             session_file = self._select_session_for_plan(plan, call_start_time=None)
             if session_file is None:
                 return ""
-            data = _json.loads(
-                session_file.read_text(encoding="utf-8", errors="replace")
-            )
-            return _json.dumps(data, ensure_ascii=False)
+            return session_file.read_text(encoding="utf-8", errors="replace")
         except Exception:
             return ""
 
@@ -538,7 +529,7 @@ class GeminiAdapter:
     def _snapshot_preexisting_sessions(self, cwd: Path) -> set[Path]:
         chats_dir = Path.home() / ".gemini" / "tmp" / cwd.name / "chats"
         try:
-            return set(chats_dir.glob("session-*.json"))
+            return set(self._session_file_candidates(chats_dir))
         except OSError:
             return set()
 
@@ -548,7 +539,7 @@ class GeminiAdapter:
         *,
         call_start_time: float | None = None,
     ) -> Path | None:
-        """Return the Gemini session JSON scoped to this invocation, if any."""
+        """Return the Gemini session trace scoped to this invocation, if any."""
         import time as _time
 
         snapshot: set[Path] = getattr(self, "_session_snapshot", None) or set()
@@ -558,7 +549,7 @@ class GeminiAdapter:
 
         chats_dir = Path.home() / ".gemini" / "tmp" / plan.cwd.name / "chats"
         try:
-            candidates = list(chats_dir.glob("session-*.json"))
+            candidates = self._session_file_candidates(chats_dir)
         except OSError:
             return None
 
@@ -600,25 +591,14 @@ class GeminiAdapter:
             return True
 
         try:
-            data = _json.loads(session_path.read_text(encoding="utf-8", errors="replace"))
-            messages = data.get("messages", [])
-            if not isinstance(messages, list):
-                return False
-
+            events = self._read_session_events(session_path)
             user_texts: list[str] = []
-            for msg in messages:
-                if not isinstance(msg, dict) or msg.get("type") != "user":
+            for msg in self._iter_session_messages(events):
+                if msg.get("type") != "user":
                     continue
-                content = msg.get("content")
-                if isinstance(content, str):
-                    user_texts.append(content)
-                elif isinstance(content, list):
-                    parts: list[str] = []
-                    for part in content:
-                        if isinstance(part, dict) and isinstance(part.get("text"), str):
-                            parts.append(part["text"])
-                    if parts:
-                        user_texts.append("\n".join(parts))
+                text = self._message_text_content(msg)
+                if text:
+                    user_texts.append(text)
 
             for text in user_texts:
                 normalized = text.rstrip()
@@ -629,6 +609,50 @@ class GeminiAdapter:
             return False
         except Exception:
             return False
+
+    @staticmethod
+    def _session_file_candidates(chats_dir: Path) -> list[Path]:
+        """Return Gemini session files for legacy JSON and current JSONL."""
+        candidates: list[Path] = []
+        seen: set[Path] = set()
+        for pattern in ("session-*.json", "session-*.jsonl"):
+            for path in chats_dir.glob(pattern):
+                if path in seen:
+                    continue
+                seen.add(path)
+                candidates.append(path)
+        return candidates
+
+    @staticmethod
+    def _iter_session_messages(
+        events: list[dict[str, object]],
+    ) -> list[dict[str, object]]:
+        messages: list[dict[str, object]] = []
+        for event in events:
+            nested = event.get("messages")
+            if isinstance(nested, list):
+                messages.extend(item for item in nested if isinstance(item, dict))
+            else:
+                messages.append(event)
+        return messages
+
+    @staticmethod
+    def _message_text_content(msg: Mapping[str, object]) -> str:
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+            return "\n".join(parts)
+        return ""
+
+    @staticmethod
+    def _read_session_events(session_path: Path) -> list[dict[str, object]]:
+        text = session_path.read_text(encoding="utf-8", errors="replace")
+        return parse_json_events(text, source="gemini-session", logger=_logger)
 
     @staticmethod
     def _prompt_fingerprint_matches(expected: str, observed: str) -> bool:
@@ -667,7 +691,7 @@ class GeminiAdapter:
             call or status update (verified: modified during exec).
           - ``~/.gemini/tmp/<project>/chats/`` — directory mtime bumps
             when a new session JSON file is created at the start of exec.
-          - ``~/.gemini/tmp/<project>/chats/session-*.json`` — newest
+          - ``~/.gemini/tmp/<project>/chats/session-*.json*`` — newest
             session file grows as messages stream in.
 
         ``<project>`` is the cwd basename per gemini-cli convention. We
@@ -698,14 +722,14 @@ class GeminiAdapter:
             if chats_dir.exists():
                 paths.append(chats_dir)
 
-                # 3. The newest session-*.json file — grows as messages stream.
+                # 3. The newest session file — grows as messages stream.
                 #    We pick by mtime at adapter build time; the watchdog then
                 #    watches THAT file. If Gemini creates a newer session file
                 #    after we start, the chats/ dir mtime bump (signal #2)
                 #    catches it.
                 try:
                     session_files = sorted(
-                        chats_dir.glob("session-*.json"),
+                        self._session_file_candidates(chats_dir),
                         key=lambda p: p.stat().st_mtime,
                         reverse=True,
                     )

--- a/scripts/agent_runtime/tool_calls.py
+++ b/scripts/agent_runtime/tool_calls.py
@@ -42,7 +42,23 @@ def parse_json_events(text: str, *, source: str, logger: logging.Logger) -> list
     Each line may be a JSON object, or a debug line containing one JSON object.
     Malformed candidate lines are logged and skipped so CLI version drift does
     not crash the adapter parse path.
+
+    Gemini session traces are JSONL in current CLI versions, for example:
+        {"type":"user","content":[{"text":"..."}]}
+        {"type":"gemini","toolCalls":[{"name":"mcp__sources__verify_words",
+         "args":{"words":["кіт"]}}]}
     """
+    stripped = text.strip()
+    if stripped:
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return [parsed]
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict)]
+
     events: list[dict[str, Any]] = []
     for lineno, raw_line in enumerate(text.splitlines(), start=1):
         line = raw_line.strip()

--- a/tests/test_agent_runtime_tool_calls.py
+++ b/tests/test_agent_runtime_tool_calls.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+
+from scripts.agent_runtime.tool_calls import normalize_tool_calls, parse_json_events
+
+
+def test_parse_json_events_accepts_pretty_printed_json_object() -> None:
+    events = parse_json_events(
+        """
+        {
+          "messages": [
+            {"type": "gemini", "toolCalls": [{"name": "read_file", "args": {}}]}
+          ]
+        }
+        """,
+        source="fixture",
+        logger=logging.getLogger(__name__),
+    )
+
+    assert len(events) == 1
+    assert events[0]["messages"][0]["toolCalls"][0]["name"] == "read_file"
+
+
+def test_normalize_tool_calls_extracts_gemini_toolcalls_shape() -> None:
+    events = [
+        {
+            "type": "gemini",
+            "toolCalls": [
+                {
+                    "id": "mcp__sources__verify_words_fixture",
+                    "name": "mcp__sources__verify_words",
+                    "args": {"words": ["кіт"]},
+                    "timestamp": "2026-05-09T19:20:01Z",
+                    "result": [
+                        {
+                            "functionResponse": {
+                                "name": "mcp__sources__verify_words",
+                                "response": {"output": "ok"},
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    calls = normalize_tool_calls(events)
+
+    assert calls[0]["name"] == "mcp__sources__verify_words"
+    assert calls[0]["arguments"] == {"words": ["кіт"]}
+    assert calls[0]["timestamp"] == "2026-05-09T19:20:01Z"
+

--- a/tests/test_gemini_adapter_tool_calls.py
+++ b/tests/test_gemini_adapter_tool_calls.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.agent_runtime.adapters.base import InvocationPlan
+from scripts.agent_runtime.adapters.gemini import GeminiAdapter
+from scripts.build import linear_pipeline
+
+
+def _plan(cwd: Path, prompt: str = "Call the sources tool.") -> InvocationPlan:
+    return InvocationPlan(
+        cmd=["gemini"],
+        cwd=cwd,
+        stdin_payload=prompt,
+        output_file=None,
+        env_overrides={},
+        env_unsets=(),
+        liveness_paths=(),
+    )
+
+
+def _write_jsonl_session(
+    home: Path,
+    cwd: Path,
+    *,
+    prompt: str = "Call the sources tool.",
+    gemini_events: list[dict[str, Any]],
+) -> Path:
+    chats_dir = home / ".gemini" / "tmp" / cwd.name / "chats"
+    chats_dir.mkdir(parents=True)
+    session = chats_dir / "session-2026-05-09T19-20-fixture.jsonl"
+    events = [
+        {"sessionId": "fixture", "startTime": "2026-05-09T19:20:00Z"},
+        {"type": "user", "content": [{"text": prompt}]},
+        *gemini_events,
+    ]
+    session.write_text(
+        "\n".join(json.dumps(event, ensure_ascii=False) for event in events) + "\n",
+        encoding="utf-8",
+    )
+    return session
+
+
+def _parse_from_session(home: Path, monkeypatch: pytest.MonkeyPatch, cwd: Path):
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda _: home))
+    return GeminiAdapter().parse_response(
+        stdout="writer output",
+        stderr="",
+        returncode=0,
+        output_file=None,
+        plan=_plan(cwd),
+    )
+
+
+def test_parse_response_extracts_mcp_tool_calls_from_gemini_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "project"
+    _write_jsonl_session(
+        home,
+        cwd,
+        gemini_events=[
+            {
+                "type": "gemini",
+                "toolCalls": [
+                    {
+                        "id": "mcp__sources__verify_words_fixture",
+                        "name": "mcp__sources__verify_words",
+                        "args": {"words": ["кіт", "добре"]},
+                        "status": "success",
+                        "timestamp": "2026-05-09T19:20:01Z",
+                    }
+                ],
+            }
+        ],
+    )
+
+    result = _parse_from_session(home, monkeypatch, cwd)
+
+    assert result.tool_calls == [
+        {
+            "name": "mcp__sources__verify_words",
+            "arguments": {"words": ["кіт", "добре"]},
+            "output_summary": "",
+            "timestamp": "2026-05-09T19:20:01Z",
+        }
+    ]
+
+
+def test_parse_response_keeps_empty_gemini_jsonl_tool_calls_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "project"
+    _write_jsonl_session(
+        home,
+        cwd,
+        gemini_events=[{"type": "gemini", "content": "No tools used."}],
+    )
+
+    result = _parse_from_session(home, monkeypatch, cwd)
+
+    assert result.tool_calls == []
+
+
+def test_parse_response_extracts_built_in_and_mcp_tool_calls_from_gemini_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "project"
+    _write_jsonl_session(
+        home,
+        cwd,
+        gemini_events=[
+            {
+                "type": "gemini",
+                "toolCalls": [
+                    {"name": "list_directory", "args": {"dir_path": "."}},
+                    {"name": "read_file", "args": {"absolute_path": "README.md"}},
+                    {
+                        "name": "mcp__sources__verify_words",
+                        "args": {"words": ["кіт"]},
+                    },
+                ],
+            }
+        ],
+    )
+
+    result = _parse_from_session(home, monkeypatch, cwd)
+
+    assert [call["name"] for call in result.tool_calls] == [
+        "list_directory",
+        "read_file",
+        "mcp__sources__verify_words",
+    ]
+    assert result.tool_calls[2]["arguments"] == {"words": ["кіт"]}
+
+
+def test_invoke_writer_persists_gemini_jsonl_mcp_calls_to_writer_tool_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "project"
+    _write_jsonl_session(
+        home,
+        cwd,
+        gemini_events=[
+            {
+                "type": "gemini",
+                "toolCalls": [
+                    {
+                        "name": "mcp__sources__verify_words",
+                        "args": {"words": ["кіт"]},
+                    }
+                ],
+            }
+        ],
+    )
+    parsed = _parse_from_session(home, monkeypatch, cwd)
+    trace_path = tmp_path / "module" / "writer_tool_calls.json"
+
+    def invoker(_agent: str, _prompt: str, **_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            response="writer output",
+            tool_calls=parsed.tool_calls,
+        )
+
+    linear_pipeline.invoke_writer(
+        "Write the module.",
+        writer="gemini-tools",
+        cwd=cwd,
+        invoker=invoker,
+        module="a1/1",
+        sections=["vocabulary"],
+        tool_trace_path=trace_path,
+    )
+
+    calls = json.loads(trace_path.read_text(encoding="utf-8"))
+    assert [call["name"] for call in calls] == ["mcp__sources__verify_words"]
+    assert calls[0]["arguments"] == {"words": ["кіт"]}
+

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -339,3 +339,15 @@ def test_telemetry_event_sink_appends_jsonl(
     assert captured.out == ""
     assert [event["event"] for event in events] == ["first", "second"]
     assert all(event["slug"] == "x" for event in events)
+
+
+def test_tools_writer_runtime_gate_still_fires_for_empty_tool_calls() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="MCP_TOOLS_NEVER_INVOKED",
+    ):
+        linear_pipeline._enforce_tools_writer_runtime_gate(
+            writer="gemini-tools",
+            module="a1/1",
+            phase_writer_summary={"tool_calls_total": 0},
+        )


### PR DESCRIPTION
## Summary

Fixes #1819. This PR makes Gemini telemetry read current Gemini CLI `session-*.jsonl` traces and extract `toolCalls` entries into `ParseResult.tool_calls`, including both built-in calls and `mcp__sources__*` calls.

Audit reference: `audit/gemini-tools-review-2026-05-09/REPORT.html`, section E9. Sections E1/E4 showed the session path pattern `~/.gemini/tmp/<project>/chats/session-*.jsonl` and the built-in `list_directory` `toolCalls` shape.

## Captured Gemini JSONL Shape

Captured in `/tmp/gemini-jsonl-shape.txt` before the fix from real Gemini session files:

```json
{"type":"gemini","toolCalls":[{"id":"mcp__sources__verify_words_1778354439047_1","name":"mcp__sources__verify_words","args":{"words":["кіт"]},"status":"error","result":[{"functionResponse":{"id":"mcp__sources__verify_words_1778354439047_1","name":"mcp__sources__verify_words","response":{"error":"Tool \"mcp__sources__verify_words\" not found. Did you mean one of: \"list_directory\", \"grep_search\", \"run_shell_command\"?"}}}]}]}
```

Audit built-in shape:

```json
{"type":"gemini","toolCalls":[{"id":"list_directory_1778267027113_0","name":"list_directory","args":{"dir_path":"/Users/krisztiankoos/projects/learn-ukrainian/audit/bakeoff-2026-05-08-claude-gemini-diagnostic/gemini"},"status":"success","result":[{"functionResponse":{"id":"list_directory_1778267027113_0","name":"list_directory","response":{"output":"Directory /Users/krisztiankoos/projects/learn-ukrainian/audit/bakeoff-2026-05-08-claude-gemini-diagnostic/gemini is empty."}}}]}]}
```

## Diagnosis

Actual root cause was failure mode 1, plus an adjacent file selection gap:

- Current Gemini sessions are JSONL, not a single JSON object.
- The adapter only selected `session-*.json`, missing `session-*.jsonl` files.
- `_read_latest_session_trace()` then tried `json.loads()` on the whole session file, which drops JSONL traces before `parse_json_events()` and `normalize_tool_calls()` can see them.
- The existing normalizer already handles the observed `toolCalls` item shape once the payload reaches it.

## Fix

- Select both legacy `session-*.json` and current `session-*.jsonl` Gemini session files.
- Read raw session text for tool-call telemetry instead of loading the whole file as one JSON document.
- Route Gemini session prompt matching and response recovery through `parse_json_events()` so JSONL and legacy single-object sessions both work.
- Harden `parse_json_events()` to accept a single pretty-printed JSON object/list before falling back to JSONL line parsing.

## Acceptance Criteria

- [x] Adapter test: synthetic Gemini JSONL fixture with `mcp__sources__verify_words` extracts name + args.
- [x] Negative test: empty session JSONL preserves `tool_calls=[]`.
- [x] Mixed test: built-ins `list_directory`, `read_file`, and `mcp__sources__verify_words` all return.
- [x] Pipeline regression: `invoke_writer(..., tool_trace_path=writer_tool_calls.json)` persists MCP entries parsed from a synthetic Gemini JSONL fixture.
- [x] Runtime-gate compatibility: `MCP_TOOLS_NEVER_INVOKED` still fires for genuinely empty `tool_calls_total=0`.
- [x] Existing focused tests still pass.

## Verification

- `.venv/bin/python -c "from scripts.build.linear_pipeline import _runtime_tool_config; cfg = _runtime_tool_config('gemini-tools'); print(cfg)"` confirms `mcp_server_names=['sources']`.
- `.venv/bin/pytest tests/test_gemini_adapter*.py tests/test_agent_runtime_tool_calls.py tests/test_linear_pipeline*.py -v` → 68 passed.
- `.venv/bin/ruff check scripts/agent_runtime/ scripts/build/ tests/` → All checks passed.
- `git diff --check` → clean.

No runtime gate contract changes, no Codex/Claude adapter changes, no generated audit/status artifacts, and protected config files are untouched.