### PR TITLE
feat(wiki_coverage): per-item gate matching + writer-side coverage block

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -844,6 +844,27 @@ def _check_obligation_text(obligation: Mapping[str, Any], target_text: str, arti
 
     if obligation_type == "sequence_step":
         claim = str(obligation.get("required_claim") or obligation.get("heading") or "")
+        normalized_claim = _normalize_required_claim(claim)
+        items = _extract_required_items(normalized_claim)
+
+        # If we have extracted items, use item-level coverage.
+        if items["vocabulary"] or items["examples"]:
+            missing_items = []
+            for word in items["vocabulary"]:
+                if not _contains(target_text, word):
+                    missing_items.append(word)
+            for example in items["examples"]:
+                if not _contains(target_text, example):
+                    missing_items.append(f"«{example}»")
+
+            if not missing_items:
+                return "PASS", "sequence_claim_present"
+            else:
+                return "FAIL", f"sequence_claim_missing: missing {', '.join(missing_items)}"
+
+        # DEPRECATED 2026-05-27: literal Крок N: substring match.
+        # Replaced by _extract_required_items + per-item coverage.
+        # Remove after one successful Phase 2a refire.
         if _claim_markers_present(claim, target_text):
             return "PASS", "sequence_claim_present"
         return "FAIL", "sequence_claim_missing"
@@ -952,8 +973,82 @@ def _phonetic_example_pairs(obligation: Mapping[str, Any]) -> list[tuple[str, ..
 
 def _normalize(text: str) -> str:
     text = re.sub(r"[`*_]", "", text.casefold())
-    text = text.replace("’", "'").replace("ʼ", "'")
+    text = text.replace("’", "\'").replace("ʼ", "\'")
     return re.sub(r"\s+", " ", text)
+
+
+def _strip_step_prefix(text: str) -> str:
+    """Strip leading 'Крок N:', 'Step N:', 'Урок N:' scaffolding labels."""
+    return re.sub(
+        r"^(?:Крок|Step|Урок)\s+\d+:\s*", "", text, flags=re.IGNORECASE
+    ).strip()
+
+
+def _strip_source_markers(text: str) -> str:
+    """Strip inline source-reference markers like [S7] or [S1, S3]."""
+    return re.sub(r"\[[SС]\d+(?:,\s*[SС]\d+)*\]", "", text).strip()
+
+
+def _normalize_required_claim(text: str) -> str:
+    """Apply both strip helpers, collapse whitespace, return pedagogical content."""
+    text = _strip_step_prefix(text)
+    text = _strip_source_markers(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _extract_required_items(claim_text: str) -> dict[str, list[str]]:
+    """Extract item-level requirements (vocabulary, examples) from a claim."""
+    vocabulary: list[str] = []
+    # Vocabulary: find Ukrainian words inside parentheses.
+    for match in re.findall(r"\(([^()]+)\)", claim_text):
+        for token in match.split(","):
+            token = token.strip().strip(" \t\r\n,;:.\"\'")
+            if token and re.search(r"[А-Яа-яІіЇїЄєҐґ]", token):
+                vocabulary.append(token)
+
+    examples: list[str] = []
+
+    def _add_item(val: str):
+        val = val.strip()
+        if not val or not re.search(r"[А-Яа-яІіЇїЄєҐґ]", val):
+            return
+        # If it's a single word, it might be vocabulary.
+        if len(val.split()) > 1:
+            examples.append(val)
+        else:
+            vocabulary.append(val)
+
+    # Examples/Vocabulary: find Ukrainian text inside quotes.
+    # 1. Guillemets «...»
+    for match in re.findall(r"«([^»]+)»", claim_text):
+        _add_item(match)
+    # 2. Double quotes "..."
+    for match in re.findall(r"\"([^\"]+)\"", claim_text):
+        _add_item(match)
+    # 3. Single quotes '...' (only if they look like quotes, not apostrophes)
+    for match in re.findall(r"(?:\s|^)'([^']+)'(?=[\s.,;!?]|$)", claim_text):
+        _add_item(match)
+
+    # Deduplicate while preserving order.
+    seen_vocab: set[str] = set()
+    dedup_vocab = []
+    for v in vocabulary:
+        if v not in seen_vocab:
+            dedup_vocab.append(v)
+            seen_vocab.add(v)
+
+    seen_examples: set[str] = set()
+    dedup_examples = []
+    for e in examples:
+        if e not in seen_examples:
+            dedup_examples.append(e)
+            seen_examples.add(e)
+
+    return {
+        "vocabulary": dedup_vocab,
+        "examples": dedup_examples,
+        "key_phrases": [],  # Substantive content could go here if needed.
+    }
 
 
 def _marker_candidates(text: str) -> list[str]:

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1026,6 +1026,61 @@ def _render_prompt_wiki_manifest(wiki_manifest: str | Mapping[str, Any]) -> str:
     return json.dumps(compact, ensure_ascii=False, indent=2)
 
 
+def _render_wiki_coverage_required_items(wiki_manifest: str | Mapping[str, Any]) -> str:
+    """Render a breakdown of required items for the writer prompt."""
+    if isinstance(wiki_manifest, str):
+        try:
+            manifest = json.loads(wiki_manifest)
+        except json.JSONDecodeError:
+            return ""
+    else:
+        manifest = wiki_manifest
+
+    from scripts.audit.wiki_coverage_gate import (
+        _extract_required_items,
+        _normalize_required_claim,
+    )
+
+    lines = []
+    # Sequence steps
+    for item in manifest.get("sequence_steps", []):
+        oid = str(item.get("id") or "")
+        claim = str(item.get("required_claim") or item.get("heading") or "")
+        if not claim:
+            continue
+        normalized = _normalize_required_claim(claim)
+        extracted = _extract_required_items(normalized)
+
+        if not (extracted["vocabulary"] or extracted["examples"]):
+            continue
+
+        lines.append(f"### {oid} (sequence step)")
+        if extracted["vocabulary"]:
+            lines.append(f"- Vocabulary to introduce: {', '.join(extracted['vocabulary'])}")
+        if extracted["examples"]:
+            lines.append(f"- Required examples: {', '.join(f'«{e}»' for e in extracted['examples'])}")
+        lines.append(f"- Pedagogical goal: {normalized}")
+        lines.append("")
+
+    # L2 errors
+    for item in manifest.get("l2_errors", []):
+        oid = str(item.get("id") or "")
+        incorrect = str(item.get("incorrect") or "")
+        correct = str(item.get("correct") or "")
+        why = str(item.get("why") or "")
+        if not (incorrect or correct):
+            continue
+
+        lines.append(f"### {oid} (L2 error contrast)")
+        lines.append(f"- Required contrast: incorrect `{incorrect}` vs correct `{correct}`")
+        lines.append(f"- Pedagogical goal: {why}")
+        if str(item.get("treatment")) == "contrast_pair":
+             lines.append("- Required location: activities.yaml `error-correction` activity, entry with `sentence`, `error`, `correction` fields")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
 def build_wiki_manifest(
     plan_path: Path | None = None,
     *,
@@ -2784,17 +2839,23 @@ def writer_context(
     learner_state = build_learner_state(level.lower(), sequence)
     activity_config = _activity_config(level, sequence, str(plan["slug"]))
     if wiki_manifest is None:
-        wiki_manifest_text = build_wiki_manifest(level=level.lower(), slug=str(plan["slug"]), plan=plan)
+        wiki_manifest_data = build_wiki_manifest_data(level=level.lower(), slug=str(plan["slug"]), plan=plan)
+        wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest_data)
+        required_items_text = _render_wiki_coverage_required_items(wiki_manifest_data)
     elif isinstance(wiki_manifest, str):
         wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest)
+        required_items_text = _render_wiki_coverage_required_items(wiki_manifest)
     else:
         wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest)
+        required_items_text = _render_wiki_coverage_required_items(wiki_manifest)
+
     if implementation_map is None:
         impl_map_contract = "(no implementation_map provided to render_writer_prompt — gate will fail)"
     else:
         from scripts.build.phases.implementation_map import render_for_writer_prompt
 
         impl_map_contract = render_for_writer_prompt(dict(implementation_map))
+
     return {
         "LEVEL": level,
         "MODULE_NUM": str(sequence),
@@ -2806,6 +2867,7 @@ def writer_context(
         "PLAN_CONTENT": plan_content,
         "KNOWLEDGE_PACKET": knowledge_packet,
         "WIKI_MANIFEST": wiki_manifest_text,
+        "WIKI_COVERAGE_REQUIRED_ITEMS": required_items_text,
         "IMPLEMENTATION_MAP_CONTRACT": impl_map_contract,
         "LEARNER_STATE": format_learner_state(learner_state),
         "IMMERSION_RULE": get_immersion_rule(level.lower(), sequence, learner_state=learner_state),

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -168,6 +168,17 @@ single largest reason A1 modules under-teach.
 
 {WIKI_MANIFEST}
 
+## Wiki Coverage Required Items (per-obligation breakdown)
+
+For each plan reference / wiki obligation, the lesson MUST teach the
+following specific items. Integrate them into the natural lesson
+flow (a model sentence using the noun, a usage example for the
+adverb, a conjugation row, a phonetic transcription). Do NOT echo
+the `Крок N:` label or `[S\d+]` source markers — those are
+writer-side scaffolding (forbidden per `#R-NO-SCAFFOLDING-LEAKS`).
+
+{WIKI_COVERAGE_REQUIRED_ITEMS}
+
 ## Implementation Map Contract
 
 The pipeline has pre-resolved every wiki obligation listed above into a concrete contract: `(obligation_id, artifact, location_hint, treatment_template)`. Your job for this section of the protocol is to **emit each row's required element at the row's `location_hint`, populated using the row's `treatment_template`**. Do NOT invent new obligations beyond those in the manifest. Do NOT skip rows. The deterministic `wiki_coverage_gate` verifies coverage row-by-row against this contract; missing rows produce `fix_proposals` and the rebuild is wasted.

--- a/scripts/build/prompt_builder.py
+++ b/scripts/build/prompt_builder.py
@@ -98,6 +98,7 @@ DOWNSTREAM_TOKENS = frozenset(
         "WRITER_MODEL",
         "WRITER_SPECIFIC_DIRECTIVES",
         "WIKI_COVERAGE_GATE",
+        "WIKI_COVERAGE_REQUIRED_ITEMS",
         "WIKI_MANIFEST",
     }
 )

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -203,9 +203,10 @@ def test_sequence_step_passes_when_h1_title_collides_with_h2_section() -> None:
         "## Мій ранок\n\n"
         "**Sequence words** — these are the connective tissue:\n\n"
         "- **спочатку** — first\n- **потім** — then\n"
-        "- **нарешті** — finally\n- **завжди** — always\n\n"
-        "Build a narrative from **іменниками** like **сніданок** "
-        "and **зарядка**, plus **прислівниками** of time.\n\n"
+        "- **нарешті** — finally\n- **завжди** — always\n"
+        "- **ніколи** — never\n\n"
+        "Build a narrative from **іменниками** like **вода**, **сніданок** "
+        "and **зарядка**, plus **прислівниками** of time like **раненько**.\n\n"
         "## Підсумок\n\nWrap-up here.\n"
     )
     implementation_map = {

--- a/tests/audit/test_wiki_coverage_integration.py
+++ b/tests/audit/test_wiki_coverage_integration.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.audit.wiki_coverage_gate import check_wiki_coverage
+
+
+def _sequence_step_manifest() -> dict[str, Any]:
+    return {
+        "slug": "my-morning",
+        "wiki_path": "wiki/grammar/a1/my-morning.md",
+        "sequence_steps": [
+            {
+                "id": "step-4",
+                "required_claim": "Крок 4: Відмінювання дієслова `дивлюся` [S3].",
+                "source_lines": "25",
+            },
+            {
+                "id": "step-5",
+                "required_claim": (
+                    "Крок 5: Розширення лексичного контексту. "
+                    "Тема ранкової рутини наповнюється іменниками "
+                    "(вода, зарядка, сніданок) та прислівниками "
+                    "часу і частотності (раненько, швиденько, завжди, ніколи) [S7]."
+                ),
+                "source_lines": "31",
+            }
+        ],
+        "l2_errors": [],
+        "phonetic_rules": [],
+        "decolonization_bans": [],
+    }
+
+def test_wiki_coverage_integration_m20_scenario():
+    """Verify that the gate correctly handles the m20 drift scenario.
+
+    - step-4: Writer included 'дивлюся' but not the label 'Крок 4'. Should PASS.
+    - step-5: Writer included 'сніданок' but missing others. Should FAIL with specific missing items.
+    """
+    manifest = _sequence_step_manifest()
+
+    # Module text mimicking the writer's output (clean, no scaffolding)
+    module_md = """
+# Мій ранок
+
+Я прокидаюся і **дивлюся** у вікно. Потім я готую **сніданок**.
+Це мій ранок.
+"""
+
+    implementation_map = {
+        "step-4": {
+            "artifact": "module.md",
+            "location": "whole file",
+            "treatment": "conjugation",
+        },
+        "step-5": {
+            "artifact": "module.md",
+            "location": "whole file",
+            "treatment": "vocabulary expansion",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md=module_md,
+        activities_yaml="[]",
+    )
+
+    results = {item["obligation_id"]: item for item in report["obligations"]}
+
+    # Assert step-4 passes because 'дивлюся' is present (even without 'Крок 4')
+    assert results["step-4"]["status"] == "PASS"
+
+    # Assert step-5 fails because of missing items
+    assert results["step-5"]["status"] == "FAIL"
+    reason = results["step-5"]["reason"]
+    assert "sequence_claim_missing" in reason
+    # It should report exactly what is missing
+    assert "вода" in reason
+    assert "зарядка" in reason
+    assert "раненько" in reason
+    assert "швиденько" in reason
+    assert "завжди" in reason
+    assert "ніколи" in reason
+    # But 'сніданок' should NOT be in the missing list
+    assert "сніданок" not in reason
+
+def test_wiki_coverage_integration_l2_error():
+    """Verify l2_error also passes via direct item matching."""
+    manifest = {
+        "l2_errors": [
+            {
+                "id": "err-1",
+                "incorrect": "Вимова: [одягайет'с'а]",
+                "correct": "Вимова: [одягайец':а]",
+                "why": "assimilation",
+                "treatment": "contrast_pair",
+            }
+        ]
+    }
+
+    # In activities.yaml, item-level
+    activities_yaml = """
+- id: act-1
+  type: error-correction
+  items:
+    - sentence: "Я одягаюся."
+      error: "Вимова: [одягайет'с'а]"
+      correction: "Вимова: [одягайец':а]"
+"""
+
+    implementation_map = {
+        "err-1": {
+            "artifact": "activities.yaml",
+            "location": "act-1",
+            "treatment": "contrast_pair",
+        }
+    }
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        implementation_map=implementation_map,
+        module_md="",
+        activities_yaml=activities_yaml,
+    )
+
+    assert report["obligations"][0]["status"] == "PASS"

--- a/tests/audit/test_wiki_coverage_normalize.py
+++ b/tests/audit/test_wiki_coverage_normalize.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from scripts.audit.wiki_coverage_gate import (
+    _extract_required_items,
+    _normalize_required_claim,
+    _strip_source_markers,
+    _strip_step_prefix,
+)
+
+
+def test_strip_step_prefix():
+    assert _strip_step_prefix("Крок 5: Розширення...") == "Розширення..."
+    assert _strip_step_prefix("Step 1: Introduction") == "Introduction"
+    assert _strip_step_prefix("Урок 10: Grammar") == "Grammar"
+    assert _strip_step_prefix("Розширення...") == "Розширення..."
+    assert _strip_step_prefix("") == ""
+
+def test_strip_source_markers():
+    assert _strip_source_markers("...автентичні конструкції [S3].") == "...автентичні конструкції ."
+    assert _strip_source_markers("...форм [S1, S3].") == "...форм ."
+    assert _strip_source_markers("No markers here.") == "No markers here."
+    assert _strip_source_markers("Multiple [S1] and [S2, S3] markers.") == "Multiple  and  markers."
+
+def test_normalize_required_claim():
+    claim = "Крок 5: Розширення... [S1, S3]."
+    assert _normalize_required_claim(claim) == "Розширення... ."
+
+def test_extract_required_items_vocabulary():
+    claim = "Розширення... (вода, зарядка, сніданок) ... (раненько, швиденько, завжди, ніколи)..."
+    items = _extract_required_items(claim)
+    assert items["vocabulary"] == ["вода", "зарядка", "сніданок", "раненько", "швиденько", "завжди", "ніколи"]
+
+def test_extract_required_items_examples():
+    claim = "Use the sentence «Я прокидаюся раненько» to illustrate."
+    items = _extract_required_items(claim)
+    assert items["examples"] == ["Я прокидаюся раненько"]
+
+def test_extract_required_items_mixed():
+    claim = "Introduce (вода, сніданок) and the sentence «Я п'ю воду»."
+    items = _extract_required_items(claim)
+    assert items["vocabulary"] == ["вода", "сніданок"]
+    assert items["examples"] == ["Я п'ю воду"]


### PR DESCRIPTION
Resolves the writer-prompt vs wiki_coverage gate drift exposed by the Phase 2a m20 refire (worktree a1-my-morning-20260527-163310).

Two-layer fix:
- Gate: normalize required_claim (strip Крок N:, [S\d+]), extract vocabulary + examples per-item, match each item in module text. Item-level coverage now drives the verdict, not literal substring.
- Writer prompt: new wiki_coverage_required_items block surfaces normalized requirements (e.g. 'step-5 requires vocab: вода, зарядка, сніданок, раненько, швиденько, завжди, ніколи') so writer integrates them without echoing scaffolding labels.

Verification:
- pytest tests/audit/test_wiki_coverage_normalize.py -v --no-header: 6 PASSED
- pytest tests/audit/test_wiki_coverage_integration.py -v --no-header: 2 PASSED (step-4 PASS, step-5 FAIL with missing items)
- pytest tests/audit/test_wiki_coverage_gate.py -v --no-header: 21 PASSED
- .venv/bin/pytest tests/audit/ tests/build/test_linear_pipeline.py -q --no-header: All passed

X-Agent: gemini/wiki-coverage-manifest-cleanup-2026-05-27