### PR TITLE
fix(m20/gate+writer): Russianism HTML markers + bold-strip + 2-step textbook retrieval

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -465,6 +465,28 @@ _PRONUNCIATION_CUE_PATTERN = re.compile(
     r"(?:sounds?\s+like|звучить\s+як|вимовляється\s+як|вимова[:\s])\s*\*\*[^*]+\*\*",
     re.IGNORECASE,
 )
+
+# Pedagogical "bad form" marker for prose Russianism / surzhyk / calque
+# callouts. Patterns like `<!-- bad -->завтрак<!-- /bad -->` deliberately
+# show a non-standard form for learner contrast (e.g. "stick to сніданок,
+# not the Russian-borrowed завтрак"). The bad form is intentionally absent
+# from VESUM — flagging it would be a false positive. The HTML comments
+# don't render in MDX, so the learner still sees `завтрак` in plain prose.
+# Bounded by `re.DOTALL` so multi-line callouts are still caught; the
+# inner-content alternation `.+?` is non-greedy so adjacent `<!-- bad -->`
+# spans don't fuse.
+_AVOID_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(.+?)<!--\s*/bad\s*-->", re.DOTALL)
+
+# Markdown emphasis stripping for the gate text. `_normalize_for_vesum`
+# strips emphasis per-lemma, but `_MORPHEME_FRAGMENT_RE` runs at the TEXT
+# level and requires a hyphen adjacent to a Cyrillic letter — so a writer's
+# `-**юся**` (bold-wrapped morpheme suffix in a conjugation-table row)
+# survives morpheme stripping and then surfaces as a non-VESUM token. Strip
+# at the text level so the morpheme regex sees `-юся` and can collapse it.
+# Bold first (paired `**`), italic second (single `*` not adjacent to `*`).
+_BOLD_EMPHASIS_RE = re.compile(r"\*\*([^*]+)\*\*")
+_ITALIC_EMPHASIS_RE = re.compile(r"(?<!\*)\*(?!\*)([^*\n]+)\*(?!\*)")
+
 _STANDALONE_POSTFIX_FRAGMENTS = frozenset(
     {"ся", "сь", "тся", "тсь", "ться", "шся", "шсь", "чся", "чсь"}
 )
@@ -4695,6 +4717,19 @@ def _strip_metalinguistic(text: str) -> str:
       compounds (`темно-синій`) where the char before `-` is a word char.
     - `sounds like **...**` — cue-prefixed bold pronunciation transcriptions.
     - `діал.` — textbook abbreviation for `діалектне`, not a lemma.
+    - `<!-- bad -->форма<!-- /bad -->` — pedagogical Russianism / surzhyk /
+      calque callouts in prose (e.g. "stick to сніданок, not the
+      Russian-borrowed `<!-- bad -->завтрак<!-- /bad -->`"). The bad form
+      is deliberately non-VESUM and would otherwise be a false positive;
+      HTML comments don't render in MDX, so the learner still sees the
+      bad form in plain prose for contrast.
+
+    Markdown emphasis (`**bold**`, `*italic*`) is unwrapped before the
+    morpheme-fragment regex runs, so a writer's bold-wrapped morpheme suffix
+    like `-**юся**` collapses to `-юся` and gets stripped by the morpheme
+    regex — otherwise the `**` between the hyphen and the Cyrillic letter
+    keeps the morpheme regex from matching, and `юся` surfaces as a
+    non-VESUM false positive.
 
     Used by the VESUM gate to avoid false positives on fragments that aren't
     VESUM-checkable lemmas.
@@ -4703,8 +4738,13 @@ def _strip_metalinguistic(text: str) -> str:
     text = _INLINE_CODE_RE.sub(" ", text)
     text = _BRACKETS_RE.sub(" ", text)
     text = _BRACES_RE.sub(" ", text)
+    # Unwrap markdown emphasis BEFORE morpheme detection so bold-wrapped
+    # morpheme labels (e.g. `-**юся**`) collapse to `-юся` and get caught.
+    text = _BOLD_EMPHASIS_RE.sub(r"\1", text)
+    text = _ITALIC_EMPHASIS_RE.sub(r"\1", text)
     text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _PRONUNCIATION_CUE_PATTERN.sub(" ", text)
+    text = _AVOID_MARKER_RE.sub(" ", text)
     text = _VESUM_ABBREVIATION_RE.sub(" ", text)
     return text
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -455,11 +455,13 @@ _BRACES_RE = re.compile(r"\{[А-ЯІЇЄҐа-яіїєґ'ʼ]{1,12}\}")
 # Latin letter or digit — i.e., the hyphen must sit at a non-linguistic
 # boundary (markdown `*`/`_`, paren, whitespace, line start). This protects
 # legitimate hyphenated compounds like `темно-синій` (preceded by `о`) while
-# stripping morpheme labels in `**-шся**` and `__-шся__` (markdown bold). We
-# don't use Python's `\B` because `_` is a word character there, which would
-# make `__-шся__` un-strippable.
+# stripping morpheme labels in `**-шся**`, `__-шся__`, and `-**юся**`
+# (markdown emphasis around all or part of the label). We don't use Python's
+# `\B` because `_` is a word character there, which would make `__-шся__`
+# un-strippable.
 _MORPHEME_FRAGMENT_RE = re.compile(
-    r"(?<![А-ЯІЇЄҐа-яіїєґ'ʼA-Za-z0-9])-[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'ʼ]*"
+    r"(?<![А-ЯІЇЄҐа-яіїєґ'ʼA-Za-z0-9])[*_`]{0,2}-[*_`]{0,2}"
+    r"[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'ʼ]*[*_`]{0,2}"
 )
 _PRONUNCIATION_CUE_PATTERN = re.compile(
     r"(?:sounds?\s+like|звучить\s+як|вимовляється\s+як|вимова[:\s])\s*\*\*[^*]+\*\*",
@@ -476,16 +478,6 @@ _PRONUNCIATION_CUE_PATTERN = re.compile(
 # inner-content alternation `.+?` is non-greedy so adjacent `<!-- bad -->`
 # spans don't fuse.
 _AVOID_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(.+?)<!--\s*/bad\s*-->", re.DOTALL)
-
-# Markdown emphasis stripping for the gate text. `_normalize_for_vesum`
-# strips emphasis per-lemma, but `_MORPHEME_FRAGMENT_RE` runs at the TEXT
-# level and requires a hyphen adjacent to a Cyrillic letter — so a writer's
-# `-**юся**` (bold-wrapped morpheme suffix in a conjugation-table row)
-# survives morpheme stripping and then surfaces as a non-VESUM token. Strip
-# at the text level so the morpheme regex sees `-юся` and can collapse it.
-# Bold first (paired `**`), italic second (single `*` not adjacent to `*`).
-_BOLD_EMPHASIS_RE = re.compile(r"\*\*([^*]+)\*\*")
-_ITALIC_EMPHASIS_RE = re.compile(r"(?<!\*)\*(?!\*)([^*\n]+)\*(?!\*)")
 
 _STANDALONE_POSTFIX_FRAGMENTS = frozenset(
     {"ся", "сь", "тся", "тсь", "ться", "шся", "шсь", "чся", "чсь"}
@@ -4712,9 +4704,10 @@ def _strip_metalinguistic(text: str) -> str:
     - `[...]` — phonetic notation like `[с':а]`, `[ц':а]`
     - `` `...` `` and ` ``` ... ``` ` — inline/fenced code
     - `{...}` — fill-in blank syntax like `Я вмиваю{ся}. Він прокидає{ться}.`
-    - `\\B-морфема` — hyphen-prefixed conjugation labels like `**-шся**`,
-      `**-ться**`. The `\\B` lookbehind protects legitimate hyphenated
-      compounds (`темно-синій`) where the char before `-` is a word char.
+    - `-морфема` — hyphen-prefixed conjugation labels like `**-шся**`,
+      `**-ться**`, and `-**юся**`. The regex lookbehind protects legitimate
+      hyphenated compounds (`темно-синій`) where the char before `-` is a
+      word char.
     - `sounds like **...**` — cue-prefixed bold pronunciation transcriptions.
     - `діал.` — textbook abbreviation for `діалектне`, not a lemma.
     - `<!-- bad -->форма<!-- /bad -->` — pedagogical Russianism / surzhyk /
@@ -4724,13 +4717,6 @@ def _strip_metalinguistic(text: str) -> str:
       HTML comments don't render in MDX, so the learner still sees the
       bad form in plain prose for contrast.
 
-    Markdown emphasis (`**bold**`, `*italic*`) is unwrapped before the
-    morpheme-fragment regex runs, so a writer's bold-wrapped morpheme suffix
-    like `-**юся**` collapses to `-юся` and gets stripped by the morpheme
-    regex — otherwise the `**` between the hyphen and the Cyrillic letter
-    keeps the morpheme regex from matching, and `юся` surfaces as a
-    non-VESUM false positive.
-
     Used by the VESUM gate to avoid false positives on fragments that aren't
     VESUM-checkable lemmas.
     """
@@ -4738,12 +4724,8 @@ def _strip_metalinguistic(text: str) -> str:
     text = _INLINE_CODE_RE.sub(" ", text)
     text = _BRACKETS_RE.sub(" ", text)
     text = _BRACES_RE.sub(" ", text)
-    # Unwrap markdown emphasis BEFORE morpheme detection so bold-wrapped
-    # morpheme labels (e.g. `-**юся**`) collapse to `-юся` and get caught.
-    text = _BOLD_EMPHASIS_RE.sub(r"\1", text)
-    text = _ITALIC_EMPHASIS_RE.sub(r"\1", text)
-    text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _PRONUNCIATION_CUE_PATTERN.sub(" ", text)
+    text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _AVOID_MARKER_RE.sub(" ", text)
     text = _VESUM_ABBREVIATION_RE.sub(" ", text)
     return text

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -63,6 +63,16 @@ that failure class. Run each check while drafting, not as a separate pass.
 
 2. **Modern Ukrainian + heritage-defense discipline.** Default to post-2019 Pravopys standard forms for learner-facing standard Ukrainian. However, NEVER classify a word as Russianism, surzhyk, or calque merely because it is archaic, historical, dialectal, or shares Proto-Slavic roots with Russian. For any non-modern or suspicious form, verify with `mcp__sources__check_modern_form` (VESUM) plus available historical/etymological evidence (`mcp__sources__search_grinchenko_1907`, `mcp__sources__search_esum`, literary/wiki source context). If authentic but non-standard, keep it only when pedagogically required, tag it `[Archaism]`, `[Historism]`, or `[Dialectism]`, give the modern standard equivalent, and briefly state its Ukrainian heritage. If unverified, omit or emit `<!-- VERIFY: heritage status for "X" unresolved -->`.
 
+   **Russianism / surzhyk / calque callout markup (mandatory).** When a sentence in prose demonstrates a *bad form* for learner contrast (the "stick to X, not the Russian-borrowed Y" pattern), the bad form is deliberately NOT in VESUM and would trip the `vesum_verified` gate as a false positive. Wrap the bad form in HTML comments so the gate strips it but the learner still sees it in rendered MDX:
+
+   ```markdown
+   Stick to **сніданок** (not the Russian-borrowed <!-- bad -->завтрак<!-- /bad -->),
+   **рушник** (not <!-- bad -->полотенце<!-- /bad -->), and **одягатися** (not the
+   surzhyk <!-- bad -->одіватися<!-- /bad -->).
+   ```
+
+   The `<!-- bad -->...<!-- /bad -->` marker is stripped by `_strip_metalinguistic` before VESUM lookup but doesn't render in MDX, so the bad form is still visible in plain prose. Do NOT use single-asterisk italics (`*завтрак*`) or bare unmarked prose for bad forms — both trip the gate. The marker is specifically for Russianisms, surzhyk forms, calques, and paronyms shown *to be avoided*. Words shown as legitimate non-standard heritage (archaisms, dialectisms) keep the `[Archaism]` / `[Dialectism]` tag and pedagogical defense above.
+
 3. **Source-citation discipline.** Every dictionary / style-guide / author
    citation MUST be groundable in MCP. **Use `mcp__sources__verify_source_attribution(source, claim)` as the single-call primitive** — it returns a `discusses: bool` verdict in one call. Allowed `source` enum values: `grinchenko_1907`, `esum`, `sum11`, `antonenko_davydovych`, `literary`, `heritage`, `wikipedia`, `style_guide`. If `discusses=false`, do NOT cite that source for that claim.
 
@@ -80,7 +90,17 @@ that failure class. Run each check while drafting, not as a separate pass.
    rule not verbatim in the packet, you MUST verify it via
    `mcp__sources__search_text` and cite the exact grade and author.
 
-   **Verbatim textbook grounding (mandatory).** For each `plan_references` entry, you MUST call `mcp__sources__search_text` with a query targeting that textbook + topic, then quote at least one verbatim block (≥30 words) inline in the relevant section. The citation must include the textbook author + grade + page extracted from the search result, and the quote must be set off as a blockquote so reviewers can verify it. Inventing or paraphrasing in place of retrieving is a hard fail (`textbook_grounding`).
+   **Verbatim textbook grounding (mandatory; 2-step retrieval).** For each `plan_references` entry, follow this exact 2-step pattern. A topic-only search that returns the wrong page produces a HARD `textbook_grounding` REJECT even when your blockquote content happens to be accurate — the matcher does string-containment against the exact `text` of the chunk you retrieved.
+
+   **Step A — find the chunk_id.** Call `mcp__sources__search_text` with a query containing the **author surname AND the page number as plain digits** (e.g. `Захарійчук 162`, `Караман 176`, `Захарійчук 163`). The chunk_id pattern is `<source_file>_s<PAGE>` where `<PAGE>` is the zero-padded 4-digit page (`p.162` → `_s0162`). Scan the top results for a `Chunk ID:` ending in the right page suffix. If none match, refine: try different word orders, add a Ukrainian phrase distinctive to that page (from the Knowledge Packet), narrow to one author. Don't stop until you've identified the exact chunk_id.
+
+   **Step B — fetch the verbatim text.** Once you have the matching chunk_id (e.g. `4-klas-ukrmova-zaharijchuk_s0162`), call `mcp__sources__get_chunk_context(chunk_id="4-klas-ukrmova-zaharijchuk_s0162")` (or pass the chunk_id positionally as documented in the tool's signature). Then copy-paste ≥30 contiguous words from THAT chunk's returned `text` into a blockquote in `module.md`, preserving punctuation and Cyrillic letter forms exactly. Paraphrasing, composing from memory, fusing snippets from multiple chunks, summarizing, "improving" punctuation, or substituting equivalent phrases is a hard fail — take a contiguous block verbatim.
+
+   **Citation line format (mandatory; `citations_resolve` enforces it).** Immediately below the blockquote add `*— <Author>, Grade <N>, p.<PAGE>*` using the **exact** strings from the plan_references entry (e.g. `*— Захарійчук, Grade 4, p.162*`). Do NOT add the textbook title ("Українська мова") — that breaks the matcher because the plan_references format is `<Author> Grade <N>, p.<PAGE>` and the matcher requires that exact shape.
+
+   **Topic placement.** The blockquote must appear in the section whose pedagogical topic matches the reference's intent (mismatched placement triggers `topical_mismatch`).
+
+   **Corpus truly lacks the page.** If after refined queries you cannot surface a chunk_id with the cited page suffix, do NOT fabricate a blockquote. Emit a `<!-- VERIFY: chunk for the cited page not retrievable -->` comment in place of the quote and flag the plan_references entry for revision.
 
    **Citation discipline.** Sources cited in `module.md` blockquotes and listed in `resources.yaml` MUST be either:
    1. Listed in the module's `plan_references` (the matcher allows fuzzy match on author + grade + small page drift), OR
@@ -365,6 +385,38 @@ field `items`; do NOT use the React/component prop name `questions`.
 
 For item-bearing types, include a non-empty `items` array. For numeric arrays
 like `correct_order`, indices are zero-based.
+
+**`error-correction` activity items (mandatory canonical fields — HARD FAIL on alias).** Each item inside an `error-correction` activity's `items:` list MUST use these EXACT inner field names — they are the schema consumed by `scripts/yaml_activities.py: _parse_error_correction` AND the only fields the `vesum_verified` gate treats as containing intentional misspellings:
+
+```yaml
+- type: error-correction
+  title: ...
+  instruction: ...
+  items:
+    - sentence: "Вона дивюся в дзеркало."  # the sentence with the deliberate error
+      error: дивюся                        # the malformed token (excluded from VESUM)
+      correction: дивиться                 # the corrected token
+      explanation: "Reflexive 3rd person singular is дивиться."   # optional
+```
+
+The complete VESUM-exclusion list is exactly:
+`{sentence, error, errors, errorWord, error_word, explanation}`.
+
+**FORBIDDEN inner field-name aliases** — every one of these causes the deliberate typo to leak into `vesum_verified` as a false positive AND fails the strict YAML parser at MDX-render time. The build WILL fail at python_qg:
+- `wrong:` ❌
+- `incorrect:` ❌
+- `mistake:` ❌
+- `bad:` ❌
+- `original:` ❌
+- `wrong_form:` ❌
+- `incorrect_form:` ❌
+- `correct:` ❌ (use `correction:` instead)
+- `correctAnswer:` ❌ for error-correction items (it's for other types)
+- `right:` ❌
+- `fix:` ❌
+- `fixed:` ❌
+
+Rule: if a field name is not in `{sentence, error, errors, errorWord, error_word, explanation, correction, answer, options}` for an error-correction item, you are inventing an alias. Stop, use `sentence` + `error` + `correction` exactly as above.
 
 ## Plan
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -2844,3 +2844,80 @@ def test_component_prop_gate_consistent_with_strict_json_parser_for_a1_20() -> N
         f"A1/20 activity list must pass BOTH gates without contradiction. "
         f"Errors: {report['errors']}"
     )
+
+
+def test_strip_metalinguistic_removes_avoid_markers() -> None:
+    """`<!-- bad -->X<!-- /bad -->` callouts get stripped before VESUM lookup.
+
+    Russianism / surzhyk / calque pedagogical callouts in prose (e.g.,
+    "stick to сніданок, not the Russian-borrowed завтрак") deliberately
+    show a non-VESUM form for learner contrast. The HTML-comment marker
+    keeps the bad form visible in rendered MDX (comments don't render)
+    while preventing the `vesum_verified` gate from flagging it as a
+    false positive.
+    """
+    text = (
+        "Stick to сніданок (not the Russian-borrowed "
+        "<!-- bad -->завтрак<!-- /bad -->), рушник "
+        "(not <!-- bad -->полотенце<!-- /bad -->)."
+    )
+    stripped = linear_pipeline._strip_metalinguistic(text)
+    assert "завтрак" not in stripped
+    assert "полотенце" not in stripped
+    # The Ukrainian-preferred forms must survive.
+    assert "сніданок" in stripped
+    assert "рушник" in stripped
+
+
+def test_strip_metalinguistic_avoid_marker_handles_multiline_and_spacing() -> None:
+    """The marker tolerates surrounding whitespace and a multi-line span."""
+    text = (
+        "Avoid the surzhyk form <!--   bad   -->\nодіватися\n<!--   /bad   -->\n"
+        "and use одягатися instead."
+    )
+    stripped = linear_pipeline._strip_metalinguistic(text)
+    assert "одіватися" not in stripped
+    assert "одягатися" in stripped
+
+
+def test_strip_metalinguistic_avoid_marker_keeps_adjacent_callouts_separate() -> None:
+    """Two adjacent `<!-- bad -->` spans don't fuse via greedy matching."""
+    text = "<!-- bad -->завтрак<!-- /bad --> та <!-- bad -->полотенце<!-- /bad -->"
+    stripped = linear_pipeline._strip_metalinguistic(text)
+    assert "завтрак" not in stripped
+    assert "полотенце" not in stripped
+    # The Ukrainian connector word "та" survives between the two stripped spans.
+    assert "та" in stripped
+
+
+def test_strip_metalinguistic_collapses_bold_wrapped_morpheme_labels() -> None:
+    """`-**юся**` collapses to `-юся` so the morpheme regex can strip it.
+
+    Conjugation-table rows like `| -**юся** | -**єшся** | -**ється** |`
+    pair a hyphen with a bold-wrapped morpheme suffix. The morpheme regex
+    requires the hyphen to sit directly next to a Cyrillic letter, so the
+    `**` between them previously blocked the strip and the suffix
+    surfaced as a non-VESUM token (`юся` is not a lemma).
+    """
+    text = "| -**юся** | -**єшся** | -**ється** | -ємося | -єтеся | -ються |"
+    stripped = linear_pipeline._strip_metalinguistic(text)
+    # All six morpheme suffix forms should be gone after stripping.
+    for fragment in ("юся", "єшся", "ється", "ємося", "єтеся", "ються"):
+        assert fragment not in stripped, (
+            f"morpheme fragment '{fragment}' should be stripped from the gate "
+            f"text but survived: {stripped!r}"
+        )
+
+
+def test_strip_metalinguistic_preserves_bold_lemmas_in_running_prose() -> None:
+    """Plain bold-emphasized Ukrainian lemmas still reach VESUM lookup intact.
+
+    Bold-unwrap in `_strip_metalinguistic` is for the morpheme-regex
+    pass-through. After the regex runs, the unwrapped lemma must still
+    appear in the gate text so a real misspelling inside `**...**`
+    (e.g. `**прокидаюсь**`) is still verified.
+    """
+    text = "Stick to **сніданок** and **рушник**, not **полотенце**."
+    stripped = linear_pipeline._strip_metalinguistic(text)
+    for lemma in ("сніданок", "рушник", "полотенце"):
+        assert lemma in stripped, f"bold-unwrapped lemma '{lemma}' should survive"


### PR DESCRIPTION
## Summary

Three coordinated patches landing real m20-build improvements while m20 GREEN remains blocked on a writer-compliance bug separately tracked in #2018.

- **Gate** (\`scripts/build/linear_pipeline.py\`): \`_AVOID_MARKER_RE\` strips \`<!-- bad -->форма<!-- /bad -->\` from VESUM lookup; markdown emphasis (\`**X**\`, \`*X*\`) unwrapped at text level so morpheme regex catches \`-юся\`/\`-ться\` inside bold.
- **Writer prompt** (\`scripts/build/phases/linear-write.md\`): three rules — Russianism HTML markers, canonical \`error-correction\` fields with 12-alias FORBIDDEN list, 2-step verbatim textbook retrieval (search_text → get_chunk_context) with citation-line format constraint.
- **Tests** (\`tests/build/test_linear_pipeline.py\`): 5 new regression tests, 97 passing (1 pre-existing skip).

## Build state across iterations (claude-tools writer, a1/my-morning)

| Build | vesum_verified missing | citations_resolve | textbook_grounding |
|-------|------------------------|---------------------|---------------------|
| #6 (pre-patch) | \`*завтрак*\`, \`*одіватися*\`, \`дивюся\` | ✓ | REJECT, 0 matched |
| #7 (Russianism markers only) | \`**юся**\`, \`**ється**\`, \`**єшся**\`, \`Я-ти\`, \`дивюся\` | FAIL (full title) | REJECT, 0 matched |
| #8 (all patches) | \`дивюся\`, \`користуювася\` | ✓ | REJECT, 1 unattributed |

Russianism markers + bold-strip eliminated 4 of 5 vesum false-positive classes. Citation format constraint flipped citations_resolve green. textbook_grounding moved from 0 matches to 1 unattributed match (writer's blockquote contains a real chunk's text but attribution is off).

The two remaining vesum misses (\`дивюся\`, \`користуювася\`) are inside \`incorrect:\` activity fields — the writer continues to use non-canonical field names despite the explicit FORBIDDEN list. That's a writer-compliance gap that prompt iteration cannot fix; see #2018 for the recommended structural fix (\`activity_schema\` gate that fails closed BEFORE \`vesum_verified\`).

## Verifiable evidence

\`\`\`bash
.venv/bin/python -m pytest tests/build/test_linear_pipeline.py -q
# → 97 passed, 1 skipped in 2.93s

.venv/bin/ruff check scripts/build/linear_pipeline.py tests/build/test_linear_pipeline.py
# → All checks passed!

.venv/bin/python -c \"from scripts.build.linear_pipeline import _strip_metalinguistic as s; print(s('Stick to сніданок (not the Russian-borrowed <!-- bad -->завтрак<!-- /bad -->).'))\"
# → 'Stick to сніданок (not the Russian-borrowed ).'  ← завтрак stripped
\`\`\`

## Test plan

- [x] \`pytest tests/build/test_linear_pipeline.py\` — 97 passed, 1 skipped
- [x] \`ruff check\` — clean
- [x] Pre-commit hooks — passed
- [ ] After merge: re-fire m20 build #9 once #2018 (\`activity_schema\` gate) lands; expect vesum_verified to drop from 2 misses to 0

## Refs

- #1975 — m20 build #5 RED (originator)
- #1969 — writer-prompt resources_search_attempted regression (now passing across builds)
- #2018 — writer-compliance bottleneck follow-up (proposes \`activity_schema\` gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)