### PR TITLE
fix(pipeline): add 6 missing author translits (Літвінова, Голуб, Варзацька, Пономарова + 2 variants)

### DIFF
--- a/scripts/audit/plan_references_audit.py
+++ b/scripts/audit/plan_references_audit.py
@@ -57,19 +57,18 @@ CANONICAL_TRANSLITS: dict[str, list[str]] = {
     "Вашуленко": ["vashulenko"],
     "Большакова": ["bolshakova"],
     "Міщенко": ["mishhenko", "mishchenko"],
+    "Літвінова": ["litvinova"],
+    "Литвінова": ["litvinova"],
+    "Голуб": ["golub"],
+    "Варзацька": ["varzatska"],
+    "Пономарова": ["ponomarova"],
+    "Пономарьова": ["ponomarova"],
 }
 
 # Authors observed in plans but not in CANONICAL_TRANSLITS. Used to
 # suggest extensions to _TEXTBOOK_AUTHOR_TRANSLITS in the aggregate
 # findings section — never to silently resolve UNKNOWN_AUTHOR citations.
-SUGGESTED_TRANSLITS: dict[str, list[str]] = {
-    "Варзацька": ["varzatska"],
-    "Голуб": ["golub"],
-    "Литвінова": ["litvinova"],
-    "Літвінова": ["litvinova"],
-    "Пономарова": ["ponomarova"],
-    "Пономарьова": ["ponomarova"],
-}
+SUGGESTED_TRANSLITS: dict[str, list[str]] = {}
 
 # "Author Grade N, p.M" / "с. M" / "стор. M". Cyrillic author block,
 # Grade integer, then a page-style marker followed by digits.

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -938,6 +938,12 @@ _TEXTBOOK_AUTHOR_TRANSLITS = {
     "Вашуленко": ["vashulenko"],
     "Большакова": ["bolshakova"],
     "Міщенко": ["mishhenko", "mishchenko"],
+    "Літвінова": ["litvinova"],
+    "Литвінова": ["litvinova"],
+    "Голуб": ["golub"],
+    "Варзацька": ["varzatska"],
+    "Пономарова": ["ponomarova"],
+    "Пономарьова": ["ponomarova"],
 }
 
 

--- a/tests/test_plan_references_audit.py
+++ b/tests/test_plan_references_audit.py
@@ -164,12 +164,19 @@ def test_audit_citation_ok_when_topic_matches(fake_db: Path):
     assert finding.mode == "OK", (finding.mode, finding.detail, finding.overlap)
 
 
-def test_audit_citation_unknown_author_flags_suggested_translits(fake_db: Path):
+def test_audit_citation_unknown_author_for_uncatalogued_name(fake_db: Path):
+    """An author absent from CANONICAL_TRANSLITS flags UNKNOWN_AUTHOR.
+
+    Previously this test exercised the SUGGESTED_TRANSLITS path with
+    `Літвінова`, but those entries have since been promoted into
+    CANONICAL_TRANSLITS — a fictional name preserves the regression on
+    the UNKNOWN_AUTHOR mode.
+    """
     cite = Citation(
         plan_slug="euphony",
         level="a1",
-        raw="Літвінова Grade 5, p.174",
-        author="Літвінова",
+        raw="Неіснуючий Grade 5, p.174",
+        author="Неіснуючий",
         grade=5,
         page=174,
         field_source="references",
@@ -179,7 +186,6 @@ def test_audit_citation_unknown_author_flags_suggested_translits(fake_db: Path):
         conn.row_factory = sqlite3.Row
         finding = _audit_citation(cite, "Милозвучність", conn)
     assert finding.mode == "UNKNOWN_AUTHOR"
-    assert "litvinova" in finding.detail
 
 
 def test_audit_citation_ghost_page(fake_db: Path):

--- a/tests/test_textbook_grounding.py
+++ b/tests/test_textbook_grounding.py
@@ -138,6 +138,211 @@ def test_free_form_title_falls_back_to_fts5(monkeypatch) -> None:
     assert [hit["chunk_id"] for hit in hits] == ["fallback-textbook-hit"]
 
 
+def test_litvinova_grade7_p55_resolves_to_chunk(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Audit citation: `Літвінова Grade 7, p.55` (a1-a2-plan-references-2026-05-15, how-many)."""
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "7-klas-ukrmova-litvinova-2024_s0055",
+                "title": "Сторінка 51",
+                "text": "Лексика. Прочитайте текст і знайдіть синоніми.",
+                "source_file": "7-klas-ukrmova-litvinova-2024",
+                "grade": "7",
+                "author": "litvinova",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Літвінова Grade 7, p.55",
+        level="a1",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert hits[0]["chunk_id"] == "7-klas-ukrmova-litvinova-2024_s0055"
+
+
+def test_litvinova_cyrillic_variant_resolves_same_as_primary(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Cyrillic spelling variant `Литвінова` must resolve identically to `Літвінова`.
+
+    Audit citation: `Литвінова Grade 5, p.104` (a2 metalanguage-syntax-cases).
+    """
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "5-klas-ukrmova-litvinova-2022_s0104",
+                "title": "Сторінка 100",
+                "text": "Синтаксис. Розгляньте речення.",
+                "source_file": "5-klas-ukrmova-litvinova-2022",
+                "grade": "5",
+                "author": "litvinova",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Литвінова Grade 5, p.104",
+        level="a2",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert hits[0]["chunk_id"] == "5-klas-ukrmova-litvinova-2022_s0104"
+
+
+def test_golub_grade6_p179_resolves_to_chunk(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Audit citation: `Голуб Grade 6, с. 179` (a2 checkpoint-instrumental).
+
+    Tested with `p.` form because `_parse_textbook_reference_title` accepts that
+    syntax; the audit script normalises `с.`/`p.` upstream.
+    """
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "6-klas-ukrmova-golub-2023_s0179",
+                "title": "Сторінка 176",
+                "text": "Іменники в орудному відмінку. Виконайте вправу.",
+                "source_file": "6-klas-ukrmova-golub-2023",
+                "grade": "6",
+                "author": "golub",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Голуб Grade 6, p.179",
+        level="a2",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert hits[0]["chunk_id"] == "6-klas-ukrmova-golub-2023_s0179"
+
+
+def test_varzatska_grade4_p38_resolves_to_chunk(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Audit citation: `Варзацька Grade 4, с. 38` (a2 checkpoint-cases)."""
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "4-klas-ukrayinska-mova-varzatska-2021-1_s0038",
+                "title": "Сторінка 40",
+                "text": "Відмінки іменників. Знайдіть закінчення.",
+                "source_file": "4-klas-ukrayinska-mova-varzatska-2021-1",
+                "grade": "4",
+                "author": "varzatska",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Варзацька Grade 4, p.38",
+        level="a2",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert (
+        hits[0]["chunk_id"]
+        == "4-klas-ukrayinska-mova-varzatska-2021-1_s0038"
+    )
+
+
+def test_ponomarova_grade3_p86_resolves_to_chunk(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Audit citation: `Пономарова Grade 3, p.86` (a1 many-things)."""
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "3-klas-ukrainska-mova-ponomarova-2020-1_s0086",
+                "title": "Сторінка 87",
+                "text": "Прочитайте текст і дайте відповіді на запитання.",
+                "source_file": "3-klas-ukrainska-mova-ponomarova-2020-1",
+                "grade": "3",
+                "author": "ponomarova",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Пономарова Grade 3, p.86",
+        level="a1",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert (
+        hits[0]["chunk_id"]
+        == "3-klas-ukrainska-mova-ponomarova-2020-1_s0086"
+    )
+
+
+def test_ponomarova_cyrillic_variant_resolves_same_as_primary(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Cyrillic spelling variant `Пономарьова` must resolve identically to `Пономарова`.
+
+    Audit citation: `Пономарьова Grade 4, с. 53` (a2 instrumental-accompaniment).
+    """
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0053",
+                "title": "Сторінка 54",
+                "text": "Іменники з прийменниками. Прочитайте.",
+                "source_file": "4-klas-ukrayinska-mova-ponomarova-2021-1",
+                "grade": "4",
+                "author": "ponomarova",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Пономарьова Grade 4, p.53",
+        level="a2",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert (
+        hits[0]["chunk_id"]
+        == "4-klas-ukrayinska-mova-ponomarova-2021-1_s0053"
+    )
+
+
 def test_textbook_excerpt_context_uses_reference_title_for_direct_lookup(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

Adds 6 author entries to `_TEXTBOOK_AUTHOR_TRANSLITS` in `scripts/build/linear_pipeline.py` (and the mirrored `CANONICAL_TRANSLITS` in `scripts/audit/plan_references_audit.py`). Recovers 19 `UNKNOWN_AUTHOR` citations identified by the A1/A2 audit (PR #2007).

Closes #2010.

## Authors added

| Cyrillic | translit | grade range | corpus source_file |
|---|---|---|---|
| Літвінова | `litvinova` | 5–7 | `5/6/7-klas-ukrmova-litvinova-2022/23/24` |
| Литвінова (variant) | `litvinova` | 5–7 | — |
| Голуб | `golub` | 5–6 | `5/6-klas-ukrmova-golub-2022/23` |
| Варзацька | `varzatska` | 4 | `4-klas-ukrayinska-mova-varzatska-2021-1` |
| Пономарова | `ponomarova` | 3–4 | `3-klas-ukrainska-mova-ponomarova-2020-1`, `4-klas-ukrayinska-mova-ponomarova-2021-1` |
| Пономарьова (variant) | `ponomarova` | 3–4 | — |

## Verifiable evidence

**Each new author maps to a real corpus source_file** (sqlite query):

```
$ sqlite3 data/sources.db "SELECT DISTINCT source_file FROM textbooks WHERE source_file LIKE '%-litvinova-%' OR source_file LIKE '%-golub-%' OR source_file LIKE '%-varzatska-%' OR source_file LIKE '%-ponomarova-%' ORDER BY source_file"
3-klas-ukrainska-mova-ponomarova-2020-1
4-klas-ukrayinska-mova-ponomarova-2021-1
4-klas-ukrayinska-mova-varzatska-2021-1
5-klas-ukrmova-golub-2022
5-klas-ukrmova-litvinova-2022
6-klas-ukrmova-golub-2023
6-klas-ukrmova-litvinova-2023
7-klas-ukrmova-litvinova-2024
```

**Audit recheck on 124 plans (66 citations)** — UNKNOWN_AUTHOR fully recovered:

```
before: OK=29, UNKNOWN_AUTHOR=19, TOPIC_MISMATCH=14, LEVEL_MISMATCH=4
after:  OK=45, UNKNOWN_AUTHOR=0,  TOPIC_MISMATCH=16, LEVEL_MISMATCH=5
```

Breakdown of the 19 recovered citations:
- **16 → OK** (now resolve to a real chunk)
- **2 → TOPIC_MISMATCH** (chunk found but plan-topic overlap too low)
- **1 → LEVEL_MISMATCH** (chunk found but grade > level cap)

The TOPIC/LEVEL shifts are expected — once the matcher resolves the author, the audit applies its topic-overlap and level-cap checks. Per-module follow-up is out of scope; #2010 only asked for the translit recovery.

## Tests

6 new regression tests in `tests/test_textbook_grounding.py` exercising each new author + the two Cyrillic spelling variants. Each test seeds a real chunk_id pattern observed in `data/sources.db` (e.g. `7-klas-ukrmova-litvinova-2024_s0055`, `6-klas-ukrmova-golub-2023_s0179`).

Repurposed `test_audit_citation_unknown_author_flags_suggested_translits` → `_for_uncatalogued_name`: the original variant tested the `SUGGESTED_TRANSLITS` suggestion path that's now retired (all 6 entries promoted to `CANONICAL_TRANSLITS`), so the test uses a fictional author to preserve UNKNOWN_AUTHOR regression coverage.

```
$ .venv/bin/python -m pytest tests/test_textbook_grounding.py tests/test_textbook_grounding_gate.py tests/test_plan_references_audit.py -v
...
============================== 34 passed in 0.30s ==============================
```

```
$ .venv/bin/ruff check scripts/build/linear_pipeline.py scripts/audit/plan_references_audit.py tests/test_textbook_grounding.py tests/test_plan_references_audit.py
All checks passed!
```

## Conflict awareness

In-flight dispatch `m20-matcher-fix-retry-2026-05-15` is editing the adjacent `_source_files_for_textbook_reference` in `scripts/build/linear_pipeline.py`. This PR is scoped strictly to the `_TEXTBOOK_AUTHOR_TRANSLITS` dict — no overlap with the other function. Whichever PR lands second rebases.

## Test plan

- [x] `data/sources.db` contains a real `source_file` for each new translit (verified above)
- [x] `tests/test_textbook_grounding.py` — 6 new tests pass against seeded fixtures
- [x] `tests/test_textbook_grounding_gate.py` — pre-existing 15 tests still pass
- [x] `tests/test_plan_references_audit.py` — 9 tests pass (1 repurposed)
- [x] `ruff check` clean
- [x] Audit recheck shows UNKNOWN_AUTHOR 19 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)