### PR TITLE
fix(plans/lit-doc): scaffold missing required fields in amelina-women-looking-at-war (closes #2220)

### DIFF
--- a/curriculum/l2-uk-en/plans/lit-doc/amelina-women-looking-at-war.yaml
+++ b/curriculum/l2-uk-en/plans/lit-doc/amelina-women-looking-at-war.yaml
@@ -38,7 +38,17 @@ content_outline:
   words: 800
 focus: Posthumous legacy, war documentation, Truth Hounds.
 level: LIT.DOC
+module: lit-doc-013
+objectives:
+- Аналізувати діяльність Вікторії Амеліної як документаторки воєнних злочинів та її внесок у фіксацію правди про війну.
+- Оцінювати вплив проєкту «Women Looking at War» на формування пам'яті та жіночу суб'єктність в умовах конфлікту.
+- Досліджувати стилістичні та наративні особливості творчості письменниці в контексті деколонізаційної перспективи.
+- Визначати роль літератури та документальних свідчень у збереженні культурної спадщини та протидії стиранню національної ідентичності.
 sequence: 13
 slug: amelina-women-looking-at-war
+title: 'Вікторія Амеліна: «Women Looking at War»'
 track: lit-doc
+version: 1.0.0
+vocabulary_hints: []
 word_target: 5000
+phase: LIT.DOC.1


### PR DESCRIPTION
**Scaffolded Fields:**
- `module`: `lit-doc-013` (derived from sibling plan conventions, using sequence 13)
- `title`: `'Вікторія Амеліна: «Women Looking at War»'` (derived from `TOPIC_TITLE` in `curriculum/l2-uk-en/_archive/lit-doc/orchestration/amelina-women-looking-at-war/placeholders.yaml`)
- `objectives`: Derived 4 learner-actionable objectives from the `content_outline` and `focus` in `curriculum/l2-uk-en/_archive/lit-doc/orchestration/amelina-women-looking-at-war/phase-A-output.md` as an explicit objectives document was missing.
- `version`: `1.0.0` (per instructions)
- `phase`: `LIT.DOC.1` (added to pass validation)
- `vocabulary_hints`: `[]` (added to pass validation)

**Validator Output:**
`curriculum/l2-uk-en/plans/lit-doc/amelina-women-looking-at-war.yaml: module-level plan validated`

**Tests Output:**
`======================= 283 passed, 17 skipped in 0.23s ========================`
*(Note: tests/audit/test_validate_plan.py and tests/audit/test_plan_invariants.py were not found; ran tests/audit/test_config_invariants.py instead)*