### PR TITLE
docs(dispatch-briefs): 2026-05-17 tech-debt drain wave (#2027, #2030, #2047)

### DIFF
--- a/docs/dispatch-briefs/2026-05-17-code-review-matcher-jaccard.md
+++ b/docs/dispatch-briefs/2026-05-17-code-review-matcher-jaccard.md
@@ -1,0 +1,125 @@
+# Dispatch: fix code-review benchmark semantic matcher false negatives (#2047)
+
+## Why this matters
+
+`scripts/audit/code_review_benchmark.py` scores LLM code-review runs.
+PR #2043 added semantic matching (category + Jaccard 0.4) but the
+2026-05-16 18:55 run on `pr-2025-openai-proxy` STILL scored
+opus-4-7/xhigh/native_cli at 0% F1 — despite the model emitting a
+verbatim correct finding (`prompt-on-command-line-leak-and-arg-max-dos`
+matches gold `arg-max`).
+
+Result: the leaderboard systematically under-rates higher-effort
+models that produce verbose, descriptive findings — the harness is
+measuring its own matcher's narrowness, not model quality. Mirror of
+the #1900 rollout-matcher class of bug.
+
+The gold corpus refresh (#2042) just landed in PR #2075 with widened
+ids/aliases. This dispatch fixes the MATCHER itself to honor those
+widened aliases AND lower the Jaccard threshold for verbose findings.
+
+## Files
+
+- `scripts/audit/code_review_benchmark.py` — the matcher. Read first;
+  understand the current category + location + Jaccard chain before
+  editing.
+- `audit/code_review_benchmark/gold/*.yaml` (or wherever — see #2042
+  for actual paths). DO NOT modify gold — that was #2042's scope.
+- `tests/test_code_review_benchmark.py` (if it exists; otherwise
+  create alongside the matcher).
+- One concrete failing model output to test against:
+  `audit/2026-05-17-code-review-benchmark-expansion-2/<path>/claude-opus-4-7/native_cli/xhigh-with_mcp.json`.
+
+## What to do (verifiable steps)
+
+1. **Worktree setup.** You were spawned with `--worktree`; cite
+   `git rev-parse --show-toplevel` + `git branch --show-current` raw.
+
+2. **Read the matcher.** Quote the current priority order from
+   `code_review_benchmark.py` — specifically the category-match,
+   location-match, and Jaccard-threshold logic.
+
+3. **Reproduce the 0% F1.** Load the
+   `xhigh-with_mcp.json` for `pr-2025-openai-proxy`, find the
+   `prompt-on-command-line-leak-and-arg-max-dos` finding, and run
+   the matcher against the gold corpus for that PR. Confirm
+   `matched_gold_ids: []`. Quote the matcher's category + location +
+   Jaccard scores for the model finding vs gold `arg-max`.
+
+4. **Diagnose WHICH of the 3 hypotheses applies** (issue body lists
+   them). The diagnosis must be backed by a quoted snippet of:
+   - the model finding's category, location, description
+   - the gold finding's category, location, description
+   - the matcher's per-pair Jaccard score (instrument it briefly to
+     log this)
+
+5. **Pick the fix.** Three options ordered cheapest → most-defensible:
+   - **A. Lower Jaccard threshold** from 0.4 → 0.25.
+     Cheap. But risks false positives — a finding about "argparse"
+     might match a gold about "argument validation" without being
+     semantically the same. Quantify by re-running ≥3 other model
+     cells and showing F1 doesn't degrade.
+   - **B. Use the new gold aliases** from PR #2075's corpus refresh
+     so descriptive ids like `prompt-on-command-line-leak-and-arg-max-dos`
+     resolve via alias lookup before Jaccard ever runs.
+   - **C. LLM-as-judge for borderline cases** (Jaccard in [0.25, 0.4]).
+     Heaviest; defer to follow-up unless A+B together are insufficient.
+
+   B is most defensible — the matcher should consume the schema that
+   #2042 just shipped. Implement B; only fall back to A if alias
+   coverage from #2042 is sparse.
+
+6. **Test.**
+   - Add `tests/test_code_review_benchmark.py` (or extend) with a
+     parametrized test that runs each of the 3 affected
+     opus-xhigh/native_cli cells through the matcher and asserts
+     `F1 > 0.0` (or whatever the realistic floor is given the corpus).
+   - Run the full pytest subset: `tests/test_code_review*` or similar.
+
+7. **Re-score the 3 affected cells.** Run the benchmark replay against
+   the existing raw JSON outputs (no LLM re-call needed; the JSON is
+   on disk). Quote the new F1 per cell.
+
+8. **Commit + push + PR.**
+   ```
+   fix(audit): code-review matcher respects gold aliases (#2047)
+   ```
+   PR body must include:
+   - the diagnosis quote pair (model finding vs gold finding)
+   - the chosen fix variant and rationale
+   - before/after F1 per cell (3 cells)
+   - the new pytest pass summary line
+   - `Closes #2047`
+
+## Verifiable claims required in the PR body
+
+Per `docs/best-practices/deterministic-over-hallucination.md`:
+
+| Claim | Evidence |
+|---|---|
+| "Diagnosis confirmed" | quoted pair of finding records + matcher's per-pair Jaccard |
+| "Matcher updated to use aliases" | per-method diff snippet from `code_review_benchmark.py` |
+| "F1 improved on 3 cells" | raw 3-cell F1 before/after table |
+| "Regression test pinned" | raw pytest output: `N passed in M.MMs` |
+
+## Out of scope
+
+- DO NOT modify gold corpus (audit/code_review_benchmark/gold/) —
+  that was PR #2075. Treat it as input.
+- DO NOT add new benchmark cases.
+- DO NOT re-call the LLMs to regenerate model outputs; replay against
+  the existing JSON in audit/2026-05-17-code-review-benchmark-expansion-2/.
+
+## Acceptance
+
+- PR opens with raw evidence
+- `Test (pytest)` CI required check passes
+- Regression test added covering at least one of the 3 affected cells
+- Closes #2047
+
+## Pointers
+
+- Issue: `gh issue view 2047`
+- Predecessor PRs: #2043 (initial matcher), #2075 (gold refresh)
+- Related: #1900 (rollout-matcher class)
+- Trailer: every commit gets `X-Agent: codex/2047-matcher-aliases`

--- a/docs/dispatch-briefs/2026-05-17-proxy-allow-remote-guard.md
+++ b/docs/dispatch-briefs/2026-05-17-proxy-allow-remote-guard.md
@@ -1,0 +1,84 @@
+# Dispatch: --host non-localhost guard for openai proxy (#2030)
+
+## Why this matters
+
+`ab serve --openai --host 0.0.0.0` silently binds the unauthenticated
+proxy to all interfaces. Phase 1 was explicitly localhost-only, no
+auth. Anyone on the LAN can hit four agent CLIs through this proxy if
+the user forgets the implication of `--host`.
+
+Severity LOW per the audit (default is safe; only triggers with
+explicit override), but it's a security ergonomics gap that's easy to
+close.
+
+## Files
+
+- `scripts/ai_agent_bridge/_cli.py` — argparse for the `serve` /
+  `serve --openai` subcommand. The `--host` flag and its handler.
+- `tests/ai_agent_bridge/` — find the existing serve-command tests
+  with `grep -rln "serve.*--host" tests/`.
+
+## What to do (verifiable steps)
+
+1. **Worktree setup.** Cite `git rev-parse --show-toplevel` +
+   `git branch --show-current` raw output.
+
+2. **Reproduce.** From the worktree:
+   ```bash
+   cd /Users/krisztiankoos/projects/learn-ukrainian
+   .venv/bin/python scripts/ai_agent_bridge/__main__.py serve --openai --host 0.0.0.0 --help
+   # observe: --host is accepted without warning
+   cd -
+   ```
+   Quote the raw output.
+
+3. **Add the guard.** Mirror the issue's recommended snippet. Add a
+   `--allow-remote` boolean flag (default False) to the serve
+   subparser. After argparse parses, before the proxy binds:
+   ```python
+   if args.host != "127.0.0.1" and not args.allow_remote:
+       parser.error(
+           "refusing to bind to non-localhost host without --allow-remote. "
+           "the proxy has no auth and exposes 4 agent CLIs to anyone on the network."
+       )
+   ```
+   Keep the message clear about WHY.
+
+4. **Test.**
+   - Add a test: `ab serve --openai --host 0.0.0.0` exits non-zero
+     with the error message.
+   - Add a test: `ab serve --openai --host 0.0.0.0 --allow-remote`
+     does not exit (mock the bind step; just verify the guard passes).
+   - Add a test: `ab serve --openai` (default 127.0.0.1) does not
+     require the flag.
+
+5. **Commit + push + PR.**
+   ```
+   fix(bridge/proxy): require --allow-remote for non-localhost bind (#2030)
+   ```
+
+## Verifiable claims required in the PR body
+
+| Claim | Evidence |
+|---|---|
+| "Reproduced unsafe bind pre-fix" | raw `serve --host 0.0.0.0 --help` output |
+| "Guard rejects unguarded non-localhost" | raw pytest output for the rejection test |
+| "Guard allows localhost without flag" | raw pytest output for the localhost test |
+| "Guard allows non-localhost with flag" | raw pytest output for the opt-in test |
+
+## Out of scope
+
+- Don't add proxy auth (out of scope, would be a separate Phase 2).
+- Don't change the default host. Don't touch other serve flags.
+
+## Acceptance
+
+- PR opens; 3 new tests; raw evidence in body
+- `Test (pytest)` CI required check passes
+- Closes #2030
+
+## Pointers
+
+- Issue: `gh issue view 2030`
+- Original bundle (hung): `proxy-bundle-2026-05-17` — #2027/#2028/#2029/#2030 are split.
+- Trailer: every commit gets `X-Agent: gemini/2030-proxy-allow-remote`

--- a/docs/dispatch-briefs/2026-05-17-proxy-arg-max-stdin.md
+++ b/docs/dispatch-briefs/2026-05-17-proxy-arg-max-stdin.md
@@ -1,0 +1,103 @@
+# Dispatch: fix ARG_MAX/E2BIG by passing prompt via stdin (#2027)
+
+## Why this matters
+
+`scripts/ai_agent_bridge/openai_proxy.py` passes the full flattened
+prompt as an argv flag (`--prompt=...`, `--oneshot=...`) to the
+underlying CLI for all three backends (`_gemini_backend`,
+`_claude_backend`, `_hermes_backend`). On macOS argv is bounded at
+~256 KB; Linux varies 128 KB–2 MB. Real OpenAI clients send 100K+
+token prompts that EASILY exceed this. Result: subprocess crashes at
+spawn with `OSError [Errno 7] Argument list too long`, which the proxy
+surfaces as HTTP 502.
+
+This is a HIGH-severity proxy bug surfaced by Gemini's adversarial
+review of PR #2025 (audit/2026-05-16-openai-proxy-gemini-review/REPORT.md).
+
+## Files
+
+- `scripts/ai_agent_bridge/openai_proxy.py` lines ~150-230 (the three
+  `_*_backend` functions). Confirm exact line numbers — file may have
+  shifted since the audit.
+- `tests/ai_agent_bridge/test_openai_proxy.py` (or wherever the proxy
+  tests live; `find tests -name 'test_*openai*proxy*'`).
+
+## What to do (verifiable steps)
+
+1. **Worktree setup.** You were spawned with `--worktree`; verify
+   `git rev-parse --show-toplevel` + `git branch --show-current` and
+   cite raw output.
+
+2. **Reproduce the failure.** From the worktree:
+   ```bash
+   cd /Users/krisztiankoos/projects/learn-ukrainian
+   # start the proxy if not already up
+   PROMPT=$(python3 -c "print('x' * 300000)")
+   curl -sX POST http://127.0.0.1:8767/v1/chat/completions \
+     -H 'content-type: application/json' \
+     -d "{\"model\":\"gemini-3.1-pro-preview\",\"messages\":[{\"role\":\"user\",\"content\":\"$PROMPT\"}]}" | head -c 500
+   cd -  # back to worktree
+   ```
+   Quote the raw 502 response (or whatever error you get).
+
+3. **Refactor.** For each of the 3 backends, change the prompt-passing
+   pattern from `--flag=PROMPT` to **stdin**:
+   - Pass an empty/short positional prompt, or use the CLI's
+     `--stdin` mode (check each tool's `--help`).
+   - Feed `prompt` via `subprocess.run(input=prompt, ...)`.
+
+   Each CLI's stdin mode differs — check `gemini --help`, `claude --help`,
+   `hermes --help`. The right flag is usually `--stdin`, `-`, or
+   bare omission of the prompt flag.
+
+4. **Add a regression test.** New `tests/ai_agent_bridge/test_openai_proxy_arg_max.py`
+   with one parametrized test per backend that:
+   - Constructs a 300KB prompt.
+   - Mocks the subprocess call to capture argv + stdin payload.
+   - Asserts `prompt not in any argv element` (no argv leak).
+   - Asserts `prompt == captured stdin`.
+
+5. **Verify.** Run the failing curl reproduction again — should now
+   return a real completion (or rate-limit error from the underlying
+   API, NOT a 502 spawn-failure). Quote the raw output.
+
+6. **Commit + push + PR.**
+   ```
+   fix(bridge/proxy): pass prompt via stdin to avoid ARG_MAX (#2027)
+   ```
+   PR body includes per-backend before/after argv snippet + the curl
+   reproduction outputs (before: 502, after: real reply). Closes #2027.
+
+## Verifiable claims required in the PR body
+
+Per `docs/best-practices/deterministic-over-hallucination.md`:
+
+| Claim | Evidence |
+|---|---|
+| "Reproduced ARG_MAX failure pre-fix" | raw curl + 502 response |
+| "Three backends refactored to stdin" | per-backend diff snippet (3 entries) |
+| "Reproduction succeeds post-fix" | raw curl + non-502 response |
+| "Regression test pinned" | raw pytest output: `N passed in M.MMs` for the new test |
+
+## Out of scope
+
+- DO NOT touch the other 3 issues bundled in the original
+  proxy-bundle dispatch (#2028 422 envelope, #2029 /healthz DoS,
+  #2030 --host non-localhost). They will be separate PRs. Each issue
+  one PR keeps review small and rollback granular.
+- DO NOT change the proxy's auth, routing, or model-mapping logic.
+
+## Acceptance
+
+- PR opens; body includes the raw evidence lines above
+- `Test (pytest)` CI required check passes
+- Regression test added
+- Closes #2027
+
+## Pointers
+
+- Issue: `gh issue view 2027`
+- Original bundle (hung): `proxy-bundle-2026-05-17` (silence_timeout
+  with response_chars=0; per #2071 likely environmental — re-fire one
+  scope at a time)
+- Trailer: every commit gets `X-Agent: codex/2027-proxy-stdin-fix`


### PR DESCRIPTION
## Summary

Three dispatch briefs from tonight's tech-debt drain wave:

- `2026-05-17-proxy-arg-max-stdin.md` — `2027-proxy-stdin-fix` (Codex, running)
- `2026-05-17-proxy-allow-remote-guard.md` — `2030-proxy-allow-remote` (PR #2078 merged ✅)
- `2026-05-17-code-review-matcher-jaccard.md` — `2047-matcher-aliases` (Codex, running)

Pure docs PR — the project record of briefs should mirror the dispatches. Mirrors the convention established by PR #2076 for `dagger-pre-push-fix.md` / `rapidfuzz-pre-commit-env-fix.md` / `codereview-gold-corpus-refresh.md`.

## Test plan

- [x] Docs-only (no code)
- [x] All three briefs pass `lint_dispatch_brief.py` (no `.venv/bin/python` outside cd-to-main fences, no `pytest -x`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)