### PR TITLE
docs(build): prepend OBSOLETE banner to v5/v6, preserve historical docstrings

### DIFF
--- a/scripts/build/build_module_v5.py
+++ b/scripts/build/build_module_v5.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""E2E Module Builder v5 — clean pipeline CLI (no v2/v3 legacy).
+"""E2E Module Builder v5 — OBSOLETE (retired 2026-05-10).
+
+Use ``scripts/build/v7_build.py`` for all new builds. This file is kept on
+disk for forensic reference only — do not invoke, extend, or import.
+V5 was retired well before V6.
+
+--- Historical docstring preserved below ---
+
+E2E Module Builder v5 — clean pipeline CLI (no v2/v3 legacy).
 
 Usage:
     %(prog)s a1 12                           # Full build (review on by default)

--- a/scripts/build/pipeline_v5.py
+++ b/scripts/build/pipeline_v5.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Pipeline v5 — Clean pipeline implementation (no v2/v3 legacy code).
+"""Pipeline v5 — OBSOLETE (retired 2026-05-10).
+
+Use ``scripts/build/v7_build.py`` for all new builds. This file is kept on
+disk for forensic reference only — do not invoke, extend, or import.
+V5 was retired well before V6; superseded first by V6 and now V7.
+
+--- Historical docstring preserved below ---
+
+Pipeline v5 — Clean pipeline implementation (no v2/v3 legacy code).
 
 Phase implementations + state management + all phase-specific helpers.
 Imported by build_module_v5.py.

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""V6 Pipeline Build — two-call Skeleton->Flesh content generation.
+"""V6 Pipeline Build — OBSOLETE (retired 2026-05-10).
+
+Use ``scripts/build/v7_build.py`` for all new builds. This file is kept on
+disk for forensic reference only — do not invoke, extend, or import.
+
+--- Historical docstring preserved below ---
+
+V6 Pipeline Build — two-call Skeleton->Flesh content generation.
 
 Orchestrates the V6 pipeline:
 1. CHECK: Plan checker validation


### PR DESCRIPTION
Replaces #1851 (closed). Preserves forensic content per Gemini adversarial review.