### PR TITLE
feat(fallback-ladder): insert agy-cli rung between gemini-cli pro and flash

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -904,6 +904,8 @@ def _build_gemini_attempt_tool_config(
     rung: GeminiRung,
 ) -> dict:
     """Clone tool_config and pin the current ladder rung's auth mode."""
+    if rung.auth_mode is None:
+        return dict(tool_config or {})
     attempt_tool_config = dict(tool_config or {})
     attempt_tool_config["auth_mode"] = (
         "subscription" if rung.auth_mode == "oauth" else "api"
@@ -1313,46 +1315,72 @@ def _invoke_gemini_with_fallback(
     ) -> AttemptOutcome:
         nonlocal last_telemetry
         nonlocal last_tool_calls
-        attempt_tool_config = _build_gemini_attempt_tool_config(tool_config, rung)
-        plan = adapter.build_invocation(
-            prompt=prompt,
-            mode=mode,
-            cwd=cwd,
-            model=rung.model,
-            task_id=task_id,
-            session_id=session_id,
-            tool_config=attempt_tool_config,
-            effort=effort,
-        )
-        last_telemetry = resolve_invocation_telemetry(
-            agent_name=agent_name,
-            plan=plan,
-            requested_model=rung.model,
-            requested_effort=effort,
-        )
-        execution = _execute_invocation_plan(
-            agent_name=agent_name,
-            adapter=adapter,
-            plan=plan,
-            prompt=prompt,
-            mode=mode,
-            cwd=cwd,
-            model=rung.model,
-            task_id=task_id,
-            session_id=session_id,
-            entrypoint=entrypoint,
-            hard_timeout=timeout_s or hard_timeout,
-            stall_timeout=stall_timeout,
-            tool_config=attempt_tool_config,
-            stdout_silence_timeout=stdout_silence_timeout,
-            initial_response_timeout=initial_response_timeout,
-        )
+        try:
+            if rung.cli == "agy-cli":
+                headroom_ok, headroom_reason = has_headroom("agy", rung.model)
+                if not headroom_ok:
+                    return AttemptOutcome(
+                        status="rate_limited",
+                        elapsed_s=0.0,
+                        stderr_excerpt=headroom_reason,
+                    )
+                attempt_agent_name = "agy"
+                attempt_adapter = _load_adapter("agy")
+                attempt_tool_config = _build_gemini_attempt_tool_config(tool_config, rung)
+                attempt_session_id = None
+            else:
+                attempt_agent_name = agent_name
+                attempt_adapter = adapter
+                attempt_tool_config = _build_gemini_attempt_tool_config(tool_config, rung)
+                attempt_session_id = session_id
+
+            plan = attempt_adapter.build_invocation(
+                prompt=prompt,
+                mode=mode,
+                cwd=cwd,
+                model=rung.model,
+                task_id=task_id,
+                session_id=attempt_session_id,
+                tool_config=attempt_tool_config,
+                effort=effort,
+            )
+            last_telemetry = resolve_invocation_telemetry(
+                agent_name=attempt_agent_name,
+                plan=plan,
+                requested_model=rung.model,
+                requested_effort=effort,
+            )
+            execution = _execute_invocation_plan(
+                agent_name=attempt_agent_name,
+                adapter=attempt_adapter,
+                plan=plan,
+                prompt=prompt,
+                mode=mode,
+                cwd=cwd,
+                model=rung.model,
+                task_id=task_id,
+                session_id=attempt_session_id,
+                entrypoint=entrypoint,
+                hard_timeout=timeout_s or hard_timeout,
+                stall_timeout=stall_timeout,
+                tool_config=attempt_tool_config,
+                stdout_silence_timeout=stdout_silence_timeout,
+                initial_response_timeout=initial_response_timeout,
+            )
+        except AgentUnavailableError as exc:
+            if rung.cli == "agy-cli":
+                return AttemptOutcome(
+                    status="retryable_error",
+                    elapsed_s=0.0,
+                    stderr_excerpt=str(exc),
+                )
+            raise
         parse = execution.parse
         last_tool_calls = list(parse.tool_calls)
 
         if execution.kill_reason in ("stdout_silence_timeout", "initial_response_timeout"):
             _raise_for_kill_reason(
-                agent_name=agent_name,
+                agent_name=attempt_agent_name,
                 kill_reason=execution.kill_reason,
                 execution=execution,
                 prompt=prompt,
@@ -1361,7 +1389,7 @@ def _invoke_gemini_with_fallback(
                 mode=mode,
                 task_id=task_id,
                 cwd=cwd,
-                session_id=session_id,
+                session_id=attempt_session_id,
                 stdout_silence_timeout=stdout_silence_timeout,
                 initial_response_timeout=initial_response_timeout,
                 stall_timeout=stall_timeout,

--- a/scripts/ai_llm/fallback.py
+++ b/scripts/ai_llm/fallback.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Literal
 
 PRIMARY_GEMINI_MODEL = "gemini-3.1-pro-preview"
+AGY_GEMINI_MODEL = "gemini-3.5-flash-high"
 FLASH_GEMINI_MODEL = "gemini-3-flash-preview"
 FINAL_GEMINI_MODEL = "gemini-2.5-pro"
 GEMINI_MODEL_LADDER = (
@@ -60,6 +61,7 @@ _RATE_LIMIT_MARKERS = (
 )
 
 AuthMode = Literal["api", "oauth"]
+CliMode = Literal["gemini-cli", "agy-cli"]
 AttemptStatus = Literal["success", "rate_limited", "retryable_error", "timeout", "fatal"]
 
 
@@ -68,7 +70,8 @@ class GeminiRung:
     index: int
     total: int
     model: str
-    auth_mode: AuthMode
+    auth_mode: AuthMode | None
+    cli: CliMode = "gemini-cli"
 
 
 @dataclass(frozen=True)
@@ -86,7 +89,7 @@ class AttemptRecord:
     rung_index: int
     rung_total: int
     model: str
-    auth_mode: AuthMode
+    auth_mode: AuthMode | None
     attempt_index: int
     max_retries: int
     status: AttemptStatus
@@ -95,6 +98,7 @@ class AttemptRecord:
     stderr_excerpt: str | None = None
     note: str | None = None
     response_chars: int = 0
+    cli: CliMode = "gemini-cli"
 
 
 @dataclass(frozen=True)
@@ -103,6 +107,7 @@ class CallResult:
     model_used: str | None
     auth_mode_used: AuthMode | None
     elapsed_s: float
+    cli_used: CliMode | None = None
     attempts: list[AttemptRecord] = field(default_factory=list)
     error_message: str | None = None
 
@@ -132,21 +137,112 @@ def build_gemini_ladder(
     else:
         model_order = [preferred_model, FLASH_GEMINI_MODEL, FINAL_GEMINI_MODEL]
 
-    rungs: list[GeminiRung] = []
-    total = len(model_order) * len(allowed_auth_modes)
+    rung_specs: list[tuple[str, AuthMode | None, CliMode]] = []
+    include_agy = preferred_model == PRIMARY_GEMINI_MODEL and allowed_auth_modes != ("api",)
     for model in model_order:
         for auth_mode in ("api", "oauth"):
             if auth_mode not in allowed_auth_modes:
                 continue
-            rungs.append(
-                GeminiRung(
-                    index=len(rungs) + 1,
-                    total=total,
-                    model=model,
-                    auth_mode=auth_mode,
-                )
-            )
-    return rungs
+            rung_specs.append((model, auth_mode, "gemini-cli"))
+        if include_agy and model == PRIMARY_GEMINI_MODEL:
+            rung_specs.append((AGY_GEMINI_MODEL, None, "agy-cli"))
+
+    total = len(rung_specs)
+    return [
+        GeminiRung(
+            index=index,
+            total=total,
+            model=model,
+            auth_mode=auth_mode,
+            cli=cli,
+        )
+        for index, (model, auth_mode, cli) in enumerate(rung_specs, start=1)
+    ]
+
+
+def _format_rung(rung: GeminiRung) -> str:
+    if rung.cli == "agy-cli":
+        return f"{rung.model} + AGY-CLI"
+    return f"{rung.model} + {str(rung.auth_mode).upper()}"
+
+
+def _format_rung_summary(rung: GeminiRung) -> str:
+    if rung.cli == "agy-cli":
+        return f"{_short_model_label(rung.model)} + AGY"
+    return f"{_short_model_label(rung.model)} + {str(rung.auth_mode).upper()}"
+
+
+def _run_agy_via_runtime(
+    prompt: str,
+    *,
+    task_name: str,
+    timeout_s: int | None,
+    cwd: Path,
+) -> AttemptOutcome:
+    """Invoke agy through the runtime adapter without touching the broker DB."""
+    call_start_mono = time.monotonic()
+    hard_timeout = timeout_s or 24 * 60 * 60
+    try:
+        from agent_runtime import runner as agent_runner
+        from agent_runtime.errors import (
+            AgentStalledError,
+            AgentTimeoutError,
+            AgentUnavailableError,
+            RateLimitedError,
+        )
+
+        result = agent_runner.invoke(
+            "agy",
+            prompt,
+            mode="read-only",
+            cwd=cwd,
+            model=AGY_GEMINI_MODEL,
+            task_id=f"{task_name}-agy-fallback",
+            session_id=None,
+            tool_config=None,
+            entrypoint="fallback-ladder",
+            hard_timeout=hard_timeout,
+            stall_timeout=min(600, hard_timeout),
+        )
+    except RateLimitedError as exc:
+        return AttemptOutcome(
+            status="rate_limited",
+            elapsed_s=time.monotonic() - call_start_mono,
+            stderr_excerpt=str(exc),
+        )
+    except (AgentStalledError, AgentUnavailableError) as exc:
+        return AttemptOutcome(
+            status="retryable_error",
+            elapsed_s=time.monotonic() - call_start_mono,
+            stderr_excerpt=str(exc),
+        )
+    except AgentTimeoutError as exc:
+        return AttemptOutcome(
+            status="timeout",
+            elapsed_s=time.monotonic() - call_start_mono,
+            stderr_excerpt=str(exc),
+        )
+    except Exception as exc:
+        return AttemptOutcome(
+            status="retryable_error",
+            elapsed_s=time.monotonic() - call_start_mono,
+            stderr_excerpt=f"{type(exc).__name__}: {exc}",
+        )
+
+    if result.ok and result.response:
+        return AttemptOutcome(
+            status="success",
+            elapsed_s=result.duration_s,
+            response_text=result.response,
+            stderr_excerpt=result.stderr_excerpt,
+            returncode=result.returncode,
+        )
+    return AttemptOutcome(
+        status="rate_limited" if result.rate_limited else "retryable_error",
+        elapsed_s=result.duration_s,
+        stderr_excerpt=result.stderr_excerpt or "Agy returned no final message",
+        returncode=result.returncode,
+    )
 
 
 def _has_gemini_api_key(env: Mapping[str, str]) -> bool:
@@ -300,7 +396,7 @@ def run_gemini_fallback_ladder(
                 if remaining_s < min_attempt_budget_s:
                     error = (
                         f"{task_name}: no budget left for rung {rung.index}/{rung.total} "
-                        f"({rung.model} + {rung.auth_mode})"
+                        f"({_format_rung(rung)})"
                     )
                     emit(f"  ❌ {error}")
                     _emit_attempt_history(emit, attempts)
@@ -309,14 +405,15 @@ def run_gemini_fallback_ladder(
                         model_used=None,
                         auth_mode_used=None,
                         elapsed_s=time.monotonic() - overall_start,
+                        cli_used=None,
                         attempts=attempts,
                         error_message=error,
                     )
                 timeout_s = min(timeout_s, remaining_s) if timeout_s is not None else remaining_s
 
             emit(
-                f"🎯 Rung {rung.index}/{rung.total}: {rung.model} + "
-                f"{rung.auth_mode.upper()} (attempt {attempt_index}/{max_retries})"
+                f"🎯 Rung {rung.index}/{rung.total}: {_format_rung(rung)} "
+                f"(attempt {attempt_index}/{max_retries})"
             )
             outcome = attempt_runner(rung, attempt_index, timeout_s)
             record = AttemptRecord(
@@ -324,6 +421,7 @@ def run_gemini_fallback_ladder(
                 rung_total=rung.total,
                 model=rung.model,
                 auth_mode=rung.auth_mode,
+                cli=rung.cli,
                 attempt_index=attempt_index,
                 max_retries=max_retries,
                 status=outcome.status,
@@ -339,20 +437,37 @@ def run_gemini_fallback_ladder(
                 response_text = outcome.response_text or ""
                 emit(
                     f"  ✓ Responded in {outcome.elapsed_s:.1f}s ({len(response_text):,} chars). "
-                    f"Model used: {rung.model}, auth: {rung.auth_mode}."
+                    f"Model used: {rung.model}, cli: {rung.cli}."
                 )
                 emit(
-                    f"✓ Gemini via [rung {rung.index}: {_short_model_label(rung.model)} + "
-                    f"{rung.auth_mode.upper()}] in {time.monotonic() - overall_start:.1f}s"
+                    f"✓ Gemini fallback via [rung {rung.index}: "
+                    f"{_format_rung_summary(rung)}] in "
+                    f"{time.monotonic() - overall_start:.1f}s"
                 )
                 return CallResult(
                     response_text=response_text,
                     model_used=rung.model,
                     auth_mode_used=rung.auth_mode,
                     elapsed_s=time.monotonic() - overall_start,
+                    cli_used=rung.cli,
                     attempts=attempts,
                     error_message=None,
                 )
+
+            if rung.cli == "agy-cli":
+                # Agy is a separate-quota probe, not another retry sink. If it
+                # cannot answer once, keep the Gemini ladder moving to flash.
+                excerpt = _clean_excerpt(outcome.stderr_excerpt or outcome.note)
+                next_step = (
+                    f"Advancing to rung {rung.index + 1}."
+                    if rung.index < rung.total
+                    else "No more rungs."
+                )
+                emit(
+                    f"  ⚠️  Agy rung returned {outcome.status} after "
+                    f"{outcome.elapsed_s:.1f}s (detail: {excerpt}). {next_step}"
+                )
+                break
 
             if outcome.status == "rate_limited":
                 excerpt = _clean_excerpt(outcome.stderr_excerpt)
@@ -392,6 +507,7 @@ def run_gemini_fallback_ladder(
                     model_used=None,
                     auth_mode_used=None,
                     elapsed_s=time.monotonic() - overall_start,
+                    cli_used=None,
                     attempts=attempts,
                     error_message=error,
                 )
@@ -413,6 +529,7 @@ def run_gemini_fallback_ladder(
                     model_used=None,
                     auth_mode_used=None,
                     elapsed_s=time.monotonic() - overall_start,
+                    cli_used=None,
                     attempts=attempts,
                     error_message=error,
                 )
@@ -421,7 +538,7 @@ def run_gemini_fallback_ladder(
         else:
             continue
 
-    error = f"{task_name}: all {len(ladder)} Gemini fallback rungs rate-limited"
+    error = f"{task_name}: all {len(ladder)} Gemini fallback rungs exhausted"
     emit(f"  ❌ {error}")
     _emit_attempt_history(emit, attempts)
     return CallResult(
@@ -429,6 +546,7 @@ def run_gemini_fallback_ladder(
         model_used=None,
         auth_mode_used=None,
         elapsed_s=time.monotonic() - overall_start,
+        cli_used=None,
         attempts=attempts,
         error_message=error,
     )
@@ -448,6 +566,7 @@ def call_gemini_with_fallback(
     logger: Callable[[str], None] | None = None,
     sleep_fn: Callable[[int, str], None] | None = None,
     recover_response: Callable[[float, str], str | None] | None = None,
+    agy_runner: Callable[[str, int | None], AttemptOutcome] | None = None,
 ) -> CallResult:
     """Call the Gemini CLI through the shared rung ladder."""
     # Default-timeout changed 2026-04-24 from `min(300 + len//500, 900)` to
@@ -462,8 +581,24 @@ def call_gemini_with_fallback(
     emit = logger or print
 
     def _attempt_runner(rung: GeminiRung, _attempt_index: int, timeout_s: int | None) -> AttemptOutcome:
+        if rung.cli == "agy-cli":
+            if agy_runner is not None:
+                return agy_runner(prompt, timeout_s)
+            return _run_agy_via_runtime(
+                prompt,
+                task_name=task_name,
+                timeout_s=timeout_s,
+                cwd=workdir,
+            )
+
         call_start_wall = time.time()
         call_start_mono = time.monotonic()
+        if rung.auth_mode is None:
+            return AttemptOutcome(
+                status="fatal",
+                elapsed_s=0.0,
+                stderr_excerpt="gemini-cli rung missing auth_mode",
+            )
         env = build_gemini_subprocess_env(rung.auth_mode, base_env=base_env)
         prompt_arg, prompt_file = _gemini_prompt_arg(prompt)
         cmd = [
@@ -613,9 +748,13 @@ def _emit_attempt_history(logger: Callable[[str], None], attempts: list[AttemptR
     logger("  Attempt history:")
     for attempt in attempts:
         detail = _clean_excerpt(attempt.stderr_excerpt)
+        if attempt.cli == "agy-cli":
+            rung_label = f"{attempt.model} + AGY-CLI"
+        else:
+            rung_label = f"{attempt.model} + {str(attempt.auth_mode).upper()}"
         logger(
             f"    - rung {attempt.rung_index}/{attempt.rung_total} "
-            f"{attempt.model} + {attempt.auth_mode.upper()} "
+            f"{rung_label} "
             f"attempt {attempt.attempt_index}/{attempt.max_retries}: "
             f"{attempt.status} in {attempt.elapsed_s:.1f}s (stderr: {detail})"
         )
@@ -624,6 +763,8 @@ def _emit_attempt_history(logger: Callable[[str], None], attempts: list[AttemptR
 def _short_model_label(model: str) -> str:
     if model == PRIMARY_GEMINI_MODEL:
         return "3.1-pro"
+    if model == AGY_GEMINI_MODEL:
+        return "agy-3.5-flash-high"
     if model == FLASH_GEMINI_MODEL:
         return "3-flash"
     if model == FINAL_GEMINI_MODEL:

--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -699,19 +699,31 @@ def _dispatch_via_runtime(
             _attempt_index: int,
             call_timeout: int | None,
         ) -> AttemptOutcome:
-            auth_mode_label = "OAuth" if rung.auth_mode == "oauth" else "API"
-            label = f"{agent} [{rung.model} + {auth_mode_label}]"
+            # Agy rung (PR #2375): separate-quota probe via Antigravity CLI.
+            # No MCP tool_config (agy doesn't share the gemini-tools MCP plumbing);
+            # caller of the dispatch path that requested MCP grounding may need
+            # to evaluate the agy response independently.
+            is_agy = rung.cli == "agy-cli"
+            if is_agy:
+                attempt_agent = "agy"
+                auth_mode_label = "AGY-CLI"
+                call_tool_config = None
+            else:
+                attempt_agent = runtime_agent_name
+                auth_mode_label = "OAuth" if rung.auth_mode == "oauth" else "API"
+                call_tool_config = dict(tool_config or {})
+                call_tool_config["auth_mode"] = "subscription" if rung.auth_mode == "oauth" else "api"
+            label = f"{attempt_agent} [{rung.model} + {auth_mode_label}]"
             t0 = time.monotonic()
             call_start = datetime.now().astimezone()
-            call_tool_config = dict(tool_config or {})
-            call_tool_config["auth_mode"] = "subscription" if rung.auth_mode == "oauth" else "api"
             try:
-                _pace_gemini_calls()
+                if not is_agy:
+                    _pace_gemini_calls()
                 with _temporary_rate_limit_bypass():
                     result = runtime_invoke(
-                        runtime_agent_name,
+                        attempt_agent,
                         prompt,
-                        mode=runtime_mode,
+                        mode=runtime_mode if not is_agy else "read-only",
                         cwd=PROJECT_ROOT,
                         model=rung.model,
                         task_id=f"{phase}-{orch_dir.name}" if orch_dir else phase,

--- a/tests/test_ai_llm_fallback.py
+++ b/tests/test_ai_llm_fallback.py
@@ -10,9 +10,12 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from ai_llm.fallback import (
+    AGY_GEMINI_MODEL,
     FINAL_GEMINI_MODEL,
     FLASH_GEMINI_MODEL,
     PRIMARY_GEMINI_MODEL,
+    AttemptOutcome,
+    build_gemini_ladder,
     call_gemini_with_fallback,
 )
 
@@ -66,6 +69,37 @@ def _base_env() -> dict[str, str]:
         "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/fake-creds.json",
         "GEMINI_SESSION": "1",
     }
+
+
+def test_build_gemini_ladder_inserts_agy_between_pro_and_flash():
+    ladder = build_gemini_ladder(allowed_auth_modes=("api", "oauth"))
+
+    assert [(r.cli, r.model, r.auth_mode) for r in ladder] == [
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "api"),
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "oauth"),
+        ("agy-cli", AGY_GEMINI_MODEL, None),
+        ("gemini-cli", FLASH_GEMINI_MODEL, "api"),
+        ("gemini-cli", FLASH_GEMINI_MODEL, "oauth"),
+        ("gemini-cli", FINAL_GEMINI_MODEL, "api"),
+        ("gemini-cli", FINAL_GEMINI_MODEL, "oauth"),
+    ]
+    assert [r.index for r in ladder] == list(range(1, 8))
+    assert all(r.total == 7 for r in ladder)
+
+
+def test_build_gemini_ladder_without_api_key_keeps_agy_rung():
+    ladder = build_gemini_ladder(
+        allowed_auth_modes=("oauth",),
+    )
+
+    assert [(r.cli, r.model, r.auth_mode) for r in ladder] == [
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "oauth"),
+        ("agy-cli", AGY_GEMINI_MODEL, None),
+        ("gemini-cli", FLASH_GEMINI_MODEL, "oauth"),
+        ("gemini-cli", FINAL_GEMINI_MODEL, "oauth"),
+    ]
+    assert [r.index for r in ladder] == [1, 2, 3, 4]
+    assert all(r.total == 4 for r in ladder)
 
 
 def test_call_gemini_with_fallback_rung1_success(tmp_path):
@@ -141,6 +175,13 @@ def test_call_gemini_with_fallback_all_rungs_rate_limited(tmp_path):
         ]
     )
 
+    def agy_runner(_prompt: str, _timeout_s: int | None) -> AttemptOutcome:
+        return AttemptOutcome(
+            status="rate_limited",
+            elapsed_s=0.1,
+            stderr_excerpt="Agy quota exceeded",
+        )
+
     with patch("ai_llm.fallback.subprocess.Popen", factory):
         result = call_gemini_with_fallback(
             "prompt",
@@ -149,21 +190,99 @@ def test_call_gemini_with_fallback_all_rungs_rate_limited(tmp_path):
             base_env=_base_env(),
             logger=lambda _msg: None,
             sleep_fn=lambda _seconds, _reason: None,
+            agy_runner=agy_runner,
         )
 
     assert result.ok is False
     assert result.response_text is None
-    assert len(result.attempts) == 6
-    assert [attempt.model for attempt in result.attempts] == [
-        PRIMARY_GEMINI_MODEL,
-        PRIMARY_GEMINI_MODEL,
-        FLASH_GEMINI_MODEL,
-        FLASH_GEMINI_MODEL,
-        FINAL_GEMINI_MODEL,
-        FINAL_GEMINI_MODEL,
+    assert len(result.attempts) == 7
+    assert [(attempt.cli, attempt.model) for attempt in result.attempts] == [
+        ("gemini-cli", PRIMARY_GEMINI_MODEL),
+        ("gemini-cli", PRIMARY_GEMINI_MODEL),
+        ("agy-cli", AGY_GEMINI_MODEL),
+        ("gemini-cli", FLASH_GEMINI_MODEL),
+        ("gemini-cli", FLASH_GEMINI_MODEL),
+        ("gemini-cli", FINAL_GEMINI_MODEL),
+        ("gemini-cli", FINAL_GEMINI_MODEL),
     ]
     assert all(attempt.status == "rate_limited" for attempt in result.attempts)
-    assert "all 6 Gemini fallback rungs rate-limited" in (result.error_message or "")
+    assert "all 7 Gemini fallback rungs exhausted" in (result.error_message or "")
+
+
+def test_call_gemini_with_fallback_agy_success_after_pro_rate_limit(tmp_path):
+    factory = _FakePopenFactory(
+        [
+            {"stdout": "", "stderr": "rate_limited 429", "returncode": 1},
+            {"stdout": "", "stderr": "quota", "returncode": 1},
+        ]
+    )
+
+    def agy_runner(_prompt: str, _timeout_s: int | None) -> AttemptOutcome:
+        return AttemptOutcome(
+            status="success",
+            elapsed_s=0.1,
+            response_text="Agy answer" * 20,
+        )
+
+    with patch("ai_llm.fallback.subprocess.Popen", factory):
+        result = call_gemini_with_fallback(
+            "prompt",
+            task_name="unit-test",
+            cwd=tmp_path,
+            base_env=_base_env(),
+            logger=lambda _msg: None,
+            sleep_fn=lambda _seconds, _reason: None,
+            agy_runner=agy_runner,
+        )
+
+    assert result.ok is True
+    assert result.model_used == AGY_GEMINI_MODEL
+    assert result.auth_mode_used is None
+    assert result.cli_used == "agy-cli"
+    assert [(attempt.cli, attempt.model, attempt.status) for attempt in result.attempts] == [
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "rate_limited"),
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "rate_limited"),
+        ("agy-cli", AGY_GEMINI_MODEL, "success"),
+    ]
+
+
+def test_call_gemini_with_fallback_agy_failure_falls_to_flash(tmp_path):
+    factory = _FakePopenFactory(
+        [
+            {"stdout": "", "stderr": "rate_limited 429", "returncode": 1},
+            {"stdout": "", "stderr": "quota", "returncode": 1},
+            {"stdout": "Flash answer" * 20, "stderr": "", "returncode": 0},
+        ]
+    )
+
+    def agy_runner(_prompt: str, _timeout_s: int | None) -> AttemptOutcome:
+        return AttemptOutcome(
+            status="retryable_error",
+            elapsed_s=0.1,
+            stderr_excerpt="agy unavailable",
+        )
+
+    with patch("ai_llm.fallback.subprocess.Popen", factory):
+        result = call_gemini_with_fallback(
+            "prompt",
+            task_name="unit-test",
+            cwd=tmp_path,
+            base_env=_base_env(),
+            logger=lambda _msg: None,
+            sleep_fn=lambda _seconds, _reason: None,
+            agy_runner=agy_runner,
+        )
+
+    assert result.ok is True
+    assert result.model_used == FLASH_GEMINI_MODEL
+    assert result.auth_mode_used == "api"
+    assert result.cli_used == "gemini-cli"
+    assert [(attempt.cli, attempt.model, attempt.status) for attempt in result.attempts] == [
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "rate_limited"),
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "rate_limited"),
+        ("agy-cli", AGY_GEMINI_MODEL, "retryable_error"),
+        ("gemini-cli", FLASH_GEMINI_MODEL, "success"),
+    ]
 
 
 def test_call_gemini_with_fallback_non_rate_limit_retries_same_rung(tmp_path):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -297,23 +297,28 @@ class TestDispatchAgent:
 
     @patch("build.dispatch._pace_gemini_calls")
     @patch("agent_runtime.runner.invoke")
-    def test_gemini_dispatch_rate_limit_falls_through_to_oauth(
+    def test_gemini_dispatch_rate_limit_falls_through_via_agy_to_flash(
         self,
         mock_invoke,
         _mock_pace,
         tmp_path,
     ):
+        """After PR #2375, the ladder hops through agy-cli between gemini-cli
+        pro and gemini-cli flash. This test exercises the FULL fallthrough:
+        pro+oauth rate-limited → agy rate-limited → flash+oauth succeeds.
+        """
         from agent_runtime.errors import RateLimitedError
         from agent_runtime.result import Result
 
         mock_invoke.side_effect = [
             RateLimitedError("gemini", "gemini-3.1-pro-preview", "429 quota"),
+            RateLimitedError("agy", "gemini-3.5-flash-high", "agy 429"),
             Result(
                 ok=True,
                 agent="gemini",
-                model="gemini-3.1-pro-preview",
+                model="gemini-3-flash-preview",
                 mode="workspace-write",
-                response="oauth fallback reply",
+                response="flash fallback reply",
                 stderr_excerpt=None,
                 duration_s=0.5,
                 session_id=None,
@@ -335,16 +340,23 @@ class TestDispatchAgent:
         )
 
         assert ok is True
-        assert raw == "oauth fallback reply"
+        assert raw == "flash fallback reply"
         first_call = mock_invoke.call_args_list[0].kwargs
         second_call = mock_invoke.call_args_list[1].kwargs
+        third_call = mock_invoke.call_args_list[2].kwargs
+        # Rung 1: gemini-cli pro + oauth
         assert first_call["model"] == "gemini-3.1-pro-preview"
-        assert second_call["model"] == "gemini-3-flash-preview"
         assert first_call["tool_config"] == {
             "mcp_server_names": ["sources"],
             "auth_mode": "subscription",
         }
-        assert second_call["tool_config"] == {
+        # Rung 2: agy-cli (the new rung) — tool_config is None, agent is "agy"
+        assert second_call["model"] == "gemini-3.5-flash-high"
+        assert mock_invoke.call_args_list[1].args[0] == "agy"
+        assert second_call["tool_config"] is None
+        # Rung 3: gemini-cli flash + oauth
+        assert third_call["model"] == "gemini-3-flash-preview"
+        assert third_call["tool_config"] == {
             "mcp_server_names": ["sources"],
             "auth_mode": "subscription",
         }

--- a/tests/test_gemini_adapter_auth.py
+++ b/tests/test_gemini_adapter_auth.py
@@ -461,26 +461,30 @@ class TestLadderAuthModeFiltering:
         env = {"GEMINI_AUTH_MODE": "api"}
         assert resolve_allowed_auth_modes(env, cooldown_active=True) == ("api",)
 
-    def test_ladder_oauth_only_has_three_rungs(self) -> None:
+    def test_ladder_oauth_only_keeps_agy_rung(self) -> None:
         ladder = build_gemini_ladder(allowed_auth_modes=("oauth",))
-        assert len(ladder) == 3
-        assert all(r.auth_mode == "oauth" for r in ladder)
-        # Rung indices renumber to filtered total so log "Rung 1/3" is honest
-        assert [r.index for r in ladder] == [1, 2, 3]
-        assert all(r.total == 3 for r in ladder)
+        assert len(ladder) == 4
+        gemini_rungs = [r for r in ladder if r.cli == "gemini-cli"]
+        assert all(r.auth_mode == "oauth" for r in gemini_rungs)
+        assert ladder[1].cli == "agy-cli"
+        # Rung indices renumber to filtered total so log "Rung 1/4" is honest
+        assert [r.index for r in ladder] == [1, 2, 3, 4]
+        assert all(r.total == 4 for r in ladder)
 
     def test_ladder_api_only_has_three_rungs(self) -> None:
         ladder = build_gemini_ladder(allowed_auth_modes=("api",))
         assert len(ladder) == 3
         assert all(r.auth_mode == "api" for r in ladder)
 
-    def test_ladder_both_has_six_rungs_with_api_first_per_model(self) -> None:
+    def test_ladder_both_has_seven_rungs_with_agy_after_pro(self) -> None:
         ladder = build_gemini_ladder(allowed_auth_modes=("api", "oauth"))
-        assert len(ladder) == 6
+        assert len(ladder) == 7
         # API-first ordering preserves the "fast-path first" intent
         assert ladder[0].auth_mode == "api"
         assert ladder[1].auth_mode == "oauth"
         assert ladder[0].model == ladder[1].model
+        assert ladder[2].cli == "agy-cli"
+        assert ladder[3].auth_mode == "api"
 
     def test_empty_allowed_modes_rejected(self) -> None:
         import pytest

--- a/tests/test_gemini_fallback_agy.py
+++ b/tests/test_gemini_fallback_agy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_llm.fallback import (
+    AGY_GEMINI_MODEL,
+    FLASH_GEMINI_MODEL,
+    PRIMARY_GEMINI_MODEL,
+    AttemptOutcome,
+    build_gemini_ladder,
+    run_gemini_fallback_ladder,
+)
+
+
+def test_shared_ladder_order_includes_agy_after_pro():
+    ladder = build_gemini_ladder(allowed_auth_modes=("api", "oauth"))
+
+    assert [(r.cli, r.model, r.auth_mode) for r in ladder[:4]] == [
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "api"),
+        ("gemini-cli", PRIMARY_GEMINI_MODEL, "oauth"),
+        ("agy-cli", AGY_GEMINI_MODEL, None),
+        ("gemini-cli", FLASH_GEMINI_MODEL, "api"),
+    ]
+    assert len(ladder) == 7
+
+
+def test_agy_retryable_error_advances_to_flash_rung():
+    outcomes = {
+        (PRIMARY_GEMINI_MODEL, "api"): AttemptOutcome(
+            status="rate_limited",
+            elapsed_s=0.1,
+            stderr_excerpt="429 quota",
+        ),
+        (PRIMARY_GEMINI_MODEL, "oauth"): AttemptOutcome(
+            status="rate_limited",
+            elapsed_s=0.1,
+            stderr_excerpt="oauth quota",
+        ),
+        (AGY_GEMINI_MODEL, None): AttemptOutcome(
+            status="retryable_error",
+            elapsed_s=0.1,
+            stderr_excerpt="agy unavailable",
+        ),
+        (FLASH_GEMINI_MODEL, "api"): AttemptOutcome(
+            status="success",
+            elapsed_s=0.1,
+            response_text="flash answer",
+        ),
+    }
+    seen: list[tuple[str, str | None]] = []
+
+    def runner(rung, _attempt_idx, _timeout_s):
+        key = (rung.model, rung.auth_mode)
+        seen.append(key)
+        return outcomes[key]
+
+    result = run_gemini_fallback_ladder(
+        task_name="agy-fallback-test",
+        attempt_runner=runner,
+        allowed_auth_modes=("api", "oauth"),
+        logger=lambda _msg: None,
+        sleep_fn=lambda _seconds, _reason: None,
+    )
+
+    assert result.ok is True
+    assert result.model_used == FLASH_GEMINI_MODEL
+    assert result.cli_used == "gemini-cli"
+    assert seen == [
+        (PRIMARY_GEMINI_MODEL, "api"),
+        (PRIMARY_GEMINI_MODEL, "oauth"),
+        (AGY_GEMINI_MODEL, None),
+        (FLASH_GEMINI_MODEL, "api"),
+    ]


### PR DESCRIPTION
## Summary

Inserts agy-cli as a ladder rung in `run_gemini_fallback_ladder` between gemini-cli pro and gemini-cli flash. agy-cli uses Antigravity's separate quota path (`gemini-3.5-flash-high`), sidestepping Gemini API/OAuth rate limits and OAuth rotations.

User direction 2026-05-27 evening — surfacing trigger was an OAuth rotation killing in-flight gemini-cli work mid-discussion.

Resolves #2373.

## New ladder order

```
Rung 1: gemini-cli  pro    + api    (skipped if no GEMINI_API_KEY)
Rung 2: gemini-cli  pro    + oauth
Rung 3: agy-cli     (Antigravity, gemini-3.5-flash-high)        ← NEW
Rung 4: gemini-cli  flash  + api
Rung 5: gemini-cli  flash  + oauth
Rung 6: gemini-cli  2.5-pro + api
Rung 7: gemini-cli  2.5-pro + oauth
```

## Implementation shape (Shape A — codex's choice)

Extended `GeminiRung` with a `cli` dimension instead of building an outer wrapper. Keeps retry/history accounting in one ordered ladder; avoids splitting attempt records across multiple calls.

- `scripts/ai_llm/fallback.py`: added `AGY_GEMINI_MODEL`, extended `GeminiRung` + `CallResult`, builder + runner now route to agy via runtime adapter.
- `scripts/agent_runtime/runner.py`: `_invoke_gemini_with_fallback` extended to handle the agy rung via `AgyAdapter` (not through bridge `ask_agy` which writes to broker DB). Falls through gracefully if agy adapter `_load_adapter()` errors before subprocess spawn (per gemini review pushback).
- `tests/test_gemini_fallback_agy.py` (new): ladder shape + fallthrough cases.
- `tests/test_ai_llm_fallback.py`, `tests/test_gemini_adapter_auth.py`: adaptations for the new `cli` dimension.

## Anti-fabrication evidence

```
$ .venv/bin/pytest tests/test_gemini_fallback_agy.py tests/test_ai_llm_fallback.py tests/test_gemini_adapter_auth.py -q --no-header
68 passed in 0.22s

$ .venv/bin/pytest tests/test_agent_runtime*.py tests/agent_runtime/ tests/test_gemini_fallback_agy.py tests/test_ai_llm_fallback.py
253 passed, 1 failure on test_cursor_entry_is_well_formed (PRE-EXISTING on
origin/main, unrelated — verified by stashing the diff and re-running).

$ .venv/bin/ruff check scripts/ai_llm/ scripts/agent_runtime/
All checks passed!
```

## Dispatch completion note

This work was dispatched to Codex (task `agy-ladder-rung-2026-05-27`, issue #2373). The dispatch's silence_timeout fired at ~40 min while codex was iterating on gemini-review findings; the worktree held uncommitted work. The orchestrator (Claude) verified the diff was clean + tests pass + ruff clean, then committed/pushed/opened this PR on codex's behalf. The substantive design + implementation is all codex's; the orchestrator only did the commit/push/PR completion steps from the dispatch brief's numbered execution plan.

## Test plan

- [ ] Review the new ladder order in `build_gemini_ladder`.
- [ ] Confirm `_invoke_gemini_with_fallback` routes the agy rung through the runtime `AgyAdapter` (not through the bridge `_agy.ask_agy`).
- [ ] Confirm fallthrough on agy adapter load failure.
- [ ] Review `tests/test_gemini_fallback_agy.py` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code) for codex