### PR TITLE
fix(delegate): mkdir parent of stdout/stderr logs for slashed task_id (#1885)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -905,6 +905,25 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print("❌ --prompt or --prompt-file is required", file=sys.stderr)
         return 2
 
+    # Set up log files before provisioning a worktree. If this cheap
+    # filesystem setup fails, dispatch exits before leaving worktree/branch
+    # side effects behind.
+    log_dir = _TASKS_DIR / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stdout_log = log_dir / f"{task_id}.stdout.log"
+    stderr_log = log_dir / f"{task_id}.stderr.log"
+    # task_id may contain "/" (for example "codex/1885-foo"), which makes
+    # the log path live under a per-agent subdir that log_dir.mkdir above
+    # does not cover.
+    stdout_log.parent.mkdir(parents=True, exist_ok=True)
+    stderr_log.parent.mkdir(parents=True, exist_ok=True)
+    # These file descriptors MUST outlive this function — Popen keeps
+    # them open for the child process. A context manager would close
+    # them the instant Popen returns, breaking the worker's output.
+    # SIM115 doesn't understand this case.
+    stdout_fd = open(stdout_log, "ab", buffering=0)  # noqa: SIM115
+    stderr_fd = open(stderr_log, "ab", buffering=0)  # noqa: SIM115
+
     worktree_path: Path | None = None
     worktree_branch: str | None = None
     worktree_telemetry: dict[str, Any] = {}
@@ -1018,17 +1037,6 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # Pipe the prompt via stdin so it doesn't hit argv length limits.
     # start_new_session=True detaches from our process group — the
     # worker survives our exit, which is what we want.
-    log_dir = _TASKS_DIR / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    stdout_log = log_dir / f"{task_id}.stdout.log"
-    stderr_log = log_dir / f"{task_id}.stderr.log"
-    # These file descriptors MUST outlive this function — Popen keeps
-    # them open for the child process. A context manager would close
-    # them the instant Popen returns, breaking the worker's output.
-    # SIM115 doesn't understand this case.
-    stdout_fd = open(stdout_log, "ab", buffering=0)  # noqa: SIM115
-    stderr_fd = open(stderr_log, "ab", buffering=0)  # noqa: SIM115
-
     # Explicit env=os.environ.copy() — makes the inherited env
     # explicit rather than implicit. Callers that want to scrub
     # secrets from the worker's env can override this here.

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -572,6 +572,43 @@ def test_dispatch_initial_state_includes_resolved_telemetry(tmp_tasks_dir):
     assert state["cli_version"] == "0.123.0"
 
 
+def test_dispatch_creates_logs_subdir_for_slashed_task_id(tmp_tasks_dir, monkeypatch):
+    """task_id may include an agent prefix, e.g. codex/test-mkdir-1885."""
+    import argparse
+
+    class _FakeStdin:
+        def write(self, _data): pass
+        def close(self): pass
+
+    class _FakeProc:
+        pid = 12345
+        stdin = _FakeStdin()
+
+    args = argparse.Namespace(
+        agent="codex",
+        task_id="codex/test-mkdir-1885",
+        prompt="test",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=None,
+        hard_timeout=3600,
+        allow_merge=False,
+        effort=None,
+    )
+
+    assert not (tmp_tasks_dir / "logs" / "codex").exists()
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    assert (tmp_tasks_dir / "logs" / "codex" / "test-mkdir-1885.stdout.log").exists()
+    assert (tmp_tasks_dir / "logs" / "codex" / "test-mkdir-1885.stderr.log").exists()
+
+
 def test_cancel_refuses_terminal_status(tmp_tasks_dir, capsys):
     """Regression (Codex 2026-04-10 audit): cmd_cancel must refuse to
     signal a PID whose task is already in a terminal state. The OS may


### PR DESCRIPTION
## Summary

- Fix `delegate.py:1021-1030` mkdir gap — when `task_id` contains `/` (e.g. `codex/1885-foo`), the per-agent subtree under `batch_state/tasks/logs/` wasn't auto-created, causing `FileNotFoundError` on `open(stdout_log, "ab")` and leaving orphaned worktree + branch behind.
- Picked AC #3 **option (a)**: reorder so log-file setup runs BEFORE worktree provisioning. Log setup is cheap + fails fast; this avoids the orphan-worktree side effect entirely.
- Belt-and-suspenders: `stdout_log.parent.mkdir(parents=True, exist_ok=True)` and same for stderr.
- Regression test `test_dispatch_creates_logs_subdir_for_slashed_task_id` in `tests/test_delegate.py`.

Closes #1885.

## Test plan

- [x] Existing delegate suite: `76 passed in 5.64s` (per dispatch commit body)
- [x] New regression test verifies the slashed-task_id path opens without `FileNotFoundError` against a synthetic tasks dir.
- [x] AC #3 satisfied via option (a) — worktree creation now runs AFTER log-dir setup.

## Incident context

2026-05-11 evening: `codex/1883-hook-trim` dispatch crashed with `FileNotFoundError` on the codex log path; orchestrator had to manually `git worktree remove --force` the orphan. This PR makes that class of failure no longer leave orphans behind.

## References

- Issue: #1885
- Dispatch brief: `docs/dispatch-briefs/2026-05-12-1885-delegate-mkdir-gap.md`