### PR TITLE
fix(audit): wiki_coverage_gate parser — collect all implementation_map blocks + accept inline format

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -21,28 +21,81 @@ _IMPLEMENTATION_MAP_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _OBLIGATION_RE = re.compile(r"obligation_id\s*:\s*(?P<id>[-\w]+)", re.IGNORECASE)
-_FIELD_RE = re.compile(r"^\s*-?\s*(?P<key>artifact|location|treatment)\s*:\s*(?P<value>.+?)\s*$", re.IGNORECASE)
+_FIELD_RE = re.compile(
+    r"^\s*-?\s*(?P<key>artifact|location|treatment)\s*:\s*(?P<value>.+?)\s*$",
+    re.IGNORECASE,
+)
+# Inline-field shape: writer emits all four fields on the SAME line as the
+# obligation_id, separated by `;` (semicolons). Example:
+#   - obligation_id: step-2; artifact: module.md; location: §Дiалоги; treatment: ...
+# Captures each known field name + its value (up to the next `;` or end of
+# string), regardless of position in the line.
+_INLINE_FIELD_RE = re.compile(
+    r"(?P<key>artifact|location|treatment)\s*:\s*(?P<value>[^;]+?)(?=\s*;\s*(?:obligation_id|artifact|location|treatment)\s*:|\s*$)",
+    re.IGNORECASE,
+)
 
 
 def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
-    """Parse the writer-visible implementation map from raw writer output."""
-    match = _IMPLEMENTATION_MAP_RE.search(text)
-    if not match:
+    """Parse the writer-visible implementation map from raw writer output.
+
+    The writer-prompt template nests `<implementation_map>` inside each
+    `<plan_reasoning>` section block (one per section, typically 4 per
+    module). This parser MUST collect entries from ALL implementation_map
+    blocks, not just the first — `re.findall` instead of `re.search`.
+
+    The prompt's example format puts each field on its own line:
+
+        <implementation_map>
+        - obligation_id: step-2
+          artifact: module.md
+          location: §Діалоги
+          treatment: ...
+        </implementation_map>
+
+    But writers (notably claude-tools) commonly emit the more compact
+    single-line semicolon-delimited form:
+
+        <implementation_map>
+        - obligation_id: step-2; artifact: module.md; location: §Діалоги; treatment: ...
+        </implementation_map>
+
+    Both are valid markdown and pedagogically equivalent. Parser accepts
+    BOTH shapes per-line: it captures any `obligation_id` mention, then
+    captures any inline `key: value` triple after `;` separators in the
+    same line, AND continues to consume bullet-list field lines below
+    in the original multi-line shape.
+
+    Per-obligation entries are merged across all implementation_map blocks
+    by obligation_id; the LAST emission wins for a given field (mirrors
+    the writer's intent if they restate a more refined claim later).
+    """
+    matches = list(_IMPLEMENTATION_MAP_RE.finditer(text))
+    if not matches:
         return {}
-    body = match.group("body")
     entries: dict[str, dict[str, str]] = {}
-    current_id: str | None = None
-    for line in body.splitlines():
-        id_match = _OBLIGATION_RE.search(line)
-        if id_match:
-            current_id = id_match.group("id").strip()
-            entries.setdefault(current_id, {"obligation_id": current_id})
-            continue
-        if current_id is None:
-            continue
-        field_match = _FIELD_RE.match(line)
-        if field_match:
-            entries[current_id][field_match.group("key").casefold()] = field_match.group("value").strip()
+    for match in matches:
+        body = match.group("body")
+        current_id: str | None = None
+        for line in body.splitlines():
+            id_match = _OBLIGATION_RE.search(line)
+            if id_match:
+                current_id = id_match.group("id").strip()
+                entries.setdefault(current_id, {"obligation_id": current_id})
+                # Also capture inline fields on the same line (semicolon shape).
+                for inline_match in _INLINE_FIELD_RE.finditer(line):
+                    entries[current_id][inline_match.group("key").casefold()] = (
+                        inline_match.group("value").strip()
+                    )
+                continue
+            if current_id is None:
+                continue
+            # Multi-line bullet-list shape: field on its own line below the id.
+            field_match = _FIELD_RE.match(line)
+            if field_match:
+                entries[current_id][field_match.group("key").casefold()] = (
+                    field_match.group("value").strip()
+                )
     return entries
 
 

--- a/tests/test_wiki_coverage_gate.py
+++ b/tests/test_wiki_coverage_gate.py
@@ -113,6 +113,96 @@ def _implementation_map() -> dict[str, dict[str, str]]:
     }
 
 
+def test_parse_implementation_map_collects_all_blocks_and_inline_format() -> None:
+    """The writer-prompt template nests `<implementation_map>` inside each
+    `<plan_reasoning>` section block — typically 4 blocks per module.
+    Parser MUST collect entries from ALL blocks, not just the first.
+
+    AND the writer (notably claude-tools) commonly emits all fields on
+    ONE line separated by `;`, not the prompt's example multi-line shape.
+    Parser MUST accept BOTH the inline-semicolon and the multi-line
+    bullet shape.
+
+    Surfaced 2026-05-17 by a1/m20 build #14: writer correctly emitted
+    4 implementation_map blocks with all 18 obligations covered, but the
+    parser only saw the first block's 3 obligation_ids and dropped their
+    artifact/location/treatment fields because they were inline on the
+    same line. Result: 0/18 coverage, gate REJECT, despite a clean
+    writer output.
+    """
+    raw = """
+<plan_reasoning section="Діалоги">
+<implementation_map>
+- obligation_id: step-2; artifact: module.md; location: §Діалоги Dialog 1; treatment: reflexive verbs introduced in dialogue.
+- obligation_id: err-1; artifact: module.md; location: §Діалоги closing; treatment: я prokidayusya vs ты prokidaeshsya contrast.
+</implementation_map>
+</plan_reasoning>
+
+<plan_reasoning section="Дієслова на -ся">
+<implementation_map>
+- obligation_id: step-1; artifact: module.md; location: §Дієслова opening sentence; treatment: explicit I-conjugation endings.
+- obligation_id: phon-1; artifact: module.md; location: §Дієслова IPA paragraph; treatment: -шся to [s:a] pair with example.
+</implementation_map>
+</plan_reasoning>
+
+<plan_reasoning section="Підсумок">
+<implementation_map>
+- obligation_id: err-5
+  artifact: module.md
+  location: §Підсумок row 5
+  treatment: дивюся to дивлюся with epenthetic l
+</implementation_map>
+</plan_reasoning>
+"""
+    result = parse_implementation_map(raw)
+
+    # All 5 obligation_ids from across the 3 blocks must be present, each
+    # with its artifact/location/treatment populated.
+    assert set(result.keys()) == {"step-2", "err-1", "step-1", "phon-1", "err-5"}
+    assert result["step-2"]["artifact"] == "module.md"
+    assert result["step-2"]["location"] == "§Діалоги Dialog 1"
+    assert "reflexive verbs" in result["step-2"]["treatment"]
+    # Multi-line bullet shape (err-5) also parsed correctly.
+    assert result["err-5"]["artifact"] == "module.md"
+    assert result["err-5"]["location"] == "§Підсумок row 5"
+    assert "epenthetic" in result["err-5"]["treatment"]
+
+
+def test_parse_implementation_map_inline_field_order_independence() -> None:
+    """Inline-format fields appear in any order on the line; parser must
+    not assume `obligation_id` comes first or that `artifact` precedes
+    `location`."""
+    raw = """<implementation_map>
+- artifact: activities.yaml; obligation_id: phon-3; treatment: phonetic explanation; location: act-3
+- treatment: ban explanation; obligation_id: ban-1; location: §Підсумок; artifact: module.md
+</implementation_map>"""
+
+    result = parse_implementation_map(raw)
+
+    assert result["phon-3"]["artifact"] == "activities.yaml"
+    assert result["phon-3"]["location"] == "act-3"
+    assert result["ban-1"]["artifact"] == "module.md"
+    assert result["ban-1"]["location"] == "§Підсумок"
+
+
+def test_parse_implementation_map_last_emission_wins() -> None:
+    """If the writer restates an obligation in a later section block with
+    a different artifact/location, the LATER claim wins. Mirrors writer
+    intent — the second mention is usually a refinement."""
+    raw = """<implementation_map>
+- obligation_id: step-5; artifact: module.md; location: §Діалоги; treatment: initial mention
+</implementation_map>
+
+<implementation_map>
+- obligation_id: step-5; artifact: module.md; location: §Мій ранок; treatment: full narrative coverage
+</implementation_map>"""
+
+    result = parse_implementation_map(raw)
+
+    assert result["step-5"]["location"] == "§Мій ранок"
+    assert result["step-5"]["treatment"] == "full narrative coverage"
+
+
 def test_parse_implementation_map_from_writer_output() -> None:
     raw = """<implementation_map>
 - obligation_id: err-1


### PR DESCRIPTION
## Summary

m20 build #14 cleared python_qg AND wiki_coverage_gate no longer crashed (#2091 ENAMETOOLONG fix landed). But the gate REJECTED the module: **0/18 obligations covered**. Inspection showed the writer had emitted 4 well-formed \`<implementation_map>\` blocks (one per \`<plan_reasoning>\` section per the prompt template's nesting structure) covering all 18 obligations cleanly.

## Two root causes

### Cause A — parser only saw the FIRST block

\`parse_implementation_map\` used \`.search(text)\`, returning just the first match. Writer-prompt template nests \`<implementation_map>\` INSIDE each \`<plan_reasoning>\` section block, so a normal module emits 4 of them. Parser dropped 3 of 4 implementation maps entirely.

**Fix:** \`finditer\` + merge entries across all blocks by \`obligation_id\`. Last emission wins per field (mirrors writer refinement intent).

### Cause B — parser didn't accept inline-semicolon format

Prompt example shows multi-line shape:

\`\`\`
- obligation_id: step-2
  artifact: module.md
  location: §Діалоги
  treatment: ...
\`\`\`

But claude-tools commonly emits the compact same-line semicolon-delimited form:

\`\`\`
- obligation_id: step-2; artifact: module.md; location: §Діалоги; treatment: ...
\`\`\`

Both are valid markdown. Old \`_FIELD_RE\` was line-anchored (\`^\s*-?\s*(artifact|location|treatment): ...$\`) so it never matched inline fields. Result: even the FIRST block's entries lost their artifact/location, so gate reported \`unknown_artifact\` for them.

**Fix:** Add \`_INLINE_FIELD_RE\` matching \`key: value\` triples on the same line as \`obligation_id\`, separated by \`;\`. Parser tries both shapes per line (backward compatible).

## Test plan

- [x] \`test_parse_implementation_map_collects_all_blocks_and_inline_format\` — canonical reproduction: 3 nested blocks with mixed inline + multi-line shape; all obligations merge correctly with fields populated.
- [x] \`test_parse_implementation_map_inline_field_order_independence\` — inline fields can appear in any order.
- [x] \`test_parse_implementation_map_last_emission_wins\` — duplicate obligation_id keeps LATER claim.
- [x] Existing wiki_coverage_gate tests (10) continue to pass.
- [x] \`tests/test_wiki_coverage_gate.py\` 13/13 PASS
- [x] \`tests/test_linear_pipeline_wiki_coverage.py\` + \`tests/build/\` 197/197 PASS

## Acceptance

After merge, rebuild a1/my-morning. python_qg already passes (PRs #2087 + #2090). wiki_coverage_gate's crash already fixed (#2091). With this parser fix, the gate should actually MATCH the writer's coverage claims and pass — then dim_review + MDX assembly proceed and m20 ships.

## Related

- PR #2087 (m20 Path A — closed 4 python_qg failure classes)
- PR #2090 (l2_exposure_floor counter fix — closed the 5th)
- PR #2091 (wiki_coverage_gate ENAMETOOLONG fix)
- This PR — gate now correctly counts the writer's emission

🤖 Generated with [Claude Code](https://claude.com/claude-code)