### PR TITLE
fix(activities_schema): make `id` optional to align with V7 INLINE/WORKBOOK split

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -360,7 +360,16 @@ WIKI_COVERAGE_NARROW_MAX_ITERATIONS = 2
 WIKI_COVERAGE_PATCHABLE_ARTIFACTS = frozenset({"module.md", "activities.yaml"})
 WIKI_COVERAGE_ARTIFACT_INFERENCE_ORDER = ("activities.yaml", "module.md")
 CORRECTION_YAML_ARTIFACT_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
-    "activities.yaml": ("id", "type"),
+    # NOTE: `id` is intentionally NOT required on activities.yaml entries —
+    # the V7 writer prompt (`scripts/build/phases/linear-write.md`, lines
+    # 700-701 as of PR #2214) specifies that WORKBOOK activities should
+    # OMIT `id`; only INLINE activities (those referenced from a
+    # `<!-- INJECT_ACTIVITY: act-N -->` marker in the prose) need a string
+    # id so the marker can resolve. The bidirectional consistency check
+    # lives in the `inject_activity_ids` content gate (not here). The
+    # deeper `_activity_schema_gate` likewise tolerates missing id (it
+    # falls back to `f"#{activity_index}"` for diagnostics).
+    "activities.yaml": ("type",),
     "vocabulary.yaml": ("lemma", "translation", "pos", "usage"),
     "resources.yaml": ("title", "role"),
 }
@@ -440,8 +449,18 @@ class JsonArtifactSchema:
 WRITER_JSON_SCHEMAS: dict[str, JsonArtifactSchema] = {
     "activities.yaml": JsonArtifactSchema(
         root_type=list,
+        # NOTE: `id` is intentionally NOT required here. The V7 writer prompt
+        # (`scripts/build/phases/linear-write.md`, lines 700-701 as of
+        # PR #2214) specifies that WORKBOOK activities should OMIT `id`;
+        # only INLINE activities (those targeted by
+        # `<!-- INJECT_ACTIVITY: act-N -->` markers in the lesson prose)
+        # need a string id so the marker can resolve. The bidirectional
+        # consistency check between INJECT markers and present ids lives
+        # in the `inject_activity_ids` content gate. `id` remains in
+        # `_UNIVERSAL_AUTHORING_FIELDS` so it is ALLOWED when present —
+        # just not required. Same rationale applied to
+        # `CORRECTION_YAML_ARTIFACT_REQUIRED_FIELDS["activities.yaml"]`.
         required_item_fields={
-            "id": str,
             "type": str,
         },
         # Polymorphic — per-activity-type allowed fields come from the

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1067,6 +1067,33 @@ def test_validate_writer_json_artifact_requires_type_for_polymorphic() -> None:
         )
 
 
+def test_validate_writer_json_artifact_allows_workbook_activity_without_id() -> None:
+    """V7 writer prompt design (linear-write.md L700-701, PR #2214) — WORKBOOK
+    activities deliberately omit `id`; only INLINE activities (those targeted
+    by `<!-- INJECT_ACTIVITY: act-N -->` markers in prose) need a string id.
+    The required-fields schema MUST allow id-less workbook entries through;
+    the bidirectional check lives in the `inject_activity_ids` content gate.
+
+    Regression for 2026-05-22 a1/my-morning build failure where the writer
+    correctly produced 4 inline + 6 workbook activities, schema rejected it
+    with `item 5 requires id as str, got NoneType (None)`.
+    """
+    activities = [
+        # Inline activities — id present per spec.
+        {"id": "act-1", "type": "match-up", "title": "Inline 1",
+         "pairs": [{"left": "a", "right": "b"}]},
+        {"id": "act-2", "type": "quiz", "title": "Inline 2",
+         "items": [{"question": "q?", "answer": "a", "options": ["a", "b"]}]},
+        # Workbook activities — id omitted per spec.
+        {"type": "fill-in", "title": "Workbook 1",
+         "items": [{"sentence": "I ___ here.", "answer": "live"}]},
+        {"type": "translate", "title": "Workbook 2",
+         "items": [{"source": "I wake up.", "target": "Я прокидаюся."}]},
+    ]
+    # MUST NOT raise — schema accepts the mixed inline+workbook payload.
+    linear_pipeline._validate_writer_json_artifact("activities.yaml", activities)
+
+
 def test_validate_writer_json_artifact_error_messages_include_actual_value() -> None:
     """Schema validation errors must include the actual value/type for redispatch.
 


### PR DESCRIPTION
## Summary

Two schema validators in `scripts/build/linear_pipeline.py` enforced `id: str (required)` on every activity, but the V7 writer prompt (PR #2214, `linear-write.md` L700-701) explicitly directs **WORKBOOK** activities to OMIT `id`. The contradiction crashed the 2026-05-22T15:50Z `a1/my-morning` refire build at writer-output validation, even though writer telemetry showed clean 4/4 sections with full CoT + 19 tool calls + end_gate fired + 0 tool theatre violations.

Fix removes `id` from both `required_item_fields` registries; `id` remains allowed via `_UNIVERSAL_AUTHORING_FIELDS` (so inline activities still validate cleanly). The deeper `_activity_schema_gate` already tolerated missing `id`.

## Why the writer prompt was right and the schema was wrong

INLINE activities reference an `id` via `<!-- INJECT_ACTIVITY: act-N -->` markers — those markers need string ids to resolve. WORKBOOK activities are aggregated in Tab 3 by index/order and don't need ids. The `inject_activity_ids` content gate enforces this bidirectional consistency for inline activities only; the schema layer should be the looser of the two. Aligns schema with the lesson-contract.md panel-confirmed INLINE/WORKBOOK split.

## Verifiable claims

| Claim | Command | Output |
|---|---|---|
| 125/126 pipeline tests pass | `.venv/bin/python -m pytest tests/build/test_linear_pipeline.py --tb=line -q` | `125 passed, 1 skipped in 4.32s` |
| New regression test catches the prior gap | `.venv/bin/python -m pytest tests/build/test_linear_pipeline.py::test_validate_writer_json_artifact_allows_workbook_activity_without_id -v` | `PASSED` |
| `id` still ALLOWED on inline activities | Same test — 2 of the 4 fixtures have `id: "act-1"`/`"act-2"` and validate cleanly | — |
| Schema-gate diagnostic message still works for missing id | `_activity_schema_gate` was already using `activity.get("id") or f"#{activity_index}"` — no change | unchanged |

## Test plan

- [x] All `_validate_writer_json_artifact*` tests pass (23/23)
- [x] All `_component_prop_gate` tests pass
- [x] All `_activity_schema_gate` tests pass
- [x] New regression test passes
- [ ] CI: `Test (pytest)` greens
- [ ] CI: blocking checks all green

## Discovery context

Found during the 2026-05-22 a1/my-morning refire which was supposed to validate the rebuilt writer (PR #2214) + reviewer (PR #2215) + promote (PR #2212) + learner_state (PR #2211) stack end-to-end. Writer did its job; schema was the next layer needing the same alignment update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)