### PR TITLE
fix(runtime/cursor): drop literal '-' positional arg; prompt is stdin-only

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -91,10 +91,21 @@ class CursorAdapter:
 
         config = tool_config or {}
 
-        # Base argv common to all paths
+        # Base argv common to all paths.
+        #
+        # NOTE on prompt delivery: cursor-agent's `-p`/`--print` is a boolean
+        # toggle for non-interactive mode; passing a literal "-" after it
+        # is parsed as the POSITIONAL prompt argument (the literal "-"
+        # string), NOT a stdin marker. The previous adapter shipped with
+        # `"-p", "-"` and silently fed cursor the single-character prompt
+        # "-" while our 14KB brief sat unread on stdin — manifest as
+        # `output_chars=0` + spurious rate_limited classification when the
+        # `_RATE_LIMIT_RE` regex matched a token inside cursor's empty-
+        # prompt thinking trace. Pass the prompt via stdin alone (cursor
+        # reads stdin in print-mode when no positional prompt is given).
         cmd: list[str] = [
             cursor_bin,
-            "-p", "-",  # Read prompt from stdin
+            "-p",  # Non-interactive print mode; prompt arrives via stdin.
             "--model", model or self.default_model,
             "--output-format", config.get("output_format", "stream-json"),
             "--trust",  # Headless workspace-trust bypass

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -31,7 +31,10 @@ def test_cursor_adapter_build_invocation_read_only(adapter, tmp_path, monkeypatc
 
     assert "/usr/local/bin/agent" in plan.cmd
     assert "-p" in plan.cmd
-    assert "-" in plan.cmd
+    # Regression: cursor-agent's -p takes NO argument; a literal "-" after
+    # it is parsed as the positional prompt = the string "-", which causes
+    # the real prompt on stdin to be ignored. Prompt delivery is stdin-only.
+    assert "-" not in plan.cmd
     assert "--model" in plan.cmd
     assert "composer-2.5" in plan.cmd
     assert "--mode" in plan.cmd
@@ -95,6 +98,42 @@ def test_cursor_adapter_build_invocation_danger(adapter, tmp_path, monkeypatch):
     assert "enabled" in plan.cmd
     assert "--yolo" not in plan.cmd
     assert "--force" not in plan.cmd
+
+
+def test_cursor_adapter_no_literal_dash_argument_anywhere(adapter, tmp_path, monkeypatch):
+    """Regression for the 2026-05-24 'cursor reads literal "-" as prompt' bug.
+
+    cursor-agent's `-p`/`--print` is a boolean toggle, NOT a flag that takes
+    "-" to mean "stdin". A bare "-" anywhere in argv after `-p` is parsed as
+    the POSITIONAL prompt = the literal string "-". The adapter therefore
+    must NEVER pass "-" as an argv element. Prompt delivery is stdin-only.
+
+    This regression bit the option-c-plan-reference-match-gate-2026-05-24
+    dispatch on the day PR #2254 merged: 14KB brief sat unread on stdin
+    while cursor processed "-" as a single-char prompt and exited with
+    output_chars=0, classified as rate_limited via a false-positive regex
+    match in `_RATE_LIMIT_RE` against cursor's empty-prompt thinking trace.
+    """
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/local/bin/agent" if x == "agent" else None)
+
+    for mode in ("read-only", "workspace-write", "danger"):
+        plan = adapter.build_invocation(
+            prompt="real prompt content",
+            mode=mode,
+            cwd=tmp_path,
+            model=None,
+            task_id="t",
+            session_id=None,
+            tool_config={},
+        )
+        assert "-" not in plan.cmd, (
+            f"mode={mode}: literal '-' found in argv {plan.cmd}; "
+            "cursor-agent parses this as positional prompt = '-' string, "
+            "ignoring the real prompt on stdin"
+        )
+        assert plan.stdin_payload == "real prompt content", (
+            f"mode={mode}: stdin_payload not set to the real prompt"
+        )
 
 
 def test_cursor_adapter_parse_response_success(adapter):


### PR DESCRIPTION
## Summary

- `CursorAdapter` shipped in PR #2254 passed `cmd = [bin, "-p", "-", ...]`. cursor-agent's `-p` is a boolean toggle for non-interactive mode — a literal `-` after it is parsed as the POSITIONAL prompt = the single-character string \"-\", NOT a stdin marker. The real 14KB prompts we delivered via `stdin_payload` were silently dropped while cursor processed `-` as the prompt.
- Observed in the `option-c-plan-reference-match-gate-2026-05-24` dispatch: returncode=0, prompt_chars=14016, response_chars=0, outcome=rate_limited (false positive — `_RATE_LIMIT_RE` matched a token in cursor's empty-prompt thinking trace).
- The existing test `test_cursor_adapter_build_invocation_read_only` asserted `assert \"-\" in plan.cmd` — enshrining the bug as a feature. That's why PR #2254 CI was green.

## Fix

1. Drop `\"-\"` from argv in `CursorAdapter.build_invocation`. cursor-agent reads stdin when given `-p` with no positional prompt — empirically verified with `echo \"say hello\" | cursor-agent -p --model composer-2.5 --output-format stream-json --trust --workspace /tmp`.
2. Flip the broken assertion: `assert \"-\" not in plan.cmd`.
3. Add a regression test `test_cursor_adapter_no_literal_dash_argument_anywhere` covering all three modes (read-only/workspace-write/danger).

## Test plan

- [x] \`.venv/bin/pytest tests/agent_runtime/adapters/test_cursor_adapter.py -v\` — 7 passed
- [x] \`.venv/bin/pytest tests/test_cursor_integration.py tests/agent_runtime/\` — 65 passed
- [x] \`.venv/bin/ruff check\` on changed files — clean
- [x] Empirical: piped-stdin cursor-agent invocation returns proper assistant response
- [ ] Post-merge: re-fire a real cursor dispatch (e.g. Option C) to confirm end-to-end prompt delivery

## Unblocks

- Every \`delegate.py --agent cursor\` invocation (Phase 2 wiring — PR #2254).
- V7 \`--writer cursor-tools\` builds (Phase 3 wiring — PR #2255 — uses the same adapter via \`_runtime_tool_config\`).
- \`ab ask-cursor\` Q&A bridge (Phase 1 — PR #2252) is unaffected; that path uses a different invocation surface.