### PR TITLE
fix(writer-telemetry): preserve search_text textbook hits

### DIFF
--- a/scripts/agent_runtime/result.py
+++ b/scripts/agent_runtime/result.py
@@ -42,10 +42,12 @@ class ParseResult:
             deliberately leave this None when the CLI doesn't expose tokens,
             rather than invent numbers. Populated opportunistically.
         tool_calls: PII-bearing tool-call telemetry parsed from the CLI trace.
-            Tool outputs are summarized and capped; callers must still treat
-            names and arguments as sensitive pipeline data. Arguments are
-            source-shaped and may contain synthetic ``_raw`` / ``_value`` keys.
-            Timestamps are provider strings or lenient ISO-8601 fallbacks.
+            Tool outputs include a capped summary and may include the raw
+            in-memory result for downstream grounding checks. Callers must
+            still treat names, arguments, and results as sensitive pipeline
+            data. Arguments are source-shaped and may contain synthetic
+            ``_raw`` / ``_value`` keys. Timestamps are provider strings or
+            lenient ISO-8601 fallbacks.
     """
     ok: bool
     response: str
@@ -87,9 +89,9 @@ class Result:
         usage_record: The exact dict written to batch_state/api_usage/. Callers
             can log or aggregate this. Follows the schema in design doc § 4.5.
         tool_calls: PII-bearing tool-call telemetry parsed from the CLI trace.
-            Each entry has name, arguments, output_summary, and timestamp.
-            Never contains full raw tool output. Kept in memory only; do not
-            persist or echo arguments to JSONL telemetry without redaction.
+            Each entry has name, arguments, output_summary, timestamp, and
+            may have result. Kept in memory only; do not persist or echo
+            arguments or results to JSONL telemetry without redaction.
     """
     ok: bool
     agent: str

--- a/scripts/agent_runtime/tool_calls.py
+++ b/scripts/agent_runtime/tool_calls.py
@@ -109,12 +109,15 @@ def normalize_tool_calls(events: Iterable[Mapping[str, Any]]) -> list[dict[str, 
             name = _tool_name(payload)
             if not name:
                 continue
+            output = _tool_output(payload)
             call = {
                 "name": name,
                 "arguments": _tool_arguments(payload),
-                "output_summary": summarize_tool_output(_tool_output(payload)),
+                "output_summary": summarize_tool_output(output),
                 "timestamp": _timestamp(payload, event),
             }
+            if output is not None:
+                call["result"] = output
             calls.append(call)
             call_id = _tool_call_id(payload)
             if call_id:
@@ -128,9 +131,10 @@ def normalize_tool_calls(events: Iterable[Mapping[str, Any]]) -> list[dict[str, 
         for payload in result_payloads:
             call_id = _tool_result_id(payload)
             if call_id and call_id in by_id:
-                by_id[call_id]["output_summary"] = summarize_tool_output(
-                    _tool_output(payload)
-                )
+                output = _tool_output(payload)
+                by_id[call_id]["output_summary"] = summarize_tool_output(output)
+                if output is not None:
+                    by_id[call_id]["result"] = output
 
     return calls
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1539,9 +1539,108 @@ def _summarize_generic_tool_result(result: Any) -> dict[str, Any]:
     return {"text_chars": len(str(result))}
 
 
+SEARCH_TEXT_RESULT_ITEM_LIMIT = 10
+SEARCH_TEXT_RESULT_TEXT_LIMIT = 500
+
+
+def _maybe_parse_json_string(value: str) -> Any:
+    stripped = value.strip()
+    if not stripped or stripped[0] not in "[{":
+        return value
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return value
+
+
+def _search_text_result_items(result: Any) -> list[Mapping[str, Any]]:
+    result = _maybe_parse_json_string(result) if isinstance(result, str) else result
+    if isinstance(result, Mapping):
+        for key in ("structuredContent", "structured_content"):
+            structured = result.get(key)
+            if structured is not None:
+                structured_items = _search_text_result_items(structured)
+                if structured_items:
+                    return structured_items
+        raw_hits = result.get("results") or result.get("hits") or result.get("items")
+        if isinstance(raw_hits, list):
+            return [item for item in raw_hits if isinstance(item, Mapping)]
+        content = result.get("content")
+        if isinstance(content, list | tuple):
+            content_items = _search_text_result_items(content)
+            if content_items:
+                return content_items
+        text = result.get("text")
+        if (
+            result.get("type") == "text"
+            and isinstance(text, str)
+            and (parsed := _maybe_parse_json_string(text)) is not text
+        ):
+            return _search_text_result_items(parsed)
+        return [result]
+    if isinstance(result, list | tuple):
+        items: list[Mapping[str, Any]] = []
+        for item in result:
+            if (
+                isinstance(item, Mapping)
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+            ):
+                parsed = _maybe_parse_json_string(item["text"])
+                if parsed is not item["text"]:
+                    items.extend(_search_text_result_items(parsed))
+                    continue
+            if isinstance(item, Mapping):
+                items.append(item)
+        return items
+    return []
+
+
+def _summarize_search_text_result(result: Any) -> dict[str, Any]:
+    items = _search_text_result_items(result)
+    if not items:
+        return _summarize_generic_tool_result(result)
+
+    summary_items: list[dict[str, Any]] = []
+    for item in items[:SEARCH_TEXT_RESULT_ITEM_LIMIT]:
+        summary_item: dict[str, Any] = {}
+        for key in (
+            "source_type",
+            "corpus",
+            "type",
+            "source",
+            "author",
+            "grade",
+            "page",
+            "title",
+            "section_title",
+            "chunk_id",
+        ):
+            value = item.get(key)
+            if value not in (None, ""):
+                summary_item[key] = _clean_telemetry_text(str(value), 160)
+        text = _textbook_hit_text(item, max_chars=SEARCH_TEXT_RESULT_TEXT_LIMIT)
+        if text:
+            summary_item["text"] = _clean_telemetry_text(
+                text,
+                SEARCH_TEXT_RESULT_TEXT_LIMIT,
+            )
+        if summary_item:
+            summary_items.append(summary_item)
+
+    summary: dict[str, Any] = {"count": len(items)}
+    if summary_items:
+        summary["items"] = summary_items
+    if len(items) > SEARCH_TEXT_RESULT_ITEM_LIMIT:
+        summary["truncated_items"] = len(items) - SEARCH_TEXT_RESULT_ITEM_LIMIT
+    return summary
+
+
 def _summarize_tool_result(tool: str, result: Any) -> dict[str, Any]:
     if tool == "verify_words":
         return _summarize_verify_words_result(result)
+    if tool == "search_text":
+        return _summarize_search_text_result(result)
     return _summarize_generic_tool_result(result)
 
 
@@ -4176,6 +4275,14 @@ def _load_writer_tool_calls(module_dir: Path) -> list[dict[str, Any]]:
 
 def _result_items_from_call(call: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     result = call.get("result", call.get("response"))
+    result_summary = call.get("result_summary")
+    has_summary_items = isinstance(result_summary, Mapping) and isinstance(
+        result_summary.get("items"),
+        list,
+    )
+    result_is_excerpt_only = isinstance(result, Mapping) and set(result) <= {"text"}
+    if has_summary_items and (result is None or result_is_excerpt_only):
+        result = result_summary
     if result is None and call.get("result_excerpt"):
         result = {"text": call["result_excerpt"]}
         if call.get("source_type"):

--- a/tests/test_agent_runtime_tool_calls.py
+++ b/tests/test_agent_runtime_tool_calls.py
@@ -49,5 +49,12 @@ def test_normalize_tool_calls_extracts_gemini_toolcalls_shape() -> None:
 
     assert calls[0]["name"] == "mcp__sources__verify_words"
     assert calls[0]["arguments"] == {"words": ["кіт"]}
+    assert calls[0]["result"] == [
+        {
+            "functionResponse": {
+                "name": "mcp__sources__verify_words",
+                "response": {"output": "ok"},
+            }
+        }
+    ]
     assert calls[0]["timestamp"] == "2026-05-09T19:20:01Z"
-

--- a/tests/test_writer_telemetry_search_text.py
+++ b/tests/test_writer_telemetry_search_text.py
@@ -1,0 +1,77 @@
+"""Regression tests for writer telemetry capture of search_text results.
+
+The textbook_grounding gate reads writer telemetry. A search_text call with
+non-empty MCP results must preserve enough attribution and text in the emitted
+event for the gate-side reader to recover textbook hits.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.build.linear_pipeline import (
+    _result_items_from_call,
+    emit_writer_response_telemetry,
+)
+
+
+def test_search_text_results_preserved_in_telemetry() -> None:
+    fake_search_result = [
+        {
+            "source_type": "textbook",
+            "author": "karaman",
+            "grade": "10",
+            "page": "176",
+            "title": "Сторінка 176",
+            "text": "Дієслова із суфіксом -ся(-сь) означають дію, спрямовану на виконавця.",
+        }
+    ]
+    tool_calls = [
+        {
+            "tool": "search_text",
+            "args": {"query": "дієслова -ся"},
+            "result": fake_search_result,
+            "section": "Дієслова на -ся",
+        }
+    ]
+    events: list[dict[str, Any]] = []
+
+    def sink(event_name: str, **fields: Any) -> None:
+        events.append({"event": event_name, **fields})
+
+    emit_writer_response_telemetry(
+        output="(writer output)",
+        writer="claude-tools",
+        module="a1/my-morning",
+        sections=["Дієслова на -ся"],
+        tool_calls=tool_calls,
+        event_sink=sink,
+    )
+
+    tool_call_events = [
+        event for event in events if event["event"] == "writer_tool_call"
+    ]
+    assert len(tool_call_events) == 1
+    event = tool_call_events[0]
+
+    assert event["result_summary"]
+    summary_or_excerpt = str(event.get("result_summary")) + str(
+        event.get("result_excerpt", "")
+    )
+    assert "karaman" in summary_or_excerpt or "Караман" in summary_or_excerpt
+    assert "176" in summary_or_excerpt
+
+    items = list(_result_items_from_call(event))
+    textbook_items = [
+        item
+        for item in items
+        if str(item.get("source_type") or item.get("corpus") or "").startswith(
+            "textbook"
+        )
+    ]
+    assert textbook_items, "gate cannot extract textbook items from telemetry"
+    assert "Дієслова із суфіксом" in str(textbook_items[0].get("text"))
+
+    loaded_jsonl_event = dict(event)
+    loaded_jsonl_event["result"] = {"text": event["result_excerpt"]}
+    loaded_items = list(_result_items_from_call(loaded_jsonl_event))
+    assert loaded_items[0]["source_type"] == "textbook"


### PR DESCRIPTION
## Summary

- Verdict: Hypothesis C.
- Capture-side: Claude/Codex adapters both feed traces through `normalize_tool_calls()`, which kept `output_summary` but did not populate `result`; `emit_writer_response_telemetry()` reads only `result` / `response`, so `search_text` arrived as `None`.
- Summarizer/gate-side: even with captured results, generic list summaries only produce counts. This PR adds bounded `search_text` item summaries and teaches `_result_items_from_call()` to read structured `result_summary.items` from writer JSONL.

## Evidence

Required grep output:

```text
$ grep -n "emit_writer_response_telemetry" scripts/build/linear_pipeline.py scripts/agent_runtime/*.py
scripts/build/linear_pipeline.py:1668:def emit_writer_response_telemetry(
scripts/build/linear_pipeline.py:2006:        phase_writer_summary = emit_writer_response_telemetry(
```

```text
$ grep -n "tool_calls" scripts/agent_runtime/adapters/claude.py scripts/agent_runtime/adapters/codex.py | head -20
scripts/agent_runtime/adapters/claude.py:57:from ..tool_calls import normalize_tool_calls, parse_json_events
scripts/agent_runtime/adapters/claude.py:332:        tool_calls = normalize_tool_calls(events)
scripts/agent_runtime/adapters/claude.py:373:            tool_calls=tool_calls,
scripts/agent_runtime/adapters/codex.py:39:from ..tool_calls import normalize_tool_calls, parse_json_events
scripts/agent_runtime/adapters/codex.py:384:        tool_calls = normalize_tool_calls(trace_events)
scripts/agent_runtime/adapters/codex.py:416:            tool_calls=tool_calls,
```

Pre-fix bakeoff evidence:

```text
$ grep '"tool": "search_text"' audit/bakeoff-2026-05-12-night/claude.write.jsonl
{"event": "writer_tool_call", "ts": "2026-05-12T00:20:09.521940+00:00", "writer": "claude-tools", "module": "a1/20", "section": "unknown", "tool": "search_text", "args_summary": {"query_chars": 60}, "result_summary": {}, "duration_ms": 0}
{"event": "writer_tool_call", "ts": "2026-05-12T00:20:09.521972+00:00", "writer": "claude-tools", "module": "a1/20", "section": "unknown", "tool": "search_text", "args_summary": {"query_chars": 49}, "result_summary": {}, "duration_ms": 0}
```

Relevant call path snippets:

```text
scripts/agent_runtime/adapters/claude.py:331-373
        events = parse_json_events(stdout, source="claude", logger=_logger)
        tool_calls = normalize_tool_calls(events)
...
            tool_calls=tool_calls,
```

```text
scripts/agent_runtime/adapters/codex.py:378-416
        trace_events = parse_json_events(
            rollout_trace,
            source="codex",
            logger=_logger,
        )
        tool_calls = normalize_tool_calls(trace_events)
...
            tool_calls=tool_calls,
```

```text
scripts/build/linear_pipeline.py:1693-1716
    for call in tool_calls or []:
        tool = _normalize_tool_name(
            call.get("tool") or call.get("tool_name") or call.get("name")
        )
...
        result = call.get("result", call.get("response"))
...
            "result_summary": _summarize_tool_result(tool, result),
...
        if tool == "search_text":
            excerpt = _bounded_result_excerpt(result)
```

## Fix

- `normalize_tool_calls()` now retains `call["result"]` from tool-use payloads and correlated tool-result payloads.
- `search_text` telemetry now emits bounded `result_summary.items` preserving `source_type` / `corpus`, author, grade, page, title, chunk id, and text fragment.
- `_result_items_from_call()` now prefers structured `result_summary.items` when a JSONL loader has only backfilled excerpt text.
- Added regression coverage for runtime capture and writer telemetry gate extraction.

## Validation

```text
$ ../../../../.venv/bin/python -m pytest tests/test_writer_telemetry_search_text.py -v
collected 1 item

tests/test_writer_telemetry_search_text.py::test_search_text_results_preserved_in_telemetry PASSED [100%]

============================== 1 passed in 0.14s ===============================
```

```text
$ ../../../../.venv/bin/python -m pytest tests/test_linear_pipeline*.py tests/test_textbook_grounding*.py -v
collected 19 items
...
============================== 19 passed in 0.21s ==============================
```

```text
$ ../../../../.venv/bin/python -m pytest tests/test_agent_runtime_tool_calls.py tests/test_runner_tool_calls.py tests/test_gemini_adapter_tool_calls.py -v
collected 18 items
...
============================== 18 passed in 0.24s ==============================
```

```text
$ ../../../../.venv/bin/ruff check scripts/agent_runtime/tool_calls.py scripts/agent_runtime/result.py scripts/build/linear_pipeline.py tests/test_agent_runtime_tool_calls.py tests/test_writer_telemetry_search_text.py
All checks passed!
```

Repo-wide ruff is not clean on current `origin/main`; I did not touch the unrelated failing files:

```text
$ ../../../../.venv/bin/ruff check
E701 Multiple statements on one line (colon)
  --> docs/reports/check_b2_plans.py:50:38
...
B007 Loop control variable `i` not used within loop body
  --> plans/patch_yaml.py:9:13
...
Found 28 errors.
```

```text
$ ../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  0d502ebd0a  PASS  X-Agent: codex/writer-telemetry-result-summary

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
