### PR TITLE
fix(sources_db): bound Path(query).exists() probe (#1901)

### DIFF
--- a/scripts/build/pilot_uk_lesson.py
+++ b/scripts/build/pilot_uk_lesson.py
@@ -36,12 +36,12 @@ def retrieval_context(plan: dict, level: str, limit: int = 12) -> str:
     query_parts.extend(plan.get("objectives", []))
     for sec in plan.get("content_outline", []):
         query_parts.append(sec.get("section", ""))
-    # search_sources' _prepare_query does Path(query).exists() which raises
-    # OSError on strings longer than the filesystem filename limit (~255 bytes).
-    # Bug filed separately. Workaround: cap to 120 chars.
+    # search_sources' _prepare_query now bounds the Path(query).exists() probe
+    # by byte length (#1901 fix), so no 120-char workaround is needed. Still
+    # cap the query length for relevance: very long queries dilute FTS scoring.
     query = " ".join(p.strip() for p in query_parts if p)
     query = " ".join(query.split())  # collapse whitespace
-    query = query[:120]
+    query = query[:120]  # keep for FTS relevance, not for OSError avoidance
 
     # Prefer the discovery YAML (that's what build_query_buckets actually parses)
     discovery_path = REPO / "curriculum" / "l2-uk-en" / level / "discovery" / f"{plan.get('slug')}.yaml"

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -35,6 +35,11 @@ from .query_builder import build_query_buckets
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SOURCES_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
 TRACK_PRIORS_PATH = PROJECT_ROOT / "scripts" / "wiki" / "track_priors.yaml"
+# Per-component path length limit is ~255 bytes on macOS HFS+/APFS and most
+# Linux filesystems. Long Cyrillic plan-topic concatenations (>1 KB) trigger
+# OSError "File name too long" inside Path.exists(). Caller fallbacks can
+# swallow that and falsely mark plan references as corpus_missing (#1901).
+_MAX_PATH_PROBE_BYTES = 255
 
 _conn: sqlite3.Connection | None = None
 
@@ -343,7 +348,13 @@ def _build_dense_query(bucket_a_phrases: list[str], bucket_b_keywords: set[str],
 
 def _prepare_query(query: str | Path, track: str) -> tuple[list[str], set[str], str]:
     candidate_path = Path(query)
-    if candidate_path.exists():
+    is_path = False
+    if isinstance(query, Path) or len(str(query).encode("utf-8")) <= _MAX_PATH_PROBE_BYTES:
+        try:
+            is_path = candidate_path.exists()
+        except OSError:
+            is_path = False
+    if is_path:
         bucket_a_phrases, bucket_b_keywords = build_query_buckets(candidate_path, track)
         return bucket_a_phrases, bucket_b_keywords, _build_dense_query(
             bucket_a_phrases,

--- a/tests/test_sources_db_prepare_query.py
+++ b/tests/test_sources_db_prepare_query.py
@@ -1,0 +1,52 @@
+"""Regression tests for scripts/wiki/sources_db.py:_prepare_query.
+
+Bug context: a >255-byte query string (typical for plan-driven textbook
+excerpt retrieval) caused Path(query).exists() to raise OSError "File name
+too long", which falsely marked textbook references as corpus_missing.
+See #1901.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from wiki.sources_db import _prepare_query
+
+
+def test_long_cyrillic_query_does_not_raise() -> None:
+    """A >1 KB Cyrillic query must be treated as a free-text query."""
+    long_query = (
+        "Караман Grade 10, p.176 Мій ранок Прокидаюся, вмиваюся — "
+        "зворотні дієслова та ранкова рутина Діалоги Діалог 1 — Ранкова рутина: "
+        "— Коли ти прокидаєшся? — Я прокидаюся о сьомій. — Що ти робиш потім? "
+    ) * 6
+    assert len(long_query.encode("utf-8")) > 255, "test fixture too short"
+
+    bucket_a, bucket_b, dense = _prepare_query(long_query, track="a1")
+
+    assert isinstance(bucket_a, list)
+    assert isinstance(bucket_b, set)
+    assert isinstance(dense, str)
+    assert dense
+
+
+def test_existing_path_still_resolved_as_file() -> None:
+    """If the query is a real path, the file-as-query branch must still fire."""
+    discovery = REPO_ROOT / "curriculum" / "l2-uk-en" / "a1" / "discovery" / "my-morning.yaml"
+    if not discovery.exists():
+        pytest.skip("discovery fixture missing")
+
+    result = _prepare_query(discovery, track="a1")
+    assert result is not None
+
+
+def test_short_string_query_treated_as_text() -> None:
+    """A short string that is not a real path stays a text query."""
+    _bucket_a, _bucket_b, dense = _prepare_query("дієслова -ся", track="a1")
+    assert dense == "дієслова -ся" or "дієслова" in dense


### PR DESCRIPTION
## Summary

Fixes #1901 by bounding `_prepare_query`'s `Path(query).exists()` probe to 255 UTF-8 bytes and guarding `OSError`. Long plan-driven Cyrillic textbook queries now fall through to the free-text query path instead of raising `OSError: [Errno 63] File name too long` and being swallowed upstream as `corpus_missing`.

Also refreshes the stale workaround comment in `scripts/build/pilot_uk_lesson.py` and adds `tests/test_sources_db_prepare_query.py`.

Dispatch brief: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/1901

## Raw Verification

### Pre-fix repro

Command:
```bash
PYTHONPATH=scripts .venv/bin/python -c "
from wiki.sources_db import _prepare_query
plan_title = 'Караман Grade 10, p.176'
plan_topic = 'Мій ранок Прокидаюся, вмиваюся — зворотні дієслова та ранкова рутина Діалоги Діалог 1 — Ранкова рутина: — Коли ти прокидаєшся? — Я прокидаюся о сьомій. — Що ти робиш потім? — Вмиваюся, одягаюся і снідаю. ' * 3
query = f'{plan_title} {plan_topic}'
print(f'query length: {len(query)} chars')
_prepare_query(query, 'a1')
"
```

Output:
```text
query length: 636 chars
Traceback (most recent call last):
  File "<string>", line 7, in <module>
  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/1901-prepare-query-oserror/scripts/wiki/sources_db.py", line 346, in _prepare_query
    if candidate_path.exists():
       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krisztiankoos/.pyenv/versions/3.12.8/lib/python3.12/pathlib.py", line 860, in exists
    self.stat(follow_symlinks=follow_symlinks)
  File "/Users/krisztiankoos/.pyenv/versions/3.12.8/lib/python3.12/pathlib.py", line 840, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 63] File name too long: 'Караман Grade 10, p.176 Мій ранок Прокидаюся, вмиваюся — зворотні дієслова та ранкова рутина Діалоги Діалог 1 — Ранкова рутина: — Коли ти прокидаєшся? — Я прокидаюся о сьомій. — Що ти робиш потім? — Вмиваюся, одягаюся і снідаю. Мій ранок Прокидаюся, вмиваюся — зворотні дієслова та ранкова рутина Діалоги Діалог 1 — Ранкова рутина: — Коли ти прокидаєшся? — Я прокидаюся о сьомій. — Що ти робиш потім? — Вмиваюся, одягаюся і снідаю. Мій ранок Прокидаюся, вмиваюся — зворотні дієслова та ранкова рутина Діалоги Діалог 1 — Ранкова рутина: — Коли ти прокидаєшся? — Я прокидаюся о сьомій. — Що ти робиш потім? — Вмиваюся, одягаюся і снідаю. '
```

### Post-fix repro

Command:
```bash
PYTHONPATH=scripts .venv/bin/python -c "
from wiki.sources_db import _prepare_query
plan_title = 'Караман Grade 10, p.176'
plan_topic = 'Мій ранок Прокидаюся, вмиваюся — зворотні дієслова та ранкова рутина Діалоги Діалог 1 — Ранкова рутина: — Коли ти прокидаєшся? — Я прокидаюся о сьомій. — Що ти робиш потім? — Вмиваюся, одягаюся і снідаю. ' * 3
query = f'{plan_title} {plan_topic}'
print(f'query length: {len(query)} chars')
result = _prepare_query(query, 'a1')
print(type(result).__name__, [type(item).__name__ for item in result], bool(result[2]))
"
```

Output:
```text
query length: 636 chars
tuple ['list', 'set', 'str'] True
```

### Regression test

Command:
```bash
.venv/bin/python -m pytest tests/test_sources_db_prepare_query.py -v
```

Output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/1901-prepare-query-oserror/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/1901-prepare-query-oserror
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collecting ... collected 3 items

tests/test_sources_db_prepare_query.py::test_long_cyrillic_query_does_not_raise PASSED [ 33%]
tests/test_sources_db_prepare_query.py::test_existing_path_still_resolved_as_file PASSED [ 66%]
tests/test_sources_db_prepare_query.py::test_short_string_query_treated_as_text PASSED [100%]

============================== 3 passed in 0.29s ===============================
```

### Existing focused tests

Command:
```bash
.venv/bin/python -m pytest tests/test_sources_db*.py tests/test_textbook_grounding*.py -v 2>&1 | tail -20
```

Output:
```text
tests/test_sources_db.py::TestSourcesDb::test_missing_db PASSED          [ 48%]
tests/test_sources_db.py::test_search_external_filters_and_returns_metadata PASSED [ 51%]
tests/test_sources_db.py::test_search_external_register_and_quality_filters PASSED [ 54%]
tests/test_sources_db.py::test_search_external_track_reranks_hist_sources PASSED [ 57%]
tests/test_textbook_grounding_gate.py::test_textbook_grounding_gate_passes_good_fixture PASSED [ 60%]
tests/test_textbook_grounding_gate.py::test_textbook_grounding_gate_rejects_bad_fixture PASSED [ 63%]
tests/test_textbook_grounding_gate.py::test_textbook_grounding_gate_requires_all_references_above_a1 PASSED [ 66%]
tests/test_textbook_grounding_gate.py::test_textbook_grounding_gate_reads_jsonl_writer_trace PASSED [ 69%]
tests/test_textbook_grounding_gate.py::test_invoke_writer_persists_tool_trace PASSED [ 72%]
tests/test_textbook_grounding_gate.py::test_query_only_reference_match_rejected PASSED [ 75%]
tests/test_textbook_grounding_gate.py::test_wiki_result_does_not_satisfy_gate PASSED [ 78%]
tests/test_textbook_grounding_gate.py::test_a1_fallback_attributes_to_actual_match PASSED [ 81%]
tests/test_textbook_grounding_gate.py::test_off_topic_quote_rejected PASSED [ 84%]
tests/test_textbook_grounding_gate.py::test_missing_corpus_rejects_to_protect_authority PASSED [ 87%]
tests/test_textbook_grounding_gate.py::test_stress_marks_do_not_break_matching PASSED [ 90%]
tests/test_textbook_grounding_gate.py::test_apostrophes_normalized_for_matching PASSED [ 93%]
tests/test_textbook_grounding_gate.py::test_empty_references_rejected_for_b1_plus PASSED [ 96%]
tests/test_textbook_grounding_gate.py::test_invoke_writer_appends_tool_trace PASSED [100%]

============================== 33 passed in 0.55s ==============================
```

### Ruff

Command:
```bash
.venv/bin/ruff check scripts/wiki/sources_db.py scripts/build/pilot_uk_lesson.py tests/test_sources_db_prepare_query.py
```

Output:
```text
All checks passed!
```

### Diff scope

Command:
```bash
git diff --stat origin/main..HEAD
```

Output:
```text
 scripts/build/pilot_uk_lesson.py       |  8 +++---
 scripts/wiki/sources_db.py             | 13 ++++++++-
 tests/test_sources_db_prepare_query.py | 52 ++++++++++++++++++++++++++++++++++
 3 files changed, 68 insertions(+), 5 deletions(-)
```

## Notes

I did not rerun `v7_build.py`; per dispatch, batch builds stay user-run. After merge, rerun the A1 batch that was blocked by `textbook_grounding`.
