### PR TITLE
feat(v7): add grok-tools writer family via hermes adapter

### DIFF
--- a/scripts/agent_runtime/adapters/__init__.py
+++ b/scripts/agent_runtime/adapters/__init__.py
@@ -10,3 +10,7 @@ authors should copy as a starting point.
 Issue: #1184
 """
 from __future__ import annotations
+
+from .hermes_grok import HermesGrokAdapter
+
+__all__ = ["HermesGrokAdapter"]

--- a/scripts/agent_runtime/adapters/hermes_grok.py
+++ b/scripts/agent_runtime/adapters/hermes_grok.py
@@ -1,0 +1,178 @@
+"""HermesGrokAdapter — wraps ``hermes -z PROMPT -m grok-4.3``.
+
+Hermes resolves MCP tool calls inside its own session loop using the user's
+``~/.hermes/config.yaml`` registration. In ``-z`` mode the adapter only sees
+Hermes's final assistant message on stdout; there is no Claude/Gemini/Codex
+stream-json trace to parse. That means tool-call telemetry is unavailable,
+not verified zero. The adapter returns a parse result whose
+``tool_calls_total`` is ``None`` so downstream V7 telemetry can preserve that
+distinction.
+
+Reasoning effort is also config-scoped for Hermes headless mode. This adapter
+never mutates ``~/.hermes/config.yaml`` because doing so per call would race
+concurrent V7 builds. If a caller passes ``effort`` and the readable top-level
+Hermes config disagrees, we log a warning and continue with the configured
+runtime behavior.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..result import ParseResult
+from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_RATE_LIMIT_RE = re.compile(
+    r"rate limit|rate_limit|quota exceeded|too many requests|\bHTTP 429\b|\b429\b",
+    re.IGNORECASE,
+)
+_HERMES_CONFIG_PATH = Path.home() / ".hermes" / "config.yaml"
+
+
+@dataclass(frozen=True)
+class HermesGrokParseResult(ParseResult):
+    """Parse result with explicit unknown tool-call telemetry."""
+
+    tool_calls_total: int | None = None
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text or "").strip()
+
+
+def _read_hermes_config(path: Path = _HERMES_CONFIG_PATH) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _top_level_agent_effort(config: dict[str, Any]) -> str | None:
+    agent = config.get("agent")
+    if not isinstance(agent, dict):
+        return None
+    effort = agent.get("reasoning_effort")
+    if isinstance(effort, str) and effort.strip():
+        return effort.strip()
+    return None
+
+
+def _sources_mcp_registered(config: dict[str, Any]) -> bool:
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return False
+    sources = servers.get("sources")
+    if not isinstance(sources, dict):
+        return False
+    return bool(sources.get("enabled") is not False and sources.get("url"))
+
+
+class HermesGrokAdapter:
+    """Adapter for the Hermes CLI using Grok 4.3."""
+
+    name: str = "grok"
+    default_model: str = "grok-4.3"
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        """Build the Hermes one-shot invocation.
+
+        ``tool_config`` is intentionally not translated into CLI flags: Hermes
+        discovers MCP servers from ``~/.hermes/config.yaml``. Unknown keys are
+        ignored for forward compatibility with the common runtime contract.
+        """
+        _ = mode
+        _ = task_id
+        _ = session_id
+        _ = tool_config
+
+        config = _read_hermes_config()
+        configured_effort = _top_level_agent_effort(config)
+        if effort and configured_effort and configured_effort != effort:
+            _logger.warning(
+                "Hermes Grok effort=%r requested, but ~/.hermes/config.yaml "
+                "agent.reasoning_effort=%r; using Hermes config without mutation",
+                effort,
+                configured_effort,
+            )
+        elif effort and configured_effort is None:
+            _logger.warning(
+                "Hermes Grok effort=%r requested, but no readable top-level "
+                "agent.reasoning_effort was found in ~/.hermes/config.yaml; "
+                "using Hermes config without mutation",
+                effort,
+            )
+
+        if not _sources_mcp_registered(config):
+            _logger.warning(
+                "Hermes Grok did not find enabled mcp_servers.sources in "
+                "~/.hermes/config.yaml; MCP tool availability depends on Hermes config"
+            )
+
+        hermes_bin = shutil.which("hermes") or "hermes"
+        return InvocationPlan(
+            cmd=[hermes_bin, "-z", prompt, "-m", model or self.default_model],
+            cwd=cwd,
+            stdin_payload="",
+            output_file=None,
+            env_overrides={},
+            liveness_paths=(),
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> HermesGrokParseResult:
+        """Parse Hermes final stdout into a runtime result."""
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+
+        response = _strip_ansi(stdout)
+        clean_stderr = _strip_ansi(stderr)
+        rate_limited = returncode != 0 and bool(_RATE_LIMIT_RE.search(clean_stderr))
+        ok = returncode == 0 and bool(response) and not rate_limited
+        stderr_excerpt = None if ok else (clean_stderr or response or None)
+
+        return HermesGrokParseResult(
+            ok=ok,
+            response=response if ok else "",
+            stderr_excerpt=stderr_excerpt[:500] if stderr_excerpt else None,
+            rate_limited=rate_limited,
+            session_id=None,
+            tokens=None,
+            tool_calls=[],
+            tool_calls_total=None,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Hermes ``-z`` writes to stdout; no separate liveness files."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -111,11 +111,15 @@ AGENTS: dict[str, AgentEntry] = {
         "resume_policy": "never",
     },
     "grok": {
-        "adapter": "scripts.agent_runtime.adapters.grok:GrokAdapter",
-        "default_model": None,
-        "cost_tier": "unknown",
-        "capabilities": frozenset(),
-        "cli_available": False,
+        "adapter": "scripts.agent_runtime.adapters.hermes_grok:HermesGrokAdapter",
+        "default_model": "grok-4.3",
+        "cost_tier": "low",
+        "capabilities": frozenset({
+            "content_writing",
+            "content_review",
+            "adversarial_review",
+        }),
+        "cli_available": True,
         "resume_policy": "never",
     },
 }

--- a/scripts/agent_runtime/result.py
+++ b/scripts/agent_runtime/result.py
@@ -92,6 +92,9 @@ class Result:
             Each entry has name, arguments, output_summary, timestamp, and
             may have result. Kept in memory only; do not persist or echo
             arguments or results to JSONL telemetry without redaction.
+        tool_calls_total: Total tool calls surfaced by the provider trace.
+            ``None`` means the provider/CLI did not expose telemetry, not
+            "verified zero".
     """
     ok: bool
     agent: str
@@ -108,3 +111,4 @@ class Result:
     cli_version: str = "unknown"
     usage_record: dict[str, Any] = field(default_factory=dict)
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    tool_calls_total: int | None = 0

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -1082,6 +1082,7 @@ def _invoke_gemini_with_fallback(
             returncode=returncode,
             usage_record=record,
             tool_calls=last_tool_calls,
+            tool_calls_total=len(last_tool_calls),
         )
 
     if call_result.attempts and all(
@@ -1168,6 +1169,7 @@ def _invoke_gemini_with_fallback(
         returncode=returncode,
         usage_record=record,
         tool_calls=last_tool_calls,
+        tool_calls_total=len(last_tool_calls),
     )
 
 
@@ -1455,4 +1457,5 @@ def invoke(
         returncode=execution.returncode,
         usage_record=record,
         tool_calls=list(parse.tool_calls),
+        tool_calls_total=getattr(parse, "tool_calls_total", len(parse.tool_calls)),
     )

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -160,6 +160,8 @@ def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | No
         return _arg_after(plan.cmd, "--effort")
     if agent_name == "gemini":
         return None
+    if agent_name == "grok":
+        return None
     return None
 
 
@@ -174,6 +176,8 @@ def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -
             _gemini_settings(),
             ("model", "defaultModel", "selectedModel", "modelName", "default_model"),
         )
+    if agent_name == "grok":
+        return _default_model_for(agent_name)
     if agent_name == "claude":
         return _default_model_for(agent_name)
     return _default_model_for(agent_name)
@@ -214,6 +218,12 @@ def _gemini_version_prefix(cmd: list[str]) -> tuple[str, ...]:
     if cmd:
         return (cmd[0],)
     return ("gemini",)
+
+
+def _grok_version_prefix(cmd: list[str]) -> tuple[str, ...]:
+    if cmd:
+        return (cmd[0],)
+    return ("hermes",)
 
 
 def _probe_version(prefix: tuple[str, ...]) -> str | None:
@@ -263,6 +273,9 @@ def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) ->
     if agent_name == "claude":
         prefix = _claude_version_prefix(plan.cmd) if plan is not None else ("claude",)
         return claude_cli_version(prefix)
+    if agent_name == "grok":
+        prefix = _grok_version_prefix(plan.cmd) if plan is not None else ("hermes",)
+        return _probe_version(prefix)
     return None
 
 

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -28,6 +28,8 @@ def _canonical_agent_name(agent: str) -> str | None:
         return "gemini"
     if agent.startswith("codex"):
         return "codex"
+    if agent.startswith("grok"):
+        return "grok"
     return None
 
 
@@ -221,6 +223,24 @@ def build_mcp_tool_config(
             {"mcp_server_names": mcp_servers},
             _basic_diagnostics(
                 mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
+
+    if canonical_agent == "grok":
+        if not mcp_servers:
+            return None, _basic_diagnostics(
+                mcp_config_path=Path.home() / ".hermes" / "config.yaml",
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status="config_empty",
+            )
+        return (
+            {"hermes_mcp_servers": mcp_servers},
+            _basic_diagnostics(
+                mcp_config_path=Path.home() / ".hermes" / "config.yaml",
                 requested_servers=mcp_servers,
                 resolved_servers=mcp_servers,
                 resolution_status="ok",

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -58,17 +58,19 @@ PLAN_REQUIRED_KEYS = {
     "references",
 }
 
-WRITER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools")
+WRITER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools", "grok-tools")
 WRITER_DEFAULTS: dict[str, dict[str, str]] = {
     "claude-tools": {"model": "claude-opus-4-7", "effort": "xhigh"},
     "gemini-tools": {"model": "gemini-3.1-pro-preview", "effort": "high"},
     "codex-tools": {"model": "gpt-5.5", "effort": "high"},
+    "grok-tools": {"model": "grok-4.3", "effort": "medium"},
 }
-REVIEWER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools")
+REVIEWER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools", "grok-tools")
 REVIEWER_DEFAULTS: dict[str, dict[str, str]] = {
     "claude-tools": {"model": "claude-opus-4-7", "effort": "xhigh"},
     "gemini-tools": {"model": "gemini-3.1-pro-preview", "effort": "high"},
     "codex-tools": {"model": "gpt-5.5", "effort": "high"},
+    "grok-tools": {"model": "grok-4.3", "effort": "medium"},
 }
 WRITER_ARTIFACTS = (
     "module.md",
@@ -1920,7 +1922,9 @@ def detect_tool_theatre(
     return sorted(cited - called)
 
 
-def _runtime_tool_calls(result: Any) -> list[dict[str, Any]]:
+def _runtime_tool_calls(result: Any) -> list[dict[str, Any]] | None:
+    if getattr(result, "tool_calls_total", "known") is None:
+        return None
     # Runtime Result.tool_calls is the producer today. usage_record support is
     # read-only forward compatibility; persisting raw arguments needs redaction.
     calls: list[dict[str, Any]] = []
@@ -2187,8 +2191,9 @@ def emit_writer_response_telemetry(
             fields_filled=result["fields_filled"],
         )
 
-    tool_calls_total = 0
-    verify_words_calls = 0
+    telemetry_unavailable = tool_calls is None
+    tool_calls_total: int | None = None if telemetry_unavailable else 0
+    verify_words_calls: int | None = None if telemetry_unavailable else 0
     for call in tool_calls or []:
         tool = _normalize_tool_name(
             call.get("tool") or call.get("tool_name") or call.get("name")
@@ -2197,8 +2202,10 @@ def emit_writer_response_telemetry(
             continue
         args = call.get("args", call.get("arguments", {}))
         result = call.get("result", call.get("response"))
+        assert tool_calls_total is not None
         tool_calls_total += 1
         if tool == "verify_words":
+            assert verify_words_calls is not None
             verify_words_calls += 1
         fields: dict[str, Any] = {
             "writer": writer,
@@ -2235,10 +2242,13 @@ def emit_writer_response_telemetry(
         "sections_with_cot": sum(1 for result in cot_results if result["block_present"]),
         "tool_calls_total": tool_calls_total,
         "verify_words_calls": verify_words_calls,
+        "tool_call_telemetry_available": not telemetry_unavailable,
         "end_gate_fired": bool(gate["gate_present"]),
         "removed_via_gate": int(gate["removed_count"]),
     }
-    theatre_violations = detect_tool_theatre(output, list(tool_calls or []))
+    theatre_violations = (
+        [] if telemetry_unavailable else detect_tool_theatre(output, list(tool_calls or []))
+    )
     capped_theatre_violations = theatre_violations[:TELEMETRY_MAX_THEATRE_VIOLATIONS]
     summary["tool_theatre_violations"] = capped_theatre_violations
     summary["tool_theatre_violation_count"] = len(theatre_violations)
@@ -2268,6 +2278,8 @@ def _enforce_tools_writer_runtime_gate(
     """Fail when a tools writer resolved MCP config but never invoked a tool."""
     if not writer.endswith("-tools"):
         return
+    if phase_writer_summary["tool_calls_total"] is None:
+        return
     if phase_writer_summary["tool_calls_total"] != 0:
         return
     raise LinearPipelineError(
@@ -2288,6 +2300,8 @@ def _mcp_tools_never_invoked_failure(
     phase_writer_summary: Mapping[str, Any],
 ) -> FailureRecord | None:
     if not writer.endswith("-tools"):
+        return None
+    if phase_writer_summary["tool_calls_total"] is None:
         return None
     if phase_writer_summary["tool_calls_total"] != 0:
         return None
@@ -2311,11 +2325,11 @@ def _enforce_writer_runtime_gates(
     writer: str,
     module: str,
     phase_writer_summary: Mapping[str, Any],
-    tool_calls: list[Mapping[str, Any]],
+    tool_calls: list[Mapping[str, Any]] | None,
     event_sink: Callable[..., None] | None = None,
 ) -> None:
     failures = [
-        *classify_writer_trace(tool_calls),
+        *classify_writer_trace(tool_calls or []),
     ]
     mcp_failure = _mcp_tools_never_invoked_failure(
         writer=writer,
@@ -2443,14 +2457,14 @@ def _runtime_tool_config(
             "mcp_servers": ["sources"],
             "allowed_tools": "mcp__sources__*",
         }
-    elif agent_label == "gemini-tools":
+    elif agent_label in {"gemini-tools", "grok-tools"}:
         agent_kwargs = {
             "mcp_servers": ["sources"],
         }
     else:
         raise LinearPipelineError(
             f"Unknown -tools writer {agent_label!r}; expected one of "
-            "codex-tools / claude-tools / gemini-tools."
+            "codex-tools / claude-tools / gemini-tools / grok-tools."
         )
 
     canonical_agent = agent_label.split("-", 1)[0]
@@ -2563,7 +2577,7 @@ def invoke_writer(
     module_ref = module or _prompt_module_ref(prompt)
     section_names = list(sections) if sections is not None else _prompt_sections(prompt)
     tool_calls = _runtime_tool_calls(result)
-    if tool_trace_path is not None:
+    if tool_trace_path is not None and tool_calls is not None:
         tool_trace_path.parent.mkdir(parents=True, exist_ok=True)
         existing_calls: list[Any] = []
         if tool_trace_path.exists():

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -29,6 +29,7 @@ WRITER_ALIASES = {
     "claude": "claude-tools",
     "gemini": "gemini-tools",
     "codex": "codex-tools",
+    "grok": "grok-tools",
 }
 WRITER_CHOICES = (*linear_pipeline.WRITER_CHOICES, *WRITER_ALIASES)
 
@@ -426,6 +427,8 @@ def _generated_content(module_dir: Path) -> str:
 def _reviewer_for_writer(writer: str) -> str:
     if writer == "claude-tools":
         return "gemini-tools"
+    if writer == "grok-tools":
+        return "claude-tools"
     return "claude-tools"
 
 
@@ -574,8 +577,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="claude-tools",
         help=(
             "Writer backend for the one-shot V7 write phase "
-            "(default: claude-tools; claude/gemini/codex aliases normalize to "
-            "claude-tools/gemini-tools/codex-tools)."
+            "(default: claude-tools; claude/gemini/codex/grok aliases normalize to "
+            "claude-tools/gemini-tools/codex-tools/grok-tools)."
         ),
     )
     parser.add_argument(
@@ -715,6 +718,8 @@ def _run(args: argparse.Namespace) -> int:
         # gemini-tools must load .gemini/settings.json from repo root;
         # module_dir cwd would leave its MCP catalog empty. See
         # audit/gemini-tools-review-2026-05-09/REPORT.html E5/E6.
+        # grok-tools gets MCP from ~/.hermes/config.yaml and can run from
+        # the module directory like claude-tools/codex-tools.
         writer_cwd = PROJECT_ROOT if writer == "gemini-tools" else module_dir
         writer_output = linear_pipeline.invoke_writer(
             prompt,

--- a/tests/agent_runtime/adapters/test_hermes_grok_adapter.py
+++ b/tests/agent_runtime/adapters/test_hermes_grok_adapter.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.adapters.hermes_grok import HermesGrokAdapter
+from agent_runtime.errors import AgentTimeoutError, AgentUnavailableError
+from agent_runtime.runner import invoke
+from agent_runtime.usage import _reset_rate_limit_cache_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime(tmp_path):
+    _reset_rate_limit_cache_for_tests()
+    with patch("agent_runtime.usage._usage_dir", return_value=tmp_path / "api_usage"):
+        yield
+    _reset_rate_limit_cache_for_tests()
+
+
+def _build(prompt: str, tmp_path: Path):
+    return HermesGrokAdapter().build_invocation(
+        prompt=prompt,
+        mode="workspace-write",
+        cwd=tmp_path,
+        model="grok-4.3",
+        task_id=None,
+        session_id=None,
+        tool_config={"hermes_mcp_servers": ["sources"]},
+        effort="medium",
+    )
+
+
+def test_grok_adapter_invokes_hermes_z_with_correct_argv(tmp_path, monkeypatch):
+    monkeypatch.setattr("agent_runtime.adapters.hermes_grok.shutil.which", lambda _: "hermes")
+
+    plan = _build("Write the module.", tmp_path)
+
+    assert plan.cmd == ["hermes", "-z", "Write the module.", "-m", "grok-4.3"]
+    assert plan.cwd == tmp_path
+    assert plan.stdin_payload == ""
+
+
+def test_grok_adapter_returns_stdout_as_response():
+    result = HermesGrokAdapter().parse_response(
+        stdout="hello from grok",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "hello from grok"
+
+
+def test_grok_adapter_tool_calls_total_is_none_not_zero():
+    result = HermesGrokAdapter().parse_response(
+        stdout="hello",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.tool_calls == []
+    assert result.tool_calls_total is None
+
+
+def test_grok_adapter_handles_missing_hermes_binary(tmp_path):
+    with (
+        patch("agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("agent_runtime.runner.write_record"),
+        patch(
+            "agent_runtime.runner.subprocess.Popen",
+            side_effect=FileNotFoundError("hermes"),
+        ),
+        pytest.raises(AgentUnavailableError, match="Popen failed: FileNotFoundError"),
+    ):
+        invoke(
+            "grok",
+            "hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="grok-4.3",
+            entrypoint="dispatch",
+            effort="medium",
+        )
+
+
+def test_grok_adapter_honors_timeout(tmp_path, monkeypatch):
+    adapter = HermesGrokAdapter()
+
+    def fake_build_invocation(**kwargs):
+        return InvocationPlan(cmd=["/bin/sh", "-c", "sleep 5"], cwd=Path(kwargs["cwd"]))
+
+    monkeypatch.setattr(adapter, "build_invocation", fake_build_invocation)
+    monkeypatch.setattr("agent_runtime.runner._load_adapter", lambda _name: adapter)
+
+    with (
+        patch("agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("agent_runtime.runner.write_record"),
+        pytest.raises(AgentTimeoutError),
+    ):
+        invoke(
+            "grok",
+            "hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="grok-4.3",
+            entrypoint="dispatch",
+            hard_timeout=1,
+        )
+
+
+def test_grok_adapter_strips_ansi_codes_from_stdout():
+    result = HermesGrokAdapter().parse_response(
+        stdout="\x1b[32mhello\x1b[0m",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.response == "hello"
+
+
+def test_runner_preserves_unknown_grok_tool_call_total(tmp_path, monkeypatch):
+    adapter = HermesGrokAdapter()
+
+    def fake_build_invocation(**kwargs):
+        return InvocationPlan(cmd=["/bin/sh", "-c", "printf hello"], cwd=Path(kwargs["cwd"]))
+
+    monkeypatch.setattr(adapter, "build_invocation", fake_build_invocation)
+    monkeypatch.setattr("agent_runtime.runner._load_adapter", lambda _name: adapter)
+
+    with (
+        patch("agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("agent_runtime.runner.write_record"),
+    ):
+        result = invoke(
+            "grok",
+            "hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="grok-4.3",
+            entrypoint="dispatch",
+            effort="medium",
+        )
+
+    assert result.response == "hello"
+    assert result.tool_calls == []
+    assert result.tool_calls_total is None

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -221,6 +221,7 @@ def test_load_adapter_unknown_raises():
         ("codex-tools", "codex"),
         ("claude-tools", "claude"),
         ("gemini-tools", "gemini"),
+        ("grok-tools", "grok"),
     ],
 )
 def test_validate_agent_name_rejects_tools_suffix(agent_name, bare_name):
@@ -242,9 +243,11 @@ def test_invoke_rejects_tools_suffix_before_adapter_load():
         invoke("codex-tools", "hello", mode="read-only")
 
 
-def test_load_adapter_grok_stub_unavailable():
-    with pytest.raises(AgentUnavailableError, match="cli_available=False"):
-        _load_adapter("grok")
+def test_load_adapter_grok():
+    adapter = _load_adapter("grok")
+    assert adapter.__class__.__name__ == "HermesGrokAdapter"
+    assert adapter.name == "grok"
+    assert adapter.default_model == "grok-4.3"
 
 
 def test_load_adapter_gemma_local():

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -47,6 +47,7 @@ def _seed_sources_mcp_config(
         ("claude-tools", "claude"),
         ("gemini-tools", "gemini"),
         ("codex-tools", "codex"),
+        ("grok-tools", "grok"),
     ],
 )
 def test_v7_writer_choices_resolve_to_runtime_adapters(
@@ -93,14 +94,19 @@ def test_v7_writer_choices_resolve_to_runtime_adapters(
             (tmp_path / ".mcp.json").resolve()
         )
         assert calls[0][2]["tool_config"]["allowed_tools"] == "mcp__sources__*"
-    else:
+    elif writer == "gemini-tools":
         assert calls[0][2]["tool_config"]["mcp_server_names"] == ["sources"]
+    else:
+        assert calls[0][2]["tool_config"]["hermes_mcp_servers"] == ["sources"]
 
 
 def test_v7_build_accepts_codex_alias() -> None:
     assert "codex-tools" in v7_build.WRITER_CHOICES
     assert "codex" in v7_build.WRITER_CHOICES
     assert v7_build._normalize_writer("codex") == "codex-tools"
+    assert "grok-tools" in v7_build.WRITER_CHOICES
+    assert "grok" in v7_build.WRITER_CHOICES
+    assert v7_build._normalize_writer("grok") == "grok-tools"
 
 
 @pytest.mark.parametrize(
@@ -109,6 +115,7 @@ def test_v7_build_accepts_codex_alias() -> None:
         ("gemini-tools", v7_build.PROJECT_ROOT),
         ("claude-tools", None),
         ("codex-tools", None),
+        ("grok-tools", None),
     ],
 )
 def test_v7_build_invokes_gemini_tools_from_project_root(
@@ -261,6 +268,37 @@ def test_positive_runtime_gate_fires_when_tools_writer_makes_zero_mcp_calls(
 
     summary = next(event for event in events if event["event"] == "phase_writer_summary")
     assert summary["tool_calls_total"] == 0
+
+
+def test_grok_unknown_tool_telemetry_is_not_treated_as_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_sources_mcp_config(tmp_path, monkeypatch)
+    events: list[dict[str, Any]] = []
+
+    def fake_invoker(_agent: str, _prompt: str, **_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            response="writer output",
+            tool_calls=[],
+            tool_calls_total=None,
+        )
+
+    response = linear_pipeline.invoke_writer(
+        "Write the module.",
+        writer="grok-tools",
+        cwd=tmp_path,
+        invoker=fake_invoker,
+        module="a1/1",
+        sections=["vocab"],
+        event_sink=lambda event, **fields: events.append({"event": event, **fields}),
+    )
+
+    summary = next(event for event in events if event["event"] == "phase_writer_summary")
+    assert response == "writer output"
+    assert summary["tool_calls_total"] is None
+    assert summary["verify_words_calls"] is None
+    assert summary["tool_call_telemetry_available"] is False
 
 
 def test_positive_runtime_gate_does_not_fire_for_non_tools_writer() -> None:


### PR DESCRIPTION
Closes Grok 4.3 onboarding Stage 3 (the only remaining stage from the 2026-05-16 onboarding study).

Adds:
- `scripts/agent_runtime/adapters/hermes_grok.py` — new adapter wrapping `hermes -z PROMPT -m grok-4.3` for V7's writer + reviewer surfaces.
- `WRITER_CHOICES` + `WRITER_DEFAULTS` + `REVIEWER_CHOICES` + `REVIEWER_DEFAULTS` extended in `linear_pipeline.py` with `"grok-tools": {"model": "grok-4.3", "effort": "medium"}`. Medium NOT high — per onboarding finding, `reasoning_effort=high` underperforms medium.
- `v7_build.py` alias `grok -> grok-tools`, reviewer pairing, `--writer` help string, and writer cwd handling.
- Runtime registry/telemetry support for the `grok` adapter.
- 7 focused unit tests for the adapter and V7 routing coverage.

Telemetry gap: Hermes `-z` mode does not expose stream-json tool-call events the way Claude/Codex/Gemini do. The adapter surfaces `tool_calls_total=None` (NOT 0) to signal "telemetry unavailable" vs "verified zero".

Per-call config mutation of `~/.hermes/config.yaml` is race-prone for concurrent V7 builds; v1 reads the user-configured Hermes runtime. `reasoning_effort` mismatch logs a warning and does not mutate config.

## Deterministic Evidence

| Claim | Evidence |
|---|---|
| `grok-tools` registered in `WRITER_CHOICES` | `grep -n grok-tools scripts/build/linear_pipeline.py`:<br><pre>61:WRITER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools", "grok-tools")
66:    "grok-tools": {"model": "grok-4.3", "effort": "medium"},
68:REVIEWER_CHOICES = ("claude-tools", "gemini-tools", "codex-tools", "grok-tools")
73:    "grok-tools": {"model": "grok-4.3", "effort": "medium"},
2460:    elif agent_label in {"gemini-tools", "grok-tools"}:
2467:            "codex-tools / claude-tools / gemini-tools / grok-tools."</pre> |
| Adapter file exists with right protocol | `.venv/bin/python -c "from scripts.agent_runtime.adapters.hermes_grok import HermesGrokAdapter; print(HermesGrokAdapter)"`:<br><pre>&lt;class 'scripts.agent_runtime.adapters.hermes_grok.HermesGrokAdapter'&gt;</pre> |
| All adapter tests pass | `.venv/bin/python -m pytest tests/agent_runtime/adapters/test_hermes_grok_adapter.py -v`:<br><pre>============================== 7 passed in 2.71s ==============================</pre> |
| No regression in adapter test suite | `.venv/bin/python -m pytest tests/agent_runtime/ -v`:<br><pre>============================== 7 passed in 2.66s ==============================</pre><br>Additional legacy runtime suite: `.venv/bin/python -m pytest tests/test_agent_runtime.py -v`:<br><pre>============================= 133 passed in 25.44s =============================</pre> |
| V7 routing tests pass | `.venv/bin/python -m pytest tests/test_v7_writer_dispatch.py -v`:<br><pre>============================== 15 passed in 1.99s ==============================</pre> |
| Wider sweep status | `.venv/bin/python -m pytest tests/ -x -q --ignore=tests/test_pipeline_runtime.py`:<br><pre>FAILED tests/test_esum_search.py::test_search_esum_berkut_returns_turkic_origin
= 1 failed, 3757 passed, 66 skipped, 1 xfailed, 3 warnings in 111.19s (0:01:51) =</pre>This is the known pre-existing #2001 ESUM failure called out in the dispatch brief. |
| Ruff clean | `.venv/bin/ruff check scripts/agent_runtime/adapters/hermes_grok.py tests/agent_runtime/adapters/test_hermes_grok_adapter.py scripts/build/linear_pipeline.py scripts/build/v7_build.py`:<br><pre>All checks passed!</pre> |
| Help string includes `grok-tools` | `.venv/bin/python scripts/build/v7_build.py --help 2>&1 | grep grok`:<br><pre>                   [--writer {claude-tools,gemini-tools,codex-tools,grok-tools,claude,gemini,codex,grok}]
  --writer {claude-tools,gemini-tools,codex-tools,grok-tools,claude,gemini,codex,grok}
                        (default: claude-tools; claude/gemini/codex/grok
                        tools/grok-tools).</pre> |
| Commit trailer clean | `.venv/bin/python scripts/audit/lint_agent_trailer.py`:<br><pre>Checking 1 commit(s) in origin/main..HEAD:

  8eeec57d91  PASS  X-Agent: codex/grok-stage-3-writer-plumbing-2026-05-16

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.</pre> |
| Affected-file pre-commit clean | `git commit` hook:<br><pre>============================= 155 passed in 30.15s =============================
✅ pre-commit passed</pre> |
