### PR TITLE
chore(dependabot): raise cooldown default-days 5→7 to silence zizmor (#209-#211)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    # Wait 5 days after a new release before opening a PR — gives the
+    # Wait 7 days after a new release before opening a PR — gives the
     # upstream time to surface regressions and avoids burning CI on
-    # versions that get yanked. Closes zizmor dependabot-cooldown
-    # warnings (CodeQL alerts #185, #186, #187).
+    # versions that get yanked. zizmor/dependabot-cooldown requires
+    # default-days >= 7 (alerts #209-#211 raised the bar from 5).
     cooldown:
-      default-days: 5
+      default-days: 7
     commit-message:
       prefix: "ci"
     labels:
@@ -31,7 +31,7 @@ updates:
       interval: "weekly"
       day: "monday"
     cooldown:
-      default-days: 5
+      default-days: 7
     commit-message:
       prefix: "deps"
     labels:
@@ -46,7 +46,7 @@ updates:
       interval: "weekly"
       day: "monday"
     cooldown:
-      default-days: 5
+      default-days: 7
     commit-message:
       prefix: "deps"
     labels:


### PR DESCRIPTION
## Summary

- All 3 `updates:` entries in `.github/dependabot.yml` had `cooldown.default-days: 5`
- zizmor/dependabot-cooldown now requires `>= 7` ("insufficient default-days configured (less than 7)")
- Bumped all three to `7`; updated the leading comment block to reflect the new threshold + alert IDs
- No new cooldown shape (still flat `default-days`, no per-update-type matrix) — matches existing cadence; can refine later if a major-bump policy emerges

## Verifiable claims

| Claim | Command | Output line |
|---|---|---|
| Alert #209 message | `gh api repos/.../code-scanning/alerts/209 --jq '.most_recent_instance.message.text'` | `insufficient cooldown in Dependabot updates: insufficient default-days configured (less than 7)` |
| Alert #210 message | `gh api repos/.../code-scanning/alerts/210 --jq '.most_recent_instance.message.text'` | (same) |
| Alert #211 message | `gh api repos/.../code-scanning/alerts/211 --jq '.most_recent_instance.message.text'` | (same) |
| YAML parses | `python -c "import yaml; print(yaml.safe_load(open('.github/dependabot.yml'))['updates'][0]['cooldown'])"` | `{'default-days': 7}` |

## Closes

- CodeQL alerts #209, #210, #211 (all `zizmor/dependabot-cooldown`, all `note` severity)

## Test plan

- [ ] `Zizmor` workflow on this PR turns green
- [ ] Once merged + CodeQL re-analyses `main`, alerts #209-#211 auto-close (`state: fixed`)
- [ ] No regression: `Dependabot` still opens grouped GHA + individual npm/pip PRs on next Monday (just delayed 2 extra days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)