### PR TITLE
feat(a1-prep): ULP presentation-pattern SSOT + m04 vocab targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Detailed standards in `docs/best-practices/`. Read the relevant doc before worki
 | Topic | Doc |
 | --- | --- |
 | **V7 design + corpus (READ FIRST before any module / writer-prompt work)** | [`v7-design-and-corpus.md`](docs/best-practices/v7-design-and-corpus.md) |
+| **ULP presentation pattern (READ before any A1/A2 build — Anna Ohoiko's 7 practices + S1→S6 progression)** | [`ulp-presentation-pattern.md`](docs/best-practices/ulp-presentation-pattern.md) |
 | Prompt engineering | [`prompt-engineering.md`](docs/best-practices/prompt-engineering.md) |
 | Context engineering | [`context-engineering.md`](docs/best-practices/context-engineering.md) |
 | Code quality | [`code-quality.md`](docs/best-practices/code-quality.md) |

--- a/curriculum/l2-uk-en/plans/a1/stress-and-melody.yaml
+++ b/curriculum/l2-uk-en/plans/a1/stress-and-melody.yaml
@@ -2,7 +2,7 @@ module: a1-004
 level: A1
 sequence: 4
 slug: stress-and-melody
-version: 1.2.1
+version: 1.2.2
 lifecycle: locked
 reviewed_at: '2026-04-23T00:00:00Z'
 reviewed_by: claude-opus-4-7-xhigh-stress-and-melody
@@ -91,6 +91,22 @@ vocabulary_hints:
   - фотографія (photograph)
   - одинадцять (eleven — stress on `-на-`; classic L2 stress-transfer target)
   - чотирнадцять (fourteen — stress on `-на-`; classic L2 stress-transfer target)
+targets:
+  new_vocabulary:
+    - "наголос"
+    - "замок"
+    - "кава"
+    - "вода"
+    - "столиця"
+    - "атлас"
+    - "орган"
+    - "ранок"
+    - "метро"
+    - "фотографія"
+    - "одинадцять"
+    - "чотирнадцять"
+  new_grammar: []
+  recycle_vocabulary: []
 activity_hints:
 - type: quiz
   focus: Де наголос? Виберіть правильний склад.

--- a/curriculum/l2-uk-en/plans/a1/stress-and-melody.yaml.bak
+++ b/curriculum/l2-uk-en/plans/a1/stress-and-melody.yaml.bak
@@ -2,26 +2,20 @@ module: a1-004
 level: A1
 sequence: 4
 slug: stress-and-melody
-version: '1.2.0'
+version: 1.2.1
 lifecycle: locked
 reviewed_at: '2026-04-23T00:00:00Z'
 reviewed_by: claude-opus-4-7-xhigh-stress-and-melody
-review_notes: >-
-  Review-and-lock pass per docs/best-practices/wiki-plan-review-and-lock.md.
-  Wiki locked to 9/10 on all 5 dimensions
-  (wiki/.reviews/pedagogy/a1/stress-and-melody-review-LOCKED.md).
-  Plan findings: (1) internal contradiction between grammar item 3
-  "питальна ↗" and grammar item 4 "питальні слова не потребують висхідної
-  інтонації" — tightened item 3 to "питання без питального слова (так/ні) ↗";
-  (2) Читаємо вголос dialogue marked `Як справи? ↗` which contradicts
-  the plan's own WH-question rule — normalised to `↘` with an author-note
-  about the conversational-register exception; (3) typo `з модуля модуль №1`
-  → `з модуля №1`; (4) added stress-transfer-error fill-in activity
-  mirroring the new wiki "Типові помилки L2 (наголос)" table; (5) added
-  `мука / борошно` writer-note to disambiguate the homograph pair's
-  pedagogical role vs. the modern standard term for "flour"; (6) wiki
-  back-reference added to references. See PR body for full findings +
-  fixes.
+review_notes: 'Review-and-lock pass per docs/best-practices/wiki-plan-review-and-lock.md. Wiki locked
+  to 9/10 on all 5 dimensions (wiki/.reviews/pedagogy/a1/stress-and-melody-review-LOCKED.md). Plan findings:
+  (1) internal contradiction between grammar item 3 "питальна ↗" and grammar item 4 "питальні слова не
+  потребують висхідної інтонації" — tightened item 3 to "питання без питального слова (так/ні) ↗"; (2)
+  Читаємо вголос dialogue marked `Як справи? ↗` which contradicts the plan''s own WH-question rule — normalised
+  to `↘` with an author-note about the conversational-register exception; (3) typo `з модуля модуль №1`
+  → `з модуля №1`; (4) added stress-transfer-error fill-in activity mirroring the new wiki "Типові помилки
+  L2 (наголос)" table; (5) added `мука / борошно` writer-note to disambiguate the homograph pair''s pedagogical
+  role vs. the modern standard term for "flour"; (6) wiki back-reference added to references. See PR body
+  for full findings + fixes.'
 title: Наголос і мелодика
 subtitle: Наголос змінює значення, інтонація змінює намір
 focus: phonetics
@@ -37,45 +31,66 @@ content_outline:
 - section: Наголос
   words: 350
   points:
-  - 'Заболотний, 5 клас, с. 73: Українська мова має 38 звуків, і наголос визначає, який склад вимовляється голосніше та довше. Наголос є ВІЛЬНИМ — він може падати на будь-який склад і РУХОМИМ — може переміщуватися між формами одного слова. Це відрізняє його від французької (завжди на останньому) чи чеської (завжди на першому).'
-  - 'Наголос змінює значення — реальні пари слів, які зустрінуться учням: за́мок (castle) / замо́к (lock), а́тлас (atlas) / атла́с (satin), о́рган (organ of the body) / орга́н (musical instrument), сі́м''я (family) / сім''я́ (seed). Неправильний наголос = неправильне слово. Ось чому позначки наголосу є важливими. (Примітка до автора: пара `му́ка / мука́` — не подавати як "torment/flour"; модерна словникова норма для "flour" — `борошно`.)'
-  - 'На письмі позначки наголосу ('') ставляться в підручниках і словниках, але НЕ у звичайних українських текстах. Учням завжди слід перевіряти наголос на goroh.pp.ua, якщо є сумніви.'
-  - 'Поширені моделі для початківців: Перший склад: мама, тато, ранок, кава, книга. Останній склад: вода, зима, рука, метро, кафе. Короткого шляху немає — потрібно вивчати наголос для кожного слова окремо.'
+  - 'Заболотний, 5 клас, с. 73: Українська мова має 38 звуків, і наголос визначає, який склад вимовляється
+    голосніше та довше. Наголос є ВІЛЬНИМ — він може падати на будь-який склад і РУХОМИМ — може переміщуватися
+    між формами одного слова. Це відрізняє його від французької (завжди на останньому) чи чеської (завжди
+    на першому).'
+  - 'Наголос змінює значення — реальні пари слів, які зустрінуться учням: замок (castle) / замок (lock),
+    атлас (atlas) / атлас (satin), орган (organ of the body) / орган (musical instrument), сім''я (family)
+    / сім''я (seed). Неправильний наголос = неправильне слово. Ось чому позначки наголосу є важливими.
+    (Примітка до автора: пара `мука / мука` — не подавати як "torment/flour"; модерна словникова норма
+    для "flour" — `борошно`.)'
+  - На письмі позначки наголосу (') ставляться в підручниках і словниках, але НЕ у звичайних українських
+    текстах. Учням завжди слід перевіряти наголос на goroh.pp.ua, якщо є сумніви.
+  - 'Поширені моделі для початківців: Перший склад: мама, тато, ранок, кава, книга. Останній склад: вода,
+    зима, рука, метро, кафе. Короткого шляху немає — потрібно вивчати наголос для кожного слова окремо.'
 - section: Інтонація
   words: 300
   points:
-  - 'Українська мова використовує інтонацію (мелодику) для розрізнення типів речень. Ті самі слова, різна мелодика, різне значення. Твердження: Це кава. ↘ Питання: Це кава? ↗ Оклик: Як гарно! ↘↘'
-  - 'Питальні слова (хто, що, де, коли) утворюють питання БЕЗ висхідної інтонації: Що це? ↘ Де метро? ↘ Але загальні питання (так/ні) завжди мають висхідну інтонацію: Це метро? ↗'
-  - 'В українській мові речення класифікують за метою висловлювання: розповідні, питальні, спонукальні. Будь-яке з них може бути також окличним — це окремий вимір. Для A1 зосередимося на трьох моделях пунктуації: . для тверджень, ? для питань, ! для окликів або наказів.'
+  - 'Українська мова використовує інтонацію (мелодику) для розрізнення типів речень. Ті самі слова, різна
+    мелодика, різне значення. Твердження: Це кава. ↘ Питання: Це кава? ↗ Оклик: Як гарно! ↘↘'
+  - 'Питальні слова (хто, що, де, коли) утворюють питання БЕЗ висхідної інтонації: Що це? ↘ Де метро?
+    ↘ Але загальні питання (так/ні) завжди мають висхідну інтонацію: Це метро? ↗'
+  - 'В українській мові речення класифікують за метою висловлювання: розповідні, питальні, спонукальні.
+    Будь-яке з них може бути також окличним — це окремий вимір. Для A1 зосередимося на трьох моделях пунктуації:
+    . для тверджень, ? для питань, ! для окликів або наказів.'
 - section: Читаємо вголос
   words: 300
   points:
-  - 'Читання багатоскладових слів із правильним наголосом: у-кра-їн-ська, фо-то-гра-фі-я, ві-дпо-чи-нок. Метод: розділити на склади → знайти наголошений склад → прочитати у природному темпі.'
-  - 'Практика читання наголошених слів — читати вголос із правильним наголосом: Ки-їв, мо-ло-ко, ран-ок, ка-ва, во-да, зи-ма, у-кра-їн-ська. Знайдіть наголошений склад, а потім прочитайте все слово в природному темпі.'
-  - 'Практика діалогів з використанням вітань з модуля №1: — Привіт! ↘ — Привіт! Як справи? ↘ — Добре! А у тебе? ↗ — Добре! ↘ Застосовуйте інтонаційні моделі до вже вивчених привітань. УВАГА до автора: `Як справи?` містить питальне слово `як`, тому за правилом має спадну інтонацію. У живому розмовному мовленні ця фраза часто звучить з висхідною (фатична функція), але для A1 подаємо нормативний спадний контур, щоб учень закріпив правило WH-питань.'
+  - 'Читання багатоскладових слів із правильним наголосом: у-кра-їн-ська, фо-то-гра-фі-я, ві-дпо-чи-нок.
+    Метод: розділити на склади → знайти наголошений склад → прочитати у природному темпі.'
+  - 'Практика читання наголошених слів — читати вголос із правильним наголосом: Ки-їв, мо-ло-ко, ран-ок,
+    ка-ва, во-да, зи-ма, у-кра-їн-ська. Знайдіть наголошений склад, а потім прочитайте все слово в природному
+    темпі.'
+  - 'Практика діалогів з використанням вітань з модуля №1: — Привіт! ↘ — Привіт! Як справи? ↘ — Добре!
+    А у тебе? ↗ — Добре! ↘ Застосовуйте інтонаційні моделі до вже вивчених привітань. УВАГА до автора:
+    `Як справи?` містить питальне слово `як`, тому за правилом має спадну інтонацію. У живому розмовному
+    мовленні ця фраза часто звучить з висхідною (фатична функція), але для A1 подаємо нормативний спадний
+    контур, щоб учень закріпив правило WH-питань.'
 - section: Підсумок
   words: 250
   points:
-  - 'Самоперевірка: Що таке наголос? Чи може він змінювати значення слова? Наведіть приклад. Яку інтонацію ви використовуєте для загальних питань (так/ні)? Для тверджень? Прочитайте це вголос: Це аптека? Так, це аптека. Як гарно!'
+  - 'Самоперевірка: Що таке наголос? Чи може він змінювати значення слова? Наведіть приклад. Яку інтонацію
+    ви використовуєте для загальних питань (так/ні)? Для тверджень? Прочитайте це вголос: Це аптека? Так,
+    це аптека. Як гарно!'
 vocabulary_hints:
   required:
   - наголос (stress/accent)
-  - за́мок (castle — stress on first syllable)
-  - замо́к (lock — stress on last syllable)
+  - замок (castle — stress on first syllable)
+  - замок (lock — stress on last syllable)
   - кава (coffee)
   - вода (water)
   - столиця (capital)
   recommended:
-  - а́тлас (atlas — stress on first syllable; pairs with атла́с for meaning-distinguishing
-    drill)
-  - атла́с (satin — stress on last syllable; pairs with а́тлас)
-  - о́рган (organ of the body — stress on first syllable; pairs with орга́н)
-  - орга́н (musical instrument — stress on last syllable; pairs with о́рган)
+  - атлас (atlas — stress on first syllable; pairs with атлас for meaning-distinguishing drill)
+  - атлас (satin — stress on last syllable; pairs with атлас)
+  - орган (organ of the body — stress on first syllable; pairs with орган)
+  - орган (musical instrument — stress on last syllable; pairs with орган)
   - ранок (morning)
   - метро (metro)
   - фотографія (photograph)
-  - одина́дцять (eleven — stress on `-на-`; classic L2 stress-transfer target)
-  - чотирна́дцять (fourteen — stress on `-на-`; classic L2 stress-transfer target)
+  - одинадцять (eleven — stress on `-на-`; classic L2 stress-transfer target)
+  - чотирнадцять (fourteen — stress on `-на-`; classic L2 stress-transfer target)
 activity_hints:
 - type: quiz
   focus: Де наголос? Виберіть правильний склад.
@@ -90,14 +105,15 @@ activity_hints:
   focus: 'Поставте правильний розділовий знак: Це кава_ Де метро_ Як гарно_'
   items: 6
 - type: fill-in
-  focus: 'Типові L2-помилки наголосу — оберіть нормативну форму (див. wiki "Типові помилки L2 (наголос)"). Формат: `слово {нормативний_наголос|помилковий_наголос}`.'
+  focus: 'Типові L2-помилки наголосу — оберіть нормативну форму (див. wiki "Типові помилки L2 (наголос)").
+    Формат: `слово {нормативний_наголос|помилковий_наголос}`.'
   items:
-  - Це моя {нови́й|но́вий} комп''ютер. (adjective ending-stress, R-L1 transfer)
-  - Мій дідусь {стари́й|ста́рий}. (adjective ending-stress, R-L1 transfer)
-  - У мене в руці {одина́дцять|оди́ннадцять} гривень. (numeral — stress on `-на-`)
-  - Я вивчив {чотирна́дцять|чоти́рнадцять} нових слів. (numeral — stress on `-на-`)
-  - У мене болять {гóлови|голови́}. (plural — mobile stress, plural is stem-stressed)
-  - Мене звати {Марі́я|Ма́рія}. (feminine -ія name — stress on `-і-`)
+  - Це моя {новий|новий} комп''ютер. (adjective ending-stress, R-L1 transfer)
+  - Мій дідусь {старий|старий}. (adjective ending-stress, R-L1 transfer)
+  - У мене в руці {одинадцять|одиннадцять} гривень. (numeral — stress on `-на-`)
+  - Я вивчив {чотирнадцять|чотирнадцять} нових слів. (numeral — stress on `-на-`)
+  - У мене болять {гóлови|голови}. (plural — mobile stress, plural is stem-stressed)
+  - Мене звати {Марія|Марія}. (feminine -ія name — stress on `-і-`)
 connects_to:
 - a1-005 (Хто я?)
 prerequisites:
@@ -117,34 +133,33 @@ references:
   url: https://www.ukrainianlessons.com/episode5/
   notes: Практика наголосу з числівниками.
 - title: 'Wiki: pedagogy/a1/stress-and-melody (LOCKED 2026-04-23)'
-  notes: 'Authoritative pedagogical brief — see Крок 5 (чотири базові інтонаційні
-    контури з прикладовими реченнями) and "Типові помилки L2 (наголос)" (R-L1 +
-    англ. stress-transfer drill).'
+  notes: Authoritative pedagogical brief — see Крок 5 (чотири базові інтонаційні контури з прикладовими
+    реченнями) and "Типові помилки L2 (наголос)" (R-L1 + англ. stress-transfer drill).
 changelog:
-- version: '1.2.0'
+- version: 1.2.0
   date: '2026-04-23'
   changes:
-  - 'Review-and-lock pass per docs/best-practices/wiki-plan-review-and-lock.md.
-    Added lifecycle markers (lifecycle / reviewed_at / reviewed_by / review_notes)
-    per the convention.'
-  - 'Fixed internal contradiction in grammar[]: tightened "Три інтонаційні моделі:
-    розповідна ↘, питальна ↗, оклична ↘↘" → "…питання без питального слова (так/ні)
-    ↗…" (matches the WH-question falling-intonation rule stated elsewhere in the
-    plan and in the locked wiki).'
-  - 'Fixed intonation inconsistency in Читаємо вголос: `Як справи? ↗` → `Як справи?
-    ↘` (applies the plan''s own WH-question rule). Added author-note explaining
-    the conversational-register exception so the writer does not silently invert
-    back to the "natural" rising contour.'
+  - Review-and-lock pass per docs/best-practices/wiki-plan-review-and-lock.md. Added lifecycle markers
+    (lifecycle / reviewed_at / reviewed_by / review_notes) per the convention.
+  - 'Fixed internal contradiction in grammar[]: tightened "Три інтонаційні моделі: розповідна ↘, питальна
+    ↗, оклична ↘↘" → "…питання без питального слова (так/ні) ↗…" (matches the WH-question falling-intonation
+    rule stated elsewhere in the plan and in the locked wiki).'
+  - 'Fixed intonation inconsistency in Читаємо вголос: `Як справи? ↗` → `Як справи? ↘` (applies the plan''s
+    own WH-question rule). Added author-note explaining the conversational-register exception so the writer
+    does not silently invert back to the "natural" rising contour.'
   - 'Fixed typo: "з модуля модуль №1" → "з модуля №1".'
-  - 'Added stress-transfer-error fill-in activity (6 items) mirroring the new wiki
-    "Типові помилки L2 (наголос)" table — covers numerals, adjective ending-stress,
-    mobile plural, homograph pairs.'
-  - 'Annotated meaning-distinguishing stress pairs directly in vocabulary_hints
-    (за́мок / замо́к, а́тлас / атла́с, о́рган / орга́н — all with stress marks
-    and English glosses). Dropped the disputed `мука́ / му́ка` flour/torment pair
-    from vocabulary_hints; a note in content_outline[0].points[1] flags that the
-    modern standard term for flour is `борошно` so the writer does not silently
-    teach a dialectal form.'
-  - 'Added одина́дцять / чотирна́дцять to recommended vocabulary as canonical
-    L2 stress-transfer targets.'
+  - Added stress-transfer-error fill-in activity (6 items) mirroring the new wiki "Типові помилки L2 (наголос)"
+    table — covers numerals, adjective ending-stress, mobile plural, homograph pairs.
+  - Annotated meaning-distinguishing stress pairs directly in vocabulary_hints (замок / замок, атлас /
+    атлас, орган / орган — all with stress marks and English glosses). Dropped the disputed `мука / мука`
+    flour/torment pair from vocabulary_hints; a note in content_outline[0].points[1] flags that the modern
+    standard term for flour is `борошно` so the writer does not silently teach a dialectal form.
+  - Added одинадцять / чотирнадцять to recommended vocabulary as canonical L2 stress-transfer targets.
   - 'Added wiki back-reference to references: (LOCKED 2026-04-23).'
+plan_fixes:
+- version: 1.2.1
+  date: '2026-04-24'
+  trigger: Plan check rejected U+0301 combining acute stress marks in 43 place(s). Pipeline adds stress
+    marks deterministically AFTER review; plans must be stress-free.
+  changes:
+  - strip U+0301 from all string values (43 removals)

--- a/docs/best-practices/ulp-presentation-pattern.md
+++ b/docs/best-practices/ulp-presentation-pattern.md
@@ -1,0 +1,284 @@
+# ULP Presentation Pattern — extracted from Anna Ohoiko's lesson notes
+
+> **WHO THIS IS FOR**: Every orchestrator / writer-prompt author / content-reviewer working on A1 or A2 modules. Anna Ohoiko's Ukrainian Lessons Podcast (ULP) is the project's gold-standard reference for student-aware bilingual immersion at A1. This doc extracts the SPECIFIC presentation practices she uses, with verbatim examples, so future-me (and any agent) can grep for the pattern without re-reading 9,209 lines of lesson notes.
+>
+> **Companions**:
+> - `docs/decisions/2026-05-13-ulp-derived-student-aware-immersion.md` — the ACCEPTED architectural decision (band derivation, gates, plan-schema).
+> - `docs/best-practices/v7-design-and-corpus.md` §1.3 — the SSOT entry point.
+> - `data/references/private/ULP {1-6}-00 Lesson Notes (all in one file).txt` — the source corpus (gitignored, local-only).
+>
+> **Encoded after** user direct feedback 2026-05-25: *"this is not the first time we talk about this. and you already don't remember. you need to remember these or have some references which will remind you where to refresh your memory."* User-supplied summary of Ohoiko's pattern (spoken layer): *"she will explain in ukranian and in english, she says don't worry if you don't understand, just get use to the sound, i will explain everything in english then she repeats the ukranian explanation and then the english explanation again."*
+
+## Why this matters
+
+User direction 2026-05-25, foreigner himself: *"i as a foreigner prefer the ukranian approach."* Typical foreigner-targeted Ukrainian-as-second-language textbooks Anglicize ("Б sounds like 'b' in English", transliteration tables, English-frame-first dialogues). ULP does the **opposite**: Ukrainian-first, English as a scaffold that recedes. The user wants A1 modules to match Ohoiko's approach, NOT foreigner-textbook conventions. The decision card already encoded the *architecture* (`compute_immersion_band`, `{LEARNER_STATE}`). This doc encodes the *presentation practices*.
+
+## The seven Ohoiko practices (extracted from ULP 1-00, S1 lessons 1, 10, 20)
+
+### Practice 1 — UK first, EN gloss after, em-dash separator
+
+Every Ukrainian word/phrase appears in Ukrainian BEFORE its English gloss, separated by an em-dash. Never "the word for X is Y" English-first phrasing.
+
+Verbatim (Lesson 1, intro paragraph):
+> "Приві́т! Мене́ зва́ти А́нна — Hi! My name is Anna."
+
+Verbatim (Lesson 11 intro):
+> "we start a yummy series of episodes about food & drinks — ї́жа і напо́ї."
+> "I am в кав'я́рні — in a coffee house."
+
+Notice: the Ukrainian term is embedded INSIDE the English narration where it appears naturally, with the gloss following. This is NOT "vocabulary list at end" pedagogy — the UK appears in the prose, where the student encounters it in context.
+
+**A1 writer-prompt directive**: Every UK term in EN narration → em-dash gloss pattern. Never gloss-first.
+
+### Practice 2 — Side-by-side bilingual story format
+
+For longer narrative passages (intros to lessons, review lessons), ULP uses a two-column layout: Ukrainian on the LEFT, English on the RIGHT, paragraph-by-paragraph aligned.
+
+Verbatim (Lesson 10 "Я і моя сім'я" review story, lines 2015-2032 of source):
+
+| UK (column 1) | EN (column 2) |
+|---|---|
+| Приві́т! Як спра́ви? У ме́не — чудо́во. Мене́ зва́ти А́нна Ого́йко, я вчи́телька украї́нської мо́ви. | Hi! How are you? I am great. My name is Anna Ohoiko. I am a Ukrainian teacher. |
+| Моя́ ма́ма — теж вчи́телька. Вчи́телька літерату́ри. Вона́ працю́є в шко́лі. Її́ зва́ти Тетя́на. | My mom is also a teacher. A literature teacher. She works at school. Her name is Tetiana. |
+| ... | ... |
+
+The student SEES Ukrainian first (left = where the eye starts in left-to-right reading) and can glance right for the gloss. NOT translation-pair drilling.
+
+**A1 writer-prompt directive**: For narrative passages ≥3 sentences, use side-by-side bilingual MD-table or `<DialogueBox>`-style two-column rendering. Single-column EN-only with a vocab footnote is foreigner-textbook anti-pattern.
+
+### Practice 3 — Stress marks on every multi-syllable UK term
+
+Every Ukrainian word with more than one syllable has its stressed vowel marked (`Приві́т`, `спра́ви`, `чудо́во`, `Мене́ зва́ти`). This is constant — intro paragraphs, dialogues, vocab tables, review stories — until the student has internalized the stress.
+
+Verbatim (Lesson 20 "Моє улюблене місто" review story, line 4284):
+> "Моє́ улю́блене мі́сто в Украї́ні — Ки́їв."
+
+Six words, six stress marks. By Lesson 20 stress marks have NOT been dropped — they're still on every multi-syllable form.
+
+**A1 writer-prompt directive**: Mandatory IPA-style stress marks on every multi-syllable UK term throughout Tab 1 prose AND Tab 2 vocab AND Tab 3 activity prompts. Drop only at B2+. The deterministic gate `vesum_verified` does NOT enforce this — needs to be a writer-prompt obligation or new audit check.
+
+### Practice 4 — Dialogue presented Ukrainian-only first, breakdown after
+
+Dialogues are presented in pure Ukrainian (no inline English in the dialogue itself). The breakdown / explanation comes AFTER the dialogue, separately.
+
+Verbatim (Lesson 1, lines ~80-95):
+```
+Анна: Приві́т!
+Інна: Приві́т!
+Анна: Як спра́ви?
+Інна: Чудо́во! Ра́да тебе́ ба́чити.
+Анна: Я теж.
+Інна: А у те́бе як спра́ви?
+Анна: До́бре.
+```
+THEN (lines 100+) the per-phrase breakdown begins: "Hi! — Привіт! The basic informal 'Hi!' in Ukrainian is: Приві́т!"
+
+This is a teach-by-immersion practice. The dialogue is the *artifact* the student encounters; the explanation follows the artifact. Dialogues are NOT pre-glossed line-by-line.
+
+**A1 writer-prompt directive**: Dialogues in Tab 1 should be pure Ukrainian. Translation, when needed, lives in a follow-up table or paragraph AFTER the dialogue ends, not interleaved per-turn.
+
+### Practice 5 — Comprehension Q&A in Ukrainian-only
+
+After a story or dialogue, comprehension questions and their model answers are BOTH in Ukrainian. No English crutches in the recall layer.
+
+Verbatim (Lesson 10 comprehension section, lines 2036-2044):
+```
+Запитання — questions          | Відповіді — answers
+1. Як у мене справи?          | 1. Чудово!
+2. Ким я працюю?              | 2. Ти — вчителька української мови.
+3. Ким працює моя мама?       | 3. Твоя мама — теж (також) вчителька.
+4. Ким працює мій тато?       | 4. Твій тато — інженер.
+5. Де живуть мої батьки?      | 5. Твої батьки живуть у місті Полонне в Хмельницькій області.
+...
+```
+
+The section *labels* have EN glosses (`Запитання — questions`, `Відповіді — answers`), but the questions and answers themselves are 100% Ukrainian. The student is being asked to comprehend + recall in Ukrainian, not translate.
+
+**A1 writer-prompt directive**: Tab 3 activities of type `Quiz`, `MatchUp`, `OddOneOut`, `TrueFalse` should have Ukrainian-only question stems and Ukrainian-only answer options for content questions. EN appears only in the activity's UI affordances (e.g. "Choose the correct form" → "Оберіть правильну форму" with optional EN secondary). Foreigner-textbook anti-pattern: "What does the dialogue say about X?" with EN question + UK answers.
+
+### Practice 6 — Bonus exercises mix translate-EN-to-UK and form-correction
+
+The reverse direction (EN→UK translation prompts) appears in BONUS exercises after the main lesson, NOT in the main lesson. Main lesson stays UK-immersive; translation drilling is the optional booster.
+
+Verbatim (Lesson 10 bonus exercise, lines 2053-2087):
+```
+Translate to Ukrainian:
+1. My father is Canadian and my mother is German. But I live in Ukraine.
+2. He is American and his wife is Ukrainian.
+3. My brother is a software too. And what does your sister do?
+4. I am from London, but I live in Kyiv now.
+5. How much do the tomatoes cost?
+```
+
+This is the ONE place EN-first appears, and it's explicitly labeled as the exercise mode (translate). The student is in a different cognitive mode here.
+
+**A1 writer-prompt directive**: EN→UK translate activities go in workbook (Tab 3, workbook section), NOT inline in Tab 1. Tab 1's purpose is immersive exposure; translation is a recall/test mechanic that belongs in the practice tab.
+
+### Practice 7 — Cultural framing via Ukrainian first-person voice
+
+Ohoiko writes as herself, in first person, with cultural anchors. Not abstracted "the speaker says X" or "in Ukrainian we have Y". She's a person, telling a story, using Ukrainian.
+
+Verbatim (Lesson 1, lines 74-80):
+> "Приві́т! Мене́ зва́ти А́нна — Hi! My name is Anna. I am a Ukrainian teacher and native speaker. I am happy to introduce you to your first Lesson Notes for the Ukrainian Lessons Podcast."
+
+Verbatim (Lesson 11, lines 2140-2145):
+> "Приві́т! With the episode #11, we start a yummy series of episodes about food & drinks — ї́жа і напо́ї. In this lesson, I am в кав'я́рні — in a coffee house."
+
+She names herself, names locations she visits (Kyiv parks, Khmelnytska oblast, Полонне, Хрещатик, Поділ, кав'ярня "Living Room"), and ties grammatical concepts to lived experience.
+
+**A1 writer-prompt directive**: Tab 1 prose should be voiced from a named first-person Ukrainian teacher persona (or named characters in dialogues), not abstracted "the student should learn that...". Cultural anchors should be real Ukrainian places, real foods, real activities — not generic L2-textbook fillers ("the man went to the store").
+
+---
+
+## What this changes about the writer prompt
+
+Add to `scripts/build/phases/linear-write.md` (or a `letter_module:true` + low-`sequence` scoped section):
+
+```
+## ULP Presentation Pattern (A1 + A2 — see docs/best-practices/ulp-presentation-pattern.md)
+
+For A1 modules (sequence ≤ 55) and early-A2 modules (sequence ≤ 90), the writer MUST follow Anna Ohoiko's Ukrainian-first bilingual presentation practices:
+
+1. EM-DASH GLOSS — every UK term in EN narration: `Приві́т! — Hi!` not `the Ukrainian word for hi is Привіт`.
+2. SIDE-BY-SIDE BILINGUAL — narrative passages ≥3 sentences render as two-column MD-table (UK left, EN right), not single-column EN with vocab footnote.
+3. STRESS MARKS — every multi-syllable UK term marked (Приві́т, спра́ви, чудо́во). Throughout Tab 1, Tab 2, Tab 3.
+4. DIALOGUE UK-ONLY — Tab 1 dialogues are pure Ukrainian with named speakers. Translation follows the dialogue, never interleaved per turn.
+5. UK-ONLY Q&A — Tab 3 comprehension/recall activities have Ukrainian-only stems and options. EN appears only in UI affordances.
+6. TRANSLATE → WORKBOOK — EN→UK translation prompts go in Tab 3 workbook activities, never in Tab 1 prose.
+7. NAMED PERSONA — Tab 1 prose voiced from a Ukrainian teacher persona or named characters; cultural anchors are real Ukrainian places/foods/activities.
+
+VIOLATIONS at A1: "Б sounds like 'b' in English" / transliteration tables / EN-first dialogue glossing / single-column EN narration with vocab dump / pseudo-pedagogical "the student must learn" framing.
+```
+
+## What this changes about content-review
+
+Add to `scripts/build/phases/linear-review-dim.md` under the **immersion** dimension (or add a new dimension `ulp_fidelity`):
+
+For A1 modules, evaluator checks all 7 Ohoiko practices with explicit pass/fail per practice. ANY single practice violated → terminal REJECT (not a soft warn) for `letter_module:true` plans.
+
+## What this changes about verify-before-promote (10-check → 11-check)
+
+Add `Check #11 — ULP fidelity (A1 only)`:
+- All UK multi-syllable terms in MDX have stress marks (grep `[а-я]{4,}` outside IPA blocks for missing marks).
+- No "X sounds like Y in English" / transliteration table patterns.
+- Tab 1 dialogues are pure Ukrainian (no inline EN per turn).
+- No EN-first translation prompts in Tab 1.
+
+## Cross-season progression — the immersion RAMP (S1 → S6)
+
+**User direction 2026-05-25**: *"she gradually changing it in season 2 and season 3 and so on, actually sometimes the switch is quite drastic."*
+
+The seven practices above describe **S1 baseline** (A1 m01-m40 range). Across seasons, Ohoiko progressively reduces EN scaffolding. The shift is NOT linear — there are discrete step-changes at season boundaries.
+
+### S1 baseline (UR module range ~m01-m40)
+
+Verbatim opener (L1 / S1):
+> "Приві́т! Мене́ зва́ти А́нна — Hi! My name is Anna. I am a Ukrainian teacher and native speaker. I am happy to introduce you to your first Lesson Notes for the Ukrainian Lessons Podcast."
+
+- **~50:50 UK:EN** in narration with heavy em-dash gloss on every UK term.
+- Section labels **bilingual** with em-dash: "Запитання — questions", "Відповіді — answers".
+- Short UK dialogues (3-5 turns), full EN breakdown follows.
+- Anna introduces UK terms ONE AT A TIME, never assumes prior exposure.
+- English is the PRIMARY narration language; Ukrainian appears as the target embedded inline.
+
+### S2 step-change (≈m41-m80) — DRASTIC, this is the first big jump
+
+Verbatim opener (L42 / S2):
+> "Приві́т-приві́т! Це А́нна, як у вас спра́ви? У ме́не все чудо́во.
+> Сього́дні уро́к 42, це дру́гий сезо́н подка́сту, і я почина́ю мій короте́нький ві́льний вступ. Слу́хайте, як я говорю́ украї́нською."
+> (translation column shows EN gloss alongside)
+
+Then the META-MOMENT confirming the pattern explicitly:
+> "Ви гото́ві почина́ти? Хо́чете почу́ти, що я сказа́ла, англі́йською? Тоді́ слу́хайте…"
+> ("Are you ready to start? Do you want to hear what I said in English? Then listen…")
+
+This is Ohoiko EXPLICITLY ANNOUNCING the new pattern. She's saying: "I just spoke in Ukrainian; the English is a follow-up if you want it." That's the structural shift the user described — the user's verbal summary ("she says don't worry... I will explain everything in English then she repeats the ukranian explanation and then the english explanation again") maps to THIS moment.
+
+**S2 changes:**
+- **~65:35 UK:EN** — Ukrainian becomes the PRIMARY narration language.
+- Section labels go **UK-only**: "Вільний вступ" (not "Вільний вступ — free intro"), "Розмова №1" (not "Conversation №1"), "Діалог" (not "Dialogue").
+- Anna delivers a **FULL Ukrainian paragraph** then announces "[in Ukrainian:] now I'll repeat that in English" — the EN follows as a single block, not interleaved per-sentence.
+- Dialogues longer (8-15 turns), still UK-only per turn, EN in side column.
+- Section titles in lesson headers: UK-first with EN subtitle ("Моя кімната. Множина іменників / My room. Plural of nouns in Ukrainian").
+
+### S3 settled-mid (≈m81-m120)
+
+Verbatim opener (L81 / S3):
+> "Приві́т-приві́т! Це А́нна, ва́ша вчи́телька украї́нської, і ви слу́хаєте подка́ст «Уро́ки украї́нської» — тре́тій сезо́н."
+
+And later in the same intro:
+> "І як і рані́ше, мій коро́ткий вступ я повто́рюю англі́йською!"
+> ("As before, I repeat my short introduction in English!")
+
+By S3 the UK-first-then-EN-repeat is a SETTLED HABIT. Anna no longer has to invite "do you want to hear in English" — it's just the established rhythm.
+
+**S3 changes:**
+- **~75:25 UK:EN.**
+- Full STORY ARC in Ukrainian spans the entire season (Khrystyna's year in Kyiv, narrative continuity across 40 lessons).
+- Anna's intros are mostly UK with a brief "повторюю англійською" repeat block.
+- Cultural anchors deepen: Іва́но-Франкі́вщина, Ки́їв districts, real Ukrainian everyday situations.
+- Per-turn dialogue glosses still present but the dialogues themselves are 100% UK and longer (10-20 turns).
+
+### S4 → S6 trend (≈m121-m240)
+
+Sample titles (not bodies):
+- S4 L121: "10 цікавих фактів про мене" (no EN subtitle in title)
+- S5 L161: "Як у мене справи і що нового в Ukrainian Lessons" (UK except brand name)
+- S6 L201: "Про шостий сезон подкасту" (UK only)
+
+**Trend (not yet sampled in detail — calibration follow-up)**:
+- **~85-95% UK** by S5-S6.
+- EN reserved for new abstract concepts.
+- Dialogues, interviews, narratives are full UK with sparse gloss only on new lemmas.
+- By S6 the format approaches B1-level immersion preparation.
+
+### Where the "drastic" jumps are
+
+| Boundary | Magnitude | Most visible change |
+|---|---|---|
+| **S1 → S2** | DRASTIC | Section labels go UK-only; EN moves from primary-narration to repeat-block-after; narration becomes UK-primary |
+| S2 → S3 | moderate | "Do you want to hear in EN?" invitation disappears; EN-repeat becomes habit |
+| S3 → S4 | moderate | EN subtitles drop from lesson titles |
+| S4 → S5 | gradual | EN gloss reserved for new abstract concepts |
+| S5 → S6 | gradual | Approaches B1 immersion preparation |
+
+### Map to our A1 + A2 modules
+
+The CORE A1/A2 levels span 55 + 69 = 124 modules. Ohoiko's S1-S6 covers ~240 podcast episodes spanning A1 through B1. Our level→season mapping (approximate, calibration replay should refine):
+
+| Our level/range | ULP analog | Posture | Reference practices |
+|---|---|---|---|
+| A1 m01-m20 (sounds-letters → my-morning) | S1 m01-m20 | EN-primary, em-dash gloss, short UK dialogues | All 7 practices S1 baseline |
+| A1 m21-m40 (checkpoint-actions → ...) | S1 m21-m40 | Bilingual, beginning to densify UK | All 7 practices S1 baseline, growing UK density |
+| A1 m41-m55 (... → a1-finale) | S2 transition | UK-primary narration, section labels start going UK-only | Practice 1+2+3 stay; Practice 4+5 strengthen; Practice 6 (translate) workbook-only |
+| A2 m01-m35 | S2 settled | UK-primary, EN-repeat-block, full UK dialogues | UK-primary; EN is the repeat-scaffold |
+| A2 m36-m69 (finale) | S3 transition | UK-dominant, EN as gloss-on-new-lemmas only | Stage for B1 full immersion |
+
+**Critical**: m20 (my-morning) is mid-S1, NOT the boundary case. The "drastic" S1→S2 jump happens around A1 m41 — note this for the writer prompt as we build later A1 modules.
+
+### Implications for `compute_immersion_band`
+
+The function at `scripts/config.py:718` derives a band from cumulative_vocabulary + plan.targets.new_vocabulary + lemma-frequency. The calibration constants live in code (`_ULP_VOCAB_KNEE_PER_BAND`). **Open question — needs replay verification**: does the current calibration capture the S1→S2 step-change, or does it interpolate smoothly through it? If smooth, the band derivation will under-immerse around A1 m41-m55 (where Ohoiko bumps UK density discretely). This is a calibration follow-up, NOT a code change today.
+
+Filed as a deferred follow-up under "calibration replay tasks" (see Decision Card 2026-05-13 Phase 4).
+
+---
+
+## Where future-me should look first
+
+If cold-starting a session and about to fire an A1 or A2 build, GREP THIS FILE BEFORE writing any writer-prompt edit:
+
+```
+grep -r "ULP Presentation Pattern\|ohoiko presentation\|seven Ohoiko practices" docs/
+```
+
+If you don't see this file referenced from `v7-design-and-corpus.md §1.3` and `CLAUDE.md` best-practices table, the cross-references got out of sync — fix that first, then resume.
+
+**Trigger phrases that should make you re-read this file**:
+- "A1 build" / "A2 build" / "letter_module" / "early A1" / "phonics"
+- "immersion" / "bilingual" / "side-by-side" / "EN gloss"
+- "ULP" / "Ohoiko" / "Анна Огойко" / "S1" / "S2"
+- "stress marks" / "em-dash gloss" / "Запитання"
+- User direction containing "as a foreigner" / "Ukrainian approach" / "native pedagogy"
+
+When in doubt, re-read this file BEFORE the writer-prompt edit, not after.

--- a/docs/best-practices/v7-design-and-corpus.md
+++ b/docs/best-practices/v7-design-and-corpus.md
@@ -40,6 +40,8 @@ Every module = ONE `.mdx` at `starlight/src/content/docs/{level}/{slug}.mdx` wit
 
 ### 1.3 Student-aware immersion — the BIG V7 design point
 
+> **PRESENTATION PATTERN — READ FIRST** before any A1/A2 build: [`docs/best-practices/ulp-presentation-pattern.md`](ulp-presentation-pattern.md) — extracted Anna Ohoiko presentation moves (UK-first em-dash gloss, side-by-side bilingual, stress marks, UK-only Q&A, named persona) + S1→S6 progression with the DRASTIC S1→S2 step-change at ~A1 m41. The decision card below specifies the ARCHITECTURE (`compute_immersion_band`, gates, schema); the presentation-pattern doc specifies the WRITER EXECUTION moves. Both are required reading.
+
 `docs/decisions/2026-05-13-ulp-derived-student-aware-immersion.md` (ACCEPTED):
 
 - **Anna Ohoiko's ULP S1-S6 is the calibration corpus** (`data/references/private/ULP {1-6}-00`, gitignored)


### PR DESCRIPTION
## Summary

Three preparatory artifacts for upcoming A1 builds (m01 sounds-letters-and-hello onward under claude-tools writer):

1. **`docs/best-practices/ulp-presentation-pattern.md`** (NEW, 284 lines) — extracted SSOT for Anna Ohoiko's 7 presentation practices from ULP S1-S6 source corpus with verbatim evidence. Documents the S1→S2 DRASTIC step-change at ~A1 m41 and the smoother S2→S3→S6 ramp. Includes grep triggers at the bottom so cold-start sessions retrieve the file before any A1/A2 writer-prompt work.
2. **`CLAUDE.md` best-practices table** — adds a row for the new SSOT doc with "READ before any A1/A2 build" prefix. CLAUDE.md is auto-loaded every session, so cold-starts now have the entry point.
3. **`docs/best-practices/v7-design-and-corpus.md` §1.3** — cross-reference at the top of the immersion section: the decision card encodes the ARCHITECTURE (`compute_immersion_band`, gates, schema), the new doc encodes the WRITER EXECUTION practices.
4. **`curriculum/l2-uk-en/plans/a1/stress-and-melody.yaml`** — backfill `targets.new_vocabulary` (12 deduped lemmas) matching m01-m03 schema. PR #2272's plan-fallback consumes this for learner-state correctness when m04 isn't built yet. Version bumped 1.2.1 → 1.2.2; `.bak` of the pre-edit state created per non-negotiable rule §7.

## Context

- User direction 2026-05-25: *"i as a foreigner prefer the Ukrainian approach"* + *"you forgot the ULP immersion pattern, you need to remember these or have some references which will remind you where to refresh your memory."*
- Existing architecture (decision card 2026-05-13, `compute_immersion_band` at `scripts/config.py:718`, `{LEARNER_STATE}` placeholder, `compute_immersion_band` derivation) is intact. This PR adds the missing **presentation SSOT** + the missing **m04 plan target**.

## Verifiable claims (per #M-4)

```
$ .venv/bin/python -m pytest tests/test_writer_prompt_size.py -q --no-header
4 passed in 0.78s
```

```
$ .venv/bin/python -c "import yaml; yaml.safe_load(open('curriculum/l2-uk-en/plans/a1/stress-and-melody.yaml')); print('yaml OK')"
yaml OK
```

```
$ .venv/bin/python -m pytest tests/ -q -k "plan or linear_write or writer_prompt or learner_state" --no-header
[run before linear-write.md revert: 1 failed (size test), 392 passed]
[after revert: 4 passed (writer_prompt_size), full sweep TBD on CI]
```

## What was DROPPED from this PR

A `## ULP Presentation Pattern` directive section was originally added to `scripts/build/phases/linear-write.md`. The rendered writer prompt then exceeded the 130 KB ceiling (137 KB > 133 KB), failing `test_fixture_writer_prompts_under_ceiling`. Reverted that edit. Will file a follow-up issue for conditional injection of ULP practices via `{IMMERSION_RULE}` substitution for `letter_module: true` plans only (so the size cost is paid only for the 4 letter-modules, not all 1713 modules).

## Test plan

- [x] `pytest tests/test_writer_prompt_size.py` (4/4 pass)
- [x] m04 plan YAML validity
- [ ] CI green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)