### PR TITLE
fix(generate_mdx): dedupe Tab3 inline activities

### DIFF
--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -159,10 +159,10 @@ def _inject_inline_activities(
     body: str,
     yaml_activities: list[Activity] | None,
     is_ukrainian_forced: bool,
-) -> str:
+) -> tuple[str, set[str]]:
     """Replace Tab 1 INJECT_ACTIVITY markers with matching component JSX."""
     if not yaml_activities or "INJECT_ACTIVITY" not in body:
-        return body
+        return body, set()
 
     parser = ActivityParser()
     by_id = {
@@ -170,15 +170,17 @@ def _inject_inline_activities(
         for activity in yaml_activities
         if getattr(activity, 'id', '')
     }
+    injected_ids: set[str] = set()
 
     def replace_marker(match: re.Match[str]) -> str:
         activity_id = match.group(1)
         activity = by_id.get(activity_id)
         if activity is None:
             raise ValueError(f"Unresolved INJECT_ACTIVITY id: {activity_id}")
+        injected_ids.add(activity_id)
         return parser._activity_to_mdx(activity, is_ukrainian_forced)
 
-    return _INJECT_ACTIVITY_RE.sub(replace_marker, body)
+    return _INJECT_ACTIVITY_RE.sub(replace_marker, body), injected_ids
 
 
 def generate_mdx(
@@ -307,6 +309,12 @@ sidebar:
 
     # --- TAB 1: Lesson (prose only) ---
     lesson_content = body
+    lesson_content = embed_youtube_video_links(lesson_content)
+    lesson_content, injected_activity_ids = _inject_inline_activities(
+        lesson_content,
+        yaml_activities,
+        is_ukrainian_forced,
+    )
 
     # --- TAB 2: Vocabulary ---
     if vocab_items:
@@ -319,8 +327,19 @@ sidebar:
         vocab_content = f"*{no_vocab_msg}*"
 
     # --- TAB 3: Activities ---
-    if yaml_activities:
-        activities_content = yaml_activities_to_jsx(yaml_activities, is_ukrainian_forced)
+    tab3_activities = [
+        activity for activity in (yaml_activities or [])
+        if str(getattr(activity, 'id', '')) not in injected_activity_ids
+    ]
+    if tab3_activities:
+        activities_content = yaml_activities_to_jsx(tab3_activities, is_ukrainian_forced)
+    elif yaml_activities and injected_activity_ids:
+        no_workbook_msg = (
+            "Немає окремих вправ у робочому зошиті; дивіться вкладку «Урок»."
+            if is_ukrainian_forced
+            else "No workbook activities for this module; see the Lesson tab."
+        )
+        activities_content = f"*{no_workbook_msg}*"
     elif activity_plans:
         activities_content = _activity_plans_to_jsx(activity_plans)
     else:
@@ -338,14 +357,6 @@ sidebar:
     # =========================================================================
     # Process lesson content (Tab 1 only)
     # =========================================================================
-
-    # Embed YouTube video links as clickable thumbnails (lesson prose only)
-    lesson_content = embed_youtube_video_links(lesson_content)
-    lesson_content = _inject_inline_activities(
-        lesson_content,
-        yaml_activities,
-        is_ukrainian_forced,
-    )
 
     # =========================================================================
     # Apply shared transforms to all content blocks

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -436,8 +436,8 @@ def vocab_items_to_components(items: list[dict], header_text: str = "Vocabulary"
     word_json = json.dumps(words, ensure_ascii=False, separators=(',', ':')).replace('`', '\\`').replace('${', '\\${')
     return (
         f"## {header_text}\n\n"
-        f"<FlashcardDeck client:only=\"react\" cards={{JSON.parse(`{card_json}`)}} />\n\n"
-        f"<VocabCard client:only=\"react\" words={{JSON.parse(`{word_json}`)}} title=\"{escape_jsx(header_text)}\" />"
+        f"<VocabCard client:only=\"react\" words={{JSON.parse(`{word_json}`)}} title=\"{escape_jsx(header_text)}\" />\n\n"
+        f"<FlashcardDeck client:only=\"react\" cards={{JSON.parse(`{card_json}`)}} />"
     )
 
 

--- a/tests/test_assemble_mdx_v7.py
+++ b/tests/test_assemble_mdx_v7.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
+import re
+
 from scripts.build.linear_pipeline import assemble_mdx
+
+_ACTIVITY_COMPONENT_RE = re.compile(
+    r"<(?:Quiz|FillIn|MatchUp|TrueFalse|GroupSort|Unjumble|Observe|Order)\b"
+)
+
+
+def _tab_item(mdx: str, label: str) -> str:
+    start = mdx.index(f'<TabItem label="{label}">')
+    end = mdx.index("</TabItem>", start)
+    return mdx[start:end]
 
 
 def test_assemble_mdx_v7_sources_render_four_tabs(tmp_path):
@@ -36,6 +48,8 @@ references:
 > **Настя:** Я прокидаюся о сьомій.
 
 <!-- INJECT_ACTIVITY: act-1 -->
+
+<!-- INJECT_ACTIVITY: act-3 -->
 """,
         encoding="utf-8",
     )
@@ -43,6 +57,7 @@ references:
         """
 - id: act-1
   type: observe
+  title: Inline observe
   instruction: Notice the pattern.
   prompt: What changes?
   examples:
@@ -50,9 +65,28 @@ references:
     - text: одягаю → одягаюся
 - id: act-2
   type: order
+  title: Workbook order
   instruction: Put the actions in order.
   items: [прокидатися, вмиватися, снідати]
   correct_order: [0, 1, 2]
+- id: act-3
+  type: true-false
+  title: Inline true false
+  items:
+    - statement: Настя прокидається о сьомій.
+      correct: true
+- id: act-4
+  type: match-up
+  title: Workbook match
+  pairs:
+    - left: прокидатися
+      right: to wake up
+- id: act-5
+  type: fill-in
+  title: Workbook fill
+  items:
+    - sentence: Я ___ о сьомій.
+      answer: прокидаюся
 """,
         encoding="utf-8",
     )
@@ -80,10 +114,23 @@ references:
     mdx = assemble_mdx(module_dir, out_path, plan_path)
 
     assert "<DialogueBox" in mdx
-    assert "<FlashcardDeck" in mdx
     assert "<VocabCard" in mdx
-    assert mdx.count("<Observe") == 2
-    assert "<Order" in mdx
+    assert "<FlashcardDeck" in mdx
+    assert mdx.index("<VocabCard") < mdx.index("<FlashcardDeck")
+
+    lesson_tab = _tab_item(mdx, "Lesson")
+    activities_tab = _tab_item(mdx, "Activities")
+    assert len(_ACTIVITY_COMPONENT_RE.findall(lesson_tab)) == 2
+    assert len(_ACTIVITY_COMPONENT_RE.findall(activities_tab)) == 3
+    assert "<Observe" in lesson_tab
+    assert "<TrueFalse" in lesson_tab
+    assert "<Observe" not in activities_tab
+    assert "<TrueFalse" not in activities_tab
+    assert "<Order" in activities_tab
+    assert "<MatchUp" in activities_tab
+    assert "<FillIn" in activities_tab
+    assert "Inline observe" not in activities_tab
+    assert "Inline true false" not in activities_tab
     assert "INJECT_ACTIVITY" not in mdx
     assert "by Unknown" not in mdx
     assert "Караман" in mdx

--- a/tests/test_generate_mdx_v7_resources_vocab.py
+++ b/tests/test_generate_mdx_v7_resources_vocab.py
@@ -28,6 +28,7 @@ def test_vocab_items_to_components_emits_flashcards_and_vocab_card():
 
     assert "<FlashcardDeck" in mdx
     assert "<VocabCard" in mdx
+    assert mdx.index("<VocabCard") < mdx.index("<FlashcardDeck")
     assert '"front":"прокидатися"' in mdx
     assert '"translation":"to wake up"' in mdx
     assert '"example":"Я прокидаюся о сьомій."' in mdx


### PR DESCRIPTION
## Summary

Closes #1934.

- Track resolved `INJECT_ACTIVITY` IDs while replacing Tab 1 inline markers.
- Render only non-injected YAML activities in Tab 3.
- Show a friendly empty-workbook message when every YAML activity was injected inline.
- Swap the vocabulary tab order so `VocabCard` renders above `FlashcardDeck`.

## Validation

```text
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_generate_mdx*.py tests/test_assemble_mdx*.py -x
============================= 104 passed in 0.36s ==============================
```

```text
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/generate_mdx
All checks passed!
```

```text
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

End-to-end `a1/my-morning` regen wrote `/tmp/test-tab3-dedupe.mdx`:

```text
wrote 18587 chars
```

Current `origin/main` source note: `curriculum/l2-uk-en/a1/my-morning` has four activities and all four are inline-injected, not the `act-1`...`act-10` shape from the dispatch brief. Therefore this source regenerates with Tab 1 count 4 and Tab 3 count 0 plus the empty-workbook message:

```text
awk '/<TabItem label="Lesson"/,/<\/TabItem>/' /tmp/test-tab3-dedupe.mdx | grep -cE '<(Quiz|FillIn|MatchUp|TrueFalse|GroupSort|Unjumble|Observe|Order)\b'
4
```

```text
awk '/<TabItem label="Activities"/,/<\/TabItem>/' /tmp/test-tab3-dedupe.mdx | grep -cE '<(Quiz|FillIn|MatchUp|TrueFalse|GroupSort|Unjumble|Observe|Order)\b'
0
```

```text
injected=['morning-sequence-fill', 'order-the-morning', 'reflexive-or-not-quiz', 'write-your-morning']
tab3=[]
overlap=[]
```

Vocab order in the regenerated MDX:

```text
3:<VocabCard client:only="react" ... />
5:<FlashcardDeck client:only="react" ... />
```

The mixed inline/workbook regression shape from the brief is covered by `tests/test_assemble_mdx_v7.py`: 2 inline activity components in Tab 1, 3 workbook components in Tab 3, and no inline-only titles in Tab 3.

## Diff hygiene

- 4 files changed.
- No generated artifacts.
- `.python-version`, `.yamllint`, and `.markdownlint.json` unchanged.
