### PR TITLE
docs(dobra-forma): fix doubled 'the the' transcription typo

### DIFF
--- a/docs/references/dobra-forma/chapters/7.1.md
+++ b/docs/references/dobra-forma/chapters/7.1.md
@@ -26,7 +26,7 @@ Note how in response to the question **звідки** (&#8216;from where'), prep
 
 – Я **з Кана́ди**.
 
-Complete the sentences below paying careful attention to context and to what you have learned about the the use of genitive case after prepositions thus far.
+Complete the sentences below paying careful attention to context and to what you have learned about the use of genitive case after prepositions thus far.
 
 ## Завда́ння 2
 
@@ -66,7 +66,7 @@ Note how the prepositional phrase with** з** is often followed by the prepositi
 
 – Пога́но. Ма́ю за́раз се́сію (&#8216;final exams period'), вчу́ся **з ра́нку до ве́чора**.
 
-Complete the sentences below paying careful attention to context and to what you have learned about the the use of genitive case after prepositions thus far.
+Complete the sentences below paying careful attention to context and to what you have learned about the use of genitive case after prepositions thus far.
 
 ## Ціка́во!
 


### PR DESCRIPTION
## Summary
- Fix two identical `the the use` doubled-word transcription typos in `docs/references/dobra-forma/chapters/7.1.md` (lines 29 and 69). Both are markdown-conversion artifacts; original OER source unchanged.

## Primary purpose: CI verification (noop carrier)
Per afternoon 2026-05-10 handoff P0 — this PR exists primarily to verify that **PR-A #1854** (trigger duplication kill) held on subsequent PRs. Specifically checking:
- `gh pr checks` shows **single check entries** (not 2× of each from `push` + `pull_request` both firing)
- **No** `gemini-dispatch.yml` debugger row
- **No** 6-job Gemini cascade (`review`/`triage`/`invoke`/`plan-execute`/`fallthrough`)

If checks look clean, **close without merging** — the typo fix is incidental.

## Test plan
- [x] `git diff --stat` shows 1 file, +2/-2
- [ ] `gh pr checks` post-CI shows single entries per workflow
- [ ] No debugger / no 6-job cascade
- [ ] Close PR (do not merge — too low value to roll the dice on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)