### PR TITLE
feat(corpus): ingest Ukrainian Lessons Podcast lesson notes (all 6 seasons)

### DIFF
--- a/scripts/ingest/ulp_lesson_notes_ingest.py
+++ b/scripts/ingest/ulp_lesson_notes_ingest.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Ingest Ukrainian Lessons Podcast (ULP) lesson-notes .txt files into
+``data/sources.db`` textbooks table.
+
+Six "lesson notes (all in one file)" books cover six seasons of the
+podcast (~40 lessons each, 240 total):
+
+- ULP 1-00 (Season 1, lessons #1-40) — English-language podcast notes
+- ULP 2-00 (Season 2, lessons #41-80)
+- ULP 3-00 (Season 3, lessons #81-120)
+- ULP 4-00 (Season 4, lessons #121-160) — Ukrainian-only podcast notes
+- ULP 5-00 (Season 5, lessons #161-200)
+- ULP 6-00 (Season 6, lessons #201-240)
+
+Schema fit:
+- One row per lesson (mid-grained — typical lesson body ~5-15K chars)
+- ``author = 'Ukrainian Lessons Podcast'``
+- ``source_file`` = per-book slug (e.g. ``ulp-1-00-lesson-notes``)
+- ``title`` = "Lesson N: <title>"
+- ``text`` = the lesson body with PDF page furniture stripped
+- ``grade`` empty (CEFR mapping is a downstream concern)
+- ``chunk_id`` = ``{source_file}_l{NNNN}`` (e.g. ``ulp-1-00-lesson-notes_l0001``)
+
+Marker formats (verified empirically against all six books):
+- Seasons 1-3: lesson start = ``Lesson Notes № N`` (with space between №
+  and the number). Page running heads use ``Episode N — Title`` format
+  in English and never conflict with the start marker.
+- Seasons 4-6: lesson start = ``Конспект уроку № N`` (with space). Page
+  running heads use ``Конспект уроку №N`` (NO space) — the spacing
+  disambiguates them cleanly. This invariant is exercised by the test
+  fixture.
+
+Idempotent: each lesson's chunk_id is checked against the DB and skipped
+when present. Re-running on an unchanged source produces zero new
+inserts; use ``--force`` to delete existing rows for the source_file
+before re-insert.
+
+Deterministic verification: prints BEFORE / AFTER row counts and three
+sample rows per call. Mirrors the evidence convention required by the
+2026-05-14 determinism rule (see
+``docs/best-practices/deterministic-over-hallucination.md``).
+
+Usage:
+    .venv/bin/python -m scripts.ingest.ulp_lesson_notes_ingest --book 1-00
+    .venv/bin/python -m scripts.ingest.ulp_lesson_notes_ingest --book 1-00 --dry-run
+    .venv/bin/python -m scripts.ingest.ulp_lesson_notes_ingest --all
+    .venv/bin/python -m scripts.ingest.ulp_lesson_notes_ingest --book 1-00 --force
+
+Source files (gitignored, in ``docs/references/private/``):
+- ``ULP 1-00 Lesson Notes (all in one file) (2023).txt``
+- ``ULP 2-00 Lesson Notes (all in one file).txt``
+- ``ULP 3-00 Lesson Notes (all in one file).txt``
+- ``ULP 4-00 Lesson Notes (all in one file).txt``
+- ``ULP 5-00 Lesson Notes (all in one file).txt``
+- ``ULP 6-00 Lesson Notes (all in one file).txt``
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
+AUTHOR = "Ukrainian Lessons Podcast"
+
+# ---------------------------------------------------------------------------
+# Marker patterns
+# ---------------------------------------------------------------------------
+
+# Lesson START anchor: requires at least one space between № and the
+# number. This is the load-bearing disambiguator versus page running
+# heads (which use ``Конспект уроку №NNN`` with no space).
+_LESSON_START_RE = re.compile(
+    r"^\s*(?P<heading>Lesson\s+Notes|Конспект\s+уроку)"
+    r"\s+№\s+(?P<num>\d{1,4})\s*$"
+)
+
+# Page-running-head pattern for seasons 4-6: ``Конспект уроку №NNN``
+# (NO space between № and the number). Always page furniture; the
+# zero-space requirement is the disambiguator from the lesson-start
+# anchor which always has ≥1 space between № and the number.
+_RUNNING_HEAD_4_6_RE = re.compile(r"^\s*Конспект\s+уроку\s+№\d{1,4}\s*$")
+
+# Page-running-head pattern for seasons 1-3: ``Episode N — Title``.
+_RUNNING_HEAD_1_3_RE = re.compile(r"^\s*Episode\s+\d+\s+—")
+
+# ``Link to audio: ukrainianlessons.com/episodeN`` appears in every
+# lesson directly below the lesson title (verified 80/80 in spot-check
+# of ULP 1-00 and 6-00). It serves as the title's natural lower bound:
+# any non-blank/non-furniture lines between the lesson-start marker and
+# this line make up the title (possibly multi-line, e.g. ``Василь Стус,
+# шістдесятники та дисиденти`` is broken across two PDF lines).
+_LINK_TO_AUDIO_RE = re.compile(r"^\s*Link to audio:")
+
+# Page footer: ``Inspiring resources for learning Ukrainian — UkrainianLessons.com``
+# May be followed by trailing spaces and a page number on the same or
+# next line.
+_PAGE_FOOTER_RE = re.compile(r"^\s*Inspiring resources for learning Ukrainian — UkrainianLessons\.com")
+
+# ``Back to Contents <page-number>`` lines that follow the page footer.
+_BACK_TO_CONTENTS_RE = re.compile(r"^\s*Back to Contents\s+\d+\s*$")
+
+# Standalone ``UkrainianLessons.com`` lines that appear at page tops
+# (cover-page style on first ~3 pages of each book).
+_UKRLESSONS_BARE_RE = re.compile(r"^\s*UkrainianLessons\.com\s*$")
+
+# Season header at page tops: ``Ukrainian Lessons Podcast: Season N``
+_SEASON_HEADER_RE = re.compile(r"^\s*Ukrainian\s+Lessons\s+Podcast:\s+Season\s+\d+\s*$")
+
+# Bare page-number lines (e.g., ``5``, ``190``). Strictly numeric +
+# optional whitespace.
+_BARE_PAGE_NUMBER_RE = re.compile(r"^\s*\d{1,4}\s*$")
+
+# End-of-content terminators. When encountered AFTER all lessons have
+# been opened (i.e. we're inside the last lesson's body), finalize the
+# current lesson without absorbing the terminator line and stop
+# accumulating.
+_SECTION_TERMINATORS = (
+    "Відповіді до вправ",  # "Answers to exercises" appendix (seasons 1-3)
+    "Key Phrases ",  # "Key Phrases N-NNN" summary appendix (season 4)
+)
+
+# Hard cap on body lines per lesson. ULP lessons are long (~200-400
+# stripped lines is typical). 2000 is the runaway-guard threshold —
+# trips if the file structure unexpectedly shifts and we absorb
+# back-matter into the final lesson.
+_MAX_BODY_LINES = 2000
+
+
+# ---------------------------------------------------------------------------
+# Per-book config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BookConfig:
+    slug: str  # CLI key, e.g. "1-00"
+    source_file: str  # textbooks.source_file value
+    txt_filename: str  # relative to REFERENCES_DIR
+    season: int  # 1..6
+    expected_lessons: int = 40  # all six books are 40 lessons each
+
+
+BOOKS: dict[str, BookConfig] = {
+    "1-00": BookConfig(
+        slug="1-00",
+        source_file="ulp-1-00-lesson-notes",
+        txt_filename="ULP 1-00 Lesson Notes (all in one file) (2023).txt",
+        season=1,
+    ),
+    "2-00": BookConfig(
+        slug="2-00",
+        source_file="ulp-2-00-lesson-notes",
+        txt_filename="ULP 2-00 Lesson Notes (all in one file).txt",
+        season=2,
+    ),
+    "3-00": BookConfig(
+        slug="3-00",
+        source_file="ulp-3-00-lesson-notes",
+        txt_filename="ULP 3-00 Lesson Notes (all in one file).txt",
+        season=3,
+    ),
+    "4-00": BookConfig(
+        slug="4-00",
+        source_file="ulp-4-00-lesson-notes",
+        txt_filename="ULP 4-00 Lesson Notes (all in one file).txt",
+        season=4,
+    ),
+    "5-00": BookConfig(
+        slug="5-00",
+        source_file="ulp-5-00-lesson-notes",
+        txt_filename="ULP 5-00 Lesson Notes (all in one file).txt",
+        season=5,
+    ),
+    "6-00": BookConfig(
+        slug="6-00",
+        source_file="ulp-6-00-lesson-notes",
+        txt_filename="ULP 6-00 Lesson Notes (all in one file).txt",
+        season=6,
+    ),
+}
+
+
+@dataclass
+class Lesson:
+    number: int
+    title: str = ""
+    body_lines: list[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        """Render the lesson as a single text block for indexing.
+
+        Format:
+            Lesson N: <title>
+
+            <body line 1>
+            <body line 2>
+            ...
+        """
+        header = f"Lesson {self.number}: {self.title}".rstrip(": ") if self.title else f"Lesson {self.number}"
+        if not self.body_lines:
+            return header + "\n"
+        return header + "\n\n" + "\n".join(self.body_lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def _is_page_furniture(line: str) -> bool:
+    """Return True if ``line`` is PDF page furniture (footer, header,
+    running head, bare page number, season header) that should be
+    stripped from lesson bodies.
+    """
+    if not line.strip():
+        return False  # blank lines handled separately
+    return bool(
+        _PAGE_FOOTER_RE.match(line)
+        or _BACK_TO_CONTENTS_RE.match(line)
+        or _UKRLESSONS_BARE_RE.match(line)
+        or _SEASON_HEADER_RE.match(line)
+        or _BARE_PAGE_NUMBER_RE.match(line)
+        or _RUNNING_HEAD_4_6_RE.match(line)
+        or _RUNNING_HEAD_1_3_RE.match(line)
+    )
+
+
+def parse_book(txt_path: Path) -> list[Lesson]:
+    """Parse a ULP lesson-notes .txt into a list of Lesson objects.
+
+    Pipeline:
+    1. Locate the first lesson-start marker (``Lesson Notes № N`` or
+       ``Конспект уроку № N`` with at least one space between № and the
+       number). Skip everything before it (cover pages + ToC).
+    2. For each subsequent line:
+       a. If it matches another lesson-start marker AND the number is
+          strictly greater than the current lesson, finalize the current
+          and open a new one.
+       b. If it matches the current lesson-start marker again (same N
+          with space), treat as a page header redundancy and skip.
+       c. If it matches page furniture, skip.
+       d. If it contains a SECTION_TERMINATORS substring, finalize the
+          current lesson and stop accumulating until EOF.
+       e. Otherwise, append to the current lesson's body (stripped of
+          trailing whitespace; leading whitespace preserved for column
+          structure where present).
+    3. Title heuristic: the first non-blank, non-furniture line AFTER
+       the lesson start is captured as the title. The title line then
+       does NOT enter the body — the renderer adds it via the header.
+    """
+    if not txt_path.exists():
+        raise FileNotFoundError(f"Source not found: {txt_path}")
+
+    lessons: list[Lesson] = []
+    current: Lesson | None = None
+    title_fragments: list[str] = []
+    captured_title = False
+    terminated = False
+    consecutive_blanks = 0
+
+    def _finalize_title() -> None:
+        """Join accumulated title fragments with single spaces and
+        clear the buffer."""
+        nonlocal captured_title, title_fragments
+        if current is not None and title_fragments:
+            current.title = " ".join(title_fragments).strip().rstrip(",")
+        captured_title = True
+        title_fragments = []
+
+    with txt_path.open(encoding="utf-8") as f:
+        for raw in f:
+            line = raw.rstrip("\n").rstrip()  # trailing whitespace only
+
+            m = _LESSON_START_RE.match(line)
+            if m:
+                num = int(m.group("num"))
+                if current is None:
+                    # First lesson opened.
+                    current = Lesson(number=num)
+                    title_fragments = []
+                    captured_title = False
+                    terminated = False
+                    consecutive_blanks = 0
+                    continue
+                if num > current.number:
+                    # Finalize current, open new. Any in-flight title
+                    # fragments for the previous lesson get committed.
+                    if not captured_title:
+                        _finalize_title()
+                    lessons.append(current)
+                    current = Lesson(number=num)
+                    title_fragments = []
+                    captured_title = False
+                    terminated = False
+                    consecutive_blanks = 0
+                    continue
+                # num == current.number — repeated page header for the
+                # same lesson (rare with the with-space pattern, but
+                # defensive). Skip.
+                continue
+
+            # No lesson in flight yet → still in cover/ToC region.
+            if current is None:
+                continue
+
+            # Already terminated for this lesson → wait for next marker
+            # or EOF, ignore content.
+            if terminated:
+                continue
+
+            if _is_page_furniture(line):
+                continue
+
+            stripped = line.strip()
+            if not stripped:
+                consecutive_blanks += 1
+                # Compress runs of blanks: keep at most one blank line
+                # between content blocks (PDF extraction produces 5-10
+                # blank lines between paragraphs).
+                if current.body_lines and current.body_lines[-1] != "" and consecutive_blanks == 1 and captured_title:
+                    current.body_lines.append("")
+                continue
+
+            consecutive_blanks = 0
+
+            # Title-capture phase: accumulate non-furniture, non-blank
+            # lines between the lesson-start marker and the
+            # ``Link to audio:`` landmark. Multi-line PDF titles
+            # (e.g. ``Василь Стус,\nшістдесятники та дисиденти``) join
+            # into one title via a single space.
+            if not captured_title:
+                if _LINK_TO_AUDIO_RE.match(line):
+                    # Title block ends — finalize accumulated fragments
+                    # (which may be empty if the PDF layout omitted the
+                    # title entirely) and DROP the link line itself.
+                    _finalize_title()
+                    continue
+                title_fragments.append(stripped)
+                continue
+
+            # Section terminator check: appears INSIDE the last
+            # lesson's body to mark the start of an appendix.
+            if any(term in stripped for term in _SECTION_TERMINATORS):
+                terminated = True
+                continue
+
+            if len(current.body_lines) >= _MAX_BODY_LINES:
+                # Runaway guard — should not trigger in practice.
+                terminated = True
+                continue
+
+            current.body_lines.append(line.rstrip())
+
+    if current is not None:
+        # Trim trailing empty body lines.
+        while current.body_lines and not current.body_lines[-1].strip():
+            current.body_lines.pop()
+        lessons.append(current)
+
+    return lessons
+
+
+# ---------------------------------------------------------------------------
+# DB ingest
+# ---------------------------------------------------------------------------
+
+
+def ingest_lessons(
+    conn: sqlite3.Connection,
+    book: BookConfig,
+    lessons: list[Lesson],
+    *,
+    force: bool = False,
+) -> tuple[int, int]:
+    """Insert each lesson as one row in textbooks. Returns (inserted, skipped).
+
+    Idempotent: skips chunk_ids that already exist unless ``force=True``,
+    in which case existing rows are DELETED for the source_file before
+    re-insert.
+    """
+    cur = conn.cursor()
+    existing_ids: set[str] = set()
+    if not force:
+        rows = cur.execute(
+            "SELECT chunk_id FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        ).fetchall()
+        existing_ids = {r[0] for r in rows}
+
+    if force:
+        cur.execute(
+            "DELETE FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        )
+
+    inserted = 0
+    skipped = 0
+    batch: list[tuple] = []
+    for lesson in lessons:
+        chunk_id = f"{book.source_file}_l{lesson.number:04d}"
+        if chunk_id in existing_ids:
+            skipped += 1
+            continue
+        text = lesson.render()
+        title = f"Lesson {lesson.number}: {lesson.title}".rstrip(": ") if lesson.title else f"Lesson {lesson.number}"
+        batch.append(
+            (
+                chunk_id,
+                title,
+                text,
+                book.source_file,
+                "",  # grade
+                AUTHOR,
+                len(text),
+            )
+        )
+        inserted += 1
+
+    if batch:
+        cur.executemany(
+            """INSERT INTO textbooks
+                  (chunk_id, title, text, source_file, grade, author, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            batch,
+        )
+
+    return inserted, skipped
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _run_book(
+    book: BookConfig,
+    *,
+    db_path: Path,
+    dry_run: bool,
+    force: bool,
+) -> int:
+    txt_path = REFERENCES_DIR / book.txt_filename
+    if not txt_path.exists():
+        print(f"❌ Source file not found: {txt_path}", file=sys.stderr)
+        return 2
+
+    print(f"\n📚 Parsing {book.txt_filename}")
+    lessons = parse_book(txt_path)
+    print(f"   parsed lessons: {len(lessons)} (expected: {book.expected_lessons})")
+    if lessons:
+        print(f"   number range: {lessons[0].number}..{lessons[-1].number}")
+        body_chars = sum(len(lesson.render()) for lesson in lessons)
+        print(f"   total body chars: {body_chars:,}")
+
+    if dry_run:
+        print("\n--- DRY-RUN sample (first / middle / last lesson) ---")
+        if not lessons:
+            print("   (no lessons parsed)")
+            return 0
+        samples = [lessons[0], lessons[len(lessons) // 2], lessons[-1]]
+        for sample in samples:
+            print(f"\n### lesson #{sample.number}: {sample.title!r} ###")
+            text = sample.render()
+            # Show first 400 chars of body
+            print(text[:400] + ("…" if len(text) > 400 else ""))
+        return 0
+
+    print(f"\n🗃️  Writing to {db_path}")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        before = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        ).fetchone()[0]
+        total_before = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        print(f"   BEFORE: {before} rows for {book.source_file!r} (table total: {total_before:,})")
+
+        inserted, skipped = ingest_lessons(conn, book, lessons, force=force)
+        conn.commit()
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (book.source_file,),
+        ).fetchone()[0]
+        total_after = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        print(f"   inserted: {inserted}, skipped: {skipped}")
+        print(
+            f"   AFTER: {after} rows for {book.source_file!r} "
+            f"(table total: {total_after:,}, delta +{total_after - total_before})"
+        )
+
+        sample = conn.execute(
+            """SELECT chunk_id, title, char_count, substr(text, 1, 80) AS snippet
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id LIMIT 3""",
+            (book.source_file,),
+        ).fetchall()
+        print("\n--- AFTER sample rows ---")
+        for row in sample:
+            print(f"  chunk_id={row[0]}")
+            print(f"    title={row[1]!r}")
+            print(f"    char_count={row[2]}")
+            print(f"    snippet={row[3]!r}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ingest ULP lesson-notes .txt files into data/sources.db",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--book",
+        choices=sorted(BOOKS),
+        help="Ingest a single book by slug (e.g. 1-00).",
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Ingest all six ULP books sequentially.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse + report, do not write to DB.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-insert: DELETE existing rows for this source_file before INSERT.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Override target DB path (testing only).",
+    )
+    args = parser.parse_args(argv)
+
+    slugs = sorted(BOOKS) if args.all else [args.book]
+
+    rc = 0
+    for slug in slugs:
+        result = _run_book(
+            BOOKS[slug],
+            db_path=args.db,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+        if result != 0:
+            rc = result
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ulp_lesson_notes_ingest.py
+++ b/tests/test_ulp_lesson_notes_ingest.py
@@ -1,0 +1,487 @@
+"""Tests for scripts/ingest/ulp_lesson_notes_ingest.py.
+
+Exercises the parser against synthetic fixtures that mirror the real
+ULP lesson-notes book quirks identified during the 2026-05-14 ingest run:
+
+- Lesson START anchor requires a SPACE between № and the number
+  (``Lesson Notes № 1`` for seasons 1-3, ``Конспект уроку № 1`` for
+  seasons 4-6). Page running heads use the no-space variant
+  (``Конспект уроку №1``) and MUST be stripped, not promoted to lesson
+  starts.
+- Cover pages + Зміст (table of contents) before the first lesson start
+  must be skipped entirely.
+- Page footer + Back to Contents + UkrainianLessons.com + bare page
+  numbers + season headers must be stripped from lesson bodies.
+- ``Відповіді до вправ`` (Answers to exercises, season 1-3 appendix)
+  and ``Key Phrases N-NNN`` (Season 4 appendix) terminate the last
+  lesson's body.
+- Verified output (chunk_id, title, char_count) lands in the textbooks
+  table via the same code path as the live ingest.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.ingest import ulp_lesson_notes_ingest as ulp
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic seasons 1 (English heading) and 4 (Ukrainian heading)
+# ---------------------------------------------------------------------------
+
+FIXTURE_S1 = """                          UkrainianLessons.com
+                   Inspiring resources for learning Ukrainian — UkrainianLessons.com
+Back to Contents                                                                       1
+                              Ukrainian Lessons Podcast: Season 1
+
+
+
+
+                                            Зміст
+Lesson Notes №1: Informal Greetings in Ukrainian                                              5
+Lesson Notes №2: Formal Greetings in Ukrainian                                                9
+
+
+
+                          Inspiring resources for learning Ukrainian — UkrainianLessons.com
+Back to Contents                                                                       2
+                                  Ukrainian Lessons Podcast: Season 1
+
+
+                                            Lesson Notes № 1
+
+       Informal Greetings in Ukrainian
+                                         Link to audio: ukrainianlessons.com/episode1
+
+
+
+
+                       Приві́т! Мене́ зва́ти А́нна — Hi! My name is Anna.
+                       In this lesson we learn basic informal greetings.
+
+   Dialogue                                                       Привіт!
+   Анна: Приві́т!                                The basic informal "Hi!"
+   Інна: Приві́т!
+
+
+
+                          Inspiring resources for learning Ukrainian — UkrainianLessons.com
+Back to Contents                                                                       5
+                                  Episode 1 — Informal Greetings in Ukrainian
+
+
+   Анна: Як спра́ви?                            How are you?
+   Інна: Чудо́во!
+
+
+                                               Lesson Notes № 2
+
+  Formal Greetings in Ukrainian
+                                         Link to audio: ukrainianlessons.com/episode2
+
+
+
+
+                          Приві́т! In the second episode of the Ukrainian Lessons Podcast,
+                          we are continuing with greetings.
+
+   Dialogue                                            Добрий день! — Hello!
+   Анна: До́брий день!                          Formal greeting in Ukrainian.
+
+
+
+                                  Відповіді до вправ 1-2
+
+   Exercise 1 answers: ...
+"""
+
+FIXTURE_S4 = """                          UkrainianLessons.com
+                   Inspiring resources for learning Ukrainian — UkrainianLessons.com
+ Back to Contents                                                                       1
+                                 Ukrainian Lessons Podcast: Season 4
+
+
+                                            Зміст
+Lesson Notes №121: 10 цікавих фактів про мене                                                5
+
+
+
+                          Inspiring resources for learning Ukrainian — UkrainianLessons.com
+ Back to Contents                                                                            4
+                                 Ukrainian Lessons Podcast: Season 4
+
+
+                                       Конспект уроку № 121
+
+
+           10 цікавих фактів про мене
+                                        Link to audio: ukrainianlessons.com/episode121
+
+
+
+
+                                                     Вступ
+
+Добрий день! Це Анна, і ви слухаєте Ukrainian Lessons Podcast.
+
+Це — четвертий сезон!
+
+
+
+                          Inspiring resources for learning Ukrainian — UkrainianLessons.com
+ Back to Contents                                                                            5
+                                        Конспект уроку №121
+                                      10 цікавих фактів про мене
+
+
+Я розповім вам 10 цікавих фактів про мене.
+
+Перший факт. Я народилась у Радянському Союзі.
+
+
+
+                                       Конспект уроку № 122
+
+
+                            Друга лекція
+
+                                        Link to audio: ukrainianlessons.com/episode122
+
+
+
+
+                                                     Вступ
+
+Привіт. Це друга лекція.
+
+
+
+                                     Key Phrases 4-122
+
+Bonus vocabulary follows...
+"""
+
+
+def _write_fixture(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Parser-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_book_skips_cover_and_toc(tmp_path: Path) -> None:
+    """Cover pages, Зміст (ToC), and pre-first-lesson content must NOT
+    enter the lesson list."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+    nums = [l.number for l in lessons]
+    assert nums == [1, 2], f"expected lessons [1, 2], got {nums}"
+    # ToC entries ``Lesson Notes №1:`` (no space) must not have been
+    # mistaken for lesson starts.
+
+
+def test_parse_book_with_space_anchor_seasons_1_3(tmp_path: Path) -> None:
+    """Season 1-3 anchor is ``Lesson Notes № N`` with space."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+    assert lessons[0].title == "Informal Greetings in Ukrainian"
+    assert lessons[1].title == "Formal Greetings in Ukrainian"
+
+
+def test_parse_book_with_space_anchor_seasons_4_6(tmp_path: Path) -> None:
+    """Season 4-6 anchor is ``Конспект уроку № N`` with space — the
+    no-space variant ``Конспект уроку №N`` is a page running head and
+    must NOT open a new lesson."""
+    txt = _write_fixture(tmp_path, "s4.txt", FIXTURE_S4)
+    lessons = ulp.parse_book(txt)
+    nums = [l.number for l in lessons]
+    assert nums == [121, 122], f"expected lessons [121, 122], got {nums}"
+    # The running-head ``Конспект уроку №121`` on the second page of
+    # lesson 121 must NOT have opened a duplicate lesson — and must not
+    # appear in the body either.
+    body = lessons[0].render()
+    # Be strict: any occurrence in body is a bug.
+    assert "Конспект уроку №121" not in body, "running-head leaked into lesson body — page-furniture strip failed"
+    assert "Конспект уроку № 121" not in body  # also not the start marker
+
+
+def test_parse_book_strips_page_furniture(tmp_path: Path) -> None:
+    """Footers, Back-to-Contents, season headers, and bare page numbers
+    must NOT appear in lesson bodies."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+    for lesson in lessons:
+        blob = lesson.render()
+        assert "Inspiring resources for learning Ukrainian" not in blob
+        assert "Back to Contents" not in blob
+        assert "Ukrainian Lessons Podcast: Season" not in blob
+        # Bare page numbers (single line of digits) — none should land
+        for line in blob.split("\n"):
+            assert not line.strip().isdigit() or len(line.strip()) > 4
+
+
+def test_parse_book_strips_episode_running_head(tmp_path: Path) -> None:
+    """Season 1-3 running head ``Episode N — Title`` must be stripped."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+    body_l1 = lessons[0].render()
+    assert "Episode 1 — Informal Greetings" not in body_l1
+
+
+def test_parse_book_terminates_at_vidpovidi(tmp_path: Path) -> None:
+    """``Відповіді до вправ`` (Season 1-3 appendix) finalizes the last
+    lesson without absorbing the appendix."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+    last_blob = lessons[-1].render()
+    assert "Відповіді до вправ" not in last_blob
+    assert "Exercise 1 answers" not in last_blob
+    # But the real lesson 2 content stays:
+    assert "До́брий день" in last_blob
+
+
+def test_parse_book_terminates_at_key_phrases(tmp_path: Path) -> None:
+    """``Key Phrases N-NNN`` (Season 4 appendix) finalizes the last
+    lesson without absorbing the appendix."""
+    txt = _write_fixture(tmp_path, "s4.txt", FIXTURE_S4)
+    lessons = ulp.parse_book(txt)
+    last_blob = lessons[-1].render()
+    assert "Key Phrases 4-122" not in last_blob
+    assert "Bonus vocabulary follows" not in last_blob
+
+
+def test_parse_book_captures_title_after_marker(tmp_path: Path) -> None:
+    """The first non-furniture line after a lesson marker is the title,
+    and it does NOT also appear at the head of the rendered body."""
+    txt = _write_fixture(tmp_path, "s4.txt", FIXTURE_S4)
+    lessons = ulp.parse_book(txt)
+    l121 = lessons[0]
+    assert l121.title == "10 цікавих фактів про мене"
+    # The renderer prepends the title via the header; it should not also
+    # appear as a duplicate body line at offset 0.
+    rendered = l121.render()
+    header_first_line = rendered.split("\n", 1)[0]
+    assert header_first_line == "Lesson 121: 10 цікавих фактів про мене"
+    # And the next non-empty line is genuine body content, NOT the
+    # title repeated.
+    body_lines = [ln for ln in rendered.split("\n")[1:] if ln.strip()]
+    # First body line should not be the title.
+    assert body_lines[0] != l121.title
+
+
+def test_parse_book_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ulp.parse_book(tmp_path / "does-not-exist.txt")
+
+
+def test_parse_book_joins_multiline_title(tmp_path: Path) -> None:
+    """PDFs broke long lesson titles across two lines. The parser must
+    join them via single space and strip the trailing comma fragment
+    (mirrors real lesson #160 in ULP 4-00: ``Василь Стус,\nшістдесятники
+    та дисиденти``)."""
+    fixture = """                                       Конспект уроку № 160
+
+
+              Василь Стус,
+       шістдесятники та дисиденти
+                                         Link to audio: ukrainianlessons.com/episode160
+
+
+
+
+Це лекція про Василя Стуса.
+"""
+    txt = _write_fixture(tmp_path, "multiline.txt", fixture)
+    lessons = ulp.parse_book(txt)
+    assert len(lessons) == 1
+    assert lessons[0].title == "Василь Стус, шістдесятники та дисиденти", f"got title: {lessons[0].title!r}"
+    # Body should still contain real content, not the Link line.
+    body = lessons[0].render()
+    assert "Це лекція" in body
+    assert "Link to audio" not in body
+
+
+def test_parse_book_link_to_audio_acts_as_title_terminator(
+    tmp_path: Path,
+) -> None:
+    """The Link to audio line MUST NOT be promoted into the title or
+    the body."""
+    fixture = """                                            Lesson Notes № 1
+
+       Informal Greetings in Ukrainian
+                                         Link to audio: ukrainianlessons.com/episode1
+
+
+
+Привіт!
+"""
+    txt = _write_fixture(tmp_path, "link.txt", fixture)
+    lessons = ulp.parse_book(txt)
+    assert len(lessons) == 1
+    assert lessons[0].title == "Informal Greetings in Ukrainian"
+    body = lessons[0].render()
+    assert "Link to audio" not in body
+    assert "ukrainianlessons.com/episode1" not in body
+    assert "Привіт!" in body
+
+
+# ---------------------------------------------------------------------------
+# DB round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def _make_textbooks_db(path: Path) -> sqlite3.Connection:
+    """Minimal textbooks schema for round-trip tests (no FTS triggers
+    needed — we exercise the INSERT layer, not retrieval)."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+        );
+        """
+    )
+    return conn
+
+
+def test_ingest_lessons_round_trip(tmp_path: Path) -> None:
+    """End-to-end: parse → ingest → SELECT confirms rows are written
+    with correct metadata."""
+    txt = _write_fixture(tmp_path, "s4.txt", FIXTURE_S4)
+    lessons = ulp.parse_book(txt)
+    assert len(lessons) == 2
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    book = ulp.BookConfig(
+        slug="test",
+        source_file="test-ulp-fixture",
+        txt_filename="s4.txt",
+        season=4,
+    )
+    inserted, skipped = ulp.ingest_lessons(conn, book, lessons)
+    conn.commit()
+    assert inserted == 2
+    assert skipped == 0
+
+    rows = list(
+        conn.execute(
+            """SELECT chunk_id, title, source_file, author, char_count
+             FROM textbooks WHERE source_file = ? ORDER BY chunk_id""",
+            (book.source_file,),
+        )
+    )
+    assert len(rows) == 2
+    assert rows[0][0] == "test-ulp-fixture_l0121"
+    assert rows[1][0] == "test-ulp-fixture_l0122"
+    assert rows[0][1] == "Lesson 121: 10 цікавих фактів про мене"
+    assert rows[1][1] == "Lesson 122: Друга лекція"
+    assert all(r[2] == "test-ulp-fixture" for r in rows)
+    assert all(r[3] == ulp.AUTHOR for r in rows)
+    assert all(r[4] > 0 for r in rows)
+    conn.close()
+
+
+def test_ingest_lessons_idempotent(tmp_path: Path) -> None:
+    """Running the ingest twice on the same source should NOT duplicate
+    rows; the second call returns (0 inserted, N skipped)."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    book = ulp.BookConfig(
+        slug="t",
+        source_file="t-ulp",
+        txt_filename="s1.txt",
+        season=1,
+    )
+
+    first = ulp.ingest_lessons(conn, book, lessons)
+    conn.commit()
+    second = ulp.ingest_lessons(conn, book, lessons)
+    conn.commit()
+    assert first == (2, 0)
+    assert second == (0, 2)
+    total = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+    assert total == 2
+    conn.close()
+
+
+def test_ingest_lessons_force_overwrites(tmp_path: Path) -> None:
+    """With force=True, existing rows are deleted before re-insert."""
+    txt = _write_fixture(tmp_path, "s1.txt", FIXTURE_S1)
+    lessons = ulp.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    book = ulp.BookConfig(
+        slug="t",
+        source_file="t-ulp",
+        txt_filename="s1.txt",
+        season=1,
+    )
+    ulp.ingest_lessons(conn, book, lessons)
+    conn.commit()
+    inserted, skipped = ulp.ingest_lessons(conn, book, lessons, force=True)
+    conn.commit()
+    assert inserted == 2
+    assert skipped == 0
+    total = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+    assert total == 2
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Furniture-recognizer parametric tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # Page footer
+        ("                          Inspiring resources for learning Ukrainian — UkrainianLessons.com", True),
+        # Back to Contents
+        ("Back to Contents                                                                       1", True),
+        ("Back to Contents 5", True),
+        # Bare page numbers
+        ("5", True),
+        ("190", True),
+        ("                    7", True),
+        # Season header
+        ("                              Ukrainian Lessons Podcast: Season 1", True),
+        ("                                 Ukrainian Lessons Podcast: Season 4", True),
+        # Bare UkrainianLessons.com
+        ("                          UkrainianLessons.com", True),
+        # Season 4-6 running head (no space between № and number)
+        ("                                        Конспект уроку №121", True),
+        ("Конспект уроку №240", True),
+        # Season 1-3 running head
+        ("                                  Episode 1 — Informal Greetings in Ukrainian", True),
+        # NOT furniture
+        ("Я люблю українську мову.", False),
+        ("Анна: Приві́т!", False),
+        ("", False),  # blank line — handled separately by parser
+        # The WITH-space lesson-start markers must NOT be classified as
+        # furniture (they're handled by the parser's marker detection).
+        ("                                            Lesson Notes № 1", False),
+        ("                                       Конспект уроку № 121", False),
+    ],
+)
+def test_is_page_furniture(line: str, expected: bool) -> None:
+    assert ulp._is_page_furniture(line) is expected


### PR DESCRIPTION
## Summary

- New ingester `scripts/ingest/ulp_lesson_notes_ingest.py` parses the six
  "ULP N-00 Lesson Notes (all in one file)" PDFs (.txt extractions) into
  lesson-level rows in the `textbooks` table.
- 240 new chunks across six seasons (40 lessons each), ~5.7M chars of
  Anna Ohoiko's podcast notes covering A1-C1 grammar, dialogues, culture,
  and history.
- 33 unit tests covering parser correctness, idempotency, DB round-trip,
  and 13 page-furniture recognizer cases.

## Design highlights

- **Lesson START anchor disambiguation.** Seasons 1-3 use ``Lesson Notes № N``
  (English); seasons 4-6 use ``Конспект уроку № N`` (Ukrainian). Both require
  at least one space between № and the number — the load-bearing
  disambiguator from page running heads ``Конспект уроку №N`` (no space)
  that otherwise look identical. Verified by fixture + 80/80 real-data
  spot-check.
- **Multi-line title joining.** PDF extraction broke long titles across
  two lines (e.g. lesson #160 "Василь Стус,\nшістдесятники та дисиденти").
  Parser accumulates non-furniture lines between the start marker and
  the universal ``Link to audio:`` landmark, joining with single spaces.
- **End-of-content terminators.** ``Відповіді до вправ`` (seasons 1-3
  appendix) and ``Key Phrases N-NNN`` (season 4-6 summary) finalize the
  last lesson without absorbing the appendix.
- **Idempotent.** Per-chunk_id skip on existing rows; ``--force``
  deletes the source_file's rows before re-insert.

## DB evidence

Run by orchestrator inline against canonical ``data/sources.db`` per the
2026-05-14 determinism rule (BEFORE / AFTER / SAMPLE).

**BEFORE** (snapshot ``data/sources.db.bak-20260514-062125-pre-ulp-ingest``,
1.5GB):

```
$ sqlite3 data/sources.db "SELECT COUNT(*) FROM textbooks; SELECT COUNT(*) FROM textbooks_fts;"
24777
24777
$ sqlite3 data/sources.db "SELECT COUNT(*) FROM textbooks WHERE source_file LIKE 'ulp%'"
0
```

**AFTER** (``--all`` run, all 6 books):

```
$ sqlite3 data/sources.db "SELECT COUNT(*) FROM textbooks; SELECT COUNT(*) FROM textbooks_fts;"
25017
25017
$ sqlite3 data/sources.db "SELECT source_file, COUNT(*), SUM(char_count) FROM textbooks WHERE source_file LIKE 'ulp%' GROUP BY source_file ORDER BY source_file"
ulp-1-00-lesson-notes|40|443622
ulp-2-00-lesson-notes|40|636857
ulp-3-00-lesson-notes|40|895486
ulp-4-00-lesson-notes|40|1005138
ulp-5-00-lesson-notes|40|1260915
ulp-6-00-lesson-notes|40|1477129
```

FTS in sync: 25,017 == 25,017 ✓

**SAMPLE rows**:

```
ulp-1-00-lesson-notes_l0001  Lesson 1: Informal Greetings in Ukrainian (10,209 chars)
ulp-4-00-lesson-notes_l0160  Lesson 160: Василь Стус, шістдесятники та дисиденти (29,290 chars)
ulp-6-00-lesson-notes_l0240  Lesson 240: Квітка Цісик — голос України за океаном (38,733 chars)
```

**FTS retrieval probe** (validates the new rows are actually searchable):

```
$ sqlite3 data/sources.db "SELECT t.source_file, t.chunk_id, snippet(textbooks_fts, -1, '[', ']', '...', 5)
                           FROM textbooks_fts f JOIN textbooks t ON f.rowid=t.id
                           WHERE textbooks_fts MATCH 'Стус' AND t.source_file LIKE 'ulp%'"
ulp-2-00-lesson-notes  ulp-2-00-lesson-notes_l0074  ...Василь [Стус] та Іван Сверстюк...
ulp-4-00-lesson-notes  ulp-4-00-lesson-notes_l0160  ...Василь [Стус], шістдесятники та дисиденти...
```

**Idempotency check** (re-run ``--book 1-00`` on a populated DB):

```
BEFORE: 40 rows for 'ulp-1-00-lesson-notes' (table total: 25,017)
inserted: 0, skipped: 40
AFTER: 40 rows for 'ulp-1-00-lesson-notes' (table total: 25,017, delta +0)
```

## Test plan

- [x] 33 new tests pass: `pytest tests/test_ulp_lesson_notes_ingest.py` → 33 passed in 0.08s
- [x] Ruff clean: `ruff check` → All checks passed
- [x] Format clean: `ruff format --check` → 2 files already formatted
- [x] Full suite: 7453 passed, 75 pre-existing failures (test_morphological_validator,
      test_plan_immutability_hook, test_sum11_sovietization_scan, etc.)
      — all unrelated to ULP ingest; tracked separately (e.g. #1958)
- [x] Dry-run all 6 books → 240 lessons parsed, ranges 1..240 sequential
- [x] Inline ingest against canonical DB → BEFORE/AFTER/SAMPLE captured above
- [x] FTS in sync: textbooks (25,017) == textbooks_fts (25,017)
- [x] FTS retrieval probe: 'Стус' query hits ulp-* rows
- [x] Idempotency: re-run --book 1-00 → 0 inserted, 40 skipped

## Carry-over (separate sessions)

- **C2** Ohoiko 500+ Verbs ingester (different page-bounded parser shape;
  verb pages use ``№ NNN`` markers preceded by ``\x0c`` form-feed)
- **C4** Pohribnyi book OCR (52MB image-only PDF; tesseract 5.5.2 with
  uk lang model verified available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)