### PR TITLE
docs(audit): plan reviews for first 7 A1 modules (sequences 1-7)

### DIFF
--- a/curriculum/l2-uk-en/a1/audit/checkpoint-first-contact-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/checkpoint-first-contact-plan-review.md
@@ -1,0 +1,76 @@
+# Plan Review: checkpoint-first-contact
+
+**Track:** a1 | **Sequence:** 7 | **Version:** 1.2.1 | **Lifecycle:** locked
+**Verdict:** NEEDS FIXES (one MEDIUM about checkpoint word_target inconsistency across A1)
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 review module (no new grammar). Cross-references all phonetics/morphology rules taught in M1–M6.
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | **MEDIUM** | Plan: 1200; **skill prompt table** says `A1-checkpoint: 1000`; **actual config** says `A1-checkpoint: 1000` (`scripts/audit/config.py:719-720`), BUT current `get_word_target` lookup uses `focus` key (plan focus is `review`, not `checkpoint`), so config falls back to A1=1200. So plan-vs-config matches **as configured**, but plan-vs-policy-intent does not. See cross-cutting in summary. |
+| section_budgets | PASS | Sum = 200+250+200+400+150 = 1200 (exact match) |
+| required_fields | PASS | All present |
+| version_string | PASS | `version: '1.2.1'` (explicit string) |
+| no Latin in Cyrillic | PASS | Scan clean (v1.2.1 removed 6 Latin tokens flagged in cross-agent review per #1392 D1/D7) |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| New grammar | N/A — review module | — | — | PASS — "Нової граматики немає" explicit |
+| Recap of: Це + іменник, nullsubject (Я — студент), у мене є, мій/моя/моє, як тебе/вас звати, звідки + country | All previously introduced in M1–M6 | A1 | A1 review | PASS |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Source | Correct? | Notes |
+|---------|--------|----------|-------|
+| Bundling 6 key constructions for synthesis | ULP Ep.10 (cited) | YES | Anna's Episode 10 is the canonical review-of-1-9 episode and the plan correctly anchors here |
+| Author-note enumerating 6 forbidden Surzhyk/calque forms (`папа`, `фамілія`, `Моє ім'я є...`, `Я є студент`, `Я маю 25 років`, `Здрастуйте/Пока`) | Wiki "Типові помилки L2" (cited) | YES | All 6 are real L2 issues at this level |
+| Two-speaker dialogue at language-meetup setting (ти-register) | Pragmatic alignment | YES | Setting reframed in v1.2.0 from formal conference to peer-meetup so ти-register and family-topic content cohere |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| Required: "All vocabulary from №1–6 is recycled" | Inherits all M1–M6 vocab | OK |
+| Recommended: ім'я, прізвище, знайомство, професія, національність, походження, Вітаю, Дуже приємно, Мені теж, тато | All FOUND | OK |
+| Russianism counter-pairs in fill-in: Здрастуйте, папа, Моє ім'я є Іван, Я є студент, Я маю 25 років, фамілія, Пока | **папа FOUND, фамілія FOUND (both are valid Ukrainian words but used differently)**; others NOT FOUND | See HIGH |
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+1. **`Мій {тато|папа} — інженер.`** (activity_hints[3].items[1]). `папа` IS in VESUM (2 matches, no restrictive tags), and the **my-family plan (M6) v1.4.0 explicitly dropped this exact pair from its Surzhyk drill** after Codex AC-3 adversarial review, citing "VESUM lists `папа` without restrictive tags, so framing it as a dictionary-backed error would be overreach." Including it here as a "wrong" form contradicts the M6 audit conclusion and inverts the team's own discipline. Suggested fix: remove this row OR reframe as a register preference (тато is more common in colloquial register), matching M6's framing. Items count drops from 7 to 6 (still meets minimum).
+2. **`Як твоє {прізвище|фамілія}?`** (activity_hints[3].items[5]). `фамілія` IS in VESUM but means "family" (archaic, low-frequency in modern usage). Calling someone's surname `фамілія` IS Russian-influenced (Russian фамилия = surname), so this Surzhyk flag IS defensible — but the author-note should clarify "фамілія exists but means «family» archaically; for surname use `прізвище`." Current framing risks teaching that the word doesn't exist at all.
+
+### MEDIUM (fix if possible)
+1. **word_target mismatch with skill policy.** Per the plan-review skill prompt table, A1-checkpoint target is 1000, but the plan has 1200. The actual `scripts/audit/config.py` enforces 1000 only when `focus: checkpoint` is set; since this plan has `focus: review`, the audit currently accepts 1200. The inconsistency is curriculum-wide (5 of 8 A1 checkpoints use 1200, 3 use 1000 — see Suggested Fixes). This is a **cross-cutting policy decision**, not a single-plan defect.
+
+### LOW (informational)
+1. Plan correctly notes the deliberate omission of wiki row 8 (`Я із Росії`) from the drill — sensitive contextual call to avoid teaching that pattern as an item, even as a negative example. Good editorial judgment.
+2. The author-note in Діалог section (forbidden Surzhyk + ти-register consistency) is excellent writer guardrails.
+3. v1.2.1 cleanup of 6 Latin tokens (per AC-3) is a sign of good adversarial-review hygiene.
+
+## Suggested Fixes
+
+```yaml
+# activity_hints[3].items — remove the тато/папа row; clarify прізвище/фамілія
+items:
+  - '{Добрий день|Здрастуйте}! Мене звати Оксана.'
+  - '{Мене звати Іван|Моє ім''я є Іван}.'
+  - Я {студент|є студент}.
+  - '{Мені 25 років|Я маю 25 років}.'
+  - Як твоє {прізвище|фамілія}?  # keep — defensible Surzhyk pattern
+  - — Дякую! — Будь ласка. — {До побачення|Пока}!
+# (6 items, matches min_items_per_activity)
+
+# vocabulary_hints.recommended — adjust author-note framing for тато
+# old:
+- тато (dad — standard; NOT the Russianism `папа`)
+# new:
+- тато (dad — preferred colloquial register; `папа` is also Ukrainian but more child-register / familial)
+
+# CROSS-CUTTING: word_target — see summary roll-up; recommend curriculum-wide audit decision before this single plan changes.
+```
+
+## Verdict
+NEEDS_FIX. One HIGH item (`тато/папа` Surzhyk-pair contradiction with M6's documented discipline) must be resolved before re-build to keep editorial line consistent. The MEDIUM word_target issue is curriculum-wide policy, not a single-plan blocker — flag in summary for orchestrator decision. Once `тато/папа` is removed and `фамілія` framing is clarified, plan is build-ready.

--- a/curriculum/l2-uk-en/a1/audit/first-7-summary-2026-05-13.md
+++ b/curriculum/l2-uk-en/a1/audit/first-7-summary-2026-05-13.md
@@ -1,0 +1,162 @@
+# A1 Plan Review — Summary Roll-Up (Sequences 1–7)
+
+**Date:** 2026-05-13
+**Reviewer:** claude-opus-4-7-xhigh (plan-review skill)
+**Scope:** A1 sequences 1–7 (slugs: `sounds-letters-and-hello`, `reading-ukrainian`, `special-signs`, `stress-and-melody`, `who-am-i`, `my-family`, `checkpoint-first-contact`)
+**Mode:** Review-only — no plan YAMLs modified.
+
+## Authority
+
+- **State Standard 2024 mapping**: `docs/l2-uk-en/state-standard-2024-mapping.yaml` (read once before review). Key A1 constraints applied throughout: nominative only as core; accusative `first_module: 11`; locative `first_module: 13`; dative/instrumental/genitive **NOT** at A1; imperative 2nd-person only at A1 (1pl `читаймо` and 3rd-person `хай/нехай` belong to A2).
+- **Config**: `scripts/audit/config.py:LEVEL_CONFIG` — A1: 1200 words; A1-checkpoint: 1000 words.
+- **RAG**: VESUM `mcp__sources__verify_words` (53-word batch verification), Антоненко-Давидович `mcp__sources__search_style_guide` (limited coverage 46%), NUS textbook citations cross-referenced inline.
+
+## PASS / FAIL / NEEDS-FIX Table
+
+| seq | slug | verdict | severity-summary | LOCK_NOW | NEEDS_FIX | NEEDS_REVISION |
+|-----|------|---------|------------------|----------|-----------|----------------|
+| 1 | sounds-letters-and-hello | NEEDS_FIX | 2 MEDIUM (1pl imperative `Прочитаймо` out-of-scope; `ирій` too rare for И) | | ✅ | |
+| 2 | reading-ukrainian | PASS | 0 issues (1 LOW info) | ✅ | | |
+| 3 | special-signs | PASS | 0 issues (2 LOW info — exemplary author-note) | ✅ | | |
+| 4 | stress-and-melody | PASS | 1 MEDIUM (forward-looking TTS note re: `Як справи?` contour exception) | ✅ | | |
+| 5 | who-am-i | NEEDS_FIX | 1 HIGH (Підсумок section `words: 0`); 3 MEDIUM (acc/gen as frozen chunks — accepted) | | ✅ | |
+| 6 | my-family | PASS (borderline) | 1 MEDIUM (`муж/чоловік` Surzhyk-framing inconsistent with `папа/тато` discipline) | ✅ | (✅ if strict) | |
+| 7 | checkpoint-first-contact | NEEDS_FIX | 1 HIGH (`тато/папа` pair contradicts M6's documented discipline); 1 MEDIUM (curriculum-wide checkpoint word_target inconsistency) | | ✅ | |
+
+**Tally:** PASS = 3 (or 4 with M6 lenient); NEEDS_FIX = 3 (or 4 with M6 strict); NEEDS_REVISION = 0.
+
+## CRITICAL Issues
+**None.** All seven plans meet all CRITICAL gates (word_target, section_budgets within ±10%, required_fields complete, version-string, no-Latin-in-Cyrillic).
+
+## HIGH Issues (Grouped by Pattern)
+
+### H-1 — `тато/папа` Surzhyk-framing contradicts dictionary evidence (1 plan)
+- **M7 (checkpoint-first-contact)** activity_hints[3].items[1]: `Мій {тато|папа} — інженер.` frames `папа` as a wrong form.
+- `папа` IS in VESUM (2 matches, no restrictive tags). **M6 (my-family) v1.4.0 explicitly dropped this exact pair** after Codex AC-3 adversarial review with the reasoning: "VESUM lists `папа` without restrictive tags, so framing it as a dictionary-backed error would be overreach."
+- M7 was reviewed in the same scale batch as M6 (2026-04-23) but contains a contradiction with its own batch's discipline.
+- **Fix:** remove the тато/папа row from M7's drill, OR reframe as register preference (mirror M6's `тато is preferred colloquial register; папа is also Ukrainian but more child-register`).
+
+### H-2 — Zero-budget section structurally anomalous (1 plan)
+- **M5 (who-am-i)** content_outline[6] (`Підсумок`) has `words: 0` with note "Самоперевірка включена до практики діалогів". Sum = 1250 (+4.2%, within ±10% but unusual).
+- **Fix options:** (a) delete the section entirely; (b) allocate 50–100 words and rebalance `Діалоги` from 350 → 300.
+
+## MEDIUM Issues (Grouped by Pattern)
+
+### M-1 — Frozen-chunk scope-stretching (cross-cutting, 2 plans: M5, M6)
+Both `who-am-i` and `my-family` use case forms (accusative `Мене звати`, `А тебе?`; genitive `у мене є`, `з України`) before State Standard 2024 introduces them (accusative `first_module: 11`, genitive at A2). Plans explicitly fence these as frozen multi-word chunks with author-notes deferring the productive paradigms to M11/M16/M29/A2. This is a **defensible pedagogical compromise** — without these chunks, learners cannot perform basic self-introduction at A1 — but is currently undocumented as a standard-deviation. **Recommended action:** add a `pedagogical_deviations_from_standard:` block to both plans listing the frozen-chunk exceptions, so future audits don't re-litigate them. Not a build-blocker.
+
+### M-2 — Out-of-scope 1pl imperative `Прочитаймо` (1 plan: M1)
+State Standard §4.2.4.2 limits A1 imperative to 2nd-person only; 1pl `читаймо/прочитаймо` belongs to A2. M1 has `Прочитаймо «Привіт» по літерах` in content_outline[3].points[3]. Used as teacher meta-language ("let's read"), but the writer may render it in module prose. **Fix:** swap to 2sg `Прочитай`. 1-line edit.
+
+### M-3 — Rare key-word `ирій` for И (1 plan: M1)
+`ирій` is in VESUM but extremely low-frequency (poetic/mythological). Most NUS A1 bukvars pair И with `іній`, `Україна`, or `лина`. **Fix:** swap to `іній` (frost — high-frequency, concrete). 1-line edit.
+
+### M-4 — `муж/чоловік` Surzhyk-framing oversimplified (1 plan: M6)
+`муж` IS in VESUM as a Ukrainian noun (archaic/elevated: "державні мужі"). M6's family-Surzhyk drill frames `муж` as wrong vs `чоловік` — but it's a **register** distinction, not a Russianism. This contradicts M6's own documented `папа/тато` discipline. **Fix:** either drop the `муж/чоловік` row OR add a register-note explaining that `муж` is elevated register, not error. Borderline.
+
+### M-5 — Curriculum-wide A1-checkpoint word_target inconsistency (cross-cutting, ≥3 plans)
+| slug | focus | word_target | skill-prompt expectation | actual config target |
+|------|-------|-------------|--------------------------|----------------------|
+| checkpoint-first-contact | review | 1200 | 1000 (A1-checkpoint) | 1200 (falls back to A1 because focus=review) |
+| checkpoint-actions | review | 1200 | 1000 | 1200 |
+| checkpoint-communication | review | 1000 | 1000 | 1000 (under-target by current routing) |
+| checkpoint-food-shopping | review | 1000 | 1000 | 1000 |
+| checkpoint-my-world | review | 1200 | 1000 | 1200 |
+| checkpoint-places | review | 1200 | 1000 | 1200 |
+| checkpoint-time-nature | review | 1200 | 1000 | 1200 |
+
+5 of 7 A1 checkpoints sit at 1200; 2 sit at 1000. The config branch only fires `A1-checkpoint=1000` if focus=`checkpoint`, but all use focus=`review`. **Not a per-plan defect** — a curriculum-wide policy decision. Orchestrator needs to decide: (a) standardize all A1 checkpoints to 1200 and update skill prompt + config doc; (b) standardize to 1000 and update plans; (c) introduce focus=`checkpoint` and rewrite all checkpoint plans.
+
+## Cross-Cutting Patterns (≥3 plans)
+
+### CC-1 — Frozen-chunk usage of out-of-scope cases (2 plans, but pattern-relevant to all A1.1)
+Both M5 and M6 use accusative/genitive frozen chunks before the State Standard introduction module. Plans are disciplined about fencing these explicitly with author-notes. **Recommendation:** add a standard plan field `pedagogical_deviations_from_standard:` and propagate to all A1 plans that use this technique. Issue tracker: file as a curriculum-wide enhancement.
+
+### CC-2 — Surzhyk-drill calibration discipline (3 plans: M5, M6, M7)
+All three vocabulary plans contain a "Типові помилки L2" / Surzhyk-pair fill-in activity. Quality varies:
+- M5 (who-am-i): clean — все відсутнє в VESUM (`спасібо`, `ізвиніть`, `тоже`, `жена`, `врач`), pairs valid.
+- M6 (my-family): mostly clean — 6 of 7 pairs verified Russianism (NOT FOUND in VESUM); `муж/чоловік` is the one register-not-Russianism outlier.
+- M7 (checkpoint): contains the `папа` pair that M6 explicitly dropped. Editorial-line inconsistency.
+
+**Recommendation:** before any future Surzhyk-drill activity, run `mcp__sources__verify_words` on both sides of each pair. If the "wrong" word is in VESUM without restrictive tags, the framing must shift to register/style rather than dictionary-correctness — or the pair must be dropped.
+
+### CC-3 — All 7 plans completed v1.x review-and-lock cycle (consistency confirmation)
+All seven plans have `lifecycle: locked`, `reviewed_at: 2026-04-23` (or 2026-04-25 for the #1550 letter-module pass), `reviewed_by` populated, and explicit `review_notes` (sometimes long-form). Their v1.x changelogs document fixes from earlier reviews (e.g., М1's А у тебе? → А тебе? fix, М3's re-scoping, М4's intonation-contradiction fix). **This is a strong consistency signal** — the LOCKED batch has internal QA discipline. The findings here are residual edge-case items, not first-pass rework.
+
+### CC-4 — NUS textbook citation hygiene (all 7 plans)
+Every plan cites specific NUS textbook authorities by author, grade, page (Заболотний 5 кл. с.83; Захарійчук 1 кл. с.13–15; Большакова 1 кл. с.24, с.25, с.29, 2 кл. с.58–59; Авраменко 5 кл. с.19, с.75; Літвінова 5 кл. с.130; Кравцова 2 кл. с.13; Вашуленко 2 кл. с.23–27). This citation density per A1 is unusual and high-quality — the build pipeline can trust these references for review-tier evidence.
+
+## Suggested Template Fixes Per Cluster
+
+### Template fix #1 — Add `pedagogical_deviations_from_standard:` field
+
+For plans that use case-form chunks before the State Standard module:
+
+```yaml
+pedagogical_deviations_from_standard:
+- form: "Мене звати"
+  case_involved: accusative
+  standard_first_module: 11
+  this_module: 5
+  rationale: "Frozen self-introduction chunk; productive accusative paradigm deferred to M11."
+- form: "А тебе?"
+  case_involved: accusative
+  standard_first_module: 11
+  this_module: 5
+  rationale: "Echo-reciprocal chunk for name exchange; explicitly distinguished from `А у тебе?` which would invoke genitive-with-preposition."
+- form: "Я з + country.GEN"
+  case_involved: genitive
+  standard_first_module: A2
+  this_module: 5
+  rationale: "Country-name set phrase; genitive paradigm deferred to A2."
+```
+
+### Template fix #2 — VESUM-anchored Surzhyk drills
+
+For Surzhyk fill-in activities: add a checklist comment at top of `activity_hints`:
+
+```yaml
+# Surzhyk-drill VESUM check (run before lock):
+# - Each "wrong" form must be NOT FOUND in VESUM, OR
+# - Must be reframed as register/style contrast, OR
+# - Must be dropped from the drill.
+# Last verified: YYYY-MM-DD with mcp__sources__verify_words batch.
+```
+
+### Template fix #3 — Zero-budget section policy
+
+Plan field validator should reject `words: 0` sections OR require an explicit `omit_from_render: true` flag. Currently the writer may silently drop content. File as plan-schema enhancement.
+
+## Per-Module LOCK Recommendation (one-line table)
+
+| slug | status | severity-summary | LOCK_NOW | NEEDS_FIX | NEEDS_REVISION |
+|------|--------|------------------|----------|-----------|----------------|
+| sounds-letters-and-hello | NEEDS_FIX | 2 MEDIUM (1pl imp; rare И key-word) | | ✅ | |
+| reading-ukrainian | PASS | clean | ✅ | | |
+| special-signs | PASS | clean (exemplary) | ✅ | | |
+| stress-and-melody | PASS | 1 MEDIUM (future TTS) | ✅ | | |
+| who-am-i | NEEDS_FIX | 1 HIGH (Підсумок=0) + 3 MEDIUM (acc/gen chunks documented) | | ✅ | |
+| my-family | PASS (borderline) | 1 MEDIUM (`муж` register) | ✅ (lenient) / ✅ (strict NEEDS_FIX) | (✅) | |
+| checkpoint-first-contact | NEEDS_FIX | 1 HIGH (`папа` contradiction) + 1 MEDIUM (checkpoint word_target policy) | | ✅ | |
+
+## Orchestrator Action Items (in priority order)
+
+1. **LOCK_NOW**: M2 (reading-ukrainian), M3 (special-signs), M4 (stress-and-melody). Three clean plans ready for overnight build queue.
+2. **Single-line YAML fixes** (NEEDS_FIX, dispatch as one batch):
+   - M1: replace `Прочитаймо` → `Прочитай`; replace `ирій` → `іній`.
+   - M5: delete `Підсумок: words: 0` section OR allocate 50 words and rebalance Діалоги 350→300.
+   - M7: remove `тато/папа` Surzhyk-drill row; reframe `тато` vocab note.
+3. **Borderline (M6)**: decide team policy on `муж/чоловік` — drop the row OR add register-note. Then LOCK.
+4. **Cross-cutting decisions** (separate dispatch, not blocking M1–M7 build):
+   - CC-1: add `pedagogical_deviations_from_standard:` field convention (template fix #1).
+   - M-5 / CC-5: curriculum-wide A1-checkpoint word_target reconciliation (1000 vs 1200). 5 plans need alignment.
+   - Template fix #2: VESUM-anchored Surzhyk-drill discipline as a plan-review checklist item.
+   - Template fix #3: schema-validator rejection of `words: 0` sections.
+5. **No NEEDS_REVISION** — all 7 plans are structurally sound with editing-grade fixes, not pedagogical rewrites.
+
+## Notes on Method
+
+- All 7 plans had been through the v1.x review-and-lock cycle in 2026-04-23/25. This audit is a second-pass cross-cutting consistency check, not a first review.
+- Verifiable claims were tool-backed via `mcp__sources__verify_words` (53-word batch) and `mcp__sources__search_style_guide` (limited 46% coverage, no hits on queried Russianism phrases).
+- Per #M-4 (deterministic-over-hallucination): no claim about word existence, level scope, or section sum was made without a tool call or yaml-arithmetic verification.
+- No plan YAMLs were modified. All edits are recommendations only.

--- a/curriculum/l2-uk-en/a1/audit/my-family-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/my-family-plan-review.md
@@ -1,0 +1,77 @@
+# Plan Review: my-family
+
+**Track:** a1 | **Sequence:** 6 | **Version:** 1.4.0 | **Lifecycle:** locked
+**Verdict:** PASS (one borderline MEDIUM around `муж` framing)
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 §4.2.1.4 (pronouns, light), §4.2.3.1 (nominative); §4.2.2.2 Genitive — A2 (used here only as frozen `у мене/тебе/вас` chunks).
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | PASS | Plan: 1200 = Config A1: 1200 |
+| section_budgets | PASS | Sum = 400+200+250+200+150 = 1200 (exact match) |
+| required_fields | PASS | All present |
+| version_string | PASS | `version: '1.4.0'` (explicit string) |
+| no Latin in Cyrillic | PASS | Scan clean per locked review_notes |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| Possessive pronouns: мій/моя/моє/мої, твій/-я/-є | YES (§4.2.1.4) | A1 | A1 | PASS — nominative only, full paradigm deferred to A2 |
+| Gender agreement (мій брат vs моя сестра) | YES (§4.2.1.2) | A1 | A1 | PASS |
+| Cardinals one/two with gender (один брат, одна сестра) | YES (§4.2.1.3 — basic forms) | A1 | A1 | PASS |
+| `У мене/тебе/вас є` (frozen genitive expression) | Genitive A2 nominally | A2 | A1 (frozen chunk) | MEDIUM — documented pedagogical exception |
+| Negative `у мене немає` deferred to A2 | Correct scope discipline | A2 | A2 (deferred) | PASS — plan explicitly defers |
+| Patronymic recognition (`-івна / -ївна`) | YES — vocative §4.2.3.4 at A1 (recognition framing) | A1 | A1 (recognition only) | PASS — properly fenced as recognition-only |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Source | Correct? | Notes |
+|---------|--------|----------|-------|
+| Ukrainian has no single «grandparents» word — must say «бабуся і дідусь» | Standard / ULP Ep.6 | YES | Correct cultural-linguistic note |
+| Two synonyms for «family»: сім'я / родина | Standard | YES | Both VESUM-confirmed; both used naturally |
+| `у мене є` not `я маю X` for possession | ULP Ep.6 (cited) | YES | Correct — `мати` for possession is calque/awkward in colloquial register |
+| Patronymic suffixes: -ович/-йович (m), -івна/-ївна (f) | NUS standard + wiki Крок 6 | YES | Plan correctly distinguishes Ukrainian -івна from Russian -овна — strong decolonization note |
+| Gender of cardinal один: один брат vs одна сестра vs два брати vs дві сестри | Standard | YES | Correctly stated |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| Required: сім'я, мама, тато, брат, сестра, бабуся, дідусь, мій/моя/моє/мої, твій/-я/-є, у мене є, у тебе є | All FOUND | OK |
+| Recommended: батьки, дядько, тітка, дочка, син, дружина, чоловік, родичі, його, її, один/одна, два/дві, чи, тільки, ім'я, прізвище, по батькові | All FOUND (note: `по батькові` is a phrase, not a single VESUM headword — component words верифіковано) | OK |
+| Russianism counter-pairs in fill-in activity: жена, муж, бабушка, родственники, ребьонок, младший, женатий | **жена / бабушка / родственники / ребьонок / младший / женатий = NOT FOUND in VESUM** | Plan correctly flags these as Surzhyk |
+| `муж` | **FOUND in VESUM** (noun) | See MEDIUM below — `муж` is a legitimate Ukrainian word (archaic/elevated register meaning "man, husband"; cf. Грінченко, Біблійні переклади). It is NOT a Russianism in the strict sense — but in modern colloquial register, native speakers default to `чоловік`. |
+| `папа` | **FOUND in VESUM** (noun, 2 matches) | Plan deliberately avoids flagging `папа` per the locked-review note ("VESUM lists `папа` without restrictive tags") — correctly handled |
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+None.
+
+### MEDIUM (fix if possible)
+1. **`муж/чоловік` framing in fill-in activity** (activity_hints[4].items[1]). `муж` IS in VESUM as a Ukrainian noun (archaic/elevated: «муж — чоловік, особа чоловічої статі», cf. «державні мужі»). Framing it as a Surzhyk pair against `чоловік` could be misleading — the contrast is **register**, not Russianism status. The locked-review explicitly dropped `папа/тато` from the drill for exactly this reason; the same logic should apply to `муж`. Suggested fix: either (a) remove the `муж/чоловік` pair from the activity (down to 6 items), OR (b) reframe the item explicitly as "У розмовному регістрі модерної української основна форма — `чоловік`. `Муж` — піднесений / архаїчний регістр (державні мужі)." Without this nuance, the writer may build the activity as a black-and-white "wrong/right" item, contradicting the plan's own author-discipline (cf. the careful `папа` handling).
+2. **Genitive in frozen `у мене/тебе/вас є`** — same documented pedagogical compromise as in M5 (who-am-i). Plan explicitly defers full paradigm to A2 and uses only the chunk. Acceptable; cross-cutting concern, see summary.
+
+### LOW (informational)
+1. The plan's family-Surzhyk drill (7 pairs) is well-curated. The dropped `папа/тато` pair (after Codex AC-3 adversarial review) shows excellent dictionary discipline.
+2. Dialogue 3 connects to A1.1 capstone (`Привіт! Мене звати... Моя мама — вчителька...`) — strong end-of-phase synthesis preview before M7 checkpoint.
+3. Plan correctly avoids teaching `у нього/неї/нас/них` paradigm — these involve case forms of personal pronouns (А2). Defers via "введемо поступово через діалоги як сталі фрази".
+
+## Suggested Fixes
+```yaml
+# activity_hints[4].items — adjust муж/чоловік framing or remove
+# Option A (recommended): remove the муж/чоловік row, keep 6 items
+items:
+  - Моя {дружина|жена} — вчителька.
+  - Це моя {бабуся|бабушка}. Їй сімдесят років.
+  - У нас велика родина — близько десяти {родичів|родственників}.
+  - Моя племінниця ще маленька {дитина|ребьонок}.
+  - Мій {молодший|младший} брат навчається в школі.
+  - Мій старший брат уже {одружений|женатий}. У нього двоє дітей.
+
+# Option B: reframe with a register-note in author_note
+```
+
+## Verdict
+PASS with one MEDIUM fix recommended. The plan is exemplary in scope management (defers full paradigm of `у мене`/possessive pronouns to A2, fences patronymics as recognition-only) and decolonization discipline (feminitive default, native-form vocab priority). The `муж/чоловік` adjustment is a 1-line edit. Recommend **NEEDS_FIX** for the muz reframing — or accept current state as LOCK_NOW if the team confirms the register-Surzhyk framing is intentional.

--- a/curriculum/l2-uk-en/a1/audit/reading-ukrainian-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/reading-ukrainian-plan-review.md
@@ -1,0 +1,68 @@
+# Plan Review: reading-ukrainian
+
+**Track:** a1 | **Sequence:** 2 | **Version:** 1.3.2 | **Lifecycle:** locked
+**Verdict:** PASS
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 §4.1.1 (alphabet), §4.1.4 (vowels/consonants), §4.1.5 (stress — light intro).
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | PASS | Plan: 1200 = Config A1: 1200 |
+| section_budgets | PASS | Sum = 250+300+500+150 = 1200 (exact match) |
+| required_fields | PASS | All present including `letter_module: true` flag |
+| version_string | PASS | `version: 1.3.2` |
+| no Latin in Cyrillic | PASS | Scan clean |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| Syllable rule (one vowel = one syllable) | Implicit (§4.1.4) | A1 | A1 | PASS |
+| Sound system [●]/[—]/[=] notation | NUS pedagogy (Захарійчук 1кл) | A1 | A1 | PASS |
+| Iotated vowels Я Ю Є Ї | YES (§4.1.4) | A1 | A1 | PASS — depth appropriate |
+| И vs І minimal pairs (кит/кіт) | YES (§4.1.4) | A1 | A1 | PASS — distinguishing phonemes |
+| Ь / apostrophe (light intro, full coverage in M3) | YES (§4.1.3) | A1 | A1 | PASS |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Textbook Source | Correct? | Notes |
+|---------|----------------|----------|-------|
+| «У слові стільки складів, скільки голосних звуків» | Большакова 1 кл. с.25 (cited) | YES | Canonical NUS formulation |
+| Chin-test for syllable counting | Кравцова 2 кл. с.13 (cited) | YES | Standard kinesthetic technique |
+| Я ZAVZHDY [йа] word-initially / after vowel / after apostrophe; softens after consonant | Standard | YES | Correctly stated |
+| Ї always [йі] — never softens | Standard | YES | Correctly identified as a uniquely Ukrainian feature |
+| Складоподіл ≠ перенесення (огі-рок vs о-гі-рок) | Вашуленко 2 кл. с.23-27 (cited) | YES | Important distinction included in activity_hints — well-aligned with NUS Pravopys 2019 perenosи rule |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| яблуко | FOUND | OK — classic Я-initial word |
+| молоко | FOUND | OK |
+| людина | FOUND | OK — Л+Ю combination as designed |
+| вулиця | FOUND | OK |
+| столиця | FOUND | OK |
+| каша | FOUND | OK |
+| пісня | FOUND | OK — softening after consonant |
+| університет | FOUND | OK |
+| бібліотека | FOUND | OK — 5 syllables as labeled |
+| фотографія | FOUND | OK |
+| шоколад | FOUND | OK |
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+None.
+
+### MEDIUM (fix if possible)
+None.
+
+### LOW (informational)
+1. The `match-up` activity in activity_hints[5] uses **8 items** (`items: 8` from the items[] list) but the field declares `items: items: [...]` — the writer must read the list length, not the missing scalar. This pattern is YAML-valid but the schema may need a length normalization. Not a plan defect; flag for schema consistency only.
+2. The plan's grammar item «Ь, апостроф (ознайомлення — детально у модулі №3)» is appropriately scoped as preview-only, deferring deep teaching to M3 — clean phase staging.
+
+## Suggested Fixes
+None required. Plan is lock-clean.
+
+## Verdict
+PASS. The plan is a model of clean phase staging: builds on M1, previews M3 (Ь/apostroph) and M4 (наголос) without overreach, and uses authentic NUS pedagogy (Большакова, Захарійчук, Вашуленко, Кравцова) with verifiable page citations. Recommend **LOCK_NOW** — no changes needed.

--- a/curriculum/l2-uk-en/a1/audit/sounds-letters-and-hello-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/sounds-letters-and-hello-plan-review.md
@@ -1,0 +1,81 @@
+# Plan Review: sounds-letters-and-hello
+
+**Track:** a1 | **Sequence:** 1 | **Version:** 1.6.2 | **Lifecycle:** locked
+**Verdict:** NEEDS FIXES (MEDIUM only; CRITICAL gates clean)
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 §4.1 (phonetics: alphabet §4.1.1, soft_sign §4.1.3, vowels/consonants §4.1.4, stress §4.1.5, euphony §4.1.7); A1 §4.2.4.2 (imperative — 2nd person only at A1).
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | PASS | Plan: 1200 = Config A1: 1200 (`scripts/audit/config.py:666`) |
+| section_budgets | PASS | Sum = 300+250+250+250+150 = 1200 (exact match, 0% deviation) |
+| required_fields | PASS | All present: module, level, sequence, slug, version, title, subtitle, focus, pedagogy, word_target, objectives, content_outline, vocabulary_hints, activity_hints, grammar, register |
+| version_string | PASS | `version: 1.6.2` parses as string per YAML (3-component dotted form) |
+| no Latin in Cyrillic | PASS | Latin-in-Cyrillic homoglyph scan clean (per locked review_notes); confirmed by manual reading |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| Alphabet (33 letters / 38 sounds split) | YES (§4.1.1) | A1 | A1 | PASS |
+| Голосні/приголосні | YES (§4.1.4) | A1 | A1 | PASS |
+| Soft sign (Ь) | YES (§4.1.3) | A1 | A1 | PASS (light intro, deep dive in M3) |
+| Stress (наголос) | YES (§4.1.5) | A1 | A1 | PASS (light intro, deep dive in M4) |
+| Euphony (у/в, і/й) | YES (§4.1.7) | A1 | A1 | PASS |
+| Iotated vowels (Я Ю Є Ї) — light intro | Implicit (§4.1.4) | A1 | A1 | PASS (deep dive in M2) |
+| Прочитаймо (1pl perfective imperative) | NO at A1 | A2 (§4.2.3.2 1pl `читаймо`) | A1 | **MEDIUM** — see issues |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Textbook Source | Correct? | Notes |
+|---------|----------------|----------|-------|
+| «Звуки чуємо й вимовляємо, а букви бачимо й пишемо» | Заболотний 5 кл. с.83 (cited in plan) | YES | Canonical pedagogical formula; matches NUS practice |
+| 33 letters / 38 sounds | Заболотний 5 кл. с.83 | YES | Standard A1 framing |
+| 10 vowel letters / 6 vowel sounds | Standard NUS framing | YES | Letters: А О У Е И І Я Ю Є Ї → sounds: [а о у е и і] |
+| Ь — no sound, softens preceding consonant | Захарійчук 1 кл. с.13–15 | YES | Confirmed standard pedagogy |
+| Щ = [шч] always | Standard | YES | Correct |
+| Ґ = [g] vs Г = [ɦ] | Standard | YES | Fix in v1.5.1 removed "uniquely Ukrainian" overstatement — correctly resolved |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| ирій (key word for И) | FOUND (noun, 2 matches) | Real Ukrainian word (mythological paradise), but **LOW**: very rare for A1 — most NUS bukvars use `іній` or `Україна`/`лина` |
+| ґудзик (key word for Ґ) | FOUND | OK |
+| їжак (Ї) | FOUND | OK |
+| юшка (Ю) | FOUND | OK |
+| Прочитаймо (1pl imp) | NOT FOUND as form; `читаймо` confirmed as 1pl imperative of `читати` | Morphologically valid but A2-scope per State Standard §4.2.3.2 |
+| мама / молоко / тато / око / дім / ніс / сон | FOUND (all) | OK |
+| Greetings as chunks: Добрий день / Доброго ранку / Добрий вечір / До побачення / На все добре | Components verified; chunks treated as multi-word units — OK |
+| Радий/Рада тебе бачити | Gender pair correct; both forms confirmed in VESUM as adj `радий` (m/f) | OK — pedagogically appropriate for first gender exposure |
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+None.
+
+### MEDIUM (fix if possible)
+1. **`Прочитаймо «Привіт» по літерах»** (content_outline[3].points[3]) — 1pl perfective imperative. Per State Standard 2024 §4.2.3.2, A1 imperative scope is **2nd person only**; 1pl forms (`читаймо`, `прочитаймо`) belong to A2. The plan uses this in author/teacher meta-language ("let's read") rather than as taught grammar, but the writer may render it in module prose and inadvertently model an A2 form before the learner has seen any imperative paradigm. Suggested fix: replace with a 2nd-person framing such as `Прочитай «Привіт» по літерах` (2sg imperative) or move the verb out of the meta-instruction.
+2. **`ирій` as key word for И** in vocabulary_hints (recommended). Word exists in VESUM but is poetic/mythological and extremely low-frequency. Most NUS-track A1 bukvars pair И with `іній`, `лина`, `Україна`, or even no key word (И is rarely word-initial). Suggested fix: replace with `іній` (frost — high-frequency, concrete, fits the literacy alphabet pattern).
+
+### LOW (informational)
+1. The `pronunciation_videos.vowels.О` entry is `null`. The module teaches all six vowel sounds; the missing О video is the only gap among the basics. Note for future fix or local recording.
+2. Plan teaches all 33 letters in vocabulary_hints (33 alphabet entries) — high count is intentional per `letter_module: true` flag and `#1550` plan_fix. This is appropriate but means activity-count gates should be calibrated separately (already handled in `scripts/audit/config.py` per the letter-module exception class).
+3. Grammar item "Привітання як неподільні лексичні чанки" overlaps with the soft-sign / iotated material that gets a full module in M3. Acceptable as light intro per phase staging.
+
+## Suggested Fixes
+```yaml
+# content_outline[3].points[3] — replace `Прочитаймо` with 2sg form
+- 'Прочитай «Привіт» по літерах — твій перший звуковий аналіз: П [п] приголосний + р [р] приголосний + и [и] голосний + в [в] приголосний + і [і] голосний + т [т] приголосний...'
+
+# vocabulary_hints.recommended (in the 33-letter alphabet block)
+# old:
+- word: И
+  key_word: ирій
+# new:
+- word: И
+  key_word: іній
+```
+
+## Verdict
+Plan is structurally sound and well-grounded in NUS textbook authorities. Two MEDIUM linguistic issues (out-of-scope 1pl imperative and obscure key word for И). Recommend **NEEDS_FIX** before next build — both are 1-line YAML edits, not pedagogical rewrites.

--- a/curriculum/l2-uk-en/a1/audit/special-signs-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/special-signs-plan-review.md
@@ -1,0 +1,64 @@
+# Plan Review: special-signs
+
+**Track:** a1 | **Sequence:** 3 | **Version:** 1.4.1 | **Lifecycle:** locked
+**Verdict:** PASS
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 §4.1.2 (apostrophe), §4.1.3 (soft sign).
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | PASS | Plan: 1200 = Config A1: 1200 |
+| section_budgets | PASS | Sum = 250+250+250+250+200 = 1200 (exact match) |
+| required_fields | PASS | All present, `letter_module: true` set |
+| version_string | PASS | `version: '1.4.1'` (explicit string-quoted) |
+| no Latin in Cyrillic | PASS | Scan clean |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| Apostrophe usage | YES (§4.1.2) | A1 | A1 | PASS |
+| Soft sign (ь) | YES (§4.1.3) | A1 | A1 | PASS |
+| Iotated vowels (precondition framing) | YES (§4.1.4) | A1 | A1 | PASS — light review, no overreach |
+| `буряк` / `бур'ян` / `свято` 3-way contrast | NUS pedagogy (Захарійчук 1 кл. с.97) | A1 | A1 | PASS — classic A1 orthography contrast |
+| Word transfer rules (`Мар'-яна`, `дере-в'яний`) | NUS pedagogy (Большакова 2 кл. с.58–59) | A1 | A1 | PASS — basic перенесення rule |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Textbook Source | Correct? | Notes |
+|---------|----------------|----------|-------|
+| Apostrophe after б, п, в, м, ф, р + я/ю/є/ї | Захарійчук 1 кл. с.97 (cited) | YES | Standard A1 rule |
+| Soft sign as silent softener | Авраменко 5 кл. с.75 (cited) | YES | Correct pedagogy — distinguishes [н] vs [н'] |
+| Apostroph keeps preceding consonant HARD (м'я = hard м + [йа]) | Standard | YES | Critical distinction correctly stated — common L2 misperception is exactly this |
+| Зона без апострофа: свято, цвях, морквяний | Standard (post-consonant cluster rule) | YES | Correct exception; presented as memorized examples not derived rule (appropriate for A1) |
+| Transfer: `Мар'-яна`, `дере-в'яний` | Большакова 2 кл. с.58-59 (cited) | YES | Verified — apostroph stays attached to preceding letter |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| день / кінь / сіль / вчитель | All FOUND | OK — high-frequency ь-words |
+| сім'я / м'ясо / п'ять / комп'ютер | All FOUND | OK — canonical apostrophe set |
+| буряк / бур'ян | Both FOUND | OK — the central contrast |
+| свято / цвях | Both FOUND | OK — post-cluster exception |
+| дев'ять / ім'я / здоров'я | All FOUND | OK |
+| маленький / сьогодні / ложка | All FOUND | OK; `ложка` correctly framed as counterexample to *льожка |
+| дерев'яний / Мар'яна | Both FOUND | OK — transfer-model words |
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+None.
+
+### MEDIUM (fix if possible)
+None.
+
+### LOW (informational)
+1. The `author_note` in vocabulary_hints provides excellent guardrails for the writer (forbids inflectional paradigm intro, forbids productive prefix rule, anchors to 3 contrasts). This is exemplary author-note design — should be propagated as a template pattern.
+2. The plan deliberately defers the префіксний апостроф (`під'їзд`, `з'їзд`) as "mentioned, not productive" — appropriate scope management for A1.
+
+## Suggested Fixes
+None required.
+
+## Verdict
+PASS. The plan is tight, narrowly scoped to ь + apostrophe, well-grounded in NUS textbooks (Захарійчук 1 кл., Авраменко 5 кл., Большакова 2 кл.), and includes a thoughtful 3-way contrast (`буряк`/`бур'ян`/`свято`) that addresses the most common L2 errors. Re-scoping pass in v1.4.0 (removed voiced/voiceless, Г/Ґ, Р, И drift) was the correct call. Recommend **LOCK_NOW**.

--- a/curriculum/l2-uk-en/a1/audit/stress-and-melody-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/stress-and-melody-plan-review.md
@@ -1,0 +1,62 @@
+# Plan Review: stress-and-melody
+
+**Track:** a1 | **Sequence:** 4 | **Version:** 1.2.1 | **Lifecycle:** locked
+**Verdict:** PASS (one MEDIUM about a pedagogical exception that author acknowledges)
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 §4.1.5 (stress), §4.1.8 (intonation).
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | PASS | Plan: 1200 = Config A1: 1200 |
+| section_budgets | PASS | Sum = 350+300+300+250 = 1200 (exact match) |
+| required_fields | PASS | All present |
+| version_string | PASS | `version: 1.2.1` |
+| no Latin in Cyrillic | PASS | Scan clean (v1.2.1 stripped U+0301 stress marks per pipeline policy) |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| Free / mobile stress | YES (§4.1.5) | A1 | A1 | PASS |
+| Intonation contours (declarative ↘, yes/no Q ↗, exclamation ↘↘, WH-Q ↘) | YES (§4.1.8) | A1 | A1 | PASS |
+| Stress-pair meaning distinction (замок/замок) | NUS pedagogy (Заболотний 5 кл. с.73) | A1 | A1 | PASS |
+| Numerals одинадцять / чотирнадцять (stress on -на-) | A1 stress-load (commonly taught early) | A1 | A1 | PASS — but the numbers themselves are A1 vocab introduced later; recommended-tier here, which is fine |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Textbook Source | Correct? | Notes |
+|---------|----------------|----------|-------|
+| Stress is free and mobile in Ukrainian | Заболотний 5 кл. с.73 (cited) | YES | Standard A1 framing |
+| Sentence types by purpose: розповідні / питальні / спонукальні / окличні | Авраменко 5 кл. с.19 (cited) | YES | Correct |
+| WH-questions take falling intonation (Що це? ↘) vs yes/no questions take rising (Це метро? ↗) | Standard | YES | Internal contradiction from prior version (питальна ↗ overstatement) was correctly fixed in v1.2.0 — plan now consistent |
+| `Як справи? ↘` (WH-Q rule) with author-note about conversational rising contour | Author-note in content_outline[2].points[2] | YES | Defensible compromise — author transparently flags conversational vs normative; writer gets clear instruction to teach normative ↘ |
+| Homograph stress pairs: замок/замок, атлас/атлас, орган/орган, сім'я/сім'я | Common stress-pair pedagogy | YES | All four pairs are real Ukrainian stress homographs |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| наголос | FOUND | OK |
+| замок | FOUND (both stress variants) | OK — meaning by stress is correct |
+| атлас | FOUND | OK |
+| орган | FOUND | OK |
+| кава / вода / столиця / ранок / метро / фотографія | All FOUND | OK |
+| одинадцять / чотирнадцять | FOUND | OK — stress on -на- is correct (validated by Pravopys/goroh) |
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+None.
+
+### MEDIUM (fix if possible)
+1. **`Як справи? ↘` author-note exception** (content_outline[2].points[2]). The plan acknowledges that conversational Ukrainian typically uses rising intonation for `Як справи?` (phatic function) but mandates the normative falling contour to consolidate the WH-question rule. This is a defensible pedagogical compromise — but the build writer may emit audio/synthesis with the wrong contour if the TTS layer defaults to rising for the `?` punctuation. Suggested fix: add an explicit `intonation_override` directive in the section's points so the audio-generation step (when added) can respect the author's intent. Note: not a blocker — current text-only build is fine, but flag for next-gen TTS phase.
+
+### LOW (informational)
+1. The `мука / мука` (flour/torment) homograph pair was correctly dropped from vocabulary_hints in v1.2.0 with a writer-note explaining that the modern standard for "flour" is `борошно` (cited in content_outline[0].points[1]). This is excellent attention to dialectal/standard register distinction.
+2. The stress-transfer fill-in activity drills classic R-L1 transfer errors (новий/новий, старий/старий, plural mobile stress, fem -ія names). Strong adversarial-learning coverage.
+
+## Suggested Fixes
+None blocking; the MEDIUM is a forward-looking note about TTS, not a current-build issue.
+
+## Verdict
+PASS. The plan is rigorous: clear intonation rules, explicit numeric stress targets, well-curated stress-pair drills, and transparent author-notes about pedagogical exceptions. The v1.2.0 review-and-lock cycle cleaned up the internal contradiction about WH-questions and the disputed `мука` pair. Recommend **LOCK_NOW**.

--- a/curriculum/l2-uk-en/a1/audit/who-am-i-plan-review.md
+++ b/curriculum/l2-uk-en/a1/audit/who-am-i-plan-review.md
@@ -1,0 +1,77 @@
+# Plan Review: who-am-i
+
+**Track:** a1 | **Sequence:** 5 | **Version:** 1.2.0 | **Lifecycle:** locked
+**Verdict:** NEEDS FIXES (one HIGH; multiple MEDIUM accepted as documented set-phrase exceptions)
+**Authority:** `docs/l2-uk-en/state-standard-2024-mapping.yaml` — A1 §4.2.1.4 (pronouns), §4.2.3.1 (nominative), §4.2.3.2 (accusative — `first_module: 11`), §4.3.1 (simple sentences).
+
+## Rule Compliance
+| Check | Status | Details |
+|-------|--------|---------|
+| word_target | PASS | Plan: 1200 = Config A1: 1200 |
+| section_budgets | **HIGH** | Sum = 350+250+200+100+150+200+0 = **1250** (+4.2%, within ±10% but one section has 0 words) — see Issues |
+| required_fields | PASS | All present |
+| version_string | PASS | `version: '1.2.0'` (explicit string) |
+| no Latin in Cyrillic | PASS | Scan clean |
+
+## State Standard Alignment
+| Grammar Topic | In Standard? | Standard Level | Plan Level | Status |
+|--------------|-------------|----------------|------------|--------|
+| Personal pronouns (nominative): я, ти, він, вона, ми, ви, вони | YES (§4.2.1.4) | A1 | A1 | PASS |
+| Nominative case (Я — студент) | YES (§4.2.3.1) | A1 | A1 | PASS |
+| Demonstrative «це» + noun (Це Київ) | YES (simple sentences §4.3.1) | A1 | A1 | PASS |
+| `Мене звати` (acc-style frozen phrase) | Accusative §4.2.3.2 first_module=11 | A1 nominally | A1 (frozen chunk before M11) | MEDIUM — documented exception |
+| `А тебе?` (acc 2sg pronoun) | Accusative §4.2.3.2 first_module=11 | A1 nominally | A1 (frozen chunk before M11) | MEDIUM — documented exception |
+| `Я з України` (gen of country) | Genitive = A2 (§4.2.2.2) | A2 | A1 (frozen chunk) | MEDIUM — documented exception; plan explicitly says "завчені фрази" |
+| Feminitives (лікарка, інженерка) | NOT in §4.2 but supported by VESUM | implicit | A1 | PASS — strong decolonization choice |
+
+## Grammar Verification (Textbook RAG)
+| Concept | Source | Correct? | Notes |
+|---------|--------|----------|-------|
+| Nullsubject-copula sentence (Я — студент) | ULP Ep.3 + standard | YES | Correctly explained — no «бути» in present tense |
+| `Як тебе/вас звати?` (informal/formal pairing) | ULP Ep.3 (cited) | YES | Canonical introduction pattern |
+| Echo pattern `А тебе? / А вас?` | Wiki Крок 1 (cited) | YES | Plan explicitly forbids `А у тебе?` (which would tie to A2 genitive-with-preposition) — excellent scope discipline |
+| Feminitives as primary form for women | Wiki Крок 6 + Декол. #5 | YES | Decolonization principle — лікарка, вчителька, інженерка all VESUM-confirmed |
+| `Звідки?` + country as set phrase | Plan defers genitive to M16/M29 explicitly | YES | Correct scope management |
+
+## Vocabulary Verification (VESUM)
+| Word | VESUM | Notes |
+|------|-------|-------|
+| All required: я, ти, він, вона, ви, це, студент(ка), вчитель(ка), лікар(ка), українець, українка, Україна | All FOUND | OK |
+| Feminitives recommended: програмістка, інженерка, авторка | All FOUND | OK |
+| Native-form recommendations: тато, дружина, дякую, спасибі, вибачте, пробачте, теж, також | All FOUND | OK |
+| Russianism counter-pairs (correctly identified as NOT Ukrainian): спасібо, ізвиніть, тоже, жена, врач | **All NOT FOUND in VESUM** | Plan correctly flags these as Russianisms |
+
+**Borderline**: `канадка` (canadian woman) — FOUND in VESUM. The alternate `канадійка` ALSO found. Both are valid; modern form is `канадка` (preferred per current VESUM frequency); `канадійка` is more colloquial. Plan uses `канадка` — fine.
+
+## Issues Found
+
+### CRITICAL (must fix before build)
+None.
+
+### HIGH (should fix before build)
+1. **Section "Підсумок" has `words: 0`** (content_outline[6]). A section with zero word budget is anomalous — the writer may either (a) skip the section entirely, leaving no closing/self-check beat, or (b) overshoot, breaking the total budget. The plan's note says "Самоперевірка включена до практики діалогів, наведеної вище" — this is a structural intent, but a zero-budget section is a code smell. Suggested fix: either remove the section entirely (better — clean structure) OR allocate 50–100 words of explicit recap content and re-balance one of the larger sections (e.g., reduce "Діалоги" from 350 to 300). Current sum 1250 > 1200 nominal but within ±10%, so this is HIGH-priority structural cleanliness rather than a hard violation.
+
+### MEDIUM (fix if possible)
+1. **Accusative `Мене звати` + `А тебе?` at sequence 5** (State Standard puts accusative first_module=11). Plan explicitly documents these as frozen chunks, which is a defensible pedagogical compromise — without this set-phrase introduction the A1 learner has no way to say their name at all. The wiki Крок 1 and the explicit `#1392 Defect 2` avoidance both show this was carefully reasoned. Recommend: keep as is, but document the standard-deviation in the plan's review_notes (`pedagogical_deviations_from_standard:` block) so future audits don't re-litigate.
+2. **Genitive `Я з України / Канади / Німеччини` at sequence 5** (Standard puts genitive at A2). Same frozen-phrase justification applies. Same recommendation.
+3. **Module sequence vs phase plan**: Plan teaches nationality forms (українець/українка/канадець/канадка) but the `канадець` (m) is absent from required/recommended vocab while `канадка` (f) is implicitly used in dialogue 1 (`Я з Канади`). The dialogue uses country names not nationality, so this is fine — flag is informational only.
+
+### LOW (informational)
+1. The fill-in Surzhyk drill (activity_hints[4]) is excellent adversarial-learning coverage — 7 pairs hit the most common L2 errors. Items[6] `Це мій {врач|лікар}` is a clean Russianism counter (врач not in VESUM).
+2. Dialogue 3 (Представлення когось іншого) explicitly mandates 2 speakers and a feminitive (`лікарка`, not лікар) — strong gendered-language modeling.
+
+## Suggested Fixes
+
+```yaml
+# OPTION A — remove the zero-budget section:
+# delete content_outline[6] entirely
+
+# OPTION B — allocate real content and re-balance:
+# content_outline[0] (Діалоги): words: 350 → 300
+# content_outline[6] (Підсумок): words: 0 → 50
+#   points:
+#   - 'Самоперевірка: Привітайся з новою людиною. Назви своє ім'я, національність, професію. Запитай у відповідь.'
+```
+
+## Verdict
+NEEDS_FIX (HIGH issue: zero-budget Підсумок section). The MEDIUM scope-stretching items (acc/gen as frozen chunks) are accepted pedagogical compromises but should be recorded as documented deviations. Recommend **NEEDS_FIX** before next build cycle. Once Підсумок is fixed (1-line YAML edit either way), the plan is build-ready.


### PR DESCRIPTION
## Summary

- Plan-review skill applied to A1 sequences 1-7 (sounds-letters-and-hello, reading-ukrainian, special-signs, stress-and-melody, who-am-i, my-family, checkpoint-first-contact).
- 7 per-module audit reports + 1 summary report.
- No plan YAMLs modified.

## Findings (one-line per plan)

| seq | slug | verdict |
|-----|------|---------|
| 1 | sounds-letters-and-hello | NEEDS_FIX (2 MEDIUM: 1pl imperative; rare И key-word) |
| 2 | reading-ukrainian | LOCK_NOW (clean) |
| 3 | special-signs | LOCK_NOW (clean, exemplary) |
| 4 | stress-and-melody | LOCK_NOW (1 MEDIUM forward-looking TTS note) |
| 5 | who-am-i | NEEDS_FIX (1 HIGH: Підсумок section words=0) |
| 6 | my-family | PASS borderline (1 MEDIUM: муж register-not-Russianism framing) |
| 7 | checkpoint-first-contact | NEEDS_FIX (1 HIGH: тато/папа contradicts M6 discipline) |

**No CRITICAL issues. No NEEDS_REVISION. All fixes are 1-line YAML edits.**

## Cross-cutting

- CC-1: 2 plans use accusative/genitive frozen chunks before State Standard module — pattern-relevant for A1.1 design template.
- CC-2: Surzhyk-drill calibration discipline — M5/M6/M7 vary; recommend VESUM-anchored pre-lock checklist.
- CC-5: A1-checkpoint word_target inconsistency (5 plans at 1200, 2 at 1000) — curriculum-wide policy decision needed.

## Test plan

- [x] All 7 per-module audit files present (\`ls curriculum/l2-uk-en/a1/audit/*-plan-review.md | wc -l\` = 7).
- [x] Summary roll-up has 10 \`## \` sections including PASS/FAIL table + cross-cutting + LOCK recommendations.
- [x] State Standard 2024 mapping cited as Authority in summary + per-module reports.
- [x] All verifiable claims tool-backed via mcp__sources__verify_words (53-word batch) and yaml-arithmetic.
- [ ] CI: docs-only, advisory checks may flag; non-blocking per #M-0.5.

## Next step (orchestrator)

Read summary → LOCK_NOW M2, M3, M4 → dispatch single 1-line fixes for M1, M5, M7 (and decide M6) → re-review fixed plans → unblock overnight build queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)