### PR TITLE
docs: V7-only sweep across CLAUDE.md + pipeline rule + 3 skill files

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -12,7 +12,7 @@ The user provides one of:
 
 1. **No args or "diff"**: Review only files changed since last commit (`git diff --name-only` + `git diff --cached --name-only`)
 2. **"all"**: Review all staged + unstaged changes
-3. **Specific files**: `scripts/build/v6_build.py scripts/build/dispatch.py`
+3. **Specific files**: `scripts/build/v7_build.py scripts/build/linear_pipeline.py`
 
 ## Execute
 

--- a/.agents/skills/code-review/code-review-checklist.md
+++ b/.agents/skills/code-review/code-review-checklist.md
@@ -33,30 +33,37 @@ If ruff finds unfixable issues, report them. If `--fix` resolves them, note what
 For each changed Python file, check for:
 
 ### 3a. Model constants
+
 - Any hardcoded model strings (`"claude-opus-4-6"`, `"claude-sonnet-4-6"`, `"gemini-3.1-pro-preview"`, `"gemini-3-flash-preview"`)?
 - Should they come from `batch_gemini_config.py` instead?
 
 ### 3b. Import hygiene
+
 - Any `import re` or `import json` inside a function when already imported at module level?
 - Any unused imports?
 
 ### 3c. SQLite connection management
+
 - Any `sqlite3.connect()` calls that open a new connection per invocation instead of reusing?
 - Any connections not closed in a `finally` block or context manager?
 
 ### 3d. Silent failures
+
 - Any bare `except: pass` or `except Exception: pass` that swallows errors?
 - Any functions that return `None` on failure without logging?
 
 ### 3e. Dead code
+
 - Any functions defined but never called? (Check with grep for the function name across the codebase)
 - Any unreachable branches (code after `return`)?
 
 ### 3f. Type hints
+
 - Do new/changed functions have return type annotations?
 - Do function parameters have type annotations?
 
 ### 3g. Test coverage
+
 - Does every new/changed function have a corresponding test?
 - If not, flag which functions need tests.
 
@@ -93,7 +100,7 @@ If Gemini is available, send the diff for adversarial review:
 ```
 
 Find relevant tests by matching changed file names to test files:
-- `scripts/build/v6_build.py` → `tests/test_v6_build.py`
+- `scripts/build/v7_build.py` → `tests/test_v7_writer_dispatch.py`
 - `scripts/audit/core.py` → `tests/test_audit_core.py`
 - etc.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 Detailed standards in `docs/best-practices/`. Read the relevant doc before working in that area.
 
 | Topic | Doc |
-|-------|-----|
+| --- | --- |
 | Prompt engineering | [`prompt-engineering.md`](docs/best-practices/prompt-engineering.md) |
 | Context engineering | [`context-engineering.md`](docs/best-practices/context-engineering.md) |
 | Code quality | [`code-quality.md`](docs/best-practices/code-quality.md) |
@@ -48,7 +48,7 @@ Detailed standards in `docs/best-practices/`. Read the relevant doc before worki
 - **Monitoring API**: [`docs/MONITOR-API.md`](docs/MONITOR-API.md)
 - **Workstreams & priorities**: [`docs/WORKSTREAMS.md`](docs/WORKSTREAMS.md)
 - **Module manifest**: `curriculum/l2-uk-en/curriculum.yaml` — source of truth for module ordering and slug mapping
-- **Build pipeline**: `.venv/bin/python scripts/build/v6_build.py {level} {num} [--step {step}] [--writer {gemini|claude}]`
+- **Build pipeline**: `.venv/bin/python scripts/build/v7_build.py {level} {slug} [--writer {claude-tools|gemini-tools|codex-tools}]`
 - **Decision journal**: [`docs/decisions/`](docs/decisions/) — architectural decisions with expiry dates. Check: `.venv/bin/python scripts/check_decisions.py`
 
 ---
@@ -74,8 +74,8 @@ Detailed standards in `docs/best-practices/`. Read the relevant doc before worki
 ### Claude Code Power Features
 
 | Feature | How | When |
-|---------|-----|------|
-| `Monitor` tool | Stream stdout events as notifications | **Build monitoring.** NEVER poll manually — use Monitor with `grep --line-buffered` to filter v6_build.py JSONL events. See below. |
+| --- | --- | --- |
+| `Monitor` tool | Stream stdout events as notifications | **Build monitoring.** Use when the USER runs a V7 build; agents never invoke `v7_build.py`. Filter JSONL events with `grep --line-buffered '^{\"event\"'`. See below. |
 | `/effort` | Set model effort dynamically mid-session | Levels: `low` / `medium` / `high` / `xhigh` / `max`. `low`: config/typo fixes. `medium`: code fixes (default). `xhigh`: content review, plan review, module building, linguistic analysis on Opus 4.7 — Anthropic notes Opus 4.7 at `high` is weaker than prior versions, so **use `xhigh` where we previously used `high`**. `max`: reserve for deep architecture / adversarial reviews where cost is justified. |
 | Transcript search | `Ctrl+O` then `/` to search, `n`/`N` to navigate | Finding previous discussions in long sessions |
 | `--bare` flag | `claude -p "..." --bare` | Scripted calls (agent bridge) — skips hooks/LSP/plugins for speed |
@@ -89,16 +89,18 @@ Detailed standards in `docs/best-practices/`. Read the relevant doc before worki
 
 **NEVER poll builds with ScheduleWakeup or manual loops.** Use the `Monitor` tool:
 
+Only used when monitoring a user-run V7 build; agents do not invoke `v7_build.py` themselves.
+
 ```
 Monitor(
-    command=".venv/bin/python -u scripts/build/v6_build.py {level} {start} --range {end} --resume 2>&1 | grep --line-buffered '^{\"event\"'",
-    description="{level} build events",
+    command=".venv/bin/python -u scripts/build/v7_build.py {level} {slug} 2>&1 | grep --line-buffered '^{\"event\"'",
+    description="V7 build events for {level}/{slug}",
     persistent=True,
     timeout_ms=3600000
 )
 ```
 
-v6_build.py emits JSONL events: `module_start`, `phase_done`, `review_score`, `module_done`, `module_failed`, `batch_done`. Each line becomes a notification — zero polling overhead.
+`v7_build.py` emits JSONL events from the wrapper and `linear_pipeline.py`: single-module lifecycle notifications such as `phase_done`, `review_score`, and `module_done`; writer/reviewer telemetry such as `writer_cot_emit`, `writer_tool_call`, `writer_end_gate`, `writer_tool_theatre`, `phase_writer_summary`, `mcp_config_resolved`, `reviewer_dim_evidence`, `reviewer_audit_call`, and `phase_review_summary`; and correction diagnostics `writer_correction_unparseable`, `reviewer_fixes_unparseable`, `reviewer_fixes_anchor_unmatched`. Each line becomes a notification — zero polling overhead.
 
 For state queries without running builds, use the Monitor API (`docs/MONITOR-API.md`):
 - Track health: `curl -s http://localhost:8765/api/state/track-health/a1`

--- a/claude_extensions/rules/pipeline.md
+++ b/claude_extensions/rules/pipeline.md
@@ -11,26 +11,16 @@ paths:
 
 <critical>
 
-**Two pipelines coexist during the reboot transition:**
+**V7 is the only live build pipeline** (`scripts/build/v7_build.py` driving `scripts/build/linear_pipeline.py`). v5/v6/v4/v3 files may remain on disk for forensic reference, but they must not be invoked, extended, or referenced as live policy.
 
-- **Reboot pipeline** (`scripts/build/linear_pipeline.py`, EPIC #1577) — fail-fast linear runner. Phase 4 exemplar in flight (PR #1594 draft). Will become the only pipeline once A1+A2+B1 ship through it.
-- **Pipeline V6** (`scripts/build/v6_build.py`) — LEGACY. The reboot replaces it. Don't add features; don't extend. Only relevant when re-running historical builds.
-- **v5, v4, v3 are RETIRED.** Do not use `build_module_v5.py` or `build_module.py`.
+## Pipeline policy authority
 
-## Reboot policy authority
-
-- **Module writer in the reboot: Codex / GPT-5.5 / codex-tools (ACCEPTED 2026-05-06).** Decision card: [`docs/decisions/2026-05-06-writer-selection-codex-gpt55.md`](../../docs/decisions/2026-05-06-writer-selection-codex-gpt55.md). Default V7 writer "until next bakeoff signal indicates otherwise" — repeatable per ADR §3. **Acceptance is conditional on #1731 Part B**: (1) agents can communicate (✅ met as of PR #1732/#1733) AND (2) Codex Desktop can join in as visual-aid preproduction layer (❌ pending PR #1735 round-3 + Strand 0 bakeoff). A1/A2/B1 batch build does NOT start until both conditions hold. Hard guardrails: VESUM gate non-negotiable; rollback triggers (invented `-ся` forms / wiki-path miscites / immersion >35%) documented in the decision card.
+- **Module writer in V7: Codex / GPT-5.5 / codex-tools (ACCEPTED 2026-05-06).** Decision card: [`docs/decisions/2026-05-06-writer-selection-codex-gpt55.md`](../../docs/decisions/2026-05-06-writer-selection-codex-gpt55.md). Default V7 writer "until next bakeoff signal indicates otherwise" — repeatable per ADR §3. **Acceptance is conditional on #1731 Part B**: (1) agents can communicate (✅ met as of PR #1732/#1733) AND (2) Codex Desktop can join in as visual-aid preproduction layer (❌ pending PR #1735 round-3 + Strand 0 bakeoff). A1/A2/B1 batch build does NOT start until both conditions hold. Hard guardrails: VESUM gate non-negotiable; rollback triggers (invented `-ся` forms / wiki-path miscites / immersion >35%) documented in the decision card.
 - **Wiki writer: Gemini, always.** [`docs/decisions/2026-04-26-reboot-agent-responsibilities.md`](../../docs/decisions/2026-04-26-reboot-agent-responsibilities.md) §1. `scripts/wiki/compile.py` defaults to `--writer gemini`; never pass `--writer=claude` for wiki rebuilds.
 - **Pipeline reviewer: Codex** (`codex-tools`) for the per-dim LLM QG; cross-agent, no self-review (`SELF_REVIEW_DETECTED` audit gate enforces). Claude reserved for cultural/creative nuance dimensions when those reviewers need a different voice. See [`docs/decisions/2026-04-26-reboot-agent-responsibilities.md`](../../docs/decisions/2026-04-26-reboot-agent-responsibilities.md) §2.
-- **Reviewer-as-fixer policy: NO LLM regeneration during review.** Reviewer outputs `<fixes>` find/replace pairs, pipeline applies deterministically. Enforced by ADR-007 (`docs/decisions/2026-04-23-rewrite-strategies-kill-or-revert.md`) and the structural invariant test `tests/test_no_rewrite_contract.py`. The reboot's REVISE/REJECT path is fail-fast, no scoped regen — see [Phase 4 brief](../../.worktree-briefs/codex-phase-4-a1-20-exemplar.md).
+- **Reviewer-as-fixer policy: NO LLM regeneration during review.** Reviewer outputs `<fixes>` find/replace pairs, pipeline applies deterministically. Enforced by ADR-007 (`docs/decisions/2026-04-23-rewrite-strategies-kill-or-revert.md`) and the structural invariant test `tests/test_no_rewrite_contract.py`. V7's REVISE/REJECT path is fail-fast, no scoped regen — see [Phase 4 brief](../../.worktree-briefs/codex-phase-4-a1-20-exemplar.md).
 - **Plans**: DRAFT → REVIEWED → LOCKED lifecycle. Review plan before content build.
 
-## V6 (legacy) reference
-
-V6 still ships in tree for historical re-runs:
-- Build: `.venv/bin/python scripts/build/v6_build.py {level} {num} [--step {step}] [--writer {gemini|claude|gemini-tools|claude-tools}]`
-- V6's hardcoded `claude-tools` writer default (`scripts/build/v6_build.py:29` + `:10706-10707`) is **legacy V6 behavior**, not reboot policy. Do not propagate it to reboot code paths.
-
-**An LLM must NEVER review its own work.** Reboot: writer-of-the-moment builds → non-writer reviews (usually Codex). V6 legacy: same constraint, enforced by `SELF_REVIEW_DETECTED` audit gate.
+**An LLM must NEVER review its own work.** V7 writer-of-the-moment builds → non-writer reviews (usually Codex), enforced by `SELF_REVIEW_DETECTED` audit gate.
 
 </critical>

--- a/claude_extensions/skills/code-review/SKILL.md
+++ b/claude_extensions/skills/code-review/SKILL.md
@@ -12,7 +12,7 @@ The user provides one of:
 
 1. **No args or "diff"**: Review only files changed since last commit (`git diff --name-only` + `git diff --cached --name-only`)
 2. **"all"**: Review all staged + unstaged changes
-3. **Specific files**: `scripts/build/v6_build.py scripts/build/dispatch.py`
+3. **Specific files**: `scripts/build/v7_build.py scripts/build/linear_pipeline.py`
 
 ## Execute
 

--- a/claude_extensions/skills/code-review/code-review-checklist.md
+++ b/claude_extensions/skills/code-review/code-review-checklist.md
@@ -33,30 +33,37 @@ If ruff finds unfixable issues, report them. If `--fix` resolves them, note what
 For each changed Python file, check for:
 
 ### 3a. Model constants
+
 - Any hardcoded model strings (`"claude-opus-4-6"`, `"claude-sonnet-4-6"`, `"gemini-3.1-pro-preview"`, `"gemini-3-flash-preview"`)?
 - Should they come from `batch_gemini_config.py` instead?
 
 ### 3b. Import hygiene
+
 - Any `import re` or `import json` inside a function when already imported at module level?
 - Any unused imports?
 
 ### 3c. SQLite connection management
+
 - Any `sqlite3.connect()` calls that open a new connection per invocation instead of reusing?
 - Any connections not closed in a `finally` block or context manager?
 
 ### 3d. Silent failures
+
 - Any bare `except: pass` or `except Exception: pass` that swallows errors?
 - Any functions that return `None` on failure without logging?
 
 ### 3e. Dead code
+
 - Any functions defined but never called? (Check with grep for the function name across the codebase)
 - Any unreachable branches (code after `return`)?
 
 ### 3f. Type hints
+
 - Do new/changed functions have return type annotations?
 - Do function parameters have type annotations?
 
 ### 3g. Test coverage
+
 - Does every new/changed function have a corresponding test?
 - If not, flag which functions need tests.
 
@@ -93,7 +100,7 @@ If Gemini is available, send the diff for adversarial review:
 ```
 
 Find relevant tests by matching changed file names to test files:
-- `scripts/build/v6_build.py` → `tests/test_v6_build.py`
+- `scripts/build/v7_build.py` → `tests/test_v7_writer_dispatch.py`
 - `scripts/audit/core.py` → `tests/test_audit_core.py`
 - etc.
 

--- a/claude_extensions/skills/prompt-template-review/template-review-checklist.md
+++ b/claude_extensions/skills/prompt-template-review/template-review-checklist.md
@@ -16,16 +16,16 @@ List all `.md` files in `scripts/build/phases/`. For each template, extract:
 
 ## Step 2: Verify placeholder replacement
 
-For each placeholder found in each template, search `scripts/build/v6_build.py` for the corresponding replacement code.
+For each placeholder found in each template, search `scripts/build/linear_pipeline.py` for the corresponding replacement code.
 
 Check:
 - Is every `{PLACEHOLDER}` in the template replaced by Python code before dispatch?
 - Are there any placeholders in the template that don't appear in any `replacements = {}` dict?
 - Are there any replacements in Python that don't correspond to a placeholder in the template?
 
-**Known pattern**: `step_write()` builds a `replacements` dict and calls `prompt.replace(key, value)` for each. Check that dict covers all placeholders.
+**Known pattern**: `render_phase_prompt()` passes a context mapping into `render_prompt()` and fails on unresolved downstream tokens. Check the writer, reviewer, and correction prompt contexts in `linear_pipeline.py`.
 
-Flag: `UNREPLACED: {PLACEHOLDER} in {template} — no replacement found in v6_build.py`
+Flag: `UNREPLACED: {PLACEHOLDER} in {template} — no replacement found in linear_pipeline.py`
 
 ---
 
@@ -34,22 +34,26 @@ Flag: `UNREPLACED: {PLACEHOLDER} in {template} — no replacement found in v6_bu
 Compare instructions ACROSS templates for contradictions:
 
 ### 3a. Exercise format
-- Does `v6-write.md` say "INJECT_ACTIVITY markers only"?
-- Does `v6-write-seminar.md` say "write exercises directly in DSL"?
+
+- Does `linear-write.md` say "INJECT_ACTIVITY markers only"?
+- Does V7 need a seminar-specific writer template, or is `linear-write.md` intentionally shared?
 - Does the chunk prompt in `_build_chunk_prompt()` match the main write prompt?
 - Do all templates agree on what the writer should produce?
 
 ### 3b. Tool prefix
+
 - Does each template use the correct tool prefix for its agent?
 - `mcp__sources__` for Claude, `rag_` for Gemini
 - Is the prefix dynamically set based on the actual dispatched agent, or hardcoded?
 
 ### 3c. Formatting instructions
+
 - Do all templates agree on dialogue format (blockquote `>` vs `<div class="dialogue">`)?
 - Do all templates agree on stress marks (writer adds vs tool adds later)?
 - Do all templates agree on vocabulary tables (writer adds vs ENRICH adds)?
 
 ### 3d. Word target references
+
 - Do all templates use `{WORD_TARGET}` consistently?
 - Are ceiling/overshoot calculations consistent (1.1x vs 1.5x)?
 
@@ -69,7 +73,7 @@ For each template, check if instructions reference:
 
 ## Step 5: Verify template-to-dispatch alignment
 
-For each template, trace the dispatch path in `v6_build.py`:
+For each template, trace the dispatch path in `linear_pipeline.py`:
 
 1. Which function loads this template?
 2. What model is dispatched? (Check for hardcoded model vs config-driven)


### PR DESCRIPTION

Evidence: obsolete V6 references in scoped files

```text
$ ugrep -n 'v6_build\|v6-write\|v6-review\|v6-skeleton\|v6-vocab\|v6-enrich\|v6-activities' CLAUDE.md claude_extensions/rules/pipeline.md claude_extensions/skills/code-review/SKILL.md claude_extensions/skills/code-review/code-review-checklist.md claude_extensions/skills/prompt-template-review/template-review-checklist.md
```

Evidence: unsupported V7 flags in scoped files

```text
$ ugrep -n -- '--range\|--step\|--resume' CLAUDE.md claude_extensions/rules/pipeline.md claude_extensions/skills/code-review/SKILL.md claude_extensions/skills/code-review/code-review-checklist.md claude_extensions/skills/prompt-template-review/template-review-checklist.md
```

Evidence: requested linear_pipeline emit_event grep

```text
$ grep -nE 'emit_event\(\s*"' scripts/build/linear_pipeline.py | sort -u
```

Evidence: linear_pipeline event names use multiline call sites

```text
$ grep -nE '"(writer_cot_emit|writer_tool_call|writer_end_gate|writer_tool_theatre|phase_writer_summary|mcp_config_resolved|reviewer_dim_evidence|reviewer_audit_call|phase_review_summary|writer_correction_unparseable|reviewer_fixes_unparseable|reviewer_fixes_anchor_unmatched)"' scripts/build/linear_pipeline.py | sort -u
1583:            "writer_cot_emit",
1620:            "writer_tool_call",
1627:        "writer_end_gate",
1652:            "writer_tool_theatre",
1660:    _emit(event_sink, "phase_writer_summary", writer=writer, module=module, **summary)
1785:    _emit(event_sink, "mcp_config_resolved", writer=agent_label, **diagnostics)
2201:        "reviewer_dim_evidence",
2285:            "reviewer_audit_call",
2567:        "phase_review_summary",
2823:        "writer_correction_unparseable",
2884:            "reviewer_fixes_unparseable",
2957:                    "reviewer_fixes_anchor_unmatched",
2975:                "reviewer_fixes_anchor_unmatched",
4138:        if event.get("event") != "writer_tool_call":
```

Evidence: V7 wrapper lifecycle events

```text
$ grep -nE '"(phase_done|module_done|review_score)"' scripts/build/v7_build.py | sort -u
313:                "module_done",
396:            "review_score",
422:            "module_done",
86:        "phase_done",
```

Evidence: V6 file still present

```text
$ ls scripts/build/v6_build.py
scripts/build/v6_build.py
```

Validation:
- `.venv/bin/python scripts/build/v7_build.py --help` confirmed positional `level slug` and V7 options.
- `npm run claude:deploy` passed and deployed V7-only pipeline rule.
- `npx markdownlint-cli2 ...` passed for all changed markdown files and tracked mirrors.
- `.venv/bin/ruff check .` still fails on unrelated pre-existing files under `docs/reports/` and `plans/`; no Python files are changed here.