### PR TITLE
fix(audit): check_adrs.py --rebuild-index handles missing sentinels (#2100)

### DIFF
--- a/scripts/audit/check_adrs.py
+++ b/scripts/audit/check_adrs.py
@@ -353,25 +353,25 @@ def _check_index_drift(records: list[AdrRecord], result: CheckResult) -> None:
         )
 
 
-def _rebuild_index(records: list[AdrRecord]) -> bool:
-    """Regenerate the README.md index block in place. Returns True if changed."""
+def _rebuild_index(records: list[AdrRecord]) -> tuple[bool, str]:
+    """Regenerate the README.md index block in place. Returns (changed, error_msg)."""
     if not README_PATH.exists():
-        return False
+        return False, f"{README_PATH.name} is missing."
 
     readme = README_PATH.read_text("utf-8")
     start = readme.find(INDEX_START)
     end = readme.find(INDEX_END)
     if start < 0 or end < 0:
-        return False
+        return False, f"ADR-INDEX sentinels are missing in {README_PATH.name}."
 
     new_block = _build_index_block(records)
     before = readme[:start]
     after = readme[end + len(INDEX_END) :]
     new_readme = before + new_block + after
     if new_readme == readme:
-        return False
+        return False, ""
     README_PATH.write_text(new_readme, "utf-8")
-    return True
+    return True, ""
 
 
 def _check_orphaned_refs(records: list[AdrRecord], result: CheckResult) -> None:
@@ -536,7 +536,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.rebuild_index:
         records = _load_adrs()
-        changed = _rebuild_index(records)
+        changed, err_msg = _rebuild_index(records)
+        if err_msg:
+            print(f"Error: {err_msg}", file=sys.stderr)
+            return 1
         if changed:
             print(f"Rewrote ADR index in {README_PATH.relative_to(PROJECT_ROOT)}")
         else:

--- a/tests/audit/test_check_adrs.py
+++ b/tests/audit/test_check_adrs.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import check_adrs
+
+
+def test_rebuild_index_missing_sentinels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    adr_dir = tmp_path / "docs" / "architecture" / "adr"
+    adr_dir.mkdir(parents=True)
+    readme = adr_dir / "README.md"
+    readme.write_text("## Index\n\nNo sentinels here.", "utf-8")
+
+    monkeypatch.setattr(check_adrs, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(check_adrs, "ADR_DIR", adr_dir)
+    monkeypatch.setattr(check_adrs, "README_PATH", readme)
+
+    exit_code = check_adrs.main(["--rebuild-index"])
+
+    assert exit_code == 1
+
+    captured = capsys.readouterr()
+    assert "ADR-INDEX sentinels are missing" in captured.err


### PR DESCRIPTION
Fixes an issue where `check_adrs.py --rebuild-index` would silently fail
and return an "already up to date" message when ADR-INDEX sentinels were missing.

The advice text in `_check_index_drift` (lines 341-345):
```python
    if start < 0 or end < 0:
        result.warnings.append(
            f"{README_PATH.name} is missing the ADR-INDEX sentinels; "
            f"run --rebuild-index to insert them."
        )
        return
```

The `_rebuild_index` False-returning branch BEFORE:
```python
    start = readme.find(INDEX_START)
    end = readme.find(INDEX_END)
    if start < 0 or end < 0:
        return False
```

The `_rebuild_index` branch AFTER:
```python
    start = readme.find(INDEX_START)
    end = readme.find(INDEX_END)
    if start < 0 or end < 0:
        return False, f"ADR-INDEX sentinels are missing in {README_PATH.name}."
```

I selected **Option B (fallback)**: propagate the False return to `main` with
an explicit error message and a non-zero exit code. This choice was made because
Option A (mechanically rebuilding the sentinels) requires unsafe assumptions
about the Markdown structure if the `## Index` heading or one of the two
sentinels is completely missing. Option B avoids corrupting the file state by
explicitly alerting the user.

Verification:
`pytest` final line raw:
`================ 1 passed, 8059 deselected, 3 warnings in 5.28s ================`

`ruff` raw output:
`All checks passed!`