### PR TITLE
fix(audit): wiki_coverage_gate JSON blob crashes Path.exists() on macOS

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -159,10 +159,25 @@ def check_wiki_coverage_paths(
 def _load_manifest(manifest: Mapping[str, Any] | str | Path) -> Mapping[str, Any]:
     if isinstance(manifest, Mapping):
         return manifest
-    path = Path(manifest)
-    if path.exists():
-        return json.loads(path.read_text(encoding="utf-8"))
-    return json.loads(str(manifest))
+    # If the string clearly looks like a JSON blob, parse it directly. This
+    # avoids passing the entire blob to `Path(...).exists()`, which on macOS
+    # APFS raises `OSError: [Errno 63] ENAMETOOLONG` when the would-be
+    # filename component exceeds 255 bytes. Linux returns False silently in
+    # the same scenario, which is why the bug only surfaced on darwin
+    # (2026-05-17 m20 build #12 — first build to reach the wiki_coverage_gate
+    # phase via the macOS Dagger-less local path).
+    text = str(manifest)
+    if text.lstrip().startswith(("{", "[")):
+        return json.loads(text)
+    try:
+        path = Path(manifest)
+        if path.exists():
+            return json.loads(path.read_text(encoding="utf-8"))
+    except OSError:
+        # Defensive: any path-related OSError (ENAMETOOLONG, ENOENT in
+        # an unusual form, EACCES) falls through to the json.loads path.
+        pass
+    return json.loads(text)
 
 
 def _read_optional(path: Path) -> str:

--- a/tests/test_wiki_coverage_gate.py
+++ b/tests/test_wiki_coverage_gate.py
@@ -1,7 +1,60 @@
 from __future__ import annotations
 
+import json
+
 import scripts.audit.wiki_coverage_gate as gate
 from scripts.audit.wiki_coverage_gate import check_wiki_coverage, parse_implementation_map
+
+
+def test_load_manifest_parses_json_blob_without_filesystem_access() -> None:
+    """`_load_manifest` must detect a JSON-blob string and parse it
+    directly, not pass it through `Path(...).exists()`.
+
+    On macOS APFS, passing a multi-kB JSON string to `Path(...).exists()`
+    raises `OSError: [Errno 63] ENAMETOOLONG` instead of returning False,
+    crashing the wiki_coverage_gate before the gate logic runs. Linux
+    returns False silently for the same input, which is why the bug
+    only surfaced on darwin (2026-05-17 m20 build #12 — the first build
+    to reach `wiki_coverage_gate` on a developer macOS workstation).
+
+    A JSON blob starts with `{` or `[` after whitespace; that signature
+    is the cheapest reliable discriminator.
+    """
+    # Realistic-shape wiki manifest as produced by build_wiki_manifest.
+    manifest = {
+        "slug": "my-morning",
+        "wiki_path": "/Users/k/projects/learn-ukrainian/wiki/pedagogy/a1/my-morning.md",
+        "sequence_steps": [
+            {"id": f"step-{i}", "heading": f"Крок {i}: ..."} for i in range(1, 8)
+        ],
+        "l2_errors": [{"id": f"err-{i}", "incorrect": "X", "correct": "Y"} for i in range(1, 6)],
+        "phonetic_rules": [
+            {"id": "phon-1", "written": "-шся", "spoken": "[с':а]"}
+        ],
+        "decolonization_bans": [],
+    }
+    blob = json.dumps(manifest, ensure_ascii=False, indent=2)
+    # Sanity: this blob would explode Path(...).exists() on macOS if not
+    # short-circuited.
+    assert len(blob) > 255, "fixture too small to reproduce the original bug"
+
+    result = gate._load_manifest(blob)
+
+    assert result == manifest
+
+
+def test_load_manifest_short_json_blob_also_short_circuits() -> None:
+    """Short JSON blobs (under 255 bytes) still take the JSON path so
+    behavior is consistent regardless of payload size."""
+    short_blob = '{"slug": "test", "sequence_steps": [], "l2_errors": [], "phonetic_rules": [], "decolonization_bans": []}'
+    result = gate._load_manifest(short_blob)
+    assert result["slug"] == "test"
+
+
+def test_load_manifest_passes_through_mapping() -> None:
+    """Mapping input returns unchanged (no path/JSON detour)."""
+    payload = {"slug": "x", "sequence_steps": []}
+    assert gate._load_manifest(payload) is payload
 
 
 def _manifest() -> dict[str, object]:


### PR DESCRIPTION
## Summary

m20 build #12 was the first build this session to clear python_qg (after PR #2087 Path A + PR #2090 counter fix). It then died at the next phase:

\`\`\`
module_failed phase: wiki_coverage_gate
reason: \"[Errno 63] File name too long: '{\\n  \"slug\": ...'\"
\`\`\`

The \"filename\" in the error is the full wiki manifest JSON blob.

## Root cause

\`scripts/audit/wiki_coverage_gate.py:_load_manifest\` accepts \`Mapping | str | Path\` for the manifest input. When a JSON-string manifest comes through (\`build_wiki_manifest\` returns \`json.dumps(...)\`), the helper does:

\`\`\`python
path = Path(manifest)
if path.exists():
    return json.loads(path.read_text(encoding=\"utf-8\"))
return json.loads(str(manifest))
\`\`\`

On macOS APFS, \`Path(...).exists()\` calls \`stat()\` which raises \`OSError: [Errno 63] ENAMETOOLONG\` when the path-component length exceeds 255 bytes — i.e., on any realistic-sized manifest. Linux silently returns False for the same input, which is why GHA never caught this. The wiki_coverage_gate phase is also relatively new and previous builds didn't reach it (python_qg failed earlier).

## Fix

Detect the JSON-blob signature (string starts with \`{\` or \`[\` after whitespace) before any filesystem access. Bypass \`Path()\` entirely on blob input. Additionally wrap the Path branch in try/except OSError so edge-case path strings can't crash the gate.

## Test plan

Three new regression tests in \`tests/test_wiki_coverage_gate.py\`:

- [x] \`test_load_manifest_parses_json_blob_without_filesystem_access\` — canonical reproduction with a multi-kB JSON blob that would ENAMETOOLONG-crash the old code path. Asserts the fixture is >255 bytes so the test stays a real reproducer.
- [x] \`test_load_manifest_short_json_blob_also_short_circuits\` — short blob takes the same path for behavior consistency.
- [x] \`test_load_manifest_passes_through_mapping\` — Mapping input returns unchanged.
- [x] Full sweep: \`tests/test_wiki_coverage_gate.py\` 10/10 PASS, \`tests/test_linear_pipeline_wiki_coverage.py\` + \`tests/build/\` 194/194 PASS.
- [x] Dagger pre-push pytest replay PASS — second clean local push of the day after PR #2088 unblocked the hook.

## Acceptance

After merge, rebuild a1/my-morning. python_qg already passes (PR #2087 + #2090). Expect the build to clear wiki_coverage_gate too and proceed to dim_review + MDX assembly. If green, m20 ships.

## Related

- PR #2087 (m20 Path A — closed 4 python_qg failure classes)
- PR #2090 (l2_exposure_floor counter fix — closed the 5th)
- This PR — clears the next phase down (wiki_coverage_gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)