### PR TITLE
chore(deploy): declare .gemini/tmp/ as orphan + clean stale pro quick-refs

### DIFF
--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -47,7 +47,9 @@ ORPHAN_PATHS_AGENTS=""
 # Codex agent definitions with no claude_extensions equivalent.
 # config.toml and hooks.json — Codex CLI configuration files managed directly by Codex.
 ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml agents/curriculum-writer.toml config.toml hooks.json"
-ORPHAN_PATHS_GEMINI="docs/ rules/"
+# tmp/ — Gemini CLI runtime workspace (e.g. .gemini/tmp/learn-ukrainian/);
+#        local working state, NOT a deploy artifact. Preserve across rsync --delete.
+ORPHAN_PATHS_GEMINI="docs/ rules/ tmp/"
 
 # Claude Code auto-loads every unscoped file in `.claude/rules/` into
 # the system prompt. These six always-load rules are now served by the


### PR DESCRIPTION
## Summary

- Adds `tmp/` to `ORPHAN_PATHS_GEMINI` in `scripts/deploy_prompts.sh` so the preflight orphan-path guard stops aborting `npm run claude:deploy` on Gemini CLI runtime workspaces.
- Companion (out of band, not in this diff): also deleted the stale `quick-ref/{b2-pro,c1-pro}.md` files from `.claude/`, `.agent/`, `.codex/` deploy targets — leftovers from PR #2009 archiving the pro tracks. Deploy targets are gitignored, so this PR doesn't carry them, but they were the second source of the preflight failure.

## Root cause

`scripts/deploy_prompts.sh` has a preflight that aborts if any destination file would be `rsync --delete`'d without being on the declared safe-list (`ORPHAN_PATHS_*`). Two undeclared orphans were tripping it:

1. **`quick-ref/b2-pro.md` (+ `c1-pro.md`)** — stale leftovers in 3 deploy targets from PR #2009 (`chore(curriculum): archive b2-pro and c1-pro tracks`). Source `claude_extensions/quick-ref/` already has them deleted; the deployed copies were never cleaned. Zero active references to b2-pro/c1-pro in `scripts/`, `curriculum/`, or the curriculum manifest, so the deletion is safe.
2. **`.gemini/tmp/`** — Gemini CLI writes runtime workspaces here (`.gemini/tmp/learn-ukrainian/`). Local working state, not a deploy artifact. Belongs on the orphan safe-list like `.agent/wake/` and `.agent/cache/`.

## Verification

- `bash tests/test_deploy_prompts_orphan_guard.sh` → 10/10 passed
- `.venv/bin/python -m pytest tests/test_deploy_script_idempotency.py` → 5 passed
- `npm run claude:deploy` → `Deploy complete.` (preflight green, no orphans flagged)

## Test plan

- [x] orphan-guard shell test green
- [x] deploy idempotency pytest green
- [x] `npm run claude:deploy` runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)