### PR TITLE
fix(textbook_grounding): scope blockquote section_title to H1/H2 only

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7034,7 +7034,19 @@ def _extract_blockquote_records(text: str) -> list[dict[str, str]]:
         pending_attribution_index = len(quotes) - 1
 
     for line in text.splitlines():
-        heading = re.match(r"^\s{0,3}#{1,6}\s+(?P<title>.+?)\s*#*\s*$", line)
+        # Track only H1/H2 as the blockquote's `section_title` — the
+        # `_textbook_grounding_gate`'s `_quote_topic_matches` check uses
+        # this string as the topic context, and sub-headings (H3+) are
+        # typically step/sub-step markers (e.g. `### Крок N: ...`) whose
+        # pedagogy-meta-talk lexicon poisons the token set. The H2 is
+        # the actual learner-navigable section that defines the topic.
+        # Build-#7 a1/my-morning regression: writer used H3 ### Крок N
+        # (pedagogically clearer than inline-bold) and the gate
+        # rejected real Захарійчук blockquotes for topical_mismatch
+        # because the H3 stems didn't overlap with concrete-content
+        # quotes. See `tests/test_textbook_grounding_gate.py::
+        # test_blockquote_under_h3_inherits_h2_section_title`.
+        heading = re.match(r"^\s{0,3}#{1,2}\s+(?P<title>.+?)\s*#*\s*$", line)
         if heading:
             current_section = re.sub(r"[*_`~]+", "", heading.group("title")).strip()
         match = re.match(r"^\s*>\s?(?P<body>.*)$", line)

--- a/tests/test_textbook_grounding_gate.py
+++ b/tests/test_textbook_grounding_gate.py
@@ -677,6 +677,47 @@ def test_a1_fallback_attributes_to_actual_match(tmp_path: Path) -> None:
     assert result["matched"] == ["Кравцова Grade 4, p.113"]
 
 
+def test_blockquote_under_h3_inherits_h2_section_title(tmp_path: Path) -> None:
+    """Build-#7 regression: when the writer organises the module with
+    H3 ### Крок N: sub-headings inside an H2 ## Section, the blockquote
+    must take the H2 section title (the actual pedagogical scope) for
+    the topic match — not the H3 sub-heading's long technical
+    meta-description, whose pedagogy-jargon stems flood topic_tokens
+    and lock out any concrete-content quote from overlapping. Build #6
+    (inline-bold Крок) passed; build #7 (H3 Крок) failed with
+    topical_mismatch on real Захарійчук quotes that DID match the
+    plan's references. The H3 'meta-talk' below mirrors the actual
+    build-#7 section title that caused the false REJECT."""
+    _write_tool_calls(
+        tmp_path,
+        [_search_call("Караман Grade 10, p.176")],
+    )
+    # SEARCH_TEXT topics: учень, умивається, одягається, готується,
+    # зборатися, зворотна, ранкова. The H2 "Зворотні дієслова" shares
+    # "зворотн*", "дієсло*" stems with SEARCH_TEXT → topic check passes
+    # when the H2 is used as section_title. The H3 below is
+    # methodology-meta-talk (історичні джерела індоєвропейських мов)
+    # with zero stem overlap with the quote — so when the gate picks
+    # H3 as section_title the topic check fails even though the quote
+    # is on-topic for the H2.
+    module_text = (
+        "## Зворотні дієслова\n\n"
+        "Quick framing of the topic.\n\n"
+        "### Крок 1: Класифікація типів за історичними джерелами "
+        "індоєвропейських мов та порівняльна типологія парадигм\n\n"
+        "Sub-step explanation.\n\n"
+        f"> **Караман Grade 10, p.176:** {SEARCH_TEXT}\n"
+    )
+
+    result = linear_pipeline._textbook_grounding_gate(module_text, _plan(), tmp_path)
+
+    assert result["passed"] is True, (
+        f"H3 sub-heading must not poison the topic check; "
+        f"reason={result.get('reason')!r} matched={result.get('matched')!r}"
+    )
+    assert "Караман Grade 10, p.176" in result["matched"]
+
+
 def test_off_topic_quote_rejected(tmp_path: Path) -> None:
     _write_tool_calls(
         tmp_path,


### PR DESCRIPTION
## Summary

`_extract_blockquote_records` matched H1–H6 for `section_title`, which `_textbook_grounding_gate`'s `_quote_topic_matches` check uses as the topic context. When the writer organises the module with H3 `### Крок N: ...` sub-headings inside an H2 section, the H3's long pedagogy-meta-talk lexicon ("Введення зворотних дієслів другої дієвідміни") flooded `topic_tokens` and locked out concrete-content blockquotes from satisfying the topic overlap rule.

## The bug in build-#7 of a1/my-morning

The writer used H3 Крок sub-headings (pedagogically clearer than build-#6's inline-bold markers). The gate rejected real Захарійчук Grade 1 p.24 / p.52 blockquotes with `topical_mismatch`, even though:

- Both quotes were real, attributed, ≥30 words
- The writer's `search_text` calls retrieved the correct chunk_ids (`s0024` and `s0052`)
- Both quotes were on-topic for the parent H2 sections (`§Дієслова на -ся` and `§Мій ранок`)

The H3 above each blockquote was the actual `section_title` the gate used.

## Fix

Restrict the section-tracking regex in `_extract_blockquote_records` to `#{1,2}`. H3+ sub-step markers are still rendered to the learner but no longer hijack the topic context. The H2 (the section a learner actually navigates) wins.

## Smoking-gun verification

Running the **fixed** gate against the **unchanged** build-#7 artifacts:

```
Build #7 textbook_grounding with FIX: passed=True reason=None
  matched=['Захарійчук Grade 1, p.24', 'Захарійчук Grade 1, p.52']
  missing=[]
```

The build's writer + reviewer + correction loops produced valid content. The detection bug was eating it.

## Test plan

- [x] TDD: one new regression test (`test_blockquote_under_h3_inherits_h2_section_title`) — H3 meta-talk under H2 + content quote that matches H2 stems. Fails before fix; passes after.
- [x] `pytest -k 'textbook_grounding or blockquote or linear_pipeline or citation_matcher'` → 68 passed, 1 skipped, 0 failed
- [x] `ruff check` → clean
- [ ] CI green

## Context — gate cascade pattern

This is the **third** gate-detection bug exposed in the 2026-05-21 a1/my-morning rebuild sequence:

| Build | Gate | Fix |
|---|---|---|
| #5 | vesum_verified (`**користу**-` stem fragment) | PR #2173 (morning, Codex) |
| #6 | wiki_coverage_gate (H1/H2 collision + YAML apostrophe re-escape) | PR #2184 (this session) |
| #7 | textbook_grounding (H3 hijacks section_title) | this PR |

Full evening handoff documenting the cascade: `docs/session-state/2026-05-21-evening-gate-cascade-three-bugs-one-after-another.md`. Each gate fix was load-bearing — without it the gate would have continued silently mis-detecting on every future build. Recommend a holistic gate-quality audit pass after this PR merges to prevent the next cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)