### PR TITLE
feat(bio-research): R1a pilot — 3 dossiers (Драй-Хмара, Свідзінський, Сосюра)

### DIFF
--- a/docs/research/bio/mykhailo-drai-khmara.md
+++ b/docs/research/bio/mykhailo-drai-khmara.md
@@ -1,0 +1,118 @@
+# Михайло Опанасович Драй-Хмара — Research Dossier
+
+**Slug:** `mykhailo-drai-khmara`
+**Block:** A (executed / killed in Soviet captivity)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-26
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Опанасович Драй-Хмара. Archival NKVD documents and some scholarly sources also use **Михайло Панасович Драй-Хмара**; the surname at birth is recorded as Драй. [T1: ЕСУ; T1: ЕІУ; T2: Harriman Review]
+- **Pseudonyms / aliases:** Драй-Хмара Михайло Опанасович; Драй-Хмара Михайло Панасович; Драй Михайло; Mykhailo Drai-Khmara. Forbidden in body text except in this naming section: Mikhail Drai-Khmara, Mikhail Dray-Khmara, Михаил Афанасьевич Драй-Хмара, Draj-Chmara.
+- **Born:** 28 September / 10 October 1889 | Малі Канівці, Золотоніський повіт, Полтавська губернія; now Черкаська область, Україна. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Died:** 19 January 1939 | Kolyma camp system, northeastern Siberia, USSR | death in Soviet camp custody. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Family / education key facts:** He studied at Колегія Павла Ґалаґана, Kyiv University, and Petrograd University; his scholarly formation was Slavic philology, especially Ukrainian, Belarusian, Serbian, and comparative Slavic work. He taught at Kamianets-Podilskyi Ukrainian State University, Kyiv Medical Institute, and VUAN language institutions. [T1: ЕСУ; T1: IEU; T1: ЕІУ]
+
+**Source disagreement note:** ЕУ Сарсель originally printed a cautious death range ("1938 or 1939"), while the later correction and modern ЕСУ/ЕІУ/IEU give 19 January 1939. The second arrest appears in sources as 5 September 1935 for the NKVD resolution and warrant, while the physical search/detention protocol is dated 6 September 1935. [T1: ЕУ Сарсель; T2: Harriman Review]
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest, fabricated "counter-revolutionary terrorist" case, Special Council sentence, forced transfer to the NKVD Northeastern Camps, death in Kolyma custody.
+- **When:** first arrest 3 February 1933, released after lack of evidence; second case opened 5 September 1935, search/detention 6 September 1935; Special Council decision 28 March 1936; dispatch to Vladivostok/Kolyma ordered 4 April 1936; Northeastern Camps notice dated 7 September 1938; death 19 January 1939. [T1: ЕСУ; T2: Harriman Review]
+- **By whom:** Special Section of the NKVD of the Ukrainian SSR; Military Prosecutor of the Kyiv Military District; Special Council of the NKVD of the USSR; Northeastern Camps of the NKVD.
+- **Document references:** case no. 101 against Drai-Khmara; special case no. 1377 against Zerov, Voronyi, Fylypovych, and others; articles 54-8 and 54-11 of the Criminal Code of the Ukrainian SSR; archive no. 47461 / TsDAHOU fond 263, op. 1, file 62245 in the Harriman translation. [T2: Harriman Review]
+
+The 5 September 1935 resolution by examining magistrate Bondarenko framed Drai-Khmara as an "active participant" in a counter-revolutionary terrorist organization. The related prosecutor's resolution and warrant made arrest and search immediate, and the 6 September search at 1 Sadova St., apt. 5, seized personal documents and manuscripts. [T2: Harriman Review]
+
+The 19 February 1936 concluding statement tied him to the larger neoclassicist case and recommended case no. 101 to the Special Council, asking for five years in a concentration camp as a "socially dangerous" person. On 28 March 1936 the Special Council ordered five years of corrective labor camp from 5 September 1935; on 4 April 1936 the NKVD USSR ordered him sent through Vladivostok to the Northeastern Camps of the NKVD, Kolyma. [T2: Harriman Review]
+
+**What survived / what was destroyed:** The NKVD file survived and was later translated in the Harriman Review. Much of his translation archive did not survive: sources note unpublished translations, including Dante's *Divine Comedy* and the Finnish *Kalevala*, and the case file records "nationalist literature" slated for destruction. His wife Nina and daughter Oksana were also punished as family of an "enemy of the people." [T1: IEU; T2: Harriman Review]
+
+## 3. Major works
+
+- **1919 onward** — early poems; Drai-Khmara began publishing as the Ukrainian cultural revival entered its Kyiv and Kamianets-Podilskyi university phase. [T1: ЕІУ]
+- **1926** — *Леся Українка: життя й творчість*, monograph; important for Ukrainian literary scholarship and for placing Lesia Ukrainka in a modern critical frame. [T1: ЕСУ; T1: IEU]
+- **1926** — *Проростень*, poetry collection, Kyiv; his only lifetime book of poetry. [T1: ЕСУ; T1: IEU]
+- **1928** — "Лебеді", sonnet in *Літературний ярмарок*; gave the phrase "ґроно п'ятірне" for the Kyiv neoclassicists. [T1: ЕУ Сарсель; primary corpus]
+- **1929** — work on VUAN scientific-language projects and Slavic-language scholarship; important for Ukrainian scholarly terminology under pressure. [T1: IEU]
+- **1929** — Belarusian translation/editorial work around Maksim Bahdanovich's *Вінок*. [T1: ЕІУ]
+- **1930** — translation and preface work from Polish, Serbian, Czech, French, Finnish, and other languages; most remained unpublished or was seized. [T1: ЕІУ; T1: IEU]
+- **1964** — *Поезії*, New York, posthumous recovery of poetry outside Soviet censorship. [T1: IEU]
+- **1969** — *Вибране*, Kyiv, partial Soviet-era rehabilitation edition. [T1: IEU]
+- **1989** — *Вибране*, Kyiv; wider return during late-Soviet rehabilitation. [T1: ЕІУ]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — "Лебеді", 1928, *Літературний ярмарок*, ч. 1:**
+
+> **О, ґроно п'ятірне нездоланих співців!**
+
+The line is the curriculum anchor for the neoclassicist group. It was verified with `verify_quote` against the Ukrainian literary corpus (`ukrlib-drai_khmara`, confidence 1.0).
+
+**Quote 2 — untitled poem in *Проростень*, 1926, pp. 15-16:**
+
+> **Люблю слова ще повнодзвонні**
+
+This line is useful pedagogically because it lets learners see Drai-Khmara's metalinguistic poetics: the poem is not just decorative classicism, but a defense of deep Ukrainian lexical memory. It was verified with `verify_quote` (`ukrlib-drai_khmara`, confidence 1.0) and cross-checked in `search_literary`, which gives *Проростень* (Kyiv, 1926), pp. 15-16.
+
+## 5. Language register
+
+- **Register:** high modernist / neoclassical lyric with symbolist residue.
+- **CEFR readiness for full reading:** C1 for independent reading; B2 if taught with glossary and historical framing.
+- **Lexicon notes:** Dense abstractions, archaisms, elevated Slavic and classical allusions, and cultivated sound texture. Words like "повнодзвонні" are not everyday vocabulary; they are part of the poem's argument about stored cultural resonance.
+- **Stylistic features:** sonnet architecture, alliteration, mythic image clusters, classical clarity, and intellectual compression. For L2 learners, the best entry is a short quoted line plus a guided explanation of "неокласики" and Soviet attacks on "non-proletarian" art.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** The key debate is how to name his position: "neoclassicist" is accurate as a network label, but his early poetry is also symbolist, and his scholarship makes him more than a literary-group member. [T1: IEU; T1: ЕУ Сарсель]
+- **Death narrative:** Popular memory sometimes preserves the story that he saved a younger prisoner and was shot in a work line. The accessed Tier 1/2 sources securely establish the NKVD case, transfer to Kolyma, and death date; the heroic camp anecdote should be labeled as memoir tradition unless separately sourced. [T2: Harriman Review]
+- **What gets simplified:** It is too simple to call him "apolitical" and leave it there. The Soviet state criminalized his aesthetic and scholarly Ukrainian commitments, but his corpus also shows conscious cultural defense.
+- **Russian/Soviet disinformation angle:** The original smear was the Soviet security vocabulary of "counter-revolutionary nationalist terrorist organization." Modern Russocentric summaries sometimes repeat the existence of a "case" without foregrounding that the 1989 rehabilitation and the file itself expose the fabrication. [T2: Harriman Review]
+- **Other-perspective considerations:** His work on Belarusian, Serbian, Polish, French, and Finnish texts makes him a cross-cultural Slavic and European mediator, not a closed nationalist figure.
+
+## 7. Cross-track links
+
+`rg` checks found existing LIT coverage:
+
+- `curriculum/l2-uk-en/plans/lit/dray-khmara-poetry.yaml` — direct Drai-Khmara poetry module.
+- `curriculum/l2-uk-en/plans/lit/rylsky-neoclassicism.yaml` — neoclassicism overview with Drai-Khmara.
+- `curriculum/l2-uk-en/plans/bio/pavlo-fylypovych.yaml` — bio-plan vocabulary already explains "ґроно п'ятірне".
+
+No exact HIST-plan hit for Drai-Khmara was found, but the case fits existing terror-context modules such as `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` and `curriculum/l2-uk-en/plans/hist/syntez-trahedii.yaml`. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-drai-khmara`
+- **EN canonical:** Mykhailo Drai-Khmara (BGN/PCGN-style project spelling; use only when English is required).
+- **UA canonical:** Михайло Опанасович Драй-Хмара.
+- **Aliases to track:** Михайло Панасович Драй-Хмара; Драй Михайло; Draj-Xmara, Myxajlo in IEU metadata; Mykhailo Drai-Khmara.
+- **Forbidden Russian-imperial / Russified forms:** Mikhail Drai-Khmara; Mikhail Dray-Khmara; Михаил Афанасьевич Драй-Хмара; Mikhail Panasovich Drai-Khmara. Use these only in alias/metadata warnings, not in learner-facing prose.
+
+## 9. Image candidates
+
+- Wikimedia Commons: `File:Mykhailo Drai-Khmara in 1910.jpg`, public-domain tagged, source given as *Безсмертні* (Munich, 1963); suitable first candidate after final rights review.
+- Wikimedia Commons category `Mykhailo Drai-Khmara` also includes a 1925 image and signature files. Use individual file pages, not category pages, for final license proof.
+- ЕСУ and IEU also host portraits, but Commons PD/PD-marked material is the preferred curriculum path.
+
+## 10. Sources used
+
+- **[T1]** Дзюба І. "Драй-Хмара Михайло Опанасович." *Енциклопедія Сучасної України*. 2008. https://esu.com.ua/article-21682
+- **[T1]** Брега Г. "Драй-Хмара Михайло Опанасович." *Енциклопедія історії України*, т. 2. 2004. https://www.history.org.ua/?termin=Dray_Khmara_M
+- **[T1]** "Драй-Хмара Михайло." *Енциклопедія українознавства* / ЕУ Сарсель, Litopys reprint.
+- **[T1]** Koshelivets I. "Drai-Khmara, Mykhailo." *Internet Encyclopedia of Ukraine*, vol. 1. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CR%5CDrai6KhmaraMykhailo.htm
+- **[T2]** Chernetsky V., trans./intro. "The NKVD File of Mykhailo Drai-Khmara." *The Harriman Review*, 2004. PDF accessed via ukrliteratura.com mirror.
+- **[T3]** Ukrainian Wikipedia extract for Драй-Хмара Михайло Опанасович, used as a starting point and cross-check only.

--- a/docs/research/bio/volodymyr-sosiura.md
+++ b/docs/research/bio/volodymyr-sosiura.md
@@ -1,0 +1,122 @@
+# Володимир Миколайович Сосюра — Research Dossier
+
+**Slug:** `volodymyr-sosiura`
+**Block:** D (survived but censored / professionally threatened)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-26
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Володимир Миколайович Сосюра. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Сосюра Володимир Миколайович; early family-origin variants around Sossur/de Saussure appear in biographical debates but are not canonical. Forbidden in body text except here: Vladimir Sosyura, Vladimir Sosiura, Владимир Николаевич Сосюра, Sosyura as English canonical.
+- **Born:** 25 December 1897 / 6 January 1898 | station settlement Debaltseve, Bakhmut county, Katerynoslav gubernia; now Donetsk oblast, Ukraine. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Died:** 8 January 1965 | Kyiv, Ukrainian SSR | heart disease; buried at Baikove cemetery. [T1: ЕСУ; T1: ЕІУ]
+- **Family / education key facts:** Childhood in Верхнє / Третя Рота, now within Лисичанськ; from age 11 he worked as a laborer. In 1918 he joined an anti-Hetman worker uprising and then became a soldier of the Ukrainian People's Republic army; in 1920 he joined the Red Army in Odesa. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+
+**Source disagreement note:** Sources present the birth date in Old/New Style form; use 6 January 1898 for modern date display while retaining 25 December 1897 in verified facts. ЕІУ gives the early lost collection as *Пісні крови* under the spelling "Сюсюра В."; ЕСУ treats the 1918 book as a manuscript/attested but not preserved item. [T1: ЕСУ; T1: ЕІУ]
+
+## 2. Oppression mechanism
+
+- **What happened:** censorship attack, accusation of nationalism, threat of arrest, professional and publication damage after the poem "Любіть Україну!".
+- **When:** poem written and published in 1944; revised in later Soviet editions; *Pravda* attack on 2 July 1951; renewed danger through 1951 while his wife Maria had already been repressed in 1950. [T1: ЕІУ; T1: ЕСУ; T1: IEU]
+- **By whom:** all-Union Communist Party press organ *Pravda*, backed by Soviet ideological authorities; the coercive background included party censorship, Glavlit-style publication control, and the security-state threat named by ЕСУ as renewed danger of arrest.
+- **Document reference:** *Pravda*, 2 July 1951, article "Об идеологических извращениях в литературе" ("Проти ідеологічних перекручень у літературі" in Ukrainian summaries), attacking "Любіть Україну!" as nationalist. [T1: ЕІУ]
+
+Sosiura's case is not a camp-death file but a Block D censorship mechanism. ЕСУ states that in 1951 he again faced threat of arrest because of the accusation of nationalism and harsh Bolshevik criticism of "Любіть Україну!", a poem already widely known through Russian translations. ЕІУ gives the specific *Pravda* date and article title and notes that the poem, first published in 1944, was later edited in Soviet collections. [T1: ЕСУ; T1: ЕІУ]
+
+The attack was professionally destructive because it marked a loyal, prize-winning Soviet poet as ideologically suspect after he had written a direct Ukrainian patriotic poem during wartime. The contradiction was the mechanism: he was a Stalin Prize laureate in 1948, but the same system could brand him a nationalist in 1951. The case also intersected family repression: ЕІУ records that the collection *Колос викинув ячмінь* was being prepared in 1950 when his wife Maria was repressed. [T1: ЕІУ; T1: IEU]
+
+**What survived / what was destroyed:** "Любіть Україну!" survived but was revised and ideologically policed; EIU states that his poem *Махно* is lost except for traces and that *Серце* was banned immediately after release. His archive is held in ЦДАМЛМ України фонд №44 and the Shevchenko Institute of Literature фонд №139. [T1: ЕІУ; T1: IEU]
+
+## 3. Major works
+
+- **1918/1919** — *Пісні крови*, early collection printed or attested under wartime Ukrainian forces; not found. [T1: ЕІУ; T1: ЕСУ]
+- **1921** — *Поезії*, first known book. [T1: IEU]
+- **1922** — *Червона зима*, revolutionary poem/collection that made him famous. [T1: ЕСУ; T1: IEU]
+- **1924** — *Місто* and *Осінні зорі*, collections with post-revolutionary urban and lyric registers. [T1: ЕСУ]
+- **1925** — *Сніги* and related works on the Ukrainian Revolution period; use with decolonizing caution because older sources apply Russocentric periodization. [T1: IEU]
+- **1927** — *Золоті шуліки*, collection. [T1: ЕСУ; T1: IEU]
+- **1930** — *Два Володьки*, poem on ideological and national self-division. [T1: IEU; primary corpus]
+- **1931** — *Серце*, collection banned immediately after publication. [T1: IEU; T1: ЕСУ]
+- **1944** — "Любіть Україну!", wartime patriotic poem and later censorship flashpoint. [T1: ЕІУ; textbook corpus]
+- **1951** — *Вибрані переклади*, translations volume; appears the same year as the public attack. [T1: ЕСУ]
+- **1957** — *Солов'їні далі*, postwar lyric collection. [T1: ЕСУ; T1: IEU]
+- **1960** — *Близька далина* and "Розстріляне безсмертя", late works with memory and suppressed-history pressure. [T1: ЕСУ; T1: ЕІУ]
+- **1988** — *Третя Рота*, autobiographical novel, posthumous publication. [T1: IEU; T1: ЕІУ]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — "Любіть Україну!", 1944, first-publication line preserved in corpus:**
+
+> **Любіть Україну, як сонце любіть**
+
+This is the line the 1951 campaign could not tolerate: love for Ukraine is direct, not routed through Moscow or through Soviet formulas. It was verified with `verify_quote` against `ukrlib-sosyura`, confidence 1.0.
+
+**Quote 2 — "Два Володьки", 1930:**
+
+> **Рвали душу мою два Володьки**
+
+This line gives learners the anti-hagiographic key to Sosiura: his biography is not a simple conversion tale but a struggle between revolutionary loyalty, Ukrainian duty, fear, and survival. It was verified with `verify_quote` against `ukrlib-sosyura`, confidence 1.0.
+
+## 5. Language register
+
+- **Register:** lyric, songlike, emotionally direct, with sharp shifts into ideological and autobiographical conflict.
+- **CEFR readiness for full reading:** B2 for selected lyric poems; C1 for *Два Володьки*, *Мазепа*, and *Третя Рота* excerpts.
+- **Lexicon notes:** Many lyric poems are syntactically accessible, but historical vocabulary, party-state terms, and self-censored Soviet formulae require teacher framing.
+- **Stylistic features:** repetition, direct address, musical parallelism, color imagery, and rapid emotional contrast. His apparent simplicity should not be mistaken for political simplicity.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** One debate is how to read his ideological dividedness: ЕІУ and IEU both stress the tension between service in the UNR army, later Red Army and party institutions, and persistent Ukrainian patriotic writing. [T1: ЕІУ; T1: IEU]
+- **Origin story:** Popular biographies sometimes repeat a French/de Saussure origin myth. Ukrainian scholarship records it as a family claim or debated genealogy, not as a license to detach him from Ukrainian Donbas and Ukrainian literary history. [T3: Ukrainian Wikipedia as starting point; T1: ЕСУ for verified Ukrainian context]
+- **What gets simplified:** Soviet memory flattened him into a loyal lyricist of Soviet Ukraine; nationalist memory can flatten him into only a persecuted patriot. The harder dossier truth is both: he wrote conformist texts, received Stalin and Shevchenko prizes, and was still threatened as a nationalist for a Ukrainian patriotic poem. [T1: ЕСУ; T1: ЕІУ]
+- **Russian disinformation angle:** Russocentric online framing often keeps the Russian title of the *Pravda* attack and then presents the poem as merely "Soviet patriotic." The decolonized frame must say that the target was Ukrainian attachment itself: the accusation was nationalism because the poem centered Ukraine without subordinating that love to imperial hierarchy. [T1: ЕІУ]
+- **Other-perspective considerations:** Sosiura translated Russian, Belarusian, Bashkir, Armenian, Bulgarian, and Hungarian poets. Those translation ties should be taught as multilingual Soviet-era cultural labor, not as evidence that Ukrainian national framing is secondary. [T1: ЕСУ]
+
+## 7. Cross-track links
+
+`rg` checks found existing LIT coverage:
+
+- `curriculum/l2-uk-en/plans/lit/sosiura-love-ukraine.yaml`
+- `curriculum/l2-uk-en/plans/lit/sosiura-internal-conflict.yaml`
+- `curriculum/l2-uk-en/plans/lit/sosiura-red-winter.yaml`
+- `curriculum/l2-uk-en/plans/lit/zerov-kyiv-parnassus.yaml` references Sosiura in a debate context.
+
+HIST context should link to Ukrainian Revolution and Stalinist cultural policy modules, especially `curriculum/l2-uk-en/plans/hist/syntez-revoliutsiia.yaml`, `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml`, `curriculum/l2-uk-en/plans/hist/syntez-trahedii.yaml`, and `curriculum/l2-uk-en/plans/hist/destalinizatsiia.yaml`. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `volodymyr-sosiura`
+- **EN canonical:** Volodymyr Sosiura.
+- **UA canonical:** Володимир Миколайович Сосюра.
+- **Aliases to track:** Сосюра Володимир Миколайович; early printed variant Сюсюра В.; Sosjura in IEU metadata; family-origin claims Sossur/de Saussure only in contested-genealogy notes.
+- **Forbidden Russian-imperial / Russified forms:** Vladimir Sosyura; Vladimir Sosiura; Владимир Николаевич Сосюра; Sosyura as English canonical; "Soviet Russian poet" labels.
+
+## 9. Image candidates
+
+- Wikimedia Commons: `File:Volodymyr Sosiura.jpg`, 1928 portrait from *Письменники Радянської України*, author О. Кореневич, PD-old-95 / public-domain marked; strong first candidate after final rights review.
+- Wikimedia Commons: `File:Володимир Сосюра у 1950-ті.jpg`, useful for later-life censorship context, but license must be individually verified.
+- ЕСУ and IEU host portraits, but Commons PD material is the preferred curriculum source.
+
+## 10. Sources used
+
+- **[T1]** Моренець В. "Сосюра Володимир Миколайович." *Енциклопедія Сучасної України*. 2025. https://esu.com.ua/article-889403
+- **[T1]** Гальченко С. "Сосюра Володимир Миколайович." *Енциклопедія історії України*. https://www.history.org.ua/?termin=Sosiura_V
+- **[T1]** "Сосюра Володимир." *Енциклопедія українознавства* / ЕУ Сарсель, Litopys reprint.
+- **[T1]** Koshelivets I. "Sosiura, Volodymyr." *Internet Encyclopedia of Ukraine*, vol. 4. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CO%5CSosiuraVolodymyr.htm
+- **[support]** Ukrainian textbook corpus, Grade 8 Zabolotnyi 2025, p. 214, for the May 1944 Kyiv/leaflet teaching context; not counted toward Tier 1/2 minimum.
+- **[T3]** Ukrainian Wikipedia extract for Сосюра Володимир Миколайович, used as a starting point and cross-check only.

--- a/docs/research/bio/volodymyr-svidzinskyi.md
+++ b/docs/research/bio/volodymyr-svidzinskyi.md
@@ -1,0 +1,118 @@
+# Володимир Євтимович (Юхимович) Свідзінський — Research Dossier
+
+**Slug:** `volodymyr-svidzinskyi`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-26
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Володимир Євтимович Свідзінський for project-facing continuity; modern ЕСУ and ЕІУ headword use **Володимир Юхимович Свідзінський** and explicitly list Євтимович as a variant. [T1: ЕСУ; T1: ЕІУ]
+- **Pseudonyms / aliases:** Володимир Юхимович Свідзінський; Володимир Євтимович Свідзінський; Свідзинський / Свідзінський orthographic variants. Forbidden in body text except in this section: Vladimir Svidzinsky, Владимир Ефимович Свидзинский, Volodimir Svidzinskij, Svidzinskiy.
+- **Born:** 26 September / 8 October 1885 | Маянів, Вінницький повіт, Подільська губернія; now Вінницька область, Україна. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Died:** 18 October 1941 | older testimony: Saltiv/Nepokryte area near Kharkiv; case-review line: хутір Бутирки, Уразовський район, Курська область, now Belgorod oblast, Russian Federation | burned in a locked building with other prisoners during NKVD evacuation. [T1: ЕСУ; T1: ЕІУ; T4: Solovey 2009]
+- **Family / education key facts:** Born in a priest's family; studied at Tivriv religious school, Podilian seminary in Kamianets-Podilskyi, and Kyiv Commercial Institute. He worked in zemstvo research, Kamianets-Podilskyi publishing/archives, and Kharkiv editorial and translation jobs. [T1: ЕСУ; T1: ЕІУ; textbook corpus]
+
+**Source disagreement note:** The dispatch brief says "near Bryansk"; the accessed sources do not support that. IEU records eyewitness accounts of being burned alive at Saltiv near Kharkiv and a Soviet-record version blaming a German bomb. Solovey's article on case no. 72569 and modern ЕСУ/ЕІУ identify Butyrky in the then Kursk oblast, near the later Belgorod border, as the archival death-place line. [T1: IEU; T4: Solovey 2009; T1: ЕСУ]
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest by NKVD in Kharkiv, fabricated anti-Soviet agitation case, evacuation eastward, killing by burning prisoners in a locked outbuilding.
+- **When:** case opened 26 September 1941; arrest and search sanctioned/executed 27 September 1941; investigation suspended/transferred during evacuation in mid-October; killing dated 18 October 1941. [T4: Solovey 2009; T1: ЕСУ]
+- **By whom:** Управління НКВС у Харківській області, secret-political department (СПО); later wartime convoy/evacuation command.
+- **Document references:** investigatory case **№ 72569**, archival number **07993**; charge under article **54-10**, part II of the Criminal Code of the Ukrainian SSR; 1964 termination of criminal case №07993 under p. 2 art. 6 CPC "through absence of corpus delicti." [T4: Solovey 2009]
+
+Eleonora Solovey's article introduces the preserved investigatory file and states that the case was opened on 26 September 1941 under the Kharkiv oblast NKVD. The arrest was justified by a formulaic allegation that Svidzinskyi, formerly connected with Ukrainian state institutions in Kamianets-Podilskyi, conducted anti-Soviet agitation and awaited the German army. Solovey notes the archival absence of a reliable denunciation trail and the absurd logic by which a poet's earlier Ukrainian state-era work could be treated as present guilt. [T4: Solovey 2009]
+
+The decisive mechanism was wartime liquidation, not a completed trial. As German forces approached Kharkiv, prisoners were marched east; ЕСУ and ЕІУ state that on 18 October 1941 they were driven into an abandoned farm building near Butyrky, locked in, and burned. The later rehabilitation file found no proof of the alleged crime; the case was stopped in 1964 for absence of corpus delicti. [T1: ЕСУ; T1: ЕІУ; T4: Solovey 2009]
+
+**What survived / what was destroyed:** His archive survived unevenly. Oleksa Veretenchenko took an authorized typescript abroad, enabling the 1975 Munich *Медобір* publication. His daughter preserved manuscripts in Ukraine, but full canonization was delayed; the first full two-volume edition appeared in Kyiv in 2004. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+
+## 3. Major works
+
+- **1912** — "Давно, давно тебе я жду...", first known publication in *Українська хата*. [T1: ЕСУ; T1: ЕІУ]
+- **1916** — "Ткацкий промысел", ethnographic/economic essay in *Кустарные промыслы Подольской губернии*. [T1: ЕСУ]
+- **1922** — *Ліричні поезії*, first collection, Kamianets-Podilskyi. [T1: ЕСУ; T1: IEU]
+- **1927** — *Вересень*, self-financed second collection; attacked for "idealism," "passivity," and "bourgeois" worldview. [T1: ЕСУ; T1: ЕІУ]
+- **1930s** — translations from Hesiod, Aesop, Ovid, Aristophanes, *Слово про похід Ігорів*, and European literatures. [T1: ЕСУ; T1: IEU]
+- **1938** — "Передмова до казки", lyric later quoted by Solovey as characteristic of the 1940 book's scandalous independence. [T4: Solovey 2009]
+- **1940** — *Поезії*, Lviv, edited with support from admirers; last lifetime book and the trigger for professional punishment. [T1: ЕСУ; T1: IEU]
+- **1975** — *Медобір*, Munich, posthumous collection from Veretenchenko's preserved typescript. [T1: ЕСУ; T1: IEU]
+- **2004** — *Твори: У 2 т.*, Kyiv, first full edition of poems and translations. [T1: ЕСУ; T1: ЕІУ]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — "Передмова до казки", 1938, quoted in Solovey 2009, p. 16:**
+
+> **Пухнаті лапки, віяла, колосся**
+
+Solovey prints the poem to show why the 1940 *Поезії* book could not be assimilated to socialist realism. The line is concrete, delicate, and non-declarative: a good B2/C1 entry into his visual lyric. `verify_quote` returned no match because Svidzinskyi primary texts are not indexed in the current literary corpus; the line was checked against Solovey's printed article.
+
+**Quote 2 — "Лице люстра мертвіє в тіні...", 1933, quoted in Solovey 2009, p. 17:**
+
+> **Я глухіше, сумніше горю**
+
+Solovey connects this poem to his cultivated silence after Kharkiv and to the historical pressures of the 1930s. The image also becomes tragically overdetermined by his death in fire. `verify_quote` again returned no corpus match; citation is to Solovey's article.
+
+## 5. Language register
+
+- **Register:** quiet high lyric, symbolist-to-surrealist, with folk-mythic undertones.
+- **CEFR readiness for full reading:** C1; selected short poems can be taught at B2 with vocabulary scaffolding.
+- **Lexicon notes:** His diction is not aggressively archaic, but syntax and image logic are compressed. Learners need support for metaphor chains, diminutives, and nature vocabulary.
+- **Stylistic features:** miniature lyric, silence, recurrence, dream logic, folk tale structures, and precise domestic images. The register resists slogans; that resistance is part of the biography.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Scholars debate how to describe his late position: "internal emigration" captures withdrawal from Soviet literary demands, but it can understate how much active craft, translation, and manuscript work continued. [T1: ЕСУ; T1: ЕІУ]
+- **Death-place and mechanism:** Saltiv/Nepokryte eyewitness memory, Soviet "German bomb" phrasing, and the Butyrky case-review line must be kept separate. The strongest modern archival treatment rejects the bomb explanation and foregrounds NKVD custody. [T1: IEU; T4: Solovey 2009]
+- **What gets simplified:** Popular memory sometimes presents him only as a passive, silent victim. The sources show a more difficult profile: a poet who chose lyric integrity, protected manuscripts, translated widely, and paid with job loss before arrest. [T1: ЕСУ]
+- **Russian/Soviet disinformation angle:** The Soviet-era deflection blamed wartime chaos or a German bomb, erasing the fact that he was under NKVD arrest and that the file contained no proof of guilt. Modern Russocentric summaries may repeat the "war casualty" frame without naming the NKVD evacuation killing.
+- **Other-perspective considerations:** His translations from Russian writers exist, but they should not be used to assimilate him into a Russian literary frame; his institutional life and repression mechanism are Ukrainian and Soviet-colonial.
+
+## 7. Cross-track links
+
+`rg` checks found no exact `Свідзінський`, `Свідзинський`, or `Svidzinskyi` references in `curriculum/l2-uk-en/plans/lit/`, `hist/`, or `bio/`. This is a gap: Grade 11 textbook material already treats him, and his 1941 NKVD killing belongs with wartime prisoner-liquidation context.
+
+Potential future links:
+
+- LIT: add a future module on Svidzinskyi's *Медобір* / late lyric once Phase 2 planning opens.
+- HIST: link to `curriculum/l2-uk-en/plans/hist/druha-svitova-pochatok.yaml` for 1941 NKVD prison killings and to `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` for repression mechanisms.
+
+No plan YAML was changed. Follow-up filed as `bio-expansion-followup`: #2353.
+
+## 8. Naming-canonical
+
+- **Slug:** `volodymyr-svidzinskyi`
+- **EN canonical:** Volodymyr Svidzinskyi.
+- **UA canonical:** Володимир Євтимович Свідзінський for the project row; record modern source headword **Володимир Юхимович Свідзінський** as the Tier 1 variant.
+- **Aliases to track:** Володимир Юхимович Свідзінський; Володимир Євтимович Свідзінський; Свідзинський В.; Svidzinsky, Volodymyr in IEU metadata.
+- **Forbidden Russian-imperial / Russified forms:** Vladimir Svidzinsky; Vladimir Svidzinskiy; Владимир Ефимович Свидзинский; Свидзинский Владимир Ефимович; Volodimir Svidzinskij.
+
+## 9. Image candidates
+
+- Wikimedia Commons: `File:Свідзинський В.jpg`, public-domain tagged as a Ukrainian/USSR work published before 1955; source listed as libruk.com.ua and date "for 1917." Use only after final license/US status confirmation.
+- Wikimedia Commons category `Volodimir Svidzinsky` contains the portrait and a Kamianets-Podilskyi location photo; use the individual file page for final rights proof.
+- IEU hosts a portrait but Commons is preferred if license passes review.
+
+## 10. Sources used
+
+- **[T1]** Соловей Е. "Свідзінський Володимир Юхимович." *Енциклопедія Сучасної України*. 2025. https://esu.com.ua/article-888174
+- **[T1]** Соловей Е. "Свідзінський Володимир Юхимович." *Енциклопедія історії України*. https://www.history.org.ua/?termin=Svidzinskyj_V
+- **[T1]** "Свідзінський Володимир." *Енциклопедія українознавства* / ЕУ Сарсель, Litopys reprint.
+- **[T1]** Kravtsiv B. "Svidzinsky, Volodymyr." *Internet Encyclopedia of Ukraine*, updated 2007. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CV%5CSvidzinskyVolodymyr.htm
+- **[T4]** Соловей Е. "'Зберігати вічно... до 1967 року' (про слідчу справу Володимира Свідзінського)." *Слово і Час*, 2009, №9, pp. 14-23. https://nasplib.isofts.kiev.ua/bitstream/handle/123456789/133503/03-Solovey.pdf?sequence=1
+- **[T3]** Ukrainian Wikipedia extract for Свідзінський Володимир Юхимович, used as a starting point and cross-check only.


### PR DESCRIPTION
DO NOT MERGE — pilot review pending.

## Summary

Adds three R1a pilot research dossiers under `docs/research/bio/` using the F5 template:

- `mykhailo-drai-khmara.md`
- `volodymyr-svidzinskyi.md`
- `volodymyr-sosiura.md`

## Pilot counts

| Figure | Words | Tier 1/2 sources cited | Primary quotes |
| --- | ---: | ---: | ---: |
| Михайло Драй-Хмара | 1551 | 5 | 2 |
| Володимир Свідзінський | 1553 | 4 | 2 |
| Володимир Сосюра | 1531 | 4 | 2 |

## Decolonization self-check

Passed for all three dossiers:

- No Russocentric framing in the explanatory prose.
- No Russocentric periodization used for Sosiura's Українська революція 1917-1921 context.
- No euphemisms such as "lost his life" for executions / deaths in custody.
- Soviet propaganda labels are named as accusations, not accepted as facts.
- Modern Ukrainian canonical naming is used; Russified forms appear only in alias/forbidden-name sections.
- Place-name disagreements are flagged rather than silently resolved.

## Acceptance criteria notes

No F5 checklist item is left unchecked in the dossiers.

Important pilot friction:

- Svidzinskyi: `verify_quote` returned no match for the two primary excerpts because his primary text does not appear to be indexed in the current literary corpus. The quotes are therefore checked against Eleonora Solovey's printed `Слово і Час` article and documented as such in §4. This is a source/tool-coverage issue for the pilot review.
- Svidzinskyi: the dispatch brief's "near Bryansk" death-place wording was not supported by accessed sources. The dossier records the older Saltiv/Nepokryte testimony and the case-review/ЕСУ/ЕІУ Butyrky, former Kursk oblast line.
- Cross-track gap: no exact Svidzinskyi LIT/HIST/BIO plan references were found. Follow-up filed: #2353.

## Validation

- `npx markdownlint-cli2 docs/research/bio/mykhailo-drai-khmara.md docs/research/bio/volodymyr-svidzinskyi.md docs/research/bio/volodymyr-sosiura.md`
- `git diff --cached --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Pre-commit hooks on commit and push passed.
