### PR TITLE
fix(wiki): backfill ext-article-N stubs with real titles and urls

### DIFF
--- a/wiki/academic/c1/euphemism-taboo.sources.yaml
+++ b/wiki/academic/c1/euphemism-taboo.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/academic/c1/euphemism-taboo.md
+# Source registry for c1/euphemism-taboo.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -49,12 +49,20 @@ sources:
 - id: S11
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-102 | Запис до лікаря – Making a Doctor’s Appointment in Ukrainian
+    + Indefinite Adverbs and Pronouns
+  url: https://www.ukrainianlessons.com/episode102/
+  domain: ukrainianlessons.com
 - id: S12
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 3-104 | Здоровий спосіб життя – Healthy Lifestyle + Degrees of Comparison
+    in Ukrainian
+  url: https://www.ukrainianlessons.com/episode104/
+  domain: ukrainianlessons.com
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 5-170 | 15 фразеологізмів з частинами тіла
+  url: https://www.ukrainianlessons.com/episode170/
+  domain: ukrainianlessons.com

--- a/wiki/academic/c1/halychyna.sources.yaml
+++ b/wiki/academic/c1/halychyna.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/academic/c1/halychyna.md
+# Source registry for c1/halychyna.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -44,12 +44,21 @@ sources:
 - id: S11
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-71 | Курс з історії України Ч. 1 “Київська Русь” | Ukrainian History
+    Course Part 1
+  url: https://www.ukrainianlessons.com/episode71/
+  domain: ukrainianlessons.com
 - id: S12
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-72 | Курс з історії України Ч. 2 “XIII-XVI століття” | Ukrainian History
+    Course Part 2
+  url: https://www.ukrainianlessons.com/episode72/
+  domain: ukrainianlessons.com
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 2-73 | Курс з історії України Ч. 3 “Українське козацтво” | Ukrainian
+    History Course Part 3 “Ukrainian Cossacks”
+  url: https://www.ukrainianlessons.com/episode73/
+  domain: ukrainianlessons.com

--- a/wiki/academic/c1/politeness-strategies.sources.yaml
+++ b/wiki/academic/c1/politeness-strategies.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/academic/c1/politeness-strategies.md
+# Source registry for c1/politeness-strategies.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -54,12 +54,21 @@ sources:
 - id: S11
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-111 | Подарунки на День народження – Birthday Presents + Imperative
+    Mood in Ukrainian
+  url: https://www.ukrainianlessons.com/episode111/
+  domain: ukrainianlessons.com
 - id: S12
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 3-112 | Майстер-клас з приготування вареників – How to Cook Varenyky
+    + Imperative Mood of the Second Person Plural
+  url: https://www.ukrainianlessons.com/episode112/
+  domain: ukrainianlessons.com
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 3-113 | Майстер-клас з вишивання – Ukrainian Traditional Embroidery Masterclass
+    + More about the Imperative Mood in Ukrainian
+  url: https://www.ukrainianlessons.com/episode113/
+  domain: ukrainianlessons.com

--- a/wiki/academic/c1/suchasna-muzyka.sources.yaml
+++ b/wiki/academic/c1/suchasna-muzyka.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/academic/c1/suchasna-muzyka.md
+# Source registry for c1/suchasna-muzyka.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -49,4 +49,7 @@ sources:
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 3-86 | Знайомство з директором школи – Meeting the Headmaster of the
+    School in Ukraine + Prefixes в-, у-
+  url: https://www.ukrainianlessons.com/episode86/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/all-cases-practice.sources.yaml
+++ b/wiki/grammar/a2/all-cases-practice.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/all-cases-practice.md
+# Source registry for a2/all-cases-practice.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,4 +34,6 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 'All Ukrainian Cases Chart: Full Table of Functions and Examples'
+  url: https://www.ukrainianlessons.com/ukrainian-cases-chart/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/aspect-in-past.sources.yaml
+++ b/wiki/grammar/a2/aspect-in-past.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/aspect-in-past.md
+# Source registry for a2/aspect-in-past.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -20,4 +20,6 @@ sources:
 - id: S5
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 27.2 Verbal Aspect (Past Tense) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/27-2/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/aspect-mastery.sources.yaml
+++ b/wiki/grammar/a2/aspect-mastery.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/aspect-mastery.md
+# Source registry for a2/aspect-mastery.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,4 +40,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 27.1 Introduction to Verbal Aspect (Prefixed Perfective Verbs) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/27-1/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/because-and-although.sources.yaml
+++ b/wiki/grammar/a2/because-and-although.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/because-and-although.md
+# Source registry for a2/because-and-although.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -65,12 +65,20 @@ sources:
 - id: S11
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-56 | Порада | Asking for Advice + Accusative Case in Ukrainian
+  url: https://www.ukrainianlessons.com/episode56/
+  domain: ukrainianlessons.com
 - id: S12
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-57 | Розклад на тиждень | Your Schedule in Ukrainian + Accusative Case
+    with Prepositions
+  url: https://www.ukrainianlessons.com/episode57/
+  domain: ukrainianlessons.com
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 2-58 | Запрошення на вечірку | Inviting to a Party in Ukrainian + Accusative
+    Case of Pronouns
+  url: https://www.ukrainianlessons.com/episode58/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/checkpoint-cases.sources.yaml
+++ b/wiki/grammar/a2/checkpoint-cases.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/checkpoint-cases.md
+# Source registry for a2/checkpoint-cases.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,8 +34,12 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 1-32 | Shopping for Clothes – Accusative Case in Ukrainian
+  url: https://www.ukrainianlessons.com/episode32/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-33 | Talking about Books in Ukrainian – Accusative Case of People
+  url: https://www.ukrainianlessons.com/episode33/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/checkpoint-verbs.sources.yaml
+++ b/wiki/grammar/a2/checkpoint-verbs.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/checkpoint-verbs.md
+# Source registry for a2/checkpoint-verbs.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,8 +40,12 @@ sources:
 - id: S7
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 27.1 Introduction to Verbal Aspect (Prefixed Perfective Verbs) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/27-1/
+  domain: opentext.ku.edu
 - id: S8
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 27.2 Verbal Aspect (Past Tense) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/27-2/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/comparison.sources.yaml
+++ b/wiki/grammar/a2/comparison.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/comparison.md
+# Source registry for a2/comparison.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,12 +52,18 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 20.1 Comparative Degree of Adjectives – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/20-1/
+  domain: opentext.ku.edu
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 20.2 Comparative Degree of Adjectives (Exceptions) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/20-2/
+  domain: opentext.ku.edu
 - id: S11
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 20.3 Superlative Degree of Adjectives – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/20-3/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/dative-nouns.sources.yaml
+++ b/wiki/grammar/a2/dative-nouns.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/dative-nouns.md
+# Source registry for a2/dative-nouns.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,12 +52,18 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 11.1 Dative Case (Feminine Nouns) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/11-1/
+  domain: opentext.ku.edu
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 11.2 Dative Case (Masculine and Neuter Nouns) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/11-2/
+  domain: opentext.ku.edu
 - id: S11
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 11.3 Dative Case (Animate Masculine Nouns) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/11-3/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/dative-pronouns.sources.yaml
+++ b/wiki/grammar/a2/dative-pronouns.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/dative-pronouns.md
+# Source registry for a2/dative-pronouns.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,12 +40,18 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 15.1 Personal Pronouns (Dative Case Forms) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/15-1/
+  domain: opentext.ku.edu
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 15.2 Personal Pronouns (Dative Case for Indirect Object) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/15-2/
+  domain: opentext.ku.edu
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Ukrainian Grammatical Cases
+  url: https://talkukrainian.com/grammatical-cases/
+  domain: talkukrainian.com

--- a/wiki/grammar/a2/dative-verbs.sources.yaml
+++ b/wiki/grammar/a2/dative-verbs.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/dative-verbs.md
+# Source registry for a2/dative-verbs.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -39,4 +39,6 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 11.1 Dative Case (Feminine Nouns) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/11-1/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/education-and-work.sources.yaml
+++ b/wiki/grammar/a2/education-and-work.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/education-and-work.md
+# Source registry for a2/education-and-work.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -28,8 +28,12 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: FMU 1-34 | Professions in Ukrainian (Male and Female Forms)
+  url: https://www.ukrainianlessons.com/fmu34/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-31 | How to Talk about Your Job / Occupation in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu31/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/imperative-complete.sources.yaml
+++ b/wiki/grammar/a2/imperative-complete.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/imperative-complete.md
+# Source registry for a2/imperative-complete.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,8 +40,14 @@ sources:
 - id: S7
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-111 | Подарунки на День народження – Birthday Presents + Imperative
+    Mood in Ukrainian
+  url: https://www.ukrainianlessons.com/episode111/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 3-112 | Майстер-клас з приготування вареників – How to Cook Varenyky
+    + Imperative Mood of the Second Person Plural
+  url: https://www.ukrainianlessons.com/episode112/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/indefinite-negative-pronouns.sources.yaml
+++ b/wiki/grammar/a2/indefinite-negative-pronouns.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/indefinite-negative-pronouns.md
+# Source registry for a2/indefinite-negative-pronouns.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,4 +40,6 @@ sources:
 - id: S7
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Indefinite and Negative Pronouns
+  url: https://talkukrainian.com/indefinite-negative-pronouns/
+  domain: talkukrainian.com

--- a/wiki/grammar/a2/instrumental-accompaniment.sources.yaml
+++ b/wiki/grammar/a2/instrumental-accompaniment.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/instrumental-accompaniment.md
+# Source registry for a2/instrumental-accompaniment.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,8 +46,13 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-61 | Різдвяна вечеря | Christmas Dinner in Ukraine + Instrumental Case
+  url: https://www.ukrainianlessons.com/episode61/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-62 | Новий рік! | New Year’s Eve in Ukraine + Instrumental Case of
+    Pronouns
+  url: https://www.ukrainianlessons.com/episode62/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/instrumental-means.sources.yaml
+++ b/wiki/grammar/a2/instrumental-means.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/instrumental-means.md
+# Source registry for a2/instrumental-means.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -33,4 +33,7 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-65 | Повторення + Моя американська мандрівка | Review + My American
+    (Road) Trip
+  url: https://www.ukrainianlessons.com/episode65/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/instrumental-profession.sources.yaml
+++ b/wiki/grammar/a2/instrumental-profession.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/instrumental-profession.md
+# Source registry for a2/instrumental-profession.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -50,12 +50,19 @@ sources:
 - id: S10
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-62 | Новий рік! | New Year’s Eve in Ukraine + Instrumental Case of
+    Pronouns
+  url: https://www.ukrainianlessons.com/episode62/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-61 | Різдвяна вечеря | Christmas Dinner in Ukraine + Instrumental Case
+  url: https://www.ukrainianlessons.com/episode61/
+  domain: ukrainianlessons.com
 - id: S12
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 10.3 Instrumental Case after Verbs (працювати, бути, and стати) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/10-3/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/motion-verbs.sources.yaml
+++ b/wiki/grammar/a2/motion-verbs.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/motion-verbs.md
+# Source registry for a2/motion-verbs.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -33,8 +33,12 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 28.3 Verbs of Motion (піти – прийти, поїхати – приїхати) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/28-3/
+  domain: opentext.ku.edu
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 27.1 Introduction to Verbal Aspect (Prefixed Perfective Verbs) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/27-1/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/nature-and-traditions.sources.yaml
+++ b/wiki/grammar/a2/nature-and-traditions.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/nature-and-traditions.md
+# Source registry for a2/nature-and-traditions.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -51,4 +51,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: FMU 1-28 | How to Talk about Weather in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu28/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/numerals-and-cases.sources.yaml
+++ b/wiki/grammar/a2/numerals-and-cases.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/numerals-and-cases.md
+# Source registry for a2/numerals-and-cases.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,4 +52,6 @@ sources:
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 16.3 Ordinal Numerals (Gender and Number in Nominative) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/16-3/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/plural-nominative-accusative.sources.yaml
+++ b/wiki/grammar/a2/plural-nominative-accusative.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/plural-nominative-accusative.md
+# Source registry for a2/plural-nominative-accusative.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,20 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-42 | Моя кімната – Множина іменників | My Room – Plural Nouns in Ukrainian
+  url: https://www.ukrainianlessons.com/episode42/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-44 | Мої домашні тваринки + Особливі форми множини | My Pets + Special
+    Plural Forms
+  url: https://www.ukrainianlessons.com/episode44/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 2-43 | Шукаю квартиру – Особливі форми множини |  Looking for an Apartment
+    + Special Plural Forms
+  url: https://www.ukrainianlessons.com/episode43/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/preferences-and-choices.sources.yaml
+++ b/wiki/grammar/a2/preferences-and-choices.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/preferences-and-choices.md
+# Source registry for a2/preferences-and-choices.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,12 +52,20 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-51 | Техніка і технології + Давальний відмінок | Electronics and Technology
+    + Dative Case
+  url: https://www.ukrainianlessons.com/episode51/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-52 | Купівля телефона + Давальний відмінок | Buying a Phone in Ukraine
+    + Dative Case
+  url: https://www.ukrainianlessons.com/episode52/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-23 | Vocabulary Booster! Hobbies in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu23/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/purpose-clauses.sources.yaml
+++ b/wiki/grammar/a2/purpose-clauses.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/purpose-clauses.md
+# Source registry for a2/purpose-clauses.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -50,8 +50,13 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-118 | Весілля в Україні – Wedding in Ukraine + Using “щоб” With the
+    Past Tense in Ukrainian
+  url: https://www.ukrainianlessons.com/episode118/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: FMU 1-54 | How to book an Appointment with a Doctor in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu54/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/services-and-communication.sources.yaml
+++ b/wiki/grammar/a2/services-and-communication.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/services-and-communication.md
+# Source registry for a2/services-and-communication.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,4 +46,7 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-53 | Соціальні мережі + Давальний відмінок | Social Media in Ukrainian
+    + Dative Case
+  url: https://www.ukrainianlessons.com/episode53/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/shopping-and-health.sources.yaml
+++ b/wiki/grammar/a2/shopping-and-health.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/shopping-and-health.md
+# Source registry for a2/shopping-and-health.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,8 +46,12 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: How to Say That Something Hurts in Ukrainian
+  url: https://www.ukrainianlessons.com/something-hurts/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-52 | Vocabulary Booster! Body Parts in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu52/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/a2/synonyms-antonyms-style.sources.yaml
+++ b/wiki/grammar/a2/synonyms-antonyms-style.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/synonyms-antonyms-style.md
+# Source registry for a2/synonyms-antonyms-style.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,8 +34,12 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 16.1 Adjectives (Gender and Number in Nominative) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/16-1/
+  domain: opentext.ku.edu
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 16.2 Soft-Stem Adjectives (Gender and Number in Nominative) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/16-2/
+  domain: opentext.ku.edu

--- a/wiki/grammar/a2/work-and-food.sources.yaml
+++ b/wiki/grammar/a2/work-and-food.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/a2/work-and-food.md
+# Source registry for a2/work-and-food.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,15 +40,23 @@ sources:
 - id: S7
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 2-47 | Гастрономічні фестивалі + Родовий відмінок | Food Festivals +
+    Genitive Case
+  url: https://www.ukrainianlessons.com/episode47/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-46 | У продуктовому магазині + Родовий відмінок | At the Grocery Store
+    + Genitive Case
+  url: https://www.ukrainianlessons.com/episode46/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 'Food Guide to Lviv: Where and What to Eat in the City of Lion'
+  url: https://www.ukrainianlessons.com/lviv-food-guide/
+  domain: ukrainianlessons.com
 - id: S10
   file: ukrainian_wiki/work-and-food_Граматика-A2-Професії-та-кулінарія-Як-це-пояснюють-у-школі
   type: ukrainian_wiki

--- a/wiki/grammar/b1/aspect-in-imperatives.sources.yaml
+++ b/wiki/grammar/b1/aspect-in-imperatives.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b1/aspect-in-imperatives.md
+# Source registry for b1/aspect-in-imperatives.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,4 +34,6 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Наказовий спосіб — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Наказовий_спосіб
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/aspect-nuances-imperative-infinitive.sources.yaml
+++ b/wiki/grammar/b2/aspect-nuances-imperative-infinitive.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/aspect-nuances-imperative-infinitive.md
+# Source registry for b2/aspect-nuances-imperative-infinitive.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,4 +34,7 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-94 | У піцерії – At the Pizzeria + Sound Changes between Imperfective
+    and Perfective Verbs in Ukrainian
+  url: https://www.ukrainianlessons.com/episode94/
+  domain: ukrainianlessons.com

--- a/wiki/grammar/b2/b2-one-member-sentences.sources.yaml
+++ b/wiki/grammar/b2/b2-one-member-sentences.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/b2-one-member-sentences.md
+# Source registry for b2/b2-one-member-sentences.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,4 +52,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Односкладне речення — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Односкладне_речення
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/complex-syntax-ellipsis-parcelling.sources.yaml
+++ b/wiki/grammar/b2/complex-syntax-ellipsis-parcelling.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/complex-syntax-ellipsis-parcelling.md
+# Source registry for b2/complex-syntax-ellipsis-parcelling.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,4 +46,6 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Бібліотека української літератури УкрЛіб
+  url: https://www.ukrlib.com.ua/
+  domain: ukrlib.com.ua

--- a/wiki/grammar/b2/emphasis-and-inversion.sources.yaml
+++ b/wiki/grammar/b2/emphasis-and-inversion.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/emphasis-and-inversion.md
+# Source registry for b2/emphasis-and-inversion.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -53,4 +53,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Синтаксис української мови — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Синтаксис_української_мови
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/multi-clause-sentences.sources.yaml
+++ b/wiki/grammar/b2/multi-clause-sentences.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/multi-clause-sentences.md
+# Source registry for b2/multi-clause-sentences.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,4 +40,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Синтаксис української мови — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Синтаксис_української_мови
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/parenthetical-expressions.sources.yaml
+++ b/wiki/grammar/b2/parenthetical-expressions.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/parenthetical-expressions.md
+# Source registry for b2/parenthetical-expressions.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,4 +40,6 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Вставне слово — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Вставні_слова
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/register-business-ukrainian.sources.yaml
+++ b/wiki/grammar/b2/register-business-ukrainian.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/register-business-ukrainian.md
+# Source registry for b2/register-business-ukrainian.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,4 +46,6 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Діловодство — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Діловодство
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/stylistic-connectors.sources.yaml
+++ b/wiki/grammar/b2/stylistic-connectors.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/stylistic-connectors.md
+# Source registry for b2/stylistic-connectors.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,4 +52,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Сполучник — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Сполучник
+  domain: uk.wikipedia.org

--- a/wiki/grammar/b2/word-formation-person-suffixes.sources.yaml
+++ b/wiki/grammar/b2/word-formation-person-suffixes.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/grammar/b2/word-formation-person-suffixes.md
+# Source registry for b2/word-formation-person-suffixes.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -40,4 +40,6 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Словотвір — Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Словотвір
+  domain: uk.wikipedia.org

--- a/wiki/mastery/c2/interpretation-advanced.sources.yaml
+++ b/wiki/mastery/c2/interpretation-advanced.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/mastery/c2/interpretation-advanced.md
+# Source registry for c2/interpretation-advanced.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,4 +34,7 @@ sources:
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 2-65 | Повторення + Моя американська мандрівка | Review + My American
+    (Road) Trip
+  url: https://www.ukrainianlessons.com/episode65/
+  domain: ukrainianlessons.com

--- a/wiki/mastery/c2/regional-varieties.sources.yaml
+++ b/wiki/mastery/c2/regional-varieties.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/mastery/c2/regional-varieties.md
+# Source registry for c2/regional-varieties.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -49,4 +49,6 @@ sources:
 - id: S13
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 2-80 | Тест з історії України | Ukrainian History Test – Review 71-79
+  url: https://www.ukrainianlessons.com/episode80/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/around-the-city.sources.yaml
+++ b/wiki/pedagogy/a1/around-the-city.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/around-the-city.md
+# Source registry for a1/around-the-city.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -49,12 +49,18 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: У місті — Around Town Vocabulary in Ukrainian (with Illustrations and Audio)
+  url: https://www.ukrainianlessons.com/vocabulary-town/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Напрямки — Directions in Ukrainian (with Illustrations and Audio)
+  url: https://www.ukrainianlessons.com/vocabulary-directions/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Places & Navigation — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-places/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/at-the-cafe.sources.yaml
+++ b/wiki/pedagogy/a1/at-the-cafe.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/at-the-cafe.md
+# Source registry for a1/at-the-cafe.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,18 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Food — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-food/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: FMU 1-17 | How to PAY at the Restaurant in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu17/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-16 | How to ORDER at the Restaurant in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu16/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/checkpoint-actions.sources.yaml
+++ b/wiki/pedagogy/a1/checkpoint-actions.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/checkpoint-actions.md
+# Source registry for a1/checkpoint-actions.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -52,4 +52,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 'Знахідний відмінок — Accusative Case in Ukrainian: How to Form and Use It'
+  url: https://www.ukrainianlessons.com/accusativecase/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/checkpoint-communication.sources.yaml
+++ b/wiki/pedagogy/a1/checkpoint-communication.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/checkpoint-communication.md
+# Source registry for a1/checkpoint-communication.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,18 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Short and Useful Ukrainian Questions You Should Learn for Your Trip to Ukraine
+  url: https://www.ukrainianlessons.com/useful-ukrainian-questions/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Language & Communication — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-language/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-02 | Useful Phrases for Learning Ukrainian
+  url: https://www.ukrainianlessons.com/fmu2/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/checkpoint-first-contact.sources.yaml
+++ b/wiki/pedagogy/a1/checkpoint-first-contact.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/checkpoint-first-contact.md
+# Source registry for a1/checkpoint-first-contact.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,4 +46,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Noun Genders in Ukrainian — Infographic of Basic Rules and Exceptions
+  url: https://www.ukrainianlessons.com/noun-genders-in-ukrainian/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/checkpoint-places.sources.yaml
+++ b/wiki/pedagogy/a1/checkpoint-places.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/checkpoint-places.md
+# Source registry for a1/checkpoint-places.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -29,11 +29,15 @@ sources:
 - id: S5
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Ukrainian Grammatical Cases
+  url: https://talkukrainian.com/grammatical-cases/
+  domain: talkukrainian.com
 - id: S6
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-32 | Shopping for Clothes – Accusative Case in Ukrainian
+  url: https://www.ukrainianlessons.com/episode32/
+  domain: ukrainianlessons.com
 - id: S8
   file: ukrainian_wiki/checkpoint-places_Педагогіка-A1-Checkpoint-Places-Методичний-підхід
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/checkpoint-time-nature.sources.yaml
+++ b/wiki/pedagogy/a1/checkpoint-time-nature.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/checkpoint-time-nature.md
+# Source registry for a1/checkpoint-time-nature.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,15 +46,21 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 1-32 | Shopping for Clothes – Accusative Case in Ukrainian
+  url: https://www.ukrainianlessons.com/episode32/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-33 | Talking about Books in Ukrainian – Accusative Case of People
+  url: https://www.ukrainianlessons.com/episode33/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-16 | How to ORDER at the Restaurant in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu16/
+  domain: ukrainianlessons.com
 - id: S11
   file: ukrainian_wiki/nature-and-traditions_Граматика-A2-Пори-року-і-свята-Повна-парадигма-Пори-року-Seasons
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/colors.sources.yaml
+++ b/wiki/pedagogy/a1/colors.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/colors.md
+# Source registry for a1/colors.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -33,12 +33,19 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 1-25 | Colors in Ukrainian + Pronunciation Trainer – How to Pronounce
+    P in Ukrainian (Rolled R)
+  url: https://www.ukrainianlessons.com/episode25/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-32 | Shopping for Clothes – Accusative Case in Ukrainian
+  url: https://www.ukrainianlessons.com/episode32/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Clothing — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-clothing/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/emergencies.sources.yaml
+++ b/wiki/pedagogy/a1/emergencies.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/emergencies.md
+# Source registry for a1/emergencies.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -44,4 +44,6 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: How to Say That Something Hurts in Ukrainian
+  url: https://www.ukrainianlessons.com/something-hurts/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/food-and-drink.sources.yaml
+++ b/wiki/pedagogy/a1/food-and-drink.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/food-and-drink.md
+# Source registry for a1/food-and-drink.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,18 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 1-13 | More about Food in Ukrainian
+  url: https://www.ukrainianlessons.com/episode13/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: FMU 1-16 | How to ORDER at the Restaurant in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu16/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Food — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-food/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/free-time.sources.yaml
+++ b/wiki/pedagogy/a1/free-time.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/free-time.md
+# Source registry for a1/free-time.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -50,4 +50,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 1-33 | Talking about Books in Ukrainian – Accusative Case of People
+  url: https://www.ukrainianlessons.com/episode33/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/holidays.sources.yaml
+++ b/wiki/pedagogy/a1/holidays.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/holidays.md
+# Source registry for a1/holidays.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,15 +34,21 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Greetings in Ukrainian for Every Occasion (with Audio Recordings)
+  url: https://www.ukrainianlessons.com/greetings/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 'The Magic of Ukrainian Christmas: From Ancient Rituals to Modern Traditions'
+  url: https://www.verba.school/post/the-magic-of-ukrainian-christmas-from-ancient-rituals-to-modern-traditions
+  domain: verba.school
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Podcast Episodes on Christmas and New Year in Ukrainian
+  url: https://www.ukrainianlessons.com/christmas-new-year-in-ukraine/
+  domain: ukrainianlessons.com
 - id: S9
   file: ukrainian_wiki/holidays_Педагогіка-A1-Holidays-Методичний-підхід
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/how-many.sources.yaml
+++ b/wiki/pedagogy/a1/how-many.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/how-many.md
+# Source registry for a1/how-many.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -58,12 +58,19 @@ sources:
 - id: S10
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: '1, 2-4, 5+: How to Use Nouns After Numbers in Ukrainian [Free Noun–Numeral
+    Agreement Chart]'
+  url: https://www.ukrainianlessons.com/nouns-after-numbers/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-19 | Asking for a Phone Number in Ukrainian
+  url: https://www.ukrainianlessons.com/episode19/
+  domain: ukrainianlessons.com
 - id: S12
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 7 Facts about Ukrainian Money — Hryvnia (+ Ukrainian Grammar Lesson)
+  url: https://www.ukrainianlessons.com/ukrainian-currency/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/i-eat-i-drink.sources.yaml
+++ b/wiki/pedagogy/a1/i-eat-i-drink.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/i-eat-i-drink.md
+# Source registry for a1/i-eat-i-drink.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,15 +34,21 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 'Знахідний відмінок — Accusative Case in Ukrainian: How to Form and Use It'
+  url: https://www.ukrainianlessons.com/accusativecase/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-32 | Shopping for Clothes – Accusative Case in Ukrainian
+  url: https://www.ukrainianlessons.com/episode32/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 1-33 | Talking about Books in Ukrainian – Accusative Case of People
+  url: https://www.ukrainianlessons.com/episode33/
+  domain: ukrainianlessons.com
 - id: S9
   file: ukrainian_wiki/i-eat-i-drink_Педагогіка-A1-I-Eat-I-Drink-Методичний-підхід
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/my-day.sources.yaml
+++ b/wiki/pedagogy/a1/my-day.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/my-day.md
+# Source registry for a1/my-day.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -55,8 +55,12 @@ sources:
 - id: S10
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Reflexive Verbs in Ukrainian (Ending with -СЯ, -СЬ)
+  url: https://www.ukrainianlessons.com/reflexive-verbs/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: FMU 1-58 | How to Describe Your Daily Routine in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu58/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/my-morning.sources.yaml
+++ b/wiki/pedagogy/a1/my-morning.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/my-morning.md
+# Source registry for a1/my-morning.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -22,15 +22,21 @@ sources:
 - id: S5
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-109 | На побаченні – On a Date in Ukrainian + Reflexive Verbs
+  url: https://www.ukrainianlessons.com/episode109/
+  domain: ukrainianlessons.com
 - id: S6
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 23.1 Present Tense of -ся Verbs (First Conjugation) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/23-1/
+  domain: opentext.ku.edu
 - id: S7
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 23.2 Present Tense of -ся Verbs (Second Conjugation) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/23-2/
+  domain: opentext.ku.edu
 - id: S8
   file: ukrainian_wiki/verbs-group-one_Педагогіка-A1-Verbs-Group-One-Послідовність-введення
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/people-around-me.sources.yaml
+++ b/wiki/pedagogy/a1/people-around-me.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/people-around-me.md
+# Source registry for a1/people-around-me.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,18 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 'Знахідний відмінок — Accusative Case in Ukrainian: How to Form and Use It'
+  url: https://www.ukrainianlessons.com/accusativecase/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Ukrainian Personal Pronouns Declension Table
+  url: https://www.ukrainianlessons.com/ukrainian-personal-pronouns/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 1-33 | Talking about Books in Ukrainian – Accusative Case of People
+  url: https://www.ukrainianlessons.com/episode33/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/please-do-this.sources.yaml
+++ b/wiki/pedagogy/a1/please-do-this.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/please-do-this.md
+# Source registry for a1/please-do-this.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,12 +34,21 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: ULP 3-111 | Подарунки на День народження – Birthday Presents + Imperative
+    Mood in Ukrainian
+  url: https://www.ukrainianlessons.com/episode111/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 3-112 | Майстер-клас з приготування вареників – How to Cook Varenyky
+    + Imperative Mood of the Second Person Plural
+  url: https://www.ukrainianlessons.com/episode112/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 3-113 | Майстер-клас з вишивання – Ukrainian Traditional Embroidery Masterclass
+    + More about the Imperative Mood in Ukrainian
+  url: https://www.ukrainianlessons.com/episode113/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/questions.sources.yaml
+++ b/wiki/pedagogy/a1/questions.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/questions.md
+# Source registry for a1/questions.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -45,12 +45,18 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Питальні слова — Question Words in Ukrainian (with Example Sentences)
+  url: https://www.ukrainianlessons.com/question-words/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 'Double Negatives or Double Negation in Ukrainian: 3 Main Rules'
+  url: https://www.ukrainianlessons.com/negation-in-ukrainian/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Short and Useful Ukrainian Questions You Should Learn for Your Trip to Ukraine
+  url: https://www.ukrainianlessons.com/useful-ukrainian-questions/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/reading-ukrainian.sources.yaml
+++ b/wiki/pedagogy/a1/reading-ukrainian.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/reading-ukrainian.md
+# Source registry for a1/reading-ukrainian.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -28,7 +28,9 @@ sources:
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Ukrainian alphabet with pronunciation
+  url: https://talkukrainian.com/ukrainian-alphabet/
+  domain: talkukrainian.com
 - id: S9
   file: ukrainian_wiki/figurative-motion_Звуки-і-літери-Голосні-звуки
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/shopping.sources.yaml
+++ b/wiki/pedagogy/a1/shopping.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/shopping.md
+# Source registry for a1/shopping.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,15 +34,21 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Clothing — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-clothing/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Money — Ukrainian Phrasebook for Helping Refugees
+  url: https://www.ukrainianlessons.com/ph-money/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-18 | Vocabulary Booster! Shopping Vocabulary in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu18/
+  domain: ukrainianlessons.com
 - id: S9
   file: ukrainian_wiki/shopping_Педагогіка-A1-Shopping-Послідовність-введення
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/sounds-letters-and-hello.sources.yaml
+++ b/wiki/pedagogy/a1/sounds-letters-and-hello.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/sounds-letters-and-hello.md
+# Source registry for a1/sounds-letters-and-hello.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -53,8 +53,12 @@ sources:
 - id: S10
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Understanding Ukrainian Cyrillic Alphabet
+  url: https://www.ukrainianlessons.com/ukrainian-cyrillic-alphabet/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Ukrainian alphabet with pronunciation
+  url: https://talkukrainian.com/ukrainian-alphabet/
+  domain: talkukrainian.com

--- a/wiki/pedagogy/a1/special-signs.sources.yaml
+++ b/wiki/pedagogy/a1/special-signs.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/special-signs.md
+# Source registry for a1/special-signs.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,8 +46,12 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Understanding Ukrainian Cyrillic Alphabet
+  url: https://www.ukrainianlessons.com/ukrainian-cyrillic-alphabet/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Ukrainian alphabet with pronunciation
+  url: https://talkukrainian.com/ukrainian-alphabet/
+  domain: talkukrainian.com

--- a/wiki/pedagogy/a1/stress-and-melody.sources.yaml
+++ b/wiki/pedagogy/a1/stress-and-melody.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/stress-and-melody.md
+# Source registry for a1/stress-and-melody.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -47,12 +47,18 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: FMU 1-02 | Useful Phrases for Learning Ukrainian
+  url: https://www.ukrainianlessons.com/fmu2/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: FMU 1-03 | How to Talk to an Uber / Taxi Driver in Ukrainian?
+  url: https://www.ukrainianlessons.com/fmu3/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: FMU 1-04 | Vocabulary Booster! Transport in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu4/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/things-have-gender.sources.yaml
+++ b/wiki/pedagogy/a1/things-have-gender.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/things-have-gender.md
+# Source registry for a1/things-have-gender.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,7 +34,9 @@ sources:
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 1.1 Gender of Nouns – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/1-1/
+  domain: opentext.ku.edu
 - id: S9
   file: ukrainian_wiki/things-have-gender_Педагогіка-A1-Things-Have-Gender-Послідовність-введення
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/this-and-that.sources.yaml
+++ b/wiki/pedagogy/a1/this-and-that.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/this-and-that.md
+# Source registry for a1/this-and-that.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -51,4 +51,6 @@ sources:
 - id: S9
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 'Ukrainian Pronouns ЦЕЙ and ТОЙ: Declension Table'
+  url: https://www.ukrainianlessons.com/pronouns-this-that/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/transport.sources.yaml
+++ b/wiki/pedagogy/a1/transport.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/transport.md
+# Source registry for a1/transport.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -22,7 +22,9 @@ sources:
 - id: S4
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: FMU 1-05 | How to Talk about Transport in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu5/
+  domain: ukrainianlessons.com
 - id: S7
   file: ukrainian_wiki/transport_Педагогіка-A1-Transport-Методичний-підхід
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/verbs-group-one.sources.yaml
+++ b/wiki/pedagogy/a1/verbs-group-one.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/verbs-group-one.md
+# Source registry for a1/verbs-group-one.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -35,11 +35,15 @@ sources:
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 21.1 Present Tense of Verbs (Читати Type) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/21-1/
+  domain: opentext.ku.edu
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 21.2 Present Tense of Verbs (Працювати Type) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/21-2/
+  domain: opentext.ku.edu
 - id: S12
   file: ukrainian_wiki/verbs-group-one_Педагогіка-A1-Verbs-Group-One-Методичний-підхід
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/verbs-group-two.sources.yaml
+++ b/wiki/pedagogy/a1/verbs-group-two.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/verbs-group-two.md
+# Source registry for a1/verbs-group-two.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -45,8 +45,12 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 'Verb Tenses in Ukrainian: Comprehensive Overview Chart'
+  url: https://www.ukrainianlessons.com/ukrainian-tenses/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-24 | What a Surprise! Second Conjugation in Ukrainian
+  url: https://www.ukrainianlessons.com/episode24/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/weather.sources.yaml
+++ b/wiki/pedagogy/a1/weather.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/weather.md
+# Source registry for a1/weather.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -37,4 +37,6 @@ sources:
 - id: S7
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: FMU 1-28 | How to Talk about Weather in Ukrainian
+  url: https://www.ukrainianlessons.com/fmu28/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/what-happened.sources.yaml
+++ b/wiki/pedagogy/a1/what-happened.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/what-happened.md
+# Source registry for a1/what-happened.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -57,8 +57,12 @@ sources:
 - id: S10
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Минулий час — Past Tense in Ukrainian (with Illustrations and Audio)
+  url: https://www.ukrainianlessons.com/grammar-past-tense/
+  domain: ukrainianlessons.com
 - id: S11
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Майбутній час — Future Tense in Ukrainian (Grammar Tables)
+  url: https://www.ukrainianlessons.com/grammar-future/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/what-is-it-like.sources.yaml
+++ b/wiki/pedagogy/a1/what-is-it-like.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/what-is-it-like.md
+# Source registry for a1/what-is-it-like.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,19 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Типові прикметники — Common Ukrainian Adjectives (Useful Table and Audio)
+  url: https://www.ukrainianlessons.com/vocabulary-adjectives/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: Прикметники і прислівники — Adjectives and Adverbs in Ukrainian (with Illustrations
+    and Audio)
+  url: https://www.ukrainianlessons.com/adjectives-and-adverbs/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: 16.1 Adjectives (Gender and Number in Nominative) – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/16-1/
+  domain: opentext.ku.edu

--- a/wiki/pedagogy/a1/what-will-happen.sources.yaml
+++ b/wiki/pedagogy/a1/what-will-happen.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/what-will-happen.md
+# Source registry for a1/what-will-happen.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -34,15 +34,21 @@ sources:
 - id: S6
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Майбутній час — Future Tense in Ukrainian (Grammar Tables)
+  url: https://www.ukrainianlessons.com/grammar-future/
+  domain: ukrainianlessons.com
 - id: S7
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 1-27 | Winter Traveling in Ukraine – More Past Tense
+  url: https://www.ukrainianlessons.com/episode27/
+  domain: ukrainianlessons.com
 - id: S8
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: Майбутній час — Future Tense in Ukrainian (Grammar Tables)
+  url: https://www.ukrainianlessons.com/grammar-future/
+  domain: ukrainianlessons.com
 - id: S9
   file: ukrainian_wiki/my-plans_Педагогіка-A1-My-Plans-Послідовність-введення
   type: ukrainian_wiki

--- a/wiki/pedagogy/a1/where-from.sources.yaml
+++ b/wiki/pedagogy/a1/where-from.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/where-from.md
+# Source registry for a1/where-from.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -46,12 +46,20 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: 10 Uses of the Genitive Case in Ukrainian
+  url: https://www.ukrainianlessons.com/genitive-case/
+  domain: ukrainianlessons.com
 - id: S9
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: ULP 2-46 | У продуктовому магазині + Родовий відмінок | At the Grocery Store
+    + Genitive Case
+  url: https://www.ukrainianlessons.com/episode46/
+  domain: ukrainianlessons.com
 - id: S10
   file: ext-article-2
   type: external
-  title: ext-article-2
+  title: ULP 2-47 | Гастрономічні фестивалі + Родовий відмінок | Food Festivals +
+    Genitive Case
+  url: https://www.ukrainianlessons.com/episode47/
+  domain: ukrainianlessons.com

--- a/wiki/pedagogy/a1/where-to.sources.yaml
+++ b/wiki/pedagogy/a1/where-to.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/where-to.md
+# Source registry for a1/where-to.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S1
@@ -60,4 +60,6 @@ sources:
 - id: S12
   file: ext-article-1
   type: external
-  title: ext-article-1
+  title: 8.2 Accusative Case after the Prepositions в/у, на and про – Добра форма
+  url: https://opentext.ku.edu/dobraforma/chapter/8-2/
+  domain: opentext.ku.edu

--- a/wiki/pedagogy/a1/who-am-i.sources.yaml
+++ b/wiki/pedagogy/a1/who-am-i.sources.yaml
@@ -1,4 +1,4 @@
-# Source registry for wiki/pedagogy/a1/who-am-i.md
+# Source registry for a1/who-am-i.md
 # Referenced inline as [S1], [S2], ...
 sources:
 - id: S2
@@ -40,7 +40,9 @@ sources:
 - id: S8
   file: ext-article-0
   type: external
-  title: ext-article-0
+  title: Polite Phrases in Ukrainian
+  url: https://www.verba.school/post/polite-phrases-in-ukrainian
+  domain: verba.school
 - id: S11
   file: ukrainian_wiki/things-have-gender_Педагогіка-A1-Things-Have-Gender-Деколонізаційні-застереження
   type: ukrainian_wiki


### PR DESCRIPTION
Fixes #2251. Ext-article-N placeholder stubs are now backfilled with real metadata from the ingestion manifest.