### PR TITLE
feat(linear_pipeline): split immersion gate into structural gates

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -75,7 +75,10 @@ PYTHON_QG_GATE_ORDER = (
     "vesum_verified",
     "citations_resolve",
     "textbook_grounding",
-    "immersion",
+    "immersion_advisory",
+    "l2_exposure_floor",
+    "long_uk_ceiling",
+    "component_density",
     "inject_activity_ids",
     "activity_types",
     "ai_slop_clean",
@@ -107,7 +110,9 @@ DICTIONARY_CANDIDATE_GATES = frozenset(
 )
 REVIEWER_FIX_GATES = DICTIONARY_CANDIDATE_GATES | frozenset(
     {
-        "immersion",
+        "l2_exposure_floor",
+        "long_uk_ceiling",
+        "component_density",
         "ai_slop_clean",
     }
 )
@@ -3243,7 +3248,10 @@ def run_python_qg(
     )
     record("citations_resolve", _citation_gate(resources, plan))
     record("textbook_grounding", _textbook_grounding_gate(module_text, plan, module_dir))
-    record("immersion", _immersion_gate(module_text, plan))
+    record("immersion_advisory", _advisory_immersion_pct(module_text, plan))
+    record("l2_exposure_floor", _l2_exposure_floor_gate(module_text, plan))
+    record("long_uk_ceiling", _long_uk_ceiling_gate(module_text, plan))
+    record("component_density", _component_density_gate(module_text, plan))
     record("inject_activity_ids", _inject_activity_gate(module_text, activities))
     record(
         "activity_types",
@@ -4665,32 +4673,22 @@ def _textbook_grounding_gate(
     }
 
 
-def _immersion_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
-    """Check Ukrainian immersion ratio + flag overly long Ukrainian sentences.
+def _advisory_immersion_pct(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    """Compute advisory Ukrainian immersion ratio telemetry.
 
-    Both the percent calculation AND the long-sentence check operate on a
-    JSX-stripped view of the body. Without that, prop KEYS (`speaker`,
-    `text`, `translation`) and English translation strings inside dialogue
-    components are counted as English tokens, deflating the immersion
-    percentage. To still credit Ukrainian-bearing dialogue text, we
-    separately extract string values from JSX (`text="..."` / `text: "..."`)
-    and add their tokens back. Net effect: only learner-facing Ukrainian
-    text inside JSX counts toward immersion, structural prop syntax doesn't.
-
-    The long-sentence check splits on Ukrainian-aware sentence punctuation
-    (`. ! ? … ‼ ⁇ ⁈ ⁉`) and markdown structure starts: dialogue dashes,
-    table rows, bullets, numbered list items, blockquotes, and headers. This
-    keeps dialogue turns and table rows from being joined into one giant run.
+    This is the demoted form of the old immersion gate. It still strips JSX
+    syntax before counting body tokens and adds learner-facing JSX strings
+    back into the numerator/denominator, but it never hard-fails. Structural
+    pass/fail decisions live in the L2 exposure, long-UK ceiling, and component
+    density gates.
     """
     level = str(plan["level"]).lower()
     sequence = int(plan["sequence"])
     min_pct, max_pct = get_immersion_range(level, sequence)
     comment_stripped = _strip_comments(text)
     body = _strip_frontmatter_and_headings(comment_stripped)
-    sentence_body = _strip_frontmatter(comment_stripped)
 
     body_no_jsx = _JSX_BLOCK_RE.sub(" ", body)
-    sentence_body_no_jsx = _JSX_BLOCK_RE.sub(" ", sentence_body)
     jsx_string_props: list[str] = []
     for jsx_block in _JSX_BLOCK_RE.findall(body):
         jsx_string_props.extend(_JSX_STRING_VALUE_RE.findall(jsx_block))
@@ -4700,15 +4698,254 @@ def _immersion_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
     uk_tokens = [token for token in tokens if _UK_WORD_RE.search(token)]
     pct = round((len(uk_tokens) / len(tokens) * 100), 2) if tokens else 0.0
 
-    long_sentences = _long_ukrainian_sentences(sentence_body_no_jsx)
     return {
-        "passed": min_pct <= pct <= max_pct and not long_sentences,
+        "passed": True,
         "pct": pct,
         "min_pct": min_pct,
         "max_pct": max_pct,
         "policy": get_immersion_policy(level, sequence)["key"],
-        "long_ukrainian_sentences": long_sentences[:20],
     }
+
+
+def _l2_exposure_floor_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    policy = get_immersion_policy(str(plan["level"]).lower(), int(plan["sequence"]))
+    body = _strip_frontmatter_and_headings(_strip_comments(text))
+    observed = {
+        "uk_dialogue_lines": _count_uk_dialogue_lines(body),
+        "vocab_entries": _count_vocab_entries(body),
+        "uk_example_sentences": _count_uk_example_bullets(body),
+        "uk_tab3_activities": len(_INJECT_RE.findall(text)),
+    }
+    required = {
+        "uk_dialogue_lines": int(policy["min_uk_dialogue_lines"]),
+        "vocab_entries": int(policy["min_vocab_entries"]),
+        "uk_example_sentences": int(policy["min_uk_example_sentences"]),
+        "uk_tab3_activities": int(policy["min_uk_tab3_activities"]),
+    }
+    reasons = [
+        f"too_few_{key}"
+        for key, required_count in required.items()
+        if observed[key] < required_count
+    ]
+    return {
+        "passed": not reasons,
+        "required": required,
+        "observed": observed,
+        "reason": reasons[0] if len(reasons) == 1 else ",".join(reasons) or None,
+        "policy": policy["key"],
+    }
+
+
+def _count_uk_dialogue_lines(text: str) -> int:
+    count = sum(
+        1
+        for line in text.splitlines()
+        if re.match(r"^\s*>\s", line) and _UK_WORD_RE.search(line)
+    )
+    for jsx_block in _JSX_BLOCK_RE.findall(text):
+        if _jsx_tag(jsx_block) != "DialogueBox":
+            continue
+        count += sum(
+            1
+            for value in _jsx_text_values(jsx_block)
+            if _UK_WORD_RE.search(value)
+        )
+    return count
+
+
+def _count_vocab_entries(text: str) -> int:
+    count = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if set(cells) <= {"", "---", ":---", "---:", ":---:"}:
+            continue
+        if any(_UK_WORD_RE.search(cell) for cell in cells) and any(
+            re.search(r"[A-Za-z]", cell) for cell in cells
+        ):
+            count += 1
+    count += sum(1 for block in _JSX_BLOCK_RE.findall(text) if _jsx_tag(block) == "VocabCard")
+    return count
+
+
+def _count_uk_example_bullets(text: str) -> int:
+    return sum(
+        1
+        for line in text.splitlines()
+        if re.match(r"^\s*[-*]\s+", line) and _UK_WORD_RE.search(line)
+    )
+
+
+def _long_uk_ceiling_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    policy = get_immersion_policy(str(plan["level"]).lower(), int(plan["sequence"]))
+    max_unsupported = int(policy["max_unsupported_uk_words"])
+    support_proximity = int(policy["support_proximity"])
+    runs = _unsupported_uk_runs(text, max_unsupported, support_proximity)
+    return {
+        "passed": not runs,
+        "required": {
+            "max_unsupported_uk_words": max_unsupported,
+            "support_proximity": support_proximity,
+        },
+        "observed": {"offending_runs": len(runs)},
+        "reason": "long_uk_without_gloss" if runs else None,
+        "offending_runs": runs[:5],
+        "policy": policy["key"],
+    }
+
+
+def _unsupported_uk_runs(
+    text: str,
+    max_unsupported: int,
+    support_proximity: int,
+) -> list[str]:
+    text = _strip_frontmatter_and_headings(_strip_comments(text))
+    text = _FENCED_CODE_RE.sub(" ", text)
+    text = _JSX_BLOCK_RE.sub(" ", text)
+    text = re.sub(r"(?m)^\s*\|.*\|\s*$", " ", text)
+    offending: list[str] = []
+    for segment in _unsupported_run_segments(text):
+        tokens = list(_WORD_RE.finditer(segment))
+        run_start: int | None = None
+        run_end: int | None = None
+        for index, token in enumerate(tokens):
+            value = token.group(0)
+            if _UK_WORD_RE.search(value):
+                if run_start is None:
+                    run_start = index
+                run_end = index
+                continue
+            if run_start is not None and run_end is not None:
+                _append_unsupported_run(
+                    offending,
+                    tokens,
+                    run_start,
+                    run_end,
+                    max_unsupported,
+                    support_proximity,
+                )
+            run_start = None
+            run_end = None
+        if run_start is not None and run_end is not None:
+            _append_unsupported_run(
+                offending, tokens, run_start, run_end, max_unsupported, support_proximity
+            )
+    return offending[:5]
+
+
+def _unsupported_run_segments(text: str) -> list[str]:
+    segments: list[str] = []
+    prose_lines: list[str] = []
+    for line in text.splitlines():
+        if re.match(r"^\s*(?:[-*]\s+|>\s*)", line):
+            if prose_lines:
+                segments.append("\n".join(prose_lines))
+                prose_lines = []
+            segments.append(line)
+            continue
+        if not line.strip():
+            if prose_lines:
+                segments.append("\n".join(prose_lines))
+                prose_lines = []
+            continue
+        prose_lines.append(line)
+    if prose_lines:
+        segments.append("\n".join(prose_lines))
+    return segments
+
+
+def _append_unsupported_run(
+    offending: list[str],
+    tokens: list[re.Match[str]],
+    start: int,
+    end: int,
+    max_unsupported: int,
+    support_proximity: int,
+) -> None:
+    run_len = end - start + 1
+    if run_len <= max_unsupported or _has_english_support(tokens, start, end, support_proximity):
+        return
+    words = [token.group(0) for token in tokens[start : min(end + 1, start + 40)]]
+    suffix = " ..." if run_len > len(words) else ""
+    offending.append(" ".join(words) + suffix)
+
+
+def _has_english_support(
+    tokens: list[re.Match[str]],
+    start: int,
+    end: int,
+    support_proximity: int,
+) -> bool:
+    before = tokens[max(0, start - support_proximity) : start]
+    after = tokens[end + 1 : min(len(tokens), end + 1 + support_proximity)]
+    return any(re.search(r"[A-Za-z]", token.group(0)) for token in (*before, *after))
+
+
+def _component_density_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    policy = get_immersion_policy(str(plan["level"]).lower(), int(plan["sequence"]))
+    required = dict(policy["required_components"])
+    mismatches: list[dict[str, Any]] = []
+    observed: list[dict[str, Any]] = []
+    ignored_components: list[str] = []
+    for jsx_block in _JSX_BLOCK_RE.findall(_strip_comments(text)):
+        tag = _jsx_tag(jsx_block)
+        if tag is None or tag == "VocabCard":
+            continue
+        if tag not in required:
+            ignored_components.append(tag)
+            continue
+        min_pct, max_pct = required[tag]
+        component_text = _component_language_text(tag, jsx_block)
+        tokens = _WORD_RE.findall(component_text)
+        if not tokens:
+            continue
+        uk_pct = round(
+            len([token for token in tokens if _UK_WORD_RE.search(token)]) / len(tokens) * 100,
+            2,
+        )
+        record = {
+            "component_tag": tag,
+            "observed_pct": uk_pct,
+            "expected_range": [int(min_pct), int(max_pct)],
+        }
+        observed.append(record)
+        if uk_pct < int(min_pct) or uk_pct > int(max_pct):
+            mismatches.append(record)
+    return {
+        "passed": not mismatches,
+        "required": required,
+        "observed": observed,
+        "reason": "component_density_mismatch" if mismatches else None,
+        "mismatches": mismatches,
+        "ignored_components": sorted(set(ignored_components)),
+        "policy": policy["key"],
+    }
+
+
+def _jsx_tag(jsx_block: str) -> str | None:
+    match = re.match(r"<([A-Z][A-Za-z0-9]*)\b", jsx_block.strip())
+    return match.group(1) if match else None
+
+
+def _jsx_text_values(jsx_block: str) -> list[str]:
+    return re.findall(r"\btext\s*(?:=|:)\s*\"([^\"\n]*)\"", jsx_block)
+
+
+def _component_language_text(tag: str, jsx_block: str) -> str:
+    if tag == "DialogueBox":
+        text_values = _jsx_text_values(jsx_block)
+        if text_values:
+            return "\n".join(text_values)
+    paired = re.match(
+        r"<([A-Z][A-Za-z0-9]*)\b[^>]*>(.*)</\1>",
+        jsx_block.strip(),
+        flags=re.DOTALL,
+    )
+    if paired:
+        return paired.group(2)
+    return "\n".join(_JSX_STRING_VALUE_RE.findall(jsx_block))
 
 
 def _split_immersion_sentences(text: str) -> list[str]:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -6,10 +6,18 @@ and live immersion policy. It is the source of truth for the dispatcher,
 watcher, writer, and audit scripts.
 """
 
+import sys
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
-from batch_gemini_config import FLASH_MODEL, PRO_MODEL
+try:
+    from batch_gemini_config import FLASH_MODEL, PRO_MODEL
+except ModuleNotFoundError:
+    _SCRIPTS_DIR = Path(__file__).resolve().parent
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from batch_gemini_config import FLASH_MODEL, PRO_MODEL
 
 # =============================================================================
 # TRACK CONFIGURATION
@@ -147,7 +155,8 @@ TRACK_CONFIG: dict[str, dict[str, Any]] = {
 # One authoritative source for live immersion policy across prompt generation
 # and audit gates. A band defines:
 # - the module range it covers
-# - the quantitative audit threshold (min/max immersion)
+# - advisory immersion-percent telemetry
+# - structural audit thresholds for deterministic immersion gates
 # - the qualitative writer instruction injected into prompts
 IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
     "a1": (
@@ -410,6 +419,154 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
     ),
 }
 
+
+_IMMERSION_STRUCTURAL_DEFAULTS: dict[str, Any] = {
+    "min_uk_dialogue_lines": 0,
+    "min_vocab_entries": 0,
+    "min_uk_example_sentences": 0,
+    "min_uk_tab3_activities": 0,
+    "max_unsupported_uk_words": 10_000,
+    "support_proximity": 8,
+    "required_components": {},
+}
+
+_A1_COMPONENT_DENSITY = {"DialogueBox": (95, 100), "RuleBox": (0, 30)}
+_A2_COMPONENT_DENSITY = {"DialogueBox": (95, 100), "RuleBox": (0, 40)}
+
+_IMMERSION_STRUCTURAL_OVERRIDES: dict[str, dict[str, Any]] = {
+    "a1-m01-03": {
+        "min_vocab_entries": 5,
+        "min_uk_example_sentences": 3,
+        "max_unsupported_uk_words": 10,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a1-m04-06": {
+        "min_uk_dialogue_lines": 1,
+        "min_vocab_entries": 5,
+        "min_uk_example_sentences": 3,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 10,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a1-m07-14": {
+        "min_uk_dialogue_lines": 1,
+        "min_vocab_entries": 5,
+        "min_uk_example_sentences": 4,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 10,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a1-m15-24": {
+        "min_uk_dialogue_lines": 1,
+        "min_vocab_entries": 5,
+        "min_uk_example_sentences": 4,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 10,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a1-m25-34": {
+        "min_uk_dialogue_lines": 1,
+        "min_vocab_entries": 5,
+        "min_uk_example_sentences": 5,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 12,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a1-m35-54": {
+        "min_uk_dialogue_lines": 3,
+        "min_vocab_entries": 8,
+        "min_uk_example_sentences": 5,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 14,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a1-m55+": {
+        "min_uk_dialogue_lines": 4,
+        "min_vocab_entries": 8,
+        "min_uk_example_sentences": 6,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 16,
+        "required_components": _A1_COMPONENT_DENSITY,
+    },
+    "a2-bridge": {
+        "min_uk_dialogue_lines": 2,
+        "min_vocab_entries": 5,
+        "min_uk_example_sentences": 5,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 15,
+        "required_components": _A2_COMPONENT_DENSITY,
+    },
+    "a2-ramp": {
+        "min_uk_dialogue_lines": 3,
+        "min_vocab_entries": 6,
+        "min_uk_example_sentences": 5,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 15,
+        "required_components": _A2_COMPONENT_DENSITY,
+    },
+    "a2-m01-20": {
+        "min_uk_dialogue_lines": 3,
+        "min_vocab_entries": 8,
+        "min_uk_example_sentences": 6,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 18,
+        "required_components": _A2_COMPONENT_DENSITY,
+    },
+    "a2-m21-50": {
+        "min_uk_dialogue_lines": 4,
+        "min_vocab_entries": 8,
+        "min_uk_example_sentences": 8,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 24,
+        "required_components": _A2_COMPONENT_DENSITY,
+    },
+    "a2-m51-70": {
+        "min_uk_dialogue_lines": 4,
+        "min_vocab_entries": 8,
+        "min_uk_example_sentences": 8,
+        "min_uk_tab3_activities": 1,
+        "max_unsupported_uk_words": 30,
+        "required_components": _A2_COMPONENT_DENSITY,
+    },
+}
+
+
+def _structural_immersion_rule(band: dict[str, Any]) -> str:
+    old_rule = str(band["rule"])
+    language_roles = old_rule
+    if old_rule.startswith("TARGET:") and "\n" in old_rule:
+        language_roles = old_rule.split("\n", 1)[1]
+    structural = (
+        "STRUCTURAL TARGETS (Phase A placeholders; Phase B calibrates):\n"
+        f"- At least N UK dialogue lines (band: {band['min_uk_dialogue_lines']})\n"
+        f"- At least N vocab entries (band: {band['min_vocab_entries']})\n"
+        "- At least N UK example sentences in bulleted lists "
+        f"(band: {band['min_uk_example_sentences']})\n"
+        "- No UK-only run longer than K words without inline English support "
+        f"(band: {band['max_unsupported_uk_words']})\n"
+    )
+    return structural + language_roles
+
+
+def _extend_immersion_band(raw_band: dict[str, Any]) -> dict[str, Any]:
+    band = dict(raw_band)
+    band["advisory_pct_min"] = int(band.pop("min_pct"))
+    band["advisory_pct_max"] = int(band.pop("max_pct"))
+    structural = {
+        **_IMMERSION_STRUCTURAL_DEFAULTS,
+        **_IMMERSION_STRUCTURAL_OVERRIDES.get(str(band["key"]), {}),
+    }
+    band.update(structural)
+    band["required_components"] = dict(band["required_components"])
+    band["rule"] = _structural_immersion_rule(band)
+    return band
+
+
+IMMERSION_POLICIES = {
+    family: tuple(_extend_immersion_band(band) for band in bands)
+    for family, bands in IMMERSION_POLICIES.items()
+}
+
 # =============================================================================
 # GLOBAL CONSTRAINTS
 # =============================================================================
@@ -475,9 +632,26 @@ def get_immersion_policy(track: str, module_num: int) -> dict[str, Any]:
 
 
 def get_immersion_range(track: str, module_num: int) -> tuple[int, int]:
-    """Return the quantitative immersion gate range for a track/module pair."""
+    """Return advisory immersion percent telemetry range for a track/module pair."""
     band = _find_immersion_band(track, module_num)
-    return int(band["min_pct"]), int(band["max_pct"])
+    return int(band["advisory_pct_min"]), int(band["advisory_pct_max"])
+
+
+def get_immersion_structural(track: str, module_num: int) -> dict[str, Any]:
+    """Return structural immersion thresholds for a track/module pair."""
+    band = _find_immersion_band(track, module_num)
+    return {
+        key: band[key]
+        for key in (
+            "min_uk_dialogue_lines",
+            "min_vocab_entries",
+            "min_uk_example_sentences",
+            "min_uk_tab3_activities",
+            "max_unsupported_uk_words",
+            "support_proximity",
+            "required_components",
+        )
+    }
 
 
 def get_immersion_rule(track: str, module_num: int) -> str:

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -27,15 +27,15 @@ def _small_plan() -> dict:
         "slug": "my-morning",
         "title": "Мій ранок",
         "subtitle": "Зворотні дієслова",
-        "word_target": 20,
+        "word_target": 89,
         "content_outline": [
             {
                 "section": "Діалоги",
-                "words": 20,
+                "words": 89,
                 "points": ["Introduce a morning dialogue."],
             }
         ],
-        "references": [{"title": "Караман Grade 10, p.176"}],
+        "references": [{"title": "Караман Grade 10, p.176", "verbatim_required": False}],
     }
 
 
@@ -76,7 +76,7 @@ def test_render_phase_prompt_fills_registered_tokens() -> None:
     assert "{NORTH_STAR}" not in rendered
     assert "{LESSON_CONTRACT}" not in rendered
     assert "{LEVEL}" not in rendered
-    assert "TARGET: 15-35% Ukrainian." in rendered
+    assert "STRUCTURAL TARGETS (Phase A placeholders; Phase B calibrates):" in rendered
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,11 @@ def test_invoke_writer_routes_supported_writers(
     assert calls[0][2]["entrypoint"] == "dispatch"
     assert calls[0][2]["model"] == linear_pipeline.WRITER_DEFAULTS[writer]["model"]
     assert calls[0][2]["effort"] == linear_pipeline.WRITER_DEFAULTS[writer]["effort"]
-    assert calls[0][2]["tool_config"] == {"output_format": "text"}
+    tool_config = calls[0][2]["tool_config"]
+    assert tool_config["output_format"] == "stream-json"
+    if writer == "claude-tools":
+        assert tool_config["mcp_config_path"].endswith(".mcp.json")
+        assert tool_config["allowed_tools"] == "mcp__sources__*"
 
 
 def test_invoke_writer_rejects_unknown_writer(tmp_path: Path) -> None:
@@ -923,6 +927,26 @@ def _passing_qg_fixture(tmp_path: Path) -> tuple[Path, Path, Callable]:
                 "learners. Use **прокидаюся**, **вмиваюся**, **одягаюся**,",
                 "and **снідаю** before breakfast today clearly.",
                 "",
+                "<DialogueBox",
+                "  lines={[",
+                '    { speaker: "Ліна", text: "Я прокидаюся рано." },',
+                '    { speaker: "Марко", text: "Я снідаю вдома." },',
+                "  ]}",
+                "/>",
+                "",
+                "| Українською | English |",
+                "|---|---|",
+                "| прокидаюся | I wake up |",
+                "| вмиваюся | I wash up |",
+                "| одягаюся | I get dressed |",
+                "| снідаю | I eat breakfast |",
+                "| вдома | at home |",
+                "",
+                "- **Я прокидаюся рано.** — I wake up early.",
+                "- **Я вмиваюся швидко.** — I wash up quickly.",
+                "- **Я одягаюся вдома.** — I get dressed at home.",
+                "- **Я снідаю вдома.** — I eat breakfast at home.",
+                "",
                 "<!-- INJECT_ACTIVITY: act-1 -->",
             ]
         ),
@@ -1523,9 +1547,9 @@ def test_immersion_gate_recognizes_unicode_sentence_boundaries(
 
     # Without the `…` boundary, all 4 short sentences would join into one
     # 12-Ukrainian-word run, exceeding the >10 threshold.
-    assert report["gates"]["immersion"]["long_ukrainian_sentences"] == [], (
+    assert report["gates"]["long_uk_ceiling"]["offending_runs"] == [], (
         f"Ukrainian ellipsis was not treated as sentence boundary: "
-        f"{report['gates']['immersion']['long_ukrainian_sentences']}"
+        f"{report['gates']['long_uk_ceiling']['offending_runs']}"
     )
 
 
@@ -1566,7 +1590,7 @@ def test_immersion_gate_credits_ukrainian_in_jsx_text_props(tmp_path: Path) -> N
         module_dir, plan_path, verify_words_fn=fake_verify
     )
 
-    pct = report["gates"]["immersion"]["pct"]
+    pct = report["gates"]["immersion_advisory"]["pct"]
     # The body has effectively no English prose (one heading, one comment).
     # All counted tokens come from Ukrainian dialogue text. Prop keys
     # (`speaker`, `text`, `lines`, `characters`) are excluded; English
@@ -1615,10 +1639,10 @@ def test_immersion_gate_strips_jsx_blocks_with_gt_in_prop_expressions(
         module_dir, plan_path, verify_words_fn=fake_verify
     )
 
-    assert report["gates"]["immersion"]["long_ukrainian_sentences"] == [], (
+    assert report["gates"]["long_uk_ceiling"]["offending_runs"] == [], (
         "JSX with `>` in a prop expression broke the regex strip and the "
         "DialogueBox lines were re-read as one giant sentence: "
-        f"{report['gates']['immersion']['long_ukrainian_sentences']}"
+        f"{report['gates']['long_uk_ceiling']['offending_runs']}"
     )
 
 
@@ -1655,9 +1679,9 @@ def test_immersion_gate_recognizes_start_of_string_bullets(tmp_path: Path) -> No
     # Each individual bullet contains <10 Ukrainian words — neither should
     # trip the long-sentence rule. If `^`-anchor were absent, the two bullets
     # plus their surrounding text might join into one >10-word run.
-    assert report["gates"]["immersion"]["long_ukrainian_sentences"] == [], (
+    assert report["gates"]["long_uk_ceiling"]["offending_runs"] == [], (
         f"start-of-string bullets joined into a long sentence: "
-        f"{report['gates']['immersion']['long_ukrainian_sentences']}"
+        f"{report['gates']['long_uk_ceiling']['offending_runs']}"
     )
 
 
@@ -1701,13 +1725,13 @@ def test_immersion_gate_strips_jsx_blocks_before_long_sentence_check(
         module_dir, plan_path, verify_words_fn=fake_verify
     )
 
-    immersion = report["gates"]["immersion"]
+    long_uk_ceiling = report["gates"]["long_uk_ceiling"]
     # The dialogue text inside JSX still counts toward the percent (Ukrainian
     # tokens were tokenized from the raw body), but the JSX block is no longer
     # treated as one giant sentence.
-    assert immersion["long_ukrainian_sentences"] == [], (
+    assert long_uk_ceiling["offending_runs"] == [], (
         f"JSX block was incorrectly read as a long sentence: "
-        f"{immersion['long_ukrainian_sentences']}"
+        f"{long_uk_ceiling['offending_runs']}"
     )
 
 

--- a/tests/test_immersion_gates.py
+++ b/tests/test_immersion_gates.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from scripts.build import linear_pipeline
+from scripts.build.linear_pipeline import (
+    _advisory_immersion_pct,
+    _component_density_gate,
+    _l2_exposure_floor_gate,
+    _long_uk_ceiling_gate,
+)
+from scripts.config import IMMERSION_POLICIES
+
+A1_PLAN = {"level": "a1", "sequence": 20}
+A1_EARLY_PLAN = {"level": "a1", "sequence": 1}
+A2_RAMP_PLAN = {"level": "a2", "sequence": 4}
+
+
+def _happy_path_text() -> str:
+    return "\n".join(
+        [
+            "English setup explains the pattern before learners practice.",
+            "",
+            "<RuleBox>Use the reflexive ending after the verb. Keep the form short.</RuleBox>",
+            "",
+            "<DialogueBox",
+            "  lines={[",
+            '    { speaker: "Ліна", text: "Я прокидаюся рано." },',
+            '    { speaker: "Марко", text: "Я снідаю вдома." },',
+            "  ]}",
+            "/>",
+            "",
+            "| Українською | English |",
+            "|---|---|",
+            "| прокидаюся | I wake up |",
+            "| вмиваюся | I wash up |",
+            "| одягаюся | I get dressed |",
+            "| снідаю | I eat breakfast |",
+            "| вдома | at home |",
+            "",
+            "- **Я прокидаюся рано.** — I wake up early.",
+            "- **Я вмиваюся швидко.** — I wash up quickly.",
+            "- **Я одягаюся вдома.** — I get dressed at home.",
+            "- **Я снідаю вдома.** — I eat breakfast at home.",
+            "",
+            "<!-- INJECT_ACTIVITY: act-1 -->",
+        ]
+    )
+
+
+def test_advisory_pct_always_passes() -> None:
+    result = _advisory_immersion_pct("Only English scaffolding appears here.", A1_EARLY_PLAN)
+
+    assert result["passed"] is True
+    assert result["pct"] == 0.0
+    assert result["min_pct"] == 5
+    assert result["max_pct"] == 25
+    assert result["policy"] == "a1-m01-03"
+
+
+def test_structural_gates_pass_happy_path_fixture() -> None:
+    text = _happy_path_text()
+
+    assert _l2_exposure_floor_gate(text, A1_PLAN)["passed"] is True
+    assert _long_uk_ceiling_gate(text, A1_PLAN)["passed"] is True
+    assert _component_density_gate(text, A1_PLAN)["passed"] is True
+
+
+def test_l2_exposure_floor_pass() -> None:
+    result = _l2_exposure_floor_gate(_happy_path_text(), A1_PLAN)
+
+    assert result["passed"] is True
+    assert result["observed"]["vocab_entries"] >= result["required"]["vocab_entries"]
+
+
+def test_l2_exposure_floor_fail_dialogue_lines() -> None:
+    text = "\n".join(
+        [
+            "| Українською | English |",
+            "|---|---|",
+            "| слово | word |",
+            "| фраза | phrase |",
+            "| ранок | morning |",
+            "| дім | home |",
+            "| кава | coffee |",
+            "| вода | water |",
+            "- **Я читаю.** — I read.",
+            "- **Я пишу.** — I write.",
+            "- **Я слухаю.** — I listen.",
+            "- **Я говорю.** — I speak.",
+            "- **Я повторюю.** — I repeat.",
+            "<!-- INJECT_ACTIVITY: act-1 -->",
+        ]
+    )
+
+    result = _l2_exposure_floor_gate(text, A2_RAMP_PLAN)
+
+    assert result["passed"] is False
+    assert "too_few_uk_dialogue_lines" in result["reason"]
+
+
+def test_l2_exposure_floor_fail_vocab_entries() -> None:
+    text = "\n".join(
+        [
+            "> **Ліна:** Я читаю. (I read.)",
+            "> **Марко:** Я пишу. (I write.)",
+            "> **Оля:** Я слухаю. (I listen.)",
+            "- **Я читаю.** — I read.",
+            "- **Я пишу.** — I write.",
+            "- **Я слухаю.** — I listen.",
+            "- **Я говорю.** — I speak.",
+            "- **Я повторюю.** — I repeat.",
+            "<!-- INJECT_ACTIVITY: act-1 -->",
+        ]
+    )
+
+    result = _l2_exposure_floor_gate(text, A2_RAMP_PLAN)
+
+    assert result["passed"] is False
+    assert "too_few_vocab_entries" in result["reason"]
+
+
+def test_long_uk_ceiling_pass() -> None:
+    text = "Слово ранок (morning) коротке. Фраза вдома (at home) теж коротка."
+
+    result = _long_uk_ceiling_gate(text, A1_EARLY_PLAN)
+
+    assert result["passed"] is True
+
+
+def test_long_uk_ceiling_fail() -> None:
+    text = " ".join(
+        [
+            "Український",
+            "студент",
+            "повільно",
+            "прокидається",
+            "вмивається",
+            "одягається",
+            "снідає",
+            "планує",
+            "повторює",
+            "записує",
+            "читає",
+            "слухає",
+            "практикує",
+            "розповідає",
+            "запитує",
+            "відповідає",
+        ]
+    )
+
+    result = _long_uk_ceiling_gate(text, A1_EARLY_PLAN)
+
+    assert result["passed"] is False
+    assert result["reason"] == "long_uk_without_gloss"
+    assert result["offending_runs"][0].startswith("Український студент")
+
+
+def test_component_density_dialoguebox_pass() -> None:
+    result = _component_density_gate('<DialogueBox text="Привіт!" />', A1_EARLY_PLAN)
+
+    assert result["passed"] is True
+
+
+def test_component_density_rulebox_fail_at_a1_early() -> None:
+    text = (
+        "<RuleBox>Український студент читає пише слухає повторює "
+        "говорить відповідає сьогодні.</RuleBox>"
+    )
+
+    result = _component_density_gate(text, A1_EARLY_PLAN)
+
+    assert result["passed"] is False
+    assert result["reason"] == "component_density_mismatch"
+    assert result["mismatches"][0]["component_tag"] == "RuleBox"
+
+
+def test_immersion_policies_schema() -> None:
+    required_keys = {
+        "advisory_pct_min",
+        "advisory_pct_max",
+        "min_uk_dialogue_lines",
+        "min_vocab_entries",
+        "min_uk_example_sentences",
+        "min_uk_tab3_activities",
+        "max_unsupported_uk_words",
+        "support_proximity",
+        "required_components",
+    }
+    min_fields = {
+        "min_uk_dialogue_lines",
+        "min_vocab_entries",
+        "min_uk_example_sentences",
+        "min_uk_tab3_activities",
+    }
+
+    for bands in IMMERSION_POLICIES.values():
+        for band in bands:
+            assert required_keys <= set(band)
+            assert "min_pct" not in band
+            assert "max_pct" not in band
+            assert isinstance(band["advisory_pct_min"], int)
+            assert isinstance(band["advisory_pct_max"], int)
+            for field in min_fields:
+                assert isinstance(band[field], int)
+            assert isinstance(band["required_components"], dict)
+
+
+def test_old_immersion_gate_removed() -> None:
+    assert not hasattr(linear_pipeline, "_immersion_gate")
+    assert hasattr(linear_pipeline, "_advisory_immersion_pct")

--- a/tests/test_immersion_splitter.py
+++ b/tests/test_immersion_splitter.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 from scripts.build.linear_pipeline import (
-    _immersion_gate,
+    _advisory_immersion_pct,
+    _long_uk_ceiling_gate,
     _long_ukrainian_sentences,
     _split_immersion_sentences,
 )
@@ -142,63 +143,7 @@ def test_real_long_sentence_still_caught() -> None:
     assert _long_ukrainian_sentences(long_sentence) == [long_sentence]
 
 
-def test_immersion_gate_fails_real_long_sentence() -> None:
-    english_scaffold = " ".join(
-        [
-            "English",
-            "scaffolding",
-            "keeps",
-            "the",
-            "ratio",
-            "inside",
-            "the",
-            "A1",
-            "range",
-            "while",
-            "the",
-            "Ukrainian",
-            "paragraph",
-            "below",
-            "remains",
-            "a",
-            "single",
-            "overlong",
-            "sentence",
-            "for",
-            "the",
-            "gate",
-            "to",
-            "catch",
-            "during",
-            "integration",
-            "testing",
-            "without",
-            "depending",
-            "on",
-            "external",
-            "fixtures",
-            "or",
-            "generated",
-            "status",
-            "files",
-            "from",
-            "the",
-            "build",
-            "pipeline",
-            "today",
-            "and",
-            "extra",
-            "plain",
-            "English",
-            "setup",
-            "keeps",
-            "the",
-            "new",
-            "policy",
-            "cap",
-            "covered",
-        ]
-    )
+def test_long_uk_ceiling_gate_fails_real_long_sentence() -> None:
     long_sentence = " ".join(
         [
             "Український",
@@ -220,21 +165,22 @@ def test_immersion_gate_fails_real_long_sentence() -> None:
         ]
     )
 
-    result = _immersion_gate(f"{english_scaffold}\n\n{long_sentence}", PLAN)
+    result = _long_uk_ceiling_gate(long_sentence, PLAN)
 
-    assert result["min_pct"] <= result["pct"] <= result["max_pct"]
     assert result["passed"] is False
-    assert result["long_ukrainian_sentences"] == [long_sentence]
+    assert result["reason"] == "long_uk_without_gloss"
+    assert result["offending_runs"] == [long_sentence]
 
 
-def test_immersion_gate_reports_a1_m15_24_policy_cap() -> None:
-    result = _immersion_gate(
+def test_advisory_immersion_pct_reports_a1_m15_24_policy_cap() -> None:
+    result = _advisory_immersion_pct(
         "English scaffold with **ранок** and **вмиваюся**.",
         PLAN,
     )
 
     assert result["policy"] == "a1-m15-24"
     assert result["max_pct"] == 24
+    assert result["passed"] is True
 
 
 def test_my_morning_immersion_passes() -> None:
@@ -263,7 +209,6 @@ policy cap while the Ukrainian examples remain available for sentence checks.
 | вона | прокидається |
 """
 
-    result = _immersion_gate(text, PLAN)
+    result = _advisory_immersion_pct(text, PLAN)
 
     assert result["min_pct"] <= result["pct"] <= result["max_pct"]
-    assert result["long_ukrainian_sentences"] == []


### PR DESCRIPTION
## Summary

Implements Card 1 Phase A from the accepted decision card: `docs/decisions/2026-05-13-immersion-gate-tab-aware-structural.md`.

- Renames/demotes the old hard `%` immersion gate to advisory telemetry: `immersion_advisory` always reports `passed=true` while preserving pct/min/max/policy telemetry.
- Adds three hard structural gates: `l2_exposure_floor`, `long_uk_ceiling`, and `component_density`.
- Extends `IMMERSION_POLICIES` with advisory pct keys plus Phase A placeholder structural thresholds. These values are not calibrated; Phase B calibrates them via replay.
- Removes the old aggregate `record("immersion", ...)` slot; the three structural gates now participate individually in QG pass/fail aggregation.
- Gate 4 is deferred: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/1916

## Replay sanity: `audit/bakeoff-2026-05-13-midday/claude/module.md`

This is an execution sanity check only, not a threshold-calibration claim.

```json
{
  "before_immersion": {
    "passed": false,
    "pct": 25.4,
    "min_pct": 15,
    "max_pct": 35,
    "policy": "a1-m15-24",
    "long_ukrainian_sentences": [
      "> Дієслова із суфіксом -ся(-сь), які виражають зворотну дію, називаються зворотними: навчатися, закохатися",
      "Сучасний дієслівний суфікс -ся(-сь) — це давня коротка форма зворотного займенника себе в Зн",
      "Уживається -ся(-сь) після інфінітивного суфікса -ти(-ть) або закінчення в особових формах дієслова: вмивати — вмиватися, взувати — взуватися",
      "Pair it with the same four sequence words: *Спочатку повертаюся додому, потім вечеряю, після цього відпочиваю, нарешті лягаю спати* (*First I come back home, then I have dinner, after that I rest, finally I go to bed*)"
    ]
  },
  "after": {
    "immersion_advisory": {
      "passed": true,
      "pct": 25.4,
      "min_pct": 15,
      "max_pct": 24,
      "policy": "a1-m15-24"
    },
    "l2_exposure_floor": {
      "passed": false,
      "required": {
        "uk_dialogue_lines": 1,
        "vocab_entries": 5,
        "uk_example_sentences": 4,
        "uk_tab3_activities": 1
      },
      "observed": {
        "uk_dialogue_lines": 26,
        "vocab_entries": 0,
        "uk_example_sentences": 18,
        "uk_tab3_activities": 7
      },
      "reason": "too_few_vocab_entries",
      "policy": "a1-m15-24"
    },
    "long_uk_ceiling": {
      "passed": false,
      "required": {
        "max_unsupported_uk_words": 10,
        "support_proximity": 8
      },
      "observed": {"offending_runs": 1},
      "reason": "long_uk_without_gloss",
      "offending_runs": [
        "Дієслова із суфіксом ся сь які виражають зворотну дію називаються зворотними навчатися закохатися Сучасний дієслівний суфікс ся сь це давня коротка форма зворотного займенника себе в Зн в однини Я не боюся Я ся не бою діал Уживається ся сь ..."
      ],
      "policy": "a1-m15-24"
    },
    "component_density": {
      "passed": true,
      "required": {"DialogueBox": [95, 100], "RuleBox": [0, 30]},
      "observed": [],
      "reason": null,
      "mismatches": [],
      "ignored_components": [],
      "policy": "a1-m15-24"
    }
  }
}
```

## Verifiable claims / raw outputs

Old gate renamed/demoted:

```text
4676:def _advisory_immersion_pct(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
```

Three new gate functions:

```text
4710:def _l2_exposure_floor_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
4781:def _long_uk_ceiling_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
4886:def _component_density_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
```

No `_immersion_gate(` callers:

```text
$ grep -n '_immersion_gate(' scripts/build/linear_pipeline.py || true
# no output
```

`IMMERSION_POLICIES` schema:

```text
['advisory_pct_max', 'advisory_pct_min', 'key', 'max_module', 'max_unsupported_uk_words', 'min_uk_dialogue_lines', 'min_uk_example_sentences', 'min_uk_tab3_activities', 'min_vocab_entries', 'required_components', 'rule', 'support_proximity']
```

Advisory pct assertion:

```text
52:    assert result["passed"] is True
53:    assert result["pct"] == 0.0
```

Synthetic happy/adversarial fixtures:

```text
59:def test_structural_gates_pass_happy_path_fixture() -> None:
74:def test_l2_exposure_floor_fail_dialogue_lines() -> None:
100:def test_l2_exposure_floor_fail_vocab_entries() -> None:
129:def test_long_uk_ceiling_fail() -> None:
164:def test_component_density_rulebox_fail_at_a1_early() -> None:
```

## Validation

```text
============================== 16 passed in 0.19s ==============================
```

```text
All checks passed!
```

Additional affected-file coverage from commit hook:

```text
============================== 97 passed in 2.19s ==============================
```

Agent trailer lint:

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Pre-submit notes

- `.python-version`, `.yamllint`, `.markdownlint.json` unchanged.
- No `status/*.json`, `audit/*-review.md`, or `review/*-review.md` files in diff.
- No `sys.executable` in changed code.
- Changed files are limited to the gate split/config/tests.
