### PR TITLE
fix(plans/a1/sounds-letters-and-hello): drop 1pl imp + low-freq И key-word (audit M-2 + M-3)

### DIFF
--- a/curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml
+++ b/curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml
@@ -2,7 +2,7 @@ module: a1-001
 level: A1
 sequence: 1
 slug: sounds-letters-and-hello
-version: 1.6.2
+version: 1.6.3
 lifecycle: locked
 reviewed_at: '2026-04-23T00:00:00Z'
 reviewed_by: claude-opus-4-7-xhigh-1412-sounds-letters-and-hello
@@ -103,7 +103,7 @@ content_outline:
   - Рада тебе бачити! (каже жінка) / Радий тебе бачити! (каже чоловік) — Радий/рада зустрічі! В українській
     мові є родові форми — жінки кажуть «рада», чоловіки — «радий». Це ваше перше знайомство з граматичним
     родом. Це стане великою темою, починаючи з модуля №8.
-  - 'Прочитаймо «Привіт» по літерах — ваш перший звуковий аналіз: П [п] приголосний + р [р] приголосний
+  - 'Прочитай «Привіт» по літерах — ваш перший звуковий аналіз: П [п] приголосний + р [р] приголосний
     + и [и] голосний + в [в] приголосний + і [і] голосний + т [т] приголосний. Два голосні, чотири приголосні.
     Кожен тип звука, який ви вивчили в цьому модулі, з''являється в цьому єдиному слові.'
 - section: Підсумок
@@ -159,7 +159,7 @@ vocabulary_hints:
   - word: З
     key_word: зуб
   - word: И
-    key_word: ирій
+    key_word: іній
   - word: І
     key_word: ім'я
   - word: Ї
@@ -370,6 +370,22 @@ plan_fixes:
   trigger: Activity grid needs explicit alphabet vocab coverage for letter-module activity generation.
   changes:
   - add letter_module flag and 33 alphabet entries with key_word examples for required activity coverage
+- version: 1.6.3
+  date: '2026-05-22'
+  ref: 'audit/2026-05-13/first-7-summary M-2 and M-3'
+  trigger: Plan-review (2026-05-13) flagged two MEDIUM issues to fix before letter-module
+    build queue. (M-2) 1pl imperative `Прочитаймо` is out-of-scope for A1 per State
+    Standard 2024 §4.2.4.2 (1pl `читаймо` / 3rd-person `хай/нехай` belong to A2 —
+    A1 imperative restricted to 2nd-person only). (M-3) Key-word `ирій` for И is in
+    VESUM but extremely low-frequency (poetic/mythological); NUS A1 bukvars pair И
+    with `іній` (high-frequency, concrete) — Захарійчук 1кл. с.46, Большакова 1кл.
+    с.32.
+  changes:
+  - 'replace content_outline[3].points[3] prose: `Прочитаймо «Привіт» по літерах`
+    → `Прочитай «Привіт» по літерах` (1pl imperative → 2sg imperative per State
+    Standard §4.2.4.2 A1 scope).'
+  - 'replace vocabulary_hints.recommended[].key_word for И: `ирій` → `іній` (poetic-
+    archaic → high-frequency concrete; NUS bukvar canonical pairing).'
 changelog:
 - version: 1.6.0
   date: '2026-04-23'

--- a/curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml.bak
+++ b/curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml.bak
@@ -2,7 +2,7 @@ module: a1-001
 level: A1
 sequence: 1
 slug: sounds-letters-and-hello
-version: 1.6.1
+version: 1.6.2
 lifecycle: locked
 reviewed_at: '2026-04-23T00:00:00Z'
 reviewed_by: claude-opus-4-7-xhigh-1412-sounds-letters-and-hello
@@ -18,6 +18,7 @@ subtitle: 33 літери, 38 звуків, Привіт!
 focus: phonetics
 pedagogy: PPP
 phase: A1.1 [Звуки, літери та перший контакт]
+letter_module: true
 word_target: 1200
 objectives:
 - Розуміти різницю між звуками та літерами — базову відмінність в українській фонетиці
@@ -137,6 +138,90 @@ vocabulary_hints:
   - дім (house)
   - ніс (nose)
   - сон (dream)
+  - word: А
+    key_word: ананас
+  - word: Б
+    key_word: банан
+  - word: В
+    key_word: вода
+  - word: Г
+    key_word: гора
+  - word: Ґ
+    key_word: ґудзик
+  - word: Д
+    key_word: дім
+  - word: Е
+    key_word: екран
+  - word: Є
+    key_word: єнот
+  - word: Ж
+    key_word: жук
+  - word: З
+    key_word: зуб
+  - word: И
+    key_word: ирій
+  - word: І
+    key_word: ім'я
+  - word: Ї
+    key_word: їжак
+  - word: Й
+    key_word: йогурт
+  - word: К
+    key_word: кіт
+  - word: Л
+    key_word: лимон
+  - word: М
+    key_word: мама
+  - word: Н
+    key_word: ніс
+  - word: О
+    key_word: око
+  - word: П
+    key_word: пес
+  - word: Р
+    key_word: рука
+  - word: С
+    key_word: сон
+  - word: Т
+    key_word: тато
+  - word: У
+    key_word: урок
+  - word: Ф
+    key_word: фото
+  - word: Х
+    key_word: хата
+  - word: Ц
+    key_word: цукор
+  - word: Ч
+    key_word: час
+  - word: Ш
+    key_word: школа
+  - word: Щ
+    key_word: щука
+  - word: Ь
+    key_word: день
+  - word: Ю
+    key_word: юшка
+  - word: Я
+    key_word: яблуко
+targets:
+  new_vocabulary:
+    - "звук"
+    - "літера"
+    - "голосний"
+    - "приголосний"
+    - "привіт"
+    - "Добрий день"
+    - "Доброго ранку"
+    - "Добрий вечір"
+    - "До побачення"
+    - "як справи"
+    - "добре"
+    - "чудово"
+    - "мама"
+    - "молоко"
+  new_grammar: []
+  recycle_vocabulary: []
 activity_hints:
 - type: quiz
   focus: 'Розрізняй звуки та літери. Приклади питань: Що ми чуємо і вимовляємо? → звуки | Що ми бачимо
@@ -279,6 +364,12 @@ plan_fixes:
     marks deterministically AFTER review; plans must be stress-free.
   changes:
   - strip U+0301 from all string values (18 removals)
+- version: 1.6.2
+  date: '2026-04-25'
+  ref: '#1550'
+  trigger: Activity grid needs explicit alphabet vocab coverage for letter-module activity generation.
+  changes:
+  - add letter_module flag and 33 alphabet entries with key_word examples for required activity coverage
 changelog:
 - version: 1.6.0
   date: '2026-04-23'


### PR DESCRIPTION
## Summary

Apply two MEDIUM fixes from the 2026-05-13 first-7 plan audit (audit/2026-05-13/first-7-summary M-2 and M-3).

**M-2** — `Прочитаймо «Привіт» по літерах` in content_outline[3].points[3] uses 1pl imperative. State Standard 2024 §4.2.4.2 restricts A1 imperative to 2nd-person only — 1pl (`читаймо`) and 3rd-person (`хай/нехай`) belong to A2. The plan uses this as teacher meta-language, but the writer may render it in module prose. → swap to 2sg `Прочитай`.

**M-3** — Key-word `ирій` for letter И is in VESUM but extremely low-frequency (poetic/mythological — folklore "warm southern land for migratory birds"). NUS A1 bukvars pair И with `іній` (frost — high-frequency, concrete) per Захарійчук 1кл. с.46 and Большакова 1кл. с.32. → swap to `іній`.

## Changes

- `version: 1.6.2 → 1.6.3`
- `content_outline[3].points[3]`: `Прочитаймо` → `Прочитай`
- `vocabulary_hints.recommended[].key_word` for `И`: `ирій` → `іній`
- New `plan_fixes` entry documenting both changes with rationale + source citations
- `.bak` file refreshed per plan-immutability hook

`lifecycle: locked` preserved; this is the standard locked-plan edit discipline via `plan_fixes` + `.bak`.

## Refs

- `audit/2026-05-13/first-7-summary` M-2 and M-3
- `docs/l2-uk-en/state-standard-2024-mapping.yaml` §4.2.4.2
- `docs/best-practices/wiki-plan-review-and-lock.md`
- Companion PR #2204 (engagement_floor + russianisms_strict gates) — unblocks the build queue these plans feed

## Test plan

- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] Plan-immutability hook passes locally (`enforce plan version bump + .bak`)
- [x] All non-advisory CI checks expected green
- [ ] After merge: ready to enter A1.1 letter-module build queue once #2204 promotes a1/my-morning

🤖 Generated with [Claude Code](https://claude.com/claude-code)