### PR TITLE
feat(audit): Path 3 PR2 — wiki_coverage_gate emits structured fix_proposals on failure

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -1,4 +1,15 @@
-"""Deterministic gate for Wiki Obligations Manifest coverage."""
+"""Deterministic gate for Wiki Obligations Manifest coverage.
+
+Path 3 PR2 extends the gate from a pass/fail coverage report into a
+deterministic repair input for the reviewer loop described in
+docs/decisions/2026-05-17-path3-per-obligation-review-loop.md. When a
+PR1 seeded ``implementation_map.json`` sidecar is available, callers can
+pass it as ``seeded_map`` (or let ``check_wiki_coverage_paths`` auto-load
+``module_dir/implementation_map.json``). On failure, the returned report
+includes ``fix_proposals``: one bounded, JSON-serializable proposal per
+failed obligation. Passing reports omit the key to keep success events
+quiet.
+"""
 
 from __future__ import annotations
 
@@ -124,6 +135,7 @@ def check_wiki_coverage(
     vocabulary_yaml: str = "",
     resources_yaml: str = "",
     level: str | None = None,
+    seeded_map: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compare manifest obligations to claimed artifact evidence."""
     map_entries = (
@@ -178,7 +190,7 @@ def check_wiki_coverage(
     )
     hard_failed = any(item["status"] == "FAIL" for item in obligation_results)
     passed = False if phonetic_hard_failed else (not hard_failed if WIKI_COVERAGE_HARD_FAIL else coverage_pct >= min_pct)
-    return {
+    report = {
         "passed": passed,
         "hard_fail": phonetic_hard_failed or (hard_failed and WIKI_COVERAGE_HARD_FAIL),
         "phonetic_hard_fail": phonetic_hard_failed,
@@ -186,8 +198,20 @@ def check_wiki_coverage(
         "covered": covered,
         "total": total,
         "min_pct": min_pct,
-        "obligations": obligation_results,
+        "obligations": [_public_obligation_result(item) for item in obligation_results],
     }
+    if not passed:
+        seeded_index = _seeded_obligation_index(seeded_map)
+        report["fix_proposals"] = [
+            _build_fix_proposal(
+                result,
+                seeded_index.get(str(result["obligation_id"])),
+                artifacts,
+            )
+            for result in obligation_results
+            if result["status"] == "FAIL"
+        ]
+    return report
 
 
 def check_wiki_coverage_paths(
@@ -196,8 +220,14 @@ def check_wiki_coverage_paths(
     implementation_map: Mapping[str, Mapping[str, str]] | str,
     module_dir: Path,
     level: str | None = None,
+    seeded_map: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     manifest_data = _load_manifest(manifest)
+    implementation_map_path = module_dir / "implementation_map.json"
+    if seeded_map is None and implementation_map_path.exists():
+        from scripts.build.phases.implementation_map import read_implementation_map
+
+        seeded_map = read_implementation_map(implementation_map_path)
     return check_wiki_coverage(
         manifest=manifest_data,
         implementation_map=implementation_map,
@@ -206,7 +236,182 @@ def check_wiki_coverage_paths(
         vocabulary_yaml=_read_optional(module_dir / "vocabulary.yaml"),
         resources_yaml=_read_optional(module_dir / "resources.yaml"),
         level=level,
+        seeded_map=seeded_map,
     )
+
+
+def _seeded_obligation_index(seeded_map: Mapping[str, Any] | None) -> dict[str, Mapping[str, Any]]:
+    if not seeded_map:
+        return {}
+    raw_entries = seeded_map.get("entries") or []
+    if not isinstance(raw_entries, Sequence) or isinstance(raw_entries, (str, bytes)):
+        return {}
+    entries: dict[str, Mapping[str, Any]] = {}
+    for entry in raw_entries:
+        if not isinstance(entry, Mapping):
+            continue
+        obligation_id = str(entry.get("obligation_id") or "")
+        if obligation_id:
+            entries[obligation_id] = entry
+    return entries
+
+
+def _build_fix_proposal(
+    obligation_result: Mapping[str, Any],
+    seeded_entry: Mapping[str, Any] | None,
+    artifacts: Mapping[str, str],
+) -> dict[str, Any]:
+    """Return a structured fix proposal for one failed obligation."""
+    reason = str(obligation_result.get("reason") or "")
+    return {
+        "obligation_id": str(obligation_result.get("obligation_id") or ""),
+        "obligation_type": str(
+            obligation_result.get("obligation_type")
+            or obligation_result.get("type")
+            or ""
+        ),
+        "failure_reason": reason,
+        "current_artifact_state": _current_artifact_state(obligation_result),
+        "expected_treatment": _seeded_dict(seeded_entry, "treatment_template"),
+        "surgical_diff_hint": _surgical_diff_hint(obligation_result, seeded_entry),
+        "manifest_payload": (
+            {}
+            if reason == "unknown_obligation_type"
+            else _seeded_dict(seeded_entry, "manifest_payload")
+        ),
+    }
+
+
+def _seeded_dict(seeded_entry: Mapping[str, Any] | None, key: str) -> dict[str, Any]:
+    if not seeded_entry:
+        return {}
+    value = seeded_entry.get(key)
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _current_artifact_state(obligation_result: Mapping[str, Any]) -> str:
+    reason = str(obligation_result.get("reason") or "")
+    if reason == "implementation_map_missing":
+        return "MISSING (no <implementation_map> entry from writer)"
+    if reason in {"unknown_artifact", "claimed_location_missing"}:
+        claim = _claim(obligation_result)
+        return f"writer_claim={claim!r}; resolved_artifact_text=''"
+    return _truncate_evidence(str(obligation_result.get("_evidence_text") or ""))
+
+
+def _truncate_evidence(text: str, limit: int = 400) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+def _surgical_diff_hint(
+    obligation_result: Mapping[str, Any],
+    seeded_entry: Mapping[str, Any] | None,
+) -> str:
+    reason = str(obligation_result.get("reason") or "")
+    oid = str(obligation_result.get("obligation_id") or "")
+    claim = _claim(obligation_result)
+    payload = _seeded_dict(seeded_entry, "manifest_payload")
+    hint_by_reason = {
+        "implementation_map_missing": _implementation_map_missing_hint(
+            oid,
+            obligation_result,
+            seeded_entry,
+        ),
+        "unknown_artifact": (
+            f"Writer claimed artifact={claim.get('artifact')}, "
+            f"but obligation requires artifact={_seeded_value(seeded_entry, 'artifact', claim.get('artifact'))}"
+        ),
+        "claimed_location_missing": (
+            f"Location {claim.get('location')!r} returns empty text in {claim.get('artifact')}. "
+            "Verify the section heading or activities.yaml block exists "
+            f"(expected: {_seeded_value(seeded_entry, 'location_hint', claim.get('location'))})"
+        ),
+        "missing_incorrect": _missing_incorrect_hint(payload, claim),
+        "missing_correct": _missing_correct_hint(payload),
+        "missing_incorrect_and_correct": (
+            _missing_incorrect_hint(payload, claim)
+            + "; "
+            + _missing_correct_hint(payload)
+        ),
+        "contrast_pair_not_in_activity": (
+            "Move contrast_pair to activities.yaml entry "
+            f"- currently claimed in {claim.get('artifact')}"
+        ),
+        "prose_substance_missing": (
+            "Add prose paragraph naming manifest_payload.correct "
+            f"({payload.get('correct')!r}) and explaining manifest_payload.why ({payload.get('why')!r})"
+        ),
+        "phonetic_rule_missing": (
+            f"Add prose stating written={payload.get('written')!r} -> "
+            f"spoken={payload.get('spoken')!r} with at least one example pair"
+        ),
+        "sequence_claim_missing": (
+            "Add section heading or step marker matching manifest_payload.heading "
+            f"({payload.get('heading')!r}); required_claim: {payload.get('required_claim')!r}"
+        ),
+        "ban_substance_missing": (
+            f"Remove phrasing matching manifest_payload.rule ({payload.get('rule')!r}) "
+            "- negative obligation: absence required"
+        ),
+        "unknown_obligation_type": (
+            f"Unknown obligation type {obligation_result.get('type')!r} "
+            "- seeder bug, file follow-up issue"
+        ),
+    }
+    hint = hint_by_reason.get(reason)
+    if hint is None:
+        hint = f"Unhandled wiki coverage failure reason {reason!r} - file follow-up issue"
+    if seeded_entry is None:
+        hint += " (no seeded sidecar - hint reduced; PR3 reviewer should run with --seeded-map)"
+    return hint
+
+
+def _implementation_map_missing_hint(
+    oid: str,
+    obligation_result: Mapping[str, Any],
+    seeded_entry: Mapping[str, Any] | None,
+) -> str:
+    return (
+        f"Add <implementation_map> entry: obligation_id={oid}; "
+        f"artifact={_seeded_value(seeded_entry, 'artifact', 'UNKNOWN')}; "
+        f"location={_seeded_value(seeded_entry, 'location_hint', 'UNKNOWN')}; "
+        f"treatment={_seeded_value(seeded_entry, 'obligation_type', obligation_result.get('type'))}"
+    )
+
+
+def _missing_incorrect_hint(payload: Mapping[str, Any], claim: Mapping[str, str]) -> str:
+    return (
+        f"Insert manifest_payload.incorrect ({payload.get('incorrect')!r}) verbatim "
+        f"into the activities.yaml entry at {claim.get('location')}"
+    )
+
+
+def _missing_correct_hint(payload: Mapping[str, Any]) -> str:
+    return f"Insert manifest_payload.correct ({payload.get('correct')!r}) verbatim"
+
+
+def _seeded_value(
+    seeded_entry: Mapping[str, Any] | None,
+    key: str,
+    fallback: Any,
+) -> Any:
+    if seeded_entry is None:
+        return fallback
+    value = seeded_entry.get(key)
+    return value if value not in (None, "") else fallback
+
+
+def _claim(obligation_result: Mapping[str, Any]) -> dict[str, str]:
+    claim = obligation_result.get("claim")
+    if not isinstance(claim, Mapping):
+        return {}
+    return {str(key): str(value) for key, value in claim.items()}
+
+
+def _public_obligation_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): value for key, value in result.items() if not str(key).startswith("_")}
 
 
 def _load_manifest(manifest: Mapping[str, Any] | str | Path) -> Mapping[str, Any]:
@@ -225,6 +430,10 @@ def _load_manifest(manifest: Mapping[str, Any] | str | Path) -> Mapping[str, Any
     try:
         path = Path(manifest)
         if path.exists():
+            if path.suffix.casefold() == ".md":
+                from scripts.build.phases.wiki_manifest import extract_manifest
+
+                return extract_manifest(path)
             return json.loads(path.read_text(encoding="utf-8"))
     except OSError:
         # Defensive: any path-related OSError (ENAMETOOLONG, ENOENT in
@@ -335,6 +544,7 @@ def _result(
         "status": status,
         "reason": reason,
         "claim": dict(claim or {}),
+        "_evidence_text": evidence_text or "",
     }
     if obligation_type == "phonetic_rule":
         written = str(obligation.get("written") or "")

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -2904,12 +2904,38 @@ def run_wiki_coverage_gate(
 ) -> dict[str, Any]:
     from scripts.audit.wiki_coverage_gate import check_wiki_coverage_paths
 
-    return check_wiki_coverage_paths(
+    result = check_wiki_coverage_paths(
         manifest=manifest,
         implementation_map=writer_output,
         module_dir=module_dir,
         level=level,
     )
+    if result.get("passed") is False:
+        proposals = list(result.get("fix_proposals") or [])
+        emit_event(
+            "wiki_coverage_fix_proposals",
+            slug=_wiki_manifest_slug(manifest, module_dir),
+            fail_count=len(proposals),
+            proposals=proposals,
+        )
+    return result
+
+
+def _wiki_manifest_slug(manifest: Mapping[str, Any] | str | Path, module_dir: Path) -> str:
+    if isinstance(manifest, Mapping):
+        return str(manifest.get("slug") or module_dir.name)
+    try:
+        raw = str(manifest)
+        if raw.lstrip().startswith(("{", "[")):
+            data = json.loads(raw)
+        else:
+            path = Path(manifest)
+            data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        data = {}
+    if isinstance(data, Mapping):
+        return str(data.get("slug") or module_dir.name)
+    return module_dir.name
 
 
 def review_context(

--- a/tests/audit/test_wiki_coverage_gate_fix_proposals.py
+++ b/tests/audit/test_wiki_coverage_gate_fix_proposals.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+import scripts.audit.wiki_coverage_gate as gate
+from scripts.audit.wiki_coverage_gate import (
+    check_wiki_coverage,
+    check_wiki_coverage_paths,
+    validate_obligations,
+)
+from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import (
+    seed_implementation_map,
+    write_implementation_map,
+)
+from scripts.build.phases.wiki_manifest import extract_manifest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROPOSAL_KEYS = {
+    "obligation_id",
+    "obligation_type",
+    "failure_reason",
+    "current_artifact_state",
+    "expected_treatment",
+    "surgical_diff_hint",
+    "manifest_payload",
+}
+
+
+def _sequence_manifest(
+    *,
+    obligation_id: str = "step-1",
+    heading: str = "Morning routine",
+    required_claim: str = "Teach `привіт` and `ранок` together.",
+) -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [
+            {
+                "id": obligation_id,
+                "heading": heading,
+                "step_num": 1,
+                "required_claim": required_claim,
+                "source_lines": "10",
+            }
+        ],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def _l2_manifest(
+    *,
+    treatment: str = "contrast_pair",
+    obligation_id: str = "err-1",
+    incorrect: str = "Я прокидаєшся.",
+    correct: str = "Я прокидаюся.",
+    why: str = "The person ending must match я.",
+) -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [],
+        "l2_errors": [
+            {
+                "id": obligation_id,
+                "incorrect": incorrect,
+                "correct": correct,
+                "why": why,
+                "treatment": treatment,
+                "source_lines": "20",
+            }
+        ],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def _phonetic_manifest() -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [
+            {
+                "id": "phon-1",
+                "written": "-шся",
+                "spoken": "[с':а]",
+                "treatment": "explicit_explanation",
+                "source_lines": "30",
+            }
+        ],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def _ban_manifest() -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [
+            {
+                "id": "ban-1",
+                "rule": "Do not frame Ukrainian as a dialect.",
+                "source_lines": "40",
+            }
+        ],
+        "external_resources": [],
+    }
+
+
+def _claim(
+    artifact: str = "module.md",
+    location: str = "whole file",
+    treatment: str = "fixture treatment",
+) -> dict[str, str]:
+    return {"artifact": artifact, "location": location, "treatment": treatment}
+
+
+def _seeded(manifest: dict[str, Any]) -> dict[str, Any]:
+    return seed_implementation_map(manifest)
+
+
+def _activity_yaml(text: str, *, activity_id: str = "act-1") -> str:
+    return yaml.safe_dump(
+        [
+            {
+                "id": activity_id,
+                "type": "select",
+                "prompt": text,
+                "items": [
+                    {
+                        "prompt": text,
+                        "options": [text],
+                        "answer": text,
+                    }
+                ],
+            }
+        ],
+        allow_unicode=True,
+        sort_keys=False,
+    )
+
+
+def _single_proposal(report: dict[str, Any]) -> dict[str, Any]:
+    proposals = report["fix_proposals"]
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert set(proposal) == PROPOSAL_KEYS
+    return proposal
+
+
+def test_pass_short_circuit_omits_fix_proposals() -> None:
+    manifest = _sequence_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"step-1": _claim()},
+        module_md="Teach `привіт` and `ранок` together.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    assert report["passed"] is True
+    assert "fix_proposals" not in report
+
+
+def test_back_compat_without_seeded_map_emits_degraded_fix_proposals_on_failure() -> None:
+    manifest = _sequence_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={},
+        module_md="",
+        activities_yaml="[]",
+    )
+
+    proposal = _single_proposal(report)
+    assert report["passed"] is False
+    assert proposal["failure_reason"] == "implementation_map_missing"
+    assert proposal["expected_treatment"] == {}
+    assert proposal["manifest_payload"] == {}
+    assert "no seeded sidecar" in proposal["surgical_diff_hint"]
+
+
+def test_implementation_map_missing_uses_seeded_artifact_and_location_hint() -> None:
+    manifest = _sequence_manifest(heading="Morning proof")
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={},
+        module_md="",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["current_artifact_state"] == "MISSING (no <implementation_map> entry from writer)"
+    assert "artifact=module.md" in proposal["surgical_diff_hint"]
+    assert "location=§Morning proof" in proposal["surgical_diff_hint"]
+    assert proposal["expected_treatment"]
+    assert proposal["manifest_payload"]["id"] == "step-1"
+
+
+def test_unknown_artifact_points_back_to_seeded_artifact() -> None:
+    manifest = _sequence_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"step-1": _claim("readme.md", "whole file")},
+        module_md="Teach `привіт` and `ранок` together.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "unknown_artifact"
+    assert "artifact=readme.md" in proposal["surgical_diff_hint"]
+    assert "requires artifact=module.md" in proposal["surgical_diff_hint"]
+    assert "writer_claim={'artifact': 'readme.md'" in proposal["current_artifact_state"]
+
+
+def test_claimed_location_missing_quotes_claim_and_seeded_location_hint() -> None:
+    manifest = _sequence_manifest(heading="Morning proof")
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"step-1": _claim("module.md", "§Diaspora")},
+        module_md="## Інший розділ\nTeach `привіт` and `ранок` together.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "claimed_location_missing"
+    assert "Location '§Diaspora' returns empty text in module.md" in proposal["surgical_diff_hint"]
+    assert "expected: §Morning proof" in proposal["surgical_diff_hint"]
+    assert "writer_claim={'artifact': 'module.md', 'location': '§Diaspora'" in proposal["current_artifact_state"]
+
+
+def test_missing_incorrect_quotes_payload_incorrect() -> None:
+    manifest = _l2_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"err-1": _claim("activities.yaml", "act-1")},
+        module_md="",
+        activities_yaml=_activity_yaml("Я прокидаюся."),
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "missing_incorrect"
+    assert "manifest_payload.incorrect ('Я прокидаєшся.')" in proposal["surgical_diff_hint"]
+    assert "act-1" in proposal["surgical_diff_hint"]
+
+
+def test_missing_correct_quotes_payload_correct() -> None:
+    manifest = _l2_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"err-1": _claim("activities.yaml", "act-1")},
+        module_md="",
+        activities_yaml=_activity_yaml("Я прокидаєшся."),
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "missing_correct"
+    assert "manifest_payload.correct ('Я прокидаюся.')" in proposal["surgical_diff_hint"]
+
+
+def test_missing_incorrect_and_correct_joins_both_hint_lines() -> None:
+    manifest = _l2_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"err-1": _claim("activities.yaml", "act-1")},
+        module_md="",
+        activities_yaml=_activity_yaml("Choose the morning form."),
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "missing_incorrect_and_correct"
+    assert "manifest_payload.incorrect ('Я прокидаєшся.')" in proposal["surgical_diff_hint"]
+    assert "; Insert manifest_payload.correct ('Я прокидаюся.')" in proposal["surgical_diff_hint"]
+
+
+def test_contrast_pair_not_in_activity_quotes_claimed_artifact() -> None:
+    manifest = _l2_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"err-1": _claim("module.md", "whole file")},
+        module_md="Я прокидаєшся. -> Я прокидаюся.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "contrast_pair_not_in_activity"
+    assert proposal["surgical_diff_hint"] == (
+        "Move contrast_pair to activities.yaml entry - currently claimed in module.md"
+    )
+
+
+def test_prose_substance_missing_quotes_payload_correct_and_why() -> None:
+    manifest = _l2_manifest(treatment="prose_explanation")
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"err-1": _claim("module.md", "whole file")},
+        module_md="This paragraph is unrelated but present.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "prose_substance_missing"
+    assert "manifest_payload.correct ('Я прокидаюся.')" in proposal["surgical_diff_hint"]
+    assert "manifest_payload.why ('The person ending must match я.')" in proposal["surgical_diff_hint"]
+
+
+def test_phonetic_rule_missing_quotes_written_spoken_and_example_pair_instruction() -> None:
+    manifest = _phonetic_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"phon-1": _claim("module.md", "whole file")},
+        module_md="The written ending -шся is introduced without IPA.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "phonetic_rule_missing"
+    assert "written='-шся'" in proposal["surgical_diff_hint"]
+    assert "spoken=\"[с':а]\"" in proposal["surgical_diff_hint"]
+    assert "example pair" in proposal["surgical_diff_hint"]
+
+
+def test_sequence_claim_missing_quotes_heading_and_required_claim() -> None:
+    manifest = _sequence_manifest(heading="Morning proof")
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"step-1": _claim("module.md", "whole file")},
+        module_md="A present but unrelated section.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "sequence_claim_missing"
+    assert "manifest_payload.heading ('Morning proof')" in proposal["surgical_diff_hint"]
+    assert "required_claim: 'Teach `привіт` and `ранок` together.'" in proposal["surgical_diff_hint"]
+
+
+def test_ban_substance_missing_quotes_seeded_rule() -> None:
+    manifest = _ban_manifest()
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"ban-1": _claim("module.md", "whole file")},
+        module_md="This paragraph is present but avoids the banned framing.",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["failure_reason"] == "ban_substance_missing"
+    assert "manifest_payload.rule ('Do not frame Ukrainian as a dialect.')" in proposal["surgical_diff_hint"]
+    assert "negative obligation: absence required" in proposal["surgical_diff_hint"]
+
+
+def test_unknown_obligation_type_proposal_names_seeder_bug() -> None:
+    proposal = gate._build_fix_proposal(
+        {
+            "obligation_id": "weird-1",
+            "type": "external_resource",
+            "reason": "unknown_obligation_type",
+            "status": "FAIL",
+            "claim": {},
+            "_evidence_text": "evidence",
+        },
+        {
+            "obligation_id": "weird-1",
+            "obligation_type": "external_resource",
+            "artifact": "module.md",
+            "location_hint": "whole file",
+            "treatment_template": {"shape": "unknown"},
+            "manifest_payload": {"id": "weird-1", "url": "https://example.invalid"},
+        },
+        {"module.md": "evidence"},
+    )
+
+    assert proposal["manifest_payload"] == {}
+    assert "seeder bug" in proposal["surgical_diff_hint"]
+    assert set(proposal) == PROPOSAL_KEYS
+
+
+def test_current_artifact_state_truncates_long_evidence_text() -> None:
+    manifest = _l2_manifest(treatment="prose_explanation")
+    long_text = "x" * 2000
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={"err-1": _claim("module.md", "whole file")},
+        module_md=long_text,
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    proposal = _single_proposal(report)
+    assert proposal["current_artifact_state"] == ("x" * 400) + "..."
+
+
+def test_fix_proposals_list_with_eighteen_entries_is_json_serializable() -> None:
+    manifest = {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [
+            {
+                "id": f"step-{index}",
+                "heading": f"Heading {index}",
+                "step_num": index,
+                "required_claim": f"Teach `term-{index}` and `ранок`.",
+                "source_lines": str(index),
+            }
+            for index in range(1, 19)
+        ],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map={},
+        module_md="",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
+    assert len(report["fix_proposals"]) == 18
+    json.dumps(report, sort_keys=True)
+
+
+def test_paths_auto_loads_seeded_sidecar(tmp_path: Path) -> None:
+    manifest = _sequence_manifest(heading="Morning proof")
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]", encoding="utf-8")
+    write_implementation_map(_seeded(manifest), module_dir / "implementation_map.json")
+
+    report = check_wiki_coverage_paths(
+        manifest=manifest,
+        implementation_map={},
+        module_dir=module_dir,
+    )
+
+    proposal = _single_proposal(report)
+    assert "location=§Morning proof" in proposal["surgical_diff_hint"]
+    assert "no seeded sidecar" not in proposal["surgical_diff_hint"]
+
+
+def test_pipeline_emits_wiki_coverage_fix_proposals_event(tmp_path: Path) -> None:
+    manifest = _sequence_manifest()
+    module_dir = tmp_path / "module"
+    telemetry = tmp_path / "events.jsonl"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]", encoding="utf-8")
+    write_implementation_map(_seeded(manifest), module_dir / "implementation_map.json")
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = linear_pipeline.run_wiki_coverage_gate(
+            manifest=manifest,
+            writer_output="",
+            module_dir=module_dir,
+            level="a1",
+        )
+
+    events = [json.loads(line) for line in telemetry.read_text(encoding="utf-8").splitlines()]
+    event = next(item for item in events if item["event"] == "wiki_coverage_fix_proposals")
+    assert result["passed"] is False
+    assert event["slug"] == "fixture"
+    assert event["fail_count"] == 1
+    assert event["proposals"] == result["fix_proposals"]
+
+
+def test_paths_accepts_wiki_markdown_manifest_path(tmp_path: Path) -> None:
+    module_dir = tmp_path / "m20-my-morning"
+    module_dir.mkdir()
+
+    report = check_wiki_coverage_paths(
+        manifest=PROJECT_ROOT / "wiki/pedagogy/a1/my-morning.md",
+        implementation_map="",
+        module_dir=module_dir,
+    )
+
+    assert report["passed"] is False
+    assert len(report["fix_proposals"]) == 18
+
+
+def test_m20_real_world_manifest_synthesizes_ten_fix_proposals() -> None:
+    manifest = extract_manifest(PROJECT_ROOT / "wiki/pedagogy/a1/my-morning.md")
+    seeded_map = seed_implementation_map(manifest)
+    obligations = validate_obligations(manifest)
+    implemented_ids = {
+        "step-1",
+        "step-2",
+        "step-3",
+        "step-4",
+        "step-5",
+        "err-1",
+        "err-4",
+        "err-6",
+    }
+    implemented = [obligation for obligation in obligations if obligation["id"] in implemented_ids]
+    implementation_map: dict[str, dict[str, str]] = {}
+    module_parts: list[str] = []
+    activities: list[dict[str, Any]] = []
+
+    for obligation in implemented:
+        obligation_id = str(obligation["id"])
+        if obligation["type"] == "l2_error":
+            activity_id = f"act-{obligation_id}"
+            implementation_map[obligation_id] = _claim("activities.yaml", activity_id)
+            activities.append(
+                {
+                    "id": activity_id,
+                    "type": "select",
+                    "prompt": f"{obligation['incorrect']} -> {obligation['correct']}",
+                    "items": [
+                        {
+                            "prompt": f"{obligation['incorrect']} -> {obligation['correct']}",
+                            "options": [obligation["incorrect"], obligation["correct"]],
+                            "answer": obligation["correct"],
+                        }
+                    ],
+                }
+            )
+            continue
+        implementation_map[obligation_id] = _claim("module.md", "whole file")
+        module_parts.append(str(obligation["required_claim"]))
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="\n\n".join(module_parts),
+        activities_yaml=yaml.safe_dump(activities, allow_unicode=True, sort_keys=False),
+        seeded_map=seeded_map,
+    )
+
+    assert len(report["fix_proposals"]) == 10
+    for proposal in report["fix_proposals"]:
+        assert set(proposal) == PROPOSAL_KEYS
+        for key in PROPOSAL_KEYS - {"manifest_payload"}:
+            assert proposal[key]


### PR DESCRIPTION
## Summary

Second of 4 Path 3 PRs per Decision Card `docs/decisions/2026-05-17-path3-per-obligation-review-loop.md`.

Extends `scripts/audit/wiki_coverage_gate.py` so failed gate reports include a structured `fix_proposals` field. Each proposal carries `obligation_id`, `obligation_type`, `failure_reason`, bounded `current_artifact_state`, seeded `expected_treatment`, deterministic `surgical_diff_hint`, and seeded `manifest_payload`.

`check_wiki_coverage_paths` auto-loads `module_dir/implementation_map.json` when present and keeps no-sidecar callers working with degraded hints. Passing reports omit `fix_proposals`. `linear_pipeline.run_wiki_coverage_gate` emits `wiki_coverage_fix_proposals` JSONL when the gate fails; PR3 consumes this later. No reviewer wiring is added here.

## Verifiable claims (per #M-4)

Gate + tests + pipeline updated:

```text
 scripts/audit/wiki_coverage_gate.py                | 216 +++++++-
 scripts/build/linear_pipeline.py                   |  28 +-
 .../audit/test_wiki_coverage_gate_fix_proposals.py | 581 +++++++++++++++++++++
 3 files changed, 821 insertions(+), 4 deletions(-)
```

New tests pass:

```text
============================== 20 passed in 0.39s ==============================
```

Existing gate tests still pass:

```text
============================== 13 passed in 0.31s ==============================
```

Full audit + build tests still green:

```text
======================= 584 passed, 25 skipped in 8.18s ========================
```

Ruff clean:

```text
All checks passed!
```

m20 real-world gate produces fix proposals:

```text
passed=False fix_proposals=18
```

Pipeline JSONL event added:

```diff
+        emit_event(
+            "wiki_coverage_fix_proposals",
+            slug=_wiki_manifest_slug(manifest, module_dir),
+            fail_count=len(proposals),
+            proposals=proposals,
+        )
```

Commit landed:

```text
1dd0ef10b5 feat(audit): Path 3 PR2 — wiki_coverage_gate emits structured fix_proposals
```

## Test plan

- [x] `.venv/bin/pytest tests/audit/test_wiki_coverage_gate_fix_proposals.py -v`
- [x] `.venv/bin/pytest tests/test_wiki_coverage_gate.py -q`
- [x] `.venv/bin/pytest tests/audit/ tests/build/ -q`
- [x] `.venv/bin/ruff check scripts/audit/wiki_coverage_gate.py tests/audit/test_wiki_coverage_gate_fix_proposals.py scripts/build/linear_pipeline.py`
- [x] `.venv/bin/python -m pre_commit run --files scripts/audit/wiki_coverage_gate.py tests/audit/test_wiki_coverage_gate_fix_proposals.py scripts/build/linear_pipeline.py`
- [x] m20 one-shot smoke command