### PR TITLE
fix(a1-m15-24-contract): bundled implementation — writer prompt + gate counter + matcher (#1962 gates 2-4)

### DIFF
--- a/scripts/build/citation_matcher.py
+++ b/scripts/build/citation_matcher.py
@@ -109,3 +109,16 @@ def extract_citation_key(value: Any) -> CitationKey | None:
 
 def fold_citation_author(author: str) -> str:
     return re.sub(r"[^a-z]", "", author.casefold().translate(_CYRILLIC_TO_LATIN))
+
+
+def citation_keys_match(
+    citation: CitationKey,
+    plan_reference: CitationKey,
+    *,
+    page_tolerance: int = 5,
+) -> bool:
+    return (
+        citation.author == plan_reference.author
+        and citation.grade == plan_reference.grade
+        and abs(citation.page - plan_reference.page) <= page_tolerance
+    )

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -30,6 +30,8 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 from scripts.audit.failure_classes import FailureClass, FailureRecord
 from scripts.build.citation_matcher import (
+    CitationKey,
+    citation_keys_match,
     extract_citation_key,
     extract_plan_reference_titles,
     normalize_citation_ref,
@@ -3693,7 +3695,14 @@ def run_python_qg(
     )
     record("immersion_advisory", _advisory_immersion_pct(module_text, plan))
     record("l2_exposure_floor", _l2_exposure_floor_gate(module_text, plan))
-    record("long_uk_ceiling", _long_uk_ceiling_gate(module_text, plan))
+    record(
+        "long_uk_ceiling",
+        _long_uk_ceiling_gate(
+            module_text,
+            plan,
+            grounding_evidence=gates.get("textbook_grounding"),
+        ),
+    )
     record("component_density", _component_density_gate(module_text, plan))
     record("inject_activity_ids", _inject_activity_gate(module_text, activities))
     record(
@@ -4713,7 +4722,10 @@ def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> 
         source_key = extract_citation_key(source_ref)
         if (
             normalized_ref not in plan_titles
-            and source_key not in plan_keys
+            and (
+                source_key is None
+                or not any(citation_keys_match(source_key, plan_key) for plan_key in plan_keys)
+            )
             and resource.get("packet_chunk_id") is None
         ):
             unknown.append(source_ref)
@@ -5087,8 +5099,10 @@ def _reference_matches_result(
             str(result.get("source_ref") or ""),
             result_text,
         ]
-        if any(extract_citation_key(text) == ref_key for text in citation_texts if text):
-            return True
+        for text in citation_texts:
+            result_key = extract_citation_key(text)
+            if result_key is not None and citation_keys_match(result_key, ref_key):
+                return True
     normalized_ref = _normalize_citation_ref(reference_title).casefold()
     normalized_result = _normalize_citation_ref(result_text).casefold()
     return bool(normalized_ref and normalized_ref in normalized_result)
@@ -5391,11 +5405,21 @@ def _count_uk_example_bullets(text: str) -> int:
     )
 
 
-def _long_uk_ceiling_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+def _long_uk_ceiling_gate(
+    text: str,
+    plan: Mapping[str, Any],
+    *,
+    grounding_evidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     policy = get_immersion_policy(str(plan["level"]).lower(), int(plan["sequence"]))
     max_unsupported = int(policy["max_unsupported_uk_words"])
     support_proximity = int(policy["support_proximity"])
-    runs = _unsupported_uk_runs(text, max_unsupported, support_proximity)
+    runs = _unsupported_uk_runs(
+        text,
+        max_unsupported,
+        support_proximity,
+        grounding_evidence=grounding_evidence,
+    )
     return {
         "passed": not runs,
         "required": {
@@ -5413,13 +5437,18 @@ def _unsupported_uk_runs(
     text: str,
     max_unsupported: int,
     support_proximity: int,
+    *,
+    grounding_evidence: Mapping[str, Any] | None = None,
 ) -> list[str]:
     text = _strip_frontmatter_and_headings(_strip_comments(text))
     text = _FENCED_CODE_RE.sub(" ", text)
     text = _JSX_BLOCK_RE.sub(" ", text)
     text = re.sub(r"(?m)^\s*\|.*\|\s*$", " ", text)
     offending: list[str] = []
-    for segment in _unsupported_run_segments(text):
+    for segment in _unsupported_run_segments(
+        text,
+        grounding_evidence=grounding_evidence,
+    ):
         tokens = list(_WORD_RE.finditer(segment))
         run_start: int | None = None
         run_end: int | None = None
@@ -5448,25 +5477,82 @@ def _unsupported_uk_runs(
     return offending[:5]
 
 
-def _unsupported_run_segments(text: str) -> list[str]:
+def _unsupported_run_segments(
+    text: str,
+    *,
+    grounding_evidence: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """Return UK runs that lack inline English support.
+
+    Citation-grounded source blockquotes are exempted as textbook grounding,
+    not learner-target prose. Learner practice blockquotes remain in scope.
+    """
+    grounded_keys = _grounded_citation_keys(grounding_evidence)
     segments: list[str] = []
     prose_lines: list[str] = []
+    quote_lines: list[str] = []
+
+    def flush_prose() -> None:
+        nonlocal prose_lines
+        if prose_lines:
+            segments.append("\n".join(prose_lines))
+            prose_lines = []
+
+    def flush_quote() -> None:
+        nonlocal quote_lines
+        if quote_lines:
+            quote_text = "\n".join(quote_lines)
+            if not _is_grounded_source_blockquote(quote_text, grounded_keys):
+                segments.append(quote_text)
+            quote_lines = []
+
     for line in text.splitlines():
-        if re.match(r"^\s*(?:[-*]\s+|>\s*)", line):
-            if prose_lines:
-                segments.append("\n".join(prose_lines))
-                prose_lines = []
+        quote_match = re.match(r"^\s*>\s?(?P<body>.*)$", line)
+        if quote_match:
+            flush_prose()
+            quote_lines.append(quote_match.group("body"))
+            continue
+        if re.match(r"^\s*[-*]\s+", line):
+            flush_prose()
+            flush_quote()
             segments.append(line)
             continue
         if not line.strip():
-            if prose_lines:
-                segments.append("\n".join(prose_lines))
-                prose_lines = []
+            flush_prose()
+            flush_quote()
             continue
+        flush_quote()
         prose_lines.append(line)
-    if prose_lines:
-        segments.append("\n".join(prose_lines))
+    flush_prose()
+    flush_quote()
     return segments
+
+
+def _grounded_citation_keys(
+    grounding_evidence: Mapping[str, Any] | None,
+) -> set[CitationKey]:
+    if not isinstance(grounding_evidence, Mapping):
+        return set()
+    matched = grounding_evidence.get("matched")
+    if not isinstance(matched, list):
+        return set()
+    return {
+        key
+        for value in matched
+        if (key := extract_citation_key(value)) is not None
+    }
+
+
+def _is_grounded_source_blockquote(
+    quote_text: str,
+    grounded_keys: set[CitationKey],
+) -> bool:
+    if not grounded_keys:
+        return False
+    quote_key = extract_citation_key(quote_text)
+    if quote_key is None:
+        return False
+    return any(citation_keys_match(quote_key, grounded_key) for grounded_key in grounded_keys)
 
 
 def _append_unsupported_run(

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -82,6 +82,12 @@ that failure class. Run each check while drafting, not as a separate pass.
 
    **Verbatim textbook grounding (mandatory).** For each `plan_references` entry, you MUST call `mcp__sources__search_text` with a query targeting that textbook + topic, then quote at least one verbatim block (≥30 words) inline in the relevant section. The citation must include the textbook author + grade + page extracted from the search result, and the quote must be set off as a blockquote so reviewers can verify it. Inventing or paraphrasing in place of retrieving is a hard fail (`textbook_grounding`).
 
+   **Citation discipline.** Sources cited in `module.md` blockquotes and listed in `resources.yaml` MUST be either:
+   1. Listed in the module's `plan_references` (the matcher allows fuzzy match on author + grade + small page drift), OR
+   2. Grounded in a Knowledge Packet retrieval the writer's `mcp__sources__search_text` call actually returned. Cite the chunk's textbook + grade + page verbatim from the search result.
+
+   Do NOT add textbook references outside `plan_references` unless option 2 holds and the citation appears in your `writer_tool_calls.json` evidence. Adding ungrounded out-of-plan citations causes `citations_resolve` to fail and the build to halt.
+
 For heritage defense, route lookups through the canonical MCP tools in this order: (1) `mcp__sources__search_heritage` is the primary entry point — it merges Грінченко 1907, ЕСУМ, slovnyk.me modern/regional dictionaries, and Антоненко-Давидович style warnings, ranking pre-Soviet attestations above modern-only rows. (2) Use `mcp__sources__search_slovnyk_me` only when you specifically need a slovnyk.me single-source result (e.g. СУМ-20 or a regional dictionary not surfaced by `search_heritage`). (3) Standard tools — `check_modern_form` (VESUM), `search_grinchenko_1907`, `search_esum`, literary corpus, and compiled wiki/source citations — remain valid evidence sources alongside the merged heritage tool. Cite the tool name and the dictionary slug in your `<plan_reasoning verification="...">` block. Do not claim heritage verification without naming a concrete tool result.
 For slovnyk.me rows, use only canonical `dictionary_slug` values defined by `scripts/wiki/slovnyk_me.py`, especially heritage slugs `newsum`, `holoskevych`, `obsolete_words`, `bukovina`, `franko`, and `slang_lviv`; for merged `search_heritage` rows without `dictionary_slug`, cite `source_family`, `source`, and `classification`. Include the first 80 characters of the raw tool-result `text` verbatim in `<plan_reasoning>`. If `search_heritage` returns empty, emit `<!-- VERIFY: heritage status for "X" unresolved -->` rather than asserting heritage status.
 
@@ -311,6 +317,22 @@ for a teacher narrating their own lesson plan. Hold to this register:
 - **Section length is bounded by the contract YAML.** If you find yourself
   expanding an English bridge sentence, cut it instead. Word budgets are
   authoritative.
+
+**Dialogue format (REQUIRED for gate counting).** All Ukrainian dialogue lines MUST be emitted as one of:
+
+- `<DialogueBox uk="..." en="...">` JSX component (preferred for V7 rendering), or
+- `> `-prefixed Markdown blockquote (Markdown fallback)
+
+The `l2_exposure_floor` gate counts only these two forms. **Em-dash dialogue lines (e.g. `— Привіт, Насте!`) under a `## Діалоги` heading WITHOUT `<DialogueBox>` or `> ` wrapping are an anti-pattern** — the gate cannot count them and the module will fail the dialogue-line floor even when the dialogue is pedagogically present.
+
+Default to `<DialogueBox>` for new modules; `> ` blockquote acceptable when a multi-line dialogue is more naturally rendered as quoted prose.
+
+**Inline gloss for dialogue lines (REQUIRED to clear `long_uk_ceiling`).** Each Ukrainian dialogue line MUST have an inline English gloss within 8 tokens of proximity. Two valid shapes:
+
+- Italic gloss directly after the UK line: `— Привіт, Насте! *(Hi, Nastia!)*`
+- Inside the same DialogueBox prop: `<DialogueBox uk="..." en="...">`
+
+**Anti-pattern: block-bottom gloss.** Do NOT emit all UK dialogue lines first and then a separate "translation:" / "English:" block at the bottom. This causes `long_uk_ceiling` to flag the entire UK run as one unsupported segment, even when every line has a corresponding English translation farther down.
 
 ## Activity Types
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -2091,6 +2091,80 @@ def test_immersion_gate_strips_jsx_blocks_before_long_sentence_check(
     )
 
 
+def test_long_uk_ceiling_exempts_citation_grounded_source_blockquote() -> None:
+    """#1962: source blockquotes cited by textbook_grounding are exempt."""
+    text = (
+        "## Дієслова на -ся\n\n"
+        "> **Караман, 10 клас, с. 176:** *Дієслова із суфіксом -ся(-сь), "
+        "які виражають зворотну дію, називаються зворотними: навчатися, "
+        "закохатися. Сучасний дієслівний суфікс -ся(-сь) — це давня "
+        "коротка форма зворотного займенника себе в Зн. в. однини: "
+        "Я не боюся. — Я ся не бою (діал.). Уживається -ся(-сь) після "
+        "інфінітивного суфікса.*\n\n"
+        "## Мій ранок\n\n"
+        "> Спочатку прокидаюся, потім вмиваюся і одягаюся, після цього "
+        "снідаю і п'ю каву, нарешті йду на роботу — це мій типовий "
+        "ранковий розпорядок без жодних відхилень.\n"
+    )
+    grounding_evidence = {
+        "matched": ["Караман Grade 10, p.176"],
+        "blockquotes_checked": 2,
+    }
+    plan = {"level": "a1", "sequence": 20, "word_target": 1200}
+
+    report = linear_pipeline._long_uk_ceiling_gate(
+        text,
+        plan,
+        grounding_evidence=grounding_evidence,
+    )
+
+    assert not any("Караман" in run for run in report.get("offending_runs", [])), (
+        f"Karaman source blockquote should be exempt; got {report['offending_runs']}"
+    )
+
+
+def test_long_uk_ceiling_still_flags_uncited_learner_blockquote() -> None:
+    """Without citation grounding, learner practice blockquotes stay in scope."""
+    text = (
+        "## Мій ранок\n\n"
+        "> Спочатку прокидаюся о сьомій ранку коли ще темно за вікном "
+        "потім швидко вмиваюся холодною водою бо нагрівач зламався і "
+        "одягаюся в найтепліший одяг щоб не змерзнути коли поспішаю "
+        "до автобуса о восьмій тридцять.\n"
+    )
+    plan = {"level": "a1", "sequence": 20, "word_target": 1200}
+
+    report = linear_pipeline._long_uk_ceiling_gate(
+        text,
+        plan,
+        grounding_evidence={"matched": [], "blockquotes_checked": 1},
+    )
+
+    assert report.get("offending_runs") or report.get("passed") is False
+
+
+def test_citation_matcher_allows_small_page_drift_same_author_grade() -> None:
+    """#1962: same author + grade may drift by a few pages."""
+    result = linear_pipeline._citation_gate(
+        [{"source_ref": "Кравцова, Українська мова, 4 клас, с. 112"}],
+        {"references": [{"title": "Кравцова Grade 4, p.113"}]},
+    )
+
+    assert result["passed"] is True
+    assert result["unknown"] == []
+
+
+def test_citation_matcher_rejects_different_grade_even_small_page() -> None:
+    """Different grade means a different lesson, even with nearby pages."""
+    result = linear_pipeline._citation_gate(
+        [{"source_ref": "Аврамченко, Українська мова, 6 клас, с. 112"}],
+        {"references": [{"title": "Аврамченко Grade 4, p.113"}]},
+    )
+
+    assert result["passed"] is False
+    assert result["unknown"] == ["Аврамченко, Українська мова, 6 клас, с. 112"]
+
+
 def test_run_python_qg_passes_structural_fixture(tmp_path: Path) -> None:
     """Smoke test: the baseline `_passing_qg_fixture` produces a green report.
 
@@ -2278,6 +2352,40 @@ def test_linear_write_prompt_documents_non_textbook_role_url_requirement() -> No
         "requires url" in normalized_prompt
         or "require a non-empty `url:`" in normalized_prompt
     ), "Template should explicitly state non-textbook roles require url"
+
+
+def test_linear_write_prompt_mandates_dialoguebox_or_blockquote_for_dialogues() -> None:
+    """#1962: writer must emit dialogues in gate-countable form."""
+    template = (
+        linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+    ).read_text(encoding="utf-8")
+
+    assert "DialogueBox" in template
+    assert "blockquote" in template.lower() or "`> `" in template
+    assert "em-dash" in template.lower() or "anti-pattern" in template.lower()
+
+
+def test_linear_write_prompt_requires_inline_gloss_within_8_tokens() -> None:
+    """#1962: each dialogue line needs inline English gloss."""
+    template = (
+        linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+    ).read_text(encoding="utf-8")
+    lower_template = template.lower()
+
+    assert "inline gloss" in lower_template or "inline english" in lower_template
+    assert "8 tokens" in template or "8 words" in template or "within 8" in template
+    assert "block-bottom" in lower_template or "block bottom" in lower_template
+
+
+def test_linear_write_prompt_restricts_non_plan_citations() -> None:
+    """#1962: writer must not invent out-of-plan citations."""
+    template = (
+        linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+    ).read_text(encoding="utf-8")
+
+    assert "plan_references" in template
+    assert "Knowledge Packet" in template or "writer_tool_calls" in template
+    assert "citations_resolve" in template
 
 
 def test_linear_write_prompt_references_component_props_schema_token() -> None:


### PR DESCRIPTION
## Summary

Implements the bundled a1-m15-24 shape contract for #1962 gates 2-4:

- writer prompt now mandates gate-countable dialogue shape, inline dialogue glosses, and bounded citation discipline
- `long_uk_ceiling` now exempts citation-grounded textbook source blockquotes while keeping learner blockquotes in scope
- citation matching now allows small page drift only within the same author + grade

Decision Card: `docs/decisions/pending/2026-05-13-a1-m15-24-shape-contract.md`

Closes #1962 gates 2-4

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/build/test_linear_pipeline.py -v`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pytest tests/test_citation_resolve.py tests/test_citation_whitespace.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/ tests/build/`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
