### PR TITLE
fix(codex-adapter): honor scoped CODEX_HOME for rollout discovery

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -132,6 +132,12 @@ class CodexAdapter:
     default_model: str = "gpt-5.5"
     supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
 
+    # Per-invocation scoped $CODEX_HOME path. Set by ``build_invocation``
+    # from ``tool_config["codex_home_override"]`` (V7 writer); read by
+    # ``_candidate_rollout_dirs`` so the post-call rollout scan looks in
+    # the scoped sessions/ dir, not the user's real ``~/.codex/sessions/``.
+    _codex_home_scope: str | None = None
+
     def build_invocation(
         self,
         *,
@@ -160,6 +166,20 @@ class CodexAdapter:
         Codex falls through to the config default (currently ``high``).
         See #1396.
         """
+        # Per-invocation scoped $CODEX_HOME (set by V7 writer via
+        # ``tool_config["codex_home_override"]``). Stored on the
+        # adapter BEFORE ``_reset_per_invocation_state`` so that the
+        # rollout-snapshot it triggers scans the correct sessions/
+        # directory (the scoped one, not the user's real
+        # ``~/.codex/sessions/``). Without this ordering the snapshot
+        # would record an empty set, and post-call rollout discovery
+        # would treat real rollouts as "already-existing" and skip
+        # them. Empirical reference: failed build
+        # a1-my-morning-20260522-205831 — codex wrote 38 valid MCP
+        # calls into ``$TMPDIR/codex-v7-writer-501/sessions/...``, the
+        # adapter scanned ``~/.codex/sessions/`` and saw 0.
+        self._codex_home_scope = (tool_config or {}).get("codex_home_override")
+
         # Reset per-invocation state so _read_latest_rollout_task_complete
         # uses a fresh rollout snapshot (prevents cross-contamination
         # between consecutive calls on the same adapter instance).
@@ -573,10 +593,36 @@ class CodexAdapter:
         Yesterday is included so a call that starts at 23:59 UTC and
         finishes at 00:01 UTC doesn't miss its own rollout when the
         day directory rolls over. Codex 2026-04-10 audit finding.
+
+        Honors the per-invocation scoped ``$CODEX_HOME`` so the V7
+        writer's scoped-tempdir rollouts (materialized by
+        ``linear_pipeline._ensure_codex_writer_home`` and passed via
+        ``tool_config["codex_home_override"]``) are discovered
+        correctly. Without this, the adapter scanned
+        ``~/.codex/sessions/`` while the subprocess wrote rollouts
+        under the scoped home — the codex-tools writer phase appeared
+        to make zero MCP calls (no rollout found → empty tool_calls
+        → ``mcp_tools_never_invoked`` fires) even though 38+ valid
+        ``mcp__sources__*`` calls were actually recorded. Empirical
+        reference: failed build ``a1-my-morning-20260522-205831``,
+        rollout at
+        ``$TMPDIR/codex-v7-writer-501/sessions/2026/05/22/...``.
+
+        Resolution order:
+        1. ``self._codex_home_scope`` — set at ``build_invocation``
+           time from ``tool_config["codex_home_override"]``.
+        2. ``os.environ["CODEX_HOME"]`` — for the (rare) case where
+           the orchestrator itself exports CODEX_HOME.
+        3. ``~/.codex/sessions/`` — legacy default.
         """
         from datetime import UTC, datetime, timedelta
 
-        base = Path.home() / ".codex" / "sessions"
+        scope = getattr(self, "_codex_home_scope", None)
+        if scope:
+            base = Path(scope) / "sessions"
+        else:
+            codex_home_env = os.environ.get("CODEX_HOME")
+            base = Path(codex_home_env) / "sessions" if codex_home_env else Path.home() / ".codex" / "sessions"
         dirs: list[Path] = []
         for delta in (0, 1):
             d = datetime.now(UTC) - timedelta(days=delta)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -942,6 +942,64 @@ def test_codex_check_early_reap_ignores_preexisting_rollouts(
     assert adapter.check_early_reap(plan, call_start_time=call_start) is False
 
 
+def test_codex_candidate_rollout_dirs_honors_codex_home_override(
+    tmp_path, monkeypatch
+):
+    """Regression pin: the V7 writer's scoped CODEX_HOME (passed via
+    ``tool_config["codex_home_override"]``) must be honored for
+    rollout discovery. Without this, the adapter scans
+    ``~/.codex/sessions/`` while the subprocess writes rollouts under
+    the scoped home — the writer phase appears to make zero MCP calls
+    (no rollout found → empty tool_calls → ``mcp_tools_never_invoked``
+    fires). Empirical reference: failed build
+    ``a1-my-morning-20260522-205831`` (38 valid sources.* calls
+    written to scoped sessions/; adapter saw 0 because it scanned
+    user home).
+    """
+    from datetime import UTC, datetime
+
+    # User's real ~/.codex/ — explicitly should NOT be scanned when scope is set.
+    fake_user_home = tmp_path / "user_home"
+    fake_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_user_home))
+    today = datetime.now(UTC)
+    user_sessions = (
+        fake_user_home
+        / ".codex"
+        / "sessions"
+        / f"{today.year:04d}"
+        / f"{today.month:02d}"
+        / f"{today.day:02d}"
+    )
+    user_sessions.mkdir(parents=True)
+    (user_sessions / "rollout-user-home.jsonl").write_text("{}\n")
+
+    # Scoped CODEX_HOME (per linear_pipeline._ensure_codex_writer_home).
+    scoped_home = tmp_path / "scoped_codex_home"
+    scoped_sessions = (
+        scoped_home
+        / "sessions"
+        / f"{today.year:04d}"
+        / f"{today.month:02d}"
+        / f"{today.day:02d}"
+    )
+    scoped_sessions.mkdir(parents=True)
+    (scoped_sessions / "rollout-scoped.jsonl").write_text("{}\n")
+
+    adapter = CodexAdapter()
+    # Without scope, the adapter scans user home.
+    adapter._codex_home_scope = None
+    dirs_unscoped = adapter._candidate_rollout_dirs()
+    assert user_sessions in dirs_unscoped
+    assert scoped_sessions not in dirs_unscoped
+
+    # With scope, the adapter scans the scoped sessions/ dir instead.
+    adapter._codex_home_scope = str(scoped_home)
+    dirs_scoped = adapter._candidate_rollout_dirs()
+    assert scoped_sessions in dirs_scoped
+    assert user_sessions not in dirs_scoped
+
+
 def test_codex_check_early_reap_skips_within_warmup_window(tmp_path, monkeypatch):
     """Early reap must NOT fire within the first 5 seconds of a call,
     even if a stale rollout from a previous run has a task_complete.


### PR DESCRIPTION
## Summary

Follow-up to PR #2232. The env_sanitize fix from #2232 finally got `CODEX_HOME` to reach the codex subprocess, which started writing rollouts under the scoped tempdir (verified: `\$TMPDIR/codex-v7-writer-501/sessions/2026/05/22/rollout-*.jsonl`). But `CodexAdapter._candidate_rollout_dirs` still hard-coded `Path.home() / ".codex" / "sessions"` — so the adapter scanned the user's real `~/.codex/sessions/` while the subprocess wrote rollouts to the scoped path.

**Symptom:** Codex made 38 valid `mcp__sources__*` calls (search_text, query_pravopys, search_heritage, verify_source_attribution, query_ulif, search_external, check_modern_form, ...) — all recorded in the scoped rollout. Post-call parse couldn't find them, produced empty `writer_tool_calls.json`, and `mcp_tools_never_invoked` fired TERMINAL on a writer phase that was actually high-quality.

**Fix:**
- `CodexAdapter._codex_home_scope` (new class attribute) stores the scoped path from `tool_config["codex_home_override"]`.
- `build_invocation` sets it **before** `_reset_per_invocation_state` so the rollout snapshot uses the scoped `sessions/` dir from the start.
- `_candidate_rollout_dirs` resolves in order: (1) `self._codex_home_scope`, (2) `os.environ["CODEX_HOME"]`, (3) `~/.codex/sessions` (legacy).

## Empirical reference

Failed build `a1-my-morning-20260522-205831` (forked off `125e0e4493` = post-#2232). Codex wrote 38 `sources.*` calls to the scoped rollout. Adapter scanned user home, found unrelated kubedojo rollouts, returned no match → `writer_tool_calls.json: []` → `WRITER_RUNTIME_GATE_FAILED: failures=[mcp_tools_never_invoked]`. Module content (module.md, 4 sections, 25 valid VESUM vocab entries) was correct.

## Test plan

- [x] New `test_codex_candidate_rollout_dirs_honors_codex_home_override` regression test
- [x] 185 tests pass across test_agent_runtime, test_writer_isolation, test_mcp_init_observability, test_agent_runtime_tool_calls
- [ ] CI green
- [ ] Post-merge: `--resume` failed worktree build to validate python_qg + downstream gates on real codex writer output

Stack closure: #2227 (shell_tool disable) + #2230 (scoped CODEX_HOME) + #2232 (env_sanitize + flag order + gate demotion) + this PR (rollout discovery) = full codex-tools writer-isolation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)