### PR TITLE
feat(healthz): add TTL cache + concurrent probing (DoS mitigation)

### DIFF
--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -6,12 +6,14 @@ model listing, non-streaming chat completions, and a cheap health probe.
 
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import re
 import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -287,7 +289,7 @@ _ROUTABLE_MODELS: dict[str, ModelRoute] = {
 }
 
 
-def _probe_cli(argv: list[str]) -> bool:
+def _probe_cli(argv: list[str]) -> tuple[bool, str]:
     try:
         result = subprocess.run(
             argv,
@@ -299,32 +301,40 @@ def _probe_cli(argv: list[str]) -> bool:
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0
+        return False, ""
+    if result.returncode == 0:
+        return True, result.stdout.strip().splitlines()[0] if result.stdout.strip() else "unknown"
+    return False, ""
 
 
-def _probe_codex() -> bool:
+def _probe_codex() -> tuple[bool, str]:
     return _probe_cli([CODEX_CLI, "--version"])
 
 
-def _probe_gemini() -> bool:
+def _probe_gemini() -> tuple[bool, str]:
     return _probe_cli([GEMINI_CLI, "--version"])
 
 
-def _probe_claude() -> bool:
+def _probe_claude() -> tuple[bool, str]:
     return _probe_cli([*CLAUDE_CMD, "--version"])
 
 
-def _probe_hermes() -> bool:
+def _probe_hermes() -> tuple[bool, str]:
     return _probe_cli([shutil.which("hermes") or "hermes", "--version"])
 
 
-_BACKEND_PROBES: dict[str, Callable[[], bool]] = {
+_BACKEND_PROBES: dict[str, Callable[[], tuple[bool, str]]] = {
     "codex": _probe_codex,
     "gemini": _probe_gemini,
     "claude": _probe_claude,
     "hermes": _probe_hermes,
 }
+
+_BRIDGE_HEALTHZ_TTL_SECS = int(os.environ.get("BRIDGE_HEALTHZ_TTL_SECS", "60"))
+
+_healthz_cache: dict[str, tuple[float, bool, str]] = {}
+_healthz_cache_lock = threading.Lock()
+_healthz_in_flight: dict[str, threading.Event] = {}
 
 
 def _openai_error(status_code: int, message: str, error_type: str, code: str) -> JSONResponse:
@@ -363,9 +373,76 @@ async def validation_exception_handler(_request: Request, exc: RequestValidation
 
 @app.get("/healthz")
 def healthz() -> dict[str, object]:
+    """Health check with backend availability probes (issue #2029).
+
+    Probe results are cached for ``BRIDGE_HEALTHZ_TTL_SECS`` (default 60s)
+    to prevent DoS via subprocess-fork storms from external monitoring.
+    Uncached probes run concurrently via ``ThreadPoolExecutor``.
+    Single-flight deduplication ensures only one probe per backend
+    runs across concurrent requests.
+    """
+    now = time.monotonic()
+    ttl = _BRIDGE_HEALTHZ_TTL_SECS
+
+    # --- Phase 1: collect cached results and identify stale/missing backends ---
+    with _healthz_cache_lock:
+        cached: dict[str, bool] = {}
+        missing: list[str] = []
+        for name in _BACKEND_PROBES:
+            entry = _healthz_cache.get(name)
+            if entry is not None and now - entry[0] < ttl:
+                cached[name] = entry[1]
+            else:
+                missing.append(name)
+
+    # --- Phase 2: probe stale/missing backends (single-flight per backend) ---
+    if missing:
+        events_to_wait: list[tuple[str, threading.Event]] = []
+        names_to_probe: list[str] = []
+
+        with _healthz_cache_lock:
+            for name in missing:
+                if name in _healthz_in_flight:
+                    events_to_wait.append((name, _healthz_in_flight[name]))
+                else:
+                    event = threading.Event()
+                    _healthz_in_flight[name] = event
+                    names_to_probe.append(name)
+
+        if names_to_probe:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(len(names_to_probe), 4)
+            ) as executor:
+                future_map = {
+                    executor.submit(_BACKEND_PROBES[name]): name
+                    for name in names_to_probe
+                }
+                for future in concurrent.futures.as_completed(future_map):
+                    probe_name = future_map[future]
+                    try:
+                        ok, version = future.result()
+                    except Exception:
+                        ok, version = False, ""
+                    with _healthz_cache_lock:
+                        _healthz_cache[probe_name] = (now, ok, version)
+                        ev = _healthz_in_flight.pop(probe_name, None)
+                        if ev is not None:
+                            ev.set()
+                    cached[probe_name] = ok
+
+        # Wait for any probes started by other concurrent requests
+        for name, event in events_to_wait:
+            event.wait()
+            with _healthz_cache_lock:
+                entry = _healthz_cache.get(name)
+                if entry is not None:
+                    cached[name] = entry[1]
+                else:
+                    cached[name] = False
+
     return {
         "ok": True,
-        "backends": {name: probe() for name, probe in _BACKEND_PROBES.items()},
+        "backends": cached,
     }
 
 

--- a/tests/ai_agent_bridge/test_openai_proxy.py
+++ b/tests/ai_agent_bridge/test_openai_proxy.py
@@ -230,14 +230,20 @@ def test_message_flatten_preserves_role_order(monkeypatch):
 
 
 def test_healthz_endpoint_returns_backend_status(monkeypatch):
+    # Clear any cached state from other tests to keep this test isolated
+    with proxy._healthz_cache_lock:
+        proxy._healthz_cache.clear()
+        proxy._healthz_in_flight.clear()
+
+    monkeypatch.setattr(proxy, "_BRIDGE_HEALTHZ_TTL_SECS", 60)
     monkeypatch.setattr(
         proxy,
         "_BACKEND_PROBES",
         {
-            "codex": lambda: True,
-            "gemini": lambda: False,
-            "claude": lambda: True,
-            "hermes": lambda: False,
+            "codex": lambda: (True, "codex v1.2.3"),
+            "gemini": lambda: (False, ""),
+            "claude": lambda: (True, "claude v4.0"),
+            "hermes": lambda: (False, ""),
         },
     )
 

--- a/tests/ai_agent_bridge/test_openai_proxy_healthz.py
+++ b/tests/ai_agent_bridge/test_openai_proxy_healthz.py
@@ -1,0 +1,203 @@
+"""Tests for /healthz endpoint TTL caching (issue #2029)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from fastapi.testclient import TestClient
+
+from scripts.ai_agent_bridge import openai_proxy as proxy
+
+
+def _client() -> TestClient:
+    return TestClient(proxy.app)
+
+
+def _clear_cache() -> None:
+    """Reset healthz cache and in-flight state between tests."""
+    with proxy._healthz_cache_lock:
+        proxy._healthz_cache.clear()
+        proxy._healthz_in_flight.clear()
+
+
+def _make_probes(slow: str | None = None, failing: str | None = None):
+    """Build a probe dict that counts calls.
+
+    If *slow* is set to a backend name, that probe sleeps 0.5s before
+    returning (to simulate concurrent request overlap).
+    If *failing* is set to a backend name, that probe raises an exception.
+    """
+
+    calls: dict[str, int] = {}
+    lock = threading.Lock()
+
+    def _make(name: str):
+        def _probe() -> tuple[bool, str]:
+            with lock:
+                calls[name] = calls.get(name, 0) + 1
+            if name == slow:
+                time.sleep(0.5)
+            if name == failing:
+                raise RuntimeError("probe failed")
+            return (True, f"{name}/v1")
+
+        return _probe
+
+    return {name: _make(name) for name in proxy._BACKEND_PROBES}, calls
+
+
+# ── Test 1: cache hit ──────────────────────────────────────────────────────
+
+
+def test_healthz_cache_hit(monkeypatch):
+    """Probe once, advance clock 30s, probe again — only 1 set of calls."""
+    probes, calls = _make_probes()
+    monkeypatch.setattr(proxy, "_BACKEND_PROBES", probes)
+
+    _clear_cache()
+
+    # First call — fills cache
+    response1 = _client().get("/healthz")
+    assert response1.status_code == 200
+    assert response1.json()["backends"] == {
+        "codex": True,
+        "gemini": True,
+        "claude": True,
+        "hermes": True,
+    }
+    assert calls == {"codex": 1, "gemini": 1, "claude": 1, "hermes": 1}
+
+    # Advance clock 30s (within 60s TTL) — capture original before patching
+    real_monotonic = time.monotonic
+    monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 30)
+
+    # Second call — should use cache, no new probes
+    response2 = _client().get("/healthz")
+    assert response2.status_code == 200
+    assert calls == {"codex": 1, "gemini": 1, "claude": 1, "hermes": 1}
+
+
+# ── Test 2: cache expiry ────────────────────────────────────────────────────
+
+
+def test_healthz_cache_expiry(monkeypatch):
+    """Probe once, advance clock 70s, probe again — 2 sets of calls."""
+    probes, calls = _make_probes()
+    monkeypatch.setattr(proxy, "_BACKEND_PROBES", probes)
+
+    _clear_cache()
+
+    # First call
+    _client().get("/healthz")
+    assert calls == {"codex": 1, "gemini": 1, "claude": 1, "hermes": 1}
+
+    # Advance clock 70s (past 60s TTL)
+    real_monotonic = time.monotonic
+    monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 70)
+
+    # Second call — cache expired, probes run again
+    _client().get("/healthz")
+    assert calls == {"codex": 2, "gemini": 2, "claude": 2, "hermes": 2}
+
+
+# ── Test 3: concurrent first-request (single-flight) ────────────────────────
+
+
+def test_healthz_concurrent_first_request(monkeypatch):
+    """10 concurrent /healthz with cold cache → max 4 probes (1 per backend)."""
+    # Make all probes slow so concurrent requests overlap
+    probes, calls = _make_probes(slow="codex")
+    monkeypatch.setattr(proxy, "_BACKEND_PROBES", probes)
+
+    _clear_cache()
+
+    errors: list[Exception] = []
+    results: list[dict] = []
+
+    def _call():
+        try:
+            client = TestClient(proxy.app)
+            resp = client.get("/healthz")
+            results.append(resp.json())
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_call) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert len(results) == 10
+
+    # Every result should report all 4 backends healthy
+    for r in results:
+        assert r["ok"] is True
+        assert r["backends"] == {
+            "codex": True,
+            "gemini": True,
+            "claude": True,
+            "hermes": True,
+        }
+
+    # Single-flight: at most 1 probe per backend across all calls
+    for name in proxy._BACKEND_PROBES:
+        assert calls.get(name, 0) <= 1, (
+            f"Backend '{name}' probed {calls.get(name, 0)} times, "
+            f"expected ≤1 with single-flight"
+        )
+
+
+# ── Test 4: TTL env var override ────────────────────────────────────────────
+
+
+def test_healthz_ttl_env_var(monkeypatch):
+    """BRIDGE_HEALTHZ_TTL_SECS=5 → cache expires at 5s."""
+    probes, calls = _make_probes()
+    monkeypatch.setattr(proxy, "_BACKEND_PROBES", probes)
+    monkeypatch.setattr(proxy, "_BRIDGE_HEALTHZ_TTL_SECS", 5)
+
+    _clear_cache()
+
+    # First call — fills cache with 5s TTL
+    _client().get("/healthz")
+    assert calls == {"codex": 1, "gemini": 1, "claude": 1, "hermes": 1}
+
+    # Advance 3s — cache still fresh
+    real_monotonic = time.monotonic
+    monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 3)
+    _client().get("/healthz")
+    assert calls == {"codex": 1, "gemini": 1, "claude": 1, "hermes": 1}
+
+    # Advance another 3s (total 6s) — cache expired
+    monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 6)
+    _client().get("/healthz")
+    assert calls == {"codex": 2, "gemini": 2, "claude": 2, "hermes": 2}
+
+
+# ── Test 5: backend failure does not block other backends ────────────────────
+
+
+def test_healthz_backend_failure_does_not_block(monkeypatch):
+    """One probe fails — other 3 still return results."""
+    probes, calls = _make_probes(failing="gemini")
+    monkeypatch.setattr(proxy, "_BACKEND_PROBES", probes)
+
+    _clear_cache()
+
+    response = _client().get("/healthz")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    # gemini is the failing probe → False
+    assert body["backends"] == {
+        "codex": True,
+        "gemini": False,
+        "claude": True,
+        "hermes": True,
+    }
+    # All 4 probes were attempted
+    assert calls == {"codex": 1, "gemini": 1, "claude": 1, "hermes": 1}


### PR DESCRIPTION
Closes #2029

## Summary

Every `GET /healthz` request previously ran 4 CLI `--version` probes
serially (1s timeout each). External monitors polling at 5s intervals
would fork 20 subprocesses/sec — a DoS surface.

This PR adds a 60-second TTL cache with single-flight deduplication
and concurrent probing.

## Changes

- `_probe_cli` now returns `tuple[bool, str]` (ok + version string)
- Cache dict `_healthz_cache` stores `{name: (timestamp, ok, version)}`
- `BRIDGE_HEALTHZ_TTL_SECS` env var controls TTL (default 60)
- Uncached probes run concurrently via `ThreadPoolExecutor(max_workers=4)`
- Single-flight: `_healthz_in_flight` dict + `threading.Event` prevent
  duplicate probes across concurrent requests
- 5 new tests covering cache hit, expiry, concurrent first-request,
  TTL override, and backend failure isolation

## Verifiable claims (per #M-4)

### Handler updated
```
 scripts/ai_agent_bridge/openai_proxy.py    | 95 +++++++++++++++++++++++++++---
 tests/ai_agent_bridge/test_openai_proxy.py | 15 +++--
 2 files changed, 97 insertions(+), 13 deletions(-)
```

### New tests pass
```
tests/ai_agent_bridge/test_openai_proxy_healthz.py::test_healthz_cache_hit PASSED [ 20%]
tests/ai_agent_bridge/test_openai_proxy_healthz.py::test_healthz_cache_expiry PASSED [ 40%]
tests/ai_agent_bridge/test_openai_proxy_healthz.py::test_healthz_concurrent_first_request PASSED [ 60%]
tests/ai_agent_bridge/test_openai_proxy_healthz.py::test_healthz_ttl_env_var PASSED [ 80%]
tests/ai_agent_bridge/test_openai_proxy_healthz.py::test_healthz_backend_failure_does_not_block PASSED [100%]

5 passed in 0.78s
```

### Existing bridge tests still pass
```
37 passed in 2.16s
```

### Ruff clean
```
All checks passed!
```

### Pre-commit clean
```
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
...all hooks passed...
```

### Commit
```
70e1fff784 feat(healthz): add TTL cache + concurrent probing (DoS mitigation)
```

### Manual DoS validation
ab serve requires extra setup (not available in worktree). Skipped.