### PR TITLE
fix(pipeline): strip id from unused workbook activities instead of auto-injecting markers

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5345,12 +5345,71 @@ def _apply_reviewer_correction(
 
 
 def _apply_activity_id_inserts(module_path: Path, gate_report: Mapping[str, Any]) -> None:
+    """Resolve ``inject_activity_ids:unused_activities_not_injected`` by
+    stripping ``id`` from unused workbook activities — NOT by promoting
+    them to inline with new INJECT markers.
+
+    Background: PR #2218 (2026-05-21) made ``id`` optional on workbook
+    activities (``inject_activity_ids`` only enforces bidirectional
+    consistency for activities INTENDED to be inline-injected, and the
+    schema rule per ``scripts/build/phases/linear-write.md`` L700 is
+    "workbook activity objects should omit `id` entirely"). When a
+    writer leaves an activity-with-id WITHOUT a matching
+    ``<!-- INJECT_ACTIVITY: act-X -->`` marker, the most-faithful
+    interpretation under the new contract is *that activity is workbook
+    and the writer over-emitted id* — NOT *that activity is inline and
+    the writer forgot the marker*.
+
+    The previous implementation appended INJECT markers for every
+    ``unused`` id to ``module.md``. That auto-promoted EVERY workbook
+    activity to inline, blowing past the level's
+    ``INLINE_MIN..INLINE_MAX`` range and producing the anti-pattern that
+    got m20 reverted on 2026-05-23 morning (``inline_n=10 / workbook_n=0``
+    in build #14). Empirical reproduction of the same anti-pattern
+    across 4 writers on 2026-05-22 night (codex / gemini / deepseek /
+    claude builds of a1/my-morning, see session-state handoff for
+    forensics).
+
+    The fix: strip ``id`` from each unused activity in
+    ``activities.yaml`` so the bidirectional consistency gate passes
+    WITHOUT touching ``module.md``, preserving the writer's authored
+    INLINE/WORKBOOK split. If the writer *did* mean these as inline
+    and forgot markers, the resulting ``inline_n`` shortfall is the
+    writer's responsibility to flag via the ``<activity_split_audit>``
+    self-audit line — that's where the corrective signal belongs, not
+    in a downstream pipeline insert that has no visibility into the
+    writer's intent.
+    """
+
     unused = [str(activity_id) for activity_id in gate_report.get("unused", [])]
     if not unused:
         return
-    text = _read_required(module_path).rstrip()
-    markers = "\n\n".join(f"<!-- INJECT_ACTIVITY: {activity_id} -->" for activity_id in unused)
-    module_path.write_text(f"{text}\n\n{markers}\n", encoding="utf-8")
+
+    module_dir = module_path.parent
+    activities_path = module_dir / "activities.yaml"
+    if not activities_path.exists():
+        return
+
+    try:
+        activities = yaml.safe_load(activities_path.read_text(encoding="utf-8")) or []
+    except yaml.YAMLError:
+        return
+    if not isinstance(activities, list):
+        return
+
+    unused_set = {str(activity_id) for activity_id in unused}
+    changed = False
+    for activity in activities:
+        if not isinstance(activity, dict):
+            continue
+        if str(activity.get("id") or "") in unused_set:
+            del activity["id"]
+            changed = True
+    if changed:
+        activities_path.write_text(
+            yaml.safe_dump(activities, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
 
 
 def _parse_reviewer_fixes(review_text: str) -> list[dict[str, str]]:

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1313,6 +1313,112 @@ def test_inject_activity_gate_passes_when_all_activities_injected() -> None:
     assert report["unused"] == []
 
 
+def test_apply_activity_id_inserts_strips_id_from_unused_workbook_activities(
+    tmp_path: Path,
+) -> None:
+    """When `inject_activity_ids` flags unused ids, the pipeline-insert
+    correction MUST strip the ids from activities.yaml — NOT add new
+    `<!-- INJECT_ACTIVITY -->` markers to module.md.
+
+    Regression test for the m20 activity-split bug: before this fix,
+    `_apply_activity_id_inserts` appended an INJECT marker for every
+    unused id, auto-promoting workbook activities to inline and blowing
+    past the A1 `INLINE_MAX=6` ceiling (10 inline / 0 workbook on m20,
+    `944f4200e4` revert). Per PR #2218 + linear-write.md L700, workbook
+    activities omit `id` — so the correct correction is to remove ids
+    from `activities.yaml`, NOT to add markers to module.md.
+    """
+    module_path = tmp_path / "module.md"
+    module_text_before = (
+        "## Діалоги\n\n"
+        "<!-- INJECT_ACTIVITY: act-1 -->\n"
+        "<!-- INJECT_ACTIVITY: act-2 -->\n"
+    )
+    module_path.write_text(module_text_before, encoding="utf-8")
+
+    activities_path = tmp_path / "activities.yaml"
+    _write_yaml(
+        activities_path,
+        [
+            {"id": "act-1", "type": "quiz", "title": "Inline check 1"},
+            {"id": "act-2", "type": "fill-in", "title": "Inline check 2"},
+            {"id": "act-3", "type": "error-correction", "title": "Workbook drill 1"},
+            {"id": "act-4", "type": "match-up", "title": "Workbook drill 2"},
+            {"id": "act-5", "type": "order", "title": "Workbook drill 3"},
+        ],
+    )
+
+    gate_report = {
+        "passed": False,
+        "injected": ["act-1", "act-2"],
+        "missing": [],
+        "unused": ["act-3", "act-4", "act-5"],
+        "reason": "unused_activities_not_injected",
+    }
+
+    linear_pipeline._apply_activity_id_inserts(module_path, gate_report)
+
+    after_module = module_path.read_text(encoding="utf-8")
+    assert after_module == module_text_before, (
+        f"_apply_activity_id_inserts must not add new INJECT markers to "
+        f"module.md; promotion to inline violates the A1 INLINE_MAX=6 "
+        f"split band. Got module.md=\n{after_module!r}"
+    )
+
+    after_activities = yaml.safe_load(activities_path.read_text(encoding="utf-8"))
+    by_title = {item.get("title"): item for item in after_activities}
+    assert by_title["Inline check 1"].get("id") == "act-1"
+    assert by_title["Inline check 2"].get("id") == "act-2"
+    for title in ("Workbook drill 1", "Workbook drill 2", "Workbook drill 3"):
+        assert "id" not in by_title[title], (
+            f"unused workbook activity {title!r} must have its `id` "
+            f"stripped to satisfy the bidirectional gate without "
+            f"promoting it to inline; got {by_title[title]!r}"
+        )
+
+
+def test_apply_activity_id_inserts_noop_when_unused_empty(tmp_path: Path) -> None:
+    """No unused ids → no-op; module.md and activities.yaml untouched."""
+    module_path = tmp_path / "module.md"
+    activities_path = tmp_path / "activities.yaml"
+    module_text = "## Section\n\n<!-- INJECT_ACTIVITY: act-1 -->\n"
+    module_path.write_text(module_text, encoding="utf-8")
+    activities_data = [{"id": "act-1", "type": "quiz", "title": "Inline only"}]
+    _write_yaml(activities_path, activities_data)
+
+    linear_pipeline._apply_activity_id_inserts(
+        module_path,
+        {"passed": True, "injected": ["act-1"], "missing": [], "unused": [], "reason": None},
+    )
+
+    assert module_path.read_text(encoding="utf-8") == module_text
+    assert yaml.safe_load(activities_path.read_text(encoding="utf-8")) == activities_data
+
+
+def test_apply_activity_id_inserts_tolerates_missing_activities_yaml(
+    tmp_path: Path,
+) -> None:
+    """If `activities.yaml` is absent, the correction silently no-ops on
+    module.md and exits cleanly — the upstream `inject_activity_ids` gate
+    will continue to fail and the build will halt naturally rather than
+    crashing inside the correction path.
+    """
+    module_path = tmp_path / "module.md"
+    module_text = "## Section\n\n<!-- INJECT_ACTIVITY: act-1 -->\n"
+    module_path.write_text(module_text, encoding="utf-8")
+
+    gate_report = {
+        "passed": False,
+        "injected": ["act-1"],
+        "missing": [],
+        "unused": ["act-2"],
+        "reason": "unused_activities_not_injected",
+    }
+    linear_pipeline._apply_activity_id_inserts(module_path, gate_report)
+
+    assert module_path.read_text(encoding="utf-8") == module_text
+
+
 def test_ai_slop_gate_ignores_correction_field_in_error_correction_activity(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

`_apply_activity_id_inserts` (linear_pipeline.py:5347) resolved `inject_activity_ids:unused_activities_not_injected` by APPENDING `<!-- INJECT_ACTIVITY: act-X -->` markers to module.md for every unused id. This auto-promoted EVERY workbook activity to inline, blowing past the level's `INLINE_MAX` ceiling and producing the exact anti-pattern that got m20 reverted on 2026-05-23 morning (`944f4200e4` revert).

**This is the m20 root cause.** PR #2218 made `id` optional on workbook activities, but this correction path was never updated to match.

## Empirical evidence

2026-05-22 night I fired 4 writer builds of a1/my-morning post-#2237. ALL 4 produced final `inline_n=10 / workbook_n=0` (or 9/1) due to this auto-promotion:

| Writer | Writer's own audit-line | Final state | LLM QG verdict |
|---|---|---|---|
| codex-tools | (rollout binding broken, separate issue) | n/a | n/a |
| gemini-tools | failed earlier at word_count | n/a | n/a |
| deepseek-tools | inline_n=4 workbook_n=6 split_valid=true | inline_n=10 workbook_n=0 | **5.5 REJECT** (pedagogical 5.5: 'Dumping five consecutive injected activities at the end of the lesson completely destroys pacing') |
| claude-tools | (no audit line emitted) | inline_n=9 workbook_n=1 | **4.0 REJECT** (pedagogical 4.0: 5 consecutive INJECT dumps) |

Deepseek explicitly self-audited the correct 4/6 split — then this pipeline-insert correction silently mutated it to 10/0.

## Fix

Strip id from each unused activity in activities.yaml, leaving module.md untouched. Per linear-write.md L700: 'workbook activity objects should omit id entirely.' An activity-with-id-without-marker is best interpreted as workbook + writer over-emitted id, not as inline + writer forgot the marker.

The bidirectional consistency gate now passes WITHOUT violating the writer's authored INLINE/WORKBOOK split. If the writer genuinely meant these as inline and forgot markers, the resulting inline_n shortfall is the writer's responsibility to flag via the mandatory <activity_split_audit> self-audit line — that's the correct layer for that signal.

## Test plan

- [x] test_apply_activity_id_inserts_strips_id_from_unused_workbook_activities — exact codex-205831 / deepseek-224911 / claude-230706 pattern. Asserts module.md byte-identical after fix, and ids stripped from unused workbook activities.
- [x] test_apply_activity_id_inserts_noop_when_unused_empty — happy path preserves both artifacts.
- [x] test_apply_activity_id_inserts_tolerates_missing_activities_yaml — defensive no-op when activities.yaml is absent.
- [x] All 523 non-flaky audit + pipeline tests pass.
- [x] Pre-commit: ruff, pytest on affected files (128 passed).

## Validation plan post-merge

Refire deepseek-tools build on a1/my-morning. Expected: writer's self-audit inline_n=4 workbook_n=6 flows through to final artifact unchanged → llm_qg pedagogical reviewer no longer rejects on activity-split → first complete V7 module shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)