### PR TITLE
fix(api): /api/delegate/active counts spawning tasks (#1801)

### DIFF
--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -150,7 +150,7 @@ def active_delegate_tasks() -> dict[str, Any]:
     active = [
         task
         for task in tasks
-        if task["status"] in {"running", "spawning"} and task.get("alive")
+        if task["status"] in {"running", "spawning"}
     ]
     return {"total": len(active), "tasks": active}
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1572,6 +1572,20 @@ def build_parser() -> argparse.ArgumentParser:
     sof = sub.add_parser(
         "status-or-fail",
         help="Exit 0 only if Monitor API says task is running",
+        description=(
+            "Verify a delegated task through the Monitor API and exit 0 only when it is running.\n"
+            "Use it in guardrails before trusting stale async-task claims; do not use it when the API may be offline."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  .venv/bin/python scripts/delegate.py status-or-fail review-123\n"
+            "  .venv/bin/python scripts/delegate.py status-or-fail review-123 --verbose\n\n"
+            "Exit codes:\n"
+            "  0 Monitor API confirms the task is running.\n"
+            "  1 Task is not running, done, missing, or stale.\n"
+            "  2 Monitor API is unreachable.\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sof.add_argument("task_id", help="Task ID to verify, e.g. review-123.")
     sof.add_argument(

--- a/tests/api/test_delegate_active.py
+++ b/tests/api/test_delegate_active.py
@@ -1,0 +1,119 @@
+"""Regression tests for delegate active task reporting."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+import scripts.api.delegate_router as delegate_router
+import scripts.api.main as api_main
+import scripts.api.state_helpers as state_helpers
+
+client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _write_task(path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _task_payload(task_id: str, **overrides) -> dict:
+    started = datetime.now(UTC) - timedelta(minutes=5)
+    payload = {
+        "task_id": task_id,
+        "agent": "codex",
+        "model": "gpt-5.5",
+        "effort": "high",
+        "cli_version": "0.130.0",
+        "status": "done",
+        "pid": 12345,
+        "started_at": _iso(started),
+        "duration_s": 30.0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _reset_orient_cache() -> None:
+    for key in [k for k in state_helpers._ttl_cache if k.startswith("orient_")]:
+        state_helpers._ttl_cache.pop(key, None)
+
+
+def _patch_non_delegate_orient_sources(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "_collect_git_orient_data", lambda: {"branch": "main"})
+    monkeypatch.setattr(api_main, "_collect_issues_orient_data", lambda: {"issues": []})
+
+    async def fake_pipeline():
+        return {"summary": {}}
+
+    monkeypatch.setattr(api_main, "_collect_pipeline_orient_data", fake_pipeline)
+    monkeypatch.setattr(api_main, "_collect_runtime_orient_data", lambda: {})
+    monkeypatch.setattr(api_main, "_collect_bridge_pending_orient_data", lambda: {})
+    monkeypatch.setattr(api_main, "_collect_wiki_orient_data", lambda: {"by_track": {}})
+    monkeypatch.setattr(
+        api_main,
+        "_collect_governance_orient_data",
+        lambda: {
+            "decisions_total": 0,
+            "decisions_stale": 0,
+            "decisions_approaching_expiry": 0,
+            "adrs_total": 0,
+            "adrs_warnings": 0,
+            "adrs_errors": 0,
+        },
+    )
+    monkeypatch.setattr(api_main, "_collect_health_orient_data", lambda: {"api": True})
+    monkeypatch.setattr(api_main, "_collect_session_hints_orient_data", lambda: [])
+
+
+def test_delegate_active_includes_spawning_task_without_pid(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+    _reset_orient_cache()
+    _patch_non_delegate_orient_sources(monkeypatch)
+
+    def fake_kill(pid: int, sig: int) -> None:
+        if pid != 111:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(delegate_router.os, "kill", fake_kill)
+    _write_task(
+        tasks_dir / "running.json",
+        _task_payload(
+            "running",
+            status="running",
+            pid=111,
+            started_at=_iso(datetime.now(UTC) - timedelta(minutes=2)),
+            duration_s=None,
+        ),
+    )
+    _write_task(
+        tasks_dir / "spawning.json",
+        _task_payload(
+            "spawning",
+            status="spawning",
+            pid=None,
+            started_at=_iso(datetime.now(UTC) - timedelta(minutes=1)),
+            duration_s=None,
+        ),
+    )
+    _write_task(tasks_dir / "done.json", _task_payload("done", status="done"))
+
+    active_response = client.get("/api/delegate/active")
+    orient_response = client.get("/api/orient?fresh=true")
+
+    assert active_response.status_code == 200
+    assert orient_response.status_code == 200
+    active = active_response.json()
+    orient = orient_response.json()
+    assert active["total"] == 2
+    assert orient["delegate"]["active_count"] == active["total"]
+    assert [task["task_id"] for task in active["tasks"]] == ["spawning", "running"]
+    assert active["tasks"][0]["status"] == "spawning"
+    assert active["tasks"][0]["alive"] is False


### PR DESCRIPTION
Fixes #1801.

Changes:
- Align /api/delegate/active with active_delegate_count() by counting running and spawning rows after derived-status filtering.
- Add a regression test for status="spawning" with pid=null and verify /api/orient delegate.active_count matches /api/delegate/active total.
- Add status-or-fail subcommand description and exit-code epilog.

Before fix evidence: `curl -s http://localhost:8765/api/delegate/active`

```json
{"total":2,"tasks":[{"task_id":"codex-1801-delegate-active","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"running","started_at":"2026-05-10T08:35:14.555924+00:00","duration_s":null,"age_s":279.8,"alive":true},{"task_id":"codex-v6-v7-doc-sweep","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"running","started_at":"2026-05-10T08:34:50.140852+00:00","duration_s":null,"age_s":304.2,"alive":true}]}
```

Before fix evidence: `curl -s http://localhost:8765/api/orient`

```json
{"generated_at":"2026-05-10T08:39:53.970440Z","git":{"branch":"main","head":"987669637","ahead_of_origin":0,"recent_commits":[{"sha":"9876696378","subject":"docs(handoff): morning 2026-05-10 — orientation rewrite + graphify install + secret-leak postmortem"},{"sha":"af01e07394","subject":"chore(graphify): install graphify skill across CLIs + secret-leak postmortem"},{"sha":"2f254b4907","subject":"chore(orientation): rewrite curriculum-maintainer; sync MEMORY to 3:3:3 + V7"},{"sha":"2f06c86294","subject":"Unify playground pages under monitor shell (#1843)"},{"sha":"eb679ad6b5","subject":"docs(handoff): late-evening closeout — watcher landed all 3 + #1848 + reload + #1843 status"}]},"issues":[],"pipeline":{"summary":{"generated_at":"2026-05-10T08:39:53.970652+00:00","tracks":{"a1":{"total":55,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"a2":{"total":69,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"b1":{"total":94,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"b2":{"total":93,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"b2-pro":{"total":40,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"c1":{"total":132,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"c1-pro":{"total":50,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"c2":{"total":110,"profile":"core","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"hist":{"total":140,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"istorio":{"total":136,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"bio":{"total":180,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit":{"total":232,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-essay":{"total":63,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-hist-fic":{"total":23,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-fantastika":{"total":25,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-war":{"total":29,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-humor":{"total":14,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-youth":{"total":32,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-doc":{"total":13,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-drama":{"total":17,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"lit-crimea":{"total":12,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"oes":{"total":102,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0},"ruth":{"total":115,"profile":"seminar","research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0}},"totals":{"total":1776,"research_done":0,"content_done":0,"audit_passing":0,"reviewed":0,"final_review_done":0,"prompt_reviewed":0,"content_reviewed":0}}},"runtime":{"agents":["claude","codex","gemini","gemma-local"],"recent_outcomes":{"ok":5,"error":0,"timeout":0,"rate_limited":0},"headroom":{"claude":true,"codex":true,"gemini":true,"gemma-local":true}},"delegate":{"active_count":3,"recent":[{"task_id":"codex-1801-spawning-fixture","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"spawning","started_at":"2026-05-10T08:37:30Z","duration_s":null,"age_s":144.3,"alive":false},{"task_id":"codex-1801-delegate-active","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"running","started_at":"2026-05-10T08:35:14.555924+00:00","duration_s":null,"age_s":279.8,"alive":true},{"task_id":"codex-v6-v7-doc-sweep","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"running","started_at":"2026-05-10T08:34:50.140852+00:00","duration_s":null,"age_s":304.2,"alive":true},{"task_id":"1778-check-plan-track-level","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"done","started_at":"2026-05-09T21:20:33.693323+00:00","duration_s":325.415,"age_s":40760.6,"alive":false},{"task_id":"1779-bridge-inbox-ttl","agent":"codex","model":"gpt-5.5","effort":"high","cli_version":"0.130.0","status":"done","started_at":"2026-05-09T21:18:50.598067+00:00","duration_s":545.723,"age_s":40863.7,"alive":false}]},"bridge_pending":{},"wiki":{"by_track":{"a1":{"compiled":55,"total":55,"pct":100.0},"a2":{"compiled":69,"total":69,"pct":100.0},"b1":{"compiled":94,"total":94,"pct":100.0},"b2":{"compiled":93,"total":93,"pct":100.0},"c1":{"compiled":133,"total":133,"pct":100.0},"c2":{"compiled":109,"total":109,"pct":100.0},"hist":{"compiled":140,"total":140,"pct":100.0},"istorio":{"compiled":136,"total":136,"pct":100.0},"bio":{"compiled":180,"total":180,"pct":100.0},"lit":{"compiled":232,"total":232,"pct":100.0},"lit-essay":{"compiled":63,"total":63,"pct":100.0},"lit-hist-fic":{"compiled":23,"total":23,"pct":100.0},"lit-fantastika":{"compiled":25,"total":25,"pct":100.0},"lit-war":{"compiled":29,"total":29,"pct":100.0},"lit-humor":{"compiled":14,"total":14,"pct":100.0},"lit-youth":{"compiled":32,"total":32,"pct":100.0},"lit-doc":{"compiled":1,"total":13,"pct":7.7},"lit-drama":{"compiled":17,"total":17,"pct":100.0},"lit-crimea":{"compiled":0,"total":12,"pct":0.0},"oes":{"compiled":102,"total":102,"pct":100.0},"ruth":{"compiled":115,"total":115,"pct":100.0},"folk":{"compiled":27,"total":27,"pct":100.0}}},"governance":{"decisions_total":6,"decisions_stale":0,"decisions_approaching_expiry":0,"adrs_total":9,"adrs_warnings":7,"adrs_errors":0},"health":{"api":true,"mcp_rag":true,"sources_db":true,"message_broker":true},"session_hints":[{"file":"docs/session-state/writer-ab-test-plan.md","first_line":"# Writer A/B Test Plan"},{"file":"docs/session-state/current.md","first_line":"# Current — multi-agent index (2026-05-10)"},{"file":"docs/session-state/2026-05-09-night-shift-orchestration.md","first_line":"# Session Handoff — 2026-05-09 (overnight orchestration shift — FINAL)"},{"file":"docs/session-state/2026-05-08-replacement-evaluation-and-autonomous-mode.md","first_line":"# Session Handoff — 2026-05-08 (replacement evaluation done; entering autonomous mode)"},{"file":"docs/session-state/2026-05-08-bakeoff-mcp-wiring-and-writer-theatre.md","first_line":"# Session Handoff — 2026-05-08 (MCP wiring + writer-prompt theatre diagnosis)"},{"file":"docs/session-state/2026-05-07-kubedojo-paradigm-followups.md","first_line":"# Kubedojo Decision Graph paradigm + persistent listener architecture — follow-up actions"},{"file":"docs/session-state/2026-05-07-bakeoff-blockers-cleared-and-first-attempt.md","first_line":"# Session Handoff — 2026-05-07 (bakeoff blockers cleared, first attempt failed, prompt fix in flight)"},{"file":"docs/session-state/2026-05-06-tonight-path-a-orchestration.md","first_line":"# Session Handoff — 2026-05-06 evening (Path A: unblock + bakeoff)"},{"file":"docs/session-state/2026-05-06-strand-1-vesum-and-textbook-grounding.md","first_line":"# Session Handoff — 2026-05-06 (strand-1 dispatch + vesum tokenizer + textbook-grounding investigation)"},{"file":"docs/session-state/2026-05-06-runbook-strand-1-and-bakeoff-validation.md","first_line":"# Runbook — Strand 1 + Bakeoff Validation (next-session play-by-play)"}],"meta":{"git":{"generated_at":"2026-05-10T08:39:53.970440Z","stale_after_s":30.0,"source":"git","cache":"miss"},"issues":{"generated_at":"2026-05-10T08:39:53.970478Z","stale_after_s":120.0,"source":"gh","cache":"miss","error":"TimeoutExpired: Command '['gh', 'issue', 'list', '--state', 'open', '--limit', '10', '--json', 'number,title,labels,createdAt']' timed out after 0.25 seconds"},"pipeline":{"generated_at":"2026-05-10T08:39:53.970493Z","stale_after_s":0.0,"source":"fs","cache":"miss"},"runtime":{"generated_at":"2026-05-10T08:39:53.970519Z","stale_after_s":60.0,"source":"fs","cache":"miss"},"delegate":{"generated_at":"2026-05-10T08:39:53.970529Z","stale_after_s":30.0,"source":"fs","cache":"miss"},"bridge_pending":{"generated_at":"2026-05-10T08:39:53.970540Z","stale_after_s":15.0,"source":"sqlite","cache":"miss"},"wiki":{"generated_at":"2026-05-10T08:39:53.970558Z","stale_after_s":120.0,"source":"fs","cache":"miss"},"governance":{"generated_at":"2026-05-10T08:39:53.970568Z","stale_after_s":120.0,"source":"fs","cache":"miss","decisions_total":6,"decisions_stale":0,"decisions_approaching_expiry":0,"adrs_total":9,"adrs_warnings":7,"adrs_errors":0},"health":{"generated_at":"2026-05-10T08:39:53.970581Z","stale_after_s":15.0,"source":"probe","cache":"miss"},"session_hints":{"generated_at":"2026-05-10T08:39:53.970592Z","stale_after_s":60.0,"source":"fs","cache":"miss"}},"issues_error":"Command '['gh', 'issue', 'list', '--state', 'open', '--limit', '10', '--json', 'number,title,labels,createdAt']' timed out after 0.25 seconds"}
```

After fix evidence: `.venv/bin/pytest tests/api/ -k "delegate"`

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/1801-delegate-active
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collecting ... collected 3 items / 2 deselected / 1 selected

tests/api/test_delegate_active.py::test_delegate_active_includes_spawning_task_without_pid PASSED [100%]

======================= 1 passed, 2 deselected in 0.74s ========================
```

After fix evidence: `.venv/bin/python scripts/delegate.py status-or-fail --help`

```text
usage: delegate.py status-or-fail [-h] [--verbose] task_id

Verify a delegated task through the Monitor API and exit 0 only when it is running.
Use it in guardrails before trusting stale async-task claims; do not use it when the API may be offline.

positional arguments:
  task_id     Task ID to verify, e.g. review-123.

options:
  -h, --help  show this help message and exit
  --verbose   Print structured status JSON before exiting.

Examples:
  .venv/bin/python scripts/delegate.py status-or-fail review-123
  .venv/bin/python scripts/delegate.py status-or-fail review-123 --verbose

Exit codes:
  0 Monitor API confirms the task is running.
  1 Task is not running, done, missing, or stale.
  2 Monitor API is unreachable.
```

Ruff: `.venv/bin/ruff check scripts/api/ scripts/delegate.py tests/`

```text
All checks passed!
```
