### PR TITLE
fix(writer-prompt): ULP S1 baseline + resource-search obligation + dialogue-gloss reconciliation

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1608,9 +1608,11 @@ def _render_wiki_knowledge_packet(
             "activities, or resources. Do not call legacy `scripts.rag` or "
             "Qdrant retrieval for this packet.",
             "",
-            "## Full Wiki Context",
+            "## Compiled Wiki Context",
             "",
-            wiki_packet,
+            "Raw compiled wiki prose is compressed into the targeted excerpts, "
+            "factual anchors, Wiki Obligations Manifest, and Implementation Map "
+            "above. Do not duplicate the full article text in the writer prompt.",
             "",
             "## Plan References",
             "",
@@ -6420,13 +6422,10 @@ def _contract_yaml(plan: Mapping[str, Any]) -> str:
                     "min": int(section["words"] * 0.9),
                     "max": int(section["words"] * 1.1),
                 },
-                "covers": section.get("points", []),
             }
             for section in plan.get("content_outline", [])
         ],
-        "activity_hints": plan.get("activity_hints", []),
-        "vocabulary_required": _required_vocabulary_for_contract(plan),
-        "references": plan.get("references", []),
+        "source_note": "Full plan below is authoritative for points, activity hints, vocabulary, and references.",
     }
     return yaml.safe_dump(contract, allow_unicode=True, sort_keys=False).strip()
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -163,9 +163,45 @@ The contract below is generated upstream by `seed_implementation_map` and is byt
 
 ### External Resources — multimedia search obligation
 
-Attempt at least one multimedia/resource discovery call (`query_wikipedia`, `search_external`, `search_images`, or browser search). `resources_search_attempted` rejects zero attempts. If the manifest lists `external_resources`, include all verified URLs with their supplied role.
+Every module MUST attempt to find at least one multimedia external resource
+(YouTube clip, blog post, podcast episode, video documentary, image gallery)
+relevant to the lesson topic. The agent MUST make at least ONE call to:
+- `mcp__sources__query_wikipedia` for Ukrainian Wikipedia context, OR
+- `mcp__sources__search_external` for blog/article search, OR
+- `mcp__sources__search_images` for image/gallery discovery, OR
+- browser-based search if available in this dispatch's tool set.
 
-Every `resources.yaml` entry needs `role`. The only role that does not require a `url` is `role: textbook`. Non-textbook roles (`youtube`, `video`, `blog`, `podcast`, `audio`, `article`, `wiki`) also require a non-empty `url:`. Omit unverifiable non-textbook entries (OMIT THE ENTRY); never emit `url: null`, `url: ""`, `url: TBD`, or a missing `url`.
+If the Wiki Obligations Manifest's `external_resources` section is non-empty,
+those URLs are AUTHORITATIVE — include all of them in `resources.yaml` with the
+supplied role.
+
+If the search returns nothing usable, that is acceptable — but the search attempt MUST be recorded in the writer telemetry. If you cannot find usable resources, you MUST still record the search attempt in writer telemetry.
+Skipping the search fails the `resources_search_attempted` gate.
+
+In `resources.yaml`, every entry MUST have a `role` field. Valid roles:
+`textbook` (📚), `youtube` (📺), `video` (🎥), `blog` (📝), `podcast` (🎧),
+`audio` (🎧), `article` (📄), `wiki` (🔗).
+
+**Schema rule for non-textbook roles: `url:` is REQUIRED.**
+
+The deterministic schema enforces:
+- `role: textbook` entries do NOT require `url:`.
+- All other roles (`youtube`, `video`, `blog`, `podcast`, `audio`, `article`, `wiki`) REQUIRE a non-empty `url:` field. Schema validation halts the build on any missing URL for these roles.
+
+If you cannot provide a **verified** URL for a non-textbook entry — e.g. the
+multimedia search returned no usable URL, or the wiki source registry shows
+only a placeholder identifier like `ext-article-N` with no real title and no
+URL — **OMIT THE ENTRY ENTIRELY**. Do not emit:
+
+- `url: null`
+- `url: ""`
+- `url: TBD`
+- the entry without the `url:` field
+
+All four patterns fail schema validation. The `resources_search_attempted` gate
+counts the multimedia search **attempt** in your telemetry, so honest omission
+of an unverifiable entry does NOT regress the search-obligation gate. Truthful
+omission is preferred over schema violation.
 
 ### Phonetic rules — MUST emit IPA notation
 
@@ -243,7 +279,7 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 
 **Dialogue format (gate-counted).** Ukrainian dialogue lines must be `<DialogueBox uk="..." en="...">` or `> ` blockquotes. Em-dash-only dialogue under `## Діалоги` is invisible to `l2_exposure_floor` and fails the module.
 
-Each Ukrainian dialogue line needs an inline English gloss within 8 tokens (or the DialogueBox `en` prop). Do not put all translations in a block-bottom gloss.
+Use `<DialogueBox uk="..." en="...">` to render dialogues with side-by-side translation. This satisfies Practice 2 + Practice 4 of ULP for A1 and the `l2_exposure_floor` gate. Em-dash bare lines without an `en` prop fail the gate.
 
 **UK example-sentence density.** A1-m15-24 modules need >=14 gate-countable Ukrainian example surfaces across bullet-list lines and Markdown table data rows. Use bullets/tables for paradigms and trap pairs; prose-only paradigms count zero.
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -580,6 +580,41 @@ def _structural_immersion_rule(band: dict[str, Any]) -> str:
     return structural + language_roles
 
 
+def _ulp_practices_rule(track: str, module_num: int) -> str:
+    """Return the compact ULP S1 presentation baseline for early A1 prompts."""
+    if track != "a1" or module_num > 25:
+        return ""
+    return (
+        "## ULP Presentation Pattern (A1 S1 baseline)\n"
+        "Follow Anna Ohoiko's Ukrainian-first bilingual practices from "
+        "`docs/best-practices/ulp-presentation-pattern.md`:\n"
+        "Key checks: UK-first presentation; em-dash glosses; stress marks; "
+        "named persona.\n"
+        "1. EM-DASH GLOSS: every UK term in EN narration uses UK-first, "
+        "em-dash gloss order: `Приві́т! — Hi!`; never gloss-first.\n"
+        "2. SIDE-BY-SIDE BILINGUAL: narrative passages of 3+ sentences render "
+        "as a two-column MD table (UK left, EN right) or `<DialogueBox>`-style "
+        "side-by-side translation, not EN-only prose with a vocab dump.\n"
+        "3. STRESS MARKS: every multi-syllable UK term has stress marks "
+        "throughout Tab 1 prose, Tab 2 vocabulary, and Tab 3 activity prompts "
+        "(`Приві́т`, `спра́ви`, `чудо́во`).\n"
+        "4. DIALOGUE UK-ONLY: Tab 1 dialogues use pure Ukrainian named-speaker "
+        "turns first. Translation or breakdown follows after the dialogue; do "
+        "not interleave English inside the UK turn text.\n"
+        "5. UK-ONLY Q&A: Tab 3 comprehension/recall stems and answer options "
+        "are Ukrainian-only for content questions. English appears only as "
+        "secondary UI support where needed.\n"
+        "6. TRANSLATE -> WORKBOOK: EN-to-UK translation is a workbook/booster "
+        "activity in Tab 3, never Tab 1 teaching prose.\n"
+        "7. NAMED PERSONA: Tab 1 uses a named persona or named characters, with "
+        "real Ukrainian places, foods, and activities instead of generic L2 "
+        "fillers.\n"
+        "A1 violations: English-first framing, transliteration tables, inline "
+        "EN glossing inside dialogue turns, single-column EN narration with "
+        "vocab dumps, and abstract 'the student must learn' framing."
+    )
+
+
 def _extend_immersion_band(raw_band: dict[str, Any]) -> dict[str, Any]:
     band = dict(raw_band)
     band["advisory_pct_min"] = int(band.pop("min_pct"))
@@ -793,7 +828,11 @@ def get_immersion_rule(
     learner_state: dict | None = None,
 ) -> str:
     """Return the writer-facing immersion instruction for a track/module pair."""
-    return str(compute_immersion_band(track, module_num, learner_state)["rule"])
+    rule = str(compute_immersion_band(track, module_num, learner_state)["rule"])
+    ulp_rule = _ulp_practices_rule(track, module_num)
+    if ulp_rule:
+        return f"{rule}\n\n{ulp_rule}"
+    return rule
 
 if __name__ == "__main__":
     # Simple CLI test

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -998,6 +998,7 @@ def search_sources(
                 limit=limit,
             ),
         )
+    require_textbook_section = strategy == "modern_dense_section"
     if strategy == "modern_dense_section":
         strategy = "unified_dense"
     if strategy != "unified_dense":
@@ -1034,6 +1035,30 @@ def search_sources(
     )
     expanded = [_expand_neighbor_context(match) for match in merged[:max(limit * 3, limit)]]
     capped = _apply_context_cap(track, expanded)
+    if require_textbook_section and not any(
+        match.get("corpus") == "textbook_sections" for match in capped
+    ):
+        textbook_section = next(
+            (match for match in expanded if match.get("corpus") == "textbook_sections"),
+            None,
+        )
+        if textbook_section is None:
+            raw_textbook_section = next(
+                (match for match in merged if match.get("corpus") == "textbook_sections"),
+                None,
+            )
+            if raw_textbook_section is not None:
+                textbook_section = _expand_neighbor_context(raw_textbook_section)
+        if textbook_section is not None:
+            capped = [
+                textbook_section,
+                *[
+                    match
+                    for match in capped
+                    if match.get("corpus") != "textbook_sections"
+                    or match.get("unit_key") != textbook_section.get("unit_key")
+                ],
+            ]
     return capped[:limit]
 
 

--- a/tests/test_compute_immersion_band.py
+++ b/tests/test_compute_immersion_band.py
@@ -41,4 +41,4 @@ def test_immersion_accessors_preserve_backward_compat_when_flag_off(monkeypatch)
     )
     structural = config.get_immersion_structural("a1", 15)
     assert structural["min_uk_dialogue_lines"] == policy["min_uk_dialogue_lines"]
-    assert config.get_immersion_rule("a1", 15) == policy["rule"]
+    assert config.get_immersion_rule("a1", 15).startswith(policy["rule"])

--- a/tests/test_immersion_rule_ulp.py
+++ b/tests/test_immersion_rule_ulp.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from scripts import config
+
+ULP_KEYWORDS = (
+    "em-dash",
+    "side-by-side",
+    "stress marks",
+    "UK-first",
+    "named persona",
+)
+
+
+def _keyword_hits(rule: str) -> int:
+    lowered = rule.lower()
+    return sum(1 for keyword in ULP_KEYWORDS if keyword.lower() in lowered)
+
+
+def test_a1_letter_module_gets_ulp_practices() -> None:
+    rule = config.get_immersion_rule("a1", 4)
+
+    assert "ULP Presentation Pattern" in rule
+    assert _keyword_hits(rule) >= 2
+
+
+def test_a1_m20_gets_ulp_practices() -> None:
+    rule = config.get_immersion_rule("a1", 20)
+
+    assert "ULP Presentation Pattern" in rule
+    assert _keyword_hits(rule) >= 2
+
+
+def test_a1_late_module_does_not_get_s1_ulp_practices() -> None:
+    rule = config.get_immersion_rule("a1", 50)
+
+    assert "ULP Presentation Pattern" not in rule
+    assert _keyword_hits(rule) == 0
+
+
+def test_c1_module_does_not_get_a1_ulp_practices() -> None:
+    rule = config.get_immersion_rule("c1", 50)
+
+    assert "ULP Presentation Pattern" not in rule
+    assert _keyword_hits(rule) == 0

--- a/tests/test_writer_prompt_no_inline_gloss_8_tokens.py
+++ b/tests/test_writer_prompt_no_inline_gloss_8_tokens.py
@@ -1,0 +1,40 @@
+import json
+
+from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import seed_implementation_map
+
+
+def _render_a1_my_morning_prompt() -> str:
+    level = "a1"
+    slug = "my-morning"
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.plan_check(plan_path)
+    manifest = {
+        "slug": slug,
+        "wiki_path": f"wiki/pedagogy/{level}/{slug}.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+    return linear_pipeline.render_writer_prompt(
+        plan=plan,
+        plan_content=plan_path.read_text(encoding="utf-8"),
+        knowledge_packet="Knowledge packet stub for dialogue prompt smoke.",
+        wiki_manifest=json.dumps(manifest, ensure_ascii=False, indent=2),
+        implementation_map=seed_implementation_map(manifest, plan=plan),
+    )
+
+
+def test_writer_prompt_does_not_require_inline_english_gloss_within_8_tokens() -> None:
+    prompt = _render_a1_my_morning_prompt()
+
+    assert "inline English gloss within 8 tokens" not in prompt
+
+
+def test_writer_prompt_requires_dialoguebox_side_by_side_translation() -> None:
+    prompt = _render_a1_my_morning_prompt()
+
+    assert 'Use `<DialogueBox uk="..." en="...">`' in prompt
+    assert "side-by-side translation" in prompt

--- a/tests/test_writer_prompt_render_size.py
+++ b/tests/test_writer_prompt_render_size.py
@@ -1,0 +1,53 @@
+import json
+
+from scripts.audit.check_writer_prompt_size import (
+    WRITER_PROMPT_CEILING_BYTES,
+    render_fixture_writer_prompt,
+)
+from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import seed_implementation_map
+
+
+def _stub_manifest(level: str, slug: str) -> dict:
+    return {
+        "slug": slug,
+        "wiki_path": f"wiki/pedagogy/{level}/{slug}.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+
+
+def _render_c1_sample_prompt() -> str:
+    level = "c1"
+    slug = "abstract-writing"
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.load_plan(plan_path)
+    manifest = _stub_manifest(level, slug)
+    return linear_pipeline.render_writer_prompt(
+        plan=plan,
+        plan_content=plan_path.read_text(encoding="utf-8"),
+        knowledge_packet="Knowledge packet stub for C1 prompt-size smoke.",
+        wiki_manifest=json.dumps(manifest, ensure_ascii=False, indent=2),
+        implementation_map=seed_implementation_map(manifest, plan=plan),
+    )
+
+
+def test_a1_letter_module_writer_prompt_stays_under_ceiling() -> None:
+    prompt = render_fixture_writer_prompt("a1", "sounds-letters-and-hello")
+
+    assert len(prompt.encode("utf-8")) <= WRITER_PROMPT_CEILING_BYTES
+
+
+def test_a1_m20_writer_prompt_stays_under_ceiling() -> None:
+    prompt = render_fixture_writer_prompt("a1", "my-morning")
+
+    assert len(prompt.encode("utf-8")) <= WRITER_PROMPT_CEILING_BYTES
+
+
+def test_c1_sample_writer_prompt_stays_under_ceiling() -> None:
+    prompt = _render_c1_sample_prompt()
+
+    assert len(prompt.encode("utf-8")) <= WRITER_PROMPT_CEILING_BYTES

--- a/tests/test_writer_prompt_resource_search_obligation.py
+++ b/tests/test_writer_prompt_resource_search_obligation.py
@@ -1,0 +1,39 @@
+import json
+
+from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import seed_implementation_map
+
+
+def _render_prompt(level: str, slug: str, *, validate: bool = True) -> str:
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.plan_check(plan_path) if validate else linear_pipeline.load_plan(plan_path)
+    manifest = {
+        "slug": slug,
+        "wiki_path": f"wiki/pedagogy/{level}/{slug}.md",
+        "sequence_steps": [],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+        "external_resources": [],
+    }
+    return linear_pipeline.render_writer_prompt(
+        plan=plan,
+        plan_content=plan_path.read_text(encoding="utf-8"),
+        knowledge_packet="Knowledge packet stub for resource-search prompt smoke.",
+        wiki_manifest=json.dumps(manifest, ensure_ascii=False, indent=2),
+        implementation_map=seed_implementation_map(manifest, plan=plan),
+    )
+
+
+def test_a1_writer_prompt_requires_resource_search_attempt_telemetry() -> None:
+    prompt = _render_prompt("a1", "my-morning")
+
+    assert "resources_search_attempted" in prompt
+    assert "MUST still record the search attempt in writer telemetry" in prompt
+
+
+def test_c1_writer_prompt_requires_resource_search_attempt_telemetry() -> None:
+    prompt = _render_prompt("c1", "abstract-writing", validate=False)
+
+    assert "resources_search_attempted" in prompt
+    assert "MUST still record the search attempt in writer telemetry" in prompt


### PR DESCRIPTION
## Summary

Addresses **#2288** (a1/m20 anchor build blocker — writer was not following ULP, not searching resources, conflicting dialogue-gloss instruction) and implements **#2278** (conditional ULP injection via `{IMMERSION_RULE}`).

Three change clusters:
1. **Core writer-prompt fix** (`scripts/build/phases/linear-write.md`) — expanded resource-search obligation to match grok prompt's "MUST be recorded in writer telemetry" language; replaced "inline English gloss within 8 tokens" with `<DialogueBox uk en>` side-by-side directive (resolves ULP Practice 4 vs `l2_exposure_floor` gate conflict)
2. **ULP S1 baseline injection** (`scripts/config.py`) — new `_ulp_practices_rule(track, module_num)` emits compact 7-practices contract for `a1` m01-m25; `get_immersion_rule()` appends it when non-empty
3. **Prompt-size budget protection** (`scripts/build/linear_pipeline.py`) — compressed `## Full Wiki Context` and slimmed `_contract_yaml` to make room for ULP content under 130KB ceiling

**Bundled (scope-adjacent)**: `scripts/wiki/sources_db.py` — `modern_dense_section` fallback ensuring at least one `textbook_section` candidate survives the BM25 cap. Fixes pre-existing flake in `tests/wiki/test_t1_t2_pipeline.py`.

## Test plan

- [x] 14/14 new+modified tests pass (`tests/test_immersion_rule_ulp.py`, `tests/test_writer_prompt_render_size.py`, `tests/test_writer_prompt_no_inline_gloss_8_tokens.py`, `tests/test_writer_prompt_resource_search_obligation.py`, `tests/test_compute_immersion_band.py`) — `14 passed in 94.96s`
- [x] Broad sweep `pytest -k 'immersion or writer_prompt or pipeline or wiki'` — `1408 passed in 208.72s` (2 worktree-only env failures: `tests/wiki/test_mlx_fault_injection.py` needs gitignored `embed-venv` symlink; `tests/test_wiki_channels.py` needs gitignored `data/external_articles/*.jsonl` symlinks. Both pass in main + CI.)
- [x] Rendered prompt size for `a1/sounds-letters-and-hello`, `a1/my-morning`, `c1 sample` all ≤ 130KB ceiling
- [ ] After merge: re-fire m20 build from existing worktree at `~/.codex/worktrees/3a9a/learn-ukrainian/.worktrees/dispatch/codex/a1-m20-anchor-2026-05-26` via `git pull && .venv/bin/python -u scripts/build/v7_build.py a1 my-morning --worktree --no-resume`

## Implementation note

Headless codex dispatch (task `writer-prompt-ulp-and-resource-search-2026-05-25`, gpt-5.5 xhigh) did the implementation + tests, then hit the 30-min silence timeout while waiting on an `ab ask-gemini` adversarial review that never returned. All work intact in the dispatch worktree; orchestrator validated tests, sanity-checked diff, committed and opened this PR.

Do not close #2288 in this PR — close it in the m20 anchor PR after the rebuilt module ships clean from this fixed writer-prompt foundation.

## Follow-up scope

- `_provision_data_symlinks` in `scripts/delegate.py` should be extended (as a follow-up to #2275) to also symlink `embed-venv` and `data/external_articles/*.jsonl` into dispatch worktrees. Both surfaced as local-env test failures during validation of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)