### PR TITLE
fix(linear_pipeline): plan_sections per-section advisory + vesum hyphenated multi-word fallback

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6211,21 +6211,43 @@ def _section_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
         section_text = _extract_section_text(text, title)
         count = _word_count(_strip_comments(section_text))
         min_words = int(target * 0.9)
-        # Per user direction (2026-05-17, repeated multiple times across
-        # sessions): word targets are MINIMUMS. Overshoot is welcome, never
-        # an error. We retain a `max` field in the output for diagnostic
-        # visibility (so we can still SEE if a section has drifted far from
-        # plan) but it does NOT fail the gate.
+        # Per user direction (2026-05-17, reaffirmed 2026-05-23): word targets
+        # are MINIMUMS. Overshoot is welcome, never an error. We retain `min`
+        # and `max` fields in the output for diagnostic visibility — they feed
+        # the writer correction prompt as targeting guidance — but they do
+        # NOT fail the gate. The 2026-05-23 reaffirmation is specifically:
+        # "the section wordcount is a guidance for the writer, it is not a
+        # reason to drop an error. The important is that the whole content
+        # is a whole and not less than the planned word count." The total
+        # `word_count` gate enforces the only hard floor; per-section budgets
+        # surface as advisory diagnostics. The 2026-05-21 a1/my-morning
+        # build #13 cascade — where word_count r1 correction balanced the
+        # total but left Діалоги (257/270) and Мій ранок (265/270) under
+        # their per-section min and triggered a terminal halt — is the
+        # canonical failure pattern this relaxation prevents.
         max_words = int(target * 1.1)  # diagnostic-only
         budgets.append({
             "section": title,
             "count": count,
             "min": min_words,
             "max": max_words,
+            # `passed` is retained on every per-section budget for backward
+            # compatibility with diagnostic consumers (writer correction
+            # render, telemetry dashboards). It marks per-section min
+            # adherence, NOT a build-fail signal — see gate-level `passed`
+            # below.
             "passed": count >= min_words,
+            "under_min": count < min_words,
+            "over_max": count > max_words,
         })
     return {
-        "passed": not missing and all(item["passed"] for item in budgets),
+        # Gate-level `passed` reflects ONLY missing headings: every contracted
+        # section must EXIST as a level-2 heading in the module. Per-section
+        # word budgets are advisory (see comment in budgets construction
+        # above). A future stricter mode could surface per-section under-min
+        # as a separate `plan_sections_balance` advisory gate, but the build
+        # halt no longer fires on it.
+        "passed": not missing,
         "missing_headings": missing,
         "word_budgets": budgets,
     }
@@ -6320,6 +6342,57 @@ def _vesum_gate(
                 if matches
             }
             missing_lc -= resolved_lc
+    # Hyphenated multi-word constructions fallback (per user direction
+    # 2026-05-23). Many legitimate Ukrainian forms appear as hyphenated
+    # compounds that VESUM only indexes by individual lemma: adverbial
+    # expressions like `літера-в-літеру` ("letter by letter"), reduplicative
+    # intensifiers like `тихо-тихо` / `день-у-день`, range constructions
+    # like `п'ять-шість`, and color/temporal compounds like `темно-синій`.
+    # The primary VESUM lookup treats the whole token as one lemma and
+    # fails. Per user: "do not drop [an] error if VESUM is not supporting
+    # it but we need to be able to check if they are correct with another
+    # tool." Tier-1 fallback: split on hyphens, verify each constituent
+    # in VESUM, accept the compound if every part above the lookup
+    # threshold itself verifies. Short connector parts (`в`, `у`, `і`,
+    # `до`) below VESUM_MIN_WORD_LENGTH are accepted without lookup —
+    # they're under the gate's standard threshold and would be skipped if
+    # encountered standalone. Russified compounds where one part fails
+    # VESUM (e.g. hypothetical `буквенного-щось`) still fail the gate
+    # because the failing constituent is itself a VESUM miss.
+    if missing_lc:
+        hyphenated_missing = sorted(w for w in missing_lc if "-" in w)
+        if hyphenated_missing:
+            constituent_lookups: set[str] = set()
+            constituent_map: dict[str, list[str]] = {}
+            for compound in hyphenated_missing:
+                parts = [part for part in compound.split("-") if part]
+                if len(parts) < 2:
+                    continue
+                eligible_parts = [
+                    part for part in parts if len(part) >= VESUM_MIN_WORD_LENGTH
+                ]
+                constituent_lookups.update(eligible_parts)
+                constituent_map[compound] = eligible_parts
+            if constituent_lookups:
+                try:
+                    constituent_verified = verify_words_fn(sorted(constituent_lookups))
+                except Exception as exc:
+                    return {
+                        "passed": False,
+                        "error": str(exc),
+                        "checked": len(unchecked_pairs),
+                    }
+            else:
+                constituent_verified = {}
+            resolved_compounds: set[str] = set()
+            for compound, parts in constituent_map.items():
+                # All eligible parts must verify. If there are zero
+                # eligible parts (every constituent below threshold),
+                # accept conservatively — the compound is a string of
+                # very short tokens we wouldn't gate individually.
+                if all(constituent_verified.get(part) for part in parts):
+                    resolved_compounds.add(compound)
+            missing_lc -= resolved_compounds
     missing = sorted(
         {surface for surface, lower, _original in unchecked_pairs if lower in missing_lc}
     )

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -3598,3 +3598,189 @@ def test_contract_yaml_tolerates_missing_vocabulary_hints() -> None:
     }
     out = linear_pipeline._contract_yaml(plan)
     assert "vocabulary_required: []" in out
+
+
+# ---------------------------------------------------------------------------
+# Gate relaxations (2026-05-23) — user-direction enforcement
+# ---------------------------------------------------------------------------
+#
+# Two surgical relaxations were applied to the `plan_sections` and
+# `vesum_verified` gates after the 2026-05-21 a1/my-morning build #13
+# terminal cascade exposed two structural false-positive patterns:
+#
+# 1. `plan_sections` failed on per-section min/max bounds when the writer's
+#    word_count correction rebalanced total but left one section ~5% short.
+#    User direction: "the section wordcount is a guidance for the writer,
+#    it is not a reason to drop an error. The important is that the whole
+#    content is a whole and not less than the planned word count."
+#
+# 2. `vesum_verified` failed on legitimate hyphenated multi-word
+#    constructions like `літера-в-літеру` ("letter by letter") which VESUM
+#    only indexes by single lemma. User direction: "there are many of these
+#    kind of constructions in the Ukrainian language, do not drop [an]
+#    error if VESUM is not supporting it but we need to be able to check
+#    if they are correct with another tool."
+#
+# The tests below pin those relaxations against regression.
+
+
+def test_section_gate_passes_when_section_below_min_but_present() -> None:
+    """Per-section under-min does NOT fail the gate (advisory only).
+
+    Reflects user direction 2026-05-23: per-section word counts are
+    GUIDANCE for the writer, not a build-fail trigger. The gate-level
+    `passed` reflects only missing headings. Per-section budgets are
+    retained as diagnostics so the writer correction prompt can use them
+    for targeting guidance, but they do NOT halt the build.
+
+    The 2026-05-21 a1/my-morning build #13 cascade — where the writer's
+    word_count r1 correction landed total at 1200 but left Діалоги
+    (257/270 = 95%) and Мій ранок (265/270 = 98%) under their per-section
+    min while Підсумок overshot, triggering terminal halt — is the
+    canonical failure pattern this relaxation prevents.
+    """
+    plan = {
+        "content_outline": [
+            {"section": "Діалоги", "words": 300, "points": ["p1"]},
+            {"section": "Підсумок", "words": 300, "points": ["p2"]},
+        ]
+    }
+    # Діалоги only has ~50 words (well below min=270). Підсумок has plenty.
+    # Both sections are PRESENT as headings.
+    text = (
+        "## Діалоги\n\n"
+        + ("слово " * 50)
+        + "\n\n## Підсумок\n\n"
+        + ("слово " * 500)
+        + "\n"
+    )
+    report = linear_pipeline._section_gate(text, plan)
+    assert report["passed"] is True, (
+        "Per-section under-min must not fail the gate per user direction "
+        "2026-05-23"
+    )
+    # Diagnostic budgets still reflect the per-section state.
+    budgets = {item["section"]: item for item in report["word_budgets"]}
+    assert budgets["Діалоги"]["under_min"] is True
+    assert budgets["Діалоги"]["passed"] is False  # per-section advisory marker
+    assert budgets["Підсумок"]["over_max"] is True
+    assert budgets["Підсумок"]["under_min"] is False
+
+
+def test_section_gate_fails_on_missing_heading() -> None:
+    """A contracted section absent from module.md still fails the gate.
+
+    Missing headings remain a hard fail — the writer must emit every
+    section the plan contracted for. Only per-section word counts were
+    relaxed by the 2026-05-23 change.
+    """
+    plan = {
+        "content_outline": [
+            {"section": "Діалоги", "words": 300, "points": ["p1"]},
+            {"section": "Підсумок", "words": 300, "points": ["p2"]},
+        ]
+    }
+    text = "## Діалоги\n\n" + ("слово " * 320) + "\n"  # Підсумок absent
+    report = linear_pipeline._section_gate(text, plan)
+    assert report["passed"] is False
+    assert "Підсумок" in report["missing_headings"]
+
+
+def test_section_gate_passes_when_sections_overshoot_max() -> None:
+    """Section overshoot (count > max) does not fail the gate either.
+
+    Reaffirms the pre-existing rule that max_words is diagnostic-only
+    ("more is always welcome" — user direction 2026-05-17 + 2026-05-23).
+    """
+    plan = {
+        "content_outline": [
+            {"section": "Підсумок", "words": 300, "points": ["p1"]},
+        ]
+    }
+    # 600 words: well over max=330 but max is diagnostic.
+    text = "## Підсумок\n\n" + ("слово " * 600) + "\n"
+    report = linear_pipeline._section_gate(text, plan)
+    assert report["passed"] is True
+    budget = report["word_budgets"][0]
+    assert budget["over_max"] is True
+    assert budget["under_min"] is False
+
+
+def test_vesum_gate_accepts_hyphenated_multi_word_compound_when_parts_verify() -> None:
+    """Hyphenated multi-word constructions where all parts verify pass.
+
+    Per user direction 2026-05-23: VESUM only indexes single lemmas, so
+    legitimate hyphenated phrases like `літера-в-літеру` (`letter by
+    letter`) need a fallback verification. The gate now splits on hyphens
+    and verifies each constituent above the lookup threshold; if every
+    part itself is a valid VESUM form, the compound is accepted.
+    """
+    # `літера-в-літеру`: every constituent (літера, в, літеру) verifies
+    # in real VESUM. `в` is below VESUM_MIN_WORD_LENGTH=3 and is accepted
+    # without lookup. The other two are listed as `known`. The surrounding
+    # vocab (`слово`) is also declared so the test isolates compound-
+    # handling from incidental missing-word false-positives.
+    fake_verify = _build_fake_verify_words(
+        known={"літера": True, "літеру": True, "слово": True},
+    )
+    report = linear_pipeline._vesum_gate(
+        module_text="Слово літера-в-літеру.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    assert "літера-в-літеру" not in report["missing"]
+    assert report["passed"] is True
+
+
+def test_vesum_gate_still_fails_hyphenated_compound_when_part_is_russianism() -> None:
+    """A hyphenated compound containing an unrecognized part still fails.
+
+    The constituent fallback is conservative — it accepts compounds ONLY
+    when every above-threshold part itself verifies. A hypothetical
+    Russified compound like `буквенного-щось` (where `буквенного` is a
+    real Russianism not in VESUM) MUST still fail the gate — otherwise
+    the relaxation would create a Russianism-laundering loophole via
+    hyphenation.
+    """
+    # `буквенного` is NOT in real VESUM (Russified form; standard is
+    # `буквений`). `щось` is real Ukrainian (`something`). Compound fails.
+    fake_verify = _build_fake_verify_words(
+        known={"щось": True, "слово": True},
+    )
+    report = linear_pipeline._vesum_gate(
+        module_text="Слово буквенного-щось.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    # The compound stays missing because `буквенного` constituent fails.
+    assert "буквенного-щось" in report["missing"]
+    assert report["passed"] is False
+
+
+def test_vesum_gate_hyphenated_compound_accepted_when_only_short_parts() -> None:
+    """Hyphenated compounds of only-short-tokens are accepted conservatively.
+
+    Edge case: `і-і-і` or `у-у-у` — strings of short prepositions/
+    conjunctions all below VESUM_MIN_WORD_LENGTH=3 — are not realistic
+    Ukrainian forms but if they ever appear, the fallback accepts them
+    conservatively (there are no constituents to verify, so no constituent
+    fails). This prevents the gate from blocking on unverifiable noise.
+    """
+    fake_verify = _build_fake_verify_words(known={"слово": True})
+    report = linear_pipeline._vesum_gate(
+        # `і-і-і` (3-part compound of single-char tokens). All below
+        # VESUM_MIN_WORD_LENGTH=3.
+        module_text="Слово і-і-і.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=fake_verify,
+    )
+    # 'і-і-і' wouldn't reach VESUM at all (below min length on the whole
+    # compound). The test is structurally a smoke test that the fallback
+    # doesn't crash on degenerate inputs.
+    assert report.get("error") is None


### PR DESCRIPTION
## Summary

Two surgical gate relaxations enforcing user direction (2026-05-23) surfaced by the a1/my-morning build #13 terminal cascade.

- **`_section_gate`**: per-section word budgets become **advisory diagnostics**. Gate-level `passed` now reflects only `missing_headings` — every contracted section must exist as a heading, but per-section count thresholds no longer halt the build. "The section wordcount is a guidance for the writer, it is not a reason to drop an error. The important is that the whole content is a whole and not less than the planned word count." The total `word_count` gate remains the floor; per-section `min` / `max` / `under_min` / `over_max` are retained in `word_budgets[*]` for writer correction prompt targeting and dashboards.
- **`_vesum_gate`**: hyphenated multi-word fallback. Compounds like `літера-в-літеру` ("letter by letter"), `день-у-день`, `темно-синій`, `тихо-тихо` are legitimate Ukrainian constructions whose constituents each verify in VESUM but whose compound form VESUM does not index by lemma. Fallback: split on hyphens, verify each constituent above `VESUM_MIN_WORD_LENGTH=3`, accept if every above-threshold part itself verifies. Short connectors (`в`, `у`, `і`, `до`) below threshold are accepted without lookup. Russified compounds where any constituent fails VESUM (e.g. hypothetical `буквенного-щось`) still fail the gate — no Russianism laundering via hyphenation.

## Build #13 root cause (closes the regression that triggered this PR)

Build #13 (`build/a1/my-morning-20260521-225659`) failed at `python_qg` because:
1. Round 0 had `word_count=1057/1200` (under) + `plan_sections` fail (3 sections short) + `vesum_verified` ✅.
2. Round 1 correction for `word_count` got only `{count, target}` from the failing gate — no per-section context, no related-gate diagnostic.
3. Writer added ~143 words concentrated in `Підсумок` (218→441), introduced `буквенного` (Russified double-н adjective) and `літера-в-літеру` (legitimate hyphenated phrase) in the new prose.
4. Round 1: `word_count` ✅ but `plan_sections` worse (per-section min still failed on Діалоги + Мій ранок) AND `vesum_verified` broken on `літера-в-літеру` (false positive — see below) + `буквенного` (real Russianism).
5. `previously_passed_regression` terminal-killed: `vesum_verified` passed in r0, fails in r1.

The `літера-в-літеру` failure is a **false positive** — the phrase is a legitimate Ukrainian construction whose parts all verify in VESUM. The `плен_sections` per-section minimum fail is too strict — total budget was hit; section-level redistribution is writer-discipline guidance, not a build-fail signal.

This PR fixes those two false positives. `буквенного` remains a real fail (correctly caught — separate writer-prompt follow-up to prevent its emission).

## Test plan

- [x] `test_section_gate_passes_when_section_below_min_but_present` — section ~50/270 words present passes; missing heading still fails.
- [x] `test_section_gate_fails_on_missing_heading` — pins the only remaining hard-fail condition for plan_sections.
- [x] `test_section_gate_passes_when_sections_overshoot_max` — reaffirms pre-existing "more is welcome" rule.
- [x] `test_vesum_gate_accepts_hyphenated_multi_word_compound_when_parts_verify` — `літера-в-літеру` passes when constituents verify.
- [x] `test_vesum_gate_still_fails_hyphenated_compound_when_part_is_russianism` — `буквенного-щось` still fails (no Russianism laundering).
- [x] `test_vesum_gate_hyphenated_compound_accepted_when_only_short_parts` — degenerate `і-і-і` smoke test.
- [x] Full `tests/build/test_linear_pipeline.py` suite: 124 passed, 1 skipped (no regression).
- [x] `test_engagement_floor_gate.py` + `test_vesum_negative_example_handling.py` + `test_adr_008_invariants.py`: 32 passed (related gate suites clean).
- [x] `test_a1_20_exemplar.py` + `test_v7_build_e2e.py`: 4 passed (end-to-end clean).
- [x] `ruff check` on both changed files: clean.

## Notes

- VESUM-constituent fallback is the **tier-1** verifier for hyphenated forms. Per user: "we need to be able to check if they are correct with another tool" — a tier-2 corpus-attestation pass via `search_idioms` / `search_text` for compounds where constituent fallback leaks false-negatives can land as a follow-up if the constituent-only approach proves insufficient in practice.
- The two relaxations together unblock the build #13 cascade pattern. Next: re-fire build (#14) on `a1/my-morning` after merge — the existing artifacts on `build/a1/my-morning-20260521-225659` can be revalidated with `--resume MODULE_DIR` (#2202) for cheap iteration if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)