### PR TITLE
feat(api): artifacts feed surfaces MD docs and decouples discovery from serving roots (#2106)

### DIFF
--- a/dashboards/artifacts.html
+++ b/dashboards/artifacts.html
@@ -30,7 +30,7 @@ body { min-height: 100vh; }
 .ops-card.agent { border-left-color:var(--accent); }
 .ops-card.curriculum { border-left-color:var(--cyan); }
 .ops-card.runtime { border-left-color:var(--purple); }
-.filters { display:grid; grid-template-columns: 1.2fr repeat(4, minmax(130px, 1fr)); gap:10px; margin-bottom: 26px; }
+.filters { display:grid; grid-template-columns: 1.2fr repeat(5, minmax(130px, 1fr)); gap:10px; margin-bottom: 26px; }
 .filters input, .filters select { background:#fffaf0; color:var(--text); border:1px solid var(--border); border-radius:4px; padding:9px 10px; font:inherit; font-size:13px; }
 .group { margin: 26px 0 34px; }
 .group h3 { font-family: Charter, Georgia, serif; font-size:21px; border-bottom:1px solid var(--border); padding-bottom:8px; margin:0 0 14px; display:flex; justify-content:space-between; gap:12px; }
@@ -77,8 +77,8 @@ body { min-height: 100vh; }
 <main class="wrap">
   <section class="hero">
     <div>
-      <h2>HTML reports and handoffs</h2>
-      <p>Browse locally served audit reports, session handoffs, decisions, and best-practice artifacts from the Monitor API.</p>
+      <h2>Documents, handoffs, reports</h2>
+      <p>Browse locally served documents, reports, session handoffs, dispatch briefs, decisions, and best-practice artifacts from the Monitor API.</p>
     </div>
     <div class="hero-count">
       <div class="value" id="total-count">—</div>
@@ -114,6 +114,7 @@ body { min-height: 100vh; }
     <select id="class-filter"><option value="">All classes</option></select>
     <select id="status-filter"><option value="">All statuses</option></select>
     <select id="author-filter"><option value="">All authors</option></select>
+    <select id="type-filter"><option value="">All types</option><option value="html">HTML</option><option value="md">MD</option></select>
     <input id="date-filter" type="date" aria-label="Date from">
   </section>
 
@@ -130,6 +131,7 @@ const els = {
   statusFilter: document.getElementById('status-filter'),
   authorFilter: document.getElementById('author-filter'),
   dateFilter: document.getElementById('date-filter'),
+  typeFilter: document.getElementById('type-filter'),
 };
 
 function escapeHtml(value) {
@@ -206,7 +208,9 @@ function render() {
 }
 
 async function loadArtifacts() {
-  const response = await fetch('/api/artifacts/html');
+  const type = els.typeFilter.value;
+  const url = type ? `/api/artifacts/html?type=${encodeURIComponent(type)}` : '/api/artifacts/html';
+  const response = await fetch(url);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const data = await response.json();
   state.artifacts = data.artifacts || [];
@@ -218,6 +222,7 @@ async function loadArtifacts() {
   el.addEventListener('input', render);
   el.addEventListener('change', render);
 });
+els.typeFilter.addEventListener('change', loadArtifacts);
 
 loadArtifacts().catch(error => {
   els.total.textContent = '!';

--- a/scripts/api/artifacts_router.py
+++ b/scripts/api/artifacts_router.py
@@ -119,14 +119,32 @@ async def html_artifacts(
     date_from: str | None = Query(None),
     status: str | None = Query(None),
     author: str | None = Query(None),
+    type_: str | None = Query(None, alias="type", pattern="^(html|md)$"),
 ):
-    """List authored HTML artifacts with parsed report metadata."""
+    """List authored artifacts (HTML + MD) with parsed report metadata.
+
+    Query params:
+        type: Filter to 'html' or 'md'. Omit for both.
+        class: Filter by artifact class.
+        date_from: ISO date lower bound.
+        status: Filter by status.
+        author: Filter by author.
+    """
+    types: tuple[str, ...]
+    if type_ == "html":
+        types = ("html",)
+    elif type_ == "md":
+        types = ("md",)
+    else:
+        types = ("html", "md")
+
     return await asyncio.to_thread(
         collect_html_artifacts,
         class_filter=class_,
         date_from=date_from,
         status=status,
         author=author,
+        types=types,
     )
 
 

--- a/scripts/api/docs_router.py
+++ b/scripts/api/docs_router.py
@@ -8,6 +8,7 @@ from approved roots.
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,6 +22,8 @@ except ImportError:
     from ..path_safety import safe_join  # scripts.api package import
 
 from .config import DASHBOARDS_DIR, PROJECT_ROOT
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["docs"])
 
@@ -45,6 +48,37 @@ ALLOWED_ROOTS = {
     "docs/proposals": PROJECT_ROOT / "docs" / "proposals",
     "docs/poc": PROJECT_ROOT / "docs" / "poc",
 }
+
+# Discovery roots: walk these trees broadly to find all artifacts.
+# Serving is still gated by ALLOWED_ROOTS / EFFECTIVE_ROOTS.
+DISCOVERY_ROOTS = (PROJECT_ROOT / "docs", PROJECT_ROOT / "audit")
+
+# Path prefixes (relative to PROJECT_ROOT) to exclude from discovery.
+DISCOVERY_EXCLUDES = ("docs/archive", "docs/resources/podcasts/raw")
+
+
+# ── Effective roots: ALLOWED_ROOTS ∪ dynamically discovered docs/ dirs ──
+# At import time, add every immediate subdirectory under docs/ (and audit/)
+# that isn't explicitly excluded, so the API surfaces ALL real content
+# directories without per-directory whitelist churn (#2106).
+
+def _build_effective_roots() -> dict[str, Path]:
+    """Build EFFECTIVE_ROOTS as ALLOWED_ROOTS ∪ discovered docs/ dirs."""
+    effective = dict(ALLOWED_ROOTS)
+    docs_dir = PROJECT_ROOT / "docs"
+    if docs_dir.is_dir():
+        for entry in sorted(docs_dir.iterdir()):
+            if not entry.is_dir() or entry.name.startswith("."):
+                continue
+            root_key = f"docs/{entry.name}"
+            # Skip if this path prefix is excluded
+            if any(root_key.startswith(excl) for excl in DISCOVERY_EXCLUDES):
+                continue
+            effective.setdefault(root_key, entry)
+    return effective
+
+
+EFFECTIVE_ROOTS = _build_effective_roots()
 
 _ALLOWED_EXT = {".html", ".md", ".txt", ".json", ".png", ".jpg", ".jpeg", ".svg", ".webp", ".pdf"}
 _MIME_TYPES = {
@@ -99,16 +133,70 @@ def _extract_html_meta(path: Path) -> dict[str, str]:
     return meta
 
 
+def _extract_md_frontmatter(path: Path) -> dict[str, str]:
+    """Extract YAML frontmatter from MD files.
+
+    Parses the leading YAML block delimited by ``---`` / ``---``.
+    Falls back to first H1 as title if no frontmatter ``title`` key.
+    Limits reads to 8KB head. Returns empty dict on any error.
+    """
+    meta: dict[str, str] = {}
+    if path.suffix.lower() != ".md" or not path.is_file():
+        return meta
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            head = f.read(8192)
+    except Exception:
+        return meta
+
+    if not head.startswith("---"):
+        # No frontmatter — try H1 as title fallback
+        for line in head.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("# ") and not stripped.startswith("## "):
+                meta["title"] = stripped[2:].strip()
+                break
+        return meta
+
+    # Find closing ---
+    end_idx = head.find("\n---", 3)
+    if end_idx == -1:
+        return meta
+
+    yaml_str = head[4:end_idx]  # Skip opening "---\n"
+    try:
+        import yaml
+
+        data = yaml.safe_load(yaml_str)
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if value is not None:
+                    meta[str(key)] = str(value)
+    except Exception:
+        logger.debug("Malformed YAML frontmatter in %s, skipping metadata", path)
+
+    # Title: first H1 if no title in frontmatter
+    if "title" not in meta:
+        body_start = head[end_idx + 4:]  # after closing ---\n
+        for line in body_start.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("# ") and not stripped.startswith("## "):
+                meta["title"] = stripped[2:].strip()
+                break
+
+    return meta
+
+
 def _get_root_info(path: str) -> tuple[str, Path, str] | None:
     """Find the matching root for a given path.
 
     Returns (root_key, root_path, relative_remainder) or None.
     """
     # Sort by length descending to match most specific root first
-    for root_key in sorted(ALLOWED_ROOTS.keys(), key=len, reverse=True):
+    for root_key in sorted(EFFECTIVE_ROOTS.keys(), key=len, reverse=True):
         if path == root_key or path.startswith(f"{root_key}/"):
-            remainder = path[len(root_key) :].lstrip("/")
-            return root_key, ALLOWED_ROOTS[root_key], remainder
+            remainder = path[len(root_key):].lstrip("/")
+            return root_key, EFFECTIVE_ROOTS[root_key], remainder
     return None
 
 
@@ -153,7 +241,7 @@ def _directory_listing(path: str, root_key: str, root_path: Path, remainder: str
 
 
 def _artifact_url_for(root_key: str, file_path: Path) -> str:
-    relative = file_path.relative_to(ALLOWED_ROOTS[root_key]).as_posix()
+    relative = file_path.relative_to(EFFECTIVE_ROOTS[root_key]).as_posix()
     return f"/artifacts/{root_key}/{relative}"
 
 
@@ -161,28 +249,87 @@ def _artifact_path_for(file_path: Path) -> str:
     return file_path.relative_to(PROJECT_ROOT).as_posix()
 
 
-def collect_html_artifacts(
+def _find_artifact_root(file_path: Path) -> str | None:
+    """Find the EFFECTIVE_ROOTS key that contains this file path.
+
+    Returns the longest matching root_key, or None if no root covers it.
+    """
+    rel = file_path.relative_to(PROJECT_ROOT).as_posix()
+    # Sort by key length descending — longest (most specific) match wins
+    for root_key in sorted(EFFECTIVE_ROOTS.keys(), key=len, reverse=True):
+        if rel == root_key or rel.startswith(f"{root_key}/"):
+            return root_key
+    return None
+
+
+def collect_artifacts(
     *,
     class_filter: str | None = None,
     date_from: str | None = None,
     status: str | None = None,
     author: str | None = None,
+    types: tuple[str, ...] = ("html", "md"),
 ) -> dict:
-    """Return all HTML report artifacts under approved documentation roots."""
-    artifacts = []
-    for root_key, root_path in ALLOWED_ROOTS.items():
-        if not root_path.exists():
+    """Return all HTML and MD artifacts under discovery roots.
+
+    Walks DISCOVERY_ROOTS (docs/ + audit/) broadly. Skips
+    DISCOVERY_EXCLUDES and dotfiles. Matches each file to an
+    EFFECTIVE_ROOTS entry for serving. Parses HTML <meta> tags
+    and MD YAML frontmatter for metadata.
+
+    Args:
+        class_filter: Filter by artifact class.
+        date_from: ISO date lower bound.
+        status: Filter by status.
+        author: Filter by author.
+        types: Tuples of extensions to include (default: html, md).
+    """
+    artifacts: list[dict] = []
+    type_set = set(types)
+
+    for discovery_root in DISCOVERY_ROOTS:
+        if not discovery_root.exists():
             continue
-        for file_path in sorted(root_path.rglob("*.html")):
-            rel_parts = file_path.relative_to(root_path).parts
-            if any(part.startswith(".") for part in rel_parts):
+        for file_path in sorted(discovery_root.rglob("*")):
+            if not file_path.is_file():
                 continue
-            _assert_under_root(file_path, root_path)
-            meta = _extract_html_meta(file_path)
+
+            # Skip dotfiles
+            rel_to_project = file_path.relative_to(PROJECT_ROOT)
+            if any(part.startswith(".") for part in rel_to_project.parts):
+                continue
+
+            # Skip excluded paths
+            rel_str = rel_to_project.as_posix()
+            if any(rel_str == excl or rel_str.startswith(f"{excl}/") for excl in DISCOVERY_EXCLUDES):
+                continue
+
+            # Filter by type
+            suffix = file_path.suffix.lower()
+            if suffix == ".html":
+                if "html" not in type_set:
+                    continue
+            elif suffix == ".md":
+                if "md" not in type_set:
+                    continue
+            else:
+                continue  # Only HTML and MD for now
+
+            # Find the serving root for this file
+            root_key = _find_artifact_root(file_path)
+            if root_key is None:
+                continue  # Not under any approved root
+
+            _assert_under_root(file_path, EFFECTIVE_ROOTS[root_key])
+
+            # Extract metadata
+            meta = _extract_html_meta(file_path) if suffix == ".html" else _extract_md_frontmatter(file_path)
+
             report_class = meta.get("class") or "document"
             report_status = meta.get("status") or "unknown"
             report_date = meta.get("date") or _iso_from_mtime(file_path)[:10]
             report_author = meta.get("author") or ""
+
             if class_filter and report_class != class_filter:
                 continue
             if status and report_status != status:
@@ -191,6 +338,7 @@ def collect_html_artifacts(
                 continue
             if date_from and report_date < date_from:
                 continue
+
             artifacts.append(
                 {
                     "path": _artifact_path_for(file_path),
@@ -199,21 +347,26 @@ def collect_html_artifacts(
                     "date": report_date,
                     "status": report_status,
                     "title": meta.get("title") or file_path.stem,
-                    "kpi_summary": meta.get("kpi-summary") or "",
-                    "related_issues": _split_csv_numbers(meta.get("related-issues")),
-                    "related_prs": _split_csv_numbers(meta.get("related-prs")),
+                    "kpi_summary": meta.get("kpi_summary") or meta.get("kpi-summary") or "",
+                    "related_issues": _split_csv_numbers(meta.get("related_issues") or meta.get("related-issues")),
+                    "related_prs": _split_csv_numbers(meta.get("related_prs") or meta.get("related-prs")),
                     "agents": _split_csv_strings(meta.get("agents")),
                     "author": report_author,
                     "size_bytes": file_path.stat().st_size,
                     "modified_at": _iso_from_mtime(file_path),
                 }
             )
+
     artifacts.sort(key=lambda item: (item["date"], item["modified_at"], item["path"]), reverse=True)
     return {
         "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "total": len(artifacts),
         "artifacts": artifacts,
     }
+
+
+# Backward-compat alias — artifacts_router.py originally imported this name.
+collect_html_artifacts = collect_artifacts
 
 
 @router.get("/")
@@ -228,7 +381,7 @@ async def list_roots(request: Request, format: str | None = Query(None, pattern=
                 "path": str(v.relative_to(PROJECT_ROOT)),
                 "exists": v.exists(),
             }
-            for k, v in ALLOWED_ROOTS.items()
+            for k, v in EFFECTIVE_ROOTS.items()
         ]
     }
 

--- a/tests/test_docs_router.py
+++ b/tests/test_docs_router.py
@@ -38,11 +38,102 @@ def controlled_docs_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dic
 
     monkeypatch.setattr(docs_router, "PROJECT_ROOT", tmp_path)
     monkeypatch.setattr(docs_router, "ALLOWED_ROOTS", {"safe": safe_root})
+    monkeypatch.setattr(docs_router, "EFFECTIVE_ROOTS", {"safe": safe_root})
+    monkeypatch.setattr(docs_router, "DISCOVERY_ROOTS", (safe_root,))
+
     return {"safe": safe_root, "outside": outside_root}
 
 
 @pytest.fixture()
 def controlled_client(controlled_docs_tree: dict[str, Path]) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture()
+def docs_tree_with_md(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Controlled tree that includes MD files under docs/ subdirectories."""
+    docs_dir = tmp_path / "docs"
+    proposals_dir = docs_dir / "proposals"
+    handoffs_dir = docs_dir / "handoffs"
+    archive_dir = docs_dir / "archive"
+    raw_podcasts_dir = docs_dir / "resources" / "podcasts" / "raw"
+
+    proposals_dir.mkdir(parents=True)
+    handoffs_dir.mkdir(parents=True)
+    archive_dir.mkdir(parents=True)
+    raw_podcasts_dir.mkdir(parents=True)
+
+    # HTML artifact in docs/proposals
+    (proposals_dir / "rfc-001.html").write_text(
+        '<!doctype html>\n<meta name="report-class" content="proposal">\n'
+        '<meta name="report-title" content="RFC 001">\n'
+        '<meta name="report-date" content="2026-05-01">\n'
+        '<meta name="report-status" content="green">\n'
+        '<meta name="report-author" content="team">\n'
+        '<title>RFC 001</title>\n<body>content</body>',
+        encoding="utf-8",
+    )
+
+    # MD artifact with YAML frontmatter in docs/handoffs
+    (handoffs_dir / "session-1.md").write_text(
+        "---\n"
+        "class: handoff\n"
+        "status: green\n"
+        "date: 2026-05-17\n"
+        "author: codex\n"
+        "title: Session Handoff 1\n"
+        "kpi_summary: Completed 3 modules\n"
+        "related_issues: \"142, 150\"\n"
+        "related_prs: \"201, 202\"\n"
+        "agents: \"codex, gemini\"\n"
+        "---\n"
+        "\n"
+        "# Session Handoff 1\n"
+        "\n"
+        "This is a handoff document.\n",
+        encoding="utf-8",
+    )
+
+    # MD artifact WITHOUT frontmatter in docs/handoffs
+    (handoffs_dir / "notes.md").write_text(
+        "# Plain Notes\n"
+        "\n"
+        "No frontmatter here, just a heading.\n",
+        encoding="utf-8",
+    )
+
+    # Excluded: docs/archive/old.html should NOT surface
+    (archive_dir / "old.html").write_text(
+        '<!doctype html><title>Archived</title>',
+        encoding="utf-8",
+    )
+
+    # Excluded: docs/resources/podcasts/raw/* should NOT surface
+    (raw_podcasts_dir / "raw.txt").write_text("raw podcast data", encoding="utf-8")
+    (raw_podcasts_dir / "episode.md").write_text("# Raw Episode\n\nraw content\n", encoding="utf-8")
+
+    # MD in docs/proposals (for dynamic root coverage)
+    (proposals_dir / "proposal-2.md").write_text(
+        "# Proposal 2\n\nSome proposal content.\n",
+        encoding="utf-8",
+    )
+
+    dashboards = tmp_path / "dashboards"
+    dashboards.mkdir()
+    (dashboards / "artifacts.html").write_text("<!doctype html><title>Artifacts</title>", encoding="utf-8")
+
+    monkeypatch.setattr(docs_router, "PROJECT_ROOT", tmp_path)
+    # Clear ALLOWED_ROOTS so _build_effective_roots only discovers tmp_path dirs
+    monkeypatch.setattr(docs_router, "ALLOWED_ROOTS", {})
+    docs_router.EFFECTIVE_ROOTS = docs_router._build_effective_roots()
+    monkeypatch.setattr(docs_router, "DISCOVERY_ROOTS", (tmp_path / "docs",))
+    monkeypatch.setattr(docs_router, "DISCOVERY_EXCLUDES", ("docs/archive", "docs/resources/podcasts/raw"))
+
+    return {"docs": docs_dir, "proposals": proposals_dir, "handoffs": handoffs_dir, "archive": archive_dir}
+
+
+@pytest.fixture()
+def docs_tree_client(docs_tree_with_md: dict[str, Path]) -> TestClient:
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -78,8 +169,8 @@ def test_docs_router_root_index_lists_allowed_roots(client: TestClient):
 
     assert response.status_code == 200
     body = response.json()
-    assert {root["id"] for root in body["roots"]} == set(docs_router.ALLOWED_ROOTS)
-    assert len(body["roots"]) == 10
+    assert {root["id"] for root in body["roots"]} == set(docs_router.EFFECTIVE_ROOTS)
+    assert len(body["roots"]) >= 10  # ≥ 10 — EFFECTIVE_ROOTS may grow with dynamic roots (#2106)
     assert all({"id", "path", "exists"} <= set(root) for root in body["roots"])
 
 
@@ -196,3 +287,134 @@ def test_docs_router_concurrent_access_sanity(controlled_client: TestClient):
     assert len(responses) == 10
     assert all(response.status_code == 200 for response in responses)
     assert all("safe" in response.text for response in responses)
+
+
+# ── New tests for MD artifact support (#2106) ──
+
+
+def test_artifacts_api_surfaces_md_files(docs_tree_client: TestClient):
+    """MD files in docs/ subdirectories should appear in /api/artifacts/html."""
+    response = docs_tree_client.get("/api/artifacts/html")
+    assert response.status_code == 200
+    body = response.json()
+
+    paths = {a["path"] for a in body["artifacts"]}
+    assert "docs/handoffs/session-1.md" in paths, (
+        "MD file with frontmatter not surfaced in artifacts API"
+    )
+    assert "docs/handoffs/notes.md" in paths, (
+        "MD file without frontmatter not surfaced in artifacts API"
+    )
+    assert "docs/proposals/proposal-2.md" in paths, (
+        "MD file in proposals not surfaced in artifacts API"
+    )
+
+
+def test_artifacts_md_with_yaml_frontmatter(docs_tree_client: TestClient):
+    """MD with YAML frontmatter should have metadata extracted."""
+    response = docs_tree_client.get("/api/artifacts/html")
+    assert response.status_code == 200
+    body = response.json()
+
+    # Find the session-1.md artifact
+    session = next(
+        (a for a in body["artifacts"] if a["path"] == "docs/handoffs/session-1.md"),
+        None,
+    )
+    assert session is not None, "session-1.md not found in artifacts"
+
+    assert session["class"] == "handoff"
+    assert session["status"] == "green"
+    assert session["date"] == "2026-05-17"
+    assert session["author"] == "codex"
+    assert session["title"] == "Session Handoff 1"
+    assert session["kpi_summary"] == "Completed 3 modules"
+    assert session["related_issues"] == [142, 150]
+    assert session["related_prs"] == [201, 202]
+    assert session["agents"] == ["codex", "gemini"]
+
+
+def test_artifacts_md_without_frontmatter(docs_tree_client: TestClient):
+    """MD without frontmatter should have class=document, date from mtime."""
+    response = docs_tree_client.get("/api/artifacts/html")
+    assert response.status_code == 200
+    body = response.json()
+
+    notes = next(
+        (a for a in body["artifacts"] if a["path"] == "docs/handoffs/notes.md"),
+        None,
+    )
+    assert notes is not None, "notes.md not found in artifacts"
+
+    assert notes["class"] == "document"
+    # Title should be first H1
+    assert notes["title"] == "Plain Notes"
+    # date should be ISO date from mtime
+    assert len(notes["date"]) == 10  # YYYY-MM-DD
+    assert notes["status"] == "unknown"
+
+
+def test_artifacts_type_filter_md_only(docs_tree_client: TestClient):
+    """?type=md should return only MD artifacts."""
+    response = docs_tree_client.get("/api/artifacts/html?type=md")
+    assert response.status_code == 200
+    body = response.json()
+
+    for artifact in body["artifacts"]:
+        assert artifact["path"].endswith(".md"), (
+            f"Expected only MD files, got {artifact['path']}"
+        )
+    # Should have our MD files
+    paths = {a["path"] for a in body["artifacts"]}
+    assert "docs/handoffs/session-1.md" in paths
+    assert "docs/handoffs/notes.md" in paths
+
+
+def test_artifacts_type_filter_html_only(docs_tree_client: TestClient):
+    """?type=html should return only HTML artifacts."""
+    response = docs_tree_client.get("/api/artifacts/html?type=html")
+    assert response.status_code == 200
+    body = response.json()
+
+    for artifact in body["artifacts"]:
+        assert artifact["path"].endswith(".html"), (
+            f"Expected only HTML files, got {artifact['path']}"
+        )
+
+
+def test_artifacts_archive_excluded(docs_tree_client: TestClient):
+    """docs/archive/* files should NOT appear in artifacts."""
+    response = docs_tree_client.get("/api/artifacts/html")
+    assert response.status_code == 200
+    body = response.json()
+
+    paths = {a["path"] for a in body["artifacts"]}
+    assert not any(p.startswith("docs/archive/") for p in paths), (
+        "docs/archive/* should be excluded from artifacts"
+    )
+
+
+def test_artifacts_podcasts_raw_excluded(docs_tree_client: TestClient):
+    """docs/resources/podcasts/raw/* files should NOT appear in artifacts."""
+    response = docs_tree_client.get("/api/artifacts/html")
+    assert response.status_code == 200
+    body = response.json()
+
+    paths = {a["path"] for a in body["artifacts"]}
+    assert not any("podcasts/raw" in p for p in paths), (
+        "docs/resources/podcasts/raw/* should be excluded from artifacts"
+    )
+
+
+def test_artifacts_dynamic_root_surfaces(docs_tree_client: TestClient):
+    """New docs/<dir> with content should auto-surface no code change (#2106)."""
+    response = docs_tree_client.get("/api/artifacts/html")
+    assert response.status_code == 200
+    body = response.json()
+
+    paths = {a["path"] for a in body["artifacts"]}
+    # proposals should contain both HTML and MD
+    assert "docs/proposals/rfc-001.html" in paths
+    assert "docs/proposals/proposal-2.md" in paths
+    # handoffs should contain MD
+    assert "docs/handoffs/session-1.md" in paths


### PR DESCRIPTION
## Summary

`/api/artifacts/html` and the `/artifacts/` dashboard now surface MD files in addition to HTML. Discovery is decoupled from the `ALLOWED_ROOTS` whitelist — new `docs/<dir>` dirs auto-surface without code changes (#2106).

## Changes

### `scripts/api/docs_router.py`
- `collect_html_artifacts` → `collect_artifacts(types=("html","md"))` — walks `DISCOVERY_ROOTS` (docs/ + audit/) broadly, skips `docs/archive` and `docs/resources/podcasts/raw` via `DISCOVERY_EXCLUDES`.
- `EFFECTIVE_ROOTS` = `ALLOWED_ROOTS` ∪ discovered docs/ subdirectories (built at import time). Any new `docs/<dirname>/` with content auto-surfaces.
- MD YAML frontmatter parser (`_extract_md_frontmatter`): extracts `class`, `status`, `date`, `author`, `title`, `kpi_summary`, `related_issues`, `related_prs`, `agents` from YAML blocks. Falls back to first H1 as title. 8KB read limit. Malformed YAML logged at DEBUG and continues.
- `list_roots` and `_get_root_info` use `EFFECTIVE_ROOTS`.
- Backward-compat alias: `collect_html_artifacts = collect_artifacts`.

### `scripts/api/artifacts_router.py`
- `GET /api/artifacts/html` accepts optional `?type=html` / `?type=md` query param. Default (no param): both.

### `dashboards/artifacts.html`
- Hero subtitle: "Documents, handoffs, reports" (was "HTML reports and handoffs").
- Type filter dropdown: All / HTML / MD.
- Grid updated to 6-column filter layout.

### `tests/test_docs_router.py` (+10 new tests)
- MD files with YAML frontmatter surface with correct metadata.
- MD files without frontmatter surface as `class=document`, title=H1, date=mtime.
- `?type=md` returns only MD; `?type=html` returns only HTML.
- `docs/archive/*` and `docs/resources/podcasts/raw/*` excluded.
- Dynamic root discovery: new `docs/<dir>/` content surfaces without code changes.
- Root count assertion updated: `>= 10` (EFFECTIVE_ROOTS comparison).

## Before / After

**Before:** `/api/artifacts/html` → `"total": 52` (HTML-only)
**After:** Expect `"total"` in the 600+ range with all `docs/**/*.md` surfaced (dispatch briefs, handoffs, decisions, issues, etc.)

## Verification

```
pytest tests/test_docs_router.py -v   → 33 passed in 1.17s
ruff check                             → All checks passed!
pre-commit run --files <all>           → All checks passed!
scripts/audit/lint_agent_trailer.py    → ✅ PASS
```

## Manual smoke (after API restart by user)
```bash
curl -s http://localhost:8765/api/artifacts/html | jq '.total'   # should jump from 52 → 600+
curl -s http://localhost:8765/api/artifacts/html?type=md | jq '.total'  # MD only
```

Closes #2106.

NO auto-merge. User reviews and merges.