### PR TITLE
docs(best-practices): bio research source-tier policy

### DIFF
--- a/docs/best-practices/bio-research-source-tiers.md
+++ b/docs/best-practices/bio-research-source-tiers.md
@@ -1,0 +1,275 @@
+# Bio Research — Source Authority Tiers
+
+> **Scope.** This policy governs Phase 1 bio-track research dossiers for epic #2309:
+> Russia-oppressed Ukrainian patriots, roughly 1500 words of research per figure
+> before any plan YAML is written.
+>
+> **Rule.** Start broad, but cite narrow. Wikipedia and general web sources may
+> help locate names, dates, and bibliographies; they do not satisfy the dossier's
+> evidentiary burden until the claim has been checked against higher-tier sources.
+
+Each dossier must make source authority visible. Every factual paragraph should
+be traceable to one of the tiers below, and every bibliography item must include
+the tier label used in the dossier. If sources disagree, do not smooth over the
+conflict. Record the disagreement, prefer the higher tier, and explain why.
+
+Do not confuse these **source authority tiers** (`T1`-`T5`) with the audit's
+**build-order tiers** (`1a`, `1b`, `2`, `3`, `4`, `5`). A dossier can be a
+build-order Tier 5 war-killed figure and still require Tier 1/Tier 2 source
+authority for its core claims.
+
+## Tier 1 — Authoritative (cite as ground truth)
+
+Use Tier 1 for identity, life dates, institutional affiliations, repression
+mechanism, rehabilitation status, canonical works, and any claim that will become
+part of the module's core biographical arc.
+
+- НТШ (Наукове товариство ім. Шевченка) publications: `Записки НТШ`, `Праці НТШ`,
+  НТШ monographs, and digitized НТШ diaspora publications.
+- Енциклопедія Сучасної України (ЕСУ) — <https://esu.com.ua/>. Prefer the
+  article page and its PDF export when both exist.
+- Енциклопедія українознавства (ЕУ, "Сарсель"; гол. ред. Володимир Кубійович):
+  both `Загальна частина` and `Словникова частина`. Use scanned page citations
+  when possible; the online Litopys/Izbornyk pages are acceptable access copies.
+- Internet Encyclopedia of Ukraine / Encyclopedia of Ukraine — use especially
+  for diaspora figures and English cross-checking, but prefer the Ukrainian ЕУ
+  or ЕСУ article when available.
+- Енциклопедія історії України (ЕІУ), Інститут історії України НАН України —
+  ground truth for historical actors, institutions, events, and repression
+  contexts.
+- Ukrainian archival or rehabilitative source editions published by НАН України,
+  the Institute of History of Ukraine, or the Institute of Ukrainian Archeography
+  and Source Studies. Case-file quotations count only when the edition gives a
+  stable archival citation.
+
+Tier 1 is not infallible. ЕУ is a diaspora product of its time; ЕСУ is still
+evolving; institutional entries can be brief. But for a dossier, a Tier 1 claim
+is the starting presumption unless a newer Tier 1 or strong Tier 2/Tier 4 source
+explicitly corrects it.
+
+## Tier 2 — Institutional
+
+Use Tier 2 to expand the dossier beyond encyclopedia facts: scholarly framing,
+archival detail, institutional memory, and field-specific expertise.
+
+- Harvard Ukrainian Research Institute (HURI) publications, including `Harvard
+  Ukrainian Studies`, Harvard Ukrainian Studies monographs, and HURI digital
+  projects — <https://www.huri.harvard.edu/>.
+- Canadian Institute of Ukrainian Studies (CIUS) Press and CIUS research reports
+  — <https://www.ualberta.ca/en/canadian-institute-of-ukrainian-studies/> and
+  <https://www.ciuspress.com/>.
+- Carleton University Institute of European, Russian and Eurasian Studies
+  (EURUS), Centre for European Studies, and Europe-Russia Working Papers when the
+  author, series, and institutional host are identifiable. Do not cite a vague
+  "Carleton URI" label unless the actual paper has been found.
+- Інститут української археографії та джерелознавства ім. М. С. Грушевського
+  НАН України — institutional publications and source editions.
+- Інститут історії України НАН України electronic library, periodicals, and
+  source portals outside ЕІУ.
+- НАН України institute profile pages and university-hosted memorial pages for
+  field-specific figures, such as mathematicians, scientists, clergy, artists,
+  or institution-builders.
+- Museum, archive, and university pages when they publish collection-based
+  biographies with named curators, archival fonds, or bibliographies.
+
+Tier 2 is strong evidence, but it does not override Tier 1 automatically. Use it
+to add depth, resolve sparse encyclopedia entries, and document specialist
+debates.
+
+## Tier 3 — Encyclopedic (starting point, not endpoint)
+
+Use Tier 3 to find the article title, alternate names, rough chronology, and
+bibliography. Never finish a dossier at Tier 3.
+
+- `uk.wikipedia.org` — start research here, but always cross-check with Tier 1
+  or Tier 2 before citing the claim in dossier prose.
+- `en.wikipedia.org` — secondary starting point. English articles often inherit
+  older Soviet or Russian framing for Ukrainian figures; treat identity labels,
+  "nationality", collaboration claims, and repression explanations as unverified
+  until checked.
+- Wikidata — useful for alternate spellings and external identifiers; not a
+  prose source.
+
+`ru.wikipedia.org`, Ruwiki, and Russian-language general encyclopedia mirrors
+are not Tier 3 for Ukrainian biography work. They fall under the Russian/Soviet
+special rule below.
+
+## Tier 4 — Modern scholarly (post-1991, UA + diaspora)
+
+Use Tier 4 for interpretation, historiography, contested evidence, and current
+scholarly debates. Tier 4 can correct or nuance a brief encyclopedia article,
+but the dossier must show the correction explicitly.
+
+- Peer-reviewed Ukrainian scholarly journals after 1991, for example
+  `Український історичний журнал`, `Україна Модерна`, and `Наукові записки
+  НаУКМА. Історичні науки`.
+- Post-1991 academic monographs from Ukrainian, diaspora, or Western university
+  and academy presses.
+- Edited scholarly collections and conference proceedings with named editors,
+  publisher, year, and page numbers.
+- Doctoral dissertations and institutional repository papers only when they are
+  hosted by a university or academy repository and corroborated by Tier 1/Tier 2.
+- Recent specialist publications on the Russo-Ukrainian war, religious
+  persecution, Crimean Tatar resistance, dissidents, and political prisoners.
+
+Do not use Tier 4 as a dumping ground for any academic-looking PDF. The source
+must have author identity, publication venue, date, and enough apparatus
+— footnotes, bibliography, archival references, or peer review — to audit.
+
+## Tier 5 — General web
+
+Use Tier 5 only with Tier 1-Tier 4 corroboration. It can supply color, interviews,
+recent updates, images to investigate, or leads to primary documents; it cannot
+establish the dossier's core claims alone.
+
+- Reputable Ukrainian media and cultural outlets: `Суспільне`, `Радіо Свобода`,
+  `Історична правда`, `Локальна історія`, `Читомо`, `The Ukrainians`, and similar
+  outlets with named authors and publication dates.
+- NGO and professional-community pages, such as PEN Ukraine, memorial projects,
+  professional associations, or local history initiatives.
+- Local government, school, library, and museum pages when they identify a
+  commemorative action or provide a lead to a better source.
+- Personal websites, blogs, social posts, YouTube transcripts, and news
+  aggregators only as leads. They require independent corroboration before any
+  claim enters the dossier.
+
+When Tier 5 is the only source for a recent death, captivity update, award, or
+commemoration, mark the claim `VERIFY` in the dossier and keep looking. A
+time-sensitive claim is not stable just because it appears on several copied
+news pages.
+
+## Minimum dossier source pack
+
+Every Phase 1 dossier must include:
+
+- At least three Tier 1/Tier 2 sources, unless the bibliography explicitly
+  explains why the figure is too recent or under-documented for that threshold.
+- At least two independent sources for birth date, death date, and oppression
+  mechanism. If only one source exists, mark the fact as provisional.
+- At least two primary-source quotes from the figure's own work, recorded speech,
+  letters, diary, court statement, or other direct documentary voice.
+- A separate `Primary-source documents accessed` subsection for NKVD/KGB/FSB,
+  court, police, censorship, or rehabilitation documents.
+- A Tier 3 note if Wikipedia was used for navigation; this note must say which
+  higher-tier source confirmed the final claim.
+
+## SPECIAL RULE — Russian / Soviet-era sources
+
+Russian and Soviet sources are allowed as historical evidence, not as authority
+over Ukrainian identity, motives, loyalty, or legitimacy.
+
+Allowed uses:
+
+- Primary-source historical documents: NKVD/MGB/KGB case files, interrogation
+  records, court documents, deportation lists, camp records, Soviet denunciation
+  articles, party resolutions, censorship rulings, and official rehabilitation
+  notices.
+- Quoted Soviet-era documents inside modern Ukrainian or diaspora scholarship,
+  provided the modern source gives the archival reference.
+- Evidence of Soviet or Russian framing itself: how the regime accused,
+  pathologized, Russified, silenced, or erased the figure.
+
+Forbidden as authoritative biography sources:
+
+- `Українська радянська енциклопедія` (УРЕ), including all Soviet-era editions.
+- `Український радянський енциклопедичний словник` (УРЕС).
+- `Радянська енциклопедія історії України` (РЕІУ).
+- `Большая советская энциклопедия` (БСЭ), `Малая советская энциклопедия` (МСЭ),
+  and Soviet encyclopedic dictionaries.
+- `Большая российская энциклопедия`, Ruwiki, Russian Wikipedia, and
+  Russian-language general encyclopedias for claims about Ukrainian figures.
+- Soviet party histories, Soviet school textbooks, Soviet literary handbooks,
+  and Russian state or occupation-administration media.
+
+If a forbidden source contains a useful datum, cite it only in a sentence that
+labels its status, for example: "The Soviet encyclopedia framed X as Y; this is
+useful evidence of Soviet framing, not a reliable identity claim." Then verify
+the underlying fact through Tier 1-Tier 4.
+
+## Worked example
+
+Verify the death date for the real audit figure **Михайло Пилипович Кравчук**.
+Do not write `Микола Кравчук`; that is a name error for this dossier.
+
+Claim to verify: `Михайло Кравчук died on 9 March 1942`.
+
+- T1: ЕСУ entry `Кравчук Михайло Пилипович` gives `Дата смерті: 9 берез. 1942`
+  and the article lead gives `09. 03. 1942`.
+- T1: Internet Encyclopedia of Ukraine entry `Kravchuk, Mykhailo` gives
+  `d 9 March 1942 near Magadan`.
+- T2: КПІ ім. Ігоря Сікорського page `Кравчук М.П.` gives
+  `9.3.1942, Колима`.
+- T2: НАН України personal profile gives `12.10.1892-09.03.1942` and states
+  that he died in a camp on `9.03.1942`.
+- T3: Ukrainian Wikipedia extract gives `9 березня 1942, концтабір ГУЛАГ СССР`.
+
+Reconciled dossier sentence:
+
+> Михайло Пилипович Кравчук (1892-1942), український математик і академік ВУАН,
+> помер 9 березня 1942 року в радянському табірному просторі Колими після
+> арешту й засудження органами НКВС. [T1: ЕСУ — Кравчук Михайло Пилипович]
+> [T2: КПІ — Кравчук М.П.]
+
+Notes for the writer:
+
+- The date is stable across T1/T2/T3. Use `9 березня 1942 року` in prose.
+- The place wording differs: `Колима`, `near Magadan`, and `концтабір ГУЛАГ`.
+  Use the precise wording supported by the source you cite; do not collapse the
+  variants into a fake exact camp name unless a Tier 1/Tier 2 source gives it.
+- A prompt or draft that mentions "Kravchuk Mathematical Society" must be
+  verified before use. If no such source is found, cite the real institutional
+  source instead.
+
+## Citation format for dossiers
+
+Inline citations must identify tier, source, and article/work title. Use several
+short inline citations instead of one vague bibliography dump.
+
+Expected inline forms:
+
+- `[T1: ЕСУ — Кравчук Михайло Пилипович]`
+- `[T1: ЕУ, Словникова частина, т. <n>, с. <page> — <гасло>]`
+- `[T1: ЕІУ, т. <n>, с. <page> — <гасло>]`
+- `[T2: HURI — <author>, <short title>]`
+- `[T2: CIUS Press — <author>, <short title>, с. <page>]`
+- `[T2: КПІ — Кравчук М.П.]`
+- `[T4: Український історичний журнал — <author>, <year>, с. <page>]`
+- `[T5: Суспільне — <article title>, <date>; corroborated by T2]`
+
+Every dossier bibliography must group sources by tier and include full access
+information:
+
+```markdown
+## Bibliography
+
+### Tier 1
+- Енциклопедія Сучасної України. "Кравчук Михайло Пилипович."
+  https://esu.com.ua/article-2611. Accessed 2026-05-26.
+- Encyclopedia of Ukraine. "Kravchuk, Mykhailo."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CR%5CKravchukMykhailo.htm.
+  Accessed 2026-05-26.
+
+### Tier 2
+- КПІ ім. Ігоря Сікорського. "Кравчук М.П." https://kpi.ua/kravchuk.
+  Accessed 2026-05-26.
+
+### Tier 3
+- Українська Вікіпедія. "Кравчук Михайло Пилипович."
+  https://uk.wikipedia.org/wiki/Кравчук_Михайло_Пилипович.
+  Accessed 2026-05-26. Used only as a starting point; dates cross-checked
+  against Tier 1/Tier 2.
+```
+
+For print or scanned sources, use canonical author-volume-page citation:
+
+- NTSh article: `<Author>. "<Article title>." Записки НТШ. Т. <volume>. <place>,
+  <year>. С. <page-range>.`
+- ЕСУ article with author shown: `<Author>. "<Entry title>." Енциклопедія
+  Сучасної України. Т. <volume>. Київ: Інститут енциклопедичних досліджень НАН
+  України, <year>. С. <page>. URL. Accessed <YYYY-MM-DD>.`
+- ЕУ / Сарсель: `Енциклопедія українознавства: Словникова частина. У <n> т. /
+  гол. ред. В. Кубійович. Париж; Нью-Йорк: Молоде життя, <year>. Т. <volume>.
+  С. <page>. Гасло "<entry>".`
+
+Do not cite a source you have not opened. Do not cite Wikipedia's bibliography
+as if it were your own lookup. If Wikipedia points to ЕСУ, open ЕСУ and cite ЕСУ.


### PR DESCRIPTION
## Summary

Closes #2312.
Part of epic #2309.

Adds `docs/best-practices/bio-research-source-tiers.md`, governing Phase 1 bio research dossiers:
- defines Tier 1-Tier 5 source authority for biography research
- distinguishes source authority tiers from audit build-order tiers
- explicitly forbids Soviet/Russian encyclopedias as authoritative biography sources
- includes dossier citation formats and bibliography examples
- includes a worked example verifying the real audit figure `Михайло Пилипович Кравчук`

## Raw lookup evidence

Quoted lookup outputs used for the verifiable claims in the doc:

- `mcp__sources__.query_wikipedia({"query":"Михайло Кравчук","mode":"extract"})` returned the article URL and: `9 березня 1942, концтабір ГУЛАГ СССР`.
- `web.open https://esu.com.ua/article-2611` lines 62-68: `Дата смерті: 9 берез. 1942`; article lead: `09. 03. 1942`.
- `web.open https://www.encyclopediaofukraine.com/...KravchukMykhailo.htm` line 33: `d 9 March 1942 near Magadan`.
- `web.open https://kpi.ua/kravchuk` lines 154-160: `Кравчук М.П.` and `9.3.1942, Колима`.
- `web.open https://www.old.nas.gov.ua/...PersonID=0000006684` lines 23, 64: `12.10.1892-09.03.1942` and `загинув у таборі 9.03.1942`.
- `web.open https://esu.com.ua/about/overview` lines 50-61 confirmed ЕСУ online status and its Ukraine-focused profile.
- `web.open https://ntsh.org/` line 34 confirmed `Наукового товариства ім. Шевченка` naming.
- `web.open https://evu.encyclopedia.kyiv.ua/article/3` lines 179-180 confirmed ЕУ dictionary-part scope and Kubiiovych/Sarcelles editorial center context.
- `web.open https://www.ciuspress.com/contact-2/` lines 68-70 confirmed `CIUSPress.com` / `Canadian Institute of Ukrainian Studies Press`.
- `web.open https://www.carleton.ca/ces/wp-content/uploads/protsyk02.pdf` lines 14-20 confirmed Carleton-hosted Europe-Russia Working Papers details.
- `web.open https://www.nas.gov.ua/institutions/institut-ukrayinskoyi-arxeografiyi-ta-dzereloznavstva-im-ms-grusevskogo-nan-ukrayini-151` lines 176-184 confirmed the institute name and official `archeos.org.ua` link.

## Verification

- `npx markdownlint-cli2 docs/best-practices/bio-research-source-tiers.md` — 0 errors
- `git diff --cached --check` — clean before commit
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- commit/pre-push hooks — ruff skipped doc-only/no files, gitleaks passed, whitespace/merge-conflict guards passed

## Notes

- No code files changed; `.venv/bin/ruff check` had no touched Python files to run against.
- Did not touch `.python-version`, `.yamllint`, `.markdownlint.json`, generated `status/*.json`, or review/audit artifacts.
