### PR TITLE
fix(writer-prompt): restore artifact-emission spec stripped in PR-C

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -452,6 +452,62 @@ Before artifacts, make the in-scope MCP calls your draft depends on:
 
 If a required call is missing for your level, make it now. Do not emit artifacts first and hope the gate catches it.
 
+## Artifact emission format (STRICT — restored 2026-05-23 after PR-C strip)
+
+Return the visible `<plan_reasoning>` blocks first, then exactly these four fenced blocks in the order below, then the `<end_gate>` block. Do not add any other prose anywhere.
+
+**Three structured artifacts (`activities.yaml`, `vocabulary.yaml`, `resources.yaml`) MUST be emitted as 3-backtick fenced blocks labelled with language `json` and an info-string `file=<name>`.** The pipeline parses them with `json.loads`. Do NOT use `yaml`, `activities.yaml`, or bare `\`\`\`` as the fence info — those fail at writer-output parse with `must be fenced as json, got <X>`.
+
+```json file=activities.yaml
+[
+  {
+    "id": "act-1",
+    "type": "fill-in",
+    "instruction": "Complete each sentence with the best word.",
+    "items": [
+      {
+        "sentence": "Я ____ о сьомій.",
+        "answer": "прокидаюся",
+        "options": ["прокидаюся", "сплю", "йду"]
+      }
+    ]
+  }
+]
+```
+
+```json file=vocabulary.yaml
+[
+  {
+    "lemma": "прокидатися",
+    "translation": "to wake up",
+    "pos": "verb",
+    "usage": "Я прокидаюся о сьомій."
+  }
+]
+```
+
+```json file=resources.yaml
+[
+  {
+    "title": "Караман Grade 10, p.176",
+    "role": "textbook",
+    "notes": "Зворотні дієслова: суфікс -ся означає дію, спрямовану на себе."
+  }
+]
+```
+
+Each activity object MUST carry the props for its declared `type` per the `COMPONENT_PROPS_SCHEMA` table. Do not strip an `items` array down to `id/type/title` just because the example above looks short.
+
+**Wrap the `module.md` artifact in a 4-backtick OUTER fence.** The OPEN fence MUST be exactly one line: four backticks, then a single space, then the info string `markdown file=module.md`, then newline. Like this (one line, no mid-line break):
+
+````markdown file=module.md
+...module body here, may contain inner 3-backtick fences for examples...
+````
+
+DO NOT split the info string across two lines (i.e. NEVER emit ` ```` ` then a newline then `markdown file=module.md`) — the parser scans the fence-open line for `file=`; a separate line gets tagged "unnamed fenced block" and the build hard-fails at writer-output parse.
+
+The CLOSE fence is four bare backticks on their own line.
+
 ## HARD STOP RULE
 
 After emitting all required `<plan_reasoning>` blocks, the 4 artifact fences


### PR DESCRIPTION
## Summary
- PR-C ([#2244](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2244)) stripped the artifact-emission specification from `scripts/build/phases/linear-write.md`. The 2026-05-23 validation build for `a1/my-morning` failed at the first parse attempt: `module_failed reason="activities.yaml must be fenced as json, got activities.yaml at line 231"`.
- Writer defaulted to legacy `\`\`\`activities.yaml` fence because the strip removed both the `language=json` requirement AND the four artifact skeletons that exemplified the correct format.
- This restore puts back the four skeletons + the explicit `\`\`\`json file=<name>` rule + the 4-backtick OUTER fence for `module.md`. +2.3KB net; rendered prompt still well under the 130KB ceiling.

## Root cause
`scripts/build/linear_pipeline.py:3387` requires any artifact in `WRITER_JSON_ARTIFACTS` (`activities.yaml`, `vocabulary.yaml`, `resources.yaml`) to be fenced as `\`\`\`json file=<name>`. PR-C salvage rounds 1+2 verified the structural-tests assert verbatim against named sections — but the artifact-emission section wasn't covered by an assert that would have caught the strip, so it shipped as a silent prompt regression. 100% of builds now fail at writer-output parse.

## What this restore does NOT include
- A unit test that asserts the writer prompt contains the artifact-emission spec verbatim. Filed as a follow-up — the right shape is a test that renders the writer prompt and asserts on the presence of `\`\`\`json file=activities.yaml`, `\`\`\`json file=vocabulary.yaml`, `\`\`\`json file=resources.yaml`, and the 4-backtick `markdown file=module.md` example.

## Test plan
- [ ] CI: writer-prompt size ceiling test (`scripts/audit/check_writer_prompt_size.py`) — locally green at 33.8KB (within ceiling).
- [ ] CI: full structural test suite green.
- [ ] After merge: re-fire `v7_build.py a1 my-morning --writer claude-tools --effort xhigh --worktree` validation build → expect `module_done` instead of `module_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)