### PR TITLE
fix(tests): align 2 stale assertions with current template wording (#1958)

### DIFF
--- a/tests/build/test_a1_20_exemplar.py
+++ b/tests/build/test_a1_20_exemplar.py
@@ -15,7 +15,7 @@ def test_a1_20_plan_context_matches_phase_4_contract() -> None:
 
     assert context["LEVEL"] == "A1"
     assert context["MODULE_NUM"] == "20"
-    assert "TARGET: 15-35% Ukrainian." in context["IMMERSION_RULE"]
+    assert "STRUCTURAL TARGETS" in context["IMMERSION_RULE"]
     assert "classify" in context["FORBIDDEN_ACTIVITY_TYPES"]
     assert "select" in context["FORBIDDEN_ACTIVITY_TYPES"]
     assert "fill-in" in context["ALLOWED_ACTIVITY_TYPES"]

--- a/tests/build/test_adr_008_invariants.py
+++ b/tests/build/test_adr_008_invariants.py
@@ -41,7 +41,7 @@ def test_no_writer_rewrite_in_correction() -> None:
         / "linear-writer-correction.md"
     ).read_text(encoding="utf-8")
 
-    assert "modify in place via append/insert, never re-author or regenerate" in template
+    assert "Modify in place via append/insert. Never re-author or regenerate." in template
     for phrase in ("regenerate", "rewrite", "produce again", "start over"):
         assert phrase in template
 


### PR DESCRIPTION
## Summary

Two pre-existing red tests on main, blocking dispatched workers per #1958. Both are 1-line assertion drift from recent feature PRs.

| Test | Old assertion | New assertion |
|---|---|---|
| `test_a1_20_plan_context_matches_phase_4_contract` | `\"TARGET: 15-35% Ukrainian.\" in context[\"IMMERSION_RULE\"]` | `\"STRUCTURAL TARGETS\" in context[\"IMMERSION_RULE\"]` |
| `test_no_writer_rewrite_in_correction` | lowercase `\"modify in place via append/insert, never re-author or regenerate\"` | `\"Modify in place via append/insert. Never re-author or regenerate.\"` (matches current template) |

## Verification

\`\`\`
$ .venv/bin/pytest tests/build/test_a1_20_exemplar.py tests/build/test_adr_008_invariants.py
============================== 7 passed in 0.47s ==============================
\`\`\`

No production-code change. Closes #1958.

## Test plan
- [x] Both previously-red tests now green
- [x] Other 5 tests in the same files still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)