### PR TITLE
feat(pipeline): retire runtime transliteration; matcher is Cyrillic-native

### DIFF
--- a/docs/decisions/2026-05-15-cyrillic-native-matcher.md
+++ b/docs/decisions/2026-05-15-cyrillic-native-matcher.md
@@ -1,0 +1,56 @@
+# DECISION — Retire runtime transliteration; textbook matcher queries Cyrillic `author_uk` directly
+
+**Status:** ACCEPTED 2026-05-15.
+**Decided:** Approve as recommended — the runtime depends on Cyrillic, not Latin.
+**Source:** Dispatch brief `docs/dispatch-briefs/2026-05-15-cyrillic-native-matcher.md`. Surfaced by the A1/A2 (#2007) and B1/B2 (#2011) `plan_references` audits, which exposed how a hand-maintained Cyrillic→Latin transliteration dict (`_TEXTBOOK_AUTHOR_TRANSLITS`) drifted from corpus reality every time a new author appeared.
+**Scope:** runtime resolution of `Author Grade N, p.M` textbook citations in `scripts/build/linear_pipeline.py` and `scripts/audit/plan_references_audit.py`. **Does NOT touch:** Latin `textbooks.author` column values (kept for backwards compatibility), `source_file` slug strings on disk (separate decolonization PR), PDF filenames, or wiki/literary/dictionary ingestion paths.
+
+---
+
+## Context — the Soviet-era seam
+
+`textbooks.source_file` values were built by scraping pipelines that used Russian-mediated transliteration schemes (`Заболотний → zabolotnyi`/`zabolotnij`, `Голуб → golub` not the native `holub`, `Захарійчук → zakhariychuk`/`zaharijchuk`/`zahariichuk`). The chunks are real Ukrainian textbook content; the file naming is a Latin scar from the scraping path.
+
+Plan files cite authors in Cyrillic, the way Ukrainian speakers read and write them. To bridge plan-Cyrillic to corpus-Latin, the runtime carried a hand-maintained dict, `_TEXTBOOK_AUTHOR_TRANSLITS`, mapping each Cyrillic name to one or more Latin slug fragments and matching via `source_file LIKE %-{translit}-%`. Every newly-cited author needed a manual entry; #2013 added 6 in a single PR after audit #2007 surfaced 19 broken citations.
+
+The transliteration dependency is a Soviet-era artifact: the runtime should never have to know any romanization scheme, let alone a Russian-mediated one. Ukrainian names match against Ukrainian names.
+
+## Decision
+
+1. Add a Cyrillic column `textbooks.author_uk` and back-fill it from the legacy Latin `author` column via a one-time migration (`scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py`). The migration owns the only remaining Latin→Cyrillic mapping in the codebase.
+2. Rewrite `_source_files_for_textbook_reference` and `plan_references_audit._source_files_for` to query `WHERE author_uk = ? AND grade = ?` — direct equality, no LIKE patterns, no transliteration.
+3. Add a small `_canonicalize_author_uk()` helper that maps Cyrillic spelling variants to their canonical form (`Литвінова → Літвінова`, `Пономарьова → Пономарова`). This is **not** transliteration: both ends are Cyrillic. It captures Ukrainian-internal spelling history, the kind of variation that exists between regional/historical orthographies of a single name.
+4. Update ingestion paths (`scripts/wiki/build_sources_db.py`, `scripts/ingest/*`) to require an explicit Cyrillic `author_uk` per row. Fail loudly when an entry has `author` but no `author_uk`.
+
+The Latin `author` column stays in the schema — archived analytics and existing source_file naming depend on it — but the runtime matcher does not read it.
+
+## Why now
+
+Three forcing functions converged: (a) audits #2007 and #2011 quantified the maintenance tax (19 + 12 broken citations from missing TRANSLITS entries); (b) #2013 added six entries by hand and the dict was still incomplete; (c) every new textbook ingestion would have required another round-trip through TRANSLITS. The bridge had to retire before the next ingestion wave.
+
+## Scope boundary (deliberately conservative)
+
+- `textbooks.author` (Latin) **stays** — deprecated via docstring, not deleted, so archived analytics, the orphan back-fill helper (`scripts/wiki/backfill_school_textbook_orphans.py`), and historical SQL queries against the column continue to work.
+- `textbooks.source_file` values **stay Latin** — these are opaque corpus keys downstream. Renaming them touches ~91 file slugs on disk plus their references in chunk JSONLs, plan citations cached as `resolved_source_file`, and the broker. Filed as a follow-up decolonization PR.
+- PDF filenames on disk **stay** — separate from the DB rename.
+- Wiki/literary/dictionary tables **not touched** — `literary_texts.author` is already Cyrillic where applicable.
+
+## Verification (#M-4 deterministic claims)
+
+| Claim | Tool |
+|---|---|
+| Migration adds the column | `sqlite3 data/sources.db ".schema textbooks"` shows `author_uk TEXT DEFAULT ''` |
+| Back-fill rate | `SELECT COUNT(*) FROM textbooks WHERE author_uk != ''` reports 25,714 / 25,714 = 100% |
+| Idempotent re-run | Second `apply()` reports `rows_updated=0` |
+| Matcher resolves Cyrillic citations | `tests/test_textbook_grounding.py` — 11 tests pass |
+| Spelling variants canonicalize | `test_litvinova_cyrillic_variant_resolves_same_as_primary`, `test_ponomarova_cyrillic_variant_resolves_same_as_primary` |
+| Audit logic preserved | `tests/test_plan_references_audit.py` — 13 tests pass |
+| Migration round-trips | `tests/test_migrations.py` — 4 tests pass |
+
+## Expiry
+
+Revisit when source_file strings are renamed to Cyrillic (the follow-up PR). At that point the migration script's `_LATIN_TO_UK` dict can be deleted: there will be no Latin-named author state anywhere in the codebase or DB.
+
+## Non-negotiable
+
+`_LATIN_TO_UK` in the migration script is **the only place transliteration is acknowledged**. It must not be re-imported into runtime code. If a future ingestion path needs a Latin→Cyrillic translation, the work belongs in the migration's bridge dict at ingestion time, not in the matcher at query time.

--- a/scripts/audit/plan_references_audit.py
+++ b/scripts/audit/plan_references_audit.py
@@ -11,13 +11,14 @@ classifying failure modes:
     GHOST_PAGE        source_file exists but no chunk for that page
     TOPIC_MISMATCH    chunk exists but text is unrelated to the plan topic
     LEVEL_MISMATCH    grade >= PLAN_AUDIT_LEVEL_MISMATCH_THRESHOLDS[track] (per-track policy)
-    UNKNOWN_AUTHOR    author not in _TEXTBOOK_AUTHOR_TRANSLITS (canonical 10)
+    UNKNOWN_AUTHOR    author not present in textbooks.author_uk
     OK                resolves cleanly with on-topic chunk
 
-The resolver uses the FIXED LIKE pattern (both `%-{translit}-%` AND
-`%-{translit}`) so the matcher bug for source_files without a year
-suffix (e.g. `4-klas-ukrmova-zaharijchuk`) does not produce spurious
-GHOST_SOURCE flags.
+The resolver queries ``textbooks.author_uk`` directly (Cyrillic-native).
+Spelling variants are canonicalized via ``_canonicalize_author_uk``
+(Литвінова ≡ Литвінова, Пономарьова ≡ Пономарова). See
+``docs/decisions/2026-05-15-cyrillic-native-matcher.md`` for the
+decolonization rationale.
 
 Usage:
     .venv/bin/python scripts/audit/plan_references_audit.py
@@ -36,7 +37,6 @@ import json
 import re
 import sqlite3
 import sys
-from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -62,31 +62,20 @@ PLAN_AUDIT_LEVEL_MISMATCH_THRESHOLDS: dict[str, int] = {
     "c2": 11,
 }
 
-# Mirror of scripts/build/linear_pipeline.py:_TEXTBOOK_AUTHOR_TRANSLITS.
-# Edit there, not here — this is the audit's reference snapshot.
-CANONICAL_TRANSLITS: dict[str, list[str]] = {
-    "Караман": ["karaman"],
-    "Захарійчук": ["zakhariychuk", "zaharijchuk", "zahariichuk"],
-    "Кравцова": ["kravcova", "kravtsova"],
-    "Авраменко": ["avramenko"],
-    "Глазова": ["glazova", "hlazova"],
-    "Заболотний": ["zabolotnyi", "zabolotnij"],
-    "Захарчук": ["zakharchuk"],
-    "Вашуленко": ["vashulenko"],
-    "Большакова": ["bolshakova"],
-    "Міщенко": ["mishhenko", "mishchenko"],
-    "Літвінова": ["litvinova"],
-    "Литвінова": ["litvinova"],
-    "Голуб": ["golub"],
-    "Варзацька": ["varzatska"],
-    "Пономарова": ["ponomarova"],
-    "Пономарьова": ["ponomarova"],
+# Cyrillic spelling-variant canonicalization. Pure Cyrillic-to-Cyrillic
+# mapping for plan citations that use a non-canonical spelling
+# (Литвінова → Літвінова; Пономарьова → Пономарова). Mirrors
+# scripts/build/linear_pipeline.py:_CYRILLIC_AUTHOR_CANONICAL. Edit
+# there, not here — this is the audit's reference snapshot.
+_CYRILLIC_AUTHOR_CANONICAL: dict[str, str] = {
+    "Литвінова": "Літвінова",
+    "Пономарьова": "Пономарова",
 }
 
-# Authors observed in plans but not in CANONICAL_TRANSLITS. Used to
-# suggest extensions to _TEXTBOOK_AUTHOR_TRANSLITS in the aggregate
-# findings section — never to silently resolve UNKNOWN_AUTHOR citations.
-SUGGESTED_TRANSLITS: dict[str, list[str]] = {}
+
+def _canonicalize_author_uk(author: str) -> str:
+    """Canonical-form lookup; pass-through on miss."""
+    return _CYRILLIC_AUTHOR_CANONICAL.get(author, author)
 
 # "Author Grade N, p.M" / "с. M" / "стор. M". Cyrillic author block,
 # Grade integer, then a page-style marker followed by digits.
@@ -225,26 +214,34 @@ def _extract_citations(
 
 
 def _source_files_for(
-    conn: sqlite3.Connection, translits: Iterable[str], grade: int
+    conn: sqlite3.Connection, author_uk: str, grade: int
 ) -> list[str]:
-    """FIXED matcher: matches `%-translit-%` (year suffix present) OR
-    `%-translit` (no year suffix, e.g. 4-klas-ukrmova-zaharijchuk)."""
-    translits = list(translits)
-    if not translits:
+    """Cyrillic-native matcher: queries textbooks.author_uk + grade directly.
+
+    Applies _canonicalize_author_uk to handle spelling variants
+    (Литвінова ≡ Літвінова, Пономарьова ≡ Пономарова).
+    """
+    if not author_uk:
         return []
-    clauses = []
-    params: list[str] = [f"{grade}-klas-%"]
-    for t in translits:
-        clauses.append("source_file LIKE ?")
-        params.append(f"%-{t}-%")
-        clauses.append("source_file LIKE ?")
-        params.append(f"%-{t}")
-    sql = (
-        "SELECT DISTINCT source_file FROM textbooks "
-        f"WHERE source_file LIKE ? AND ({' OR '.join(clauses)})"
-    )
-    rows = conn.execute(sql, params).fetchall()
+    canonical = _canonicalize_author_uk(author_uk)
+    rows = conn.execute(
+        (
+            "SELECT DISTINCT source_file FROM textbooks "
+            "WHERE author_uk = ? AND grade = ?"
+        ),
+        (canonical, str(grade)),
+    ).fetchall()
     return sorted(str(r[0]) for r in rows)
+
+
+def _author_uk_exists(conn: sqlite3.Connection, author_uk: str) -> bool:
+    """True iff at least one row exists with this Cyrillic author at any grade."""
+    canonical = _canonicalize_author_uk(author_uk)
+    row = conn.execute(
+        "SELECT 1 FROM textbooks WHERE author_uk = ? LIMIT 1",
+        (canonical,),
+    ).fetchone()
+    return row is not None
 
 
 def _fetch_chunk(
@@ -318,39 +315,21 @@ def _classify_level_mismatch(level: str, grade: int) -> bool:
 def _audit_citation(
     cite: Citation, plan_text: str, conn: sqlite3.Connection
 ) -> Finding:
-    canonical = CANONICAL_TRANSLITS.get(cite.author)
-
-    if canonical is None:
-        # UNKNOWN_AUTHOR — note if SUGGESTED_TRANSLITS would resolve it.
-        suggested = SUGGESTED_TRANSLITS.get(cite.author)
-        if suggested:
-            files = _source_files_for(conn, suggested, cite.grade)
-            if files:
-                fix = (
-                    f"add {cite.author!r}: {suggested!r} to "
-                    f"_TEXTBOOK_AUTHOR_TRANSLITS (corpus has {files[0]})"
-                )
-            else:
-                fix = (
-                    f"add {cite.author!r}: {suggested!r} to "
-                    f"_TEXTBOOK_AUTHOR_TRANSLITS — but Grade "
-                    f"{cite.grade} not in corpus"
-                )
-        else:
-            fix = (
-                f"unknown author {cite.author!r}; verify against "
-                "data/sources.db"
-            )
+    if not _author_uk_exists(conn, cite.author):
+        fix = (
+            f"unknown author {cite.author!r}; not present in "
+            "textbooks.author_uk (verify spelling or add to corpus)"
+        )
         return Finding(citation=cite, mode="UNKNOWN_AUTHOR", detail=fix)
 
-    files = _source_files_for(conn, canonical, cite.grade)
+    files = _source_files_for(conn, cite.author, cite.grade)
     if not files:
         return Finding(
             citation=cite,
             mode="GHOST_SOURCE",
             detail=(
                 f"{cite.author} Grade {cite.grade} not in corpus "
-                f"(translits tried: {canonical})"
+                f"(canonical: {_canonicalize_author_uk(cite.author)!r})"
             ),
             suggested_fix="drop citation or replace with a grade in corpus",
         )
@@ -534,7 +513,7 @@ def _render_markdown(
 
     lines.append("## Aggregate findings")
     lines.append("")
-    lines.append("### Authors to add to `_TEXTBOOK_AUTHOR_TRANSLITS`")
+    lines.append("### Authors absent from `textbooks.author_uk`")
     lines.append("")
     unknown_by_author: dict[str, int] = {}
     for f in findings:
@@ -543,19 +522,14 @@ def _render_markdown(
                 unknown_by_author.get(f.citation.author, 0) + 1
             )
     if unknown_by_author:
-        lines.append(
-            "| author | citations affected | suggested translits | corpus has it? |"
-        )
-        lines.append("| --- | --- | --- | --- |")
+        lines.append("| author | citations affected |")
+        lines.append("| --- | --- |")
         for author in sorted(unknown_by_author):
-            translits = SUGGESTED_TRANSLITS.get(author, [])
-            in_corpus = "yes" if translits else "unknown"
-            lines.append(
-                f"| {author} | {unknown_by_author[author]} | "
-                f"{translits or '—'} | {in_corpus} |"
-            )
+            lines.append(f"| {author} | {unknown_by_author[author]} |")
     else:
-        lines.append("_All cited authors are in `_TEXTBOOK_AUTHOR_TRANSLITS`._")
+        lines.append(
+            "_All cited authors resolve against `textbooks.author_uk`._"
+        )
     lines.append("")
 
     lines.append("### Level-mismatch summary")
@@ -616,8 +590,9 @@ def _render_markdown(
     )
     lines.append(
         "- GHOST_SOURCE and GHOST_PAGE are deterministic against "
-        "`data/sources.db` using the FIXED LIKE pattern "
-        "(`%-translit-%` OR `%-translit`)."
+        "`data/sources.db` via direct `textbooks.author_uk = ? AND grade = ?` "
+        "queries (Cyrillic-native matcher; see ADR "
+        "`docs/decisions/2026-05-15-cyrillic-native-matcher.md`)."
     )
     lines.append("")
     return "\n".join(lines)

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -927,24 +927,33 @@ _TEXTBOOK_REFERENCE_TITLE_RE = re.compile(
     r"^(?P<author>\S+)\s+Grade\s+(?P<grade>\d+),\s*p\.\s*(?P<page>\d+)$",
     re.IGNORECASE,
 )
-_TEXTBOOK_AUTHOR_TRANSLITS = {
-    "Караман": ["karaman"],
-    "Захарійчук": ["zakhariychuk", "zaharijchuk", "zahariichuk"],
-    "Кравцова": ["kravcova", "kravtsova"],
-    "Авраменко": ["avramenko"],
-    "Глазова": ["glazova", "hlazova"],
-    "Заболотний": ["zabolotnyi", "zabolotnij"],
-    "Захарчук": ["zakharchuk"],
-    "Вашуленко": ["vashulenko"],
-    "Большакова": ["bolshakova"],
-    "Міщенко": ["mishhenko", "mishchenko"],
-    "Літвінова": ["litvinova"],
-    "Литвінова": ["litvinova"],
-    "Голуб": ["golub"],
-    "Варзацька": ["varzatska"],
-    "Пономарова": ["ponomarova"],
-    "Пономарьова": ["ponomarova"],
+
+# Cyrillic spelling-variant canonicalization. Maps non-canonical Cyrillic
+# author spellings (regional/historical variants like Литвінова or the
+# soft-sign-bearing Пономарьова) to the canonical form stored in
+# textbooks.author_uk. This is NOT transliteration — it never crosses
+# writing systems. Add entries only when a real plan citation surfaces a
+# variant spelling not in textbooks.author_uk.
+_CYRILLIC_AUTHOR_CANONICAL: dict[str, str] = {
+    "Литвінова": "Літвінова",
+    "Пономарьова": "Пономарова",
 }
+
+# Historical: an _TEXTBOOK_AUTHOR_TRANSLITS dict lived here and mapped
+# Cyrillic plan-author names to Latin source_file fragments. It is gone:
+# the matcher now queries textbooks.author_uk directly (Cyrillic-native).
+# The Latin→Cyrillic bridge survives only in
+# scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py for the
+# one-time back-fill of historical rows. See ADR
+# docs/decisions/2026-05-15-cyrillic-native-matcher.md.
+
+
+def _canonicalize_author_uk(author: str) -> str:
+    """Map a Cyrillic author name to its canonical form (handles spelling variants).
+
+    Pure Cyrillic-to-Cyrillic mapping; never crosses writing systems.
+    """
+    return _CYRILLIC_AUTHOR_CANONICAL.get(author, author)
 
 
 def _parse_textbook_reference_title(title: str) -> tuple[str, int, int] | None:
@@ -968,24 +977,29 @@ def _source_files_for_textbook_reference(
     author: str,
     grade: int,
 ) -> list[str] | None:
-    translits = _TEXTBOOK_AUTHOR_TRANSLITS.get(author)
-    if not translits:
+    """Resolve source_files for a Cyrillic-author + grade citation.
+
+    Queries textbooks.author_uk directly — no transliteration, no
+    LIKE patterns. Returns None if the author has no rows at any grade
+    (treated as "unknown author"), [] if rows exist for the author but
+    not at this grade, or a non-empty list of source_files.
+    """
+    canonical = _canonicalize_author_uk(author)
+    has_any_rows = conn.execute(
+        "SELECT 1 FROM textbooks WHERE author_uk = ? LIMIT 1",
+        (canonical,),
+    ).fetchone()
+    if has_any_rows is None:
         return None
 
-    patterns = [
-        pattern
-        for translit in translits
-        for pattern in (f"%-{translit}-%", f"%-{translit}")
-    ]
-    author_clauses = " OR ".join("source_file LIKE ?" for _ in patterns)
     rows = conn.execute(
-        f"""
+        """
         SELECT DISTINCT source_file
         FROM textbooks
-        WHERE source_file LIKE ?
-          AND ({author_clauses})
+        WHERE author_uk = ?
+          AND grade = ?
         """,
-        (f"{grade}-klas-%", *patterns),
+        (canonical, str(grade)),
     ).fetchall()
     return sorted(
         (str(row["source_file"]) for row in rows),

--- a/scripts/ingest/antonenko_full_book_ingest.py
+++ b/scripts/ingest/antonenko_full_book_ingest.py
@@ -84,6 +84,9 @@ REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
 SOURCE_FILE = "antonenko-davydovych-yak-my-hovorymo"
 TXT_FILENAME = "antonenko-davydovych-yak-my-hovorymo-1991.txt"
 AUTHOR = "Borys Antonenko-Davydovych"
+# Canonical Cyrillic author; populates textbooks.author_uk so the
+# Cyrillic-native matcher resolves citations.
+AUTHOR_UK = "Борис Антоненко-Давидович"
 EXPECTED_PAGES = 169
 
 
@@ -170,7 +173,16 @@ def ingest_pages(
         text = page.render()
         title = f"Antonenko-Davydovych «Як ми говоримо», p. {page.number}"
         batch.append(
-            (chunk_id, title, text, SOURCE_FILE, "", AUTHOR, len(text))
+            (
+                chunk_id,
+                title,
+                text,
+                SOURCE_FILE,
+                "",
+                AUTHOR,
+                AUTHOR_UK,
+                len(text),
+            )
         )
         new_sections.append(
             LessonSection(
@@ -185,8 +197,9 @@ def ingest_pages(
     if batch:
         cur.executemany(
             """INSERT INTO textbooks
-                  (chunk_id, title, text, source_file, grade, author, char_count)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                  (chunk_id, title, text, source_file, grade, author,
+                   author_uk, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             batch,
         )
         link_lesson_sections(

--- a/scripts/ingest/ohoiko_books_ingest.py
+++ b/scripts/ingest/ohoiko_books_ingest.py
@@ -97,6 +97,9 @@ class BookConfig:
     source_file: str  # textbooks.source_file value
     txt_filename: str  # relative to REFERENCES_DIR
     author: str
+    # Canonical Cyrillic author (populates textbooks.author_uk; required
+    # by the Cyrillic-native matcher).
+    author_uk: str
     grade: str  # left empty for Ohoiko books; reserved for CEFR mapping later
     max_entry_number: int  # advertised entry count (hard cap)
 
@@ -107,6 +110,7 @@ BOOKS: dict[str, BookConfig] = {
         source_file="anna-ohoiko-1000-words-2nd-ed",
         txt_filename="1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt",
         author="Anna Ohoiko",
+        author_uk="Анна Огоїко",
         grade="",
         # The 2nd edition advertises "1000 Most Useful Ukrainian Words"
         # and the alphabetical entries run #1..#1000 exactly. After
@@ -347,6 +351,7 @@ def ingest_entries(
                 book.source_file,
                 book.grade,
                 book.author,
+                book.author_uk,
                 len(text),
             )
         )
@@ -367,8 +372,9 @@ def ingest_entries(
     if batch:
         cur.executemany(
             """INSERT INTO textbooks
-                  (chunk_id, title, text, source_file, grade, author, char_count)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                  (chunk_id, title, text, source_file, grade, author,
+                   author_uk, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             batch,
         )
         link_lesson_sections(

--- a/scripts/ingest/ohoiko_verbs_ingest.py
+++ b/scripts/ingest/ohoiko_verbs_ingest.py
@@ -66,6 +66,9 @@ REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
 SOURCE_FILE = "anna-ohoiko-500-verbs"
 TXT_FILENAME = "500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt"
 AUTHOR = "Anna Ohoiko"
+# Canonical Cyrillic author; populates textbooks.author_uk so the
+# Cyrillic-native matcher resolves citations.
+AUTHOR_UK = "Анна Огоїко"
 MAX_VERB_NUMBER = 500  # hard cap; book advertises "500+ verbs" but the
 # numbered series ends at exactly #500.
 
@@ -315,6 +318,7 @@ def ingest_verbs(
                 SOURCE_FILE,
                 "",  # grade
                 AUTHOR,
+                AUTHOR_UK,
                 len(text),
             )
         )
@@ -331,8 +335,9 @@ def ingest_verbs(
     if batch:
         cur.executemany(
             """INSERT INTO textbooks
-                  (chunk_id, title, text, source_file, grade, author, char_count)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                  (chunk_id, title, text, source_file, grade, author,
+                   author_uk, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             batch,
         )
         link_lesson_sections(

--- a/scripts/ingest/pohribnyi_pronunciation_ingest.py
+++ b/scripts/ingest/pohribnyi_pronunciation_ingest.py
@@ -84,6 +84,9 @@ REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
 SOURCE_FILE = "pohribnyi-ukrainska-literaturna-vymova-1992"
 TXT_FILENAME = "pohribnyi-ukrainska-literaturna-vymova-1992.txt"
 AUTHOR = "Mykola Pohribnyi"
+# Canonical Cyrillic author; populates textbooks.author_uk so the
+# Cyrillic-native matcher resolves citations.
+AUTHOR_UK = "Микола Погрібний"
 EXPECTED_PAGES = 28  # Verified against pdfinfo of the 1992 booklet.
 
 
@@ -205,6 +208,7 @@ def ingest_pages(
                 SOURCE_FILE,
                 "",  # grade (TEXT-typed on textbooks; sections use sentinel 0)
                 AUTHOR,
+                AUTHOR_UK,
                 len(text),
             )
         )
@@ -221,8 +225,9 @@ def ingest_pages(
     if batch:
         cur.executemany(
             """INSERT INTO textbooks
-                  (chunk_id, title, text, source_file, grade, author, char_count)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                  (chunk_id, title, text, source_file, grade, author,
+                   author_uk, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             batch,
         )
         link_lesson_sections(

--- a/scripts/ingest/ulp_lesson_notes_ingest.py
+++ b/scripts/ingest/ulp_lesson_notes_ingest.py
@@ -68,6 +68,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DB_PATH = PROJECT_ROOT / "data" / "sources.db"
 REFERENCES_DIR = PROJECT_ROOT / "docs" / "references" / "private"
 AUTHOR = "Ukrainian Lessons Podcast"
+# Cyrillic canonical form; populated into textbooks.author_uk so the
+# Cyrillic-native matcher resolves citations. The ULP brand name has no
+# direct Cyrillic translation, so we keep it as-is — the canonical form
+# is the brand. See ADR docs/decisions/2026-05-15-cyrillic-native-matcher.md.
+AUTHOR_UK = "Ukrainian Lessons Podcast"
 
 # ---------------------------------------------------------------------------
 # Marker patterns
@@ -437,6 +442,7 @@ def ingest_lessons(
                 book.source_file,
                 "",  # grade (textbooks.grade is TEXT; sections use sentinel 0)
                 AUTHOR,
+                AUTHOR_UK,
                 len(text),
             )
         )
@@ -453,8 +459,9 @@ def ingest_lessons(
     if batch:
         cur.executemany(
             """INSERT INTO textbooks
-                  (chunk_id, title, text, source_file, grade, author, char_count)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                  (chunk_id, title, text, source_file, grade, author,
+                   author_uk, char_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             batch,
         )
         link_lesson_sections(

--- a/scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py
+++ b/scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py
@@ -1,0 +1,303 @@
+"""Add ``author_uk`` (Cyrillic) column to ``textbooks`` and back-fill it.
+
+This migration retires runtime transliteration from the textbook matcher.
+Historically, ``textbooks.author`` stored Latin-romanized author names
+(``zabolotnyi``, ``glazova``, ``golub``) because scraping pipelines used
+Russian-mediated romanization schemes. Plan files cite authors in
+Cyrillic (``Заболотний``, ``Глазова``, ``Голуб``), so the runtime matcher
+maintained a Cyrillic→Latin translit dictionary and matched via
+``source_file LIKE %-translit-%`` patterns.
+
+After this migration:
+
+* ``textbooks.author_uk`` holds the canonical Cyrillic form of the author.
+* The runtime matcher queries ``WHERE author_uk = ? AND grade = ?`` —
+  no transliteration, no LIKE patterns.
+* The Latin ``author`` column stays for backwards compatibility with
+  archived analytics and corpus-naming history (Latin source_file strings
+  on disk are renamed in a separate follow-up PR).
+
+The ``_LATIN_TO_UK`` dict below is the ONLY place transliteration is still
+acknowledged in the codebase. It's a one-time bridge from the
+Latin-named past to the Cyrillic-clean future. New ingestion paths must
+supply ``author_uk`` explicitly (see ``scripts/wiki/build_sources_db.py``
+and ``scripts/ingest/*``).
+
+See ADR ``docs/decisions/2026-05-15-cyrillic-native-matcher.md`` for the
+decolonization rationale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
+
+
+@dataclass
+class MigrationStatus:
+    column_added: bool = False
+    rows_updated: int = 0
+    unmapped_authors: list[str] = field(default_factory=list)
+    total_rows: int = 0
+    populated_author_uk: int = 0
+
+
+# Inverted from the historical _TEXTBOOK_AUTHOR_TRANSLITS dict
+# (plus the 6 entries added in PR #2013 and additional corpus authors
+# discovered via SELECT DISTINCT author FROM textbooks). Latin keys are
+# matched verbatim against textbooks.author.
+_LATIN_TO_UK: dict[str, str] = {
+    # Core mova/lit textbook authors (originally in TRANSLITS)
+    "karaman": "Караман",
+    "zakhariychuk": "Захарійчук",
+    "zaharijchuk": "Захарійчук",
+    "zahariichuk": "Захарійчук",
+    "kravcova": "Кравцова",
+    "kravtsova": "Кравцова",
+    "avramenko": "Авраменко",
+    "glazova": "Глазова",
+    "hlazova": "Глазова",
+    "zabolotnyi": "Заболотний",
+    "zabolotnij": "Заболотний",
+    "zakharchuk": "Захарчук",
+    "vashulenko": "Вашуленко",
+    "bolshakova": "Большакова",
+    "mishhenko": "Міщенко",
+    "mishchenko": "Міщенко",
+    "litvinova": "Літвінова",
+    "golub": "Голуб",
+    "varzatska": "Варзацька",
+    "ponomarova": "Пономарова",
+    # Additional textbook authors present in the corpus
+    "borzenko": "Борзенко",
+    "burnejko": "Бурнейко",
+    "galimov": "Галімов",
+    "gisem": "Гісем",
+    # Хлібовська: front-matter of 7-klas/8-klas/11-klas history textbooks
+    # confirms Х (Kh), not Г — the Latin transliteration here is unusual
+    # (h→Х instead of the more common h→Г). Verified via in-corpus
+    # textbook front-matter (2026-05-15 audit).
+    "hlibovska": "Хлібовська",
+    "kovalenko": "Коваленко",
+    "onatiy": "Онатій",
+    "pometun": "Пометун",
+    "savchenko": "Савченко",
+    "savchuk": "Савчук",
+    "schupak": "Щупак",
+    "shchupak": "Щупак",
+    "voron": "Ворон",
+    # Non-textbook author-name strings already stored in Latin/English on
+    # ingestion (literary works, podcast, style-guide author). Map them
+    # to Cyrillic so author_uk is uniformly Cyrillic when populated.
+    "Anna Ohoiko": "Анна Огоїко",
+    "Borys Antonenko-Davydovych": "Борис Антоненко-Давидович",
+    "Mykola Pohribnyi": "Микола Погрібний",
+    "Ukrainian Lessons Podcast": "Ukrainian Lessons Podcast",
+}
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def _ensure_column(conn: sqlite3.Connection, *, dry_run: bool) -> bool:
+    """Add author_uk column to textbooks if missing. Returns True if added.
+
+    In dry-run mode, returns whether the column WOULD be added but does
+    not touch the schema.
+    """
+    if _has_column(conn, "textbooks", "author_uk"):
+        return False
+    if not dry_run:
+        conn.execute("ALTER TABLE textbooks ADD COLUMN author_uk TEXT DEFAULT ''")
+    return True
+
+
+def _distinct_authors(conn: sqlite3.Connection) -> list[str]:
+    rows = conn.execute(
+        "SELECT DISTINCT author FROM textbooks WHERE author IS NOT NULL AND author != ''"
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _author_uk_for(latin: str) -> str | None:
+    """Return canonical Cyrillic form for a stored ``textbooks.author`` value.
+
+    If the input is already Cyrillic (post-migration ingestion), return it
+    unchanged. Otherwise look up the Latin key.
+    """
+    if not latin:
+        return None
+    if any("Ѐ" <= ch <= "ӿ" for ch in latin):
+        return latin
+    return _LATIN_TO_UK.get(latin)
+
+
+def _backfill(
+    conn: sqlite3.Connection,
+    *,
+    dry_run: bool,
+    column_exists: bool,
+) -> tuple[int, list[str]]:
+    """Back-fill author_uk from author. Returns (rows_updated, unmapped).
+
+    If ``column_exists`` is False (dry-run before ALTER TABLE), the
+    idempotency filter is skipped — we count all rows with a non-empty
+    author as "would update".
+    """
+    updated_total = 0
+    unmapped: list[str] = []
+    for author in _distinct_authors(conn):
+        author_uk = _author_uk_for(author)
+        if author_uk is None:
+            unmapped.append(author)
+            continue
+        if column_exists:
+            count_sql = """
+                SELECT COUNT(*) FROM textbooks
+                WHERE author = ?
+                  AND (author_uk IS NULL OR author_uk = '')
+            """
+        else:
+            count_sql = "SELECT COUNT(*) FROM textbooks WHERE author = ?"
+        cursor = conn.execute(count_sql, (author,))
+        count = int(cursor.fetchone()[0])
+        if count == 0:
+            continue
+        if not dry_run:
+            conn.execute(
+                """
+                UPDATE textbooks SET author_uk = ?
+                WHERE author = ?
+                  AND (author_uk IS NULL OR author_uk = '')
+                """,
+                (author_uk, author),
+            )
+        updated_total += count
+    return updated_total, unmapped
+
+
+def _backfill_orphan_rows_from_source_file(
+    conn: sqlite3.Connection,
+    *,
+    dry_run: bool,
+    column_exists: bool,
+) -> int:
+    """Back-fill author_uk for rows with empty ``author`` by parsing ``source_file``.
+
+    Some legacy textbook chunks were ingested with an empty ``author``
+    column (e.g. ``4-klas-ukrmova-zaharijchuk`` — 195 rows with author='').
+    The Latin author is embedded in the source_file slug, so we can still
+    derive author_uk via the _LATIN_TO_UK bridge with a LIKE match on
+    each Latin key.
+
+    Returns the number of rows updated (or that WOULD be updated under dry-run).
+    """
+    if not column_exists:
+        return 0
+    updated_total = 0
+    for latin, cyrillic in _LATIN_TO_UK.items():
+        # source_file slug shape: {N}-klas-{...}-{translit}[-{year-or-suffix}]
+        pattern_mid = f"%-{latin}-%"
+        pattern_end = f"%-{latin}"
+        count = int(
+            conn.execute(
+                """
+                SELECT COUNT(*) FROM textbooks
+                WHERE (author IS NULL OR author = '')
+                  AND (author_uk IS NULL OR author_uk = '')
+                  AND (source_file LIKE ? OR source_file LIKE ?)
+                """,
+                (pattern_mid, pattern_end),
+            ).fetchone()[0]
+        )
+        if count == 0:
+            continue
+        if not dry_run:
+            conn.execute(
+                """
+                UPDATE textbooks SET author_uk = ?
+                WHERE (author IS NULL OR author = '')
+                  AND (author_uk IS NULL OR author_uk = '')
+                  AND (source_file LIKE ? OR source_file LIKE ?)
+                """,
+                (cyrillic, pattern_mid, pattern_end),
+            )
+        updated_total += count
+    return updated_total
+
+
+def apply(conn: sqlite3.Connection, *, dry_run: bool = False) -> MigrationStatus:
+    """Apply the migration idempotently."""
+    had_column_before = _has_column(conn, "textbooks", "author_uk")
+    column_added = _ensure_column(conn, dry_run=dry_run)
+    updated, unmapped = _backfill(
+        conn, dry_run=dry_run, column_exists=had_column_before
+    )
+    updated += _backfill_orphan_rows_from_source_file(
+        conn,
+        dry_run=dry_run,
+        column_exists=had_column_before or not dry_run,
+    )
+    if not dry_run:
+        conn.commit()
+    total_rows = int(conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0])
+    if had_column_before or not dry_run:
+        populated_author_uk = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM textbooks "
+                "WHERE author_uk IS NOT NULL AND author_uk != ''"
+            ).fetchone()[0]
+        )
+    else:
+        # Dry-run before column exists: nothing is populated yet.
+        populated_author_uk = 0
+    return MigrationStatus(
+        column_added=column_added,
+        rows_updated=updated,
+        unmapped_authors=unmapped,
+        total_rows=total_rows,
+        populated_author_uk=populated_author_uk,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.db.exists():
+        raise SystemExit(f"Sources DB not found: {args.db}")
+
+    with sqlite3.connect(str(args.db)) as conn:
+        status = apply(conn, dry_run=args.dry_run)
+
+    prefix = "[dry-run] " if args.dry_run else ""
+    print(f"{prefix}column_added={status.column_added}")
+    print(f"{prefix}rows_updated={status.rows_updated}")
+    print(
+        f"{prefix}populated_author_uk={status.populated_author_uk}/"
+        f"{status.total_rows} (rows with Cyrillic author_uk / total textbook rows)"
+    )
+    if status.unmapped_authors:
+        print(f"{prefix}WARNING: unmapped Latin authors (no Cyrillic mapping):")
+        for name in sorted(status.unmapped_authors):
+            print(f"{prefix}  - {name}")
+    else:
+        print(f"{prefix}all distinct authors mapped to Cyrillic.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -77,6 +77,10 @@ CREATE TABLE IF NOT EXISTS textbooks (
     source_file TEXT NOT NULL DEFAULT '',
     grade TEXT DEFAULT '',
     author TEXT DEFAULT '',
+    -- author_uk: canonical Cyrillic form of the author. Populated by
+    -- ingestion or back-filled via scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py.
+    -- Matcher queries this column directly (Cyrillic-native).
+    author_uk TEXT DEFAULT '',
     char_count INTEGER DEFAULT 0
 );
 CREATE VIRTUAL TABLE IF NOT EXISTS textbooks_fts USING fts5(
@@ -265,6 +269,42 @@ CREATE TABLE IF NOT EXISTS wikipedia_negative_cache (
 
 def _normalize_url(url: str) -> str:
     return url.replace("://www.", "://")
+
+
+def _build_textbook_row(
+    entry: dict,
+    *,
+    source_file: str,
+    grade: str,
+    chunk_index: int,
+) -> tuple:
+    """Assemble a textbooks-table row tuple from a JSONL entry.
+
+    Requires ``author_uk`` (canonical Cyrillic author form) in every entry
+    that supplies a non-empty ``author``. Raises ``ValueError`` otherwise.
+    The matcher in ``scripts/build/linear_pipeline.py`` queries
+    ``author_uk`` directly — silently inserting rows with empty
+    ``author_uk`` would break textbook citation resolution.
+    """
+    author = str(entry.get("author") or "").strip()
+    author_uk = str(entry.get("author_uk") or "").strip()
+    if author and not author_uk:
+        raise ValueError(
+            f"Textbook entry in {source_file} (chunk {chunk_index}) has "
+            f"author={author!r} but no author_uk. Ingestion paths must "
+            "supply the canonical Cyrillic author form. See ADR "
+            "docs/decisions/2026-05-15-cyrillic-native-matcher.md."
+        )
+    return (
+        entry.get("chunk_id", f"tb-{source_file}-{chunk_index}"),
+        entry.get("section_title", ""),
+        entry.get("text", ""),
+        source_file,
+        entry.get("grade", grade),
+        author,
+        author_uk,
+        entry.get("token_count", len(entry.get("text", ""))),
+    )
 
 
 def _ingest_jsonl(conn: sqlite3.Connection, table: str, jsonl_path: Path,
@@ -584,8 +624,9 @@ def build(db_path: Path | None = None,
     # --- Textbook chunks ---
     print("\n📖 Textbooks")
     tb_sql = """INSERT INTO textbooks
-                (chunk_id, title, text, source_file, grade, author, char_count)
-                VALUES (?, ?, ?, ?, ?, ?, ?)"""
+                (chunk_id, title, text, source_file, grade, author,
+                 author_uk, char_count)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
     if tb_dir.exists():
         for grade_dir in sorted(tb_dir.glob("grade-*")):
             grade = grade_dir.name
@@ -598,14 +639,11 @@ def build(db_path: Path | None = None,
                         if not line:
                             continue
                         entry = json.loads(line)
-                        batch.append((
-                            entry.get("chunk_id", f"tb-{source_file}-{len(batch)}"),
-                            entry.get("section_title", ""),
-                            entry.get("text", ""),
-                            source_file,
-                            entry.get("grade", grade),
-                            entry.get("author", ""),
-                            entry.get("token_count", len(entry.get("text", ""))),
+                        batch.append(_build_textbook_row(
+                            entry,
+                            source_file=source_file,
+                            grade=grade,
+                            chunk_index=len(batch),
                         ))
                 if batch:
                     conn.executemany(tb_sql, batch)

--- a/scripts/wiki/rollback_sections.py
+++ b/scripts/wiki/rollback_sections.py
@@ -18,6 +18,7 @@ CREATE TABLE textbooks (
     source_file TEXT NOT NULL DEFAULT '',
     grade TEXT DEFAULT '',
     author TEXT DEFAULT '',
+    author_uk TEXT DEFAULT '',
     char_count INTEGER DEFAULT 0
 )
 """
@@ -37,8 +38,10 @@ def rebuild_textbooks_without_parent(conn: sqlite3.Connection) -> None:
     conn.execute(ORIGINAL_TEXTBOOKS_SCHEMA)
     conn.execute(
         """
-        INSERT INTO textbooks (id, chunk_id, title, text, source_file, grade, author, char_count)
-        SELECT id, chunk_id, title, text, source_file, grade, author, char_count
+        INSERT INTO textbooks (
+            id, chunk_id, title, text, source_file, grade, author, author_uk, char_count
+        )
+        SELECT id, chunk_id, title, text, source_file, grade, author, author_uk, char_count
         FROM textbooks__before_parent_rollback
         """
     )

--- a/tests/test_antonenko_full_book_ingest.py
+++ b/tests/test_antonenko_full_book_ingest.py
@@ -111,6 +111,7 @@ def _make_textbooks_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
         );
         """

--- a/tests/test_backfill_school_textbook_orphans.py
+++ b/tests/test_backfill_school_textbook_orphans.py
@@ -77,6 +77,7 @@ def _make_textbooks_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
         );
         """

--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -97,15 +97,15 @@ def test_plan_references_field_is_supported() -> None:
 
 def test_my_morning_module_passes_citations_resolve() -> None:
     # Source refs must match the LIVE plan_references at curriculum/l2-uk-en/
-    # plans/a1/my-morning.yaml (corrected by PR #1972: Караман p.176 → p.187,
-    # Кравцова Grade 4 p.113 removed as redundant with Захарійчук p.162's
-    # Білоус verse coverage of the same -шся/-ться pronunciation rule).
+    # plans/a1/my-morning.yaml. PR #2014 (2026-05-15) replaced the off-level
+    # `Караман Grade 10, p.187` citation with on-level `Захарійчук Grade 4,
+    # p.163`; this test is pinned to that current state.
     plan_path = linear_pipeline.PROJECT_ROOT / "curriculum/l2-uk-en/plans/a1/my-morning.yaml"
     plan = yaml.safe_load(plan_path.read_text("utf-8"))
     result = linear_pipeline._citation_gate(
         [
-            {"source_ref": "Караман, Українська мова, 10 клас, с. 187"},
             {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 162"},
+            {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 163"},
         ],
         plan,
     )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,145 @@
+"""Smoke tests for ``scripts/migrations/2026-05-15-add-author-uk-to-textbooks``.
+
+The migration is the one-time bridge from Latin-romanized
+``textbooks.author`` values to Cyrillic ``textbooks.author_uk``. Tests
+verify (1) the column is added, (2) the back-fill resolves both
+author-column rows and orphan rows via source_file inference, (3)
+re-running is a no-op.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _load_migration():
+    """Import the dated migration script under a stable module name.
+
+    Filename starts with a digit, so ``import`` won't reach it — load via
+    importlib.util.
+    """
+    repo = Path(__file__).resolve().parent.parent
+    src = (
+        repo
+        / "scripts"
+        / "migrations"
+        / "2026-05-15-add-author-uk-to-textbooks.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_mig_author_uk_2026_05_15", src
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_pre_migration_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO textbooks (chunk_id, title, text, source_file, "
+        "grade, author) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (
+                "10-klas-ukrmova-karaman-2018_s0187",
+                "Сторінка 187",
+                "...",
+                "10-klas-ukrmova-karaman-2018",
+                "10",
+                "karaman",
+            ),
+            # Orphan row: no author, but source_file contains the translit.
+            (
+                "4-klas-ukrmova-zaharijchuk_s0162",
+                "Сторінка 162",
+                "...",
+                "4-klas-ukrmova-zaharijchuk",
+                "4",
+                "",
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_migration_adds_column_and_backfills(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+    with sqlite3.connect(str(db)) as conn:
+        status = mig.apply(conn, dry_run=False)
+    assert status.column_added is True
+    assert status.rows_updated == 2  # one author-row + one orphan-row
+    with sqlite3.connect(str(db)) as conn:
+        row = conn.execute(
+            "SELECT author_uk FROM textbooks WHERE author = 'karaman'"
+        ).fetchone()
+        assert row[0] == "Караман"
+        row = conn.execute(
+            "SELECT author_uk FROM textbooks "
+            "WHERE source_file = '4-klas-ukrmova-zaharijchuk'"
+        ).fetchone()
+        assert row[0] == "Захарійчук"
+
+
+def test_migration_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+    with sqlite3.connect(str(db)) as conn:
+        first = mig.apply(conn, dry_run=False)
+    with sqlite3.connect(str(db)) as conn:
+        second = mig.apply(conn, dry_run=False)
+    assert first.column_added is True
+    assert second.column_added is False
+    assert second.rows_updated == 0
+    assert second.unmapped_authors == []
+
+
+def test_migration_dry_run_does_not_write(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+    with sqlite3.connect(str(db)) as conn:
+        status = mig.apply(conn, dry_run=True)
+    assert status.column_added is True  # would-add
+    with sqlite3.connect(str(db)) as conn:
+        # Column was not actually added in dry-run.
+        cols = [
+            row[1] for row in conn.execute("PRAGMA table_info(textbooks)").fetchall()
+        ]
+    assert "author_uk" not in cols
+    assert status.rows_updated >= 1  # would-update count is non-zero
+
+
+def test_migration_reports_unmapped_latin_authors(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute(
+            "INSERT INTO textbooks (chunk_id, source_file, grade, author) "
+            "VALUES ('x', 'x.jsonl', '5', 'fictional_author_xyz')"
+        )
+        conn.commit()
+        status = mig.apply(conn, dry_run=False)
+    assert "fictional_author_xyz" in status.unmapped_authors

--- a/tests/test_ohoiko_books_ingest.py
+++ b/tests/test_ohoiko_books_ingest.py
@@ -140,6 +140,7 @@ def _make_textbooks_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
         );
         """
@@ -161,6 +162,7 @@ def test_ingest_entries_round_trip(tmp_path: Path) -> None:
         source_file="test-fixture-source",
         txt_filename="fixture.txt",
         author="Anna Ohoiko",
+        author_uk="Анна Огоїко",
         grade="",
         max_entry_number=10,
     )
@@ -198,6 +200,7 @@ def test_ingest_entries_idempotent(tmp_path: Path) -> None:
         source_file="t",
         txt_filename="fixture.txt",
         author="A",
+        author_uk="А",
         grade="",
         max_entry_number=10,
     )
@@ -225,6 +228,7 @@ def test_ingest_entries_force_overwrites(tmp_path: Path) -> None:
         source_file="t",
         txt_filename="fixture.txt",
         author="A",
+        author_uk="А",
         grade="",
         max_entry_number=10,
     )

--- a/tests/test_ohoiko_verbs_ingest.py
+++ b/tests/test_ohoiko_verbs_ingest.py
@@ -161,6 +161,7 @@ def _make_full_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0,
             parent_section_id INTEGER REFERENCES textbook_sections(section_id)
         );

--- a/tests/test_plan_references_audit.py
+++ b/tests/test_plan_references_audit.py
@@ -45,12 +45,13 @@ def fake_db(tmp_path: Path) -> Path:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
         );
         """
     )
     rows = [
-        # year-suffix file — matched by `%-translit-%`
+        # year-suffix textbook
         (
             "4-klas-ukrayinska-mova-zaharijchuk-2021-1_s0162",
             "Сторінка 100",
@@ -59,8 +60,11 @@ def fake_db(tmp_path: Path) -> Path:
             "4-klas-ukrayinska-mova-zaharijchuk-2021-1",
             "4",
             "zaharijchuk",
+            "Захарійчук",
         ),
-        # no-year-suffix file — matched only by `%-translit`
+        # no-year-suffix textbook (legacy ingest left author empty;
+        # post-migration the orphan back-fill still populates author_uk
+        # via source_file pattern)
         (
             "4-klas-ukrmova-zaharijchuk_s0050",
             "Сторінка 50",
@@ -68,6 +72,7 @@ def fake_db(tmp_path: Path) -> Path:
             "4-klas-ukrmova-zaharijchuk",
             "4",
             "",
+            "Захарійчук",
         ),
         # Grade 10 textbook for level-mismatch + topic-mismatch cases
         (
@@ -77,11 +82,12 @@ def fake_db(tmp_path: Path) -> Path:
             "10-klas-ukrmova-karaman-2018",
             "10",
             "karaman",
+            "Караман",
         ),
     ]
     conn.executemany(
         "INSERT INTO textbooks (chunk_id, title, text, source_file, "
-        "grade, author) VALUES (?, ?, ?, ?, ?, ?)",
+        "grade, author, author_uk) VALUES (?, ?, ?, ?, ?, ?, ?)",
         rows,
     )
     conn.commit()
@@ -137,14 +143,41 @@ def test_parse_tracks_rejects_unknown_and_accepts_csv():
         _parse_tracks("")
 
 
-def test_source_files_for_fixed_pattern_catches_no_year_file(fake_db: Path):
-    """The FIXED matcher must find `4-klas-ukrmova-zaharijchuk` (no
-    year suffix) alongside the dated 2021 file."""
+def test_source_files_for_cyrillic_query_finds_both_files(fake_db: Path):
+    """The Cyrillic-native matcher resolves both the dated and undated
+    source_files when their author_uk = 'Захарійчук' and grade = '4'."""
     with sqlite3.connect(str(fake_db)) as conn:
         conn.row_factory = sqlite3.Row
-        files = _source_files_for(conn, ["zaharijchuk"], 4)
+        files = _source_files_for(conn, "Захарійчук", 4)
     assert "4-klas-ukrmova-zaharijchuk" in files
     assert "4-klas-ukrayinska-mova-zaharijchuk-2021-1" in files
+
+
+def test_source_files_for_canonicalizes_spelling_variants(fake_db: Path):
+    """Литвінова → Літвінова canonicalization in the audit's matcher."""
+    # Insert a Літвінова grade-7 row inline (the fake_db fixture covers
+    # only Захарійчук + Караман; this test extends it).
+    with sqlite3.connect(str(fake_db)) as conn:
+        conn.execute(
+            "INSERT INTO textbooks "
+            "(chunk_id, title, text, source_file, grade, author, author_uk) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "7-klas-ukrmova-litvinova-2024_s0055",
+                "Сторінка 51",
+                "Лексика. Прочитайте.",
+                "7-klas-ukrmova-litvinova-2024",
+                "7",
+                "litvinova",
+                "Літвінова",
+            ),
+        )
+        conn.commit()
+        conn.row_factory = sqlite3.Row
+        primary = _source_files_for(conn, "Літвінова", 7)
+        variant = _source_files_for(conn, "Литвінова", 7)
+    assert primary == variant
+    assert "7-klas-ukrmova-litvinova-2024" in primary
 
 
 def test_audit_citation_topic_mismatch(fake_db: Path):
@@ -233,6 +266,24 @@ def test_audit_citation_ghost_page(fake_db: Path):
 
 
 def test_audit_citation_ghost_source(fake_db: Path):
+    # Add a Міщенко row at Grade 7 so the author IS in the corpus, just
+    # not at Grade 4 — this is the GHOST_SOURCE semantic.
+    with sqlite3.connect(str(fake_db)) as conn:
+        conn.execute(
+            "INSERT INTO textbooks (chunk_id, title, text, source_file, "
+            "grade, author, author_uk) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "7-klas-ukrmova-mishhenko-2024_s0050",
+                "Сторінка 50",
+                "Фразеологізми.",
+                "7-klas-ukrmova-mishhenko-2024",
+                "7",
+                "mishhenko",
+                "Міщенко",
+            ),
+        )
+        conn.commit()
+
     cite = Citation(
         plan_slug="x",
         level="a1",
@@ -246,7 +297,7 @@ def test_audit_citation_ghost_source(fake_db: Path):
     with sqlite3.connect(str(fake_db)) as conn:
         conn.row_factory = sqlite3.Row
         finding = _audit_citation(cite, "test plan text", conn)
-    # Міщенко exists in TRANSLITS but not for Grade 4 in our fixture
+    # Міщенко exists in textbooks.author_uk (Grade 7) but not Grade 4.
     assert finding.mode == "GHOST_SOURCE"
 
 

--- a/tests/test_pohribnyi_pronunciation_ingest.py
+++ b/tests/test_pohribnyi_pronunciation_ingest.py
@@ -146,6 +146,7 @@ def _make_textbooks_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
         );
         """

--- a/tests/test_section_coverage.py
+++ b/tests/test_section_coverage.py
@@ -46,6 +46,7 @@ def _make_textbooks_db(path: Path, *, with_parent_col: bool = False) -> sqlite3.
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
             {parent_col_sql}
         );
@@ -206,6 +207,7 @@ def test_ohoiko_ingest_produces_zero_orphans(tmp_path: Path) -> None:
         source_file="test-ohoiko",
         txt_filename="ohoiko-fixture.txt",
         author="Anna Ohoiko",
+        author_uk="Анна Огоїко",
         grade="",
         max_entry_number=10,
     )
@@ -286,6 +288,7 @@ def test_ohoiko_force_rerun_keeps_zero_orphans(tmp_path: Path) -> None:
         source_file="t-ohoiko",
         txt_filename="f.txt",
         author="A",
+        author_uk="А",
         grade="",
         max_entry_number=10,
     )

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -53,7 +53,8 @@ def sample_data(tmp_path):
              "лексичного значення слова. Правильне вживання відмінкових форм є ознакою "
              "грамотного мовлення."
          ),
-         "grade": "5", "author": "avramenko", "token_count": 50},
+         "grade": "5", "author": "avramenko", "author_uk": "Авраменко",
+         "token_count": 50},
     ]
     with open(tb_dir / "5-klas-test.jsonl", "w") as f:
         for c in chunks:

--- a/tests/test_textbook_grounding.py
+++ b/tests/test_textbook_grounding.py
@@ -8,6 +8,12 @@ from scripts.build import linear_pipeline
 
 
 def _seed_textbook_db(path: Path, rows: list[dict[str, Any]]) -> None:
+    """Seed a textbooks table that matches the post-migration schema.
+
+    Rows MUST provide ``author_uk`` (Cyrillic). The legacy Latin
+    ``author`` field is optional and unused by the runtime matcher; it
+    is kept for backwards compatibility with archived analytics.
+    """
     with sqlite3.connect(str(path)) as conn:
         conn.execute(
             """
@@ -19,6 +25,7 @@ def _seed_textbook_db(path: Path, rows: list[dict[str, Any]]) -> None:
                 source_file TEXT NOT NULL,
                 grade TEXT,
                 author TEXT,
+                author_uk TEXT DEFAULT '',
                 char_count INTEGER DEFAULT 0,
                 parent_section_id INTEGER
             )
@@ -28,9 +35,9 @@ def _seed_textbook_db(path: Path, rows: list[dict[str, Any]]) -> None:
             conn.execute(
                 """
                 INSERT INTO textbooks (
-                    id, chunk_id, title, text, source_file, grade, author
+                    id, chunk_id, title, text, source_file, grade, author, author_uk
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     index,
@@ -40,6 +47,7 @@ def _seed_textbook_db(path: Path, rows: list[dict[str, Any]]) -> None:
                     row["source_file"],
                     row.get("grade", ""),
                     row.get("author", ""),
+                    row["author_uk"],
                 ),
             )
 
@@ -60,6 +68,7 @@ def test_karaman_grade10_p187_resolves_to_chunk(
                 "source_file": "10-klas-ukrmova-karaman-2018",
                 "grade": "10",
                 "author": "karaman",
+                "author_uk": "Караман",
             }
         ],
     )
@@ -91,6 +100,7 @@ def test_zakhariychuk_grade4_p162_reports_corpus_missing_deterministically(
                 "source_file": "4-klas-ukrayinska-mova-zaharijchuk-2021-1",
                 "grade": "4",
                 "author": "zaharijchuk",
+                "author_uk": "Захарійчук",
             }
         ],
     )
@@ -121,6 +131,7 @@ def test_zakhariychuk_grade4_p162_matches_source_file_without_suffix(
                 "source_file": "4-klas-ukrayinska-mova-zaharijchuk-2021-1",
                 "grade": "4",
                 "author": "zaharijchuk",
+                "author_uk": "Захарійчук",
             },
             {
                 "chunk_id": "4-klas-ukrmova-zaharijchuk_s0162",
@@ -129,6 +140,7 @@ def test_zakhariychuk_grade4_p162_matches_source_file_without_suffix(
                 "source_file": "4-klas-ukrmova-zaharijchuk",
                 "grade": "4",
                 "author": "zaharijchuk",
+                "author_uk": "Захарійчук",
             },
         ],
     )
@@ -193,6 +205,7 @@ def test_litvinova_grade7_p55_resolves_to_chunk(
                 "source_file": "7-klas-ukrmova-litvinova-2024",
                 "grade": "7",
                 "author": "litvinova",
+                "author_uk": "Літвінова",
             }
         ],
     )
@@ -227,6 +240,7 @@ def test_litvinova_cyrillic_variant_resolves_same_as_primary(
                 "source_file": "5-klas-ukrmova-litvinova-2022",
                 "grade": "5",
                 "author": "litvinova",
+                "author_uk": "Літвінова",
             }
         ],
     )
@@ -262,6 +276,7 @@ def test_golub_grade6_p179_resolves_to_chunk(
                 "source_file": "6-klas-ukrmova-golub-2023",
                 "grade": "6",
                 "author": "golub",
+                "author_uk": "Голуб",
             }
         ],
     )
@@ -293,6 +308,7 @@ def test_varzatska_grade4_p38_resolves_to_chunk(
                 "source_file": "4-klas-ukrayinska-mova-varzatska-2021-1",
                 "grade": "4",
                 "author": "varzatska",
+                "author_uk": "Варзацька",
             }
         ],
     )
@@ -327,6 +343,7 @@ def test_ponomarova_grade3_p86_resolves_to_chunk(
                 "source_file": "3-klas-ukrainska-mova-ponomarova-2020-1",
                 "grade": "3",
                 "author": "ponomarova",
+                "author_uk": "Пономарова",
             }
         ],
     )
@@ -364,6 +381,7 @@ def test_ponomarova_cyrillic_variant_resolves_same_as_primary(
                 "source_file": "4-klas-ukrayinska-mova-ponomarova-2021-1",
                 "grade": "4",
                 "author": "ponomarova",
+                "author_uk": "Пономарова",
             }
         ],
     )
@@ -397,6 +415,7 @@ def test_textbook_excerpt_context_uses_reference_title_for_direct_lookup(
                 "source_file": "10-klas-ukrmova-karaman-2018",
                 "grade": "10",
                 "author": "karaman",
+                "author_uk": "Караман",
             }
         ],
     )

--- a/tests/test_ulp_lesson_notes_ingest.py
+++ b/tests/test_ulp_lesson_notes_ingest.py
@@ -351,6 +351,7 @@ def _make_textbooks_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0
         );
         """

--- a/tests/test_wiki_backfill_source_attribution.py
+++ b/tests/test_wiki_backfill_source_attribution.py
@@ -33,7 +33,8 @@ CREATE TABLE textbooks (
     title TEXT NOT NULL DEFAULT '',
     source_file TEXT NOT NULL DEFAULT '',
     grade TEXT DEFAULT '',
-    author TEXT DEFAULT ''
+    author TEXT DEFAULT '',
+    author_uk TEXT DEFAULT ''
 );
 
 CREATE TABLE literary_texts (
@@ -42,6 +43,7 @@ CREATE TABLE literary_texts (
     title TEXT NOT NULL DEFAULT '',
     source_file TEXT NOT NULL DEFAULT '',
     author TEXT DEFAULT '',
+    author_uk TEXT DEFAULT '',
     work TEXT DEFAULT ''
 );
 

--- a/tests/test_wiki_source_attribution.py
+++ b/tests/test_wiki_source_attribution.py
@@ -34,7 +34,8 @@ def attribution_db(tmp_path, monkeypatch):
             title TEXT NOT NULL DEFAULT '',
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
-            author TEXT DEFAULT ''
+            author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT ''
         );
 
         CREATE TABLE literary_texts (
@@ -43,6 +44,7 @@ def attribution_db(tmp_path, monkeypatch):
             title TEXT NOT NULL DEFAULT '',
             source_file TEXT NOT NULL DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             work TEXT DEFAULT ''
         );
 

--- a/tests/test_wiki_sources_db.py
+++ b/tests/test_wiki_sources_db.py
@@ -25,6 +25,7 @@ def _make_conn() -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0,
             parent_section_id INTEGER
         )

--- a/tests/wiki/diagnostics/test_corpus_gaps.py
+++ b/tests/wiki/diagnostics/test_corpus_gaps.py
@@ -29,6 +29,7 @@ def _make_db(path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL,
             grade TEXT,
             author TEXT,
+            author_uk TEXT DEFAULT '',
             char_count INTEGER
         )
         """

--- a/tests/wiki/test_extract_sections.py
+++ b/tests/wiki/test_extract_sections.py
@@ -25,6 +25,7 @@ CREATE TABLE textbooks (
     source_file TEXT NOT NULL DEFAULT '',
     grade TEXT DEFAULT '',
     author TEXT DEFAULT '',
+    author_uk TEXT DEFAULT '',
     char_count INTEGER DEFAULT 0
 )
 """

--- a/tests/wiki/test_multi_corpus_retrieval.py
+++ b/tests/wiki/test_multi_corpus_retrieval.py
@@ -63,6 +63,7 @@ def _conn(tmp_path: Path) -> sqlite3.Connection:
             source_file TEXT NOT NULL,
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0,
             parent_section_id INTEGER
         );
@@ -92,6 +93,7 @@ def _conn(tmp_path: Path) -> sqlite3.Connection:
             text TEXT NOT NULL,
             source_file TEXT NOT NULL,
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             work TEXT DEFAULT '',
             work_id TEXT DEFAULT '',
             year INTEGER,

--- a/tests/wiki/test_search_sources.py
+++ b/tests/wiki/test_search_sources.py
@@ -24,6 +24,7 @@ def _make_conn() -> sqlite3.Connection:
             source_file TEXT NOT NULL DEFAULT '',
             grade TEXT DEFAULT '',
             author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
             char_count INTEGER DEFAULT 0,
             parent_section_id INTEGER
         )


### PR DESCRIPTION
## Summary

- Adds `textbooks.author_uk` (Cyrillic) column. Back-fills 25,714 rows via a one-time migration; runtime matcher now queries `WHERE author_uk = ? AND grade = ?` directly — no transliteration, no LIKE patterns.
- Retires `_TEXTBOOK_AUTHOR_TRANSLITS` from `scripts/build/linear_pipeline.py` and `scripts/audit/plan_references_audit.py`. The Latin→Cyrillic bridge survives only in `scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py` for one-time back-fill.
- New `_canonicalize_author_uk` handles Cyrillic spelling variants (`Литвінова → Літвінова`, `Пономарьова → Пономарова`). Pure Cyrillic-to-Cyrillic; never crosses writing systems.
- All ingestion paths (`build_sources_db.py`, `scripts/ingest/*`) now supply `author_uk` explicitly. `build_sources_db.py` raises `ValueError` on a JSONL entry with `author` set but no `author_uk`.
- ADR: `docs/decisions/2026-05-15-cyrillic-native-matcher.md`.

## Verifiable claims (#M-4)

| Claim | Tool | Evidence |
|---|---|---|
| Migration adds the column | `sqlite3 data/sources.db \".schema textbooks\" \| grep author_uk` | `..., author_uk TEXT DEFAULT '');` |
| Back-fill rate | `SELECT COUNT(*) FILTER (WHERE author_uk != ''), COUNT(*) FROM textbooks` | **25714 / 25714 = 100%** |
| Migration is idempotent | re-run of `apply()` | `column_added=False, rows_updated=0` |
| Audit script preserved A1/A2 | run vs. `audit/a1-a2-plan-references-2026-05-15/findings.json` | All 47 pre-existing OK/TOPIC/LEVEL classifications byte-stable; 19 UNKNOWN_AUTHOR citations now resolve correctly |
| Audit script B1/B2 | `--tracks b1,b2` | 70 of 71 prior UNKNOWN_AUTHOR resolve; 1 remaining is a real plan-side typo (`Болшакова` missing ь) |
| Tests pass | `pytest tests/test_textbook_grounding.py tests/test_plan_references_audit.py tests/test_migrations.py` | **51 passed** |
| All affected tests pass | full suite | **169 passed** (pre-commit run) |
| Ruff clean | `ruff check scripts/migrations/ scripts/build/linear_pipeline.py scripts/audit/plan_references_audit.py …` | `All checks passed!` |

## Behavior-preservation diff (A1/A2 audit, 66 citations)

| Mode | before | after |
|---|---:|---:|
| OK | 29 | 45 |
| TOPIC_MISMATCH | 14 | 16 |
| LEVEL_MISMATCH | 4 | 5 |
| GHOST_PAGE | 0 | 0 |
| GHOST_SOURCE | 0 | 0 |
| UNKNOWN_AUTHOR | 19 | 0 |

All 47 pre-existing OK/TOPIC/LEVEL classifications preserved exactly. The 19 UNKNOWN_AUTHOR citations all resolve (16 → OK, 2 → TOPIC_MISMATCH, 1 → LEVEL_MISMATCH).

## Scope boundary (deliberate)

- **Latin `textbooks.source_file` strings stay** — opaque corpus keys; renaming touches ~91 file slugs on disk + JSONL chunks. Separate follow-up PR.
- **Legacy `textbooks.author` (Latin) column stays** — deprecated via docstring, not deleted. Archived analytics depend on it.
- **No re-ingestion** — the migration back-fills in place.

## Test plan

- [x] `pytest tests/test_textbook_grounding.py tests/test_plan_references_audit.py tests/test_migrations.py tests/test_section_coverage.py` — 51 passed
- [x] `pytest` on every other test that defines a `textbooks` schema (13 files) — all green via pre-commit (169 passed total)
- [x] `ruff check` on all touched paths — clean
- [x] `python scripts/audit/plan_references_audit.py --tracks a1,a2` — UNKNOWN_AUTHOR drops 19 → 0; behavior preserved on stable cases
- [x] `python scripts/audit/plan_references_audit.py --tracks b1,b2` — UNKNOWN_AUTHOR drops 71 → 1 (the remaining is a real plan-side typo)
- [x] `python scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py --dry-run` — reports `rows_updated=0` after live apply (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)