### PR TITLE
fix(bridge/proxy): reconcile Gemini 3.0 alias with available CLI models (#2022)

### DIFF
--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -67,6 +67,7 @@ class ModelRoute:
 
     family: str
     backend: Backend
+    cli_model_name: str | None = None
 
 
 def _backend_timeout_s() -> int:
@@ -277,9 +278,12 @@ def _hermes_backend(model: str, messages: list[Message], **kwargs: Any) -> Compl
     return CompletionResponse(content=result.stdout.strip())
 
 
+# Alias Mapping Table:
+# - gemini-3.0-flash-preview: Remapped to cli_model_name="gemini-2.5-flash" because the local Gemini CLI
+#   does not recognize the 3.0-flash-preview alias, but 2.5-flash is supported and functional (Issue #2022).
 _ROUTABLE_MODELS: dict[str, ModelRoute] = {
     "codex": ModelRoute(family="openai-codex", backend=_codex_backend),
-    "gemini-3.0-flash-preview": ModelRoute(family="google-gemini", backend=_gemini_backend),
+    "gemini-3.0-flash-preview": ModelRoute(family="google-gemini", backend=_gemini_backend, cli_model_name="gemini-2.5-flash"),
     "gemini-3.1-pro-preview": ModelRoute(family="google-gemini", backend=_gemini_backend),
     "claude-opus-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
     "claude-sonnet-4-7": ModelRoute(family="anthropic", backend=_claude_backend),
@@ -400,7 +404,7 @@ def chat_completions(request: ChatCompletionRequest) -> dict[str, object] | JSON
     prompt = _flatten_messages(request.messages)
     try:
         completion = route.backend(
-            request.model,
+            route.cli_model_name or request.model,
             request.messages,
             prompt=prompt,
             user=request.user,

--- a/tests/ai_agent_bridge/test_openai_proxy.py
+++ b/tests/ai_agent_bridge/test_openai_proxy.py
@@ -75,6 +75,8 @@ def test_chat_completions_gemini_round_trip(monkeypatch):
     model_id = "gemini-3.0-flash-preview"
 
     def backend(model, messages, **kwargs):
+        # Assert the alias is resolved to the underlying CLI model
+        assert model == "gemini-2.5-flash"
         return proxy.CompletionResponse(content="hello from gemini")
 
     monkeypatch.setitem(proxy._ROUTABLE_MODELS, model_id, _route_with_backend(model_id, backend))
@@ -88,6 +90,28 @@ def test_chat_completions_gemini_round_trip(monkeypatch):
     assert response.status_code == 200
     assert body["model"] == model_id
     assert body["choices"][0]["message"]["content"] == "hello from gemini"
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_gemini_pro_round_trip(monkeypatch):
+    model_id = "gemini-3.1-pro-preview"
+
+    def backend(model, messages, **kwargs):
+        # Assert no remapping occurs for the pro model
+        assert model == "gemini-3.1-pro-preview"
+        return proxy.CompletionResponse(content="hello from gemini pro")
+
+    monkeypatch.setitem(proxy._ROUTABLE_MODELS, model_id, _route_with_backend(model_id, backend))
+
+    response = _client().post(
+        "/v1/chat/completions",
+        json={"model": model_id, "messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["model"] == model_id
+    assert body["choices"][0]["message"]["content"] == "hello from gemini pro"
     assert body["choices"][0]["finish_reason"] == "stop"
 
 


### PR DESCRIPTION
Fixes #2022.

**Decision: REMAP**

**Evidence:**
- Running the `gemini-3.0-flash-preview` model through the CLI resulted in a Google API error: `ModelNotFoundError: Requested entity was not found.`
- The `gemini-2.5-flash` model was verified as a valid, supported Flash-class model within the CLI context that successfully processed prompts.
- The `gemini-3.1-pro-preview` model alias was also validated as working and has been preserved.

**Changes:**
1. Modified the `ModelRoute` dataclass to include an optional `cli_model_name` parameter.
2. Updated the proxy `chat_completions` handler to dynamically select `cli_model_name` over `model_id` if it is provided.
3. Added a routing entry remap for `gemini-3.0-flash-preview` to `gemini-2.5-flash` to ensure downstream functionality matches the alias.
4. Added documentation tracking the alias remap.
5. Added tests confirming model resolution mechanics and regression checks for the 3.1 Pro model.