### PR TITLE
fix(wiki_coverage_gate): section ends at sibling heading, not first H3 child

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -542,11 +542,23 @@ def _location_text(text: str, location: str) -> str:
         chosen_index = candidates[0][2]
         heading = headings[chosen_index]
         start = heading.start()
-        end = (
-            headings[chosen_index + 1].start()
-            if chosen_index + 1 < len(headings)
-            else len(text)
-        )
+        # End the section at the next heading whose depth is <= chosen
+        # depth (sibling or shallower). Sub-headings (deeper) are
+        # structurally INSIDE the chosen section and must stay in
+        # `target_text`. Build-#8 a1/my-morning regression: chosen was
+        # H2 `## Дієслова на -ся`, next-by-document was H3
+        # `### Крок 1: ...`; without depth-aware boundary the returned
+        # text was just the 620-char H2 intro, excluding every H3
+        # paradigm block that carried the substance terms step-2 needed
+        # to match. See `tests/audit/test_wiki_coverage_gate.py::
+        # test_sequence_step_h2_section_includes_h3_subsection_content`.
+        chosen_depth = len(heading.group("marks"))
+        end = len(text)
+        for next_idx in range(chosen_index + 1, len(headings)):
+            next_depth = len(headings[next_idx].group("marks"))
+            if next_depth <= chosen_depth:
+                end = headings[next_idx].start()
+                break
         return text[start:end]
     return text if location_key in text.casefold() else ""
 

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -233,6 +233,59 @@ def test_sequence_step_passes_when_h1_title_collides_with_h2_section() -> None:
     )
 
 
+def test_sequence_step_h2_section_includes_h3_subsection_content() -> None:
+    """Build-#8 regression: PR #2184's `_location_text` correctly picks
+    the H2 section over the H1 module title, but ended the section at
+    the next heading regardless of depth. When the H2 contains H3
+    sub-sections (writer uses `### Крок N: ...` markers), the returned
+    text is only the H2 intro + space before the first H3 — all H3
+    sub-content is excluded from substance matching.
+
+    The H3 is structurally INSIDE the H2 section; the section boundary
+    should be the next heading whose depth is <= chosen depth (a
+    sibling or shallower heading), so H3+ sub-content stays included.
+
+    Build #8 of a1/my-morning ended at 17/18 with this exact shape:
+    only the parent H2 matched (writer's H3 title diverged from the
+    implementation_map's subsection name), and the returned 620-char
+    H2 intro excluded the H3 paradigm tables that carried the
+    substance-term overlap step-5's claim needed."""
+    manifest = _sequence_step_manifest()
+    module_md = (
+        "## Дієслова на -ся\n\n"
+        "Short H2 intro paragraph that mentions ранкової only briefly.\n\n"
+        "### Крок 1: Шаблон\n\nReader paradigm content here.\n\n"
+        "### Крок 2: Зворотні дієслова\n\n"
+        "Substance lives here: іменниками вода зарядка сніданок "
+        "прислівниками часу частотності раненько швиденько завжди "
+        "ніколи — all the wiki-claim stems the substance check needs.\n\n"
+        "## Підсумок\n\nWrap-up.\n"
+    )
+    implementation_map = {
+        "step-5": {
+            "artifact": "module.md",
+            "location": "§Дієслова на -ся",
+            "treatment": "in-prose vocabulary block in H3 sub-section",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md=module_md,
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    step_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "step-5"
+    )
+    assert step_result["status"] == "PASS", (
+        f"H2 section must include its H3 sub-section content when "
+        f"computing target_text; got reason={step_result['reason']!r}"
+    )
+
+
 def test_l2_error_passes_when_marker_contains_apostrophe() -> None:
     """`_activity_text` must surface activity content without YAML re-
     serialisation double-escaping apostrophes. The build-#6 regression:


### PR DESCRIPTION
## Summary

Follow-up to PR #2184. That PR fixed the H1/H2 heading-collision case (deeper heading wins as section root), but kept the original "end = next heading in document order" semantics. When the chosen heading is H2 and the next heading is H3 (a sub-section), the returned target text excludes everything inside the H3 — which is the bulk of the section's substance for any module the writer chose to structure with sub-headings.

## The bug in build-#8 of a1/my-morning

The writer organised `## Дієслова на -ся` with `### Крок 1: Шаблон ...` and `### Крок 2: Введення зворотних дієслів...` paradigm sub-sections. The implementation_map's location for step-2 named a different subsection title than the writer actually used (`Зворотні дієслова + вимова` vs the writer's longer wiki-aligned title), so only the parent H2 matched as a candidate.

The 620-char H2 intro returned by `_location_text` lacked the substance terms step-2's wiki claim required (`прокидатися`, `одягатися`, `вмиватися`, `закінчення`, etc.) — all of which sat inside the H3 paradigm blocks.

Final gate: `cov=0.9444 (17/18)`, single failure `step-2 sequence_claim_missing`.

## Fix

Compute `end` as the next heading whose depth is `<=` chosen depth (sibling or shallower). H3+ sub-content stays in `target_text` since it is structurally INSIDE the chosen section.

## Smoking-gun verification

Running the **fixed** gate against the **unchanged** build-#8 artifacts:

```
passed=True hard_fail=False cov=1.0000 (18/18)
```

## Test plan

- [x] TDD: one new regression test (`test_sequence_step_h2_section_includes_h3_subsection_content`) — H2 with two H3 children where substance lives in the second H3 only. Fails before fix; passes after.
- [x] `pytest -k 'wiki_coverage or wiki_manifest or linear_pipeline_wiki'` → 51 passed, 1 skipped, 0 failed
- [x] `ruff check` → clean
- [x] Existing PR-#2184 regressions still pass (`test_sequence_step_passes_when_h1_title_collides_with_h2_section`, `test_l2_error_passes_when_marker_contains_apostrophe`)
- [ ] CI green

## Cascade context

This is the **fourth** gate-detection bug exposed in the 2026-05-21 a1/my-morning rebuild cascade:

| Build | Gate | Fix |
|---|---|---|
| #5 | vesum_verified (stem fragment) | PR #2173 |
| #6 | wiki_coverage_gate (H1/H2 collision + YAML re-escape) | PR #2184 |
| #7 | textbook_grounding (H3 hijacks section_title) | PR #2185 |
| #8 | wiki_coverage_gate (H2 truncates at first H3 child) | this PR |

Hopefully terminating — the section-boundary fix is the missing piece that lets builds with H3 sub-headings actually pass wiki_coverage when the parent H2 is the matched location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)