### PR TITLE
fix(bridge/proxy): pass prompt via stdin to avoid ARG_MAX (#2027)

### DIFF
--- a/scripts/ai_agent_bridge/_hermes_stdin.py
+++ b/scripts/ai_agent_bridge/_hermes_stdin.py
@@ -1,0 +1,21 @@
+"""Run Hermes oneshot mode with the user prompt supplied on stdin."""
+
+from __future__ import annotations
+
+import sys
+
+from hermes_cli.oneshot import run_oneshot
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        sys.stderr.write("usage: scripts.ai_agent_bridge._hermes_stdin MODEL\n")
+        return 2
+
+    prompt = sys.stdin.read()
+    return run_oneshot(prompt, model=args[0])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -7,6 +7,8 @@ model listing, non-streaming chat completions, and a cheap health probe.
 from __future__ import annotations
 
 import os
+import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -24,6 +26,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from ._config import _PARENT_ENV, CLAUDE_CMD, CODEX_CLI, GEMINI_CLI, REPO_ROOT
 
 _DEFAULT_BACKEND_TIMEOUT_S = 120
+_HERMES_STDIN_MODULE = "scripts.ai_agent_bridge._hermes_stdin"
+_SHELL_EXEC_RE = re.compile(r"^\s*exec\s+")
 
 
 class Message(BaseModel):
@@ -145,6 +149,57 @@ def _run_backend_command(
     return result
 
 
+def _python_argv_for_console_script(executable: str, seen: set[Path] | None = None) -> list[str] | None:
+    path = Path(shutil.which(executable) or executable).expanduser()
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+
+    seen = set() if seen is None else seen
+    if resolved in seen:
+        return None
+    seen.add(resolved)
+
+    try:
+        text = resolved.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    lines = text.splitlines()
+    if lines and lines[0].startswith("#!"):
+        shebang = shlex.split(lines[0][2:].strip())
+        if shebang:
+            command_name = Path(shebang[0]).name
+            if command_name == "env" and len(shebang) > 1 and "python" in Path(shebang[1]).name:
+                return shebang
+            if "python" in command_name:
+                return shebang
+
+    for line in lines[:10]:
+        if not _SHELL_EXEC_RE.match(line):
+            continue
+        try:
+            parts = shlex.split(line)
+        except ValueError:
+            continue
+        if len(parts) >= 3 and parts[0] == "exec" and "$@" in parts[2:]:
+            nested = Path(parts[1])
+            if not nested.is_absolute():
+                nested = resolved.parent / nested
+            return _python_argv_for_console_script(str(nested), seen)
+
+    return None
+
+
+def _hermes_python_argv() -> list[str]:
+    hermes = shutil.which("hermes") or "hermes"
+    python_argv = _python_argv_for_console_script(hermes)
+    if python_argv is None:
+        raise OSError(f"could not resolve Python interpreter for Hermes executable: {hermes}")
+    return python_argv
+
+
 def _codex_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
     prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
     codex_model = os.environ.get("BRIDGE_PROXY_CODEX_MODEL", "gpt-5.5")
@@ -187,11 +242,10 @@ def _gemini_backend(model: str, messages: list[Message], **kwargs: Any) -> Compl
         GEMINI_CLI,
         "-m",
         model,
-        f"--prompt={prompt}",
         "--approval-mode",
         "plan",
     ]
-    result = _run_backend_command("gemini", argv)
+    result = _run_backend_command("gemini", argv, prompt=prompt)
     return CompletionResponse(content=result.stdout.strip())
 
 
@@ -203,22 +257,22 @@ def _claude_backend(model: str, messages: list[Message], **kwargs: Any) -> Compl
         "--bare",
         "--model",
         model,
-        "--",
-        prompt,
+        "--input-format",
+        "text",
     ]
-    result = _run_backend_command("claude", argv)
+    result = _run_backend_command("claude", argv, prompt=prompt)
     return CompletionResponse(content=result.stdout.strip())
 
 
 def _hermes_backend(model: str, messages: list[Message], **kwargs: Any) -> CompletionResponse:
     prompt = str(kwargs.get("prompt") or _flatten_messages(messages))
     argv = [
-        shutil.which("hermes") or "hermes",
-        f"--oneshot={prompt}",
+        *_hermes_python_argv(),
         "-m",
+        _HERMES_STDIN_MODULE,
         model,
     ]
-    result = _run_backend_command("hermes", argv)
+    result = _run_backend_command("hermes", argv, prompt=prompt)
     return CompletionResponse(content=result.stdout.strip())
 
 

--- a/tests/ai_agent_bridge/test_openai_proxy_arg_max.py
+++ b/tests/ai_agent_bridge/test_openai_proxy_arg_max.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+
+import pytest
+
+from scripts.ai_agent_bridge import openai_proxy as proxy
+
+
+@pytest.mark.parametrize(
+    ("backend", "model"),
+    [
+        (proxy._gemini_backend, "gemini-3.1-pro-preview"),
+        (proxy._claude_backend, "claude-sonnet-4-7"),
+        (proxy._hermes_backend, "grok-4.3"),
+    ],
+)
+def test_large_prompt_is_passed_via_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: Callable[..., proxy.CompletionResponse],
+    model: str,
+) -> None:
+    prompt = "x" * 300_000
+    captured: dict[str, object] = {}
+
+    def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        captured["input"] = kwargs.get("input")
+        return subprocess.CompletedProcess(argv, 0, stdout="backend response\n", stderr="")
+
+    monkeypatch.setattr(proxy.subprocess, "run", fake_run)
+    monkeypatch.setattr(proxy, "_hermes_python_argv", lambda: ["hermes-python"])
+
+    completion = backend(model, [], prompt=prompt)
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert completion.content == "backend response"
+    assert captured["input"] == prompt
+    assert all(prompt not in str(item) for item in argv)


### PR DESCRIPTION
Closes #2027

## Summary

- Passes flattened prompts to Gemini, Claude, and Hermes through `subprocess.run(input=prompt, ...)` instead of argv.
- Keeps Gemini and Claude on their native stdin/headless paths.
- Adds a small Hermes stdin runner because current `hermes --help` exposes `--oneshot/--query` prompt arguments but no stdin prompt flag.
- Adds a 300 KB regression test that captures subprocess argv and stdin for all three backends.

## Worktree Evidence

```text
$ git rev-parse --show-toplevel
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/2027-proxy-stdin-fix

$ git branch --show-current
codex/2027-proxy-stdin-fix
```

## Backend Argv Before/After

Gemini:

```text
Before: [GEMINI_CLI, "-m", model, f"--prompt={prompt}", "--approval-mode", "plan"]
After:  [GEMINI_CLI, "-m", model, "--approval-mode", "plan"]
        _run_backend_command("gemini", argv, prompt=prompt)
```

Claude:

```text
Before: [*CLAUDE_CMD, "--print", "--bare", "--model", model, "--", prompt]
After:  [*CLAUDE_CMD, "--print", "--bare", "--model", model, "--input-format", "text"]
        _run_backend_command("claude", argv, prompt=prompt)
```

Hermes:

```text
Before: [shutil.which("hermes") or "hermes", f"--oneshot={prompt}", "-m", model]
After:  [*_hermes_python_argv(), "-m", "scripts.ai_agent_bridge._hermes_stdin", model]
        _run_backend_command("hermes", argv, prompt=prompt)
```

## Reproduction Evidence

This host reports a larger argv ceiling than the dispatch note, so the requested 300 KB live curl does not fail locally. I used 1.2 MB to cross the observed local limit while keeping the regression test pinned at 300 KB.

```text
$ getconf ARG_MAX
1048576
```

Pre-fix, using the HEAD version of `openai_proxy.py` loaded in memory on an unused high port:

```text
$ curl -sS -m 30 -X POST http://127.0.0.1:18768/v1/chat/completions \
  -H 'content-type: application/json' --data-binary @- -w '\nHTTP %{http_code}\n'
{"error":{"message":"google-gemini backend failed: [Errno 7] Argument list too long: '/opt/homebrew/bin/gemini'","type":"upstream_error","code":"backend_failed"}}
HTTP 502
```

Post-fix, same 1.2 MB request against the patched proxy on an unused high port:

```text
$ curl -sS -m 180 -X POST http://127.0.0.1:18767/v1/chat/completions \
  -H 'content-type: application/json' --data-binary @- -w '\nHTTP %{http_code}\n'
{"id":"chatcmpl-f640670a-d7f4-4e12-a905-cdf4db1a5134","object":"chat.completion","created":1778979428,"model":"gemini-3.1-pro-preview","choices":[{"index":0,"message":{"role":"assistant","content":"It looks like you've sent a very long string of characters. If this was intentional, please let me know how I can help you with it. If it was a mistake, feel free to send your actual question or request, and I'll be happy to assist!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tok
HTTP 200
```

## Tests

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/ai_agent_bridge/test_openai_proxy_arg_max.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/2027-proxy-stdin-fix
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collected 3 items

tests/ai_agent_bridge/test_openai_proxy_arg_max.py ...                   [100%]

============================== 3 passed in 0.20s ===============================
```

Additional local checks:

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/ai_agent_bridge/test_openai_proxy.py tests/ai_agent_bridge/test_openai_proxy_arg_max.py -q
============================== 14 passed in 0.21s ==============================

$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/ai_agent_bridge/openai_proxy.py scripts/ai_agent_bridge/_hermes_stdin.py tests/ai_agent_bridge/test_openai_proxy_arg_max.py
All checks passed!

$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
