### PR TITLE
feat(bridge): ab ask-hermes + ab ask-opencode subcommands (PR-D1)

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -28,6 +28,7 @@ from ._dispatch_wrappers import (
     handle_review_deep,
 )
 from ._gemini import ask_gemini, converse_gemini, process_and_respond
+from ._hermes import HERMES_DEFAULT_MODEL, ask_hermes
 from ._messaging import (
     acknowledge,
     acknowledge_all,
@@ -37,6 +38,7 @@ from ._messaging import (
     send_message,
 )
 from ._model import check_model
+from ._opencode import OPENCODE_DEFAULT_MODEL, ask_opencode
 
 _CALLER_IDENTITY_ENV_HINTS = (
     "CLAUDE_AGENT_NAME",
@@ -562,6 +564,44 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_agy_parser.add_argument("--review", action="store_true",
                                 help="Prepend docs/review-protocol.md")
 
+    # ask-hermes
+    ask_hermes_parser = subparsers.add_parser(
+        "ask-hermes",
+        help="Send message AND invoke Hermes one-shot (use '-' to read from stdin)",
+    )
+    ask_hermes_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_hermes_parser.add_argument("--task-id", required=True, help="Task ID")
+    ask_hermes_parser.add_argument("--type", default="query", help="Message type")
+    ask_hermes_parser.add_argument("--data", help="Path to data file to attach")
+    ask_hermes_parser.add_argument(
+        "--model",
+        default=HERMES_DEFAULT_MODEL,
+        help=f"Hermes model (default {HERMES_DEFAULT_MODEL})",
+    )
+    ask_hermes_parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+    ask_hermes_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
+    ask_hermes_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
+    ask_hermes_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+
+    # ask-opencode
+    ask_opencode_parser = subparsers.add_parser(
+        "ask-opencode",
+        help="Send message AND invoke opencode one-shot (use '-' to read from stdin)",
+    )
+    ask_opencode_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_opencode_parser.add_argument("--task-id", required=True, help="Task ID")
+    ask_opencode_parser.add_argument("--type", default="query", help="Message type")
+    ask_opencode_parser.add_argument("--data", help="Path to data file to attach")
+    ask_opencode_parser.add_argument(
+        "--model",
+        default=OPENCODE_DEFAULT_MODEL,
+        help=f"Opencode model (default {OPENCODE_DEFAULT_MODEL})",
+    )
+    ask_opencode_parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+    ask_opencode_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
+    ask_opencode_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
+    ask_opencode_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
     converse_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
@@ -777,6 +817,10 @@ def _dispatch_command(args):
         _handle_ask_gemini(args)
     elif args.command == "ask-agy":
         _handle_ask_agy(args)
+    elif args.command == "ask-hermes":
+        _handle_ask_hermes(args)
+    elif args.command == "ask-opencode":
+        _handle_ask_opencode(args)
     elif args.command == "converse":
         content = sys.stdin.read() if args.content == "-" else args.content
         converse_gemini(content, args.task_id, args.model,
@@ -870,6 +914,40 @@ def _handle_ask_agy(args):
     ask_agy(content, args.task_id, args.type, data,
             args.new_session, from_llm, args.from_model,
             args.to_model, args.no_timeout, **kwargs)
+
+
+def _handle_ask_hermes(args):
+    """Handle ask-hermes subcommand."""
+    content = sys.stdin.read() if args.content == "-" else args.content
+    from_llm = _resolve_from_llm(args)
+    ask_hermes(
+        content,
+        args.task_id,
+        msg_type=args.type,
+        data=args.data,
+        model=args.model,
+        from_llm=from_llm,
+        from_model=args.from_model,
+        to_model=args.to_model,
+        no_timeout=args.no_timeout,
+    )
+
+
+def _handle_ask_opencode(args):
+    """Handle ask-opencode subcommand."""
+    content = sys.stdin.read() if args.content == "-" else args.content
+    from_llm = _resolve_from_llm(args)
+    ask_opencode(
+        content,
+        args.task_id,
+        msg_type=args.type,
+        data=args.data,
+        model=args.model,
+        from_llm=from_llm,
+        from_model=args.from_model,
+        to_model=args.to_model,
+        no_timeout=args.no_timeout,
+    )
 
 
 def _handle_ask_gemini(args):

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -1,0 +1,106 @@
+"""Hermes adapter for ai_agent_bridge ask-hermes subcommand.
+
+Mirrors ask-codex / ask-gemini pattern. Hermes is the underlying runtime for
+several already-supported model adapters (hermes_grok, hermes_deepseek,
+hermes_qwen). This bridge subcommand exposes ad-hoc one-shot Hermes calls
+with arbitrary models so cross-model adversarial reviews can route through
+hermes the same way they route through codex/gemini.
+
+Invocation pattern:
+    .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-hermes <content> \\
+      --task-id <task> --model qwen/qwen3.6-plus
+
+Under the hood: hermes -z "<content>" -m <model>
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._messaging import acknowledge, send_message
+
+HERMES_DEFAULT_MODEL = "qwen/qwen3.6-plus"
+HERMES_DEFAULT_TIMEOUT_S = 900  # 15 min — adversarial reviews can be long
+
+
+def ask_hermes(
+    content: str,
+    task_id: str,
+    msg_type: str = "query",
+    data: str | None = None,
+    model: str | None = None,
+    from_llm: str = "claude",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+) -> int:
+    """Send message to Hermes AND invoke Hermes one-shot to process it."""
+    effective_model = model or HERMES_DEFAULT_MODEL
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="hermes",
+        from_model=from_model,
+        to_model=to_model or effective_model,
+    )
+    print(f"\n🚀 Invoking Hermes ({effective_model}) to process message #{msg_id}...")
+    response = _invoke_hermes(content, effective_model, data=data, no_timeout=no_timeout)
+
+    reply_id = send_message(
+        content=response,
+        task_id=task_id,
+        msg_type="response",
+        from_llm="hermes",
+        to_llm=from_llm,
+        to_model=from_model,
+    )
+    acknowledge(msg_id)
+    acknowledge(reply_id)
+
+    return msg_id
+
+
+def _invoke_hermes(
+    content: str,
+    model: str,
+    *,
+    data: str | None = None,
+    no_timeout: bool = False,
+) -> str:
+    """Run hermes -z PROMPT -m MODEL; return captured stdout."""
+    hermes_bin = shutil.which("hermes")
+    if not hermes_bin:
+        raise SystemExit("ask-hermes: hermes CLI not found in PATH")
+
+    # If data file attached, prepend its content to the prompt under a fenced block.
+    prompt = content
+    if data:
+        data_path = Path(data)
+        if not data_path.exists():
+            raise SystemExit(f"ask-hermes: --data file does not exist: {data}")
+        attached = data_path.read_text(encoding="utf-8", errors="replace")
+        prompt = f"{content}\n\n## Attached data: {data_path.name}\n\n```\n{attached}\n```"
+
+    timeout = None if no_timeout else HERMES_DEFAULT_TIMEOUT_S
+    try:
+        result = subprocess.run(
+            [hermes_bin, "-z", prompt, "-m", model],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"ask-hermes: hermes timed out after {timeout}s") from exc
+
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ask-hermes: hermes exited {result.returncode}\n"
+            f"stderr: {result.stderr[-2000:]}"
+        )
+
+    return result.stdout.strip()

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -1,0 +1,108 @@
+"""Opencode adapter for ai_agent_bridge ask-opencode subcommand.
+
+Exposes ad-hoc one-shot opencode calls with arbitrary openrouter models.
+Useful for cross-model adversarial reviews where the target model isn't
+in the hermes proxy (e.g. openrouter/qwen/qwen3.7-max as demonstrated in
+the 2026-05-23 strip-plan review).
+
+Invocation pattern:
+    .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-opencode <content> \\
+      --task-id <task> --model openrouter/qwen/qwen3.7-max [--data FILE]
+
+Under the hood: opencode run --model PROVIDER/MODEL [--file FILE] "CONTENT"
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._messaging import acknowledge, send_message
+
+OPENCODE_DEFAULT_MODEL = "openrouter/qwen/qwen3.7-max"
+OPENCODE_DEFAULT_TIMEOUT_S = 900
+
+
+def ask_opencode(
+    content: str,
+    task_id: str,
+    msg_type: str = "query",
+    data: str | None = None,
+    model: str | None = None,
+    from_llm: str = "claude",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+) -> int:
+    effective_model = model or OPENCODE_DEFAULT_MODEL
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="opencode",
+        from_model=from_model,
+        to_model=to_model or effective_model,
+    )
+    print(f"\n🚀 Invoking opencode ({effective_model}) to process message #{msg_id}...")
+    response = _invoke_opencode(content, effective_model, data=data, no_timeout=no_timeout)
+
+    reply_id = send_message(
+        content=response,
+        task_id=task_id,
+        msg_type="response",
+        from_llm="opencode",
+        to_llm=from_llm,
+        to_model=from_model,
+    )
+    acknowledge(msg_id)
+    acknowledge(reply_id)
+
+    return msg_id
+
+
+def _invoke_opencode(
+    content: str,
+    model: str,
+    *,
+    data: str | None = None,
+    no_timeout: bool = False,
+) -> str:
+    opencode_bin = shutil.which("opencode")
+    if not opencode_bin:
+        raise SystemExit("ask-opencode: opencode CLI not found in PATH")
+
+    argv = [opencode_bin, "run", "--model", model, "--format", "default"]
+    if data:
+        data_path = Path(data)
+        if not data_path.exists():
+            raise SystemExit(f"ask-opencode: --data file does not exist: {data}")
+        argv.extend(["--file", str(data_path.resolve()), "--"])
+    argv.append(content)
+
+    timeout = None if no_timeout else OPENCODE_DEFAULT_TIMEOUT_S
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"ask-opencode: opencode timed out after {timeout}s") from exc
+
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ask-opencode: opencode exited {result.returncode}\n"
+            f"stderr: {result.stderr[-2000:]}"
+        )
+
+    # opencode run prints ANSI control codes and a banner before the response.
+    # Strip leading ANSI sequences and the "build · model" line.
+    output = result.stdout
+    # Crude strip: lines that are escape sequences or the banner.
+    # If a more robust ANSI stripper exists in the project (e.g. _ANSI_RE in
+    # hermes adapters), reuse it.
+    return output.strip()

--- a/tests/test_ask_hermes.py
+++ b/tests/test_ask_hermes.py
@@ -1,0 +1,53 @@
+"""Tests for ab ask-hermes bridge subcommand (PR-D1)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.ai_agent_bridge._hermes import HERMES_DEFAULT_MODEL, _invoke_hermes
+
+
+def test_hermes_default_model_is_qwen_plus():
+    assert HERMES_DEFAULT_MODEL == "qwen/qwen3.6-plus"
+
+
+def test_invoke_hermes_constructs_correct_argv(tmp_path):
+    """Hermes subprocess is invoked with -z PROMPT -m MODEL."""
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value="/fake/hermes"):
+        with patch("scripts.ai_agent_bridge._hermes.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="response body", stderr="")
+            _invoke_hermes("hello", "qwen/qwen3.6-plus")
+            argv = run_mock.call_args[0][0]
+            assert argv[0] == "/fake/hermes"
+            assert "-z" in argv
+            assert "hello" in argv
+            assert "-m" in argv
+            assert "qwen/qwen3.6-plus" in argv
+
+
+def test_invoke_hermes_attaches_data_file(tmp_path):
+    data_file = tmp_path / "context.md"
+    data_file.write_text("# Context\nSome content.")
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value="/fake/hermes"):
+        with patch("scripts.ai_agent_bridge._hermes.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+            _invoke_hermes("review this", "qwen/qwen3.6-plus", data=str(data_file))
+            argv = run_mock.call_args[0][0]
+            # data should be in the prompt, not as a separate flag
+            prompt_arg = argv[argv.index("-z") + 1]
+            assert "Some content." in prompt_arg
+            assert "review this" in prompt_arg
+
+
+def test_invoke_hermes_raises_when_binary_missing():
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value=None):
+        with pytest.raises(SystemExit, match="hermes CLI not found"):
+            _invoke_hermes("hello", "qwen/qwen3.6-plus")
+
+
+def test_invoke_hermes_raises_on_nonzero_exit():
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value="/fake/hermes"):
+        with patch("scripts.ai_agent_bridge._hermes.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=1, stdout="", stderr="auth failed")
+            with pytest.raises(SystemExit, match="hermes exited 1"):
+                _invoke_hermes("hello", "qwen/qwen3.6-plus")

--- a/tests/test_ask_opencode.py
+++ b/tests/test_ask_opencode.py
@@ -1,0 +1,45 @@
+"""Tests for ab ask-opencode bridge subcommand (PR-D1)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.ai_agent_bridge._opencode import OPENCODE_DEFAULT_MODEL, _invoke_opencode
+
+
+def test_opencode_default_model_is_qwen_max():
+    assert OPENCODE_DEFAULT_MODEL == "openrouter/qwen/qwen3.7-max"
+
+
+def test_invoke_opencode_constructs_correct_argv():
+    with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value="/fake/opencode"):
+        with patch("scripts.ai_agent_bridge._opencode.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="response", stderr="")
+            _invoke_opencode("hello", "openrouter/qwen/qwen3.7-max")
+            argv = run_mock.call_args[0][0]
+            assert argv[0] == "/fake/opencode"
+            assert argv[1] == "run"
+            assert "--model" in argv
+            assert "openrouter/qwen/qwen3.7-max" in argv
+            assert "hello" in argv
+
+
+def test_invoke_opencode_attaches_file(tmp_path):
+    data_file = tmp_path / "report.html"
+    data_file.write_text("<html><body>data</body></html>")
+    with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value="/fake/opencode"):
+        with patch("scripts.ai_agent_bridge._opencode.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+            _invoke_opencode("review", "openrouter/qwen/qwen3.7-max", data=str(data_file))
+            argv = run_mock.call_args[0][0]
+            assert "--file" in argv
+            # file path is in argv right after --file
+            file_idx = argv.index("--file")
+            assert str(data_file.resolve()) == argv[file_idx + 1]
+            assert argv[file_idx + 2] == "--"
+
+
+def test_invoke_opencode_raises_when_binary_missing():
+    with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value=None):
+        with pytest.raises(SystemExit, match="opencode CLI not found"):
+            _invoke_opencode("hello", "openrouter/qwen/qwen3.7-max")


### PR DESCRIPTION
Adds first-class bridge support for two more agents:

- ask-hermes: one-shot hermes -z PROMPT -m MODEL via the hermes CLI. Default
  model qwen/qwen3.6-plus (matches the hermes_qwen adapter default at
  scripts/agent_runtime/adapters/hermes_qwen.py). Useful for ad-hoc cross-
  model reviews via hermes proxy.

- ask-opencode: one-shot opencode run --model PROVIDER/MODEL via opencode
  CLI. Default model openrouter/qwen/qwen3.7-max (demonstrated as effective
  adversarial reviewer in the 2026-05-23 strip-plan review). Useful for
  routing models not in hermes proxy (any openrouter model).

Both subcommands mirror the existing ask-codex / ask-gemini pattern:
broker send → CLI invoke → broker reply. Optional --data flag attaches
file content to the prompt for context.

Out of scope: delegate.py --agent hermes / --agent opencode for dispatched
commits-and-PR work. That's PR-D2 (filed as follow-up).

Per user direction 2026-05-23: "would like both hermes and opencode
support for everything."