### PR TITLE
fix(writer-prompt): document non-textbook role url requirement (#1959)

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -219,6 +219,21 @@ In `resources.yaml`, every entry MUST have a `role` field. Valid roles:
 `textbook` (📚), `youtube` (📺), `video` (🎥), `blog` (📝), `podcast` (🎧),
 `audio` (🎧), `article` (📄), `wiki` (🔗).
 
+**Schema rule for non-textbook roles: `url:` is REQUIRED.**
+
+The deterministic schema enforces:
+- `role: textbook` entries do NOT require `url:`.
+- All other roles (`youtube`, `video`, `blog`, `podcast`, `audio`, `article`, `wiki`) REQUIRE a non-empty `url:` field. Schema validation halts the build on any missing URL for these roles.
+
+If you cannot provide a **verified** URL for a non-textbook entry — e.g. the multimedia search returned no usable URL, or the wiki source registry shows only a placeholder identifier like `ext-article-N` with no real title and no URL — **OMIT THE ENTRY ENTIRELY**. Do not emit:
+
+- `url: null`
+- `url: ""`
+- `url: TBD`
+- the entry without the `url:` field
+
+All four patterns fail schema validation. The `resources_search_attempted` gate counts the multimedia search **attempt** in your telemetry, so honest omission of an unverifiable entry does NOT regress the search-obligation gate. Truthful omission is preferred over schema violation (compare MEMORY #M-4: deterministic over hallucination).
+
 ### Phonetic rules — MUST emit IPA notation
 
 For every entry under `phonetic_rules:` in the Wiki Obligations Manifest, the

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -2020,6 +2020,31 @@ def test_linear_write_prompt_carries_anti_meta_narration_directive() -> None:
         )
 
 
+def test_linear_write_prompt_documents_non_textbook_role_url_requirement() -> None:
+    """Regression for #1959: non-textbook resource entries require url:.
+
+    The writer prompt lists valid roles, but the deterministic schema only
+    allows `role: textbook` without a URL. This guards the direct instruction
+    that unverifiable non-textbook entries should be omitted, not emitted with
+    missing or placeholder URLs.
+    """
+    prompt_text = (
+        linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+    ).read_text(encoding="utf-8")
+
+    assert "role: textbook" in prompt_text, (
+        "Template should reference role: textbook in the schema-rule explanation"
+    )
+    assert "OMIT THE ENTRY" in prompt_text, (
+        "Template should instruct the writer to omit entries without verifiable URL"
+    )
+    normalized_prompt = prompt_text.lower()
+    assert (
+        "requires url" in normalized_prompt
+        or "require a non-empty `url:`" in normalized_prompt
+    ), "Template should explicitly state non-textbook roles require url"
+
+
 def test_linear_write_prompt_references_component_props_schema_token() -> None:
     """The writer prompt must consume `{COMPONENT_PROPS_SCHEMA}` somewhere.
 


### PR DESCRIPTION
## Summary

- Single-file prompt template edit: adds a "Schema rule for non-textbook roles: \`url:\` is REQUIRED" directive to \`scripts/build/phases/linear-write.md\` § "External Resources" after the Valid roles list.
- Instructs the writer to OMIT entries with no verifiable URL for non-textbook roles, NOT emit them with placeholder/missing URL (which the schema rejects).
- Reinforces MEMORY #M-4 alignment: honest omission preferred over schema violation.
- Regression test in \`tests/build/test_linear_pipeline.py\` asserts the directive's key phrases.

## Why

m20 (\`a1/my-morning\`) V7 build under Card 1 writer-isolation halted on 2026-05-13 at \`resources.yaml\` schema validation with \`role 'podcast' requires url\`. Tier 1 verification (writer-isolation gates) was clean. The writer (\`claude-tools\`) correctly refused to fabricate a URL per #M-4 but kept the entry instead of omitting it — because the writer prompt never explained the schema constraint.

## Test plan

- [x] \`pytest tests/build/test_linear_pipeline.py -v\` — all green including new regression test
- [x] \`ruff check scripts/build/ tests/build/test_linear_pipeline.py\` — clean
- [ ] Follow-up: re-run m20 V7 build under Monitor (orchestrator handles post-merge)

## Related

- **Surfaces** #1960 (wiki ingestion gap: \`ext-article-N\` placeholder stubs in \`wiki/pedagogy/*.sources.yaml\` — deeper architectural fix, tracked separately).
- **Builds on** #1957 (writer-output parser fix — m20's first halt) and #1953 (Card 1 writer-isolation).

Closes #1959.

🤖 Generated with [Codex CLI](https://github.com/openai/codex-cli)