### PR TITLE
fix(v7.2): purge m20 literals from linear-write.md (#2383)

### DIFF
--- a/docs/decisions/2026-05-28-decolonization-contrast-pair-rationale.md
+++ b/docs/decisions/2026-05-28-decolonization-contrast-pair-rationale.md
@@ -1,0 +1,21 @@
+# Decolonization Contrast-Pair Rationale
+
+**Status:** Recorded 2026-05-28 as rationale for the module-agnostic writer rule.
+
+**Related:** `docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`, issue #2383, PR #2358.
+
+## Context
+
+The writer prompt requires A1-A2 vocabulary modules in L1-Russian-substitutable domains to include at least one explicit bad-form contrast pair with `<!-- bad -->...<!-- /bad -->` markers. The rule belongs in the universal prompt because it is a general pedagogical and review obligation. The empirical build history that motivated the rule does not belong in the prompt template because it contaminates future modules with one module's vocabulary, source shape, and review history.
+
+## Empirical Grounding
+
+The immediate trigger was m20 round #12 with `codex-tools` on build `a1-my-morning-20260526-204640`. The module used Ukrainian-canonical vocabulary throughout and included one decolonization stance line, but it emitted zero bad-form markers. Under the recalibrated decolonization rubric from PR #2358, the reviewer scored the module 8.7: Ukrainian-canonical vocabulary and grammar-on-Ukrainian-terms were present, but criterion (b), an explicit bad-form contrast pair, was absent. That was 0.3 below the A1 decolonization floor of 9.0.
+
+Follow-up review identified the missing contrast-pair shape as the practical gap: for an A1 routine vocabulary domain, one concrete marked pair was enough to make the decolonization work visible without forcing extra political rhetoric into a grammar lesson.
+
+## Decision
+
+Keep the universal rule body in `scripts/build/phases/linear-write.md`: eligible A1-A2 vocabulary modules must include at least one topic-appropriate contrast pair using the bad-form marker syntax. The actual pair must come from the module's wiki, plan, or cited RAG content.
+
+Keep the empirical m20/PR #2358 history here in the decision journal only. Prompt templates must not name m20, its build IDs, its textbook chunk IDs, or its morning-routine vocabulary as canonical examples.

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -42,7 +42,7 @@ Upstream guard: the `wiki_completeness_gate` blocks the build BEFORE you run if 
 
 `plan.references` is the SOLE source of `resources.yaml` citations. Knowledge Packet anchors (S1, S2, ...) are research material — NOT citation candidates. If a Knowledge Packet anchor points to a chunk OUTSIDE `plan.references`, you MUST NOT cite that chunk.
 
-Concrete example: if `plan.references` lists [Захарійчук Grade 1, p.24] and Knowledge Packet S1 points to Захарійчук Grade 4 p.150, cite ONLY Grade 1 p.24. This overrides any later "enrich plan_references" instruction.
+Concrete example: if `plan.references` lists [`<Plan Author> Grade <N>, p.<P>`] and Knowledge Packet S1 points to `<Different Author> Grade <M>, p.<Q>`, cite ONLY `<Plan Author> Grade <N>, p.<P>`. This overrides any later "enrich plan_references" instruction.
 
 Published tabs are fixed: Tab 1 `Урок` from `module.md`; Tab 2 `Словник` from `vocabulary.yaml`; Tab 3 `Вправи` from `activities.yaml` plus inline cross-references; Tab 4 `Ресурси` from `resources.yaml`.
 
@@ -91,18 +91,17 @@ If `activity_split_audit.split_valid=false`, rebalance inline/workbook first.
 <!-- rule_id: #R-VESUM-ALL-WORDS -->
 **1. Verify every example word in VESUM** (VESUM all-words coverage). Verify every Cyrillic word form in `module.md`, `activities.yaml`, `vocabulary.yaml`, and `resources.yaml` via `mcp__sources__verify_words`, except intentionally bad forms protected by `<!-- bad -->...<!-- /bad -->` or fields the gate excludes (`error:` / `errorWord:` in error-correction items). Selective verification is silent fabrication.
 
-**L2-trap: over-applied reflexive -ся.** Before emitting any `-ся` form, verify it. These always fail as personal reflexives unless VESUM says otherwise: `пити → *п'юся`, `снідати → *снідаюся / *снідається`, `читати → *читаюся`, `писати → *пишуся`.
+**L2-trap: over-applied reflexive -ся.** Before emitting any `-ся` form, verify it. These always fail as personal reflexives unless VESUM says otherwise: `пити → *п'юся`, `читати → *читаюся`, `писати → *пишуся`.
 
 <!-- rule_id: #R-BAD-FORM-MARKER -->
 **Bad-form marker convention (MANDATORY everywhere).** Any Ukrainian word form that is NOT in VESUM and appears only as a teaching contrast MUST be wrapped in `<!-- bad -->...<!-- /bad -->` markers in every artifact. Do not use italics or bare prose for bad forms.
 
 ```markdown
-Stick to **сніданок** (not the Russian-borrowed <!-- bad -->завтрак<!-- /bad -->),
-**рушник** (not <!-- bad -->полотенце<!-- /bad -->), and **одягатися**
-(not the surzhyk <!-- bad -->одіватися<!-- /bad -->).
+Stick to **<canonical Ukrainian form>** (not the Russian-borrowed <!-- bad -->X<!-- /bad -->),
+and use **<native Ukrainian verb>** (not the surzhyk <!-- bad -->Y<!-- /bad -->).
 ```
 
-**Positive requirement for A1-A2 vocabulary modules:** when the module covers vocabulary domains where L1-Russian-exposure learners are likely to substitute Russian borrowings (food/dining, household items, clothing, daily routines, family, body, time-of-day expressions, transportation, common verbs of action), include **AT LEAST ONE** explicit bad-form contrast pair using the marker syntax above. This is a pedagogical tool (contrast pairs accelerate L2 acquisition) AND satisfies the `llm_qg.decolonization` rubric's criterion (b) — see `scripts/build/phases/linear-review-dim.md` § `decolonization`. Empirical evidence (m20 round #12, codex-tools, a1-my-morning-20260526-204640): module had Ukrainian-canonical vocabulary throughout + one stance line but **zero** bad-form markers; under the recalibrated rubric (PR #2358) the reviewer scored decolonization 8.7 (criterion a + c satisfied, b absent) — 0.3 short of the A1 9.0 floor that would have shipped the module. Pick the single most-likely L1 substitution for the module's topic (e.g. for a morning-routine module: завтрак→сніданок is the canonical one) and include it concretely. One marker pair is sufficient; this isn't a quantity gate.
+**Positive requirement for A1-A2 vocabulary modules:** when the module covers vocabulary domains where L1-Russian-exposure learners are likely to substitute Russian borrowings (food/dining, household items, clothing, daily routines, family, body, time-of-day expressions, transportation, common verbs of action), include **AT LEAST ONE** explicit bad-form contrast pair using the marker syntax above. This is a pedagogical tool (contrast pairs accelerate L2 acquisition) AND satisfies the `llm_qg.decolonization` rubric's criterion (b) — see `scripts/build/phases/linear-review-dim.md` § `decolonization`. Pick the single most-likely L1 substitution for the module's topic from the wiki/plan/RAG content and include it concretely. One marker pair is sufficient; this isn't a quantity gate.
 
 Modules whose topic does NOT involve L1-Russian-substitutable vocabulary (e.g. pure grammar abstractions, IPA-only phonetics drill, formal-letter templates) are exempt — but for those, document the exemption inline in your `<plan_reasoning>` so the reviewer doesn't dock for absence.
 
@@ -117,7 +116,7 @@ Apply the same convention in `module.md`, `activities.yaml` statements/items, an
 ✅ REQUIRED: `Stick to **X** (not the Russian-borrowed <!-- bad -->Y<!-- /bad -->).`
 When in doubt, omit the bad contrast and teach only the good form.
 
-**Morpheme-bold notation.** Do not put hyphens/slashes inside bold spans: write `прокидаюся (**-ся**)`, not `прокида**ю-ся**` or `**-ся/-сь**`.
+**Morpheme-bold notation.** Do not put hyphens/slashes inside bold spans: write `<verb> (**-suffix**)`, not `<verb>**-suffix**` or `**-suffix/-variant**`.
 
 **Textbook syllable-break notation.** Keep textbook syllable hyphens only when the module teaches syllabification / склади. Otherwise strip display hyphens before learner-facing prose.
 
@@ -271,7 +270,7 @@ Rules of engagement with prior learning (binding):
 
 2. **Don't introduce vocabulary that is neither in the cumulative list nor in this module's declared `vocabulary.yaml`.** From m04 onward this is a HARD audit failure (`unknown_vocab_in_prose`); for m01-m03 it's a WARN. Specifically: every Ukrainian content word in your `module.md` prose, dialogue lines, and example sentences MUST appear either (a) in the cumulative list, (b) in this module's `vocabulary.yaml`, OR (c) be a proper noun / Latin-character borrowing exempt from this rule.
 
-3. **Soft scaffolding via foreshadowing.** When you introduce a new lemma BEFORE its formal vocabulary entry (e.g. you use a word in the lesson prose that gets defined later in `vocabulary.yaml`), provide an inline gloss — `**вмиватися** *(to wash oneself)*` — at first mention. This is the "show before you tell" pattern, not a violation.
+3. **Soft scaffolding via foreshadowing.** When you introduce a new lemma BEFORE its formal vocabulary entry (e.g. you use a word in the lesson prose that gets defined later in `vocabulary.yaml`), provide an inline gloss — `**креслити** *(to draw lines)*` — at first mention. This is the "show before you tell" pattern, not a violation.
 
 4. **Frequency-and-CEFR awareness when introducing new vocab.** Before introducing any non-plan lemma, run the stacked check from §1.2 (Corpus Access). PULS-level → freq-rank → ULP-coverage. If none pass for your `{LEVEL}`, omit and choose differently.
 
@@ -303,13 +302,13 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 **Russianism floor.** `russianisms_strict` fails on any critical Russicism/calque/surzhyk finding. Check suspicious forms with `check_russian_shadow`, `search_style_guide`, `search_ua_gec_errors`, `search_heritage`, and `query_pravopys`. Never paste raw Russian forms into prose/dialogue; use a `<!-- VERIFY -->` placeholder or omit.
 
 <!-- rule_id: #R-SINGLE-VOICE-A1 -->
-**Single teacher voice at A1.** One teacher voice across the whole module: warm, clear, direct ("you" / "your"). No third-person framing of the learner (`the student`, `студента`, `the reader`, `учня`) and no mid-paragraph register shifts (English -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase). Good: "You use **я прокидаюся** for your own routine." Bad: "the student enters an authentic space."
+**Single teacher voice at A1.** One teacher voice across the whole module: warm, clear, direct ("you" / "your"). No third-person framing of the learner (`the student`, `студента`, `the reader`, `учня`) and no mid-paragraph register shifts (English -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase). Good: "You use **я креслю** when you describe your own action." Bad: "the student enters an authentic space."
 
 <!-- rule_id: #R-AUDIENCE-LANGUAGE-A1 -->
 **A1 audience language.** A1 explanation prose stays in English. Ukrainian appears only as TARGET: inline vocabulary words with English glosses, dialogue boxes, tables, conjugations, model sentences. Never use Ukrainian metalanguage TO the learner (`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`), because the learner cannot read Ukrainian explanations yet.
 
 <!-- rule_id: #R-NO-CHILDREN-PRIMARY-QUOTES -->
-**No children-primary blockquotes in adult A1.** No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body. Grade 1-3 RAG hits can still ground lexical choices, but do not surface as quoted material. Default: NO blockquote unless it pedagogically advances the lesson AND comes from an adult-appropriate source (Grade 7+, adult literature, Антоненко-Давидович, style guides). Adult A1 learners are not reading children's primers; do not print `Захарійчук, Grade 1, p.24` as lesson prose.
+**No children-primary blockquotes in adult A1.** No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body. Grade 1-3 RAG hits can still ground lexical choices, but do not surface as quoted material. Default: NO blockquote unless it pedagogically advances the lesson AND comes from an adult-appropriate source (Grade 7+, adult literature, Антоненко-Давидович, style guides). Adult A1 learners are not reading children's primers; do not print `<Author>, Grade 1, p.<P>` as lesson prose.
 
 <!-- rule_id: #R-NO-SCAFFOLDING-LEAKS -->
 **No writer-side scaffolding leaks.** Writer-side scaffolding never appears in module body. Forbidden in published markdown: panel IDs (`P1`, `P2`, ...), Krok-N labels (`Крок 5:`, `Step 5:`), obligation names from the wiki_coverage manifest (`ban-4`, `step-5`, ...), reviewer-fix anchors, phase names, gate names. The module is a finished lesson, not a writer's worksheet.
@@ -327,7 +326,7 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 
 Use `<DialogueBox uk="..." en="...">` to render dialogues with side-by-side translation. This satisfies Practice 2 + Practice 4 of ULP for A1 and the `l2_exposure_floor` gate. Em-dash bare lines without an `en` prop fail the gate. Every dialogue line needs an **inline English gloss** provided **within 8 tokens** of the Ukrainian text. Place longer expression notes at the **block-bottom** of the component.
 
-**Minimum UK dialogue lines (A1-A2).** For A1 and A2 modules, emit at least **15 distinct gate-countable Ukrainian dialogue surfaces** (`<DialogueBox uk="..." en="...">` entries and `> ` blockquote lines, summed). The `l2_exposure_floor` gate's floor is 14; overshoot by ≥1 for safety. m20 build #9 hit exactly 13 and HARD-failed via `too_few_uk_dialogue_lines`. Count BEFORE emitting: if you have <15, add another exchange to the dialogue section or split a long turn into two shorter ones.
+**Minimum UK dialogue lines (A1-A2).** For A1 and A2 modules, emit at least **15 distinct gate-countable Ukrainian dialogue surfaces** (`<DialogueBox uk="..." en="...">` entries and `> ` blockquote lines, summed). The `l2_exposure_floor` gate's floor is 14; overshoot by ≥1 for safety. Prior builds have failed at exactly 13 gate-countable lines via `too_few_uk_dialogue_lines`. Count BEFORE emitting: if you have <15, add another exchange to the dialogue section or split a long turn into two shorter ones.
 
 `шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. When you use it, add a `notes:` field to the `що` entry in `vocabulary.yaml` flagging the literary↔colloquial pair so learners know when each is appropriate (the per-item schema accepts `notes`, NOT `note` — singular fails schema validation). Do NOT add a separate top-level entry for `шо` — VESUM does not codify it and the vocab gate will reject a standalone lemma.
 
@@ -458,10 +457,10 @@ See `## Knowledge Packet` above. This is the same wiki-obligation content; the p
 
 Before artifacts, make the in-scope MCP calls your draft depends on:
 1. Textbook grounding (mandatory chunk_id-first protocol):
-   For each entry in `plan_references`, parse the `notes` field for the literal substring `chunk_id: <ID>` (always present — example: `chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0024`).
+   For each entry in `plan_references`, parse the `notes` field for the literal substring `chunk_id: <ID>` (always present — example: `chunk_id: <textbook-slug>_s<NNNN>`).
    Call `mcp__sources__get_chunk_context(chunk_id=<ID>)` to fetch the chunk text.
    DO NOT call `mcp__sources__search_text` for plan references — the chunk_id in notes is authoritative.
-   Concrete example: plan says `chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0024` → call `get_chunk_context(chunk_id="1-klas-bukvar-zaharijchuk-2025-1_s0024")`, paste from THAT returned text. Do NOT search by "p.24" — FTS5 will return the wrong author (e.g. Pohribnyi instead of Захарійчук).
+   Concrete example: plan says `chunk_id: <textbook-slug>_s<NNNN>` → call `get_chunk_context(chunk_id="<textbook-slug>_s<NNNN>")`, paste from THAT returned text. Do NOT search by page number — FTS5 can return the wrong author or page.
 2. Multimedia obligation: at least one `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, or `mcp__sources__search_images`; `resources_search_attempted` rejects zero attempts.
 3. VESUM: `mcp__sources__verify_words` over every Ukrainian form you will emit.
 4. Russianism/style: `mcp__sources__search_style_guide`, `mcp__sources__search_ua_gec_errors`, `mcp__sources__check_russian_shadow`, or `mcp__sources__search_heritage` for contrast pairs or suspicious forms.
@@ -497,9 +496,9 @@ Return the visible `<plan_reasoning>` blocks first, then exactly these four fenc
     "instruction": "Complete each sentence with the best word.",
     "items": [
       {
-        "sentence": "Я ____ о сьомій.",
-        "answer": "прокидаюся",
-        "options": ["прокидаюся", "сплю", "йду"]
+        "sentence": "Я ____ схему.",
+        "answer": "креслю",
+        "options": ["креслю", "питаю", "тримаю"]
       }
     ]
   }
@@ -509,10 +508,10 @@ Return the visible `<plan_reasoning>` blocks first, then exactly these four fenc
 ```json file=vocabulary.yaml
 [
   {
-    "lemma": "прокидатися",
-    "translation": "to wake up",
+    "lemma": "креслити",
+    "translation": "to draw lines",
     "pos": "verb",
-    "usage": "Я прокидаюся о сьомій."
+    "usage": "Я креслю схему."
   }
 ]
 ```

--- a/tests/build/test_writer_prompt_no_lesson_specific_leakage.py
+++ b/tests/build/test_writer_prompt_no_lesson_specific_leakage.py
@@ -1,0 +1,155 @@
+"""Guard writer prompts against cross-lesson literal leakage."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.build import linear_pipeline
+from scripts.build.phases.implementation_map import seed_implementation_map
+from scripts.build.phases.wiki_manifest import extract_manifest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CHUNK_ID_RE = re.compile(r"chunk_id:\s*([A-Za-z0-9_-]+)")
+CYRILLIC_WORD_RE = re.compile(r"[А-ЯІЇЄҐа-яіїєґ][А-ЯІЇЄҐа-яіїєґ'’ʼ-]{3,}")
+QUOTED_TEXT_RE = re.compile(r"[«“]([^»”]+)[»”]")
+BAD_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(.*?)<!--\s*/bad\s*-->", re.DOTALL)
+TEXTBOOK_HINT_RE = re.compile(r"\b(?:Grade|p\.|клас|стор)\b", re.IGNORECASE)
+MIN_TOKEN_LENGTH = 4
+
+
+@pytest.mark.parametrize(
+    ("self_slug", "other_slug"),
+    [
+        ("sounds-letters-and-hello", "my-morning"),
+    ],
+)
+def test_no_cross_lesson_token_leakage(self_slug: str, other_slug: str) -> None:
+    self_prompt = _render_writer_prompt_for_module(level="a1", slug=self_slug)
+    self_source_text = _lesson_source_text(level="a1", slug=self_slug)
+    self_specific = _extract_lesson_specific_tokens(level="a1", slug=self_slug)
+    other_specific = _extract_lesson_specific_tokens(level="a1", slug=other_slug)
+
+    leaked_tokens = sorted(
+        tok
+        for tok in other_specific - self_specific
+        if _contains_token(self_prompt, tok) and not _contains_token(self_source_text, tok)
+    )
+
+    assert not leaked_tokens, (
+        f"Lesson '{other_slug}' specific tokens leaked into '{self_slug}' "
+        f"rendered writer prompt: {leaked_tokens}"
+    )
+
+
+def _render_writer_prompt_for_module(*, level: str, slug: str) -> str:
+    """Render a writer prompt without invoking a writer agent."""
+    plan_path = linear_pipeline.plan_path_for(level, slug)
+    plan = linear_pipeline.plan_check(plan_path)
+    plan_content = plan_path.read_text(encoding="utf-8")
+    wiki_manifest_data = linear_pipeline.build_wiki_manifest_data(
+        level=level,
+        slug=slug,
+        plan=plan,
+    )
+    implementation_map = seed_implementation_map(wiki_manifest_data, plan=plan)
+    return linear_pipeline.render_writer_prompt(
+        plan=plan,
+        plan_content=plan_content,
+        knowledge_packet="Knowledge packet stub for leakage-sentinel prompt rendering.",
+        wiki_manifest=json.dumps(wiki_manifest_data, ensure_ascii=False, indent=2),
+        implementation_map=implementation_map,
+    )
+
+
+def _extract_lesson_specific_tokens(*, level: str, slug: str) -> set[str]:
+    """Return lesson-specific wiki/plan tokens that must not leak elsewhere."""
+    tokens: set[str] = set()
+    plan = _load_plan(level=level, slug=slug)
+    wiki_path = PROJECT_ROOT / "wiki" / "pedagogy" / level / f"{slug}.md"
+    wiki_manifest = extract_manifest(wiki_path)
+
+    for item in wiki_manifest.get("wiki_vocabulary_minimum", []):
+        if isinstance(item, dict):
+            tokens.update(_split_vocab_lemma(str(item.get("lemma") or "")))
+
+    for ref in _plan_references(plan):
+        tokens.update(_extract_textbook_author_names(str(ref.get("title") or "")))
+        tokens.update(CHUNK_ID_RE.findall(str(ref.get("notes") or "")))
+
+    for item in wiki_manifest.get("decolonization_bans", []):
+        if isinstance(item, dict):
+            tokens.update(_extract_decolonization_contrast_tokens(str(item.get("rule") or "")))
+
+    return _clean_tokens(tokens)
+
+
+def _load_plan(*, level: str, slug: str) -> dict[str, Any]:
+    plan_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans" / level / f"{slug}.yaml"
+    with plan_path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    assert isinstance(data, dict), f"Plan must be a mapping: {plan_path}"
+    return data
+
+
+def _lesson_source_text(*, level: str, slug: str) -> str:
+    plan_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans" / level / f"{slug}.yaml"
+    wiki_path = PROJECT_ROOT / "wiki" / "pedagogy" / level / f"{slug}.md"
+    return "\n".join(
+        [
+            plan_path.read_text(encoding="utf-8"),
+            wiki_path.read_text(encoding="utf-8"),
+        ]
+    )
+
+
+def _plan_references(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    references = plan.get("references") or []
+    return [ref for ref in references if isinstance(ref, dict)]
+
+
+def _split_vocab_lemma(lemma: str) -> set[str]:
+    cleaned = re.sub(r"\([^)]*\)", "", lemma)
+    return {part.strip(" `*.;:") for part in re.split(r"\s*/\s*|\s*,\s*", cleaned)}
+
+
+def _extract_textbook_author_names(title: str) -> set[str]:
+    if not TEXTBOOK_HINT_RE.search(title):
+        return set()
+    return {match.group(0) for match in CYRILLIC_WORD_RE.finditer(title)}
+
+
+def _extract_decolonization_contrast_tokens(rule: str) -> set[str]:
+    tokens = set(BAD_MARKER_RE.findall(rule))
+    contrast_pair_re = re.compile(
+        r"[«“]([^»”]+)[»”]\s*\(\s*не\s+[«“]([^»”]+)[»”]\s*\)",
+        re.IGNORECASE,
+    )
+    for good, bad in contrast_pair_re.findall(rule):
+        tokens.update({good, bad})
+    if "замін" in rule.casefold() or "замість" in rule.casefold():
+        tokens.update(QUOTED_TEXT_RE.findall(rule))
+    return tokens
+
+
+def _clean_tokens(tokens: set[str]) -> set[str]:
+    cleaned: set[str] = set()
+    for token in tokens:
+        normalized = re.sub(r"\s+", " ", token).strip(" `*.;:()[]{}")
+        if len(normalized) >= MIN_TOKEN_LENGTH:
+            cleaned.add(normalized)
+    return cleaned
+
+
+def _contains_token(text: str, token: str) -> bool:
+    if re.fullmatch(r"[А-ЯІЇЄҐа-яіїєґ'’ʼ-]+", token):
+        token_re = re.compile(
+            rf"(?<![А-ЯІЇЄҐа-яіїєґ'’ʼ-]){re.escape(token)}(?![А-ЯІЇЄҐа-яіїєґ'’ʼ-])"
+        )
+        return bool(token_re.search(text))
+    return token in text

--- a/tests/test_writer_prompt_v7_register_rules.py
+++ b/tests/test_writer_prompt_v7_register_rules.py
@@ -30,7 +30,7 @@ WRITER_RULE_ANCHORS = (
             "No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels "
             "in the published module body",
             "Grade 1-3 RAG hits can still ground lexical choices",
-            "`Захарійчук, Grade 1, p.24`",
+            "`<Author>, Grade 1, p.<P>`",
         ),
     ),
     (


### PR DESCRIPTION
## Summary

Closes #2383.

Parent ADR: `docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`.

- Purges m20-specific vocabulary, textbook author, chunk ID, and build-history literals from `scripts/build/phases/linear-write.md` while preserving rule semantics.
- Moves the m20/PR #2358 empirical rationale for the bad-form contrast-pair rule into `docs/decisions/2026-05-28-decolonization-contrast-pair-rationale.md`.
- Adds a rendered writer-prompt leakage sentinel and updates the existing prompt-pin test to the new generic child-textbook placeholder.

## Verification

No m20 literals remain:

```console
$ grep -nE 'прокидаюся|Захарійчук|сніданок|завтрак|m20|a1-my-morning-20260526-204640|PR #2358' scripts/build/phases/linear-write.md
```

Existing prompt-pinning tests:

```console
============================= 97 passed in 35.27s ==============================
```

New leakage test:

```console
============================== 1 passed in 0.43s ===============================
```

Combined prompt surface after the prompt-pin update:

```console
============================= 105 passed in 35.17s =============================
```

Lint clean:

```console
All checks passed!
```

Agent trailer lint:

```console
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Full pytest attempt:

```console
= 7 failed, 8298 passed, 206 skipped, 11 xfailed, 3 warnings in 776.10s (0:12:56) =
```

Local full-suite failures were unrelated environment/live-data failures except for the old prompt-pin expectation, which this PR updates and reruns cleanly. Remaining local failures: empty live source registry assertions, monitor telemetry footer state, missing `data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl`, missing `embed-venv/bin/python` for MLX, and the matching wiki channel registry assertion.

## Scope Note

`tests/test_writer_prompt_v7_register_rules.py` is included because its old anchor pinned the exact `Захарійчук, Grade 1, p.24` literal that this PR is required to remove from the writer prompt.
