### PR TITLE
fix(writer+wiki-coverage): require IPA notation for phonetic_rules + hard-fail gate

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -91,13 +91,13 @@ def check_wiki_coverage(
         obligation_id = str(obligation.get("id") or "")
         claim = map_entries.get(obligation_id)
         if not claim:
-            obligation_results.append(_result(obligation, "FAIL", "implementation_map_missing"))
+            obligation_results.append(_result(obligation, "FAIL", "implementation_map_missing", evidence_text=""))
             continue
 
         artifact = str(claim.get("artifact") or "").strip()
         location = str(claim.get("location") or "").strip()
         if artifact not in artifacts:
-            obligation_results.append(_result(obligation, "FAIL", "unknown_artifact", claim))
+            obligation_results.append(_result(obligation, "FAIL", "unknown_artifact", claim, evidence_text=""))
             continue
 
         target_text = (
@@ -106,11 +106,11 @@ def check_wiki_coverage(
             else _location_text(artifacts[artifact], location)
         )
         if not target_text.strip():
-            obligation_results.append(_result(obligation, "FAIL", "claimed_location_missing", claim))
+            obligation_results.append(_result(obligation, "FAIL", "claimed_location_missing", claim, evidence_text=""))
             continue
 
         status, reason = _check_obligation_text(obligation, target_text, artifact)
-        obligation_results.append(_result(obligation, status, reason, claim))
+        obligation_results.append(_result(obligation, status, reason, claim, evidence_text=target_text))
 
     covered = sum(1 for item in obligation_results if item["status"] == "PASS")
     total = len(obligation_results)
@@ -119,11 +119,16 @@ def check_wiki_coverage(
         str(level or "").lower(),
         WIKI_COVERAGE_DEFAULT_MIN_PCT,
     )
+    phonetic_hard_failed = any(
+        item["category"] == "phonetic_rules" and item.get("spoken_present") is False
+        for item in obligation_results
+    )
     hard_failed = any(item["status"] == "FAIL" for item in obligation_results)
-    passed = not hard_failed if WIKI_COVERAGE_HARD_FAIL else coverage_pct >= min_pct
+    passed = False if phonetic_hard_failed else (not hard_failed if WIKI_COVERAGE_HARD_FAIL else coverage_pct >= min_pct)
     return {
         "passed": passed,
-        "hard_fail": hard_failed and WIKI_COVERAGE_HARD_FAIL,
+        "hard_fail": phonetic_hard_failed or (hard_failed and WIKI_COVERAGE_HARD_FAIL),
+        "phonetic_hard_fail": phonetic_hard_failed,
         "coverage_pct": round(coverage_pct, 4),
         "covered": covered,
         "total": total,
@@ -222,7 +227,13 @@ def _check_obligation_text(obligation: Mapping[str, Any], target_text: str, arti
     if obligation_type == "phonetic_rule":
         written = str(obligation.get("written") or "")
         spoken = str(obligation.get("spoken") or "")
-        if _contains(target_text, written) and _contains(target_text, spoken):
+        if (
+            bool(written)
+            and bool(spoken)
+            and _contains(target_text, written)
+            and _contains(target_text, spoken)
+            and _phonetic_examples_present(obligation, target_text)
+        ):
             return "PASS", "phonetic_rule_present"
         return "FAIL", "phonetic_rule_missing"
 
@@ -246,18 +257,84 @@ def _result(
     status: str,
     reason: str,
     claim: Mapping[str, str] | None = None,
+    evidence_text: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    obligation_type = str(obligation.get("type") or "")
+    result = {
         "obligation_id": obligation.get("id"),
-        "type": obligation.get("type"),
+        "type": obligation_type,
+        "category": _category_for_obligation_type(obligation_type),
         "status": status,
         "reason": reason,
         "claim": dict(claim or {}),
     }
+    if obligation_type == "phonetic_rule":
+        written = str(obligation.get("written") or "")
+        spoken = str(obligation.get("spoken") or "")
+        target_text = evidence_text or ""
+        example_pairs = _phonetic_example_pairs(obligation)
+        result.update(
+            {
+                "written": written,
+                "spoken_target": spoken,
+                "written_present": bool(written) and _contains(target_text, written),
+                "spoken_present": bool(spoken) and _contains(target_text, spoken),
+                "example_pairs_present": _phonetic_examples_present(obligation, target_text),
+                "example_pairs_required": bool(example_pairs),
+            }
+        )
+    return result
+
+
+def _category_for_obligation_type(obligation_type: str) -> str:
+    if obligation_type == "l2_error":
+        return "l2_errors"
+    if obligation_type == "phonetic_rule":
+        return "phonetic_rules"
+    if obligation_type == "sequence_step":
+        return "sequence_steps"
+    if obligation_type == "decolonization_ban":
+        return "decolonization_bans"
+    return obligation_type
 
 
 def _contains(text: str, marker: str) -> bool:
     return _normalize(marker) in _normalize(text)
+
+
+def _phonetic_examples_present(obligation: Mapping[str, Any], text: str) -> bool:
+    pairs = _phonetic_example_pairs(obligation)
+    if not pairs:
+        return True
+    return any(all(_contains(text, marker) for marker in pair) for pair in pairs)
+
+
+def _phonetic_example_pairs(obligation: Mapping[str, Any]) -> list[tuple[str, ...]]:
+    pairs: list[tuple[str, ...]] = []
+    for key in ("example_pairs", "examples"):
+        raw_examples = obligation.get(key) or []
+        if not isinstance(raw_examples, Sequence) or isinstance(raw_examples, (str, bytes)):
+            continue
+        for raw_example in raw_examples:
+            if isinstance(raw_example, str):
+                example = raw_example.strip()
+                if example:
+                    pairs.append((example,))
+                continue
+            if not isinstance(raw_example, Mapping):
+                continue
+            written = str(
+                raw_example.get("written")
+                or raw_example.get("word")
+                or raw_example.get("surface")
+                or raw_example.get("example")
+                or ""
+            ).strip()
+            spoken = str(raw_example.get("spoken") or raw_example.get("ipa") or raw_example.get("pronunciation") or "").strip()
+            pair = tuple(marker for marker in (written, spoken) if marker)
+            if pair:
+                pairs.append(pair)
+    return pairs
 
 
 def _normalize(text: str) -> str:

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -195,6 +195,25 @@ single largest reason A1 modules under-teach.
 
 {WIKI_MANIFEST}
 
+### Phonetic rules — MUST emit IPA notation
+
+For every entry under `phonetic_rules:` in the Wiki Obligations Manifest, the
+module MUST include the spoken target verbatim in square brackets (e.g.
+`[с':а]`, `[ц':а]`) alongside the written form (e.g. `-шся`, `-ться`). The IPA
+notation is what teaches the pronunciation contrast for English-speaking
+learners — emitting only the written form leaves the rule pedagogically useless.
+
+Format requirements:
+- Spoken target appears inside `[...]` brackets (single-character square
+  brackets, not Unicode look-alikes).
+- Pair the written and spoken form in close lexical proximity (same sentence or
+  adjacent bullet), so the contrast is visible to the learner.
+- If the wiki provides example word pairs (e.g. `сміється [с'м'ійец':а]`), copy
+  at least one example verbatim into a vocabulary card or example sentence.
+
+The deterministic wiki-coverage gate hard-fails when any phonetic_rule has
+`spoken_present=false`. There is no advisory-mode escape for this category.
+
 ## Knowledge Packet
 
 {KNOWLEDGE_PACKET}

--- a/tests/test_wiki_coverage_gate.py
+++ b/tests/test_wiki_coverage_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import scripts.audit.wiki_coverage_gate as gate
 from scripts.audit.wiki_coverage_gate import check_wiki_coverage, parse_implementation_map
 
 
@@ -159,3 +160,67 @@ def test_check_wiki_coverage_fails_missing_phonetic_rule() -> None:
     assert report["passed"] is False
     assert any(item["reason"] == "phonetic_rule_missing" for item in report["obligations"])
 
+
+def test_check_wiki_coverage_hard_fails_missing_phonetic_spoken_target_when_advisory(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gate, "WIKI_COVERAGE_HARD_FAIL", False)
+
+    report = check_wiki_coverage(
+        manifest=_manifest(),
+        implementation_map=_implementation_map(),
+        module_md="## Дієслова на -ся\nпрокидатися вмиватися одягатися -шся",
+        activities_yaml=(
+            "- id: act-1\n"
+            "  type: select\n"
+            "  items:\n"
+            "    - prompt: Choose the correct form.\n"
+            "      options: [Я прокидаєшся., Я прокидаюся.]\n"
+            "      answer: Я прокидаюся.\n"
+        ),
+        level="a1",
+    )
+
+    phonetic_failures = [
+        item
+        for item in report["obligations"]
+        if item["category"] == "phonetic_rules" and item["status"] == "FAIL"
+    ]
+    assert report["passed"] is False
+    assert report["hard_fail"] is True
+    assert report["phonetic_hard_fail"] is True
+    assert phonetic_failures[0]["spoken_target"] == "[с':а]"
+    assert phonetic_failures[0]["spoken_present"] is False
+
+
+def test_check_wiki_coverage_passes_phonetic_rule_with_one_manifest_example_pair() -> None:
+    manifest = _manifest()
+    manifest["phonetic_rules"][0]["example_pairs"] = [
+        {"written": "смієшся", "spoken": "[с'м'ійес':а]"},
+        {"written": "вітаєшся", "spoken": "[в'ітайес':а]"},
+    ]
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=_implementation_map(),
+        module_md=(
+            "## Дієслова на -ся\n"
+            "The morning pattern uses **прокидатися**, **вмиватися**, and **одягатися**. "
+            "The written ending **-шся** is pronounced **[с':а]**. "
+            "Example: **смієшся [с'м'ійес':а]**."
+        ),
+        activities_yaml=(
+            "- id: act-1\n"
+            "  type: select\n"
+            "  items:\n"
+            "    - prompt: Choose the correct form.\n"
+            "      options: [Я прокидаєшся., Я прокидаюся.]\n"
+            "      answer: Я прокидаюся.\n"
+        ),
+        level="a1",
+    )
+
+    phonetic_result = next(item for item in report["obligations"] if item["category"] == "phonetic_rules")
+    assert report["passed"] is True
+    assert phonetic_result["example_pairs_required"] is True
+    assert phonetic_result["example_pairs_present"] is True


### PR DESCRIPTION
Closes #1924

## Summary
- Added the writer prompt directive under `## Wiki Obligations Manifest` requiring IPA spoken targets for every `phonetic_rules` obligation.
- Added deterministic phonetic hard-fail behavior when `spoken_present=false`, even if global wiki coverage hard-fail mode is disabled.
- Added regression tests for missing IPA in advisory mode and manifest example-pair coverage.

## Prompt Directive Quote

```text
198:### Phonetic rules — MUST emit IPA notation
199-
200:For every entry under `phonetic_rules:` in the Wiki Obligations Manifest, the
201:module MUST include the spoken target verbatim in square brackets (e.g.
202:`[с':а]`, `[ц':а]`) alongside the written form (e.g. `-шся`, `-ться`). The IPA
203-notation is what teaches the pronunciation contrast for English-speaking
204-learners — emitting only the written form leaves the rule pedagogically useless.
205-
206-Format requirements:
207:- Spoken target appears inside `[...]` brackets (single-character square
208-  brackets, not Unicode look-alikes).
209-- Pair the written and spoken form in close lexical proximity (same sentence or
210-  adjacent bullet), so the contrast is visible to the learner.
211:- If the wiki provides example word pairs (e.g. `сміється [с'м'ійец':а]`), copy
212-  at least one example verbatim into a vocabulary card or example sentence.
213-
214-The deterministic wiki-coverage gate hard-fails when any phonetic_rule has
215-`spoken_present=false`. There is no advisory-mode escape for this category.
```

## Gate Hard-Fail Quote

```text
122:    phonetic_hard_failed = any(
123:        item["category"] == "phonetic_rules" and item.get("spoken_present") is False
124-        for item in obligation_results
125-    )
126-    hard_failed = any(item["status"] == "FAIL" for item in obligation_results)
127:    passed = False if phonetic_hard_failed else (not hard_failed if WIKI_COVERAGE_HARD_FAIL else coverage_pct >= min_pct)
128-    return {
129-        "passed": passed,
130:        "hard_fail": phonetic_hard_failed or (hard_failed and WIKI_COVERAGE_HARD_FAIL),
131:        "phonetic_hard_fail": phonetic_hard_failed,
```

```text
278-                "written": written,
279:                "spoken_target": spoken,
280-                "written_present": bool(written) and _contains(target_text, written),
281:                "spoken_present": bool(spoken) and _contains(target_text, spoken),
```

## Missing-IPA Test Quote

```text
164:def test_check_wiki_coverage_hard_fails_missing_phonetic_spoken_target_when_advisory(
165-    monkeypatch,
166-) -> None:
167-    monkeypatch.setattr(gate, "WIKI_COVERAGE_HARD_FAIL", False)
168-
169-    report = check_wiki_coverage(
170-        manifest=_manifest(),
171-        implementation_map=_implementation_map(),
172-        module_md="## Дієслова на -ся\nпрокидатися вмиватися одягатися -шся",
173-        activities_yaml=(
174-            "- id: act-1\n"
175-            "  type: select\n"
176-            "  items:\n"
177-            "    - prompt: Choose the correct form.\n"
178-            "      options: [Я прокидаєшся., Я прокидаюся.]\n"
179-            "      answer: Я прокидаюся.\n"
180-        ),
181-        level="a1",
182-    )
183-
184-    phonetic_failures = [
185-        item
186-        for item in report["obligations"]
187-        if item["category"] == "phonetic_rules" and item["status"] == "FAIL"
188-    ]
189-    assert report["passed"] is False
190-    assert report["hard_fail"] is True
191-    assert report["phonetic_hard_fail"] is True
192-    assert phonetic_failures[0]["spoken_target"] == "[с':а]"
193-    assert phonetic_failures[0]["spoken_present"] is False
```

## Regression Manifest Check

Read-only main checkout manifest contains:

```text
phon-1: written=-шся spoken=[с':а] treatment=explicit_explanation
phon-2: written=-ться spoken=[ц':а] treatment=explicit_explanation
phon-3: written=-ся spoken=[с':а] treatment=explicit_explanation
```

## Tests

Required wiki glob. Note: `tests/test_wiki_channels.py` expects local untracked `data/external_articles/*.jsonl` corpus files; I temporarily symlinked the existing local main-checkout JSONL files into this worktree for the test run and removed the symlinks afterward.

```text
============================= 368 passed in 13.00s =============================
```

Ruff:

```text
All checks passed!
```

Agent trailer lint:

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
