### PR TITLE
fix(audit): unclosed-italic anti-example + я-форма linguistic whitelist

### DIFF
--- a/scripts/audit/config.py
+++ b/scripts/audit/config.py
@@ -57,6 +57,15 @@ PROPER_NAME_WHITELIST: set[str] = {
     "Лобел", "Лобела", "Лобеле", "Лобелу", "Лобелі", "Лобелем", "Лобелом",
     "Квак", "Квака", "Кваку", "Кваком", "Кваче",
     "Кнак", "Кнака", "Кнаку", "Кнаком", "Кначе",
+    # Added 2026-05-17: hyphenated Ukrainian linguistic terminology that
+    # VESUM does not contain because it's a compound term, not a single
+    # lemma. The writer's reflexive-verb m20 build surfaced `я-форма`
+    # ("I-form" — 1sg verb form) as a HARD gate failure even though the
+    # term is standard pedagogical Ukrainian (вживається в посібниках
+    # Заболотного, Авраменка). Sibling pronoun-form terms (`ти-форма`,
+    # `він-форма`, `ми-форма`, `ви-форма`, `вони-форма`) will be added
+    # as they surface; tonight only `я-форма` actually trips a build.
+    "я-форма", "я-форми", "я-формі", "я-форму", "я-формою", "я-формах",
     # Common abbreviations and brand names
     "ІТ", "ЗНО", "НМТ", "ЄС", "ООН", "НАТО", "ЗСУ",
     "МійКлас",

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -500,23 +500,36 @@ _AVOID_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(.+?)<!--\s*/bad\s*-->", re.DOTA
 # correctly fail it, but the writer's pedagogical intent is to show it as
 # wrong, not to assert it as Ukrainian).
 #
-# Three surface forms supported, both English and Ukrainian negators:
-#   1. Straight quotes:  `not "дивюся"`  /  `не "завтрак"`
-#   2. Guillemets:       `not «дивюся»`  /  `не «завтрак»`
-#   3. Markdown italics: `not *дивюся*`  /  `не *завтрак*`
+# Four surface forms supported, both English and Ukrainian negators:
+#   1. Straight quotes:    `not "дивюся"`   /  `не "завтрак"`
+#   2. Guillemets:         `not «дивюся»`   /  `не «завтрак»`
+#   3. Closed markdown italics: `not *дивюся*` / `не *завтрак*`
+#   4. Unclosed italic terminated by sentence punctuation:
+#        `not *дивюся.`  /  `не *завтрак,`  /  `not *дивюся` (end-of-string)
 #
-# #2038 originally shipped the quote-only variant. The italic variant was
-# added 2026-05-17 after a1/m20 rebuild #2 surfaced `*дивюся*` from the
-# writer's `*я дивлюся*, not *дивюся*` contrast pattern. Strikethrough,
-# bold, and explicit ❌ markers are NOT matched here — extend
-# alternation rather than introducing new constants.
+# #2038 originally shipped quote-only. PR #2076 added closed-italic. The
+# unclosed-italic variant was added 2026-05-17 after a1/m20 rebuild #4
+# surfaced `*дивюся` (no closing `*` — the writer typed
+# `not *дивюся.` inside a JSON `"explanation"` field, where the sentence-
+# ending period takes the role of the closing italic marker).
+#
+# Strikethrough, bold, and explicit ❌ markers are NOT matched here —
+# extend alternation rather than introducing new constants.
 #
 # Bold (`**X**`) is intentionally excluded. Writers reserve bold for the
 # CORRECT form (the structural emphasis: "**л**" is the epenthetic
 # consonant being taught). Matching bold here would strip the very tokens
 # we want VESUM to verify.
 _WARNING_QUOTE_RE = re.compile(
-    r'\b(?:not|не)\s+(?:["«][^"»]+["»]|\*[^*]+\*)',
+    # Four alternations: quotes, guillemets, closed italics, unclosed italics.
+    # The unclosed-italic arm requires the inner span to be Cyrillic-only
+    # (no asterisk, no whitespace, no punctuation) so it stops cleanly at
+    # the next boundary instead of swallowing the rest of the sentence.
+    r'\b(?:not|не)\s+(?:'
+    r'["«][^"»]+["»]'
+    r'|\*[^*\n]+?\*'
+    r'|\*[A-Za-zА-ЯІЇЄҐа-яіїєґ\'ʼ-]+'
+    r')',
     re.IGNORECASE,
 )
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -2982,6 +2982,66 @@ def test_strip_metalinguistic_warning_quote_pattern() -> None:
     assert "дивлюся" in bold_correct_form
 
 
+def test_warning_quote_unclosed_italic_terminated_by_punctuation() -> None:
+    """`not *X.` / `не *X,` / `not *X<EOS>` — unclosed italics terminated by
+    sentence punctuation or end-of-string also strip the anti-example.
+
+    PR #2076 added closed-italic handling (`not *X*`). a1/m20 rebuild #4
+    (2026-05-17) surfaced the unclosed variant: the writer typed
+    `In II-conjugation: дивлюся, not *дивюся.` inside a JSON
+    `"explanation"` field, where the sentence-ending period implicitly
+    closes the italic span. The closed-italic-only regex missed it; the
+    bare token `*дивюся` (with the opening asterisk attached) reached
+    VESUM and tripped the gate.
+    """
+    cases = [
+        # Unclosed italic + period (the m20 trigger)
+        ("In II-conjugation: дивлюся, not *дивюся.", ["*дивюся"]),
+        # Unclosed italic + comma
+        ("кажуть, не *завтрак, а сніданок", ["завтрак"]),
+        # Unclosed italic + end-of-string
+        ("finally, not *X", ["*X"]),
+        # Closed italic still works (regression)
+        ("Use *сніданок*, не *завтрак*.", ["завтрак"]),
+        # Quote still works (regression)
+        ('Say not "X" but Y.', ['"X"']),
+    ]
+    for text, must_be_gone in cases:
+        stripped = linear_pipeline._strip_metalinguistic(text)
+        for fragment in must_be_gone:
+            assert fragment not in stripped, (
+                f"anti-example {fragment!r} should be stripped from {text!r}, "
+                f"got {stripped!r}"
+            )
+
+    # Bold-wrapped CORRECT form must survive.
+    bold = linear_pipeline._strip_metalinguistic("Bold **дивлюся** stays.")
+    assert "дивлюся" in bold, (
+        f"bold-wrapped correct form should survive, got {bold!r}"
+    )
+
+
+def test_proper_name_whitelist_covers_ya_forma() -> None:
+    """`я-форма` and its declined forms are pedagogical Ukrainian
+    linguistics terminology, not a VESUM lemma. Whitelist must cover
+    the surface forms a writer can realistically emit so the m20
+    `Інфінітив ↔ я-форма` activity title doesn't trip the gate."""
+    from scripts.audit.config import PROPER_NAME_WHITELIST
+
+    whitelist_lc = {name.lower() for name in PROPER_NAME_WHITELIST}
+    for surface in (
+        "я-форма",  # nom
+        "я-форми",  # gen / nom-pl
+        "я-формі",  # dat / loc
+        "я-форму",  # acc
+        "я-формою",  # instr
+    ):
+        assert surface in whitelist_lc, (
+            f"linguistic term {surface!r} must be in PROPER_NAME_WHITELIST "
+            f"(VESUM does not contain hyphenated pronoun-forma compounds)"
+        )
+
+
 def test_iter_vesum_word_surfaces_skips_mixed_script_typos() -> None:
     """Mixed-script Cyrillic-abutting-Latin tokens are writer typos, not words.
 


### PR DESCRIPTION
## Summary

m20 rebuild #4 surfaced two new vesum_verified trippers (post-#2079).

### 1. `*дивюся` (unclosed italic) — `_WARNING_QUOTE_RE` extension

PR #2076 added closed-italic handling (`not *X*`). The writer's `"explanation"` JSON field used the UNCLOSED variant:

```
"...in II-conjugation: дивлюся, not *дивюся."
```

The sentence-ending period implicitly closes the italic span — but the closed-only regex didn't match, so `*дивюся` (with leading `*` attached) reached VESUM and tripped the gate.

Extended `_WARNING_QUOTE_RE` with a third alternation arm: unclosed italic followed by a word ending at the next boundary (`\*[A-Za-zА-ЯІЇЄҐа-яіїєґ'ʼ-]+`). Closed-italic, quote-based, and guillemet variants unchanged. Bold (`**X**`) still excluded.

### 2. `я-форма` — Ukrainian linguistic terminology whitelist

The m20 activity title `Інфінітив ↔ я-форма` references the standard Ukrainian pedagogical term for "1st-person singular verb form" (вживається в посібниках Заболотного, Авраменка). VESUM does NOT contain hyphenated pronoun-forma compounds — they're terminology, not single lemmas.

Added `я-форма` + 5 declined forms to `PROPER_NAME_WHITELIST` (consistent with how Лобел/Квак/Кнак, ІТ/ЗНО/НАТО, etc are handled — the whitelist's actual function is "VESUM-misses-this-but-it's-correct"). Sibling pronoun-form terms will be added as they surface.

## Test plan

- [x] `pytest tests/build/test_linear_pipeline.py -k "warning_quote or metalinguistic or ya_forma or mixed_script or morpheme or vesum_gate or hyphen"` → 28 passed
  - 1 new for unclosed-italic anti-example (5 cases: m20 period trigger, comma, EOS, closed regression, quote regression)
  - 1 new for я-форма whitelist coverage
- [ ] After merge: rebuild #5 should pass vesum_verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)