### PR TITLE
fix(audit): VESUM accepts quiz correctAnswer + textbook_grounding ignores punctuation (#2103)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5416,6 +5416,17 @@ def _normalize_citation_ref(value: Any) -> str:
     return normalize_citation_ref(value)
 
 
+def _normalize_citation_match_text(value: Any) -> str:
+    normalized = _normalize_citation_ref(value).casefold()
+    return re.sub(r"[^\wа-яіїєґА-ЯІЇЄҐ]+", "", normalized)
+
+
+def _citation_ref_text_contains(reference_title: str, text: str) -> bool:
+    normalized_ref = _normalize_citation_match_text(reference_title)
+    normalized_text = _normalize_citation_match_text(text)
+    return bool(normalized_ref and normalized_ref in normalized_text)
+
+
 def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> dict[str, Any]:
     plan_reference_titles = extract_plan_reference_titles(plan)
     plan_titles = {_normalize_citation_ref(title) for title in plan_reference_titles}
@@ -5449,6 +5460,23 @@ def _extract_blockquote_records(text: str) -> list[dict[str, str]]:
     current: list[str] = []
     current_section = ""
     quote_section = ""
+    pending_attribution_index: int | None = None
+
+    def flush_quote() -> None:
+        nonlocal current, quote_section, pending_attribution_index
+        if not current:
+            return
+        quotes.append(
+            {
+                "quote": "\n".join(current).strip(),
+                "section_title": quote_section,
+                "attribution": "",
+            }
+        )
+        current = []
+        quote_section = ""
+        pending_attribution_index = len(quotes) - 1
+
     for line in text.splitlines():
         heading = re.match(r"^\s{0,3}#{1,6}\s+(?P<title>.+?)\s*#*\s*$", line)
         if heading:
@@ -5460,23 +5488,31 @@ def _extract_blockquote_records(text: str) -> list[dict[str, str]]:
             current.append(match.group("body"))
             continue
         if current:
-            quotes.append(
-                {
-                    "quote": "\n".join(current).strip(),
-                    "section_title": quote_section,
-                }
-            )
-            current = []
-            quote_section = ""
+            flush_quote()
+        if pending_attribution_index is not None:
+            if not line.strip():
+                continue
+            attribution = _extract_textbook_attribution(line)
+            if attribution:
+                quotes[pending_attribution_index]["attribution"] = attribution
+                pending_attribution_index = None
+                continue
+            pending_attribution_index = None
     if current:
-        quotes.append(
-            {"quote": "\n".join(current).strip(), "section_title": quote_section}
-        )
+        flush_quote()
     return [record for record in quotes if record["quote"]]
 
 
 def _extract_blockquotes(text: str) -> list[str]:
     return [record["quote"] for record in _extract_blockquote_records(text)]
+
+
+def _extract_textbook_attribution(line: str) -> str:
+    stripped = line.strip().strip("*_`~ ")
+    match = re.match(r"^[—–-]\s*(?P<body>.+?)\s*$", stripped)
+    if match is None:
+        return ""
+    return match.group("body").strip().strip("*_`~ ")
 
 
 def _normalize_match_text(text: str) -> str:
@@ -5826,9 +5862,7 @@ def _reference_matches_result(
             result_key = extract_citation_key(text)
             if result_key is not None and citation_keys_match(result_key, ref_key):
                 return True
-    normalized_ref = _normalize_citation_ref(reference_title).casefold()
-    normalized_result = _normalize_citation_ref(result_text).casefold()
-    return bool(normalized_ref and normalized_ref in normalized_result)
+    return _citation_ref_text_contains(reference_title, result_text)
 
 
 def _missing_corpus_refs_from_packet(module_dir: Path) -> set[str]:
@@ -5945,9 +5979,13 @@ def _textbook_grounding_gate(
         ]
         for record in long_blockquote_records:
             quote = record["quote"]
+            attribution = record.get("attribution", "")
+            candidate_results = ref_results
+            if not candidate_results and _citation_ref_text_contains(ref, attribution):
+                candidate_results = [result for _call, result in textbook_results]
             if not any(
                 _contains_textbook_quote(quote, _result_text_for_match(result))
-                for result in ref_results
+                for result in candidate_results
             ):
                 continue
             topic_text = f"{record['section_title']} {plan_reasoning}".strip()

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5280,12 +5280,14 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
 
     out: list[str] = []
 
-    def answer_values(answer: Any) -> set[str]:
-        if isinstance(answer, str):
-            return {answer}
-        if isinstance(answer, list):
-            return {item for item in answer if isinstance(item, str)}
-        return set()
+    def answer_values(*answers: Any) -> set[str]:
+        values: set[str] = set()
+        for answer in answers:
+            if isinstance(answer, str):
+                values.add(answer)
+            elif isinstance(answer, list):
+                values.update(item for item in answer if isinstance(item, str))
+        return values
 
     def walk_answer_options(options: Any, answers: set[str]) -> None:
         if not answers:
@@ -5327,8 +5329,13 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
                     # is always a suffix fragment.  Skip unconditionally.
                     # See #1967.
                     continue
-                if key == "options" and "answer" in node:
-                    walk_answer_options(child, answer_values(node.get("answer")))
+                if key == "options" and (
+                    "answer" in node or "correctAnswer" in node
+                ):
+                    walk_answer_options(
+                        child,
+                        answer_values(node.get("answer"), node.get("correctAnswer")),
+                    )
                     continue
                 if wrong_option and key == "text":
                     continue

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -3135,6 +3135,67 @@ def test_textbook_match_tokens_strips_syllable_breaks_symmetrically() -> None:
     assert compounds == ["івано-франківськ", "темно-синіи", "я-форма"]
 
 
+def test_textbook_grounding_matches_punctuation_different_attribution(
+    tmp_path: Path,
+) -> None:
+    quote = (
+        "Ранковий план Євгена простий і послідовний. Уранці він устав із "
+        "ліжка сам, прибрав ліжко сам, зробив зарядку сам, на кухні "
+        "поставив чашку, після сніданку помив посуд, а тато усміхався "
+        "й уважно дивився на сина."
+    )
+    module_text = "\n".join(
+        [
+            "## Ранковий план",
+            "",
+            f"> {quote}",
+            "",
+            "*— Захарійчук, Grade 1, p.24*",
+            "",
+        ]
+    )
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "writer_tool_calls.json").write_text(
+        json.dumps(
+            [
+                {
+                    "name": "mcp__sources__search_text",
+                    "result": [{"source_type": "textbook", "text": quote}],
+                }
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    plan = {"level": "a1", "references": [{"title": "Захарійчук Grade 1, p.24"}]}
+    wrong_page_plan = {
+        "level": "a1",
+        "references": [{"title": "Захарійчук Grade 1, p.52"}],
+    }
+
+    assert linear_pipeline._citation_ref_text_contains(
+        "Захарійчук Grade 1, p.24",
+        "— Захарійчук, Grade 1, p.24",
+    )
+    assert not linear_pipeline._citation_ref_text_contains(
+        "Захарійчук Grade 1, p.52",
+        "— Захарійчук, Grade 1, p.24",
+    )
+    report = linear_pipeline._textbook_grounding_gate(module_text, plan, module_dir)
+    wrong_page_report = linear_pipeline._textbook_grounding_gate(
+        module_text,
+        wrong_page_plan,
+        module_dir,
+    )
+
+    assert report["passed"] is True
+    assert report["matched"] == ["Захарійчук Grade 1, p.24"]
+    assert wrong_page_report["passed"] is False
+    assert wrong_page_report["matched"] == []
+    assert wrong_page_report["missing"] == ["Захарійчук Grade 1, p.52"]
+
+
 def test_count_uk_example_bullets_includes_table_rows() -> None:
     """`_count_uk_example_bullets` counts both bullet-list lines AND
     markdown table data rows containing UK content.

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1485,6 +1485,29 @@ def test_vesum_gate_skips_error_field_of_error_correction_items_shape(
     assert "одягаєшся" in forwarded
 
 
+@pytest.mark.parametrize("answer_key", ["correctAnswer", "answer"])
+def test_activity_vesum_text_filters_quiz_distractors_by_answer_spelling(
+    answer_key: str,
+) -> None:
+    activity = {
+        "id": "act-1",
+        "type": "quiz",
+        "title": "Оберіть правильну форму",
+        "items": [
+            {
+                "question": "Яка форма правильна для «я»?",
+                "options": ["користуювася", "користуюся"],
+                answer_key: "користуюся",
+            }
+        ],
+    }
+
+    vesum_text = linear_pipeline._activity_vesum_text(activity)
+
+    assert "користуювася" not in vesum_text
+    assert "користуюся" in vesum_text
+
+
 def test_vesum_gate_skips_fill_in_answer_suffix_without_options_field(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Two gate-scope fixes for m20 build #18:

- VESUM quiz option filtering now accepts both `answer` and `correctAnswer`, merging both if present, so intentional wrong distractors do not leak into VESUM scope.
- `textbook_grounding` fallback citation matching now strips punctuation/spacing before comparison and can use the immediate blockquote attribution when the `search_text` result contains the quote but no comparable source title.

## Test plan

- [x] Regression test: quiz with `correctAnswer` filters distractors
- [x] Regression test: quiz with `answer` still filters distractors
- [x] Regression test: punctuation-different textbook attribution matches
- [x] Regression test: substantively different page does not match
- [ ] After merge: m20 rebuild expected to pass `vesum_verified` and `textbook_grounding`

## Raw verification

`.venv/bin/pytest tests/build/test_linear_pipeline.py -k "vesum or textbook" -v`

```text
====================== 28 passed, 85 deselected in 1.11s =======================
```

`git diff --stat main && git diff --name-only main`

```text
 scripts/build/linear_pipeline.py    | 91 +++++++++++++++++++++++++++----------
 tests/build/test_linear_pipeline.py | 84 ++++++++++++++++++++++++++++++++++
 2 files changed, 152 insertions(+), 23 deletions(-)
scripts/build/linear_pipeline.py
tests/build/test_linear_pipeline.py
```

`.venv/bin/python -m pre_commit run --files scripts/build/linear_pipeline.py tests/build/test_linear_pipeline.py`

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

`.venv/bin/python scripts/audit/lint_agent_trailer.py`

```text
Checking 2 commit(s) in origin/main..HEAD:

  f92bb8cfb0  PASS  X-Agent: codex/2103-vesum-textbook-scope
  83302311bb  PASS  X-Agent: codex/2103-vesum-textbook-scope

✅ All 2 non-skipped commit(s) carry an X-Agent trailer.
```