### PR TITLE
feat(local-ci): act-based local CI replay (#1891)

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,25 @@
+# Local CI replay via `act` (nektos/act).
+# Tracked under issue #1891. Decision: act > Dagger for the 4m17s GHA loop pain.
+# See docs/best-practices/local-ci-replay.md for the per-project usage pattern.
+
+# Apple Silicon: GHA runners are amd64 — pin to match so `actions/setup-python`
+# and other amd64-only actions resolve correctly. Adds emulation overhead but
+# avoids "no matching manifest" errors on arm64-only images.
+--container-architecture linux/amd64
+
+# Runner image: `act-latest` (medium, ~1GB) — has python3, node, git, common
+# tools. Good fit for the CI jobs in .github/workflows/ci.yml. `act-22.04` is
+# the alias for ubuntu-22.04 → same medium image. Avoid `act-full` (~17GB) and
+# `act-micro` (no Python).
+-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
+-P ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04
+-P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
+
+# Auto-remove containers when the run ends. Without this, OrbStack accumulates
+# stopped containers fast on iterative runs.
+--rm
+
+# Reuse the same container across `act` invocations when possible — speeds up
+# the dev loop because pip install caches survive. Pair with --rm: act removes
+# only on graceful exit, so a re-run on the same job reuses the cached layers.
+--reuse

--- a/.github/act-event-push.json
+++ b/.github/act-event-push.json
@@ -1,0 +1,18 @@
+{
+  "_doc": "Push-event payload for local CI replay via act. Tracked under #1891.",
+  "_why_this_exists": "act emits a minimal synthetic event that omits repository.default_branch. dorny/paths-filter@v4 (used in ci.yml::changes) errors without it. We don't want to modify ci.yml to pass a fallback (would deviate from GHA). Instead, feed act this event payload via --eventpath.",
+  "ref": "refs/heads/main",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "0000000000000000000000000000000000000000",
+  "repository": {
+    "name": "learn-ukrainian.github.io",
+    "full_name": "learn-ukrainian/learn-ukrainian.github.io",
+    "default_branch": "main",
+    "owner": {
+      "login": "learn-ukrainian"
+    }
+  },
+  "pusher": {
+    "name": "local-act-runner"
+  }
+}

--- a/docs/best-practices/local-ci-replay.md
+++ b/docs/best-practices/local-ci-replay.md
@@ -1,0 +1,187 @@
+# Local CI Replay with `act`
+
+> **TL;DR.** `scripts/local-ci.sh -W .github/workflows/ci.yml -j lint` runs
+> the exact GHA workflow file locally in Docker via [act][act]. Same
+> workflow file as production; no fork. First run pulls a ~1 GB runner
+> image; subsequent runs reuse the container with `--reuse` so
+> iteration drops to seconds for lightweight jobs.
+>
+> Tracked under GH issue [#1891][issue-1891]. Decision history: we chose
+> `act` over Dagger after the orchestrator pushed back — Dagger requires
+> rewriting all pipelines as Python/Go/TS code (months of work), while
+> `act` replays the existing `.github/workflows/*.yml` unchanged.
+
+[act]: https://github.com/nektos/act
+[issue-1891]: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/1891
+
+---
+
+## Why this exists
+
+The `Test (pytest)` GHA job takes ~4m17s end-to-end (cold setup-python,
+fresh pip install of every requirement, full sources.db build). Locally
+in `.venv/`, pytest discovery is ~0.19s. The 1300× gap is the dev-loop
+tax we pay every time we have to debug something that only reproduces
+on a GHA runner — typically the gnarliest CI bugs.
+
+`act` closes the gap by running the same workflow YAML inside a
+container that approximates the GHA runner. The first run is the
+investment (image pull + dep install), every subsequent run is fast.
+
+## Setup (one-time)
+
+```bash
+brew install act      # macOS host
+```
+
+You also need a running container daemon. The project assumes
+**OrbStack** — `scripts/local-ci.sh` auto-resolves the OrbStack socket
+at `~/.orbstack/run/docker.sock` and auto-starts the daemon if it's
+not running. Docker Desktop also works; set `DOCKER_HOST` manually
+(`unix:///var/run/docker.sock`) and skip the OrbStack auto-start logic
+or replace it in the wrapper.
+
+The repo already contains:
+
+- **`.actrc`** — project defaults: Apple-Silicon arch pin
+  (`--container-architecture linux/amd64`), runner image
+  (`ghcr.io/catthehacker/ubuntu:act-latest`), `--rm`, `--reuse`.
+- **`.github/act-event-push.json`** — static fallback event payload
+  (used when git lookup fails inside the wrapper).
+- **`scripts/local-ci.sh`** — thin wrapper that:
+  1. starts OrbStack if needed,
+  2. exports `DOCKER_HOST` to the OrbStack socket,
+  3. templates a fresh push-event payload with real `before`/`after`
+     SHAs from `git rev-parse` so `dorny/paths-filter@v4` (the gating
+     action in `ci.yml::changes`) detects real changes,
+  4. forwards every other flag verbatim to `act`.
+
+## Common commands
+
+```bash
+# List discoverable jobs
+scripts/local-ci.sh -l
+
+# Validate a job without running it
+scripts/local-ci.sh -W .github/workflows/ci.yml -j lint --dryrun
+
+# Run one job
+scripts/local-ci.sh -W .github/workflows/ci.yml -j lint
+scripts/local-ci.sh -W .github/workflows/ci.yml -j test
+scripts/local-ci.sh -W .github/workflows/ci.yml -j frontend
+
+# Force a fresh container (no --reuse), useful when you need a true
+# cold-start replay of the GHA path
+scripts/local-ci.sh -W .github/workflows/ci.yml -j test --rm
+```
+
+## Measured timings (`Lint (ruff)`)
+
+| Run | Description | Real time |
+|---|---|---|
+| 1 (cold) | Fresh image pull + first run | ~42s (failed on event payload — pre-wrapper-fix) |
+| 2 (image cached) | Image cached, container fresh | **64s** end-to-end |
+| 3 (`--reuse`) | Same job, container reused, deps already installed | **38s** |
+
+For comparison, the same `Lint (ruff)` job on GHA: ~25-35s plus queue
+wait. Local with `--reuse` is comparable to GHA wall-clock with zero
+queue wait, and the diff is closing for repeat-iteration scenarios.
+
+The pytest job pays a much steeper first-run cost (torch CPU wheel
+~600 MB, full requirements-lock install) but should benefit much more
+from `--reuse` since pip cache survives across runs.
+
+## Known gotchas
+
+### `dorny/paths-filter@v4` needs `repository.default_branch`
+
+`act` synthesizes a minimal event payload that omits
+`repository.default_branch`. The `changes` job in `ci.yml` uses
+`dorny/paths-filter@v4` to decide which downstream jobs run; without
+the field, the action errors out with:
+
+> Error: This action requires 'base' input to be configured or
+> 'repository.default_branch' to be set in the event payload
+
+The wrapper script handles this by templating a richer event payload
+on every invocation. If you call `act` directly, pass
+`--eventpath .github/act-event-push.json` or accept that gated jobs
+will fail their `needs:` step.
+
+### `before`/`after` SHAs must produce a real diff
+
+Path-filter compares files changed between `before` and `after`. If
+both are `0000...0000`, no files appear changed, and every job gated
+on `needs.changes.outputs.code == 'true'` skips its inner steps (the
+job itself still passes — that's how the production CI satisfies its
+required check on docs-only PRs). The wrapper sets `before = HEAD~1`
+and `after = HEAD` so the most recent commit's changes register.
+
+### `actions/cache@v4` is a no-op
+
+`act` does not implement GHA's hosted cache. The `cache: 'pip'`
+parameter on `actions/setup-python` quietly does nothing. Mitigation:
+
+- `--reuse` in `.actrc` keeps the same container across invocations,
+  so pip's local install survives between runs.
+- The first run still pays the full install cost; that's the
+  one-time investment.
+
+### Heavy native deps re-download every fresh-image run
+
+`requirements-lock.txt` includes `torch==2.11.0` (~600 MB CPU wheel),
+`pyarrow`, `lxml`, etc. With `--reuse`, the second run skips re-install
+because pip sees "already satisfied." Without `--reuse`, every run
+re-downloads everything. Stick with `--reuse` for iteration; pass
+`--rm` only when you specifically need a cold-start replay.
+
+### Apple Silicon emulation overhead
+
+We pin `--container-architecture linux/amd64` to match GHA runners.
+QEMU emulation on arm64 hosts makes CPU-heavy steps ~2-3× slower than
+they'd be on a native amd64 host. For pure I/O and pip install this is
+invisible; for pytest collection on a large test suite it adds 10-20s.
+
+### Gemini-Dispatch workflows don't replay locally
+
+`gemini-*.yml` workflows need `secrets.GEMINI_API_KEY` and OIDC tokens
+that don't exist on a local runner. Don't try to `act` them; their
+local equivalent is the regular `gemini` CLI or `ab ask-gemini`.
+
+## When NOT to use `act`
+
+- **You just want to run pytest on the actual code.** Use
+  `.venv/bin/python -m pytest tests/` — it's 0.19s for discovery,
+  seconds for the suite. `act` is for testing the GHA workflow
+  configuration itself, not the application code.
+- **You're debugging a Gemini-Dispatch (GHA-only) workflow.** Those
+  need GHA secrets `act` can't provide. Test by pushing a draft PR.
+- **You don't have Docker available** (corporate-locked laptop, etc).
+  Without a container daemon, `act` can't run anything.
+
+## Lifting this pattern to another project
+
+Per the design goal of #1891 (callable from any project):
+
+1. Copy `.actrc`, `scripts/local-ci.sh`, and
+   `.github/act-event-push.json` into the target project.
+2. Adjust `.actrc` runner images if the project uses non-Ubuntu
+   runners or specific Ubuntu versions.
+3. Adjust the static event JSON's `repository.full_name` and `owner`
+   to match the target project (the wrapper-templated version uses
+   them but the static fallback hardcodes ours).
+4. Replace the OrbStack-specific lines in `scripts/local-ci.sh` if
+   you're on Docker Desktop or another daemon — see the comment block
+   at the top of the wrapper.
+
+The repo-local install pattern (per-project `scripts/` wrapper) was
+chosen over a global tool because:
+
+- Each project's runner-image / arch / event-payload requirements
+  differ; baking them into `.actrc` keeps them versioned with the
+  project.
+- The wrapper code is short (~50 lines) and self-explanatory; no
+  install ceremony.
+- A global `~/.dotfiles`-style install would couple the user's setup
+  to one specific daemon (OrbStack), losing portability for
+  collaborators on Docker Desktop.

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# local-ci.sh — thin wrapper around `act` for local CI replay.
+#
+# Why this wrapper exists:
+#   - User runs OrbStack (not Docker Desktop). OrbStack puts its socket at
+#     `~/.orbstack/run/docker.sock`, not the canonical `/var/run/docker.sock`.
+#   - `act` defaults to the canonical path and exits with "Couldn't get a
+#     valid docker connection" if the socket isn't there.
+#   - This wrapper exports `DOCKER_HOST` to the OrbStack socket BEFORE
+#     invoking `act`, plus auto-starts OrbStack if not running.
+#
+# Usage:
+#   scripts/local-ci.sh                          # interactive — pick a job
+#   scripts/local-ci.sh -l                       # list discoverable jobs
+#   scripts/local-ci.sh -W .github/workflows/ci.yml -j lint
+#   scripts/local-ci.sh -W .github/workflows/ci.yml -j test --dryrun
+#
+# Any flag is forwarded to `act` verbatim — `.actrc` provides project defaults
+# (Apple Silicon arch, runner images, container reuse).
+#
+# Related: GH issue #1891 (local CI replay decision), docs/best-practices/
+# local-ci-replay.md (per-project pattern).
+
+set -euo pipefail
+
+# Resolve the OrbStack docker socket. Auto-start the daemon if it's not up
+# already — OrbStack starts in ~3-5s and the socket appears immediately after.
+ORBSTACK_SOCK="${HOME}/.orbstack/run/docker.sock"
+
+if [[ ! -S "$ORBSTACK_SOCK" ]]; then
+    echo "ℹ️  OrbStack daemon not running — starting it…" >&2
+    open -a OrbStack
+    # Wait up to 30s for the socket to appear. Real-world: <5s on a warm Mac.
+    for _ in $(seq 1 15); do
+        [[ -S "$ORBSTACK_SOCK" ]] && break
+        sleep 2
+    done
+    if [[ ! -S "$ORBSTACK_SOCK" ]]; then
+        echo "❌ OrbStack socket did not appear within 30s at $ORBSTACK_SOCK" >&2
+        echo "   Start it manually with: open -a OrbStack" >&2
+        exit 1
+    fi
+    echo "✅ OrbStack daemon up." >&2
+fi
+
+export DOCKER_HOST="unix://${ORBSTACK_SOCK}"
+
+# Auto-include a default event payload UNLESS the caller already passed `-e`
+# or `--eventpath`. The payload supplies:
+#
+#   - `repository.default_branch` (required by `dorny/paths-filter@v4`,
+#     used in ci.yml::changes — without it the job errors out)
+#   - `before` = the previous commit SHA, `after` = HEAD (so the
+#     path-filter sees a real diff and downstream jobs gated on
+#     `needs.changes.outputs.code == 'true'` actually run)
+#
+# We template both SHAs dynamically per invocation so the diff matches the
+# real working state. .github/act-event-push.json is a static fallback used
+# when git lookup fails (e.g. running outside a repo).
+HAS_EVENT_FLAG=false
+for arg in "$@"; do
+    if [[ "$arg" == "-e" || "$arg" == "--eventpath" ]]; then
+        HAS_EVENT_FLAG=true
+        break
+    fi
+done
+
+if [[ "$HAS_EVENT_FLAG" == false ]]; then
+    # Template a fresh event payload to /tmp with real git SHAs. Falls back to
+    # the static .github/act-event-push.json if git lookup fails.
+    EVENT_TMP="$(mktemp -t act-event-push.XXXXXX.json)"
+    trap 'rm -f "$EVENT_TMP"' EXIT
+
+    BEFORE_SHA="$(git rev-parse --verify HEAD~1 2>/dev/null || echo '0000000000000000000000000000000000000000')"
+    AFTER_SHA="$(git rev-parse --verify HEAD 2>/dev/null || echo '0000000000000000000000000000000000000000')"
+
+    cat >"$EVENT_TMP" <<EOF
+{
+  "ref": "refs/heads/main",
+  "before": "$BEFORE_SHA",
+  "after": "$AFTER_SHA",
+  "repository": {
+    "name": "learn-ukrainian.github.io",
+    "full_name": "learn-ukrainian/learn-ukrainian.github.io",
+    "default_branch": "main",
+    "owner": { "login": "learn-ukrainian" }
+  },
+  "pusher": { "name": "local-act-runner" }
+}
+EOF
+
+    exec act --eventpath "$EVENT_TMP" "$@"
+else
+    exec act "$@"
+fi


### PR DESCRIPTION
Closes #1891.

## Summary

- Replaces "we need Dagger urgently" with `act` after orchestrator pushback. Dagger requires rewriting all pipelines as Python/Go/TS code (months); `act` replays the existing `.github/workflows/*.yml` unchanged.
- Adds `.actrc` + `scripts/local-ci.sh` wrapper + `.github/act-event-push.json` fallback + `docs/best-practices/local-ci-replay.md`.
- Wrapper handles two real gotchas: OrbStack socket auto-resolution (user runs OrbStack, not Docker Desktop) and `dorny/paths-filter@v4` requiring `repository.default_branch` in the event payload.

## Measured timings (verified)

| Run | Description | Real time |
|---|---|---|
| 2 | `Lint (ruff)`, image cached, fresh container | **64s** end-to-end |
| 3 | `Lint (ruff)`, `--reuse` (deps installed) | **38s** |

Pytest first-run timing pending — background verification in progress. Will note in a follow-up commit/issue if anything surprising surfaces.

## What changed

- **`.actrc`** — project defaults: Apple-Silicon arch pin, `act-latest` runner image, `--rm --reuse` for fast iteration.
- **`.github/act-event-push.json`** — static fallback push-event payload with `repository.default_branch` so `dorny/paths-filter@v4` doesn't error. Used only when git lookup in the wrapper fails.
- **`scripts/local-ci.sh`** — wrapper that:
  1. Auto-starts OrbStack if its socket isn't bound.
  2. Exports `DOCKER_HOST=unix://$HOME/.orbstack/run/docker.sock`.
  3. Templates a fresh push-event payload to `/tmp` per invocation with real `before`=`HEAD~1` and `after`=`HEAD` SHAs so the path-filter detects actual changes (otherwise `needs.changes.outputs.code == 'true'`-gated jobs skip their bodies — including `test`).
  4. Forwards all flags to `act`.
- **`docs/best-practices/local-ci-replay.md`** — usage commands, gotchas (no `actions/cache` honor, Apple-Silicon emulation overhead, Gemini-Dispatch workflows can't replay), and a "lifting to another project" section.

## Tool-grounded verification

```
$ which act && act --version
/opt/homebrew/bin/act
act version 0.2.88

$ docker info --format '{{.Name}} | {{.OperatingSystem}}'
orbstack | OrbStack

$ time scripts/local-ci.sh -W .github/workflows/ci.yml -j lint
...
[CI/Lint (ruff)]   | All checks passed!
[CI/Lint (ruff)] 🏁  Job succeeded
real    1m4.533s

$ time scripts/local-ci.sh -W .github/workflows/ci.yml -j lint
...
[CI/Lint (ruff)] 🏁  Job succeeded
real    0m37.927s
```

## Trailer

`X-Agent: claude-inline/1891-act-local-ci`

## Test plan

- [ ] CI green
- [ ] After merge: pytest verification run timing added to doc (follow-up commit)
- [ ] Optional: try replaying `validate-yaml.yml` or `rules-deployment-check.yml` as smoke tests for the wrapper

🤖 Orchestrator-inline (`claude-inline/1891-act-local-ci`)