### PR TITLE
fix(learner_state): planned-vocab fallback for not-yet-built modules — unblocks student-aware immersion

### DIFF
--- a/scripts/pipeline/learner_state.py
+++ b/scripts/pipeline/learner_state.py
@@ -23,22 +23,92 @@ def _load_curriculum() -> dict:
         return yaml.safe_load(f) or {}
 
 
+def _parse_vocab_hint_lemma(entry: str) -> str | None:
+    """Extract the lemma prefix from a plan vocabulary hint."""
+    text = entry.strip()
+    if not text:
+        return None
+    return text.split(" (", 1)[0].strip() or None
+
+
+def _load_planned_vocab(track: str, slug: str) -> list[str]:
+    """Load planned vocabulary lemmas from vocabulary_hints."""
+    path = CURRICULUM_ROOT / "plans" / track / f"{slug}.yaml"
+    if not path.exists():
+        return []
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            plan = yaml.safe_load(f)
+    except Exception:
+        return []
+
+    if not isinstance(plan, dict):
+        return []
+
+    hints = plan.get("vocabulary_hints")
+    if isinstance(hints, dict):
+        sections = [hints.get("required", []), hints.get("recommended", [])]
+    elif isinstance(hints, list):
+        sections = [hints]
+    else:
+        return []
+
+    lemmas: list[str] = []
+    seen: set[str] = set()
+
+    def add_entry(entry) -> None:
+        raw: str | None = None
+        if isinstance(entry, str):
+            raw = entry
+        elif isinstance(entry, dict):
+            for key in ("lemma", "word", "term", "text", "value"):
+                value = entry.get(key)
+                if isinstance(value, str):
+                    raw = value
+                    break
+            if raw is None and len(entry) == 1:
+                key, value = next(iter(entry.items()))
+                if isinstance(key, str) and isinstance(value, str):
+                    raw = key
+        if raw is None:
+            return
+
+        lemma = _parse_vocab_hint_lemma(raw)
+        if lemma and lemma not in seen:
+            lemmas.append(lemma)
+            seen.add(lemma)
+
+    for section in sections:
+        if isinstance(section, list):
+            for entry in section:
+                add_entry(entry)
+        else:
+            add_entry(section)
+
+    return lemmas
+
+
 def _load_vocab(track: str, slug: str) -> list[str]:
     """Load vocabulary lemmas for a module."""
     path = CURRICULUM_ROOT / track / slug / "vocabulary.yaml"
-    if not path.exists():
-        return []
-    try:
-        with open(path) as f:
-            data = yaml.safe_load(f)
-        if not data:
-            return []
-        items = data.get("items", data) if isinstance(data, dict) else data
-        if not isinstance(items, list):
-            return []
-        return [item["lemma"] for item in items if isinstance(item, dict) and "lemma" in item]
-    except Exception:
-        return []
+    built_vocab: list[str] = []
+    if path.exists():
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if data:
+                items = data.get("items", data) if isinstance(data, dict) else data
+                if isinstance(items, list):
+                    built_vocab = [
+                        item["lemma"]
+                        for item in items
+                        if isinstance(item, dict) and isinstance(item.get("lemma"), str)
+                    ]
+        except Exception:
+            built_vocab = []
+
+    return built_vocab or _load_planned_vocab(track, slug)
 
 
 def _load_grammar(track: str, slug: str) -> list[str]:

--- a/tests/test_learner_state.py
+++ b/tests/test_learner_state.py
@@ -7,7 +7,78 @@ from unittest.mock import patch
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-from pipeline.learner_state import build_learner_state, format_learner_state
+from pipeline.learner_state import (
+    _load_planned_vocab,
+    _load_vocab,
+    _parse_vocab_hint_lemma,
+    build_learner_state,
+    format_learner_state,
+)
+
+
+class TestPlannedVocabulary:
+    """Planned vocab fills learner-state gaps before modules are built."""
+
+    def test_parse_vocab_hint_lemma_basic(self):
+        assert _parse_vocab_hint_lemma("готовий (ready, adj m)") == "готовий"
+        assert _parse_vocab_hint_lemma("синку (son — vocative, from син)") == "синку"
+        assert _parse_vocab_hint_lemma("вітаю (congratulations — chunk)") == "вітаю"
+        assert _parse_vocab_hint_lemma("") is None
+
+    def test_load_planned_vocab_a1_colors(self):
+        lemmas = _load_planned_vocab("a1", "colors")
+
+        assert len(lemmas) >= 10
+        assert "червоний" in lemmas
+        assert "синій" in lemmas
+        assert "блакитний" in lemmas
+        assert "якого кольору?" in lemmas
+        assert "прапор" in lemmas
+
+    def test_load_vocab_falls_back_to_planned(self, tmp_path):
+        root = tmp_path / "curriculum" / "l2-uk-en"
+        plans_dir = root / "plans" / "test"
+        plans_dir.mkdir(parents=True)
+        (plans_dir / "plan-only.yaml").write_text(yaml.dump({
+            "vocabulary_hints": {
+                "required": [
+                    "готовий (ready, adj m)",
+                    "синку (son — vocative, from син)",
+                ],
+                "recommended": ["вітаю (congratulations — chunk)"],
+            }
+        }, allow_unicode=True))
+
+        with patch("pipeline.learner_state.CURRICULUM_ROOT", root):
+            lemmas = _load_vocab("test", "plan-only")
+
+        assert lemmas == ["готовий", "синку", "вітаю"]
+
+    def test_load_vocab_prefers_built_when_present(self, tmp_path):
+        root = tmp_path / "curriculum" / "l2-uk-en"
+
+        plans_dir = root / "plans" / "test"
+        plans_dir.mkdir(parents=True)
+        (plans_dir / "sample.yaml").write_text(yaml.dump({
+            "vocabulary_hints": {
+                "required": ["плановий (planned)"],
+                "recommended": ["запасний (backup)"],
+            }
+        }, allow_unicode=True))
+
+        built_dir = root / "test" / "sample"
+        built_dir.mkdir(parents=True)
+        (built_dir / "vocabulary.yaml").write_text(yaml.dump({
+            "items": [
+                {"lemma": "готовий", "translation": "ready"},
+                {"lemma": "вітаю", "translation": "congratulations"},
+            ]
+        }, allow_unicode=True))
+
+        with patch("pipeline.learner_state.CURRICULUM_ROOT", root):
+            lemmas = _load_vocab("test", "sample")
+
+        assert lemmas == ["готовий", "вітаю"]
 
 
 class TestBuildLearnerState:
@@ -102,6 +173,11 @@ class TestBuildLearnerState:
 
         assert state["cumulative_vocabulary"] == ["так"]
         assert "ні" not in state["cumulative_vocabulary"]
+
+    def test_build_learner_state_a1_m20_has_vocab(self):
+        state = build_learner_state("a1", 20)
+
+        assert state["cumulative_vocabulary"]
 
 
 class TestFormatLearnerState:


### PR DESCRIPTION
## Bug evidence

Current output before the fix:

```text
cumulative_vocabulary len: 0
known_grammar len: 95
band key: a1-m01-03
```

## Fix summary

`scripts/pipeline/learner_state.py` now parses planned vocabulary hint lemmas from `vocabulary_hints.required` and `vocabulary_hints.recommended`. `_load_vocab` still prefers built `vocabulary.yaml` artifacts when they contain lemmas, but falls back to planned vocabulary when built vocab is missing or empty. The added tests cover parser edge cases, plan fallback, built-artifact precedence, and the A1/m20 regression where prior planned vocab must be visible.

## Acceptance reproducer output

```text
1 cumulative_vocabulary len a1/m20: 295
2 known_grammar len a1/m20: 95
3 band key a1/m20: a1-m07-14
4 cumulative_vocabulary len a1/m1: 0
5 cumulative_vocabulary len a1/m2: 56
6 parse готовий: готовий
7 parse синку: синку
8 parse empty: None
```

## Pytest output

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/learner-state-planned-vocab-2026-05-23
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0
collecting ... collected 10 items

tests/test_learner_state.py::TestPlannedVocabulary::test_parse_vocab_hint_lemma_basic PASSED [ 10%]
tests/test_learner_state.py::TestPlannedVocabulary::test_load_planned_vocab_a1_colors PASSED [ 20%]
tests/test_learner_state.py::TestPlannedVocabulary::test_load_vocab_falls_back_to_planned PASSED [ 30%]
tests/test_learner_state.py::TestPlannedVocabulary::test_load_vocab_prefers_built_when_present PASSED [ 40%]
tests/test_learner_state.py::TestBuildLearnerState::test_first_module_empty PASSED [ 50%]
tests/test_learner_state.py::TestBuildLearnerState::test_collects_vocab_from_previous PASSED [ 60%]
tests/test_learner_state.py::TestBuildLearnerState::test_module_2_only_sees_module_1 PASSED [ 70%]
tests/test_learner_state.py::TestBuildLearnerState::test_build_learner_state_a1_m20_has_vocab PASSED [ 80%]
tests/test_learner_state.py::TestFormatLearnerState::test_first_module PASSED [ 90%]
tests/test_learner_state.py::TestFormatLearnerState::test_with_vocab_and_grammar PASSED [100%]

============================== 10 passed in 0.43s ==============================
```

## Ruff output

```text
All checks passed!
```

## Commit landed

```text
d4774962bb fix(learner_state): planned-vocab fallback for not-yet-built modules — unblocks student-aware immersion
```

## PR opened

```text
https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2211
```
