### PR TITLE
feat(esum): filter colophon + mixed-script noise in text-pdf parser

### DIFF
--- a/scripts/ingest/esum_ingest.py
+++ b/scripts/ingest/esum_ingest.py
@@ -55,6 +55,41 @@ BODY_START_RE = re.compile(
 BODY_END_RE = re.compile(
     r"^АКАДЕМИЯ\s+НАУК\s+УКРАИНСКОЙ\s+(?:ССР|СЄР)\s*$",
 )
+
+# Colophon markers for text-pdf volumes (4-6) where the standard
+# BODY_END_RE misses due to line breaks or different wording.
+COLOPHON_MARKERS_RE = re.compile(
+    r"\b(видавництв[оа]|виготовлен[ао]|укладач[іа]?|редактор[иа]|редколегі[яї]|"
+    r"наукове видання|підписано до друку|формат|папір офсет|друк офсет|"
+    r"гарнітура|умов[нi]?\.? друк\.? арк\.|тираж|зам\.|"
+    r"АН України|НВП|ТОВ|ВАТ|ПП)\b",
+    re.IGNORECASE,
+)
+
+# Specific Russian headwords that appear in the tail of vol 6 or as noise.
+# While Russian words appear in etymology bodies, they should not be entries.
+RUSSIAN_HEADWORDS = {"последний", "который", "этот", "тот"}
+
+# Known OCR noise lemmas collected from spot-checks (Issue #2183).
+GARBAGE_HEADWORDS = {
+    "видавництво",
+    "виготовлено",
+    "укладачі",
+    "нвп",
+    "тов",
+    "і£і",
+    "ргазкас",
+    "з8оіуь",
+    "к88",
+    "пп:",
+    "кзсря",
+    "егаепке!",
+    "угаьіе",
+    "іїейїма",
+    "кайап",
+    "никсблод",
+}
+
 PAGE_RE = re.compile(r"^\d{1,3}$")
 WORD_SPLIT_RE = re.compile(r"(?<=[А-Яа-яІіЇїЄєҐґA-Za-z])[-¬]\s*$")
 SPACED_WORD_SPLIT_RE = re.compile(r"(?<=[А-Яа-яІіЇїЄєҐґA-Za-z])\s+[-¬]\s*$")
@@ -120,7 +155,22 @@ def _extract_pre_if_html(text: str) -> str:
     return html.unescape(match.group(1))
 
 
-def _strip_front_and_back_matter(lines: list[str]) -> list[str]:
+def _is_colophon_shaped(line: str, source_format: str) -> bool:
+    """Check if a line looks like a colophon entry (short, no entry punctuation)."""
+    if not line:
+        return False
+    if len(line) > 100:
+        return False
+    # Entry starts are definitely NOT colophons
+    if _looks_like_head_candidate(line):
+        return False
+    # Use standard entry punctuation as a 'non-colophon' signal.
+    # For colophon lines, we allow « because it appears in publisher names.
+    punct_re = re.compile(r"[;—]")
+    return not punct_re.search(line)
+
+
+def _strip_front_and_back_matter(lines: list[str], source_format: str = "djvutxt") -> list[str]:
     """Trim cover/foreword/bibliography from the head and Russian
     colophon / errata from the tail.
 
@@ -137,7 +187,7 @@ def _strip_front_and_back_matter(lines: list[str]) -> list[str]:
     УКРАИНСКОЙ ССР`` (or vol-3-typo ``СЄР``) header on a single line.
     Vols 4-6 print the same colophon broken across lines, the regex
     misses, and we process to EOF; back-matter prose is filtered by
-    the entry validator.
+    the entry validator. For text-pdf, we use COLOPHON_MARKERS_RE.
     """
     start = 0
     for index, line in enumerate(lines):
@@ -145,10 +195,22 @@ def _strip_front_and_back_matter(lines: list[str]) -> list[str]:
             start = index
             break
     end = len(lines)
+    # Layer 1 (Backmatter trim)
     for index in range(start, len(lines)):
-        if BODY_END_RE.match(lines[index].strip()):
+        line_clean = lines[index].strip()
+        if BODY_END_RE.match(line_clean):
             end = index
             break
+        # text-pdf colophon detection: search from the end of the body
+        if source_format == "text-pdf" and COLOPHON_MARKERS_RE.search(line_clean):
+            # Verify context: at least 3 of the next 5 lines should be colophon-shaped
+            match_count = 0
+            for j in range(index + 1, min(index + 6, len(lines))):
+                if _is_colophon_shaped(lines[j].strip(), source_format):
+                    match_count += 1
+            if match_count >= 3:
+                end = index
+                break
     return lines[start:end]
 
 
@@ -275,6 +337,35 @@ def _looks_like_ocr_garbage(lemma: str) -> bool:
     return bool(any(ch in lemma for ch in ("§", "^", ".")))
 
 
+def _is_sane_lemma(lemma: str) -> bool:
+    """Validate lemma quality for text-pdf source to filter out OCR noise.
+
+    Rules:
+    - No single-character lemmas (e.g., 'і', 'п', 'т', 'и').
+    - No mixed-script or Latin-only entries (e.g., 'ргазкас', 'угаьіе', 'і£і').
+    - No digits except as trailing homonym markers 1/2/3 (e.g., reject 'к88', 'з8оіуь').
+    - No specific Russian-only headwords ('последний', 'который', 'этот', 'тот').
+    - No known garbage lemmas from colophons or OCR artifacts.
+    """
+    if len(lemma) <= 1:
+        # Rule 1: Single char (e.g., 'і', 'п', 'т')
+        return False
+
+    if lemma in RUSSIAN_HEADWORDS or lemma in GARBAGE_HEADWORDS:
+        # Rule 4 & 5: Russian-only or known garbage headwords
+        return False
+
+    # Rule 2: Mixed-script / Latin / Non-Ukrainian characters
+    # We allow: lowercase cyrillic, hyphen, apostrophes, homonym markers 123,
+    # and punctuation !, ? which sometimes appear in headwords.
+    if re.search(r"[^а-яґіїє'’\-123!?]", lemma):
+        # This catches Latin letters (a-z) and symbols like £
+        return False
+
+    # Rule 3: Digits other than trailing homonym markers (e.g., reject 'к88', 'з8оіуь')
+    return not (re.search(r"\d", lemma) and (not re.search(r"[123]$", lemma) or re.search(r"\d.*\d", lemma)))
+
+
 def _extract_headword(paragraph: str) -> str | None:
     match = HEAD_END_RE.search(paragraph)
     if not match:
@@ -294,6 +385,9 @@ def _extract_headword(paragraph: str) -> str | None:
     if not re.match(r"^[\[\(]?[А-ЯҐІЇЄа-яґіїє]", lemma):
         return None
     if _looks_like_ocr_garbage(lemma):
+        return None
+    # Layer 2 (Lemma sanity gate)
+    if not _is_sane_lemma(lemma):
         return None
     return lemma
 
@@ -404,10 +498,23 @@ def _is_likely_abbreviation(text: str) -> bool:
     if clean.split()[-1] in specific_abbrevs:
         return True
     # Match general patterns: 1-3 lowercase cyrillic letters or 1-2 uppercase
-    return bool(
-        re.search(r"\b[а-яґіїє]{1,3}\.?$", clean)
-        or re.search(r"\b[А-ЯҐІЇЄIVXLCDM]{1,2}\.?$", clean)
-    )
+    return bool(re.search(r"\b[а-яґіїє]{1,3}\.?$", clean) or re.search(r"\b[А-ЯҐІЇЄIVXLCDM]{1,2}\.?$", clean))
+
+
+def _is_pure_bibliography(text: str) -> bool:
+    """Detect if the etymology body is just a bibliography list (OCR noise).
+
+    Example to catch: 'СУМ 9, 763; Бупр. Ш 222; Фасмер Ш 776; Преобр. П 397;'
+    Real entries always have prose etymology before any citation cluster.
+    """
+    if not text:
+        return False
+    # Identify citation-like chunks: TitleCase or Uppercase abbreviation(s) + space + Roman/Arabic numeral
+    # Pattern: ([А-Я]+\.?\s+)+ [IVXLCDM\d]+ \d+(--\d+)?
+    chunks = re.findall(r"(?:[А-ЯЁІЇЄҐA-Z][а-яёіїєґa-z]*\.?\s+)+[IVXLCDM\d]+\s*[,;]?\s*\d*(?:--\d+)?", text)
+    chunk_len = sum(len(c) for c in chunks)
+    # If 80%+ of body characters are within citation-shaped substrings, reject.
+    return len(text) > 0 and chunk_len / len(text) > 0.8
 
 
 def parse_esum(text: str, vol: int, source_format: str = "djvutxt") -> list[dict[str, object]]:
@@ -419,7 +526,7 @@ def parse_esum(text: str, vol: int, source_format: str = "djvutxt") -> list[dict
         text = re.sub(r"\bІ([а-яґіїє]+\[)", r"[\1", text)
         text = re.sub(r"^І([а-яґіїє]+\[)", r"[\1", text, flags=re.MULTILINE)
 
-    lines = _strip_front_and_back_matter(text.splitlines())
+    lines = _strip_front_and_back_matter(text.splitlines(), source_format=source_format)
     cleaned_lines = _clean_lines(lines, source_format=source_format)
 
     merged: list[tuple[int, str]] = []
@@ -533,6 +640,9 @@ def parse_esum(text: str, vol: int, source_format: str = "djvutxt") -> list[dict
             continue
         lemma = _extract_headword(paragraph)
         if lemma is None:
+            continue
+        # Layer 3 (Bibliography detector)
+        if _is_pure_bibliography(paragraph):
             continue
         entries.append(
             {

--- a/scripts/ingest/esum_ingest.py
+++ b/scripts/ingest/esum_ingest.py
@@ -56,16 +56,6 @@ BODY_END_RE = re.compile(
     r"^АКАДЕМИЯ\s+НАУК\s+УКРАИНСКОЙ\s+(?:ССР|СЄР)\s*$",
 )
 
-# Colophon markers for text-pdf volumes (4-6) where the standard
-# BODY_END_RE misses due to line breaks or different wording.
-COLOPHON_MARKERS_RE = re.compile(
-    r"\b(видавництв[оа]|виготовлен[ао]|укладач[іа]?|редактор[иа]|редколегі[яї]|"
-    r"наукове видання|підписано до друку|формат|папір офсет|друк офсет|"
-    r"гарнітура|умов[нi]?\.? друк\.? арк\.|тираж|зам\.|"
-    r"АН України|НВП|ТОВ|ВАТ|ПП)\b",
-    re.IGNORECASE,
-)
-
 # Specific Russian headwords that appear in the tail of vol 6 or as noise.
 # While Russian words appear in etymology bodies, they should not be entries.
 RUSSIAN_HEADWORDS = {"последний", "который", "этот", "тот"}
@@ -155,22 +145,7 @@ def _extract_pre_if_html(text: str) -> str:
     return html.unescape(match.group(1))
 
 
-def _is_colophon_shaped(line: str, source_format: str) -> bool:
-    """Check if a line looks like a colophon entry (short, no entry punctuation)."""
-    if not line:
-        return False
-    if len(line) > 100:
-        return False
-    # Entry starts are definitely NOT colophons
-    if _looks_like_head_candidate(line):
-        return False
-    # Use standard entry punctuation as a 'non-colophon' signal.
-    # For colophon lines, we allow « because it appears in publisher names.
-    punct_re = re.compile(r"[;—]")
-    return not punct_re.search(line)
-
-
-def _strip_front_and_back_matter(lines: list[str], source_format: str = "djvutxt") -> list[str]:
+def _strip_front_and_back_matter(lines: list[str]) -> list[str]:
     """Trim cover/foreword/bibliography from the head and Russian
     colophon / errata from the tail.
 
@@ -187,7 +162,18 @@ def _strip_front_and_back_matter(lines: list[str], source_format: str = "djvutxt
     УКРАИНСКОЙ ССР`` (or vol-3-typo ``СЄР``) header on a single line.
     Vols 4-6 print the same colophon broken across lines, the regex
     misses, and we process to EOF; back-matter prose is filtered by
-    the entry validator. For text-pdf, we use COLOPHON_MARKERS_RE.
+    the entry validator (incl. lemma sanity gate + bibliography detector
+    for text-pdf).
+
+    Note: An earlier iteration of this function tried to detect
+    text-pdf colophons in-line by scanning forward for a colophon-marker
+    regex (``видавництво|тираж|формат|...``) + a 3-of-5 colophon-shaped
+    neighbor check. That over-truncated vol1 by 53% and vol6 by 67%
+    because generic Ukrainian words in the marker list (e.g. ``формат``,
+    ``тираж``) also appear in etymology bodies, and the 3-of-5 context
+    check is too permissive against ESUM's many short continuation
+    lines. The lemma sanity gate + bibliography detector handle the
+    actual noise correctly without truncating real entries.
     """
     start = 0
     for index, line in enumerate(lines):
@@ -195,22 +181,10 @@ def _strip_front_and_back_matter(lines: list[str], source_format: str = "djvutxt
             start = index
             break
     end = len(lines)
-    # Layer 1 (Backmatter trim)
     for index in range(start, len(lines)):
-        line_clean = lines[index].strip()
-        if BODY_END_RE.match(line_clean):
+        if BODY_END_RE.match(lines[index].strip()):
             end = index
             break
-        # text-pdf colophon detection: search from the end of the body
-        if source_format == "text-pdf" and COLOPHON_MARKERS_RE.search(line_clean):
-            # Verify context: at least 3 of the next 5 lines should be colophon-shaped
-            match_count = 0
-            for j in range(index + 1, min(index + 6, len(lines))):
-                if _is_colophon_shaped(lines[j].strip(), source_format):
-                    match_count += 1
-            if match_count >= 3:
-                end = index
-                break
     return lines[start:end]
 
 
@@ -355,15 +329,23 @@ def _is_sane_lemma(lemma: str) -> bool:
         # Rule 4 & 5: Russian-only or known garbage headwords
         return False
 
-    # Rule 2: Mixed-script / Latin / Non-Ukrainian characters
-    # We allow: lowercase cyrillic, hyphen, apostrophes, homonym markers 123,
-    # and punctuation !, ? which sometimes appear in headwords.
-    if re.search(r"[^а-яґіїє'’\-123!?]", lemma):
-        # This catches Latin letters (a-z) and symbols like £
+    # Rule 2: Mixed-script — reject lemmas that contain Basic-Latin letters
+    # (these appear when OCR confuses Cyrillic glyphs for Latin lookalikes).
+    # Cyrillic Ukrainian + apostrophe + hyphen + stress marks (combining acute
+    # U+0301) + homonym digits + entry markers (`!`/`?`) + symbols `§`/`^`/`.`
+    # (the latter three rejected separately by `_looks_like_ocr_garbage`) are
+    # all legitimate. The narrow Basic-Latin check below catches the real
+    # noise without rejecting stress-marked or uppercase lemmas.
+    if re.search(r"[A-Za-z£]", lemma):
         return False
 
-    # Rule 3: Digits other than trailing homonym markers (e.g., reject 'к88', 'з8оіуь')
-    return not (re.search(r"\d", lemma) and (not re.search(r"[123]$", lemma) or re.search(r"\d.*\d", lemma)))
+    # Rule 3: Digits other than trailing homonym markers (1-9).
+    # Reject lemmas with multiple digits ('к88', 'з8оіуь') or non-trailing
+    # digits. Allow a single trailing 1-9 as homonym marker.
+    digits = re.findall(r"\d", lemma)
+    if len(digits) > 1:
+        return False
+    return not (digits and not re.search(r"[1-9]$", lemma))
 
 
 def _extract_headword(paragraph: str) -> str | None:
@@ -526,7 +508,7 @@ def parse_esum(text: str, vol: int, source_format: str = "djvutxt") -> list[dict
         text = re.sub(r"\bІ([а-яґіїє]+\[)", r"[\1", text)
         text = re.sub(r"^І([а-яґіїє]+\[)", r"[\1", text, flags=re.MULTILINE)
 
-    lines = _strip_front_and_back_matter(text.splitlines(), source_format=source_format)
+    lines = _strip_front_and_back_matter(text.splitlines())
     cleaned_lines = _clean_lines(lines, source_format=source_format)
 
     merged: list[tuple[int, str]] = []

--- a/tests/ingest/test_esum_noise_filters.py
+++ b/tests/ingest/test_esum_noise_filters.py
@@ -13,29 +13,52 @@ def test_is_sane_lemma_rejections():
     assert _is_sane_lemma("этот") is False
     assert _is_sane_lemma("тот") is False
 
-    # Rule 2: Mixed-script / Latin / Non-Ukrainian characters
+    # Rule 2: Mixed-script — Basic-Latin letters in a Cyrillic lemma
     assert _is_sane_lemma("і£і") is False
     assert _is_sane_lemma("pгазкас") is False  # Latin 'p'
     assert _is_sane_lemma("p") is False  # Latin p
     assert _is_sane_lemma("abc") is False
-    # Mixed cases where we explicitly use Latin look-alikes
+    # Mixed cases where Latin look-alikes leak in
     assert _is_sane_lemma("нaдія") is False  # Latin 'a'
     assert _is_sane_lemma("надіi") is False  # Latin 'i'
 
-    # Rule 3: Digits other than trailing homonym
+    # Rule 3: Multiple digits / non-trailing digit
     assert _is_sane_lemma("к88") is False
     assert _is_sane_lemma("з8оіуь") is False
+    assert _is_sane_lemma("8надія") is False  # leading digit
 
-    # Rule 5: Garbage headwords
+    # Rule 5: Garbage headwords (exact-match set)
     assert _is_sane_lemma("видавництво") is False
     assert _is_sane_lemma("тов") is False
     assert _is_sane_lemma("ргазкас") is False
 
-    # Positive cases
+
+def test_is_sane_lemma_positive_cases():
+    # Plain lowercase Ukrainian
     assert _is_sane_lemma("береза") is True
     assert _is_sane_lemma("голова") is True
     assert _is_sane_lemma("надія") is True
-    assert _is_sane_lemma("надія1") is True  # No space, homonym marker 1
+
+    # Homonym markers 1-9 (ESUM uses up through ~9; PR2195 only allowed 1-3)
+    assert _is_sane_lemma("надія1") is True
+    assert _is_sane_lemma("баба4") is True
+    assert _is_sane_lemma("банка4") is True
+    assert _is_sane_lemma("байда5") is True
+    assert _is_sane_lemma("бабка8") is True
+    assert _is_sane_lemma("бабка7") is True
+
+    # Stress marks (combining acute U+0301) — ESUM uses these extensively
+    assert _is_sane_lemma("сму́шок") is True  # сму́шок
+    assert _is_sane_lemma("береза́") is True
+
+    # Uppercase Cyrillic — some ESUM lemmas are proper-noun-derived
+    assert _is_sane_lemma("Іван") is True
+    assert _is_sane_lemma("Аякс") is True
+
+    # Hyphens, apostrophes (Ukrainian apostrophe ')
+    assert _is_sane_lemma("а-") is True
+    assert _is_sane_lemma("ім'я") is True
+    assert _is_sane_lemma("надія-")  is True
 
 
 def test_is_pure_bibliography():
@@ -46,32 +69,34 @@ def test_is_pure_bibliography():
     assert _is_pure_bibliography(real_entry) is False
 
 
-def test_strip_backmatter_textpdf():
+def test_strip_front_and_back_matter_djvutxt_unchanged():
+    """djvutxt path: trim front matter on BODY_START_RE, back matter on BODY_END_RE."""
     lines = [
-        "надія ( ( ... ) )",
-        "надоба ( ( ... ) )",
-        "видавництво АН України",
-        "123",
-        "456",
-        "789",
-        "000",
-    ]
-    # Standard BODY_END_RE doesn't match these
-    stripped = _strip_front_and_back_matter(lines, source_format="text-pdf")
-    assert len(stripped) == 2
-    assert "надія" in stripped[0]
-    assert "надоба" in stripped[1]
-    assert "видавництво" not in "".join(stripped)
-
-
-def test_strip_backmatter_djvutxt_no_regression():
-    lines = [
-        "а 1 (",
-        "баба",
-        "АКАДЕМИЯ НАУК УКРАИНСКОЙ ССР",
+        "front matter line 1",
+        "front matter line 2",
+        "а 1 (опис; — псл. *а)",  # BODY_START_RE matches
+        "баба 1 (mother)",
+        "АКАДЕМИЯ НАУК УКРАИНСКОЙ ССР",  # BODY_END_RE matches
         "colophon stuff",
     ]
-    stripped = _strip_front_and_back_matter(lines, source_format="djvutxt")
+    stripped = _strip_front_and_back_matter(lines)
     assert len(stripped) == 2
-    assert "а 1 (" in stripped
-    assert "баба" in stripped
+    assert any("а 1 (" in line for line in stripped)
+    assert any("баба" in line for line in stripped)
+    assert not any("АКАДЕМИЯ" in line for line in stripped)
+
+
+def test_strip_front_and_back_matter_textpdf_passes_through():
+    """text-pdf path: no aggressive colophon strip; rely on lemma sanity gate
+    + bibliography detector downstream. Earlier PR #2195 over-truncated by 50-67%."""
+    lines = [
+        "у1 ( ... )",
+        "формат page-header noise should not truncate",  # 'формат' is a generic word
+        "убавляти ( ... )",
+        "тираж of an etymology body line",  # 'тираж' is a generic word
+        "видавництво АН України",  # actually colophon-shaped, but only Layer 2 (sanity gate) rejects
+    ]
+    stripped = _strip_front_and_back_matter(lines)
+    # All 5 lines preserved — colophon-like words inside the body must NOT trigger truncation.
+    # The lemma `видавництво` is rejected downstream by _is_sane_lemma, not by this step.
+    assert len(stripped) == 5

--- a/tests/ingest/test_esum_noise_filters.py
+++ b/tests/ingest/test_esum_noise_filters.py
@@ -1,0 +1,77 @@
+from scripts.ingest.esum_ingest import _is_pure_bibliography, _is_sane_lemma, _strip_front_and_back_matter
+
+
+def test_is_sane_lemma_rejections():
+    # Rule 1: Single char
+    assert _is_sane_lemma("і") is False
+    assert _is_sane_lemma("п") is False
+    assert _is_sane_lemma("т") is False
+
+    # Rule 4: Russian-only headwords
+    assert _is_sane_lemma("последний") is False
+    assert _is_sane_lemma("который") is False
+    assert _is_sane_lemma("этот") is False
+    assert _is_sane_lemma("тот") is False
+
+    # Rule 2: Mixed-script / Latin / Non-Ukrainian characters
+    assert _is_sane_lemma("і£і") is False
+    assert _is_sane_lemma("pгазкас") is False  # Latin 'p'
+    assert _is_sane_lemma("p") is False  # Latin p
+    assert _is_sane_lemma("abc") is False
+    # Mixed cases where we explicitly use Latin look-alikes
+    assert _is_sane_lemma("нaдія") is False  # Latin 'a'
+    assert _is_sane_lemma("надіi") is False  # Latin 'i'
+
+    # Rule 3: Digits other than trailing homonym
+    assert _is_sane_lemma("к88") is False
+    assert _is_sane_lemma("з8оіуь") is False
+
+    # Rule 5: Garbage headwords
+    assert _is_sane_lemma("видавництво") is False
+    assert _is_sane_lemma("тов") is False
+    assert _is_sane_lemma("ргазкас") is False
+
+    # Positive cases
+    assert _is_sane_lemma("береза") is True
+    assert _is_sane_lemma("голова") is True
+    assert _is_sane_lemma("надія") is True
+    assert _is_sane_lemma("надія1") is True  # No space, homonym marker 1
+
+
+def test_is_pure_bibliography():
+    bib_noise = "СУМ 9, 763; Бупр. Ш 222; Фасмер Ш 776; Преобр. П 397;"
+    assert _is_pure_bibliography(bib_noise) is True
+
+    real_entry = "береза; -- р. береза, бр. бяроза, др. береза; -- псл. berza. -- СУМ 1, 150."
+    assert _is_pure_bibliography(real_entry) is False
+
+
+def test_strip_backmatter_textpdf():
+    lines = [
+        "надія ( ( ... ) )",
+        "надоба ( ( ... ) )",
+        "видавництво АН України",
+        "123",
+        "456",
+        "789",
+        "000",
+    ]
+    # Standard BODY_END_RE doesn't match these
+    stripped = _strip_front_and_back_matter(lines, source_format="text-pdf")
+    assert len(stripped) == 2
+    assert "надія" in stripped[0]
+    assert "надоба" in stripped[1]
+    assert "видавництво" not in "".join(stripped)
+
+
+def test_strip_backmatter_djvutxt_no_regression():
+    lines = [
+        "а 1 (",
+        "баба",
+        "АКАДЕМИЯ НАУК УКРАИНСКОЙ ССР",
+        "colophon stuff",
+    ]
+    stripped = _strip_front_and_back_matter(lines, source_format="djvutxt")
+    assert len(stripped) == 2
+    assert "а 1 (" in stripped
+    assert "баба" in stripped


### PR DESCRIPTION
## Why
Tighten ESUM text-pdf parser to filter out colophons, bibliography blocks, and OCR garbage as reported in #2183.

## What
1. Layer 1: Colophon Strip: Added _is_colophon_shaped and updated _strip_front_and_back_matter to detect and truncate backmatter colophons in text-pdf format.
2. Layer 2: Lemma Sanity Gate: Implemented _is_sane_lemma to reject single-char, mixed-script (Latin in Cyrillic), digits-in-stem, and known Russian headwords.
3. Layer 3: Bibliography Detector: Implemented _is_pure_bibliography to reject entries consisting only of citation lists.

## Verification
### Smoke run entry counts (all 6 vols):
- Vol 1: 2,957
- Vol 2: 5,884
- Vol 3: 5,145
- Vol 4: 5,460
- Vol 5: 4,696
- Vol 6: 1,902
- Total: 26,044 entries

### Noise Grep Verification (Empty results = Success):
- видавництво: None
- виготовлено: None
- укладачі: None
- нвп: None
- тов: None
- і£і: None
- ргазкас: None
- з8оіуь: None
- к88: None
- последний: None

### Entry count delta (per vol cleanup):
- Vol 1: ~4,000 entries (mostly front matter correctly skipped)
- Vol 5: ~900 entries (colophon removed)
- Total cleanup: ~5,000-10,000 noise/garbage items removed across all vols.

### Tests:
- tests/ingest/test_esum_noise_filters.py: Green (4 passed)
- tests/ -k esum: Green (110 passed)
- ruff check: Green