### PR TITLE
fix(a1-m20): plan recommended-pool + writer-prompt pre-emit checklist

### DIFF
--- a/curriculum/l2-uk-en/plans/a1/my-morning.yaml.bak
+++ b/curriculum/l2-uk-en/plans/a1/my-morning.yaml.bak
@@ -2,7 +2,7 @@ module: a1-020
 level: A1
 sequence: 20
 slug: my-morning
-version: 1.2.4
+version: 1.2.3
 title: Мій ранок
 subtitle: Прокидаюся, вмиваюся — зворотні дієслова та ранкова рутина
 focus: grammar
@@ -40,23 +40,6 @@ content_outline:
   words: 300
   points:
   - 'Зворотні дієслова = звичайне дієслово + ся в кінці. я -юся, ти -єшся, він/вона -ється (схема І дієвідміни + ся). Ранкова рутина: прокидатися → вмиватися → одягатися → снідати → йти. Слова послідовності: спочатку, потім, після цього, нарешті. Самоперевірка: Опишіть свій ранок у 4-5 реченнях, використовуючи слова послідовності.'
-targets:
-  # NEW vocabulary introduced by m20. Twelve deduped lemmas consumed by
-  # the learner-state plan-fallback (#2272) for downstream modules' cumulative
-  # vocab window. Mirrors the required + high-value recommended set.
-  new_vocabulary:
-  - прокидатися
-  - вмиватися
-  - одягатися
-  - снідати
-  - збиратися
-  - повертатися
-  - навчатися
-  - поспішати
-  - спочатку
-  - потім
-  - після цього
-  - нарешті
 vocabulary_hints:
   required:
   - прокидатися (to wake up)
@@ -75,18 +58,6 @@ vocabulary_hints:
   - нарешті (finally)
   - вранці (in the morning)
   - пізно (late)
-  # m20 anchor expansion (2026-05-26): pad headroom for vocab_floor gate
-  # (#2296). All 12 verified in VESUM. Topically anchored to morning routine.
-  - чистити зуби (to brush teeth)
-  - причісуватися (to comb one's hair — reflexive, supplements core focus)
-  - рушник (towel)
-  - мило (soap)
-  - зубна паста (toothpaste)
-  - будильник (alarm clock)
-  - сніданок (breakfast — noun form of снідати)
-  - рано (early — contrast partner of пізно)
-  - швидко (quickly)
-  - готовий (ready)
 activity_hints:
 - type: fill-in
   focus: 'Додайте -ся: я вмиваю__ , ти одягаєш__ , він прокидаєть__'

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -136,7 +136,18 @@ Sources in blockquotes/resources must be either in `plan_references` or grounded
 
 **5. End-of-output gate.** Before artifacts, rescan: all Ukrainian forms verified or marker-protected, every source grounded, every quote literal. Omit or rewrite anything unverifiable.
 
-You MUST record this scan as a visible `<end_gate>...</end_gate>` block AFTER the four artifact fences. Required sub-nodes: `<rescanned_words>`, `<rescanned_sources>`, `<grammar_claims_grounded>`, `<removed_unverified>`. A missing block records `gate_present=false` and the writer is treated as having skipped the protocol.
+You MUST record this scan as a visible `<end_gate>...</end_gate>` block AFTER the four artifact fences. Required sub-nodes:
+
+- `<rescanned_words>` — list of Ukrainian word forms re-verified during the end-of-output rescan.
+- `<rescanned_sources>` — list of sources re-grounded.
+- `<grammar_claims_grounded>` — list of grammar claims with their cite source.
+- `<removed_unverified>` — list of forms/claims removed because they could not be verified.
+- `<chunk_context_calls>N</chunk_context_calls>` — integer count of `mcp__sources__get_chunk_context` calls you made this turn. **MUST equal the count of `plan_references` entries.** If you wrote `0` here while the plan has textbook references, you have skipped step 3(B) of Textbook grounding — STOP, return to step 3(B), call `get_chunk_context(chunk_id=<ID>)` for each plan reference, then re-emit.
+- `<chunk_context_chunk_ids>` — bullet list of the EXACT chunk_id strings you passed to `get_chunk_context`. The deterministic gate cross-references these against the writer telemetry; mismatches are treated as `tool_theatre` (a hard fail).
+- `<resources_search_calls>N</resources_search_calls>` — integer count of multimedia search calls (`mcp__sources__query_wikipedia` + `mcp__sources__search_external` + `mcp__sources__search_images`). **MUST be ≥ 1.** Other tool calls (`search_text`, `search_style_guide`, `verify_words`, `query_cefr_level`, `query_pravopys`) DO NOT count toward this gate. If you wrote `0` here, STOP, call ONE of the three multimedia tools, then re-emit.
+- `<resources_search_tools>` — bullet list of the exact tool names you called toward the multimedia search obligation (e.g. `mcp__sources__query_wikipedia`).
+
+A missing block records `gate_present=false` and the writer is treated as having skipped the protocol. Lying about counts is detected post-hoc: the pipeline compares your self-reported counts against tool telemetry; a mismatch is treated as `tool_theatre` (hard fail, no correction loop).
 
 **Tool-citation honesty (mandatory).** Every tool name you cite inside `<plan_reasoning verification="...">` or block body MUST correspond to an actual tool call you made on this turn. The pipeline cross-references citations against the trace; unmatched names are a hard fail (`tool_theatre`). Canonical names only: use exact `mcp__sources__...` names; no family aliases.
 
@@ -411,6 +422,16 @@ Before artifacts, make the in-scope MCP calls your draft depends on:
 7. Source attribution: `mcp__sources__verify_source_attribution` for every named source claim.
 
 If a required call is missing for your level, make it now. Do not emit artifacts first and hope the gate catches it.
+
+## PRE-EMIT HARD STOP — read this NOW, before any artifact fence
+
+Two writer-failure modes have repeatedly survived earlier prompt strengthening because their MANDATORY language sits in the middle of this 470-line prompt and gets forgotten by emission time. Re-check both BEFORE emitting:
+
+1. **`get_chunk_context` for every plan reference.** Counting `search_text` calls toward `textbook_grounding` is wrong — the gate explicitly rejects builds where `chunk_context_calls=0` even if `search_text_calls > 0`. For EACH entry in `plan.references`, call `mcp__sources__get_chunk_context(chunk_id=<the ID from notes>)`. If your count is currently zero, you have NOT satisfied this obligation, regardless of how many `search_text` calls you made. The blockquote in your draft MUST be ≥30 contiguous words from that returned chunk text, verbatim.
+
+2. **At least ONE multimedia search call.** Counting `search_text`, `search_style_guide`, `verify_words`, `query_pravopys`, `search_definitions`, or `query_cefr_level` toward `resources_search_attempted` is wrong — the gate counts ONLY `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, and `mcp__sources__search_images`. Make at least ONE of these THREE calls before emitting. An empty result is acceptable (omit unverifiable entries from `resources.yaml`); a zero attempt is not.
+
+If your current tool history does not include BOTH of the above, STOP, make the missing calls, then resume to artifact emission. The `<end_gate>` block will require explicit integer counts for both — and the pipeline cross-references those counts against your telemetry. Lying fails the build via `tool_theatre`; honestly reporting zero fails the build via `textbook_grounding` / `resources_search_attempted`. Only doing the calls satisfies both.
 
 ## Artifact emission format (STRICT — restored 2026-05-23 after PR-C strip)
 


### PR DESCRIPTION
## Summary

Two root-cause fixes for the m20 anchor build (a1/my-morning) that failed gates this round:

| Failing gate | Why | Fix |
|---|---|---|
| `textbook_grounding` HARD | `chunk_context_calls=0` — writer called `search_text` 2× but skipped the MANDATORY `get_chunk_context` follow-up. Buried at line 123 of the 105KB prompt. | Writer prompt: PRE-EMIT HARD STOP callout + explicit end_gate count requirement |
| `resources_search_attempted` HARD | `search_attempt_count=0` — writer didn't call ANY of `query_wikipedia` / `search_external` / `search_images`. | Same PRE-EMIT HARD STOP + end_gate count |
| `vocab_count` (triggered correction) | 20/25 with `unused_recommended_count=0` — plan ran out of pad-pool headroom for #2296's `vocab_floor` gate. | Plan: +10 recommended lemmas + `targets.new_vocabulary` block |

No shared-pipeline architecture change. **Diff-only correction architecture remains deferred** until we verify whether prompt-strengthening is sufficient (it might be — the writer DID emit 25 tool calls, just the wrong ones).

## Plan changes

`curriculum/l2-uk-en/plans/a1/my-morning.yaml` v1.2.3 → v1.2.4. With `.yaml.bak` snapshot per non-negotiable-rules §7.

- Adds `targets.new_vocabulary` block (12 deduped lemmas) — the brief at `docs/dispatch-briefs/2026-05-26-a1-m20-anchor-codex.md` line 25 expected this block in v1.2.3 but it was missing. Consumed by learner-state plan-fallback (#2272).
- Expands `vocabulary_hints.recommended` from 8 → 18 lemmas. Adds 10 morning-routine words verified in VESUM (12/12 batch-checked): чистити зуби, причісуватися, рушник, мило, зубна паста, будильник, сніданок, рано, швидко, готовий.

## Writer prompt changes

`scripts/build/phases/linear-write.md`:

1. **End-gate sub-nodes**: now requires `<chunk_context_calls>N</chunk_context_calls>` (must equal plan_references count), `<resources_search_calls>N</resources_search_calls>` (must be ≥1), plus list nodes for the actual chunk_ids and tool names called. Pipeline can post-hoc compare against tool telemetry; mismatches surface as `tool_theatre`.
2. **New PRE-EMIT HARD STOP** callout immediately before artifact emission format. Explicitly names which tools DO NOT count (search_text alone does not satisfy textbook_grounding; verify_words / cefr_level / style_guide do not count toward resources_search_attempted). Recency-biased reminder right before the writer emits.

## Test plan
- [x] `pytest tests/ -k "plan or my_morning or vocab_count or vocab_floor or yaml_activ"` → 399 passed
- [x] `pytest tests/ -k "writer_pre_emit or write_prompt or linear_write"` → 6 passed
- [x] `ruff check scripts curriculum` clean
- [x] All 12 added lemmas verified in VESUM (batch check)
- [ ] m20 anchor rebuild after this merges — codex UI dispatch follows

## Related
- Closes follow-up of #2294 (correction loop architectural fix #2296 was insufficient without plan headroom)
- Closes follow-up of #2288 (writer prompt ULP/resource obligations from #2289 needed enforcement strengthening)
- Anchor build for #2294 / m20 anchor build remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)