### PR TITLE
fix(audit): audit_level.py exits non-zero when no modules audited (#2099)

### DIFF
--- a/scripts/audit/audit_level.py
+++ b/scripts/audit/audit_level.py
@@ -344,6 +344,7 @@ def main():
 
     # Run audit
     passed, failed, failed_modules, slug_results = run_audit(files, fix=args.fix, verbose=args.verbose, skip_activities=args.skip_activities)
+    audited = passed + failed
 
     # Sync batch state (unless --no-sync or auditing a subset)
     if not args.no_sync and slug_results:
@@ -368,6 +369,13 @@ def main():
     if missing and args.check_missing:
         print(f"MISSING MODULES: {', '.join(missing)}")
         print()
+
+    if audited == 0:
+        if missing and not args.check_missing:
+            print(f"Missing modules: {', '.join(missing)}")
+            print()
+        print("Error: No modules were audited.")
+        sys.exit(1)
 
     if failed > 0 or (len(missing) > 0 and args.check_missing):
         print(f"Failed modules: {', '.join(failed_modules)}")

--- a/tests/audit/test_audit_level.py
+++ b/tests/audit/test_audit_level.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from audit import audit_level
+
+
+def test_missing_slug_exits_nonzero_and_names_slug(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    missing_slug = "__nonexistent__"
+    run_audit_calls = []
+
+    def fake_find_module_files(level: str, module_filter: str | None) -> tuple[list[Path], list[str]]:
+        assert level == "a1"
+        assert module_filter is None
+        return [], [missing_slug]
+
+    def fake_run_audit(files: list[Path], *args: object, **kwargs: object) -> tuple[int, int, list[str], dict[str, str]]:
+        run_audit_calls.append(files)
+        return 0, 0, [], {}
+
+    monkeypatch.setattr(sys, "argv", ["audit_level.py", "a1"])
+    monkeypatch.setattr(audit_level, "find_module_files", fake_find_module_files)
+    monkeypatch.setattr(audit_level, "run_audit", fake_run_audit)
+
+    with pytest.raises(SystemExit) as exc_info:
+        audit_level.main()
+
+    output = capsys.readouterr()
+    assert exc_info.value.code != 0
+    assert run_audit_calls == [[]]
+    assert missing_slug in output.out or missing_slug in output.err
+
+
+@pytest.mark.parametrize(
+    ("audit_result", "expected_code"),
+    [
+        ((1, 0, [], {"existing-module": "pass"}), 0),
+        ((0, 0, [], {}), 1),
+    ],
+)
+def test_exit_zero_requires_at_least_one_successful_module_audit(
+    monkeypatch: pytest.MonkeyPatch,
+    audit_result: tuple[int, int, list[str], dict[str, str]],
+    expected_code: int,
+) -> None:
+    module_file = Path("curriculum/l2-uk-en/a1/existing-module.md")
+
+    monkeypatch.setattr(sys, "argv", ["audit_level.py", "a1"])
+    monkeypatch.setattr(audit_level, "find_module_files", lambda _level, _module_filter: ([module_file], []))
+    monkeypatch.setattr(audit_level, "run_audit", lambda *args, **kwargs: audit_result)
+    monkeypatch.setattr(audit_level, "sync_batch_state", lambda _level, _slug_results: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        audit_level.main()
+
+    assert exc_info.value.code == expected_code


### PR DESCRIPTION
## Summary

- Preserve the existing no-requested-modules early failure for `files=[]` and `missing=[]`.
- Let `files=[]` and `missing=[...]` full-level audits flow through the summary, then fail at the zero-audited guard with missing slugs named.
- Add focused regression coverage for the full-level missing-only path and for the success guard requiring at least one successful module audit.

## Patched ranges read

Original `scripts/audit/audit_level.py:321-326`:

```text
   321     if not files and not missing:
   322         if args.modules:
   323             print(f"Error: No matching modules found for: {args.modules}")
   324         else:
   325             print(f"Error: No modules found for level: {args.level}")
   326         sys.exit(1)
```

Original `scripts/audit/audit_level.py:372-383`:

```text
   372     if failed > 0 or (len(missing) > 0 and args.check_missing):
   373         print(f"Failed modules: {', '.join(failed_modules)}")
   374         print()
   375         print("To audit a specific module:")
   376         print(f"  .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/{args.level}/[NUM]-*.md")
   377         print()
   378         print("To auto-fix YAML issues:")
   379         print(f"  npm run audit -- {args.level} --fix")
   380         sys.exit(1)
   381     else:
   382         print(f"✅ All {level_upper} modules passed audit!")
   383         sys.exit(0)
```

## Reproducer

Before, using `origin/main` script against a full A1 audit where discovery planned 55 modules but found 0 files:

```text
════════════════════════════════════════════════════════════════
  A1 Full Level Audit: 55 modules
════════════════════════════════════════════════════════════════


════════════════════════════════════════════════════════════════
  Audit Summary
════════════════════════════════════════════════════════════════

Total Planned: 55
Found:         0
Passed:        0
Failed:        0

✅ All A1 modules passed audit!
before_exit=0
```

After:

```text
════════════════════════════════════════════════════════════════
  A1 Full Level Audit: 55 modules
════════════════════════════════════════════════════════════════


════════════════════════════════════════════════════════════════
  Audit Summary
════════════════════════════════════════════════════════════════

Total Planned: 55
Found:         0
Passed:        0
Failed:        0

Missing modules: sounds-letters-and-hello, reading-ukrainian, special-signs, stress-and-melody, who-am-i, my-family, checkpoint-first-contact, things-have-gender, what-is-it-like, colors, how-many, this-and-that, many-things, checkpoint-my-world, what-i-like, verbs-group-one, verbs-group-two, i-want-i-can, questions, my-morning, checkpoint-actions, what-time, days-and-months, weather, my-day, free-time, checkpoint-time-nature, euphony, where-is-it, my-city, where-to, transport, around-the-city, where-from, checkpoint-places, food-and-drink, i-eat-i-drink, at-the-cafe, shopping, people-around-me, checkpoint-food-shopping, hey-friend, please-do-this, linking-ideas, when-and-where, holidays, checkpoint-communication, what-happened, yesterday, what-will-happen, my-plans, my-story, health, emergencies, a1-finale

Error: No modules were audited.
after_exit=1
```

## Verification

`.venv/bin/pytest tests/audit/ -q`

```text
======================= 364 passed, 24 skipped in 2.52s ========================
```

`.venv/bin/pytest tests/audit/test_audit_level.py -v`

```text
============================== 3 passed in 0.29s ===============================
```

`.venv/bin/ruff check scripts/audit/audit_level.py tests/audit/`

```text
All checks passed!
```

`.venv/bin/python -m pre_commit run --files scripts/audit/audit_level.py`

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

## Review follow-up

Addressed Gemini review comment on #2111 by:

- keeping the original `files=[]` / `missing=[]` early failure shape;
- moving the `files=[]` / `missing=[...]` case to the summary plus `audited == 0` failure path;
- changing the regression tests to exercise full-level argv (`["audit_level.py", "a1"]`) rather than module-specific argv.
