### PR TITLE
fix(v7): harden generated module plumbing

### DIFF
--- a/scripts/agent_runtime/tool_calls.py
+++ b/scripts/agent_runtime/tool_calls.py
@@ -228,6 +228,7 @@ def _is_tool_result_payload(payload: Mapping[str, Any]) -> bool:
         "tool_output",
         "function_result",
         "function_call_output",
+        "mcp_tool_call_end",
     } or (
         any(key in payload for key in ("tool_use_id", "tool_call_id", "call_id"))
         and any(key in payload for key in ("content", "output", "result"))
@@ -287,7 +288,32 @@ def _coerce_arguments(value: Any) -> dict[str, Any]:
 def _tool_output(payload: Mapping[str, Any]) -> Any:
     for key in ("output", "result", "content", "observation"):
         if key in payload:
-            return payload.get(key)
+            return _coerce_tool_output(payload.get(key))
+    return None
+
+
+def _coerce_tool_output(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    parsed = _parse_codex_output_envelope(value)
+    return parsed if parsed is not None else value
+
+
+def _parse_codex_output_envelope(value: str) -> Any | None:
+    """Decode Codex CLI ``function_call_output`` wrappers when possible."""
+    candidates = [value.strip()]
+    marker = "\nOutput:\n"
+    if marker in value:
+        candidates.insert(0, value.split(marker, 1)[1].strip())
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, (dict, list)):
+            return parsed
     return None
 
 

--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -55,6 +55,54 @@ _INLINE_FIELD_RE = re.compile(
     r"(?=\s*[;|]\s*(?:obligation_id|artifact|location|treatment)\s*:|\s*$)",
     re.IGNORECASE,
 )
+_COMPACT_PIPE_ENTRY_RE = re.compile(
+    r"(?:^|\s)(?:\|\s*)?(?P<id>[-\w]+)\s*\|\s*"
+    r"(?P<artifact>module\.md|activities\.yaml)\s*\|\s*"
+    r"(?P<location>[^|<\n]+?)\s*\|\s*"
+    r"(?P<treatment>.*?)(?=\s+(?:\|\s*)?[-\w]+\s*\|\s*(?:module\.md|activities\.yaml)\s*\||\s*$)",
+    re.IGNORECASE | re.DOTALL,
+)
+_WORKBOOK_AGGREGATE_ACTIVITY_TYPES = (
+    "anagram",
+    "authorial-intent",
+    "cloze",
+    "comparative-study",
+    "count-syllables",
+    "critical-analysis",
+    "debate",
+    "dialect-comparison",
+    "divide-words",
+    "error-correction",
+    "essay-response",
+    "etymology-trace",
+    "fill-in",
+    "grammar-identify",
+    "group-sort",
+    "highlight-morphemes",
+    "mark-the-words",
+    "match-up",
+    "multiple-choice",
+    "observe",
+    "odd-one-out",
+    "order",
+    "paleography-analysis",
+    "phrase-table",
+    "pick-syllables",
+    "quiz",
+    "reading",
+    "source-evaluation",
+    "transcription",
+    "translate",
+    "translation-critique",
+    "true-false",
+    "unjumble",
+)
+_WORKBOOK_AGGREGATE_LOCATION_RE = re.compile(
+    r"^workbook\b.*\b("
+    + "|".join(re.escape(activity_type) for activity_type in _WORKBOOK_AGGREGATE_ACTIVITY_TYPES)
+    + r")\b",
+    re.IGNORECASE,
+)
 
 
 def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
@@ -97,6 +145,14 @@ def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
     entries: dict[str, dict[str, str]] = {}
     for match in matches:
         body = match.group("body")
+        for pipe_match in _COMPACT_PIPE_ENTRY_RE.finditer(body):
+            obligation_id = pipe_match.group("id").strip()
+            entries[obligation_id] = {
+                "obligation_id": obligation_id,
+                "artifact": pipe_match.group("artifact").strip(),
+                "location": pipe_match.group("location").strip(),
+                "treatment": pipe_match.group("treatment").strip().rstrip("|").strip(),
+            }
         current_id: str | None = None
         for line in body.splitlines():
             id_match = _OBLIGATION_RE.search(line)
@@ -549,7 +605,13 @@ def _activity_text(activities: list[dict[str, Any]], location: str) -> str:
         return "\n".join(s for activity in activities for s in _flatten_strings(activity))
 
     location_cf = location.casefold().strip()
-    if location_cf in {"activities.yaml", "all", "any", "(any)", "(any activity)"}:
+    if location_cf in {
+        "activities.yaml",
+        "all",
+        "any",
+        "(any)",
+        "(any activity)",
+    } or _WORKBOOK_AGGREGATE_LOCATION_RE.search(location_cf):
         return "\n".join(s for activity in activities for s in _flatten_strings(activity))
 
     for activity in activities:

--- a/scripts/build/activity_renderer.py
+++ b/scripts/build/activity_renderer.py
@@ -389,8 +389,8 @@ def _render_grammar_identify(act: dict) -> str:
     items = []
     for item in act.get("items", []):
         items.append({
-            "text": item.get("word", ""),
-            "form": item.get("task", ""),
+            "text": item.get("text") or item.get("sentence") or item.get("word", ""),
+            "form": item.get("form") or item.get("task") or act.get("instruction", ""),
             "answer": item.get("answer", ""),
         })
 
@@ -459,6 +459,8 @@ def _render_highlight_morphemes(act: dict) -> str:
             {"text": m.get("text", ""), "type": m.get("type", "")}
             for m in item.get("morphemes", [])
         ]
+        if not morphemes and item.get("answer"):
+            morphemes = [{"text": item["answer"], "type": item.get("type", "suffix")}]
         items.append({
             "word": item.get("word", ""),
             "morphemes": morphemes,
@@ -538,9 +540,13 @@ def _render_odd_one_out(act: dict) -> str:
     """odd-one-out → <OddOneOut items={[...]} />"""
     items = []
     for item in act.get("items", []):
+        words = item.get("words") or item.get("options", [])
+        correct = item.get("correct", 0)
+        if item.get("answer") in words:
+            correct = words.index(item["answer"])
         entry = {
-            "words": item.get("words", []),
-            "correct": item.get("correct", 0),
+            "words": words,
+            "correct": correct,
             "explanation": item.get("explanation", ""),
         }
         items.append(entry)

--- a/scripts/build/citation_matcher.py
+++ b/scripts/build/citation_matcher.py
@@ -50,7 +50,7 @@ _CYRILLIC_TO_LATIN = str.maketrans(
 
 _PAGE_RE = re.compile(
     r"(?i)(?:\bp\.?\s*|\bpage\s+|[сc]\.?\s*|\bстор\.?\s*|"
-    r"\bсторінка\s+)(\d+)\b"
+    r"\bсторінка\s+)(?P<page>\d+)(?:\s*[-–—]\s*(?P<page_end>\d+))?\b"
 )
 
 
@@ -59,6 +59,7 @@ class CitationKey:
     author: str
     grade: int
     page: int
+    page_end: int | None = None
 
 
 def normalize_citation_ref(value: Any) -> str:
@@ -102,14 +103,19 @@ def extract_citation_key(value: Any) -> CitationKey | None:
     if len(page_matches) != 1:
         return None
     page_match = page_matches[0]
-    if text[page_match.end() : page_match.end() + 1] in {"-", "–", "—"}:
+    if re.match(r"\s*[-–—]", text[page_match.end() :]):
+        return None
+    page = int(page_match.group("page"))
+    page_end_text = page_match.group("page_end")
+    page_end = int(page_end_text) if page_end_text is not None else None
+    if page_end is not None and page_end < page:
         return None
 
     author = fold_citation_author(author_match.group(0))
     if not author:
         return None
     grade = int(next(group for group in grade_match.groups() if group is not None))
-    return CitationKey(author=author, grade=grade, page=int(page_match.group(1)))
+    return CitationKey(author=author, grade=grade, page=page, page_end=page_end)
 
 
 def fold_citation_author(author: str) -> str:
@@ -149,8 +155,15 @@ def citation_keys_match(
     *,
     page_tolerance: int = 5,
 ) -> bool:
+    citation_start, citation_end = _page_bounds(citation)
+    plan_start, plan_end = _page_bounds(plan_reference)
     return (
         citation.author == plan_reference.author
         and citation.grade == plan_reference.grade
-        and abs(citation.page - plan_reference.page) <= page_tolerance
+        and citation_start <= plan_end + page_tolerance
+        and plan_start <= citation_end + page_tolerance
     )
+
+
+def _page_bounds(citation: CitationKey) -> tuple[int, int]:
+    return citation.page, citation.page_end if citation.page_end is not None else citation.page

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -1,3 +1,8 @@
+You are reviewing one quality dimension for the generated module below.
+Return ONLY the JSON object described in the response format. Do not ask for
+clarification, do not summarize the prompt, and do not emit prose outside the
+JSON object.
+
 {NORTH_STAR}
 
 {LESSON_CONTRACT}
@@ -256,3 +261,8 @@ them to know what to fix on retry.
 ## Generated Content
 
 {GENERATED_CONTENT}
+
+## Task
+
+Review the assigned dimension `{DIM}` and return the required JSON object now.
+No preamble, no markdown, no questions.

--- a/scripts/build/phases/linear-review-wiki-coverage.md
+++ b/scripts/build/phases/linear-review-wiki-coverage.md
@@ -1,3 +1,8 @@
+You are reviewing wiki-obligation coverage for the generated module below.
+Return ONLY the JSON object described in "Response Format — STRICT". Do not
+ask for clarification, do not summarize the prompt, and do not emit prose
+outside the JSON object.
+
 {NORTH_STAR}
 
 {LESSON_CONTRACT}
@@ -166,3 +171,8 @@ Mixed-verdict shape:
 ## Generated Content
 
 {GENERATED_CONTENT}
+
+## Task
+
+Review every obligation in the manifest against the generated content and
+return the required JSON object now. No preamble, no markdown, no questions.

--- a/scripts/build/phases/linear-write-grok.md
+++ b/scripts/build/phases/linear-write-grok.md
@@ -39,6 +39,18 @@ Every signature listed here is a commitment to call that exact tool this turn; o
 
 Keep the whole `<plan_thinking>` block to 150 words or fewer. Do not use triple backticks inside `<plan_thinking>`; fenced code belongs only in the four artifact blocks below.
 
+Before artifact fences, emit these three audit lines in this exact order:
+
+1. `<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[<deferred IDs>]</implementation_map_audit>`
+2. `<bad_form_audit>italic_bad_form_patterns_found=N converted_to_marker=N remaining=0</bad_form_audit>`
+3. `<activity_split_audit>level={LEVEL} inline_n=N workbook_n=N inline_range=[lo,hi] workbook_range=[lo,hi] split_valid=true|false</activity_split_audit>`
+
+If `M < N`, stop and fix the map before writing artifacts. If
+`bad_form_audit.remaining` is not `0`, convert every remaining italic/bare
+bad-form contrast to `<!-- bad -->...<!-- /bad -->` before writing artifacts.
+If `activity_split_audit.split_valid=false`, rebalance inline vs workbook
+activities before writing artifacts.
+
 Only after `<plan_thinking>` is complete and passed may you emit the four fenced artifact blocks.
 
 ## Tier-1 verification discipline (do this WHILE drafting — #1661)

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -45,26 +45,32 @@ authoring artifacts: `module.md`, `activities.yaml`, `vocabulary.yaml`, and
 
 ## Mandatory visible verification block (emit BEFORE drafting — #1673/#1661)
 
-Before the four artifact fences, emit one `<plan_reasoning section="...">...</plan_reasoning>` block per contracted section. Keep each block <=200 words.
+Emit one `<plan_reasoning section="...">...</plan_reasoning>` block per section (<=200 words).
 
 Each `<plan_reasoning>` block MUST contain these exact XML sub-nodes (do not write a single blob of prose):
 
-<word_budget>Section word allocation and running total check against {WORD_TARGET} (gate tolerates 8% lower band per scripts/build/linear_pipeline.py::_word_count_gate).</word_budget>
-<plan_vocab>Required plan-vocabulary lemmas used in this section, with the exact Ukrainian sentence that grounds each lemma.</plan_vocab>
-<register>The immersion ratio from the Immersion Rule and how this section preserves it.</register>
+<word_budget>Section word allocation and running total vs {WORD_TARGET}.</word_budget>
+<plan_vocab>Required plan-vocabulary lemmas used here, with the grounding Ukrainian sentence.</plan_vocab>
+<register>Immersion ratio from the Immersion Rule and how this section preserves it.</register>
 <teaching_sequence>Which Knowledge Packet facts/citations this section uses.</teaching_sequence>
 <implementation_map>
 <!-- rule_id: #R-IMPL-MAP-COMPLETE -->
-List every `obligation_id` exactly once across all section blocks with: obligation_id, artifact, location, treatment. Silent omission causes `implementation_map_missing` hard failure. If a row truly cannot fit A1 scope, emit artifact/location `<none>` and treatment `deferred (out of A1 scope) — <one-sentence justification>`.
+List every `obligation_id` exactly once: obligation_id, artifact, location, treatment. Omission causes `implementation_map_missing`. If a row cannot fit A1 scope, emit artifact/location `<none>` and treatment `deferred — <why>`.
 </implementation_map>
-<verification_plan>Specific MCP tools to be called for this section's claims.</verification_plan>
-<verification_trace>Exact tool call signatures you will actually make; omit speculative examples.</verification_trace>
+<verification_plan>MCP tools to call for this section's claims.</verification_plan>
+<verification_trace>Exact tool call signatures; omit speculative examples.</verification_trace>
 
-Prefer single-call primitives for verification: `verify_quote`, `verify_source_attribution`, `check_modern_form`, `check_russian_shadow`. Use search tools when you need evidence chunks to quote.
+Prefer single-call verification: `verify_quote`, `verify_source_attribution`, `check_modern_form`, `check_russian_shadow`. Search for quote evidence.
 
-Before artifact fences, emit:
-`<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[<deferred IDs>]</implementation_map_audit>`
-If `M < N`, stop and fix the map before writing artifacts.
+Emit audit lines in order:
+
+1. `<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[<deferred IDs>]</implementation_map_audit>`
+2. `<bad_form_audit>italic_bad_form_patterns_found=N converted_to_marker=N remaining=0</bad_form_audit>`
+3. `<activity_split_audit>level={LEVEL} inline_n=N workbook_n=N inline_range=[lo,hi] workbook_range=[lo,hi] split_valid=true|false</activity_split_audit>`
+
+If `M < N`, fix the map before artifacts. If `bad_form_audit.remaining != 0`,
+convert remaining italic/bare bad forms to `<!-- bad -->...<!-- /bad -->`.
+If `activity_split_audit.split_valid=false`, rebalance inline/workbook first.
 
 ## Tier-1 verification discipline (do this WHILE drafting — #1661)
 

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -641,15 +641,41 @@ def _writer_prompt(
     )
 
 
+_PRE_EMIT_AUDIT_LINE_RE = re.compile(
+    r"<(?P<tag>implementation_map_audit|bad_form_audit|activity_split_audit)\b"
+    r"[^>]*>.*?</(?P=tag)>",
+    re.DOTALL,
+)
+
+
+def _writer_preemit_audit_context(module_dir: Path) -> str:
+    path = module_dir / "writer_output.raw.md"
+    if not path.exists():
+        return ""
+    raw_output = path.read_text(encoding="utf-8")
+    lines = [
+        " ".join(match.group(0).split())
+        for match in _PRE_EMIT_AUDIT_LINE_RE.finditer(raw_output)
+    ]
+    if not lines:
+        return ""
+    return "## writer_output.raw.md pre-emit audit lines\n\n" + "\n".join(lines)
+
+
 def _generated_content(module_dir: Path) -> str:
     parts = []
+    audit_context = _writer_preemit_audit_context(module_dir)
+    if audit_context:
+        parts.append(audit_context)
     for artifact in linear_pipeline.WRITER_ARTIFACTS:
         path = module_dir / artifact
         parts.append(f"## {artifact}\n\n{path.read_text(encoding='utf-8')}")
     return "\n\n".join(parts)
 
 
-def _reviewer_for_writer(writer: str) -> str:
+def _reviewer_for_writer(writer: str, reviewer_override: str | None = None) -> str:
+    if reviewer_override:
+        return _normalize_writer(reviewer_override)
     if writer == "claude-tools":
         return "gemini-tools"
     if writer == "grok-tools":
@@ -669,11 +695,12 @@ def _run_llm_qg(
     plan_content: str,
     module_dir: Path,
     writer: str,
+    reviewer_override: str | None = None,
     stdout_silence_timeout: int | None = None,
 ) -> dict[str, Any]:
     from scripts.agent_runtime.runner import invoke
 
-    reviewer = _reviewer_for_writer(writer)
+    reviewer = _reviewer_for_writer(writer, reviewer_override)
     defaults = linear_pipeline.REVIEWER_DEFAULTS[reviewer]
 
     assert linear_pipeline.WRITER_DEFAULTS[writer]["model"] != defaults["model"], \
@@ -722,13 +749,14 @@ def _run_wiki_coverage_review(
     plan_content: str,
     module_dir: Path,
     writer: str,
+    reviewer_override: str | None = None,
     wiki_manifest: str | Mapping[str, Any],
     wiki_coverage_gate: Mapping[str, Any],
     stdout_silence_timeout: int | None = None,
 ) -> dict[str, Any]:
     from scripts.agent_runtime.runner import invoke
 
-    reviewer = _reviewer_for_writer(writer)
+    reviewer = _reviewer_for_writer(writer, reviewer_override)
     defaults = linear_pipeline.REVIEWER_DEFAULTS[reviewer]
 
     assert linear_pipeline.WRITER_DEFAULTS[writer]["model"] != defaults["model"], \
@@ -836,6 +864,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Writer backend for the one-shot V7 write phase "
             "(default: claude-tools; claude/gemini/codex/grok/deepseek/qwen/agy "
             "aliases normalize to <name>-tools)."
+        ),
+    )
+    parser.add_argument(
+        "--reviewer",
+        choices=WRITER_CHOICES,
+        default=None,
+        help=(
+            "Override the reviewer backend for wiki coverage review and LLM QG. "
+            "Defaults to the pipeline's writer-specific reviewer routing; aliases "
+            "normalize to <name>-tools."
         ),
     )
     parser.add_argument(
@@ -996,6 +1034,7 @@ def _run(args: argparse.Namespace) -> int:
     level = args.level.lower()
     slug = args.slug
     writer = _normalize_writer(args.writer)
+    reviewer_override = _normalize_writer(args.reviewer) if args.reviewer else None
     module_started_at = time.monotonic()
     phase = "start"
     timeout_agent = writer
@@ -1249,7 +1288,7 @@ def _run(args: argparse.Namespace) -> int:
 
         phase = "wiki_coverage_review"
         _phase_started(archive, phase)
-        timeout_agent = _reviewer_for_writer(writer)
+        timeout_agent = _reviewer_for_writer(writer, reviewer_override)
         started_at = time.monotonic()
         if (
             resume_enabled
@@ -1266,6 +1305,7 @@ def _run(args: argparse.Namespace) -> int:
                 plan_content=plan_content,
                 module_dir=module_dir,
                 writer=writer,
+                reviewer_override=reviewer_override,
                 wiki_manifest=wiki_manifest,
                 wiki_coverage_gate=wiki_coverage_gate,
                 stdout_silence_timeout=args.writer_timeout,
@@ -1308,7 +1348,7 @@ def _run(args: argparse.Namespace) -> int:
 
         phase = "llm_qg"
         _phase_started(archive, phase)
-        timeout_agent = _reviewer_for_writer(writer)
+        timeout_agent = _reviewer_for_writer(writer, reviewer_override)
         started_at = time.monotonic()
         if (
             resume_enabled
@@ -1325,6 +1365,7 @@ def _run(args: argparse.Namespace) -> int:
                 plan_content=plan_content,
                 module_dir=module_dir,
                 writer=writer,
+                reviewer_override=reviewer_override,
                 stdout_silence_timeout=args.writer_timeout,
             )
             linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)

--- a/scripts/yaml_activities.py
+++ b/scripts/yaml_activities.py
@@ -977,9 +977,13 @@ class ActivityParser:
     def _parse_grammar_identify(self, data: dict) -> GrammarIdentifyActivity:
         items = []
         for item_data in data.get('items', []):
+            form = item_data.get('form') or item_data.get('task') or data.get('instruction', '')
+            text = item_data.get('text') or item_data.get('sentence') or item_data.get('word')
+            if text is None:
+                raise ValueError("grammar-identify item requires text, sentence, or word")
             items.append(GrammarIdentifyItem(
-                text=item_data['text'],
-                form=item_data['form'],
+                text=text,
+                form=form,
                 answer=item_data['answer']
             ))
         return GrammarIdentifyActivity(
@@ -1203,6 +1207,12 @@ class ActivityParser:
                     morpheme=str(item['morpheme']),
                     type=str(item.get('type', 'unknown')),
                 ))
+            elif item.get('answer'):
+                morphemes.append(HighlightMorphemeItem(
+                    word=word,
+                    morpheme=str(item['answer']),
+                    type=str(item.get('type', 'suffix')),
+                ))
             else:
                 raise ValueError("highlight-morphemes item requires morphemes")
         if not morphemes:
@@ -1238,18 +1248,21 @@ class ActivityParser:
     def _parse_odd_one_out(self, data: dict) -> OddOneOutActivity:
         items = []
         for item in data.get('items', []):
-            if not isinstance(item.get('words'), list) or not item['words']:
+            words = item.get('words') or item.get('options')
+            if not isinstance(words, list) or not words:
                 raise ValueError("odd-one-out item requires non-empty words list")
             correct = item.get('correct')
+            if correct is None and item.get('answer') in words:
+                correct = words.index(item['answer'])
             if not isinstance(correct, int):
                 raise TypeError("odd-one-out item correct must be an integer")
-            if correct < 0 or correct >= len(item['words']):
+            if correct < 0 or correct >= len(words):
                 raise ValueError("odd-one-out item correct index out of range")
             explanation = item.get('explanation')
             if not isinstance(explanation, str) or not explanation.strip():
                 raise ValueError("odd-one-out item requires explanation")
             items.append(OddOneOutItem(
-                words=[str(word) for word in item['words']],
+                words=[str(word) for word in words],
                 correct=correct,
                 explanation=explanation,
             ))

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from scripts.audit.wiki_coverage_gate import check_wiki_coverage
+from scripts.audit.wiki_coverage_gate import check_wiki_coverage, parse_implementation_map
 from scripts.build.phases.implementation_map import seed_implementation_map
 
 BAN_1_RULE = (
@@ -556,6 +556,122 @@ def test_l2_error_resolves_via_bare_activities_yaml_location() -> None:
         f"err-2 must PASS when the writer's location equals the seeded "
         f"bare-artifact hint and the contrast pair is present anywhere "
         f"in activities.yaml; got reason={err_result['reason']!r}"
+    )
+
+
+def test_parse_implementation_map_accepts_compact_pipe_rows_on_same_line() -> None:
+    """Codex sometimes emits compact implementation-map rows without
+    ``obligation_id:`` labels. The parser must still recognize every row,
+    even when multiple rows share one ``<implementation_map>`` line."""
+    implementation_map = (
+        "<implementation_map>"
+        "err-1 | activities.yaml | workbook error-correction | first contrast. "
+        "err-2 | activities.yaml | workbook error-correction | second contrast. "
+        "ban-1 | module.md | §Intro | absence of banned framing."
+        "</implementation_map>"
+    )
+
+    parsed = parse_implementation_map(implementation_map)
+
+    assert parsed["err-1"]["artifact"] == "activities.yaml"
+    assert parsed["err-1"]["location"] == "workbook error-correction"
+    assert parsed["err-2"]["treatment"] == "second contrast."
+    assert parsed["ban-1"]["artifact"] == "module.md"
+
+
+def test_parse_implementation_map_accepts_compact_markdown_table_rows() -> None:
+    implementation_map = """
+<implementation_map>
+| err-1 | activities.yaml | workbook error-correction | first contrast. |
+| err-2 | activities.yaml | workbook fill-in review | second contrast. |
+| ban-1 | module.md | §Intro | absence of banned framing. |
+</implementation_map>
+"""
+
+    parsed = parse_implementation_map(implementation_map)
+
+    assert parsed["err-1"]["artifact"] == "activities.yaml"
+    assert parsed["err-1"]["treatment"] == "first contrast."
+    assert parsed["err-2"]["location"] == "workbook fill-in review"
+    assert parsed["err-2"]["treatment"] == "second contrast."
+    assert parsed["ban-1"]["artifact"] == "module.md"
+
+
+def test_l2_error_passes_with_compact_pipe_workbook_location() -> None:
+    """The compact Codex pipe-map shape plus a generic workbook location
+    should widen to all activities, then let the substance check decide."""
+    manifest = _phonetic_l2_error_manifest()
+    activities_yaml = (
+        "- type: error-correction\n"
+        "  title: Редагування типових помилок\n"
+        "  items:\n"
+        "    - sentence: 'Вимова: [прокидайешся]'\n"
+        "      error: 'Вимова: [прокидайешся]'\n"
+        "      correction: \"Вимова: [прокидайес':а]\"\n"
+        "      explanation: assimilation rule.\n"
+    )
+    implementation_map = (
+        "<implementation_map>"
+        "err-2 | activities.yaml | workbook error-correction | sentence/error/correction contrast."
+        "</implementation_map>"
+    )
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="# Module body unrelated to err-2.\n",
+        activities_yaml=activities_yaml,
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    err_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "err-2"
+    )
+    assert err_result["status"] == "PASS", (
+        f"err-2 must PASS from compact pipe-map claim when the workbook "
+        f"activity contains the contrast pair; got reason={err_result['reason']!r}"
+    )
+
+
+def test_l2_error_widens_for_any_workbook_aggregate_activity_type() -> None:
+    """Workbook aggregate map locations name practice buckets, not stable ids.
+
+    The resolver should therefore widen all ``workbook <type>`` references for
+    known workbook activity types, not only the original error-correction case.
+    The obligation substance check still decides whether the widened text is
+    sufficient.
+    """
+    manifest = _phonetic_l2_error_manifest()
+    activities_yaml = (
+        "- type: error-correction\n"
+        "  title: Comprehensive contrast review\n"
+        "  items:\n"
+        "    - sentence: 'Вимова: [прокидайешся]'\n"
+        "      error: 'Вимова: [прокидайешся]'\n"
+        "      correction: \"Вимова: [прокидайес':а]\"\n"
+        "      explanation: assimilation rule.\n"
+    )
+    implementation_map = (
+        "<implementation_map>"
+        "err-2 | activities.yaml | workbook fill-in review | contrast in workbook bucket."
+        "</implementation_map>"
+    )
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="# Module body unrelated to err-2.\n",
+        activities_yaml=activities_yaml,
+        seeded_map=seed_implementation_map(manifest),
+    )
+
+    err_result = next(
+        item for item in report["obligations"] if item["obligation_id"] == "err-2"
+    )
+    assert err_result["status"] == "PASS", (
+        f"err-2 must PASS when a known workbook aggregate type widens to the "
+        f"activity text and the contrast pair is present; got "
+        f"reason={err_result['reason']!r}"
     )
 
 

--- a/tests/test_activity_renderer.py
+++ b/tests/test_activity_renderer.py
@@ -251,6 +251,53 @@ class TestGrammarIdentify:
         assert parsed[0]["text"] == "стіл"
         assert parsed[0]["form"] == "Визначте рід"
 
+    def test_sentence_alias_mapping(self):
+        act = {
+            "type": "grammar-identify",
+            "instruction": "Визначте модель порівняння.",
+            "items": [{"sentence": "Петро вищий за Марію.", "answer": "за + знахідний"}],
+        }
+        jsx = render_activity_to_jsx(act)
+        parsed = _extract_prop(jsx, "items")
+        assert parsed[0]["text"] == "Петро вищий за Марію."
+        assert parsed[0]["form"] == "Визначте модель порівняння."
+
+
+class TestOddOneOut:
+    def test_options_answer_alias_mapping(self):
+        act = {
+            "type": "odd-one-out",
+            "instruction": "Оберіть зайве.",
+            "items": [
+                {
+                    "options": ["сильніший", "молодший", "більш цікавий", "дорожчий"],
+                    "answer": "більш цікавий",
+                    "explanation": "Це складена форма, решта прості.",
+                },
+            ],
+        }
+        jsx = render_activity_to_jsx(act)
+        parsed = _extract_prop(jsx, "items")
+        assert parsed[0]["words"] == [
+            "сильніший",
+            "молодший",
+            "більш цікавий",
+            "дорожчий",
+        ]
+        assert parsed[0]["correct"] == 2
+
+
+class TestHighlightMorphemes:
+    def test_answer_alias_mapping(self):
+        act = {
+            "type": "highlight-morphemes",
+            "instruction": "Позначте суфікс.",
+            "items": [{"word": "сильніший", "answer": "-іш-"}],
+        }
+        jsx = render_activity_to_jsx(act)
+        parsed = _extract_prop(jsx, "items")
+        assert parsed[0]["morphemes"] == [{"text": "-іш-", "type": "suffix"}]
+
 
 class TestObserve:
     def test_basic(self):

--- a/tests/test_agent_runtime_tool_calls.py
+++ b/tests/test_agent_runtime_tool_calls.py
@@ -152,5 +152,5 @@ def test_normalize_tool_calls_correlates_codex_function_call_output() -> None:
 
     assert len(calls) == 1
     assert calls[0]["name"] == "mcp__sources__search_text"
-    assert calls[0]["result"].startswith("Wall time: 0.0212 seconds\nOutput:\n")
+    assert calls[0]["result"] == [{"type": "text", "text": "Found 10 results"}]
     assert "Found 10 results" in calls[0]["output_summary"]

--- a/tests/test_citation_matcher.py
+++ b/tests/test_citation_matcher.py
@@ -90,3 +90,47 @@ class TestCitationKeysMatchAcrossTransliterations:
         wrong_grade = extract_citation_key("Zaharijchuk Grade 2, p.24")
         assert plan_key is not None and wrong_grade is not None
         assert not citation_keys_match(wrong_grade, plan_key)
+
+    def test_extracts_plan_page_range(self):
+        plan_key = extract_citation_key("Авраменко Grade 6, p.124-125")
+
+        assert plan_key is not None
+        assert plan_key.page == 124
+        assert plan_key.page_end == 125
+
+    def test_trailing_page_range_hyphen_is_rejected(self):
+        assert extract_citation_key("Авраменко Grade 6, p.124-") is None
+
+    def test_multi_hyphen_page_range_is_rejected(self):
+        assert extract_citation_key("Авраменко Grade 6, p.124-125-127") is None
+
+    def test_reversed_page_range_is_rejected(self):
+        assert extract_citation_key("Авраменко Grade 6, p.125-124") is None
+
+    def test_ukrainian_page_word_extracts_page_range(self):
+        plan_key = extract_citation_key("Авраменко Grade 6, сторінка 124-125")
+
+        assert plan_key is not None
+        assert plan_key.page == 124
+        assert plan_key.page_end == 125
+
+    def test_result_page_matches_plan_page_range(self):
+        plan_key = extract_citation_key("Авраменко Grade 6, p.124-125")
+        result_key = extract_citation_key("Avramenko Grade 6, p.124")
+
+        assert plan_key is not None and result_key is not None
+        assert citation_keys_match(result_key, plan_key)
+
+    def test_result_page_inside_plan_range_matches(self):
+        plan_key = extract_citation_key("Заболотний Grade 8, p.18-21")
+        result_key = extract_citation_key("Zabolotnyi Grade 8, p.20")
+
+        assert plan_key is not None and result_key is not None
+        assert citation_keys_match(result_key, plan_key)
+
+    def test_page_outside_range_and_tolerance_does_not_match(self):
+        plan_key = extract_citation_key("Заболотний Grade 8, p.18-21")
+        far_key = extract_citation_key("Zabolotnyi Grade 8, p.40")
+
+        assert plan_key is not None and far_key is not None
+        assert not citation_keys_match(far_key, plan_key)

--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -69,12 +69,12 @@ def test_partial_match_does_not_pass() -> None:
     assert wrong_page["unknown"] == ["Караман, Українська мова, 10 клас, с. 999"]
 
 
-def test_page_range_and_second_page_label_do_not_pass() -> None:
+def test_page_range_passes_but_second_page_label_does_not() -> None:
     page_range = _result("Караман, Українська мова, 10 клас, с. 176-178")
     second_page = _result("Караман, Українська мова, 10 клас, с. 176, p.999")
 
-    assert page_range["passed"] is False
-    assert page_range["unknown"] == ["Караман, Українська мова, 10 клас, с. 176-178"]
+    assert page_range["passed"] is True
+    assert page_range["unknown"] == []
     assert second_page["passed"] is False
     assert second_page["unknown"] == ["Караман, Українська мова, 10 клас, с. 176, p.999"]
 

--- a/tests/test_prompt_cot_tier1_scaffolding.py
+++ b/tests/test_prompt_cot_tier1_scaffolding.py
@@ -19,6 +19,7 @@ import re
 import pytest
 
 from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import seed_implementation_map
 from scripts.common.thresholds import QG_DIMS
 
 REFERENCE_PLANS: tuple[tuple[str, str], ...] = (
@@ -88,6 +89,29 @@ def _writer_prompt(level: str, slug: str) -> str:
     return linear_pipeline.render_phase_prompt(WRITER_TEMPLATE, context)
 
 
+def _writer_family_prompt(level: str, slug: str, writer: str) -> str:
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.plan_check(plan_path)
+    plan_content = plan_path.read_text(encoding="utf-8")
+    wiki_manifest = {
+        "slug": slug,
+        "wiki_path": f"wiki/pedagogy/{level}/{slug}.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+    return linear_pipeline.render_writer_prompt(
+        plan=plan,
+        plan_content=plan_content,
+        knowledge_packet="Knowledge packet stub for prompt-rendering smoke.",
+        wiki_manifest=wiki_manifest,
+        implementation_map=seed_implementation_map(wiki_manifest, plan=plan),
+        writer=writer,
+    )
+
+
 def _reviewer_prompt(level: str, slug: str, dim: str) -> str:
     plan_path = linear_pipeline.plan_path_for(level, slug)
     plan = linear_pipeline.plan_check(plan_path)
@@ -148,6 +172,41 @@ def test_writer_prompt_has_tier1_discipline(level: str, slug: str) -> None:
     ):
         assert tool in rendered, (
             f"Writer Tier-1 MCP-tool reference missing: {tool!r} for {level}/{slug}"
+        )
+
+
+@pytest.mark.parametrize(("level", "slug"), REFERENCE_PLANS)
+def test_writer_prompt_mandates_preemit_audit_lines(level: str, slug: str) -> None:
+    rendered = _writer_prompt(level, slug)
+    for marker in (
+        "<implementation_map_audit>",
+        "<bad_form_audit>",
+        "<activity_split_audit>level=",
+    ):
+        assert marker in rendered, (
+            f"Writer pre-emit audit marker missing: {marker!r} for {level}/{slug}"
+        )
+
+
+@pytest.mark.parametrize(
+    "writer",
+    (
+        "claude-tools",
+        "codex-tools",
+        "gemini-tools",
+        "deepseek-tools",
+        "grok-tools",
+    ),
+)
+def test_writer_family_prompts_mandate_preemit_audit_lines(writer: str) -> None:
+    rendered = _writer_family_prompt("b1", "adjectives-comparative", writer)
+    for marker in (
+        "<implementation_map_audit>",
+        "<bad_form_audit>",
+        "<activity_split_audit>level=",
+    ):
+        assert marker in rendered, (
+            f"Writer pre-emit audit marker missing: {marker!r} for {writer}"
         )
 
 

--- a/tests/test_runner_tool_calls.py
+++ b/tests/test_runner_tool_calls.py
@@ -229,6 +229,55 @@ def test_codex_adapter_parses_matching_rollout_tool_calls(
     assert result.tool_calls[0]["output_summary"] == "день: verified"
 
 
+def test_codex_adapter_attaches_function_call_output(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = tmp_path / "home"
+    today = datetime.now(UTC)
+    rollout_dir = (
+        home
+        / ".codex"
+        / "sessions"
+        / f"{today.year:04d}"
+        / f"{today.month:02d}"
+        / f"{today.day:02d}"
+    )
+    rollout_dir.mkdir(parents=True)
+    output_file = tmp_path / "codex-output.txt"
+    output_file.write_text("Final answer.", encoding="utf-8")
+    prompt = "Write the module."
+    monkeypatch.setattr(Path, "home", lambda: home)
+    adapter = CodexAdapter()
+    adapter._reset_per_invocation_state()
+
+    rollout = rollout_dir / "rollout-test.jsonl"
+    rollout.write_text(
+        "\n".join(
+            [
+                '{"type":"event_msg","payload":{"type":"user_message","message":"Write the module."}}',
+                '{"type":"response_item","payload":{"type":"function_call","name":"search_text","namespace":"mcp__sources__","arguments":"{\\"query\\":\\"ступені\\"}","call_id":"call-1"}}',
+                '{"type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"Wall time: 0.0010 seconds\\nOutput:\\n[{\\"type\\":\\"text\\",\\"text\\":\\"Found 1 result\\"}]"}}',
+                '{"type":"event_msg","payload":{"type":"mcp_tool_call_end","call_id":"call-2","result":{"Ok":{"content":[{"type":"text","text":"verified"}]}}}}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = adapter.parse_response(
+        stdout="session id: 00000000-0000-0000-0000-000000000002",
+        stderr="",
+        returncode=0,
+        output_file=output_file,
+        plan=InvocationPlan(cmd=["codex"], cwd=tmp_path, stdin_payload=prompt),
+    )
+
+    assert result.ok is True
+    assert result.tool_calls[0]["name"] == "mcp__sources__search_text"
+    assert result.tool_calls[0]["result"] == [{"type": "text", "text": "Found 1 result"}]
+    assert result.tool_calls[0]["output_summary"] == '[{"text": "Found 1 result", "type": "text"}]'
+
+
 def test_tool_call_output_summary_truncation() -> None:
     summary = summarize_tool_output("x" * 10_000)
 

--- a/tests/test_v7_build_reviewer_assert.py
+++ b/tests/test_v7_build_reviewer_assert.py
@@ -6,6 +6,93 @@ import pytest
 from scripts.build import linear_pipeline, v7_build
 
 
+def test_reviewer_override_normalizes_alias():
+    args = v7_build.parse_args(
+        ["b1", "genitive-nuances", "--writer", "codex-tools", "--reviewer", "cursor"]
+    )
+
+    assert v7_build._reviewer_for_writer(args.writer, args.reviewer) == "cursor-tools"
+
+
+def test_generated_content_includes_writer_preemit_audit_lines(tmp_path: Path):
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "writer_output.raw.md").write_text(
+        "\n".join(
+            [
+                "<implementation_map_audit>manifest_obligations=8 covered_in_map=8 missing=[]</implementation_map_audit>",
+                "<bad_form_audit>italic_bad_form_patterns_found=0 converted_to_marker=0 remaining=0</bad_form_audit>",
+                "<activity_split_audit>",
+                "level=B1 inline_n=6 workbook_n=11 inline_range=[5,7] workbook_range=[11,15] split_valid=true",
+                "</activity_split_audit>",
+                "````markdown file=module.md",
+                "# Lesson",
+                "````",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    for artifact in linear_pipeline.WRITER_ARTIFACTS:
+        (module_dir / artifact).write_text(f"{artifact} body\n", encoding="utf-8")
+
+    generated = v7_build._generated_content(module_dir)
+
+    assert "## writer_output.raw.md pre-emit audit lines" in generated
+    assert "<implementation_map_audit>" in generated
+    assert "<bad_form_audit>" in generated
+    assert "<activity_split_audit>" in generated
+    assert "level=B1 inline_n=6" in generated
+    assert generated.index("<activity_split_audit>") < generated.index("## module.md")
+
+
+def test_writer_preemit_audit_context_extracts_all_three_tags(tmp_path: Path):
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "writer_output.raw.md").write_text(
+        "\n".join(
+            [
+                "<implementation_map_audit>manifest_obligations=3 covered_in_map=3 missing=[]</implementation_map_audit>",
+                "<bad_form_audit>italic_bad_form_patterns_found=1 converted_to_marker=1 remaining=0</bad_form_audit>",
+                "<activity_split_audit>level=B1 inline_n=5 workbook_n=11 inline_range=[5,7] workbook_range=[11,15] split_valid=true</activity_split_audit>",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    context = v7_build._writer_preemit_audit_context(module_dir)
+
+    assert "## writer_output.raw.md pre-emit audit lines" in context
+    assert context.count("<implementation_map_audit>") == 1
+    assert context.count("<bad_form_audit>") == 1
+    assert context.count("<activity_split_audit>") == 1
+
+
+def test_writer_preemit_audit_context_missing_tags_returns_empty(tmp_path: Path):
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "writer_output.raw.md").write_text("plain writer output\n", encoding="utf-8")
+
+    assert v7_build._writer_preemit_audit_context(module_dir) == ""
+    assert v7_build._writer_preemit_audit_context(tmp_path / "missing") == ""
+
+
+def test_writer_preemit_audit_context_malformed_tags_do_not_match(tmp_path: Path):
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "writer_output.raw.md").write_text(
+        "\n".join(
+            [
+                "<implementation_map_audit>manifest_obligations=3",
+                "<bad_form_audit>remaining=0</activity_split_audit>",
+                "<activity_split_audit level=B1 split_valid=true>",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert v7_build._writer_preemit_audit_context(module_dir) == ""
+
+
 def test_reviewer_assert_v7_build(tmp_path: Path):
     """v7_build must assert if writer and reviewer use the same model."""
     plan = {"slug": "test-slug", "level": "a1"}

--- a/tests/test_yaml_activities_v7_types.py
+++ b/tests/test_yaml_activities_v7_types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from yaml_activities import ActivityParser
@@ -109,3 +111,99 @@ def test_v7_authoring_types_parse_and_render(tmp_path):
 
     assert "ActivityPlaceholder" not in mdx
 
+
+def test_grammar_identify_accepts_sentence_alias(tmp_path):
+    fixture = tmp_path / "grammar.yaml"
+    fixture.write_text(
+        """
+- id: grammar-1
+  type: grammar-identify
+  title: Конструкція
+  instruction: Визначте модель порівняння.
+  items:
+    - sentence: Петро вищий за Марію.
+      answer: за + знахідний відмінок
+""",
+        encoding="utf-8",
+    )
+
+    parser = ActivityParser()
+    activities = parser.parse(fixture)
+
+    assert activities[0].items[0].text == "Петро вищий за Марію."
+    assert activities[0].items[0].form == "Визначте модель порівняння."
+    assert "<GrammarIdentify" in parser.to_mdx(activities)
+
+
+def test_grammar_identify_requires_text_sentence_or_word(tmp_path):
+    fixture = tmp_path / "grammar.yaml"
+    fixture.write_text(
+        """
+- id: grammar-1
+  type: grammar-identify
+  title: Конструкція
+  instruction: Визначте модель порівняння.
+  items:
+    - answer: за + знахідний відмінок
+""",
+        encoding="utf-8",
+    )
+
+    parser = ActivityParser()
+
+    with pytest.raises(ValueError, match="requires text, sentence, or word"):
+        parser.parse(fixture)
+
+
+def test_odd_one_out_accepts_options_answer_alias(tmp_path):
+    fixture = tmp_path / "odd.yaml"
+    fixture.write_text(
+        """
+- id: odd-1
+  type: odd-one-out
+  title: Зайва форма
+  instruction: Оберіть форму, яка не належить до групи.
+  items:
+    - options: [сильніший, молодший, більш цікавий, дорожчий]
+      answer: більш цікавий
+      explanation: Це складена форма, решта прості.
+""",
+        encoding="utf-8",
+    )
+
+    parser = ActivityParser()
+    activities = parser.parse(fixture)
+
+    assert activities[0].items[0].words == [
+        "сильніший",
+        "молодший",
+        "більш цікавий",
+        "дорожчий",
+    ]
+    assert activities[0].items[0].correct == 2
+    assert "<OddOneOut" in parser.to_mdx(activities)
+
+
+def test_highlight_morphemes_accepts_answer_alias(tmp_path):
+    fixture = tmp_path / "morphemes.yaml"
+    fixture.write_text(
+        """
+- id: morphemes-1
+  type: highlight-morphemes
+  title: Суфікси
+  instruction: Позначте суфікс.
+  text: сильніший
+  items:
+    - word: сильніший
+      answer: -іш-
+""",
+        encoding="utf-8",
+    )
+
+    parser = ActivityParser()
+    activities = parser.parse(fixture)
+
+    assert activities[0].morphemes[0].word == "сильніший"
+    assert activities[0].morphemes[0].morpheme == "-іш-"
+    assert activities[0].morphemes[0].type == "suffix"
+    assert "<HighlightMorphemes" in parser.to_mdx(activities)


### PR DESCRIPTION
## Summary
- split the generated-module plumbing/runtime fixes out of #2266
- harden v7 activity parsing/rendering, Codex tool-output envelope parsing, and reviewer override/pre-emit audit context
- fix page-range citation matching and compact Markdown implementation-map row parsing

## Validation
- `.venv/bin/python -m pytest -q` -> 8184 passed, 205 skipped, 11 xfailed, 3 warnings before final local-code-review fixes
- targeted affected suite after review fixes -> 188 passed
- commit hook affected suite -> 227 passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`

Supersedes the plumbing portion of #2266.
