### PR TITLE
fix(wiki): MCP fail-fast on codex reviewer dispatch

### DIFF
--- a/scripts/wiki/review.py
+++ b/scripts/wiki/review.py
@@ -134,6 +134,11 @@ HARD_TIMEOUT_S = 600
 #: Verdicts a reviewer is allowed to emit. Anything else → treated as ERROR.
 _VALID_VERDICTS: frozenset[str] = frozenset({"PASS", "REVISE", "REJECT"})
 
+
+class WikiReviewError(RuntimeError):
+    """Hard failure in wiki review orchestration."""
+
+
 # ── Dataclasses ────────────────────────────────────────────────────
 
 
@@ -250,16 +255,41 @@ class ReviewReport:
 # ── Tool-config per agent (§3b dim 1+4 need MCP) ───────────────────
 
 
-def _tool_config_for(agent: str, *, needs_mcp: bool) -> dict | None:
+def _emit(
+    event_sink: Callable[..., None] | None,
+    event: str,
+    **fields: Any,
+) -> None:
+    if event_sink is not None:
+        event_sink(event, **fields)
+
+
+def _tool_config_for(
+    agent: str,
+    *,
+    needs_mcp: bool,
+    event_sink: Callable[..., None] | None = None,
+) -> dict | None:
     """Build per-agent tool_config enabling the MCP `sources` server."""
     if not needs_mcp:
         return None
 
-    tool_config, _diagnostics = build_mcp_tool_config(
+    tool_config, diagnostics = build_mcp_tool_config(
         agent,
         mcp_servers=["sources"],
         allowed_tools="mcp__sources__*" if agent == "claude" else None,
     )
+    _emit(event_sink, "mcp_config_resolved", reviewer=agent, **diagnostics)
+
+    requested = diagnostics["requested_servers"]
+    resolved = diagnostics["resolved_servers"]
+    status = diagnostics["resolution_status"]
+    if agent == "codex" and requested and not resolved:
+        raise WikiReviewError(
+            f"Reviewer {agent!r} requested MCP servers {requested!r} "
+            f"but resolver returned none ({status}). Refusing to dispatch "
+            "tool-less."
+        )
     return tool_config
 
 
@@ -433,6 +463,7 @@ def _run_single_dim(
     primary: str,
     fallbacks: tuple[str, ...],
     cwd: Path,
+    event_sink: Callable[..., None] | None = None,
 ) -> DimResult:
     """Run one dim; on primary failure, try fallbacks in order.
 
@@ -450,7 +481,11 @@ def _run_single_dim(
     last_error = ""
 
     for agent in agents_to_try:
-        tool_config = _tool_config_for(agent, needs_mcp=needs_mcp)
+        tool_config = _tool_config_for(
+            agent,
+            needs_mcp=needs_mcp,
+            event_sink=event_sink,
+        )
         if needs_mcp and tool_config is None:
             # Agent can't serve MCP-requiring dim — skip silently
             last_error = f"{agent}: MCP required but unavailable"
@@ -467,6 +502,7 @@ def _run_single_dim(
                 tool_config=tool_config,
                 entrypoint="runtime",
                 hard_timeout=HARD_TIMEOUT_S,
+                event_sink=event_sink,
                 task_id=f"wiki-review-{dim}-{article_path.stem}",
             )
         except (RateLimitedError, AgentTimeoutError, AgentUnavailableError) as exc:
@@ -519,6 +555,7 @@ def _run_round(
     cwd: Path,
     round_num: int = 1,
     progress_logger: Callable[[str], None] | None = None,
+    event_sink: Callable[..., None] | None = None,
 ) -> dict[str, DimResult]:
     """Fire all 4 dim reviews in parallel via ThreadPoolExecutor.
 
@@ -551,6 +588,7 @@ def _run_round(
                 primary=primary_agent,
                 fallbacks=DEFAULT_FALLBACKS[dim],
                 cwd=cwd,
+                event_sink=event_sink,
             )] = dim
         for future in as_completed(futures):
             dim = futures[future]
@@ -560,6 +598,8 @@ def _run_round(
             # it guarantees every dim gets a result entry for _failing_dims.
             try:
                 dr = future.result()
+            except WikiReviewError:
+                raise
             except Exception as exc:  # pragma: no cover
                 dr = DimResult(
                     dim=dim, agent="?", model="", score=0, verdict="ERROR",
@@ -588,6 +628,7 @@ def review_article(
     max_rounds: int = MAX_ROUNDS,
     shadow_mode: bool = False,
     cwd: Path | None = None,
+    event_sink: Callable[..., None] | None = None,
 ) -> tuple[ReviewReport, str]:
     """Run dimensional review on one article.
 
@@ -617,6 +658,7 @@ def review_article(
             agent_overrides=agent_overrides,
             cwd=cwd,
             round_num=round_num,
+            event_sink=event_sink,
         )
 
         all_fixes: list[Fix] = []

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -10,16 +10,21 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from agent_runtime import tool_config as wiki_tool_config_mod
+
 from scripts.agent_runtime import tool_config as tool_config_mod
 from scripts.agent_runtime.runner import _McpRuntimeObserver
 from scripts.build import linear_pipeline
+from scripts.wiki import review as wiki_review
 
 
 @pytest.fixture(autouse=True)
 def _clear_mcp_config_cache() -> None:
     tool_config_mod._load_mcp_config.cache_clear()
+    wiki_tool_config_mod._load_mcp_config.cache_clear()
     yield
     tool_config_mod._load_mcp_config.cache_clear()
+    wiki_tool_config_mod._load_mcp_config.cache_clear()
 
 
 def _write_mcp_config(path: Path, data: dict[str, Any]) -> Path:
@@ -194,6 +199,70 @@ def test_runtime_tool_config_emits_resolution_event_success(
     assert events[0][0] == "mcp_config_resolved"
     assert events[0][1]["resolution_status"] == "ok"
     assert events[0][1]["resolved_servers"] == ["sources"]
+
+
+def test_wiki_review_codex_emits_resolution_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(wiki_tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = wiki_review._tool_config_for(
+        "codex",
+        needs_mcp=True,
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config is not None
+    assert config["mcp_servers"]["sources"]["url"].endswith("/mcp")
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["reviewer"] == "codex"
+    assert events[0][1]["resolution_status"] == "ok"
+    assert events[0][1]["resolved_servers"] == ["sources"]
+
+
+def test_wiki_review_codex_raises_when_unconfigured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_mcp_config(tmp_path / ".mcp.json", {"mcpServers": {}})
+    monkeypatch.setattr(wiki_tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    with pytest.raises(wiki_review.WikiReviewError, match="tool-less"):
+        wiki_review._tool_config_for(
+            "codex",
+            needs_mcp=True,
+            event_sink=lambda event, **fields: events.append((event, fields)),
+        )
+
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["reviewer"] == "codex"
+    assert events[0][1]["resolution_status"] == "config_empty"
+    assert events[0][1]["resolved_servers"] == []
+
+
+def test_wiki_review_claude_no_raise_when_unconfigured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / ".mcp.json"
+    monkeypatch.setattr(wiki_tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = wiki_review._tool_config_for(
+        "claude",
+        needs_mcp=True,
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config is None
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["reviewer"] == "claude"
+    assert events[0][1]["resolution_status"] == "config_missing"
+    assert events[0][1]["resolved_servers"] == []
 
 
 def test_runtime_tool_config_claude_tools_emits_resolution_event_success(

--- a/tests/test_wiki_review.py
+++ b/tests/test_wiki_review.py
@@ -24,6 +24,7 @@ def test_run_round_emits_per_dim_progress_lines(tmp_path: Path, monkeypatch) -> 
         primary: str,
         fallbacks: tuple[str, ...],
         cwd: Path,
+        event_sink=None,
     ) -> DimResult:
         assert article_path.name == "article.md"
         assert article_text == "# Test\n"


### PR DESCRIPTION
## Summary
- add wiki review MCP pre-flight diagnostics event emission
- fail hard before dispatch when codex needs MCP but resolves no servers
- cover codex success/failure and claude non-fail-fast behavior

## Tests
- .venv/bin/pytest tests/test_mcp_init_observability.py tests/test_wiki_review*.py -v
- .venv/bin/ruff check scripts/wiki/review.py tests/test_mcp_init_observability.py tests/test_wiki_review.py

Closes #1806
Refs #1802, #1798