### PR TITLE
fix(runtime): Codex dispatch stdin, startup probe, finalize gates (#2159 #2134 #2071)

### DIFF
--- a/scripts/agent_runtime/errors.py
+++ b/scripts/agent_runtime/errors.py
@@ -70,10 +70,18 @@ class AgentStalledError(AgentRuntimeError):
     detection, we only kill if truly silent.
     """
 
-    def __init__(self, agent: str, stall_timeout: int, last_activity_age: float):
+    def __init__(
+        self,
+        agent: str,
+        stall_timeout: int,
+        last_activity_age: float,
+        *,
+        kind: str = "stall",
+    ):
         self.agent = agent
         self.stall_timeout = stall_timeout
         self.last_activity_age = last_activity_age
+        self.kind = kind
         super().__init__(
             f"{agent} stalled: {last_activity_age:.0f}s since last activity "
             f"(stall_timeout={stall_timeout}s)"

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import signal
 import subprocess
+import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -72,6 +73,7 @@ from .watchdog import (
 # fast enough that stall detection fires within 1s of the threshold, slow
 # enough that we don't burn CPU in the wait loop.
 _POLL_INTERVAL_S = 1.0
+_STDIN_TEMP_PREFIX = "agent-runtime-stdin-"
 _SHIMS_DIR = Path(__file__).resolve().parent / "shims"
 _MCP_RUNTIME_INIT_TIMEOUT_S = 30.0
 _MCP_TOOL_EVENT_RE = re.compile(
@@ -110,6 +112,50 @@ def _pty_disabled_via_env() -> bool:
         "yes",
         "on",
     }
+
+
+def _stdin_uses_text_mode(stdin: Any) -> bool:
+    """Return True when Popen should use text mode for pipe stdout/stderr."""
+    import io
+
+    if stdin in (subprocess.PIPE, subprocess.DEVNULL, None):
+        return True
+    return isinstance(stdin, io.TextIOBase)
+
+
+def _prepare_stdin_handle(
+    stdin_payload: str,
+) -> tuple[Any, Path | None]:
+    """Return ``(stdin_for_Popen, temp_path)`` for a prompt payload.
+
+    PTY-wrapped spawns with ``stdin=PIPE`` plus a large ``write()`` crash
+    Codex CLI before session init (#2159). Feeding stdin from a temp file
+    matches ``cat prompt.txt | codex exec -`` and avoids the silent exit-1
+    path where ``BrokenPipeError`` was previously swallowed.
+    """
+    if not stdin_payload:
+        return subprocess.DEVNULL, None
+
+    fd, path_str = tempfile.mkstemp(prefix=_STDIN_TEMP_PREFIX, suffix=".txt")
+    path = Path(path_str)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(stdin_payload.encode("utf-8"))
+    except OSError:
+        with contextlib.suppress(OSError):
+            path.unlink()
+        raise
+
+    return open(path, encoding="utf-8"), path
+
+
+def _cleanup_stdin_temp(path: Path | None, handle: Any) -> None:
+    if handle not in (None, subprocess.DEVNULL, subprocess.PIPE):
+        with contextlib.suppress(OSError):
+            handle.close()
+    if path is not None and _is_temp_file(path):
+        with contextlib.suppress(OSError):
+            path.unlink()
 
 
 def _spawn_pty_subprocess(
@@ -194,6 +240,7 @@ def _spawn_pty_subprocess(
     # the runner's existing FileNotFoundError handling can turn it into
     # AgentUnavailableError. Do NOT translate this to PTYUnavailable.
     try:
+        text_mode = _stdin_uses_text_mode(stdin)
         proc = subprocess.Popen(
             list(cmd),
             cwd=str(cwd),
@@ -201,12 +248,8 @@ def _spawn_pty_subprocess(
             stdin=stdin,
             stdout=stdout_slave,
             stderr=stderr_slave,
-            # text=True / bufsize=1 here are no-ops for stdout/stderr
-            # (those are raw int fds, not Python-managed pipes), but
-            # they make stdin a line-buffered text pipe when the
-            # caller passes stdin=PIPE for stdin_payload writes.
-            text=True,
-            bufsize=1,
+            text=text_mode,
+            bufsize=1 if text_mode else -1,
             start_new_session=True,
         )
     except BaseException:
@@ -246,10 +289,10 @@ def _spawn_pipe_subprocess(
         stdin=stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        text=_stdin_uses_text_mode(stdin),
         cwd=str(cwd),
         env=dict(env),
-        bufsize=1,
+        bufsize=1 if _stdin_uses_text_mode(stdin) else -1,
         start_new_session=True,
     )
     return proc, None, None
@@ -885,6 +928,7 @@ def _execute_invocation_plan(
     tool_config: dict | None = None,
     event_sink: Callable[..., None] | None = None,
     stdout_silence_timeout: int | None = None,
+    initial_response_timeout: int | None = None,
 ) -> _ExecutionOutcome:
     """Spawn one plan, run watchdog/parse flow, and return raw execution state."""
     env = build_agent_env(provider=agent_name, overrides=plan.env_overrides)
@@ -900,14 +944,18 @@ def _execute_invocation_plan(
     liveness_paths: tuple[Path, ...] = ()
     stdout_master_fd: int | None = None
     stderr_master_fd: int | None = None
+    stdin_handle: Any = subprocess.DEVNULL
+    stdin_temp_path: Path | None = None
 
     try:
         try:
+            if plan.stdin_payload:
+                stdin_handle, stdin_temp_path = _prepare_stdin_handle(plan.stdin_payload)
             proc, stdout_master_fd, stderr_master_fd = _spawn_subprocess(
                 plan.cmd,
                 cwd=cwd,
                 env=env,
-                stdin=subprocess.PIPE if plan.stdin_payload else subprocess.DEVNULL,
+                stdin=stdin_handle,
             )
         except (FileNotFoundError, PermissionError, OSError) as exc:
             record = _build_usage_record(
@@ -934,13 +982,6 @@ def _execute_invocation_plan(
             raise AgentUnavailableError(
                 f"{agent_name!r} Popen failed: {type(exc).__name__}: {exc}"
             ) from exc
-
-        if plan.stdin_payload and proc.stdin is not None:
-            try:
-                proc.stdin.write(plan.stdin_payload)
-                proc.stdin.close()
-            except BrokenPipeError:
-                pass
 
         liveness_paths = tuple(adapter.liveness_signal_paths(plan))
         if plan.output_file is not None and plan.output_file not in liveness_paths:
@@ -999,6 +1040,7 @@ def _execute_invocation_plan(
                 stall_timeout,
                 hard_timeout,
                 stdout_silence_timeout=stdout_silence_timeout,
+                initial_response_timeout=initial_response_timeout,
             )
             if kill_reason is not None:
                 returncode = proc.poll()
@@ -1052,6 +1094,27 @@ def _execute_invocation_plan(
             plan=plan,
             call_start_time=start_time,
         )
+        if (
+            not parse.ok
+            and proc.returncode not in (None, 0)
+            and not parse.response
+            and not (parse.stderr_excerpt or "").strip()
+            and not stdout_text.strip()
+            and not stderr_text.strip()
+        ):
+            parse = ParseResult(
+                ok=False,
+                response="",
+                stderr_excerpt=(
+                    f"{agent_name} subprocess exited rc={proc.returncode} in "
+                    f"{duration_s:.2f}s with no captured stdout/stderr "
+                    f"(stdin_bytes={len(plan.stdin_payload or '')})"
+                )[:500],
+                rate_limited=parse.rate_limited,
+                session_id=parse.session_id,
+                tokens=parse.tokens,
+                tool_calls=parse.tool_calls,
+            )
         return _ExecutionOutcome(
             parse=parse,
             duration_s=duration_s,
@@ -1106,6 +1169,120 @@ def _execute_invocation_plan(
             with contextlib.suppress(Exception):
                 cleanup_invocation(plan)
 
+        _cleanup_stdin_temp(stdin_temp_path, stdin_handle)
+
+
+def _raise_for_kill_reason(
+    *,
+    agent_name: str,
+    kill_reason: str | None,
+    execution: _ExecutionOutcome,
+    prompt: str,
+    entrypoint: str,
+    model: str,
+    mode: str,
+    task_id: str | None,
+    cwd: Path,
+    session_id: str | None,
+    stdout_silence_timeout: int | None,
+    initial_response_timeout: int | None,
+    stall_timeout: int,
+    hard_timeout: int,
+) -> None:
+    """Map watchdog kill reasons to typed runtime errors + usage records."""
+    if not kill_reason:
+        return
+    parse = execution.parse
+    if kill_reason == "hard_timeout" and parse.ok:
+        return
+    if kill_reason == "stdout_silence_timeout":
+        record = _build_usage_record(
+            agent=agent_name,
+            entrypoint=entrypoint,
+            model=model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            duration_s=execution.duration_s,
+            input_chars=len(prompt),
+            output_chars=len(execution.stdout_text),
+            returncode=execution.returncode,
+            outcome="stalled",
+            rate_limited=False,
+            stalled=True,
+            stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
+            tokens=None,
+        )
+        write_record(record)
+        raise AgentStalledError(
+            agent_name,
+            stdout_silence_timeout or stall_timeout,
+            execution.duration_s,
+            kind="stdout_silence_timeout",
+        )
+
+    if kill_reason == "initial_response_timeout":
+        record = _build_usage_record(
+            agent=agent_name,
+            entrypoint=entrypoint,
+            model=model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            duration_s=execution.duration_s,
+            input_chars=len(prompt),
+            output_chars=len(execution.stdout_text),
+            returncode=execution.returncode,
+            outcome="stalled",
+            rate_limited=False,
+            stalled=True,
+            stderr_excerpt=(
+                parse.stderr_excerpt
+                or execution.stderr_text[:500]
+                or (
+                    f"initial_response_timeout: {agent_name} produced no "
+                    f"stdout/stderr/liveness activity within "
+                    f"{initial_response_timeout}s"
+                )
+            ),
+            tokens=None,
+        )
+        write_record(record)
+        raise AgentStalledError(
+            agent_name,
+            initial_response_timeout or stall_timeout,
+            execution.duration_s,
+            kind="initial_response_timeout",
+        )
+
+    if kill_reason == "hard_timeout" and not parse.ok:
+        record = _build_usage_record(
+            agent=agent_name,
+            entrypoint=entrypoint,
+            model=model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            duration_s=execution.duration_s,
+            input_chars=len(prompt),
+            output_chars=len(execution.stdout_text),
+            returncode=execution.returncode,
+            outcome="hard_timeout",
+            rate_limited=False,
+            stalled=False,
+            stderr_excerpt=(
+                parse.stderr_excerpt
+                or execution.stderr_text[:500]
+                or tail_liveness_file_for_debug(execution.liveness_paths)[:500]
+            ),
+            tokens=None,
+        )
+        write_record(record)
+        raise AgentTimeoutError(agent_name, hard_timeout)
+
 
 def _invoke_gemini_with_fallback(
     *,
@@ -1122,6 +1299,7 @@ def _invoke_gemini_with_fallback(
     hard_timeout: int,
     stall_timeout: int,
     stdout_silence_timeout: int | None = None,
+    initial_response_timeout: int | None = None,
     effort: str | None = None,
 ) -> Result:
     """Run Gemini through the shared model/auth fallback ladder."""
@@ -1167,34 +1345,27 @@ def _invoke_gemini_with_fallback(
             stall_timeout=stall_timeout,
             tool_config=attempt_tool_config,
             stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_response_timeout,
         )
         parse = execution.parse
         last_tool_calls = list(parse.tool_calls)
 
-        if execution.kill_reason == "stdout_silence_timeout":
-            record = _build_usage_record(
-                agent=agent_name,
+        if execution.kill_reason in ("stdout_silence_timeout", "initial_response_timeout"):
+            _raise_for_kill_reason(
+                agent_name=agent_name,
+                kill_reason=execution.kill_reason,
+                execution=execution,
+                prompt=prompt,
                 entrypoint=entrypoint,
                 model=last_telemetry.model if last_telemetry is not None else rung.model,
                 mode=mode,
                 task_id=task_id,
                 cwd=cwd,
                 session_id=session_id,
-                duration_s=execution.duration_s,
-                input_chars=len(prompt),
-                output_chars=len(execution.stdout_text),
-                returncode=execution.returncode,
-                outcome="stalled",
-                rate_limited=False,
-                stalled=True,
-                stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
-                tokens=None,
-            )
-            write_record(record)
-            raise AgentStalledError(
-                agent_name,
-                stdout_silence_timeout or stall_timeout,
-                execution.duration_s,
+                stdout_silence_timeout=stdout_silence_timeout,
+                initial_response_timeout=initial_response_timeout,
+                stall_timeout=stall_timeout,
+                hard_timeout=hard_timeout,
             )
 
         if execution.kill_reason == "hard_timeout" and not parse.ok:
@@ -1413,6 +1584,7 @@ def invoke(
                                  # for the full design rationale.
     stall_timeout: int = 180,  # accepted but ignored; see docstring
     stdout_silence_timeout: int | None = None,
+    initial_response_timeout: int | None = None,
     event_sink: Callable[..., None] | None = None,
     effort: str | None = None,
 ) -> Result:
@@ -1450,6 +1622,10 @@ def invoke(
         stdout_silence_timeout: Optional per-call stdout silence watchdog in
             seconds. Disabled by default. Use only for protocols where stdout
             bytes are the authoritative liveness signal.
+        initial_response_timeout: Optional startup probe in seconds. When set,
+            the runtime kills the subprocess if it produces no stdout/stderr
+            or liveness-file activity within this window (#2071). Distinct
+            from ``stdout_silence_timeout``, which only watches stdout lines.
         event_sink: Optional ``event_sink(event_name, **fields)`` callback for
             dispatch JSONL observability events.
         effort: Cross-agent reasoning/effort level. First-class peer of
@@ -1536,6 +1712,7 @@ def invoke(
             hard_timeout=hard_timeout,
             stall_timeout=stall_timeout,
             stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_response_timeout,
             effort=effort,
         )
 
@@ -1574,60 +1751,27 @@ def invoke(
         tool_config=tool_config,
         event_sink=event_sink,
         stdout_silence_timeout=stdout_silence_timeout,
+        initial_response_timeout=initial_response_timeout,
     )
     parse = execution.parse
 
-    if execution.kill_reason == "stdout_silence_timeout":
-        record = _build_usage_record(
-            agent=agent_name,
+    if execution.kill_reason:
+        _raise_for_kill_reason(
+            agent_name=agent_name,
+            kill_reason=execution.kill_reason,
+            execution=execution,
+            prompt=prompt,
             entrypoint=entrypoint,
             model=effective_model,
             mode=mode,
             task_id=task_id,
             cwd=effective_cwd,
             session_id=session_id,
-            duration_s=execution.duration_s,
-            input_chars=len(prompt),
-            output_chars=len(execution.stdout_text),
-            returncode=execution.returncode,
-            outcome="stalled",
-            rate_limited=False,
-            stalled=True,
-            stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
-            tokens=None,
+            stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_response_timeout,
+            stall_timeout=stall_timeout,
+            hard_timeout=hard_timeout,
         )
-        write_record(record)
-        raise AgentStalledError(
-            agent_name,
-            stdout_silence_timeout or stall_timeout,
-            execution.duration_s,
-        )
-
-    if execution.kill_reason == "hard_timeout" and not parse.ok:
-        record = _build_usage_record(
-            agent=agent_name,
-            entrypoint=entrypoint,
-            model=effective_model,
-            mode=mode,
-            task_id=task_id,
-            cwd=effective_cwd,
-            session_id=session_id,
-            duration_s=execution.duration_s,
-            input_chars=len(prompt),
-            output_chars=len(execution.stdout_text),
-            returncode=execution.returncode,
-            outcome="hard_timeout",
-            rate_limited=False,
-            stalled=False,
-            stderr_excerpt=(
-                parse.stderr_excerpt
-                or execution.stderr_text[:500]
-                or tail_liveness_file_for_debug(execution.liveness_paths)[:500]
-            ),
-            tokens=None,
-        )
-        write_record(record)
-        raise AgentTimeoutError(agent_name, hard_timeout)
 
     if parse.rate_limited:
         outcome = "rate_limited"

--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -106,6 +106,7 @@ class WatchdogState:
     last_activity: float
     last_stdout_activity: float = 0.0
     stop: bool = False
+    observed_io: bool = False
     stdout_lines: list[str] = field(default_factory=list)
     stderr_lines: list[str] = field(default_factory=list)
 
@@ -249,6 +250,7 @@ def _emit_line(state: WatchdogState, line: str, *, is_stderr: bool) -> None:
         state.stdout_lines.append(line)
         state.last_stdout_activity = now
     state.last_activity = now
+    state.observed_io = True
 
 
 def _mtime_poller(paths: Iterable[Path], state: WatchdogState) -> None:
@@ -275,6 +277,7 @@ def _mtime_poller(paths: Iterable[Path], state: WatchdogState) -> None:
                 continue  # file disappeared or permission denied; skip
             if current > baseline:
                 state.last_activity = time.monotonic()
+                state.observed_io = True
                 baseline_mtimes[p] = current
 
 
@@ -453,12 +456,16 @@ def should_kill(
     hard_timeout: int,
     *,
     stdout_silence_timeout: int | None = None,
+    initial_response_timeout: int | None = None,
 ) -> str | None:
     """Check if the subprocess should be killed. Returns the kill reason or None.
 
     Returns:
         None if the process should continue running.
         "hard_timeout" if total runtime exceeded hard_timeout.
+        "initial_response_timeout" if the caller enabled startup probing and
+        the subprocess produced no stdout/stderr/liveness activity within that
+        window (#2071 startup hangs with response_chars=0).
         "stdout_silence_timeout" if the caller explicitly enabled stdout
         silence detection and no stdout line has arrived within that window.
 
@@ -493,6 +500,13 @@ def should_kill(
     now = time.monotonic()
     if (now - state.start_time) > hard_timeout:
         return "hard_timeout"
+    if (
+        initial_response_timeout is not None
+        and initial_response_timeout > 0
+        and (now - state.start_time) > initial_response_timeout
+        and not state.observed_io
+    ):
+        return "initial_response_timeout"
     if (
         stdout_silence_timeout is not None
         and stdout_silence_timeout > 0

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -170,6 +170,9 @@ DEFAULT_HARD_TIMEOUT_S = 7200
 # silence window is the stopgap. See watchdog.py:323-332 for the historical
 # Gemini block-buffering incident chain (#1184).
 DEFAULT_SILENCE_TIMEOUT_S = 3600
+# Fail fast when Codex (or any agent) never produces stdout/stderr/liveness
+# activity at startup — distinct from the long silence window above (#2071).
+DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 180
 
 
 def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
@@ -406,6 +409,23 @@ def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
         return None
     sha = (proc.stdout or "").strip()
     return sha or None
+
+
+def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
+    """Return commits on HEAD not reachable from ``base_ref``, or None."""
+    proc = subprocess.run(
+        ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        return int((proc.stdout or "").strip())
+    except ValueError:
+        return None
 
 
 def _validate_existing_worktree(
@@ -678,6 +698,7 @@ def _run_worker(
     silence_timeout: int = DEFAULT_SILENCE_TIMEOUT_S,
     effort: str | None = None,
     max_budget_usd: float | None = None,
+    initial_response_timeout: int = DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
 ) -> int:
     """Worker main loop. Invokes the runtime, updates the state file.
 
@@ -736,6 +757,9 @@ def _run_worker(
     cancelled = False
     try:
         stdout_silence_timeout = silence_timeout if silence_timeout > 0 else None
+        initial_probe = (
+            initial_response_timeout if initial_response_timeout > 0 else None
+        )
         tool_config = (
             {"max_budget_usd": max_budget_usd}
             if max_budget_usd is not None
@@ -753,6 +777,7 @@ def _run_worker(
             entrypoint="delegate",
             hard_timeout=hard_timeout,
             stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_probe,
             effort=effort,
         )
         ok_outcome = result.ok
@@ -772,9 +797,12 @@ def _run_worker(
         stderr_excerpt = str(exc)[:500]
     except AgentStalledError as exc:
         timed_out = True
-        stderr_excerpt = (
-            f"stdout_silence_timeout: {exc}"
-        )[:500]
+        prefix = (
+            "initial_response_timeout"
+            if getattr(exc, "kind", "stall") == "initial_response_timeout"
+            else "stdout_silence_timeout"
+        )
+        stderr_excerpt = f"{prefix}: {exc}"[:500]
     except AgentTimeoutError as exc:
         stderr_excerpt = f"hard_timeout: {exc}"[:500]
     except AgentRuntimeError as exc:
@@ -825,6 +853,23 @@ def _run_worker(
         except OSError:
             dirty_on_exit = None
 
+    commits_ahead: int | None = None
+    needs_finalize = False
+    if worktree_path and mode == "danger":
+        base_branch = final_state.get("worktree_base") or "main"
+        commits_ahead = _count_commits_ahead(
+            Path(worktree_path),
+            f"origin/{base_branch}",
+        )
+        if commits_ahead == 0 and dirty_on_exit:
+            needs_finalize = True
+
+    if needs_finalize and (
+        final_status == "done"
+        or (final_status == "failed" and dirty_on_exit)
+    ):
+        final_status = "needs_finalize"
+
     final_state.update({
         "model": getattr(result, "model", final_state.get("model")),
         "effort": getattr(result, "effort", final_state.get("effort")),
@@ -837,6 +882,8 @@ def _run_worker(
         "stderr_excerpt": stderr_excerpt,
         "returncode": returncode,
         "worktree_dirty_on_exit": dirty_on_exit,
+        "commits_ahead": commits_ahead,
+        "needs_finalize": needs_finalize,
     })
     _write_state_atomic(state_path, final_state)
 
@@ -857,7 +904,7 @@ def _run_worker(
             stderr_excerpt=stderr_excerpt,
         )
 
-    return 0 if ok_outcome else 1
+    return 0 if ok_outcome and not needs_finalize else 1
 
 
 # ---------------------------------------------------------------------------
@@ -873,6 +920,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     state_path = _state_path(task_id)
     worktree_arg = getattr(args, "worktree", None)
     silence_timeout = getattr(args, "silence_timeout", DEFAULT_SILENCE_TIMEOUT_S)
+    initial_response_timeout = getattr(
+        args,
+        "initial_response_timeout",
+        DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
+    )
     max_budget_usd = getattr(args, "max_budget_usd", None)
 
     if args.mode == "danger" and not worktree_arg:
@@ -999,6 +1051,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "worktree_layout": worktree_layout,
         "hard_timeout": args.hard_timeout,
         "silence_timeout": silence_timeout,
+        "initial_response_timeout": initial_response_timeout,
         "max_budget_usd": max_budget_usd,
         "pid": None,  # worker fills this
         "status": "spawning",
@@ -1050,6 +1103,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "--cwd", cwd,
         "--hard-timeout", str(args.hard_timeout),
         "--silence-timeout", str(silence_timeout),
+        "--initial-response-timeout", str(initial_response_timeout),
     ]
     if max_budget_usd is not None:
         cmd.extend(["--max-budget-usd", str(max_budget_usd)])
@@ -1500,6 +1554,11 @@ def cmd_worker(args: argparse.Namespace) -> int:
         silence_timeout=args.silence_timeout,
         max_budget_usd=getattr(args, "max_budget_usd", None),
         effort=args.effort,
+        initial_response_timeout=getattr(
+            args,
+            "initial_response_timeout",
+            DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
+        ),
     )
 
 
@@ -1651,6 +1710,19 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     d.add_argument(
+        "--initial-response-timeout",
+        type=int,
+        metavar="SECS",
+        default=DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
+        help=(
+            "Startup probe: kill the agent CLI if it produces no "
+            "stdout/stderr/liveness activity within this many seconds "
+            f"(default: {DEFAULT_INITIAL_RESPONSE_TIMEOUT_S}; 0 disables). "
+            "Distinct from --silence-timeout, which only watches stdout "
+            "lines after startup (#2071)."
+        ),
+    )
+    d.add_argument(
         "--max-budget-usd",
         type=float,
         default=None,
@@ -1719,7 +1791,8 @@ def build_parser() -> argparse.ArgumentParser:
     l = sub.add_parser("list", help="List tasks (with optional status filter)")
     l.add_argument("--status", default=None,
                    choices=["spawning", "running", "done", "failed",
-                            "timeout", "rate_limited", "crashed", "cancelled"],
+                            "timeout", "rate_limited", "crashed", "cancelled",
+                            "needs_finalize"],
                    help="Optional status filter, e.g. running or failed.")
     l.set_defaults(func=cmd_list)
 
@@ -1737,6 +1810,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wk.add_argument("--hard-timeout", type=int, default=DEFAULT_HARD_TIMEOUT_S)
     wk.add_argument("--silence-timeout", type=int, default=DEFAULT_SILENCE_TIMEOUT_S)
+    wk.add_argument(
+        "--initial-response-timeout",
+        type=int,
+        default=DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
+    )
     wk.add_argument("--max-budget-usd", type=float, default=None)
     wk.set_defaults(func=cmd_worker)
 

--- a/tests/agent_runtime/test_stdin_tempfile_spawn.py
+++ b/tests/agent_runtime/test_stdin_tempfile_spawn.py
@@ -1,0 +1,146 @@
+"""Regression tests for stdin temp-file spawn (#2159).
+
+PTY-wrapped stdout/stderr plus PIPE stdin and a large write() caused Codex
+CLI to exit rc=1 in under a second with no stderr. Feeding stdin from a temp
+file matches ``cat prompt.txt | codex exec -``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from agent_runtime.runner import (
+    _STDIN_TEMP_PREFIX,
+    _cleanup_stdin_temp,
+    _prepare_stdin_handle,
+    _spawn_subprocess,
+)
+
+
+def _resolve_test_python() -> str:
+    candidate = _REPO_ROOT / ".venv" / "bin" / "python"
+    if candidate.exists():
+        return str(candidate)
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=str(_REPO_ROOT),
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if common_dir:
+            main_venv = (Path(common_dir) / ".." / ".venv" / "bin" / "python").resolve()
+            if main_venv.exists():
+                return str(main_venv)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+    raise RuntimeError("missing .venv/bin/python")
+
+
+_TEST_PYTHON = _resolve_test_python()
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("DELEGATE_DISABLE_PTY", raising=False)
+    yield
+
+
+def test_prepare_stdin_handle_writes_payload_to_temp_file():
+    handle, path = _prepare_stdin_handle("alpha\nomega")
+    try:
+        assert path is not None
+        assert path.name.startswith(_STDIN_TEMP_PREFIX)
+        assert path.read_text(encoding="utf-8") == "alpha\nomega"
+    finally:
+        _cleanup_stdin_temp(path, handle)
+
+
+def test_large_stdin_reaches_child_via_temp_file_not_pipe_write(
+    clean_env, tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("DELEGATE_DISABLE_PTY", "1")
+    payload = "X" * 200_000 + "\n"
+    handle, path = _prepare_stdin_handle(payload)
+    proc = None
+    try:
+        proc, _, _ = _spawn_subprocess(
+            [
+                _TEST_PYTHON,
+                "-c",
+                "import sys; data=sys.stdin.read(); "
+                "print(len(data), data[:1], data[-2:])",
+            ],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            stdin=handle,
+        )
+        stdout, _stderr = proc.communicate(timeout=10)
+        assert proc.returncode == 0, f"child failed: rc={proc.returncode}"
+        assert "200001" in stdout
+        assert "X" in stdout
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+        _cleanup_stdin_temp(path, handle)
+
+
+def test_initial_response_timeout_kills_silent_child(clean_env, tmp_path, monkeypatch):
+    from agent_runtime import runner as runtime_runner
+    from agent_runtime.adapters.base import InvocationPlan
+    from agent_runtime.errors import AgentStalledError
+    from agent_runtime.result import ParseResult
+    from agent_runtime.telemetry import InvocationTelemetry
+
+    class SilentAdapter:
+        name = "claude"
+        default_model = "fixture"
+        supported_modes = frozenset({"read-only"})
+
+        def build_invocation(self, **kwargs):
+            return InvocationPlan(
+                cmd=["/bin/sh", "-c", "sleep 60"],
+                cwd=Path(kwargs["cwd"]),
+            )
+
+        def parse_response(self, *, returncode: int, **_kwargs):
+            return ParseResult(ok=False, response="", stderr_excerpt="")
+
+        def liveness_signal_paths(self, _plan):
+            return ()
+
+    monkeypatch.setattr(runtime_runner, "has_headroom", lambda *_a, **_k: (True, ""))
+    monkeypatch.setattr(runtime_runner, "write_record", lambda _r: None)
+    monkeypatch.setattr(
+        runtime_runner,
+        "resolve_invocation_telemetry",
+        lambda **_k: InvocationTelemetry(
+            model="fixture",
+            effort="unknown",
+            cli_version="fixture",
+        ),
+    )
+    monkeypatch.setitem(runtime_runner._ADAPTER_CACHE, "claude", SilentAdapter())
+
+    started = __import__("time").monotonic()
+    with pytest.raises(AgentStalledError) as exc_info:
+        runtime_runner.invoke(
+            "claude",
+            "hi",
+            mode="read-only",
+            cwd=tmp_path,
+            hard_timeout=60,
+            initial_response_timeout=2,
+            stdout_silence_timeout=None,
+        )
+    elapsed = __import__("time").monotonic() - started
+    assert exc_info.value.kind == "initial_response_timeout"
+    assert elapsed < 15

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -911,6 +911,74 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["cli_version"] == "2.1.89"
 
 
+def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Danger dispatches with edits but no commits surface needs_finalize (#2134)."""
+    state_path = delegate._state_path("needs-finalize")
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    delegate._write_state_atomic(state_path, {
+        "task_id": "needs-finalize",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+    (tmp_path / "orphan.txt").write_text("left behind", encoding="utf-8")
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.5",
+            "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    monkeypatch.setattr(delegate, "_count_commits_ahead", lambda *_a, **_k: 0)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_count_commits_ahead", return_value=0),
+    ):
+        rc = delegate._run_worker(
+            task_id="needs-finalize",
+            agent="codex",
+            prompt="hi",
+            mode="danger",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            effort="xhigh",
+        )
+
+    assert rc == 1
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "needs_finalize"
+    assert state["needs_finalize"] is True
+    assert state["commits_ahead"] == 0
+    assert state["worktree_dirty_on_exit"] is True
+
+
 def test_run_worker_forwards_max_budget_usd_to_runtime(tmp_tasks_dir, tmp_path):
     state_path = delegate._state_path("worker-budget")
     delegate._write_state_atomic(state_path, {"task_id": "worker-budget"})


### PR DESCRIPTION
## Summary

- **#2159** — Stop feeding large prompts via `PTY stdout + PIPE stdin + write()`. The runner now materializes `stdin_payload` to a temp file (same semantics as `cat prompt | codex exec -`), surfaces useful errors on silent rc=1 exits, and adds a 200K-char regression test.
- **#2071** — Add `initial_response_timeout` (default 180s on delegate dispatch) distinct from `stdout_silence_timeout` (3600s). Kills startup hangs with `response_chars=0` in ~3 minutes instead of waiting 30–60 minutes.
- **#2134** — Danger-mode dispatches with a dirty worktree but zero commits ahead of base now finish as `status=needs_finalize` with `commits_ahead=0`, so the orchestrator can salvage uncommitted work instead of treating the dispatch as cleanly done.

## Test plan

- [x] `pytest tests/agent_runtime/test_stdin_tempfile_spawn.py` — temp-file stdin + initial_response_timeout
- [x] `pytest tests/agent_runtime/test_pty_subprocess_wrap.py` — PTY path unchanged
- [x] `pytest tests/test_delegate.py::test_run_worker_marks_needs_finalize_for_dirty_danger_worktree`
- [x] Full `tests/agent_runtime/` + `tests/test_delegate.py` (135 passed)

## Follow-up (not in this PR)

- Auto-finalize hook when `needs_finalize=true` (orchestrator-side)
- Live B1 bakeoff re-run with `codex-tools` on 210K prompts to confirm end-to-end

Closes #2159, #2134, #2071


Made with [Cursor](https://cursor.com)