### PR TITLE
feat(corpus): ingest full Антоненко-Давидович «Як ми говоримо» (#1663 — page-grained)

### DIFF
--- a/scripts/ingest/antonenko_full_book_ingest.py
+++ b/scripts/ingest/antonenko_full_book_ingest.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Ingest the FULL text of Борис Антоненко-Давидович *«Як ми говоримо»*
+into ``data/sources.db`` textbooks table (page-grained).
+
+Context
+-------
+
+The project already has 342 structured entries from this book in the
+``style_guide`` table (used by ``mcp__sources__search_style_guide`` for
+calque / Russianism lookups by headword). Those entries cover the
+high-value usage notes but represent only ~50% of the actual book —
+foreword, afterword, section preambles, and many discussion paragraphs
+that don't fit the "one headword, one warning" entry pattern are
+absent. Issue #1663 tracked the completion gap.
+
+Closing the gap by extracting MORE structured entries from the PDF/HTML
+turned out to be a real parser engineering problem (the HTML source
+only contains 279 entries; the PDF text via the V7
+``dictionary_ingest.py`` parser produces 170; neither path improves on
+the 342 already present). The book itself has prose sections,
+multi-word lemmas, and entry-less commentary that don't reliably fit
+the dictionary-row shape.
+
+This ingester takes the simpler-and-more-useful path: drop the FULL
+book content into the textbooks table as page-grained chunks (169
+chunks, one per page). That makes every word of the book searchable
+via ``mcp__sources__search_text`` while the existing 342 ``style_guide``
+entries continue to serve ``search_style_guide`` for headword lookups.
+
+Both retrieval surfaces remain in service:
+- ``search_style_guide`` — 342 structured entries (existing, untouched)
+- ``search_text`` over textbooks — full 169-page book (new)
+
+Schema fit
+----------
+- 169 chunks (one per page) into ``textbooks``
+- 169 sections (1:1 chunk:section) into ``textbook_sections`` via the
+  shared ``_section_coverage`` helper (PR #1982 / #1986 pattern)
+- ``author = 'Borys Antonenko-Davydovych'``
+- ``source_file = 'antonenko-davydovych-yak-my-hovorymo'``
+- ``title`` = ``Antonenko-Davydovych «Як ми говоримо», p. N``
+- ``text`` = the page body (pdftotext output, untouched)
+- ``grade`` = ``''`` (sentinel 0 used by sections)
+- ``chunk_id`` = ``{source_file}_p{NNN}``
+
+Idempotent on chunk_id. ``--force`` clears both ``textbooks`` and
+``textbook_sections`` rows for the source before re-insert.
+
+Source preparation (one-time, out-of-band)
+------------------------------------------
+The PDF is text-extractable (mPDF-produced; no OCR needed):
+
+    pdftotext docs/references/private/antonenko-davydovych-yak-my-hovorymo-1991.pdf \\
+              docs/references/private/antonenko-davydovych-yak-my-hovorymo-1991.txt
+
+pdftotext emits ``\\f`` form-feed between pages. This ingester splits
+on form-feed and assigns each non-empty part a sequential page number.
+
+Usage
+-----
+    .venv/bin/python -m scripts.ingest.antonenko_full_book_ingest
+    .venv/bin/python -m scripts.ingest.antonenko_full_book_ingest --dry-run
+    .venv/bin/python -m scripts.ingest.antonenko_full_book_ingest --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.ingest._section_coverage import (
+    LessonSection,
+    ensure_section_schema,
+    link_lesson_sections,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
+
+SOURCE_FILE = "antonenko-davydovych-yak-my-hovorymo"
+TXT_FILENAME = "antonenko-davydovych-yak-my-hovorymo-1991.txt"
+AUTHOR = "Borys Antonenko-Davydovych"
+EXPECTED_PAGES = 169
+
+
+@dataclass
+class Page:
+    number: int
+    body: str = ""
+
+    def render(self) -> str:
+        """Render the page chunk text. Strip leading and trailing blank
+        lines; preserve internal blanks (paragraph separators)."""
+        lines = self.body.splitlines()
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        while lines and not lines[-1].strip():
+            lines.pop()
+        return "\n".join(lines) + "\n" if lines else ""
+
+
+def parse_book(txt_path: Path) -> list[Page]:
+    """Split the pdftotext output on form-feed. Each non-empty part is
+    a page assigned a sequential 1-based number. Empty leading or
+    trailing parts (split artifacts) are dropped.
+
+    Raises FileNotFoundError if ``txt_path`` doesn't exist.
+    """
+    if not txt_path.exists():
+        raise FileNotFoundError(f"Source not found: {txt_path}")
+
+    raw = txt_path.read_text(encoding="utf-8")
+    parts = raw.split("\f")
+    pages: list[Page] = []
+    for body in parts:
+        page_number = len(pages) + 1
+        page = Page(number=page_number, body=body)
+        if not page.render():
+            continue  # empty page (e.g. trailing form-feed) — no number assigned
+        pages.append(page)
+    return pages
+
+
+def ingest_pages(
+    conn: sqlite3.Connection,
+    pages: list[Page],
+    *,
+    force: bool = False,
+) -> tuple[int, int]:
+    """Insert each page as one row in textbooks + one row in
+    textbook_sections (1:1). Returns (inserted, skipped).
+
+    Idempotent on ``chunk_id``. ``force=True`` DELETEs existing rows
+    for this source_file (both textbook_sections + textbooks) before
+    re-insert.
+    """
+    ensure_section_schema(conn)
+
+    cur = conn.cursor()
+    existing_ids: set[str] = set()
+    if force:
+        cur.execute(
+            "DELETE FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        )
+        cur.execute(
+            "DELETE FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        )
+    else:
+        rows = cur.execute(
+            "SELECT chunk_id FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchall()
+        existing_ids = {r[0] for r in rows}
+
+    inserted = 0
+    skipped = 0
+    batch: list[tuple] = []
+    new_sections: list[LessonSection] = []
+    for page in pages:
+        chunk_id = f"{SOURCE_FILE}_p{page.number:03d}"
+        if chunk_id in existing_ids:
+            skipped += 1
+            continue
+        text = page.render()
+        title = f"Antonenko-Davydovych «Як ми говоримо», p. {page.number}"
+        batch.append(
+            (chunk_id, title, text, SOURCE_FILE, "", AUTHOR, len(text))
+        )
+        new_sections.append(
+            LessonSection(
+                chunk_id=chunk_id,
+                section_title=title,
+                section_number=str(page.number),
+                full_text=text,
+            )
+        )
+        inserted += 1
+
+    if batch:
+        cur.executemany(
+            """INSERT INTO textbooks
+                  (chunk_id, title, text, source_file, grade, author, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            batch,
+        )
+        link_lesson_sections(
+            conn,
+            source_file=SOURCE_FILE,
+            sections=new_sections,
+        )
+
+    return inserted, skipped
+
+
+def _run(*, db_path: Path, dry_run: bool, force: bool) -> int:
+    txt_path = REFERENCES_DIR / TXT_FILENAME
+    if not txt_path.exists():
+        print(
+            f"❌ Source file not found: {txt_path}\n"
+            "   Generate via:\n"
+            "   pdftotext docs/references/private/"
+            "antonenko-davydovych-yak-my-hovorymo-1991.pdf {txt_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"\n📚 Parsing {TXT_FILENAME}")
+    pages = parse_book(txt_path)
+    print(f"   parsed pages: {len(pages)} (expected: {EXPECTED_PAGES})")
+    if pages:
+        body_chars = sum(len(p.render()) for p in pages)
+        print(f"   page range: {pages[0].number}..{pages[-1].number}")
+        print(f"   total body chars: {body_chars:,}")
+    if len(pages) != EXPECTED_PAGES:
+        print(
+            f"   ⚠️  parsed page count {len(pages)} differs from expected "
+            f"{EXPECTED_PAGES} — inspect before proceeding.",
+            file=sys.stderr,
+        )
+
+    if dry_run:
+        print("\n--- DRY-RUN sample (first / middle / last page) ---")
+        if not pages:
+            print("   (no pages parsed)")
+            return 0
+        samples = [pages[0], pages[len(pages) // 2], pages[-1]]
+        for sample in samples:
+            print(f"\n### page #{sample.number} ###")
+            text = sample.render()
+            print(text[:400] + ("…" if len(text) > 400 else ""))
+        return 0
+
+    print(f"\n🗃️  Writing to {db_path}")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        before = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        total_before = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        sections_before = conn.execute(
+            "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        print(
+            f"   BEFORE: {before} chunks for {SOURCE_FILE!r} "
+            f"({sections_before} sections; textbooks total: {total_before:,})"
+        )
+
+        inserted, skipped = ingest_pages(conn, pages, force=force)
+        conn.commit()
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        total_after = conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0]
+        sections_after = conn.execute(
+            "SELECT COUNT(*) FROM textbook_sections WHERE source_file = ?",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+        orphans = conn.execute(
+            "SELECT COUNT(*) FROM textbooks "
+            "WHERE source_file = ? AND parent_section_id IS NULL",
+            (SOURCE_FILE,),
+        ).fetchone()[0]
+
+        print(f"   inserted: {inserted}, skipped: {skipped}")
+        print(
+            f"   AFTER: {after} chunks for {SOURCE_FILE!r} "
+            f"({sections_after} sections; textbooks total: {total_after:,}, "
+            f"delta +{total_after - total_before})"
+        )
+        print(f"   section-orphan chunks for {SOURCE_FILE!r}: {orphans} (expected 0)")
+
+        sample = conn.execute(
+            """SELECT chunk_id, title, char_count, substr(text, 1, 80) AS snippet
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id LIMIT 3""",
+            (SOURCE_FILE,),
+        ).fetchall()
+        print("\n--- AFTER sample rows ---")
+        for row in sample:
+            print(f"  chunk_id={row[0]}")
+            print(f"    title={row[1]!r}")
+            print(f"    char_count={row[2]}")
+            print(f"    snippet={row[3]!r}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ingest the full text of Антоненко-Давидович «Як ми говоримо» "
+            "(169 pages → 169 chunks → 169 sections). Complements the existing "
+            "342 structured style_guide entries."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse + report, do not write to DB.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-insert: DELETE existing rows for this source_file before INSERT.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Override target DB path (testing only).",
+    )
+    args = parser.parse_args(argv)
+    return _run(db_path=args.db, dry_run=args.dry_run, force=args.force)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_antonenko_full_book_ingest.py
+++ b/tests/test_antonenko_full_book_ingest.py
@@ -1,0 +1,237 @@
+"""Tests for scripts/ingest/antonenko_full_book_ingest.py.
+
+Mirrors the test shape of test_pohribnyi_pronunciation_ingest.py — the
+two ingesters share the page-grained pdftotext-output pattern and the
+``_section_coverage`` linkage. These tests exercise the form-feed split
+on a synthetic fixture, the round-trip with section coverage, idempotency,
+and the ``--force`` deletion path.
+
+The full Antonenko book is exercised in the live ingest run captured in
+the PR body per the determinism rule.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.ingest import antonenko_full_book_ingest as antonenko
+
+# pdftotext emits page content directly followed by ``\f`` between pages,
+# with a single trailing ``\f`` after the last page. The fixture mirrors
+# that real-world shape, NOT the Pohribnyi shape (which had a leading
+# form-feed because we generated it manually with a different pipeline).
+FIXTURE_3_PAGES = (
+    "Як ми говоримо\n"
+    "Борис Антоненко-Давидович\n"
+    "ПЕРЕДНЄ СЛОВО\n"
+    "\f"
+    'Мова – така ж давня, як і свідомість.\n'
+    "\n"
+    'Це окремий абзац.\n'
+    "\f"
+    "ІМЕННИКИ\n"
+    "Називний відмінок у складеному присудку\n"
+    "\f"
+)
+
+
+FIXTURE_WITH_EMPTY_PAGE = (
+    "Page A body.\n"
+    "\f"
+    "\f"
+    "Page B body.\n"
+    "\f"
+)
+
+
+def _write_fixture(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# --- Parser ---------------------------------------------------------------
+
+
+def test_parse_book_assigns_sequential_page_numbers(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = antonenko.parse_book(txt)
+    assert [p.number for p in pages] == [1, 2, 3]
+
+
+def test_parse_book_drops_empty_pages(tmp_path: Path) -> None:
+    """An empty form-feed segment (e.g. trailing \\f or stray double \\f)
+    must not produce a phantom chunk."""
+    txt = _write_fixture(tmp_path, "empty.txt", FIXTURE_WITH_EMPTY_PAGE)
+    pages = antonenko.parse_book(txt)
+    assert [p.number for p in pages] == [1, 2]
+    assert "Page A body." in pages[0].render()
+    assert "Page B body." in pages[1].render()
+
+
+def test_parse_book_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        antonenko.parse_book(tmp_path / "missing.txt")
+
+
+def test_page_render_strips_leading_and_trailing_blanks(tmp_path: Path) -> None:
+    """A page that's all blanks renders as empty string; non-blank pages
+    drop their leading/trailing blank lines while keeping content."""
+    fixture = "\n\n  Real content.  \n\n"
+    txt = _write_fixture(tmp_path, "p.txt", fixture)
+    pages = antonenko.parse_book(txt)
+    assert len(pages) == 1
+    rendered = pages[0].render()
+    assert rendered.startswith("  Real content."), rendered
+    assert rendered.endswith("\n")
+
+
+def test_page_render_preserves_internal_blanks(tmp_path: Path) -> None:
+    fixture = "Paragraph A.\n\nParagraph B.\n"
+    txt = _write_fixture(tmp_path, "p.txt", fixture)
+    pages = antonenko.parse_book(txt)
+    assert "Paragraph A.\n\nParagraph B." in pages[0].render()
+
+
+# --- DB round trip --------------------------------------------------------
+
+
+def _make_textbooks_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+        );
+        """
+    )
+    return conn
+
+
+def test_ingest_pages_round_trip_with_section_coverage(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = antonenko.parse_book(txt)
+    assert len(pages) == 3
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    inserted, skipped = antonenko.ingest_pages(conn, pages)
+    conn.commit()
+    assert inserted == 3
+    assert skipped == 0
+
+    chunks = list(
+        conn.execute(
+            """SELECT chunk_id, title, source_file, author, char_count,
+                      parent_section_id
+                 FROM textbooks WHERE source_file = ? ORDER BY chunk_id""",
+            (antonenko.SOURCE_FILE,),
+        )
+    )
+    assert [c[0] for c in chunks] == [
+        f"{antonenko.SOURCE_FILE}_p001",
+        f"{antonenko.SOURCE_FILE}_p002",
+        f"{antonenko.SOURCE_FILE}_p003",
+    ]
+    assert chunks[0][1] == "Antonenko-Davydovych «Як ми говоримо», p. 1"
+    assert chunks[2][1] == "Antonenko-Davydovych «Як ми говоримо», p. 3"
+    assert all(c[3] == antonenko.AUTHOR for c in chunks)
+    assert all(c[4] > 0 for c in chunks)
+    # CRITICAL: every chunk must be linked to a section row.
+    assert all(c[5] is not None for c in chunks)
+
+    sections = list(
+        conn.execute(
+            """SELECT section_id, grade, section_title, section_number, chunk_count
+                 FROM textbook_sections WHERE source_file = ? ORDER BY section_id""",
+            (antonenko.SOURCE_FILE,),
+        )
+    )
+    assert len(sections) == 3
+    assert all(s[1] == 0 for s in sections)  # non-school sentinel grade
+    assert [s[3] for s in sections] == ["1", "2", "3"]
+    assert all(s[4] == 1 for s in sections)
+
+    section_ids = {s[0] for s in sections}
+    assert all(c[5] in section_ids for c in chunks)
+    conn.close()
+
+
+def test_ingest_pages_uses_three_digit_page_number(tmp_path: Path) -> None:
+    """169 pages — the chunk_id padding must be 3 digits so chunks sort
+    correctly. Regression check: 2-digit padding would produce
+    ``_p10`` < ``_p2`` under string sort."""
+    # Synthesize 12 pages so the padding-needs gap is exercised.
+    fixture = "\f".join(f"Body of page {i}\n" for i in range(1, 13)) + "\f"
+    txt = _write_fixture(tmp_path, "many.txt", fixture)
+    pages = antonenko.parse_book(txt)
+    assert len(pages) == 12
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    antonenko.ingest_pages(conn, pages)
+    conn.commit()
+    chunk_ids = [
+        r[0]
+        for r in conn.execute(
+            "SELECT chunk_id FROM textbooks WHERE source_file = ? ORDER BY chunk_id",
+            (antonenko.SOURCE_FILE,),
+        )
+    ]
+    # Sorted string order matches numeric page order — three-digit padding works.
+    assert chunk_ids == [
+        f"{antonenko.SOURCE_FILE}_p{i:03d}" for i in range(1, 13)
+    ]
+    conn.close()
+
+
+def test_ingest_pages_idempotent(tmp_path: Path) -> None:
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = antonenko.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    first = antonenko.ingest_pages(conn, pages)
+    conn.commit()
+    second = antonenko.ingest_pages(conn, pages)
+    conn.commit()
+    assert first == (3, 0)
+    assert second == (0, 3)
+    assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 3
+    assert conn.execute("SELECT COUNT(*) FROM textbook_sections").fetchone()[0] == 3
+    conn.close()
+
+
+def test_ingest_pages_force_clears_orphan_sections(tmp_path: Path) -> None:
+    """``--force`` must DELETE existing textbook_sections rows for the
+    source before re-inserting. Without that step, the unique
+    (source_file, section_title) constraint hits, the helper silently
+    skips section creation, and chunks land orphaned. Regression guard
+    against the failure mode #1982 was filed for."""
+    txt = _write_fixture(tmp_path, "ok.txt", FIXTURE_3_PAGES)
+    pages = antonenko.parse_book(txt)
+
+    db_path = tmp_path / "sources.db"
+    conn = _make_textbooks_db(db_path)
+    antonenko.ingest_pages(conn, pages)
+    conn.commit()
+    inserted, _ = antonenko.ingest_pages(conn, pages, force=True)
+    conn.commit()
+    assert inserted == 3
+    orphan = conn.execute(
+        "SELECT COUNT(*) FROM textbooks "
+        "WHERE source_file = ? AND parent_section_id IS NULL",
+        (antonenko.SOURCE_FILE,),
+    ).fetchone()[0]
+    assert orphan == 0
+    conn.close()


### PR DESCRIPTION
## Summary

- Closes the **#1663 Antonenko-Davydovych completion gap** by making the full book content searchable via `mcp__sources__search_text`.
- **Complements (not replaces)** the existing 342 structured `style_guide` entries — `mcp__sources__search_style_guide` continues to work unchanged for per-headword calque/Russianism lookups.
- Page-grained ingest (169 chunks = 169 pages = 169 sections) using the same pattern shipped in PR #1986 (Pohribnyi) and the `_section_coverage` helper from PR #1982 (Ohoiko + ULP).

## Why page-grained, not more structured entries

The existing 342 entries in `style_guide` cover the high-value per-headword usage notes but are roughly 50% of the actual book. Foreword, afterword, section preambles, and many discussion paragraphs don't fit the one-headword-one-warning shape.

I evaluated three alternatives to close the gap structurally and rejected all three:

| Approach | Entries produced | Verdict |
|---|---|---|
| Re-run `prepare_antonenko.py` on the HTML source | 279 (regression vs 342) | The HTML source itself only yields 279 entries |
| Re-run V7 `dictionary_ingest.py --source antonenko` on the PDF text | 170 (regression) | V7 parser's blank-line heuristic misses entries embedded in continuous prose |
| Write a custom entry-detection parser for the PDF text | 400-700 (estimate) | Substantial engineering — multi-word lemmas, comma-separated word lists, and prose-only sections resist consistent heuristics |

Page-grained is the simpler-and-more-useful path: every word of the 169-page book is searchable, and the structured headword-keyed lookups are preserved.

## Canonical DB evidence (live run against `data/sources.db`)

**BEFORE:**

```
textbooks: 25545
textbooks_fts: 25545      ← in sync ✓
textbook_sections: 6839
antonenko-davydovych-yak-my-hovorymo chunks: 0
antonenko-davydovych-yak-my-hovorymo sections: 0
style_guide: 342          ← existing structured entries
```

**AFTER:**

```
textbooks: 25714          (+169)
textbooks_fts: 25714      (+169, still in sync ✓)
textbook_sections: 7008   (+169)
antonenko chunks: 169
antonenko sections: 169
antonenko orphan chunks: 0     ← all chunks section-linked ✓
style_guide: 342               ← unchanged, search_style_guide preserved
```

**Total body chars indexed:** 504,299 across 169 pages.

**Sample chunks:**

- `_p001` — `ПЕРЕДНЄ СЛОВО` (foreword opener)
- `_p085` — discussion of `позаяк`, `крокувати` calques
- `_p169` — closing reflection

**Retrieval probes:**

- FTS `іменник` → returns `p010/p011/p013` ✓
- Section-level query `кальк` (calque) → returns `p42/p55/p58` — discussions absent from `style_guide`'s per-headword entries

Pre-ingest backup retained: `data/sources.db.bak-20260514-150259-pre-antonenko-full` (1.5 GB).

## Test plan

- [x] 9 new pytest tests; full ingest-suite green
- [x] `ruff check` clean
- [x] Live ingest against canonical DB with BEFORE/AFTER/SAMPLE evidence above
- [x] FTS in-sync post-ingest: 25,714 = 25,714 ✓
- [x] Section orphan check post-ingest: 0 ✓
- [x] Both FTS and section-level retrieval probes return Antonenko content
- [x] `style_guide` row count unchanged (342 → 342, search_style_guide preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)