### PR TITLE
fix(bridge/proxy): 422 validation errors use OpenAI error envelope (#2028)

### DIFF
--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -19,7 +19,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -339,7 +340,25 @@ def _first_error_line(value: object) -> str:
     return first[0] if first else "unknown error"
 
 
+def _validation_error_message(exc: RequestValidationError) -> str:
+    first = exc.errors()[0] if exc.errors() else {}
+    message = str(first.get("msg") or "validation error")
+    loc_parts = [str(part) for part in first.get("loc", ()) if part != "body"]
+    location = ".".join(loc_parts)
+    return f"{message} ({location})" if location else message
+
+
 app = FastAPI(title="AI Agent Bridge OpenAI Proxy", version="1.0")
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(_request: Request, exc: RequestValidationError) -> JSONResponse:
+    return _openai_error(
+        422,
+        _validation_error_message(exc),
+        "invalid_request_error",
+        "validation_error",
+    )
 
 
 @app.get("/healthz")

--- a/tests/ai_agent_bridge/test_openai_proxy.py
+++ b/tests/ai_agent_bridge/test_openai_proxy.py
@@ -16,6 +16,17 @@ def _route_with_backend(model: str, backend):
     return replace(proxy._ROUTABLE_MODELS[model], backend=backend)
 
 
+def _assert_openai_validation_error(response, field: str | None = None) -> None:
+    assert response.status_code == 422
+    body = response.json()
+    assert set(body) == {"error"}
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["code"] == "validation_error"
+    assert body["error"]["message"]
+    if field is not None:
+        assert field in body["error"]["message"]
+
+
 def test_models_endpoint_lists_routable_models():
     response = _client().get("/v1/models")
 
@@ -152,8 +163,41 @@ def test_chat_completions_backend_timeout_returns_504(monkeypatch):
 def test_chat_completions_missing_messages_returns_422():
     response = _client().post("/v1/chat/completions", json={"model": "codex"})
 
-    assert response.status_code == 422
-    assert any(item["loc"][-1] == "messages" for item in response.json()["detail"])
+    _assert_openai_validation_error(response, "messages")
+
+
+def test_chat_completions_missing_model_returns_422():
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    _assert_openai_validation_error(response, "model")
+
+
+def test_chat_completions_messages_wrong_type_returns_422():
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": "codex", "messages": "hello"},
+    )
+
+    _assert_openai_validation_error(response, "messages")
+
+
+def test_chat_completions_empty_body_returns_422():
+    response = _client().post("/v1/chat/completions", json={})
+
+    _assert_openai_validation_error(response, "model")
+
+
+def test_chat_completions_invalid_json_body_returns_422():
+    response = _client().post(
+        "/v1/chat/completions",
+        content='{"model": "codex", "messages":',
+        headers={"content-type": "application/json"},
+    )
+
+    _assert_openai_validation_error(response)
 
 
 def test_message_flatten_preserves_role_order(monkeypatch):


### PR DESCRIPTION
## Summary

Closes #2028. Adds a `RequestValidationError` handler to the OpenAI proxy at `scripts/ai_agent_bridge/openai_proxy.py` so 422 validation errors return the OpenAI error envelope instead of FastAPI's default `detail` array. Flips the existing test that was locking in the wrong behavior + adds validation cases for missing model, wrong `messages` type, empty body, and invalid JSON.

Existing helper used: `def _openai_error(status_code: int, message: str, error_type: str, code: str) -> JSONResponse:`

## Verifiable claims (per #M-4)

* `git diff --stat`:

```text
 scripts/ai_agent_bridge/openai_proxy.py    | 21 ++++++++++++-
 tests/ai_agent_bridge/test_openai_proxy.py | 48 ++++++++++++++++++++++++++++--
 2 files changed, 66 insertions(+), 3 deletions(-)
```

* `pytest test_openai_proxy.py`: `============================== 15 passed in 0.26s ==============================`
* `pytest tests/ai_agent_bridge/`: `============================== 32 passed in 1.32s ==============================`
* `ruff`: `All checks passed!`
* `pre-commit`: `ruff (lint) ... Passed`, `gitleaks (secret scan) ... Passed`, `trim trailing whitespace ... Passed`, `block bare python/python3 in new scripts ... Passed`
* curl repro now returns OpenAI envelope: `{"error":{"message":"Field required (messages)","type":"invalid_request_error","code":"validation_error"}}`

Note: `./services.sh restart bridge` reports `Unknown service: bridge` in this checkout, so the curl smoke used direct startup of `scripts.ai_agent_bridge.openai_proxy:app` on `127.0.0.1:8767` from the worktree.

## Test plan

* [x] `test_chat_completions_missing_messages_returns_422` flipped to assert OpenAI envelope
* [x] New: missing `model` -> OpenAI envelope
* [x] New: `messages` wrong type -> OpenAI envelope
* [x] New: empty body `{}` -> OpenAI envelope
* [x] New: invalid JSON body -> OpenAI envelope
* [x] New: status code 422 preserved across validation cases
* [x] Full `tests/ai_agent_bridge/` green