### PR TITLE
fix(cursor-adapter): wire --resume; remove stale "no resume" comment (#2287)

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -20,6 +20,7 @@ Issue: #2253 (Phase 2)
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import shutil
@@ -72,7 +73,7 @@ class CursorAdapter:
             cwd: Working directory for the subprocess.
             model: Model override (e.g. "composer-2.5").
             task_id: Optional task identifier.
-            session_id: Ignored (cursor-agent does not yet support resume).
+            session_id: Session ID to resume (passed by runner or derived).
             tool_config: Config overrides. Supported keys:
                 - ``cursor_workspace``: overrides the ``--workspace`` path.
                 - ``approve_mcps``: bool, toggles ``--approve-mcps``.
@@ -80,9 +81,6 @@ class CursorAdapter:
                 - ``sandbox``: "enabled" | "disabled", toggles ``--sandbox``.
             effort: Logged and ignored (no cursor equivalent today).
         """
-        _ = session_id
-        _ = task_id
-
         if effort:
             _logger.debug("cursor adapter ignoring effort=%s (not supported by CLI)", effort)
 
@@ -90,6 +88,20 @@ class CursorAdapter:
         cursor_bin = shutil.which("agent") or shutil.which("cursor-agent") or "agent"
 
         config = tool_config or {}
+
+        # Workspace resolution
+        workspace = config.get("cursor_workspace") or str(cwd)
+
+        # Snapshot pre-existing transcripts to detect a new one generated during this run
+        self._workspace = workspace
+        self._transcripts_snapshot = self._snapshot_preexisting_transcripts(workspace)
+
+        # Resolve session ID to resume
+        resolved_session_id = session_id
+        if not resolved_session_id and task_id:
+            resolved_session_id = self._find_session_id_by_task_id(task_id)
+            if not resolved_session_id:
+                resolved_session_id = self._find_session_id_on_disk(workspace)
 
         # Base argv common to all paths.
         #
@@ -111,8 +123,9 @@ class CursorAdapter:
             "--trust",  # Headless workspace-trust bypass
         ]
 
-        # Workspace resolution
-        workspace = config.get("cursor_workspace") or str(cwd)
+        if resolved_session_id:
+            cmd.extend(["--resume", resolved_session_id])
+
         cmd.extend(["--workspace", workspace])
 
         # Mode-specific argv assembly
@@ -150,6 +163,74 @@ class CursorAdapter:
             liveness_paths=(),  # rely on stdout streaming
         )
 
+    def _encode_workspace_path(self, workspace_path: str) -> str:
+        """Encode workspace path into the encoded folder name used by Cursor."""
+        cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", workspace_path)
+        return cleaned.strip("-")
+
+    def _snapshot_preexisting_transcripts(self, workspace_path: str) -> set[str]:
+        """Snapshot the transcript directories that exist before the run starts."""
+        encoded = self._encode_workspace_path(workspace_path)
+        path = Path.home() / ".cursor" / "projects" / encoded / "agent-transcripts"
+        preexisting: set[str] = set()
+        if path.exists():
+            try:
+                for entry in path.iterdir():
+                    if entry.is_dir():
+                        preexisting.add(entry.name)
+            except OSError:
+                pass
+        return preexisting
+
+    def _find_session_id_by_task_id(self, task_id: str) -> str | None:
+        """Scan api_usage files for a session_id matching the given task_id."""
+        repo_root = Path(__file__).resolve().parents[3]
+        usage_dir = repo_root / "batch_state" / "api_usage"
+        if not usage_dir.exists():
+            return None
+
+        last_session_id = None
+        try:
+            # Sort files so we check the most recent ones first
+            for file_path in sorted(usage_dir.glob("usage_cursor-*.jsonl"), reverse=True):
+                try:
+                    with open(file_path, encoding="utf-8") as f:
+                        for line in f:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                record = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
+                            if record.get("task_id") == task_id:
+                                sid = record.get("session_id")
+                                if sid:
+                                    last_session_id = sid
+                except OSError:
+                    continue
+        except Exception:
+            pass
+        return last_session_id
+
+    def _find_session_id_on_disk(self, workspace_path: str) -> str | None:
+        """Find the newest session directory on disk for this workspace."""
+        encoded = self._encode_workspace_path(workspace_path)
+        path = Path.home() / ".cursor" / "projects" / encoded / "agent-transcripts"
+        if not path.exists():
+            return None
+        try:
+            entries = []
+            for entry in path.iterdir():
+                if entry.is_dir():
+                    entries.append(entry)
+            if entries:
+                newest = max(entries, key=lambda p: p.stat().st_mtime)
+                return newest.name
+        except OSError:
+            pass
+        return None
+
     def parse_response(
         self,
         *,
@@ -171,6 +252,34 @@ class CursorAdapter:
         # Parse JSONL events
         events = parse_json_events(stdout, source="cursor", logger=_logger)
         tool_calls = normalize_tool_calls(events)
+
+        # Detect the session ID of the current run
+        session_id = None
+        for event in events:
+            if "sessionId" in event:
+                session_id = str(event["sessionId"])
+                break
+
+        # If not found in stdout events, scan the filesystem for a new transcript
+        if not session_id and getattr(self, "_workspace", None):
+            encoded = self._encode_workspace_path(self._workspace)
+            path = Path.home() / ".cursor" / "projects" / encoded / "agent-transcripts"
+            if path.exists():
+                try:
+                    snapshot = getattr(self, "_transcripts_snapshot", None) or set()
+                    candidates = []
+                    for entry in path.iterdir():
+                        if entry.is_dir() and entry.name not in snapshot:
+                            candidates.append(entry)
+                    if candidates:
+                        newest = max(candidates, key=lambda p: p.stat().st_mtime)
+                        session_id = newest.name
+                except OSError:
+                    pass
+
+        # If still not found, check the disk generally for the newest one
+        if not session_id and getattr(self, "_workspace", None):
+            session_id = self._find_session_id_on_disk(self._workspace)
 
         # The final response is usually the last 'content' or 'text' event
         # in the stream. parse_json_events + normalize_tool_calls handles
@@ -203,6 +312,7 @@ class CursorAdapter:
             response=response,
             stderr_excerpt=stderr_excerpt,
             rate_limited=rate_limited,
+            session_id=session_id,
             tool_calls=tool_calls,
         )
 

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -147,7 +147,7 @@ AGENTS: dict[str, AgentEntry] = {
             "adversarial_review",
         }),
         "cli_available": True,
-        "resume_policy": "never",
+        "resume_policy": "bridge_only",
     },
     "agy": {
         # Antigravity CLI shipping Gemini Flash 3.5 on a separate meter from

--- a/tests/agent_runtime/test_cursor_adapter_resume.py
+++ b/tests/agent_runtime/test_cursor_adapter_resume.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.agent_runtime.adapters.cursor import CursorAdapter
+
+
+@pytest.fixture
+def adapter():
+    return CursorAdapter()
+
+
+def test_cursor_adapter_resume_first_run(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
+
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id="new-task-1",
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert "--resume" not in plan.cmd
+
+
+def test_cursor_adapter_resume_explicit_session(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
+
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id="new-task-1",
+        session_id="session-explicit-123",
+        tool_config=None,
+    )
+
+    # Verify `--resume` and `session-explicit-123` are passed in argv
+    idx = plan.cmd.index("--resume")
+    assert plan.cmd[idx + 1] == "session-explicit-123"
+
+
+def test_cursor_adapter_resume_from_disk(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
+
+    # Mock Path.home() so we can construct a fake .cursor directory
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+    # Create a fake transcript directory
+    encoded = adapter._encode_workspace_path(str(tmp_path))
+    transcript_dir = fake_home / ".cursor" / "projects" / encoded / "agent-transcripts" / "session-disk-789"
+    transcript_dir.mkdir(parents=True, exist_ok=True)
+
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id="task-disk",
+        session_id=None,
+        tool_config=None,
+    )
+
+    idx = plan.cmd.index("--resume")
+    assert plan.cmd[idx + 1] == "session-disk-789"
+
+
+def test_cursor_adapter_resume_from_api_usage(adapter, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
+
+    # Create fake api_usage directory and write log
+    repo_root = Path(__file__).resolve().parents[2]
+    usage_dir = repo_root / "batch_state" / "api_usage"
+    usage_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = usage_dir / "usage_cursor-delegate_test.jsonl"
+    record = {
+        "ts": "2026-05-26T00:00:00Z",
+        "agent": "cursor",
+        "entrypoint": "delegate",
+        "task_id": "task-api-usage",
+        "session_id": "session-api-usage-456",
+    }
+
+    # Write a test log record
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+    try:
+        plan = adapter.build_invocation(
+            prompt="hello",
+            mode="workspace-write",
+            cwd=tmp_path,
+            model=None,
+            task_id="task-api-usage",
+            session_id=None,
+            tool_config=None,
+        )
+
+        idx = plan.cmd.index("--resume")
+        assert plan.cmd[idx + 1] == "session-api-usage-456"
+    finally:
+        # Clean up the test log
+        if log_file.exists():
+            log_file.unlink()
+
+
+def test_cursor_adapter_parse_response_session_id_stdout(adapter):
+    stdout = '{"type": "message", "role": "assistant", "sessionId": "session-stdout-111", "content": "Done"}'
+    res = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert res.ok is True
+    assert res.session_id == "session-stdout-111"
+
+
+def test_cursor_adapter_parse_response_session_id_disk(adapter, tmp_path, monkeypatch):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+    # Initialize workspace and snapshot
+    workspace = str(tmp_path)
+    adapter._workspace = workspace
+    adapter._transcripts_snapshot = adapter._snapshot_preexisting_transcripts(workspace)
+
+    # Now simulate running the session, which creates a new directory on disk
+    encoded = adapter._encode_workspace_path(workspace)
+    session_dir = fake_home / ".cursor" / "projects" / encoded / "agent-transcripts" / "session-new-999"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    res = adapter.parse_response(
+        stdout='{"type": "text", "content": "Hello"}',
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert res.ok is True
+    assert res.session_id == "session-new-999"


### PR DESCRIPTION
## Summary

Dispatched to Antigravity CLI (agy / gemini-3.5-flash-high) via `delegate.py` against the brief at `docs/dispatch-briefs/2026-05-26-issue-2287-cursor-resume-agy.md`. Closes #2287.

Per the 2026-05-25 Cursor consultation: `cursor-agent --resume <chatId>` IS supported on the current machine (verified `cursor-agent --help | rg resume`). The stale comment in the cursor adapter was the only blocker.

## Changes

- `scripts/agent_runtime/adapters/cursor.py` (+116/-6): wires `--resume <chatId>` plumbing, removes stale "no resume" comment, adds session-resolution helpers (filesystem-based via `~/.cursor/projects/<encoded-path>/agent-transcripts/`).
- `scripts/agent_runtime/registry.py` (+1/-1): `cursor` resume_policy moved from `never` → `bridge_only`.
- `tests/agent_runtime/test_cursor_adapter_resume.py` (+153 new): unit test suite covering resume behaviors, filesystem/API usage resolvers, and parse_response session-capture edge cases.

## Test plan

- [x] Targeted pytest of new test file (run by dispatch — see batch_state log)
- [x] Regression pytest of `tests/agent_runtime/`
- [x] `ruff check scripts/agent_runtime/adapters/cursor.py tests/agent_runtime/` clean

## Notes

Original dispatched PR body was just the literal placeholder `@PR_BODY.md` (agy didn't substitute the file path into the body field). Replaced here by the orchestrator post-dispatch. Filed as a learnable for future agy briefs — the dispatch path should write a tmp file and pass it via `gh pr create --body-file <path>` rather than `--body "$(cat ...)"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (orchestrator) + Antigravity CLI (executor)

Co-Authored-By: Antigravity CLI <noreply@google.com>