### PR TITLE
fix(runtime): PTY-wrap subprocess spawn to fix block-buffered stdout hangs (#2071)

### DIFF
--- a/scripts/agent_runtime/_smoke_pty_agents.sh
+++ b/scripts/agent_runtime/_smoke_pty_agents.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Per-agent PTY smoke validation (#2071).
+#
+# Fires a small "say hello" probe via runner.invoke against each of the
+# 5 supported agents and asserts:
+#
+#   1. response_chars > 0  — output was captured (the actual #2071 bug)
+#   2. result.ok is True   — the call completed cleanly
+#
+# This is a MANUAL post-merge validation tool. It makes real LLM calls
+# (small ones — "say hello"), so we don't run it automatically in CI;
+# the user / orchestrator runs it once after PR merge, captures the
+# per-agent output, and either confirms green or files a follow-up
+# issue for any regression.
+#
+# Usage:
+#     bash scripts/agent_runtime/_smoke_pty_agents.sh            # all 5
+#     bash scripts/agent_runtime/_smoke_pty_agents.sh codex      # one
+#     bash scripts/agent_runtime/_smoke_pty_agents.sh codex gemini
+#
+# Output: one JSON line per agent on stdout. On any failure (no
+# response, regression, etc.) the script prints the failure and
+# continues to the next agent. Final exit code = number of failed
+# agents (0 = all green).
+#
+# Per-agent regression workaround: set DELEGATE_DISABLE_PTY=1 in the
+# adapter's spawn path. Document the issue, file a follow-up, restore
+# PTY mode once the agent-specific fix lands.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${ROOT}" || exit 1
+
+VENV_PY="${ROOT}/.venv/bin/python"
+if [[ ! -x "${VENV_PY}" ]]; then
+    COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+    if [[ -n "${COMMON_DIR}" ]]; then
+        CANDIDATE="$(cd "${COMMON_DIR}/.." 2>/dev/null && pwd)/.venv/bin/python"
+        if [[ -x "${CANDIDATE}" ]]; then
+            VENV_PY="${CANDIDATE}"
+        fi
+    fi
+fi
+if [[ ! -x "${VENV_PY}" ]]; then
+    echo "ERROR: cannot locate .venv/bin/python (worktree or main checkout)" >&2
+    exit 99
+fi
+
+# The Python smoke driver — written to a temp file so we can invoke it
+# without heredoc-pipe parsing oddities.
+DRIVER="$(mktemp -t pty-smoke-driver.XXXXXX.py)"
+cat >"${DRIVER}" <<'PYDRIVER'
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+agent = sys.argv[1]
+repo_root = Path(os.environ["LU_ROOT"])
+sys.path.insert(0, str(repo_root / "scripts"))
+
+MODEL_BY_AGENT = {
+    "codex":    None,
+    "gemini":   "gemini-3-flash-preview",
+    "claude":   "claude-haiku-4-5-20251001",
+    "deepseek": "deepseek-v4-flash",
+    "grok":     None,
+}
+
+prompt = "Reply with exactly: SMOKE_OK"
+
+start = time.monotonic()
+result = None
+err = None
+try:
+    from agent_runtime.runner import invoke
+    result = invoke(
+        agent_name=agent,
+        prompt=prompt,
+        mode="read-only",
+        cwd=repo_root,
+        model=MODEL_BY_AGENT.get(agent),
+        entrypoint="runtime",
+        hard_timeout=120,
+    )
+except Exception as exc:
+    err = f"{type(exc).__name__}: {exc}"
+elapsed = time.monotonic() - start
+
+report = {
+    "agent": agent,
+    "elapsed_s": round(elapsed, 2),
+    "ok": result.ok if result is not None else False,
+    "response_chars": len(result.response) if result is not None else 0,
+    "model": getattr(result, "model", None) if result is not None else None,
+    "error": err,
+}
+print(json.dumps(report))
+
+fail_reasons = []
+if not report["ok"]:
+    fail_reasons.append(f"result.ok=False (err={err})")
+if report["response_chars"] == 0:
+    fail_reasons.append("response_chars=0 — PTY may not be flowing")
+if fail_reasons:
+    print("REGRESSION:", "; ".join(fail_reasons), file=sys.stderr)
+    sys.exit(2)
+PYDRIVER
+
+cleanup() {
+    rm -f "${DRIVER}"
+}
+trap cleanup EXIT
+
+AGENTS=("$@")
+if [[ ${#AGENTS[@]} -eq 0 ]]; then
+    AGENTS=(codex gemini claude deepseek grok)
+fi
+
+FAILED=0
+export LU_ROOT="${ROOT}"
+
+for AGENT in "${AGENTS[@]}"; do
+    echo "=== smoke: ${AGENT} ==="
+    if "${VENV_PY}" "${DRIVER}" "${AGENT}"; then
+        echo "  OK"
+    else
+        echo "  AGENT FAILED (exit $?)"
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+echo
+echo "=== smoke summary: ${FAILED} failed of ${#AGENTS[@]} agents ==="
+exit "${FAILED}"

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -34,7 +34,7 @@ import shutil
 import signal
 import subprocess
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -84,6 +84,210 @@ _MCP_FAILURE_URL_RE = re.compile(r"url \((?P<url>https?://[^)\s]+)\)")
 # In-process cache of instantiated adapters. Adapters are stateless so we
 # can reuse one instance across all invocations of the same agent.
 _ADAPTER_CACHE: dict[str, AgentAdapter] = {}
+
+
+class _PTYUnavailableError(RuntimeError):
+    """Raised when PTY setup itself fails on this host.
+
+    Distinguishes "PTY allocation / termios setup failed" (the
+    fail-soft case where we fall back to pipe spawn) from "Popen
+    failed because the binary doesn't exist" (a real error the
+    caller must surface). Both would otherwise show up as ``OSError``,
+    which made the original fail-soft path swallow binary-not-found
+    errors with a misleading warning.
+    """
+
+
+def _pty_disabled_via_env() -> bool:
+    """Return True when ``DELEGATE_DISABLE_PTY`` opts back into pipe spawn.
+
+    Read at call time (not module import) so tests can flip the env var
+    inside a single process without re-importing the module.
+    """
+    return os.environ.get("DELEGATE_DISABLE_PTY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _spawn_pty_subprocess(
+    cmd: Sequence[str],
+    *,
+    cwd: Path | str,
+    env: Mapping[str, str],
+    stdin: Any = subprocess.DEVNULL,
+    pty_window: tuple[int, int] = (40, 200),
+) -> tuple[subprocess.Popen, int, int]:
+    """Spawn ``cmd`` in a PTY so stdout/stderr line-buffer naturally.
+
+    Returns ``(proc, stdout_master_fd, stderr_master_fd)``. The slave
+    fds are closed in the parent immediately after spawn so EOF / EIO
+    propagates cleanly when the child closes its side.
+
+    PTY usage forces the child's libc to detect a TTY and switch from
+    block-buffered to line-buffered stdout. Without this, agents that
+    write to stdout via stdio (most CLIs) emit no data to the parent
+    for minutes at a time, defeating the watchdog's silence-timeout
+    detection. See #2071 + watchdog.py::should_kill incident chain
+    (#1184): Gemini block-buffers stdout when not a TTY → stdout
+    streamer goes silent → looks identical to a hang but is actually
+    successful work.
+
+    Per-slave termios: ``OPOST`` is disabled so the kernel does NOT
+    convert ``\\n`` to ``\\r\\n`` on output. That keeps stream-json
+    payloads byte-identical to what the child wrote — which the
+    streamer's UTF-8 decode + ANSI strip expects. We additionally
+    set ``TIOCSWINSZ`` to ``pty_window`` so children that query
+    terminal size for output formatting get sane defaults.
+
+    Caller is responsible for closing the master fds via the watchdog's
+    ``stop_watchdog(..., stdout_master_fd=..., stderr_master_fd=...)``.
+    """
+    # --- Phase 1: PTY allocation + termios configuration. ---
+    # Failure here is "PTY unavailable on this host" — surface a
+    # dedicated exception so the caller can fall back to pipe spawn
+    # rather than swallowing unrelated Popen errors with a misleading
+    # warning.
+    try:
+        import fcntl
+        import pty
+        import struct
+        import termios
+
+        stdout_master, stdout_slave = pty.openpty()
+        try:
+            stderr_master, stderr_slave = pty.openpty()
+        except (OSError, AttributeError):
+            with contextlib.suppress(OSError):
+                os.close(stdout_master)
+            with contextlib.suppress(OSError):
+                os.close(stdout_slave)
+            raise
+
+        # Disable OPOST on each slave so \n stays \n (no ONLCR rewrite).
+        # Belt-and-suspenders: the streamer also strips \r\n → \n if a
+        # platform somehow ignores the termios change. Suppression is
+        # narrow — these calls are advisory; the spawn proceeds either
+        # way.
+        for slave_fd in (stdout_slave, stderr_slave):
+            with contextlib.suppress(termios.error, OSError):
+                attrs = termios.tcgetattr(slave_fd)
+                attrs[1] &= ~termios.OPOST  # oflag
+                termios.tcsetattr(slave_fd, termios.TCSANOW, attrs)
+
+        # Set sane window size so agents that query TIOCGWINSZ for output
+        # formatting (e.g. ANSI tables) get reasonable defaults.
+        winsize = struct.pack("HHHH", pty_window[0], pty_window[1], 0, 0)
+        for slave_fd in (stdout_slave, stderr_slave):
+            with contextlib.suppress(OSError):
+                fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, winsize)
+    except (OSError, AttributeError) as exc:
+        raise _PTYUnavailableError(
+            f"PTY setup failed ({type(exc).__name__}: {exc})"
+        ) from exc
+
+    # --- Phase 2: spawn the child against the PTY slaves. ---
+    # Any failure here (FileNotFoundError, PermissionError, generic
+    # OSError) is a real spawn problem and must propagate UNCHANGED so
+    # the runner's existing FileNotFoundError handling can turn it into
+    # AgentUnavailableError. Do NOT translate this to PTYUnavailable.
+    try:
+        proc = subprocess.Popen(
+            list(cmd),
+            cwd=str(cwd),
+            env=dict(env),
+            stdin=stdin,
+            stdout=stdout_slave,
+            stderr=stderr_slave,
+            # text=True / bufsize=1 here are no-ops for stdout/stderr
+            # (those are raw int fds, not Python-managed pipes), but
+            # they make stdin a line-buffered text pipe when the
+            # caller passes stdin=PIPE for stdin_payload writes.
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+    except BaseException:
+        for fd in (stdout_master, stderr_master, stdout_slave, stderr_slave):
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        raise
+
+    # Parent does NOT need slave fds; close them so EOF arrives on
+    # master when child closes its side.
+    with contextlib.suppress(OSError):
+        os.close(stdout_slave)
+    with contextlib.suppress(OSError):
+        os.close(stderr_slave)
+
+    return proc, stdout_master, stderr_master
+
+
+def _spawn_pipe_subprocess(
+    cmd: Sequence[str],
+    *,
+    cwd: Path | str,
+    env: Mapping[str, str],
+    stdin: Any = subprocess.DEVNULL,
+) -> tuple[subprocess.Popen, None, None]:
+    """Spawn ``cmd`` with PIPE stdout/stderr (legacy pre-PTY path).
+
+    Returned only when ``DELEGATE_DISABLE_PTY`` is set OR PTY is
+    unavailable on the host (rare; ``pty`` is POSIX). Reserved as an
+    escape hatch in case PTY mode regresses for a specific agent
+    (e.g. one that emits ANSI codes in the middle of stream-json
+    events and breaks parsing). See ``_spawn_subprocess`` for the
+    fail-soft selection logic.
+    """
+    proc = subprocess.Popen(
+        list(cmd),
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(cwd),
+        env=dict(env),
+        bufsize=1,
+        start_new_session=True,
+    )
+    return proc, None, None
+
+
+def _spawn_subprocess(
+    cmd: Sequence[str],
+    *,
+    cwd: Path | str,
+    env: Mapping[str, str],
+    stdin: Any,
+) -> tuple[subprocess.Popen, int | None, int | None]:
+    """Spawn ``cmd`` using PTY mode by default; pipe mode on opt-out.
+
+    Fail-soft: if ``pty.openpty()`` or the termios calls raise on the
+    host platform (Linux containers without /dev/pts, etc.), fall back
+    to pipe-based spawn with a warning rather than crashing the
+    runner. Pipe mode is correct but defeats the block-buffer fix —
+    that's the trade-off the env var documents.
+
+    Popen failures (missing binary, EACCES) are NOT caught here — they
+    propagate as ``FileNotFoundError`` / ``PermissionError`` / ``OSError``
+    so the caller's existing ``AgentUnavailableError`` mapping fires.
+    """
+    if _pty_disabled_via_env():
+        return _spawn_pipe_subprocess(cmd, cwd=cwd, env=env, stdin=stdin)
+    try:
+        return _spawn_pty_subprocess(cmd, cwd=cwd, env=env, stdin=stdin)
+    except _PTYUnavailableError as exc:
+        import warnings
+
+        warnings.warn(
+            f"{exc}; falling back to pipe-based spawn. Set "
+            f"DELEGATE_DISABLE_PTY=1 to silence this warning.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _spawn_pipe_subprocess(cmd, cwd=cwd, env=env, stdin=stdin)
 
 
 def _normalize_mcp_url(url: str | None) -> str:
@@ -694,19 +898,16 @@ def _execute_invocation_plan(
     watchdog_state: WatchdogState | None = None
     watchdog_threads: list = []
     liveness_paths: tuple[Path, ...] = ()
+    stdout_master_fd: int | None = None
+    stderr_master_fd: int | None = None
 
     try:
         try:
-            proc = subprocess.Popen(
+            proc, stdout_master_fd, stderr_master_fd = _spawn_subprocess(
                 plan.cmd,
-                stdin=subprocess.PIPE if plan.stdin_payload else subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                cwd=str(cwd),
+                cwd=cwd,
                 env=env,
-                bufsize=1,
-                start_new_session=True,
+                stdin=subprocess.PIPE if plan.stdin_payload else subprocess.DEVNULL,
             )
         except (FileNotFoundError, PermissionError, OSError) as exc:
             record = _build_usage_record(
@@ -744,7 +945,12 @@ def _execute_invocation_plan(
         liveness_paths = tuple(adapter.liveness_signal_paths(plan))
         if plan.output_file is not None and plan.output_file not in liveness_paths:
             liveness_paths = (*liveness_paths, plan.output_file)
-        watchdog_state, watchdog_threads = start_watchdog(proc, list(liveness_paths))
+        watchdog_state, watchdog_threads = start_watchdog(
+            proc,
+            list(liveness_paths),
+            stdout_master_fd=stdout_master_fd,
+            stderr_master_fd=stderr_master_fd,
+        )
         mcp_observer = _McpRuntimeObserver.from_tool_config(
             agent_name=agent_name,
             task_id=task_id,
@@ -827,7 +1033,17 @@ def _execute_invocation_plan(
         stdout_text = "".join(watchdog_state.stdout_lines)
         stderr_text = "".join(watchdog_state.stderr_lines)
 
-        stop_watchdog(watchdog_state, watchdog_threads, proc=proc)
+        stop_watchdog(
+            watchdog_state,
+            watchdog_threads,
+            proc=proc,
+            stdout_master_fd=stdout_master_fd,
+            stderr_master_fd=stderr_master_fd,
+        )
+        # stop_watchdog closed the master fds; null out our locals so
+        # the finally clause doesn't try to close them again.
+        stdout_master_fd = None
+        stderr_master_fd = None
         parse = adapter.parse_response(
             stdout=stdout_text,
             stderr=stderr_text,
@@ -851,7 +1067,13 @@ def _execute_invocation_plan(
                 _kill_process_tree(proc)
 
         if watchdog_state is not None:
-            stop_watchdog(watchdog_state, watchdog_threads, proc=proc)
+            stop_watchdog(
+                watchdog_state,
+                watchdog_threads,
+                proc=proc,
+                stdout_master_fd=stdout_master_fd,
+                stderr_master_fd=stderr_master_fd,
+            )
 
         if (
             plan.output_file is not None

--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -31,7 +31,9 @@ Issue: #1184
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
+import re
 import subprocess
 import threading
 import time
@@ -48,6 +50,23 @@ _MTIME_POLL_INTERVAL_S = 5.0
 # this many paths will only have the first _MAX_LIVENESS_PATHS polled.
 # Arbitrary but bounded — prevents adapter mistakes from causing poll storms.
 _MAX_LIVENESS_PATHS = 5
+
+# Read chunk size for PTY master reads. 4 KiB matches the typical libc
+# line-buffer size; bigger reads are fine but waste no time on partial
+# kernel buffers because os.read on a PTY returns whatever is available.
+_PTY_READ_CHUNK = 4096
+
+# Strip CSI / SGR escape sequences emitted by TTY-detecting CLIs. PTY-wrapped
+# children think their stdout is interactive and may emit ANSI color codes,
+# cursor saves, and similar. Stream-json payloads never contain literal
+# control bytes (RFC 8259 requires they be escaped), so stripping here is
+# safe for the JSON event consumer in the runner.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(line: str) -> str:
+    """Remove ANSI SGR / CSI escape sequences from a line."""
+    return _ANSI_ESCAPE_RE.sub("", line)
 
 
 @dataclass
@@ -153,6 +172,85 @@ def _stderr_streamer(proc: subprocess.Popen, state: WatchdogState) -> None:
             pass
 
 
+def _pty_line_streamer(
+    master_fd: int,
+    state: WatchdogState,
+    *,
+    is_stderr: bool,
+) -> None:
+    """Background thread: read from a PTY master fd, emit complete lines.
+
+    Unlike the pipe-based streamers above, this path reads raw bytes
+    from a master pty fd via ``os.read`` and reassembles them into
+    newline-terminated strings. PTY usage means the child's libc
+    detects a TTY and switches stdout to line-buffered mode — events
+    arrive in real time rather than sitting in a block-buffer for
+    minutes. See ``_spawn_pty_subprocess`` in runner.py for the why.
+
+    EOF semantics differ by OS:
+      * macOS / *BSD: ``os.read`` returns ``b""`` when the slave side
+        closes (child exits or closes the fd).
+      * Linux: ``os.read`` raises ``OSError(errno=EIO)`` instead.
+
+    Both cases are treated as a clean shutdown signal — symmetrical
+    with how the pipe-based streamer ends on ``iter(..., "")``.
+
+    Issue: #2071.
+    """
+    buffer = bytearray()
+    try:
+        while not state.stop:
+            try:
+                chunk = os.read(master_fd, _PTY_READ_CHUNK)
+            except OSError as exc:
+                # Linux EIO == PTY slave closed; mac/BSD returns b"" instead.
+                if exc.errno == errno.EIO:
+                    chunk = b""
+                else:
+                    raise
+            if not chunk:
+                break  # EOF — child closed its end of the PTY
+            buffer.extend(chunk)
+            while True:
+                nl_index = buffer.find(b"\n")
+                if nl_index == -1:
+                    break
+                raw_line = bytes(buffer[: nl_index + 1])
+                del buffer[: nl_index + 1]
+                line = raw_line.decode("utf-8", errors="replace")
+                # PTY default output mode adds \r before \n. We disable
+                # OPOST on the slave (see runner._spawn_pty_subprocess)
+                # but strip \r defensively in case that termios call
+                # fails or the platform behaves differently.
+                if line.endswith("\r\n"):
+                    line = line[:-2] + "\n"
+                line = _strip_ansi(line)
+                _emit_line(state, line, is_stderr=is_stderr)
+    except (ValueError, OSError):
+        # Master fd closed underneath us (e.g. cleanup raced ahead);
+        # treat as clean shutdown — same semantics as the pipe path.
+        pass
+    finally:
+        # Flush any tail that didn't end in \n — agents sometimes exit
+        # mid-line on crash, and we want to capture that final fragment.
+        if buffer:
+            tail = bytes(buffer).decode("utf-8", errors="replace")
+            tail = tail.replace("\r\n", "\n")
+            tail = _strip_ansi(tail)
+            _emit_line(state, tail, is_stderr=is_stderr)
+
+
+def _emit_line(state: WatchdogState, line: str, *, is_stderr: bool) -> None:
+    """Append a decoded line to the relevant state buffer + bump activity."""
+    now = time.monotonic()
+    if is_stderr:
+        state.stderr_lines.append(line)
+    else:
+        state.stdout_lines.append(line)
+        state.last_stdout_activity = now
+    state.last_activity = now
+
+
 def _mtime_poller(paths: Iterable[Path], state: WatchdogState) -> None:
     """Background thread: poll file mtimes, bump last_activity on changes.
 
@@ -182,27 +280,51 @@ def _mtime_poller(paths: Iterable[Path], state: WatchdogState) -> None:
 
 def start_watchdog(
     proc: subprocess.Popen,
-    liveness_paths: Iterable[Path],
+    liveness_paths: Iterable[Path] = (),
+    *,
+    stdout_master_fd: int | None = None,
+    stderr_master_fd: int | None = None,
 ) -> tuple[WatchdogState, list[threading.Thread]]:
     """Start the stdout streamer + mtime poller threads for a running subprocess.
 
     Args:
-        proc: A Popen object with ``stdout=subprocess.PIPE`` and ``text=True``.
+        proc: A Popen object.
         liveness_paths: Paths to poll for mtime changes (adapter-provided).
             Capped at ``_MAX_LIVENESS_PATHS``.
+        stdout_master_fd: PTY master fd for the child's stdout. When
+            provided, a PTY-mode streamer (``_pty_line_streamer``) reads
+            from this fd instead of ``proc.stdout``. Required for
+            block-buffer-breaking line-buffered streaming — see
+            ``_spawn_pty_subprocess`` in runner.py (#2071).
+        stderr_master_fd: PTY master fd for the child's stderr. Same
+            semantics as ``stdout_master_fd``.
+
+    When the fd kwargs are ``None`` the watchdog falls back to the
+    legacy pipe-mode streamers — exercised by the ``DELEGATE_DISABLE_PTY``
+    opt-out and the regression-pin tests at tests/test_agent_runtime.py.
 
     Returns:
         (state, threads): The shared state and the list of started threads.
-        Callers must call ``stop_watchdog(state, threads)`` to join them
-        cleanly after the subprocess terminates.
+        Callers must call ``stop_watchdog(state, threads, proc=proc, ...)``
+        to join them cleanly after the subprocess terminates.
     """
     now = time.monotonic()
     state = WatchdogState(start_time=now, last_activity=now, last_stdout_activity=now)
 
     threads: list[threading.Thread] = []
 
-    # Layer 1a: stdout streamer (always started if stdout is a pipe)
-    if proc.stdout is not None:
+    # Layer 1a: stdout streamer.
+    if stdout_master_fd is not None:
+        t_stdout = threading.Thread(
+            target=_pty_line_streamer,
+            args=(stdout_master_fd, state),
+            kwargs={"is_stderr": False},
+            name=f"watchdog-stdout-{proc.pid}",
+            daemon=True,
+        )
+        t_stdout.start()
+        threads.append(t_stdout)
+    elif proc.stdout is not None:
         t_stdout = threading.Thread(
             target=_stdout_streamer,
             args=(proc, state),
@@ -219,7 +341,17 @@ def start_watchdog(
     # macOS buffer and block the subprocess forever on its next
     # stderr write. Added 2026-04-10 after reproducing a multi-minute
     # hang on tool-heavy Codex tasks. See _stderr_streamer docstring.
-    if proc.stderr is not None:
+    if stderr_master_fd is not None:
+        t_stderr = threading.Thread(
+            target=_pty_line_streamer,
+            args=(stderr_master_fd, state),
+            kwargs={"is_stderr": True},
+            name=f"watchdog-stderr-{proc.pid}",
+            daemon=True,
+        )
+        t_stderr.start()
+        threads.append(t_stderr)
+    elif proc.stderr is not None:
         t_stderr = threading.Thread(
             target=_stderr_streamer,
             args=(proc, state),
@@ -249,6 +381,9 @@ def stop_watchdog(
     threads: list[threading.Thread],
     timeout: float = 2.0,
     proc: subprocess.Popen | None = None,
+    *,
+    stdout_master_fd: int | None = None,
+    stderr_master_fd: int | None = None,
 ) -> None:
     """Signal the watchdog threads to stop and join them.
 
@@ -257,19 +392,22 @@ def stop_watchdog(
     1. ``state.stop = True`` unblocks the mtime poller (it checks this
        flag between sleeps).
 
-    2. Closing ``proc.stdout`` (if ``proc`` is provided) unblocks the
-       stdout streamer. Without this, the streamer sits on
-       ``proc.stdout.readline()`` forever because the OS pipe read is
-       not interruptible from another thread. Setting state.stop has
-       no effect on a blocked read. Closing the pipe from THIS thread
-       causes ``readline`` to raise ValueError (closed file) which the
-       streamer's try/except catches for a clean exit.
+    2. Closing ``proc.stdout`` (if ``proc`` is provided) — OR closing
+       the PTY master fds (when running in PTY mode, see #2071) —
+       unblocks the streamer. Without this, the streamer sits on
+       ``proc.stdout.readline()`` / ``os.read(master_fd, ...)`` forever
+       because the OS read is not interruptible from another thread.
+       Setting state.stop has no effect on a blocked read. Closing the
+       pipe or master fd from THIS thread causes the read to raise
+       ValueError / OSError which the streamer's try/except catches for
+       a clean exit.
 
-       Pass ``proc`` when you want the streamer to drop IMMEDIATELY
-       without waiting for the subprocess to exit on its own. If you
-       omit ``proc``, the streamer will still exit when the subprocess
-       terminates and its stdout pipe naturally closes — acceptable
-       for the normal path where we've already waited for exit.
+       Pass ``proc`` (and/or fds) when you want the streamer to drop
+       IMMEDIATELY without waiting for the subprocess to exit on its
+       own. If you omit them, the streamer will still exit when the
+       subprocess terminates and its descriptors naturally close —
+       acceptable for the normal path where we've already waited for
+       exit.
 
     Safe to call multiple times. Threads that don't join within
     ``timeout`` are left running as daemons — they'll be cleaned up
@@ -295,6 +433,15 @@ def stop_watchdog(
         if proc.stderr is not None:
             with contextlib.suppress(OSError, ValueError):
                 proc.stderr.close()
+
+    # PTY-mode equivalent: closing the master fds yields EIO/EOF in the
+    # streamer's os.read, which exits cleanly via the same try/except
+    # pattern as the pipe path. Idempotent — if the streamer's finally
+    # block already closed the fd, os.close raises EBADF, suppressed.
+    for fd in (stdout_master_fd, stderr_master_fd):
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
     for t in threads:
         t.join(timeout=timeout)

--- a/tests/agent_runtime/test_pty_subprocess_wrap.py
+++ b/tests/agent_runtime/test_pty_subprocess_wrap.py
@@ -1,0 +1,654 @@
+"""Tests for the PTY-wrapped subprocess spawn path in agent_runtime.
+
+Background — Issue #2071: Codex (and any agent CLI that uses libc stdio)
+block-buffers stdout when it isn't a TTY. With the legacy pipe-based
+spawn, events accumulated in the child's stdout buffer and only flushed
+on buffer-full / exit / explicit fflush — so the watchdog's stdout
+silence timer fired even though the child was actively producing
+events. The PTY-wrapped spawn makes the child's stdout look like a TTY,
+which forces libc to switch to line-buffering, and events arrive in
+real time.
+
+These tests pin the PTY spawn helper + the PTY-mode watchdog streamer:
+
+* Spawn returns valid fds, applies window size, EOF works on child exit
+* Block-buffering regression — the load-bearing assertion: an unflushed
+  child write becomes visible to the watchdog BEFORE the child exits
+* UTF-8 split across read boundary doesn't corrupt characters
+* ANSI escape sequences emitted by TTY-detecting CLIs are stripped
+* DELEGATE_DISABLE_PTY=1 falls back to pipe spawn (escape hatch)
+* Master fds are closed on cleanup; multi-line chunks split correctly;
+  streamer threads join cleanly on child kill
+* End-to-end via the watchdog: 10 child lines with no fflush all reach
+  state.stdout_lines in real time
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+_VENV_PYTHON_CANDIDATES = [
+    _REPO_ROOT / ".venv" / "bin" / "python",
+]
+
+
+def _resolve_test_python() -> str:
+    """Resolve `.venv/bin/python` for subprocess tests.
+
+    Worktree-aware: when the worktree's own .venv doesn't exist, walk
+    up via ``git rev-parse --git-common-dir`` to the main checkout's
+    venv. AGENTS.md forbids falling back to ``sys.executable``.
+    """
+    for candidate in _VENV_PYTHON_CANDIDATES:
+        if candidate.exists():
+            return str(candidate)
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=str(_REPO_ROOT),
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if common_dir:
+            main_venv = (Path(common_dir) / ".." / ".venv" / "bin" / "python").resolve()
+            if main_venv.exists():
+                return str(main_venv)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+    raise RuntimeError(
+        "No project virtualenv Python found. Expected `.venv/bin/python` "
+        "in the current checkout or via git-common-dir."
+    )
+
+
+_TEST_PYTHON = _resolve_test_python()
+
+from agent_runtime.runner import (
+    _pty_disabled_via_env,
+    _spawn_pipe_subprocess,
+    _spawn_pty_subprocess,
+    _spawn_subprocess,
+)
+from agent_runtime.watchdog import (
+    WatchdogState,
+    _strip_ansi,
+    start_watchdog,
+    stop_watchdog,
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Ensure DELEGATE_DISABLE_PTY is unset; tests opt in explicitly."""
+    monkeypatch.delenv("DELEGATE_DISABLE_PTY", raising=False)
+    yield
+
+
+# ----------------------------------------------------------------------
+# Test 1: PTY spawn returns valid fds + child output reaches master.
+# ----------------------------------------------------------------------
+
+def test_pty_spawn_returns_valid_fds_and_master_reads_child_output(clean_env, tmp_path):
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        ["echo", "hi"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+    )
+    try:
+        assert isinstance(stdout_fd, int) and stdout_fd >= 0
+        assert isinstance(stderr_fd, int) and stderr_fd >= 0
+        # fds are valid (fstat succeeds)
+        assert os.fstat(stdout_fd).st_mode != 0
+        assert os.fstat(stderr_fd).st_mode != 0
+        # Read until EOF — child is `echo hi`.
+        chunks = []
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                chunk = os.read(stdout_fd, 4096)
+            except OSError:  # Linux EIO on PTS close
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+            if proc.poll() is not None and not chunk:
+                break
+        data = b"".join(chunks)
+        # OPOST disabled → \n stays \n. Some kernels still re-add \r,
+        # so check the payload not the exact line terminator.
+        assert b"hi" in data
+    finally:
+        for fd in (stdout_fd, stderr_fd):
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5.0)
+
+
+# ----------------------------------------------------------------------
+# Test 2: TIOCSWINSZ is applied to the slave so children see the window.
+# ----------------------------------------------------------------------
+
+def test_pty_spawn_sets_window_size_visible_to_child(clean_env, tmp_path):
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        [
+            _TEST_PYTHON,
+            "-c",
+            "import sys, fcntl, termios, struct; "
+            "buf = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, b'\\0'*8); "
+            "rows, cols, _, _ = struct.unpack('HHHH', buf); "
+            "print(f'{rows} {cols}', flush=True)",
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        pty_window=(48, 132),
+    )
+    try:
+        data = _read_until_eof(stdout_fd, timeout_s=5.0)
+        assert "48 132" in data, f"window not applied; got {data!r}"
+    finally:
+        _safe_close(stdout_fd)
+        _safe_close(stderr_fd)
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5.0)
+
+
+# ----------------------------------------------------------------------
+# Test 3: EOF on child exit — either b"" or EIO, both treated as shutdown.
+# ----------------------------------------------------------------------
+
+def test_pty_master_read_returns_eof_or_eio_on_child_exit(clean_env, tmp_path):
+    import errno as _errno
+
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        [_TEST_PYTHON, "-c", "import sys; sys.stdout.write('done\\n'); sys.stdout.flush()"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+    )
+    try:
+        # Drain the pty as the child runs — on macOS, kernel may discard
+        # pending bytes when the slave side closes, so we MUST read while
+        # the child is still alive or right at the boundary.
+        data = b""
+        deadline = time.monotonic() + 5.0
+        saw_eof = False
+        while time.monotonic() < deadline:
+            try:
+                chunk = os.read(stdout_fd, 4096)
+            except OSError as exc:
+                # Linux raises EIO on slave close — that IS the EOF signal.
+                assert exc.errno == _errno.EIO, f"unexpected errno: {exc.errno}"
+                saw_eof = True
+                break
+            if not chunk:
+                # macOS path: empty bytes signal EOF.
+                saw_eof = True
+                break
+            data += chunk
+        proc.wait(timeout=5.0)
+        assert b"done" in data, f"missed 'done' marker: {data!r}"
+        assert saw_eof, "expected EOF / EIO after child exit"
+    finally:
+        _safe_close(stdout_fd)
+        _safe_close(stderr_fd)
+
+
+# ----------------------------------------------------------------------
+# Test 4 (LOAD-BEARING): block-buffered child output reaches the streamer
+# in real time when PTY-wrapped.
+#
+# This is the core regression guard. With the legacy pipe spawn, a child
+# that writes "a", sleeps 0.5s, writes "b" — without ever calling
+# fflush(stdout) — would not surface "a" until the buffer filled or the
+# child exited. PTY makes the child line-buffer, so "a" appears
+# immediately.
+# ----------------------------------------------------------------------
+
+def test_pty_breaks_block_buffering_for_unflushed_child(clean_env, tmp_path):
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        [
+            _TEST_PYTHON,
+            "-c",
+            # No flush calls — relies entirely on line-buffering kicking in
+            # because the child detects stdout is a TTY (PTY).
+            "import sys, time; "
+            "sys.stdout.write('a\\n'); "
+            "time.sleep(0.5); "
+            "sys.stdout.write('b\\n')",
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+    )
+    state = None
+    threads = []
+    try:
+        state, threads = start_watchdog(
+            proc,
+            liveness_paths=[],
+            stdout_master_fd=stdout_fd,
+            stderr_master_fd=stderr_fd,
+        )
+        # Within ~0.3s — before the 0.5s sleep — "a\n" must be visible.
+        # If we get this within 0.3s the PTY line-buffering is working.
+        # If it only shows up after the child exits (~0.5s+), the PTY
+        # change isn't actually taking effect.
+        deadline = time.monotonic() + 0.4
+        while time.monotonic() < deadline:
+            if state.stdout_lines and any("a" in ln for ln in state.stdout_lines):
+                break
+            time.sleep(0.02)
+        assert state.stdout_lines, (
+            "no stdout lines reached the streamer within 0.4s — "
+            "PTY is not actually line-buffering the child"
+        )
+        assert any("a" in ln for ln in state.stdout_lines), (
+            f"first line missing 'a'; got lines: {state.stdout_lines!r}"
+        )
+        # Both lines should be present after child exits.
+        proc.wait(timeout=5.0)
+        time.sleep(0.1)  # let streamer drain
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+        if state is not None:
+            stop_watchdog(
+                state,
+                threads,
+                proc=proc,
+                stdout_master_fd=stdout_fd,
+                stderr_master_fd=stderr_fd,
+                timeout=2.0,
+            )
+        else:
+            _safe_close(stdout_fd)
+            _safe_close(stderr_fd)
+    # After draining, both lines must be present.
+    joined = "".join(state.stdout_lines) if state else ""
+    assert "a" in joined and "b" in joined, (
+        f"expected both 'a' and 'b' lines; got: {joined!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Test 5: UTF-8 multi-byte sequence split across two reads stays intact.
+#
+# We construct this at the streamer level: feed a pre-made WatchdogState
+# and master_fd from a socketpair to deterministically split bytes.
+# ----------------------------------------------------------------------
+
+def test_pty_streamer_handles_utf8_split_across_read_boundary():
+    import socket
+
+    from agent_runtime.watchdog import _pty_line_streamer
+
+    # Use socketpair as a stand-in for the master_fd. os.read() works
+    # the same way on a socket fd, so this isolates the streamer logic
+    # from PTY-specific termios behavior.
+    parent, child = socket.socketpair()
+    parent.setblocking(True)
+
+    state = WatchdogState(start_time=time.monotonic(), last_activity=time.monotonic())
+    t = threading.Thread(
+        target=_pty_line_streamer,
+        args=(parent.fileno(), state),
+        kwargs={"is_stderr": False},
+        daemon=True,
+    )
+    t.start()
+    try:
+        # Encode "україна\n" as UTF-8 then write 1 byte at a time so the
+        # streamer's reads land on a multi-byte boundary.
+        payload = "україна\n".encode()
+        for byte in payload:
+            child.sendall(bytes([byte]))
+            time.sleep(0.005)
+        child.close()  # EOF
+        t.join(timeout=2.0)
+        assert state.stdout_lines == ["україна\n"], (
+            f"UTF-8 was corrupted by the read split; got: {state.stdout_lines!r}"
+        )
+    finally:
+        parent.close()
+        with contextlib.suppress(OSError):
+            child.close()
+
+
+# ----------------------------------------------------------------------
+# Test 6: ANSI escape sequences are stripped from streamed lines.
+# ----------------------------------------------------------------------
+
+def test_pty_streamer_strips_ansi_sgr_codes():
+    import socket
+
+    from agent_runtime.watchdog import _pty_line_streamer
+
+    parent, child = socket.socketpair()
+    parent.setblocking(True)
+
+    state = WatchdogState(start_time=time.monotonic(), last_activity=time.monotonic())
+    t = threading.Thread(
+        target=_pty_line_streamer,
+        args=(parent.fileno(), state),
+        kwargs={"is_stderr": False},
+        daemon=True,
+    )
+    t.start()
+    try:
+        # Red "hello" then reset, plus a cursor-position CSI.
+        payload = b"\x1b[31mhello\x1b[0m\x1b[2;5Hworld\n"
+        child.sendall(payload)
+        child.close()
+        t.join(timeout=2.0)
+        assert state.stdout_lines == ["helloworld\n"], (
+            f"ANSI not stripped; got: {state.stdout_lines!r}"
+        )
+    finally:
+        parent.close()
+        with contextlib.suppress(OSError):
+            child.close()
+
+
+def test_strip_ansi_helper_unit():
+    assert _strip_ansi("\x1b[31mred\x1b[0m") == "red"
+    assert _strip_ansi("plain") == "plain"
+    assert _strip_ansi("\x1b[K") == ""  # CSI K = erase-line, all-stripped
+
+
+# ----------------------------------------------------------------------
+# Test 7: DELEGATE_DISABLE_PTY env var falls back to pipe spawn.
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_delegate_disable_pty_env_var_routes_to_pipe_spawn(monkeypatch, tmp_path, value):
+    monkeypatch.setenv("DELEGATE_DISABLE_PTY", value)
+    assert _pty_disabled_via_env()
+    proc, stdout_fd, stderr_fd = _spawn_subprocess(
+        [_TEST_PYTHON, "-c", "print('hi')"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        stdin=subprocess.DEVNULL,
+    )
+    try:
+        # Pipe path returns None fds and exposes proc.stdout/proc.stderr.
+        assert stdout_fd is None
+        assert stderr_fd is None
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        proc.wait(timeout=5.0)
+        out = proc.stdout.read()
+        assert "hi" in out
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5.0)
+
+
+def test_delegate_disable_pty_unset_routes_to_pty_spawn(clean_env, tmp_path):
+    assert not _pty_disabled_via_env()
+    proc, stdout_fd, stderr_fd = _spawn_subprocess(
+        [_TEST_PYTHON, "-c", "print('hi')"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        stdin=subprocess.DEVNULL,
+    )
+    try:
+        assert stdout_fd is not None and stdout_fd >= 0
+        assert stderr_fd is not None and stderr_fd >= 0
+        proc.wait(timeout=5.0)
+    finally:
+        _safe_close(stdout_fd)
+        _safe_close(stderr_fd)
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+
+def test_pipe_spawn_helper_directly(tmp_path):
+    proc, sfd, efd = _spawn_pipe_subprocess(
+        [_TEST_PYTHON, "-c", "print('p')"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        stdin=subprocess.DEVNULL,
+    )
+    try:
+        assert sfd is None and efd is None
+        assert proc.stdout is not None
+        proc.wait(timeout=5.0)
+        assert "p" in proc.stdout.read()
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+
+# ----------------------------------------------------------------------
+# Test 8: Master fds are closed after stop_watchdog cleanup.
+# ----------------------------------------------------------------------
+
+def test_stop_watchdog_closes_pty_master_fds(clean_env, tmp_path):
+    import errno as _errno
+
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        [_TEST_PYTHON, "-c", "print('cleanup')"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+    )
+    state, threads = start_watchdog(
+        proc,
+        liveness_paths=[],
+        stdout_master_fd=stdout_fd,
+        stderr_master_fd=stderr_fd,
+    )
+    proc.wait(timeout=5.0)
+    stop_watchdog(
+        state,
+        threads,
+        proc=proc,
+        stdout_master_fd=stdout_fd,
+        stderr_master_fd=stderr_fd,
+        timeout=2.0,
+    )
+    # Verify both fds are closed (fstat raises EBADF).
+    for fd in (stdout_fd, stderr_fd):
+        with pytest.raises(OSError) as exc_info:
+            os.fstat(fd)
+        assert exc_info.value.errno == _errno.EBADF, (
+            f"expected EBADF on closed fd; got {exc_info.value.errno}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Test 9: Multiple lines in a single os.read chunk are split correctly.
+# ----------------------------------------------------------------------
+
+def test_pty_streamer_splits_multiple_lines_per_read():
+    import socket
+
+    from agent_runtime.watchdog import _pty_line_streamer
+
+    parent, child = socket.socketpair()
+    state = WatchdogState(start_time=time.monotonic(), last_activity=time.monotonic())
+    t = threading.Thread(
+        target=_pty_line_streamer,
+        args=(parent.fileno(), state),
+        kwargs={"is_stderr": False},
+        daemon=True,
+    )
+    t.start()
+    try:
+        # Send 3 lines in a single write; streamer must emit 3 entries.
+        child.sendall(b"line-1\nline-2\nline-3\n")
+        child.close()
+        t.join(timeout=2.0)
+        assert state.stdout_lines == ["line-1\n", "line-2\n", "line-3\n"], (
+            f"line splitting wrong; got: {state.stdout_lines!r}"
+        )
+    finally:
+        parent.close()
+        with contextlib.suppress(OSError):
+            child.close()
+
+
+def test_pty_streamer_flushes_trailing_fragment_on_eof():
+    """If the child writes a partial last line then exits, capture it."""
+    import socket
+
+    from agent_runtime.watchdog import _pty_line_streamer
+
+    parent, child = socket.socketpair()
+    state = WatchdogState(start_time=time.monotonic(), last_activity=time.monotonic())
+    t = threading.Thread(
+        target=_pty_line_streamer,
+        args=(parent.fileno(), state),
+        kwargs={"is_stderr": False},
+        daemon=True,
+    )
+    t.start()
+    try:
+        child.sendall(b"final-fragment-no-newline")
+        child.close()
+        t.join(timeout=2.0)
+        # Trailing fragment is emitted on EOF as its own entry.
+        joined = "".join(state.stdout_lines)
+        assert "final-fragment-no-newline" in joined, (
+            f"trailing fragment dropped; got: {state.stdout_lines!r}"
+        )
+    finally:
+        parent.close()
+        with contextlib.suppress(OSError):
+            child.close()
+
+
+# ----------------------------------------------------------------------
+# Test 10: Streamer thread joins cleanly on child kill.
+# ----------------------------------------------------------------------
+
+def test_streamer_threads_join_quickly_after_child_kill(clean_env, tmp_path):
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        [_TEST_PYTHON, "-c", "import time; time.sleep(30)"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+    )
+    state, threads = start_watchdog(
+        proc,
+        liveness_paths=[],
+        stdout_master_fd=stdout_fd,
+        stderr_master_fd=stderr_fd,
+    )
+    try:
+        stdout_threads = [t for t in threads if "stdout" in t.name]
+        assert stdout_threads, "stdout streamer thread missing"
+        proc.kill()
+        proc.wait(timeout=5.0)
+        stop_watchdog(
+            state,
+            threads,
+            proc=proc,
+            stdout_master_fd=stdout_fd,
+            stderr_master_fd=stderr_fd,
+            timeout=2.0,
+        )
+        # All streamer threads must have exited.
+        for t in threads:
+            assert not t.is_alive(), (
+                f"thread {t.name} leaked after stop_watchdog"
+            )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+
+# ----------------------------------------------------------------------
+# Test 11 (END-TO-END): 10 unflushed child lines all reach state in ~1s.
+# Combines the block-buffer fix with the full watchdog hookup.
+# ----------------------------------------------------------------------
+
+def test_end_to_end_pty_watchdog_streams_unflushed_child_in_real_time(
+    clean_env, tmp_path,
+):
+    proc, stdout_fd, stderr_fd = _spawn_pty_subprocess(
+        [
+            _TEST_PYTHON,
+            "-c",
+            "import sys, time; "
+            "[(sys.stdout.write(f'event-{i}\\n')) or time.sleep(0.05) "
+            "for i in range(10)]",
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+    )
+    state, threads = start_watchdog(
+        proc,
+        liveness_paths=[],
+        stdout_master_fd=stdout_fd,
+        stderr_master_fd=stderr_fd,
+    )
+    try:
+        proc.wait(timeout=10.0)
+        # Give the streamer a brief moment to drain after EOF.
+        for _ in range(50):
+            if len(state.stdout_lines) >= 10:
+                break
+            time.sleep(0.05)
+        assert len(state.stdout_lines) >= 10, (
+            f"streamer captured {len(state.stdout_lines)} / 10 lines; "
+            f"got: {state.stdout_lines!r}"
+        )
+        # All event-N markers should be present.
+        joined = "".join(state.stdout_lines)
+        for i in range(10):
+            assert f"event-{i}" in joined, (
+                f"missing event-{i} in: {joined!r}"
+            )
+    finally:
+        stop_watchdog(
+            state,
+            threads,
+            proc=proc,
+            stdout_master_fd=stdout_fd,
+            stderr_master_fd=stderr_fd,
+            timeout=2.0,
+        )
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+def _safe_close(fd: int | None) -> None:
+    if fd is None:
+        return
+    with contextlib.suppress(OSError):
+        os.close(fd)
+
+
+def _read_until_eof(fd: int, *, timeout_s: float) -> str:
+    """Drain a PTY master fd until EOF or timeout; return decoded text."""
+    chunks: list[bytes] = []
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break  # Linux EIO
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8", errors="replace")

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1712,6 +1712,13 @@ def test_invoke_gemini_runtime_falls_through_to_subscription_rung(tmp_path):
         {
             "GEMINI_API_KEY": "secret-key",
             "LU_GEMINI_COOLDOWN_PATH": str(tmp_path / "gemini-cooldown.json"),
+            # This test mocks subprocess.Popen with fake procs that
+            # expose proc.stderr.readline (a pipe-mode contract).
+            # PTY-mode reads from a master fd that the mock never
+            # writes to, so opt out for ladder-logic tests. The PTY
+            # path is exercised end-to-end in
+            # tests/agent_runtime/test_pty_subprocess_wrap.py (#2071).
+            "DELEGATE_DISABLE_PTY": "1",
         },
         clear=False,
     ), patch(
@@ -1781,6 +1788,8 @@ def test_invoke_gemini_runtime_reports_actual_fallback_model(tmp_path):
             "GEMINI_AUTH_MODE": "api",
             "GEMINI_API_KEY": "secret-key",
             "LU_GEMINI_COOLDOWN_PATH": str(tmp_path / "gemini-cooldown.json"),
+            # Pipe-mode mocks (see ladder-fallback test above). #2071.
+            "DELEGATE_DISABLE_PTY": "1",
         },
         clear=False,
     ), patch(
@@ -1840,6 +1849,8 @@ def test_invoke_gemini_runtime_all_rate_limited_raises(tmp_path):
             "GEMINI_AUTH_MODE": "api",
             "GEMINI_API_KEY": "secret-key",
             "LU_GEMINI_COOLDOWN_PATH": str(tmp_path / "gemini-cooldown.json"),
+            # Pipe-mode mocks (see ladder-fallback tests above). #2071.
+            "DELEGATE_DISABLE_PTY": "1",
         },
         clear=False,
     ), patch(

--- a/tests/test_writer_isolation.py
+++ b/tests/test_writer_isolation.py
@@ -161,6 +161,14 @@ def test_claude_subprocess_argv_contains_allowed_tools(
         lambda _cmd_prefix: (2, 1, 119),
     )
 
+    # This test mocks subprocess.Popen with a FakeProc whose
+    # ``stdout`` is an in-memory ``io.StringIO``. That's a pipe-mode
+    # contract — the PTY path (#2071) reads from a real master fd
+    # that the fake never writes to, so we'd see response='' even
+    # when the mock did the right thing. Opt out: the test is about
+    # argv assembly + adapter parse, not about the spawn mechanism.
+    monkeypatch.setenv("DELEGATE_DISABLE_PTY", "1")
+
     with patch("scripts.agent_runtime.runner.has_headroom", return_value=(True, "")), patch(
         "scripts.agent_runtime.runner.write_record"
     ), patch("scripts.agent_runtime.runner.subprocess.Popen", side_effect=fake_popen):


### PR DESCRIPTION
## Summary

Resolves the root cause of #2071 (Codex dispatches hang with
`response_chars=0` and `status=timeout`). The watchdog's stdout
silence timer was firing on healthy long-running dispatches because
agent CLIs **block-buffer stdout when not connected to a TTY** —
events accumulated inside the child's libc buffer for minutes and
the watchdog's `last_stdout_activity` never advanced. PR #2122
doubled `DEFAULT_SILENCE_TIMEOUT_S` to 1h as a stopgap; this PR
fixes the underlying behaviour by spawning the child against a PTY
pair so its libc switches to line-buffered output.

## Mechanism

* **PTY allocation** at the spawn layer (`runner._spawn_pty_subprocess`):
  one PTY pair for stdout, one for stderr. The parent keeps the
  master fds; slave fds are closed after `Popen` so EOF/EIO arrive
  on the master when the child exits.
* **Slave termios**: `OPOST` disabled so `\n` stays `\n` (no
  `\r\n` rewrite). `TIOCSWINSZ` set to 40×200 so children that query
  terminal size for output formatting get sane defaults.
* **PTY streamer** (`watchdog._pty_line_streamer`): reads raw bytes
  via `os.read(master_fd)`, reassembles lines, handles UTF-8 split
  across read boundaries, strips CSI/SGR ANSI sequences, treats Linux
  `EIO` and mac/BSD `b""` as the same EOF.
* **Dual-mode watchdog**: `start_watchdog` / `stop_watchdog` accept
  optional `stdout_master_fd` / `stderr_master_fd` kwargs. When
  provided, the PTY streamer runs and the master fds get closed on
  stop. When `None`, the legacy pipe-mode streamer runs unchanged —
  preserves the 2026-04-10 stderr-backpressure regression pin.
* **Failure mode separation**: PTY-setup failures (no /dev/pts, etc.)
  raise the private `_PTYUnavailableError` and `_spawn_subprocess`
  falls back to pipe-spawn with a `RuntimeWarning`. Popen failures
  (missing binary, EACCES, …) propagate **unchanged** so the existing
  `AgentUnavailableError` mapping still fires — no misleading "PTY
  unavailable" warning on binary-not-found.
* **Escape hatch**: `DELEGATE_DISABLE_PTY=1` opts back into pipe spawn.
  Documented in the helper docstrings. Set in 4 existing tests that
  mock `subprocess.Popen` with `io.StringIO`/`MagicMock` procs (those
  are pipe-mode contracts; PTY reads from a real master fd the mocks
  never write to).

## Test plan

* [x] **Load-bearing regression guard**:
  `test_pty_breaks_block_buffering_for_unflushed_child` — Python child
  writes `a\n` → sleeps 0.5s → writes `b\n` with NO `fflush`; assert
  `state.stdout_lines` contains `a` within 0.4s of spawn (before the
  0.5s sleep ends). With the legacy pipe spawn this would not flush
  until the child exits.
* [x] **PTY test suite**: 19 cases — spawn returns valid fds, window
  size visible to child, EOF/EIO on child exit, UTF-8 split across
  read boundary, ANSI strip, env-var fallback (`1`/`true`/`TRUE`/`yes`/
  `on`), master fds closed on stop_watchdog, multi-line per chunk,
  trailing fragment flush on EOF, streamer thread joins on kill,
  end-to-end watchdog hookup. **19/19 PASS** (1.66s).
* [x] **Targeted agent_runtime + dispatch suites** (PTY + runner +
  watchdog + adapters + telemetry + batch gemini env):
  **214/214 PASS** (41.6s).
* [x] **Pre-commit** on changed files: ruff + gitleaks + EOF +
  whitespace + merge-conflict + bare-python + size — all Passed.
* [x] **Pre-existing baseline failures outside agent_runtime** (worktree
  `.venv/bin/python` resolution, real-remote `git push` requirements,
  curriculum data assertions in `test_esum_search`) are unchanged
  and pre-date this PR — verified by `git stash`-ing changes and
  re-running the same failing test selection on baseline.
* [ ] **Per-agent smoke** (`scripts/agent_runtime/_smoke_pty_agents.sh`)
  — MANUAL post-merge. Makes real LLM calls so we don't fire it from
  the dispatch. Orchestrator runs against {codex, gemini, claude,
  deepseek, grok}; on any regression set `DELEGATE_DISABLE_PTY=1` for
  that adapter and file a follow-up.

## Notes

* The #2122 silence-timeout bump (1800s → 3600s) stays in place as
  belt-and-suspenders; revisit after 1 week of green PTY operation.
* macOS-and-Linux compatible. Windows would need `pywinpty` or named
  pipes; documented inline. The runner is POSIX-only in practice.
* No adapter changes — every agent's `build_invocation()` is
  untouched. The fix lives strictly at the spawn + streaming layer.
* Pre-June-15 Claude dispatch lane was used for this PR (Opus 4.7
  xhigh, danger mode); post-June-15 dispatches go to Codex per
  user direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)