### PR TITLE
[codex] fix(v7.2): wiki_coverage_gate parses inline implementation maps

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -95,6 +95,10 @@ _ROW_XML_ATTR_RE = re.compile(
     r"\"(?P<value>[^\"]*)\"",
     re.IGNORECASE | re.DOTALL,
 )
+_INLINE_IMPLEMENTATION_MAP_XML_RE = re.compile(
+    r"<implementation_map\b(?P<attrs>(?:\s+\w+\s*=\s*\"[^\"]*\")+)\s*/\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
 _WORKBOOK_AGGREGATE_ACTIVITY_TYPES = (
     "anagram",
     "authorial-intent",
@@ -173,8 +177,6 @@ def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
     the writer's intent if they restate a more refined claim later).
     """
     matches = list(_IMPLEMENTATION_MAP_RE.finditer(text))
-    if not matches:
-        return {}
     entries: dict[str, dict[str, str]] = {}
     for match in matches:
         body = match.group("body")
@@ -228,6 +230,24 @@ def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
                 entries[current_id][field_match.group("key").casefold()] = (
                     field_match.group("value").strip()
                 )
+    # During the V7.2 transition, accept both legacy nested-block maps and
+    # V7.1 self-closing inline `<implementation_map ... />` tags. Step 6's
+    # prompt-generator work will standardize on one canonical shape.
+    for inline_map_match in _INLINE_IMPLEMENTATION_MAP_XML_RE.finditer(text):
+        attrs_text = inline_map_match.group("attrs")
+        attrs: dict[str, str] = {}
+        for attr_match in _ROW_XML_ATTR_RE.finditer(attrs_text):
+            attrs[attr_match.group("key").casefold()] = attr_match.group(
+                "value"
+            ).strip()
+        obligation_id = attrs.get("obligation_id", "").strip()
+        if not obligation_id:
+            continue
+        existing = entries.setdefault(obligation_id, {"obligation_id": obligation_id})
+        for key in ("artifact", "location", "treatment"):
+            value = attrs.get(key)
+            if value is not None:
+                existing[key] = value
     return entries
 
 

--- a/tests/audit/fixtures/v7.1-self-closing-implementation-map.md
+++ b/tests/audit/fixtures/v7.1-self-closing-implementation-map.md
@@ -1,0 +1,18 @@
+<!--
+Fixture derived from the V7.1 m20 build:
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/builds/a1-my-morning-20260528-122552/curriculum/l2-uk-en/a1/my-morning/module.md
+
+module.md emitted self-closing inline implementation_map tags for module-targeted
+obligations; the same build's implementation_map.json tracked the full
+18-obligation contract. This fixture preserves that V7.1 self-closing shape for
+all obligation ids so the parser regression test covers the full gate contract.
+-->
+<implementation_map obligation_id="step-1" artifact="module.md" location="Дієслова на -ся" treatment="sequence_step" />
+<implementation_map obligation_id="step-2" artifact="module.md" location="Дієслова на -ся" treatment="sequence_step" /><implementation_map obligation_id="step-3" artifact="module.md" location="Дієслова на -ся" treatment="sequence_step" /><implementation_map obligation_id="step-4" artifact="module.md" location="Дієслова на -ся" treatment="sequence_step" />
+<implementation_map obligation_id="step-5" artifact="module.md" location="Мій ранок" treatment="sequence_step" />
+<implementation_map obligation_id="err-1" artifact="activities.yaml" location="activities.yaml" treatment="l2_error" />
+<implementation_map obligation_id="err-2" artifact="activities.yaml" location="activities.yaml" treatment="l2_error" /><implementation_map obligation_id="err-3" artifact="activities.yaml" location="activities.yaml" treatment="l2_error" /><implementation_map obligation_id="err-4" artifact="activities.yaml" location="activities.yaml" treatment="l2_error" />
+<implementation_map obligation_id="err-5" artifact="activities.yaml" location="activities.yaml" treatment="l2_error" /><implementation_map obligation_id="err-6" artifact="activities.yaml" location="activities.yaml" treatment="l2_error" />
+<implementation_map obligation_id="phon-1" artifact="module.md" location="Дієслова на -ся" treatment="phonetic_rule" />
+<implementation_map obligation_id="phon-2" artifact="module.md" location="Дієслова на -ся" treatment="phonetic_rule" /><implementation_map obligation_id="phon-3" artifact="module.md" location="Дієслова на -ся" treatment="phonetic_rule" /><implementation_map obligation_id="ban-2" artifact="module.md" location="Дієслова на -ся" treatment="decolonization_ban" /><implementation_map obligation_id="ban-3" artifact="module.md" location="Дієслова на -ся" treatment="decolonization_ban" />
+<implementation_map obligation_id="ban-1" artifact="module.md" location="§Мій ранок" treatment="decolonization_ban" /><implementation_map obligation_id="ban-4" artifact="module.md" location="Мій ранок" treatment="decolonization_ban" />

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from scripts.audit.wiki_coverage_gate import check_wiki_coverage, parse_implementation_map
 from scripts.build.phases.implementation_map import seed_implementation_map
+
+FIXTURES_DIR = Path(__file__).with_name("fixtures")
 
 BAN_1_RULE = (
     "При викладанні теми «Мій ранок» та семантики зворотних дієслів категорично заборонено "
@@ -659,6 +662,71 @@ def test_parse_implementation_map_xml_row_tolerates_whitespace_and_self_close_va
     # bullet path; the XML parser leaves entries it already added alone.
     assert parsed["step-9"]["artifact"] == "module.md"
     assert parsed["step-9"]["treatment"] == "closing recap"
+
+
+def test_parse_implementation_map_accepts_v71_self_closing_inline_fixture() -> None:
+    fixture_text = (
+        FIXTURES_DIR / "v7.1-self-closing-implementation-map.md"
+    ).read_text(encoding="utf-8")
+
+    parsed = parse_implementation_map(fixture_text)
+
+    expected_ids = {
+        "step-1",
+        "step-2",
+        "step-3",
+        "step-4",
+        "step-5",
+        "err-1",
+        "err-2",
+        "err-3",
+        "err-4",
+        "err-5",
+        "err-6",
+        "phon-1",
+        "phon-2",
+        "phon-3",
+        "ban-1",
+        "ban-2",
+        "ban-3",
+        "ban-4",
+    }
+    assert set(parsed) == expected_ids
+    assert len(parsed) == 18
+    assert parsed["step-1"] == {
+        "obligation_id": "step-1",
+        "artifact": "module.md",
+        "location": "Дієслова на -ся",
+        "treatment": "sequence_step",
+    }
+    assert parsed["err-6"]["artifact"] == "activities.yaml"
+    assert parsed["ban-4"]["location"] == "Мій ранок"
+
+
+def test_parse_implementation_map_merges_nested_and_inline_shapes_once() -> None:
+    implementation_map = """
+<implementation_map>
+<row obligation_id="step-1" artifact="module.md" location="§Nested" treatment="legacy row" />
+- obligation_id: err-1; artifact: activities.yaml; location: workbook error-correction; treatment: legacy bullet
+</implementation_map>
+<implementation_map obligation_id="phon-1" artifact="module.md" location="§Inline" treatment="inline tag" />
+<implementation_map obligation_id="step-1" artifact="module.md" location="§Inline override" treatment="inline restatement" />
+<implementation_map obligation_id="ban-1" artifact="module.md" location="§Inline empty" treatment="" />
+"""
+
+    parsed = parse_implementation_map(implementation_map)
+
+    assert set(parsed) == {"step-1", "err-1", "phon-1", "ban-1"}
+    assert len(parsed) == 4
+    assert parsed["err-1"]["artifact"] == "activities.yaml"
+    assert parsed["phon-1"]["treatment"] == "inline tag"
+    assert parsed["ban-1"]["treatment"] == ""
+    assert parsed["step-1"] == {
+        "obligation_id": "step-1",
+        "artifact": "module.md",
+        "location": "§Inline override",
+        "treatment": "inline restatement",
+    }
 
 
 def test_l2_error_passes_with_compact_pipe_workbook_location() -> None:


### PR DESCRIPTION
## Summary

Fixes #2385. Implements the Step 3 compatibility shim from `docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`.

- updates `parse_implementation_map()` to merge V7.1 self-closing inline `<implementation_map ... />` tags with the existing legacy nested-block parser
- keeps last-write-wins behavior by `obligation_id`, including inline restatements
- adds a V7.1 m20-style self-closing fixture covering the full 18-obligation contract
- adds a mixed nested + inline parser regression test

## Root Cause

The gate only scanned `<implementation_map>...</implementation_map>` blocks. V7.1 writer output can emit standalone self-closing `<implementation_map obligation_id="..." artifact="..." location="..." treatment="..." />` tags, so the parser returned no entries for those documents and every obligation failed as `implementation_map_missing`.

## Validation

- ` .venv/bin/python -m pytest tests/audit/test_wiki_coverage_gate.py -v --no-header` -> `23 passed in 0.31s`
- pre-commit affected tests -> `37 passed in 0.33s`
- `.venv/bin/ruff check scripts tests` -> `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> `All 1 non-skipped commit(s) carry an X-Agent trailer.`
- `git diff --check` -> clean

Repository-wide check was run with `.venv/bin/python -m pytest tests/ -q --no-header`; it completed with `6 failed, 8301 passed, 206 skipped, 11 xfailed` in 15:11. Failures were outside this parser change and include missing local fixtures/env such as `data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl` and `embed-venv/bin/python`, plus monitor/channel registry telemetry tests.

## Notes

This intentionally accepts both shapes during V7.2 transition only. Step 6's single-source prompt generator work should choose and emit one canonical implementation-map shape.