### PR TITLE
fix(codex-adapter): honor bridge_only session resume — mirror gemini.py pattern (#1894)

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -7,10 +7,10 @@ routed through the unified runtime.
 
 Key design points:
 
-- **Fresh session always.** CodexAdapter has ``resume_policy="never"`` in
-  the registry AND defensively ignores ``session_id`` even if passed.
-  Belt + suspenders against the cross-worktree contamination footgun that
-  Codex flagged in his own consultation (msg #28506).
+- **Bridge-only warm resume.** CodexAdapter has ``resume_policy="bridge_only"``
+  in the registry: dispatch/delegate invocations stay fresh-session via the
+  runner policy gate, while ``ab discuss`` bridge rounds may resume a prior
+  Codex CLI session for prompt-cache reuse (#1894).
 - **All three modes supported:** read-only, workspace-write, danger.
   Mode → flag mapping matches ``_codex.py::_codex_bridge_flags`` and
   ``dispatch.py::_codex_dispatch_flags``.
@@ -19,8 +19,8 @@ Key design points:
   goes into ``liveness_signal_paths`` so the runner's mtime poller catches
   Codex writing progress even when stdout is quiet.
 - **Session ID parsed from stdout.** The CLI prints "session id: <uuid>"
-  somewhere in stdout; we extract it for the usage record even though
-  we never resume it.
+  somewhere in stdout; we extract it so bridge callers can feed it into
+  later rounds.
 
 Issue: #1184
 """
@@ -146,8 +146,9 @@ class CodexAdapter:
     ) -> InvocationPlan:
         """Build the codex exec invocation.
 
-        Defensively ignores ``session_id`` regardless of value — Codex
-        is always fresh-session (registry resume_policy="never").
+        Uses ``codex exec`` for fresh calls and ``codex exec resume`` when a
+        bridge caller passes ``session_id``. The runner rejects non-bridge
+        session reuse before the adapter is invoked.
         Supports Codex MCP config overrides via ``tool_config``:
             - ``{"mcp_servers": {"sources": {"url": "http://127.0.0.1:8766/sse"}}}``
               → ``-c 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"'``
@@ -159,11 +160,6 @@ class CodexAdapter:
         Codex falls through to the config default (currently ``high``).
         See #1396.
         """
-        # Defensively drop session_id — Codex is always fresh-session by
-        # design (see class docstring). Local `_ =` rebind silences the
-        # "unused parameter" linter without changing semantics.
-        _ = session_id
-
         # Reset per-invocation state so _read_latest_rollout_task_complete
         # uses a fresh rollout snapshot (prevents cross-contamination
         # between consecutive calls on the same adapter instance).
@@ -197,7 +193,11 @@ class CodexAdapter:
         ) as output_fd:
             output_path = Path(output_fd.name)
 
+        has_session_to_resume = session_id is not None
+
         cmd: list[str] = [codex_bin, "exec"]
+        if has_session_to_resume:
+            cmd.append("resume")
         cmd.extend(self._tool_config_flags(tool_config))
         if effort is not None:
             # Per-invocation override of ~/.codex/config.toml (#1396).
@@ -210,6 +210,8 @@ class CodexAdapter:
             "-m", model or self.default_model,
         ])
         cmd.extend(self._mode_flags(mode))
+        if has_session_to_resume:
+            cmd.append(session_id)
         cmd.append("-")  # Read prompt from stdin.
 
         return InvocationPlan(

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -46,7 +46,7 @@ AGENTS: dict[str, AgentEntry] = {
             "adversarial_review",
         }),
         "cli_available": True,
-        "resume_policy": "never",
+        "resume_policy": "bridge_only",
     },
     "codex-desktop": {
         "adapter": "scripts.agent_runtime.adapters.codex:CodexAdapter",

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -1347,10 +1347,14 @@ def _handle_discuss(args) -> int:
         session_id_to_pass: str | None = None
         is_new_session = False
         if resume_policy == "bridge_only":
-            if agent_name not in discussion_session_ids:
+            if agent_name == "codex":
+                session_id_to_pass = discussion_session_ids.get(agent_name)
+            elif agent_name not in discussion_session_ids:
                 discussion_session_ids[agent_name] = str(uuid.uuid4())
                 is_new_session = True
-            session_id_to_pass = discussion_session_ids[agent_name]
+                session_id_to_pass = discussion_session_ids[agent_name]
+            else:
+                session_id_to_pass = discussion_session_ids[agent_name]
 
         tool_config = dict(_DISCUSSION_READONLY_TOOL_CONFIG)
         if is_new_session:
@@ -1388,6 +1392,13 @@ def _handle_discuss(args) -> int:
                 f"[failed: {result.stderr_excerpt or 'no response'}]",
                 False,
             )
+        if (
+            resume_policy == "bridge_only"
+            and agent_name == "codex"
+            and agent_name not in discussion_session_ids
+            and result.session_id
+        ):
+            discussion_session_ids[agent_name] = result.session_id
         return (agent_name, result.response.strip(), True)
 
     completed_rounds = 0

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -64,7 +64,7 @@ def test_discuss_round_four_prompt_preserves_root_and_all_thread_replies(
         marker = f"ROUND_{round_idx}_REPLY_MARKER_{agent_name.upper()}"
         body = f"{('x' * 200)} {marker}\n[DISAGREE]"
         round_responses.append(body)
-        return SimpleNamespace(ok=True, response=body, stderr_excerpt="")
+        return SimpleNamespace(ok=True, response=body, stderr_excerpt="", session_id=None)
 
     monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
 

--- a/tests/test_ab_discuss_read_only.py
+++ b/tests/test_ab_discuss_read_only.py
@@ -110,7 +110,7 @@ def test_discuss_posts_normal_reply_when_worktree_is_unchanged(
     def fake_invoke(agent_name: str, prompt: str, **kwargs):
         assert agent_name == "codex"
         assert kwargs["mode"] == "read-only"
-        return SimpleNamespace(ok=True, response="Normal analysis only. [DISAGREE]")
+        return SimpleNamespace(ok=True, response="Normal analysis only. [DISAGREE]", session_id=None)
 
     monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
     args = SimpleNamespace(

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -175,8 +175,8 @@ def test_registry_has_known_agents():
     }
 
 
-def test_codex_entry_has_never_resume_policy():
-    assert get_agent_entry("codex")["resume_policy"] == "never"
+def test_codex_entry_has_bridge_only_resume_policy():
+    assert get_agent_entry("codex")["resume_policy"] == "bridge_only"
 
 
 def test_codex_desktop_entry_is_human_invoked():
@@ -267,9 +267,6 @@ def test_load_adapter_cached():
 
 def test_resume_policy_never_rejects_session_id():
     with pytest.raises(ValueError, match="resume_policy='never'"):
-        _enforce_resume_policy("codex", session_id="some-uuid", entrypoint="bridge")
-
-    with pytest.raises(ValueError, match="resume_policy='never'"):
         _enforce_resume_policy("gemma-local", session_id="some-uuid", entrypoint="bridge")
 
 
@@ -280,11 +277,14 @@ def test_resume_policy_never_allows_none():
 
 def test_resume_policy_bridge_only_allows_bridge():
     _enforce_resume_policy("claude", session_id="uuid", entrypoint="bridge")
+    _enforce_resume_policy("codex", session_id="uuid", entrypoint="bridge")
 
 
 def test_resume_policy_bridge_only_rejects_dispatch():
     with pytest.raises(ValueError, match="bridge_only"):
         _enforce_resume_policy("claude", session_id="uuid", entrypoint="dispatch")
+    with pytest.raises(ValueError, match="bridge_only"):
+        _enforce_resume_policy("codex", session_id="uuid", entrypoint="dispatch")
 
 
 def test_resume_policy_bridge_only_rejects_delegate():
@@ -376,22 +376,34 @@ def test_codex_adapter_discussion_readonly_sets_env(tmp_path):
     assert plan.env_overrides == {"AB_DISCUSS_READONLY": "1"}
 
 
-def test_codex_adapter_build_invocation_ignores_session_id(tmp_path):
-    """Defensive: Codex adapter MUST ignore session_id even when passed."""
+def test_codex_adapter_bridge_creates_then_resumes(tmp_path):
     adapter = CodexAdapter()
-    plan = adapter.build_invocation(
+    first = adapter.build_invocation(
         prompt="hello",
         mode="read-only",
         cwd=tmp_path,
         model=None,
         task_id=None,
-        session_id="should-be-ignored-uuid",
+        session_id=None,
         tool_config=None,
     )
-    # No --resume flag anywhere in the command
-    assert "--resume" not in plan.cmd
-    # No "resume" subcommand
-    assert "resume" not in plan.cmd
+    assert first.cmd[1] == "exec"
+    assert "resume" not in first.cmd[1:3]
+    assert first.cmd[-1] == "-"
+
+    session_id = "2c8337b6-35da-415d-806d-91d10b5b1381"
+    second = adapter.build_invocation(
+        prompt="hello again",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=session_id,
+        tool_config=None,
+    )
+    assert second.cmd[1:3] == ["exec", "resume"]
+    assert second.cmd[-2:] == [session_id, "-"]
+    assert second.stdin_payload == "hello again"
 
 
 def test_codex_adapter_build_invocation_workspace_write(tmp_path):
@@ -1269,15 +1281,18 @@ def test_invoke_requires_cwd_for_danger_mode():
         invoke("codex", "hello", mode="danger", cwd=None)
 
 
-def test_invoke_codex_rejects_session_id(tmp_path):
-    with pytest.raises(ValueError, match="resume_policy='never'"):
-        invoke(
-            "codex",
-            "hello",
-            mode="read-only",
-            cwd=tmp_path,
-            session_id="some-uuid",
-        )
+def test_codex_adapter_dispatch_ignores_session_id_via_runner_policy(tmp_path):
+    with patch("agent_runtime.runner.subprocess.Popen") as mock_popen:
+        with pytest.raises(ValueError, match="bridge_only"):
+            invoke(
+                "codex",
+                "hello",
+                mode="read-only",
+                cwd=tmp_path,
+                session_id="some-uuid",
+                entrypoint="delegate",
+            )
+    mock_popen.assert_not_called()
 
 
 def test_invoke_rate_limit_short_circuit(tmp_path):

--- a/tests/test_channels_discuss_resume.py
+++ b/tests/test_channels_discuss_resume.py
@@ -36,18 +36,22 @@ def _successful_result(agent: str) -> MagicMock:
     result = MagicMock()
     result.ok = True
     result.response = f"[reply from {agent}] [AGREE]"
+    result.session_id = None
     return result
 
 
 def test_discuss_passes_session_id_for_resumable_agents(monkeypatch):
-    """Claude + Gemini get a session_id; Codex does not (registry policy)."""
+    """Claude/Gemini get named IDs; Codex reuses the CLI-generated ID."""
     _channels.create_channel("shared")
     monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
     captured_invokes = []
 
     def fake_runtime_invoke(agent, _prompt, **kwargs):
         captured_invokes.append((agent, kwargs))
-        return _successful_result(agent)
+        result = _successful_result(agent)
+        if agent == "codex":
+            result.session_id = "2c8337b6-35da-415d-806d-91d10b5b1381"
+        return result
 
     monkeypatch.setattr("agent_runtime.runner.invoke", fake_runtime_invoke)
 
@@ -76,9 +80,11 @@ def test_discuss_passes_session_id_for_resumable_agents(monkeypatch):
         assert first["tool_config"]["is_new_session"] is True
         assert "is_new_session" not in second["tool_config"]
 
-    for call in by_agent["codex"]:
-        assert call["session_id"] is None
-        assert "is_new_session" not in call["tool_config"]
+    first, second = by_agent["codex"]
+    assert first["session_id"] is None
+    assert second["session_id"] == "2c8337b6-35da-415d-806d-91d10b5b1381"
+    assert "is_new_session" not in first["tool_config"]
+    assert "is_new_session" not in second["tool_config"]
 
     assert all(kwargs["entrypoint"] == "bridge" for _, kwargs in captured_invokes)
 


### PR DESCRIPTION
## Summary

- Flip `CodexAdapter`'s registry policy `never` → `bridge_only` (`scripts/agent_runtime/registry.py:49`).
- Adapter conditionally uses `codex exec resume <SESSION_ID>` subcommand when bridge passes `session_id`; fresh-session command shape otherwise.
- Bridge wiring in `scripts/ai_agent_bridge/_channels_cli.py` to thread the session_id across `ab discuss` rounds.
- `_SESSION_RE` + `parse_response` (codex.py:45, 369-372) already extracted the session UUID from stdout (5th header line of normal `codex exec` output) — that side of the pipeline was complete before this PR; we just start using it.
- `codex-desktop` registry entry stays `"never"` (cli_available=False, no CLI usage to optimize).
- Dispatch isolation preserved by `runner.py:288-324` policy enforcement: for `entrypoint="delegate"`, `session_id` is dropped before reaching the adapter, so worktree-per-task isolation is untouched.

Closes #1894.

## Test plan

- [x] `tests/test_agent_runtime.py` — Codex bridge first-call vs resume-call command shapes asserted; dispatch path asserts session_id is ignored.
- [x] `tests/test_channels_discuss_resume.py` — multi-agent `ab discuss` round-2 reuses round-1 session UUIDs for Codex (in addition to Gemini + Claude).
- [x] Full agent-runtime + discuss-resume suite: `134 passed in 26.74s` (per dispatch commit body).
- [ ] Real `ab discuss` smoke (3-agent, 2-round) — leaving for post-merge given the test fixtures already verify the session-reuse contract.

## CLI shape verification

The Codex resume entry point differs from Gemini's `--resume <uuid>` flag — it's a subcommand: `codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]`. Verified against codex-cli 0.130.0 (see `docs/dispatch-briefs/2026-05-12-1894-codex-bridge-resume.md` for the captured `--help` outputs that fed the brief).

## References

- Issue: #1894
- Prior art: PR #1889 (Gemini bridge_only resume)
- Adapter design rationale (cross-worktree contamination footgun for dispatch): `scripts/agent_runtime/adapters/codex.py:1-30`
- Dispatch brief: `docs/dispatch-briefs/2026-05-12-1894-codex-bridge-resume.md`