### PR TITLE
feat(routing-budget): observability for agent capacity state

### DIFF
--- a/claude_extensions/memory/MEMORY.md
+++ b/claude_extensions/memory/MEMORY.md
@@ -115,6 +115,7 @@ DO NOT run `v6_build.py --range` or `--step all`. Only user runs builds. Heal: `
 - `ai_agent_bridge` → COMMUNICATION (discussions, reviews, Q&A). NOT execution. `ab discuss` is analysis-only — filesystem writes during discussion = HARD STOP, dispatch the work as a separate brief.
 - `Monitor` → watch long-running. Never ScheduleWakeup loops.
 - Monitor API `localhost:8765` → state queries. One curl > custom scripts.
+- `/api/state/routing-budget` → pre-dispatch capacity check. Add `--check-budget` to delegate.py for warnings. Soft-fail when API down.
 - `ugrep` → prefer over grep (faster, parallel, binary-safe).
 
 ## INVESTIGATE BEFORE ACTING

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -122,6 +122,7 @@ app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"]
 app.include_router(blue_router, prefix="/api/blue")
 app.include_router(comms_router, prefix="/api/comms")
 app.include_router(consultation_router, prefix="/api/consultation")
+app.include_router(cost_router, prefix="/api/cost")
 app.include_router(cost_router, prefix="/api/analytics/cost")
 app.include_router(dashboard_router, prefix="/api/dashboard")
 app.include_router(decisions_router, prefix="/api/decisions", tags=["decisions"])

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -16,6 +16,7 @@ Endpoints:
   GET /api/state/research/{track}    Per-module research quality + dimensions + upgrade queue
   GET /api/state/review-coverage      Per-track review completeness + quality
   GET /api/state/issues               Aggregated outstanding issues
+  GET /api/state/routing-budget       Per-agent capacity burn + routing recommendation
 
 Performance notes:
   - Heavy endpoints run their sync I/O in asyncio.to_thread().
@@ -23,16 +24,22 @@ Performance notes:
 """
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any
 
+import yaml
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
+
+from scripts.analytics.cost_report import CostRecord, load_cost_records
 
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
+from . import delegate_router as delegate_api
 from .config import CURRICULUM_ROOT, LEVELS
 from .state_build import (
     compute_build_stats,
@@ -78,8 +85,336 @@ _is_content_done = is_content_done
 
 router = APIRouter(tags=["state"])
 
+BUDGET_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "agent_budgets.yaml"
+AGENT_NAMES = ("claude", "codex", "gemini")
+
+
+def _isoformat_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _load_agent_budgets() -> tuple[dict[str, Any], list[str]]:
+    try:
+        loaded = yaml.safe_load(BUDGET_CONFIG_PATH.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return {}, [f"budget config unavailable: {type(exc).__name__}"]
+    if not isinstance(loaded, dict):
+        return {}, ["budget config unavailable: root is not a mapping"]
+    return loaded, []
+
+
+def _agent_key(raw_agent: str | None) -> str | None:
+    agent = (raw_agent or "").lower().strip()
+    for name in AGENT_NAMES:
+        if agent == name or agent.startswith(f"{name} ") or agent.startswith(f"{name}("):
+            return name
+    return None
+
+
+def _record_has_cost(record: CostRecord) -> bool:
+    return (
+        float(getattr(record, "cost_usd_est", 0.0) or 0.0) > 0
+        or int(getattr(record, "prompt_tokens_est", 0) or 0) > 0
+        or int(getattr(record, "response_tokens_est", 0) or 0) > 0
+    )
+
+
+def _sum_agent_spend(
+    records: list[CostRecord],
+    *,
+    agent: str,
+    since: datetime,
+) -> tuple[float, int]:
+    spent = 0.0
+    missing = 0
+    for record in records:
+        if _agent_key(getattr(record, "agent", None)) != agent:
+            continue
+        if getattr(record, "mtime", datetime.min.replace(tzinfo=UTC)) < since:
+            continue
+        if not _record_has_cost(record):
+            missing += 1
+            continue
+        spent += float(getattr(record, "cost_usd_est", 0.0) or 0.0)
+    return spent, missing
+
+
+def _status_from_burn(burn_pct: float | None) -> str:
+    if burn_pct is None:
+        return "pre_launch"
+    if burn_pct < 50:
+        return "cool"
+    if burn_pct < 75:
+        return "warm"
+    if burn_pct <= 90:
+        return "hot"
+    return "near_cap"
+
+
+def _burn_pct(spent_usd: float | None, cap_usd: float | None) -> float | None:
+    if spent_usd is None or not cap_usd:
+        return None
+    return round((spent_usd / cap_usd) * 100, 1)
+
+
+def _round_money(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 2)
+
+
+def _format_pct(value: float | None) -> str:
+    if value is None:
+        return "unknown"
+    return f"{value:.1f}".rstrip("0").rstrip(".")
+
+
+def _days_until(today: date, target: date | None) -> int | None:
+    if target is None:
+        return None
+    return (target - today).days
+
+
+def _in_flight_by_agent() -> dict[str, int]:
+    in_flight = {agent: 0 for agent in AGENT_NAMES}
+    try:
+        tasks = delegate_api.list_delegate_tasks(status="all", limit=500)["tasks"]
+    except Exception:
+        return in_flight
+    for task in tasks:
+        if task.get("status") not in {"running", "spawning"}:
+            continue
+        agent = _agent_key(task.get("agent"))
+        if agent:
+            in_flight[agent] += 1
+    return in_flight
+
+
+def _recommend_agent(agents: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
+    status_by_agent = {
+        "claude": agents["claude"]["interactive"]["status"],
+        "codex": agents["codex"]["status"],
+        "gemini": agents["gemini"]["status"],
+    }
+    burn_by_agent = {
+        "claude": agents["claude"]["interactive"]["burn_pct_7d"],
+        "codex": agents["codex"]["burn_pct_7d"],
+        "gemini": agents["gemini"]["burn_pct_7d"],
+    }
+
+    if all(status in {"hot", "near_cap"} for status in status_by_agent.values()):
+        warnings.append("all agents near cap — orchestrator inline-mode contingency may be needed soon")
+        return {
+            "primary_agent_for_code": "inline_orchestrator",
+            "rationale": "All agents are hot or near cap; preserve remaining provider quota for high-judgment work.",
+            "warnings": warnings,
+        }
+
+    if "near_cap" in status_by_agent.values():
+        candidates = [
+            agent for agent, status in status_by_agent.items()
+            if status in {"cool", "warm"}
+        ]
+        if candidates:
+            recommended = min(candidates, key=lambda agent: burn_by_agent[agent] or 0.0)
+            return {
+                "primary_agent_for_code": recommended,
+                "rationale": (
+                    f"At least one agent is near cap; {recommended} has the lowest "
+                    f"available 7d burn ({_format_pct(burn_by_agent[recommended])}%)."
+                ),
+                "warnings": warnings,
+            }
+
+    agentic_pool = agents["claude"]["agentic_pool"]
+    if agentic_pool.get("active") and agentic_pool.get("status") == "cool":
+        return {
+            "primary_agent_for_code": "claude",
+            "rationale": "Claude agentic pool is active and cool; drain the separate monthly pool first.",
+            "warnings": warnings,
+        }
+
+    if all(status in {"cool", "warm"} for status in status_by_agent.values()):
+        codex_burn = burn_by_agent["codex"]
+        return {
+            "primary_agent_for_code": "codex",
+            "rationale": (
+                "All agents cool or warm; default 3:3:3 split applies. "
+                f"Codex 7d burn is {_format_pct(codex_burn)}%. "
+                "Claude agentic pool "
+                + (
+                    "active."
+                    if agentic_pool.get("active")
+                    else "pre-launch — interactive pool used for claude headless."
+                )
+            ),
+            "warnings": warnings,
+        }
+
+    recommended = min(status_by_agent, key=lambda agent: burn_by_agent[agent] or 0.0)
+    return {
+        "primary_agent_for_code": recommended,
+        "rationale": (
+            f"Mixed routing state; {recommended} currently has the lowest 7d burn "
+            f"({_format_pct(burn_by_agent[recommended])}%)."
+        ),
+        "warnings": warnings,
+    }
+
+
+def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
+    current_time = (now or datetime.now(UTC)).astimezone(UTC)
+    today = current_time.date()
+    window_start = current_time - timedelta(days=7)
+    budgets, warnings = _load_agent_budgets()
+    if not budgets:
+        agents = {
+            "claude": {
+                "interactive": {
+                    "spent_7d_usd": None,
+                    "weekly_cap_usd": None,
+                    "burn_pct_7d": None,
+                    "promo_active": False,
+                    "status": "pre_launch",
+                },
+                "agentic_pool": {
+                    "spent_cycle_usd": None,
+                    "monthly_cap_usd": None,
+                    "burn_pct_cycle": None,
+                    "active": False,
+                    "starts_on": None,
+                    "status": "pre_launch",
+                },
+            },
+            "codex": {"spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "status": "pre_launch"},
+            "gemini": {"spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "status": "pre_launch"},
+        }
+        return {
+            "generated_at": _isoformat_z(current_time),
+            "agents": agents,
+            "in_flight": _in_flight_by_agent(),
+            "recommendation": {
+                "primary_agent_for_code": "inline_orchestrator",
+                "rationale": "Budget config could not be loaded; routing recommendation is unavailable.",
+                "warnings": warnings,
+            },
+            "diagnostics": {
+                "records_loaded": 0,
+                "missing_cost_records": 0,
+                "window_start": _isoformat_z(window_start),
+            },
+        }
+
+    records = load_cost_records()
+    agents: dict[str, Any] = {}
+    missing_cost_records = 0
+
+    claude_config = budgets.get("claude") if isinstance(budgets.get("claude"), dict) else {}
+    interactive_config = claude_config.get("interactive") if isinstance(claude_config.get("interactive"), dict) else {}
+    agentic_config = claude_config.get("agentic_pool") if isinstance(claude_config.get("agentic_pool"), dict) else {}
+    promo_through = _parse_iso_date(interactive_config.get("promo_through"))
+    promo_active = bool(promo_through and today <= promo_through)
+    claude_cap = float(
+        interactive_config.get("promo_weekly_cap_usd" if promo_active else "weekly_cap_usd") or 0.0
+    )
+    claude_spent, missing = _sum_agent_spend(records, agent="claude", since=window_start)
+    missing_cost_records += missing
+    claude_burn = _burn_pct(claude_spent, claude_cap)
+
+    starts_on = _parse_iso_date(agentic_config.get("starts_on"))
+    agentic_active = bool(starts_on and today >= starts_on)
+    agentic_cap = float(agentic_config.get("monthly_cap_usd") or 0.0)
+    if agentic_active and starts_on:
+        cycle_start = datetime.combine(starts_on, datetime.min.time(), tzinfo=UTC)
+        agentic_spent, missing = _sum_agent_spend(records, agent="claude", since=cycle_start)
+        missing_cost_records += missing
+        agentic_burn = _burn_pct(agentic_spent, agentic_cap)
+        agentic_status = _status_from_burn(agentic_burn)
+    else:
+        agentic_spent = None
+        agentic_burn = None
+        agentic_status = "pre_launch"
+
+    agents["claude"] = {
+        "interactive": {
+            "spent_7d_usd": _round_money(claude_spent),
+            "weekly_cap_usd": _round_money(claude_cap),
+            "burn_pct_7d": claude_burn,
+            "promo_active": promo_active,
+            "status": _status_from_burn(claude_burn),
+        },
+        "agentic_pool": {
+            "spent_cycle_usd": _round_money(agentic_spent),
+            "monthly_cap_usd": _round_money(agentic_cap),
+            "burn_pct_cycle": agentic_burn,
+            "active": agentic_active,
+            "starts_on": starts_on.isoformat() if starts_on else None,
+            "status": agentic_status,
+        },
+        "spent_7d_usd": _round_money(claude_spent),
+        "weekly_cap_usd": _round_money(claude_cap),
+        "burn_pct_7d": claude_burn,
+        "status": _status_from_burn(claude_burn),
+    }
+
+    for agent in ("codex", "gemini"):
+        agent_config = budgets.get(agent) if isinstance(budgets.get(agent), dict) else {}
+        cap = float(agent_config.get("weekly_cap_usd") or 0.0)
+        spent, missing = _sum_agent_spend(records, agent=agent, since=window_start)
+        missing_cost_records += missing
+        burn = _burn_pct(spent, cap)
+        agents[agent] = {
+            "spent_7d_usd": _round_money(spent),
+            "weekly_cap_usd": _round_money(cap),
+            "burn_pct_7d": burn,
+            "status": _status_from_burn(burn),
+        }
+
+    claude_burn_pct = agents["claude"]["interactive"]["burn_pct_7d"]
+    if agents["claude"]["interactive"]["status"] in {"hot", "near_cap"}:
+        warnings.append(
+            f"claude.interactive at {_format_pct(claude_burn_pct)}% — consider --agent codex for next mechanical fix"
+        )
+    starts_in_days = _days_until(today, starts_on)
+    if starts_in_days is not None and 0 <= starts_in_days <= 14:
+        warnings.append(f"agentic_pool launches in {starts_in_days} days")
+    promo_days = _days_until(today, promo_through)
+    if promo_days is not None and 0 <= promo_days <= 14:
+        warnings.append(
+            f"promo expires in {promo_days} days; +50% bonus capacity ends {promo_through.isoformat()}"
+        )
+
+    return {
+        "generated_at": _isoformat_z(current_time),
+        "agents": agents,
+        "in_flight": _in_flight_by_agent(),
+        "recommendation": _recommend_agent(agents, warnings),
+        "diagnostics": {
+            "records_loaded": len(records),
+            "missing_cost_records": missing_cost_records,
+            "window_start": _isoformat_z(window_start),
+        },
+    }
+
 
 # ==================== ENDPOINTS ====================
+
+
+@router.get("/routing-budget")
+async def routing_budget():
+    """Per-agent soft-cap burn and routing recommendation for dispatch planning."""
+    return await asyncio.to_thread(compute_routing_budget)
 
 
 @router.get("/summary")

--- a/scripts/config/agent_budgets.yaml
+++ b/scripts/config/agent_budgets.yaml
@@ -1,0 +1,25 @@
+# Agent budget soft-caps used by /api/state/routing-budget for burn% computation.
+# These are SOFT caps — the router warns when burn% approaches; it does not block.
+# Update when Anthropic announces tier or promo changes.
+#
+# Effective windows (anchored to user's billing cycle, treated as ISO weeks for now):
+#   - claude.interactive: Max 20× = ~$2000/mo API-equivalent. +50% promo until 2026-07-13.
+#   - claude.agentic_pool: $200/mo from 2026-06-15 (Anthropic Pro+/Max agentic credit).
+#   - codex: ~$1000/wk effective weekly quota (rough; revise from observed cap-hits).
+#   - gemini: ~$500/wk effective daily quota aggregated (rough).
+#
+# All caps are dollar-denominated. Records that lack a cost estimate are excluded
+# from burn% (counted in "missing_cost_records" diagnostic).
+
+claude:
+  interactive:
+    weekly_cap_usd: 460  # $2000/mo ÷ 4.33 weeks; this is the "shared with chat" pool
+    promo_through: "2026-07-13"
+    promo_weekly_cap_usd: 690  # +50%
+  agentic_pool:
+    monthly_cap_usd: 200
+    starts_on: "2026-06-15"
+codex:
+  weekly_cap_usd: 1000
+gemini:
+  weekly_cap_usd: 500

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -905,6 +905,13 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print("❌ --prompt or --prompt-file is required", file=sys.stderr)
         return 2
 
+    if getattr(args, "check_budget", False) and not getattr(args, "force_agent", False):
+        _check_routing_budget_for_dispatch(args.agent)
+
+    if getattr(args, "dry_run", False):
+        print(task_id)
+        return 0
+
     # Set up log files before provisioning a worktree. If this cheap
     # filesystem setup fails, dispatch exits before leaving worktree/branch
     # side effects behind.
@@ -1205,6 +1212,46 @@ def _fetch_monitor_task(task_id: str) -> dict[str, Any] | None:
     except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
         raise MonitorApiUnavailable(str(exc)) from exc
     return payload if isinstance(payload, dict) else {}
+
+
+def _fetch_routing_budget() -> dict[str, Any]:
+    url = f"{_monitor_api_base_url()}/api/state/routing-budget"
+    try:
+        with urllib.request.urlopen(url, timeout=3) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise MonitorApiUnavailable(str(exc)) from exc
+    return payload if isinstance(payload, dict) else {}
+
+
+def _check_routing_budget_for_dispatch(agent: str) -> None:
+    try:
+        payload = _fetch_routing_budget()
+    except MonitorApiUnavailable:
+        print("⚠ ROUTING CHECK SKIPPED: Monitor API unreachable", file=sys.stderr)
+        return
+
+    recommendation = payload.get("recommendation")
+    if not isinstance(recommendation, dict):
+        return
+    recommended = recommendation.get("primary_agent_for_code")
+    if not recommended or recommended == agent:
+        return
+
+    print(
+        f"⚠ ROUTING WARNING: budget recommends --agent {recommended}, "
+        f"you passed --agent {agent}.",
+        file=sys.stderr,
+    )
+    print(
+        f"Rationale: {recommendation.get('rationale') or 'No rationale provided.'}",
+        file=sys.stderr,
+    )
+    print(
+        "Proceed anyway? (use --force-agent to suppress this check, or Ctrl+C to abort.)",
+        file=sys.stderr,
+    )
+    time.sleep(3)
 
 
 def _status_or_fail_payload(task_id: str) -> dict[str, Any]:
@@ -1537,6 +1584,24 @@ def build_parser() -> argparse.ArgumentParser:
             "Opt in to allow PR approval/merge and pushes to main inside the "
             "delegated subprocess. Default is off: AGENT_NO_MERGE=1 is set."
         ),
+    )
+    d.add_argument(
+        "--check-budget",
+        action="store_true",
+        help=(
+            "Query /api/state/routing-budget before spawning and warn when "
+            "budget telemetry recommends a different agent."
+        ),
+    )
+    d.add_argument(
+        "--force-agent",
+        action="store_true",
+        help="Suppress --check-budget routing warnings and dispatch with the requested agent.",
+    )
+    d.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run dispatch pre-flight checks and print task-id without spawning a worker.",
     )
     d.add_argument(
         "--hard-timeout",

--- a/tests/analytics/test_cost_report_smoke.py
+++ b/tests/analytics/test_cost_report_smoke.py
@@ -1,0 +1,7 @@
+"""Analytics package smoke tests for targeted dispatch verification."""
+
+from scripts.analytics.cost_report import estimate_tokens
+
+
+def test_estimate_tokens_smoke():
+    assert estimate_tokens(3800) == 1000

--- a/tests/api/test_routing_budget_endpoint.py
+++ b/tests/api/test_routing_budget_endpoint.py
@@ -1,0 +1,165 @@
+"""Tests for /api/state/routing-budget."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from scripts.analytics.cost_report import CostRecord
+from scripts.api import state_router
+
+
+def _write_budget_config(tmp_path: Path) -> Path:
+    path = tmp_path / "agent_budgets.yaml"
+    path.write_text(
+        """
+claude:
+  interactive:
+    weekly_cap_usd: 460
+    promo_through: "2026-07-13"
+    promo_weekly_cap_usd: 690
+  agentic_pool:
+    monthly_cap_usd: 200
+    starts_on: "2026-06-15"
+codex:
+  weekly_cap_usd: 1000
+gemini:
+  weekly_cap_usd: 500
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _record(agent: str, cost_usd: float, mtime: datetime) -> CostRecord:
+    return CostRecord(
+        path=Path("fixture-meta.json"),
+        level="a1",
+        slug="fixture",
+        phase="write",
+        agent=agent,
+        model="fixture-model",
+        model_source="stored",
+        ok=True,
+        timestamp=mtime.isoformat(),
+        mtime=mtime,
+        prompt_chars=1,
+        response_chars=1,
+        prompt_tokens_est=1,
+        response_tokens_est=1,
+        prompt_tokens_source="stored",
+        response_tokens_source="stored",
+        rate_model="fixture-model",
+        used_default_rate=False,
+        cost_usd_est=cost_usd,
+    )
+
+
+def _configure(monkeypatch, tmp_path: Path, records: list[CostRecord]) -> None:
+    monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: records)
+    monkeypatch.setattr(
+        state_router.delegate_api,
+        "list_delegate_tasks",
+        lambda **_kwargs: {"tasks": []},
+    )
+
+
+def test_endpoint_returns_documented_shape(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, [])
+    app = FastAPI()
+    app.include_router(state_router.router, prefix="/api/state")
+
+    response = TestClient(app).get("/api/state/routing-budget")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert {"agents", "in_flight", "recommendation", "diagnostics", "generated_at"} <= data.keys()
+
+
+def test_status_cool_when_burn_under_50(monkeypatch, tmp_path):
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [_record("codex (gpt-5.5)", 100.0, now)])
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["agents"]["claude"]["burn_pct_7d"] == data["agents"]["claude"]["interactive"]["burn_pct_7d"]
+    assert data["agents"]["codex"]["burn_pct_7d"] == 10.0
+    assert data["agents"]["codex"]["status"] == "cool"
+
+
+def test_status_hot_when_burn_75_90(monkeypatch, tmp_path):
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [_record("codex (gpt-5.5)", 800.0, now)])
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["agents"]["codex"]["burn_pct_7d"] == 80.0
+    assert data["agents"]["codex"]["status"] == "hot"
+
+
+def test_pre_launch_agentic_pool_before_2026_06_15(monkeypatch, tmp_path):
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [_record("claude (sonnet)", 100.0, now)])
+
+    data = state_router.compute_routing_budget(now)
+
+    pool = data["agents"]["claude"]["agentic_pool"]
+    assert pool["status"] == "pre_launch"
+    assert pool["active"] is False
+    assert pool["spent_cycle_usd"] is None
+
+
+def test_recommendation_picks_coolest_when_one_near_cap(monkeypatch, tmp_path):
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(
+        monkeypatch,
+        tmp_path,
+        [
+            _record("claude (sonnet)", 634.8, now),
+            _record("codex (gpt-5.5)", 300.0, now),
+            _record("gemini (pro)", 300.0, now),
+        ],
+    )
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["agents"]["claude"]["interactive"]["status"] == "near_cap"
+    assert data["recommendation"]["primary_agent_for_code"] == "codex"
+
+
+def test_recommendation_inline_when_all_hot(monkeypatch, tmp_path):
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(
+        monkeypatch,
+        tmp_path,
+        [
+            _record("claude (sonnet)", 586.5, now),
+            _record("codex (gpt-5.5)", 850.0, now),
+            _record("gemini (pro)", 425.0, now),
+        ],
+    )
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["recommendation"]["primary_agent_for_code"] == "inline_orchestrator"
+    assert "all agents near cap" in data["recommendation"]["warnings"][-1]
+
+
+def test_promo_through_uses_promo_cap_until_expiry(monkeypatch, tmp_path):
+    before = datetime(2026, 7, 12, 20, 30, tzinfo=UTC)
+    after = datetime(2026, 7, 14, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [_record("claude (sonnet)", 345.0, before)])
+
+    before_data = state_router.compute_routing_budget(before)
+
+    _configure(monkeypatch, tmp_path, [_record("claude (sonnet)", 345.0, after)])
+    after_data = state_router.compute_routing_budget(after)
+
+    assert before_data["agents"]["claude"]["interactive"]["weekly_cap_usd"] == 690.0
+    assert before_data["agents"]["claude"]["interactive"]["burn_pct_7d"] == 50.0
+    assert after_data["agents"]["claude"]["interactive"]["weekly_cap_usd"] == 460.0
+    assert after_data["agents"]["claude"]["interactive"]["burn_pct_7d"] == 75.0

--- a/tests/test_cost_api.py
+++ b/tests/test_cost_api.py
@@ -47,6 +47,15 @@ def test_cost_summary_empty_payload(tmp_path, monkeypatch):
     assert payload["windows"]["all_time"]["records_total"] == 0
 
 
+def test_cost_summary_compat_alias(tmp_path, monkeypatch):
+    monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", tmp_path)
+
+    response = client.get("/api/cost")
+
+    assert response.status_code == 200
+    assert response.json()["windows"]["all_time"]["records_total"] == 0
+
+
 def test_cost_module_route_returns_windows(tmp_path, monkeypatch):
     monkeypatch.setattr(cost_report, "CURRICULUM_ROOT", tmp_path)
     _write_meta(tmp_path, "a1", "my-family", "01-write-meta.json", "write", 3800, 380)

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -1,0 +1,159 @@
+"""Tests for delegate.py --check-budget pre-dispatch guard."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import delegate
+
+
+class _FakeBudgetResponse:
+    def __init__(self, recommended: str = "codex"):
+        self.recommended = recommended
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+    def read(self):
+        return json.dumps(
+            {
+                "recommendation": {
+                    "primary_agent_for_code": self.recommended,
+                    "rationale": "fixture rationale",
+                    "warnings": [],
+                }
+            }
+        ).encode("utf-8")
+
+
+class _FakeStdin:
+    def write(self, _data):
+        pass
+
+    def close(self):
+        pass
+
+
+class _FakeProc:
+    pid = 12345
+    stdin = _FakeStdin()
+
+
+def _dispatch_args(*extra: str):
+    return delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "claude",
+            "--task-id",
+            "budget-check-fixture",
+            "--prompt",
+            "no-op",
+            "--mode",
+            "read-only",
+            *extra,
+        ]
+    )
+
+
+def _patch_spawn(monkeypatch, tmp_path):
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProc())
+    telemetry = type(
+        "_Telemetry",
+        (),
+        {"model": "fixture-model", "effort": "high", "cli_version": "fixture"},
+    )()
+    monkeypatch.setattr(
+        "agent_runtime.telemetry.resolve_dispatch_start_telemetry",
+        lambda **_kwargs: telemetry,
+    )
+
+
+def test_check_budget_warns_when_agent_mismatch(monkeypatch, tmp_path, capsys):
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _FakeBudgetResponse("codex"),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "⚠ ROUTING WARNING: budget recommends --agent codex, you passed --agent claude." in captured.err
+    assert "Rationale: fixture rationale" in captured.err
+
+
+def test_check_budget_skipped_when_force_agent(monkeypatch, tmp_path, capsys):
+    _patch_spawn(monkeypatch, tmp_path)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("urlopen should not be called with --force-agent")
+
+    monkeypatch.setattr(delegate.urllib.request, "urlopen", fail_if_called)
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget", "--force-agent"))
+
+    assert rc == 0
+    assert "ROUTING WARNING" not in capsys.readouterr().err
+
+
+def test_check_budget_skipped_when_api_down(monkeypatch, tmp_path, capsys):
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(urllib.error.URLError("timeout")),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    assert "⚠ ROUTING CHECK SKIPPED: Monitor API unreachable" in capsys.readouterr().err
+
+
+def test_check_budget_off_by_default(monkeypatch, tmp_path, capsys):
+    _patch_spawn(monkeypatch, tmp_path)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("urlopen should not be called unless --check-budget is passed")
+
+    monkeypatch.setattr(delegate.urllib.request, "urlopen", fail_if_called)
+
+    rc = delegate.cmd_dispatch(_dispatch_args())
+
+    assert rc == 0
+    assert "ROUTING" not in capsys.readouterr().err
+
+
+def test_check_budget_dry_run_does_not_spawn(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(delegate.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _FakeBudgetResponse("codex"),
+    )
+
+    def fail_if_spawned(*_args, **_kwargs):
+        raise AssertionError("dry-run must not spawn a worker")
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", fail_if_spawned)
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget", "--dry-run"))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "budget-check-fixture"
+    assert "ROUTING WARNING" in captured.err


### PR DESCRIPTION
## Summary

- New `GET /api/state/routing-budget` endpoint exposing per-agent burn% + recommendation
- New `scripts/config/agent_budgets.yaml` config for soft-cap values
- New `delegate.py dispatch --check-budget` opt-in pre-flight + `--force-agent` override
- MEMORY.md footnote pointing at the new endpoint
- Compatibility mount for existing cost telemetry at `/api/cost`

Closes #1970

## Why

User direction 2026-05-13: "we need much smarter routing." From 2026-06-15 the Anthropic agentic credit pool (~00/mo, separate bucket) launches; until 2026-07-13 the Claude Code weekly cap is +50%. Without observability into per-agent burn rate, the orchestrator routes blind and can only react to rate-limit failures. This PR wires a routing-recommendation layer onto existing cost telemetry (`scripts/analytics/cost_report.py` + `/api/cost/`).

## Test plan

- [x] New endpoint returns documented JSON shape; status thresholds (cool/warm/hot/near_cap) deterministic
- [x] `pre_launch` status returned for agentic_pool before 2026-06-15
- [x] Promo-window divisor switches on 2026-07-13
- [x] Recommendation picks coolest agent; inline_orchestrator when all hot
- [x] `--check-budget` warns on mismatch, skips on `--force-agent`, soft-fails on API down
- [x] Existing `/api/cost` and `/api/batch/usage` endpoints unbroken
- [x] Ruff clean