### PR TITLE
fix(learner_state): plan-based fallback for not-yet-built module vocab

### DIFF
--- a/scripts/pipeline/learner_state.py
+++ b/scripts/pipeline/learner_state.py
@@ -32,7 +32,7 @@ def _parse_vocab_hint_lemma(entry: str) -> str | None:
 
 
 def _load_planned_vocab(track: str, slug: str) -> list[str]:
-    """Load planned vocabulary lemmas from vocabulary_hints."""
+    """Load planned vocabulary lemmas from plan targets and hints."""
     path = CURRICULUM_ROOT / "plans" / track / f"{slug}.yaml"
     if not path.exists():
         return []
@@ -44,14 +44,6 @@ def _load_planned_vocab(track: str, slug: str) -> list[str]:
         return []
 
     if not isinstance(plan, dict):
-        return []
-
-    hints = plan.get("vocabulary_hints")
-    if isinstance(hints, dict):
-        sections = [hints.get("required", []), hints.get("recommended", [])]
-    elif isinstance(hints, list):
-        sections = [hints]
-    else:
         return []
 
     lemmas: list[str] = []
@@ -79,12 +71,23 @@ def _load_planned_vocab(track: str, slug: str) -> list[str]:
             lemmas.append(lemma)
             seen.add(lemma)
 
-    for section in sections:
+    def add_section(section) -> None:
         if isinstance(section, list):
             for entry in section:
                 add_entry(entry)
         else:
             add_entry(section)
+
+    targets = plan.get("targets")
+    if isinstance(targets, dict):
+        add_section(targets.get("new_vocabulary", []))
+
+    hints = plan.get("vocabulary_hints")
+    if isinstance(hints, dict):
+        add_section(hints.get("required", []))
+        add_section(hints.get("recommended", []))
+    elif isinstance(hints, list):
+        add_section(hints)
 
     return lemmas
 
@@ -92,8 +95,8 @@ def _load_planned_vocab(track: str, slug: str) -> list[str]:
 def _load_vocab(track: str, slug: str) -> list[str]:
     """Load vocabulary lemmas for a module."""
     path = CURRICULUM_ROOT / track / slug / "vocabulary.yaml"
-    built_vocab: list[str] = []
     if path.exists():
+        built_vocab: list[str] = []
         try:
             with open(path, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
@@ -107,8 +110,9 @@ def _load_vocab(track: str, slug: str) -> list[str]:
                     ]
         except Exception:
             built_vocab = []
+        return built_vocab
 
-    return built_vocab or _load_planned_vocab(track, slug)
+    return _load_planned_vocab(track, slug)
 
 
 def _load_grammar(track: str, slug: str) -> list[str]:

--- a/tests/test_learner_state_v7_layout.py
+++ b/tests/test_learner_state_v7_layout.py
@@ -2,6 +2,7 @@
 
 import yaml
 
+from scripts import config
 from scripts.pipeline import learner_state
 
 
@@ -15,17 +16,63 @@ def test_load_vocab_reads_v7_module_layout(tmp_path, monkeypatch):
     _write_yaml(root / "a1" / "module-a" / "vocabulary.yaml", {
         "items": [{"lemma": "тест"}],
     })
+    _write_yaml(root / "plans" / "a1" / "module-a.yaml", {
+        "targets": {"new_vocabulary": ["плановий"]},
+    })
     monkeypatch.setattr(learner_state, "CURRICULUM_ROOT", root)
 
     assert learner_state._load_vocab("a1", "module-a") == ["тест"]
 
 
-def test_load_vocab_missing_file_returns_empty_list(tmp_path, monkeypatch):
+def test_load_vocab_reads_plan_targets_when_built_vocab_is_missing(tmp_path, monkeypatch):
     root = tmp_path / "curriculum" / "l2-uk-en"
-    root.mkdir(parents=True)
+    _write_yaml(root / "plans" / "a1" / "plan-only.yaml", {
+        "targets": {"new_vocabulary": ["план", "ранок"]},
+    })
     monkeypatch.setattr(learner_state, "CURRICULUM_ROOT", root)
 
-    assert learner_state._load_vocab("a1", "missing-module") == []
+    assert learner_state._load_vocab("a1", "plan-only") == ["план", "ранок"]
+
+
+def test_load_vocab_merges_plan_targets_required_and_recommended(tmp_path, monkeypatch):
+    root = tmp_path / "curriculum" / "l2-uk-en"
+    _write_yaml(root / "plans" / "a1" / "merged-plan.yaml", {
+        "targets": {"new_vocabulary": ["план", "ранок"]},
+        "vocabulary_hints": {
+            "required": ["ранок (morning)", "кава (coffee)"],
+            "recommended": ["після цього (after this)"],
+        },
+    })
+    monkeypatch.setattr(learner_state, "CURRICULUM_ROOT", root)
+
+    assert learner_state._load_vocab("a1", "merged-plan") == [
+        "план",
+        "ранок",
+        "кава",
+        "після цього",
+    ]
+
+
+def test_load_vocab_reads_required_hints_when_targets_are_missing(tmp_path, monkeypatch):
+    root = tmp_path / "curriculum" / "l2-uk-en"
+    _write_yaml(root / "plans" / "a1" / "hint-only.yaml", {
+        "vocabulary_hints": {
+            "required": ["вікно (window)", "двері (door)"],
+        },
+    })
+    monkeypatch.setattr(learner_state, "CURRICULUM_ROOT", root)
+
+    assert learner_state._load_vocab("a1", "hint-only") == ["вікно", "двері"]
+
+
+def test_load_vocab_plan_without_vocab_returns_empty_list(tmp_path, monkeypatch):
+    root = tmp_path / "curriculum" / "l2-uk-en"
+    _write_yaml(root / "plans" / "a1" / "no-vocab.yaml", {
+        "title": "No vocabulary here",
+    })
+    monkeypatch.setattr(learner_state, "CURRICULUM_ROOT", root)
+
+    assert learner_state._load_vocab("a1", "no-vocab") == []
 
 
 def test_build_learner_state_accumulates_only_previous_modules(tmp_path, monkeypatch):
@@ -60,6 +107,36 @@ def test_build_learner_state_accumulates_only_previous_modules(tmp_path, monkeyp
 
     assert state["cumulative_vocabulary"] == ["тест", "слово"]
     assert "зайве" not in state["cumulative_vocabulary"]
+
+
+def test_compute_immersion_band_uses_plan_only_learner_state(tmp_path, monkeypatch):
+    root = tmp_path / "curriculum" / "l2-uk-en"
+    slugs = [f"module-{index:02d}" for index in range(1, 21)]
+    _write_yaml(root / "curriculum.yaml", {
+        "levels": {"a1": {"modules": slugs}},
+    })
+    for module_index, slug in enumerate(slugs[:19], start=1):
+        _write_yaml(root / "plans" / "a1" / f"{slug}.yaml", {
+            "targets": {
+                "new_vocabulary": [
+                    f"слово-{module_index:02d}-{word_index:02d}"
+                    for word_index in range(1, 9)
+                ],
+            },
+        })
+    monkeypatch.setattr(learner_state, "CURRICULUM_ROOT", root)
+    monkeypatch.setattr(config, "USE_ULP_IMMERSION_DERIVATION", True)
+
+    state = learner_state.build_learner_state("a1", 20)
+    band = config.compute_immersion_band("a1", 20, learner_state=state)
+
+    assert state["cumulative_vocabulary"] == [
+        f"слово-{module_index:02d}-{word_index:02d}"
+        for module_index in range(1, 20)
+        for word_index in range(1, 9)
+    ]
+    assert band["key"] == "a1-m04-06"
+    assert (band["advisory_pct_min"], band["advisory_pct_max"]) == (8, 30)
 
 
 def test_format_learner_state_contains_rule_footer_for_non_empty_state():


### PR DESCRIPTION
## Summary
- Prefer built V7 `vocabulary.yaml` artifacts when present, preserving the #2211 path-layout fix behavior.
- Extend the not-yet-built fallback to read `plan.targets.new_vocabulary`, `vocabulary_hints.required`, and `vocabulary_hints.recommended` in order with de-duplication.
- Add synthetic coverage for built artifacts, plan-only targets, hint-only plans, empty plans, and `compute_immersion_band()` consuming plan-only learner state.

Related history: PR #2211 fixed the V7 learner-state vocabulary artifact path. This PR keeps built artifacts authoritative and closes the remaining drift for modules that have not produced `curriculum/l2-uk-en/{track}/{slug}/vocabulary.yaml` yet.

Closes #2210.

## Verifiable claims
- Drift is closed: `test_load_vocab_reads_plan_targets_when_built_vocab_is_missing` constructs a synthetic plan with `targets.new_vocabulary: ["план", "ранок"]` and no built `vocabulary.yaml`, then asserts `_load_vocab("a1", "plan-only") == ["план", "ранок"]`.
- `compute_immersion_band` uses the new source: `test_compute_immersion_band_uses_plan_only_learner_state` builds synthetic plan-only m01-m19 state, asserts the exact 152-item cumulative list, and asserts derived band `a1-m04-06` with advisory `8-30`.
- No regression on built modules: `test_load_vocab_reads_v7_module_layout` writes both a built artifact lemma `тест` and a plan target `плановий`, then asserts `_load_vocab(...) == ["тест"]`.

## Validation
```text
.venv/bin/python -m pytest tests/test_learner_state* -q
18 passed in 0.59s
```

```text
.venv/bin/python -m pytest tests/test_compute_immersion_band.py tests/test_ulp_immersion_calibration.py -q
21 passed in 0.18s
```

```text
.venv/bin/ruff check scripts tests
All checks passed!
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Smoke test
```text
synthetic_modules_completed=19
synthetic_cumulative_vocab_count=152
first_vocab=['слово-01-01', 'слово-01-02', 'слово-01-03']
last_vocab=['слово-19-06', 'слово-19-07', 'слово-19-08']
band=a1-m04-06 advisory=8-30 min_dialogue=10
```

Current A1 m01-m19 data check: all 19 prior modules resolve vocabulary from plan sources in this checkout, and actual `build_learner_state("a1", 20)` returns 295 unique cumulative vocab items.