### PR TITLE
fix(wiki_coverage): parse XML <row .../> shape in implementation_map

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -62,6 +62,39 @@ _COMPACT_PIPE_ENTRY_RE = re.compile(
     r"(?P<treatment>.*?)(?=\s+(?:\|\s*)?[-\w]+\s*\|\s*(?:module\.md|activities\.yaml)\s*\||\s*$)",
     re.IGNORECASE | re.DOTALL,
 )
+# XML-attribute row shape: writer (codex-tools in particular) reads the
+# `<implementation_map>` XML parent tag as a hint to nest `<row .../>` XML
+# elements with quoted attributes. Both formats are present in the wild —
+# claude-tools emits markdown bullets, codex-tools emits XML rows. Example:
+#
+#   <implementation_map>
+#   <row obligation_id="ban-1" artifact="module.md" location="§Мій ранок"
+#        treatment="No Russian-language explanation appears." />
+#   <row obligation_id="step-2" artifact="module.md" location="§Дiалоги"
+#        treatment="..." />
+#   </implementation_map>
+#
+# Captures the full attribute body of any self-closing <row .../> tag inside
+# an <implementation_map> block. Attribute extraction below pulls the four
+# known fields (obligation_id, artifact, location, treatment). Discovered
+# 2026-05-26 in m20 round #11 build a1-my-morning-20260526-200639, where
+# codex-tools emitted all 18 obligations as <row .../> entries and the gate
+# saw `implementation_map_missing` on every one (coverage 0/18) because the
+# bullet/pipe parsers don't match the XML-attribute shape.
+_ROW_XML_RE = re.compile(
+    # Match `<row attr1="val1" attr2="val2" ... />` where values may contain
+    # `/` and `>` characters (common in treatment text). The body is captured
+    # as a sequence of one-or-more key="value" pairs, NOT as a free-form blob,
+    # so the regex stops cleanly at the closing `/>` even when values contain
+    # slashes (e.g. `treatment="Я прокидаюся. / Він прокидається."`).
+    r"<row\b(?P<attrs>(?:\s+\w+\s*=\s*\"[^\"]*\")+)\s*/\s*>",
+    re.IGNORECASE,
+)
+_ROW_XML_ATTR_RE = re.compile(
+    r"(?P<key>obligation_id|artifact|location|treatment)\s*=\s*"
+    r"\"(?P<value>[^\"]*)\"",
+    re.IGNORECASE | re.DOTALL,
+)
 _WORKBOOK_AGGREGATE_ACTIVITY_TYPES = (
     "anagram",
     "authorial-intent",
@@ -153,6 +186,28 @@ def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
                 "location": pipe_match.group("location").strip(),
                 "treatment": pipe_match.group("treatment").strip().rstrip("|").strip(),
             }
+        # XML-row shape: `<row obligation_id="..." artifact="..." location="..."
+        # treatment="..." />` — extract the attribute block, then pull each
+        # known key=value pair out of it. Per-row obligation_id is required;
+        # rows without it are silently skipped (matches the bullet/pipe
+        # parser's tolerance for malformed lines).
+        for row_match in _ROW_XML_RE.finditer(body):
+            attrs_text = row_match.group("attrs")
+            attrs: dict[str, str] = {}
+            for attr_match in _ROW_XML_ATTR_RE.finditer(attrs_text):
+                attrs[attr_match.group("key").casefold()] = (
+                    attr_match.group("value").strip()
+                )
+            obligation_id = attrs.get("obligation_id", "").strip()
+            if not obligation_id:
+                continue
+            existing = entries.setdefault(
+                obligation_id, {"obligation_id": obligation_id}
+            )
+            for key in ("artifact", "location", "treatment"):
+                value = attrs.get(key)
+                if value:
+                    existing[key] = value
         current_id: str | None = None
         for line in body.splitlines():
             id_match = _OBLIGATION_RE.search(line)

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -597,6 +597,69 @@ def test_parse_implementation_map_accepts_compact_markdown_table_rows() -> None:
     assert parsed["ban-1"]["artifact"] == "module.md"
 
 
+def test_parse_implementation_map_accepts_xml_row_attribute_shape() -> None:
+    """codex-tools (m20 round #11) read the ``<implementation_map>`` parent tag
+    as a cue to nest ``<row .../>`` XML elements with quoted attributes
+    instead of markdown bullets/pipes. The parser MUST recognize this shape:
+    round #11 emitted 18 well-formed XML row entries and the gate failed all
+    18 with ``implementation_map_missing`` because the parser only matched
+    bullet/pipe shapes. Fixture mirrors the exact codex-tools envelope from
+    that build (`a1-my-morning-20260526-200639`)."""
+    implementation_map = """
+<implementation_map>
+<row obligation_id="ban-1" artifact="module.md" location="§Мій ранок" treatment="No Russian-language explanation, parallel, or phonetic comparison appears." />
+<row obligation_id="ban-2" artifact="module.md" location="all prose" treatment="No comparison of Ukrainian -ться to Russian appears." />
+<row obligation_id="err-1" artifact="activities.yaml" location="workbook error-correction" treatment="sentence/error/correction item for Я прокидаюся. / Він прокидається." />
+<row obligation_id="phon-1" artifact="module.md" location="§Дієслова на -ся" treatment="Written -шся maps to spoken [с':а]." />
+<row obligation_id="step-1" artifact="module.md" location="§Дієслова на -ся" treatment="Крок 1 marker with читати paradigm." />
+</implementation_map>
+<implementation_map>No new obligation_id rows here; all 18 rows are listed exactly once in the first implementation_map.</implementation_map>
+"""
+
+    parsed = parse_implementation_map(implementation_map)
+
+    assert set(parsed.keys()) == {"ban-1", "ban-2", "err-1", "phon-1", "step-1"}
+    assert parsed["ban-1"]["artifact"] == "module.md"
+    assert parsed["ban-1"]["location"] == "§Мій ранок"
+    assert parsed["ban-1"]["treatment"].startswith("No Russian-language")
+    assert parsed["err-1"]["artifact"] == "activities.yaml"
+    assert parsed["err-1"]["location"] == "workbook error-correction"
+    assert parsed["phon-1"]["artifact"] == "module.md"
+    assert parsed["phon-1"]["location"] == "§Дієслова на -ся"
+    assert parsed["step-1"]["treatment"] == "Крок 1 marker with читати paradigm."
+
+
+def test_parse_implementation_map_xml_row_tolerates_whitespace_and_self_close_variants() -> None:
+    """The XML-row parser must tolerate the common formatting variants
+    a writer might produce: multi-line attribute layout, attributes in
+    any order, space-around-slash in the closing token, and mixed
+    bullet+XML entries inside one implementation_map block."""
+    implementation_map = """
+<implementation_map>
+<row
+  artifact="module.md"
+  obligation_id="phon-2"
+  location="§Phonetics"
+  treatment="written -ться → spoken [ц':а]"
+/>
+<row obligation_id="ban-3" artifact="module.md" location="§Intro" treatment="absence required"/>
+- obligation_id: step-9; artifact: module.md; location: §Outro; treatment: closing recap
+</implementation_map>
+"""
+
+    parsed = parse_implementation_map(implementation_map)
+
+    assert "phon-2" in parsed
+    assert parsed["phon-2"]["artifact"] == "module.md"
+    assert parsed["phon-2"]["treatment"] == "written -ться → spoken [ц':а]"
+    assert "ban-3" in parsed
+    assert parsed["ban-3"]["location"] == "§Intro"
+    # Bullet entry on the same line as XML rows still parses via the existing
+    # bullet path; the XML parser leaves entries it already added alone.
+    assert parsed["step-9"]["artifact"] == "module.md"
+    assert parsed["step-9"]["treatment"] == "closing recap"
+
+
 def test_l2_error_passes_with_compact_pipe_workbook_location() -> None:
     """The compact Codex pipe-map shape plus a generic workbook location
     should widen to all activities, then let the substance check decide."""


### PR DESCRIPTION
## Summary

m20 round #11 build (codex-tools, BUILD_BASE `6597f33752`) cleared ALL 28 python_qg hard gates but then HARD-failed `wiki_coverage_gate` with ALL 18 obligations reporting `implementation_map_missing` (coverage 0/18).

**Root cause: writer-parser format mismatch.** The writer prompt's `<implementation_map>` XML wrapper doesn't specify the inner row shape. claude-tools reads it as a cue for markdown bullets / compact-pipe rows (parser supports). codex-tools reads it as a cue for nested `<row .../>` XML elements with quoted attributes — a perfectly reasonable XML reading. The parser only matched bullet/pipe shapes, so every codex-tools XML row dropped silently → coverage 0/18 → terminal hard fail.

## End-to-end verification

Running the patched parser against the actual round #11 `writer_output.raw.md`:

```
parsed 18 entries
ids: ['ban-1', 'ban-2', 'ban-3', 'ban-4', 'err-1', 'err-2', 'err-3', 'err-4', 'err-5',
      'err-6', 'phon-1', 'phon-2', 'phon-3', 'step-1', 'step-2', 'step-3', 'step-4', 'step-5']
incomplete entries: []
```

All 18 obligations now parse with all 4 fields (obligation_id, artifact, location, treatment). The build that emitted this output would have shipped with this fix.

## The fix

- `_ROW_XML_RE` matches `<row attr1="v1" attr2="v2" ... />` (one or more well-formed key="value" pairs, then `/>`). Constrained attribute body correctly handles values containing `/` and `>` (e.g. `treatment="Я прокидаюся. / Він прокидається."`).
- `_ROW_XML_ATTR_RE` extracts the four known fields from each matched row's attribute string.
- `parse_implementation_map` iterates `_ROW_XML_RE` over each block body alongside the existing bullet/pipe parsers. Mixed shapes inside one block are accepted.

## Test plan

- [x] `pytest tests/audit/test_wiki_coverage_gate.py -q` → 18 passed (16 pre-existing + 2 new)
- [x] `ruff check scripts/audit/wiki_coverage_gate.py tests/audit/test_wiki_coverage_gate.py` → All checks passed
- [x] End-to-end against round #11 actual writer output: 18/18 parsed correctly
- [ ] CI green
- [ ] m20 round #12 with `--writer codex-tools` clears `wiki_coverage_gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)