### PR TITLE
fix(vesum-gate): preserve decorated surface + tighten pronunciation cue

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -455,11 +455,13 @@ _BRACES_RE = re.compile(r"\{[А-ЯІЇЄҐа-яіїєґ'ʼ]{1,12}\}")
 # Latin letter or digit — i.e., the hyphen must sit at a non-linguistic
 # boundary (markdown `*`/`_`, paren, whitespace, line start). This protects
 # legitimate hyphenated compounds like `темно-синій` (preceded by `о`) while
-# stripping morpheme labels in `**-шся**` and `__-шся__` (markdown bold). We
-# don't use Python's `\B` because `_` is a word character there, which would
-# make `__-шся__` un-strippable.
+# stripping morpheme labels in `**-шся**`, `__-шся__`, and `-**юся**`
+# (markdown emphasis around all or part of the label). We don't use Python's
+# `\B` because `_` is a word character there, which would make `__-шся__`
+# un-strippable.
 _MORPHEME_FRAGMENT_RE = re.compile(
-    r"(?<![А-ЯІЇЄҐа-яіїєґ'ʼA-Za-z0-9])-[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'ʼ]*"
+    r"(?<![А-ЯІЇЄҐа-яіїєґ'ʼA-Za-z0-9])[*_`]{0,2}-[*_`]{0,2}"
+    r"[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'ʼ]*[*_`]{0,2}"
 )
 _PRONUNCIATION_CUE_PATTERN = re.compile(
     r"(?:sounds?\s+like|звучить\s+як|вимовляється\s+як|вимова[:\s])\s*\*\*[^*]+\*\*",
@@ -476,16 +478,6 @@ _PRONUNCIATION_CUE_PATTERN = re.compile(
 # inner-content alternation `.+?` is non-greedy so adjacent `<!-- bad -->`
 # spans don't fuse.
 _AVOID_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(.+?)<!--\s*/bad\s*-->", re.DOTALL)
-
-# Markdown emphasis stripping for the gate text. `_normalize_for_vesum`
-# strips emphasis per-lemma, but `_MORPHEME_FRAGMENT_RE` runs at the TEXT
-# level and requires a hyphen adjacent to a Cyrillic letter — so a writer's
-# `-**юся**` (bold-wrapped morpheme suffix in a conjugation-table row)
-# survives morpheme stripping and then surfaces as a non-VESUM token. Strip
-# at the text level so the morpheme regex sees `-юся` and can collapse it.
-# Bold first (paired `**`), italic second (single `*` not adjacent to `*`).
-_BOLD_EMPHASIS_RE = re.compile(r"\*\*([^*]+)\*\*")
-_ITALIC_EMPHASIS_RE = re.compile(r"(?<!\*)\*(?!\*)([^*\n]+)\*(?!\*)")
 
 _STANDALONE_POSTFIX_FRAGMENTS = frozenset(
     {"ся", "сь", "тся", "тсь", "ться", "шся", "шсь", "чся", "чсь"}
@@ -4712,9 +4704,10 @@ def _strip_metalinguistic(text: str) -> str:
     - `[...]` — phonetic notation like `[с':а]`, `[ц':а]`
     - `` `...` `` and ` ``` ... ``` ` — inline/fenced code
     - `{...}` — fill-in blank syntax like `Я вмиваю{ся}. Він прокидає{ться}.`
-    - `\\B-морфема` — hyphen-prefixed conjugation labels like `**-шся**`,
-      `**-ться**`. The `\\B` lookbehind protects legitimate hyphenated
-      compounds (`темно-синій`) where the char before `-` is a word char.
+    - `-морфема` — hyphen-prefixed conjugation labels like `**-шся**`,
+      `**-ться**`, and `-**юся**`. The regex lookbehind protects legitimate
+      hyphenated compounds (`темно-синій`) where the char before `-` is a
+      word char.
     - `sounds like **...**` — cue-prefixed bold pronunciation transcriptions.
     - `діал.` — textbook abbreviation for `діалектне`, not a lemma.
     - `<!-- bad -->форма<!-- /bad -->` — pedagogical Russianism / surzhyk /
@@ -4724,13 +4717,6 @@ def _strip_metalinguistic(text: str) -> str:
       HTML comments don't render in MDX, so the learner still sees the
       bad form in plain prose for contrast.
 
-    Markdown emphasis (`**bold**`, `*italic*`) is unwrapped before the
-    morpheme-fragment regex runs, so a writer's bold-wrapped morpheme suffix
-    like `-**юся**` collapses to `-юся` and gets stripped by the morpheme
-    regex — otherwise the `**` between the hyphen and the Cyrillic letter
-    keeps the morpheme regex from matching, and `юся` surfaces as a
-    non-VESUM false positive.
-
     Used by the VESUM gate to avoid false positives on fragments that aren't
     VESUM-checkable lemmas.
     """
@@ -4738,12 +4724,8 @@ def _strip_metalinguistic(text: str) -> str:
     text = _INLINE_CODE_RE.sub(" ", text)
     text = _BRACKETS_RE.sub(" ", text)
     text = _BRACES_RE.sub(" ", text)
-    # Unwrap markdown emphasis BEFORE morpheme detection so bold-wrapped
-    # morpheme labels (e.g. `-**юся**`) collapse to `-юся` and get caught.
-    text = _BOLD_EMPHASIS_RE.sub(r"\1", text)
-    text = _ITALIC_EMPHASIS_RE.sub(r"\1", text)
-    text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _PRONUNCIATION_CUE_PATTERN.sub(" ", text)
+    text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _AVOID_MARKER_RE.sub(" ", text)
     text = _VESUM_ABBREVIATION_RE.sub(" ", text)
     return text


### PR DESCRIPTION
## Summary

Fixes the 3 vesum-gate test failures blocking PR #2019.

Branches off #2019's tip so the merge stacks. Once this lands into `fix/m20-writer-gate-russianism-markers`, #2019 can rerun with the VESUM regressions fixed.

## Failures fixed

The pronunciation cue regex itself matched `sounds like **Y**`, but `_strip_metalinguistic()` unwrapped all Markdown before applying the cue strip. That turned `sounds like **вмиваєсся**` into `sounds like вмиваєсся`, so the phonetic form reached VESUM. The fix applies `_PRONUNCIATION_CUE_PATTERN` before any morpheme stripping and no longer globally unwraps emphasis in this text-level strip path.

The decorated missing report lost Markdown because the same global emphasis unwrap ran before `_iter_vesum_lookup_surface_pairs()`. The lookup key still normalized correctly, but the report surface had already become `вмива́юся`. The fix preserves Markdown in the text passed to pair-building, so missing reports keep surfaces like `вмива́ю**ся**`.

The standalone decorated postfix `**ся**` was not actually blocked by `VESUM_MIN_WORD_LENGTH` once the decorated path could see the raw Markdown. The trace showed it was dropped because `_strip_metalinguistic()` had first converted it to plain `ся`, which `_iter_vesum_word_surfaces()` intentionally treats as a standalone postfix fragment. Preserving Markdown lets the existing decorated-path short-word allowlist send lookup key `ся` while keeping plain `ся` behavior unchanged.

To keep the previous morpheme false-positive protection, `_MORPHEME_FRAGMENT_RE` now consumes Markdown-decorated hyphen labels directly, including `**-шся**`, `__-шся__`, and `-**юся**`, without unwrapping all learner-facing emphasis.

## Diagnostic trace

Command, cwd, and output:

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/python - <<'PY'
from scripts.build import linear_pipeline as lp

cases = [
    "The spelling **вмиваєшся** sounds like **вмиваєсся**, and **вмивається** sounds like **вмиваєцця**.",
    "вмива́ю**ся** вмива́ю **ся** чу́до**в**",
    "вмива́ю**ся**",
]
for text in cases:
    stripped = lp._strip_metalinguistic(text)
    pairs = sorted(lp._iter_vesum_lookup_surface_pairs(stripped, min_word_length=3))
    print({"stripped": stripped, "pairs": pairs})
PY
{'stripped': 'The spelling **вмиваєшся**  , and **вмивається**  .', 'pairs': [('**вмивається**', 'вмивається', 'вмивається'), ('**вмиваєшся**', 'вмиваєшся', 'вмиваєшся')]}
{'stripped': 'вмива́ю**ся** вмива́ю **ся** чу́до**в**', 'pairs': [('**ся**', 'ся', 'ся'), ('вмива́ю', 'вмиваю', 'вмиваю'), ('вмива́ю**ся**', 'вмиваюся', 'вмиваюся'), ('чу́до**в**', 'чудов', 'чудов')]}
{'stripped': 'вмива́ю**ся**', 'pairs': [('вмива́ю**ся**', 'вмиваюся', 'вмиваюся')]}
```

## Test plan

- [x] 3 originally-failing tests now pass
- [x] Full both-files pytest green
- [x] Wider `pytest tests/` attempted; stopped on unrelated local corpus/data and fixture failures documented below
- [x] `ruff check scripts/build/linear_pipeline.py` clean
- [ ] `ruff format --check scripts/build/linear_pipeline.py` clean; not clean on this branch without unrelated whole-file formatter churn

## Verifiable evidence

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/python -m pytest tests/test_vesum_gate_distractor_and_phonetic.py::test_pronunciation_transcription_stripped_in_prose tests/test_vesum_verified_postfix.py::test_vesum_gate_normalizes_stress_and_markdown_before_lookup tests/test_vesum_verified_postfix.py::test_vesum_gate_missing_report_preserves_decorated_surface -v
============================== 3 passed in 0.33s ===============================
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/python -m pytest tests/test_vesum_gate_distractor_and_phonetic.py tests/test_vesum_verified_postfix.py -v
============================== 15 passed in 0.37s ==============================
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/python -m pytest tests/ -x -q --ignore=tests/test_pipeline_runtime.py
FAILED tests/test_channels_registry.py::test_registry_covers_all_external_source_files
= 1 failed, 1682 passed, 30 skipped, 1 xfailed, 3 warnings in 86.39s (0:01:26) =
```

The failure is unrelated to this VESUM change: in this worktree `data/external_articles` has no `*.jsonl` files, while `channels.yaml` registers eight channels.

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ PYTHONPATH=scripts .venv/bin/python - <<'PY'
from wiki.channels import CHANNELS_PATH
print(CHANNELS_PATH)
print(CHANNELS_PATH.parent)
print([p.name for p in CHANNELS_PATH.parent.glob('*.jsonl')])
PY
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2/data/external_articles/channels.yaml
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2/data/external_articles
[]
```

Best-effort continuation excluding that local-corpus registry file:

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/python -m pytest tests/ -x -q --ignore=tests/test_pipeline_runtime.py --ignore=tests/test_channels_registry.py
FAILED tests/test_esum_search.py::test_search_esum_berkut_returns_turkic_origin
= 1 failed, 3721 passed, 67 skipped, 1 xfailed, 3 warnings in 121.73s (0:02:01) =
```

That later failure is also outside this change: the returned fixture text says `запозичення з тюркських мов` but does not contain the expected substring `тат. біркут`.

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/ruff check scripts/build/linear_pipeline.py
All checks passed!
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/ruff format --check scripts/build/linear_pipeline.py
Would reformat: scripts/build/linear_pipeline.py
1 file would be reformatted
```

I did not commit `ruff format` output because it rewrites broad pre-existing formatting across `linear_pipeline.py`, far outside the VESUM gate fix.

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ git log -1 --oneline
3d6712685f fix(vesum-gate): preserve decorated lookup surfaces
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr2019-vesum-gate-fixes-2026-05-16-v2
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 2 commit(s) in origin/main..HEAD:

  3d6712685f  PASS  X-Agent: codex/pr2019-vesum-gate-fixes-2026-05-16-v2
  21de50bf96  FAIL  missing X-Agent trailer in commit "fix(m20/gate+writer): Russianism markers + bold-strip + 2-st"

❌ 1/2 commit(s) missing X-Agent trailer.
```

The new commit has the required trailer. The failure is from the underlying PR #2019 base commit, which this stacked fix branch does not rewrite.

🤖 Generated with [Codex](https://codex.openai.com)