### PR TITLE
fix(etymology): drop featured slugs sertse + maty (unblock main CI)

### DIFF
--- a/starlight/src/pages/etymology/index.astro
+++ b/starlight/src/pages/etymology/index.astro
@@ -27,10 +27,14 @@ const data = manifest as {
 // Verification: scripts/etymology/transliterate.py emits the slug; we check
 // it's in manifest.slug_groups. (Failed once with 'хата' — hand-picked, not
 // an ESUM headword; closest real entries are 'хати' / 'хатьма'. Replaced
-// with 'хліб'.)
+// with 'хліб'.) On 2026-05-21 the manifest was regenerated from new
+// ABBYY+text.pdf parsers (PRs #2180/#2181, commit 7d3ab9d898). The new
+// ingest dropped headwords 'серце' / 'мати'; their featured cards
+// (slugs 'sertse' / 'maty') started 404-ing in dev and the
+// `tests/unit/etymology-featured-slugs.test.ts` quality gate started
+// failing on every CI run from that point. Removed both until the
+// etymology team re-includes those lemmas in a future ingest.
 const featured: Array<{ slug: string; lemma: string; gloss: string }> = [
-  { slug: 'sertse', lemma: 'серце', gloss: 'Том 5, с. 222 — серце як орган і символ' },
-  { slug: 'maty', lemma: 'мати', gloss: "5 статей в ЕСУМ — іменник, дієслово, прислівник" },
   { slug: 'dim', lemma: 'дім', gloss: 'Том 2, с. 90 — псл. *domъ, споріднене з лат. domus' },
   { slug: 'zhinka', lemma: 'жінка', gloss: 'Том 2, с. 200 — псл. *žena, споріднене з гр. γυνή' },
   { slug: 'khlib', lemma: 'хліб', gloss: 'Том 6, с. 180 — давнє запозичення з широким розгалуженням' },


### PR DESCRIPTION
## Summary

Main CI's frontend quality gate (`starlight/tests/unit/etymology-featured-slugs.test.ts`) has been failing on every push since 7d3ab9d898 (manifest regen from new ABBYY + text.pdf parsers — PRs #2180/#2181). The new ESUM ingest dropped headwords `серце` and `мати`; the two featured slugs `sertse` / `maty` on the /etymology/ landing now point at 404 pages, and the gate is a hard fail.

## Smoking-gun

```
sertse: False
maty: False
dim: True
zhinka: True
khlib: True
voda: True
```

## Fix

Remove the two missing entries from the `featured` array. The remaining four are verified in the regenerated manifest.

## Why this PR (and not 're-add them to the manifest')

Re-adding `серце`/`мати` to the manifest requires the etymology team's input on how to source them (manual override entries, or wait for the next ingest covering the missing headwords). That's a content/data decision out of scope for a frontend-unblock. This PR keeps the curation honest (no 404 cards) and lets every blocked PR's frontend gate pass.

The etymology team can re-add the entries in a follow-up commit when the data is available.

## Test plan

- [x] Manual verification: 4 remaining featured slugs all present in `starlight/src/data/etymology-manifest.json:slug_groups`
- [ ] CI green — especially `Frontend (build + vitest)` which was the blocker

## Blocks

This unblocks PR #2193 (wiki_coverage_gate H2-truncates-at-H3 follow-up) and any other open PR whose Frontend check is currently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)