### PR TITLE
fix(build): skip false true-false VESUM statements

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5270,6 +5270,10 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
     not VESUM lemmas. For quiz-like item dicts with `options:` plus `answer:`,
     only the option equal to the answer is verified; sibling distractors can be
     fabricated wrong forms.
+
+    For true-false activities, false statements are intentional wrong claims
+    and may contain fabricated Ukrainian forms. Only true statements are
+    verified; missing answers fail soft by skipping the statement.
     """
     activity_type = activity.get("type")
     skip_subtree = (
@@ -5304,6 +5308,10 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
         elif isinstance(options, str) and options in answers:
             walk(options, "options")
 
+    def walk_truefalse_statement(statement: Any, answer: Any) -> None:
+        if answer is True:
+            walk(statement, "statement")
+
     def walk(node: Any, parent_key: str | None, *, in_options_list: bool = False) -> None:
         if isinstance(node, dict):
             wrong_option = (
@@ -5336,6 +5344,9 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
                         child,
                         answer_values(node.get("answer"), node.get("correctAnswer")),
                     )
+                    continue
+                if activity_type == "true-false" and key == "statement":
+                    walk_truefalse_statement(child, node.get("answer"))
                     continue
                 if wrong_option and key == "text":
                     continue

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1508,6 +1508,30 @@ def test_activity_vesum_text_filters_quiz_distractors_by_answer_spelling(
     assert "користуюся" in vesum_text
 
 
+def test_activity_vesum_text_skips_false_true_false_statements() -> None:
+    activity = {
+        "id": "act-7",
+        "type": "true-false",
+        "title": "Перевірте твердження",
+        "items": [
+            {
+                "statement": "The verb «дивитися» has «я дивюся» in the 1st person singular.",
+                "answer": False,
+            },
+            {
+                "statement": "Форма «я дивлюся» правильна.",
+                "answer": True,
+            },
+        ],
+    }
+
+    vesum_text = linear_pipeline._activity_vesum_text(activity)
+
+    assert "дивюся" not in vesum_text
+    assert "дивлюся" in vesum_text
+    assert "правильна" in vesum_text
+
+
 def test_vesum_gate_skips_fill_in_answer_suffix_without_options_field(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Refs #2104.

## Summary
- Skip true-false `statement` text from VESUM when `answer: false` or the answer is missing.
- Continue scanning `answer: true` statements.
- Add a regression test covering fabricated false-statement content and valid true-statement content.

## Verification
```text
.venv/bin/pytest tests/build/test_linear_pipeline.py -k vesum -v
====================== 25 passed, 89 deselected in 1.16s ======================
```

```text
.venv/bin/python -m pre_commit run --files scripts/build/linear_pipeline.py tests/build/test_linear_pipeline.py
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

```text
git diff --stat main
 scripts/build/linear_pipeline.py    | 11 +++++++++++
 tests/build/test_linear_pipeline.py | 24 ++++++++++++++++++++++++
 2 files changed, 35 insertions(+)
```