### PR TITLE
fix(audit): vesum_verified excludes resources notes field (#2098)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5244,7 +5244,11 @@ def _build_vesum_text(
     for entry in resources:
         if isinstance(entry, dict):
             parts.append(_strip_metalinguistic(str(entry.get("title", ""))))
-            parts.append(_strip_metalinguistic(str(entry.get("notes", ""))))
+            # Resource `notes` field is descriptive metadata (textbook
+            # attribution, sourcing context) — proper-noun inflections
+            # like "за Ларисою Ніцою" trip VESUM with false positives.
+            # The notes field is NOT learner-facing content. Skip from
+            # VESUM scope. Keep title / lemma / usage in scope (#2098).
     return "\n".join(part for part in parts if part)
 
 

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -2026,6 +2026,33 @@ def test_vesum_gate_passes_m20_build_3_artifacts() -> None:
         assert report["passed"] is True
 
 
+def test_vesum_gate_skips_resource_notes_field() -> None:
+    """Regression for #2098: resources notes field excluded, title kept."""
+    resources = [
+        {
+            "title": "Текст Фабрикація",
+            "notes": "за Ларисою Ніцою",
+            "lemma": "слово",
+            "usage": "вживання",
+        }
+    ]
+    fake_verify = _build_fake_verify_words(
+        known={"текст": True, "слово": True, "вживання": True, "за": True, "ларисою": True}
+    )
+    report = linear_pipeline._vesum_gate(
+        module_text="",
+        activities=[],
+        vocabulary=[],
+        resources=resources,
+        verify_words_fn=fake_verify,
+    )
+    # Notes field skipped, so "Ніцою" should not be missing
+    assert "ніцою" not in report["missing"]
+    assert "Ніцою" not in report["missing"]
+    # Title field included, so "Фабрикація" should be missing
+    assert "фабрикація" in report["missing"] or "Фабрикація" in report["missing"]
+
+
 def test_immersion_gate_recognizes_unicode_sentence_boundaries(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

vesum_verified gate at linear_pipeline.py:5247 included resources.yaml `notes` field in scope. The notes field is descriptive metadata (textbook attribution, sourcing context) and frequently contains inflected Ukrainian proper nouns (author surnames, place names) that VESUM doesn't index — guaranteed false-positive surface.

m20 build #17 example: "за Ларисою Ніцою" attribution trip. "Ніцою" is the legitimate instrumental of children's-author Лариса Ніца.

This patch excludes only the notes field. Other resource fields (title, lemma, usage) remain in scope.

## Test plan

- [x] Regression test: notes-field fabricated word doesn't trip gate
- [x] Regression test: title-field fabricated word DOES trip gate (scope preserved)
- [ ] After merge: m20 rebuild expected to clear the Ніцою false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)