### PR TITLE
feat(pipeline): demote 4 LLM dims to warning + --resume default (PR-A+A2)

### DIFF
--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -26,7 +26,7 @@ from scripts.build.phases.implementation_map import (
     seed_implementation_map,
     write_implementation_map,
 )
-from scripts.common.thresholds import QG_DIMS
+from scripts.common.thresholds import LLM_QG_TERMINAL_DIMS, QG_DIMS
 
 DEFAULT_WRITER_TIMEOUT_S = 1800
 FETCH_TIMEOUT_S = 30
@@ -767,7 +767,7 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Build one V7 curriculum module through scripts.build.linear_pipeline.\n"
             "Use for single-module V7 reboot builds; do not use for V6 legacy "
-            "batch, resume, rewrite, or regeneration workflows."
+            "batch, rewrite, or regeneration workflows."
         ),
         epilog=(
             "Examples:\n"
@@ -893,17 +893,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--resume",
-        metavar="MODULE_DIR",
-        default=None,
+        "--no-resume",
+        action="store_true",
         help=(
-            "Resume a previous v7_build run from MODULE_DIR (e.g. "
-            ".worktrees/builds/a1-my-morning-20260521-202848/curriculum/"
-            "l2-uk-en/a1/my-morning). Phases whose artifacts already exist "
-            "AND report PASS are skipped; the first failed or missing phase "
-            "AND everything downstream re-runs. MDX assembly always re-runs. "
-            "Mutually exclusive with --worktree (resume operates on the "
-            "existing module_dir directly, without creating a new worktree)."
+            "Force a full rebuild from scratch. Default behavior resumes from "
+            "the last failed phase using artifact existence checks."
         ),
     )
     return parser.parse_args(argv)
@@ -912,14 +906,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     args = parse_args(raw_argv)
-    if args.resume is not None and args.worktree is not None:
-        print(
-            "v7_build: --resume and --worktree are mutually exclusive — "
-            "resume targets an existing module_dir.",
-            file=sys.stderr,
-            flush=True,
-        )
-        return 2
     if args.worktree is not None:
         return _run_in_worktree(args, raw_argv)
     telemetry_out = _resolve_project_path(args.telemetry_out)
@@ -950,8 +936,9 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
 
     The on-disk shapes mirror the success conditions enforced in `_run` itself
     (see the post-phase guards: `gates.passed`, `wiki_coverage_gate.passed`,
-    `wiki_coverage_review.overall_verdict == "PASS"`, `aggregate.verdict ==
-    "PASS"`). Any deviation means the phase needs to re-run.
+    `wiki_coverage_review.overall_verdict == "PASS"`, and
+    `aggregate.terminal_verdict == "PASS"`). Any deviation means the phase
+    needs to re-run.
     """
     if phase == "knowledge_packet":
         return (module_dir / "knowledge_packet.md").exists() and (
@@ -987,10 +974,10 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
         if not isinstance(data, Mapping):
             return False
         aggregate = data.get("aggregate")
-        return (
-            isinstance(aggregate, Mapping)
-            and str(aggregate.get("verdict", "")).upper() == "PASS"
-        )
+        if not isinstance(aggregate, Mapping):
+            return False
+        terminal_verdict = aggregate.get("terminal_verdict", aggregate.get("verdict", ""))
+        return str(terminal_verdict).upper() == "PASS"
     return False
 
 
@@ -1006,21 +993,12 @@ def _run(args: argparse.Namespace) -> int:
     plan_path: Path | None = None
     module_dir: Path | None = None
 
-    # Resume-mode setup: when --resume MODULE_DIR is set, use that directory
-    # directly and downstream phase blocks check on-disk artifact validity to
-    # decide whether to skip. Once one phase re-runs (`force_rerun` flips
-    # True), every downstream phase re-runs unconditionally.
-    resume_path = getattr(args, "resume", None)
-    if resume_path is not None:
-        resume_module_dir = Path(resume_path).expanduser().resolve()
-        if not resume_module_dir.exists():
-            print(
-                f"v7_build: --resume MODULE_DIR does not exist: {resume_module_dir}",
-                file=sys.stderr,
-                flush=True,
-            )
-            return 2
-        args.out = str(resume_module_dir)
+    # Resume is the default. Pass --no-resume for a forced full restart.
+    # Per architectural reset 2026-05-23
+    # (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+    # decision #8), each of 6 failed builds 2026-05-22 to 2026-05-23 burned
+    # 5-20 minutes replaying writer when only a later phase had failed.
+    resume_enabled = not getattr(args, "no_resume", False)
     force_rerun = False
 
     tracker.emit("module_start", level=level, slug=slug)
@@ -1045,13 +1023,10 @@ def _run(args: argparse.Namespace) -> int:
         phase = "knowledge_packet"
         _phase_started(archive, phase)
         started_at = time.monotonic()
-        resume_module_dir = (
-            Path(args.out).expanduser().resolve() if resume_path is not None else None
-        )
+        resume_module_dir = _resolve_output_dir(args.out, level, slug)
         if (
-            resume_path is not None
+            resume_enabled
             and not force_rerun
-            and resume_module_dir is not None
             and _phase_artifact_passes(resume_module_dir, "knowledge_packet")
         ):
             knowledge_packet = (resume_module_dir / "knowledge_packet.md").read_text(
@@ -1063,7 +1038,7 @@ def _run(args: argparse.Namespace) -> int:
             wiki_manifest_data = json.loads(wiki_manifest)
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
-            if resume_path is not None:
+            if resume_enabled:
                 force_rerun = True
             knowledge_packet = linear_pipeline.build_knowledge_packet(
                 level=level,
@@ -1116,7 +1091,7 @@ def _run(args: argparse.Namespace) -> int:
         started_at = time.monotonic()
         module_dir.mkdir(parents=True, exist_ok=True)
         if (
-            resume_path is not None
+            resume_enabled
             and not force_rerun
             and _phase_artifact_passes(module_dir, "writer")
         ):
@@ -1125,7 +1100,7 @@ def _run(args: argparse.Namespace) -> int:
             )
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
-            if resume_path is not None:
+            if resume_enabled:
                 force_rerun = True
             impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
             impl_map_path = module_dir / "implementation_map.json"
@@ -1193,14 +1168,14 @@ def _run(args: argparse.Namespace) -> int:
         _phase_started(archive, phase)
         started_at = time.monotonic()
         if (
-            resume_path is not None
+            resume_enabled
             and not force_rerun
             and _phase_artifact_passes(module_dir, "python_qg")
         ):
             python_qg = _read_json(module_dir / "python_qg.json")
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
-            if resume_path is not None:
+            if resume_enabled:
                 force_rerun = True
             python_qg = linear_pipeline.run_python_qg_with_corrections(
                 module_dir,
@@ -1227,14 +1202,14 @@ def _run(args: argparse.Namespace) -> int:
         _phase_started(archive, phase)
         started_at = time.monotonic()
         if (
-            resume_path is not None
+            resume_enabled
             and not force_rerun
             and _phase_artifact_passes(module_dir, "wiki_coverage_gate")
         ):
             wiki_coverage_gate = _read_json(module_dir / "wiki_coverage_gate.json")
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
-            if resume_path is not None:
+            if resume_enabled:
                 force_rerun = True
             wiki_coverage_gate = linear_pipeline.run_wiki_coverage_with_corrections(
                 plan=plan,
@@ -1266,14 +1241,14 @@ def _run(args: argparse.Namespace) -> int:
         timeout_agent = _reviewer_for_writer(writer)
         started_at = time.monotonic()
         if (
-            resume_path is not None
+            resume_enabled
             and not force_rerun
             and _phase_artifact_passes(module_dir, "wiki_coverage_review")
         ):
             wiki_coverage_review = _read_json(module_dir / "wiki_coverage_review.json")
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
-            if resume_path is not None:
+            if resume_enabled:
                 force_rerun = True
             wiki_coverage_review = _run_wiki_coverage_review(
                 plan=plan,
@@ -1325,14 +1300,14 @@ def _run(args: argparse.Namespace) -> int:
         timeout_agent = _reviewer_for_writer(writer)
         started_at = time.monotonic()
         if (
-            resume_path is not None
+            resume_enabled
             and not force_rerun
             and _phase_artifact_passes(module_dir, "llm_qg")
         ):
             llm_qg = _read_json(module_dir / "llm_qg.json")
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
-            if resume_path is not None:
+            if resume_enabled:
                 force_rerun = True
             llm_qg = _run_llm_qg(
                 plan=plan,
@@ -1359,9 +1334,36 @@ def _run(args: argparse.Namespace) -> int:
             archive=archive,
             artifact_dir=module_dir,
         )
-        if aggregate["verdict"] != "PASS":
+        terminal_verdict = aggregate.get("terminal_verdict", aggregate["verdict"])
+
+        # Emit warning telemetry when warning dims drove the non-PASS aggregate.
+        # Build continues regardless of warning-dim verdict; reviewer output stays
+        # in llm_qg.json for human review. Per architectural reset 2026-05-23
+        # (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md).
+        warning_dims = aggregate.get("warning_dims") or ()
+        if aggregate["verdict"] != "PASS" and warning_dims:
+            tracker.emit(
+                "llm_qg_warning",
+                level=level,
+                slug=slug,
+                aggregate_verdict=aggregate["verdict"],
+                terminal_verdict=terminal_verdict,
+                warning_dims=list(warning_dims),
+                rejected_dims=list(aggregate.get("rejected_dims") or ()),
+                min_dim=aggregate.get("min_dim"),
+                min_score=aggregate.get("min_score"),
+            )
+
+        # Only terminal-dim verdicts kill the build.
+        if terminal_verdict != "PASS":
+            failing_terminal_dims = [
+                dim
+                for dim in aggregate.get("failing_dims", ())
+                if dim in LLM_QG_TERMINAL_DIMS
+            ]
             raise linear_pipeline.LinearPipelineError(
-                f"LLM QG verdict was {aggregate['verdict']}"
+                f"LLM QG terminal verdict was {terminal_verdict} "
+                f"(failing terminal dims: {failing_terminal_dims})"
             )
 
         phase = "mdx"

--- a/scripts/common/thresholds.py
+++ b/scripts/common/thresholds.py
@@ -55,6 +55,29 @@ QG_DIMS: tuple[str, ...] = (
 )
 """The 5 LLM QG dimensions per North Star §7."""
 
+LLM_QG_TERMINAL_DIMS: frozenset[str] = frozenset({"decolonization"})
+"""LLM QG dims whose REJECT verdict terminates the build.
+
+Per architectural reset 2026-05-23
+(docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+decision #2): subjective dims (pedagogical, naturalness, engagement, tone)
+were stochastic and produced zero shipped modules across 6 builds
+2026-05-22 to 2026-05-23. They're demoted to warning. Decolonization stays
+terminal because political safety is not subjective: Russian framing leaking
+in is a hard rule, not a judgment call.
+
+Adding a dim here means: a REJECT in that dim raises LinearPipelineError and
+kills the build. Removing a dim means: a REJECT in that dim emits
+llm_qg_warning telemetry but the build continues.
+
+When per-dim LLM/human agreement empirics support re-promotion (about 20+
+shipped modules with captured human decisions; see PR-G placeholder), dims can
+be re-added to this set with the agreement-rate justification logged.
+"""
+
+LLM_QG_WARNING_DIMS: frozenset[str] = frozenset(QG_DIMS) - LLM_QG_TERMINAL_DIMS
+"""Derived: LLM QG dims whose REJECT verdict is logged but does not terminate."""
+
 STYLE_REVIEW_TARGET: float = 9.0
 """Style-reviewer verdict target. Stricter than the general reviewer
 because pragmatic authenticity / stylistic consistency / culture-register /
@@ -128,8 +151,16 @@ class ReviewVerdict:
     """Aggregate LLM QG verdict and the dimensions that drove it."""
 
     verdict: Literal["PASS", "REVISE", "REJECT"]
+    """Full aggregate verdict across all dims. Used for telemetry and review."""
+
+    terminal_verdict: Literal["PASS", "REVISE", "REJECT"]
+    """Verdict computed from LLM_QG_TERMINAL_DIMS only. This gates the build."""
+
     failing_dims: tuple[str, ...]
     rejected_dims: tuple[str, ...]
+    warning_dims: tuple[str, ...]
+    """Subset of failing_dims in LLM_QG_WARNING_DIMS, logged but not terminal."""
+
     min_score: float
     min_dim: str
 
@@ -257,11 +288,7 @@ def aggregate_review(
     scores: Mapping[str, float],
     level_code: str | None,
 ) -> ReviewVerdict:
-    """MIN aggregator for Phase 4 LLM QG.
-
-    PASS iff every scored QG dim is at or above its per-level pass floor.
-    REJECT if any scored QG dim is below its reject floor. Otherwise REVISE.
-    """
+    """MIN aggregator for Phase 4 LLM QG, terminal/warning split."""
     floors = get_level_thresholds(level_code).review_floors
     scored_qg = {dim: score for dim, score in scores.items() if dim in floors}
     if not scored_qg:
@@ -277,9 +304,11 @@ def aggregate_review(
         for dim, score in scored_qg.items()
         if score < floors[dim].reject_floor
     )
+    warnings = tuple(dim for dim in failing if dim in LLM_QG_WARNING_DIMS)
     min_dim = min(scored_qg, key=scored_qg.__getitem__)
     min_score = scored_qg[min_dim]
 
+    # Full verdict: used for telemetry and human review.
     if rejected:
         verdict: Literal["PASS", "REVISE", "REJECT"] = "REJECT"
     elif failing:
@@ -287,10 +316,22 @@ def aggregate_review(
     else:
         verdict = "PASS"
 
+    # Terminal verdict: used for build gating. Only terminal dims count.
+    terminal_rejected = tuple(dim for dim in rejected if dim in LLM_QG_TERMINAL_DIMS)
+    terminal_failing = tuple(dim for dim in failing if dim in LLM_QG_TERMINAL_DIMS)
+    if terminal_rejected:
+        terminal_verdict: Literal["PASS", "REVISE", "REJECT"] = "REJECT"
+    elif terminal_failing:
+        terminal_verdict = "REVISE"
+    else:
+        terminal_verdict = "PASS"
+
     return ReviewVerdict(
         verdict=verdict,
+        terminal_verdict=terminal_verdict,
         failing_dims=failing,
         rejected_dims=rejected,
+        warning_dims=warnings,
         min_score=min_score,
         min_dim=min_dim,
     )

--- a/tests/build/test_v7_build_resume.py
+++ b/tests/build/test_v7_build_resume.py
@@ -1,4 +1,4 @@
-"""Tests for the v7_build.py --resume flag and phase-skip helpers.
+"""Tests for v7_build.py resume-default phase-skip helpers.
 
 Resume policy:
   - A phase is skipped iff its on-disk artifact exists AND reports the canonical
@@ -146,20 +146,40 @@ def test_wiki_coverage_review_reruns_when_overall_fail(module_dir: Path) -> None
 
 # ----- llm_qg ------------------------------------------------------------------
 
-def test_llm_qg_skipped_when_aggregate_pass(module_dir: Path) -> None:
+def test_llm_qg_skipped_when_terminal_verdict_pass(module_dir: Path) -> None:
+    _write_json(
+        module_dir / "llm_qg.json",
+        {
+            "aggregate": {
+                "verdict": "REJECT",
+                "terminal_verdict": "PASS",
+                "min_score": 4.0,
+            }
+        },
+    )
+    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
+
+
+def test_llm_qg_reruns_when_terminal_verdict_revise(module_dir: Path) -> None:
+    _write_json(
+        module_dir / "llm_qg.json",
+        {
+            "aggregate": {
+                "verdict": "REVISE",
+                "terminal_verdict": "REVISE",
+                "min_score": 8.5,
+            }
+        },
+    )
+    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
+
+
+def test_llm_qg_skipped_for_legacy_aggregate_pass(module_dir: Path) -> None:
     _write_json(
         module_dir / "llm_qg.json",
         {"aggregate": {"verdict": "PASS", "min_score": 9.0}},
     )
     assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
-
-
-def test_llm_qg_reruns_when_aggregate_revise(module_dir: Path) -> None:
-    _write_json(
-        module_dir / "llm_qg.json",
-        {"aggregate": {"verdict": "REVISE", "min_score": 6.0}},
-    )
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
 
 
 def test_llm_qg_reruns_when_aggregate_missing(module_dir: Path) -> None:
@@ -176,29 +196,16 @@ def test_unknown_phase_returns_false(module_dir: Path) -> None:
 
 # ----- CLI flag wiring --------------------------------------------------------
 
-def test_parse_args_accepts_resume() -> None:
-    args = v7_build.parse_args(
-        ["a1", "my-morning", "--resume", "/tmp/some/module/dir"]
-    )
-    assert args.resume == "/tmp/some/module/dir"
+def test_parse_args_rejects_removed_resume_flag() -> None:
+    with pytest.raises(SystemExit):
+        v7_build.parse_args(["a1", "my-morning", "--resume", "/tmp/some/module/dir"])
 
 
-def test_parse_args_resume_defaults_to_none() -> None:
+def test_parse_args_resume_defaults_to_enabled() -> None:
     args = v7_build.parse_args(["a1", "my-morning"])
-    assert args.resume is None
+    assert args.no_resume is False
 
 
-def test_main_rejects_resume_with_worktree(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """--resume and --worktree are mutually exclusive — resume already targets
-    an existing build dir, so creating a new worktree alongside it is a
-    user error caught upfront with exit 2."""
-    fake_module = tmp_path / "module"
-    fake_module.mkdir()
-    code = v7_build.main(
-        ["a1", "my-morning", "--resume", str(fake_module), "--worktree"]
-    )
-    assert code == 2
-    captured = capsys.readouterr()
-    assert "mutually exclusive" in captured.err
+def test_parse_args_no_resume_disables_resume_default() -> None:
+    args = v7_build.parse_args(["a1", "my-morning", "--no-resume"])
+    assert args.no_resume is True

--- a/tests/test_llm_qg_demote.py
+++ b/tests/test_llm_qg_demote.py
@@ -1,0 +1,97 @@
+"""Tests for LLM QG terminal/warning dim split (PR-A, 2026-05-23)."""
+
+from scripts.build import linear_pipeline
+from scripts.common.thresholds import (
+    LLM_QG_TERMINAL_DIMS,
+    LLM_QG_WARNING_DIMS,
+    QG_DIMS,
+    aggregate_review,
+)
+
+
+def test_terminal_and_warning_dims_partition_qg_dims() -> None:
+    """LLM_QG_TERMINAL_DIMS union LLM_QG_WARNING_DIMS == QG_DIMS, disjoint."""
+    assert frozenset(QG_DIMS) == LLM_QG_TERMINAL_DIMS | LLM_QG_WARNING_DIMS
+    assert frozenset() == LLM_QG_TERMINAL_DIMS & LLM_QG_WARNING_DIMS
+
+
+def test_decolonization_is_only_terminal_dim_in_2026_05_23_baseline() -> None:
+    """Per architectural reset 2026-05-23 decision #3."""
+    assert frozenset({"decolonization"}) == LLM_QG_TERMINAL_DIMS
+
+
+def test_warning_dim_reject_does_not_drive_terminal_verdict() -> None:
+    """A REJECT in a warning dim leaves terminal_verdict == PASS."""
+    scores = {
+        "pedagogical": 4.0,  # REJECT (below 6.0 reject floor)
+        "naturalness": 9.0,
+        "decolonization": 9.5,  # PASS
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    verdict = aggregate_review(scores, "A1")
+    assert verdict.verdict == "REJECT"
+    assert verdict.terminal_verdict == "PASS"
+    assert "pedagogical" in verdict.rejected_dims
+    assert "pedagogical" in verdict.warning_dims
+
+
+def test_decolonization_reject_drives_terminal_verdict() -> None:
+    """A REJECT in decolonization terminates the build."""
+    scores = {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 4.0,  # REJECT
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    verdict = aggregate_review(scores, "A1")
+    assert verdict.verdict == "REJECT"
+    assert verdict.terminal_verdict == "REJECT"
+    assert "decolonization" in verdict.rejected_dims
+
+
+def test_all_pass_yields_pass_on_both() -> None:
+    scores = {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    verdict = aggregate_review(scores, "A1")
+    assert verdict.verdict == "PASS"
+    assert verdict.terminal_verdict == "PASS"
+    assert verdict.warning_dims == ()
+
+
+def test_warning_revise_does_not_drive_terminal_revise() -> None:
+    """A warning-dim REVISE yields verdict=REVISE but terminal_verdict=PASS."""
+    scores = {
+        "pedagogical": 7.0,  # below A1 pass floor 9.0, above reject floor 6.0
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    verdict = aggregate_review(scores, "A1")
+    assert verdict.verdict == "REVISE"
+    assert verdict.terminal_verdict == "PASS"
+
+
+def test_aggregate_llm_review_json_shape_includes_terminal_warning_fields() -> None:
+    """linear_pipeline.asdict output includes the additive gate fields."""
+    report = {
+        dim: {
+            "score": 4.0 if dim == "pedagogical" else 9.0,
+            "evidence": '"The module gives a concrete morning sequence."',
+            "verdict": "REJECT" if dim == "pedagogical" else "PASS",
+        }
+        for dim in QG_DIMS
+    }
+
+    aggregate = linear_pipeline.aggregate_llm_review(report, "A1")["aggregate"]
+
+    assert aggregate["verdict"] == "REJECT"
+    assert aggregate["terminal_verdict"] == "PASS"
+    assert aggregate["warning_dims"] == ("pedagogical",)

--- a/tests/test_resume_default.py
+++ b/tests/test_resume_default.py
@@ -1,0 +1,15 @@
+"""Tests for --no-resume default behavior (PR-A2, 2026-05-23)."""
+
+import subprocess
+
+
+def test_v7_build_help_lists_no_resume_not_resume() -> None:
+    """--resume flag was removed; --no-resume is the new opt-out."""
+    out = subprocess.run(
+        [".venv/bin/python", "scripts/build/v7_build.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "--no-resume" in out, f"--no-resume missing from --help:\n{out}"
+    assert "--resume" not in out, f"--resume should not be in --help:\n{out}"


### PR DESCRIPTION
## Summary

Implements PR-A + PR-A2 from the 2026-05-23 architectural reset (handoff: `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md`).

### PR-A — LLM dim terminal/warning split

- `LLM_QG_TERMINAL_DIMS = frozenset({"decolonization"})` in `scripts/common/thresholds.py`
- `LLM_QG_WARNING_DIMS = frozenset(QG_DIMS) - LLM_QG_TERMINAL_DIMS` (4 dims: pedagogical, naturalness, engagement, tone)
- `ReviewVerdict` gains `terminal_verdict` and `warning_dims` fields (additive, non-breaking)
- `aggregate_review` computes both verdicts; full aggregate stays for telemetry + human review, terminal verdict gates the build
- `v7_build.py` raises only on `terminal_verdict != PASS`; emits `llm_qg_warning` telemetry when warning dims drove a non-PASS full aggregate
- Decolonization stays terminal — political safety, not subjective

### PR-A2 — --resume default

- `--resume PATH` flag removed; `--no-resume` added as opt-out
- Resume from last failed phase via existing `_phase_artifact_passes` checks, now reading `terminal_verdict` (with back-compat fallback to legacy `verdict`)
- Saves 5-20 min writer-phase replay per failed build

### Breaking CLI change

`--resume MODULE_DIR` is no longer accepted. Migration: use `--out MODULE_DIR` instead (resume is automatic). Test `test_parse_args_rejects_removed_resume_flag` enforces this.

## Why

4 weeks of LLM-dim-terminal gating on subjective dims produced 0 shipped A1 modules across 6 builds 2026-05-22 to 2026-05-23. Per-build replay of the writer phase compounded the cost. Manual human review replaces LLM gating on subjective dims; corpus-grounding gates (wiki obligations, implementation_map, VESUM, MCP) stay load-bearing.

## Test plan

- [x] `tests/test_llm_qg_demote.py` (7 tests) — terminal/warning partition, decolonization-only-terminal, warning-REJECT-doesn't-terminate, decolonization-REJECT-does-terminate, all-pass, warning-REVISE-doesn't-terminate, JSON output shape includes new fields
- [x] `tests/test_resume_default.py` (1 test) — `--help` lists `--no-resume`, omits removed `--resume`
- [x] `tests/build/test_v7_build_resume.py` updated — 14 tests for resume mechanics + CLI; includes back-compat for legacy `aggregate.verdict` payloads
- [x] `tests/test_threshold_source_of_truth.py` (8 tests) — no regression on threshold invariants
- [x] `tests/test_thresholds_consumers.py` + `tests/test_v7_review.py` + related — 50 passed, 2 skipped, 0 failed on the threshold consumer surface
- [x] `ruff check` clean on all touched files

## Co-authoring

Codex (gpt-5.5 xhigh) drafted the edits + tests under dispatch task `pr-a-llm-demote-resume-default-2026-05-23`. Codex stalled at silence timeout after running the test suite but before committing. Orchestrator (Claude) reverted one out-of-scope edit (`starlight/src/content/docs/a1/index.mdx`, unrelated to PR-A scope) and completed the commit + push + PR-open steps.

## Out of scope

- PR-B (band widening) — separate PR, queued
- PR-C (writer prompt strip) — separate PR, requires user review of strip plan at `audit/2026-05-23-writer-prompt-strip-plan/REPORT.html`
- Per-rule firing telemetry — comes with PR-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)