### PR TITLE
feat(starlight): vocab → etymology linker (closes vocab-linking ask 2026-05-21)

### DIFF
--- a/scripts/etymology/build_vesum_vocab_lemmas.py
+++ b/scripts/etymology/build_vesum_vocab_lemmas.py
@@ -1,0 +1,286 @@
+"""Build a small VESUM lemma subset for Starlight vocabulary-table links.
+
+The full VESUM database has millions of forms. The Astro remark plugin should
+not query it during the site build, so this script scans committed Starlight
+MDX vocabulary tables and writes only the form→lemma pairs that the plugin can
+use safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sqlite3
+import unicodedata
+from pathlib import Path
+
+DEFAULT_CONTENT_ROOT = Path("starlight/src/content/docs")
+DEFAULT_MANIFEST = Path("starlight/src/data/etymology-manifest.json")
+DEFAULT_OUTPUT = Path("starlight/src/data/vesum-vocab-lemmas.json")
+DEFAULT_VESUM_DB = Path("data/vesum.db")
+VERSION = "2026-05-21-v1"
+STRESS_MARKS = {"\u0300", "\u0301", "\u0341"}
+
+VOCAB_TAB_LABELS = {"vocabulary", "словник"}
+WORD_HEADERS = {"word", "слово"}
+OPT_OUT_RE = re.compile(r"(?:vocab-etymology|etymology-links)\s*:\s*(?:off|false)", re.IGNORECASE)
+TAB_OPEN_RE = re.compile(r"<TabItem\b(?P<attrs>[^>]*)>", re.IGNORECASE)
+TAB_CLOSE_RE = re.compile(r"</TabItem>", re.IGNORECASE)
+LABEL_RE = re.compile(r"""(?:^|\s)label\s*=\s*(?P<quote>["'])(?P<label>.*?)(?P=quote)""", re.DOTALL)
+
+
+def normalize_lemma(value: str) -> str:
+    """Lowercase and strip combining stress marks without changing й/ї."""
+    decomposed = unicodedata.normalize("NFD", value.strip().lower())
+    stripped = "".join(ch for ch in decomposed if ch not in STRESS_MARKS)
+    return unicodedata.normalize("NFC", stripped)
+
+
+def strip_markdown_inline(value: str) -> str:
+    value = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", value)
+    value = re.sub(r"</?[^>]+>", "", value)
+    value = value.replace("\\|", "|")
+    value = re.sub(r"[*_`~]", "", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def split_markdown_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+
+    cells: list[str] = []
+    current: list[str] = []
+    escaped = False
+    for char in stripped:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "|":
+            cells.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    cells.append("".join(current).strip())
+    return cells
+
+
+def is_separator_row(line: str) -> bool:
+    cells = split_markdown_table_row(line)
+    return bool(cells) and all(re.fullmatch(r":?-{3,}:?", cell.strip()) for cell in cells)
+
+
+def tab_label(opening_line: str) -> str | None:
+    match = TAB_OPEN_RE.search(opening_line)
+    if not match:
+        return None
+    label_match = LABEL_RE.search(match.group("attrs"))
+    if not label_match:
+        return None
+    return label_match.group("label")
+
+
+def tab_opted_out(opening_line: str) -> bool:
+    match = TAB_OPEN_RE.search(opening_line)
+    return bool(match and OPT_OUT_RE.search(match.group("attrs")))
+
+
+def vocabulary_tab_blocks(text: str) -> list[list[str]]:
+    lines = text.splitlines()
+    blocks: list[list[str]] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        label = tab_label(line)
+        if label is None:
+            index += 1
+            continue
+
+        body: list[str] = []
+        index += 1
+        while index < len(lines) and not TAB_CLOSE_RE.search(lines[index]):
+            body.append(lines[index])
+            index += 1
+
+        if normalize_lemma(label) in VOCAB_TAB_LABELS and not tab_opted_out(line):
+            blocks.append(body)
+
+        index += 1
+
+    return blocks
+
+
+def extract_vocabulary_words_from_text(text: str) -> set[str]:
+    words: set[str] = set()
+
+    for block in vocabulary_tab_blocks(text):
+        index = 0
+        while index < len(block):
+            line = block[index]
+            if not line.lstrip().startswith("|"):
+                index += 1
+                continue
+
+            table_lines: list[str] = []
+            while index < len(block) and block[index].lstrip().startswith("|"):
+                table_lines.append(block[index])
+                index += 1
+
+            if len(table_lines) < 2 or not is_separator_row(table_lines[1]):
+                continue
+
+            header = split_markdown_table_row(table_lines[0])
+            if not header or normalize_lemma(strip_markdown_inline(header[0])) not in WORD_HEADERS:
+                continue
+
+            for row in table_lines[2:]:
+                cells = split_markdown_table_row(row)
+                if not cells:
+                    continue
+                word = strip_markdown_inline(cells[0])
+                if word:
+                    words.add(word)
+
+    return words
+
+
+def extract_vocabulary_words(content_root: Path) -> tuple[set[str], list[str]]:
+    words: set[str] = set()
+    files: list[str] = []
+    for path in sorted(content_root.rglob("*.mdx")):
+        extracted = extract_vocabulary_words_from_text(path.read_text(encoding="utf-8"))
+        if extracted:
+            words.update(extracted)
+            files.append(str(path))
+    return words, files
+
+
+def load_manifest_lemma_keys(manifest_path: Path) -> set[str]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return {
+        normalize_lemma(entry["lemma"])
+        for entry in manifest.get("entries", [])
+        if isinstance(entry, dict) and entry.get("lemma")
+    }
+
+
+def single_token(value: str) -> bool:
+    return bool(value.strip()) and not re.search(r"\s", value.strip())
+
+
+def strip_reflexive_suffix(value: str) -> str:
+    normalized = normalize_lemma(value)
+    if normalized.endswith(("ся", "сь")):
+        return normalized[:-2]
+    return normalized
+
+
+def choose_unambiguous_manifest_lemma(
+    conn: sqlite3.Connection, form: str, manifest_lemma_keys: set[str]
+) -> str | None:
+    rows = conn.execute("SELECT DISTINCT lemma FROM forms WHERE word_form = ?", (form,)).fetchall()
+    if not rows:
+        return None
+
+    by_key = {normalize_lemma(row[0]): row[0] for row in rows}
+    if len(by_key) != 1:
+        return None
+
+    lemma_key, lemma = next(iter(by_key.items()))
+    if lemma_key not in manifest_lemma_keys:
+        return None
+    return lemma
+
+
+def build_vesum_vocab_lemmas(
+    *,
+    content_root: Path = DEFAULT_CONTENT_ROOT,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    vesum_db: Path = DEFAULT_VESUM_DB,
+) -> dict:
+    words, source_files = extract_vocabulary_words(content_root)
+    manifest_lemma_keys = load_manifest_lemma_keys(manifest_path)
+
+    form_to_lemma: dict[str, str] = {}
+    skipped_multiword = 0
+    direct_manifest_matches = 0
+    ambiguous_or_missing = 0
+
+    conn = sqlite3.connect(vesum_db)
+    try:
+        for word in sorted(words, key=normalize_lemma):
+            normalized_word = normalize_lemma(word)
+            if not single_token(normalized_word):
+                skipped_multiword += 1
+                continue
+            if normalized_word in manifest_lemma_keys:
+                direct_manifest_matches += 1
+                continue
+
+            candidates = [normalized_word]
+            stripped = strip_reflexive_suffix(normalized_word)
+            if stripped != normalized_word:
+                candidates.append(stripped)
+            lemma = None
+            for candidate in candidates:
+                lemma = choose_unambiguous_manifest_lemma(conn, candidate, manifest_lemma_keys)
+                if lemma:
+                    break
+
+            if lemma:
+                form_to_lemma[normalized_word] = lemma
+            else:
+                ambiguous_or_missing += 1
+    finally:
+        conn.close()
+
+    return {
+        "version": VERSION,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(timespec="seconds"),
+        "source": {
+            "content_root": str(content_root),
+            "manifest": str(manifest_path),
+            "vesum_db": str(vesum_db),
+            "mdx_files": source_files,
+        },
+        "stats": {
+            "vocabulary_words": len(words),
+            "direct_manifest_matches": direct_manifest_matches,
+            "vesum_form_matches": len(form_to_lemma),
+            "skipped_multiword": skipped_multiword,
+            "ambiguous_or_missing": ambiguous_or_missing,
+        },
+        "form_to_lemma": dict(sorted(form_to_lemma.items())),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--content-root", type=Path, default=DEFAULT_CONTENT_ROOT)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--vesum-db", type=Path, default=DEFAULT_VESUM_DB)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    output = build_vesum_vocab_lemmas(
+        content_root=args.content_root,
+        manifest_path=args.manifest,
+        vesum_db=args.vesum_db,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({**output["stats"], "output_file": str(args.output)}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -5,6 +5,7 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import starlightDocSearch from '@astrojs/starlight-docsearch';
 import rehypeMermaid from 'rehype-mermaid';
+import vocabEtymologyLinker from './plugins/vocab-etymology-link.mjs';
 
 
 // https://astro.build/config
@@ -15,6 +16,7 @@ export default defineConfig({
   compressHTML: true,
 
   markdown: {
+    remarkPlugins: [vocabEtymologyLinker],
     rehypePlugins: [rehypeMermaid],
   },
 

--- a/starlight/plugins/README.md
+++ b/starlight/plugins/README.md
@@ -1,0 +1,39 @@
+# Starlight Plugins
+
+## `vocab-etymology-link.mjs`
+
+Build-time remark plugin that links Starlight vocabulary tables to checked-in
+ESUM etymology pages.
+
+The plugin only edits tables inside `<TabItem label="Vocabulary">` or
+`<TabItem label="Словник">`. The first header cell must be `Word` or `Слово`.
+For each data row, the first cell is linked when the word is a single token and
+resolves to an existing `starlight/src/data/etymology-manifest.json` slug.
+Multi-word phrases are left unchanged.
+
+Resolution order:
+
+1. Direct normalized manifest lemma match.
+2. `starlight/src/data/vesum-vocab-lemmas.json` form→lemma fallback.
+3. No link.
+
+Regenerate the VESUM subset after adding lesson vocabulary:
+
+```bash
+.venv/bin/python scripts/etymology/build_vesum_vocab_lemmas.py
+```
+
+Opt out for an entire tab:
+
+```mdx
+<TabItem label="Vocabulary" data-etymology-links="false">
+```
+
+Opt out for one table with an adjacent MDX comment:
+
+```mdx
+{/* vocab-etymology: off */}
+| Word | IPA | English |
+| --- | --- | --- |
+| кава |  | coffee |
+```

--- a/starlight/plugins/vocab-etymology-link.mjs
+++ b/starlight/plugins/vocab-etymology-link.mjs
@@ -1,0 +1,137 @@
+import {
+  loadDefaultEtymologyResolver,
+  normalizeLemma,
+  resolveVocabWord,
+} from '../src/data/etymology-lemma-index.mjs';
+
+const VOCAB_TAB_LABELS = new Set(['vocabulary', 'словник']);
+const WORD_HEADERS = new Set(['word', 'слово']);
+const OPT_OUT_RE = /(?:vocab-etymology|etymology-links)\s*:\s*(?:off|false)/i;
+
+function visit(node, callback, parent = null) {
+  if (!node || typeof node !== 'object') return;
+  callback(node, parent);
+  if (!Array.isArray(node.children)) return;
+  for (const child of node.children) visit(child, callback, node);
+}
+
+function nodeText(node) {
+  if (!node || typeof node !== 'object') return '';
+  if (typeof node.value === 'string') return node.value;
+  if (!Array.isArray(node.children)) return '';
+  return node.children.map((child) => nodeText(child)).join('');
+}
+
+function getAttribute(node, name) {
+  const attribute = node.attributes?.find((attr) => attr.type === 'mdxJsxAttribute' && attr.name === name);
+  if (!attribute) return undefined;
+  if (typeof attribute.value === 'string' || attribute.value === null) return attribute.value;
+  if (typeof attribute.value?.value === 'string') return attribute.value.value;
+  return undefined;
+}
+
+function isVocabularyTab(node) {
+  if (node.type !== 'mdxJsxFlowElement' || node.name !== 'TabItem') return false;
+  const label = getAttribute(node, 'label');
+  return label ? VOCAB_TAB_LABELS.has(normalizeLemma(label)) : false;
+}
+
+function tabOptedOut(node) {
+  for (const name of ['data-etymology-links', 'etymologyLinks']) {
+    const value = getAttribute(node, name);
+    if (value === null || String(value).toLowerCase() === 'false') return true;
+  }
+  return false;
+}
+
+function tableOptedOut(children, tableIndex) {
+  for (let index = tableIndex - 1; index >= 0; index -= 1) {
+    const sibling = children[index];
+    if (!sibling) continue;
+    if (sibling.type === 'html' || sibling.type === 'mdxFlowExpression') {
+      if (OPT_OUT_RE.test(String(sibling.value ?? ''))) return true;
+      continue;
+    }
+    if (sibling.type === 'text' && !String(sibling.value ?? '').trim()) continue;
+    break;
+  }
+  return false;
+}
+
+function hasExistingLink(node) {
+  let found = false;
+  visit(node, (candidate) => {
+    if (candidate.type === 'link') found = true;
+    if (
+      (candidate.type === 'mdxJsxTextElement' || candidate.type === 'mdxJsxFlowElement') &&
+      candidate.name === 'a'
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function isWordHeader(cell) {
+  return WORD_HEADERS.has(normalizeLemma(nodeText(cell)));
+}
+
+function makeLinkNode(children, resolution) {
+  return {
+    type: 'link',
+    url: resolution.href,
+    title: `Etymology: ${resolution.slug}`,
+    data: {
+      hProperties: {
+        className: ['vocab-etymology-link'],
+        'data-etymology-slug': resolution.slug,
+      },
+    },
+    children,
+  };
+}
+
+function linkVocabularyTable(table, resolver) {
+  const [headerRow, ...bodyRows] = table.children ?? [];
+  const wordHeader = headerRow?.children?.[0];
+  if (headerRow?.type !== 'tableRow' || !wordHeader || !isWordHeader(wordHeader)) return;
+
+  for (const row of bodyRows) {
+    if (row.type !== 'tableRow') continue;
+    const wordCell = row.children?.[0];
+    if (!wordCell || hasExistingLink(wordCell)) continue;
+
+    const word = nodeText(wordCell);
+    const resolution = resolveVocabWord(word, resolver);
+    if (!resolution) continue;
+
+    wordCell.children = [makeLinkNode(wordCell.children ?? [], resolution)];
+  }
+}
+
+function linkTablesInside(node, resolver) {
+  const children = node.children ?? [];
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    if (child.type === 'table') {
+      if (!tableOptedOut(children, index)) linkVocabularyTable(child, resolver);
+      continue;
+    }
+    if (Array.isArray(child.children)) linkTablesInside(child, resolver);
+  }
+}
+
+export function createVocabEtymologyLinker({ resolver } = {}) {
+  const etymologyResolver = resolver ?? loadDefaultEtymologyResolver();
+
+  return function vocabEtymologyTransformer(tree) {
+    visit(tree, (node) => {
+      if (!isVocabularyTab(node) || tabOptedOut(node)) return;
+      linkTablesInside(node, etymologyResolver);
+    });
+  };
+}
+
+export default function vocabEtymologyLinker(options = {}) {
+  return createVocabEtymologyLinker(options);
+}

--- a/starlight/src/css/custom.css
+++ b/starlight/src/css/custom.css
@@ -14,7 +14,7 @@
   --co-gold: #FFD700;
   --co-gold-dark: #D4AF37;
   --co-gold-light: #FFE57F;
-  
+
   /* Neutrals */
   --co-white: #FFFFFF;
   --co-gray-50: #FAFBFC;
@@ -24,7 +24,7 @@
   --co-gray-600: #5F6368;
   --co-gray-800: #3C4043;
   --co-gray-900: #202124;
-  
+
   /* Semantic colors */
   --co-success: #34A853;
   --co-success-bg: rgba(52, 168, 83, 0.1);
@@ -32,7 +32,7 @@
   --co-error-bg: rgba(234, 67, 53, 0.1);
   --co-warning: #FBBC04;
   --co-info: #4285F4;
-  
+
   /* ── Infima / Docusaurus compatibility shim ──────────────────────────────
    * Starlight does not define --ifm-* variables. Activities.module.css and
    * other migrated components depend on these. Define them here so the
@@ -69,22 +69,22 @@
   --ifm-color-primary-light: #0061c9;
   --ifm-color-primary-lighter: #0066d3;
   --ifm-color-primary-lightest: #1A73E8;
-  
+
   --ifm-font-family-base: 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --ifm-heading-font-family: 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --ifm-font-size-base: 16px;
   --ifm-line-height-base: 1.6;
-  
+
   --ifm-code-font-size: 90%;
   --ifm-heading-font-weight: 700;
   --ifm-h1-font-size: 2.5rem;
   --ifm-h2-font-size: 1.75rem;
-  
+
   --ifm-border-radius: 12px;
   --ifm-global-shadow-lw: 0 2px 8px rgba(0, 0, 0, 0.08);
   --ifm-global-shadow-md: 0 4px 16px rgba(0, 0, 0, 0.12);
   --ifm-global-shadow-tl: 0 8px 32px rgba(0, 0, 0, 0.16);
-  
+
   --docusaurus-highlighted-code-line-bg: rgba(0, 87, 183, 0.1);
 }
 
@@ -116,7 +116,7 @@
   --co-gray-600: #9CA3AF;
   --co-gray-800: #E5E7EB;
   --co-gray-900: #F9FAFB;
-  
+
   --ifm-color-primary: #5B9BD5;
   --ifm-color-primary-dark: #4690d0;
   --ifm-color-primary-darker: #3b88cd;
@@ -124,10 +124,10 @@
   --ifm-color-primary-light: #70a6da;
   --ifm-color-primary-lighter: #7baedc;
   --ifm-color-primary-lightest: #9fc4e6;
-  
+
   --ifm-background-color: #0f0f1a;
   --ifm-background-surface-color: #1a1a2e;
-  
+
   --docusaurus-highlighted-code-line-bg: rgba(91, 155, 213, 0.2);
 }
 
@@ -331,6 +331,20 @@ a {
   border-bottom: none;
 }
 
+.theme-doc-markdown .vocab-etymology-link,
+.sl-markdown-content .vocab-etymology-link {
+  color: inherit;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+
+.theme-doc-markdown .vocab-etymology-link:hover,
+.sl-markdown-content .vocab-etymology-link:hover {
+  color: var(--co-blue-bright);
+}
+
 /* ============= ADMONITIONS / ALERTS ============= */
 .alert {
   border-radius: 12px;
@@ -520,7 +534,7 @@ code {
   .theme-doc-markdown h1 {
     font-size: 2rem;
   }
-  
+
   .theme-doc-markdown h2 {
     font-size: 1.5rem;
   }

--- a/starlight/src/data/etymology-lemma-index.mjs
+++ b/starlight/src/data/etymology-lemma-index.mjs
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const MANIFEST_URL = new URL('./etymology-manifest.json', import.meta.url);
+const VESUM_LEMMAS_URL = new URL('./vesum-vocab-lemmas.json', import.meta.url);
+
+let cachedResolver;
+
+export function normalizeLemma(value) {
+  return String(value ?? '')
+    .trim()
+    .toLocaleLowerCase('uk')
+    .normalize('NFD')
+    .replace(/[\u0300\u0301\u0341]/g, '')
+    .normalize('NFC');
+}
+
+export function stripReflexiveSuffix(value) {
+  const normalized = normalizeLemma(value);
+  if (normalized.endsWith('ся')) return normalized.slice(0, -2);
+  if (normalized.endsWith('сь')) return normalized.slice(0, -2);
+  return normalized;
+}
+
+export function buildLemmaRoutes(manifest) {
+  const routes = new Map();
+  const entries = Array.isArray(manifest?.entries) ? manifest.entries : [];
+  const slugGroups = manifest?.slug_groups ?? {};
+
+  for (const entry of entries) {
+    if (!entry?.lemma || !entry?.slug) continue;
+
+    const key = normalizeLemma(entry.lemma);
+    if (!key || routes.has(key)) continue;
+
+    const group = slugGroups[entry.slug] ?? [];
+    routes.set(key, {
+      href: `/etymology/${entry.slug}/`,
+      lemma: entry.lemma,
+      slug: entry.slug,
+      polysemy: group.length > 1,
+    });
+  }
+
+  return routes;
+}
+
+export function buildVesumLemmaMap(data) {
+  const rawMap = data?.form_to_lemma ?? data?.lemmas ?? {};
+  const lemmas = new Map();
+
+  for (const [form, lemma] of Object.entries(rawMap)) {
+    const formKey = normalizeLemma(form);
+    const lemmaKey = normalizeLemma(lemma);
+    if (formKey && lemmaKey) lemmas.set(formKey, lemma);
+  }
+
+  return lemmas;
+}
+
+export function createEtymologyResolver({ manifest, lemmaRoutes, vesumLemmas } = {}) {
+  return {
+    lemmaRoutes: lemmaRoutes ?? buildLemmaRoutes(manifest ?? { entries: [], slug_groups: {} }),
+    vesumLemmas: vesumLemmas instanceof Map ? vesumLemmas : buildVesumLemmaMap(vesumLemmas ?? {}),
+  };
+}
+
+export function loadDefaultEtymologyResolver() {
+  if (cachedResolver) return cachedResolver;
+
+  const manifest = JSON.parse(readFileSync(MANIFEST_URL, 'utf8'));
+  const vesumLemmas = existsSync(VESUM_LEMMAS_URL)
+    ? JSON.parse(readFileSync(VESUM_LEMMAS_URL, 'utf8'))
+    : { form_to_lemma: {} };
+
+  cachedResolver = createEtymologyResolver({ manifest, vesumLemmas });
+  return cachedResolver;
+}
+
+export function cleanVocabWord(value) {
+  return String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function isSingleVocabToken(value) {
+  const cleaned = cleanVocabWord(value);
+  return cleaned.length > 0 && !/\s/.test(cleaned);
+}
+
+export function resolveVocabWord(value, resolver = loadDefaultEtymologyResolver()) {
+  const cleaned = cleanVocabWord(value);
+  if (!isSingleVocabToken(cleaned)) return null;
+
+  const directKey = normalizeLemma(cleaned);
+  const direct = resolver.lemmaRoutes.get(directKey);
+  if (direct) {
+    return {
+      ...direct,
+      source: 'manifest',
+      matchedLemma: direct.lemma,
+    };
+  }
+
+  const candidateForms = new Set([directKey, stripReflexiveSuffix(directKey)]);
+  for (const formKey of candidateForms) {
+    const lemma = resolver.vesumLemmas.get(formKey);
+    if (!lemma) continue;
+
+    const route = resolver.lemmaRoutes.get(normalizeLemma(lemma));
+    if (route) {
+      return {
+        ...route,
+        source: 'vesum',
+        matchedLemma: lemma,
+      };
+    }
+  }
+
+  return null;
+}

--- a/starlight/src/data/vesum-vocab-lemmas.json
+++ b/starlight/src/data/vesum-vocab-lemmas.json
@@ -1,0 +1,25 @@
+{
+  "version": "2026-05-21-v1",
+  "generated_at": "2026-05-21T21:17:06+00:00",
+  "source": {
+    "content_root": "starlight/src/content/docs",
+    "manifest": "starlight/src/data/etymology-manifest.json",
+    "vesum_db": "data/vesum.db",
+    "mdx_files": [
+      "starlight/src/content/docs/a1/my-morning.mdx",
+      "starlight/src/content/docs/a1/review-clears-needs-human.mdx",
+      "starlight/src/content/docs/folk/dumy-lytsarski.mdx",
+      "starlight/src/content/docs/folk/koliadky-shchedrivky.mdx"
+    ]
+  },
+  "stats": {
+    "vocabulary_words": 59,
+    "direct_manifest_matches": 10,
+    "vesum_form_matches": 1,
+    "skipped_multiword": 2,
+    "ambiguous_or_missing": 46
+  },
+  "form_to_lemma": {
+    "повертатися": "повертати"
+  }
+}

--- a/starlight/tests/unit/vocab-etymology-link.test.ts
+++ b/starlight/tests/unit/vocab-etymology-link.test.ts
@@ -1,0 +1,133 @@
+import { compile } from '@mdx-js/mdx';
+import remarkGfm from 'remark-gfm';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createEtymologyResolver,
+  normalizeLemma,
+  resolveVocabWord,
+} from '../../src/data/etymology-lemma-index.mjs';
+import vocabEtymologyLinker from '../../plugins/vocab-etymology-link.mjs';
+
+const resolver = createEtymologyResolver({
+  lemmaRoutes: new Map([
+    ['кава', { href: '/etymology/kava/', lemma: 'кава', slug: 'kava', polysemy: false }],
+    ['субота', { href: '/etymology/subota/', lemma: 'субота', slug: 'subota', polysemy: false }],
+    [
+      'прокидатися',
+      {
+        href: '/etymology/prokydatysia/',
+        lemma: 'прокидатися',
+        slug: 'prokydatysia',
+        polysemy: false,
+      },
+    ],
+  ]),
+  vesumLemmas: new Map([
+    ['суботу', 'субота'],
+    ['прокидаюся', 'прокидатися'],
+  ]),
+});
+
+async function compileMdx(source: string): Promise<string> {
+  const compiled = await compile(source, {
+    jsx: true,
+    remarkPlugins: [remarkGfm, [vocabEtymologyLinker, { resolver }]],
+  });
+  return String(compiled);
+}
+
+describe('vocab etymology linker', () => {
+  it('normalizes lowercase and combining stress marks', () => {
+    expect(normalizeLemma('Ка́ва')).toBe('кава');
+    expect(normalizeLemma('СУБО́ТА')).toBe('субота');
+    expect(normalizeLemma('краї́на й')).toBe('країна й');
+  });
+
+  it('resolves direct, declined, and reflexive VESUM forms', () => {
+    expect(resolveVocabWord('кава', resolver)?.href).toBe('/etymology/kava/');
+    expect(resolveVocabWord('суботу', resolver)?.href).toBe('/etymology/subota/');
+    expect(resolveVocabWord('прокидаюся', resolver)?.href).toBe('/etymology/prokydatysia/');
+  });
+
+  it('links matched words in vocabulary tables and leaves misses plain', async () => {
+    const compiled = await compileMdx(`
+<TabItem label="Vocabulary">
+
+| Word | IPA | English |
+| --- | --- | --- |
+| кава |  | coffee |
+| невідоме |  | unknown |
+
+</TabItem>
+`);
+
+    expect(compiled).toContain('href="/etymology/kava/"');
+    expect(compiled).toContain('className="vocab-etymology-link"');
+    expect(compiled).toContain('data-etymology-slug="kava"');
+    expect(compiled).toContain('{"невідоме"}');
+    expect(compiled).not.toContain('/etymology/nevidome/');
+  });
+
+  it('does not link multi-word phrases or non-vocabulary tabs', async () => {
+    const compiled = await compileMdx(`
+<TabItem label="Vocabulary">
+
+| Word | IPA | English |
+| --- | --- | --- |
+| добра кава |  | good coffee |
+
+</TabItem>
+<TabItem label="Activities">
+
+| Word | IPA | English |
+| --- | --- | --- |
+| кава |  | coffee |
+
+</TabItem>
+`);
+
+    expect(compiled).not.toContain('href="/etymology/kava/"');
+  });
+
+  it('supports Ukrainian vocabulary tabs and table opt-out comments', async () => {
+    const compiled = await compileMdx(`
+<TabItem label="Словник">
+
+{/* vocab-etymology: off */}
+| Слово | Переклад |
+| --- | --- |
+| кава | coffee |
+
+| Слово | Переклад |
+| --- | --- |
+| суботу | Saturday |
+
+</TabItem>
+`);
+
+    expect(compiled).not.toContain('href="/etymology/kava/"');
+    expect(compiled).toContain('href="/etymology/subota/"');
+  });
+
+  it('is idempotent when the plugin runs twice', async () => {
+    const compiled = await compile(`
+<TabItem label="Vocabulary">
+
+| Word | IPA | English |
+| --- | --- | --- |
+| кава |  | coffee |
+
+</TabItem>
+`, {
+      jsx: true,
+      remarkPlugins: [
+        remarkGfm,
+        [vocabEtymologyLinker, { resolver }],
+        [vocabEtymologyLinker, { resolver }],
+      ],
+    });
+
+    expect(String(compiled).match(/href="\/etymology\/kava\/"/g)).toHaveLength(1);
+  });
+});

--- a/tests/etymology/test_build_vesum_vocab_lemmas.py
+++ b/tests/etymology/test_build_vesum_vocab_lemmas.py
@@ -1,0 +1,100 @@
+"""Tests for the Starlight vocab-table VESUM subset builder."""
+
+import json
+import sqlite3
+
+from scripts.etymology.build_vesum_vocab_lemmas import (
+    build_vesum_vocab_lemmas,
+    extract_vocabulary_words_from_text,
+    normalize_lemma,
+)
+
+
+def _write_manifest(path):
+    manifest = {
+        "entries": [
+            {"lemma": "субота", "slug": "subota"},
+            {"lemma": "прокидатися", "slug": "prokydatysia"},
+            {"lemma": "робот", "slug": "robot"},
+        ],
+        "slug_groups": {
+            "subota": ["subota-5-461"],
+            "prokydatysia": ["prokydatysia-1-1"],
+            "robot": ["robot-1-1"],
+        },
+    }
+    path.write_text(json.dumps(manifest, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_vesum_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE forms (word_form TEXT NOT NULL, lemma TEXT NOT NULL, tags TEXT NOT NULL, pos TEXT NOT NULL)")
+    conn.executemany(
+        "INSERT INTO forms (word_form, lemma, tags, pos) VALUES (?, ?, ?, ?)",
+        [
+            ("суботу", "субота", "noun:inanim:f:v_zna", "noun"),
+            ("прокидаюся", "прокидатися", "verb:rev:imperf:pres:s:1", "verb"),
+            ("роботу", "робот", "noun:anim:m:v_zna", "noun"),
+            ("роботу", "робота", "noun:inanim:f:v_zna", "noun"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_normalize_lemma_strips_combining_marks():
+    assert normalize_lemma("Субо́та") == "субота"
+    assert normalize_lemma("краї́на й") == "країна й"
+
+
+def test_extract_vocabulary_words_only_from_vocab_tabs():
+    text = """
+<TabItem label="Lesson">
+
+| Word | English |
+| --- | --- |
+| кава | coffee |
+
+</TabItem>
+<TabItem label="Словник">
+
+| Слово | Переклад |
+| --- | --- |
+| **суботу** | Saturday |
+| доброго ранку | good morning |
+
+</TabItem>
+"""
+
+    assert extract_vocabulary_words_from_text(text) == {"суботу", "доброго ранку"}
+
+
+def test_build_subset_links_unambiguous_forms_and_skips_homonyms(tmp_path):
+    content_root = tmp_path / "docs"
+    content_root.mkdir()
+    (content_root / "lesson.mdx").write_text(
+        """
+<TabItem label="Vocabulary">
+
+| Word | IPA | English |
+| --- | --- | --- |
+| суботу |  | Saturday |
+| прокидаюся |  | I wake up |
+| роботу |  | work |
+
+</TabItem>
+""",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "manifest.json"
+    vesum_db = tmp_path / "vesum.db"
+    _write_manifest(manifest)
+    _write_vesum_db(vesum_db)
+
+    output = build_vesum_vocab_lemmas(content_root=content_root, manifest_path=manifest, vesum_db=vesum_db)
+
+    assert output["form_to_lemma"] == {
+        "прокидаюся": "прокидатися",
+        "суботу": "субота",
+    }
+    assert output["stats"]["ambiguous_or_missing"] == 1


### PR DESCRIPTION
Closes #2200.

## Summary

- Adds a build-time Astro remark plugin that links `Word`/`Слово` cells inside `Vocabulary`/`Словник` tabs to existing `/etymology/{slug}/` pages.
- Adds a cached manifest lemma resolver plus a precomputed VESUM subset JSON for safe form→lemma fallback without SQLite access during Astro build.
- Preserves formatted table-cell content, skips existing links and multi-word phrases, and supports opt-out via `data-etymology-links="false"` or `{/* vocab-etymology: off */}`.
- Adds dotted-underlined styling for generated vocab etymology links.

## Coverage

A1/A2/B1 source MDX vocab tables currently available in Starlight:

```text
src/content/docs/a1/my-morning.mdx: linked=5 single=19 rows=20 multi=1 coverage=26.3%
src/content/docs/a1/review-clears-needs-human.mdx: linked=1 single=2 rows=2 multi=0 coverage=50.0%
A1/A2/B1 total: linked=6 single=21 rows=22 multi=1 coverage=28.6%
```

`my-morning.mdx` is still `draft: true`, so it is counted in source coverage but not emitted into `dist/` by the production build.

VESUM subset generation:

```text
$ .venv/bin/python scripts/etymology/build_vesum_vocab_lemmas.py
{
  "vocabulary_words": 59,
  "direct_manifest_matches": 10,
  "vesum_form_matches": 1,
  "skipped_multiword": 2,
  "ambiguous_or_missing": 46,
  "output_file": "starlight/src/data/vesum-vocab-lemmas.json"
}
```

Built vocab links sampled:

```text
$ grep -Hc 'class="vocab-etymology-link"' starlight/dist/a1/*/index.html 2>&1 | head -10
starlight/dist/a1/review-clears-needs-human/index.html:1

$ grep -Hc 'href="/etymology/' starlight/dist/a1/*/index.html 2>&1 | head -10
starlight/dist/a1/review-clears-needs-human/index.html:2
```

Sample rendered vocab links:

```text
/etymology/bayda/ Байда
/etymology/dyskusiia/ диску́сія
/etymology/etymolohiia/ етимоло́гія
/etymology/pryvit/ привіт
/etymology/slava/ слава
/etymology/synkretyzm/ синкрети́зм
```

Before/after rendering shape:

```mdx
| **привіт** |  | ім. | ч. |
```

```html
<a href="/etymology/pryvit/" title="Etymology: pryvit" class="vocab-etymology-link" data-etymology-slug="pryvit"><strong>привіт</strong></a>
```

## Verification

```text
$ .venv/bin/ruff check scripts/ tests/
All checks passed!
```

```text
$ .venv/bin/python -m pytest tests/etymology/ -v --tb=short
======================== 48 passed, 1 skipped in 0.21s =========================
```

```text
$ npm --prefix starlight run test -- vocab-etymology-link.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  23:17:16
   Duration  509ms (transform 20ms, setup 69ms, import 97ms, tests 17ms, environment 219ms)
```

```text
$ bash -o pipefail -c 'npm --prefix starlight run build 2>&1 | tail -30'
23:18:28   ├─ /etymology/index.html (+10ms) 
23:18:28   ├─ /a1/index.html (+11ms) 
23:18:28   ├─ /a1/review-clears-needs-human/index.html (+9ms) 
23:18:28   ├─ /a2/index.html (+3ms) 
23:18:28   ├─ /b1/index.html (+6ms) 
23:18:28   ├─ /b2-pro/index.html (+3ms) 
23:18:28   ├─ /bio/index.html (+4ms) 
23:18:28   ├─ /c1-pro/index.html (+2ms) 
23:18:28   ├─ /folk/index.html (+2ms) 
23:18:28   ├─ /folk/dumy-lytsarski/index.html (+11ms) 
23:18:28   ├─ /folk/koliadky-shchedrivky/index.html (+14ms) 
23:18:28   ├─ /hist/index.html (+5ms) 
23:18:28   ├─ /index.html (+3ms) 
23:18:28   ├─ /istorio/index.html (+3ms) 
23:18:28   ├─ /lit/index.html (+4ms) 
23:18:28   ├─ /lit-drama/index.html (+4ms) 
23:18:28   ├─ /lit-essay/index.html (+2ms) 
23:18:28   ├─ /lit-fantastika/index.html (+2ms) 
23:18:28   ├─ /lit-hist-fic/index.html (+2ms) 
23:18:28   ├─ /lit-humor/index.html (+2ms) 
23:18:28   ├─ /lit-war/index.html (+4ms) 
23:18:28   ├─ /lit-youth/index.html (+2ms) 
23:18:28   ├─ /oes/index.html (+2ms) 
23:18:28   ├─ /ruth/index.html (+2ms) 
23:18:28 ✓ Completed in 55.30s.

23:18:28 [build] ✓ Completed in 58.49s.
23:18:29 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
23:18:29 [build] 37921 page(s) built in 65.23s
23:18:29 [build] Complete!
```

```text
$ .venv/bin/python - <<'PY'
...check built vocab link targets...
PY
checked_vocab_links=6
missing_vocab_links=0
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  2bcb054c15  PASS  X-Agent: codex/vocab-etymology-linker-2026-05-21

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Implementation review: Gemini returned `[AGREE]` and the review is posted on #2200.
