### PR TITLE
fix(vesum_gate): MC distractor + pronunciation transcription awareness

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -377,6 +377,10 @@ _BRACES_RE = re.compile(r"\{[А-ЯІЇЄҐа-яіїєґ'ʼ]{1,12}\}")
 _MORPHEME_FRAGMENT_RE = re.compile(
     r"(?<![А-ЯІЇЄҐа-яіїєґ'ʼA-Za-z0-9])-[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'ʼ]*"
 )
+_PRONUNCIATION_CUE_PATTERN = re.compile(
+    r"(?:sounds?\s+like|звучить\s+як|вимовляється\s+як|вимова[:\s])\s*\*\*[^*]+\*\*",
+    re.IGNORECASE,
+)
 _STANDALONE_POSTFIX_FRAGMENTS = frozenset(
     {"ся", "сь", "тся", "тсь", "ться", "шся", "шсь", "чся", "чсь"}
 )
@@ -3648,7 +3652,7 @@ def _vesum_gate(
 ) -> dict[str, Any]:
     """Verify Ukrainian words against VESUM, walking artifacts structurally.
 
-    Three classes of false positives are deliberately excluded:
+    Four classes of false positives are deliberately excluded:
 
     1. **Phonetic transcriptions and inline code** — `[с':а]`, `[ц':а]`, and
        backticked fragments like `` `вмиваєс':а` `` are metalinguistic notation
@@ -3656,7 +3660,10 @@ def _vesum_gate(
     2. **Intentional misspellings in `error-correction` activities** —
        `error:`, `errorWord:`, and `error_word:` fields contain the typo the
        student must fix (e.g. `прокидаєштся`). Verifying them would always fail.
-    3. **Sentence-initial capitalization** — VESUM is case-sensitive, so
+    3. **Wrong multiple-choice options** — `options: [{text, correct}]` values
+       with `correct: false` are author-labeled distractors. They may include
+       intentionally non-standard forms that test overgeneralization.
+    4. **Sentence-initial capitalization** — VESUM is case-sensitive, so
        `Спочатку` (capitalized first word) returns no matches even though
        `спочатку` does. Lookup is performed in lowercase; the report keeps
        original casing for evidence.
@@ -3824,7 +3831,7 @@ def _walk_artifact_strings(
 def _strip_metalinguistic(text: str) -> str:
     """Strip phonetic transcriptions, code, blank syntax, and morpheme labels.
 
-    Four categories of metalinguistic content are removed before VESUM lookup:
+    Five categories of metalinguistic content are removed before VESUM lookup:
 
     - `[...]` — phonetic notation like `[с':а]`, `[ц':а]`
     - `` `...` `` and ` ``` ... ``` ` — inline/fenced code
@@ -3832,6 +3839,7 @@ def _strip_metalinguistic(text: str) -> str:
     - `\\B-морфема` — hyphen-prefixed conjugation labels like `**-шся**`,
       `**-ться**`. The `\\B` lookbehind protects legitimate hyphenated
       compounds (`темно-синій`) where the char before `-` is a word char.
+    - `sounds like **...**` — cue-prefixed bold pronunciation transcriptions.
 
     Used by the VESUM gate to avoid false positives on fragments that aren't
     VESUM-checkable lemmas.
@@ -3841,6 +3849,7 @@ def _strip_metalinguistic(text: str) -> str:
     text = _BRACKETS_RE.sub(" ", text)
     text = _BRACES_RE.sub(" ", text)
     text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
+    text = _PRONUNCIATION_CUE_PATTERN.sub(" ", text)
     return text
 
 
@@ -3873,18 +3882,41 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
     always fail. The skip is at the dict (subtree) level so even a future
     nested shape like `error: { text: "...", note: "..." }` would be entirely
     excluded.
+
+    For multiple-choice-style `options: [{text, correct}]` lists, `text` on
+    options with falsy `correct` is an intentional wrong answer. Skip only that
+    option's text leaf so correct options and surrounding prompts are still
+    verified.
     """
     if activity.get("type") == _ERROR_CORRECTION_TYPE:
         skip_subtree = _ERROR_CORRECTION_INTENTIONAL_FIELDS
     else:
         skip_subtree = frozenset()
 
-    def keep(_parent_key: str | None, value: str) -> str | None:
-        return value
+    out: list[str] = []
 
-    return "\n".join(
-        _walk_artifact_strings(activity, keep=keep, skip_subtree_keys=skip_subtree)
-    )
+    def walk(node: Any, parent_key: str | None, *, in_options_list: bool = False) -> None:
+        if isinstance(node, dict):
+            wrong_option = (
+                in_options_list
+                and isinstance(node.get("text"), str)
+                and "correct" in node
+                and not node.get("correct", False)
+            )
+            for key, child in node.items():
+                if key in skip_subtree:
+                    continue
+                if wrong_option and key == "text":
+                    continue
+                walk(child, key)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, parent_key, in_options_list=parent_key == "options")
+        elif isinstance(node, str):
+            out.append(node)
+
+    walk(activity, None)
+    return "\n".join(out)
 
 
 def _extract_prose_text(

--- a/tests/test_vesum_gate_distractor_and_phonetic.py
+++ b/tests/test_vesum_gate_distractor_and_phonetic.py
@@ -1,0 +1,112 @@
+"""Regression tests for VESUM gate false-positive classes."""
+
+from __future__ import annotations
+
+from scripts.build.linear_pipeline import _vesum_gate
+
+
+def test_mc_distractor_text_not_verified() -> None:
+    """correct: false option text must not be checked against VESUM."""
+    activity = {
+        "type": "multiple-choice",
+        "questions": [
+            {
+                "question": "Я ___ каву.",
+                "options": [
+                    {"text": "п'ю", "correct": True},
+                    {"text": "п'юся", "correct": False},
+                    {"text": "п'єшся", "correct": False},
+                ],
+            }
+        ],
+    }
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {word: [{"lemma": word}] for word in words}
+
+    _vesum_gate(
+        module_text="",
+        activities=[activity],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert "п'юся" not in sent_for_verification
+    assert "п'єшся" not in sent_for_verification
+
+
+def test_correct_option_text_still_verified() -> None:
+    """correct: true option text must still be checked."""
+    activity = {
+        "type": "multiple-choice",
+        "questions": [
+            {
+                "question": "Я ___ каву.",
+                "options": [
+                    {"text": "п'ю", "correct": True},
+                    {"text": "п'юся", "correct": False},
+                ],
+            }
+        ],
+    }
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {word: [{"lemma": word}] for word in words}
+
+    _vesum_gate(
+        module_text="",
+        activities=[activity],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert "п'ю" in sent_for_verification
+
+
+def test_pronunciation_transcription_stripped_in_prose() -> None:
+    """A bold phonetic form following 'sounds like' must not hit VESUM."""
+    module_text = (
+        "The spelling **вмиваєшся** sounds like **вмиваєсся**, and "
+        "**вмивається** sounds like **вмиваєцця**."
+    )
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {word: [{"lemma": word}] for word in words}
+
+    _vesum_gate(
+        module_text=module_text,
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert "вмиваєсся" not in sent_for_verification
+    assert "вмиваєцця" not in sent_for_verification
+    assert "вмиваєшся" in sent_for_verification
+
+
+def test_isolated_misspelling_still_caught() -> None:
+    """A non-standard form outside a transcription context must be flagged."""
+    module_text = "She написала вмиваєсся without context."
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {word: [] for word in words}
+
+    result = _vesum_gate(
+        module_text=module_text,
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert "вмиваєсся" in result["missing"]


### PR DESCRIPTION
## Summary

- Exclude author-labeled wrong MC option text (`options: [{text, correct: false}]`) from `_vesum_gate` verification while still checking correct option text.
- Strip narrow cue-prefixed bold pronunciation transcriptions such as `sounds like **вмиваєсся**` before VESUM lookup.
- Add regression coverage for MC distractors, correct options, pronunciation transcriptions, and isolated misspellings.

## Raw verification

Pre-fix repro on `curriculum/l2-uk-en/a1/my-morning` (same generated module content from the bakeoff case), captured before the fix:

```text
passed=False
missing=['вмиваєсся', 'вмиваєцця', "п'юся", "п'єшся", 'снідаюся', 'снідаєшся']
missing_count=6
```

Post-fix repro on the same module:

```text
passed=True
missing=[]
missing_count=0
```

Regression test:

```text
tests/test_vesum_gate_distractor_and_phonetic.py::test_mc_distractor_text_not_verified PASSED [ 25%]
tests/test_vesum_gate_distractor_and_phonetic.py::test_correct_option_text_still_verified PASSED [ 50%]
tests/test_vesum_gate_distractor_and_phonetic.py::test_pronunciation_transcription_stripped_in_prose PASSED [ 75%]
tests/test_vesum_gate_distractor_and_phonetic.py::test_isolated_misspelling_still_caught PASSED [100%]

============================== 4 passed in 0.26s ===============================
```

Existing VESUM + linear pipeline tests:

```text
tests/test_linear_pipeline_telemetry.py::test_writer_telemetry_events_fire_from_invocation_wrapper PASSED [ 87%]
tests/test_linear_pipeline_telemetry.py::test_reviewer_telemetry_events_and_rollup_fire_from_dim_wrappers PASSED [ 90%]
tests/test_linear_pipeline_telemetry.py::test_telemetry_event_schema_is_bounded_and_flat PASSED [ 93%]
tests/test_linear_pipeline_telemetry.py::test_telemetry_event_sink_appends_jsonl PASSED [ 96%]
tests/test_linear_pipeline_telemetry.py::test_tools_writer_runtime_gate_still_fires_for_empty_tool_calls PASSED [100%]

============================== 32 passed in 0.41s ==============================
```

Ruff:

```text
All checks passed!
```

Commit trailer audit:

```text
Checking 1 commit(s) in origin/main..HEAD:

  0447aa8cd6  PASS  X-Agent: codex/vesum-gate-distractor-awareness

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```