### PR TITLE
feat(build): Path 3 PR4 — Goodhart sentinel on wiki_coverage_review (KEYWORD_STUFFING verdict)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -286,6 +286,10 @@ WIKI_COVERAGE_BATCH_MAX_ITERATIONS = 2
 WIKI_COVERAGE_NARROW_MAX_ITERATIONS = 2
 WIKI_COVERAGE_PATCHABLE_ARTIFACTS = frozenset({"module.md", "activities.yaml"})
 WIKI_COVERAGE_ARTIFACT_INFERENCE_ORDER = ("activities.yaml", "module.md")
+ALLOWED_WIKI_COVERAGE_VERDICTS = {"PASS", "KEYWORD_STUFFING", "PARTIAL", "FAIL"}
+WIKI_COVERAGE_OVERALL_FAIL_VERDICTS = {"FAIL", "KEYWORD_STUFFING"}
+WIKI_COVERAGE_OVERALL_VERDICTS = {"PASS", "PARTIAL", "FAIL"}
+WIKI_COVERAGE_EVIDENCE_QUOTE_MARKERS = ('"', "“", "«")
 _TELEMETRY_EVENT_SINK: Callable[..., None] | None = None
 
 
@@ -3512,23 +3516,45 @@ def parse_review_response(
 
 
 def parse_wiki_coverage_review_response(response: str) -> dict[str, Any]:
-    payload = parse_json_or_yaml_mapping(response)
+    payload = _parse_json_or_yaml_mapping(response)
     verdicts = payload.get("verdicts")
     if not isinstance(verdicts, list):
         raise LinearPipelineError("Wiki coverage review response missing verdicts list")
+    normalized_verdicts: list[dict[str, Any]] = []
+    hard_fail_seen = False
     for item in verdicts:
         if not isinstance(item, Mapping):
             raise LinearPipelineError("Wiki coverage review verdict entries must be mappings")
-        if str(item.get("verdict") or "").upper() not in {"PASS", "PARTIAL", "FAIL"}:
-            raise LinearPipelineError("Wiki coverage review verdict must be PASS, PARTIAL, or FAIL")
+        verdict = str(item.get("verdict") or "").upper()
+        if verdict not in ALLOWED_WIKI_COVERAGE_VERDICTS:
+            raise LinearPipelineError(
+                "Wiki coverage review verdict must be PASS, KEYWORD_STUFFING, PARTIAL, or FAIL"
+            )
         if not str(item.get("obligation_id") or "").strip():
             raise LinearPipelineError("Wiki coverage review verdict missing obligation_id")
-        if not str(item.get("evidence") or "").strip():
+        evidence = str(item.get("evidence") or "").strip()
+        if not evidence:
             raise LinearPipelineError("Wiki coverage review verdict missing evidence")
+        if len(evidence) < 8 or not any(
+            marker in evidence for marker in WIKI_COVERAGE_EVIDENCE_QUOTE_MARKERS
+        ):
+            raise LinearPipelineError(
+                "Wiki coverage review evidence must be a quoted excerpt of ≥8 chars"
+            )
+        if verdict in WIKI_COVERAGE_OVERALL_FAIL_VERDICTS:
+            hard_fail_seen = True
+        normalized_item = dict(item)
+        normalized_item["verdict"] = verdict
+        normalized_item["evidence"] = evidence
+        normalized_verdicts.append(normalized_item)
     overall = str(payload.get("overall_verdict") or "").upper()
-    if overall not in {"PASS", "PARTIAL", "FAIL"}:
+    if overall not in WIKI_COVERAGE_OVERALL_VERDICTS:
         raise LinearPipelineError("Wiki coverage review overall_verdict must be PASS, PARTIAL, or FAIL")
-    return {**payload, "overall_verdict": overall}
+    if hard_fail_seen and overall != "FAIL":
+        raise LinearPipelineError(
+            "Wiki coverage review overall_verdict must be FAIL when any obligation verdict fails"
+        )
+    return {**payload, "verdicts": normalized_verdicts, "overall_verdict": overall}
 
 
 def validate_llm_review_report(report: Mapping[str, Any]) -> None:

--- a/scripts/build/phases/linear-review-wiki-coverage.md
+++ b/scripts/build/phases/linear-review-wiki-coverage.md
@@ -2,14 +2,15 @@
 
 {LESSON_CONTRACT}
 
-# Phase 4 Linear Wiki-Coverage Reviewer Prompt
+# Phase 5 Linear Wiki-Coverage Goodhart Sentinel Prompt
 
 Review only wiki-obligation coverage. This pass is parallel to the five
 standard QG dimensions; it is not a `QG_DIMS` dimension.
 
 The deterministic gate has already checked objective presence. Your job is to
-verify semantic adequacy: each obligation must be implemented in the claimed
-artifact location with evidence consistent with its treatment type.
+verify semantic adequacy after that gate passes: each obligation must be woven
+into substantive prose, dialogue, or activity work, not keyword-stuffed into the
+claimed artifact location merely to satisfy deterministic coverage.
 
 ## Required Method
 
@@ -20,22 +21,68 @@ For every obligation in the Wiki Obligations Manifest:
 2. Read the writer's implementation_map claim for that same obligation id.
 3. Inspect the cited artifact and location in Generated Content.
 4. Emit one verdict:
-   - PASS: cited evidence implements the obligation.
-   - PARTIAL: evidence exists but is thin, vague, or in a weaker location.
+   - PASS: the cited evidence implements the obligation as substantive
+     pedagogy — the manifest claim is woven into prose/dialogue/activity with
+     explanation, example use, or integrated context.
+   - KEYWORD_STUFFING: the cited evidence contains the required string verbatim
+     but the surrounding prose does not actually teach, contrast, or apply it.
+     Example failure: a contrast_pair where the "incorrect" and "correct" forms
+     appear in a list with no learner activity around them; a phonetic_rule
+     where the written→spoken mapping is named in a one-sentence aside with no
+     example pair; a sequence_step where the section heading exists but the body
+     skips to the next step. THIS VERDICT FAILS THE BUILD.
+   - PARTIAL: evidence exists and shows some pedagogy, but is thin enough that
+     the obligation is taught at a shallower level than the manifest target.
+     Soft signal.
    - FAIL: missing, contradicted, or not in the claimed location.
 
 Treatment-specific checks:
 
-- `contrast_pair`: both the incorrect and correct forms appear in the activity
-  body, and the learner has to distinguish them.
-- `prose_explanation`: module.md prose discusses the wiki claim's substance,
-  not merely a related vocabulary item.
-- `explicit_explanation`: learner-facing pronunciation guidance is present; a
-  vague "smooth speech" reminder is not enough.
-- `sequence_step`: the module prose teaches the step's canonical pedagogical
-  claim in an appropriate order.
-- decolonization bans: the generated content avoids the banned framing and, if
-  relevant, gives a Ukrainian-centered replacement.
+- `contrast_pair`:
+  * PASS: both forms appear in an activity body AND the learner must distinguish
+    them (multiple-choice, fill-in, correction exercise).
+  * KEYWORD_STUFFING: both forms appear in a static list without an activity
+    that requires distinguishing them; or both forms appear in a single example
+    sentence with no learner-facing task.
+- `prose_explanation`:
+  * PASS: module.md prose names the manifest's `incorrect` and `correct`
+    strings AND explains why one is preferred, with at least one substantive
+    sentence of explanation beyond the bare contrast.
+  * KEYWORD_STUFFING: the strings appear in a list/table/footnote without
+    explanation prose; or the explanation is a generic "this is correct"
+    without engaging the manifest's `why` field.
+- `explicit_explanation` (phonetic):
+  * PASS: learner-facing pronunciation guidance with at least one
+    written→spoken example pair AND a brief contextual note (when does this rule
+    apply, common confusable, etc.).
+  * KEYWORD_STUFFING: a one-line "smooth speech" or "soft pronunciation"
+    reminder without the actual rule mapping; or the rule is stated but no
+    example pair is provided.
+- `sequence_step`:
+  * PASS: the module prose teaches the step's canonical pedagogical claim in
+    the appropriate order, with the heading or marker AND body text that
+    advances the learner toward the step's goal.
+  * KEYWORD_STUFFING: the heading exists but the body skips ahead without
+    teaching the step; or the step is named in a metadiscourse sentence ("we
+    will now learn X") without actually teaching X.
+- `decolonization_ban`:
+  * PASS: the generated content avoids the banned framing AND, if the contrast
+    is naturally adjacent (e.g. "Kyiv not Kiev"), offers a Ukrainian-centered
+    framing.
+  * KEYWORD_STUFFING: the banned framing is technically absent but a
+    near-paraphrase remains; or a meta-disclaimer about avoiding the ban
+    replaces the substance of the lesson.
+
+Evidence MUST be a verbatim quote from the cited artifact location
+(quote-marked). Paraphrase or summary evidence is invalid and forces
+KEYWORD_STUFFING. Quotes must be at least 8 words long unless the obligation is
+a single short word/phrase the manifest specifies — in which case quote the
+full surrounding sentence containing it.
+
+The new verdict enum: `PASS | KEYWORD_STUFFING | PARTIAL | FAIL`.
+`overall_verdict` must be `FAIL` if any obligation verdict is `FAIL` OR
+`KEYWORD_STUFFING`. `PARTIAL` is a soft signal — system aggregates, build
+continues, but logs the pattern.
 
 Return only JSON:
 
@@ -45,17 +92,20 @@ Return only JSON:
     {
       "obligation_id": "err-1",
       "verdict": "PASS",
-      "evidence": "verbatim excerpt from the cited artifact location",
-      "rationale": "why this evidence satisfies or misses the treatment"
+      "evidence": "\"Choose between я вибачаюся and я вибачаю себе, then explain which one fits the dialogue.\"",
+      "rationale": "The activity requires learners to distinguish both forms in context."
+    },
+    {
+      "obligation_id": "phon-1",
+      "verdict": "KEYWORD_STUFFING",
+      "evidence": "\"Remember smooth speech for this phrase.\"",
+      "rationale": "The quote names smooth speech but gives no written→spoken mapping or example pair."
     }
   ],
-  "overall_verdict": "PASS",
-  "summary": "short aggregate rationale"
+  "overall_verdict": "FAIL",
+  "summary": "One obligation is keyword-stuffed rather than substantively taught."
 }
 ```
-
-`overall_verdict` must be `FAIL` if any obligation verdict is `FAIL`.
-`PARTIAL` is a soft signal unless the pattern shows systematic under-teaching.
 
 ## Module Context
 
@@ -81,4 +131,3 @@ Return only JSON:
 ## Generated Content
 
 {GENERATED_CONTENT}
-

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -825,6 +825,26 @@ def _run(args: argparse.Namespace) -> int:
             module_dir / "wiki_coverage_review.json",
             wiki_coverage_review,
         )
+        # Phase 5 Goodhart sentinel telemetry (PR4)
+        stuffing_count = sum(
+            1
+            for v in wiki_coverage_review.get("verdicts", [])
+            if str(v.get("verdict", "")).upper() == "KEYWORD_STUFFING"
+        )
+        partial_count = sum(
+            1
+            for v in wiki_coverage_review.get("verdicts", [])
+            if str(v.get("verdict", "")).upper() == "PARTIAL"
+        )
+        tracker.emit(
+            "wiki_coverage_goodhart_sentinel",
+            level=level,
+            slug=slug,
+            overall_verdict=wiki_coverage_review["overall_verdict"],
+            keyword_stuffing_count=stuffing_count,
+            partial_count=partial_count,
+            total_verdicts=len(wiki_coverage_review.get("verdicts", [])),
+        )
         _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
         if wiki_coverage_review["overall_verdict"] == "FAIL":
             raise linear_pipeline.LinearPipelineError("Wiki coverage review failed")

--- a/tests/build/test_wiki_coverage_goodhart_sentinel.py
+++ b/tests/build/test_wiki_coverage_goodhart_sentinel.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.build import linear_pipeline, v7_build
+
+VALID_EVIDENCE = '"This quoted excerpt gives enough surrounding lesson context."'
+
+
+def _verdict(
+    obligation_id: str,
+    verdict: str,
+    evidence: str = VALID_EVIDENCE,
+) -> dict[str, str]:
+    return {
+        "obligation_id": obligation_id,
+        "verdict": verdict,
+        "evidence": evidence,
+        "rationale": "fixture rationale",
+    }
+
+
+def _parse(
+    verdicts: list[dict[str, str]],
+    *,
+    overall_verdict: str = "PASS",
+) -> dict[str, Any]:
+    return linear_pipeline.parse_wiki_coverage_review_response(
+        json.dumps(
+            {
+                "verdicts": verdicts,
+                "overall_verdict": overall_verdict,
+                "summary": "fixture summary",
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def _install_v7_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    review_result: dict[str, Any],
+) -> tuple[SimpleNamespace, Path]:
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("level: a1\nslug: fixture\nsequence: 1\n", encoding="utf-8")
+    module_dir = tmp_path / "module"
+    plan = {
+        "level": "a1",
+        "slug": "fixture",
+        "sequence": 1,
+        "content_outline": [],
+    }
+
+    def write_artifacts(target_dir: Path, artifacts: dict[str, str]) -> None:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for name, text in artifacts.items():
+            (target_dir / name).write_text(text, encoding="utf-8")
+
+    def write_implementation_map(payload: dict[str, Any], path: Path) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(v7_build.linear_pipeline, "plan_path_for", lambda *_: plan_path)
+    monkeypatch.setattr(v7_build.linear_pipeline, "load_plan", lambda _: plan)
+    monkeypatch.setattr(v7_build.linear_pipeline, "validate_plan", lambda _: None)
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "build_knowledge_packet",
+        lambda **_: "knowledge packet",
+    )
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "build_wiki_manifest_data",
+        lambda **_: {"slug": "fixture", "sequence_steps": []},
+    )
+    monkeypatch.setattr(
+        v7_build,
+        "seed_implementation_map",
+        lambda *_args, **_kwargs: {"schema_version": 1, "entries": []},
+    )
+    monkeypatch.setattr(v7_build, "write_implementation_map", write_implementation_map)
+    monkeypatch.setattr(v7_build, "_writer_prompt", lambda **_: "writer prompt")
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "invoke_writer",
+        lambda *_args, **_kwargs: "writer output",
+    )
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "parse_writer_output",
+        lambda _: {
+            "module.md": "# Fixture\n",
+            "activities.yaml": "[]\n",
+            "vocabulary.yaml": "[]\n",
+            "resources.yaml": "[]\n",
+        },
+    )
+    monkeypatch.setattr(v7_build.linear_pipeline, "write_writer_artifacts", write_artifacts)
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "run_python_qg_with_corrections",
+        lambda *_args, **_kwargs: {"gates": {"passed": True}},
+    )
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "run_wiki_coverage_with_corrections",
+        lambda **_: {"passed": True, "coverage_pct": 1.0},
+    )
+    monkeypatch.setattr(v7_build, "_run_wiki_coverage_review", lambda **_: review_result)
+    monkeypatch.setattr(
+        v7_build,
+        "_run_llm_qg",
+        lambda **_: {"aggregate": {"min_score": 9.0, "verdict": "PASS"}},
+    )
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "assemble_mdx",
+        lambda _module_dir, mdx_path, _plan_path: mdx_path.write_text(
+            "# Fixture\n",
+            encoding="utf-8",
+        ),
+    )
+
+    return (
+        SimpleNamespace(
+            level="a1",
+            slug="fixture",
+            writer="claude-tools",
+            dry_run=False,
+            out=str(module_dir),
+            writer_timeout=5,
+        ),
+        tmp_path / "events.jsonl",
+    )
+
+
+def _run_v7_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    review_result: dict[str, Any],
+) -> tuple[int, list[dict[str, Any]]]:
+    args, telemetry_path = _install_v7_fixture(monkeypatch, tmp_path, review_result)
+    with linear_pipeline.telemetry_event_sink(telemetry_path):
+        exit_code = v7_build._run(args)
+    events = [
+        json.loads(line)
+        for line in telemetry_path.read_text(encoding="utf-8").splitlines()
+    ]
+    return exit_code, events
+
+
+def test_pass_only_verdicts_allow_overall_pass() -> None:
+    result = _parse(
+        [_verdict(f"step-{index}", "PASS") for index in range(5)],
+        overall_verdict="PASS",
+    )
+
+    assert result["overall_verdict"] == "PASS"
+    assert [item["verdict"] for item in result["verdicts"]] == ["PASS"] * 5
+
+
+def test_keyword_stuffing_requires_overall_fail() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="overall_verdict must be FAIL",
+    ):
+        _parse(
+            [
+                _verdict("step-1", "PASS"),
+                _verdict("err-1", "KEYWORD_STUFFING"),
+            ],
+            overall_verdict="PASS",
+        )
+
+
+@pytest.mark.parametrize("overall_verdict", ["PASS", "PARTIAL"])
+def test_partial_only_is_soft_signal(overall_verdict: str) -> None:
+    result = _parse(
+        [
+            _verdict("step-1", "PARTIAL"),
+            _verdict("step-2", "PARTIAL"),
+        ],
+        overall_verdict=overall_verdict,
+    )
+
+    assert result["overall_verdict"] == overall_verdict
+    assert [item["verdict"] for item in result["verdicts"]] == [
+        "PARTIAL",
+        "PARTIAL",
+    ]
+
+
+def test_fail_verdict_requires_overall_fail() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="overall_verdict must be FAIL",
+    ):
+        _parse(
+            [_verdict("step-1", "FAIL")],
+            overall_verdict="PARTIAL",
+        )
+
+
+def test_evidence_without_quote_marker_raises() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="evidence must be a quoted excerpt",
+    ):
+        _parse(
+            [
+                _verdict(
+                    "step-1",
+                    "PASS",
+                    evidence="just plain text no quote chars",
+                )
+            ]
+        )
+
+
+def test_evidence_shorter_than_eight_chars_raises() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="evidence must be a quoted excerpt",
+    ):
+        _parse([_verdict("step-1", "PASS", evidence='"tiny"')])
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        '"This quoted excerpt is long enough for review."',
+        "“This quoted excerpt is long enough for review.”",
+        "«This quoted excerpt is long enough for review.»",
+    ],
+)
+def test_quote_markers_are_accepted(evidence: str) -> None:
+    result = _parse([_verdict("step-1", "PASS", evidence=evidence)])
+
+    assert result["verdicts"][0]["evidence"] == evidence
+
+
+def test_v7_build_emits_goodhart_sentinel_telemetry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review_result = {
+        "verdicts": [
+            _verdict("step-1", "PASS"),
+            _verdict("step-2", "PARTIAL"),
+            _verdict("err-1", "KEYWORD_STUFFING"),
+        ],
+        "overall_verdict": "FAIL",
+        "summary": "fixture summary",
+    }
+
+    exit_code, events = _run_v7_fixture(monkeypatch, tmp_path, review_result)
+    event = next(
+        item for item in events if item["event"] == "wiki_coverage_goodhart_sentinel"
+    )
+
+    assert exit_code == 1
+    assert event["overall_verdict"] == "FAIL"
+    assert event["keyword_stuffing_count"] == 1
+    assert event["partial_count"] == 1
+    assert event["total_verdicts"] == 3
+
+
+def test_v7_build_fails_on_keyword_stuffing_overall_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    review_result = {
+        "verdicts": [_verdict("err-1", "KEYWORD_STUFFING")],
+        "overall_verdict": "FAIL",
+        "summary": "fixture summary",
+    }
+
+    exit_code, events = _run_v7_fixture(monkeypatch, tmp_path, review_result)
+    captured = capsys.readouterr()
+    failure = next(item for item in events if item["event"] == "module_failed")
+
+    assert exit_code == 1
+    assert "v7_build failed in phase wiki_coverage_review" in captured.err
+    assert failure["reason"] == "Wiki coverage review failed"
+
+
+def test_prompt_template_renders_keyword_stuffing_instruction() -> None:
+    prompt = linear_pipeline.render_wiki_coverage_review_prompt(
+        {
+            "level": "a1",
+            "sequence": 1,
+            "slug": "fixture",
+            "word_target": 600,
+        },
+        "level: a1\nslug: fixture\n",
+        "## module.md\n\nGenerated content",
+        {"slug": "fixture", "sequence_steps": []},
+        {"passed": True, "coverage_pct": 1.0},
+    )
+
+    assert "KEYWORD_STUFFING" in prompt


### PR DESCRIPTION
## Summary

- Refines the existing `wiki_coverage_review` prompt into the Phase 5 Goodhart sentinel with a hard-failing `KEYWORD_STUFFING` verdict.
- Extends the parser verdict schema, enforces quoted evidence, and requires hard-fail per-obligation verdicts to set `overall_verdict: FAIL`.
- Emits v7 telemetry for keyword-stuffing, partial, and total semantic-review verdict counts.
- Adds focused regression tests for parser behavior, prompt rendering, and v7 sentinel telemetry/failure behavior.

## Verifiable Claims (#M-4)

Prompt template updated:

Command: `git diff origin/main -- scripts/build/phases/linear-review-wiki-coverage.md`

```diff
+# Phase 5 Linear Wiki-Coverage Goodhart Sentinel Prompt
+   - KEYWORD_STUFFING: the cited evidence contains the required string verbatim
+Evidence MUST be a verbatim quote from the cited artifact location
+The new verdict enum: `PASS | KEYWORD_STUFFING | PARTIAL | FAIL`.
+`overall_verdict` must be `FAIL` if any obligation verdict is `FAIL` OR
+`KEYWORD_STUFFING`. `PARTIAL` is a soft signal — system aggregates, build
```

Parser extended:

Command: `git diff origin/main -- scripts/build/linear_pipeline.py`

```diff
+ALLOWED_WIKI_COVERAGE_VERDICTS = {"PASS", "KEYWORD_STUFFING", "PARTIAL", "FAIL"}
+WIKI_COVERAGE_OVERALL_FAIL_VERDICTS = {"FAIL", "KEYWORD_STUFFING"}
+    payload = _parse_json_or_yaml_mapping(response)
+    hard_fail_seen = False
+                "Wiki coverage review evidence must be a quoted excerpt of ≥8 chars"
+        if verdict in WIKI_COVERAGE_OVERALL_FAIL_VERDICTS:
+    if hard_fail_seen and overall != "FAIL":
+            "Wiki coverage review overall_verdict must be FAIL when any obligation verdict fails"
```

v7_build telemetry added:

Command: `git diff origin/main -- scripts/build/v7_build.py`

```diff
+        # Phase 5 Goodhart sentinel telemetry (PR4)
+        stuffing_count = sum(
+        partial_count = sum(
+            "wiki_coverage_goodhart_sentinel",
+            keyword_stuffing_count=stuffing_count,
+            partial_count=partial_count,
+            total_verdicts=len(wiki_coverage_review.get("verdicts", [])),
```

New tests pass:

Command: `.venv/bin/pytest tests/build/test_wiki_coverage_goodhart_sentinel.py -v`

```text
============================== 13 passed in 0.29s ==============================
```

Existing wiki_coverage_review tests still pass:

Command: `.venv/bin/pytest tests/ -q -k wiki_coverage`

```text
=============== 38 passed, 8083 deselected, 3 warnings in 11.72s ===============
```

Full audit + build green:

Command: `.venv/bin/pytest tests/audit/ tests/build/ -q`

```text
======================= 612 passed, 25 skipped in 7.40s ========================
```

Ruff clean:

Command: `.venv/bin/ruff check scripts/build/linear_pipeline.py scripts/build/v7_build.py tests/build/test_wiki_coverage_goodhart_sentinel.py`

```text
All checks passed!
```

Pre-commit clean:

Command: `.venv/bin/python -m pre_commit run --files scripts/build/phases/linear-review-wiki-coverage.md scripts/build/linear_pipeline.py scripts/build/v7_build.py tests/build/test_wiki_coverage_goodhart_sentinel.py`

```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

Commit + PR:

Command: `git log -1 --oneline`

```text
c414e6ce0c feat(build): Path 3 PR4 — Goodhart sentinel on wiki_coverage_review (KEYWORD_STUFFING verdict)
```

Command: `gh pr view --json url`

```json
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2125"}
```