### PR TITLE
feat(audit): evidence-retrieval infrastructure + H1 calibration archive (PROD prompt unchanged)

### DIFF
--- a/audit/2026-05-17-judge-calibration-h1/COMPARISON.md
+++ b/audit/2026-05-17-judge-calibration-h1/COMPARISON.md
@@ -1,0 +1,100 @@
+# H1 Before/After Comparison — Evidence-Rich Judge Prompt
+
+**Date:** 2026-05-17
+**Baseline:** `audit/2026-05-17-judge-calibration-matrix/`
+**H1:** `audit/2026-05-17-judge-calibration-h1/`
+**Same 12-case calibration set** (`eval/russianism/calibration-cases.jsonl` on `origin/pr-2006`).
+
+## Headline
+
+**Hypothesis on the canonical-greeting false positive: CONFIRMED.**
+All three cells that previously false-flagged `cal_clean_greeting` ("Доброго дня! Як ваші справи?…") now correctly output CLEAN.
+
+**Hypothesis on net F1: FALSIFIED.**
+F1 collapsed on every cell because the strict cite-or-forbid rule made all judges output CLEAN on most dirty cases. Precision is now 1.0 (no false flags survive the citation requirement) but recall fell from a baseline mean of ~0.65 to a uniform 0.06–0.13.
+
+## Per-cell deltas
+
+| Cell | Prior F1 | H1 F1 | ΔF1 | Prior P | H1 P | ΔP | Prior R | H1 R | ΔR | Prior case_acc | H1 case_acc | Δacc | Prior greeting | H1 greeting |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|:---:|
+| opus-4.7 xhigh+mcp        | 0.839 | 0.118 | **−0.721** | 0.867 | 1.000 | +0.133 | 0.813 | 0.063 | **−0.750** | 0.917 | 0.500 | −0.417 | ✗ FP | ✓ CLEAN |
+| opus-4.7 high −mcp        | 0.828 | 0.118 | **−0.710** | 0.923 | 1.000 | +0.077 | 0.750 | 0.063 | **−0.687** | 0.917 | 0.583 | −0.334 | ✗ FP | ✓ CLEAN |
+| haiku-4.5 high −mcp       | 0.546 | 0.118 | **−0.428** | 1.000 | 1.000 |  0.000 | 0.375 | 0.063 | **−0.312** | 0.750 | 0.500 | −0.250 | ✓ CLEAN | ✓ CLEAN |
+| gpt-5.5 medium +mcp       | 0.720 | 0.118 | **−0.602** | 1.000 | 1.000 |  0.000 | 0.563 | 0.063 | **−0.500** | 1.000 | 0.500 | −0.500 | ✓ CLEAN | ✓ CLEAN |
+| gemini-3.1-pro default+mcp| 0.800 | 0.222 | **−0.578** | 0.857 | 1.000 | +0.143 | 0.750 | 0.125 | **−0.625** | 0.917 | 0.583 | −0.334 | ✗ FP | ✓ CLEAN |
+| grok-4.3 hermes xhigh+mcp | 0.786 | 0.118 | **−0.668** | 0.917 | 1.000 | +0.083 | 0.688 | 0.063 | **−0.625** | 1.000 | 0.500 | −0.500 | ✓ CLEAN | ✓ CLEAN |
+
+(Greeting columns: `✗ FP` = judge incorrectly flagged "Доброго дня…" as Russianism. `✓ CLEAN` = correctly judged clean.)
+
+## Greeting FP outcome (the specific motivation)
+
+Quoting the per-case judgments via `jq`:
+
+| Cell | Prior `cal_clean_greeting.case_acc` | H1 `cal_clean_greeting.case_acc` |
+|---|:---:|:---:|
+| opus-4.7 xhigh+mcp | `false` | `true` |
+| opus-4.7 high −mcp | `false` | `true` |
+| gemini-3.1-pro default+mcp | `false` | `true` |
+
+Three FPs eliminated. The inverted CLEAN-by-default opener + explicit anti-flag rule for "Доброго дня! Як ваші справи?" + token-level Grinchenko/ESUM attestation (вас, гаразд, усе) all reinforced the correct verdict.
+
+## Why F1 collapsed — evidence-anchor scarcity on this case set
+
+Profiling `retrieve_evidence` over all 12 calibration cases:
+
+```
+cal_clean_greeting             CLEAN         ant=0 vu=0 rs=0 her=3
+cal_clean_short_prose          CLEAN         ant=0 vu=0 rs=0 her=4
+cal_clean_travel               CLEAN         ant=0 vu=0 rs=0 her=1
+cal_clean_workplace            CLEAN         ant=0 vu=0 rs=0 her=3
+cal_dirty_email_calques        DIRTY (4)     ant=0 vu=0 rs=0 her=1   ← 0 anchors
+cal_dirty_medical              DIRTY (3)     ant=0 vu=1 rs=0 her=3   ← 1 anchor (`прийом`)
+cal_dirty_workplace            DIRTY (2)     ant=0 vu=0 rs=0 her=4   ← 0 anchors
+cal_dirty_meetup               DIRTY (2)     ant=0 vu=0 rs=0 her=2   ← 0 anchors
+cal_dirty_register             DIRTY (2)     ant=0 vu=0 rs=0 her=2   ← 0 anchors
+cal_debatable_next_steps       DIRTY (1)     ant=0 vu=0 rs=0 her=3   ← 0 anchors
+cal_clean_with_lure            CLEAN         ant=0 vu=0 rs=0 her=2
+cal_dirty_business_meeting     DIRTY (2)     ant=0 vu=1 rs=0 her=0   ← 1 anchor (`слідуючим`)
+```
+
+`ant`=Antonenko entries; `vu`=VESUM-unknown tokens; `rs`=Russian-shadow morphology hits; `her`=token-level heritage attestation.
+
+Of the 8 dirty cases (16 expected flags total at sev≥2), only **2 cases** had ANY evidence anchor under the H1 strict rules, and those anchors covered only **2 of the 16 expected flags**. The H1 prompt forbids unsupported flags, so the judge correctly defaulted to CLEAN on the other 6 dirty cases — yielding the floor `tp=1, fp=0, fn=15` → P=1.0, R=0.0625, F1=0.118 that 5 of 6 models hit exactly. Gemini caught one extra anchor (medical `прийом`) for F1=0.222.
+
+This is **not a model failure**. Every model behaved identically and correctly under the rules. The bottleneck is the evidence catalog:
+- **Antonenko** (279 entries indexed of ~600 — issue #1663) — keyed on isolated headwords; misses none of these phrasings.
+- **VESUM** correctly contains nearly every Ukrainian-morphology calque (e.g. `повістка`, `обставини`, `звертайтеся`) — they ARE valid Ukrainian forms morphologically; the russianism is pragmatic / register / phraseological.
+- **Russian-shadow** (pymorphy3 over non-VESUM tokens) — fires only on tokens like `спасибо`, `пожалуйста` — outright Russian, not present in this calibration set.
+
+Practical conclusion: the H1 design is well-suited to **morphological** russianism detection. It is structurally unable to detect the **lexical/phraseological/register** calques that dominate this 12-case calibration set.
+
+## Surprises
+
+1. **Five of six models converged on identical numbers** (F1=0.118, P=1.0, R=0.0625, exactly 1 tp). The strict cite-or-forbid rule is more determinative than model intelligence — the bottleneck is the evidence floor, not the model's reasoning.
+
+2. **Opus's case_acc actually DROPPED** despite the FP fix (0.917 → 0.500) because the prior over-flagging was secretly carrying recall.
+
+3. **Haiku's prior recall (0.375) was already evidence-floor-limited** without any prompt change. Haiku H1 matches the others exactly, suggesting Haiku was already roughly at the evidence-anchored floor.
+
+## Decision implications
+
+- **Don't ship this prompt as-is for production reviewer use.** Recall is too low for routing decisions.
+- **The H1 design IS valuable for**: surfaces where a single false-flag is more harmful than a missed flag — e.g. user-visible content rejection, where a clean-greeting FP would block correct output. Precision = 1.0 is meaningful when over-flagging is the failure mode.
+- **Next experiment (H2):** add a fourth evidence channel for phraseological calques — either (a) a curated list of high-confidence calque phrases (повістка дня, забір крові, наступним питанням) checked against the text, or (b) a register-evidence channel that gives the judge license to flag based on cited Antonenko style-guide register rules even when no headword directly matches the input. Option (b) reopens hallucination risk and needs careful prompting.
+- **The proper-noun filter (added during this experiment) was crucial.** Without it, `Львова` (Lviv-gen, missing from VESUM common-form table) would have been a fake russianism candidate on `cal_clean_travel`, regressing a previously-clean case into a false positive across all models.
+
+## Errors
+
+0 errors across all 6 cells. All judges returned parseable JSON.
+
+```
+$ for f in audit/2026-05-17-judge-calibration-h1/*/*/*/*.json; do
+    jq -r '"\(input_filename): errors=\(.raw_telemetry.errors | length)"' "$f"
+  done | sort -u
+audit/.../anthropic/claude-haiku-4-5-20251001/native_cli/high-without_mcp.json: errors=0
+audit/.../anthropic/claude-opus-4-7/native_cli/high-without_mcp.json: errors=0
+audit/.../anthropic/claude-opus-4-7/native_cli/xhigh-with_mcp.json: errors=0
+audit/.../google/gemini-3.1-pro-preview/native_cli/default-with_mcp.json: errors=0
+audit/.../openai/gpt-5.5/native_cli/medium-with_mcp.json: errors=0
+audit/.../xai/grok-4.3/hermes/xhigh-with_mcp.json: errors=0
+```

--- a/audit/2026-05-17-judge-calibration-h1/REPORT.html
+++ b/audit/2026-05-17-judge-calibration-h1/REPORT.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Russianism Judge Calibration Matrix</title>
+<style>
+body{font-family:system-ui,sans-serif;line-height:1.45;max-width:1180px;margin:32px auto;padding:0 24px;color:#1f2933}
+h1{margin-bottom:8px}
+h2{margin-top:32px;border-bottom:1px solid #cbd2d9;padding-bottom:4px}
+table{border-collapse:collapse;width:100%;margin:16px 0 28px}
+th,td{border:1px solid #cbd2d9;padding:6px 8px;text-align:left;vertical-align:top}
+th{background:#eef2f6}
+td{font-variant-numeric:tabular-nums}
+p{margin:6px 0}
+</style>
+</head>
+<body>
+<h1>Russianism Judge Calibration Matrix</h1>
+<p>Generated: 2026-05-16T19:37:48Z</p>
+<h2>Summary</h2>
+<p>- Cells scored: 6</p>
+<p>- Cells n/a: 0</p>
+<p>- Cells with harness errors: 0</p>
+<h2>Leaderboard</h2>
+<table><thead><tr><th>family</th><th>model</th><th>harness</th><th>effort</th><th>mcp_state</th><th>F1</th><th>P</th><th>R</th><th>case_acc</th><th>avg_dur</th><th>n/a-count</th></tr></thead><tbody>
+<tr><td>google</td><td>gemini-3.1-pro-preview</td><td>native_cli</td><td>default</td><td>with_mcp</td><td>22.2%</td><td>100.0%</td><td>12.5%</td><td>58.3%</td><td>113.2s</td><td>0</td></tr>
+<tr><td>anthropic</td><td>claude-haiku-4-5-20251001</td><td>native_cli</td><td>high</td><td>without_mcp</td><td>11.8%</td><td>100.0%</td><td>6.2%</td><td>50.0%</td><td>100.5s</td><td>0</td></tr>
+<tr><td>anthropic</td><td>claude-opus-4-7</td><td>native_cli</td><td>high</td><td>without_mcp</td><td>11.8%</td><td>100.0%</td><td>6.2%</td><td>58.3%</td><td>44.7s</td><td>0</td></tr>
+<tr><td>anthropic</td><td>claude-opus-4-7</td><td>native_cli</td><td>xhigh</td><td>with_mcp</td><td>11.8%</td><td>100.0%</td><td>6.2%</td><td>50.0%</td><td>53.7s</td><td>0</td></tr>
+<tr><td>openai</td><td>gpt-5.5</td><td>native_cli</td><td>medium</td><td>with_mcp</td><td>11.8%</td><td>100.0%</td><td>6.2%</td><td>50.0%</td><td>102.9s</td><td>0</td></tr>
+<tr><td>xai</td><td>grok-4.3</td><td>hermes</td><td>xhigh</td><td>with_mcp</td><td>11.8%</td><td>100.0%</td><td>6.2%</td><td>50.0%</td><td>86.1s</td><td>0</td></tr>
+</tbody></table>
+<h2>Harness Comparison</h2>
+<table><thead><tr><th>model</th><th>effort</th><th>mcp_state</th><th>native_cli F1</th><th>hermes F1</th><th>delta</th></tr></thead><tbody>
+<tr><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td></tr>
+</tbody></table>
+<h2>MCP Impact</h2>
+<table><thead><tr><th>model</th><th>harness</th><th>effort</th><th>without case_acc</th><th>with case_acc</th><th>delta</th></tr></thead><tbody>
+<tr><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td></tr>
+</tbody></table>
+<h2>Effort Scaling</h2>
+<table><thead><tr><th>model</th><th>harness</th><th>mcp_state</th><th>F1 by effort</th></tr></thead><tbody>
+<tr><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td></tr>
+</tbody></table>
+<h2>Failure Log</h2>
+<table><thead><tr><th>family</th><th>model</th><th>harness</th><th>effort</th><th>mcp_state</th><th>reason</th></tr></thead><tbody>
+<tr><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td><td>n/a</td><td>none</td></tr>
+</tbody></table>
+</body>
+</html>

--- a/audit/2026-05-17-judge-calibration-h1/REPORT.md
+++ b/audit/2026-05-17-judge-calibration-h1/REPORT.md
@@ -1,0 +1,44 @@
+# Russianism Judge Calibration Matrix
+
+Generated: 2026-05-16T19:37:48Z
+
+## Summary
+
+- Cells scored: 6
+- Cells n/a: 0
+- Cells with harness errors: 0
+
+## Leaderboard
+
+| family | model | harness | effort | mcp_state | F1 | P | R | case_acc | avg_dur | n/a-count |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| google | gemini-3.1-pro-preview | native_cli | default | with_mcp | 22.2% | 100.0% | 12.5% | 58.3% | 113.2s | 0 |
+| anthropic | claude-haiku-4-5-20251001 | native_cli | high | without_mcp | 11.8% | 100.0% | 6.2% | 50.0% | 100.5s | 0 |
+| anthropic | claude-opus-4-7 | native_cli | high | without_mcp | 11.8% | 100.0% | 6.2% | 58.3% | 44.7s | 0 |
+| anthropic | claude-opus-4-7 | native_cli | xhigh | with_mcp | 11.8% | 100.0% | 6.2% | 50.0% | 53.7s | 0 |
+| openai | gpt-5.5 | native_cli | medium | with_mcp | 11.8% | 100.0% | 6.2% | 50.0% | 102.9s | 0 |
+| xai | grok-4.3 | hermes | xhigh | with_mcp | 11.8% | 100.0% | 6.2% | 50.0% | 86.1s | 0 |
+
+## Harness Comparison
+
+| model | effort | mcp_state | native_cli F1 | hermes F1 | delta |
+| --- | --- | --- | --- | --- | --- |
+| n/a | n/a | n/a | n/a | n/a | n/a |
+
+## MCP Impact
+
+| model | harness | effort | without case_acc | with case_acc | delta |
+| --- | --- | --- | --- | --- | --- |
+| n/a | n/a | n/a | n/a | n/a | n/a |
+
+## Effort Scaling
+
+| model | harness | mcp_state | F1 by effort |
+| --- | --- | --- | --- |
+| n/a | n/a | n/a | n/a |
+
+## Failure Log
+
+| family | model | harness | effort | mcp_state | reason |
+| --- | --- | --- | --- | --- | --- |
+| n/a | n/a | n/a | n/a | n/a | none |

--- a/audit/2026-05-17-judge-calibration-h1/anthropic/claude-haiku-4-5-20251001/native_cli/high-without_mcp.json
+++ b/audit/2026-05-17-judge-calibration-h1/anthropic/claude-haiku-4-5-20251001/native_cli/high-without_mcp.json
@@ -1,0 +1,149 @@
+{
+  "cell": {
+    "family": "anthropic",
+    "model": "claude-haiku-4-5-20251001",
+    "harness": "native_cli",
+    "effort": "high",
+    "mcp_state": "without_mcp"
+  },
+  "started_at": "2026-05-16T19:36:07Z",
+  "finished_at": "2026-05-16T19:37:48Z",
+  "duration_s": 100.49,
+  "n_cases": 12,
+  "judgments": [
+    {
+      "case_id": "cal_clean_greeting",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_short_prose",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_travel",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_workplace",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_email_calques",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 4
+    },
+    {
+      "case_id": "cal_dirty_medical",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 3
+    },
+    {
+      "case_id": "cal_dirty_workplace",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_meetup",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_register",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_debatable_next_steps",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 1
+    },
+    {
+      "case_id": "cal_clean_with_lure",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 47,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_business_meeting",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 247,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 2
+    }
+  ],
+  "scores": {
+    "f1": 0.1176,
+    "case_acc": 0.5,
+    "precision": 1.0,
+    "recall": 0.0625
+  },
+  "raw_telemetry": {
+    "harness": "native_cli",
+    "harness_version": "2.1.143 (Claude Code)",
+    "model_id": "claude-haiku-4-5-20251001",
+    "effort_actual": "high",
+    "mcp_servers": [],
+    "errors": []
+  }
+}

--- a/audit/2026-05-17-judge-calibration-h1/anthropic/claude-opus-4-7/native_cli/high-without_mcp.json
+++ b/audit/2026-05-17-judge-calibration-h1/anthropic/claude-opus-4-7/native_cli/high-without_mcp.json
@@ -1,0 +1,149 @@
+{
+  "cell": {
+    "family": "anthropic",
+    "model": "claude-opus-4-7",
+    "harness": "native_cli",
+    "effort": "high",
+    "mcp_state": "without_mcp"
+  },
+  "started_at": "2026-05-16T19:35:55Z",
+  "finished_at": "2026-05-16T19:36:39Z",
+  "duration_s": 44.67,
+  "n_cases": 12,
+  "judgments": [
+    {
+      "case_id": "cal_clean_greeting",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_short_prose",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_travel",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_workplace",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_email_calques",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 4
+    },
+    {
+      "case_id": "cal_dirty_medical",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 242,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 3
+    },
+    {
+      "case_id": "cal_dirty_workplace",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_meetup",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_register",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_debatable_next_steps",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 1
+    },
+    {
+      "case_id": "cal_clean_with_lure",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_business_meeting",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 185,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 2
+    }
+  ],
+  "scores": {
+    "f1": 0.1176,
+    "case_acc": 0.5833,
+    "precision": 1.0,
+    "recall": 0.0625
+  },
+  "raw_telemetry": {
+    "harness": "native_cli",
+    "harness_version": "2.1.143 (Claude Code)",
+    "model_id": "claude-opus-4-7",
+    "effort_actual": "high",
+    "mcp_servers": [],
+    "errors": []
+  }
+}

--- a/audit/2026-05-17-judge-calibration-h1/anthropic/claude-opus-4-7/native_cli/xhigh-with_mcp.json
+++ b/audit/2026-05-17-judge-calibration-h1/anthropic/claude-opus-4-7/native_cli/xhigh-with_mcp.json
@@ -1,0 +1,151 @@
+{
+  "cell": {
+    "family": "anthropic",
+    "model": "claude-opus-4-7",
+    "harness": "native_cli",
+    "effort": "xhigh",
+    "mcp_state": "with_mcp"
+  },
+  "started_at": "2026-05-16T19:35:38Z",
+  "finished_at": "2026-05-16T19:36:31Z",
+  "duration_s": 53.66,
+  "n_cases": 12,
+  "judgments": [
+    {
+      "case_id": "cal_clean_greeting",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_short_prose",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_travel",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_workplace",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_email_calques",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 4
+    },
+    {
+      "case_id": "cal_dirty_medical",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 3
+    },
+    {
+      "case_id": "cal_dirty_workplace",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_meetup",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_register",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_debatable_next_steps",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 1
+    },
+    {
+      "case_id": "cal_clean_with_lure",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_business_meeting",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 173,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 2
+    }
+  ],
+  "scores": {
+    "f1": 0.1176,
+    "case_acc": 0.5,
+    "precision": 1.0,
+    "recall": 0.0625
+  },
+  "raw_telemetry": {
+    "harness": "native_cli",
+    "harness_version": "2.1.143 (Claude Code)",
+    "model_id": "claude-opus-4-7",
+    "effort_actual": "xhigh",
+    "mcp_servers": [
+      "sources"
+    ],
+    "errors": []
+  }
+}

--- a/audit/2026-05-17-judge-calibration-h1/google/gemini-3.1-pro-preview/native_cli/default-with_mcp.json
+++ b/audit/2026-05-17-judge-calibration-h1/google/gemini-3.1-pro-preview/native_cli/default-with_mcp.json
@@ -1,0 +1,151 @@
+{
+  "cell": {
+    "family": "google",
+    "model": "gemini-3.1-pro-preview",
+    "harness": "native_cli",
+    "effort": "default",
+    "mcp_state": "with_mcp"
+  },
+  "started_at": "2026-05-16T19:35:46Z",
+  "finished_at": "2026-05-16T19:37:40Z",
+  "duration_s": 113.18,
+  "n_cases": 12,
+  "judgments": [
+    {
+      "case_id": "cal_clean_greeting",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_short_prose",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_travel",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_workplace",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 41,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_email_calques",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 4
+    },
+    {
+      "case_id": "cal_dirty_medical",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 207,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 3
+    },
+    {
+      "case_id": "cal_dirty_workplace",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_meetup",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_register",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_debatable_next_steps",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 41,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 1
+    },
+    {
+      "case_id": "cal_clean_with_lure",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_business_meeting",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 181,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 2
+    }
+  ],
+  "scores": {
+    "f1": 0.2222,
+    "case_acc": 0.5833,
+    "precision": 1.0,
+    "recall": 0.125
+  },
+  "raw_telemetry": {
+    "harness": "native_cli",
+    "harness_version": "0.42.0",
+    "model_id": "gemini-3.1-pro-preview",
+    "effort_actual": "default",
+    "mcp_servers": [
+      "sources"
+    ],
+    "errors": []
+  }
+}

--- a/audit/2026-05-17-judge-calibration-h1/openai/gpt-5.5/native_cli/medium-with_mcp.json
+++ b/audit/2026-05-17-judge-calibration-h1/openai/gpt-5.5/native_cli/medium-with_mcp.json
@@ -1,0 +1,151 @@
+{
+  "cell": {
+    "family": "openai",
+    "model": "gpt-5.5",
+    "harness": "native_cli",
+    "effort": "medium",
+    "mcp_state": "with_mcp"
+  },
+  "started_at": "2026-05-16T19:35:42Z",
+  "finished_at": "2026-05-16T19:37:25Z",
+  "duration_s": 102.92,
+  "n_cases": 12,
+  "judgments": [
+    {
+      "case_id": "cal_clean_greeting",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 32,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_short_prose",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_travel",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 32,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_workplace",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 32,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_email_calques",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 32,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 4
+    },
+    {
+      "case_id": "cal_dirty_medical",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 3
+    },
+    {
+      "case_id": "cal_dirty_workplace",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 32,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_meetup",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_register",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_debatable_next_steps",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 1
+    },
+    {
+      "case_id": "cal_clean_with_lure",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 32,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_business_meeting",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 173,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 2
+    }
+  ],
+  "scores": {
+    "f1": 0.1176,
+    "case_acc": 0.5,
+    "precision": 1.0,
+    "recall": 0.0625
+  },
+  "raw_telemetry": {
+    "harness": "native_cli",
+    "harness_version": "codex-cli 0.130.0",
+    "model_id": "gpt-5.5",
+    "effort_actual": "medium",
+    "mcp_servers": [
+      "sources"
+    ],
+    "errors": []
+  }
+}

--- a/audit/2026-05-17-judge-calibration-h1/probe-results.jsonl
+++ b/audit/2026-05-17-judge-calibration-h1/probe-results.jsonl
@@ -1,0 +1,1 @@
+{"family": "anthropic", "model": "claude-haiku-4-5-20251001", "harness": "native_cli", "effort": "high", "mcp_state": "without_mcp", "result": "valid_response", "reason": null}

--- a/audit/2026-05-17-judge-calibration-h1/xai/grok-4.3/hermes/xhigh-with_mcp.json
+++ b/audit/2026-05-17-judge-calibration-h1/xai/grok-4.3/hermes/xhigh-with_mcp.json
@@ -1,0 +1,151 @@
+{
+  "cell": {
+    "family": "xai",
+    "model": "grok-4.3",
+    "harness": "hermes",
+    "effort": "xhigh",
+    "mcp_state": "with_mcp"
+  },
+  "started_at": "2026-05-16T19:35:50Z",
+  "finished_at": "2026-05-16T19:37:16Z",
+  "duration_s": 86.06,
+  "n_cases": 12,
+  "judgments": [
+    {
+      "case_id": "cal_clean_greeting",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_short_prose",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_travel",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_clean_workplace",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_email_calques",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 4
+    },
+    {
+      "case_id": "cal_dirty_medical",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 3
+    },
+    {
+      "case_id": "cal_dirty_workplace",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_meetup",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_dirty_register",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 2
+    },
+    {
+      "case_id": "cal_debatable_next_steps",
+      "true_label": "issues_found",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": false,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 1
+    },
+    {
+      "case_id": "cal_clean_with_lure",
+      "true_label": "clean",
+      "model_label": "clean",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 35,
+      "case_acc": true,
+      "judge_sev2_plus_count": 0,
+      "expected_flags_count": 0
+    },
+    {
+      "case_id": "cal_dirty_business_meeting",
+      "true_label": "issues_found",
+      "model_label": "issues_found",
+      "model_confidence": "unspecified",
+      "raw_response_chars": 190,
+      "case_acc": true,
+      "judge_sev2_plus_count": 1,
+      "expected_flags_count": 2
+    }
+  ],
+  "scores": {
+    "f1": 0.1176,
+    "case_acc": 0.5,
+    "precision": 1.0,
+    "recall": 0.0625
+  },
+  "raw_telemetry": {
+    "harness": "hermes",
+    "harness_version": "Hermes Agent v0.13.0 (2026.5.7)",
+    "model_id": "grok-4.3",
+    "effort_actual": "xhigh",
+    "mcp_servers": [
+      "sources"
+    ],
+    "errors": []
+  }
+}

--- a/scripts/audit/_judge_eval_lib.py
+++ b/scripts/audit/_judge_eval_lib.py
@@ -17,9 +17,12 @@ from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 DB = PROJECT_ROOT / "data" / "sources.db"
+VESUM_DB = PROJECT_ROOT / "data" / "vesum.db"
 
 PR_2006_REF = "origin/pr-2006"
 CALIBRATION_BLOB = "eval/russianism/calibration-cases.jsonl"
+
+CYRILLIC_TOKEN_RE = re.compile(r"[А-Яа-яҐґЄєІіЇї'’ʼ\-]+")
 
 
 def utc_timestamp() -> str:
@@ -97,8 +100,157 @@ def retrieve_antonenko(text: str, k: int = 8, *, db_path: Path = DB) -> list[dic
     ]
 
 
+def _text_tokens(text: str, *, min_len: int = 3) -> list[str]:
+    """Lowercased Cyrillic tokens of length >= ``min_len``, deduplicated, sorted."""
+    return sorted({m for m in (t.lower() for t in CYRILLIC_TOKEN_RE.findall(text)) if len(m) >= min_len})
+
+
+def _proper_noun_tokens(text: str) -> set[str]:
+    """Lowercased tokens that appear capitalized in non-sentence-initial position.
+
+    Used to exclude proper nouns from VESUM-unknown / Russian-shadow checks.
+    ``Львова`` (Lviv-gen) is morphologically valid Ukrainian but absent from
+    VESUM's common-form table, so a naive check creates fake Russianism
+    candidates on clean travel prose.
+    """
+    proper_nouns: set[str] = set()
+    sentence_boundary = True
+    for match in re.finditer(r"\S+", text):
+        token = match.group(0)
+        cyrillic_match = CYRILLIC_TOKEN_RE.match(token)
+        if cyrillic_match and cyrillic_match.group(0)[0].isupper() and not sentence_boundary:
+            proper_nouns.add(cyrillic_match.group(0).lower())
+        sentence_boundary = token[-1] in ".!?…"
+    return proper_nouns
+
+
+def _heritage_check(text: str, *, db_path: Path = DB) -> list[dict[str, Any]]:
+    """Tokens with attestation in Grinchenko (1907) or ESUM etymology.
+
+    Single-word attestation in pre-Soviet / etymological dictionaries is strong
+    evidence that the form is canonical Ukrainian, NOT a Russianism.
+    """
+    tokens = _text_tokens(text)
+    if not tokens:
+        return []
+    conn = sqlite3.connect(db_path)
+    try:
+        placeholders = ",".join("?" * len(tokens))
+        grinchenko = {
+            r[0].lower()
+            for r in conn.execute(
+                f"SELECT word FROM grinchenko WHERE lower(word) IN ({placeholders})",
+                tokens,
+            ).fetchall()
+        }
+        esum = {
+            r[0].lower()
+            for r in conn.execute(
+                f"SELECT lemma FROM esum_etymology WHERE lower(lemma) IN ({placeholders})",
+                tokens,
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+    attested = []
+    for token in tokens:
+        sources = []
+        if token in grinchenko:
+            sources.append("Grinchenko 1907")
+        if token in esum:
+            sources.append("ESUM etymology")
+        if sources:
+            attested.append({"token": token, "sources": sources})
+    return attested
+
+
+def _russian_shadow_check(text: str) -> dict[str, Any]:
+    """Run pymorphy3-based Russian-shadow heuristic over Cyrillic tokens.
+
+    Returns ``{"available": bool, "triggered_tokens": [{token, ru_lemma, confidence}]}``.
+    ``check_ru_morph.is_russian_pattern`` short-circuits on VESUM hits, so this
+    only fires on tokens that are NOT valid Ukrainian forms AND look Russian.
+    Proper nouns are excluded to avoid flagging place/person names.
+    """
+    try:
+        from scripts.verification.check_ru_morph import is_russian_pattern
+    except ImportError:
+        return {"available": False, "triggered_tokens": []}
+    proper_nouns = _proper_noun_tokens(text)
+    triggered = []
+    for token in _text_tokens(text):
+        if token in proper_nouns:
+            continue
+        try:
+            result = is_russian_pattern(token)
+        except Exception:
+            continue
+        if result.get("matches_russian"):
+            triggered.append(
+                {
+                    "token": token,
+                    "ru_lemma": result.get("russian_lemma"),
+                    "confidence": round(float(result.get("confidence", 0.0)), 2),
+                }
+            )
+    return {"available": True, "triggered_tokens": triggered}
+
+
+def _vesum_unknown(text: str, *, db_path: Path = VESUM_DB) -> list[str]:
+    """Cyrillic tokens NOT present in VESUM as a known word_form.
+
+    Proper nouns are excluded — place and person names are typically absent
+    from VESUM's common-form table even when morphologically valid Ukrainian.
+    """
+    tokens = _text_tokens(text)
+    if not tokens:
+        return []
+    if not db_path.exists():
+        return []
+    proper_nouns = _proper_noun_tokens(text)
+    candidate_tokens = [t for t in tokens if t not in proper_nouns]
+    if not candidate_tokens:
+        return []
+    conn = sqlite3.connect(db_path)
+    try:
+        placeholders = ",".join("?" * len(candidate_tokens))
+        known = {
+            r[0]
+            for r in conn.execute(
+                f"SELECT DISTINCT word_form FROM forms WHERE word_form IN ({placeholders})",
+                candidate_tokens,
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+    return sorted(set(candidate_tokens) - known)
+
+
+def retrieve_evidence(text: str) -> dict[str, Any]:
+    """Aggregate all evidence signals for one judge prompt.
+
+    Combines Antonenko-Davydovych entries (style guide), Grinchenko/ESUM
+    token attestation (heritage defense), pymorphy3 Russian-shadow morphology
+    detection, and VESUM-unknown token enumeration.
+    """
+    return {
+        "antonenko": retrieve_antonenko(text),
+        "heritage_attested": _heritage_check(text),
+        "russian_shadow": _russian_shadow_check(text),
+        "vesum_unknown_tokens": _vesum_unknown(text),
+    }
+
+
 def build_judge_prompt(target_text: str, antonenko_entries: list[dict[str, Any]]) -> str:
-    """Universal Russianism-judge prompt, identical across model families."""
+    """Universal Russianism-judge prompt, identical across model families.
+
+    Preserved at main as the production baseline. The H1 evidence-rich variant
+    documented in ``audit/2026-05-17-judge-calibration-h1/COMPARISON.md`` was
+    falsified on the current 12-case calibration set (recall collapsed because
+    the evidence catalog couldn't anchor 14 of 16 sev>=2 flags). The
+    ``retrieve_evidence`` helper below is preserved for H2c use (typed
+    calibration set authoring + per-channel coverage metrics).
+    """
     if antonenko_entries:
         rules_section = (
             "## Relevant Antonenko-Davydovych entries "


### PR DESCRIPTION
## Summary

**Rebased 2026-05-16 to drop the H1 \`build_judge_prompt\` rewrite.** The production prompt is unchanged at main; only the supporting infrastructure + the experiment archive ship.

What lands:
- New \`retrieve_evidence(text)\` aggregates 4 evidence channels: Antonenko entries + Grinchenko/ESUM token attestation + pymorphy3 Russian-shadow signal + VESUM-unknown tokens
- New helpers: \`_text_tokens\`, \`_proper_noun_tokens\` (Cyrillic NNP filter), \`_heritage_check\`, \`_russian_shadow_check\`, \`_vesum_unknown\`
- 6-cell H1 A/B run preserved at \`audit/2026-05-17-judge-calibration-h1/\` with full \`COMPARISON.md\`

What does NOT land (reverted from initial commit):
- \`build_judge_prompt\` body rewrite — kept at main's wording per the COMPARISON.md decision (recall collapsed across all 6 models due to evidence-anchor scarcity on the 12-case set)
- \`judge_calibration_matrix.py\` is back to calling \`retrieve_antonenko\`, not \`retrieve_evidence\` — production calibration baseline unchanged

## Why the rebase

H1 was an honest negative: ✅ canonical-greeting FP eliminated on 3 of 3 cells; ❌ net F1 collapsed from baseline ~0.65 to 0.118 on 5 of 6 cells. Root cause is the evidence catalog, not the prompt — only 2 of 12 calibration cases had ANY anchor under the strict cite-or-forbid rule, because the current calibration is dominated by lexical/phraseological/register calques that the morphology-and-style-guide channels can't anchor.

The path forward is H2c (typed calibration set) using \`retrieve_evidence\` to label per-case which channel SHOULD anchor each flag, giving us per-channel coverage metrics. This PR lands the infrastructure so H2c authoring can use it.

Full analysis in \`audit/2026-05-17-judge-calibration-h1/COMPARISON.md\`.

## Test plan

- [x] pytest tests/audit/ — 336 pass, 17 skip (skips pre-existing)
- [x] ruff check clean
- [x] smoke import: \`from scripts.audit._judge_eval_lib import build_judge_prompt, retrieve_antonenko, retrieve_evidence\` works
- [x] manual: read audit/2026-05-17-judge-calibration-h1/COMPARISON.md — honest negative documented
- [x] regression check: prod prompt unchanged at main version (\`build_judge_prompt\` body is byte-identical to pre-PR main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)