### PR TITLE
fix(linear_pipeline): gate parser and immersion policy fixes

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -434,7 +434,10 @@ _SENTENCE_SPLIT_RE = re.compile(
 # Activity fields whose values are intentionally misspelled — students correct
 # them. Excluded from VESUM lookup only for error-correction activities.
 _ERROR_CORRECTION_TYPE = "error-correction"
-_ERROR_CORRECTION_INTENTIONAL_FIELDS = frozenset({"error", "errorWord", "error_word"})
+_ERROR_CORRECTION_INTENTIONAL_FIELDS = frozenset(
+    {"error", "errors", "errorWord", "error_word", "sentence"}
+)
+_VESUM_ABBREVIATION_RE = re.compile(r"\bдіал\.", re.IGNORECASE)
 
 # String fields whose values are user-facing prose (subject to AI-slop checks).
 # YAML structural keys like `correction:` and `correctAnswer:` are deliberately
@@ -3945,6 +3948,7 @@ def _strip_metalinguistic(text: str) -> str:
       `**-ться**`. The `\\B` lookbehind protects legitimate hyphenated
       compounds (`темно-синій`) where the char before `-` is a word char.
     - `sounds like **...**` — cue-prefixed bold pronunciation transcriptions.
+    - `діал.` — textbook abbreviation for `діалектне`, not a lemma.
 
     Used by the VESUM gate to avoid false positives on fragments that aren't
     VESUM-checkable lemmas.
@@ -3955,6 +3959,7 @@ def _strip_metalinguistic(text: str) -> str:
     text = _BRACES_RE.sub(" ", text)
     text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _PRONUNCIATION_CUE_PATTERN.sub(" ", text)
+    text = _VESUM_ABBREVIATION_RE.sub(" ", text)
     return text
 
 
@@ -3982,11 +3987,11 @@ def _build_vesum_text(
 def _activity_vesum_text(activity: dict[str, Any]) -> str:
     """Walk an activity's string values, excluding intentional-error fields.
 
-    For `error-correction` activities, fields like `error:` and `errorWord:`
-    hold the typo the student must fix; verifying them against VESUM would
-    always fail. The skip is at the dict (subtree) level so even a future
-    nested shape like `error: { text: "...", note: "..." }` would be entirely
-    excluded.
+    For `error-correction` activities, fields like `error:`, `errorWord:`,
+    and `sentence:` hold the typo the student must fix; verifying them against
+    VESUM would always fail. The skip is at the dict (subtree) level so even a
+    future nested shape like `error: { text: "...", note: "..." }` would be
+    entirely excluded.
 
     For multiple-choice-style `options: [{text, correct}]` lists, `text` on
     options with falsy `correct` is an intentional wrong answer. Skip only that
@@ -4150,6 +4155,12 @@ def _extract_blockquotes(text: str) -> list[str]:
 def _normalize_match_text(text: str) -> str:
     text = re.sub(r"<!--.*?-->", " ", text, flags=re.DOTALL)
     text = re.sub(r"\[[^\]]+\]\([^)]+\)", " ", text)
+    text = text.replace("\xad", "")
+    text = re.sub(
+        r"(?<=[A-Za-zА-Яа-яҐґЄєІіЇї])-\s+(?=[A-Za-zА-Яа-яҐґЄєІіЇї])",
+        "",
+        text,
+    )
     text = text.replace("’", "'").replace("ʼ", "'")
     decomposed = unicodedata.normalize("NFD", text)
     return "".join(char for char in decomposed if not unicodedata.combining(char))
@@ -4311,6 +4322,53 @@ def _load_writer_tool_calls(module_dir: Path) -> list[dict[str, Any]]:
     return calls
 
 
+_MCP_SEARCH_TEXT_RESULT_RE = re.compile(
+    r"(?ms)^###\s+Result\s+\d+\s*$"
+    r"(?P<body>.*?)(?=^###\s+Result\s+\d+\s*$|\Z)"
+)
+
+
+def _parse_mcp_search_text_markdown(text: str) -> list[Mapping[str, Any]]:
+    """Parse sources.search_text markdown output into textbook result items."""
+    items: list[Mapping[str, Any]] = []
+    for match in _MCP_SEARCH_TEXT_RESULT_RE.finditer(text):
+        body = match.group("body").strip()
+        source_match = re.search(r"(?m)^-\s+\*\*Source\*\*:\s*(?P<source>.+?)\s*$", body)
+        text_match = re.search(r"(?ms)^-\s+\*\*Text\*\*:\s*\n(?P<text>.*)\Z", body)
+        if source_match is None or text_match is None:
+            continue
+
+        source = source_match.group("source").strip()
+        grade_match = re.search(r"(?i)\bgrade\s+(?P<grade>1[01]|[1-9])\b", source)
+        page_match = re.search(
+            r"(?im)^-\s+\*\*Section\*\*:\s*(?:Сторінка|Page|p\.?)\s*(?P<page>\d+)\b",
+            body,
+        )
+        author = re.sub(r"(?i)\bgrade\s+(?:1[01]|[1-9])\b", "", source)
+        author = author.strip(" ,;:-")
+        title = source
+        if author and grade_match and page_match:
+            title = (
+                f"{author[:1].upper()}{author[1:]} "
+                f"Grade {grade_match.group('grade')}, p.{page_match.group('page')}"
+            )
+
+        item: dict[str, Any] = {
+            "source_type": "textbook",
+            "source": source,
+            "title": title,
+            "text": text_match.group("text").strip(),
+        }
+        if author:
+            item["author"] = author
+        if grade_match:
+            item["grade"] = int(grade_match.group("grade"))
+        if page_match:
+            item["page"] = int(page_match.group("page"))
+        items.append(item)
+    return items
+
+
 def _result_items_from_call(call: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     result = call.get("result", call.get("response"))
     result_summary = call.get("result_summary")
@@ -4326,7 +4384,21 @@ def _result_items_from_call(call: Mapping[str, Any]) -> list[Mapping[str, Any]]:
         if call.get("source_type"):
             result["source_type"] = call["source_type"]
     if isinstance(result, list):
-        return [item for item in result if isinstance(item, Mapping)]
+        items: list[Mapping[str, Any]] = []
+        for item in result:
+            if not isinstance(item, Mapping):
+                continue
+            if (
+                _tool_name_from_call(call) == "search_text"
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+            ):
+                parsed = _parse_mcp_search_text_markdown(item["text"])
+                if parsed:
+                    items.extend(parsed)
+                    continue
+            items.append(item)
+        return items
     if isinstance(result, Mapping):
         result = dict(result)
         if call.get("source_type") and not result.get("source_type"):
@@ -4334,6 +4406,14 @@ def _result_items_from_call(call: Mapping[str, Any]) -> list[Mapping[str, Any]]:
         raw_hits = result.get("results") or result.get("hits") or result.get("items")
         if isinstance(raw_hits, list):
             return [item for item in raw_hits if isinstance(item, Mapping)]
+        if (
+            _tool_name_from_call(call) == "search_text"
+            and result.get("type") == "text"
+            and isinstance(result.get("text"), str)
+        ):
+            parsed = _parse_mcp_search_text_markdown(result["text"])
+            if parsed:
+                return parsed
         return [result]
     return []
 
@@ -4380,8 +4460,14 @@ def _reference_matches_result(
 ) -> bool:
     result_text = "\n".join(_flatten_tool_text(result))
     ref_key = extract_citation_key(reference_title)
-    if ref_key is not None and result_text and extract_citation_key(result_text) == ref_key:
-        return True
+    if ref_key is not None:
+        citation_texts = [
+            str(result.get("title") or ""),
+            str(result.get("source_ref") or ""),
+            result_text,
+        ]
+        if any(extract_citation_key(text) == ref_key for text in citation_texts if text):
+            return True
     normalized_ref = _normalize_citation_ref(reference_title).casefold()
     normalized_result = _normalize_citation_ref(result_text).casefold()
     return bool(normalized_ref and normalized_ref in normalized_result)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -203,9 +203,9 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "key": "a1-m15-24",
             "max_module": 24,
             "min_pct": 15,
-            "max_pct": 35,
+            "max_pct": 24,
             "rule": (
-                "TARGET: 15-35% Ukrainian.\n"
+                "TARGET: 15-24% Ukrainian.\n"
                 "LANGUAGE ROLES:\n"
                 "- THEORY & EXPLANATION: English prose — explain the grammar concept once, clearly.\n"
                 "- EXAMPLES: Ukrainian sentences in bulleted lists (each line: Ukrainian — English gloss). Max 2-4 per rule.\n"

--- a/tests/test_adaptive_immersion.py
+++ b/tests/test_adaptive_immersion.py
@@ -33,8 +33,8 @@ class TestA1ImmersionRange:
 
     def test_sentence_building_band(self):
         """M15-24: verbs, questions, possessives."""
-        assert get_a1_immersion_range(15) == (15, 35)
-        assert get_a1_immersion_range(24) == (15, 35)
+        assert get_a1_immersion_range(15) == (15, 24)
+        assert get_a1_immersion_range(24) == (15, 24)
 
     def test_cases_band(self):
         """M25-34: accusative, locative, genitive."""

--- a/tests/test_immersion_splitter.py
+++ b/tests/test_immersion_splitter.py
@@ -186,6 +186,17 @@ def test_immersion_gate_fails_real_long_sentence() -> None:
             "build",
             "pipeline",
             "today",
+            "and",
+            "extra",
+            "plain",
+            "English",
+            "setup",
+            "keeps",
+            "the",
+            "new",
+            "policy",
+            "cap",
+            "covered",
         ]
     )
     long_sentence = " ".join(
@@ -216,6 +227,16 @@ def test_immersion_gate_fails_real_long_sentence() -> None:
     assert result["long_ukrainian_sentences"] == [long_sentence]
 
 
+def test_immersion_gate_reports_a1_m15_24_policy_cap() -> None:
+    result = _immersion_gate(
+        "English scaffold with **ранок** and **вмиваюся**.",
+        PLAN,
+    )
+
+    assert result["policy"] == "a1-m15-24"
+    assert result["max_pct"] == 24
+
+
 def test_my_morning_immersion_passes() -> None:
     fixture = Path("audit/bakeoff-2026-05-05/claude/module.md")
     if fixture.exists():
@@ -227,6 +248,8 @@ Learners read the examples, notice the endings, compare the forms, and then
 practice the dialogue aloud with a partner before writing their own version.
 The surrounding English is intentionally present because early A1 modules need
 clear scaffolding and should not become full immersion lessons yet.
+Additional English teacher notes keep this compact fixture inside the stricter
+policy cap while the Ukrainian examples remain available for sentence checks.
 
 Що ти робиш потім?**
 — **Вмиваюся, одягаюся, снідаю.**

--- a/tests/test_textbook_grounding_gate.py
+++ b/tests/test_textbook_grounding_gate.py
@@ -163,6 +163,43 @@ def test_textbook_grounding_gate_reads_jsonl_writer_trace(tmp_path: Path) -> Non
     assert result["passed"] is True
 
 
+def test_textbook_grounding_gate_reads_mcp_markdown_result(tmp_path: Path) -> None:
+    _write_tool_calls(
+        tmp_path,
+        [
+            {
+                "name": "mcp__sources__search_text",
+                "arguments": {"query": "Караман Grade 10 reflexive verbs"},
+                "result": [
+                    {
+                        "type": "text",
+                        "text": (
+                            'Found 1 results for: "reflexive verbs"\n\n'
+                            "### Result 1\n"
+                            "- **Section**: Сторінка 176\n"
+                            "- **Source**: Grade 10, karaman\n"
+                            "- **Chunk ID**: `10-klas-ukrmova-karaman-2018_s0315`\n"
+                            "- **Text**:\n"
+                            f"{SEARCH_TEXT}\n"
+                        ),
+                    }
+                ],
+            }
+        ],
+    )
+    module_text = (FIXTURES / "good-module.md").read_text(encoding="utf-8")
+
+    result = linear_pipeline._textbook_grounding_gate(
+        module_text,
+        _plan(),
+        tmp_path,
+    )
+
+    assert result["passed"] is True
+    assert result["matched"] == ["Караман Grade 10, p.176"]
+    assert result["textbook_result_hits"] == 1
+
+
 def test_invoke_writer_persists_tool_trace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_vesum_gate_distractor_and_phonetic.py
+++ b/tests/test_vesum_gate_distractor_and_phonetic.py
@@ -69,6 +69,56 @@ def test_correct_option_text_still_verified() -> None:
     assert "п'ю" in sent_for_verification
 
 
+def test_error_correction_sentence_not_verified() -> None:
+    """error-correction sentence text contains the deliberate wrong form."""
+    activity = {
+        "type": "error-correction",
+        "items": [
+            {
+                "sentence": "Я снідаюся о восьмій.",
+                "errors": ["снідаюся"],
+                "corrected": "Я снідаю о восьмій.",
+            }
+        ],
+    }
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {word: [{"lemma": word}] for word in words}
+
+    result = _vesum_gate(
+        module_text="",
+        activities=[activity],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert result["passed"] is True
+    assert "снідаюся" not in sent_for_verification
+
+
+def test_dialect_abbreviation_not_verified() -> None:
+    """Textbook abbreviation `діал.` is metadata, not a VESUM lemma."""
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {word: [{"lemma": word}] for word in words}
+
+    result = _vesum_gate(
+        module_text="Я ся не бою (діал.).",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert result["passed"] is True
+    assert "діал" not in sent_for_verification
+
+
 def test_pronunciation_transcription_stripped_in_prose() -> None:
     """A bold phonetic form following 'sounds like' must not hit VESUM."""
     module_text = (


### PR DESCRIPTION
## Summary
- Close #1910 by excluding error-correction `sentence` / `errors` values from VESUM checks and stripping the textbook abbreviation `діал.`.
- Close #1911 by parsing MCP `search_text` markdown result blobs into textbook hit records.
- Close #1912 by correcting the shared `a1-m15-24` immersion cap to 24% and covering the linear gate display.

## Bakeoff Regression Evidence
Command: `.venv/bin/python - <<'PY' ... run_python_qg(audit/bakeoff-2026-05-13-midday/claude, curriculum/l2-uk-en/plans/a1/my-morning.yaml) ... PY`

### VESUM
Before:
```json
{
  "passed": false,
  "checked": 193,
  "whitelisted": 6,
  "missing": ["діал", "йдуся", "снідаюся"],
  "missing_count": 3
}
```
After:
```json
{
  "passed": true,
  "checked": 190,
  "whitelisted": 6,
  "missing": [],
  "missing_count": 0
}
```

Sentence-exclusion grep:
```text
438:    {"error", "errors", "errorWord", "error_word", "sentence"}
3990:    For `error-correction` activities, fields like `error:`, `errorWord:`,
3991:    and `sentence:` hold the typo the student must fix; verifying them against
```

### textbook_grounding
Before:
```json
{
  "passed": false,
  "verdict": "REJECT",
  "severity": "HARD",
  "required": 1,
  "matched": [],
  "missing": ["Караман Grade 10, p.176", "Кравцова Grade 4, p.113", "Захарійчук Grade 4, p.162"],
  "search_text_calls": 5,
  "textbook_result_hits": 0
}
```
After:
```json
{
  "passed": true,
  "verdict": "PASS",
  "severity": "HARD",
  "required": 1,
  "matched": ["Караман Grade 10, p.176"],
  "missing": ["Кравцова Grade 4, p.113", "Захарійчук Grade 4, p.162"],
  "search_text_calls": 5,
  "textbook_result_hits": 25
}
```

### immersion
Before:
```json
{
  "passed": false,
  "pct": 25.4,
  "min_pct": 15,
  "max_pct": 35,
  "policy": "a1-m15-24"
}
```
After:
```json
{
  "passed": false,
  "pct": 25.4,
  "min_pct": 15,
  "max_pct": 24,
  "policy": "a1-m15-24"
}
```
Note: the bakeoff artifact still fails immersion because the content is 25.4% Ukrainian and has long-sentence findings; this PR fixes the policy-derived cap display/gate threshold, not the artifact prose.

## Verification
```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_linear_pipeline*.py tests/test_*gate*.py -x
======================== 193 passed, 1 skipped in 7.12s ========================
```

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_linear_pipeline*.py tests/test_*gate*.py -q
======================== 193 passed, 1 skipped in 7.02s ========================
```

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/linear_pipeline.py
All checks passed!
```

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Pre-submit Checklist
- `.python-version` unchanged.
- `.yamllint` and `.markdownlint.json` unchanged.
- No `status/*.json`, `audit/*-review.md`, or `review/*-review.md` files in diff.
- No `sys.executable` introduced.
- No skipped/pass-body tests added.
- Changed files are limited to the gate/policy code and focused tests.

Closes #1910
Closes #1911
Closes #1912