### PR TITLE
fix(v7.2): pass reviewer wiki obligations through

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1065,6 +1065,18 @@ def _render_prompt_wiki_manifest(wiki_manifest: str | Mapping[str, Any]) -> str:
     return json.dumps(compact, ensure_ascii=False, indent=2)
 
 
+def _manifest_mapping(wiki_manifest: str | Mapping[str, Any]) -> dict[str, Any] | None:
+    if isinstance(wiki_manifest, Mapping):
+        return dict(wiki_manifest)
+    try:
+        manifest = json.loads(wiki_manifest)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(manifest, Mapping):
+        return None
+    return dict(manifest)
+
+
 def _render_wiki_coverage_required_items(wiki_manifest: str | Mapping[str, Any]) -> str:
     """Render a breakdown of required items for the writer prompt."""
     if isinstance(wiki_manifest, str):
@@ -3689,6 +3701,8 @@ def review_context(
     plan_content: str,
     generated_content: str,
     dim: str,
+    wiki_manifest: str | Mapping[str, Any] | None = None,
+    implementation_map: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     """Build context for one independent per-dimension LLM QG prompt."""
     if dim not in QG_DIMS:
@@ -3696,6 +3710,27 @@ def review_context(
     level = str(plan["level"])
     sequence = int(plan["sequence"])
     learner_state = build_learner_state(level.lower(), sequence)
+    if wiki_manifest is None:
+        wiki_manifest_data = build_wiki_manifest_data(level=level.lower(), slug=str(plan["slug"]), plan=plan)
+        wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest_data)
+    else:
+        wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest)
+
+    if implementation_map is None:
+        manifest_for_map = _manifest_mapping(wiki_manifest) if wiki_manifest is not None else wiki_manifest_data
+        if manifest_for_map is None:
+            impl_map_contract = "(no implementation_map provided and wiki_manifest was not parseable)"
+        else:
+            from scripts.build.phases.implementation_map import render_for_writer_prompt, seed_implementation_map
+
+            impl_map_contract = render_for_writer_prompt(
+                seed_implementation_map(dict(manifest_for_map), plan=dict(plan))
+            )
+    else:
+        from scripts.build.phases.implementation_map import render_for_writer_prompt
+
+        impl_map_contract = render_for_writer_prompt(dict(implementation_map))
+
     return {
         "LEVEL": level,
         "MODULE_NUM": str(sequence),
@@ -3706,6 +3741,8 @@ def review_context(
         "CONTRACT_YAML": _contract_yaml(plan),
         "PLAN_CONTENT": plan_content,
         "GENERATED_CONTENT": generated_content,
+        "WIKI_MANIFEST": wiki_manifest_text,
+        "IMPLEMENTATION_MAP_CONTRACT": impl_map_contract,
         "DIM": dim,
     }
 
@@ -3715,10 +3752,19 @@ def render_review_prompt(
     plan_content: str,
     generated_content: str,
     dim: str,
+    wiki_manifest: str | Mapping[str, Any] | None = None,
+    implementation_map: Mapping[str, Any] | None = None,
 ) -> str:
     return render_phase_prompt(
         PROJECT_ROOT / "scripts" / "build" / "phases" / "linear-review-dim.md",
-        review_context(plan, plan_content, generated_content, dim),
+        review_context(
+            plan,
+            plan_content,
+            generated_content,
+            dim,
+            wiki_manifest,
+            implementation_map,
+        ),
     )
 
 

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -139,6 +139,25 @@ For `{DIM}` specifically:
 A dim score that re-states what a deterministic gate already enforced is a
 reviewer-protocol failure. Cite something the gate cannot see.
 
+## Writer Obligation Context — same source material the writer saw
+
+Use these blocks as context when judging the residual quality dimension. Do
+not turn this into a new scoring dimension and do not re-run the deterministic
+wiki coverage gate; the point is to know what the writer was obligated to
+teach while applying the existing `{DIM}` rubric.
+
+### Wiki Obligations Manifest
+
+```json
+{WIKI_MANIFEST}
+```
+
+### Implementation Map Contract
+
+```text
+{IMPLEMENTATION_MAP_CONTRACT}
+```
+
 The Tier-1 audits below (A through I, expanded in this rebuild) feed evidence
 into specific dims as labeled. Audit F (activity split) → pedagogical +
 engagement. Audit G (corpus access) → all dims, weighted strongest for

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -23,6 +23,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from scripts.agent_runtime.errors import AgentStalledError
 from scripts.build import linear_pipeline, run_archive
 from scripts.build.phases.implementation_map import (
+    read_implementation_map,
     seed_implementation_map,
     write_implementation_map,
 )
@@ -721,6 +722,8 @@ def _run_llm_qg(
     module_dir: Path,
     writer: str,
     reviewer_override: str | None = None,
+    wiki_manifest: str | Mapping[str, Any] | None = None,
+    implementation_map: Mapping[str, Any] | None = None,
     stdout_silence_timeout: int | None = None,
 ) -> dict[str, Any]:
     from scripts.agent_runtime.runner import invoke
@@ -741,6 +744,8 @@ def _run_llm_qg(
             plan_content,
             generated_content,
             dim,
+            wiki_manifest,
+            implementation_map,
         )
         (module_dir / f"llm-qg-{dim}-prompt.md").write_text(prompt, encoding="utf-8")
         result = invoke(
@@ -1208,6 +1213,7 @@ def _run(args: argparse.Namespace) -> int:
         timeout_agent = writer
         started_at = time.monotonic()
         module_dir.mkdir(parents=True, exist_ok=True)
+        impl_map_path = module_dir / "implementation_map.json"
         if (
             resume_enabled
             and not force_rerun
@@ -1216,12 +1222,16 @@ def _run(args: argparse.Namespace) -> int:
             writer_output = (module_dir / "writer_output.raw.md").read_text(
                 encoding="utf-8",
             )
+            if impl_map_path.exists():
+                impl_map = read_implementation_map(impl_map_path)
+            else:
+                impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
+                write_implementation_map(impl_map, impl_map_path)
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
             if resume_enabled:
                 force_rerun = True
             impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
-            impl_map_path = module_dir / "implementation_map.json"
             write_implementation_map(impl_map, impl_map_path)
             tracker.emit(
                 "implementation_map_seeded",
@@ -1434,6 +1444,8 @@ def _run(args: argparse.Namespace) -> int:
                 module_dir=module_dir,
                 writer=writer,
                 reviewer_override=reviewer_override,
+                wiki_manifest=wiki_manifest,
+                implementation_map=impl_map,
                 stdout_silence_timeout=args.writer_timeout,
             )
             linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)

--- a/tests/test_review_context_passthrough.py
+++ b/tests/test_review_context_passthrough.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import seed_implementation_map
+
+
+def test_per_dim_reviewer_prompt_receives_manifest_and_implementation_map() -> None:
+    plan_path = linear_pipeline.plan_path_for("a1", "my-morning")
+    plan = linear_pipeline.plan_check(plan_path)
+    manifest = linear_pipeline.build_wiki_manifest_data(
+        level="a1",
+        slug="my-morning",
+        plan=plan,
+    )
+    implementation_map = seed_implementation_map(manifest, plan=plan)
+
+    prompt = linear_pipeline.render_review_prompt(
+        plan,
+        plan_path.read_text(encoding="utf-8"),
+        "## module.md\n\nGenerated content",
+        "pedagogical",
+        manifest,
+        implementation_map,
+    )
+
+    assert "## Writer Obligation Context" in prompt
+    assert "### Wiki Obligations Manifest" in prompt
+    assert '"slug": "my-morning"' in prompt
+    assert '"id": "step-5"' in prompt
+    assert "### Implementation Map Contract" in prompt
+    assert "Manifest obligations:" in prompt
+    assert "obligation_id: step-5" in prompt
+    assert "treatment_template:" in prompt


### PR DESCRIPTION
## Summary
- Pass `wiki_manifest` and `implementation_map_contract` through `review_context()` / `render_review_prompt()` so per-dim reviewers see the same obligation context as the writer.
- Render both slots in `scripts/build/phases/linear-review-dim.md` without changing the 9-dim rubric or scoring weights.
- Forward the actual seeded `implementation_map` from `v7_build._run_llm_qg()`, including resume handling for existing `implementation_map.json`.
- Add a focused a1/my-morning prompt-render test asserting both blocks appear.

Closes #2384.
ADR: `docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`

## Validation
- `.venv/bin/python -m pytest tests/build/ -k review -q --no-header` -> 22 passed, 326 deselected in 0.73s
- `.venv/bin/python -m pytest tests/test_review_context_passthrough.py tests/test_linear_pipeline_wiki_coverage.py::test_wiki_coverage_review_prompt_receives_manifest_and_gate tests/test_prompt_cot_tier1_scaffolding.py::test_reviewer_prompt_has_no_unresolved_placeholders -q --no-header` -> 17 passed in 9.50s
- `.venv/bin/ruff check scripts tests` -> All checks passed
- `git diff --check` -> passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> All 1 non-skipped commit(s) carry an X-Agent trailer

## Notes
- Full `.venv/bin/python -m pytest tests/ -q --no-header` was attempted locally and failed in unrelated environment/infrastructure tests: dirty-worktree read-only discussion guard, missing source fixture `data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl`, missing `embed-venv/bin/python`, and existing channel/monitor telemetry registry expectations. No failure touched the changed reviewer pass-through path.
- Gemini local code review was attempted via `ask-gemini --model gemini-3.1-pro-preview`; it hung for ~10 minutes without returning findings, so it was treated as unavailable for this turn.
