### PR TITLE
fix(audit): whitelist Лобел/Квак/Кнак from Захарійчук Grade 1 textbook

### DIFF
--- a/scripts/audit/config.py
+++ b/scripts/audit/config.py
@@ -46,6 +46,17 @@ PROPER_NAME_WHITELIST: set[str] = {
     # forms included so citations like "За Караманом" or "у Карамана"
     # don't re-trip the VESUM gate (PR #1603 review).
     "Караман", "Карамана", "Караманом", "Караману", "Карамані",
+    # Added 2026-05-17: textbook character names + translator surname
+    # surfaced by the A1/m20 (`my-morning`) rebuild after PR #2068's
+    # citation-matcher fix unblocked textbook_grounding. The Захарійчук
+    # Grade 1 p.24 passage ("за Арнольдом Лобелом") cites Arnold Lobel,
+    # and the Ukrainian-translated Frog & Toad characters `Квак` and
+    # `Кнак` are dialogue characters in the same excerpt. All declined
+    # forms included so the writer can address or reference them in
+    # any case without re-tripping the VESUM gate.
+    "Лобел", "Лобела", "Лобеле", "Лобелу", "Лобелі", "Лобелем", "Лобелом",
+    "Квак", "Квака", "Кваку", "Кваком", "Кваче",
+    "Кнак", "Кнака", "Кнаку", "Кнаком", "Кначе",
     # Common abbreviations and brand names
     "ІТ", "ЗНО", "НМТ", "ЄС", "ООН", "НАТО", "ЗСУ",
     "МійКлас",


### PR DESCRIPTION
## Summary

Follow-up to PR #2068 (the citation_matcher transliteration fix unblocked m20's textbook_grounding). The m20 rebuild reduced VESUM misses 9 → 1; the single remaining token is `Кнак` — a fictional frog character from the Захарійчук Grade 1 p.24 excerpt the writer correctly quoted.

This PR whitelists three families of proper nouns from that same Захарійчук passage:

- **Лобел** + declined forms — Arnold Lobel (the original author the textbook attributes via "за Арнольдом Лобелом"). Both instrumental variants `Лобелем`/`Лобелом` included; both are grammatically valid Ukrainian.
- **Квак** + declined forms — Frog character from the Ukrainian translation of Lobel's *Frog and Toad*. Cited in the p.24 plan-list: "Піти до Квака. Прогулятися з Кваком."
- **Кнак** + declined forms — Toad character (the speaker: "— мовило жабеня Кнак").

VESUM does not contain fictional-character names; the whitelist is the right surface for these. Pattern follows the 2026-04-26 addition for `Караман` (PR #1603 review).

## Test plan

- [x] `pytest tests/test_textbook_grounding.py tests/test_citation_matcher.py` → 19 passed.
- [x] Whitelist membership verified for `Кнак`, `Квак`, `Лобел`, `Лобелом`, `Лобелем`, `Кнаком`.
- [ ] After merge: rebuild a1/my-morning under Monitor — `vesum_verified` expected to drop missing_count 1 → 0; module should ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)