### PR TITLE
feat(etymology): Cyrillic→Latin sanitizer for damaged ESUM cognate forms (closes #2186)

### DIFF
--- a/migrations/add_esum_cognate_forms_recovered.sql
+++ b/migrations/add_esum_cognate_forms_recovered.sql
@@ -1,0 +1,2 @@
+ALTER TABLE esum_cognate_forms
+ADD COLUMN cognate_forms_recovered TEXT NOT NULL DEFAULT '{}';

--- a/scripts/etymology/build_data_manifest.py
+++ b/scripts/etymology/build_data_manifest.py
@@ -62,15 +62,22 @@ def load_manifest(db_path: Path) -> dict:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
+        cognate_columns = {row["name"] for row in conn.execute("PRAGMA table_info(esum_cognate_forms)")}
+        recovered_select = (
+            "COALESCE(f.cognate_forms_recovered, '{}') AS cognate_forms_recovered"
+            if "cognate_forms_recovered" in cognate_columns
+            else "'{}' AS cognate_forms_recovered"
+        )
         rows = conn.execute(
-            """
+            f"""
             SELECT
                 e.id,
                 e.lemma,
                 e.vol,
                 e.page,
                 e.etymology_text,
-                COALESCE(f.cognate_forms, '{}') AS cognate_forms,
+                COALESCE(f.cognate_forms, '{{}}') AS cognate_forms,
+                {recovered_select},
                 f.proto_form
             FROM esum_etymology_meta e
             LEFT JOIN esum_cognate_forms f ON f.entry_id = e.id
@@ -108,24 +115,33 @@ def load_manifest(db_path: Path) -> dict:
         if not isinstance(cognate_forms, dict):
             cognate_forms = {}
 
-        entries.append(
-            {
-                "id": row["id"],
-                "lemma": row["lemma"],
-                "vol": row["vol"],
-                "page": row["page"],
-                "slug": slug,
-                "page_slug": page_slug,
-                "etymology_text": row["etymology_text"],
-                "cognate_forms": cognate_forms,
-                "proto_form": row["proto_form"],
-            }
-        )
+        try:
+            cognate_forms_recovered = json.loads(row["cognate_forms_recovered"])
+        except (json.JSONDecodeError, TypeError):
+            cognate_forms_recovered = {}
+        if not isinstance(cognate_forms_recovered, dict):
+            cognate_forms_recovered = {}
+
+        entry = {
+            "id": row["id"],
+            "lemma": row["lemma"],
+            "vol": row["vol"],
+            "page": row["page"],
+            "slug": slug,
+            "page_slug": page_slug,
+            "etymology_text": row["etymology_text"],
+            "cognate_forms": cognate_forms,
+            "proto_form": row["proto_form"],
+        }
+        if cognate_forms_recovered:
+            entry["cognate_forms_recovered"] = cognate_forms_recovered
+        entries.append(entry)
         slug_groups[slug].append(page_slug)
 
     # Stats for the build process + landing page.
     polysemy_count = sum(1 for v in slug_groups.values() if len(v) > 1)
     with_forms = sum(1 for e in entries if e["cognate_forms"])
+    with_recovered_forms = sum(1 for e in entries if e.get("cognate_forms_recovered"))
 
     return {
         "version": MANIFEST_VERSION,
@@ -135,6 +151,7 @@ def load_manifest(db_path: Path) -> dict:
             "unique_slugs": len(slug_groups),
             "polysemy_slugs": polysemy_count,
             "entries_with_cognate_forms": with_forms,
+            "entries_with_cognate_forms_recovered": with_recovered_forms,
         },
         "entries": entries,
         "slug_groups": dict(slug_groups),

--- a/scripts/etymology/extract_cognate_forms.py
+++ b/scripts/etymology/extract_cognate_forms.py
@@ -10,6 +10,11 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable
 from pathlib import Path
 
+try:
+    from scripts.etymology.recover_latin_cognates import ensure_recovered_column, recover_cognate_forms
+except ModuleNotFoundError:  # pragma: no cover - direct-script support
+    from recover_latin_cognates import ensure_recovered_column, recover_cognate_forms
+
 DEFAULT_DB = Path("data/sources.db")
 DEFAULT_TELEMETRY = Path("audit/etymology-phase-1/cognate_extraction_coverage.json")
 PROTO_MARKERS = ("псл.", "іє.", "стел.")
@@ -57,6 +62,7 @@ def create_schema(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS esum_cognate_forms (
             entry_id INTEGER PRIMARY KEY,
             cognate_forms TEXT NOT NULL DEFAULT '{}',
+            cognate_forms_recovered TEXT NOT NULL DEFAULT '{}',
             proto_form TEXT,
             extracted_count INTEGER NOT NULL DEFAULT 0,
             expected_count INTEGER NOT NULL DEFAULT 0,
@@ -66,6 +72,7 @@ def create_schema(conn: sqlite3.Connection) -> None:
         ON esum_cognate_forms(entry_id);
         """
     )
+    ensure_recovered_column(conn)
 
 
 def _clean_form(raw_form: str) -> str:
@@ -200,14 +207,17 @@ def extract_database(db_path: Path, telemetry_path: Path, min_coverage_pct: floa
                     entries_with_forms += 1
                 total_forms += len(forms)
                 marker_extracted.update(forms.keys())
+                recovered_forms = recover_cognate_forms(forms)
                 conn.execute(
                     """
                     INSERT INTO esum_cognate_forms (
-                        entry_id, cognate_forms, proto_form, extracted_count, expected_count
+                        entry_id, cognate_forms, cognate_forms_recovered,
+                        proto_form, extracted_count, expected_count
                     )
-                    VALUES (?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?)
                     ON CONFLICT(entry_id) DO UPDATE SET
                         cognate_forms = excluded.cognate_forms,
+                        cognate_forms_recovered = excluded.cognate_forms_recovered,
                         proto_form = excluded.proto_form,
                         extracted_count = excluded.extracted_count,
                         expected_count = excluded.expected_count
@@ -215,6 +225,7 @@ def extract_database(db_path: Path, telemetry_path: Path, min_coverage_pct: floa
                     (
                         row["id"],
                         json.dumps(forms, ensure_ascii=False, sort_keys=True),
+                        json.dumps(recovered_forms, ensure_ascii=False, sort_keys=True),
                         proto_form,
                         len(forms),
                         len(markers),

--- a/scripts/etymology/recover_latin_cognates.py
+++ b/scripts/etymology/recover_latin_cognates.py
@@ -1,0 +1,330 @@
+"""Recover Latin-script ESUM cognate forms damaged as Cyrillic OCR text."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DB = Path("data/sources.db")
+
+CYRILLIC_SCRIPT_MARKERS = {
+    "р.",
+    "бр.",
+    "др.",
+    "болг.",
+    "схв.",
+    "слн.",
+    "мак.",
+    "срб.",
+    "церк.-сл.",
+    "прасл.",
+    "псл.",
+    "стел.",
+    "укр.",
+}
+
+NON_CYRILLIC_SCRIPT_MARKERS = {
+    "п.",
+    "ч.",
+    "слц.",
+    "вл.",
+    "нл.",
+    "полаб.",
+    "лит.",
+    "латиш.",
+    "прус.",
+    "лат.",
+    "гр.",
+    "рум.",
+    "угор.",
+    "нвн.",
+    "н.",
+    "дангл.",
+    "англ.",
+    "двн.",
+    "гот.",
+    "фр.",
+    "іт.",
+    "ісп.",
+    "тур.",
+    "тат.",
+    "тюрк.",
+    "чу́в.",
+    "чув.",
+    "узб.",
+    "туркм.",
+    "башк.",
+    "ягноб.",
+    "ар.",
+    "євр.",
+    "ід.",
+    "іє.",
+    "дінд.",
+    "ав.",
+    "лтс.",
+    "перс.",
+}
+
+# Longer OCR clusters that need context. These are applied before the
+# character table so ambiguous glyphs such as г and і can resolve differently
+# inside known Latin clusters (rdz, -nty-, -nti-, -str-).
+SEQUENCE_CONFUSIONS: tuple[tuple[str, str], ...] = (
+    ("пії", "nti"),
+    ("піу", "nty"),
+    ("ПІЇ", "NTI"),
+    ("ПІУ", "NTY"),
+    ("бей", "dce"),
+    ("БЕЙ", "DCE"),
+    ("дг", "dz"),
+    ("ДГ", "DZ"),
+    ("зку", "sty"),
+    ("ЗКУ", "STY"),
+    ("зіг", "str"),
+    ("ЗІГ", "STR"),
+    ("с^", "cj"),
+    ("С^", "Cj"),
+    ("ійК", "juk"),
+    ("ійк", "juk"),
+    ("аша", "awia"),
+)
+
+CONFUSIONS: dict[str, str] = {
+    "5": "s",
+    "8": "s",
+    "0": "o",
+    "1": "l",
+    "а": "a",
+    "А": "A",
+    "б": "d",
+    "Б": "D",
+    "в": "b",
+    "В": "B",
+    "г": "r",
+    "Г": "R",
+    "д": "d",
+    "Д": "D",
+    "е": "e",
+    "Е": "E",
+    "з": "s",
+    "З": "S",
+    "и": "u",
+    "И": "U",
+    "і": "i",
+    "І": "l",  # ABBYY uses U+0406 for Latin small l in forms like аІІаЬеіа.
+    "ї": "i",
+    "Ї": "I",
+    "й": "j",
+    "Й": "J",
+    "к": "k",
+    "К": "K",
+    "л": "l",
+    "Л": "L",
+    "м": "m",
+    "М": "M",
+    "н": "n",
+    "Н": "N",
+    "о": "o",
+    "О": "O",
+    "п": "n",
+    "П": "N",
+    "р": "p",
+    "Р": "P",
+    "с": "c",
+    "С": "C",
+    "т": "m",
+    "Т": "M",
+    "у": "y",
+    "У": "Y",
+    "ф": "f",
+    "Ф": "F",
+    "х": "h",
+    "Х": "H",
+    "ц": "c",
+    "Ц": "C",
+    "ч": "ch",
+    "Ч": "Ch",
+    "ш": "m",
+    "Ш": "M",
+    "щ": "w",
+    "Щ": "W",
+    "ь": "b",
+    "Ь": "b",
+    "ю": "u",
+    "Ю": "U",
+    "я": "ia",
+    "Я": "Ia",
+}
+
+
+def normalize_marker(marker: str) -> str:
+    """Normalize ESUM marker spacing enough for script-scope checks."""
+
+    return re.sub(r"\s+", "", marker).strip()
+
+
+def should_recover_marker(marker: str) -> bool:
+    """Return True for language markers whose cognate form should be Latinized."""
+
+    normalized = normalize_marker(marker)
+    if normalized in CYRILLIC_SCRIPT_MARKERS:
+        return False
+    if normalized in NON_CYRILLIC_SCRIPT_MARKERS:
+        return True
+
+    parts = re.findall(r"[^\s]+?\.", marker)
+    if len(parts) > 1:
+        return all(should_recover_marker(part) for part in parts)
+
+    return False
+
+
+def _is_latin_char(char: str) -> bool:
+    if "A" <= char <= "Z" or "a" <= char <= "z":
+        return True
+    return "LATIN" in unicodedata.name(char, "")
+
+
+def _is_plausible_latin(text: str) -> bool:
+    letters = [char for char in text if char.isalpha()]
+    if not letters:
+        return False
+
+    latin_letters = sum(1 for char in letters if _is_latin_char(char))
+    cyrillic_letters = sum(1 for char in letters if "CYRILLIC" in unicodedata.name(char, ""))
+    if latin_letters / len(letters) < 0.8:
+        return False
+    if cyrillic_letters:
+        return False
+
+    meaningful = sum(1 for char in text if char.isalpha() or char in {"-", "'", "’", "ˊ", "ˈ", " "})
+    return meaningful / max(len(text), 1) >= 0.7
+
+
+def _has_recoverable_damage(text: str) -> bool:
+    return any(char in CONFUSIONS for char in text)
+
+
+def recover_latin(text: str) -> str:
+    """Return a plausible Latin recovery candidate, or the original text."""
+
+    if not text:
+        return text
+    if not _has_recoverable_damage(text):
+        return text
+
+    recovered = text
+    for damaged, replacement in SEQUENCE_CONFUSIONS:
+        recovered = recovered.replace(damaged, replacement)
+    recovered = "".join(CONFUSIONS.get(char, char) for char in recovered)
+    recovered = re.sub(r"\s+", " ", recovered).strip()
+
+    if _is_plausible_latin(recovered):
+        return recovered
+    return text
+
+
+def recover_cognate_forms(cognate_forms: dict[str, Any]) -> dict[str, str]:
+    """Recover eligible cognate forms while leaving Cyrillic-script markers out."""
+
+    recovered: dict[str, str] = {}
+    for marker, form in cognate_forms.items():
+        if not isinstance(marker, str) or not isinstance(form, str):
+            continue
+        if not should_recover_marker(marker):
+            continue
+        candidate = recover_latin(form)
+        if _is_plausible_latin(candidate):
+            recovered[marker] = candidate
+    return recovered
+
+
+def ensure_recovered_column(conn: sqlite3.Connection) -> None:
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(esum_cognate_forms)")}
+    if "cognate_forms_recovered" not in columns:
+        conn.execute("ALTER TABLE esum_cognate_forms ADD COLUMN cognate_forms_recovered TEXT NOT NULL DEFAULT '{}'")
+
+
+def _load_forms(raw_json: str) -> dict[str, Any]:
+    try:
+        decoded = json.loads(raw_json)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def recover_database(db_path: Path, dry_run: bool = False) -> dict[str, int | float]:
+    """Populate esum_cognate_forms.cognate_forms_recovered from cognate_forms."""
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        if not dry_run:
+            ensure_recovered_column(conn)
+
+        rows = conn.execute(
+            """
+            SELECT entry_id, cognate_forms
+            FROM esum_cognate_forms
+            ORDER BY entry_id
+            """
+        ).fetchall()
+
+        entries_with_eligible = 0
+        entries_with_recovered = 0
+        recovered_forms_total = 0
+
+        updates: list[tuple[str, int]] = []
+        for row in rows:
+            forms = _load_forms(row["cognate_forms"])
+            if any(should_recover_marker(marker) for marker in forms):
+                entries_with_eligible += 1
+            recovered = recover_cognate_forms(forms)
+            if recovered:
+                entries_with_recovered += 1
+                recovered_forms_total += len(recovered)
+            updates.append((json.dumps(recovered, ensure_ascii=False, sort_keys=True), row["entry_id"]))
+
+        if not dry_run:
+            with conn:
+                conn.executemany(
+                    """
+                    UPDATE esum_cognate_forms
+                    SET cognate_forms_recovered = ?
+                    WHERE entry_id = ?
+                    """,
+                    updates,
+                )
+
+        coverage_pct = round(
+            (entries_with_recovered / entries_with_eligible * 100) if entries_with_eligible else 0.0,
+            2,
+        )
+        return {
+            "rows_processed": len(rows),
+            "entries_with_non_cyrillic_markers": entries_with_eligible,
+            "entries_with_recovered_latin": entries_with_recovered,
+            "recovered_forms_total": recovered_forms_total,
+            "coverage_pct": coverage_pct,
+        }
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    stats = recover_database(args.db, dry_run=args.dry_run)
+    print(json.dumps(stats, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starlight/src/pages/etymology/[slug].astro
+++ b/starlight/src/pages/etymology/[slug].astro
@@ -25,6 +25,7 @@ interface EtymEntry {
   page_slug: string;
   etymology_text: string;
   cognate_forms: Record<string, string>;
+  cognate_forms_recovered?: Record<string, string>;
   proto_form: string | null;
 }
 
@@ -145,12 +146,19 @@ const summary = (text: string, length = 90): string => {
         <tbody>
           {Object.entries(props.entry.cognate_forms)
             .sort(([a], [b]) => a.localeCompare(b))
-            .map(([marker, form]) => (
-              <tr>
-                <td>{MARKER_LABELS[marker] ?? marker} <span class="esum-marker">({marker})</span></td>
-                <td>{form}</td>
-              </tr>
-            ))}
+            .map(([marker, form]) => {
+              const recovered = props.entry.cognate_forms_recovered?.[marker];
+              const hasRecovered = recovered && recovered !== form;
+              return (
+                <tr>
+                  <td>{MARKER_LABELS[marker] ?? marker} <span class="esum-marker">({marker})</span></td>
+                  <td>
+                    <span>{form}</span>
+                    {hasRecovered && <span class="esum-recovered">→ {recovered}</span>}
+                  </td>
+                </tr>
+              );
+            })}
         </tbody>
       </table>
     ) : (
@@ -227,6 +235,12 @@ const summary = (text: string, length = 90): string => {
   .esum-marker {
     color: var(--sl-color-gray-3);
     font-weight: normal;
+  }
+  .esum-recovered {
+    display: inline-block;
+    margin-left: 0.5rem;
+    color: var(--sl-color-accent-high);
+    font-weight: 600;
   }
   .esum-body {
     white-space: pre-wrap;

--- a/starlight/src/pages/etymology/index.astro
+++ b/starlight/src/pages/etymology/index.astro
@@ -20,6 +20,7 @@ const data = manifest as {
     unique_slugs: number;
     polysemy_slugs: number;
     entries_with_cognate_forms: number;
+    entries_with_cognate_forms_recovered?: number;
   };
 };
 
@@ -83,6 +84,12 @@ const fmtCount = (n: number) => n.toLocaleString('uk-UA');
       <tr><th>Унікальних лем (після транслітерації)</th><td>{fmtCount(data.stats.unique_slugs)}</td></tr>
       <tr><th>Сторінок розгалуження (омонімія)</th><td>{fmtCount(data.stats.polysemy_slugs)}</td></tr>
       <tr><th>Статей із витягнутими формами когнатів</th><td>{fmtCount(data.stats.entries_with_cognate_forms)}</td></tr>
+      {(data.stats.entries_with_cognate_forms_recovered ?? 0) > 0 && (
+        <tr>
+          <th>Статей із відновленими латинськими формами</th>
+          <td>{fmtCount(data.stats.entries_with_cognate_forms_recovered ?? 0)}</td>
+        </tr>
+      )}
     </tbody>
   </table>
 

--- a/tests/etymology/test_build_data_manifest.py
+++ b/tests/etymology/test_build_data_manifest.py
@@ -24,6 +24,7 @@ def _make_db(path):
         CREATE TABLE esum_cognate_forms (
             entry_id INTEGER PRIMARY KEY,
             cognate_forms TEXT NOT NULL DEFAULT '{}',
+            cognate_forms_recovered TEXT NOT NULL DEFAULT '{}',
             proto_form TEXT,
             extracted_count INTEGER NOT NULL DEFAULT 0,
             expected_count INTEGER NOT NULL DEFAULT 0,
@@ -32,22 +33,49 @@ def _make_db(path):
         """
     )
     entries = [
-        (1, "дім", 2, 90, "hash-1", "дім; — р. дом, п. dom.", {"р.": "дом", "п.": "dom"}, None),
-        (2, "мати", 2, 48, "hash-2", "мати більш загальне значення.", {}, None),
-        (3, "мати", 3, 412, "hash-3", "мати 1 (іменник)", {"р.": "мать"}, None),
-        (4, "мати", 3, 413, "hash-4", "мати 2 (дієслово); — псл. *mati.", {"псл.": "*mati"}, "*mati"),
-        (5, "серце", 5, 222, "hash-5", "серце; — псл. *sьrdьce.", {"р.": "сéрдце"}, "*sьrdьce"),
+        (1, "дім", 2, 90, "hash-1", "дім; — р. дом, п. dom.", {"р.": "дом", "п.": "dom"}, {}, None),
+        (2, "мати", 2, 48, "hash-2", "мати більш загальне значення.", {}, {}, None),
+        (3, "мати", 3, 412, "hash-3", "мати 1 (іменник)", {"р.": "мать"}, {}, None),
+        (
+            4,
+            "мати",
+            3,
+            413,
+            "hash-4",
+            "мати 2 (дієслово); — псл. *mati.",
+            {"псл.": "*mati"},
+            {},
+            "*mati",
+        ),
+        (
+            5,
+            "серце",
+            5,
+            222,
+            "hash-5",
+            "серце; — ч. 5гбей; — псл. *sьrdьce.",
+            {"ч.": "5гбей", "р.": "сéрдце"},
+            {"ч.": "srdce"},
+            "*sьrdьce",
+        ),
     ]
-    for entry_id, lemma, vol, page, entry_hash, text, forms, proto in entries:
+    for entry_id, lemma, vol, page, entry_hash, text, forms, recovered, proto in entries:
         conn.execute(
             "INSERT INTO esum_etymology_meta (id, lemma, vol, page, entry_hash, etymology_text)"
             " VALUES (?, ?, ?, ?, ?, ?)",
             (entry_id, lemma, vol, page, entry_hash, text),
         )
         conn.execute(
-            "INSERT INTO esum_cognate_forms (entry_id, cognate_forms, proto_form,"
-            " extracted_count, expected_count) VALUES (?, ?, ?, ?, ?)",
-            (entry_id, json.dumps(forms, ensure_ascii=False), proto, len(forms), len(forms)),
+            "INSERT INTO esum_cognate_forms (entry_id, cognate_forms, cognate_forms_recovered,"
+            " proto_form, extracted_count, expected_count) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                entry_id,
+                json.dumps(forms, ensure_ascii=False),
+                json.dumps(recovered, ensure_ascii=False),
+                proto,
+                len(forms),
+                len(forms),
+            ),
         )
     conn.commit()
     conn.close()
@@ -64,6 +92,7 @@ def test_manifest_shape_and_stats(tmp_path):
     assert manifest["stats"]["unique_slugs"] == 3  # дім, мати (3 senses), серце
     assert manifest["stats"]["polysemy_slugs"] == 1  # only мати has >1 entry
     assert manifest["stats"]["entries_with_cognate_forms"] == 4  # all but мати-2-48
+    assert manifest["stats"]["entries_with_cognate_forms_recovered"] == 1
 
 
 def test_slug_groups_index_polysemy(tmp_path):
@@ -101,6 +130,10 @@ def test_entry_fields_include_cognates_and_proto(tmp_path):
     )
     assert maty_dieslovo["proto_form"] == "*mati"
     assert maty_dieslovo["cognate_forms"] == {"псл.": "*mati"}
+    assert "cognate_forms_recovered" not in maty_dieslovo
+
+    sertse = next(e for e in manifest["entries"] if e["lemma"] == "серце")
+    assert sertse["cognate_forms_recovered"] == {"ч.": "srdce"}
 
 
 def test_polysemy_page_slug_includes_ordinal_when_vol_page_collide(tmp_path):

--- a/tests/etymology/test_recover_latin_cognates.py
+++ b/tests/etymology/test_recover_latin_cognates.py
@@ -1,0 +1,85 @@
+import json
+import sqlite3
+
+from scripts.etymology.recover_latin_cognates import (
+    recover_cognate_forms,
+    recover_database,
+    recover_latin,
+    should_recover_marker,
+)
+
+
+def test_known_damaged_forms_recover_to_latin():
+    assert recover_latin("зіегдгізку") == "sierdzisty"
+    assert recover_latin("5гбей") == "srdce"
+    assert recover_latin("5егрепіуп") == "serpentyn"
+    assert recover_latin("8егрепіїп") == "serpentin"
+
+
+def test_clean_latin_cases_stay_clean_or_improve_digit_noise():
+    assert recover_latin("serce") == "serce"
+    assert recover_latin("abazur") == "abazur"
+    assert recover_latin("5cgemenetz") == "scgemenetz"
+
+
+def test_marker_scope_avoids_cyrillic_script_cognates():
+    forms = {
+        "р.": "сердце",
+        "бр.": "сэрца",
+        "п.": "зіегдгізку",
+        "ч.": "5гбей",
+        "псл.": "*sьrdьce",
+    }
+
+    assert recover_cognate_forms(forms) == {"п.": "sierdzisty", "ч.": "srdce"}
+    assert not should_recover_marker("р.")
+    assert not should_recover_marker("псл.")
+    assert should_recover_marker("ч. слц.")
+
+
+def test_edge_cases():
+    assert recover_latin("") == ""
+    assert recover_latin("5") == "s"
+    assert recover_latin("s") == "s"
+    assert recover_latin("1234") == "1234"
+
+
+def test_recover_database_adds_column_and_populates(tmp_path):
+    db_path = tmp_path / "sources.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE esum_cognate_forms (
+            entry_id INTEGER PRIMARY KEY,
+            cognate_forms TEXT NOT NULL DEFAULT '{}',
+            proto_form TEXT,
+            extracted_count INTEGER NOT NULL DEFAULT 0,
+            expected_count INTEGER NOT NULL DEFAULT 0
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO esum_cognate_forms (entry_id, cognate_forms, extracted_count, expected_count)"
+        " VALUES (?, ?, ?, ?)",
+        [
+            (1, json.dumps({"п.": "5егрепіуп", "р.": "серпентин"}, ensure_ascii=False), 2, 2),
+            (2, json.dumps({"р.": "сердце"}, ensure_ascii=False), 1, 1),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    stats = recover_database(db_path)
+
+    conn = sqlite3.connect(db_path)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(esum_cognate_forms)")}
+    rows = conn.execute(
+        "SELECT entry_id, cognate_forms_recovered FROM esum_cognate_forms ORDER BY entry_id"
+    ).fetchall()
+    conn.close()
+
+    assert "cognate_forms_recovered" in columns
+    assert stats["entries_with_non_cyrillic_markers"] == 1
+    assert stats["entries_with_recovered_latin"] == 1
+    assert json.loads(rows[0][1]) == {"п.": "serpentyn"}
+    assert json.loads(rows[1][1]) == {}


### PR DESCRIPTION
## Summary
- Added `scripts/etymology/recover_latin_cognates.py` with scoped Cyrillic/digit-to-Latin recovery for damaged ESUM cognate forms.
- Added the `esum_cognate_forms.cognate_forms_recovered` migration path and wired extraction, manifest export, and Astro rendering to keep raw forms while showing recovered candidates when different.
- Added etymology tests for known damaged cases, clean/no-op cases, marker scoping, edge cases, DB population, and manifest output.

## Investigation: ABBYY vs text-pdf vs djvutxt
Decision: ABBYY vol1 also preserves the same Cyrillic-as-Latin text-layer damage as `pdftotext` and the deployed `djvutxt`. I kept the sanitizer-only path for all 6 volumes and did not switch vols 1/2/3/6 back to ABBYY. No `data/sources.db` or generated manifest reload is included in this PR.

For each form below, `exact_match=True` means the same damaged string was found in that source.

```text
адміністрація п. абшіпізігас^а
  codepoints: а=U+0430/CYRILLIC SMALL LETTER A б=U+0431/CYRILLIC SMALL LETTER BE ш=U+0448/CYRILLIC SMALL LETTER SHA і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I п=U+043F/CYRILLIC SMALL LETTER PE і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I з=U+0437/CYRILLIC SMALL LETTER ZE і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I г=U+0433/CYRILLIC SMALL LETTER GHE а=U+0430/CYRILLIC SMALL LETTER A с=U+0441/CYRILLIC SMALL LETTER ES ^=U+005E/CIRCUMFLEX ACCENT а=U+0430/CYRILLIC SMALL LETTER A
  ABBYY charParams: exact_match=True
  text-pdf pdftotext: exact_match=True
  djvutxt: exact_match=True

абетка п. аЬесасіїо
  codepoints: а=U+0430/CYRILLIC SMALL LETTER A Ь=U+042C/CYRILLIC CAPITAL LETTER SOFT SIGN е=U+0435/CYRILLIC SMALL LETTER IE с=U+0441/CYRILLIC SMALL LETTER ES а=U+0430/CYRILLIC SMALL LETTER A с=U+0441/CYRILLIC SMALL LETTER ES і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I ї=U+0457/CYRILLIC SMALL LETTER YI о=U+043E/CYRILLIC SMALL LETTER O
  ABBYY charParams: exact_match=True
  text-pdf pdftotext: exact_match=True
  djvutxt: exact_match=True

абревіатура п./вл. аЬгешіаіига
  codepoints: а=U+0430/CYRILLIC SMALL LETTER A Ь=U+042C/CYRILLIC CAPITAL LETTER SOFT SIGN г=U+0433/CYRILLIC SMALL LETTER GHE е=U+0435/CYRILLIC SMALL LETTER IE ш=U+0448/CYRILLIC SMALL LETTER SHA і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I а=U+0430/CYRILLIC SMALL LETTER A і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I и=U+0438/CYRILLIC SMALL LETTER I г=U+0433/CYRILLIC SMALL LETTER GHE а=U+0430/CYRILLIC SMALL LETTER A
  ABBYY charParams: exact_match=True
  text-pdf pdftotext: exact_match=True
  djvutxt: exact_match=True

абсурд п./вл. аЬзигб
  codepoints: а=U+0430/CYRILLIC SMALL LETTER A Ь=U+042C/CYRILLIC CAPITAL LETTER SOFT SIGN з=U+0437/CYRILLIC SMALL LETTER ZE и=U+0438/CYRILLIC SMALL LETTER I г=U+0433/CYRILLIC SMALL LETTER GHE б=U+0431/CYRILLIC SMALL LETTER BE
  ABBYY charParams: exact_match=True
  text-pdf pdftotext: exact_match=True
  djvutxt: exact_match=True

альфабет ч./слц. аІІаЬеіа
  codepoints: а=U+0430/CYRILLIC SMALL LETTER A І=U+0406/CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I І=U+0406/CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I а=U+0430/CYRILLIC SMALL LETTER A Ь=U+042C/CYRILLIC CAPITAL LETTER SOFT SIGN е=U+0435/CYRILLIC SMALL LETTER IE і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I а=U+0430/CYRILLIC SMALL LETTER A
  ABBYY charParams: exact_match=True
  text-pdf pdftotext: exact_match=True
  djvutxt: exact_match=True

авіація п. ашасіа
  codepoints: а=U+0430/CYRILLIC SMALL LETTER A ш=U+0448/CYRILLIC SMALL LETTER SHA а=U+0430/CYRILLIC SMALL LETTER A с=U+0441/CYRILLIC SMALL LETTER ES і=U+0456/CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I а=U+0430/CYRILLIC SMALL LETTER A
  ABBYY charParams: exact_match=True
  text-pdf pdftotext: exact_match=True
  djvutxt: exact_match=True
```

## Sanitizer architecture
- Recovery applies only when a cognate marker resolves to a non-Cyrillic-script language marker. Cyrillic-script markers such as `р.`, `бр.`, `болг.`, `схв.`, `прасл.`, `псл.`, and `укр.` are left untouched.
- The recovery uses a hand-curated sequence table first, then a Cyrillic/digit confusion table. Validation rejects implausible conversions and falls back to the original string.
- Raw `cognate_forms` remain unchanged. Recovered candidates are stored as a mirrored JSON dict in `cognate_forms_recovered`.
- Astro now renders both the raw and recovered form when the recovered value exists and differs. A follow-up corpus reload/population step still needs to run so the shipped DB/generated manifest contain recovered values.

## Smoke-run on known cases
```text
  'зіегдгізку'                   -> 'sierdzisty'                   (expected 'sierdzisty')
  '5гбей'                        -> 'srdce'                        (expected 'srdce')
  '5егрепіуп'                    -> 'serpentyn'                    (expected 'serpentyn')
  '8егрепіїп'                    -> 'serpentin'                    (expected 'serpentin')
```

## Dry-run coverage on current `data/sources.db`
```json
{
  "rows_processed": 64462,
  "entries_with_non_cyrillic_markers": 31216,
  "entries_with_recovered_latin": 30412,
  "recovered_forms_total": 84432,
  "coverage_pct": 97.42
}
```

## Verification
```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/etymology/ tests/
All checks passed!
```

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/etymology/ -v --tb=short
======================== 45 passed, 1 skipped in 0.13s =========================
```

```text
$ npm --prefix starlight run build
21:09:07   ├─ /lit-hist-fic/index.html (+1ms) 
21:09:07   ├─ /lit-humor/index.html (+1ms) 
21:09:07   ├─ /lit-war/index.html (+2ms) 
21:09:07   ├─ /lit-youth/index.html (+2ms) 
21:09:07   ├─ /oes/index.html (+2ms) 
21:09:07   ├─ /ruth/index.html (+2ms) 
21:09:07 ✓ Completed in 54.53s.

21:09:07 [build] ✓ Completed in 58.11s.
21:09:08 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
21:09:08 [build] 36814 page(s) built in 63.55s
21:09:08 [build] Complete!
```

```text
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  b0a2861d03  PASS  X-Agent: codex/esum-cognate-latin-sanitizer-2026-05-21

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Review notes
Gemini local review found one real sanitizer-risk item: the global `к -> t` mapping could damage clean mixed forms. I changed the global mapping to `к -> k` and kept the specific `зку -> sty` sequence needed for `sierdzisty`.