### PR TITLE
fix(ocr): migrate gemini-cli tool restriction to Policy Engine

### DIFF
--- a/scripts/etymology/bulk_ocr_gemini.py
+++ b/scripts/etymology/bulk_ocr_gemini.py
@@ -28,6 +28,7 @@ JP2_STAGING = RAW_ESUM / "jp2-staging"
 OCR_DIR = RAW_ESUM / "gemini-ocr"
 DEFAULT_PROMPT = ROOT / "audit/etymology-ocr-feasibility/prompts/transcription-v1.txt"
 DEFAULT_LOG = ROOT / "audit/etymology-ocr-feasibility/bulk-run-log.jsonl"
+GEMINI_OCR_POLICY = ROOT / "scripts/etymology/gemini-ocr-policy.toml"
 GEMINI_TMP_DIR = ROOT / "gemini_ocr_images"
 DEFAULT_MODEL = "gemini-2.5-flash"
 DEFAULT_CONCURRENCY = 10
@@ -72,13 +73,7 @@ TRANSIENT_RE = re.compile(
     # 429 / RESOURCE_EXHAUSTED when NOT daily (DAILY_QUOTA_RE catches the
     # multi-hour-reset case first). Account-level burst rate-limit recovers
     # within seconds; backoff is enough.
-    r"|\b429\b|RESOURCE_EXHAUSTED(?!.*daily)|\brate[- ]?limit"
-    # Silent failure: gemini-cli exits 0 with only the --allowed-tools
-    # deprecation warning + YOLO mode message + Ripgrep notice on stderr, and
-    # no usable output. is_low_quality_output() catches the output side; this
-    # regex lets classify_error see the deprecation-only stderr and route to
-    # transient retry. ~13% of stderr observed in run #8 is this pattern.
-    r"|allowed-tools.*deprecated",
+    r"|\b429\b|RESOURCE_EXHAUSTED(?!.*daily)|\brate[- ]?limit",
     re.IGNORECASE,
 )
 IMAGE_REFUSAL_RE = re.compile(
@@ -379,8 +374,8 @@ async def run_gemini_once(page: Page, prompt_text: str, model: str, attempt: int
             model,
             "--output-format",
             "text",
-            "--allowed-tools",
-            "read_file",
+            "--policy",
+            str(GEMINI_OCR_POLICY),
             "-y",
             cwd=ROOT,
             stdin=asyncio.subprocess.PIPE,

--- a/scripts/etymology/gemini-ocr-policy.toml
+++ b/scripts/etymology/gemini-ocr-policy.toml
@@ -1,0 +1,13 @@
+# Tool restriction for bulk OCR; replaces deprecated `--allowed-tools read_file`
+# flag in `bulk_ocr_gemini.py`.
+
+[[rule]]
+toolName = "read_file"
+decision = "allow"
+priority = 999
+
+[[rule]]
+toolName = "*"
+decision = "deny"
+priority = 900
+denyMessage = "Bulk OCR may only read the image file attached with @<path>."

--- a/tests/etymology/test_bulk_ocr_quality.py
+++ b/tests/etymology/test_bulk_ocr_quality.py
@@ -1,10 +1,15 @@
 """Regression tests for Gemini OCR quality filtering."""
 
+import asyncio
 from textwrap import dedent
 
+from scripts.etymology import bulk_ocr_gemini
 from scripts.etymology.bulk_ocr_gemini import (
+    GEMINI_OCR_POLICY,
+    Page,
     is_low_quality_output,
     is_repetition_hallucination,
+    run_gemini_once,
     strip_planning_preamble,
 )
 
@@ -215,6 +220,42 @@ REPETITION_SHORT_PAGE = "\n".join(
 
 def test_is_low_quality_rejects_bare_refusal():
     assert is_low_quality_output(BARE_REFUSAL) is True
+
+
+def test_run_gemini_once_uses_policy_not_deprecated_allowed_tools(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+    copied_image = tmp_path / "copied.png"
+
+    class DummyProc:
+        returncode = 0
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return DummyProc()
+
+    async def fake_communicate_with_heartbeat(proc, page, prompt_text, attempt):
+        return b"\xd1\x83\xd0\xba\xd1\x80", b""
+
+    def fake_prepare_gemini_image(page):
+        copied_image.write_bytes(b"png")
+        return copied_image
+
+    monkeypatch.setattr(bulk_ocr_gemini.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(bulk_ocr_gemini, "communicate_with_heartbeat", fake_communicate_with_heartbeat)
+    monkeypatch.setattr(bulk_ocr_gemini, "prepare_gemini_image", fake_prepare_gemini_image)
+
+    page = Page(1, 1, tmp_path / "p0001.jp2", tmp_path / "p0001.png", tmp_path / "p0001.md")
+    returncode, stdout, stderr = asyncio.run(run_gemini_once(page, "Transcribe", "gemini-2.5-flash", 1))
+
+    args = captured["args"]
+    assert returncode == 0
+    assert stdout == b"\xd1\x83\xd0\xba\xd1\x80"
+    assert stderr == b""
+    assert "--allowed-tools" not in args
+    assert "--policy" in args
+    assert args[args.index("--policy") + 1] == str(GEMINI_OCR_POLICY)
+    assert not copied_image.exists()
 
 
 def test_is_low_quality_rejects_mixed_refusal_block():


### PR DESCRIPTION
## Summary
- Replace deprecated `--allowed-tools read_file` with `--policy scripts/etymology/gemini-ocr-policy.toml`.
- Add a deny-all-by-default Policy Engine file that only allows `read_file` for OCR image attachment.
- Add a regression test that verifies `run_gemini_once` passes `--policy` and never passes the deprecated args.

## Policy docs evidence
Fetched `https://geminicli.com/docs/core/policy-engine`, which redirects to `https://geminicli.com/docs/reference/policy-engine/`.

Key facts read from the docs:
- Policy files are TOML: “Policies are defined in `.toml` files.”
- Rules use `[[rule]]`, `toolName`, `decision`, and `priority`.
- `toolName = "*"` matches any tool.
- Decisions include `allow`, `deny`, and `ask_user`; `deny` is recommended for excluding tools.
- Approval modes include `yolo`; rules without `modes` apply in all modes.

Installed CLI confirmation:
```
$ gemini --version
0.42.0

$ gemini --help
      --policy                    Additional policy files or directories to load (comma-separated or multiple --policy)  [array]
      --admin-policy              Additional admin policy files or directories to load (comma-separated or multiple --admin-policy)  [array]
      --allowed-tools             [DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/core/policy-engine] Tools that are allowed to run without confirmation  [array]
```

## Diagnostic chain
1. `scripts/etymology/bulk_ocr_gemini.py:374-389` invokes `gemini` with:
   ```
   --allowed-tools read_file
   -y
   ```
2. `gemini --help` on installed version 0.42.0 says:
   ```
   --allowed-tools  [DEPRECATED: Use Policy Engine instead See https://geminicli.com/docs/core/policy-engine] Tools that are allowed to run without confirmation  [array]
   ```
3. Deprecated = silently a no-op. Combined with `-y` (yolo auto-approves ALL tools), the model can call any tool.
4. Observed effect (per `audit/etymology-ocr-feasibility/bulk-run-log.jsonl` last entries):
   ```
   Error executing tool web_fetch: The 'prompt' must contain at least one valid URL (starting with http:// or https://).
   ```
5. 21 such errors in last 100 pages (mostly vol6/p0006–p0047 range) tripped `BULK_QUALITY_HALT page=vol6/p0047 errors_last_100=21`.

## Smoke test evidence
```
cwd=/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/ocr-policy-2026-05-21
command=/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python - <<PY [run_gemini_once vol1/p0004]
returncode=0
stderr_begin
Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support.
Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience.
YOLO mode is enabled. All tool calls will be automatically approved.
YOLO mode is enabled. All tool calls will be automatically approved.
Ripgrep is not available. Falling back to GrepTool.
WARNING: The following project-level hooks have been detected in this workspace:
  - python -c "import sys,pathlib,json;e=pathlib.Path('graphify-out/graph.json').exists();d={'decision':'allow'};e and d.update({'additionalContext':'graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.'});sys.stdout.write(json.dumps(d))"

These hooks will be executed. If you did not configure these hooks or do not trust this project,
please review the project settings (.gemini/settings.json) and remove them.
stderr_end
stdout_chars=4041
stdout_head_begin
**бгати** «гнути, м'яти, стискати; збирати докупи» Ж,
Ш, СУМ, [обіймати] ВеУз; — *бга́ний* «м'ятий» Ж;
— *бга́тися* «м'ятися, збиратися» Ж; — по́бга-
ний «зім'ятий» Ж; п. *b^gać* «гнути», бга́ти «гнути,
м'яти» М, ВеУз;
— *збга́ти* «зім'яти, згорнути» Ж;
— *набга́ти* «нам'яти» Ж;
— *оббга́ти* «обтиснути» Ж;
— *бга́вка* «складочка» Ж;
— *бгани́на* «зім'ята тканина» Ж;
— *бганиця* «складочка» Ж;
— *бганка* «складка» Ж; — *бганки* «зморшки»
stdout_head_end
```

There are zero `Error executing tool` lines in stderr.

## Required raw diff evidence
`git diff scripts/etymology/bulk_ocr_gemini.py | head -40`:
```
diff --git a/scripts/etymology/bulk_ocr_gemini.py b/scripts/etymology/bulk_ocr_gemini.py
index 1072e8e526..caab7a8013 100644
--- a/scripts/etymology/bulk_ocr_gemini.py
+++ b/scripts/etymology/bulk_ocr_gemini.py
@@ -28,6 +28,7 @@ JP2_STAGING = RAW_ESUM / "jp2-staging"
 OCR_DIR = RAW_ESUM / "gemini-ocr"
 DEFAULT_PROMPT = ROOT / "audit/etymology-ocr-feasibility/prompts/transcription-v1.txt"
 DEFAULT_LOG = ROOT / "audit/etymology-ocr-feasibility/bulk-run-log.jsonl"
+GEMINI_OCR_POLICY = ROOT / "scripts/etymology/gemini-ocr-policy.toml"
 GEMINI_TMP_DIR = ROOT / "gemini_ocr_images"
 DEFAULT_MODEL = "gemini-2.5-flash"
 DEFAULT_CONCURRENCY = 10
@@ -72,13 +73,7 @@ TRANSIENT_RE = re.compile(
     # 429 / RESOURCE_EXHAUSTED when NOT daily (DAILY_QUOTA_RE catches the
     # multi-hour-reset case first). Account-level burst rate-limit recovers
     # within seconds; backoff is enough.
-    r"|\b429\b|RESOURCE_EXHAUSTED(?!.*daily)|\brate[- ]?limit"
-    # Silent failure: gemini-cli exits 0 with only the --allowed-tools
-    # deprecation warning + YOLO mode message + Ripgrep notice on stderr, and
-    # no usable output. is_low_quality_output() catches the output side; this
-    # regex lets classify_error see the deprecation-only stderr and route to
-    # transient retry. ~13% of stderr observed in run #8 is this pattern.
-    r"|allowed-tools.*deprecated",
+    r"|\b429\b|RESOURCE_EXHAUSTED(?!.*daily)|\brate[- ]?limit",
     re.IGNORECASE,
 )
 IMAGE_REFUSAL_RE = re.compile(
@@ -379,8 +374,8 @@ async def run_gemini_once(page: Page, prompt_text: str, model: str, attempt: int
             model,
             "--output-format",
             "text",
-            "--allowed-tools",
-            "read_file",
+            "--policy",
+            str(GEMINI_OCR_POLICY),
             "-y",
             cwd=ROOT,
             stdin=asyncio.subprocess.PIPE,
```

`cat scripts/etymology/gemini-ocr-policy.toml`:
```
# Tool restriction for bulk OCR; replaces deprecated `--allowed-tools read_file`
# flag in `bulk_ocr_gemini.py`.

[[rule]]
toolName = "read_file"
decision = "allow"
priority = 999

[[rule]]
toolName = "*"
decision = "deny"
priority = 900
denyMessage = "Bulk OCR may only read the image file attached with @<path>."
```

## Test plan
- [x] One fresh page OCRs with zero `Error executing tool` lines.
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/etymology/test_bulk_ocr_quality.py -x`
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/etymology/bulk_ocr_gemini.py`
- [x] `git diff --check`
- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

Pytest tail:
```
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_rejects_bare_refusal PASSED [  8%]
tests/etymology/test_bulk_ocr_quality.py::test_run_gemini_once_uses_policy_not_deprecated_allowed_tools PASSED [ 16%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_rejects_mixed_refusal_block PASSED [ 25%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_rejects_completion_meta_self_praise PASSED [ 33%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_rejects_trailing_update_topic PASSED [ 41%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_rejects_repetition_hallucination_extreme PASSED [ 50%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_rejects_repetition_hallucination_moderate PASSED [ 58%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_accepts_legit_cross_reference_heavy_page PASSED [ 66%]
tests/etymology/test_bulk_ocr_quality.py::test_is_repetition_hallucination_short_page_skip PASSED [ 75%]
tests/etymology/test_bulk_ocr_quality.py::test_strip_planning_preamble_removes_trailing_update_topic PASSED [ 83%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_accepts_clean_page PASSED [ 91%]
tests/etymology/test_bulk_ocr_quality.py::test_is_low_quality_accepts_legit_apology PASSED [100%]

============================== 12 passed in 0.06s ==============================
```

Ruff:
```
All checks passed!
```

Agent trailer:
```
Checking 1 commit(s) in origin/main..HEAD:

  aa0bcb1fd8  PASS  X-Agent: codex/ocr-policy-2026-05-21

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Issues encountered
- The requested `tests/test_bulk_ocr_gemini.py` file does not exist; `find tests -name '*ocr*' -o -name '*gemini*'` found the relevant existing OCR test at `tests/etymology/test_bulk_ocr_quality.py`, so the regression test was added there.
- This dispatch worktree does not contain its own `.venv` symlink; commands used the local project venv at `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/...`.

Generated by Codex dispatch `codex/ocr-policy-2026-05-21`.