### PR TITLE
fix(mdx): drop pipeline metadata from Tab 4 Resources tab

### DIFF
--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -266,6 +266,19 @@ RESOURCE_GROUPS = (
     ('online', '🔗', 'Online resources', 'Онлайн-ресурси', {'wiki', 'website'}),
 )
 
+_PIPELINE_METADATA_LINE_RE = re.compile(
+    r"\b(?:writer telemetry|retrieved chunk(?:_id)?\b)",
+    re.IGNORECASE,
+)
+_PIPELINE_METADATA_FRAGMENT_RE = re.compile(
+    r"\([^)]*\b(?:packet_)?chunk_id\b[^)]*\)"
+    r"|\([^)]*\b(?:wiki|vesum)_query_id\b[^)]*\)"
+    r"|\bknowledge packet anchor\s+[A-Za-z0-9_-]+\s*:?"
+    r"|\b(?:packet_)?chunk_id\s*[:=]\s*[\w./:-]+"
+    r"|\b(?:wiki|vesum)_query_id\s*[:=]\s*[\w./:-]+",
+    re.IGNORECASE,
+)
+
 LEGACY_RESOURCE_ROLE = {
     'podcasts': 'podcast',
     'youtube': 'youtube',
@@ -318,12 +331,39 @@ def _resource_sort_key(item: dict) -> tuple[int, int, str]:
     )
 
 
+def _public_resource_text(value: object) -> str:
+    """Return learner-facing resource text with pipeline metadata removed."""
+    text = str(value or '').strip()
+    if not text:
+        return ''
+
+    lines = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not _PIPELINE_METADATA_LINE_RE.search(line)
+    ]
+    text = ' '.join(lines)
+    text = _PIPELINE_METADATA_FRAGMENT_RE.sub('', text)
+    text = re.sub(r'\s+', ' ', text)
+    text = re.sub(r'\s+([,.;:])', r'\1', text)
+    text = re.sub(r'^[\s,.;:()/-]+|[\s,;:()/-]+$', '', text)
+    return text
+
+
+def _public_resource_description(item: dict) -> str:
+    for key in ('match_reason', 'description', 'notes', 'channel', 'source'):
+        desc = _public_resource_text(item.get(key))
+        if desc:
+            return desc
+    return ''
+
+
 def _format_textbook_resource(item: dict) -> list[str]:
-    title = str(item.get('title') or 'Unknown').strip()
-    author = str(item.get('author') or '').strip()
+    title = _public_resource_text(item.get('title')) or 'Unknown'
+    author = _public_resource_text(item.get('author'))
     pages = item.get('pages') or item.get('page') or ''
-    desc = str(item.get('description') or item.get('notes') or '').strip()
-    source_ref = str(item.get('source_ref') or title).strip()
+    desc = _public_resource_description(item)
+    source_ref = _public_resource_text(item.get('source_ref')) or title
 
     display_title = source_ref
     if pages and str(pages) not in display_title:
@@ -340,16 +380,9 @@ def _format_textbook_resource(item: dict) -> list[str]:
 def _format_linked_resource(item: dict) -> str:
     role = _resource_role(item)
     icon = RESOURCE_ROLE_ICONS.get(role, '🔗')
-    title = str(item.get('title') or 'Unknown').strip()
+    title = _public_resource_text(item.get('title')) or 'Unknown'
     url = validate_and_clean_url(str(item.get('url') or ''), title)
-    desc = (
-        item.get('match_reason')
-        or item.get('description')
-        or item.get('notes')
-        or item.get('channel')
-        or item.get('source')
-        or ''
-    )
+    desc = _public_resource_description(item)
     label = f"[{title}]({url})" if url else f"**{title}**"
     suffix = f" — {desc}" if desc else ""
     return f"> - {icon} {label}{suffix}"

--- a/tests/test_assemble_mdx_v7.py
+++ b/tests/test_assemble_mdx_v7.py
@@ -107,6 +107,12 @@ references:
   pages: "176"
   description: Reflexive verbs with -ся.
   role: textbook
+- title: "Morning routine wiki (wiki_query_id: wiki-123)"
+  url: https://example.com/wiki
+  role: wiki
+  match_reason: "writer telemetry retrieved chunk_id: wiki-123"
+  description: Background article.
+  wiki_query_id: wiki-123
 """,
         encoding="utf-8",
     )
@@ -135,3 +141,10 @@ references:
     assert "INJECT_ACTIVITY" not in mdx
     assert "by Unknown" not in mdx
     assert "Караман" in mdx
+    assert "Morning routine wiki" in mdx
+    assert "Background article." in mdx
+    assert "chunk_id" not in mdx
+    assert "retrieved chunk" not in mdx
+    assert "writer telemetry" not in mdx
+    assert "wiki_query_id" not in mdx
+    assert "vesum_query_id" not in mdx

--- a/tests/test_generate_mdx_v7_resources_vocab.py
+++ b/tests/test_generate_mdx_v7_resources_vocab.py
@@ -114,3 +114,37 @@ def test_format_resources_for_mdx_groups_mixed_roles_with_icons():
     assert "📝 [Morning vocabulary blog](https://example.com/blog)" in mdx
     assert "🎧 [Audio drill](https://example.com/audio)" in mdx
     assert "🔗 [Wikipedia article](https://uk.wikipedia.org/wiki/Ранок)" in mdx
+
+
+def test_format_resources_for_mdx_strips_pipeline_metadata_from_public_text():
+    mdx = format_resources_for_mdx([
+        {
+            "title": "Захарійчук Grade 1 (chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0024)",
+            "source_ref": "Knowledge Packet anchor S1 (chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0024): Захарійчук Grade 1",
+            "pages": "24",
+            "notes": (
+                "writer telemetry retrieved chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0024\n"
+                "Ранкова рутина у підручнику."
+            ),
+            "packet_chunk_id": "1-klas-bukvar-zaharijchuk-2025-1_s0024",
+            "role": "textbook",
+        },
+        {
+            "title": "Morning routine article (wiki_query_id: wiki-123)",
+            "url": "https://example.com/morning",
+            "match_reason": "retrieved chunk_id: wiki-123",
+            "description": "Background article.",
+            "wiki_query_id": "wiki-123",
+            "role": "article",
+        },
+    ])
+
+    assert "Захарійчук Grade 1, p. 24" in mdx
+    assert "Ранкова рутина у підручнику." in mdx
+    assert "[Morning routine article](https://example.com/morning)" in mdx
+    assert "Background article." in mdx
+    assert "chunk_id" not in mdx
+    assert "retrieved chunk" not in mdx
+    assert "writer telemetry" not in mdx
+    assert "wiki_query_id" not in mdx
+    assert "vesum_query_id" not in mdx


### PR DESCRIPTION
## Summary

Closes #2283.

Root cause: `scripts/generate_mdx/resources.py::format_resources_for_mdx()` rendered resource text fields verbatim. V7 resource entries can carry retrieval/debug metadata in fields that are otherwise learner-visible, including `match_reason`, `description`, `notes`, `source_ref`, and `title`.

This PR sanitizes learner-visible resource text at the MDX render layer while preserving public titles/descriptions. It strips or drops pipeline markers such as `chunk_id`, `retrieved chunk`, `writer telemetry`, `wiki_query_id`, and `vesum_query_id` from Tab 4 output.

## Regression coverage

- `tests/test_generate_mdx_v7_resources_vocab.py::test_format_resources_for_mdx_strips_pipeline_metadata_from_public_text` covers direct formatter output with metadata in `title`, `source_ref`, `notes`, `match_reason`, and hidden metadata fields.
- `tests/test_assemble_mdx_v7.py::test_assemble_mdx_v7_sources_render_four_tabs` now covers assembled MDX from a sample `resources.yaml` and asserts the rendered output contains no pipeline metadata strings.

## Evidence

`git grep -nE 'chunk_id|retrieved chunk|writer telemetry|wiki_query_id|vesum_query_id' d1658685353185559628bd3588c82b73e5d12c31 -- curriculum/l2-uk-en/a1/my-morning starlight/src/content/docs/a1/my-morning.mdx` returned no matches in the reverted content commit; current reproducible root cause is source-level rendering of resource metadata fields.

`/Users/krisztiankoos/.codex/worktrees/3a9a/learn-ukrainian$ .venv/bin/pytest tests/test_generate_mdx_v7_resources_vocab.py tests/test_assemble_mdx_v7.py -v --tb=short`

`5 passed in 0.36s`

`/Users/krisztiankoos/.codex/worktrees/3a9a/learn-ukrainian$ .venv/bin/python -m pytest tests/test_generate_mdx*.py tests/test_assemble_mdx*.py -q`

`107 passed in 0.52s`

`/Users/krisztiankoos/.codex/worktrees/3a9a/learn-ukrainian$ .venv/bin/ruff check scripts tests`

`All checks passed!`

`/Users/krisztiankoos/.codex/worktrees/3a9a/learn-ukrainian$ .venv/bin/python scripts/audit/lint_agent_trailer.py`

`All 1 non-skipped commit(s) carry an X-Agent trailer.`

## Review

Local-code-review was run before commit. Gemini kept one regex finding for `retrieved chunk_id`; the Codex challenge round agreed. The fix and test update are included in this PR.

## Phase gate

This is Phase 1 only. Do not start the a1/m20 anchor build until this PR and the Phase 2 #2275 worktree-symlink PR are merged to main.