### PR TITLE
feat(bridge): ab send-agy-ui — drive Antigravity UI thread analogous to send-codex-ui

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -821,6 +821,49 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Inline message text. Mutually exclusive with --from-file.",
     )
 
+    # send-agy-ui — Antigravity UI bridge mirroring send-codex-ui
+    send_agy_ui_parser = subparsers.add_parser(
+        "send-agy-ui",
+        help="Send a prompt to an Antigravity UI conversation via `agy --print`",
+    )
+    send_agy_ui_parser.add_argument(
+        "--thread",
+        required=False,
+        default=None,
+        help="Antigravity conversation id (omit or pass 'new' for a fresh conversation)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--cwd",
+        default=None,
+        help="Working directory for the agy subprocess (default: caller's cwd)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=1800,
+        help="Max wall-clock seconds (default 1800 = 30min)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--from-file",
+        default=None,
+        help="Read message body from a file (use '-' for stdin)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes verbose events list)",
+    )
+    send_agy_ui_parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+
     # Channel bridge commands (#1190) — registered in _channels_cli
     from ._channels_cli import register_channel_commands
     register_channel_commands(subparsers)
@@ -934,6 +977,25 @@ def _dispatch_command(args):
         if args.message:
             argv += [args.message]
         rc = _ui_codex_cli_main(argv)
+        sys.exit(rc)
+    elif args.command == "send-agy-ui":
+        from ._ui_agy import cli_main as _ui_agy_cli_main
+        argv = []
+        if args.thread:
+            argv += ["--thread", args.thread]
+        if args.bridge_id:
+            argv += ["--bridge-id", args.bridge_id]
+        if args.cwd:
+            argv += ["--cwd", args.cwd]
+        if args.timeout != 1800:
+            argv += ["--timeout", str(args.timeout)]
+        if getattr(args, "json", False):
+            argv += ["--json"]
+        if args.from_file:
+            argv += ["--from-file", args.from_file]
+        if args.message is not None:
+            argv += [args.message]
+        rc = _ui_agy_cli_main(argv)
         sys.exit(rc)
     elif args.command in ("channel", "post", "p", "reconcile", "sync", "discuss"):
         # Channel bridge commands (#1190)

--- a/scripts/ai_agent_bridge/_ui_agy.py
+++ b/scripts/ai_agent_bridge/_ui_agy.py
@@ -1,0 +1,405 @@
+"""Send a prompt to an Antigravity UI conversation via `agy --print`.
+
+Lane 2 implementation for the agent bridge: drive a persisted Antigravity
+(`agy`) conversation in the same orchestration shape as `send-codex-ui`.
+
+## How it works
+
+`agy --conversation <CONVERSATION_ID> --print "<message>"` resumes a
+persisted Antigravity conversation non-interactively. Unlike Codex, agy does
+not emit a JSON event stream on stdout in print mode. It prints plain text,
+then writes richer turn events to its local transcript files.
+
+The bridge runs agy in print mode, prefixes the prompt with a `Bridge-ID:`
+line for correlation, and returns a structured result. When the transcript is
+available, the final message is extracted from the latest
+`MODEL_RESPONSE`/`PLANNER_RESPONSE` event. Otherwise stdout is treated as the
+final message.
+
+## Empirical findings (2026-05-27 bridge probe)
+
+Commands run from this worktree:
+
+1. `agy --print-timeout 60s --print 'Reply with exactly: hello-from-agy-probe'`
+   returned plain stdout: `hello-from-agy-probe`.
+2. The invocation created conversation
+   `48fd721e-a259-438c-9eb9-53b0fd271c11` under
+   `~/.gemini/antigravity-cli/conversations/48fd721e-a259-438c-9eb9-53b0fd271c11.pb`.
+3. `~/.gemini/antigravity-cli/cache/last_conversations.json` maps the
+   worktree path to that conversation id.
+4. `agy --print-timeout 60s --conversation 48fd721e-a259-438c-9eb9-53b0fd271c11
+   --print 'Reply with exactly: resumed-agy-probe'` succeeded. The log line
+   said `Print mode: resuming conversation 48fd...`; stdout contained the
+   prior and current short replies, while the transcript JSONL contained the
+   latest `PLANNER_RESPONSE` content `resumed-agy-probe`.
+5. Turn transcripts are written at
+   `~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl`.
+
+## Usage from CLI
+
+    ab send-agy-ui --thread <CONVERSATION-ID> "your message"
+    ab send-agy-ui --thread <CONVERSATION-ID> --from-file relay.md
+    ab send-agy-ui --cwd ~/some/worktree --from-file relay.md --json
+
+Omit `--thread`, or pass `--thread new`, to start a fresh conversation. The
+result's `thread_id` is then parsed from the agy log file.
+
+## Usage from Python
+
+    from ai_agent_bridge._ui_agy import send
+    result = send(thread_id="48fd721e-...", message="ping", cwd=Path("/tmp"))
+    print(result["final_message"])
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+AGY_APP_DATA_ROOT = Path.home() / ".gemini" / "antigravity-cli"
+AGY_CONVERSATIONS_ROOT = AGY_APP_DATA_ROOT / "conversations"
+DEFAULT_TIMEOUT_S = 1800  # 30 min - covers most multi-turn dispatches
+
+_AGY_CONVERSATION_RE = re.compile(
+    r"\b(?:conversation=|Created conversation\s+|resuming conversation\s+)"
+    r"(?P<id>[0-9a-fA-F-]{36})\b",
+    re.IGNORECASE,
+)
+_NEW_THREAD_SENTINELS = {"", "-", "new", "fresh", "none", "null"}
+
+
+def find_session_file(thread_id: str) -> Path | None:
+    """Locate Antigravity's persisted conversation protobuf for *thread_id*."""
+    if not thread_id:
+        return None
+    exact = AGY_CONVERSATIONS_ROOT / f"{thread_id}.pb"
+    if exact.exists():
+        return exact
+    matches = sorted(
+        AGY_CONVERSATIONS_ROOT.glob(f"*{thread_id}*.pb"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _transcript_file(thread_id: str | None) -> Path | None:
+    if not thread_id:
+        return None
+    path = (
+        AGY_APP_DATA_ROOT
+        / "brain"
+        / thread_id
+        / ".system_generated"
+        / "logs"
+        / "transcript.jsonl"
+    )
+    return path if path.exists() else None
+
+
+def _read_transcript_events(thread_id: str | None) -> list[dict]:
+    transcript = _transcript_file(thread_id)
+    if transcript is None:
+        return []
+
+    events: list[dict] = []
+    try:
+        lines = transcript.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def _parse_stdout_events(stdout: str) -> list[dict]:
+    """Parse stdout JSON lines, or wrap plain print-mode stdout as one event."""
+    events: list[dict] = []
+    saw_json = False
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+            saw_json = True
+
+    if saw_json:
+        return events
+
+    text = stdout.strip()
+    if not text:
+        return []
+    return [{"type": "stdout_text", "content": text}]
+
+
+def _extract_final_message(events: list[dict]) -> str | None:
+    """Pick the last informative model message from agy or fallback events."""
+    final_content: str | None = None
+
+    for evt in events:
+        event_type = evt.get("type")
+        content = evt.get("content")
+        if event_type in {"MODEL_RESPONSE", "PLANNER_RESPONSE", "stdout_text"}:
+            if isinstance(content, str) and content.strip():
+                final_content = content.strip()
+            continue
+
+        # Keep this fallback compatible with Codex-style synthetic tests and
+        # future agy JSON stream shapes.
+        if event_type == "item.completed":
+            item = evt.get("item", {})
+            item_type = item.get("type")
+            if item_type == "agent_message":
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str) and text.strip():
+                    final_content = text.strip()
+            elif item_type == "command_execution":
+                output = item.get("aggregated_output")
+                if isinstance(output, str) and output.strip():
+                    final_content = output.strip()
+
+    return final_content
+
+
+def _thread_arg_is_new(thread_id: str | None) -> bool:
+    return thread_id is None or thread_id.strip().lower() in _NEW_THREAD_SENTINELS
+
+
+def _conversation_id_from_log(log_file: Path) -> str | None:
+    latest: str | None = None
+    try:
+        with log_file.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                match = _AGY_CONVERSATION_RE.search(line)
+                if match:
+                    latest = match.group("id")
+    except OSError:
+        return None
+    return latest
+
+
+def _decode_timeout_text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def send(
+    thread_id: str | None,
+    message: str,
+    *,
+    bridge_id: str | None = None,
+    cwd: Path | None = None,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Send a prompt to an Antigravity UI conversation via `agy --print`.
+
+    Args:
+        thread_id: Antigravity conversation id. Pass None, "", "-", or
+            "new" to start a fresh conversation.
+        message: prompt body. A `Bridge-ID: <id>` line is prepended for
+            correlation; the receiving agent should echo the Bridge-ID in
+            its reply if asked.
+        bridge_id: correlation id (auto-generated if None).
+        cwd: working directory for the agy subprocess. If None, inherits
+            the caller's cwd. Agy chooses workspace context from this cwd.
+        timeout_s: max wall-clock for the agy subprocess (default 30 min).
+
+    Returns:
+        dict with:
+            bridge_id (str), thread_id (str | None), exit_code (int),
+            events (list[dict] parsed from agy transcript/stdout),
+            final_message (str | None), duration_s (float),
+            session_file (str | None) for the conversation protobuf,
+            stderr (str).
+    """
+    bridge_id = bridge_id or f"bridge-{uuid.uuid4().hex[:8]}"
+    framed_message = f"Bridge-ID: {bridge_id}\n\n{message}"
+    requested_thread_id = None if _thread_arg_is_new(thread_id) else thread_id
+    session_file = find_session_file(requested_thread_id or "")
+    preexisting_transcript_count = (
+        len(_read_transcript_events(requested_thread_id)) if requested_thread_id else 0
+    )
+
+    log_path = Path(tempfile.gettempdir()) / f"agy-ui-bridge-{bridge_id}.log"
+    cmd = [
+        "agy",
+        "--print-timeout",
+        f"{timeout_s}s",
+        "--dangerously-skip-permissions",
+        "--log-file",
+        str(log_path),
+    ]
+    if requested_thread_id:
+        cmd += ["--conversation", requested_thread_id]
+    cmd += ["--print", framed_message]
+
+    start = datetime.now(UTC)
+    try:
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(cwd) if cwd else None,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+            stdout = proc.stdout
+            stderr = proc.stderr
+            exit_code = proc.returncode
+        except subprocess.TimeoutExpired as e:
+            stdout = _decode_timeout_text(e.stdout)
+            stderr = f"[timeout after {timeout_s}s]\n{_decode_timeout_text(e.stderr)}"
+            exit_code = -1
+        duration_s = (datetime.now(UTC) - start).total_seconds()
+
+        resolved_thread_id = requested_thread_id or _conversation_id_from_log(log_path)
+        if resolved_thread_id and session_file is None:
+            session_file = find_session_file(resolved_thread_id)
+
+        stdout_events = _parse_stdout_events(stdout)
+        all_transcript_events = _read_transcript_events(resolved_thread_id)
+        if requested_thread_id and resolved_thread_id == requested_thread_id:
+            transcript_events = all_transcript_events[preexisting_transcript_count:]
+        else:
+            transcript_events = all_transcript_events
+        events = transcript_events or stdout_events
+        final_message = _extract_final_message(events) or _extract_final_message(stdout_events)
+
+        return {
+            "bridge_id": bridge_id,
+            "thread_id": resolved_thread_id,
+            "exit_code": exit_code,
+            "events": events,
+            "final_message": final_message,
+            "duration_s": duration_s,
+            "session_file": str(session_file) if session_file else None,
+            "stderr": stderr,
+        }
+    finally:
+        with contextlib.suppress(OSError):
+            log_path.unlink()
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ab send-agy-ui",
+        description=(
+            "Send a prompt to an Antigravity UI conversation via "
+            "`agy --conversation ... --print`. Returns the agy subprocess "
+            "exit code."
+        ),
+    )
+    parser.add_argument(
+        "--thread",
+        default=None,
+        help=(
+            "Antigravity conversation id. Omit or pass 'new' to start a "
+            "fresh conversation."
+        ),
+    )
+    parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given).",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help=(
+            "Working directory for the agy subprocess. Agy will choose "
+            "workspace context from this cwd."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        help=f"Max wall-clock seconds (default {DEFAULT_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read message body from a file (use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes the verbose events list).",
+    )
+    parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file and args.message:
+        parser.error("provide either --from-file or a positional message, not both")
+    if args.from_file:
+        message = (
+            sys.stdin.read()
+            if str(args.from_file) == "-"
+            else args.from_file.read_text(encoding="utf-8")
+        )
+    elif args.message is not None:
+        message = args.message
+    else:
+        parser.error("must provide a message via positional arg or --from-file")
+
+    result = send(
+        thread_id=args.thread,
+        message=message,
+        bridge_id=args.bridge_id,
+        cwd=args.cwd,
+        timeout_s=args.timeout,
+    )
+
+    if args.json:
+        compact = {k: v for k, v in result.items() if k != "events"}
+        compact["event_count"] = len(result["events"])
+        print(json.dumps(compact, indent=2, default=str))
+    else:
+        print(f"thread:       {result['thread_id']}")
+        print(f"bridge_id:    {result['bridge_id']}")
+        print(f"exit_code:    {result['exit_code']}")
+        print(f"duration_s:   {result['duration_s']:.2f}")
+        print(f"events:       {len(result['events'])}")
+        print(f"session_file: {result['session_file']}")
+        if result["final_message"]:
+            print()
+            print("=== final message ===")
+            print(result["final_message"])
+        if result["stderr"]:
+            print()
+            print("=== stderr (truncated) ===")
+            print(result["stderr"][:2000])
+
+    return 0 if result["exit_code"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/tests/ai_agent_bridge/test_ui_agy.py
+++ b/tests/ai_agent_bridge/test_ui_agy.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts.ai_agent_bridge import _ui_agy as ui_agy
+
+THREAD_ID = "48fd721e-a259-438c-9eb9-53b0fd271c11"
+
+
+def _patch_agy_roots(monkeypatch, tmp_path: Path) -> Path:
+    app_data = tmp_path / "antigravity-cli"
+    monkeypatch.setattr(ui_agy, "AGY_APP_DATA_ROOT", app_data)
+    monkeypatch.setattr(ui_agy, "AGY_CONVERSATIONS_ROOT", app_data / "conversations")
+    return app_data
+
+
+def _write_transcript_events(app_data: Path, events: list[dict]) -> Path:
+    transcript = (
+        app_data
+        / "brain"
+        / THREAD_ID
+        / ".system_generated"
+        / "logs"
+        / "transcript.jsonl"
+    )
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+    return transcript
+
+
+def test_find_session_file_happy_path_and_missing(tmp_path: Path, monkeypatch) -> None:
+    app_data = _patch_agy_roots(monkeypatch, tmp_path)
+    conversations = app_data / "conversations"
+    conversations.mkdir(parents=True)
+    session = conversations / f"{THREAD_ID}.pb"
+    session.write_bytes(b"probe")
+
+    assert ui_agy.find_session_file(THREAD_ID) == session
+    assert ui_agy.find_session_file("00000000-0000-0000-0000-000000000000") is None
+
+
+def test_extract_final_message_from_synthetic_agy_event_stream() -> None:
+    events = [
+        {"type": "USER_INPUT", "content": "question"},
+        {"type": "PLANNER_RESPONSE", "content": "first answer"},
+        {"type": "MODEL_RESPONSE", "content": "final answer"},
+    ]
+
+    assert ui_agy._extract_final_message(events) == "final answer"
+
+
+def test_send_with_mocked_subprocess_parses_stdout_event_stream(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    app_data = _patch_agy_roots(monkeypatch, tmp_path)
+    monkeypatch.setattr(ui_agy.tempfile, "gettempdir", lambda: "/tmp")
+    conversations = app_data / "conversations"
+    conversations.mkdir(parents=True)
+    session = conversations / f"{THREAD_ID}.pb"
+    session.write_bytes(b"probe")
+
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "USER_INPUT", "content": "Bridge prompt"}),
+            json.dumps({"type": "PLANNER_RESPONSE", "content": "known final"}),
+        ]
+    )
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[:6] == [
+            "agy",
+            "--print-timeout",
+            "12s",
+            "--dangerously-skip-permissions",
+            "--log-file",
+            str(Path("/tmp") / "agy-ui-bridge-bridge-test.log"),
+        ]
+        assert cmd[6:8] == ["--conversation", THREAD_ID]
+        assert cmd[8] == "--print"
+        assert cmd[9].startswith("Bridge-ID: bridge-test\n\n")
+        assert kwargs["cwd"] == str(tmp_path)
+        assert kwargs["timeout"] == 12
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(ui_agy.subprocess, "run", fake_run)
+
+    result = ui_agy.send(
+        thread_id=THREAD_ID,
+        message="hello",
+        bridge_id="bridge-test",
+        cwd=tmp_path,
+        timeout_s=12,
+    )
+
+    assert result["bridge_id"] == "bridge-test"
+    assert result["thread_id"] == THREAD_ID
+    assert result["exit_code"] == 0
+    assert result["final_message"] == "known final"
+    assert result["session_file"] == str(session)
+    assert len(result["events"]) == 2
+
+
+def test_send_uses_only_current_transcript_events(tmp_path: Path, monkeypatch) -> None:
+    app_data = _patch_agy_roots(monkeypatch, tmp_path)
+    monkeypatch.setattr(ui_agy.tempfile, "gettempdir", lambda: str(tmp_path))
+    _write_transcript_events(
+        app_data,
+        [{"type": "PLANNER_RESPONSE", "content": "stale previous answer"}],
+    )
+
+    def fake_run(cmd, **kwargs):
+        log_path = Path(cmd[5])
+        log_path.write_text(
+            f"Print mode: conversation={THREAD_ID}, sending message\n",
+            encoding="utf-8",
+        )
+        _write_transcript_events(
+            app_data,
+            [
+                {"type": "PLANNER_RESPONSE", "content": "stale previous answer"},
+                {"type": "PLANNER_RESPONSE", "content": "current answer"},
+            ],
+        )
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="stale previous answer\ncurrent answer\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ui_agy.subprocess, "run", fake_run)
+
+    result = ui_agy.send(
+        thread_id=THREAD_ID,
+        message="hello",
+        bridge_id="bridge-current",
+        cwd=tmp_path,
+        timeout_s=12,
+    )
+
+    assert result["final_message"] == "current answer"
+    assert result["events"] == [{"type": "PLANNER_RESPONSE", "content": "current answer"}]
+    assert not (tmp_path / "agy-ui-bridge-bridge-current.log").exists()
+
+
+def test_send_timeout_returns_negative_exit_code(tmp_path: Path, monkeypatch) -> None:
+    app_data = _patch_agy_roots(monkeypatch, tmp_path)
+    _write_transcript_events(
+        app_data,
+        [{"type": "PLANNER_RESPONSE", "content": "stale previous answer"}],
+    )
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=cmd,
+            timeout=3,
+            output="partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr(ui_agy.subprocess, "run", fake_run)
+
+    result = ui_agy.send(
+        thread_id=THREAD_ID,
+        message="hello",
+        bridge_id="bridge-timeout",
+        cwd=tmp_path,
+        timeout_s=3,
+    )
+
+    assert result["exit_code"] == -1
+    assert result["final_message"] == "partial stdout"
+    assert result["events"] == [{"type": "stdout_text", "content": "partial stdout"}]
+    assert result["stderr"].startswith("[timeout after 3s]")
+    assert "partial stderr" in result["stderr"]
+
+
+def test_cli_main_reads_message_from_file(tmp_path: Path, monkeypatch, capsys) -> None:
+    message_file = tmp_path / "relay.md"
+    message_file.write_text("from file", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_send(**kwargs):
+        captured.update(kwargs)
+        return {
+            "bridge_id": "bridge-file",
+            "thread_id": THREAD_ID,
+            "exit_code": 0,
+            "events": [{"type": "PLANNER_RESPONSE", "content": "ok"}],
+            "final_message": "ok",
+            "duration_s": 0.1,
+            "session_file": "/tmp/session.pb",
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(ui_agy, "send", fake_send)
+
+    rc = ui_agy.cli_main(
+        ["--thread", THREAD_ID, "--from-file", str(message_file), "--json"]
+    )
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert captured["thread_id"] == THREAD_ID
+    assert captured["message"] == "from file"
+    assert out["event_count"] == 1


### PR DESCRIPTION
## Summary

- Add `ab send-agy-ui` for Antigravity UI conversations, mirroring `send-codex-ui` argument shape: `--thread`, `--from-file`, `--cwd`, `--timeout`, `--json`, and `--bridge-id`.
- Add `scripts/ai_agent_bridge/_ui_agy.py` with session lookup, transcript parsing, timeout handling, current-turn transcript slicing, temp-log cleanup, and fresh-conversation support.
- Add focused tests for session lookup, final-message extraction, mocked subprocess send, stale transcript avoidance, timeout fallback, and `--from-file` CLI parsing.

## Empirical investigation

`agy --help` exposes the needed flags:

```text
Usage of agy:
  --add-dir                       Add a directory to the workspace (repeatable) (default [])
  -c                              Short alias for --continue
  --continue                      Continue the most recent conversation
  --conversation                  Resume a previous conversation by ID
  --dangerously-skip-permissions  Auto-approve all tool permission requests without prompting
  -i                              Short alias for --prompt-interactive
  --log-file                      Override CLI log file path
  -p                              Short alias for --print
  --print                         Run a single prompt non-interactively and print the response
  --print-timeout                 Timeout for print mode wait (default 5m0s)
  --prompt                        Alias for --print
  --prompt-interactive            Run an initial prompt interactively and continue the session
  --sandbox                       Run in a sandbox with terminal restrictions enabled
```

Fresh print-mode probe:

```text
$ agy --print-timeout 60s --print 'Reply with exactly: hello-from-agy-probe'
hello-from-agy-probe
```

Resume-print combo probe:

```text
$ agy --print-timeout 60s --conversation 48fd721e-a259-438c-9eb9-53b0fd271c11 --print 'Reply with exactly: resumed-agy-probe'
hello-from-agy-probe
resumed-agy-probe
```

Resume evidence from the agy log:

```text
31:46:I0527 08:38:38.339174 76905 printmode.go:71] Print mode: starting (promptLength=37, model="", conversationID="48fd721e-a259-438c-9eb9-53b0fd271c11")
45:47:I0527 08:38:40.419793 76905 printmode.go:125] Print mode: resuming conversation 48fd721e-a259-438c-9eb9-53b0fd271c11
50:47:I0527 08:38:40.424267 76905 printmode.go:130] Print mode: conversation=48fd721e-a259-438c-9eb9-53b0fd271c11, sending message
53:58:I0527 08:38:40.595435 76905 conversation_manager.go:321] Forwarding user message to conversation 48fd721e-a259-438c-9eb9-53b0fd271c11 (items=1, media=0)
54:45:I0527 08:38:40.595492 76905 server.go:1072] Sending user message to conversation 48fd721e-a259-438c-9eb9-53b0fd271c11 (items=1, media=0)
```

Storage evidence after creating/resuming the conversation:

```text
-rw-r--r--  1 krisztiankoos staff  16448 May 27 08:51 /Users/krisztiankoos/.gemini/antigravity-cli/brain/48fd721e-a259-438c-9eb9-53b0fd271c11/.system_generated/logs/transcript.jsonl
-rw-------  1 krisztiankoos staff  42126 May 27 08:51 /Users/krisztiankoos/.gemini/antigravity-cli/cache/last_conversations.json
-rw-r--r--  1 krisztiankoos staff 261673 May 27 08:51 /Users/krisztiankoos/.gemini/antigravity-cli/conversations/48fd721e-a259-438c-9eb9-53b0fd271c11.pb

/Users/krisztiankoos/.gemini/antigravity-cli:
total 24
drwxr-xr-x  19 krisztiankoos staff   608 May 27 08:38 .
drwxr-xr-x  20 krisztiankoos staff   640 May 27 08:46 ..
drwxr-xr-x   4 krisztiankoos staff   128 May 19 22:58 bin
drwxr-xr-x 452 krisztiankoos staff 14464 May 27 08:37 brain
drwxr-xr-x   5 krisztiankoos staff   160 May 20 19:27 cache
lrwxr-xr-x   1 krisztiankoos staff    27 May 27 08:38 cli.log -> log/cli-20260527_083838.log
drwxr-xr-x 446 krisztiankoos staff 14272 May 27 08:51 conversations
```

Observed parser-relevant behavior: agy stdout is plain text and, on resume, may include prior assistant replies. The adapter therefore extracts `final_message` from the current turn's transcript events when available, falling back to stdout only when the transcript has no current-turn model response.

## Validation

Ruff:

```text
All checks passed!
```

Pytest:

```text
tests/ai_agent_bridge/test_serve_security.py ....                        [ 72%]
tests/ai_agent_bridge/test_ui_agy.py ......                              [ 86%]
tests/ai_agent_bridge/test_verify_review.py ......                       [100%]

============================== 44 passed in 1.96s ==============================
```

Commit trailer audit:

```text
Checking 1 commit(s) in origin/main..HEAD:

  93a2b07f9e  PASS  X-Agent: codex/agy-ui-bridge-2026-05-27

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Local cross-agent review: Gemini flagged stale transcript risk on timeout/crash, temp-log cleanup, empty-string CLI forwarding, and test gaps. Those were applied before this PR: current-turn transcript slicing, temp-log cleanup, empty-string handling for `send-agy-ui`, and tests for stale transcript avoidance, timeout fallback, and `--from-file`.

## Smoke test

In this shell, `/usr/sbin/ab` is ApacheBench, so I used the documented bridge alias target as a shell function:

```bash
ab() { .venv/bin/python scripts/ai_agent_bridge/__main__.py "$@"; }
ab send-agy-ui --thread 48fd721e-a259-438c-9eb9-53b0fd271c11 --from-file /tmp/agy-smoke.md --timeout 600 --json
```

Smoke output:

```json
{
  "bridge_id": "bridge-61875111",
  "thread_id": "48fd721e-a259-438c-9eb9-53b0fd271c11",
  "exit_code": 0,
  "final_message": "agy-bridge-smoke-ok-final",
  "duration_s": 6.990048,
  "session_file": "/Users/krisztiankoos/.gemini/antigravity-cli/conversations/48fd721e-a259-438c-9eb9-53b0fd271c11.pb",
  "stderr": "",
  "event_count": 4
}
```

## Notes

- I did not modify `_ui_codex.py` or the existing `send-codex-ui` behavior.
- The `bridge` label was requested, but no `bridge` label exists in this repository (`gh label list --limit 200 | rg '^bridge\\b'` returned no match).
