### PR TITLE
fix(writer-prompt): budget + citation + immersion discipline for V7 claude-tools writer

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -73,6 +73,13 @@ that failure class. Run each check while drafting, not as a separate pass.
 
    **Verbatim textbook grounding (mandatory).** For each `plan_references` entry, you MUST call `mcp__sources__search_text` with a query targeting that textbook + topic, then quote at least one verbatim block (≥30 words) inline in the relevant section. The citation must include the textbook author + grade + page extracted from the search result, and the quote must be set off as a blockquote so reviewers can verify it. Inventing or paraphrasing in place of retrieving is a hard fail (`textbook_grounding`).
 
+   <!-- CITATION DISCIPLINE -->
+   **`resources.yaml` ↔ `plan_references` parity (the `citations_resolve` gate).** Every entry you emit in `resources.yaml` MUST resolve to an entry in this prompt's `plan_references` list (rendered under "Plan" below). The gate resolves via either:
+   (a) whitespace-normalized title match, or
+   (b) an (author, grade, page) triple match — where **`page` MUST be a single integer**. A page range like `с. 162-163` or `p.176-177` fails key extraction and the gate marks the entry unknown.
+
+   Concrete contract: if `plan_references` carries `Захарійчук Grade 4, p.162`, your `resources.yaml` title MUST be `Захарійчук, 4 клас, с. 162` (same single page) — NOT `Захарійчук, 4 клас, с. 162-163` (widened page range fails). Do NOT add `resources.yaml` entries for sources absent from `plan_references`; the gate has no path to resolve them. If you want to cite a supporting source inline, quote it in prose with proper attribution, but do not list it in `resources.yaml`. The canonical reference form is the same one the plan uses — copy the plan's `title` verbatim into `resources.yaml.title` and the citation can never desync.
+
 For heritage defense, route lookups through the canonical MCP tools in this order: (1) `mcp__sources__search_heritage` is the primary entry point — it merges Грінченко 1907, ЕСУМ, slovnyk.me modern/regional dictionaries, and Антоненко-Давидович style warnings, ranking pre-Soviet attestations above modern-only rows. (2) Use `mcp__sources__search_slovnyk_me` only when you specifically need a slovnyk.me single-source result (e.g. СУМ-20 or a regional dictionary not surfaced by `search_heritage`). (3) Standard tools — `check_modern_form` (VESUM), `search_grinchenko_1907`, `search_esum`, literary corpus, and compiled wiki/source citations — remain valid evidence sources alongside the merged heritage tool. Cite the tool name and the dictionary slug in your `<plan_reasoning verification="...">` block. Do not claim heritage verification without naming a concrete tool result.
 For slovnyk.me rows, use only canonical `dictionary_slug` values defined by `scripts/wiki/slovnyk_me.py`, especially heritage slugs `newsum`, `holoskevych`, `obsolete_words`, `bukovina`, `franko`, and `slang_lviv`; for merged `search_heritage` rows without `dictionary_slug`, cite `source_family`, `source`, and `classification`. Include the first 80 characters of the raw tool-result `text` verbatim in `<plan_reasoning>`. If `search_heritage` returns empty, emit `<!-- VERIFY: heritage status for "X" unresolved -->` rather than asserting heritage status.
 
@@ -103,6 +110,9 @@ For slovnyk.me rows, use only canonical `dictionary_slug` values defined by `scr
    <rescanned_sources>List of citations actually checked against MCP.</rescanned_sources>
    <grammar_claims_grounded>List of grammar rules traced back to the Knowledge Packet or textbook.</grammar_claims_grounded>
    <removed_unverified>What you deleted because it failed verification.</removed_unverified>
+   <section_word_counts>One line per `## H2` section: "Section name — N words (band X-Y, status: in-band|over-by-K|under-by-K)". For any section outside its band, trim or expand it now (cut one example or compress one sentence; add one example or expand one explanation) BEFORE this end_gate block is emitted, and re-state the post-fix count. The `plan_sections` gate is a HARD GATE — even 6 words over fails.</section_word_counts>
+   <resources_match_plan>One line per `resources.yaml` entry: "Title — resolves to plan_references[K] via [normalized|triple]". For any entry with no resolution path (page range vs the plan's single page, or a source absent from `plan_references`), remove it from `resources.yaml` now and re-state. The `citations_resolve` gate fails closed on any unmatched entry.</resources_match_plan>
+   <long_uk_sentences>List any Ukrainian-bearing sentence in `module.md` whose UK-word count exceeds 10. For each, split the sentence across structural breaks (separate `> ` lines, list items, paragraphs) or shorten the Ukrainian clause now, then re-state with the post-fix count. An empty list confirms the immersion long-sentence check is clean.</long_uk_sentences>
    </end_gate>
    ```
 
@@ -221,6 +231,31 @@ for a teacher narrating their own lesson plan. Hold to this register:
 - **Section length is bounded by the contract YAML.** If you find yourself
   expanding an English bridge sentence, cut it instead. Word budgets are
   authoritative.
+<!-- BUDGET DISCIPLINE -->
+- **Section word budgets are HARD GATES, not soft targets.** The
+  `plan_sections` gate counts words per `## H2` section and fails the
+  build if any section is outside its `min..max` band. The `<word_budget>`
+  block in `<plan_reasoning>` is your pre-write plan; the `<end_gate>` is
+  where you verify reality. Before emitting fences, count each section
+  and trim/expand to land inside its band. A single section 6 words over
+  fails the gate just as hard as one 60 over.
+<!-- IMMERSION DISCIPLINE -->
+- **No single sentence may contain more than 10 Ukrainian words.** The
+  immersion gate's `long_ukrainian_sentences` check flags any sentence
+  whose UK-word count exceeds 10 — this includes mixed English-and-Ukrainian
+  sentences (an English bridge followed by a long Ukrainian example
+  counts together). Break long Ukrainian content into separate sentences
+  across multiple blockquote lines, list items, table rows, or paragraphs;
+  the gate treats those structural breaks as sentence boundaries. If a
+  textbook passage you want to verbatim-quote has a single sentence with
+  >10 Ukrainian words, prefer (a) quoting a shorter excerpt, or (b)
+  splitting the quote into clauses on separate `> ` lines so each clause
+  is its own sentence. The `textbook_grounding` gate requires only one
+  ≥30-token verbatim block somewhere in the module — it does NOT require
+  every cited source to be pasted as a full-sentence quote.
+- **Aim for the middle of the Immersion Rule's percent band**, not the top
+  edge. If the rule says 15-35%, target ~20-25% so you have headroom
+  against per-section drift and the long-sentence check has slack.
 
 ## Activity Types
 


### PR DESCRIPTION
## Summary

Three surgical prompt edits (+35 LOC) to `scripts/build/phases/linear-write.md` targeting the three prompt-tunable gate fails from the 2026-05-13 midday a1/my-morning bakeoff (claude-tools writer):

1. **`citations_resolve`** — added `resources.yaml` ↔ `plan_references` parity sub-paragraph naming the gate's two resolution paths (normalized title OR `(author, grade, page)` triple). Warns that page ranges fail key extraction.
2. **`plan_sections`** — added "Section word budgets are HARD GATES" bullet + a new `<section_word_counts>` end_gate sub-node forcing per-section trim BEFORE emitting fences.
3. **`immersion.long_ukrainian_sentences`** — added the ">10 UK words per sentence" rule + a new `<long_uk_sentences>` end_gate sub-node + a "target middle of band, not top edge" bullet for headroom.

Two more end_gate sub-nodes added (`<resources_match_plan>`, `<section_word_counts>`) so the discipline lives both as guidance (Tier-1 / Tone) AND enforcement (end_gate self-check with "fix it now and re-state").

## The three prompt diff hunks (one per fail)

### Hunk A — citation parity (citations_resolve)
\`\`\`md
<!-- CITATION DISCIPLINE -->
**\`resources.yaml\` ↔ \`plan_references\` parity (the \`citations_resolve\` gate).**
Every entry you emit in \`resources.yaml\` MUST resolve to an entry in this
prompt's \`plan_references\` list. The gate resolves via either:
(a) whitespace-normalized title match, or
(b) an (author, grade, page) triple match — where **\`page\` MUST be a
single integer**. A page range like \`с. 162-163\` or \`p.176-177\` fails key
extraction and the gate marks the entry unknown.
\`\`\`

Plus a concrete contract example using the exact failed citation from the bakeoff.

### Hunk B — budget discipline (plan_sections)
\`\`\`md
<!-- BUDGET DISCIPLINE -->
- **Section word budgets are HARD GATES, not soft targets.** The
  \`plan_sections\` gate counts words per \`## H2\` section and fails the
  build if any section is outside its \`min..max\` band. ... A single
  section 6 words over fails the gate just as hard as one 60 over.
\`\`\`

Plus a new \`<section_word_counts>\` end_gate sub-node requiring per-section count + trim-before-fences.

### Hunk C — long-sentence + middle-band (immersion)
\`\`\`md
<!-- IMMERSION DISCIPLINE -->
- **No single sentence may contain more than 10 Ukrainian words.** The
  immersion gate's \`long_ukrainian_sentences\` check flags any sentence
  whose UK-word count exceeds 10 — this includes mixed English-and-Ukrainian
  sentences ...
- **Aim for the middle of the Immersion Rule's percent band**, not the top
  edge. ... so you have headroom against per-section drift.
\`\`\`

Plus a new \`<long_uk_sentences>\` end_gate sub-node.

## Prior-state evidence

From \`audit/bakeoff-2026-05-13-midday/claude/python_qg.json\`:

\`\`\`json
\"plan_sections\": {
  \"passed\": false,
  \"word_budgets\": [
    {\"section\": \"Дієслова на -ся\", \"count\": 336, \"min\": 270, \"max\": 330, \"passed\": false}
  ]
}
\`\`\`

\`\`\`json
\"citations_resolve\": {
  \"passed\": false,
  \"unknown\": [
    \"Захарійчук, 4 клас, с. 162-163\",
    \"Кравцова, 4 клас, с. 112-113\",
    \"Авраменко, 7 клас, с. 67\"
  ]
}
\`\`\`

\`\`\`json
\"immersion\": {
  \"passed\": false,
  \"pct\": 25.4,
  \"long_ukrainian_sentences\": [
    \"> Дієслова із суфіксом -ся(-сь), які виражають зворотну дію, ...\",
    \"Сучасний дієслівний суфікс -ся(-сь) — це давня коротка форма ...\",
    \"Уживається -ся(-сь) після інфінітивного суфікса -ти(-ть) ...\"
  ]
}
\`\`\`

(Note: the failure-mode root cause for immersion is \`long_ukrainian_sentences\` — 4 sentences each >10 UK words. The pct (25.4%) was actually inside the policy band (15-35% for a1-m15-24). The dispatch brief's "25.4% > 24% cap" framing conflated the gate output with the bakeoff brief's recommended sweet spot. Both behaviors are addressed: short-sentence rule + middle-of-band target.)

## What the gate code actually enforces

- \`scripts/build/citation_matcher.py:100\` — \`extract_citation_key\` returns \`None\` if the page is followed by \`-\`, \`–\`, or \`—\` (page range). Hence the strict single-page requirement in the prompt.
- \`scripts/build/linear_pipeline.py:4644\` — \`_long_ukrainian_sentences\` flags any sentence with \`len(_UK_WORD_RE.findall(sentence)) > 10\`. Hence the ≤10 UK words / structural-break guidance.
- \`scripts/build/linear_pipeline.py:4093\` — \`_citation_gate\` iterates \`resources\` and rejects entries that match neither plan's normalized titles nor plan's keys. Hence the \"no entry absent from plan_references\" rule.

## Test plan

- [x] \`ruff check scripts/build/phases/\` — clean
- [x] \`pytest -k \"prompt or writer or linear_pipeline\"\` — 523 passed, 14 skipped. One preexisting failure (\`test_invoke_writer_routes_supported_writers\`) is unrelated to prompt content (tool_config routing); verified preexisting on origin/main via \`git stash && pytest\`.
- [x] Grep verified all three discipline markers + three new end_gate sub-nodes present in source.
- [ ] **Validation requires user-run V7 rebuild on a1/my-morning to confirm gate fixes — not run here per orchestrator-only build policy.**

## Pre-submit checklist (per AGENTS.md:11-26)

- ✅ \`.python-version\` unchanged
- ✅ \`.yamllint\` and \`.markdownlint.json\` unchanged
- ✅ No \`status/*.json\` or \`audit/*-review.md\` files in diff
- ✅ Only one file changed: \`scripts/build/phases/linear-write.md\` (phase prompt)
- ✅ Total files changed: 1 (< 5)

## Related

- ADR: \`docs/decisions/2026-05-06-writer-selection-codex-gpt55.md\` (REVISED-AGAIN; claude-tools is V7 writer)
- Dispatch brief: \`docs/dispatch-briefs/2026-05-13-writer-prompt-tune.md\`
- Companion (Codex, pipeline gate trio): \`docs/dispatch-briefs/2026-05-13-pipeline-gate-trio.md\`
- Bakeoff artifacts: \`audit/bakeoff-2026-05-13-midday/claude/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)