### PR TITLE
fix(etymology/ocr): reject Gemini repetition-hallucination output (#2001)

### DIFF
--- a/scripts/etymology/bulk_ocr_gemini.py
+++ b/scripts/etymology/bulk_ocr_gemini.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import time
 import zipfile
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
@@ -412,6 +412,10 @@ def is_non_ocr_response(stdout_text: str) -> bool:
 # below treats these as errors so they get retried instead of silently shipped
 # as bad data.
 MIN_OUTPUT_BYTES = 500
+MIN_LINES_FOR_REPETITION_CHECK = 10
+REPETITION_LINE_THRESHOLD = 5
+REPETITION_TAIL_UNIQUE_MAX = 10
+REPETITION_TAIL_WINDOW = 30
 CONTROL_GARBAGE_RE = re.compile(r"<ctrl\d+>")
 REFUSAL_AND_META_PATTERNS = (
     re.compile(r"\bas an AI\b", re.IGNORECASE),
@@ -436,6 +440,19 @@ REFUSAL_AND_META_PATTERNS = (
 )
 
 
+def is_repetition_hallucination(text: str) -> bool:
+    """True if output shows Gemini-style generation loop (same line repeated)."""
+    lines = [line.strip() for line in text.splitlines() if len(line.strip()) > 5]
+    if len(lines) < MIN_LINES_FOR_REPETITION_CHECK:
+        return False
+    most_count = Counter(lines).most_common(1)[0][1]
+    tail_unique = len(set(lines[-REPETITION_TAIL_WINDOW:]))
+    return (
+        most_count >= REPETITION_LINE_THRESHOLD
+        and tail_unique < REPETITION_TAIL_UNIQUE_MAX
+    )
+
+
 def is_low_quality_output(stdout_text: str) -> bool:
     """True if stdout looks like a silent OCR failure (garbage, refusal, too short).
 
@@ -446,6 +463,8 @@ def is_low_quality_output(stdout_text: str) -> bool:
     - Output containing Gemini refusal, completion-meta, or tool-schema leaks.
     """
     if len(stdout_text.encode("utf-8")) < MIN_OUTPUT_BYTES:
+        return True
+    if is_repetition_hallucination(stdout_text):
         return True
     if any(pattern.search(stdout_text) for pattern in REFUSAL_AND_META_PATTERNS):
         return True

--- a/tests/etymology/test_bulk_ocr_quality.py
+++ b/tests/etymology/test_bulk_ocr_quality.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 
 from scripts.etymology.bulk_ocr_gemini import (
     is_low_quality_output,
+    is_repetition_hallucination,
     strip_planning_preamble,
 )
 
@@ -171,6 +172,46 @@ LEGIT_APOLOGY = (
     "чи службового повідомлення про завершення транскрипції. "
 ) * 3
 
+REPETITION_EXTREME = "\n".join(
+    ["**крути́тися** «обертатися» — див. *крути́ти*."] * 100
+)
+
+REPETITION_MODERATE = "\n".join(
+    [
+        "**пере́зрівати** «надмірно зріти»",
+        "Ж, Ох, *пере́зрівати*. – Так. Надмірно зріти.",
+        "пере́зрівати, пере́зрілий, пере́зріти; приклади словникового тексту.",
+        "р. перезревать, бр. пераспяваць; словниковий опис походження.",
+        "утворене з префікса пере- та дієслова зріти з прозорою мотивацією.",
+        "Пор. дозрівати, визрівати, зрілий; джерельні скорочення подано далі.",
+        "Далі сторінка зривається в повторюваний перехресний покажчик.",
+        *(["**пере́зрілий** – див. *пере́зріти*."] * 10),
+    ]
+)
+
+LEGIT_CROSS_REFERENCE_HEAVY_PAGE = "\n".join(
+    [
+        CLEAN_PAGE,
+        "**абза́цний** «пов'язаний з абзацом» — опис словникової статті.",
+        "**абза́цовий** «тс.» — коротка словникова позначка.",
+        "**абза́цувати** «ділити на абзаци» — книжне утворення.",
+        "**абза́цний** — див. *абза́ц*.",
+        "**абза́цовий** — див. *абза́ц*.",
+        "**абза́цувати** — див. *абза́ц*.",
+        "**аку́тний** — див. *аку́т*.",
+        "**акце́нтний** — див. *акце́нт*.",
+        "**абза́цний** — див. *абза́ц*.",
+        "**абза́цовий** — див. *абза́ц*.",
+        "**абза́цувати** — див. *абза́ц*.",
+        "**аку́тний** — див. *аку́т*.",
+        "**акце́нтний** — див. *акце́нт*.",
+    ]
+)
+
+REPETITION_SHORT_PAGE = "\n".join(
+    ["**крути́тися** «обертатися» — див. *крути́ти*."] * 5
+)
+
 
 def test_is_low_quality_rejects_bare_refusal():
     assert is_low_quality_output(BARE_REFUSAL) is True
@@ -186,6 +227,22 @@ def test_is_low_quality_rejects_completion_meta_self_praise():
 
 def test_is_low_quality_rejects_trailing_update_topic():
     assert is_low_quality_output(TRAILING_UPDATE_TOPIC) is True
+
+
+def test_is_low_quality_rejects_repetition_hallucination_extreme():
+    assert is_low_quality_output(REPETITION_EXTREME) is True
+
+
+def test_is_low_quality_rejects_repetition_hallucination_moderate():
+    assert is_low_quality_output(REPETITION_MODERATE) is True
+
+
+def test_is_low_quality_accepts_legit_cross_reference_heavy_page():
+    assert is_low_quality_output(LEGIT_CROSS_REFERENCE_HEAVY_PAGE) is False
+
+
+def test_is_repetition_hallucination_short_page_skip():
+    assert is_repetition_hallucination(REPETITION_SHORT_PAGE) is False
 
 
 def test_strip_planning_preamble_removes_trailing_update_topic():


### PR DESCRIPTION
## Summary

- Add `is_repetition_hallucination()` to catch Gemini generation loops before the existing refusal/meta regex checks.
- Extend `tests/etymology/test_bulk_ocr_quality.py` with extreme, moderate, legitimate cross-reference, and short-page skip coverage.

## Verifiable Claims

| Claim | Evidence |
|---|---|
| Pattern sourced from real failures | From `vol3/p0293.md` tail: `* «Не ѣсться, не п'ється, світ менѣ крутиться.» *Н. п.*` repeated throughout the final 30 lines. |
| All 41 quarantined files rejected | `caught=41/41` |
| Zero false positives on existing live tree | `false_positives=0/2123` for the new repetition heuristic across live OCR files. |
| Tests pass | `11 passed in 0.06s` |
| Lint clean | `All checks passed!` |
| Commit landed | `e63468b038 fix(etymology/ocr): reject Gemini repetition-hallucination output (#2001)` |
| PR opened | `{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2129"}` |

## Validation

```text
git rev-parse --show-toplevel
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/2001-ocr-repetition-filter
```

```text
git branch --show-current
codex/2001-ocr-repetition-filter
```

```text
.venv/bin/python -m pytest tests/etymology/test_bulk_ocr_quality.py -v
============================== 11 passed in 0.06s ==============================
```

```text
.venv/bin/ruff check scripts/etymology/bulk_ocr_gemini.py tests/etymology/test_bulk_ocr_quality.py
All checks passed!
```

```text
caught=41/41
```

```text
false_positives=0/2123
```

Note: the ignored OCR corpus is not present inside this worktree, so the corpus checks read the same ignored data read-only from `/Users/krisztiankoos/projects/learn-ukrainian/data/raw/esum/gemini-ocr`. The broader `is_low_quality_output` live-tree command currently reports pre-existing non-repetition planning-preamble leaks in that ignored local data; isolating this PR's new repetition heuristic reports zero live-tree hits.

Refs #2001.