### PR TITLE
feat(reviewer-prompt): mirror V7 writer audit contracts

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3241,12 +3241,16 @@ def review_context(
         raise LinearPipelineError(f"Unknown LLM QG dimension: {dim}")
     level = str(plan["level"])
     sequence = int(plan["sequence"])
+    learner_state = build_learner_state(level.lower(), sequence)
     return {
         "LEVEL": level,
         "MODULE_NUM": str(sequence),
         "MODULE_SLUG": str(plan["slug"]),
         "WORD_TARGET": str(plan["word_target"]),
-        "IMMERSION_RULE": get_immersion_rule(level.lower(), sequence),
+        "LEARNER_STATE": format_learner_state(learner_state),
+        "IMMERSION_RULE": get_immersion_rule(
+            level.lower(), sequence, learner_state=learner_state
+        ),
         "CONTRACT_YAML": _contract_yaml(plan),
         "PLAN_CONTENT": plan_content,
         "GENERATED_CONTENT": generated_content,

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -44,6 +44,18 @@ For `{DIM}` specifically:
 A dim score that re-states what a deterministic gate already enforced is a
 reviewer-protocol failure. Cite something the gate cannot see.
 
+The Tier-1 audits below (A through I, expanded in this rebuild) feed evidence
+into specific dims as labeled. Audit F (activity split) → pedagogical +
+engagement. Audit G (corpus access) → all dims, weighted strongest for
+pedagogical (out-of-level citations are mostly a pedagogical problem). Audit H
+(student-aware) → pedagogical + engagement + naturalness. Audit I (audit-line
+integrity) → all dims, as a meta-signal that the writer was honest with itself.
+
+A dim scoring high while the audits surface FLAGs is a reviewer-protocol
+failure — the dim's rubric must absorb the audit evidence. A dim scoring low
+without any audit FLAGs is allowed, but evidence_quotes must justify the score
+from the residual rubric alone.
+
 ## Reasoning checklist (do this BEFORE scoring — #1673)
 
 Before producing the JSON response, reason through this dimension explicitly.
@@ -104,11 +116,119 @@ E. **Reinforce rule #6.** Every claim pairs (i) a verbatim quote from the
    absence-of-verification flag. A `PASS` with no grounded evidence is a
    reviewer-protocol failure.
 
+F. **Activity split audit (pedagogical, engagement).** The writer is
+contracted to emit two complementary activity sets per `ACTIVITY_CONFIGS[{LEVEL}]`:
+INLINE (light, theory-time checks anchored via `<!-- INJECT_ACTIVITY: act-N -->`)
+and WORKBOOK (substantive, after-lesson drill, no INJECT marker). For A1:
+INLINE 4-6 / WORKBOOK 6-9 (10 total). For A2: INLINE 4-6 / WORKBOOK 8-11
+(12 total). For B1-core/B2-core/C1-core: INLINE 5-7 / WORKBOOK 11-15
+(16 total). For C2: INLINE 4-5 / WORKBOOK 8-10 (12 total).
+
+The writer is required to emit a self-audit line
+`<activity_split_audit>level={LEVEL} inline_n=N workbook_n=N inline_range=[lo,hi] workbook_range=[lo,hi] split_valid=true|false</activity_split_audit>`
+before the artifact fences. Locate this line and verify:
+
+1. The line is PRESENT. Missing → FLAG `activity_split_audit_missing`
+   (counts as evidence-against this dim).
+2. The reported `inline_n` matches the actual count of
+   `<!-- INJECT_ACTIVITY: act-N -->` markers in `module.md`.
+3. The reported `workbook_n` matches `len(activities.yaml) - inline_n`.
+4. Both counts fall within the level's allowed ranges per §"Corpus Access" of
+   the writer prompt.
+
+If the writer's self-audit reports `split_valid=true` BUT the actual counts
+violate the range, that is a worse failure than `split_valid=false` (a writer
+lying in its own audit). FLAG `activity_split_audit_lied`.
+
+Pedagogical consequence to score against: INLINE activities that are too
+long/substantive (item count > 3, multi-paragraph rubrics) break their "fast
+theory check" purpose; WORKBOOK activities that are too trivial (single-item
+quizzes, no discrimination depth) break their drill purpose. Score the
+BALANCE-vs-PURPOSE not just the count.
+
+G. **Corpus-access audit (all dims).** The writer is gated to a level-specific
+corpus surface per the Corpus Access (level-gated) table in `linear-write.md`.
+Verify the writer did not cite out-of-level sources:
+
+- **a1/a2 textbook scope**: only Grades 1-4 (a1) or 1-5 (a2) source files
+  allowed in citations. A `Караман Grade 10` citation in an a1 module is OUT
+  OF SCOPE. FLAG `out_of_level_textbook`.
+- **a1/a2 literary scope**: only children's literature, folk songs,
+  fairy-tale openings, iconic phrases. A Stus / Khvylovy / Zabuzhko /
+  Pidmohylny quote in an a1/a2 module is a register break. FLAG
+  `out_of_level_literary`. (The curated-tag filter — F1 — is not yet built;
+  rely on author/work register judgment.)
+- **a1/a2 external scope**: only `ulp_blogs`, `ulp_youtube`,
+  `pohribnyi_pronunciation` from `search_external`. Citations from
+  `istoria_movy`, `realna_istoria`, `komik_istoryk`, `imtgsh`, `other_blogs`
+  at a1/a2 are out of scope. FLAG `out_of_level_external`.
+- **b1+/seminars**: full corpus allowed; only flag if the writer claims a
+  source NOT in our corpus at all (fabrication, separate failure class covered
+  by audits A-B).
+
+For ANY out-of-level citation, the quote may STILL be factually correct but the
+register/source choice is wrong for the learner level. Score this as
+PEDAGOGICAL evidence-against, not as a fabrication.
+
+H. **Student-aware audit (pedagogical, engagement, naturalness).** The writer
+is given a `{LEARNER_STATE}` block listing cumulative_vocabulary +
+known_grammar from prior modules. Verify the writer:
+
+1. **Did not re-explain already-taught grammar.** If the learner-state lists
+   "Genitive case endings -а/-я" as known_grammar and this module derives the
+   rule from scratch in 200+ words, FLAG `re_explained_known_grammar`. Brief
+   reference (`як ти бачив у модулі 7`) is fine; a full re-derivation is not.
+
+2. **Did not introduce unknown vocabulary without inline gloss.** Scan
+   `module.md` prose for Ukrainian content words. For any word that is (a) NOT
+   in cumulative_vocabulary, (b) NOT in this module's `vocabulary.yaml`, (c)
+   NOT a proper noun / Latin borrowing, and (d) NOT introduced with inline
+   italic gloss `*(translation)*`, FLAG `unknown_vocab_unscaffolded`.
+
+3. **Foreshadowing pattern visible.** If new lemmas appear in prose BEFORE
+   their `vocabulary.yaml` entry, they should carry inline gloss at first
+   mention. Absence of gloss on first mention = `missing_foreshadowing_gloss`.
+
+4. **Stacked vocab-level check evidence.** For non-plan lemmas the writer
+   introduced, check the `<plan_reasoning>` for `<vocab_level_check>` nodes.
+   Missing for a non-plan lemma = `unverified_vocab_introduction`.
+
+Pedagogical score: respecting the learner's prior knowledge is what makes the
+module BUILD instead of REPEAT. Naturalness score: scaffolded vocabulary
+introduction reads as a real teacher's voice; un-introduced vocab feels like a
+textbook dump.
+
+I. **Pre-emit audit-line integrity (all dims).** The writer is required to
+emit three machine-readable audit lines BEFORE the artifact fences, in order:
+
+1. `<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[...]</implementation_map_audit>`
+   (per #2094)
+2. `<bad_form_audit>italic_bad_form_patterns_found=N converted_to_marker=N remaining=0</bad_form_audit>`
+   (per #2095)
+3. `<activity_split_audit>level={LEVEL} inline_n=N workbook_n=N inline_range=[lo,hi] workbook_range=[lo,hi] split_valid=true|false</activity_split_audit>`
+   (per the just-merged Activity Types section)
+
+Verify ALL THREE lines are present, parseable, and report values consistent
+with the artifacts. Any missing line = the writer has failed the protocol;
+FLAG `audit_line_missing` with the missing line name. Any line whose claim
+doesn't match the artifacts = FLAG `audit_line_inconsistent`.
+
+These audits exist BECAUSE the writer is doing self-grading; the reviewer's
+job here is to cross-check that the self-grading matches reality. A green audit
+line on broken content is a more serious failure than a red audit line on
+broken content (the writer is lying to its own audit).
+
 Return only JSON:
 
 ```json
-{"score": 0.0, "evidence_quotes": ["verbatim quote 1", "verbatim quote 2", "verbatim quote 3"], "rubric_mapping": "Quote 1: ...; Quote 2: ...; Quote 3: ...", "evidence": "\"verbatim quote from evidence_quotes\"", "verdict": "REVISE"}
+{"score": 0.0, "evidence_quotes": ["verbatim quote 1", "verbatim quote 2", "verbatim quote 3"], "rubric_mapping": "Quote 1: ...; Quote 2: ...; Quote 3: ...", "evidence": "\"verbatim quote from evidence_quotes\"", "flags": ["activity_split_audit_missing", "out_of_level_literary", "..."], "verdict": "REVISE"}
 ```
+
+The `flags` array MUST contain any FLAG strings raised during audits A-I that
+apply to your assigned dim per the per-dim labeling in §"Scope". An empty array
+is fine when no flags fired. The pipeline aggregates flags across dims and
+surfaces them in the build telemetry; the writer's self-correction loop reads
+them to know what to fix on retry.
 
 ## Module Context
 


### PR DESCRIPTION
## Summary
- Adds Tier-1 reviewer audits F-I for activity split, corpus access, student-aware scaffolding, and pre-emit audit-line integrity.
- Wires the new audits into the per-dimension scope language so flags affect the right dim scores.
- Extends the reviewer JSON contract with a `flags` array for retry/build telemetry.

Mirrors the writer-side contract from PR #2214.

## Acceptance criteria raw output

```text
$ grep -c "^F\. \*\*Activity split audit" scripts/build/phases/linear-review-dim.md
1

$ grep -c "^G\. \*\*Corpus-access audit" scripts/build/phases/linear-review-dim.md
1

$ grep -c "^H\. \*\*Student-aware audit" scripts/build/phases/linear-review-dim.md
1

$ grep -c "^I\. \*\*Pre-emit audit-line integrity" scripts/build/phases/linear-review-dim.md
1

$ grep -c "activity_split_audit_missing\|activity_split_audit_lied" scripts/build/phases/linear-review-dim.md
3

$ grep -c "out_of_level_textbook\|out_of_level_literary\|out_of_level_external" scripts/build/phases/linear-review-dim.md
4

$ grep -c "unknown_vocab_unscaffolded\|missing_foreshadowing_gloss\|re_explained_known_grammar\|unverified_vocab_introduction" scripts/build/phases/linear-review-dim.md
4

$ grep -c "\"flags\":" scripts/build/phases/linear-review-dim.md
1

$ wc -l scripts/build/phases/linear-review-dim.md
258 scripts/build/phases/linear-review-dim.md

$ grep -c "{DIM}\|{LEVEL}\|{LEARNER_STATE}" scripts/build/phases/linear-review-dim.md
11
```

## Placeholder integrity raw output

```text
$ grep "{DIM}\|{LEVEL}\|{LEARNER_STATE}\|{IMMERSION_RULE}\|{CONTRACT_YAML}\|{PLAN_CONTENT}\|{MODULE_NUM}\|{MODULE_SLUG}\|{WORD_TARGET}\|{GENERATED_CONTENT}" scripts/build/phases/linear-review-dim.md
Assigned dimension: {DIM}
For `{DIM}` specifically:
   `{DIM}`.** Quote them verbatim — character-for-character strings that
   `{DIM}`** (see scope section above; deterministic checks already ran).
The JSON response MUST include `evidence_quotes` with 3 verbatim quotes from step 1 and `rubric_mapping` explaining how each quote maps to `{DIM}` before the score. The `evidence` field MUST be one of those verbatim quotes, wrapped in escaped quotes. A summary or paraphrase in any evidence field is a reviewer-protocol failure.
that touches dimension `{DIM}`. The audit feeds the evidence list above:
contracted to emit two complementary activity sets per `ACTIVITY_CONFIGS[{LEVEL}]`:
`<activity_split_audit>level={LEVEL} inline_n=N workbook_n=N inline_range=[lo,hi] workbook_range=[lo,hi] split_valid=true|false</activity_split_audit>`
is given a `{LEARNER_STATE}` block listing cumulative_vocabulary +
3. `<activity_split_audit>level={LEVEL} inline_n=N workbook_n=N inline_range=[lo,hi] workbook_range=[lo,hi] split_valid=true|false</activity_split_audit>`
- Level: {LEVEL}
- Module: {MODULE_NUM}
- Slug: {MODULE_SLUG}
- Word target: {WORD_TARGET}
{IMMERSION_RULE}
{CONTRACT_YAML}
{PLAN_CONTENT}
{GENERATED_CONTENT}
```

## Commit evidence raw output

```text
$ git log -1 --oneline
025a3839b7 feat(reviewer-prompt): activity-split + corpus-access + student-aware audits + flags array — mirrors writer-prompt rebuild from PR #2214
```

## Test plan

```text
$ git diff --check
```

`git diff --check` produced no output.

Next validation: run the next `a1/my-morning` build and confirm the per-dim reviewer flags activity-split, corpus-access, student-aware, and audit-line failures when the generated artifacts violate the new writer contract.
