### PR TITLE
fix(gemini-adapter): honor bridge_only session resume

### DIFF
--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -17,11 +17,10 @@ flag requirements in the codebase:
   selects API-key auth first; otherwise the adapter falls back to
   subscription/OAuth and strips Gemini API env vars from the subprocess.
   Explicit ``GEMINI_AUTH_MODE=api`` or ``subscription`` still wins.
-- No session IDs. Gemini CLI doesn't expose them, so ``parse_response``
-  returns ``session_id=None`` always. Resume policy is ``bridge_only``
-  for cost economics, but session IDs come from the bridge's own SQLite
-  ``sessions`` table and are passed in as ``session_id=...`` — we just
-  ignore it here because the CLI has no ``--resume`` equivalent anyway.
+- **``--resume`` vs ``--session-id``**: Gemini CLI accepts UUID resume.
+  ``--resume <uuid>`` resumes an existing session and ``--session-id
+  <uuid>`` starts a NEW named session with that UUID. The bridge passes
+  ``tool_config={"is_new_session": bool}``, matching ClaudeAdapter.
 
 Key differences from CodexAdapter:
 - Output to stdout (no ``-o <file>``); ``output_file`` stays None.
@@ -61,6 +60,11 @@ _AUTH_MODE_VALUES = frozenset({"auto", "subscription", "api"})
 _INLINE_PROMPT_LIMIT_CHARS = 100_000
 _PROMPT_FILE_PREFIX = "learn-ukrainian-gemini-prompt-"
 _DISCUSS_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
+_UUID_PATTERN = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+_SESSION_ID_RE = re.compile(
+    rf"(?:session[_-]?id[:=]\s*|gemini\s+--resume\s+)({_UUID_PATTERN})",
+    re.IGNORECASE,
+)
 
 
 def _discussion_readonly_requested(tool_config: dict | None) -> bool:
@@ -145,6 +149,19 @@ def _cleanup_prompt_file(path: Path | None) -> None:
         path.unlink()
 
 
+def _extract_session_id(stdout: str, events: list[Mapping[str, object]]) -> str | None:
+    """Extract Gemini's resumable UUID from stdout or parsed trace events."""
+    match = _SESSION_ID_RE.search(stdout or "")
+    if match:
+        return match.group(1)
+
+    for event in events:
+        raw = event.get("session_id") or event.get("sessionId")
+        if isinstance(raw, str) and re.fullmatch(_UUID_PATTERN, raw, re.IGNORECASE):
+            return raw
+    return None
+
+
 class GeminiAdapter:
     """Adapter for the ``gemini`` CLI (Google Gemini)."""
 
@@ -169,12 +186,10 @@ class GeminiAdapter:
     ) -> InvocationPlan:
         """Build the ``gemini`` CLI invocation.
 
-        Defensively ignores ``session_id``: Gemini CLI has no ``--resume``
-        equivalent. The bridge tracks session IDs in its own SQLite table
-        and uses them for conversation-context injection into the prompt,
-        not for CLI-level resume. We silently drop it here.
-
         Supports ``tool_config``:
+            - ``is_new_session: bool`` — if True, use ``--session-id`` (new
+              named session); if False or absent, use ``--resume`` (resume
+              existing). Only meaningful when ``session_id`` is provided.
             - ``{"mcp_server_names": ["rag", "other"]}`` → appended as
               ``--allowed-mcp-server-names rag,other``
             - Any other keys are ignored (forward-compatible).
@@ -230,11 +245,19 @@ class GeminiAdapter:
                     joined = str(mcp_server_names)
                 cmd.extend(["--allowed-mcp-server-names", joined])
 
-        # Silently ignore session_id (CLI has no equivalent) and task_id
-        # (runner already logs it via usage record). cwd IS stamped into
-        # the plan — liveness_signal_paths() needs it to derive the
-        # ~/.gemini/tmp/<basename>/ project dir without reading os.getcwd().
-        _ = session_id
+        # Session handling mirrors ClaudeAdapter: --session-id creates the
+        # named session on the first bridge call, --resume reuses it later.
+        has_session = session_id is not None
+        if has_session:
+            is_new = bool((tool_config or {}).get("is_new_session", False))
+            if is_new:
+                cmd.extend(["--session-id", session_id])
+            else:
+                cmd.extend(["--resume", session_id])
+
+        # task_id is logged by the runner. cwd IS stamped into the plan —
+        # liveness_signal_paths() needs it to derive the ~/.gemini/tmp/
+        # <basename>/ project dir without reading os.getcwd().
         _ = task_id
         requested_auth_mode = None
         if tool_config:
@@ -436,12 +459,14 @@ class GeminiAdapter:
             # do NOT mark rate_limited.
             stderr_excerpt = "transient retry resolved by CLI backoff"
 
+        session_id = _extract_session_id(stdout, trace_events)
+
         return ParseResult(
             ok=ok,
             response=response,
             stderr_excerpt=stderr_excerpt,
             rate_limited=rate_limited,
-            session_id=None,  # Gemini CLI doesn't expose session IDs.
+            session_id=session_id,
             tokens=None,      # Nor tokens.
             tool_calls=tool_calls,
         )

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -2230,8 +2230,7 @@ def test_gemini_adapter_ignores_unknown_tool_config_keys(tmp_path):
     assert "another_future_field" not in cmd_str
 
 
-def test_gemini_adapter_ignores_session_id(tmp_path):
-    """Gemini CLI has no --resume equivalent; session_id must be silently dropped."""
+def test_gemini_adapter_stateless_dispatch_omits_session_flags(tmp_path):
     adapter = GeminiAdapter()
     plan = adapter.build_invocation(
         prompt="hello",
@@ -2239,11 +2238,45 @@ def test_gemini_adapter_ignores_session_id(tmp_path):
         cwd=tmp_path,
         model=None,
         task_id=None,
-        session_id="some-uuid",
+        session_id=None,
         tool_config=None,
     )
     assert "--resume" not in plan.cmd
-    assert "some-uuid" not in " ".join(plan.cmd)
+    assert "--session-id" not in plan.cmd
+
+
+def test_gemini_adapter_new_named_session(tmp_path):
+    adapter = GeminiAdapter()
+    session_id = "2c8337b6-35da-415d-806d-91d10b5b1381"
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="test",
+        session_id=session_id,
+        tool_config={"is_new_session": True},
+    )
+    assert "--session-id" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--session-id") + 1] == session_id
+    assert "--resume" not in plan.cmd
+
+
+def test_gemini_adapter_resume_existing_session(tmp_path):
+    adapter = GeminiAdapter()
+    session_id = "2c8337b6-35da-415d-806d-91d10b5b1381"
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="test",
+        session_id=session_id,
+        tool_config=None,
+    )
+    assert "--resume" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--resume") + 1] == session_id
+    assert "--session-id" not in plan.cmd
 
 
 def test_gemini_parse_response_success():
@@ -2259,6 +2292,22 @@ def test_gemini_parse_response_success():
     assert result.rate_limited is False
     assert result.session_id is None
     assert result.tokens is None
+
+
+def test_gemini_parse_response_extracts_session_uuid_from_resume_hint():
+    adapter = GeminiAdapter()
+    session_id = "2c8337b6-35da-415d-806d-91d10b5b1381"
+    result = adapter.parse_response(
+        stdout=(
+            "Done.\n\n"
+            f"To resume this session: gemini --resume {session_id}\n"
+        ),
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+    assert result.ok is True
+    assert result.session_id == session_id
 
 
 def test_gemini_parse_response_rate_limit_resource_exhausted():


### PR DESCRIPTION
## Summary

- Fixes #1887. Adapter was dropping `session_id` despite registry policy `resume_policy="bridge_only"`. Tier-2 #1783 set the policy but adapter never honored it.
- Mirrors `claude.py` pattern (verified by user 2026-05-11 night via deterministic CLI proof: `gemini --resume <uuid>` works per docs + on-quit hint).

## Test plan

- [ ] CI green
- [ ] Adapter unit test for `bridge_only` resume path passes
- [ ] X-Agent trailer present (`codex/1887-gemini-warm-cache`)
- [ ] No out-of-scope file changes (only `scripts/agent_runtime/gemini.py` + tests)

🤖 Dispatched via `scripts/delegate.py` — Codex worktree `.worktrees/dispatch/codex/1887-gemini-warm-cache/`