### PR TITLE
fix(audit): audit_external_resources.py uses correct RESOURCES_FILE path (#2101)

### DIFF
--- a/scripts/audit/audit_external_resources.py
+++ b/scripts/audit/audit_external_resources.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 import requests
 import yaml
 
-RESOURCES_FILE = Path(__file__).resolve().parent.parent / "docs" / "resources" / "external_resources.yaml"
+RESOURCES_FILE = Path(__file__).resolve().parents[2] / "docs" / "resources" / "external_resources.yaml"
 
 # Timeout per request (seconds)
 REQUEST_TIMEOUT = 15

--- a/tests/audit/test_audit_external_resources_paths.py
+++ b/tests/audit/test_audit_external_resources_paths.py
@@ -1,0 +1,29 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "audit" / "audit_external_resources.py"
+    spec = importlib.util.spec_from_file_location("audit_external_resources", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["audit_external_resources"] = module
+    spec.loader.exec_module(module)
+    return module
+
+def test_resources_file_exists():
+    module = get_module()
+    assert module.RESOURCES_FILE.exists(), f"File does not exist: {module.RESOURCES_FILE}"
+
+def test_resources_file_path_resolution():
+    module = get_module()
+    parts = module.RESOURCES_FILE.parts[-3:]
+    assert "scripts" not in parts, f"Path resolved incorrectly into scripts/: {module.RESOURCES_FILE}"
+    assert "docs" in module.RESOURCES_FILE.parts, f"Path should contain 'docs': {module.RESOURCES_FILE}"
+
+def test_live_reproducer():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "audit" / "audit_external_resources.py"
+    # We use subprocess with sys.executable to run exactly how the test is run
+    result = subprocess.run([sys.executable, str(script_path), "--stats"], capture_output=True, text=True)
+    assert result.returncode == 0, f"Script failed with output: {result.stderr}\n{result.stdout}"


### PR DESCRIPTION
Fixes #2101

**Path Resolution Change:**
Before:
```python
RESOURCES_FILE = Path(__file__).resolve().parent.parent / "docs" / "resources" / "external_resources.yaml"
```
After:
```python
RESOURCES_FILE = Path(__file__).resolve().parents[2] / "docs" / "resources" / "external_resources.yaml"
```

**Live Reproducer Output:**
*BEFORE:*
```
$ .venv/bin/python scripts/audit/audit_external_resources.py --stats
FileNotFoundError: [Errno 2] No such file or directory:
  '.../scripts/docs/resources/external_resources.yaml'
```
*AFTER:*
```
$ .venv/bin/python scripts/audit/audit_external_resources.py --stats
Total URL references: 1739
Unique URLs: 751

Top domains:
  www.youtube.com: 393
  www.ukrainianlessons.com: 251
  opentext.ku.edu: 44
  uk.wikipedia.org: 34
  talkukrainian.com: 9
  www.verba.school: 4
  ukrainianlessons.com: 4
  www.talkukrainian.com: 3
  r2u.org.ua: 3
  litopys.org.ua: 2

Duplicate URLs (shared across modules): 212
```

**Verification:**
```
$ .venv/bin/pytest tests/audit/test_audit_external_resources_paths.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/gemini/fix-2101-resources-path-20260517-223202
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collected 3 items                                                              

tests/audit/test_audit_external_resources_paths.py ...                   [100%]

============================== 3 passed in 0.41s ===============================

$ .venv/bin/ruff check scripts/audit/audit_external_resources.py tests/audit/test_audit_external_resources_paths.py
All checks passed!
```