### PR TITLE
feat(corpus): ingest Anna Ohoiko 1000 Most Useful Ukrainian Words

### DIFF
--- a/scripts/ingest/ohoiko_books_ingest.py
+++ b/scripts/ingest/ohoiko_books_ingest.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Ingest Anna Ohoiko book .txt files into ``data/sources.db`` textbooks table.
+
+Source files live in ``docs/references/private/`` (gitignored). Currently
+supports the 2-edition "1000 Most Useful Ukrainian Words" book; the parser
+is extensible to "500+ Ukrainian Verbs" and future Ohoiko books.
+
+Schema fit:
+- One row per numbered entry → one chunk
+- ``author = 'Anna Ohoiko'`` (Анна Огойко)
+- ``source_file`` is a stable per-book slug (e.g.
+  ``anna-ohoiko-1000-words-2nd-ed``)
+- ``title`` is the Ukrainian headword(s) with stress marks
+- ``text`` is the full entry body (headword + alt forms + English
+  translation + example sentences UK/EN)
+- ``grade`` is left empty — Ohoiko's word lists are level-agnostic;
+  CEFR mapping is a downstream concern.
+
+Idempotent: the ingest checks each chunk_id against the DB and skips
+existing rows. Re-running on an unchanged source produces zero new
+inserts; re-running after edits inserts only the changed entries (caveat:
+mid-entry edits to the source produce the same chunk_id with different
+text — see ``--force`` to overwrite).
+
+Deterministic verification: prints BEFORE / AFTER row counts and a
+sample row for each call. Mirrors the evidence convention applied to
+the 2026-05-14 channel_id fix (#1976).
+
+Usage:
+    .venv/bin/python -m scripts.ingest.ohoiko_books_ingest --book 1000-words
+    .venv/bin/python -m scripts.ingest.ohoiko_books_ingest --book 1000-words --dry-run
+    .venv/bin/python -m scripts.ingest.ohoiko_books_ingest --book 1000-words --force
+
+Reference:
+- ``docs/references/private/1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt``
+- ``docs/references/private/500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt``
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
+
+# Page-furniture patterns that should be stripped from entry bodies.
+# These match Ohoiko's PDF-extracted text exactly; do not over-generalise.
+_PAGE_FOOTER_RE = re.compile(
+    r"^\s*Inspiring resources for learning Ukrainian — UkrainianLessons\.com\s+\d+\s*$"
+)
+_BARE_PAGE_NUMBER_RE = re.compile(r"^\s*\d+\s*$")
+# Page header is a single right-aligned word (the running headword). It
+# follows the page footer line and precedes the next entry. We detect it
+# heuristically as "≥ 20 leading spaces + 1-3 word tokens with Cyrillic
+# content".
+_PAGE_HEADER_RE = re.compile(r"^\s{20,}[А-Яа-яҐґЄєІіЇї'’\-\sʼ́]{2,}$")
+_ENTRY_START_RE = re.compile(r"^(?P<num>\d{1,4})\.\s+(?P<headword>.+?)(?:\s{2,}(?P<english>.+))?$")
+
+# Headwords in Ohoiko's word list are Ukrainian — Cyrillic letters,
+# stress marks, hyphens, apostrophes, optional ``= альт-форма`` segments.
+# This filter cleanly rejects matches against:
+# - the "How to Use Anki" numbered instruction list earlier in the book
+#   (steps like ``2. Anki uses a spaced repetition algorithm…``),
+# - back-matter promotional pages where the first character is Latin.
+# Allows apostrophes/quotes/parens around the leading char for unusual
+# headwords (e.g. quoted clitics), but the leading non-space char must
+# eventually be Cyrillic.
+_CYRILLIC_CHAR_RE = re.compile(r"[А-ЯҐЄІЇа-яґєії]")
+
+# Hard cap on body lines per entry. A verb-pair entry with two examples
+# tops out around ~10 lines (verb pair + aspectual annotation + 2 UK
+# examples + 2 EN examples, each potentially wrapping). 25 is generous
+# and guarantees we stop accumulating before runaway parsing past the
+# last real entry sweeps in promotional back-matter.
+_MAX_BODY_LINES = 25
+
+# Lines that signal the end of the word-list section. When we see one
+# of these inside an in-flight entry's body, finalize and stop
+# accumulating. Matched as a substring on the stripped body line so we
+# tolerate leading spacing variation.
+_SECTION_TERMINATORS = (
+    "Кросворд",          # "Crossword №N" section headers (post-1000)
+    "Хай щастить",        # Author's closing line before back-matter
+    "Find out more at",   # Promotional back-matter URLs
+    "Most Useful Ukrainian Words",  # Repeating header in back-matter pages
+    "My New Ukrainian Words",       # Blank-journal section header
+)
+
+
+@dataclass(frozen=True)
+class BookConfig:
+    slug: str  # CLI key, e.g. "1000-words"
+    source_file: str  # textbooks.source_file value
+    txt_filename: str  # relative to REFERENCES_DIR
+    author: str
+    grade: str  # left empty for Ohoiko books; reserved for CEFR mapping later
+    max_entry_number: int  # advertised entry count (hard cap)
+
+
+BOOKS: dict[str, BookConfig] = {
+    "1000-words": BookConfig(
+        slug="1000-words",
+        source_file="anna-ohoiko-1000-words-2nd-ed",
+        txt_filename="1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt",
+        author="Anna Ohoiko",
+        grade="",
+        # The 2nd edition advertises "1000 Most Useful Ukrainian Words"
+        # and the alphabetical entries run #1..#1000 exactly. After
+        # entry #1000 the book continues with crossword puzzles and
+        # blank journal slots (1001+) for the reader to fill in their
+        # own words — none of which is corpus-grade content.
+        max_entry_number=1000,
+    ),
+    # "500-verbs" added in C2 once the 1000-words ingest is verified.
+}
+
+
+@dataclass
+class Entry:
+    number: int
+    headword: str
+    english: str
+    body_lines: list[str]
+
+    def full_text(self) -> str:
+        """Render the entry body as a single text block for indexing.
+
+        Format:
+            <headword>  —  <english translation>
+
+            <example UK 1>
+                <example EN 1>
+            <example UK 2>
+                <example EN 2>
+        """
+        lines = [f"{self.headword}  —  {self.english}".rstrip(" —")]
+        if self.body_lines:
+            lines.append("")
+            lines.extend(self.body_lines)
+        return "\n".join(lines).strip() + "\n"
+
+
+def _is_cyrillic_headword(headword: str) -> bool:
+    """True iff the headword starts with (or contains as its first
+    non-punctuation char) a Cyrillic letter. Filters out English-headed
+    matches like ``Anki uses a spaced repetition…`` from the Anki
+    instructions section.
+    """
+    for ch in headword:
+        if ch.isspace() or ch in "\"'’«»()[]{}—-":
+            continue
+        return bool(_CYRILLIC_CHAR_RE.match(ch))
+    return False
+
+
+def parse_book(txt_path: Path, max_entry_number: int | None = None) -> list[Entry]:
+    """Parse a Ohoiko book .txt into a list of Entry objects.
+
+    Pipeline:
+    1. Strip page furniture (PDF page footers, bare page numbers,
+       right-aligned running headers).
+    2. Match ``NNN. <headword> <english>`` entry starts.
+    3. Filter to Cyrillic-headed entries only (rejects the
+       ``How to Use Anki`` numbered-instruction section that uses the
+       same ``NNN.`` shape).
+    4. Cap body accumulation at ``_MAX_BODY_LINES`` per entry — guards
+       against runaway accumulation past the last real entry (the book's
+       back-matter promotional pages have no entry markers, so they
+       would otherwise flow into entry #1109's body indefinitely).
+
+    Each Entry starts at a ``NNN.`` marker and consumes subsequent
+    non-empty lines until the next marker or the body cap.
+    """
+    if not txt_path.exists():
+        raise FileNotFoundError(f"Source not found: {txt_path}")
+
+    entries: list[Entry] = []
+    current: Entry | None = None
+    previous_was_footer = False
+
+    with txt_path.open(encoding="utf-8") as f:
+        for raw in f:
+            line = raw.rstrip("\n")
+
+            # Page footer + the right-aligned running headword that
+            # follows it on the next line.
+            if _PAGE_FOOTER_RE.match(line):
+                previous_was_footer = True
+                continue
+            if previous_was_footer:
+                previous_was_footer = False
+                if _PAGE_HEADER_RE.match(line):
+                    continue
+
+            # Bare page-number lines (rare; mostly absorbed by the footer
+            # rule above, but a few survive in odd page-break contexts).
+            if _BARE_PAGE_NUMBER_RE.match(line) and current is None:
+                continue
+
+            m = _ENTRY_START_RE.match(line)
+            if m:
+                num = int(m.group("num"))
+                headword = m.group("headword").strip()
+                english = (m.group("english") or "").strip()
+
+                # GATE 1: hard cap. After the advertised word count,
+                # the book contains crossword puzzles and blank journal
+                # slots (1001+) that should NOT enter the corpus.
+                # Finalize whatever entry was in flight and stop opening
+                # new ones.
+                if max_entry_number is not None and num > max_entry_number:
+                    if current is not None:
+                        entries.append(current)
+                        current = None
+                    continue
+
+                # GATE 2: Cyrillic-headed only. Non-Cyrillic ``NNN.``
+                # markers belong to the Anki instruction list or other
+                # meta-content.
+                if not _is_cyrillic_headword(headword):
+                    if current is not None:
+                        entries.append(current)
+                        current = None
+                    continue
+
+                # GATE 3: monotonicity. Crossword answer sections after
+                # entry #1000 restart numbering at 1; even with the
+                # max-entry cap, a mid-book numbering reset would be
+                # corruption. Drop any backwards/duplicate number.
+                if entries and num <= entries[-1].number:
+                    if current is not None:
+                        entries.append(current)
+                        current = None
+                    continue
+
+                # Finalize the previous in-flight entry now that we
+                # have a fresh real-entry start.
+                if current is not None:
+                    entries.append(current)
+
+                current = Entry(
+                    number=num,
+                    headword=headword,
+                    english=english,
+                    body_lines=[],
+                )
+                continue
+
+            # Body line for the in-flight entry.
+            if current is not None:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if any(term in stripped for term in _SECTION_TERMINATORS):
+                    # Section break (crossword start, journal section,
+                    # back-matter). Finalize the current entry without
+                    # absorbing the marker line, and stop accumulating
+                    # until the next valid entry start arrives.
+                    entries.append(current)
+                    current = None
+                    continue
+                if len(current.body_lines) >= _MAX_BODY_LINES:
+                    # Hard cap hit — either a runaway long entry (rare
+                    # but possible for verb-pair entries with many
+                    # examples) OR we've fallen off the end of the word
+                    # list into promotional back-matter. Either way,
+                    # finalize and stop accumulating until the next
+                    # valid entry start arrives (or doesn't).
+                    entries.append(current)
+                    current = None
+                    continue
+                current.body_lines.append(stripped)
+
+    if current is not None:
+        entries.append(current)
+
+    return entries
+
+
+def ingest_entries(
+    conn: sqlite3.Connection,
+    book: BookConfig,
+    entries: list[Entry],
+    *,
+    force: bool = False,
+) -> tuple[int, int]:
+    """Insert each entry as one row in textbooks. Returns (inserted, skipped).
+
+    Idempotent: skips chunk_ids that already exist unless ``force=True``,
+    in which case existing rows are DELETED before re-insert (the FTS5
+    AFTER-INSERT trigger handles the index).
+    """
+    cur = conn.cursor()
+    existing_ids: set[str] = set()
+    if not force:
+        rows = cur.execute(
+            "SELECT chunk_id FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        ).fetchall()
+        existing_ids = {r[0] for r in rows}
+
+    if force:
+        cur.execute(
+            "DELETE FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        )
+
+    inserted = 0
+    skipped = 0
+    batch: list[tuple] = []
+    for e in entries:
+        chunk_id = f"{book.source_file}_e{e.number:04d}"
+        if chunk_id in existing_ids:
+            skipped += 1
+            continue
+        text = e.full_text()
+        batch.append((
+            chunk_id,
+            e.headword,
+            text,
+            book.source_file,
+            book.grade,
+            book.author,
+            len(text),
+        ))
+        inserted += 1
+
+    if batch:
+        cur.executemany(
+            """INSERT INTO textbooks
+                  (chunk_id, title, text, source_file, grade, author, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            batch,
+        )
+
+    return inserted, skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ingest Anna Ohoiko book .txt files into data/sources.db",
+    )
+    parser.add_argument(
+        "--book",
+        choices=sorted(BOOKS),
+        required=True,
+        help="Which Ohoiko book to ingest (slug).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse + report, do not write to DB.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-insert: DELETE existing rows for this source_file before INSERT.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Override target DB path (testing only).",
+    )
+    args = parser.parse_args(argv)
+
+    book = BOOKS[args.book]
+    txt_path = REFERENCES_DIR / book.txt_filename
+    if not txt_path.exists():
+        print(f"❌ Source file not found: {txt_path}", file=sys.stderr)
+        return 2
+
+    print(f"📚 Parsing {book.txt_filename}")
+    entries = parse_book(txt_path, max_entry_number=book.max_entry_number)
+    print(f"   parsed entries: {len(entries)}")
+    print(f"   number range: {entries[0].number}..{entries[-1].number}")
+    body_chars = sum(len(e.full_text()) for e in entries)
+    print(f"   total body chars: {body_chars:,}")
+
+    if args.dry_run:
+        # Show 3 sample renders for spot-check
+        print("\n--- DRY-RUN sample (first / middle / last entry) ---")
+        for sample in (entries[0], entries[len(entries) // 2], entries[-1]):
+            print(f"\n### entry #{sample.number} ###")
+            print(sample.full_text())
+        return 0
+
+    print(f"\n🗃️  Writing to {args.db}")
+    conn = sqlite3.connect(str(args.db))
+    try:
+        # Deterministic BEFORE evidence
+        before = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        ).fetchone()[0]
+        total_before = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        print(f"   BEFORE: {before} rows for {book.source_file!r} "
+              f"(table total: {total_before:,})")
+
+        inserted, skipped = ingest_entries(conn, book, entries, force=args.force)
+        conn.commit()
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        ).fetchone()[0]
+        total_after = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        print(f"   inserted: {inserted}, skipped: {skipped}")
+        print(f"   AFTER: {after} rows for {book.source_file!r} "
+              f"(table total: {total_after:,}, delta +{total_after - total_before})")
+
+        # Sample row evidence
+        sample = conn.execute(
+            """SELECT chunk_id, title, char_count, substr(text, 1, 80) AS snippet
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id LIMIT 3""",
+            (book.source_file,),
+        ).fetchall()
+        print("\n--- AFTER sample rows ---")
+        for row in sample:
+            print(f"  chunk_id={row[0]}")
+            print(f"    title={row[1]!r}")
+            print(f"    char_count={row[2]}")
+            print(f"    snippet={row[3]!r}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ohoiko_books_ingest.py
+++ b/tests/test_ohoiko_books_ingest.py
@@ -1,0 +1,255 @@
+"""Tests for scripts/ingest/ohoiko_books_ingest.py.
+
+Exercises the parser against a synthetic fixture that mirrors the
+real Ohoiko book quirks identified during the 2026-05-14 ingest run:
+
+- ``How to Use Anki`` numbered-instruction section (English-headed
+  ``N.`` markers) must be filtered out.
+- Hard cap at ``max_entry_number`` keeps crossword puzzle clues and
+  blank-journal slots (1001+) out of the corpus.
+- Monotonicity guard drops any backwards-jumping number that survives
+  the cap.
+- ``Кросворд`` / ``Find out more at`` section terminators stop body
+  accumulation so the LAST real entry's body doesn't absorb back-matter.
+- Verified output (chunk_id, title, char_count) lands in the textbooks
+  table via the same code path as the live ingest.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.ingest import ohoiko_books_ingest as obi
+
+FIXTURE_TXT = """Welcome page
+
+How to Use Anki
+
+1. Open Anki and create a new deck.
+2. Anki uses a spaced repetition algorithm to show you cards.
+3. Make sure to use the audio.
+
+Most Useful Ukrainian Words
+
+1.    а                                               and, but
+      (contrast between sentences)
+      Я люблю́ готува́ти, а ти?                       I like to cook, and you (informal)?
+2.    або́ = чи                                       or
+      За́раз або́ ніко́ли.                            Now or never.
+3.    авто́бус                                        bus
+      Сашко́ ї́здить в шко́лу                         Sashko goes to school
+      авто́бусом.                                     by bus.
+
+
+
+                 Inspiring resources for learning Ukrainian — UkrainianLessons.com         12
+                                                                                            але́
+
+
+
+
+4.    але́                                            but (contrast)
+      Я хочу́, але́ не мо́жу.                         I want to, but I cannot.
+5.    якщо́                                          if
+      Якщо́ ти го́лодний, їж.                         If you're hungry, eat.
+Кросворд №1
+1. бана́н
+2. ві́кно
+3. сонце
+"""
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    p = tmp_path / "fixture.txt"
+    p.write_text(FIXTURE_TXT, encoding="utf-8")
+    return p
+
+
+def test_parse_book_filters_english_instruction_steps(tmp_path: Path) -> None:
+    """The Anki instructions (English-headed) must NOT enter the entry list."""
+    entries = obi.parse_book(_write_fixture(tmp_path), max_entry_number=10)
+    headwords = [e.headword for e in entries]
+    # Only Cyrillic headwords land in the result.
+    for h in headwords:
+        assert obi._is_cyrillic_headword(h), (
+            f"non-Cyrillic headword leaked through: {h!r}"
+        )
+    # First real entry is 'а', not 'Open Anki and create a new deck.'
+    assert entries[0].headword == "а"
+
+
+def test_parse_book_caps_at_max_entry_number(tmp_path: Path) -> None:
+    """Entries with num > max_entry_number must be dropped."""
+    # Cap at 5: real entries are #1-#5 in the fixture; crossword answers
+    # (also #1, #2, #3) must NOT land because they're below cap but
+    # monotonicity guards them, AND they sit behind the Кросворд marker.
+    entries = obi.parse_book(_write_fixture(tmp_path), max_entry_number=5)
+    nums = [e.number for e in entries]
+    assert nums == [1, 2, 3, 4, 5], f"expected #1..#5, got {nums}"
+
+
+def test_parse_book_drops_monotonicity_violations(tmp_path: Path) -> None:
+    """A backwards number jump (crossword answer reset) must be dropped."""
+    # With max=20 (above all fixture numbers), the crossword "1./2./3."
+    # answers would otherwise be captured. The monotonicity guard
+    # rejects them because they restart numbering after entry #5.
+    entries = obi.parse_book(_write_fixture(tmp_path), max_entry_number=20)
+    nums = [e.number for e in entries]
+    assert nums == [1, 2, 3, 4, 5], f"expected #1..#5, got {nums}"
+
+
+def test_parse_book_section_terminator_stops_body(tmp_path: Path) -> None:
+    """``Кросворд`` inside an entry body finalizes the entry without
+    absorbing the marker line into its text."""
+    entries = obi.parse_book(_write_fixture(tmp_path), max_entry_number=10)
+    last = entries[-1]
+    assert last.number == 5
+    assert last.headword == "якщо́"
+    body_blob = last.full_text()
+    # The "Кросворд №1" header must not appear in the last entry's body
+    # and neither must any crossword answer.
+    assert "Кросворд" not in body_blob
+    assert "бана́н" not in body_blob
+    assert "сонце" not in body_blob
+    # But the entry's real example sentence stays.
+    assert "Якщо́ ти го́лодний" in body_blob
+
+
+def test_parse_book_full_text_renders_clean_header(tmp_path: Path) -> None:
+    """full_text() yields ``<headword>  —  <english>`` followed by examples."""
+    entries = obi.parse_book(_write_fixture(tmp_path), max_entry_number=10)
+    a = entries[0]
+    blob = a.full_text()
+    assert blob.startswith("а  —  and, but\n"), blob[:40]
+    assert "Я люблю́ готува́ти" in blob
+
+
+def _make_textbooks_db(path: Path) -> sqlite3.Connection:
+    """Minimal textbooks schema for round-trip tests (no FTS triggers
+    needed — we exercise the INSERT layer, not retrieval)."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+        );
+        """
+    )
+    return conn
+
+
+def test_ingest_entries_round_trip(tmp_path: Path) -> None:
+    """End-to-end: parse → ingest → SELECT confirms rows are written
+    with correct metadata."""
+    txt = _write_fixture(tmp_path)
+    entries = obi.parse_book(txt, max_entry_number=10)
+    assert len(entries) == 5
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    book = obi.BookConfig(
+        slug="test-fixture",
+        source_file="test-fixture-source",
+        txt_filename="fixture.txt",
+        author="Anna Ohoiko",
+        grade="",
+        max_entry_number=10,
+    )
+    inserted, skipped = obi.ingest_entries(conn, book, entries)
+    conn.commit()
+    assert inserted == 5
+    assert skipped == 0
+
+    rows = list(conn.execute(
+        """SELECT chunk_id, title, source_file, author, char_count
+             FROM textbooks WHERE source_file = ? ORDER BY chunk_id""",
+        (book.source_file,),
+    ))
+    assert len(rows) == 5
+    # chunk_id format: <source_file>_e<NNNN>
+    assert rows[0][0] == "test-fixture-source_e0001"
+    assert rows[-1][0] == "test-fixture-source_e0005"
+    assert rows[0][1] == "а"
+    assert all(r[2] == "test-fixture-source" for r in rows)
+    assert all(r[3] == "Anna Ohoiko" for r in rows)
+    assert all(r[4] > 0 for r in rows)
+    conn.close()
+
+
+def test_ingest_entries_idempotent(tmp_path: Path) -> None:
+    """Running the ingest twice on the same source should NOT duplicate
+    rows; the second call returns (0 inserted, N skipped)."""
+    txt = _write_fixture(tmp_path)
+    entries = obi.parse_book(txt, max_entry_number=10)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    book = obi.BookConfig(
+        slug="t",
+        source_file="t",
+        txt_filename="fixture.txt",
+        author="A",
+        grade="",
+        max_entry_number=10,
+    )
+
+    first = obi.ingest_entries(conn, book, entries)
+    conn.commit()
+    second = obi.ingest_entries(conn, book, entries)
+    conn.commit()
+    assert first == (5, 0)
+    assert second == (0, 5)
+    total = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+    assert total == 5
+    conn.close()
+
+
+def test_ingest_entries_force_overwrites(tmp_path: Path) -> None:
+    """With force=True, existing rows are deleted before re-insert."""
+    txt = _write_fixture(tmp_path)
+    entries = obi.parse_book(txt, max_entry_number=10)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    book = obi.BookConfig(
+        slug="t",
+        source_file="t",
+        txt_filename="fixture.txt",
+        author="A",
+        grade="",
+        max_entry_number=10,
+    )
+    obi.ingest_entries(conn, book, entries)
+    conn.commit()
+    inserted, skipped = obi.ingest_entries(conn, book, entries, force=True)
+    conn.commit()
+    assert inserted == 5
+    assert skipped == 0
+    total = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+    assert total == 5
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "headword,expected",
+    [
+        ("а", True),
+        ("або́ = чи", True),
+        ("'а́", True),
+        ("Open Anki and create a new deck.", False),
+        ("Anki uses a spaced repetition algorithm", False),
+        ("", False),
+        ("   ", False),
+    ],
+)
+def test_is_cyrillic_headword(headword: str, expected: bool) -> None:
+    assert obi._is_cyrillic_headword(headword) is expected


### PR DESCRIPTION
## Summary

- First book of the **Ohoiko + ULP corpus expansion** the user directed 2026-05-14 (priority pivot away from m20 build-iteration arc).
- 1,000 alphabetical word entries (#1..#1000) from Anna Ohoiko's *"1000 Most Useful Ukrainian Words"* (2nd ed), now landed in `textbooks` table with `source_file='anna-ohoiko-1000-words-2nd-ed'`.
- Source file is gitignored (`docs/references/private/`), so this PR ships the parser/ingester only; the data was loaded inline against canonical `data/sources.db` before commit.

## Why a new parser

The book has four real PDF-extraction quirks the parser handles:
1. An earlier *"How to Use Anki"* section uses `1.`/`2.`/`3.` numbering — rejected by Cyrillic-headword gate.
2. Crossword puzzles after entry #1000 restart numbering at 1 — rejected by `max_entry_number=1000` cap + monotonicity guard.
3. Blank journal slots `1001`..`1109` for the reader's own words — rejected by the same cap.
4. Back-matter promotional pages — section terminators (`Кросворд`, `Find out more at`, `My New Ukrainian Words`) finalize the in-flight entry without absorbing the marker line.

## Deterministic evidence (live run against canonical `data/sources.db`)

```
📚 Parsing 1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt
   parsed entries: 1000
   number range: 1..1000
   total body chars: 148,348

🗃️  Writing to /Users/.../data/sources.db
   BEFORE: 0 rows for 'anna-ohoiko-1000-words-2nd-ed' (table total: 23,777)
   inserted: 1000, skipped: 0
   AFTER: 1000 rows for 'anna-ohoiko-1000-words-2nd-ed' (table total: 24,777, delta +1000)
```

FTS5 sync after insert:
```
$ sqlite3 data/sources.db "SELECT 'fts', COUNT(*) FROM textbooks_fts UNION ALL SELECT 'tbl', COUNT(*) FROM textbooks"
fts|24777
tbl|24777
```

FTS retrieval spot-check (verify new rows are queryable):
```
$ sqlite3 data/sources.db "SELECT t.chunk_id FROM textbooks t JOIN textbooks_fts f ON t.id=f.rowid WHERE f.text MATCH 'якщо' AND t.source_file='anna-ohoiko-1000-words-2nd-ed' LIMIT 1"
anna-ohoiko-1000-words-2nd-ed_e1000
```

Sample rows after ingest:
```
chunk_id=anna-ohoiko-1000-words-2nd-ed_e0001
  title='а'   char_count=129
  snippet='а  —  and, but\n\n(contrast between sentences)\nЯ люблю́ готува́ти, а ти?...'
chunk_id=anna-ohoiko-1000-words-2nd-ed_e0002
  title='або́ = чи'   char_count=186
  snippet='або́ = чи  —  or\n\nЗа́раз або́ ніко́ли.    Now or never.'
chunk_id=anna-ohoiko-1000-words-2nd-ed_e0003
  title='авто́бус'   char_count=108
  snippet='авто́бус  —  bus\n\nСашко́ ї́здить в шко́лу    Sashko goes to...'
```

## Tests

```
$ .venv/bin/python -m pytest tests/test_ohoiko_books_ingest.py
============================== 15 passed in 0.06s ==============================
$ .venv/bin/ruff check scripts/ingest/ohoiko_books_ingest.py tests/test_ohoiko_books_ingest.py
All checks passed!
```

15 new tests cover: Cyrillic-headword filter, max-entry cap, monotonicity guard, section terminators, full_text rendering, round-trip parse→ingest→SELECT, idempotency, --force overwrite, and 7 parametrized cases for `_is_cyrillic_headword`.

## What this PR commits

- `scripts/ingest/ohoiko_books_ingest.py` — extensible CLI ingester. The `BOOKS` registry adds one entry per Ohoiko book; `500-verbs` and future books slot in there.
- `tests/test_ohoiko_books_ingest.py` — 15 unit tests with a synthetic fixture mirroring real book quirks.

## What's next (carry-over tasks)

- C2: extend `BOOKS` registry with `500-verbs` config + verify the same parser shape handles verb-page structure.
- C3: write a separate prose-chunk parser for ULP 1-00 → 6-00 lesson notes (different structure).
- C4: OCR pipeline for Pohribnyi book (52MB image-based PDF, needs Tesseract Ukrainian).

🤖 Generated with [Claude Code](https://claude.com/claude-code)