### PR TITLE
fix(delegate): bump silence_timeout 1800->3600 (#2071 stopgap)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -162,7 +162,14 @@ def _inject_gh_token_for_agent(worker_env: dict[str, str], agent: str) -> None:
 
 
 DEFAULT_HARD_TIMEOUT_S = 7200
-DEFAULT_SILENCE_TIMEOUT_S = 1800
+# Bumped 1800 -> 3600 on 2026-05-18 after kubedojo-artifacts Codex dispatch
+# timed out at exactly 1800s with worktree_dirty_on_exit=true and
+# response_chars=0 — i.e. the agent was actively making file changes but
+# its stream-json output was block-buffered by libc (non-TTY stdout) and
+# never reached the watchdog. Until #2071 PTY-wrapping lands, the looser
+# silence window is the stopgap. See watchdog.py:323-332 for the historical
+# Gemini block-buffering incident chain (#1184).
+DEFAULT_SILENCE_TIMEOUT_S = 3600
 
 
 def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
@@ -1609,8 +1616,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Absolute wall-clock seconds for the worker before the runtime "
             f"hard-kills it (default: {DEFAULT_HARD_TIMEOUT_S}). "
-            "--silence-timeout defaults to 1800s and catches stdout-silent "
-            "hangs sooner."
+            f"--silence-timeout defaults to {DEFAULT_SILENCE_TIMEOUT_S}s and catches "
+            "stdout-silent hangs sooner."
         ),
     )
     d.add_argument(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -99,10 +99,10 @@ def test_dispatch_parser_timeout_defaults():
     ])
 
     assert args.hard_timeout == 7200
-    assert args.silence_timeout == 1800
+    assert args.silence_timeout == 3600
 
 
-def test_silence_timeout_default_is_1800():
+def test_silence_timeout_default_is_3600():
     args = delegate.build_parser().parse_args([
         "dispatch",
         "--agent",
@@ -113,7 +113,7 @@ def test_silence_timeout_default_is_1800():
         "hi",
     ])
 
-    assert args.silence_timeout == 1800
+    assert args.silence_timeout == 3600
 
 
 def test_explicit_silence_timeout_override_still_works():
@@ -142,7 +142,7 @@ def test_dispatch_help_documents_timeout_interaction(capsys):
     assert exc_info.value.code == 0
     assert "--hard-timeout" in captured.out
     assert "--silence-timeout" in captured.out
-    assert "1800s" in captured.out
+    assert "3600s" in captured.out
     assert "pass 600" in captured.out
     assert "fallback" in captured.out
     assert "0 disables" in captured.out


### PR DESCRIPTION
## Summary

Stopgap for #2071 ahead of the proper PTY-wrap fix. Doubles the silence
window from 30 min to 60 min so legitimately-working Codex dispatches
(which produce zero stdout for stretches due to libc block-buffering on
non-TTY pipes) aren't false-killed.

## Evidence motivating this bump

Tonight's \`adopt-kubedojo-artifacts-20260517-215941\` dispatch:

- \`status=timeout\`, \`duration_s=1801.57\` (exactly the silence window)
- \`response_chars=0\` (no stdout reached delegate.py)
- \`worktree_dirty_on_exit=true\` — Codex DID modify files
  (\`scripts/api/artifacts_page.py\`, \`docs_router.py\`,
  \`starlight/src/content/docs/a1/index.mdx\`, etc.)
- File mtimes inside the worktree show edits between T+8min and T+24min

So the agent wasn't crashed and wasn't idle — its stream-json output
was stuck in libc's stdout buffer and never reached the watchdog's
\`last_stdout_activity\` counter. The watchdog correctly fired
\`stdout_silence_timeout\` per its rule, but the rule fires false-positive
on block-buffered non-TTY agents.

Per the docstring at \`scripts/agent_runtime/watchdog.py:323-332\`
(incident chain #1184), Gemini exhibited the same pattern in
April 2026 — the historical fix was to ditch mtime-poller-based stall
detection in favor of pure stdout-line-watching. This works as long as
stdout actually streams; for block-buffered subprocesses it does not.

## What this PR does

* \`DEFAULT_SILENCE_TIMEOUT_S\`: \`1800\` -> \`3600\`
* Inline comment naming the buffering bug + pointing at #2071 + the
  watchdog incident chain
* Help text and tests updated to match new default

## What this PR does NOT do

* Fix the root cause (block-buffered stdout from non-TTY subprocesses).
  That requires PTY-wrapping the \`subprocess.Popen\` invocation in
  \`scripts/agent_runtime/runner.py\` so line-buffering kicks in
  naturally. Filed/dispatched separately as the proper #2071 fix.

## Verifiable claims (per #M-4)

* \`tests/test_delegate.py\`: \`67 passed in 5.06s\`
* \`ruff check scripts/delegate.py tests/test_delegate.py\`: \`All checks passed!\`
* \`git diff --stat\`: \`2 files changed, 14 insertions(+), 7 deletions(-)\`

## Test plan

* [x] All existing \`test_delegate.py\` tests updated to match new default
* [x] Help text test now expects \`3600s\`
* [x] Two default-assertion tests updated (parser default + rename)
* [x] Pre-commit clean (ran on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)