### PR TITLE
feat(delegate): thread --max-budget-usd to claude adapter (gap-close from zodchiii review)

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -90,6 +90,15 @@ class AgyAdapter:
         if mode not in self.supported_modes:
             raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
 
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; "
+                "use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
+
         if effort is not None:
             _logger.debug(
                 "agy effort %r not yet wired through CLI — "

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -159,6 +159,8 @@ class ClaudeAdapter:
               calls can be captured from the CLI trace.
             - ``use_bare: bool`` — explicit opt-out of --bare (default: auto-enable
               when no session + ANTHROPIC_API_KEY is set)
+            - ``max_budget_usd: float`` — optional Claude Code print-mode
+              API spend cap, emitted as ``--max-budget-usd <amount>``
 
         ``effort``: optional reasoning-level string. When non-None and the
         probed Claude binary supports ``--effort`` (CC 2.1.98+), the flag
@@ -240,6 +242,12 @@ class ClaudeAdapter:
         # Model override
         if model:
             cmd.extend(["--model", model])
+
+        max_budget_usd = tc.get("max_budget_usd")
+        if max_budget_usd is not None:
+            # Claude Code only honors --max-budget-usd in print mode. This
+            # adapter always uses -p, so the constraint is satisfied here.
+            cmd.extend(["--max-budget-usd", f"{float(max_budget_usd):.2f}"])
 
         # Effort (reasoning level) — version-gated. See #1396.
         if effort is not None:

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -170,6 +170,15 @@ class CodexAdapter:
         if discussion_readonly and mode != "read-only":
             raise ValueError("AB_DISCUSS_READONLY requires mode='read-only'")
 
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; "
+                "use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
+
         # Resolve binary. shutil.which handles PATH lookup; fall back to
         # bare "codex" if not on PATH so subprocess.Popen can report the
         # error clearly.

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -208,6 +208,15 @@ class GeminiAdapter:
         if discussion_readonly and mode != "read-only":
             raise ValueError("AB_DISCUSS_READONLY requires mode='read-only'")
 
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; "
+                "use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
+
         if effort is not None:
             _logger.debug(
                 "gemini effort %r not yet wired through CLI — "

--- a/scripts/agent_runtime/adapters/hermes_deepseek.py
+++ b/scripts/agent_runtime/adapters/hermes_deepseek.py
@@ -143,7 +143,15 @@ class HermesDeepSeekAdapter:
         _ = mode
         _ = task_id
         _ = session_id
-        _ = tool_config
+
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; "
+                "use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
 
         config = _read_hermes_config()
         configured_effort = _top_level_agent_effort(config)

--- a/scripts/agent_runtime/adapters/hermes_grok.py
+++ b/scripts/agent_runtime/adapters/hermes_grok.py
@@ -116,7 +116,15 @@ class HermesGrokAdapter:
         _ = mode
         _ = task_id
         _ = session_id
-        _ = tool_config
+
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; "
+                "use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
 
         config = _read_hermes_config()
         configured_effort = _top_level_agent_effort(config)

--- a/scripts/agent_runtime/adapters/hermes_qwen.py
+++ b/scripts/agent_runtime/adapters/hermes_qwen.py
@@ -140,7 +140,15 @@ class HermesQwenAdapter:
         _ = mode
         _ = task_id
         _ = session_id
-        _ = tool_config
+
+        max_budget_usd = (tool_config or {}).get("max_budget_usd")
+        if max_budget_usd is not None:
+            _logger.warning(
+                "non-claude adapter %s ignoring max_budget_usd=%s; "
+                "use hard-timeout/silence-timeout instead",
+                self.name,
+                max_budget_usd,
+            )
 
         config = _read_hermes_config()
         configured_effort = _top_level_agent_effort(config)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -677,6 +677,7 @@ def _run_worker(
     hard_timeout: int,
     silence_timeout: int = DEFAULT_SILENCE_TIMEOUT_S,
     effort: str | None = None,
+    max_budget_usd: float | None = None,
 ) -> int:
     """Worker main loop. Invokes the runtime, updates the state file.
 
@@ -710,6 +711,7 @@ def _run_worker(
     state = _read_state(state_path) or {}
     state["pid"] = os.getpid()
     state["status"] = "running"
+    state["max_budget_usd"] = max_budget_usd
     if "cli_version" not in state:
         start_telemetry = resolve_dispatch_start_telemetry(
             agent_name=agent,
@@ -734,6 +736,11 @@ def _run_worker(
     cancelled = False
     try:
         stdout_silence_timeout = silence_timeout if silence_timeout > 0 else None
+        tool_config = (
+            {"max_budget_usd": max_budget_usd}
+            if max_budget_usd is not None
+            else None
+        )
         result = runtime_invoke(
             agent,
             prompt,
@@ -742,7 +749,7 @@ def _run_worker(
             model=model,
             task_id=task_id,
             session_id=None,  # Layer 3 is always fresh-session
-            tool_config=None,
+            tool_config=tool_config,
             entrypoint="delegate",
             hard_timeout=hard_timeout,
             stdout_silence_timeout=stdout_silence_timeout,
@@ -845,6 +852,7 @@ def _run_worker(
             status=final_status,
             silence_timeout_s=silence_timeout,
             hard_timeout_s=hard_timeout,
+            max_budget_usd=max_budget_usd,
             duration_s=round(duration_s, 3),
             stderr_excerpt=stderr_excerpt,
         )
@@ -865,6 +873,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     state_path = _state_path(task_id)
     worktree_arg = getattr(args, "worktree", None)
     silence_timeout = getattr(args, "silence_timeout", DEFAULT_SILENCE_TIMEOUT_S)
+    max_budget_usd = getattr(args, "max_budget_usd", None)
 
     if args.mode == "danger" and not worktree_arg:
         print(
@@ -990,6 +999,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "worktree_layout": worktree_layout,
         "hard_timeout": args.hard_timeout,
         "silence_timeout": silence_timeout,
+        "max_budget_usd": max_budget_usd,
         "pid": None,  # worker fills this
         "status": "spawning",
         "started_at": datetime.now(UTC).isoformat(),
@@ -1041,6 +1051,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "--hard-timeout", str(args.hard_timeout),
         "--silence-timeout", str(silence_timeout),
     ]
+    if max_budget_usd is not None:
+        cmd.extend(["--max-budget-usd", str(max_budget_usd)])
     if args.model:
         cmd.extend(["--model", args.model])
     effort = getattr(args, "effort", None)
@@ -1486,6 +1498,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
         model=args.model,
         hard_timeout=args.hard_timeout,
         silence_timeout=args.silence_timeout,
+        max_budget_usd=getattr(args, "max_budget_usd", None),
         effort=args.effort,
     )
 
@@ -1505,6 +1518,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Examples:\n"
             "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id review-123 --prompt-file prompt.md --mode workspace-write --cwd .\n"
             "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id pr-123 --prompt-file brief.md --mode danger --worktree .worktrees/codex-pr-123\n"
+            "  .venv/bin/python scripts/delegate.py dispatch --agent claude --task-id review-456 --prompt-file brief.md --max-budget-usd 0.50\n"
             "  .venv/bin/python scripts/delegate.py status-or-fail review-123\n"
             "  .venv/bin/python scripts/delegate.py wait review-123 --timeout 600\n"
             "  .venv/bin/python scripts/delegate.py list --status running\n\n"
@@ -1514,6 +1528,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  --hard-timeout is the absolute wall-clock fallback for the worker.\n"
             "  --silence-timeout kills the agent CLI earlier when no stdout line arrives within the window.\n"
             "    Default is 1800s to tolerate long Codex thinking/test phases; pass 600 for a tighter watchdog; 0 disables it.\n\n"
+            "  --max-budget-usd caps Claude Code API spend for this dispatch when set; omitted means no dollar cap.\n\n"
             "Exit codes:\n"
             "  0 on successful command completion; non-zero on CLI misuse or worker/task failures.\n\n"
             "Related:\n"
@@ -1635,6 +1650,16 @@ def build_parser() -> argparse.ArgumentParser:
             "absolute wall-clock fallback."
         ),
     )
+    d.add_argument(
+        "--max-budget-usd",
+        type=float,
+        default=None,
+        help=(
+            "Optional Claude Code dollar cap for this dispatch. Only Claude "
+            "translates this to a CLI flag; non-Claude adapters warn and "
+            "ignore it. Omit to run uncapped."
+        ),
+    )
     d.set_defaults(func=cmd_dispatch)
 
     # status
@@ -1712,6 +1737,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wk.add_argument("--hard-timeout", type=int, default=DEFAULT_HARD_TIMEOUT_S)
     wk.add_argument("--silence-timeout", type=int, default=DEFAULT_SILENCE_TIMEOUT_S)
+    wk.add_argument("--max-budget-usd", type=float, default=None)
     wk.set_defaults(func=cmd_worker)
 
     return p

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -17,6 +17,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -499,6 +500,41 @@ def test_codex_adapter_ignores_unknown_tool_config_keys(tmp_path):
     assert 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"' in config_values
     cmd_str = " ".join(plan.cmd)
     assert "some_future_field" not in cmd_str
+
+
+def test_codex_adapter_ignores_max_budget_usd_tool_config(tmp_path, caplog):
+    adapter = CodexAdapter()
+    with caplog.at_level(logging.WARNING, logger="agent_runtime.adapters.codex"):
+        plan = adapter.build_invocation(
+            prompt="hello",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={"max_budget_usd": 0.5},
+        )
+
+    assert "--max-budget-usd" not in plan.cmd
+    assert any(
+        "non-claude adapter codex ignoring max_budget_usd=0.5" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_codex_adapter_omits_max_budget_usd_by_default(tmp_path):
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert "--max-budget-usd" not in plan.cmd
 
 
 # ---------------------------------------------------------------------------
@@ -2714,6 +2750,37 @@ def test_claude_adapter_basic_stateless(tmp_path):
     assert "--session-id" not in plan.cmd
     assert "--output-format" in plan.cmd
     assert plan.stdin_payload == ""  # Claude -p takes prompt as positional
+
+
+def test_claude_adapter_emits_max_budget_usd_from_tool_config(tmp_path):
+    adapter = ClaudeAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={"max_budget_usd": 0.5},
+    )
+
+    assert "--max-budget-usd" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--max-budget-usd") + 1] == "0.50"
+
+
+def test_claude_adapter_omits_max_budget_usd_by_default(tmp_path):
+    adapter = ClaudeAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert "--max-budget-usd" not in plan.cmd
 
 
 def test_claude_adapter_discussion_readonly_uses_restricted_tools_without_plan_mode(tmp_path):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -523,6 +523,70 @@ def test_dispatch_popen_failure_marks_task_failed(tmp_tasks_dir, capsys):
     assert "failed to spawn" in captured.err
 
 
+def test_dispatch_parses_max_budget_usd_flag():
+    parser = delegate.build_parser()
+    args = parser.parse_args([
+        "dispatch",
+        "--agent", "claude",
+        "--task-id", "budget-task",
+        "--prompt", "hi",
+        "--max-budget-usd", "0.50",
+    ])
+
+    assert args.max_budget_usd == 0.5
+
+
+def test_worker_parser_accepts_max_budget_usd():
+    parser = delegate.build_parser()
+    args = parser.parse_args([
+        "_worker",
+        "--task-id", "budget-task",
+        "--agent", "claude",
+        "--mode", "read-only",
+        "--cwd", "/tmp",
+        "--max-budget-usd", "0.50",
+    ])
+
+    assert args.max_budget_usd == 0.5
+
+
+def test_dispatch_persists_and_forwards_max_budget_usd(tmp_tasks_dir):
+    args = delegate.build_parser().parse_args([
+        "dispatch",
+        "--agent", "claude",
+        "--task-id", "budget-dispatch",
+        "--prompt", "hi",
+        "--max-budget-usd", "0.50",
+    ])
+    captured: dict[str, list[str]] = {}
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 12345
+        stdin = _FakeStdin()
+
+    def fake_popen(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    with patch("delegate.subprocess.Popen", side_effect=fake_popen):
+        rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("budget-dispatch"))
+    assert state is not None
+    assert state["max_budget_usd"] == 0.5
+    cmd = captured["cmd"]
+    assert "--max-budget-usd" in cmd
+    assert cmd[cmd.index("--max-budget-usd") + 1] == "0.5"
+
+
 def test_dispatch_initial_state_includes_resolved_telemetry(tmp_tasks_dir):
     """Dispatch should persist model/effort/cli_version immediately."""
     import argparse
@@ -845,6 +909,45 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["model"] == "claude-opus-4-6"
     assert state["effort"] == "xhigh"
     assert state["cli_version"] == "2.1.89"
+
+
+def test_run_worker_forwards_max_budget_usd_to_runtime(tmp_tasks_dir, tmp_path):
+    state_path = delegate._state_path("worker-budget")
+    delegate._write_state_atomic(state_path, {"task_id": "worker-budget"})
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "claude-opus-4-7",
+            "effort": "unknown",
+            "cli_version": "2.1.116",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result) as mock_invoke:
+        rc = delegate._run_worker(
+            task_id="worker-budget",
+            agent="claude",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            max_budget_usd=0.5,
+            effort=None,
+        )
+
+    assert rc == 0
+    assert mock_invoke.call_args.kwargs["tool_config"] == {"max_budget_usd": 0.5}
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["max_budget_usd"] == 0.5
 
 
 def test_run_worker_silence_timeout_kills_silent_subprocess(


### PR DESCRIPTION
## Summary
- Add `delegate.py dispatch/_worker --max-budget-usd` with default-off `None` semantics.
- Persist the cap in delegate task state and thread it through worker argv into runtime `tool_config`.
- Emit `--max-budget-usd <amount>` only from `ClaudeAdapter` print-mode invocations; non-Claude adapters warn and ignore the value.
- Add regression coverage for Claude emission, Codex ignoring, omitted-flag defaults, and delegate parent/worker propagation.

## Context
MEMORY #M0 was softened on 2026-05-21 from a hard ban on post-2026-06-15 Claude dispatches to quota-conditional use. This gap-close gives dispatched Claude an opt-in hard dollar cap while preserving current uncapped behavior when omitted.

Dispatch brief: `max-budget-usd-2026-05-21`.
Background handoff: `docs/session-state/2026-05-21-morning-gemini-042-alignment-and-deepseek-viability.md`.

## Touch Points
- `scripts/delegate.py`: CLI args, state persistence, worker argv, timeout telemetry field.
- `scripts/agent_runtime/adapters/claude.py`: Claude CLI flag emission in `-p` print mode.
- `scripts/agent_runtime/adapters/{codex,gemini,hermes_deepseek,hermes_grok,hermes_qwen,agy}.py`: warn and ignore for non-Claude adapters.
- `tests/test_delegate.py`, `tests/test_agent_runtime.py`: regression tests.

## Verification
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/delegate.py scripts/agent_runtime/adapters/`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/ -k 'delegate or claude_adapter or budget' -v --tb=short`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

Note: this worktree has no local `.venv`, so verification used the main checkout project venv resolved from the same repository.
