### PR TITLE
fix(writer-prompt): dedupe diglossia paragraph + correct note→notes field name

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -291,9 +291,8 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 **Dialogue format (gate-counted).** Ukrainian dialogue lines must be `<DialogueBox uk="..." en="...">` or `> ` blockquotes. Em-dash-only dialogue under `## Діалоги` is invisible to `l2_exposure_floor` and fails the module.
 
 Use `<DialogueBox uk="..." en="...">` to render dialogues with side-by-side translation. This satisfies Practice 2 + Practice 4 of ULP for A1 and the `l2_exposure_floor` gate. Em-dash bare lines without an `en` prop fail the gate.
-`шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. Mention the literary↔colloquial pair in vocab when the module surfaces it.
 
-`шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. When you use it, add a `note` (or equivalent free-text explanation field per the vocabulary YAML schema) to the `що` entry in `vocabulary.yaml` flagging the literary↔colloquial pair so learners know when each is appropriate. Do NOT add a separate top-level entry for `шо` — VESUM does not codify it and the gate will reject a standalone lemma.
+`шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. When you use it, add a `notes:` field to the `що` entry in `vocabulary.yaml` flagging the literary↔colloquial pair so learners know when each is appropriate (the per-item schema accepts `notes`, NOT `note` — singular fails schema validation). Do NOT add a separate top-level entry for `шо` — VESUM does not codify it and the vocab gate will reject a standalone lemma.
 
 **UK example-sentence density.** A1-m15-24 modules need >=14 gate-countable Ukrainian example surfaces across bullet-list lines and Markdown table data rows. Use bullets/tables for paradigms and trap pairs; prose-only paradigms count zero.
 


### PR DESCRIPTION
## Summary

m20 round #5 hard-failed at `vocabulary.yaml` schema validation. Two coordination issues caused this; both fixed in one tiny commit.

**Issue 1 — Duplicate paragraph from parallel PRs.** PRs #2306 (writer-prompt-deltas) and #2307 (register-consistency) both added their own diglossia one-liner on adjacent lines. Each was correct in isolation; the conflict only surfaced when both landed on main. Net result: two nearly-identical paragraphs back-to-back in `linear-write.md`.

**Issue 2 — Wrong schema field name.** The #2306 iteration commit (applying Gemini-Code-Assist's review feedback) used `note` (singular). The vocabulary YAML per-item schema accepts `notes` (plural) — verified at `scripts/build/linear_pipeline.py:492`:

```python
optional_item_fields=frozenset({"notes", "examples", "tags"})
```

The writer faithfully followed the prompt's typo, and the schema gate hard-rejected with:

> `vocabulary.yaml schema validation failed: item 3 has unexpected fields ['note']; allowed: ['examples', 'lemma', 'notes', 'pos', 'tags', 'translation', 'usage']`

## What changed

Keep the more prescriptive version (clearer guidance about WHERE to put the note + warning against a standalone `шо` lemma), with:
1. correct `notes:` field name,
2. a parenthetical pinning the schema distinction so the next reader can't slip back to singular `note`.

Net diff: +1 / -2 lines.

## Test plan

- [x] `scripts/lint_prompts.py` — `✅ All prompts clean — no violations found.`
- [ ] CI green
- [ ] m20 round #6 reaches `module_done` (or fails on a different gate — Step B, INJECT_ACTIVITY parity, tool_theatre were all green on round #5)

Refs: m20 build round #5 failure log at `b14mqsazu` bridge subprocess output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)