### PR TITLE
fix(mcp-observer): observer hardening (4 sub-tasks, #1805)

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -86,6 +86,11 @@ _MCP_FAILURE_URL_RE = re.compile(r"url \((?P<url>https?://[^)\s]+)\)")
 _ADAPTER_CACHE: dict[str, AgentAdapter] = {}
 
 
+def _normalize_mcp_url(url: str | None) -> str:
+    """Normalize MCP endpoint URLs for observer attribution."""
+    return str(url or "").strip().rstrip("/")
+
+
 def _validate_agent_name(agent_name: str) -> None:
     """Reject legacy public labels before registry lookup."""
     if agent_name.endswith("-tools") and agent_name not in AGENTS:
@@ -494,10 +499,11 @@ class _McpRuntimeObserver:
 
     def _servers_for_failed_line(self, url: str | None) -> list[str]:
         if url:
+            normalized_url = _normalize_mcp_url(url)
             matched = [
                 server
                 for server, server_url in self.server_urls.items()
-                if server_url == url
+                if _normalize_mcp_url(server_url) == normalized_url
             ]
             if matched:
                 return matched

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -412,6 +412,7 @@ class _McpRuntimeObserver:
     ready_servers: set[str] = field(default_factory=set)
     failed_servers: set[str] = field(default_factory=set)
     timed_out_servers: set[str] = field(default_factory=set)
+    pending_ready_events: dict[str, dict[str, str]] = field(default_factory=dict)
 
     @classmethod
     def from_tool_config(
@@ -518,16 +519,50 @@ class _McpRuntimeObserver:
         stream: str,
         line: str,
     ) -> None:
+        """Record ready as pending; failed is terminal and suppresses it.
+
+        Ordering is intentionally "failed trumps ready": a later transport
+        failure for the same server wins over an earlier Codex
+        ``mcp: server/tool started`` or ``(completed)`` line.
+        """
+        if server in self.failed_servers or server in self.timed_out_servers:
+            return
         if server in self.ready_servers:
             return
         self.ready_servers.add(server)
-        self._emit(server=server, status="ready", stream=stream, line=line, tool=tool)
+        self.pending_ready_events[server] = {
+            "tool": tool,
+            "stream": stream,
+            "line": line,
+        }
 
     def _emit_failed(self, server: str, *, stream: str, line: str) -> None:
+        """Emit failed immediately; failed is terminal and suppresses ready.
+
+        If Codex prints both a ready line and a later transport failure for
+        the same server, consumers see one final ``failed`` status rather
+        than a ready/failed flap.
+        """
         if server in self.failed_servers:
             return
         self.failed_servers.add(server)
+        self.pending_ready_events.pop(server, None)
         self._emit(server=server, status="failed", stream=stream, line=line)
+
+    def finalize(self) -> None:
+        """Emit pending ready statuses that were not superseded by failures."""
+        for server in sorted(self.pending_ready_events):
+            if server in self.failed_servers:
+                continue
+            event = self.pending_ready_events[server]
+            self._emit(
+                server=server,
+                status="ready",
+                stream=event["stream"],
+                line=event["line"],
+                tool=event["tool"],
+            )
+        self.pending_ready_events.clear()
 
     def _emit_unattributed_failure(self, *, stream: str, line: str) -> None:
         fields: dict[str, Any] = {
@@ -786,6 +821,7 @@ def _execute_invocation_plan(
                 stream="stderr",
             )
             mcp_observer.maybe_emit_timeout(time.monotonic())
+            mcp_observer.finalize()
 
         stdout_text = "".join(watchdog_state.stdout_lines)
         stderr_text = "".join(watchdog_state.stderr_lines)

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -473,6 +473,9 @@ class _McpRuntimeObserver:
         servers = self._servers_for_failed_line(
             url_match.group("url") if url_match else None
         )
+        if not servers:
+            self._emit_unattributed_failure(stream=stream, line=line)
+            return
         for server in servers:
             self._emit_failed(server, stream=stream, line=line)
 
@@ -498,17 +501,14 @@ class _McpRuntimeObserver:
             )
 
     def _servers_for_failed_line(self, url: str | None) -> list[str]:
-        if url:
-            normalized_url = _normalize_mcp_url(url)
-            matched = [
-                server
-                for server, server_url in self.server_urls.items()
-                if _normalize_mcp_url(server_url) == normalized_url
-            ]
-            if matched:
-                return matched
-        unresolved = self.configured_servers - self.ready_servers - self.failed_servers
-        return sorted(unresolved) or ["unknown"]
+        normalized_url = _normalize_mcp_url(url)
+        if not normalized_url:
+            return []
+        return [
+            server
+            for server, server_url in self.server_urls.items()
+            if _normalize_mcp_url(server_url) == normalized_url
+        ]
 
     def _emit_ready(
         self,
@@ -528,6 +528,17 @@ class _McpRuntimeObserver:
             return
         self.failed_servers.add(server)
         self._emit(server=server, status="failed", stream=stream, line=line)
+
+    def _emit_unattributed_failure(self, *, stream: str, line: str) -> None:
+        fields: dict[str, Any] = {
+            "agent": self.agent_name,
+            "raw_line": line[:500],
+        }
+        if self.task_id:
+            fields["task_id"] = self.task_id
+        if stream:
+            fields["stream"] = stream
+        self.event_sink("mcp_runtime_unattributed_failure", **fields)
 
     def _emit(
         self,

--- a/tests/fixtures/codex_mcp_init_stdout.txt
+++ b/tests/fixtures/codex_mcp_init_stdout.txt
@@ -1,0 +1,22 @@
+Reading additional input from stdin...
+OpenAI Codex v0.130.0
+--------
+workdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/1805-mcp-observer
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: danger-full-access
+reasoning effort: high
+reasoning summaries: none
+session id: 019e129f-8e3c-73d0-ae0a-ccd84822064f
+--------
+user
+Use the sources MCP tool verify_word for the Ukrainian word кіт, then answer with exactly: done
+mcp: sources/verify_word started
+mcp: sources/verify_word (completed)
+codex
+done
+hook: Stop
+hook: Stop Completed
+tokens used
+18,798

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import time
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from agent_runtime import tool_config as wiki_tool_config_mod
 
 from scripts.agent_runtime import tool_config as tool_config_mod
-from scripts.agent_runtime.runner import _McpRuntimeObserver
+from scripts.agent_runtime.runner import _MCP_TOOL_EVENT_RE, _McpRuntimeObserver
 from scripts.build import linear_pipeline
 from scripts.wiki import review as wiki_review
 
@@ -551,3 +552,22 @@ def test_mcp_runtime_observer_emits_timeout() -> None:
     assert events[0][0] == "mcp_runtime_init"
     assert events[0][1]["server"] == "sources"
     assert events[0][1]["status"] == "timeout"
+
+
+def test_mcp_tool_event_regex_matches_real_codex_fixture() -> None:
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "codex_mcp_init_stdout.txt"
+    ).read_text(encoding="utf-8")
+
+    matches = list(_MCP_TOOL_EVENT_RE.finditer(fixture))
+
+    assert len(matches) == 2
+    assert Counter(
+        (match.group("server"), match.group("tool")) for match in matches
+    ) == {("sources", "verify_word"): 2}
+    assert [match.group(0) for match in matches] == [
+        "mcp: sources/verify_word started",
+        "mcp: sources/verify_word (completed)",
+    ]

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -459,6 +459,43 @@ def test_mcp_runtime_observer_matches_failed_url_with_trailing_slash() -> None:
     assert events[0][1]["status"] == "failed"
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        "2026-05-08T11:37:32.975327Z ERROR rmcp::transport::worker: "
+        "worker quit with fatal: Transport channel closed",
+        "2026-05-08T11:37:32.975327Z ERROR rmcp::transport::worker: "
+        "worker quit with fatal: Transport channel closed, when "
+        'Client(HttpRequest(HttpRequest("http/request failed: error sending '
+        'request for url (http://127.0.0.1:4444/mcp)")))',
+    ],
+)
+def test_mcp_runtime_observer_warns_for_unattributed_failure(line: str) -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    observer = _McpRuntimeObserver.from_tool_config(
+        agent_name="codex",
+        task_id="writer",
+        tool_config={
+            "mcp_servers": {
+                "sources": {"url": "http://127.0.0.1:8766/mcp"},
+                "wikipedia": {"url": "http://127.0.0.1:8767/mcp"},
+            }
+        },
+        event_sink=lambda event, **fields: events.append((event, fields)),
+        start_time=time.monotonic(),
+    )
+    assert observer is not None
+
+    observer.observe_line(line, stream="stderr")
+
+    assert [event for event, _fields in events] == [
+        "mcp_runtime_unattributed_failure"
+    ]
+    assert events[0][1]["raw_line"] == line[:500]
+    assert events[0][1]["task_id"] == "writer"
+    assert events[0][1]["stream"] == "stderr"
+
+
 def test_mcp_runtime_observer_emits_timeout() -> None:
     events: list[tuple[str, dict[str, Any]]] = []
     observer = _McpRuntimeObserver.from_tool_config(

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -396,6 +396,7 @@ def test_mcp_runtime_observer_emits_ready() -> None:
     assert observer is not None
 
     observer.observe_line("mcp: sources/verify_words started", stream="stdout")
+    observer.finalize()
 
     assert events[0][0] == "mcp_runtime_init"
     assert events[0][1]["server"] == "sources"
@@ -494,6 +495,39 @@ def test_mcp_runtime_observer_warns_for_unattributed_failure(line: str) -> None:
     assert events[0][1]["raw_line"] == line[:500]
     assert events[0][1]["task_id"] == "writer"
     assert events[0][1]["stream"] == "stderr"
+
+
+def test_mcp_runtime_observer_failed_suppresses_prior_ready() -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    observer = _McpRuntimeObserver.from_tool_config(
+        agent_name="codex",
+        task_id="writer",
+        tool_config={
+            "mcp_servers": {
+                "sources": {"url": "http://127.0.0.1:8766/mcp"},
+            }
+        },
+        event_sink=lambda event, **fields: events.append((event, fields)),
+        start_time=time.monotonic(),
+    )
+    assert observer is not None
+
+    observer.observe_lines(
+        [
+            "mcp: sources/verify_words started",
+            "2026-05-08T11:37:32.975327Z ERROR rmcp::transport::worker: "
+            "worker quit with fatal: Transport channel closed, when "
+            'Client(HttpRequest(HttpRequest("http/request failed: error sending '
+            'request for url (http://127.0.0.1:8766/mcp)")))',
+        ],
+        start_index=0,
+        stream="stdout",
+    )
+    observer.finalize()
+
+    assert [event for event, _fields in events] == ["mcp_runtime_init"]
+    assert events[0][1]["server"] == "sources"
+    assert events[0][1]["status"] == "failed"
 
 
 def test_mcp_runtime_observer_emits_timeout() -> None:

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -431,6 +431,34 @@ def test_mcp_runtime_observer_emits_failed_for_codex_rmcp_error() -> None:
     assert events[0][1]["status"] == "failed"
 
 
+def test_mcp_runtime_observer_matches_failed_url_with_trailing_slash() -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    observer = _McpRuntimeObserver.from_tool_config(
+        agent_name="codex",
+        task_id="writer",
+        tool_config={
+            "mcp_servers": {
+                "sources": {"url": "http://127.0.0.1:8766/mcp/"},
+            }
+        },
+        event_sink=lambda event, **fields: events.append((event, fields)),
+        start_time=time.monotonic(),
+    )
+    assert observer is not None
+
+    observer.observe_line(
+        "2026-05-08T11:37:32.975327Z ERROR rmcp::transport::worker: "
+        "worker quit with fatal: Transport channel closed, when "
+        'Client(HttpRequest(HttpRequest("http/request failed: error sending '
+        'request for url (http://127.0.0.1:8766/mcp)")))',
+        stream="stderr",
+    )
+
+    assert events[0][0] == "mcp_runtime_init"
+    assert events[0][1]["server"] == "sources"
+    assert events[0][1]["status"] == "failed"
+
+
 def test_mcp_runtime_observer_emits_timeout() -> None:
     events: list[tuple[str, dict[str, Any]]] = []
     observer = _McpRuntimeObserver.from_tool_config(


### PR DESCRIPTION
Closes #1805.

4 sub-tasks per #1805 EPIC:

- A) URL normalization in `_servers_for_failed_line` (`56910eeac3`)
- B) Unattributed-failure warning instead of fan-out (`759389ede9`)
- C) Pin last-wins ordering for ready+failed events (`337f29586e`)
- D) Codex stdout fixture for regex-drift regression test (`f7094e1fe9`)

Refs PR #1802 (commit b94c9cb066).

Generated by Codex dispatch `codex-1805-mcp-observer` from brief `briefs/2026-05-10/codex-1805-mcp-runtime-observer-hardening.md`. PR creation step skipped by worker — surfaced and opened by orchestrator.