### PR TITLE
feat(wiki-obligations): manifest extractor and coverage gate

### DIFF
--- a/audit/wiki-coverage-baseline-2026-05-13/REPORT.md
+++ b/audit/wiki-coverage-baseline-2026-05-13/REPORT.md
@@ -1,0 +1,44 @@
+# Wiki Coverage Baseline: a1/my-morning
+
+Command:
+
+```bash
+/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/measure_wiki_coverage.py wiki/pedagogy/a1/my-morning.md curriculum/l2-uk-en/a1/my-morning/module.md
+```
+
+Summary:
+
+| Obligation type | Covered | Total |
+| --- | ---: | ---: |
+| L2 errors | 0 | 6 |
+| Sequence steps | 1 | 5 |
+| Phonetic rules | 0 | 3 |
+
+Raw output excerpt:
+
+```json
+{
+  "wiki_path": "wiki/pedagogy/a1/my-morning.md",
+  "module_path": "curriculum/l2-uk-en/a1/my-morning/module.md",
+  "l2_errors": {
+    "covered": 0,
+    "total": 6,
+    "coverage": "0/6"
+  },
+  "sequence_steps": {
+    "covered": 1,
+    "total": 5,
+    "coverage": "1/5"
+  },
+  "phonetic_rules": {
+    "covered": 0,
+    "total": 3,
+    "coverage": "0/3"
+  }
+}
+```
+
+Interpretation: the current module confirms the empirical failure mode. It
+does not implement any wiki-named L2 contrast pair and does not give the
+learner-facing IPA-style pronunciation rules extracted from the wiki page.
+

--- a/scripts/audit/measure_wiki_coverage.py
+++ b/scripts/audit/measure_wiki_coverage.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Measure manifest coverage heuristically for an existing module.md."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.build.phases.wiki_manifest import extract_manifest
+
+
+def measure_wiki_coverage(wiki_path: Path, module_path: Path) -> dict[str, Any]:
+    manifest = extract_manifest(wiki_path)
+    module_text = module_path.read_text(encoding="utf-8")
+    return {
+        "wiki_path": str(wiki_path),
+        "module_path": str(module_path),
+        "l2_errors": _measure_l2(manifest["l2_errors"], module_text),
+        "sequence_steps": _measure_sequence(manifest["sequence_steps"], module_text),
+        "phonetic_rules": _measure_phonetic(manifest["phonetic_rules"], module_text),
+    }
+
+
+def _measure_l2(items: list[dict[str, Any]], text: str) -> dict[str, Any]:
+    results = []
+    for item in items:
+        incorrect_present = _any_marker_present(str(item.get("incorrect") or ""), text)
+        correct_present = _any_marker_present(str(item.get("correct") or ""), text)
+        results.append(
+            {
+                "id": item.get("id"),
+                "covered": incorrect_present and correct_present,
+                "incorrect_present": incorrect_present,
+                "correct_present": correct_present,
+            }
+        )
+    return _summary(results)
+
+
+def _measure_sequence(items: list[dict[str, Any]], text: str) -> dict[str, Any]:
+    results = []
+    for item in items:
+        markers = _claim_markers(str(item.get("required_claim") or ""))
+        present = [marker for marker in markers if _contains(text, marker)]
+        covered = len(present) >= min(3, max(1, len(markers)))
+        results.append(
+            {
+                "id": item.get("id"),
+                "covered": covered,
+                "markers_present": present,
+                "markers_required": markers,
+            }
+        )
+    return _summary(results)
+
+
+def _measure_phonetic(items: list[dict[str, Any]], text: str) -> dict[str, Any]:
+    results = []
+    for item in items:
+        written_present = _contains(text, str(item.get("written") or ""))
+        spoken_present = _contains(text, str(item.get("spoken") or ""))
+        results.append(
+            {
+                "id": item.get("id"),
+                "covered": written_present and spoken_present,
+                "written_present": written_present,
+                "spoken_present": spoken_present,
+            }
+        )
+    return _summary(results)
+
+
+def _summary(results: list[dict[str, Any]]) -> dict[str, Any]:
+    covered = sum(1 for item in results if item["covered"])
+    total = len(results)
+    return {
+        "covered": covered,
+        "total": total,
+        "coverage": f"{covered}/{total}",
+        "items": results,
+    }
+
+
+def _contains(text: str, marker: str) -> bool:
+    return _normalize(marker) in _normalize(text)
+
+
+def _normalize(text: str) -> str:
+    text = re.sub(r"[`*_]", "", text.casefold())
+    text = text.replace("’", "'").replace("ʼ", "'")
+    return re.sub(r"\s+", " ", text)
+
+
+def _marker_candidates(text: str) -> list[str]:
+    cleaned = re.sub(r"^(?:Вимова|Pronunciation)\s*:\s*", "", text.strip(), flags=re.IGNORECASE)
+    raw_parts = re.split(r"\s*/\s*|\s+або\s+|\s+чи\s+", cleaned)
+    parts = []
+    for part in raw_parts:
+        part = re.sub(r"\[[SС]\d+\]", "", part)
+        part = re.sub(r"[`*_]", "", part).strip(" .;:,")
+        if part:
+            parts.append(part)
+    return parts
+
+
+def _any_marker_present(markers: str, text: str) -> bool:
+    candidates = _marker_candidates(markers)
+    return bool(candidates) and any(_contains(text, candidate) for candidate in candidates)
+
+
+def _claim_markers(claim: str) -> list[str]:
+    markers = re.findall(r"`([^`]+)`|\*([^*]{2,80})\*", claim)
+    flattened = [left or right for left, right in markers if (left or right)]
+    if flattened:
+        return [marker for marker in flattened if len(marker.strip()) >= 2]
+    stop = {
+        "крок",
+        "учні",
+        "учень",
+        "повинні",
+        "потрібно",
+        "використовуючи",
+        "наприклад",
+        "зокрема",
+        "введення",
+        "вводяться",
+        "засвоєння",
+        "засвоїти",
+        "зворотних",
+        "дієслів",
+        "дієслова",
+        "граматичного",
+        "фонетичного",
+        "після",
+        "ранок",
+        "ранку",
+    }
+    terms = re.findall(r"[А-Яа-яІіЇїЄєҐґA-Za-z][\w'’ʼ-]{4,}", _normalize(claim))
+    result = []
+    for term in terms:
+        if term in stop or term in result:
+            continue
+        result.append(term)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wiki_path", type=Path)
+    parser.add_argument("module_path", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    report = measure_wiki_coverage(args.wiki_path, args.module_path)
+    output = json.dumps(report, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output + "\n", encoding="utf-8")
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -1,0 +1,325 @@
+"""Deterministic gate for Wiki Obligations Manifest coverage."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.config import (
+    WIKI_COVERAGE_DEFAULT_MIN_PCT,
+    WIKI_COVERAGE_HARD_FAIL,
+    WIKI_COVERAGE_MIN_PCT_BY_LEVEL,
+)
+
+_IMPLEMENTATION_MAP_RE = re.compile(
+    r"<implementation_map\b[^>]*>(?P<body>.*?)</implementation_map>",
+    re.IGNORECASE | re.DOTALL,
+)
+_OBLIGATION_RE = re.compile(r"obligation_id\s*:\s*(?P<id>[-\w]+)", re.IGNORECASE)
+_FIELD_RE = re.compile(r"^\s*-?\s*(?P<key>artifact|location|treatment)\s*:\s*(?P<value>.+?)\s*$", re.IGNORECASE)
+
+
+def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
+    """Parse the writer-visible implementation map from raw writer output."""
+    match = _IMPLEMENTATION_MAP_RE.search(text)
+    if not match:
+        return {}
+    body = match.group("body")
+    entries: dict[str, dict[str, str]] = {}
+    current_id: str | None = None
+    for line in body.splitlines():
+        id_match = _OBLIGATION_RE.search(line)
+        if id_match:
+            current_id = id_match.group("id").strip()
+            entries.setdefault(current_id, {"obligation_id": current_id})
+            continue
+        if current_id is None:
+            continue
+        field_match = _FIELD_RE.match(line)
+        if field_match:
+            entries[current_id][field_match.group("key").casefold()] = field_match.group("value").strip()
+    return entries
+
+
+def validate_obligations(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Flatten manifest obligations in deterministic manifest order."""
+    obligations: list[dict[str, Any]] = []
+    for group in ("sequence_steps", "l2_errors", "phonetic_rules", "decolonization_bans"):
+        raw_items = manifest.get(group) or []
+        if not isinstance(raw_items, Sequence) or isinstance(raw_items, (str, bytes)):
+            continue
+        for item in raw_items:
+            if not isinstance(item, Mapping):
+                continue
+            obligation = dict(item)
+            obligation["type"] = group.removesuffix("s")
+            obligations.append(obligation)
+    return obligations
+
+
+def check_wiki_coverage(
+    *,
+    manifest: Mapping[str, Any],
+    implementation_map: Mapping[str, Mapping[str, str]] | str,
+    module_md: str,
+    activities_yaml: str,
+    vocabulary_yaml: str = "",
+    resources_yaml: str = "",
+    level: str | None = None,
+) -> dict[str, Any]:
+    """Compare manifest obligations to claimed artifact evidence."""
+    map_entries = (
+        parse_implementation_map(implementation_map)
+        if isinstance(implementation_map, str)
+        else {str(key): dict(value) for key, value in implementation_map.items()}
+    )
+    artifacts = {
+        "module.md": module_md,
+        "activities.yaml": activities_yaml,
+        "vocabulary.yaml": vocabulary_yaml,
+        "resources.yaml": resources_yaml,
+    }
+    activities = _load_activity_items(activities_yaml)
+    obligation_results: list[dict[str, Any]] = []
+
+    for obligation in validate_obligations(manifest):
+        obligation_id = str(obligation.get("id") or "")
+        claim = map_entries.get(obligation_id)
+        if not claim:
+            obligation_results.append(_result(obligation, "FAIL", "implementation_map_missing"))
+            continue
+
+        artifact = str(claim.get("artifact") or "").strip()
+        location = str(claim.get("location") or "").strip()
+        if artifact not in artifacts:
+            obligation_results.append(_result(obligation, "FAIL", "unknown_artifact", claim))
+            continue
+
+        target_text = (
+            _activity_text(activities, location)
+            if artifact == "activities.yaml"
+            else _location_text(artifacts[artifact], location)
+        )
+        if not target_text.strip():
+            obligation_results.append(_result(obligation, "FAIL", "claimed_location_missing", claim))
+            continue
+
+        status, reason = _check_obligation_text(obligation, target_text, artifact)
+        obligation_results.append(_result(obligation, status, reason, claim))
+
+    covered = sum(1 for item in obligation_results if item["status"] == "PASS")
+    total = len(obligation_results)
+    coverage_pct = covered / total if total else 1.0
+    min_pct = WIKI_COVERAGE_MIN_PCT_BY_LEVEL.get(
+        str(level or "").lower(),
+        WIKI_COVERAGE_DEFAULT_MIN_PCT,
+    )
+    hard_failed = any(item["status"] == "FAIL" for item in obligation_results)
+    passed = not hard_failed if WIKI_COVERAGE_HARD_FAIL else coverage_pct >= min_pct
+    return {
+        "passed": passed,
+        "hard_fail": hard_failed and WIKI_COVERAGE_HARD_FAIL,
+        "coverage_pct": round(coverage_pct, 4),
+        "covered": covered,
+        "total": total,
+        "min_pct": min_pct,
+        "obligations": obligation_results,
+    }
+
+
+def check_wiki_coverage_paths(
+    *,
+    manifest: Mapping[str, Any] | str | Path,
+    implementation_map: Mapping[str, Mapping[str, str]] | str,
+    module_dir: Path,
+    level: str | None = None,
+) -> dict[str, Any]:
+    manifest_data = _load_manifest(manifest)
+    return check_wiki_coverage(
+        manifest=manifest_data,
+        implementation_map=implementation_map,
+        module_md=_read_optional(module_dir / "module.md"),
+        activities_yaml=_read_optional(module_dir / "activities.yaml"),
+        vocabulary_yaml=_read_optional(module_dir / "vocabulary.yaml"),
+        resources_yaml=_read_optional(module_dir / "resources.yaml"),
+        level=level,
+    )
+
+
+def _load_manifest(manifest: Mapping[str, Any] | str | Path) -> Mapping[str, Any]:
+    if isinstance(manifest, Mapping):
+        return manifest
+    path = Path(manifest)
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return json.loads(str(manifest))
+
+
+def _read_optional(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_activity_items(activities_yaml: str) -> list[dict[str, Any]]:
+    try:
+        parsed = yaml.safe_load(activities_yaml) if activities_yaml.strip() else []
+    except yaml.YAMLError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def _activity_text(activities: list[dict[str, Any]], location: str) -> str:
+    if not location:
+        return yaml.safe_dump(activities, allow_unicode=True, sort_keys=False)
+    for activity in activities:
+        activity_id = str(activity.get("id") or "")
+        if activity_id and activity_id in location:
+            return yaml.safe_dump(activity, allow_unicode=True, sort_keys=False)
+    return ""
+
+
+def _location_text(text: str, location: str) -> str:
+    if not location or location.casefold() in {"module.md", "whole file", "file"}:
+        return text
+    location_key = location.strip().lstrip("#§ ").casefold()
+    heading_re = re.compile(r"^(?P<marks>#{1,6})\s+(?P<title>.+?)\s*$", re.MULTILINE)
+    headings = list(heading_re.finditer(text))
+    for index, heading in enumerate(headings):
+        title = heading.group("title").strip().casefold()
+        if location_key and location_key not in title and title not in location_key:
+            continue
+        start = heading.start()
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(text)
+        return text[start:end]
+    return text if location_key in text.casefold() else ""
+
+
+def _check_obligation_text(obligation: Mapping[str, Any], target_text: str, artifact: str) -> tuple[str, str]:
+    obligation_type = str(obligation.get("type") or "")
+    if obligation_type == "l2_error":
+        treatment = str(obligation.get("treatment") or "")
+        if treatment == "contrast_pair":
+            missing = []
+            if not _any_marker_present(str(obligation.get("incorrect") or ""), target_text):
+                missing.append("incorrect")
+            if not _any_marker_present(str(obligation.get("correct") or ""), target_text):
+                missing.append("correct")
+            if missing:
+                return "FAIL", "missing_" + "_and_".join(missing)
+            if artifact != "activities.yaml":
+                return "FAIL", "contrast_pair_not_in_activity"
+            return "PASS", "contrast_pair_present"
+        if _has_substance(str(obligation.get("correct") or ""), str(obligation.get("why") or ""), target_text):
+            return "PASS", "prose_substance_present"
+        return "FAIL", "prose_substance_missing"
+
+    if obligation_type == "phonetic_rule":
+        written = str(obligation.get("written") or "")
+        spoken = str(obligation.get("spoken") or "")
+        if _contains(target_text, written) and _contains(target_text, spoken):
+            return "PASS", "phonetic_rule_present"
+        return "FAIL", "phonetic_rule_missing"
+
+    if obligation_type == "sequence_step":
+        claim = str(obligation.get("required_claim") or obligation.get("heading") or "")
+        if _claim_markers_present(claim, target_text):
+            return "PASS", "sequence_claim_present"
+        return "FAIL", "sequence_claim_missing"
+
+    if obligation_type == "decolonization_ban":
+        rule = str(obligation.get("rule") or "")
+        if _claim_markers_present(rule, target_text):
+            return "PASS", "ban_substance_present"
+        return "FAIL", "ban_substance_missing"
+
+    return "FAIL", "unknown_obligation_type"
+
+
+def _result(
+    obligation: Mapping[str, Any],
+    status: str,
+    reason: str,
+    claim: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "obligation_id": obligation.get("id"),
+        "type": obligation.get("type"),
+        "status": status,
+        "reason": reason,
+        "claim": dict(claim or {}),
+    }
+
+
+def _contains(text: str, marker: str) -> bool:
+    return _normalize(marker) in _normalize(text)
+
+
+def _normalize(text: str) -> str:
+    text = re.sub(r"[`*_]", "", text.casefold())
+    text = text.replace("’", "'").replace("ʼ", "'")
+    return re.sub(r"\s+", " ", text)
+
+
+def _marker_candidates(text: str) -> list[str]:
+    cleaned = re.sub(r"^(?:Вимова|Pronunciation)\s*:\s*", "", text.strip(), flags=re.IGNORECASE)
+    raw_parts = re.split(r"\s*/\s*|\s+або\s+|\s+чи\s+", cleaned)
+    parts = []
+    for part in raw_parts:
+        part = re.sub(r"\[[SС]\d+\]", "", part)
+        part = re.sub(r"[`*_]", "", part).strip(" .;:,")
+        if part:
+            parts.append(part)
+    return parts
+
+
+def _any_marker_present(markers: str, text: str) -> bool:
+    candidates = _marker_candidates(markers)
+    return bool(candidates) and any(_contains(text, candidate) for candidate in candidates)
+
+
+def _claim_markers_present(claim: str, text: str) -> bool:
+    markers = re.findall(r"`([^`]+)`|\*([^*]{2,80})\*", claim)
+    flattened = [left or right for left, right in markers if (left or right)]
+    if not flattened:
+        flattened = _substance_terms(claim)
+    present = sum(1 for marker in flattened if _contains(text, marker))
+    return present >= min(3, max(1, len(flattened)))
+
+
+def _has_substance(correct: str, why: str, text: str) -> bool:
+    if correct and not _any_marker_present(correct, text):
+        return False
+    terms = _substance_terms(why)
+    if not terms:
+        return bool(correct)
+    present = sum(1 for term in terms[:8] if _contains(text, term))
+    return present >= min(2, len(terms))
+
+
+def _substance_terms(text: str) -> list[str]:
+    stop = {
+        "учень",
+        "учні",
+        "англомовні",
+        "українська",
+        "українській",
+        "помилка",
+        "часто",
+        "тому",
+        "потрібно",
+        "пояснити",
+        "використання",
+    }
+    words = re.findall(r"[А-Яа-яІіЇїЄєҐґA-Za-z][\w'’ʼ-]{4,}", _normalize(text))
+    result = []
+    for word in words:
+        if word in stop or word in result:
+            continue
+        result.append(word)
+    return result

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -580,6 +580,71 @@ def build_knowledge_packet(
     )
 
 
+def build_wiki_manifest_data(
+    plan_path: Path | None = None,
+    *,
+    level: str | None = None,
+    slug: str | None = None,
+    plan: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic Wiki Obligations Manifest for one module."""
+    if plan is None:
+        if plan_path is None:
+            if level is None or slug is None:
+                raise LinearPipelineError(
+                    "build_wiki_manifest_data requires plan_path or level+slug"
+                )
+            plan_path = plan_path_for(level.lower(), slug)
+        plan_data = load_plan(plan_path)
+    else:
+        plan_data = dict(plan)
+    validate_plan(plan_data)
+
+    level_key = str(level or plan_data["level"]).lower()
+    slug_key = str(slug or plan_data["slug"]).strip()
+    article_paths = _wiki_article_paths(level_key, slug_key)
+    if not article_paths:
+        raise LinearPipelineError(
+            f"No wiki article found for level={level_key!r}, slug={slug_key!r}"
+        )
+    from scripts.build.phases.wiki_manifest import extract_manifest
+
+    # Current module wiki layout resolves to one canonical article. If future
+    # tracks add siblings, preserve deterministic order by merging list fields.
+    merged: dict[str, Any] | None = None
+    for article_path in article_paths:
+        manifest = extract_manifest(article_path)
+        if merged is None:
+            merged = manifest
+            continue
+        for key in (
+            "sequence_steps",
+            "l2_errors",
+            "phonetic_rules",
+            "decolonization_bans",
+        ):
+            merged.setdefault(key, [])
+            for item in manifest.get(key, []):
+                copied = dict(item)
+                prefix = str(copied.get("id") or "").split("-", 1)[0] or key[:4]
+                copied["id"] = f"{prefix}-{len(merged[key]) + 1}"
+                merged[key].append(copied)
+        merged["wiki_path"] = f"{merged['wiki_path']}; {manifest['wiki_path']}"
+    return merged or {}
+
+
+def build_wiki_manifest(
+    plan_path: Path | None = None,
+    *,
+    level: str | None = None,
+    slug: str | None = None,
+    plan: Mapping[str, Any] | None = None,
+) -> str:
+    """Return compact JSON for the writer/reviewer manifest slot."""
+    manifest = build_wiki_manifest_data(plan_path, level=level, slug=slug, plan=plan)
+    return json.dumps(manifest, ensure_ascii=False, indent=2)
+
+
 def _extract_dictionary_lemmas(plan: Mapping[str, Any]) -> list[str]:
     """Return required vocabulary lemmas for dictionary-context enrichment."""
     candidates: list[Any] = []
@@ -1800,10 +1865,21 @@ def _enforce_tools_writer_runtime_gate(
     )
 
 
-def writer_context(plan: Mapping[str, Any], plan_content: str, knowledge_packet: str) -> dict[str, str]:
+def writer_context(
+    plan: Mapping[str, Any],
+    plan_content: str,
+    knowledge_packet: str,
+    wiki_manifest: str | Mapping[str, Any] | None = None,
+) -> dict[str, str]:
     level = str(plan["level"])
     sequence = int(plan["sequence"])
     activity_config = _activity_config(level, sequence, str(plan["slug"]))
+    if wiki_manifest is None:
+        wiki_manifest_text = build_wiki_manifest(level=level.lower(), slug=str(plan["slug"]), plan=plan)
+    elif isinstance(wiki_manifest, str):
+        wiki_manifest_text = wiki_manifest
+    else:
+        wiki_manifest_text = json.dumps(wiki_manifest, ensure_ascii=False, indent=2)
     return {
         "LEVEL": level,
         "MODULE_NUM": str(sequence),
@@ -1813,6 +1889,7 @@ def writer_context(plan: Mapping[str, Any], plan_content: str, knowledge_packet:
         "WORD_TARGET": str(plan["word_target"]),
         "PLAN_CONTENT": plan_content,
         "KNOWLEDGE_PACKET": knowledge_packet,
+        "WIKI_MANIFEST": wiki_manifest_text,
         "IMMERSION_RULE": get_immersion_rule(level.lower(), sequence),
         "CONTRACT_YAML": _contract_yaml(plan),
         "ALLOWED_ACTIVITY_TYPES": activity_config["ALLOWED_ACTIVITY_TYPES"],
@@ -2210,6 +2287,23 @@ def write_writer_artifacts(module_dir: Path, artifacts: Mapping[str, str]) -> No
         (module_dir / name).write_text(str(artifacts[name]), encoding="utf-8")
 
 
+def run_wiki_coverage_gate(
+    *,
+    manifest: Mapping[str, Any] | str | Path,
+    writer_output: str,
+    module_dir: Path,
+    level: str | None = None,
+) -> dict[str, Any]:
+    from scripts.audit.wiki_coverage_gate import check_wiki_coverage_paths
+
+    return check_wiki_coverage_paths(
+        manifest=manifest,
+        implementation_map=writer_output,
+        module_dir=module_dir,
+        level=level,
+    )
+
+
 def review_context(
     plan: Mapping[str, Any],
     plan_content: str,
@@ -2243,6 +2337,56 @@ def render_review_prompt(
     return render_phase_prompt(
         PROJECT_ROOT / "scripts" / "build" / "phases" / "linear-review-dim.md",
         review_context(plan, plan_content, generated_content, dim),
+    )
+
+
+def wiki_coverage_review_context(
+    plan: Mapping[str, Any],
+    plan_content: str,
+    generated_content: str,
+    wiki_manifest: str | Mapping[str, Any],
+    wiki_coverage_gate: Mapping[str, Any],
+) -> dict[str, str]:
+    level = str(plan["level"])
+    sequence = int(plan["sequence"])
+    manifest_text = (
+        wiki_manifest
+        if isinstance(wiki_manifest, str)
+        else json.dumps(wiki_manifest, ensure_ascii=False, indent=2)
+    )
+    return {
+        "LEVEL": level,
+        "MODULE_NUM": str(sequence),
+        "MODULE_SLUG": str(plan["slug"]),
+        "WORD_TARGET": str(plan["word_target"]),
+        "PLAN_CONTENT": plan_content,
+        "GENERATED_CONTENT": generated_content,
+        "WIKI_MANIFEST": manifest_text,
+        "WIKI_COVERAGE_GATE": json.dumps(
+            dict(wiki_coverage_gate),
+            ensure_ascii=False,
+            indent=2,
+            default=str,
+        ),
+    }
+
+
+def render_wiki_coverage_review_prompt(
+    plan: Mapping[str, Any],
+    plan_content: str,
+    generated_content: str,
+    wiki_manifest: str | Mapping[str, Any],
+    wiki_coverage_gate: Mapping[str, Any],
+) -> str:
+    return render_phase_prompt(
+        PROJECT_ROOT / "scripts" / "build" / "phases" / "linear-review-wiki-coverage.md",
+        wiki_coverage_review_context(
+            plan,
+            plan_content,
+            generated_content,
+            wiki_manifest,
+            wiki_coverage_gate,
+        ),
     )
 
 
@@ -2605,6 +2749,26 @@ def parse_review_response(
             event_sink=event_sink,
         )
     return entry
+
+
+def parse_wiki_coverage_review_response(response: str) -> dict[str, Any]:
+    payload = parse_json_or_yaml_mapping(response)
+    verdicts = payload.get("verdicts")
+    if not isinstance(verdicts, list):
+        raise LinearPipelineError("Wiki coverage review response missing verdicts list")
+    for item in verdicts:
+        if not isinstance(item, Mapping):
+            raise LinearPipelineError("Wiki coverage review verdict entries must be mappings")
+        if str(item.get("verdict") or "").upper() not in {"PASS", "PARTIAL", "FAIL"}:
+            raise LinearPipelineError("Wiki coverage review verdict must be PASS, PARTIAL, or FAIL")
+        if not str(item.get("obligation_id") or "").strip():
+            raise LinearPipelineError("Wiki coverage review verdict missing obligation_id")
+        if not str(item.get("evidence") or "").strip():
+            raise LinearPipelineError("Wiki coverage review verdict missing evidence")
+    overall = str(payload.get("overall_verdict") or "").upper()
+    if overall not in {"PASS", "PARTIAL", "FAIL"}:
+        raise LinearPipelineError("Wiki coverage review overall_verdict must be PASS, PARTIAL, or FAIL")
+    return {**payload, "overall_verdict": overall}
 
 
 def validate_llm_review_report(report: Mapping[str, Any]) -> None:

--- a/scripts/build/phases/linear-review-wiki-coverage.md
+++ b/scripts/build/phases/linear-review-wiki-coverage.md
@@ -1,0 +1,84 @@
+{NORTH_STAR}
+
+{LESSON_CONTRACT}
+
+# Phase 4 Linear Wiki-Coverage Reviewer Prompt
+
+Review only wiki-obligation coverage. This pass is parallel to the five
+standard QG dimensions; it is not a `QG_DIMS` dimension.
+
+The deterministic gate has already checked objective presence. Your job is to
+verify semantic adequacy: each obligation must be implemented in the claimed
+artifact location with evidence consistent with its treatment type.
+
+## Required Method
+
+For every obligation in the Wiki Obligations Manifest:
+
+1. Read the manifest obligation id, obligation type, required treatment, and
+   source-line metadata.
+2. Read the writer's implementation_map claim for that same obligation id.
+3. Inspect the cited artifact and location in Generated Content.
+4. Emit one verdict:
+   - PASS: cited evidence implements the obligation.
+   - PARTIAL: evidence exists but is thin, vague, or in a weaker location.
+   - FAIL: missing, contradicted, or not in the claimed location.
+
+Treatment-specific checks:
+
+- `contrast_pair`: both the incorrect and correct forms appear in the activity
+  body, and the learner has to distinguish them.
+- `prose_explanation`: module.md prose discusses the wiki claim's substance,
+  not merely a related vocabulary item.
+- `explicit_explanation`: learner-facing pronunciation guidance is present; a
+  vague "smooth speech" reminder is not enough.
+- `sequence_step`: the module prose teaches the step's canonical pedagogical
+  claim in an appropriate order.
+- decolonization bans: the generated content avoids the banned framing and, if
+  relevant, gives a Ukrainian-centered replacement.
+
+Return only JSON:
+
+```json
+{
+  "verdicts": [
+    {
+      "obligation_id": "err-1",
+      "verdict": "PASS",
+      "evidence": "verbatim excerpt from the cited artifact location",
+      "rationale": "why this evidence satisfies or misses the treatment"
+    }
+  ],
+  "overall_verdict": "PASS",
+  "summary": "short aggregate rationale"
+}
+```
+
+`overall_verdict` must be `FAIL` if any obligation verdict is `FAIL`.
+`PARTIAL` is a soft signal unless the pattern shows systematic under-teaching.
+
+## Module Context
+
+- Level: {LEVEL}
+- Module: {MODULE_NUM}
+- Slug: {MODULE_SLUG}
+- Word target: {WORD_TARGET}
+
+## Wiki Obligations Manifest
+
+{WIKI_MANIFEST}
+
+## Deterministic Wiki Coverage Gate
+
+{WIKI_COVERAGE_GATE}
+
+## Plan
+
+```yaml
+{PLAN_CONTENT}
+```
+
+## Generated Content
+
+{GENERATED_CONTENT}
+

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -17,6 +17,15 @@ Each `<plan_reasoning>` block MUST contain these exact XML sub-nodes (do not wri
 <plan_vocab>Required plan-vocabulary lemmas used in this section, with the exact Ukrainian sentence that grounds each lemma.</plan_vocab>
 <register>The immersion ratio from the Immersion Rule and how this section preserves it.</register>
 <teaching_sequence>Which Knowledge Packet facts/citations this section uses.</teaching_sequence>
+<implementation_map>
+For each obligation_id in the Wiki Obligations Manifest, list:
+  - obligation_id: <id>
+  - artifact: <module.md | activities.yaml | vocabulary.yaml | resources.yaml>
+  - location: <section name or activity id>
+  - treatment: <how the obligation is addressed, for example "contrast_pair in activity act-3"
+                or "prose explanation in section §Дієслова на -ся paragraph 2">
+Do not defer. Every obligation must be implemented in THIS module, not a later one.
+</implementation_map>
 <verification_plan>Specific MCP tools to be called for this section's claims.</verification_plan>
 <verification_trace>
 List the exact tool call signatures you intend to use for this section.
@@ -173,6 +182,23 @@ lists, or tables instead. Triple backticks inside the artifact will be parsed as
 a closing fence and break the artifact boundary. Single backticks for inline code
 spans (e.g., `verify_words`) are fine — only triple backticks are forbidden.
 
+## LESSON SOURCE — synthesize this wiki content into the 4-tab format
+
+The wiki content below is the LESSON SOURCE you must translate into the
+four artifacts. It is not background reference. Every obligation listed in
+the Wiki Obligations Manifest must be implemented in the artifacts you
+produce. Failure to address a wiki-named L2 error, sequence step, or
+phonetic rule is the project's most common writer failure and is the
+single largest reason A1 modules under-teach.
+
+## Wiki Obligations Manifest
+
+{WIKI_MANIFEST}
+
+## Knowledge Packet
+
+{KNOWLEDGE_PACKET}
+
 ## Module Context
 
 - Level: {LEVEL}
@@ -260,7 +286,7 @@ like `correct_order`, indices are zero-based.
 {PLAN_CONTENT}
 ```
 
-## Knowledge Packet
+## Full Wiki Context (source of truth for citations)
 
 {KNOWLEDGE_PACKET}
 

--- a/scripts/build/phases/wiki_manifest.py
+++ b/scripts/build/phases/wiki_manifest.py
@@ -1,0 +1,262 @@
+"""Extract deterministic wiki obligations for V7 writer/reviewer prompts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+
+@dataclass(frozen=True, slots=True)
+class L2Error:
+    id: str
+    incorrect: str
+    correct: str
+    why: str
+    treatment: Literal["contrast_pair", "prose_explanation"]
+    source_lines: str
+
+
+@dataclass(frozen=True, slots=True)
+class SequenceStep:
+    id: str
+    heading: str
+    step_num: int
+    required_claim: str
+    source_lines: str
+
+
+@dataclass(frozen=True, slots=True)
+class PhoneticRule:
+    id: str
+    written: str
+    spoken: str
+    treatment: Literal["explicit_explanation"]
+    source_lines: str
+
+
+@dataclass(frozen=True, slots=True)
+class DecolonizationBan:
+    id: str
+    rule: str
+    source_lines: str
+
+
+@dataclass(frozen=True, slots=True)
+class WikiManifest:
+    slug: str
+    wiki_path: str
+    sequence_steps: list[SequenceStep]
+    l2_errors: list[L2Error]
+    phonetic_rules: list[PhoneticRule]
+    decolonization_bans: list[DecolonizationBan]
+
+
+_SEQUENCE_HEADING_RE = re.compile(r"^##\s+Послідовність\s+(?:викладання|введення)\b", re.IGNORECASE)
+_L2_HEADING_RE = re.compile(r"^##\s+Типові\s+помилки\s+L2\b", re.IGNORECASE)
+_BAN_HEADING_RE = re.compile(r"^##\s+Деколонізаційні\s+застереження\b", re.IGNORECASE)
+_ANY_H2_RE = re.compile(r"^##\s+\S")
+_STEP_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:\*\*)?Крок\s+(?P<num>\d+)\s*[:.]\s*(?P<title>.+?)\s*$")
+_META_SLUG_RE = re.compile(r"^\s*slug\s*:\s*(?P<slug>[-\w]+)\s*$", re.MULTILINE)
+_IPA_RE = re.compile(r"\[(?![SС]\d)(?=[^\]\n]*(?:[:'ʼ’]|[A-Za-z]))[^\]\n]{1,60}\]")
+_WRITTEN_RE = re.compile(r"(?<!\w)(-[\w'’ʼ-]{0,12}ся|-шся|-ться)(?!\w)", re.IGNORECASE)
+
+
+def extract_manifest(wiki_path: str | Path) -> dict[str, Any]:
+    """Extract a JSON-serializable wiki obligations manifest."""
+    path = Path(wiki_path)
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    slug = _extract_slug(text, path)
+
+    manifest = WikiManifest(
+        slug=slug,
+        wiki_path=str(path),
+        sequence_steps=_extract_sequence_steps(lines),
+        l2_errors=_extract_l2_errors(lines),
+        phonetic_rules=_extract_phonetic_rules(lines),
+        decolonization_bans=_extract_decolonization_bans(lines),
+    )
+    return asdict(manifest)
+
+
+def _extract_slug(text: str, path: Path) -> str:
+    match = _META_SLUG_RE.search(text)
+    return match.group("slug").strip() if match else path.stem
+
+
+def _section_span(lines: list[str], heading_re: re.Pattern[str]) -> tuple[int, int] | None:
+    start = None
+    for index, line in enumerate(lines):
+        if heading_re.search(line):
+            start = index
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if _ANY_H2_RE.search(lines[index]):
+            end = index
+            break
+    return start, end
+
+
+def _line_range(start_index: int, end_index: int) -> str:
+    start = start_index + 1
+    end = end_index + 1
+    return str(start) if start == end else f"{start}-{end}"
+
+
+def _clean_inline(text: str) -> str:
+    text = text.replace("`", "")
+    text = re.sub(r"\*\*(.*?)\*\*", r"\1", text)
+    text = re.sub(r"\*(.*?)\*", r"\1", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _extract_sequence_steps(lines: list[str]) -> list[SequenceStep]:
+    span = _section_span(lines, _SEQUENCE_HEADING_RE)
+    if not span:
+        return []
+    start, end = span
+    step_starts: list[tuple[int, re.Match[str]]] = []
+    for index in range(start + 1, end):
+        match = _STEP_RE.match(lines[index])
+        if match:
+            step_starts.append((index, match))
+
+    steps: list[SequenceStep] = []
+    for seq_index, (line_index, match) in enumerate(step_starts, start=1):
+        next_line = step_starts[seq_index][0] if seq_index < len(step_starts) else end
+        body = " ".join(line.strip() for line in lines[line_index:next_line] if line.strip())
+        body = _clean_inline(body)
+        step_num = int(match.group("num"))
+        title = _clean_inline(match.group("title"))
+        heading = f"Крок {step_num}: {title}"
+        steps.append(
+            SequenceStep(
+                id=f"step-{step_num}",
+                heading=heading,
+                step_num=step_num,
+                required_claim=body,
+                source_lines=_line_range(line_index, max(line_index, next_line - 1)),
+            )
+        )
+    return steps
+
+
+def _parse_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return []
+    cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+    return [_clean_inline(cell) for cell in cells]
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    return bool(cells) and all(re.fullmatch(r":?-{3,}:?", cell.replace(" ", "")) for cell in cells)
+
+
+def _extract_l2_errors(lines: list[str]) -> list[L2Error]:
+    span = _section_span(lines, _L2_HEADING_RE)
+    if not span:
+        return []
+    start, end = span
+    errors: list[L2Error] = []
+    table_started = False
+    for index in range(start + 1, end):
+        cells = _parse_table_row(lines[index])
+        if not cells:
+            if table_started:
+                break
+            continue
+        if _is_separator_row(cells):
+            table_started = True
+            continue
+        lowered = " ".join(cells).casefold()
+        if "помилково" in lowered and "правильно" in lowered:
+            table_started = True
+            continue
+        table_started = True
+        if len(cells) < 3:
+            continue
+        errors.append(
+            L2Error(
+                id=f"err-{len(errors) + 1}",
+                incorrect=cells[0],
+                correct=cells[1],
+                why=" | ".join(cells[2:]),
+                treatment="contrast_pair",
+                source_lines=_line_range(index, index),
+            )
+        )
+    return errors
+
+
+def _extract_phonetic_rules(lines: list[str]) -> list[PhoneticRule]:
+    rules: list[PhoneticRule] = []
+    seen: set[tuple[str, str]] = set()
+    for index, line in enumerate(lines):
+        clean = _clean_inline(line)
+        if not clean or not _IPA_RE.search(clean):
+            continue
+        if "вимов" not in clean.casefold() and not _WRITTEN_RE.search(clean):
+            continue
+        written = _WRITTEN_RE.findall(clean)
+        spoken = _IPA_RE.findall(clean)
+        if not written or not spoken:
+            continue
+        for written_item, spoken_item in zip(written, spoken, strict=False):
+            key = (written_item, spoken_item)
+            if key in seen:
+                continue
+            seen.add(key)
+            rules.append(
+                PhoneticRule(
+                    id=f"phon-{len(rules) + 1}",
+                    written=written_item,
+                    spoken=spoken_item,
+                    treatment="explicit_explanation",
+                    source_lines=_line_range(index, index),
+                )
+            )
+    return rules
+
+
+def _extract_decolonization_bans(lines: list[str]) -> list[DecolonizationBan]:
+    span = _section_span(lines, _BAN_HEADING_RE)
+    if not span:
+        return []
+    start, end = span
+    bans: list[DecolonizationBan] = []
+    paragraph_lines: list[str] = []
+    paragraph_start = start + 1
+
+    def flush(last_index: int) -> None:
+        nonlocal paragraph_lines, paragraph_start
+        if not paragraph_lines:
+            return
+        rule = _clean_inline(" ".join(paragraph_lines))
+        if rule:
+            bans.append(
+                DecolonizationBan(
+                    id=f"ban-{len(bans) + 1}",
+                    rule=rule,
+                    source_lines=_line_range(paragraph_start, last_index),
+                )
+            )
+        paragraph_lines = []
+
+    for index in range(start + 1, end):
+        line = lines[index].strip()
+        if not line:
+            flush(index - 1)
+            paragraph_start = index + 1
+            continue
+        if not paragraph_lines:
+            paragraph_start = index
+        paragraph_lines.append(line)
+    flush(end - 1)
+    return bans

--- a/scripts/build/prompt_builder.py
+++ b/scripts/build/prompt_builder.py
@@ -79,6 +79,8 @@ DOWNSTREAM_TOKENS = frozenset(
         "WORKBOOK_MIN",
         "WORKBOOK_PRIORITY_TYPES",
         "WRITER_MODEL",
+        "WIKI_COVERAGE_GATE",
+        "WIKI_MANIFEST",
     }
 )
 

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -97,10 +97,11 @@ def _writer_prompt(
     plan: Mapping[str, Any],
     plan_content: str,
     knowledge_packet: str,
+    wiki_manifest: str | Mapping[str, Any],
 ) -> str:
     return linear_pipeline.render_phase_prompt(
         PROJECT_ROOT / "scripts" / "build" / "phases" / "linear-write.md",
-        linear_pipeline.writer_context(plan, plan_content, knowledge_packet),
+        linear_pipeline.writer_context(plan, plan_content, knowledge_packet, wiki_manifest),
     )
 
 
@@ -161,6 +162,45 @@ def _run_llm_qg(
         report[dim] = linear_pipeline.parse_review_response(response, dim)
 
     return linear_pipeline.aggregate_llm_review(report, str(plan["level"]))
+
+
+def _run_wiki_coverage_review(
+    *,
+    plan: Mapping[str, Any],
+    plan_content: str,
+    module_dir: Path,
+    writer: str,
+    wiki_manifest: str | Mapping[str, Any],
+    wiki_coverage_gate: Mapping[str, Any],
+    stdout_silence_timeout: int | None = None,
+) -> dict[str, Any]:
+    from scripts.agent_runtime.runner import invoke
+
+    reviewer = _reviewer_for_writer(writer)
+    defaults = linear_pipeline.REVIEWER_DEFAULTS[reviewer]
+    agent_name = reviewer.split("-", 1)[0]
+    generated_content = _generated_content(module_dir)
+    prompt = linear_pipeline.render_wiki_coverage_review_prompt(
+        plan,
+        plan_content,
+        generated_content,
+        wiki_manifest,
+        wiki_coverage_gate,
+    )
+    result = invoke(
+        agent_name,
+        prompt,
+        mode="read-only",
+        cwd=module_dir,
+        model=defaults["model"],
+        task_id=f"linear-v7-wiki-coverage-{plan['slug']}",
+        entrypoint="dispatch",
+        effort=defaults["effort"],
+        tool_config={"output_format": "stream-json"},
+        stdout_silence_timeout=stdout_silence_timeout,
+    )
+    response = str(getattr(result, "response", "") or "")
+    return linear_pipeline.parse_wiki_coverage_review_response(response)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -293,6 +333,11 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             plan=plan,
         )
+        wiki_manifest = linear_pipeline.build_wiki_manifest(
+            level=level,
+            slug=slug,
+            plan=plan,
+        )
         _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
 
         if args.dry_run:
@@ -328,6 +373,7 @@ def _run(args: argparse.Namespace) -> int:
             plan=plan,
             plan_content=plan_content,
             knowledge_packet=knowledge_packet,
+            wiki_manifest=wiki_manifest,
         )
         # gemini-tools must load .gemini/settings.json from repo root;
         # module_dir cwd would leave its MCP catalog empty. See
@@ -352,6 +398,10 @@ def _run(args: argparse.Namespace) -> int:
         (module_dir / "writer_prompt.md").write_text(prompt, encoding="utf-8")
         (module_dir / "knowledge_packet.md").write_text(
             knowledge_packet,
+            encoding="utf-8",
+        )
+        (module_dir / "wiki_manifest.json").write_text(
+            wiki_manifest,
             encoding="utf-8",
         )
         artifacts = linear_pipeline.parse_writer_output(writer_output)
@@ -379,6 +429,39 @@ def _run(args: argparse.Namespace) -> int:
             raise linear_pipeline.LinearPipelineError(
                 "Python QG failed after ADR-008 correction paths"
             )
+
+        phase = "wiki_coverage_gate"
+        started_at = time.monotonic()
+        wiki_coverage_gate = linear_pipeline.run_wiki_coverage_gate(
+            manifest=wiki_manifest,
+            writer_output=writer_output,
+            module_dir=module_dir,
+            level=level,
+        )
+        linear_pipeline.write_json(module_dir / "wiki_coverage_gate.json", wiki_coverage_gate)
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        if wiki_coverage_gate.get("passed") is not True:
+            raise linear_pipeline.LinearPipelineError("Wiki coverage gate failed")
+
+        phase = "wiki_coverage_review"
+        timeout_agent = _reviewer_for_writer(writer)
+        started_at = time.monotonic()
+        wiki_coverage_review = _run_wiki_coverage_review(
+            plan=plan,
+            plan_content=plan_content,
+            module_dir=module_dir,
+            writer=writer,
+            wiki_manifest=wiki_manifest,
+            wiki_coverage_gate=wiki_coverage_gate,
+            stdout_silence_timeout=args.writer_timeout,
+        )
+        linear_pipeline.write_json(
+            module_dir / "wiki_coverage_review.json",
+            wiki_coverage_review,
+        )
+        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        if wiki_coverage_review["overall_verdict"] == "FAIL":
+            raise linear_pipeline.LinearPipelineError("Wiki coverage review failed")
 
         phase = "llm_qg"
         timeout_agent = _reviewer_for_writer(writer)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -419,6 +419,31 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
     ),
 }
 
+# =============================================================================
+# WIKI COVERAGE
+# =============================================================================
+
+# Placeholder thresholds for the Wiki Obligations Manifest gate. Calibrate with
+# a Phase-B-style replay after the gate has real build telemetry.
+WIKI_COVERAGE_HARD_FAIL = True
+WIKI_COVERAGE_DEFAULT_MIN_PCT = 0.80
+WIKI_COVERAGE_MIN_PCT_BY_LEVEL: dict[str, float] = {
+    "a1": 0.80,
+    "a2": 0.80,
+    "b1": 0.80,
+    "b2": 0.80,
+    "c1": 0.80,
+    "c2": 0.80,
+    "b2-pro": 0.80,
+    "c1-pro": 0.80,
+    "hist": 0.80,
+    "istorio": 0.80,
+    "bio": 0.80,
+    "lit": 0.80,
+    "oes": 0.80,
+    "ruth": 0.80,
+}
+
 
 _IMMERSION_STRUCTURAL_DEFAULTS: dict[str, Any] = {
     "min_uk_dialogue_lines": 0,

--- a/tests/test_linear_pipeline_wiki_coverage.py
+++ b/tests/test_linear_pipeline_wiki_coverage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.build import linear_pipeline
+from scripts.common.thresholds import QG_DIMS
+
+ROOT = Path(__file__).resolve().parents[1]
+WRITER_TEMPLATE = ROOT / "scripts/build/phases/linear-write.md"
+
+
+def test_qg_dims_remain_five_standard_dimensions() -> None:
+    assert QG_DIMS == (
+        "pedagogical",
+        "naturalness",
+        "decolonization",
+        "engagement",
+        "tone",
+    )
+
+
+def test_writer_prompt_places_manifest_before_module_context() -> None:
+    plan_path = linear_pipeline.plan_path_for("a1", "my-morning")
+    plan = linear_pipeline.plan_check(plan_path)
+    context = linear_pipeline.writer_context(
+        plan,
+        plan_path.read_text(encoding="utf-8"),
+        "Knowledge packet stub.",
+        {"slug": "my-morning", "sequence_steps": [], "l2_errors": [], "phonetic_rules": [], "decolonization_bans": []},
+    )
+    rendered = linear_pipeline.render_phase_prompt(WRITER_TEMPLATE, context)
+
+    assert rendered.index("## LESSON SOURCE") < rendered.index("## Module Context")
+    assert rendered.index("## Wiki Obligations Manifest") < rendered.index("## Module Context")
+    assert "<implementation_map>" in rendered
+    assert "Full Wiki Context (source of truth for citations)" in rendered
+
+
+def test_build_wiki_manifest_renders_my_morning_json() -> None:
+    manifest = linear_pipeline.build_wiki_manifest(level="a1", slug="my-morning")
+
+    assert '"slug": "my-morning"' in manifest
+    assert '"id": "err-1"' in manifest
+    assert '"id": "step-5"' in manifest
+
+
+def test_wiki_coverage_review_prompt_receives_manifest_and_gate() -> None:
+    plan_path = linear_pipeline.plan_path_for("a1", "my-morning")
+    plan = linear_pipeline.plan_check(plan_path)
+    prompt = linear_pipeline.render_wiki_coverage_review_prompt(
+        plan,
+        plan_path.read_text(encoding="utf-8"),
+        "## module.md\n\nGenerated content",
+        {"slug": "my-morning", "l2_errors": [{"id": "err-1"}]},
+        {"passed": True, "coverage_pct": 1.0},
+    )
+
+    assert "Wiki Obligations Manifest" in prompt
+    assert "Deterministic Wiki Coverage Gate" in prompt
+    assert '"err-1"' in prompt
+    assert "QG_DIMS" in prompt
+
+
+def test_v7_build_orders_wiki_gate_before_aggregate_qg() -> None:
+    source = (ROOT / "scripts/build/v7_build.py").read_text(encoding="utf-8")
+    run_body = source[source.index("def _run(") :]
+
+    assert run_body.index("build_wiki_manifest(") < run_body.index("_writer_prompt(")
+    assert run_body.index("run_wiki_coverage_gate(") < run_body.index("_run_wiki_coverage_review(")
+    assert run_body.index("_run_wiki_coverage_review(") < run_body.index("_run_llm_qg(")

--- a/tests/test_wiki_coverage_gate.py
+++ b/tests/test_wiki_coverage_gate.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from scripts.audit.wiki_coverage_gate import check_wiki_coverage, parse_implementation_map
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [
+            {
+                "id": "step-1",
+                "heading": "Крок 1: Reflexive morning verbs",
+                "step_num": 1,
+                "required_claim": "Teach *прокидатися*, *вмиватися*, and *одягатися* as one routine pattern.",
+                "source_lines": "10-12",
+            }
+        ],
+        "l2_errors": [
+            {
+                "id": "err-1",
+                "incorrect": "Я прокидаєшся.",
+                "correct": "Я прокидаюся.",
+                "why": "The person ending must match я.",
+                "treatment": "contrast_pair",
+                "source_lines": "20",
+            }
+        ],
+        "phonetic_rules": [
+            {
+                "id": "phon-1",
+                "written": "-шся",
+                "spoken": "[с':а]",
+                "treatment": "explicit_explanation",
+                "source_lines": "30",
+            }
+        ],
+        "decolonization_bans": [],
+    }
+
+
+def _implementation_map() -> dict[str, dict[str, str]]:
+    return {
+        "step-1": {
+            "artifact": "module.md",
+            "location": "Дієслова на -ся",
+            "treatment": "sequence prose",
+        },
+        "err-1": {
+            "artifact": "activities.yaml",
+            "location": "act-1",
+            "treatment": "contrast_pair in activity act-1",
+        },
+        "phon-1": {
+            "artifact": "module.md",
+            "location": "Дієслова на -ся",
+            "treatment": "explicit explanation",
+        },
+    }
+
+
+def test_parse_implementation_map_from_writer_output() -> None:
+    raw = """<implementation_map>
+- obligation_id: err-1
+  artifact: activities.yaml
+  location: act-1
+  treatment: contrast_pair in activity act-1
+</implementation_map>"""
+
+    assert parse_implementation_map(raw) == {
+        "err-1": {
+            "obligation_id": "err-1",
+            "artifact": "activities.yaml",
+            "location": "act-1",
+            "treatment": "contrast_pair in activity act-1",
+        }
+    }
+
+
+def test_check_wiki_coverage_passes_when_claimed_evidence_exists() -> None:
+    report = check_wiki_coverage(
+        manifest=_manifest(),
+        implementation_map=_implementation_map(),
+        module_md=(
+            "## Дієслова на -ся\n"
+            "The morning pattern uses **прокидатися**, **вмиватися**, and **одягатися**. "
+            "The written ending **-шся** is pronounced **[с':а]**."
+        ),
+        activities_yaml=(
+            "- id: act-1\n"
+            "  type: select\n"
+            "  items:\n"
+            "    - prompt: Choose the correct form.\n"
+            "      options: [Я прокидаєшся., Я прокидаюся.]\n"
+            "      answer: Я прокидаюся.\n"
+        ),
+        level="a1",
+    )
+
+    assert report["passed"] is True
+    assert report["covered"] == 3
+
+
+def test_check_wiki_coverage_fails_missing_implementation_map_entry() -> None:
+    implementation_map = _implementation_map()
+    implementation_map.pop("phon-1")
+
+    report = check_wiki_coverage(
+        manifest=_manifest(),
+        implementation_map=implementation_map,
+        module_md="## Дієслова на -ся\nпрокидатися вмиватися одягатися",
+        activities_yaml="- id: act-1\n  type: select\n  items: []\n",
+        level="a1",
+    )
+
+    assert report["passed"] is False
+    assert any(item["reason"] == "implementation_map_missing" for item in report["obligations"])
+
+
+def test_check_wiki_coverage_fails_contrast_pair_without_wrong_form() -> None:
+    report = check_wiki_coverage(
+        manifest=_manifest(),
+        implementation_map=_implementation_map(),
+        module_md=(
+            "## Дієслова на -ся\n"
+            "прокидатися вмиватися одягатися -шся [с':а]"
+        ),
+        activities_yaml=(
+            "- id: act-1\n"
+            "  type: select\n"
+            "  items:\n"
+            "    - prompt: Choose the correct form.\n"
+            "      options: [Я прокидаюся.]\n"
+            "      answer: Я прокидаюся.\n"
+        ),
+        level="a1",
+    )
+
+    assert report["passed"] is False
+    assert any(item["reason"] == "missing_incorrect" for item in report["obligations"])
+
+
+def test_check_wiki_coverage_fails_missing_phonetic_rule() -> None:
+    report = check_wiki_coverage(
+        manifest=_manifest(),
+        implementation_map=_implementation_map(),
+        module_md="## Дієслова на -ся\nпрокидатися вмиватися одягатися -шся",
+        activities_yaml=(
+            "- id: act-1\n"
+            "  type: select\n"
+            "  items:\n"
+            "    - prompt: Choose the correct form.\n"
+            "      options: [Я прокидаєшся., Я прокидаюся.]\n"
+            "      answer: Я прокидаюся.\n"
+        ),
+        level="a1",
+    )
+
+    assert report["passed"] is False
+    assert any(item["reason"] == "phonetic_rule_missing" for item in report["obligations"])
+

--- a/tests/test_wiki_manifest.py
+++ b/tests/test_wiki_manifest.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.build.phases.wiki_manifest import extract_manifest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_my_morning_manifest_extracts_required_obligations() -> None:
+    manifest = extract_manifest(ROOT / "wiki/pedagogy/a1/my-morning.md")
+
+    assert len(manifest["l2_errors"]) == 6
+    assert len(manifest["sequence_steps"]) == 5
+    incorrect = [item["incorrect"] for item in manifest["l2_errors"]]
+    assert "Я прокидаєшся. / Він прокидаюся." in incorrect
+    assert "Вимова: [прокидайешся]" in incorrect
+    assert "Вимова: [одягайет'с'а]" in incorrect
+    assert "Я мию себе." in incorrect
+    assert "Я дивюся. / Я дивюсь." in incorrect
+    assert "Я користуювася." in incorrect
+    assert any(item["written"] == "-шся" and item["spoken"] == "[с':а]" for item in manifest["phonetic_rules"])
+    assert any(item["written"] == "-ться" and item["spoken"] == "[ц':а]" for item in manifest["phonetic_rules"])
+
+
+def test_manifest_handles_a1_heading_variants() -> None:
+    pages = [
+        "around-the-city",
+        "at-the-cafe",
+        "checkpoint-actions",
+        "checkpoint-first-contact",
+    ]
+    counts = {}
+    for slug in pages:
+        manifest = extract_manifest(ROOT / f"wiki/pedagogy/a1/{slug}.md")
+        counts[slug] = (len(manifest["l2_errors"]), len(manifest["sequence_steps"]))
+
+    assert counts == {
+        "around-the-city": (6, 5),
+        "at-the-cafe": (6, 4),
+        "checkpoint-actions": (6, 6),
+        "checkpoint-first-contact": (7, 6),
+    }
+
+
+def test_manifest_accepts_sequence_heading_variants(tmp_path: Path) -> None:
+    wiki = tmp_path / "variant.md"
+    wiki.write_text(
+        """# Variant
+
+## Послідовність викладання
+
+Крок 1: Перша дія.
+Треба показати форму.
+
+## Типові помилки L2
+
+| ❌ Помилково | ✅ Правильно | Чому |
+|---|---|---|
+| Я є студент. | Я студент. | Калька з English is. |
+""",
+        encoding="utf-8",
+    )
+
+    manifest = extract_manifest(wiki)
+
+    assert manifest["sequence_steps"][0]["heading"] == "Крок 1: Перша дія."
+    assert manifest["l2_errors"][0]["incorrect"] == "Я є студент."
+


### PR DESCRIPTION
## Summary

Ships the Wiki Obligations Manifest architecture from `wiki-enforcement-2026-05-13`:

- Discussion thread: `ab channel tail wiki-enforcement-2026-05-13 --thread 03b423305969482f84e46d574388297a`
- Agreement/read thread: `ab channel tail wiki-enforcement-2026-05-13 --thread 65fb2ccb4fd44dcc91ec2024a1c2976e`

## Per-file rationale

- `scripts/build/phases/wiki_manifest.py`: deterministic wiki parser for `sequence_steps`, `l2_errors`, `phonetic_rules`, and `decolonization_bans` with stable ids and source-line metadata.
- `scripts/audit/wiki_coverage_gate.py`: deterministic coverage gate from manifest obligations + writer implementation map + final artifacts.
- `scripts/audit/measure_wiki_coverage.py`: baseline measurement tool for existing modules without running V7 builds.
- `scripts/build/phases/linear-review-wiki-coverage.md`: dedicated wiki coverage reviewer prompt, separate from `QG_DIMS`.
- `scripts/build/phases/linear-write.md`: moves lesson source/manifest near the top and requires `<implementation_map>`.
- `scripts/build/linear_pipeline.py` and `scripts/build/v7_build.py`: generate manifest once, pass it to writer/reviewer, run deterministic gate and reviewer pass before aggregate LLM QG.
- `scripts/config.py`: SSOT wiki coverage hard-fail and threshold constants.
- `scripts/build/prompt_builder.py`: registers new prompt tokens.
- `tests/test_wiki_manifest.py`, `tests/test_wiki_coverage_gate.py`, `tests/test_linear_pipeline_wiki_coverage.py`: parser, gate, prompt order, and pipeline wiring coverage.
- `audit/wiki-coverage-baseline-2026-05-13/REPORT.md`: baseline measurement for current `a1/my-morning` output.

## Verifiable claims

### Manifest extractor exists and handles `a1/my-morning`

Command:

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -c "from scripts.build.phases.wiki_manifest import extract_manifest; import json; print(json.dumps(extract_manifest('wiki/pedagogy/a1/my-morning.md'), indent=2, ensure_ascii=False)[:2000])"
```

Stdout excerpt:

```json
{
  "slug": "my-morning",
  "wiki_path": "wiki/pedagogy/a1/my-morning.md",
  "sequence_steps": [
    {
      "id": "step-1",
      "heading": "Крок 1: Ознайомлення з базовою парадигмою на прикладі регулярного дієслова. Перш ніж переходити до зворотних дієслів, учні повинні чітко засвоїти відмінювання звичайних дієслів першої дієвідміни (наприклад, читати) [S8]. Це створює надійний шаблон із закінченнями -ю, -єш, -є, -ємо, -єте, -ють, до якого в майбутньому просто додаватиметься частка -ся [S6, S8]. Без цього міцного фундаменту введення зворотних дієслів призведе до хаосу в закінченнях та нерозуміння структури слова [S8].",
      "step_num": 1,
      "required_claim": "Крок 1: Ознайомлення з базовою парадигмою на прикладі регулярного дієслова. Перш ніж переходити до зворотних дієслів, учні повинні чітко засвоїти відмінювання звичайних дієслів першої дієвідміни (наприклад, читати) [S8]. Це створює надійний шаблон із закінченнями -ю, -єш, -є, -ємо, -єте, -ють, до якого в майбутньому просто додаватиметься частка -ся [S6, S8]. Без цього міцного фундаменту введення зворотних дієслів призведе до хаосу в закінченнях та нерозуміння структури слова [S8].",
      "source_lines": "23-24"
    }
  ]
}
```

Unit test also asserts `my-morning` extracts `6` L2 errors and `5` sequence steps.

### Parser handles wiki heading variants

```text
my-morning: l2_errors=6, sequence_steps=5, phonetic_rules=3
around-the-city: l2_errors=6, sequence_steps=5, phonetic_rules=0
at-the-cafe: l2_errors=6, sequence_steps=4, phonetic_rules=0
checkpoint-actions: l2_errors=6, sequence_steps=6, phonetic_rules=0
checkpoint-communication: l2_errors=6, sequence_steps=4, phonetic_rules=0
checkpoint-first-contact: l2_errors=7, sequence_steps=6, phonetic_rules=0
checkpoint-food-shopping: l2_errors=7, sequence_steps=6, phonetic_rules=0
checkpoint-places: l2_errors=6, sequence_steps=5, phonetic_rules=0
colors: l2_errors=6, sequence_steps=5, phonetic_rules=0
days-and-months: l2_errors=6, sequence_steps=7, phonetic_rules=0
```

### Prompt restructure landed

```text
21:For each obligation_id in the Wiki Obligations Manifest, list:
185:## LESSON SOURCE — synthesize this wiki content into the 4-tab format
187:The wiki content below is the LESSON SOURCE you must translate into the
189:the Wiki Obligations Manifest must be implemented in the artifacts you
194:## Wiki Obligations Manifest
198:## Knowledge Packet
202:## Module Context
```

`grep -i 'DEFERRED' scripts/build/phases/linear-write.md` returned no output.

### Reviewer pass and deterministic gate exist

```text
scripts/build/phases/linear-review-wiki-coverage.md:18:1. Read the manifest obligation id, obligation type, required treatment, and
scripts/build/phases/linear-review-wiki-coverage.md:20:2. Read the writer's implementation_map claim for that same obligation id.
scripts/audit/wiki_coverage_gate.py:45:def validate_obligations(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
scripts/audit/wiki_coverage_gate.py:61:def check_wiki_coverage(
```

### Gate wired into pipeline

```text
scripts/build/linear_pipeline.py:583:def build_wiki_manifest_data(
scripts/build/linear_pipeline.py:636:def build_wiki_manifest(
scripts/build/linear_pipeline.py:2290:def run_wiki_coverage_gate(
scripts/build/linear_pipeline.py:2374:def render_wiki_coverage_review_prompt(
scripts/build/v7_build.py:336:        wiki_manifest = linear_pipeline.build_wiki_manifest(
scripts/build/v7_build.py:433:        phase = "wiki_coverage_gate"
scripts/build/v7_build.py:446:        phase = "wiki_coverage_review"
```

### QG_DIMS unchanged

```text
QG_DIMS: tuple[str, ...] = (
    "pedagogical",
    "naturalness",
    "decolonization",
    "engagement",
    "tone",
)
"""The 5 LLM QG dimensions per North Star §7."""
```

### Baseline measurement on existing `a1/my-morning`

Command:

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/measure_wiki_coverage.py wiki/pedagogy/a1/my-morning.md curriculum/l2-uk-en/a1/my-morning/module.md
```

Before-state report:

```text
l2_errors: 0/6
sequence_steps: 1/5
phonetic_rules: 0/3
```

This PR does not claim post-rebuild improvement. It ships the infrastructure and records the current failure baseline.

## Validation

```text
============================== 18 passed in 0.38s ==============================
```

```text
All checks passed!
```

Additional prompt regression check:

```text
============================== 84 passed in 0.72s ==============================
```

Agent trailer lint:

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Suggested user-run validation after merge

Do not run this inside agent dispatch. User/orchestrator can run:

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/build/v7_build.py a1 my-morning
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/measure_wiki_coverage.py wiki/pedagogy/a1/my-morning.md curriculum/l2-uk-en/a1/my-morning/module.md
```