### PR TITLE
feat(sync): paired promote_module + prune_module_forensics helpers

### DIFF
--- a/scripts/sync/promote_module.py
+++ b/scripts/sync/promote_module.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Promote V7 build-branch artifacts into the canonical curriculum tree."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import difflib
+import hashlib
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CURRICULUM_ROOT = Path("curriculum") / "l2-uk-en"
+DOCS_ROOT = Path("starlight") / "src" / "content" / "docs"
+
+LESSON_SOURCE_FILES = frozenset(
+    {
+        "module.md",
+        "activities.yaml",
+        "vocabulary.yaml",
+        "resources.yaml",
+    }
+)
+FORENSICS_FILES = frozenset(
+    {
+        "writer_prompt.md",
+        "writer_output.raw.md",
+        "hermes.write.jsonl",
+        "writer_tool_calls.json",
+        "python_qg.json",
+        "llm_qg.json",
+        "knowledge_packet.md",
+        "implementation_map.json",
+    }
+)
+
+_BUILD_BRANCH_RE = re.compile(r"^(?:refs/heads/|origin/)?build/(?P<level>[^/]+)/(?P<slug>.+)-(?P<stamp>\d{8}-\d{6})$")
+_WORKTREE_NAME_RE = re.compile(r"^(?P<level>[^-]+)-(?P<slug>.+)-(?P<stamp>\d{8}-\d{6})$")
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    build_ref: str
+    level: str
+    slug: str
+    worktree: Path | None = None
+
+
+@dataclass(frozen=True)
+class SourceFile:
+    source_rel: Path
+    dest_rel: Path
+    content: bytes
+
+
+def _sanitized_git_env() -> dict[str, str]:
+    """Drop ambient GIT_* / PRE_COMMIT* vars so `-C <repo_root>` resolves the
+    target repo's context cleanly even when this script is invoked from
+    inside a pre-commit hook or a parent git process that has set GIT_DIR /
+    GIT_INDEX_FILE / etc."""
+    return {k: v for k, v in os.environ.items() if not k.startswith(("GIT_", "PRE_COMMIT"))}
+
+
+def _run_git(repo_root: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=check,
+        capture_output=True,
+        env=_sanitized_git_env(),
+    )
+
+
+def _decode(data: bytes) -> str:
+    return data.decode("utf-8", errors="replace")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_build_branch(ref: str) -> tuple[str, str, str] | None:
+    match = _BUILD_BRANCH_RE.match(ref)
+    if match is None:
+        return None
+    return match.group("level").lower(), match.group("slug"), match.group("stamp")
+
+
+def _parse_worktree_name(path: Path) -> tuple[str, str, str] | None:
+    match = _WORKTREE_NAME_RE.match(path.name)
+    if match is None:
+        return None
+    return match.group("level").lower(), match.group("slug"), match.group("stamp")
+
+
+def _write_atomically(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as tmp:
+            tmp_name = tmp.name
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        if tmp_name:
+            with contextlib.suppress(FileNotFoundError):
+                Path(tmp_name).unlink()
+
+
+def _source_rel_for_lesson(level: str, slug: str, filename: str) -> Path:
+    return CURRICULUM_ROOT / level / slug / filename
+
+
+def _source_rel_for_mdx(level: str, slug: str) -> Path:
+    return DOCS_ROOT / level / f"{slug}.mdx"
+
+
+def _read_build_file(repo_root: Path, source: SourceSpec, source_rel: Path) -> bytes | None:
+    if source.build_ref:
+        proc = _run_git(repo_root, ["show", f"{source.build_ref}:{source_rel.as_posix()}"], check=False)
+        if proc.returncode == 0:
+            return proc.stdout
+
+    if source.worktree is None:
+        return None
+
+    disk_path = source.worktree / source_rel
+    try:
+        return disk_path.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def _resolve_latest_branch(repo_root: Path, level: str, slug: str) -> str:
+    pattern = f"refs/heads/build/{level}/{slug}-*"
+    proc = _run_git(
+        repo_root,
+        ["for-each-ref", "--sort=-creatordate", pattern, "--format=%(refname:short)"],
+    )
+    refs = [line.strip() for line in _decode(proc.stdout).splitlines() if line.strip()]
+    if not refs:
+        raise ValueError(f"no build branches match build/{level}/{slug}-*")
+
+    def sort_key(ref: str) -> tuple[str, str]:
+        parsed = _parse_build_branch(ref)
+        return ((parsed[2] if parsed is not None else ""), ref)
+
+    return max(refs, key=sort_key)
+
+
+def _branch_for_worktree(worktree: Path) -> str | None:
+    proc = subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=False,
+        capture_output=True,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        return None
+    branch = _decode(proc.stdout).strip()
+    return branch if branch and branch != "HEAD" else None
+
+
+def _resolve_source(args: argparse.Namespace, repo_root: Path) -> SourceSpec:
+    if args.latest:
+        if not args.level or not args.slug:
+            raise ValueError("--latest requires --level and --slug")
+        level = args.level.lower()
+        build_ref = _resolve_latest_branch(repo_root, level, args.slug)
+        return SourceSpec(build_ref=build_ref, level=level, slug=args.slug)
+
+    if args.build_branch:
+        parsed = _parse_build_branch(args.build_branch)
+        if parsed is None:
+            if not args.level or not args.slug:
+                raise ValueError("--build-branch must look like build/<level>/<slug>-<YYYYMMDD-HHMMSS>")
+            return SourceSpec(build_ref=args.build_branch, level=args.level.lower(), slug=args.slug)
+        level, slug, _stamp = parsed
+        return SourceSpec(build_ref=args.build_branch, level=level, slug=slug)
+
+    worktree = Path(args.worktree).expanduser().resolve()
+    branch = _branch_for_worktree(worktree)
+    parsed = _parse_build_branch(branch or "") if branch else None
+    if parsed is None:
+        parsed = _parse_worktree_name(worktree)
+    if parsed is None:
+        if not args.level or not args.slug:
+            raise ValueError("could not infer level/slug from worktree; pass --level and --slug")
+        level, slug = args.level.lower(), args.slug
+    else:
+        level, slug, _stamp = parsed
+    return SourceSpec(build_ref=branch or "", level=level, slug=slug, worktree=worktree)
+
+
+def _collect_source_files(repo_root: Path, source: SourceSpec) -> tuple[list[SourceFile], list[Path], list[Path]]:
+    files: list[SourceFile] = []
+    missing_required: list[Path] = []
+    missing_optional: list[Path] = []
+
+    for filename in sorted(LESSON_SOURCE_FILES):
+        source_rel = _source_rel_for_lesson(source.level, source.slug, filename)
+        content = _read_build_file(repo_root, source, source_rel)
+        if content is None:
+            missing_required.append(source_rel)
+        else:
+            files.append(SourceFile(source_rel=source_rel, dest_rel=source_rel, content=content))
+
+    mdx_rel = _source_rel_for_mdx(source.level, source.slug)
+    mdx = _read_build_file(repo_root, source, mdx_rel)
+    if mdx is None:
+        missing_required.append(mdx_rel)
+    else:
+        files.append(SourceFile(source_rel=mdx_rel, dest_rel=mdx_rel, content=mdx))
+
+    for filename in sorted(FORENSICS_FILES):
+        source_rel = _source_rel_for_lesson(source.level, source.slug, filename)
+        content = _read_build_file(repo_root, source, source_rel)
+        if content is None:
+            missing_optional.append(source_rel)
+        else:
+            files.append(SourceFile(source_rel=source_rel, dest_rel=source_rel, content=content))
+
+    return files, missing_required, missing_optional
+
+
+def _diff_summary(path: Path, current: bytes, wanted: bytes) -> str:
+    current_text = _decode(current).splitlines(keepends=True)
+    wanted_text = _decode(wanted).splitlines(keepends=True)
+    diff = difflib.unified_diff(
+        current_text,
+        wanted_text,
+        fromfile=f"{path.as_posix()} (current)",
+        tofile=f"{path.as_posix()} (build)",
+        n=3,
+    )
+    lines = list(diff)
+    if lines:
+        return "".join(lines[:80])
+    return (
+        f"{path.as_posix()}: binary or encoding-only difference "
+        f"current={_sha256(current)} build={_sha256(wanted)}\n"
+    )
+
+
+def _classify_destination(repo_root: Path, source: SourceSpec, files: list[SourceFile]) -> tuple[bool, list[str]]:
+    required_dest_rels = {
+        _source_rel_for_lesson(source.level, source.slug, filename)
+        for filename in LESSON_SOURCE_FILES
+    }
+    required_dest_rels.add(_source_rel_for_mdx(source.level, source.slug))
+
+    required_by_dest = {item.dest_rel: item for item in files if item.dest_rel in required_dest_rels}
+    any_required_exists = False
+    mismatches: list[str] = []
+
+    for dest_rel, item in sorted(required_by_dest.items(), key=lambda pair: pair[0].as_posix()):
+        dest = repo_root / dest_rel
+        if not dest.exists():
+            mismatches.append(f"{dest_rel.as_posix()}: missing in current tree")
+            continue
+        any_required_exists = True
+        current = dest.read_bytes()
+        if current != item.content:
+            mismatches.append(_diff_summary(dest_rel, current, item.content))
+
+    return any_required_exists, mismatches
+
+
+def _dry_run(repo_root: Path, files: list[SourceFile], missing_optional: list[Path]) -> None:
+    print("DRY-RUN promote plan:")
+    for item in files:
+        dest = repo_root / item.dest_rel
+        if dest.exists():
+            current = dest.read_bytes()
+            action = "unchanged" if current == item.content else "update"
+        else:
+            action = "create"
+        print(f"  {action} {item.dest_rel.as_posix()}")
+        if action == "update":
+            print(_diff_summary(item.dest_rel, current, item.content), end="")
+    for rel in missing_optional:
+        print(f"  optional missing {rel.as_posix()}")
+
+
+def _commit(repo_root: Path, rels: list[Path], message: str) -> None:
+    rel_args = [rel.as_posix() for rel in rels]
+    _run_git(repo_root, ["add", "--", *rel_args])
+    staged = _run_git(repo_root, ["diff", "--cached", "--quiet"], check=False)
+    if staged.returncode == 0:
+        print("OK no staged changes")
+        return
+    _run_git(repo_root, ["commit", "-m", message])
+
+
+def promote(args: argparse.Namespace, *, repo_root: Path = ROOT) -> int:
+    repo_root = repo_root.resolve()
+    try:
+        source = _resolve_source(args, repo_root)
+        files, missing_required, missing_optional = _collect_source_files(repo_root, source)
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"ERROR {exc}", file=sys.stderr)
+        return 1
+
+    for rel in missing_optional:
+        print(f"optional missing {rel.as_posix()}")
+
+    if missing_required:
+        print("ERROR missing required build artifacts:", file=sys.stderr)
+        for rel in missing_required:
+            print(f"  {rel.as_posix()}", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        _dry_run(repo_root, files, missing_optional)
+        return 0
+
+    any_required_exists, mismatches = _classify_destination(repo_root, source, files)
+    if any_required_exists and mismatches and not args.force:
+        print("ERROR partial or conflicting promotion detected; use --force to overwrite", file=sys.stderr)
+        for mismatch in mismatches:
+            print(mismatch, file=sys.stderr, end="" if mismatch.endswith("\n") else "\n")
+        return 1
+
+    if any_required_exists and not mismatches:
+        print("OK already-promoted")
+        return 0
+
+    written: list[Path] = []
+    for item in files:
+        dest = repo_root / item.dest_rel
+        if dest.exists() and dest.read_bytes() == item.content:
+            continue
+        _write_atomically(dest, item.content)
+        written.append(item.dest_rel)
+        print(f"wrote {item.dest_rel.as_posix()}")
+
+    if not written:
+        print("OK no changes")
+        return 0
+
+    if args.no_commit:
+        print("OK promoted without commit (--no-commit)")
+        return 0
+
+    message = args.message or f"feat(content): promote {source.level}/{source.slug} from {source.build_ref}"
+    try:
+        _commit(repo_root, written, message)
+    except subprocess.CalledProcessError as exc:
+        print(_decode(exc.stderr), file=sys.stderr, end="")
+        return exc.returncode or 1
+    print("OK promoted and committed")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--build-branch", help="Build branch ref, e.g. build/a1/my-morning-20260520-123456")
+    source.add_argument("--worktree", help="Build worktree directory to read from")
+    source.add_argument("--latest", action="store_true", help="Use most recent build/<level>/<slug>-* branch")
+    parser.add_argument("--level", help="Level for --latest, or fallback when a ref cannot be parsed")
+    parser.add_argument("--slug", help="Slug for --latest, or fallback when a ref cannot be parsed")
+    parser.add_argument("--dry-run", action="store_true", help="Show planned writes and diffs without writing")
+    parser.add_argument("--no-commit", action="store_true", help="Write files but skip git commit")
+    parser.add_argument("--message", help="Override the default commit message")
+    parser.add_argument("--force", action="store_true", help="Overwrite conflicting in-tree lesson source")
+    return parser
+
+
+def main(argv: list[str] | None = None, *, repo_root: Path = ROOT) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return promote(args, repo_root=repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync/prune_module_forensics.py
+++ b/scripts/sync/prune_module_forensics.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Prune promoted V7 forensics from locked curriculum modules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.sync.promote_module import CURRICULUM_ROOT, FORENSICS_FILES, _sanitized_git_env
+
+
+@dataclass(frozen=True)
+class ModuleTarget:
+    level: str
+    slug: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.level}/{self.slug}"
+
+    @property
+    def module_rel(self) -> Path:
+        return CURRICULUM_ROOT / self.level / self.slug
+
+
+def _run_git(repo_root: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=check,
+        capture_output=True,
+        env=_sanitized_git_env(),
+    )
+
+
+def _decode(data: bytes) -> str:
+    return data.decode("utf-8", errors="replace")
+
+
+def _status_path(target: ModuleTarget) -> Path:
+    return target.module_rel / "status" / f"{target.slug}.json"
+
+
+def _read_status(repo_root: Path, target: ModuleTarget) -> str | None:
+    path = repo_root / _status_path(target)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    status = data.get("status")
+    return status if isinstance(status, str) else None
+
+
+def _is_locked(repo_root: Path, target: ModuleTarget) -> bool:
+    return _read_status(repo_root, target) == "locked"
+
+
+def _discover_all_targets(repo_root: Path, *, force: bool) -> list[ModuleTarget]:
+    root = repo_root / CURRICULUM_ROOT
+    targets: list[ModuleTarget] = []
+    if not root.exists():
+        return targets
+    for level_dir in sorted(path for path in root.iterdir() if path.is_dir() and not path.name.startswith("_")):
+        if level_dir.name == "plans":
+            continue
+        for module_dir in sorted(path for path in level_dir.iterdir() if path.is_dir()):
+            target = ModuleTarget(level=level_dir.name, slug=module_dir.name)
+            has_status = (repo_root / _status_path(target)).exists()
+            has_forensics = any((module_dir / filename).exists() for filename in FORENSICS_FILES)
+            if force:
+                if has_forensics:
+                    targets.append(target)
+            elif has_status:
+                targets.append(target)
+    return targets
+
+
+def _forensics_paths(target: ModuleTarget) -> list[Path]:
+    return [target.module_rel / filename for filename in sorted(FORENSICS_FILES)]
+
+
+def _commit(repo_root: Path, rels: list[Path], message: str) -> None:
+    rel_args = [rel.as_posix() for rel in rels]
+    _run_git(repo_root, ["add", "-u", "--", *rel_args])
+    staged = _run_git(repo_root, ["diff", "--cached", "--quiet"], check=False)
+    if staged.returncode == 0:
+        print("OK no staged changes")
+        return
+    _run_git(repo_root, ["commit", "-m", message])
+
+
+def _prune_one(repo_root: Path, target: ModuleTarget, *, dry_run: bool) -> list[Path]:
+    removed: list[Path] = []
+    for rel in _forensics_paths(target):
+        path = repo_root / rel
+        if not path.exists():
+            print(f"{target.label}: already pruned, skip {rel.name}")
+            continue
+        if dry_run:
+            print(f"{target.label}: would remove {rel.as_posix()}")
+        else:
+            path.unlink()
+            print(f"{target.label}: removed {rel.as_posix()}")
+        removed.append(rel)
+    return removed
+
+
+def prune(args: argparse.Namespace, *, repo_root: Path = ROOT) -> int:
+    repo_root = repo_root.resolve()
+    if args.all:
+        targets = _discover_all_targets(repo_root, force=args.force)
+        if not targets:
+            print("OK nothing-to-prune")
+            return 0
+    else:
+        if not args.level or not args.slug:
+            print("ERROR specify --level and --slug, or use --all", file=sys.stderr)
+            return 2
+        targets = [ModuleTarget(level=args.level.lower(), slug=args.slug)]
+
+    removed: list[Path] = []
+    refused = False
+    for target in targets:
+        if not args.force and not _is_locked(repo_root, target):
+            status = _read_status(repo_root, target)
+            if args.all:
+                print(f"{target.label}: skip status={status or 'missing'}")
+                continue
+            print(
+                f"ERROR {target.label} is not locked "
+                f"(status={status or 'missing'}); use --force to bypass",
+                file=sys.stderr,
+            )
+            refused = True
+            continue
+        removed.extend(_prune_one(repo_root, target, dry_run=args.dry_run))
+
+    if refused:
+        return 1
+
+    if not removed:
+        print("OK nothing-to-prune")
+        return 0
+
+    if args.dry_run:
+        print(f"OK dry-run would remove {len(removed)} file(s)")
+        return 0
+
+    if args.no_commit:
+        print("OK pruned without commit (--no-commit)")
+        return 0
+
+    if args.all:
+        message = "chore(content): prune forensics for locked modules"
+    else:
+        target = targets[0]
+        message = f"chore(content): prune forensics for locked {target.label}"
+    try:
+        _commit(repo_root, removed, message)
+    except subprocess.CalledProcessError as exc:
+        print(_decode(exc.stderr), file=sys.stderr, end="")
+        return exc.returncode or 1
+    print("OK pruned and committed")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--level", help="Level to prune")
+    parser.add_argument("--slug", help="Module slug to prune")
+    parser.add_argument("--all", action="store_true", help="Prune every locked module")
+    parser.add_argument("--dry-run", action="store_true", help="Show planned deletions without deleting")
+    parser.add_argument("--no-commit", action="store_true", help="Delete files but skip git commit")
+    parser.add_argument("--force", action="store_true", help="Bypass locked-status check")
+    return parser
+
+
+def main(argv: list[str] | None = None, *, repo_root: Path = ROOT) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return prune(args, repo_root=repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sync/test_promote_module.py
+++ b/tests/sync/test_promote_module.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.sync import promote_module
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    # Strip any inherited GIT_* / pre-commit env vars so the inner test repo
+    # isn't confused by the outer repo's GIT_DIR / GIT_INDEX_FILE / etc. when
+    # the suite runs under pre-commit's pytest hook.
+    merged_env = {k: v for k, v in os.environ.items() if not k.startswith(("GIT_", "PRE_COMMIT"))}
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=merged_env,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Use _git (which strips inherited GIT_*/PRE_COMMIT env vars) for init too —
+    # the bare subprocess.run path inherits the parent shell's git context and
+    # under pre-commit's pytest hook that confuses init enough to leak into
+    # the parent repo's config.
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _rel_module(level: str, slug: str, filename: str) -> Path:
+    return Path("curriculum") / "l2-uk-en" / level / slug / filename
+
+
+def _rel_mdx(level: str, slug: str) -> Path:
+    return Path("starlight") / "src" / "content" / "docs" / level / f"{slug}.mdx"
+
+
+def _seed_build_branch(
+    repo: Path,
+    branch: str,
+    *,
+    level: str = "a1",
+    slug: str = "foo",
+    omit: set[str] | None = None,
+    module_text: str = "# Module\n",
+    stamp: str = "2026-05-20T01:01:01 +0000",
+) -> None:
+    omit = omit or set()
+    _git(repo, "switch", "-c", branch)
+    files = {
+        "module.md": module_text,
+        "activities.yaml": "- kind: quiz\n",
+        "vocabulary.yaml": "- word: тест\n",
+        "resources.yaml": "resources: []\n",
+        "writer_prompt.md": "prompt\n",
+        "writer_output.raw.md": "raw\n",
+        "hermes.write.jsonl": "{}\n",
+        "writer_tool_calls.json": "[]\n",
+        "python_qg.json": "{}\n",
+        "llm_qg.json": "{}\n",
+        "knowledge_packet.md": "packet\n",
+        "implementation_map.json": "{}\n",
+    }
+    for filename, content in files.items():
+        if filename in omit:
+            continue
+        path = repo / _rel_module(level, slug, filename)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    if "mdx" not in omit:
+        mdx = repo / _rel_mdx(level, slug)
+        mdx.parent.mkdir(parents=True, exist_ok=True)
+        mdx.write_text("mdx content\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    env = {"GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp}
+    _git(repo, "commit", "-m", f"build {branch}", env=env)
+    _git(repo, "switch", "main")
+
+
+def test_promote_copies_lesson_source_and_forensics(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    branch = "build/a1/foo-20260520-010101"
+    _seed_build_branch(repo, branch)
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    assert (repo / _rel_module("a1", "foo", "module.md")).read_text(encoding="utf-8") == "# Module\n"
+    assert (repo / _rel_module("a1", "foo", "writer_prompt.md")).read_text(encoding="utf-8") == "prompt\n"
+    assert (repo / _rel_mdx("a1", "foo")).read_text(encoding="utf-8") == "mdx content\n"
+
+
+def test_promote_fails_if_lesson_source_incomplete(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    branch = "build/a1/foo-20260520-010101"
+    _seed_build_branch(repo, branch, omit={"module.md"})
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 2
+    assert not (repo / _rel_module("a1", "foo", "activities.yaml")).exists()
+    assert not (repo / _rel_mdx("a1", "foo")).exists()
+
+
+def test_promote_idempotent_on_matching_content(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    branch = "build/a1/foo-20260520-010101"
+    _seed_build_branch(repo, branch)
+    assert promote_module.main(["--build-branch", branch], repo_root=repo) == 0
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    rc = promote_module.main(["--build-branch", branch], repo_root=repo)
+
+    assert rc == 0
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == head
+
+
+def test_promote_aborts_on_partial_match_without_force(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    branch = "build/a1/foo-20260520-010101"
+    _seed_build_branch(repo, branch)
+    dest = repo / _rel_module("a1", "foo", "module.md")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("# Hand edited\n", encoding="utf-8")
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 1
+    assert dest.read_text(encoding="utf-8") == "# Hand edited\n"
+
+
+def test_promote_dry_run_writes_nothing(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    branch = "build/a1/foo-20260520-010101"
+    _seed_build_branch(repo, branch)
+
+    rc = promote_module.main(["--build-branch", branch, "--dry-run"], repo_root=repo)
+
+    assert rc == 0
+    assert not (repo / _rel_module("a1", "foo", "module.md")).exists()
+    assert _git(repo, "status", "--short").stdout == ""
+
+
+def test_promote_resolves_latest_branch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    older = "build/a1/foo-20260520-010101"
+    newer = "build/a1/foo-20260520-020202"
+    _seed_build_branch(repo, newer, module_text="# Newer\n", stamp="2026-05-20T02:02:02 +0000")
+    _seed_build_branch(repo, older, module_text="# Older\n", stamp="2026-05-20T01:01:01 +0000")
+
+    rc = promote_module.main(["--latest", "--level", "a1", "--slug", "foo", "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    assert (repo / _rel_module("a1", "foo", "module.md")).read_text(encoding="utf-8") == "# Newer\n"

--- a/tests/sync/test_prune_module_forensics.py
+++ b/tests/sync/test_prune_module_forensics.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.sync import prune_module_forensics
+from scripts.sync.promote_module import FORENSICS_FILES, LESSON_SOURCE_FILES
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    # Strip any inherited GIT_* / pre-commit env vars so the inner test repo
+    # isn't confused by the outer repo's git context (e.g. when the suite
+    # runs under pre-commit's pytest hook).
+    sanitized = {k: v for k, v in os.environ.items() if not k.startswith(("GIT_", "PRE_COMMIT"))}
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=sanitized,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Use _git (which strips inherited GIT_*/PRE_COMMIT env vars) for init too —
+    # the bare subprocess.run path inherits the parent shell's git context and
+    # under pre-commit's pytest hook that confuses init enough to leak into
+    # the parent repo's config.
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _module_dir(repo: Path, level: str, slug: str) -> Path:
+    return repo / "curriculum" / "l2-uk-en" / level / slug
+
+
+def _mdx_path(repo: Path, level: str, slug: str) -> Path:
+    return repo / "starlight" / "src" / "content" / "docs" / level / f"{slug}.mdx"
+
+
+def _seed_module(repo: Path, level: str, slug: str, *, status: str = "locked", forensics: bool = True) -> None:
+    module_dir = _module_dir(repo, level, slug)
+    module_dir.mkdir(parents=True, exist_ok=True)
+    for filename in LESSON_SOURCE_FILES:
+        (module_dir / filename).write_text(f"{filename}\n", encoding="utf-8")
+    if forensics:
+        for filename in FORENSICS_FILES:
+            (module_dir / filename).write_text(f"{filename}\n", encoding="utf-8")
+    status_dir = module_dir / "status"
+    status_dir.mkdir(parents=True, exist_ok=True)
+    (status_dir / f"{slug}.json").write_text(json.dumps({"status": status}) + "\n", encoding="utf-8")
+    mdx = _mdx_path(repo, level, slug)
+    mdx.parent.mkdir(parents=True, exist_ok=True)
+    mdx.write_text("mdx\n", encoding="utf-8")
+
+
+def test_prune_removes_forensics_keeps_lesson_source(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _seed_module(repo, "a1", "foo")
+
+    rc = prune_module_forensics.main(["--level", "a1", "--slug", "foo", "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    module_dir = _module_dir(repo, "a1", "foo")
+    for filename in FORENSICS_FILES:
+        assert not (module_dir / filename).exists()
+    for filename in LESSON_SOURCE_FILES:
+        assert (module_dir / filename).exists()
+    assert _mdx_path(repo, "a1", "foo").exists()
+
+
+def test_prune_refuses_when_status_not_locked(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _seed_module(repo, "a1", "foo", status="draft")
+
+    rc = prune_module_forensics.main(["--level", "a1", "--slug", "foo", "--no-commit"], repo_root=repo)
+
+    assert rc == 1
+    assert (_module_dir(repo, "a1", "foo") / "writer_prompt.md").exists()
+
+
+def test_prune_force_bypasses_status_check(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _seed_module(repo, "a1", "foo", status="draft")
+
+    rc = prune_module_forensics.main(["--level", "a1", "--slug", "foo", "--force", "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    assert not (_module_dir(repo, "a1", "foo") / "writer_prompt.md").exists()
+
+
+def test_prune_idempotent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _seed_module(repo, "a1", "foo", forensics=False)
+
+    rc = prune_module_forensics.main(["--level", "a1", "--slug", "foo", "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    assert (_module_dir(repo, "a1", "foo") / "module.md").exists()
+
+
+def test_prune_all_skips_non_locked(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _seed_module(repo, "a1", "locked")
+    _seed_module(repo, "a1", "draft", status="draft")
+    _seed_module(repo, "a1", "ready", status="ready")
+
+    rc = prune_module_forensics.main(["--all", "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    assert not (_module_dir(repo, "a1", "locked") / "writer_prompt.md").exists()
+    assert (_module_dir(repo, "a1", "draft") / "writer_prompt.md").exists()
+    assert (_module_dir(repo, "a1", "ready") / "writer_prompt.md").exists()


### PR DESCRIPTION
## Summary

Closes the loop opened by #M-10 (build-artifact preservation):
`v7_build.py` auto-commits artifacts to `build/<level>/<slug>-<stamp>`; this
PR ships the matching tools to:

- **promote** a green V7 build's source + forensics into the canonical curriculum tree
- **prune** the forensics once the module is locked

Scope locked by handoff §7 Decision 2 (2026-05-20): copy the **full** artifact set on promote — clean up at lock-time via the prune helper. "Later = tool call" not "later = never."

## What ships

- `scripts/sync/promote_module.py` — `--build-branch | --worktree | --latest`, `--dry-run`, `--no-commit`, `--message`, `--force`. Fails fast on missing lesson source; idempotent on matching content; aborts on partial-match conflicts without `--force`.
- `scripts/sync/prune_module_forensics.py` — `--level/--slug` single or `--all` (every locked module). Refuses unless `status/<slug>.json` is locked, unless `--force`.
- `tests/sync/test_promote_module.py` + `tests/sync/test_prune_module_forensics.py` — 11 tests pinning the happy + edge paths.

## Env-sanitization (load-bearing fix Claude added on top of Codex's work)

Both scripts AND both test fixtures strip inherited `GIT_*` / `PRE_COMMIT*` env vars before any git subprocess call (`_sanitized_git_env()` lives in `promote_module.py`, re-used by `prune_module_forensics.py` and the test fixtures).

Without the strip, the parent repo's git context (`GIT_DIR` / `GIT_INDEX_FILE`) leaks into `git -C <repo> ...` calls. Two visible symptoms when running under pre-commit's pytest hook:

1. test fixture's `git init -b main` → subsequent `git -C <repo> add README.md` exits 128 with "must be run in a work tree."
2. during the leaky early init/config, the fixture's test-user identity AND `core.bare=true` get written into the **outer** repo's `.git/config`, breaking subsequent live git operations in the parent worktree.

## Verifiable claims

| Claim | Command + raw output |
|---|---|
| sync helpers exist | `ls -la scripts/sync/promote_module.py scripts/sync/prune_module_forensics.py` — both present, ~13.3 KB + ~6.4 KB |
| `--help` renders | `.venv/bin/python scripts/sync/promote_module.py --help` and `... prune_module_forensics.py --help` — both render full usage strings |
| sync tests pass | `.venv/bin/python -m pytest tests/sync/ -v` — `11 passed in 1.40s` |
| ruff clean | `.venv/bin/ruff check scripts/sync/ tests/sync/` — `All checks passed!` |
| commit landed | `git log -1 --oneline` — `788765d8d2 feat(sync): paired promote_module + prune_module_forensics helpers` |

## Provenance

- Authored by Codex via `delegate.py dispatch --agent codex` (task `promote-prune-helpers-20260521`, 2117s).
- Codex correctly refused to commit because the full pytest suite was red on `test_build_knowledge_packet_appends_textbook_excerpts` (out-of-scope per its brief). That + one other stale test were fixed in `afc3510364` directly on main; this branch was merged onto that fix before committing.
- Dispatch brief: `docs/dispatch-briefs/2026-05-21-promote-prune-helpers-codex.md`.

## Test plan

- [x] `.venv/bin/python -m pytest tests/sync/ -v` — 11 passed
- [x] `.venv/bin/ruff check scripts/sync/ tests/sync/` — clean
- [x] `--help` smoke for both scripts
- [ ] Smoke-test against the existing `build/a1/my-morning-20260520-223609` branch with `--dry-run` to confirm promote behavior — recommended next session before relying on the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)