### PR TITLE
feat(bridge): OpenAI-compatible HTTP proxy at :8767

### DIFF
--- a/docs/best-practices/openai-compat-proxy.md
+++ b/docs/best-practices/openai-compat-proxy.md
@@ -1,0 +1,20 @@
+# OpenAI-Compatible Agent Proxy
+
+`ab serve --openai` starts a localhost-only FastAPI service on
+`127.0.0.1:8767` by default. It exposes:
+
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+- `GET /healthz`
+
+The model registry lives in `scripts/ai_agent_bridge/openai_proxy.py` as
+`_ROUTABLE_MODELS`. Add or remove routable public model IDs there first; the
+models endpoint reads from that single source of truth.
+
+Phase 1 is intentionally non-streaming and does not translate tool-use or
+Assistants API envelopes. Token usage is reported as zero unless a backend
+surfaces real counts; do not invent approximate totals in the response.
+
+The Grok route uses `hermes -z PROMPT -m grok-4.3` and respects the user's
+existing `~/.hermes/config.yaml`. The proxy must not mutate Hermes config per
+request because that would be race-prone under concurrent clients.

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -669,6 +669,25 @@ def _build_parser() -> argparse.ArgumentParser:
     # status
     subparsers.add_parser("status", help="Show running bridge processes")
 
+    # serve
+    serve_parser = subparsers.add_parser("serve", help="Serve local HTTP bridge surfaces")
+    serve_parser.add_argument(
+        "--openai",
+        action="store_true",
+        help="Serve the OpenAI-compatible proxy",
+    )
+    serve_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host for --openai (default: 127.0.0.1)",
+    )
+    serve_parser.add_argument(
+        "--port",
+        type=int,
+        default=8767,
+        help="Port for --openai (default: 8767)",
+    )
+
     # interactive
     subparsers.add_parser("interactive", help="Interactive mode")
 
@@ -736,6 +755,14 @@ def _dispatch_command(args):
         broker_cleanup(args.max_age, args.dry_run, args.older_than)
     elif args.command == "status":
         bridge_status()
+    elif args.command == "serve":
+        if not args.openai:
+            raise SystemExit("serve currently requires --openai")
+        import uvicorn
+
+        from .openai_proxy import app
+
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")
     elif args.command == "interactive":
         interactive_mode()
     elif args.command in ("channel", "post", "p", "reconcile", "sync", "discuss"):

--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -1,0 +1,376 @@
+"""OpenAI-compatible HTTP proxy for local agent CLIs.
+
+Phase 1 intentionally exposes only the narrow chat-completions surface:
+model listing, non-streaming chat completions, and a cheap health probe.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from ._config import _PARENT_ENV, CLAUDE_CMD, CODEX_CLI, GEMINI_CLI, REPO_ROOT
+
+_DEFAULT_BACKEND_TIMEOUT_S = 120
+
+
+class Message(BaseModel):
+    """Minimal OpenAI chat message shape accepted by the proxy."""
+
+    role: str = Field(min_length=1)
+    content: str | list[dict[str, Any]] | None = ""
+
+
+class ChatCompletionRequest(BaseModel):
+    """Subset of the OpenAI chat completion request envelope used in v1."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str = Field(min_length=1)
+    messages: list[Message] = Field(min_length=1)
+    user: str | None = None
+
+
+@dataclass(frozen=True)
+class CompletionResponse:
+    """Normalized backend response before wrapping in OpenAI JSON."""
+
+    content: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+Backend = Callable[..., CompletionResponse]
+
+
+@dataclass(frozen=True)
+class ModelRoute:
+    """Routing metadata for a public model id."""
+
+    family: str
+    backend: Backend
+
+
+def _backend_timeout_s() -> int:
+    raw = os.environ.get("BRIDGE_PROXY_BACKEND_TIMEOUT_S")
+    if raw is None:
+        return _DEFAULT_BACKEND_TIMEOUT_S
+    try:
+        timeout = int(raw)
+    except ValueError:
+        return _DEFAULT_BACKEND_TIMEOUT_S
+    return timeout if timeout > 0 else _DEFAULT_BACKEND_TIMEOUT_S
+
+
+def _message_content_to_text(content: str | list[dict[str, Any]] | None) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type in {None, "text", "input_text", "output_text"}:
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _flatten_messages(messages: list[Message]) -> str:
+    """Flatten OpenAI role messages into a deterministic CLI prompt."""
+
+    system_blocks: list[str] = []
+    turns: list[Message] = []
+    for message in messages:
+        if message.role in {"system", "developer"}:
+            system_blocks.append(_message_content_to_text(message.content))
+        else:
+            turns.append(message)
+
+    sections: list[str] = []
+    if system_blocks:
+        sections.append("[system]: " + "\n\n".join(block for block in system_blocks if block))
+
+    for index, message in enumerate(turns, start=1):
+        content = _message_content_to_text(message.content)
+        sections.append(f"--- Round {index} ---\n[{message.role}]: {content}")
+
+    return "\n\n".join(sections)
+
+
+def _run_backend_command(
+    backend_name: str,
+    argv: list[str],
+    *,
+    prompt: str | None = None,
+    cwd: Path = REPO_ROOT,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(_PARENT_ENV)
+    env["TERM"] = "xterm-256color"
+    env["COLORTERM"] = "truecolor"
+    result = subprocess.run(
+        argv,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=_backend_timeout_s(),
+        cwd=str(cwd),
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            argv,
+            output=result.stdout,
+            stderr=result.stderr or result.stdout or f"{backend_name} exited with {result.returncode}",
+        )
+    return result
+
+
+def _codex_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
+    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
+    codex_model = os.environ.get("BRIDGE_PROXY_CODEX_MODEL", "gpt-5.5")
+
+    with tempfile.NamedTemporaryFile(prefix="openai-proxy-codex-", suffix=".txt", delete=False) as handle:
+        output_path = Path(handle.name)
+
+    try:
+        argv = [
+            CODEX_CLI,
+            "exec",
+            "--json",
+            "--skip-git-repo-check",
+            "-C",
+            str(REPO_ROOT),
+            "--color",
+            "never",
+            "-s",
+            "read-only",
+            "-o",
+            str(output_path),
+            "-m",
+            codex_model,
+            "-",
+        ]
+        result = _run_backend_command("codex", argv, prompt=prompt)
+        content = ""
+        if output_path.exists():
+            content = output_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not content:
+            content = result.stdout.strip()
+        return CompletionResponse(content=content)
+    finally:
+        output_path.unlink(missing_ok=True)
+
+
+def _gemini_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
+    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
+    argv = [
+        GEMINI_CLI,
+        "-m",
+        model,
+        f"--prompt={prompt}",
+        "--approval-mode",
+        "plan",
+    ]
+    result = _run_backend_command("gemini", argv)
+    return CompletionResponse(content=result.stdout.strip())
+
+
+def _claude_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
+    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
+    argv = [
+        *CLAUDE_CMD,
+        "--print",
+        "--bare",
+        "--model",
+        model,
+        "--",
+        prompt,
+    ]
+    result = _run_backend_command("claude", argv)
+    return CompletionResponse(content=result.stdout.strip())
+
+
+def _hermes_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
+    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
+    argv = [
+        shutil.which("hermes") or "hermes",
+        f"--oneshot={prompt}",
+        "-m",
+        model,
+    ]
+    result = _run_backend_command("hermes", argv)
+    return CompletionResponse(content=result.stdout.strip())
+
+
+_ROUTABLE_MODELS: dict[str, ModelRoute] = {
+    "codex": ModelRoute(family="openai-codex", backend=_codex_backend),
+    "gemini-3.0-flash-preview": ModelRoute(family="google-gemini", backend=_gemini_backend),
+    "gemini-3.1-pro-preview": ModelRoute(family="google-gemini", backend=_gemini_backend),
+    "claude-opus-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
+    "claude-sonnet-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
+    "grok-4.3": ModelRoute(family="xai", backend=_hermes_backend),
+}
+
+
+def _probe_cli(argv: list[str]) -> bool:
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=1,
+            cwd=str(REPO_ROOT),
+            env=_PARENT_ENV,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _probe_codex() -> bool:
+    return _probe_cli([CODEX_CLI, "--version"])
+
+
+def _probe_gemini() -> bool:
+    return _probe_cli([GEMINI_CLI, "--version"])
+
+
+def _probe_claude() -> bool:
+    return _probe_cli([*CLAUDE_CMD, "--version"])
+
+
+def _probe_hermes() -> bool:
+    return _probe_cli([shutil.which("hermes") or "hermes", "--version"])
+
+
+_BACKEND_PROBES: dict[str, Callable[[], bool]] = {
+    "codex": _probe_codex,
+    "gemini": _probe_gemini,
+    "claude": _probe_claude,
+    "hermes": _probe_hermes,
+}
+
+
+def _openai_error(status_code: int, message: str, error_type: str, code: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"message": message, "type": error_type, "code": code}},
+    )
+
+
+def _first_error_line(value: object) -> str:
+    text = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else str(value or "")
+    first = text.strip().splitlines()
+    return first[0] if first else "unknown error"
+
+
+app = FastAPI(title="AI Agent Bridge OpenAI Proxy", version="1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, object]:
+    return {
+        "ok": True,
+        "backends": {name: probe() for name, probe in _BACKEND_PROBES.items()},
+    }
+
+
+@app.get("/v1/models")
+def list_models() -> dict[str, object]:
+    created = int(time.time())
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": model_id,
+                "object": "model",
+                "created": created,
+                "owned_by": route.family,
+            }
+            for model_id, route in _ROUTABLE_MODELS.items()
+        ],
+    }
+
+
+@app.post("/v1/chat/completions", response_model=None)
+def chat_completions(request: ChatCompletionRequest) -> dict[str, object] | JSONResponse:
+    route = _ROUTABLE_MODELS.get(request.model)
+    if route is None:
+        return _openai_error(
+            404,
+            f"model '{request.model}' not found",
+            "invalid_request_error",
+            "model_not_found",
+        )
+
+    prompt = _flatten_messages(request.messages)
+    try:
+        completion = route.backend(
+            request.model,
+            request.messages,
+            prompt=prompt,
+            user=request.user,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _openai_error(
+            504,
+            f"{route.family} backend timed out: {_first_error_line(exc.stderr)}",
+            "upstream_error",
+            "backend_timeout",
+        )
+    except subprocess.CalledProcessError as exc:
+        return _openai_error(
+            502,
+            f"{route.family} backend failed: {_first_error_line(exc.stderr)}",
+            "upstream_error",
+            "backend_failed",
+        )
+    except OSError as exc:
+        return _openai_error(
+            502,
+            f"{route.family} backend failed: {_first_error_line(exc)}",
+            "upstream_error",
+            "backend_failed",
+        )
+
+    # Backends do not expose consistent token accounting yet; keep zeroes
+    # instead of fabricating approximate usage.
+    return {
+        "id": f"chatcmpl-{uuid.uuid4()}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": request.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": completion.content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": completion.prompt_tokens,
+            "completion_tokens": completion.completion_tokens,
+            "total_tokens": completion.total_tokens,
+        },
+    }

--- a/tests/ai_agent_bridge/test_openai_proxy.py
+++ b/tests/ai_agent_bridge/test_openai_proxy.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import replace
+
+from fastapi.testclient import TestClient
+
+from scripts.ai_agent_bridge import openai_proxy as proxy
+
+
+def _client() -> TestClient:
+    return TestClient(proxy.app)
+
+
+def _route_with_backend(model: str, backend):
+    return replace(proxy._ROUTABLE_MODELS[model], backend=backend)
+
+
+def test_models_endpoint_lists_routable_models():
+    response = _client().get("/v1/models")
+
+    assert response.status_code == 200
+    model_ids = {item["id"] for item in response.json()["data"]}
+    assert model_ids == set(proxy._ROUTABLE_MODELS)
+
+
+def test_chat_completions_codex_round_trip(monkeypatch):
+    def backend(model, messages, **kwargs):
+        return proxy.CompletionResponse(content="hello from codex")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": "codex", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["model"] == "codex"
+    assert body["choices"][0]["message"]["content"] == "hello from codex"
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_grok_via_hermes(monkeypatch):
+    def backend(model, messages, **kwargs):
+        return proxy.CompletionResponse(content="hello from grok")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "grok-4.3", _route_with_backend("grok-4.3", backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": "grok-4.3", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["model"] == "grok-4.3"
+    assert body["choices"][0]["message"]["content"] == "hello from grok"
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_gemini_round_trip(monkeypatch):
+    model_id = "gemini-3.0-flash-preview"
+
+    def backend(model, messages, **kwargs):
+        return proxy.CompletionResponse(content="hello from gemini")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, model_id, _route_with_backend(model_id, backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": model_id, "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["model"] == model_id
+    assert body["choices"][0]["message"]["content"] == "hello from gemini"
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_claude_round_trip(monkeypatch):
+    model_id = "claude-sonnet-4-7"
+
+    def backend(model, messages, **kwargs):
+        return proxy.CompletionResponse(content="hello from claude")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, model_id, _route_with_backend(model_id, backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": model_id, "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["model"] == model_id
+    assert body["choices"][0]["message"]["content"] == "hello from claude"
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_unknown_model_returns_404():
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": "unknown-model-xyz", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "model_not_found"
+
+
+def test_chat_completions_backend_failure_returns_502(monkeypatch):
+    def backend(model, messages, **kwargs):
+        raise subprocess.CalledProcessError(
+            1,
+            ["agent"],
+            stderr="first failure line\nsecond failure line",
+        )
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": "codex", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 502
+    assert body["error"]["code"] == "backend_failed"
+    assert "first failure line" in body["error"]["message"]
+    assert "second failure line" not in body["error"]["message"]
+
+
+def test_chat_completions_backend_timeout_returns_504(monkeypatch):
+    def backend(model, messages, **kwargs):
+        raise subprocess.TimeoutExpired(["agent"], timeout=120, stderr="timeout line\nlater")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": "codex", "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 504
+    assert body["error"]["code"] == "backend_timeout"
+    assert "timeout line" in body["error"]["message"]
+
+
+def test_chat_completions_missing_messages_returns_422():
+    response = _client().post("/v1/chat/completions", json={"model": "codex"})
+
+    assert response.status_code == 422
+    assert any(item["loc"][-1] == "messages" for item in response.json()["detail"])
+
+
+def test_message_flatten_preserves_role_order(monkeypatch):
+    prompts = []
+
+    def backend(model, messages, **kwargs):
+        prompts.append(kwargs["prompt"])
+        return proxy.CompletionResponse(content="ok")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={
+            "model": "codex",
+            "messages": [
+                {"role": "system", "content": "system rules"},
+                {"role": "user", "content": "first user"},
+                {"role": "assistant", "content": "first assistant"},
+                {"role": "user", "content": "second user"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    prompt = prompts[0]
+    assert prompt.index("[system]: system rules") < prompt.index("[user]: first user")
+    assert prompt.index("[user]: first user") < prompt.index("[assistant]: first assistant")
+    assert prompt.index("[assistant]: first assistant") < prompt.index("[user]: second user")
+
+
+def test_healthz_endpoint_returns_backend_status(monkeypatch):
+    monkeypatch.setattr(
+        proxy,
+        "_BACKEND_PROBES",
+        {
+            "codex": lambda: True,
+            "gemini": lambda: False,
+            "claude": lambda: True,
+            "hermes": lambda: False,
+        },
+    )
+
+    response = _client().get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "backends": {
+            "codex": True,
+            "gemini": False,
+            "claude": True,
+            "hermes": False,
+        },
+    }


### PR DESCRIPTION
## Summary

Adds an OpenAI-compatible HTTP proxy at `:8767` that wraps Codex, Gemini, Claude headless, and Grok-via-Hermes behind `/v1/chat/completions` + `/v1/models` + `/healthz`.

Phase 1 is narrow:
- 4 backend families, 11 mocked tests, live curl round-trips where local CLI/auth/model availability allows
- No streaming, no tool-use translation, no Assistants API, no auth
- Localhost-only by default: `127.0.0.1:8767`

Follow-up issues filed from live smoke gaps:
- Gemini 3.0 route rejected by local Gemini CLI: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2022
- Claude `--bare` local auth gap: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2023

## Test plan

- [x] `pytest tests/ai_agent_bridge/test_openai_proxy.py` -> 11 passed
- [x] `pytest tests/ai_agent_bridge/` -> 21 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Live curl: `/v1/models`
- [x] Live curl: codex round-trip
- [x] Live curl: grok round-trip via Hermes
- [x] Live curl: gemini round-trip with locally available `gemini-3.1-pro-preview`
- [x] Live curl: unknown model 404 envelope
- [ ] Live curl: `gemini-3.0-flash-preview` returned backend failure locally; follow-up #2022
- [ ] Live curl: claude returned local auth failure; follow-up #2023

## Verifiable evidence

### Pytest: new proxy tests

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ .venv/bin/python -m pytest tests/ai_agent_bridge/test_openai_proxy.py -v
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collecting ... collected 11 items

tests/ai_agent_bridge/test_openai_proxy.py::test_models_endpoint_lists_routable_models PASSED [  9%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_codex_round_trip PASSED [ 18%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_grok_via_hermes PASSED [ 27%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_gemini_round_trip PASSED [ 36%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_claude_round_trip PASSED [ 45%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_unknown_model_returns_404 PASSED [ 54%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_backend_failure_returns_502 PASSED [ 63%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_backend_timeout_returns_504 PASSED [ 72%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_missing_messages_returns_422 PASSED [ 81%]
tests/ai_agent_bridge/test_openai_proxy.py::test_message_flatten_preserves_role_order PASSED [ 90%]
tests/ai_agent_bridge/test_openai_proxy.py::test_healthz_endpoint_returns_backend_status PASSED [100%]

============================== 11 passed in 0.29s ==============================
```

### Pytest: full bridge subtree

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ .venv/bin/python -m pytest tests/ai_agent_bridge/ -v
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collecting ... collected 21 items

tests/ai_agent_bridge/test_ab_discuss_bugs.py::test_discuss_round_four_prompt_preserves_root_and_all_thread_replies PASSED [  4%]
tests/ai_agent_bridge/test_ab_discuss_bugs.py::test_discuss_claude_subagent_uses_restricted_tools_without_plan_mode PASSED [  9%]
tests/ai_agent_bridge/test_ab_discuss_bugs.py::test_ask_codex_without_from_fails_when_sender_cannot_be_inferred PASSED [ 14%]
tests/ai_agent_bridge/test_ab_discuss_bugs.py::test_ask_codex_infers_from_claude_agent_name PASSED [ 19%]
tests/ai_agent_bridge/test_openai_proxy.py::test_models_endpoint_lists_routable_models PASSED [ 23%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_codex_round_trip PASSED [ 28%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_grok_via_hermes PASSED [ 33%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_gemini_round_trip PASSED [ 38%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_claude_round_trip PASSED [ 42%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_unknown_model_returns_404 PASSED [ 47%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_backend_failure_returns_502 PASSED [ 52%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_backend_timeout_returns_504 PASSED [ 57%]
tests/ai_agent_bridge/test_openai_proxy.py::test_chat_completions_missing_messages_returns_422 PASSED [ 61%]
tests/ai_agent_bridge/test_openai_proxy.py::test_message_flatten_preserves_role_order PASSED [ 66%]
tests/ai_agent_bridge/test_openai_proxy.py::test_healthz_endpoint_returns_backend_status PASSED [ 71%]
tests/ai_agent_bridge/test_verify_review.py::test_verify_review_outcomes PASSED [ 76%]
tests/ai_agent_bridge/test_verify_review.py::test_malformed_finding_is_discarded_with_reason PASSED [ 80%]
tests/ai_agent_bridge/test_verify_review.py::test_issue_mode_reads_latest_comment_and_posts_summary PASSED [ 85%]
tests/ai_agent_bridge/test_verify_review.py::test_review_protocol_is_loaded_at_call_time PASSED [ 90%]
tests/ai_agent_bridge/test_verify_review.py::test_build_agent_prompt_review_prefix_precedes_channel_context PASSED [ 95%]
tests/ai_agent_bridge/test_verify_review.py::test_inbox_thread_prompt_includes_review_prefix_before_context PASSED [100%]

============================== 21 passed in 1.28s ==============================
```

### Ruff

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ .venv/bin/ruff check scripts/ai_agent_bridge/openai_proxy.py tests/ai_agent_bridge/test_openai_proxy.py scripts/ai_agent_bridge/__main__.py scripts/ai_agent_bridge/_cli.py
All checks passed!
```

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ .venv/bin/ruff format --check scripts/ai_agent_bridge/openai_proxy.py tests/ai_agent_bridge/test_openai_proxy.py
2 files already formatted
```

### Server starts and models list

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ BRIDGE_PROXY_BACKEND_TIMEOUT_S=180 .venv/bin/python -c "from scripts.ai_agent_bridge.openai_proxy import app; import uvicorn; uvicorn.run(app, host='127.0.0.1', port=8767)"
INFO:     Started server process [98825]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8767 (Press CTRL+C to quit)
```

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s http://127.0.0.1:8767/v1/models | jq '.data[].id'
"codex"
"gemini-3.0-flash-preview"
"gemini-3.1-pro-preview"
"claude-opus-4-7"
"claude-sonnet-4-7"
"grok-4.3"
```

### Healthz

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s http://127.0.0.1:8767/healthz | jq
{
  "ok": true,
  "backends": {
    "codex": true,
    "gemini": true,
    "claude": true,
    "hermes": true
  }
}
```

### Unknown model 404

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s -X POST http://127.0.0.1:8767/v1/chat/completions -H 'content-type: application/json' -d '{"model":"unknown-model-xyz","messages":[{"role":"user","content":"Hello"}]}' | jq
{
  "error": {
    "message": "model 'unknown-model-xyz' not found",
    "type": "invalid_request_error",
    "code": "model_not_found"
  }
}
```

### Codex live round-trip

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s -X POST http://127.0.0.1:8767/v1/chat/completions -H 'content-type: application/json' -d '{"model":"codex","messages":[{"role":"user","content":"Reply with exactly the word: PONG"}]}' | jq -r '.choices[0].message.content // .error.message'
PONG
```

### Grok via Hermes live round-trip

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s -X POST http://127.0.0.1:8767/v1/chat/completions -H 'content-type: application/json' -d '{"model":"grok-4.3","messages":[{"role":"user","content":"What is 2+2? Answer with just the number."}]}' | jq -r '.choices[0].message.content // .error.message'
4
```

### Gemini live round-trip

`gemini-3.1-pro-preview` is the locally available Gemini model route; it returned successfully.

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s -X POST http://127.0.0.1:8767/v1/chat/completions -H 'content-type: application/json' -d '{"model":"gemini-3.1-pro-preview","messages":[{"role":"user","content":"Reply with exactly: PONG"}]}' | jq -r '.choices[0].message.content // .error.message'
PONG
```

`gemini-3.0-flash-preview` was also attempted because it is in the v1 registry, but the local CLI rejected it; follow-up #2022 tracks route/model reconciliation.

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s -X POST http://127.0.0.1:8767/v1/chat/completions -H 'content-type: application/json' -d '{"model":"gemini-3.0-flash-preview","messages":[{"role":"user","content":"Reply with exactly: PONG"}]}' | jq -r '.choices[0].message.content // .error.message'
google-gemini backend failed: Ripgrep is not available. Falling back to GrepTool.
```

Direct CLI detail for that same local model failure:

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ gemini -m gemini-3.0-flash-preview --prompt='--- Round 1 ---\n[user]: Reply with exactly: PONG' --approval-mode plan > /tmp/gemini-proxy-smoke.out 2> /tmp/gemini-proxy-smoke.err; rc=$?; printf 'rc=%s\n' "$rc"; printf 'stderr:\n'; sed -n '1,20p' /tmp/gemini-proxy-smoke.err; printf 'stdout:\n'; sed -n '1,20p' /tmp/gemini-proxy-smoke.out
rc=1
stderr:
Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support.
Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience.
Ripgrep is not available. Falling back to GrepTool.
Error when talking to Gemini API Full report available at: /var/folders/pd/wvj52r1j3bd4z9y3dfc2k4180000gn/T/gemini-client-error-Turn.run-sendMessageStream-2026-05-15T22-45-50-687Z.json ModelNotFoundError: Requested entity was not found.
    at classifyGoogleError (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:269998:12)
    at retryWithBackoff (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:270707:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async GeminiChat.makeApiCallAndProcessStream (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:293631:28)
    at async GeminiChat.streamWithRetries (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:293450:29)
    at async Turn.run (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:294024:24)
    at async GeminiClient.processTurn (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:306709:22)
    at async GeminiClient.sendMessageStream (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-7VVHSNDQ.js:306797:14)
    at async file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/gemini-QSTQ2DBG.js:10859:26
    at async main (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/gemini-QSTQ2DBG.js:16137:5) {
  code: 404
}
An unexpected critical error occurred:[object Object]
stdout:
```

### Claude live round-trip

The Claude CLI is installed, but `--bare` was not authenticated locally; follow-up #2023 tracks docs or backend-mode resolution.

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ curl -s -X POST http://127.0.0.1:8767/v1/chat/completions -H 'content-type: application/json' -d '{"model":"claude-sonnet-4-7","messages":[{"role":"user","content":"Reply with exactly: PONG"}]}' | jq -r '.choices[0].message.content // .error.message'
anthropic backend failed: Not logged in · Please run /login
```

### Follow-up issues

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ gh issue create --title "bridge: reconcile Gemini 3.0 OpenAI proxy route with available CLI models" --body "..."
https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2022
```

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ gh issue create --title "bridge: document or fix Claude --bare auth for OpenAI proxy" --body "..."
https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2023
```

### Commit landed

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ git log -1 --oneline
db04f07bed feat(bridge): OpenAI-compatible HTTP proxy at :8767
```

### Agent trailer check

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  db04f07bed  PASS  X-Agent: codex/openai-compat-bridge-proxy-2026-05-16

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

### PR opened

Pending; Codex will update after `gh pr view --json url -q '.url'`.

🤖 Generated with [Codex](https://codex.openai.com)


### PR URL evidence

```bash
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/openai-compat-bridge-proxy-2026-05-16
$ gh pr view feat/openai-compat-bridge-proxy --json url -q '.url'
https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2024
```
