### PR TITLE
fix(cursor): default model auto, not composer-2.5

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -50,7 +50,7 @@ class CursorAdapter:
     """Adapter for the Cursor agent CLI (``agent`` or ``cursor-agent``)."""
 
     name: str = "cursor"
-    default_model: str = "composer-2.5"
+    default_model: str = "auto"
     supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
 
     def build_invocation(

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -139,7 +139,7 @@ AGENTS: dict[str, AgentEntry] = {
     },
     "cursor": {
         "adapter": "scripts.agent_runtime.adapters.cursor:CursorAdapter",
-        "default_model": "composer-2.5",
+        "default_model": "auto",
         "cost_tier": "low",
         "capabilities": frozenset({
             "content_writing",

--- a/scripts/ai_agent_bridge/_cursor.py
+++ b/scripts/ai_agent_bridge/_cursor.py
@@ -5,7 +5,12 @@ and single-shot reads through Cursor's Composer or other models.
 
 Invocation pattern:
     .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-cursor <content> \
-      --task-id <task> --model composer-2.5 [--data FILE]
+      --task-id <task> [--model composer-2.5] [--data FILE]
+
+Default model is ``auto`` so cursor-agent picks the best available model from
+the user's plan without burning the per-model composer-2.5 quota. Pass
+``--model composer-2.5`` explicitly only when you specifically need that model
+(e.g. judge-calibration runs or A/B comparisons).
 
 Under the hood: agent -p PROMPT --model MODEL --output-format text --trust
 """
@@ -18,7 +23,7 @@ from pathlib import Path
 
 from ._messaging import acknowledge, send_message
 
-CURSOR_DEFAULT_MODEL = "composer-2.5"
+CURSOR_DEFAULT_MODEL = "auto"
 CURSOR_DEFAULT_TIMEOUT_S = 900
 
 

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -36,7 +36,11 @@ def test_cursor_adapter_build_invocation_read_only(adapter, tmp_path, monkeypatc
     # the real prompt on stdin to be ignored. Prompt delivery is stdin-only.
     assert "-" not in plan.cmd
     assert "--model" in plan.cmd
-    assert "composer-2.5" in plan.cmd
+    # Default flipped from "composer-2.5" to "auto" (2026-05-28). cursor-agent
+    # picks the best available model from the user's plan rather than burning
+    # the per-model composer-2.5 quota every call. Pass an explicit
+    # `model="composer-2.5"` only when that specific model is required.
+    assert "auto" in plan.cmd
     assert "--mode" in plan.cmd
     assert "ask" in plan.cmd
     assert "--trust" in plan.cmd

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -183,9 +183,12 @@ def test_registry_has_known_agents():
 def test_cursor_entry_is_well_formed():
     entry = get_agent_entry("cursor")
     assert entry["adapter"] == "scripts.agent_runtime.adapters.cursor:CursorAdapter"
-    assert entry["default_model"] == "composer-2.5"
+    # Default flipped from "composer-2.5" to "auto" so cursor-agent picks the
+    # best available model from the user's plan instead of burning the
+    # per-model composer-2.5 quota every call.
+    assert entry["default_model"] == "auto"
     assert entry["cli_available"] is True
-    assert entry["resume_policy"] == "never"
+    assert entry["resume_policy"] == "bridge_only"
     assert {"content_writing", "content_review", "adversarial_review"} <= entry["capabilities"]
 
 
@@ -235,7 +238,7 @@ def test_load_adapter_codex():
 def test_load_adapter_cursor():
     adapter = _load_adapter("cursor")
     assert adapter.name == "cursor"
-    assert adapter.default_model == "composer-2.5"
+    assert adapter.default_model == "auto"
     assert adapter.supported_modes == frozenset({"read-only", "workspace-write", "danger"})
 
 

--- a/tests/test_ask_cursor.py
+++ b/tests/test_ask_cursor.py
@@ -7,8 +7,12 @@ import pytest
 from scripts.ai_agent_bridge._cursor import CURSOR_DEFAULT_MODEL, _invoke_cursor
 
 
-def test_cursor_default_model_is_composer_2_5():
-    assert CURSOR_DEFAULT_MODEL == "composer-2.5"
+def test_cursor_default_model_is_auto():
+    # Cursor's default model is "auto" so cursor-agent picks the best available
+    # model from the user's plan without burning the per-model composer-2.5
+    # quota. Pass `--model composer-2.5` explicitly only when you specifically
+    # need that model (judge-calibration, A/B comparisons, etc.).
+    assert CURSOR_DEFAULT_MODEL == "auto"
 
 
 def test_invoke_cursor_constructs_correct_argv():


### PR DESCRIPTION
## Summary
- Flip cursor's default model from `composer-2.5` → `auto` in three places (bridge `_cursor.py`, runtime `registry.py`, adapter `cursor.py`)
- Tests + commit message + module docstring explain why composer-2.5 was the wrong default
- Drive-by fix: stale `resume_policy == "never"` assertion in `test_cursor_entry_is_well_formed` (registry says `bridge_only`)

## Why

Pt 11's `wiki-driven-writer-pivot` consultation hit `cursor/composer-2.5 rate limited` on the first cursor fire. That's because composer-2.5 has its own per-model sliding-window quota separate from cursor-agent's general `auto` pool. A re-fire with `model=auto` went through and produced the full r1 reply that's now in the merged V7.1 ADR (PR #2374).

User direction 2026-05-28:
> we should use model=auto for everyrhing by default for cursor unless we really want to ask the composer 2.5 model

## What stays composer-2.5 (intentionally)
- `scripts/audit/cursor_judge_calibration.py` — composer-2.5 is the evaluation target
- `scripts/build/linear_pipeline.py:85` `cursor-tools` V7 writer config — explicit writer/reviewer pair
- All callers that pass `--model composer-2.5` explicitly

## Test plan
- [x] `pytest tests/test_ask_cursor.py tests/test_agent_runtime.py tests/agent_runtime/` → 219 passed
- [x] `ruff check` → All checks passed
- [ ] CI green (blocking checks only — review/review is advisory per #M-0.5)
- [ ] After merge, `ab ask-cursor` and `delegate.py --agent cursor` default to `auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)