### PR TITLE
fix(wiki_coverage_gate): location-fallback when writer's anchor doesn't resolve

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -570,7 +570,23 @@ def _location_text(text: str, location: str) -> str:
                 end = headings[next_idx].start()
                 break
         return text[start:end]
-    return text if location_key in text.casefold() else ""
+    if location_key in text.casefold():
+        return text
+    # No heading match AND location isn't a literal substring of the text.
+    # The writer's `location` field is a descriptive hint that doesn't
+    # anchor cleanly (e.g. "same :::caution block, bullet 2" — observed
+    # 2026-05-22 a1/my-morning build #14 phon-2/phon-3). Degrade
+    # gracefully to whole-artifact matching so the obligation-specific
+    # substance check below can still validate that the required content
+    # is present somewhere in the artifact. The substance check is the
+    # actual correctness gate (e.g. phonetic_rule requires both `written`
+    # and `spoken` strings to appear in `target_text`); writer drift on
+    # the `location` field's prose anchor must not silently fail
+    # obligations whose content is genuinely present. If the content is
+    # genuinely missing, the substance check will still fail and the
+    # obligation will still report FAIL — just with a more accurate reason
+    # than `claimed_location_missing` (e.g. `phonetic_rule_missing`).
+    return text
 
 
 def _check_obligation_text(obligation: Mapping[str, Any], target_text: str, artifact: str) -> tuple[str, str]:

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -286,6 +286,140 @@ def test_sequence_step_h2_section_includes_h3_subsection_content() -> None:
     )
 
 
+def _phonetic_rule_manifest() -> dict[str, Any]:
+    """Manifest for testing phonetic_rule obligations.
+
+    Mirrors the a1/my-morning wiki obligations for `-ться → [ц':а]` and
+    `-ся → [с':а]` rules — the two phon-2 / phon-3 obligations whose
+    `claimed_location_missing` failure motivated PR #2207's resolver
+    fallback (see `test_phonetic_rule_falls_back_to_whole_artifact_when_location_unresolved`).
+    """
+    return {
+        "slug": "fixture",
+        "wiki_path": "wiki/pedagogy/a1/fixture.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [
+            {
+                "id": "phon-2",
+                "written": "-ться",
+                "spoken": "[ц':а]",
+                "treatment": "explicit_explanation",
+                "source_lines": "15",
+            }
+        ],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def test_phonetic_rule_falls_back_to_whole_artifact_when_location_unresolved() -> None:
+    """`_location_text` must degrade gracefully when the writer's claim
+    location is a descriptive phrase that doesn't anchor to a heading.
+
+    Build #14 of a1/my-morning (2026-05-22) wrote the `-ться → [ц':а]`
+    rule into a `:::caution[Спелінг ≠ Вимова]` block under
+    `## Дієслова на -ся`. The writer's implementation_map for phon-2
+    described the location as `"same :::caution block, bullet 2"` —
+    accurate prose, but not a heading and not a literal substring of the
+    module. The resolver returned empty target_text → FAIL with
+    `claimed_location_missing`, even though both the `written` (-ться)
+    and `spoken` ([ц':а]) markers were present in the module a few lines
+    apart.
+
+    The fix: when no heading matches AND the location isn't a literal
+    substring of the artifact, fall back to whole-artifact matching. The
+    obligation-specific substance check (phonetic_rule requires both
+    `written` and `spoken` to appear in `target_text`) is the real
+    correctness gate; writer drift on the descriptive `location` field
+    must not silently fail obligations whose content is genuinely present.
+    """
+    manifest = _phonetic_rule_manifest()
+    module_md = (
+        "## Дієслова на -ся\n\n"
+        "Intro paragraph.\n\n"
+        ":::caution[Спелінг ≠ Вимова]\n"
+        "Spelling diverges from pronunciation here:\n\n"
+        "- Written **-ться** → spoken **[ц':а]**: прокидається → [прокидайец':а].\n"
+        "- Written **-ся** → spoken **[с':а]**: прокидаюся → [прокидайус':а].\n"
+        ":::\n"
+    )
+    implementation_map = {
+        "phon-2": {
+            "artifact": "module.md",
+            # Writer's descriptive prose anchor: no `## same :::caution block`
+            # heading exists, and this string is not a substring of the
+            # module either. Pre-fix behaviour: FAIL claimed_location_missing.
+            "location": "same :::caution block, bullet 2",
+            "treatment": "explicit IPA",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md=module_md,
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    phon_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "phon-2"
+    )
+    assert phon_result["status"] == "PASS", (
+        f"phon-2 must PASS via whole-artifact fallback when the writer's "
+        f"location string doesn't anchor to a heading and the substance "
+        f"(-ться + [ц':а]) is present somewhere in module.md; got "
+        f"reason={phon_result['reason']!r}"
+    )
+
+
+def test_phonetic_rule_still_fails_when_substance_absent_anywhere() -> None:
+    """The whole-artifact fallback must NOT bypass the substance check.
+
+    The fix in `_location_text` makes location a hint rather than a hard
+    contract, but the obligation-specific substance check still gates
+    correctness. If the writer claims a phon obligation is satisfied but
+    neither the `written` nor the `spoken` markers appear anywhere in
+    the artifact, the gate must still FAIL — just with the more accurate
+    `phonetic_rule_missing` reason instead of `claimed_location_missing`.
+    """
+    manifest = _phonetic_rule_manifest()
+    module_md = (
+        "## Дієслова на -ся\n\n"
+        "Plain paragraph about morning routines. No reflexive ending\n"
+        "discussion here, no phonetic transcription, just narrative prose.\n"
+    )
+    implementation_map = {
+        "phon-2": {
+            "artifact": "module.md",
+            "location": "same :::caution block, bullet 2",
+            "treatment": "explicit IPA",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md=module_md,
+        activities_yaml="[]",
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    phon_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "phon-2"
+    )
+    assert phon_result["status"] == "FAIL", (
+        "phon-2 must FAIL when neither the written nor the spoken marker is "
+        "present anywhere in the module — the location fallback must not "
+        "create a false-positive escape hatch"
+    )
+    assert phon_result["reason"] == "phonetic_rule_missing", (
+        f"FAIL reason must now reflect the actual substance gap, not the "
+        f"location-resolution failure; got {phon_result['reason']!r}"
+    )
+
+
 def test_l2_error_passes_when_marker_contains_apostrophe() -> None:
     """`_activity_text` must surface activity content without YAML re-
     serialisation double-escaping apostrophes. The build-#6 regression:

--- a/tests/audit/test_wiki_coverage_gate_fix_proposals.py
+++ b/tests/audit/test_wiki_coverage_gate_fix_proposals.py
@@ -233,7 +233,26 @@ def test_unknown_artifact_points_back_to_seeded_artifact() -> None:
     assert "writer_claim={'artifact': 'readme.md'" in proposal["current_artifact_state"]
 
 
-def test_claimed_location_missing_quotes_claim_and_seeded_location_hint() -> None:
+def test_unresolved_location_passes_when_substance_present_anywhere() -> None:
+    """PR #2207: `_location_text` now falls back to whole-artifact matching
+    when the writer's `location` field doesn't anchor to a heading and
+    isn't a literal substring of the artifact. If the obligation's
+    substance markers (backticked terms, italicized markers, or fallback
+    substance words) are present anywhere in the artifact, the obligation
+    PASSES — writer drift on the descriptive `location` field is a soft
+    signal, not a hard contract.
+
+    Pre-PR-#2207 behavior: location='§Diaspora' returned "" target_text
+    → FAIL with `claimed_location_missing` + fix_proposal generated.
+    New behavior: falls back to whole module.md → substance check finds
+    the backticked markers `привіт` and `ранок` from the required_claim
+    → PASS, no fix_proposal.
+
+    This converts a noisy false-positive class (writer used descriptive
+    location prose) into clean passes, while still failing when content
+    is genuinely absent (see
+    `test_unresolved_location_surfaces_substance_failure_with_proposal`).
+    """
     manifest = _sequence_manifest(heading="Morning proof")
 
     report = check_wiki_coverage(
@@ -244,11 +263,62 @@ def test_claimed_location_missing_quotes_claim_and_seeded_location_hint() -> Non
         seeded_map=_seeded(manifest),
     )
 
+    # New behavior: substance IS in the module (just at a section that
+    # doesn't match the descriptive location), so the obligation passes
+    # via the whole-artifact fallback.
+    assert report["passed"] is True
+    assert "fix_proposals" not in report, (
+        "When the gate passes via location fallback, no fix proposals "
+        "should be emitted"
+    )
+    step_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "step-1"
+    )
+    assert step_result["status"] == "PASS"
+    assert step_result["reason"] == "sequence_claim_present"
+
+
+def test_unresolved_location_surfaces_substance_failure_with_proposal() -> None:
+    """When the writer's `location` doesn't anchor AND the obligation's
+    substance is genuinely absent from the artifact, the gate must still
+    FAIL — but with the substance-level reason (`sequence_claim_missing`,
+    `phonetic_rule_missing`, etc.) instead of the location-level reason
+    (`claimed_location_missing`). A fix_proposal must be emitted so the
+    correction loop can target the missing substance markers.
+
+    PR #2207 made `_location_text` permissive on location resolution but
+    did NOT loosen the substance check — that's still the canonical
+    correctness gate. This test pins the FAIL path: bogus location +
+    absent substance → FAIL + actionable proposal.
+    """
+    # Use a required_claim with markers that are deliberately ABSENT from
+    # the module. The default required_claim ("Teach `привіт` and `ранок`
+    # together.") would match the fallback module — supply an explicit one.
+    manifest = _sequence_manifest(
+        heading="Diaspora deep-dive",
+        required_claim="Diaspora deep-dive — discuss `діаспора` and `еміграція`.",
+    )
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        # location doesn't anchor + substance markers absent from module.
+        implementation_map={"step-1": _claim("module.md", "§Diaspora")},
+        module_md="## Routine\nA brief morning narrative without diaspora content.\n",
+        activities_yaml="[]",
+        seeded_map=_seeded(manifest),
+    )
+
     proposal = _single_proposal(report)
-    assert proposal["failure_reason"] == "claimed_location_missing"
-    assert "Location '§Diaspora' returns empty text in module.md" in proposal["surgical_diff_hint"]
-    assert "expected: §Morning proof" in proposal["surgical_diff_hint"]
-    assert "writer_claim={'artifact': 'module.md', 'location': '§Diaspora'" in proposal["current_artifact_state"]
+    # New failure mode is the substance-level reason.
+    assert proposal["failure_reason"] == "sequence_claim_missing"
+    # current_artifact_state now reflects the substance-check evidence
+    # (the actual module text scanned by the fallback), giving the
+    # correction loop the real context for proposing fixes — not a
+    # placeholder "resolved_artifact_text=''" sentinel.
+    assert "A brief morning narrative" in proposal["current_artifact_state"]
+    # Surgical diff hint must surface the missing markers / claim shape
+    # so the correction loop can target them.
+    assert "Diaspora deep-dive" in proposal["surgical_diff_hint"]
 
 
 def test_missing_incorrect_quotes_payload_incorrect() -> None:


### PR DESCRIPTION
## Summary

Follow-on to PR #2206. When the writer's `implementation_map.location` field is descriptive prose that doesn't anchor to a section heading AND isn't a literal substring of the artifact, `_location_text` now falls back to whole-artifact matching instead of returning empty `target_text`. The obligation-specific substance check (phonetic_rule requires both `written` + `spoken`; sequence_step requires `required_claim` markers; l2_error requires `incorrect` + `correct`) remains the canonical correctness gate.

## Build #14 motivation

Build #14 (`build/a1/my-morning-20260522-063200`) completed the writer phase cleanly with PR #2206's relaxed python_qg gates — `resources_search_attempted` ✅ (writer called `query_wikipedia`), `plan_sections` ✅ (advisory), `vesum_verified` ✅. Python_qg passed in 20s on first try. The IPA notation for `-ться → [ц':а]` and `-ся → [с':а]` was correctly embedded in a `:::caution[Спелінг ≠ Вимова]` block under `## Дієслова на -ся`.

Build still failed at `wiki_coverage_gate` at 88.89% (16/18), stuck on `phon-2` and `phon-3` with `claimed_location_missing`. Writer claimed `location: "same :::caution block, bullet 2"` — accurate prose, but neither a heading nor a literal substring. Resolver returned empty target_text → FAIL. Both batched + narrow correction passes exhausted on 4 iterations of fix-application that kept patching content the substance check would already have accepted if it had been allowed to run against the whole module.

**Forensic replay with the fix applied**: build #14's same artifacts pass the gate at 100% (18/18). Content was always present; the resolver was over-strict on the location anchor.

## What this PR does NOT do

- **Does NOT weaken the substance check.** If `written` + `spoken` markers for a phonetic_rule are absent from the entire artifact, the gate still FAILs — with `phonetic_rule_missing` (substance-level) instead of `claimed_location_missing` (location-level), which is more actionable for the correction loop.
- **Does NOT trust the writer's location field for diagnostic output.** Original claim is still surfaced in `claim` on the obligation result + fix_proposal's `current_artifact_state`.
- **Does NOT change behaviour for resolved locations.** When heading match OR literal-substring match succeeds, behaviour is unchanged. PR #2184's depth-aware boundary + PR #2193's H1-collision fix both preserved.

## Test plan

- [x] 4 new tests covering both PASS and FAIL paths
- [x] Full tests/audit/ + tests/build/: 729 pass, 18 skipped
- [x] Forensic replay: build #14 artifacts pass at 100% with fix applied

## After-merge plan

1. Re-run wiki_coverage_gate via `--resume MODULE_DIR` against build #14 artifacts to confirm pipeline passes through wiki_coverage_review (LLM phase) + MDX render.
2. If clean → `scripts/sync/promote_module.py --latest --level a1 --slug my-morning` ships the first complete V7 module on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)