### PR TITLE
feat(v7-preservation): ship run-archive wrapper

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3923,6 +3923,7 @@ def run_python_qg_with_corrections(
     """
     attempts: set[str] = set()
     vesum_missing_exclusions: set[str] = set()
+    correction_round = 0
 
     def _run_qg() -> dict[str, Any]:
         if qg_runner is not None:
@@ -3947,9 +3948,10 @@ def run_python_qg_with_corrections(
             )
             return report
         attempts.add(failed_gate)
+        correction_round += 1
 
         before = report
-        handled, unmatched_anchors = _apply_python_qg_correction(
+        handled, unmatched_anchors, correction_payload = _apply_python_qg_correction(
             failed_gate,
             report,
             module_dir=module_dir,
@@ -3961,6 +3963,16 @@ def run_python_qg_with_corrections(
             invoker=invoker,
         )
         if not handled:
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                {
+                    "round": correction_round,
+                    "gate": failed_gate,
+                    "handled": False,
+                    "before": before,
+                    "correction": correction_payload,
+                },
+            )
             _annotate_correction_terminal(
                 report,
                 failed_gate,
@@ -3973,6 +3985,16 @@ def run_python_qg_with_corrections(
         report = _run_qg()
         vesum_missing_exclusions.clear()
         regressions = _previously_passing_regressions(before, report)
+        correction_artifact: dict[str, Any] = {
+            "round": correction_round,
+            "gate": failed_gate,
+            "handled": True,
+            "unmatched_anchors": sorted(unmatched_anchors),
+            "before": before,
+            "correction": correction_payload,
+            "after": report,
+            "regressions": regressions,
+        }
         if regressions:
             gates = report.setdefault("gates", {})
             if isinstance(gates, dict):
@@ -3981,7 +4003,16 @@ def run_python_qg_with_corrections(
                     "regressions": regressions,
                 }
                 gates["passed"] = False
+            correction_artifact["after"] = report
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                correction_artifact,
+            )
             return report
+        _write_correction_artifact(
+            module_dir / f"python_qg_correction_r{correction_round}.json",
+            correction_artifact,
+        )
 
 
 def run_wiki_coverage_with_corrections(
@@ -4021,11 +4052,13 @@ def run_wiki_coverage_with_corrections(
 
     batched_attempts = 0
     narrow_attempts = 0
+    correction_round = 0
     for iteration in range(1, WIKI_COVERAGE_BATCH_MAX_ITERATIONS + 1):
         proposals = _wiki_coverage_fix_proposals(result)
         if not proposals:
             break
         batched_attempts = iteration
+        correction_round += 1
         coverage_before = _wiki_coverage_coverage_pct(result)
         groups = _wiki_coverage_grouped_fix_proposals(proposals, module_dir)
         _emit(
@@ -4042,6 +4075,7 @@ def run_wiki_coverage_with_corrections(
             iteration=iteration,
         )
         fixes_applied_total = 0
+        attempt_records: list[dict[str, Any]] = []
         for group in groups:
             artifact = str(group["artifact"])
             artifact_text = _read_required(module_dir / artifact)
@@ -4068,6 +4102,14 @@ def run_wiki_coverage_with_corrections(
                 artifact_text=artifact_text,
             )
             fixes = _parse_reviewer_fixes(response)
+            attempt_record: dict[str, Any] = {
+                "group_key": str(group["key"]),
+                "artifact": artifact,
+                "prompt": prompt,
+                "response": response,
+                "fixes": fixes,
+                "fixes_applied": 0,
+            }
             if not fixes:
                 _emit(
                     event_sink,
@@ -4077,8 +4119,10 @@ def run_wiki_coverage_with_corrections(
                     group_key=str(group["key"]),
                     response_preview=str(response or "")[:800],
                 )
+                attempt_record["status"] = "unparseable"
+                attempt_records.append(attempt_record)
                 continue
-            fixes_applied_total += _apply_wiki_coverage_fixes(
+            fixes_applied = _apply_wiki_coverage_fixes(
                 module_dir=module_dir,
                 artifact=artifact,
                 fixes=fixes,
@@ -4087,12 +4131,35 @@ def run_wiki_coverage_with_corrections(
                 event_sink=event_sink,
                 group_key=str(group["key"]),
             )
+            fixes_applied_total += fixes_applied
+            attempt_record["fixes_applied"] = fixes_applied
+            attempt_record["status"] = "applied" if fixes_applied else "no_applicable_fix"
+            attempt_records.append(attempt_record)
 
         after = _run_gate()
         coverage_after = _wiki_coverage_coverage_pct(after)
+        correction_payload: dict[str, Any] = {
+            "round": correction_round,
+            "phase": "batched",
+            "iteration": iteration,
+            "coverage_pct_before": coverage_before,
+            "coverage_pct_after": coverage_after,
+            "fail_count": len(proposals),
+            "fixes_applied_total": fixes_applied_total,
+            "groups_processed": len(groups),
+            "before": result,
+            "after": after,
+            "attempts": attempt_records,
+        }
         if coverage_after < coverage_before - 1e-6:
             _restore_wiki_coverage_artifacts(module_dir, backup_dir)
             result = _run_gate()
+            correction_payload["status"] = "regression"
+            correction_payload["restored"] = result
+            _write_correction_artifact(
+                module_dir / f"wiki_coverage_correction_r{correction_round}.json",
+                correction_payload,
+            )
             _emit(
                 event_sink,
                 "wiki_coverage_correction_regression",
@@ -4102,6 +4169,11 @@ def run_wiki_coverage_with_corrections(
                 coverage_pct_after=coverage_after,
             )
             break
+        correction_payload["status"] = "done"
+        _write_correction_artifact(
+            module_dir / f"wiki_coverage_correction_r{correction_round}.json",
+            correction_payload,
+        )
         _emit(
             event_sink,
             "wiki_coverage_correction_pass_done",
@@ -4124,6 +4196,7 @@ def run_wiki_coverage_with_corrections(
         if not proposals:
             break
         narrow_attempts = iteration
+        correction_round += 1
         coverage_before = _wiki_coverage_coverage_pct(result)
         _emit(
             event_sink,
@@ -4140,6 +4213,7 @@ def run_wiki_coverage_with_corrections(
         )
         fixes_applied_total = 0
         obligations_processed = 0
+        attempt_records = []
         for proposal in proposals:
             obligations_processed += 1
             artifact = _wiki_coverage_target_artifact(proposal, module_dir)
@@ -4165,6 +4239,14 @@ def run_wiki_coverage_with_corrections(
                 artifact_text=artifact_text,
             )
             fixes = _parse_reviewer_fixes(response)
+            attempt_record = {
+                "obligation_id": str(proposal.get("obligation_id") or ""),
+                "artifact": artifact,
+                "prompt": prompt,
+                "response": response,
+                "fixes": fixes,
+                "fixes_applied": 0,
+            }
             if not fixes:
                 _emit(
                     event_sink,
@@ -4174,8 +4256,10 @@ def run_wiki_coverage_with_corrections(
                     obligation_id=str(proposal.get("obligation_id") or ""),
                     response_preview=str(response or "")[:800],
                 )
+                attempt_record["status"] = "unparseable"
+                attempt_records.append(attempt_record)
                 continue
-            fixes_applied_total += _apply_wiki_coverage_fixes(
+            fixes_applied = _apply_wiki_coverage_fixes(
                 module_dir=module_dir,
                 artifact=artifact,
                 fixes=fixes,
@@ -4184,12 +4268,35 @@ def run_wiki_coverage_with_corrections(
                 event_sink=event_sink,
                 obligation_id=str(proposal.get("obligation_id") or ""),
             )
+            fixes_applied_total += fixes_applied
+            attempt_record["fixes_applied"] = fixes_applied
+            attempt_record["status"] = "applied" if fixes_applied else "no_applicable_fix"
+            attempt_records.append(attempt_record)
 
         after = _run_gate()
         coverage_after = _wiki_coverage_coverage_pct(after)
+        correction_payload = {
+            "round": correction_round,
+            "phase": "narrow",
+            "iteration": iteration,
+            "coverage_pct_before": coverage_before,
+            "coverage_pct_after": coverage_after,
+            "fail_count": len(proposals),
+            "fixes_applied_total": fixes_applied_total,
+            "obligations_processed": obligations_processed,
+            "before": result,
+            "after": after,
+            "attempts": attempt_records,
+        }
         if coverage_after < coverage_before - 1e-6:
             _restore_wiki_coverage_artifacts(module_dir, backup_dir)
             result = _run_gate()
+            correction_payload["status"] = "regression"
+            correction_payload["restored"] = result
+            _write_correction_artifact(
+                module_dir / f"wiki_coverage_correction_r{correction_round}.json",
+                correction_payload,
+            )
             _emit(
                 event_sink,
                 "wiki_coverage_correction_regression",
@@ -4199,6 +4306,11 @@ def run_wiki_coverage_with_corrections(
                 coverage_pct_after=coverage_after,
             )
             break
+        correction_payload["status"] = "done"
+        _write_correction_artifact(
+            module_dir / f"wiki_coverage_correction_r{correction_round}.json",
+            correction_payload,
+        )
         _emit(
             event_sink,
             "wiki_coverage_correction_pass_done",
@@ -4649,20 +4761,24 @@ def _apply_python_qg_correction(
     dictionary_lookup_fn: Callable[[str, str], list[str | Mapping[str, str]]] | None,
     writer: str,
     invoker: Callable[..., Any] | None,
-) -> tuple[bool, frozenset[str]]:
+) -> tuple[bool, frozenset[str], dict[str, Any]]:
     gates = qg_report.get("gates")
     if not isinstance(gates, Mapping):
-        return False, frozenset()
+        return False, frozenset(), {"reason": "missing gates mapping"}
     gate_report = gates.get(gate)
     if not isinstance(gate_report, Mapping):
-        return False, frozenset()
+        return False, frozenset(), {"reason": "missing gate report"}
     if gate in TERMINAL_ZERO_RETRY_GATES:
-        return False, frozenset()
+        return False, frozenset(), {"reason": "terminal zero-retry gate"}
     if gate in PIPELINE_INSERT_GATES:
         _apply_activity_id_inserts(module_dir / "module.md", gate_report)
-        return True, frozenset()
+        return True, frozenset(), {
+            "kind": "pipeline_insert",
+            "gate": gate,
+            "gate_report": dict(gate_report),
+        }
     if gate in WRITER_CORRECTION_GATES:
-        _apply_writer_correction(
+        payload = _apply_writer_correction(
             gate,
             gate_report,
             qg_report=qg_report,
@@ -4672,7 +4788,7 @@ def _apply_python_qg_correction(
             writer=writer,
             invoker=invoker,
         )
-        return True, frozenset()
+        return True, frozenset(), payload
     if gate in REVIEWER_FIX_GATES:
         candidates = ()
         if gate in DICTIONARY_CANDIDATE_GATES:
@@ -4682,7 +4798,7 @@ def _apply_python_qg_correction(
                 qg_report=qg_report,
                 dictionary_lookup_fn=dictionary_lookup_fn,
             )
-        unmatched_anchors = _apply_reviewer_correction(
+        unmatched_anchors, payload = _apply_reviewer_correction(
             gate,
             gate_report,
             qg_report=qg_report,
@@ -4692,8 +4808,8 @@ def _apply_python_qg_correction(
             reviewer_corrector=reviewer_corrector,
             invoker=invoker,
         )
-        return True, unmatched_anchors
-    return False, frozenset()
+        return True, unmatched_anchors, payload
+    return False, frozenset(), {"reason": "no correction path", "gate": gate}
 
 
 def _apply_writer_correction(
@@ -4707,7 +4823,7 @@ def _apply_writer_correction(
     | None,
     writer: str,
     invoker: Callable[..., Any] | None,
-) -> None:
+) -> dict[str, Any]:
     module_text = _read_required(module_dir / "module.md")
     prompt = render_writer_correction_prompt(
         gate=gate,
@@ -4734,7 +4850,13 @@ def _apply_writer_correction(
         response = writer_corrector(context)
     if isinstance(response, Mapping):
         write_writer_artifacts(module_dir, response)
-        return
+        return {
+            "kind": "writer",
+            "gate": gate,
+            "prompt": prompt,
+            "response": dict(response),
+            "applied": "writer_artifacts_mapping",
+        }
     if isinstance(response, str):
         # Strict-JSON-parse failures need all 4 artifact blocks back since the
         # original parse was the failure mode itself. Other gates are
@@ -4742,12 +4864,24 @@ def _apply_writer_correction(
         # contract.
         if all(name in response for name in WRITER_ARTIFACTS):
             write_writer_artifacts(module_dir, parse_writer_output_strict_json(response))
-            return
+            return {
+                "kind": "writer",
+                "gate": gate,
+                "prompt": prompt,
+                "response": response,
+                "applied": "strict_json_artifacts",
+            }
         if gate != "strict_json_parse":
             patched = parse_writer_correction_module_only(response)
             if patched is not None:
                 (module_dir / "module.md").write_text(patched, encoding="utf-8")
-                return
+                return {
+                    "kind": "writer",
+                    "gate": gate,
+                    "prompt": prompt,
+                    "response": response,
+                    "applied": "module_patch",
+                }
     emit_event(
         "writer_correction_unparseable",
         **_correction_event_fields(
@@ -4757,6 +4891,13 @@ def _apply_writer_correction(
         ),
         response_preview=_correction_preview(response),
     )
+    return {
+        "kind": "writer",
+        "gate": gate,
+        "prompt": prompt,
+        "response": response,
+        "applied": "unparseable",
+    }
 
 
 def _apply_reviewer_correction(
@@ -4769,7 +4910,7 @@ def _apply_reviewer_correction(
     candidates: tuple[CorrectionCandidate, ...],
     reviewer_corrector: Callable[[CorrectionContext], str | None] | None,
     invoker: Callable[..., Any] | None,
-) -> frozenset[str]:
+) -> tuple[frozenset[str], dict[str, Any]]:
     module_path = module_dir / "module.md"
     module_text = _read_required(module_path)
     prompt = render_reviewer_correction_prompt(
@@ -4818,7 +4959,16 @@ def _apply_reviewer_correction(
             ),
             response_preview=_correction_preview(response),
         )
-        return frozenset()
+        return frozenset(), {
+            "kind": "reviewer",
+            "gate": gate,
+            "prompt": prompt,
+            "response": response,
+            "fixes": [],
+            "accepted_fixes": [],
+            "rejected_fixes": [],
+            "applied": False,
+        }
     accepted_fixes, rejected_fixes = _validate_reviewer_fix_shapes(fixes)
     correction_fields = _correction_event_fields(
         gate=gate,
@@ -4833,7 +4983,16 @@ def _apply_reviewer_correction(
         **correction_fields,
     )
     if not accepted_fixes:
-        return frozenset()
+        return frozenset(), {
+            "kind": "reviewer",
+            "gate": gate,
+            "prompt": prompt,
+            "response": response,
+            "fixes": fixes,
+            "accepted_fixes": [],
+            "rejected_fixes": rejected_fixes,
+            "applied": False,
+        }
     result = _apply_reviewer_fixes(
         module_text,
         accepted_fixes,
@@ -4857,7 +5016,17 @@ def _apply_reviewer_correction(
                 artifact=module_path.name,
                 error_preview=str(exc)[:800],
             )
-    return result.unmatched_anchors
+    return result.unmatched_anchors, {
+        "kind": "reviewer",
+        "gate": gate,
+        "prompt": prompt,
+        "response": response,
+        "fixes": fixes,
+        "accepted_fixes": accepted_fixes,
+        "rejected_fixes": rejected_fixes,
+        "unmatched_anchors": sorted(result.unmatched_anchors),
+        "applied": True,
+    }
 
 
 def _apply_activity_id_inserts(module_path: Path, gate_report: Mapping[str, Any]) -> None:
@@ -5217,6 +5386,14 @@ def write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_correction_artifact(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, default=str) + "\n",
         encoding="utf-8",
     )
 

--- a/scripts/build/run_archive.py
+++ b/scripts/build/run_archive.py
@@ -1,0 +1,479 @@
+"""V7 run archive preservation helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+ENV_KEY = "V7_RUN_ARCHIVE_CONTEXT"
+
+_PASSTHROUGH_ARTIFACTS = (
+    "writer_output.raw.md",
+    "knowledge_packet.md",
+    "wiki_manifest.json",
+    "implementation_map.json",
+    "writer_tool_calls.json",
+    "module.md",
+    "activities.yaml",
+    "vocabulary.yaml",
+    "resources.yaml",
+    "python_qg.json",
+    "wiki_coverage_gate.json",
+    "wiki_coverage_review.json",
+    "llm_qg.json",
+)
+_RENAMED_ARTIFACTS = {
+    "writer_prompt.md": "v7-writer-prompt.md",
+}
+_ARTIFACT_GLOBS = (
+    "python_qg_correction_r*.json",
+    "wiki_coverage_correction_r*.json",
+    "llm-qg-*-prompt.md",
+    "wiki-coverage-review-prompt.md",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def file_sha256(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_jsonable(payload), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def archive_dir_for(
+    project_root: Path,
+    *,
+    level: str,
+    slug: str,
+    run_id: str,
+) -> Path:
+    return (
+        project_root
+        / "curriculum"
+        / "l2-uk-en"
+        / "_orchestration"
+        / level.lower()
+        / slug
+        / "runs"
+        / run_id
+    )
+
+
+def _latest_parent_run_id(project_root: Path, *, level: str, slug: str) -> str | None:
+    runs_root = (
+        project_root
+        / "curriculum"
+        / "l2-uk-en"
+        / "_orchestration"
+        / level.lower()
+        / slug
+        / "runs"
+    )
+    if not runs_root.exists():
+        return None
+    run_ids = sorted(path.name for path in runs_root.iterdir() if path.is_dir())
+    return run_ids[-1] if run_ids else None
+
+
+def parse_git_diff_stat(
+    raw: str,
+    *,
+    run_id: str,
+    parent_run_id: str | None,
+    base_ref: str,
+    head_ref: str,
+) -> dict[str, Any]:
+    lines = [line.rstrip() for line in raw.splitlines() if line.strip()]
+    summary = lines[-1] if lines else ""
+    path_lines = lines[:-1] if summary and "changed" in summary else lines
+
+    files_changed = _summary_int(summary, r"(\d+)\s+files?\s+changed")
+    insertions = _summary_int(summary, r"(\d+)\s+insertions?\(\+\)")
+    deletions = _summary_int(summary, r"(\d+)\s+deletions?\(-\)")
+    paths: list[dict[str, Any]] = []
+    for line in path_lines:
+        if "|" not in line:
+            continue
+        path_part, stat_part = line.rsplit("|", 1)
+        path = path_part.strip()
+        added = stat_part.count("+")
+        removed = stat_part.count("-")
+        status = "modified"
+        if added and not removed:
+            status = "added"
+        elif removed and not added:
+            status = "deleted"
+        paths.append(
+            {
+                "path": path,
+                "status": status,
+                "insertions": added,
+                "deletions": removed,
+            }
+        )
+
+    return {
+        "run_id": run_id,
+        "parent_run_id": parent_run_id,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "files_changed": files_changed,
+        "insertions": insertions,
+        "deletions": deletions,
+        "paths": paths,
+    }
+
+
+def _summary_int(summary: str, pattern: str) -> int:
+    match = re.search(pattern, summary)
+    return int(match.group(1)) if match else 0
+
+
+def _with_failed_frontmatter(mdx: str, *, failed_phase: str | None) -> str:
+    phase = failed_phase or "unknown"
+    if not mdx.startswith("---\n"):
+        return f"---\nbuild_status: failed\nfailed_phase: {phase}\n---\n\n{mdx}"
+    end = mdx.find("\n---", 4)
+    if end == -1:
+        return f"---\nbuild_status: failed\nfailed_phase: {phase}\n---\n\n{mdx}"
+    frontmatter = mdx[4:end].splitlines()
+    body = mdx[end + len("\n---") :]
+    filtered = [
+        line
+        for line in frontmatter
+        if not line.startswith("build_status:") and not line.startswith("failed_phase:")
+    ]
+    filtered.extend(["build_status: failed", f"failed_phase: {phase}"])
+    return "---\n" + "\n".join(filtered).rstrip() + "\n---" + body
+
+
+@dataclass(slots=True)
+class RunArchive:
+    project_root: Path
+    worktree_path: Path
+    archive_dir: Path
+    level: str
+    slug: str
+    run_id: str
+    parent_run_id: str | None
+    base_ref: str
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        project_root: Path,
+        worktree_path: Path,
+        level: str,
+        slug: str,
+        run_id: str,
+        writer: str,
+        model: str,
+        effort: str,
+        prompt_sha: str | None,
+        base_ref: str,
+    ) -> RunArchive:
+        project_root = project_root.resolve()
+        worktree_path = worktree_path.resolve()
+        level = level.lower()
+        parent_run_id = _latest_parent_run_id(project_root, level=level, slug=slug)
+        archive_dir = archive_dir_for(
+            project_root,
+            level=level,
+            slug=slug,
+            run_id=run_id,
+        )
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        archive = cls(
+            project_root=project_root,
+            worktree_path=worktree_path,
+            archive_dir=archive_dir,
+            level=level,
+            slug=slug,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            base_ref=base_ref,
+        )
+        archive._write_state(
+            {
+                "mode": "v7",
+                "track": level,
+                "slug": slug,
+                "run_id": run_id,
+                "parent_run_id": parent_run_id,
+                "started_at": utc_now(),
+                "finished_at": None,
+                "status": "partial",
+                "failed_phase": None,
+                "failure_class": None,
+                "agent": writer,
+                "model": model,
+                "effort": effort,
+                "prompt_sha": prompt_sha,
+                "phases": {},
+            }
+        )
+        return archive
+
+    @classmethod
+    def from_env(cls) -> RunArchive | None:
+        raw = os.environ.get(ENV_KEY)
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        archive_dir = Path(str(data["archive_dir"])).resolve()
+        return cls(
+            project_root=Path(str(data["project_root"])).resolve(),
+            worktree_path=Path(str(data["worktree_path"])).resolve(),
+            archive_dir=archive_dir,
+            level=str(data["level"]).lower(),
+            slug=str(data["slug"]),
+            run_id=str(data["run_id"]),
+            parent_run_id=data.get("parent_run_id"),
+            base_ref=str(data.get("base_ref") or "HEAD"),
+        )
+
+    def env(self) -> dict[str, str]:
+        return {
+            ENV_KEY: json.dumps(
+                {
+                    "project_root": str(self.project_root),
+                    "worktree_path": str(self.worktree_path),
+                    "archive_dir": str(self.archive_dir),
+                    "level": self.level,
+                    "slug": self.slug,
+                    "run_id": self.run_id,
+                    "parent_run_id": self.parent_run_id,
+                    "base_ref": self.base_ref,
+                },
+                ensure_ascii=False,
+            )
+        }
+
+    @property
+    def state_path(self) -> Path:
+        return self.archive_dir / "state.json"
+
+    def phase_started(self, phase: str) -> None:
+        state = self._state()
+        phases = state.setdefault("phases", {})
+        phase_state = phases.setdefault(phase, {})
+        phase_state.setdefault("started_at", utc_now())
+        phase_state["status"] = "running"
+        phase_state.setdefault("attempts", 0)
+        phase_state.setdefault("artifacts", [])
+        self._write_state(state)
+
+    def phase_succeeded(
+        self,
+        phase: str,
+        *,
+        artifact_dir: Path | None = None,
+        extra_paths: list[Path] | None = None,
+        fields: dict[str, Any] | None = None,
+    ) -> None:
+        artifacts = self.copy_artifacts(artifact_dir, extra_paths=extra_paths)
+        state = self._state()
+        phases = state.setdefault("phases", {})
+        phase_state = phases.setdefault(phase, {})
+        phase_state.setdefault("started_at", utc_now())
+        phase_state["finished_at"] = utc_now()
+        phase_state["status"] = "complete"
+        phase_state["attempts"] = self._phase_attempts(phase)
+        phase_state["artifacts"] = sorted(set(phase_state.get("artifacts", []) + artifacts))
+        if fields:
+            phase_state["fields"] = _jsonable(fields)
+        self._write_state(state)
+
+    def phase_failed(
+        self,
+        phase: str,
+        *,
+        artifact_dir: Path | None = None,
+        failure_class: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        artifacts = self.copy_artifacts(artifact_dir)
+        state = self._state()
+        phases = state.setdefault("phases", {})
+        phase_state = phases.setdefault(phase, {})
+        phase_state.setdefault("started_at", utc_now())
+        phase_state["finished_at"] = utc_now()
+        phase_state["status"] = "failed"
+        phase_state["attempts"] = self._phase_attempts(phase)
+        phase_state["artifacts"] = sorted(set(phase_state.get("artifacts", []) + artifacts))
+        if reason:
+            phase_state["reason"] = reason[:1000]
+        state["status"] = "failed"
+        state["failed_phase"] = phase
+        state["failure_class"] = failure_class
+        self._write_state(state)
+
+    def copy_artifacts(
+        self,
+        artifact_dir: Path | None,
+        *,
+        extra_paths: list[Path] | None = None,
+    ) -> list[str]:
+        copied: list[str] = []
+        if artifact_dir is not None and artifact_dir.exists():
+            for source_name, dest_name in _RENAMED_ARTIFACTS.items():
+                copied.extend(self._copy_one(artifact_dir / source_name, dest_name))
+            for name in (*_PASSTHROUGH_ARTIFACTS, f"{self.slug}.mdx"):
+                copied.extend(self._copy_one(artifact_dir / name, name))
+            for pattern in _ARTIFACT_GLOBS:
+                for path in sorted(artifact_dir.glob(pattern)):
+                    copied.extend(self._copy_one(path, path.name))
+        for path in extra_paths or []:
+            copied.extend(self._copy_one(path, path.name))
+        return copied
+
+    def write_failed_mdx(
+        self,
+        *,
+        module_dir: Path | None,
+        plan_path: Path | None,
+        failed_phase: str | None,
+    ) -> Path | None:
+        if module_dir is None or plan_path is None:
+            return None
+        output_path = self.archive_dir / f"{self.slug}.mdx"
+        try:
+            mdx = linear_pipeline.assemble_mdx(module_dir, output_path, plan_path)
+            output_path.write_text(
+                _with_failed_frontmatter(mdx, failed_phase=failed_phase),
+                encoding="utf-8",
+            )
+            return output_path
+        except Exception as exc:
+            state = self._state()
+            state["failed_mdx_error"] = str(exc)[:1000]
+            self._write_state(state)
+            return None
+
+    def terminal(
+        self,
+        *,
+        status: str,
+        failed_phase: str | None = None,
+        failure_class: str | None = None,
+        artifact_dir: Path | None = None,
+        extra_paths: list[Path] | None = None,
+    ) -> None:
+        self.copy_artifacts(artifact_dir, extra_paths=extra_paths)
+        state = self._state()
+        prior_failed_phase = state.get("failed_phase")
+        state["status"] = status
+        state["finished_at"] = utc_now()
+        if status != "complete":
+            state["failed_phase"] = failed_phase or prior_failed_phase or self._active_phase(state)
+            state["failure_class"] = failure_class or state.get("failure_class")
+        self._write_state(state)
+
+    def write_commit_diff_summary(self, *, worktree_path: Path | None = None) -> None:
+        worktree = worktree_path or self.worktree_path
+        raw = ""
+        head_ref = "HEAD"
+        try:
+            diff = subprocess.run(
+                ["git", "-C", str(worktree), "diff", "--stat", "--no-ext-diff", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if diff.returncode == 0:
+                raw = diff.stdout
+            head = subprocess.run(
+                ["git", "-C", str(worktree), "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if head.returncode == 0 and head.stdout.strip():
+                head_ref = head.stdout.strip()
+        except OSError:
+            raw = ""
+        summary = parse_git_diff_stat(
+            raw,
+            run_id=self.run_id,
+            parent_run_id=self.parent_run_id,
+            base_ref=self.base_ref,
+            head_ref=head_ref,
+        )
+        _write_json(self.archive_dir / "commit_diff_summary.json", summary)
+
+    def _copy_one(self, source: Path, dest_name: str) -> list[str]:
+        if not source.exists() or not source.is_file():
+            return []
+        dest = self.archive_dir / dest_name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(source.read_bytes())
+        return [dest_name]
+
+    def _state(self) -> dict[str, Any]:
+        return _read_json(self.state_path)
+
+    def _write_state(self, state: dict[str, Any]) -> None:
+        _write_json(self.state_path, state)
+
+    def _phase_attempts(self, phase: str) -> int:
+        if phase == "python_qg":
+            return len(list(self.archive_dir.glob("python_qg_correction_r*.json")))
+        if phase == "wiki_coverage_gate":
+            return len(list(self.archive_dir.glob("wiki_coverage_correction_r*.json")))
+        return 1
+
+    def _active_phase(self, state: dict[str, Any]) -> str | None:
+        phases = state.get("phases")
+        if not isinstance(phases, dict):
+            return None
+        for phase, phase_state in reversed(list(phases.items())):
+            if isinstance(phase_state, dict) and phase_state.get("status") == "running":
+                return str(phase)
+        return None

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -20,7 +21,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.agent_runtime.errors import AgentStalledError
-from scripts.build import linear_pipeline
+from scripts.build import linear_pipeline, run_archive
 from scripts.build.phases.implementation_map import (
     seed_implementation_map,
     write_implementation_map,
@@ -58,6 +59,7 @@ class BuildWorktree:
     branch: str
     base_sha: str
     repo_root: Path
+    run_id: str
 
 
 class WorktreeSetupError(RuntimeError):
@@ -214,6 +216,53 @@ def _derive_build_branch(
     return f"build/{safe_level}/{suffix}"
 
 
+def _resolve_worktree_output_dir(
+    raw: str | None,
+    *,
+    worktree_path: Path,
+    level: str,
+    slug: str,
+) -> Path:
+    if raw is None:
+        return worktree_path / "curriculum" / "l2-uk-en" / level.lower() / slug
+    path = Path(raw)
+    if not path.is_absolute():
+        path = worktree_path / path
+    return path
+
+
+def _worktree_mdx_path(
+    raw_out: str | None,
+    *,
+    worktree_path: Path,
+    module_dir: Path,
+    level: str,
+    slug: str,
+) -> Path:
+    if raw_out is None:
+        return (
+            worktree_path
+            / "starlight"
+            / "src"
+            / "content"
+            / "docs"
+            / level.lower()
+            / f"{slug}.mdx"
+        )
+    return module_dir / f"{slug}.mdx"
+
+
+def _writer_model_effort(writer: str, effort_override: str | None) -> tuple[str, str]:
+    defaults = linear_pipeline.WRITER_DEFAULTS.get(writer, {})
+    model = defaults.get("model", "unknown")
+    effort = effort_override or defaults.get("effort", "unknown")
+    return model, effort
+
+
+def _writer_prompt_template_sha(writer: str) -> str | None:
+    return run_archive.file_sha256(linear_pipeline.writer_prompt_path(writer))
+
+
 def _fetch_origin_main(repo_root: Path) -> bool:
     try:
         fetch = _run_git(["fetch", "origin"], cwd=repo_root, timeout=FETCH_TIMEOUT_S)
@@ -315,6 +364,7 @@ def _setup_worktree(level: str, slug: str, raw_path: str | None) -> BuildWorktre
         branch=branch,
         base_sha=base_sha,
         repo_root=repo_root,
+        run_id=timestamp,
     )
 
 
@@ -436,12 +486,26 @@ def _persist_build_artifacts(
 def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
     level = args.level.lower()
     slug = args.slug
+    writer = _normalize_writer(args.writer)
     try:
         worktree = _setup_worktree(level, slug, args.worktree)
     except WorktreeSetupError as exc:
         print(str(exc), file=sys.stderr)
         return exc.exit_code
 
+    model, effort = _writer_model_effort(writer, args.effort)
+    archive = run_archive.RunArchive.start(
+        project_root=worktree.repo_root,
+        worktree_path=worktree.path,
+        level=level,
+        slug=slug,
+        run_id=worktree.run_id,
+        writer=writer,
+        model=model,
+        effort=effort,
+        prompt_sha=_writer_prompt_template_sha(writer),
+        base_ref=worktree.base_sha,
+    )
     result = "failed"
     child_argv = _strip_worktree_args(raw_argv)
     command = [
@@ -449,8 +513,10 @@ def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
         "scripts/build/v7_build.py",
         *child_argv,
     ]
+    child_env = os.environ.copy()
+    child_env.update(archive.env())
     try:
-        proc = subprocess.run(command, cwd=worktree.path, check=False)
+        proc = subprocess.run(command, cwd=worktree.path, check=False, env=child_env)
         exit_code = proc.returncode
         if exit_code == 0:
             result = "success"
@@ -458,6 +524,25 @@ def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
         print(f"v7_build worktree child failed to start: {exc}", file=sys.stderr)
         exit_code = 1
     finally:
+        module_dir = _resolve_worktree_output_dir(
+            args.out,
+            worktree_path=worktree.path,
+            level=level,
+            slug=slug,
+        )
+        mdx_path = _worktree_mdx_path(
+            args.out,
+            worktree_path=worktree.path,
+            module_dir=module_dir,
+            level=level,
+            slug=slug,
+        )
+        archive.terminal(
+            status="complete" if result == "success" else "failed",
+            artifact_dir=module_dir,
+            extra_paths=[mdx_path],
+        )
+        archive.write_commit_diff_summary(worktree_path=worktree.path)
         # Persist artifacts BEFORE printing the summary so the summary
         # can include the commit-status line. Even if the build crashed,
         # the writer_prompt + partial writer_output remain queryable via
@@ -475,6 +560,8 @@ def _phase_done(
     level: str,
     slug: str,
     event_sink: Callable[..., None] = emit_event,
+    archive: run_archive.RunArchive | None = None,
+    artifact_dir: Path | None = None,
     **fields: Any,
 ) -> None:
     event_sink(
@@ -484,6 +571,52 @@ def _phase_done(
         phase=phase,
         duration_s=round(time.monotonic() - started_at, 3),
         **fields,
+    )
+    if archive is not None:
+        extra_paths = []
+        output = fields.get("output")
+        if isinstance(output, Path):
+            extra_paths.append(output)
+        archive.phase_succeeded(
+            phase,
+            artifact_dir=artifact_dir,
+            extra_paths=extra_paths,
+            fields=fields,
+        )
+
+
+def _phase_started(archive: run_archive.RunArchive | None, phase: str) -> None:
+    if archive is not None:
+        archive.phase_started(phase)
+
+
+def _archive_failure(
+    archive: run_archive.RunArchive | None,
+    *,
+    phase: str,
+    module_dir: Path | None,
+    plan_path: Path | None,
+    exc: Exception,
+) -> None:
+    if archive is None:
+        return
+    failed_mdx = archive.write_failed_mdx(
+        module_dir=module_dir,
+        plan_path=plan_path,
+        failed_phase=phase,
+    )
+    archive.phase_failed(
+        phase,
+        artifact_dir=module_dir,
+        failure_class=type(exc).__name__,
+        reason=str(exc),
+    )
+    archive.terminal(
+        status="failed",
+        failed_phase=phase,
+        failure_class=type(exc).__name__,
+        artifact_dir=module_dir,
+        extra_paths=[failed_mdx] if failed_mdx is not None else None,
     )
 
 
@@ -549,6 +682,7 @@ def _run_llm_qg(
             generated_content,
             dim,
         )
+        (module_dir / f"llm-qg-{dim}-prompt.md").write_text(prompt, encoding="utf-8")
         result = invoke(
             agent_name,
             prompt,
@@ -589,6 +723,10 @@ def _run_wiki_coverage_review(
         generated_content,
         wiki_manifest,
         wiki_coverage_gate,
+    )
+    (module_dir / "wiki-coverage-review-prompt.md").write_text(
+        prompt,
+        encoding="utf-8",
     )
     result = invoke(
         agent_name,
@@ -757,19 +895,31 @@ def _run(args: argparse.Namespace) -> int:
     phase = "start"
     timeout_agent = writer
     tracker = LastEventTracker()
+    archive = run_archive.RunArchive.from_env()
+    plan_path: Path | None = None
+    module_dir: Path | None = None
 
     tracker.emit("module_start", level=level, slug=slug)
 
     try:
         phase = "plan"
+        _phase_started(archive, phase)
         started_at = time.monotonic()
         plan_path = linear_pipeline.plan_path_for(level, slug)
         plan_content = plan_path.read_text(encoding="utf-8")
         plan = linear_pipeline.load_plan(plan_path)
         linear_pipeline.validate_plan(plan)
-        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+        )
 
         phase = "knowledge_packet"
+        _phase_started(archive, phase)
         started_at = time.monotonic()
         knowledge_packet = linear_pipeline.build_knowledge_packet(
             level=level,
@@ -782,7 +932,14 @@ def _run(args: argparse.Namespace) -> int:
             plan=plan,
         )
         wiki_manifest = json.dumps(wiki_manifest_data, ensure_ascii=False, indent=2)
-        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+        )
 
         if args.dry_run:
             sections = [
@@ -810,6 +967,7 @@ def _run(args: argparse.Namespace) -> int:
         module_dir = _resolve_output_dir(args.out, level, slug)
 
         phase = "writer"
+        _phase_started(archive, phase)
         timeout_agent = writer
         started_at = time.monotonic()
         module_dir.mkdir(parents=True, exist_ok=True)
@@ -871,9 +1029,12 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             writer=writer,
             event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
         )
 
         phase = "python_qg"
+        _phase_started(archive, phase)
         started_at = time.monotonic()
         python_qg = linear_pipeline.run_python_qg_with_corrections(
             module_dir,
@@ -881,7 +1042,15 @@ def _run(args: argparse.Namespace) -> int:
             writer=writer,
         )
         linear_pipeline.write_json(module_dir / "python_qg.json", python_qg)
-        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
         gates = python_qg.get("gates")
         if not isinstance(gates, Mapping) or gates.get("passed") is not True:
             raise linear_pipeline.LinearPipelineError(
@@ -889,6 +1058,7 @@ def _run(args: argparse.Namespace) -> int:
             )
 
         phase = "wiki_coverage_gate"
+        _phase_started(archive, phase)
         started_at = time.monotonic()
         wiki_coverage_gate = linear_pipeline.run_wiki_coverage_with_corrections(
             plan=plan,
@@ -899,13 +1069,22 @@ def _run(args: argparse.Namespace) -> int:
             event_sink=tracker.emit,
         )
         linear_pipeline.write_json(module_dir / "wiki_coverage_gate.json", wiki_coverage_gate)
-        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
         if wiki_coverage_gate.get("passed") is not True:
             raise linear_pipeline.LinearPipelineError(
                 "Wiki coverage gate failed after batched + narrow correction passes"
             )
 
         phase = "wiki_coverage_review"
+        _phase_started(archive, phase)
         timeout_agent = _reviewer_for_writer(writer)
         started_at = time.monotonic()
         wiki_coverage_review = _run_wiki_coverage_review(
@@ -941,11 +1120,20 @@ def _run(args: argparse.Namespace) -> int:
             partial_count=partial_count,
             total_verdicts=len(wiki_coverage_review.get("verdicts", [])),
         )
-        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
         if wiki_coverage_review["overall_verdict"] == "FAIL":
             raise linear_pipeline.LinearPipelineError("Wiki coverage review failed")
 
         phase = "llm_qg"
+        _phase_started(archive, phase)
         timeout_agent = _reviewer_for_writer(writer)
         started_at = time.monotonic()
         llm_qg = _run_llm_qg(
@@ -964,13 +1152,22 @@ def _run(args: argparse.Namespace) -> int:
             score=aggregate["min_score"],
             verdict=aggregate["verdict"],
         )
-        _phase_done(phase, started_at, level=level, slug=slug, event_sink=tracker.emit)
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
         if aggregate["verdict"] != "PASS":
             raise linear_pipeline.LinearPipelineError(
                 f"LLM QG verdict was {aggregate['verdict']}"
             )
 
         phase = "mdx"
+        _phase_started(archive, phase)
         started_at = time.monotonic()
         # MDX is the BUILT artifact and goes where Starlight reads it. Source
         # artifacts (.md, *.yaml) stay in curriculum/ as authoring source. When
@@ -997,6 +1194,8 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             output=mdx_path,
             event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
         )
 
         tracker.emit(
@@ -1007,6 +1206,13 @@ def _run(args: argparse.Namespace) -> int:
         )
         return 0
     except AgentStalledError as exc:
+        _archive_failure(
+            archive,
+            phase=phase,
+            module_dir=module_dir,
+            plan_path=plan_path,
+            exc=exc,
+        )
         tracker.emit(
             "writer_timeout",
             level=level,
@@ -1021,6 +1227,13 @@ def _run(args: argparse.Namespace) -> int:
         print(f"v7_build timed out in phase {phase}: {exc}", file=sys.stderr, flush=True)
         return 124
     except Exception as exc:
+        _archive_failure(
+            archive,
+            phase=phase,
+            module_dir=module_dir,
+            plan_path=plan_path,
+            exc=exc,
+        )
         tracker.emit(
             "module_failed",
             level=level,

--- a/tests/test_linear_pipeline_wiki_coverage.py
+++ b/tests/test_linear_pipeline_wiki_coverage.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import pytest
 
 from scripts.build import linear_pipeline
 from scripts.common.thresholds import QG_DIMS
@@ -86,3 +89,55 @@ def test_v7_build_orders_wiki_gate_before_aggregate_qg() -> None:
     # The ordering invariant remains: wiki coverage runs BEFORE review/LLM QG.
     assert run_body.index("run_wiki_coverage_with_corrections(") < run_body.index("_run_wiki_coverage_review(")
     assert run_body.index("_run_wiki_coverage_review(") < run_body.index("_run_llm_qg(")
+
+
+def test_wiki_coverage_correction_attempt_is_written(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("Original text.\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    reports = [
+        {
+            "passed": False,
+            "coverage_pct": 0.0,
+            "fix_proposals": [
+                {
+                    "obligation_id": "obl-1",
+                    "obligation_type": "concept",
+                    "expected_treatment": {"artifact": "module.md"},
+                    "surgical_diff_hint": "Add the missing wiki obligation.",
+                }
+            ],
+        },
+        {"passed": True, "coverage_pct": 1.0, "fix_proposals": []},
+    ]
+
+    def fake_gate(**_kwargs: object) -> dict[str, object]:
+        return reports.pop(0)
+
+    def fake_corrector(**_kwargs: object) -> str:
+        return (
+            "<fixes><fix><find>Original text.</find>"
+            "<replace>Original text with wiki obligation.</replace></fix></fixes>"
+        )
+
+    monkeypatch.setattr(linear_pipeline, "run_wiki_coverage_gate", fake_gate)
+
+    result = linear_pipeline.run_wiki_coverage_with_corrections(
+        plan={"level": "a1", "sequence": 1, "slug": "my-morning", "word_target": 100},
+        manifest={"slug": "my-morning"},
+        writer_output="",
+        module_dir=module_dir,
+        batched_corrector=fake_corrector,
+    )
+
+    correction = json.loads(
+        (module_dir / "wiki_coverage_correction_r1.json").read_text("utf-8")
+    )
+    assert result["passed"] is True
+    assert correction["phase"] == "batched"
+    assert correction["fixes_applied_total"] == 1
+    assert "Wiki-Coverage Correction" in correction["attempts"][0]["prompt"]

--- a/tests/test_run_archive.py
+++ b/tests/test_run_archive.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.build import run_archive
+
+
+def _start_archive(tmp_path: Path) -> tuple[run_archive.RunArchive, Path]:
+    project_root = tmp_path / "project"
+    worktree = tmp_path / "worktree"
+    module_dir = worktree / "curriculum" / "l2-uk-en" / "a1" / "my-morning"
+    module_dir.mkdir(parents=True)
+    prior = (
+        project_root
+        / "curriculum"
+        / "l2-uk-en"
+        / "_orchestration"
+        / "a1"
+        / "my-morning"
+        / "runs"
+        / "20260518-120000"
+    )
+    prior.mkdir(parents=True)
+    archive = run_archive.RunArchive.start(
+        project_root=project_root,
+        worktree_path=worktree,
+        level="a1",
+        slug="my-morning",
+        run_id="20260519-123456",
+        writer="codex-tools",
+        model="gpt-5.5",
+        effort="xhigh",
+        prompt_sha="abc123",
+        base_ref="base123",
+    )
+    return archive, module_dir
+
+
+def _write_contract_artifacts(module_dir: Path) -> None:
+    artifacts = {
+        "writer_prompt.md": "writer prompt",
+        "writer_output.raw.md": "raw writer output",
+        "knowledge_packet.md": "knowledge",
+        "wiki_manifest.json": "{}\n",
+        "implementation_map.json": "{}\n",
+        "python_qg.json": "{}\n",
+        "python_qg_correction_r1.json": "{}\n",
+        "wiki_coverage_gate.json": "{}\n",
+        "wiki_coverage_correction_r1.json": "{}\n",
+        "wiki_coverage_review.json": "{}\n",
+        "llm_qg.json": "{}\n",
+        "llm-qg-naturalness-prompt.md": "naturalness prompt",
+        "my-morning.mdx": "---\ntitle: Test\n---\n",
+    }
+    for name, text in artifacts.items():
+        (module_dir / name).write_text(text, encoding="utf-8")
+
+
+def test_run_archive_copies_contract_artifacts_with_hyphenated_prompt(
+    tmp_path: Path,
+) -> None:
+    archive, module_dir = _start_archive(tmp_path)
+    _write_contract_artifacts(module_dir)
+
+    archive.phase_started("writer")
+    archive.phase_succeeded("writer", artifact_dir=module_dir)
+    archive.terminal(status="complete", artifact_dir=module_dir)
+
+    run_dir = archive.archive_dir
+    state = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
+
+    assert state["mode"] == "v7"
+    assert state["track"] == "a1"
+    assert state["slug"] == "my-morning"
+    assert state["run_id"] == "20260519-123456"
+    assert state["parent_run_id"] == "20260518-120000"
+    assert state["status"] == "complete"
+    assert state["failed_phase"] is None
+    assert state["agent"] == "codex-tools"
+    assert state["model"] == "gpt-5.5"
+    assert state["effort"] == "xhigh"
+    assert state["prompt_sha"] == "abc123"
+    assert state["phases"]["writer"]["status"] == "complete"
+
+    expected = {
+        "state.json",
+        "v7-writer-prompt.md",
+        "writer_output.raw.md",
+        "knowledge_packet.md",
+        "wiki_manifest.json",
+        "implementation_map.json",
+        "python_qg.json",
+        "python_qg_correction_r1.json",
+        "wiki_coverage_gate.json",
+        "wiki_coverage_correction_r1.json",
+        "wiki_coverage_review.json",
+        "llm_qg.json",
+        "llm-qg-naturalness-prompt.md",
+        "my-morning.mdx",
+    }
+    assert expected <= {path.name for path in run_dir.iterdir()}
+    assert not (run_dir / "writer_prompt.md").exists()
+
+
+def test_run_archive_writes_failed_mdx_frontmatter(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    archive, module_dir = _start_archive(tmp_path)
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("level: a1\nslug: my-morning\nsequence: 1\n", encoding="utf-8")
+
+    def fake_assemble_mdx(
+        _module_dir: Path,
+        output_path: Path,
+        _plan_path: Path,
+    ) -> str:
+        mdx = "---\ntitle: Test\nbuild_status: draft\n---\n\nBody\n"
+        output_path.write_text(mdx, encoding="utf-8")
+        return mdx
+
+    monkeypatch.setattr(run_archive.linear_pipeline, "assemble_mdx", fake_assemble_mdx)
+
+    failed_mdx = archive.write_failed_mdx(
+        module_dir=module_dir,
+        plan_path=plan_path,
+        failed_phase="python_qg",
+    )
+    archive.phase_failed("python_qg", artifact_dir=module_dir)
+    archive.terminal(
+        status="failed",
+        failed_phase="python_qg",
+        artifact_dir=module_dir,
+        extra_paths=[failed_mdx] if failed_mdx is not None else None,
+    )
+
+    mdx = (archive.archive_dir / "my-morning.mdx").read_text(encoding="utf-8")
+    state = json.loads((archive.archive_dir / "state.json").read_text("utf-8"))
+
+    assert "build_status: failed" in mdx
+    assert "failed_phase: python_qg" in mdx
+    assert "build_status: draft" not in mdx
+    assert state["status"] == "failed"
+    assert state["failed_phase"] == "python_qg"
+
+
+def test_parse_git_diff_stat_extracts_summary_and_paths() -> None:
+    raw = """
+ starlight/src/content/docs/a1/my-morning.mdx | 8 +++++---
+ curriculum/l2-uk-en/a1/my-morning/module.md | 2 ++
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+"""
+
+    summary = run_archive.parse_git_diff_stat(
+        raw,
+        run_id="20260519-123456",
+        parent_run_id="20260518-120000",
+        base_ref="base123",
+        head_ref="head456",
+    )
+
+    assert summary["run_id"] == "20260519-123456"
+    assert summary["parent_run_id"] == "20260518-120000"
+    assert summary["base_ref"] == "base123"
+    assert summary["head_ref"] == "head456"
+    assert summary["files_changed"] == 2
+    assert summary["insertions"] == 7
+    assert summary["deletions"] == 3
+    assert summary["paths"] == [
+        {
+            "path": "starlight/src/content/docs/a1/my-morning.mdx",
+            "status": "modified",
+            "insertions": 5,
+            "deletions": 3,
+        },
+        {
+            "path": "curriculum/l2-uk-en/a1/my-morning/module.md",
+            "status": "added",
+            "insertions": 2,
+            "deletions": 0,
+        },
+    ]

--- a/tests/test_v7_build_worktree.py
+++ b/tests/test_v7_build_worktree.py
@@ -24,8 +24,9 @@ def _install_fake_subprocess_run(
         text: bool = False,
         check: bool = False,
         timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        del cwd, capture_output, text, check, timeout
+        del cwd, capture_output, text, check, timeout, env
         calls.append(cmd)
         if cmd[:2] == ["git", "rev-parse"] and "--show-toplevel" in cmd:
             return subprocess.CompletedProcess(cmd, 0, f"{repo}\n", "")

--- a/tests/test_writer_correction_no_op_diagnostic.py
+++ b/tests/test_writer_correction_no_op_diagnostic.py
@@ -397,6 +397,12 @@ def test_writer_correction_handles_tool_theatre_gate(tmp_path: Path) -> None:
     assert (module_dir / "module.md").read_text("utf-8") == (
         "## Morning\n\nOriginal prose with verification not performed theatre.\n"
     )
+    correction = json.loads(
+        (module_dir / "python_qg_correction_r1.json").read_text("utf-8")
+    )
+    assert correction["gate"] == "tool_theatre"
+    assert correction["correction"]["applied"] == "module_patch"
+    assert "search_heritage" in correction["correction"]["prompt"]
 
 
 def test_writer_correction_strict_json_parse_gate_still_requires_full_artifacts(


### PR DESCRIPTION
## Summary
- Add scripts/build/run_archive.py for V7 run directories, state.json, terminal state, failed-MDX frontmatter, and commit_diff_summary.json parsing.
- Wire v7_build --worktree so the parent creates the archive context and the child snapshots phase starts/success/failures into _orchestration/{level}/{slug}/runs/{stamp}/.
- Preserve python/wiki correction iteration JSON and per-dimension LLM reviewer prompts as separate hyphenated files.

## Verification
- ls scripts/build/run_archive.py -> scripts/build/run_archive.py
- ruff: All checks passed!
- pytest tests/test_run_archive.py: 3 passed in 0.28s
- targeted pytest: 64 passed in 2.17s
- lint_agent_trailer.py: PASS for X-Agent trailer

## Pre-submit checklist
- .python-version, .yamllint, and .markdownlint.json unchanged.
- No status/*.json, audit/*-review.md, review/*-review.md, or docs/*-STATUS.md files in the diff.
- No sys.executable usage added.
- Changed files: 7, all task-scoped.

Closes #2151