### PR TITLE
fix(build): tighten PR3 corrector contract + harden YAML guard (#2127)

### DIFF
--- a/docs/decisions/2026-05-17-path3-per-obligation-review-loop.md
+++ b/docs/decisions/2026-05-17-path3-per-obligation-review-loop.md
@@ -79,6 +79,22 @@ For each remaining failed obligation:
 2. **Cap at 2 iterations per obligation** (Grok). After cap, emit `plan_revision_request` (defer to next plan iteration) rather than further LLM thrashing.
 3. Each `<fixes>` diff capped in size (Grok); each accepted fix logged with before/after gate scores + rationale.
 
+### Corrector contract enforcement
+
+Issue #2127 hardens PR3's `<fixes>`-only contract in both prompt and pipeline
+code. Wiki coverage correctors may now emit only local `find`/`replace` fixes
+or `insert_after`/`text` insertions, and each replacement/insertion body is
+capped at 6 lines and 240 characters. Oversize reviewer fixes are rejected with
+`reviewer_fix_oversize_rejected` before any artifact write, which prevents
+activity-block regeneration from entering the correction loop.
+
+The artifact writer also validates YAML correction outputs before accepting
+them. `activities.yaml`, `vocabulary.yaml`, and `resources.yaml` must remain
+bare lists of mappings, required identity fields must stay non-empty strings,
+activity `items` must remain lists of mappings, and YAML parser or round-trip
+failures are normalized to `LinearPipelineError` so the correction rollback path
+emits `wiki_coverage_correction_yaml_invalid` instead of a raw stacktrace.
+
 ### Phase 5 — Goodhart sentinel (Gemini + Grok merge)
 
 After Phase 3+4 converge on the deterministic gate, run a **secondary semantic reviewer** (cross-family — Codex if writer was Claude, etc.) that judges "is this obligation woven into the prose, or just keyword-stuffed?" If the gate passes but the semantic reviewer flags "substance missing," fail the build with explicit signal.

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -286,6 +286,11 @@ WIKI_COVERAGE_BATCH_MAX_ITERATIONS = 2
 WIKI_COVERAGE_NARROW_MAX_ITERATIONS = 2
 WIKI_COVERAGE_PATCHABLE_ARTIFACTS = frozenset({"module.md", "activities.yaml"})
 WIKI_COVERAGE_ARTIFACT_INFERENCE_ORDER = ("activities.yaml", "module.md")
+CORRECTION_YAML_ARTIFACT_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "activities.yaml": ("id", "type"),
+    "vocabulary.yaml": ("lemma", "translation", "pos", "usage"),
+    "resources.yaml": ("title", "role"),
+}
 ALLOWED_WIKI_COVERAGE_VERDICTS = {"PASS", "KEYWORD_STUFFING", "PARTIAL", "FAIL"}
 WIKI_COVERAGE_OVERALL_FAIL_VERDICTS = {"FAIL", "KEYWORD_STUFFING"}
 WIKI_COVERAGE_OVERALL_VERDICTS = {"PASS", "PARTIAL", "FAIL"}
@@ -4193,10 +4198,23 @@ def _apply_wiki_coverage_fixes(
 ) -> int:
     artifact_path = module_dir / artifact
     original = _read_required(artifact_path)
-    applicable_count = _count_applicable_reviewer_fixes(original, fixes)
+    accepted_fixes, rejected_fixes = _validate_reviewer_fix_shapes(fixes)
+    _emit_reviewer_fix_oversize_rejections(
+        rejected_fixes,
+        gate="wiki_coverage_gate",
+        group_key=group_key,
+        event_sink=event_sink,
+        phase=phase,
+        iteration=iteration,
+        artifact=artifact,
+        obligation_id=obligation_id,
+    )
+    if not accepted_fixes:
+        return 0
+    applicable_count = _count_applicable_reviewer_fixes(original, accepted_fixes)
     result = _apply_reviewer_fixes(
         original,
-        fixes,
+        accepted_fixes,
         gate="wiki_coverage_gate",
         module_dir=module_dir,
     )
@@ -4244,14 +4262,130 @@ def _count_applicable_reviewer_fixes(text: str, fixes: Sequence[Mapping[str, str
     return count
 
 
+def _reviewer_fix_body(fix: Mapping[str, str]) -> tuple[str, str] | None:
+    if "replace" in fix:
+        return "replace", str(fix["replace"])
+    if "text" in fix:
+        return "text", str(fix["text"])
+    return None
+
+
+def _reviewer_fix_line_count(body: str) -> int:
+    if body == "":
+        return 0
+    return body.count("\n") + 1
+
+
+def _validate_reviewer_fix_shapes(
+    fixes: list[dict[str, str]],
+    *,
+    max_lines: int = 6,
+    max_chars: int = 240,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Split parsed fixes into (accepted, rejected_oversize).
+
+    A fix is rejected when its `replace` or `text` body exceeds the size
+    limit, which is evidence of regeneration per the corrector prompt contract.
+    """
+    accepted: list[dict[str, str]] = []
+    rejected: list[dict[str, str]] = []
+    for fix in fixes:
+        body_info = _reviewer_fix_body(fix)
+        if body_info is None:
+            accepted.append(fix)
+            continue
+        _, body = body_info
+        if _reviewer_fix_line_count(body) > max_lines or len(body) > max_chars:
+            rejected.append(fix)
+            continue
+        accepted.append(fix)
+    return accepted, rejected
+
+
+def _emit_reviewer_fix_oversize_rejections(
+    rejected_fixes: Sequence[Mapping[str, str]],
+    *,
+    gate: str,
+    group_key: str | None,
+    event_sink: Callable[..., None] | None = None,
+    **fields: Any,
+) -> None:
+    for fix in rejected_fixes:
+        body_info = _reviewer_fix_body(fix)
+        if body_info is None:
+            continue
+        body_field, body = body_info
+        _emit(
+            event_sink,
+            "reviewer_fix_oversize_rejected",
+            gate=gate,
+            group_key=group_key,
+            body_field=body_field,
+            body_len=len(body),
+            line_count=_reviewer_fix_line_count(body),
+            body_preview=_correction_preview(body),
+            **fields,
+        )
+
+
 def _validate_wiki_coverage_artifact_text(artifact: str, text: str) -> None:
-    if artifact != "activities.yaml":
+    required_fields = CORRECTION_YAML_ARTIFACT_REQUIRED_FIELDS.get(artifact)
+    if required_fields is None:
         return
-    parsed = yaml.safe_load(text)
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise LinearPipelineError(f"{artifact} invalid YAML: {exc}") from exc
     if not isinstance(parsed, list):
-        raise LinearPipelineError("activities.yaml must remain a bare YAML list")
-    if not all(isinstance(item, dict) for item in parsed):
-        raise LinearPipelineError("activities.yaml entries must remain mappings")
+        raise LinearPipelineError(f"{artifact} must remain a bare YAML list")
+    for index, item in enumerate(parsed, start=1):
+        if not isinstance(item, dict):
+            raise LinearPipelineError(
+                f"{artifact} entries must remain mappings; item {index} is "
+                f"{type(item).__name__}"
+            )
+    try:
+        redumped = yaml.safe_dump(parsed, allow_unicode=True, sort_keys=False)
+        reparsed = yaml.safe_load(redumped)
+    except yaml.YAMLError as exc:
+        raise LinearPipelineError(f"{artifact} failed YAML round-trip: {exc}") from exc
+    if parsed != reparsed:
+        raise LinearPipelineError(
+            f"{artifact} does not round-trip cleanly; likely scalar/mapping "
+            "ambiguity or non-portable scalar value"
+        )
+    for index, item in enumerate(parsed, start=1):
+        for field in required_fields:
+            value = item.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise LinearPipelineError(
+                    f"{artifact} item {index} requires {field} as a non-empty "
+                    f"string (got {type(value).__name__}: {value!r})"
+                )
+        if artifact == "activities.yaml" and "items" in item:
+            items = item["items"]
+            if not isinstance(items, list):
+                raise LinearPipelineError(
+                    f"{artifact} item {index} field items must remain a list"
+                )
+            activity_type = str(item.get("type") or "")
+            required_item_fields = _ACTIVITY_ITEM_REQUIRED_FIELDS.get(activity_type)
+            if required_item_fields is None:
+                continue
+            for item_index, nested_item in enumerate(items, start=1):
+                if not isinstance(nested_item, dict):
+                    raise LinearPipelineError(
+                        f"{artifact} item {index} items entry {item_index} "
+                        f"must remain a mapping (got {type(nested_item).__name__})"
+                    )
+                for field in required_item_fields:
+                    value = nested_item.get(field)
+                    if not isinstance(value, str) or not value.strip():
+                        raise LinearPipelineError(
+                            f"{artifact} item {index} items entry {item_index} "
+                            f"requires {field} as a non-empty string "
+                            f"(got {type(value).__name__}: {value!r})"
+                        )
 
 
 def _wiki_coverage_remaining_failures(result: Mapping[str, Any]) -> list[Mapping[str, Any]]:
@@ -4476,15 +4610,44 @@ def _apply_reviewer_correction(
             response_preview=_correction_preview(response),
         )
         return frozenset()
-    result = _apply_reviewer_fixes(
-        module_text,
-        fixes,
+    accepted_fixes, rejected_fixes = _validate_reviewer_fix_shapes(fixes)
+    correction_fields = _correction_event_fields(
         gate=gate,
         module_dir=module_dir,
         plan_path=plan_path,
     )
-    if fixes:
+    correction_fields.pop("gate", None)
+    _emit_reviewer_fix_oversize_rejections(
+        rejected_fixes,
+        gate=gate,
+        group_key=None,
+        **correction_fields,
+    )
+    if not accepted_fixes:
+        return frozenset()
+    result = _apply_reviewer_fixes(
+        module_text,
+        accepted_fixes,
+        gate=gate,
+        module_dir=module_dir,
+        plan_path=plan_path,
+    )
+    if accepted_fixes:
         module_path.write_text(result.text, encoding="utf-8")
+        try:
+            _validate_wiki_coverage_artifact_text(module_path.name, result.text)
+        except LinearPipelineError as exc:
+            module_path.write_text(module_text, encoding="utf-8")
+            emit_event(
+                "reviewer_correction_yaml_invalid",
+                **_correction_event_fields(
+                    gate=gate,
+                    module_dir=module_dir,
+                    plan_path=plan_path,
+                ),
+                artifact=module_path.name,
+                error_preview=str(exc)[:800],
+            )
     return result.unmatched_anchors
 
 

--- a/scripts/build/phases/linear-correction-wiki-coverage-narrow.md
+++ b/scripts/build/phases/linear-correction-wiki-coverage-narrow.md
@@ -14,6 +14,21 @@ smallest local change that satisfies the supplied obligation.
 
 Return exactly one `<fixes>` block and nothing else.
 
+You may emit ONLY these two fix shapes inside `<fixes>...</fixes>`
+(XML or YAML, no other content):
+
+- `<fix><find>...</find><replace>...</replace></fix>` - local textual
+  find/replace.
+- `<fix><insert_after>...</insert_after><text>...</text></fix>` - inserts
+  AFTER an existing anchor.
+
+You MUST NOT:
+
+- Regenerate full activity blocks (`- id: act-N` with multiple keys).
+- Add new top-level activity entries.
+- Rewrite multi-line YAML structures.
+- Output any Markdown, prose, or YAML outside `<fixes>`.
+
 Allowed XML form:
 
 ```xml
@@ -25,6 +40,17 @@ Allowed XML form:
 </fixes>
 ```
 
+Allowed XML insert form:
+
+```xml
+<fixes>
+  <fix obligation_id="err-1">
+    <insert_after>exact existing anchor text</insert_after>
+    <text>small inserted text</text>
+  </fix>
+</fixes>
+```
+
 Allowed YAML-list form:
 
 ```yaml
@@ -32,6 +58,16 @@ Allowed YAML-list form:
 - obligation_id: err-1
   find: exact text currently present in the artifact
   replace: small corrected text
+</fixes>
+```
+
+Allowed YAML insert form:
+
+```yaml
+<fixes>
+- obligation_id: err-1
+  insert_after: exact existing anchor text
+  text: small inserted text
 </fixes>
 ```
 
@@ -49,8 +85,37 @@ artifact. No section rewrite. Strictly follow ADR-007:
 - Use `manifest_payload` values verbatim. If it contains `incorrect`,
   `correct`, `written`, `spoken`, `heading`, `required_claim`, `why`, or
   `rule`, reproduce the relevant value exactly.
-- No single `replace` value may exceed 600 characters.
+- Each `replace` and each `text` body must satisfy both caps: at most 6 lines
+  and at most 240 characters. Exceeding either cap is evidence of
+  regeneration. If you need a larger patch, abort with `<fixes></fixes>` and
+  let the next gate iteration handle it.
 - Patch only this artifact. Do not mention or modify unrelated files.
+
+## Anti-Pattern: m20 Build #1 Regeneration
+
+WRONG (regeneration):
+
+```yaml
+- find: |
+    - id: act-7
+      ...existing block...
+  replace: |
+    - id: act-7
+      ...rewritten block...
+    - id: act-8           # FORBIDDEN: brand-new entry
+      type: true-false
+      ...
+```
+
+RIGHT (additive via `insert_after`):
+
+```yaml
+- insert_after: |
+    # last item of an existing activity's `items:` list
+  text: |
+    - left: foo
+      right: bar
+```
 
 ## Module Context
 

--- a/scripts/build/phases/linear-correction-wiki-coverage.md
+++ b/scripts/build/phases/linear-correction-wiki-coverage.md
@@ -14,6 +14,21 @@ the smallest local changes that satisfy the supplied proposals.
 
 Return exactly one `<fixes>` block and nothing else.
 
+You may emit ONLY these two fix shapes inside `<fixes>...</fixes>`
+(XML or YAML, no other content):
+
+- `<fix><find>...</find><replace>...</replace></fix>` - local textual
+  find/replace.
+- `<fix><insert_after>...</insert_after><text>...</text></fix>` - inserts
+  AFTER an existing anchor.
+
+You MUST NOT:
+
+- Regenerate full activity blocks (`- id: act-N` with multiple keys).
+- Add new top-level activity entries.
+- Rewrite multi-line YAML structures.
+- Output any Markdown, prose, or YAML outside `<fixes>`.
+
 Allowed XML form:
 
 ```xml
@@ -25,6 +40,17 @@ Allowed XML form:
 </fixes>
 ```
 
+Allowed XML insert form:
+
+```xml
+<fixes>
+  <fix obligation_id="err-1">
+    <insert_after>exact existing anchor text</insert_after>
+    <text>small inserted text</text>
+  </fix>
+</fixes>
+```
+
 Allowed YAML-list form:
 
 ```yaml
@@ -32,6 +58,16 @@ Allowed YAML-list form:
 - obligation_id: err-1
   find: exact text currently present in the artifact
   replace: small corrected text
+</fixes>
+```
+
+Allowed YAML insert form:
+
+```yaml
+<fixes>
+- obligation_id: err-1
+  insert_after: exact existing anchor text
+  text: small inserted text
 </fixes>
 ```
 
@@ -49,8 +85,37 @@ artifact. No section rewrite. Strictly follow ADR-007:
 - Use `manifest_payload` values verbatim. For example, if the proposal says
   `incorrect: Я прокидаєшся.` and `correct: Я прокидаюся.`, the replacement
   must contain those strings exactly.
-- No single `replace` value may exceed 600 characters.
+- Each `replace` and each `text` body must satisfy both caps: at most 6 lines
+  and at most 240 characters. Exceeding either cap is evidence of
+  regeneration. If you need a larger patch, abort with `<fixes></fixes>` and
+  let the next gate iteration handle it.
 - Patch only this artifact. Do not mention or modify unrelated files.
+
+## Anti-Pattern: m20 Build #1 Regeneration
+
+WRONG (regeneration):
+
+```yaml
+- find: |
+    - id: act-7
+      ...existing block...
+  replace: |
+    - id: act-7
+      ...rewritten block...
+    - id: act-8           # FORBIDDEN: brand-new entry
+      type: true-false
+      ...
+```
+
+RIGHT (additive via `insert_after`):
+
+```yaml
+- insert_after: |
+    # last item of an existing activity's `items:` list
+  text: |
+    - left: foo
+      right: bar
+```
 
 ## Module Context
 

--- a/tests/build/test_wiki_coverage_correction_yaml_guard.py
+++ b/tests/build/test_wiki_coverage_correction_yaml_guard.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.build import linear_pipeline
+
+VALID_ACTIVITIES = """\
+- id: act-1
+  type: error-correction
+  items:
+  - sentence: Я прокидаюся.
+    error: прокидаєшся
+    correction: прокидаюся
+"""
+
+
+def _sink(events: list[dict[str, Any]]):
+    def append(event: str, **fields: Any) -> None:
+        events.append({"event": event, **fields})
+
+    return append
+
+
+def _events(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text("utf-8").splitlines()]
+
+
+def test_oversize_replace_rejected_and_event_emitted() -> None:
+    body = "\n".join(f"line {index}" for index in range(10))
+    fixes = [{"find": "old", "replace": body}]
+
+    accepted, rejected = linear_pipeline._validate_reviewer_fix_shapes(fixes)
+    events: list[dict[str, Any]] = []
+    linear_pipeline._emit_reviewer_fix_oversize_rejections(
+        rejected,
+        gate="wiki_coverage_gate",
+        group_key="(artifact=activities.yaml, obligation_type=l2_error)",
+        event_sink=_sink(events),
+    )
+
+    assert accepted == []
+    assert rejected == fixes
+    assert events == [
+        {
+            "event": "reviewer_fix_oversize_rejected",
+            "gate": "wiki_coverage_gate",
+            "group_key": "(artifact=activities.yaml, obligation_type=l2_error)",
+            "body_field": "replace",
+            "body_len": len(body),
+            "line_count": 10,
+            "body_preview": body,
+        }
+    ]
+
+
+def test_oversize_insert_text_rejected_and_event_emitted() -> None:
+    body = "x" * 241
+    fixes = [{"insert_after": "anchor", "text": body}]
+
+    accepted, rejected = linear_pipeline._validate_reviewer_fix_shapes(fixes)
+    events: list[dict[str, Any]] = []
+    linear_pipeline._emit_reviewer_fix_oversize_rejections(
+        rejected,
+        gate="wiki_coverage_gate",
+        group_key="group",
+        event_sink=_sink(events),
+    )
+
+    assert accepted == []
+    assert rejected == fixes
+    assert events[0]["event"] == "reviewer_fix_oversize_rejected"
+    assert events[0]["body_field"] == "text"
+    assert events[0]["body_len"] == 241
+    assert events[0]["line_count"] == 1
+
+
+def test_within_limit_fix_accepted() -> None:
+    fixes = [{"find": "old", "replace": "line 1\nline 2\nline 3"}]
+
+    accepted, rejected = linear_pipeline._validate_reviewer_fix_shapes(fixes)
+
+    assert accepted == fixes
+    assert rejected == []
+
+
+def test_activities_yaml_m20_pronunciation_scalar_raises() -> None:
+    malformed = """\
+- id: act-1
+  type: error-correction
+  items:
+  - sentence: Вимова: [прокидайешся]
+    error: Вимова: [прокидайешся]
+    correction: Вимова: [прокидайес':а]
+"""
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="invalid YAML"):
+        linear_pipeline._validate_wiki_coverage_artifact_text(
+            "activities.yaml",
+            malformed,
+        )
+
+
+def test_activities_yaml_valid_shape_passes() -> None:
+    linear_pipeline._validate_wiki_coverage_artifact_text(
+        "activities.yaml",
+        VALID_ACTIVITIES,
+    )
+
+
+def test_round_trip_mismatch_raises() -> None:
+    non_portable = """\
+- id: act-1
+  type: select
+  notes: !!omap
+  - a: 1
+  - b: 2
+"""
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="round-trip"):
+        linear_pipeline._validate_wiki_coverage_artifact_text(
+            "activities.yaml",
+            non_portable,
+        )
+
+
+def test_apply_wiki_coverage_fixes_rejects_oversize_and_preserves_artifact(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "activities.yaml"
+    artifact_path.write_text(VALID_ACTIVITIES, encoding="utf-8")
+    oversize = "\n".join(f"- id: act-{index}" for index in range(10))
+    events: list[dict[str, Any]] = []
+
+    applied = linear_pipeline._apply_wiki_coverage_fixes(
+        module_dir=tmp_path,
+        artifact="activities.yaml",
+        fixes=[{"find": VALID_ACTIVITIES, "replace": oversize}],
+        phase="batched",
+        iteration=1,
+        event_sink=_sink(events),
+        group_key="(artifact=activities.yaml, obligation_type=l2_error)",
+    )
+
+    assert applied == 0
+    assert artifact_path.read_text(encoding="utf-8") == VALID_ACTIVITIES
+    assert events[0]["event"] == "reviewer_fix_oversize_rejected"
+    assert events[0]["gate"] == "wiki_coverage_gate"
+    assert events[0]["line_count"] == 10
+
+
+def test_apply_wiki_coverage_fixes_valid_fix_applies_and_validates(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "activities.yaml"
+    artifact_path.write_text(VALID_ACTIVITIES, encoding="utf-8")
+    events: list[dict[str, Any]] = []
+
+    applied = linear_pipeline._apply_wiki_coverage_fixes(
+        module_dir=tmp_path,
+        artifact="activities.yaml",
+        fixes=[
+            {
+                "find": "  - sentence: Я прокидаюся.\n",
+                "replace": "  - sentence: Я прокидаюся зараз.\n",
+            }
+        ],
+        phase="batched",
+        iteration=1,
+        event_sink=_sink(events),
+        group_key="(artifact=activities.yaml, obligation_type=l2_error)",
+    )
+
+    assert applied == 1
+    assert "Я прокидаюся зараз." in artifact_path.read_text(encoding="utf-8")
+    assert events[-1]["event"] == "wiki_coverage_correction_fixes_applied"
+
+
+def test_python_qg_reviewer_correction_rejects_oversize_fix(
+    tmp_path: Path,
+) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    module_path = module_dir / "module.md"
+    module_path.write_text("Anchor sentence.\n", encoding="utf-8")
+    telemetry = tmp_path / "events.jsonl"
+    oversize = "\n".join(f"line {index}" for index in range(10))
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        changed, unmatched = linear_pipeline._apply_python_qg_correction(
+            "l2_exposure_floor",
+            {"gates": {"l2_exposure_floor": {"passed": False}}},
+            module_dir=module_dir,
+            plan_path=tmp_path / "plan.yaml",
+            writer_corrector=None,
+            reviewer_corrector=lambda _context: (
+                "<fixes><fix><find>Anchor sentence.</find>"
+                f"<replace>{oversize}</replace></fix></fixes>"
+            ),
+            dictionary_lookup_fn=None,
+            writer="claude-tools",
+            invoker=None,
+        )
+
+    assert changed is True
+    assert unmatched == frozenset()
+    assert module_path.read_text(encoding="utf-8") == "Anchor sentence.\n"
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == ["reviewer_fix_oversize_rejected"]
+    assert events[0]["gate"] == "l2_exposure_floor"


### PR DESCRIPTION
## Summary

Fixes #2127 by hardening both sides of the PR3 correction loop:

- Tightens `linear-correction-wiki-coverage*.md` so correctors may emit only `find`/`replace` or `insert_after`/`text` fixes inside `<fixes>`, with each `replace`/`text` body capped at 6 lines and 240 characters.
- Adds `_validate_reviewer_fix_shapes` and emits `reviewer_fix_oversize_rejected` before applying oversize reviewer fixes in both wiki coverage and Python-QG reviewer correction paths.
- Hardens `_validate_wiki_coverage_artifact_text` so YAML parser failures become `LinearPipelineError`, YAML list artifacts round-trip cleanly, activities/vocabulary/resources keep required top-level fields, and error-correction items keep required mapping shape.
- Adds focused regression tests and a Path 3 documentation note for corrector contract enforcement.

## Verifiable Claims

Prompt update raw diff check:

```text
git diff origin/main -- scripts/build/phases/linear-correction-wiki-coverage*.md
+You may emit ONLY these two fix shapes inside `<fixes>...</fixes>`
+- Each `replace` and each `text` body must satisfy both caps: at most 6 lines
+## Anti-Pattern: m20 Build #1 Regeneration
```

Pipeline diff check:

```text
git diff origin/main -- scripts/build/linear_pipeline.py
+def _validate_reviewer_fix_shapes(
+            "reviewer_fix_oversize_rejected",
+def _validate_wiki_coverage_artifact_text(artifact: str, text: str) -> None:
+        redumped = yaml.safe_dump(parsed, allow_unicode=True, sort_keys=False)
+        reparsed = yaml.safe_load(redumped)
+            _validate_wiki_coverage_artifact_text(module_path.name, result.text)
```

Focused tests:

```text
.venv/bin/pytest tests/build/test_wiki_coverage_correction_yaml_guard.py -v
============================== 9 passed in 0.30s ===============================
```

Existing build/audit/wiki pipeline subset:

```text
.venv/bin/pytest tests/build/ tests/audit/ tests/test_linear_pipeline_wiki_coverage.py -q
======================= 637 passed, 25 skipped in 6.91s ========================
```

Full suite attempt, no `-x`:

```text
.venv/bin/pytest tests/ -q
= 10 failed, 7905 passed, 218 skipped, 11 xfailed, 3 warnings in 490.94s (0:08:10) =
```

Full-suite failure note: the failures are unrelated local data/env tests (`test_channels_registry`, ESUM data-content assertions, monitor telemetry with `AGENT_NO_TELEMETRY_FOOTER=1`, missing/fixture-dependent literary/textbook/wiki data, and MLX embed worker setup). After linking ignored local data fixtures, the focused failed-test rerun reduced to 6 unrelated failures in ESUM data-content, monitor telemetry env, and textbook source fixtures.

Ruff:

```text
.venv/bin/ruff check scripts/build/linear_pipeline.py scripts/build/phases/ tests/build/
All checks passed!
```

Pre-commit:

```text
.venv/bin/python -m pre_commit run --files scripts/build/linear_pipeline.py scripts/build/phases/linear-correction-wiki-coverage.md scripts/build/phases/linear-correction-wiki-coverage-narrow.md tests/build/test_wiki_coverage_correction_yaml_guard.py docs/decisions/2026-05-17-path3-per-obligation-review-loop.md
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
block .yaml.bak / .yaml.orig files.......................................Passed
block bare python/python3 in new scripts.................................Passed
lesson schema drift gate.............................(no files to check)Skipped
dispatch brief .venv worktree guardrail..............(no files to check)Skipped
lint session-state env references....................(no files to check)Skipped
```

m20 replay:

```text
GOOD: broken caught: activities.yaml invalid YAML: mapping values are not allowed here
  in "<unicode string>", line 214, column 21:
      - sentence: Вимова: [прокидайешся]
                        ^
GOOD: clean file passed validator
```

Diff stat:

```text
git diff --stat origin/main
 .../2026-05-17-path3-per-obligation-review-loop.md |  16 ++
 scripts/build/linear_pipeline.py                   | 181 ++++++++++++++++-
 .../linear-correction-wiki-coverage-narrow.md      |  67 ++++++-
 .../phases/linear-correction-wiki-coverage.md      |  67 ++++++-
 .../test_wiki_coverage_correction_yaml_guard.py    | 213 +++++++++++++++++++++
 5 files changed, 533 insertions(+), 11 deletions(-)
```

Trailer audit:

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```