### PR TITLE
feat(agent-runtime): port agy adapter from kubedojo

### DIFF
--- a/scripts/agent_runtime/adapters/__init__.py
+++ b/scripts/agent_runtime/adapters/__init__.py
@@ -11,8 +11,14 @@ Issue: #1184
 """
 from __future__ import annotations
 
+from .agy import AgyAdapter
 from .hermes_deepseek import HermesDeepSeekAdapter
 from .hermes_grok import HermesGrokAdapter
 from .hermes_qwen import HermesQwenAdapter
 
-__all__ = ["HermesDeepSeekAdapter", "HermesGrokAdapter", "HermesQwenAdapter"]
+__all__ = [
+    "AgyAdapter",
+    "HermesDeepSeekAdapter",
+    "HermesGrokAdapter",
+    "HermesQwenAdapter",
+]

--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -1,0 +1,184 @@
+"""AgyAdapter — wraps the Antigravity (`agy`) CLI for the agent runtime.
+
+Ported from `kubedojo/scripts/agent_runtime/adapters/agy.py` for the
+2026-05-20 seminar-writer evaluation. `agy` ships Gemini Flash 3.5
+("gemini-3.5-flash-high") on a separate meter from gemini-cli; the
+seminar-track writer ADR at
+`docs/decisions/pending/2026-05-20-seminar-track-writer-assignment.md`
+adds it as candidate D pending empirical testing.
+
+Known behavioral facts as of agy 1.0.0 (verified locally 2026-05-20):
+
+- Headless prompt mode is ``agy -p "<prompt>"``. Stdin prompts are ignored.
+- Resume/new conversation is ``--conversation=<uuid>``.
+- Write-capable modes use ``--dangerously-skip-permissions``. Read-only
+  hangs on interactive permission prompts; callers must force
+  ``mode="danger"`` for headless dispatch (mirrors the codex protection).
+- No known on-disk session or liveness file exists — stdout is canonical.
+- ``agy`` model selection is controlled by the interactive TUI and persists
+  across ``agy -p`` invocations; there is no CLI model flag. The runtime
+  records the caller-passed ``model`` in the JSONL audit row for
+  provenance only.
+- ``agy plugin`` only exposes ``import gemini|claude``, ``install``,
+  ``enable``, ``disable``. There is no plugin-marketplace browse surface,
+  and ``import gemini`` is a no-op in a default install. The adapter
+  accepts ``tool_config["mcp_server_names"]`` for API parity with
+  ``GeminiAdapter`` but does not act on it today; wire ``agy plugin
+  enable <name>`` once concrete MCP servers are available.
+
+Phase-2 follow-up will wire MCP plugin enablement; until then ``-tools``
+writer mode will trip ``MCP_TOOLS_NEVER_INVOKED`` if agy is selected,
+which is the expected (and informative) signal in the seminar-writer
+bakeoff.
+
+Differences from the kubedojo source:
+
+- ``effort: str | None = None`` parameter added on ``build_invocation``
+  to match this repo's ``AgentAdapter`` protocol; treated as a no-op with
+  a debug log (mirrors the Gemini adapter; follow-up #1396).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+
+from ..result import ParseResult
+from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
+
+# Defensive defaults borrowed from Gemini CLI. Agy is new enough that these
+# may need adjustment once we see real Antigravity rate-limit errors.
+_RATE_LIMIT_PATTERNS = (
+    r"RESOURCE_EXHAUSTED",
+    r"usage limit reached",
+    r"quota exceeded",
+    r"daily.{0,10}limit.{0,10}exceeded",
+)
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+
+class AgyAdapter:
+    """Adapter for the ``agy`` Antigravity CLI."""
+
+    name: str = "agy"
+    default_model: str = os.environ.get("LEARN_UK_AGY_MODEL", "gemini-3.5-flash-high")
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        """Build the ``agy`` print-mode invocation.
+
+        ``model`` is intentionally not mapped to a CLI flag. The active
+        model is whichever model the operator selected in the ``agy`` TUI
+        panel. ``effort`` is accepted for protocol uniformity but is a
+        no-op until agy exposes a reasoning-effort flag (follow-up #1396).
+        """
+        if mode not in self.supported_modes:
+            raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
+
+        if effort is not None:
+            _logger.debug(
+                "agy effort %r not yet wired through CLI — "
+                "using TUI-selected model default (#1396 follow-up)",
+                effort,
+            )
+
+        agy_bin = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
+        # `--dangerously-skip-permissions` is unconditional: any tool-using
+        # prompt (file read, shell call) triggers an interactive permission
+        # prompt that would hang a headless dispatch waiting for human input.
+        # The `mode` field is retained for runtime accounting + adapter-API
+        # parity, but agy has no finer-grained permission model than this
+        # single flag. Callers (delegate.py/dispatch_smart.py) should force
+        # mode=danger for --agent agy to avoid accidental routes around this.
+        cmd: list[str] = [agy_bin, "-p", prompt, "--dangerously-skip-permissions"]
+
+        if session_id:
+            cmd.append(f"--conversation={session_id}")
+
+        # Phase-2 follow-up: agy uses `agy plugin` for MCP configuration,
+        # not a per-invocation CLI flag like gemini-cli. tool_config is
+        # accepted for parity but not acted on yet.
+        _ = tool_config
+        _ = task_id
+        _ = model
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            stdin_payload="",
+            output_file=None,
+            env_overrides={},
+            env_unsets=(),
+            liveness_paths=(),
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        """Parse ``agy -p`` output.
+
+        Stdout is the only known canonical response source. We deliberately
+        do not attempt Gemini-style session-file recovery because no
+        Antigravity on-disk session location is known yet.
+        """
+        _ = output_file
+        _ = call_start_time
+        _ = plan
+
+        stdout_response = (stdout or "").strip()
+        stderr_text = (stderr or "").strip()
+        combined = f"{stdout_response}\n{stderr_text}"
+        hard_limit_hit = bool(_RATE_LIMIT_RE.search(combined))
+        call_failed = returncode != 0 or not bool(stdout_response)
+        rate_limited = hard_limit_hit and call_failed
+
+        ok = returncode == 0 and bool(stdout_response) and not rate_limited
+        response = stdout_response if ok else ""
+
+        # `stderr_excerpt` follows the documented convention in result.py:
+        # populated only when there's diagnostic stderr or the call failed.
+        # The model hint is informational and lives in the JSONL audit row
+        # via env_overrides, not in stderr_excerpt (which is also used as
+        # an error-presence signal by some callers).
+        stderr_excerpt: str | None = None
+        if not ok:
+            excerpt_source = stderr_text or stdout_response
+            stderr_excerpt = excerpt_source[:500] or None
+        elif stderr_text:
+            stderr_excerpt = stderr_text[:500]
+
+        return ParseResult(
+            ok=ok,
+            response=response,
+            stderr_excerpt=stderr_excerpt,
+            rate_limited=rate_limited,
+            session_id=None,
+            tokens=None,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Agy has no known on-disk liveness signal; stdout is canonical."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -137,6 +137,23 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": True,
         "resume_policy": "never",
     },
+    "agy": {
+        # Antigravity CLI shipping Gemini Flash 3.5 on a separate meter from
+        # gemini-cli. Added 2026-05-20 for the seminar-writer ADR bakeoff
+        # (`docs/decisions/pending/2026-05-20-seminar-track-writer-assignment.md`).
+        # MCP plugin wiring is a Phase-2 follow-up — until then `-tools`
+        # writer mode will trip MCP_TOOLS_NEVER_INVOKED, which is the
+        # expected signal in the bakeoff.
+        "adapter": "scripts.agent_runtime.adapters.agy:AgyAdapter",
+        "default_model": "gemini-3.5-flash-high",
+        "cost_tier": "low",
+        "capabilities": frozenset({
+            "content_writing",
+            "content_review",
+        }),
+        "cli_available": True,
+        "resume_policy": "bridge_only",
+    },
 }
 
 

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -34,6 +34,8 @@ def _canonical_agent_name(agent: str) -> str | None:
         return "deepseek"
     if agent.startswith("qwen"):
         return "qwen"
+    if agent.startswith("agy"):
+        return "agy"
     return None
 
 
@@ -216,6 +218,31 @@ def build_mcp_tool_config(
         )
 
     if canonical_agent == "gemini":
+        if not mcp_servers:
+            return None, _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status="config_empty",
+            )
+        return (
+            {"mcp_server_names": mcp_servers},
+            _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
+
+    if canonical_agent == "agy":
+        # agy 1.0.0 has no per-invocation MCP flag (Phase 2 follow-up).
+        # We mirror the Gemini path's diagnostics shape so the upstream
+        # `_runtime_tool_config` validator does not fail-fast at dispatch
+        # time; the lack of MCP wiring then surfaces at runtime as
+        # MCP_TOOLS_NEVER_INVOKED, which is the precise + intended signal
+        # for the seminar-writer bakeoff. The adapter itself ignores
+        # `mcp_server_names`; we pass it through for parity / debuggability.
         if not mcp_servers:
             return None, _basic_diagnostics(
                 mcp_config_path=resolved_config_path,

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -70,6 +70,7 @@ WRITER_CHOICES = (
     "grok-tools",
     "deepseek-tools",
     "qwen-tools",
+    "agy-tools",
 )
 WRITER_DEFAULTS: dict[str, dict[str, str]] = {
     "claude-tools": {"model": "claude-opus-4-7", "effort": "xhigh"},
@@ -78,6 +79,10 @@ WRITER_DEFAULTS: dict[str, dict[str, str]] = {
     "grok-tools": {"model": "grok-4.3", "effort": "medium"},
     "deepseek-tools": {"model": "deepseek-v4-pro", "effort": "medium"},
     "qwen-tools": {"model": "qwen/qwen3.6-plus", "effort": "medium"},
+    # agy effort is a no-op on the CLI today (Phase-2 follow-up). The
+    # model field is informational only; the TUI-selected model is what
+    # actually runs. "medium" is a placeholder for telemetry parity.
+    "agy-tools": {"model": "gemini-3.5-flash-high", "effort": "medium"},
 }
 PROMPT_BY_WRITER = {
     "grok-tools": "linear-write-grok.md",
@@ -92,6 +97,7 @@ REVIEWER_CHOICES = (
     "grok-tools",
     "deepseek-tools",
     "qwen-tools",
+    "agy-tools",
 )
 REVIEWER_DEFAULTS: dict[str, dict[str, str]] = {
     "claude-tools": {"model": "claude-opus-4-7", "effort": "xhigh"},
@@ -100,6 +106,7 @@ REVIEWER_DEFAULTS: dict[str, dict[str, str]] = {
     "grok-tools": {"model": "grok-4.3", "effort": "medium"},
     "deepseek-tools": {"model": "deepseek-v4-pro", "effort": "medium"},
     "qwen-tools": {"model": "qwen/qwen3.6-plus", "effort": "medium"},
+    "agy-tools": {"model": "gemini-3.5-flash-high", "effort": "medium"},
 }
 WRITER_ARTIFACTS = (
     "module.md",
@@ -2670,6 +2677,7 @@ def _runtime_tool_config(
         "grok-tools",
         "deepseek-tools",
         "qwen-tools",
+        "agy-tools",
     }:
         agent_kwargs = {
             "mcp_servers": ["sources"],
@@ -2678,7 +2686,7 @@ def _runtime_tool_config(
         raise LinearPipelineError(
             f"Unknown -tools writer {agent_label!r}; expected one of "
             "codex-tools / claude-tools / gemini-tools / grok-tools / "
-            "deepseek-tools / qwen-tools."
+            "deepseek-tools / qwen-tools / agy-tools."
         )
 
     canonical_agent = agent_label.split("-", 1)[0]

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -38,6 +38,7 @@ WRITER_ALIASES = {
     "grok": "grok-tools",
     "deepseek": "deepseek-tools",
     "qwen": "qwen-tools",
+    "agy": "agy-tools",
 }
 WRITER_CHOICES = (*linear_pipeline.WRITER_CHOICES, *WRITER_ALIASES)
 
@@ -805,8 +806,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="claude-tools",
         help=(
             "Writer backend for the one-shot V7 write phase "
-            "(default: claude-tools; claude/gemini/codex/grok aliases normalize to "
-            "claude-tools/gemini-tools/codex-tools/grok-tools)."
+            "(default: claude-tools; claude/gemini/codex/grok/deepseek/qwen/agy "
+            "aliases normalize to <name>-tools)."
         ),
     )
     parser.add_argument(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1534,8 +1534,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fire a task, return immediately",
         formatter_class=_dispatch_help_formatter,
     )
-    d.add_argument("--agent", required=True, choices=["codex", "gemini", "claude", "grok", "deepseek", "qwen"],
-                   help="Agent to run for the task: codex, gemini, claude, grok, deepseek, or qwen.")
+    d.add_argument("--agent", required=True,
+                   choices=["codex", "gemini", "claude", "grok", "deepseek", "qwen", "agy"],
+                   help="Agent to run for the task: codex, gemini, claude, grok, deepseek, qwen, or agy.")
     d.add_argument("--task-id", required=True,
                    help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -174,7 +174,17 @@ def test_registry_has_known_agents():
         "grok",
         "deepseek",
         "qwen",
+        "agy",
     }
+
+
+def test_agy_entry_is_well_formed():
+    entry = get_agent_entry("agy")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.agy:AgyAdapter"
+    assert entry["default_model"] == "gemini-3.5-flash-high"
+    assert entry["cli_available"] is True
+    assert entry["resume_policy"] == "bridge_only"
+    assert {"content_writing", "content_review"} <= entry["capabilities"]
 
 
 def test_codex_entry_has_bridge_only_resume_policy():

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -349,6 +349,30 @@ def test_runtime_tool_config_gemini_tools_raises_when_unconfigured(
     assert events[0][1]["resolved_servers"] == []
 
 
+def test_runtime_tool_config_agy_tools_emits_resolution_event_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """agy-tools mirrors gemini-tools diagnostics so the dispatch gate passes;
+    actual MCP wiring is a Phase-2 follow-up and the runtime MCP_TOOLS_NEVER_INVOKED
+    gate then surfaces the gap."""
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = linear_pipeline._runtime_tool_config(
+        "agy-tools",
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config["output_format"] == "stream-json"
+    assert config["mcp_server_names"] == ["sources"]
+    assert events[0][0] == "mcp_config_resolved"
+    assert events[0][1]["writer"] == "agy-tools"
+    assert events[0][1]["resolution_status"] == "ok"
+    assert events[0][1]["resolved_servers"] == ["sources"]
+
+
 @pytest.mark.parametrize("writer", ["grok-tools", "deepseek-tools", "qwen-tools"])
 def test_runtime_tool_config_hermes_tools_emits_resolution_event_success(
     writer: str,


### PR DESCRIPTION
## Summary

- Ports the `AgyAdapter` from `kubedojo/scripts/agent_runtime/adapters/agy.py` for the Antigravity CLI (`agy`), shipping Gemini Flash 3.5 on a separate meter from `gemini-cli`.
- Wires `agy` into the registry, `delegate.py`, `tool_config.build_mcp_tool_config`, `linear_pipeline.WRITER_CHOICES/REVIEWER_CHOICES`, and `v7_build.WRITER_ALIASES` (alias `agy → agy-tools`).
- Adds two tests pinning the registry shape and the runtime tool-config event.

Per handoff [`docs/session-state/2026-05-20-overnight-three-gate-fixes-plus-2151-dispatch.md`](docs/session-state/2026-05-20-overnight-three-gate-fixes-plus-2151-dispatch.md) §7 Decision 1, this is the prerequisite for the seminar-track writer ADR bakeoff. The next step (out of scope for this PR) is to fire one `--writer agy-tools` smoke build of a low-sequence HIST or LIT module and re-open [`docs/decisions/pending/2026-05-20-seminar-track-writer-assignment.md`](docs/decisions/pending/2026-05-20-seminar-track-writer-assignment.md) with empirical data.

## Phase-2 follow-up — MCP wiring

`agy 1.0.0` exposes only `agy plugin import gemini|claude / install / enable / disable` — there is no per-invocation MCP flag and no plugin-marketplace browse surface, so `tool_config["mcp_server_names"]` is accepted for API parity with `GeminiAdapter` but **not acted on**. The `tool_config.py` branch mirrors the Gemini diagnostics shape (resolution_status="ok") so the dispatch fail-fast gate passes; the runtime `MCP_TOOLS_NEVER_INVOKED` gate then surfaces the missing wiring, which is the **expected and informative signal** for the bakeoff. When `agy plugin enable <name>` ships, that branch becomes a real config + the resolution_status flip is the trigger to remove this note.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_agent_runtime.py` — 132 passed (incl. new `test_agy_entry_is_well_formed` + registry-set assertion update)
- [x] `.venv/bin/python -m pytest tests/test_mcp_init_observability.py` — 28 passed (incl. new `test_runtime_tool_config_agy_tools_emits_resolution_event_success`)
- [x] `.venv/bin/python -m pytest tests/test_dispatch.py tests/test_v7_review.py tests/test_writer_telemetry_search_text.py tests/test_convergence_loop.py` — 43 passed
- [x] `.venv/bin/python -m pytest tests/test_v7_build_worktree.py tests/test_linear_pipeline_telemetry.py tests/build/test_linear_pipeline.py` — 128 passed
- [x] `.venv/bin/ruff check` — all clean on touched files
- [x] Adapter loads (`AgyAdapter().build_invocation(...)` produces the expected `agy -p PROMPT --dangerously-skip-permissions` command + correct InvocationPlan)
- [x] `build_mcp_tool_config("agy", mcp_servers=["sources"])` returns `({"mcp_server_names": ["sources"]}, resolution_status="ok")`
- [ ] Smoke build of one HIST/LIT module with `--writer agy-tools --worktree` — follow-up after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)