### PR TITLE
fix(corpus): backfill textbook_sections for 1240 orphan chunks (Ohoiko + 6 ULP)

### DIFF
--- a/scripts/ingest/_section_coverage.py
+++ b/scripts/ingest/_section_coverage.py
@@ -1,0 +1,168 @@
+"""Shared helper: link each ingested textbook chunk to a textbook_sections row.
+
+Context
+-------
+``scripts/wiki/sources_db.py`` exposes section-level retrieval via
+``_search_sections_fts5``. That function filters textbook chunks by
+``parent_section_id IS NOT NULL`` and joins to ``textbook_sections`` for
+section-grouped results. Any chunk with NULL parent_section_id is
+invisible to section-level retrieval — even if it lives in the base
+``textbooks`` table and is searchable via raw FTS.
+
+The school-textbook pipeline at ``scripts/wiki/extract_sections.py`` is
+designed for traditional textbook PDFs with markers like ``§ N``,
+``Сторінка N``, ``Розділ N``. It does not produce sections for
+lesson-style books (Anna Ohoiko's word lists, Ukrainian Lessons Podcast
+lesson notes) — those books simply don't have those markers.
+
+This helper provides the missing path: for any ingester whose source
+unit naturally maps 1:1 to a chunk AND a section (e.g. one ULP lesson →
+one chunk → one section), it writes the corresponding
+``textbook_sections`` row and sets ``textbooks.parent_section_id``.
+
+The helper is idempotent on the natural key (source_file, section_title)
+and writes a sentinel ``grade=0`` for non-school reference material
+(school books use grades 1-11; 0 is unused by them per audit
+2026-05-14).
+
+Usage
+-----
+    from scripts.ingest._section_coverage import LessonSection, link_lesson_sections
+
+    sections = [
+        LessonSection(
+            chunk_id="ulp-1-00-lesson-notes_l0001",
+            section_title="Lesson 1: Informal Greetings in Ukrainian",
+            section_number="1",
+            full_text="<lesson body>",
+        ),
+        ...
+    ]
+    inserted, linked = link_lesson_sections(
+        conn,
+        source_file="ulp-1-00-lesson-notes",
+        sections=sections,
+    )
+
+Returns ``(inserted_section_rows, linked_chunk_rows)`` for evidence
+reporting. Skipped sections/chunks are inferred as ``len(sections) -
+inserted``.
+
+The helper does NOT commit; the caller controls transactions.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+# Sentinel grade for non-school reference material (Anna Ohoiko books,
+# Ukrainian Lessons Podcast lesson notes, etc.). School-textbook
+# sections use grades 1-11; grade=0 is unused there per
+# 2026-05-14 audit of textbook_sections.grade distribution.
+NON_SCHOOL_GRADE = 0
+
+
+@dataclass(frozen=True)
+class LessonSection:
+    """One chunk = one section. Reference-material ingest unit."""
+
+    chunk_id: str
+    section_title: str
+    section_number: str  # textbook_sections.section_number is TEXT-typed
+    full_text: str
+
+
+def link_lesson_sections(
+    conn: sqlite3.Connection,
+    *,
+    source_file: str,
+    sections: list[LessonSection],
+    grade: int = NON_SCHOOL_GRADE,
+) -> tuple[int, int]:
+    """Write textbook_sections rows and link textbooks.parent_section_id.
+
+    Returns ``(inserted_section_rows, linked_chunk_rows)``.
+
+    Idempotent:
+    - The UNIQUE (source_file, section_title) constraint guards against
+      duplicate inserts. We use ``INSERT OR IGNORE`` and re-read the
+      section_id for each row after.
+    - ``UPDATE textbooks SET parent_section_id = ?`` is unconditional —
+      re-running on already-linked chunks is a no-op.
+
+    Caller commits or rolls back. The helper performs no transaction
+    management of its own.
+    """
+    cur = conn.cursor()
+    inserted_count = 0
+    linked_count = 0
+
+    for sec in sections:
+        # 1. INSERT OR IGNORE the section row (idempotent on unique key)
+        before = cur.execute(
+            "SELECT section_id FROM textbook_sections WHERE source_file = ? AND section_title = ?",
+            (source_file, sec.section_title),
+        ).fetchone()
+        if before is None:
+            cur.execute(
+                """INSERT INTO textbook_sections
+                       (source_file, grade, section_title, section_number,
+                        page_start, page_end, chunk_count, full_text)
+                   VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)""",
+                (
+                    source_file,
+                    grade,
+                    sec.section_title,
+                    sec.section_number,
+                    1,  # chunk_count: 1:1 mapping
+                    sec.full_text,
+                ),
+            )
+            section_id = cur.lastrowid
+            inserted_count += 1
+        else:
+            section_id = before[0]
+
+        # 2. Link the corresponding textbooks row to this section
+        result = cur.execute(
+            "UPDATE textbooks SET parent_section_id = ? WHERE chunk_id = ? AND source_file = ?",
+            (section_id, sec.chunk_id, source_file),
+        )
+        if result.rowcount > 0:
+            linked_count += 1
+
+    return inserted_count, linked_count
+
+
+def ensure_section_schema(conn: sqlite3.Connection) -> None:
+    """Create textbook_sections + parent_section_id column if missing.
+
+    Defensive — the schema is normally provisioned by
+    ``scripts/wiki/extract_sections.py``. This guards against running
+    this helper against a fresh DB where the school-textbook pipeline
+    has never run. No-op when the schema is already present.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS textbook_sections (
+               section_id INTEGER PRIMARY KEY,
+               source_file TEXT NOT NULL,
+               grade INTEGER NOT NULL,
+               section_title TEXT NOT NULL,
+               section_number TEXT,
+               page_start INTEGER,
+               page_end INTEGER,
+               chunk_count INTEGER NOT NULL,
+               full_text TEXT NOT NULL,
+               UNIQUE (source_file, section_title)
+           )"""
+    )
+    # textbooks.parent_section_id is added by the school-textbook
+    # pipeline. If it's missing, add it as a nullable INTEGER ref.
+    cols = {r[1] for r in cur.execute("PRAGMA table_info(textbooks)").fetchall()}
+    if "parent_section_id" not in cols:
+        cur.execute(
+            "ALTER TABLE textbooks ADD COLUMN parent_section_id INTEGER REFERENCES textbook_sections(section_id)"
+        )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_textbooks_parent ON textbooks (parent_section_id)")

--- a/scripts/ingest/backfill_lesson_sections.py
+++ b/scripts/ingest/backfill_lesson_sections.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""One-shot backfill: add textbook_sections rows for orphaned chunks.
+
+Context: audit on 2026-05-14 (after PR #1981 merged) found 1,240
+fully-orphaned chunks across 7 source_files:
+
+    anna-ohoiko-1000-words-2nd-ed: 1000 chunks
+    ulp-1-00-lesson-notes:          40 chunks
+    ulp-2-00-lesson-notes:          40 chunks
+    ulp-3-00-lesson-notes:          40 chunks
+    ulp-4-00-lesson-notes:          40 chunks
+    ulp-5-00-lesson-notes:          40 chunks
+    ulp-6-00-lesson-notes:          40 chunks
+
+All seven are reference-material ingests (Anna Ohoiko's word list +
+Ukrainian Lessons Podcast lesson notes) whose original ingesters wrote
+to ``textbooks`` only — never to ``textbook_sections``. Without sections,
+``_search_sections_fts5`` in scripts/wiki/sources_db.py skips these
+chunks entirely (it filters ``parent_section_id IS NOT NULL``).
+
+This script reads each orphaned chunk and synthesises a 1:1 section
+row, then links ``textbooks.parent_section_id``. Section title is
+reconstructed from the existing chunk's ``title`` column. Section
+number is derived from the chunk_id suffix (``_e0001`` → ``1`` for
+Ohoiko, ``_l0001`` → ``1`` for ULP).
+
+After both ingesters have been updated (same PR) to write sections
+natively, this backfill is a one-shot remediation. Re-running is
+idempotent (the helper uses ``INSERT OR IGNORE`` on the unique
+(source_file, section_title) key).
+
+Usage:
+    .venv/bin/python -m scripts.ingest.backfill_lesson_sections
+    .venv/bin/python -m scripts.ingest.backfill_lesson_sections --dry-run
+
+Determinism evidence (BEFORE / AFTER / SAMPLE) printed to stdout per
+the 2026-05-14 ingest rule. The orchestrator captures this in the PR
+body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+from scripts.ingest._section_coverage import (
+    LessonSection,
+    ensure_section_schema,
+    link_lesson_sections,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+
+# Source_files we expect to backfill, with how to derive section_number
+# from the chunk_id suffix. The suffix format is the chunk_id's tail
+# after the last ``_`` (e.g. ``e0001`` or ``l0042``); we strip the
+# alpha prefix and parse the digits.
+TARGETED_SOURCE_FILES = (
+    "anna-ohoiko-1000-words-2nd-ed",
+    "ulp-1-00-lesson-notes",
+    "ulp-2-00-lesson-notes",
+    "ulp-3-00-lesson-notes",
+    "ulp-4-00-lesson-notes",
+    "ulp-5-00-lesson-notes",
+    "ulp-6-00-lesson-notes",
+)
+
+# chunk_id format: ``<source_file>_<prefix><digits>`` where prefix is
+# one of ``e`` (entry) for Ohoiko and ``l`` (lesson) for ULP.
+_CHUNK_SUFFIX_RE = re.compile(r"_([elv])(\d+)$")
+
+
+def _section_title_for(source_file: str, chunk_title: str, number: int) -> str:
+    """Match the natural title format that the live ingesters now write.
+
+    - Ohoiko 1000-words: ``Entry N: <headword>``
+    - ULP lesson notes:  ``Lesson N: <Title>`` (already in chunk_title)
+    """
+    if source_file.startswith("anna-ohoiko-"):
+        return f"Entry {number}: {chunk_title}"
+    # ULP chunk_title is already ``Lesson N: <title>`` from the ingester.
+    return chunk_title
+
+
+def backfill_source_file(
+    conn: sqlite3.Connection,
+    source_file: str,
+    *,
+    dry_run: bool,
+) -> tuple[int, int, int]:
+    """Backfill orphans for a single source_file.
+
+    Returns ``(n_orphans_before, n_sections_inserted, n_chunks_linked)``.
+    Dry-run skips the writes.
+    """
+    cur = conn.cursor()
+    orphans = cur.execute(
+        """SELECT id, chunk_id, title, text
+             FROM textbooks
+            WHERE source_file = ? AND parent_section_id IS NULL
+            ORDER BY chunk_id""",
+        (source_file,),
+    ).fetchall()
+    n_orphans = len(orphans)
+    if n_orphans == 0:
+        return 0, 0, 0
+
+    sections: list[LessonSection] = []
+    for _, chunk_id, chunk_title, chunk_text in orphans:
+        m = _CHUNK_SUFFIX_RE.search(chunk_id)
+        if not m:
+            print(
+                f"   ⚠️  skipping {chunk_id!r}: cannot derive section_number "
+                f"(suffix doesn't match {_CHUNK_SUFFIX_RE.pattern!r})",
+                file=sys.stderr,
+            )
+            continue
+        number = int(m.group(2))
+        sections.append(
+            LessonSection(
+                chunk_id=chunk_id,
+                section_title=_section_title_for(source_file, chunk_title, number),
+                section_number=str(number),
+                full_text=chunk_text,
+            )
+        )
+
+    if dry_run:
+        return n_orphans, 0, 0
+
+    inserted, linked = link_lesson_sections(
+        conn,
+        source_file=source_file,
+        sections=sections,
+    )
+    return n_orphans, inserted, linked
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill textbook_sections rows for orphaned lesson/entry chunks",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Override target DB path (testing only).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would happen, do not write.",
+    )
+    parser.add_argument(
+        "--source-file",
+        action="append",
+        default=None,
+        help=(
+            "Limit backfill to this source_file. Repeat to target several. Defaults to all 7 known orphan source_files."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    conn = sqlite3.connect(str(args.db))
+    try:
+        ensure_section_schema(conn)
+
+        targets = tuple(args.source_file) if args.source_file else TARGETED_SOURCE_FILES
+
+        # BEFORE evidence
+        print(f"🗃️  Target DB: {args.db}")
+        total_orphans_before = conn.execute(
+            f"""SELECT COUNT(*) FROM textbooks
+                 WHERE source_file IN ({",".join("?" * len(targets))})
+                   AND parent_section_id IS NULL""",
+            targets,
+        ).fetchone()[0]
+        total_sections_before = conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+        print(
+            f"\nBEFORE: {total_orphans_before:,} orphan chunks across "
+            f"{len(targets)} source_files; total textbook_sections rows: "
+            f"{total_sections_before:,}"
+        )
+
+        # Per-source backfill
+        total_inserted = 0
+        total_linked = 0
+        for sf in targets:
+            print(f"\n📚 {sf}")
+            n_orphan, inserted, linked = backfill_source_file(conn, sf, dry_run=args.dry_run)
+            print(f"   orphans found: {n_orphan}")
+            print(f"   sections inserted: {inserted}")
+            print(f"   chunks linked: {linked}")
+            total_inserted += inserted
+            total_linked += linked
+
+        if not args.dry_run:
+            conn.commit()
+
+        # AFTER evidence
+        total_orphans_after = conn.execute(
+            f"""SELECT COUNT(*) FROM textbooks
+                 WHERE source_file IN ({",".join("?" * len(targets))})
+                   AND parent_section_id IS NULL""",
+            targets,
+        ).fetchone()[0]
+        total_sections_after = conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+        print(
+            f"\nAFTER: {total_orphans_after:,} orphan chunks remain across "
+            f"{len(targets)} source_files; total textbook_sections rows: "
+            f"{total_sections_after:,} "
+            f"(delta +{total_sections_after - total_sections_before})"
+        )
+
+        # SAMPLE rows for the largest source
+        if not args.dry_run and total_inserted > 0:
+            print("\n--- SAMPLE backfilled sections ---")
+            for sf in targets:
+                row = conn.execute(
+                    """SELECT s.section_id, s.section_title, s.section_number, s.grade,
+                              t.chunk_id, t.parent_section_id
+                         FROM textbook_sections s
+                         JOIN textbooks t ON t.parent_section_id = s.section_id
+                        WHERE s.source_file = ?
+                        ORDER BY CAST(s.section_number AS INTEGER) LIMIT 1""",
+                    (sf,),
+                ).fetchone()
+                if row:
+                    print(
+                        f"   {sf}: section_id={row[0]} title={row[1]!r} "
+                        f"num={row[2]!r} grade={row[3]} chunk={row[4]} "
+                        f"parent={row[5]}"
+                    )
+
+        return 0 if total_orphans_after == 0 or args.dry_run else 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingest/ohoiko_books_ingest.py
+++ b/scripts/ingest/ohoiko_books_ingest.py
@@ -35,6 +35,7 @@ Reference:
 - ``docs/references/private/1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt``
 - ``docs/references/private/500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt``
 """
+
 from __future__ import annotations
 
 import argparse
@@ -50,9 +51,7 @@ REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
 
 # Page-furniture patterns that should be stripped from entry bodies.
 # These match Ohoiko's PDF-extracted text exactly; do not over-generalise.
-_PAGE_FOOTER_RE = re.compile(
-    r"^\s*Inspiring resources for learning Ukrainian — UkrainianLessons\.com\s+\d+\s*$"
-)
+_PAGE_FOOTER_RE = re.compile(r"^\s*Inspiring resources for learning Ukrainian — UkrainianLessons\.com\s+\d+\s*$")
 _BARE_PAGE_NUMBER_RE = re.compile(r"^\s*\d+\s*$")
 # Page header is a single right-aligned word (the running headword). It
 # follows the page footer line and precedes the next entry. We detect it
@@ -84,11 +83,11 @@ _MAX_BODY_LINES = 25
 # accumulating. Matched as a substring on the stripped body line so we
 # tolerate leading spacing variation.
 _SECTION_TERMINATORS = (
-    "Кросворд",          # "Crossword №N" section headers (post-1000)
-    "Хай щастить",        # Author's closing line before back-matter
-    "Find out more at",   # Promotional back-matter URLs
+    "Кросворд",  # "Crossword №N" section headers (post-1000)
+    "Хай щастить",  # Author's closing line before back-matter
+    "Find out more at",  # Promotional back-matter URLs
     "Most Useful Ukrainian Words",  # Repeating header in back-matter pages
-    "My New Ukrainian Words",       # Blank-journal section header
+    "My New Ukrainian Words",  # Blank-journal section header
 )
 
 
@@ -289,12 +288,27 @@ def ingest_entries(
     *,
     force: bool = False,
 ) -> tuple[int, int]:
-    """Insert each entry as one row in textbooks. Returns (inserted, skipped).
+    """Insert each entry as one row in textbooks AND link a 1:1
+    ``textbook_sections`` row. Returns (inserted, skipped).
 
     Idempotent: skips chunk_ids that already exist unless ``force=True``,
     in which case existing rows are DELETED before re-insert (the FTS5
-    AFTER-INSERT trigger handles the index).
+    AFTER-INSERT trigger handles the FTS index).
+
+    Section coverage (added 2026-05-14 per #1981 follow-up): each entry
+    also produces a ``textbook_sections`` row so the chunk is visible to
+    ``_search_sections_fts5`` in scripts/wiki/sources_db.py. Without
+    this, the entry's chunk is FTS-searchable but invisible to
+    section-level retrieval. See ``_section_coverage.py`` for details.
     """
+    from scripts.ingest._section_coverage import (
+        LessonSection,
+        ensure_section_schema,
+        link_lesson_sections,
+    )
+
+    ensure_section_schema(conn)
+
     cur = conn.cursor()
     existing_ids: set[str] = set()
     if not force:
@@ -305,6 +319,11 @@ def ingest_entries(
         existing_ids = {r[0] for r in rows}
 
     if force:
+        # Reset both textbooks rows and their section parents.
+        cur.execute(
+            "DELETE FROM textbook_sections WHERE source_file = ?",
+            (book.source_file,),
+        )
         cur.execute(
             "DELETE FROM textbooks WHERE source_file = ?",
             (book.source_file,),
@@ -313,21 +332,36 @@ def ingest_entries(
     inserted = 0
     skipped = 0
     batch: list[tuple] = []
+    new_sections: list[LessonSection] = []
     for e in entries:
         chunk_id = f"{book.source_file}_e{e.number:04d}"
         if chunk_id in existing_ids:
             skipped += 1
             continue
         text = e.full_text()
-        batch.append((
-            chunk_id,
-            e.headword,
-            text,
-            book.source_file,
-            book.grade,
-            book.author,
-            len(text),
-        ))
+        batch.append(
+            (
+                chunk_id,
+                e.headword,
+                text,
+                book.source_file,
+                book.grade,
+                book.author,
+                len(text),
+            )
+        )
+        # Section title format: ``Entry N: <headword>`` — N
+        # disambiguates collisions (e.g. ``мати`` as both "mother" and
+        # "to have" could share a headword in some books). The unique
+        # constraint on (source_file, section_title) keeps this safe.
+        new_sections.append(
+            LessonSection(
+                chunk_id=chunk_id,
+                section_title=f"Entry {e.number}: {e.headword}",
+                section_number=str(e.number),
+                full_text=text,
+            )
+        )
         inserted += 1
 
     if batch:
@@ -336,6 +370,11 @@ def ingest_entries(
                   (chunk_id, title, text, source_file, grade, author, char_count)
                VALUES (?, ?, ?, ?, ?, ?, ?)""",
             batch,
+        )
+        link_lesson_sections(
+            conn,
+            source_file=book.source_file,
+            sections=new_sections,
         )
 
     return inserted, skipped
@@ -399,8 +438,7 @@ def main(argv: list[str] | None = None) -> int:
             (book.source_file,),
         ).fetchone()[0]
         total_before = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
-        print(f"   BEFORE: {before} rows for {book.source_file!r} "
-              f"(table total: {total_before:,})")
+        print(f"   BEFORE: {before} rows for {book.source_file!r} (table total: {total_before:,})")
 
         inserted, skipped = ingest_entries(conn, book, entries, force=args.force)
         conn.commit()
@@ -411,8 +449,10 @@ def main(argv: list[str] | None = None) -> int:
         ).fetchone()[0]
         total_after = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
         print(f"   inserted: {inserted}, skipped: {skipped}")
-        print(f"   AFTER: {after} rows for {book.source_file!r} "
-              f"(table total: {total_after:,}, delta +{total_after - total_before})")
+        print(
+            f"   AFTER: {after} rows for {book.source_file!r} "
+            f"(table total: {total_after:,}, delta +{total_after - total_before})"
+        )
 
         # Sample row evidence
         sample = conn.execute(

--- a/scripts/ingest/ulp_lesson_notes_ingest.py
+++ b/scripts/ingest/ulp_lesson_notes_ingest.py
@@ -385,6 +385,19 @@ def ingest_lessons(
     in which case existing rows are DELETED for the source_file before
     re-insert.
     """
+    # Section coverage (added 2026-05-14 per #1981 follow-up): each
+    # lesson also produces a ``textbook_sections`` row so the chunk is
+    # visible to ``_search_sections_fts5`` in scripts/wiki/sources_db.py.
+    # Without this, the lesson's chunk is FTS-searchable but invisible
+    # to section-level retrieval. See ``_section_coverage.py``.
+    from scripts.ingest._section_coverage import (
+        LessonSection,
+        ensure_section_schema,
+        link_lesson_sections,
+    )
+
+    ensure_section_schema(conn)
+
     cur = conn.cursor()
     existing_ids: set[str] = set()
     if not force:
@@ -395,6 +408,11 @@ def ingest_lessons(
         existing_ids = {r[0] for r in rows}
 
     if force:
+        # Reset both textbooks rows and their section parents.
+        cur.execute(
+            "DELETE FROM textbook_sections WHERE source_file = ?",
+            (book.source_file,),
+        )
         cur.execute(
             "DELETE FROM textbooks WHERE source_file = ?",
             (book.source_file,),
@@ -403,6 +421,7 @@ def ingest_lessons(
     inserted = 0
     skipped = 0
     batch: list[tuple] = []
+    new_sections: list[LessonSection] = []
     for lesson in lessons:
         chunk_id = f"{book.source_file}_l{lesson.number:04d}"
         if chunk_id in existing_ids:
@@ -416,9 +435,17 @@ def ingest_lessons(
                 title,
                 text,
                 book.source_file,
-                "",  # grade
+                "",  # grade (textbooks.grade is TEXT; sections use sentinel 0)
                 AUTHOR,
                 len(text),
+            )
+        )
+        new_sections.append(
+            LessonSection(
+                chunk_id=chunk_id,
+                section_title=title,
+                section_number=str(lesson.number),
+                full_text=text,
             )
         )
         inserted += 1
@@ -429,6 +456,11 @@ def ingest_lessons(
                   (chunk_id, title, text, source_file, grade, author, char_count)
                VALUES (?, ?, ?, ?, ?, ?, ?)""",
             batch,
+        )
+        link_lesson_sections(
+            conn,
+            source_file=book.source_file,
+            sections=new_sections,
         )
 
     return inserted, skipped

--- a/tests/test_section_coverage.py
+++ b/tests/test_section_coverage.py
@@ -1,0 +1,435 @@
+"""Tests for the textbook_sections coverage helper + ingester integration.
+
+Covers:
+- ``ensure_section_schema`` creates the table + parent_section_id column on
+  a fresh DB (idempotent).
+- ``link_lesson_sections`` writes section rows + links parent_section_id.
+- Idempotency: re-running the helper does not duplicate sections.
+- Ohoiko + ULP ingesters now produce 0 orphan chunks (regression for the
+  2026-05-14 audit gap).
+- Backfill script converts existing orphans into linked chunks.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from scripts.ingest import ohoiko_books_ingest as obi
+from scripts.ingest import ulp_lesson_notes_ingest as ulp
+from scripts.ingest._section_coverage import (
+    NON_SCHOOL_GRADE,
+    LessonSection,
+    ensure_section_schema,
+    link_lesson_sections,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal schema helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_textbooks_db(path: Path, *, with_parent_col: bool = False) -> sqlite3.Connection:
+    """Minimal textbooks-only schema (no FTS triggers; we test the
+    INSERT layer)."""
+    conn = sqlite3.connect(str(path))
+    parent_col_sql = (
+        ",\n        parent_section_id INTEGER REFERENCES textbook_sections(section_id)" if with_parent_col else ""
+    )
+    conn.executescript(
+        f"""
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+            {parent_col_sql}
+        );
+        """
+    )
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_section_schema_creates_table_and_column(tmp_path: Path) -> None:
+    """On a fresh DB with only ``textbooks``, the helper provisions both
+    ``textbook_sections`` AND ``textbooks.parent_section_id``."""
+    db = _make_textbooks_db(tmp_path / "fresh.db")
+    ensure_section_schema(db)
+
+    # textbook_sections exists with the right columns
+    sect_cols = {r[1] for r in db.execute("PRAGMA table_info(textbook_sections)").fetchall()}
+    assert "section_id" in sect_cols
+    assert "source_file" in sect_cols
+    assert "grade" in sect_cols
+    assert "section_title" in sect_cols
+    assert "full_text" in sect_cols
+
+    # textbooks.parent_section_id exists
+    tb_cols = {r[1] for r in db.execute("PRAGMA table_info(textbooks)").fetchall()}
+    assert "parent_section_id" in tb_cols
+
+    db.close()
+
+
+def test_ensure_section_schema_idempotent(tmp_path: Path) -> None:
+    """Running ``ensure_section_schema`` twice is a no-op the second
+    time."""
+    db = _make_textbooks_db(tmp_path / "x.db")
+    ensure_section_schema(db)
+    n_sect = db.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+    ensure_section_schema(db)
+    assert db.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0] == n_sect
+    db.close()
+
+
+def _setup_db_with_chunks(tmp_path: Path) -> sqlite3.Connection:
+    db = _make_textbooks_db(tmp_path / "x.db", with_parent_col=True)
+    ensure_section_schema(db)
+    # Manually insert two textbook chunks (no parent_section_id yet — orphans)
+    db.execute(
+        """INSERT INTO textbooks (chunk_id, title, text, source_file, char_count)
+           VALUES ('test_l0001', 'Lesson 1: Hello', 'Hello world.', 'test', 12),
+                  ('test_l0002', 'Lesson 2: Bye', 'Goodbye.', 'test', 8)"""
+    )
+    return db
+
+
+def test_link_lesson_sections_writes_rows_and_links(tmp_path: Path) -> None:
+    db = _setup_db_with_chunks(tmp_path)
+    sections = [
+        LessonSection(
+            chunk_id="test_l0001",
+            section_title="Lesson 1: Hello",
+            section_number="1",
+            full_text="Hello world.",
+        ),
+        LessonSection(
+            chunk_id="test_l0002",
+            section_title="Lesson 2: Bye",
+            section_number="2",
+            full_text="Goodbye.",
+        ),
+    ]
+    inserted, linked = link_lesson_sections(db, source_file="test", sections=sections)
+    db.commit()
+
+    assert inserted == 2
+    assert linked == 2
+    # Both chunks now have parent_section_id
+    rows = list(
+        db.execute("SELECT chunk_id, parent_section_id FROM textbooks WHERE source_file='test' ORDER BY chunk_id")
+    )
+    assert all(r[1] is not None for r in rows), f"orphans remain: {rows}"
+    # section_number is text-typed
+    sec_rows = list(
+        db.execute(
+            "SELECT section_number, section_title, grade, chunk_count FROM textbook_sections "
+            "WHERE source_file='test' ORDER BY section_number"
+        )
+    )
+    assert sec_rows[0] == ("1", "Lesson 1: Hello", NON_SCHOOL_GRADE, 1)
+    assert sec_rows[1] == ("2", "Lesson 2: Bye", NON_SCHOOL_GRADE, 1)
+    db.close()
+
+
+def test_link_lesson_sections_idempotent_on_unique_key(tmp_path: Path) -> None:
+    """Re-running with the same (source_file, section_title) pairs must
+    not duplicate section rows."""
+    db = _setup_db_with_chunks(tmp_path)
+    sections = [
+        LessonSection(
+            chunk_id="test_l0001",
+            section_title="Lesson 1: Hello",
+            section_number="1",
+            full_text="Hello world.",
+        ),
+    ]
+    link_lesson_sections(db, source_file="test", sections=sections)
+    db.commit()
+    link_lesson_sections(db, source_file="test", sections=sections)
+    db.commit()
+    n_sect = db.execute("SELECT COUNT(*) FROM textbook_sections WHERE source_file='test'").fetchone()[0]
+    assert n_sect == 1, f"expected 1 section, got {n_sect}"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# Ingester integration tests (regression for the 2026-05-14 audit gap)
+# ---------------------------------------------------------------------------
+
+
+OHOIKO_FIXTURE = """1.    а                                               and, but
+      Я люблю́ готува́ти, а ти?                       I like to cook, and you (informal)?
+2.    або́ = чи                                       or
+      За́раз або́ ніко́ли.                            Now or never.
+"""
+
+
+ULP_FIXTURE = """                                            Lesson Notes № 1
+
+       Greetings
+                                         Link to audio: ukrainianlessons.com/episode1
+
+Привіт!
+"""
+
+
+def _make_full_db(path: Path) -> sqlite3.Connection:
+    """DB with textbooks + textbook_sections schema (full schema match
+    for the ingesters which now write to both tables)."""
+    conn = _make_textbooks_db(path, with_parent_col=True)
+    ensure_section_schema(conn)
+    return conn
+
+
+def test_ohoiko_ingest_produces_zero_orphans(tmp_path: Path) -> None:
+    """Regression: after the 2026-05-14 section-coverage fix, Ohoiko
+    ingest must produce 0 orphan chunks."""
+    fixture_path = tmp_path / "ohoiko-fixture.txt"
+    fixture_path.write_text(OHOIKO_FIXTURE, encoding="utf-8")
+    entries = obi.parse_book(fixture_path, max_entry_number=10)
+    assert len(entries) == 2
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    book = obi.BookConfig(
+        slug="test",
+        source_file="test-ohoiko",
+        txt_filename="ohoiko-fixture.txt",
+        author="Anna Ohoiko",
+        grade="",
+        max_entry_number=10,
+    )
+    obi.ingest_entries(conn, book, entries)
+    conn.commit()
+
+    n_orphan = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=? AND parent_section_id IS NULL",
+        (book.source_file,),
+    ).fetchone()[0]
+    assert n_orphan == 0, f"orphans remain: {n_orphan}"
+
+    n_sec = conn.execute(
+        "SELECT COUNT(*) FROM textbook_sections WHERE source_file=?",
+        (book.source_file,),
+    ).fetchone()[0]
+    assert n_sec == 2  # 1:1 with chunks
+
+    # Section title format check
+    titles = sorted(
+        r[0]
+        for r in conn.execute(
+            "SELECT section_title FROM textbook_sections WHERE source_file=?",
+            (book.source_file,),
+        )
+    )
+    assert titles[0].startswith("Entry 1: ")
+    assert titles[1].startswith("Entry 2: ")
+    conn.close()
+
+
+def test_ulp_ingest_produces_zero_orphans(tmp_path: Path) -> None:
+    """Regression: after the 2026-05-14 section-coverage fix, ULP
+    ingest must produce 0 orphan chunks."""
+    fixture_path = tmp_path / "ulp-fixture.txt"
+    fixture_path.write_text(ULP_FIXTURE, encoding="utf-8")
+    lessons = ulp.parse_book(fixture_path)
+    assert len(lessons) == 1
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    book = ulp.BookConfig(
+        slug="test",
+        source_file="test-ulp",
+        txt_filename="ulp-fixture.txt",
+        season=1,
+    )
+    ulp.ingest_lessons(conn, book, lessons)
+    conn.commit()
+
+    n_orphan = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=? AND parent_section_id IS NULL",
+        (book.source_file,),
+    ).fetchone()[0]
+    assert n_orphan == 0, f"orphans remain: {n_orphan}"
+
+    # Section title matches the ULP convention.
+    title = conn.execute(
+        "SELECT section_title FROM textbook_sections WHERE source_file=?",
+        (book.source_file,),
+    ).fetchone()[0]
+    assert title == "Lesson 1: Greetings"
+    conn.close()
+
+
+def test_ohoiko_force_rerun_keeps_zero_orphans(tmp_path: Path) -> None:
+    """When --force is used, the ingester DELETEs and re-creates
+    everything (textbooks + textbook_sections). Result must still be
+    0 orphans, no leftover sections."""
+    fixture_path = tmp_path / "f.txt"
+    fixture_path.write_text(OHOIKO_FIXTURE, encoding="utf-8")
+    entries = obi.parse_book(fixture_path, max_entry_number=10)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    book = obi.BookConfig(
+        slug="t",
+        source_file="t-ohoiko",
+        txt_filename="f.txt",
+        author="A",
+        grade="",
+        max_entry_number=10,
+    )
+    obi.ingest_entries(conn, book, entries)
+    conn.commit()
+    # Re-run with force
+    obi.ingest_entries(conn, book, entries, force=True)
+    conn.commit()
+
+    n_chunks = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=?",
+        (book.source_file,),
+    ).fetchone()[0]
+    n_sec = conn.execute(
+        "SELECT COUNT(*) FROM textbook_sections WHERE source_file=?",
+        (book.source_file,),
+    ).fetchone()[0]
+    n_orphan = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file=? AND parent_section_id IS NULL",
+        (book.source_file,),
+    ).fetchone()[0]
+    assert n_chunks == 2
+    assert n_sec == 2
+    assert n_orphan == 0
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Backfill script tests
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_converts_existing_orphans(tmp_path: Path) -> None:
+    """Simulate the pre-fix state: chunks present, no sections, all
+    orphans. Run the backfill → 0 orphans, 1:1 sections."""
+    from scripts.ingest import backfill_lesson_sections as bf
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    # Pre-fix state: Ohoiko chunks exist but are unlinked
+    conn.executemany(
+        """INSERT INTO textbooks (chunk_id, title, text, source_file, grade, author, char_count)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            (
+                "anna-ohoiko-1000-words-2nd-ed_e0001",
+                "а",
+                "а — and",
+                "anna-ohoiko-1000-words-2nd-ed",
+                "",
+                "Anna Ohoiko",
+                8,
+            ),
+            (
+                "anna-ohoiko-1000-words-2nd-ed_e0002",
+                "або́",
+                "або — or",
+                "anna-ohoiko-1000-words-2nd-ed",
+                "",
+                "Anna Ohoiko",
+                7,
+            ),
+            (
+                "ulp-1-00-lesson-notes_l0001",
+                "Lesson 1: Greetings",
+                "Hi!",
+                "ulp-1-00-lesson-notes",
+                "",
+                "Ukrainian Lessons Podcast",
+                3,
+            ),
+        ],
+    )
+    conn.commit()
+
+    # All 3 are orphans
+    n_orphan_before = conn.execute("SELECT COUNT(*) FROM textbooks WHERE parent_section_id IS NULL").fetchone()[0]
+    assert n_orphan_before == 3
+
+    # Run backfill for the two source_files we know about
+    bf.backfill_source_file(conn, "anna-ohoiko-1000-words-2nd-ed", dry_run=False)
+    bf.backfill_source_file(conn, "ulp-1-00-lesson-notes", dry_run=False)
+    conn.commit()
+
+    n_orphan_after = conn.execute("SELECT COUNT(*) FROM textbooks WHERE parent_section_id IS NULL").fetchone()[0]
+    assert n_orphan_after == 0, f"orphans remain: {n_orphan_after}"
+
+    # Verify the section titles use the right format per source
+    titles_oh = sorted(
+        r[0]
+        for r in conn.execute(
+            "SELECT section_title FROM textbook_sections WHERE source_file='anna-ohoiko-1000-words-2nd-ed'"
+        )
+    )
+    assert titles_oh == ["Entry 1: а", "Entry 2: або́"]
+    titles_ulp = sorted(
+        r[0]
+        for r in conn.execute("SELECT section_title FROM textbook_sections WHERE source_file='ulp-1-00-lesson-notes'")
+    )
+    assert titles_ulp == ["Lesson 1: Greetings"]
+    conn.close()
+
+
+def test_backfill_dry_run_makes_no_changes(tmp_path: Path) -> None:
+    """``--dry-run`` reports orphans but writes nothing."""
+    from scripts.ingest import backfill_lesson_sections as bf
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    conn.execute(
+        """INSERT INTO textbooks (chunk_id, title, text, source_file, char_count)
+           VALUES ('ulp-1-00-lesson-notes_l0001', 'Lesson 1: X', 'body', 'ulp-1-00-lesson-notes', 4)"""
+    )
+    conn.commit()
+
+    n_orphan, inserted, linked = bf.backfill_source_file(conn, "ulp-1-00-lesson-notes", dry_run=True)
+    assert n_orphan == 1
+    assert inserted == 0
+    assert linked == 0
+    # DB unchanged
+    n_sec = conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+    assert n_sec == 0
+    conn.close()
+
+
+def test_backfill_idempotent(tmp_path: Path) -> None:
+    """Running backfill twice must not duplicate sections."""
+    from scripts.ingest import backfill_lesson_sections as bf
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    conn.execute(
+        """INSERT INTO textbooks (chunk_id, title, text, source_file, char_count)
+           VALUES ('anna-ohoiko-1000-words-2nd-ed_e0001', 'а', 'а — and', 'anna-ohoiko-1000-words-2nd-ed', 8)"""
+    )
+    conn.commit()
+
+    bf.backfill_source_file(conn, "anna-ohoiko-1000-words-2nd-ed", dry_run=False)
+    conn.commit()
+    bf.backfill_source_file(conn, "anna-ohoiko-1000-words-2nd-ed", dry_run=False)
+    conn.commit()
+
+    n_sec = conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+    n_orphan = conn.execute("SELECT COUNT(*) FROM textbooks WHERE parent_section_id IS NULL").fetchone()[0]
+    assert n_sec == 1
+    assert n_orphan == 0
+    conn.close()


### PR DESCRIPTION
## Summary

Audit on 2026-05-14 (after PR #1981 merged) found **1,240 fully-orphaned
chunks** across 7 source_files — chunks present in `textbooks` + FTS but
invisible to section-level retrieval (`_search_sections_fts5` in
`scripts/wiki/sources_db.py` filters `parent_section_id IS NOT NULL`).
User-flagged 2026-05-14: *"make sure after everything ingested that all
our content is indexed, i don't know why we missed indexes on our
already ingested contents"*.

## Root cause

The school-textbook section-extraction pipeline at
`scripts/wiki/extract_sections.py` is designed for traditional textbook
PDFs with markers like `§ N`, `Сторінка N`, `Розділ N`. It cannot
produce sections for lesson-style books (Anna Ohoiko's word lists,
Ukrainian Lessons Podcast lesson notes). Both PR #1977 (Ohoiko
1000-words) and PR #1981 (ULP) wrote only to `textbooks`, leaving their
chunks unlinked from `textbook_sections`.

## Fix

- **NEW** `scripts/ingest/_section_coverage.py` — shared helper. One
  chunk = one section; idempotent on `(source_file, section_title)`;
  `grade=0` sentinel for non-school reference material; defensive
  `ensure_section_schema()`.
- `scripts/ingest/ohoiko_books_ingest.py` updated — writes sections
  natively. Title format: `Entry N: <headword>`.
- `scripts/ingest/ulp_lesson_notes_ingest.py` updated — writes sections
  natively. Title format: `Lesson N: <title>`.
- **NEW** `scripts/ingest/backfill_lesson_sections.py` — one-shot
  remediation for the existing 1240 orphans.
- 10 unit tests in `tests/test_section_coverage.py`.

## Canonical DB backfill evidence

Inline-orchestrator backfill run against `data/sources.db`:

```
BEFORE: 1,240 orphan chunks across 7 source_files; textbook_sections rows: 5,071

📚 anna-ohoiko-1000-words-2nd-ed   1000 orphans → 1000 inserted, 1000 linked
📚 ulp-1-00-lesson-notes              40 orphans →   40 inserted,   40 linked
📚 ulp-2-00-lesson-notes              40 orphans →   40 inserted,   40 linked
📚 ulp-3-00-lesson-notes              40 orphans →   40 inserted,   40 linked
📚 ulp-4-00-lesson-notes              40 orphans →   40 inserted,   40 linked
📚 ulp-5-00-lesson-notes              40 orphans →   40 inserted,   40 linked
📚 ulp-6-00-lesson-notes              40 orphans →   40 inserted,   40 linked

AFTER: 0 orphan chunks across the 7 source_files; textbook_sections rows: 6,311 (+1,240)
```

### SAMPLE backfilled sections

```
section_id=5277  Entry 1: а                                  anna-ohoiko-1000-words-2nd-ed
section_id=6277  Lesson 1: Informal Greetings in Ukrainian   ulp-1-00-lesson-notes
section_id=6317  Lesson 41: Повторення: Сезон 1 ...           ulp-2-00-lesson-notes
section_id=6357  Lesson 81: Знайомство в літаку ...           ulp-3-00-lesson-notes
section_id=6397  Lesson 121: 10 цікавих фактів про мене      ulp-4-00-lesson-notes
section_id=6437  Lesson 161: Як у мене справи ...             ulp-5-00-lesson-notes
section_id=6477  Lesson 201: Про шостий сезон подкасту       ulp-6-00-lesson-notes
```

### Section-level retrieval probe (was returning 0 hits for these source_files; now hits)

```sql
SELECT s.section_id, s.source_file, s.section_title
  FROM textbook_sections s
  JOIN textbooks t ON t.parent_section_id = s.section_id
  JOIN textbooks_fts f ON f.rowid = t.id
 WHERE textbooks_fts MATCH 'Стус' AND s.source_file LIKE 'ulp%';

→ section_id=6436 ulp-4-00-lesson-notes: Lesson 160: Василь Стус, шістдесятники та дисиденти
→ section_id=6503 ulp-6-00-lesson-notes: Lesson 227: Українська поезія. Василь Симоненко...
→ section_id=6504 ulp-6-00-lesson-notes: Lesson 228: Українська поезія. Дмитро Павличко...
→ section_id=6350 ulp-2-00-lesson-notes: Lesson 74: Курс з історії України Ч. 4...

SELECT s.section_id, s.source_file, s.section_title
  FROM textbook_sections s
  JOIN textbooks t ON t.parent_section_id = s.section_id
  JOIN textbooks_fts f ON f.rowid = t.id
 WHERE textbooks_fts MATCH 'автобус' AND s.source_file = 'anna-ohoiko-1000-words-2nd-ed';

→ section_id=5279 anna-ohoiko-1000-words-2nd-ed: Entry 3: авто́бус
```

### Idempotency

Re-running the backfill on the post-fix DB returns `0 inserted, 0
linked`; table totals unchanged.

## Companion audit findings (separate follow-ups, not in this PR)

A full content-indexing audit was run as part of resolving the user's
concern. Other findings:

- ✅ All 5 FTS shadows in sync: textbooks (25,017), ukrainian_wiki
  (22,385), wikipedia (1,026), literary_texts (137,688), external_articles
  (1,205).
- ✅ All 9 dictionary tables have b-tree indexes on word lookup columns
  (balla_en_uk, dmklinger_uk_en, frazeolohichnyi, grinchenko, puls_cefr,
  style_guide, sum11, ukrajinet, wiktionary).
- ⚠️  179 spillover orphans remain across ~15 school textbooks (1-18%
  each — `extract_sections.py` didn't find structural markers for those
  specific chunks). Not in scope here.
- ⚠️  `ukrainian_wiki.track` vocabulary mismatch: wiki uses `figures`,
  `historiography`, `works`, `periods`, etc. while curriculum declares
  `bio`, `istorio`, `lit`, `hist`, etc. Need to investigate alias
  mapping. Filed as separate follow-up.

## Test plan

- [x] 10 new tests in `test_section_coverage.py` pass (helper + ingester
      + backfill regressions)
- [x] Existing 15 ohoiko tests + 31 ULP tests still pass
- [x] Ruff clean; format clean
- [x] BEFORE/AFTER evidence captured against canonical DB (above)
- [x] Section-retrieval probe validates new chunks are now visible
- [x] Idempotency: re-run backfill → 0 inserted, 0 linked, no drift
- [x] DB backup created: `data/sources.db.bak-20260514-064136-pre-section-backfill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)