### PR TITLE
feat(v7.1): wiki_completeness_gate + layered vocab allowlist + manifest vocab_minimum

### DIFF
--- a/scripts/audit/checks/learner_state.py
+++ b/scripts/audit/checks/learner_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,126 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - CLI path compatibility
     from config import get_immersion_structural
     from pipeline.learner_state import build_learner_state
+
+VerifyWordsFn = Callable[[list[str]], dict[str, list[dict[str, Any]]]]
+
+# Closed-class words are grammatical glue: learners need them to parse A1 prose,
+# but they should not be treated like newly introduced content vocabulary.
+CLOSED_CLASS_FUNCTION_WORDS = frozenset(
+    {
+        # Personal and demonstrative pronouns: high-frequency reference words.
+        "я",
+        "ти",
+        "він",
+        "вона",
+        "воно",
+        "ми",
+        "ви",
+        "вони",
+        "мене",
+        "тебе",
+        "його",
+        "її",
+        "нас",
+        "вас",
+        "їх",
+        "мені",
+        "тобі",
+        "собі",
+        "мій",
+        "твій",
+        "свій",
+        "цей",
+        "ця",
+        "це",
+        "ці",
+        "той",
+        "та",
+        "те",
+        "ті",
+        # Prepositions: small relational words, not topical content lemmas.
+        "у",
+        "в",
+        "на",
+        "з",
+        "із",
+        "зі",
+        "до",
+        "від",
+        "для",
+        "без",
+        "за",
+        "під",
+        "над",
+        "перед",
+        "після",
+        "між",
+        "біля",
+        "через",
+        "про",
+        "при",
+        # Conjunctions and discourse connectors needed for basic clauses.
+        "і",
+        "й",
+        "але",
+        "що",
+        "як",
+        "тому",
+        "бо",
+        "або",
+        "чи",
+        "якщо",
+        "коли",
+        "поки",
+        "щоб",
+        # Particles and deictics: frequent scaffolding tokens.
+        "не",
+        "ні",
+        "же",
+        "ж",
+        "ось",
+        "тут",
+        "там",
+        "ще",
+        "вже",
+        "лише",
+        "тільки",
+        "саме",
+        # Interrogatives support A1 question formation and comprehension.
+        "де",
+        "куди",
+        "звідки",
+        "чому",
+        "чого",
+        "хто",
+        "який",
+        "яка",
+        "яке",
+        "які",
+        "скільки",
+        # Closed small numerals are common in schedules, ages, and exercise items.
+        "один",
+        "одна",
+        "одне",
+        "два",
+        "дві",
+        "три",
+        "чотири",
+        "п'ять",
+        "шість",
+        "сім",
+        "вісім",
+        "дев'ять",
+        "десять",
+        # Modal predicates are classroom-workhorse words across A1/A2 tasks.
+        "можна",
+        "треба",
+        "потрібно",
+    }
+)
+
+CONTENT_POS_PREFIXES = ("noun", "verb", "adj")
+NON_CONTENT_POS_PREFIXES = ("prep", "conj", "part", "pron", "num", "advp", "intj")
 
 
 def _vesum_helpers():
@@ -81,6 +202,254 @@ def _load_declared_vocab(module_dir: str | Path | None) -> set[str]:
     }
 
 
+def _load_json_or_yaml(path: Path) -> Any:
+    if not path.exists():
+        return None
+    try:
+        if path.suffix == ".json":
+            import json
+
+            return json.loads(path.read_text(encoding="utf-8"))
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _load_plan_for_module(module_dir: str | Path | None, level: str) -> Mapping[str, Any] | None:
+    if module_dir is None:
+        return None
+    path = Path(module_dir)
+    slug = path.name
+    plan_path = path.parents[1] / "plans" / level.lower() / f"{slug}.yaml" if len(path.parents) > 1 else None
+    if plan_path is None or not plan_path.exists():
+        plan_path = Path(__file__).resolve().parents[3] / "curriculum" / "l2-uk-en" / "plans" / level.lower() / f"{slug}.yaml"
+    data = _load_json_or_yaml(plan_path)
+    return data if isinstance(data, Mapping) else None
+
+
+def _load_wiki_manifest_for_module(module_dir: str | Path | None) -> Mapping[str, Any] | None:
+    if module_dir is None:
+        return None
+    data = _load_json_or_yaml(Path(module_dir) / "wiki_manifest.json")
+    return data if isinstance(data, Mapping) else None
+
+
+def _load_wiki_text_from_manifest(wiki_manifest: Mapping[str, Any] | None) -> str:
+    if not wiki_manifest:
+        return ""
+    raw_path = str(wiki_manifest.get("wiki_path") or "").split(";", 1)[0].strip()
+    if not raw_path:
+        return ""
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = Path(__file__).resolve().parents[3] / path
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _plan_vocab_entries(plan: Mapping[str, Any] | None, source: str) -> set[str]:
+    if not isinstance(plan, Mapping):
+        return set()
+    entries: set[str] = set()
+
+    def add_entry(entry: Any) -> None:
+        raw: str | None = None
+        if isinstance(entry, str):
+            raw = entry
+        elif isinstance(entry, Mapping):
+            for key in ("lemma", "word", "term", "text", "value"):
+                value = entry.get(key)
+                if isinstance(value, str):
+                    raw = value
+                    break
+        if raw:
+            lemma = re.split(r"\s+\(|\s+[—–-]\s+", raw, maxsplit=1)[0].strip()
+            if lemma:
+                entries.add(lemma)
+
+    if source == "new_vocabulary":
+        targets = plan.get("targets")
+        if isinstance(targets, Mapping):
+            for entry in targets.get("new_vocabulary", []) or []:
+                add_entry(entry)
+        return entries
+
+    hints = plan.get("vocabulary_hints")
+    if isinstance(hints, Mapping):
+        for key in ("required", "recommended"):
+            for entry in hints.get(key, []) or []:
+                add_entry(entry)
+    elif isinstance(hints, list):
+        for entry in hints:
+            add_entry(entry)
+    return entries
+
+
+def _wiki_vocabulary_entries(wiki_manifest: Mapping[str, Any] | None) -> set[str]:
+    if not isinstance(wiki_manifest, Mapping):
+        return set()
+    return {
+        str(item.get("lemma") or "").strip()
+        for item in wiki_manifest.get("wiki_vocabulary_minimum", []) or []
+        if isinstance(item, Mapping) and str(item.get("lemma") or "").strip()
+    }
+
+
+def _extract_bad_form_surfaces(*texts: str) -> set[str]:
+    surfaces: set[str] = set()
+    for text in texts:
+        for match in re.finditer(r"<!--\s*bad\s*-->(.*?)<!--\s*/bad\s*-->", text, flags=re.IGNORECASE | re.DOTALL):
+            surfaces.update(_extract_ukrainian_surfaces(match.group(1)))
+    return surfaces
+
+
+def _extract_quoted_evidence_surfaces(content: str) -> set[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in content.splitlines():
+        if line.lstrip().startswith(">"):
+            current.append(re.sub(r"^\s*>\s?", "", line))
+            continue
+        if current:
+            blocks.append("\n".join(current))
+            current = []
+    if current:
+        blocks.append("\n".join(current))
+    surfaces: set[str] = set()
+    for block in blocks:
+        if re.search(r"\[S\d+\]", block):
+            surfaces.update(_extract_ukrainian_surfaces(block))
+    return surfaces
+
+
+def _extract_proper_noun_surfaces(wiki_text: str) -> set[str]:
+    surfaces: set[str] = set()
+    for match in re.finditer(r"\b[А-ЯІЇЄҐ][а-яіїєґ]+(?:[-'’ʼ][А-ЯІЇЄҐа-яіїєґ]+)?\b", wiki_text):
+        token = match.group(0)
+        line_start = wiki_text.rfind("\n", 0, match.start()) + 1
+        prefix = wiki_text[line_start:match.start()].strip()
+        if not prefix or prefix.startswith("#"):
+            continue
+        surfaces.add(token.lower())
+    return surfaces
+
+
+def _verify_words(words: list[str], verify_words_fn: VerifyWordsFn | None) -> dict[str, list[dict[str, Any]]]:
+    if not words:
+        return {}
+    if verify_words_fn is None:
+        try:
+            from scripts.verification.vesum import verify_words as verify_words_fn
+        except Exception:
+            return {word: [] for word in words}
+    try:
+        return verify_words_fn(words)
+    except Exception:
+        return {word: [] for word in words}
+
+
+def _normalize_key(value: str) -> str:
+    _, _normalize_for_vesum = _vesum_helpers()
+    return _normalize_for_vesum(value).lower()
+
+
+def _choose_vesum_match(matches: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not matches:
+        return None
+    for prefix in CONTENT_POS_PREFIXES:
+        for match in matches:
+            if str(match.get("pos") or "").lower().startswith(prefix):
+                return match
+    return matches[0]
+
+
+def _surface_records(
+    surfaces: list[str] | set[str],
+    verify_words_fn: VerifyWordsFn | None,
+) -> list[dict[str, str | None]]:
+    ordered = sorted({_normalize_key(surface) for surface in surfaces if str(surface).strip()})
+    matches_by_word = _verify_words(ordered, verify_words_fn)
+    records: list[dict[str, str | None]] = []
+    for surface in ordered:
+        match = _choose_vesum_match(matches_by_word.get(surface, []))
+        lemma = _normalize_key(str(match.get("lemma"))) if match and match.get("lemma") else surface
+        pos = str(match.get("pos")) if match and match.get("pos") else None
+        records.append({"surface": surface, "lemma": lemma, "pos": pos})
+    return records
+
+
+def _normalize_entry_set(
+    entries: set[str],
+    verify_words_fn: VerifyWordsFn | None,
+) -> set[str]:
+    surfaces: set[str] = set()
+    for entry in entries:
+        surfaces.update(_extract_ukrainian_surfaces(entry))
+    return {str(record["lemma"]) for record in _surface_records(surfaces, verify_words_fn)}
+
+
+def build_layered_allowlist(
+    *,
+    level: str,
+    module_num: int,
+    module_dir: str | Path | None = None,
+    wiki_manifest: Mapping[str, Any] | None = None,
+    plan: Mapping[str, Any] | None = None,
+    wiki_text: str = "",
+    content: str = "",
+    verify_words_fn: VerifyWordsFn | None = None,
+) -> dict[str, set[str]]:
+    """Build the V7.1 layered vocabulary allowlist by source."""
+    level_key = level.lower()
+    manifest = wiki_manifest or _load_wiki_manifest_for_module(module_dir)
+    plan_data = plan or _load_plan_for_module(module_dir, level_key)
+    wiki_source_text = wiki_text or _load_wiki_text_from_manifest(manifest)
+    learner_state = build_learner_state(level_key, module_num)
+
+    sources = {
+        "wiki_vocabulary_minimum": _normalize_entry_set(_wiki_vocabulary_entries(manifest), verify_words_fn),
+        "plan_new_vocabulary": _normalize_entry_set(_plan_vocab_entries(plan_data, "new_vocabulary"), verify_words_fn),
+        "plan_vocabulary_hints": _normalize_entry_set(_plan_vocab_entries(plan_data, "vocabulary_hints"), verify_words_fn),
+        "cumulative_learner_state": _normalize_entry_set(
+            {str(lemma) for lemma in learner_state.get("cumulative_vocabulary", []) if lemma},
+            verify_words_fn,
+        ),
+        "closed_class_function_words": _normalize_entry_set(set(CLOSED_CLASS_FUNCTION_WORDS), verify_words_fn),
+        "proper_nouns_in_wiki_examples": _extract_proper_noun_surfaces(wiki_source_text),
+        "bad_form_markers": _normalize_entry_set(
+            _extract_bad_form_surfaces(wiki_source_text, content),
+            verify_words_fn,
+        ),
+        "quoted_evidence_from_cited_rag_chunks": _normalize_entry_set(
+            _extract_quoted_evidence_surfaces(content),
+            verify_words_fn,
+        ),
+    }
+    legacy_vocab = _load_declared_vocab(module_dir)
+    if legacy_vocab:
+        sources["legacy_module_vocabulary"] = _normalize_entry_set(legacy_vocab, verify_words_fn)
+    sources["_allowed_lemmas"] = set().union(
+        *(
+            value
+            for key, value in sources.items()
+            if key not in {"proper_nouns_in_wiki_examples"}
+        )
+    )
+    sources["_allowed_surfaces"] = set(sources["proper_nouns_in_wiki_examples"])
+    return sources
+
+
+def _is_content_pos(pos: str | None) -> bool:
+    if pos is None:
+        return True
+    pos_key = pos.lower()
+    if pos_key.startswith(CONTENT_POS_PREFIXES):
+        return True
+    return not pos_key.startswith(NON_CONTENT_POS_PREFIXES)
+
+
 def _unknown_vocab_severity(module_num: int) -> str:
     return "WARN" if module_num <= 3 else "HARD"
 
@@ -99,34 +468,72 @@ def check_unknown_vocabulary(
     level: str,
     module_num: int,
     module_dir: str | Path | None = None,
+    *,
+    wiki_manifest: Mapping[str, Any] | None = None,
+    plan: Mapping[str, Any] | None = None,
+    wiki_text: str = "",
+    max_unsupported: int | None = None,
+    verify_words_fn: VerifyWordsFn | None = None,
 ) -> list[dict[str, Any]]:
-    """Flag Ukrainian prose words outside learner-state and module vocabulary."""
-    learner_state = build_learner_state(level.lower(), module_num)
-    allowed = {
-        str(lemma).lower()
-        for lemma in learner_state.get("cumulative_vocabulary", [])
-        if lemma
-    }
-    allowed.update(_load_declared_vocab(module_dir))
-
-    unknown = [word for word in _extract_ukrainian_surfaces(content) if word not in allowed]
-    tolerance = _unsupported_tolerance(level, module_num)
-    if len(unknown) <= tolerance:
+    """Flag Ukrainian prose lemmas outside the V7.1 layered allowlist."""
+    allowlist = build_layered_allowlist(
+        level=level,
+        module_num=module_num,
+        module_dir=module_dir,
+        wiki_manifest=wiki_manifest,
+        plan=plan,
+        wiki_text=wiki_text,
+        content=content,
+        verify_words_fn=verify_words_fn,
+    )
+    allowed_lemmas = allowlist["_allowed_lemmas"]
+    allowed_surfaces = allowlist["_allowed_surfaces"]
+    records = _surface_records(_extract_ukrainian_surfaces(content), verify_words_fn)
+    unsupported = [
+        record
+        for record in records
+        if str(record["lemma"]) not in allowed_lemmas
+        and str(record["surface"]) not in allowed_surfaces
+    ]
+    tolerance = _unsupported_tolerance(level, module_num) if max_unsupported is None else max_unsupported
+    if len(unsupported) <= tolerance:
         return []
 
     severity = _unknown_vocab_severity(module_num)
+    content_unsupported = [
+        record
+        for record in unsupported
+        if _is_content_pos(record.get("pos"))
+    ]
+    if not content_unsupported:
+        return [
+            {
+                "type": "unknown_vocabulary_band",
+                "severity": severity,
+                "lemma": None,
+                "unsupported_count": len(unsupported),
+                "tolerance": tolerance,
+                "issue": (
+                    f"Unsupported Ukrainian function/edge tokens exceed the band "
+                    f"({len(unsupported)} > {tolerance})."
+                ),
+                "fix": "Expand the closed-class allowlist or rewrite the prose with taught vocabulary.",
+            }
+        ]
     return [
         {
             "type": "unknown_vocabulary",
             "severity": severity,
-            "lemma": word,
+            "lemma": str(record["lemma"]),
+            "surface": str(record["surface"]),
+            "pos": record.get("pos"),
             "issue": (
-                f"Ukrainian lemma '{word}' is not in cumulative learner state "
-                "or this module's vocabulary.yaml."
+                f"Ukrainian lemma '{record['lemma']}' is not in the V7.1 "
+                "wiki/plan/cumulative/closed-class layered allowlist."
             ),
-            "fix": "Add the lemma to vocabulary.yaml or rewrite the prose with taught vocabulary.",
+            "fix": "Add the lemma to the wiki vocabulary minimum or plan vocabulary, or rewrite the prose.",
         }
-        for word in unknown
+        for record in content_unsupported
     ]
 
 
@@ -175,9 +582,23 @@ def check_learner_state(
     level: str,
     module_num: int,
     module_dir: str | Path | None = None,
+    *,
+    wiki_manifest: Mapping[str, Any] | None = None,
+    plan: Mapping[str, Any] | None = None,
+    wiki_text: str = "",
+    verify_words_fn: VerifyWordsFn | None = None,
 ) -> list[dict[str, Any]]:
     """Run all learner-state checks for a module."""
     return [
-        *check_unknown_vocabulary(content, level, module_num, module_dir),
+        *check_unknown_vocabulary(
+            content,
+            level,
+            module_num,
+            module_dir,
+            wiki_manifest=wiki_manifest,
+            plan=plan,
+            wiki_text=wiki_text,
+            verify_words_fn=verify_words_fn,
+        ),
         *check_known_grammar_re_explanation(content, level, module_num),
     ]

--- a/scripts/audit/wiki_completeness_gate.py
+++ b/scripts/audit/wiki_completeness_gate.py
@@ -1,0 +1,352 @@
+"""Upstream wiki completeness gate for V7.1 writer builds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.build.phases.wiki_manifest import extract_manifest
+
+CORE_LEVELS = frozenset({"a1", "a2", "b1", "b2", "c1", "c2"})
+SEMINAR_LEVELS = frozenset(
+    {
+        "hist",
+        "istorio",
+        "bio",
+        "lit",
+        "lit-essay",
+        "lit-hist-fic",
+        "lit-fantastika",
+        "lit-war",
+        "lit-humor",
+        "lit-youth",
+        "lit-doc",
+        "lit-drama",
+        "lit-crimea",
+        "oes",
+        "ruth",
+    }
+)
+
+METHODOLOGY_HEADING_RE = re.compile(r"^##\s+Методичний\s+підхід\b", re.IGNORECASE)
+DECOLONIZATION_HEADING_RE = re.compile(r"^##\s+Деколонізаційні\s+застереження\b", re.IGNORECASE)
+TEXTBOOK_EXAMPLES_HEADING_RE = re.compile(r"^##\s+Приклади\s+з\s+підручників\b", re.IGNORECASE)
+ANY_H2_RE = re.compile(r"^##\s+\S")
+SOURCE_REF_RE = re.compile(r"\[S(?P<num>\d+)\]")
+BAD_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(?P<body>.*?)<!--\s*/bad\s*-->", re.IGNORECASE | re.DOTALL)
+GUILLEMET_NEGATED_PAIR_RE = re.compile(r"«[^»\n]{1,120}»\s*\(\s*не\s+«[^»\n]{1,120}»\s*\)", re.IGNORECASE)
+UKRAINIAN_RE = re.compile(r"[А-Яа-яІіЇїЄєҐґ]")
+
+CHECK_TITLES = {
+    "methodology": "Методичний підхід",
+    "sequence_steps": "Послідовність введення",
+    "l2_errors": "Типові помилки L2",
+    "decolonization_pairs": "Деколонізаційні застереження",
+    "vocabulary_minimum": "Словниковий мінімум",
+    "textbook_exercises": "Приклади з підручників",
+    "distractor_inventory": "distractor_inventory",
+    "chunk_citations_spot_check": "chunk_citations_spot_check",
+}
+CHECK_ORDER = tuple(CHECK_TITLES)
+
+
+def thresholds_for_level(level: str) -> dict[str, int]:
+    """Return V7.1 wiki completeness thresholds for implemented core levels."""
+    level_key = level.lower()
+    if level_key in SEMINAR_LEVELS:
+        # Seminar checks need all-chunk verification, URL resolution, and a
+        # claim/source registry. That infrastructure is intentionally deferred
+        # to the separate seminar ADR called out in the V7.1 decision.
+        raise NotImplementedError(
+            "Seminar wiki completeness checks are deferred pending all-chunk "
+            "verify_quote, URL resolution, and two-source-rule infrastructure."
+        )
+    if level_key not in CORE_LEVELS:
+        raise ValueError(f"Unknown level for wiki completeness gate: {level!r}")
+    if level_key in {"a1", "a2"}:
+        return {
+            "sequence_steps": 5,
+            "l2_errors": 3,
+            "decolonization_pairs": 1,
+            "vocabulary_minimum": 20,
+            "textbook_exercises": 3,
+            "distractor_inventory": 6,
+            "chunk_citations_spot_check": 3,
+        }
+    return {
+        "sequence_steps": 5,
+        "l2_errors": 3,
+        "decolonization_pairs": 2,
+        "vocabulary_minimum": 50,
+        "textbook_exercises": 3,
+        "distractor_inventory": 10,
+        "chunk_citations_spot_check": 5,
+    }
+
+
+def check_wiki_completeness(
+    wiki_path: str | Path,
+    *,
+    level: str,
+    slug: str | None = None,
+    verify_quote_fn: Callable[[str, str, Mapping[str, Any]], Mapping[str, Any] | bool] | None = None,
+) -> dict[str, Any]:
+    """Return a JSON-serializable PASS/FAIL report for one compiled wiki."""
+    path = Path(wiki_path)
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    manifest = extract_manifest(path)
+    slug_value = slug or str(manifest.get("slug") or path.stem)
+    level_key = level.lower()
+    thresholds = thresholds_for_level(level_key)
+
+    methodology_text = _section_text(lines, METHODOLOGY_HEADING_RE)
+    decolonization_text = _section_text(lines, DECOLONIZATION_HEADING_RE)
+    textbook_text = _section_text(lines, TEXTBOOK_EXAMPLES_HEADING_RE)
+
+    decolonization_pairs = _count_decolonization_pairs(decolonization_text)
+    l2_distractors = _count_l2_distractors(manifest.get("l2_errors", []))
+    decolonization_distractors = _count_decolonization_distractors(decolonization_text)
+
+    checks = {
+        "methodology": _section_presence_check(methodology_text, "Methodology section is non-empty."),
+        "sequence_steps": _minimum_check(
+            len(manifest.get("sequence_steps", [])),
+            thresholds["sequence_steps"],
+            "sequence step(s) found in ## Послідовність введення.",
+        ),
+        "l2_errors": _minimum_check(
+            len(manifest.get("l2_errors", [])),
+            thresholds["l2_errors"],
+            "L2 error table row(s) found.",
+        ),
+        "decolonization_pairs": _minimum_check(
+            decolonization_pairs,
+            thresholds["decolonization_pairs"],
+            "decolonization bad-form pair(s) found.",
+        ),
+        "vocabulary_minimum": _minimum_check(
+            len(manifest.get("wiki_vocabulary_minimum", [])),
+            thresholds["vocabulary_minimum"],
+            "wiki vocabulary-minimum lemma(s) found.",
+        ),
+        "textbook_exercises": _minimum_check(
+            _count_textbook_exercises(textbook_text),
+            thresholds["textbook_exercises"],
+            "textbook exercise format(s) with chunk citations found.",
+        ),
+        "distractor_inventory": _minimum_check(
+            l2_distractors + decolonization_distractors,
+            thresholds["distractor_inventory"],
+            "wrong-form distractor(s) found across L2 errors and decolonization pairs.",
+        ),
+        "chunk_citations_spot_check": _chunk_citation_check(
+            text,
+            path,
+            thresholds["chunk_citations_spot_check"],
+            verify_quote_fn=verify_quote_fn,
+        ),
+    }
+
+    failed = [name for name in CHECK_ORDER if checks[name]["verdict"] == "FAIL"]
+    return {
+        "verdict": "FAIL" if failed else "PASS",
+        "level": level_key,
+        "slug": slug_value,
+        "checks": checks,
+        "diagnostic": _diagnostic(failed[0], checks[failed[0]]) if failed else "Wiki completeness gate passed.",
+    }
+
+
+def _section_presence_check(section_text: str, detail: str) -> dict[str, Any]:
+    if section_text.strip():
+        return {"verdict": "PASS", "detail": detail}
+    return {"verdict": "FAIL", "actual": 0, "minimum": 1, "detail": "section missing or empty"}
+
+
+def _minimum_check(actual: int, minimum: int, detail: str) -> dict[str, Any]:
+    verdict = "PASS" if actual >= minimum else "FAIL"
+    return {"verdict": verdict, "actual": actual, "minimum": minimum, "detail": detail}
+
+
+def _diagnostic(check_name: str, check: Mapping[str, Any]) -> str:
+    title = CHECK_TITLES.get(check_name, check_name)
+    actual = check.get("actual")
+    minimum = check.get("minimum")
+    if actual is not None and minimum is not None:
+        return f"Wiki section [{title}] is insufficient ({actual} < {minimum})."
+    return f"Wiki section [{title}] is missing or incomplete."
+
+
+def _section_text(lines: list[str], heading_re: re.Pattern[str]) -> str:
+    start = None
+    for index, line in enumerate(lines):
+        if heading_re.search(line):
+            start = index
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if ANY_H2_RE.search(lines[index]):
+            end = index
+            break
+    return "\n".join(lines[start + 1 : end]).strip()
+
+
+def _count_decolonization_pairs(section_text: str) -> int:
+    marked = len(BAD_MARKER_RE.findall(section_text))
+    explicit = len(GUILLEMET_NEGATED_PAIR_RE.findall(section_text))
+    return marked + explicit
+
+
+def _count_decolonization_distractors(section_text: str) -> int:
+    return _count_decolonization_pairs(section_text)
+
+
+def _count_l2_distractors(raw_errors: Any) -> int:
+    if not isinstance(raw_errors, list):
+        return 0
+    count = 0
+    for error in raw_errors:
+        if not isinstance(error, Mapping):
+            continue
+        incorrect = str(error.get("incorrect") or "")
+        parts = [part.strip() for part in re.split(r"\s*/\s*|\s*;\s*", incorrect) if part.strip()]
+        count += sum(1 for part in parts if UKRAINIAN_RE.search(part) or "[" in part)
+    return count
+
+
+def _count_textbook_exercises(section_text: str) -> int:
+    count = 0
+    blocks = re.split(r"(?=^\*\*Вправа\s+\d+\b)", section_text, flags=re.MULTILINE)
+    for block in blocks:
+        if not block.lstrip().startswith("**Вправа"):
+            continue
+        if re.search(r"Chunk ID\s*:", block, flags=re.IGNORECASE) and SOURCE_REF_RE.search(block):
+            count += 1
+    return count
+
+
+def _chunk_citation_check(
+    wiki_text: str,
+    wiki_path: Path,
+    sample_size: int,
+    *,
+    verify_quote_fn: Callable[[str, str, Mapping[str, Any]], Mapping[str, Any] | bool] | None,
+) -> dict[str, Any]:
+    citations = _ordered_source_ids(wiki_text)
+    selected = citations[: min(sample_size, len(citations))]
+    if len(selected) < sample_size:
+        return {
+            "verdict": "FAIL",
+            "actual": len(selected),
+            "minimum": sample_size,
+            "detail": f"{len(selected)}/{sample_size} chunk citations available for spot-check",
+        }
+
+    sources = _load_source_registry(wiki_path)
+    passed = 0
+    failures: list[str] = []
+    for source_id in selected:
+        source = sources.get(source_id, {})
+        if verify_quote_fn is None:
+            if source:
+                passed += 1
+            else:
+                failures.append(source_id)
+            continue
+        result = verify_quote_fn(source_id, _citation_context(wiki_text, source_id), source)
+        if _verification_passed(result):
+            passed += 1
+        else:
+            failures.append(source_id)
+
+    if verify_quote_fn is None:
+        detail = f"{passed}/{len(selected)} source registry ids resolved (verify_quote adapter not configured)"
+    else:
+        detail = f"{passed}/{len(selected)} verify_quote returned PASS"
+    verdict = "PASS" if passed == len(selected) else "FAIL"
+    report: dict[str, Any] = {"verdict": verdict, "detail": detail}
+    if verdict == "FAIL":
+        report.update({"actual": passed, "minimum": len(selected), "failures": failures})
+    return report
+
+
+def _ordered_source_ids(text: str) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for match in SOURCE_REF_RE.finditer(text):
+        source_id = f"S{match.group('num')}"
+        if source_id not in seen:
+            seen.add(source_id)
+            ordered.append(source_id)
+    return ordered
+
+
+def _load_source_registry(wiki_path: Path) -> dict[str, Mapping[str, Any]]:
+    registry_path = wiki_path.with_suffix(".sources.yaml")
+    if not registry_path.exists():
+        return {}
+    data = yaml.safe_load(registry_path.read_text(encoding="utf-8")) or {}
+    sources = data.get("sources", []) if isinstance(data, Mapping) else []
+    out: dict[str, Mapping[str, Any]] = {}
+    if isinstance(sources, list):
+        for item in sources:
+            if isinstance(item, Mapping) and item.get("id"):
+                out[str(item["id"])] = item
+    return out
+
+
+def _citation_context(text: str, source_id: str) -> str:
+    match = re.search(rf"[^.\n]*\[{re.escape(source_id)}\][^.\n]*", text)
+    return re.sub(r"\s+", " ", match.group(0)).strip() if match else source_id
+
+
+def _verification_passed(result: Mapping[str, Any] | bool) -> bool:
+    if isinstance(result, bool):
+        return result
+    if not isinstance(result, Mapping):
+        return False
+    verdict = result.get("verdict", result.get("passed", result.get("ok")))
+    if isinstance(verdict, bool):
+        return verdict
+    return str(verdict).upper() == "PASS"
+
+
+def _default_wiki_path(level: str, slug: str) -> Path:
+    direct = PROJECT_ROOT / "wiki" / "pedagogy" / level.lower() / f"{slug}.md"
+    if direct.exists():
+        return direct
+    matches = sorted((PROJECT_ROOT / "wiki").glob(f"**/{slug}.md"))
+    if not matches:
+        raise FileNotFoundError(f"No wiki article found for level={level!r}, slug={slug!r}")
+    return matches[0]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the V7.1 wiki completeness gate")
+    parser.add_argument("level")
+    parser.add_argument("slug")
+    parser.add_argument("--wiki-path", type=Path)
+    args = parser.parse_args(argv)
+
+    wiki_path = args.wiki_path or _default_wiki_path(args.level, args.slug)
+    report = check_wiki_completeness(wiki_path, level=args.level, slug=args.slug)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -920,12 +920,14 @@ def build_wiki_manifest_data(
             "l2_errors",
             "phonetic_rules",
             "decolonization_bans",
+            "wiki_vocabulary_minimum",
         ):
             merged.setdefault(key, [])
             for item in manifest.get(key, []):
                 copied = dict(item)
                 prefix = str(copied.get("id") or "").split("-", 1)[0] or key[:4]
-                copied["id"] = f"{prefix}-{len(merged[key]) + 1}"
+                if "id" in copied:
+                    copied["id"] = f"{prefix}-{len(merged[key]) + 1}"
                 merged[key].append(copied)
         merged.setdefault("external_resources", [])
         merged["external_resources"].extend(manifest.get("external_resources", []))
@@ -933,6 +935,43 @@ def build_wiki_manifest_data(
     if merged is not None:
         validate_manifest(merged)
     return merged or {}
+
+
+def run_wiki_completeness_gate(
+    *,
+    level: str,
+    slug: str,
+    wiki_manifest: Mapping[str, Any] | str | None = None,
+) -> dict[str, Any]:
+    """Run the V7.1 upstream wiki completeness gate for one module."""
+    level_key = level.lower()
+    slug_key = slug.strip()
+    article_paths = _wiki_article_paths(level_key, slug_key)
+    if not article_paths:
+        raise LinearPipelineError(f"No wiki article found for level={level_key!r}, slug={slug_key!r}")
+    from scripts.audit.wiki_completeness_gate import check_wiki_completeness
+
+    # Current build layout resolves to a single canonical wiki article. If a
+    # future module has multiple articles, each must be complete enough to act
+    # as the renderer spine; fail fast on the first thin article.
+    reports = [
+        check_wiki_completeness(path, level=level_key, slug=slug_key)
+        for path in article_paths
+    ]
+    if len(reports) == 1:
+        return reports[0]
+    failed = [report for report in reports if report.get("verdict") != "PASS"]
+    if failed:
+        return failed[0]
+    merged_report = dict(reports[0])
+    merged_report["diagnostic"] = f"{len(reports)} wiki articles passed completeness gate."
+    if wiki_manifest is not None:
+        merged_report["wiki_manifest_slug"] = (
+            wiki_manifest.get("slug")
+            if isinstance(wiki_manifest, Mapping)
+            else slug_key
+        )
+    return merged_report
 
 
 PHONETIC_FORMAT_REFERENCE = (
@@ -1045,6 +1084,17 @@ def _render_wiki_coverage_required_items(wiki_manifest: str | Mapping[str, Any])
         "**Coverage rule**: every listed item MUST appear at least once in `module.md` PROSE (model sentence, definition, or paragraph). A vocab table entry alone is NOT coverage. Structural elements (tables, dialogue boxes) count for vocabulary but NOT for wiki_coverage obligations.",
         "",
     ]
+    # Sequence steps
+    vocab_items = [
+        str(item.get("lemma") or "")
+        for item in manifest.get("wiki_vocabulary_minimum", [])
+        if isinstance(item, Mapping) and item.get("lemma")
+    ]
+    if vocab_items:
+        lines.append("### wiki_vocabulary_minimum")
+        lines.append("- Lemmas: " + ", ".join(vocab_items))
+        lines.append("")
+
     # Sequence steps
     for item in manifest.get("sequence_steps", []):
         oid = str(item.get("id") or "")

--- a/scripts/build/phases/wiki_manifest.py
+++ b/scripts/build/phases/wiki_manifest.py
@@ -30,6 +30,7 @@ WIKI_MANIFEST_SCHEMA: dict[str, Any] = {
         "l2_errors",
         "phonetic_rules",
         "decolonization_bans",
+        "wiki_vocabulary_minimum",
         "external_resources",
     ],
     "properties": {
@@ -39,6 +40,7 @@ WIKI_MANIFEST_SCHEMA: dict[str, Any] = {
         "l2_errors": {"type": "array"},
         "phonetic_rules": {"type": "array"},
         "decolonization_bans": {"type": "array"},
+        "wiki_vocabulary_minimum": {"type": "array"},
         "external_resources": {
             "type": "array",
             "items": {
@@ -93,6 +95,13 @@ class DecolonizationBan:
 
 
 @dataclass(frozen=True, slots=True)
+class WikiVocabularyMinimum:
+    lemma: str
+    frequency_tier: Literal["high", "mid", "low", "unknown"]
+    gloss: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class ExternalResource:
     role: str
     title: str
@@ -109,12 +118,14 @@ class WikiManifest:
     l2_errors: list[L2Error]
     phonetic_rules: list[PhoneticRule]
     decolonization_bans: list[DecolonizationBan]
+    wiki_vocabulary_minimum: list[WikiVocabularyMinimum]
     external_resources: list[ExternalResource]
 
 
 _SEQUENCE_HEADING_RE = re.compile(r"^##\s+Послідовність\s+(?:викладання|введення)\b", re.IGNORECASE)
 _L2_HEADING_RE = re.compile(r"^##\s+Типові\s+помилки\s+L2\b", re.IGNORECASE)
 _BAN_HEADING_RE = re.compile(r"^##\s+Деколонізаційні\s+застереження\b", re.IGNORECASE)
+_VOCAB_MINIMUM_HEADING_RE = re.compile(r"^##\s+Словниковий\s+мінімум\b", re.IGNORECASE)
 _EXTERNAL_RESOURCES_HEADING_RE = re.compile(
     r"^##\s+(?:Зовнішні\s+ресурси|External\s+Resources)\b",
     re.IGNORECASE,
@@ -128,6 +139,9 @@ _MD_LINK_RE = re.compile(r"\[(?P<title>[^\]]+)\]\((?P<url>[^)]+)\)")
 _BULLET_RESOURCE_RE = re.compile(
     r"^\s*[-*]\s*(?:(?P<role>[A-Za-zА-ЯІЇЄҐа-яіїєґ-]+)\s*[:—-]\s*)?(?P<body>.+?)\s*$"
 )
+_VOCAB_BULLET_RE = re.compile(r"^\s*[-*]\s+(?P<body>.+?)\s*$")
+_VOCAB_PREFIX_STARS_RE = re.compile(r"^(?P<stars>[★☆]{1,8})\s+(?P<body>.+?)$")
+_VOCAB_STARS_RE = re.compile(r"\((?P<stars>[★☆\s]{0,8})\)")
 
 
 def extract_manifest(wiki_path: str | Path) -> dict[str, Any]:
@@ -144,6 +158,7 @@ def extract_manifest(wiki_path: str | Path) -> dict[str, Any]:
         l2_errors=_extract_l2_errors(lines),
         phonetic_rules=_extract_phonetic_rules(lines),
         decolonization_bans=_extract_decolonization_bans(lines),
+        wiki_vocabulary_minimum=_extract_wiki_vocabulary_minimum(lines),
         external_resources=_extract_external_resources(lines),
     )
     manifest_data = asdict(manifest)
@@ -213,6 +228,23 @@ def _clean_optional(text: str | None) -> str | None:
         return None
     cleaned = _clean_inline(text)
     return cleaned or None
+
+
+def _strip_source_markers(text: str) -> str:
+    text = re.sub(r"\[[SС]\d+\]", "", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip().rstrip(".;")
+
+
+def _frequency_tier(stars: str | None) -> Literal["high", "mid", "low", "unknown"]:
+    count = (stars or "").count("★")
+    if count >= 3:
+        return "high"
+    if count == 2:
+        return "mid"
+    if count == 1:
+        return "low"
+    return "unknown"
 
 
 def _normalize_external_role(raw_role: str | None, *, url: str | None = None) -> str:
@@ -498,3 +530,57 @@ def _extract_decolonization_bans(lines: list[str]) -> list[DecolonizationBan]:
         paragraph_lines.append(line)
     flush(end - 1)
     return bans
+
+
+def _extract_wiki_vocabulary_minimum(lines: list[str]) -> list[WikiVocabularyMinimum]:
+    span = _section_span(lines, _VOCAB_MINIMUM_HEADING_RE)
+    if not span:
+        return []
+    start, end = span
+    items: list[WikiVocabularyMinimum] = []
+    for line in lines[start + 1 : end]:
+        match = _VOCAB_BULLET_RE.match(line)
+        if not match:
+            continue
+        body = _clean_inline(match.group("body"))
+        if not body:
+            continue
+        prefix_star_match = _VOCAB_PREFIX_STARS_RE.match(body)
+        if prefix_star_match:
+            tier = _frequency_tier(prefix_star_match.group("stars"))
+            rest_body = prefix_star_match.group("body").strip()
+            gloss_match = re.search(r"\((?P<gloss>[^)]{1,240})\)\s*$", rest_body)
+            if gloss_match:
+                lemma = _clean_inline(rest_body[: gloss_match.start()])
+                gloss = _clean_optional(_strip_source_markers(gloss_match.group("gloss")))
+            else:
+                parts = re.split(r"\s*[—–-]\s+", rest_body, maxsplit=1)
+                lemma = _clean_inline(parts[0])
+                gloss = _clean_optional(_strip_source_markers(parts[1])) if len(parts) == 2 else None
+        elif star_match := _VOCAB_STARS_RE.search(body):
+            lemma = _clean_inline(body[: star_match.start()])
+            rest = body[star_match.end() :].strip()
+            tier = _frequency_tier(star_match.group("stars"))
+            dash_parts = re.split(r"\s*[—–-]\s+", rest, maxsplit=1)
+            if len(dash_parts) == 2:
+                gloss = _clean_optional(_strip_source_markers(dash_parts[1]))
+            elif rest and not rest.startswith("["):
+                gloss = _clean_optional(_strip_source_markers(rest))
+            else:
+                gloss = None
+        else:
+            parts = re.split(r"\s+[—–-]\s+", body, maxsplit=1)
+            lemma = _clean_inline(parts[0])
+            rest = parts[1].strip() if len(parts) > 1 else ""
+            tier = "unknown"
+            gloss = _clean_optional(_strip_source_markers(rest)) if rest and not rest.startswith("[") else None
+        if not lemma:
+            continue
+        items.append(
+            WikiVocabularyMinimum(
+                lemma=lemma,
+                frequency_tier=tier,
+                gloss=gloss,
+            )
+        )
+    return items

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -984,7 +984,8 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
     """Return True if `phase`'s on-disk artifact exists and reports success.
 
     The on-disk shapes mirror the success conditions enforced in `_run` itself
-    (see the post-phase guards: `gates.passed`, `wiki_coverage_gate.passed`,
+    (see the post-phase guards: `gates.passed`,
+    `wiki_completeness_gate.verdict == "PASS"`, `wiki_coverage_gate.passed`,
     `wiki_coverage_review.overall_verdict == "PASS"`, and
     `aggregate.terminal_verdict == "PASS"`). Any deviation means the phase
     needs to re-run.
@@ -1009,6 +1010,9 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
             return False
         gates = data.get("gates")
         return isinstance(gates, Mapping) and gates.get("passed") is True
+    if phase == "wiki_completeness_gate":
+        data = _read_json(module_dir / "wiki_completeness_gate.json")
+        return isinstance(data, Mapping) and data.get("verdict") == "PASS"
     if phase == "wiki_coverage_gate":
         data = _read_json(module_dir / "wiki_coverage_gate.json")
         return isinstance(data, Mapping) and data.get("passed") is True
@@ -1110,6 +1114,47 @@ def _run(args: argparse.Namespace) -> int:
             archive=archive,
         )
 
+        module_dir = _resolve_output_dir(args.out, level, slug)
+
+        phase = "wiki_completeness_gate"
+        _phase_started(archive, phase)
+        started_at = time.monotonic()
+        module_dir.mkdir(parents=True, exist_ok=True)
+        if (
+            resume_enabled
+            and not force_rerun
+            and _phase_artifact_passes(module_dir, "wiki_completeness_gate")
+        ):
+            wiki_completeness_gate = _read_json(module_dir / "wiki_completeness_gate.json")
+            tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
+        else:
+            if resume_enabled:
+                force_rerun = True
+            wiki_completeness_gate = linear_pipeline.run_wiki_completeness_gate(
+                level=level,
+                slug=slug,
+                wiki_manifest=wiki_manifest_data,
+            )
+            linear_pipeline.write_json(
+                module_dir / "wiki_completeness_gate.json", wiki_completeness_gate
+            )
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
+        if not isinstance(wiki_completeness_gate, Mapping) or wiki_completeness_gate.get("verdict") != "PASS":
+            diagnostic = (
+                wiki_completeness_gate.get("diagnostic")
+                if isinstance(wiki_completeness_gate, Mapping)
+                else "Wiki completeness gate returned malformed output"
+            )
+            raise linear_pipeline.LinearPipelineError(str(diagnostic))
+
         if args.dry_run:
             sections = [
                 str(item.get("section"))
@@ -1132,8 +1177,6 @@ def _run(args: argparse.Namespace) -> int:
                 duration_s=round(time.monotonic() - module_started_at, 3),
             )
             return 0
-
-        module_dir = _resolve_output_dir(args.out, level, slug)
 
         phase = "writer"
         _phase_started(archive, phase)

--- a/tests/audit/test_wiki_completeness_gate.py
+++ b/tests/audit/test_wiki_completeness_gate.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.audit.wiki_completeness_gate import (
+    check_wiki_completeness,
+    thresholds_for_level,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pass_verify_quote(source_id: str, quote: str, source: dict[str, Any]) -> dict[str, Any]:
+    return {"verdict": "PASS", "source_id": source_id, "quote": quote, "source": dict(source)}
+
+
+def _write_sources(path: Path, count: int) -> None:
+    path.with_suffix(".sources.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sources": [
+                    {
+                        "id": f"S{index}",
+                        "file": f"chunk-{index}",
+                        "type": "textbook",
+                        "title": f"Source {index}",
+                    }
+                    for index in range(1, count + 1)
+                ]
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _full_wiki(
+    tmp_path: Path,
+    *,
+    vocab_count: int = 20,
+    step_count: int = 5,
+    l2_rows: int = 3,
+    decolonization_pairs: int = 1,
+    exercise_count: int = 3,
+    citation_count: int = 5,
+) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    vocab = "\n".join(f"- слово{index} (★★★) — word {index}." for index in range(vocab_count))
+    steps = "\n\n".join(f"Крок {index}: Послідовність {index} [S1]." for index in range(1, step_count + 1))
+    l2 = "\n".join(
+        f"| Хиба{index}а. / Хиба{index}б. | Правильно{index}. | Пояснення [S2]. |"
+        for index in range(1, l2_rows + 1)
+    )
+    pairs = ", ".join(f"«правильно{index}» (не «помилка{index}»)" for index in range(1, decolonization_pairs + 1))
+    exercises = "\n\n".join(
+        f"**Вправа {index}: Формат**\n- *Chunk ID:* chunk-{index} [S{index}]\n- *Формат:* Вправа."
+        for index in range(1, exercise_count + 1)
+    )
+    citations = " ".join(f"Речення з джерелом [S{index}]." for index in range(1, citation_count + 1))
+    wiki = tmp_path / "fixture.md"
+    wiki.write_text(
+        f"""# Fixture
+
+<!-- wiki-meta
+slug: fixture
+-->
+
+## Методичний підхід
+
+Методика повна. {citations}
+
+## Послідовність введення
+
+{steps}
+
+## Типові помилки L2 (англомовні учні)
+
+| ❌ Помилково | ✅ Правильно | Чому |
+|---|---|---|
+{l2}
+
+## Деколонізаційні застереження
+
+Використовуємо {pairs}.
+
+## Словниковий мінімум
+
+{vocab}
+
+## Приклади з підручників
+
+{exercises}
+""",
+        encoding="utf-8",
+    )
+    _write_sources(wiki, citation_count)
+    return wiki
+
+
+def test_m20_my_morning_wiki_passes_completeness_gate() -> None:
+    report = check_wiki_completeness(
+        ROOT / "wiki/pedagogy/a1/my-morning.md",
+        level="a1",
+        slug="my-morning",
+        verify_quote_fn=_pass_verify_quote,
+    )
+
+    assert report["verdict"] == "PASS"
+    assert report["checks"]["vocabulary_minimum"]["actual"] == 21
+    assert report["checks"]["l2_errors"]["actual"] == 6
+    assert report["checks"]["decolonization_pairs"]["actual"] == 3
+    assert report["checks"]["textbook_exercises"]["actual"] == 5
+    assert report["checks"]["chunk_citations_spot_check"]["detail"] == "3/3 verify_quote returned PASS"
+
+
+def test_synthetic_thin_wiki_fails_with_specific_check_name(tmp_path: Path) -> None:
+    wiki = _full_wiki(tmp_path, vocab_count=18, step_count=3, l2_rows=3)
+
+    report = check_wiki_completeness(
+        wiki,
+        level="a1",
+        slug="fixture",
+        verify_quote_fn=_pass_verify_quote,
+    )
+
+    assert report["verdict"] == "FAIL"
+    assert report["checks"]["sequence_steps"]["verdict"] == "FAIL"
+    assert report["checks"]["sequence_steps"]["actual"] == 3
+    assert report["checks"]["vocabulary_minimum"]["verdict"] == "FAIL"
+    assert "Послідовність введення" in report["diagnostic"]
+
+
+def test_per_level_threshold_application_and_seminar_deferred(tmp_path: Path) -> None:
+    assert thresholds_for_level("a1")["vocabulary_minimum"] == 20
+    assert thresholds_for_level("b1")["vocabulary_minimum"] == 50
+    with pytest.raises(NotImplementedError, match="Seminar wiki completeness checks are deferred"):
+        thresholds_for_level("hist")
+
+    wiki = _full_wiki(tmp_path, vocab_count=49, decolonization_pairs=2, citation_count=5)
+    report = check_wiki_completeness(
+        wiki,
+        level="b1",
+        slug="fixture",
+        verify_quote_fn=_pass_verify_quote,
+    )
+    assert report["checks"]["vocabulary_minimum"] == {
+        "verdict": "FAIL",
+        "actual": 49,
+        "minimum": 50,
+        "detail": "wiki vocabulary-minimum lemma(s) found.",
+    }
+    assert report["checks"]["chunk_citations_spot_check"]["detail"] == "5/5 verify_quote returned PASS"
+
+
+def test_distractor_inventory_counts_l2_and_decolonization_together(tmp_path: Path) -> None:
+    wiki = _full_wiki(
+        tmp_path,
+        l2_rows=2,
+        decolonization_pairs=2,
+        vocab_count=20,
+        exercise_count=3,
+        citation_count=3,
+    )
+
+    report = check_wiki_completeness(
+        wiki,
+        level="a1",
+        slug="fixture",
+        verify_quote_fn=_pass_verify_quote,
+    )
+
+    assert report["checks"]["distractor_inventory"]["actual"] == 6
+    assert report["checks"]["distractor_inventory"]["verdict"] == "PASS"
+
+
+def test_spot_check_sample_size_is_three_for_a1_and_five_for_b1(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def recorder(source_id: str, quote: str, source: dict[str, Any]) -> dict[str, Any]:
+        calls.append(source_id)
+        return {"verdict": "PASS"}
+
+    a1_wiki = _full_wiki(tmp_path / "a1", citation_count=5)
+    a1_report = check_wiki_completeness(a1_wiki, level="a1", slug="fixture", verify_quote_fn=recorder)
+    assert a1_report["checks"]["chunk_citations_spot_check"]["detail"] == "3/3 verify_quote returned PASS"
+    assert calls == ["S1", "S2", "S3"]
+
+    calls.clear()
+    b1_wiki = _full_wiki(tmp_path / "b1", vocab_count=50, decolonization_pairs=2, l2_rows=4, citation_count=5)
+    b1_report = check_wiki_completeness(b1_wiki, level="b1", slug="fixture", verify_quote_fn=recorder)
+    assert b1_report["checks"]["chunk_citations_spot_check"]["detail"] == "5/5 verify_quote returned PASS"
+    assert calls == ["S1", "S2", "S3", "S4", "S5"]
+
+
+def test_missing_sections_fail_with_named_checks(tmp_path: Path) -> None:
+    wiki = tmp_path / "missing.md"
+    wiki.write_text("# Missing sections\n\nNo required sections.\n", encoding="utf-8")
+
+    report = check_wiki_completeness(
+        wiki,
+        level="a1",
+        slug="missing",
+        verify_quote_fn=_pass_verify_quote,
+    )
+
+    assert report["verdict"] == "FAIL"
+    assert {
+        "methodology",
+        "sequence_steps",
+        "l2_errors",
+        "decolonization_pairs",
+        "vocabulary_minimum",
+        "textbook_exercises",
+        "distractor_inventory",
+        "chunk_citations_spot_check",
+    } == {name for name, check in report["checks"].items() if check["verdict"] == "FAIL"}

--- a/tests/build/test_v7_build_resume.py
+++ b/tests/build/test_v7_build_resume.py
@@ -97,6 +97,24 @@ def test_python_qg_reruns_when_artifact_malformed(module_dir: Path) -> None:
     assert v7_build._phase_artifact_passes(module_dir, "python_qg") is False
 
 
+# ----- wiki_completeness_gate -------------------------------------------------
+
+def test_wiki_completeness_gate_skipped_when_passed(module_dir: Path) -> None:
+    _write_json(
+        module_dir / "wiki_completeness_gate.json",
+        {"verdict": "PASS", "checks": {}},
+    )
+    assert v7_build._phase_artifact_passes(module_dir, "wiki_completeness_gate") is True
+
+
+def test_wiki_completeness_gate_reruns_when_failed(module_dir: Path) -> None:
+    _write_json(
+        module_dir / "wiki_completeness_gate.json",
+        {"verdict": "FAIL", "checks": {}},
+    )
+    assert v7_build._phase_artifact_passes(module_dir, "wiki_completeness_gate") is False
+
+
 # ----- wiki_coverage_gate -----------------------------------------------------
 
 def test_wiki_coverage_gate_skipped_when_passed(module_dir: Path) -> None:

--- a/tests/test_audit_learner_state.py
+++ b/tests/test_audit_learner_state.py
@@ -34,6 +34,185 @@ def _setup_curriculum(root, level):
         _write_yaml(root / level / slug / "vocabulary.yaml", {"items": []})
 
 
+def _empty_learner_state(*_args):
+    return {
+        "cumulative_vocabulary": [],
+        "known_grammar": [],
+        "module_count": 0,
+        "previous_theme": None,
+        "next_topic": [],
+    }
+
+
+def _fake_verify_words(words):
+    lookup = {
+        "ранку": {"lemma": "ранок", "pos": "noun", "tags": ""},
+        "понадкрай": {"lemma": "понадкрай", "pos": "prep", "tags": ""},
+    }
+    return {
+        word: [lookup[word]] if word in lookup else []
+        for word in words
+    }
+
+
+def _assert_allowed(content, monkeypatch, **kwargs):
+    monkeypatch.setattr(learner_state_checks, "build_learner_state", _empty_learner_state)
+    assert learner_state_checks.check_unknown_vocabulary(
+        content,
+        "a1",
+        20,
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+        **kwargs,
+    ) == []
+
+
+def test_layered_allowlist_accepts_wiki_vocabulary_minimum(monkeypatch):
+    _assert_allowed(
+        "ранок",
+        monkeypatch,
+        wiki_manifest={"wiki_vocabulary_minimum": [{"lemma": "ранок"}]},
+    )
+
+
+def test_layered_allowlist_accepts_plan_new_vocabulary(monkeypatch):
+    _assert_allowed(
+        "кава",
+        monkeypatch,
+        plan={"targets": {"new_vocabulary": ["кава"]}},
+    )
+
+
+def test_layered_allowlist_accepts_plan_vocabulary_hints(monkeypatch):
+    _assert_allowed(
+        "чай",
+        monkeypatch,
+        plan={"vocabulary_hints": {"required": ["чай (tea)"]}},
+    )
+
+
+def test_layered_allowlist_accepts_cumulative_learner_state(monkeypatch):
+    monkeypatch.setattr(
+        learner_state_checks,
+        "build_learner_state",
+        lambda *_args: {
+            "cumulative_vocabulary": ["вчора"],
+            "known_grammar": [],
+            "module_count": 1,
+            "previous_theme": None,
+            "next_topic": [],
+        },
+    )
+
+    assert learner_state_checks.check_unknown_vocabulary(
+        "вчора",
+        "a1",
+        20,
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+    ) == []
+
+
+def test_layered_allowlist_accepts_closed_class_function_words(monkeypatch):
+    _assert_allowed("і", monkeypatch)
+
+
+def test_layered_allowlist_accepts_proper_nouns_from_wiki_examples(monkeypatch):
+    _assert_allowed("Леся", monkeypatch, wiki_text="Приклад: Леся Українка пише.")
+
+
+def test_layered_allowlist_accepts_bad_form_markers(monkeypatch):
+    _assert_allowed(
+        "завтрак",
+        monkeypatch,
+        wiki_text="Маркер: <!-- bad -->завтрак<!-- /bad -->.",
+    )
+
+
+def test_layered_allowlist_accepts_quoted_evidence_from_cited_chunks(monkeypatch):
+    monkeypatch.setattr(learner_state_checks, "build_learner_state", _empty_learner_state)
+    content = "> Тут є цитата [S1]\n\nцитата"
+    assert learner_state_checks.check_unknown_vocabulary(
+        content,
+        "a1",
+        20,
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+    ) == []
+
+
+def test_combined_allowlist_rejects_lemma_in_no_source(monkeypatch):
+    monkeypatch.setattr(learner_state_checks, "build_learner_state", _empty_learner_state)
+
+    violations = learner_state_checks.check_unknown_vocabulary(
+        "ранок невідоме",
+        "a1",
+        20,
+        wiki_manifest={"wiki_vocabulary_minimum": [{"lemma": "ранок"}]},
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+    )
+
+    assert [violation["lemma"] for violation in violations] == ["невідоме"]
+
+
+def test_unknown_vocabulary_band_tolerance(monkeypatch):
+    monkeypatch.setattr(learner_state_checks, "build_learner_state", _empty_learner_state)
+
+    assert learner_state_checks.check_unknown_vocabulary(
+        "одина дваа",
+        "a1",
+        20,
+        max_unsupported=2,
+        verify_words_fn=_fake_verify_words,
+    ) == []
+    violations = learner_state_checks.check_unknown_vocabulary(
+        "одина дваа триа чотира",
+        "a1",
+        20,
+        max_unsupported=2,
+        verify_words_fn=_fake_verify_words,
+    )
+    assert [violation["lemma"] for violation in violations] == ["дваа", "одина", "триа", "чотира"]
+
+
+def test_function_word_miss_counts_toward_band_without_individual_fail(monkeypatch):
+    monkeypatch.setattr(learner_state_checks, "build_learner_state", _empty_learner_state)
+
+    violations = learner_state_checks.check_unknown_vocabulary(
+        "понадкрай",
+        "a1",
+        20,
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+    )
+
+    assert violations[0]["type"] == "unknown_vocabulary_band"
+    assert violations[0]["lemma"] is None
+    assert violations[0]["unsupported_count"] == 1
+
+
+def test_vesum_normalization_allows_inflected_form_when_lemma_is_allowed(monkeypatch):
+    monkeypatch.setattr(learner_state_checks, "build_learner_state", _empty_learner_state)
+
+    assert learner_state_checks.check_unknown_vocabulary(
+        "ранку",
+        "a1",
+        20,
+        plan={"targets": {"new_vocabulary": ["ранок"]}},
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+    ) == []
+    violations = learner_state_checks.check_unknown_vocabulary(
+        "ранку",
+        "a1",
+        20,
+        max_unsupported=0,
+        verify_words_fn=_fake_verify_words,
+    )
+    assert violations[0]["lemma"] == "ранок"
+
+
 def test_unknown_vocabulary_returns_violation_lemma(tmp_path, monkeypatch):
     root = tmp_path / "curriculum" / "l2-uk-en"
     _setup_curriculum(root, "a1")

--- a/tests/test_wiki_manifest.py
+++ b/tests/test_wiki_manifest.py
@@ -29,6 +29,12 @@ def test_my_morning_manifest_extracts_required_obligations() -> None:
     manifest = extract_manifest(ROOT / "wiki/pedagogy/a1/my-morning.md")
 
     assert manifest["external_resources"] == []
+    assert len(manifest["wiki_vocabulary_minimum"]) == 21
+    assert manifest["wiki_vocabulary_minimum"][0] == {
+        "lemma": "прокидатися",
+        "frequency_tier": "high",
+        "gloss": "базова ранкова дія, з якої починається день",
+    }
     assert len(manifest["l2_errors"]) == 6
     assert len(manifest["sequence_steps"]) == 5
     incorrect = [item["incorrect"] for item in manifest["l2_errors"]]
@@ -40,6 +46,69 @@ def test_my_morning_manifest_extracts_required_obligations() -> None:
     assert "Я користуювася." in incorrect
     assert any(item["written"] == "-шся" and item["spoken"] == "[с':а]" for item in manifest["phonetic_rules"])
     assert any(item["written"] == "-ться" and item["spoken"] == "[ц':а]" for item in manifest["phonetic_rules"])
+
+
+def test_manifest_extracts_vocabulary_minimum_tiers_and_glosses(tmp_path: Path) -> None:
+    wiki = tmp_path / "vocab.md"
+    wiki.write_text(
+        """# Vocabulary fixture
+
+## Словниковий мінімум
+
+- ранок (★★★) — morning [S1].
+- обід (★★) — lunch.
+- вечір (★) — evening.
+""",
+        encoding="utf-8",
+    )
+
+    manifest = extract_manifest(wiki)
+
+    assert manifest["wiki_vocabulary_minimum"] == [
+        {"lemma": "ранок", "frequency_tier": "high", "gloss": "morning"},
+        {"lemma": "обід", "frequency_tier": "mid", "gloss": "lunch"},
+        {"lemma": "вечір", "frequency_tier": "low", "gloss": "evening"},
+    ]
+
+
+def test_manifest_missing_vocabulary_minimum_returns_empty_list(tmp_path: Path) -> None:
+    wiki = tmp_path / "no-vocab.md"
+    wiki.write_text(
+        """# No vocabulary fixture
+
+## Методичний підхід
+
+Є методика.
+""",
+        encoding="utf-8",
+    )
+
+    manifest = extract_manifest(wiki)
+
+    assert manifest["wiki_vocabulary_minimum"] == []
+
+
+def test_manifest_handles_mixed_or_missing_vocabulary_stars(tmp_path: Path) -> None:
+    wiki = tmp_path / "mixed-stars.md"
+    wiki.write_text(
+        """# Mixed stars fixture
+
+## Словниковий мінімум
+
+- кава (★★☆) — coffee.
+- чай () — tea.
+- сік — juice.
+""",
+        encoding="utf-8",
+    )
+
+    manifest = extract_manifest(wiki)
+
+    assert manifest["wiki_vocabulary_minimum"] == [
+        {"lemma": "кава", "frequency_tier": "mid", "gloss": "coffee"},
+        {"lemma": "чай", "frequency_tier": "unknown", "gloss": "tea"},
+        {"lemma": "сік", "frequency_tier": "unknown", "gloss": "juice"},
+    ]
 
 
 def test_manifest_handles_a1_heading_variants() -> None:


### PR DESCRIPTION
## Summary

- Extends the wiki manifest with a typed `wiki_vocabulary_minimum` surface from `## Словниковий мінімум` bullets, including lemma, frequency tier, and optional gloss.
- Adds `scripts/audit/wiki_completeness_gate.py` and wires it into `v7_build.py` before the writer phase so thin wikis fail before writer invocation.
- Replaces learner-state unknown vocabulary checking with the V7.1 layered allowlist described in `docs/decisions/pending/2026-05-27-v7.1-wiki-driven-writer.md`.

## Verification

- `.venv/bin/python -m pytest tests/test_wiki_manifest.py tests/audit/test_wiki_completeness_gate.py tests/test_audit_learner_state.py tests/build/test_v7_build_resume.py tests/test_linear_pipeline_wiki_coverage.py -q`
- `.venv/bin/python -m pytest tests/ -q --no-header 2>&1 | tail -20` currently reports 8 known/global failures locally; targeted affected tests pass.
- `.venv/bin/ruff check scripts tests`

No auto-merge.