### PR TITLE
feat(build): Path 3 PR1 - deterministic implementation_map.json seeder

### DIFF
--- a/scripts/build/phases/implementation_map.py
+++ b/scripts/build/phases/implementation_map.py
@@ -1,0 +1,331 @@
+"""Deterministic implementation_map seeder for V7 Path 3."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+ObligationType = Literal[
+    "sequence_step",
+    "l2_error",
+    "phonetic_rule",
+    "decolonization_ban",
+]
+Artifact = Literal["module.md", "activities.yaml"]
+
+OBLIGATION_GROUPS: tuple[tuple[str, ObligationType], ...] = (
+    ("sequence_steps", "sequence_step"),
+    ("l2_errors", "l2_error"),
+    ("phonetic_rules", "phonetic_rule"),
+    ("decolonization_bans", "decolonization_ban"),
+)
+
+IMPLEMENTATION_MAP_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "schema_version",
+        "slug",
+        "wiki_path",
+        "manifest_obligation_count",
+        "entries",
+    ],
+    "properties": {
+        "schema_version": {"const": 1},
+        "slug": {"type": "string"},
+        "wiki_path": {"type": "string"},
+        "manifest_obligation_count": {"type": "integer", "minimum": 0},
+        "entries": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "obligation_id",
+                    "obligation_type",
+                    "artifact",
+                    "location_hint",
+                    "treatment_template",
+                    "manifest_payload",
+                ],
+                "properties": {
+                    "obligation_id": {"type": "string"},
+                    "obligation_type": {
+                        "enum": [obligation_type for _, obligation_type in OBLIGATION_GROUPS],
+                    },
+                    "artifact": {"enum": ["module.md", "activities.yaml"]},
+                    "location_hint": {"type": "string"},
+                    "treatment_template": {"type": "object"},
+                    "manifest_payload": {"type": "object"},
+                },
+                "additionalProperties": False,
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+TREATMENT_TEMPLATES: dict[str, dict[str, Any]] = {
+    "l2_error.contrast_pair": {
+        "shape": "activities.yaml entry with fields {sentence, error, correction}",
+        "expected_error_value": "<from manifest_payload.incorrect>",
+        "expected_correction_value": "<from manifest_payload.correct>",
+    },
+    "l2_error.prose_explanation": {
+        "shape": (
+            "module.md prose paragraph that names manifest_payload.incorrect verbatim, "
+            "contrasts with manifest_payload.correct, and explains manifest_payload.why"
+        ),
+    },
+    "sequence_step": {
+        "shape": (
+            "module.md section heading or in-prose step marker matching "
+            "manifest_payload.heading at the position implied by manifest_payload.step_num"
+        ),
+        "required_claim": "<from manifest_payload.required_claim>",
+    },
+    "phonetic_rule": {
+        "shape": (
+            "module.md prose that states the rule mapping manifest_payload.written "
+            "-> manifest_payload.spoken with an explicit IPA bracket or equivalent"
+        ),
+    },
+    "decolonization_ban": {
+        "shape": (
+            "module.md prose absent of any phrasing matching manifest_payload.rule "
+            "(negative obligation: absence-of-pattern)"
+        ),
+    },
+}
+
+
+class ImplementationMapEntry(TypedDict):
+    obligation_id: str
+    obligation_type: ObligationType
+    artifact: Artifact
+    location_hint: str
+    treatment_template: dict[str, Any]
+    manifest_payload: dict[str, Any]
+
+
+def seed_implementation_map(
+    manifest: dict[str, Any],
+    *,
+    plan: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Seed one deterministic implementation-map entry per manifest obligation."""
+    entries: list[ImplementationMapEntry] = []
+    for obligation_type, manifest_payload in _iter_manifest_obligations(manifest):
+        artifact = _artifact_for(obligation_type, manifest_payload)
+        entries.append(
+            {
+                "obligation_id": str(manifest_payload.get("id") or ""),
+                "obligation_type": obligation_type,
+                "artifact": artifact,
+                "location_hint": _location_hint(obligation_type, manifest_payload, artifact, plan),
+                "treatment_template": _treatment_template(obligation_type, manifest_payload),
+                "manifest_payload": manifest_payload,
+            }
+        )
+
+    payload = {
+        "schema_version": 1,
+        "slug": str(manifest.get("slug") or ""),
+        "wiki_path": str(manifest.get("wiki_path") or ""),
+        "manifest_obligation_count": len(entries),
+        "entries": entries,
+    }
+    validate_implementation_map(payload)
+    return payload
+
+
+def write_implementation_map(payload: dict[str, Any], path: Path) -> None:
+    """Write a validated implementation map as deterministic JSON."""
+    validate_implementation_map(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_implementation_map(path: Path) -> dict[str, Any]:
+    """Read and validate an implementation map from JSON."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("implementation_map payload must be an object")
+    validate_implementation_map(payload)
+    return payload
+
+
+def validate_implementation_map(payload: dict[str, Any]) -> None:
+    """Validate the implementation_map.json contract."""
+    if not isinstance(payload, dict):
+        raise ValueError("implementation_map payload must be an object")
+
+    required = set(IMPLEMENTATION_MAP_SCHEMA["required"])
+    missing = sorted(required.difference(payload))
+    if missing:
+        raise ValueError(f"implementation_map missing required keys: {', '.join(missing)}")
+
+    allowed = required
+    extra = sorted(set(payload).difference(allowed))
+    if extra:
+        raise ValueError(f"implementation_map has unexpected keys: {', '.join(extra)}")
+
+    if payload["schema_version"] != 1:
+        raise ValueError("implementation_map schema_version must be 1")
+    if not isinstance(payload["slug"], str) or not payload["slug"].strip():
+        raise ValueError("implementation_map slug must be a non-empty string")
+    if not isinstance(payload["wiki_path"], str):
+        raise ValueError("implementation_map wiki_path must be a string")
+    if not isinstance(payload["manifest_obligation_count"], int) or payload["manifest_obligation_count"] < 0:
+        raise ValueError("implementation_map manifest_obligation_count must be a non-negative integer")
+
+    entries = payload["entries"]
+    if not isinstance(entries, list):
+        raise ValueError("implementation_map entries must be a list")
+    if payload["manifest_obligation_count"] != len(entries):
+        raise ValueError("implementation_map manifest_obligation_count must equal len(entries)")
+
+    for index, entry in enumerate(entries, start=1):
+        _validate_entry(index, entry)
+
+
+def _iter_manifest_obligations(manifest: Mapping[str, Any]) -> list[tuple[ObligationType, dict[str, Any]]]:
+    obligations: list[tuple[ObligationType, dict[str, Any]]] = []
+    for group, obligation_type in OBLIGATION_GROUPS:
+        raw_items = manifest.get(group) or []
+        if not isinstance(raw_items, Sequence) or isinstance(raw_items, (str, bytes)):
+            continue
+        for item in raw_items:
+            if isinstance(item, Mapping):
+                obligations.append((obligation_type, copy.deepcopy(dict(item))))
+    return obligations
+
+
+def _artifact_for(obligation_type: ObligationType, manifest_payload: Mapping[str, Any]) -> Artifact:
+    if obligation_type == "l2_error" and manifest_payload.get("treatment") == "contrast_pair":
+        return "activities.yaml"
+    return "module.md"
+
+
+def _template_key(obligation_type: ObligationType, manifest_payload: Mapping[str, Any]) -> str:
+    if obligation_type == "l2_error":
+        if manifest_payload.get("treatment") == "contrast_pair":
+            return "l2_error.contrast_pair"
+        return "l2_error.prose_explanation"
+    return obligation_type
+
+
+def _treatment_template(
+    obligation_type: ObligationType,
+    manifest_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    template = copy.deepcopy(TREATMENT_TEMPLATES[_template_key(obligation_type, manifest_payload)])
+    for key, value in list(template.items()):
+        if isinstance(value, str) and value.startswith("<from manifest_payload.") and value.endswith(">"):
+            payload_key = value.removeprefix("<from manifest_payload.").removesuffix(">")
+            template[key] = manifest_payload.get(payload_key)
+    return template
+
+
+def _location_hint(
+    obligation_type: ObligationType,
+    manifest_payload: Mapping[str, Any],
+    artifact: Artifact,
+    plan: Mapping[str, Any] | None,
+) -> str:
+    if artifact == "activities.yaml":
+        return "activities.yaml"
+    if obligation_type == "sequence_step":
+        return f"§{str(manifest_payload.get('heading') or '').strip()}"
+    if plan is None:
+        return "(any prose section)"
+
+    keywords = _location_keywords(obligation_type, manifest_payload)
+    for heading in _plan_section_headings(plan):
+        heading_text = heading.casefold()
+        if any(keyword.casefold() in heading_text for keyword in keywords):
+            return f"§{heading}"
+    return "(any prose section)"
+
+
+def _location_keywords(
+    obligation_type: ObligationType,
+    manifest_payload: Mapping[str, Any],
+) -> list[str]:
+    fields = ["id"]
+    if obligation_type == "l2_error":
+        fields.append("incorrect")
+    elif obligation_type == "phonetic_rule":
+        fields.append("written")
+    elif obligation_type == "decolonization_ban":
+        fields.append("rule")
+
+    keywords: list[str] = []
+    for field in fields:
+        value = manifest_payload.get(field)
+        if value is None:
+            continue
+        keywords.extend(_keywords(str(value)))
+    return keywords
+
+
+def _keywords(value: str) -> list[str]:
+    return [token for token in re.findall(r"[\w'’ʼ]+", value, flags=re.UNICODE) if len(token) >= 3]
+
+
+def _plan_section_headings(plan: Mapping[str, Any]) -> list[str]:
+    headings: list[str] = []
+    for collection_key in ("sections", "content_outline"):
+        sections = plan.get(collection_key)
+        if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
+            continue
+        for section in sections:
+            if not isinstance(section, Mapping):
+                continue
+            for heading_key in ("heading", "section", "title", "id"):
+                heading = section.get(heading_key)
+                if isinstance(heading, str) and heading.strip():
+                    headings.append(heading.strip())
+                    break
+    return headings
+
+
+def _validate_entry(index: int, entry: Any) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(f"implementation_map entries[{index}] must be an object")
+
+    required = set(IMPLEMENTATION_MAP_SCHEMA["properties"]["entries"]["items"]["required"])
+    missing = sorted(required.difference(entry))
+    if missing:
+        raise ValueError(f"implementation_map entries[{index}] missing required keys: {', '.join(missing)}")
+
+    extra = sorted(set(entry).difference(required))
+    if extra:
+        raise ValueError(f"implementation_map entries[{index}] has unexpected keys: {', '.join(extra)}")
+
+    obligation_id = entry["obligation_id"]
+    obligation_type = entry["obligation_type"]
+    artifact = entry["artifact"]
+    location_hint = entry["location_hint"]
+    treatment_template = entry["treatment_template"]
+    manifest_payload = entry["manifest_payload"]
+
+    if not isinstance(obligation_id, str) or not obligation_id.strip():
+        raise ValueError(f"implementation_map entries[{index}] obligation_id must be a non-empty string")
+    if obligation_type not in {obligation_type for _, obligation_type in OBLIGATION_GROUPS}:
+        raise ValueError(f"implementation_map entries[{index}] has invalid obligation_type: {obligation_type}")
+    if artifact not in {"module.md", "activities.yaml"}:
+        raise ValueError(f"implementation_map entries[{index}] has invalid artifact: {artifact}")
+    if not isinstance(location_hint, str) or not location_hint.strip():
+        raise ValueError(f"implementation_map entries[{index}] location_hint must be a non-empty string")
+    if not isinstance(treatment_template, dict) or not treatment_template.get("shape"):
+        raise ValueError(f"implementation_map entries[{index}] treatment_template must include shape")
+    if not isinstance(manifest_payload, dict):
+        raise ValueError(f"implementation_map entries[{index}] manifest_payload must be an object")
+    if manifest_payload.get("id") != obligation_id:
+        raise ValueError(f"implementation_map entries[{index}] obligation_id must match manifest_payload.id")

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
 import sys
@@ -20,6 +21,10 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from scripts.agent_runtime.errors import AgentStalledError
 from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import (
+    seed_implementation_map,
+    write_implementation_map,
+)
 from scripts.common.thresholds import QG_DIMS
 
 DEFAULT_WRITER_TIMEOUT_S = 1800
@@ -677,11 +682,12 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             plan=plan,
         )
-        wiki_manifest = linear_pipeline.build_wiki_manifest(
+        wiki_manifest_data = linear_pipeline.build_wiki_manifest_data(
             level=level,
             slug=slug,
             plan=plan,
         )
+        wiki_manifest = json.dumps(wiki_manifest_data, ensure_ascii=False, indent=2)
         _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
 
         if args.dry_run:
@@ -713,6 +719,15 @@ def _run(args: argparse.Namespace) -> int:
         timeout_agent = writer
         started_at = time.monotonic()
         module_dir.mkdir(parents=True, exist_ok=True)
+        impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
+        impl_map_path = module_dir / "implementation_map.json"
+        write_implementation_map(impl_map, impl_map_path)
+        tracker.emit(
+            "implementation_map_seeded",
+            slug=slug,
+            entry_count=len(impl_map["entries"]),
+            path=str(impl_map_path),
+        )
         prompt = _writer_prompt(
             plan=plan,
             plan_content=plan_content,

--- a/tests/build/test_implementation_map.py
+++ b/tests/build/test_implementation_map.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.audit.wiki_coverage_gate import validate_obligations
+from scripts.build.phases.implementation_map import (
+    read_implementation_map,
+    seed_implementation_map,
+    validate_implementation_map,
+    write_implementation_map,
+)
+from scripts.build.phases.wiki_manifest import extract_manifest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fixture_manifest() -> dict[str, Any]:
+    return {
+        "slug": "fixture-module",
+        "wiki_path": "wiki/pedagogy/a1/fixture-module.md",
+        "sequence_steps": [
+            {
+                "id": "step-1",
+                "heading": "Привітання",
+                "step_num": 1,
+                "required_claim": "Start with a morning greeting.",
+                "source_lines": "10-11",
+            },
+            {
+                "id": "step-2",
+                "heading": "Дії вранці",
+                "step_num": 2,
+                "required_claim": "Introduce routine verbs.",
+                "source_lines": "12-13",
+            },
+            {
+                "id": "step-3",
+                "heading": "Зворотні дієслова",
+                "step_num": 3,
+                "required_claim": "Contrast actions done to oneself.",
+                "source_lines": "14-15",
+            },
+            {
+                "id": "step-4",
+                "heading": "Мінідіалог",
+                "step_num": 4,
+                "required_claim": "End with a short dialogue.",
+                "source_lines": "16-17",
+            },
+        ],
+        "l2_errors": [
+            {
+                "id": "l2-1",
+                "incorrect": "я вмиваю",
+                "correct": "я вмиваюся",
+                "why": "Reflexive morning routines need -ся.",
+                "treatment": "contrast_pair",
+                "source_lines": "20",
+            },
+            {
+                "id": "l2-2",
+                "incorrect": "він миєся",
+                "correct": "він миється",
+                "why": "The third-person reflexive ending is -ться.",
+                "treatment": "contrast_pair",
+                "source_lines": "21",
+            },
+            {
+                "id": "l2-3",
+                "incorrect": "я прокидаю",
+                "correct": "я прокидаюся",
+                "why": "The verb прокидатися is reflexive in this meaning.",
+                "treatment": "prose_explanation",
+                "source_lines": "22",
+            },
+        ],
+        "phonetic_rules": [
+            {
+                "id": "phon-1",
+                "written": "-ться",
+                "spoken": "[ц':а]",
+                "treatment": "explicit_explanation",
+                "source_lines": "30",
+            },
+            {
+                "id": "phon-2",
+                "written": "-шся",
+                "spoken": "[с':а]",
+                "treatment": "explicit_explanation",
+                "source_lines": "31",
+            },
+        ],
+        "decolonization_bans": [
+            {"id": "ban-1", "rule": "Do not frame Ukrainian as a dialect.", "source_lines": "40"},
+            {"id": "ban-2", "rule": "Avoid imperial place-name defaults.", "source_lines": "41"},
+            {"id": "ban-3", "rule": "Do not normalize Russian calques.", "source_lines": "42"},
+            {"id": "ban-4", "rule": "Avoid Soviet nostalgia framing.", "source_lines": "43"},
+            {"id": "ban-5", "rule": "Do not omit Ukrainian agency.", "source_lines": "44"},
+        ],
+        "external_resources": [],
+    }
+
+
+def _manifest_items(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for group in ("sequence_steps", "l2_errors", "phonetic_rules", "decolonization_bans"):
+        items.extend(manifest[group])
+    return items
+
+
+def test_seed_emits_one_entry_per_obligation_in_manifest_order() -> None:
+    manifest = _fixture_manifest()
+    payload = seed_implementation_map(manifest)
+
+    assert len(payload["entries"]) == 14
+    assert payload["manifest_obligation_count"] == 14
+    assert [entry["obligation_id"] for entry in payload["entries"]] == [
+        item["id"] for item in _manifest_items(manifest)
+    ]
+    assert [entry["obligation_type"] for entry in payload["entries"]] == [
+        "sequence_step",
+        "sequence_step",
+        "sequence_step",
+        "sequence_step",
+        "l2_error",
+        "l2_error",
+        "l2_error",
+        "phonetic_rule",
+        "phonetic_rule",
+        "decolonization_ban",
+        "decolonization_ban",
+        "decolonization_ban",
+        "decolonization_ban",
+        "decolonization_ban",
+    ]
+
+
+def test_artifact_mapping_matches_obligation_type_and_treatment() -> None:
+    payload = seed_implementation_map(_fixture_manifest())
+    artifacts = {entry["obligation_id"]: entry["artifact"] for entry in payload["entries"]}
+
+    assert artifacts == {
+        "step-1": "module.md",
+        "step-2": "module.md",
+        "step-3": "module.md",
+        "step-4": "module.md",
+        "l2-1": "activities.yaml",
+        "l2-2": "activities.yaml",
+        "l2-3": "module.md",
+        "phon-1": "module.md",
+        "phon-2": "module.md",
+        "ban-1": "module.md",
+        "ban-2": "module.md",
+        "ban-3": "module.md",
+        "ban-4": "module.md",
+        "ban-5": "module.md",
+    }
+
+
+def test_manifest_payload_round_trips_verbatim() -> None:
+    manifest = _fixture_manifest()
+    payload = seed_implementation_map(manifest)
+    manifest_by_id = {item["id"]: item for item in _manifest_items(manifest)}
+
+    for entry in payload["entries"]:
+        assert entry["manifest_payload"] == manifest_by_id[entry["obligation_id"]]
+
+
+def test_json_schema_validates_seeded_output() -> None:
+    validate_implementation_map(seed_implementation_map(_fixture_manifest()))
+
+
+def test_write_read_round_trip_identity(tmp_path: Path) -> None:
+    payload = seed_implementation_map(_fixture_manifest())
+    path = tmp_path / "implementation_map.json"
+
+    write_implementation_map(payload, path)
+
+    assert read_implementation_map(path) == payload
+
+
+def test_empty_manifest_writes_empty_entries(tmp_path: Path) -> None:
+    manifest = {
+        "slug": "empty-module",
+        "wiki_path": "wiki/pedagogy/a1/empty-module.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+    payload = seed_implementation_map(manifest)
+    path = tmp_path / "empty-implementation-map.json"
+    write_implementation_map(payload, path)
+
+    assert payload["entries"] == []
+    assert read_implementation_map(path) == payload
+
+
+def test_location_hint_fallback_without_plan() -> None:
+    payload = seed_implementation_map(_fixture_manifest(), plan=None)
+    hints = {entry["obligation_id"]: entry["location_hint"] for entry in payload["entries"]}
+
+    assert hints["step-1"] == "§Привітання"
+    assert hints["step-2"] == "§Дії вранці"
+    assert hints["step-3"] == "§Зворотні дієслова"
+    assert hints["step-4"] == "§Мінідіалог"
+    assert hints["l2-1"] == "activities.yaml"
+    assert hints["l2-2"] == "activities.yaml"
+    assert hints["l2-3"] == "(any prose section)"
+    assert hints["phon-1"] == "(any prose section)"
+    assert hints["phon-2"] == "(any prose section)"
+    assert hints["ban-1"] == "(any prose section)"
+
+
+def test_location_hint_uses_simple_plan_section_match() -> None:
+    plan = {
+        "sections": [
+            {"heading": "Розминка"},
+            {"heading": "Вимова -ться"},
+            {"heading": "Пояснення: я прокидаю"},
+            {"heading": "Деколонізація: dialect"},
+        ]
+    }
+
+    payload = seed_implementation_map(_fixture_manifest(), plan=plan)
+    hints = {entry["obligation_id"]: entry["location_hint"] for entry in payload["entries"]}
+
+    assert hints["phon-1"] == "§Вимова -ться"
+    assert hints["l2-3"] == "§Пояснення: я прокидаю"
+    assert hints["ban-1"] == "§Деколонізація: dialect"
+
+
+def test_seeder_is_byte_deterministic() -> None:
+    manifest = _fixture_manifest()
+
+    first = json.dumps(seed_implementation_map(manifest), ensure_ascii=False, indent=2, sort_keys=True)
+    second = json.dumps(seed_implementation_map(manifest), ensure_ascii=False, indent=2, sort_keys=True)
+
+    assert first == second
+
+
+def test_m20_real_world_manifest_seeds_gate_obligation_count() -> None:
+    manifest = extract_manifest(PROJECT_ROOT / "wiki/pedagogy/a1/my-morning.md")
+    payload = seed_implementation_map(manifest)
+    gate_obligations = validate_obligations(manifest)
+
+    assert len(payload["entries"]) == len(gate_obligations)
+    assert len(payload["entries"]) >= 10

--- a/tests/test_linear_pipeline_wiki_coverage.py
+++ b/tests/test_linear_pipeline_wiki_coverage.py
@@ -76,6 +76,10 @@ def test_v7_build_orders_wiki_gate_before_aggregate_qg() -> None:
     source = (ROOT / "scripts/build/v7_build.py").read_text(encoding="utf-8")
     run_body = source[source.index("def _run(") :]
 
-    assert run_body.index("build_wiki_manifest(") < run_body.index("_writer_prompt(")
+    # PR #2108 (Path 3 PR1) split build_wiki_manifest into a dict-returning
+    # build_wiki_manifest_data + a json-stringifying wrapper so the deterministic
+    # implementation_map seeder can consume the dict before the writer phase.
+    # The structural assertion (manifest built before writer prompt) is unchanged.
+    assert run_body.index("build_wiki_manifest_data(") < run_body.index("_writer_prompt(")
     assert run_body.index("run_wiki_coverage_gate(") < run_body.index("_run_wiki_coverage_review(")
     assert run_body.index("_run_wiki_coverage_review(") < run_body.index("_run_llm_qg(")

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -388,6 +388,11 @@ def test_v7_build_writer_timeout_kills_silent_subprocess(
     assert int(returncode_file.read_text("utf-8")) == -signal.SIGKILL
     assert "timed out in phase writer" in captured.err
     assert timeout_event["writer"] == "claude-tools"
-    assert timeout_event["last_event_type"] == "phase_done"
+    # PR #2108 (Path 3 PR1) seeds implementation_map.json BETWEEN the
+    # phase_done event for the wiki/plan phases and the writer subprocess
+    # spawn. So when the writer subprocess is killed for silence, the most
+    # recently-emitted event is the seeder, not phase_done. Adjust the
+    # assertion to match the actual last event before the spawn.
+    assert timeout_event["last_event_type"] == "implementation_map_seeded"
     assert timeout_event["last_event_ts"]
     assert timeout_event["total_wall_time_s"] < 6


### PR DESCRIPTION
## Summary

First of 4 Path 3 PRs per Decision Card `docs/decisions/2026-05-17-path3-per-obligation-review-loop.md`.

Adds a deterministic per-obligation sidecar `implementation_map.json` written to `module_dir` before the writer runs. Seeder reads the wiki Obligations Manifest and produces one entry per gate-scoped obligation with:

* `obligation_id`, `obligation_type`, deterministic `artifact` (`module.md` vs `activities.yaml` per type+treatment)
* `location_hint` with simple plan-section matching and safe fallback
* `treatment_template` for PR2/PR3 consumers
* verbatim `manifest_payload`

No downstream behavioral change in this PR. Writer prompt unchanged. `wiki_coverage_gate` unchanged. Reviewer unchanged.

## Verifiable Claims (per #M-4)

New module + tests landed:

```text
 scripts/build/phases/implementation_map.py | 331 +++++++++++++++++++++++++++++
 scripts/build/v7_build.py                  |  17 +-
 tests/build/test_implementation_map.py     | 252 ++++++++++++++++++++++
 3 files changed, 599 insertions(+), 1 deletion(-)
```

Changed files:

```text
scripts/build/phases/implementation_map.py
scripts/build/v7_build.py
tests/build/test_implementation_map.py
```

`tests/build/test_implementation_map.py`:

```text
============================== 10 passed in 0.27s ==============================
```

Full `tests/build/`:

```text
======================== 196 passed, 1 skipped in 5.35s ========================
```

`ruff check`:

```text
All checks passed!
```

Pre-commit:

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

m20 (`wiki/pedagogy/a1/my-morning.md`) real-world seed:

```text
entries=18 types=['decolonization_ban', 'l2_error', 'phonetic_rule', 'sequence_step']
```

Pipeline wiring evidence (`git diff origin/main -- scripts/build/v7_build.py` excerpt):

```diff
+from scripts.build.phases.implementation_map import (
+    seed_implementation_map,
+    write_implementation_map,
+)
...
-        wiki_manifest = linear_pipeline.build_wiki_manifest(
+        wiki_manifest_data = linear_pipeline.build_wiki_manifest_data(
             level=level,
             slug=slug,
             plan=plan,
         )
+        wiki_manifest = json.dumps(wiki_manifest_data, ensure_ascii=False, indent=2)
...
+        impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
+        impl_map_path = module_dir / "implementation_map.json"
+        write_implementation_map(impl_map, impl_map_path)
+        tracker.emit(
+            "implementation_map_seeded",
+            slug=slug,
+            entry_count=len(impl_map["entries"]),
+            path=str(impl_map_path),
+        )
```

Commit landed:

```text
90d047cc94 feat(build): add deterministic implementation map seeder
```

Agent trailer lint:

```text
Checking 1 commit(s) in origin/main..HEAD:

  90d047cc94  PASS  X-Agent: codex/path3-pr1-impl-map-seeder-20260517-214115

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Test Plan

* [x] One entry per manifest obligation, in manifest order
* [x] Artifact mapping correct per type+treatment table
* [x] `manifest_payload` round-trips verbatim
* [x] Schema validates seeded output
* [x] write -> read identity
* [x] Empty manifest produces empty entries and still validates/writes
* [x] `location_hint` fallback when `plan=None`
* [x] Byte-determinism across two seeder runs
* [x] m20 real-world smoke against `validate_obligations(manifest)`

PR opened:

```json
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2108"}
```
