### PR TITLE
feat(audit): add 17 UA-GEC-derived calque patterns to Russianism detector

### DIFF
--- a/scripts/audit/checks/russicism_detection.py
+++ b/scripts/audit/checks/russicism_detection.py
@@ -159,10 +159,142 @@ _RUSSICISMS: list[dict] = [
     },
 ]
 
+# ---------------------------------------------------------------------------
+# Calque patterns mined from UA-GEC v2 F/Calque annotations
+#
+# Source: github.com/grammarly/ua-gec (CC-BY-4.0, Syvokon et al., UNLP 2023).
+# Each pattern below appears ≥5 times in 2,397 human-validated F/Calque
+# annotations from professional Ukrainian proofreaders (two annotators per
+# document). Patterns selected for LOW false-positive risk: discourse
+# markers, fixed expressions, and lexical Russianisms with no legitimate
+# Ukrainian use in the matched form.
+#
+# Higher-frequency patterns from UA-GEC that were intentionally NOT added
+# here due to context-dependence or legitimate dual usage:
+#   - доктор → лікар (academic title vs. medical context disambiguation)
+#   - даний → цей (acceptable as participle in math/scientific contexts)
+#   - наступні → такі (валід у багатьох контекстах: "наступні дні")
+#   - задача → завдання (broadly used; pedagogical-judgment territory)
+#   - дозволяє → дає змогу (correct in "permits" sense)
+# Full mining analysis: docs/decisions or PR description.
+# ---------------------------------------------------------------------------
+_RUSSICISMS_FROM_UA_GEC: list[dict] = [
+    # --- Discourse-marker calques (universal: no legitimate dual usage) ---
+    {
+        "pattern": r"\bтаким\s+чином\b",
+        "term": "таким чином",
+        "fix": "отже / у такий спосіб",
+        "note": "RU 'таким образом' calque (UA-GEC top F/Calque, 25× occurrences)",
+    },
+    {
+        "pattern": r"\bтак\s+як\b",
+        "term": "так як",
+        "fix": "оскільки",
+        "note": "RU 'так как' calque",
+    },
+    {
+        "pattern": r"\bв\s+цілому\b",
+        "term": "в цілому",
+        "fix": "загалом",
+        "note": "RU 'в целом' calque",
+    },
+    {
+        "pattern": r"\bв\s+першу\s+чергу\b",
+        "term": "в першу чергу",
+        "fix": "передусім / насамперед",
+        "note": "RU 'в первую очередь' calque",
+    },
+    {
+        "pattern": r"\bз\s+(?:іншої|однієї)\s+сторони\b",
+        "term": "з іншої / однієї сторони",
+        "fix": "з іншого / одного боку",
+        "note": "RU 'с другой / одной стороны' discourse calque",
+    },
+    {
+        # Discourse-marker `значить,` — verbal `значить` (= 'means') is fine
+        "pattern": r"\bзначить\b(?=\s*,)",
+        "term": "значить, (як вступне слово)",
+        "fix": "отже / тобто",
+        "note": "RU 'значит,' as parenthetical calque (verbal 'значить' is correct)",
+    },
+    # --- Lexical Russianisms (VESUM-verified absent or definitely calque) ---
+    {
+        "pattern": r"\bспівпада(?:є|ють|ло|ла|ли|в|ала)\b",
+        "term": "співпадати",
+        "fix": "збігатися",
+        "note": "RU 'совпадать' calque — VESUM-verified absent",
+    },
+    {
+        "pattern": r"\bбормот(?:ати|ів|ала|али|ять|ить)\b",
+        "term": "бормотати",
+        "fix": "бурмотіти",
+        "note": "RU 'бормотать' phonology (о→у) — VESUM-verified absent",
+    },
+    {
+        "pattern": r"\bбуфетчик[аеуіою]?\b",
+        "term": "буфетчик",
+        "fix": "буфетник",
+        "note": "RU agentive suffix '-чик' on Ukrainian root",
+    },
+    {
+        "pattern": r"\bприйшлось\b",
+        "term": "прийшлось",
+        "fix": "довелося",
+        "note": "RU 'пришлось' calque (impersonal past)",
+    },
+    {
+        "pattern": r"\bповезе(?:ться)?\b",
+        "term": "повезе(ться)",
+        "fix": "пощастить",
+        "note": "RU 'повезёт' calque (luck sense)",
+    },
+    {
+        "pattern": r"\bвідправ(?:ився|илась|илися|ились)\b",
+        "term": "відправився",
+        "fix": "вирушив",
+        "note": "RU 'отправился' reflexive — UK uses 'вирушив' for departure",
+    },
+    {
+        "pattern": r"\bвідношення\b",
+        "term": "відношення",
+        "fix": "стосунок / ставлення",
+        "note": "RU 'отношение' calque (relationship / attitude senses)",
+    },
+    # --- Fixed-expression calques ---
+    {
+        "pattern": r"\bроби(?:в|ла|ли|ть)\s+вигляд\b",
+        "term": "робив вигляд",
+        "fix": "вдавав",
+        "note": "RU 'делал вид' fixed-expression calque",
+    },
+    {
+        "pattern": r"\bна\s+фоні\b",
+        "term": "на фоні",
+        "fix": "на тлі",
+        "note": "RU 'на фоне' calque",
+    },
+    {
+        "pattern": r"\bсправа\s+[ув]\s+тому\b",
+        "term": "справа в тому",
+        "fix": "річ у тому",
+        "note": "RU 'дело в том' fixed-expression calque",
+    },
+    # --- Numerical-sense calque ---
+    {
+        # `пару` as a numeral ("a couple of X") — Russian usage.
+        # `пару` as a noun ("a pair of shoes") is correct UK; lookahead
+        # for temporal nouns isolates the numerical sense.
+        "pattern": r"\bпару\s+(?:днів|годин|хвилин|секунд|тижнів|місяців|років|разів)\b",
+        "term": "пару (як числівник)",
+        "fix": "кілька",
+        "note": "RU 'пару дней / часов' numerical calque (UK 'пара' = noun only)",
+    },
+]
+
 # Pre-compile patterns
 _COMPILED_RUSSICISMS = [
     {**r, "_compiled": re.compile(r["pattern"], re.IGNORECASE)}
-    for r in _RUSSICISMS
+    for r in (_RUSSICISMS + _RUSSICISMS_FROM_UA_GEC)
 ]
 
 # Tracks where Russicisms might appear in quoted historical sources

--- a/tests/test_russicism_detection.py
+++ b/tests/test_russicism_detection.py
@@ -225,3 +225,124 @@ class TestCaseInsensitivity:
         content = _wrap("ВООБЩЕ це дивно.")
         violations = check_russicisms(content)
         assert len(violations) == 1
+
+
+# =============================================================================
+# UA-GEC CALQUE PATTERNS — added 2026-05-14 from UA-GEC v2 F/Calque mining
+# (CC-BY-4.0, github.com/grammarly/ua-gec)
+# =============================================================================
+
+class TestUaGecCalquePatterns:
+    """Each new pattern: positive case + negative (legitimate use) where applicable."""
+
+    # --- Discourse-marker calques ---
+
+    def test_таким_чином_caught(self):
+        violations = check_russicisms(_wrap("Таким чином, ми розглянули проблему."))
+        assert violations and "таким чином" in violations[0]["issue"]
+
+    def test_так_як_caught(self):
+        violations = check_russicisms(_wrap("Це питання так як і інші не вирішено."))
+        assert violations and "так як" in violations[0]["issue"]
+
+    def test_в_цілому_caught(self):
+        violations = check_russicisms(_wrap("В цілому ситуація стабільна."))
+        assert violations and "в цілому" in violations[0]["issue"]
+
+    def test_в_першу_чергу_caught(self):
+        violations = check_russicisms(_wrap("В першу чергу слід згадати про це."))
+        assert violations and "в першу чергу" in violations[0]["issue"]
+
+    def test_з_іншої_сторони_caught(self):
+        violations = check_russicisms(_wrap("З іншої сторони, це не зовсім так."))
+        assert violations and "сторони" in violations[0]["issue"]
+
+    def test_з_однієї_сторони_caught(self):
+        violations = check_russicisms(_wrap("З однієї сторони, це добре."))
+        assert violations and "сторони" in violations[0]["issue"]
+
+    def test_значить_discourse_marker_caught(self):
+        """`Значить,` as parenthetical — calque."""
+        violations = check_russicisms(_wrap("Значить, ми маємо рацію."))
+        assert violations and "значить" in violations[0]["issue"]
+
+    def test_значить_verbal_use_clean(self):
+        """`значить` as verb (= 'means') — correct UK, must NOT flag."""
+        violations = check_russicisms(_wrap("Це слово багато значить для мене."))
+        assert violations == []
+
+    # --- Lexical Russianisms ---
+
+    def test_співпадають_caught(self):
+        violations = check_russicisms(_wrap("Числа співпадають точно."))
+        assert violations and "співпада" in violations[0]["issue"]
+
+    def test_бормотати_caught(self):
+        violations = check_russicisms(_wrap("Він почав бормотати щось незрозуміле."))
+        assert violations and "бормот" in violations[0]["issue"]
+
+    def test_буфетчик_caught(self):
+        violations = check_russicisms(_wrap("Буфетчик подав каву."))
+        assert violations and "буфетчик" in violations[0]["issue"]
+
+    def test_прийшлось_caught(self):
+        violations = check_russicisms(_wrap("Прийшлось довго чекати."))
+        assert violations and "прийшлось" in violations[0]["issue"]
+
+    def test_повезе_caught(self):
+        violations = check_russicisms(_wrap("Може повезе наступного разу."))
+        assert violations and "повезе" in violations[0]["issue"]
+
+    def test_відправився_reflexive_caught(self):
+        """Reflexive `відправився` (= departed) is RU calque."""
+        violations = check_russicisms(_wrap("Він відправився у дорогу рано-вранці."))
+        assert violations and "відправ" in violations[0]["issue"]
+
+    def test_відправляється_transitive_clean(self):
+        """Transitive `відправляється` (= is sent) is correct UK."""
+        violations = check_russicisms(_wrap("Поїзд відправляється о шостій."))
+        assert violations == []
+
+    def test_відношення_caught(self):
+        violations = check_russicisms(_wrap("Це важливе відношення між нами."))
+        assert violations and "відношення" in violations[0]["issue"]
+
+    # --- Fixed-expression calques ---
+
+    def test_робив_вигляд_caught(self):
+        violations = check_russicisms(_wrap("Він робив вигляд, що читає."))
+        assert violations and "робив вигляд" in violations[0]["issue"]
+
+    def test_на_фоні_caught(self):
+        violations = check_russicisms(_wrap("На фоні цих подій настав спокій."))
+        assert violations and "на фоні" in violations[0]["issue"]
+
+    def test_справа_в_тому_caught(self):
+        violations = check_russicisms(_wrap("Справа в тому, що ми не готові."))
+        assert violations and "справа в тому" in violations[0]["issue"]
+
+    def test_справа_у_тому_caught(self):
+        """`Справа у тому` — variant spelling of same calque."""
+        violations = check_russicisms(_wrap("Справа у тому, що часу немає."))
+        assert violations and "справа в тому" in violations[0]["issue"]
+
+    def test_справа_other_sense_clean(self):
+        """`справа` in 'matter / case' sense — correct UK, must NOT flag."""
+        violations = check_russicisms(_wrap("Кожна справа важлива для людей."))
+        assert violations == []
+
+    # --- Numerical-sense calque ---
+
+    def test_пару_numerical_caught(self):
+        """`пару` as numeral ('a couple of days') — RU calque."""
+        violations = check_russicisms(_wrap("Зустрінемось через пару днів."))
+        assert violations and "пару" in violations[0]["issue"]
+
+    def test_пару_numerical_hours_caught(self):
+        violations = check_russicisms(_wrap("Чекай пару годин."))
+        assert violations and "пару" in violations[0]["issue"]
+
+    def test_пару_noun_clean(self):
+        """`пара / пару` as noun ('a pair of shoes') — correct UK."""
+        violations = check_russicisms(_wrap("Купив нову пару взуття."))
+        assert violations == []


### PR DESCRIPTION
## Summary

Mines high-frequency calques from [UA-GEC v2](https://github.com/grammarly/ua-gec) F/Calque annotations (Syvokon et al., UNLP 2023, CC-BY-4.0) and adds them to our deterministic Russianism detector.

Each new pattern appears ≥5 times in the 2,397 human-validated F/Calque entries from professional Ukrainian proofreaders (two annotators per document).

**Coverage:** 22 → 39 deterministic Russianism patterns (~75% increase).

## What's added

`_RUSSICISMS_FROM_UA_GEC` in `scripts/audit/checks/russicism_detection.py`, concatenated into `_COMPILED_RUSSICISMS` alongside the existing list.

| Category | Count | Examples |
|---|---:|---|
| Discourse-marker calques | 6 | `таким чином → отже`, `так як → оскільки`, `в цілому → загалом`, `в першу чергу → передусім`, `з іншої сторони → з іншого боку`, `значить, → отже,` (parenthetical) |
| Lexical Russianisms | 7 | `співпадати → збігатися`, `бормотати → бурмотіти`, `прийшлось → довелося`, `повезе(ться) → пощастить`, `відправився → вирушив`, `відношення → стосунок`, `буфетчик → буфетник` |
| Fixed-expression calques | 3 | `робив вигляд → вдавав`, `на фоні → на тлі`, `справа в тому → річ у тому` |
| Numerical-sense calque | 1 | `пару днів/годин/... → кілька` |

Where possible, lexical Russianisms were verified absent from VESUM (`бормотати`, `співпадають`).

## Conservative scope (what's NOT included, and why)

Higher-frequency UA-GEC patterns intentionally deferred to a follow-up bulk-lookup PR due to context-dependence or legitimate dual usage — flagged in source comment:

- `доктор → лікар` (academic title vs. medical context)
- `даний → цей` (acceptable as participle in math/scientific contexts)
- `наступні → такі` (valid in many contexts)
- `задача → завдання` (broadly used; pedagogical-judgment territory)
- `дозволяє → дає змогу` (correct in "permits" sense)

**Follow-up planned:** PR-2 will add a CSV-backed bulk lookup table covering ~340 additional pairs (256 single-word F/Calque ≥2× + 51 multi-word + selected F/Style) with `severity: info` rather than `warning`, so context-dependent matches surface as suggestions without escalating gates.

## Tests

24 new tests in `TestUaGecCalquePatterns`:
- Positive case for every new pattern
- Negative cases for dual-use words: `значить` verbal use, `відправляється` transitive, `справа` generic sense, `пару` as noun ("pair of shoes")

```
tests/test_russicism_detection.py: 55 passed (31 existing + 24 new)
tests/test_semantic_russianisms.py: 7 passed
```

Full suite (`pytest tests/ --ignore=tests/wiki`): 7,478 passed. Unrelated pre-existing failures (`test_morphological_validator`, `test_scrape_diasporiana`, `test_wiki_channels`) match open issues #1958, #1969, #1975 — not affected by this PR.

## Test plan

- [ ] Pre-commit ruff passes (verified locally)
- [ ] Pre-commit pytest on affected files passes (verified locally)
- [ ] Full pytest sweep — only pre-existing main-branch failures remain
- [ ] CI runs

## Attribution

Source data: [grammarly/ua-gec](https://github.com/grammarly/ua-gec) — CC-BY-4.0. Cited in source comment per license terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)