### PR TITLE
fix(audit): inject_activity_ids gate fails when activities are unused (#2096)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6422,11 +6422,17 @@ def _inject_activity_gate(text: str, activities: list[dict[str, Any]]) -> dict[s
     injected = _INJECT_RE.findall(text)
     missing = [activity_id for activity_id in injected if activity_id not in ids]
     unused = sorted(ids - set(injected))
+    reasons = []
+    if missing:
+        reasons.append("missing_activity_ids")
+    if unused:
+        reasons.append("unused_activities_not_injected")
     return {
-        "passed": not missing,
+        "passed": not missing and not unused,
         "injected": injected,
         "missing": missing,
         "unused": unused,
+        "reason": ",".join(reasons) or None,
     }
 
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1157,6 +1157,33 @@ def _build_fake_verify_words(
     return fake_verify
 
 
+def test_inject_activity_gate_fails_when_activities_unused() -> None:
+    activities = [{"id": "act-1"}, {"id": "act-2"}, {"id": "act-3"}]
+    report = linear_pipeline._inject_activity_gate("## Діалоги\n\nБез маркерів.", activities)
+
+    assert report["passed"] is False
+    assert report["unused"] == ["act-1", "act-2", "act-3"]
+    assert "unused_activities" in report["reason"]
+
+
+def test_inject_activity_gate_passes_when_all_activities_injected() -> None:
+    activities = [{"id": "act-1"}, {"id": "act-2"}, {"id": "act-3"}]
+    text = "\n".join(
+        [
+            "## Діалоги",
+            "",
+            "<!-- INJECT_ACTIVITY: act-1 -->",
+            "<!-- INJECT_ACTIVITY: act-2 -->",
+            "<!-- INJECT_ACTIVITY: act-3 -->",
+        ]
+    )
+
+    report = linear_pipeline._inject_activity_gate(text, activities)
+
+    assert report["passed"] is True
+    assert report["unused"] == []
+
+
 def test_ai_slop_gate_ignores_correction_field_in_error_correction_activity(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

m20 build #17 (post-PR #2094) showed:
- `inject_activity_ids` gate passed (no missing IDs)
- BUT all 10 activities in `activities.yaml` were marked `unused` (zero `INJECT_ACTIVITY` markers in `module.md`)
- `l2_exposure_floor` failed counting `uk_tab3_activities = 0`

Root cause: `_inject_activity_gate` only failed on missing IDs, ignoring the `unused` list. The auto-correction in `_apply_activity_id_inserts` already exists and is wired through `PIPELINE_INSERT_GATES`, but it never triggered because the gate passed.

This patch makes the predicate strict: both `missing` and `unused` must be empty for pass. Auto-correction then runs on gate failure and appends `INJECT_ACTIVITY` markers for unused IDs, unblocking `l2_exposure_floor` downstream.

## Test plan

- [x] Regression test: gate fails when all activities unused
- [x] Regression test: gate passes when all activities injected
- [ ] After merge: m20 rebuild expected to pass `l2_exposure_floor` `uk_tab3_activities` check

## Verification output

`PIPELINE_INSERT_GATES` wiring:

```text
145:PIPELINE_INSERT_GATES = frozenset({"inject_activity_ids"})
```

`.venv/bin/pytest tests/build/test_linear_pipeline.py -k inject_activity -v`:

```text
====================== 2 passed, 107 deselected in 0.35s ======================
```

`git diff --stat main`:

```text
 scripts/build/linear_pipeline.py    |  8 +++++++-
 tests/build/test_linear_pipeline.py | 27 +++++++++++++++++++++++++++
 2 files changed, 34 insertions(+), 1 deletion(-)
```

`git diff --name-only main`:

```text
scripts/build/linear_pipeline.py
tests/build/test_linear_pipeline.py
```

`.venv/bin/python -m pre_commit run --files scripts/build/linear_pipeline.py tests/build/test_linear_pipeline.py`:

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

`git push -u origin codex/2096-inject-activity-gate-fix`:

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
warn on commits missing an X-Agent trailer...............................Passed
To github.com:learn-ukrainian/learn-ukrainian.github.io.git
 * [new branch]            codex/2096-inject-activity-gate-fix -> codex/2096-inject-activity-gate-fix
branch 'codex/2096-inject-activity-gate-fix' set up to track 'origin/codex/2096-inject-activity-gate-fix'.
```

Commit trailer check:

```text
Checking 1 commit(s) in origin/main..HEAD:

  f3b7696f05  PASS  X-Agent: codex/2096-inject-activity-gate-fix

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```