### PR TITLE
chore(rules): add DeepSeek lanes to model-assignment routing table

### DIFF
--- a/claude_extensions/rules/model-assignment.md
+++ b/claude_extensions/rules/model-assignment.md
@@ -8,8 +8,10 @@ Match the EXACT command — not a principle. Memory does not enforce; the dispat
 |---|---|
 | Inline code edit ≤5 LOC, fixing a CI failure I just caused | Me, current model |
 | Code change >5 LOC, mechanical / pattern-applying / fixtures | `delegate.py dispatch --agent codex --mode danger --worktree --base origin/main` (no `--model`) |
+| Code Review (PR diff) — cheap second opinion | `delegate.py dispatch --agent deepseek --model deepseek-v4-flash --mode read-only` (hermes; PR #2107 adapter). Empirical winner 2026-05-17 bakeoff (A+ at 15s) |
+| Content Review with VESUM verification (load-bearing) | `delegate.py dispatch --agent deepseek --model deepseek-v4-pro` (hermes; MCP-backed: proactively calls `sources` `verify_words`, `query_cefr_level`, `check_russian_shadow`). Validated by PR #2112 write-mode dispatch on artifacts-MD feature |
 | Wiki / content writing | `delegate.py dispatch --agent gemini` (Gemini sub, unmetered) |
-| Adversarial review of design / ADR / architecture | `delegate.py dispatch --agent claude --mode read-only --model claude-opus-4-7 --effort xhigh` (headless Opus, separate billing) |
+| Adversarial review of design / ADR / architecture | `delegate.py dispatch --agent claude --mode read-only --model claude-opus-4-7 --effort xhigh` (headless Opus, separate billing — DROPS 2026-06-15: substitute via `scripts/config/agent_fallback_substitutions.yaml`) |
 | Q&A or single-shot review without commit | `ab ask-codex` / `ab ask-gemini --model gemini-3.0-flash-preview` for routine, `--model gemini-3.1-pro-preview` only for deep |
 | Search / grep / "find me X" across files | `Agent` tool with `subagent_type: Explore`, `model: "haiku"` |
 | Status check on running dispatches | Monitor API curl, never inline file scans |


### PR DESCRIPTION
## Summary

- Adds **DeepSeek-flash** (Code Review cheap second opinion) and **DeepSeek-pro hermes** (Content Review with VESUM verification) to the load-bearing `claude_extensions/rules/model-assignment.md` routing table.
- Flags 2026-06-15 Claude-dispatch drop on the adversarial-review row, pointing at `scripts/config/agent_fallback_substitutions.yaml` as the canonical fallback map.
- Carry-over P0 item 7 from the 2026-05-17 late-night handoff.

## Context

Last session shipped the `hermes_deepseek` adapter (PR #2107) and validated write-mode end-to-end (PR #2112). The capability matrix at `docs/agents/AGENT-CAPABILITY-MATRIX.md` was updated, but the routing rules that actually load into agent context still didn't mention DeepSeek. This propagates the bakeoff results into the rule that gets read.

## Test plan

- [x] `tests/test_deploy_script_idempotency.py + tests/test_manifest_api.py` — 17 passed in 3.06s (deploy invariants intact; fixture only references the filename, content is free)
- [x] No new file under `claude_extensions/rules/` (edit only) — `CLAUDE_RULE_FILES` tuple unchanged
- [x] MEMORY.md #M0 updated symmetrically in the auto-MEMORY at `~/.claude/projects/.../memory/MEMORY.md` (148 → 150 lines, at budget — trim before next add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)