### PR TITLE
fix(yaml_activities): handle list-shape unjumble target

### DIFF
--- a/scripts/yaml_activities.py
+++ b/scripts/yaml_activities.py
@@ -523,14 +523,23 @@ class ActivityParser:
         for i, item in enumerate(raw_data):
             try:
                 activity = self._parse_activity(item)
-                if activity:
-                    activities.append(activity)
+                activities.append(activity)
             except Exception as e:
-                activity_type = item.get('type', 'unknown') if isinstance(item, dict) else 'unknown'
-                print(f"  ⚠️ Skipping activity {i} (type={activity_type!r}): {e}")
+                raise ValueError(f"Failed to parse {self._activity_context(i, item)}: {e}") from e
         return activities
 
-    def _parse_activity(self, data: dict) -> Activity | None:
+    def _activity_context(self, index: int, data: Any) -> str:
+        if not isinstance(data, dict):
+            return f"activity {index} (non-dict {type(data).__name__})"
+        parts = [f"activity {index}"]
+        if data.get('id'):
+            parts.append(f"id={data['id']!r}")
+        parts.append(f"type={data.get('type', 'unknown')!r}")
+        return " ".join(parts)
+
+    def _parse_activity(self, data: dict) -> Activity:
+        if not isinstance(data, dict):
+            raise TypeError(f"activity must be a dict, got {type(data).__name__}")
         activity_type = data.get('type')
         parsers = {
             'quiz': self._parse_quiz,
@@ -563,7 +572,9 @@ class ActivityParser:
             'watch-and-repeat': self._parse_watch_and_repeat,
         }
         parser = parsers.get(activity_type)
-        return parser(data) if parser else None
+        if not parser:
+            raise ValueError(f"unknown activity type {activity_type!r}")
+        return parser(data)
 
     def _parse_quiz(self, data: dict) -> QuizActivity:
         items = []
@@ -649,16 +660,27 @@ class ActivityParser:
 
     def _parse_unjumble(self, data: dict) -> UnjumbleActivity:
         items = []
-        for item_data in data.get('items', []):
-            words = item_data.get('words', [])
-            if not words and 'jumbled' in item_data:
-                words = [w.strip() for w in item_data['jumbled'].split('/')]
-            if not words and 'prompt' in item_data:
-                words = [w.strip() for w in item_data['prompt'].split('/')]
-            if not words and 'scrambled' in item_data:
-                words = [w.strip() for w in item_data['scrambled'].split('/')]
+        for item_index, item_data in enumerate(data.get('items', [])):
+            words = self._unjumble_words(item_data, item_index)
             items.append(UnjumbleItem(words=words, answer=item_data['answer']))
         return UnjumbleActivity(title=data.get('title', ''), items=items)
+
+    def _unjumble_words(self, item_data: dict, item_index: int) -> list[str]:
+        for field_name in ('words', 'jumbled', 'prompt', 'scrambled'):
+            if field_name in item_data:
+                return self._tokens_from_unjumble_field(item_data[field_name], field_name, item_index)
+        raise KeyError(f"unjumble item {item_index} missing one of: words, jumbled, prompt, scrambled")
+
+    def _tokens_from_unjumble_field(self, value: Any, field_name: str, item_index: int) -> list[str]:
+        if isinstance(value, list):
+            return [str(token) for token in value]
+        if isinstance(value, str):
+            separator = '/' if '/' in value else None
+            return [token.strip() for token in value.split(separator) if token.strip()]
+        raise TypeError(
+            f"unjumble item {item_index} field {field_name!r} must be str or list, "
+            f"got {type(value).__name__}"
+        )
 
     def _parse_error_correction(self, data: dict) -> ErrorCorrectionActivity:
         items = [ErrorCorrectionItem(
@@ -718,7 +740,7 @@ class ActivityParser:
         items = []
         for i in data.get('items', []):
             # Support V2 schema ('letters' array) and legacy ('scrambled' string).
-            # If neither key is present, KeyError propagates → activity skipped by caller.
+            # If neither key is present, KeyError propagates with activity context.
             if 'letters' in i:
                 scrambled = ' '.join(str(ch) for ch in i['letters'])
             elif 'scrambled' in i:

--- a/tests/test_yaml_activities.py
+++ b/tests/test_yaml_activities.py
@@ -213,15 +213,16 @@ class TestParserEdgeCases:
         with pytest.raises(ValueError, match="Expected list"):
             parser.parse(yaml_file)
 
-    def test_unknown_activity_type_skipped(self, parser, tmp_path):
-        """Unknown activity types are silently skipped."""
+    def test_unknown_activity_type_raises(self, parser, tmp_path):
+        """Unknown activity types fail loudly."""
         yaml_file = tmp_path / "unknown.yaml"
         yaml_file.write_text(
-            "- type: nonexistent-type\n"
+            "- id: ghost-act\n"
+            "  type: nonexistent-type\n"
             "  title: Ghost\n"
         )
-        activities = parser.parse(yaml_file)
-        assert len(activities) == 0
+        with pytest.raises(ValueError, match=r"ghost-act.*unknown activity type 'nonexistent-type'"):
+            parser.parse(yaml_file)
 
     def test_parse_true_false(self, parser, tmp_path):
         yaml_file = tmp_path / "tf.yaml"
@@ -285,6 +286,51 @@ class TestParserEdgeCases:
         assert activities[0].type == "translate"
 
 
+class TestUnjumbleParsing:
+    def test_parse_unjumble_list_shape_round_trips_to_mdx(self, parser, tmp_path):
+        yaml_file = tmp_path / "unjumble_list.yaml"
+        yaml_file.write_text(
+            "- id: act-7\n"
+            "  type: unjumble\n"
+            "  title: Складіть речення\n"
+            "  items:\n"
+            "    - jumbled: [о, я, прокидаюся, сьомій]\n"
+            "      answer: Я прокидаюся о сьомій\n"
+        )
+        activities = parser.parse(yaml_file)
+        mdx = parser.to_mdx(activities)
+        assert "о / я / прокидаюся / сьомій" in mdx
+        assert "Я прокидаюся о сьомій" in mdx
+
+    def test_parse_unjumble_string_shape_still_round_trips_to_mdx(self, parser, tmp_path):
+        yaml_file = tmp_path / "unjumble_string.yaml"
+        yaml_file.write_text(
+            "- id: legacy-unjumble\n"
+            "  type: unjumble\n"
+            "  title: Складіть речення\n"
+            "  items:\n"
+            "    - jumbled: Я / вранці / читаю\n"
+            "      answer: Я читаю вранці\n"
+        )
+        activities = parser.parse(yaml_file)
+        mdx = parser.to_mdx(activities)
+        assert "Я / вранці / читаю" in mdx
+        assert "Я читаю вранці" in mdx
+
+    def test_parse_unjumble_bad_shape_raises_with_context(self, parser, tmp_path):
+        yaml_file = tmp_path / "unjumble_bad.yaml"
+        yaml_file.write_text(
+            "- id: bad-unjumble\n"
+            "  type: unjumble\n"
+            "  title: Bad\n"
+            "  items:\n"
+            "    - jumbled: 42\n"
+            "      answer: Я читаю вранці\n"
+        )
+        with pytest.raises(ValueError, match=r"bad-unjumble.*field 'jumbled'.*str or list.*int"):
+            parser.parse(yaml_file)
+
+
 class TestAnagramParsing:
     """Tests for anagram activity parsing — both V2 (letters array) and legacy (scrambled string)."""
 
@@ -330,8 +376,8 @@ class TestAnagramParsing:
         assert activities[0].items[0].scrambled == "к і т"
         assert activities[0].items[0].answer == "кіт"
 
-    def test_parse_anagram_error_does_not_crash_other_activities(self, parser, tmp_path):
-        """A bad activity should be skipped, not crash the whole file."""
+    def test_parse_anagram_error_raises_with_context(self, parser, tmp_path):
+        """A bad activity should fail loudly instead of being dropped."""
         yaml_file = tmp_path / "mixed.yaml"
         yaml_file.write_text(
             "- type: quiz\n"
@@ -339,7 +385,8 @@ class TestAnagramParsing:
             "    - question: Що це?\n"
             "      options: [кіт, собака]\n"
             "      correct: 0\n"
-            "- type: anagram\n"
+            "- id: bad-anagram\n"
+            "  type: anagram\n"
             "  items:\n"
             "    - bad_key: something_invalid\n"
             "      answer: кіт\n"
@@ -348,13 +395,8 @@ class TestAnagramParsing:
             "    - statement: Кіт — тварина.\n"
             "      correct: true\n"
         )
-        # Should parse quiz and true-false; anagram skipped with warning
-        activities = parser.parse(yaml_file)
-        types = [a.type for a in activities]
-        assert "quiz" in types
-        assert "true-false" in types
-        # Anagram with bad key is skipped (no scrambled and no letters key)
-        assert len(activities) == 2
+        with pytest.raises(ValueError, match=r"bad-anagram.*missing both 'letters' and 'scrambled'"):
+            parser.parse(yaml_file)
 
     def test_parse_v2_activities_file_with_anagram(self, parser, tmp_path):
         """V2 format (inline/workbook split) with anagram in workbook parses all sections."""


### PR DESCRIPTION
## Summary

Fixes the `yaml_activities` silent-drop path and accepts list-shaped `unjumble` token fields. `ActivityParser.parse()` now raises with activity index/id/type context instead of printing `Skipping activity`, and `unjumble` items accept either token lists or legacy strings.

Closes #1923

## Reproducer / failing shape

Read-only evidence from the main checkout's dirty live input at `curriculum/l2-uk-en/a1/my-morning/activities.yaml`:

```yaml
- id: act-7
  type: unjumble
  instruction: Put the words in the right order to form a correct Ukrainian sentence.
  items:
  - jumbled:
    - о
    - я
    - прокидаюся
    - сьомій
    answer: Я прокидаюся о сьомій
```

The failing field is `jumbled`: it is already a YAML list of tokens, while the old parser called `.split('/')` on it.

## Fix shape

Before:

```python
except Exception as e:
    activity_type = item.get('type', 'unknown') if isinstance(item, dict) else 'unknown'
    print(f"  ⚠️ Skipping activity {i} (type={activity_type!r}): {e}")
```

After:

```python
except Exception as e:
    raise ValueError(f"Failed to parse {self._activity_context(i, item)}: {e}") from e
```

Unjumble token extraction now accepts both shapes:

```python
if isinstance(value, list):
    return [str(token) for token in value]
if isinstance(value, str):
    separator = '/' if '/' in value else None
    return [token.strip() for token in value.split(separator) if token.strip()]
```

`rg -n "Skipping activity" scripts/yaml_activities.py` returns no matches.

## Tests added

List-shape fixture:

```python
yaml_file.write_text(
    "- id: act-7\n"
    "  type: unjumble\n"
    "  title: Складіть речення\n"
    "  items:\n"
    "    - jumbled: [о, я, прокидаюся, сьомій]\n"
    "      answer: Я прокидаюся о сьомій\n"
)
assert "о / я / прокидаюся / сьомій" in mdx
```

Also covered:
- legacy string-shape `jumbled: Я / вранці / читаю`
- malformed scalar `jumbled: 42`, raising with activity id and field name
- former anagram skip behavior now raises with activity context

## Validation

```text
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_yaml_activities*.py tests/test_*activity*.py -x
======================== 197 passed, 2 skipped in 0.87s ========================
```

```text
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/yaml_activities.py
All checks passed!
```

```text
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## MDX repro

Using the fixed parser from this worktree against the live `act-7` unjumble block from the main checkout produces the unjumble MDX instead of the old list `.split()` failure:

```mdx
### 

<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "о / я / прокидаюся / сьомій", "answer": "Я прокидаюся о сьомій"}, {"jumbled": "потім / вмиваюся / я / і / одягаюся", "answer": "Потім я вмиваюся і одягаюся"}, {"jumbled": "на / йду / роботу / о / восьмій / я", "answer": "Я йду на роботу о восьмій"}, {"jumbled": "спочатку / снідаю / я / потім / і / вмиваюся", "answer": "Спочатку я вмиваюся і потім снідаю"}]`)} />
```

Full parsing of that dirty main-checkout file now correctly stops earlier on an unrelated unsupported `observe` activity (`act-3`) instead of silently dropping it; the branch base itself still has the committed four-activity `a1/my-morning` file without the live unjumble block. This PR keeps the code change scoped to the `yaml_activities` silent-drop and unjumble-token bug.

## Pre-submit checklist

- `.python-version` unchanged
- `.yamllint` / `.markdownlint.json` unchanged
- No `status/*.json`, `audit/*-review.md`, or `review/*-review.md` files in diff
- No `sys.executable` introduced
- No skip markers or weakened bool assertions introduced
- Changed files: 2