### PR TITLE
docs(build): mark v5/v6 OBSOLETE in module docstrings

### DIFF
--- a/scripts/build/build_module_v5.py
+++ b/scripts/build/build_module_v5.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""E2E Module Builder v5 — clean pipeline CLI (no v2/v3 legacy).
+"""E2E Module Builder v5 — OBSOLETE.
+
+This v5 CLI is kept for forensic reference only; use
+``scripts/build/v7_build.py`` for all new builds.
 
 Usage:
     %(prog)s a1 12                           # Full build (review on by default)

--- a/scripts/build/pipeline_v5.py
+++ b/scripts/build/pipeline_v5.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Pipeline v5 — Clean pipeline implementation (no v2/v3 legacy code).
+"""Pipeline v5 — OBSOLETE.
 
-Phase implementations + state management + all phase-specific helpers.
-Imported by build_module_v5.py.
+V5 was retired well before 2026-05-10 (superseded first by V6 and now V7).
+Use ``scripts/build/v7_build.py`` + ``scripts/build/linear_pipeline.py`` for
+all new work. Kept on disk for forensic reference only — do not invoke,
+extend, or import.
 
-Pipeline: research (+ discover) → content → validate → activities → review → mdx
-(Sandbox phase removed in #820 — VESUM post-validation replaces it.)
-(Discover merged into research — phase_discover() is a passthrough.)
-
-State file: state.json (plain phase keys, mode: "v5").
+Original purpose (historical): clean pipeline implementation; phase
+implementations + state management + phase-specific helpers; imported by
+``build_module_v5.py``.
 """
 
 from __future__ import annotations

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -1,38 +1,12 @@
 #!/usr/bin/env python3
-"""V6 Pipeline Build — two-call Skeleton->Flesh content generation.
+"""V6 Pipeline Build — OBSOLETE.
 
-Orchestrates the V6 pipeline:
-1. CHECK: Plan checker validation
-2. RESEARCH: Build knowledge packet from RAG
-3. SKELETON: Paragraph-level structure plan (always on, --no-skeleton to skip)
-4. WRITE: LLM session constrained by skeleton (prose + exercises)
-5b. EXERCISES: Fill placeholders with DSL
-5d. VERIFY EXERCISES: Check exercise items grounded in prose (#1016)
-6. ANNOTATE: Stress marks + deterministic fixes
-7. VERIFY: VESUM + grammar scope
-8. REVIEW: Cross-agent adversarial review
-9. PUBLISH: Assemble 4-tab MDX from prose (.md) + vocabulary YAML + activities YAML + resources
+V6 was retired on 2026-05-10. Use ``scripts/build/v7_build.py`` (which drives
+``scripts/build/linear_pipeline.py``) for all new builds. This file is kept
+on disk for forensic reference only — do not invoke, extend, or import.
 
-The Skeleton->Flesh architecture (#998) splits content generation into two calls
-for all modules (use --no-skeleton to skip):
-- Call 1 (Skeleton): Short output (~500-800 words) planning every paragraph
-- Call 2 (Flesh): Full prose following the skeleton exactly
-
-This prevents frontloading early sections and rushing later ones.
-Use --no-skeleton to skip for quick iteration.
-
-Usage:
-    .venv/bin/python scripts/build/v6_build.py a1 1
-    .venv/bin/python scripts/build/v6_build.py b1 1 --skeleton    # force skeleton
-    .venv/bin/python scripts/build/v6_build.py b1 1 --no-skeleton # skip skeleton
-    .venv/bin/python scripts/build/v6_build.py a1 1 --step write  # run single step
-    .venv/bin/python scripts/build/v6_build.py a1 1 --writer claude-tools  # V6-LEGACY default (2026-04-23). Reboot: NOT YET DECIDED — see docs/decisions/2026-04-26-reboot-agent-responsibilities.md §3.
-    .venv/bin/python scripts/build/v6_build.py a1 1 --writer gemini-tools  # research/exercises
-    .venv/bin/python scripts/build/v6_build.py a1 1 --resume       # resume from last completed phase
-    .venv/bin/python scripts/build/v6_build.py a1 1 --range 14     # batch (skips complete, rebuilds partial)
-    .venv/bin/python scripts/build/v6_build.py a1 1 --range 14 --resume  # batch + resume partial modules
-
-Issue: #993, #998
+Original purpose (historical): two-call Skeleton->Flesh content generation
+through a Plan-checker / Skeleton / Flesh / Activities / Audit pipeline.
 """
 
 from __future__ import annotations
@@ -11947,4 +11921,3 @@ def main():
 
 if __name__ == "__main__":
     raise SystemExit(0 if main() is not False else 1)
-


### PR DESCRIPTION
## Summary
- Marked `scripts/build/v6_build.py` and `scripts/build/pipeline_v5.py` module docstrings as `OBSOLETE` and pointed new builds at V7.
- Applied the allowed boy-scout marker to `scripts/build/build_module_v5.py` so the v5 CLI docstring no longer reads live.

## Context
- Orchestrator brief: `codex-v5-v6-deprecate-docstrings`.
- Follow-up to the v6→V7 sweep companion PR/branch: `codex/v6-v7-doc-sweep`.

## Validation
- `grep -n 'OBSOLETE' scripts/build/v6_build.py scripts/build/pipeline_v5.py | head`
- `.venv/bin/python -c "import ast; [ast.parse(open(f).read()) for f in ['scripts/build/v6_build.py', 'scripts/build/pipeline_v5.py']]"`
- `.venv/bin/ruff check scripts/build/v6_build.py scripts/build/pipeline_v5.py`
- `.venv/bin/ruff check scripts/build/build_module_v5.py`
- `.venv/bin/pytest tests/ -k "v5 or v6" -x` — 392 passed, 7136 deselected, 3 warnings
- pre-commit affected-file pytest — 138 passed