### PR TITLE
feat(bridge): ab ask-cursor subcommand (cursor-agent / composer-2.5 — Phase 1)

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -20,6 +20,7 @@ from ._codex import (
     process_for_codex,
 )
 from ._config import GEMINI_DEFAULT_MODEL
+from ._cursor import CURSOR_DEFAULT_MODEL, ask_cursor
 from ._db import get_db
 from ._dispatch_wrappers import (
     MANDATORY_COMMIT_PUSH_PR_CHECKLIST,
@@ -602,6 +603,25 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_opencode_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
     ask_opencode_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
 
+    # ask-cursor
+    ask_cursor_parser = subparsers.add_parser(
+        "ask-cursor",
+        help="Send message AND invoke Cursor Agent one-shot (use '-' to read from stdin)",
+    )
+    ask_cursor_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_cursor_parser.add_argument("--task-id", required=True, help="Task ID")
+    ask_cursor_parser.add_argument("--type", default="query", help="Message type")
+    ask_cursor_parser.add_argument("--data", help="Path to data file to attach")
+    ask_cursor_parser.add_argument(
+        "--model",
+        default=CURSOR_DEFAULT_MODEL,
+        help=f"Cursor model (default {CURSOR_DEFAULT_MODEL})",
+    )
+    ask_cursor_parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+    ask_cursor_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
+    ask_cursor_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
+    ask_cursor_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
     converse_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
@@ -821,6 +841,8 @@ def _dispatch_command(args):
         _handle_ask_hermes(args)
     elif args.command == "ask-opencode":
         _handle_ask_opencode(args)
+    elif args.command == "ask-cursor":
+        _handle_ask_cursor(args)
     elif args.command == "converse":
         content = sys.stdin.read() if args.content == "-" else args.content
         converse_gemini(content, args.task_id, args.model,
@@ -938,6 +960,23 @@ def _handle_ask_opencode(args):
     content = sys.stdin.read() if args.content == "-" else args.content
     from_llm = _resolve_from_llm(args)
     ask_opencode(
+        content,
+        args.task_id,
+        msg_type=args.type,
+        data=args.data,
+        model=args.model,
+        from_llm=from_llm,
+        from_model=args.from_model,
+        to_model=args.to_model,
+        no_timeout=args.no_timeout,
+    )
+
+
+def _handle_ask_cursor(args):
+    """Handle ask-cursor subcommand."""
+    content = sys.stdin.read() if args.content == "-" else args.content
+    from_llm = _resolve_from_llm(args)
+    ask_cursor(
         content,
         args.task_id,
         msg_type=args.type,

--- a/scripts/ai_agent_bridge/_cursor.py
+++ b/scripts/ai_agent_bridge/_cursor.py
@@ -1,0 +1,117 @@
+"""Cursor adapter for ai_agent_bridge ask-cursor subcommand.
+
+Exposes ad-hoc one-shot Cursor Agent calls. Useful for Q&A, discussions,
+and single-shot reads through Cursor's Composer or other models.
+
+Invocation pattern:
+    .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-cursor <content> \
+      --task-id <task> --model composer-2.5 [--data FILE]
+
+Under the hood: agent -p PROMPT --model MODEL --output-format text --trust
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._messaging import acknowledge, send_message
+
+CURSOR_DEFAULT_MODEL = "composer-2.5"
+CURSOR_DEFAULT_TIMEOUT_S = 900
+
+
+def ask_cursor(
+    content: str,
+    task_id: str,
+    msg_type: str = "query",
+    data: str | None = None,
+    model: str | None = None,
+    from_llm: str = "claude",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+) -> int:
+    """Send message to Cursor Agent AND invoke Cursor one-shot to process it."""
+    effective_model = model or CURSOR_DEFAULT_MODEL
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="cursor",
+        from_model=from_model,
+        to_model=to_model or effective_model,
+    )
+    print(f"\n🚀 Invoking cursor ({effective_model}) to process message #{msg_id}...")
+    response = _invoke_cursor(content, effective_model, data=data, no_timeout=no_timeout)
+
+    reply_id = send_message(
+        content=response,
+        task_id=task_id,
+        msg_type="response",
+        from_llm="cursor",
+        to_llm=from_llm,
+        to_model=from_model,
+    )
+    acknowledge(msg_id)
+    acknowledge(reply_id)
+
+    return msg_id
+
+
+def _invoke_cursor(
+    content: str,
+    model: str,
+    *,
+    data: str | None = None,
+    no_timeout: bool = False,
+) -> str:
+    """Run agent -p PROMPT --model MODEL --output-format text --trust; return captured stdout."""
+    agent_bin = shutil.which("agent")
+    if not agent_bin:
+        # Fallback to cursor-agent if 'agent' is not found
+        agent_bin = shutil.which("cursor-agent")
+
+    if not agent_bin:
+        raise SystemExit("ask-cursor: cursor-agent CLI not found in PATH")
+
+    # If data file attached, prepend its content to the prompt under a fenced block.
+    # Cursor agent doesn't have a direct --file flag for one-shot prompts that
+    # behaves exactly like opencode's. Prepending to prompt is the safest pattern.
+    prompt = content
+    if data:
+        data_path = Path(data)
+        if not data_path.exists():
+            raise SystemExit(f"ask-cursor: --data file does not exist: {data}")
+        attached = data_path.read_text(encoding="utf-8", errors="replace")
+        prompt = f"{content}\n\n## Attached data: {data_path.name}\n\n```\n{attached}\n```"
+
+    argv = [
+        agent_bin,
+        "-p", prompt,
+        "--model", model,
+        "--output-format", "text",
+        "--trust"
+    ]
+
+    timeout = None if no_timeout else CURSOR_DEFAULT_TIMEOUT_S
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"ask-cursor: cursor-agent timed out after {timeout}s") from exc
+
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ask-cursor: cursor-agent exited {result.returncode}\n"
+            f"stderr: {result.stderr[-2000:]}"
+        )
+
+    return result.stdout.strip()

--- a/tests/test_ask_cursor.py
+++ b/tests/test_ask_cursor.py
@@ -1,0 +1,81 @@
+"""Tests for ab ask-cursor bridge subcommand (Phase 1)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.ai_agent_bridge._cursor import CURSOR_DEFAULT_MODEL, _invoke_cursor
+
+
+def test_cursor_default_model_is_composer_2_5():
+    assert CURSOR_DEFAULT_MODEL == "composer-2.5"
+
+
+def test_invoke_cursor_constructs_correct_argv():
+    """Cursor subprocess is invoked with -p PROMPT --model MODEL --output-format text --trust."""
+    with patch("scripts.ai_agent_bridge._cursor.shutil.which", return_value="/fake/agent"):
+        with patch("scripts.ai_agent_bridge._cursor.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="response body", stderr="")
+            _invoke_cursor("hello", "composer-2.5")
+            argv = run_mock.call_args[0][0]
+            assert argv[0] == "/fake/agent"
+            assert "-p" in argv
+            assert "hello" in argv
+            assert "--model" in argv
+            assert "composer-2.5" in argv
+            assert "--output-format" in argv
+            assert "text" in argv
+            assert "--trust" in argv
+
+
+def test_invoke_cursor_falls_back_to_cursor_agent():
+    """If 'agent' binary is missing, it should try 'cursor-agent'."""
+    def which_side_effect(name):
+        if name == "agent":
+            return None
+        if name == "cursor-agent":
+            return "/fake/cursor-agent"
+        return None
+
+    with patch("scripts.ai_agent_bridge._cursor.shutil.which", side_effect=which_side_effect):
+        with patch("scripts.ai_agent_bridge._cursor.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="response body", stderr="")
+            _invoke_cursor("hello", "composer-2.5")
+            argv = run_mock.call_args[0][0]
+            assert argv[0] == "/fake/cursor-agent"
+
+
+def test_invoke_cursor_attaches_data_file(tmp_path):
+    data_file = tmp_path / "context.md"
+    data_file.write_text("# Context\nSome content.")
+    with patch("scripts.ai_agent_bridge._cursor.shutil.which", return_value="/fake/agent"):
+        with patch("scripts.ai_agent_bridge._cursor.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+            _invoke_cursor("review this", "composer-2.5", data=str(data_file))
+            argv = run_mock.call_args[0][0]
+            # data should be in the prompt, not as a separate flag
+            prompt_arg = argv[argv.index("-p") + 1]
+            assert "Some content." in prompt_arg
+            assert "review this" in prompt_arg
+
+
+def test_invoke_cursor_raises_when_binary_missing():
+    with patch("scripts.ai_agent_bridge._cursor.shutil.which", return_value=None):
+        with pytest.raises(SystemExit, match="cursor-agent CLI not found"):
+            _invoke_cursor("hello", "composer-2.5")
+
+
+def test_invoke_cursor_raises_on_nonzero_exit():
+    with patch("scripts.ai_agent_bridge._cursor.shutil.which", return_value="/fake/agent"):
+        with patch("scripts.ai_agent_bridge._cursor.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=1, stdout="", stderr="auth failed")
+            with pytest.raises(SystemExit, match="cursor-agent exited 1"):
+                _invoke_cursor("hello", "composer-2.5")
+
+
+def test_invoke_cursor_strips_output():
+    with patch("scripts.ai_agent_bridge._cursor.shutil.which", return_value="/fake/agent"):
+        with patch("scripts.ai_agent_bridge._cursor.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="  response with spaces  \n", stderr="")
+            result = _invoke_cursor("hello", "composer-2.5")
+            assert result == "response with spaces"


### PR DESCRIPTION
### Summary
Added the `ab ask-cursor` subcommand to the AI Agent Bridge. This enables one-shot Q&A and discussions routed through Cursor Agent (default model: `composer-2.5`).

### Changes
- Created `scripts/ai_agent_bridge/_cursor.py` to handle `agent` CLI invocation.
- Registered `ask-cursor` in `scripts/ai_agent_bridge/_cli.py`.
- Added unit tests in `tests/test_ask_cursor.py`.

### Smoke Test Output
```
$ GEMINI_SESSION=smoke-test .venv/bin/python -m scripts.ai_agent_bridge ask-cursor --task-id smoke-test 'Reply with exactly the single word: OK'
✅ Message sent to Cursor (ID: 1)

🚀 Invoking cursor (composer-2.5) to process message #1...
✅ Message sent to Gemini (ID: 2)
✓ Message 1 acknowledged
✓ Message 2 acknowledged

$ sqlite3 .mcp/servers/message-broker/messages.db "SELECT content FROM messages WHERE id = 2"
OK
```

### Test Plan
- Run `pytest tests/test_ask_cursor.py` (7 passed).
- Verified correct command line argument construction for `agent -p PROMPT --model MODEL --output-format text --trust`.
- Verified data file attachment (prepended to prompt).
- Verified fallback from `agent` to `cursor-agent` binary name.
