### PR TITLE
feat(runtime): cursor adapter — Phase 2 of cursor integration

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -117,14 +117,15 @@ class CursorAdapter:
             sandbox = config.get("sandbox", "enabled")
             cmd.extend(["--sandbox", sandbox])
         elif mode == "danger":
-            # Same as writer path but NO --mode plan (file edits allowed)
-            # Use sparingly — most delegate calls should use workspace-write.
-            cursor_mode = config.get("cursor_mode", "ask")  # "ask" allows edits in non-plan mode?
-            # Actually spec §1 says: "Danger mode: same as writer path but NO --mode plan (file edits allowed)"
-            # For cursor-agent, --mode ask is the default for "ask" where it can edit if allowed?
-            # Wait, let me check spec §1 again.
-            # "Danger mode: same as writer path but NO --mode plan (file edits allowed)"
-            cmd.extend(["--mode", cursor_mode])
+            # Danger mode: no --mode flag (cursor-agent default allows edits;
+            # --mode plan blocks edits, --mode ask is read-only Q&A — neither
+            # matches "danger" intent). Sandbox + approve-mcps kept on for
+            # MCP discipline + shell-side guard; --yolo deliberately omitted
+            # so shell tools still need explicit approval (matches the
+            # "no --yolo in any path" Phase 2 spec §2 boundary).
+            #
+            # Use sparingly — most delegate calls should use workspace-write
+            # (which blocks edits via --mode plan).
             if config.get("approve_mcps") is not False:
                 cmd.append("--approve-mcps")
             sandbox = config.get("sandbox", "enabled")

--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -1,0 +1,200 @@
+"""CursorAdapter — wraps ``agent`` / ``cursor-agent`` for the agent runtime.
+
+Mirrors the Gemini I/O pattern (stdout JSONL stream) and the Codex adapter's
+per-invocation configuration patterns. Supports read-only, workspace-write,
+and danger modes with appropriate security boundaries.
+
+Key design points:
+
+- **Prompt delivery via stdin.** Matches the Gemini pattern to avoid
+  shell-limit issues with large prompts.
+- **JSONL event stream.** Parses stdout using ``parse_json_events`` to
+  extract tool-call telemetry and the final assistant response.
+- **Security boundaries.** Explicitly avoids ``--yolo`` and ``--force``
+  flags. Uses ``--mode plan`` for workspace-write by default.
+- **Per-invocation workspace.** Caller can specify ``cursor_workspace`` in
+  ``tool_config`` to scope the agent to a specific directory.
+
+Issue: #2253 (Phase 2)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from pathlib import Path
+
+from ..result import ParseResult
+from ..tool_calls import normalize_tool_calls, parse_json_events
+from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
+
+# Stderr/stdout phrases that indicate the provider rate-limited us.
+_RATE_LIMIT_PATTERNS = (
+    r"usage limit reached",
+    r"rate limit",
+    r"rate_limit",
+    r"quota exceeded",
+    r"too many requests",
+    r"\bHTTP 429\b",
+    r"\bstatus 429\b",
+    r"\b429\b",
+)
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+
+class CursorAdapter:
+    """Adapter for the Cursor agent CLI (``agent`` or ``cursor-agent``)."""
+
+    name: str = "cursor"
+    default_model: str = "composer-2.5"
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        """Build the cursor-agent invocation.
+
+        Args:
+            prompt: The prompt text to send via stdin.
+            mode: One of "read-only", "workspace-write", "danger".
+            cwd: Working directory for the subprocess.
+            model: Model override (e.g. "composer-2.5").
+            task_id: Optional task identifier.
+            session_id: Ignored (cursor-agent does not yet support resume).
+            tool_config: Config overrides. Supported keys:
+                - ``cursor_workspace``: overrides the ``--workspace`` path.
+                - ``approve_mcps``: bool, toggles ``--approve-mcps``.
+                - ``cursor_mode``: "plan" | "ask", toggles ``--mode``.
+                - ``sandbox``: "enabled" | "disabled", toggles ``--sandbox``.
+            effort: Logged and ignored (no cursor equivalent today).
+        """
+        _ = session_id
+        _ = task_id
+
+        if effort:
+            _logger.debug("cursor adapter ignoring effort=%s (not supported by CLI)", effort)
+
+        # Resolve binary. shutil.which handles PATH lookup.
+        cursor_bin = shutil.which("agent") or shutil.which("cursor-agent") or "agent"
+
+        config = tool_config or {}
+
+        # Base argv common to all paths
+        cmd: list[str] = [
+            cursor_bin,
+            "-p", "-",  # Read prompt from stdin
+            "--model", model or self.default_model,
+            "--output-format", config.get("output_format", "stream-json"),
+            "--trust",  # Headless workspace-trust bypass
+        ]
+
+        # Workspace resolution
+        workspace = config.get("cursor_workspace") or str(cwd)
+        cmd.extend(["--workspace", workspace])
+
+        # Mode-specific argv assembly
+        if mode == "read-only":
+            cursor_mode = config.get("cursor_mode", "ask")
+            cmd.extend(["--mode", cursor_mode])
+        elif mode == "workspace-write":
+            cursor_mode = config.get("cursor_mode", "plan")
+            cmd.extend(["--mode", cursor_mode])
+            # Security boundaries from Phase 2 spec
+            if config.get("approve_mcps") is not False:
+                cmd.append("--approve-mcps")
+            sandbox = config.get("sandbox", "enabled")
+            cmd.extend(["--sandbox", sandbox])
+        elif mode == "danger":
+            # Same as writer path but NO --mode plan (file edits allowed)
+            # Use sparingly — most delegate calls should use workspace-write.
+            cursor_mode = config.get("cursor_mode", "ask")  # "ask" allows edits in non-plan mode?
+            # Actually spec §1 says: "Danger mode: same as writer path but NO --mode plan (file edits allowed)"
+            # For cursor-agent, --mode ask is the default for "ask" where it can edit if allowed?
+            # Wait, let me check spec §1 again.
+            # "Danger mode: same as writer path but NO --mode plan (file edits allowed)"
+            cmd.extend(["--mode", cursor_mode])
+            if config.get("approve_mcps") is not False:
+                cmd.append("--approve-mcps")
+            sandbox = config.get("sandbox", "enabled")
+            cmd.extend(["--sandbox", sandbox])
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            stdin_payload=prompt,
+            output_file=None,  # Cursor writes to stdout
+            liveness_paths=(),  # rely on stdout streaming
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        """Parse cursor-agent JSONL output into a ParseResult."""
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+
+        # Detect rate limits
+        rate_limited = bool(_RATE_LIMIT_RE.search(f"{stdout}\n{stderr}"))
+
+        # Parse JSONL events
+        events = parse_json_events(stdout, source="cursor", logger=_logger)
+        tool_calls = normalize_tool_calls(events)
+
+        # The final response is usually the last 'content' or 'text' event
+        # in the stream. parse_json_events + normalize_tool_calls handles
+        # most of this, but we need to extract the assistant's final prose.
+        response = ""
+        for event in events:
+            # Typical cursor event shape: {"type": "text", "content": "..."}
+            # or {"type": "message", "role": "assistant", "content": "..."}
+            if event.get("type") == "text":
+                response += event.get("content", "")
+            elif event.get("type") == "message" and event.get("role") == "assistant":
+                content = event.get("content", "")
+                if isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            response += part.get("text", "")
+                elif isinstance(content, str):
+                    response += content
+
+        response = response.strip()
+
+        ok = returncode == 0 and bool(response) and not rate_limited
+
+        stderr_excerpt = None
+        if not ok:
+            stderr_excerpt = (stderr or stdout).strip()[:500]
+
+        return ParseResult(
+            ok=ok,
+            response=response,
+            stderr_excerpt=stderr_excerpt,
+            rate_limited=rate_limited,
+            tool_calls=tool_calls,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Cursor writes to stdout; no separate liveness files."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -137,6 +137,18 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": True,
         "resume_policy": "never",
     },
+    "cursor": {
+        "adapter": "scripts.agent_runtime.adapters.cursor:CursorAdapter",
+        "default_model": "composer-2.5",
+        "cost_tier": "low",
+        "capabilities": frozenset({
+            "content_writing",
+            "content_review",
+            "adversarial_review",
+        }),
+        "cli_available": True,
+        "resume_policy": "never",
+    },
     "agy": {
         # Antigravity CLI shipping Gemini Flash 3.5 on a separate meter from
         # gemini-cli. Added 2026-05-20 for the seminar-writer ADR bakeoff

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -36,6 +36,8 @@ def _canonical_agent_name(agent: str) -> str | None:
         return "qwen"
     if agent.startswith("agy"):
         return "agy"
+    if agent.startswith("cursor"):
+        return "cursor"
     return None
 
 
@@ -278,6 +280,25 @@ def build_mcp_tool_config(
                 requested_servers=mcp_servers,
                 resolved_servers=mcp_servers,
                 resolution_status="ok",
+            ),
+        )
+
+    if canonical_agent == "cursor":
+        # For Phase 2, the workspace value defaults to cwd of the subprocess.
+        # Diagnostic config_path should point at {cwd}/.cursor/mcp.json
+        # (not repo .mcp.json).
+        workspace_mcp_path = Path.cwd() / ".cursor" / "mcp.json"
+        return (
+            {
+                "output_format": "stream-json",
+                "approve_mcps": True,
+                "mcp_server_names": mcp_servers,
+            },
+            _basic_diagnostics(
+                mcp_config_path=workspace_mcp_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok" if mcp_servers else "config_empty",
             ),
         )
 

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -77,6 +77,7 @@ VALID_AGENTS = (
     "grok",
     "deepseek",
     "qwen",
+    "cursor",
     "claude-desktop",
     "codex-desktop",
 )

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -67,7 +67,7 @@ def _cli_available_agent(agent: str) -> bool:
     try:
         from agent_runtime.registry import get_agent_entry
     except ImportError:
-        return agent in {"claude", "codex", "gemini", "grok", "deepseek"}
+        return agent in {"claude", "codex", "gemini", "grok", "deepseek", "qwen", "cursor"}
 
     try:
         return bool(get_agent_entry(agent)["cli_available"])

--- a/scripts/audit/lint_agent_trailer.py
+++ b/scripts/audit/lint_agent_trailer.py
@@ -68,7 +68,7 @@ import subprocess
 import sys
 
 _TRAILER_RE = re.compile(
-    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|grok|deepseek-v4-pro|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
+    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|grok|deepseek-v4-pro|cursor|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
     re.MULTILINE,
 )
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1550,8 +1550,8 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=_dispatch_help_formatter,
     )
     d.add_argument("--agent", required=True,
-                   choices=["codex", "gemini", "claude", "grok", "deepseek", "qwen", "agy"],
-                   help="Agent to run for the task: codex, gemini, claude, grok, deepseek, qwen, or agy.")
+                   choices=["codex", "gemini", "claude", "grok", "deepseek", "qwen", "agy", "cursor"],
+                   help="Agent to run for the task: codex, gemini, claude, grok, deepseek, qwen, agy, or cursor.")
     d.add_argument("--task-id", required=True,
                    help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -83,13 +83,18 @@ def test_cursor_adapter_build_invocation_danger(adapter, tmp_path, monkeypatch):
         model=None,
         task_id="task-123",
         session_id=None,
-        tool_config={"cursor_mode": "ask"},
+        tool_config={},
     )
 
-    assert "--mode" in plan.cmd
-    assert "ask" in plan.cmd
+    # Danger mode: no --mode flag (cursor-agent default allows edits;
+    # --mode plan blocks edits, --mode ask is read-only Q&A).
+    assert "--mode" not in plan.cmd
+    # MCP discipline + sandbox kept on; --yolo deliberately omitted per Phase 2 spec.
     assert "--approve-mcps" in plan.cmd
+    assert "--sandbox" in plan.cmd
+    assert "enabled" in plan.cmd
     assert "--yolo" not in plan.cmd
+    assert "--force" not in plan.cmd
 
 
 def test_cursor_adapter_parse_response_success(adapter):

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -1,0 +1,141 @@
+"""Tests for CursorAdapter."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from scripts.agent_runtime.adapters.cursor import CursorAdapter
+
+
+@pytest.fixture
+def adapter():
+    return CursorAdapter()
+
+
+def test_cursor_adapter_build_invocation_read_only(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/local/bin/agent" if x == "agent" else None)
+
+    plan = adapter.build_invocation(
+        prompt="Hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="task-123",
+        session_id=None,
+        tool_config={"cursor_mode": "ask"},
+    )
+
+    assert "/usr/local/bin/agent" in plan.cmd
+    assert "-p" in plan.cmd
+    assert "-" in plan.cmd
+    assert "--model" in plan.cmd
+    assert "composer-2.5" in plan.cmd
+    assert "--mode" in plan.cmd
+    assert "ask" in plan.cmd
+    assert "--trust" in plan.cmd
+    assert "--workspace" in plan.cmd
+    assert str(tmp_path) in plan.cmd
+    assert plan.stdin_payload == "Hello"
+    assert "--yolo" not in plan.cmd
+    assert "--force" not in plan.cmd
+
+
+def test_cursor_adapter_build_invocation_workspace_write(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/local/bin/agent" if x == "agent" else None)
+
+    plan = adapter.build_invocation(
+        prompt="Fix bug",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model="composer-2.5-heavy",
+        task_id="task-123",
+        session_id=None,
+        tool_config={
+            "cursor_workspace": "/tmp/scoped",
+            "approve_mcps": True,
+            "sandbox": "enabled",
+        },
+    )
+
+    assert "--mode" in plan.cmd
+    assert "plan" in plan.cmd  # default for workspace-write
+    assert "--workspace" in plan.cmd
+    assert "/tmp/scoped" in plan.cmd
+    assert "--approve-mcps" in plan.cmd
+    assert "--sandbox" in plan.cmd
+    assert "enabled" in plan.cmd
+    assert "--model" in plan.cmd
+    assert "composer-2.5-heavy" in plan.cmd
+    assert "--yolo" not in plan.cmd
+
+
+def test_cursor_adapter_build_invocation_danger(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/local/bin/agent" if x == "agent" else None)
+
+    plan = adapter.build_invocation(
+        prompt="Delete all",
+        mode="danger",
+        cwd=tmp_path,
+        model=None,
+        task_id="task-123",
+        session_id=None,
+        tool_config={"cursor_mode": "ask"},
+    )
+
+    assert "--mode" in plan.cmd
+    assert "ask" in plan.cmd
+    assert "--approve-mcps" in plan.cmd
+    assert "--yolo" not in plan.cmd
+
+
+def test_cursor_adapter_parse_response_success(adapter):
+    stdout = """
+{"type": "text", "content": "I have fixed the bug."}
+{"type": "tool_use", "name": "mcp__sources__search_text", "arguments": {"query": "test"}}
+{"type": "text", "content": " Done."}
+"""
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "I have fixed the bug. Done."
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0]["name"] == "mcp__sources__search_text"
+
+
+def test_cursor_adapter_parse_response_rate_limited(adapter):
+    stdout = ""
+    stderr = "Error: 429 Too Many Requests"
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr=stderr,
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.rate_limited is True
+    assert "429" in result.stderr_excerpt
+
+
+def test_cursor_adapter_parse_response_message_format(adapter):
+    stdout = """
+{"type": "message", "role": "assistant", "content": [{"type": "text", "text": "Hello world"}]}
+"""
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "Hello world"

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -176,7 +176,17 @@ def test_registry_has_known_agents():
         "deepseek",
         "qwen",
         "agy",
+        "cursor",
     }
+
+
+def test_cursor_entry_is_well_formed():
+    entry = get_agent_entry("cursor")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.cursor:CursorAdapter"
+    assert entry["default_model"] == "composer-2.5"
+    assert entry["cli_available"] is True
+    assert entry["resume_policy"] == "never"
+    assert {"content_writing", "content_review", "adversarial_review"} <= entry["capabilities"]
 
 
 def test_agy_entry_is_well_formed():
@@ -222,6 +232,13 @@ def test_load_adapter_codex():
     assert adapter.supported_modes == frozenset({"read-only", "workspace-write", "danger"})
 
 
+def test_load_adapter_cursor():
+    adapter = _load_adapter("cursor")
+    assert adapter.name == "cursor"
+    assert adapter.default_model == "composer-2.5"
+    assert adapter.supported_modes == frozenset({"read-only", "workspace-write", "danger"})
+
+
 def test_load_adapter_unknown_raises():
     with pytest.raises(AgentUnavailableError, match="not in the registry"):
         _load_adapter("nonexistent")
@@ -234,6 +251,7 @@ def test_load_adapter_unknown_raises():
         ("claude-tools", "claude"),
         ("gemini-tools", "gemini"),
         ("grok-tools", "grok"),
+        ("cursor-tools", "cursor"),
     ],
 )
 def test_validate_agent_name_rejects_tools_suffix(agent_name, bare_name):

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -572,9 +572,9 @@ def test_sync_all_iterates_known_agents(monkeypatch, capsys):
     # Mirrors the live `cmd_sync --all` iteration order, which is
     # `[agent for agent in _channels.VALID_AGENTS if _cli_available_agent(agent)]`.
     # When a new CLI agent is registered (e.g. grok via #1934, deepseek
-    # via #2107), this list tracks the registry — the test guards the
-    # iteration order, not a frozen subset.
-    cli_agents = ["claude", "gemini", "codex", "grok", "deepseek", "qwen"]
+    # via #2107, cursor via Phase 2 PR), this list tracks the registry —
+    # the test guards the iteration order, not a frozen subset.
+    cli_agents = ["claude", "gemini", "codex", "grok", "deepseek", "qwen", "cursor"]
 
     calls: list[tuple[str, dict[str, object]]] = []
 

--- a/tests/test_cursor_integration.py
+++ b/tests/test_cursor_integration.py
@@ -1,0 +1,91 @@
+"""Integration test surfaces for Cursor in delegate.py / ab discuss / lint.
+
+The agent runtime registry already exposes ``cursor`` via
+``scripts/agent_runtime/registry.py`` (CursorAdapter, ``cli_available:
+True``). These tests pin the surface allowlists so future churn cannot
+silently strip ``cursor`` from any of them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_registry_exposes_cursor():
+    """The agent_runtime registry is the canonical source of truth."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from agent_runtime.registry import AGENTS, available_agents
+
+    assert "cursor" in AGENTS, "cursor must be in agent_runtime.registry.AGENTS"
+    assert AGENTS["cursor"]["cli_available"] is True
+    assert "cursor" in available_agents()
+
+
+def test_delegate_dispatch_accepts_cursor_agent():
+    """``delegate.py dispatch --agent cursor ...`` must parse without error."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / "delegate.py"),
+            "dispatch",
+            "--agent", "cursor",
+            "--task-id", "test-cursor-argparse-probe",
+            "--prompt", "noop",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(_REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"delegate dispatch --agent cursor failed:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "test-cursor-argparse-probe" in result.stdout
+
+
+def test_ab_channels_valid_agents_includes_cursor():
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from ai_agent_bridge import _channels
+
+    importlib.reload(_channels)
+    assert "cursor" in _channels.VALID_AGENTS
+
+
+def test_ab_channels_cli_marks_cursor_cli_available():
+    """``ab discuss`` requires the agent to be CLI-spawnable.
+
+    The fallback set (used when agent_runtime is unimportable) must also
+    list cursor so the discuss command doesn't refuse it in degraded
+    environments.
+    """
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from ai_agent_bridge import _channels_cli
+
+    assert _channels_cli._cli_available_agent("cursor") is True
+
+
+def test_lint_agent_trailer_accepts_cursor():
+    """Commits authored by ``cursor`` dispatches must pass the X-Agent trailer linter."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from audit.lint_agent_trailer import _TRAILER_RE
+
+    sample = "X-Agent: cursor/2026-05-23-integration"
+    match = _TRAILER_RE.search(sample)
+    assert match is not None, "lint_agent_trailer rejected cursor-authored trailer"
+    assert match.group("agent") == "cursor"
+    assert match.group("task") == "2026-05-23-integration"


### PR DESCRIPTION
## Summary
Phase 2 of the Cursor agent integration: adds `CursorAdapter` as a first-class agent in `scripts/agent_runtime/`. This enables `scripts/delegate.py --agent cursor` for code-execution dispatches via the cursor-agent CLI (`agent`).

## Design Spec
Cites: `docs/dispatch-briefs/2026-05-23-cursor-phase-2-3-v7-writer-reviewer-design.md` (referenced in dispatch brief).

## Changes
- Created `scripts/agent_runtime/adapters/cursor.py` (mirrors Gemini I/O + Codex MCP scoping).
- Registered `cursor` in `scripts/agent_runtime/registry.py`.
- Extended `scripts/agent_runtime/tool_config.py` for `cursor` canonical name and MCP config.
- Added `cursor` to `VALID_AGENTS` in `scripts/ai_agent_bridge/_channels.py`.
- Added `cursor` to `_TRAILER_RE` in `scripts/audit/lint_agent_trailer.py`.
- Added `cursor` to `--agent` choices in `scripts/delegate.py`.
- Added tests: `tests/agent_runtime/adapters/test_cursor_adapter.py` and `tests/test_cursor_integration.py`.
- Updated `tests/test_agent_runtime.py`.

## Smoke Test
```bash
python scripts/delegate.py dispatch --agent cursor --model composer-2.5 --dry-run --task-id "smoke-test" --prompt "echo OK"
# Output: smoke-test
```

## Test Plan
- Run all new and modified tests (`tests/agent_runtime/`, `tests/test_agent_runtime.py`, `tests/test_cursor_integration.py`, `tests/test_delegate.py`).
- Verified all 304 tests passed.

## Tests Discovered (Step 2)
- `tests/test_agent_runtime.py`
- `tests/test_agent_runtime_tool_config.py`
- `tests/test_delegate.py`
- `tests/test_dispatch.py`
- `tests/agent_runtime/test_pty_subprocess_wrap.py`
- `tests/agent_runtime/adapters/test_hermes_*`
- ... and many others referencing registry/tool_config/delegate.

X-Agent: gemini/cursor-phase-2