### PR TITLE
fix(vesum_gate): skip fill-in answer field unconditionally (#1967)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -4619,9 +4619,17 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
                 if activity_type == "fill-in" and key == "options":
                     continue
                 if activity_type == "fill-in" and key == "answer":
-                    options = node.get("options")
-                    if isinstance(options, list) and child in options:
-                        continue
+                    # Fill-in answers are morphological suffix fragments by
+                    # design (e.g. -юся, -ються, -єшся) — they are never
+                    # standalone VESUM lemmas. #1963 skipped them only when
+                    # the answer was also listed in `options:`; in build #4
+                    # (m20 a1-m15-24 contract) the writer emits fill-in items
+                    # with a `sentence` + `answer` pair and no `options` list,
+                    # so the conditional skip didn't fire. The pedagogical
+                    # rationale doesn't change with shape: a fill-in answer
+                    # is always a suffix fragment.  Skip unconditionally.
+                    # See #1967.
+                    continue
                 if key == "options" and "answer" in node:
                     walk_answer_options(child, answer_values(node.get("answer")))
                     continue

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1451,6 +1451,68 @@ def test_vesum_gate_skips_error_word_field_of_error_correction_activity(
     assert "одягаєшся" in forwarded
 
 
+def test_vesum_gate_skips_fill_in_answer_suffix_without_options_field(
+    tmp_path: Path,
+) -> None:
+    """Fill-in `answer:` fragments must be skipped even when `options:` absent.
+
+    Regression for #1967: build #4 of m20 (`a1/my-morning`) emitted fill-in
+    activities with item shape `{sentence, answer}` (no `options:` list — the
+    student types the suffix). #1963's logic at `_activity_vesum_text` skipped
+    the `answer` field only when its value appeared in a sibling `options:`
+    list; with no `options:` present, the suffix fragments (-юся, -ються,
+    -єшся, etc.) fell through to VESUM and were reported missing, halting the
+    build. The fix makes the skip unconditional for fill-in activities since
+    the pedagogical rationale (answer IS a morphological fragment) doesn't
+    depend on whether an options list is present.
+    """
+    module_dir, plan_path, _ = _passing_qg_fixture(tmp_path)
+    _write_yaml(
+        module_dir / "activities.yaml",
+        [
+            {
+                "id": "act-1",
+                "type": "fill-in",
+                "title": "Додайте -ся",
+                "items": [
+                    {"sentence": "Я вмива____ о сьомій.", "answer": "юся"},
+                    {"sentence": "Ти одяга____ швидко.", "answer": "єшся"},
+                    {"sentence": "Він прокида____ пізно.", "answer": "ється"},
+                    {"sentence": "Ми збира____ на роботу.", "answer": "ємося"},
+                    {"sentence": "Ви поверта____ додому?", "answer": "єтеся"},
+                    {"sentence": "Вони навча____ вранці.", "answer": "ються"},
+                ],
+            }
+        ],
+    )
+
+    received: list[list[str]] = []
+
+    def fake_verify(words: list[str]) -> dict[str, list[dict]]:
+        received.append(list(words))
+        # Sentence fragments (whole UK words) verify fine; suffixes do not.
+        # But the fix should mean the suffixes never reach this function.
+        return {
+            word: [{"lemma": word, "pos": "x", "tags": ""}] for word in words
+        }
+
+    report = linear_pipeline.run_python_qg(
+        module_dir, plan_path, verify_words_fn=fake_verify
+    )
+
+    forwarded = received[0]
+    # None of the bare reflexive suffix fragments should be in the VESUM scope.
+    suffix_fragments = {"юся", "єшся", "ється", "ємося", "єтеся", "ються"}
+    leaked = suffix_fragments & set(forwarded)
+    assert not leaked, (
+        f"fill-in `answer` suffix fragments leaked into VESUM scope: {leaked}"
+    )
+    # And the sentence-shell tokens around the blank still get verified
+    # (sanity: we didn't accidentally skip too much).
+    assert "вмива" in forwarded or "сьомій" in forwarded
+    assert report["gates"]["vesum_verified"]["passed"] is True
+
+
 def test_vesum_gate_still_checks_correct_form_in_error_correction_activity(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- `_activity_vesum_text` now skips the `answer:` field of fill-in activities unconditionally, not only when the answer value appears in a sibling `options:` list
- Closes #1967

## Why

Fill-in `answer:` values are morphological suffix fragments by design (e.g. `-юся`, `-ються`, `-єшся`) — they are never standalone VESUM lemmas. PR #1963 skipped them only when the answer was a duplicate of an `options:` list entry. m20 build #4 emitted fill-in items with shape `{sentence, answer}` and **no** `options:` (the student types the suffix directly) — the suffix fragments fell through to VESUM and were reported missing, halting the build at `python_qg.vesum_verified` with `missing=[юся, ються, ємося, єтеся, ється, єшся]`.

The pedagogical rationale doesn't depend on `options:` presence: a fill-in answer is always a morphological fragment. Skip unconditionally.

## Build #4 evidence

- Worktree: `.worktrees/builds/a1-my-morning-20260513-193448/`
- Source: `curriculum/l2-uk-en/a1/my-morning/activities.yaml` lines 22-40 (act-2, type=fill-in, 10 items)
- Halt: `curriculum/l2-uk-en/a1/my-morning/python_qg.json` → `gates.vesum_verified.missing` = 6 suffix fragments

## Test plan

- [x] New regression test `test_vesum_gate_skips_fill_in_answer_suffix_without_options_field` uses the exact 6 suffixes from build #4 and asserts they don't leak into VESUM scope
- [x] All 18 existing vesum tests pass including #1963's `test_vesum_gate_passes_m20_build_3_artifacts` integration replay
- [x] 106 passed / 0 failed across `tests/build/test_linear_pipeline.py` + `tests/test_immersion_gates.py`
- [x] Ruff clean

Continues the build-iteration arc with #1965/#1966. m20 build #5 should clear `vesum_verified` after this lands; remaining halts to address: `resources_search_attempted=0` writer-behavior regression, `textbook_grounding` corpus_missing (#1901).

🤖 Filed by orchestrator using inline-with-context routing (diagnosis already loaded, ~15 LOC change + 60 LOC test).