### PR TITLE
feat(mcp): add verify_quote tool (#1877)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -26,7 +26,9 @@ Tools:
 import asyncio
 import contextlib
 import json
+import re
 import sys
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -332,6 +334,33 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["word"]
+            },
+        ),
+        Tool(
+            name="verify_quote",
+            description=(
+                "Verify whether a Ukrainian literary quote is genuinely attested in the corpus for a given author. "
+                "Returns boolean verdict + matched line(s) with work/year provenance + confidence score. "
+                "Use INSTEAD of search_literary + grep + manual line reading when checking a quotation."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string",
+                        "description": "Author name in Ukrainian (e.g., 'Шевченко', 'Леся Українка'). Matched against the literary corpus author column with normalization.",
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "The quoted text to verify, in Ukrainian. Accents/stress marks and punctuation differences tolerated.",
+                    },
+                    "min_confidence": {
+                        "type": "number",
+                        "description": "Minimum fuzzy-match confidence to count as 'matched' (0.0-1.0). Default 0.80.",
+                        "default": 0.80,
+                    },
+                },
+                "required": ["author", "text"],
             },
         ),
         Tool(
@@ -891,6 +920,79 @@ async def handle_check_russian_shadow(args: dict):
     return [TextContent(type="text", text=json.dumps(result, indent=2, ensure_ascii=False))]
 
 
+def _normalize_quote_text(value: str) -> str:
+    text = "".join(
+        ch for ch in unicodedata.normalize("NFKD", str(value).lower())
+        if not "\u0300" <= ch <= "\u036f"
+    )
+    text = text.translate(str.maketrans({ch: " " for ch in "«»“”„\"'`"}))
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _normalize_author_name(value: str) -> str:
+    text = _normalize_quote_text(str(value).replace(".", " "))
+    tokens = [t for t in text.split() if len(t) > 1]
+    patronymics = ("ович", "евич", "ич", "івна", "ївна", "овна", "евна")
+    tokens = [t for t in tokens if not t.endswith(patronymics)]
+    return tokens[-1] if tokens else text
+
+
+def _best_quote_excerpt(text_query: str, chunk_text: str) -> str:
+    from rapidfuzz import fuzz
+
+    lines = [line.strip() for line in str(chunk_text).splitlines() if line.strip()]
+    windows = [" ".join(lines[i:i + width]) for i in range(len(lines)) for width in range(1, 5)]
+    if not windows:
+        windows = [str(chunk_text)]
+    return max(windows, key=lambda line: fuzz.partial_ratio(text_query, _normalize_quote_text(line)))
+
+
+async def handle_verify_quote(args: dict) -> list[TextContent]:
+    author_query = _normalize_author_name(args.get("author", ""))
+    text_query = _normalize_quote_text(args.get("text", ""))
+    if not author_query:
+        raise ValueError("author is required")
+    if not text_query:
+        raise ValueError("text is required")
+
+    min_confidence = max(0.0, min(float(args.get("min_confidence", 0.80)), 1.0))
+    keywords = {word for word in text_query.split() if len(word) >= 3}
+
+    from wiki.sources_db import search_literary
+
+    hits = await asyncio.to_thread(search_literary, keywords, 20)
+    candidates = []
+    from rapidfuzz import fuzz
+
+    for hit in hits:
+        if _normalize_author_name(hit.get("author", "")) != author_query:
+            continue
+        chunk_text = hit.get("text", "")
+        line = _best_quote_excerpt(text_query, chunk_text)
+        confidence = fuzz.partial_ratio(text_query, _normalize_quote_text(chunk_text)) / 100
+        candidates.append({
+            "line": line,
+            "work": hit.get("title") or hit.get("source_file") or "",
+            "year": hit.get("year"),
+            "confidence": round(confidence, 4),
+            "context_chunk_id": hit.get("chunk_id"),
+        })
+
+    candidates.sort(key=lambda item: item["confidence"], reverse=True)
+    matched = bool(candidates and candidates[0]["confidence"] >= min_confidence)
+    result = {
+        "matched": matched,
+        "best_confidence": candidates[0]["confidence"] if candidates else 0.0,
+        "matched_lines": [item for item in candidates if item["confidence"] >= min_confidence][:3]
+        if matched else candidates[:3],
+        "search_normalized": {
+            "author_query": author_query,
+            "text_query": text_query,
+        },
+    }
+    return [TextContent(type="text", text=json.dumps(result, indent=2, ensure_ascii=False))]
+
+
 @server.call_tool()
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Handle tool calls."""
@@ -909,6 +1011,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             "collection_stats": lambda: handle_collection_stats(arguments),
             "check_russian_shadow": lambda: handle_check_russian_shadow(arguments),
             "check_modern_form": lambda: handle_check_modern_form(arguments),
+            "verify_quote": lambda: handle_verify_quote(arguments),
             "verify_word": lambda: handle_verify_word(arguments),
             "verify_words": lambda: handle_verify_words(arguments),
             "verify_lemma": lambda: handle_verify_lemma(arguments),

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -49,7 +49,7 @@ class TestListTools:
         expected = {
             "search_sources", "search_text", "search_images", "search_literary", "search_external",
             "get_full_text", "get_chunk_context", "collection_stats",
-            "verify_word", "verify_words", "verify_lemma", "check_modern_form",
+            "verify_word", "verify_words", "verify_lemma", "verify_quote", "check_modern_form",
             "query_wikipedia", "query_grac", "query_ulif",
             "query_r2u", "query_e2u", "query_sum20", "query_slovnyk_me",
             "query_pravopys", "query_cefr_level",
@@ -85,6 +85,12 @@ class TestListTools:
         assert props["type"] == "array"
         assert props["items"]["type"] == "string"
 
+    def test_verify_quote_schema(self, server_module):
+        tools = _run(server_module.list_tools())
+        vq = next(t for t in tools if t.name == "verify_quote")
+        assert vq.inputSchema["required"] == ["author", "text"]
+        assert vq.inputSchema["properties"]["min_confidence"]["default"] == 0.80
+
 
 class TestCallToolDispatch:
     """Test that call_tool routes to correct handlers."""
@@ -105,6 +111,12 @@ class TestCallToolDispatch:
             mock.return_value = [MagicMock(text="ok")]
             _run(server_module.call_tool("verify_words", {"words": ["тест"]}))
             mock.assert_called_once_with({"words": ["тест"]})
+
+    def test_verify_quote_dispatches(self, server_module):
+        with patch.object(server_module, "handle_verify_quote", new_callable=AsyncMock) as mock:
+            mock.return_value = [MagicMock(text="ok")]
+            _run(server_module.call_tool("verify_quote", {"author": "Шевченко", "text": "Та в Сибір загнали"}))
+            mock.assert_called_once_with({"author": "Шевченко", "text": "Та в Сибір загнали"})
 
     def test_search_sources_dispatches(self, server_module):
         with patch.object(server_module, "handle_search_sources", new_callable=AsyncMock) as mock:
@@ -189,6 +201,89 @@ class TestVerifyWordsHandler:
             assert "Found: 1/2" in text
             assert "**стій** — FOUND" in text
             assert "**взяйте** — NOT FOUND" in text
+
+
+def _shevchenko_quote_hits():
+    # Known-good source confirmed with mcp__sources__search_literary:
+    # query="загнали в Сибір", chunk_id=d1b5c8a6_c0084, author="Шевченко Т."
+    return [
+        {
+            "chunk_id": "d1b5c8a6_c0084",
+            "title": "",
+            "author": "Шевченко Т.",
+            "year": 1814,
+            "source_file": "ukrlib-shevchenko",
+            "text": (
+                "Що розлили з річку крові\n\n"
+                "Та в Сибір загнали\n\n"
+                "Свою шляхту, то вже й годі,\n\n"
+                "Уже й запишались."
+            ),
+        },
+        {
+            "chunk_id": "9976239a_c0473",
+            "title": "",
+            "author": "Шевченко Т.",
+            "year": 1961,
+            "source_file": "wave10-shevchenko-tvory-t1",
+            "text": "Сибір неісходима,\n\nА тюрм, а люду! що й казать!",
+        },
+        {
+            "chunk_id": "other_shevchenko",
+            "title": "Садок вишневий коло хати",
+            "author": "Т. Г. Шевченко",
+            "year": 1847,
+            "source_file": "fixture",
+            "text": "Садок вишневий коло хати,\n\nХрущі над вишнями гудуть.",
+        },
+    ]
+
+
+class TestVerifyQuoteHandler:
+    """Test verify_quote fuzzy attribution checks."""
+
+    def test_known_good_shevchenko_line_matches(self, server_module):
+        with patch("wiki.sources_db.search_literary", return_value=_shevchenko_quote_hits()):
+            result = _run(
+                server_module.handle_verify_quote(
+                    {"author": "Шевченко", "text": "Та в Сибір загнали Свою шляхту"}
+                )
+            )
+        data = json.loads(result[0].text)
+        assert data["matched"] is True
+        assert data["best_confidence"] >= 0.90
+        assert data["matched_lines"][0]["context_chunk_id"] == "d1b5c8a6_c0084"
+
+    def test_fabricated_fused_quote_returns_near_misses(self, server_module):
+        with patch("wiki.sources_db.search_literary", return_value=_shevchenko_quote_hits()):
+            result = _run(
+                server_module.handle_verify_quote(
+                    {"author": "Шевченко", "text": "Загнали в Сибір неісходиму"}
+                )
+            )
+        data = json.loads(result[0].text)
+        assert data["matched"] is False
+        assert len(data["matched_lines"]) == 3
+        assert data["matched_lines"][0]["confidence"] < 0.80
+
+    def test_author_variants_find_same_line(self, server_module):
+        matched_ids = []
+        for author in ["Шевченко", "Т. Г. Шевченко", "Тарас Шевченко"]:
+            with patch("wiki.sources_db.search_literary", return_value=_shevchenko_quote_hits()):
+                result = _run(
+                    server_module.handle_verify_quote(
+                        {"author": author, "text": "Та в Сибір загнали Свою шляхту"}
+                    )
+                )
+            data = json.loads(result[0].text)
+            assert data["matched"] is True
+            matched_ids.append(data["matched_lines"][0]["context_chunk_id"])
+        assert matched_ids == ["d1b5c8a6_c0084"] * 3
+
+    def test_empty_text_returns_clean_error(self, server_module):
+        result = _run(server_module.call_tool("verify_quote", {"author": "Шевченко", "text": ""}))
+        assert "ValueError: text is required" in result[0].text
+        assert "Traceback" not in result[0].text
 
 
 class TestSearchSourcesHandler:


### PR DESCRIPTION
Parent EPIC: #1657
Closes #1877

## Summary
- Adds `verify_quote(author, text, min_confidence=0.80)` to the sources MCP server.
- Normalizes quote text with NFKD accent stripping, lowercase, quote removal, and whitespace collapse.
- Normalizes author variants so `Шевченко`, `Т. Г. Шевченко`, and `Тарас Шевченко` resolve to the same corpus author surname.
- Returns the issue-specified JSON shape with boolean verdict, best confidence, matched/near-miss lines, provenance, and normalized search inputs.

## Test cases passing
Raw pytest output:
```text
tests/test_mcp_sources_server.py::TestVerifyQuoteHandler::test_known_good_shevchenko_line_matches PASSED [ 61%]
tests/test_mcp_sources_server.py::TestVerifyQuoteHandler::test_fabricated_fused_quote_returns_near_misses PASSED [ 64%]
tests/test_mcp_sources_server.py::TestVerifyQuoteHandler::test_author_variants_find_same_line PASSED [ 67%]
tests/test_mcp_sources_server.py::TestVerifyQuoteHandler::test_empty_text_returns_clean_error PASSED [ 70%]
============================== 34 passed in 0.58s ==============================
```

Full command:
```text
.venv/bin/pytest tests/test_mcp_sources_server.py -x
```

## Lint
Raw output:
```text
All checks passed!
ruff_exit:0
```

Full command:
```text
.venv/bin/ruff check .mcp/servers/sources/server.py tests/test_mcp_sources_server.py; printf 'ruff_exit:%s\n' "$?"
```

## Tool registration evidence
Raw output:
```text
340:            name="verify_quote",
956:async def handle_verify_quote(args: dict) -> list[TextContent]:
1022:            "verify_quote": lambda: handle_verify_quote(arguments),
```

Full command:
```text
grep -n verify_quote .mcp/servers/sources/server.py
```

## Quote provenance used in tests
Tool call used before writing the fixture:
```text
mcp__sources__search_literary({"query":"загнали в Сибір","limit":5})
```

Raw output excerpt establishing the known-good quote and chunk:
```text
Found 5 results for: "загнали в Сибір"

### Result 1
- **Author**: Шевченко Т.
- **Source**: ukrlib-shevchenko
- **Chunk ID**: `d1b5c8a6_c0084`
- **Text**:
...
Що розлили з річку крові

Та в Сибір загнали

Свою шляхту, то вже й годі,
...
```

Real handler smoke output:
```text
Та в Сибір загнали Свою шляхту
{
  "matched": true,
  "best_confidence": 1.0,
  "top_chunk": "d1b5c8a6_c0084",
  "top_line": "Поганці погані! Що розлили з річку крові Та в Сибір загнали Свою шляхту, то вже й годі,"
}
Загнали в Сибір неісходиму
{
  "matched": false,
  "best_confidence": 0.6923,
  "top_chunk": "9c5bb9e1_c0001",
  "top_line": "Одна Сибір неісходима!"
}
```

## rapidfuzz/difflib rationale
Used `rapidfuzz.fuzz.partial_ratio` because the issue explicitly specifies it and the runtime import is available in the worktree venv. I did not add a `difflib` fallback because that would change the score scale/behavior and make review prompts less deterministic.

Raw runtime dependency check:
```text
Python 3.12.8
rapidfuzz_spec ModuleSpec(name='rapidfuzz', loader=<_frozen_importlib_external.SourceFileLoader object at 0x1010732f0>, origin='/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/codex-1657p2-verify-quote/.venv/lib/python3.12/site-packages/rapidfuzz/__init__.py', submodule_search_locations=['/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/codex-1657p2-verify-quote/.venv/lib/python3.12/site-packages/rapidfuzz'])
```

## Pre-submit evidence
```text
3.12.8
```

```text
.mcp/servers/sources/server.py
tests/test_mcp_sources_server.py
103	0	.mcp/servers/sources/server.py
96	1	tests/test_mcp_sources_server.py
```

```text
diff_check_exit:0
```

No generated status/audit/review artifacts are in the diff. Changed files: 2. Total insertions: 199.
