### PR TITLE
fix(ui): strip dark-theme CSS from orient/channels/comms playgrounds (#1828)

### DIFF
--- a/playgrounds/channels.html
+++ b/playgrounds/channels.html
@@ -5,13 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Agent Channels - #1190</title>
 <link rel="icon" href="data:,">
+<link rel="stylesheet" href="/monitor.css">
 <style>
-:root {
-  --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
-  --text: #e6edf3; --text2: #8b949e; --text3: #6e7681;
-  --green: #3fb950; --blue: #58a6ff; --red: #f85149; --yellow: #d29922;
-  --gray: #484f58; --purple: #bc8cff; --orange: #f0883e;
-}
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
 
@@ -21,7 +16,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .top-bar h1 { font-size: 18px; font-weight: 600; }
 .top-bar a { color: var(--text2); text-decoration: none; font-size: 13px; }
 .top-bar a:hover { color: var(--text); }
-.home-link { color: var(--blue) !important; font-weight: 600; white-space: nowrap; }
+.home-link { color: var(--accent); font-weight: 600; white-space: nowrap; }
 .banner { display: none; background: var(--red); color: white; padding: 8px 24px; font-size: 13px; text-align: center; }
 
 /* Main layout */
@@ -32,7 +27,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 /* Sidebar items */
 .channel-item { padding: 12px 16px; border-bottom: 1px solid var(--border); cursor: pointer; display: block; border-left: 3px solid transparent; }
 .channel-item:hover { background: var(--bg3); }
-.channel-item.active { border-left-color: var(--blue); background: var(--bg2); }
+.channel-item.active { border-left-color: var(--accent); background: var(--bg2); }
 .channel-name { font-weight: 600; font-size: 14px; margin-bottom: 4px; display: flex; justify-content: space-between; }
 .channel-meta { font-size: 11px; color: var(--text2); }
 .badge { background: var(--bg3); color: var(--text2); padding: 2px 6px; border-radius: 12px; font-size: 10px; font-weight: 600; }
@@ -53,7 +48,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .messages-area { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; gap: 16px; }
 .message { display: flex; flex-direction: column; gap: 4px; }
 .msg-header { display: flex; gap: 8px; align-items: baseline; font-size: 12px; margin-bottom: 2px; }
-.msg-author { font-weight: 600; color: var(--blue); }
+.msg-author { font-weight: 600; color: var(--accent); }
 .msg-author.gemini { color: var(--green); }
 .msg-author.claude { color: var(--purple); }
 .msg-author.user { color: var(--text); }
@@ -70,17 +65,17 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .post-success { color: var(--green); font-size: 12px; margin-bottom: 8px; display: none; }
 .post-row { display: flex; gap: 12px; margin-bottom: 8px; align-items: flex-end; }
 .post-textarea { flex: 1; background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 10px; border-radius: 6px; font-family: monospace; font-size: 12px; resize: vertical; min-height: 70px; }
-.post-textarea:focus { outline: none; border-color: var(--blue); }
+.post-textarea:focus { outline: none; border-color: var(--accent); }
 .post-controls { display: flex; justify-content: space-between; align-items: center; }
 .post-recipients { display: flex; gap: 12px; font-size: 12px; color: var(--text2); align-items: center; }
 .recipient-cb { display: flex; align-items: center; gap: 4px; cursor: pointer; }
-.post-btn { background: var(--blue); color: #fff; border: none; padding: 8px 24px; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; }
+.post-btn { background: var(--accent); color: #fff; border: none; padding: 8px 24px; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; }
 .post-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .post-btn:hover:not(:disabled) { opacity: 0.9; }
 .parent-id-container { font-size: 12px; color: var(--text3); display: flex; align-items: center; gap: 8px; }
 .parent-id-container input { background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 4px 8px; border-radius: 4px; width: 80px; font-family: monospace; font-size: 11px; }
 .msg-reply { font-size: 10px; color: var(--text3); cursor: pointer; }
-.msg-reply:hover { color: var(--blue); text-decoration: underline; }
+.msg-reply:hover { color: var(--accent); text-decoration: underline; }
 
 /* Deliveries Dropdown */
 .deliveries-toggle { cursor: pointer; font-size: 12px; display: flex; align-items: center; gap: 6px; color: var(--text2); }
@@ -90,7 +85,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .delivery-item { padding: 10px 12px; border-bottom: 1px solid var(--border); font-size: 11px; }
 .delivery-item:last-child { border-bottom: none; }
 .d-status { color: var(--yellow); font-weight: 600; text-transform: uppercase; font-size: 10px; }
-.d-agent { color: var(--blue); font-weight: 600; }
+.d-agent { color: var(--accent); font-weight: 600; }
 
 /* User-post visual treatment (#1731 pain #4) — orange accent so user
    contributions stand out from agent posts. The `::before` injects a
@@ -106,9 +101,9 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .thread-bar { padding: 8px 24px; border-bottom: 1px solid var(--border); background: var(--bg); display: none; align-items: center; gap: 12px; font-size: 12px; color: var(--text2); flex-shrink: 0; }
 .thread-bar.shown { display: flex; }
 .thread-bar select { background: var(--bg2); color: var(--text); border: 1px solid var(--border); padding: 4px 8px; border-radius: 4px; font-size: 12px; max-width: 480px; font-family: inherit; }
-.thread-bar select:focus { outline: none; border-color: var(--blue); }
+.thread-bar select:focus { outline: none; border-color: var(--accent); }
 .thread-bar .thread-meta { color: var(--text3); font-size: 11px; }
-.thread-bar .clear-filter { color: var(--blue); cursor: pointer; font-size: 11px; }
+.thread-bar .clear-filter { color: var(--accent); cursor: pointer; font-size: 11px; }
 .thread-bar .clear-filter:hover { text-decoration: underline; }
 
 /* Live-discussion strip (#1731 pain #5) — green pulse + per-agent
@@ -124,7 +119,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .discussion-strip .ds-participant { padding: 2px 8px; border-radius: 10px; font-size: 11px; background: var(--bg2); border: 1px solid var(--border); color: var(--text3); }
 .discussion-strip .ds-participant.done { color: var(--text); border-color: var(--text3); }
 .discussion-strip .ds-participant.agreed { color: var(--green); border-color: var(--green); background: rgba(63,185,80,0.15); font-weight: 600; }
-.discussion-strip .ds-jump { margin-left: auto; cursor: pointer; color: var(--blue); font-size: 11px; }
+.discussion-strip .ds-jump { margin-left: auto; cursor: pointer; color: var(--accent); font-size: 11px; }
 .discussion-strip .ds-jump:hover { text-decoration: underline; }
 
 /* Make sure messages-area stays the only flex-grow child below the
@@ -133,7 +128,6 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
    off-screen on narrow viewports. */
 .messages-area { flex: 1 1 0; min-height: 0; }
 </style>
-<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 

--- a/playgrounds/comms.html
+++ b/playgrounds/comms.html
@@ -5,13 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Agent Comms - ukraine-ops</title>
 <link rel="icon" href="data:,">
+<link rel="stylesheet" href="/monitor.css">
 <style>
-:root {
-  --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
-  --text: #e6edf3; --text2: #8b949e; --text3: #6e7681;
-  --green: #3fb950; --blue: #58a6ff; --red: #f85149; --yellow: #d29922;
-  --gray: #484f58; --purple: #bc8cff; --orange: #f0883e;
-}
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; padding: 24px; }
 
@@ -20,7 +15,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .top-bar h1 { font-size: 24px; font-weight: 700; }
 .top-bar a { color: var(--text2); text-decoration: none; font-size: 13px; }
 .top-bar a:hover { color: var(--text); }
-.home-link { color: var(--blue) !important; font-weight: 600; white-space: nowrap; }
+.home-link { color: var(--accent); font-weight: 600; white-space: nowrap; }
 .top-bar .refresh-info { font-size: 12px; color: var(--text3); }
 
 /* Health summary bar */
@@ -69,7 +64,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .feed-title .count { font-size: 11px; color: var(--text3); font-weight: 400; }
 
 .feed-item { background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; margin-bottom: 6px; font-size: 12px; }
-.feed-item:hover { border-color: var(--blue); }
+.feed-item:hover { border-color: var(--accent); }
 .feed-item .fi-top { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
 .feed-item .fi-track { font-size: 10px; padding: 1px 6px; border-radius: 4px; background: var(--bg3); color: var(--text2); }
 .feed-item .fi-age { font-size: 10px; color: var(--text3); }
@@ -94,7 +89,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .zombie-alert.warning { border-left: 3px solid var(--yellow); }
 .zombie-type { font-size: 12px; font-weight: 600; min-width: 120px; }
 .zombie-detail { font-size: 12px; color: var(--text2); flex: 1; }
-.zombie-action { font-size: 11px; color: var(--blue); cursor: pointer; white-space: nowrap; }
+.zombie-action { font-size: 11px; color: var(--accent); cursor: pointer; white-space: nowrap; }
 .zombie-action:hover { text-decoration: underline; }
 .no-zombies { font-size: 13px; color: var(--text3); padding: 12px; }
 
@@ -106,11 +101,11 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
   background: var(--bg3); border: 1px solid var(--border); color: var(--text); border-radius: 4px; padding: 6px 10px; font-size: 12px; font-family: inherit;
 }
 .compose-panel textarea { resize: vertical; min-height: 36px; }
-.compose-btn { background: var(--blue); color: #fff; border: none; border-radius: 4px; padding: 8px 20px; font-size: 12px; font-weight: 600; cursor: pointer; white-space: nowrap; }
+.compose-btn { background: var(--accent); color: #fff; border: none; border-radius: 4px; padding: 8px 20px; font-size: 12px; font-weight: 600; cursor: pointer; white-space: nowrap; }
 .compose-btn:hover { opacity: 0.85; }
 
 /* GitHub issue links */
-a.gh-issue { color: var(--blue); text-decoration: none; font-weight: 600; }
+a.gh-issue { color: var(--accent); text-decoration: none; font-weight: 600; }
 a.gh-issue:hover { text-decoration: underline; }
 
 /* Messages table */
@@ -133,7 +128,7 @@ a.gh-issue:hover { text-decoration: underline; }
 .tabs { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid var(--border); }
 .tab { padding: 8px 16px; font-size: 13px; color: var(--text2); cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
 .tab:hover { color: var(--text); }
-.tab.active { color: var(--text); border-bottom-color: var(--blue); font-weight: 600; }
+.tab.active { color: var(--text); border-bottom-color: var(--accent); font-weight: 600; }
 .tab-panel { display: none; }
 .tab-panel.active { display: block; }
 
@@ -180,7 +175,6 @@ a.gh-issue:hover { text-decoration: underline; }
 .module-link .ml-slug { font-weight: 600; }
 .module-link .ml-phase { font-size: 10px; color: var(--text3); }
 </style>
-<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 
@@ -259,7 +253,7 @@ a.gh-issue:hover { text-decoration: underline; }
     <div style="color:var(--text2);">
       This tab still shows the raw broker-messages table used by the <code>ask-claude</code> / <code>ask-gemini</code> / <code>ask-codex</code> CLI commands. Those commands are NOT deprecated and will keep working.
       <br><br>
-      For sustained multi-agent conversations, code reviews, design debates, and anything that benefits from pinned context + threaded history, use the new <a href="/channels.html" style="color:var(--blue);">Channels dashboard</a>. See <code>docs/best-practices/agent-bridge.md</code> for when to use each. (#1190)
+      For sustained multi-agent conversations, code reviews, design debates, and anything that benefits from pinned context + threaded history, use the new <a href="/channels.html" style="color:var(--accent);">Channels dashboard</a>. See <code>docs/best-practices/agent-bridge.md</code> for when to use each. (#1190)
     </div>
   </div>
   <!-- Compose panel -->

--- a/playgrounds/orient.html
+++ b/playgrounds/orient.html
@@ -5,16 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Orient - ukraine-ops</title>
 <link rel="icon" href="data:,">
+<link rel="stylesheet" href="/monitor.css">
 <style>
-:root {
-  --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
-  --text: #e6edf3; --text2: #8b949e; --text3: #6e7681;
-  --green: #3fb950; --blue: #58a6ff; --red: #f85149; --yellow: #d29922;
-  --gray: #484f58; --purple: #bc8cff; --orange: #f0883e; --cyan: #39d2c0;
-}
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
-a { color: var(--blue); text-decoration: none; }
+a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 .topbar { display: flex; align-items: center; gap: 16px; padding: 16px 24px; border-bottom: 1px solid var(--border); background: var(--bg2); position: sticky; top: 0; z-index: 10; }
 .topbar h1 { font-size: 22px; font-weight: 700; }
@@ -22,10 +17,10 @@ a:hover { text-decoration: underline; }
 .topbar .spacer { flex: 1; }
 .topbar .meta { text-align: right; font-size: 12px; color: var(--text3); }
 .btn { background: var(--bg3); border: 1px solid var(--border); color: var(--text); border-radius: 6px; padding: 7px 12px; font-size: 12px; cursor: pointer; }
-.btn:hover { border-color: var(--blue); color: var(--blue); }
+.btn:hover { border-color: var(--accent); color: var(--accent); }
 .container { max-width: 1400px; margin: 0 auto; padding: 24px; }
 .page-banner, .card-banner { display: none; border-radius: 8px; padding: 10px 12px; margin-bottom: 16px; background: rgba(248,81,73,0.14); border: 1px solid rgba(248,81,73,0.35); color: var(--red); font-size: 13px; }
-.section { background: var(--bg2); border: 1px solid var(--border); border-left: 3px solid var(--blue); border-radius: 10px; padding: 18px; margin-bottom: 16px; }
+.section { background: var(--bg2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 10px; padding: 18px; margin-bottom: 16px; }
 .section.orange { border-left-color: var(--orange); }
 .section.green { border-left-color: var(--green); }
 .section.yellow { border-left-color: var(--yellow); }
@@ -46,7 +41,7 @@ a:hover { text-decoration: underline; }
 .truncate { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .issue-row { display: grid; grid-template-columns: 72px 1fr 90px; gap: 12px; align-items: start; padding: 10px 0; border-bottom: 1px solid var(--border); }
 .issue-row:last-child { border-bottom: none; }
-.issue-num { font-weight: 700; color: var(--blue); }
+.issue-num { font-weight: 700; color: var(--accent); }
 .issue-title { font-size: 13px; font-weight: 500; margin-bottom: 6px; }
 .issue-meta { display: flex; flex-wrap: wrap; gap: 6px; }
 .pill { display: inline-flex; align-items: center; gap: 4px; border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 600; background: var(--bg3); color: var(--text2); }
@@ -64,7 +59,7 @@ a:hover { text-decoration: underline; }
 .mini-card .big { font-size: 32px; font-weight: 700; line-height: 1; margin-bottom: 8px; }
 .mini-card .sub { font-size: 12px; color: var(--text3); }
 .bar-track { width: 100%; height: 10px; background: var(--bg); border-radius: 999px; overflow: hidden; margin-top: 8px; }
-.bar-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--cyan), var(--blue)); }
+.bar-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--cyan), var(--accent)); }
 table { width: 100%; border-collapse: collapse; font-size: 13px; }
 th { text-align: left; padding: 8px 10px; color: var(--text3); font-size: 11px; text-transform: uppercase; border-bottom: 1px solid var(--border); }
 td { padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
@@ -83,7 +78,6 @@ tr:last-child td { border-bottom: none; }
   .issue-age { text-align: left; }
 }
 </style>
-<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -30,6 +32,26 @@ def test_index_page_uses_shared_parchment_monitor_design():
         "/wiki.html",
     ]:
         assert f'href="{href}"' in html
+
+
+@pytest.mark.parametrize(
+    ("filename", "active_link", "heading"),
+    [
+        ("orient.html", '<a class="active" href="/orient.html">Orient</a>', "One-page session orientation snapshot"),
+        ("channels.html", '<a class="active" href="/channels.html">Channels</a>', "Agent Channels"),
+        ("comms.html", '<a class="active" href="/comms.html">Comms</a>', "Agent Comms"),
+    ],
+)
+def test_playground_page_uses_shared_parchment_monitor_design(filename, active_link, heading):
+    html = (ROOT / "playgrounds" / filename).read_text(encoding="utf-8")
+    assert '<link rel="stylesheet" href="/monitor.css">' in html
+    assert 'class="monitor-nav"' in html
+    assert 'aria-label="Monitor sections"' in html
+    assert active_link in html
+    assert heading in html
+    assert ":root" not in html
+    assert "!important" not in html
+    assert "#0d1117" not in html
 
 
 def test_channels_page_has_shareable_deeplink_contract():


### PR DESCRIPTION
## Summary

Mirrors the index.html cleanup from PR #1839 across the remaining three playground HTMLs. Removes inline `:root` dark-theme color vars and any `!important` workarounds — `monitor.css` parchment palette wins on specificity now.

Adds contract tests asserting `#0d1117` stays out of each file (regression guard, same shape as the `index.html` test added in #1839).

## Files
- `playgrounds/orient.html` — dark-theme :root removed, monitor.css linked
- `playgrounds/channels.html` — same
- `playgrounds/comms.html` — same
- `tests/test_monitor_ui_contracts.py` — 3 new contract tests

## Verification
Codex's dispatch report (commit `1f1a5b047e`):
- `.venv/bin/pytest tests/test_monitor_ui_contracts.py -v` — passing
- Ruff clean
- All 8 ALLOWED_ROOTS still serve cleanly via the parchment palette

Closes #1828
Refs #1839 (the index.html fix that established this pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)