### PR TITLE
fix(writer): force explicit obligation coverage in implementation_map (#2094)

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -18,13 +18,23 @@ Each `<plan_reasoning>` block MUST contain these exact XML sub-nodes (do not wri
 <register>The immersion ratio from the Immersion Rule and how this section preserves it.</register>
 <teaching_sequence>Which Knowledge Packet facts/citations this section uses.</teaching_sequence>
 <implementation_map>
-For each obligation_id in the Wiki Obligations Manifest, list:
+**MUST list ALL `obligation_id`s from the Wiki Obligations Manifest. No exceptions.**
+
+The `<implementation_map>` blocks across your N section-`<plan_reasoning>` nodes, taken together, MUST mention every `obligation_id` in the manifest exactly once. Silent omission of any `obligation_id` is a HARD REJECT — the rebuild is wasted and the gate will fail with `implementation_map_missing`.
+
+For each `obligation_id` in the Wiki Obligations Manifest, list:
   - obligation_id: <id>
   - artifact: <module.md | activities.yaml | vocabulary.yaml | resources.yaml>
   - location: <section name or activity id>
   - treatment: <how the obligation is addressed, for example "contrast_pair in activity act-3"
                 or "prose explanation in section §Дієслова на -ся paragraph 2">
-Do not defer. Every obligation must be implemented in THIS module, not a later one.
+
+**Do not defer silently. Every obligation must be implemented in THIS module unless you explicitly mark it deferred.** If, after careful drafting, an obligation genuinely cannot fit within the four sections of this A1 module (e.g., it requires grammar not yet introduced), emit it anyway with:
+  - artifact: <none>
+  - location: <none>
+  - treatment: `deferred (out of A1 scope) — <one-sentence justification>`
+
+Explicit deferral is far better than silent omission: the gate sees an honest decision and the orchestrator can reassign the obligation. Silent omission is a HARD REJECT and forces a full rebuild.
 </implementation_map>
 <verification_plan>Specific MCP tools to be called for this section's claims.</verification_plan>
 <verification_trace>
@@ -46,6 +56,21 @@ Every signature listed here is a commitment to call that exact tool this turn; o
 Keep each `<plan_reasoning>` block to 200 words or fewer. Do not use triple backticks inside `<plan_reasoning>` blocks; fenced code belongs only in the four artifact blocks below.
 
 Only after all `<plan_reasoning>` blocks are complete and passed may you emit the four fenced artifact blocks.
+
+### Pre-emit obligation-count check (mandatory — #2094)
+
+Before emitting the four artifact fences, you MUST audit your own `<implementation_map>` blocks against the Wiki Obligations Manifest:
+
+1. Count the `obligation_id`s in the Wiki Obligations Manifest (call this `N`).
+2. Count the distinct `obligation_id`s mentioned across all your `<implementation_map>` blocks (call this `M`).
+3. If `M < N`, STOP. Go back, find the missing `obligation_id`s, and add them to the appropriate section's `<implementation_map>` — either with a real `treatment` or with the explicit `deferred (out of A1 scope)` escape hatch.
+4. Only when `M == N` may you proceed to emit the four artifact fences.
+
+Emit a single visible audit line BEFORE the artifact fences:
+
+`<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[<list any IDs that ended up with treatment: deferred>]</implementation_map_audit>`
+
+If this audit line is missing, or if `covered_in_map < manifest_obligations`, the writer has failed the protocol and the rebuild is wasted.
 
 ## Tier-1 verification discipline (do this WHILE drafting — #1661)
 


### PR DESCRIPTION
## Summary

Yesterday's 5-PR cascade (#2087, #2088, #2090, #2091, #2092, #2093) closed every infrastructure bug around `wiki_coverage_gate`. The residual problem is the writer itself: best build of the day hit only **4/18 = 22% coverage**, and worst (#15) regressed to 2/18, because the writer treats the existing 'list each obligation' instruction as suggestive rather than load-bearing.

This patch implements **Path 1** from the morning handoff (`docs/session-state/2026-05-17-morning-m20-five-fixes-plus-dagger-cleanup.md` § "Recommended next step"): convert the `<implementation_map>` block into a hard contract with an explicit-deferral escape hatch and a pre-emit count check.

### Why not Path 2 (lower threshold) or Path 3 (per-obligation loop)

- Path 2 violates `memory/MEMORY.md` #1 ("no lowering thresholds") and the broader pedagogy principle that incomplete wiki coverage is incomplete teaching.
- Path 3 (per-obligation review loop) is the right answer eventually but is a Phase 2b-sized refactor; Path 1 is the surgical now-fix.

### What this changes

| File | Before | After |
|---|---|---|
| `scripts/build/phases/linear-write.md` | `<implementation_map>` block says "for each obligation" without enforcement; no count check | HARD REJECT wording for silent omission; explicit `treatment: deferred (out of A1 scope) — <reason>` escape hatch; pre-emit count audit emitting `<implementation_map_audit>` visible line |

Total prompt delta: ~30 LOC additions, no logic / no tests / no API surface change.

### Expected impact

Per morning handoff: ~50% odds of >=80% coverage in 1-2 m20 rebuilds. The next session will validate by re-running `.venv/bin/python -u scripts/build/v7_build.py a1 m20-cooking-and-meals --worktree` and checking `wiki_coverage_gate` output for `covered_pct >= 0.8`.

### Verification

```text
> sed -n '20,50p' scripts/build/phases/linear-write.md
<implementation_map>
**MUST list ALL `obligation_id`s from the Wiki Obligations Manifest. No exceptions.**

The `<implementation_map>` blocks across your N section-`<plan_reasoning>` nodes, taken together, MUST mention every `obligation_id` in the manifest exactly once. Silent omission of any `obligation_id` is a HARD REJECT — the rebuild is wasted and the gate will fail with `implementation_map_missing`.

For each `obligation_id` in the Wiki Obligations Manifest, list:
  - obligation_id: <id>
  - artifact: <module.md | activities.yaml | vocabulary.yaml | resources.yaml>
  - location: <section name or activity id>
  - treatment: <how the obligation is addressed, for example "contrast_pair in activity act-3"
                or "prose explanation in section §Дієслова на -ся paragraph 2">

**Do not defer silently. Every obligation must be implemented in THIS module unless you explicitly mark it deferred.** If, after careful drafting, an obligation genuinely cannot fit within the four sections of this A1 module (e.g., it requires grammar not yet introduced), emit it anyway with:
  - artifact: <none>
  - location: <none>
  - treatment: `deferred (out of A1 scope) — <one-sentence justification>`

Explicit deferral is far better than silent omission: the gate sees an honest decision and the orchestrator can reassign the obligation. Silent omission is a HARD REJECT and forces a full rebuild.
</implementation_map>
<verification_plan>Specific MCP tools to be called for this section's claims.</verification_plan>
<verification_trace>
List the exact tool call signatures you intend to use for this section.

**Prefer single-primitive calls over compose-patterns.** The pipeline ships four single-call verifiers that collapse multi-step compositions:

- For Ukrainian quotes: `mcp__sources__verify_quote(author="...", text="...")` — ONE call returns `matched: bool, best_confidence: float`. Do not compose `search_literary + grep + reason`.
- For source attribution: `mcp__sources__verify_source_attribution(source="grinchenko_1907"|"esum"|"sum11"|"antonenko_davydovych"|"literary"|"heritage"|"wikipedia"|"style_guide", claim="...")` — ONE call returns `discusses: bool, evidence: [...]`. Do not compose multiple per-source `search_*` calls.
- For modernity / archaism: `mcp__sources__check_modern_form(word="...")` — ONE call returns modernity flags. Do not infer from raw VESUM tags.
- For Russian-shadow detection: `mcp__sources__check_russian_shadow(word="...")` — ONE call returns Russian-morphology confidence.

Use the compose-pattern (`mcp__sources__search_literary` / `search_grinchenko_1907` / `search_style_guide` etc.) ONLY when you need to retrieve evidence chunks for inclusion in the artifact (e.g., quoting a textbook passage). For verification (`matched/discusses/modern/russian-shadow` boolean questions), the single-primitive call is mandatory.
```

```text
> grep -n 'HARD REJECT\|MUST list ALL\|deferred (out of A1 scope)' scripts/build/phases/linear-write.md
21:**MUST list ALL `obligation_id`s from the Wiki Obligations Manifest. No exceptions.**
23:The `<implementation_map>` blocks across your N section-`<plan_reasoning>` nodes, taken together, MUST mention every `obligation_id` in the manifest exactly once. Silent omission of any `obligation_id` is a HARD REJECT — the rebuild is wasted and the gate will fail with `implementation_map_missing`.
35:  - treatment: `deferred (out of A1 scope) — <one-sentence justification>`
37:Explicit deferral is far better than silent omission: the gate sees an honest decision and the orchestrator can reassign the obligation. Silent omission is a HARD REJECT and forces a full rebuild.
66:3. If `M < N`, STOP. Go back, find the missing `obligation_id`s, and add them to the appropriate section's `<implementation_map>` — either with a real `treatment` or with the explicit `deferred (out of A1 scope)` escape hatch.
```

```text
> grep -n 'Pre-emit obligation-count check\|implementation_map_audit\|manifest_obligations=' scripts/build/phases/linear-write.md
60:### Pre-emit obligation-count check (mandatory — #2094)
71:`<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[<list any IDs that ended up with treatment: deferred>]</implementation_map_audit>`
```

```text
> git diff --stat main
 scripts/build/phases/linear-write.md | 29 +++++++++++++++++++++++++++--
 1 file changed, 27 insertions(+), 2 deletions(-)
```

```text
> .venv/bin/python -m pre_commit run --files scripts/build/phases/linear-write.md
ruff (lint)..........................................(no files to check)Skipped
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

## Test plan

- [x] Pre-commit hooks pass on the changed file
- [ ] Next-session test: rebuild m20-cooking-and-meals and check `wiki_coverage_gate` output (>=80% target)
- [ ] If coverage <80% after 2 rebuilds, escalate to Path 3 (per-obligation review loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)