### PR TITLE
fix(audit): vesum_verified handles negative-example forms in true-false statements (#2128)

### DIFF
--- a/docs/best-practices/vocabulary-activity-standards.md
+++ b/docs/best-practices/vocabulary-activity-standards.md
@@ -142,6 +142,32 @@ Apostrophes in Ukrainian (пам'ять) inside single-quoted strings need doubl
 
 ---
 
+## Bad-Form Markers in YAML
+
+Intentional non-VESUM forms used for teaching contrast must be wrapped wherever
+they appear, not only in `module.md` prose:
+
+```yaml
+- type: true-false
+  items:
+    - statement: "Правильно: дивлюся, а не <!-- bad -->дивюся<!-- /bad -->."
+      answer: true
+```
+
+Use `<!-- bad -->...<!-- /bad -->` in `activities.yaml` strings such as
+`true-false` statements, `match` / `fill-in` / `multiple-choice` items, and
+`vocabulary.yaml` `usage:` only when it explicitly names a wrong form. The
+VESUM gate strips these markers before lookup. `error-correction` `sentence:`
+and `error:` fields are already excluded from VESUM lookup, so markers there are
+optional but harmless.
+
+The gate has a narrow safety net for true-false statements ending in
+`X, а не Y.` or `X, not Y.`, but writers must still marker the `Y` form. Safety
+net telemetry (`vesum_verified_negative_example_stripped`) should be rare; if it
+appears often, the writer prompt convention is not being followed.
+
+---
+
 ## Vocabulary YAML Format
 
 ```yaml

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -507,6 +507,15 @@ _PRONUNCIATION_CUE_PATTERN = re.compile(
 # inner-content alternation `.+?` is non-greedy so adjacent `<!-- bad -->`
 # spans don't fuse.
 _AVOID_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(.+?)<!--\s*/bad\s*-->", re.DOTALL)
+# True-false grammar statements often teach contrast as "X, а не Y." / "X, not Y."
+# The Y form can be intentionally malformed and absent from VESUM. This safety
+# net is deliberately narrow: it only strips the sentence-final tail after an
+# explicit comma + negator, and only in true-false statements that are otherwise
+# VESUM-checked.
+_TF_NEGATIVE_EXAMPLE_RE = re.compile(
+    r"(?:,\s*(?:а\s+)?не|,\s*not)\s+([\w'’ʼ-]+)\s*[.!?]",
+    re.UNICODE | re.IGNORECASE,
+)
 # Anti-example contrast patterns in pedagogical prose. Writers use these to
 # show learners "say X, not Y" — Y is intentionally the wrong form and must
 # be excluded from VESUM lookup (it's NOT a valid Ukrainian word; VESUM would
@@ -2906,6 +2915,12 @@ def write_writer_artifacts(module_dir: Path, artifacts: Mapping[str, str]) -> No
     module_dir.mkdir(parents=True, exist_ok=True)
     for name in WRITER_ARTIFACTS:
         (module_dir / name).write_text(str(artifacts[name]), encoding="utf-8")
+    module_ref = _module_ref_from_module_dir(module_dir)
+    for finding in detect_unmarkered_negative_examples(str(artifacts["activities.yaml"])):
+        fields = dict(finding)
+        if module_ref is not None:
+            fields["module"] = module_ref
+        emit_event("writer_negative_example_unmarkered", **fields)
 
 
 def run_wiki_coverage_gate(
@@ -5485,7 +5500,13 @@ def _vesum_gate(
     """
     from scripts.audit.config import VESUM_MIN_WORD_LENGTH
 
-    text = _build_vesum_text(module_text, activities, vocabulary, resources)
+    text = _build_vesum_text(
+        module_text,
+        activities,
+        vocabulary,
+        resources,
+        emit_negative_example_events=True,
+    )
 
     # Pair each surface form with its normalized lowercase lookup key once, so
     # subsequent whitelist + missing computations don't re-normalize repeatedly.
@@ -5901,16 +5922,147 @@ def _strip_usage_parentheticals(text: str) -> str:
     return _USAGE_PARENTHETICAL_RE.sub(" ", text)
 
 
+def _negative_example_tail_forms(text: str) -> list[str]:
+    forms: list[str] = []
+    for match in _TF_NEGATIVE_EXAMPLE_RE.finditer(text):
+        forms.extend(_iter_vesum_word_surfaces(match.group(1)))
+    return _unique_preserving_order(forms)
+
+
+def _unique_preserving_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        unique.append(value)
+    return unique
+
+
+def _strip_truefalse_negative_examples(statement: str) -> tuple[str, list[str]]:
+    """Remove narrow sentence-final negative examples from TF VESUM scope."""
+    skipped_forms: list[str] = []
+    chunks: list[str] = []
+    last_end = 0
+    for match in _TF_NEGATIVE_EXAMPLE_RE.finditer(statement):
+        forms = _negative_example_tail_forms(match.group(0))
+        if not forms:
+            continue
+        start, end = match.span(1)
+        chunks.append(statement[last_end:start])
+        chunks.append(" " * (end - start))
+        last_end = end
+        skipped_forms.extend(forms)
+    if not skipped_forms:
+        return statement, []
+    chunks.append(statement[last_end:])
+    return "".join(chunks), _unique_preserving_order(skipped_forms)
+
+
+def detect_unmarkered_negative_examples(activities_yaml: str) -> list[dict[str, Any]]:
+    """Find obvious unmarkered negative examples in writer activity YAML.
+
+    This is a soft writer-output warning, not a gate. It catches the narrow
+    `X, а не Y.` / `X, not Y.` pattern in true-false statements and item bodies
+    outside `error-correction`, where malformed forms should normally be wrapped
+    in `<!-- bad -->...<!-- /bad -->` markers.
+    """
+    try:
+        activities = yaml.safe_load(activities_yaml)
+    except yaml.YAMLError:
+        return []
+    if not isinstance(activities, list):
+        return []
+
+    findings: list[dict[str, Any]] = []
+    for activity in activities:
+        if not isinstance(activity, dict):
+            continue
+        activity_type = str(activity.get("type") or "")
+        if activity_type == _ERROR_CORRECTION_TYPE:
+            continue
+        activity_id = str(activity.get("id") or "")
+        items = activity.get("items")
+        if isinstance(items, list):
+            for item_idx, item in enumerate(items):
+                texts = _negative_example_candidate_texts(activity_type, item)
+                findings.extend(
+                    _negative_example_findings(activity_id, item_idx, texts)
+                )
+        else:
+            texts = _negative_example_candidate_texts(activity_type, activity)
+            findings.extend(_negative_example_findings(activity_id, None, texts))
+    return findings
+
+
+def _negative_example_candidate_texts(activity_type: str, item: Any) -> list[str]:
+    if activity_type == "true-false":
+        if isinstance(item, dict) and isinstance(item.get("statement"), str):
+            return [item["statement"]]
+        return []
+    return _walk_yaml_strings(item)
+
+
+def _walk_yaml_strings(node: Any) -> list[str]:
+    strings: list[str] = []
+    if isinstance(node, dict):
+        for child in node.values():
+            strings.extend(_walk_yaml_strings(child))
+    elif isinstance(node, list):
+        for child in node:
+            strings.extend(_walk_yaml_strings(child))
+    elif isinstance(node, str):
+        strings.append(node)
+    return strings
+
+
+def _negative_example_findings(
+    activity_id: str,
+    item_idx: int | None,
+    texts: list[str],
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    seen: set[tuple[int | None, str]] = set()
+    for text in texts:
+        for form in _negative_example_tail_forms(text):
+            key = (item_idx, form)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                {
+                    "activity_id": activity_id,
+                    "item_idx": item_idx,
+                    "form": form,
+                    "hint": (
+                        "Wrap the negative example as "
+                        f"<!-- bad -->{form}<!-- /bad -->."
+                    ),
+                }
+            )
+    return findings
+
+
 def _build_vesum_text(
     module_text: str,
     activities: list[dict[str, Any]],
     vocabulary: list[dict[str, Any]],
     resources: list[dict[str, Any]],
+    *,
+    emit_negative_example_events: bool = False,
 ) -> str:
     """Compose the text blob that VESUM verifies, with structural exclusions."""
     parts = [_strip_metalinguistic(module_text)]
     for activity in activities:
-        parts.append(_strip_metalinguistic(_activity_vesum_text(activity)))
+        parts.append(
+            _strip_metalinguistic(
+                _activity_vesum_text(
+                    activity,
+                    emit_negative_example_events=emit_negative_example_events,
+                )
+            )
+        )
     for entry in vocabulary:
         if isinstance(entry, dict):
             parts.append(_strip_metalinguistic(str(entry.get("lemma", ""))))
@@ -5927,7 +6079,11 @@ def _build_vesum_text(
     return "\n".join(part for part in parts if part)
 
 
-def _activity_vesum_text(activity: dict[str, Any]) -> str:
+def _activity_vesum_text(
+    activity: dict[str, Any],
+    *,
+    emit_negative_example_events: bool = False,
+) -> str:
     """Walk an activity's string values, excluding intentional-error fields.
 
     For `error-correction` activities, fields like `error:`, `errorWord:`,
@@ -5948,9 +6104,12 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
 
     For true-false activities, false statements are intentional wrong claims
     and may contain fabricated Ukrainian forms. Only true statements are
-    verified; missing answers fail soft by skipping the statement.
+    verified; missing answers fail soft by skipping the statement. True
+    statements also get a narrow safety net for sentence-final negative examples
+    like ``X, а не дивюся.`` where the tail is named as wrong teaching content.
     """
     activity_type = activity.get("type")
+    activity_id = str(activity.get("id") or "")
     skip_subtree = (
         _ERROR_CORRECTION_INTENTIONAL_FIELDS
         if activity_type == _ERROR_CORRECTION_TYPE
@@ -5983,11 +6142,36 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
         elif isinstance(options, str) and options in answers:
             walk(options, "options")
 
-    def walk_truefalse_statement(statement: Any, answer: Any) -> None:
+    def walk_truefalse_statement(
+        statement: Any,
+        answer: Any,
+        *,
+        item_idx: int | None = None,
+    ) -> None:
         if answer is True:
+            if isinstance(statement, str):
+                original_statement = statement
+                statement, skipped_forms = _strip_truefalse_negative_examples(statement)
+                if skipped_forms and emit_negative_example_events:
+                    emit_event(
+                        "vesum_verified_negative_example_stripped",
+                        activity_id=activity_id,
+                        item_idx=item_idx,
+                        forms=skipped_forms,
+                        statement_preview=_clean_telemetry_text(
+                            original_statement,
+                            180,
+                        ),
+                    )
             walk(statement, "statement")
 
-    def walk(node: Any, parent_key: str | None, *, in_options_list: bool = False) -> None:
+    def walk(
+        node: Any,
+        parent_key: str | None,
+        *,
+        in_options_list: bool = False,
+        item_idx: int | None = None,
+    ) -> None:
         if isinstance(node, dict):
             wrong_option = (
                 in_options_list
@@ -6021,14 +6205,28 @@ def _activity_vesum_text(activity: dict[str, Any]) -> str:
                     )
                     continue
                 if activity_type == "true-false" and key == "statement":
-                    walk_truefalse_statement(child, node.get("answer"))
+                    walk_truefalse_statement(
+                        child,
+                        node.get("answer"),
+                        item_idx=item_idx,
+                    )
                     continue
                 if wrong_option and key == "text":
                     continue
-                walk(child, key)
+                walk(child, key, item_idx=item_idx)
         elif isinstance(node, list):
-            for item in node:
-                walk(item, parent_key, in_options_list=parent_key == "options")
+            for index, item in enumerate(node):
+                child_item_idx = (
+                    index
+                    if activity_type == "true-false" and parent_key == "items"
+                    else item_idx
+                )
+                walk(
+                    item,
+                    parent_key,
+                    in_options_list=parent_key == "options",
+                    item_idx=child_item_idx,
+                )
         elif isinstance(node, str):
             out.append(node)
 

--- a/scripts/build/phases/linear-write-grok.md
+++ b/scripts/build/phases/linear-write-grok.md
@@ -57,7 +57,7 @@ that failure class. Run each check while drafting, not as a separate pass.
 
 2. **Modern Ukrainian + heritage-defense discipline.** Default to post-2019 Pravopys standard forms for learner-facing standard Ukrainian. However, NEVER classify a word as Russianism, surzhyk, or calque merely because it is archaic, historical, dialectal, or shares Proto-Slavic roots with Russian. For any non-modern or suspicious form, verify with `mcp__sources__check_modern_form` (VESUM) plus available historical/etymological evidence (`mcp__sources__search_grinchenko_1907`, `mcp__sources__search_esum`, literary/wiki source context). If authentic but non-standard, keep it only when pedagogically required, tag it `[Archaism]`, `[Historism]`, or `[Dialectism]`, give the modern standard equivalent, and briefly state its Ukrainian heritage. If unverified, omit or emit `<!-- VERIFY: heritage status for "X" unresolved -->`.
 
-   **Russianism / surzhyk / calque callout markup (mandatory).** When a sentence in prose demonstrates a *bad form* for learner contrast (the "stick to X, not the Russian-borrowed Y" pattern), the bad form is deliberately NOT in VESUM and would trip the `vesum_verified` gate as a false positive. Wrap the bad form in HTML comments so the gate strips it but the learner still sees it in rendered MDX:
+   **Bad-form marker convention (MANDATORY everywhere).** Any Ukrainian word form that is NOT in VESUM — intentional misspellings, Russianisms, Surzhyk, calques, archaisms appearing only for teaching contrast — MUST be wrapped in `<!-- bad -->...<!-- /bad -->` markers wherever it appears in the output, regardless of artifact. The marker lets `vesum_verified` strip the form while the learner still sees it in rendered MDX:
 
    ```markdown
    Stick to **сніданок** (not the Russian-borrowed <!-- bad -->завтрак<!-- /bad -->),
@@ -65,7 +65,11 @@ that failure class. Run each check while drafting, not as a separate pass.
    surzhyk <!-- bad -->одіватися<!-- /bad -->).
    ```
 
-   The `<!-- bad -->...<!-- /bad -->` marker is stripped by `_strip_metalinguistic` before VESUM lookup but doesn't render in MDX, so the bad form is still visible in plain prose. Do NOT use single-asterisk italics (`*завтрак*`) or bare unmarked prose for bad forms — both trip the gate. The marker is specifically for Russianisms, surzhyk forms, calques, and paronyms shown *to be avoided*. Words shown as legitimate non-standard heritage (archaisms, dialectisms) keep the `[Archaism]` / `[Dialectism]` tag and pedagogical defense above.
+   Apply it in `module.md` prose, `activities.yaml` `true-false` `statement:` fields, `match` / `fill-in` / `multiple-choice` / `order` / `pair-up` item strings, and `vocabulary.yaml` `usage:` when a wrong form is named for contrast. `resources.yaml title:` / notes are out of scope. `type: error-correction` `sentence:` / `error:` fields are already excluded from VESUM; markers are optional there but harmless.
+
+   **True-false anti-pattern:** statements that say `X, а не Y` / `X, not Y` MUST marker the Y form when Y is a malformed, Russianism, Surzhyk, or other non-VESUM teaching contrast. WRONG: `statement: "правильно: X, а не Y."`. RIGHT: `statement: "правильно: X, а не <!-- bad -->Y<!-- /bad -->."`
+
+   The `<!-- bad -->...<!-- /bad -->` marker is stripped by `_strip_metalinguistic` before VESUM lookup but doesn't render in MDX. Do NOT use single-asterisk italics (`*завтрак*`) or bare unmarked prose for bad forms — both trip the gate. Words shown as legitimate non-standard heritage (archaisms, dialectisms) keep the `[Archaism]` / `[Dialectism]` tag and pedagogical defense above.
 
 3. **Source-citation discipline.** Every dictionary / style-guide / author
    citation MUST be groundable in MCP. **Use `mcp__sources__verify_source_attribution(source, claim)` as the single-call primitive** — it returns a `discusses: bool` verdict in one call. Allowed `source` enum values: `grinchenko_1907`, `esum`, `sum11`, `antonenko_davydovych`, `literary`, `heritage`, `wikipedia`, `style_guide`. If `discusses=false`, do NOT cite that source for that claim.

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -88,13 +88,24 @@ that failure class. Run each check while drafting, not as a separate pass.
 
 2. **Modern Ukrainian + heritage-defense discipline.** Default to post-2019 Pravopys standard forms for learner-facing standard Ukrainian. However, NEVER classify a word as Russianism, surzhyk, or calque merely because it is archaic, historical, dialectal, or shares Proto-Slavic roots with Russian. For any non-modern or suspicious form, verify with `mcp__sources__check_modern_form` (VESUM) plus available historical/etymological evidence (`mcp__sources__search_grinchenko_1907`, `mcp__sources__search_esum`, literary/wiki source context). If authentic but non-standard, keep it only when pedagogically required, tag it `[Archaism]`, `[Historism]`, or `[Dialectism]`, give the modern standard equivalent, and briefly state its Ukrainian heritage. If unverified, omit or emit `<!-- VERIFY: heritage status for "X" unresolved -->`.
 
-   **Russianism / surzhyk / calque callout markup (mandatory).** When a sentence in prose demonstrates a *bad form* for learner contrast (the "stick to X, not the Russian-borrowed Y" pattern), the bad form is deliberately NOT in VESUM and would trip the `vesum_verified` gate as a false positive. Wrap the bad form in HTML comments so the gate strips it but the learner still sees it in rendered MDX:
+   **Bad-form marker convention (MANDATORY everywhere).** Any Ukrainian word form that is NOT in VESUM — intentional misspellings, Russianisms, Surzhyk, calques, archaisms appearing only for teaching contrast — MUST be wrapped in `<!-- bad -->...<!-- /bad -->` markers wherever it appears in the output, regardless of which artifact. The bad form is deliberately NOT in VESUM and would trip the `vesum_verified` gate as a false positive; the marker lets the gate strip it while the learner still sees the form in rendered MDX.
 
    ```markdown
    Stick to **сніданок** (not the Russian-borrowed <!-- bad -->завтрак<!-- /bad -->),
    **рушник** (not <!-- bad -->полотенце<!-- /bad -->), and **одягатися** (not the
    surzhyk <!-- bad -->одіватися<!-- /bad -->).
    ```
+
+   Apply this same convention in ALL writer artifacts:
+   - **module.md prose:** `**дивитися → я дивлюся**, not <!-- bad -->дивюся<!-- /bad -->`.
+   - **activities.yaml `true-false` `statement:` fields:** any negative example named in a true statement must be marker-wrapped. WRONG: `statement: "правильно: X, а не Y."`. RIGHT: `statement: "правильно: X, а не <!-- bad -->Y<!-- /bad -->."`
+   - **activities.yaml `match`, `fill-in`, `multiple-choice`, `order`, `pair-up`, etc. items:** any wrong form named as a contrast — if it is not a structural field like `error:` that the gate already skips — MUST have markers.
+   - **vocabulary.yaml `usage:` field:** usually exemplifies the correct form, so markers should not normally be needed. If a usage line names a wrong form for teaching, marker it.
+   - **resources.yaml `title:` / notes:** out of scope; do not marker.
+
+   **Exception:** `type: error-correction` activity items already have `sentence:` / `error:` fields fully excluded from VESUM lookup; markers are optional there but harmless.
+
+   **True-false anti-pattern:** statements that say `X, а не Y` / `X, not Y` MUST marker the Y form when Y is a malformed, Russianism, Surzhyk, or other non-VESUM teaching contrast. Do not leave Y bare just because the statement's `answer: true`.
 
    The `<!-- bad -->...<!-- /bad -->` marker is stripped by `_strip_metalinguistic` before VESUM lookup but doesn't render in MDX, so the bad form is still visible in plain prose. Do NOT use single-asterisk italics (`*завтрак*`) or bare unmarked prose for bad forms — both trip the gate. The marker is specifically for Russianisms, surzhyk forms, calques, and paronyms shown *to be avoided*. Words shown as legitimate non-standard heritage (archaisms, dialectisms) keep the `[Archaism]` / `[Dialectism]` tag and pedagogical defense above.
 
@@ -107,14 +118,15 @@ that failure class. Run each check while drafting, not as a separate pass.
    - ❌ `*X*, not *Y*` — italic contrast pair. The italicized *Y* leaks into VESUM and is rejected.
    - ❌ `... not *Y*.` / `... not *Y*,` — bare italic bad form.
    - ❌ `say X, not Y` — unmarked bad form in prose. The unmarked Y leaks into VESUM lookup.
+   - ❌ `true-false statement: X, а не Y.` — unmarked YAML negative example. The unmarked Y leaks into VESUM lookup unless marker-wrapped.
    - ❌ `instead of Y` / `замість Y` — unmarked bad form after a contrast preposition.
    - ❌ `(not Y)` / `(не Y)` — unmarked bad form in parentheses.
 
 ### Pre-emit bad-form audit (mandatory — #2095)
 
-Before emitting the four artifact fences (after the `<implementation_map_audit>` line from #2094), you MUST self-audit your draft for any italic-wrapped bad-form pattern:
+Before emitting the four artifact fences (after the `<implementation_map_audit>` line from #2094), you MUST self-audit your draft across `module.md`, `activities.yaml`, and `vocabulary.yaml` for any unmarked or italic-wrapped bad-form pattern:
 
-1. Scan your draft `module.md` for any of: `❌ *X*`, `*X*, not *Y*`, `... not *Y*.`, `... not *Y*,`, or `say X, not Y`.
+1. Scan your draft for any of: `❌ *X*`, `*X*, not *Y*`, `... not *Y*.`, `... not *Y*,`, `say X, not Y`, `X, а не Y`, or `X, not Y` inside YAML `statement:` / item strings.
 2. For EVERY match, the bad form `X` or `Y` MUST be wrapped in `<!-- bad -->X<!-- /bad -->` markers, NOT in `*italic*` and NOT bare prose. The Russianism, surzhyk, calque, or L2-trap form is the load-bearing case.
 3. If your scan finds zero italic-bad-form patterns, you may proceed. If your scan finds any, STOP, replace them with `<!-- bad -->` markers, and re-scan.
 

--- a/tests/build/test_vesum_negative_example_handling.py
+++ b/tests/build/test_vesum_negative_example_handling.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.build import linear_pipeline
+
+
+def _verify_except(
+    missing: set[str],
+    seen: list[list[str]] | None = None,
+):
+    def verify(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        if seen is not None:
+            seen.append(list(words))
+        return {
+            word: ([] if word in missing else [{"lemma": word}])
+            for word in words
+        }
+
+    return verify
+
+
+def _events(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _vesum_gate(
+    activities: list[dict[str, object]],
+    *,
+    missing: set[str] | None = None,
+    seen: list[list[str]] | None = None,
+) -> dict[str, object]:
+    return linear_pipeline._vesum_gate(
+        module_text="## Діалоги\n\nЯ дивлюся в дзеркало.",
+        activities=activities,
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_verify_except(missing or set(), seen),
+    )
+
+
+def test_bad_marker_in_true_false_statement_is_stripped() -> None:
+    seen: list[list[str]] = []
+    activity = {
+        "id": "act-tf",
+        "type": "true-false",
+        "items": [
+            {
+                "statement": (
+                    "Правильна форма — дивлюся, а не "
+                    "<!-- bad -->дивюся<!-- /bad -->."
+                ),
+                "answer": True,
+            }
+        ],
+    }
+
+    result = _vesum_gate([activity], missing={"дивюся"}, seen=seen)
+
+    assert result["passed"] is True
+    assert "дивлюся" in seen[0]
+    assert "дивюся" not in seen[0]
+
+
+def test_bad_marker_in_error_correction_sentence_is_harmless() -> None:
+    seen: list[list[str]] = []
+    activity = {
+        "id": "act-error",
+        "type": "error-correction",
+        "items": [
+            {
+                "sentence": "Я <!-- bad -->дивюся<!-- /bad --> в дзеркало.",
+                "error": "дивюся",
+                "correction": "дивлюся",
+            }
+        ],
+    }
+
+    result = _vesum_gate([activity], missing={"дивюся"}, seen=seen)
+
+    assert result["passed"] is True
+    assert "дивюся" not in seen[0]
+    assert "дивлюся" in seen[0]
+
+
+def test_true_false_ukrainian_negative_example_tail_is_stripped(
+    tmp_path: Path,
+) -> None:
+    seen: list[list[str]] = []
+    telemetry = tmp_path / "events.jsonl"
+    activity = {
+        "id": "act-tf",
+        "type": "true-false",
+        "items": [
+            {
+                "statement": "Правильна форма — дивлюся, а не дивюся.",
+                "answer": True,
+            }
+        ],
+    }
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = _vesum_gate([activity], missing={"дивюся"}, seen=seen)
+
+    assert result["passed"] is True
+    assert "дивюся" not in seen[0]
+    events = _events(telemetry)
+    event = next(
+        item
+        for item in events
+        if item["event"] == "vesum_verified_negative_example_stripped"
+    )
+    assert event["activity_id"] == "act-tf"
+    assert event["item_idx"] == 0
+    assert event["forms"] == ["дивюся"]
+
+
+def test_true_false_english_negative_example_tail_is_stripped(
+    tmp_path: Path,
+) -> None:
+    seen: list[list[str]] = []
+    telemetry = tmp_path / "events.jsonl"
+    activity = {
+        "id": "act-tf-pro",
+        "type": "true-false",
+        "items": [
+            {
+                "statement": "The correct first-person form is дивлюся, not дивюся.",
+                "answer": True,
+            }
+        ],
+    }
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = _vesum_gate([activity], missing={"дивюся"}, seen=seen)
+
+    assert result["passed"] is True
+    assert "дивюся" not in seen[0]
+    assert any(
+        event["event"] == "vesum_verified_negative_example_stripped"
+        and event["forms"] == ["дивюся"]
+        for event in _events(telemetry)
+    )
+
+
+def test_true_false_without_negative_example_pattern_emits_no_event(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+    activity = {
+        "id": "act-tf",
+        "type": "true-false",
+        "items": [
+            {"statement": "Форма дивлюся правильна.", "answer": True}
+        ],
+    }
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = _vesum_gate([activity], missing={"дивюся"})
+
+    assert result["passed"] is True
+    assert not any(
+        event["event"] == "vesum_verified_negative_example_stripped"
+        for event in _events(telemetry)
+    )
+
+
+def test_true_false_multi_form_negative_example_still_requires_markers(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+    activity = {
+        "id": "act-tf",
+        "type": "true-false",
+        "items": [
+            {
+                "statement": (
+                    "Правильна форма — дивлюся, а не дивюся або користуювася."
+                ),
+                "answer": True,
+            }
+        ],
+    }
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = _vesum_gate([activity], missing={"дивюся", "користуювася"})
+
+    assert result["passed"] is False
+    assert result["missing"] == ["дивюся", "користуювася"]
+    assert not any(
+        event["event"] == "vesum_verified_negative_example_stripped"
+        for event in _events(telemetry)
+    )
+
+
+def test_false_true_false_statement_stays_out_of_vesum_scope(
+    tmp_path: Path,
+) -> None:
+    seen: list[list[str]] = []
+    telemetry = tmp_path / "events.jsonl"
+    activity = {
+        "id": "act-tf",
+        "type": "true-false",
+        "items": [
+            {
+                "statement": "Правильна форма — дивлюся, а не дивюся.",
+                "answer": False,
+            }
+        ],
+    }
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = _vesum_gate([activity], missing={"дивюся"}, seen=seen)
+
+    assert result["passed"] is True
+    assert "дивюся" not in seen[0]
+    assert not any(
+        event["event"] == "vesum_verified_negative_example_stripped"
+        for event in _events(telemetry)
+    )
+
+
+def test_match_activity_bad_form_requires_marker() -> None:
+    unmarked = {
+        "id": "act-match",
+        "type": "match",
+        "items": [{"left": "Я дивюся в дзеркало.", "right": "I look."}],
+    }
+    marked = {
+        "id": "act-match",
+        "type": "match",
+        "items": [
+            {
+                "left": "Я <!-- bad -->дивюся<!-- /bad --> в дзеркало.",
+                "right": "I look.",
+            }
+        ],
+    }
+
+    assert _vesum_gate([unmarked], missing={"дивюся"})["missing"] == ["дивюся"]
+    assert _vesum_gate([marked], missing={"дивюся"})["passed"] is True
+
+
+def test_fill_in_sentence_bad_form_requires_marker() -> None:
+    unmarked = {
+        "id": "act-fill",
+        "type": "fill-in",
+        "items": [{"sentence": "Я дивюся в дзеркало.", "answer": "дивлюся"}],
+    }
+    marked = {
+        "id": "act-fill",
+        "type": "fill-in",
+        "items": [
+            {
+                "sentence": "Я <!-- bad -->дивюся<!-- /bad --> в дзеркало.",
+                "answer": "дивлюся",
+            }
+        ],
+    }
+
+    assert _vesum_gate([unmarked], missing={"дивюся"})["missing"] == ["дивюся"]
+    assert _vesum_gate([marked], missing={"дивюся"})["passed"] is True
+
+
+def test_detect_unmarkered_negative_examples_finds_writer_omission() -> None:
+    activities_yaml = yaml.safe_dump(
+        [
+            {
+                "id": "act-tf",
+                "type": "true-false",
+                "items": [
+                    {
+                        "statement": "Правильна форма — дивлюся, не дивюся.",
+                        "answer": True,
+                    }
+                ],
+            }
+        ],
+        allow_unicode=True,
+        sort_keys=False,
+    )
+
+    findings = linear_pipeline.detect_unmarkered_negative_examples(activities_yaml)
+
+    assert findings == [
+        {
+            "activity_id": "act-tf",
+            "item_idx": 0,
+            "form": "дивюся",
+            "hint": (
+                "Wrap the negative example as "
+                "<!-- bad -->дивюся<!-- /bad -->."
+            ),
+        }
+    ]
+
+
+def test_m20_style_true_false_negative_example_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    activities = [
+        {
+            "id": "act-error-l2",
+            "type": "error-correction",
+            "items": [
+                {
+                    "sentence": "Я дивюся в дзеркало.",
+                    "error": "дивюся",
+                    "correction": "дивлюся",
+                }
+            ],
+        },
+        {
+            "id": "act-tf",
+            "type": "true-false",
+            "items": [
+                {
+                    "statement": (
+                        "У дієсловах другої дієвідміни 1-ша особа однини "
+                        "після губних має вставне 'л' — дивлюся, а не дивюся."
+                    ),
+                    "answer": True,
+                }
+            ],
+        },
+    ]
+
+    with monkeypatch.context() as disabled_safety_net:
+        disabled_safety_net.setattr(
+            linear_pipeline,
+            "_TF_NEGATIVE_EXAMPLE_RE",
+            re.compile(r"a^"),
+        )
+        baseline = _vesum_gate(activities, missing={"дивюся"})
+
+    telemetry = tmp_path / "events.jsonl"
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = _vesum_gate(activities, missing={"дивюся"})
+
+    assert baseline["passed"] is False
+    assert baseline["missing"] == ["дивюся"]
+    assert result["passed"] is True
+    assert any(
+        event["event"] == "vesum_verified_negative_example_stripped"
+        and event["activity_id"] == "act-tf"
+        and event["forms"] == ["дивюся"]
+        for event in _events(telemetry)
+    )


### PR DESCRIPTION
## Summary

- Two-pronged fix for #2128 (also closes #1975, same root cause):
  1. Writer prompt: extend `<!-- bad -->...<!-- /bad -->` marker convention to all artifact locations (TF statements, match items, fill-in sentences) — both `linear-write.md` and `linear-write-grok.md`.
  2. Gate-side safety net: `linear_pipeline.py` detects "..., а не Y" / "..., not Y" pattern in TF statements, strips Y from VESUM lookup conservatively, emits `vesum_verified_negative_example_stripped` telemetry event.
- 11 new tests cover markers / TF-tail strip (UA + EN) / no-pattern path / match + fill-in / m20-style smoke. All pass.

## Test plan

- [x] `pytest tests/build/test_vesum_negative_example_handling.py -v` → 11/11 pass (0.48s)
- [x] `pytest tests/build/ tests/audit/ -q` → 623 passed, 25 skipped, 0 failed (9.39s)
- [x] `ruff check` → All checks passed
- [x] **m20 worktree replay** on `.worktrees/builds/a1-my-morning-20260518-000636/`:
  ```
  vesum_verified_negative_example_stripped fires on act-tf-pronounce
  forms stripped: ["дивюся"]
  passed: True, checked: 206, missing: 0
  ```
  This is THE original m20 build #2 failure case. Fix unblocks the build.

## Provenance

Codex dispatch `2128-vesum-bad-marker-20260518-024000` completed all file edits (linear_pipeline.py +218 LOC, both writer prompts updated, 11-case test file, vocab-activity-standards.md update) but exited silently before committing — empty stdout/stderr logs (PR #2124 PTY fix didn't catch this case), worker process gone, worktree contained complete and validated work. Orchestrator (Claude) finalized: ran pytest + ruff + m20 replay (all green), committed on the existing dispatch branch, opened this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)