### PR TITLE
feat(api): in-tool cost telemetry footer (#1865 item #3)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -6,6 +6,55 @@ FastAPI auto-docs: `http://localhost:8765/docs` (Swagger UI)
 
 ---
 
+## Optional Context Telemetry Footer
+
+Set `LEARN_UKRAINIAN_TELEMETRY_FOOTER=1` on the Monitor API process to
+include live context-window telemetry in cold-start responses. Dispatched
+subprocesses set `AGENT_NO_TELEMETRY_FOOTER=1`, which suppresses the
+footer even if the parent process has the opt-in variable set.
+
+The token source is the same deterministic transcript-JSONL path used by
+the Claude statusline: parse assistant `message.usage` records and sum
+`input_tokens`, `cache_read_input_tokens`, and
+`cache_creation_input_tokens` from the latest assistant turn. The
+previous assistant usage record supplies the per-turn delta, and the
+assistant usage record count supplies the monotonic turn number. The
+`.context_window.used_tokens` field is not used because Claude Code
+2.1.139 did not populate it; API headers are unavailable to server-side
+Monitor endpoints.
+
+Text responses append a tail footer:
+
+```text
+[ctx: 187K (+22K this turn), tier: base, 13K to premium, turn: 47]
+```
+
+JSON responses add a top-level `_telemetry` object instead of changing
+the response text:
+
+```json
+{
+  "_telemetry": {
+    "ctx": 187000,
+    "prev_ctx": 165000,
+    "delta": 22000,
+    "tier": "base",
+    "distance_tokens": 13000,
+    "distance_label": "to premium",
+    "turn": 47,
+    "source": "transcript-jsonl"
+  }
+}
+```
+
+When telemetry is enabled, `/api/rules` and `/api/session/current`
+continue to expose `X-Rules-Hash` / `X-Session-Hash` for the underlying
+stable markdown, but dynamic telemetry responses do not use `304 Not
+Modified` or strong `ETag` headers. With telemetry disabled, existing
+ETag and cache semantics are unchanged.
+
+---
+
 ## Agent Quick Start
 
 **Recommended cold-start sequence (GH #1309, since P1):**
@@ -1168,6 +1217,10 @@ One-call agent orientation: git, issues, pipeline, runtime, delegate, wiki, heal
 }
 ```
 
+When `LEARN_UKRAINIAN_TELEMETRY_FOOTER=1`, the JSON response includes
+top-level `_telemetry` with the same context-window fields documented
+above.
+
 #### Per-section caching + freshness metadata (#1309)
 
 Each section is computed by an independent collector. Most have a
@@ -1289,6 +1342,9 @@ hashes against its local cache and only refetches what changed.
   already carries per-section `meta` with its own `generated_at` +
   `cache` + `source` fields, and `/api/comms/inbox` is always
   point-in-time.
+- When `LEARN_UKRAINIAN_TELEMETRY_FOOTER=1`, this JSON response also
+  includes top-level `_telemetry` derived from transcript JSONL. It
+  never appends text to the manifest body.
 
 ### `GET /api/rules?format={markdown,json}`
 
@@ -1298,9 +1354,11 @@ checked-in files so a fresh clone or worktree that hasn't deployed
 to `.claude/rules/` still gets correct content.
 
 - `format=markdown` (default) → `text/markdown; charset=utf-8` with
-  an `X-Rules-Hash` header. Drop-in for a system prompt.
+  an `X-Rules-Hash` header. Drop-in for a system prompt. With telemetry
+  enabled, a context footer is appended after the markdown body.
 - `format=json` → `{hash, bytes, sources[], markdown}`. Use this when
-  an SDK needs to reconcile the hash against its on-disk cache.
+  an SDK needs to reconcile the hash against its on-disk cache. With
+  telemetry enabled, the response also includes top-level `_telemetry`.
 
 ### `GET /api/session/current?format={markdown,json}`
 
@@ -1308,6 +1366,9 @@ to `.claude/rules/` still gets correct content.
 filenames (newest first). Kept intentionally small — the endpoint
 answers "what do I need to know RIGHT NOW to keep working", not
 "give me the full history".
+
+With telemetry enabled, `format=markdown` appends the context footer and
+`format=json` adds top-level `_telemetry`.
 
 ### `GET /api/comms/inbox?agent={claude,gemini,codex}&limit=10`
 

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -686,6 +686,7 @@ def _execute_invocation_plan(
     env = build_agent_env(provider=agent_name, overrides=plan.env_overrides)
     for key in plan.env_unsets:
         env.pop(key, None)
+    env["AGENT_NO_TELEMETRY_FOOTER"] = "1"
     env = _apply_merge_guard(mode=mode, env=env)
 
     start_time = time.monotonic()

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -72,6 +72,7 @@ from .session_router import router as session_router
 from .site_router import router as site_router
 from .state_helpers import cache_get, cache_invalidate, cache_set
 from .state_router import router as state_router
+from .telemetry.response import add_json_telemetry
 from .telemetry_router import router as telemetry_router
 from .wiki_router import router as wiki_router
 from .worktrees_router import router as worktrees_router
@@ -687,7 +688,7 @@ async def orient(fresh: bool = False):
     # clients that were reading it before per-section meta existed.
     if isinstance(issues_info, dict) and issues_info.get("error"):
         response["issues_error"] = issues_info["error"]
-    return response
+    return add_json_telemetry(response)
 
 
 @app.get("/api/config")

--- a/scripts/api/rules_router.py
+++ b/scripts/api/rules_router.py
@@ -28,6 +28,11 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 
 from .config import PROJECT_ROOT
+from .telemetry.response import (
+    add_json_telemetry,
+    append_telemetry_footer,
+    telemetry_footer_enabled,
+)
 
 router = APIRouter(tags=["rules"])
 
@@ -136,7 +141,7 @@ def get_rules(
     markdown, sources, digest = _assemble_rules()
     etag = f'"{digest}"'
 
-    if _matches_etag(request.headers.get("If-None-Match"), digest):
+    if not telemetry_footer_enabled() and _matches_etag(request.headers.get("If-None-Match"), digest):
         return Response(
             status_code=304,
             headers={"ETag": etag, "X-Rules-Hash": digest},
@@ -151,9 +156,9 @@ def get_rules(
     from fastapi.responses import PlainTextResponse
 
     return PlainTextResponse(
-        content=markdown,
+        content=append_telemetry_footer(markdown),
         media_type="text/markdown; charset=utf-8",
-        headers={"ETag": etag, "X-Rules-Hash": digest},
+        headers=_cache_headers(etag, digest, "X-Rules-Hash"),
     )
 
 
@@ -161,14 +166,21 @@ def _rules_json_response(markdown: str, sources, digest: str, etag: str):
     from fastapi.responses import JSONResponse
 
     return JSONResponse(
-        content={
+        content=add_json_telemetry({
             "hash": digest,
             "bytes": len(markdown.encode("utf-8")),
             "sources": sources,
             "markdown": markdown,
-        },
-        headers={"ETag": etag, "X-Rules-Hash": digest},
+        }),
+        headers=_cache_headers(etag, digest, "X-Rules-Hash"),
     )
+
+
+def _cache_headers(etag: str, digest: str, hash_header: str) -> dict[str, str]:
+    headers = {hash_header: digest}
+    if not telemetry_footer_enabled():
+        headers["ETag"] = etag
+    return headers
 
 
 def rules_hash() -> str:

--- a/scripts/api/session_router.py
+++ b/scripts/api/session_router.py
@@ -30,6 +30,11 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 
 from .config import PROJECT_ROOT
 from .rules_router import _matches_etag  # shared ETag parser
+from .telemetry.response import (
+    add_json_telemetry,
+    append_telemetry_footer,
+    telemetry_footer_enabled,
+)
 
 router = APIRouter(tags=["session"])
 
@@ -125,7 +130,7 @@ def session_current(
     markdown, sections, digest = _assemble_session()
     etag = f'"{digest}"'
 
-    if _matches_etag(request.headers.get("If-None-Match"), digest):
+    if not telemetry_footer_enabled() and _matches_etag(request.headers.get("If-None-Match"), digest):
         return Response(
             status_code=304,
             headers={"ETag": etag, "X-Session-Hash": digest},
@@ -133,20 +138,27 @@ def session_current(
 
     if format == "json":
         return JSONResponse(
-            content={
+            content=add_json_telemetry({
                 "hash": digest,
                 "bytes": len(markdown.encode("utf-8")),
                 "sections": sections,
                 "markdown": markdown,
-            },
-            headers={"ETag": etag, "X-Session-Hash": digest},
+            }),
+            headers=_cache_headers(etag, digest),
         )
 
     return PlainTextResponse(
-        content=markdown,
+        content=append_telemetry_footer(markdown),
         media_type="text/markdown; charset=utf-8",
-        headers={"ETag": etag, "X-Session-Hash": digest},
+        headers=_cache_headers(etag, digest),
     )
+
+
+def _cache_headers(etag: str, digest: str) -> dict[str, str]:
+    headers = {"X-Session-Hash": digest}
+    if not telemetry_footer_enabled():
+        headers["ETag"] = etag
+    return headers
 
 
 def session_hash() -> str:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -715,8 +715,9 @@ async def manifest():
 
     from .rules_router import rules_hash
     from .session_router import session_hash
+    from .telemetry.response import add_json_telemetry
 
-    return {
+    return add_json_telemetry({
         "generated_at": _dt.now(UTC).isoformat().replace("+00:00", "Z"),
         "rules": {
             "hash": rules_hash(),
@@ -739,4 +740,4 @@ async def manifest():
             "url_template": "/api/comms/inbox?agent={name}",
             "note": "Read-only view of unread channel deliveries for one agent.",
         },
-    }
+    })

--- a/scripts/api/telemetry/__init__.py
+++ b/scripts/api/telemetry/__init__.py
@@ -1,0 +1,2 @@
+"""Monitor API context-window telemetry helpers."""
+

--- a/scripts/api/telemetry/footer.py
+++ b/scripts/api/telemetry/footer.py
@@ -1,0 +1,18 @@
+"""Pure renderer for context-window telemetry footers."""
+
+
+PREMIUM_THRESHOLD_TOKENS = 200_000
+
+
+def render_footer(*, tokens: int, prev_tokens: int | None, turn: int | None) -> str:
+    """Render the [ctx: ...] footer line. Pure; no I/O."""
+    delta = f" (+{(tokens - prev_tokens) // 1000}K this turn)" if prev_tokens is not None else ""
+    tier = "premium" if tokens > PREMIUM_THRESHOLD_TOKENS else "base"
+    distance = (
+        (PREMIUM_THRESHOLD_TOKENS - tokens) // 1000
+        if tier == "base"
+        else (tokens - PREMIUM_THRESHOLD_TOKENS) // 1000
+    )
+    distance_str = f", {distance}K {'to premium' if tier == 'base' else 'over premium'}"
+    turn_str = f", turn: {turn}" if turn is not None else ""
+    return f"[ctx: {tokens // 1000}K{delta}, tier: {tier}{distance_str}{turn_str}]"

--- a/scripts/api/telemetry/response.py
+++ b/scripts/api/telemetry/response.py
@@ -1,0 +1,71 @@
+"""Response helpers for opt-in Monitor API context telemetry."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from scripts.api.config import PROJECT_ROOT
+
+from .footer import PREMIUM_THRESHOLD_TOKENS, render_footer
+from .transcript_tokens import TranscriptTelemetry, current_context_telemetry
+
+
+def telemetry_footer_enabled() -> bool:
+    """Return whether Monitor API responses should include context telemetry."""
+    if os.environ.get("AGENT_NO_TELEMETRY_FOOTER") == "1":
+        return False
+    return os.environ.get("LEARN_UKRAINIAN_TELEMETRY_FOOTER") == "1"
+
+
+def current_telemetry() -> TranscriptTelemetry | None:
+    """Return current context telemetry when the footer is enabled and parseable."""
+    if not telemetry_footer_enabled():
+        return None
+    return current_context_telemetry(PROJECT_ROOT)
+
+
+def append_telemetry_footer(text: str) -> str:
+    """Append the telemetry footer to a text response when enabled."""
+    telemetry = current_telemetry()
+    if telemetry is None:
+        return text
+    footer = render_footer(
+        tokens=telemetry.tokens,
+        prev_tokens=telemetry.prev_tokens,
+        turn=telemetry.turn,
+    )
+    return text.rstrip() + f"\n\n{footer}\n"
+
+
+def telemetry_dict(telemetry: TranscriptTelemetry) -> dict[str, Any]:
+    """Return the structured JSON telemetry payload."""
+    tier = "premium" if telemetry.tokens > PREMIUM_THRESHOLD_TOKENS else "base"
+    distance_tokens = (
+        PREMIUM_THRESHOLD_TOKENS - telemetry.tokens
+        if tier == "base"
+        else telemetry.tokens - PREMIUM_THRESHOLD_TOKENS
+    )
+    return {
+        "ctx": telemetry.tokens,
+        "prev_ctx": telemetry.prev_tokens,
+        "delta": (
+            telemetry.tokens - telemetry.prev_tokens
+            if telemetry.prev_tokens is not None
+            else None
+        ),
+        "tier": tier,
+        "distance_tokens": distance_tokens,
+        "distance_label": "to premium" if tier == "base" else "over premium",
+        "turn": telemetry.turn,
+        "source": "transcript-jsonl",
+    }
+
+
+def add_json_telemetry(payload: dict[str, Any]) -> dict[str, Any]:
+    """Add top-level ``_telemetry`` to a JSON-compatible dict when enabled."""
+    telemetry = current_telemetry()
+    if telemetry is None:
+        return payload
+    return {**payload, "_telemetry": telemetry_dict(telemetry)}
+

--- a/scripts/api/telemetry/transcript_tokens.py
+++ b/scripts/api/telemetry/transcript_tokens.py
@@ -1,0 +1,119 @@
+"""Parse Claude transcript JSONL usage for context-window telemetry."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptTelemetry:
+    """Context-window telemetry derived from assistant usage records."""
+
+    tokens: int
+    prev_tokens: int | None
+    turn: int | None
+    transcript_path: Path
+
+
+def usage_input_tokens(usage: dict[str, Any]) -> int:
+    """Return the statusline-compatible input-token sum for one usage block."""
+    return int(usage.get("input_tokens") or 0) + int(
+        usage.get("cache_read_input_tokens") or 0
+    ) + int(usage.get("cache_creation_input_tokens") or 0)
+
+
+def parse_transcript_tokens(path: Path) -> TranscriptTelemetry | None:
+    """Return latest and previous assistant context totals from a JSONL transcript."""
+    latest: int | None = None
+    previous: int | None = None
+    turn = 0
+
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                message = obj.get("message")
+                if not isinstance(message, dict):
+                    continue
+                usage = message.get("usage")
+                if not isinstance(usage, dict):
+                    continue
+                tokens = usage_input_tokens(usage)
+                if tokens <= 0:
+                    continue
+                previous = latest
+                latest = tokens
+                turn += 1
+    except OSError:
+        return None
+
+    if latest is None:
+        return None
+    return TranscriptTelemetry(
+        tokens=latest,
+        prev_tokens=previous,
+        turn=turn or None,
+        transcript_path=path,
+    )
+
+
+def _claude_project_dir_name(project_root: Path) -> str:
+    return str(project_root.resolve()).replace("/", "-")
+
+
+def _newest_jsonl(paths: list[Path]) -> Path | None:
+    candidates = [p for p in paths if p.is_file()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: (p.stat().st_mtime, str(p)))
+
+
+def resolve_transcript_paths(project_root: Path) -> list[Path]:
+    """Resolve candidate Claude transcript paths for this checkout, newest first."""
+    explicit = os.environ.get("LEARN_UKRAINIAN_TRANSCRIPT_PATH") or os.environ.get(
+        "CLAUDE_TRANSCRIPT_PATH"
+    )
+    if explicit:
+        path = Path(explicit).expanduser()
+        return [path] if path.is_file() else []
+
+    projects_dir = Path.home() / ".claude" / "projects"
+    candidates: list[Path] = []
+    exact_dir = projects_dir / _claude_project_dir_name(project_root)
+    if exact_dir.is_dir():
+        candidates.extend(exact_dir.glob("*.jsonl"))
+
+    fallback_dirs = sorted(projects_dir.glob("*learn-ukrainian*"))
+    for directory in fallback_dirs:
+        if directory.is_dir():
+            candidates.extend(directory.glob("*.jsonl"))
+
+    unique = {path.resolve(): path for path in candidates if path.is_file()}
+    return sorted(
+        unique.values(),
+        key=lambda p: (p.stat().st_mtime, str(p)),
+        reverse=True,
+    )
+
+
+def resolve_transcript_path(project_root: Path) -> Path | None:
+    """Resolve the newest Claude transcript path for this checkout."""
+    return _newest_jsonl(resolve_transcript_paths(project_root))
+
+
+def current_context_telemetry(project_root: Path) -> TranscriptTelemetry | None:
+    """Resolve and parse the current transcript telemetry, if available."""
+    for path in resolve_transcript_paths(project_root):
+        telemetry = parse_transcript_tokens(path)
+        if telemetry is not None:
+            return telemetry
+    return None

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1042,6 +1042,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # secrets from the worker's env can override this here.
     worker_env = os.environ.copy()
     _inject_gh_token_for_agent(worker_env, args.agent)
+    worker_env["AGENT_NO_TELEMETRY_FOOTER"] = "1"
     if getattr(args, "allow_merge", False):
         worker_env.pop("AGENT_NO_MERGE", None)
         worker_env["AGENT_ALLOW_MERGE"] = "1"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -116,6 +116,7 @@ echo ""
 # Balances: using the 1M window we pay for vs. leaving buffer before degradation
 # Subagents handle isolated work in their own windows, so main thread stays clean
 export CLAUDE_CODE_AUTO_COMPACT_WINDOW=750000
+export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 
 # Launch via npx to avoid cache bugs (stale binary + prompt caching issues)
 echo "Launching Claude Code via npx (cache-safe)..."

--- a/tests/test_api_telemetry_footer.py
+++ b/tests/test_api_telemetry_footer.py
@@ -1,0 +1,139 @@
+"""Tests for Monitor API context-window telemetry footers."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.api.telemetry.footer import render_footer
+from scripts.api.telemetry.transcript_tokens import (
+    current_context_telemetry,
+    parse_transcript_tokens,
+)
+
+
+def test_render_footer_base_tier() -> None:
+    assert (
+        render_footer(tokens=187_000, prev_tokens=165_000, turn=47)
+        == "[ctx: 187K (+22K this turn), tier: base, 13K to premium, turn: 47]"
+    )
+
+
+def test_render_footer_premium_tier() -> None:
+    assert (
+        render_footer(tokens=222_000, prev_tokens=187_000, turn=48)
+        == "[ctx: 222K (+35K this turn), tier: premium, 22K over premium, turn: 48]"
+    )
+
+
+def test_render_footer_without_previous_tokens() -> None:
+    assert (
+        render_footer(tokens=13_000, prev_tokens=None, turn=1)
+        == "[ctx: 13K, tier: base, 187K to premium, turn: 1]"
+    )
+
+
+def test_render_footer_without_turn() -> None:
+    assert (
+        render_footer(tokens=13_000, prev_tokens=None, turn=None)
+        == "[ctx: 13K, tier: base, 187K to premium]"
+    )
+
+
+def test_render_footer_exact_200k_boundary_is_base() -> None:
+    assert (
+        render_footer(tokens=200_000, prev_tokens=187_000, turn=48)
+        == "[ctx: 200K (+13K this turn), tier: base, 0K to premium, turn: 48]"
+    )
+
+
+def test_render_footer_exact_zero_delta() -> None:
+    assert (
+        render_footer(tokens=187_000, prev_tokens=187_000, turn=48)
+        == "[ctx: 187K (+0K this turn), tier: base, 13K to premium, turn: 48]"
+    )
+
+
+def test_parse_transcript_tokens_uses_latest_assistant_usage(tmp_path) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "hello"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "usage": {
+                                "input_tokens": 100_000,
+                                "cache_read_input_tokens": 20_000,
+                                "cache_creation_input_tokens": 5_000,
+                                "output_tokens": 1_000,
+                            }
+                        },
+                    }
+                ),
+                "{not json",
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "usage": {
+                                "input_tokens": 150_000,
+                                "cache_read_input_tokens": 30_000,
+                                "cache_creation_input_tokens": 7_000,
+                                "output_tokens": 2_000,
+                            }
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_transcript_tokens(transcript)
+
+    assert telemetry is not None
+    assert telemetry.tokens == 187_000
+    assert telemetry.prev_tokens == 125_000
+    assert telemetry.turn == 2
+
+
+def test_current_context_telemetry_skips_newest_transcript_without_usage(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    projects = tmp_path / ".claude" / "projects"
+    project_dir = projects / "-tmp-learn-ukrainian"
+    project_dir.mkdir(parents=True)
+    older = project_dir / "older.jsonl"
+    older.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "usage": {
+                        "input_tokens": 187_000,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    newer = project_dir / "newer.jsonl"
+    newer.write_text(
+        json.dumps({"type": "user", "message": {"content": "hi"}}),
+        encoding="utf-8",
+    )
+    newer.touch()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    telemetry = current_context_telemetry(tmp_path / "learn-ukrainian")
+
+    assert telemetry is not None
+    assert telemetry.transcript_path == older
+    assert telemetry.tokens == 187_000

--- a/tests/test_monitor_api_telemetry.py
+++ b/tests/test_monitor_api_telemetry.py
@@ -1,0 +1,82 @@
+"""Monitor API endpoint tests for opt-in context telemetry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.api.main import app
+
+
+def _write_transcript(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "usage": {
+                                "input_tokens": 100_000,
+                                "cache_read_input_tokens": 20_000,
+                                "cache_creation_input_tokens": 5_000,
+                            }
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "usage": {
+                                "input_tokens": 150_000,
+                                "cache_read_input_tokens": 30_000,
+                                "cache_creation_input_tokens": 7_000,
+                            }
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_rules_markdown_appends_footer_when_enabled(tmp_path, monkeypatch) -> None:
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(transcript)
+    monkeypatch.setenv("LEARN_UKRAINIAN_TELEMETRY_FOOTER", "1")
+    monkeypatch.setenv("LEARN_UKRAINIAN_TRANSCRIPT_PATH", str(transcript))
+
+    response = TestClient(app).get("/api/rules?format=markdown")
+
+    assert response.status_code == 200
+    assert response.text.endswith(
+        "\n\n[ctx: 187K (+62K this turn), tier: base, 13K to premium, turn: 2]\n"
+    )
+    assert response.headers["X-Rules-Hash"]
+    assert "etag" not in response.headers
+
+
+def test_manifest_json_adds_structured_telemetry_when_enabled(tmp_path, monkeypatch) -> None:
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(transcript)
+    monkeypatch.setenv("LEARN_UKRAINIAN_TELEMETRY_FOOTER", "1")
+    monkeypatch.setenv("LEARN_UKRAINIAN_TRANSCRIPT_PATH", str(transcript))
+
+    response = TestClient(app).get("/api/state/manifest")
+
+    assert response.status_code == 200
+    assert response.json()["_telemetry"] == {
+        "ctx": 187_000,
+        "prev_ctx": 125_000,
+        "delta": 62_000,
+        "tier": "base",
+        "distance_tokens": 13_000,
+        "distance_label": "to premium",
+        "turn": 2,
+        "source": "transcript-jsonl",
+    }


### PR DESCRIPTION
## Summary
- Adds opt-in Monitor API context telemetry via LEARN_UKRAINIAN_TELEMETRY_FOOTER=1.
- Uses transcript JSONL assistant usage as the deterministic context source and derives turn/delta from the same records.
- Adds text footer support for markdown responses and structured _telemetry for JSON responses.
- Stamps dispatched subprocess environments with AGENT_NO_TELEMETRY_FOOTER=1 and leaves MEMORY #2 changes for #1865 item #5.

Refs #1865.

## Verification
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_api_telemetry_footer.py tests/test_monitor_api*.py -v
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/api/ tests/test_api_telemetry_footer.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py