### PR TITLE
fix(codex-adapter): normalize payload before rollout match (#2239)

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -33,6 +33,7 @@ import os
 import re
 import shutil
 import tempfile
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -65,6 +66,13 @@ _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 # so ^/$ match at each line boundary.
 _CODEX_DIVIDER_LINE_RE = re.compile(r"^-{3,}\s*$", re.MULTILINE)
 _DISCUSS_READONLY_TOOL_CONFIG_KEY = "discussion_readonly"
+
+
+def _normalize_payload_for_rollout_match(payload: str) -> str:
+    """Normalize Codex-stored prompt text before rollout binding."""
+    normalized = unicodedata.normalize("NFC", payload)
+    normalized = normalized.replace("\r\n", "\n").replace("\r", "\n")
+    return normalized.rstrip()
 
 
 def _discussion_readonly_requested(tool_config: dict | None) -> bool:
@@ -786,7 +794,7 @@ class CodexAdapter:
         Validate against the actual stdin payload so we never recover unrelated
         durable output from another task in the same repo.
         """
-        expected = (plan.stdin_payload or "").rstrip()
+        expected = _normalize_payload_for_rollout_match(plan.stdin_payload or "")
         if not expected:
             return True
 
@@ -809,7 +817,8 @@ class CodexAdapter:
                         event.get("type") == "event_msg"
                         and payload.get("type") == "user_message"
                         and isinstance(payload.get("message"), str)
-                        and payload["message"].rstrip() == expected
+                        and _normalize_payload_for_rollout_match(payload["message"])
+                        == expected
                     ):
                         return True
 
@@ -826,7 +835,11 @@ class CodexAdapter:
                                     text = item.get("text")
                                     if isinstance(text, str):
                                         parts.append(text)
-                            if parts and "\n".join(parts).rstrip() == expected:
+                            if (
+                                parts
+                                and _normalize_payload_for_rollout_match("\n".join(parts))
+                                == expected
+                            ):
                                 return True
             return False
         except Exception:

--- a/tests/agent_runtime/test_codex_adapter.py
+++ b/tests/agent_runtime/test_codex_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.agent_runtime.adapters.codex import CodexAdapter
+
+
+def test_codex_build_invocation_sends_prompt_via_stdin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("scripts.agent_runtime.adapters.codex.shutil.which", lambda _: "codex")
+    adapter = CodexAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="write the module",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model="gpt-5.5",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+        effort="xhigh",
+    )
+
+    assert plan.cwd == tmp_path
+    assert plan.stdin_payload == "write the module"
+    assert plan.cmd[-1] == "-"
+
+
+def test_codex_build_invocation_honors_scoped_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("scripts.agent_runtime.adapters.codex.shutil.which", lambda _: "codex")
+    adapter = CodexAdapter()
+    scoped_home = tmp_path / "codex-home"
+
+    plan = adapter.build_invocation(
+        prompt="write the module",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={"codex_home_override": str(scoped_home)},
+        effort=None,
+    )
+
+    assert plan.env_overrides["CODEX_HOME"] == str(scoped_home)

--- a/tests/agent_runtime/test_codex_rollout_match.py
+++ b/tests/agent_runtime/test_codex_rollout_match.py
@@ -1,0 +1,89 @@
+"""Regression tests for Codex rollout binding (#2239)."""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from pathlib import Path
+
+from scripts.agent_runtime.adapters.base import InvocationPlan
+from scripts.agent_runtime.adapters.codex import CodexAdapter
+
+
+def _plan(tmp_path: Path, stdin_payload: str) -> InvocationPlan:
+    return InvocationPlan(cmd=["codex"], cwd=tmp_path, stdin_payload=stdin_payload)
+
+
+def _write_rollout(tmp_path: Path, user_message: str) -> Path:
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(
+        json.dumps(
+            {
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": user_message},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return rollout
+
+
+def test_rollout_matches_with_trailing_newline(tmp_path: Path) -> None:
+    """Codex CLI may add or strip a final newline when storing rollouts."""
+    adapter = CodexAdapter()
+    rollout = _write_rollout(tmp_path, "hello world\n")
+
+    assert adapter._rollout_matches_plan(rollout, _plan(tmp_path, "hello world")) is True
+
+
+def test_rollout_matches_with_crlf_normalization(tmp_path: Path) -> None:
+    """CRLF in rollout storage matches LF in the invocation payload."""
+    adapter = CodexAdapter()
+    rollout = _write_rollout(tmp_path, "line1\r\nline2\r\nline3\r\n")
+
+    assert (
+        adapter._rollout_matches_plan(
+            rollout,
+            _plan(tmp_path, "line1\nline2\nline3"),
+        )
+        is True
+    )
+
+
+def test_rollout_matches_with_unicode_normalization(tmp_path: Path) -> None:
+    """NFD prompt storage matches the invocation's NFC payload."""
+    adapter = CodexAdapter()
+    rollout = _write_rollout(tmp_path, unicodedata.normalize("NFD", "їжак"))
+
+    assert adapter._rollout_matches_plan(rollout, _plan(tmp_path, "їжак")) is True
+
+
+def test_rollout_rejects_unrelated_message(tmp_path: Path) -> None:
+    """Different content should still reject."""
+    adapter = CodexAdapter()
+    rollout = _write_rollout(tmp_path, "goodbye")
+
+    assert adapter._rollout_matches_plan(rollout, _plan(tmp_path, "hello")) is False
+
+
+def test_rollout_matches_response_item_shape(tmp_path: Path) -> None:
+    """response_item events with content-list shape also match."""
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(
+        json.dumps(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"text": "the prompt body"}],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    adapter = CodexAdapter()
+
+    assert adapter._rollout_matches_plan(rollout, _plan(tmp_path, "the prompt body")) is True


### PR DESCRIPTION
## Summary

Closes #2239. Rollout-binding in `scripts/agent_runtime/adapters/codex.py::_rollout_matches_plan` rejected valid 1MB rollouts with 48 valid mcp__sources__* tool calls because byte-exact equality didn't account for Codex CLI's storage-side normalization.

Fix: apply NFC + CRLF→LF + trailing-whitespace normalization on BOTH sides via new `_normalize_payload_for_rollout_match` helper.

## Tests

- trailing-newline tolerance
- CRLF→LF normalization
- NFC unicode normalization
- still rejects truly unrelated messages (no false positives)
- response_item content-list shape matches
- existing stdin-payload + scoped CODEX_HOME regression tests pass

7/7 passed. Ruff clean.

## Co-authoring

Codex drafted fix + tests under dispatch `issue-2239-codex-rollout-binding-fix-2026-05-23`. Stalled at silence timeout before commit (same PR-A pattern). Orchestrator finished commit + push + PR inline. Going forward: 60min silence timeout on codex dispatches.

## Unblocks

- codex-tools as V7 seminar writer (only writer that invokes query_ulif + query_pravopys + search_heritage)
- Fair codex-tools bakeoff for A1 once PR-C lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)