### PR TITLE
feat(audit): catch dotfile typos + document closed-world limitation (#1799)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -803,6 +803,10 @@ Known user-scoped paths that are expected but not committed live in
 `scripts/audit/known_user_paths.yaml`. This check is also wired into pre-commit
 for `docs/session-state/*.md`.
 
+**Capabilities and Limitations:**
+- ✅ Catches: missing-file references for tilde-rooted dotfiles (`~/.bash_secrets`, etc.) + `.env*` variants.
+- ❌ Does NOT catch: typos that resolve to a different *existing* file, or verify content-correctness *inside* referenced files.
+
 ### `scripts/audit/lint_anti_menu.py`
 
 Scans markdown for MEMORY #0I anti-menu sign-off prompts while ignoring

--- a/scripts/audit/known_user_paths.yaml
+++ b/scripts/audit/known_user_paths.yaml
@@ -1,3 +1,17 @@
 paths:
   - ~/.codex/config.toml
   - ~/.gemini/settings.json
+  - ~/.envrc
+  - ~/.bashrc
+  - ~/.zshrc
+  - ~/.profile
+  - ~/.zprofile
+  - ~/.pyenv/shims/.pyenv-shim
+  - ~/.codex/sessions/YYYY/MM/DD/rollout
+  - ~/.codex/sessions/2026/04/24/rollout
+  - ~/.claude/projects/.../memory/MEMORY.md
+  - ~/.claude/projects/.../memory
+  - ~/.claude/.../memory/fact-corrections.md
+  - ~/.claude/.../memory
+  - ~/.claude/projects/-Users-krisztiankoos-projects-learn-ukrainian--worktrees-dispatch-claude-adr007-prf-invariant-test
+  - ~/.agents/skills/graphify

--- a/scripts/audit/lint_session_state.py
+++ b/scripts/audit/lint_session_state.py
@@ -15,21 +15,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SESSION_STATE_DIR = PROJECT_ROOT / "docs" / "session-state"
 ALLOWLIST_FILE = Path(__file__).with_name("known_user_paths.yaml")
 
-PATH_PATTERN = re.compile(
-    r"(?<![\w/.-])("
-    r"~/\.claude/settings\.json|"
-    r"~/\.codex/config\.toml|"
-    r"~/\.gemini/settings\.json|"
-    r"~/\.bash_secrets|"
-    r"~/\.zprofile|"
-    r"~/\.bashrc|"
-    r"~/\.profile|"
-    r"~/\.zshrc|"
-    r"\.env\.local|"
-    r"\.envrc|"
-    r"\.env"
-    r")(?![\w/.-])"
-)
+PATH_PATTERN = re.compile(r"(\B~/\.[\w./_-]+\b|\B(?<!\.)\.env(?:\.[\w-]+)?\b)")
 FENCE_PATTERN = re.compile(r"^\s*(```|~~~)(.*)$")
 
 

--- a/tests/audit/test_lint_session_state.py
+++ b/tests/audit/test_lint_session_state.py
@@ -74,3 +74,31 @@ source ~/.notreal
     )
 
     assert lint_session_state.main(["--file", str(handoff)]) == 0
+
+
+@pytest.mark.parametrize(
+    "typo_path",
+    [
+        "~/.bash_secret",
+        "~/.totally_not_a_real_file_xyz",
+        ".env.foofake",
+        ".env.production",
+        ".env.development",
+        ".env.staging",
+        ".env.example",
+    ],
+)
+def test_closed_world_typos_and_variants_are_flagged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    typo_path: str,
+) -> None:
+    _isolate_cli(monkeypatch, tmp_path)
+    handoff = _write(tmp_path / "handoff.md", f"Check {typo_path} for secrets.\n")
+
+    exit_code = lint_session_state.main(["--file", str(handoff)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert typo_path in output


### PR DESCRIPTION
- Option A: Broadened PATH_PATTERN to catch `~/.` and `.env` typos instead of a closed-world allowlist.
- Option C: Added capabilities and limitations to docs/SCRIPTS.md.
- Expanded known_user_paths.yaml with missing references across docs/session-state/*.md to keep the false-positive rate at 0% (< 5% AC).

Evidence (#M-4):
Linter correctly flags the following closed-world typos:
m4_test.md:2: referenced env file '~/.bash_secret' does not exist
m4_test.md:3: referenced env file '.env.foofake' does not exist
m4_test.md:4: referenced env file '.env.production' does not exist
m4_test.md:5: referenced env file '.env.development' does not exist
m4_test.md:6: referenced env file '.env.staging' does not exist
m4_test.md:7: referenced env file '.env.example' does not exist
m4_test.md:8: referenced env file '~/.totally_not_a_real_file_xyz' does not exist

False-positive rate on `docs/session-state/*.md` corpus:
0 FPs out of 44 path-shaped tokens detected (0%).

Tests pass:
11 passed in 0.11s (pytest tests/audit/test_lint_session_state.py -v)
