### PR TITLE
feat(v7-prompt): writer + reviewer hardening for single-voice A1 register

### DIFF
--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -38,6 +38,35 @@ For `{DIM}` specifically:
 - `pedagogical`: does the sequencing actually teach? Are examples
   illuminating? Does each concept earn the next? The gate confirmed word
   budgets and section presence; you assess whether the pedagogy *works*.
+  REJECT-level failures mirroring writer rules:
+  - Mirrors `#R-NO-SCAFFOLDING-LEAKS`: REJECT writer-side scaffolding leaks.
+    Writer-side scaffolding never appears in module body. Forbidden in
+    published markdown: panel IDs (`P1`, `P2`, ...), Krok-N labels
+    (`Крок 5:`, `Step 5:`), obligation names from the wiki_coverage manifest
+    (`ban-4`, `step-5`, ...), reviewer-fix anchors, phase names, gate names.
+    The module is a finished lesson, not a writer's worksheet.
+  - Mirrors `#R-NO-CHILDREN-PRIMARY-QUOTES`: REJECT `>` blockquotes from
+    textbooks at Grade 1, 2, or 3 levels in the published module body. Grade
+    1-3 RAG hits can still ground lexical choices, but do not surface as
+    quoted material. Default: NO blockquote unless it pedagogically advances
+    the lesson AND comes from an adult-appropriate source (Grade 7+, adult
+    literature, Антоненко-Давидович, style guides). Adult A1 learners are
+    not reading children's primers; reject `Захарійчук, Grade 1, p.24` as
+    lesson prose.
+  - Mirrors `#R-GRAMMAR-TERMS-A1`: REJECT A1 English explanations that avoid
+    the rule: Use proper grammatical terminology in English explanations.
+    The accepted terms are **noun**, **verb**, **adjective**, **adverb**,
+    **pronoun**, **reflexive**, **conjugation**.
+    REJECT folksy paraphrase (`a thing`, `an action`, `a word for`,
+    `a doing-word`, `the X-form of Y`) in lieu of grammar terms.
+  - Mirrors `#R-CLEAN-TABLES`: REJECT bold-everywhere tables. Tables: bold
+    ONLY the target Ukrainian forms; pronoun columns (`я`, `ти`, ...),
+    English headers, and English glosses remain in regular weight. REJECT
+    conjugation tables teaching a present-tense paradigm that omit `ви` or
+    `вони` from the FULL set of person/number rows: **я / ти /
+    він,вона,воно / ми / ви / вони** (six rows). Vocabulary tables stay
+    two-column unless a third column adds essential teaching value (e.g.,
+    stress mark, IPA).
 - `naturalness`: does Ukrainian read as native? The gate confirmed VESUM +
   russianism shadow; you assess flow, register, idiom.
 - `decolonization`: is the lesson teaching Ukrainian **on its own terms**?
@@ -95,6 +124,17 @@ For `{DIM}` specifically:
   reviewer-protocol failure under this anchor.
 - `tone`: is the teacher's voice consistent and warm? The gate caught
   META_NARRATION; you assess everything else about register.
+  REJECT-level failures mirroring writer rules:
+  - Mirrors `#R-SINGLE-VOICE-A1`: REJECT mid-module register shifts (English
+    -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase).
+    The module must have one teacher voice across the whole module: warm,
+    clear, direct ("you" / "your"). REJECT third-person framing of the
+    learner (`the student`, `студента`, `the reader`, `учня`).
+  - Mirrors `#R-AUDIENCE-LANGUAGE-A1`: REJECT Ukrainian metalanguage TO the
+    A1 learner (`Контролюй чистоту словника`, `Рішуче відкидай`,
+    `Запам'ятай...`). A1 explanation prose stays in English. Ukrainian
+    appears only as TARGET: inline vocabulary words with English glosses,
+    dialogue boxes, tables, conjugations, model sentences.
 
 A dim score that re-states what a deterministic gate already enforced is a
 reviewer-protocol failure. Cite something the gate cannot see.

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -120,17 +120,17 @@ Use the canonical MCP names as applicable for Tier-1 checks: `mcp__sources__chec
 **Grammar claim grounding.** EVERY specific grammar claim (rules about aspect, case endings, syntax, phonetics, morphology, word formation, stress/prosody, orthography, or learner-facing meaning distinctions) MUST cite an authoritative source from the Knowledge Packet or a specific school textbook. Name the source in the text or as an HTML comment with concrete metadata: `<!-- VERIFY: source="..." grade="..." author="..." -->`. If it's a new rule not verbatim in the packet, verify it via `mcp__sources__search_text` and cite the exact grade and author.
 
 <!-- rule_id: #R-TEXTBOOK-30W -->
-**Textbook grounding.** For each `plan_references` entry, you MUST retrieve the chunk text from MCP and paste from THAT text verbatim — paraphrasing, topic-keyword search, or pasting from memory all fail this gate.
+**Textbook grounding.** For each `plan_references` entry, you MUST retrieve the chunk text from MCP and use THAT text as grounding — paraphrasing, topic-keyword search, or pasting from memory all fail this gate.
 
 (A) **Identify the chunk_id.** Look at the plan entry's `notes` field. If it contains the literal substring `chunk_id: <ID>` (it usually does — e.g. `chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0024`), copy that `<ID>` verbatim and go DIRECTLY to step (B). **`search_text` for this reference is FORBIDDEN when notes already gives a chunk_id** — it returns wrong-author chunks for short queries like `"Author p.24"` (FTS5 matches the page number across ALL textbooks; you will get back a chunk from a different book). Only call `mcp__sources__search_text(query="<author surname> p. <page digits>", subject="<corpus>", limit=3)` when `notes` truly lacks a chunk_id. Topic-keyword queries are a separate hard fail mode — never search by what the chunk is ABOUT, only by author + page.
 
 (B) **Retrieve the chunk text.** Call `mcp__sources__get_chunk_context(chunk_id=<ID>)`. This step is MANDATORY — calling `search_text` alone returns a truncated snippet, not the full chunk text. The gate counts `chunk_context_calls`; if zero while `plan_references` is non-empty, the gate HARD-rejects regardless of blockquote content.
 
-(C) **Paste >=30 contiguous Ukrainian words from the returned `text` field into a blockquote.** Verbatim only — no paraphrasing, no translation, no stitching from multiple chunks, no Russian-script characters, no syllable-hyphen removal that breaks contiguity. The gate uses string-containment against the chunk's exact `text`. Each `plan_references` entry needs its own ≥30-word blockquote (one per cited page) — a single aggregate blockquote does not cover multiple references.
+(C) **Surface only adult-appropriate source blockquotes in the published module body.** For Grade 1, 2, or 3 textbook chunks, retrieve the returned `text` field and use it to ground lexical choices, but do NOT paste a `>` blockquote into `module.md`; see `#R-NO-CHILDREN-PRIMARY-QUOTES`. For adult-appropriate sources (Grade 7+, adult literature, Антоненко-Давидович, style guides), paste >=30 contiguous Ukrainian words from the returned `text` field into a blockquote. Verbatim only — no paraphrasing, no translation, no stitching from multiple chunks, no Russian-script characters, no syllable-hyphen removal that breaks contiguity. The gate uses string-containment against the chunk's exact `text`. Each adult-appropriate `plan_references` entry needs its own ≥30-word blockquote (one per cited page) — a single aggregate blockquote does not cover multiple references.
 
 (D) Add the exact citation line immediately after the blockquote: `*— <Author>, Grade <N>, p.<PAGE>*` (em-dash + spaces, italic).
 
-Fewer than 30 words per blockquote, or a blockquote whose text is not literally contained in the returned chunk, makes `textbook_grounding.long_blockquotes_checked` fail and the gate HARD-rejects.
+For adult-appropriate blockquotes, fewer than 30 words per blockquote, or a blockquote whose text is not literally contained in the returned chunk, makes `textbook_grounding.long_blockquotes_checked` fail and the gate HARD-rejects. For Grade 1, 2, or 3 chunks, missing a learner-facing `>` blockquote is correct; the chunk still must be retrieved and used as grounding.
 
 <!-- rule_id: #R-CITE-HONEST -->
 Sources in blockquotes/resources must be either in `plan_references` or grounded in a Knowledge Packet / `search_text` result that appears in writer telemetry, EXCEPT `resources.yaml` entries with `role: textbook`: those come ONLY from `plan.references`. Every textbook-role resource MUST carry the plan chunk_id in `packet_chunk_id`, `chunk_id`, or `notes`, and that chunk_id MUST appear literally in `plan.references[*].notes`. Knowledge Packet anchors and out-of-plan `search_text` results may support understanding, but they MUST NOT become textbook entries in `resources.yaml`.
@@ -291,6 +291,24 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 
 <!-- rule_id: #R-BAD-FORM-MARKER -->
 **Russianism floor.** `russianisms_strict` fails on any critical Russicism/calque/surzhyk finding. Check suspicious forms with `check_russian_shadow`, `search_style_guide`, `search_ua_gec_errors`, `search_heritage`, and `query_pravopys`. Never paste raw Russian forms into prose/dialogue; use a `<!-- VERIFY -->` placeholder or omit.
+
+<!-- rule_id: #R-SINGLE-VOICE-A1 -->
+**Single teacher voice at A1.** One teacher voice across the whole module: warm, clear, direct ("you" / "your"). No third-person framing of the learner (`the student`, `студента`, `the reader`, `учня`) and no mid-paragraph register shifts (English -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase). Good: "You use **я прокидаюся** for your own routine." Bad: "the student enters an authentic space."
+
+<!-- rule_id: #R-AUDIENCE-LANGUAGE-A1 -->
+**A1 audience language.** A1 explanation prose stays in English. Ukrainian appears only as TARGET: inline vocabulary words with English glosses, dialogue boxes, tables, conjugations, model sentences. Never use Ukrainian metalanguage TO the learner (`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`), because the learner cannot read Ukrainian explanations yet.
+
+<!-- rule_id: #R-NO-CHILDREN-PRIMARY-QUOTES -->
+**No children-primary blockquotes in adult A1.** No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body. Grade 1-3 RAG hits can still ground lexical choices, but do not surface as quoted material. Default: NO blockquote unless it pedagogically advances the lesson AND comes from an adult-appropriate source (Grade 7+, adult literature, Антоненко-Давидович, style guides). Adult A1 learners are not reading children's primers; do not print `Захарійчук, Grade 1, p.24` as lesson prose.
+
+<!-- rule_id: #R-NO-SCAFFOLDING-LEAKS -->
+**No writer-side scaffolding leaks.** Writer-side scaffolding never appears in module body. Forbidden in published markdown: panel IDs (`P1`, `P2`, ...), Krok-N labels (`Крок 5:`, `Step 5:`), obligation names from the wiki_coverage manifest (`ban-4`, `step-5`, ...), reviewer-fix anchors, phase names, gate names. The module is a finished lesson, not a writer's worksheet.
+
+<!-- rule_id: #R-GRAMMAR-TERMS-A1 -->
+**Use grammar terms at A1.** Use proper grammatical terminology in English explanations: **noun**, **verb**, **adjective**, **adverb**, **pronoun**, **reflexive**, **conjugation**. Do NOT paraphrase (`a thing`, `an action`, `a word for`, `a doing-word`, `the X-form of Y`). Adult learners benefit from real grammar terms because they transfer to future modules and outside references.
+
+<!-- rule_id: #R-CLEAN-TABLES -->
+**Clean table formatting.** Tables: bold ONLY the target Ukrainian forms. Pronoun columns (`я`, `ти`, ...), English headers, and English glosses remain in regular weight. Conjugation tables teaching a present-tense paradigm must include the FULL set of person/number rows: **я / ти / він,вона,воно / ми / ви / вони** (six rows). Vocabulary tables stay two-column unless a third column adds essential teaching value (e.g., stress mark, IPA).
 
 **Dialogue format (gate-counted).** Ukrainian dialogue lines must be `<DialogueBox uk="..." en="...">` or `> ` blockquotes. Em-dash-only dialogue under `## Діалоги` is invisible to `l2_exposure_floor` and fails the module.
 

--- a/tests/test_reviewer_prompt_v7_register_rules.py
+++ b/tests/test_reviewer_prompt_v7_register_rules.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REVIEWER_PROMPT = PROJECT_ROOT / "scripts/build/phases/linear-review-dim.md"
+
+REVIEWER_RULE_ANCHORS = (
+    (
+        "#R-SINGLE-VOICE-A1",
+        (
+            "REJECT mid-module register shifts",
+            "third-person framing of the learner",
+            "`the student`, `студента`, `the reader`, `учня`",
+        ),
+    ),
+    (
+        "#R-AUDIENCE-LANGUAGE-A1",
+        (
+            "REJECT Ukrainian metalanguage TO the A1 learner",
+            "A1 explanation prose stays in English",
+            "`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`",
+        ),
+    ),
+    (
+        "#R-NO-CHILDREN-PRIMARY-QUOTES",
+        (
+            "REJECT `>` blockquotes from textbooks at Grade 1, 2, or 3 levels "
+            "in the published module body",
+            "Grade 1-3 RAG hits can still ground lexical choices",
+            "`Захарійчук, Grade 1, p.24`",
+        ),
+    ),
+    (
+        "#R-NO-SCAFFOLDING-LEAKS",
+        (
+            "REJECT writer-side scaffolding leaks",
+            "Writer-side scaffolding never appears in module body",
+            "obligation names from the wiki_coverage manifest (`ban-4`, `step-5`, ...)",
+        ),
+    ),
+    (
+        "#R-GRAMMAR-TERMS-A1",
+        (
+            "Use proper grammatical terminology in English explanations",
+            "REJECT folksy paraphrase",
+            "`a thing`, `an action`, `a word for`, `a doing-word`, `the X-form of Y`",
+        ),
+    ),
+    (
+        "#R-CLEAN-TABLES",
+        (
+            "REJECT bold-everywhere tables",
+            "Tables: bold ONLY the target Ukrainian forms",
+            "я / ти / він,вона,воно / ми / ви / вони",
+        ),
+    ),
+)
+
+
+def _prompt() -> str:
+    return REVIEWER_PROMPT.read_text(encoding="utf-8")
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@pytest.mark.parametrize(("rule_id", "anchors"), REVIEWER_RULE_ANCHORS)
+def test_reviewer_prompt_mirrors_v7_register_rule(
+    rule_id: str,
+    anchors: tuple[str, ...],
+) -> None:
+    prompt = _prompt()
+    normalized = _normalize(prompt)
+
+    assert f"Mirrors `{rule_id}`" in prompt
+    for anchor in anchors:
+        assert _normalize(anchor) in normalized

--- a/tests/test_writer_prompt_v7_register_rules.py
+++ b/tests/test_writer_prompt_v7_register_rules.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+WRITER_PROMPT = PROJECT_ROOT / "scripts/build/phases/linear-write.md"
+
+WRITER_RULE_ANCHORS = (
+    (
+        "#R-SINGLE-VOICE-A1",
+        (
+            "One teacher voice across the whole module",
+            "third-person framing of the learner",
+            "`the student`, `студента`, `the reader`, `учня`",
+        ),
+    ),
+    (
+        "#R-AUDIENCE-LANGUAGE-A1",
+        (
+            "A1 explanation prose stays in English",
+            "Ukrainian appears only as TARGET",
+            "`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`",
+        ),
+    ),
+    (
+        "#R-NO-CHILDREN-PRIMARY-QUOTES",
+        (
+            "No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels "
+            "in the published module body",
+            "Grade 1-3 RAG hits can still ground lexical choices",
+            "`Захарійчук, Grade 1, p.24`",
+        ),
+    ),
+    (
+        "#R-NO-SCAFFOLDING-LEAKS",
+        (
+            "Writer-side scaffolding never appears in module body",
+            "Krok-N labels (`Крок 5:`, `Step 5:`)",
+            "obligation names from the wiki_coverage manifest (`ban-4`, `step-5`, ...)",
+        ),
+    ),
+    (
+        "#R-GRAMMAR-TERMS-A1",
+        (
+            "Use proper grammatical terminology in English explanations",
+            "`a thing`, `an action`, `a word for`, `a doing-word`, `the X-form of Y`",
+            "Adult learners benefit from real grammar terms",
+        ),
+    ),
+    (
+        "#R-CLEAN-TABLES",
+        (
+            "Tables: bold ONLY the target Ukrainian forms",
+            "Pronoun columns (`я`, `ти`, ...), English headers, and English glosses",
+            "я / ти / він,вона,воно / ми / ви / вони",
+        ),
+    ),
+)
+
+
+def _prompt() -> str:
+    return WRITER_PROMPT.read_text(encoding="utf-8")
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+@pytest.mark.parametrize(("rule_id", "anchors"), WRITER_RULE_ANCHORS)
+def test_writer_prompt_contains_v7_register_rule(
+    rule_id: str,
+    anchors: tuple[str, ...],
+) -> None:
+    prompt = _prompt()
+    normalized = _normalize(prompt)
+
+    assert f"rule_id: {rule_id}" in prompt
+    for anchor in anchors:
+        assert _normalize(anchor) in normalized


### PR DESCRIPTION
## Summary

Adds six V7 writer rules to `linear-write.md` and mirrors them as reviewer REJECT criteria in `linear-review-dim.md`:

- `#R-SINGLE-VOICE-A1`
- `#R-AUDIENCE-LANGUAGE-A1`
- `#R-NO-CHILDREN-PRIMARY-QUOTES`
- `#R-NO-SCAFFOLDING-LEAKS`
- `#R-GRAMMAR-TERMS-A1`
- `#R-CLEAN-TABLES`

Also adds prompt-pinning tests for all six writer rules and all six reviewer mirrors.

## m20 line-ref justifications

- `#R-SINGLE-VOICE-A1`: m20 line 29 is English teacher explanation; lines 30-31 switch into Ukrainian metalanguage and third-person `студента`; line 35 switches again into casual paraphrase.
- `#R-AUDIENCE-LANGUAGE-A1`: m20 lines 30-31 use Ukrainian metalanguage TO the A1 learner (`Контролюй...`, `Рішуче відкидай...`).
- `#R-NO-CHILDREN-PRIMARY-QUOTES`: m20 lines 55-62 and 95-105 print Grade 1 textbook blockquotes in adult A1 content.
- `#R-NO-SCAFFOLDING-LEAKS`: m20 line 133 leaks `Крок 5:` writer-side scaffolding into the published body.
- `#R-GRAMMAR-TERMS-A1`: m20 line 35 says `сніданок is a thing; снідати is an action` instead of noun/verb terminology.
- `#R-CLEAN-TABLES`: m20 conjugation/table surface bolds pronoun cells and truncates the present-tense paradigm before `ви` / `вони`.

## Required read evidence

`wc -l scripts/build/phases/linear-write.md scripts/build/phases/linear-review-dim.md` initial raw output:

```text
  510 scripts/build/phases/linear-write.md
  318 scripts/build/phases/linear-review-dim.md
  828 total
```

Existing `#R-` rule names before this change:

- `#R-BAD-FORM-MARKER`
- `#R-CITE-HONEST`
- `#R-IMPL-MAP-COMPLETE`
- `#R-TEXTBOOK-30W`
- `#R-VESUM-ALL-WORDS`
- `#R-VOICE-META`

Existing reviewer dim names before this change:

- `engagement`
- `pedagogical`
- `naturalness`
- `decolonization`
- `tone`

`grep -n "^##\|^>\|<!-- bad\|Крок" curriculum/l2-uk-en/a1/my-morning/module.md` raw output:

```text
1:## Діалоги
29:Use **сніданок** (breakfast), not the Russian-borrowed <!-- bad -->завтрак<!-- /bad -->. The Ukrainian pair is clean and useful: **сніданок** is the noun, and **снідати** is the verb.
40:## Дієслова на -ся
55:> Мій день
56:> — Сьогодні в мене багато справ, — мови-
57:> ло жабеня Кнак. — Запишу.
58:> «Поснідати. Одягнутися. Піти до Квака.
59:> Прогулятися з Кваком. Пообідати. Подрімати.
60:> Погратися з Кваком. Повечеряти. Лягти спати».
61:> — Ну от і все. Тут за-пи-са-ний  у-весь 
62:> мій  день (за Арнольдом  Лобелом).
75:## Мій ранок
95:> Євген довго не був удома. Тепер повернув-
96:> ся. Він за­йшов у свою кімнату й побачив роз-
97:> кидані іграшки, кленові листочки від гербарію, 
98:> машинки. І хто повинен це прибирати? Згадав 
99:> татові слова: «Ти вже не малий. Спробуй про-
100:> жити  один день самостійною людиною. Не 
101:> сподівайся на диво, усе роби сам!»
102:> Уранці Євген устав із ліжка САМ. При-
103:> брав ліжко САМ. Зробив зарядку САМ. 
104:> На кухні САМ поставив на стіл чашку. 
105:> Після сніданку САМ помив посуд.
113:## Підсумок
133:Крок 5: Розширення лексичного та синтаксичного контексту. Додай **вода**, **зарядка**, **сніданок** і **раненько**, **швиденько**, **завжди**, **ніколи** до розповіді про щоденний розклад.
143:## Міні-практика
```

## Non-overlap notes

- `#R-SINGLE-VOICE-A1` nearest existing rule: `#R-VOICE-META`. Non-overlap: existing rule bans meta-narration; new rule bans register drift and third-person learner framing.
- `#R-AUDIENCE-LANGUAGE-A1` nearest existing rule: `#R-VOICE-META` / Immersion Rule. Non-overlap: existing rule controls English/Ukrainian ratio; new rule forbids Ukrainian metalanguage TO A1 learners.
- `#R-NO-CHILDREN-PRIMARY-QUOTES` nearest existing rule: `#R-TEXTBOOK-30W`. Overlap handled in prompt text: Grade 1-3 chunks still ground choices, but learner-facing `>` blockquotes are reserved for adult-appropriate sources. Follow-up caveat: the deterministic `textbook_grounding` gate may still need alignment; `linear_pipeline.py` is explicitly out of scope for this dispatch.
- `#R-NO-SCAFFOLDING-LEAKS` nearest existing rule: `#R-IMPL-MAP-COMPLETE`. Non-overlap: existing rule requires writer-side implementation map coverage; new rule prevents implementation-map/pipeline labels from leaking into `module.md`.
- `#R-GRAMMAR-TERMS-A1` nearest existing rule: grammar claim grounding under `#R-CITE-HONEST`. Non-overlap: existing rule grounds claims; new rule controls learner-facing terminology.
- `#R-CLEAN-TABLES` nearest existing rule: UK example-sentence density / table counting. Non-overlap: existing text controls table surfaces counted by gates; new rule controls table formatting and complete present-tense paradigm rows.

## Cross-file consistency mapping

| Writer rule | Reviewer mirror | Shared key phrase |
| --- | --- | --- |
| `#R-SINGLE-VOICE-A1` | `tone` REJECT criterion | `third-person framing of the learner`; `the student`, `студента`, `the reader`, `учня` |
| `#R-AUDIENCE-LANGUAGE-A1` | `tone` REJECT criterion | `A1 explanation prose stays in English`; `Ukrainian metalanguage TO the A1 learner` |
| `#R-NO-CHILDREN-PRIMARY-QUOTES` | `pedagogical` REJECT criterion | `blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body`; `Захарійчук, Grade 1, p.24` |
| `#R-NO-SCAFFOLDING-LEAKS` | `pedagogical` REJECT criterion | `Writer-side scaffolding never appears in module body`; `Krok-N labels (`Крок 5:`, `Step 5:`)` |
| `#R-GRAMMAR-TERMS-A1` | `pedagogical` REJECT criterion | `Use proper grammatical terminology in English explanations`; `a thing`, `an action`, `a word for`, `a doing-word`, `the X-form of Y` |
| `#R-CLEAN-TABLES` | `pedagogical` REJECT criterion | `Tables: bold ONLY the target Ukrainian forms`; `я / ти / він,вона,воно / ми / ви / вони` |

## Verification

` .venv/bin/pytest tests/test_writer_prompt_*.py tests/test_reviewer_prompt_*.py -q --no-header` final summary line:

```text
======================== 34 passed in 60.32s (0:01:00) =========================
```

`.venv/bin/ruff check scripts/build/phases/ tests/` final line:

```text
All checks passed!
```

Commit hook also ran affected prompt tests:

```text
============================== 12 passed in 0.09s ==============================
```

Trailer lint:

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Broader suite note: `.venv/bin/pytest tests/ -q --no-header` was also attempted and failed outside this change surface:

```text
= 8 failed, 8249 passed, 206 skipped, 11 xfailed, 3 warnings in 633.52s (0:10:33) =
```

A one-time `origin/main` baseline of the failed nodeids reproduced the unrelated runtime/source/MLX failures:

```text
========================= 5 failed, 3 passed in 4.83s ==========================
```

## Local review

Gemini local-code-review found five items. Applied the in-scope wording fixes: `Krok-N`, added `воно` to the third-person singular row label, and simplified duplicated reviewer phrasing. The remaining gate-compatibility warning for Grade 1-3 textbook blockquotes requires `scripts/build/linear_pipeline.py`, which this dispatch explicitly forbids touching.

## PR URL evidence

`gh pr view --json url -q .url` raw output:

```text
https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/2366
```

## Merge

Do not auto-merge. Orchestrator review required.
