### PR TITLE
feat(audit): add judge calibration matrix harness

### DIFF
--- a/docs/runbooks/judge-calibration-matrix-runbook.md
+++ b/docs/runbooks/judge-calibration-matrix-runbook.md
@@ -1,0 +1,104 @@
+# Judge Calibration Matrix Runbook
+
+This runbook is for the Russianism judge calibration matrix implemented in
+`scripts/audit/judge_calibration_matrix.py`.
+
+## Pre-flight
+
+Fetch the PR #2006 calibration cases if the local ref is missing:
+
+```bash
+git fetch origin 'refs/pull/2006/head:refs/remotes/origin/pr-2006'
+```
+
+Verify Hermes routes return non-empty output before spending matrix quota:
+
+```bash
+hermes -z "Reply PONG." -m gpt-5.5
+hermes -z "Reply PONG." -m claude-opus-4-7
+```
+
+Until #2036 is resolved (`hermes auth add anthropic`), run the Anthropic
+family with `--harnesses native_cli` only. The harness supports `hermes` for
+Anthropic, but the auth is currently missing.
+If `hermes auth status anthropic` reports logged in but the Claude PONG check
+still returns empty stdout, keep the same `native_cli` fallback and update
+#2036 with the fresh evidence.
+
+If Claude via Hermes still returns empty output after auth is repaired, debug:
+
+```bash
+hermes -z "Reply PONG." -m claude-opus-4-7 --provider anthropic
+hermes -z "Reply PONG." -m claude-opus-4-7 2>&1 | head -200
+HERMES_DEBUG=1 hermes -z "Reply PONG." -m claude-opus-4-7
+```
+
+Then check `~/.hermes/logs/`, try `claude-opus-4-6`, and try
+`claude-sonnet-4-6` to separate an opus-4-7 issue from a provider issue.
+
+## Smoke
+
+Run the dispatch smoke only, not the full matrix:
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --smoke \
+  --out-dir audit/2026-05-17-judge-calibration-matrix-smoke/
+```
+
+## Per-family Runs
+
+Run families serially after smoke passes:
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --families xai \
+  --harnesses hermes \
+  --out-dir audit/2026-05-17-judge-calibration-matrix/
+```
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --families anthropic \
+  --harnesses native_cli \
+  --resume \
+  --out-dir audit/2026-05-17-judge-calibration-matrix/
+```
+
+After #2036 is resolved, include Hermes for Anthropic:
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --families anthropic \
+  --harnesses native_cli,hermes \
+  --resume \
+  --out-dir audit/2026-05-17-judge-calibration-matrix/
+```
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --families openai \
+  --harnesses native_cli,hermes \
+  --resume \
+  --out-dir audit/2026-05-17-judge-calibration-matrix/
+```
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --families google \
+  --harnesses native_cli \
+  --resume \
+  --out-dir audit/2026-05-17-judge-calibration-matrix/
+```
+
+Gemini via Hermes is excluded because Google ToS forbids that route.
+
+## Report
+
+Regenerate the consolidated leaderboard from existing cell JSON:
+
+```bash
+.venv/bin/python scripts/audit/judge_calibration_matrix.py \
+  --build-report-only \
+  --out-dir audit/2026-05-17-judge-calibration-matrix/
+```

--- a/scripts/audit/_judge_eval_lib.py
+++ b/scripts/audit/_judge_eval_lib.py
@@ -1,0 +1,316 @@
+"""Shared Russianism-judge calibration helpers.
+
+The Grok single-model harness and the multi-model matrix use the same
+Antonenko-grounded prompt, PR #2006 gold loader, and sev2-tolerant scoring.
+Keep this module free of provider-specific subprocess logic.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DB = PROJECT_ROOT / "data" / "sources.db"
+
+PR_2006_REF = "origin/pr-2006"
+CALIBRATION_BLOB = "eval/russianism/calibration-cases.jsonl"
+
+
+def utc_timestamp() -> str:
+    """Return a stable UTC timestamp for artifact metadata."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def pull_calibration_cases(
+    *,
+    ref: str = PR_2006_REF,
+    blob: str = CALIBRATION_BLOB,
+    project_root: Path = PROJECT_ROOT,
+) -> list[dict[str, Any]]:
+    """Pull the calibration cases from PR #2006's branch without copying them.
+
+    The branch may not be checked out locally; callers should fetch
+    ``refs/pull/2006/head`` into ``refs/remotes/origin/pr-2006`` if this
+    read fails.
+    """
+    proc = subprocess.run(
+        ["git", "show", f"{ref}:{blob}"],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(
+            f"ERROR: could not read {blob} from {ref}.\n"
+            f"git stderr: {proc.stderr.strip()}\n"
+            "If origin/pr-2006 has been pruned, refetch with:\n"
+            "  git fetch origin 'refs/pull/2006/head:refs/remotes/origin/pr-2006'"
+        )
+
+    cases: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line:
+            cases.append(json.loads(line))
+    return cases
+
+
+def retrieve_antonenko(text: str, k: int = 8, *, db_path: Path = DB) -> list[dict[str, Any]]:
+    """Find Antonenko entries whose headwords appear in ``text``.
+
+    Ported from ``scripts/audit/russianism_judge.py`` on ``origin/pr-2006``.
+    It grounds the judge prompt in canonical evidence from the local sources DB.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        words = set(re.findall(r"[А-Яа-яҐґЄєІіЇї'’ʼ\-]+", text.lower()))
+        if not words:
+            return []
+        placeholders = ",".join("?" * len(words))
+        rows = conn.execute(
+            f"""
+            SELECT word, section, page, text
+            FROM style_guide
+            WHERE word_lower IN ({placeholders})
+               OR EXISTS (
+                   SELECT 1 FROM (
+                       SELECT value FROM json_each(?)
+                   ) t WHERE word_lower = t.value
+               )
+            LIMIT ?
+            """,
+            (*words, json.dumps(list(words), ensure_ascii=False), k),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    return [
+        {"headword": r[0], "section": r[1], "page": r[2], "text": (r[3] or "")[:600]}
+        for r in rows
+    ]
+
+
+def build_judge_prompt(target_text: str, antonenko_entries: list[dict[str, Any]]) -> str:
+    """Universal Russianism-judge prompt, identical across model families."""
+    if antonenko_entries:
+        rules_section = (
+            "## Relevant Antonenko-Davydovych entries "
+            "(potentially applicable rules):\n\n"
+        )
+        for i, entry in enumerate(antonenko_entries[:8], 1):
+            rules_section += f"### Rule {i}: {entry['headword']}\n{entry['text']}\n\n"
+    else:
+        rules_section = (
+            "(No directly-keyed Antonenko entries found for words in this text. "
+            "Apply general knowledge of Ukrainian register and Russianism patterns.)\n"
+        )
+
+    return f"""You are an expert Ukrainian-language proofreader specializing in identifying Russianisms (русизми), calques (кальки), Surzhyk (суржик), and unnatural Ukrainian phrasing.
+Your authority is Антоненко-Давидович «Як ми говоримо» — the canonical Ukrainian reference for Russianism identification and correction.
+
+## Text to evaluate
+
+```
+{target_text}
+```
+
+{rules_section}
+
+## Your task
+
+Identify EVERY Russianism, calque, Surzhyk, or unnatural Ukrainian construction in the text above. For each issue:
+
+- Quote the exact problematic phrase
+- Cite the relevant Antonenko rule by its headword (if applicable from the rules above) or general principle
+- Provide the correct Ukrainian alternative
+- Severity: 1=minor (debatable), 2=clear Russianism, 3=blatant calque or borrowing
+
+If the text is genuinely clean Ukrainian with NO Russianisms, output `{{"verdict": "clean", "issues": []}}`.
+
+Otherwise output JSON with this exact shape:
+
+```json
+{{
+  "verdict": "issues_found",
+  "issues": [
+    {{"phrase": "...", "rule": "...", "correct": "...", "severity": 1-3}}
+  ]
+}}
+```
+
+Output ONLY the JSON object — no commentary, no markdown fences, no preamble."""
+
+
+def parse_json_verdict(raw_content: str, *, duration_s: float = 0.0) -> dict[str, Any]:
+    """Parse a judge response into the verdict shape used by scoring."""
+    match = re.search(r"\{.*\}", raw_content or "", re.DOTALL)
+    if not match:
+        return {
+            "verdict": "judge_error",
+            "raw": (raw_content or "")[:500],
+            "duration_s": duration_s,
+            "note": "no JSON object in response",
+        }
+    try:
+        verdict = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        return {
+            "verdict": "json_parse_error",
+            "raw": match.group(0)[:500],
+            "error": str(exc),
+            "duration_s": duration_s,
+        }
+    if isinstance(verdict, dict):
+        verdict["_duration_s"] = duration_s
+        return verdict
+    return {
+        "verdict": "json_parse_error",
+        "raw": match.group(0)[:500],
+        "error": "parsed JSON was not an object",
+        "duration_s": duration_s,
+    }
+
+
+def score_case(verdict: dict[str, Any], gold: dict[str, Any]) -> dict[str, Any]:
+    """Score one case with PR #2006's sev2-tolerant approximation.
+
+    Case-level accuracy is clean-vs-issues. Precision/recall/F1 count only
+    severity >= 2 flags, so debatable severity-1 flags do not dominate routing.
+    """
+    expected_clean = bool(gold.get("expected_clean"))
+    judged_clean = verdict.get("verdict") == "clean"
+    case_acc = expected_clean == judged_clean
+
+    issues = verdict.get("issues") or []
+    sev2_plus_judge = sum(
+        1
+        for item in issues
+        if isinstance(item, dict)
+        and isinstance(item.get("severity"), int)
+        and item["severity"] >= 2
+    )
+    expected_flags_n = len(gold.get("expected_flags") or [])
+
+    if expected_clean:
+        tp = 0
+        fp = sev2_plus_judge
+        fn = 0
+    else:
+        tp = min(sev2_plus_judge, expected_flags_n)
+        fn = max(0, expected_flags_n - sev2_plus_judge)
+        fp = max(0, sev2_plus_judge - expected_flags_n)
+
+    return {
+        "case_acc": case_acc,
+        "judged_clean": judged_clean,
+        "expected_clean": expected_clean,
+        "judge_sev2_plus_count": sev2_plus_judge,
+        "expected_flags_count": expected_flags_n,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }
+
+
+def aggregate(scores: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-case scores into precision, recall, F1, and case accuracy."""
+    tp = sum(int(s["tp"]) for s in scores)
+    fp = sum(int(s["fp"]) for s in scores)
+    fn = sum(int(s["fn"]) for s in scores)
+    n = len(scores)
+    case_acc = sum(1 for s in scores if s["case_acc"]) / n if n else 0.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    rounded_case_acc = round(case_acc, 4)
+    return {
+        "n": n,
+        "case_accuracy": rounded_case_acc,
+        "case_acc": rounded_case_acc,
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }
+
+
+def judgment_row_from_case(
+    *,
+    case: dict[str, Any],
+    model: str,
+    verdict: dict[str, Any],
+    score: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the legacy judgment row written by ``grok_judge_calibration.py``."""
+    return {
+        "prompt_id": case["prompt_id"],
+        "model": model,
+        "verdict": verdict.get("verdict"),
+        "judge_sev2_plus_count": score["judge_sev2_plus_count"],
+        "expected_flags_count": score["expected_flags_count"],
+        "case_acc": score["case_acc"],
+        "duration_s": round(float(verdict.get("_duration_s", verdict.get("duration_s", 0.0))), 2),
+        "raw": verdict,
+    }
+
+
+def render_grok_report(
+    *,
+    model: str,
+    agg: dict[str, Any],
+    judgments_path: Path,
+    calibration_blob: str = CALIBRATION_BLOB,
+    ref: str = PR_2006_REF,
+) -> str:
+    """Render the legacy single-model Grok report body."""
+    report_lines = [
+        f"# Grok 4.3 Russianism judge calibration — {time.strftime('%Y-%m-%d %H:%M UTC', time.gmtime())}",
+        "",
+        f"Model: `{model}` via Hermes OAuth (`api.x.ai/v1`)",
+        f"Cases: {agg['n']} (from `{calibration_blob}` on `{ref}`)",
+        "",
+        "## Aggregate",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Case accuracy | **{agg['case_accuracy']*100:.1f}%** |",
+        f"| Precision (sev≥2) | {agg['precision']*100:.1f}% |",
+        f"| Recall (sev≥2) | {agg['recall']*100:.1f}% |",
+        f"| **F1 (sev≥2)** | **{agg['f1']*100:.1f}%** |",
+        f"| tp / fp / fn | {agg['tp']} / {agg['fp']} / {agg['fn']} |",
+        "",
+        "## Reference leaderboard (2026-05-15, n=12)",
+        "",
+        "| Judge | F1 | Precision | Recall | Case acc |",
+        "|---|---:|---:|---:|---:|",
+        "| claude-opus-4-7 | 86% | 79% | 94% | 100% |",
+        "| gemini-3.1-pro-preview | 84% | 81% | 87% | 92% |",
+        "| gpt-5.5 | 78% | 90% | 69% | 83% |",
+        f"| **{model}** | **{agg['f1']*100:.0f}%** | **{agg['precision']*100:.0f}%** | **{agg['recall']*100:.0f}%** | **{agg['case_accuracy']*100:.0f}%** |",
+        "",
+        f"Source: `audit/2026-05-15-russianism-judge-calibration/REPORT.md` on `{ref}` for the prior 3 judges.",
+        "",
+        "## Per-case breakdown",
+        "",
+        "| Case | Expected | Judged | Match | sev≥2 flags | Dur (s) |",
+        "|---|---|---|:---:|---:|---:|",
+    ]
+    with judgments_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            row = json.loads(line)
+            expected = "clean" if row["expected_flags_count"] == 0 else "issues"
+            mark = "✓" if row["case_acc"] else "✗"
+            report_lines.append(
+                f"| `{row['prompt_id']}` | {expected} | {row['verdict']} | {mark} | "
+                f"{row['judge_sev2_plus_count']} | {row['duration_s']:.1f} |"
+            )
+    return "\n".join(report_lines) + "\n"

--- a/scripts/audit/grok_judge_calibration.py
+++ b/scripts/audit/grok_judge_calibration.py
@@ -32,22 +32,41 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
-import sqlite3
 import subprocess
 import sys
 import time
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-DB = PROJECT_ROOT / "data" / "sources.db"
-HERMES_AUTH = Path.home() / ".hermes" / "auth.json"
+try:
+    from _judge_eval_lib import (
+        CALIBRATION_BLOB,
+        PR_2006_REF,
+        PROJECT_ROOT,
+        aggregate,
+        build_judge_prompt,
+        judgment_row_from_case,
+        parse_json_verdict,
+        pull_calibration_cases,
+        render_grok_report,
+        retrieve_antonenko,
+        score_case,
+    )
+except ModuleNotFoundError:
+    from scripts.audit._judge_eval_lib import (
+        CALIBRATION_BLOB,
+        PR_2006_REF,
+        PROJECT_ROOT,
+        aggregate,
+        build_judge_prompt,
+        judgment_row_from_case,
+        parse_json_verdict,
+        pull_calibration_cases,
+        render_grok_report,
+        retrieve_antonenko,
+        score_case,
+    )
 
-# Use PR #2006's branch as the canonical source for the calibration set
-# + Antonenko prompt template. This keeps the test reproducible without
-# requiring PR #2006 to merge first.
-PR_2006_REF = "origin/pr-2006"
-CALIBRATION_BLOB = "eval/russianism/calibration-cases.jsonl"
+HERMES_AUTH = Path.home() / ".hermes" / "auth.json"
 
 # Hermes CLI provides the OAuth-authenticated path to Grok 4.3.
 # Direct calls to api.x.ai/v1 return 403 (token has session-level scope,
@@ -89,121 +108,6 @@ def load_hermes_oauth_token() -> str:
     if not isinstance(token, str) or not token.strip():
         sys.exit("ERROR: xai-oauth access_token is empty.")
     return token.strip()
-
-
-def pull_calibration_cases() -> list[dict]:
-    """Pull the 12 calibration cases from PR #2006's branch (read-only).
-
-    We do NOT copy the file to the working tree — keeps PR #2006 the
-    single source of truth for the gold labels.
-    """
-    proc = subprocess.run(
-        ["git", "show", f"{PR_2006_REF}:{CALIBRATION_BLOB}"],
-        cwd=str(PROJECT_ROOT),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        sys.exit(
-            f"ERROR: could not read {CALIBRATION_BLOB} from {PR_2006_REF}.\n"
-            f"git stderr: {proc.stderr.strip()}\n"
-            "If origin/pr-2006 has been pruned, refetch with:\n"
-            "  git fetch origin 'refs/pull/2006/head:refs/remotes/origin/pr-2006'"
-        )
-    cases = []
-    for line in proc.stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        cases.append(json.loads(line))
-    return cases
-
-
-def retrieve_antonenko(text: str, k: int = 8) -> list[dict]:
-    """Find Antonenko entries whose headwords appear in ``text``.
-
-    Ported verbatim from ``scripts/audit/russianism_judge.py`` on
-    ``origin/pr-2006``. Grounds the judge prompt in canonical evidence.
-    """
-    conn = sqlite3.connect(DB)
-    try:
-        words = set(re.findall(r"[А-Яа-яҐґЄєІіЇї'’ʼ\-]+", text.lower()))
-        if not words:
-            return []
-        placeholders = ",".join("?" * len(words))
-        rows = conn.execute(
-            f"""
-            SELECT word, section, page, text
-            FROM style_guide
-            WHERE word_lower IN ({placeholders})
-               OR EXISTS (
-                   SELECT 1 FROM (
-                       SELECT value FROM json_each(?)
-                   ) t WHERE word_lower = t.value
-               )
-            LIMIT ?
-            """,
-            (*words, json.dumps(list(words)), k),
-        ).fetchall()
-    finally:
-        conn.close()
-    return [
-        {"headword": r[0], "section": r[1], "page": r[2], "text": (r[3] or "")[:600]}
-        for r in rows
-    ]
-
-
-def build_judge_prompt(target_text: str, antonenko_entries: list[dict]) -> str:
-    """Universal Russianism-judge prompt (identical across families)."""
-    rules_section = ""
-    if antonenko_entries:
-        rules_section = (
-            "## Relevant Antonenko-Davydovych entries "
-            "(potentially applicable rules):\n\n"
-        )
-        for i, e in enumerate(antonenko_entries[:8], 1):
-            rules_section += f"### Rule {i}: {e['headword']}\n{e['text']}\n\n"
-    else:
-        rules_section = (
-            "(No directly-keyed Antonenko entries found for words in this text. "
-            "Apply general knowledge of Ukrainian register and Russianism patterns.)\n"
-        )
-
-    return f"""You are an expert Ukrainian-language proofreader specializing in identifying Russianisms (русизми), calques (кальки), Surzhyk (суржик), and unnatural Ukrainian phrasing.
-Your authority is Антоненко-Давидович «Як ми говоримо» — the canonical Ukrainian reference for Russianism identification and correction.
-
-## Text to evaluate
-
-```
-{target_text}
-```
-
-{rules_section}
-
-## Your task
-
-Identify EVERY Russianism, calque, Surzhyk, or unnatural Ukrainian construction in the text above. For each issue:
-
-- Quote the exact problematic phrase
-- Cite the relevant Antonenko rule by its headword (if applicable from the rules above) or general principle
-- Provide the correct Ukrainian alternative
-- Severity: 1=minor (debatable), 2=clear Russianism, 3=blatant calque or borrowing
-
-If the text is genuinely clean Ukrainian with NO Russianisms, output `{{"verdict": "clean", "issues": []}}`.
-
-Otherwise output JSON with this exact shape:
-
-```json
-{{
-  "verdict": "issues_found",
-  "issues": [
-    {{"phrase": "...", "rule": "...", "correct": "...", "severity": 1-3}}
-  ]
-}}
-```
-
-Output ONLY the JSON object — no commentary, no markdown fences, no preamble."""
 
 
 def call_grok(prompt: str, model: str) -> dict:
@@ -252,98 +156,7 @@ def call_grok(prompt: str, model: str) -> dict:
             "duration_s": duration,
         }
 
-    raw_content = proc.stdout
-    # Strip markdown fences if the judge wrapped its JSON.
-    m = re.search(r"\{.*\}", raw_content, re.DOTALL)
-    if not m:
-        return {
-            "verdict": "judge_error",
-            "raw": raw_content[:500],
-            "duration_s": duration,
-            "note": "no JSON object in response",
-        }
-    try:
-        verdict = json.loads(m.group(0))
-    except json.JSONDecodeError as e:
-        return {
-            "verdict": "json_parse_error",
-            "raw": m.group(0)[:500],
-            "error": str(e),
-            "duration_s": duration,
-        }
-    verdict["_duration_s"] = duration
-    return verdict
-
-
-def score_case(verdict: dict, gold: dict) -> dict:
-    """Per-case scoring vs hand-labels.
-
-    Returns ``{"case_acc": bool, "sev1_tolerant": dict}``.
-    Mirrors ``score_judge_calibration.py`` logic from PR #2006:
-
-    - Case-level accuracy = correctly classified clean vs issues_found.
-    - Sev1-tolerant P/R/F1 = count sev≥2 flags only (sev1 is debatable
-      and not penalized).
-    """
-    expected_clean = bool(gold.get("expected_clean"))
-    judged_clean = verdict.get("verdict") == "clean"
-    case_acc = expected_clean == judged_clean
-
-    # Sev≥2 flags from the judge (the "actionable" set).
-    issues = verdict.get("issues") or []
-    sev2_plus_judge = sum(
-        1
-        for it in issues
-        if isinstance(it, dict) and isinstance(it.get("severity"), int) and it["severity"] >= 2
-    )
-    # Gold's expected_flags is the count of expected sev≥2 patterns.
-    expected_flags_n = len(gold.get("expected_flags") or [])
-    if expected_clean:
-        # Clean cases: any sev≥2 flag is a false positive.
-        fp = sev2_plus_judge
-        fn = 0
-        tp = 0
-    else:
-        # Dirty cases: tp = min(judge flags, expected), fn = remaining
-        # expected, fp = judge flags beyond expected. This is a coarse
-        # but defensible approximation when phrase-level alignment isn't
-        # tracked here.
-        tp = min(sev2_plus_judge, expected_flags_n)
-        fn = max(0, expected_flags_n - sev2_plus_judge)
-        fp = max(0, sev2_plus_judge - expected_flags_n)
-
-    return {
-        "case_acc": case_acc,
-        "judged_clean": judged_clean,
-        "expected_clean": expected_clean,
-        "judge_sev2_plus_count": sev2_plus_judge,
-        "expected_flags_count": expected_flags_n,
-        "tp": tp,
-        "fp": fp,
-        "fn": fn,
-    }
-
-
-def aggregate(scores: list[dict]) -> dict:
-    """Aggregate per-case scores into P/R/F1 + case accuracy."""
-    tp = sum(s["tp"] for s in scores)
-    fp = sum(s["fp"] for s in scores)
-    fn = sum(s["fn"] for s in scores)
-    n = len(scores)
-    case_acc = sum(1 for s in scores if s["case_acc"]) / n if n else 0.0
-    precision = tp / (tp + fp) if (tp + fp) else 0.0
-    recall = tp / (tp + fn) if (tp + fn) else 0.0
-    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
-    return {
-        "n": n,
-        "case_accuracy": round(case_acc, 4),
-        "precision": round(precision, 4),
-        "recall": round(recall, 4),
-        "f1": round(f1, 4),
-        "tp": tp,
-        "fp": fp,
-        "fn": fn,
-    }
+    return parse_json_verdict(proc.stdout, duration_s=duration)
 
 
 def main() -> int:
@@ -385,16 +198,7 @@ def main() -> int:
             verdict = call_grok(prompt, args.model)
             score = score_case(verdict, case["gold"])
             scores.append(score)
-            row = {
-                "prompt_id": case["prompt_id"],
-                "model": args.model,
-                "verdict": verdict.get("verdict"),
-                "judge_sev2_plus_count": score["judge_sev2_plus_count"],
-                "expected_flags_count": score["expected_flags_count"],
-                "case_acc": score["case_acc"],
-                "duration_s": round(verdict.get("_duration_s", verdict.get("duration_s", 0.0)), 2),
-                "raw": verdict,
-            }
+            row = judgment_row_from_case(case=case, model=args.model, verdict=verdict, score=score)
             fh.write(json.dumps(row, ensure_ascii=False) + "\n")
             tag = "✓" if score["case_acc"] else "✗"
             print(f"{tag} verdict={verdict.get('verdict')} dur={row['duration_s']}s")
@@ -418,50 +222,10 @@ def main() -> int:
         "tested_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
     leaderboard_path.write_text(json.dumps(leaderboard_row, indent=2, ensure_ascii=False), encoding="utf-8")
-
-    report_lines = [
-        f"# Grok 4.3 Russianism judge calibration — {time.strftime('%Y-%m-%d %H:%M UTC', time.gmtime())}",
-        "",
-        f"Model: `{args.model}` via Hermes OAuth (`api.x.ai/v1`)",
-        f"Cases: {agg['n']} (from `{CALIBRATION_BLOB}` on `{PR_2006_REF}`)",
-        "",
-        "## Aggregate",
-        "",
-        "| Metric | Value |",
-        "|---|---:|",
-        f"| Case accuracy | **{agg['case_accuracy']*100:.1f}%** |",
-        f"| Precision (sev≥2) | {agg['precision']*100:.1f}% |",
-        f"| Recall (sev≥2) | {agg['recall']*100:.1f}% |",
-        f"| **F1 (sev≥2)** | **{agg['f1']*100:.1f}%** |",
-        f"| tp / fp / fn | {agg['tp']} / {agg['fp']} / {agg['fn']} |",
-        "",
-        "## Reference leaderboard (2026-05-15, n=12)",
-        "",
-        "| Judge | F1 | Precision | Recall | Case acc |",
-        "|---|---:|---:|---:|---:|",
-        "| claude-opus-4-7 | 86% | 79% | 94% | 100% |",
-        "| gemini-3.1-pro-preview | 84% | 81% | 87% | 92% |",
-        "| gpt-5.5 | 78% | 90% | 69% | 83% |",
-        f"| **{args.model}** | **{agg['f1']*100:.0f}%** | **{agg['precision']*100:.0f}%** | **{agg['recall']*100:.0f}%** | **{agg['case_accuracy']*100:.0f}%** |",
-        "",
-        f"Source: `audit/2026-05-15-russianism-judge-calibration/REPORT.md` on `{PR_2006_REF}` for the prior 3 judges.",
-        "",
-        "## Per-case breakdown",
-        "",
-        "| Case | Expected | Judged | Match | sev≥2 flags | Dur (s) |",
-        "|---|---|---|:---:|---:|---:|",
-    ]
-    with judgments_path.open("r", encoding="utf-8") as fh:
-        for line in fh:
-            row = json.loads(line)
-            case_id = row["prompt_id"]
-            expected = "clean" if row["expected_flags_count"] == 0 else "issues"
-            judged = row["verdict"]
-            mark = "✓" if row["case_acc"] else "✗"
-            report_lines.append(
-                f"| `{case_id}` | {expected} | {judged} | {mark} | {row['judge_sev2_plus_count']} | {row['duration_s']:.1f} |"
-            )
-    report_path.write_text("\n".join(report_lines) + "\n", encoding="utf-8")
+    report_path.write_text(
+        render_grok_report(model=args.model, agg=agg, judgments_path=judgments_path),
+        encoding="utf-8",
+    )
 
     print("")
     print(f"Wrote {judgments_path}")

--- a/scripts/audit/judge_calibration_matrix.py
+++ b/scripts/audit/judge_calibration_matrix.py
@@ -1,0 +1,898 @@
+#!/usr/bin/env python3
+"""Run the Russianism judge calibration matrix across models and harnesses."""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import html
+import json
+import shutil
+import subprocess
+import time
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from _judge_eval_lib import (
+        PROJECT_ROOT,
+        aggregate,
+        build_judge_prompt,
+        parse_json_verdict,
+        pull_calibration_cases,
+        retrieve_antonenko,
+        score_case,
+        utc_timestamp,
+    )
+except ModuleNotFoundError:
+    from scripts.audit._judge_eval_lib import (
+        PROJECT_ROOT,
+        aggregate,
+        build_judge_prompt,
+        parse_json_verdict,
+        pull_calibration_cases,
+        retrieve_antonenko,
+        score_case,
+        utc_timestamp,
+    )
+
+REQUEST_TIMEOUT_S = 480
+HERMES_TIMEOUT_S = 600
+HERMES_BIN = "hermes"
+HERMES_CFG = Path.home() / ".hermes" / "config.yaml"
+DEFAULT_OUT_DIR = PROJECT_ROOT / "audit" / "2026-05-17-judge-calibration-matrix"
+
+FAMILIES = ("xai", "anthropic", "openai", "google")
+HARNESSES = ("native_cli", "hermes")
+MCP_STATES = ("with_mcp", "without_mcp")
+
+FAMILY_MODELS: dict[str, tuple[str, ...]] = {
+    "xai": ("grok-4.3",),
+    "anthropic": (
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-opus-4-5-20251101",
+        "claude-sonnet-4-5-20250929",
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    ),
+    "openai": (
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+    ),
+    "google": ("gemini-3.0-flash-preview", "gemini-3.1-pro-preview"),
+}
+
+SUPPORTED_HARNESSES: dict[str, tuple[str, ...]] = {
+    "xai": ("hermes",),
+    "anthropic": ("native_cli", "hermes"),
+    "openai": ("native_cli", "hermes"),
+    "google": ("native_cli",),
+}
+
+DEFAULT_EFFORTS: dict[str, tuple[str, ...]] = {
+    "xai": ("low", "minimal", "medium", "high", "xhigh"),
+    "anthropic": ("low", "medium", "high", "xhigh"),
+    "openai": ("low", "medium", "high"),
+    "google": ("default",),
+}
+
+SMOKE_CELLS = (
+    ("xai", "grok-4.3", "hermes", "medium", "with_mcp"),
+    ("anthropic", "claude-haiku-4-5-20251001", "native_cli", "medium", "with_mcp"),
+    ("openai", "gpt-5.4-mini", "native_cli", "medium", "with_mcp"),
+    ("openai", "gpt-5.5", "hermes", "medium", "with_mcp"),
+    ("google", "gemini-3.1-pro-preview", "native_cli", "default", "with_mcp"),
+)
+
+
+@dataclass(frozen=True)
+class Cell:
+    family: str
+    model: str
+    harness: str
+    effort: str
+    mcp_state: str
+
+
+@dataclass(frozen=True)
+class HarnessCall:
+    ok: bool
+    stdout: str
+    stderr: str
+    returncode: int | None
+    duration_s: float
+    cmd: tuple[str, ...]
+    error: str | None = None
+
+
+def parse_csv(raw: str | None, allowed: Iterable[str] | None = None) -> list[str] | None:
+    """Parse comma-separated CLI values."""
+    if raw is None:
+        return None
+    values = [part.strip() for part in raw.split(",") if part.strip()]
+    if allowed is not None:
+        allowed_set = set(allowed)
+        bad = [value for value in values if value not in allowed_set]
+        if bad:
+            raise SystemExit(f"invalid value(s): {', '.join(bad)}; allowed: {', '.join(sorted(allowed_set))}")
+    return values
+
+
+def effort_palette(family: str, model: str) -> tuple[str, ...]:
+    """Return the pre-locked effort palette for one model."""
+    if family == "anthropic" and model == "claude-opus-4-7":
+        return (*DEFAULT_EFFORTS["anthropic"], "max")
+    return DEFAULT_EFFORTS[family]
+
+
+def cell_path(out_dir: Path, cell: Cell) -> Path:
+    """Return the per-cell JSON path."""
+    return out_dir / cell.family / cell.model / cell.harness / f"{cell.effort}-{cell.mcp_state}.json"
+
+
+def is_forbidden_cell(cell: Cell) -> bool:
+    """Return True for combinations the matrix must not materialize."""
+    return cell.family == "google" and cell.harness == "hermes"
+
+
+def unsupported_reason(cell: Cell) -> str | None:
+    """Return a deterministic skip reason for unsupported cells."""
+    if cell.family not in FAMILIES:
+        return f"unknown family: {cell.family}"
+    if cell.model not in FAMILY_MODELS[cell.family]:
+        return f"{cell.model} is not in the configured {cell.family} model palette"
+    if cell.harness not in HARNESSES:
+        return f"unknown harness: {cell.harness}"
+    if cell.harness not in SUPPORTED_HARNESSES[cell.family]:
+        return f"{cell.family} does not have a {cell.harness} route"
+    if cell.mcp_state not in MCP_STATES:
+        return f"unknown MCP state: {cell.mcp_state}"
+    if cell.effort not in effort_palette(cell.family, cell.model):
+        return (
+            f"{cell.model} does not accept effort={cell.effort} via {cell.harness}; "
+            f"configured palette: {', '.join(effort_palette(cell.family, cell.model))}"
+        )
+    return None
+
+
+def build_matrix(
+    *,
+    families: list[str] | None,
+    harnesses: list[str] | None,
+    models: list[str] | None,
+    efforts: list[str] | None,
+    mcp_states: list[str] | None,
+    smoke: bool,
+) -> list[Cell]:
+    """Build the requested sparse matrix."""
+    selected_families = families or list(FAMILIES)
+    selected_harnesses = harnesses or list(HARNESSES)
+    selected_mcp_states = mcp_states or list(MCP_STATES)
+
+    if smoke:
+        cells = [
+            Cell(*raw)
+            for raw in SMOKE_CELLS
+            if raw[0] in selected_families
+            and raw[2] in selected_harnesses
+            and raw[4] in selected_mcp_states
+            and (models is None or raw[1] in models)
+            and (efforts is None or raw[3] in efforts)
+        ]
+        return [cell for cell in cells if not is_forbidden_cell(cell)]
+
+    cells: list[Cell] = []
+    for family in selected_families:
+        family_models = [model for model in FAMILY_MODELS[family] if models is None or model in models]
+        for model in family_models:
+            selected_efforts = efforts or list(effort_palette(family, model))
+            for harness in selected_harnesses:
+                for effort in selected_efforts:
+                    for mcp_state in selected_mcp_states:
+                        cell = Cell(family, model, harness, effort, mcp_state)
+                        if not is_forbidden_cell(cell):
+                            cells.append(cell)
+    return cells
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON deterministically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_na_cell(out_dir: Path, cell: Cell, reason: str) -> dict[str, Any]:
+    """Write an unsupported-combo record."""
+    record = {
+        "cell": asdict(cell),
+        "result": "n/a",
+        "reason": reason,
+        "checked_at": utc_timestamp(),
+    }
+    write_json(cell_path(out_dir, cell), record)
+    return record
+
+
+def command_version(binary: str) -> str:
+    """Best-effort CLI version string for telemetry."""
+    try:
+        proc = subprocess.run(
+            [binary, "--version"],
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return f"unavailable: {exc}"
+    combined = (proc.stdout or proc.stderr or "").strip()
+    return combined.splitlines()[0] if combined else f"rc={proc.returncode}; empty version output"
+
+
+def run_subprocess(cmd: list[str], *, timeout_s: int, stdin: str | None = None) -> HarnessCall:
+    """Run a provider CLI and capture bounded telemetry."""
+    display_cmd = tuple(cmd[:])
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin,
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return HarnessCall(False, "", "", None, time.time() - t0, display_cmd, error=str(exc))
+    except subprocess.TimeoutExpired as exc:
+        return HarnessCall(
+            False,
+            exc.stdout or "",
+            exc.stderr or "",
+            None,
+            time.time() - t0,
+            display_cmd,
+            error=f"timed out after {timeout_s}s",
+        )
+    return HarnessCall(
+        proc.returncode == 0 and bool((proc.stdout or "").strip()),
+        proc.stdout or "",
+        proc.stderr or "",
+        proc.returncode,
+        time.time() - t0,
+        display_cmd,
+    )
+
+
+def build_native_command(cell: Cell, prompt: str) -> list[str]:
+    """Build the native CLI command for one prompt."""
+    if cell.family == "anthropic":
+        cmd = ["claude", "-p", "--bare", "--model", cell.model]
+        if cell.effort != "default":
+            cmd.extend(["--effort", cell.effort])
+        if cell.mcp_state == "with_mcp" and (PROJECT_ROOT / ".mcp.json").exists():
+            cmd.extend(["--mcp-config", str(PROJECT_ROOT / ".mcp.json")])
+        cmd.extend(["--", prompt])
+        return cmd
+
+    if cell.family == "openai":
+        cmd = [
+            "codex",
+            "exec",
+            "--skip-git-repo-check",
+            "-C",
+            str(PROJECT_ROOT),
+            "--color",
+            "never",
+            "--model",
+            cell.model,
+        ]
+        if cell.effort != "default":
+            cmd.extend(["-c", f"model_reasoning_effort={cell.effort}"])
+        if cell.mcp_state == "with_mcp":
+            cmd.extend(["-c", 'mcp_servers.sources.url="http://127.0.0.1:8766/mcp"'])
+        cmd.append(prompt)
+        return cmd
+
+    if cell.family == "google":
+        cmd = ["gemini", "-m", cell.model]
+        if cell.mcp_state == "with_mcp":
+            cmd.extend(["--allowed-mcp-server-names", "sources"])
+        cmd.extend(["-p", prompt])
+        return cmd
+
+    raise ValueError(f"no native CLI route for {cell.family}")
+
+
+def run_native_cli(cell: Cell, prompt: str) -> HarnessCall:
+    """Invoke a native provider CLI for one calibration prompt."""
+    return run_subprocess(build_native_command(cell, prompt), timeout_s=REQUEST_TIMEOUT_S)
+
+
+def _read_effort_line(text: str) -> tuple[int, str] | None:
+    """Find the agent-level Hermes ``reasoning_effort`` line."""
+    for idx, line in enumerate(text.splitlines()):
+        stripped = line.strip()
+        if line.startswith("  reasoning_effort:") and stripped.startswith("reasoning_effort:"):
+            value = stripped.split(":", 1)[1].strip()
+            return idx, value
+    return None
+
+
+def set_hermes_effort(config_path: Path, effort: str) -> str:
+    """Edit Hermes config in place and return the previous effort."""
+    text = config_path.read_text(encoding="utf-8")
+    located = _read_effort_line(text)
+    if located is None:
+        raise RuntimeError(
+            "could not locate `  reasoning_effort: <value>` in ~/.hermes/config.yaml; "
+            "Hermes may have changed config shape"
+        )
+    line_idx, previous = located
+    lines = text.splitlines(keepends=True)
+    newline = "\n" if lines[line_idx].endswith("\n") else ""
+    lines[line_idx] = f"  reasoning_effort: {effort}{newline}"
+    config_path.write_text("".join(lines), encoding="utf-8")
+    return previous
+
+
+@contextlib.contextmanager
+def hermes_effort_swap(config_path: Path, effort: str) -> Iterable[str]:
+    """Lock, back up, edit, and restore Hermes effort for one call."""
+    backup_path = config_path.with_name(f"{config_path.name}.judge-calibration-backup")
+    with config_path.open("r", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        shutil.copy2(config_path, backup_path)
+        previous = set_hermes_effort(config_path, effort)
+        try:
+            yield previous
+        finally:
+            shutil.copy2(backup_path, config_path)
+            backup_path.unlink(missing_ok=True)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def hermes_mcp_command(action: str) -> HarnessCall:
+    """Run ``hermes mcp disable/enable sources``."""
+    call = run_subprocess([HERMES_BIN, "mcp", action, "sources"], timeout_s=60)
+    if call.returncode == 0 and call.error is None:
+        return HarnessCall(
+            True,
+            call.stdout,
+            call.stderr,
+            call.returncode,
+            call.duration_s,
+            call.cmd,
+        )
+    return call
+
+
+def run_hermes(cell: Cell, prompt: str, *, config_path: Path = HERMES_CFG) -> HarnessCall:
+    """Invoke Hermes one-shot mode with atomic effort config swapping."""
+    try:
+        with hermes_effort_swap(config_path, cell.effort):
+            disabled: HarnessCall | None = None
+            if cell.mcp_state == "without_mcp":
+                disabled = hermes_mcp_command("disable")
+                if not disabled.ok:
+                    return disabled
+            try:
+                return run_subprocess(
+                    [HERMES_BIN, "-z", prompt, "-m", cell.model],
+                    timeout_s=HERMES_TIMEOUT_S,
+                )
+            finally:
+                if disabled is not None:
+                    hermes_mcp_command("enable")
+    except (OSError, RuntimeError) as exc:
+        return HarnessCall(False, "", "", None, 0.0, (HERMES_BIN, "-z", "-m", cell.model), error=str(exc))
+
+
+def run_harness(cell: Cell, prompt: str) -> HarnessCall:
+    """Dispatch a single prompt to the configured harness."""
+    if cell.harness == "hermes":
+        return run_hermes(cell, prompt)
+    if cell.harness == "native_cli":
+        return run_native_cli(cell, prompt)
+    raise ValueError(f"unknown harness {cell.harness}")
+
+
+def verdict_from_call(call: HarnessCall) -> dict[str, Any]:
+    """Convert CLI output into a scoreable verdict."""
+    if call.ok:
+        return parse_json_verdict(call.stdout, duration_s=call.duration_s)
+    return {
+        "verdict": "judge_error",
+        "error": call.error,
+        "returncode": call.returncode,
+        "stdout": call.stdout[:500],
+        "stderr": call.stderr[:500],
+        "duration_s": call.duration_s,
+    }
+
+
+def run_cell(
+    *,
+    out_dir: Path,
+    cell: Cell,
+    cases: list[dict[str, Any]],
+    harness_runner: Callable[[Cell, str], HarnessCall] = run_harness,
+) -> dict[str, Any]:
+    """Run or n/a one cell and write its JSON artifact."""
+    reason = unsupported_reason(cell)
+    if reason:
+        return write_na_cell(out_dir, cell, reason)
+
+    started = utc_timestamp()
+    t0 = time.time()
+    scores: list[dict[str, Any]] = []
+    judgments: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    for case in cases:
+        target = case["output_text"]
+        prompt = build_judge_prompt(target, retrieve_antonenko(target))
+        call = harness_runner(cell, prompt)
+        verdict = verdict_from_call(call)
+        score = score_case(verdict, case["gold"])
+        scores.append(score)
+
+        if verdict.get("verdict") in {"judge_error", "json_parse_error"}:
+            errors.append(
+                {
+                    "case_id": case["prompt_id"],
+                    "verdict": verdict.get("verdict"),
+                    "error": verdict.get("error") or verdict.get("note"),
+                    "returncode": verdict.get("returncode"),
+                    "stdout": verdict.get("stdout") or verdict.get("raw"),
+                    "stderr": verdict.get("stderr"),
+                }
+            )
+
+        true_label = "clean" if score["expected_clean"] else "issues_found"
+        judgments.append(
+            {
+                "case_id": case["prompt_id"],
+                "true_label": true_label,
+                "model_label": verdict.get("verdict"),
+                "model_confidence": verdict.get("confidence", "unspecified"),
+                "raw_response_chars": len(call.stdout or verdict.get("raw", "") or ""),
+                "case_acc": score["case_acc"],
+                "judge_sev2_plus_count": score["judge_sev2_plus_count"],
+                "expected_flags_count": score["expected_flags_count"],
+            }
+        )
+
+    agg = aggregate(scores)
+    record = {
+        "cell": asdict(cell),
+        "started_at": started,
+        "finished_at": utc_timestamp(),
+        "duration_s": round(time.time() - t0, 2),
+        "n_cases": len(cases),
+        "judgments": judgments,
+        "scores": {
+            "f1": agg["f1"],
+            "case_acc": agg["case_acc"],
+            "precision": agg["precision"],
+            "recall": agg["recall"],
+        },
+        "raw_telemetry": {
+            "harness": cell.harness,
+            "harness_version": command_version(HERMES_BIN if cell.harness == "hermes" else _native_binary(cell.family)),
+            "model_id": cell.model,
+            "effort_actual": cell.effort,
+            "mcp_servers": ["sources"] if cell.mcp_state == "with_mcp" else [],
+            "errors": errors,
+        },
+    }
+    write_json(cell_path(out_dir, cell), record)
+    return record
+
+
+def _native_binary(family: str) -> str:
+    if family == "anthropic":
+        return "claude"
+    if family == "openai":
+        return "codex"
+    if family == "google":
+        return "gemini"
+    return family
+
+
+def existing_cell_complete(path: Path) -> bool:
+    """Return True when a resume-able cell JSON already exists."""
+    if not path.exists():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return isinstance(data, dict) and "cell" in data and (
+        data.get("result") == "n/a" or "scores" in data or data.get("result") == "error"
+    )
+
+
+def run_cells(
+    *,
+    out_dir: Path,
+    cells: list[Cell],
+    cases: list[dict[str, Any]],
+    resume: bool,
+    max_parallel: int,
+    harness_runner: Callable[[Cell, str], HarnessCall] = run_harness,
+) -> list[dict[str, Any]]:
+    """Run cells serially by family, with bounded intra-family parallelism."""
+    records: list[dict[str, Any]] = []
+    for family in FAMILIES:
+        family_cells = [cell for cell in cells if cell.family == family]
+        if not family_cells:
+            continue
+
+        runnable: list[Cell] = []
+        for cell in family_cells:
+            path = cell_path(out_dir, cell)
+            if resume and existing_cell_complete(path):
+                print(f"[resume] {path}")
+                records.append(json.loads(path.read_text(encoding="utf-8")))
+            else:
+                runnable.append(cell)
+
+        if not runnable:
+            continue
+
+        workers = max(1, min(max_parallel, len(runnable)))
+        if workers == 1:
+            for cell in runnable:
+                records.append(run_cell(out_dir=out_dir, cell=cell, cases=cases, harness_runner=harness_runner))
+            continue
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(run_cell, out_dir=out_dir, cell=cell, cases=cases, harness_runner=harness_runner): cell
+                for cell in runnable
+            }
+            for future in as_completed(futures):
+                records.append(future.result())
+    return records
+
+
+def write_probe_results(out_dir: Path, records: list[dict[str, Any]]) -> Path:
+    """Write a compact JSONL probe summary for PR evidence."""
+    path = out_dir / "probe-results.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for record in records:
+        cell = record["cell"]
+        errors = record.get("raw_telemetry", {}).get("errors") or []
+        if record.get("result") == "n/a":
+            result = "skipped"
+            reason = record.get("reason")
+        elif errors:
+            result = "error"
+            reason = errors[0].get("error") or errors[0].get("stdout") or errors[0].get("stderr")
+        else:
+            result = "valid_response"
+            reason = None
+        lines.append(
+            json.dumps(
+                {
+                    "family": cell["family"],
+                    "model": cell["model"],
+                    "harness": cell["harness"],
+                    "effort": cell["effort"],
+                    "mcp_state": cell["mcp_state"],
+                    "result": result,
+                    "reason": reason,
+                },
+                ensure_ascii=False,
+            )
+        )
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def load_cell_results(out_dir: Path) -> list[dict[str, Any]]:
+    """Load all per-cell JSON artifacts under the output directory."""
+    results: list[dict[str, Any]] = []
+    for path in sorted(out_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and isinstance(data.get("cell"), dict):
+            results.append(data)
+    return results
+
+
+def pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Build a Markdown table."""
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    lines.extend("| " + " | ".join(row) + " |" for row in rows)
+    return lines
+
+
+def successful_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [r for r in results if isinstance(r.get("scores"), dict) and r.get("result") != "n/a"]
+
+
+def failure_reason(result: dict[str, Any]) -> str:
+    if result.get("result") == "n/a":
+        return str(result.get("reason", "n/a"))
+    errors = result.get("raw_telemetry", {}).get("errors") or []
+    if errors:
+        return json.dumps(errors[:3], ensure_ascii=False)
+    return ""
+
+
+def build_markdown_report(results: list[dict[str, Any]]) -> str:
+    """Render the consolidated Markdown report."""
+    ok_results = successful_results(results)
+    na_results = [r for r in results if r.get("result") == "n/a"]
+    errored_results = [
+        r for r in ok_results
+        if r.get("raw_telemetry", {}).get("errors")
+    ]
+    sorted_ok = sorted(ok_results, key=lambda r: r["scores"]["f1"], reverse=True)
+
+    lines = [
+        "# Russianism Judge Calibration Matrix",
+        "",
+        f"Generated: {utc_timestamp()}",
+        "",
+        "## Summary",
+        "",
+        f"- Cells scored: {len(ok_results)}",
+        f"- Cells n/a: {len(na_results)}",
+        f"- Cells with harness errors: {len(errored_results)}",
+        "",
+        "## Leaderboard",
+        "",
+    ]
+
+    leaderboard_rows = []
+    for result in sorted_ok:
+        cell = result["cell"]
+        scores = result["scores"]
+        leaderboard_rows.append(
+            [
+                cell["family"],
+                cell["model"],
+                cell["harness"],
+                cell["effort"],
+                cell["mcp_state"],
+                pct(scores.get("f1")),
+                pct(scores.get("precision")),
+                pct(scores.get("recall")),
+                pct(scores.get("case_acc")),
+                f"{result.get('duration_s', 0):.1f}s",
+                "0",
+            ]
+        )
+    lines.extend(
+        table(
+            ["family", "model", "harness", "effort", "mcp_state", "F1", "P", "R", "case_acc", "avg_dur", "n/a-count"],
+            leaderboard_rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", str(len(na_results))]],
+        )
+    )
+
+    lines.extend(["", "## Harness Comparison", ""])
+    lines.extend(table(["model", "effort", "mcp_state", "native_cli F1", "hermes F1", "delta"], harness_comparison_rows(ok_results)))
+
+    lines.extend(["", "## MCP Impact", ""])
+    lines.extend(table(["model", "harness", "effort", "without case_acc", "with case_acc", "delta"], mcp_impact_rows(ok_results)))
+
+    lines.extend(["", "## Effort Scaling", ""])
+    lines.extend(table(["model", "harness", "mcp_state", "F1 by effort"], effort_scaling_rows(ok_results)))
+
+    lines.extend(["", "## Failure Log", ""])
+    failure_rows = []
+    for result in results:
+        reason = failure_reason(result)
+        if not reason:
+            continue
+        cell = result["cell"]
+        failure_rows.append(
+            [
+                cell["family"],
+                cell["model"],
+                cell["harness"],
+                cell["effort"],
+                cell["mcp_state"],
+                reason.replace("\n", " ")[:300],
+            ]
+        )
+    lines.extend(table(["family", "model", "harness", "effort", "mcp_state", "reason"], failure_rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "none"]]))
+    return "\n".join(lines) + "\n"
+
+
+def harness_comparison_rows(results: list[dict[str, Any]]) -> list[list[str]]:
+    by_key: dict[tuple[str, str, str], dict[str, float]] = {}
+    for result in results:
+        cell = result["cell"]
+        key = (cell["model"], cell["effort"], cell["mcp_state"])
+        by_key.setdefault(key, {})[cell["harness"]] = result["scores"]["f1"]
+    rows = []
+    for (model, effort, mcp_state), values in sorted(by_key.items()):
+        if "native_cli" in values and "hermes" in values:
+            delta = values["hermes"] - values["native_cli"]
+            rows.append([model, effort, mcp_state, pct(values["native_cli"]), pct(values["hermes"]), f"{delta * 100:+.1f}pp"])
+    return rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "n/a"]]
+
+
+def mcp_impact_rows(results: list[dict[str, Any]]) -> list[list[str]]:
+    by_key: dict[tuple[str, str, str], dict[str, float]] = {}
+    for result in results:
+        cell = result["cell"]
+        key = (cell["model"], cell["harness"], cell["effort"])
+        by_key.setdefault(key, {})[cell["mcp_state"]] = result["scores"]["case_acc"]
+    rows = []
+    for (model, harness, effort), values in sorted(by_key.items()):
+        if "with_mcp" in values and "without_mcp" in values:
+            delta = values["with_mcp"] - values["without_mcp"]
+            rows.append([model, harness, effort, pct(values["without_mcp"]), pct(values["with_mcp"]), f"{delta * 100:+.1f}pp"])
+    return rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "n/a"]]
+
+
+def effort_scaling_rows(results: list[dict[str, Any]]) -> list[list[str]]:
+    by_key: dict[tuple[str, str, str], list[tuple[str, float]]] = {}
+    for result in results:
+        cell = result["cell"]
+        key = (cell["model"], cell["harness"], cell["mcp_state"])
+        by_key.setdefault(key, []).append((cell["effort"], result["scores"]["f1"]))
+    rows = []
+    for (model, harness, mcp_state), values in sorted(by_key.items()):
+        if len(values) < 2:
+            continue
+        rendered = ", ".join(f"{effort}={pct(value)}" for effort, value in sorted(values))
+        rows.append([model, harness, mcp_state, rendered])
+    return rows or [["n/a", "n/a", "n/a", "n/a"]]
+
+
+def markdown_to_html(md: str) -> str:
+    """Render simple audit-style HTML from the generated Markdown."""
+    body_lines: list[str] = []
+    in_table = False
+    for line in md.splitlines():
+        if line.startswith("# "):
+            body_lines.append(f"<h1>{html.escape(line[2:])}</h1>")
+        elif line.startswith("## "):
+            if in_table:
+                body_lines.append("</tbody></table>")
+                in_table = False
+            body_lines.append(f"<h2>{html.escape(line[3:])}</h2>")
+        elif line.startswith("- "):
+            body_lines.append(f"<p>{html.escape(line)}</p>")
+        elif line.startswith("| "):
+            cells = [html.escape(part.strip()) for part in line.strip("|").split("|")]
+            if set(cells) == {"---"}:
+                continue
+            tag = "th" if not in_table else "td"
+            if not in_table:
+                body_lines.append("<table><thead><tr>" + "".join(f"<th>{cell}</th>" for cell in cells) + "</tr></thead><tbody>")
+                in_table = True
+            else:
+                body_lines.append("<tr>" + "".join(f"<{tag}>{cell}</{tag}>" for cell in cells) + "</tr>")
+        elif line.strip():
+            body_lines.append(f"<p>{html.escape(line)}</p>")
+    if in_table:
+        body_lines.append("</tbody></table>")
+    return """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Russianism Judge Calibration Matrix</title>
+<style>
+body{font-family:system-ui,sans-serif;line-height:1.45;max-width:1180px;margin:32px auto;padding:0 24px;color:#1f2933}
+h1{margin-bottom:8px}
+h2{margin-top:32px;border-bottom:1px solid #cbd2d9;padding-bottom:4px}
+table{border-collapse:collapse;width:100%;margin:16px 0 28px}
+th,td{border:1px solid #cbd2d9;padding:6px 8px;text-align:left;vertical-align:top}
+th{background:#eef2f6}
+td{font-variant-numeric:tabular-nums}
+p{margin:6px 0}
+</style>
+</head>
+<body>
+""" + "\n".join(body_lines) + "\n</body>\n</html>\n"
+
+
+def build_reports(out_dir: Path) -> tuple[Path, Path]:
+    """Generate REPORT.md and REPORT.html from per-cell JSON files."""
+    results = load_cell_results(out_dir)
+    md = build_markdown_report(results)
+    md_path = out_dir / "REPORT.md"
+    html_path = out_dir / "REPORT.html"
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(md, encoding="utf-8")
+    html_path.write_text(markdown_to_html(md), encoding="utf-8")
+    return md_path, html_path
+
+
+def print_dry_run(cells: list[Cell]) -> None:
+    """Print the requested matrix without running model calls."""
+    for cell in cells:
+        reason = unsupported_reason(cell)
+        status = "n/a" if reason else "run"
+        suffix = f" reason={reason}" if reason else ""
+        print(f"{status}: {cell.family}/{cell.model}/{cell.harness}/{cell.effort}-{cell.mcp_state}{suffix}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--families", help="Comma-separated families (default: all)")
+    parser.add_argument("--harnesses", help="Comma-separated harnesses: native_cli,hermes (default: all)")
+    parser.add_argument("--models", help="Comma-separated model ids (default: all supported for selected families)")
+    parser.add_argument("--efforts", help="Comma-separated efforts (default: per-model palette)")
+    parser.add_argument("--mcp-states", help="Comma-separated MCP states: with_mcp,without_mcp (default: both)")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--smoke", action="store_true", help="Run the cheapest smoke subset")
+    parser.add_argument("--dry-run", action="store_true", help="Print matrix without running")
+    parser.add_argument("--resume", action="store_true", help="Skip complete cell JSON files")
+    parser.add_argument("--max-parallel", type=int, default=4, help="Per-family parallelism")
+    parser.add_argument("--build-report-only", action="store_true", help="Only rebuild REPORT.md and REPORT.html")
+    args = parser.parse_args()
+
+    if args.build_report_only:
+        md_path, html_path = build_reports(args.out_dir)
+        print(f"Wrote {md_path}")
+        print(f"Wrote {html_path}")
+        return 0
+
+    families = parse_csv(args.families, FAMILIES)
+    harnesses = parse_csv(args.harnesses, HARNESSES)
+    models = parse_csv(args.models)
+    efforts = parse_csv(args.efforts)
+    mcp_states = parse_csv(args.mcp_states, MCP_STATES)
+    cells = build_matrix(
+        families=families,
+        harnesses=harnesses,
+        models=models,
+        efforts=efforts,
+        mcp_states=mcp_states,
+        smoke=args.smoke,
+    )
+
+    if args.dry_run:
+        print_dry_run(cells)
+        return 0
+
+    cases = pull_calibration_cases()
+    if args.smoke:
+        cases = cases[:1]
+    records = run_cells(
+        out_dir=args.out_dir,
+        cells=cells,
+        cases=cases,
+        resume=args.resume,
+        max_parallel=args.max_parallel,
+    )
+    probe_path = write_probe_results(args.out_dir, records)
+    md_path, html_path = build_reports(args.out_dir)
+    print(f"Wrote {probe_path}")
+    print(f"Wrote {md_path}")
+    print(f"Wrote {html_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_judge_calibration_matrix.py
+++ b/tests/audit/test_judge_calibration_matrix.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import judge_calibration_matrix as matrix
+from scripts.audit._judge_eval_lib import aggregate, score_case
+
+
+def test_cell_key_format() -> None:
+    cell = matrix.Cell(
+        family="anthropic",
+        model="claude-opus-4-7",
+        harness="hermes",
+        effort="max",
+        mcp_state="with_mcp",
+    )
+
+    assert matrix.cell_path(Path("audit/matrix"), cell) == Path(
+        "audit/matrix/anthropic/claude-opus-4-7/hermes/max-with_mcp.json"
+    )
+
+
+def test_unsupported_effort_returns_n_a_not_fabricated(tmp_path: Path) -> None:
+    cell = matrix.Cell(
+        family="anthropic",
+        model="claude-sonnet-4-6",
+        harness="native_cli",
+        effort="max",
+        mcp_state="with_mcp",
+    )
+    called = False
+
+    def runner(_cell: matrix.Cell, _prompt: str) -> matrix.HarnessCall:
+        nonlocal called
+        called = True
+        raise AssertionError("unsupported cells must not call a harness")
+
+    record = matrix.run_cell(out_dir=tmp_path, cell=cell, cases=[], harness_runner=runner)
+
+    assert record["result"] == "n/a"
+    assert "effort=max" in record["reason"]
+    assert "scores" not in record
+    assert called is False
+    assert matrix.cell_path(tmp_path, cell).exists()
+
+
+def test_resume_skips_existing_cells(tmp_path: Path) -> None:
+    cell = matrix.Cell(
+        family="openai",
+        model="gpt-5.5",
+        harness="native_cli",
+        effort="medium",
+        mcp_state="with_mcp",
+    )
+    existing = {"cell": asdict(cell), "scores": {"f1": 0.42}}
+    matrix.write_json(matrix.cell_path(tmp_path, cell), existing)
+
+    def runner(_cell: matrix.Cell, _prompt: str) -> matrix.HarnessCall:
+        raise AssertionError("resume should skip complete cell JSON")
+
+    records = matrix.run_cells(
+        out_dir=tmp_path,
+        cells=[cell],
+        cases=[],
+        resume=True,
+        max_parallel=1,
+        harness_runner=runner,
+    )
+
+    assert records == [existing]
+
+
+def test_hermes_config_swap_is_atomic(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    original = "model:\n  default: gpt-5.5\nagent:\n  reasoning_effort: medium\n"
+    config.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with matrix.hermes_effort_swap(config, "xhigh") as previous:
+            assert previous == "medium"
+            assert "  reasoning_effort: xhigh\n" in config.read_text(encoding="utf-8")
+            raise RuntimeError("boom")
+
+    assert config.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "config.yaml.judge-calibration-backup").exists()
+
+
+def test_score_calculation_matches_grok_baseline() -> None:
+    judgments_path = Path("audit/2026-05-15-grok-4.3-judge-calibration-with-mcp/judgments.jsonl")
+    scores = []
+    for line in judgments_path.read_text(encoding="utf-8").splitlines():
+        row = json.loads(line)
+        gold = {
+            "expected_clean": row["expected_flags_count"] == 0,
+            "expected_flags": [{}] * row["expected_flags_count"],
+        }
+        scores.append(score_case(row["raw"], gold))
+
+    agg = aggregate(scores)
+
+    assert agg["f1"] == 0.7586
+    assert agg["case_acc"] == 0.9167
+    assert agg["precision"] == 0.8462
+    assert agg["recall"] == 0.6875
+
+
+def test_leaderboard_sorted_by_f1_descending(tmp_path: Path) -> None:
+    weak = matrix.Cell("openai", "gpt-5.4-mini", "native_cli", "medium", "with_mcp")
+    strong = matrix.Cell("openai", "gpt-5.5", "hermes", "medium", "with_mcp")
+    for cell, f1 in ((weak, 0.2), (strong, 0.9)):
+        matrix.write_json(
+            matrix.cell_path(tmp_path, cell),
+            {
+                "cell": asdict(cell),
+                "duration_s": 1.0,
+                "scores": {
+                    "f1": f1,
+                    "precision": f1,
+                    "recall": f1,
+                    "case_acc": f1,
+                },
+                "raw_telemetry": {"errors": []},
+            },
+        )
+
+    report_md, _ = matrix.build_reports(tmp_path)
+    text = report_md.read_text(encoding="utf-8")
+
+    assert text.index("| openai | gpt-5.5 | hermes |") < text.index(
+        "| openai | gpt-5.4-mini | native_cli |"
+    )


### PR DESCRIPTION
## Summary

- Extracts shared Russianism judge calibration helpers into `scripts/audit/_judge_eval_lib.py` and refactors the Grok harness to use them without changing its dry-run behavior.
- Adds `scripts/audit/judge_calibration_matrix.py` for sparse model × harness × effort × MCP matrix runs, n/a cell JSON, resume, Hermes effort config swap with flock/restore, smoke mode, probe JSONL, and Markdown/HTML reports.
- Adds focused pytest coverage plus the runbook with the #2036 Anthropic Hermes fallback note.

## Raw Evidence

All commands below used CWD:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/judge-calibration-matrix-harness-2026-05-16
```

### Ruff

Command:

```bash
.venv/bin/ruff check scripts/audit/_judge_eval_lib.py scripts/audit/judge_calibration_matrix.py tests/audit/test_judge_calibration_matrix.py
```

Output:

```text
All checks passed!
```

### Targeted Pytest

Command:

```bash
.venv/bin/python -m pytest tests/audit/test_judge_calibration_matrix.py -v
```

Output:

```text
collected 6 items

tests/audit/test_judge_calibration_matrix.py::test_cell_key_format PASSED [ 16%]
tests/audit/test_judge_calibration_matrix.py::test_unsupported_effort_returns_n_a_not_fabricated PASSED [ 33%]
tests/audit/test_judge_calibration_matrix.py::test_resume_skips_existing_cells PASSED [ 50%]
tests/audit/test_judge_calibration_matrix.py::test_hermes_config_swap_is_atomic PASSED [ 66%]
tests/audit/test_judge_calibration_matrix.py::test_score_calculation_matches_grok_baseline PASSED [ 83%]
tests/audit/test_judge_calibration_matrix.py::test_leaderboard_sorted_by_f1_descending PASSED [100%]

============================== 6 passed in 0.26s ===============================
```

### Audit Pytest Sweep

Command:

```bash
.venv/bin/python -m pytest tests/audit/ -x -q
```

Output:

```text
collected 341 items

======================= 324 passed, 17 skipped in 1.67s ========================
```

### Grok Harness Dry-run Compatibility

Command:

```bash
.venv/bin/python scripts/audit/grok_judge_calibration.py --dry-run
```

Output:

```text
Loaded 12 calibration cases from origin/pr-2006:eval/russianism/calibration-cases.jsonl
Would subprocess `hermes -z PROMPT -m grok-4.3` for each case
Would write artifacts to /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/judge-calibration-matrix-harness-2026-05-16/audit/2026-05-15-grok-4.3-judge-calibration
  - cal_clean_greeting  (expected_clean=True)
  - cal_clean_short_prose  (expected_clean=True)
  - cal_clean_travel  (expected_clean=True)
  - cal_clean_workplace  (expected_clean=True)
  - cal_dirty_email_calques  (expected_clean=False)
  - cal_dirty_medical  (expected_clean=False)
  - cal_dirty_workplace  (expected_clean=False)
  - cal_dirty_meetup  (expected_clean=False)
  - cal_dirty_register  (expected_clean=False)
  - cal_debatable_next_steps  (expected_clean=False)
  - cal_clean_with_lure  (expected_clean=True)
  - cal_dirty_business_meeting  (expected_clean=False)
```

### Smoke Matrix

Command:

```bash
.venv/bin/python scripts/audit/judge_calibration_matrix.py --smoke --max-parallel 1 --out-dir audit/2026-05-17-judge-calibration-matrix-smoke/
```

Output:

```text
Wrote audit/2026-05-17-judge-calibration-matrix-smoke/REPORT.md
Wrote audit/2026-05-17-judge-calibration-matrix-smoke/REPORT.html
```

Command:

```bash
find audit/2026-05-17-judge-calibration-matrix-smoke -name '*.json' -print
```

Output:

```text
audit/2026-05-17-judge-calibration-matrix-smoke/google/gemini-3.1-pro-preview/native_cli/default-with_mcp.json
audit/2026-05-17-judge-calibration-matrix-smoke/xai/grok-4.3/hermes/medium-with_mcp.json
audit/2026-05-17-judge-calibration-matrix-smoke/anthropic/claude-haiku-4-5-20251001/native_cli/medium-with_mcp.json
audit/2026-05-17-judge-calibration-matrix-smoke/openai/gpt-5.5/hermes/medium-with_mcp.json
audit/2026-05-17-judge-calibration-matrix-smoke/openai/gpt-5.4-mini/native_cli/medium-with_mcp.json
```

Command:

```bash
sed -n '1,220p' audit/2026-05-17-judge-calibration-matrix-smoke/REPORT.md
```

Output excerpt:

```text
## Summary

- Cells scored: 5
- Cells n/a: 0
- Cells with harness errors: 1
...
| anthropic | claude-haiku-4-5-20251001 | native_cli | medium | with_mcp | 0.0% | 0.0% | 0.0% | 0.0% | 0.8s | 0 |
| google | gemini-3.1-pro-preview | native_cli | default | with_mcp | 0.0% | 0.0% | 0.0% | 0.0% | 18.2s | 0 |
| openai | gpt-5.4-mini | native_cli | medium | with_mcp | 0.0% | 0.0% | 0.0% | 100.0% | 13.4s | 0 |
| openai | gpt-5.5 | hermes | medium | with_mcp | 0.0% | 0.0% | 0.0% | 100.0% | 7.2s | 0 |
| xai | grok-4.3 | hermes | medium | with_mcp | 0.0% | 0.0% | 0.0% | 100.0% | 13.7s | 0 |
...
| anthropic | claude-haiku-4-5-20251001 | native_cli | medium | with_mcp | [{"case_id": "cal_clean_greeting", "verdict": "judge_error", "error": null, "returncode": 1, "stdout": "Not logged in · Please run /login\n", "stderr": ""}] |
```

### Probe-result JSONL

Command:

```bash
.venv/bin/python scripts/audit/judge_calibration_matrix.py --smoke --resume --max-parallel 1 --out-dir audit/2026-05-17-judge-calibration-matrix-smoke/
```

Output:

```text
[resume] audit/2026-05-17-judge-calibration-matrix-smoke/xai/grok-4.3/hermes/medium-with_mcp.json
[resume] audit/2026-05-17-judge-calibration-matrix-smoke/anthropic/claude-haiku-4-5-20251001/native_cli/medium-with_mcp.json
[resume] audit/2026-05-17-judge-calibration-matrix-smoke/openai/gpt-5.4-mini/native_cli/medium-with_mcp.json
[resume] audit/2026-05-17-judge-calibration-matrix-smoke/openai/gpt-5.5/hermes/medium-with_mcp.json
[resume] audit/2026-05-17-judge-calibration-matrix-smoke/google/gemini-3.1-pro-preview/native_cli/default-with_mcp.json
Wrote audit/2026-05-17-judge-calibration-matrix-smoke/probe-results.jsonl
Wrote audit/2026-05-17-judge-calibration-matrix-smoke/REPORT.md
Wrote audit/2026-05-17-judge-calibration-matrix-smoke/REPORT.html
```

Command:

```bash
sed -n '1,20p' audit/2026-05-17-judge-calibration-matrix-smoke/probe-results.jsonl
```

Output:

```jsonl
{"family": "xai", "model": "grok-4.3", "harness": "hermes", "effort": "medium", "mcp_state": "with_mcp", "result": "valid_response", "reason": null}
{"family": "anthropic", "model": "claude-haiku-4-5-20251001", "harness": "native_cli", "effort": "medium", "mcp_state": "with_mcp", "result": "error", "reason": "Not logged in · Please run /login\n"}
{"family": "openai", "model": "gpt-5.4-mini", "harness": "native_cli", "effort": "medium", "mcp_state": "with_mcp", "result": "valid_response", "reason": null}
{"family": "openai", "model": "gpt-5.5", "harness": "hermes", "effort": "medium", "mcp_state": "with_mcp", "result": "valid_response", "reason": null}
{"family": "google", "model": "gemini-3.1-pro-preview", "harness": "native_cli", "effort": "default", "mcp_state": "with_mcp", "result": "valid_response", "reason": null}
```

### Unsupported Cell Is Logged, Not Fabricated

Command:

```bash
.venv/bin/python scripts/audit/judge_calibration_matrix.py --families anthropic --harnesses native_cli --models claude-sonnet-4-6 --efforts max --mcp-states with_mcp --out-dir audit/2026-05-17-judge-calibration-matrix-na-sample/
```

Output:

```text
Wrote audit/2026-05-17-judge-calibration-matrix-na-sample/probe-results.jsonl
Wrote audit/2026-05-17-judge-calibration-matrix-na-sample/REPORT.md
Wrote audit/2026-05-17-judge-calibration-matrix-na-sample/REPORT.html
```

Command:

```bash
sed -n '1,80p' audit/2026-05-17-judge-calibration-matrix-na-sample/anthropic/claude-sonnet-4-6/native_cli/max-with_mcp.json
```

Output:

```json
{
  "cell": {
    "family": "anthropic",
    "model": "claude-sonnet-4-6",
    "harness": "native_cli",
    "effort": "max",
    "mcp_state": "with_mcp"
  },
  "result": "n/a",
  "reason": "claude-sonnet-4-6 does not accept effort=max via native_cli; configured palette: low, medium, high, xhigh",
  "checked_at": "2026-05-16T12:18:11Z"
}
```

### Hermes Routes

Command:

```bash
hermes -z "Reply PONG." -m gpt-5.5
```

Output:

```text
PONG
```

Command:

```bash
hermes auth status anthropic
```

Output:

```text
anthropic: logged in
```

Command:

```bash
hermes -z "Reply PONG." -m claude-opus-4-7
```

Output:

```text
<empty stdout; command exited 0>
```

The harness supports Anthropic via Hermes, but the runbook keeps the Anthropic family on `native_cli` until #2036 is resolved because Claude via Hermes still returns empty stdout in this environment.

### Commit and PR

Command:

```bash
git log -1 --oneline
```

Output:

```text
8ff3a5c74a feat(audit): add judge calibration matrix harness
```

Command:

```bash
gh pr view --json url --jq .url
```

Output:

```text
https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2037
```