### PR TITLE
fix(writer-prompt): add pre-emit checklist for multimedia/vesum/textbook obligations (#1969)

### DIFF
--- a/scripts/build/phases/linear-write-grok.md
+++ b/scripts/build/phases/linear-write-grok.md
@@ -428,27 +428,32 @@ Rule: if a field name is not in `{sentence, error, errors, errorWord, error_word
 
 ## Pre-emit verification (run BEFORE you write any artifact)
 
-Before emitting the four fenced blocks and the `<end_gate>` block, confirm
-you have made AT LEAST one of each of the following tool calls during this
-turn. If any line below is FALSE, make the call now before emitting.
+Confirm you have made AT LEAST one of each of the following MCP tool calls.
+If any line below is FALSE for your current session, make the call now BEFORE
+emitting any artifact:
 
-1. `mcp__sources__search_text` — at least one call per `plan_references`
-   textbook entry (textbook grounding obligation; gate
-   `textbook_grounding`).
-2. `mcp__sources__query_wikipedia` OR `mcp__sources__search_external` OR
-   `mcp__sources__search_images` — at least one call (multimedia search
-   obligation; gate `resources_search_attempted`). Honest "no result"
-   counts — the attempt is what the gate counts.
-3. `mcp__sources__verify_words` (or `verify_word` / `verify_lemma`) — at
-   least one call on novel Ukrainian forms before writing them
-   (verification obligation; reviewer evidence requirement).
-4. `mcp__sources__search_style_guide` — at least one call on a Russianism
-   or paronym candidate from the topic vocabulary (heritage-defense
-   obligation; reviewer evidence requirement).
+1. **Textbook grounding** — `mcp__sources__search_text` for each
+   `plan_references` textbook entry (one call per entry; verify the citation
+   page exists in the search hit).
+2. **Multimedia obligation** — AT LEAST ONE of
+   `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, OR
+   `mcp__sources__search_images`. This is non-negotiable: the
+   `resources_search_attempted` gate will REJECT modules with
+   `multimedia_calls_total == 0`.
+3. **VESUM verification** — `mcp__sources__verify_words` on EVERY Ukrainian
+   form you intend to write that isn't trivially known (i.e. anything beyond
+   top-100 frequency). One batched call per dozen lemmas/forms is fine.
+4. **Russianism check** — `mcp__sources__search_style_guide` on at least one
+   Russianism-candidate form (when teaching contrast pairs).
 
-This checklist is not a substitute for the per-mandate instructions above;
-it is a final cross-check that no mandate was forgotten under the attention
-budget of the early-prompt contract directives.
+If any line above is FALSE, make the call now. Do not emit artifacts until
+the checklist is fully green.
+
+Failure to satisfy ANY checklist line will cause the build to fail at the
+`resources_search_attempted` / `vesum_verified` / `textbook_grounding` /
+`style_guide_evidence` gate AFTER you've spent compute generating prose. The
+4 tool calls above cost you 30 seconds of latency and unblock the entire
+build. Make them.
 
 ## HARD STOP RULE
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -525,27 +525,32 @@ Rule: if a field name is not in `{sentence, error, errors, errorWord, error_word
 
 ## Pre-emit verification (run BEFORE you write any artifact)
 
-Before emitting the four fenced blocks and the `<end_gate>` block, confirm
-you have made AT LEAST one of each of the following tool calls during this
-turn. If any line below is FALSE, make the call now before emitting.
+Confirm you have made AT LEAST one of each of the following MCP tool calls.
+If any line below is FALSE for your current session, make the call now BEFORE
+emitting any artifact:
 
-1. `mcp__sources__search_text` — at least one call per `plan_references`
-   textbook entry (textbook grounding obligation; gate
-   `textbook_grounding`).
-2. `mcp__sources__query_wikipedia` OR `mcp__sources__search_external` OR
-   `mcp__sources__search_images` — at least one call (multimedia search
-   obligation; gate `resources_search_attempted`). Honest "no result"
-   counts — the attempt is what the gate counts.
-3. `mcp__sources__verify_words` (or `verify_word` / `verify_lemma`) — at
-   least one call on novel Ukrainian forms before writing them
-   (verification obligation; reviewer evidence requirement).
-4. `mcp__sources__search_style_guide` — at least one call on a Russianism
-   or paronym candidate from the topic vocabulary (heritage-defense
-   obligation; reviewer evidence requirement).
+1. **Textbook grounding** — `mcp__sources__search_text` for each
+   `plan_references` textbook entry (one call per entry; verify the citation
+   page exists in the search hit).
+2. **Multimedia obligation** — AT LEAST ONE of
+   `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, OR
+   `mcp__sources__search_images`. This is non-negotiable: the
+   `resources_search_attempted` gate will REJECT modules with
+   `multimedia_calls_total == 0`.
+3. **VESUM verification** — `mcp__sources__verify_words` on EVERY Ukrainian
+   form you intend to write that isn't trivially known (i.e. anything beyond
+   top-100 frequency). One batched call per dozen lemmas/forms is fine.
+4. **Russianism check** — `mcp__sources__search_style_guide` on at least one
+   Russianism-candidate form (when teaching contrast pairs).
 
-This checklist is not a substitute for the per-mandate instructions above;
-it is a final cross-check that no mandate was forgotten under the attention
-budget of the early-prompt contract directives.
+If any line above is FALSE, make the call now. Do not emit artifacts until
+the checklist is fully green.
+
+Failure to satisfy ANY checklist line will cause the build to fail at the
+`resources_search_attempted` / `vesum_verified` / `textbook_grounding` /
+`style_guide_evidence` gate AFTER you've spent compute generating prose. The
+4 tool calls above cost you 30 seconds of latency and unblock the entire
+build. Make them.
 
 ## HARD STOP RULE
 

--- a/tests/build/test_writer_pre_emit_checklist.py
+++ b/tests/build/test_writer_pre_emit_checklist.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+PHASES_DIR = Path("scripts/build/phases")
+CHECKLIST_HEADING = "## Pre-emit verification"
+OBLIGATION_LABELS = (
+    "Textbook grounding",
+    "Multimedia obligation",
+    "VESUM verification",
+    "Russianism check",
+)
+
+
+def _pre_emit_checklist_body(prompt_path: Path) -> str:
+    prompt = prompt_path.read_text(encoding="utf-8")
+    heading_start = prompt.index(CHECKLIST_HEADING)
+    next_heading_start = prompt.index("\n## ", heading_start + len(CHECKLIST_HEADING))
+    return prompt[heading_start:next_heading_start]
+
+
+def _assert_prompt_contains_pre_emit_checklist(prompt_name: str) -> None:
+    checklist = _pre_emit_checklist_body(PHASES_DIR / prompt_name)
+
+    assert "Pre-emit verification" in checklist
+    for label in OBLIGATION_LABELS:
+        assert label in checklist
+
+
+def test_linear_write_contains_pre_emit_checklist() -> None:
+    _assert_prompt_contains_pre_emit_checklist("linear-write.md")
+
+
+def test_linear_write_grok_contains_pre_emit_checklist() -> None:
+    _assert_prompt_contains_pre_emit_checklist("linear-write-grok.md")


### PR DESCRIPTION
## Summary

Root cause: the #1964 shape-contract tightening increased early-prompt attention load and crowded out the later multimedia-search obligation. The existing pre-emit section was present in both writer prompts, but it did not use the explicit four obligation labels or the hard gate-failure framing requested by #1969.

Fix: strengthened the existing near-end pre-emit checklist in both `linear-write.md` and `linear-write-grok.md` so writers must confirm textbook grounding, multimedia search, VESUM verification, and Russianism checks before emitting artifacts.

Coverage: added `tests/build/test_writer_pre_emit_checklist.py` to lint both prompt templates for the checklist and four obligation labels.

## Verification

### Prompt diff: linear-write.md

Command: `git diff origin/main -- scripts/build/phases/linear-write.md`

```diff
+1. **Textbook grounding** — `mcp__sources__search_text` for each
+   `plan_references` textbook entry (one call per entry; verify the citation
+   page exists in the search hit).
+2. **Multimedia obligation** — AT LEAST ONE of
+   `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, OR
+   `mcp__sources__search_images`. This is non-negotiable: the
+   `resources_search_attempted` gate will REJECT modules with
+   `multimedia_calls_total == 0`.
+3. **VESUM verification** — `mcp__sources__verify_words` on EVERY Ukrainian
+   form you intend to write that isn't trivially known (i.e. anything beyond
+   top-100 frequency). One batched call per dozen lemmas/forms is fine.
+4. **Russianism check** — `mcp__sources__search_style_guide` on at least one
+   Russianism-candidate form (when teaching contrast pairs).
+```

### Prompt diff: linear-write-grok.md

Command: `git diff origin/main -- scripts/build/phases/linear-write-grok.md`

```diff
+1. **Textbook grounding** — `mcp__sources__search_text` for each
+   `plan_references` textbook entry (one call per entry; verify the citation
+   page exists in the search hit).
+2. **Multimedia obligation** — AT LEAST ONE of
+   `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, OR
+   `mcp__sources__search_images`. This is non-negotiable: the
+   `resources_search_attempted` gate will REJECT modules with
+   `multimedia_calls_total == 0`.
+3. **VESUM verification** — `mcp__sources__verify_words` on EVERY Ukrainian
+   form you intend to write that isn't trivially known (i.e. anything beyond
+   top-100 frequency). One batched call per dozen lemmas/forms is fine.
+4. **Russianism check** — `mcp__sources__search_style_guide` on at least one
+   Russianism-candidate form (when teaching contrast pairs).
+```

### Test file diff

Command: `git diff origin/main -- tests/build/test_writer_pre_emit_checklist.py`

```diff
+def test_linear_write_contains_pre_emit_checklist() -> None:
+    _assert_prompt_contains_pre_emit_checklist("linear-write.md")
+
+
+def test_linear_write_grok_contains_pre_emit_checklist() -> None:
+    _assert_prompt_contains_pre_emit_checklist("linear-write-grok.md")
```

### Targeted new test

Command: `.venv/bin/pytest tests/build/test_writer_pre_emit_checklist.py -v`

```text
tests/build/test_writer_pre_emit_checklist.py::test_linear_write_contains_pre_emit_checklist PASSED [ 50%]
tests/build/test_writer_pre_emit_checklist.py::test_linear_write_grok_contains_pre_emit_checklist PASSED [100%]

============================== 2 passed in 0.05s ===============================
```

### Existing build/audit prompt tests

Command: `.venv/bin/pytest tests/build/ tests/audit/ -q`

```text
======================= 625 passed, 25 skipped in 7.03s ========================
```

### Full pytest

Command: `.venv/bin/pytest tests/ -q`

```text
FAILED tests/test_channels_registry.py::test_registry_covers_all_external_source_files
FAILED tests/test_esum_search.py::test_search_esum_berkut_returns_turkic_origin
FAILED tests/test_esum_search.py::test_search_esum_voda_returns_cross_slavic_and_proto_slavic_cognates
FAILED tests/test_monitor_api_telemetry.py::test_rules_markdown_appends_footer_when_enabled
FAILED tests/test_monitor_api_telemetry.py::test_manifest_json_adds_structured_telemetry_when_enabled
FAILED tests/test_scrape_diasporiana.py::TestDiasporianaJsonlSchema::test_chunk_schema_matches_existing_litopys_waves
FAILED tests/test_wiki_channels.py::test_registry_schema_covers_all_live_source_files
FAILED tests/test_wiki_packet_dictionary_context.py::test_build_knowledge_packet_appends_textbook_excerpts
FAILED tests/wiki/test_mlx_fault_injection.py::test_mlx_fault_injection_halves_batch_and_preserves_row_order
FAILED tests/wiki/test_t1_t2_pipeline.py::test_t1_t2_pipeline_surfaces_section_level_a1_evidence
= 10 failed, 7905 passed, 218 skipped, 11 xfailed, 3 warnings in 529.71s (0:08:49) =
```

Notes: the full-suite failures are outside this prompt/test diff. After adding ignored local links for sparse worktree corpus assets and unsetting the ambient `AGENT_NO_TELEMETRY_FOOTER=1`, the affected-failure rerun reduced to four local corpus-content failures:

Command: `unset AGENT_NO_TELEMETRY_FOOTER; .venv/bin/pytest <10 prior failing tests> -q`

```text
FAILED tests/test_esum_search.py::test_search_esum_berkut_returns_turkic_origin
FAILED tests/test_esum_search.py::test_search_esum_voda_returns_cross_slavic_and_proto_slavic_cognates
FAILED tests/test_wiki_packet_dictionary_context.py::test_build_knowledge_packet_appends_textbook_excerpts
FAILED tests/wiki/test_t1_t2_pipeline.py::test_t1_t2_pipeline_surfaces_section_level_a1_evidence
========================= 4 failed, 6 passed in 11.14s =========================
```

### Ruff

Command: `.venv/bin/ruff check tests/build/test_writer_pre_emit_checklist.py scripts/build/phases/`

```text
All checks passed!
```

### Pre-commit

Command: `.venv/bin/python -m pre_commit run --files scripts/build/phases/linear-write.md scripts/build/phases/linear-write-grok.md tests/build/test_writer_pre_emit_checklist.py`

```text
ruff (lint)..........................................(no files to check)Skipped
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

### Diff stat

Command: `git diff --stat origin/main`

```text
 scripts/build/phases/linear-write-grok.md     | 47 +++++++++++++++------------
 scripts/build/phases/linear-write.md          | 47 +++++++++++++++------------
 tests/build/test_writer_pre_emit_checklist.py | 33 +++++++++++++++++++
 3 files changed, 85 insertions(+), 42 deletions(-)
```

### Commit

Command: `git log -1 --oneline`

```text
967de84199 fix(writer-prompt): add pre-emit checklist for multimedia/vesum/textbook obligations (#1969)
```

### Trailer lint

Command: `.venv/bin/python scripts/audit/lint_agent_trailer.py`

```text
Checking 1 commit(s) in origin/main..HEAD:

  967de84199  PASS  X-Agent: codex/1969-multimedia-pre-emit-checklist-20260518-094300

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

### PR URL

Command: `gh pr view --json url`

```json
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2135"}
```
