### PR TITLE
fix(writer-isolation): allow CODEX_HOME thru sanitizer + reorder codex flags + demote wrong_tool_family to WARN

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -24,6 +24,7 @@ Key design points:
 
 Issue: #1184
 """
+
 from __future__ import annotations
 
 import json as _json
@@ -69,8 +70,7 @@ _DISCUSS_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
 def _discussion_readonly_requested(tool_config: dict | None) -> bool:
     """Return True when the caller is an ab discuss read-only invocation."""
     return bool(
-        os.environ.get("AB_DISCUSS_READONLY") == "1"
-        or (tool_config or {}).get(_DISCUSS_READONLY_TOOL_CONFIG_KEY)
+        os.environ.get("AB_DISCUSS_READONLY") == "1" or (tool_config or {}).get(_DISCUSS_READONLY_TOOL_CONFIG_KEY)
     )
 
 
@@ -122,7 +122,7 @@ def _strip_codex_prompt_echo(stderr: str) -> str:
     if last_divider is None:
         # No dividers — return as-is. Likely a very early crash.
         return stderr
-    return stderr[last_divider.end():]
+    return stderr[last_divider.end() :]
 
 
 class CodexAdapter:
@@ -173,8 +173,7 @@ class CodexAdapter:
         max_budget_usd = (tool_config or {}).get("max_budget_usd")
         if max_budget_usd is not None:
             _logger.warning(
-                "non-claude adapter %s ignoring max_budget_usd=%s; "
-                "use hard-timeout/silence-timeout instead",
+                "non-claude adapter %s ignoring max_budget_usd=%s; use hard-timeout/silence-timeout instead",
                 self.name,
                 max_budget_usd,
             )
@@ -207,18 +206,33 @@ class CodexAdapter:
         cmd: list[str] = [codex_bin, "exec"]
         if has_session_to_resume:
             cmd.append("resume")
-        cmd.extend(self._tool_config_flags(tool_config))
         if effort is not None:
             # Per-invocation override of ~/.codex/config.toml (#1396).
             cmd.extend(["-c", f"model_reasoning_effort={effort}"])
-        cmd.extend([
-            "--skip-git-repo-check",
-            "-C", str(cwd),
-            "--color", "never",
-            "-o", str(output_path),
-            "-m", model or self.default_model,
-        ])
+        cmd.extend(
+            [
+                "--skip-git-repo-check",
+                "-C",
+                str(cwd),
+                "--color",
+                "never",
+                "-o",
+                str(output_path),
+                "-m",
+                model or self.default_model,
+            ]
+        )
+        # ``_mode_flags`` emits ``--enable multi_agent`` for non-read-only
+        # modes (matches start-codex.sh). ``_tool_config_flags`` emits the
+        # writer-isolation ``--disable shell_tool / goals / browser_use /
+        # in_app_browser / image_generation / apps / plugins / multi_agent``
+        # list. ORDER MATTERS: Codex CLI processes ``--enable`` and
+        # ``--disable`` as ordered toggles, so the disable list MUST come
+        # after the enable to actually suppress ``multi_agent``. The 2026-05-22
+        # ab ask-codex `codex-node-repl-leak-2026-05-22` diagnosis flagged
+        # this ordering as a secondary leak path (see PR #2230 follow-up).
         cmd.extend(self._mode_flags(mode))
+        cmd.extend(self._tool_config_flags(tool_config))
         if has_session_to_resume:
             cmd.append(session_id)
         cmd.append("-")  # Read prompt from stdin.
@@ -361,14 +375,11 @@ class CodexAdapter:
         rollout_source_note: str | None = None
         if not file_output and plan is not None:
             rollout_response = self._read_latest_rollout_task_complete(
-                plan, call_start_time=call_start_time,
+                plan,
+                call_start_time=call_start_time,
             )
             if rollout_response:
-                reason = (
-                    "rc=0 but -o empty (post-completion hang)"
-                    if returncode == 0
-                    else f"rc={returncode}, -o empty"
-                )
+                reason = "rc=0 but -o empty (post-completion hang)" if returncode == 0 else f"rc={returncode}, -o empty"
                 rollout_source_note = (
                     f"recovered {len(rollout_response)} chars from "
                     f"~/.codex/sessions/.../rollout-*.jsonl (reason: {reason})"
@@ -416,9 +427,7 @@ class CodexAdapter:
             rate_limited = False
         else:
             stderr_for_check = _strip_codex_prompt_echo(stderr)
-            combined_for_rl_check = "\n".join(
-                part for part in (stdout, stderr_for_check, durable_output) if part
-            )
+            combined_for_rl_check = "\n".join(part for part in (stdout, stderr_for_check, durable_output) if part)
             pattern_hit = bool(_RATE_LIMIT_RE.search(combined_for_rl_check))
             # Call failed if neither -o nor rollout gave us content.
             call_failed = returncode != 0 or not durable_output
@@ -509,6 +518,7 @@ class CodexAdapter:
            rollout file's mtime and only re-scan when it advances.
         """
         import time as _time
+
         now = _time.monotonic()
 
         # Guard 1: warmup window.
@@ -523,10 +533,10 @@ class CodexAdapter:
 
         # Guard 3: mtime gate — quick stat instead of a full file scan.
         from datetime import UTC, datetime
+
         today = datetime.now(UTC)
         sessions_today = (
-            Path.home() / ".codex" / "sessions"
-            / f"{today.year:04d}" / f"{today.month:02d}" / f"{today.day:02d}"
+            Path.home() / ".codex" / "sessions" / f"{today.year:04d}" / f"{today.month:02d}" / f"{today.day:02d}"
         )
         try:
             if not sessions_today.exists():
@@ -548,7 +558,8 @@ class CodexAdapter:
 
         # All guards passed — do the actual scan.
         msg = self._read_latest_rollout_task_complete(
-            plan, call_start_time=call_start_time,
+            plan,
+            call_start_time=call_start_time,
         )
         return bool(msg)
 
@@ -564,6 +575,7 @@ class CodexAdapter:
         day directory rolls over. Codex 2026-04-10 audit finding.
         """
         from datetime import UTC, datetime, timedelta
+
         base = Path.home() / ".codex" / "sessions"
         dirs: list[Path] = []
         for delta in (0, 1):
@@ -823,10 +835,7 @@ class CodexAdapter:
         # Today's sessions directory (catches startup via dir mtime
         # bump, but does NOT track subsequent content writes).
         today = datetime.now(UTC)
-        sessions_today = (
-            codex_home / "sessions" / f"{today.year:04d}"
-            / f"{today.month:02d}" / f"{today.day:02d}"
-        )
+        sessions_today = codex_home / "sessions" / f"{today.year:04d}" / f"{today.month:02d}" / f"{today.day:02d}"
         if sessions_today.exists():
             paths.append(sessions_today)
 

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -4,6 +4,7 @@ Agent CLIs can run shell commands and inspect ``os.environ`` directly. The
 runtime should therefore pass only ordinary process context plus the credential
 for the provider being invoked, not the full orchestrator environment.
 """
+
 from __future__ import annotations
 
 import os
@@ -70,6 +71,19 @@ _PROVIDER_SECRET_ALLOWLIST = {
 _PROVIDER_SAFE_NAME_ALLOWLIST = {
     "gemini": {
         "GEMINI_AUTH_MODE",
+    },
+    # CODEX_HOME must reach the codex subprocess so the V7 writer's
+    # scoped config (materialized by
+    # `linear_pipeline._ensure_codex_writer_home`) actually takes
+    # effect. Without this allowlist entry the sanitizer dropped the
+    # `env_overrides["CODEX_HOME"]` set by the codex adapter, the
+    # subprocess fell back to `~/.codex/config.toml`, and writers
+    # discovered the user's globally-registered MCP servers (e.g.
+    # `mcp__node_repl__js`) — see writer-isolation #2228 / #2230 +
+    # the 2026-05-22 ab ask-codex `codex-node-repl-leak-2026-05-22`
+    # diagnosis.
+    "codex": {
+        "CODEX_HOME",
     },
 }
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -2117,15 +2117,26 @@ def classify_writer_trace(
 
     failures: list[FailureRecord] = []
     if wrong_family_calls:
+        # Demoted from TERMINAL → WARN on 2026-05-22 (user direction:
+        # "i dont care how they do it as long as they do it" — quality is
+        # judged by python_qg / wiki_coverage / llm_qg, not by tool-family
+        # cosmetics). The 2026-05-22 codex-tools build that surfaced this
+        # used `mcp__node_repl__js` to spawn `rg` and `sed` against the
+        # worktree's own scripts/ — resourceful self-correction behavior
+        # that the prior TERMINAL framing punished. The companion
+        # `handoff_or_orchestrator_file` check below remains TERMINAL
+        # because reading session-state into curriculum content IS a
+        # content-quality concern (orchestrator decisions leaking into
+        # learner-facing material), distinct from tool-choice surface.
         failures.append(
             FailureRecord(
                 failure_class=FailureClass.INFRA_CONTEXT_CONTAMINATION,
                 sub_class="wrong_tool_family",
                 gate="writer_trace_isolation",
-                severity="TERMINAL",
+                severity="WARN",
                 recovery_action="none",
                 evidence={"offending_tool_calls": wrong_family_calls},
-                terminal=True,
+                terminal=False,
             )
         )
     if handoff_reads:
@@ -2617,6 +2628,16 @@ def _enforce_writer_runtime_gates(
     if not failures:
         return
 
+    # Emit ALL failures (including WARN) for telemetry / forensics — but
+    # only raise on TERMINAL ones. The writer_trace_isolation
+    # `wrong_tool_family` record is WARN since 2026-05-22: a writer
+    # reaching for a non-sources tool is observed and logged, but does
+    # not kill the build — python_qg / wiki_coverage / llm_qg judge
+    # quality, not tool-family cosmetics. TERMINAL conditions
+    # (`handoff_or_orchestrator_file`, `mcp_tools_never_invoked`) still
+    # halt the build because they represent content-leakage or
+    # zero-corpus-grounding states that python_qg cannot recover from
+    # downstream.
     for record in failures:
         _emit(
             event_sink,
@@ -2626,10 +2647,14 @@ def _enforce_writer_runtime_gates(
             **_failure_record_to_event(record),
         )
 
+    terminal_failures = [record for record in failures if record.terminal]
+    if not terminal_failures:
+        return
+
     classes = ", ".join(
         f"{record.failure_class.value}"
         + (f":{record.sub_class}" if record.sub_class else "")
-        for record in failures
+        for record in terminal_failures
     )
     raise LinearPipelineError(
         f"WRITER_RUNTIME_GATE_FAILED: writer={writer!r} module={module!r} "

--- a/tests/test_writer_isolation.py
+++ b/tests/test_writer_isolation.py
@@ -25,9 +25,7 @@ def _failure_subclasses(records: list) -> set[str | None]:
 
 def test_classify_1944_incident_as_infra_context_contamination() -> None:
     trace = json.loads(
-        (REPO_ROOT / "audit/incidents/2026-05-13-1944-writer-tool-calls.json").read_text(
-            encoding="utf-8"
-        )
+        (REPO_ROOT / "audit/incidents/2026-05-13-1944-writer-tool-calls.json").read_text(encoding="utf-8")
     )
 
     records = classify_writer_trace(trace)
@@ -35,11 +33,17 @@ def test_classify_1944_incident_as_infra_context_contamination() -> None:
     assert {
         FailureClass.INFRA_CONTEXT_CONTAMINATION,
     } == {record.failure_class for record in records}
-    assert {"wrong_tool_family", "handoff_or_orchestrator_file"} <= _failure_subclasses(
-        records
-    )
-    assert all(record.severity == "TERMINAL" for record in records)
-    assert all(record.terminal is True for record in records)
+    assert {"wrong_tool_family", "handoff_or_orchestrator_file"} <= _failure_subclasses(records)
+    # Per-subclass severity since 2026-05-22 (see classify_writer_trace
+    # comment): `wrong_tool_family` is WARN/non-terminal (tool-family
+    # choice doesn't kill the build; quality gates downstream judge);
+    # `handoff_or_orchestrator_file` stays TERMINAL because session-state
+    # reads contaminate curriculum content.
+    by_sub = {record.sub_class: record for record in records}
+    assert by_sub["wrong_tool_family"].severity == "WARN"
+    assert by_sub["wrong_tool_family"].terminal is False
+    assert by_sub["handoff_or_orchestrator_file"].severity == "TERMINAL"
+    assert by_sub["handoff_or_orchestrator_file"].terminal is True
 
 
 def test_pure_mcp_writer_passes_isolation() -> None:
@@ -97,11 +101,7 @@ def test_gemini_dangerous_builtins_still_fail_isolation() -> None:
     )
 
     assert "wrong_tool_family" in _failure_subclasses(records)
-    offending = {
-        entry["name"]
-        for record in records
-        for entry in record.evidence.get("offending_tool_calls", [])
-    }
+    offending = {entry["name"] for record in records for entry in record.evidence.get("offending_tool_calls", [])}
     assert "run_shell_command" in offending
 
 
@@ -170,9 +170,7 @@ def test_writer_reads_handoff_fails_isolation() -> None:
         ]
     )
 
-    assert {"wrong_tool_family", "handoff_or_orchestrator_file"} <= _failure_subclasses(
-        records
-    )
+    assert {"wrong_tool_family", "handoff_or_orchestrator_file"} <= _failure_subclasses(records)
 
 
 def test_writer_runtime_gate_reports_contamination_and_zero_mcp() -> None:
@@ -189,9 +187,14 @@ def test_writer_runtime_gate_reports_contamination_and_zero_mcp() -> None:
             ],
         )
 
+    # Since 2026-05-22 `wrong_tool_family` is WARN/non-terminal, so the
+    # raise message only lists TERMINAL failures — here that's
+    # `mcp_tools_never_invoked`. Both classes still emit
+    # `writer_failure_class` events (telemetry), the assertions below
+    # cover that.
     with pytest.raises(
         linear_pipeline.LinearPipelineError,
-        match=r"infra_context_contamination:wrong_tool_family.*mcp_tools_never_invoked",
+        match=r"mcp_tools_never_invoked",
     ):
         linear_pipeline.invoke_writer(
             "Write the module.",
@@ -202,9 +205,7 @@ def test_writer_runtime_gate_reports_contamination_and_zero_mcp() -> None:
             event_sink=lambda event, **fields: events.append({"event": event, **fields}),
         )
 
-    failure_events = [
-        event for event in events if event["event"] == "writer_failure_class"
-    ]
+    failure_events = [event for event in events if event["event"] == "writer_failure_class"]
     assert [event["failure_class"] for event in failure_events] == [
         "infra_context_contamination",
         "mcp_tools_never_invoked",
@@ -257,9 +258,11 @@ def test_claude_subprocess_argv_contains_allowed_tools(
     # argv assembly + adapter parse, not about the spawn mechanism.
     monkeypatch.setenv("DELEGATE_DISABLE_PTY", "1")
 
-    with patch("scripts.agent_runtime.runner.has_headroom", return_value=(True, "")), patch(
-        "scripts.agent_runtime.runner.write_record"
-    ), patch("scripts.agent_runtime.runner.subprocess.Popen", side_effect=fake_popen):
+    with (
+        patch("scripts.agent_runtime.runner.has_headroom", return_value=(True, "")),
+        patch("scripts.agent_runtime.runner.write_record"),
+        patch("scripts.agent_runtime.runner.subprocess.Popen", side_effect=fake_popen),
+    ):
         result = invoke(
             "claude",
             "Write the module.",


### PR DESCRIPTION
## Summary

- **`env_sanitize.py`**: Allowlist `CODEX_HOME` for codex provider — without this, PR #2230's scoped-tempdir `env_overrides["CODEX_HOME"]` was silently dropped before `Popen`, so the writer fell back to the user's real `~/.codex/config.toml` and discovered globally-registered MCP servers (`mcp__node_repl__js`) regardless of the scope. Diagnosed via `ab ask-codex codex-node-repl-leak-2026-05-22` (msg 1072).
- **`adapters/codex.py`**: Reorder `_tool_config_flags` to fire AFTER `_mode_flags` so `--disable multi_agent` wins over `--enable multi_agent`. Codex CLI processes enable/disable as ordered toggles; previous ordering silently re-enabled `multi_agent`.
- **`linear_pipeline.py` policy correction**: Demote `writer_trace_isolation:wrong_tool_family` from TERMINAL → WARN per user direction: *"i dont care how they do it as long as they do it"* — quality is judged by `python_qg` / `wiki_coverage` / `llm_qg`, not by tool-family cosmetics. The 2026-05-22 codex build used `mcp__node_repl__js` to spawn `rg` and `sed` against the worktree's own scripts/ for self-correction — resourceful behavior the prior framing punished. Companion `handoff_or_orchestrator_file` stays TERMINAL (session-state reads ARE content-quality issue).

Runtime gate now emits ALL failures (including WARN) for telemetry, but only raises on TERMINAL. `mcp_tools_never_invoked` still halts builds because zero corpus grounding can't be recovered downstream.

## Test plan
- [x] `tests/test_writer_isolation.py` — 9 tests pass (updated `test_classify_1944_incident` for per-subclass severity; relaxed `test_writer_runtime_gate_reports_contamination_and_zero_mcp` regex to TERMINAL-only)
- [x] `tests/test_env_sanitize.py` — 4 tests pass
- [x] `tests/test_agent_runtime.py` — 116 tests pass
- [x] `tests/test_mcp_init_observability.py` — 33 tests pass
- [x] `tests/test_agent_runtime_tool_calls.py` — 3 tests pass
- [x] Total: 188 tests, all green
- [ ] CI green
- [ ] Post-merge: refire `a1/my-morning --writer codex-tools --worktree` to validate writer reaches python_qg (writer was 36 mcp__sources__* calls + 7 node_repl calls — gate now WARN; should proceed to quality gates)

Closes #2228 follow-up (issue stays closed; this is the piece PR #2230 didn't fully cover per Codex's 2026-05-22 diagnosis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)