### PR TITLE
feat(agents): integrate grok into ab discuss + delegate.py dispatch

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -74,6 +74,7 @@ VALID_AGENTS = (
     "claude",
     "gemini",
     "codex",
+    "grok",
     "claude-desktop",
     "codex-desktop",
 )

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -67,7 +67,7 @@ def _cli_available_agent(agent: str) -> bool:
     try:
         from agent_runtime.registry import get_agent_entry
     except ImportError:
-        return agent in {"claude", "codex", "gemini"}
+        return agent in {"claude", "codex", "gemini", "grok"}
 
     try:
         return bool(get_agent_entry(agent)["cli_available"])

--- a/scripts/audit/lint_agent_trailer.py
+++ b/scripts/audit/lint_agent_trailer.py
@@ -68,7 +68,7 @@ import subprocess
 import sys
 
 _TRAILER_RE = re.compile(
-    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
+    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|grok|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
     re.MULTILINE,
 )
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1527,8 +1527,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fire a task, return immediately",
         formatter_class=_dispatch_help_formatter,
     )
-    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude"],
-                   help="Agent to run for the task: codex, gemini, or claude.")
+    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude", "grok"],
+                   help="Agent to run for the task: codex, gemini, claude, or grok.")
     d.add_argument("--task-id", required=True,
                    help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -569,7 +569,12 @@ def test_inbox_run_once_processes_one_thread(monkeypatch, capsys):
 def test_sync_all_iterates_known_agents(monkeypatch, capsys):
     for agent in _channels.VALID_AGENTS:
         _make_thread(agent, channel=f"{agent}-topic", count=1)
-    cli_agents = ["claude", "gemini", "codex"]
+    # Mirrors the live `cmd_sync --all` iteration order, which is
+    # `[agent for agent in _channels.VALID_AGENTS if _cli_available_agent(agent)]`.
+    # When a new CLI agent is registered (e.g. grok via #1934), this list
+    # tracks the registry — the test guards the iteration order, not a
+    # frozen subset.
+    cli_agents = ["claude", "gemini", "codex", "grok"]
 
     calls: list[tuple[str, dict[str, object]]] = []
 

--- a/tests/test_grok_integration.py
+++ b/tests/test_grok_integration.py
@@ -1,0 +1,106 @@
+"""Integration test surfaces for Grok in delegate.py / ab discuss / lint.
+
+The agent runtime registry already exposes ``grok`` via
+``scripts/agent_runtime/registry.py`` (HermesGrokAdapter, ``cli_available:
+True``). What was missing was the surface integration so the user could
+actually invoke it from the orchestration tools the rest of the project
+uses. These tests pin the surface allowlists so future churn cannot
+silently strip ``grok`` from any of them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_registry_exposes_grok():
+    """The agent_runtime registry is the canonical source of truth — every
+    surface allowlist tested below must consult it (directly or via the
+    fallback). If grok ever falls out of the registry, all the other tests
+    in this module also stop being meaningful."""
+    # Importing under tests/ may not have scripts/ on path; install it.
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from agent_runtime.registry import AGENTS, available_agents
+
+    assert "grok" in AGENTS, "grok must be in agent_runtime.registry.AGENTS"
+    assert AGENTS["grok"]["cli_available"] is True
+    assert "grok" in available_agents()
+
+
+def test_delegate_dispatch_accepts_grok_agent():
+    """``delegate.py dispatch --agent grok ...`` must parse without error.
+
+    We use ``--dry-run`` so the subprocess only validates argparse and
+    returns the task-id without actually spawning a worker. A non-zero
+    exit here means argparse rejected ``grok`` from the choices list.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / "delegate.py"),
+            "dispatch",
+            "--agent", "grok",
+            "--task-id", "test-grok-argparse-probe",
+            "--prompt", "noop",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(_REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"delegate dispatch --agent grok failed:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "test-grok-argparse-probe" in result.stdout
+
+
+def test_ab_channels_valid_agents_includes_grok():
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from ai_agent_bridge import _channels
+
+    importlib.reload(_channels)
+    assert "grok" in _channels.VALID_AGENTS
+
+
+def test_ab_channels_cli_marks_grok_cli_available():
+    """``ab discuss`` requires the agent to be CLI-spawnable.
+
+    The fallback set (used when agent_runtime is unimportable) must also
+    list grok so the discuss command doesn't refuse it in degraded
+    environments.
+    """
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from ai_agent_bridge import _channels_cli
+
+    assert _channels_cli._cli_available_agent("grok") is True
+
+
+def test_lint_agent_trailer_accepts_grok():
+    """Commits authored by ``grok`` dispatches must pass the X-Agent
+    trailer linter. The committer email is identical for every agent
+    (the user's local git config), so the trailer is the only way to
+    attribute provenance — if grok isn't on the allowed list, every
+    grok-authored PR fails CI."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from audit.lint_agent_trailer import _TRAILER_RE
+
+    sample = "X-Agent: grok/2026-05-17-integration"
+    match = _TRAILER_RE.search(sample)
+    assert match is not None, "lint_agent_trailer rejected grok-authored trailer"
+    assert match.group("agent") == "grok"
+    assert match.group("task") == "2026-05-17-integration"


### PR DESCRIPTION
## Summary

The agent runtime registry has carried a complete `grok` entry since #1934 (HermesGrokAdapter, `cli_available: True`, default model `grok-4.3`). What was missing was the **surface integration** so the user could actually invoke grok from the orchestration tools the rest of the project uses every day.

After this PR:

- `ab discuss <channel> --with grok,codex,gemini` — works.
- `delegate.py dispatch --agent grok --task-id X` — works.

Both ride the existing `runtime_invoke` infrastructure that already talks to `HermesGrokAdapter`. The only thing standing in the way was four argparse/allowlist edits.

## Changes

- `scripts/delegate.py` — `"grok"` added to the dispatch `--agent` choices.
- `scripts/ai_agent_bridge/_channels.py` — `"grok"` added to `VALID_AGENTS` (canonical bridge-side allowlist).
- `scripts/ai_agent_bridge/_channels_cli.py` — registry-unavailable fallback set includes `"grok"`.
- `scripts/audit/lint_agent_trailer.py` — `grok` accepted as a valid `X-Agent:` trailer authority (without this every grok-authored PR fails CI).
- `tests/test_bridge_inbox_cli.py::test_sync_all_iterates_known_agents` — updated to track the registry rather than a frozen subset.
- `tests/test_grok_integration.py` — new pin for each surface allowlist + `delegate.py dispatch --dry-run` argparse smoke (5 tests).

## Verification

```
delegate.py dispatch --agent grok --task-id grok-cli-integration-probe \
    --prompt noop --dry-run
# -> "grok-cli-integration-probe"

pytest tests/test_grok_integration.py \
       tests/test_bridge_inbox_cli.py::test_sync_all_iterates_known_agents \
       tests/test_agent_runtime.py \
       tests/agent_runtime/adapters/test_hermes_grok_adapter.py
# -> 146 passed in 33.14s

hermes -z "Привіт. Скажи 'OK_GROK_PROBE' одним словом." -m grok-4.3
# -> OK_GROK_PROBE  (auth healthy)
```

## Out of scope (follow-ups)

- `ask-grok` subparser + dedicated `_grok.py` bridge module — discuss covers the multi-agent path and dispatch covers the execution path, which is the user's stated bar (handoff `2026-05-17-late-night-m20-fixes-plus-grok-integration.md`).
- Documenting Grok's role/lane in `docs/best-practices/agent-cooperation.md` — separate docs PR.

## Test plan

- [x] Local pytest suite — 146 green
- [x] Local argparse smoke for delegate.py
- [x] Hermes auth probe — OK
- [ ] End-to-end: `delegate.py dispatch --agent grok --task-id grok-probe --prompt "Reply with the string OK_GROK_PROBE" --mode danger --worktree` — open PR via grok
- [ ] End-to-end: `ab discuss evidence-layer-unification-2026-05-17 "Round 3 follow-up: Grok's vote?" --with grok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)