### PR TITLE
feat(content-pipeline): add multimedia external resources

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -76,6 +76,7 @@ PYTHON_QG_GATE_ORDER = (
     "vesum_verified",
     "citations_resolve",
     "textbook_grounding",
+    "resources_search_attempted",
     "immersion_advisory",
     "l2_exposure_floor",
     "long_uk_ceiling",
@@ -122,6 +123,7 @@ TERMINAL_ZERO_RETRY_GATES = frozenset(
     {
         "component_props",
         "previously_passed_regression",
+        "resources_search_attempted",
     }
 )
 
@@ -191,8 +193,32 @@ WRITER_TOOL_NAMES = frozenset(
         "search_idioms",
         "query_pravopys",
         "query_wikipedia",
+        "search_external",
+        "search_images",
         "search_text",
         "check_modern_form",
+    }
+)
+RESOURCE_ROLES = frozenset(
+    {
+        "textbook",
+        "youtube",
+        "video",
+        "blog",
+        "podcast",
+        "audio",
+        "article",
+        "wiki",
+    }
+)
+MULTIMEDIA_SEARCH_TOOLS = frozenset(
+    {
+        "query_wikipedia",
+        "search_external",
+        "search_images",
+        "browser_search",
+        "search_query",
+        "web_search",
     }
 )
 REVIEW_AUDIT_TYPES = frozenset(
@@ -302,20 +328,21 @@ WRITER_JSON_SCHEMAS: dict[str, JsonArtifactSchema] = {
         root_type=list,
         required_item_fields={
             "title": str,
+            "role": str,
         },
-        # `author` and `role` added 2026-05-13 after codex-tools bakeoff
-        # produced these fields naturally for textbook references (e.g.,
-        # author="Караман", role="grammar-source"). Both are semantically
-        # useful and don't harm downstream consumers.
         optional_item_fields=frozenset({
             "notes",
+            "description",
             "source_ref",
             "packet_chunk_id",
             "url",
             "section",
             "page",
+            "pages",
             "author",
-            "role",
+            "channel",
+            "source",
+            "match_reason",
         }),
     ),
 }
@@ -622,7 +649,7 @@ def build_wiki_manifest_data(
         raise LinearPipelineError(
             f"No wiki article found for level={level_key!r}, slug={slug_key!r}"
         )
-    from scripts.build.phases.wiki_manifest import extract_manifest
+    from scripts.build.phases.wiki_manifest import extract_manifest, validate_manifest
 
     # Current module wiki layout resolves to one canonical article. If future
     # tracks add siblings, preserve deterministic order by merging list fields.
@@ -644,7 +671,11 @@ def build_wiki_manifest_data(
                 prefix = str(copied.get("id") or "").split("-", 1)[0] or key[:4]
                 copied["id"] = f"{prefix}-{len(merged[key]) + 1}"
                 merged[key].append(copied)
+        merged.setdefault("external_resources", [])
+        merged["external_resources"].extend(manifest.get("external_resources", []))
         merged["wiki_path"] = f"{merged['wiki_path']}; {manifest['wiki_path']}"
+    if merged is not None:
+        validate_manifest(merged)
     return merged or {}
 
 
@@ -3457,6 +3488,10 @@ def run_python_qg(
     )
     record("citations_resolve", _citation_gate(resources, plan))
     record("textbook_grounding", _textbook_grounding_gate(module_text, plan, module_dir))
+    record(
+        "resources_search_attempted",
+        _resources_search_attempted_gate(_load_writer_tool_calls(module_dir)),
+    )
     record("immersion_advisory", _advisory_immersion_pct(module_text, plan))
     record("l2_exposure_floor", _l2_exposure_floor_gate(module_text, plan))
     record("long_uk_ceiling", _long_uk_ceiling_gate(module_text, plan))
@@ -3658,6 +3693,18 @@ def _validate_writer_json_artifact(artifact: str, parsed: Any) -> None:
                 raise LinearPipelineError(
                     f"{artifact} schema validation failed: item {index} "
                     f"requires {field} as a non-empty string (got empty/whitespace)"
+                )
+        if artifact == "resources.yaml":
+            role = str(item.get("role") or "").strip()
+            if role not in RESOURCE_ROLES:
+                raise LinearPipelineError(
+                    f"{artifact} schema validation failed: item {index} "
+                    f"has invalid role {role!r}; allowed: {sorted(RESOURCE_ROLES)}"
+                )
+            if role != "textbook" and not str(item.get("url") or "").strip():
+                raise LinearPipelineError(
+                    f"{artifact} schema validation failed: item {index} "
+                    f"role {role!r} requires url"
                 )
 
 
@@ -4393,6 +4440,9 @@ def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> 
     }
     unknown = []
     for resource in resources:
+        role = str(resource.get("role") or "textbook").strip()
+        if role != "textbook":
+            continue
         source_ref = str(resource.get("source_ref") or resource.get("title") or "")
         normalized_ref = _normalize_citation_ref(source_ref)
         source_key = extract_citation_key(source_ref)
@@ -4608,6 +4658,24 @@ def _load_writer_tool_calls(module_dir: Path) -> list[dict[str, Any]]:
     for path in sorted(module_dir.glob("*.write.jsonl")):
         calls.extend(_load_jsonl_tool_calls(path))
     return calls
+
+
+def _resources_search_attempted_gate(
+    writer_tool_calls: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """HARD gate: writer must attempt at least one external-resource search."""
+    attempted = [
+        call
+        for call in writer_tool_calls
+        if _tool_name_from_call(call) in MULTIMEDIA_SEARCH_TOOLS
+    ]
+    search_tools_used = sorted({_tool_name_from_call(call) for call in attempted})
+    return {
+        "passed": bool(attempted),
+        "severity": "HARD",
+        "search_attempt_count": len(attempted),
+        "search_tools_used": search_tools_used,
+    }
 
 
 _MCP_SEARCH_TEXT_RESULT_RE = re.compile(

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -163,6 +163,7 @@ just because the example looks shorter that way.
 [
   {
     "title": "Караман Grade 10, p.176",
+    "role": "textbook",
     "notes": "Зворотні дієслова: суфікс -ся означає дію, спрямовану на себе."
   }
 ]
@@ -194,6 +195,29 @@ single largest reason A1 modules under-teach.
 ## Wiki Obligations Manifest
 
 {WIKI_MANIFEST}
+
+### External Resources — multimedia search obligation
+
+Every module MUST attempt to find at least one multimedia external resource
+(YouTube clip, blog post, podcast episode, video documentary, image gallery)
+relevant to the lesson topic. The agent MUST make at least ONE call to:
+- `mcp__sources__query_wikipedia` for Ukrainian Wikipedia context, OR
+- `mcp__sources__search_external` for blog/article search, OR
+- `mcp__sources__search_images` for image/gallery discovery, OR
+- browser-based search if available in this dispatch's tool set.
+
+If the Wiki Obligations Manifest's `external_resources` section is non-empty,
+those URLs are AUTHORITATIVE — include all of them in `resources.yaml` with the
+supplied role.
+
+If the search returns nothing usable, that is acceptable — but the search
+attempt MUST be recorded in the writer telemetry. The deterministic
+`resources_search_attempted` gate fails the build if the writer skipped the
+search entirely.
+
+In `resources.yaml`, every entry MUST have a `role` field. Valid roles:
+`textbook` (📚), `youtube` (📺), `video` (🎥), `blog` (📝), `podcast` (🎧),
+`audio` (🎧), `article` (📄), `wiki` (🔗).
 
 ### Phonetic rules — MUST emit IPA notation
 

--- a/scripts/build/phases/wiki_manifest.py
+++ b/scripts/build/phases/wiki_manifest.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 EXTERNAL_RESOURCE_ROLES = frozenset(
     {
@@ -239,8 +240,13 @@ def _normalize_external_role(raw_role: str | None, *, url: str | None = None) ->
     }
     if role in aliases:
         return aliases[role]
-    if url and ("youtube.com" in url or "youtu.be" in url):
-        return "youtube"
+    if url:
+        try:
+            host = (urlparse(url).hostname or "").lower()
+        except (ValueError, TypeError):
+            host = ""
+        if host == "youtube.com" or host.endswith(".youtube.com") or host == "youtu.be":
+            return "youtube"
     return "article" if url else "textbook"
 
 

--- a/scripts/build/phases/wiki_manifest.py
+++ b/scripts/build/phases/wiki_manifest.py
@@ -7,6 +7,54 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+EXTERNAL_RESOURCE_ROLES = frozenset(
+    {
+        "textbook",
+        "youtube",
+        "video",
+        "blog",
+        "podcast",
+        "audio",
+        "article",
+        "wiki",
+    }
+)
+
+WIKI_MANIFEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "slug",
+        "wiki_path",
+        "sequence_steps",
+        "l2_errors",
+        "phonetic_rules",
+        "decolonization_bans",
+        "external_resources",
+    ],
+    "properties": {
+        "slug": {"type": "string"},
+        "wiki_path": {"type": "string"},
+        "sequence_steps": {"type": "array"},
+        "l2_errors": {"type": "array"},
+        "phonetic_rules": {"type": "array"},
+        "decolonization_bans": {"type": "array"},
+        "external_resources": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["role", "title", "url", "author", "description"],
+                "properties": {
+                    "role": {"enum": sorted(EXTERNAL_RESOURCE_ROLES)},
+                    "title": {"type": "string"},
+                    "url": {"type": ["string", "null"]},
+                    "author": {"type": ["string", "null"]},
+                    "description": {"type": ["string", "null"]},
+                },
+            },
+        },
+    },
+}
+
 
 @dataclass(frozen=True, slots=True)
 class L2Error:
@@ -44,6 +92,15 @@ class DecolonizationBan:
 
 
 @dataclass(frozen=True, slots=True)
+class ExternalResource:
+    role: str
+    title: str
+    url: str | None
+    author: str | None
+    description: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class WikiManifest:
     slug: str
     wiki_path: str
@@ -51,16 +108,25 @@ class WikiManifest:
     l2_errors: list[L2Error]
     phonetic_rules: list[PhoneticRule]
     decolonization_bans: list[DecolonizationBan]
+    external_resources: list[ExternalResource]
 
 
 _SEQUENCE_HEADING_RE = re.compile(r"^##\s+Послідовність\s+(?:викладання|введення)\b", re.IGNORECASE)
 _L2_HEADING_RE = re.compile(r"^##\s+Типові\s+помилки\s+L2\b", re.IGNORECASE)
 _BAN_HEADING_RE = re.compile(r"^##\s+Деколонізаційні\s+застереження\b", re.IGNORECASE)
+_EXTERNAL_RESOURCES_HEADING_RE = re.compile(
+    r"^##\s+(?:Зовнішні\s+ресурси|External\s+Resources)\b",
+    re.IGNORECASE,
+)
 _ANY_H2_RE = re.compile(r"^##\s+\S")
 _STEP_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:\*\*)?Крок\s+(?P<num>\d+)\s*[:.]\s*(?P<title>.+?)\s*$")
 _META_SLUG_RE = re.compile(r"^\s*slug\s*:\s*(?P<slug>[-\w]+)\s*$", re.MULTILINE)
 _IPA_RE = re.compile(r"\[(?![SС]\d)(?=[^\]\n]*(?:[:'ʼ’]|[A-Za-z]))[^\]\n]{1,60}\]")
 _WRITTEN_RE = re.compile(r"(?<!\w)(-[\w'’ʼ-]{0,12}ся|-шся|-ться)(?!\w)", re.IGNORECASE)
+_MD_LINK_RE = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<url>[^)]+)\)")
+_BULLET_RESOURCE_RE = re.compile(
+    r"^\s*[-*]\s*(?:(?P<role>[A-Za-zА-ЯІЇЄҐа-яіїєґ-]+)\s*[:—-]\s*)?(?P<body>.+?)\s*$"
+)
 
 
 def extract_manifest(wiki_path: str | Path) -> dict[str, Any]:
@@ -77,8 +143,33 @@ def extract_manifest(wiki_path: str | Path) -> dict[str, Any]:
         l2_errors=_extract_l2_errors(lines),
         phonetic_rules=_extract_phonetic_rules(lines),
         decolonization_bans=_extract_decolonization_bans(lines),
+        external_resources=_extract_external_resources(lines),
     )
-    return asdict(manifest)
+    manifest_data = asdict(manifest)
+    validate_manifest(manifest_data)
+    return manifest_data
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    """Validate the manifest shape that writer/reviewer prompts consume."""
+    for key in WIKI_MANIFEST_SCHEMA["required"]:
+        if key not in manifest:
+            raise ValueError(f"wiki manifest missing required key: {key}")
+    for index, resource in enumerate(manifest["external_resources"], start=1):
+        if not isinstance(resource, dict):
+            raise ValueError(f"external_resources[{index}] must be an object")
+        for key in ("role", "title", "url", "author", "description"):
+            if key not in resource:
+                raise ValueError(f"external_resources[{index}] missing {key}")
+        role = resource["role"]
+        if role not in EXTERNAL_RESOURCE_ROLES:
+            raise ValueError(f"external_resources[{index}] has invalid role: {role}")
+        if not isinstance(resource["title"], str) or not resource["title"].strip():
+            raise ValueError(f"external_resources[{index}] requires non-empty title")
+        if role != "textbook" and not resource["url"]:
+            raise ValueError(
+                f"external_resources[{index}] role {role!r} requires url"
+            )
 
 
 def _extract_slug(text: str, path: Path) -> str:
@@ -114,6 +205,147 @@ def _clean_inline(text: str) -> str:
     text = re.sub(r"\*(.*?)\*", r"\1", text)
     text = re.sub(r"\s+", " ", text)
     return text.strip()
+
+
+def _clean_optional(text: str | None) -> str | None:
+    if text is None:
+        return None
+    cleaned = _clean_inline(text)
+    return cleaned or None
+
+
+def _normalize_external_role(raw_role: str | None, *, url: str | None = None) -> str:
+    role = _clean_inline(raw_role or "").casefold()
+    aliases = {
+        "book": "textbook",
+        "books": "textbook",
+        "підручник": "textbook",
+        "textbook": "textbook",
+        "youtube": "youtube",
+        "ютуб": "youtube",
+        "відео": "video",
+        "video": "video",
+        "blog": "blog",
+        "блог": "blog",
+        "podcast": "podcast",
+        "подкаст": "podcast",
+        "audio": "audio",
+        "аудіо": "audio",
+        "article": "article",
+        "стаття": "article",
+        "wiki": "wiki",
+        "wikipedia": "wiki",
+        "вікіпедія": "wiki",
+    }
+    if role in aliases:
+        return aliases[role]
+    if url and ("youtube.com" in url or "youtu.be" in url):
+        return "youtube"
+    return "article" if url else "textbook"
+
+
+def _extract_markdown_link(value: str) -> tuple[str, str | None]:
+    match = _MD_LINK_RE.search(value)
+    if not match:
+        return value, None
+    return match.group("title"), match.group("url").strip() or None
+
+
+def _external_resource_from_cells(
+    row: dict[str, str],
+    *,
+    fallback_role: str | None = None,
+) -> ExternalResource | None:
+    title_raw = (
+        row.get("title")
+        or row.get("назва")
+        or row.get("ресурс")
+        or row.get("resource")
+        or ""
+    )
+    title_from_link, link_url = _extract_markdown_link(title_raw)
+    url = _clean_optional(row.get("url") or row.get("посилання") or link_url)
+    role = _normalize_external_role(row.get("role") or row.get("роль") or fallback_role, url=url)
+    title = _clean_inline(title_from_link)
+    if not title:
+        return None
+    return ExternalResource(
+        role=role,
+        title=title,
+        url=url,
+        author=_clean_optional(row.get("author") or row.get("автор")),
+        description=_clean_optional(
+            row.get("description") or row.get("опис") or row.get("notes") or row.get("нотатки")
+        ),
+    )
+
+
+def _extract_external_resources(lines: list[str]) -> list[ExternalResource]:
+    span = _section_span(lines, _EXTERNAL_RESOURCES_HEADING_RE)
+    if not span:
+        return []
+    start, end = span
+    table_resources = _extract_external_resources_table(lines[start + 1 : end])
+    if table_resources:
+        return table_resources
+    return _extract_external_resources_bullets(lines[start + 1 : end])
+
+
+def _extract_external_resources_table(lines: list[str]) -> list[ExternalResource]:
+    resources: list[ExternalResource] = []
+    headers: list[str] = []
+    table_started = False
+    for line in lines:
+        cells = _parse_table_row(line)
+        if not cells:
+            if table_started:
+                break
+            continue
+        if _is_separator_row(cells):
+            table_started = True
+            continue
+        lowered = [cell.casefold() for cell in cells]
+        if not headers:
+            if any(cell in {"title", "назва", "ресурс", "resource"} for cell in lowered):
+                headers = lowered
+                table_started = True
+            continue
+        table_started = True
+        row = {headers[index]: cell for index, cell in enumerate(cells[: len(headers)])}
+        resource = _external_resource_from_cells(row)
+        if resource is not None:
+            resources.append(resource)
+    return resources
+
+
+def _extract_external_resources_bullets(lines: list[str]) -> list[ExternalResource]:
+    resources: list[ExternalResource] = []
+    for line in lines:
+        match = _BULLET_RESOURCE_RE.match(line)
+        if not match:
+            continue
+        body = match.group("body")
+        title_raw, url = _extract_markdown_link(body)
+        parts = [part.strip() for part in re.split(r"\s+[—–-]\s+", body, maxsplit=2)]
+        if url:
+            author = parts[1] if len(parts) > 1 else None
+            description = parts[2] if len(parts) > 2 else None
+        else:
+            title_raw = parts[0]
+            author = parts[1] if len(parts) > 1 else None
+            description = parts[2] if len(parts) > 2 else None
+        resource = _external_resource_from_cells(
+            {
+                "role": match.group("role") or "",
+                "title": title_raw,
+                "url": url or "",
+                "author": author or "",
+                "description": description or "",
+            }
+        )
+        if resource is not None:
+            resources.append(resource)
+    return resources
 
 
 def _extract_sequence_steps(lines: list[str]) -> list[SequenceStep]:

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -245,133 +245,142 @@ def merge_resources(curated: dict, discovery: dict) -> dict:
     return merged
 
 
-def format_resources_for_mdx(resources: dict, is_ukrainian_forced: bool = False) -> str:
-    """Format external resources for MDX output (emoji template).
+RESOURCE_ROLE_ICONS = {
+    'textbook': '📚',
+    'book': '📚',
+    'youtube': '📺',
+    'video': '🎥',
+    'blog': '📝',
+    'podcast': '🎧',
+    'audio': '🎧',
+    'article': '📄',
+    'wiki': '🔗',
+    'website': '🔗',
+}
 
-    Args:
-        resources: Dict with keys: podcasts, youtube, articles, books, websites
-        is_ukrainian_forced: Whether to force Ukrainian headers
+RESOURCE_GROUPS = (
+    ('books', '📚', 'Books', 'Книги', {'textbook', 'book'}),
+    ('videos', '📺', 'Videos', 'Відео', {'youtube', 'video'}),
+    ('articles', '📝', 'Articles', 'Статті', {'blog', 'article'}),
+    ('audio', '🎧', 'Audio', 'Аудіо', {'podcast', 'audio'}),
+    ('online', '🔗', 'Online resources', 'Онлайн-ресурси', {'wiki', 'website'}),
+)
 
-    Returns:
-        Formatted markdown string for [!resources] callout block
-    """
-    if not resources or not any(resources.get(t) for t in ['podcasts', 'youtube', 'articles', 'books', 'websites']):
+LEGACY_RESOURCE_ROLE = {
+    'podcasts': 'podcast',
+    'youtube': 'youtube',
+    'articles': 'article',
+    'books': 'textbook',
+    'websites': 'wiki',
+}
+
+
+def _resource_role(item: dict, legacy_bucket: str | None = None) -> str:
+    role = str(item.get('role') or '').strip().lower()
+    if role:
+        return role
+    if legacy_bucket is not None:
+        return LEGACY_RESOURCE_ROLE.get(legacy_bucket, legacy_bucket)
+    return 'textbook'
+
+
+def _iter_resources_by_role(resources: dict | list) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = {group_id: [] for group_id, *_ in RESOURCE_GROUPS}
+    if isinstance(resources, list):
+        iterable = [(None, resources)]
+    else:
+        iterable = [(key, value) for key, value in resources.items()]
+
+    role_to_group = {
+        role: group_id
+        for group_id, _icon, _en, _uk, roles in RESOURCE_GROUPS
+        for role in roles
+    }
+    for bucket, items in iterable:
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            role = _resource_role(item, bucket)
+            group_id = role_to_group.get(role, 'online')
+            grouped[group_id].append({**item, 'role': role})
+    return grouped
+
+
+def _resource_sort_key(item: dict) -> tuple[int, int, str]:
+    priority_map = {1: 5, 2: 4, 3: 3, 4: 2, 5: 1, None: 0}
+    relevance_priority = {'high': 3, 'medium': 2, 'low': 1}
+    return (
+        -priority_map.get(item.get('priority'), 0),
+        -relevance_priority.get(item.get('relevance', 'low'), 0),
+        str(item.get('title', '')).lower(),
+    )
+
+
+def _format_textbook_resource(item: dict) -> list[str]:
+    title = str(item.get('title') or 'Unknown').strip()
+    author = str(item.get('author') or '').strip()
+    pages = item.get('pages') or item.get('page') or ''
+    desc = str(item.get('description') or item.get('notes') or '').strip()
+    source_ref = str(item.get('source_ref') or title).strip()
+
+    display_title = source_ref
+    if pages and str(pages) not in display_title:
+        display_title = f"{display_title}, p. {pages}"
+    if author and not display_title.startswith(author):
+        display_title = f"{author} — {display_title}"
+
+    lines = [f"> - 📚 **{display_title}**"]
+    if desc:
+        lines.append(f">   {desc}")
+    return lines
+
+
+def _format_linked_resource(item: dict) -> str:
+    role = _resource_role(item)
+    icon = RESOURCE_ROLE_ICONS.get(role, '🔗')
+    title = str(item.get('title') or 'Unknown').strip()
+    url = validate_and_clean_url(str(item.get('url') or ''), title)
+    desc = (
+        item.get('match_reason')
+        or item.get('description')
+        or item.get('notes')
+        or item.get('channel')
+        or item.get('source')
+        or ''
+    )
+    label = f"[{title}]({url})" if url else f"**{title}**"
+    suffix = f" — {desc}" if desc else ""
+    return f"> - {icon} {label}{suffix}"
+
+
+def format_resources_for_mdx(resources: dict | list, is_ukrainian_forced: bool = False) -> str:
+    """Format external resources for MDX output, grouped by resource role."""
+    if not resources:
+        return ""
+
+    grouped = _iter_resources_by_role(resources)
+    if not any(grouped.values()):
         return ""
 
     header_title = "Зовнішні ресурси" if is_ukrainian_forced else "External Resources"
 
-    lines = []
-    lines.append(f"> [!resources] \U0001f517 {header_title}")
-    lines.append(">")
+    lines = [f"> [!resources] 🔗 {header_title}", ">"]
 
-    # Emoji icons per resource type
-    display_names = {
-        'Podcasts': 'Подкасти',
-        'YouTube': 'YouTube',
-        'Articles': 'Статті',
-        'Books': 'Книги',
-        'Websites': 'Сайти'
-    }
-
-    resource_config = [
-        ('podcasts', '\U0001f3a7', 'Podcasts'),
-        ('youtube', '\U0001f4fa', 'YouTube'),
-        ('articles', '\U0001f4d6', 'Articles'),
-        ('books', '\U0001f4da', 'Books'),
-        ('websites', '\U0001f310', 'Websites')
-    ]
-    role_icons = {
-        'textbook': '\U0001f4da',
-        'book': '\U0001f4da',
-        'wiki': '\U0001f517',
-        'website': '\U0001f310',
-        'article': '\U0001f4d6',
-        'audio': '\U0001f3a7',
-        'podcast': '\U0001f3a7',
-        'video': '\U0001f4fa',
-        'youtube': '\U0001f4fa',
-    }
-
-    # Priority and relevance maps for sorting
-    priority_map = {1: 5, 2: 4, 3: 3, 4: 2, 5: 1, None: 0}
-    relevance_priority = {'high': 3, 'medium': 2, 'low': 1}
-
-    for resource_type, icon, display_name in resource_config:
-        items = resources.get(resource_type, [])
+    for group_id, icon, english_name, ukrainian_name, _roles in RESOURCE_GROUPS:
+        items = grouped[group_id]
         if not items:
             continue
-
-        final_display_name = display_names.get(display_name, display_name) if is_ukrainian_forced else display_name
-
-        # Sort by: priority (1->5, highest first) -> relevance (high->low) -> title (A->Z)
-        sorted_items = sorted(
-            items,
-            key=lambda x: (
-                -priority_map.get(x.get('priority'), 0),
-                -relevance_priority.get(x.get('relevance', 'low'), 0),
-                x.get('title', '').lower()
-            )
-        )
-
-        # Add section header
-        lines.append(f"> **{icon} {final_display_name}:**")
-
-        # Format each item
-        for item in sorted_items:
-            title = item.get('title', 'Unknown')
-            url = validate_and_clean_url(item.get('url', ''), title)
-
-            if resource_type == 'podcasts':
-                desc = item.get('match_reason') or item.get('description', '')
-                if desc:
-                    lines.append(f"> - [{title}]({url}) \u2014 {desc}")
-                else:
-                    lines.append(f"> - [{title}]({url})")
-
-            elif resource_type == 'articles':
-                source = item.get('source', '')
-                desc = item.get('description', source)
-                if desc:
-                    lines.append(f"> - [{title}]({url}) \u2014 {desc}")
-                else:
-                    lines.append(f"> - [{title}]({url})")
-
-            elif resource_type == 'books':
-                role = item.get('role') or 'textbook'
-                item_icon = role_icons.get(str(role).lower(), icon)
-                author = item.get('author', '').strip()
-                pages = item.get('pages', '')
-                desc = item.get('description', '')
-                source_ref = item.get('source_ref') or title
-
-                display_title = source_ref
-                if pages and str(pages) not in display_title:
-                    display_title = f"{display_title}, p. {pages}"
-                if author and not display_title.startswith(author):
-                    display_title = f"{author} \u2014 {display_title}"
-                lines.append(f"> - {item_icon} **{display_title}**")
-                if desc:
-                    lines.append(f">   {desc}")
-
-            elif resource_type == 'youtube':
-                channel = item.get('channel', '')
-                if channel:
-                    lines.append(f"> - [{title}]({url}) \u2014 {channel}")
-                else:
-                    lines.append(f"> - [{title}]({url})")
-
-            elif resource_type == 'websites':
-                source = item.get('source', '')
-                desc = item.get('description', source)
-                if desc:
-                    lines.append(f"> - [{title}]({url}) \u2014 {desc}")
-                else:
-                    lines.append(f"> - [{title}]({url})")
-
-        # Add blank line between sections
+        display_name = ukrainian_name if is_ukrainian_forced else english_name
+        lines.append(f"> **{icon} {display_name}:**")
+        for item in sorted(items, key=_resource_sort_key):
+            if _resource_role(item) in {'textbook', 'book'}:
+                lines.extend(_format_textbook_resource(item))
+            else:
+                lines.append(_format_linked_resource(item))
         lines.append(">")
 
-    # Remove trailing blank line
     if lines and lines[-1] == ">":
         lines.pop()
 

--- a/tests/test_generate_mdx_v7_resources_vocab.py
+++ b/tests/test_generate_mdx_v7_resources_vocab.py
@@ -56,6 +56,61 @@ def test_format_resources_for_mdx_uses_author_description_and_role_icon():
     })
 
     assert "by Unknown" not in mdx
+    assert "📚 Books" in mdx
+    assert "🔗 Online resources" in mdx
     assert "📚 **Караман Grade 10, p.176**" in mdx
     assert "Reflexive verbs with -ся." in mdx
-    assert "🔗 **Вікіпедія — Ukrainian Wikipedia**" in mdx
+    assert "🔗 **Wikipedia overview**" in mdx
+
+
+def test_format_resources_for_mdx_groups_mixed_roles_with_icons():
+    mdx = format_resources_for_mdx([
+        {
+            "title": "Караман Grade 10, p.176",
+            "author": "Караман",
+            "pages": "176",
+            "description": "Reflexive verbs with -ся.",
+            "role": "textbook",
+        },
+        {
+            "title": "Morning routine clip",
+            "url": "https://www.youtube.com/watch?v=abc12345678",
+            "channel": "Speak Ukrainian",
+            "role": "youtube",
+        },
+        {
+            "title": "Grammar documentary",
+            "url": "https://example.com/video",
+            "description": "Documentary excerpt.",
+            "role": "video",
+        },
+        {
+            "title": "Morning vocabulary blog",
+            "url": "https://example.com/blog",
+            "description": "Blog post.",
+            "role": "blog",
+        },
+        {
+            "title": "Audio drill",
+            "url": "https://example.com/audio",
+            "description": "Pronunciation practice.",
+            "role": "audio",
+        },
+        {
+            "title": "Wikipedia article",
+            "url": "https://uk.wikipedia.org/wiki/Ранок",
+            "role": "wiki",
+        },
+    ])
+
+    assert "📚 Books" in mdx
+    assert "📺 Videos" in mdx
+    assert "📝 Articles" in mdx
+    assert "🎧 Audio" in mdx
+    assert "🔗 Online resources" in mdx
+    assert "📚 **Караман Grade 10, p.176**" in mdx
+    assert "📺 [Morning routine clip](https://www.youtube.com/watch?v=abc12345678)" in mdx
+    assert "🎥 [Grammar documentary](https://example.com/video)" in mdx
+    assert "📝 [Morning vocabulary blog](https://example.com/blog)" in mdx
+    assert "🎧 [Audio drill](https://example.com/audio)" in mdx
+    assert "🔗 [Wikipedia article](https://uk.wikipedia.org/wiki/Ранок)" in mdx

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -72,7 +72,7 @@ def _writer_response() -> str:
 
 ```json file=resources.yaml
 [
-  {{"title": "Fixture source", "notes": "Test source."}}
+  {{"title": "Fixture source", "role": "textbook", "notes": "Test source."}}
 ]
 ```
 

--- a/tests/test_linear_pipeline_wiki_coverage.py
+++ b/tests/test_linear_pipeline_wiki_coverage.py
@@ -26,12 +26,22 @@ def test_writer_prompt_places_manifest_before_module_context() -> None:
         plan,
         plan_path.read_text(encoding="utf-8"),
         "Knowledge packet stub.",
-        {"slug": "my-morning", "sequence_steps": [], "l2_errors": [], "phonetic_rules": [], "decolonization_bans": []},
+        {
+            "slug": "my-morning",
+            "sequence_steps": [],
+            "l2_errors": [],
+            "phonetic_rules": [],
+            "decolonization_bans": [],
+            "external_resources": [],
+        },
     )
     rendered = linear_pipeline.render_phase_prompt(WRITER_TEMPLATE, context)
 
     assert rendered.index("## LESSON SOURCE") < rendered.index("## Module Context")
     assert rendered.index("## Wiki Obligations Manifest") < rendered.index("## Module Context")
+    assert "External Resources — multimedia search obligation" in rendered
+    assert "resources_search_attempted" in rendered
+    assert "mcp__sources__search_external" in rendered
     assert "<implementation_map>" in rendered
     assert "Full Wiki Context (source of truth for citations)" in rendered
 
@@ -42,6 +52,7 @@ def test_build_wiki_manifest_renders_my_morning_json() -> None:
     assert '"slug": "my-morning"' in manifest
     assert '"id": "err-1"' in manifest
     assert '"id": "step-5"' in manifest
+    assert '"external_resources": []' in manifest
 
 
 def test_wiki_coverage_review_prompt_receives_manifest_and_gate() -> None:

--- a/tests/test_resources_search_gate.py
+++ b/tests/test_resources_search_gate.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from scripts.build import linear_pipeline
+
+
+def test_resources_search_attempted_gate_rejects_missing_search() -> None:
+    result = linear_pipeline._resources_search_attempted_gate(
+        [
+            {"tool": "mcp__sources__verify_words", "args": {"words": ["ранок"]}},
+            {"name": "mcp__sources__search_text", "arguments": {"query": "Караман"}},
+        ]
+    )
+
+    assert result["passed"] is False
+    assert result["severity"] == "HARD"
+    assert result["search_attempt_count"] == 0
+    assert result["search_tools_used"] == []
+
+
+def test_resources_search_attempted_gate_accepts_multimedia_search() -> None:
+    result = linear_pipeline._resources_search_attempted_gate(
+        [
+            {
+                "tool_name": "mcp__sources__search_external",
+                "args": {"query": "ранкова рутина українська мова відео"},
+            }
+        ]
+    )
+
+    assert result["passed"] is True
+    assert result["search_attempt_count"] == 1
+    assert result["search_tools_used"] == ["search_external"]

--- a/tests/test_wiki_manifest.py
+++ b/tests/test_wiki_manifest.py
@@ -2,9 +2,27 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.build.phases.wiki_manifest import WIKI_MANIFEST_SCHEMA, extract_manifest
+from scripts.build.phases.wiki_manifest import (
+    WIKI_MANIFEST_SCHEMA,
+    _normalize_external_role,
+    extract_manifest,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_normalize_external_role_rejects_substring_only_youtube_match() -> None:
+    """py/incomplete-url-substring-sanitization regression: use host check, not substring."""
+    # Real YouTube hosts → "youtube"
+    assert _normalize_external_role(None, url="https://www.youtube.com/watch?v=x") == "youtube"
+    assert _normalize_external_role(None, url="https://youtube.com/watch?v=x") == "youtube"
+    assert _normalize_external_role(None, url="https://youtu.be/abc") == "youtube"
+    # Attack patterns where "youtube.com" appears in path or query → must NOT match
+    assert _normalize_external_role(None, url="https://evil.com/youtube.com/watch") != "youtube"
+    assert _normalize_external_role(None, url="https://evil.com?host=youtube.com") != "youtube"
+    assert _normalize_external_role(None, url="https://youtube.com.evil.com/") != "youtube"
+    # Malformed URLs must not crash; fall through to article since URL is non-empty
+    assert _normalize_external_role(None, url="not a url") == "article"
 
 
 def test_my_morning_manifest_extracts_required_obligations() -> None:

--- a/tests/test_wiki_manifest.py
+++ b/tests/test_wiki_manifest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.build.phases.wiki_manifest import extract_manifest
+from scripts.build.phases.wiki_manifest import WIKI_MANIFEST_SCHEMA, extract_manifest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_my_morning_manifest_extracts_required_obligations() -> None:
     manifest = extract_manifest(ROOT / "wiki/pedagogy/a1/my-morning.md")
 
+    assert manifest["external_resources"] == []
     assert len(manifest["l2_errors"]) == 6
     assert len(manifest["sequence_steps"]) == 5
     incorrect = [item["incorrect"] for item in manifest["l2_errors"]]
@@ -67,3 +68,53 @@ def test_manifest_accepts_sequence_heading_variants(tmp_path: Path) -> None:
     assert manifest["sequence_steps"][0]["heading"] == "Крок 1: Перша дія."
     assert manifest["l2_errors"][0]["incorrect"] == "Я є студент."
 
+
+def test_manifest_extracts_external_resources_section(tmp_path: Path) -> None:
+    wiki = tmp_path / "external.md"
+    wiki.write_text(
+        """# External resources fixture
+
+slug: external-fixture
+
+## Зовнішні ресурси
+
+| Роль | Назва | URL | Автор | Опис |
+|---|---|---|---|---|
+| youtube | [Ukrainian morning routine](https://youtu.be/abc12345678) | | Speak Ukrainian | Short listening clip. |
+| blog | Morning vocabulary | https://example.com/morning | Ukrainian Lessons | Blog explainer. |
+| textbook | Караман Grade 10, p.176 | | Караман | Зворотні дієслова. |
+
+## Послідовність викладання
+
+Крок 1: Перша дія.
+Треба показати форму.
+""",
+        encoding="utf-8",
+    )
+
+    manifest = extract_manifest(wiki)
+
+    assert "external_resources" in WIKI_MANIFEST_SCHEMA["required"]
+    assert manifest["external_resources"] == [
+        {
+            "role": "youtube",
+            "title": "Ukrainian morning routine",
+            "url": "https://youtu.be/abc12345678",
+            "author": "Speak Ukrainian",
+            "description": "Short listening clip.",
+        },
+        {
+            "role": "blog",
+            "title": "Morning vocabulary",
+            "url": "https://example.com/morning",
+            "author": "Ukrainian Lessons",
+            "description": "Blog explainer.",
+        },
+        {
+            "role": "textbook",
+            "title": "Караман Grade 10, p.176",
+            "url": None,
+            "author": "Караман",
+            "description": "Зворотні дієслова.",
+        },
+    ]


### PR DESCRIPTION
Closes #1932

## Summary
- Adds wiki manifest `external_resources` extraction/schema validation from `## Зовнішні ресурси`.
- Adds writer prompt multimedia-search obligations and `resources.yaml` role contract.
- Groups Resources tab output by role with 📚/📺/🎥/📝/🎧/📄/🔗 icons.
- Adds hard `resources_search_attempted` Python QG gate from writer telemetry.

## Verification
- `grep -n 'external_resources' scripts/build/phases/wiki_manifest.py` includes `32:        "external_resources",` and `41:        "external_resources": {`.\n- `grep -inE 'youtube|blog|video|podcast|multimedia|external.search|search_external' scripts/build/phases/linear-write.md` includes `199:### External Resources — multimedia search obligation` and `205:- `mcp__sources__search_external` for blog/article search, OR`.\n- Gate fixture: `tests/test_resources_search_gate.py:31:    assert result["search_attempt_count"] == 1` and `tests/test_resources_search_gate.py:32:    assert result["search_tools_used"] == ["search_external"]`.\n- Renderer fixture: `tests/test_generate_mdx_v7_resources_vocab.py:106:    assert "📚 Books" in mdx`, `107:    assert "📺 Videos" in mdx`, `113:    assert "🎥 [Grammar documentary](https://example.com/video)" in mdx`.\n- `pytest tests/test_wiki_manifest*.py tests/test_writer*.py tests/test_generate_mdx_v7_resources_vocab.py tests/test_resources_search_gate.py -x` -> `40 passed in 0.35s`.\n- `ruff check scripts/build scripts/generate_mdx` -> `All checks passed!`.\n- a1/my-morning smoke assemble to `/tmp/my-morning-multimedia-resources.mdx`: output length `18587`; `rg` showed `217::::info[🎧 🔗 External Resources]` and `219:3:**📚 Books:**`.\n\n## Notes\n- Did not auto-merge.\n