### PR TITLE
fix(promote_module): read MDX from build's curriculum tree, not stale starlight tree

### DIFF
--- a/scripts/sync/promote_module.py
+++ b/scripts/sync/promote_module.py
@@ -118,7 +118,21 @@ def _source_rel_for_lesson(level: str, slug: str, filename: str) -> Path:
     return CURRICULUM_ROOT / level / slug / filename
 
 
-def _source_rel_for_mdx(level: str, slug: str) -> Path:
+def _build_rel_for_mdx(level: str, slug: str) -> Path:
+    """Path where `assemble_mdx` writes the freshly-built MDX inside the build branch.
+
+    The build is the SOURCE of truth for the rendered MDX content. Reading from
+    DOCS_ROOT in the build branch instead would silently pick up whatever stale
+    Starlight-tree MDX happened to be there from a prior PR, which is exactly
+    how the m20 (a1/my-morning) revert (2026-05-23) shipped a broken module —
+    the build wrote a fresh MDX to `curriculum/.../{slug}.mdx`, but the promote
+    read DOCS_ROOT, found an unchanged stale exemplar, and the diff was empty.
+    """
+    return CURRICULUM_ROOT / level / slug / f"{slug}.mdx"
+
+
+def _dest_rel_for_mdx(level: str, slug: str) -> Path:
+    """Path Starlight reads to render the lesson page (deploy target)."""
     return DOCS_ROOT / level / f"{slug}.mdx"
 
 
@@ -212,12 +226,13 @@ def _collect_source_files(repo_root: Path, source: SourceSpec) -> tuple[list[Sou
         else:
             files.append(SourceFile(source_rel=source_rel, dest_rel=source_rel, content=content))
 
-    mdx_rel = _source_rel_for_mdx(source.level, source.slug)
-    mdx = _read_build_file(repo_root, source, mdx_rel)
+    mdx_source_rel = _build_rel_for_mdx(source.level, source.slug)
+    mdx_dest_rel = _dest_rel_for_mdx(source.level, source.slug)
+    mdx = _read_build_file(repo_root, source, mdx_source_rel)
     if mdx is None:
-        missing_required.append(mdx_rel)
+        missing_required.append(mdx_source_rel)
     else:
-        files.append(SourceFile(source_rel=mdx_rel, dest_rel=mdx_rel, content=mdx))
+        files.append(SourceFile(source_rel=mdx_source_rel, dest_rel=mdx_dest_rel, content=mdx))
 
     for filename in sorted(FORENSICS_FILES):
         source_rel = _source_rel_for_lesson(source.level, source.slug, filename)
@@ -254,7 +269,7 @@ def _classify_destination(repo_root: Path, source: SourceSpec, files: list[Sourc
         _source_rel_for_lesson(source.level, source.slug, filename)
         for filename in LESSON_SOURCE_FILES
     }
-    required_dest_rels.add(_source_rel_for_mdx(source.level, source.slug))
+    required_dest_rels.add(_dest_rel_for_mdx(source.level, source.slug))
 
     required_by_dest = {item.dest_rel: item for item in files if item.dest_rel in required_dest_rels}
     any_required_exists = False

--- a/tests/sync/test_promote_module.py
+++ b/tests/sync/test_promote_module.py
@@ -43,7 +43,13 @@ def _rel_module(level: str, slug: str, filename: str) -> Path:
     return Path("curriculum") / "l2-uk-en" / level / slug / filename
 
 
+def _rel_mdx_build(level: str, slug: str) -> Path:
+    """Where `assemble_mdx` writes the freshly-built MDX inside the build branch."""
+    return Path("curriculum") / "l2-uk-en" / level / slug / f"{slug}.mdx"
+
+
 def _rel_mdx(level: str, slug: str) -> Path:
+    """Deploy target Starlight reads from."""
     return Path("starlight") / "src" / "content" / "docs" / level / f"{slug}.mdx"
 
 
@@ -80,7 +86,10 @@ def _seed_build_branch(
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
     if "mdx" not in omit:
-        mdx = repo / _rel_mdx(level, slug)
+        # The build's assemble_mdx step writes here (curriculum tree), not into
+        # starlight/. Promote reads from this path and writes the deploy copy
+        # into starlight/src/content/docs/.
+        mdx = repo / _rel_mdx_build(level, slug)
         mdx.parent.mkdir(parents=True, exist_ok=True)
         mdx.write_text("mdx content\n", encoding="utf-8")
     _git(repo, "add", ".")
@@ -151,6 +160,46 @@ def test_promote_dry_run_writes_nothing(tmp_path: Path) -> None:
     assert rc == 0
     assert not (repo / _rel_module("a1", "foo", "module.md")).exists()
     assert _git(repo, "status", "--short").stdout == ""
+
+
+def test_promote_reads_mdx_from_build_curriculum_tree_not_stale_starlight(tmp_path: Path) -> None:
+    """Regression: promote must read MDX from the build's curriculum/ tree
+    (where assemble_mdx writes), not from the build branch's DOCS_ROOT.
+
+    The m20 (a1/my-morning) revert on 2026-05-23 shipped a broken module
+    because promote_module read DOCS_ROOT, found a stale Phase 4 exemplar
+    that happened to be there, and the diff against main was empty (since
+    main also had the same stale file). The freshly-built MDX written by
+    assemble_mdx to `curriculum/.../{slug}.mdx` never reached Starlight.
+
+    This test seeds a build branch with a FRESH curriculum-tree MDX AND a
+    STALE starlight-tree MDX, then asserts the FRESH content lands on main.
+    """
+    repo = _init_repo(tmp_path)
+    branch = "build/a1/foo-20260520-010101"
+    # Use the standard seed (writes fresh MDX to the curriculum tree path
+    # via the updated helper) and then pollute the build branch's
+    # DOCS_ROOT with a stale, divergent MDX as the regression bait.
+    _seed_build_branch(repo, branch)
+    _git(repo, "switch", branch)
+    stale = repo / _rel_mdx("a1", "foo")
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text("stale exemplar — must NOT be promoted\n", encoding="utf-8")
+    _git(repo, "add", str(_rel_mdx("a1", "foo")))
+    env = {
+        "GIT_AUTHOR_DATE": "2026-05-20T01:01:02 +0000",
+        "GIT_COMMITTER_DATE": "2026-05-20T01:01:02 +0000",
+    }
+    _git(repo, "commit", "-m", "seed stale starlight mdx", env=env)
+    _git(repo, "switch", "main")
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    promoted = (repo / _rel_mdx("a1", "foo")).read_text(encoding="utf-8")
+    assert promoted == "mdx content\n", (
+        f"Expected fresh build-tree MDX content on main; got stale starlight content: {promoted!r}"
+    )
 
 
 def test_promote_resolves_latest_branch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Root cause of the m20 (a1/my-morning) revert on 2026-05-23. The promote script was reading the MDX from `starlight/src/content/docs/{level}/{slug}.mdx` inside the build branch — where a Phase 4 exemplar from commit `c91ae3bbe1` had been sitting since pre-V7 setup. The build's `assemble_mdx` step writes the freshly-rendered MDX to `curriculum/l2-uk-en/{level}/{slug}/{slug}.mdx` (per `scripts/build/linear_pipeline.py:5490`), but that path was never read by promote.

Result: every promote shipped the stale exemplar instead of the actual build output. The m20 revert's handoff misdiagnosed this as separate "Tab 3 fallback eaten by transforms" and "Tab 4 not reading canonical resources.yaml" bugs. Neither is a real bug — the assembler is correct end-to-end. The promote read the wrong path.

- Splits `_source_rel_for_mdx` into `_build_rel_for_mdx` (curriculum/, where assemble_mdx writes) and `_dest_rel_for_mdx` (DOCS_ROOT, where Starlight reads)
- `_collect_source_files` now reads from build path, writes to dest path
- `_classify_destination` continues using dest path for required-destination tracking

## Test plan

- [x] `pytest tests/sync/test_promote_module.py -v` — 7/7 passing
- [x] `ruff check scripts/sync/promote_module.py tests/sync/test_promote_module.py` — clean
- [x] Regression test `test_promote_reads_mdx_from_build_curriculum_tree_not_stale_starlight` proves the fix
- [x] Verified against m20's preserved worktree: assemble_mdx against saved artifacts produces correct Tab 3 + Tab 4 content (Захарійчук G1 p.24/p.52, not the stale G4/G10 the promoted MDX shipped)
- [ ] After merge: next promote will sync fresh MDX into Starlight tree

Closes the misdiagnosed items #4a + #4b from `docs/session-state/2026-05-23-v7-design-alignment-m20-reverted.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)