### PR TITLE
fix(vesum_gate): scope extraction across 4 leak surfaces (#1962 gate 1)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -507,7 +507,7 @@ _SENTENCE_SPLIT_RE = re.compile(
 # them. Excluded from VESUM lookup only for error-correction activities.
 _ERROR_CORRECTION_TYPE = "error-correction"
 _ERROR_CORRECTION_INTENTIONAL_FIELDS = frozenset(
-    {"error", "errors", "errorWord", "error_word", "sentence"}
+    {"error", "errors", "errorWord", "error_word", "explanation", "sentence"}
 )
 _VESUM_ABBREVIATION_RE = re.compile(r"\bдіал\.", re.IGNORECASE)
 
@@ -4510,6 +4510,20 @@ def _strip_metalinguistic(text: str) -> str:
     return text
 
 
+_USAGE_PARENTHETICAL_RE = re.compile(r"\([^()]*\)")
+
+
+def _strip_usage_parentheticals(text: str) -> str:
+    """Strip vocabulary-usage parentheticals before VESUM lookup.
+
+    Vocabulary `usage:` fields sometimes append English or grammatical notes
+    after the Ukrainian sample sentence, e.g. `(стем + -л- ...)`. Those notes
+    are not asserted Ukrainian prose, while parentheticals in module prose can
+    be meaningful learner-facing Ukrainian, so this is usage-field specific.
+    """
+    return _USAGE_PARENTHETICAL_RE.sub(" ", text)
+
+
 def _build_vesum_text(
     module_text: str,
     activities: list[dict[str, Any]],
@@ -4523,7 +4537,8 @@ def _build_vesum_text(
     for entry in vocabulary:
         if isinstance(entry, dict):
             parts.append(_strip_metalinguistic(str(entry.get("lemma", ""))))
-            parts.append(_strip_metalinguistic(str(entry.get("usage", ""))))
+            usage = _strip_usage_parentheticals(str(entry.get("usage", "")))
+            parts.append(_strip_metalinguistic(usage))
     for entry in resources:
         if isinstance(entry, dict):
             parts.append(_strip_metalinguistic(str(entry.get("title", ""))))
@@ -4544,13 +4559,42 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
     options with falsy `correct` is an intentional wrong answer. Skip only that
     option's text leaf so correct options and surrounding prompts are still
     verified.
+
+    For fill-in activities, bare-list `options:` values are suffix fragments,
+    not VESUM lemmas. For quiz-like item dicts with `options:` plus `answer:`,
+    only the option equal to the answer is verified; sibling distractors can be
+    fabricated wrong forms.
     """
-    if activity.get("type") == _ERROR_CORRECTION_TYPE:
-        skip_subtree = _ERROR_CORRECTION_INTENTIONAL_FIELDS
-    else:
-        skip_subtree = frozenset()
+    activity_type = activity.get("type")
+    skip_subtree = (
+        _ERROR_CORRECTION_INTENTIONAL_FIELDS
+        if activity_type == _ERROR_CORRECTION_TYPE
+        else frozenset()
+    )
 
     out: list[str] = []
+
+    def answer_values(answer: Any) -> set[str]:
+        if isinstance(answer, str):
+            return {answer}
+        if isinstance(answer, list):
+            return {item for item in answer if isinstance(item, str)}
+        return set()
+
+    def walk_answer_options(options: Any, answers: set[str]) -> None:
+        if not answers:
+            return
+        if isinstance(options, list):
+            for option in options:
+                if isinstance(option, str):
+                    if option in answers:
+                        walk(option, "options")
+                elif isinstance(option, dict):
+                    text = option.get("text")
+                    if isinstance(text, str) and text in answers:
+                        walk(option, "options", in_options_list=True)
+        elif isinstance(options, str) and options in answers:
+            walk(options, "options")
 
     def walk(node: Any, parent_key: str | None, *, in_options_list: bool = False) -> None:
         if isinstance(node, dict):
@@ -4562,6 +4606,15 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
             )
             for key, child in node.items():
                 if key in skip_subtree:
+                    continue
+                if activity_type == "fill-in" and key == "options":
+                    continue
+                if activity_type == "fill-in" and key == "answer":
+                    options = node.get("options")
+                    if isinstance(options, list) and child in options:
+                        continue
+                if key == "options" and "answer" in node:
+                    walk_answer_options(child, answer_values(node.get("answer")))
                     continue
                 if wrong_option and key == "text":
                     continue

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1112,6 +1112,20 @@ def _passing_qg_fixture(tmp_path: Path) -> tuple[Path, Path, Callable]:
     return module_dir, plan_path, fake_verify
 
 
+def _build_fake_verify_words(
+    known: dict[str, bool],
+) -> Callable[[list[str]], dict[str, list[dict]]]:
+    def fake_verify(words: list[str]) -> dict[str, list[dict]]:
+        return {
+            word: [{"lemma": word, "pos": "x", "tags": ""}]
+            if known.get(word, False)
+            else []
+            for word in words
+        }
+
+    return fake_verify
+
+
 def test_ai_slop_gate_ignores_correction_field_in_error_correction_activity(
     tmp_path: Path,
 ) -> None:
@@ -1644,6 +1658,227 @@ def test_vesum_gate_skips_nested_error_subtree_in_error_correction(
     assert "прокидаєштся" not in forwarded, (
         f"intentional typo leaked from nested error: subtree: {forwarded}"
     )
+
+
+def test_vesum_gate_skips_fillin_options_bare_list() -> None:
+    """Regression for #1962 gate 1 leak 1. fill-in options are fragments."""
+    activities = [
+        {
+            "id": "act-2",
+            "type": "fill-in",
+            "items": [
+                {
+                    "sentence": "Я вмива___ о сьомій.",
+                    "answer": "юся",
+                    "options": ["юся", "єшся", "ється"],
+                }
+            ],
+        }
+    ]
+    fake_verify = _build_fake_verify_words(known={"вмива": True, "сьомій": True})
+    report = linear_pipeline._vesum_gate(
+        module_text="",
+        activities=activities,
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    assert "юся" not in report["missing"]
+    assert "єшся" not in report["missing"]
+    assert "ється" not in report["missing"]
+    assert report["passed"] is True
+
+
+def test_vesum_gate_skips_quiz_options_distractors() -> None:
+    """Regression for #1962 gate 1 leak 2. quiz non-answer options are distractors."""
+    activities = [
+        {
+            "id": "act-1",
+            "type": "quiz",
+            "items": [
+                {
+                    "question": "Я ___ каву.",
+                    "options": ["п'юся", "п'ю"],
+                    "answer": "п'ю",
+                }
+            ],
+        }
+    ]
+    fake_verify = _build_fake_verify_words(known={"каву": True, "п'ю": True})
+    report = linear_pipeline._vesum_gate(
+        module_text="",
+        activities=activities,
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    assert "п'юся" not in report["missing"]
+    assert report["passed"] is True
+
+
+def test_vesum_gate_skips_error_correction_explanation() -> None:
+    """Regression for #1962 gate 1 leak 3. explanations cite wrong forms."""
+    activities = [
+        {
+            "id": "act-8",
+            "type": "error-correction",
+            "items": [
+                {
+                    "sentence": "На сніданок я завжди їм завтрак.",
+                    "error": "завтрак",
+                    "correction": "сніданок",
+                    "explanation": (
+                        "«Завтрак» is a Russianism. Standard Ukrainian: сніданок."
+                    ),
+                }
+            ],
+        }
+    ]
+    fake_verify = _build_fake_verify_words(known={"сніданок": True})
+    report = linear_pipeline._vesum_gate(
+        module_text="",
+        activities=activities,
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    assert "Завтрак" not in report["missing"]
+    assert "завтрак" not in report["missing"]
+    assert report["passed"] is True
+
+
+def test_vesum_gate_strips_vocabulary_usage_parentheticals() -> None:
+    """Regression for #1962 gate 1 leak 4. usage parentheticals can be meta."""
+    vocabulary = [
+        {
+            "lemma": "дивлюся",
+            "pos": "verb",
+            "usage": "Я дивлюся у дзеркало (стем + -л- у 1-й особі однини).",
+        }
+    ]
+    fake_verify = _build_fake_verify_words(
+        known={"дивлюся": True, "дзеркало": True}
+    )
+    report = linear_pipeline._vesum_gate(
+        module_text="",
+        activities=[],
+        vocabulary=vocabulary,
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    assert "стем" not in report["missing"]
+    assert report["passed"] is True
+
+
+def test_vesum_gate_passes_m20_build_3_artifacts() -> None:
+    """Replay m20 build #3 leak forms without requiring the build worktree."""
+    build_dir = (
+        Path(__file__).resolve().parents[2]
+        / ".worktrees/builds/a1-my-morning-20260513-164953"
+        / "curriculum/l2-uk-en/a1/my-morning"
+    )
+    if build_dir.exists():
+        module_text = (build_dir / "module.md").read_text(encoding="utf-8")
+        activities = yaml.safe_load(
+            (build_dir / "activities.yaml").read_text(encoding="utf-8")
+        )
+        vocabulary = yaml.safe_load(
+            (build_dir / "vocabulary.yaml").read_text(encoding="utf-8")
+        )
+        resources = yaml.safe_load(
+            (build_dir / "resources.yaml").read_text(encoding="utf-8")
+        )
+    else:
+        module_text = ""
+        activities = [
+            {
+                "id": "act-1",
+                "type": "quiz",
+                "items": [
+                    {
+                        "question": "Я ___ каву о восьмій.",
+                        "options": ["п'юся", "п'ю"],
+                        "answer": "п'ю",
+                    }
+                ],
+            },
+            {
+                "id": "act-2",
+                "type": "fill-in",
+                "items": [
+                    {
+                        "sentence": "Я вмива___ о сьомій.",
+                        "answer": "юся",
+                        "options": ["юся", "єшся", "ється"],
+                    },
+                    {
+                        "sentence": "Ми збира___ швидко.",
+                        "answer": "ємося",
+                        "options": ["теся", "ємося", "єтеся", "ються"],
+                    },
+                ],
+            },
+            {
+                "id": "act-8",
+                "type": "error-correction",
+                "items": [
+                    {
+                        "sentence": "На сніданок я завжди їм завтрак.",
+                        "error": "завтрак",
+                        "correction": "сніданок",
+                        "explanation": (
+                            "«Завтрак» is a Russianism; do not use користу- here."
+                        ),
+                    }
+                ],
+            },
+        ]
+        vocabulary = [
+            {
+                "lemma": "дивлюся",
+                "pos": "verb",
+                "usage": "Я дивлюся у дзеркало (стем + -л- у 1-й особі однини).",
+            }
+        ]
+        resources = []
+
+    leaked_forms = {
+        "Завтрак",
+        "користу",
+        "п'юся",
+        "стем",
+        "теся",
+        "юся",
+        "ються",
+        "ємося",
+        "єтеся",
+        "ється",
+        "єшся",
+    }
+    known = {
+        "восьмій": True,
+        "вмива": True,
+        "дзеркало": True,
+        "дивлюся": True,
+        "збира": True,
+        "каву": True,
+        "о": True,
+        "п'ю": True,
+        "сніданок": True,
+        "сьомій": True,
+        "швидко": True,
+    }
+    report = linear_pipeline._vesum_gate(
+        module_text=module_text,
+        activities=activities,
+        vocabulary=vocabulary,
+        resources=resources,
+        verify_words_fn=_build_fake_verify_words(known=known),
+    )
+
+    assert leaked_forms.isdisjoint(report["missing"])
+    if not build_dir.exists():
+        assert report["passed"] is True
 
 
 def test_immersion_gate_recognizes_unicode_sentence_boundaries(


### PR DESCRIPTION
## Summary

- Adds \`explanation\` to \`_ERROR_CORRECTION_INTENTIONAL_FIELDS\` (leak 3).
- Extends \`_activity_vesum_text\` to skip bare-list \`options:\` for \`type: fill-in\` and to skip non-\`answer\` entries in bare-list \`options:\` for \`type: quiz\` / \`match-up\` / \`true-false\` (leaks 1+2).
- Adds \`_strip_usage_parentheticals\` helper called in \`_build_vesum_text\` vocabulary loop (leak 4).
- 5 regression tests covering each leak surface + an integration replay of m20 build #3's actual artifacts.

## Why

m20 V7 build #3 halted at \`vesum_verified\` after ADR-008 correction. All 11 reported missing forms were legitimate non-Ukrainian-assertion contexts (suffix fragments in fill-in options, distractor wrong-forms in quiz options, capitalized wrong-form references in error-correction explanations, English meta-linguistic terms in vocabulary usage parentheticals). The fix tightens gate scope without weakening the gate's real job (verifying actual Ukrainian-text assertions).

## Test plan

- [x] \`pytest tests/build/test_linear_pipeline.py -v\` — all green including 5 new tests
- [x] \`ruff check\` — clean
- [ ] Follow-up: orchestrator re-runs m20 V7 build (#4) post-merge to confirm gate now passes

Closes #1962 gate 1. Gates 2-4 deserve joint design — not in this PR's scope.

🤖 Generated with [Codex CLI](https://github.com/openai/codex-cli)