### PR TITLE
feat(bridge): ab send-codex-ui — Lane 1 send to running Codex Desktop (#2285)

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -779,6 +779,48 @@ def _build_parser() -> argparse.ArgumentParser:
     # interactive
     subparsers.add_parser("interactive", help="Interactive mode")
 
+    # send-codex-ui — Lane 1 from issue #2285 (agent bridge to running UI)
+    send_codex_ui_parser = subparsers.add_parser(
+        "send-codex-ui",
+        help="Send a prompt to a running Codex Desktop UI session via `codex exec resume`",
+    )
+    send_codex_ui_parser.add_argument(
+        "--thread",
+        required=True,
+        help="Codex thread UUID (find via `codex sessions list --last` or ~/.codex/sessions/)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--cwd",
+        default=None,
+        help="Working directory for the codex subprocess (default: caller's cwd)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=1800,
+        help="Max wall-clock seconds (default 1800 = 30min)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--from-file",
+        default=None,
+        help="Read message body from a file (use '-' for stdin)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes verbose events list)",
+    )
+    send_codex_ui_parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+
     # Channel bridge commands (#1190) — registered in _channels_cli
     from ._channels_cli import register_channel_commands
     register_channel_commands(subparsers)
@@ -876,6 +918,23 @@ def _dispatch_command(args):
         uvicorn.run(app, host=args.host, port=args.port, log_level="info")
     elif args.command == "interactive":
         interactive_mode()
+    elif args.command == "send-codex-ui":
+        from ._ui_codex import cli_main as _ui_codex_cli_main
+        argv: list[str] = ["--thread", args.thread]
+        if args.bridge_id:
+            argv += ["--bridge-id", args.bridge_id]
+        if args.cwd:
+            argv += ["--cwd", args.cwd]
+        if args.timeout != 1800:
+            argv += ["--timeout", str(args.timeout)]
+        if getattr(args, "json", False):
+            argv += ["--json"]
+        if args.from_file:
+            argv += ["--from-file", args.from_file]
+        if args.message:
+            argv += [args.message]
+        rc = _ui_codex_cli_main(argv)
+        sys.exit(rc)
     elif args.command in ("channel", "post", "p", "reconcile", "sync", "discuss"):
         # Channel bridge commands (#1190)
         from ._channels_cli import dispatch_channel_command

--- a/scripts/ai_agent_bridge/_ui_codex.py
+++ b/scripts/ai_agent_bridge/_ui_codex.py
@@ -1,0 +1,279 @@
+"""Send a prompt to a running Codex Desktop UI session via `codex exec resume`.
+
+Lane 1 implementation from issue #2285 (agent bridge — send + receive to
+running Codex UI / Cursor / Claude Code Desktop sessions).
+
+## How it works
+
+`codex exec resume <THREAD_UUID> --json -` (Codex CLI 0.133.0+) resumes a
+persisted thread non-interactively. The subprocess emits a JSON event stream
+on stdout containing turn events, item executions, and the agent's final
+message. We feed the prompt via stdin (prefixed with a `Bridge-ID:` line for
+correlation), then parse the stream.
+
+## Empirical findings (2026-05-25 bridge probe)
+
+The probe ran `codex exec resume 019e6063-... --json -` with a small prompt,
+targeting a thread that the Codex Desktop process held open for write.
+Observed behavior:
+
+1. The original session JSONL grew (codex APPENDED events). The live UI
+   process (PID 83697) and the resume subprocess BOTH wrote to the same
+   rollout file. The thread state is consistent on disk regardless of
+   which subprocess produced an event.
+2. A NEW parallel rollout JSONL was ALSO created (new UUID, sharing thread
+   history). This is harmless overhead — both files reflect the same turn.
+3. The resume subprocess inherits the caller's CWD. Codex executed
+   `git rev-parse --short HEAD` and saw the caller's commit SHA, NOT the
+   UI session's worktree HEAD. Callers wanting the work to happen in a
+   specific worktree must `cd` there before invoking (or use `cwd=` here).
+4. Whether the visible Codex Desktop window displays the new turn live is
+   not verified here. The thread state is consistent on disk — re-opening
+   the same thread in the UI shows the appended events regardless.
+
+## Usage from CLI
+
+    ab send-codex-ui --thread <UUID> "your message"
+    ab send-codex-ui --thread <UUID> --from-file relay.md
+    ab send-codex-ui --thread <UUID> --cwd ~/some/worktree "message"
+
+## Usage from Python
+
+    from ai_agent_bridge._ui_codex import send
+    result = send(thread_id="019e6063-...", message="ping", cwd=Path("/tmp"))
+    print(result["final_message"])
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+CODEX_SESSIONS_ROOT = Path.home() / ".codex" / "sessions"
+DEFAULT_TIMEOUT_S = 1800  # 30 min — covers most multi-turn dispatches
+
+
+def find_session_file(thread_id: str) -> Path | None:
+    """Locate the most recent rollout JSONL for a given thread UUID.
+
+    Codex stores session JSONLs as
+    `~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<UUID>.jsonl`. The
+    `<UUID>` segment matches the thread id. There may be multiple files
+    per thread when `codex exec resume` has been invoked previously; we
+    return the most recently modified.
+    """
+    matches = sorted(
+        CODEX_SESSIONS_ROOT.glob(f"**/rollout-*{thread_id}.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _extract_final_message(events: list[dict]) -> str | None:
+    """Pick the last informative message from a stream of resume events.
+
+    Prefer the last `agent_message` content. Fall back to the last
+    completed `command_execution`'s aggregated_output if no agent_message
+    fired (e.g. when the prompt asked codex to print a shell line directly).
+    """
+    final_agent_msg: str | None = None
+    final_cmd_output: str | None = None
+    for evt in events:
+        if evt.get("type") != "item.completed":
+            continue
+        item = evt.get("item", {})
+        item_type = item.get("type")
+        if item_type == "agent_message":
+            final_agent_msg = item.get("text") or item.get("content")
+        elif item_type == "command_execution":
+            final_cmd_output = item.get("aggregated_output")
+    return final_agent_msg or final_cmd_output
+
+
+def send(
+    thread_id: str,
+    message: str,
+    *,
+    bridge_id: str | None = None,
+    cwd: Path | None = None,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Send a prompt to a running Codex Desktop UI session via `codex exec resume`.
+
+    Args:
+        thread_id: UUID of the persisted codex thread (find via
+            `codex sessions list` or by inspecting `~/.codex/sessions/`
+            for a rollout JSONL whose codex process holds it open for write).
+        message: prompt body. A `Bridge-ID: <id>` line is prepended for
+            correlation; the receiving agent should echo the Bridge-ID
+            in its reply if asked.
+        bridge_id: correlation id (auto-generated if None).
+        cwd: working directory for the codex subprocess. If None, inherits
+            the caller's cwd. Codex will run shell commands against this
+            directory's git state — important when targeting a worktree.
+        timeout_s: max wall-clock for the codex subprocess (default 30 min).
+
+    Returns:
+        dict with:
+            bridge_id (str), thread_id (str), exit_code (int),
+            events (list[dict] of parsed JSON event lines from stdout),
+            final_message (str | None) — best-effort extraction,
+            duration_s (float), session_file (str | None) — path to the
+            original UI session JSONL if locatable, stderr (str).
+    """
+    bridge_id = bridge_id or f"bridge-{uuid.uuid4().hex[:8]}"
+    framed_message = f"Bridge-ID: {bridge_id}\n\n{message}"
+    session_file = find_session_file(thread_id)
+
+    start = datetime.now(UTC)
+    try:
+        proc = subprocess.run(
+            ["codex", "exec", "resume", "--json", thread_id, "-"],
+            input=framed_message,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        stdout = proc.stdout
+        stderr = proc.stderr
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired as e:
+        stdout = e.stdout.decode("utf-8", errors="replace") if isinstance(e.stdout, bytes) else (e.stdout or "")
+        stderr = e.stderr.decode("utf-8", errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or "")
+        stderr = f"[timeout after {timeout_s}s]\n{stderr}"
+        exit_code = -1
+    duration_s = (datetime.now(UTC) - start).total_seconds()
+
+    events: list[dict] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    return {
+        "bridge_id": bridge_id,
+        "thread_id": thread_id,
+        "exit_code": exit_code,
+        "events": events,
+        "final_message": _extract_final_message(events),
+        "duration_s": duration_s,
+        "session_file": str(session_file) if session_file else None,
+        "stderr": stderr,
+    }
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ab send-codex-ui",
+        description=(
+            "Send a prompt to a running Codex Desktop UI session via "
+            "`codex exec resume`. Lane 1 from issue #2285. "
+            "Returns the codex subprocess exit code."
+        ),
+    )
+    parser.add_argument(
+        "--thread",
+        required=True,
+        help=(
+            "Codex thread UUID. Find via `codex sessions list --last` or "
+            "by inspecting `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`"
+            " (the file whose codex process holds it open for write)."
+        ),
+    )
+    parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given).",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help=(
+            "Working directory for the codex subprocess. Codex will run "
+            "shell commands against this directory's git state — point it "
+            "at the target worktree when relevant."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        help=f"Max wall-clock seconds (default {DEFAULT_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read message body from a file (use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes the verbose events list).",
+    )
+    parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file and args.message:
+        parser.error("provide either --from-file or a positional message, not both")
+    if args.from_file:
+        message = (
+            sys.stdin.read()
+            if str(args.from_file) == "-"
+            else args.from_file.read_text(encoding="utf-8")
+        )
+    elif args.message:
+        message = args.message
+    else:
+        parser.error("must provide a message via positional arg or --from-file")
+
+    result = send(
+        thread_id=args.thread,
+        message=message,
+        bridge_id=args.bridge_id,
+        cwd=args.cwd,
+        timeout_s=args.timeout,
+    )
+
+    if args.json:
+        compact = {k: v for k, v in result.items() if k != "events"}
+        compact["event_count"] = len(result["events"])
+        print(json.dumps(compact, indent=2, default=str))
+    else:
+        print(f"thread:       {result['thread_id']}")
+        print(f"bridge_id:    {result['bridge_id']}")
+        print(f"exit_code:    {result['exit_code']}")
+        print(f"duration_s:   {result['duration_s']:.2f}")
+        print(f"events:       {len(result['events'])}")
+        print(f"session_file: {result['session_file']}")
+        if result["final_message"]:
+            print()
+            print("=== final message ===")
+            print(result["final_message"])
+        if result["stderr"]:
+            print()
+            print("=== stderr (truncated) ===")
+            print(result["stderr"][:2000])
+
+    return 0 if result["exit_code"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())


### PR DESCRIPTION
## Summary

First codex-side delivery of issue #2285. Implements the Lane 1 send path empirically verified against codex-cli 0.133.0.

\`ab send-codex-ui --thread <UUID> "<message>"\` injects a turn into a persisted codex thread held open by the Codex Desktop UI. Closes the \"~4 manual relays per 3-phase delivery\" pain point from the issue body.

## Empirical findings (answers the open question in #2285)

Probe 2026-05-25 23:27 against the live m20 Codex Desktop session (thread \`019e6063-c3da-78d1-acaa-4cd684a08786\`, codex PID 83697):

1. \`codex exec resume <UUID>\` **APPENDS** events to the original session JSONL that the live UI process holds open for write. Thread state consistent on disk; re-opening the same thread in the UI shows the appended turn regardless of live-window refresh.
2. A **NEW parallel rollout JSONL is also created** alongside the append. Harmless overhead — both files reflect the same turn events.
3. The resume subprocess **inherits the caller's CWD**, NOT the UI session's cwd. Codex ran \`git rev-parse\` and saw the caller's HEAD (a local unpushed commit). Callers must \`cd\` to the target worktree before invoking (or pass \`--cwd\`).
4. The PONG sanity probe round-tripped in **9.8s, exit 0**, with \`final_message: \"PONG\"\` correctly extracted.

## Coverage (this PR)

Codex UI only — Cursor + Claude Code Desktop + **Antigravity UI** (Gemini-side, added to scope per user direction 2026-05-26) follow as separate commits. Lane 2 (AX/AppleScript) is unnecessary based on this empirical result and deferred indefinitely.

## CLI surface

\`\`\`
ab send-codex-ui --thread <UUID> "<message>"
ab send-codex-ui --thread <UUID> --from-file relay.md
ab send-codex-ui --thread <UUID> --cwd ~/some/worktree "message"
ab send-codex-ui --thread <UUID> --json
\`\`\`

Returns \`{bridge_id, thread_id, exit_code, events, final_message, duration_s, session_file, stderr}\`.

## Test plan
- [x] \`ruff check scripts/ai_agent_bridge\` clean
- [x] Empirical probe against live Codex Desktop session — PONG round-trip 9.8s, exit 0
- [ ] Unit tests for find_session_file + _extract_final_message (follow-up — easier to write once we have the full 4-agent surface design landed)
- [ ] Tests against a mock codex CLI subprocess (follow-up)

## Related
- #2285 (issue body — original design + Cursor consultation + UI lifecycle requirements)
- Companion of #2287 (cursor adapter --resume wiring — similar Lane 1 surface for cursor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)