### PR TITLE
fix(gate): wiki_coverage_gate dispatches decolonization_ban by subtype (substance vs absence) — closes #2155

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -151,9 +151,14 @@ def check_wiki_coverage(
     }
     activities = _load_activity_items(activities_yaml)
     obligation_results: list[dict[str, Any]] = []
+    seeded_index = _seeded_obligation_index(seeded_map)
 
     for obligation in validate_obligations(manifest):
         obligation_id = str(obligation.get("id") or "")
+        obligation = _enrich_obligation_from_seeded_map(
+            obligation,
+            seeded_index.get(obligation_id),
+        )
         claim = map_entries.get(obligation_id)
         if not claim:
             obligation_results.append(_result(obligation, "FAIL", "implementation_map_missing", evidence_text=""))
@@ -201,7 +206,6 @@ def check_wiki_coverage(
         "obligations": [_public_obligation_result(item) for item in obligation_results],
     }
     if not passed:
-        seeded_index = _seeded_obligation_index(seeded_map)
         report["fix_proposals"] = [
             _build_fix_proposal(
                 result,
@@ -212,6 +216,19 @@ def check_wiki_coverage(
             if result["status"] == "FAIL"
         ]
     return report
+
+
+def _enrich_obligation_from_seeded_map(
+    obligation: Mapping[str, Any],
+    seeded_entry: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    enriched = dict(obligation)
+    if enriched.get("subtype") or not seeded_entry:
+        return enriched
+    subtype = str(seeded_entry.get("subtype") or "")
+    if subtype in {"substance_required", "absence_required"}:
+        enriched["subtype"] = subtype
+    return enriched
 
 
 def check_wiki_coverage_paths(
@@ -352,8 +369,8 @@ def _surgical_diff_hint(
             f"({payload.get('heading')!r}); required_claim: {payload.get('required_claim')!r}"
         ),
         "ban_substance_missing": (
-            f"Remove phrasing matching manifest_payload.rule ({payload.get('rule')!r}) "
-            "- negative obligation: absence required"
+            f"Add prose implementing the lexical substitution substance in manifest_payload.rule "
+            f"({payload.get('rule')!r})"
         ),
         "unknown_obligation_type": (
             f"Unknown obligation type {obligation_result.get('type')!r} "
@@ -521,10 +538,15 @@ def _check_obligation_text(obligation: Mapping[str, Any], target_text: str, arti
         return "FAIL", "sequence_claim_missing"
 
     if obligation_type == "decolonization_ban":
-        rule = str(obligation.get("rule") or "")
-        if _claim_markers_present(rule, target_text):
-            return "PASS", "ban_substance_present"
-        return "FAIL", "ban_substance_missing"
+        subtype = str(obligation.get("subtype") or "substance_required")
+        if subtype == "substance_required":
+            rule = str(obligation.get("rule") or "")
+            if _claim_markers_present(rule, target_text):
+                return "PASS", "ban_substance_present"
+            return "FAIL", "ban_substance_missing"
+        # Arbitrary prose prohibitions cannot be affirmatively verified here;
+        # concrete violations belong to the russianism/shadow gates.
+        return "PASS", "absence_obligation_assumed_satisfied"
 
     return "FAIL", "unknown_obligation_type"
 
@@ -561,6 +583,8 @@ def _result(
                 "example_pairs_required": bool(example_pairs),
             }
         )
+    if obligation_type == "decolonization_ban" and obligation.get("subtype"):
+        result["subtype"] = str(obligation.get("subtype"))
     return result
 
 

--- a/scripts/build/phases/implementation_map.py
+++ b/scripts/build/phases/implementation_map.py
@@ -64,6 +64,16 @@ IMPLEMENTATION_MAP_SCHEMA: dict[str, Any] = {
                         "enum": ["substance_required", "absence_required"],
                     },
                 },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {"obligation_type": {"const": "decolonization_ban"}},
+                            "required": ["obligation_type"],
+                        },
+                        "then": {},
+                        "else": {"not": {"required": ["subtype"]}},
+                    }
+                ],
                 "additionalProperties": False,
             },
         },
@@ -124,12 +134,22 @@ _GUILLEMET_SLASH_PAIR_RE = re.compile(
     rf"{_GUILLEMET_TERM}\s*/\s*{_GUILLEMET_TERM}",
     re.IGNORECASE,
 )
+_GUILLEMET_A_NOT_B_PAIR_RE = re.compile(
+    rf"{_GUILLEMET_TERM}\s*(?:[,—-]\s*)?(?:а\s+)?не\s+{_GUILLEMET_TERM}",
+    re.IGNORECASE,
+)
 _GUILLEMET_MARKED_CALQUE_RE = re.compile(
-    rf"{_GUILLEMET_TERM}[^.?!\n]{{0,80}}\(\s*(?:калька|русизм|суржик)\s*\)",
+    rf"{_GUILLEMET_TERM}[^.?!\n]{{0,80}}\([^)\n]{{0,80}}(?:калька|русизм|суржик)[^)\n]{{0,80}}\)",
     re.IGNORECASE,
 )
 _EXPLICIT_SUBSTITUTION_RE = re.compile(
     rf"(?:{_GUILLEMET_TERM}|[\w'’ʼ-]{{2,}})\s+замість\s+"
+    rf"(?:{_GUILLEMET_TERM}|[\w'’ʼ-]{{2,}})",
+    re.IGNORECASE | re.UNICODE,
+)
+_EXPLICIT_REPLACEMENT_RE = re.compile(
+    rf"(?:заміню(?:ємо|йте|ють|ється|ються)|замінити)\s+"
+    rf"(?:{_GUILLEMET_TERM}|[\w'’ʼ-]{{2,}})\s+на\s+"
     rf"(?:{_GUILLEMET_TERM}|[\w'’ʼ-]{{2,}})",
     re.IGNORECASE | re.UNICODE,
 )
@@ -150,9 +170,13 @@ def classify_decolonization_ban_subtype(
         return "substance_required"
     if _GUILLEMET_SLASH_PAIR_RE.search(rule):
         return "substance_required"
+    if _GUILLEMET_A_NOT_B_PAIR_RE.search(rule):
+        return "substance_required"
     if _GUILLEMET_MARKED_CALQUE_RE.search(rule):
         return "substance_required"
     if _EXPLICIT_SUBSTITUTION_RE.search(rule):
+        return "substance_required"
+    if _EXPLICIT_REPLACEMENT_RE.search(rule):
         return "substance_required"
     return "absence_required"
 

--- a/scripts/build/phases/implementation_map.py
+++ b/scripts/build/phases/implementation_map.py
@@ -7,7 +7,7 @@ import json
 import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 ObligationType = Literal[
     "sequence_step",
@@ -16,6 +16,7 @@ ObligationType = Literal[
     "decolonization_ban",
 ]
 Artifact = Literal["module.md", "activities.yaml"]
+DecolonizationBanSubtype = Literal["substance_required", "absence_required"]
 
 OBLIGATION_GROUPS: tuple[tuple[str, ObligationType], ...] = (
     ("sequence_steps", "sequence_step"),
@@ -59,6 +60,9 @@ IMPLEMENTATION_MAP_SCHEMA: dict[str, Any] = {
                     "location_hint": {"type": "string"},
                     "treatment_template": {"type": "object"},
                     "manifest_payload": {"type": "object"},
+                    "subtype": {
+                        "enum": ["substance_required", "absence_required"],
+                    },
                 },
                 "additionalProperties": False,
             },
@@ -108,6 +112,49 @@ class ImplementationMapEntry(TypedDict):
     location_hint: str
     treatment_template: dict[str, Any]
     manifest_payload: dict[str, Any]
+    subtype: NotRequired[DecolonizationBanSubtype]
+
+
+_GUILLEMET_TERM = r"«[^»\n]{1,120}»"
+_GUILLEMET_NEGATED_PAIR_RE = re.compile(
+    rf"{_GUILLEMET_TERM}\s*\(\s*не\s+{_GUILLEMET_TERM}\s*\)",
+    re.IGNORECASE,
+)
+_GUILLEMET_SLASH_PAIR_RE = re.compile(
+    rf"{_GUILLEMET_TERM}\s*/\s*{_GUILLEMET_TERM}",
+    re.IGNORECASE,
+)
+_GUILLEMET_MARKED_CALQUE_RE = re.compile(
+    rf"{_GUILLEMET_TERM}[^.?!\n]{{0,80}}\(\s*(?:калька|русизм|суржик)\s*\)",
+    re.IGNORECASE,
+)
+_EXPLICIT_SUBSTITUTION_RE = re.compile(
+    rf"(?:{_GUILLEMET_TERM}|[\w'’ʼ-]{{2,}})\s+замість\s+"
+    rf"(?:{_GUILLEMET_TERM}|[\w'’ʼ-]{{2,}})",
+    re.IGNORECASE | re.UNICODE,
+)
+
+
+def classify_decolonization_ban_subtype(
+    rule_or_obligation: str | Mapping[str, Any],
+) -> DecolonizationBanSubtype:
+    """Classify a decolonization ban by whether it carries checkable substance."""
+    rule = (
+        str(rule_or_obligation.get("rule") or "")
+        if isinstance(rule_or_obligation, Mapping)
+        else str(rule_or_obligation or "")
+    )
+    if not rule.strip():
+        return "absence_required"
+    if _GUILLEMET_NEGATED_PAIR_RE.search(rule):
+        return "substance_required"
+    if _GUILLEMET_SLASH_PAIR_RE.search(rule):
+        return "substance_required"
+    if _GUILLEMET_MARKED_CALQUE_RE.search(rule):
+        return "substance_required"
+    if _EXPLICIT_SUBSTITUTION_RE.search(rule):
+        return "substance_required"
+    return "absence_required"
 
 
 def seed_implementation_map(
@@ -119,16 +166,17 @@ def seed_implementation_map(
     entries: list[ImplementationMapEntry] = []
     for obligation_type, manifest_payload in _iter_manifest_obligations(manifest):
         artifact = _artifact_for(obligation_type, manifest_payload)
-        entries.append(
-            {
-                "obligation_id": str(manifest_payload.get("id") or ""),
-                "obligation_type": obligation_type,
-                "artifact": artifact,
-                "location_hint": _location_hint(obligation_type, manifest_payload, artifact, plan),
-                "treatment_template": _treatment_template(obligation_type, manifest_payload),
-                "manifest_payload": manifest_payload,
-            }
-        )
+        entry: ImplementationMapEntry = {
+            "obligation_id": str(manifest_payload.get("id") or ""),
+            "obligation_type": obligation_type,
+            "artifact": artifact,
+            "location_hint": _location_hint(obligation_type, manifest_payload, artifact, plan),
+            "treatment_template": _treatment_template(obligation_type, manifest_payload),
+            "manifest_payload": manifest_payload,
+        }
+        if obligation_type == "decolonization_ban":
+            entry["subtype"] = classify_decolonization_ban_subtype(manifest_payload)
+        entries.append(entry)
 
     payload = {
         "schema_version": 1,
@@ -304,7 +352,8 @@ def _validate_entry(index: int, entry: Any) -> None:
     if missing:
         raise ValueError(f"implementation_map entries[{index}] missing required keys: {', '.join(missing)}")
 
-    extra = sorted(set(entry).difference(required))
+    allowed = set(IMPLEMENTATION_MAP_SCHEMA["properties"]["entries"]["items"]["properties"])
+    extra = sorted(set(entry).difference(allowed))
     if extra:
         raise ValueError(f"implementation_map entries[{index}] has unexpected keys: {', '.join(extra)}")
 
@@ -329,6 +378,12 @@ def _validate_entry(index: int, entry: Any) -> None:
         raise ValueError(f"implementation_map entries[{index}] manifest_payload must be an object")
     if manifest_payload.get("id") != obligation_id:
         raise ValueError(f"implementation_map entries[{index}] obligation_id must match manifest_payload.id")
+    subtype = entry.get("subtype")
+    if subtype is not None:
+        if obligation_type != "decolonization_ban":
+            raise ValueError(f"implementation_map entries[{index}] subtype is only valid for decolonization_ban")
+        if subtype not in {"substance_required", "absence_required"}:
+            raise ValueError(f"implementation_map entries[{index}] has invalid subtype: {subtype}")
 
 
 def render_for_writer_prompt(payload: dict[str, Any]) -> str:
@@ -342,9 +397,11 @@ def render_for_writer_prompt(payload: dict[str, Any]) -> str:
                 f"(obligation_type: {entry['obligation_type']})",
                 f"  artifact: {entry['artifact']}",
                 f"  location_hint: {entry['location_hint']}",
-                "  treatment_template:",
             ]
         )
+        if entry.get("subtype"):
+            rows.append(f"  subtype: {entry['subtype']}")
+        rows.append("  treatment_template:")
         for key, value in sorted(entry["treatment_template"].items()):
             rows.append(f"    {key}: {_render_template_value(value)}")
     body = "\n".join(rows)

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.audit.wiki_coverage_gate import check_wiki_coverage
+from scripts.build.phases.implementation_map import seed_implementation_map
+
+BAN_1_RULE = (
+    "При викладанні теми «Мій ранок» та семантики зворотних дієслів категорично заборонено "
+    "використовувати будь-які російськомовні пояснення, паралелі чи фонетичні порівняння. "
+    "Це абсолютна вимога деколонізованої педагогіки [S9]."
+)
+BAN_4_RULE = (
+    "У лексичному наповненні теми ранкової рутини слід рішуче відкидати русизми, суржик "
+    "та кальки, які можуть випадково просочитися в тексти. Слід суворо контролювати чистоту "
+    "словника: використовуємо виключно «рушник» (не «полотенце»), «сніданок» (не «завтрак»), "
+    "«одягатися» (не «одіватися») [S2, S3]. Процес навчання має занурювати студента в "
+    "автентичний простір, де панує українська мова без сторонніх домішок [S3]. Будь-які "
+    "конструкції, що вказують на вік, на кшталт «Я маю N років» (калька) беззастережно "
+    "замінюються на питомо українські: «Мені N років» [S8, S9]."
+)
+
+
+def _ban_manifest(rule: str) -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [
+            {
+                "id": "ban-1",
+                "rule": rule,
+                "source_lines": "50",
+            }
+        ],
+        "external_resources": [],
+    }
+
+
+def _claim() -> dict[str, dict[str, str]]:
+    return {
+        "ban-1": {
+            "artifact": "module.md",
+            "location": "whole file",
+            "treatment": "decolonization ban treatment",
+        }
+    }
+
+
+def _ban_result(report: dict[str, Any]) -> dict[str, Any]:
+    return next(item for item in report["obligations"] if item["obligation_id"] == "ban-1")
+
+
+def test_decolonization_ban_substance_required_passes_when_pair_present() -> None:
+    manifest = _ban_manifest(BAN_4_RULE)
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=_claim(),
+        module_md=(
+            "Use «рушник» (не «полотенце»), «сніданок» (не «завтрак»), "
+            "and «одягатися» (не «одіватися»). Prefer «Мені N років» over "
+            "the calque «Я маю N років»."
+        ),
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    result = _ban_result(report)
+    assert report["passed"] is True
+    assert result["status"] == "PASS"
+    assert result["reason"] == "ban_substance_present"
+    assert result["subtype"] == "substance_required"
+
+
+def test_decolonization_ban_substance_required_fails_when_pair_missing() -> None:
+    manifest = _ban_manifest(BAN_4_RULE)
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=_claim(),
+        module_md="This paragraph is present but does not include the lexical substitutions.",
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    result = _ban_result(report)
+    assert report["passed"] is False
+    assert result["status"] == "FAIL"
+    assert result["reason"] == "ban_substance_missing"
+    assert result["subtype"] == "substance_required"
+
+
+def test_decolonization_ban_absence_required_passes_automatically() -> None:
+    manifest = _ban_manifest(BAN_1_RULE)
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=_claim(),
+        module_md="This module teaches the Ukrainian morning routine with Ukrainian-only framing.",
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    result = _ban_result(report)
+    assert report["passed"] is True
+    assert result["status"] == "PASS"
+    assert result["reason"] == "absence_obligation_assumed_satisfied"
+    assert result["subtype"] == "absence_required"
+
+
+def test_decolonization_ban_legacy_manifest_without_subtype_field() -> None:
+    manifest = _ban_manifest(BAN_1_RULE)
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=_claim(),
+        module_md="This module avoids the prohibited framing.",
+        activities_yaml="[]",
+    )
+
+    result = _ban_result(report)
+    assert report["passed"] is False
+    assert result["status"] == "FAIL"
+    assert result["reason"] == "ban_substance_missing"
+    assert "subtype" not in result

--- a/tests/audit/test_wiki_coverage_gate_fix_proposals.py
+++ b/tests/audit/test_wiki_coverage_gate_fix_proposals.py
@@ -373,6 +373,7 @@ def test_sequence_claim_missing_quotes_heading_and_required_claim() -> None:
 
 def test_ban_substance_missing_quotes_seeded_rule() -> None:
     manifest = _ban_manifest()
+    manifest["decolonization_bans"][0]["rule"] = "Use «рушник» (не «полотенце»)."
 
     report = check_wiki_coverage(
         manifest=manifest,
@@ -384,8 +385,8 @@ def test_ban_substance_missing_quotes_seeded_rule() -> None:
 
     proposal = _single_proposal(report)
     assert proposal["failure_reason"] == "ban_substance_missing"
-    assert "manifest_payload.rule ('Do not frame Ukrainian as a dialect.')" in proposal["surgical_diff_hint"]
-    assert "negative obligation: absence required" in proposal["surgical_diff_hint"]
+    assert "manifest_payload.rule ('Use «рушник» (не «полотенце»).')" in proposal["surgical_diff_hint"]
+    assert "lexical substitution substance" in proposal["surgical_diff_hint"]
 
 
 def test_unknown_obligation_type_proposal_names_seeder_bug() -> None:

--- a/tests/build/test_implementation_map.py
+++ b/tests/build/test_implementation_map.py
@@ -4,8 +4,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+import jsonschema
+
 from scripts.audit.wiki_coverage_gate import validate_obligations
 from scripts.build.phases.implementation_map import (
+    IMPLEMENTATION_MAP_SCHEMA,
     classify_decolonization_ban_subtype,
     read_implementation_map,
     seed_implementation_map,
@@ -201,6 +204,18 @@ def test_json_schema_validates_seeded_output() -> None:
     validate_implementation_map(seed_implementation_map(_fixture_manifest()))
 
 
+def test_json_schema_allows_subtype_only_for_decolonization_bans() -> None:
+    payload = seed_implementation_map(_fixture_manifest())
+    validator = jsonschema.Draft7Validator(IMPLEMENTATION_MAP_SCHEMA)
+
+    assert list(validator.iter_errors(payload)) == []
+
+    invalid_payload = json.loads(json.dumps(payload, ensure_ascii=False))
+    invalid_payload["entries"][0]["subtype"] = "absence_required"
+
+    assert list(validator.iter_errors(invalid_payload))
+
+
 def test_write_read_round_trip_identity(tmp_path: Path) -> None:
     payload = seed_implementation_map(_fixture_manifest())
     path = tmp_path / "implementation_map.json"
@@ -301,6 +316,17 @@ def test_classify_ban_edge_case_mixed_prose_and_pair() -> None:
     )
 
     assert classify_decolonization_ban_subtype(rule) == "substance_required"
+
+
+def test_classify_ban_edge_case_variant_substitution_phrasings() -> None:
+    rules = [
+        "Не лишайте «полотенце» (це русизм) у лексиці ранкової рутини.",
+        "Пояснюйте як українську норму: «рушник», а не «полотенце».",
+        "У вправах замінюємо «одіватися» на «одягатися».",
+    ]
+
+    for rule in rules:
+        assert classify_decolonization_ban_subtype(rule) == "substance_required"
 
 
 def test_seed_stamps_decolonization_ban_subtype() -> None:

--- a/tests/build/test_implementation_map.py
+++ b/tests/build/test_implementation_map.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from scripts.audit.wiki_coverage_gate import validate_obligations
 from scripts.build.phases.implementation_map import (
+    classify_decolonization_ban_subtype,
     read_implementation_map,
     seed_implementation_map,
     validate_implementation_map,
@@ -14,6 +15,34 @@ from scripts.build.phases.implementation_map import (
 from scripts.build.phases.wiki_manifest import extract_manifest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+M20_BAN_1_RULE = (
+    "При викладанні теми «Мій ранок» та семантики зворотних дієслів категорично заборонено "
+    "використовувати будь-які російськомовні пояснення, паралелі чи фонетичні порівняння. "
+    "Це абсолютна вимога деколонізованої педагогіки [S9]."
+)
+M20_BAN_2_RULE = (
+    "Часто недосвідчені автори чи викладачі намагаються пояснити вимову українського "
+    "закінчення -ться як «схоже на російське -тся», що є грубим порушенням. Учень має "
+    "вибудовувати українські фонетичні категорії з нуля, спираючись виключно на українські "
+    "правила асиміляції (звук [т] плюс звук [с] дають подовжений м'який [ц':а]) [S1, S9]. "
+    "Жодних відсилок до мови колонізатора бути не може."
+)
+M20_BAN_3_RULE = (
+    "Також слід уникати хибного тлумачення походження частки -ся. Вона не є «запозиченою» "
+    "чи «спільною з російською». Навпаки, глибоке питомо українське етимологічне коріння "
+    "цієї частки лежить у давній короткій формі зворотного займенника «себе» "
+    "(Знахідний відмінок однини: «Я ся не бою»), що чітко й досі фіксується в українських "
+    "карпатських діалектах та історичних текстах [S9]."
+)
+M20_BAN_4_RULE = (
+    "У лексичному наповненні теми ранкової рутини слід рішуче відкидати русизми, суржик "
+    "та кальки, які можуть випадково просочитися в тексти. Слід суворо контролювати чистоту "
+    "словника: використовуємо виключно «рушник» (не «полотенце»), «сніданок» (не «завтрак»), "
+    "«одягатися» (не «одіватися») [S2, S3]. Процес навчання має занурювати студента в "
+    "автентичний простір, де панує українська мова без сторонніх домішок [S3]. Будь-які "
+    "конструкції, що вказують на вік, на кшталт «Я маю N років» (калька) беззастережно "
+    "замінюються на питомо українські: «Мені N років» [S8, S9]."
+)
 
 
 def _fixture_manifest() -> dict[str, Any]:
@@ -250,3 +279,45 @@ def test_m20_real_world_manifest_seeds_gate_obligation_count() -> None:
 
     assert len(payload["entries"]) == len(gate_obligations)
     assert len(payload["entries"]) >= 10
+
+
+def test_classify_ban_substance_required_with_substitution_pairs() -> None:
+    assert classify_decolonization_ban_subtype(M20_BAN_4_RULE) == "substance_required"
+
+
+def test_classify_ban_absence_required_pure_prohibition() -> None:
+    for rule in (M20_BAN_1_RULE, M20_BAN_2_RULE, M20_BAN_3_RULE):
+        assert classify_decolonization_ban_subtype(rule) == "absence_required"
+
+
+def test_classify_ban_edge_case_empty_rule() -> None:
+    assert classify_decolonization_ban_subtype("") == "absence_required"
+
+
+def test_classify_ban_edge_case_mixed_prose_and_pair() -> None:
+    rule = (
+        "Не пояснюйте тему через мову колонізатора; натомість у словнику давайте "
+        "«рушник» (не «полотенце»)."
+    )
+
+    assert classify_decolonization_ban_subtype(rule) == "substance_required"
+
+
+def test_seed_stamps_decolonization_ban_subtype() -> None:
+    manifest = {
+        "slug": "fixture-module",
+        "wiki_path": "wiki/pedagogy/a1/fixture-module.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [
+            {"id": "ban-1", "rule": M20_BAN_1_RULE, "source_lines": "50"},
+            {"id": "ban-4", "rule": M20_BAN_4_RULE, "source_lines": "56"},
+        ],
+        "external_resources": [],
+    }
+
+    payload = seed_implementation_map(manifest)
+    subtypes = {entry["obligation_id"]: entry["subtype"] for entry in payload["entries"]}
+
+    assert subtypes == {"ban-1": "absence_required", "ban-4": "substance_required"}


### PR DESCRIPTION
## What this PR does

Closes #2155.

- Adds `classify_decolonization_ban_subtype()` for `decolonization_ban` rules. It treats guillemet lexical substitutions (`«рушник» (не «полотенце»)`, `«A»/«B»`, `«A», а не «B»`), calque/rusism/surzhyk markers, `замість` substitutions, and `замінюємо ... на ...` replacements as `substance_required`; otherwise bans default to `absence_required`.
- Stamps `subtype` into seeded `implementation_map.json` entries and renders it into the writer-visible implementation-map contract.
- Teaches `wiki_coverage_gate` to enrich manifest obligations from the seeded sidecar, dispatch substance-required bans through the existing marker check, and pass absence-required bans with `absence_obligation_assumed_satisfied`.
- Preserves backward compatibility: subtype-less legacy manifests still default to `substance_required`.
- Tightens the exported JSON schema so `subtype` is accepted only on `decolonization_ban` entries.

## Verifiable claims

| Claim | Command | Evidence |
| --- | --- | --- |
| Classifier function exists and is tested | `.venv/bin/pytest tests/build/test_implementation_map.py -k classify_ban -v` | `======================= 5 passed, 12 deselected in 0.27s =======================` |
| Gate subtype-dispatch works | `.venv/bin/pytest tests/audit/test_wiki_coverage_gate.py -k decolonization_ban -v` | `============================== 4 passed in 0.27s ===============================` |
| Full build/audit suite green | `.venv/bin/pytest tests/build tests/audit` | `======================= 652 passed, 25 skipped in 9.52s ========================` |
| Ruff clean | `.venv/bin/ruff check scripts/audit scripts/build tests` | `All checks passed!` |
| m20 replay shows 3 false-failures resolved | replay script in dispatch brief §D | Before `12/18`, `coverage_pct=0.6667`; after `15/18`, `coverage_pct=0.8333`; ban-1/2/3 now `PASS absence_obligation_assumed_satisfied` |
| ban-4 verdict unchanged | same replay | ban-4 before `PASS ban_substance_present`; after `PASS ban_substance_present` |
| X-Agent trailer valid | `.venv/bin/python scripts/audit/lint_agent_trailer.py` | `✅ All 2 non-skipped commit(s) carry an X-Agent trailer.` |
| Pre-commit passed | `git commit` | `✅ pre-commit passed` |

## m20 build #8 replay

Replay used the preserved build output at `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/builds/a1-my-morning-20260519-075852/curriculum/l2-uk-en/a1/my-morning`, the captured before report at `audit/2026-05-19-m20-build-8-gamma-results/wiki_coverage_gate_replay.json`, and a freshly seeded implementation map with the new subtype field.

| Metric | Before | After |
| --- | ---: | ---: |
| covered / total | 12 / 18 | 15 / 18 |
| coverage_pct | 0.6667 | 0.8333 |
| top-level passed | `false` | `false` |

| Obligation | Subtype | Before | After |
| --- | --- | --- | --- |
| ban-1 | `absence_required` | `FAIL ban_substance_missing` | `PASS absence_obligation_assumed_satisfied` |
| ban-2 | `absence_required` | `FAIL ban_substance_missing` | `PASS absence_obligation_assumed_satisfied` |
| ban-3 | `absence_required` | `FAIL ban_substance_missing` | `PASS absence_obligation_assumed_satisfied` |
| ban-4 | `substance_required` | `PASS ban_substance_present` | `PASS ban_substance_present` |

Note: under the current repo config, `WIKI_COVERAGE_HARD_FAIL=True`, so the replay report's top-level `passed` remains false while the three unrelated non-ban failures remain. This PR only fixes the #2155 ban-subtype false-failures and raises deterministic coverage from 66.67% to 83.33%.

## Review follow-up

GitHub's `review / review` workflow failed before code review because the runner has no Gemini auth env configured. I routed the independent Gemini review locally; it posted to this PR and found classifier/schema edge cases. The second commit addresses the concrete findings for marked calque/rusism parentheticals, `«A», а не «B»` pairs, `замінюємо ... на ...` replacements, and JSON schema subtype scoping.

## Scope checks

- Changed files: 5.
- No `.python-version`, `.yamllint`, or `.markdownlint.json` changes.
- No generated `status/*.json`, `audit/*-review.md`, `review/*-review.md`, or `docs/*-STATUS.md` files.
