### PR TITLE
fix(audit): code-review matcher respects gold aliases (#2047)

### DIFF
--- a/scripts/audit/code_review_benchmark.py
+++ b/scripts/audit/code_review_benchmark.py
@@ -39,6 +39,8 @@ MCP_STATES = ("with_mcp", "without_mcp")
 SEVERITIES = ("HIGH", "MEDIUM", "LOW")
 SEVERITY_ORDER = {"LOW": 0, "MEDIUM": 1, "HIGH": 2}
 RAW_RESPONSE_TRUNCATE = 8000
+LOCATION_DESCRIPTION_JACCARD_THRESHOLD = 0.12
+DESCRIPTION_JACCARD_THRESHOLD = 0.4
 TOKEN_STOPWORDS = {
     "the",
     "a",
@@ -120,6 +122,7 @@ REQUIRED_CASE_KEYS = {
     "gold_findings",
 }
 REQUIRED_FINDING_KEYS = {"id", "severity", "category", "location", "description"}
+LOCATION_FILE_RE = re.compile(r"[\w./-]+\.[A-Za-z0-9_]+")
 
 
 @dataclass(frozen=True)
@@ -241,13 +244,19 @@ def _validate_finding(raw: Any, *, source: Path) -> dict[str, Any]:
     severity = str(raw["severity"]).upper()
     if severity not in SEVERITIES:
         raise ValueError(f"{source}: invalid severity {raw['severity']!r}")
-    return {
+    finding = {
         "id": str(raw["id"]),
         "severity": severity,
         "category": str(raw["category"]),
         "location": str(raw["location"]),
         "description": str(raw["description"]),
     }
+    aliases = raw.get("aliases", [])
+    if aliases:
+        if not isinstance(aliases, list):
+            raise ValueError(f"{source}: gold finding aliases must be a list")
+        finding["aliases"] = [str(alias) for alias in aliases]
+    return finding
 
 
 def _resolve_diff_path(yaml_path: Path, diff_path: str) -> Path:
@@ -581,6 +590,9 @@ def verdict_from_call(call: HarnessCall) -> dict[str, Any]:
 
 def location_file(location: Any) -> str:
     """Normalize a finding location to file-level granularity."""
+    files = location_files(location)
+    if files:
+        return files[0]
     raw = str(location or "").strip()
     if not raw:
         return ""
@@ -591,10 +603,50 @@ def location_file(location: Any) -> str:
     return raw
 
 
+def location_files(location: Any) -> list[str]:
+    """Return file paths mentioned in a finding location, preserving order."""
+    raw = str(location or "").strip()
+    if not raw:
+        return []
+    files: list[str] = []
+    seen: set[str] = set()
+    for match in LOCATION_FILE_RE.finditer(raw):
+        file_path = match.group(0)
+        if file_path not in seen:
+            files.append(file_path)
+            seen.add(file_path)
+    return files
+
+
 def _tokenize(s: Any) -> list[str]:
     """Split text into normalized content tokens for lightweight similarity."""
     toks = re.findall(r"\w{3,}", str(s or "").lower())
     return [token for token in toks if token not in TOKEN_STOPWORDS]
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    return len(left & right) / max(len(left | right), 1)
+
+
+def _normalize_finding_id(raw: Any) -> str:
+    """Normalize model/gold finding identifiers for alias matching."""
+    return re.sub(r"[^a-z0-9]+", "-", str(raw or "").strip().casefold()).strip("-")
+
+
+def _finding_identifiers(finding: dict[str, Any]) -> set[str]:
+    identifiers = {_normalize_finding_id(finding.get("id"))}
+    aliases = finding.get("aliases", [])
+    if isinstance(aliases, list):
+        identifiers.update(_normalize_finding_id(alias) for alias in aliases)
+    identifiers.discard("")
+    return identifiers
+
+
+def _identifier_tokens(finding: dict[str, Any]) -> set[str]:
+    tokens: set[str] = set()
+    for identifier in _finding_identifiers(finding):
+        tokens.update(token for token in identifier.split("-") if len(token) >= 3 and token not in TOKEN_STOPWORDS)
+    return tokens
 
 
 def _severity_value(finding: dict[str, Any]) -> int:
@@ -607,35 +659,51 @@ def _semantic_match_candidate(
     matched_already: set[str],
 ) -> tuple[str, str] | None:
     model_category = str(model_finding.get("category", "")).strip().lower()
-    model_loc_file = location_file(model_finding.get("location"))
+    model_loc_files = set(location_files(model_finding.get("location")) or [location_file(model_finding.get("location"))])
+    model_loc_files.discard("")
     model_sev = _severity_value(model_finding)
     model_desc_tokens = set(_tokenize(model_finding.get("description", "")))
+    model_identifiers = _finding_identifiers(model_finding)
+    model_identifier_tokens = _identifier_tokens(model_finding)
 
+    best_location: str | None = None
+    best_location_score = 0.0
     best: str | None = None
     best_score = 0.0
     for gold in gold_findings:
         gold_id = str(gold.get("id", ""))
         if gold_id in matched_already:
             continue
+        if model_identifiers & _finding_identifiers(gold):
+            return gold_id, "strong"
+
         gold_category = str(gold.get("category", "")).strip().lower()
         if model_category != gold_category:
             continue
 
-        gold_loc_file = location_file(gold.get("location"))
+        gold_loc_files = set(location_files(gold.get("location")) or [location_file(gold.get("location"))])
+        gold_loc_files.discard("")
         gold_sev = _severity_value(gold)
-        same_file = bool(model_loc_file) and model_loc_file == gold_loc_file
+        same_file = bool(model_loc_files & gold_loc_files)
+        gold_desc_tokens = set(_tokenize(gold.get("description", "")))
+        description_jaccard = _jaccard(model_desc_tokens, gold_desc_tokens)
 
         if same_file:
             if abs(model_sev - gold_sev) <= 1:
-                return gold_id, "strong"
+                identifier_jaccard = _jaccard(model_identifier_tokens, _identifier_tokens(gold))
+                if identifier_jaccard > 0 or description_jaccard > LOCATION_DESCRIPTION_JACCARD_THRESHOLD:
+                    location_score = max(identifier_jaccard, description_jaccard)
+                    if location_score > best_location_score:
+                        best_location = gold_id
+                        best_location_score = location_score
             continue
 
-        gold_desc_tokens = set(_tokenize(gold.get("description", "")))
-        jaccard = len(model_desc_tokens & gold_desc_tokens) / max(len(model_desc_tokens | gold_desc_tokens), 1)
-        if jaccard > 0.4 and jaccard > best_score:
+        if description_jaccard > DESCRIPTION_JACCARD_THRESHOLD and description_jaccard > best_score:
             best = gold_id
-            best_score = jaccard
+            best_score = description_jaccard
 
+    if best_location is not None:
+        return best_location, "strong"
     if best is not None:
         return best, "weak"
     return None
@@ -650,9 +718,10 @@ def find_semantic_match(
     Find the best gold finding that matches a model finding semantically.
 
     Match criteria, in priority order:
-    1. category + file-location match -> strong match, with severity tolerated +/-1 step
-    2. category match + description token-set Jaccard > 0.4 -> weak match
-    3. otherwise no match
+    1. model id/aliases match gold id/aliases -> strong match
+    2. category + file-location match + identifier/description signal -> strong match, with severity tolerated +/-1 step
+    3. category match + description token-set Jaccard > 0.4 -> weak match
+    4. otherwise no match
     """
     match = _semantic_match_candidate(model_finding, gold_findings, matched_already)
     return match[0] if match else None

--- a/tests/audit/test_code_review_benchmark.py
+++ b/tests/audit/test_code_review_benchmark.py
@@ -7,6 +7,13 @@ import pytest
 
 from scripts.audit import code_review_benchmark as bench
 
+CORPUS_DIR = Path("audit/code-review-benchmark/corpus")
+AFFECTED_OPUS_NATIVE_CELLS = (
+    Path("audit/2026-05-17-code-review-benchmark-expansion-2/anthropic/claude-opus-4-7/native_cli/xhigh-with_mcp.json"),
+    Path("audit/2026-05-17-code-review-benchmark-expansion-2/anthropic/claude-opus-4-7/native_cli/xhigh-without_mcp.json"),
+    Path("audit/2026-05-17-code-review-benchmark-expansion-2/anthropic/claude-opus-4-7/native_cli/high-with_mcp.json"),
+)
+
 
 def _write_case(tmp_path: Path, *, extra: str = "") -> Path:
     corpus = tmp_path / "corpus"
@@ -68,6 +75,19 @@ def test_corpus_loader_reads_valid_case(tmp_path: Path) -> None:
     assert "diff --git" in cases[0]["diff"]
 
 
+def test_corpus_loader_preserves_gold_aliases(tmp_path: Path) -> None:
+    _write_case(
+        tmp_path,
+        extra="""    aliases:
+      - prompt-on-command-line-leak-and-arg-max-dos
+""",
+    )
+
+    cases = bench.load_corpus(tmp_path / "corpus")
+
+    assert cases[0]["gold_findings"][0]["aliases"] == ["prompt-on-command-line-leak-and-arg-max-dos"]
+
+
 def test_semantic_match_strong() -> None:
     gold = [
         {
@@ -87,6 +107,40 @@ def test_semantic_match_strong() -> None:
     }
 
     assert bench.find_semantic_match(model_finding, gold, set()) == "arg-max"
+
+
+def test_semantic_match_gold_alias_before_location_and_jaccard() -> None:
+    gold = [
+        {
+            "id": "arg-max",
+            "aliases": ["prompt-on-command-line-leak-and-arg-max-dos"],
+            "severity": "HIGH",
+            "category": "security",
+            "location": "scripts/proxy.py:204",
+            "description": "Short argv limit finding.",
+        }
+    ]
+    model_finding = {
+        "id": "prompt-on-command-line-leak-and-arg-max-dos",
+        "severity": "HIGH",
+        "category": "security",
+        "location": "scripts/proxy.py:153-186",
+        "description": "Verbose review prose with enough unrelated detail that token overlap alone is weak.",
+    }
+
+    assert bench.find_semantic_match(model_finding, gold, set()) == "arg-max"
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        ("scripts/proxy.py:153-186", "scripts/proxy.py"),
+        ("scripts/proxy.py:153-186 (handler)", "scripts/proxy.py"),
+        ("scripts/proxy.py:153-186; scripts/cli.py:680", "scripts/proxy.py"),
+    ],
+)
+def test_location_file_normalizes_ranges(location: str, expected: str) -> None:
+    assert bench.location_file(location) == expected
 
 
 def test_semantic_match_severity_tolerance() -> None:
@@ -229,7 +283,7 @@ def test_scorer_matches_file_not_line_and_tolerates_adjacent_severity() -> None:
                 "severity": "MEDIUM",
                 "category": "dos-surface",
                 "location": "scripts/proxy.py:999",
-                "description": "Same file, shifted line.",
+                "description": "Forks on health checks from the same file, shifted line.",
             },
             {
                 "id": "health-check-low",
@@ -247,6 +301,20 @@ def test_scorer_matches_file_not_line_and_tolerates_adjacent_severity() -> None:
     assert score["fp"] == 1
     assert score["fn"] == 0
     assert score["f1"] == 0.6667
+
+
+@pytest.mark.parametrize("cell_path", AFFECTED_OPUS_NATIVE_CELLS)
+def test_semantic_match_replays_affected_opus_native_cells(cell_path: Path) -> None:
+    cases = {case["case_id"]: case for case in bench.load_corpus(CORPUS_DIR)}
+    data = json.loads(cell_path.read_text(encoding="utf-8"))
+
+    scores = [
+        bench.score_case({"findings": judgment["model_findings"]}, cases[judgment["case_id"]])
+        for judgment in data["judgments"]
+    ]
+    aggregate = bench.aggregate(scores)
+
+    assert aggregate["f1"] > 0.0
 
 
 def test_run_cell_uses_injected_runner_and_writes_reportable_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Diagnosis

Current worktree context:

```text
$ git rev-parse --show-toplevel
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/2047-matcher-aliases
$ git branch --show-current
codex/2047-matcher-aliases
```

Before this patch, `find_semantic_match()` documented this priority order:

```text
1. category + file-location match -> strong match, with severity tolerated +/-1 step
2. category match + description token-set Jaccard > 0.4 -> weak match
3. otherwise no match
```

Re-scoring `audit/2026-05-17-code-review-benchmark-expansion-2/anthropic/claude-opus-4-7/native_cli/xhigh-with_mcp.json` against the refreshed corpus still produced:

```text
pr-2025-openai-proxy [] ['prompt-on-command-line-leak-and-arg-max-dos', 'fastapi-422-validation-leaks-framework-envelope', 'healthz-dos-amplification-via-subprocess-forking', 'unauthenticated-remote-host-binding', 'unbounded-request-size', 'tempfile-leak-on-crash'] 0.0
```

Diagnosis quote pair for the `arg-max`/argv finding:

```text
MODEL category: security
MODEL location_file: scripts/ai_agent_bridge/openai_proxy.py:153-186
MODEL location: scripts/ai_agent_bridge/openai_proxy.py:153-186
MODEL description: Three of four backends pass the user-supplied prompt as an argv element rather than over stdin ... argv is bounded by `ARG_MAX` ... will silently `E2BIG` ... Pipe prompts through stdin for all backends, as already done for codex.

GOLD id: prompt-on-command-line-leak-and-arg-max-dos
GOLD category: security
GOLD location_file: scripts/ai_agent_bridge/openai_proxy.py
GOLD location: scripts/ai_agent_bridge/openai_proxy.py:204
GOLD description: Prompts larger than the OS argv limit hit ARG_MAX/E2BIG because the proxy passes prompt text through command-line arguments to the upstream CLI. The prompt should be sent over stdin or another streaming channel.

JACCARD: 0.0918
INTERSECTION: ['arg_max', 'argv', 'e2big', 'over', 'prompt', 'prompts', 'stdin', 'than', 'through']
```

Hypothesis 1 is ruled out: category is `security` on both records. Hypotheses 2 and 3 are confirmed: the matcher did not normalize `:153-186` to file granularity, and description Jaccard was far below `0.4` for the verbose model finding.

## Fix

Chosen variant: **B, alias/id matching first**. The matcher now preserves optional gold `aliases`, normalizes model/gold ids, and matches `model id/aliases ∩ gold id/aliases` before category/location/Jaccard. I did not lower the global Jaccard threshold. Because the refreshed corpus currently widens ids but does not add explicit alias arrays for every affected finding, the file-location path also now understands range/multi-file locations and requires identifier-token or description signal before accepting same-file matches.

Relevant diff snippet:

```diff
+    aliases = raw.get("aliases", [])
+    if aliases:
+        if not isinstance(aliases, list):
+            raise ValueError(f"{source}: gold finding aliases must be a list")
+        finding["aliases"] = [str(alias) for alias in aliases]
+
+def _finding_identifiers(finding: dict[str, Any]) -> set[str]:
+    identifiers = {_normalize_finding_id(finding.get("id"))}
+    aliases = finding.get("aliases", [])
+    if isinstance(aliases, list):
+        identifiers.update(_normalize_finding_id(alias) for alias in aliases)
+    identifiers.discard("")
+    return identifiers
+
+        if model_identifiers & _finding_identifiers(gold):
+            return gold_id, "strong"
```

## Replay Results

No LLMs were re-called; these are replays against existing raw JSON outputs.

| cell | before F1 | after F1 |
| --- | ---: | ---: |
| `anthropic/claude-opus-4-7/native_cli/xhigh-with_mcp.json` | 0.0000 | 0.2143 |
| `anthropic/claude-opus-4-7/native_cli/xhigh-without_mcp.json` | 0.0000 | 0.3571 |
| `anthropic/claude-opus-4-7/native_cli/high-with_mcp.json` | 0.0000 | 0.2963 |

## Tests

```text
$ .venv/bin/python -m pytest tests/audit/test_code_review_benchmark.py
============================== 20 passed in 0.28s ==============================
```

Additional local checks:

```text
$ .venv/bin/ruff check scripts/audit/code_review_benchmark.py tests/audit/test_code_review_benchmark.py
All checks passed!
$ git diff --check
# no output
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Closes #2047