### PR TITLE
fix(parsers): correlate codex function_call_output + unwrap Wall-time envelope

### DIFF
--- a/scripts/agent_runtime/tool_calls.py
+++ b/scripts/agent_runtime/tool_calls.py
@@ -211,9 +211,25 @@ def _is_tool_use_payload(payload: Mapping[str, Any]) -> bool:
 
 
 def _is_tool_result_payload(payload: Mapping[str, Any]) -> bool:
+    # Codex CLI emits ``function_call_output`` as the result-event type with
+    # ``call_id`` as the correlation key (not ``tool_call_id``/``tool_use_id``).
+    # Without including both here, codex rollouts parse the function_call
+    # but never correlate the output back, leaving ``writer_tool_calls.json``
+    # entries with empty ``result`` / ``output_summary`` and breaking the
+    # ``textbook_grounding`` gate (textbook_result_hits=0 even when the
+    # writer's search_text/get_chunk_context calls returned grounded chunks).
+    # Empirical reference: rollout-2026-05-22T22-58-38 for the codex-tools
+    # a1/my-morning build at codex-cli 0.133.0 — 38 valid mcp__sources__*
+    # calls fired with full results in the rollout, all dropped on the floor
+    # by the result-correlation pass.
     payload_type = _payload_type(payload)
-    return payload_type in {"tool_result", "tool_output", "function_result"} or (
-        any(key in payload for key in ("tool_use_id", "tool_call_id"))
+    return payload_type in {
+        "tool_result",
+        "tool_output",
+        "function_result",
+        "function_call_output",
+    } or (
+        any(key in payload for key in ("tool_use_id", "tool_call_id", "call_id"))
         and any(key in payload for key in ("content", "output", "result"))
     )
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8056,6 +8056,30 @@ def _result_items_from_call(call: Mapping[str, Any]) -> list[Mapping[str, Any]]:
         result = {"text": call["result_excerpt"]}
         if call.get("source_type"):
             result["source_type"] = call["source_type"]
+    # Codex CLI envelope: tool outputs from codex (mcp_sources_* via codex-cli
+    # 0.133.0+) arrive as a wrapped string ``Wall time: X.XXXX seconds\nOutput:\n<json>``
+    # where ``<json>`` is the canonical content-block list shape
+    # ``[{"type":"text","text":"<md>"}]``. Without unwrapping, the canonical
+    # list branch below skips the result (string isn't list/Mapping) and
+    # ``textbook_grounding`` reads ``textbook_result_hits: 0`` even when
+    # the writer's search_text/get_chunk_context calls returned grounded
+    # textbook chunks. Empirical reference: rollout-2026-05-22T22-58-38
+    # for the post-#2233 codex-tools a1/my-morning build — 38 valid
+    # mcp__sources__* calls fired with full results, all dropped by the
+    # result-extraction pass.
+    if isinstance(result, str):
+        stripped = result.lstrip()
+        if stripped.startswith("Wall time:"):
+            output_marker = "Output:\n"
+            idx = stripped.find(output_marker)
+            if idx >= 0:
+                payload_text = stripped[idx + len(output_marker):]
+                try:
+                    parsed = json.loads(payload_text)
+                except (json.JSONDecodeError, ValueError):
+                    parsed = None
+                if isinstance(parsed, (list, dict)):
+                    result = parsed
     if isinstance(result, list):
         items: list[Mapping[str, Any]] = []
         tool_name = _tool_name_from_call(call)

--- a/tests/test_agent_runtime_tool_calls.py
+++ b/tests/test_agent_runtime_tool_calls.py
@@ -109,3 +109,48 @@ def test_normalize_tool_calls_extracts_gemini_toolcalls_shape() -> None:
         }
     ]
     assert calls[0]["timestamp"] == "2026-05-09T19:20:01Z"
+
+
+def test_normalize_tool_calls_correlates_codex_function_call_output() -> None:
+    """Codex CLI emits ``function_call_output`` events with ``call_id`` as
+    the correlation key (not ``tool_call_id``/``tool_use_id``).
+
+    Without recognising both, codex rollouts pair the function_call with no
+    output, leaving ``writer_tool_calls.json`` entries blank and the
+    ``textbook_grounding`` gate reading ``textbook_result_hits: 0`` even
+    when the writer's search_text/get_chunk_context calls returned grounded
+    textbook chunks. Empirical reference: rollout-2026-05-22T22-58-38 for
+    the post-#2233 codex-tools a1/my-morning build — 38 valid mcp__sources__*
+    calls with full results in the rollout, all dropped on the floor by the
+    result-correlation pass.
+    """
+    events = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "search_text",
+                "namespace": "mcp__sources__",
+                "arguments": '{"query":"Захарійчук 24","grade":1,"limit":10}',
+                "call_id": "call_ujhILo8Q08B3NwugWTPbXbOm",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_ujhILo8Q08B3NwugWTPbXbOm",
+                "output": (
+                    'Wall time: 0.0212 seconds\nOutput:\n'
+                    '[{"type":"text","text":"Found 10 results"}]'
+                ),
+            },
+        },
+    ]
+
+    calls = normalize_tool_calls(events)
+
+    assert len(calls) == 1
+    assert calls[0]["name"] == "mcp__sources__search_text"
+    assert calls[0]["result"].startswith("Wall time: 0.0212 seconds\nOutput:\n")
+    assert "Found 10 results" in calls[0]["output_summary"]

--- a/tests/test_writer_telemetry_search_text.py
+++ b/tests/test_writer_telemetry_search_text.py
@@ -75,3 +75,42 @@ def test_search_text_results_preserved_in_telemetry() -> None:
     loaded_jsonl_event["result"] = {"text": event["result_excerpt"]}
     loaded_items = list(_result_items_from_call(loaded_jsonl_event))
     assert loaded_items[0]["source_type"] == "textbook"
+
+
+def test_result_items_from_call_unwraps_codex_envelope() -> None:
+    """Pin codex-cli's ``Wall time: X.XXXX seconds\\nOutput:\\n<json>`` envelope.
+
+    Codex CLI 0.133.0+ wraps MCP tool outputs as a string starting with
+    ``Wall time:`` followed by ``Output:\\n`` and the canonical content-block
+    list ``[{"type":"text","text":"<md>"}]``. Without unwrapping, the gate's
+    ``isinstance(result, list)`` branch skips the result (string isn't a list)
+    and ``textbook_grounding`` reads ``textbook_result_hits: 0`` even when
+    the writer's search_text/get_chunk_context calls returned grounded
+    textbook chunks.
+
+    Empirical reference: rollout-2026-05-22T22-58-38 for the post-#2233
+    codex-tools a1/my-morning build — 38 valid mcp__sources__* calls with
+    full results in the rollout, all dropped by ``_result_items_from_call``
+    until this unwrap landed.
+    """
+    canonical_payload = (
+        '[{"type":"text","text":"Found 1 results for: \\"Захарійчук 24\\"'
+        '\\n\\n### Result 1\\n- **Section**: Сторінка 24\\n'
+        "- **Source**: Grade 1, zaharijchuk\\n"
+        "- **Chunk ID**: `1-klas-bukvar-zaharijchuk-2025-1_s0024`\\n"
+        '- **Text**:\\nМій день\\nПоснідати. Одягнутися. Піти до Квака."}]'
+    )
+    codex_envelope_event = {
+        "tool": "search_text",
+        "args": {"query": "Захарійчук 24"},
+        "result": f"Wall time: 0.0212 seconds\nOutput:\n{canonical_payload}",
+    }
+
+    items = list(_result_items_from_call(codex_envelope_event))
+
+    assert items, "codex envelope was not unwrapped by _result_items_from_call"
+    assert items[0]["source"].startswith("Grade 1")
+    assert items[0]["author"] == "zaharijchuk"
+    assert items[0]["grade"] == 1
+    assert items[0]["page"] == 24
+    assert "Поснідати" in items[0]["text"]


### PR DESCRIPTION
## Summary

Two latent bugs prevented codex-tools writer telemetry from reaching the `textbook_grounding` gate, even when codex was correctly invoking `mcp__sources__search_text` / `get_chunk_context` and the rollout JSONL contained valid textbook chunks.

### Bug 1 — `scripts/agent_runtime/tool_calls.py::_is_tool_result_payload`

Codex CLI emits `function_call_output` events with `call_id` as the correlation key. The predicate only recognised `tool_result` / `tool_output` / `function_result` types and only checked `tool_use_id` / `tool_call_id` in its fallback. Codex's `function_call` payloads normalised cleanly but their outputs were never paired back — `writer_tool_calls.json` entries had no `result` / `output_summary`.

### Bug 2 — `scripts/build/linear_pipeline.py::_result_items_from_call`

Codex wraps tool outputs as a string `Wall time: X.XXXX seconds\nOutput:\n<json>` where `<json>` is the canonical content-block list `[{"type":"text","text":"<md>"}]`. Without unwrapping, the `isinstance(result, list)` branch skipped string-typed results and `textbook_grounding` read `textbook_result_hits: 0` even when the writer's calls returned grounded textbook chunks.

## Empirical reference

Rollout `\$TMPDIR/codex-v7-writer-501/sessions/2026/05/22/rollout-2026-05-22T22-58-38-019e517b-a429-7f72-b101-bea6e7f56dd9.jsonl` for the post-#2233 codex-tools `a1/my-morning` build — 38 valid `mcp__sources__*` calls across 15 distinct tools (including unique uses of `query_ulif` + `query_pravopys`), with full results in the rollout, all dropped on the floor before this fix.

Captured pass/fail flip:

| Gate | Pre-fix | Post-fix |
|---|---|---|
| `textbook_grounding` | HARD REJECT (matched 0/2, textbook_result_hits=0) | **PASS (matched 2/2)** |
| `vesum_verified` | PASS | PASS |
| `resources_search_attempted` | PASS | PASS |
| `immersion_advisory` | PASS | PASS |
| `l2_exposure_floor` | PASS | PASS |

After both code fixes + two surgical content patches (engagement_floor meta-narration removal, +25 words to clear word_count=1200 floor), `a1/my-morning` codex-tools build clears all 24 `python_qg` gates.

## Regression coverage

- `tests/test_agent_runtime_tool_calls.py` — codex `function_call_output` correlation by `call_id`, including the Wall-time envelope output preservation. (4 tests pass.)
- `tests/test_writer_telemetry_search_text.py` — string-result envelope unwrap in `_result_items_from_call`, asserting chunk metadata (author, grade, page, text) all extract correctly. (2 tests pass.)

## Verifiable claims

| Claim | Command | Output |
|---|---|---|
| 40 targeted tests pass | `.venv/bin/python -m pytest tests/test_agent_runtime_tool_calls.py tests/test_writer_telemetry_search_text.py tests/test_textbook_grounding_gate.py tests/test_textbook_grounding.py -q` | `40 passed in 0.45s` |
| Ruff clean | `.venv/bin/ruff check scripts/agent_runtime/tool_calls.py scripts/build/linear_pipeline.py tests/test_agent_runtime_tool_calls.py tests/test_writer_telemetry_search_text.py` | `All checks passed!` |
| Commit landed | `git log -1 --oneline` | `a289880790 fix(parsers): correlate codex function_call_output + unwrap Wall-time envelope` |

## Test plan

- [ ] CI green (pytest + ruff + frontend + lesson schema drift)
- [ ] After merge, any codex-tools V7 build (or anchor refire of `a1/my-morning`) will see correctly-populated `writer_tool_calls.json` and the `textbook_grounding` gate will read the right hit count.

## Refs

- #2233 (scoped CODEX_HOME rollout discovery)
- #2232 (env_sanitize CODEX_HOME + flag reorder + wrong_tool_family demotion)
- #2230 (scoped CODEX_HOME tempdir materialization)
- #2227 (initial \`--disable shell_tool\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)