### PR TITLE
ci: drop torch force-reinstall + use setup-python pip cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,25 +297,21 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         with:
           python-version: '3.12'
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        if: needs.changes.outputs.code == 'true'
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('requirements-lock.txt', 'pyproject.toml') }}
-          restore-keys: |
-            pip-${{ runner.os }}-
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-lock.txt
+            pyproject.toml
 
       - name: Install dependencies
         if: needs.changes.outputs.code == 'true'
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install --no-deps -r requirements-lock.txt
-          .venv/bin/python -m pip install multiprocess==0.70.18 huggingface-hub==0.36.0
-          .venv/bin/python -m pip install --no-deps --force-reinstall \
+          .venv/bin/python -m pip install --no-deps \
             --index-url https://download.pytorch.org/whl/cpu \
             torch==2.11.0 torchvision==0.26.0
+          .venv/bin/python -m pip install --no-deps -r requirements-lock.txt
+          .venv/bin/python -m pip install multiprocess==0.70.18 huggingface-hub==0.36.0
 
       - name: Run tests
         if: needs.changes.outputs.code == 'true' && !cancelled() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (github.event_name != 'push' || github.ref != 'refs/heads/main')


### PR DESCRIPTION
## Summary
- replace the pytest job's manual actions/cache pip cache with setup-python cache: 'pip'
- keep PyTorch CPU wheel selection but drop --force-reinstall and install CPU torch/torchvision before the lockfile install so the pinned lockfile requirements are satisfied by CPU wheels

## Evidence
```
$ grep -E '^torch(vision)?==' requirements-lock.txt
torch==2.11.0
torchvision==0.26.0
```

First CI attempt showed the lockfile pins alone are not enough on GitHub-hosted Ubuntu: tests failed with `libcudart.so.13` after the direct lockfile install pulled a CUDA-linked torch wheel. This branch keeps the CPU index path without `--force-reinstall`, so pip can still reuse cache.

## Validation
- `.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- `git diff --check`
- `git diff --stat`: 1 file changed, 7 insertions(+), 11 deletions(-)

## Timing
- BEFORE baseline: recent merged PR Test (pytest) jobs averaged ~4m53s (#1854: 4m53s, #1853: 4m49s, #1852: 4m58s)
- AFTER: cold corrected run passed in 4m50s; warm cache rerun passed in 4m44s with `Cache restored from key: ...`
