### PR TITLE
fix(writer-prompt): add pre-emit checklist for multimedia obligation (#1969)

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -376,6 +376,30 @@ like `correct_order`, indices are zero-based.
 
 {KNOWLEDGE_PACKET}
 
+## Pre-emit verification (run BEFORE you write any artifact)
+
+Before emitting the four fenced blocks and the `<end_gate>` block, confirm
+you have made AT LEAST one of each of the following tool calls during this
+turn. If any line below is FALSE, make the call now before emitting.
+
+1. `mcp__sources__search_text` — at least one call per `plan_references`
+   textbook entry (textbook grounding obligation; gate
+   `textbook_grounding`).
+2. `mcp__sources__query_wikipedia` OR `mcp__sources__search_external` OR
+   `mcp__sources__search_images` — at least one call (multimedia search
+   obligation; gate `resources_search_attempted`). Honest "no result"
+   counts — the attempt is what the gate counts.
+3. `mcp__sources__verify_words` (or `verify_word` / `verify_lemma`) — at
+   least one call on novel Ukrainian forms before writing them
+   (verification obligation; reviewer evidence requirement).
+4. `mcp__sources__search_style_guide` — at least one call on a Russianism
+   or paronym candidate from the topic vocabulary (heritage-defense
+   obligation; reviewer evidence requirement).
+
+This checklist is not a substitute for the per-mandate instructions above;
+it is a final cross-check that no mandate was forgotten under the attention
+budget of the early-prompt contract directives.
+
 ## HARD STOP RULE
 
 After emitting all required `<plan_reasoning>` blocks, the 4 artifact fences

--- a/tests/test_writer_prompt_preemit_checklist.py
+++ b/tests/test_writer_prompt_preemit_checklist.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from scripts.build import linear_pipeline
+
+WRITER_TEMPLATE = (
+    linear_pipeline.PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+)
+
+CHECKLIST_HEADER = "## Pre-emit verification (run BEFORE you write any artifact)"
+
+REQUIRED_TOOL_MENTIONS = (
+    "mcp__sources__search_text",
+    "mcp__sources__query_wikipedia",
+    "mcp__sources__search_external",
+    "mcp__sources__search_images",
+    "mcp__sources__verify_words",
+    "mcp__sources__search_style_guide",
+)
+
+
+def _writer_template() -> str:
+    return WRITER_TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_writer_prompt_has_preemit_checklist() -> None:
+    prompt = _writer_template()
+    assert CHECKLIST_HEADER in prompt, (
+        "Pre-emit checklist header missing from writer prompt — see #1969."
+    )
+
+
+def test_writer_prompt_preemit_lists_required_tool_calls() -> None:
+    prompt = _writer_template()
+    # Find the checklist section, assert each required tool is mentioned
+    # inside it (not just somewhere in the file).
+    idx = prompt.find(CHECKLIST_HEADER)
+    assert idx >= 0
+    hard_stop_idx = prompt.find("## HARD STOP RULE", idx)
+    assert hard_stop_idx > idx, "HARD STOP RULE must follow the checklist"
+    checklist_body = prompt[idx:hard_stop_idx]
+    for tool in REQUIRED_TOOL_MENTIONS:
+        assert tool in checklist_body, f"{tool} missing from pre-emit checklist"
+
+
+def test_writer_prompt_preemit_precedes_hard_stop() -> None:
+    prompt = _writer_template()
+    checklist_idx = prompt.find(CHECKLIST_HEADER)
+    hard_stop_idx = prompt.find("## HARD STOP RULE")
+    assert 0 <= checklist_idx < hard_stop_idx, (
+        "Pre-emit checklist must appear before HARD STOP RULE, "
+        "and HARD STOP RULE must remain the final section."
+    )


### PR DESCRIPTION
| Claim | Required raw output |
|---|---|
| Test file added | ` scripts/build/phases/linear-write.md          | 24 +++++++++++++`<br>` tests/test_writer_prompt_preemit_checklist.py | 52 +++++++++++++++++++++++++++`<br>` 2 files changed, 76 insertions(+)` |
| Prompt edited | ` scripts/build/phases/linear-write.md | 24 ++++++++++++++++++++++++`<br>` 1 file changed, 24 insertions(+)` |
| Tests pass | `======================== 75 passed, 14 skipped in 0.68s ========================` |
| Lint clean | `All checks passed!` |
| HARD STOP still last | `375:## Full Wiki Context (source of truth for citations)`<br>`379:## Pre-emit verification (run BEFORE you write any artifact)`<br>`403:## HARD STOP RULE` |