### PR TITLE
Unify playground UI shell

### DIFF
--- a/playgrounds/admin.html
+++ b/playgrounds/admin.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Admin &amp; Maintenance</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -89,6 +90,7 @@ table.stats-table tr:hover { background: var(--bg3); }
 .bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s; }
 .bar-value { font-size: 12px; color: var(--text3); min-width: 70px; text-align: right; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
@@ -96,7 +98,14 @@ table.stats-table tr:hover { background: var(--bg3); }
   <h1>Admin &amp; Maintenance</h1>
   <div class="spacer"></div>
   <span class="refresh-info" id="last-refresh"></span>
-  <a href="/">Back to Hub</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="layout">
@@ -227,10 +236,6 @@ document.querySelectorAll('.sidebar a').forEach(a => {
   });
 });
 
-// Restore section from hash or default to health
-const hash = location.hash.slice(1);
-activateSection(hash || 'health');
-
 // ── API helpers ─────────────────────────────────────
 
 function escapeHtml(s) {
@@ -250,6 +255,10 @@ async function apiFetch(path, opts) {
 const apiGet = (path) => apiFetch(path);
 const apiPost = (path) => apiFetch(path, { method: 'POST' });
 const apiDelete = (path) => apiFetch(path, { method: 'DELETE' });
+
+// Restore section from hash or default to health after API helpers exist.
+const hash = location.hash.slice(1);
+activateSection(hash || 'health');
 
 function showResult(id, data) {
   const el = document.getElementById(id);

--- a/playgrounds/audit-dashboard.html
+++ b/playgrounds/audit-dashboard.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Module Quality Dashboard</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -16,8 +17,8 @@ body { font-family: 'Noto Sans', -apple-system, sans-serif; background: var(--bg
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 12px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
 .topbar h1 { font-size: 18px; font-weight: 600; }
-.topbar .nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
-.topbar .nav a { color: var(--text2); text-decoration: none; }
+.topbar .monitor-nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
+.topbar .monitor-nav a { color: var(--text2); text-decoration: none; }
 
 .container { max-width: 1200px; margin: 0 auto; padding: 24px; }
 
@@ -56,17 +57,27 @@ body { font-family: 'Noto Sans', -apple-system, sans-serif; background: var(--bg
 .gate { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; }
 .gate .icon { width: 16px; text-align: center; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
 <div class="topbar">
   <h1>Module Quality Dashboard</h1>
-  <div class="nav">
-    <a href="/track-health.html">Track Health</a>
-    <a href="/docs">API Docs</a>
-    <span id="refresh-info" style="color:var(--text3);font-size:11px;"></span>
-  </div>
+  <div class="spacer"></div>
+  <span id="refresh-info" style="color:var(--text3);font-size:11px;"></span>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
+<nav class="ops-nav" aria-label="Operations pages">
+  <a href="/track-health.html">Track Health</a>
+  <a href="/docs">API Docs</a>
+</nav>
 
 <div class="container">
   <div class="stats" id="stats"></div>

--- a/playgrounds/build-events.html
+++ b/playgrounds/build-events.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Build Events - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -48,6 +49,7 @@ tr:last-child td { border-bottom: none; }
 .pill.err { background: rgba(248,81,73,0.15); color: var(--red); }
 @media (max-width: 760px) { .topbar { flex-wrap: wrap; } }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">
@@ -58,7 +60,14 @@ tr:last-child td { border-bottom: none; }
   <div class="spacer"></div>
   <button class="btn" onclick="refreshAll()">Refresh</button>
   <div class="muted" id="last-refresh">Auto-refresh every 10s</div>
-  <a href="/">Home</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="container">

--- a/playgrounds/channels.html
+++ b/playgrounds/channels.html
@@ -138,6 +138,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
     <h1>Agent Channels <span style="font-weight:400;color:var(--text3);font-size:14px;margin-left:8px;">#1190</span></h1>
   </div>
   <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
     <a href="/orient.html">Orient</a>
     <a class="active" href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>

--- a/playgrounds/comms.html
+++ b/playgrounds/comms.html
@@ -185,6 +185,7 @@ a.gh-issue:hover { text-decoration: underline; }
   <div style="display:flex;align-items:center;gap:16px;">
     <span class="refresh-info" id="refresh-info">Loading...</span>
     <nav class="monitor-nav" aria-label="Monitor sections">
+      <a href="/">Home</a>
       <a href="/orient.html">Orient</a>
       <a href="/channels.html">Channels</a>
       <a class="active" href="/comms.html">Comms</a>

--- a/playgrounds/consultation.html
+++ b/playgrounds/consultation.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Consultation Loop - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -122,14 +123,22 @@ tr:hover td { background: var(--bg2); }
 .spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--purple); border-radius: 50%; animation: spin 0.6s linear infinite; margin-left: 8px; vertical-align: middle; }
 @keyframes spin { to { transform: rotate(360deg); } }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
 <div class="topbar">
   <h1>Consultation Loop</h1>
   <div class="spacer"></div>
-  <a href="/">Back to Hub</a>
   <span class="refresh-info" id="refresh-info"></span>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="tabs">

--- a/playgrounds/cost.html
+++ b/playgrounds/cost.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Cost - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -37,6 +38,7 @@ th { color: var(--text2); font-size: 11px; text-transform: uppercase; }
 .empty { color: var(--text2); font-size: 13px; }
 @media (max-width: 720px) { .topbar { flex-wrap: wrap; } }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">
@@ -45,7 +47,14 @@ th { color: var(--text2); font-size: 11px; text-transform: uppercase; }
     <div class="sub">Estimated token usage and USD spend from dispatch meta logs</div>
   </div>
   <div class="spacer"></div>
-  <a href="/">Home</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="container">

--- a/playgrounds/curriculum-dashboard.html
+++ b/playgrounds/curriculum-dashboard.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Curriculum Dashboard - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -18,8 +19,8 @@ a:hover { text-decoration: underline; }
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 12px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
 .topbar h1 { font-size: 18px; font-weight: 600; }
-.topbar .nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
-.topbar .nav a { color: var(--text2); }
+.topbar .monitor-nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
+.topbar .monitor-nav a { color: var(--text2); }
 .refresh-indicator { font-size: 11px; color: var(--text3); }
 
 .main { display: grid; grid-template-columns: 1fr 400px; height: calc(100vh - 49px); }
@@ -95,21 +96,29 @@ a:hover { text-decoration: underline; }
 .track-title { font-size: 16px; font-weight: 600; margin-bottom: 8px; }
 .track-stats { display: flex; gap: 12px; font-size: 12px; color: var(--text2); margin-bottom: 12px; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
 <div class="topbar">
   <h1>Curriculum Dashboard</h1>
+  <div class="spacer"></div>
   <span class="refresh-indicator" id="refresh-info"></span>
-  <div class="nav">
+  <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
-    <a href="/audit-dashboard.html">Audit</a>
-    <a href="/progress.html">Progress</a>
-    <a href="/quality.html">Quality</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>
-    <a href="/track-health.html">Health</a>
-  </div>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
+<nav class="ops-nav" aria-label="Operations pages">
+  <a href="/audit-dashboard.html">Audit</a>
+  <a href="/progress.html">Progress</a>
+  <a href="/quality.html">Quality</a>
+  <a href="/track-health.html">Health</a>
+</nav>
 
 <div class="main">
   <div class="left-panel" id="left-panel">

--- a/playgrounds/delegate.html
+++ b/playgrounds/delegate.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Delegate - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -60,6 +61,7 @@ pre { background: var(--bg); border: 1px solid var(--border); border-radius: 8px
   .topbar { flex-wrap: wrap; }
 }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">
@@ -70,7 +72,14 @@ pre { background: var(--bg); border: 1px solid var(--border); border-radius: 8px
   <div class="spacer"></div>
   <button class="btn" onclick="loadTasks()">Refresh</button>
   <div class="muted" id="last-refresh">No auto-refresh</div>
-  <a href="/">Home</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="container">

--- a/playgrounds/image-explorer.html
+++ b/playgrounds/image-explorer.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Images - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -173,12 +174,24 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 
 .toast.visible { display: block; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
-<div class="header">
-  <a href="/">&larr; Home</a>
-  <h1>Images</h1>
+<div class="topbar">
+  <div>
+    <h1>Images</h1>
+    <div class="sub">Textbook image context, annotations, search, and quality checks</div>
+  </div>
+  <div class="spacer"></div>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="tabs">

--- a/playgrounds/images.html
+++ b/playgrounds/images.html
@@ -4,8 +4,27 @@
 <meta charset="UTF-8">
 <meta http-equiv="refresh" content="0; url=/image-explorer.html">
 <title>Redirecting...</title>
+<link rel="icon" href="data:,">
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
-<p>Redirecting to <a href="/image-explorer.html">Image Explorer</a>...</p>
+<div class="topbar">
+  <div>
+    <h1>Images</h1>
+    <div class="sub">Redirecting to the image explorer</div>
+  </div>
+  <div class="spacer"></div>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
+</div>
+<main class="container">
+  <p>Redirecting to <a href="/image-explorer.html">Image Explorer</a>...</p>
+</main>
 </body>
 </html>

--- a/playgrounds/monitor.css
+++ b/playgrounds/monitor.css
@@ -46,8 +46,16 @@ a { color: var(--accent); }
   letter-spacing: 0;
 }
 
+.topbar .spacer,
+.top-bar .spacer {
+  flex: 1 1 auto;
+}
+
 .topbar .sub,
 .topbar .meta,
+.topbar .muted,
+.topbar .refresh-info,
+.topbar .refresh-indicator,
 .top-bar .refresh-info,
 .top-bar a,
 .top-bar span,
@@ -105,6 +113,32 @@ a { color: var(--accent); }
   border-color: var(--accent);
 }
 
+.topbar .monitor-nav,
+.top-bar .monitor-nav {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 12px;
+  margin-left: auto;
+}
+
+.topbar .monitor-nav a,
+.top-bar .monitor-nav a {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text2) !important;
+  padding: 5px 8px;
+  text-decoration: none;
+}
+
+.topbar .monitor-nav a:hover,
+.top-bar .monitor-nav a:hover {
+  color: var(--accent) !important;
+  border-color: var(--accent);
+}
+
 .home-link {
   color: var(--accent) !important;
 }
@@ -123,7 +157,27 @@ a { color: var(--accent); }
 .thread-msg,
 .detail-panel,
 .details,
-.detail-overlay.open + .detail-panel {
+.detail-overlay.open + .detail-panel,
+.card,
+.stat-card,
+.status-item,
+.panel,
+.controls,
+.modal,
+.confirm-box,
+.inspector-overlay,
+.inspector-panel,
+.bulk-bar,
+.backup-item,
+.text-result,
+.annotation-card,
+.track-section,
+.track-row,
+.module-row,
+.metric-card,
+.issue-card,
+.coverage-card,
+.score-card {
   background: var(--bg2) !important;
   border-color: var(--border) !important;
 }
@@ -135,7 +189,25 @@ a { color: var(--accent); }
 .kv,
 .health-pill,
 .stat-box,
-.compose-panel {
+.compose-panel,
+.card,
+.stat-card,
+.status-item,
+.panel,
+.controls,
+.modal,
+.confirm-box,
+.bulk-bar,
+.backup-item,
+.text-result,
+.annotation-card,
+.track-section,
+.track-row,
+.module-row,
+.metric-card,
+.issue-card,
+.coverage-card,
+.score-card {
   border-radius: 4px !important;
 }
 
@@ -144,7 +216,11 @@ a { color: var(--accent); }
 .messages-area,
 .thread-bar,
 .discussion-strip,
-.layout {
+.layout,
+.main,
+.container,
+.left-panel,
+.right-panel {
   background: var(--bg) !important;
   border-color: var(--border) !important;
 }
@@ -171,7 +247,10 @@ a { color: var(--accent); }
 .compose-panel input,
 .compose-panel textarea,
 .parent-id-container input,
-.thread-bar select {
+.thread-bar select,
+input,
+select,
+textarea {
   background: #fffaf0 !important;
   border-color: var(--border) !important;
   color: var(--text) !important;
@@ -196,9 +275,16 @@ th,
 td,
 .list li,
 .tabs,
+.tab,
+.track-tabs,
+.track-tab,
 .feed-title,
 .msg-table th,
-.msg-table td {
+.msg-table td,
+table,
+.module-table,
+.module-table th,
+.module-table td {
   border-color: var(--border) !important;
 }
 

--- a/playgrounds/orient.html
+++ b/playgrounds/orient.html
@@ -92,6 +92,7 @@ tr:last-child td { border-bottom: none; }
     <div id="generated-at">Waiting for data...</div>
   </div>
   <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
     <a class="active" href="/orient.html">Orient</a>
     <a href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>

--- a/playgrounds/progress.html
+++ b/playgrounds/progress.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Progress - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -18,9 +19,9 @@ a:hover { text-decoration: underline; }
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 12px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
 .topbar h1 { font-size: 18px; font-weight: 600; }
-.topbar .nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
-.topbar .nav a { color: var(--text2); }
-.topbar .nav a:hover { color: var(--text); }
+.topbar .monitor-nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
+.topbar .monitor-nav a { color: var(--text2); }
+.topbar .monitor-nav a:hover { color: var(--text); }
 
 .stats-bar { display: flex; gap: 24px; padding: 16px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); flex-wrap: wrap; }
 .stat-card { text-align: center; min-width: 100px; }
@@ -88,6 +89,7 @@ a:hover { text-decoration: underline; }
 
 .error-msg { color: var(--red); font-size: 13px; padding: 8px 0; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div id="tooltip"></div>
@@ -95,15 +97,22 @@ a:hover { text-decoration: underline; }
 <div class="topbar">
   <h1>&#9654; Progress</h1>
   <div style="font-size:12px;color:var(--text3);" id="topbar-subtitle">Pipeline state across all tracks</div>
-  <div class="nav">
+  <div class="spacer"></div>
+  <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
-    <a href="/audit-dashboard.html">Audit</a>
-    <a href="/quality.html">Quality</a>
-    <a href="/docs">API</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>
-    <a href="/track-health.html">Health</a>
-  </div>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
+<nav class="ops-nav" aria-label="Operations pages">
+  <a href="/audit-dashboard.html">Audit</a>
+  <a href="/quality.html">Quality</a>
+  <a href="/track-health.html">Health</a>
+  <a href="/docs">API</a>
+</nav>
 
 <div class="stats-bar" id="stats-bar">
   <div class="stat-card"><div class="value" id="total-modules">—</div><div class="label">Total Modules</div></div>

--- a/playgrounds/quality.html
+++ b/playgrounds/quality.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Quality - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -18,9 +19,9 @@ a:hover { text-decoration: underline; }
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 12px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
 .topbar h1 { font-size: 18px; font-weight: 600; }
-.topbar .nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
-.topbar .nav a { color: var(--text2); }
-.topbar .nav a:hover { color: var(--text); }
+.topbar .monitor-nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
+.topbar .monitor-nav a { color: var(--text2); }
+.topbar .monitor-nav a:hover { color: var(--text); }
 
 /* Tab bar */
 .tabs { display: flex; gap: 0; padding: 0 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
@@ -86,21 +87,29 @@ tr:hover td { background: var(--bg3); }
 .loading-msg { color: var(--text3); font-size: 13px; padding: 16px 0; }
 .error-msg { color: var(--red); font-size: 13px; padding: 8px 0; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
 <div class="topbar">
   <h1>&#9881; Quality</h1>
   <div style="font-size:12px;color:var(--text3);">Research coverage · Review scores · Outstanding issues · Weak modules</div>
-  <div class="nav">
+  <div class="spacer"></div>
+  <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
-    <a href="/audit-dashboard.html">Audit</a>
-    <a href="/progress.html">Progress</a>
-    <a href="/docs">API</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>
-    <a href="/track-health.html">Health</a>
-  </div>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
+<nav class="ops-nav" aria-label="Operations pages">
+  <a href="/audit-dashboard.html">Audit</a>
+  <a href="/progress.html">Progress</a>
+  <a href="/track-health.html">Health</a>
+  <a href="/docs">API</a>
+</nav>
 
 <div class="tabs">
   <div class="tab active" onclick="switchTab('research')">Research Coverage</div>

--- a/playgrounds/runtime.html
+++ b/playgrounds/runtime.html
@@ -77,6 +77,7 @@ tr:last-child td { border-bottom: none; }
     <div id="last-refresh">Waiting for data...</div>
   </div>
   <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
     <a href="/orient.html">Orient</a>
     <a href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>

--- a/playgrounds/track-health.html
+++ b/playgrounds/track-health.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Track Health - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -18,9 +19,9 @@ a:hover { text-decoration: underline; }
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 12px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
 .topbar h1 { font-size: 18px; font-weight: 600; }
-.topbar .nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
-.topbar .nav a { color: var(--text2); }
-.topbar .nav a:hover { color: var(--text); }
+.topbar .monitor-nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
+.topbar .monitor-nav a { color: var(--text2); }
+.topbar .monitor-nav a:hover { color: var(--text); }
 
 .container { padding: 16px 24px; max-width: 1400px; }
 
@@ -87,8 +88,8 @@ a:hover { text-decoration: underline; }
 .attention-item.clickable:hover { background: var(--bg3); }
 
 /* Module inspector panel */
-.inspector-overlay { position: fixed; top: 0; right: 0; width: 520px; height: 100vh; background: var(--bg2); border-left: 1px solid var(--border); z-index: 1000; transform: translateX(100%); transition: transform 0.25s ease; overflow-y: auto; box-shadow: -4px 0 20px rgba(0,0,0,0.5); }
-.inspector-overlay.open { transform: translateX(0); }
+.inspector-overlay { position: fixed; top: 0; right: 0; width: 520px; height: 100vh; background: var(--bg2); border-left: 1px solid var(--border); z-index: 1000; transform: translateX(100%); visibility: hidden; pointer-events: none; transition: transform 0.25s ease, visibility 0.25s ease; overflow-y: auto; box-shadow: -4px 0 20px rgba(0,0,0,0.5); }
+.inspector-overlay.open { transform: translateX(0); visibility: visible; pointer-events: auto; }
 .inspector-header { display: flex; align-items: center; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg2); z-index: 1; }
 .inspector-header h2 { font-size: 15px; font-weight: 600; flex: 1; }
 .inspector-close { background: none; border: 1px solid var(--border); border-radius: 4px; color: var(--text2); font-size: 16px; cursor: pointer; padding: 2px 8px; }
@@ -124,33 +125,30 @@ a:hover { text-decoration: underline; }
 .comms-content { color: var(--text2); line-height: 1.5; word-break: break-word; }
 .comms-empty { color: var(--text3); font-size: 12px; padding: 12px; text-align: center; }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
-
-<!-- Module inspector slide-in panel -->
-<div class="inspector-overlay" id="inspector">
-  <div class="inspector-header">
-    <h2 id="inspector-title">Module Inspector</h2>
-    <button class="inspector-close" onclick="closeInspector()">&times;</button>
-  </div>
-  <div class="inspector-body" id="inspector-body">
-    <div class="loading">Select a module...</div>
-  </div>
-</div>
 
 <div class="topbar">
   <h1>&#x1F3E5; Track Health</h1>
   <div style="font-size:12px;color:var(--text3);">Build progress, quality, enrichment — one view per track</div>
-  <div class="nav">
+  <div class="spacer"></div>
+  <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
-    <a href="/progress.html">Progress</a>
-    <a href="/audit-dashboard.html">Audit</a>
-    <a href="/quality.html">Quality</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
     <a href="/comms.html">Comms</a>
-    <a href="/curriculum-dashboard.html">Curriculum</a>
-    <a href="/docs">API</a>
-  </div>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
+<nav class="ops-nav" aria-label="Operations pages">
+  <a href="/progress.html">Progress</a>
+  <a href="/audit-dashboard.html">Audit</a>
+  <a href="/quality.html">Quality</a>
+  <a href="/curriculum-dashboard.html">Curriculum</a>
+  <a href="/docs">API</a>
+</nav>
 
 <div class="container">
   <!-- All-tracks overview -->
@@ -163,6 +161,17 @@ a:hover { text-decoration: underline; }
 
   <!-- Health dashboard for selected track -->
   <div id="health-container"></div>
+</div>
+
+<!-- Module inspector slide-in panel -->
+<div class="inspector-overlay" id="inspector" aria-hidden="true">
+  <div class="inspector-header">
+    <h2 id="inspector-title">Module Inspector</h2>
+    <button class="inspector-close" onclick="closeInspector()">&times;</button>
+  </div>
+  <div class="inspector-body" id="inspector-body">
+    <div class="loading">Select a module...</div>
+  </div>
 </div>
 
 <script>
@@ -395,6 +404,7 @@ const inspectorBody = document.getElementById('inspector-body');
 
 function closeInspector() {
   inspector.classList.remove('open');
+  inspector.setAttribute('aria-hidden', 'true');
 }
 
 // Close on Escape
@@ -402,6 +412,7 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeInspect
 
 async function inspectModule(trackId, num) {
   inspector.classList.add('open');
+  inspector.setAttribute('aria-hidden', 'false');
   inspectorTitle.textContent = `#${num} — Loading...`;
   inspectorBody.innerHTML = '<div class="loading">Fetching module data...</div>';
 

--- a/playgrounds/wiki.html
+++ b/playgrounds/wiki.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Wiki - ukraine-ops</title>
+<link rel="icon" href="data:,">
 <style>
 :root {
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
@@ -61,6 +62,7 @@ tr:last-child td { border-bottom: none; }
   .topbar { flex-wrap: wrap; }
 }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">
@@ -71,7 +73,14 @@ tr:last-child td { border-bottom: none; }
   <div class="spacer"></div>
   <button class="btn" onclick="refreshAll()">Refresh</button>
   <div class="muted" id="last-refresh">Auto-refresh every 60s</div>
-  <a href="/">Home</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 
 <div class="container">

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -3,10 +3,19 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
+PLAYGROUNDS = ROOT / "playgrounds"
+PRIMARY_NAV_HREFS = [
+    "/",
+    "/orient.html",
+    "/channels.html",
+    "/comms.html",
+    "/artifacts/",
+    "/runtime.html",
+]
 
 
 def test_index_page_uses_shared_parchment_monitor_design():
-    html = (ROOT / "playgrounds" / "index.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "index.html").read_text(encoding="utf-8")
     assert '<link rel="stylesheet" href="/monitor.css">' in html
     assert '<a class="active" href="/">Home</a>' in html
     assert "Operations launchpad" in html
@@ -55,7 +64,7 @@ def test_playground_page_uses_shared_parchment_monitor_design(filename, active_l
 
 
 def test_channels_page_has_shareable_deeplink_contract():
-    html = (ROOT / "playgrounds" / "channels.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "channels.html").read_text(encoding="utf-8")
     assert "new URLSearchParams(location.search)" in html
     assert "params.get('channel')" in html
     assert "params.get('thread')" in html
@@ -65,7 +74,7 @@ def test_channels_page_has_shareable_deeplink_contract():
 
 
 def test_orient_page_renders_active_discussions_widget():
-    html = (ROOT / "playgrounds" / "orient.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "orient.html").read_text(encoding="utf-8")
     assert "Active Discussions" in html
     assert "/api/discussions/active" in html
     assert "Promise.allSettled" in html
@@ -75,7 +84,7 @@ def test_orient_page_renders_active_discussions_widget():
 
 
 def test_runtime_page_keeps_primary_monitor_nav():
-    html = (ROOT / "playgrounds" / "runtime.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "runtime.html").read_text(encoding="utf-8")
     assert '<link rel="stylesheet" href="/monitor.css">' in html
     assert '<a class="active" href="/runtime.html">Runtime</a>' in html
     for href in [
@@ -88,8 +97,15 @@ def test_runtime_page_keeps_primary_monitor_nav():
         assert f'href="{href}"' in html
 
 
+def test_shared_monitor_css_targets_unified_nav_classes():
+    css = (PLAYGROUNDS / "monitor.css").read_text(encoding="utf-8")
+    assert ".topbar .nav" not in css
+    assert ".topbar .monitor-nav" in css
+    assert ".top-bar .monitor-nav" in css
+
+
 def test_comms_page_keeps_secondary_dashboard_links():
-    html = (ROOT / "playgrounds" / "comms.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "comms.html").read_text(encoding="utf-8")
     for href in [
         "/audit-dashboard.html",
         "/progress.html",
@@ -101,7 +117,7 @@ def test_comms_page_keeps_secondary_dashboard_links():
 
 
 def test_artifacts_page_uses_metadata_endpoint_and_filters():
-    html = (ROOT / "playgrounds" / "artifacts.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "artifacts.html").read_text(encoding="utf-8")
     assert "/api/artifacts/html" in html
     assert "class-filter" in html
     assert "status-filter" in html
@@ -111,7 +127,7 @@ def test_artifacts_page_uses_metadata_endpoint_and_filters():
 
 
 def test_artifacts_page_preserves_legacy_dashboard_links():
-    html = (ROOT / "playgrounds" / "artifacts.html").read_text(encoding="utf-8")
+    html = (PLAYGROUNDS / "artifacts.html").read_text(encoding="utf-8")
     assert 'href="/"' in html
     for href in [
         "/admin.html",
@@ -132,4 +148,41 @@ def test_artifacts_page_preserves_legacy_dashboard_links():
         "/wiki.html",
     ]:
         assert f'href="{href}"' in html
-        assert (ROOT / "playgrounds" / href.lstrip("/")).exists()
+        assert (PLAYGROUNDS / href.lstrip("/")).exists()
+
+
+def test_all_playground_pages_use_single_monitor_shell():
+    for path in sorted(PLAYGROUNDS.glob("*.html")):
+        html = path.read_text(encoding="utf-8")
+        assert '<link rel="stylesheet" href="/monitor.css">' in html, path.name
+        assert 'class="monitor-nav"' in html, path.name
+        for href in PRIMARY_NAV_HREFS:
+            assert f'href="{href}"' in html, path.name
+        if "#0d1117" in html:
+            assert html.rfind('<link rel="stylesheet" href="/monitor.css">') > html.rfind("</style>"), path.name
+
+
+def test_operations_pages_keep_secondary_navigation():
+    pages_to_hrefs = {
+        "audit-dashboard.html": ["/track-health.html", "/docs"],
+        "curriculum-dashboard.html": [
+            "/audit-dashboard.html",
+            "/progress.html",
+            "/quality.html",
+            "/track-health.html",
+        ],
+        "progress.html": ["/audit-dashboard.html", "/quality.html", "/track-health.html", "/docs"],
+        "quality.html": ["/audit-dashboard.html", "/progress.html", "/track-health.html", "/docs"],
+        "track-health.html": [
+            "/progress.html",
+            "/audit-dashboard.html",
+            "/quality.html",
+            "/curriculum-dashboard.html",
+            "/docs",
+        ],
+    }
+    for page, hrefs in pages_to_hrefs.items():
+        html = (PLAYGROUNDS / page).read_text(encoding="utf-8")
+        assert 'class="ops-nav"' in html, page
+        for href in hrefs:
+            assert f'href="{href}"' in html, page


### PR DESCRIPTION
## Summary
- applies the shared parchment monitor shell and primary nav to every playground page
- preserves secondary operational dashboard links for audit/progress/quality/health pages
- fixes admin page initialization order and keeps the track-health inspector out of the initial page flow until opened
- adds monitor UI contract tests covering all playground HTML pages

## Validation
- .venv/bin/python -m pytest tests/test_monitor_ui_contracts.py tests/test_playgrounds.py -q
- git diff --check
- Lightpanda semantic sweep over all playground routes on http://127.0.0.1:8765
- pre-commit affected-file pytest + ruff during commit