### PR TITLE
fix(linear_pipeline): writer-output parser label-line tightening + 2 stale fixture fixes (#1956)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -70,6 +70,11 @@ WRITER_ARTIFACTS = (
     "vocabulary.yaml",
     "resources.yaml",
 )
+_LABEL_LINE_RE = re.compile(
+    r"^[\s>#\-*]*(?P<name>"
+    + "|".join(re.escape(name) for name in WRITER_ARTIFACTS)
+    + r")\s*:?\s*$"
+)
 
 PYTHON_QG_GATE_ORDER = (
     "tool_theatre",
@@ -2426,7 +2431,7 @@ def parse_writer_output_strict_json(output: str) -> dict[str, str]:
             fence_lines.append(line)
             continue
 
-        name = _artifact_name_from_text(line)
+        name = _artifact_name_from_label_line(line)
         if name in WRITER_ARTIFACTS:
             pending_name = name
 
@@ -3764,6 +3769,19 @@ def _artifact_name_from_text(text: str) -> str | None:
         if re.search(rf"(?<![\w.-]){re.escape(artifact)}(?![\w.-])", text):
             return artifact
     return None
+
+
+def _artifact_name_from_label_line(line: str) -> str | None:
+    """Return the artifact name if `line` is a standalone label line.
+
+    This is intentionally narrower than `_artifact_name_from_text`, which
+    finds artifact names embedded in fence info strings like
+    `markdown file=module.md`. Preceding labels should only count when the
+    artifact name is the line's dominant content, not when it appears in
+    prose such as `<plan_reasoning>` implementation-map rows.
+    """
+    match = _LABEL_LINE_RE.match(line)
+    return match.group("name") if match else None
 
 
 def _fence_language(info: str) -> str | None:

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -153,6 +153,7 @@ def test_parse_writer_output_strict_json() -> None:
 [
   {
     "title": "Караман Grade 10, p.176",
+    "role": "textbook",
     "notes": "Зворотні дієслова: суфікс -ся означає дію на себе."
   }
 ]
@@ -437,6 +438,116 @@ activities.yaml
         match=r"mismatched artifact label and fence name.*activities\.yaml.*vocabulary\.yaml",
     ):
         linear_pipeline.parse_writer_output_strict_json(output)
+
+
+def test_parse_writer_output_accepts_plan_reasoning_with_artifact_mentions() -> None:
+    """Regression for #1956: CoT artifact mentions are not label headers."""
+    output = '''<plan_reasoning section="Діалоги">
+<implementation_map>
+- act-5 (match-up verb-pairs) | activities.yaml | INJECT_ACTIVITY end of §Діалоги | inline match-up
+- step-2 | module.md | §Діалоги paragraphs 2-3 | prose with я/ти reflexive forms
+</implementation_map>
+</plan_reasoning>
+
+```markdown file=module.md
+# Module body
+Some prose.
+```
+
+```json file=activities.yaml
+[
+  {
+    "id": "act-1",
+    "title": "Match-up",
+    "type": "match-up",
+    "instruction": "Match these.",
+    "pairs": [
+      {"left": "вмивати", "right": "вмиватися"},
+      {"left": "одягати", "right": "одягатися"}
+    ]
+  }
+]
+```
+
+```json file=vocabulary.yaml
+[
+  {
+    "lemma": "ранок",
+    "translation": "morning",
+    "pos": "noun",
+    "usage": "Мій ранок простий."
+  }
+]
+```
+
+```json file=resources.yaml
+[
+  {"title": "Караман Grade 10, p.176", "role": "textbook"}
+]
+```
+'''
+    artifacts = linear_pipeline.parse_writer_output_strict_json(output)
+    assert set(artifacts) == {
+        "module.md",
+        "activities.yaml",
+        "vocabulary.yaml",
+        "resources.yaml",
+    }
+    assert "Module body" in artifacts["module.md"]
+    assert yaml.safe_load(artifacts["activities.yaml"])[0]["id"] == "act-1"
+
+
+def test_parse_writer_output_handles_real_m20_plan_reasoning_prefix() -> None:
+    """Replay the 2026-05-13 m20 prefix that triggered #1956."""
+    repo_root = Path(__file__).resolve().parents[2]
+    raw_path = (
+        repo_root
+        / ".worktrees/builds/a1-my-morning-20260513-122043/"
+        "curriculum/l2-uk-en/a1/my-morning/writer_output.raw.md"
+    )
+    if not raw_path.exists():
+        worktrees_root = next(
+            (parent for parent in repo_root.parents if parent.name == ".worktrees"),
+            None,
+        )
+        if worktrees_root is not None:
+            raw_path = (
+                worktrees_root
+                / "builds/a1-my-morning-20260513-122043/"
+                "curriculum/l2-uk-en/a1/my-morning/writer_output.raw.md"
+            )
+    if not raw_path.exists():
+        pytest.skip(
+            "Failed m20 build worktree not present; this optional replay "
+            "fixture preserves the real-world repro for #1956"
+        )
+
+    raw = raw_path.read_text(encoding="utf-8")
+    module_start = raw.find("```markdown file=module.md")
+    module_end = raw.find("\n```\n", module_start)
+    if module_start == -1 or module_end == -1:
+        pytest.skip("Real m20 artifact shape changed; refresh fixture")
+    prefix = raw[: module_end + len("\n```\n")]
+    completion = (
+        '\n```json file=activities.yaml\n'
+        '[{"id":"a","title":"x","type":"match-up",'
+        '"instruction":"x","pairs":[{"left":"x","right":"y"}]}]\n'
+        '```\n\n'
+        '```json file=vocabulary.yaml\n'
+        '[{"lemma":"ранок","translation":"morning","pos":"noun","usage":"x"}]\n'
+        '```\n\n'
+        '```json file=resources.yaml\n'
+        '[{"title":"x","role":"textbook"}]\n'
+        '```\n'
+    )
+
+    artifacts = linear_pipeline.parse_writer_output_strict_json(prefix + completion)
+    assert set(artifacts) == {
+        "module.md",
+        "activities.yaml",
+        "vocabulary.yaml",
+        "resources.yaml",
+    }
 
 
 def test_activity_type_field_whitelist_uses_authoring_shape() -> None:
@@ -982,7 +1093,17 @@ def _passing_qg_fixture(tmp_path: Path) -> tuple[Path, Path, Callable]:
     )
     _write_yaml(
         module_dir / "resources.yaml",
-        [{"title": "Караман Grade 10, p.176", "source_ref": "Караман Grade 10, p.176"}],
+        [
+            {
+                "title": "Караман Grade 10, p.176",
+                "role": "textbook",
+                "source_ref": "Караман Grade 10, p.176",
+            }
+        ],
+    )
+    (module_dir / "writer_tool_calls.json").write_text(
+        json.dumps([{"tool": "search_images", "args": {"query": "ранок"}}]) + "\n",
+        encoding="utf-8",
     )
 
     def fake_verify(words: list[str]) -> dict[str, list[dict]]:


### PR DESCRIPTION
## Summary

Closes **#1956** — the writer-output parser bug that halted m20 (`a1/my-morning`) V7 build under Card 1 writer-isolation on 2026-05-13.

### Primary fix
- New `_artifact_name_from_label_line` helper at `linear_pipeline.py:3771`, anchored on `_LABEL_LINE_RE` (compiled from `WRITER_ARTIFACTS`).
- Single call-site swap at `linear_pipeline.py:2426`: preceding-label detection now requires the artifact name be the **dominant content of a standalone line** (with optional markdown decoration prefix `#`, `-`, `*`, `>` and optional trailing `:`), rejecting in-prose embed matches like `| activities.yaml |` rows inside `<plan_reasoning><implementation_map>` CoT blocks.
- The fence-info-string call site at `linear_pipeline.py:2376` is **untouched** — it still needs `_artifact_name_from_text`'s embed-search semantics to extract `module.md` from `markdown file=module.md`.

### Two regression tests
- `test_parse_writer_output_accepts_plan_reasoning_with_artifact_mentions` — minimal `<plan_reasoning>` CoT case.
- `test_parse_writer_output_handles_real_m20_plan_reasoning_prefix` — real-world replay of the 2026-05-13 m20 failed `writer_output.raw.md` prefix (skips cleanly if the failed-build worktree has been removed).

### Existing adversarial guard preserved
- `test_parse_writer_output_rejects_label_vs_fence_name_mismatch` (Codex review 2026-04-26) stays green — its fixture uses a true standalone label line, which the new regex still recognizes.

### Secondary fixes — pre-existing main-red fixtures unblocked

While verifying, two unrelated tests were already red on main from recent schema/gate tightening (verified by running `pytest tests/build/test_linear_pipeline.py` on `main@d1a2d9b13d`):

1. `test_parse_writer_output_strict_json` was failing with `resources.yaml schema validation failed: item 1 requires role as str`. Added `"role": "textbook"` to the inline fixture's resources entry.
2. `test_run_python_qg_passes_structural_fixture` was failing with `Unexpected gate failures: ['resources_search_attempted']`. Added a `writer_tool_calls.json` fixture file with a `search_images` call so the new resources-search-evidence gate finds proof of resource discovery.

Both are local additive schema completions, not behavioral changes.

## Why

The 2026-05-13 m20 V7 build under Card 1 writer-isolation halted at writer-output parse. Tier-1 verification of Card 1 was clean (`tool_calls_total=12, verify_words_calls=5, tool_theatre_violations=[], end_gate_fired=true`). The writer followed prompt spec perfectly — emitting the fence-info-string form `markdown file=module.md` exclusively. The parser was over-eager. This PR unblocks Phase 2 of the student-aware immersion plan.

## Test plan

- [x] `pytest tests/build/test_linear_pipeline.py -v` → 75 passed in 2.84s (worktree)
- [x] Pre-commit hook auto-pytest → 75 passed
- [x] `pytest tests/build/test_linear_pipeline.py -v` → was 2 failed, 71 passed on `main@d1a2d9b13d` (secondary fixes confirmed needed)
- [ ] Wait for CI green on this PR before merge
- [ ] Follow-up: re-run m20 V7 build under Monitor (orchestrator handles post-merge)

## Follow-up issues to file (not in this PR)

Two further pre-existing red tests in `tests/build/` are stale assertion drift, beyond this PR's scope:
- `test_a1_20_plan_context_matches_phase_4_contract` — expects old `TARGET: 15-35% Ukrainian.` text in `IMMERSION_RULE`, but the rule now renders Phase A structural placeholders.
- `test_no_writer_rewrite_in_correction` — expects `"modify in place via append/insert, never re-author or regenerate"` but the template now has `"Modify in place via append/insert. Never re-author or regenerate."` (capital M, period separators).

🤖 Filed by orchestrator after dispatch `parser-label-tightening-2026-05-13` completed (Codex GPT-5.5, 279s).