### PR TITLE
feat(audit): code-review benchmark harness

### DIFF
--- a/audit/code-review-benchmark/corpus/pr-2025-openai-proxy.diff
+++ b/audit/code-review-benchmark/corpus/pr-2025-openai-proxy.diff
@@ -1,0 +1,678 @@
+commit db04f07beda401c31b50a175b55d737095d88365
+Author: Krisztian oos <krisztian.koos@gmail.com>
+Date:   Sat May 16 00:50:00 2026 +0200
+
+    feat(bridge): OpenAI-compatible HTTP proxy at :8767
+
+    X-Agent: codex/openai-compat-bridge-proxy-2026-05-16
+
+diff --git a/docs/best-practices/openai-compat-proxy.md b/docs/best-practices/openai-compat-proxy.md
+new file mode 100644
+index 0000000000..75e314f053
+--- /dev/null
++++ b/docs/best-practices/openai-compat-proxy.md
+@@ -0,0 +1,20 @@
++# OpenAI-Compatible Agent Proxy
++
++`ab serve --openai` starts a localhost-only FastAPI service on
++`127.0.0.1:8767` by default. It exposes:
++
++- `GET /v1/models`
++- `POST /v1/chat/completions`
++- `GET /healthz`
++
++The model registry lives in `scripts/ai_agent_bridge/openai_proxy.py` as
++`_ROUTABLE_MODELS`. Add or remove routable public model IDs there first; the
++models endpoint reads from that single source of truth.
++
++Phase 1 is intentionally non-streaming and does not translate tool-use or
++Assistants API envelopes. Token usage is reported as zero unless a backend
++surfaces real counts; do not invent approximate totals in the response.
++
++The Grok route uses `hermes -z PROMPT -m grok-4.3` and respects the user's
++existing `~/.hermes/config.yaml`. The proxy must not mutate Hermes config per
++request because that would be race-prone under concurrent clients.
+diff --git a/scripts/ai_agent_bridge/_cli.py b/scripts/ai_agent_bridge/_cli.py
+index 54d8e2cc18..1c4350922e 100644
+--- a/scripts/ai_agent_bridge/_cli.py
++++ b/scripts/ai_agent_bridge/_cli.py
+@@ -669,6 +669,25 @@ def _build_parser() -> argparse.ArgumentParser:
+     # status
+     subparsers.add_parser("status", help="Show running bridge processes")
+
++    # serve
++    serve_parser = subparsers.add_parser("serve", help="Serve local HTTP bridge surfaces")
++    serve_parser.add_argument(
++        "--openai",
++        action="store_true",
++        help="Serve the OpenAI-compatible proxy",
++    )
++    serve_parser.add_argument(
++        "--host",
++        default="127.0.0.1",
++        help="Host for --openai (default: 127.0.0.1)",
++    )
++    serve_parser.add_argument(
++        "--port",
++        type=int,
++        default=8767,
++        help="Port for --openai (default: 8767)",
++    )
++
+     # interactive
+     subparsers.add_parser("interactive", help="Interactive mode")
+
+@@ -736,6 +755,14 @@ def _dispatch_command(args):
+         broker_cleanup(args.max_age, args.dry_run, args.older_than)
+     elif args.command == "status":
+         bridge_status()
++    elif args.command == "serve":
++        if not args.openai:
++            raise SystemExit("serve currently requires --openai")
++        import uvicorn
++
++        from .openai_proxy import app
++
++        uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+     elif args.command == "interactive":
+         interactive_mode()
+     elif args.command in ("channel", "post", "p", "reconcile", "sync", "discuss"):
+diff --git a/scripts/ai_agent_bridge/openai_proxy.py b/scripts/ai_agent_bridge/openai_proxy.py
+new file mode 100644
+index 0000000000..8d24a49000
+--- /dev/null
++++ b/scripts/ai_agent_bridge/openai_proxy.py
+@@ -0,0 +1,376 @@
++"""OpenAI-compatible HTTP proxy for local agent CLIs.
++
++Phase 1 intentionally exposes only the narrow chat-completions surface:
++model listing, non-streaming chat completions, and a cheap health probe.
++"""
++
++from __future__ import annotations
++
++import os
++import shutil
++import subprocess
++import tempfile
++import time
++import uuid
++from collections.abc import Callable
++from dataclasses import dataclass
++from pathlib import Path
++from typing import Any
++
++from fastapi import FastAPI
++from fastapi.responses import JSONResponse
++from pydantic import BaseModel, ConfigDict, Field
++
++from ._config import _PARENT_ENV, CLAUDE_CMD, CODEX_CLI, GEMINI_CLI, REPO_ROOT
++
++_DEFAULT_BACKEND_TIMEOUT_S = 120
++
++
++class Message(BaseModel):
++    """Minimal OpenAI chat message shape accepted by the proxy."""
++
++    role: str = Field(min_length=1)
++    content: str | list[dict[str, Any]] | None = ""
++
++
++class ChatCompletionRequest(BaseModel):
++    """Subset of the OpenAI chat completion request envelope used in v1."""
++
++    model_config = ConfigDict(extra="allow")
++
++    model: str = Field(min_length=1)
++    messages: list[Message] = Field(min_length=1)
++    user: str | None = None
++
++
++@dataclass(frozen=True)
++class CompletionResponse:
++    """Normalized backend response before wrapping in OpenAI JSON."""
++
++    content: str
++    prompt_tokens: int = 0
++    completion_tokens: int = 0
++    total_tokens: int = 0
++
++
++Backend = Callable[..., CompletionResponse]
++
++
++@dataclass(frozen=True)
++class ModelRoute:
++    """Routing metadata for a public model id."""
++
++    family: str
++    backend: Backend
++
++
++def _backend_timeout_s() -> int:
++    raw = os.environ.get("BRIDGE_PROXY_BACKEND_TIMEOUT_S")
++    if raw is None:
++        return _DEFAULT_BACKEND_TIMEOUT_S
++    try:
++        timeout = int(raw)
++    except ValueError:
++        return _DEFAULT_BACKEND_TIMEOUT_S
++    return timeout if timeout > 0 else _DEFAULT_BACKEND_TIMEOUT_S
++
++
++def _message_content_to_text(content: str | list[dict[str, Any]] | None) -> str:
++    if content is None:
++        return ""
++    if isinstance(content, str):
++        return content
++
++    parts: list[str] = []
++    for item in content:
++        if not isinstance(item, dict):
++            continue
++        item_type = item.get("type")
++        if item_type in {None, "text", "input_text", "output_text"}:
++            text = item.get("text")
++            if isinstance(text, str):
++                parts.append(text)
++    return "\n".join(parts)
++
++
++def _flatten_messages(messages: list[Message]) -> str:
++    """Flatten OpenAI role messages into a deterministic CLI prompt."""
++
++    system_blocks: list[str] = []
++    turns: list[Message] = []
++    for message in messages:
++        if message.role in {"system", "developer"}:
++            system_blocks.append(_message_content_to_text(message.content))
++        else:
++            turns.append(message)
++
++    sections: list[str] = []
++    if system_blocks:
++        sections.append("[system]: " + "\n\n".join(block for block in system_blocks if block))
++
++    for index, message in enumerate(turns, start=1):
++        content = _message_content_to_text(message.content)
++        sections.append(f"--- Round {index} ---\n[{message.role}]: {content}")
++
++    return "\n\n".join(sections)
++
++
++def _run_backend_command(
++    backend_name: str,
++    argv: list[str],
++    *,
++    prompt: str | None = None,
++    cwd: Path = REPO_ROOT,
++) -> subprocess.CompletedProcess[str]:
++    env = dict(_PARENT_ENV)
++    env["TERM"] = "xterm-256color"
++    env["COLORTERM"] = "truecolor"
++    result = subprocess.run(
++        argv,
++        input=prompt,
++        capture_output=True,
++        text=True,
++        timeout=_backend_timeout_s(),
++        cwd=str(cwd),
++        env=env,
++        check=False,
++    )
++    if result.returncode != 0:
++        raise subprocess.CalledProcessError(
++            result.returncode,
++            argv,
++            output=result.stdout,
++            stderr=result.stderr or result.stdout or f"{backend_name} exited with {result.returncode}",
++        )
++    return result
++
++
++def _codex_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
++    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
++    codex_model = os.environ.get("BRIDGE_PROXY_CODEX_MODEL", "gpt-5.5")
++
++    with tempfile.NamedTemporaryFile(prefix="openai-proxy-codex-", suffix=".txt", delete=False) as handle:
++        output_path = Path(handle.name)
++
++    try:
++        argv = [
++            CODEX_CLI,
++            "exec",
++            "--json",
++            "--skip-git-repo-check",
++            "-C",
++            str(REPO_ROOT),
++            "--color",
++            "never",
++            "-s",
++            "read-only",
++            "-o",
++            str(output_path),
++            "-m",
++            codex_model,
++            "-",
++        ]
++        result = _run_backend_command("codex", argv, prompt=prompt)
++        content = ""
++        if output_path.exists():
++            content = output_path.read_text(encoding="utf-8", errors="replace").strip()
++        if not content:
++            content = result.stdout.strip()
++        return CompletionResponse(content=content)
++    finally:
++        output_path.unlink(missing_ok=True)
++
++
++def _gemini_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
++    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
++    argv = [
++        GEMINI_CLI,
++        "-m",
++        model,
++        f"--prompt={prompt}",
++        "--approval-mode",
++        "plan",
++    ]
++    result = _run_backend_command("gemini", argv)
++    return CompletionResponse(content=result.stdout.strip())
++
++
++def _claude_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
++    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
++    argv = [
++        *CLAUDE_CMD,
++        "--print",
++        "--bare",
++        "--model",
++        model,
++        "--",
++        prompt,
++    ]
++    result = _run_backend_command("claude", argv)
++    return CompletionResponse(content=result.stdout.strip())
++
++
++def _hermes_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
++    prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
++    argv = [
++        shutil.which("hermes") or "hermes",
++        f"--oneshot={prompt}",
++        "-m",
++        model,
++    ]
++    result = _run_backend_command("hermes", argv)
++    return CompletionResponse(content=result.stdout.strip())
++
++
++_ROUTABLE_MODELS: dict[str, ModelRoute] = {
++    "codex": ModelRoute(family="openai-codex", backend=_codex_backend),
++    "gemini-3.0-flash-preview": ModelRoute(family="google-gemini", backend=_gemini_backend),
++    "gemini-3.1-pro-preview": ModelRoute(family="google-gemini", backend=_gemini_backend),
++    "claude-opus-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
++    "claude-sonnet-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
++    "grok-4.3": ModelRoute(family="xai", backend=_hermes_backend),
++}
++
++
++def _probe_cli(argv: list[str]) -> bool:
++    try:
++        result = subprocess.run(
++            argv,
++            capture_output=True,
++            text=True,
++            timeout=1,
++            cwd=str(REPO_ROOT),
++            env=_PARENT_ENV,
++            check=False,
++        )
++    except (OSError, subprocess.TimeoutExpired):
++        return False
++    return result.returncode == 0
++
++
++def _probe_codex() -> bool:
++    return _probe_cli([CODEX_CLI, "--version"])
++
++
++def _probe_gemini() -> bool:
++    return _probe_cli([GEMINI_CLI, "--version"])
++
++
++def _probe_claude() -> bool:
++    return _probe_cli([*CLAUDE_CMD, "--version"])
++
++
++def _probe_hermes() -> bool:
++    return _probe_cli([shutil.which("hermes") or "hermes", "--version"])
++
++
++_BACKEND_PROBES: dict[str, Callable[[], bool]] = {
++    "codex": _probe_codex,
++    "gemini": _probe_gemini,
++    "claude": _probe_claude,
++    "hermes": _probe_hermes,
++}
++
++
++def _openai_error(status_code: int, message: str, error_type: str, code: str) -> JSONResponse:
++    return JSONResponse(
++        status_code=status_code,
++        content={"error": {"message": message, "type": error_type, "code": code}},
++    )
++
++
++def _first_error_line(value: object) -> str:
++    text = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else str(value or "")
++    first = text.strip().splitlines()
++    return first[0] if first else "unknown error"
++
++
++app = FastAPI(title="AI Agent Bridge OpenAI Proxy", version="1.0")
++
++
++@app.get("/healthz")
++def healthz() -> dict[str, object]:
++    return {
++        "ok": True,
++        "backends": {name: probe() for name, probe in _BACKEND_PROBES.items()},
++    }
++
++
++@app.get("/v1/models")
++def list_models() -> dict[str, object]:
++    created = int(time.time())
++    return {
++        "object": "list",
++        "data": [
++            {
++                "id": model_id,
++                "object": "model",
++                "created": created,
++                "owned_by": route.family,
++            }
++            for model_id, route in _ROUTABLE_MODELS.items()
++        ],
++    }
++
++
++@app.post("/v1/chat/completions", response_model=None)
++def chat_completions(request: ChatCompletionRequest) -> dict[str, object] | JSONResponse:
++    route = _ROUTABLE_MODELS.get(request.model)
++    if route is None:
++        return _openai_error(
++            404,
++            f"model '{request.model}' not found",
++            "invalid_request_error",
++            "model_not_found",
++        )
++
++    prompt = _flatten_messages(request.messages)
++    try:
++        completion = route.backend(
++            request.model,
++            request.messages,
++            prompt=prompt,
++            user=request.user,
++        )
++    except subprocess.TimeoutExpired as exc:
++        return _openai_error(
++            504,
++            f"{route.family} backend timed out: {_first_error_line(exc.stderr)}",
++            "upstream_error",
++            "backend_timeout",
++        )
++    except subprocess.CalledProcessError as exc:
++        return _openai_error(
++            502,
++            f"{route.family} backend failed: {_first_error_line(exc.stderr)}",
++            "upstream_error",
++            "backend_failed",
++        )
++    except OSError as exc:
++        return _openai_error(
++            502,
++            f"{route.family} backend failed: {_first_error_line(exc)}",
++            "upstream_error",
++            "backend_failed",
++        )
++
++    # Backends do not expose consistent token accounting yet; keep zeroes
++    # instead of fabricating approximate usage.
++    return {
++        "id": f"chatcmpl-{uuid.uuid4()}",
++        "object": "chat.completion",
++        "created": int(time.time()),
++        "model": request.model,
++        "choices": [
++            {
++                "index": 0,
++                "message": {"role": "assistant", "content": completion.content},
++                "finish_reason": "stop",
++            }
++        ],
++        "usage": {
++            "prompt_tokens": completion.prompt_tokens,
++            "completion_tokens": completion.completion_tokens,
++            "total_tokens": completion.total_tokens,
++        },
++    }
+diff --git a/tests/ai_agent_bridge/test_openai_proxy.py b/tests/ai_agent_bridge/test_openai_proxy.py
+new file mode 100644
+index 0000000000..d9ecd03cb9
+--- /dev/null
++++ b/tests/ai_agent_bridge/test_openai_proxy.py
+@@ -0,0 +1,211 @@
++from __future__ import annotations
++
++import subprocess
++from dataclasses import replace
++
++from fastapi.testclient import TestClient
++
++from scripts.ai_agent_bridge import openai_proxy as proxy
++
++
++def _client() -> TestClient:
++    return TestClient(proxy.app)
++
++
++def _route_with_backend(model: str, backend):
++    return replace(proxy._ROUTABLE_MODELS[model], backend=backend)
++
++
++def test_models_endpoint_lists_routable_models():
++    response = _client().get("/v1/models")
++
++    assert response.status_code == 200
++    model_ids = {item["id"] for item in response.json()["data"]}
++    assert model_ids == set(proxy._ROUTABLE_MODELS)
++
++
++def test_chat_completions_codex_round_trip(monkeypatch):
++    def backend(model, messages, **kwargs):
++        return proxy.CompletionResponse(content="hello from codex")
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": "codex", "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    body = response.json()
++    assert response.status_code == 200
++    assert body["model"] == "codex"
++    assert body["choices"][0]["message"]["content"] == "hello from codex"
++    assert body["choices"][0]["finish_reason"] == "stop"
++
++
++def test_chat_completions_grok_via_hermes(monkeypatch):
++    def backend(model, messages, **kwargs):
++        return proxy.CompletionResponse(content="hello from grok")
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "grok-4.3", _route_with_backend("grok-4.3", backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": "grok-4.3", "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    body = response.json()
++    assert response.status_code == 200
++    assert body["model"] == "grok-4.3"
++    assert body["choices"][0]["message"]["content"] == "hello from grok"
++    assert body["choices"][0]["finish_reason"] == "stop"
++
++
++def test_chat_completions_gemini_round_trip(monkeypatch):
++    model_id = "gemini-3.0-flash-preview"
++
++    def backend(model, messages, **kwargs):
++        return proxy.CompletionResponse(content="hello from gemini")
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, model_id, _route_with_backend(model_id, backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": model_id, "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    body = response.json()
++    assert response.status_code == 200
++    assert body["model"] == model_id
++    assert body["choices"][0]["message"]["content"] == "hello from gemini"
++    assert body["choices"][0]["finish_reason"] == "stop"
++
++
++def test_chat_completions_claude_round_trip(monkeypatch):
++    model_id = "claude-sonnet-4-7"
++
++    def backend(model, messages, **kwargs):
++        return proxy.CompletionResponse(content="hello from claude")
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, model_id, _route_with_backend(model_id, backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": model_id, "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    body = response.json()
++    assert response.status_code == 200
++    assert body["model"] == model_id
++    assert body["choices"][0]["message"]["content"] == "hello from claude"
++    assert body["choices"][0]["finish_reason"] == "stop"
++
++
++def test_chat_completions_unknown_model_returns_404():
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": "unknown-model-xyz", "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    assert response.status_code == 404
++    assert response.json()["error"]["code"] == "model_not_found"
++
++
++def test_chat_completions_backend_failure_returns_502(monkeypatch):
++    def backend(model, messages, **kwargs):
++        raise subprocess.CalledProcessError(
++            1,
++            ["agent"],
++            stderr="first failure line\nsecond failure line",
++        )
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": "codex", "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    body = response.json()
++    assert response.status_code == 502
++    assert body["error"]["code"] == "backend_failed"
++    assert "first failure line" in body["error"]["message"]
++    assert "second failure line" not in body["error"]["message"]
++
++
++def test_chat_completions_backend_timeout_returns_504(monkeypatch):
++    def backend(model, messages, **kwargs):
++        raise subprocess.TimeoutExpired(["agent"], timeout=120, stderr="timeout line\nlater")
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={"model": "codex", "messages": [{"role": "user", "content": "hello"}]},
++    )
++
++    body = response.json()
++    assert response.status_code == 504
++    assert body["error"]["code"] == "backend_timeout"
++    assert "timeout line" in body["error"]["message"]
++
++
++def test_chat_completions_missing_messages_returns_422():
++    response = _client().post("/v1/chat/completions", json={"model": "codex"})
++
++    assert response.status_code == 422
++    assert any(item["loc"][-1] == "messages" for item in response.json()["detail"])
++
++
++def test_message_flatten_preserves_role_order(monkeypatch):
++    prompts = []
++
++    def backend(model, messages, **kwargs):
++        prompts.append(kwargs["prompt"])
++        return proxy.CompletionResponse(content="ok")
++
++    monkeypatch.setitem(proxy._ROUTABLE_MODELS, "codex", _route_with_backend("codex", backend))
++
++    response = _client().post(
++        "/v1/chat/completions",
++        json={
++            "model": "codex",
++            "messages": [
++                {"role": "system", "content": "system rules"},
++                {"role": "user", "content": "first user"},
++                {"role": "assistant", "content": "first assistant"},
++                {"role": "user", "content": "second user"},
++            ],
++        },
++    )
++
++    assert response.status_code == 200
++    prompt = prompts[0]
++    assert prompt.index("[system]: system rules") < prompt.index("[user]: first user")
++    assert prompt.index("[user]: first user") < prompt.index("[assistant]: first assistant")
++    assert prompt.index("[assistant]: first assistant") < prompt.index("[user]: second user")
++
++
++def test_healthz_endpoint_returns_backend_status(monkeypatch):
++    monkeypatch.setattr(
++        proxy,
++        "_BACKEND_PROBES",
++        {
++            "codex": lambda: True,
++            "gemini": lambda: False,
++            "claude": lambda: True,
++            "hermes": lambda: False,
++        },
++    )
++
++    response = _client().get("/healthz")
++
++    assert response.status_code == 200
++    assert response.json() == {
++        "ok": True,
++        "backends": {
++            "codex": True,
++            "gemini": False,
++            "claude": True,
++            "hermes": False,
++        },
++    }

--- a/audit/code-review-benchmark/corpus/pr-2025-openai-proxy.yaml
+++ b/audit/code-review-benchmark/corpus/pr-2025-openai-proxy.yaml
@@ -1,0 +1,44 @@
+case_id: pr-2025-openai-proxy
+pr_number: 2025
+title: "OpenAI-compat HTTP proxy at :8767"
+diff_path: corpus/pr-2025-openai-proxy.diff
+context: |
+  This PR adds an OpenAI-compatible HTTP proxy for routing model requests
+  through local agent CLIs, with support for chat/completions-style requests,
+  a health endpoint, and command-line configuration.
+
+  Reviewers should focus on proxy boundary risks: large untrusted request
+  bodies crossing subprocess boundaries, API shape compatibility with OpenAI
+  clients, accidental denial-of-service surfaces, and whether network binding
+  choices are explicit enough for local-only tooling.
+gold_findings:
+  - id: arg-max
+    severity: HIGH
+    category: security
+    location: scripts/ai_agent_bridge/openai_proxy.py
+    description: >
+      Prompts larger than the OS argv limit hit ARG_MAX/E2BIG because the
+      proxy passes prompt text through command-line arguments to the upstream
+      CLI. The prompt should be sent over stdin or another streaming channel.
+  - id: error-envelope
+    severity: HIGH
+    category: spec-compliance
+    location: scripts/ai_agent_bridge/openai_proxy.py
+    description: >
+      FastAPI validation failures return the framework default
+      {detail: [...]} response instead of OpenAI's required
+      {error: {message, type, code}} envelope.
+  - id: healthz-fork
+    severity: MEDIUM
+    category: dos-surface
+    location: scripts/ai_agent_bridge/openai_proxy.py
+    description: >
+      /healthz forks multiple subprocess probes on every request, making the
+      endpoint a trivial denial-of-service amplifier.
+  - id: host-flag
+    severity: LOW
+    category: security
+    location: scripts/ai_agent_bridge/openai_proxy.py
+    description: >
+      --host accepts non-localhost bind addresses without requiring an
+      explicit --allow-remote acknowledgement.

--- a/audit/code-review-benchmark/corpus/pr-2031-activity-schema.diff
+++ b/audit/code-review-benchmark/corpus/pr-2031-activity-schema.diff
@@ -1,0 +1,461 @@
+commit 55d577887d7eac40238de0562673bab68e22d9d0
+Author: Krisztian oos <krisztian.koos@gmail.com>
+Date:   Sat May 16 01:31:52 2026 +0200
+
+    feat(qg): activity schema gate rejects forbidden field aliases
+
+    X-Agent: codex/2018-activity-schema-gate-2026-05-16
+
+diff --git a/scripts/build/linear_pipeline.py b/scripts/build/linear_pipeline.py
+index 55e5f317d2..98efe23861 100644
+--- a/scripts/build/linear_pipeline.py
++++ b/scripts/build/linear_pipeline.py
+@@ -84,6 +84,7 @@ _LABEL_LINE_RE = re.compile(
+
+ PYTHON_QG_GATE_ORDER = (
+     "tool_theatre",
++    "activity_schema",
+     "word_count",
+     "plan_sections",
+     "formatting_standards",
+@@ -106,6 +107,7 @@ PYTHON_QG_GATE_ORDER = (
+ )
+ WRITER_CORRECTION_GATES = frozenset(
+     {
++        "activity_schema",
+         "strict_json_parse",
+         "tool_theatre",
+         "word_count",
+@@ -529,6 +531,41 @@ _ERROR_CORRECTION_TYPE = "error-correction"
+ _ERROR_CORRECTION_INTENTIONAL_FIELDS = frozenset(
+     {"error", "errors", "errorWord", "error_word", "explanation", "sentence"}
+ )
++_ERROR_CORRECTION_REQUIRED_ITEM_FIELDS = frozenset({"sentence", "error"})
++_ERROR_CORRECTION_OPTIONAL_ITEM_FIELDS = frozenset(
++    {"answer", "correction", "options", "explanation"}
++)
++_ACTIVITY_ITEM_AUTHORING_FIELDS: dict[str, frozenset[str]] = {
++    _ERROR_CORRECTION_TYPE: (
++        _ERROR_CORRECTION_REQUIRED_ITEM_FIELDS
++        | _ERROR_CORRECTION_OPTIONAL_ITEM_FIELDS
++    ),
++}
++_ACTIVITY_ITEM_REQUIRED_FIELDS: dict[str, frozenset[str]] = {
++    _ERROR_CORRECTION_TYPE: _ERROR_CORRECTION_REQUIRED_ITEM_FIELDS,
++}
++_ACTIVITY_ITEM_FORBIDDEN_ALIASES: dict[str, dict[str, str]] = {
++    _ERROR_CORRECTION_TYPE: {
++        "wrong": "error",
++        "incorrect": "error",
++        "mistake": "error",
++        "bad": "error",
++        "original": "error",
++        "wrong_form": "error",
++        "incorrect_form": "error",
++        "correct": "correction",
++        "correctAnswer": "correction",
++        "right": "correction",
++        "fix": "correction",
++        "fixed": "correction",
++    },
++}
++_ACTIVITY_ITEM_FIELD_PURPOSES: dict[str, str] = {
++    "sentence": "the sentence containing the error",
++    "error": "the misspelled form",
++    "correction": "the corrected form",
++    "answer": "the corrected form",
++}
+ _VESUM_ABBREVIATION_RE = re.compile(r"\bдіал\.", re.IGNORECASE)
+
+ # String fields whose values are user-facing prose (subject to AI-slop checks).
+@@ -3878,6 +3915,11 @@ def run_python_qg(
+             gate_observer(name)
+         gates[name] = report
+
++    record("activity_schema", _activity_schema_gate(activities))
++    if gates["activity_schema"].get("passed") is False:
++        gates["passed"] = False
++        return _python_qg_report(plan, gates)
++
+     record("word_count", _word_count_gate(module_text, int(plan["word_target"])))
+     record("plan_sections", _section_gate(module_text, plan))
+     record("formatting_standards", _formatting_standards_gate(module_text))
+@@ -3929,13 +3971,20 @@ def run_python_qg(
+         for key, gate in gates.items()
+         if isinstance(gate, dict) and key != "mdx_render"
+     )
++    return _python_qg_report(plan, gates)
++
++
++def _python_qg_report(
++    plan: Mapping[str, Any],
++    gates: Mapping[str, Any],
++) -> dict[str, Any]:
+     return {
+         "module": plan["module"],
+         "level": plan["level"],
+         "slug": plan["slug"],
+         "pipeline": "linear-phase-4",
+         "plan_references": plan.get("references", []),
+-        "gates": gates,
++        "gates": dict(gates),
+     }
+
+
+@@ -4234,6 +4283,18 @@ def _activity_type_field_whitelist() -> dict[str, frozenset[str]]:
+     return _ACTIVITY_AUTHORING_FIELDS
+
+
++def _activity_item_schema_whitelist() -> dict[str, frozenset[str]]:
++    """Return per-activity-type allowed item fields in authoring YAML.
++
++    V1 is intentionally narrow: `error-correction` is the only strict
++    item-level schema needed for #2018. Its required fields come directly from
++    `ActivityParser._parse_error_correction`, which indexes `sentence` and
++    `error`, while `answer`/`correction`/`options`/`explanation` are optional
++    parser-supported fields.
++    """
++    return _ACTIVITY_ITEM_AUTHORING_FIELDS
++
++
+ # Per-type aliases mapping React COMPONENT prop names (as declared
+ # in `docs/lesson-schema.yaml`) to AUTHORING YAML field names (as
+ # emitted by writers and consumed by `scripts/yaml_activities.py`
+@@ -4387,6 +4448,149 @@ def _load_bare_activity_list(path: Path) -> list[dict[str, Any]]:
+     return data
+
+
++def _activity_schema_gate(activities: list[dict[str, Any]]) -> dict[str, Any]:
++    """Validate strict item-level authoring schemas before content gates run."""
++    item_fields_by_type = _activity_item_schema_whitelist()
++    violations: list[dict[str, Any]] = []
++    checked = 0
++
++    for activity_index, activity in enumerate(activities, start=1):
++        if not isinstance(activity, Mapping):
++            continue
++        activity_type = str(activity.get("type") or "")
++        allowed_fields = item_fields_by_type.get(activity_type)
++        if allowed_fields is None:
++            continue
++        aliases = _ACTIVITY_ITEM_FORBIDDEN_ALIASES.get(activity_type, {})
++        required_fields = _ACTIVITY_ITEM_REQUIRED_FIELDS.get(activity_type, frozenset())
++        activity_id = str(activity.get("id") or f"#{activity_index}")
++        items = activity.get("items", [])
++        if not isinstance(items, list):
++            continue
++
++        for item_index, item in enumerate(items, start=1):
++            if not isinstance(item, Mapping):
++                continue
++            checked += 1
++            item_fields = {str(field) for field in item}
++            aliased_required = {
++                expected
++                for field in item_fields
++                if (expected := aliases.get(field)) in required_fields
++            }
++
++            for field in sorted(item_fields):
++                if field in allowed_fields:
++                    continue
++                expected = aliases.get(field)
++                violations.append(
++                    _activity_schema_violation(
++                        activity_id=activity_id,
++                        activity_index=activity_index,
++                        item_index=item_index,
++                        activity_type=activity_type,
++                        offending_field=field,
++                        expected_field=expected,
++                    )
++                )
++
++            for required_field in sorted(required_fields - item_fields - aliased_required):
++                violations.append(
++                    _activity_schema_violation(
++                        activity_id=activity_id,
++                        activity_index=activity_index,
++                        item_index=item_index,
++                        activity_type=activity_type,
++                        offending_field=None,
++                        expected_field=required_field,
++                    )
++                )
++
++    report = {
++        "passed": not violations,
++        "checked": checked,
++        "violations": violations,
++    }
++    if violations:
++        report["message"] = _format_activity_schema_diagnostic(violations)
++    return report
++
++
++def _activity_schema_violation(
++    *,
++    activity_id: str,
++    activity_index: int,
++    item_index: int,
++    activity_type: str,
++    offending_field: str | None,
++    expected_field: str | None,
++) -> dict[str, Any]:
++    if offending_field is None:
++        purpose = _ACTIVITY_ITEM_FIELD_PURPOSES.get(expected_field or "", "this item")
++        message = (
++            f"{activity_type} items must include '{expected_field}:' for {purpose}"
++        )
++    elif expected_field is not None:
++        purpose = _ACTIVITY_ITEM_FIELD_PURPOSES.get(expected_field, "this value")
++        message = (
++            f"{activity_type} items must use '{expected_field}:' for {purpose}, "
++            f"not '{offending_field}:'"
++        )
++    else:
++        message = f"{activity_type} items do not allow field '{offending_field}:'"
++
++    return {
++        "activity_id": activity_id,
++        "activity_index": activity_index,
++        "item_index": item_index,
++        "activity_type": activity_type,
++        "offending_field": offending_field,
++        "expected_field": expected_field,
++        "message": message,
++    }
++
++
++def _format_activity_schema_diagnostic(violations: list[dict[str, Any]]) -> str:
++    lines = [
++        f"ACTIVITY_SCHEMA_GATE FAILED: {len(violations)} violations",
++        "",
++    ]
++    for violation in violations[:10]:
++        activity_id = violation["activity_id"]
++        activity_index = violation["activity_index"]
++        item_index = violation["item_index"]
++        lines.append(
++            f"  activity #{activity_index} '{activity_id}' (item {item_index}):"
++        )
++        offending = violation.get("offending_field")
++        expected = violation.get("expected_field")
++        if offending is None:
++            lines.append(f"    missing required field '{expected}:'")
++        elif expected is None:
++            lines.append(f"    forbidden field '{offending}'")
++        else:
++            purpose = _ACTIVITY_ITEM_FIELD_PURPOSES.get(str(expected), "this value")
++            lines.append(
++                f"    forbidden field '{offending}' - use '{expected}:' for {purpose}"
++            )
++        lines.append("")
++
++    remaining = len(violations) - 10
++    if remaining > 0:
++        lines.append(f"  ... ({remaining} more)")
++        lines.append("")
++
++    lines.extend(
++        [
++            "Canonical 'error-correction' item shape:",
++            '  - sentence: "Я <error> вранці."',
++            '    error: "вмиваюся"',
++            '    correction: "вмиваюся"',
++        ]
++    )
++    return "\n".join(lines)
++
++
+ def _word_count(text: str) -> int:
+     return len(_WORD_RE.findall(text))
+
+diff --git a/tests/test_activity_schema_gate.py b/tests/test_activity_schema_gate.py
+new file mode 100644
+index 0000000000..cef099366c
+--- /dev/null
++++ b/tests/test_activity_schema_gate.py
+@@ -0,0 +1,182 @@
++"""Tests for the early activity_schema Python QG gate."""
++
++from __future__ import annotations
++
++from scripts.build.linear_pipeline import PYTHON_QG_GATE_ORDER, _activity_schema_gate
++
++
++def test_canonical_error_correction_passes() -> None:
++    activities = [
++        {
++            "id": "morning-routine-error-correction",
++            "type": "error-correction",
++            "items": [
++                {
++                    "sentence": "Я <error> о сьомій.",
++                    "error": "прокидаєшся",
++                    "correction": "прокидаюся",
++                }
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++
++    assert result == {"passed": True, "checked": 1, "violations": []}
++
++
++def test_forbidden_alias_incorrect_fails() -> None:
++    activities = [
++        {
++            "id": "morning-routine-error-correction",
++            "type": "error-correction",
++            "items": [
++                {
++                    "sentence": "Я <error> о сьомій.",
++                    "incorrect": "прокидаєшся",
++                    "correction": "прокидаюся",
++                }
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++
++    assert result["passed"] is False
++    assert result["checked"] == 1
++    assert result["violations"][0]["offending_field"] == "incorrect"
++    assert result["violations"][0]["expected_field"] == "error"
++    assert "use 'error:'" in result["violations"][0]["message"]
++
++
++def test_forbidden_alias_wrong_fails() -> None:
++    activities = [
++        {
++            "id": "wrong-field-error-correction",
++            "type": "error-correction",
++            "items": [
++                {
++                    "sentence": "Він <error> пізно.",
++                    "wrong": "прокидаюся",
++                    "answer": "прокидається",
++                }
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++
++    assert result["passed"] is False
++    assert any(
++        violation["offending_field"] == "wrong"
++        and violation["expected_field"] == "error"
++        for violation in result["violations"]
++    )
++
++
++def test_missing_required_error_field_fails() -> None:
++    activities = [
++        {
++            "id": "missing-error-field",
++            "type": "error-correction",
++            "items": [
++                {
++                    "sentence": "Я <error> вранці.",
++                    "correction": "вмиваюся",
++                }
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++
++    assert result["passed"] is False
++    assert any(
++        violation["offending_field"] is None
++        and violation["expected_field"] == "error"
++        and "must include 'error:'" in violation["message"]
++        for violation in result["violations"]
++    )
++
++
++def test_multiple_violations_all_reported() -> None:
++    activities = [
++        {
++            "id": "multi-alias-error-correction",
++            "type": "error-correction",
++            "items": [
++                {
++                    "sentence": "Я <error> о сьомій.",
++                    "incorrect": "прокидаєшся",
++                    "correction": "прокидаюся",
++                },
++                {
++                    "sentence": "Він <error> пізно.",
++                    "wrong": "прокидаюся",
++                    "answer": "прокидається",
++                },
++                {
++                    "sentence": "Я <error> в дзеркало.",
++                    "correctAnswer": "дивлюся",
++                    "error": "дивюся",
++                },
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++    fields = {
++        (violation["offending_field"], violation["expected_field"])
++        for violation in result["violations"]
++    }
++
++    assert result["passed"] is False
++    assert ("incorrect", "error") in fields
++    assert ("wrong", "error") in fields
++    assert ("correctAnswer", "correction") in fields
++
++
++def test_non_error_correction_activities_pass_through() -> None:
++    activities = [
++        {
++            "id": "dialogue-practice",
++            "type": "dialogue",
++            "items": [
++                {
++                    "incorrect": "This field is ignored because dialogue has no strict item schema.",
++                }
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++
++    assert result == {"passed": True, "checked": 0, "violations": []}
++
++
++def test_replays_m20_build8_failure_shape() -> None:
++    activities = [
++        {
++            "id": "morning-routine-error-correction",
++            "type": "error-correction",
++            "items": [
++                {"incorrect": "Я прокидаєшся о сьомій."},
++                {"incorrect": "Я дивюся в дзеркало."},
++            ],
++        }
++    ]
++
++    result = _activity_schema_gate(activities)
++
++    assert result["passed"] is False
++    assert any(
++        violation["offending_field"] == "incorrect"
++        and violation["expected_field"] == "error"
++        for violation in result["violations"]
++    )
++
++
++def test_activity_schema_gate_precedes_vesum_verified() -> None:
++    assert PYTHON_QG_GATE_ORDER.index("activity_schema") < PYTHON_QG_GATE_ORDER.index(
++        "vesum_verified"
++    )

--- a/audit/code-review-benchmark/corpus/pr-2031-activity-schema.yaml
+++ b/audit/code-review-benchmark/corpus/pr-2031-activity-schema.yaml
@@ -1,0 +1,22 @@
+case_id: pr-2031-activity-schema
+pr_number: 2031
+title: "Activity schema gate rejects forbidden field aliases"
+diff_path: corpus/pr-2031-activity-schema.diff
+context: |
+  This PR adds an activity-schema gate intended to block writer output that
+  uses non-canonical YAML fields in generated activities. The target failure
+  mode came from prior module-generation regressions where aliases looked
+  plausible but bypassed the expected schema contract.
+
+  Reviewers should check whether the gate rejects real writer mistakes rather
+  than only the exact canonical examples covered by tests.
+gold_findings:
+  - id: forbidden-field-aliases
+    severity: HIGH
+    category: correctness
+    location: scripts/build/linear_pipeline.py
+    description: >
+      The schema gate must reject non-canonical writer aliases such as
+      error_field: when the schema expects error:. If alias handling is missed,
+      invalid activity YAML can pass the gate and recreate the #2018 class of
+      failures.

--- a/audit/code-review-benchmark/corpus/pr-2038-m20-three-fixes.diff
+++ b/audit/code-review-benchmark/corpus/pr-2038-m20-three-fixes.diff
@@ -1,0 +1,54 @@
+commit a2ff0db8aaf726652346bb2005ebaad6e69344e8
+Author: Krisztian oos <krisztian.koos@gmail.com>
+Date:   Sat May 16 14:57:24 2026 +0200
+
+    fix(test): repin test_my_morning_module_passes_citations_resolve to Grade 1 cites
+
+    Fix #3 in this PR swapped a1/my-morning.yaml's plan_references from
+    Захарійчук Grade 4 (NOT in corpus per #1901) to MCP-grounded Grade 1
+    chunks (p.24 + p.52). The companion test in tests/test_citation_resolve.py
+    was hardcoded to the OLD Grade 4 strings — CI pytest caught it post-merge:
+
+        FAILED tests/test_citation_resolve.py::test_my_morning_module_passes_citations_resolve
+        assert False is True
+
+    Local verification:
+      $ .venv/bin/python -m pytest tests/test_citation_resolve.py -v
+      15 passed in 0.34s
+
+    Lesson: the test's own comment said "pinned to that current state" — so
+    whoever swaps the plan cites must also update this test. Codex's targeted
+    pytest scope (`tests/build/test_linear_pipeline.py`) missed it.
+
+    Refs #2032
+
+    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+diff --git a/tests/test_citation_resolve.py b/tests/test_citation_resolve.py
+index db23ddaa2b..27b0d3671a 100644
+--- a/tests/test_citation_resolve.py
++++ b/tests/test_citation_resolve.py
+@@ -97,15 +97,18 @@ def test_plan_references_field_is_supported() -> None:
+
+ def test_my_morning_module_passes_citations_resolve() -> None:
+     # Source refs must match the LIVE plan_references at curriculum/l2-uk-en/
+-    # plans/a1/my-morning.yaml. PR #2014 (2026-05-15) replaced the off-level
+-    # `Караман Grade 10, p.187` citation with on-level `Захарійчук Grade 4,
+-    # p.163`; this test is pinned to that current state.
++    # plans/a1/my-morning.yaml. Citation history on this plan:
++    # - PR #2014 (2026-05-15) replaced off-level `Караман Grade 10, p.187`
++    #   with `Захарійчук Grade 4, p.162/163`.
++    # - PR #2038 (2026-05-16, this commit) replaced Захарійчук Grade 4 (NOT
++    #   in corpus per #1901) with MCP-grounded Grade 1 chunks at p.24/p.52.
++    # Pinned to the current Grade 1 state.
+     plan_path = linear_pipeline.PROJECT_ROOT / "curriculum/l2-uk-en/plans/a1/my-morning.yaml"
+     plan = yaml.safe_load(plan_path.read_text("utf-8"))
+     result = linear_pipeline._citation_gate(
+         [
+-            {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 162"},
+-            {"source_ref": "Захарійчук, Українська мова, 4 клас, с. 163"},
++            {"source_ref": "Захарійчук, Українська мова, 1 клас, с. 24"},
++            {"source_ref": "Захарійчук, Українська мова, 1 клас, с. 52"},
+         ],
+         plan,
+     )

--- a/audit/code-review-benchmark/corpus/pr-2038-m20-three-fixes.yaml
+++ b/audit/code-review-benchmark/corpus/pr-2038-m20-three-fixes.yaml
@@ -1,0 +1,35 @@
+case_id: pr-2038-m20-three-fixes
+pr_number: 2038
+title: "m20 three fixes for vesum_verified and textbook_grounding"
+diff_path: corpus/pr-2038-m20-three-fixes.diff
+context: |
+  This PR bundles three small fixes for the m20 pipeline: a VESUM reviewer
+  scope leak, a textbook-grounding plan reference issue, and quote cleanup in
+  metalinguistic stripping. Each fix corresponds to a separate regression that
+  should be visible in a careful code review of the diff.
+
+  Reviewers should look for whether the patch fully addresses each regression
+  without moving the checks to a weaker signal or leaving edge cases in the
+  text-cleaning path.
+gold_findings:
+  - id: vesum-reviewer-anchor-leak
+    severity: HIGH
+    category: correctness
+    location: scripts/build/linear_pipeline.py
+    description: >
+      The VESUM verification path can leak reviewer anchor text into the word
+      extraction scope, causing non-answer prose to be checked as vocabulary.
+  - id: textbook-grounding-plan-reference-swap
+    severity: HIGH
+    category: correctness
+    location: curriculum/l2-uk-en/plans/a1/my-morning.yaml
+    description: >
+      The plan reference swap must use the corrected textbook grounding source
+      instead of the stale citation that caused the m20 failure.
+  - id: warning-quote-strip
+    severity: MEDIUM
+    category: correctness
+    location: scripts/build/linear_pipeline.py
+    description: >
+      _strip_metalinguistic must strip warning quotes and related markers so
+      metalinguistic notes do not contaminate checked learner-facing text.

--- a/audit/code-review-benchmark/prompts/review-v1.txt
+++ b/audit/code-review-benchmark/prompts/review-v1.txt
@@ -1,0 +1,11 @@
+You are a meticulous code reviewer. Read the diff below and return findings as a JSON array.
+
+Each finding must have: id (short kebab-case), severity (HIGH|MEDIUM|LOW), category (security|spec-compliance|dos-surface|performance|correctness|other), location (file:line), description (one paragraph).
+
+Return ONLY a JSON array, no preamble, no postscript. If the diff is clean, return [].
+
+--- BEGIN DIFF ---
+{DIFF}
+--- END DIFF ---
+
+Context: {CONTEXT}

--- a/scripts/audit/code_review_benchmark.py
+++ b/scripts/audit/code_review_benchmark.py
@@ -1,0 +1,1149 @@
+#!/usr/bin/env python3
+"""Run the code-review benchmark matrix across models and harnesses."""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import html
+import json
+import re
+import shutil
+import subprocess
+import time
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+try:
+    from _judge_eval_lib import PROJECT_ROOT, utc_timestamp
+except ModuleNotFoundError:
+    from scripts.audit._judge_eval_lib import PROJECT_ROOT, utc_timestamp
+
+REQUEST_TIMEOUT_S = 480
+HERMES_TIMEOUT_S = 600
+HERMES_BIN = "hermes"
+HERMES_CFG = Path.home() / ".hermes" / "config.yaml"
+DEFAULT_CORPUS_DIR = PROJECT_ROOT / "audit" / "code-review-benchmark" / "corpus"
+DEFAULT_PROMPT_PATH = PROJECT_ROOT / "audit" / "code-review-benchmark" / "prompts" / "review-v1.txt"
+DEFAULT_OUT_DIR = PROJECT_ROOT / "audit" / "2026-05-17-code-review-benchmark"
+
+FAMILIES = ("xai", "anthropic", "openai", "google")
+HARNESSES = ("native_cli", "hermes")
+MCP_STATES = ("with_mcp", "without_mcp")
+SEVERITIES = ("HIGH", "MEDIUM", "LOW")
+
+FAMILY_MODELS: dict[str, tuple[str, ...]] = {
+    "xai": ("grok-4.3",),
+    "anthropic": (
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-opus-4-5-20251101",
+        "claude-sonnet-4-5-20250929",
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    ),
+    "openai": (
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+    ),
+    "google": ("gemini-3.0-flash-preview", "gemini-3.1-pro-preview"),
+}
+
+SUPPORTED_HARNESSES: dict[str, tuple[str, ...]] = {
+    "xai": ("hermes",),
+    "anthropic": ("native_cli", "hermes"),
+    "openai": ("native_cli", "hermes"),
+    "google": ("native_cli",),
+}
+
+DEFAULT_EFFORTS: dict[str, tuple[str, ...]] = {
+    "xai": ("low", "minimal", "medium", "high", "xhigh"),
+    "anthropic": ("low", "medium", "high", "xhigh"),
+    "openai": ("low", "medium", "high"),
+    "google": ("default",),
+}
+
+SMOKE_CELLS = (
+    ("xai", "grok-4.3", "hermes", "medium", "with_mcp"),
+    ("anthropic", "claude-haiku-4-5-20251001", "native_cli", "medium", "with_mcp"),
+    ("openai", "gpt-5.4-mini", "native_cli", "medium", "with_mcp"),
+    ("openai", "gpt-5.5", "hermes", "medium", "with_mcp"),
+    ("google", "gemini-3.1-pro-preview", "native_cli", "default", "with_mcp"),
+)
+
+REQUIRED_CASE_KEYS = {
+    "case_id",
+    "pr_number",
+    "title",
+    "diff_path",
+    "context",
+    "gold_findings",
+}
+REQUIRED_FINDING_KEYS = {"id", "severity", "category", "location", "description"}
+
+
+@dataclass(frozen=True)
+class Cell:
+    family: str
+    model: str
+    harness: str
+    effort: str
+    mcp_state: str
+
+
+@dataclass(frozen=True)
+class HarnessCall:
+    ok: bool
+    stdout: str
+    stderr: str
+    returncode: int | None
+    duration_s: float
+    cmd: tuple[str, ...]
+    error: str | None = None
+
+
+def parse_csv(raw: str | None, allowed: Iterable[str] | None = None) -> list[str] | None:
+    """Parse comma-separated CLI values."""
+    if raw is None:
+        return None
+    values = [part.strip() for part in raw.split(",") if part.strip()]
+    if allowed is not None:
+        allowed_set = set(allowed)
+        bad = [value for value in values if value not in allowed_set]
+        if bad:
+            raise SystemExit(f"invalid value(s): {', '.join(bad)}; allowed: {', '.join(sorted(allowed_set))}")
+    return values
+
+
+def effort_palette(family: str, model: str) -> tuple[str, ...]:
+    """Return the pre-locked effort palette for one model."""
+    if family == "anthropic" and model == "claude-opus-4-7":
+        return (*DEFAULT_EFFORTS["anthropic"], "max")
+    return DEFAULT_EFFORTS[family]
+
+
+def cell_path(out_dir: Path, cell: Cell) -> Path:
+    """Return the per-cell JSON path."""
+    return out_dir / cell.family / cell.model / cell.harness / f"{cell.effort}-{cell.mcp_state}.json"
+
+
+def is_forbidden_cell(cell: Cell) -> bool:
+    """Return True for combinations the matrix must not materialize."""
+    return cell.family == "google" and cell.harness == "hermes"
+
+
+def unsupported_reason(cell: Cell) -> str | None:
+    """Return a deterministic skip reason for unsupported cells."""
+    if cell.family not in FAMILIES:
+        return f"unknown family: {cell.family}"
+    if cell.model not in FAMILY_MODELS[cell.family]:
+        return f"{cell.model} is not in the configured {cell.family} model palette"
+    if cell.harness not in HARNESSES:
+        return f"unknown harness: {cell.harness}"
+    if cell.harness not in SUPPORTED_HARNESSES[cell.family]:
+        return f"{cell.family} does not have a {cell.harness} route"
+    if cell.mcp_state not in MCP_STATES:
+        return f"unknown MCP state: {cell.mcp_state}"
+    if cell.effort not in effort_palette(cell.family, cell.model):
+        return (
+            f"{cell.model} does not accept effort={cell.effort} via {cell.harness}; "
+            f"configured palette: {', '.join(effort_palette(cell.family, cell.model))}"
+        )
+    return None
+
+
+def build_matrix(
+    *,
+    families: list[str] | None,
+    harnesses: list[str] | None,
+    models: list[str] | None,
+    efforts: list[str] | None,
+    mcp_states: list[str] | None,
+    smoke: bool,
+) -> list[Cell]:
+    """Build the requested sparse matrix."""
+    selected_families = families or list(FAMILIES)
+    selected_harnesses = harnesses or list(HARNESSES)
+    selected_mcp_states = mcp_states or list(MCP_STATES)
+
+    if smoke:
+        cells = [
+            Cell(*raw)
+            for raw in SMOKE_CELLS
+            if raw[0] in selected_families
+            and raw[2] in selected_harnesses
+            and raw[4] in selected_mcp_states
+            and (models is None or raw[1] in models)
+            and (efforts is None or raw[3] in efforts)
+        ]
+        return [cell for cell in cells if not is_forbidden_cell(cell)]
+
+    cells: list[Cell] = []
+    for family in selected_families:
+        family_models = [model for model in FAMILY_MODELS[family] if models is None or model in models]
+        for model in family_models:
+            selected_efforts = efforts or list(effort_palette(family, model))
+            for harness in selected_harnesses:
+                for effort in selected_efforts:
+                    for mcp_state in selected_mcp_states:
+                        cell = Cell(family, model, harness, effort, mcp_state)
+                        if not is_forbidden_cell(cell):
+                            cells.append(cell)
+    return cells
+
+
+def _validate_finding(raw: Any, *, source: Path) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{source}: each gold finding must be a mapping")
+    missing = REQUIRED_FINDING_KEYS - set(raw)
+    if missing:
+        raise ValueError(f"{source}: gold finding missing keys: {', '.join(sorted(missing))}")
+    severity = str(raw["severity"]).upper()
+    if severity not in SEVERITIES:
+        raise ValueError(f"{source}: invalid severity {raw['severity']!r}")
+    return {
+        "id": str(raw["id"]),
+        "severity": severity,
+        "category": str(raw["category"]),
+        "location": str(raw["location"]),
+        "description": str(raw["description"]),
+    }
+
+
+def _resolve_diff_path(yaml_path: Path, diff_path: str) -> Path:
+    path = Path(diff_path)
+    if path.is_absolute():
+        return path
+    benchmark_root = yaml_path.parent.parent
+    candidate = benchmark_root / path
+    if candidate.exists():
+        return candidate
+    return yaml_path.parent / path
+
+
+def load_case(path: Path) -> dict[str, Any]:
+    """Load and validate one code-review benchmark case."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: malformed YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: case YAML must be a mapping")
+    missing = REQUIRED_CASE_KEYS - set(raw)
+    if missing:
+        raise ValueError(f"{path}: case missing keys: {', '.join(sorted(missing))}")
+    findings = raw["gold_findings"]
+    if not isinstance(findings, list):
+        raise ValueError(f"{path}: gold_findings must be a list")
+    diff_path = _resolve_diff_path(path, str(raw["diff_path"]))
+    if not diff_path.exists():
+        raise ValueError(f"{path}: diff_path does not exist: {diff_path}")
+    return {
+        "case_id": str(raw["case_id"]),
+        "pr_number": int(raw["pr_number"]),
+        "title": str(raw["title"]),
+        "diff_path": str(diff_path),
+        "diff": diff_path.read_text(encoding="utf-8"),
+        "context": str(raw["context"]),
+        "gold_findings": [_validate_finding(item, source=path) for item in findings],
+        "source_path": str(path),
+    }
+
+
+def load_corpus(corpus_dir: Path, *, case_ids: list[str] | None = None) -> list[dict[str, Any]]:
+    """Load all YAML cases from a corpus directory."""
+    selected = set(case_ids or [])
+    cases = []
+    for path in sorted(corpus_dir.glob("*.yaml")):
+        case = load_case(path)
+        if selected and case["case_id"] not in selected:
+            continue
+        cases.append(case)
+    if selected:
+        found = {case["case_id"] for case in cases}
+        missing = selected - found
+        if missing:
+            raise ValueError(f"requested case(s) not found: {', '.join(sorted(missing))}")
+    if not cases:
+        raise ValueError(f"no corpus cases found in {corpus_dir}")
+    return cases
+
+
+def build_review_prompt(case: dict[str, Any], prompt_template: str) -> str:
+    """Render the review prompt for one case."""
+    return prompt_template.replace("{DIFF}", case["diff"]).replace("{CONTEXT}", case["context"])
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON deterministically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_na_cell(out_dir: Path, cell: Cell, reason: str) -> dict[str, Any]:
+    """Write an unsupported-combo record."""
+    record = {
+        "cell": asdict(cell),
+        "result": "n/a",
+        "reason": reason,
+        "checked_at": utc_timestamp(),
+    }
+    write_json(cell_path(out_dir, cell), record)
+    return record
+
+
+def command_version(binary: str) -> str:
+    """Best-effort CLI version string for telemetry."""
+    try:
+        proc = subprocess.run(
+            [binary, "--version"],
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return f"unavailable: {exc}"
+    combined = (proc.stdout or proc.stderr or "").strip()
+    return combined.splitlines()[0] if combined else f"rc={proc.returncode}; empty version output"
+
+
+def run_subprocess(cmd: list[str], *, timeout_s: int, stdin: str | None = None) -> HarnessCall:
+    """Run a provider CLI and capture bounded telemetry."""
+    display_cmd = tuple(cmd[:])
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin,
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return HarnessCall(False, "", "", None, time.time() - t0, display_cmd, error=str(exc))
+    except subprocess.TimeoutExpired as exc:
+        return HarnessCall(
+            False,
+            exc.stdout or "",
+            exc.stderr or "",
+            None,
+            time.time() - t0,
+            display_cmd,
+            error=f"timed out after {timeout_s}s",
+        )
+    return HarnessCall(
+        proc.returncode == 0 and bool((proc.stdout or "").strip()),
+        proc.stdout or "",
+        proc.stderr or "",
+        proc.returncode,
+        time.time() - t0,
+        display_cmd,
+    )
+
+
+def build_native_command(cell: Cell, prompt: str) -> list[str]:
+    """Build the native CLI command for one prompt."""
+    if cell.family == "anthropic":
+        cmd = ["claude", "-p", "--bare", "--model", cell.model]
+        if cell.effort != "default":
+            cmd.extend(["--effort", cell.effort])
+        if cell.mcp_state == "with_mcp" and (PROJECT_ROOT / ".mcp.json").exists():
+            cmd.extend(["--mcp-config", str(PROJECT_ROOT / ".mcp.json")])
+        cmd.extend(["--", prompt])
+        return cmd
+
+    if cell.family == "openai":
+        cmd = [
+            "codex",
+            "exec",
+            "--skip-git-repo-check",
+            "-C",
+            str(PROJECT_ROOT),
+            "--color",
+            "never",
+            "--model",
+            cell.model,
+        ]
+        if cell.effort != "default":
+            cmd.extend(["-c", f"model_reasoning_effort={cell.effort}"])
+        if cell.mcp_state == "with_mcp":
+            cmd.extend(["-c", 'mcp_servers.sources.url="http://127.0.0.1:8766/mcp"'])
+        cmd.append(prompt)
+        return cmd
+
+    if cell.family == "google":
+        cmd = ["gemini", "-m", cell.model]
+        if cell.mcp_state == "with_mcp":
+            cmd.extend(["--allowed-mcp-server-names", "sources"])
+        cmd.extend(["-p", prompt])
+        return cmd
+
+    raise ValueError(f"no native CLI route for {cell.family}")
+
+
+def run_native_cli(cell: Cell, prompt: str) -> HarnessCall:
+    """Invoke a native provider CLI for one benchmark prompt."""
+    return run_subprocess(build_native_command(cell, prompt), timeout_s=REQUEST_TIMEOUT_S)
+
+
+def _read_effort_line(text: str) -> tuple[int, str] | None:
+    """Find the agent-level Hermes reasoning_effort line."""
+    for idx, line in enumerate(text.splitlines()):
+        stripped = line.strip()
+        if line.startswith("  reasoning_effort:") and stripped.startswith("reasoning_effort:"):
+            value = stripped.split(":", 1)[1].strip()
+            return idx, value
+    return None
+
+
+def set_hermes_effort(config_path: Path, effort: str) -> str:
+    """Edit Hermes config in place and return the previous effort."""
+    text = config_path.read_text(encoding="utf-8")
+    located = _read_effort_line(text)
+    if located is None:
+        raise RuntimeError(
+            "could not locate `  reasoning_effort: <value>` in ~/.hermes/config.yaml; "
+            "Hermes may have changed config shape"
+        )
+    line_idx, previous = located
+    lines = text.splitlines(keepends=True)
+    newline = "\n" if lines[line_idx].endswith("\n") else ""
+    lines[line_idx] = f"  reasoning_effort: {effort}{newline}"
+    config_path.write_text("".join(lines), encoding="utf-8")
+    return previous
+
+
+@contextlib.contextmanager
+def hermes_effort_swap(config_path: Path, effort: str) -> Iterable[str]:
+    """Lock, back up, edit, and restore Hermes effort for one call."""
+    backup_path = config_path.with_name(f"{config_path.name}.code-review-benchmark-backup")
+    with config_path.open("r", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        shutil.copy2(config_path, backup_path)
+        previous = set_hermes_effort(config_path, effort)
+        try:
+            yield previous
+        finally:
+            shutil.copy2(backup_path, config_path)
+            backup_path.unlink(missing_ok=True)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def hermes_mcp_command(action: str) -> HarnessCall:
+    """Run hermes mcp disable/enable sources."""
+    call = run_subprocess([HERMES_BIN, "mcp", action, "sources"], timeout_s=60)
+    if call.returncode == 0 and call.error is None:
+        return HarnessCall(True, call.stdout, call.stderr, call.returncode, call.duration_s, call.cmd)
+    return call
+
+
+def run_hermes(cell: Cell, prompt: str, *, config_path: Path = HERMES_CFG) -> HarnessCall:
+    """Invoke Hermes one-shot mode with atomic effort config swapping."""
+    try:
+        with hermes_effort_swap(config_path, cell.effort):
+            disabled: HarnessCall | None = None
+            if cell.mcp_state == "without_mcp":
+                disabled = hermes_mcp_command("disable")
+                if not disabled.ok:
+                    return disabled
+            try:
+                return run_subprocess([HERMES_BIN, "-z", prompt, "-m", cell.model], timeout_s=HERMES_TIMEOUT_S)
+            finally:
+                if disabled is not None:
+                    hermes_mcp_command("enable")
+    except (OSError, RuntimeError) as exc:
+        return HarnessCall(False, "", "", None, 0.0, (HERMES_BIN, "-z", "-m", cell.model), error=str(exc))
+
+
+def run_harness(cell: Cell, prompt: str) -> HarnessCall:
+    """Dispatch a single prompt to the configured harness."""
+    if cell.harness == "hermes":
+        return run_hermes(cell, prompt)
+    if cell.harness == "native_cli":
+        return run_native_cli(cell, prompt)
+    raise ValueError(f"unknown harness {cell.harness}")
+
+
+def parse_findings(raw_content: str, *, duration_s: float = 0.0) -> dict[str, Any]:
+    """Parse a review response into a normalized findings verdict."""
+    text = raw_content or ""
+    match = re.search(r"\[.*\]", text, re.DOTALL)
+    if not match:
+        return {
+            "verdict": "review_error",
+            "findings": [],
+            "raw": text[:500],
+            "duration_s": duration_s,
+            "note": "no JSON array in response",
+        }
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        return {
+            "verdict": "json_parse_error",
+            "findings": [],
+            "raw": match.group(0)[:500],
+            "error": str(exc),
+            "duration_s": duration_s,
+        }
+    if not isinstance(parsed, list):
+        return {
+            "verdict": "json_parse_error",
+            "findings": [],
+            "raw": match.group(0)[:500],
+            "error": "parsed JSON was not an array",
+            "duration_s": duration_s,
+        }
+    findings = [item for item in parsed if isinstance(item, dict)]
+    return {
+        "verdict": "findings",
+        "findings": findings,
+        "_duration_s": duration_s,
+    }
+
+
+def verdict_from_call(call: HarnessCall) -> dict[str, Any]:
+    """Convert CLI output into a scoreable verdict."""
+    if call.ok:
+        return parse_findings(call.stdout, duration_s=call.duration_s)
+    return {
+        "verdict": "review_error",
+        "findings": [],
+        "error": call.error,
+        "returncode": call.returncode,
+        "stdout": call.stdout[:500],
+        "stderr": call.stderr[:500],
+        "duration_s": call.duration_s,
+    }
+
+
+def location_file(location: Any) -> str:
+    """Normalize a finding location to file-level granularity."""
+    raw = str(location or "").strip()
+    if not raw:
+        return ""
+    if ":" in raw:
+        prefix, suffix = raw.rsplit(":", 1)
+        if suffix.isdigit():
+            return prefix
+    return raw
+
+
+def finding_key(finding: dict[str, Any]) -> tuple[str, str, str]:
+    """Return the tuple used for file-level finding matching."""
+    return (
+        str(finding.get("category", "")).strip().lower(),
+        str(finding.get("severity", "")).strip().upper(),
+        location_file(finding.get("location")),
+    )
+
+
+def _high_gold_keys(gold_findings: list[dict[str, Any]]) -> set[tuple[str, str, str]]:
+    return {finding_key(item) for item in gold_findings if str(item.get("severity")).upper() == "HIGH"}
+
+
+def score_case(verdict: dict[str, Any], gold: dict[str, Any]) -> dict[str, Any]:
+    """Score one case by exact category/severity/location-file tuple matching."""
+    model_findings = [item for item in verdict.get("findings", []) if isinstance(item, dict)]
+    gold_findings = [item for item in gold.get("gold_findings", []) if isinstance(item, dict)]
+    gold_keys = [finding_key(item) for item in gold_findings]
+    remaining_gold_keys = set(gold_keys)
+    matched_keys: set[tuple[str, str, str]] = set()
+    fp = 0
+    for item in model_findings:
+        key = finding_key(item)
+        if key in remaining_gold_keys:
+            matched_keys.add(key)
+            remaining_gold_keys.remove(key)
+        else:
+            fp += 1
+    high_gold_keys = _high_gold_keys(gold_findings)
+    high_matched = matched_keys & high_gold_keys
+
+    tp = len(matched_keys)
+    fn = len(remaining_gold_keys)
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    high_recall = len(high_matched) / len(high_gold_keys) if high_gold_keys else 1.0
+
+    return {
+        "case_acc": tp == len(gold_keys) and fp == 0,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "high_recall": round(high_recall, 4),
+        "high_gold_count": len(high_gold_keys),
+        "high_matched_count": len(high_matched),
+        "catastrophic_misses": len(high_gold_keys - matched_keys),
+        "matched_gold_ids": [
+            item["id"]
+            for item in gold_findings
+            if finding_key(item) in matched_keys
+        ],
+        "missed_gold_ids": [
+            item["id"]
+            for item in gold_findings
+            if finding_key(item) not in matched_keys
+        ],
+        "model_findings_count": len(model_findings),
+        "gold_findings_count": len(gold_keys),
+    }
+
+
+def aggregate(scores: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-case scores into precision, recall, F1, and high recall."""
+    tp = sum(int(s["tp"]) for s in scores)
+    fp = sum(int(s["fp"]) for s in scores)
+    fn = sum(int(s["fn"]) for s in scores)
+    n = len(scores)
+    case_acc = sum(1 for s in scores if s["case_acc"]) / n if n else 0.0
+    catastrophic_misses = sum(int(s["catastrophic_misses"]) for s in scores)
+    high_total = sum(int(s["high_gold_count"]) for s in scores)
+    high_matched = sum(int(s["high_matched_count"]) for s in scores)
+    high_recall = high_matched / high_total if high_total else 1.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    return {
+        "n": n,
+        "case_acc": round(case_acc, 4),
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "high_recall": round(high_recall, 4),
+        "catastrophic_misses": catastrophic_misses,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }
+
+
+def run_cell(
+    *,
+    out_dir: Path,
+    cell: Cell,
+    cases: list[dict[str, Any]],
+    prompt_template: str,
+    harness_runner: Callable[[Cell, str], HarnessCall] = run_harness,
+) -> dict[str, Any]:
+    """Run or n/a one cell and write its JSON artifact."""
+    reason = unsupported_reason(cell)
+    if reason:
+        return write_na_cell(out_dir, cell, reason)
+
+    started = utc_timestamp()
+    t0 = time.time()
+    scores: list[dict[str, Any]] = []
+    judgments: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    for case in cases:
+        prompt = build_review_prompt(case, prompt_template)
+        call = harness_runner(cell, prompt)
+        verdict = verdict_from_call(call)
+        score = score_case(verdict, case)
+        scores.append(score)
+
+        if verdict.get("verdict") in {"review_error", "json_parse_error"}:
+            errors.append(
+                {
+                    "case_id": case["case_id"],
+                    "verdict": verdict.get("verdict"),
+                    "error": verdict.get("error") or verdict.get("note"),
+                    "returncode": verdict.get("returncode"),
+                    "stdout": verdict.get("stdout") or verdict.get("raw"),
+                    "stderr": verdict.get("stderr"),
+                }
+            )
+
+        judgments.append(
+            {
+                "case_id": case["case_id"],
+                "model_findings_count": score["model_findings_count"],
+                "gold_findings_count": score["gold_findings_count"],
+                "matched_gold_ids": score["matched_gold_ids"],
+                "missed_gold_ids": score["missed_gold_ids"],
+                "precision": score["precision"],
+                "recall": score["recall"],
+                "f1": score["f1"],
+                "high_recall": score["high_recall"],
+                "catastrophic_misses": score["catastrophic_misses"],
+                "raw_response_chars": len(call.stdout or verdict.get("raw", "") or ""),
+            }
+        )
+
+    agg = aggregate(scores)
+    record = {
+        "cell": asdict(cell),
+        "started_at": started,
+        "finished_at": utc_timestamp(),
+        "duration_s": round(time.time() - t0, 2),
+        "n_cases": len(cases),
+        "judgments": judgments,
+        "scores": {
+            "f1": agg["f1"],
+            "case_acc": agg["case_acc"],
+            "precision": agg["precision"],
+            "recall": agg["recall"],
+            "high_recall": agg["high_recall"],
+            "catastrophic_misses": agg["catastrophic_misses"],
+        },
+        "raw_telemetry": {
+            "harness": cell.harness,
+            "harness_version": command_version(HERMES_BIN if cell.harness == "hermes" else _native_binary(cell.family)),
+            "model_id": cell.model,
+            "effort_actual": cell.effort,
+            "mcp_servers": ["sources"] if cell.mcp_state == "with_mcp" else [],
+            "errors": errors,
+        },
+    }
+    write_json(cell_path(out_dir, cell), record)
+    return record
+
+
+def _native_binary(family: str) -> str:
+    if family == "anthropic":
+        return "claude"
+    if family == "openai":
+        return "codex"
+    if family == "google":
+        return "gemini"
+    return family
+
+
+def existing_cell_complete(path: Path) -> bool:
+    """Return True when a resume-able cell JSON already exists."""
+    if not path.exists():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return isinstance(data, dict) and "cell" in data and (
+        data.get("result") == "n/a" or "scores" in data or data.get("result") == "error"
+    )
+
+
+def run_cells(
+    *,
+    out_dir: Path,
+    cells: list[Cell],
+    cases: list[dict[str, Any]],
+    prompt_template: str,
+    resume: bool,
+    max_parallel: int,
+    harness_runner: Callable[[Cell, str], HarnessCall] = run_harness,
+) -> list[dict[str, Any]]:
+    """Run cells serially by family, with bounded intra-family parallelism."""
+    records: list[dict[str, Any]] = []
+    for family in FAMILIES:
+        family_cells = [cell for cell in cells if cell.family == family]
+        if not family_cells:
+            continue
+
+        runnable: list[Cell] = []
+        for cell in family_cells:
+            path = cell_path(out_dir, cell)
+            if resume and existing_cell_complete(path):
+                print(f"[resume] {path}")
+                records.append(json.loads(path.read_text(encoding="utf-8")))
+            else:
+                runnable.append(cell)
+
+        if not runnable:
+            continue
+
+        workers = max(1, min(max_parallel, len(runnable)))
+        if workers == 1:
+            for cell in runnable:
+                records.append(
+                    run_cell(
+                        out_dir=out_dir,
+                        cell=cell,
+                        cases=cases,
+                        prompt_template=prompt_template,
+                        harness_runner=harness_runner,
+                    )
+                )
+            continue
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(
+                    run_cell,
+                    out_dir=out_dir,
+                    cell=cell,
+                    cases=cases,
+                    prompt_template=prompt_template,
+                    harness_runner=harness_runner,
+                ): cell
+                for cell in runnable
+            }
+            for future in as_completed(futures):
+                records.append(future.result())
+    return records
+
+
+def write_probe_results(out_dir: Path, records: list[dict[str, Any]]) -> Path:
+    """Write a compact JSONL probe summary for PR evidence."""
+    path = out_dir / "probe-results.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for record in records:
+        cell = record["cell"]
+        errors = record.get("raw_telemetry", {}).get("errors") or []
+        if record.get("result") == "n/a":
+            result = "skipped"
+            reason = record.get("reason")
+        elif errors:
+            result = "error"
+            reason = errors[0].get("error") or errors[0].get("stdout") or errors[0].get("stderr")
+        else:
+            result = "valid_response"
+            reason = None
+        lines.append(
+            json.dumps(
+                {
+                    "family": cell["family"],
+                    "model": cell["model"],
+                    "harness": cell["harness"],
+                    "effort": cell["effort"],
+                    "mcp_state": cell["mcp_state"],
+                    "result": result,
+                    "reason": reason,
+                },
+                ensure_ascii=False,
+            )
+        )
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def load_cell_results(out_dir: Path) -> list[dict[str, Any]]:
+    """Load all per-cell JSON artifacts under the output directory."""
+    results = []
+    for path in sorted(out_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and isinstance(data.get("cell"), dict):
+            results.append(data)
+    return results
+
+
+def pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Build a Markdown table."""
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    lines.extend("| " + " | ".join(row) + " |" for row in rows)
+    return lines
+
+
+def successful_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [r for r in results if isinstance(r.get("scores"), dict) and r.get("result") != "n/a"]
+
+
+def failure_reason(result: dict[str, Any]) -> str:
+    if result.get("result") == "n/a":
+        return str(result.get("reason", "n/a"))
+    errors = result.get("raw_telemetry", {}).get("errors") or []
+    if errors:
+        return json.dumps(errors[:3], ensure_ascii=False)
+    return ""
+
+
+def build_markdown_report(results: list[dict[str, Any]]) -> str:
+    """Render the consolidated Markdown report."""
+    ok_results = successful_results(results)
+    na_results = [r for r in results if r.get("result") == "n/a"]
+    errored_results = [r for r in ok_results if r.get("raw_telemetry", {}).get("errors")]
+    sorted_ok = sorted(ok_results, key=lambda r: (r["scores"]["f1"], r["scores"].get("high_recall", 0.0)), reverse=True)
+    summary_line = (
+        f"Best F1: {pct(sorted_ok[0]['scores']['f1'])} "
+        f"({sorted_ok[0]['cell']['model']} / {sorted_ok[0]['cell']['harness']})"
+        if sorted_ok
+        else "Best F1: n/a"
+    )
+
+    lines = [
+        "# Code Review Benchmark Matrix",
+        "",
+        f"Generated: {utc_timestamp()}",
+        "",
+        "## Summary",
+        "",
+        f"- Cells scored: {len(ok_results)}",
+        f"- Cells n/a: {len(na_results)}",
+        f"- Cells with harness errors: {len(errored_results)}",
+        f"- {summary_line}",
+        "",
+        "## Leaderboard",
+        "",
+    ]
+
+    leaderboard_rows = []
+    for result in sorted_ok:
+        cell = result["cell"]
+        scores = result["scores"]
+        leaderboard_rows.append(
+            [
+                cell["family"],
+                cell["model"],
+                cell["harness"],
+                cell["effort"],
+                cell["mcp_state"],
+                pct(scores.get("f1")),
+                pct(scores.get("precision")),
+                pct(scores.get("recall")),
+                pct(scores.get("high_recall")),
+                str(scores.get("catastrophic_misses", 0)),
+                f"{result.get('duration_s', 0):.1f}s",
+            ]
+        )
+    lines.extend(
+        table(
+            ["family", "model", "harness", "effort", "mcp_state", "F1", "P", "R", "HIGH R", "cat-miss", "avg_dur"],
+            leaderboard_rows
+            or [["n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", str(len(na_results)), "n/a"]],
+        )
+    )
+
+    lines.extend(["", "## Harness Comparison", ""])
+    lines.extend(table(["model", "effort", "mcp_state", "native_cli F1", "hermes F1", "delta"], harness_comparison_rows(ok_results)))
+
+    lines.extend(["", "## MCP Impact", ""])
+    lines.extend(table(["model", "harness", "effort", "without F1", "with F1", "delta"], mcp_impact_rows(ok_results)))
+
+    lines.extend(["", "## Effort Scaling", ""])
+    lines.extend(table(["model", "harness", "mcp_state", "F1 by effort"], effort_scaling_rows(ok_results)))
+
+    lines.extend(["", "## Failure Log", ""])
+    failure_rows = []
+    for result in results:
+        reason = failure_reason(result)
+        if not reason:
+            continue
+        cell = result["cell"]
+        failure_rows.append(
+            [
+                cell["family"],
+                cell["model"],
+                cell["harness"],
+                cell["effort"],
+                cell["mcp_state"],
+                reason.replace("\n", " ")[:300],
+            ]
+        )
+    lines.extend(table(["family", "model", "harness", "effort", "mcp_state", "reason"], failure_rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "none"]]))
+    return "\n".join(lines) + "\n"
+
+
+def harness_comparison_rows(results: list[dict[str, Any]]) -> list[list[str]]:
+    by_key: dict[tuple[str, str, str], dict[str, float]] = {}
+    for result in results:
+        cell = result["cell"]
+        key = (cell["model"], cell["effort"], cell["mcp_state"])
+        by_key.setdefault(key, {})[cell["harness"]] = result["scores"]["f1"]
+    rows = []
+    for (model, effort, mcp_state), values in sorted(by_key.items()):
+        if "native_cli" in values and "hermes" in values:
+            delta = values["hermes"] - values["native_cli"]
+            rows.append([model, effort, mcp_state, pct(values["native_cli"]), pct(values["hermes"]), f"{delta * 100:+.1f}pp"])
+    return rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "n/a"]]
+
+
+def mcp_impact_rows(results: list[dict[str, Any]]) -> list[list[str]]:
+    by_key: dict[tuple[str, str, str], dict[str, float]] = {}
+    for result in results:
+        cell = result["cell"]
+        key = (cell["model"], cell["harness"], cell["effort"])
+        by_key.setdefault(key, {})[cell["mcp_state"]] = result["scores"]["f1"]
+    rows = []
+    for (model, harness, effort), values in sorted(by_key.items()):
+        if "with_mcp" in values and "without_mcp" in values:
+            delta = values["with_mcp"] - values["without_mcp"]
+            rows.append([model, harness, effort, pct(values["without_mcp"]), pct(values["with_mcp"]), f"{delta * 100:+.1f}pp"])
+    return rows or [["n/a", "n/a", "n/a", "n/a", "n/a", "n/a"]]
+
+
+def effort_scaling_rows(results: list[dict[str, Any]]) -> list[list[str]]:
+    by_key: dict[tuple[str, str, str], list[tuple[str, float]]] = {}
+    for result in results:
+        cell = result["cell"]
+        key = (cell["model"], cell["harness"], cell["mcp_state"])
+        by_key.setdefault(key, []).append((cell["effort"], result["scores"]["f1"]))
+    rows = []
+    for (model, harness, mcp_state), values in sorted(by_key.items()):
+        if len(values) < 2:
+            continue
+        rendered = ", ".join(f"{effort}={pct(value)}" for effort, value in sorted(values))
+        rows.append([model, harness, mcp_state, rendered])
+    return rows or [["n/a", "n/a", "n/a", "n/a"]]
+
+
+def markdown_to_html(md: str) -> str:
+    """Render simple audit-style HTML from the generated Markdown."""
+    body_lines: list[str] = []
+    in_table = False
+    for line in md.splitlines():
+        if line.startswith("# "):
+            body_lines.append(f"<h1>{html.escape(line[2:])}</h1>")
+        elif line.startswith("## "):
+            if in_table:
+                body_lines.append("</tbody></table>")
+                in_table = False
+            body_lines.append(f"<h2>{html.escape(line[3:])}</h2>")
+        elif line.startswith("- "):
+            body_lines.append(f"<p>{html.escape(line)}</p>")
+        elif line.startswith("| "):
+            cells = [html.escape(part.strip()) for part in line.strip("|").split("|")]
+            if set(cells) == {"---"}:
+                continue
+            tag = "th" if not in_table else "td"
+            if not in_table:
+                body_lines.append("<table><thead><tr>" + "".join(f"<th>{cell}</th>" for cell in cells) + "</tr></thead><tbody>")
+                in_table = True
+            else:
+                body_lines.append("<tr>" + "".join(f"<{tag}>{cell}</{tag}>" for cell in cells) + "</tr>")
+        elif line.strip():
+            body_lines.append(f"<p>{html.escape(line)}</p>")
+    if in_table:
+        body_lines.append("</tbody></table>")
+    return """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Code Review Benchmark Matrix</title>
+<style>
+body{font-family:system-ui,sans-serif;line-height:1.45;max-width:1180px;margin:32px auto;padding:0 24px;color:#1f2933}
+h1{margin-bottom:8px}
+h2{margin-top:32px;border-bottom:1px solid #cbd2d9;padding-bottom:4px}
+table{border-collapse:collapse;width:100%;margin:16px 0 28px}
+th,td{border:1px solid #cbd2d9;padding:6px 8px;text-align:left;vertical-align:top}
+th{background:#eef2f6}
+td{font-variant-numeric:tabular-nums}
+p{margin:6px 0}
+</style>
+</head>
+<body>
+""" + "\n".join(body_lines) + "\n</body>\n</html>\n"
+
+
+def build_reports(out_dir: Path) -> tuple[Path, Path]:
+    """Generate REPORT.md and REPORT.html from per-cell JSON files."""
+    results = load_cell_results(out_dir)
+    md = build_markdown_report(results)
+    md_path = out_dir / "REPORT.md"
+    html_path = out_dir / "REPORT.html"
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(md, encoding="utf-8")
+    html_path.write_text(markdown_to_html(md), encoding="utf-8")
+    return md_path, html_path
+
+
+def print_dry_run(cells: list[Cell]) -> None:
+    """Print the requested matrix without running model calls."""
+    for cell in cells:
+        reason = unsupported_reason(cell)
+        status = "n/a" if reason else "run"
+        suffix = f" reason={reason}" if reason else ""
+        print(f"{status}: {cell.family}/{cell.model}/{cell.harness}/{cell.effort}-{cell.mcp_state}{suffix}")
+
+
+def _first_non_empty(*values: str | None) -> str | None:
+    for value in values:
+        if value:
+            return value
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--corpus", "--corpus-dir", dest="corpus_dir", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument("--out", "--out-dir", dest="out_dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--prompt", type=Path, default=DEFAULT_PROMPT_PATH)
+    parser.add_argument("--family", "--families", dest="families", help="Comma-separated families (default: all)")
+    parser.add_argument("--harness", "--harnesses", dest="harnesses", help="Comma-separated harnesses: native_cli,hermes")
+    parser.add_argument("--model", "--models", dest="models", help="Comma-separated model ids")
+    parser.add_argument("--effort", "--efforts", dest="efforts", help="Comma-separated efforts")
+    parser.add_argument("--mcp", "--mcp-states", dest="mcp_states", help="Comma-separated MCP states: with_mcp,without_mcp")
+    parser.add_argument("--case", "--cases", dest="cases", help="Comma-separated case ids")
+    parser.add_argument("--smoke", action="store_true", help="Run the smoke subset")
+    parser.add_argument("--dry-run", action="store_true", help="Print matrix without running")
+    parser.add_argument("--resume", action="store_true", help="Skip complete cell JSON files")
+    parser.add_argument("--max-parallel", type=int, default=4, help="Per-family parallelism")
+    parser.add_argument("--build-report-only", action="store_true", help="Only rebuild REPORT.md and REPORT.html")
+    args = parser.parse_args()
+
+    if args.build_report_only:
+        md_path, html_path = build_reports(args.out_dir)
+        print(f"Wrote {md_path}")
+        print(f"Wrote {html_path}")
+        return 0
+
+    families = parse_csv(args.families, FAMILIES)
+    harnesses = parse_csv(args.harnesses, HARNESSES)
+    models = parse_csv(args.models)
+    efforts = parse_csv(args.efforts)
+    mcp_states = parse_csv(args.mcp_states, MCP_STATES)
+    case_ids = parse_csv(args.cases)
+    smoke = args.smoke or bool(case_ids and not _first_non_empty(args.models, args.efforts, args.mcp_states))
+    cells = build_matrix(
+        families=families,
+        harnesses=harnesses,
+        models=models,
+        efforts=efforts,
+        mcp_states=mcp_states,
+        smoke=smoke,
+    )
+
+    if args.dry_run:
+        print_dry_run(cells)
+        return 0
+
+    prompt_template = args.prompt.read_text(encoding="utf-8")
+    cases = load_corpus(args.corpus_dir, case_ids=case_ids)
+    records = run_cells(
+        out_dir=args.out_dir,
+        cells=cells,
+        cases=cases,
+        prompt_template=prompt_template,
+        resume=args.resume,
+        max_parallel=args.max_parallel,
+    )
+    probe_path = write_probe_results(args.out_dir, records)
+    md_path, html_path = build_reports(args.out_dir)
+    print(f"Wrote {probe_path}")
+    print(f"Wrote {md_path}")
+    print(f"Wrote {html_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_code_review_benchmark.py
+++ b/tests/audit/test_code_review_benchmark.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import code_review_benchmark as bench
+
+
+def _write_case(tmp_path: Path, *, extra: str = "") -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    diff = corpus / "sample.diff"
+    diff.write_text("diff --git a/sample.py b/sample.py\n", encoding="utf-8")
+    case = corpus / "sample.yaml"
+    case.write_text(
+        f"""case_id: sample
+pr_number: 1
+title: Sample
+diff_path: sample.diff
+context: Test context.
+gold_findings:
+  - id: arg-max
+    severity: HIGH
+    category: security
+    location: sample.py
+    description: Test finding.
+{extra}""",
+        encoding="utf-8",
+    )
+    return case
+
+
+def test_cli_parses_single_cell_arguments() -> None:
+    families = bench.parse_csv("openai", bench.FAMILIES)
+    harnesses = bench.parse_csv("hermes", bench.HARNESSES)
+    cases = bench.parse_csv("pr-2031-activity-schema")
+
+    cells = bench.build_matrix(
+        families=families,
+        harnesses=harnesses,
+        models=None,
+        efforts=None,
+        mcp_states=None,
+        smoke=bool(cases),
+    )
+
+    assert cells == [bench.Cell("openai", "gpt-5.5", "hermes", "medium", "with_mcp")]
+
+
+def test_corpus_loader_rejects_malformed_yaml(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "bad.yaml").write_text("case_id: [unterminated\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="malformed YAML"):
+        bench.load_corpus(corpus)
+
+
+def test_corpus_loader_reads_valid_case(tmp_path: Path) -> None:
+    _write_case(tmp_path)
+
+    cases = bench.load_corpus(tmp_path / "corpus")
+
+    assert cases[0]["case_id"] == "sample"
+    assert cases[0]["gold_findings"][0]["severity"] == "HIGH"
+    assert "diff --git" in cases[0]["diff"]
+
+
+def test_scorer_returns_perfect_f1_for_perfect_match() -> None:
+    gold = {
+        "gold_findings": [
+            {
+                "id": "arg-max",
+                "severity": "HIGH",
+                "category": "security",
+                "location": "scripts/proxy.py",
+                "description": "Uses argv.",
+            }
+        ]
+    }
+    verdict = {
+        "findings": [
+            {
+                "id": "large-prompt-argv",
+                "severity": "HIGH",
+                "category": "security",
+                "location": "scripts/proxy.py:27",
+                "description": "Large prompts go through argv.",
+            }
+        ]
+    }
+
+    score = bench.score_case(verdict, gold)
+
+    assert score["precision"] == 1.0
+    assert score["recall"] == 1.0
+    assert score["f1"] == 1.0
+    assert score["catastrophic_misses"] == 0
+
+
+def test_scorer_returns_zero_f1_for_empty_model_output() -> None:
+    gold = {
+        "gold_findings": [
+            {
+                "id": "error-envelope",
+                "severity": "HIGH",
+                "category": "spec-compliance",
+                "location": "scripts/proxy.py",
+                "description": "Wrong envelope.",
+            }
+        ]
+    }
+
+    score = bench.score_case({"findings": []}, gold)
+
+    assert score["precision"] == 0.0
+    assert score["recall"] == 0.0
+    assert score["f1"] == 0.0
+    assert score["catastrophic_misses"] == 1
+
+
+def test_scorer_matches_file_not_line_and_rejects_wrong_severity() -> None:
+    gold = {
+        "gold_findings": [
+            {
+                "id": "healthz-fork",
+                "severity": "MEDIUM",
+                "category": "dos-surface",
+                "location": "scripts/proxy.py",
+                "description": "Forks on health checks.",
+            }
+        ]
+    }
+    verdict = {
+        "findings": [
+            {
+                "id": "health-check-dos",
+                "severity": "MEDIUM",
+                "category": "dos-surface",
+                "location": "scripts/proxy.py:999",
+                "description": "Same file, shifted line.",
+            },
+            {
+                "id": "health-check-low",
+                "severity": "LOW",
+                "category": "dos-surface",
+                "location": "scripts/proxy.py:10",
+                "description": "Wrong severity should not match.",
+            },
+        ]
+    }
+
+    score = bench.score_case(verdict, gold)
+
+    assert score["tp"] == 1
+    assert score["fp"] == 1
+    assert score["fn"] == 0
+    assert score["f1"] == 0.6667
+
+
+def test_run_cell_uses_injected_runner_and_writes_reportable_json(tmp_path: Path) -> None:
+    case_path = _write_case(tmp_path)
+    case = bench.load_case(case_path)
+    cell = bench.Cell("openai", "gpt-5.5", "native_cli", "medium", "with_mcp")
+
+    def runner(_cell: bench.Cell, _prompt: str) -> bench.HarnessCall:
+        payload = [
+            {
+                "id": "arg-max",
+                "severity": "HIGH",
+                "category": "security",
+                "location": "sample.py:1",
+                "description": "Test finding.",
+            }
+        ]
+        return bench.HarnessCall(True, json.dumps(payload), "", 0, 0.1, ("test",))
+
+    record = bench.run_cell(
+        out_dir=tmp_path / "out",
+        cell=cell,
+        cases=[case],
+        prompt_template="{DIFF}\n{CONTEXT}",
+        harness_runner=runner,
+    )
+
+    assert record["scores"]["f1"] == 1.0
+    assert bench.cell_path(tmp_path / "out", cell).exists()


### PR DESCRIPTION
## Summary

- Add `scripts/audit/code_review_benchmark.py`, a matrix-style PR-diff review benchmark harness modeled on `judge_calibration_matrix.py`.
- Add a 3-case starter corpus under `audit/code-review-benchmark/corpus/` with PR diffs and gold findings.
- Add `review-v1.txt` prompt template and focused scorer/CLI tests.

## Verification

| Claim | Tool + raw output |
|---|---|
| Harness exists | `ls -la scripts/audit/code_review_benchmark.py` -> `-rw-r--r-- 1 krisztiankoos staff 42276 May 16 18:52 scripts/audit/code_review_benchmark.py` |
| Corpus has 3 cases | `ls audit/code-review-benchmark/corpus/*.yaml` -> `pr-2025-openai-proxy.yaml`, `pr-2031-activity-schema.yaml`, `pr-2038-m20-three-fixes.yaml` |
| Tests pass | `.venv/bin/pytest tests/audit/test_code_review_benchmark.py -v` -> `============================== 7 passed in 0.30s ==============================` |
| Lint clean | `.venv/bin/ruff check scripts/audit/code_review_benchmark.py tests/audit/test_code_review_benchmark.py` -> `All checks passed!` |
| Smoke run completes | `.venv/bin/python scripts/audit/code_review_benchmark.py --corpus audit/code-review-benchmark/corpus --out audit/2026-05-17-code-review-benchmark-smoke --family openai --harness hermes --case pr-2031-activity-schema` -> wrote `probe-results.jsonl`, `REPORT.md`, `REPORT.html`; summary line: `- Best F1: 0.0% (gpt-5.5 / hermes)` |
| Trailer audit | `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.` |

Smoke output was not committed; it was only used to validate the pipeline.
