### PR TITLE
feat(corpus): ingest Pohribnyi 1992 'Українська літературна вимова' (C4 — final corpus task)

### DIFF
--- a/scripts/ingest/pohribnyi_pronunciation_ingest.py
+++ b/scripts/ingest/pohribnyi_pronunciation_ingest.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Ingest Mykola Pohribnyi *"Українська літературна вимова"* (1992) into
+``data/sources.db`` textbooks table.
+
+The book is a 28-page Ukrainian-pronunciation textbook authored by
+Микола Іванович Погрібний (lexicographer of «Словника наголосів» and
+«Орфоепічного словника») and published 1992 in Dnipropetrovsk by the
+"TRANSFORM" Agency, distributed as a printed booklet alongside a set
+of LPs / audio cassettes. Topics: phonetic transcription, vowel and
+consonant pronunciation norms, common assimilation rules, and the
+pronunciation of select grammatical forms.
+
+Source: 51 MB image-based PDF (CorelDRAW 11.0, 28 pages, A5 format)
+laid out as scanned plates with no embedded text. OCR is performed
+out-of-band with Tesseract 5 + ``-l ukr`` on 300 dpi PNGs derived via
+``pdftoppm``; the concatenated OCR output ships alongside the PDF as
+``pohribnyi-ukrainska-literaturna-vymova-1992.txt`` in
+``docs/references/private/`` (gitignored).
+
+Schema fit:
+- One row per page (28 chunks total). The book is short and structurally
+  cohesive enough that page-grained chunks are the natural retrieval
+  unit. Per-headword chunking would require entry-boundary detection
+  inside dense paragraph prose where OCR is imperfect; that work is
+  filed for a follow-up.
+- ``author = 'Mykola Pohribnyi'``
+- ``source_file = 'pohribnyi-ukrainska-literaturna-vymova-1992'``
+- ``title`` = ``Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. N``
+- ``text`` = the page body (OCR output, untouched)
+- ``grade`` = ``''`` (CEFR mapping is downstream; sections use sentinel 0)
+- ``chunk_id`` = ``{source_file}_p{NN}`` (``p`` for page)
+
+Section coverage: writes ``textbook_sections`` rows natively via the
+shared ``_section_coverage`` helper so the chunks are visible to
+section-level retrieval (``_search_sections_fts5``). Mirrors the pattern
+established in PR #1982 (Ohoiko + ULP).
+
+Idempotent: each page's chunk_id is checked against the DB and skipped
+when present. Re-running on an unchanged source produces zero new
+inserts; use ``--force`` to delete existing rows for the source_file
+(both ``textbooks`` and ``textbook_sections``) before re-insert.
+
+Deterministic verification: prints BEFORE / AFTER row counts and three
+sample rows per call. Mirrors the evidence convention required by the
+2026-05-14 determinism rule (see
+``docs/best-practices/deterministic-over-hallucination.md``).
+
+Usage:
+    .venv/bin/python -m scripts.ingest.pohribnyi_pronunciation_ingest
+    .venv/bin/python -m scripts.ingest.pohribnyi_pronunciation_ingest --dry-run
+    .venv/bin/python -m scripts.ingest.pohribnyi_pronunciation_ingest --force
+
+Source file (gitignored, in ``docs/references/private/``):
+    ``pohribnyi-ukrainska-literaturna-vymova-1992.txt`` (OCR output)
+    ``pohribnyi-ukrainska-literaturna-vymova-1992.pdf`` (original 28 pp.)
+
+Re-OCR (only if source PDF replaced or OCR output lost):
+    mkdir -p /tmp/pohribnyi-ocr && cd /tmp/pohribnyi-ocr
+    pdftoppm -r 300 -png docs/references/private/pohribnyi-*.pdf page
+    ls page-*.png | xargs -n1 -P4 -I{} sh -c \\
+        'tesseract "$1" "${1%.png}" -l ukr 2>/dev/null' _ {}
+    : > all.txt
+    for i in $(seq -w 1 28); do printf '\\f' >> all.txt; cat page-$i.txt >> all.txt; done
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.ingest._section_coverage import (
+    LessonSection,
+    ensure_section_schema,
+    link_lesson_sections,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
+
+SOURCE_FILE = "pohribnyi-ukrainska-literaturna-vymova-1992"
+TXT_FILENAME = "pohribnyi-ukrainska-literaturna-vymova-1992.txt"
+AUTHOR = "Mykola Pohribnyi"
+EXPECTED_PAGES = 28  # Verified against pdfinfo of the 1992 booklet.
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Page:
+    number: int
+    body: str = ""
+
+    def render(self) -> str:
+        """Render the page chunk text. The OCR output already contains
+        the page number as its first line plus the body; we trim a
+        leading run of blank lines and a trailing run of blank lines but
+        preserve internal blank lines (they separate paragraphs)."""
+        lines = self.body.splitlines()
+        # Strip leading blanks
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        # Strip trailing blanks
+        while lines and not lines[-1].strip():
+            lines.pop()
+        return "\n".join(lines) + "\n" if lines else ""
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def parse_book(txt_path: Path) -> list[Page]:
+    """Split the concatenated OCR output into one Page per form-feed.
+
+    Convention: the OCR pipeline prepends ``\\f`` (form-feed) before each
+    page-N body. After splitting on form-feed, position 0 is empty (the
+    file starts with ``\\f``), positions 1..N are page bodies.
+
+    Empty pages (after trimming) are dropped from the result; a parsed
+    page list shorter than EXPECTED_PAGES is permitted but should be
+    flagged by the caller.
+    """
+    if not txt_path.exists():
+        raise FileNotFoundError(f"Source not found: {txt_path}")
+
+    raw = txt_path.read_text(encoding="utf-8")
+    parts = raw.split("\f")
+    pages: list[Page] = []
+    for idx, body in enumerate(parts):
+        if idx == 0 and not body.strip():
+            # Leading split-artifact: the file starts with \f.
+            continue
+        page_number = len(pages) + 1
+        page = Page(number=page_number, body=body)
+        if not page.render():
+            # Empty page (form-feed with no content). Don't number it.
+            continue
+        pages.append(page)
+    return pages
+
+
+# ---------------------------------------------------------------------------
+# DB ingest
+# ---------------------------------------------------------------------------
+
+
+def ingest_pages(
+    conn: sqlite3.Connection,
+    pages: list[Page],
+    *,
+    force: bool = False,
+) -> tuple[int, int]:
+    """Insert each page as one row in textbooks + one row in
+    textbook_sections (1:1 chunk:section mapping). Returns
+    ``(inserted, skipped)``.
+
+    Idempotent on ``chunk_id``. ``force=True`` DELETEs existing rows
+    for this source_file (both textbook_sections + textbooks) before
+    re-insert so re-runs are deterministic.
+    """
+    ensure_section_schema(conn)
+
+    cur = conn.cursor()
+    existing_ids: set[str] = set()
+    if force:
+        cur.execute(
+            "DELETE FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        )
+        cur.execute(
+            "DELETE FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        )
+    else:
+        rows = cur.execute(
+            "SELECT chunk_id FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchall()
+        existing_ids = {r[0] for r in rows}
+
+    inserted = 0
+    skipped = 0
+    batch: list[tuple] = []
+    new_sections: list[LessonSection] = []
+    for page in pages:
+        chunk_id = f"{SOURCE_FILE}_p{page.number:02d}"
+        if chunk_id in existing_ids:
+            skipped += 1
+            continue
+        text = page.render()
+        title = f"Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. {page.number}"
+        batch.append(
+            (
+                chunk_id,
+                title,
+                text,
+                SOURCE_FILE,
+                "",  # grade (TEXT-typed on textbooks; sections use sentinel 0)
+                AUTHOR,
+                len(text),
+            )
+        )
+        new_sections.append(
+            LessonSection(
+                chunk_id=chunk_id,
+                section_title=title,
+                section_number=str(page.number),
+                full_text=text,
+            )
+        )
+        inserted += 1
+
+    if batch:
+        cur.executemany(
+            """INSERT INTO textbooks
+                  (chunk_id, title, text, source_file, grade, author, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            batch,
+        )
+        link_lesson_sections(
+            conn,
+            source_file=SOURCE_FILE,
+            sections=new_sections,
+        )
+
+    return inserted, skipped
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _run(*, db_path: Path, dry_run: bool, force: bool) -> int:
+    txt_path = REFERENCES_DIR / TXT_FILENAME
+    if not txt_path.exists():
+        print(
+            f"❌ Source file not found: {txt_path}\n"
+            "   Run the OCR pipeline (see module docstring) and place the\n"
+            "   concatenated output as the filename above before re-running.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"\n📚 Parsing {TXT_FILENAME}")
+    pages = parse_book(txt_path)
+    print(f"   parsed pages: {len(pages)} (expected: {EXPECTED_PAGES})")
+    if pages:
+        body_chars = sum(len(p.render()) for p in pages)
+        print(f"   page range: {pages[0].number}..{pages[-1].number}")
+        print(f"   total body chars: {body_chars:,}")
+    if len(pages) != EXPECTED_PAGES:
+        print(
+            f"   ⚠️  parsed page count {len(pages)} differs from expected "
+            f"{EXPECTED_PAGES} — likely an OCR artifact (empty page or "
+            f"form-feed missing). Inspect before proceeding.",
+            file=sys.stderr,
+        )
+
+    if dry_run:
+        print("\n--- DRY-RUN sample (first / middle / last page) ---")
+        if not pages:
+            print("   (no pages parsed)")
+            return 0
+        samples = [pages[0], pages[len(pages) // 2], pages[-1]]
+        for sample in samples:
+            print(f"\n### page #{sample.number} ###")
+            text = sample.render()
+            print(text[:400] + ("…" if len(text) > 400 else ""))
+        return 0
+
+    print(f"\n🗃️  Writing to {db_path}")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        before = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        total_before = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        sections_before = conn.execute(
+            "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        print(
+            f"   BEFORE: {before} chunks for {SOURCE_FILE!r} "
+            f"({sections_before} sections; textbooks total: {total_before:,})"
+        )
+
+        inserted, skipped = ingest_pages(conn, pages, force=force)
+        conn.commit()
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        total_after = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        sections_after = conn.execute(
+            "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        orphans = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ? AND parent_section_id IS NULL",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+
+        print(f"   inserted: {inserted}, skipped: {skipped}")
+        print(
+            f"   AFTER: {after} chunks for {SOURCE_FILE!r} "
+            f"({sections_after} sections; textbooks total: {total_after:,}, "
+            f"delta +{total_after - total_before})"
+        )
+        print(f"   section-orphan chunks for {SOURCE_FILE!r}: {orphans} (expected 0)")
+
+        sample = conn.execute(
+            """SELECT chunk_id, title, char_count, substr(text, 1, 80) AS snippet
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id LIMIT 3""",
+            (SOURCE_FILE,),
+        ).fetchall()
+        print("\n--- AFTER sample rows ---")
+        for row in sample:
+            print(f"  chunk_id={row[0]}")
+            print(f"    title={row[1]!r}")
+            print(f"    char_count={row[2]}")
+            print(f"    snippet={row[3]!r}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ingest Mykola Pohribnyi 1992 'Ukrainian Literary Pronunciation' "
+            "into data/sources.db (28 pages → 28 chunks → 28 sections)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse + report, do not write to DB.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-insert: DELETE existing rows for this source_file before INSERT.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Override target DB path (testing only).",
+    )
+    args = parser.parse_args(argv)
+
+    return _run(db_path=args.db, dry_run=args.dry_run, force=args.force)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pohribnyi_pronunciation_ingest.py
+++ b/tests/test_pohribnyi_pronunciation_ingest.py
@@ -34,7 +34,6 @@ import pytest
 
 from scripts.ingest import pohribnyi_pronunciation_ingest as pohribnyi
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — a 3-page synthetic fixture mirroring the real OCR layout
 # (the real file leads with a form-feed and uses form-feed between pages)

--- a/tests/test_pohribnyi_pronunciation_ingest.py
+++ b/tests/test_pohribnyi_pronunciation_ingest.py
@@ -1,0 +1,285 @@
+"""Tests for scripts/ingest/pohribnyi_pronunciation_ingest.py.
+
+The Pohribnyi 1992 source ships as a 28-page image-based PDF that we
+OCR out-of-band into a single .txt with form-feed page separators. The
+ingester's parsing surface is intentionally narrow — split on form-feed,
+trim leading/trailing blanks, one chunk per page — so the tests focus
+on:
+
+- correct page count from a synthetic fixture mirroring the real OCR
+  layout (leading form-feed before page 1, form-feeds between pages)
+- empty-page handling (a stray form-feed should not introduce a phantom
+  chunk)
+- trimming behavior on the Page.render output
+- round-trip into a minimal sqlite schema with the shared
+  ``_section_coverage`` helper attached, so each chunk lands with a
+  non-NULL ``parent_section_id`` pointing at a row in
+  ``textbook_sections``
+- idempotency (re-run = 0 inserted / N skipped)
+- ``--force`` resets both textbooks and textbook_sections rows for the
+  source_file
+
+The synthetic fixture is short on purpose; the production data lives in
+``docs/references/private/pohribnyi-ukrainska-literaturna-vymova-1992.txt``
+and is exercised by the live ingest run whose evidence is captured in
+the PR description per the determinism rule.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.ingest import pohribnyi_pronunciation_ingest as pohribnyi
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a 3-page synthetic fixture mirroring the real OCR layout
+# (the real file leads with a form-feed and uses form-feed between pages)
+# ---------------------------------------------------------------------------
+
+FIXTURE_3_PAGES = (
+    "\f"
+    "2\n"
+    "\n"
+    "УКРАЇНСЬКА\n"
+    "ЛІТЕРАТУРНА\n"
+    "ВИМОВА\n"
+    "\n"
+    "МИКОЛА ПОГРІБНИЙ\n"
+    "\f"
+    "3\n"
+    "\n"
+    "ПЕРЕДМОВА\n"
+    "\n"
+    "Навчальний посібник 'Українська літературна вимова'.\n"
+    "\f"
+    "4\n"
+    "\n"
+    "ЗНАКИ ФОНЕТИЧНОГО АЛФАВІТУ\n"
+    "\n"
+    "[й] — голосний звук, проміжний між [е] і [и].\n"
+)
+
+
+# Fixture with a stray empty form-feed between content pages, to verify
+# the parser doesn't emit a phantom chunk for the empty page.
+FIXTURE_WITH_EMPTY_PAGE = (
+    "\f"
+    "Page A body.\n"
+    "\f"
+    "\f"
+    "Page B body.\n"
+)
+
+
+def _write_fixture(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Parser-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_book_yields_one_page_per_form_feed(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = pohribnyi.parse_book(txt)
+    assert [p.number for p in pages] == [1, 2, 3]
+
+
+def test_parse_book_drops_empty_pages(tmp_path: Path) -> None:
+    """A stray form-feed with no content between two pages must not
+    promote a phantom chunk."""
+    txt = _write_fixture(tmp_path, "empty.txt", FIXTURE_WITH_EMPTY_PAGE)
+    pages = pohribnyi.parse_book(txt)
+    assert [p.number for p in pages] == [1, 2]
+    assert "Page A body." in pages[0].render()
+    assert "Page B body." in pages[1].render()
+
+
+def test_parse_book_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        pohribnyi.parse_book(tmp_path / "does-not-exist.txt")
+
+
+def test_page_render_strips_leading_and_trailing_blanks(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = pohribnyi.parse_book(txt)
+    rendered = pages[1].render()  # page 2 has leading "3\n\n" and content
+    assert not rendered.startswith("\n"), "leading blank should be stripped"
+    assert rendered.endswith("\n"), "trailing newline retained for delimiter cleanliness"
+    # The page-number line ``3`` is OCR content for page 2 — it stays.
+    assert rendered.startswith("3\n")
+
+
+def test_page_render_preserves_internal_blanks(tmp_path: Path) -> None:
+    """Blank lines between paragraphs are content structure, not stripped."""
+    fixture = "\fParagraph A.\n\nParagraph B.\n"
+    txt = _write_fixture(tmp_path, "p.txt", fixture)
+    pages = pohribnyi.parse_book(txt)
+    rendered = pages[0].render()
+    assert "Paragraph A.\n\nParagraph B." in rendered
+
+
+# ---------------------------------------------------------------------------
+# DB round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def _make_textbooks_db(path: Path) -> sqlite3.Connection:
+    """Minimal schema: textbooks + textbook_sections + the
+    parent_section_id column. The ``_section_coverage`` helper provides
+    its own ``ensure_section_schema`` defensive layer, but we still
+    create the textbooks table because the helper does not."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+        );
+        """
+    )
+    return conn
+
+
+def test_ingest_pages_round_trip_with_section_coverage(tmp_path: Path) -> None:
+    """End-to-end: parse → ingest → verify chunks + sections + linkage."""
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = pohribnyi.parse_book(txt)
+    assert len(pages) == 3
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    inserted, skipped = pohribnyi.ingest_pages(conn, pages)
+    conn.commit()
+    assert inserted == 3
+    assert skipped == 0
+
+    chunks = list(
+        conn.execute(
+            """SELECT chunk_id, title, source_file, author, char_count,
+                      parent_section_id
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id""",
+            (pohribnyi.SOURCE_FILE,),
+        )
+    )
+    assert [c[0] for c in chunks] == [
+        f"{pohribnyi.SOURCE_FILE}_p01",
+        f"{pohribnyi.SOURCE_FILE}_p02",
+        f"{pohribnyi.SOURCE_FILE}_p03",
+    ]
+    assert chunks[0][1] == "Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. 1"
+    assert chunks[2][1] == "Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. 3"
+    assert all(c[3] == pohribnyi.AUTHOR for c in chunks)
+    assert all(c[4] > 0 for c in chunks)
+    # CRITICAL: each chunk must be linked to a section row.
+    assert all(c[5] is not None for c in chunks), (
+        "ingester must populate parent_section_id via _section_coverage "
+        "helper — None values mean the section coverage path didn't run"
+    )
+
+    sections = list(
+        conn.execute(
+            """SELECT section_id, source_file, grade, section_title, section_number, chunk_count
+                 FROM textbook_sections WHERE source_file = ? ORDER BY section_id""",
+            (pohribnyi.SOURCE_FILE,),
+        )
+    )
+    assert len(sections) == 3
+    # Sentinel grade=0 for non-school reference material.
+    assert all(s[2] == 0 for s in sections)
+    assert [s[4] for s in sections] == ["1", "2", "3"]
+    assert all(s[5] == 1 for s in sections)  # 1:1 chunk:section mapping
+
+    # Linkage is consistent: every chunk.parent_section_id resolves to a
+    # row in textbook_sections.
+    section_ids = {s[0] for s in sections}
+    assert all(c[5] in section_ids for c in chunks)
+
+    conn.close()
+
+
+def test_ingest_pages_idempotent(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = pohribnyi.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+
+    first = pohribnyi.ingest_pages(conn, pages)
+    conn.commit()
+    second = pohribnyi.ingest_pages(conn, pages)
+    conn.commit()
+    assert first == (3, 0)
+    assert second == (0, 3)
+
+    total = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+    assert total == 3
+    sections_total = conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+    assert sections_total == 3
+    conn.close()
+
+
+def test_ingest_pages_force_overwrites(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = pohribnyi.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    pohribnyi.ingest_pages(conn, pages)
+    conn.commit()
+
+    inserted, skipped = pohribnyi.ingest_pages(conn, pages, force=True)
+    conn.commit()
+    assert inserted == 3
+    assert skipped == 0
+
+    # No drift in totals.
+    total = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+    assert total == 3
+    sections_total = conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0]
+    assert sections_total == 3
+    conn.close()
+
+
+def test_ingest_pages_force_clears_orphan_sections(tmp_path: Path) -> None:
+    """``--force`` must delete textbook_sections rows for the source
+    BEFORE re-inserting; otherwise the unique (source_file, section_title)
+    constraint hits and the helper skips section creation, leaving
+    chunks unlinked.
+
+    Regression guard: this is the failure mode #1982 was filed against
+    when ingesters wrote chunks but no sections.
+    """
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = pohribnyi.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    pohribnyi.ingest_pages(conn, pages)
+    conn.commit()
+    # Simulate the legacy state: stale sections that pre-date this
+    # ingester (the situation #1982 backfilled).
+    inserted, _ = pohribnyi.ingest_pages(conn, pages, force=True)
+    conn.commit()
+
+    assert inserted == 3
+    orphan_chunks = conn.execute(
+        "SELECT COUNT(*) FROM textbooks "
+        "WHERE source_file = ? AND parent_section_id IS NULL",
+        (pohribnyi.SOURCE_FILE,),
+    ).fetchone()[0]
+    assert orphan_chunks == 0, "force must re-link sections, not leave orphans"
+    conn.close()


### PR DESCRIPTION
## Summary

- **C4 corpus-completion task complete.** Last item from the 2026-05-14 corpus-completion night brief.
- Mykola Pohribnyi's 1992 Ukrainian-pronunciation textbook (28 pp., Dnipropetrovsk "TRANSFORM" Agency, distributed with LPs/audio cassettes) was shipped as a 51 MB image-based CorelDRAW PDF with no embedded text.
- OCR performed out-of-band with Tesseract 5.5.2 + `-l ukr` on 300 dpi PNGs from `pdftoppm`; concatenated output lives in `docs/references/private/` (gitignored).
- Page-grained chunking (28 chunks = 28 pages = 28 sections) because the book is structurally cohesive prose-with-transcription rather than a true alphabetical dictionary, and OCR artifacts on dense IPA-bracket notation make reliable headword-boundary detection brittle. Per-page is the natural retrieval unit at this size; per-headword refinement remains possible later.
- Reuses the `_section_coverage` helper from PR #1982 so every chunk lands with a non-NULL `parent_section_id`. Sentinel `grade=0` for non-school reference material.

## Deterministic DB evidence (canonical `data/sources.db`)

**BEFORE:**

\`\`\`
textbooks: 25517
textbooks_fts: 25517      ← in sync ✓
textbook_sections: 6811
pohribnyi chunks: 0
pohribnyi sections: 0
\`\`\`

**AFTER:**

\`\`\`
textbooks: 25545          (+28)
textbooks_fts: 25545      (+28, still in sync ✓)
textbook_sections: 6839   (+28)
pohribnyi chunks: 28
pohribnyi sections: 28
pohribnyi orphan chunks: 0   ← all chunks section-linked ✓
\`\`\`

**Sample chunks:**

\`\`\`
chunk_id=pohribnyi-ukrainska-literaturna-vymova-1992_p01
  title='Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. 1'
  snippet='2\\n\\nУКРАЇНСЬКА\\nЛІТЕРАТУРНА\\nВИМОВА\\n\\nМИКОЛА ПОГРІБНИЙ\\n…'
chunk_id=pohribnyi-ukrainska-literaturna-vymova-1992_p02
  title='Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. 2'
  snippet='Микола Іванович Погрібний -- лексикограф, автор «Словника наголосів» та «Орфоепі…'
chunk_id=pohribnyi-ukrainska-literaturna-vymova-1992_p03
  title='Pohribnyi 1992 (Ukrainian Literary Pronunciation), p. 3'
  snippet='ПЕРЕДМОВА\\n\\nНавчальний посібник "Українська літературна вимова" розрахований…'
\`\`\`

**Retrieval probes:**

- FTS `наголо*` (stress) → returns `p02/p04/p05`.
- Section-level query for `дзвінкий приголосний` (voiced consonant) → returns `p13`.

Both base FTS and section-level retrieval paths work, confirming the `_section_coverage` linkage is correct.

**Pre-ingest backup retained:** `data/sources.db.bak-20260514-142842-pre-pohribnyi-ingest` (1.5 GB).

## Architectural notes

- The page-grained design will likely want refinement once the textbook_grounding gate (m20 #1975) starts consulting Pohribnyi-style sources — at that point per-page citations could be too coarse for `verify_quote` purposes. The OCR text is preserved on disk (gitignored) so a re-chunk run is cheap.
- OCR has the usual IPA-bracket artifacts (`[е]` reads as `Ге)`, `[й]` as `Гй]`, etc.) because Cyrillic + square-bracket transcription is one of Tesseract's known weak spots. Future improvement: post-process bracket sequences during ingest if retrieval quality proves insufficient.

## Test plan

- [x] `pytest tests/test_pohribnyi_pronunciation_ingest.py` — 9/9 pass
- [x] Full ingest-suite regression (`tests/test_*_ingest.py + test_section_coverage.py`) — 87/87 pass
- [x] `ruff check` clean (1 auto-fix applied)
- [x] Live ingest against canonical DB — BEFORE/AFTER/SAMPLE evidence above
- [x] FTS in-sync check post-ingest: 25,545 = 25,545 ✓
- [x] Section orphan check post-ingest: 0 ✓
- [x] Both FTS and section-level retrieval probes return Pohribnyi content

🤖 Generated with [Claude Code](https://claude.com/claude-code)