### PR TITLE
feat(audit): widen word_count to 8% lower-band tolerance + drop callout_min to 1 (PR-B)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6455,12 +6455,24 @@ def _word_count(text: str) -> int:
     return len(_WORD_RE.findall(text))
 
 
+# Word-target tolerance: 8% lower band. User direction 2026-05-23
+# (handoff docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+# decision row B): word targets stay as MINIMUMS for the writer prompt
+# guidance, but the gate tolerates ±8% below target to avoid 0.25%-short
+# rejections like deepseek-pro 1197/1200. Empirically the 8% band still
+# rejects gemini-tools 1031/1200 (14% short).
+_WORD_COUNT_TOLERANCE_BELOW = 0.08
+
+
 def _word_count_gate(text: str, target: int) -> dict[str, Any]:
     count = _word_count(_strip_comments(text))
+    min_with_tolerance = int(target * (1 - _WORD_COUNT_TOLERANCE_BELOW))
     return {
-        "passed": count >= target,
+        "passed": count >= min_with_tolerance,
         "count": count,
         "target": target,
+        "min_with_tolerance": min_with_tolerance,
+        "tolerance_below_pct": _WORD_COUNT_TOLERANCE_BELOW * 100,
     }
 
 
@@ -8810,7 +8822,10 @@ def _engagement_floor_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]
     callout_hits = _CALLOUT_PATTERN.findall(text)
     meta_hits = sorted({m.lower().strip() for m in _META_NARRATION_RE.findall(text)})
 
-    callout_min = 2
+    # callout_min: 2 → 1 per user direction 2026-05-23 (handoff decision row B).
+    # Writers consistently emit 1 callout; "minimum 2" was aspirational not
+    # empirical. The full engagement_floor still catches modules with 0 callouts.
+    callout_min = 1
     callouts_ok = len(callout_hits) >= callout_min
     meta_ok = not meta_hits
 

--- a/tests/test_pr_b_band_widening.py
+++ b/tests/test_pr_b_band_widening.py
@@ -1,0 +1,103 @@
+"""Tests for PR-B band widening: word_count tolerance + callout_min (2026-05-23)."""
+
+from scripts.build.linear_pipeline import (
+    _engagement_floor_gate,
+    _word_count_gate,
+)
+
+# ----- word_count tolerance --------------------------------------------------
+
+
+def test_word_count_at_target_passes() -> None:
+    """Baseline: count exactly at target passes."""
+    text = "word " * 1200
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+    assert report["count"] == 1200
+
+
+def test_word_count_above_target_passes() -> None:
+    text = "word " * 1300
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+
+
+def test_word_count_within_8pct_tolerance_passes() -> None:
+    """Regression: deepseek-pro 1197 vs A1 target 1200 (0.25% short) now passes."""
+    text = "word " * 1197
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+    assert report["count"] == 1197
+    assert report["min_with_tolerance"] == 1104  # int(1200 * 0.92)
+
+
+def test_word_count_at_band_edge_passes() -> None:
+    """count == min_with_tolerance (target * 0.92) passes."""
+    text = "word " * 1104  # int(1200 * 0.92)
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+    assert report["min_with_tolerance"] == 1104
+
+
+def test_word_count_just_below_band_fails() -> None:
+    """count == min_with_tolerance - 1 fails."""
+    text = "word " * 1103
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is False
+    assert report["count"] == 1103
+
+
+def test_word_count_14pct_below_target_fails() -> None:
+    """Regression: gemini-tools 1031 vs A1 target 1200 (14% short) still fails."""
+    text = "word " * 1031
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is False
+    assert report["count"] == 1031
+
+
+def test_word_count_reports_tolerance_metadata() -> None:
+    """The gate report includes min_with_tolerance + tolerance_below_pct."""
+    report = _word_count_gate("word " * 1200, 1200)
+    assert report["min_with_tolerance"] == 1104
+    assert report["tolerance_below_pct"] == 8.0
+    assert report["target"] == 1200
+
+
+# ----- callout_min ------------------------------------------------------------
+
+
+def test_engagement_floor_passes_with_one_callout() -> None:
+    """Regression: single callout now satisfies the floor (was minimum 2)."""
+    text = """
+# Module
+
+Some intro prose.
+
+:::tip
+A pedagogical mnemonic the learner can carry.
+:::
+
+More prose with a bullet list:
+
+- Перший приклад (first example)
+- Другий приклад (second example)
+- Третій приклад (third example)
+- Четвертий приклад (fourth example)
+- П'ятий приклад (fifth example)
+- Шостий приклад (sixth example)
+"""
+    plan = {"word_target": 100, "level": "a1"}
+    report = _engagement_floor_gate(text, plan)
+    # callout_min is the load-bearing check for this PR. The engagement_floor
+    # also requires other signals; we assert specifically on callout_min.
+    assert report["callout_min"] == 1
+    # If the only failing dimension was callout count, passing now succeeds.
+    assert report["callout_count"] >= 1
+
+
+def test_engagement_floor_callout_min_is_1() -> None:
+    """The callout floor is exactly 1, not 2 (regression on PR-B)."""
+    text = ":::tip\nA mnemonic.\n:::\n"
+    plan = {"word_target": 100, "level": "a1"}
+    report = _engagement_floor_gate(text, plan)
+    assert report["callout_min"] == 1


### PR DESCRIPTION
## Summary

Implements PR-B from the 2026-05-23 architectural reset (handoff: `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md`, decision row B).

### word_count tolerance

`_word_count_gate` was `count >= target` (one-sided floor, no tolerance). Now `count >= int(target * 0.92)`. The gate report adds `min_with_tolerance` and `tolerance_below_pct` for telemetry.

Empirical justification:
- deepseek-pro 1197/1200 (0.25% short) → was rejected; now passes
- gemini-tools 1031/1200 (14% short) → was rejected; still rejected
- Tolerance 8% catches the rounding-error case while preserving the quality floor

### engagement_floor callout_min

`callout_min` 2 → 1. Writers consistently emit 1 callout; minimum-2 was aspirational. Modules with 0 callouts still fail.

## Why

Word targets remain MINIMUMS in the writer prompt + per-section budgets (user direction 2026-05-23 reaffirming 2026-05-17). The tolerance applies only at the deterministic gate level. A 0.25% shortfall is a rounding error, not a quality regression. The previous gate rejected deepseek-pro 1197 on this basis, wasting a build.

## Test plan

- [x] `tests/test_pr_b_band_widening.py` (9 tests) — at-target, above-target, within-tolerance, band-edge, just-below-band, 14%-below, metadata reporting; callout_min == 1
- [x] Pipeline-helpers regression tests pass
- [x] `ruff check` clean

## Breaking change

None. Gate report adds new fields (`min_with_tolerance`, `tolerance_below_pct`); existing fields unchanged.

## Out of scope

- PR-C (writer prompt strip) — requires user review of strip plan at `audit/2026-05-23-writer-prompt-strip-plan/REPORT.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)