### PR TITLE
fix(generate_mdx+yaml_activities): align assembler to V7 source format

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3723,7 +3723,7 @@ _ACTIVITY_AUTHORING_FIELDS: dict[str, frozenset[str]] = {
     # the old `lesson-schema.yaml`-sourced loader, which accepted them.
     "count-syllables":    _activity("items", "maxCount"),
     "divide-words":       _activity("items"),
-    "highlight-morphemes": _activity(),
+    "highlight-morphemes": _activity("items", "text"),
     "letter-grid":        _activity("letters"),
     "observe":            _activity("examples", "prompt"),
     "odd-one-out":        _activity("items"),

--- a/scripts/generate_mdx/converters.py
+++ b/scripts/generate_mdx/converters.py
@@ -7,6 +7,7 @@ and MDX normalization.
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -321,12 +322,7 @@ def process_story_sections(content: str) -> str:
 
 
 def process_dialogues(content: str) -> str:
-    """Group consecutive dialog lines into conversation blocks.
-
-    Detects sequences of lines starting with em-dash and wraps
-    them in a styled conversation container. Separates Ukrainian
-    from English translations (they're separated by blank lines).
-    """
+    """Group consecutive V6/V7 dialogue blockquotes into DialogueBox components."""
     lines = content.split('\n')
     result = []
     i = 0
@@ -346,36 +342,70 @@ def process_dialogues(content: str) -> str:
         if re.match(r'^</[A-Z]', stripped):
             inside_jsx = max(0, inside_jsx - 1)
 
-        # Check if this starts a dialog sequence (outside JSX)
-        if stripped.startswith('\u2014') and inside_jsx == 0 and '`' not in line:
+        # Check if this starts a dialogue sequence (outside JSX)
+        first_exchange = _parse_dialogue_line(stripped)
+        if first_exchange and inside_jsx == 0 and '`' not in line:
             # Collect consecutive dialog lines (stop at blank line)
-            dialog_lines = []
+            start = i
+            exchanges = []
             while i < len(lines):
                 current = lines[i].strip()
-                if current.startswith('\u2014') and '`' not in lines[i]:
-                    dialog_lines.append(lines[i])
+                parsed = _parse_dialogue_line(current)
+                if parsed and '`' not in lines[i]:
+                    exchanges.append(parsed)
+                    i += 1
+                elif re.match(r'^>\s*$', current):
                     i += 1
                 else:
                     # Stop at any non-dialog line (including blank)
                     break
 
             # Only wrap if we have 2+ dialog lines (actual conversation)
-            if len(dialog_lines) >= 2:
-                result.append('<div className="conversation">')
-                result.append('')
-                for dl in dialog_lines:
-                    result.append(dl)
-                    result.append('')
-                result.append('</div>')
+            if len(exchanges) >= 2:
+                result.append(_dialogue_box_mdx(exchanges, _dialogue_title(result)))
             else:
                 # Single line - just keep as-is
-                for dl in dialog_lines:
-                    result.append(dl)
+                result.extend(lines[start:i])
         else:
             result.append(line)
             i += 1
 
     return '\n'.join(result)
+
+
+_DIALOGUE_LINE_RE = re.compile(
+    r'^>\s*(?:\u2014\s*)?\*\*(?P<speaker>[^:*]+):\*\*\s*(?P<text>.+?)\s*$'
+)
+
+
+def _parse_dialogue_line(stripped_line: str) -> dict[str, str] | None:
+    match = _DIALOGUE_LINE_RE.match(stripped_line)
+    if not match:
+        return None
+    text = re.sub(r'\s*\*\([^)]*\)\*\s*$', '', match.group('text')).strip()
+    return {"speaker": match.group('speaker').strip(), "text": text}
+
+
+def _dialogue_title(previous_lines: list[str]) -> str:
+    for line in reversed(previous_lines[-3:]):
+        stripped = line.strip()
+        match = re.match(r'^\*\*(Діалог\s+\d+\s+[\u2014-]\s+.+?)\*\*$', stripped)
+        if match:
+            return match.group(1)
+    return "Діалог"
+
+
+def _dialogue_box_mdx(exchanges: list[dict[str, str]], title: str) -> str:
+    payload = json.dumps(exchanges, ensure_ascii=False, separators=(',', ':'))
+    payload = payload.replace('\\', '\\\\').replace("'", "\\'")
+    safe_title = title.replace('"', '&quot;')
+    return (
+        '<DialogueBox\n'
+        '  client:only="react"\n'
+        f'  title="{safe_title}"\n'
+        f"  exchanges={{JSON.parse('{payload}')}}\n"
+        '/>'
+    )
 
 
 def resolve_slug_links(content: str) -> str:

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -22,10 +22,9 @@ from .converters import (
     yaml_activities_to_jsx,
 )
 from .resources import (
-    b1_vocab_items_to_markdown,
     embed_youtube_video_links,
     format_resources_for_mdx,
-    vocab_items_to_markdown,
+    vocab_items_to_components,
 )
 from .utils import CURRICULUM_DIR, PROJECT_ROOT, SCRIPT_DIR, STARLIGHT_DOCS_DIR, escape_jsx, fix_html_for_jsx
 
@@ -153,6 +152,35 @@ def _activity_plans_to_jsx(plans: list[dict]) -> str:
     return '\n\n'.join(parts)
 
 
+_INJECT_ACTIVITY_RE = re.compile(r'<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->')
+
+
+def _inject_inline_activities(
+    body: str,
+    yaml_activities: list[Activity] | None,
+    is_ukrainian_forced: bool,
+) -> str:
+    """Replace Tab 1 INJECT_ACTIVITY markers with matching component JSX."""
+    if not yaml_activities or "INJECT_ACTIVITY" not in body:
+        return body
+
+    parser = ActivityParser()
+    by_id = {
+        str(getattr(activity, 'id', '')): activity
+        for activity in yaml_activities
+        if getattr(activity, 'id', '')
+    }
+
+    def replace_marker(match: re.Match[str]) -> str:
+        activity_id = match.group(1)
+        activity = by_id.get(activity_id)
+        if activity is None:
+            raise ValueError(f"Unresolved INJECT_ACTIVITY id: {activity_id}")
+        return parser._activity_to_mdx(activity, is_ukrainian_forced)
+
+    return _INJECT_ACTIVITY_RE.sub(replace_marker, body)
+
+
 def generate_mdx(
     md_content: str,
     module_num: int,
@@ -234,6 +262,15 @@ import DialectComparison from '@site/src/components/DialectComparison';
 import TranslationCritique from '@site/src/components/TranslationCritique';
 import Transcription from '@site/src/components/Transcription';
 import Observe from '@site/src/components/Observe';
+import Order from '@site/src/components/Order';
+import CountSyllables from '@site/src/components/CountSyllables';
+import DivideWords from '@site/src/components/DivideWords';
+import OddOneOut from '@site/src/components/OddOneOut';
+import PickSyllables from '@site/src/components/PickSyllables';
+import LetterGrid from '@site/src/components/LetterGrid';
+import FlashcardDeck from '@site/src/components/FlashcardDeck';
+import VocabCard from '@site/src/components/VocabCard';
+import DialogueBox from '@site/src/components/DialogueBox';
 import ActivityHelp from '@site/src/components/ActivityHelp';
 import YouTubeVideo from '@site/src/components/YouTubeVideo';
 import WatchAndRepeat from '@site/src/components/WatchAndRepeat';
@@ -274,10 +311,7 @@ sidebar:
     # --- TAB 2: Vocabulary ---
     if vocab_items:
         vocab_header = "\u0421\u043b\u043e\u0432\u043d\u0438\u043a" if is_ukrainian_forced else "Vocabulary"
-        if is_ukrainian_forced:
-            vocab_content = b1_vocab_items_to_markdown(vocab_items, vocab_header)
-        else:
-            vocab_content = vocab_items_to_markdown(vocab_items, vocab_header)
+        vocab_content = vocab_items_to_components(vocab_items, vocab_header)
         # Strip the H2 header - the tab label serves as the header
         vocab_content = re.sub(r'^## [^\n]+\n+', '', vocab_content)
     else:
@@ -307,6 +341,11 @@ sidebar:
 
     # Embed YouTube video links as clickable thumbnails (lesson prose only)
     lesson_content = embed_youtube_video_links(lesson_content)
+    lesson_content = _inject_inline_activities(
+        lesson_content,
+        yaml_activities,
+        is_ukrainian_forced,
+    )
 
     # =========================================================================
     # Apply shared transforms to all content blocks

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -6,6 +6,7 @@ resource merging/deduplication, and vocabulary table formatting.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -279,6 +280,17 @@ def format_resources_for_mdx(resources: dict, is_ukrainian_forced: bool = False)
         ('books', '\U0001f4da', 'Books'),
         ('websites', '\U0001f310', 'Websites')
     ]
+    role_icons = {
+        'textbook': '\U0001f4da',
+        'book': '\U0001f4da',
+        'wiki': '\U0001f517',
+        'website': '\U0001f310',
+        'article': '\U0001f4d6',
+        'audio': '\U0001f3a7',
+        'podcast': '\U0001f3a7',
+        'video': '\U0001f4fa',
+        'youtube': '\U0001f4fa',
+    }
 
     # Priority and relevance maps for sorting
     priority_map = {1: 5, 2: 4, 3: 3, 4: 2, 5: 1, None: 0}
@@ -325,16 +337,21 @@ def format_resources_for_mdx(resources: dict, is_ukrainian_forced: bool = False)
                     lines.append(f"> - [{title}]({url})")
 
             elif resource_type == 'books':
-                author = item.get('author', 'Unknown')
+                role = item.get('role') or 'textbook'
+                item_icon = role_icons.get(str(role).lower(), icon)
+                author = item.get('author', '').strip()
                 pages = item.get('pages', '')
                 desc = item.get('description', '')
+                source_ref = item.get('source_ref') or title
 
-                parts = [f"{title} by {author}"]
-                if pages:
-                    parts.append(f"(pages: {pages})")
+                display_title = source_ref
+                if pages and str(pages) not in display_title:
+                    display_title = f"{display_title}, p. {pages}"
+                if author and not display_title.startswith(author):
+                    display_title = f"{author} \u2014 {display_title}"
+                lines.append(f"> - {item_icon} **{display_title}**")
                 if desc:
-                    parts.append(f"\u2014 {desc}")
-                lines.append(f"> - {' '.join(parts)}")
+                    lines.append(f">   {desc}")
 
             elif resource_type == 'youtube':
                 channel = item.get('channel', '')
@@ -387,6 +404,41 @@ def vocab_items_to_markdown(items: list[dict], header_text: str = "Vocabulary") 
         lines.append(line)
 
     return '\n'.join(lines)
+
+
+def vocab_items_to_components(items: list[dict], header_text: str = "Vocabulary") -> str:
+    """Tier 1/2 (A1/A2): flashcards plus browsable vocabulary cards."""
+    cards = []
+    words = []
+    for item in items:
+        lemma = str(item.get('lemma') or item.get('word') or '').strip()
+        translation = str(item.get('translation') or '').strip()
+        example = str(item.get('example') or item.get('usage') or '').strip()
+        if not lemma:
+            continue
+
+        cards.append({
+            "front": lemma,
+            "back": translation,
+        })
+
+        entry = {
+            "word": lemma,
+            "translation": translation,
+            "pos": item.get('pos', ''),
+            "gender": item.get('gender', ''),
+            "example": example,
+            "examples": [value for value in (translation, example) if value],
+        }
+        words.append({key: value for key, value in entry.items() if value not in (None, "", [])})
+
+    card_json = json.dumps(cards, ensure_ascii=False, separators=(',', ':')).replace('`', '\\`').replace('${', '\\${')
+    word_json = json.dumps(words, ensure_ascii=False, separators=(',', ':')).replace('`', '\\`').replace('${', '\\${')
+    return (
+        f"## {header_text}\n\n"
+        f"<FlashcardDeck client:only=\"react\" cards={{JSON.parse(`{card_json}`)}} />\n\n"
+        f"<VocabCard client:only=\"react\" words={{JSON.parse(`{word_json}`)}} title=\"{escape_jsx(header_text)}\" />"
+    )
 
 
 def b1_vocab_items_to_markdown(items: list[dict], header_text: str = "\u0421\u043b\u043e\u0432\u043d\u0438\u043a") -> str:

--- a/scripts/yaml_activities.py
+++ b/scripts/yaml_activities.py
@@ -457,6 +457,105 @@ class WatchAndRepeatActivity:
     items: list[WatchAndRepeatItem] = field(default_factory=list)
 
 
+@dataclass
+class ObserveActivity:
+    type: str = "observe"
+    title: str = ""
+    instruction: str = ""
+    examples: list[str] = field(default_factory=list)
+    prompt: str = ""
+
+
+@dataclass
+class OrderActivity:
+    type: str = "order"
+    title: str = ""
+    instruction: str = ""
+    items: list[str] = field(default_factory=list)
+    correct_order: list[int] = field(default_factory=list)
+
+
+@dataclass
+class CountSyllablesItem:
+    word: str
+    correct: int
+    translation: str | None = None
+
+
+@dataclass
+class CountSyllablesActivity:
+    type: str = "count-syllables"
+    title: str = ""
+    instruction: str = ""
+    items: list[CountSyllablesItem] = field(default_factory=list)
+    max_count: int | None = None
+
+
+@dataclass
+class DivideWordsItem:
+    word: str
+    answer: str
+    hint: str | None = None
+
+
+@dataclass
+class DivideWordsActivity:
+    type: str = "divide-words"
+    title: str = ""
+    instruction: str = ""
+    items: list[DivideWordsItem] = field(default_factory=list)
+
+
+@dataclass
+class HighlightMorphemeItem:
+    word: str
+    morpheme: str
+    type: str = "unknown"
+
+
+@dataclass
+class HighlightMorphemesActivity:
+    type: str = "highlight-morphemes"
+    title: str = ""
+    instruction: str = ""
+    text: str = ""
+    morphemes: list[HighlightMorphemeItem] = field(default_factory=list)
+
+
+@dataclass
+class LetterGridActivity:
+    type: str = "letter-grid"
+    title: str = ""
+    instruction: str = ""
+    letters: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class OddOneOutItem:
+    words: list[str]
+    correct: int
+    explanation: str
+
+
+@dataclass
+class OddOneOutActivity:
+    type: str = "odd-one-out"
+    title: str = ""
+    instruction: str = ""
+    items: list[OddOneOutItem] = field(default_factory=list)
+
+
+@dataclass
+class PickSyllablesActivity:
+    type: str = "pick-syllables"
+    title: str = ""
+    instruction: str = ""
+    syllables: list[str] = field(default_factory=list)
+    correct_indices: list[int] = field(default_factory=list)
+    category: str = ""
+    explanation: str = ""
+
+
 # Type alias
 Activity = Union[  # noqa: UP007
     QuizActivity, SelectActivity, TrueFalseActivity, FillInActivity,
@@ -468,6 +567,9 @@ Activity = Union[  # noqa: UP007
     SourceEvaluationActivity, DebateActivity,
     EtymologyTraceActivity, GrammarIdentifyActivity,
     ClassifyActivity, ImageToLetterActivity, WatchAndRepeatActivity,
+    ObserveActivity, OrderActivity, CountSyllablesActivity,
+    DivideWordsActivity, HighlightMorphemesActivity, LetterGridActivity,
+    OddOneOutActivity, PickSyllablesActivity,
 ]
 
 
@@ -570,11 +672,21 @@ class ActivityParser:
             'classify': self._parse_classify,
             'image-to-letter': self._parse_image_to_letter,
             'watch-and-repeat': self._parse_watch_and_repeat,
+            'observe': self._parse_observe,
+            'order': self._parse_order,
+            'count-syllables': self._parse_count_syllables,
+            'divide-words': self._parse_divide_words,
+            'highlight-morphemes': self._parse_highlight_morphemes,
+            'letter-grid': self._parse_letter_grid,
+            'odd-one-out': self._parse_odd_one_out,
+            'pick-syllables': self._parse_pick_syllables,
         }
         parser = parsers.get(activity_type)
         if not parser:
             raise ValueError(f"unknown activity type {activity_type!r}")
-        return parser(data)
+        activity = parser(data)
+        activity.id = data.get('id', '')
+        return activity
 
     def _parse_quiz(self, data: dict) -> QuizActivity:
         items = []
@@ -985,6 +1097,193 @@ class ActivityParser:
             items=items,
         )
 
+    def _parse_observe(self, data: dict) -> ObserveActivity:
+        raw_examples = data.get('examples')
+        if not isinstance(raw_examples, list) or not raw_examples:
+            raise ValueError("observe requires non-empty examples list")
+        examples = [
+            str(item.get('text', '')) if isinstance(item, dict) else str(item)
+            for item in raw_examples
+        ]
+        if not all(example.strip() for example in examples):
+            raise ValueError("observe examples must be non-empty strings")
+        prompt = data.get('prompt')
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("observe requires non-empty prompt")
+        return ObserveActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            examples=examples,
+            prompt=prompt,
+        )
+
+    def _parse_order(self, data: dict) -> OrderActivity:
+        items = data.get('items')
+        correct_order = data.get('correct_order')
+        if not isinstance(items, list) or not items:
+            raise ValueError("order requires non-empty items list")
+        if not isinstance(correct_order, list) or not correct_order:
+            raise ValueError("order requires non-empty correct_order list")
+        if not all(isinstance(index, int) for index in correct_order):
+            raise TypeError("order correct_order must contain integers")
+        if any(index < 0 or index >= len(items) for index in correct_order):
+            raise ValueError("order correct_order index out of range")
+        return OrderActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            items=[str(item) for item in items],
+            correct_order=correct_order,
+        )
+
+    def _parse_count_syllables(self, data: dict) -> CountSyllablesActivity:
+        items = []
+        for item in data.get('items', []):
+            if 'word' not in item or 'correct' not in item:
+                raise KeyError("count-syllables item requires word and correct")
+            if not isinstance(item['correct'], int):
+                raise TypeError("count-syllables item correct must be an integer")
+            items.append(CountSyllablesItem(
+                word=str(item['word']),
+                correct=item['correct'],
+                translation=str(item['translation']) if item.get('translation') else None,
+            ))
+        if not items:
+            raise ValueError("count-syllables requires non-empty items list")
+        max_count = data.get('maxCount')
+        if max_count is not None and not isinstance(max_count, int):
+            raise TypeError("count-syllables maxCount must be an integer")
+        return CountSyllablesActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            items=items,
+            max_count=max_count,
+        )
+
+    def _parse_divide_words(self, data: dict) -> DivideWordsActivity:
+        items = []
+        for item in data.get('items', []):
+            if 'word' not in item or 'answer' not in item:
+                raise KeyError("divide-words item requires word and answer")
+            items.append(DivideWordsItem(
+                word=str(item['word']),
+                answer=str(item['answer']),
+                hint=str(item['hint']) if item.get('hint') else None,
+            ))
+        if not items:
+            raise ValueError("divide-words requires non-empty items list")
+        return DivideWordsActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            items=items,
+        )
+
+    def _parse_highlight_morphemes(self, data: dict) -> HighlightMorphemesActivity:
+        items = data.get('items', [])
+        text = data.get('text', '')
+        morphemes = []
+        for item in items:
+            word = str(item.get('word', '')).strip()
+            if not word:
+                raise ValueError("highlight-morphemes item requires word")
+            raw_morphemes = item.get('morphemes', [])
+            if isinstance(raw_morphemes, list) and raw_morphemes:
+                for raw in raw_morphemes:
+                    if isinstance(raw, dict):
+                        morpheme = str(raw.get('morpheme') or raw.get('text') or '').strip()
+                        mtype = str(raw.get('type', 'unknown'))
+                    else:
+                        morpheme = str(raw).strip()
+                        mtype = 'unknown'
+                    if not morpheme:
+                        raise ValueError("highlight-morphemes morpheme must be non-empty")
+                    morphemes.append(HighlightMorphemeItem(word=word, morpheme=morpheme, type=mtype))
+            elif item.get('morpheme'):
+                morphemes.append(HighlightMorphemeItem(
+                    word=word,
+                    morpheme=str(item['morpheme']),
+                    type=str(item.get('type', 'unknown')),
+                ))
+            else:
+                raise ValueError("highlight-morphemes item requires morphemes")
+        if not morphemes:
+            raise ValueError("highlight-morphemes requires non-empty items list")
+        if not text:
+            text = " ".join(item.word for item in morphemes)
+        return HighlightMorphemesActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            text=str(text),
+            morphemes=morphemes,
+        )
+
+    def _parse_letter_grid(self, data: dict) -> LetterGridActivity:
+        letters = data.get('letters')
+        if not isinstance(letters, list) or not letters:
+            raise ValueError("letter-grid requires non-empty letters list")
+        normalized = []
+        for letter in letters:
+            if not isinstance(letter, dict):
+                raise TypeError("letter-grid letters must be dictionaries")
+            required = ('upper', 'lower', 'emoji', 'key_word')
+            missing = [key for key in required if not letter.get(key)]
+            if missing:
+                raise KeyError(f"letter-grid letter missing required fields: {missing}")
+            normalized.append({key: letter[key] for key in letter if key in {'upper', 'lower', 'emoji', 'key_word', 'note', 'sound_type'}})
+        return LetterGridActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            letters=normalized,
+        )
+
+    def _parse_odd_one_out(self, data: dict) -> OddOneOutActivity:
+        items = []
+        for item in data.get('items', []):
+            if not isinstance(item.get('words'), list) or not item['words']:
+                raise ValueError("odd-one-out item requires non-empty words list")
+            correct = item.get('correct')
+            if not isinstance(correct, int):
+                raise TypeError("odd-one-out item correct must be an integer")
+            if correct < 0 or correct >= len(item['words']):
+                raise ValueError("odd-one-out item correct index out of range")
+            explanation = item.get('explanation')
+            if not isinstance(explanation, str) or not explanation.strip():
+                raise ValueError("odd-one-out item requires explanation")
+            items.append(OddOneOutItem(
+                words=[str(word) for word in item['words']],
+                correct=correct,
+                explanation=explanation,
+            ))
+        if not items:
+            raise ValueError("odd-one-out requires non-empty items list")
+        return OddOneOutActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            items=items,
+        )
+
+    def _parse_pick_syllables(self, data: dict) -> PickSyllablesActivity:
+        syllables = data.get('syllables')
+        correct_indices = data.get('correctIndices')
+        category = data.get('category')
+        if not isinstance(syllables, list) or not syllables:
+            raise ValueError("pick-syllables requires non-empty syllables list")
+        if not isinstance(correct_indices, list) or not correct_indices:
+            raise ValueError("pick-syllables requires non-empty correctIndices list")
+        if not all(isinstance(index, int) for index in correct_indices):
+            raise TypeError("pick-syllables correctIndices must contain integers")
+        if any(index < 0 or index >= len(syllables) for index in correct_indices):
+            raise ValueError("pick-syllables correctIndices index out of range")
+        if not isinstance(category, str) or not category.strip():
+            raise ValueError("pick-syllables requires non-empty category")
+        return PickSyllablesActivity(
+            title=data.get('title', ''),
+            instruction=data.get('instruction', ''),
+            syllables=[str(syllable) for syllable in syllables],
+            correct_indices=correct_indices,
+            category=category,
+            explanation=str(data.get('explanation', '')),
+        )
+
     def _escape_jsx(self, text: str) -> str:
         """Escapes characters that break JSX parsing when used as a string literal attribute."""
         if not text:
@@ -1078,6 +1377,95 @@ class ActivityParser:
             return self._image_to_letter_to_mdx(activity)
         if isinstance(activity, WatchAndRepeatActivity):
             return self._watch_and_repeat_to_mdx(activity)
+        if isinstance(activity, ObserveActivity):
+            return self._observe_to_mdx(activity, is_ukrainian_forced)
+        if isinstance(activity, OrderActivity):
+            return self._order_to_mdx(activity, is_ukrainian_forced)
+        if isinstance(activity, CountSyllablesActivity):
+            return self._count_syllables_to_mdx(activity)
+        if isinstance(activity, DivideWordsActivity):
+            return self._divide_words_to_mdx(activity)
+        if isinstance(activity, HighlightMorphemesActivity):
+            return self._highlight_morphemes_to_mdx(activity, is_ukrainian_forced)
+        if isinstance(activity, LetterGridActivity):
+            return self._letter_grid_to_mdx(activity)
+        if isinstance(activity, OddOneOutActivity):
+            return self._odd_one_out_to_mdx(activity)
+        if isinstance(activity, PickSyllablesActivity):
+            return self._pick_syllables_to_mdx(activity)
+        activity_type = getattr(activity, 'type', '')
+        if activity_type == 'quiz':
+            return self._quiz_to_mdx(activity)
+        if activity_type == 'select':
+            return self._select_to_mdx(activity)
+        if activity_type == 'true-false':
+            return self._true_false_to_mdx(activity)
+        if activity_type == 'fill-in':
+            return self._fill_in_to_mdx(activity)
+        if activity_type == 'cloze':
+            return self._cloze_to_mdx(activity)
+        if activity_type == 'match-up':
+            return self._match_up_to_mdx(activity)
+        if activity_type == 'group-sort':
+            return self._group_sort_to_mdx(activity)
+        if activity_type == 'unjumble':
+            return self._unjumble_to_mdx(activity)
+        if activity_type == 'error-correction':
+            return self._error_correction_to_mdx(activity)
+        if activity_type == 'mark-the-words':
+            return self._mark_the_words_to_mdx(activity)
+        if activity_type == 'translate':
+            return self._translate_to_mdx(activity)
+        if activity_type == 'anagram':
+            return self._anagram_to_mdx(activity)
+        if activity_type == 'reading':
+            return self._reading_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'essay-response':
+            return self._essay_response_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'critical-analysis':
+            return self._critical_analysis_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'comparative-study':
+            return self._comparative_study_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'authorial-intent':
+            return self._authorial_intent_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'source-evaluation':
+            return self._source_evaluation_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'debate':
+            return self._debate_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'etymology-trace':
+            return self._etymology_trace_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'grammar-identify':
+            return self._grammar_identify_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'transcription':
+            return self._transcription_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'paleography-analysis':
+            return self._paleography_analysis_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'dialect-comparison':
+            return self._dialect_comparison_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'translation-critique':
+            return self._translation_critique_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'classify':
+            return self._classify_to_mdx(activity)
+        if activity_type == 'image-to-letter':
+            return self._image_to_letter_to_mdx(activity)
+        if activity_type == 'watch-and-repeat':
+            return self._watch_and_repeat_to_mdx(activity)
+        if activity_type == 'observe':
+            return self._observe_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'order':
+            return self._order_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'count-syllables':
+            return self._count_syllables_to_mdx(activity)
+        if activity_type == 'divide-words':
+            return self._divide_words_to_mdx(activity)
+        if activity_type == 'highlight-morphemes':
+            return self._highlight_morphemes_to_mdx(activity, is_ukrainian_forced)
+        if activity_type == 'letter-grid':
+            return self._letter_grid_to_mdx(activity)
+        if activity_type == 'odd-one-out':
+            return self._odd_one_out_to_mdx(activity)
+        if activity_type == 'pick-syllables':
+            return self._pick_syllables_to_mdx(activity)
         return ''
 
     def _quiz_to_mdx(self, activity: QuizActivity) -> str:
@@ -1312,3 +1700,87 @@ class ActivityParser:
             props += f' title="{self._escape_jsx(activity.title)}"'
         heading = activity.title or 'Watch and Repeat'
         return f"### {self._escape_jsx(heading)}\n\n<WatchAndRepeat client:only='react' {props} />"
+
+    def _observe_to_mdx(self, activity: ObserveActivity, is_ukrainian_forced: bool = False) -> str:
+        heading = activity.title or activity.instruction or 'Observe'
+        props = (
+            f"examples={{JSON.parse(`{self._dump_safe_json(activity.examples)}`)}} "
+            f"prompt={{{json.dumps(activity.prompt, ensure_ascii=False)}}} "
+            f"isUkrainian={{{'true' if is_ukrainian_forced else 'false'}}}"
+        )
+        return f"### {self._escape_jsx(heading)}\n\n<Observe client:only='react' {props} />"
+
+    def _order_to_mdx(self, activity: OrderActivity, is_ukrainian_forced: bool = False) -> str:
+        heading = activity.title or activity.instruction or 'Order'
+        instruction_prop = f' instruction={{{json.dumps(activity.instruction, ensure_ascii=False)}}}' if activity.instruction else ''
+        return (
+            f"### {self._escape_jsx(heading)}\n\n"
+            f"<Order client:only='react' items={{JSON.parse(`{self._dump_safe_json(activity.items)}`)}} "
+            f"correct_order={{JSON.parse(`{self._dump_safe_json(activity.correct_order)}`)}}"
+            f"{instruction_prop} isUkrainian={{{'true' if is_ukrainian_forced else 'false'}}} />"
+        )
+
+    def _count_syllables_to_mdx(self, activity: CountSyllablesActivity) -> str:
+        heading = activity.title or activity.instruction or 'Count Syllables'
+        items = []
+        for item in activity.items:
+            payload: dict[str, Any] = {'word': item.word, 'correct': item.correct}
+            if item.translation:
+                payload['translation'] = item.translation
+            items.append(payload)
+        instruction_prop = f' instruction={{{json.dumps(activity.instruction, ensure_ascii=False)}}}' if activity.instruction else ''
+        max_prop = f' maxCount={{{activity.max_count}}}' if activity.max_count is not None else ''
+        return f"### {self._escape_jsx(heading)}\n\n<CountSyllables client:only='react'{instruction_prop} items={{JSON.parse(`{self._dump_safe_json(items)}`)}}{max_prop} />"
+
+    def _divide_words_to_mdx(self, activity: DivideWordsActivity) -> str:
+        heading = activity.title or activity.instruction or 'Divide Words'
+        items = []
+        for item in activity.items:
+            payload = {'word': item.word, 'answer': item.answer}
+            if item.hint:
+                payload['hint'] = item.hint
+            items.append(payload)
+        instruction_prop = f' instruction={{{json.dumps(activity.instruction, ensure_ascii=False)}}}' if activity.instruction else ''
+        return f"### {self._escape_jsx(heading)}\n\n<DivideWords client:only='react'{instruction_prop} items={{JSON.parse(`{self._dump_safe_json(items)}`)}} />"
+
+    def _highlight_morphemes_to_mdx(self, activity: HighlightMorphemesActivity, is_ukrainian_forced: bool = False) -> str:
+        heading = activity.title or activity.instruction or 'Highlight Morphemes'
+        morphemes = [
+            {'word': item.word, 'morpheme': item.morpheme, 'type': item.type}
+            for item in activity.morphemes
+        ]
+        instruction_prop = f' instruction={{{json.dumps(activity.instruction, ensure_ascii=False)}}}' if activity.instruction else ''
+        return (
+            f"### {self._escape_jsx(heading)}\n\n"
+            f"<HighlightMorphemes client:only='react' isUkrainian={{{'true' if is_ukrainian_forced else 'false'}}}>\n"
+            f"  <HighlightMorphemesActivity{instruction_prop} text={{{json.dumps(activity.text, ensure_ascii=False)}}} "
+            f"morphemes={{JSON.parse(`{self._dump_safe_json(morphemes)}`)}} "
+            f"isUkrainian={{{'true' if is_ukrainian_forced else 'false'}}} />\n"
+            f"</HighlightMorphemes>"
+        )
+
+    def _letter_grid_to_mdx(self, activity: LetterGridActivity) -> str:
+        heading = activity.title or 'Letter Grid'
+        title_prop = f' title="{self._escape_jsx(activity.title)}"' if activity.title else ''
+        return f"### {self._escape_jsx(heading)}\n\n<LetterGrid client:only='react' letters={{JSON.parse(`{self._dump_safe_json(activity.letters)}`)}}{title_prop} />"
+
+    def _odd_one_out_to_mdx(self, activity: OddOneOutActivity) -> str:
+        heading = activity.title or activity.instruction or 'Odd One Out'
+        items = [
+            {'words': item.words, 'correct': item.correct, 'explanation': item.explanation}
+            for item in activity.items
+        ]
+        instruction_prop = f' instruction={{{json.dumps(activity.instruction, ensure_ascii=False)}}}' if activity.instruction else ''
+        return f"### {self._escape_jsx(heading)}\n\n<OddOneOut client:only='react'{instruction_prop} items={{JSON.parse(`{self._dump_safe_json(items)}`)}} />"
+
+    def _pick_syllables_to_mdx(self, activity: PickSyllablesActivity) -> str:
+        heading = activity.title or activity.instruction or 'Pick Syllables'
+        instruction_prop = f' instruction={{{json.dumps(activity.instruction, ensure_ascii=False)}}}' if activity.instruction else ''
+        explanation_prop = f' explanation={{{json.dumps(activity.explanation, ensure_ascii=False)}}}' if activity.explanation else ''
+        return (
+            f"### {self._escape_jsx(heading)}\n\n"
+            f"<PickSyllables client:only='react'{instruction_prop} "
+            f"syllables={{JSON.parse(`{self._dump_safe_json(activity.syllables)}`)}} "
+            f"correctIndices={{JSON.parse(`{self._dump_safe_json(activity.correct_indices)}`)}} "
+            f"category={{{json.dumps(activity.category, ensure_ascii=False)}}}{explanation_prop} />"
+        )

--- a/tests/test_assemble_mdx_v7.py
+++ b/tests/test_assemble_mdx_v7.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from scripts.build.linear_pipeline import assemble_mdx
+
+
+def test_assemble_mdx_v7_sources_render_four_tabs(tmp_path):
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    plan_path = tmp_path / "plan.yaml"
+    out_path = tmp_path / "out.mdx"
+
+    plan_path.write_text(
+        """
+module: 1
+level: a1
+sequence: 1
+slug: my-morning
+title: Мій ранок
+subtitle: Test
+word_target: 100
+content_outline:
+  - section: Діалоги
+    words: 50
+    points: [Test]
+references:
+  - title: Караман Grade 10, p.176
+""",
+        encoding="utf-8",
+    )
+    (module_dir / "module.md").write_text(
+        """# Мій ранок
+
+**Діалог 1 — Будній ранок**
+
+> **Ліна:** Коли ти прокидаєшся?
+> **Настя:** Я прокидаюся о сьомій.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+""",
+        encoding="utf-8",
+    )
+    (module_dir / "activities.yaml").write_text(
+        """
+- id: act-1
+  type: observe
+  instruction: Notice the pattern.
+  prompt: What changes?
+  examples:
+    - text: мию → миюся
+    - text: одягаю → одягаюся
+- id: act-2
+  type: order
+  instruction: Put the actions in order.
+  items: [прокидатися, вмиватися, снідати]
+  correct_order: [0, 1, 2]
+""",
+        encoding="utf-8",
+    )
+    (module_dir / "vocabulary.yaml").write_text(
+        """
+- lemma: прокидатися
+  translation: to wake up
+  pos: verb
+  usage: Я прокидаюся о сьомій.
+""",
+        encoding="utf-8",
+    )
+    (module_dir / "resources.yaml").write_text(
+        """
+- title: Караман Grade 10, p.176
+  source_ref: Караман Grade 10, p.176
+  author: Караман
+  pages: "176"
+  description: Reflexive verbs with -ся.
+  role: textbook
+""",
+        encoding="utf-8",
+    )
+
+    mdx = assemble_mdx(module_dir, out_path, plan_path)
+
+    assert "<DialogueBox" in mdx
+    assert "<FlashcardDeck" in mdx
+    assert "<VocabCard" in mdx
+    assert mdx.count("<Observe") == 2
+    assert "<Order" in mdx
+    assert "INJECT_ACTIVITY" not in mdx
+    assert "by Unknown" not in mdx
+    assert "Караман" in mdx

--- a/tests/test_dialogue_render.py
+++ b/tests/test_dialogue_render.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from generate_mdx import process_dialogues
+
+
+def test_process_dialogues_converts_v7_blockquote_dialogue_to_dialogue_box():
+    content = """**Діалог 1 — Будній ранок**
+
+> **Ліна:** Коли ти прокидаєшся?
+> **Настя:** Я прокидаюся о сьомій.
+> **Ліна:** Що ти робиш потім?
+> **Настя:** Спочатку вмиваюся.
+> **Ліна:** А далі?
+> **Настя:** Потім одягаюся і снідаю.
+> **Ліна:** Коли ти йдеш на роботу?
+> **Настя:** О восьмій. А ти?
+> **Ліна:** Я прокидаюся пізно — о дев'ятій.
+"""
+
+    mdx = process_dialogues(content)
+
+    assert mdx.count("<DialogueBox") == 1
+    assert 'title="Діалог 1 — Будній ранок"' in mdx
+    assert mdx.count('"speaker"') == 9
+    assert "Коли ти прокидаєшся?" in mdx
+    assert "> **Ліна:**" not in mdx
+

--- a/tests/test_generate_mdx_v7_resources_vocab.py
+++ b/tests/test_generate_mdx_v7_resources_vocab.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from scripts.generate_mdx.resources import format_resources_for_mdx, vocab_items_to_components
+
+
+def test_vocab_items_to_components_emits_flashcards_and_vocab_card():
+    mdx = vocab_items_to_components([
+        {
+            "lemma": "прокидатися",
+            "translation": "to wake up",
+            "pos": "verb",
+            "usage": "Я прокидаюся о сьомій.",
+        },
+        {
+            "lemma": "кава",
+            "translation": "coffee",
+            "pos": "noun",
+            "gender": "f",
+            "usage": "Я п'ю каву.",
+        },
+        {
+            "lemma": "потім",
+            "translation": "then",
+            "pos": "adv",
+            "usage": "Потім я вмиваюся.",
+        },
+    ])
+
+    assert "<FlashcardDeck" in mdx
+    assert "<VocabCard" in mdx
+    assert '"front":"прокидатися"' in mdx
+    assert '"translation":"to wake up"' in mdx
+    assert '"example":"Я прокидаюся о сьомій."' in mdx
+
+
+def test_format_resources_for_mdx_uses_author_description_and_role_icon():
+    mdx = format_resources_for_mdx({
+        "books": [
+            {
+                "title": "Караман Grade 10, p.176",
+                "source_ref": "Караман Grade 10, p.176",
+                "author": "Караман",
+                "pages": "176",
+                "description": "Reflexive verbs with -ся.",
+                "role": "textbook",
+            },
+            {
+                "title": "Wikipedia overview",
+                "source_ref": "Ukrainian Wikipedia",
+                "author": "Вікіпедія",
+                "description": "Background article.",
+                "role": "wiki",
+            },
+        ],
+    })
+
+    assert "by Unknown" not in mdx
+    assert "📚 **Караман Grade 10, p.176**" in mdx
+    assert "Reflexive verbs with -ся." in mdx
+    assert "🔗 **Вікіпедія — Ukrainian Wikipedia**" in mdx

--- a/tests/test_yaml_activities_v7_types.py
+++ b/tests/test_yaml_activities_v7_types.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from yaml_activities import ActivityParser
+
+
+def test_v7_authoring_types_parse_and_render(tmp_path):
+    fixture = tmp_path / "activities.yaml"
+    fixture.write_text(
+        """
+- id: observe-1
+  type: observe
+  title: Observe
+  instruction: Notice the pattern.
+  prompt: What changes?
+  examples:
+    - text: мию → миюся
+    - text: одягаю → одягаюся
+- id: order-1
+  type: order
+  title: Order
+  instruction: Put the actions in order.
+  items: [прокидатися, вмиватися, снідати]
+  correct_order: [0, 1, 2]
+- id: count-1
+  type: count-syllables
+  title: Count
+  instruction: Count syllables.
+  maxCount: 5
+  items:
+    - word: молоко
+      correct: 3
+      translation: milk
+- id: divide-1
+  type: divide-words
+  title: Divide
+  instruction: Divide words.
+  items:
+    - word: молоко
+      answer: мо-ло-ко
+- id: morphemes-1
+  type: highlight-morphemes
+  title: Morphemes
+  instruction: Find suffixes.
+  text: прокидаюся вмиваюся
+  items:
+    - word: прокидаюся
+      morphemes:
+        - morpheme: ся
+          type: suffix
+- id: grid-1
+  type: letter-grid
+  title: Letters
+  letters:
+    - upper: А
+      lower: а
+      emoji: 🍉
+      key_word: кавун
+      sound_type: vowel
+- id: odd-1
+  type: odd-one-out
+  title: Odd
+  instruction: Pick the odd word.
+  items:
+    - words: [кава, чай, хліб, вода]
+      correct: 2
+      explanation: Хліб is not a drink.
+- id: pick-1
+  type: pick-syllables
+  title: Pick
+  instruction: Pick open syllables.
+  syllables: [ма, мок, ко]
+  correctIndices: [0, 2]
+  category: відкриті
+  explanation: Open syllables end in vowels.
+""",
+        encoding="utf-8",
+    )
+
+    parser = ActivityParser()
+    activities = parser.parse(fixture)
+    assert [activity.type for activity in activities] == [
+        "observe",
+        "order",
+        "count-syllables",
+        "divide-words",
+        "highlight-morphemes",
+        "letter-grid",
+        "odd-one-out",
+        "pick-syllables",
+    ]
+
+    mdx = parser.to_mdx(activities)
+    for tag in (
+        "<Observe",
+        "<Order",
+        "<CountSyllables",
+        "<DivideWords",
+        "<HighlightMorphemes",
+        "<LetterGrid",
+        "<OddOneOut",
+        "<PickSyllables",
+    ):
+        assert tag in mdx
+
+    assert "ActivityPlaceholder" not in mdx
+


### PR DESCRIPTION
## Summary

Aligns the MDX assembler with the V7 four-artifact source contract from `docs/lesson-contract.md` and the visual/component target in `docs/poc/poc-lesson-design.html`:

- parses and renders the V7 activity types that were authoring-valid but parser-missing
- converts V7 dialogue blockquotes to `<DialogueBox>`
- substitutes `<!-- INJECT_ACTIVITY: id -->` before comment stripping
- renders vocabulary as `<FlashcardDeck>` + `<VocabCard>`
- renders resources with role icons, descriptions, and real author/source attribution

Reference docs: `docs/lesson-contract.md`, `docs/poc/poc-lesson-design.html`, `docs/lesson-schema-design.md`, `docs/lesson-schema.yaml`.

## Verification

Required tests:

```text
============================= 132 passed in 0.56s ==============================
```

Required ruff:

```text
All checks passed!
```

Activity parser fixture for all missing `_ACTIVITY_AUTHORING_FIELDS` types:

```text
PASS parsed 8 _ACTIVITY_AUTHORING_FIELDS types
PASS rendered tags: Observe=1, Order=1, CountSyllables=1, DivideWords=1, HighlightMorphemes=2, LetterGrid=1, OddOneOut=1, PickSyllables=1
```

End-to-end `a1/my-morning` assembler repro:

```text
OK wrote 21816 chars
DialogueBox=2
FlashcardOrVocab=2
ActivityComponents=8
Unknown=0
NamedAuthors=6
```

Main-checkout V7 reference source repro:

```text
OK main-ref wrote 25715 chars
MainRefDialogueBox=2
MainRefFlashcardOrVocab=2
MainRefActivityComponents=17
MainRefUnknown=0
MainRefNamedAuthors=5
```

Folk regression smoke:

```text
OK folk assemble wrote 69853 chars
folk components FlashcardDeck=1 VocabCard=1
```

Trailer lint:

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Before / After MDX Excerpts

Tab 1, dialogues:

```mdx
# before
> **Ліна:** Коли ти прокидаєшся?
> **Настя:** Я прокидаюся о сьомій.
```

```mdx
# after
<DialogueBox
  client:only="react"
  title="Діалог 1 — Будній ранок"
  exchanges={JSON.parse('[{"speaker":"Ліна","text":"Коли ти прокидаєшся?"},{"speaker":"Настя","text":"Я прокидаюся о сьомій."}]')}
/>
```

Tab 2, vocabulary:

```mdx
# before
| Word | IPA | English | POS | Gender | Note |
| --- | --- | --- | --- | --- | --- |
| прокидатися |  | to wake up | verb |  | Я прокидаюся о сьомій. |
```

```mdx
# after
<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"прокидатися","back":"to wake up"}]`)} />

<VocabCard client:only="react" words={JSON.parse(`[{"word":"прокидатися","translation":"to wake up","pos":"verb","example":"Я прокидаюся о сьомій."}]`)} title="Vocabulary" />
```

Tab 3, activities:

```mdx
# before
*No activities for this module.*
```

```mdx
# after
<Observe client:only='react' examples={JSON.parse(`["мию → миюся","одягаю → одягаюся"]`)} prompt={"What changes?"} isUkrainian={false} />

<Order client:only='react' items={JSON.parse(`["прокидатися","вмиватися","снідати"]`)} correct_order={JSON.parse(`[0,1,2]`)} />
```

Tab 4, resources:

```mdx
# before
- Караман Grade 10, p.176 by Unknown
```

```mdx
# after
- 📚 **Караман Grade 10, p.176**
  Reflexive verbs with -ся/-сь as actions directed back to the subject.
```

Closes #1929
