### PR TITLE
chore(precommit): remove Dagger pre-push pytest hook (manual-only now)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,17 +162,23 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-      # Full GHA-replay pytest via Dagger. Runs when scripts/, tests/,
-      # .dagger/, or any .py is in the push. ~2-3 min warm; replicates
-      # the CI Test (pytest) job byte-for-byte using the .dagger/ pipeline.
-      # If `dagger` is not installed locally, the hook skips with a
-      # warning (CI will catch failures). Bypass with --no-verify.
-      # Reference: MEMORY.md #M-7 (pytest locally before push to main).
-      - id: dagger-pytest
-        name: full pytest via Dagger (GHA replay)
-        entry: scripts/pre_push/dagger_pytest.sh
-        language: system
-        pass_filenames: false
-        # Only run when something pytest-relevant is in the push.
-        files: ^(scripts/|tests/|\.dagger/|.*\.py$)
-        stages: [pre-push]
+      # Dagger pre-push pytest hook REMOVED 2026-05-17 per user direction.
+      # Cause: Dagger's cache_volume design accumulates pip wheels every
+      # cold run (was 30 GB/run pre-#2088, ~6 GB/run post-#2088 with .venv
+      # mount filter), and the resulting disk creep filled the SSD to 99%
+      # twice in 12 hours. Local replay value did not justify the recurring
+      # disk cost.
+      #
+      # Manual invocation still available:
+      #
+      #     bash scripts/pre_push/dagger_pytest.sh
+      #
+      # The script remains in-tree for ad-hoc GHA-replay debugging of a
+      # CI-only failure. CI's `Test (pytest)` workflow remains the
+      # canonical pre-merge gate. For local validation between pushes:
+      #
+      #     .venv/bin/python -m pytest <targeted-paths>
+      #
+      # MEMORY.md #M-7 still applies — run pytest locally before push when
+      # editing .py, scripts/, tests/, .dagger/, or hardcoded test fixtures.
+      # The hook automation is gone; the obligation isn't.

--- a/scripts/pre_push/dagger_pytest.sh
+++ b/scripts/pre_push/dagger_pytest.sh
@@ -1,31 +1,37 @@
 #!/usr/bin/env bash
 #
-# Pre-push hook: full GHA-replay pytest via Dagger.
+# Full GHA-replay pytest via Dagger — MANUAL invocation only.
 #
-# Invoked by pre-commit framework (stage=pre-push) when the push touches
-# scripts/, tests/, .dagger/, or any .py file. The file filter is set in
-# .pre-commit-config.yaml (id: dagger-pytest), so this script just runs
-# unconditionally when called.
+# Status: this script was originally a pre-push pre-commit hook (id:
+# dagger-pytest in .pre-commit-config.yaml). Removed from the pre-push
+# stage 2026-05-17 because Dagger's cache_volume design accumulated pip
+# wheels every cold run (was 30 GB/run pre-#2088, ~6 GB/run after the
+# .venv mount filter), and the disk creep filled the SSD to 99% twice
+# in 12 hours. CI's `Test (pytest)` workflow is the canonical pre-merge
+# gate; this script is kept in-tree for ad-hoc GHA-replay debugging of
+# a CI-only failure that needs reproduction locally.
+#
+# Usage:
+#   bash scripts/pre_push/dagger_pytest.sh
 #
 # Behavior:
-#   - If `dagger` is not installed: WARN and exit 0 (allow push). CI
-#     remains the safety net; we don't punish devs who haven't installed
-#     Dagger yet.
+#   - If `dagger` is not installed: WARN and exit 0.
 #   - If `dagger` is installed: run `dagger call pytest --source=.`.
-#     Exit non-zero on test failure (blocks push). Exit 0 on success.
+#     Exit non-zero on test failure. Exit 0 on success.
 #
-# Why this exists:
-#   MEMORY.md #M-7 — "PYTEST LOCALLY BEFORE PUSH TO MAIN" — encodes the
-#   lesson that pre-commit's ruff-only checks are insufficient. We've
-#   merged red commits to main by skipping local pytest before push.
-#   This hook makes the slow-but-safe path automatic so it can't be
-#   forgotten.
+# Cost reminder:
+#   Each cold run rebuilds the `learn-ukrainian-pip` cache_volume to
+#   ~6 GB. Use `docker volume prune -f` (after stopping
+#   `dagger-engine-v*`) periodically if you invoke this often.
 #
-# Bypass:
-#   `git push --no-verify`  — only when you're sure (e.g. you know the
-#   path filter caught a non-Python change that triggered the hook).
+# Why MEMORY.md #M-7 still applies:
+#   The hook automation is gone but the obligation is not — run pytest
+#   locally before push when editing .py, scripts/, tests/, .dagger/,
+#   or hardcoded test fixtures. For most pushes, the faster path is
+#   `.venv/bin/python -m pytest <targeted-paths>` (5s vs Dagger's
+#   3-5 min). Use this script only when you suspect a CI-only diff.
 #
-# Reference: PR #TBD (added 2026-05-17).
+# Reference: PR #TBD (de-hooked 2026-05-17).
 
 set -u
 


### PR DESCRIPTION
## Summary

Per user direction 2026-05-17: remove the auto-firing Dagger pre-push pytest hook because the cache_volume design drives SSD usage to 99% within ~1 day of normal hook activity. Keep the underlying script callable for ad-hoc CI-only failure debugging.

## Cost data this session

- **Pre-#2088** (host \`.venv/\` shadowing): cache_volume grew to **30 GB per cold run**. Disk filled 99% in 12 hours.
- **Post-#2088** (.venv mount filter shipped this morning): cache_volume now **~6 GB per cold run** — material improvement (5x), but the creep was still enough to push disk 73% → 82% from a single validation run.

Both cycles required manual \`docker volume prune -f\` after stopping the engine.

## What this PR does

- Removes the \`dagger-pytest\` hook from \`.pre-commit-config.yaml\`. No more automatic Dagger invocation on \`git push\`.
- Updates \`scripts/pre_push/dagger_pytest.sh\` header to reflect manual-invocation-only status + cost reminder.

## What this PR does NOT do

- Does NOT delete \`scripts/pre_push/dagger_pytest.sh\` — kept for ad-hoc manual GHA-replay debugging.
- Does NOT delete \`.dagger/\` module — still callable directly via \`dagger call pytest --source=.\`.
- Does NOT change CI gating. GHA \`Test (pytest)\` remains the canonical pre-merge gate.

## Local pytest replacement

For routine local validation between pushes:

\`\`\`bash
.venv/bin/python -m pytest <targeted-paths>     # 5s targeted, 60s full
\`\`\`

For CI-only failure reproduction (rare):

\`\`\`bash
bash scripts/pre_push/dagger_pytest.sh           # 3-5 min, full GHA replay
\`\`\`

## MEMORY.md #M-7 unchanged

The pre-push-pytest obligation is unchanged — only the automated enforcement is gone. Authors must still run pytest locally before pushing when editing .py, scripts/, tests/, .dagger/, or hardcoded test fixtures.

## Test plan

- [x] Branch pushed cleanly through the pre-commit suite (Dagger hook either ran and passed, or didn't fire since this PR's only \`scripts/\` change is the dagger_pytest.sh script itself).
- [x] No \`.py\` test code changed; existing test suite unaffected.
- [ ] After merge: confirm next push (any branch) does NOT trigger \`dagger-pytest\` line in pre-commit output.

## Related

- PR #2088 (.venv mount fix that reduced cache cost 30 GB → 6 GB)
- Issue #2089 (root-cause infra writeup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)