### PR TITLE
fix(delegate): symlink .venv + node_modules into dispatch worktrees (closes #2275)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -525,17 +525,24 @@ def _validate_existing_worktree(
 
 
 def _provision_data_symlinks(worktree_path: Path, main_repo_root: Path) -> None:
-    """Symlink heavy generated data files into a delegated worktree.
+    """Symlink heavy local-only files into a delegated worktree.
 
-    Worktrees omit gitignored DBs such as data/vesum.db, but Python quality
+    Worktrees omit gitignored DBs and dependency directories, but quality
     gates open them relative to the running checkout. Use symlinks so each
-    delegated worktree sees the same local data without copying multi-GB files.
+    delegated worktree sees the same local files without copying multi-GB
+    directories.
     """
-    for relative_path in ("data/vesum.db", "data/sources.db"):
+    for relative_path in (
+        "data/vesum.db",
+        "data/sources.db",
+        ".venv",
+        "node_modules",
+        "starlight/node_modules",
+    ):
         source = main_repo_root / relative_path
         if not source.exists():
             print(
-                f"⚠️  skipping worktree data link for missing {source}",
+                f"⚠️  skipping worktree link for missing {source}",
                 file=sys.stderr,
             )
             continue
@@ -546,7 +553,7 @@ def _provision_data_symlinks(worktree_path: Path, main_repo_root: Path) -> None:
 
         if target.parent.exists() and not target.parent.is_dir():
             print(
-                f"⚠️  skipping worktree data link because {target.parent} "
+                f"⚠️  skipping worktree link because {target.parent} "
                 "is not a directory",
                 file=sys.stderr,
             )

--- a/tests/test_delegate_data_symlinks.py
+++ b/tests/test_delegate_data_symlinks.py
@@ -1,4 +1,4 @@
-"""Tests for delegate.py worktree data-file provisioning."""
+"""Tests for delegate.py worktree local-file provisioning."""
 from __future__ import annotations
 
 import sys
@@ -29,22 +29,43 @@ def test_provision_data_symlinks_links_heavy_dbs_and_is_idempotent(tmp_path):
     sources_db = data_dir / "sources.db"
     vesum_db.touch()
     sources_db.touch()
+    venv_dir = main_repo / ".venv"
+    node_modules_dir = main_repo / "node_modules"
+    starlight_node_modules_dir = main_repo / "starlight" / "node_modules"
+    venv_dir.mkdir()
+    node_modules_dir.mkdir()
+    starlight_node_modules_dir.mkdir(parents=True)
 
     delegate._provision_data_symlinks(worktree, main_repo)
 
     vesum_link = worktree / "data" / "vesum.db"
     sources_link = worktree / "data" / "sources.db"
+    venv_link = worktree / ".venv"
+    node_modules_link = worktree / "node_modules"
+    starlight_node_modules_link = worktree / "starlight" / "node_modules"
     assert vesum_link.is_symlink()
     assert sources_link.is_symlink()
+    assert venv_link.is_symlink()
+    assert node_modules_link.is_symlink()
+    assert starlight_node_modules_link.is_symlink()
     assert vesum_link.readlink() == vesum_db.resolve()
     assert sources_link.readlink() == sources_db.resolve()
+    assert venv_link.readlink() == venv_dir.resolve()
+    assert node_modules_link.readlink() == node_modules_dir.resolve()
+    assert starlight_node_modules_link.readlink() == starlight_node_modules_dir.resolve()
 
     delegate._provision_data_symlinks(worktree, main_repo)
 
     assert vesum_link.is_symlink()
     assert sources_link.is_symlink()
+    assert venv_link.is_symlink()
+    assert node_modules_link.is_symlink()
+    assert starlight_node_modules_link.is_symlink()
     assert vesum_link.readlink() == vesum_db.resolve()
     assert sources_link.readlink() == sources_db.resolve()
+    assert venv_link.readlink() == venv_dir.resolve()
+    assert node_modules_link.readlink() == node_modules_dir.resolve()
+    assert starlight_node_modules_link.readlink() == starlight_node_modules_dir.resolve()
 
 
 def test_provision_data_symlinks_skips_missing_main_files(tmp_path, capsys):
@@ -55,6 +76,9 @@ def test_provision_data_symlinks_skips_missing_main_files(tmp_path, capsys):
     delegate._provision_data_symlinks(worktree, main_repo)
 
     captured = capsys.readouterr()
-    assert "skipping worktree data link for missing" in captured.err
+    assert "skipping worktree link for missing" in captured.err
     assert not (worktree / "data" / "vesum.db").exists()
     assert not (worktree / "data" / "sources.db").exists()
+    assert not (worktree / ".venv").exists()
+    assert not (worktree / "node_modules").exists()
+    assert not (worktree / "starlight" / "node_modules").exists()


### PR DESCRIPTION
## Summary

- Symlink `.venv`, `node_modules`, and `starlight/node_modules` into dispatch worktrees alongside the existing heavy DB links.
- Keep provisioning idempotent and tolerant of missing optional dependency directories.
- Cover the new dependency links in `tests/test_delegate_data_symlinks.py`.

Closes #2275.

## Validation

- `.venv/bin/python -m pytest tests/test_delegate_data_symlinks.py -q` -> `3 passed in 0.07s`
- `.venv/bin/ruff check scripts/delegate.py tests/test_delegate_data_symlinks.py` -> `All checks passed!`
- `.venv/bin/python -m pytest tests/test_delegate.py tests/test_delegate_data_symlinks.py tests/test_delegate_check_budget.py -q` -> `80 passed in 5.80s`
- `.venv/bin/python -m pytest tests/test_delegate.py tests/test_delegate_data_symlinks.py tests/test_delegate_check_budget.py tests/test_delegate_api.py tests/api/test_delegate_active.py -q` -> `87 passed in 6.52s`
- `.venv/bin/ruff check scripts tests` -> `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> `All 1 non-skipped commit(s) carry an X-Agent trailer.`
- `git diff --check origin/main..HEAD` -> clean
- Manual smoke: `delegate._ensure_worktree(...)` created and then removed a throwaway worktree with `.venv`, `node_modules`, and `starlight/node_modules` symlinked to the main checkout.