### PR TITLE
feat(corpus): ingest Pohribnyi pronunciation playlist

### DIFF
--- a/data/external_articles/channels.yaml
+++ b/data/external_articles/channels.yaml
@@ -1,3 +1,4 @@
+---
 channels:
   # Template for future additions:
   # - id: new_source
@@ -58,6 +59,31 @@ channels:
       istorio: 0.1
     description: "Professional pedagogy and culture explainers for beginner-to-intermediate Ukrainian learners."
 
+  - id: pohribnyi_pronunciation
+    name: "Українська літературна вимова (3LP, 1992)"
+    host: "Микола Погрібний"
+    url: "https://www.youtube.com/playlist?list=PLKTBLqy7kMugWc9_dOpw18zaIlhuBVtgz"
+    source_file: pohribnyi_pronunciation
+    register_tag: scripted
+    decolonization_tag: strong
+    quality_tier: 1
+    language_purity: vetted
+    track_affinity:  # phonetic-foundation modules benefit most
+      a1: 1.0      # phonetic foundations
+      a2: 1.0      # continued phonetic refinement
+      b1: 0.7      # advanced phonetic awareness
+      b2: 0.4
+      c1: 0.3
+      c2: 0.3
+      hist: 0.1    # only narrative segments useful
+      bio: 0.1
+      ruth: 0.5    # heritage-context phonetic reference
+    description: >-
+      Canonical Ukrainian literary pronunciation reference recording (3LP vinyl
+      rip, 1992) by linguist Mykola Pohribnyi. Gold-standard phonetic /
+      orthoepic source for A1-A2 phonetic gates. Vetted, scripted reading
+      register.
+
   - id: imtgsh
     name: "Історія України ім. Т.Г. Шевченка"
     host: "Редакційний голос каналу"  # REVIEW: host name needs confirmation
@@ -76,7 +102,9 @@ channels:
       ruth: 0.1
       b2: 0.1
       c1: 0.2
-    description: "Accessible Ukrainian history explainers with strong anti-imperial framing and current-affairs tie-ins."
+    description: >-
+      Accessible Ukrainian history explainers with strong anti-imperial framing
+      and current-affairs tie-ins.
 
   - id: istoria_movy
     name: "Історія Мови"
@@ -113,7 +141,9 @@ channels:
       lit-hist-fic: 0.4
       folk: 0.2
       b2: 0.1
-    description: "Conversational public-history podcast pairing a comedian with a historian for accessible historical storytelling."
+    description: >-
+      Conversational public-history podcast pairing a comedian with a historian
+      for accessible historical storytelling.
 
   - id: ulp_blogs
     name: "Ukrainian Lessons Blog"
@@ -154,4 +184,6 @@ channels:
       lit: 0.1
       oes: 0.2
       ruth: 0.2
-    description: "Mixed background corpus spanning blogs, reference pages, and a small amount of miscellaneous web content."
+    description: >-
+      Mixed background corpus spanning blogs, reference pages, and a small
+      amount of miscellaneous web content.

--- a/scripts/wiki/fetch_external_sources.py
+++ b/scripts/wiki/fetch_external_sources.py
@@ -30,19 +30,23 @@ import os
 import re
 import socket
 import subprocess
+import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import requests
 import yaml
 from bs4 import BeautifulSoup
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
 CACHE_DIR = PROJECT_ROOT / "data" / "external_articles"
 EXT_RESOURCES = PROJECT_ROOT / "docs" / "resources" / "external_resources.yaml"
 VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
@@ -113,6 +117,13 @@ YOUTUBE_CHANNELS: dict[str, YouTubeChannel] = {
         output_filename="realna_istoria.jsonl",
         speaker="Akím Galímov",
         description="Реальна Історія — HIST, BIO, ISTORIO",
+    ),
+    "pohribnyi-pronunciation": YouTubeChannel(
+        key="pohribnyi-pronunciation",
+        url="https://www.youtube.com/playlist?list=PLKTBLqy7kMugWc9_dOpw18zaIlhuBVtgz",
+        output_filename="pohribnyi_pronunciation.jsonl",
+        speaker="Микола Погрібний",
+        description="Українська літературна вимова (3LP, 1992) — canonical pronunciation reference",
     ),
     "imtgsh": YouTubeChannel(
         key="imtgsh",
@@ -309,6 +320,9 @@ def normalize_channel_url(channel_url: str, *, videos_tab: bool = False) -> str:
 
     parsed = urlparse(normalized)
     if parsed.netloc not in {"youtube.com", "www.youtube.com"}:
+        return normalized
+
+    if parsed.path == "/playlist" and parse_qs(parsed.query).get("list"):
         return normalized
 
     parts = [part for part in parsed.path.split("/") if part]

--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -96,12 +96,15 @@ def test_plan_references_field_is_supported() -> None:
 
 
 def test_my_morning_module_passes_citations_resolve() -> None:
+    # Source refs must match the LIVE plan_references at curriculum/l2-uk-en/
+    # plans/a1/my-morning.yaml (corrected by PR #1972: Караман p.176 → p.187,
+    # Кравцова Grade 4 p.113 removed as redundant with Захарійчук p.162's
+    # Білоус verse coverage of the same -шся/-ться pronunciation rule).
     plan_path = linear_pipeline.PROJECT_ROOT / "curriculum/l2-uk-en/plans/a1/my-morning.yaml"
     plan = yaml.safe_load(plan_path.read_text("utf-8"))
     result = linear_pipeline._citation_gate(
         [
-            {"source_ref": "Караман, Українська мова, 10 клас, с. 176"},
-            {"source_ref": "Кравцова, Українська мова, 4 клас, с. 113"},
+            {"source_ref": "Караман, Українська мова, 10 клас, с. 187"},
             {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 162"},
         ],
         plan,

--- a/tests/test_fetch_external_sources_channels.py
+++ b/tests/test_fetch_external_sources_channels.py
@@ -62,6 +62,12 @@ def test_registry_lookup_by_channel_name(fetcher_module) -> None:
     assert channel.speaker == "Akím Galímov"
 
 
+def test_playlist_urls_are_not_normalized_to_videos_tab(fetcher_module) -> None:
+    playlist_url = "https://www.youtube.com/playlist?list=PLKTBLqy7kMugWc9_dOpw18zaIlhuBVtgz"
+
+    assert fetcher_module.normalize_channel_url(playlist_url, videos_tab=True) == playlist_url
+
+
 def test_unknown_channel_name_raises_clear_error(fetcher_module) -> None:
     with pytest.raises(ValueError, match="Unknown channel-name 'missing-channel'"):
         fetcher_module.resolve_named_channel("missing-channel")


### PR DESCRIPTION
## Summary
- register Микола Погрібний's 1992 "Українська літературна вимова" 3LP playlist as `pohribnyi_pronunciation`
- allow YouTube playlist URLs through `fetch_external_sources.py` without appending `/videos`
- add a regression test for playlist URL normalization

## Ingestion evidence
- Playlist scrape found 6 videos and fetched 6/6 Ukrainian subtitle records.
- `data/external_articles/pohribnyi_pronunciation.jsonl`: 6 JSONL rows, 241K.
- External chunk migration: 35 rows for `channel_id='pohribnyi_pronunciation'`; external rows moved 1205 -> 6511.

## Validation
- `.venv/bin/python -m pytest tests/wiki/ -v` -> 106 passed, 1 skipped
- `.venv/bin/python -m pytest tests/test_channels_registry.py tests/test_wiki_channels.py tests/test_fetch_external_sources_channels.py -v` -> 20 passed
- `.venv/bin/ruff check scripts/wiki/ tests/test_fetch_external_sources_channels.py` -> All checks passed!
- `.venv/bin/yamllint data/external_articles/channels.yaml` -> passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed

Note: the brief's exact `.venv/bin/ruff check data/external_articles/channels.yaml scripts/wiki/` command is not valid because ruff parses YAML as Python; YAML was validated with yamllint instead.