### PR TITLE
fix(monitor): polish artifacts UI and migrate comms off deprecated endpoints

### DIFF
--- a/dashboards/artifacts.html
+++ b/dashboards/artifacts.html
@@ -10,6 +10,10 @@
 body { min-height: 100vh; }
 .top-bar { display:flex; align-items:center; justify-content:space-between; gap:16px; padding:16px 24px; position:sticky; top:0; z-index:10; }
 .top-left h1 { font-size:24px; margin:0; }
+.top-right { display:flex; align-items:center; gap:10px; color:var(--text3); font-size:12px; }
+.btn { background:var(--bg2); border:1px solid var(--border); color:var(--text); border-radius:4px; padding:7px 12px; font:inherit; font-size:12px; cursor:pointer; }
+.btn:hover { border-color:var(--accent); color:var(--accent); }
+.btn:disabled { opacity:.55; cursor:default; }
 .wrap { max-width: 1180px; margin: 0 auto; padding: 28px 24px 72px; }
 .hero { border-bottom: 1.5px solid var(--text); padding-bottom: 18px; margin-bottom: 22px; display:grid; grid-template-columns: 1fr auto; gap:24px; align-items:end; }
 .hero h2 { font-family: Charter, Georgia, serif; font-size: 30px; line-height: 1.15; margin:0 0 8px; }
@@ -17,11 +21,16 @@ body { min-height: 100vh; }
 .hero-count { background: var(--bg2); border:1px solid var(--border); border-radius:4px; padding:14px 18px; min-width:160px; text-align:right; }
 .hero-count .value { font-family: Charter, Georgia, serif; font-size:34px; font-weight:700; }
 .hero-count .label { color: var(--text3); font-size:11px; text-transform:uppercase; letter-spacing:.08em; }
+.hero-count .sub { color: var(--text3); font-size:11px; margin-top:4px; }
 .ops-directory { margin: 0 0 28px; }
-.ops-directory h3 { font-family: Charter, Georgia, serif; font-size:21px; margin:0 0 6px; }
-.ops-directory p { color: var(--text2); font-size:13px; margin:0 0 14px; max-width:760px; }
+.ops-directory summary { cursor:pointer; list-style:none; display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 14px; background:var(--bg2); border:1px solid var(--border); border-radius:4px; }
+.ops-directory summary::-webkit-details-marker { display:none; }
+.ops-directory summary h3 { font-family: Charter, Georgia, serif; font-size:18px; margin:0; }
+.ops-directory summary p { color: var(--text3); font-size:12px; margin:4px 0 0; }
+.ops-directory[open] summary { border-bottom-left-radius:0; border-bottom-right-radius:0; border-bottom-color:transparent; }
+.ops-directory .ops-body { border:1px solid var(--border); border-top:none; border-radius:0 0 4px 4px; padding:14px; background:var(--bg2); }
 .ops-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap:10px; }
-.ops-card { display:block; background:var(--bg2); border:1px solid var(--border); border-left:3px solid var(--text3); border-radius:4px; color:var(--text); padding:12px 13px; text-decoration:none; min-height:98px; }
+.ops-card { display:block; background:var(--bg); border:1px solid var(--border); border-left:3px solid var(--text3); border-radius:4px; color:var(--text); padding:12px 13px; text-decoration:none; min-height:98px; }
 .ops-card:hover { border-color:var(--accent); box-shadow:0 6px 18px rgba(122,28,32,.07); }
 .ops-card strong { display:block; font-family: Charter, Georgia, serif; font-size:16px; margin-bottom:5px; }
 .ops-card span { display:block; color:var(--text2); font-size:12px; line-height:1.35; }
@@ -30,25 +39,39 @@ body { min-height: 100vh; }
 .ops-card.agent { border-left-color:var(--accent); }
 .ops-card.curriculum { border-left-color:var(--cyan); }
 .ops-card.runtime { border-left-color:var(--purple); }
-.filters { display:grid; grid-template-columns: 1.2fr repeat(5, minmax(130px, 1fr)); gap:10px; margin-bottom: 26px; }
-.filters input, .filters select { background:#fffaf0; color:var(--text); border:1px solid var(--border); border-radius:4px; padding:9px 10px; font:inherit; font-size:13px; }
+.filter-bar { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; flex-wrap:wrap; }
+.filter-bar .hint { color:var(--text3); font-size:12px; }
+.filters { display:grid; grid-template-columns: 1.2fr repeat(5, minmax(130px, 1fr)) auto; gap:10px; margin-bottom: 26px; }
+.filters input, .filters select { background:#fffaf0; color:var(--text); border:1px solid var(--border); border-radius:4px; padding:9px 10px; font:inherit; font-size:13px; width:100%; }
 .group { margin: 26px 0 34px; }
 .group h3 { font-family: Charter, Georgia, serif; font-size:21px; border-bottom:1px solid var(--border); padding-bottom:8px; margin:0 0 14px; display:flex; justify-content:space-between; gap:12px; }
 .group h3 span { color:var(--text3); font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size:12px; font-weight:500; }
 .grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap:14px; }
-.artifact-card { display:block; background:var(--bg2); color:var(--text); border:1px solid var(--border); border-left:3px solid var(--accent); border-radius:4px; padding:15px 16px; text-decoration:none; min-height:158px; }
+.artifact-card { display:block; background:var(--bg2); color:var(--text); border:1px solid var(--border); border-left:3px solid var(--accent); border-radius:4px; padding:15px 16px; text-decoration:none; min-height:158px; transition: box-shadow .15s ease, border-color .15s ease; }
 .artifact-card:hover { border-color:var(--accent); box-shadow:0 8px 24px rgba(122,28,32,.08); }
 .card-top { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; margin-bottom:10px; }
 .card-title { font-family: Charter, Georgia, serif; font-size:17px; line-height:1.25; font-weight:700; }
-.pill { display:inline-flex; align-items:center; border:1px solid var(--border); border-radius:999px; padding:2px 8px; font-size:11px; font-weight:700; text-transform:uppercase; }
+.card-path { color:var(--text3); font-size:11px; margin-top:4px; word-break:break-all; }
+.pill { display:inline-flex; align-items:center; border:1px solid var(--border); border-radius:999px; padding:2px 8px; font-size:11px; font-weight:700; text-transform:uppercase; white-space:nowrap; }
 .pill.ok { color:var(--green); background:rgba(61,107,74,.12); }
 .pill.warn, .pill.unknown { color:var(--yellow); background:rgba(168,132,43,.13); }
 .pill.fail { color:var(--red); background:rgba(156,40,40,.13); }
+.pill.type { color:var(--blue); background:rgba(42,86,128,.1); text-transform:none; font-weight:600; }
 .meta { color:var(--text3); font-size:12px; margin-bottom:10px; }
-.summary { color:var(--text2); font-size:13px; line-height:1.45; }
+.summary { color:var(--text2); font-size:13px; line-height:1.45; display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
 .badges { display:flex; gap:6px; flex-wrap:wrap; margin-top:12px; }
 .badge { background:var(--bg3); border:1px solid var(--border); color:var(--text2); border-radius:999px; padding:2px 8px; font-size:11px; }
-.empty { background:var(--bg2); border:1px solid var(--border); padding:22px; border-radius:4px; color:var(--text3); }
+.empty, .loading { background:var(--bg2); border:1px solid var(--border); padding:22px; border-radius:4px; color:var(--text3); }
+.loading { display:flex; align-items:center; gap:10px; }
+.spinner { width:16px; height:16px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation: spin .8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.skeleton-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap:14px; }
+.skeleton-card { background:var(--bg2); border:1px solid var(--border); border-radius:4px; min-height:158px; padding:16px; }
+.skeleton-line { height:12px; background:linear-gradient(90deg, var(--bg3), var(--bg), var(--bg3)); background-size:200% 100%; animation: shimmer 1.2s infinite; border-radius:4px; margin-bottom:10px; }
+.skeleton-line.wide { width:85%; }
+.skeleton-line.mid { width:60%; }
+.skeleton-line.short { width:35%; }
+@keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 @media (max-width: 820px) {
   .hero { grid-template-columns: 1fr; }
   .hero-count { text-align:left; }
@@ -64,6 +87,10 @@ body { min-height: 100vh; }
 <body>
 <div class="top-bar">
   <div class="top-left"><h1>Artifacts</h1></div>
+  <div class="top-right">
+    <span id="refresh-info">Loading…</span>
+    <button class="btn" id="refresh-btn" type="button" disabled>Refresh</button>
+  </div>
   <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
     <a href="/orient.html">Orient</a>
@@ -82,35 +109,48 @@ body { min-height: 100vh; }
     </div>
     <div class="hero-count">
       <div class="value" id="total-count">—</div>
-      <div class="label">artifacts</div>
+      <div class="label">matching artifacts</div>
+      <div class="sub" id="total-sub">of — total</div>
     </div>
   </section>
 
-  <section class="ops-directory" aria-label="Operational dashboards">
-    <h3>Operational dashboards</h3>
-    <p>The legacy home dashboard remains the full operations launchpad. These links keep the old working surfaces close while browsing reports and handoffs.</p>
-    <div class="ops-grid">
-      <a class="ops-card runtime" href="/admin.html"><strong>Admin</strong><span>Backups, health checks, disk usage, broker vacuum, log cleanup.</span></a>
-      <a class="ops-card agent" href="/channels.html"><strong>Agent Channels</strong><span>Topic-scoped multi-agent discussion threads.</span></a>
-      <a class="ops-card agent" href="/comms.html"><strong>Agent Comms</strong><span>Live activity, direct messages, batch progress, zombie monitor.</span></a>
-      <a class="ops-card audit" href="/audit-dashboard.html"><strong>Audit Dashboard</strong><span>Track overview, module heatmaps, QA gate breakdowns.</span></a>
-      <a class="ops-card pipeline" href="/build-events.html"><strong>Build Events</strong><span>Active module builds and dispatch meta events.</span></a>
-      <a class="ops-card runtime" href="/consultation.html"><strong>Consultation Loop</strong><span>Template proposals, review queue, history, metrics.</span></a>
-      <a class="ops-card runtime" href="/cost.html"><strong>Cost</strong><span>Per-module, per-phase, per-model token and USD spend.</span></a>
-      <a class="ops-card curriculum" href="/curriculum-dashboard.html"><strong>Curriculum Dashboard</strong><span>Track plans, module plans, word targets, outlines.</span></a>
-      <a class="ops-card pipeline" href="/delegate.html"><strong>Delegate</strong><span>Delegation tasks, zombie detection, task detail modal.</span></a>
-      <a class="ops-card curriculum" href="/image-explorer.html"><strong>Images</strong><span>Page context, bounding boxes, annotation editor, RAG search.</span></a>
-      <a class="ops-card runtime" href="/orient.html"><strong>Orient</strong><span>Session snapshot: git, issues, pipeline, runtime, health.</span></a>
-      <a class="ops-card pipeline" href="/progress.html"><strong>Progress</strong><span>Pipeline state across tracks from research through MDX.</span></a>
-      <a class="ops-card audit" href="/quality.html"><strong>Quality</strong><span>Research coverage, review scores, weak modules, fix queue.</span></a>
-      <a class="ops-card runtime" href="/runtime.html"><strong>Runtime</strong><span>Agent binaries, usage, headroom, recent runtime calls.</span></a>
-      <a class="ops-card audit" href="/track-health.html"><strong>Track Health</strong><span>Build progress, audits, enrichment, reviews, ETA.</span></a>
-      <a class="ops-card curriculum" href="/wiki.html"><strong>Wiki</strong><span>Wiki compilation progress, quality failures, build logs.</span></a>
+  <details class="ops-directory">
+    <summary>
+      <div>
+        <h3>Operational dashboards</h3>
+        <p>Jump to build, audit, comms, and runtime surfaces without leaving the monitor shell.</p>
+      </div>
+      <span aria-hidden="true">▾</span>
+    </summary>
+    <div class="ops-body">
+      <div class="ops-grid">
+        <a class="ops-card runtime" href="/admin.html"><strong>Admin</strong><span>Backups, health checks, disk usage, broker vacuum, log cleanup.</span></a>
+        <a class="ops-card agent" href="/channels.html"><strong>Agent Channels</strong><span>Topic-scoped multi-agent discussion threads.</span></a>
+        <a class="ops-card agent" href="/comms.html"><strong>Agent Comms</strong><span>Live activity, direct messages, batch progress, zombie monitor.</span></a>
+        <a class="ops-card audit" href="/audit-dashboard.html"><strong>Audit Dashboard</strong><span>Track overview, module heatmaps, QA gate breakdowns.</span></a>
+        <a class="ops-card pipeline" href="/build-events.html"><strong>Build Events</strong><span>Active module builds and dispatch meta events.</span></a>
+        <a class="ops-card runtime" href="/consultation.html"><strong>Consultation Loop</strong><span>Template proposals, review queue, history, metrics.</span></a>
+        <a class="ops-card runtime" href="/cost.html"><strong>Cost</strong><span>Per-module, per-phase, per-model token and USD spend.</span></a>
+        <a class="ops-card curriculum" href="/curriculum-dashboard.html"><strong>Curriculum Dashboard</strong><span>Track plans, module plans, word targets, outlines.</span></a>
+        <a class="ops-card pipeline" href="/delegate.html"><strong>Delegate</strong><span>Delegation tasks, zombie detection, task detail modal.</span></a>
+        <a class="ops-card curriculum" href="/image-explorer.html"><strong>Images</strong><span>Page context, bounding boxes, annotation editor, RAG search.</span></a>
+        <a class="ops-card runtime" href="/orient.html"><strong>Orient</strong><span>Session snapshot: git, issues, pipeline, runtime, health.</span></a>
+        <a class="ops-card pipeline" href="/progress.html"><strong>Progress</strong><span>Pipeline state across tracks from research through MDX.</span></a>
+        <a class="ops-card audit" href="/quality.html"><strong>Quality</strong><span>Research coverage, review scores, weak modules, fix queue.</span></a>
+        <a class="ops-card runtime" href="/runtime.html"><strong>Runtime</strong><span>Agent binaries, usage, headroom, recent runtime calls.</span></a>
+        <a class="ops-card audit" href="/track-health.html"><strong>Track Health</strong><span>Build progress, audits, enrichment, reviews, ETA.</span></a>
+        <a class="ops-card curriculum" href="/wiki.html"><strong>Wiki</strong><span>Wiki compilation progress, quality failures, build logs.</span></a>
+      </div>
     </div>
-  </section>
+  </details>
+
+  <div class="filter-bar">
+    <div class="hint" id="filter-hint">Filter by class, status, author, type, or date.</div>
+    <button class="btn" id="clear-filters" type="button" hidden>Clear filters</button>
+  </div>
 
   <section class="filters" aria-label="Artifact filters">
-    <input id="search" placeholder="Search titles, paths, KPI summaries">
+    <input id="search" placeholder="Search titles, paths, KPI summaries" autocomplete="off">
     <select id="class-filter"><option value="">All classes</option></select>
     <select id="status-filter"><option value="">All statuses</option></select>
     <select id="author-filter"><option value="">All authors</option></select>
@@ -122,9 +162,10 @@ body { min-height: 100vh; }
 </main>
 
 <script>
-const state = { artifacts: [], filtered: [] };
+const state = { artifacts: [], filtered: [], generatedAt: null, loading: true };
 const els = {
   total: document.getElementById('total-count'),
+  totalSub: document.getElementById('total-sub'),
   groups: document.getElementById('groups'),
   search: document.getElementById('search'),
   classFilter: document.getElementById('class-filter'),
@@ -132,6 +173,10 @@ const els = {
   authorFilter: document.getElementById('author-filter'),
   dateFilter: document.getElementById('date-filter'),
   typeFilter: document.getElementById('type-filter'),
+  refreshInfo: document.getElementById('refresh-info'),
+  refreshBtn: document.getElementById('refresh-btn'),
+  clearFilters: document.getElementById('clear-filters'),
+  filterHint: document.getElementById('filter-hint'),
 };
 
 function escapeHtml(value) {
@@ -144,22 +189,58 @@ function optionList(values) {
   return values.map(value => `<option value="${escapeHtml(value)}">${escapeHtml(value)}</option>`).join('');
 }
 
+function artifactType(item) {
+  const path = item.path || '';
+  if (path.endsWith('.html')) return 'html';
+  if (path.endsWith('.md')) return 'md';
+  return '';
+}
+
+function formatStatus(status) {
+  if (!status || status === 'unknown') return 'unknown';
+  return status;
+}
+
+function formatAuthor(author) {
+  return author && author.trim() ? author.trim() : '—';
+}
+
+function filtersActive() {
+  return Boolean(
+    els.search.value.trim()
+    || els.classFilter.value
+    || els.statusFilter.value
+    || els.authorFilter.value
+    || els.typeFilter.value
+    || els.dateFilter.value
+  );
+}
+
 function initFilters() {
   const classes = [...new Set(state.artifacts.map(item => item.class).filter(Boolean))].sort();
   const statuses = [...new Set(state.artifacts.map(item => item.status).filter(Boolean))].sort();
   const authors = [...new Set(state.artifacts.map(item => item.author).filter(Boolean))].sort();
+  const keep = {
+    class: els.classFilter.value,
+    status: els.statusFilter.value,
+    author: els.authorFilter.value,
+  };
   els.classFilter.innerHTML = '<option value="">All classes</option>' + optionList(classes);
   els.statusFilter.innerHTML = '<option value="">All statuses</option>' + optionList(statuses);
   els.authorFilter.innerHTML = '<option value="">All authors</option>' + optionList(authors);
+  els.classFilter.value = classes.includes(keep.class) ? keep.class : '';
+  els.statusFilter.value = statuses.includes(keep.status) ? keep.status : '';
+  els.authorFilter.value = authors.includes(keep.author) ? keep.author : '';
 }
 
 function artifactMatches(item) {
   const q = els.search.value.trim().toLowerCase();
-  const haystack = [item.title, item.path, item.kpi_summary, item.author].join(' ').toLowerCase();
+  const haystack = [item.title, item.path, item.kpi_summary, item.author, item.class].join(' ').toLowerCase();
   if (q && !haystack.includes(q)) return false;
   if (els.classFilter.value && item.class !== els.classFilter.value) return false;
   if (els.statusFilter.value && item.status !== els.statusFilter.value) return false;
   if (els.authorFilter.value && item.author !== els.authorFilter.value) return false;
+  if (els.typeFilter.value && artifactType(item) !== els.typeFilter.value) return false;
   if (els.dateFilter.value && item.date < els.dateFilter.value) return false;
   return true;
 }
@@ -171,17 +252,40 @@ function statusClass(status) {
   return 'unknown';
 }
 
+function renderLoading() {
+  els.groups.innerHTML = `
+    <div class="loading"><span class="spinner" aria-hidden="true"></span> Loading artifact index…</div>
+    <div class="skeleton-grid" aria-hidden="true">
+      ${Array.from({ length: 6 }, () => `
+        <div class="skeleton-card">
+          <div class="skeleton-line wide"></div>
+          <div class="skeleton-line mid"></div>
+          <div class="skeleton-line short"></div>
+        </div>
+      `).join('')}
+    </div>`;
+}
+
 function renderCard(item) {
+  const type = artifactType(item);
   const issues = (item.related_issues || []).map(n => `<span class="badge">#${n}</span>`).join('');
   const prs = (item.related_prs || []).map(n => `<span class="badge">PR #${n}</span>`).join('');
   const agents = (item.agents || []).map(a => `<span class="badge">${escapeHtml(a)}</span>`).join('');
+  const summary = item.kpi_summary || (type === 'md' ? 'Markdown document — open to view source.' : item.path);
+  const showPath = item.title && item.path && item.title !== item.path.split('/').pop()?.replace(/\.(html|md)$/i, '');
   return `<a class="artifact-card" href="${escapeHtml(item.url)}" target="_blank" rel="noopener">
     <div class="card-top">
-      <div class="card-title">${escapeHtml(item.title || item.path)}</div>
-      <span class="pill ${statusClass(item.status)}">${escapeHtml(item.status || 'unknown')}</span>
+      <div>
+        <div class="card-title">${escapeHtml(item.title || item.path)}</div>
+        ${showPath ? `<div class="card-path">${escapeHtml(item.path)}</div>` : ''}
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px;">
+        ${type ? `<span class="pill type">${escapeHtml(type.toUpperCase())}</span>` : ''}
+        <span class="pill ${statusClass(item.status)}">${escapeHtml(formatStatus(item.status))}</span>
+      </div>
     </div>
-    <div class="meta">${escapeHtml(item.date || 'undated')} · ${escapeHtml(item.class || 'document')} · ${escapeHtml(item.author || 'unknown author')}</div>
-    <div class="summary">${escapeHtml(item.kpi_summary || item.path)}</div>
+    <div class="meta">${escapeHtml(item.date || 'undated')} · ${escapeHtml(item.class || 'document')} · ${escapeHtml(formatAuthor(item.author))}</div>
+    <div class="summary">${escapeHtml(summary)}</div>
     <div class="badges">${issues}${prs}${agents}</div>
   </a>`;
 }
@@ -189,10 +293,21 @@ function renderCard(item) {
 function render() {
   state.filtered = state.artifacts.filter(artifactMatches);
   els.total.textContent = state.filtered.length;
+  els.totalSub.textContent = `of ${state.artifacts.length} total`;
+  els.clearFilters.hidden = !filtersActive();
+  els.filterHint.textContent = filtersActive()
+    ? `Showing ${state.filtered.length} of ${state.artifacts.length} artifacts`
+    : 'Filter by class, status, author, type, or date.';
+
   if (!state.filtered.length) {
-    els.groups.innerHTML = '<div class="empty">No artifacts match the current filters.</div>';
+    els.groups.innerHTML = filtersActive()
+      ? `<div class="empty">No artifacts match the current filters. <button class="btn" type="button" id="empty-clear">Clear filters</button></div>`
+      : '<div class="empty">No artifacts found in the index.</div>';
+    const emptyClear = document.getElementById('empty-clear');
+    if (emptyClear) emptyClear.addEventListener('click', clearFilters);
     return;
   }
+
   const byClass = new Map();
   for (const item of state.filtered) {
     const key = item.class || 'document';
@@ -207,27 +322,61 @@ function render() {
   `).join('');
 }
 
-async function loadArtifacts() {
-  const type = els.typeFilter.value;
-  const url = type ? `/api/artifacts/html?type=${encodeURIComponent(type)}` : '/api/artifacts/html';
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const data = await response.json();
-  state.artifacts = data.artifacts || [];
-  initFilters();
+function clearFilters() {
+  els.search.value = '';
+  els.classFilter.value = '';
+  els.statusFilter.value = '';
+  els.authorFilter.value = '';
+  els.typeFilter.value = '';
+  els.dateFilter.value = '';
   render();
 }
 
-[els.search, els.classFilter, els.statusFilter, els.authorFilter, els.dateFilter].forEach(el => {
-  el.addEventListener('input', render);
+function setRefreshInfo() {
+  if (state.loading) {
+    els.refreshInfo.textContent = 'Loading…';
+    return;
+  }
+  const when = state.generatedAt ? new Date(state.generatedAt) : new Date();
+  els.refreshInfo.textContent = `Updated ${when.toLocaleTimeString()}`;
+}
+
+async function loadArtifacts() {
+  state.loading = true;
+  els.refreshBtn.disabled = true;
+  renderLoading();
+  setRefreshInfo();
+  try {
+    const response = await fetch('/api/artifacts/html');
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    state.artifacts = data.artifacts || [];
+    state.generatedAt = data.generated_at || null;
+    initFilters();
+    render();
+  } catch (error) {
+    els.total.textContent = '!';
+    els.totalSub.textContent = 'load failed';
+    els.groups.innerHTML = `<div class="empty">Failed to load artifacts: ${escapeHtml(error.message)}</div>`;
+  } finally {
+    state.loading = false;
+    els.refreshBtn.disabled = false;
+    setRefreshInfo();
+  }
+}
+
+let searchTimer = null;
+els.search.addEventListener('input', () => {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(render, 180);
+});
+[els.classFilter, els.statusFilter, els.authorFilter, els.dateFilter, els.typeFilter].forEach(el => {
   el.addEventListener('change', render);
 });
-els.typeFilter.addEventListener('change', loadArtifacts);
+els.clearFilters.addEventListener('click', clearFilters);
+els.refreshBtn.addEventListener('click', loadArtifacts);
 
-loadArtifacts().catch(error => {
-  els.total.textContent = '!';
-  els.groups.innerHTML = `<div class="empty">Failed to load artifacts: ${escapeHtml(error.message)}</div>`;
-});
+loadArtifacts();
 </script>
 </body>
 </html>

--- a/dashboards/audit-dashboard.html
+++ b/dashboards/audit-dashboard.html
@@ -5,20 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Module Quality Dashboard</title>
 <link rel="icon" href="data:,">
+<link rel="stylesheet" href="/monitor.css">
 <style>
-:root {
-  --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
-  --text: #e6edf3; --text2: #8b949e; --text3: #6e7681;
-  --green: #3fb950; --blue: #58a6ff; --red: #f85149; --yellow: #d29922;
-  --gray: #484f58; --purple: #bc8cff;
-}
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: 'Noto Sans', -apple-system, sans-serif; background: var(--bg); color: var(--text); }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 12px 24px; background: var(--bg2); border-bottom: 1px solid var(--border); }
 .topbar h1 { font-size: 18px; font-weight: 600; }
 .topbar .monitor-nav { margin-left: auto; display: flex; gap: 12px; font-size: 13px; }
 .topbar .monitor-nav a { color: var(--text2); text-decoration: none; }
+.topbar .monitor-nav a:hover { color: var(--text); }
 
 .container { max-width: 1200px; margin: 0 auto; padding: 24px; }
 
@@ -31,33 +27,32 @@ body { font-family: 'Noto Sans', -apple-system, sans-serif; background: var(--bg
 /* Track selector */
 .track-tabs { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 20px; }
 .track-tab { padding: 6px 14px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg2); color: var(--text2); font-size: 12px; cursor: pointer; }
-.track-tab:hover { border-color: var(--blue); color: var(--text); }
-.track-tab.active { background: var(--blue); color: #000; font-weight: 600; }
+.track-tab:hover { border-color: var(--accent); color: var(--text); }
+.track-tab.active { background: var(--accent); color: #fff; border-color: var(--accent); font-weight: 600; }
 
 /* Module table */
 .module-table { width: 100%; border-collapse: collapse; }
 .module-table th { text-align: left; padding: 8px 12px; font-size: 11px; color: var(--text3); text-transform: uppercase; border-bottom: 2px solid var(--border); }
 .module-table td { padding: 8px 12px; font-size: 13px; border-bottom: 1px solid var(--border); }
 .module-table tr:hover { background: var(--bg3); cursor: pointer; }
-.module-table tr.shippable { background: rgba(63,185,80,0.05); }
+.module-table tr.shippable { background: rgba(61,107,74,0.08); }
 .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
-.badge-pass { background: rgba(63,185,80,0.15); color: var(--green); }
-.badge-fail { background: rgba(248,81,73,0.15); color: var(--red); }
-.badge-warn { background: rgba(210,153,34,0.15); color: var(--yellow); }
-.badge-ship { background: rgba(63,185,80,0.3); color: var(--green); }
-.badge-info { background: rgba(88,166,255,0.15); color: var(--blue); }
+.badge-pass { background: rgba(61,107,74,0.15); color: var(--green); }
+.badge-fail { background: rgba(156,40,40,0.15); color: var(--red); }
+.badge-warn { background: rgba(168,132,43,0.15); color: var(--yellow); }
+.badge-ship { background: rgba(61,107,74,0.25); color: var(--green); }
+.badge-info { background: rgba(42,86,128,0.12); color: var(--blue); }
 
 /* Side panel */
-.overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 10; }
+.overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(26,26,26,0.35); z-index: 10; }
 .overlay.open { display: block; }
-.panel { position: fixed; top: 0; right: -500px; width: 500px; height: 100vh; background: var(--bg2); border-left: 1px solid var(--border); overflow-y: auto; z-index: 11; transition: right 0.2s; padding: 24px; }
+.panel { position: fixed; top: 0; right: -500px; width: 500px; height: 100vh; background: var(--bg2); border-left: 1px solid var(--border); overflow-y: auto; z-index: 11; transition: right 0.2s; padding: 24px; box-shadow: -8px 0 24px rgba(26,26,26,0.12); }
 .panel.open { right: 0; }
 .panel h2 { font-size: 16px; margin-bottom: 12px; }
-.panel .close { position: absolute; top: 12px; right: 16px; font-size: 20px; cursor: pointer; color: var(--text2); }
+.panel .close { position: absolute; top: 12px; right: 16px; font-size: 20px; cursor: pointer; color: var(--text2); background: none; border: none; }
 .gate { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; }
 .gate .icon { width: 16px; text-align: center; }
 </style>
-<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 

--- a/dashboards/comms.html
+++ b/dashboards/comms.html
@@ -487,15 +487,25 @@ function phaseLabel(phase) {
 // ========= LIVE ACTIVITY =========
 async function loadLiveActivity() {
   try {
-    const params = new URLSearchParams({
-      minutes: '30',
-      limit: String(DISPATCH_LIMIT),
-    });
-    const res = await fetch(`/api/comms/live-activity?${params}`);
-    const data = await res.json();
+    const [activeRes, recentRes] = await Promise.all([
+      fetch('/api/build/events/active'),
+      fetch(`/api/build/events/recent?limit=${Math.max(DISPATCH_LIMIT, 40)}`),
+    ]);
+    if (!activeRes.ok) throw new Error(`active HTTP ${activeRes.status}`);
+    if (!recentRes.ok) throw new Error(`recent HTTP ${recentRes.status}`);
+    const activeData = await activeRes.json();
+    const recentData = await recentRes.json();
+    const now = Date.now();
 
-    // Building Now — modules with recently updated state
-    const building = data.in_progress || [];
+    // Building Now — modules with recent dispatch activity (#1309: build/events)
+    const building = (activeData.active || []).map(b => ({
+      track: b.level,
+      slug: b.slug,
+      phase: b.current_phase || '',
+      phase_status: 'in progress',
+      task_id: '',
+      seconds_ago: Math.round(b.age_s || 0),
+    }));
     document.getElementById('building-count').textContent = `(${building.length})`;
     const buildEl = document.getElementById('feed-building');
     if (building.length === 0) {
@@ -530,8 +540,20 @@ async function loadLiveActivity() {
       }).join('');
     }
 
-    // Recent Completions — research files
-    const completions = data.recent_completions || [];
+    // Recent Completions — successful build events
+    const completions = (recentData.events || [])
+      .filter(e => e.ok === true)
+      .slice(0, 30)
+      .map(e => {
+        const ts = e.ts ? new Date(e.ts).getTime() : now;
+        return {
+          track: e.level,
+          slug: e.slug,
+          type: e.phase || 'phase',
+          size_kb: e.duration_s != null ? String(e.duration_s) : '',
+          seconds_ago: Math.max(0, Math.round((now - ts) / 1000)),
+        };
+      });
     document.getElementById('completions-count').textContent = `(${completions.length})`;
     const compEl = document.getElementById('feed-completions');
     if (completions.length === 0) {
@@ -550,14 +572,24 @@ async function loadLiveActivity() {
               <span class="fi-age">${timeAgo(c.seconds_ago)} ago</span>
             </div>
             <div class="fi-slug">${slug}</div>
-            <div class="fi-detail">${type} &middot; ${sizeKb} KB</div>
+            <div class="fi-detail">${type}${sizeKb ? ` &middot; ${sizeKb}s` : ''}</div>
           </div>
         `;
       }).join('');
     }
 
-    // Dispatch Feed — recent broker messages
-    const dispatches = data.recent_dispatches || [];
+    // Dispatch Feed — recent build events (replaces deprecated live-activity dispatches)
+    const dispatches = (recentData.events || []).slice(0, DISPATCH_LIMIT).map(e => {
+      const ts = e.ts ? new Date(e.ts).getTime() : now;
+      return {
+        task_id: `${e.level || ''}-${e.slug || ''}-${e.phase || 'event'}`,
+        from: e.agent || 'pipeline',
+        to: e.level || '',
+        type: e.ok ? 'success' : 'error',
+        preview: `${e.phase || 'phase'} ${e.ok ? 'ok' : 'failed'}${e.duration_s != null ? ` (${e.duration_s}s)` : ''}`,
+        seconds_ago: Math.max(0, Math.round((now - ts) / 1000)),
+      };
+    });
     document.getElementById('dispatch-count').textContent = `(${dispatches.length})`;
     const dispEl = document.getElementById('feed-dispatches');
     if (dispatches.length === 0) {

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -80,7 +80,7 @@ Agents should keep a small on-disk cache keyed by manifest hash
 what you cached, skip the payload fetch entirely — the bytes are
 still authoritative. A ready-to-use helper lives at
 ``scripts/ai_agent_bridge/_monitor_cache.py``; the client SDK
-(``scripts/monitor_client.py``) will wrap this in P3.
+(``scripts/ai_agent_bridge/monitor_client.py``) will wrap this in P3.
 
 ---
 
@@ -1394,7 +1394,7 @@ body = cache.get("rules", expected_hash="...")
 cache.put("rules", body, body_hash="...", url="/api/rules?format=markdown")
 ```
 
-For most callers, **use the SDK**: `scripts/monitor_client.py`.
+For most callers, **use the SDK**: `scripts/ai_agent_bridge/monitor_client.py`.
 
 ```python
 # Requires ``scripts/`` on sys.path. Tests + any caller launched via
@@ -1825,9 +1825,9 @@ revision of this endpoint was removed per reviewer BLOCKER on
 | Page | URL | Data source |
 |------|-----|-------------|
 | Home | `/` | `/api/dashboard/overview`, `/api/state/summary`, `/api/comms/batch-progress` |
-| Audit Dashboard | `/audit-dashboard.html` | `/api/blue/live-status`, `/api/dashboard/track/{id}` |
+| Audit Dashboard | `/audit-dashboard.html` | `/api/dashboard/overview`, `/api/dashboard/track/{id}` |
 | Progress | `/progress.html` | `/api/state/summary`, `/api/state/pipeline/{track}` |
-| Agent Comms | `/comms.html` | `/api/comms/live-activity`, `/api/comms/batch-progress`, `/api/comms/zombies`, `/api/comms/messages`, `/api/comms/stats` |
+| Agent Comms | `/comms.html` | `/api/build/events/active`, `/api/build/events/recent`, `/api/comms/batch-progress`, `/api/comms/zombies`, `/api/comms/messages`, `/api/comms/stats` |
 | Quality | `/quality.html` | `/api/state/research-coverage`, `/api/state/review-coverage`, `/api/state/issues`, `/api/state/weak-points` |
 | Track Health | `/track-health.html` | `/api/state/track-health/{track}`, `/api/state/build-status`, `/api/state/enrichment-status` |
 | Curriculum | `/curriculum-dashboard.html` | `/api/dashboard/overview` |

--- a/docs/api-endpoint-consumer-map-2026-05-06.md
+++ b/docs/api-endpoint-consumer-map-2026-05-06.md
@@ -1,6 +1,6 @@
 # API Endpoint Consumer Map - 2026-05-06
 
-Scope: `scripts/api/*_router.py`, `scripts/api/main.py`, and `playgrounds/*.html`. Route inventory comes from the FastAPI app object; consumers were checked with `rg` across `playgrounds/`, `scripts/`, and `docs/`. `MEMORY.md` is not present in this worktree.
+Scope: `scripts/api/*_router.py`, `scripts/api/main.py`, and `dashboards/*.html`. Route inventory comes from the FastAPI app object; consumers were checked with `rg` across `dashboards/`, `scripts/`, and `docs/`. `MEMORY.md` is not present in this worktree.
 
 ## Endpoint x Consumer Matrix
 

--- a/docs/api-endpoint-consumer-map-2026-05-06.md
+++ b/docs/api-endpoint-consumer-map-2026-05-06.md
@@ -6,17 +6,17 @@ Scope: `scripts/api/*_router.py`, `scripts/api/main.py`, and `dashboards/*.html`
 
 | Route | HTTP method | Router file | Consumer(s) | Last touched | Verdict |
 | --- | --- | --- | --- | --- | --- |
-| /api/admin/backup/list | GET | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/backup/qdrant | POST | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/backup/{filename} | DELETE | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/collections | GET | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/collections/verify | POST | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/disk-usage | GET | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/health | GET | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/maintenance/annotation-stats | GET | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/maintenance/clean-logs | POST | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/maintenance/embedding-cache-stats | GET | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/admin/maintenance/vacuum-broker | POST | scripts/api/admin_router.py | playgrounds/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/backup/list | GET | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/backup/qdrant | POST | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/backup/{filename} | DELETE | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/collections | GET | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/collections/verify | POST | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/disk-usage | GET | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/health | GET | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/maintenance/annotation-stats | GET | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/maintenance/clean-logs | POST | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/maintenance/embedding-cache-stats | GET | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/admin/maintenance/vacuum-broker | POST | scripts/api/admin_router.py | dashboards/admin.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
 | /api/agent/module/{level}/{slug} | GET | scripts/api/agent_router.py | docs/MONITOR-API.md | 2026-05-05 | KEEP |
 | /api/agent/orchestration/{level}/{slug} | GET | scripts/api/agent_router.py | docs/MONITOR-API.md | 2026-05-05 | KEEP |
 | /api/agent/prompt-summary/{level}/{slug} | GET | scripts/api/agent_router.py | docs/MONITOR-API.md | 2026-05-05 | KEEP |
@@ -36,57 +36,57 @@ Scope: `scripts/api/*_router.py`, `scripts/api/main.py`, and `dashboards/*.html`
 | /api/blue/history | GET | scripts/api/blue_router.py | docs/MONITOR-API.md | 2026-05-04 | KEEP |
 | /api/blue/live-status | GET | scripts/api/blue_router.py | docs/MONITOR-API.md | 2026-05-04 | DEPRECATE |
 | /api/blue/metrics | GET | scripts/api/blue_router.py | docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/build/events/active | GET | scripts/api/build_events_router.py | playgrounds/build-events.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/build/events/recent | GET | scripts/api/build_events_router.py | playgrounds/build-events.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/comms/acknowledge/{message_id} | POST | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/active-processes | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/batch-progress | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/batch-progress/{track} | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/by-module/{track}/{slug} | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/channels | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/channels/{name} | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/channels/{name}/deliveries | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/channels/{name}/messages | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/channels/{name}/post | POST | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/channels/{name}/threads/{thread_id} | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/cleanup | POST | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/conversation/{task_id} | GET | scripts/api/comms_router.py | playgrounds/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
-| /api/comms/conversations | GET | scripts/api/comms_router.py | playgrounds/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
-| /api/comms/health | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/inbox | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/live-activity | GET | scripts/api/comms_router.py | playgrounds/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
-| /api/comms/messages | GET | scripts/api/comms_router.py | playgrounds/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
-| /api/comms/send | POST | scripts/api/comms_router.py | playgrounds/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
-| /api/comms/stats | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/comms/zombies | GET | scripts/api/comms_router.py | playgrounds/channels.html; playgrounds/track-health.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/consultation/history | GET | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/consultation/history/{track}/{slug} | GET | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/consultation/metrics | GET | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/consultation/queue | GET | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/consultation/queue/{filename} | GET | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/consultation/queue/{filename}/approve | POST | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/consultation/queue/{filename}/reject | POST | scripts/api/consultation_router.py | playgrounds/consultation.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
-| /api/analytics/cost | GET | scripts/api/cost_router.py | playgrounds/cost.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-11 | KEEP |
-| /api/analytics/cost/module/{level}/{slug} | GET | scripts/api/cost_router.py | playgrounds/cost.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-11 | KEEP |
-| /api/analytics/cost/phase/{name} | GET | scripts/api/cost_router.py | playgrounds/cost.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-11 | KEEP |
-| /api/dashboard/activity-config | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/comms | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/comms/conversation/{task_id} | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/comms/message/{message_id} | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/comms/messages | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/module/{track_id}/{slug} | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/overview | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/pipeline | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/research | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/track/{track_id} | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/dashboard/track/{track_id}/summary | GET | scripts/api/dashboard_router.py | playgrounds/audit-dashboard.html; playgrounds/curriculum-dashboard.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/build/events/active | GET | scripts/api/build_events_router.py | dashboards/build-events.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/build/events/recent | GET | scripts/api/build_events_router.py | dashboards/build-events.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/comms/acknowledge/{message_id} | POST | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/active-processes | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/batch-progress | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/batch-progress/{track} | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/by-module/{track}/{slug} | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/channels | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/channels/{name} | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/channels/{name}/deliveries | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/channels/{name}/messages | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/channels/{name}/post | POST | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/channels/{name}/threads/{thread_id} | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/cleanup | POST | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/conversation/{task_id} | GET | scripts/api/comms_router.py | dashboards/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
+| /api/comms/conversations | GET | scripts/api/comms_router.py | dashboards/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
+| /api/comms/health | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/inbox | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/live-activity | GET | scripts/api/comms_router.py | docs/MONITOR-API.md (no consumers post-#2256) | 2026-05-06 | DEPRECATE |
+| /api/comms/messages | GET | scripts/api/comms_router.py | dashboards/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
+| /api/comms/send | POST | scripts/api/comms_router.py | dashboards/comms.html; docs/MONITOR-API.md | 2026-05-06 | DEPRECATE |
+| /api/comms/stats | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/comms/zombies | GET | scripts/api/comms_router.py | dashboards/channels.html; dashboards/track-health.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/consultation/history | GET | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/consultation/history/{track}/{slug} | GET | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/consultation/metrics | GET | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/consultation/queue | GET | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/consultation/queue/{filename} | GET | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/consultation/queue/{filename}/approve | POST | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/consultation/queue/{filename}/reject | POST | scripts/api/consultation_router.py | dashboards/consultation.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-05 | KEEP |
+| /api/analytics/cost | GET | scripts/api/cost_router.py | dashboards/cost.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-11 | KEEP |
+| /api/analytics/cost/module/{level}/{slug} | GET | scripts/api/cost_router.py | dashboards/cost.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-11 | KEEP |
+| /api/analytics/cost/phase/{name} | GET | scripts/api/cost_router.py | dashboards/cost.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-11 | KEEP |
+| /api/dashboard/activity-config | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/comms | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/comms/conversation/{task_id} | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/comms/message/{message_id} | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/comms/messages | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/module/{track_id}/{slug} | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/overview | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/pipeline | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/research | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/track/{track_id} | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/dashboard/track/{track_id}/summary | GET | scripts/api/dashboard_router.py | dashboards/audit-dashboard.html; dashboards/curriculum-dashboard.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
 | /api/decisions | GET | scripts/api/decisions_router.py | docs/MONITOR-API.md; docs/decisions/* | 2026-04-04 | KEEP |
 | /api/decisions/budget | GET | scripts/api/decisions_router.py | docs/MONITOR-API.md; docs/decisions/* | 2026-04-04 | KEEP |
 | /api/decisions/scope/{scope} | GET | scripts/api/decisions_router.py | docs/MONITOR-API.md; docs/decisions/* | 2026-04-04 | KEEP |
 | /api/decisions/stale | GET | scripts/api/decisions_router.py | docs/MONITOR-API.md; docs/decisions/* | 2026-04-04 | KEEP |
 | /api/decisions/{dec_id} | GET | scripts/api/decisions_router.py | docs/MONITOR-API.md; docs/decisions/* | 2026-04-04 | KEEP |
-| /api/delegate/tasks | GET | scripts/api/delegate_router.py | playgrounds/delegate.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-23 | KEEP |
-| /api/delegate/tasks/{task_id} | GET | scripts/api/delegate_router.py | playgrounds/delegate.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-23 | KEEP |
+| /api/delegate/tasks | GET | scripts/api/delegate_router.py | dashboards/delegate.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-23 | KEEP |
+| /api/delegate/tasks/{task_id} | GET | scripts/api/delegate_router.py | dashboards/delegate.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-23 | KEEP |
 | /api/git/cleanup | GET | scripts/api/git_hygiene_router.py | docs/MONITOR-API.md | 2026-04-25 | KEEP |
 | /api/git/hygiene | GET | scripts/api/git_hygiene_router.py | docs/MONITOR-API.md | 2026-04-25 | KEEP |
 | /api/gold/active-orchestration | GET | scripts/api/gold_router.py | docs/MONITOR-API.md | 2026-05-05 | KEEP |
@@ -98,106 +98,106 @@ Scope: `scripts/api/*_router.py`, `scripts/api/main.py`, and `dashboards/*.html`
 | /api/gold/plan-details/{track_id} | GET | scripts/api/gold_router.py | docs/MONITOR-API.md | 2026-05-05 | KEEP |
 | /api/gold/union-stats | GET | scripts/api/gold_router.py | docs/MONITOR-API.md | 2026-05-05 | KEEP |
 | /api/state/governance | GET | scripts/api/governance_router.py | docs/MONITOR-API.md; docs/session-state/* | 2026-04-24 | KEEP |
-| /api/images/annotations | GET | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/annotations/bulk | POST | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/annotations/{image_id} | PUT | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/cleanup | POST | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/page/{pdf_stem}/{page_num} | GET | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/page_render/{pdf_stem}/{page_num}.png | GET | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/reload | POST | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/stats | GET | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/images/textbooks | GET | scripts/api/images_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/issues/map | GET | scripts/api/issues_router.py | playgrounds/quality.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/batch/active | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/checkpoints | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/dispatcher | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/dispatcher/logs | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/dispatcher/running | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/dispatcher/scan | POST | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/failures | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/batch/usage | GET | scripts/api/main.py | playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/config | GET | scripts/api/main.py | playgrounds/consultation.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/health | GET | scripts/api/main.py | playgrounds/* smoke tests; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /api/orient | GET | scripts/api/main.py | playgrounds/orient.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
-| /images/{path:path} | GET | scripts/api/main.py | playgrounds/image-explorer.html | 2026-05-04 | KEEP |
-| /{path:path} | GET | scripts/api/main.py | playgrounds/*.html static serving | 2026-05-04 | KEEP |
-| /api/rag/browse_images | GET | scripts/api/rag_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/rag/search_images | GET | scripts/api/rag_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/rag/search_literary | GET | scripts/api/rag_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/rag/search_text | GET | scripts/api/rag_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/rag/stats | GET | scripts/api/rag_router.py | playgrounds/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/images/annotations | GET | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/annotations/bulk | POST | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/annotations/{image_id} | PUT | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/cleanup | POST | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/page/{pdf_stem}/{page_num} | GET | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/page_render/{pdf_stem}/{page_num}.png | GET | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/reload | POST | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/stats | GET | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/images/textbooks | GET | scripts/api/images_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/issues/map | GET | scripts/api/issues_router.py | dashboards/quality.html; docs/MONITOR-API.md | 2026-04-17 | KEEP |
+| /api/batch/active | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/checkpoints | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/dispatcher | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/dispatcher/logs | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/dispatcher/running | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/dispatcher/scan | POST | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/failures | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/batch/usage | GET | scripts/api/main.py | dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/config | GET | scripts/api/main.py | dashboards/consultation.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/health | GET | scripts/api/main.py | dashboards/* smoke tests; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /api/orient | GET | scripts/api/main.py | dashboards/orient.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-04 | KEEP |
+| /images/{path:path} | GET | scripts/api/main.py | dashboards/image-explorer.html | 2026-05-04 | KEEP |
+| /{path:path} | GET | scripts/api/main.py | dashboards/*.html static serving | 2026-05-04 | KEEP |
+| /api/rag/browse_images | GET | scripts/api/rag_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/rag/search_images | GET | scripts/api/rag_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/rag/search_literary | GET | scripts/api/rag_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/rag/search_text | GET | scripts/api/rag_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/rag/stats | GET | scripts/api/rag_router.py | dashboards/image-explorer.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
 | /api/state/reviewer-ghosts/{track} | GET | scripts/api/reviewer_ghosts_router.py | docs/MONITOR-API.md | 2026-04-24 | KEEP |
 | /api/rules | GET | scripts/api/rules_router.py | docs/MONITOR-API.md; docs/session-state/* | 2026-04-17 | KEEP |
-| /api/runtime/agents | GET | scripts/api/runtime_router.py | playgrounds/runtime.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
-| /api/runtime/auth | GET | scripts/api/runtime_router.py | playgrounds/runtime.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
-| /api/runtime/headroom | GET | scripts/api/runtime_router.py | playgrounds/runtime.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
-| /api/runtime/recent | GET | scripts/api/runtime_router.py | playgrounds/runtime.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
-| /api/runtime/usage | GET | scripts/api/runtime_router.py | playgrounds/runtime.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
+| /api/runtime/agents | GET | scripts/api/runtime_router.py | dashboards/runtime.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
+| /api/runtime/auth | GET | scripts/api/runtime_router.py | dashboards/runtime.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
+| /api/runtime/headroom | GET | scripts/api/runtime_router.py | dashboards/runtime.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
+| /api/runtime/recent | GET | scripts/api/runtime_router.py | dashboards/runtime.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
+| /api/runtime/usage | GET | scripts/api/runtime_router.py | dashboards/runtime.html; dashboards/index.html; docs/MONITOR-API.md | 2026-04-21 | KEEP |
 | /api/session/current | GET | scripts/api/session_router.py | docs/MONITOR-API.md | 2026-04-17 | KEEP |
 | /api/site/deployments | GET | scripts/api/site_router.py | docs/MONITOR-API.md | 2026-04-17 | KEEP |
 | /api/site/health | GET | scripts/api/site_router.py | docs/MONITOR-API.md | 2026-04-17 | KEEP |
-| /api/state/build-stats | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/build-stats/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/build-status | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/build-status/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/enrichment-status | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/failing | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/final-reviews/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/issues | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/manifest | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/module/{track_id}/slug/{slug} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/module/{track_id}/{num} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/pipeline-versions | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/pipeline/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/range/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/ready-to-build | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/research-coverage | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/research/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/review-coverage | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/summary | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/track-health/{track_id} | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/state/weak-points | GET | scripts/api/state_router.py | playgrounds/index.html; playgrounds/progress.html; playgrounds/quality.html; playgrounds/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/build-stats | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/build-stats/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/build-status | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/build-status/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/enrichment-status | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/failing | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/final-reviews/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/issues | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/manifest | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/module/{track_id}/slug/{slug} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/module/{track_id}/{num} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/pipeline-versions | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/pipeline/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/range/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/ready-to-build | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/research-coverage | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/research/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/review-coverage | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/summary | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/track-health/{track_id} | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/state/weak-points | GET | scripts/api/state_router.py | dashboards/index.html; dashboards/progress.html; dashboards/quality.html; dashboards/track-health.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
 | /api/telemetry/tool-timings | GET | scripts/api/telemetry_router.py | docs/MONITOR-API.md | 2026-04-25 | KEEP |
 | /api/telemetry/tool-timings | POST | scripts/api/telemetry_router.py | docs/MONITOR-API.md | 2026-04-25 | KEEP |
-| /api/wiki/article/{track}/{slug} | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/build-log | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/quality-gate | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/quality-gate/{track} | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/sources | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/sources/{track}/{slug} | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/status | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
-| /api/wiki/status/{track} | GET | scripts/api/wiki_router.py | playgrounds/wiki.html; playgrounds/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/article/{track}/{slug} | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/build-log | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/quality-gate | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/quality-gate/{track} | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/sources | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/sources/{track}/{slug} | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/status | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
+| /api/wiki/status/{track} | GET | scripts/api/wiki_router.py | dashboards/wiki.html; dashboards/index.html; docs/MONITOR-API.md | 2026-05-06 | KEEP |
 | /api/worktrees | GET | scripts/api/worktrees_router.py | docs/MONITOR-API.md | 2026-04-17 | KEEP |
 
 ## Playground x Usefulness Matrix
 
 | File | Linked from index.html? | Last visited (mtime / git log) | Functional today? | Endpoints used | Verdict |
 | --- | --- | --- | --- | --- | --- |
-| playgrounds/admin.html | yes | mtime 2026-05-06; git 2026-05-06 | yes (covered by smoke test) | /api/admin/health; /api/admin/disk-usage; /api/admin/backup/list; /api/admin/maintenance/*; /api/admin/collections* | KEEP |
-| playgrounds/audit-dashboard.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/dashboard/overview; /api/dashboard/track/{track_id}/summary; /api/dashboard/module/{track_id}/{slug}; /api/state/module/{track_id}/{num} | KEEP |
-| playgrounds/build-events.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/build/events/active; /api/build/events/recent | KEEP |
-| playgrounds/channels.html | yes | mtime 2026-05-06; git 2026-05-06 | yes (covered by smoke test) | /api/comms/channels; /api/comms/channels/{name}; /api/comms/channels/{name}/messages; /api/comms/channels/{name}/deliveries; /api/comms/channels/{name}/post | KEEP |
-| playgrounds/comms.html | no | mtime 2026-05-06; git 2026-05-03 | yes (legacy UI, hidden from index) | /api/comms/messages; /api/comms/conversation/{task_id}; /api/comms/live-activity; /api/comms/batch-progress; /api/comms/zombies; /api/comms/acknowledge/{id}; /api/comms/send; /api/comms/stats; /api/comms/health | DEPRECATE |
-| playgrounds/consultation.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/config; /api/consultation/queue; /api/consultation/history; /api/consultation/metrics; /api/consultation/queue/{filename}/{action} | KEEP |
-| playgrounds/cost.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/analytics/cost; /api/analytics/cost/module/{level}/{slug}; /api/analytics/cost/phase/{name} | KEEP |
-| playgrounds/curriculum-dashboard.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/dashboard/overview; /api/dashboard/track/{track_id}; /api/dashboard/module/{track_id}/{slug} | KEEP |
-| playgrounds/delegate.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/delegate/tasks; /api/delegate/tasks/{task_id} | KEEP |
-| playgrounds/image-explorer.html | yes | mtime 2026-05-06; git 2026-05-06 | yes (covered by smoke test) | /api/images/textbooks; /api/images/stats; /api/images/annotations; /api/images/annotations/{image_id}; /api/images/annotations/bulk; /api/images/cleanup; /api/images/page/{stem}/{page}; /api/rag/search_text; /api/rag/search_images; /api/rag/search_literary; /images/{path} | KEEP |
-| playgrounds/images.html | no | mtime 2026-05-06; git 2026-03-01 | yes (redirect-only) | none; redirect-only alias to /image-explorer.html | DELETE |
-| playgrounds/index.html | n/a | mtime 2026-05-06; git 2026-05-06 | yes (root dashboard) | /api/dashboard/overview; /api/state/pipeline-versions; /api/consultation/metrics; /api/state/summary; /api/comms/batch-progress; /api/state/weak-points?limit=1; /api/orient; /api/runtime/agents; /api/delegate/tasks?limit=100; /api/build/events/active; /api/wiki/status; /api/analytics/cost | KEEP |
-| playgrounds/orient.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/orient | KEEP |
-| playgrounds/progress.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/state/pipeline/{track}; /api/state/summary; /api/state/pipeline-versions | KEEP |
-| playgrounds/quality.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/state/research-coverage; /api/state/review-coverage; /api/state/issues; /api/state/weak-points?limit=500 | KEEP |
-| playgrounds/runtime.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/runtime/agents; /api/runtime/usage; /api/runtime/headroom; /api/runtime/recent; /api/runtime/auth | KEEP |
-| playgrounds/track-health.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/state/build-status; /api/state/enrichment-status; /api/state/track-health/{track}; /api/state/module/{track}/{num}; /api/comms/by-module/{track}/{slug} | KEEP |
-| playgrounds/wiki.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/wiki/status; /api/wiki/status/{track}; /api/wiki/quality-gate/{track}; /api/wiki/build-log | KEEP |
+| dashboards/admin.html | yes | mtime 2026-05-06; git 2026-05-06 | yes (covered by smoke test) | /api/admin/health; /api/admin/disk-usage; /api/admin/backup/list; /api/admin/maintenance/*; /api/admin/collections* | KEEP |
+| dashboards/audit-dashboard.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/dashboard/overview; /api/dashboard/track/{track_id}/summary; /api/dashboard/module/{track_id}/{slug}; /api/state/module/{track_id}/{num} | KEEP |
+| dashboards/build-events.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/build/events/active; /api/build/events/recent | KEEP |
+| dashboards/channels.html | yes | mtime 2026-05-06; git 2026-05-06 | yes (covered by smoke test) | /api/comms/channels; /api/comms/channels/{name}; /api/comms/channels/{name}/messages; /api/comms/channels/{name}/deliveries; /api/comms/channels/{name}/post | KEEP |
+| dashboards/comms.html | no | mtime 2026-05-06; git 2026-05-03 | yes (legacy UI, hidden from index) | /api/comms/messages; /api/comms/conversation/{task_id}; /api/build/events/active; /api/build/events/recent; /api/comms/batch-progress; /api/comms/zombies; /api/comms/acknowledge/{id}; /api/comms/send; /api/comms/stats; /api/comms/health | DEPRECATE |
+| dashboards/consultation.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/config; /api/consultation/queue; /api/consultation/history; /api/consultation/metrics; /api/consultation/queue/{filename}/{action} | KEEP |
+| dashboards/cost.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/analytics/cost; /api/analytics/cost/module/{level}/{slug}; /api/analytics/cost/phase/{name} | KEEP |
+| dashboards/curriculum-dashboard.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/dashboard/overview; /api/dashboard/track/{track_id}; /api/dashboard/module/{track_id}/{slug} | KEEP |
+| dashboards/delegate.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/delegate/tasks; /api/delegate/tasks/{task_id} | KEEP |
+| dashboards/image-explorer.html | yes | mtime 2026-05-06; git 2026-05-06 | yes (covered by smoke test) | /api/images/textbooks; /api/images/stats; /api/images/annotations; /api/images/annotations/{image_id}; /api/images/annotations/bulk; /api/images/cleanup; /api/images/page/{stem}/{page}; /api/rag/search_text; /api/rag/search_images; /api/rag/search_literary; /images/{path} | KEEP |
+| dashboards/images.html | no | mtime 2026-05-06; git 2026-03-01 | yes (redirect-only) | none; redirect-only alias to /image-explorer.html | DELETE |
+| dashboards/index.html | n/a | mtime 2026-05-06; git 2026-05-06 | yes (root dashboard) | /api/dashboard/overview; /api/state/pipeline-versions; /api/consultation/metrics; /api/state/summary; /api/comms/batch-progress; /api/state/weak-points?limit=1; /api/orient; /api/runtime/agents; /api/delegate/tasks?limit=100; /api/build/events/active; /api/wiki/status; /api/analytics/cost | KEEP |
+| dashboards/orient.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/orient | KEEP |
+| dashboards/progress.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/state/pipeline/{track}; /api/state/summary; /api/state/pipeline-versions | KEEP |
+| dashboards/quality.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/state/research-coverage; /api/state/review-coverage; /api/state/issues; /api/state/weak-points?limit=500 | KEEP |
+| dashboards/runtime.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/runtime/agents; /api/runtime/usage; /api/runtime/headroom; /api/runtime/recent; /api/runtime/auth | KEEP |
+| dashboards/track-health.html | yes | mtime 2026-05-06; git 2026-04-17 | yes (covered by smoke test) | /api/state/build-status; /api/state/enrichment-status; /api/state/track-health/{track}; /api/state/module/{track}/{num}; /api/comms/by-module/{track}/{slug} | KEEP |
+| dashboards/wiki.html | yes | mtime 2026-05-06; git 2026-04-11 | yes (covered by smoke test) | /api/wiki/status; /api/wiki/status/{track}; /api/wiki/quality-gate/{track}; /api/wiki/build-log | KEEP |
 
 ## Candidates for deletion
 
 | Path | LOC | Why it is dead or stale | Risk if deleted |
 | --- | ---: | --- | --- |
-| `playgrounds/images.html` | 11 | Redirect-only alias to `image-explorer.html`; not linked from `playgrounds/index.html`; no API calls. | low |
-| `playgrounds/comms.html` | 860 | Hidden legacy comms UI. It is the only active UI consumer of deprecated legacy broker routes; `channels.html` is the current chat surface. | medium; user signoff before deletion |
+| `dashboards/images.html` | 11 | Redirect-only alias to `image-explorer.html`; not linked from `dashboards/index.html`; no API calls. | low |
+| `dashboards/comms.html` | 860 | Hidden legacy comms UI. It is the only active UI consumer of deprecated legacy broker routes; `channels.html` is the current chat surface. | medium; user signoff before deletion |
 | `scripts/api/comms_router.py` legacy route section | 1485 | The file still has active channel routes, but `/messages`, `/conversations`, `/conversation/{task_id}`, `/live-activity`, and `/send` only serve hidden `comms.html` plus docs. | medium; delete only after migrating/removing `comms.html` |
 | `scripts/api/blue_router.py` `/api/blue/live-status` | 413 | Already marked deprecated; retained for monitor-client compatibility tests. | medium; remove only after docs/tests/client migration |
 

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -328,7 +328,7 @@ when the conversation will have at least two turns.
 
 ## Web dashboard
 
-`playgrounds/channels.html` — read-only monitor plus post form,
+`dashboards/channels.html` — read-only monitor plus post form,
 localhost only. Shows:
 
 - All channels with message counts + pending deliveries + last activity
@@ -340,7 +340,7 @@ Served by `scripts/api/main.py` at `http://localhost:8765`. The
 browser POST endpoint is `/api/comms/channels/{name}/post` — user-only,
 gated by localhost binding. Agents still post via CLI.
 
-`playgrounds/comms.html` is the legacy operational dashboard for live
+`dashboards/comms.html` is the legacy operational dashboard for live
 activity, DM-style broker messages, zombie detection, and batch progress.
 Its hot message endpoints are bounded by server-side `limit` defaults
 and keyset cursors; keep client polling paced so heavy views refresh no

--- a/docs/best-practices/local-api-server.md
+++ b/docs/best-practices/local-api-server.md
@@ -84,7 +84,7 @@ The full route and playground consumer inventory lives in
 
 ## Deprecating An Endpoint
 
-1. Prove the endpoint has no active consumer with `rg` across `playgrounds/`,
+1. Prove the endpoint has no active consumer with `rg` across `dashboards/`,
    `scripts/`, and `docs/`.
 2. Mark the FastAPI route `deprecated=True` and add a response header or docs
    pointer to the replacement when compatibility clients still exist.

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -1067,7 +1067,7 @@ async def send_message(msg: SendMessageRequest):
 # ══════════════════════════════════════════════════════════════════
 #
 # These endpoints expose the channel bridge to the web dashboard
-# (playgrounds/channels.html). They reuse the same broker DB as the
+# (dashboards/channels.html). They reuse the same broker DB as the
 # legacy /api/comms/messages* endpoints but operate on the new
 # `channels`, `channel_messages`, `deliveries` tables.
 #

--- a/scripts/api/images_router.py
+++ b/scripts/api/images_router.py
@@ -290,14 +290,8 @@ async def list_textbooks():
     """List PDFs on disk with image counts and annotation coverage."""
     await _index.ensure_loaded()
 
-    catalog_items = sorted(_index.pdf_catalog.items())
-    page_counts = await asyncio.gather(*(
-        asyncio.to_thread(_read_pdf_page_count, info["path"])
-        for _stem, info in catalog_items
-    ))
-
     result = []
-    for (stem, info), page_count in zip(catalog_items, page_counts, strict=False):
+    for stem, info in sorted(_index.pdf_catalog.items()):
         # Count images from this PDF
         pages_with_images = _index.by_pdf_page.get(stem, {})
         image_count = sum(len(imgs) for imgs in pages_with_images.values())
@@ -306,6 +300,10 @@ async def list_textbooks():
             for img in imgs
             if img.get("description_uk")
         )
+        # Avoid opening every PDF on each list call — derive from the index
+        # when possible. Image explorer only needs a rough page span here;
+        # per-page context still reads the PDF on demand.
+        page_count = max(pages_with_images.keys(), default=0) if pages_with_images else 0
 
         result.append({
             "stem": stem,

--- a/scripts/api/images_router.py
+++ b/scripts/api/images_router.py
@@ -111,6 +111,7 @@ class _ImageIndex:
                         "path": str(pdf_file),
                         "grade_dir": grade_dir.name,
                         "stem": pdf_file.stem,
+                        "page_count": _read_pdf_page_count(str(pdf_file)),
                     }
 
         self._records = records
@@ -300,10 +301,7 @@ async def list_textbooks():
             for img in imgs
             if img.get("description_uk")
         )
-        # Avoid opening every PDF on each list call — derive from the index
-        # when possible. Image explorer only needs a rough page span here;
-        # per-page context still reads the PDF on demand.
-        page_count = max(pages_with_images.keys(), default=0) if pages_with_images else 0
+        page_count = info.get("page_count", 0)
 
         result.append({
             "stem": stem,

--- a/scripts/build/build_playgrounds.py
+++ b/scripts/build/build_playgrounds.py
@@ -4,8 +4,8 @@
 import json
 from pathlib import Path
 
-PLAYGROUNDS_DIR = Path(__file__).parent.parent.parent / "playgrounds"
-DATA_FILE = PLAYGROUNDS_DIR / "data" / "status.json"
+DASHBOARDS_DIR = Path(__file__).parent.parent.parent / "dashboards"
+DATA_FILE = DASHBOARDS_DIR / "data" / "status.json"
 
 
 def build_status_dashboard():
@@ -736,7 +736,7 @@ Click a module cell to see detailed audit results.\\`;
 </body>
 </html>'''
 
-    output_path = PLAYGROUNDS_DIR / "playground-module-status.html"
+    output_path = DASHBOARDS_DIR / "playground-module-status.html"
     with open(output_path, "w") as f:
         f.write(html)
 
@@ -744,10 +744,10 @@ Click a module cell to see detailed audit results.\\`;
 
 
 def main():
-    """Build all playgrounds."""
-    print("Building playgrounds with real data...\n")
+    """Build legacy static dashboard HTML with embedded status data."""
+    print("Building dashboards with real data...\n")
     build_status_dashboard()
-    print("\nDone! Open playgrounds/index.html to see the landing page.")
+    print("\nDone! Open dashboards/index.html to see the launchpad.")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_mdx/generate_playground_data.py
+++ b/scripts/generate_mdx/generate_playground_data.py
@@ -176,8 +176,8 @@ def main():
         "total_pending": total_modules - total_pass - total_fail,
     }
 
-    # Write to playgrounds directory
-    output_path = Path(__file__).parent.parent / "playgrounds" / "data" / "status.json"
+    # Write to dashboards directory
+    output_path = Path(__file__).parent.parent / "dashboards" / "data" / "status.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w") as f:

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -117,9 +117,10 @@ class TestApiEndpoints:
     # All endpoints referenced in dashboard HTML files
     EXPECTED_ENDPOINTS: ClassVar[set[str]] = {
         "/api/artifacts/html",
+        "/api/build/events/active",
+        "/api/build/events/recent",
         "/api/comms/batch-progress",
         "/api/comms/health",
-        "/api/comms/live-activity",
         "/api/comms/messages",
         "/api/comms/send",
         "/api/comms/stats",

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -51,7 +51,8 @@ DASHBOARD_LOADS = {
     ],
     "comms.html": [
         "/api/comms/messages?limit=1&offset=0",
-        "/api/comms/live-activity?minutes=30",
+        "/api/build/events/active",
+        "/api/build/events/recent?limit=40",
         "/api/comms/batch-progress",
         "/api/comms/zombies",
     ],
@@ -128,6 +129,7 @@ BUDGETS = {
     "/api/analytics/cost/module/a1/hello": 1.5,
     "/api/analytics/cost/phase/write": 1.5,
     "/api/build/events/active": 1.5,
+    "/api/build/events/recent?limit=40": 1.5,
     "/api/build/events/recent?limit=50&offset=0": 1.5,
     "/api/comms/batch-progress": 1.5,
     "/api/comms/channels": 1.5,


### PR DESCRIPTION
## Summary
- Polish the artifacts browser (`/artifacts/`) with loading state, filters, refresh, and clearer metadata cards
- Migrate comms live activity from deprecated `/api/comms/live-activity` to `/api/build/events/active` + `/api/build/events/recent`
- Align audit dashboard with the shared parchment monitor theme
- Fix stale `playgrounds/` → `dashboards/` references in docs and `build_playgrounds.py`
- Speed up `/api/images/textbooks` by avoiding per-request PDF opens (fixes stability test 504)

## Test plan
- [x] `pytest tests/test_monitor_ui_contracts.py tests/test_dashboards.py tests/test_docs_router.py` (154 passed)
- [x] `pytest tests/test_playground_api_stability.py` (111 passed incl. pre-commit hook)
- [ ] Reload `http://localhost:8765/artifacts/` — filters, refresh, card links work
- [ ] Reload `http://localhost:8765/comms.html` — Live Activity tab shows build events
- [ ] Reload `http://localhost:8765/audit-dashboard.html` — parchment theme consistent with other dashboards


Made with [Cursor](https://cursor.com)