### PR TITLE
feat(agent-runtime): wire DeepSeek v4 (pro + flash) for dispatch + ab discuss

### DIFF
--- a/docs/dispatch-briefs/2026-05-17-path3-pr1-implementation-map-seeder.md
+++ b/docs/dispatch-briefs/2026-05-17-path3-pr1-implementation-map-seeder.md
@@ -1,0 +1,399 @@
+# Dispatch brief — Path 3 PR1: `implementation_map.json` deterministic seeder
+
+**Agent:** Codex gpt-5.5 xhigh
+**Mode:** danger (commits + PR open; NO auto-merge)
+**Worktree:** required (per #1952, enforced by `delegate.py dispatch`)
+**Scope:** PR1 of 4 in Path 3 architecture per
+`docs/decisions/2026-05-17-path3-per-obligation-review-loop.md`. Sidecar file +
+deterministic seeder + contract tests. NO downstream behavioral changes
+(those are PR2/3). NO activity-stub generation (deferred to PR5 per card line 141).
+
+---
+
+## Why
+
+The V7 single-pass writer asymptotes at ~44% on strict 18-obligation manifests
+(m20 builds #16–#21 evidence in afternoon handoff). The architectural fix is
+to seed a deterministic skeleton BEFORE the writer runs so the writer's job
+becomes "fill slots" rather than "invent coverage structure." This PR creates
+that sidecar.
+
+Decision Card is approved (user sign-off recorded in
+`docs/session-state/2026-05-17-afternoon-path3-decision-card-handoff.md`
+under `afternoon_bar_status`). Card forbids "silently starting PR1"; that gate
+is satisfied — start now.
+
+---
+
+## What you build
+
+### 1. New module: `scripts/build/phases/implementation_map.py`
+
+Three responsibilities only. No imports of `linear_pipeline` (one-way
+dependency: pipeline imports this, not reverse).
+
+```python
+"""Deterministic implementation_map seeder for V7 Path 3."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+IMPLEMENTATION_MAP_SCHEMA: dict[str, Any] = { ... }  # see schema below
+TREATMENT_TEMPLATES: dict[str, dict[str, Any]] = { ... }  # per-type expected output shape
+
+class ImplementationMapEntry(TypedDict):
+    obligation_id: str
+    obligation_type: Literal[
+        "sequence_step", "l2_error", "phonetic_rule", "decolonization_ban"
+    ]
+    artifact: Literal["module.md", "activities.yaml"]
+    location_hint: str
+    treatment_template: dict[str, Any]
+    manifest_payload: dict[str, Any]   # verbatim copy of source row
+
+def seed_implementation_map(
+    manifest: dict[str, Any], *, plan: dict[str, Any] | None = None
+) -> dict[str, Any]: ...
+
+def write_implementation_map(payload: dict[str, Any], path: Path) -> None: ...
+
+def read_implementation_map(path: Path) -> dict[str, Any]: ...
+
+def validate_implementation_map(payload: dict[str, Any]) -> None: ...
+```
+
+#### Artifact-assignment rules (deterministic; per Decision Card Phase 0)
+
+| `obligation_type` | extra check | `artifact` |
+|---|---|---|
+| `l2_error` | `treatment == "contrast_pair"` | `activities.yaml` |
+| `l2_error` | `treatment == "prose_explanation"` (or anything else) | `module.md` |
+| `sequence_step` | — | `module.md` |
+| `phonetic_rule` | — | `module.md` |
+| `decolonization_ban` | — | `module.md` |
+
+#### `treatment_template` per type (the expected output shape the writer fills)
+
+The template documents what the gate expects the writer to put in
+the chosen artifact for THIS obligation. Used by PR2's gate output and PR3's
+batched reviewer. Keep it minimal here — just structural promise, not prose.
+
+```python
+TREATMENT_TEMPLATES = {
+    "l2_error.contrast_pair": {
+        "shape": "activities.yaml entry with fields {sentence, error, correction}",
+        "expected_error_value": "<from manifest_payload.incorrect>",
+        "expected_correction_value": "<from manifest_payload.correct>",
+    },
+    "l2_error.prose_explanation": {
+        "shape": "module.md prose paragraph that names manifest_payload.incorrect verbatim, contrasts with manifest_payload.correct, and explains manifest_payload.why",
+    },
+    "sequence_step": {
+        "shape": "module.md section heading or in-prose step marker matching manifest_payload.heading at the position implied by manifest_payload.step_num",
+        "required_claim": "<from manifest_payload.required_claim>",
+    },
+    "phonetic_rule": {
+        "shape": "module.md prose that states the rule mapping manifest_payload.written → manifest_payload.spoken with an explicit IPA bracket or equivalent",
+    },
+    "decolonization_ban": {
+        "shape": "module.md prose absent of any phrasing matching manifest_payload.rule (negative obligation: absence-of-pattern)",
+    },
+}
+```
+
+The `manifest_payload` field on each entry carries the verbatim manifest row
+so downstream consumers (PR2 gate, PR3 reviewer) don't need to re-join with
+the manifest. This is the "first-class mutable sidecar" Codex called out in
+the cross-agent votes.
+
+#### `location_hint` derivation
+
+If `plan` is provided AND contains sections with stable identifiers
+(`plan["sections"][i]["heading"]` or similar), pick the section whose
+heading most closely matches the obligation's manifest text. **First pass:
+keep this simple.** Use a substring-match heuristic:
+
+1. For `sequence_step`: location_hint = `f"§{manifest_payload['heading']}"` (the
+   step's own heading is the strongest hint).
+2. For `l2_error` / `phonetic_rule` / `decolonization_ban`: location_hint =
+   the first plan section heading whose text contains any keyword from the
+   obligation's `id` or its `incorrect`/`written`/`rule` field, falling back
+   to `"(any prose section)"` if no plan or no match.
+
+Do NOT do anything fancier — the writer can override location during fill-in;
+this is a hint, not a constraint. PR3's reviewer reads `manifest_payload.id`
+when applying fixes, not `location_hint`.
+
+If `plan is None`, `location_hint = "(any prose section)"` for the prose
+artifacts and `"activities.yaml"` for contrast_pair.
+
+#### Output shape
+
+```json
+{
+  "schema_version": 1,
+  "slug": "<from manifest.slug>",
+  "wiki_path": "<from manifest.wiki_path>",
+  "manifest_obligation_count": <int>,
+  "entries": [
+    {
+      "obligation_id": "step-1",
+      "obligation_type": "sequence_step",
+      "artifact": "module.md",
+      "location_hint": "§Привітання",
+      "treatment_template": { "shape": "...", "required_claim": "..." },
+      "manifest_payload": { "id": "step-1", "heading": "Привітання", "step_num": 1, "required_claim": "...", "source_lines": "..." }
+    },
+    ...
+  ]
+}
+```
+
+Entries appear in **manifest order** (the same order `validate_obligations`
+in `scripts/audit/wiki_coverage_gate.py` returns: sequence_steps → l2_errors
+→ phonetic_rules → decolonization_bans). This is deterministic and matches
+existing gate expectations.
+
+### 2. Pipeline wiring (LIGHT — write-only, no behavior change)
+
+In `scripts/build/v7_build.py` (NOT `linear_pipeline.py` — pipeline is
+write-once for this PR), after the wiki manifest is extracted and BEFORE the
+writer phase runs, call:
+
+```python
+from scripts.build.phases.implementation_map import (
+    seed_implementation_map, write_implementation_map,
+)
+
+impl_map = seed_implementation_map(wiki_manifest, plan=plan_data)
+write_implementation_map(impl_map, module_dir / "implementation_map.json")
+```
+
+Emit a JSONL event:
+`{"event": "implementation_map_seeded", "slug": <slug>, "entry_count": <int>, "path": "<module_dir>/implementation_map.json"}`
+
+That's it for wiring. Do NOT pass `impl_map` to the writer. Do NOT change
+prompts. Do NOT change gates. Writer still emits its own
+`<implementation_map>` blocks inline as today — PR2/3 will start consuming
+the sidecar.
+
+### 3. Contract tests: `tests/build/test_implementation_map.py`
+
+Mandatory test cases:
+
+1. **One entry per manifest obligation**: build a fixture manifest with 4
+   sequence_steps + 3 l2_errors (2 contrast_pair + 1 prose_explanation) + 2
+   phonetic_rules + 5 decolonization_bans → seeded map MUST have exactly 14
+   entries, in manifest order.
+2. **Artifact mapping is correct per the table**: assert each entry's
+   `artifact` field matches the rule for its type+treatment.
+3. **manifest_payload round-trips**: each entry's `manifest_payload` equals
+   the original manifest dict for that obligation (deep equality).
+4. **JSON schema validates seeded output**: `validate_implementation_map`
+   accepts the seeder output without raising.
+5. **Round-trip identity**: `read_implementation_map(write_implementation_map(x))`
+   equals `x` (deep equality, including key order doesn't matter but values do).
+6. **Empty manifest**: a manifest with zero obligations in all 4 groups
+   produces an empty `entries` array but still validates and writes.
+7. **`location_hint` fallback**: when `plan=None`, sequence_step entries use
+   `f"§{heading}"` from manifest_payload; other prose obligations use
+   `"(any prose section)"`; contrast_pair uses `"activities.yaml"`.
+8. **Determinism**: calling the seeder twice on the same input produces
+   byte-identical JSON (sort_keys, indent=2; verify in the test).
+9. **m20 real-world fixture**: extract the actual manifest from
+   `wiki/pedagogy/a1/my-morning.md` via `wiki_manifest.extract_manifest`,
+   seed the map, assert entry count equals the gate's obligation count for
+   that wiki (18 per afternoon handoff evidence — verify exact count from
+   the fixture; if my-morning.md has changed and the count differs, use
+   whatever the deterministic extractor returns and assert ≥10 and that
+   the count equals `len(validate_obligations(manifest))`).
+
+Use existing pytest patterns from `tests/build/test_linear_pipeline.py` for
+fixture loading.
+
+### 4. Schema JSON (optional, recommended)
+
+If schema validation needs a referenceable JSON file, write it to
+`scripts/build/phases/implementation_map.schema.json` and reference it from
+`IMPLEMENTATION_MAP_SCHEMA`. Otherwise inline the dict is fine.
+
+---
+
+## Verifiable claims this PR must produce (per #M-4)
+
+| Claim | Tool + raw output to quote in PR body |
+|---|---|
+| New module created | `git diff --stat origin/main` showing the new `scripts/build/phases/implementation_map.py` row |
+| Tests pass | `.venv/bin/pytest tests/build/test_implementation_map.py -v` final line raw (`N passed in M.MMs`) |
+| Full pytest still green | `.venv/bin/pytest tests/build/ -q` final summary line raw (NO `-x` — must surface every downstream failure, not just the first; per #1942) |
+| Ruff clean | `.venv/bin/ruff check scripts/build/phases/implementation_map.py tests/build/test_implementation_map.py` raw output (must be `All checks passed!`) |
+| m20 real-world seed works | one-shot: `.venv/bin/python -c "from scripts.build.phases.wiki_manifest import extract_manifest; from scripts.build.phases.implementation_map import seed_implementation_map; m = extract_manifest('wiki/pedagogy/a1/my-morning.md'); s = seed_implementation_map(m); print(f'entries={len(s[\"entries\"])} types={sorted({e[\"obligation_type\"] for e in s[\"entries\"]})}')"` raw output |
+| Pipeline wiring runs | dry-run of the new emit by importing v7_build and confirming `implementation_map_seeded` event appears (quote the new event in JSONL) — OR if dry-run too painful, quote `git diff scripts/build/v7_build.py` to prove the 5-line wiring landed |
+| Commit landed + PR opened | `git log -1 --oneline` raw + `gh pr view --json url` raw URL |
+
+**No claim allowed without its raw output line.** Per #M-4: a model can claim "we're done" with no evidence and the evaluator has nothing to disprove. Forbid that pattern.
+
+---
+
+## Worktree setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin
+git worktree add .worktrees/path3-pr1-impl-map-seeder -b feat/path3-pr1-implementation-map-seeder origin/main
+cd .worktrees/path3-pr1-impl-map-seeder
+```
+
+`delegate.py dispatch` handles the worktree creation when given
+`--worktree`. The path above is the canonical shape.
+
+---
+
+## Verification (must run all BEFORE pushing)
+
+`delegate.py dispatch` symlinks `.venv` into the worktree, so the
+`.venv/bin/...` invocations below resolve from inside the worktree.
+
+```bash
+# venv symlinked into worktree by delegate.py
+.venv/bin/pytest tests/build/test_implementation_map.py -v
+.venv/bin/pytest tests/build/ -q
+.venv/bin/ruff check scripts/build/phases/implementation_map.py tests/build/test_implementation_map.py
+.venv/bin/python -m pre_commit run --files scripts/build/phases/implementation_map.py tests/build/test_implementation_map.py scripts/build/v7_build.py
+git diff --stat origin/main
+git diff --name-only origin/main
+```
+
+Per #M-7: pre-commit ≠ pytest. Both required.
+Per #1942: do NOT pass `-x` to pytest in dispatched verification — must
+surface every downstream failure, not just the first.
+
+---
+
+## Commit + PR
+
+```bash
+git add scripts/build/phases/implementation_map.py \
+        tests/build/test_implementation_map.py \
+        scripts/build/v7_build.py
+# also: scripts/build/phases/implementation_map.schema.json if you broke schema out
+git commit -m "$(cat <<'EOF'
+feat(build): Path 3 PR1 — deterministic implementation_map.json seeder
+
+Path 3 architecture (docs/decisions/2026-05-17-path3-per-obligation-review-loop.md)
+splits coverage enforcement out of the writer prompt and into a deterministic
+sidecar + per-obligation review loop. This PR ships the sidecar.
+
+PR1 scope (this PR):
+* New module scripts/build/phases/implementation_map.py with schema,
+  deterministic seeder seed_implementation_map(manifest, plan=None),
+  read/write/validate utilities, and TREATMENT_TEMPLATES per obligation type.
+* Light wiring in scripts/build/v7_build.py: after wiki manifest extraction
+  and before writer phase, seed the map and write it to module_dir as
+  implementation_map.json. Emits "implementation_map_seeded" JSONL event.
+  No prompt or gate changes (those are PR2/PR3).
+* Contract tests covering: 1-row-per-obligation, deterministic artifact
+  assignment per type+treatment, manifest_payload round-trip, JSON schema
+  validation, write→read identity, empty-manifest, plan=None location_hint
+  fallback, byte-determinism, and an m20 wiki real-world smoke.
+
+Out of scope:
+* Activity-stub generation (deferred to PR5 per Decision Card line 141).
+* Any change to writer prompt, wiki_coverage_gate, or reviewer behavior
+  (those are PR2/PR3/PR4).
+* External resources are NOT seeded (wiki_coverage_gate's
+  validate_obligations excludes them today; keep PR1 aligned with the
+  current gate scope).
+
+Cross-agent vote convergence: Codex (first-class mutable sidecar),
+Gemini (Allocation-First), Grok (strict ADR-007 fixes-only), Claude
+(separate pipeline stage). Refined Path 3 = 4-vote consensus.
+
+Verification:
+* tests/build/test_implementation_map.py: <quote pytest final line>
+* tests/build/ green: <quote pytest final line>
+* ruff: <quote raw>
+* m20 real-world seed entry count: <quote stdout>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Codex <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/path3-pr1-implementation-map-seeder
+gh pr create --title "feat(build): Path 3 PR1 — deterministic implementation_map.json seeder" --body "$(cat <<'EOF'
+## Summary
+
+First of 4 Path 3 PRs per Decision Card `docs/decisions/2026-05-17-path3-per-obligation-review-loop.md`.
+
+Adds a deterministic per-obligation sidecar `implementation_map.json` written to module_dir before the writer runs. Seeder reads the wiki Obligations Manifest (already extracted deterministically by `scripts/build/phases/wiki_manifest.py`) and produces one entry per obligation with:
+* `obligation_id`, `obligation_type`, deterministically-picked `artifact` (module.md vs activities.yaml per type+treatment),
+* `location_hint` (best-effort plan section match; safe fallback when no plan),
+* `treatment_template` (per-type expected output shape — consumed by PR2/PR3 reviewer),
+* verbatim `manifest_payload` (first-class mutable sidecar per Codex's vote).
+
+NO downstream behavioral change in this PR. Writer prompt unchanged. wiki_coverage_gate unchanged. Reviewer unchanged. PR2 will extend wiki_coverage_gate to emit `<fix_proposals>` against this sidecar; PR3 wires the batched correction loop; PR4 adds the Goodhart sentinel.
+
+## Verifiable claims (per #M-4)
+
+* New module + tests landed: <quote git diff --stat>
+* `tests/build/test_implementation_map.py`: <quote pytest final line raw>
+* Full `tests/build/`: <quote pytest final line raw>
+* `ruff check`: <quote raw "All checks passed!" line>
+* m20 (`wiki/pedagogy/a1/my-morning.md`) real-world seed produces N entries: <quote stdout>
+* Determinism: byte-equal JSON across two seeder runs on same input (asserted in test 8)
+
+## Test plan
+
+* [x] One entry per manifest obligation, in manifest order
+* [x] Artifact mapping correct per type+treatment table (5 cases)
+* [x] manifest_payload round-trips verbatim
+* [x] Schema validates seeded output
+* [x] write→read identity
+* [x] Empty manifest produces empty entries, still validates
+* [x] location_hint fallback when plan=None
+* [x] Byte-determinism across two seeder runs
+* [x] m20 real-world smoke
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+NO `--auto-merge`. Leave the PR open; orchestrator merges after review.
+
+---
+
+## Out of scope (do NOT include)
+
+* Activity-stub generation in `activities.yaml` (PR5, per card line 141).
+* Any change to `linear-write.md` / writer prompt.
+* Any change to `wiki_coverage_gate.py` (PR2's job).
+* Any change to reviewer prompts or `_apply_writer_correction` (PR3's job).
+* Seeding external_resources (`wiki_coverage_gate.validate_obligations` excludes
+  them today; aligning with current gate scope avoids divergence).
+* Trying to be clever about location_hint matching. The hint is best-effort.
+  PR3's reviewer uses `obligation_id`, not `location_hint`, when applying
+  fixes.
+
+---
+
+## Anti-fabrication preamble
+
+If anything in this brief surprises you — the wiki_manifest dataclass shape
+is different from what you expected, a test fixture doesn't load, the m20
+manifest extraction errors — STOP and quote the surprise verbatim before
+patching. Don't paper over.
+
+If the `validate_obligations` in `wiki_coverage_gate.py` includes obligations
+beyond the 4 groups listed above by the time you read this, mirror its scope
+EXACTLY in the seeder (single source of truth: the gate). Quote both the
+`validate_obligations` group tuple and your seeder's group tuple in the PR
+description to prove they match.
+
+If a test feels redundant or impossible to write deterministically, name the
+specific test and the specific blocker — do not silently drop tests from the
+list.

--- a/scripts/agent_runtime/adapters/__init__.py
+++ b/scripts/agent_runtime/adapters/__init__.py
@@ -11,6 +11,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
+from .hermes_deepseek import HermesDeepSeekAdapter
 from .hermes_grok import HermesGrokAdapter
 
-__all__ = ["HermesGrokAdapter"]
+__all__ = ["HermesDeepSeekAdapter", "HermesGrokAdapter"]

--- a/scripts/agent_runtime/adapters/hermes_deepseek.py
+++ b/scripts/agent_runtime/adapters/hermes_deepseek.py
@@ -1,0 +1,193 @@
+"""HermesDeepSeekAdapter — wraps ``hermes -z PROMPT -m deepseek-v4-{pro|flash}``.
+
+Same Hermes -z one-shot pattern as HermesGrokAdapter: hermes resolves MCP tool
+calls inside its own session loop using ``~/.hermes/config.yaml``. The adapter
+only sees Hermes's final assistant message on stdout, so ``tool_calls_total``
+remains ``None`` (unknown, not zero).
+
+Model variants surfaced through ``model`` arg:
+* ``deepseek-v4-pro`` (default) — DeepSeek v4 Pro, primary content/review slot
+  post-2026-06-15 (per the late-evening 2026-05-17 bakeoff: A+ on content
+  review with MCP-backed verdict; matches Opus xhigh on coding; A- on plan).
+* ``deepseek-v4-flash`` — faster/cheaper variant, A+ on code review at ~15s
+  with zero false positives (the role winner per the same bakeoff).
+
+DeepSeek streams empty lines as keep-alives during reasoning (per their API
+FAQ). Hermes accumulates content past those lines correctly; opencode does
+not (33% banner-only flake observed). That's why this adapter wraps hermes
+instead of an OpenAI-shaped opencode adapter.
+
+Reasoning effort is config-scoped in Hermes ``-z`` mode (same as Grok). This
+adapter does NOT mutate ``~/.hermes/config.yaml`` per call to avoid races
+with concurrent dispatches; if a caller passes ``effort`` and the readable
+top-level Hermes config disagrees, we log a warning and continue with the
+configured runtime behavior.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..result import ParseResult
+from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_RATE_LIMIT_RE = re.compile(
+    r"rate limit|rate_limit|quota exceeded|too many requests|\bHTTP 429\b|\b429\b",
+    re.IGNORECASE,
+)
+_HERMES_CONFIG_PATH = Path.home() / ".hermes" / "config.yaml"
+
+
+@dataclass(frozen=True)
+class HermesDeepSeekParseResult(ParseResult):
+    """Parse result with explicit unknown tool-call telemetry.
+
+    Mirrors HermesGrokParseResult — Hermes ``-z`` mode does not expose a
+    structured tool-call trace, so ``tool_calls_total`` is ``None`` (unknown)
+    rather than ``0`` (zero verified calls). Downstream V7 telemetry preserves
+    that distinction.
+    """
+
+    tool_calls_total: int | None = None
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text or "").strip()
+
+
+def _read_hermes_config(path: Path = _HERMES_CONFIG_PATH) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _top_level_agent_effort(config: dict[str, Any]) -> str | None:
+    agent = config.get("agent")
+    if not isinstance(agent, dict):
+        return None
+    effort = agent.get("reasoning_effort")
+    if isinstance(effort, str) and effort.strip():
+        return effort.strip()
+    return None
+
+
+def _sources_mcp_registered(config: dict[str, Any]) -> bool:
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return False
+    sources = servers.get("sources")
+    if not isinstance(sources, dict):
+        return False
+    return bool(sources.get("enabled") is not False and sources.get("url"))
+
+
+class HermesDeepSeekAdapter:
+    """Adapter for the Hermes CLI using DeepSeek v4 (pro or flash)."""
+
+    name: str = "deepseek"
+    default_model: str = "deepseek-v4-pro"
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        """Build the Hermes one-shot invocation.
+
+        ``tool_config`` is intentionally not translated into CLI flags: Hermes
+        discovers MCP servers from ``~/.hermes/config.yaml``. Unknown keys are
+        ignored for forward compatibility with the common runtime contract.
+        """
+        _ = mode
+        _ = task_id
+        _ = session_id
+        _ = tool_config
+
+        config = _read_hermes_config()
+        configured_effort = _top_level_agent_effort(config)
+        if effort and configured_effort and configured_effort != effort:
+            _logger.warning(
+                "Hermes DeepSeek effort=%r requested, but ~/.hermes/config.yaml "
+                "agent.reasoning_effort=%r; using Hermes config without mutation",
+                effort,
+                configured_effort,
+            )
+        elif effort and configured_effort is None:
+            _logger.warning(
+                "Hermes DeepSeek effort=%r requested, but no readable top-level "
+                "agent.reasoning_effort was found in ~/.hermes/config.yaml; "
+                "using Hermes config without mutation",
+                effort,
+            )
+
+        if not _sources_mcp_registered(config):
+            _logger.warning(
+                "Hermes DeepSeek did not find enabled mcp_servers.sources in "
+                "~/.hermes/config.yaml; MCP tool availability depends on Hermes config"
+            )
+
+        hermes_bin = shutil.which("hermes") or "hermes"
+        return InvocationPlan(
+            cmd=[hermes_bin, "-z", prompt, "-m", model or self.default_model],
+            cwd=cwd,
+            stdin_payload="",
+            output_file=None,
+            env_overrides={},
+            liveness_paths=(),
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> HermesDeepSeekParseResult:
+        """Parse Hermes final stdout into a runtime result."""
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+
+        response = _strip_ansi(stdout)
+        clean_stderr = _strip_ansi(stderr)
+        rate_limited = returncode != 0 and bool(_RATE_LIMIT_RE.search(clean_stderr))
+        ok = returncode == 0 and bool(response) and not rate_limited
+        stderr_excerpt = None if ok else (clean_stderr or response or None)
+
+        return HermesDeepSeekParseResult(
+            ok=ok,
+            response=response if ok else "",
+            stderr_excerpt=stderr_excerpt[:500] if stderr_excerpt else None,
+            rate_limited=rate_limited,
+            session_id=None,
+            tokens=None,
+            tool_calls=[],
+            tool_calls_total=None,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Hermes ``-z`` writes to stdout; no separate liveness files."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -122,6 +122,20 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": True,
         "resume_policy": "never",
     },
+    "deepseek": {
+        "adapter": "scripts.agent_runtime.adapters.hermes_deepseek:HermesDeepSeekAdapter",
+        "default_model": "deepseek-v4-pro",
+        "cost_tier": "low",
+        "capabilities": frozenset({
+            "code_writing",
+            "code_review",
+            "content_writing",
+            "content_review",
+            "adversarial_review",
+        }),
+        "cli_available": True,
+        "resume_policy": "never",
+    },
 }
 
 

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -160,7 +160,11 @@ def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | No
         return _arg_after(plan.cmd, "--effort")
     if agent_name == "gemini":
         return None
-    if agent_name == "grok":
+    if agent_name in ("grok", "deepseek"):
+        # Hermes -z mode: effort is config-scoped (~/.hermes/config.yaml),
+        # not surfaced on the command line. Adapter logs a warning when the
+        # caller's request disagrees with the config — telemetry has nothing
+        # to resolve from the plan.
         return None
     return None
 
@@ -176,7 +180,7 @@ def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -
             _gemini_settings(),
             ("model", "defaultModel", "selectedModel", "modelName", "default_model"),
         )
-    if agent_name == "grok":
+    if agent_name in ("grok", "deepseek"):
         return _default_model_for(agent_name)
     if agent_name == "claude":
         return _default_model_for(agent_name)
@@ -220,7 +224,8 @@ def _gemini_version_prefix(cmd: list[str]) -> tuple[str, ...]:
     return ("gemini",)
 
 
-def _grok_version_prefix(cmd: list[str]) -> tuple[str, ...]:
+def _hermes_version_prefix(cmd: list[str]) -> tuple[str, ...]:
+    """Prefix for ``hermes --version`` probes. Used by every Hermes-backed agent."""
     if cmd:
         return (cmd[0],)
     return ("hermes",)
@@ -273,8 +278,9 @@ def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) ->
     if agent_name == "claude":
         prefix = _claude_version_prefix(plan.cmd) if plan is not None else ("claude",)
         return claude_cli_version(prefix)
-    if agent_name == "grok":
-        prefix = _grok_version_prefix(plan.cmd) if plan is not None else ("hermes",)
+    if agent_name in ("grok", "deepseek"):
+        # Both grok and deepseek run through hermes; one shared version probe.
+        prefix = _hermes_version_prefix(plan.cmd) if plan is not None else ("hermes",)
         return _probe_version(prefix)
     return None
 

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -30,6 +30,8 @@ def _canonical_agent_name(agent: str) -> str | None:
         return "codex"
     if agent.startswith("grok"):
         return "grok"
+    if agent.startswith("deepseek"):
+        return "deepseek"
     return None
 
 
@@ -229,7 +231,10 @@ def build_mcp_tool_config(
             ),
         )
 
-    if canonical_agent == "grok":
+    if canonical_agent in ("grok", "deepseek"):
+        # Both grok and deepseek route through Hermes; tool_config translation
+        # is identical (Hermes reads MCP servers from ~/.hermes/config.yaml,
+        # not from the per-call payload). Diagnostics point at the same file.
         if not mcp_servers:
             return None, _basic_diagnostics(
                 mcp_config_path=Path.home() / ".hermes" / "config.yaml",

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -75,6 +75,7 @@ VALID_AGENTS = (
     "gemini",
     "codex",
     "grok",
+    "deepseek",
     "claude-desktop",
     "codex-desktop",
 )

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -67,7 +67,7 @@ def _cli_available_agent(agent: str) -> bool:
     try:
         from agent_runtime.registry import get_agent_entry
     except ImportError:
-        return agent in {"claude", "codex", "gemini", "grok"}
+        return agent in {"claude", "codex", "gemini", "grok", "deepseek"}
 
     try:
         return bool(get_agent_entry(agent)["cli_available"])

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1527,8 +1527,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fire a task, return immediately",
         formatter_class=_dispatch_help_formatter,
     )
-    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude", "grok"],
-                   help="Agent to run for the task: codex, gemini, claude, or grok.")
+    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude", "grok", "deepseek"],
+                   help="Agent to run for the task: codex, gemini, claude, grok, or deepseek.")
     d.add_argument("--task-id", required=True,
                    help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")

--- a/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
+++ b/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.adapters.hermes_deepseek import HermesDeepSeekAdapter
+from agent_runtime.errors import AgentTimeoutError, AgentUnavailableError
+from agent_runtime.runner import invoke
+from agent_runtime.usage import _reset_rate_limit_cache_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime(tmp_path):
+    _reset_rate_limit_cache_for_tests()
+    with patch("agent_runtime.usage._usage_dir", return_value=tmp_path / "api_usage"):
+        yield
+    _reset_rate_limit_cache_for_tests()
+
+
+def _build(prompt: str, tmp_path: Path, model: str = "deepseek-v4-pro"):
+    return HermesDeepSeekAdapter().build_invocation(
+        prompt=prompt,
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=model,
+        task_id=None,
+        session_id=None,
+        tool_config={"hermes_mcp_servers": ["sources"]},
+        effort="medium",
+    )
+
+
+def test_deepseek_adapter_invokes_hermes_z_with_correct_argv_pro(tmp_path, monkeypatch):
+    monkeypatch.setattr("agent_runtime.adapters.hermes_deepseek.shutil.which", lambda _: "hermes")
+
+    plan = _build("Write the module.", tmp_path, model="deepseek-v4-pro")
+
+    assert plan.cmd == ["hermes", "-z", "Write the module.", "-m", "deepseek-v4-pro"]
+    assert plan.cwd == tmp_path
+    assert plan.stdin_payload == ""
+
+
+def test_deepseek_adapter_invokes_hermes_z_with_correct_argv_flash(tmp_path, monkeypatch):
+    """Flash variant uses the same shape, different ``-m``."""
+    monkeypatch.setattr("agent_runtime.adapters.hermes_deepseek.shutil.which", lambda _: "hermes")
+
+    plan = _build("Review this code.", tmp_path, model="deepseek-v4-flash")
+
+    assert plan.cmd == ["hermes", "-z", "Review this code.", "-m", "deepseek-v4-flash"]
+
+
+def test_deepseek_adapter_default_model_is_pro(tmp_path, monkeypatch):
+    """When model=None, the adapter falls back to deepseek-v4-pro (primary)."""
+    monkeypatch.setattr("agent_runtime.adapters.hermes_deepseek.shutil.which", lambda _: "hermes")
+    adapter = HermesDeepSeekAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="hi",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+        effort=None,
+    )
+
+    assert plan.cmd[-1] == "deepseek-v4-pro"
+
+
+def test_deepseek_adapter_returns_stdout_as_response():
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="hello from deepseek",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "hello from deepseek"
+
+
+def test_deepseek_adapter_tool_calls_total_is_none_not_zero():
+    """Hermes ``-z`` exposes no tool-call trace — distinguish unknown from zero."""
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="hello",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.tool_calls == []
+    assert result.tool_calls_total is None
+
+
+def test_deepseek_adapter_handles_missing_hermes_binary(tmp_path):
+    with (
+        patch("agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("agent_runtime.runner.write_record"),
+        patch(
+            "agent_runtime.runner.subprocess.Popen",
+            side_effect=FileNotFoundError("hermes"),
+        ),
+        pytest.raises(AgentUnavailableError, match="Popen failed: FileNotFoundError"),
+    ):
+        invoke(
+            "deepseek",
+            "hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="deepseek-v4-pro",
+            entrypoint="dispatch",
+            effort="medium",
+        )
+
+
+def test_deepseek_adapter_honors_timeout(tmp_path, monkeypatch):
+    adapter = HermesDeepSeekAdapter()
+
+    def fake_build_invocation(**kwargs):
+        return InvocationPlan(cmd=["/bin/sh", "-c", "sleep 5"], cwd=Path(kwargs["cwd"]))
+
+    monkeypatch.setattr(adapter, "build_invocation", fake_build_invocation)
+    monkeypatch.setattr("agent_runtime.runner._load_adapter", lambda _name: adapter)
+
+    with (
+        patch("agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("agent_runtime.runner.write_record"),
+        pytest.raises(AgentTimeoutError),
+    ):
+        invoke(
+            "deepseek",
+            "hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="deepseek-v4-pro",
+            entrypoint="dispatch",
+            hard_timeout=1,
+        )
+
+
+def test_deepseek_adapter_strips_ansi_codes_from_stdout():
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="\x1b[32mhello\x1b[0m",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.response == "hello"
+
+
+def test_deepseek_adapter_detects_rate_limit():
+    """Rate-limit pattern (HTTP 429 / "rate limit") is surfaced on returncode != 0."""
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="",
+        stderr="HTTP 429 rate limit exceeded",
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.rate_limited is True
+    assert result.ok is False
+
+
+def test_runner_preserves_unknown_deepseek_tool_call_total(tmp_path, monkeypatch):
+    """Runner round-trip preserves the unknown-vs-zero distinction."""
+    adapter = HermesDeepSeekAdapter()
+
+    def fake_build_invocation(**kwargs):
+        return InvocationPlan(cmd=["/bin/sh", "-c", "printf hello"], cwd=Path(kwargs["cwd"]))
+
+    monkeypatch.setattr(adapter, "build_invocation", fake_build_invocation)
+    monkeypatch.setattr("agent_runtime.runner._load_adapter", lambda _name: adapter)
+
+    with (
+        patch("agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("agent_runtime.runner.write_record"),
+    ):
+        result = invoke(
+            "deepseek",
+            "hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model="deepseek-v4-pro",
+            entrypoint="dispatch",
+            effort="medium",
+        )
+
+    assert result.response == "hello"
+    assert result.tool_calls == []
+    assert result.tool_calls_total is None
+
+
+def test_registry_lists_deepseek_with_hermes_adapter():
+    """Sanity check: registry entry is wired to the new adapter class."""
+    from agent_runtime.registry import get_agent_entry
+
+    entry = get_agent_entry("deepseek")
+    assert entry["cli_available"] is True
+    assert entry["default_model"] == "deepseek-v4-pro"
+    assert entry["adapter"].endswith(":HermesDeepSeekAdapter")
+    assert entry["resume_policy"] == "never"

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -571,10 +571,10 @@ def test_sync_all_iterates_known_agents(monkeypatch, capsys):
         _make_thread(agent, channel=f"{agent}-topic", count=1)
     # Mirrors the live `cmd_sync --all` iteration order, which is
     # `[agent for agent in _channels.VALID_AGENTS if _cli_available_agent(agent)]`.
-    # When a new CLI agent is registered (e.g. grok via #1934), this list
-    # tracks the registry — the test guards the iteration order, not a
-    # frozen subset.
-    cli_agents = ["claude", "gemini", "codex", "grok"]
+    # When a new CLI agent is registered (e.g. grok via #1934, deepseek
+    # via #2107), this list tracks the registry — the test guards the
+    # iteration order, not a frozen subset.
+    cli_agents = ["claude", "gemini", "codex", "grok", "deepseek"]
 
     calls: list[tuple[str, dict[str, object]]] = []
 


### PR DESCRIPTION
## Summary

Full DeepSeek support per user TOP PRIO override 2026-05-17 evening — so DeepSeek can be dispatched via \`delegate.py\` AND participate in \`ab discuss\` multi-agent rounds. Bakeoff evidence in \`docs/agents/AGENT-CAPABILITY-MATRIX.md\` shows DeepSeek-flash is the Code Review winner (A+, ~15s, zero false positives) and DeepSeek-pro is the Content Review winner (A+, MCP-backed verdict); DeepSeek-pro inherits the Content Writing slot post-2026-06-15 when Opus dispatches end.

Both variants route through \`hermes -z PROMPT -m MODEL\`, the same pattern as the existing grok adapter. This PR adds a hermes-backed adapter for DeepSeek and wires it into every surface that knew about grok before.

## What changed

* New \`HermesDeepSeekAdapter\` — exact shape of \`HermesGrokAdapter\`, defaults to \`deepseek-v4-pro\`, accepts \`deepseek-v4-flash\` via \`--model\`. \`tool_calls_total=None\` (unknown, not zero — Hermes -z exposes no tool-call trace).
* Registry: \`AGENTS[\"deepseek\"]\` entry with capabilities frozenset({code_writing, code_review, content_writing, content_review, adversarial_review}), \`cli_available=True\`, \`resume_policy=\"never\"\`.
* \`tool_config.py\`: \`_canonical_agent_name('deepseek*') -> 'deepseek'\` + MCP tool_config translation merged with the grok branch (both share \`~/.hermes/config.yaml\` discovery).
* \`telemetry.py\`: \`_grok_version_prefix\` renamed to the shared \`_hermes_version_prefix\` (no external callers — safe rename). Model/effort/version resolution arms collapse via \"in (grok, deepseek)\" checks.
* \`delegate.py\`: \`dispatch --agent\` choices now include \"deepseek\".
* \`scripts/ai_agent_bridge/_channels.py\`: \`VALID_AGENTS\` adds \"deepseek\".
* \`scripts/ai_agent_bridge/_channels_cli.py\`: \`_cli_available_agent\` fallback set (only hit when \`agent_runtime.registry\` import fails) adds \"deepseek\".
* \`tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py\`: 11-test contract suite mirroring \`test_hermes_grok_adapter.py\` (pro + flash argv shape, default-model fallback, response parsing, tool_calls_total=None invariant, missing-binary, timeout, ANSI strip, rate-limit detection, runner round-trip, registry sanity).

Also includes a separately-committed dispatch brief for **Path 3 PR1** (the deterministic \`implementation_map.json\` seeder) — drafted last session per the signed-off Decision Card. Not fired yet; documented here for traceability and to ride the same PR queue cycle.

## Verifiable claims (per #M-4)

| Claim | Raw output |
|---|---|
| \`hermes -z\` end-to-end works | \`hermes -z \"Respond with exactly: PING_OK\" -m deepseek-v4-flash\` → \`PING_OK\` |
| New adapter tests pass | \`.venv/bin/pytest tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py -v\` → \`11 passed in 4.86s\` |
| Adjacent suites still green | \`pytest tests/agent_runtime/ tests/test_channels_registry.py tests/test_grok_integration.py tests/test_delegate.py\` → \`113 passed in 10.93s\` |
| Telemetry + dispatch-api suites green | \`pytest tests/test_delegate_api.py tests/test_delegate_check_budget.py tests/test_delegate_data_symlinks.py tests/test_telemetry_router.py tests/api/test_delegate_active.py\` → \`22 passed in 0.94s\` |
| Ruff clean | \`ruff check\` on changed files → \`All checks passed!\` |
| Pre-commit clean | \`pre_commit run --files <changed>\` → all Passed/Skipped |
| \`delegate.py dispatch --help\` exposes deepseek | argv choices: \`{codex,gemini,claude,grok,deepseek}\` |
| Dry-run dispatch pre-flight passes | \`delegate.py dispatch --agent deepseek --task-id deepseek-smoke-test --prompt ping --dry-run\` → \`deepseek-smoke-test\` |
| Canonical name resolution | \`_canonical_agent_name('deepseek-v4-pro') == 'deepseek'\`, \`('deepseek-v4-flash') == 'deepseek'\` |
| Registry sanity | \`get_agent_entry('deepseek').cli_available is True\`, adapter ends \":HermesDeepSeekAdapter\" |
| Bridge VALID_AGENTS includes deepseek | \`_channels.VALID_AGENTS == ('claude','gemini','codex','grok','deepseek','claude-desktop','codex-desktop')\` |

## Test plan

- [x] 11 new adapter contract tests pass
- [x] Existing grok integration tests stay green (parallel pattern not regressed)
- [x] Delegate dry-run pre-flight passes for \`--agent deepseek\`
- [x] \`ab discuss --with deepseek,...\` would accept the agent (VALID_AGENTS + \`_cli_available_agent\` both wired)
- [ ] **After merge:** smoke-test a real \`delegate.py dispatch --agent deepseek --task-id deepseek-live-smoke --prompt \"PING\"\` and one \`ab discuss\` round including deepseek alongside codex+gemini

NO --auto-merge. Leave open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)