### PR TITLE
security(dashboards+ci): close 5 CodeQL alerts — 2 XSS fixes + dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Wait 5 days after a new release before opening a PR — gives the
+    # upstream time to surface regressions and avoids burning CI on
+    # versions that get yanked. Closes zizmor dependabot-cooldown
+    # warnings (CodeQL alerts #185, #186, #187).
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "ci"
     labels:
@@ -24,6 +30,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "deps"
     labels:
@@ -37,6 +45,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "deps"
     labels:

--- a/dashboards/channels.html
+++ b/dashboards/channels.html
@@ -198,7 +198,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
       </div>
     </div>
   </div>
-  
+
   <div class="main-panel" id="main-empty" style="justify-content:center; align-items:center;">
     <div class="empty-state" id="global-empty-state">
       Select a channel to view messages
@@ -307,7 +307,7 @@ function renderSidebar() {
     DOM.sidebar.innerHTML = '<div class="empty-state">No channels yet<br><br>Create one via CLI:<br><code>ab channel new &lt;name&gt;</code></div>';
     return;
   }
-  
+
   DOM.sidebar.innerHTML = channels.map(c => {
     const safeName = escapeHTML(c.name);
     // HTML-escape FIRST (so `"` can't break out of the onclick="..."
@@ -382,7 +382,7 @@ async function loadChannelDetail(name, isBackground = false) {
 
     renderChannelHeader(meta);
     renderMessages(msgs, isBackground);
-    
+
     if (!isBackground) {
       const subs = meta.subscribers || [];
       DOM.postRecipients.innerHTML = '<span style="font-weight:600;">To:</span> ' + subs.map(s => {
@@ -396,17 +396,17 @@ async function loadChannelDetail(name, isBackground = false) {
     }
   } catch(e) {
     if (!isBackground) {
-      DOM.messagesArea.innerHTML = `<div class="empty-state">Failed to load channel details: ${e.message}</div>`;
+      DOM.messagesArea.innerHTML = `<div class="empty-state">Failed to load channel details: ${escapeHTML(e.message)}</div>`;
     }
   }
 }
 
 function renderChannelHeader(meta) {
   const pending = meta.pending_deliveries || 0;
-  const pendingHtml = pending > 0 
-    ? `<div class="deliveries-toggle" onclick="toggleDeliveries()">● ${pending} pending deliveries ▾</div>` 
+  const pendingHtml = pending > 0
+    ? `<div class="deliveries-toggle" onclick="toggleDeliveries()">● ${pending} pending deliveries ▾</div>`
     : '<div class="deliveries-toggle">0 pending deliveries</div>';
-    
+
   let contextHtml = '';
   if (meta.context_preview) {
     contextHtml = `
@@ -419,7 +419,7 @@ function renderChannelHeader(meta) {
       </div>
     `;
   }
-  
+
   const includeList = meta.include || meta.includes || [];
   const includes = includeList.length ? includeList.map(escapeHTML).join(', ') : 'none';
   const subList = meta.subscribers || [];
@@ -450,10 +450,10 @@ window.toggleDeliveries = async function() {
     panel.classList.remove('open');
     return;
   }
-  
+
   panel.innerHTML = '<div style="padding:12px;font-size:11px;color:var(--text2);">Loading deliveries...</div>';
   panel.classList.add('open');
-  
+
   try {
     const delsResp = await api(`/api/comms/channels/${encodeURIComponent(activeChannel)}/deliveries?status=pending&limit=20`);
     const dels = delsResp.deliveries || [];
@@ -473,7 +473,7 @@ window.toggleDeliveries = async function() {
       `).join('');
     }
   } catch(e) {
-    panel.innerHTML = `<div style="padding:12px;font-size:11px;color:var(--red);">Error: ${e.message}</div>`;
+    panel.innerHTML = `<div style="padding:12px;font-size:11px;color:var(--red);">Error: ${escapeHTML(e.message)}</div>`;
   }
 };
 
@@ -828,14 +828,14 @@ DOM.postBody.addEventListener('blur', () => {
 DOM.postBtn.addEventListener('click', async () => {
   const body = DOM.postBody.value.trim();
   if (!body || !activeChannel) return;
-  
+
   DOM.postBtn.disabled = true;
   DOM.postError.style.display = 'none';
   DOM.postSuccess.style.display = 'none';
-  
+
   const to_agents = Array.from(DOM.postRecipients.querySelectorAll('input:checked')).map(cb => cb.value);
   const parent_id = DOM.postParentId.value.trim();
-  
+
   const payload = {
     body,
     to_agents,
@@ -843,22 +843,22 @@ DOM.postBtn.addEventListener('click', async () => {
     auto_snapshot: false
   };
   if (parent_id) payload.parent_id = parent_id;
-  
+
   try {
     await api(`/api/comms/channels/${encodeURIComponent(activeChannel)}/post`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     });
-    
+
     DOM.postBody.value = '';
     DOM.postBtn.disabled = true;
     startAutoRefresh();
     clearReply();
-    
+
     DOM.postSuccess.style.display = 'block';
     setTimeout(() => { DOM.postSuccess.style.display = 'none'; }, 3000);
-    
+
     await loadChannelDetail(activeChannel);
     DOM.messagesArea.scrollTop = DOM.messagesArea.scrollHeight;
   } catch(e) {

--- a/dashboards/image-explorer.html
+++ b/dashboards/image-explorer.html
@@ -715,8 +715,13 @@ async function loadPage() {
         title="${escapeHtml(tb.text.substring(0, 100))}"></div>`;
     });
 
+    // `imgUrl` derives from the DOM-controlled `currentStem` (textbook
+    // select value) and `currentPage` (numeric input). Escape it as an
+    // HTML attribute even though the realistic exploit surface is
+    // self-XSS — CodeQL's flow analysis can't see the bounded select
+    // values and flagged the raw interpolation (alert #178).
     container.innerHTML = `
-      <img src="${imgUrl}" onload="this.parentElement.style.width=this.naturalWidth+'px'">
+      <img src="${escapeHtml(imgUrl)}" onload="this.parentElement.style.width=this.naturalWidth+'px'">
       <div id="img-overlays" style="${showImageOverlay ? '' : 'display:none'}">${imgOverlays}</div>
       <div id="text-overlays" style="${showTextOverlay ? '' : 'display:none'}">${textOverlays}</div>`;
 
@@ -724,13 +729,23 @@ async function loadPage() {
     let sidebarHtml = `<div style="font-size:12px;color:var(--text2);margin-bottom:8px;">${data.images.length} images, ${data.text_blocks.length} text blocks</div>`;
 
     data.images.forEach((img, i) => {
+      // Defense-in-depth: every server-controlled string interpolated
+      // into innerHTML/onclick must be escaped, even though the
+      // textbook_images ingestion pipeline is our own. The original
+      // raw `${imgSrc}` and `${img.description_uk}` were the
+      // hardening gaps left around CodeQL alert #178.
       const imgSrc = img.image_path ? `/images/${img.image_path.replace('data/textbook_images/','')}` : '';
+      const imgSrcAttr = escapeHtml(imgSrc);
+      const imgSrcJS = imgSrc.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      const descSafe = img.description_uk
+        ? escapeHtml(img.description_uk)
+        : '<span style="color:var(--text3)">no description</span>';
       sidebarHtml += `<div class="page-img-row" id="row-${i}" data-idx="${i}"
         onmouseenter="highlightBbox(${i})" onmouseleave="unhighlightBbox(${i})"
         onclick="if(event.target.tagName!=='IMG') highlightBbox(${i})">
-        ${imgSrc ? `<img class="thumb" src="${imgSrc}" onclick="openLightbox('${imgSrc}')" loading="lazy">` : '<div class="thumb-placeholder" style="width:60px;height:45px">?</div>'}
+        ${imgSrc ? `<img class="thumb" src="${imgSrcAttr}" onclick="openLightbox('${imgSrcJS}')" loading="lazy">` : '<div class="thumb-placeholder" style="width:60px;height:45px">?</div>'}
         <div class="meta">
-          <div class="desc">${img.description_uk || '<span style="color:var(--text3)">no description</span>'}</div>
+          <div class="desc">${descSafe}</div>
           <div class="tags">
             <span class="tag tag-type">#${i+1}</span>
             ${tvTag(img.teaching_value)}


### PR DESCRIPTION
## Summary

Triages 8 open code-scanning alerts (3 HIGH + 2 MEDIUM + 3 zizmor warnings). This PR fixes the 5 that are real (or trivial); the other 3 are documented false positives to dismiss-with-reason on GitHub.

### Fixed

| # | Rule | File | Fix |
|---|---|---|---|
| **#179** | js/xss-through-exception (medium) | `dashboards/channels.html` lines 399, 476 | wrap `${e.message}` in `escapeHTML()` |
| **#178** | js/xss-through-dom (high) | `dashboards/image-explorer.html` lines 718–741 | escape `imgUrl`, `img.image_path` (HTML + JS-string contexts), `img.description_uk` |
| **#185** | zizmor/dependabot-cooldown | `.github/dependabot.yml` github-actions | add `cooldown: { default-days: 5 }` |
| **#186** | zizmor/dependabot-cooldown | `.github/dependabot.yml` npm | add `cooldown: { default-days: 5 }` |
| **#187** | zizmor/dependabot-cooldown | `.github/dependabot.yml` pip | add `cooldown: { default-days: 5 }` |

### Not fixed (dismiss-with-reason after this PR lands)

| # | Rule | File | Why dismiss |
|---|---|---|---|
| #181 | py/path-injection (high) | `scripts/api/docs_router.py:413` | Already has `safe_join` (commonpath) + `_assert_under_root` (`resolve().relative_to()`) + `.suffix` allowlist + hidden-file block. Existing `codeql[py/path-injection]` suppression comments at lines 412/416/429 document the defense; flow analysis can't trace through `_assert_under_root`. See #1860. |
| #180 | js/unvalidated-dynamic-method-call (high) | `dashboards/admin.html:228` | Dispatch is `sectionLoaders[section]()` guarded by `Object.prototype.hasOwnProperty.call(sectionLoaders, section)` on the preceding line — narrows the surface to own-properties of the hardcoded loader map. Not arbitrary method dispatch. |
| #184 | py/stack-trace-exposure (medium) | `scripts/ai_agent_bridge/openai_proxy.py:347` | Every caller of `_openai_error` sanitizes upstream — `_first_error_line()` truncates `exc.stderr`/`str(exc)` to one line; `_validation_error_message()` extracts msg + location only. No stack traces reach the response body. |

## Test plan

- [x] Manual review of all interpolation sites in the touched files
- [x] Pre-commit hooks (ruff, gitleaks, trailing whitespace, yaml syntax) — green
- [ ] CI green
- [ ] After merge: dismiss #181, #180, #184 on GitHub with the rationale above

## Notes

The textbook_images ingestion pipeline that feeds `image-explorer.html` is ours — `img.description_uk`/`img.image_path` aren't attacker-controlled in current usage. The XSS hardening here is defense-in-depth + future-proofing for any future API that ingests user-influenced content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)