### PR TITLE
fix(writer-prompt): A1-A2 dialogue floor + tighter meta-narration ban

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -3,7 +3,7 @@
 This is the actionable subset of `docs/north-star.md` for the writer phase.
 
 <!-- rule_id: #R-VOICE-META -->
-Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`, including "Welcome to the start of our journey", "In this section we will learn", "Now that you have seen these verbs", "Let's now look at", "Before we move on", "Note that…", "Notice that…", "Observe that…", "Pay attention to…", "Remember that…", or "It is important to…".
+Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`. The `engagement_floor` gate HARD-fails on phrases that describe the artifact rather than addressing the learner. Forbidden patterns (English): "Welcome to the start of our journey", "In this section we will learn", "in this module", "in this lesson", "this module covers", "this lesson covers", "we will learn", "you will learn" (in the meta sense, not a real plan), "Now that you have seen these verbs", "Let's now look at", "Before we move on", "Note that…", "Notice that…", "Observe that…", "Pay attention to…", "Remember that…", "It is important to…". Forbidden patterns (Ukrainian): "у цьому модулі", "у цьому уроці", "у цьому розділі", "у цій темі", "ми вивчимо", "ми побачимо", "далі ми…". Rule of thumb: speak TO the learner in second person about the LANGUAGE; never narrate ABOUT the module or section. Open every section with a fact, an example, a dialogue line, or a direct second-person instruction — never with a preamble about what the section will do.
 
 <!-- rule_id: #R-VOICE-META -->
 B1+ body text outside Tab 2 is Ukrainian only: no rescue notes, mirrored translations, parenthetical English grammar glosses, or English activity instructions. Tab 2 may carry English translations and expression notes.
@@ -291,6 +291,8 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 **Dialogue format (gate-counted).** Ukrainian dialogue lines must be `<DialogueBox uk="..." en="...">` or `> ` blockquotes. Em-dash-only dialogue under `## Діалоги` is invisible to `l2_exposure_floor` and fails the module.
 
 Use `<DialogueBox uk="..." en="...">` to render dialogues with side-by-side translation. This satisfies Practice 2 + Practice 4 of ULP for A1 and the `l2_exposure_floor` gate. Em-dash bare lines without an `en` prop fail the gate.
+
+**Minimum UK dialogue lines (A1-A2).** For A1 and A2 modules, emit at least **15 distinct gate-countable Ukrainian dialogue surfaces** (`<DialogueBox uk="..." en="...">` entries and `> ` blockquote lines, summed). The `l2_exposure_floor` gate's floor is 14; overshoot by ≥1 for safety. m20 build #9 hit exactly 13 and HARD-failed via `too_few_uk_dialogue_lines`. Count BEFORE emitting: if you have <15, add another exchange to the dialogue section or split a long turn into two shorter ones.
 
 `шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. When you use it, add a `notes:` field to the `що` entry in `vocabulary.yaml` flagging the literary↔colloquial pair so learners know when each is appropriate (the per-item schema accepts `notes`, NOT `note` — singular fails schema validation). Do NOT add a separate top-level entry for `шо` — VESUM does not codify it and the vocab gate will reject a standalone lemma.
 


### PR DESCRIPTION
## Summary

m20 round #9 with `--writer codex-tools` HARD-failed two small content gates that previous rounds had cleared. Both fixed in this PR with a ~5-line writer-prompt patch.

| Round #9 failure | Root cause | Fix in this PR |
|---|---|---|
| `l2_exposure_floor`: 13/14 UK dialogue lines (1 short) | Writer prompt explained the format but not the count target | Add explicit ≥15 minimum UK dialogue surfaces for A1-A2, with overshoot guidance citing m20 #9 |
| `engagement_floor`: "in this module" meta narration | `#R-VOICE-META`'s forbidden list covered "In this section we will learn" but not the shorter "in this module" / "in this lesson" variants | Expand banned-phrase list (English + Ukrainian equivalents); reframe with clearer "second person TO learner, never ABOUT module" rule of thumb |

## Why round #9 ranks as a near-publish failure

Round #9 progression vs prior rounds:

| Gate | Round #8 | Round #9 |
|---|---|---|
| `word_count` | 981/1200 ❌ | **1126/1200 ✅** (+145 words; PR #2340 framing fix worked) |
| `textbook_grounding` | ✅ | ✅ |
| `tool_theatre_violation_count` | 0 | 0 |
| `chunk_context_calls` | 2 | 2 |
| 22 other gates | ✅ | ✅ |
| `l2_exposure_floor` | ✅ | ❌ 13/14 |
| `engagement_floor` | ✅ | ❌ "in this module" |

Round #9 cleared 26 of 28 hard gates. The two failures are both <5-line writer-prompt issues, fixed here.

## Test plan

- [x] `scripts/lint_prompts.py` — `✅ All prompts clean — no violations found.`
- [ ] CI green
- [ ] m20 round #10 with `--writer codex-tools` against post-merge main reaches `module_done` and opens the m20 anchor PR

## Empirical chain across rounds 4-9

- Round #4-#6 (claude-tools): 3 hard fails per round, structural Step B blind spot
- Round #7 (codex-tools): cleared Step B + tool_theatre, failed on gate parser bug (PR #2339 fixed)
- Round #8 (codex-tools): 25/26 gates, failed only on word_count framing (PR #2340 fixed)
- Round #9 (codex-tools): **26/28** gates, two new small content failures (this PR fixes)
- Round #10 (queued): expected `module_done` + m20 anchor PR

Refs: `docs/session-state/2026-05-26-pt4-codex-tools-writer-empirical-win.md` (PR #2341, in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)