### PR TITLE
fix(tests): isolate TestCacheFunctions with autouse _ttl_cache.clear() fixture (#2002)

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -17,6 +17,8 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 # ==================== review_parsing ====================
 
 
@@ -279,7 +281,24 @@ class TestParsePhaseStatus:
 
 
 class TestCacheFunctions:
-    """TTL cache get/set."""
+    """TTL cache get/set.
+
+    `_ttl_cache` is a module-global singleton; tests in this class assert
+    exact key counts after invalidation. To keep them robust against
+    pollution from earlier tests in the full pytest sweep (which can
+    populate `orient_*`-prefixed keys via the `/api/orient` test suite),
+    we clear the cache before AND after every test in this class.
+
+    See issue #2002 — replaces the prior CI workaround that re-ran these
+    tests in a fresh subprocess.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_ttl_cache(self):
+        from scripts.api.state_helpers import _ttl_cache
+        _ttl_cache.clear()
+        yield
+        _ttl_cache.clear()
 
     def test_cache_hit(self):
         from scripts.api.state_helpers import cache_get, cache_set


### PR DESCRIPTION
## Summary

Fixes #2002 — `tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix` and `test_cache_invalidate_default_clears_all` fail in the main pytest sweep on main when `orient_*`-prefixed keys leak from earlier tests into the module-global `_ttl_cache`.

## Fix

Add an `autouse` fixture in `TestCacheFunctions` that clears `_ttl_cache` before AND after each test in the class. This makes the exact-count assertions robust to whatever populated the cache earlier in the full-suite run.

```python
@pytest.fixture(autouse=True)
def _clear_ttl_cache(self):
    from scripts.api.state_helpers import _ttl_cache
    _ttl_cache.clear()
    yield
    _ttl_cache.clear()
```

Plus one `import pytest` line.

## Verification

```
$ .venv/bin/python -m pytest tests/test_api_helpers.py::TestCacheFunctions -v
5 passed in 0.57s
```

```
$ .venv/bin/python -m pytest tests/ --ignore=tests/wiki -q
[full sweep — confirm both cache tests now pass in full-suite context]
```

## Follow-up

The CI workaround in `.github/workflows/ci.yml` (re-running these two tests in a fresh subprocess) can be removed in a separate PR once this lands. Leaving it in this PR for safety.

## Test plan

- [x] `pytest tests/test_api_helpers.py::TestCacheFunctions` — 5 passed
- [ ] `pytest tests/ --ignore=tests/wiki` — confirm cache tests no longer in failures list
- [ ] Confirms PR #2000 unblocks (no longer fails on this test)

Closes #2002
