### PR TITLE
fix(tests): test_my_morning_module_passes_citations_resolve — drop Караман

### DIFF
--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -97,15 +97,20 @@ def test_plan_references_field_is_supported() -> None:
 
 def test_my_morning_module_passes_citations_resolve() -> None:
     # Source refs must match the LIVE plan_references at curriculum/l2-uk-en/
-    # plans/a1/my-morning.yaml (corrected by PR #1972: Караман p.176 → p.187,
-    # Кравцова Grade 4 p.113 removed as redundant with Захарійчук p.162's
-    # Білоус verse coverage of the same -шся/-ться pronunciation rule).
+    # plans/a1/my-morning.yaml. PR #2014 swapped two bad citations:
+    #   - Караман Grade 10 p.187 (off-topic — that page is "Розмовна,
+    #     просторічна лексика. Сленг", not reflexive verbs)
+    #   - Кравцова Grade 4 p.113 (ghost source — corpus has only Grade 2
+    #     Кравцова, not Grade 4)
+    # Both replaced with Захарійчук Grade 4 pages — the actual "Дієслова
+    # на -ся" lesson. The matcher LIKE-pattern fix in PR #2012 enabled
+    # 4-klas-ukrmova-zaharijchuk (no -year suffix) to resolve.
     plan_path = linear_pipeline.PROJECT_ROOT / "curriculum/l2-uk-en/plans/a1/my-morning.yaml"
     plan = yaml.safe_load(plan_path.read_text("utf-8"))
     result = linear_pipeline._citation_gate(
         [
-            {"source_ref": "Караман, Українська мова, 10 клас, с. 187"},
             {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 162"},
+            {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 163"},
         ],
         plan,
     )


### PR DESCRIPTION
## Why

PR #2014 swapped the m20 plan's two bad citations (Караман Grade 10 p.187 off-topic + Кравцова Grade 4 ghost source) for the actual Захарійчук Grade 4 -ся lesson. The test \`test_my_morning_module_passes_citations_resolve\` still hardcoded Караман in its source_ref list — fails on every PR rebased to current main.

Surfaced via:
- PR #2000 \`CI / Test (pytest): FAILURE\` (after rebase onto post-#2014 main)
- PR #2016 \`CI / Test (pytest): FAILURE\` (newly-opened on post-#2014 main)

Per MEMORY #M-7 — pre-commit doesn't run pytest, so this test never fired locally during #2014's merge.

## Fix

Update the hardcoded \`source_ref\` list to match the live plan: \`Захарійчук Grade 4, с. 162\` + \`Захарійчук Grade 4, с. 163\`.

Long-term the test should iterate \`plan["references"]\` instead of hardcoding strings — but keeping the hardcoded form for readability + explicit coupling.

## Verifiable claims

- Test pass: \`pytest tests/test_citation_resolve.py\` → **15 passed in 0.27s**
- Ruff clean: \`ruff check tests/test_citation_resolve.py\` → \`All checks passed!\`
- Head SHA: \`e21f9319d1\`

## Unblocks

- PR #2000 (after rebase onto main with this fix)
- PR #2016 (after rebase)
- Future PRs that ran pytest on post-#2014 main

## Refs

- #2014 — the citation swap that broke this test
- MEMORY #M-7 — "pytest locally before push to main" rule (this is a clean recurrence: #2014 merged without pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)