### PR TITLE
fix(pipeline): resolve textbook chunks by reference title

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9,7 +9,9 @@ any LLM rewrite or regeneration loop.
 from __future__ import annotations
 
 import json
+import logging
 import re
+import sqlite3
 import sys
 import unicodedata
 import xml.etree.ElementTree as ET
@@ -23,10 +25,12 @@ from typing import Any
 
 import yaml
 
+LOGGER = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = PROJECT_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
+TEXTBOOK_SOURCES_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
 
 from scripts.audit.failure_classes import FailureClass, FailureRecord
 from scripts.build.citation_matcher import (
@@ -919,7 +923,153 @@ def _textbook_hit_label(hit: Mapping[str, Any]) -> str:
     return title + (f" ({', '.join(details)})" if details else "")
 
 
+_TEXTBOOK_REFERENCE_TITLE_RE = re.compile(
+    r"^(?P<author>\S+)\s+Grade\s+(?P<grade>\d+),\s*p\.\s*(?P<page>\d+)$",
+    re.IGNORECASE,
+)
+_TEXTBOOK_AUTHOR_TRANSLITS = {
+    "Караман": ["karaman"],
+    "Захарійчук": ["zakhariychuk", "zaharijchuk", "zahariichuk"],
+    "Кравцова": ["kravcova", "kravtsova"],
+    "Авраменко": ["avramenko"],
+    "Глазова": ["glazova", "hlazova"],
+    "Заболотний": ["zabolotnyi", "zabolotnij"],
+    "Захарчук": ["zakharchuk"],
+    "Вашуленко": ["vashulenko"],
+    "Большакова": ["bolshakova"],
+    "Міщенко": ["mishhenko", "mishchenko"],
+}
+
+
+def _parse_textbook_reference_title(title: str) -> tuple[str, int, int] | None:
+    match = _TEXTBOOK_REFERENCE_TITLE_RE.match(title.strip())
+    if not match:
+        return None
+    return (
+        match.group("author"),
+        int(match.group("grade")),
+        int(match.group("page")),
+    )
+
+
+def _textbook_source_year(source_file: str) -> int:
+    years = [int(year) for year in re.findall(r"(?:^|-)(\d{4})(?:-|$)", source_file)]
+    return max(years) if years else 0
+
+
+def _source_files_for_textbook_reference(
+    conn: sqlite3.Connection,
+    author: str,
+    grade: int,
+) -> list[str] | None:
+    translits = _TEXTBOOK_AUTHOR_TRANSLITS.get(author)
+    if not translits:
+        return None
+
+    author_clauses = " OR ".join("source_file LIKE ?" for _ in translits)
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT source_file
+        FROM textbooks
+        WHERE source_file LIKE ?
+          AND ({author_clauses})
+        """,
+        (f"{grade}-klas-%", *(f"%-{translit}-%" for translit in translits)),
+    ).fetchall()
+    return sorted(
+        (str(row["source_file"]) for row in rows),
+        key=lambda source_file: (_textbook_source_year(source_file), source_file),
+        reverse=True,
+    )
+
+
+def _lookup_textbook_reference_chunk(
+    title: str,
+    *,
+    limit: int = 1,
+    missing_reason: list[str] | None = None,
+) -> list[dict] | None:
+    parsed = _parse_textbook_reference_title(title)
+    if parsed is None:
+        return None
+    author, grade, page = parsed
+    if not TEXTBOOK_SOURCES_DB_PATH.exists():
+        return None
+
+    try:
+        with sqlite3.connect(str(TEXTBOOK_SOURCES_DB_PATH)) as conn:
+            conn.row_factory = sqlite3.Row
+            source_files = _source_files_for_textbook_reference(conn, author, grade)
+            if source_files is None:
+                return None
+            if not source_files:
+                if missing_reason is not None:
+                    missing_reason.append(
+                        f"source_file not in corpus for {author} Grade {grade}"
+                    )
+                return []
+            quoted_sources = ",".join("?" for _ in source_files)
+            rows: list[sqlite3.Row] = []
+            for width in (4, 3):
+                suffix = f"\\_s{page:0{width}d}"
+                rows = conn.execute(
+                    f"""
+                    SELECT chunk_id, title, text, source_file, grade, author
+                    FROM textbooks
+                    WHERE source_file IN ({quoted_sources})
+                      AND chunk_id LIKE ? ESCAPE '\\'
+                    ORDER BY source_file DESC, chunk_id
+                    """,
+                    (*source_files, f"%{suffix}"),
+                ).fetchall()
+                if rows:
+                    break
+    except sqlite3.Error:
+        return None
+
+    if not rows:
+        if missing_reason is not None:
+            missing_reason.append(
+                f"page {page} not in corpus for {', '.join(source_files)}"
+            )
+        return []
+
+    source_file_count = len({str(row["source_file"]) for row in rows})
+    if source_file_count > 1:
+        LOGGER.warning(
+            "Ambiguous textbook source_file candidates for %s: %s; using most recent",
+            title,
+            ", ".join(sorted({str(row["source_file"]) for row in rows})),
+        )
+    sorted_rows = sorted(
+        rows,
+        key=lambda row: (
+            _textbook_source_year(str(row["source_file"])),
+            str(row["source_file"]),
+            str(row["chunk_id"]),
+        ),
+        reverse=True,
+    )
+    return [
+        {
+            "chunk_id": str(row["chunk_id"]),
+            "title": str(row["title"]),
+            "text": str(row["text"]),
+            "source_file": str(row["source_file"]),
+            "source_type": "textbook",
+            "grade": str(row["grade"]),
+            "author": str(row["author"] or author),
+            "page": page,
+        }
+        for row in sorted_rows[:limit]
+    ]
+
+
 def _search_textbook_hits(query: str, *, level: str, limit: int = 1) -> list[dict]:
+    direct_hits = _lookup_textbook_reference_chunk(query, limit=limit)
+    if direct_hits is not None:
+        return direct_hits
+
     try:
         from wiki.sources_db import search_sources
     except Exception:
@@ -956,15 +1106,30 @@ def _build_textbook_excerpt_context(
     found_any = False
     for title in references:
         query = f"{title} {topic_query}".strip()
-        hits = _search_textbook_hits(query, level=level, limit=1)
+        missing_reasons: list[str] = []
+        direct_hits = _lookup_textbook_reference_chunk(
+            title,
+            limit=1,
+            missing_reason=missing_reasons,
+        )
+        hits = (
+            direct_hits
+            if direct_hits is not None
+            else _search_textbook_hits(query, level=level, limit=1)
+        )
         lines.append(f"### {title}")
         lines.append("")
         if not hits:
+            missing_reason = missing_reasons[0] if missing_reasons else ""
             for ref in plan.get("references") or []:
                 if isinstance(ref, dict) and str(ref.get("title") or "").strip() == title:
                     ref["corpus_missing"] = True
+                    if missing_reason:
+                        ref["corpus_missing_reason"] = missing_reason
             lines.append("*No textbook excerpt found for this reference.*")
             lines.append("corpus_missing: true")
+            if missing_reason:
+                lines.append(f"corpus_missing_reason: {missing_reason}")
             lines.append("")
             continue
         hit = hits[0]

--- a/tests/test_textbook_grounding.py
+++ b/tests/test_textbook_grounding.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+
+def _seed_textbook_db(path: Path, rows: list[dict[str, Any]]) -> None:
+    with sqlite3.connect(str(path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE textbooks (
+                id INTEGER PRIMARY KEY,
+                chunk_id TEXT NOT NULL,
+                title TEXT NOT NULL,
+                text TEXT NOT NULL,
+                source_file TEXT NOT NULL,
+                grade TEXT,
+                author TEXT,
+                char_count INTEGER DEFAULT 0,
+                parent_section_id INTEGER
+            )
+            """
+        )
+        for index, row in enumerate(rows, start=1):
+            conn.execute(
+                """
+                INSERT INTO textbooks (
+                    id, chunk_id, title, text, source_file, grade, author
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    index,
+                    row["chunk_id"],
+                    row.get("title", "Сторінка"),
+                    row["text"],
+                    row["source_file"],
+                    row.get("grade", ""),
+                    row.get("author", ""),
+                ),
+            )
+
+
+def test_karaman_grade10_p187_resolves_to_chunk(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Reproducer from #1975: matcher must find the existing chunk."""
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "10-klas-ukrmova-karaman-2018_s0187",
+                "title": "Сторінка 105",
+                "text": "§ 38 Розмовна, просторічна, емоційно забарвлена лексика.",
+                "source_file": "10-klas-ukrmova-karaman-2018",
+                "grade": "10",
+                "author": "karaman",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Караман Grade 10, p.187 ",
+        level="a1",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert hits[0]["chunk_id"] == "10-klas-ukrmova-karaman-2018_s0187"
+
+
+def test_zakhariychuk_grade4_p162_reports_corpus_missing_deterministically(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A missing page should not fall through to topic FTS and a false hit."""
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "4-klas-ukrayinska-mova-zaharijchuk-2021-1_s0161",
+                "title": "Сторінка 161",
+                "text": "Сусідня сторінка є в корпусі.",
+                "source_file": "4-klas-ukrayinska-mova-zaharijchuk-2021-1",
+                "grade": "4",
+                "author": "zaharijchuk",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Захарійчук Grade 4, p.162 ",
+        level="a1",
+        limit=1,
+    )
+
+    assert hits == []
+
+
+def test_free_form_title_falls_back_to_fts5(monkeypatch) -> None:
+    """Titles without 'Grade N, p.M' format use the existing FTS5 path."""
+    from wiki import sources_db
+
+    calls: list[tuple[str, str, int]] = []
+
+    def fake_search_sources(query: str, *, track: str, limit: int) -> list[dict]:
+        calls.append((query, track, limit))
+        return [
+            {
+                "chunk_id": "fallback-textbook-hit",
+                "source_type": "textbook_sections",
+                "text": "Fallback textbook excerpt.",
+            },
+            {
+                "chunk_id": "external-hit",
+                "source_type": "external",
+                "text": "External excerpt.",
+            },
+        ]
+
+    monkeypatch.setattr(sources_db, "search_sources", fake_search_sources)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "free-form source title morning routine",
+        level="a1",
+        limit=1,
+    )
+
+    assert calls == [("free-form source title morning routine", "a1", 4)]
+    assert [hit["chunk_id"] for hit in hits] == ["fallback-textbook-hit"]
+
+
+def test_textbook_excerpt_context_uses_reference_title_for_direct_lookup(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "10-klas-ukrmova-karaman-2018_s0187",
+                "title": "Сторінка 105",
+                "text": "§ 38 Розмовна, просторічна, емоційно забарвлена лексика.",
+                "source_file": "10-klas-ukrmova-karaman-2018",
+                "grade": "10",
+                "author": "karaman",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+    plan = {
+        "references": [{"title": "Караман Grade 10, p.187"}],
+        "title": "ranok",
+        "subtitle": "routine morning",
+        "content_outline": [
+            {"section": "ranok routine", "points": ["morning", "breakfast"]}
+        ],
+    }
+
+    context = linear_pipeline._build_textbook_excerpt_context(plan, "a1")
+
+    assert "10-klas-ukrmova-karaman-2018" in context
+    assert "corpus_missing: true" not in context


### PR DESCRIPTION
## Summary
- Add a metadata-first lookup for textbook references shaped like `Author Grade N, p.M` before unified FTS search.
- Resolve candidate textbook source files by grade and transliterated author, then fetch direct chunk suffixes with 4-digit and 3-digit page fallbacks.
- Preserve free-form title fallback to existing FTS search and add regression coverage for #1975.

Refs #1975

## Verification
- `sqlite3 data/sources.db "SELECT chunk_id FROM textbooks WHERE chunk_id='10-klas-ukrmova-karaman-2018_s0187';"` -> `10-klas-ukrmova-karaman-2018_s0187`
- `.venv/bin/pytest tests/test_textbook_grounding.py -v` -> `4 passed in 0.35s`
- `.venv/bin/pytest tests/test_textbook_grounding_gate.py -v` -> `15 passed in 0.28s`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/` -> `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> `All 1 non-skipped commit(s) carry an X-Agent trailer.`