### PR TITLE
feat(audit): Russianism eval harness v1

### DIFF
--- a/eval/russianism/README.md
+++ b/eval/russianism/README.md
@@ -1,0 +1,9 @@
+# Russianism Eval
+
+This directory contains starter prompts for `scripts/audit/russianism_eval.py`.
+
+Default model names follow the dispatch brief, with one local bridge-name
+substitution: `gemini-3.0-pro` is represented as `gemini-3-pro-preview`.
+The bridge passes Gemini model IDs through to `gemini -m`; the repository has
+current local references for `gemini-3-pro-preview` but none for
+`gemini-3.0-pro`.

--- a/eval/russianism/prompts-v1.yaml
+++ b/eval/russianism/prompts-v1.yaml
@@ -1,0 +1,92 @@
+version: 1
+description: Starter Russianism eval prompts for bridge model comparison.
+prompts:
+  - id: translation_a2_email
+    category: translation
+    prompt_text: |-
+      You are writing for a Ukrainian-language email at A2 level. Translate the
+      following English text into idiomatic standard Ukrainian. Avoid Russianisms.
+
+      "Hello! I am writing to let you know that I will be taking part in the
+      meeting next week. I want to receive the documents in advance so I can
+      prepare. Generally, I think the following points are the most important:
+      budget, timeline, and the next steps. Please send everything by any moment
+      that works for you. Thanks!"
+
+      Output ONLY the Ukrainian translation -- no commentary.
+    expected_calque_categories:
+      - participation calque
+      - receive/get calque
+      - following/next calque
+      - any moment false friend
+    notes: A2 business-adjacent email engineered to elicit "pryimaty uchast", "poluchaty", "sliduiuchyi", and "liubyi moment" patterns.
+
+  - id: translation_literary_mixed
+    category: translation
+    prompt_text: |-
+      Translate to standard literary Ukrainian. Avoid Russianisms, calques, and
+      Surzhyk. Output only the translation.
+
+      "In the first place, the following points concern us. The doctor said that
+      in general the situation is improving. Pretty much everyone takes part in
+      the discussion. As soon as we receive the documents, we will send them to
+      you. From one side it looks fine, from another it does not. We made a
+      couple of decisions and decided to act accordingly."
+    expected_calque_categories:
+      - following/next calque
+      - direct Russian borrowing
+      - participation calque
+      - receive/get calque
+      - from one side calque
+    notes: Longer mixed-domain translation with several English phrases that often trigger Russian-pattern Ukrainian.
+
+  - id: medical_patient_update
+    category: medical_generation
+    prompt_text: |-
+      Write a short standard-Ukrainian message from a clinic nurse to a patient.
+      Avoid Russianisms, calques, and Surzhyk. Keep it clear and polite.
+
+      Include these ideas: the next appointment, receiving test results, eating
+      before the visit, the patient's condition in general, and which symptoms
+      concern the doctor. Output only the Ukrainian message.
+    expected_calque_categories:
+      - following/next calque
+      - receive/get calque
+      - eating lexical Russianism
+      - concern/relate calque
+      - direct Russian borrowing
+    notes: Medical domain prompt where literal generation can drift toward "sliduiuchyi", "poluchaty", "kushaty", "vidnosytysia", or "voobsche".
+
+  - id: business_project_email
+    category: business_generation
+    prompt_text: |-
+      Write a concise standard-Ukrainian business email to a project team.
+      Avoid Russianisms, calques, and Surzhyk. Output only the email.
+
+      The message should say that everyone should take part in the planning
+      meeting, the next steps are attached, documents will be received today,
+      and the team can add comments at any moment before Friday.
+    expected_calque_categories:
+      - participation calque
+      - following/next calque
+      - receive/get calque
+      - add lexical Russianism
+      - any moment false friend
+    notes: Business email prompt targeting high-frequency project-management calques.
+
+  - id: social_media_cafe_post
+    category: social_media_generation
+    prompt_text: |-
+      Write a friendly standard-Ukrainian social-media post about meeting
+      friends at a cafe after work. Avoid Russianisms, calques, and Surzhyk.
+      Output only the post.
+
+      Mention that the place is cool, you miss your friends, people can join at
+      any time, everyone will eat together, and the next meetup will be soon.
+    expected_calque_categories:
+      - Russian slang borrowing
+      - miss/feel bored Russianism
+      - any time false friend
+      - eating lexical Russianism
+      - following/next calque
+    notes: Informal register prompt that probes slang and casual lexical Russianisms without asking for Surzhyk.

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -14,6 +14,7 @@ fire-and-forget path's logging. They will be deleted in Phase 6 cleanup.
 
 import atexit
 import contextlib
+import json
 import subprocess
 import sys
 import uuid
@@ -132,12 +133,13 @@ def _run_claude_sync_via_runtime(
 
     _response_sent = False
     try:
+        target_model = _extract_target_model(msg)
         result = runtime_invoke(
             "claude",
             build_claude_prompt(msg, review),
             mode="read-only",
             cwd=REPO_ROOT,
-            model=None,  # Bridge uses Claude's default
+            model=target_model,
             task_id=msg.get('task_id'),
             session_id=session_id_to_pass,
             tool_config=tool_config,
@@ -166,7 +168,8 @@ def _run_claude_sync_via_runtime(
 
         reply_id = send_message(
             content=response, task_id=msg['task_id'], msg_type="response",
-            from_llm="claude", to_llm=msg['from'], from_model=None, to_model=None,
+            from_llm="claude", to_llm=msg['from'],
+            from_model=result.model, to_model=None,
         )
         _response_sent = True
 
@@ -244,6 +247,19 @@ def _fetch_claude_message(message_id: int) -> dict | None:
         "data": row[6],
         "timestamp": row[7]
     }
+
+
+def _extract_target_model(msg: dict) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    value = payload.get("to_model")
+    return str(value) if value else None
 
 
 def _print_claude_message_info(msg, fire_and_forget, no_timeout, claude_session_id):

--- a/scripts/audit/russianism_eval.py
+++ b/scripts/audit/russianism_eval.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Run prompt x model Russianism evals through the local agent bridge."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.ai_agent_bridge._db import get_db
+from scripts.audit.checks.russicism_detection import check_russicisms
+
+PYTHON, BRIDGE = Path(".venv/bin/python"), Path("scripts/ai_agent_bridge/__main__.py")
+DEFAULT_MODELS = (
+    "claude-opus-4-7,claude-sonnet-4-5,claude-haiku-4-5,"
+    "gpt-5.5,gpt-5.5-mini,gemini-3.1-pro-preview,"
+    "gemini-3-pro-preview,gemini-3.0-flash-preview"
+)
+FROM_AGENT = "russianism-eval"
+_FOUND_COUNT_RE, _WORD_RE = re.compile(r"Found\s+(\d+)\s+Russicism", re.IGNORECASE), re.compile(r"[\w'’-]+", re.UNICODE)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptCase:
+    id: str
+    category: str
+    prompt_text: str
+    expected_calque_categories: list[str]
+    notes: str
+
+@dataclass(frozen=True, slots=True)
+class BridgeCall:
+    prompt_id: str
+    model: str
+    family: str
+    task_id: str
+    argv: list[str]
+    stdin: str | None
+
+@dataclass(slots=True)
+class EvalRow:
+    prompt_id: str
+    category: str
+    model: str
+    family: str
+    task_id: str
+    status: str
+    output_text: str
+    error: str
+    word_count: int
+    russicism_count: int
+    gec_calque_count: int
+    russicism_rate_per_100_words: float
+    combined_rate_per_100_words: float
+    findings: list[dict[str, Any]]
+
+
+def _load_optional_gec_checker() -> Callable[[str], list[dict[str, Any]]] | None:
+    try:
+        checker = getattr(importlib.import_module("scripts.audit.checks.ua_gec_calques"), "check_ua_gec_calques", None)
+    except ImportError:
+        return None
+    return checker if callable(checker) else None
+
+
+CHECK_UA_GEC_CALQUES = _load_optional_gec_checker()
+
+def _parse_models(raw: str) -> list[str]:
+    models = [part.strip() for part in raw.split(",") if part.strip()]
+    deduped = list(dict.fromkeys(models))
+    if not deduped:
+        raise ValueError("--models must name at least one model")
+    return deduped
+
+def _require_str(row: dict[str, Any], key: str, idx: int) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"prompt #{idx} field {key!r} must be a non-empty string")
+    return value.strip()
+
+def load_prompts(path: Path) -> list[PromptCase]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    raw_prompts = payload.get("prompts") if isinstance(payload, dict) else None
+    if not isinstance(raw_prompts, list) or not raw_prompts:
+        raise ValueError("prompt YAML must include a non-empty 'prompts' list")
+    prompts: list[PromptCase] = []
+    seen: set[str] = set()
+    for idx, row in enumerate(raw_prompts, start=1):
+        if not isinstance(row, dict):
+            raise ValueError(f"prompt #{idx} must be a mapping")
+        prompt_id = _require_str(row, "id", idx)
+        if prompt_id in seen:
+            raise ValueError(f"duplicate prompt id: {prompt_id}")
+        categories = row.get("expected_calque_categories")
+        if not isinstance(categories, list) or not all(isinstance(item, str) for item in categories):
+            raise ValueError(f"prompt {prompt_id!r} field 'expected_calque_categories' must be a list of strings")
+        seen.add(prompt_id)
+        prompts.append(
+            PromptCase(
+                prompt_id,
+                _require_str(row, "category", idx),
+                _require_str(row, "prompt_text", idx),
+                list(categories),
+                _require_str(row, "notes", idx),
+            )
+        )
+    return prompts
+
+def _family_for_model(model: str) -> str:
+    if model.startswith("claude-"):
+        return "claude"
+    if model.startswith("gemini-"):
+        return "gemini"
+    if model.startswith(("gpt-", "o", "codex-")):
+        return "codex"
+    raise ValueError(f"cannot infer bridge family for model {model!r}")
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")[:80]
+
+
+class BridgeCaller:
+    """Thin wrapper around scripts/ai_agent_bridge/__main__.py ask-* commands."""
+
+    def __init__(self, run_id: str):
+        self.run_id = run_id
+
+    def plan(self, prompt: PromptCase, model: str) -> BridgeCall:
+        family = _family_for_model(model)
+        task_id = f"{self.run_id}-{_slug(prompt.id)}-{_slug(model)}"
+        base = [str(PYTHON), str(BRIDGE)]
+        if family == "claude":
+            argv = [*base, "ask-claude", prompt.prompt_text, "--task-id", task_id, "--from", FROM_AGENT, "--to-model", model, "--new-session"]
+            return BridgeCall(prompt.id, model, family, task_id, argv, None)
+        if family == "codex":
+            argv = [*base, "ask-codex", "-", "--task-id", task_id, "--from", FROM_AGENT, "--to-model", model, "--new-session"]
+            return BridgeCall(prompt.id, model, family, task_id, argv, prompt.prompt_text)
+        argv = [*base, "ask-gemini", "-", "--task-id", task_id, "--from", FROM_AGENT, "--model", model, "--stdout-only", "--skip-model-check", "--no-github"]
+        return BridgeCall(prompt.id, model, family, task_id, argv, prompt.prompt_text)
+
+    def __call__(self, prompt: PromptCase, model: str) -> tuple[BridgeCall, str]:
+        call = self.plan(prompt, model)
+        result = subprocess.run(call.argv, cwd=PROJECT_ROOT, input=call.stdin, text=True, capture_output=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError((result.stderr or result.stdout or f"exit {result.returncode}").strip())
+        if call.family == "gemini" and result.stdout.strip():
+            return call, result.stdout.strip()
+        response = _latest_bridge_response(call.task_id, call.family)
+        if response:
+            return call, response
+        raise RuntimeError(f"bridge completed but no response row found for task_id={call.task_id}")
+
+
+def _latest_bridge_response(task_id: str, family: str) -> str | None:
+    conn = get_db()
+    try:
+        row = conn.execute(
+            """
+            SELECT content FROM messages
+            WHERE task_id = ? AND from_llm = ? AND to_llm = ?
+              AND message_type IN ('response', 'error')
+            ORDER BY id DESC LIMIT 1
+            """,
+            (task_id, family, FROM_AGENT),
+        ).fetchone()
+    finally:
+        conn.close()
+    return str(row["content"]) if row else None
+
+def _issue_count(violation: dict[str, Any]) -> int:
+    match = _FOUND_COUNT_RE.search(str(violation.get("issue") or ""))
+    return int(match.group(1)) if match else 1
+
+def _rate(count: int, words: int) -> float:
+    return round(count * 100 / (words or 1), 3)
+
+
+def score_output(prompt: PromptCase, model: str, family: str, task_id: str, output: str) -> EvalRow:
+    russ = check_russicisms(output, file_path=f"eval/russianism/{prompt.id}.md")
+    gec = CHECK_UA_GEC_CALQUES(output) if CHECK_UA_GEC_CALQUES else []
+    russ_count = sum(_issue_count(item) for item in russ)
+    gec_count = len(gec)
+    words = len(_WORD_RE.findall(output))
+    findings = [{"source": "check_russicisms", **item} for item in russ]
+    findings.extend({"source": "check_ua_gec_calques", **item} for item in gec)
+    return EvalRow(
+        prompt.id, prompt.category, model, family, task_id, "ok", output, "", words, russ_count, gec_count,
+        _rate(russ_count, words), _rate(russ_count + gec_count, words), findings
+    )
+
+def error_row(prompt: PromptCase, model: str, family: str, task_id: str, error: str) -> EvalRow:
+    return EvalRow(prompt.id, prompt.category, model, family, task_id, "error", "", error, 0, 0, 0, 0.0, 0.0, [])
+
+
+def _model_summaries(rows: Sequence[EvalRow]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[EvalRow]] = defaultdict(list)
+    for row in rows:
+        grouped[row.model].append(row)
+    summaries = {}
+    for model, model_rows in grouped.items():
+        words = sum(row.word_count for row in model_rows)
+        russ = sum(row.russicism_count for row in model_rows)
+        gec = sum(row.gec_calque_count for row in model_rows)
+        summaries[model] = {
+            "model": model, "family": model_rows[0].family, "prompt_count": len(model_rows),
+            "ok_count": sum(row.status == "ok" for row in model_rows),
+            "error_count": sum(row.status == "error" for row in model_rows), "word_count": words,
+            "russicism_count": russ, "gec_calque_count": gec, "combined_count": russ + gec,
+            "russicism_rate_per_100_words": _rate(russ, words),
+            "combined_rate_per_100_words": _rate(russ + gec, words),
+        }
+    return summaries
+
+def write_outputs(out_dir: Path, prompts_path: Path, rows: Sequence[EvalRow], models: Sequence[str]) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "outputs.jsonl").write_text(
+        "".join(json.dumps(asdict(row), ensure_ascii=False) + "\n" for row in rows), encoding="utf-8"
+    )
+    fields = [
+        "prompt_id", "category", "model", "family", "task_id", "status", "word_count", "russicism_count",
+        "gec_calque_count", "russicism_rate_per_100_words", "combined_rate_per_100_words", "error", "findings_json",
+    ]
+    with (out_dir / "scores.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            data = asdict(row) | {"findings_json": json.dumps(row.findings, ensure_ascii=False)}
+            writer.writerow({field: data[field] for field in fields})
+    summary = {
+        "run_id": out_dir.name, "created_at": datetime.now(UTC).isoformat(), "prompt_file": _display_path(prompts_path),
+        "models": list(models), "prompt_count": len({row.prompt_id for row in rows}), "dispatch_count": len(rows),
+        "model_summaries": _model_summaries(rows), "rows": [asdict(row) for row in rows],
+    }
+    (out_dir / "summary.json").write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    (out_dir / "REPORT.md").write_text(render_report(summary, rows), encoding="utf-8")
+
+def render_report(summary: dict[str, Any], rows: Sequence[EvalRow]) -> str:
+    leaderboard = sorted(
+        summary["model_summaries"].values(),
+        key=lambda item: (item["combined_rate_per_100_words"], item["combined_count"], item["model"]),
+    )
+    scorer = "`check_russicisms`" + (" + `check_ua_gec_calques`" if CHECK_UA_GEC_CALQUES else "")
+    lines = [
+        "# Russianism Eval Report", "", f"- Run: `{summary['run_id']}`", f"- Prompt file: `{summary['prompt_file']}`",
+        f"- Dispatches: {summary['dispatch_count']}", f"- Scorer: {scorer}", "", "## Leaderboard", "",
+        "Lower combined rate is better.", "",
+        "| Rank | Model | Family | OK | Errors | Russianisms | GEC calques | Words | Combined / 100 words |",
+        "| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for rank, item in enumerate(leaderboard, start=1):
+        lines.append(
+            f"| {rank} | `{item['model']}` | {item['family']} | {item['ok_count']} | {item['error_count']} | "
+            f"{item['russicism_count']} | {item['gec_calque_count']} | {item['word_count']} | "
+            f"{item['combined_rate_per_100_words']:.3f} |"
+        )
+    lines += [
+        "", "## Per-Prompt Breakdown", "",
+        "| Prompt | Category | Model | Status | Russianisms | GEC calques | Words | Russ. / 100 words |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: |",
+    ]
+    for row in sorted(rows, key=lambda item: (item.prompt_id, item.model)):
+        lines.append(
+            f"| `{row.prompt_id}` | {row.category} | `{row.model}` | {row.status} | {row.russicism_count} | "
+            f"{row.gec_calque_count} | {row.word_count} | {row.russicism_rate_per_100_words:.3f} |"
+        )
+    bad = sorted(
+        [row for row in rows if row.russicism_count + row.gec_calque_count > 0],
+        key=lambda item: (item.combined_rate_per_100_words, item.russicism_count + item.gec_calque_count),
+        reverse=True,
+    )[:5]
+    lines += ["", "## Sample Bad Outputs", ""]
+    if not bad:
+        lines.append("No scorer findings.")
+    for row in bad:
+        findings = "; ".join(str(item.get("issue") or item.get("type") or item) for item in row.findings[:3])
+        lines += [f"### `{row.model}` on `{row.prompt_id}`", "", f"Findings: {findings}", "", "```text", _excerpt(row.output_text), "```", ""]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _excerpt(text: str, limit: int = 700) -> str:
+    trimmed = "\n".join(line.rstrip() for line in text.strip().splitlines())
+    return trimmed[: limit - 3] + "..." if len(trimmed) > limit else trimmed
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def print_cost_report(rows: Sequence[EvalRow], prompts: Sequence[PromptCase], models: Sequence[str]) -> None:
+    prompt_tokens = round(sum(len(prompt.prompt_text) for prompt in prompts) / 4)
+    output_chars: dict[str, int] = defaultdict(int)
+    for row in rows:
+        output_chars[row.model] += len(row.output_text)
+    print("Estimated token use (rough chars/4)")
+    print("model,input_tokens,output_tokens,total_tokens")
+    for model in models:
+        output_tokens = round(output_chars[model] / 4)
+        print(f"{model},{prompt_tokens},{output_tokens},{prompt_tokens + output_tokens}")
+
+
+def _redacted_command(call: BridgeCall) -> str:
+    parts = list(call.argv)
+    if call.family == "claude" and "ask-claude" in parts and parts.index("ask-claude") + 1 < len(parts):
+        parts[parts.index("ask-claude") + 1] = "<prompt_text>"
+    return " ".join(parts)
+
+
+def dry_run(prompts: Sequence[PromptCase], models: Sequence[str], max_parallel: int, caller: BridgeCaller) -> None:
+    print(f"Dry run: prompts={len(prompts)} models={len(models)} dispatches={len(prompts) * len(models)}")
+    print(f"Max parallel: {max_parallel}")
+    for prompt in prompts:
+        for model in models:
+            call = caller.plan(prompt, model)
+            stdin = " stdin=<prompt_text>" if call.stdin is not None else ""
+            print(
+                f"DRY-RUN prompt={prompt.id} model={model} family={call.family} "
+                f"task_id={call.task_id} command={_redacted_command(call)}{stdin}"
+            )
+    print_cost_report([], prompts, models)
+    print("No agent calls were made.")
+
+
+def run_eval(
+    prompts: Sequence[PromptCase],
+    models: Sequence[str],
+    out_dir: Path,
+    max_parallel: int,
+    caller: Callable[[PromptCase, str], tuple[BridgeCall, str]],
+) -> list[EvalRow]:
+    rows: list[EvalRow] = []
+    with ThreadPoolExecutor(max_workers=max_parallel) as executor:
+        futures = {executor.submit(caller, prompt, model): (prompt, model) for prompt in prompts for model in models}
+        for future in as_completed(futures):
+            prompt, model = futures[future]
+            family = _family_for_model(model)
+            try:
+                call, output = future.result()
+            except Exception as exc:
+                rows.append(error_row(prompt, model, family, f"{out_dir.name}-{_slug(prompt.id)}-{_slug(model)}", str(exc)))
+            else:
+                rows.append(score_output(prompt, model, call.family, call.task_id, output))
+    return sorted(rows, key=lambda item: (item.prompt_id, item.model))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Russianism eval prompts across bridge model variants.")
+    parser.add_argument("--prompts", required=True, type=Path, help="Prompt YAML path.")
+    parser.add_argument("--models", default=DEFAULT_MODELS, help=f"Comma-separated model list. Default: {DEFAULT_MODELS}")
+    parser.add_argument("--out-dir", type=Path, help="Output directory. Default: audit/russianism-eval-{timestamp}.")
+    parser.add_argument("--max-parallel", type=int, default=1, help="Maximum concurrent bridge calls.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and print planned dispatches without agent calls.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, caller: BridgeCaller | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        prompts, models = load_prompts(args.prompts), _parse_models(args.models)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.max_parallel < 1:
+        print("error: --max-parallel must be >= 1", file=sys.stderr)
+        return 2
+    out_dir = args.out_dir or PROJECT_ROOT / "audit" / f"russianism-eval-{datetime.now(UTC):%Y%m%dT%H%M%SZ}"
+    active_caller = caller or BridgeCaller(out_dir.name)
+    if args.dry_run:
+        dry_run(prompts, models, args.max_parallel, active_caller)
+        return 0
+    rows = run_eval(prompts, models, out_dir, args.max_parallel, active_caller)
+    write_outputs(out_dir, args.prompts, rows, models)
+    print_cost_report(rows, prompts, models)
+    print(f"Wrote {_display_path(out_dir)}")
+    return 1 if any(row.status == "error" for row in rows) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_russianism_eval.py
+++ b/tests/test_russianism_eval.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.ai_agent_bridge import _claude
+from scripts.audit import russianism_eval
+
+
+def _prompt_payload() -> dict:
+    return {
+        "version": 1,
+        "prompts": [
+            {
+                "id": "p1",
+                "category": "translation",
+                "prompt_text": "Translate a short email to Ukrainian.",
+                "expected_calque_categories": ["participation calque"],
+                "notes": "Fixture prompt one.",
+            },
+            {
+                "id": "p2",
+                "category": "business",
+                "prompt_text": "Write a Ukrainian business update.",
+                "expected_calque_categories": ["receive/get calque"],
+                "notes": "Fixture prompt two.",
+            },
+        ],
+    }
+
+
+def _write_prompts(tmp_path: Path, payload: dict | None = None) -> Path:
+    path = tmp_path / "prompts.yaml"
+    path.write_text(
+        yaml.safe_dump(payload or _prompt_payload(), allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+class FakeCaller:
+    def __init__(self, outputs: dict[tuple[str, str], str] | None = None):
+        self.outputs = outputs or {}
+        self.calls: list[tuple[str, str]] = []
+
+    def plan(self, prompt: russianism_eval.PromptCase, model: str) -> russianism_eval.BridgeCall:
+        family = russianism_eval._family_for_model(model)
+        return russianism_eval.BridgeCall(
+            prompt_id=prompt.id,
+            model=model,
+            family=family,
+            task_id=f"fake-run-{prompt.id}-{model}",
+            argv=[".venv/bin/python", "scripts/ai_agent_bridge/__main__.py", f"ask-{family}"],
+            stdin=prompt.prompt_text if family != "claude" else None,
+        )
+
+    def __call__(self, prompt: russianism_eval.PromptCase, model: str) -> tuple[russianism_eval.BridgeCall, str]:
+        self.calls.append((prompt.id, model))
+        output = self.outputs[(prompt.id, model)]
+        return self.plan(prompt, model), output
+
+
+def test_load_prompts_validates_required_schema(tmp_path: Path) -> None:
+    path = _write_prompts(tmp_path)
+
+    prompts = russianism_eval.load_prompts(path)
+
+    assert [prompt.id for prompt in prompts] == ["p1", "p2"]
+    assert prompts[0].expected_calque_categories == ["participation calque"]
+
+
+def test_load_prompts_rejects_duplicate_ids(tmp_path: Path) -> None:
+    payload = _prompt_payload()
+    payload["prompts"][1]["id"] = "p1"
+    path = _write_prompts(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="duplicate prompt id"):
+        russianism_eval.load_prompts(path)
+
+
+def test_dry_run_prints_matrix_without_calling_agents(tmp_path: Path, capsys) -> None:
+    prompts_path = _write_prompts(tmp_path)
+    fake = FakeCaller()
+
+    exit_code = russianism_eval.main(
+        [
+            "--prompts",
+            str(prompts_path),
+            "--models",
+            "claude-opus-4-7,gpt-5.5",
+            "--dry-run",
+            "--max-parallel",
+            "2",
+        ],
+        caller=fake,
+    )
+
+    stdout = capsys.readouterr().out
+    assert exit_code == 0
+    assert fake.calls == []
+    assert "Dry run: prompts=2 models=2 dispatches=4" in stdout
+    assert "DRY-RUN prompt=p1 model=claude-opus-4-7" in stdout
+    assert "DRY-RUN prompt=p2 model=gpt-5.5" in stdout
+    assert "No agent calls were made." in stdout
+
+
+def test_run_eval_scores_known_russicisms(tmp_path: Path) -> None:
+    prompts = russianism_eval.load_prompts(_write_prompts(tmp_path))[:1]
+    outputs = {
+        ("p1", "gpt-5.5"): "Він буде приймати участь. Вони хочуть получати лист. Вообще це важливо.",
+        ("p1", "claude-opus-4-7"): "Він братиме участь. Вони хочуть отримати лист. Загалом це важливо.",
+    }
+
+    rows = russianism_eval.run_eval(
+        prompts,
+        ["gpt-5.5", "claude-opus-4-7"],
+        tmp_path / "out",
+        max_parallel=1,
+        caller=FakeCaller(outputs),
+    )
+
+    by_model = {row.model: row for row in rows}
+    assert by_model["gpt-5.5"].russicism_count == 3
+    assert by_model["gpt-5.5"].combined_rate_per_100_words > 0
+    assert by_model["claude-opus-4-7"].russicism_count == 0
+
+
+def test_write_outputs_generates_report_summary_and_scores(tmp_path: Path) -> None:
+    prompts_path = _write_prompts(tmp_path)
+    prompts = russianism_eval.load_prompts(prompts_path)[:1]
+    rows = russianism_eval.run_eval(
+        prompts,
+        ["gpt-5.5"],
+        tmp_path / "out",
+        max_parallel=1,
+        caller=FakeCaller({("p1", "gpt-5.5"): "Він приймати участь і получати лист."}),
+    )
+
+    russianism_eval.write_outputs(tmp_path / "out", prompts_path, rows, ["gpt-5.5"])
+
+    assert (tmp_path / "out" / "REPORT.md").exists()
+    assert (tmp_path / "out" / "outputs.jsonl").exists()
+    summary = json.loads((tmp_path / "out" / "summary.json").read_text(encoding="utf-8"))
+    assert summary["prompt_count"] == 1
+    assert summary["dispatch_count"] == 1
+    assert summary["model_summaries"]["gpt-5.5"]["russicism_count"] == 2
+    with (tmp_path / "out" / "scores.csv").open(encoding="utf-8") as handle:
+        scores = list(csv.DictReader(handle))
+    assert scores[0]["prompt_id"] == "p1"
+    assert scores[0]["model"] == "gpt-5.5"
+
+
+def test_report_includes_sample_bad_outputs(tmp_path: Path) -> None:
+    prompts_path = _write_prompts(tmp_path)
+    prompts = russianism_eval.load_prompts(prompts_path)[:1]
+    rows = russianism_eval.run_eval(
+        prompts,
+        ["gpt-5.5"],
+        tmp_path / "out",
+        max_parallel=1,
+        caller=FakeCaller({("p1", "gpt-5.5"): "Мені нравитися цей самий кращий варіант."}),
+    )
+    russianism_eval.write_outputs(tmp_path / "out", prompts_path, rows, ["gpt-5.5"])
+
+    report = (tmp_path / "out" / "REPORT.md").read_text(encoding="utf-8")
+    assert "## Leaderboard" in report
+    assert "## Sample Bad Outputs" in report
+    assert "нравитися" in report
+
+
+def test_optional_gec_checker_is_included(monkeypatch, tmp_path: Path) -> None:
+    prompts = russianism_eval.load_prompts(_write_prompts(tmp_path))[:1]
+
+    monkeypatch.setattr(
+        russianism_eval,
+        "CHECK_UA_GEC_CALQUES",
+        lambda text: [{"type": "UA_GEC_CALQUE", "issue": "synthetic calque"}],
+    )
+
+    row = russianism_eval.score_output(
+        prompts[0],
+        "gpt-5.5",
+        "codex",
+        "task-1",
+        "Чистий український текст.",
+    )
+
+    assert row.russicism_count == 0
+    assert row.gec_calque_count == 1
+    assert row.findings[0]["source"] == "check_ua_gec_calques"
+
+
+def test_bridge_caller_builds_family_specific_commands() -> None:
+    prompt = russianism_eval.PromptCase(
+        id="p1",
+        category="translation",
+        prompt_text="Translate.",
+        expected_calque_categories=[],
+        notes="Fixture.",
+    )
+    caller = russianism_eval.BridgeCaller("run")
+
+    claude = caller.plan(prompt, "claude-opus-4-7")
+    codex = caller.plan(prompt, "gpt-5.5")
+    gemini = caller.plan(prompt, "gemini-3.1-pro-preview")
+
+    assert claude.argv[2] == "ask-claude"
+    assert "--to-model" in claude.argv
+    assert claude.argv[claude.argv.index("--to-model") + 1] == "claude-opus-4-7"
+    assert codex.argv[2] == "ask-codex"
+    assert codex.stdin == "Translate."
+    assert "--to-model" in codex.argv
+    assert gemini.argv[2] == "ask-gemini"
+    assert "--stdout-only" in gemini.argv
+    assert gemini.argv[gemini.argv.index("--model") + 1] == "gemini-3.1-pro-preview"
+
+
+def test_claude_bridge_extracts_target_model_metadata() -> None:
+    msg = {"data": json.dumps({"to_model": "claude-sonnet-4-5"})}
+
+    assert _claude._extract_target_model(msg) == "claude-sonnet-4-5"
+    assert _claude._extract_target_model({"data": "{bad json"}) is None


### PR DESCRIPTION
## What
- Adds scripts/audit/russianism_eval.py to run prompt x model Russianism evals through the existing ai_agent_bridge ask-* commands.
- Adds eval/russianism/prompts-v1.yaml with five starter prompts and a short README documenting the local Gemini Pro model-name substitution.
- Writes REPORT.md, outputs.jsonl, scores.csv, and summary.json for real runs, with --dry-run for schema/model verification without agent calls.
- Makes ask-claude --to-model effective by passing stored to_model metadata into the Claude runtime invocation.

## Why now
- Supports empirical comparison for the V7 writer-selection decision in docs/decisions/2026-05-06-writer-selection-codex-gpt55.md.
- Produces reproducible evidence for anthropics/claude-code#59146 without running the live eval in this PR.

## Tests
- .venv/bin/python -m pytest tests/test_russianism_eval.py
- .venv/bin/ruff check scripts/audit/russianism_eval.py tests/test_russianism_eval.py
- .venv/bin/ruff check scripts/ai_agent_bridge/_claude.py
- .venv/bin/python scripts/audit/russianism_eval.py --prompts eval/russianism/prompts-v1.yaml --dry-run
- .venv/bin/python scripts/audit/lint_agent_trailer.py

## Notes
- No live model eval was run in this PR; only dry-run and mocked tests were executed.
- No auto-merge requested.
- Default model substitution: gemini-3.0-pro -> gemini-3-pro-preview, because the local bridge/repo has current references for gemini-3-pro-preview and no local reference for gemini-3.0-pro.