### PR TITLE
fix(rename): complete playgrounds→dashboards rename across Python + tests

### DIFF
--- a/scripts/api/docs_router.py
+++ b/scripts/api/docs_router.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import
 
-from .config import PROJECT_ROOT
+from .config import DASHBOARDS_DIR, PROJECT_ROOT
 
 router = APIRouter(tags=["docs"])
 
@@ -36,11 +36,12 @@ ALLOWED_ROOTS = {
     "docs/references/external": PROJECT_ROOT / "docs" / "references" / "external",
 }
 
-_ALLOWED_EXT = {".html", ".md", ".txt", ".png", ".jpg", ".jpeg", ".svg", ".webp", ".pdf"}
+_ALLOWED_EXT = {".html", ".md", ".txt", ".json", ".png", ".jpg", ".jpeg", ".svg", ".webp", ".pdf"}
 _MIME_TYPES = {
     ".html": "text/html",
     ".md": "text/markdown",
     ".txt": "text/plain",
+    ".json": "application/json",
     ".png": "image/png",
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",
@@ -207,7 +208,7 @@ def collect_html_artifacts(
 async def list_roots(request: Request, format: str | None = Query(None, pattern="^(json)$")):
     """List all approved documentation roots."""
     if request.url.path.startswith("/artifacts") and format != "json":
-        return FileResponse(PROJECT_ROOT / "playgrounds" / "artifacts.html", media_type="text/html")
+        return FileResponse(DASHBOARDS_DIR / "artifacts.html", media_type="text/html")
     return {
         "roots": [
             {
@@ -248,7 +249,7 @@ async def serve_artifact(
 
     if full_path.is_dir():
         if request.url.path.startswith("/artifacts") and format != "json":
-            return FileResponse(PROJECT_ROOT / "playgrounds" / "artifacts.html", media_type="text/html")
+            return FileResponse(DASHBOARDS_DIR / "artifacts.html", media_type="text/html")
         return _directory_listing(path, root_key, root_path, remainder)
 
     # File serving

--- a/tests/test_api_router_split.py
+++ b/tests/test_api_router_split.py
@@ -21,7 +21,7 @@ from scripts.api.main import app
 
 client = TestClient(app)
 
-DASHBOARD_PATH = Path(__file__).resolve().parent.parent / "playgrounds" / "v2-blue" / "batch-monitor.html"
+DASHBOARD_PATH = Path(__file__).resolve().parent.parent / "dashboards" / "v2-blue" / "batch-monitor.html"
 _DASHBOARD_MISSING = not DASHBOARD_PATH.exists()
 
 
@@ -201,13 +201,13 @@ class TestStaticServing:
         assert r.status_code in (200, 404)
 
     def test_static_path_traversal_is_rejected(self, tmp_path, monkeypatch):
-        playgrounds_dir = tmp_path / "playgrounds"
-        playgrounds_dir.mkdir()
-        (playgrounds_dir / "index.html").write_text("ok", "utf-8")
+        dashboards_dir = tmp_path / "dashboards"
+        dashboards_dir.mkdir()
+        (dashboards_dir / "index.html").write_text("ok", "utf-8")
         outside_file = tmp_path / "secret.txt"
         outside_file.write_text("secret", "utf-8")
 
-        monkeypatch.setattr("scripts.api.main.PLAYGROUNDS_DIR", playgrounds_dir)
+        monkeypatch.setattr("scripts.api.main.DASHBOARDS_DIR", dashboards_dir)
 
         r = client.get("/%2e%2e/secret.txt")
 

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -1,4 +1,4 @@
-"""Tests for playground data generation and HTML validation."""
+"""Tests for dashboard data generation and HTML validation."""
 from __future__ import annotations
 
 import re
@@ -9,7 +9,7 @@ from typing import ClassVar
 import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
-PLAYGROUNDS_DIR = ROOT / "playgrounds"
+DASHBOARDS_DIR = ROOT / "dashboards"
 sys.path.insert(0, str(ROOT / "scripts"))
 sys.path.insert(0, str(ROOT / "scripts" / "generate_mdx"))
 
@@ -72,9 +72,9 @@ class TestParseNaturalness:
 # ── HTML validation tests ───────────────────────────────────────
 
 class TestHtmlValidation:
-    """Validate playground HTML files have valid structure."""
+    """Validate dashboard HTML files have valid structure."""
 
-    HTML_FILES = sorted(PLAYGROUNDS_DIR.glob("*.html"))
+    HTML_FILES = sorted(DASHBOARDS_DIR.glob("*.html"))
 
     @pytest.mark.parametrize("html_file", HTML_FILES, ids=lambda p: p.name)
     def test_has_doctype(self, html_file):
@@ -114,7 +114,7 @@ class TestHtmlValidation:
 class TestApiEndpoints:
     """Verify dashboard API endpoints are defined in the API server."""
 
-    # All endpoints referenced in playground HTML files
+    # All endpoints referenced in dashboard HTML files
     EXPECTED_ENDPOINTS: ClassVar[set[str]] = {
         "/api/artifacts/html",
         "/api/comms/batch-progress",
@@ -171,7 +171,7 @@ class TestApiEndpoints:
     def test_fetch_calls_in_html(self):
         """Verify all fetch calls reference known endpoints."""
         all_endpoints = set()
-        for html_file in PLAYGROUNDS_DIR.glob("*.html"):
+        for html_file in DASHBOARDS_DIR.glob("*.html"):
             text = html_file.read_text()
             # Extract fetch URLs, strip query params
             fetches = re.findall(r"fetch\(['\"]([^'\"]+)['\"]", text)
@@ -181,7 +181,7 @@ class TestApiEndpoints:
 
         # All found endpoints should be in our known set
         unknown = all_endpoints - self.EXPECTED_ENDPOINTS
-        assert not unknown, f"Unknown API endpoints in playgrounds: {unknown}"
+        assert not unknown, f"Unknown API endpoints in dashboards: {unknown}"
 
 
 # ── Dashboard inventory ─────────────────────────────────────────
@@ -201,13 +201,13 @@ class TestDashboardInventory:
     }
 
     def test_expected_dashboards_exist(self):
-        actual = {f.name for f in PLAYGROUNDS_DIR.glob("*.html")}
+        actual = {f.name for f in DASHBOARDS_DIR.glob("*.html")}
         missing = self.EXPECTED_DASHBOARDS - actual
         assert not missing, f"Missing dashboards: {missing}"
 
     def test_index_links_to_other_dashboards(self):
         """Index page should link to other dashboards."""
-        index = PLAYGROUNDS_DIR / "index.html"
+        index = DASHBOARDS_DIR / "index.html"
         if not index.exists():
             pytest.skip("No index.html")
         text = index.read_text()

--- a/tests/test_docs_router.py
+++ b/tests/test_docs_router.py
@@ -32,9 +32,9 @@ def controlled_docs_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dic
     (outside_root / "secret.html").write_text("secret outside root", encoding="utf-8")
     (safe_root / "escape.html").symlink_to(outside_root / "secret.html")
 
-    playgrounds = tmp_path / "playgrounds"
-    playgrounds.mkdir()
-    (playgrounds / "artifacts.html").write_text("<!doctype html><title>Artifacts</title>", encoding="utf-8")
+    dashboards = tmp_path / "dashboards"
+    dashboards.mkdir()
+    (dashboards / "artifacts.html").write_text("<!doctype html><title>Artifacts</title>", encoding="utf-8")
 
     monkeypatch.setattr(docs_router, "PROJECT_ROOT", tmp_path)
     monkeypatch.setattr(docs_router, "ALLOWED_ROOTS", {"safe": safe_root})

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-PLAYGROUNDS = ROOT / "playgrounds"
+DASHBOARDS = ROOT / "dashboards"
 PRIMARY_NAV_HREFS = [
     "/",
     "/orient.html",
@@ -15,7 +15,7 @@ PRIMARY_NAV_HREFS = [
 
 
 def test_index_page_uses_shared_parchment_monitor_design():
-    html = (PLAYGROUNDS / "index.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "index.html").read_text(encoding="utf-8")
     assert '<link rel="stylesheet" href="/monitor.css">' in html
     assert '<a class="active" href="/">Home</a>' in html
     assert "Operations launchpad" in html
@@ -52,7 +52,7 @@ def test_index_page_uses_shared_parchment_monitor_design():
     ],
 )
 def test_playground_page_uses_shared_parchment_monitor_design(filename, active_link, heading):
-    html = (ROOT / "playgrounds" / filename).read_text(encoding="utf-8")
+    html = (ROOT / "dashboards" / filename).read_text(encoding="utf-8")
     assert '<link rel="stylesheet" href="/monitor.css">' in html
     assert 'class="monitor-nav"' in html
     assert 'aria-label="Monitor sections"' in html
@@ -64,7 +64,7 @@ def test_playground_page_uses_shared_parchment_monitor_design(filename, active_l
 
 
 def test_channels_page_has_shareable_deeplink_contract():
-    html = (PLAYGROUNDS / "channels.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "channels.html").read_text(encoding="utf-8")
     assert "new URLSearchParams(location.search)" in html
     assert "params.get('channel')" in html
     assert "params.get('thread')" in html
@@ -74,7 +74,7 @@ def test_channels_page_has_shareable_deeplink_contract():
 
 
 def test_orient_page_renders_active_discussions_widget():
-    html = (PLAYGROUNDS / "orient.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "orient.html").read_text(encoding="utf-8")
     assert "Active Discussions" in html
     assert "/api/discussions/active" in html
     assert "Promise.allSettled" in html
@@ -84,7 +84,7 @@ def test_orient_page_renders_active_discussions_widget():
 
 
 def test_runtime_page_keeps_primary_monitor_nav():
-    html = (PLAYGROUNDS / "runtime.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "runtime.html").read_text(encoding="utf-8")
     assert '<link rel="stylesheet" href="/monitor.css">' in html
     assert '<a class="active" href="/runtime.html">Runtime</a>' in html
     for href in [
@@ -98,14 +98,14 @@ def test_runtime_page_keeps_primary_monitor_nav():
 
 
 def test_shared_monitor_css_targets_unified_nav_classes():
-    css = (PLAYGROUNDS / "monitor.css").read_text(encoding="utf-8")
+    css = (DASHBOARDS / "monitor.css").read_text(encoding="utf-8")
     assert ".topbar .nav" not in css
     assert ".topbar .monitor-nav" in css
     assert ".top-bar .monitor-nav" in css
 
 
 def test_comms_page_keeps_secondary_dashboard_links():
-    html = (PLAYGROUNDS / "comms.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "comms.html").read_text(encoding="utf-8")
     for href in [
         "/audit-dashboard.html",
         "/progress.html",
@@ -117,7 +117,7 @@ def test_comms_page_keeps_secondary_dashboard_links():
 
 
 def test_artifacts_page_uses_metadata_endpoint_and_filters():
-    html = (PLAYGROUNDS / "artifacts.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "artifacts.html").read_text(encoding="utf-8")
     assert "/api/artifacts/html" in html
     assert "class-filter" in html
     assert "status-filter" in html
@@ -127,7 +127,7 @@ def test_artifacts_page_uses_metadata_endpoint_and_filters():
 
 
 def test_artifacts_page_preserves_legacy_dashboard_links():
-    html = (PLAYGROUNDS / "artifacts.html").read_text(encoding="utf-8")
+    html = (DASHBOARDS / "artifacts.html").read_text(encoding="utf-8")
     assert 'href="/"' in html
     for href in [
         "/admin.html",
@@ -148,11 +148,11 @@ def test_artifacts_page_preserves_legacy_dashboard_links():
         "/wiki.html",
     ]:
         assert f'href="{href}"' in html
-        assert (PLAYGROUNDS / href.lstrip("/")).exists()
+        assert (DASHBOARDS / href.lstrip("/")).exists()
 
 
 def test_all_playground_pages_use_single_monitor_shell():
-    for path in sorted(PLAYGROUNDS.glob("*.html")):
+    for path in sorted(DASHBOARDS.glob("*.html")):
         html = path.read_text(encoding="utf-8")
         assert '<link rel="stylesheet" href="/monitor.css">' in html, path.name
         assert 'class="monitor-nav"' in html, path.name
@@ -182,7 +182,7 @@ def test_operations_pages_keep_secondary_navigation():
         ],
     }
     for page, hrefs in pages_to_hrefs.items():
-        html = (PLAYGROUNDS / page).read_text(encoding="utf-8")
+        html = (DASHBOARDS / page).read_text(encoding="utf-8")
         assert 'class="ops-nav"' in html, page
         for href in hrefs:
             assert f'href="{href}"' in html, page

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -1,4 +1,4 @@
-"""Smoke tests for playground dashboard API stability."""
+"""Smoke tests for dashboard API stability."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Point remaining dashboard/documentation serving paths at `DASHBOARDS_DIR` / `dashboards`.
- Rename `tests/test_playgrounds.py` to `tests/test_dashboards.py` and update dashboard test fixtures/constants.
- Keep scope-guard files untouched. `scripts/build/build_playgrounds.py` and `scripts/generate_mdx/generate_playground_data.py` still contain legacy names by request and are left for a follow-up.

## Survey

Exact requested survey command was run first:

```bash
ugrep -rn 'PLAYGROUNDS\|playgrounds' scripts/ tests/ --include='*.py' | tee /tmp/playgrounds-survey.txt
```

On local `ugrep 7.8.1`, that emitted no lines because the escaped pipe is literal in the default regex mode. The effective pre-edit scope survey was run with basic regex mode so `\|` is treated as alternation:

```bash
ugrep -G -rn 'PLAYGROUNDS\|playgrounds' scripts/ tests/ --include='*.py'
```

```text
scripts/build_dashboards.py:2:"""Stub: module moved to scripts/build/build_playgrounds.py"""
scripts/build_dashboards.py:7:_f = _P(__file__).parent / "build" / "build_playgrounds.py"
scripts/build_dashboards.py:12:    _s = _ilu.spec_from_file_location("build_playgrounds", _f)
scripts/generate_mdx/generate_playground_data.py:179:    # Write to playgrounds directory
scripts/generate_mdx/generate_playground_data.py:180:    output_path = Path(__file__).parent.parent / "playgrounds" / "data" / "status.json"
scripts/api/comms_router.py:1070:# (playgrounds/channels.html). They reuse the same broker DB as the
scripts/api/docs_router.py:210:        return FileResponse(PROJECT_ROOT / "playgrounds" / "artifacts.html", media_type="text/html")
scripts/api/docs_router.py:251:            return FileResponse(PROJECT_ROOT / "playgrounds" / "artifacts.html", media_type="text/html")
scripts/build/build_playgrounds.py:7:PLAYGROUNDS_DIR = Path(__file__).parent.parent.parent / "playgrounds"
scripts/build/build_playgrounds.py:8:DATA_FILE = PLAYGROUNDS_DIR / "data" / "status.json"
scripts/build/build_playgrounds.py:739:    output_path = PLAYGROUNDS_DIR / "playground-module-status.html"
scripts/build/build_playgrounds.py:747:    """Build all playgrounds."""
scripts/build/build_playgrounds.py:748:    print("Building playgrounds with real data...\n")
scripts/build/build_playgrounds.py:750:    print("\nDone! Open playgrounds/index.html to see the landing page.")
tests/test_docs_router.py:35:    playgrounds = tmp_path / "playgrounds"
tests/test_docs_router.py:36:    playgrounds.mkdir()
tests/test_docs_router.py:37:    (playgrounds / "artifacts.html").write_text("<!doctype html><title>Artifacts</title>", encoding="utf-8")
tests/test_monitor_ui_contracts.py:6:PLAYGROUNDS = ROOT / "playgrounds"
tests/test_monitor_ui_contracts.py:18:    html = (PLAYGROUNDS / "index.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:55:    html = (ROOT / "playgrounds" / filename).read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:67:    html = (PLAYGROUNDS / "channels.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:77:    html = (PLAYGROUNDS / "orient.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:87:    html = (PLAYGROUNDS / "runtime.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:101:    css = (PLAYGROUNDS / "monitor.css").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:108:    html = (PLAYGROUNDS / "comms.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:120:    html = (PLAYGROUNDS / "artifacts.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:130:    html = (PLAYGROUNDS / "artifacts.html").read_text(encoding="utf-8")
tests/test_monitor_ui_contracts.py:151:        assert (PLAYGROUNDS / href.lstrip("/")).exists()
tests/test_monitor_ui_contracts.py:155:    for path in sorted(PLAYGROUNDS.glob("*.html")):
tests/test_monitor_ui_contracts.py:185:        html = (PLAYGROUNDS / page).read_text(encoding="utf-8")
tests/test_playgrounds.py:12:PLAYGROUNDS_DIR = ROOT / "playgrounds"
tests/test_playgrounds.py:77:    HTML_FILES = sorted(PLAYGROUNDS_DIR.glob("*.html"))
tests/test_playgrounds.py:174:        for html_file in PLAYGROUNDS_DIR.glob("*.html"):
tests/test_playgrounds.py:184:        assert not unknown, f"Unknown API endpoints in playgrounds: {unknown}"
tests/test_playgrounds.py:204:        actual = {f.name for f in PLAYGROUNDS_DIR.glob("*.html")}
tests/test_playgrounds.py:210:        index = PLAYGROUNDS_DIR / "index.html"
tests/test_api_router_split.py:24:DASHBOARD_PATH = Path(__file__).resolve().parent.parent / "playgrounds" / "v2-blue" / "batch-monitor.html"
tests/test_api_router_split.py:204:        playgrounds_dir = tmp_path / "playgrounds"
tests/test_api_router_split.py:205:        playgrounds_dir.mkdir()
tests/test_api_router_split.py:206:        (playgrounds_dir / "index.html").write_text("ok", "utf-8")
tests/test_api_router_split.py:210:        monkeypatch.setattr("scripts.api.main.PLAYGROUNDS_DIR", playgrounds_dir)
```

## Diff Stat

```text
 scripts/api/docs_router.py                        |  9 ++++----
 tests/test_api_router_split.py                    | 10 ++++-----
 tests/{test_playgrounds.py => test_dashboards.py} | 18 ++++++++--------
 tests/test_docs_router.py                         |  6 +++---
 tests/test_monitor_ui_contracts.py                | 26 +++++++++++------------
 tests/test_playground_api_stability.py            |  2 +-
 6 files changed, 36 insertions(+), 35 deletions(-)
```

## Verification

```text
$ .venv/bin/ruff check scripts/ tests/
All checks passed!
```

```text
$ .venv/bin/python -m pytest tests/test_docs_router.py tests/test_monitor_ui_contracts.py tests/test_api_router_split.py tests/test_dashboards.py tests/test_playground_api_stability.py -v
tests/test_playground_api_stability.py::test_dashboard_endpoint_budget_coverage_is_explicit PASSED [ 98%]
tests/test_playground_api_stability.py::test_p95_of_three_perf_probe_allows_one_slow_tail PASSED [ 99%]
tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast PASSED [100%]

======================== 172 passed, 6 skipped in 4.53s ========================
```

No test deletions:

```text
$ git diff origin/main...HEAD -- tests/ | grep -E '^-(async )?def test_'
# no output
```

## Scope Guards

Confirmed untouched: `.python-version`, `.yamllint`, `.markdownlint.json`, `scripts/delegate.py`, `scripts/audit_module.sh`, `scripts/verification/vesum.py`, `scripts/api/agent_router.py`, `scripts/api/rag_router.py`, `scripts/api/admin_router.py`, `scripts/build/build_playgrounds.py`, `scripts/generate_mdx/generate_playground_data.py`, `dashboards/admin.html`, `starlight/`, `curriculum/`, and `plans/`.

No `status/*.json`, `audit/*-review.md`, `review/*-review.md`, or `.bak` files are in the diff. No `sys.executable` or new `@pytest.mark.skip` appears in the diff.
