### PR TITLE
fix(wiki_coverage_gate): accept | as field separator (parser-side fix for build #9)

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -37,12 +37,22 @@ _FIELD_RE = re.compile(
     re.IGNORECASE,
 )
 # Inline-field shape: writer emits all four fields on the SAME line as the
-# obligation_id, separated by `;` (semicolons). Example:
+# obligation_id, separated by EITHER `;` (semicolons) OR `|` (pipes).
+# Examples (both accepted):
 #   - obligation_id: step-2; artifact: module.md; location: §Дiалоги; treatment: ...
-# Captures each known field name + its value (up to the next `;` or end of
-# string), regardless of position in the line.
+#   - obligation_id: step-2 | artifact: module.md | location: §Дiалоги | treatment: ...
+# Captures each known field name + its value (up to the next `;`/`|` or end
+# of string), regardless of position in the line. Pipe support added 2026-05-21
+# after build-#9 a1/my-morning regression: writer-prompt template uses
+# `<module.md | activities.yaml | vocabulary.yaml | resources.yaml>` to denote
+# alternatives, and the writer copied the `|` pattern as a field separator
+# across all four implementation_map fields. Coverage at 0/18 unknown_artifact
+# because `artifact = "module.md | location: §... | treatment: ..."` did not
+# match any artifact filename.
 _INLINE_FIELD_RE = re.compile(
-    r"(?P<key>artifact|location|treatment)\s*:\s*(?P<value>[^;]+?)(?=\s*;\s*(?:obligation_id|artifact|location|treatment)\s*:|\s*$)",
+    r"(?P<key>artifact|location|treatment)\s*:\s*"
+    r"(?P<value>[^;|]+?)"
+    r"(?=\s*[;|]\s*(?:obligation_id|artifact|location|treatment)\s*:|\s*$)",
     re.IGNORECASE,
 )
 

--- a/tests/test_wiki_coverage_gate.py
+++ b/tests/test_wiki_coverage_gate.py
@@ -185,6 +185,33 @@ def test_parse_implementation_map_inline_field_order_independence() -> None:
     assert result["ban-1"]["location"] == "§Підсумок"
 
 
+def test_parse_implementation_map_inline_pipe_separator_accepted() -> None:
+    """Build-#9 a1/my-morning regression: the writer-prompt template
+    describes the artifact field as `<module.md | activities.yaml | ...>`
+    (pipes denote alternatives), and the writer copied the `|` pattern
+    as a field separator across all four implementation_map fields:
+
+        - obligation_id: step-1 | artifact: module.md | location: §... | treatment: ...
+
+    Parser originally accepted only `;` as separator, so `artifact` ate
+    the rest of the line and every obligation returned `unknown_artifact`
+    with coverage stuck at 0/18. Accept pipe-with-spaces as alternative
+    separator (alongside semicolons) so this writer shape parses cleanly."""
+    raw = """<implementation_map>
+- obligation_id: step-1 | artifact: module.md | location: §Дієслова на -ся | treatment: H3 step marker
+- obligation_id: err-2 | artifact: activities.yaml | location: act-5 item 2 | treatment: contrast_pair
+</implementation_map>"""
+
+    result = parse_implementation_map(raw)
+
+    assert result["step-1"]["artifact"] == "module.md"
+    assert result["step-1"]["location"] == "§Дієслова на -ся"
+    assert result["step-1"]["treatment"] == "H3 step marker"
+    assert result["err-2"]["artifact"] == "activities.yaml"
+    assert result["err-2"]["location"] == "act-5 item 2"
+    assert result["err-2"]["treatment"] == "contrast_pair"
+
+
 def test_parse_implementation_map_last_emission_wins() -> None:
     """If the writer restates an obligation in a later section block with
     a different artifact/location, the LATER claim wins. Mirrors writer


### PR DESCRIPTION
## Summary

`parse_implementation_map` originally accepted only `;` (semicolon) as field separator in the single-line implementation_map shape. Build-#9 of a1/my-morning surfaced a writer-prompt UX bug: the template at `scripts/build/phases/linear-write.md:29` describes the artifact field as `<module.md | activities.yaml | vocabulary.yaml | resources.yaml>` (pipes denote alternatives), and the writer copied the `|` pattern as a field separator across all four implementation_map fields.

## The bug in build-#9

Writer emitted:
```
- obligation_id: step-1 | artifact: module.md | location: §... | treatment: ...
```

With only `;` accepted, `artifact` captured the rest of the line. Every obligation returned `unknown_artifact` and coverage stuck at 0/18, even after the correction loop applied 20 valid content fixes — the gate failed earlier on artifact identification.

## Fix

Extend the inline-field regex to accept either `;` or `|` as separator. Symmetric: value character class becomes `[^;|]+?`; lookahead matches either character.

## Smoking-gun

Running the fixed parser on the **unchanged** build-#9 writer output (`curriculum/l2-uk-en/_orchestration/a1/my-morning/runs/20260521-190246/writer_output.raw.md`):

```
parsed entries: 18
  ban-1: artifact: module.md, location: §Діалоги and every other prose section, treatment: absence-required ...
  ban-2: artifact: module.md, location: §Діалоги + §Дієслова на -ся, treatment: ...
  ban-3: artifact: module.md, location: §Мій ранок ..., treatment: ...
  ...
```

All 18 entries parse cleanly with valid `artifact` filenames.

## Test plan

- [x] TDD: one new regression test (`test_parse_implementation_map_inline_pipe_separator_accepted`) — pipe-shape parses identically to semicolon-shape. Fails before fix; passes after.
- [x] `pytest -k 'wiki_coverage or wiki_manifest or linear_pipeline_wiki'` → 52 passed, 1 skipped, 0 failed
- [x] `ruff check` → clean
- [x] Existing semicolon-shape, multi-line bullet shape, field-order-independence, and last-emission-wins tests still pass
- [ ] CI green

## Cascade context — fifth fix

This is the **fifth** distinct fix in the 2026-05-21 a1/my-morning rebuild cascade:

| Build | Issue | Fix |
|---|---|---|
| #5 | vesum_verified (stem fragment) | PR #2173 |
| #6 | wiki_coverage_gate (H1/H2 collision + YAML re-escape) | PR #2184 |
| #7 | textbook_grounding (H3 hijacks section_title) | PR #2185 |
| #8 | wiki_coverage_gate (H2 truncates at first H3 child) | PR #2193 |
| #9 | implementation_map parser doesn't accept `|` separator | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)