### PR TITLE
fix(wiki_coverage): resolve workbook activity claims via title fallback + bare-artifact hint

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -508,13 +508,90 @@ def _flatten_strings(value: Any) -> list[str]:
 
 
 def _activity_text(activities: list[dict[str, Any]], location: str) -> str:
+    """Resolve a writer's claim ``location`` to flattened activity text.
+
+    Resolution strategies (first match wins):
+
+    1. Empty ``location`` → all activities flattened.
+    2. ``location`` equals the bare artifact name ``activities.yaml`` (or
+       an explicit ``all``/``any`` marker) → all activities flattened.
+       This honours the seeded ``location_hint`` produced by
+       ``seed_implementation_map`` for ``activities.yaml``-targeted
+       obligations (see ``scripts/build/phases/implementation_map.py::
+       _location_hint``: activity-targeted entries are seeded with the
+       bare string ``"activities.yaml"``).
+    3. An activity's ``id`` appears as a substring of ``location`` —
+       canonical handle for **inline** activities targeted by
+       ``<!-- INJECT_ACTIVITY: act-N -->`` markers.
+    4. An activity's ``title`` overlaps ``location`` (either direction)
+       — workbook activities legitimately **omit** ``id`` per
+       ``scripts/build/phases/linear-write.md`` L700, so ``title`` is
+       the next-most-stable handle when the writer's claim names a
+       workbook activity. Codex-tools build-205831 regression: writer
+       packed 6 ``err-N`` items into one workbook activity titled
+       ``workbook error-correction item 5`` and wrote
+       ``location: workbook error-correction item N``. Without title
+       fallback, all 6 obligations hard-failed ``claimed_location_missing``
+       even though the activity flattens to text containing every
+       required contrast pair.
+    5. No match → empty string (downstream gate FAILs the obligation
+       with ``claimed_location_missing``).
+
+    The flattened-text return is intentionally lenient: the downstream
+    ``_check_obligation_text`` substance check validates that the
+    required ``expected_error_value``/``expected_correction_value``
+    markers are actually present. ``_activity_text``'s job is to give
+    that substance check a sufficiently wide search window, not to
+    enforce per-item exact-location accounting.
+    """
+
     if not location:
         return "\n".join(s for activity in activities for s in _flatten_strings(activity))
+
+    location_cf = location.casefold().strip()
+    if location_cf in {"activities.yaml", "all", "any", "(any)", "(any activity)"}:
+        return "\n".join(s for activity in activities for s in _flatten_strings(activity))
+
     for activity in activities:
         activity_id = str(activity.get("id") or "")
         if activity_id and activity_id in location:
             return "\n".join(_flatten_strings(activity))
+
+    for activity in activities:
+        title = str(activity.get("title") or "")
+        if not title:
+            continue
+        title_cf = title.casefold().strip()
+        if not title_cf:
+            continue
+        if title_cf in location_cf or location_cf in title_cf:
+            return "\n".join(_flatten_strings(activity))
+
+    # Last-resort: strip a single trailing numeric index off both strings
+    # and retry equality. Handles the codex-tools build-205831 pattern
+    # where the writer packed 6 ``err-N`` items into ONE workbook activity
+    # whose title happened to bake in one row's index (``workbook error-
+    # correction item 5``) while every per-row claim location named a
+    # different index (``workbook error-correction item 1``..``6``).
+    # Pure substring matching can't unify them; stripping the trailing
+    # ``\s*\d+\s*$`` from each yields the same stem and the activity (which
+    # contains all 6 items as flattened text) covers every per-index claim.
+    stripped_location = _TRAILING_INDEX_RE.sub("", location_cf).strip()
+    if stripped_location:
+        for activity in activities:
+            title = str(activity.get("title") or "")
+            if not title:
+                continue
+            stripped_title = _TRAILING_INDEX_RE.sub(
+                "", title.casefold().strip()
+            ).strip()
+            if stripped_title and stripped_title == stripped_location:
+                return "\n".join(_flatten_strings(activity))
+
     return ""
+
+
+_TRAILING_INDEX_RE = re.compile(r"\s*\d+\s*$")
 
 
 def _location_text(text: str, location: str) -> str:

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -460,3 +460,147 @@ def test_l2_error_passes_when_marker_contains_apostrophe() -> None:
         f"err-2 should PASS when activity contains the correct apostrophe "
         f"marker; got reason={err_result['reason']!r}"
     )
+
+
+def test_l2_error_resolves_via_title_when_workbook_activity_omits_id() -> None:
+    """`_activity_text` MUST fall back to ``title`` matching when the writer
+    targets a workbook activity, because workbook activities legitimately
+    omit ``id`` per ``scripts/build/phases/linear-write.md`` L700 (#2218).
+
+    The codex-tools build-205831 regression: writer packed 6 ``err-N``
+    items into one workbook activity titled
+    ``workbook error-correction item 5`` and emitted
+    ``location: workbook error-correction item N`` per row. The pre-fix
+    resolver only matched on ``activity.id``, so every workbook row hard-
+    failed ``claimed_location_missing`` even though the activity's
+    flattened text contained the required contrast pair.
+    """
+    manifest = _phonetic_l2_error_manifest()
+    activities_yaml = (
+        "- type: error-correction\n"
+        "  title: workbook error-correction item 5\n"
+        "  items:\n"
+        "    - sentence: 'Вимова: [прокидайешся]'\n"
+        "      error: 'Вимова: [прокидайешся]'\n"
+        "      correction: \"Вимова: [прокидайес':а]\"\n"
+        "      explanation: assimilation rule.\n"
+    )
+    implementation_map = {
+        "err-2": {
+            "artifact": "activities.yaml",
+            # Codex's actual claim string, not present anywhere as an
+            # activity id (no `id` field on workbook activity).
+            "location": "workbook error-correction item 2",
+            "treatment": "sentence/error/correction contrast",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="# Module body unrelated to err-2.\n",
+        activities_yaml=activities_yaml,
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    err_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "err-2"
+    )
+    assert err_result["status"] == "PASS", (
+        f"err-2 must PASS via title-substring fallback when the writer's "
+        f"location string overlaps the workbook activity's `title` field; "
+        f"got reason={err_result['reason']!r}"
+    )
+
+
+def test_l2_error_resolves_via_bare_activities_yaml_location() -> None:
+    """When the writer copies the seeded ``location_hint: \"activities.yaml\"``
+    verbatim, ``_activity_text`` MUST return all activities flattened so the
+    substance check has a chance to find the markers.
+
+    ``scripts/build/phases/implementation_map.py::_location_hint`` seeds
+    activity-targeted obligations with the bare string ``\"activities.yaml\"``.
+    Pre-fix resolver returned empty string when no activity ``id`` matched
+    that literal, hard-failing every faithful copy of the seeded hint.
+    """
+    manifest = _phonetic_l2_error_manifest()
+    activities_yaml = (
+        "- type: error-correction\n"
+        "  title: Fix the contrast pair\n"
+        "  items:\n"
+        "    - sentence: 'Вимова: [прокидайешся]'\n"
+        "      error: 'Вимова: [прокидайешся]'\n"
+        "      correction: \"Вимова: [прокидайес':а]\"\n"
+        "      explanation: assimilation rule.\n"
+    )
+    implementation_map = {
+        "err-2": {
+            "artifact": "activities.yaml",
+            "location": "activities.yaml",
+            "treatment": "sentence/error/correction contrast",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="# Module body unrelated to err-2.\n",
+        activities_yaml=activities_yaml,
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    err_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "err-2"
+    )
+    assert err_result["status"] == "PASS", (
+        f"err-2 must PASS when the writer's location equals the seeded "
+        f"bare-artifact hint and the contrast pair is present anywhere "
+        f"in activities.yaml; got reason={err_result['reason']!r}"
+    )
+
+
+def test_l2_error_still_fails_when_workbook_activity_lacks_substance() -> None:
+    """Title-fallback resolution MUST NOT bypass the substance check.
+
+    Companion to ``test_phonetic_rule_still_fails_when_substance_absent_anywhere``:
+    if ``_activity_text`` widens the search window via title fallback OR
+    bare-artifact fallback, the obligation-specific substance check must
+    still reject activities that don't contain the required
+    ``expected_error_value`` / ``expected_correction_value`` markers. The
+    gate's leniency is a hint-resolution concession, not a substance
+    waiver.
+    """
+    manifest = _phonetic_l2_error_manifest()
+    activities_yaml = (
+        "- type: order\n"
+        "  title: workbook error-correction item 5\n"
+        "  items:\n"
+        "    - Спочатку я прокидаюся.\n"
+        "    - Потім я вмиваюся.\n"
+        "    - Нарешті я йду на роботу.\n"
+        "  correct_order: [0, 1, 2]\n"
+    )
+    implementation_map = {
+        "err-2": {
+            "artifact": "activities.yaml",
+            "location": "workbook error-correction item 2",
+            "treatment": "sentence/error/correction contrast",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="# Module body unrelated to err-2.\n",
+        activities_yaml=activities_yaml,
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    err_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "err-2"
+    )
+    assert err_result["status"] == "FAIL", (
+        "err-2 must FAIL when the title-matched activity does NOT contain "
+        "the required incorrect/correct contrast pair — the widened "
+        "resolution window must not create a false-positive escape hatch"
+    )


### PR DESCRIPTION
## Summary

- Adds three resolution strategies to `_activity_text` so workbook activity claims can resolve when the activity omits `id` (per #2218 / `linear-write.md` L700).
- Net effect: codex/gemini/claude builds with workbook-targeted obligations (l2_error contrast pairs, etc.) stop hard-failing `claimed_location_missing` on structural shape; substance check stays load-bearing.
- Empirical validation on `.worktrees/builds/a1-my-morning-20260522-205831/`: coverage was **11/18 (61%, hard_fail)** after 3 correction rounds → **17/18 (94%)** with this fix. The 6 `err-N` fails were structural; the remaining `step-5` fail is a genuine substance gap.

## Why it matters

This bug blocks every writer (codex, gemini, claude) on every module with workbook-targeted obligations. Net cost: ~25 min wall-clock + LLM spend per build, with no recovery path. Without this fix the writer-bench v0 (6 writers × 5 modules) produces mostly `wiki_coverage` failures regardless of writer quality. Fix is small and local; one function, one regex constant, three tests.

## Root cause

PR #2218 (2 days ago) made `id` optional on workbook activities to clear `inject_activity_ids` complaints. But `_activity_text` only matched claims on activity `id`, leaving workbook activities unaddressable. Writer prompt (linear-write.md L700) explicitly tells writers to OMIT `id` from workbook activities — direct contradiction with the gate's contract.

## Resolution strategies (first match wins)

1. **Empty location** → all activities flattened (unchanged).
2. **Bare-artifact hint** (`activities.yaml`, `all`, `any`) → all activities flattened. Honours the seeded `location_hint` produced by `seed_implementation_map._location_hint` for activity-targeted obligations.
3. **`id` substring** → that activity (unchanged; preserves inline activity behavior).
4. **`title` substring** (either direction) → that activity.
5. **Trailing-index strip equality** → that activity. Handles codex-tools-205831: writer packed 6 `err-N` items into ONE workbook activity titled `workbook error-correction item 5` and emitted six per-row claim locations (`workbook error-correction item 1`..`6`). Stripping `\s*\d+\s*$` from both yields the same stem.
6. **No match** → empty (unchanged; gate FAILs `claimed_location_missing`).

## Test plan

- [x] New `test_l2_error_resolves_via_title_when_workbook_activity_omits_id` — exact codex-205831 pattern (one activity, 6 items, indexed title vs indexed locations).
- [x] New `test_l2_error_resolves_via_bare_activities_yaml_location` — verbatim seeded-hint case.
- [x] New `test_l2_error_still_fails_when_workbook_activity_lacks_substance` — guard: widened resolution must not bypass substance check.
- [x] Existing `test_l2_error_passes_when_marker_contains_apostrophe` still PASSes (apostrophe handling unaffected).
- [x] All 12 tests in `tests/audit/test_wiki_coverage_gate.py` pass.
- [x] All 61 related tests pass (`tests/test_wiki_coverage_gate.py`, `tests/test_linear_pipeline_wiki_coverage.py`, `tests/build/test_wiki_coverage_*`, `tests/build/test_implementation_map_render.py`).
- [x] All 384 audit tests pass (`tests/audit/`).
- [x] E2E sanity: re-run gate on `.worktrees/builds/a1-my-morning-20260522-205831/` → 17/18, only substance-genuine `step-5` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)