### PR TITLE
fix(wiki_coverage_review): tolerate prose-wrapped JSON + persist raw response

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5803,15 +5803,102 @@ def _strip_outer_code_fence(text: str) -> str:
     return stripped
 
 
+# Fenced-block + bare-JSON-object extractor used when the LLM wraps the
+# expected JSON/YAML payload in prose preamble/epilogue (a common pattern —
+# "I have verified all 18 obligations. Here is the structured output:" + ```json
+# {...} ``` + closing remarks). Without these fallbacks, ``json.loads`` and
+# ``yaml.safe_load`` both fail on the prose, masking the actual reviewer
+# output. Build #10 (a1/my-morning, 2026-05-21) exposed this: codex-tools
+# emitted a prose preamble, the gate raised
+# ``LLM QG response must be a JSON/YAML mapping`` with no way to recover the
+# structured payload from inside the response. Order matters: try a fenced
+# block first (most LLMs use ``` ```json `` or `` ```yaml ``); then try to
+# extract the first balanced ``{...}`` object span; finally fall through to
+# the whole-string parse so existing well-formed responses are unchanged.
+_FENCED_BLOCK_RE = re.compile(
+    r"```(?:json|yaml|yml)?\s*\n(?P<body>.*?)\n```",
+    re.DOTALL,
+)
+
+
+def _extract_first_fenced_block(text: str) -> str | None:
+    match = _FENCED_BLOCK_RE.search(text)
+    if match:
+        return match.group("body").strip()
+    return None
+
+
+def _extract_first_balanced_json_object(text: str) -> str | None:
+    """Return the first top-level ``{...}`` span with balanced braces.
+
+    Naive bracket-counter that ignores braces inside double-quoted strings
+    (so ``"key": "}{"`` does not break the count) and respects backslash
+    escapes inside those strings. Returns None if no balanced object is found.
+    Used as a last-resort extractor for prose-wrapped reviewer responses; we
+    don't try to handle arrays — every reviewer-response schema is a top-level
+    mapping.
+    """
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for idx, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = idx
+            depth += 1
+            continue
+        if ch == "}":
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0 and start >= 0:
+                return text[start : idx + 1]
+    return None
+
+
 def _parse_json_or_yaml_mapping(text: str) -> dict[str, Any]:
+    candidates: list[str] = []
     body = _strip_outer_code_fence(text)
-    try:
-        parsed = json.loads(body)
-    except json.JSONDecodeError:
-        parsed = yaml.safe_load(body)
-    if not isinstance(parsed, dict):
-        raise LinearPipelineError("LLM QG response must be a JSON/YAML mapping")
-    return parsed
+    candidates.append(body)
+    fenced = _extract_first_fenced_block(text)
+    if fenced is not None and fenced != body:
+        candidates.append(fenced)
+    bare_object = _extract_first_balanced_json_object(text)
+    if bare_object is not None and bare_object not in candidates:
+        candidates.append(bare_object)
+
+    last_error: Exception | None = None
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            last_error = exc
+            try:
+                parsed = yaml.safe_load(candidate)
+            except yaml.YAMLError as yaml_exc:
+                last_error = yaml_exc
+                continue
+        if isinstance(parsed, dict):
+            return parsed
+    if last_error is not None:
+        raise LinearPipelineError(
+            "LLM QG response must be a JSON/YAML mapping"
+        ) from last_error
+    raise LinearPipelineError("LLM QG response must be a JSON/YAML mapping")
 
 
 def _placeholder_review_report() -> dict[str, dict[str, Any]]:

--- a/scripts/build/phases/linear-review-wiki-coverage.md
+++ b/scripts/build/phases/linear-review-wiki-coverage.md
@@ -84,7 +84,42 @@ The new verdict enum: `PASS | KEYWORD_STUFFING | PARTIAL | FAIL`.
 `KEYWORD_STUFFING`. `PARTIAL` is a soft signal — system aggregates, build
 continues, but logs the pattern.
 
-Return only JSON:
+## Response Format — STRICT
+
+Return ONLY a single JSON object. No preamble. No epilogue. No "I have
+verified" narration. No markdown bold. No prose confirmation. The parser
+calls `json.loads` on your response (with a fenced-block fallback) — any
+prose outside the JSON shape will cause the build to fail at this phase
+even when every obligation passes.
+
+The JSON object MUST contain:
+
+- `verdicts`: a list with one entry per obligation in the manifest. Each
+  entry MUST have `obligation_id`, `verdict`, `evidence` (verbatim quote
+  ≥8 chars containing `"…"` / `«…»` / `“…”`), and `rationale`.
+- `overall_verdict`: `"PASS"`, `"PARTIAL"`, or `"FAIL"`. MUST be `"FAIL"`
+  if any per-obligation verdict is `FAIL` or `KEYWORD_STUFFING`.
+- `summary`: a single-sentence string (still inside the JSON object).
+
+If every obligation passes, emit the all-PASS shape — STILL JSON, STILL no
+narration:
+
+```json
+{
+  "verdicts": [
+    {
+      "obligation_id": "err-1",
+      "verdict": "PASS",
+      "evidence": "\"Choose between я вибачаюся and я вибачаю себе, then explain which one fits the dialogue.\"",
+      "rationale": "Activity body requires learners to distinguish both forms."
+    }
+  ],
+  "overall_verdict": "PASS",
+  "summary": "All 1 obligation woven into substantive pedagogy."
+}
+```
+
+Mixed-verdict shape:
 
 ```json
 {

--- a/scripts/build/run_archive.py
+++ b/scripts/build/run_archive.py
@@ -38,7 +38,9 @@ _ARTIFACT_GLOBS = (
     "python_qg_correction_r*.json",
     "wiki_coverage_correction_r*.json",
     "llm-qg-*-prompt.md",
+    "llm-qg-*-response.raw.md",
     "wiki-coverage-review-prompt.md",
+    "wiki-coverage-review-response.raw.md",
 )
 
 

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -697,6 +697,13 @@ def _run_llm_qg(
             stdout_silence_timeout=stdout_silence_timeout,
         )
         response = str(getattr(result, "response", "") or "")
+        # Persist raw reviewer response BEFORE parse so #M-10 forensic
+        # continuity holds when the parser raises (build #10, 2026-05-21
+        # exposed prose-wrapped JSON shape with no saved artifact).
+        (module_dir / f"llm-qg-{dim}-response.raw.md").write_text(
+            response,
+            encoding="utf-8",
+        )
         report[dim] = linear_pipeline.parse_review_response(response, dim)
 
     return linear_pipeline.aggregate_llm_review(report, str(plan["level"]))
@@ -742,6 +749,16 @@ def _run_wiki_coverage_review(
         stdout_silence_timeout=stdout_silence_timeout,
     )
     response = str(getattr(result, "response", "") or "")
+    # Persist raw reviewer response BEFORE parse so #M-10 forensic continuity
+    # holds when the parser raises. Build #10 (a1/my-morning, 2026-05-21)
+    # exposed prose-wrapped JSON: codex-tools emitted "I have verified all
+    # **18 obligations**..." narrative around the structured payload, the
+    # parser failed, no artifact was saved, and the only diagnostic was the
+    # YAML-parser error string in the build event log.
+    (module_dir / "wiki-coverage-review-response.raw.md").write_text(
+        response,
+        encoding="utf-8",
+    )
     return linear_pipeline.parse_wiki_coverage_review_response(response)
 
 

--- a/tests/build/test_wiki_coverage_goodhart_sentinel.py
+++ b/tests/build/test_wiki_coverage_goodhart_sentinel.py
@@ -134,6 +134,7 @@ def _install_v7_fixture(
             dry_run=False,
             out=str(module_dir),
             writer_timeout=5,
+            effort=None,  # added 2026-05-13 in 9e5a6496b9 (--effort flag)
         ),
         tmp_path / "events.jsonl",
     )
@@ -305,3 +306,103 @@ def test_prompt_template_renders_keyword_stuffing_instruction() -> None:
     )
 
     assert "KEYWORD_STUFFING" in prompt
+
+
+def test_prompt_template_enforces_strict_response_format() -> None:
+    """Build #10 (2026-05-21) failed because the reviewer emitted prose
+    narration around the JSON. The prompt must now explicitly forbid
+    preamble/epilogue and demonstrate the all-PASS shape."""
+    prompt = linear_pipeline.render_wiki_coverage_review_prompt(
+        {
+            "level": "a1",
+            "sequence": 1,
+            "slug": "fixture",
+            "word_target": 600,
+        },
+        "level: a1\nslug: fixture\n",
+        "## module.md\n\nGenerated content",
+        {"slug": "fixture", "sequence_steps": []},
+        {"passed": True, "coverage_pct": 1.0},
+    )
+
+    assert "Response Format — STRICT" in prompt
+    assert "No preamble" in prompt
+    assert "No epilogue" in prompt
+    # All-PASS worked example so the reviewer has no excuse to narrate.
+    assert '"overall_verdict": "PASS"' in prompt
+
+
+def test_parser_recovers_from_prose_preamble_with_fenced_block() -> None:
+    """Codex reviewer pattern from build #10: prose narration wrapping a
+    fenced JSON payload. The parser must extract the fenced block."""
+    response = (
+        "I have verified all **18 obligations** in the wiki coverage manifest. "
+        "Each one was checked against the cited artifact and the surrounding "
+        "lesson context. Here is the structured output:\n\n"
+        "```json\n"
+        + json.dumps(
+            {
+                "verdicts": [_verdict("err-1", "PASS")],
+                "overall_verdict": "PASS",
+                "summary": "All obligations satisfied.",
+            }
+        )
+        + "\n```\n\nLet me know if you need further detail."
+    )
+
+    parsed = linear_pipeline.parse_wiki_coverage_review_response(response)
+    assert parsed["overall_verdict"] == "PASS"
+    assert parsed["verdicts"][0]["obligation_id"] == "err-1"
+
+
+def test_parser_recovers_from_prose_preamble_with_bare_object() -> None:
+    """LLMs sometimes drop the fence and emit a bare object inside prose."""
+    payload = json.dumps(
+        {
+            "verdicts": [_verdict("err-1", "PASS")],
+            "overall_verdict": "PASS",
+            "summary": "All obligations satisfied.",
+        }
+    )
+    response = (
+        "I have verified all obligations. The result is " + payload + " Thanks!"
+    )
+
+    parsed = linear_pipeline.parse_wiki_coverage_review_response(response)
+    assert parsed["overall_verdict"] == "PASS"
+
+
+def test_parser_still_handles_bare_json_payload() -> None:
+    """Regression guard: well-formed responses without prose still parse."""
+    payload = json.dumps(
+        {
+            "verdicts": [_verdict("err-1", "PASS")],
+            "overall_verdict": "PASS",
+            "summary": "OK.",
+        }
+    )
+    parsed = linear_pipeline.parse_wiki_coverage_review_response(payload)
+    assert parsed["overall_verdict"] == "PASS"
+
+
+def test_parser_still_handles_outer_fenced_payload() -> None:
+    payload = json.dumps(
+        {
+            "verdicts": [_verdict("err-1", "PASS")],
+            "overall_verdict": "PASS",
+            "summary": "OK.",
+        }
+    )
+    parsed = linear_pipeline.parse_wiki_coverage_review_response(
+        f"```json\n{payload}\n```"
+    )
+    assert parsed["overall_verdict"] == "PASS"
+
+
+def test_parser_rejects_pure_prose_with_no_json() -> None:
+    """Without any extractable JSON, the parser must still raise so the
+    build doesn't silently succeed on a bare confirmation."""
+    with pytest.raises(linear_pipeline.LinearPipelineError):
+        linear_pipeline.parse_wiki_coverage_review_response(
+            "I have verified all 18 obligations. They are all good."
+        )


### PR DESCRIPTION
## Summary

The 6th cascade issue surfaced by build #10 (a1/my-morning, 2026-05-21 evening): wiki_coverage_gate hit **18/18 (100%)** but the subsequent `wiki_coverage_review` phase failed at YAML parse — codex-tools emitted prose narration around the structured payload, both `json.loads` and `yaml.safe_load` failed, and **no raw response was persisted** so post-hoc diagnosis was impossible.

This PR is one PR away from first complete V7 module promotion. Three coordinated fixes:

- **Tolerant parser** (`linear_pipeline.py::_parse_json_or_yaml_mapping`): try the existing whole-string strip-outer-fence path first, then fall through to (a) the first embedded ` ```json|yaml|yml ` fenced block and (b) the first balanced `{...}` object span. Pure-prose responses still raise; the rejection just now has real parsing attempts behind it.
- **Persist raw reviewer response BEFORE parse** in `_run_wiki_coverage_review` (`wiki-coverage-review-response.raw.md`) and `_run_llm_review` (`llm-qg-{dim}-response.raw.md`) — #M-10 forensic continuity. Build #10 burned because we had only a YAML parse error string. Glob entries added to `run_archive.py::_ARTIFACT_GLOBS` so promote-to-main carries the raw responses.
- **Tighten the reviewer prompt** with an explicit `Response Format — STRICT` gate, "no preamble / no narration" wording, and a worked **all-PASS** JSON example so the reviewer cannot rationalize narration on the empty-fixes path. The prior prompt only showed a mixed-verdict FAIL shape; build #10's reviewer had no all-PASS template to mirror.

Plus an inline pre-existing test fix: the `SimpleNamespace` fixture in `test_wiki_coverage_goodhart_sentinel.py` was missing `effort` (added 2026-05-13 in `9e5a6496b9` with the `--effort` flag, fixture never updated) — `test_v7_build_emits_goodhart_sentinel_telemetry` was failing on main with `'types.SimpleNamespace' object has no attribute 'effort'`.

## Cascade context

Continuation of the 5-fix gate-detection cascade documented in `docs/session-state/2026-05-21-evening-2-cascade-five-fixes-shipped-six-issue-found.md`. PRs #2184 → #2185 → #2187 → #2193 → #2194 → #2197 → **this**. Build #10 was the inflection — wiki_coverage_gate finally hit 100% on first attempt — but reviewer-response handling became the next brittle assumption to harden.

## Test plan

- [x] `.venv/bin/pytest tests/build/test_wiki_coverage_goodhart_sentinel.py` → 19/19 pass (6 new test cases)
- [x] `.venv/bin/pytest tests/build/` → 271/271 pass
- [x] `.venv/bin/pytest tests/` wider sweep → 5060 passed; 1 unrelated pre-existing failure (`test_monitor_client_sdk.py::test_rules_etag_matches_returns_304`, Monitor API ETag header, untouched here)
- [x] `ruff check` clean on all changed files
- [x] Pre-commit hooks pass
- [ ] Build #11 of a1/my-morning to confirm cascade terminates and module hits `module_done`

## New test cases

1. `test_parser_recovers_from_prose_preamble_with_fenced_block` — the exact codex shape from build #10
2. `test_parser_recovers_from_prose_preamble_with_bare_object` — bare `{...}` inside prose
3. `test_parser_still_handles_bare_json_payload` — happy-path regression guard
4. `test_parser_still_handles_outer_fenced_payload` — existing fenced shape regression guard
5. `test_parser_rejects_pure_prose_with_no_json` — confirmation-only prose still raises
6. `test_prompt_template_enforces_strict_response_format` — prompt carries STRICT gate + all-PASS example

🤖 Generated with [Claude Code](https://claude.com/claude-code)