### PR TITLE
fix(textbook_grounding): parse get_chunk_context list-shape envelope

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8377,6 +8377,29 @@ def _result_items_from_call(call: Mapping[str, Any]) -> list[Mapping[str, Any]]:
                 if parsed:
                     items.extend(parsed)
                     continue
+            # Mirror of the search_text branch above for the
+            # ``get_chunk_context`` canonical MCP content-block shape
+            # ``[{"type": "text", "text": "**[<chunk_id>]** — ..."}]``.
+            # Empirical reference: m20 build #7 (2026-05-26, codex-tools
+            # writer): codex called ``get_chunk_context`` twice and returned
+            # the canonical list-of-text-blocks envelope, but the gate
+            # produced ``matched=[]`` and HARD-rejected on
+            # ``textbook_grounding`` because the items got appended raw
+            # (with ``type="text"`` and no ``source_type``), so
+            # ``_is_textbook_result`` returned False and dropped every chunk.
+            # The dict-shape branch at line 8440 handles the equivalent
+            # ``{"type": "text", "text": "<md>"}`` for get_chunk_context;
+            # this branch closes the LIST-shape gap and is symmetric with
+            # the search_text branch directly above.
+            if (
+                tool_name == "get_chunk_context"
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+            ):
+                parsed = _parse_mcp_get_chunk_context_markdown(item["text"])
+                if parsed:
+                    items.extend(parsed)
+                    continue
             # Gemini-CLI list-shape MCP response. Empirical evidence: the
             # 2026-05-21 a1/my-morning gemini-tools build wrote the writer
             # call result as

--- a/tests/test_textbook_grounding_gate.py
+++ b/tests/test_textbook_grounding_gate.py
@@ -612,6 +612,79 @@ def test_textbook_grounding_gate_unwraps_gemini_function_response_shape(
     assert result["matched"] == ["Караман Grade 10, p.176"]
 
 
+def test_textbook_grounding_gate_parses_get_chunk_context_list_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """m20 build #7 (2026-05-26, codex-tools writer) regression.
+
+    Codex-tools returns the canonical MCP content-block envelope as a
+    LIST of text blocks:
+
+        [{"type": "text", "text": "**[<chunk_id>]** — Сторінка N\\n\\n<body>"}]
+
+    The list-branch parser at `_result_items_from_call` already handled
+    this shape for `search_text` (parsing the markdown into structured
+    textbook items). The equivalent branch for `get_chunk_context` was
+    missing — items got appended raw and ``_is_textbook_result`` rejected
+    them (``type="text"`` not ``type="textbook"``). Result: round #7
+    produced ``matched=[]`` and hard-failed `textbook_grounding` despite
+    codex correctly making 2 get_chunk_context calls and pasting verbatim
+    ≥30-word blockquotes from the returned chunks.
+
+    The fix mirrors the search_text list-branch handling. This test pins
+    the exact codex-tools envelope shape so the bug can't silently come
+    back.
+    """
+    body = (
+        "Зворотна форма дієслова показує дію, яка повертається до виконавця. "
+        "Учень умивається, одягається, готується до уроку, вітається з учителем, "
+        "збирається швидко і повертається до щоденної ранкової справи без зайвих "
+        "пояснень сьогодні."
+    )
+    chunk_id = "10-klas-ukrmova-karaman-2018_s0176"
+    chunk_markdown = f"**[{chunk_id}]** — Сторінка 176\n\n{body}"
+
+    # Exact shape codex-tools writer_tool_calls.json round-trip captured
+    # at the 2026-05-26 m20 build #7 artifact:
+    #     /Users/k/.codex/worktrees/.../a1-my-morning-20260526-181133/
+    #     curriculum/l2-uk-en/a1/my-morning/writer_tool_calls.json
+    _write_tool_calls(
+        tmp_path,
+        [
+            {
+                "tool": "mcp__sources__get_chunk_context",
+                "args": {"chunk_id": chunk_id, "window": 1},
+                "result": [{"type": "text", "text": chunk_markdown}],
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_lookup_textbook_metadata",
+        lambda source_file: {"author_uk": "Караман", "grade": "10"}
+        if source_file == "10-klas-ukrmova-karaman-2018"
+        else None,
+    )
+
+    module_text = (FIXTURES / "good-module.md").read_text(encoding="utf-8")
+
+    result = linear_pipeline._textbook_grounding_gate(
+        module_text,
+        _plan(),
+        tmp_path,
+    )
+
+    assert result["passed"] is True, (
+        f"Codex-tools list-shape get_chunk_context envelope must parse "
+        f"into a textbook item; got result={result!r}"
+    )
+    assert result["chunk_context_calls"] == 1
+    assert result["textbook_result_hits"] == 1
+    assert result["matched"] == ["Караман Grade 10, p.176"]
+
+
 def test_parse_mcp_get_chunk_context_markdown_no_db(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

m20 build round #7 with `--writer codex-tools` hard-failed `textbook_grounding` despite codex correctly making 2 honest `get_chunk_context` calls + pasting verbatim ≥30-word blockquotes from the returned chunks. **Codex did everything right**; the gate parser had a coverage gap for codex's envelope shape.

**Root cause:** `_result_items_from_call`'s list-branch parser handles `[{"type":"text","text":"<md>"}]` for `search_text` (line 8375) but not for `get_chunk_context`. Items got appended raw; `_is_textbook_result` rejected them (`type="text"`, not `"textbook"`). The dict-shape branch lower in the function already handled the equivalent envelope for get_chunk_context (line 8440); this PR closes the **list-shape** gap with a mirror-symmetric branch.

This is the same class of bug as the existing Hermes inner-result and Gemini functionResponse fixes — each new writer agent surfaces a new envelope shape the parser must learn.

## Empirical evidence

Round #7 artifacts at `~/.codex/worktrees/3a9a/learn-ukrainian/.worktrees/builds/a1-my-morning-20260526-181133/curriculum/l2-uk-en/a1/my-morning/`:

```text
python_qg.json:
  chunk_context_calls=2
  search_text_calls=2
  textbook_grounding=false
  matched=[]
  missing=[Захарійчук Grade 1, p.24, Захарійчук Grade 1, p.52]

writer_tool_calls.json (the two chunk_context calls):
  [{"type":"text","text":"**[1-klas-bukvar-zaharijchuk-2025-1_s0024]** — Сторінка 26\n\n<verbatim body>"}]
  [{"type":"text","text":"**[1-klas-bukvar-zaharijchuk-2025-2_s0052]** — Сторінка 53\n\n<verbatim body>"}]

module.md blockquotes: byte-for-byte copies of the chunk bodies above.
```

The writer's blockquotes match the chunk content exactly; the parser just never extracted the chunk metadata so `_is_textbook_result` rejected each item before the matcher ran.

## What changed

- `scripts/build/linear_pipeline.py`: +20 lines (mostly comment), 1 new branch in `_result_items_from_call`'s list-handling, mirror of the `search_text` branch above it.
- `tests/test_textbook_grounding_gate.py`: +76 lines, 1 new test `test_textbook_grounding_gate_parses_get_chunk_context_list_shape` pinning the exact codex-tools envelope shape from m20 #7.

## Test plan

- [x] `pytest tests/test_textbook_grounding_gate.py` — 27 passed (26 existing + 1 new). Final summary line: `============================== 27 passed in 0.38s ==============================`
- [x] `ruff check scripts/build/linear_pipeline.py tests/test_textbook_grounding_gate.py` — `All checks passed!`
- [ ] CI green (this PR)
- [ ] m20 round #8 with `--writer codex-tools` against post-merge main reaches `module_done` OR fails on a non-textbook_grounding gate (most likely `word_count` — round #7 hit 1139/1200 = 95%; that's a separate writer-prompt iteration if it recurs)

## Cross-references

- Round #7 result (bridge subprocess `bridge-19ab885e`): codex-tools cleared every gate claude-tools failed on rounds #4-#6 (Step B obligation, tool_theatre, inject_activity_ids, surzhyk_clean) — except `textbook_grounding`, which this PR fixes, and `word_count`, which is a different writer issue.
- PR #2305 fixed the inverse problem: gate previously *false-passed* claude-tools' Step-B-skipped builds. With both fixes, the gate now correctly hard-rejects skipped Step B AND correctly accepts honest Step B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)