### PR TITLE
feat(corpus): ingest Anna Ohoiko "500+ Ukrainian Verbs" (page-based parser)

### DIFF
--- a/scripts/ingest/ohoiko_verbs_ingest.py
+++ b/scripts/ingest/ohoiko_verbs_ingest.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Ingest Anna Ohoiko *"500+ Ukrainian Verbs"* (1st ed, 2024) into
+``data/sources.db`` textbooks table.
+
+Unlike the 2nd-edition *"1000 Most Useful Ukrainian Words"* book
+(parsed by ``ohoiko_books_ingest.py``), this book has a *page-based*
+shape: each verb gets a full page with its conjugation tables, stems,
+aspectual info, and example sentences. Per-line markers like
+``NNN. <headword> <english>`` don't apply here — instead a page-break
+form-feed ``\\x0c`` followed by ``№N`` (or ``№ N`` with optional
+spacing) opens each verb page.
+
+Schema fit:
+- One row per verb page (mid-grained chunk, ~3-5 KB per verb)
+- ``author = 'Anna Ohoiko'``
+- ``source_file = 'anna-ohoiko-500-verbs'``
+- ``title = '<imperfective> | <perfective>'`` (the headword pair)
+- ``text = full page body`` (stems + translation + conjugation tables
+  + example sentences with bilingual UK/EN pairs)
+- ``grade = ''`` (CEFR mapping is a downstream concern)
+- ``chunk_id = '<source_file>_v<NNNN>'`` (``v`` for verb)
+
+Section coverage: writes ``textbook_sections`` rows natively via the
+shared ``_section_coverage`` helper so the chunks are visible to
+section-level retrieval (``_search_sections_fts5``). Without this,
+chunks land in textbooks + FTS but are invisible to the section query
+path (see ``docs/session-state/2026-05-14-content-indexing-audit-brief.md``).
+
+Idempotent: each verb's chunk_id is checked against the DB and skipped
+when present. Re-running on an unchanged source produces zero new
+inserts; use ``--force`` to delete existing rows for the source_file
+before re-insert.
+
+Deterministic verification: prints BEFORE / AFTER row counts and three
+sample rows per call. Mirrors the evidence convention required by the
+2026-05-14 determinism rule.
+
+Usage:
+    .venv/bin/python -m scripts.ingest.ohoiko_verbs_ingest
+    .venv/bin/python -m scripts.ingest.ohoiko_verbs_ingest --dry-run
+    .venv/bin/python -m scripts.ingest.ohoiko_verbs_ingest --force
+
+Source file:
+    docs/references/private/500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scripts.ingest._section_coverage import (
+    LessonSection,
+    ensure_section_schema,
+    link_lesson_sections,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
+
+SOURCE_FILE = "anna-ohoiko-500-verbs"
+TXT_FILENAME = "500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt"
+AUTHOR = "Anna Ohoiko"
+MAX_VERB_NUMBER = 500  # hard cap; book advertises "500+ verbs" but the
+# numbered series ends at exactly #500.
+
+# ---------------------------------------------------------------------------
+# Marker patterns
+# ---------------------------------------------------------------------------
+
+# Verb-page START anchor.
+# Format observed across the file:
+#   * ``\f№1`` (form-feed + no space) for early pages
+#   * ``№ 10`` and ``№ 211`` (with space, with optional leading
+#     whitespace from PDF column-alignment artifacts)
+#   * ``№ 212`` (form-feed + leading space + ``№`` + space + digits)
+# The single regex below covers all variants. Leading whitespace,
+# optional form-feed, optional whitespace, ``№``, optional whitespace,
+# digits, optional trailing whitespace, end of line.
+_VERB_START_RE = re.compile(r"^\s*\f?\s*№\s*(?P<num>\d+)\s*$")
+
+# Page footer: ``Back to Contents Inspiring resources for learning
+# Ukrainian — UkrainianLessons.com <page>``. Single line per page break.
+_PAGE_FOOTER_RE = re.compile(r"^\s*Back to Contents\s+Inspiring resources for learning Ukrainian")
+
+# Running section header at top of certain pages.
+_SECTION_HEADER_RE = re.compile(r"^\s*Ukrainian Verb Conjugation Charts\s*$")
+
+# Bare form-feed-only line (page break with nothing else).
+_BARE_FF_RE = re.compile(r"^\s*\f\s*$")
+
+# End-of-content terminator. After the last verb page, the book has
+# alphabetical indexes of Ukrainian + English verbs. The first
+# appearance of ``Index of Ukrainian Verbs`` (outside the ToC at the
+# top of the file) marks the end of the verb content.
+_INDEX_TERMINATOR = "Index of Ukrainian Verbs"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Verb:
+    number: int
+    body_lines: list[str] = field(default_factory=list)
+    headword_line: str = ""  # cached: first non-empty body line
+
+    @property
+    def title(self) -> str:
+        """Render a compact section title from the headword line.
+
+        The headword line is shaped like
+        ``аналізува́ти | проаналізува́ти   Present / Future Stems: …``.
+        We keep only the imperfective + perfective pair (everything
+        before two or more spaces).
+        """
+        line = self.headword_line.strip()
+        # Split on the first multi-space gap (the headword and the
+        # stems metadata are separated by long PDF column padding).
+        m = re.match(r"^(.+?)\s{2,}", line)
+        return (m.group(1) if m else line).strip()
+
+    def render(self) -> str:
+        """Render the verb page as a single text block for indexing.
+
+        Format: headword pair + blank + body lines (joined with newlines).
+        Lines retain their original leading whitespace so the
+        conjugation-table column structure is preserved in retrieval
+        snippets.
+        """
+        if not self.body_lines:
+            return f"Verb {self.number}\n"
+        # Keep title from being printed twice — the body already starts
+        # with the headword line. Just join.
+        return "\n".join(self.body_lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def _is_furniture(line: str) -> bool:
+    """Return True when ``line`` is PDF page furniture (page footer,
+    running header, bare form-feed) that should be stripped from
+    verb bodies."""
+    if _PAGE_FOOTER_RE.match(line):
+        return True
+    if _SECTION_HEADER_RE.match(line):
+        return True
+    return bool(_BARE_FF_RE.match(line))
+
+
+def parse_book(txt_path: Path) -> list[Verb]:
+    """Parse the 500+ Ukrainian Verbs .txt into a list of Verb objects.
+
+    Pipeline:
+    1. Skip everything before the first verb-start marker. The book
+       opens with a grammar guide + ToC + introduction; the numbered
+       series of verb pages starts around line 2600.
+    2. For each subsequent line:
+       a. If it matches a verb-start marker AND ``num > current.number``:
+          finalize the current verb, open a new one.
+       b. If it matches a verb-start marker with the same number:
+          treat as a page-header redundancy (rare; defensive). Skip.
+       c. If it matches page furniture, skip.
+       d. If it contains ``Index of Ukrainian Verbs``, finalize the
+          current verb and stop accumulating (we've reached the
+          alphabetical appendix).
+       e. Otherwise, append to the current verb's body (preserve
+          leading whitespace; strip trailing whitespace only).
+    3. The first non-empty body line is captured as the
+       ``headword_line`` for title extraction.
+    """
+    if not txt_path.exists():
+        raise FileNotFoundError(f"Source not found: {txt_path}")
+
+    verbs: list[Verb] = []
+    current: Verb | None = None
+    terminated = False
+
+    with txt_path.open(encoding="utf-8") as f:
+        for raw in f:
+            line = raw.rstrip("\n").rstrip()
+
+            # Verb-start marker first (must precede furniture check
+            # because the form-feed lives ON the marker line).
+            m = _VERB_START_RE.match(line)
+            if m:
+                num = int(m.group("num"))
+                if num > MAX_VERB_NUMBER:
+                    # Defensive: book advertises "500+" but numbered
+                    # series ends at #500. Anything past that is not a
+                    # real entry — could be appendix material.
+                    if current is not None:
+                        verbs.append(current)
+                        current = None
+                    continue
+                if current is None:
+                    current = Verb(number=num)
+                    terminated = False
+                    continue
+                if num > current.number:
+                    verbs.append(current)
+                    current = Verb(number=num)
+                    terminated = False
+                    continue
+                # Same or lower number — page-header redundancy. Skip.
+                continue
+
+            if current is None:
+                # Still in cover/ToC/intro region.
+                continue
+
+            if terminated:
+                continue
+
+            if _is_furniture(line):
+                continue
+
+            # End-of-content: alphabetical appendix.
+            if _INDEX_TERMINATOR in line:
+                terminated = True
+                continue
+
+            # Strip form-feed embedded inside a non-marker line
+            # (defensive — should not happen, but guard anyway).
+            cleaned = line.replace("\f", "").rstrip()
+            if not cleaned.strip():
+                # Blank line. Collapse: keep one blank between content
+                # blocks, drop runs.
+                if current.body_lines and current.body_lines[-1] != "":
+                    current.body_lines.append("")
+                continue
+
+            # First non-empty content line of this verb = headword line.
+            if not current.headword_line:
+                current.headword_line = cleaned.strip()
+
+            current.body_lines.append(cleaned)
+
+    if current is not None:
+        # Trim trailing blanks.
+        while current.body_lines and not current.body_lines[-1].strip():
+            current.body_lines.pop()
+        verbs.append(current)
+
+    return verbs
+
+
+# ---------------------------------------------------------------------------
+# DB ingest
+# ---------------------------------------------------------------------------
+
+
+def ingest_verbs(
+    conn: sqlite3.Connection,
+    verbs: list[Verb],
+    *,
+    force: bool = False,
+) -> tuple[int, int]:
+    """Insert each verb page as one row in textbooks AND one
+    ``textbook_sections`` row, links via ``parent_section_id``.
+
+    Returns (inserted, skipped).
+
+    Idempotent: skips chunk_ids that already exist unless ``force=True``,
+    in which case existing rows are DELETED (including their section
+    parents) before re-insert.
+    """
+    ensure_section_schema(conn)
+
+    cur = conn.cursor()
+    existing_ids: set[str] = set()
+    if not force:
+        rows = cur.execute(
+            "SELECT chunk_id FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchall()
+        existing_ids = {r[0] for r in rows}
+
+    if force:
+        cur.execute(
+            "DELETE FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        )
+        cur.execute(
+            "DELETE FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        )
+
+    inserted = 0
+    skipped = 0
+    batch: list[tuple] = []
+    new_sections: list[LessonSection] = []
+    for verb in verbs:
+        chunk_id = f"{SOURCE_FILE}_v{verb.number:04d}"
+        if chunk_id in existing_ids:
+            skipped += 1
+            continue
+        text = verb.render()
+        title = verb.title or f"Verb {verb.number}"
+        batch.append(
+            (
+                chunk_id,
+                title,
+                text,
+                SOURCE_FILE,
+                "",  # grade
+                AUTHOR,
+                len(text),
+            )
+        )
+        new_sections.append(
+            LessonSection(
+                chunk_id=chunk_id,
+                section_title=f"Verb {verb.number}: {title}",
+                section_number=str(verb.number),
+                full_text=text,
+            )
+        )
+        inserted += 1
+
+    if batch:
+        cur.executemany(
+            """INSERT INTO textbooks
+                  (chunk_id, title, text, source_file, grade, author, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            batch,
+        )
+        link_lesson_sections(
+            conn,
+            source_file=SOURCE_FILE,
+            sections=new_sections,
+        )
+
+    return inserted, skipped
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description='Ingest Anna Ohoiko "500+ Ukrainian Verbs" into data/sources.db',
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse + report, do not write to DB.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-insert: DELETE existing rows for this source_file before INSERT.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Override target DB path (testing only).",
+    )
+    args = parser.parse_args(argv)
+
+    txt_path = REFERENCES_DIR / TXT_FILENAME
+    if not txt_path.exists():
+        print(f"❌ Source file not found: {txt_path}", file=sys.stderr)
+        return 2
+
+    print(f"📚 Parsing {TXT_FILENAME}")
+    verbs = parse_book(txt_path)
+    print(f"   parsed verbs: {len(verbs)} (expected: {MAX_VERB_NUMBER})")
+    if verbs:
+        print(f"   number range: {verbs[0].number}..{verbs[-1].number}")
+        body_chars = sum(len(v.render()) for v in verbs)
+        print(f"   total body chars: {body_chars:,}")
+
+    if args.dry_run:
+        print("\n--- DRY-RUN sample (first / middle / last verb) ---")
+        if not verbs:
+            print("   (no verbs parsed)")
+            return 0
+        samples = [verbs[0], verbs[len(verbs) // 2], verbs[-1]]
+        for sample in samples:
+            print(f"\n### verb #{sample.number}: {sample.title!r} ###")
+            text = sample.render()
+            print(text[:400] + ("…" if len(text) > 400 else ""))
+        return 0
+
+    print(f"\n🗃️  Writing to {args.db}")
+    conn = sqlite3.connect(str(args.db))
+    try:
+        before = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        total_before = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        sec_before = conn.execute(
+            "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        print(f"   BEFORE: {before} chunks, {sec_before} sections for {SOURCE_FILE!r} (table total: {total_before:,})")
+
+        inserted, skipped = ingest_verbs(conn, verbs, force=args.force)
+        conn.commit()
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        total_after = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        sec_after = conn.execute(
+            "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        print(f"   inserted: {inserted}, skipped: {skipped}")
+        print(
+            f"   AFTER: {after} chunks, {sec_after} sections for {SOURCE_FILE!r} "
+            f"(table total: {total_after:,}, delta +{total_after - total_before})"
+        )
+
+        sample = conn.execute(
+            """SELECT chunk_id, title, char_count, substr(text, 1, 100) AS snippet
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id LIMIT 3""",
+            (SOURCE_FILE,),
+        ).fetchall()
+        print("\n--- AFTER sample rows ---")
+        for row in sample:
+            print(f"  chunk_id={row[0]}")
+            print(f"    title={row[1]!r}")
+            print(f"    char_count={row[2]}")
+            print(f"    snippet={row[3]!r}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ohoiko_verbs_ingest.py
+++ b/tests/test_ohoiko_verbs_ingest.py
@@ -1,0 +1,318 @@
+"""Tests for scripts/ingest/ohoiko_verbs_ingest.py.
+
+Exercises the page-based parser against a synthetic fixture that
+mirrors the real *500+ Ukrainian Verbs* layout quirks:
+
+- Verb-page start marker handles both ``\\x0c№N`` (form-feed + no
+  space, used for early pages) and ``\\x0c № N`` (form-feed + leading
+  space + space) — the latter shape appears around verb #211 due to
+  PDF column-alignment artifacts.
+- Page furniture (``Back to Contents ...UkrainianLessons.com NNN``,
+  running header ``Ukrainian Verb Conjugation Charts``, bare form-feed
+  lines) must be stripped from verb bodies.
+- The first non-empty body line after the start marker is captured as
+  the headword pair (``імперф. | перф.``) and forms the title.
+- ``Index of Ukrainian Verbs`` (appendix marker) terminates the last
+  verb's body without absorbing the index content.
+- Hard cap at ``MAX_VERB_NUMBER = 500`` rejects any marker beyond #500.
+- Verified output (chunk_id, title, section_title, char_count) lands
+  in textbooks + textbook_sections via the same code path as the live
+  ingest. Zero orphans after ingest.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.ingest import ohoiko_verbs_ingest as ovi
+from scripts.ingest._section_coverage import ensure_section_schema
+
+FIXTURE_TXT = (
+    "Some grammar guide content here.\nMore intro text.\n\n"
+    "\x0c№1\n\n"
+    "аналізува́ти | проаналізува́ти                                        Present / Future Stems: аналізу- | проаналізу-\n"
+    "to analyze                                                                                            Conjugation: 1st (-ють)\n"
+    "      ОСОБА                          НЕДОКОНАНИЙ ВИД                                                 ДОКОНАНИЙ ВИД\n"
+    " я                   аналізу́ю\n"
+    "+ accusative:\n"
+    "Експе́рти аналізу́ють ситуа́цію.                                 Experts are analyzing the situation.\n"
+    "\n"
+    "  Back to Contents              Inspiring resources for learning Ukrainian — UkrainianLessons.com                          57\n"
+    "\x0c№2\n\n"
+    "атакува́ти | атакува́ти                                                                 Present / Future Stems: атаку- | атаку-\n"
+    "to attack, to assault                                                              Two-Aspect Verb, Conjugation: 1st (-ють)\n"
+    " я                      атаку́ю\n"
+    "+ accusative:\n"
+    "Воро́г атаку́є.                                                  The enemy attacks.\n"
+    "\n"
+    "Back to Contents                     Inspiring resources for learning Ukrainian — UkrainianLessons.com                              267\n"
+    "  \x0c № 3\n\n"
+    "ї́здити | з’ї́здити, пої́здити                                  Present / Future Stems: їждж-/їзд- | з’їждж-/з’їзд-\n"
+    "to go by transport (multidirectional); to travel\n"
+    " я                        ї́жджу\n"
+    "\n"
+    "Index of Ukrainian Verbs\n"
+    "аналізувати .......... 56\n"
+    "атакувати ............. 57\n"
+)
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    p = tmp_path / "verbs-fixture.txt"
+    p.write_text(FIXTURE_TXT, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Parser-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_book_finds_all_verb_pages(tmp_path: Path) -> None:
+    verbs = ovi.parse_book(_write_fixture(tmp_path))
+    nums = [v.number for v in verbs]
+    assert nums == [1, 2, 3], f"expected [1, 2, 3], got {nums}"
+
+
+def test_parse_book_handles_form_feed_no_space_marker(tmp_path: Path) -> None:
+    """Markers like ``\\x0c№1`` (form-feed + no space) must open a
+    new verb page."""
+    verbs = ovi.parse_book(_write_fixture(tmp_path))
+    assert verbs[0].number == 1
+    assert "аналізу́ю" in verbs[0].render()
+
+
+def test_parse_book_handles_space_marker(tmp_path: Path) -> None:
+    """Markers like ``\\x0c № 3`` (form-feed + leading space + space)
+    must also open a new verb page — this is the shape around verb
+    #211 in the real source."""
+    verbs = ovi.parse_book(_write_fixture(tmp_path))
+    assert verbs[-1].number == 3
+    assert "ї́жджу" in verbs[-1].render()
+
+
+def test_parse_book_strips_page_furniture(tmp_path: Path) -> None:
+    """Page footer ``Back to Contents ...UkrainianLessons.com NNN`` must
+    NOT appear in any verb body."""
+    verbs = ovi.parse_book(_write_fixture(tmp_path))
+    for v in verbs:
+        body = v.render()
+        assert "Back to Contents" not in body
+        assert "Inspiring resources for learning Ukrainian" not in body
+
+
+def test_parse_book_captures_headword_pair_as_title(tmp_path: Path) -> None:
+    """Title comes from the first non-empty body line, trimmed at the
+    first run of 2+ spaces (which separates the headword pair from the
+    stems/conjugation metadata in the PDF column layout)."""
+    verbs = ovi.parse_book(_write_fixture(tmp_path))
+    assert verbs[0].title == "аналізува́ти | проаналізува́ти"
+    assert verbs[1].title == "атакува́ти | атакува́ти"
+    assert verbs[2].title.startswith("ї́здити | з’ї́здити")
+
+
+def test_parse_book_terminates_at_index_marker(tmp_path: Path) -> None:
+    """``Index of Ukrainian Verbs`` (appendix start) finalizes the last
+    verb and stops accumulation."""
+    verbs = ovi.parse_book(_write_fixture(tmp_path))
+    last_body = verbs[-1].render()
+    assert "Index of Ukrainian Verbs" not in last_body
+    assert "аналізувати .......... 56" not in last_body
+    # But real content for verb #3 stays:
+    assert "ї́жджу" in last_body
+
+
+def test_parse_book_rejects_marker_beyond_max(tmp_path: Path) -> None:
+    """Hard cap: numbers > MAX_VERB_NUMBER are dropped (defensive
+    against appendix material that might incidentally carry a №N
+    pattern)."""
+    fixture = (
+        "\x0c№1\n\nаналізува́ти | проаналізува́ти\nto analyze\n\x0c№600\n\nЩось після кінця\nsomething after the end\n"
+    )
+    p = tmp_path / "f.txt"
+    p.write_text(fixture, encoding="utf-8")
+    verbs = ovi.parse_book(p)
+    nums = [v.number for v in verbs]
+    assert nums == [1], f"expected [1], got {nums}"
+
+
+def test_parse_book_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ovi.parse_book(tmp_path / "does-not-exist.txt")
+
+
+# ---------------------------------------------------------------------------
+# DB round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def _make_full_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0,
+            parent_section_id INTEGER REFERENCES textbook_sections(section_id)
+        );
+        """
+    )
+    ensure_section_schema(conn)
+    return conn
+
+
+def test_ingest_verbs_round_trip(tmp_path: Path) -> None:
+    """End-to-end: parse → ingest → SELECT confirms rows are written
+    with correct metadata and zero orphans."""
+    txt = _write_fixture(tmp_path)
+    verbs = ovi.parse_book(txt)
+    assert len(verbs) == 3
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    inserted, skipped = ovi.ingest_verbs(conn, verbs)
+    conn.commit()
+
+    assert inserted == 3
+    assert skipped == 0
+
+    rows = list(
+        conn.execute(
+            """SELECT chunk_id, title, source_file, author, char_count, parent_section_id
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id""",
+            (ovi.SOURCE_FILE,),
+        )
+    )
+    assert len(rows) == 3
+    assert rows[0][0] == f"{ovi.SOURCE_FILE}_v0001"
+    assert rows[-1][0] == f"{ovi.SOURCE_FILE}_v0003"
+    assert all(r[2] == ovi.SOURCE_FILE for r in rows)
+    assert all(r[3] == ovi.AUTHOR for r in rows)
+    assert all(r[4] > 0 for r in rows)
+    # Zero orphans
+    assert all(r[5] is not None for r in rows), f"orphans remain: {rows}"
+
+    # Section coverage check
+    n_sec = conn.execute(
+        "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+        (ovi.SOURCE_FILE,),
+    ).fetchone()[0]
+    assert n_sec == 3  # 1:1
+
+    # Section title format: ``Verb N: <headword_pair>``
+    titles = sorted(
+        r[0]
+        for r in conn.execute(
+            "SELECT section_title FROM textbook_sections WHERE source_file = ?",
+            (ovi.SOURCE_FILE,),
+        )
+    )
+    assert titles[0].startswith("Verb 1: ")
+    assert "аналізува́ти" in titles[0]
+    conn.close()
+
+
+def test_ingest_verbs_idempotent(tmp_path: Path) -> None:
+    """Running the ingest twice on the same source should NOT
+    duplicate rows; the second call returns (0 inserted, N skipped)."""
+    txt = _write_fixture(tmp_path)
+    verbs = ovi.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+
+    first = ovi.ingest_verbs(conn, verbs)
+    conn.commit()
+    second = ovi.ingest_verbs(conn, verbs)
+    conn.commit()
+    assert first == (3, 0)
+    assert second == (0, 3)
+    total = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+        (ovi.SOURCE_FILE,),
+    ).fetchone()[0]
+    assert total == 3
+    n_sec = conn.execute(
+        "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+        (ovi.SOURCE_FILE,),
+    ).fetchone()[0]
+    assert n_sec == 3
+    conn.close()
+
+
+def test_ingest_verbs_force_overwrites(tmp_path: Path) -> None:
+    """With force=True, existing rows AND sections are deleted before
+    re-insert."""
+    txt = _write_fixture(tmp_path)
+    verbs = ovi.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_full_db(db_path)
+    ovi.ingest_verbs(conn, verbs)
+    conn.commit()
+    inserted, skipped = ovi.ingest_verbs(conn, verbs, force=True)
+    conn.commit()
+    assert inserted == 3
+    assert skipped == 0
+    n_chunks = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+        (ovi.SOURCE_FILE,),
+    ).fetchone()[0]
+    n_sec = conn.execute(
+        "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+        (ovi.SOURCE_FILE,),
+    ).fetchone()[0]
+    n_orphan = conn.execute(
+        "SELECT COUNT(*) FROM textbooks WHERE source_file = ? AND parent_section_id IS NULL",
+        (ovi.SOURCE_FILE,),
+    ).fetchone()[0]
+    assert n_chunks == 3
+    assert n_sec == 3
+    assert n_orphan == 0
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Furniture-recognizer parametric tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # Page footer (the single-line shape that's typical in this book)
+        (
+            "  Back to Contents              Inspiring resources for learning Ukrainian — UkrainianLessons.com                          57",
+            True,
+        ),
+        (
+            "Back to Contents                     Inspiring resources for learning Ukrainian — UkrainianLessons.com                              267",
+            True,
+        ),
+        # Running section header
+        ("            Ukrainian Verb Conjugation Charts", True),
+        ("Ukrainian Verb Conjugation Charts", True),
+        # Bare form-feed
+        ("\x0c", True),
+        # NOT furniture: regular content
+        ("аналізува́ти | проаналізува́ти", False),
+        ("+ accusative:", False),
+        ("Експе́рти аналізу́ють ситуа́цію.", False),
+        # NOT furniture: the verb-start marker itself (handled by parser, not
+        # furniture-recognizer)
+        ("№1", False),
+        ("\x0c№1", False),
+        (" № 211", False),
+    ],
+)
+def test_is_furniture(line: str, expected: bool) -> None:
+    assert ovi._is_furniture(line) is expected


### PR DESCRIPTION
## Summary

NEW `scripts/ingest/ohoiko_verbs_ingest.py` (380 LOC) + 22 unit tests.
Ingests the 1st-edition (2024) Anna Ohoiko verb-conjugation reference:
500 verbs with full conjugation tables across all tenses/moods/persons,
stems, aspect annotations, and bilingual UK/EN example sentences.

This completes **C2** of the 2026-05-14 corpus-completion arc:

| Task | PR | Status |
|---|---|---|
| C1: Ohoiko 1000-words | #1977 | ✅ merged |
| C3: ULP lesson notes  | #1981 | ✅ merged |
| **C2: Ohoiko 500+ verbs** | **THIS** | 🟡 open |
| C4: Pohribnyi book OCR | — | BLOCKED on source PDF placement |

## Design highlights

- **Page-based parser, not entry-line-based.** Each verb gets a full
  page in the PDF, separated by `\x0c` form-feeds. The 2nd-edition
  1000-words book uses `NNN. <headword> <english>` per-line markers;
  the verbs book has nothing equivalent. New module rather than adding
  another mode to `ohoiko_books_ingest.py`.
- **Marker shape tolerance.** PDF extraction produced three variants
  for the same `№N` lesson-start anchor — `\x0c№1` (no space, early
  pages), `№ 10` (with space, later pages), and ` № 211`
  (leading-whitespace + space, around verb #211 due to column
  alignment). The single regex `^\s*\f?\s*№\s*(\d+)\s*$` catches all
  three. Without the leading-whitespace tolerance, an initial audit
  found 499 of 500 verbs — #211 had silently disappeared.
- **Section coverage native.** Writes `textbook_sections` rows at
  ingest time via `_section_coverage.link_lesson_sections()` (helper
  from #1982). Title format: `Verb N: <imperfective> | <perfective>`.
  Zero orphans.

## DB evidence

```
$ sqlite3 data/sources.db "SELECT COUNT(*) FROM textbooks; SELECT COUNT(*) FROM textbooks_fts"
25517
25517

$ sqlite3 data/sources.db "SELECT COUNT(*), SUM(char_count) FROM textbooks WHERE source_file='anna-ohoiko-500-verbs'"
500|2181710

$ sqlite3 data/sources.db "SELECT COUNT(*) FROM textbook_sections WHERE source_file='anna-ohoiko-500-verbs'"
500

$ sqlite3 data/sources.db "SELECT COUNT(*) FROM textbooks WHERE source_file='anna-ohoiko-500-verbs' AND parent_section_id IS NULL"
0
```

### SAMPLE rows

```
chunk_id                          title                              char_count
anna-ohoiko-500-verbs_v0001       аналізува́ти | проаналізува́ти    4,253
anna-ohoiko-500-verbs_v0251       могти́ | змогти́                   ~3,900
anna-ohoiko-500-verbs_v0500       щасти́ти | пощасти́ти              ~3,500
```

### FTS + section retrieval probe (joins through parent_section_id)

```sql
SELECT t.chunk_id, s.section_title
  FROM textbooks_fts f
  JOIN textbooks t ON f.rowid = t.id
  JOIN textbook_sections s ON t.parent_section_id = s.section_id
 WHERE textbooks_fts MATCH 'аналізувати'
   AND t.source_file = 'anna-ohoiko-500-verbs';
→ anna-ohoiko-500-verbs_v0001: Verb 1: аналізува́ти | проаналізува́ти

WHERE textbooks_fts MATCH 'могти'
→ anna-ohoiko-500-verbs_v0251: Verb 251: могти́ | змогти́
```

### Idempotency

Re-run on populated DB: 0 inserted, 500 skipped, table totals
unchanged. `--force` deletes both chunks AND sections cleanly via
`DELETE FROM textbook_sections WHERE source_file=?` then re-inserts.

## Test plan

- [x] 22 new tests in `test_ohoiko_verbs_ingest.py` pass
- [x] Ruff clean (1 SIM103 fix: ternary on `_BARE_FF_RE.match`)
- [x] Format clean
- [x] Dry-run against real source: 500 verbs parsed, #1..#500 sequential,
      all titles cleanly extracted as `imperfective | perfective` pairs
- [x] BEFORE/AFTER/SAMPLE captured against canonical DB
- [x] FTS retrieval probe validates new chunks are searchable
- [x] Section-level retrieval probe validates `parent_section_id`
      linkage works
- [x] Idempotency: re-run inserts 0, skips 500
- [x] DB backup created: `data/sources.db.bak-*-pre-verbs-ingest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)