### PR TITLE
feat(bridge): channel TTL + auto-expire + orient surfacing (#1779 P0)

### DIFF
--- a/playgrounds/orient.html
+++ b/playgrounds/orient.html
@@ -134,6 +134,11 @@ tr:last-child td { border-bottom: none; }
     <div id="delegate-content" class="empty">Loading...</div>
   </section>
 
+  <section class="section orange">
+    <div class="section-header"><h2>&#128229; Bridge Inbox</h2><div class="muted" id="bridge-muted"></div></div>
+    <div id="bridge-content" class="empty">Loading...</div>
+  </section>
+
   <section class="section purple">
     <div class="section-header"><h2>&#128172; Active Discussions</h2><div class="muted" id="discussions-muted"></div></div>
     <div id="discussions-content" class="empty">Loading...</div>
@@ -176,6 +181,12 @@ function formatTimestamp(value) {
 function formatAgeDays(days) {
   if (typeof days !== 'number') return '—';
   return days === 0 ? '0d' : `${days}d`;
+}
+
+function formatAgeHours(hours) {
+  if (typeof hours !== 'number') return '—';
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  return `${hours.toFixed(1)}h`;
 }
 
 function truncate(value, max) {
@@ -308,6 +319,25 @@ function renderDelegate(delegate) {
   `;
 }
 
+function renderBridgePending(bridgePending) {
+  const rows = Object.entries(bridgePending || {})
+    .filter(([, item]) => item && typeof item.count === 'number' && item.count > 0)
+    .sort((a, b) => (b[1].oldest_hours || 0) - (a[1].oldest_hours || 0));
+  const total = rows.reduce((sum, [, item]) => sum + (item.count || 0), 0);
+  document.getElementById('bridge-muted').textContent = `${total} pending`;
+  if (!rows.length) {
+    document.getElementById('bridge-content').innerHTML = '<div class="empty">No pending bridge deliveries</div>';
+    return;
+  }
+  document.getElementById('bridge-content').innerHTML = `<table><thead><tr><th>Agent</th><th>Pending</th><th>Oldest</th></tr></thead><tbody>${
+    rows.map(([agent, item]) => `<tr>
+      <td class="mono">${escapeHtml(agent)}</td>
+      <td><span class="pill ${item.oldest_hours >= 12 ? 'err' : item.oldest_hours >= 2 ? 'warn' : 'ok'}">${item.count}</span></td>
+      <td>${formatAgeHours(item.oldest_hours)}</td>
+    </tr>`).join('')
+  }</tbody></table>`;
+}
+
 function discussionAge(value) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return 'unknown age';
@@ -417,6 +447,7 @@ async function loadOrient() {
     renderPipeline(data.pipeline || {});
     renderRuntime(data.runtime || {});
     renderDelegate(data.delegate || {});
+    renderBridgePending(data.bridge_pending || {});
     renderDiscussions(discussions || {});
     if (discussions && discussions.error) {
       document.getElementById('discussions-content').innerHTML = `<div class="empty">Discussion lookup unavailable: ${escapeHtml(discussions.error)}</div>`;

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -86,6 +86,7 @@ VALID_DELIVERY_STATUSES = (
     "dispatched",
     "delivered",
     "failed",
+    "expired",
 )
 VALID_DELIVERY_ERROR_KINDS = (
     "rate_limited",
@@ -159,6 +160,11 @@ def _parse_iso(value: str) -> datetime:
 
 def _iso_after(value: str, *, seconds: int) -> str:
     return (_parse_iso(value) + timedelta(seconds=seconds)).isoformat()
+
+
+def _age_hours(from_iso: str, *, now: datetime | None = None) -> float:
+    current = now or datetime.now(UTC)
+    return max((current - _parse_iso(from_iso)).total_seconds() / 3600, 0.0)
 
 
 def context_sha256(path: Path) -> str:
@@ -704,7 +710,7 @@ def create_channel(
     conn = get_db()
     try:
         existing = conn.execute(
-            "SELECT name, description, include, subscribers, created_at "
+            "SELECT name, description, include, subscribers, created_at, max_age_hours "
             "FROM channels WHERE name = ?",
             (name,),
         ).fetchone()
@@ -732,6 +738,7 @@ def create_channel(
             "include": include,
             "subscribers": subscribers,
             "created_at": _now_iso(),
+            "max_age_hours": 24,
         }
     finally:
         conn.close()
@@ -742,7 +749,7 @@ def get_channel(name: str) -> dict[str, Any] | None:
     conn = get_db()
     try:
         row = conn.execute(
-            "SELECT name, description, include, subscribers, created_at "
+            "SELECT name, description, include, subscribers, created_at, max_age_hours "
             "FROM channels WHERE name = ?",
             (name,),
         ).fetchone()
@@ -756,7 +763,7 @@ def list_channels() -> list[dict[str, Any]]:
     conn = get_db()
     try:
         rows = conn.execute(
-            "SELECT name, description, include, subscribers, created_at "
+            "SELECT name, description, include, subscribers, created_at, max_age_hours "
             "FROM channels ORDER BY created_at ASC"
         ).fetchall()
         return [_row_to_channel(r) for r in rows]
@@ -776,7 +783,39 @@ def _row_to_channel(row) -> dict[str, Any]:
         "include": [s for s in row["include"].split(",") if s],
         "subscribers": [s for s in row["subscribers"].split(",") if s],
         "created_at": row["created_at"],
+        "max_age_hours": int(row["max_age_hours"] or 24),
     }
+
+
+def set_channel_ttl(name: str, hours: int) -> dict[str, Any]:
+    """Set the pending-delivery TTL for one channel."""
+    if hours <= 0:
+        raise ValueError("max_age_hours must be a positive integer")
+
+    conn = get_db()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        cursor = conn.execute(
+            "UPDATE channels SET max_age_hours = ? WHERE name = ?",
+            (hours, name),
+        )
+        if cursor.rowcount == 0:
+            raise ValueError(f"channel '{name}' does not exist")
+        row = conn.execute(
+            """
+            SELECT name, description, include, subscribers, created_at, max_age_hours
+            FROM channels
+            WHERE name = ?
+            """,
+            (name,),
+        ).fetchone()
+        conn.commit()
+        return _row_to_channel(row)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
 
 # ── Posting ───────────────────────────────────────────────────────────
@@ -1164,7 +1203,7 @@ def mark_delivery(
                 """,
                 (status, delivered_at or now, error, delivery_id),
             )
-        elif status == "failed":
+        elif status in {"failed", "expired"}:
             conn.execute(
                 """
                 UPDATE deliveries
@@ -1266,7 +1305,7 @@ def mark_delivery_delivered(
         ).fetchone()
         if not row:
             raise ValueError(f"delivery '{delivery_id}' not found")
-        if row["status"] in {"delivered", "failed"}:
+        if row["status"] in {"delivered", "failed", "expired"}:
             if row["attempt_count"] != expected_attempt_count:
                 raise StaleClaimError(f"Stale claim for delivery {delivery_id}: expected attempt {expected_attempt_count}")
             conn.commit()
@@ -1321,7 +1360,7 @@ def mark_delivery_failed(
         ).fetchone()
         if not row:
             raise ValueError(f"delivery '{delivery_id}' not found")
-        if row["status"] in {"delivered", "failed"}:
+        if row["status"] in {"delivered", "failed", "expired"}:
             if row["attempt_count"] != expected_attempt_count:
                 raise StaleClaimError(f"Stale claim for delivery {delivery_id}: expected attempt {expected_attempt_count}")
             conn.commit()
@@ -1382,6 +1421,48 @@ def release_expired_leases(now: str | None = None) -> int:
                 lease_until=NULL
             WHERE status='processing'
               AND lease_until < ?
+            """,
+            (now,),
+        )
+        conn.commit()
+        return cursor.rowcount
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def expire_stale_deliveries(now: str | None = None) -> int:
+    """Mark pending deliveries older than their channel TTL as expired."""
+    now = now or _now_iso()
+    conn = get_db()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        cursor = conn.execute(
+            """
+            UPDATE deliveries
+            SET status = 'expired',
+                error = (
+                    SELECT 'auto-expired (>' || COALESCE(c.max_age_hours, 24)
+                           || 'h pending, channel=' || cm.channel || ')'
+                    FROM channel_messages cm
+                    JOIN channels c ON c.name = cm.channel
+                    WHERE cm.message_id = deliveries.message_id
+                ),
+                lease_until = NULL,
+                retry_after = NULL,
+                last_error_kind = NULL
+            WHERE status = 'pending'
+              AND EXISTS (
+                    SELECT 1
+                    FROM channel_messages cm
+                    JOIN channels c ON c.name = cm.channel
+                    WHERE cm.message_id = deliveries.message_id
+                      AND (
+                            julianday(?) - julianday(cm.created_at)
+                          ) * 24.0 > COALESCE(c.max_age_hours, 24)
+              )
             """,
             (now,),
         )
@@ -1459,3 +1540,33 @@ def pending_deliveries_for(agent: str) -> list[dict[str, Any]]:
         return [_row_to_pending_delivery(r) for r in rows]
     finally:
         conn.close()
+
+
+def bridge_pending_summary(now: str | None = None) -> dict[str, dict[str, float | int]]:
+    """Return per-agent pending counts and oldest pending age in hours."""
+    current = _parse_iso(now) if now else datetime.now(UTC)
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            """
+            SELECT d.to_agent, COUNT(*) AS count, MIN(cm.created_at) AS oldest_created_at
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            WHERE d.status = 'pending'
+            GROUP BY d.to_agent
+            ORDER BY d.to_agent ASC
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    summary: dict[str, dict[str, float | int]] = {}
+    for row in rows:
+        oldest = row["oldest_created_at"]
+        if not oldest:
+            continue
+        summary[str(row["to_agent"])] = {
+            "count": int(row["count"]),
+            "oldest_hours": round(_age_hours(str(oldest), now=current), 1),
+        }
+    return summary

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -12,6 +12,7 @@ everything else lives here.
 ab channel new <name> [--description D] [--include C,...] [--agents A,...]
 ab channel list
 ab channel info <name>
+ab channel set-ttl <name> <hours>
 ab channel context <name> [--edit] [--show]
 ab channel tail <name> [--n N] [--thread TID]
 ab channel watch <thread_id> [--follow] [--event-stream]
@@ -235,6 +236,18 @@ def register_channel_commands(subparsers: Any) -> None:
         help="Show channel metadata + context preview + pending counts",
     )
     info_parser.add_argument("name", help="Channel name")
+
+    # ab channel set-ttl
+    ttl_parser = channel_sub.add_parser(
+        "set-ttl",
+        help="Set pending-delivery auto-expire TTL for a channel",
+    )
+    ttl_parser.add_argument("name", help="Channel name")
+    ttl_parser.add_argument(
+        "hours",
+        type=int,
+        help="Positive integer TTL in hours",
+    )
 
     # ab channel context
     ctx_parser = channel_sub.add_parser(
@@ -536,6 +549,8 @@ def _dispatch_channel_group(args) -> int:
         return _handle_channel_list(args)
     if sub == "info":
         return _handle_channel_info(args)
+    if sub == "set-ttl":
+        return _handle_channel_set_ttl(args)
     if sub == "context":
         return _handle_channel_context(args)
     if sub == "tail":
@@ -628,6 +643,8 @@ def _print_inbox_run_summary(summary: Any, *, duration_s: float) -> None:
 def _query_inbox_show(agent: str) -> dict[str, Any]:
     """Return read-only inbox status details for one agent."""
     from ._db import get_db
+
+    _channels.expire_stale_deliveries()
 
     now = _now_utc()
     failed_cutoff = (now - timedelta(hours=24)).isoformat()
@@ -815,6 +832,7 @@ def _handle_channel_info(args) -> int:
     print(f"created:     {ch['created_at']}")
     print(f"includes:    {', '.join(ch['include']) or '(none)'}")
     print(f"subscribers: {', '.join(ch['subscribers']) or '(none)'}")
+    print(f"ttl:         {ch['max_age_hours']}h")
 
     # Context preview
     ctx = _channels.load_channel_context(args.name)
@@ -829,6 +847,19 @@ def _handle_channel_info(args) -> int:
         print(f"\ncontext.md:  {ctx_path} (missing)")
     if ctx["missing"]:
         print(f"⚠️  missing context for: {', '.join(ctx['missing'])}")
+    return 0
+
+
+def _handle_channel_set_ttl(args) -> int:
+    if args.hours <= 0:
+        print("❌ hours must be a positive integer", file=sys.stderr)
+        return 2
+    try:
+        ch = _channels.set_channel_ttl(args.name, args.hours)
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+    print(f"✅ channel '{ch['name']}' TTL set to {ch['max_age_hours']}h")
     return 0
 
 
@@ -1042,6 +1073,8 @@ def _handle_inbox_run(args) -> int:
 
     if _reject_non_cli_agent(args.agent, "ab inbox run"):
         return 1
+
+    _channels.expire_stale_deliveries()
 
     until_idle = not args.once
     if args.until_idle:

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -85,7 +85,8 @@ CREATE TABLE IF NOT EXISTS channels (
     description TEXT DEFAULT '',
     include TEXT DEFAULT '',          -- comma-sep channels to auto-include (e.g. "shared")
     subscribers TEXT DEFAULT '',      -- comma-sep agents (e.g. "claude,gemini,codex")
-    context_sha256 TEXT DEFAULT ''    -- last-seen sha256 of {channel}/context.md
+    context_sha256 TEXT DEFAULT '',   -- last-seen sha256 of {channel}/context.md
+    max_age_hours INTEGER DEFAULT 24  -- TTL for pending deliveries before auto-expire
 );
 
 CREATE TABLE IF NOT EXISTS channel_messages (
@@ -122,7 +123,7 @@ CREATE TABLE IF NOT EXISTS deliveries (
     message_id TEXT NOT NULL,             -- FK → channel_messages.message_id
     to_agent TEXT NOT NULL,               -- claude/gemini/codex
     to_model TEXT,                        -- target model (nullable)
-    status TEXT DEFAULT 'pending',        -- pending/processing/dispatched/delivered/failed
+    status TEXT DEFAULT 'pending',        -- pending/processing/dispatched/delivered/failed/expired
     dispatched_at TEXT,
     delivered_at TEXT,
     error TEXT,
@@ -309,6 +310,13 @@ def get_db():
         if not cursor.fetchone():
             conn.executescript(_CHANNELS_SCHEMA)
         else:
+            cursor.execute("PRAGMA table_info(channels)")
+            channel_columns = [row[1] for row in cursor.fetchall()]
+            if "max_age_hours" not in channel_columns:
+                conn.execute(
+                    "ALTER TABLE channels ADD COLUMN max_age_hours INTEGER DEFAULT 24"
+                )
+
             cursor.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='deliveries'"
             )

--- a/scripts/ai_agent_bridge/_inbox.py
+++ b/scripts/ai_agent_bridge/_inbox.py
@@ -890,6 +890,7 @@ def run_inbox(
     if stop_after_seconds is not None and stop_after_seconds <= 0:
         raise ValueError("stop_after_seconds must be > 0 when provided")
     _validate_hard_timeout_seconds(hard_timeout, field_name="hard_timeout")
+    _channels.expire_stale_deliveries()
 
     claimed_total = 0
     delivered_total = 0

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -197,6 +197,7 @@ ORIENT_SECTION_TTLS: dict[str, float] = {
     "pipeline": 0.0,
     "runtime": 60.0,
     "delegate": 30.0,
+    "bridge_pending": 15.0,
     "wiki": 120.0,
     "governance": 120.0,
     "health": 15.0,
@@ -209,6 +210,7 @@ ORIENT_SECTION_SOURCES: dict[str, str] = {
     "pipeline": "fs",
     "runtime": "fs",
     "delegate": "fs",
+    "bridge_pending": "sqlite",
     "wiki": "fs",
     "governance": "fs",
     "health": "probe",
@@ -370,6 +372,12 @@ def _collect_delegate_orient_data() -> dict:
         "active_count": delegate_api.active_delegate_count(),
         "recent": recent["tasks"],
     }
+
+
+def _collect_bridge_pending_orient_data() -> dict:
+    from scripts.ai_agent_bridge import _channels
+
+    return _channels.bridge_pending_summary()
 
 
 def _collect_wiki_orient_data() -> dict:
@@ -586,6 +594,7 @@ async def orient(fresh: bool = False):
         (pipeline_info, pipeline_meta),
         (runtime_info, runtime_meta),
         (delegate_info, delegate_meta),
+        (bridge_pending_info, bridge_pending_meta),
         (wiki_info, wiki_meta),
         (governance_info, governance_meta),
         (health_info, health_meta),
@@ -604,6 +613,11 @@ async def orient(fresh: bool = False):
             "delegate",
             _collect_delegate_orient_data,
             {"active_count": 0, "recent": []},
+        ),
+        _cached_orient_section(
+            "bridge_pending",
+            _collect_bridge_pending_orient_data,
+            {},
         ),
         _cached_orient_section("wiki", _collect_wiki_orient_data, {"by_track": {}}),
         _cached_orient_section(
@@ -628,6 +642,7 @@ async def orient(fresh: bool = False):
         "pipeline": pipeline_meta,
         "runtime": runtime_meta,
         "delegate": delegate_meta,
+        "bridge_pending": bridge_pending_meta,
         "wiki": wiki_meta,
         "governance": {**governance_meta, **governance_info},
         "health": health_meta,
@@ -656,6 +671,7 @@ async def orient(fresh: bool = False):
         "pipeline": pipeline_info,
         "runtime": runtime_info,
         "delegate": delegate_info,
+        "bridge_pending": bridge_pending_info,
         "wiki": wiki_info,
         "governance": governance_info,
         "health": health_info,

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -49,6 +49,18 @@ def _delivery_row(delivery_id: str) -> sqlite3.Row:
         conn.close()
 
 
+def _set_message_created_at(message_id: str, created_at: str) -> None:
+    conn = _db.get_db()
+    try:
+        conn.execute(
+            "UPDATE channel_messages SET created_at = ? WHERE message_id = ?",
+            (created_at, message_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 # 1. Channel CRUD
 
 def test_create_channel_basic():
@@ -60,6 +72,51 @@ def test_create_channel_basic():
     listed = _channels.list_channels()
     assert len(listed) == 1
     assert listed[0]["name"] == "my-topic"
+
+
+def test_get_db_migrates_channel_max_age_hours(isolate_db):
+    """Existing bridge DBs gain the default channel TTL column."""
+    for suffix in ("", "-wal", "-shm"):
+        path = Path(f"{isolate_db}{suffix}")
+        if path.exists():
+            path.unlink()
+    conn = sqlite3.connect(isolate_db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE channels (
+                name TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                include TEXT DEFAULT '',
+                subscribers TEXT DEFAULT '',
+                context_sha256 TEXT DEFAULT ''
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO channels (name, created_at) VALUES ('legacy', ?)",
+            (_iso_at(0),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    migrated = _db.get_db()
+    try:
+        columns = [
+            row["name"]
+            for row in migrated.execute("PRAGMA table_info(channels)").fetchall()
+        ]
+        ttl = migrated.execute(
+            "SELECT max_age_hours FROM channels WHERE name = 'legacy'"
+        ).fetchone()["max_age_hours"]
+    finally:
+        migrated.close()
+
+    assert "max_age_hours" in columns
+    assert ttl == 24
+
 
 def test_create_channel_duplicate_exist_ok_returns_existing():
     """Verify idempotent creation returns the existing channel unmodified."""
@@ -431,6 +488,73 @@ def test_pending_deliveries_for_agent_ordered_oldest_first():
     assert len(q) == 2
     assert q[0]["body"] == "msg1"
     assert q[1]["body"] == "msg2"
+
+
+def test_expire_stale_deliveries_marks_aged_pending_as_expired():
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic",
+        "user",
+        "stale",
+        to_agents=["claude"],
+        auto_snapshot=False,
+    )
+    _set_message_created_at(str(res["message_id"]), _iso_at(0))
+
+    expired = _channels.expire_stale_deliveries(now=_iso_at(25 * 3600))
+
+    assert expired == 1
+    row = _delivery_row(str(res["delivery_ids"][0]))
+    assert row["status"] == "expired"
+    assert row["error"] == "auto-expired (>24h pending, channel=topic)"
+
+
+def test_expire_stale_deliveries_respects_channel_ttl():
+    _channels.create_channel("short-ttl")
+    _channels.create_channel("long-ttl")
+    _channels.set_channel_ttl("short-ttl", 2)
+    _channels.set_channel_ttl("long-ttl", 48)
+    short = _channels.post(
+        "short-ttl",
+        "user",
+        "short",
+        to_agents=["claude"],
+        auto_snapshot=False,
+    )
+    long = _channels.post(
+        "long-ttl",
+        "user",
+        "long",
+        to_agents=["claude"],
+        auto_snapshot=False,
+    )
+    _set_message_created_at(str(short["message_id"]), _iso_at(0))
+    _set_message_created_at(str(long["message_id"]), _iso_at(0))
+
+    expired = _channels.expire_stale_deliveries(now=_iso_at(3 * 3600))
+
+    assert expired == 1
+    assert _delivery_row(str(short["delivery_ids"][0]))["status"] == "expired"
+    assert _delivery_row(str(long["delivery_ids"][0]))["status"] == "pending"
+
+
+def test_expire_stale_deliveries_skips_already_delivered():
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic",
+        "user",
+        "handled",
+        to_agents=["claude"],
+        auto_snapshot=False,
+    )
+    delivery_id = str(res["delivery_ids"][0])
+    _set_message_created_at(str(res["message_id"]), _iso_at(0))
+    _channels.mark_delivery(delivery_id, "delivered")
+
+    expired = _channels.expire_stale_deliveries(now=_iso_at(25 * 3600))
+
+    assert expired == 0
+    assert _delivery_row(delivery_id)["status"] == "delivered"
 
 # 6. Concurrency
 

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -348,6 +348,18 @@ def test_post_from_existing_codex_path_still_works(capsys):
     assert _channels.read("topic")[0]["from_agent"] == "codex"
 
 
+def test_channel_set_ttl_persists(capsys):
+    _channels.create_channel("topic")
+
+    exit_code = _run_cli(["channel", "set-ttl", "topic", "6"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "TTL set to 6h" in captured.out
+    assert _channels.get_channel("topic")["max_age_hours"] == 6
+
+
 @patch("agent_runtime.runner.invoke")
 def test_discuss_replies_create_delivered_reply_deliveries(mock_invoke, monkeypatch, capsys):
     _channels.create_channel("shared")

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -47,6 +47,7 @@ def _patch_orient_sources(monkeypatch) -> None:
         lambda: {"agents": ["codex"], "recent_outcomes": {"ok": 1, "error": 0, "rate_limited": 0}, "headroom": {"codex": True}},
     )
     monkeypatch.setattr(api_main, "_collect_delegate_orient_data", lambda: {"active_count": 0, "recent": []})
+    monkeypatch.setattr(api_main, "_collect_bridge_pending_orient_data", lambda: {})
     monkeypatch.setattr(api_main, "_collect_wiki_orient_data", lambda: {"by_track": {"hist": {"compiled": 1, "total": 2, "pct": 50.0}}})
     monkeypatch.setattr(api_main, "_collect_health_orient_data", lambda: {"api": True, "mcp_rag": False, "sources_db": True, "message_broker": True})
     monkeypatch.setattr(api_main, "_collect_session_hints_orient_data", lambda: [{"file": "docs/session-state/example.md", "first_line": "# Example"}])
@@ -59,7 +60,18 @@ def test_orient_returns_all_top_level_keys(monkeypatch):
 
     assert response.status_code == 200
     data = response.json()
-    expected = {"generated_at", "git", "issues", "pipeline", "runtime", "delegate", "wiki", "health", "session_hints"}
+    expected = {
+        "generated_at",
+        "git",
+        "issues",
+        "pipeline",
+        "runtime",
+        "delegate",
+        "bridge_pending",
+        "wiki",
+        "health",
+        "session_hints",
+    }
     assert expected <= set(data)
 
 
@@ -77,6 +89,24 @@ def test_orient_swallows_failing_subquery(monkeypatch):
     data = response.json()
     assert data["git"]["error"] == "git failed"
     assert data["runtime"]["agents"] == ["codex"]
+
+
+def test_orient_includes_bridge_pending_field(monkeypatch):
+    _patch_orient_sources(monkeypatch)
+    monkeypatch.setattr(
+        api_main,
+        "_collect_bridge_pending_orient_data",
+        lambda: {"claude": {"count": 1, "oldest_hours": 6.5}},
+    )
+
+    response = client.get("/api/orient")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["bridge_pending"] == {
+        "claude": {"count": 1, "oldest_hours": 6.5}
+    }
+    assert "bridge_pending" in data["meta"]
 
 
 def test_orient_completes_within_500ms(monkeypatch):


### PR DESCRIPTION
## Summary

Channel TTL + auto-expire + /api/orient surfacing — solves the deliveries-rot-for-days failure mode (real consequence: 2026-05-07 had a 2.3-day-old PR re-review request that was meaningless because the PR had already merged).

## Changes
- `channels.max_age_hours` column (default 24h); per-channel override via `ab channel set-ttl <channel> <hours>`
- `expire_stale_deliveries()` janitor with pending → expired transition + audit-friendly error text
- Janitor wired into `inbox show` + `inbox run` so visible state is fresh
- `/api/orient.bridge_pending` field with per-agent count + oldest_hours

## Verification
Codex's dispatch report at commit `c4ab8fa8a5` — see PR commits.

Closes #1779 (P0 scope; P1+ deferred to follow-up if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)