### PR TITLE
fix(audit): _judge_eval_lib sys.path shim — restore russian_shadow channel (#2050)

### DIFF
--- a/scripts/audit/_judge_eval_lib.py
+++ b/scripts/audit/_judge_eval_lib.py
@@ -16,6 +16,17 @@ from pathlib import Path
 from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Ensure cross-package absolute imports (e.g. `scripts.verification.*`) resolve
+# regardless of how this module is loaded. When the matrix runner is invoked
+# as `python scripts/audit/judge_calibration_matrix.py`, Python sets
+# `sys.path[0]` to `scripts/audit/`, so the absolute import
+# `from scripts.verification.check_ru_morph import is_russian_pattern` inside
+# `_russian_shadow_check` would raise `ModuleNotFoundError` without this
+# shim — silently disabling the Russian-shadow morphology channel. See #2050.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 DB = PROJECT_ROOT / "data" / "sources.db"
 VESUM_DB = PROJECT_ROOT / "data" / "vesum.db"
 UA_GEC_ROOT = PROJECT_ROOT / "data" / "ua-gec"
@@ -179,7 +190,17 @@ def _russian_shadow_check(text: str) -> dict[str, Any]:
     """
     try:
         from scripts.verification.check_ru_morph import is_russian_pattern
-    except ImportError:
+    except ImportError as exc:
+        # Silent-disable is the existing contract (the channel renders as
+        # "(pymorphy3 unavailable in this environment)" in the prompt),
+        # but the failure must be visible in CLI output so missing/broken
+        # installs do not bias future calibration runs.
+        print(
+            f"[_judge_eval_lib._russian_shadow_check] ImportError: {exc}; "
+            "channel will render as 'pymorphy3 unavailable'. Fix sys.path "
+            "or install pymorphy3 to restore the russian_shadow signal.",
+            file=sys.stderr,
+        )
         return {"available": False, "triggered_tokens": []}
     proper_nouns = _proper_noun_tokens(text)
     triggered = []

--- a/tests/audit/test_russian_shadow_channel_alive.py
+++ b/tests/audit/test_russian_shadow_channel_alive.py
@@ -1,0 +1,103 @@
+"""Regression test for #2050.
+
+The russian_shadow channel inside ``_judge_eval_lib._russian_shadow_check``
+silently went dead in both the H1 (PR #2046) and H2 (PR #2049) calibration
+runs because `from scripts.verification.check_ru_morph import is_russian_pattern`
+raises ``ModuleNotFoundError`` when the entry-point script
+``scripts/audit/judge_calibration_matrix.py`` is invoked with
+``python scripts/audit/judge_calibration_matrix.py`` (Python sets
+``sys.path[0]`` to ``scripts/audit/``, not the repo root). The bare
+``except ImportError`` swallowed the failure and the prompt rendered
+``(pymorphy3 unavailable in this environment)``.
+
+The fix is a module-level ``sys.path`` shim in ``_judge_eval_lib.py`` that
+inserts ``PROJECT_ROOT`` so absolute imports resolve regardless of how the
+module is loaded. This test reproduces the exact bug scenario: it spawns a
+subprocess whose ``cwd`` is ``scripts/audit/`` and verifies the channel
+imports + fires on a token that is unambiguously Russian.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _has_pymorphy3() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("pymorphy3") is not None
+
+
+@pytest.mark.skipif(
+    not _has_pymorphy3(),
+    reason="pymorphy3 not installed; russian_shadow channel cannot be tested at all",
+)
+def test_russian_shadow_channel_alive_in_process() -> None:
+    """In-process import — the module-level sys.path shim makes the absolute
+    `scripts.verification.check_ru_morph` import resolve."""
+    from scripts.audit._judge_eval_lib import _russian_shadow_check
+
+    result = _russian_shadow_check("спасибо")
+    assert result["available"] is True, (
+        "russian_shadow channel reported unavailable; sys.path shim did not "
+        "make `scripts.verification.check_ru_morph` importable. See #2050."
+    )
+    # `спасибо` is a Russian-only common word; pymorphy3 RU should match it.
+    triggered = result["triggered_tokens"]
+    assert triggered, (
+        "russian_shadow channel imported but did not fire on `спасибо`; "
+        "expected at least one triggered token. Got: " + repr(result)
+    )
+
+
+@pytest.mark.skipif(
+    not _has_pymorphy3(),
+    reason="pymorphy3 not installed; russian_shadow channel cannot be tested at all",
+)
+def test_russian_shadow_channel_alive_from_audit_cwd() -> None:
+    """Reproduce the exact #2050 bug scenario: subprocess launched with
+    cwd=`scripts/audit/`, simulating `python scripts/audit/<runner>.py`
+    where `sys.path[0]` becomes `scripts/audit/`."""
+    audit_dir = PROJECT_ROOT / "scripts" / "audit"
+    assert audit_dir.is_dir(), f"scripts/audit not found at {audit_dir}"
+
+    # Strip PYTHONPATH so the subprocess doesn't inherit repo-root from the
+    # pytest invocation; otherwise the shim wouldn't be exercised.
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+
+    script = (
+        "import sys, json;"
+        "from _judge_eval_lib import _russian_shadow_check;"
+        "result = _russian_shadow_check('спасибо');"
+        "print(json.dumps(result))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(audit_dir),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"subprocess failed (rc={proc.returncode}). "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    import json as _json
+    result = _json.loads(proc.stdout.splitlines()[-1])
+    assert result["available"] is True, (
+        "russian_shadow channel reported unavailable when run from "
+        "scripts/audit/ — the #2050 sys.path bug is back. "
+        f"subprocess stderr={proc.stderr!r}"
+    )
+    assert result["triggered_tokens"], (
+        "russian_shadow channel imported but did not fire on `спасибо` "
+        f"from audit cwd. Got: {result!r}"
+    )


### PR DESCRIPTION
## Summary

- Module-level `sys.path` shim in `scripts/audit/_judge_eval_lib.py` so absolute imports (e.g. `scripts.verification.check_ru_morph`) resolve regardless of how the module is loaded
- Stderr log on the `ImportError` branch of `_russian_shadow_check` so future regressions surface instead of hiding inside the prompt
- Regression test `tests/audit/test_russian_shadow_channel_alive.py` reproduces the exact #2050 bug scenario via a subprocess with `cwd=scripts/audit/` + stripped `PYTHONPATH`

## Why this matters

Both the H1 (PR #2046) and H2 (PR #2049) Russianism judge calibration runs rendered the russian_shadow channel as `(pymorphy3 unavailable in this environment)` despite pymorphy3 being installed locally. The channel was the only signal that catches outright Russian-form tokens (e.g. `спасибо`, `пожалуйста`) that aren't VESUM-unknown — without it, those flags silently fall back to `general_principle` (judge intuition), which is the failure mode H1/H2 were trying to eliminate.

## Test plan

- [x] `pytest tests/audit/test_russian_shadow_channel_alive.py -v` → 2 passed
- [x] `pytest tests/audit/test_judge_eval_lib_h2.py tests/audit/test_judge_calibration_matrix.py tests/audit/test_russian_shadow_channel_alive.py -v` → 8 passed, 7 pre-existing skipped
- [x] `ruff check scripts/audit/_judge_eval_lib.py tests/audit/test_russian_shadow_channel_alive.py` → All checks passed!
- [ ] Next calibration matrix run (H3) verifies the channel renders as `(no Russian-pattern tokens)` or with real hits, not `(pymorphy3 unavailable)`

Closes #2050

🤖 Generated with [Claude Code](https://claude.com/claude-code)