### PR TITLE
fix(wiki_coverage_gate): scope to deepest heading + drop YAML re-escape

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -473,28 +473,80 @@ def _load_activity_items(activities_yaml: str) -> list[dict[str, Any]]:
     return [item for item in parsed if isinstance(item, dict)]
 
 
+def _flatten_strings(value: Any) -> list[str]:
+    """Yield every string value reachable inside a YAML-decoded structure.
+
+    Used by `_activity_text` so that the activity's content reaches the
+    marker-match step as plain text. `yaml.safe_dump` would round-trip
+    inner apostrophes inside single-quoted YAML strings as `''` (e.g.
+    `Вимова: [прокидайес':а]` becomes `Вимова: [прокидайес'':а]`), which
+    breaks `_contains` substring matching against the wiki-manifest
+    marker. Concatenating raw string fields avoids that escape artifact.
+    """
+
+    out: list[str] = []
+    stack: list[Any] = [value]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            out.append(node)
+        elif isinstance(node, Mapping):
+            stack.extend(node.values())
+        elif isinstance(node, Sequence) and not isinstance(node, (str, bytes)):
+            stack.extend(node)
+    return out
+
+
 def _activity_text(activities: list[dict[str, Any]], location: str) -> str:
     if not location:
-        return yaml.safe_dump(activities, allow_unicode=True, sort_keys=False)
+        return "\n".join(s for activity in activities for s in _flatten_strings(activity))
     for activity in activities:
         activity_id = str(activity.get("id") or "")
         if activity_id and activity_id in location:
-            return yaml.safe_dump(activity, allow_unicode=True, sort_keys=False)
+            return "\n".join(_flatten_strings(activity))
     return ""
 
 
 def _location_text(text: str, location: str) -> str:
+    """Return the text of the heading section that best matches `location`.
+
+    A module may legitimately repeat its title as a section heading
+    (`# Мій ранок` for the module title and `## Мій ранок` for the
+    matching section). Picking the first match in document order returns
+    the H1 title-only block (a few lines of intro) instead of the H2
+    section. Score candidates by heading depth (deeper = more specific)
+    with title-length proximity as a tiebreaker so the deeper match
+    wins, but degrade gracefully to the earlier behaviour when only one
+    candidate exists.
+    """
+
     if not location or location.casefold() in {"module.md", "whole file", "file"}:
         return text
     location_key = location.strip().lstrip("#§ ").casefold()
     heading_re = re.compile(r"^(?P<marks>#{1,6})\s+(?P<title>.+?)\s*$", re.MULTILINE)
     headings = list(heading_re.finditer(text))
+    candidates: list[tuple[int, int, int]] = []
     for index, heading in enumerate(headings):
         title = heading.group("title").strip().casefold()
         if location_key and location_key not in title and title not in location_key:
             continue
+        depth = len(heading.group("marks"))
+        title_gap = abs(len(title) - len(location_key))
+        # Sort key: deeper first (negate depth), then closer title-length, then
+        # earlier in the document — matches author intent that "§Мій ранок ..."
+        # refers to the section, not the H1 module title.
+        candidates.append((-depth, title_gap, index))
+
+    if candidates:
+        candidates.sort()
+        chosen_index = candidates[0][2]
+        heading = headings[chosen_index]
         start = heading.start()
-        end = headings[index + 1].start() if index + 1 < len(headings) else len(text)
+        end = (
+            headings[chosen_index + 1].start()
+            if chosen_index + 1 < len(headings)
+            else len(text)
+        )
         return text[start:end]
     return text if location_key in text.casefold() else ""
 

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -126,3 +126,150 @@ def test_decolonization_ban_legacy_manifest_without_subtype_field() -> None:
     assert result["status"] == "FAIL"
     assert result["reason"] == "ban_substance_missing"
     assert "subtype" not in result
+
+
+# Regression tests for two bugs that masked the build #6 a1/my-morning gate
+# (2026-05-21). Both fixes are required for the gate to recognise content
+# the writer and correction loop actually emitted.
+
+
+def _sequence_step_manifest() -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [
+            {
+                "id": "step-5",
+                "heading": (
+                    "Крок 5: Розширення лексичного контексту. "
+                    "Тема ранкової рутини наповнюється іменниками "
+                    "(вода, зарядка, сніданок) та прислівниками "
+                    "часу і частотності (раненько, завжди, ніколи)."
+                ),
+                "step_num": 5,
+                "required_claim": (
+                    "Крок 5: Розширення лексичного контексту. "
+                    "Тема ранкової рутини наповнюється іменниками "
+                    "(вода, зарядка, сніданок) та прислівниками "
+                    "часу і частотності (раненько, завжди, ніколи)."
+                ),
+                "source_lines": "31",
+            }
+        ],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def _phonetic_l2_error_manifest() -> dict[str, Any]:
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [],
+        "l2_errors": [
+            {
+                "id": "err-2",
+                "incorrect": "Вимова: [прокидайешся]",
+                "correct": "Вимова: [прокидайес':а]",
+                "why": (
+                    "Побуквене прочитання. Учень намагається чітко "
+                    "вимовити звук [ш], хоча українська норма вимагає "
+                    "повної асиміляції в подовжений м'який [с':а]."
+                ),
+                "treatment": "contrast_pair",
+                "source_lines": "40",
+            }
+        ],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def test_sequence_step_passes_when_h1_title_collides_with_h2_section() -> None:
+    """`_location_text` must prefer the deeper heading when an H1 module
+    title and an H2 section share the same name. The build-#6 regression:
+    module starts with `# Мій ранок` (title) and contains `## Мій ранок`
+    (section); the gate was scoping to the H1 title-only block and
+    failing step-5 even though the section had the required substance."""
+    manifest = _sequence_step_manifest()
+    module_md = (
+        "# Мій ранок\n\n"
+        "Two roommates compare their mornings. Listen for **-ся**.\n\n"
+        "## Діалоги\n\nDialogue content here.\n\n"
+        "## Дієслова на -ся\n\nGrammar content here.\n\n"
+        "## Мій ранок\n\n"
+        "**Sequence words** — these are the connective tissue:\n\n"
+        "- **спочатку** — first\n- **потім** — then\n"
+        "- **нарешті** — finally\n- **завжди** — always\n\n"
+        "Build a narrative from **іменниками** like **сніданок** "
+        "and **зарядка**, plus **прислівниками** of time.\n\n"
+        "## Підсумок\n\nWrap-up here.\n"
+    )
+    implementation_map = {
+        "step-5": {
+            "artifact": "module.md",
+            "location": "§Мій ранок (sequence-words + nouns block)",
+            "treatment": "in-prose vocabulary expansion",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md=module_md,
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    step_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "step-5"
+    )
+    assert step_result["status"] == "PASS", (
+        f"step-5 should PASS when H2 section has the substance, even "
+        f"with a colliding H1 title; got reason={step_result['reason']!r}"
+    )
+
+
+def test_l2_error_passes_when_marker_contains_apostrophe() -> None:
+    """`_activity_text` must surface activity content without YAML re-
+    serialisation double-escaping apostrophes. The build-#6 regression:
+    `correction: \"Вимова: [прокидайес':а]\"` round-tripped through
+    `yaml.safe_dump` as `[прокидайес'':а]` (double apostrophe), so the
+    marker substring match failed even though the artifact was correct."""
+    manifest = _phonetic_l2_error_manifest()
+    activities_yaml = (
+        "- id: act-5\n"
+        "  type: error-correction\n"
+        "  title: Fix the trap forms\n"
+        "  items:\n"
+        "    - sentence: 'Вимова: [прокидайешся]'\n"
+        "      error: 'Вимова: [прокидайешся]'\n"
+        "      correction: \"Вимова: [прокидайес':а]\"\n"
+        "      explanation: phonetic assimilation explanation.\n"
+    )
+    implementation_map = {
+        "err-2": {
+            "artifact": "activities.yaml",
+            "location": "act-5 item 2",
+            "treatment": "contrast_pair for phonetic assimilation",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="# Module body unrelated to err-2.\n",
+        activities_yaml=activities_yaml,
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    err_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "err-2"
+    )
+    assert err_result["status"] == "PASS", (
+        f"err-2 should PASS when activity contains the correct apostrophe "
+        f"marker; got reason={err_result['reason']!r}"
+    )


### PR DESCRIPTION
## Summary

Two bugs in `scripts/audit/wiki_coverage_gate.py` made the gate misdetect valid module content. The same artifacts the writer + correction loop produced for build/a1/my-morning-20260521-140634 (claude-tools build #6, 2026-05-21) now pass 18/18 with the fix.

### Bug 1 — `_location_text` heading-depth blindness

When `implementation_map.location` matched both an H1 title and an H2 section (e.g. `# Мій ранок` + `## Мій ранок`), the function returned the first match in document order — the 4-line H1 title block — instead of the H2 section that actually held the substance. **Fix**: score candidates by heading depth (deeper wins), tie-break on title-length proximity to the `location_key`.

### Bug 2 — `_activity_text` YAML apostrophe re-escape

The function returned `yaml.safe_dump(activity, ...)`, which round-trips inner apostrophes inside single-quoted YAML strings as `''`. The phonetic IPA pair `Вимова: [прокидайес':а]` in `act-5` became `Вимова: [прокидайес'':а]` in the dump, so the wiki-manifest marker no longer substring-matched and `err-2` / `err-3` failed even though the artifact was correct. **Fix**: recursive `_flatten_strings` walk over the YAML-decoded structure.

### Smoking-gun verification

Running the **fixed** gate against the build-#6 artifacts (unchanged):

```
passed=True hard_fail=False coverage=1.0000 (18/18)
FAILURES: (none)
```

The build's `wiki_coverage_correction` loop applied 7 successful fixes to bring real coverage to 100%. The gate's two detection bugs hid that and ended the build at the misreported 0.8333.

## Test plan

- [x] TDD: 2 new regression tests added to `tests/audit/test_wiki_coverage_gate.py` (H1/H2 collision + apostrophe marker) — both fail before the fix, pass after.
- [x] `pytest -k 'wiki_coverage or wiki_manifest or linear_pipeline_wiki'` → 50 passed, 1 skipped, 0 failed
- [x] `ruff check scripts/audit/wiki_coverage_gate.py tests/audit/test_wiki_coverage_gate.py` → clean
- [x] Pre-commit hooks: green
- [ ] CI green

## Notes

Build #6 was labeled "wiki_coverage failed" in autopsy at the close. With this fix that build would have closed `module_done` at 22/22 and become the first complete V7 module ready to promote. Next session can re-run claude-tools `a1/my-morning` against this branch (or after merge) to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)