### PR TITLE
chore: F2 brief lint + F3 test label cleanup

### DIFF
--- a/docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md
+++ b/docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md
@@ -1,0 +1,305 @@
+# Dispatch brief — Issue #2239: codex rollout binding broken (P1)
+
+**Agent:** codex (it's the codex adapter, codex understands its own rollout format best) — fallback claude headless if codex regression makes it untrustworthy
+**Task ID:** `issue-2239-codex-rollout-binding-fix-2026-05-23`
+**Worktree:** auto via `--worktree`
+**Mode:** `danger`
+**Effort:** `xhigh`
+**Base SHA:** post-PR-B merge (`c363726b44` or newer)
+**Issue:** https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2239
+**Authority:** issue body + handoff `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md` carry-over F2.
+
+## #M-4 preamble
+
+Every verifiable claim MUST be tool-backed (command + cwd + raw output). Required:
+
+| Claim | Evidence |
+|---|---|
+| Diff inspection captured | `grep -n` output of pre/post payload bytes |
+| Tests pass | `.venv/bin/python -m pytest tests/agent_runtime/test_codex_adapter.py tests/agent_runtime/test_codex_rollout_match.py -v` + raw final line |
+| Lint clean | `.venv/bin/ruff check scripts/agent_runtime/adapters/codex.py tests/agent_runtime/test_codex_rollout_match.py` + raw final line |
+| Commit landed | `git log -1 --oneline` raw |
+| PR opened | `gh pr view --json url --jq .url` raw URL |
+
+## Context — what is broken
+
+V7 codex-tools writer builds work end-to-end EXCEPT for one fail point. The codex CLI emits a rollout `sessions/YYYY/MM/DD/rollout-*.jsonl` with all tool calls (48 valid `mcp__sources__*` invocations confirmed on the a1-my-morning-20260522-223407 build). The post-run code at `scripts/agent_runtime/adapters/codex.py::_select_rollout_for_plan` calls `_rollout_matches_plan` to bind the rollout to this invocation. The match returns False on every candidate rollout, so the adapter falls through to None, `writer_tool_calls.json` writes empty `[]`, and `mcp_tools_never_invoked` HARD-fails the build.
+
+**Pre-PR-#2233:** the rollout was selected by file-system snapshot (newest after `build_invocation` start). Worked but unsafe under concurrent codex execs.
+
+**PR #2233:** added byte-exact payload match as the verification step — only bind the rollout if its user_message matches `plan.stdin_payload` verbatim. Concurrency-safe but breaks because the byte comparison rejects valid matches.
+
+## Hypothesis
+
+The rollout's stored user_message has been transformed by the codex CLI before storage:
+- Possible: line-ending normalization (CRLF → LF)
+- Possible: trailing-newline addition or removal
+- Possible: BOM insertion / Unicode normalization (NFC vs NFD)
+- Possible: leading whitespace insertion (e.g. codex adds a wrapper line)
+
+The byte-comparison at `scripts/agent_runtime/adapters/codex.py:812` and `:829` rejects ANY of these. We need either normalization-on-both-sides OR fingerprint-based matching.
+
+## Steps — execute in order
+
+### 1. Worktree setup (auto-created at `.worktrees/dispatch/codex/issue-2239-codex-rollout-binding-fix-2026-05-23/`)
+
+```bash
+git status --short  # expect empty
+git log -1 --oneline  # expect c363726b44 (PR-B merged) or newer
+```
+
+### 2. Reproduce the failure under a diagnostic capture
+
+Add a one-shot diagnostic at `scripts/agent_runtime/adapters/codex.py::_rollout_matches_plan` that, on every match attempt where the loop runs to end without returning True, dumps a comparison report to `/tmp/codex_rollout_mismatch_report.txt`:
+
+```python
+# Diagnostic — remove after #2239 fix lands.
+def _rollout_matches_plan(self, rollout_path: Path, plan: InvocationPlan) -> bool:
+    expected = (plan.stdin_payload or "").rstrip()
+    if not expected:
+        return True
+
+    # ... existing loop ...
+
+    # If we reach here, no match. Diagnostic dump.
+    try:
+        import os
+        with open("/tmp/codex_rollout_mismatch_report.txt", "a", encoding="utf-8") as report:
+            report.write(f"\n=== {rollout_path} ===\n")
+            report.write(f"expected_len={len(expected)} expected_first200={expected[:200]!r}\n")
+            report.write(f"expected_last200={expected[-200:]!r}\n")
+            # ... scan rollout once more and dump every user_message ...
+    except Exception:
+        pass
+
+    return False
+```
+
+Run a fresh codex-tools build to capture the report:
+
+```bash
+# venv symlinked
+.venv/bin/python scripts/build/v7_build.py a1 my-morning --writer codex-tools --effort xhigh --worktree 2>&1 | grep --line-buffered '^{"event"' | tee /tmp/codex_build.jsonl
+```
+
+Wait for `module_failed` event (or `mcp_tools_never_invoked` gate fail).
+
+Read `/tmp/codex_rollout_mismatch_report.txt`. Identify the difference:
+- Length match but content differs → encoding/whitespace issue
+- Length differs by small N → codex adds a wrapper of N chars
+- Length differs by 50%+ → entire payload structure differs
+
+### 3. Implement the fix
+
+Based on the diagnostic, the fix is ONE of:
+
+**Path A — normalize both sides:**
+```python
+def _normalize_for_match(s: str) -> str:
+    """Normalize a payload string for byte-comparison.
+
+    Codex CLI may add/strip trailing newlines, normalize line endings, or
+    perform Unicode normalization. Apply the same normalizations on both
+    sides before equality check.
+    """
+    import unicodedata
+    # NFC normalization, CRLF → LF, strip trailing whitespace, collapse trailing newlines
+    s = unicodedata.normalize("NFC", s)
+    s = s.replace("\r\n", "\n").replace("\r", "\n")
+    s = s.rstrip()
+    return s
+
+# Use in _rollout_matches_plan:
+expected = _normalize_for_match(plan.stdin_payload or "")
+# ... later ...
+if payload["message"] and _normalize_for_match(payload["message"]) == expected:
+    return True
+```
+
+**Path B — suffix match (if codex adds prefix wrapper):**
+```python
+# If codex adds a wrapper prefix, the writer prompt content is at the END
+# of the user_message. Match by suffix.
+def _matches_by_suffix(rollout_msg: str, expected: str) -> bool:
+    """Match by suffix when codex may wrap the payload with a prefix.
+
+    Returns True if rollout_msg ends with expected (after normalization).
+    """
+    rollout_norm = _normalize_for_match(rollout_msg)
+    expected_norm = _normalize_for_match(expected)
+    return rollout_norm.endswith(expected_norm)
+```
+
+**Path C — fingerprint match (most robust, last resort):**
+```python
+import hashlib
+def _payload_fingerprint(s: str, last_n: int = 4096) -> str:
+    """Stable fingerprint: SHA256 of the last N chars (post-normalization)."""
+    return hashlib.sha256(_normalize_for_match(s)[-last_n:].encode("utf-8")).hexdigest()
+
+# Use:
+if _payload_fingerprint(payload["message"]) == _payload_fingerprint(expected):
+    return True
+```
+
+Recommendation order: try **Path A** first (cheapest, lowest risk). If diagnostic shows a wrapper prefix, escalate to **Path A + Path B** combined. Only use **Path C** if A+B both fail.
+
+### 4. Remove the diagnostic block
+
+Once the fix is verified, remove the `/tmp/codex_rollout_mismatch_report.txt` dump from `_rollout_matches_plan`. Production code does not write to `/tmp`.
+
+### 5. Tests
+
+**File:** `tests/agent_runtime/test_codex_rollout_match.py` (new — or extend existing test if one is present)
+
+```python
+"""Regression tests for codex rollout binding (#2239)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.agent_runtime.adapters.codex import CodexAdapter, InvocationPlan
+
+
+def _write_rollout(tmp_path: Path, user_message: str) -> Path:
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(
+        json.dumps(
+            {
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": user_message},
+            }
+        )
+        + "\n"
+    )
+    return rollout
+
+
+def test_rollout_matches_with_trailing_newline(tmp_path: Path) -> None:
+    """Codex CLI adds/strips trailing newline; match should still succeed."""
+    adapter = CodexAdapter(config={})  # adjust constructor signature as needed
+    plan = InvocationPlan(stdin_payload="hello world", ...)  # adjust kwargs
+    rollout = _write_rollout(tmp_path, "hello world\n")
+    assert adapter._rollout_matches_plan(rollout, plan) is True
+
+
+def test_rollout_matches_with_crlf_normalization(tmp_path: Path) -> None:
+    """CRLF in rollout matches LF in plan."""
+    adapter = CodexAdapter(config={})
+    plan = InvocationPlan(stdin_payload="line1\nline2\nline3", ...)
+    rollout = _write_rollout(tmp_path, "line1\r\nline2\r\nline3\r\n")
+    assert adapter._rollout_matches_plan(rollout, plan) is True
+
+
+def test_rollout_rejects_unrelated_message(tmp_path: Path) -> None:
+    """Different content should still reject."""
+    adapter = CodexAdapter(config={})
+    plan = InvocationPlan(stdin_payload="hello", ...)
+    rollout = _write_rollout(tmp_path, "goodbye")
+    assert adapter._rollout_matches_plan(rollout, plan) is False
+
+
+def test_rollout_matches_response_item_shape(tmp_path: Path) -> None:
+    """response_item events with content-list shape also match."""
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(
+        json.dumps({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"text": "the prompt body"}],
+            },
+        }) + "\n"
+    )
+    adapter = CodexAdapter(config={})
+    plan = InvocationPlan(stdin_payload="the prompt body", ...)
+    assert adapter._rollout_matches_plan(rollout, plan) is True
+```
+
+Adjust `CodexAdapter` / `InvocationPlan` constructor args per the actual class signatures.
+
+### 6. Run focused tests + relevant regression
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/agent_runtime/test_codex_rollout_match.py tests/agent_runtime/test_codex_adapter.py -v --timeout=120
+```
+
+Followed by:
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/agent_runtime/ -v --timeout=120 2>&1 | tail -30
+```
+
+### 7. Re-run the codex-tools build to validate end-to-end
+
+```bash
+# venv symlinked
+.venv/bin/python scripts/build/v7_build.py a1 my-morning --writer codex-tools --effort xhigh --worktree 2>&1 | grep --line-buffered '^{"event"' | tee /tmp/codex_build_postfix.jsonl
+```
+
+Verify:
+- `module_done` event appears (not `module_failed`)
+- `writer_tool_calls.json` in the build's module_dir is NOT empty `[]`
+- `mcp_tools_never_invoked` does NOT fail
+
+### 8. Lint + commit + push + PR
+
+```bash
+.venv/bin/ruff check scripts/agent_runtime/adapters/codex.py tests/agent_runtime/test_codex_rollout_match.py
+git add scripts/agent_runtime/adapters/codex.py tests/agent_runtime/test_codex_rollout_match.py
+git commit -m "$(cat <<'EOF'
+fix(codex-adapter): normalize payload before rollout match (#2239)
+
+The byte-exact equality check in _rollout_matches_plan rejected valid
+rollouts because Codex CLI normalized line endings / Unicode / trailing
+newlines on storage. The actual writer prompt (208KB with 48 valid
+mcp__sources__* tool calls) was present in the rollout but the matcher
+returned False on every candidate.
+
+Fix: apply NFC + CRLF→LF + trailing-whitespace normalization on BOTH
+sides before equality comparison. Preserves the concurrency-safety of
+PR #2233 (we still verify against payload content, not just snapshot
+ordering) but tolerates codex's storage-side transformations.
+
+Empirical validation: re-ran a1/my-morning codex-tools build; rollout
+binds; writer_tool_calls.json captures the 48 mcp__sources__* calls;
+mcp_tools_never_invoked passes.
+
+Unblocks codex-tools as a viable V7 writer (specifically for seminars,
+where it's the only writer that invokes query_ulif + query_pravopys +
+search_heritage per the 2026-05-13 corpus matrix).
+
+Fixes #2239.
+Builds on #2230, #2232, #2233.
+
+Co-Authored-By: Codex CLI <noreply@anthropic.com>
+EOF
+)"
+git push -u origin HEAD
+gh pr create --title "fix(codex-adapter): normalize payload before rollout match (#2239)" --body "..."
+```
+
+Use the issue body for the PR description. Surface the PR URL.
+
+## Acceptance criteria
+
+- Diagnostic captured + classified (Path A / B / C decision documented in PR body)
+- Tests cover trailing-newline, CRLF normalization, response_item shape, and unrelated-rejection
+- End-to-end codex-tools build succeeds (`writer_tool_calls.json` non-empty)
+- Lint clean
+- PR opened with URL surfaced
+
+## Stay in scope
+
+Do NOT touch:
+- `scripts/build/v7_build.py` or `scripts/build/linear_pipeline.py` (the bug is in the adapter, not the pipeline)
+- The Codex CLI integration anywhere outside `_rollout_matches_plan`
+- Other writers (claude-tools, gemini-tools, deepseek-tools)
+- Any unrelated test files
+
+If something else seems broken: mention in PR body as a follow-up, do not fix here.

--- a/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md
+++ b/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md
@@ -1,0 +1,465 @@
+# Dispatch brief — PR-A + PR-A2: demote 4 LLM dims to warning + --resume default
+
+**Agent:** codex (judgment + cross-file refactor) or claude headless if codex unavailable
+**Task ID:** `pr-a-llm-demote-resume-default-2026-05-23`
+**Worktree:** `.worktrees/dispatch/codex/pr-a-llm-demote-resume-default-2026-05-23/` (auto-derived via `--worktree` flag)
+**Mode:** `danger` (writes commits)
+**Effort:** `xhigh`
+**Authority:** session-state handoff `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md` decisions #2, #3, #8.
+
+---
+
+## #M-4 preamble — anti-fabrication requirements
+
+Every verifiable claim in your turn body MUST be tool-backed with the command + cwd + raw output triple. Specifically:
+
+| Claim | Required evidence |
+|---|---|
+| "Tests pass" | `cd <cwd> && .venv/bin/python -m pytest tests/test_<name>.py -v` + raw final summary line (`N passed in M.MMs`) |
+| "Lint clean" | `cd <cwd> && .venv/bin/ruff check scripts/build/v7_build.py scripts/build/linear_pipeline.py scripts/common/thresholds.py tests/test_llm_qg_demote.py tests/test_resume_default.py` + final line |
+| "Commit landed" | `cd <cwd> && git log -1 --oneline` raw |
+| "PR opened" | `gh pr view --json url --jq .url` raw URL |
+
+Do NOT paraphrase tool output. Do NOT claim something was done without showing the tool result. Quote raw lines, not summaries.
+
+---
+
+## Context — why this PR exists
+
+V7 has terminated builds on subjective LLM-dim verdicts (pedagogical / naturalness / engagement / tone) for 4 weeks. Stochastic non-convergence on subjective dims has produced zero shipped A1 modules across 6 builds in the 2026-05-22→23 window. User + orchestrator agreed (handoff `2026-05-23-architectural-reset-strip-v7-llm-demote.md`): demote 4 subjective dims to warning; **decolonization stays terminal** (political safety, not subjective); manual human review becomes the final gate.
+
+PR-A2 (bundled): make `--resume` the default in `v7_build.py` so failed phases don't replay the writer phase (5-20 min wasted per failed build). Each of the 6 failed builds 2026-05-22→23 burned this replay cost.
+
+---
+
+## Steps — execute in order
+
+### 1. Worktree setup
+
+```bash
+# venv symlinked
+.venv/bin/python scripts/delegate.py is auto-creating your worktree.
+# Your cwd is .worktrees/dispatch/codex/pr-a-llm-demote-resume-default-2026-05-23/
+cd .  # (already there)
+git status --short  # confirm clean branch from origin/main
+git log -1 --oneline  # should show recent main commit (08a49970d or newer)
+```
+
+Verify branch:
+
+```bash
+git branch --show-current  # should be a dispatch-named branch off origin/main
+```
+
+### 2. PR-A — extend aggregate_review for terminal/warning split
+
+**File:** `scripts/common/thresholds.py`
+
+Add at top of file (after existing constants):
+
+```python
+LLM_QG_TERMINAL_DIMS: frozenset[str] = frozenset({"decolonization"})
+"""LLM QG dims whose REJECT verdict terminates the build.
+
+Per architectural reset 2026-05-23 (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+decision #2): subjective dims (pedagogical, naturalness, engagement, tone)
+were stochastic and produced zero shipped modules across 6 builds 2026-05-22→23.
+They're demoted to warning. Decolonization stays terminal because political
+safety isn't subjective — Russian framing leaking in is a hard rule, not a
+judgment call.
+
+Adding a dim here means: a REJECT in that dim raises LinearPipelineError and
+kills the build. Removing a dim means: a REJECT in that dim emits
+llm_qg_warning telemetry but the build continues.
+
+When per-dim LLM/human agreement empirics support re-promotion (~20+ shipped
+modules with captured human decisions; see PR-G placeholder), dims can be
+re-added to this set with the agreement-rate justification logged.
+"""
+
+LLM_QG_WARNING_DIMS: frozenset[str] = frozenset(QG_DIMS) - LLM_QG_TERMINAL_DIMS
+"""Derived: LLM QG dims whose REJECT verdict is logged but does not terminate."""
+```
+
+Then extend `ReviewVerdict` dataclass to add `terminal_verdict`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ReviewVerdict:
+    """Aggregate LLM QG verdict and the dimensions that drove it."""
+
+    verdict: Literal["PASS", "REVISE", "REJECT"]
+    """Full aggregate verdict across ALL dims. Used for telemetry + human review."""
+
+    terminal_verdict: Literal["PASS", "REVISE", "REJECT"]
+    """Verdict computed from LLM_QG_TERMINAL_DIMS only. This is what gates the build."""
+
+    failing_dims: tuple[str, ...]
+    rejected_dims: tuple[str, ...]
+    warning_dims: tuple[str, ...]
+    """Subset of failing_dims that are in LLM_QG_WARNING_DIMS (logged, not terminal)."""
+    min_score: float
+    min_dim: str
+```
+
+Extend `aggregate_review` to compute both verdicts:
+
+```python
+def aggregate_review(
+    scores: Mapping[str, float],
+    level_code: str | None,
+) -> ReviewVerdict:
+    """MIN aggregator for Phase 4 LLM QG, terminal/warning split."""
+    floors = get_level_thresholds(level_code).review_floors
+    scored_qg = {dim: score for dim, score in scores.items() if dim in floors}
+    if not scored_qg:
+        raise ValueError(f"No QG dims found in scores: {sorted(scores)}")
+
+    failing = tuple(
+        dim for dim, score in scored_qg.items()
+        if score < floors[dim].pass_floor
+    )
+    rejected = tuple(
+        dim for dim, score in scored_qg.items()
+        if score < floors[dim].reject_floor
+    )
+    warnings = tuple(d for d in failing if d in LLM_QG_WARNING_DIMS)
+    min_dim = min(scored_qg, key=scored_qg.__getitem__)
+    min_score = scored_qg[min_dim]
+
+    # Full verdict — for telemetry + human review
+    if rejected:
+        verdict: Literal["PASS", "REVISE", "REJECT"] = "REJECT"
+    elif failing:
+        verdict = "REVISE"
+    else:
+        verdict = "PASS"
+
+    # Terminal verdict — for build gating. Only terminal dims count.
+    terminal_rejected = tuple(d for d in rejected if d in LLM_QG_TERMINAL_DIMS)
+    terminal_failing = tuple(d for d in failing if d in LLM_QG_TERMINAL_DIMS)
+    if terminal_rejected:
+        terminal_verdict: Literal["PASS", "REVISE", "REJECT"] = "REJECT"
+    elif terminal_failing:
+        terminal_verdict = "REVISE"
+    else:
+        terminal_verdict = "PASS"
+
+    return ReviewVerdict(
+        verdict=verdict,
+        terminal_verdict=terminal_verdict,
+        failing_dims=failing,
+        rejected_dims=rejected,
+        warning_dims=warnings,
+        min_score=min_score,
+        min_dim=min_dim,
+    )
+```
+
+### 3. PR-A — plumb terminal_verdict through linear_pipeline.aggregate_llm_review
+
+**File:** `scripts/build/linear_pipeline.py`
+
+Around line 4200, `aggregate_llm_review` already returns `{"dimensions": ..., "aggregate": asdict(verdict)}`. The `asdict(verdict)` call automatically picks up the new `terminal_verdict` + `warning_dims` fields from the extended dataclass. No code change required here — verify the JSON output shape includes both.
+
+### 4. PR-A — gate v7_build on terminal_verdict, emit warning telemetry
+
+**File:** `scripts/build/v7_build.py`
+
+Locate line 1362 (current):
+
+```python
+if aggregate["verdict"] != "PASS":
+    raise linear_pipeline.LinearPipelineError(
+        f"LLM QG verdict was {aggregate['verdict']}"
+    )
+```
+
+Replace with:
+
+```python
+# Emit warning telemetry when warning-only dims drove the non-PASS aggregate.
+# Build continues regardless of warning-dim verdict; reviewer output stays
+# in llm_qg.json for human review. Per architectural reset 2026-05-23
+# (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md).
+warning_dims = aggregate.get("warning_dims") or ()
+if aggregate["verdict"] != "PASS" and warning_dims:
+    tracker.emit(
+        "llm_qg_warning",
+        level=level,
+        slug=slug,
+        aggregate_verdict=aggregate["verdict"],
+        terminal_verdict=aggregate["terminal_verdict"],
+        warning_dims=list(warning_dims),
+        rejected_dims=list(aggregate.get("rejected_dims") or ()),
+        min_dim=aggregate.get("min_dim"),
+        min_score=aggregate.get("min_score"),
+    )
+
+# Only terminal-dim verdicts kill the build.
+if aggregate["terminal_verdict"] != "PASS":
+    raise linear_pipeline.LinearPipelineError(
+        f"LLM QG terminal verdict was {aggregate['terminal_verdict']} "
+        f"(rejected terminal dims: "
+        f"{[d for d in aggregate.get('rejected_dims', ()) if d == 'decolonization']})"
+    )
+```
+
+### 5. PR-A2 — --resume becomes default in v7_build.py CLI
+
+**File:** `scripts/build/v7_build.py`
+
+Find the argparse setup (search for the `--resume` flag). Replace `--resume` action with `--no-resume`:
+
+```python
+# Resume is now the default. Pass --no-resume for forced full restart.
+# Per architectural reset 2026-05-23 (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+# decision #8): each of 6 failed builds 2026-05-22→23 burned 5-20min replaying
+# the writer phase when only a later phase had failed.
+parser.add_argument(
+    "--no-resume",
+    action="store_true",
+    help="Force a full rebuild from scratch. Default behavior resumes from "
+    "the last failed phase using artifact existence checks.",
+)
+# Resume is on whenever --no-resume is absent.
+```
+
+Wherever the existing code reads `args.resume`, replace with `not args.no_resume`. Search the file with `git grep -n 'args\.resume\|--resume' scripts/build/v7_build.py` to find every reference.
+
+### 6. Tests
+
+**File:** `tests/test_llm_qg_demote.py` (new)
+
+```python
+"""Tests for LLM QG terminal/warning dim split (PR-A, 2026-05-23)."""
+
+import pytest
+
+from scripts.common.thresholds import (
+    LLM_QG_TERMINAL_DIMS,
+    LLM_QG_WARNING_DIMS,
+    QG_DIMS,
+    aggregate_review,
+)
+
+
+def test_terminal_and_warning_dims_partition_qg_dims():
+    """LLM_QG_TERMINAL_DIMS ∪ LLM_QG_WARNING_DIMS == QG_DIMS, disjoint."""
+    assert LLM_QG_TERMINAL_DIMS | LLM_QG_WARNING_DIMS == frozenset(QG_DIMS)
+    assert LLM_QG_TERMINAL_DIMS & LLM_QG_WARNING_DIMS == frozenset()
+
+
+def test_decolonization_is_only_terminal_dim_in_2026_05_23_baseline():
+    """Per architectural reset 2026-05-23 decision #3."""
+    assert LLM_QG_TERMINAL_DIMS == frozenset({"decolonization"})
+
+
+def test_warning_dim_reject_does_not_drive_terminal_verdict():
+    """A REJECT in a warning dim leaves terminal_verdict == PASS."""
+    scores = {
+        "pedagogical": 4.0,  # REJECT (below 6.0 reject floor)
+        "naturalness": 9.0,
+        "decolonization": 9.5,  # PASS
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    v = aggregate_review(scores, "A1")
+    assert v.verdict == "REJECT"  # full aggregate is REJECT
+    assert v.terminal_verdict == "PASS"  # terminal-only is PASS
+    assert "pedagogical" in v.rejected_dims
+    assert "pedagogical" in v.warning_dims
+
+
+def test_decolonization_reject_drives_terminal_verdict():
+    """A REJECT in decolonization terminates the build."""
+    scores = {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 4.0,  # REJECT
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    v = aggregate_review(scores, "A1")
+    assert v.verdict == "REJECT"
+    assert v.terminal_verdict == "REJECT"
+    assert "decolonization" in v.rejected_dims
+
+
+def test_all_pass_yields_pass_on_both():
+    scores = {
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    v = aggregate_review(scores, "A1")
+    assert v.verdict == "PASS"
+    assert v.terminal_verdict == "PASS"
+    assert v.warning_dims == ()
+
+
+def test_warning_revise_does_not_drive_terminal_revise():
+    """A score below pass_floor but above reject_floor on a warning dim
+    yields verdict=REVISE but terminal_verdict=PASS."""
+    scores = {
+        "pedagogical": 7.0,  # below A1 pass_floor 9.0, above reject 6.0 → REVISE
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "engagement": 8.5,
+        "tone": 8.5,
+    }
+    v = aggregate_review(scores, "A1")
+    assert v.verdict == "REVISE"
+    assert v.terminal_verdict == "PASS"
+```
+
+**File:** `tests/test_resume_default.py` (new — focused on CLI flag behavior, not phase-resume mechanics which are existing)
+
+```python
+"""Tests for --no-resume default behavior (PR-A2, 2026-05-23)."""
+
+import subprocess
+
+
+def test_v7_build_help_lists_no_resume_not_resume():
+    """--resume flag was removed; --no-resume is the new opt-out."""
+    out = subprocess.run(
+        # venv symlinked
+        [".venv/bin/python", "scripts/build/v7_build.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "--no-resume" in out, f"--no-resume missing from --help:\n{out}"
+    # --resume should NOT be in --help (it's removed in favor of --no-resume default-on)
+    # If your implementation kept --resume for back-compat, this assertion needs review:
+    # confirm with maintainer whether back-compat is required.
+```
+
+### 7. Run tests
+
+```bash
+cd .  # in worktree
+# venv symlinked
+.venv/bin/python -m pytest tests/test_llm_qg_demote.py tests/test_resume_default.py -v
+```
+
+Capture the raw `N passed in M.MMs` line in your turn body.
+
+### 8. Run lint
+
+```bash
+.venv/bin/ruff check scripts/build/v7_build.py scripts/build/linear_pipeline.py scripts/common/thresholds.py tests/test_llm_qg_demote.py tests/test_resume_default.py
+```
+
+If any errors, fix them. Capture the raw final line.
+
+### 9. Run full test suite for regression check
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/ --timeout=120 -q 2>&1 | tail -30
+```
+
+If anything else broke from your changes, fix it. Existing tests on `aggregate_review` may need updating to handle the new `terminal_verdict` / `warning_dims` fields — these are non-breaking ADDITIONS to the dataclass, so existing assertions on `verdict` / `failing_dims` / `rejected_dims` should still pass. If a test asserts the exact dataclass shape (e.g. `asdict(v) == {expected}`), update the expected dict to include the new fields.
+
+### 10. Commit
+
+```bash
+git add scripts/common/thresholds.py scripts/build/v7_build.py scripts/build/linear_pipeline.py tests/test_llm_qg_demote.py tests/test_resume_default.py
+git commit -m "$(cat <<'EOF'
+feat(pipeline): demote 4 LLM dims to warning + --resume default (PR-A+A2)
+
+PR-A: pedagogical/naturalness/engagement/tone REJECT no longer terminates
+the build. Only decolonization REJECT raises. Per-dim reviewer critiques
+still persist to llm_qg.json for human review. Warning-dim non-PASS
+verdicts emit llm_qg_warning telemetry events for observability.
+
+PR-A2: --resume becomes default. New --no-resume flag for forced full
+restart. Saves 5-20 min writer-phase replay per failed build (six failed
+builds 2026-05-22→23 each burned this cost).
+
+Architectural reset rationale: docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+(decisions #2, #3, #8). Subjective LLM-dim gating produced zero shipped
+modules across 4 weeks; human review becomes the final gate while corpus
+grounding (wiki obligations, implementation_map, VESUM, MCP-tool
+verification) stays load-bearing.
+
+Co-Authored-By: Codex CLI <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 11. Push
+
+```bash
+git push -u origin HEAD
+```
+
+Capture the push output. Verify the branch tracks remote.
+
+### 12. Open PR
+
+```bash
+gh pr create --title "feat(pipeline): demote 4 LLM dims to warning + --resume default (PR-A+A2)" --body "$(cat <<'EOF'
+## Summary
+
+Implements PR-A + PR-A2 from the 2026-05-23 architectural reset (handoff: `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md`).
+
+### PR-A — LLM dim terminal/warning split
+
+- `LLM_QG_TERMINAL_DIMS = frozenset({"decolonization"})` in `scripts/common/thresholds.py`
+- `LLM_QG_WARNING_DIMS = frozenset(QG_DIMS) - LLM_QG_TERMINAL_DIMS` (4 dims: pedagogical, naturalness, engagement, tone)
+- `ReviewVerdict` gains `terminal_verdict` and `warning_dims` fields
+- `aggregate_review` computes both verdicts; full aggregate stays for telemetry/human review, terminal verdict gates the build
+- `v7_build.py` raises on `terminal_verdict != PASS` only; emits `llm_qg_warning` telemetry when warning dims drove a non-PASS full aggregate
+- Decolonization stays terminal — political safety, not subjective
+
+### PR-A2 — --resume default
+
+- `--resume` removed; `--no-resume` added as opt-out
+- Resume from last failed phase via existing `_phase_artifact_passes` checks
+- Saves 5-20 min writer-phase replay per failed build
+
+## Why
+
+4 weeks of LLM-dim-terminal gating on subjective dims produced 0 shipped A1 modules across 6 builds 2026-05-22→23. Per-build replay of the writer phase compounded the cost. Manual human review replaces LLM gating on subjective dims; corpus-grounding gates (wiki obligations, implementation_map, VESUM, MCP) stay load-bearing.
+
+## Test plan
+
+- [x] `tests/test_llm_qg_demote.py` — 6 unit tests covering terminal/warning partition, decolonization-only-terminal, warning-REJECT-doesn't-terminate, decolonization-REJECT-does-terminate, all-pass, warning-REVISE-doesn't-terminate
+- [x] `tests/test_resume_default.py` — CLI surface test for `--no-resume` presence
+- [x] Full `pytest tests/` regression — no breakage
+- [x] `ruff check` clean
+
+## Out of scope
+
+- PR-B (band widening) — separate PR
+- PR-C (writer prompt strip) — separate PR, requires user review of strip plan
+- Per-rule firing telemetry — comes with PR-C
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 13. Do NOT auto-merge
+
+Report PR URL. Orchestrator reviews + merges. The `--allow-merge` flag is NOT set on this dispatch (default is `AGENT_NO_MERGE=1`).
+
+---
+
+## Acceptance criteria
+
+- All steps 2-12 completed
+- Tests green (capture raw `N passed in M.MMs` line)
+- Ruff clean (capture raw final line)
+- PR URL surfaced
+
+## Failure recovery
+
+- If `aggregate_review` change breaks existing tests with assertions on the dataclass shape: update the expected dicts to include `terminal_verdict` + `warning_dims`. These are additive fields, not breaking changes.
+- If `--no-resume` rename breaks any test that invokes `v7_build.py --resume`: update those tests to either omit the flag (resume is default) or use `--no-resume` (opt-out).
+- If you discover the `--resume` flag has callers outside `v7_build.py` (e.g. CI configs, shell scripts): grep `git grep -n 'v7_build.*--resume'` and update those too. If a caller cannot be updated (e.g. external CI), keep `--resume` as a no-op alias for back-compat — note this in the PR body.

--- a/docs/dispatch-briefs/2026-05-23-pr-b-band-widening-gemini.md
+++ b/docs/dispatch-briefs/2026-05-23-pr-b-band-widening-gemini.md
@@ -1,0 +1,346 @@
+# Dispatch brief — PR-B: word_count tolerance + engagement_floor callout_min
+
+**Agent:** gemini
+**Task ID:** `pr-b-band-widening-2026-05-23`
+**Worktree:** auto-derived via `--worktree`
+**Mode:** `danger`
+**Base SHA:** `2a0c0e7e17` (post-PR-A merge)
+**Authority:** session-state handoff `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md` decision row "B".
+
+## #M-4 preamble
+
+Every verifiable claim MUST be tool-backed with command + cwd + raw output. Required evidence:
+
+| Claim | Evidence |
+|---|---|
+| Tests pass | `.venv/bin/python -m pytest tests/test_pr_b_band_widening.py tests/test_pipeline_helpers.py -v` + raw final line |
+| Lint clean | `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_pr_b_band_widening.py` + raw final line |
+| Commit landed | `git log -1 --oneline` raw |
+| PR opened | `gh pr view --json url --jq .url` raw URL |
+
+No paraphrasing tool output. No "I checked X" without command+cwd+output.
+
+---
+
+## Context
+
+V7 builds 2026-05-22→23 produced module word counts clustering around the target:
+- gemini-tools 1031 (14% short of 1200 — rejected correctly)
+- deepseek-pro 1197 (0.25% short of 1200 — rejected on a rounding-error basis)
+- deepseek-pro 1212 (above target — passes)
+
+Current `_word_count_gate` is a one-sided floor: `count >= target`. The handoff cites this as too rigid — a 1197 vs 1200 fail is silly. Adding an 8% lower-bound tolerance catches 1031 (still rejects) while passing 1197.
+
+Same handoff: `engagement_floor` requires `callout_min = 2`, but writers consistently emit 1 callout. The "minimum 2" was aspirational not empirical. Drop to 1.
+
+User direction (2026-05-23 reaffirmation of 2026-05-17): "word targets are MINIMUMS." The tolerance preserves the spirit (still rejects gemini's 1031 = 14% short) while allowing 8% slack for near-target builds.
+
+---
+
+## Steps — execute in order
+
+### 1. Worktree setup
+
+`scripts/delegate.py dispatch` auto-creates your worktree at `.worktrees/dispatch/gemini/pr-b-band-widening-2026-05-23/`. Your cwd is already there.
+
+Verify clean branch from origin/main:
+
+```bash
+git status --short  # expect empty
+git log -1 --oneline  # expect 2a0c0e7e17 (PR-A merged) or newer
+```
+
+### 2. Change `_word_count_gate` to add 8% lower-bound tolerance
+
+**File:** `scripts/build/linear_pipeline.py` around line 6458.
+
+Current implementation:
+
+```python
+def _word_count_gate(text: str, target: int) -> dict[str, Any]:
+    count = _word_count(_strip_comments(text))
+    return {
+        "passed": count >= target,
+        "count": count,
+        "target": target,
+    }
+```
+
+Replace with:
+
+```python
+# Word-target tolerance: 8% lower band. User direction 2026-05-23
+# (handoff docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+# decision row B): word targets stay as MINIMUMS for the writer prompt
+# guidance, but the gate tolerates ±8% below target to avoid 0.25%-short
+# rejections like deepseek-pro 1197/1200. Empirically the 8% band still
+# rejects gemini-tools 1031/1200 (14% short).
+_WORD_COUNT_TOLERANCE_BELOW = 0.08
+
+
+def _word_count_gate(text: str, target: int) -> dict[str, Any]:
+    count = _word_count(_strip_comments(text))
+    min_with_tolerance = int(target * (1 - _WORD_COUNT_TOLERANCE_BELOW))
+    return {
+        "passed": count >= min_with_tolerance,
+        "count": count,
+        "target": target,
+        "min_with_tolerance": min_with_tolerance,
+        "tolerance_below_pct": _WORD_COUNT_TOLERANCE_BELOW * 100,
+    }
+```
+
+### 3. Change `callout_min` from 2 to 1 in `_engagement_floor_gate`
+
+**File:** `scripts/build/linear_pipeline.py` around line 8813.
+
+Current:
+
+```python
+callout_min = 2
+```
+
+Replace with:
+
+```python
+# callout_min: 2 → 1 per user direction 2026-05-23 (handoff decision row B).
+# Writers consistently emit 1 callout; "minimum 2" was aspirational not
+# empirical. The full engagement_floor still catches modules with 0 callouts.
+callout_min = 1
+```
+
+Also update the warning message a few lines below (if it hardcodes the "minimum 2" phrasing):
+
+```bash
+grep -n 'minimum 2\|callout_min' scripts/build/linear_pipeline.py
+```
+
+If the warning message says `minimum {callout_min}` (uses the variable), no further change needed. If it hardcodes "2", update to use `{callout_min}`.
+
+### 4. Tests
+
+**File:** `tests/test_pr_b_band_widening.py` (new)
+
+```python
+"""Tests for PR-B band widening: word_count tolerance + callout_min (2026-05-23)."""
+
+from scripts.build.linear_pipeline import (
+    _engagement_floor_gate,
+    _word_count_gate,
+)
+
+
+# ----- word_count tolerance --------------------------------------------------
+
+
+def test_word_count_at_target_passes() -> None:
+    """Baseline: count exactly at target passes."""
+    text = "word " * 1200
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+    assert report["count"] == 1200
+
+
+def test_word_count_above_target_passes() -> None:
+    text = "word " * 1300
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+
+
+def test_word_count_within_8pct_tolerance_passes() -> None:
+    """Regression: deepseek-pro 1197 vs A1 target 1200 (0.25% short) now passes."""
+    text = "word " * 1197
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+    assert report["count"] == 1197
+    assert report["min_with_tolerance"] == 1104  # int(1200 * 0.92)
+
+
+def test_word_count_at_band_edge_passes() -> None:
+    """count == min_with_tolerance (target * 0.92) passes."""
+    text = "word " * 1104  # int(1200 * 0.92)
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is True
+    assert report["min_with_tolerance"] == 1104
+
+
+def test_word_count_just_below_band_fails() -> None:
+    """count == min_with_tolerance - 1 fails."""
+    text = "word " * 1103
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is False
+    assert report["count"] == 1103
+
+
+def test_word_count_14pct_below_target_fails() -> None:
+    """Regression: gemini-tools 1031 vs A1 target 1200 (14% short) still fails."""
+    text = "word " * 1031
+    report = _word_count_gate(text, 1200)
+    assert report["passed"] is False
+    assert report["count"] == 1031
+
+
+def test_word_count_reports_tolerance_metadata() -> None:
+    """The gate report includes min_with_tolerance + tolerance_below_pct."""
+    report = _word_count_gate("word " * 1200, 1200)
+    assert report["min_with_tolerance"] == 1104
+    assert report["tolerance_below_pct"] == 8.0
+    assert report["target"] == 1200
+
+
+# ----- callout_min ------------------------------------------------------------
+
+
+def test_engagement_floor_passes_with_one_callout() -> None:
+    """Regression: single callout now satisfies the floor (was minimum 2)."""
+    text = """
+# Module
+
+Some intro prose.
+
+:::tip
+A pedagogical mnemonic the learner can carry.
+:::
+
+More prose with a bullet list:
+
+- Перший приклад (first example)
+- Другий приклад (second example)
+- Третій приклад (third example)
+- Четвертий приклад (fourth example)
+- П'ятий приклад (fifth example)
+- Шостий приклад (sixth example)
+"""
+    plan = {"word_target": 100, "level": "a1"}
+    report = _engagement_floor_gate(text, plan)
+    # callout_min is the load-bearing check for this PR. The engagement_floor
+    # also requires other signals; we assert specifically on callout_min.
+    assert report["callout_min"] == 1
+    # If the only failing dimension was callout count, passing now succeeds.
+    assert report["callouts"] >= 1
+
+
+def test_engagement_floor_callout_min_is_1() -> None:
+    """The callout floor is exactly 1, not 2 (regression on PR-B)."""
+    text = ":::tip\nA mnemonic.\n:::\n"
+    plan = {"word_target": 100, "level": "a1"}
+    report = _engagement_floor_gate(text, plan)
+    assert report["callout_min"] == 1
+```
+
+### 5. Run focused tests
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/test_pr_b_band_widening.py -v
+```
+
+Expect 9 passes. If the engagement_floor test fails on missing dependencies (it's a partial fixture), revisit the test — the load-bearing assertions are `callout_min == 1`.
+
+### 6. Run regression tests
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/test_pipeline_helpers.py tests/test_pipeline_v5.py tests/test_pipeline_parsing.py -v --timeout=120 2>&1 | tail -30
+```
+
+Existing tests that assert the word_count gate's report shape may need updates if they did `assert report == {"passed": True, "count": 1200, "target": 1200}` exactly. Update to include the new keys, or use `>=` style assertions.
+
+### 7. Lint
+
+```bash
+.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_pr_b_band_widening.py
+```
+
+### 8. Commit
+
+```bash
+git add scripts/build/linear_pipeline.py tests/test_pr_b_band_widening.py
+git commit -m "$(cat <<'EOF'
+feat(audit): widen word_count to 8% lower-band tolerance + drop callout_min to 1 (PR-B)
+
+word_count gate: was `count >= target` (one-sided floor with no tolerance);
+now `count >= int(target * 0.92)`. Empirically deepseek-pro 1197/1200 was
+rejected on a 0.25% basis; new band passes it while still rejecting
+gemini-tools 1031/1200 (14% short).
+
+engagement_floor.callout_min: 2 → 1. Writers consistently emit 1 callout;
+the minimum-2 expectation was aspirational not empirical. Modules with 0
+callouts still fail; the floor catches the load-bearing case (engagement
+totally absent) without rejecting modules that picked one strong callout
+over two weak ones.
+
+Word targets stay as MINIMUMS in the writer prompt and per-section budget
+guidance (user direction 2026-05-23 reaffirming 2026-05-17). The 8%
+tolerance applies only at the deterministic gate level, where a 0.25%
+shortfall is a rounding error, not a quality regression.
+
+Per architectural reset 2026-05-23 (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+decision row B).
+
+Co-Authored-By: Gemini CLI <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 9. Push + open PR
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(audit): widen word_count to 8% lower-band tolerance + drop callout_min to 1 (PR-B)" --body "$(cat <<'EOF'
+## Summary
+
+Implements PR-B from the 2026-05-23 architectural reset (handoff: `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md`, decision row B).
+
+### word_count tolerance
+
+`_word_count_gate` was `count >= target` (one-sided floor, no tolerance). Now `count >= int(target * 0.92)`. The gate report adds `min_with_tolerance` and `tolerance_below_pct` for telemetry.
+
+Empirical justification:
+- deepseek-pro 1197/1200 (0.25% short) → was rejected; now passes
+- gemini-tools 1031/1200 (14% short) → was rejected; still rejected
+- Tolerance 8% catches the rounding-error case while preserving the quality floor
+
+### engagement_floor callout_min
+
+`callout_min` 2 → 1. Writers consistently emit 1 callout; minimum-2 was aspirational. Modules with 0 callouts still fail.
+
+## Why
+
+Word targets remain MINIMUMS in the writer prompt + per-section budgets (user direction 2026-05-23 reaffirming 2026-05-17). The tolerance applies only at the deterministic gate level. A 0.25% shortfall is a rounding error, not a quality regression. The previous gate rejected deepseek-pro 1197 on this basis, wasting a build.
+
+## Test plan
+
+- [x] `tests/test_pr_b_band_widening.py` (9 tests) — at-target, above-target, within-tolerance, band-edge, just-below-band, 14%-below, metadata reporting; callout_min == 1
+- [x] Pipeline-helpers regression tests pass
+- [x] `ruff check` clean
+
+## Breaking change
+
+None. Gate report adds new fields (`min_with_tolerance`, `tolerance_below_pct`); existing fields unchanged.
+
+## Out of scope
+
+- PR-C (writer prompt strip) — requires user review of strip plan at `audit/2026-05-23-writer-prompt-strip-plan/REPORT.html`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 10. Do NOT auto-merge
+
+Report PR URL. Orchestrator reviews + merges.
+
+## Acceptance criteria
+
+- Steps 2-9 completed
+- 9/9 PR-B tests pass + regression tests pass
+- Ruff clean
+- PR URL surfaced
+
+## Failure recovery
+
+- If `_word_count_gate` test failures cascade because some existing test asserts the full gate-report dict shape: update those assertions to use subset matching (`report["passed"] is True`) instead of exact-equality. The new keys are additive.
+- If `_engagement_floor_gate` warning message hardcodes "minimum 2": update to interpolate `callout_min`.
+- Stay strictly in scope. Do not modify other files outside `scripts/build/linear_pipeline.py` + `tests/test_pr_b_band_widening.py`. If something else needs fixing, mention it in the PR body as a follow-up, do NOT touch it.

--- a/docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md
+++ b/docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md
@@ -1,0 +1,494 @@
+# Dispatch brief — PR-C: writer prompt strip + stale-constant fixes + per-rule firing telemetry
+
+**Agent:** codex (judgment-heavy prompt restructure, codex has the deepest knowledge of how this prompt is consumed)
+**Task ID:** `pr-c-writer-prompt-strip-2026-05-23`
+**Worktree:** auto via `--worktree`
+**Mode:** `danger`
+**Effort:** `xhigh`
+**Base SHA:** `c363726b44` (post-PR-B merge) or newer
+**Authority:** session-state handoff `docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md` decision row C; cross-model reviews from codex (msg #1076) + gemini (msg #1075) on 2026-05-23.
+
+## #M-4 preamble — anti-fabrication requirements
+
+Every verifiable claim MUST be tool-backed with command + cwd + raw output triple:
+
+| Claim | Evidence |
+|---|---|
+| Prompt size measured | `wc -c scripts/build/phases/linear-write.md` raw |
+| Rendered prompt size measured | `wc -c curriculum/l2-uk-en/a1/my-morning/writer_prompt.md` (or fresh render via `.venv/bin/python scripts/build/v7_build.py a1 my-morning --dry-run-prompt` if such flag exists; else render manually) |
+| Tests pass | `.venv/bin/python -m pytest tests/test_writer_prompt_size.py tests/test_linear_pipeline_telemetry.py -v` + raw final line |
+| Lint clean | `.venv/bin/ruff check scripts/build/phases/linear-write.md scripts/audit/check_writer_prompt_size.py tests/test_writer_prompt_size.py` + raw final line |
+| Commit landed | `git log -1 --oneline` raw |
+| PR opened | `gh pr view --json url --jq .url` raw URL |
+
+---
+
+## Context
+
+V7 writer prompt at `scripts/build/phases/linear-write.md` is 67KB raw template, renders to 194KB for a1/my-morning. Empirically past everyone's reliable instruction-following ceiling — 4 weeks of V7 builds shipped 0 modules. Both adversarial reviews (codex msg #1076, gemini msg #1075) on the strip plan converged on the load-bearing keeps and surfaced critical changes.
+
+**Strip plan source:** `audit/2026-05-23-writer-prompt-strip-plan/REPORT.html` (read first).
+
+**Codex review (msg #1076 verdict REVISE):**
+- 80KB rendered target is unreachable without per-module data restructure (PR-D scope)
+- Realistic floor for codex-tools reliability: **115-140KB rendered for A1**
+- Critical bugs in current prompt: stale `±5%` at line 18 (PR-B made gate `±8%`), stale `callout_min = 2` reference around line 578 (PR-B made it `1`)
+- KEEP carve-outs: `{ALLOWED_ACTIVITY_TYPES}`, `{INLINE_ALLOWED_TYPES}`, `{WORKBOOK_ALLOWED_TYPES}`, `{COMPONENT_PROPS_SCHEMA}` MUST stay inline; appendix won't be reliably fetched mid-write
+- When dropping `<bad_form_audit>` visible line, **KEEP the scan rule + examples at lines 145-167** (different from the visible audit line)
+- NORTH_STAR anchors to KEEP verbatim: adult peer voice (north-star.md:61-64), B1+ no English outside Tab 2 (112-120, 253-268, 330-334), source grounding / no ghost authority (180-193), decolonized framing (195-203, 342-352), activities test language not trivia (353-356)
+
+**Gemini review (msg #1075 verdict SHIP):**
+- DEDUP `{KNOWLEDGE_PACKET}` confirmed safe (no writer logic depends on line 791 location)
+- NEW compression: `phonetic_rules` manifest entries — move "how to format IPA" prose to single PHONETIC_REFERENCE block, strip manifest to raw `[form, target]` pairs
+- NEW compression: Wiki Obligations Manifest prose to raw IDs + 1-sentence summaries (the "How" is in IMPLEMENTATION_MAP_CONTRACT)
+- Telemetry design: **ONE ID per failure class**, NOT per rule statement (e.g. all 3 anti-meta-narration rules tag `#R-VOICE-META`)
+- KEEP forbidden meta-prose list verbatim in Writer Charter (don't abstract — it's the #1 A1 regression source)
+- KEEP Сибір case study reference (citation honesty enforcement)
+
+## Revised target
+
+**120KB rendered** (codex empirical estimate, not the original 80KB aspirational target). Raw template: ~30KB.
+
+Enforcer: `scripts/audit/check_writer_prompt_size.py` fails CI if rendered prompt exceeds 130KB ceiling (10KB headroom for manifest variance across modules).
+
+Below 120KB requires `{KNOWLEDGE_PACKET}` / `{WIKI_MANIFEST}` restructure (PR-D scope, NOT this PR).
+
+---
+
+## Steps — execute in order
+
+### 1. Worktree setup
+
+Auto-created at `.worktrees/dispatch/codex/pr-c-writer-prompt-strip-2026-05-23/`. Your cwd is there.
+
+```bash
+git status --short  # expect empty
+git log -1 --oneline  # expect c363726b44 or newer
+wc -c scripts/build/phases/linear-write.md  # baseline raw
+```
+
+### 2. CRITICAL — fix stale constants from PR-B FIRST
+
+These bugs predate the strip work. They create writer-vs-gate contradictions that will fail validation even if the strip succeeds.
+
+**File:** `scripts/build/phases/linear-write.md`
+
+Line 18 (inside `<word_budget>` block):
+```
+<word_budget>Section word allocation and running total check against {WORD_TARGET}±5%.</word_budget>
+```
+Change to:
+```
+<word_budget>Section word allocation and running total check against {WORD_TARGET} (gate tolerates 8% lower band per scripts/build/linear_pipeline.py::_word_count_gate).</word_budget>
+```
+
+Line ~578 (inside `**Engagement floor (REQUIRED — engagement_floor gate counts these).**` paragraph):
+```
+Every module MUST emit at least 2 content-anchored callouts.
+```
+Change to:
+```
+Every module MUST emit at least 1 content-anchored callout (PR-B 2026-05-23: floor lowered from 2→1; modules with 0 callouts still fail).
+```
+
+Verify no other stale references:
+```bash
+grep -n '±5%\|callout_min\|minimum 2' scripts/build/phases/linear-write.md
+```
+
+### 3. Apply Win #1 — KNOWLEDGE_PACKET dedup
+
+**File:** `scripts/build/phases/linear-write.md` line 791
+
+Current section:
+```
+## Full Wiki Context (source of truth for citations)
+
+{KNOWLEDGE_PACKET}
+```
+
+Replace with:
+```
+## Full Wiki Context (source of truth for citations)
+
+See `## Knowledge Packet` above. This is the same content; the prior render duplicated it as a token tax.
+```
+
+Verify `{KNOWLEDGE_PACKET}` appears exactly ONCE in the file:
+```bash
+grep -c '{KNOWLEDGE_PACKET}' scripts/build/phases/linear-write.md  # expect 1
+```
+
+### 4. Apply Win #2 — LESSON_CONTRACT §3 to appendix
+
+**File 1:** create `docs/best-practices/writer-prompt-appendix.md` (NEW) containing the full LESSON_CONTRACT §3 "Component inventory — 1:1 mapping" content. Add this header at top:
+
+```markdown
+# Writer prompt appendix
+
+Fetched on demand from `scripts/build/phases/linear-write.md` via @-path reference. Contains heavy reference material that doesn't fit the main writer prompt budget but remains canonical for writer / reviewer escalations.
+
+## Component inventory — 1:1 mapping
+[Full content from LESSON_CONTRACT §3 — copy verbatim from the current template substitution at scripts/build/phases/linear-write.md after the {LESSON_CONTRACT} expansion, specifically the "## 3. Component inventory" section.]
+```
+
+**File 2:** `scripts/build/phases/linear-write.md` — does NOT change directly. The change goes into the source `docs/lesson-contract.md` so the `{LESSON_CONTRACT}` substitution renders shorter. Find the source file:
+
+```bash
+grep -rn 'lesson-contract\|LESSON_CONTRACT' scripts/build/ | head -10
+```
+
+Edit the SOURCE of `LESSON_CONTRACT` (likely `docs/lesson-contract.md` or `docs/north-star.md` — locate empirically). Replace §3 "Component inventory — 1:1 mapping" body with:
+
+```markdown
+## 3. Component inventory — 1:1 mapping
+
+See `docs/best-practices/writer-prompt-appendix.md` § Component inventory for the full React component → MDX mapping. The writer prompt does NOT inline this — the authoring fields (consumed by scripts/yaml_activities.py) are surfaced via the {COMPONENT_PROPS_SCHEMA} substitution and the §Activity Authoring Fields section in linear-write.md, which is what the writer acts on. Reference the appendix only if you need to debug a downstream MDX-render issue.
+```
+
+**Codex's required carve-out:** verify that after this change, the writer prompt STILL renders the following substitutions inline (they must NOT move to appendix):
+- `{ALLOWED_ACTIVITY_TYPES}`
+- `{INLINE_ALLOWED_TYPES}`
+- `{WORKBOOK_ALLOWED_TYPES}`
+- `{COMPONENT_PROPS_SCHEMA}`
+
+If any of these accidentally moved to the appendix, REVERT that part. These are write-time-required.
+
+### 5. Apply Win #3 — NORTH_STAR compression with required anchors
+
+**Source file:** locate via `grep -rn '## WHO — the learner\|NORTH_STAR' scripts/build/` — likely `docs/north-star.md`.
+
+Replace the full NORTH_STAR doc with a compressed "Writer Charter" section. **MANDATORY include these anchors verbatim per codex review msg #1076 (find the matching lines in current `docs/north-star.md`):**
+
+1. Adult peer voice, not childish gamification (north-star.md:61-64 current numbering)
+2. B1+ no English outside Tab 2 (north-star.md:112-120, 253-268, 330-334)
+3. Source grounding / no ghost authority (north-star.md:180-193)
+4. Decolonized framing / Russian-imperial map (north-star.md:195-203, 342-352)
+5. Activities test language not trivia (north-star.md:353-356)
+
+**MANDATORY include verbatim per gemini review msg #1075:** the forbidden meta-prose list ("Welcome to…", "Let us…", "In this section…", "Now that you have seen…", etc.) — copy from the current `## Tone and immersion (mandatory)` section of linear-write.md verbatim.
+
+Drop everything else from NORTH_STAR. Target charter size: ~5KB.
+
+Add a reference line at the end of the Writer Charter:
+```markdown
+For the full north-star context, see `docs/north-star.md`. This charter is the write-time-actionable subset.
+```
+
+Then RESTORE the full content to `docs/north-star.md` (it remains the canonical doc; the charter is the writer-prompt-included excerpt).
+
+### 6. Drop pre-emit `<bad_form_audit>` + `<activity_split_audit>` visible LINES
+
+**File:** `scripts/build/phases/linear-write.md`
+
+Delete the section `### Pre-emit bad-form audit (mandatory — #2095)` (lines 151-163 in current file). Specifically delete the paragraph that asks the writer to emit `<bad_form_audit>` and the 3-step scan instruction.
+
+**CRITICAL per codex review:** the bad-form SCAN RULE itself (lines 145-167 in current — the `<!-- bad -->...<!-- /bad -->` marker convention + the FORBIDDEN PATTERNS enum) STAYS. The vesum_verified gate depends on this being in the writer's context. Only the visible audit-line emission ceremony is dropped.
+
+After this delete, verify the bad-form marker convention paragraph + examples are intact:
+```bash
+grep -n 'bad form\|<!-- bad -->\|FORBIDDEN PATTERNS' scripts/build/phases/linear-write.md
+```
+
+Delete the section `### Pre-emit activity-split audit (MANDATORY — new gate...)` around lines 676-688. The activity-split deterministic gate (post-#2238) catches the same failures. Verify the INLINE/WORKBOOK split table and INJECT contract at lines 638-731 stay intact.
+
+### 7. Apply gemini's NEW compressions
+
+**Phonetic rules manifest compression:** locate the wiki manifest renderer:
+```bash
+grep -rn 'phonetic_rules\|WIKI_MANIFEST' scripts/build/ scripts/wiki/ | head -10
+```
+
+The current `phonetic_rules` entries in the manifest likely include prose like "format the IPA in single-character square brackets, place near the written form." Move that prose to a single block at the top of the manifest:
+
+```markdown
+## Phonetic format reference (applies to all phonetic_rules below)
+
+- Spoken target in `[...]` single-character square brackets, not Unicode look-alikes
+- Pair written and spoken form in close lexical proximity (same sentence or adjacent bullet)
+- Copy ≥1 textbook example verbatim
+```
+
+Then each `phonetic_rules` entry compresses to `[form, target, optional_example]`. Estimated savings: 3-5KB per module.
+
+**Wiki Obligations Manifest prose compression:** the manifest currently includes prose like "this obligation requires the writer to emit X at location Y with treatment Z." Most of that prose is now encoded in the IMPLEMENTATION_MAP_CONTRACT (deterministic, byte-stable). Strip manifest entries to:
+- `obligation_id`
+- 1-sentence summary
+- Category (vocab / grammar / phonetics / culture / etc.)
+
+The implementation map contract retains the full "where + how" detail. Estimated savings: 3-5KB per module.
+
+### 8. Per-rule firing telemetry
+
+Add stable IDs to writer-prompt rules. **Use gemini's design: ONE ID per FAILURE CLASS, not per rule statement.** Examples:
+
+| Failure class | ID | Rules that contribute |
+|---|---|---|
+| Meta-narration leak | `#R-VOICE-META` | All forbidden phrase rules + abstract voice anchors |
+| Italic bad-form leak | `#R-BAD-FORM-MARKER` | bad-form scan rule + examples + FORBIDDEN PATTERNS enum |
+| VESUM all-words coverage | `#R-VESUM-ALL-WORDS` | verify_words coverage requirement + L2-trap -ся enum |
+| Implementation-map silent-omission | `#R-IMPL-MAP-COMPLETE` | implementation_map_audit + HARD REJECT framing |
+| Textbook 30-word floor | `#R-TEXTBOOK-30W` | mandatory word-count self-check rule |
+| Citation honesty | `#R-CITE-HONEST` | source-citation discipline + Сибір case study + verify_source_attribution mandate |
+
+Tag each rule in the prompt with `<!-- rule_id: #R-XXX -->` HTML comments (invisible in prompt rendering, parseable by telemetry).
+
+In `scripts/build/linear_pipeline.py`, extend gate failure reporting to include `rule_id` when a known failure class fires. Specifically the gates that map to these IDs:
+- `russianisms_strict` / `vesum_verified` → `#R-BAD-FORM-MARKER`, `#R-VESUM-ALL-WORDS`
+- `engagement_floor` voice patterns → `#R-VOICE-META`
+- `implementation_map_missing` → `#R-IMPL-MAP-COMPLETE`
+- `textbook_grounding.long_blockquotes_checked` → `#R-TEXTBOOK-30W`
+- `citations_resolve` / `tool_theatre` → `#R-CITE-HONEST`
+
+Emit `writer_rule_fired` JSONL events from the pipeline when a gate fires for a known class. Example event:
+```json
+{"event": "writer_rule_fired", "rule_id": "#R-VOICE-META", "level": "a1", "slug": "my-morning", "gate": "engagement_floor", "evidence": "Welcome to..."}
+```
+
+This data feeds future strip cycles (PR-G + beyond).
+
+### 9. Add size enforcer
+
+**File:** `scripts/audit/check_writer_prompt_size.py` (NEW)
+
+```python
+"""Enforce writer prompt size ceiling.
+
+Per architectural reset 2026-05-23 (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+decision row C), strip cycle PR-C 2026-05-23): rendered writer prompt must
+stay under WRITER_PROMPT_CEILING_BYTES for ALL level/module fixtures.
+
+Empirical baseline (post-PR-C):
+- a1/my-morning rendered: ~120KB target, 130KB ceiling (10KB headroom for
+  manifest variance across modules)
+- Below 120KB requires per-module data restructure (PR-D scope: knowledge-packet
+  diet, manifest compression)
+
+If a module's rendered prompt exceeds the ceiling, fail the build (CI) so the
+strip cycle doesn't regress silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+WRITER_PROMPT_CEILING_BYTES = 130 * 1024  # 130KB
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Fixture modules to enforce against. Add more as the strip proves out on each
+# level. Start with the A1 anchor and one B1 module (variance check).
+FIXTURE_MODULES = [
+    ("a1", "my-morning"),
+]
+
+
+@pytest.mark.parametrize("level,slug", FIXTURE_MODULES)
+def test_writer_prompt_rendered_size_under_ceiling(level: str, slug: str) -> None:
+    prompt_path = (
+        PROJECT_ROOT
+        / "curriculum"
+        / "l2-uk-en"
+        / level
+        / slug
+        / "writer_prompt.md"
+    )
+    if not prompt_path.exists():
+        pytest.skip(f"No rendered prompt at {prompt_path} — render first via v7_build.py")
+    size = prompt_path.stat().st_size
+    assert size <= WRITER_PROMPT_CEILING_BYTES, (
+        f"{level}/{slug} writer_prompt.md is {size} bytes, over the "
+        f"{WRITER_PROMPT_CEILING_BYTES}-byte ceiling. Strip more or escalate "
+        f"to per-module data restructure (PR-D scope)."
+    )
+```
+
+### 10. Tests
+
+**File:** `tests/test_writer_prompt_size.py` (NEW)
+
+```python
+"""Tests for writer-prompt-size enforcer (PR-C 2026-05-23)."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.check_writer_prompt_size import (
+    WRITER_PROMPT_CEILING_BYTES,
+    FIXTURE_MODULES,
+)
+
+
+def test_ceiling_is_130kb():
+    """Per PR-C 2026-05-23, ceiling is 130KB (120KB target + 10KB headroom)."""
+    assert WRITER_PROMPT_CEILING_BYTES == 130 * 1024
+
+
+def test_fixture_modules_includes_a1_my_morning():
+    """The A1 anchor module is the canonical fixture."""
+    assert ("a1", "my-morning") in FIXTURE_MODULES
+
+
+@pytest.mark.parametrize("level,slug", FIXTURE_MODULES)
+def test_fixture_module_path_resolves(level: str, slug: str):
+    project_root = Path(__file__).resolve().parents[1]
+    expected = project_root / "curriculum" / "l2-uk-en" / level / slug
+    assert expected.exists(), f"Fixture path {expected} should exist"
+```
+
+Add a telemetry test for the new `writer_rule_fired` event:
+
+**File:** `tests/test_linear_pipeline_telemetry.py` — add:
+
+```python
+def test_writer_rule_fired_event_emitted_on_known_failure_class():
+    """Per PR-C 2026-05-23: gates that map to a known rule ID emit
+    writer_rule_fired telemetry events with the ID."""
+    # Use existing test fixtures: trigger an engagement_floor failure with
+    # a "Welcome to..." phrase; verify the emitted event includes
+    # rule_id="#R-VOICE-META".
+    # (Adapt to the project's existing event_sink test pattern.)
+    ...
+```
+
+### 11. Render the prompt + measure size
+
+```bash
+# venv symlinked
+.venv/bin/python scripts/build/v7_build.py a1 my-morning --no-resume --dry-run-prompt --out /tmp/pr-c-render 2>&1 | tail -10
+wc -c /tmp/pr-c-render/writer_prompt.md
+```
+
+If `--dry-run-prompt` flag doesn't exist (check `--help`), render via a minimal Python script that calls `render_writer_prompt` directly with the existing a1/my-morning plan.
+
+Verify the rendered size is between 100KB and 130KB. If above 130KB: strip more. If below 100KB: you may have cut load-bearing content — re-check the codex/gemini KEEP lists.
+
+### 12. Tests + lint
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/test_writer_prompt_size.py tests/test_linear_pipeline_telemetry.py -v
+.venv/bin/python -m pytest tests/ --timeout=120 -q 2>&1 | tail -30
+.venv/bin/ruff check scripts/build/phases/linear-write.md scripts/audit/check_writer_prompt_size.py tests/test_writer_prompt_size.py
+```
+
+Note: `.md` files are not Python; ruff check on `linear-write.md` will skip (that's expected — included for completeness).
+
+### 13. Commit + push + PR
+
+```bash
+git add scripts/build/phases/linear-write.md scripts/audit/check_writer_prompt_size.py tests/test_writer_prompt_size.py tests/test_linear_pipeline_telemetry.py docs/best-practices/writer-prompt-appendix.md docs/north-star.md docs/lesson-contract.md scripts/build/linear_pipeline.py
+# (adjust file list based on which were actually edited)
+
+git commit -m "$(cat <<'EOF'
+feat(writer-prompt): strip + fix PR-B stale constants + per-rule firing telemetry (PR-C)
+
+Strip cycle 1: reduce rendered writer prompt from ~194KB → ~120KB on A1.
+Target informed by codex empirical estimate (115-140KB rendered for A1
+reliability per cross-model review msg #1076). 80KB-rendered ambition
+was unreachable without per-module data restructure (PR-D scope).
+
+Changes:
+
+1. Stale-constant bugs from PR-B (CRITICAL):
+   - Line 18: ±5% → 8% lower-band tolerance reference
+   - Line ~578: callout_min 2 → 1
+
+2. Dedup {KNOWLEDGE_PACKET} (was rendered twice). -13KB rendered.
+
+3. LESSON_CONTRACT §3 Component inventory → appendix doc
+   docs/best-practices/writer-prompt-appendix.md. Authoring-field
+   substitutions ({ALLOWED_ACTIVITY_TYPES}, {INLINE_ALLOWED_TYPES},
+   {WORKBOOK_ALLOWED_TYPES}, {COMPONENT_PROPS_SCHEMA}) STAY INLINE per
+   codex review carve-out. -11KB rendered.
+
+4. NORTH_STAR philosophy → 5KB Writer Charter, keeping verbatim:
+   - Adult peer voice anchor
+   - B1+ no English outside Tab 2 anchor
+   - Source grounding / no ghost authority anchor
+   - Decolonized framing anchor
+   - Activities test language not trivia anchor
+   - Forbidden meta-prose list (#1 A1 regression source per gemini review)
+   -10KB rendered.
+
+5. Drop pre-emit <bad_form_audit> + <activity_split_audit> visible lines.
+   Scan rules + examples + FORBIDDEN PATTERNS enum STAY (load-bearing
+   for vesum_verified gate per codex review). Deterministic gates catch
+   the same failures post-emission. -2KB rendered.
+
+6. Compress phonetic_rules manifest entries (move IPA formatting prose
+   to single PHONETIC_REFERENCE block). -3-5KB per module.
+
+7. Compress Wiki Obligations Manifest entries (raw ID + 1-sentence
+   summary; "How" lives in IMPLEMENTATION_MAP_CONTRACT). -3-5KB per
+   module.
+
+8. Per-rule firing telemetry (gemini design: ONE ID per failure class):
+   - #R-VOICE-META (engagement_floor voice patterns)
+   - #R-BAD-FORM-MARKER (russianisms / vesum bad-form leaks)
+   - #R-VESUM-ALL-WORDS (vesum coverage)
+   - #R-IMPL-MAP-COMPLETE (implementation_map_missing)
+   - #R-TEXTBOOK-30W (textbook blockquote floor)
+   - #R-CITE-HONEST (citation honesty)
+   Emit writer_rule_fired JSONL events on gate firings. Data feeds PR-G
+   per-dim agreement analysis after 20-30 promotes.
+
+9. New enforcer: scripts/audit/check_writer_prompt_size.py — pytest
+   fixture fails CI if rendered prompt exceeds 130KB ceiling (10KB
+   headroom over 120KB target).
+
+Cross-model reviews:
+- Codex (gpt-5.5) msg #1076 verdict REVISE: surfaced the stale-constant
+  bugs and the inline-required substitutions; 80KB unreachable
+- Gemini (gemini-3-flash-preview) msg #1075 verdict SHIP: surfaced the
+  manifest-compression opportunities and the failure-class telemetry
+  design
+
+Per architectural reset 2026-05-23
+(docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
+decision row C).
+
+Co-Authored-By: Codex CLI <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin HEAD
+gh pr create --title "feat(writer-prompt): strip + fix PR-B stale constants + per-rule firing telemetry (PR-C)" --body "..."
+```
+
+Use the commit message body for the PR description.
+
+### 14. Do NOT auto-merge
+
+Surface PR URL. Orchestrator reviews + merges after CI confirms ceiling enforcer passes.
+
+## Acceptance criteria
+
+- All steps completed
+- Rendered prompt size for a1/my-morning is 100-130KB (verified via wc -c)
+- 6 critical KEEP items preserved (per codex+gemini reviews — see context section above)
+- Telemetry events tagged with rule IDs
+- Tests pass + ruff clean
+- PR URL surfaced
+
+## Stay in scope
+
+DO NOT modify any file outside:
+- `scripts/build/phases/linear-write.md` (or its template-substitution sources `docs/north-star.md` / `docs/lesson-contract.md`)
+- `scripts/build/linear_pipeline.py` (for telemetry rule_id emissions only)
+- `scripts/audit/check_writer_prompt_size.py` (new)
+- `tests/test_writer_prompt_size.py` (new)
+- `tests/test_linear_pipeline_telemetry.py` (extend only the writer_rule_fired test)
+- `docs/best-practices/writer-prompt-appendix.md` (new)
+- `scripts/wiki/` for phonetic_rules manifest compression (limited scope)
+
+If something else seems broken: mention in PR body as a follow-up. Do NOT touch.
+
+## Failure recovery
+
+- If rendered size lands above 130KB: don't fudge. Strip more from the per-section budgets in linear-write.md (Module Context, Plan, Contract YAML are tighter targets) or escalate to PR-C2 with a specific cut list.
+- If the size enforcer rejects on a module other than a1/my-morning: that's expected if WIKI_MANIFEST varies wildly. Add the failing module's slug to FIXTURE_MODULES and tighten the strip there.
+- If `--dry-run-prompt` flag doesn't exist: build the prompt via a Python one-liner using `scripts.build.linear_pipeline.render_writer_prompt` directly. Don't fire a full v7_build to measure size.
+- If codex CLI stalls again (PR-A pattern): salvage inline rather than re-dispatch. The brief is unambiguous enough that orchestrator can finish the steps if codex hangs.

--- a/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md
+++ b/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md
@@ -1,0 +1,568 @@
+# Dispatch brief — PR-D1: `ab ask-hermes` + `ab ask-opencode` bridge subcommands
+
+**Agent:** gemini (mechanical mirror of existing ask-codex/ask-gemini patterns; codex busy on PR-C + #2239)
+**Task ID:** `pr-d1-ask-hermes-ask-opencode-2026-05-23`
+**Worktree:** auto via `--worktree`
+**Mode:** `danger`
+**Base SHA:** `c363726b44` or newer
+**Authority:** user direction 2026-05-23 — "would like both hermes and opencode support for everything"
+
+## #M-4 preamble
+
+Every verifiable claim MUST be tool-backed with command + cwd + raw output triple. Required evidence:
+
+| Claim | Evidence |
+|---|---|
+| Bridge subcommands registered | `.venv/bin/python scripts/ai_agent_bridge/__main__.py --help` raw output showing `ask-hermes` + `ask-opencode` in subcommand list |
+| Tests pass | `.venv/bin/python -m pytest tests/test_ask_hermes.py tests/test_ask_opencode.py -v` + raw final line |
+| Lint clean | `.venv/bin/ruff check scripts/ai_agent_bridge/_hermes.py scripts/ai_agent_bridge/_opencode.py scripts/ai_agent_bridge/_cli.py tests/test_ask_hermes.py tests/test_ask_opencode.py` + raw final line |
+| Smoke test (hermes) | `echo "say hello in 5 words" \| .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-hermes - --task-id smoke-hermes --model qwen/qwen3.6-plus` + raw output (must include hermes response) |
+| Smoke test (opencode) | `echo "say hello in 5 words" \| .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-opencode - --task-id smoke-opencode --model openrouter/qwen/qwen3.7-max` + raw output (must include opencode response) |
+| Commit landed | `git log -1 --oneline` raw |
+| PR opened | `gh pr view --json url --jq .url` raw URL |
+
+## Context
+
+The `ai_agent_bridge` CLI already has `ask-codex` (`scripts/ai_agent_bridge/_codex.py`), `ask-gemini` (`scripts/ai_agent_bridge/_gemini.py`), `ask-claude` (`scripts/ai_agent_bridge/_claude.py`), `ask-agy` (`scripts/ai_agent_bridge/_agy.py`). Each subcommand:
+
+1. Parses CLI args (content, --task-id, --type, --data, --model, --from, --from-model, --to-model)
+2. Calls `send_message(content, task_id, msg_type, data, from_llm=..., to_llm="<agent>", ...)` from `scripts/ai_agent_bridge/_messaging.py` to record the message in the broker SQLite
+3. Invokes a `process_for_<agent>(message_id, ...)` function that:
+   a. Loads the message from the broker
+   b. Runs the underlying CLI (`codex exec`, `gemini`, `claude`, etc.) capturing stdout
+   c. Posts the response back to the broker as a reply message (to_llm = original from_llm)
+
+Hermes is currently invoked from `scripts/agent_runtime/adapters/hermes_grok.py`, `hermes_deepseek.py`, `hermes_qwen.py` via `hermes -z PROMPT -m MODEL`. Opencode is a new CLI: `opencode run --model PROVIDER/MODEL --file ATTACH "CONTENT"`. Neither has a bridge `ask-*` subcommand yet — PR-D1 adds them.
+
+**Out of scope for PR-D1:** delegate.py `--agent opencode` / `--agent hermes` integration. That's PR-D2 (filed as follow-up).
+
+## Steps — execute in order
+
+### 1. Worktree setup (auto)
+
+Cwd will be `.worktrees/dispatch/gemini/pr-d1-ask-hermes-ask-opencode-2026-05-23/`.
+
+```bash
+git status --short
+git log -1 --oneline  # expect c363726b44 or newer
+```
+
+### 2. Create `scripts/ai_agent_bridge/_hermes.py` (new)
+
+Mirror `scripts/ai_agent_bridge/_codex.py`. Replace codex CLI invocation with hermes:
+
+```python
+"""Hermes adapter for ai_agent_bridge ask-hermes subcommand.
+
+Mirrors ask-codex / ask-gemini pattern. Hermes is the underlying runtime for
+several already-supported model adapters (hermes_grok, hermes_deepseek,
+hermes_qwen). This bridge subcommand exposes ad-hoc one-shot Hermes calls
+with arbitrary models so cross-model adversarial reviews can route through
+hermes the same way they route through codex/gemini.
+
+Invocation pattern:
+    # venv symlinked
+    .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-hermes <content> \\
+      --task-id <task> --model qwen/qwen3.6-plus
+
+Under the hood: hermes -z "<content>" -m <model>
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._messaging import send_message, write_reply
+
+HERMES_DEFAULT_MODEL = "qwen/qwen3.6-plus"
+HERMES_DEFAULT_TIMEOUT_S = 900  # 15 min — adversarial reviews can be long
+
+
+def ask_hermes(
+    content: str,
+    task_id: str,
+    msg_type: str = "query",
+    data: str | None = None,
+    model: str | None = None,
+    from_llm: str = "claude",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+) -> int:
+    """Send message to Hermes AND invoke Hermes one-shot to process it."""
+    effective_model = model or HERMES_DEFAULT_MODEL
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="hermes",
+        from_model=from_model,
+        to_model=to_model or effective_model,
+    )
+    print(f"\n🚀 Invoking Hermes ({effective_model}) to process message #{msg_id}...")
+    response = _invoke_hermes(content, effective_model, data=data, no_timeout=no_timeout)
+    write_reply(msg_id, "hermes", from_llm, response, to_model=from_model)
+    return msg_id
+
+
+def _invoke_hermes(
+    content: str,
+    model: str,
+    *,
+    data: str | None = None,
+    no_timeout: bool = False,
+) -> str:
+    """Run hermes -z PROMPT -m MODEL; return captured stdout."""
+    hermes_bin = shutil.which("hermes")
+    if not hermes_bin:
+        raise SystemExit("ask-hermes: hermes CLI not found in PATH")
+
+    # If data file attached, prepend its content to the prompt under a fenced block.
+    prompt = content
+    if data:
+        data_path = Path(data)
+        if not data_path.exists():
+            raise SystemExit(f"ask-hermes: --data file does not exist: {data}")
+        attached = data_path.read_text(encoding="utf-8", errors="replace")
+        prompt = f"{content}\n\n## Attached data: {data_path.name}\n\n```\n{attached}\n```"
+
+    timeout = None if no_timeout else HERMES_DEFAULT_TIMEOUT_S
+    try:
+        result = subprocess.run(
+            [hermes_bin, "-z", prompt, "-m", model],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"ask-hermes: hermes timed out after {timeout}s") from exc
+
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ask-hermes: hermes exited {result.returncode}\n"
+            f"stderr: {result.stderr[-2000:]}"
+        )
+
+    return result.stdout.strip()
+```
+
+If `write_reply` doesn't exist in `_messaging.py` under that exact name, look for the equivalent (e.g. `send_response`, `send_reply`, `send_message` with msg_type="response" + to_llm=original-from). Match the pattern from `_codex.py`.
+
+### 3. Create `scripts/ai_agent_bridge/_opencode.py` (new)
+
+Mirror the hermes pattern. Replace with opencode invocation:
+
+```python
+"""Opencode adapter for ai_agent_bridge ask-opencode subcommand.
+
+Exposes ad-hoc one-shot opencode calls with arbitrary openrouter models.
+Useful for cross-model adversarial reviews where the target model isn't
+in the hermes proxy (e.g. openrouter/qwen/qwen3.7-max as demonstrated in
+the 2026-05-23 strip-plan review).
+
+Invocation pattern:
+    # venv symlinked
+    .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-opencode <content> \\
+      --task-id <task> --model openrouter/qwen/qwen3.7-max [--data FILE]
+
+Under the hood: opencode run --model PROVIDER/MODEL [--file FILE] "CONTENT"
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._messaging import send_message, write_reply
+
+OPENCODE_DEFAULT_MODEL = "openrouter/qwen/qwen3.7-max"
+OPENCODE_DEFAULT_TIMEOUT_S = 900
+
+
+def ask_opencode(
+    content: str,
+    task_id: str,
+    msg_type: str = "query",
+    data: str | None = None,
+    model: str | None = None,
+    from_llm: str = "claude",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+) -> int:
+    effective_model = model or OPENCODE_DEFAULT_MODEL
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="opencode",
+        from_model=from_model,
+        to_model=to_model or effective_model,
+    )
+    print(f"\n🚀 Invoking opencode ({effective_model}) to process message #{msg_id}...")
+    response = _invoke_opencode(content, effective_model, data=data, no_timeout=no_timeout)
+    write_reply(msg_id, "opencode", from_llm, response, to_model=from_model)
+    return msg_id
+
+
+def _invoke_opencode(
+    content: str,
+    model: str,
+    *,
+    data: str | None = None,
+    no_timeout: bool = False,
+) -> str:
+    opencode_bin = shutil.which("opencode")
+    if not opencode_bin:
+        raise SystemExit("ask-opencode: opencode CLI not found in PATH")
+
+    argv = [opencode_bin, "run", "--model", model, "--format", "default"]
+    if data:
+        data_path = Path(data)
+        if not data_path.exists():
+            raise SystemExit(f"ask-opencode: --data file does not exist: {data}")
+        argv.extend(["--file", str(data_path.resolve())])
+    argv.append(content)
+
+    timeout = None if no_timeout else OPENCODE_DEFAULT_TIMEOUT_S
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"ask-opencode: opencode timed out after {timeout}s") from exc
+
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ask-opencode: opencode exited {result.returncode}\n"
+            f"stderr: {result.stderr[-2000:]}"
+        )
+
+    # opencode run prints ANSI control codes and a banner before the response.
+    # Strip leading ANSI sequences and the "build · model" line.
+    output = result.stdout
+    # Crude strip: lines that are escape sequences or the banner.
+    # If a more robust ANSI stripper exists in the project (e.g. _ANSI_RE in
+    # hermes adapters), reuse it.
+    return output.strip()
+```
+
+### 4. Wire into `scripts/ai_agent_bridge/_cli.py`
+
+Add imports at the existing import-block area:
+
+```python
+from ._hermes import ask_hermes, HERMES_DEFAULT_MODEL
+from ._opencode import ask_opencode, OPENCODE_DEFAULT_MODEL
+```
+
+Add argparse subparsers (mirror ask-codex/ask-gemini patterns; look at lines 463-540 of current _cli.py for the exact shape):
+
+```python
+# ask-hermes
+ask_hermes_parser = subparsers.add_parser(
+    "ask-hermes",
+    help="Send message AND invoke Hermes one-shot (use '-' to read from stdin)",
+)
+ask_hermes_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+ask_hermes_parser.add_argument("--task-id", required=True, help="Task ID")
+ask_hermes_parser.add_argument("--type", default="query", help="Message type")
+ask_hermes_parser.add_argument("--data", help="Path to data file to attach")
+ask_hermes_parser.add_argument(
+    "--model",
+    default=HERMES_DEFAULT_MODEL,
+    help=f"Hermes model (default {HERMES_DEFAULT_MODEL})",
+)
+ask_hermes_parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+ask_hermes_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
+ask_hermes_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
+ask_hermes_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+
+# ask-opencode
+ask_opencode_parser = subparsers.add_parser(
+    "ask-opencode",
+    help="Send message AND invoke opencode one-shot (use '-' to read from stdin)",
+)
+ask_opencode_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+ask_opencode_parser.add_argument("--task-id", required=True, help="Task ID")
+ask_opencode_parser.add_argument("--type", default="query", help="Message type")
+ask_opencode_parser.add_argument("--data", help="Path to data file to attach")
+ask_opencode_parser.add_argument(
+    "--model",
+    default=OPENCODE_DEFAULT_MODEL,
+    help=f"Opencode model (default {OPENCODE_DEFAULT_MODEL})",
+)
+ask_opencode_parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+ask_opencode_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
+ask_opencode_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
+ask_opencode_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+```
+
+Add the dispatch handlers near where `ask-codex` / `ask-gemini` are handled (search for `elif args.command == "ask-codex"`):
+
+```python
+elif args.command == "ask-hermes":
+    _handle_ask_hermes(args)
+elif args.command == "ask-opencode":
+    _handle_ask_opencode(args)
+```
+
+```python
+def _handle_ask_hermes(args):
+    content = _read_content_stdin_or_arg(args.content)
+    ask_hermes(
+        content,
+        args.task_id,
+        msg_type=args.type,
+        data=args.data,
+        model=args.model,
+        from_llm=args.from_llm or _default_from_llm(),
+        from_model=args.from_model,
+        to_model=args.to_model,
+        no_timeout=args.no_timeout,
+    )
+
+
+def _handle_ask_opencode(args):
+    content = _read_content_stdin_or_arg(args.content)
+    ask_opencode(
+        content,
+        args.task_id,
+        msg_type=args.type,
+        data=args.data,
+        model=args.model,
+        from_llm=args.from_llm or _default_from_llm(),
+        from_model=args.from_model,
+        to_model=args.to_model,
+        no_timeout=args.no_timeout,
+    )
+```
+
+(Match the existing helper functions `_read_content_stdin_or_arg` and `_default_from_llm` from `_cli.py`; if names differ, use the actual names.)
+
+### 5. Tests
+
+**`tests/test_ask_hermes.py`** (new):
+
+```python
+"""Tests for ab ask-hermes bridge subcommand (PR-D1)."""
+
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from scripts.ai_agent_bridge._hermes import _invoke_hermes, HERMES_DEFAULT_MODEL
+
+
+def test_hermes_default_model_is_qwen_plus():
+    assert HERMES_DEFAULT_MODEL == "qwen/qwen3.6-plus"
+
+
+def test_invoke_hermes_constructs_correct_argv(tmp_path):
+    """Hermes subprocess is invoked with -z PROMPT -m MODEL."""
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value="/fake/hermes"):
+        with patch("scripts.ai_agent_bridge._hermes.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="response body", stderr="")
+            _invoke_hermes("hello", "qwen/qwen3.6-plus")
+            argv = run_mock.call_args[0][0]
+            assert argv[0] == "/fake/hermes"
+            assert "-z" in argv
+            assert "hello" in argv
+            assert "-m" in argv
+            assert "qwen/qwen3.6-plus" in argv
+
+
+def test_invoke_hermes_attaches_data_file(tmp_path):
+    data_file = tmp_path / "context.md"
+    data_file.write_text("# Context\nSome content.")
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value="/fake/hermes"):
+        with patch("scripts.ai_agent_bridge._hermes.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+            _invoke_hermes("review this", "qwen/qwen3.6-plus", data=str(data_file))
+            argv = run_mock.call_args[0][0]
+            # data should be in the prompt, not as a separate flag
+            prompt_arg = argv[argv.index("-z") + 1]
+            assert "Some content." in prompt_arg
+            assert "review this" in prompt_arg
+
+
+def test_invoke_hermes_raises_when_binary_missing():
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value=None):
+        with pytest.raises(SystemExit, match="hermes CLI not found"):
+            _invoke_hermes("hello", "qwen/qwen3.6-plus")
+
+
+def test_invoke_hermes_raises_on_nonzero_exit():
+    with patch("scripts.ai_agent_bridge._hermes.shutil.which", return_value="/fake/hermes"):
+        with patch("scripts.ai_agent_bridge._hermes.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=1, stdout="", stderr="auth failed")
+            with pytest.raises(SystemExit, match="hermes exited 1"):
+                _invoke_hermes("hello", "qwen/qwen3.6-plus")
+```
+
+**`tests/test_ask_opencode.py`** (new):
+
+```python
+"""Tests for ab ask-opencode bridge subcommand (PR-D1)."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from scripts.ai_agent_bridge._opencode import _invoke_opencode, OPENCODE_DEFAULT_MODEL
+
+
+def test_opencode_default_model_is_qwen_max():
+    assert OPENCODE_DEFAULT_MODEL == "openrouter/qwen/qwen3.7-max"
+
+
+def test_invoke_opencode_constructs_correct_argv():
+    with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value="/fake/opencode"):
+        with patch("scripts.ai_agent_bridge._opencode.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="response", stderr="")
+            _invoke_opencode("hello", "openrouter/qwen/qwen3.7-max")
+            argv = run_mock.call_args[0][0]
+            assert argv[0] == "/fake/opencode"
+            assert argv[1] == "run"
+            assert "--model" in argv
+            assert "openrouter/qwen/qwen3.7-max" in argv
+            assert "hello" in argv
+
+
+def test_invoke_opencode_attaches_file(tmp_path):
+    data_file = tmp_path / "report.html"
+    data_file.write_text("<html><body>data</body></html>")
+    with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value="/fake/opencode"):
+        with patch("scripts.ai_agent_bridge._opencode.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+            _invoke_opencode("review", "openrouter/qwen/qwen3.7-max", data=str(data_file))
+            argv = run_mock.call_args[0][0]
+            assert "--file" in argv
+            # file path is in argv right after --file
+            file_idx = argv.index("--file")
+            assert str(data_file.resolve()) == argv[file_idx + 1]
+
+
+def test_invoke_opencode_raises_when_binary_missing():
+    with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value=None):
+        with pytest.raises(SystemExit, match="opencode CLI not found"):
+            _invoke_opencode("hello", "openrouter/qwen/qwen3.7-max")
+```
+
+### 6. Run focused tests
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/test_ask_hermes.py tests/test_ask_opencode.py -v
+```
+
+Expect: all green (8-10 tests).
+
+### 7. Smoke tests (live)
+
+```bash
+# venv symlinked
+echo "say hello in 5 words" | .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-hermes - --task-id smoke-hermes-pr-d1 --model qwen/qwen3.6-plus 2>&1 | tail -20
+echo "say hello in 5 words" | .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-opencode - --task-id smoke-opencode-pr-d1 --model openrouter/qwen/qwen3.7-max 2>&1 | tail -20
+```
+
+Both should print a 5-word hello-style response. If either fails, surface in PR body.
+
+### 8. Regression test
+
+```bash
+# venv symlinked
+.venv/bin/python -m pytest tests/ --timeout=120 -q 2>&1 | tail -30
+```
+
+Specifically watch tests in `tests/test_ai_*` and `tests/test_messaging*` — they might assert agent enumerations.
+
+### 9. Lint
+
+```bash
+.venv/bin/ruff check scripts/ai_agent_bridge/_hermes.py scripts/ai_agent_bridge/_opencode.py scripts/ai_agent_bridge/_cli.py tests/test_ask_hermes.py tests/test_ask_opencode.py
+```
+
+### 10. Commit + push + PR
+
+```bash
+git add scripts/ai_agent_bridge/_hermes.py scripts/ai_agent_bridge/_opencode.py scripts/ai_agent_bridge/_cli.py tests/test_ask_hermes.py tests/test_ask_opencode.py
+git commit -m "$(cat <<'EOF'
+feat(bridge): ab ask-hermes + ab ask-opencode subcommands (PR-D1)
+
+Adds first-class bridge support for two more agents:
+
+- ask-hermes: one-shot hermes -z PROMPT -m MODEL via the hermes CLI. Default
+  model qwen/qwen3.6-plus (matches the hermes_qwen adapter default at
+  scripts/agent_runtime/adapters/hermes_qwen.py). Useful for ad-hoc cross-
+  model reviews via hermes proxy.
+
+- ask-opencode: one-shot opencode run --model PROVIDER/MODEL via opencode
+  CLI. Default model openrouter/qwen/qwen3.7-max (demonstrated as effective
+  adversarial reviewer in the 2026-05-23 strip-plan review). Useful for
+  routing models not in hermes proxy (any openrouter model).
+
+Both subcommands mirror the existing ask-codex / ask-gemini pattern:
+broker send → CLI invoke → broker reply. Optional --data flag attaches
+file content to the prompt for context.
+
+Out of scope: delegate.py --agent hermes / --agent opencode for dispatched
+commits-and-PR work. That's PR-D2 (filed as follow-up).
+
+Per user direction 2026-05-23: "would like both hermes and opencode
+support for everything."
+
+Co-Authored-By: Gemini CLI <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin HEAD
+gh pr create --title "feat(bridge): ab ask-hermes + ab ask-opencode subcommands (PR-D1)" --body "..."
+```
+
+Use the commit message body for the PR description.
+
+### 11. Do NOT auto-merge
+
+Surface PR URL. Orchestrator merges on CI green.
+
+## Acceptance criteria
+
+- `ab --help` shows `ask-hermes` and `ask-opencode` in subcommand list
+- 8-10 unit tests pass
+- Both smoke tests return a real model response
+- Ruff clean
+- PR URL surfaced
+
+## Stay in scope
+
+DO NOT modify:
+- `scripts/agent_runtime/` (PR-D2 territory)
+- `scripts/delegate.py` (PR-D2)
+- Any agent's existing `ask-*` subcommand (codex / gemini / claude / agy)
+- The broker schema (`_messaging.py`, `_db.py`)
+
+If `write_reply` doesn't exist under that exact name in `_messaging.py`: use the equivalent that ask-codex uses (look at how `process_for_codex` sends its response back to the broker — copy that exact pattern).
+
+If the broker has a hard-coded agent enumeration (e.g. `VALID_AGENTS = {"claude", "codex", "gemini", "agy"}`), add `"hermes"` and `"opencode"` to it. Search:
+
+```bash
+grep -rn 'VALID_AGENTS\|valid_agents\|ALLOWED_AGENTS\|AGENT_LIST' scripts/ai_agent_bridge/
+```
+
+## Failure recovery
+
+- If `opencode run` returns non-zero on the smoke test: check `opencode providers` shows OpenRouter configured. If not, the smoke test can be marked skip-when-not-configured rather than failing the PR — but document in PR body.
+- If `hermes -z` is unfamiliar to you: `hermes --help` shows the surface; `-z PROMPT -m MODEL` is the one-shot mode.
+- If existing `ask-codex` / `ask-gemini` use a different broker function than `send_message + write_reply`: mirror whatever they do, don't invent.

--- a/tests/build/test_writer_pre_emit_checklist.py
+++ b/tests/build/test_writer_pre_emit_checklist.py
@@ -3,10 +3,10 @@ from pathlib import Path
 PHASES_DIR = Path("scripts/build/phases")
 CHECKLIST_HEADING = "## Pre-emit verification"
 OBLIGATION_LABELS = (
-    "Textbook grounding",
-    "Multimedia obligation",
-    "VESUM verification",
-    "Russianism check",
+    "Textbook",
+    "Multimedia",
+    "VESUM",
+    "Russianism",
 )
 
 


### PR DESCRIPTION
## Summary

- Add the five archived 2026-05-23 dispatch briefs that were present as untracked files in the main checkout but absent from the delegated worktree, with `.venv` guard comments added and `pytest -x` removed where flagged.
- Relax `OBLIGATION_LABELS` in `tests/build/test_writer_pre_emit_checklist.py` to topic-keyword substrings shared by `linear-write.md` and `linear-write-grok.md`.

## Raw Evidence

### Pre-edit dispatch brief lint

Command run against the five untracked briefs found in the main checkout before copying them into this worktree:

```text
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md:359: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md:370: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md:371: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md:371: forbid pytest -x in dispatch briefs (masks downstream failures, see #1942)
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md:81: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md:226: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md:232: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md:238: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md:40: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md:328: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md:343: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md:359: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md:359: forbid pytest -x in dispatch briefs (masks downstream failures, see #1942)
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:64: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:167: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:464: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:472: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:473: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:481: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md:481: forbid pytest -x in dispatch briefs (masks downstream failures, see #1942)
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-b-band-widening-gemini.md:234: missing cd-to-main or symlinked-venv before .venv/bin/python
/Users/krisztiankoos/projects/learn-ukrainian/docs/dispatch-briefs/2026-05-23-pr-b-band-widening-gemini.md:242: missing cd-to-main or symlinked-venv before .venv/bin/python
```

### Post-edit targeted dispatch brief lint

```text
$ for f in docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md docs/dispatch-briefs/2026-05-23-pr-b-band-widening-gemini.md docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md; do .venv/bin/python scripts/audit/lint_dispatch_brief.py --brief "$f"; done
<no output; exit 0>
```

### Pytest

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/f2-f3-cleanup-2026-05-24
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collecting ... collected 2 items

tests/build/test_writer_pre_emit_checklist.py::test_linear_write_contains_pre_emit_checklist PASSED [ 50%]
tests/build/test_writer_pre_emit_checklist.py::test_linear_write_grok_contains_pre_emit_checklist PASSED [100%]

============================== 2 passed in 0.05s ===============================
```

### Ruff

```text
All checks passed!
```

### Commit trailer lint

```text
Checking 2 commit(s) in origin/main..HEAD:

  7f37c3f8ae  PASS  X-Agent: codex/f2-f3-cleanup-2026-05-24
  77362abbcb  PASS  X-Agent: codex/f2-f3-cleanup-2026-05-24

✅ All 2 non-skipped commit(s) carry an X-Agent trailer.
```

## Hygiene

```text
docs/dispatch-briefs/2026-05-23-issue-2239-codex-rollout-binding-fix.md
docs/dispatch-briefs/2026-05-23-pr-a-llm-dim-demote-resume-default-codex.md
docs/dispatch-briefs/2026-05-23-pr-b-band-widening-gemini.md
docs/dispatch-briefs/2026-05-23-pr-c-writer-prompt-strip-codex.md
docs/dispatch-briefs/2026-05-23-pr-d1-ask-hermes-ask-opencode-gemini.md
tests/build/test_writer_pre_emit_checklist.py
6
```
