### PR TITLE
fix(immersion_gates): extract uk= attribute for V7 DialogueBox (#1965)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5629,7 +5629,14 @@ def _jsx_tag(jsx_block: str) -> str | None:
 
 
 def _jsx_text_values(jsx_block: str) -> list[str]:
-    return re.findall(r"\btext\s*(?:=|:)\s*\"([^\"\n]*)\"", jsx_block)
+    """Extract canonical UK-content attributes from V7 components.
+
+    `text=` is the legacy convention; `uk=` is the V7 DialogueBox convention
+    introduced by the a1-m15-24 shape contract (#1964 / PR #1962).
+    """
+    text_attrs = re.findall(r"\btext\s*(?:=|:)\s*\"([^\"\n]*)\"", jsx_block)
+    uk_attrs = re.findall(r"\buk\s*(?:=|:)\s*\"([^\"\n]*)\"", jsx_block)
+    return text_attrs + uk_attrs
 
 
 def _component_language_text(tag: str, jsx_block: str) -> str:

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -59,6 +59,37 @@ def test_plan_check_rejects_missing_required_key(tmp_path: Path) -> None:
         linear_pipeline.plan_check(path)
 
 
+def test_jsx_text_values_extracts_uk_attribute() -> None:
+    result = linear_pipeline._jsx_text_values(
+        '<DialogueBox uk="привіт" en="hi" />'
+    )
+
+    assert result == ["привіт"]
+
+
+def test_jsx_text_values_extracts_legacy_text_attribute() -> None:
+    result = linear_pipeline._jsx_text_values('<DialogueBox text="привіт" />')
+
+    assert result == ["привіт"]
+
+
+def test_jsx_text_values_extracts_both_when_present() -> None:
+    result = linear_pipeline._jsx_text_values(
+        '<DialogueBox text="доброго ранку" /><DialogueBox uk="як справи?" en="how are you?" />'
+    )
+
+    assert result == ["доброго ранку", "як справи?"]
+
+
+def test_component_language_text_dialoguebox_uk_prop() -> None:
+    result = linear_pipeline._component_language_text(
+        "DialogueBox",
+        '<DialogueBox uk="привіт" en="hi" />',
+    )
+
+    assert result == "привіт"
+
+
 def test_render_phase_prompt_fills_registered_tokens() -> None:
     plan_path = linear_pipeline.plan_path_for("a1", "my-morning")
     plan = linear_pipeline.plan_check(plan_path)

--- a/tests/test_immersion_gates.py
+++ b/tests/test_immersion_gates.py
@@ -101,6 +101,63 @@ def test_l2_exposure_floor_pass() -> None:
     assert result["observed"]["vocab_entries"] >= result["required"]["vocab_entries"]
 
 
+def test_l2_exposure_floor_credits_dialoguebox_uk_prop() -> None:
+    dialogue_lines = [
+        '<DialogueBox uk="Я прокидаюся о сьомій." en="I wake up at seven." />',
+        '<DialogueBox uk="Я вмиваюся швидко." en="I wash up quickly." />',
+        '<DialogueBox uk="Я одягаюся вдома." en="I get dressed at home." />',
+        '<DialogueBox uk="Я снідаю на кухні." en="I eat breakfast in the kitchen." />',
+        '<DialogueBox uk="Я пʼю теплу воду." en="I drink warm water." />',
+        '<DialogueBox uk="Я читаю повідомлення." en="I read messages." />',
+        '<DialogueBox uk="Я беру синю сумку." en="I take a blue bag." />',
+        '<DialogueBox uk="Я йду до зупинки." en="I go to the stop." />',
+        '<DialogueBox uk="Я чекаю автобус." en="I wait for the bus." />',
+        '<DialogueBox uk="Я слухаю подкаст." en="I listen to a podcast." />',
+        '<DialogueBox uk="Я повторюю нові слова." en="I repeat new words." />',
+        '<DialogueBox uk="Я пишу короткий план." en="I write a short plan." />',
+        '<DialogueBox uk="Я працюю після кави." en="I work after coffee." />',
+        '<DialogueBox uk="Я повертаюся ввечері." en="I return in the evening." />',
+    ]
+    example_lines = [
+        "- **Я прокидаюся о сьомій.** — I wake up at seven.",
+        "- **Я вмиваюся швидко.** — I wash up quickly.",
+        "- **Я одягаюся вдома.** — I get dressed at home.",
+        "- **Я снідаю на кухні.** — I eat breakfast in the kitchen.",
+        "- **Я пʼю теплу воду.** — I drink warm water.",
+        "- **Я читаю повідомлення.** — I read messages.",
+        "- **Я беру синю сумку.** — I take a blue bag.",
+        "- **Я йду до зупинки.** — I go to the stop.",
+        "- **Я чекаю автобус.** — I wait for the bus.",
+        "- **Я слухаю подкаст.** — I listen to a podcast.",
+        "- **Я повторюю нові слова.** — I repeat new words.",
+        "- **Я пишу короткий план.** — I write a short plan.",
+        "- **Я працюю після кави.** — I work after coffee.",
+        "- **Я повертаюся ввечері.** — I return in the evening.",
+    ]
+    text = "\n".join(
+        [
+            "English setup introduces a morning routine.",
+            *dialogue_lines,
+            "| Українською | English |",
+            "|---|---|",
+            "| прокидаюся | I wake up |",
+            "| вмиваюся | I wash up |",
+            "| одягаюся | I get dressed |",
+            "| снідаю | I eat breakfast |",
+            "| вдома | at home |",
+            *example_lines,
+            "<!-- INJECT_ACTIVITY: act-1 -->",
+            "<!-- INJECT_ACTIVITY: act-2 -->",
+            "<!-- INJECT_ACTIVITY: act-3 -->",
+        ]
+    )
+
+    result = _l2_exposure_floor_gate(text, A1_PLAN)
+
+    assert result["passed"] is True
+    assert result["observed"]["uk_dialogue_lines"] == 14
+
+
 def test_l2_exposure_floor_fail_dialogue_lines() -> None:
     text = "\n".join(
         [
@@ -189,6 +246,23 @@ def test_component_density_dialoguebox_pass() -> None:
     result = _component_density_gate('<DialogueBox text="Привіт!" />', A1_EARLY_PLAN)
 
     assert result["passed"] is True
+
+
+def test_component_density_dialoguebox_uk_prop_pass() -> None:
+    result = _component_density_gate(
+        '<DialogueBox uk="Привіт, як справи?" en="Hi, how are you?" />',
+        A1_EARLY_PLAN,
+    )
+
+    assert result["passed"] is True
+    assert result["observed"][0]["observed_pct"] == 100.0
+
+
+def test_component_density_dialoguebox_legacy_text_prop_still_passes() -> None:
+    result = _component_density_gate('<DialogueBox text="Привіт!" />', A1_EARLY_PLAN)
+
+    assert result["passed"] is True
+    assert result["observed"][0]["observed_pct"] == 100.0
 
 
 def test_component_density_rulebox_fail_at_a1_early() -> None:


### PR DESCRIPTION
## Summary

- `_jsx_text_values` now extracts `uk=` attribute (V7 DialogueBox convention) in addition to `text=` (legacy)
- Cascades through `_count_uk_dialogue_lines` and `_component_language_text` to fix `l2_exposure_floor` and `component_density` gate counters
- Closes #1965

## Why

Per the #1964 a1-m15-24 shape contract, the writer correctly emits `<DialogueBox uk="..." en="..." />` for bilingual dialogue. Gate counters were calibrated against an older `text=` shape that the writer no longer uses. Build #4 (`.worktrees/builds/a1-my-morning-20260513-193448/`) showed 10 DialogueBox elements scored 0 toward `uk_dialogue_lines` and ~50% per-box on `component_density` — both miscounts trace to one missing regex alternative in `_jsx_text_values`.

## Build #4 sanity check (before/after)

Before: `uk_dialogue_lines = 5` (only counts blockquote sources)
After: `uk_dialogue_lines = 15` (counts 10 DialogueBox elements + 5 blockquote)

## Test plan

- [x] New tests in `tests/test_immersion_gates.py` cover DialogueBox `uk=` prop for both `l2_exposure_floor` and `component_density`
- [x] New unit tests in `tests/build/test_linear_pipeline.py` cover `_jsx_text_values` + `_component_language_text` directly
- [x] Existing `text=` legacy-form tests still pass (back-compat preserved)
- [x] Ruff clean