### PR TITLE
fix(vesum_verified): exempt morphological stem fragments

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6280,6 +6280,8 @@ def _iter_vesum_lookup_surface_pairs(
         raw = match.group(0).strip("-'ʼ")
         if not raw or "__" in raw or not _has_vesum_lookup_decoration(raw):
             continue
+        if _looks_like_stem_fragment(text, match.start(), match.end()):
+            continue
         normalized = _normalize_for_vesum(raw)
         for word in _iter_vesum_candidate_words(normalized):
             lower = word.lower()
@@ -6334,6 +6336,8 @@ def _iter_vesum_word_surfaces(text: str) -> list[str]:
             # only fires when the abutting character is a Latin LETTER,
             # not whitespace or punctuation.
             continue
+        if _looks_like_stem_fragment(text, match.start(), match.end()):
+            continue
         raw = match.group(0)
         if _looks_like_elided_notation(text, match.start(), raw):
             continue
@@ -6385,6 +6389,42 @@ def _touches_blank_marker(text: str, start: int, end: int) -> bool:
     return (start > 0 and text[start - 1] == "_") or (
         end < len(text) and text[end] == "_"
     )
+
+
+_CYRILLIC_LETTER_RE = re.compile(r"[А-ЯІЇЄҐа-яіїєґ]")
+_STEM_FRAGMENT_LEFT_BOUNDARY = frozenset({"*", "_", "`"})
+_STEM_FRAGMENT_MARKDOWN_CLOSERS = frozenset({"*", "_", "`"})
+
+
+def _looks_like_stem_fragment(text: str, start: int, end: int) -> bool:
+    """Return true for pedagogical stem notation like `користу-`.
+
+    Motivated by claude-tools a1/my-morning build 2026-05-21: the correct
+    stem fragment `**користу**-` is not a VESUM lemma and should not be checked.
+    """
+    if start > 0:
+        previous = text[start - 1]
+        if not previous.isspace() and previous not in _STEM_FRAGMENT_LEFT_BOUNDARY:
+            return False
+
+    if start >= end:
+        return False
+
+    hyphen_pos: int | None = None
+    if text[end - 1] == "-":
+        hyphen_pos = end - 1
+    else:
+        cursor = end
+        while cursor < len(text) and text[cursor] in _STEM_FRAGMENT_MARKDOWN_CLOSERS:
+            cursor += 1
+        if cursor < len(text) and text[cursor] == "-":
+            hyphen_pos = cursor
+
+    if hyphen_pos is None:
+        return False
+
+    after_hyphen = hyphen_pos + 1
+    return after_hyphen >= len(text) or not _CYRILLIC_LETTER_RE.match(text[after_hyphen])
 
 
 _LATIN_LETTER_RE = re.compile(r"[A-Za-z]")

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -4,9 +4,15 @@ import yaml
 
 from scripts.build.linear_pipeline import (
     _iter_vesum_word_surfaces,
+    _looks_like_stem_fragment,
     _normalize_for_vesum,
     _vesum_gate,
 )
+
+
+def _span(text: str, token: str) -> tuple[int, int]:
+    start = text.index(token)
+    return start, start + len(token)
 
 
 def test_reflexive_verb_not_split() -> None:
@@ -43,6 +49,24 @@ def test_em_dash_splits_sentences() -> None:
     tokens = _iter_vesum_word_surfaces(text)
 
     assert tokens == ["Привіт", "як", "справи"]
+
+
+def test_looks_like_stem_fragment_accepts_markdown_stem_examples() -> None:
+    bold = '**користу**-, not "користуву-"'
+    single_asterisk = "*користу*-"
+    backtick = "`користу-`"
+
+    assert _looks_like_stem_fragment(bold, *_span(bold, "користу"))
+    assert _looks_like_stem_fragment(
+        single_asterisk,
+        *_span(single_asterisk, "користу"),
+    )
+    assert _looks_like_stem_fragment(backtick, *_span(backtick, "користу-"))
+
+
+def test_looks_like_stem_fragment_rejects_compounds_and_complete_words() -> None:
+    for text in ("темно-синій", "Івано-Франківськ", "я-форма", "користу"):
+        assert not _looks_like_stem_fragment(text, 0, len(text))
 
 
 def test_normalize_for_vesum_strips_stress_and_markdown() -> None:
@@ -88,6 +112,31 @@ def test_vesum_gate_missing_report_preserves_decorated_surface() -> None:
 
     assert gate["passed"] is False
     assert gate["missing"] == ["вмива́ю**ся**"]
+
+
+def test_vesum_gate_ignores_morphological_stem_fragments() -> None:
+    module_text = (
+        "Verbs like **користуватися** lose the suffix **-ва-** in the present "
+        'tense. The stem begins **користу**-, not "користуву-".'
+    )
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        valid = {"користуватися"}
+        return {word: ([{"lemma": word}] if word in valid else []) for word in words}
+
+    gate = _vesum_gate(
+        module_text=module_text,
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert seen == [["користуватися"]]
 
 
 def test_proper_noun_genitive_resolves() -> None:


### PR DESCRIPTION
## Summary

- Exempts pedagogical morphological stem fragments like `**користу**-` from `vesum_verified` when the trailing ASCII hyphen is not followed by a Cyrillic letter.
- Keeps real compounds such as `темно-синій`, `Івано-Франківськ`, and `я-форма` in the VESUM candidate stream.
- Adds direct helper coverage plus an integration regression using the exact claude-tools `a1/my-morning` build #5 prose.

## Context

claude-tools V7 build of `a1/my-morning` on branch `build/a1/my-morning-20260521-101042` reached 21/22 gates. The single hard failure was `vesum_verified` on `**користу**` from the sentence explaining that `користуватися` drops `-ва-` in present-tense stem notation: `**користу**-`, not `користуву-`. VESUM correctly has no bare-stem lemma, so the gate needed a pedagogical-fragment exemption.

Dispatch brief: `docs/dispatch-briefs/2026-05-21-vesum-stem-fragment-exemption-codex.md`

## Gate Touch Point

- `scripts/build/linear_pipeline.py::_iter_vesum_word_surfaces` now skips stem fragments before stripping lookup punctuation.
- `scripts/build/linear_pipeline.py::_iter_vesum_lookup_surface_pairs` applies the same guard to decorated surfaces so `**користу**-` is not re-added through the decorated evidence path.

## Verification

- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/`
- `.venv/bin/python -m pytest tests/ -k 'vesum or linear_pipeline' -v --tb=short`\n- `.venv/bin/python scripts/audit/lint_agent_trailer.py`