### PR TITLE
fix(linear_pipeline): _contract_yaml accepts list-shape vocabulary_hints

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5781,6 +5781,31 @@ def _activity_config(level: str, module_num: int, slug: str | None = None) -> di
     return get_activity_config(level.lower(), module_num, slug)
 
 
+def _required_vocabulary_for_contract(plan: Mapping[str, Any]) -> list[Any]:
+    """Extract required-vocabulary list, tolerating both plan-schema shapes.
+
+    Two shapes exist in the wild (discovered 2026-05-20 seminar smoke build):
+
+    * CORE plans + some LIT plans: ``vocabulary_hints`` is a dict with
+      ``required`` / ``optional`` / ``recommended`` keys, each a list.
+    * Most LIT/BIO seminar plans + ``required_vocab`` callers: a bare list
+      of ``{word, pos, definition}`` entries.
+
+    ``_vocabulary_lemmas`` already handles both shapes (line ~895); this
+    helper applies the same pattern to ``_contract_yaml`` so seminar
+    builds don't crash with ``'list' object has no attribute 'get'``.
+    Follow-up: schema unification (see issue tracking the parallel
+    ``title:`` gap).
+    """
+    vh = plan.get("vocabulary_hints")
+    if isinstance(vh, dict):
+        required = vh.get("required")
+        return list(required) if isinstance(required, list) else []
+    if isinstance(vh, list):
+        return list(vh)
+    return []
+
+
 def _contract_yaml(plan: Mapping[str, Any]) -> str:
     contract = {
         "sections": [
@@ -5796,7 +5821,7 @@ def _contract_yaml(plan: Mapping[str, Any]) -> str:
             for section in plan.get("content_outline", [])
         ],
         "activity_hints": plan.get("activity_hints", []),
-        "vocabulary_required": plan.get("vocabulary_hints", {}).get("required", []),
+        "vocabulary_required": _required_vocabulary_for_contract(plan),
         "references": plan.get("references", []),
     }
     return yaml.safe_dump(contract, allow_unicode=True, sort_keys=False).strip()

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -3538,3 +3538,53 @@ def test_strip_metalinguistic_preserves_bold_lemmas_in_running_prose() -> None:
     stripped = linear_pipeline._strip_metalinguistic(text)
     for lemma in ("сніданок", "рушник", "полотенце"):
         assert lemma in stripped, f"bold-unwrapped lemma '{lemma}' should survive"
+
+
+def test_contract_yaml_handles_dict_shape_vocabulary_hints() -> None:
+    """CORE plans express vocabulary_hints as `{required: [...], optional: [...]}`."""
+    plan = {
+        "content_outline": [{"section": "S", "words": 100, "points": ["p1"]}],
+        "activity_hints": [],
+        "references": [{"title": "Ref"}],
+        "vocabulary_hints": {
+            "required": [{"word": "сніданок", "pos": "ч.", "definition": "ранкова їжа"}],
+            "optional": [],
+        },
+    }
+    out = linear_pipeline._contract_yaml(plan)
+    assert "vocabulary_required" in out
+    assert "сніданок" in out
+
+
+def test_contract_yaml_handles_list_shape_vocabulary_hints() -> None:
+    """Seminar plans (most LIT + BIO) express vocabulary_hints as a bare list.
+
+    Regression for the 2026-05-20 seminar smoke build that crashed on
+    `'list' object has no attribute 'get'` while rendering the writer
+    prompt for `lit/natalka-poltavka`. `_vocabulary_lemmas` (line ~895)
+    already handled both shapes; `_contract_yaml` lagged.
+    """
+    plan = {
+        "content_outline": [{"section": "S", "words": 100, "points": ["p1"]}],
+        "activity_hints": [],
+        "references": [{"title": "Ref"}],
+        "vocabulary_hints": [
+            {"word": "сентименталізм", "pos": "ч.", "definition": "літ. напрям"},
+            {"word": "ремарка", "pos": "ж.", "definition": "авторська вказівка"},
+        ],
+    }
+    out = linear_pipeline._contract_yaml(plan)
+    assert "vocabulary_required" in out
+    assert "сентименталізм" in out
+    assert "ремарка" in out
+
+
+def test_contract_yaml_tolerates_missing_vocabulary_hints() -> None:
+    """Plans without vocabulary_hints render an empty required list."""
+    plan = {
+        "content_outline": [{"section": "S", "words": 100, "points": ["p1"]}],
+        "activity_hints": [],
+        "references": [{"title": "Ref"}],
+    }
+    out = linear_pipeline._contract_yaml(plan)
+    assert "vocabulary_required: []" in out


### PR DESCRIPTION
## Summary

- `_contract_yaml` crashed on `'list' object has no attribute 'get'` for any plan where `vocabulary_hints` is a bare list (most LIT + BIO seminar plans). The dict-shape (CORE plans + some LIT) was the only supported form.
- Extracts `_required_vocabulary_for_contract(plan)` helper mirroring the dispatch logic already in `_vocabulary_lemmas` (line ~895) — accepts dict, list, or missing.
- Adds 3 pinning tests.

## Why now

Surfaced during the 2026-05-20 agy-tools smoke build of `lit/natalka-poltavka` for the seminar-writer ADR bakeoff (handoff §7 Decision 1). Writer phase hard-failed before the agy CLI was ever invoked. With this fix the seminar smoke build can proceed and exercise the agy adapter end-to-end.

## Related issues

- Issue #2164 — parallel plan-schema gap on `references[].title` field; the two together suggest a broader plan-schema unification audit is worth filing.

## Test plan

- [x] `.venv/bin/python -m pytest tests/build/test_linear_pipeline.py tests/test_linear_pipeline_telemetry.py` — 123 passed
- [x] `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/build/test_linear_pipeline.py` — clean
- [x] Manual repro: both `lit/natalka-poltavka` (list-shape) and `a1/my-morning` (dict-shape) `_contract_yaml` returns now succeed
- [ ] Refire `v7_build.py lit natalka-poltavka --writer agy-tools --worktree` after merge — should progress past the writer-phase TypeError into the actual agy invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)