### PR TITLE
fix(writer-prompt): word target → minimum + overshoot guidance

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -245,7 +245,7 @@ Non-plan vocabulary must pass `query_cefr_level`, frequency, or ULP coverage for
 - Slug: {MODULE_SLUG}
 - Topic: {TOPIC_TITLE}
 - Phase: {PHASE}
-- Word target: {WORD_TARGET}
+- Word **minimum**: {WORD_TARGET} — this is a FLOOR, not a target. The `word_count` gate hard-rejects below 92% of this number (8% tolerance per `_WORD_COUNT_TOLERANCE_BELOW`). Overshoot by 10-15% — your self-counted prose total runs ~10-15% higher than the gate's strict tokenization (which excludes markdown comments and may exclude certain JSX attribute text). The 2026-05-23 user direction is explicit: word counts are MINIMUMS; overshoot is welcome, never an error. Empirical evidence (m20 builds #7-#8 with codex-tools): a writer aiming exactly at the target lands 80-95% of the gate's count and triggers a hard fail. Plan your section budgets accordingly — sum your sections to ~1.15× the minimum.
 
 ## Learner State
 


### PR DESCRIPTION
## Summary

m20 round #8 with `--writer codex-tools` cleared **every gate except `word_count`** (count=981, target=1200, min_with_tolerance=1104 → 123 below floor). Round #7 came in at 1139 (borderline). Codex-tools' word_count is variable and consistently below target.

**Root cause:** the writer prompt communicated word count as a **target** (`Word target: {WORD_TARGET}`), a single line with no floor framing. The pipeline's policy is "word counts are MINIMUMS, overshoot welcome" (per `_word_count_gate` 2026-05-23 reaffirmation comment), but the prompt doesn't say that. Codex-tools reads "target" as "aim AT", landing AT or below the value. The gate's strict tokenization (excludes markdown comments, may exclude some JSX attribute text) widens the gap another ~10-15%, so a writer aiming exactly at target lands 80-95% of the gate's count.

**Fix:** replace the single-line `Word target` entry with explicit floor framing + an explicit "overshoot 10-15%" suggestion, citing the 2026-05-23 user direction and the empirical m20 #7-#8 evidence.

## Diff size

+1 longer bullet, -1 short bullet. The `{WORD_TARGET}` substitution variable is unchanged. Only the surrounding prose framing.

## Test plan

- [x] `scripts/lint_prompts.py` — `✅ All prompts clean — no violations found.`
- [ ] CI green
- [ ] m20 round #9 with `--writer codex-tools` against post-merge main reaches `module_done`. If the writer plans sections summing to ~1.15× the minimum, gate count lands ≥1104 (the 92% floor). If word_count still fails after this prompt change, that's a stronger signal — escalate to either (a) gate-side adjustment of what `_WORD_RE` counts, or (b) targeted ADR-008 correction loop for word_count specifically.

## Why this fix and not another

Three options were considered:

1. **Increase ADR-008 correction rounds for word_count.** Less targeted — the writer's self-correction prompt would still have the wrong framing.
2. **Adjust the `_word_count_gate` tokenizer to match the writer's self-count.** Right long-term fix but invasive; would change behavior for every existing build and require re-validation.
3. **Fix the writer-prompt framing.** Smallest possible diff, addresses the root cause (writer misreads "target"), survives writer-agent swaps. **Picked this one.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)