### PR TITLE
fix(codex-adapter): disable shell_tool feature so V7 writers can't trip writer_trace_isolation

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -234,17 +234,37 @@ class CodexAdapter:
 
     @classmethod
     def _tool_config_flags(cls, tool_config: dict | None) -> list[str]:
-        """Translate supported tool_config keys into ``codex exec`` flags."""
+        """Translate supported tool_config keys into ``codex exec`` flags.
+
+        Supported keys:
+        - ``mcp_servers``: ``{"<name>": {"url": "...", ...}}`` →
+          ``-c mcp_servers.<name>.<field>=<value>`` overrides.
+        - ``disable_features``: ``list[str]`` of Codex feature-flag names
+          (per ``codex features list``) → ``--disable <name>`` per item.
+          Used by ``linear_pipeline._runtime_tool_config`` to enforce
+          writer tool-isolation: V7 writers may only call ``mcp__sources__*``
+          tools, so the Codex ``shell_tool`` feature (which surfaces the
+          ``exec_command`` shell tool) must be disabled before invocation
+          so the model can't reach for it and trip the
+          ``writer_trace_isolation`` gate with ``wrong_tool_family``
+          (failure observed 2026-05-22 a1-my-morning-20260522-181103:
+          18× ``exec_command`` calls vs. 22 valid ``mcp__sources__*``).
+        """
+        flags: list[str] = []
         if not tool_config:
-            return []
+            return flags
 
         mcp_servers = tool_config.get("mcp_servers")
-        if not isinstance(mcp_servers, dict):
-            return []
+        if isinstance(mcp_servers, dict):
+            for key, value in cls._flatten_config_overrides("mcp_servers", mcp_servers):
+                flags.extend(["-c", f"{key}={value}"])
 
-        flags: list[str] = []
-        for key, value in cls._flatten_config_overrides("mcp_servers", mcp_servers):
-            flags.extend(["-c", f"{key}={value}"])
+        disable_features = tool_config.get("disable_features")
+        if isinstance(disable_features, (list, tuple)):
+            for feature in disable_features:
+                if isinstance(feature, str) and feature:
+                    flags.extend(["--disable", feature])
+
         return flags
 
     @classmethod

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -2732,10 +2732,21 @@ def _runtime_tool_config(
 
     from scripts.agent_runtime.tool_config import _load_mcp_config, build_mcp_tool_config
 
+    codex_disable_features: list[str] = []
     if agent_label == "codex-tools":
         agent_kwargs = {
             "mcp_servers": ["sources"],
         }
+        # V7 writer tool-isolation: Codex's built-in `shell_tool` surfaces
+        # the `exec_command` shell. The writer must only call
+        # `mcp__sources__*` — anything else trips the
+        # `writer_trace_isolation` gate with `wrong_tool_family`.
+        # Disable the feature at CLI invocation so the model can't reach
+        # for it. Observed failure: a1-my-morning-20260522-181103 ran
+        # 18× exec_command vs. 22 valid MCP calls; gate fired TERMINAL
+        # before python_qg. See `scripts/agent_runtime/adapters/codex.py::
+        # _tool_config_flags` for the flag mapping.
+        codex_disable_features = ["shell_tool"]
     elif agent_label == "claude-tools":
         agent_kwargs = {
             "mcp_servers": ["sources"],
@@ -2778,6 +2789,8 @@ def _runtime_tool_config(
         )
     if mcp_dict:
         tool_config.update(mcp_dict)
+    if codex_disable_features:
+        tool_config["disable_features"] = codex_disable_features
     if agent_label == "claude-tools":
         tool_config["agent"] = "curriculum-writer"
     assert tool_config.get("output_format") == "stream-json", (

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -475,6 +475,84 @@ def test_codex_adapter_mcp_tool_config_multiple(tmp_path):
     assert "mcp_servers.other.enabled=true" in config_values
 
 
+def test_codex_adapter_disable_features_emits_flags(tmp_path):
+    """tool_config['disable_features'] must map to one --disable <name> per item.
+
+    Used by V7 writer tool-isolation: the pipeline sets
+    ``disable_features=["shell_tool"]`` so Codex's ``exec_command`` shell
+    tool isn't surfaced — without this the writer trips
+    ``writer_trace_isolation`` with ``wrong_tool_family``
+    (observed 2026-05-22 a1-my-morning-20260522-181103: 18× exec_command).
+    """
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={
+            "mcp_servers": {"sources": {"url": "http://127.0.0.1:8766/sse"}},
+            "disable_features": ["shell_tool"],
+        },
+    )
+    assert "--disable" in plan.cmd
+    disable_idx = plan.cmd.index("--disable")
+    assert plan.cmd[disable_idx + 1] == "shell_tool"
+    # Both flags coexist with MCP override.
+    config_values = [
+        plan.cmd[index + 1]
+        for index, token in enumerate(plan.cmd[:-1])
+        if token == "-c"
+    ]
+    assert 'mcp_servers.sources.url="http://127.0.0.1:8766/sse"' in config_values
+
+
+def test_codex_adapter_disable_features_multiple(tmp_path):
+    """Multiple disable_features entries each emit a separate --disable pair."""
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={
+            "disable_features": ["shell_tool", "browser_use"],
+        },
+    )
+    disable_pairs = [
+        plan.cmd[index + 1]
+        for index, token in enumerate(plan.cmd[:-1])
+        if token == "--disable"
+    ]
+    assert disable_pairs == ["shell_tool", "browser_use"]
+
+
+def test_codex_adapter_disable_features_ignores_non_string_entries(tmp_path):
+    """Defensive: non-string entries (None, ints) must be dropped silently."""
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={
+            "disable_features": ["shell_tool", None, 0, "", "browser_use"],
+        },
+    )
+    disable_pairs = [
+        plan.cmd[index + 1]
+        for index, token in enumerate(plan.cmd[:-1])
+        if token == "--disable"
+    ]
+    assert disable_pairs == ["shell_tool", "browser_use"]
+
+
 def test_codex_adapter_ignores_unknown_tool_config_keys(tmp_path):
     """Forward compatibility: unknown Codex tool_config keys stay local."""
     adapter = CodexAdapter()

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -202,6 +202,48 @@ def test_runtime_tool_config_emits_resolution_event_success(
     assert events[0][1]["resolved_servers"] == ["sources"]
 
 
+def test_runtime_tool_config_codex_tools_disables_shell_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """V7 codex-tools writer must disable Codex's ``shell_tool`` feature.
+
+    Failure observed 2026-05-22 a1-my-morning-20260522-181103: the writer
+    called ``exec_command`` (surfaced by ``shell_tool``) 18× and tripped
+    the ``writer_trace_isolation`` gate with ``wrong_tool_family``
+    BEFORE python_qg ran. The fix surfaces the disable at CLI
+    invocation time via ``tool_config["disable_features"]``.
+
+    Defense-in-depth: also applies when codex-tools is invoked as the
+    reviewer — reviewers should also only call ``mcp__sources__*``.
+    """
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+
+    config = linear_pipeline._runtime_tool_config("codex-tools")
+
+    assert config.get("disable_features") == ["shell_tool"]
+
+
+def test_runtime_tool_config_non_codex_tools_no_disable_features(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-codex writers must NOT inherit the codex-specific disable.
+
+    The ``disable_features`` flag is a Codex CLI feature; other adapters
+    don't understand the key. The pipeline emits it only for codex-tools.
+    """
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+
+    for agent in ("claude-tools", "gemini-tools", "grok-tools", "deepseek-tools"):
+        config = linear_pipeline._runtime_tool_config(agent)
+        assert "disable_features" not in config, (
+            f"{agent} unexpectedly carries disable_features={config.get('disable_features')!r}"
+        )
+
+
 def test_wiki_review_codex_emits_resolution_event(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Unblocks the V7 codex-tools writer by disabling Codex's `shell_tool` feature at CLI invocation time so the model can't reach for `exec_command`. Without this, the writer trips the `writer_trace_isolation` gate with `wrong_tool_family` and the build fails TERMINAL before `python_qg` ever runs.

## Background

The 2026-05-22 night handoff (PR #2221 §3) identified codex-tools as showing the most aggressive corpus use of any tested V7 writer — it hit the `resources_search_attempted` HARD gate organically — but couldn't complete because of one CLI flag. Build trace (`.worktrees/builds/a1-my-morning-20260522-181103/curriculum/l2-uk-en/a1/my-morning/writer_tool_calls.json`):

| Tool | Count |
|---|---|
| `exec_command` (shell_tool) | 18 |
| `mcp__sources__query_cefr_level` | 8 |
| `mcp__sources__check_russian_shadow` | 3 |
| `mcp__sources__search_text` | 2 |
| `mcp__sources__search_external` | 2 |
| `mcp__sources__get_chunk_context` | 2 |
| `mcp__sources__verify_words` | 2 |
| `mcp__sources__search_style_guide` | 1 |
| `mcp__sources__verify_source_attribution` | 1 |
| `mcp__sources__search_ua_gec_errors` | 1 |
| **Total** | **40** (18 invalid + 22 valid) |

Per `linear_pipeline.py::WRITER_ALLOWED_TOOL_PREFIXES`, only `mcp__sources__*` and `mcp_sources_*` are allowed in writer traces; anything else trips `wrong_tool_family`. The 18 `exec_command` calls came from Codex's built-in shell, which is exposed via the `shell_tool` feature (per `codex features list`).

## Changes

1. **`CodexAdapter._tool_config_flags`** accepts a new `disable_features: list[str]` key. Each item maps to `--disable <feature>` per `codex --help`. Coexists with the existing `mcp_servers` flow. Non-string entries (`None`, ints) are dropped silently for robustness.

2. **`linear_pipeline._runtime_tool_config`** sets `disable_features=["shell_tool"]` for `agent_label == "codex-tools"`. Applies to both writer and reviewer paths — defense-in-depth, since reviewers should also only call `mcp__sources__*` audit tools.

3. **Five new tests** (3 adapter + 2 pipeline) verify the wiring, the multi-feature case, the non-string-defensive case, and that non-codex writers don't inadvertently inherit a flag they don't understand.

## Verifiable claims

| Claim | Command | Output |
|---|---|---|
| Codex CLI 0.133.0 supports `--disable <feature>` | `codex --help \| grep disable` | `--disable <FEATURE>  Disable a feature (repeatable). Equivalent to \`-c features.<name>=false\`` |
| `shell_tool` is the right feature name | `codex features list \| grep shell_tool` | `shell_tool                              stable             true` |
| Failed writer trace was 18 × exec_command | `python -c "..." (see Counter above)` | shown in table |
| All affected tests pass | `.venv/bin/python -m pytest tests/test_agent_runtime.py tests/test_mcp_init_observability.py -q` | `169 passed in 26.56s` |
| Ruff clean on changed files | `.venv/bin/ruff check scripts/agent_runtime/adapters/codex.py scripts/build/linear_pipeline.py tests/test_agent_runtime.py tests/test_mcp_init_observability.py` | `All checks passed!` |

## Test plan

- [ ] CI green (pytest, ruff, frontend, schema-drift, gitleaks, radon, zizmor)
- [ ] After merge: refire `a1/my-morning` with `--writer codex-tools --model gpt-5.5 --effort xhigh --worktree` and verify `writer_trace_isolation` passes (no `exec_command` in `writer_tool_calls.json`)
- [ ] If `python_qg` also passes, codex-tools is the V7 writer-bench anchor (per PR #2221 §2.1)

## Out-of-scope

- Other potentially-exec-capable Codex features (`browser_use`, `computer_use`, `unified_exec`) — not observed in the failed trace, leaving them enabled until evidence accumulates. The gate catches them post-hoc as defense-in-depth if any surface.
- Writer-bench implementation itself (PR #2221 §2; depends on this PR landing first).
- Reviewer-side `reviewer_trace_isolation` gate (doesn't exist yet; the disable already applies to reviewer invocations as side-effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)