### PR TITLE
fix(writer-prompt): require ≥1 bad-form contrast pair for L1-Russian-likely A1-A2 vocabulary

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -91,6 +91,10 @@ Stick to **сніданок** (not the Russian-borrowed <!-- bad -->завтра
 (not the surzhyk <!-- bad -->одіватися<!-- /bad -->).
 ```
 
+**Positive requirement for A1-A2 vocabulary modules:** when the module covers vocabulary domains where L1-Russian-exposure learners are likely to substitute Russian borrowings (food/dining, household items, clothing, daily routines, family, body, time-of-day expressions, transportation, common verbs of action), include **AT LEAST ONE** explicit bad-form contrast pair using the marker syntax above. This is a pedagogical tool (contrast pairs accelerate L2 acquisition) AND satisfies the `llm_qg.decolonization` rubric's criterion (b) — see `scripts/build/phases/linear-review-dim.md` § `decolonization`. Empirical evidence (m20 round #12, codex-tools, a1-my-morning-20260526-204640): module had Ukrainian-canonical vocabulary throughout + one stance line but **zero** bad-form markers; under the recalibrated rubric (PR #2358) the reviewer scored decolonization 8.7 (criterion a + c satisfied, b absent) — 0.3 short of the A1 9.0 floor that would have shipped the module. Pick the single most-likely L1 substitution for the module's topic (e.g. for a morning-routine module: завтрак→сніданок is the canonical one) and include it concretely. One marker pair is sufficient; this isn't a quantity gate.
+
+Modules whose topic does NOT involve L1-Russian-substitutable vocabulary (e.g. pure grammar abstractions, IPA-only phonetics drill, formal-letter templates) are exempt — but for those, document the exemption inline in your `<plan_reasoning>` so the reviewer doesn't dock for absence.
+
 Apply the same convention in `module.md`, `activities.yaml` statements/items, and `vocabulary.yaml` usage lines when they name a wrong form. `type: error-correction` `sentence:` / `error:` fields are already excluded from VESUM; markers are optional there.
 
 **CONCRETE FORBIDDEN PATTERNS — HARD REJECT.** These trip `vesum_verified`, `formatting_standards`, or `russianisms_clean` unless the bad form is comment-marked:


### PR DESCRIPTION
## Summary

Empirical follow-up to PR #2358 (decolonization rubric recalibration).

Tested the recalibrated rubric against m20 round #12's actual module artifacts: claude-tools reviewer scored decolonization **8.7** (up from codex's 8.5 under old rubric) — still 0.3 short of A1 floor 9.0.

Reviewer's specific finding: *"the absent explicit bad-form contrast pair — for an A1 routine module where learners are likely to encounter завтрак / полотенце / одіваться from L1-Russian carryover, one explicit marker pair would have lifted this cleanly to 9.0+."*

Verified across m20 rounds #12, #13, #14: **ZERO** bad-form markers in any codex-tools `module.md` output.

The existing `#R-BAD-FORM-MARKER` rule MANDATES the marker SYNTAX when used but doesn't REQUIRE the writer to include any. A module with zero contrasts was technically compliant.

## What changed

- Adds a **positive requirement**: A1-A2 modules covering vocabulary domains with L1-Russian substitution risk (food/dining, household, clothing, daily routines, family, body, time, transportation, common verbs) MUST include AT LEAST ONE explicit bad-form contrast marker pair.
- Frames it as pedagogical first (contrast pairs are standard L2-acquisition technique), rubric-satisfying second.
- Inline empirical anchor: round #12 specifics.
- Exemption clause for topics genuinely without L1-substitutable vocab (pure grammar abstractions, IPA drills, formal templates) — writer documents inline.

## Not forcing extra rhetoric

This is contrast-pair pedagogy (`true-positive` teaching), not anti-colonial commentary. Decolonization benefit is incidental. Per user direction 2026-05-27 the rubric was already recalibrated to credit clean canonical teaching as substantive decolonization; this PR closes the writer-side gap so modules actually emit the markers the recalibrated rubric expects.

## Test plan

- [x] `pytest tests/test_writer_prompt_size.py tests/test_writer_prompt_structured_cot.py tests/test_prompt_cot_tier1_scaffolding.py -q` → 96 passed
- [ ] CI green
- [ ] m20 round #15 codex-tools includes ≥1 marker pair and scores decolonization 9.0+ → ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)