### PR TITLE
feat(v7.2): universal rules registry scaffold (Step 4)

### DIFF
--- a/docs/best-practices/universal-rules-registry.md
+++ b/docs/best-practices/universal-rules-registry.md
@@ -1,0 +1,149 @@
+# Universal Rules Registry (V7.2)
+
+This doc describes the universal-rules registry that lives at
+`scripts/build/universal_rules/`. The registry is the single source of truth
+for the universal layer of the wiki-driven prompt generator described in
+[`docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`](../decisions/pending/2026-05-28-wiki-driven-prompt-generator.md).
+
+> **Status (2026-05-28):** Step 4 — registry + loader scaffold only. Generator
+> wiring (Step 5) and reviewer single-source emission (Step 6) are separate
+> follow-ups. The legacy `scripts/build/phases/linear-write.md` template
+> remains the active writer prompt during the migration; the registry runs
+> parallel to it until the generator is wired.
+
+## Why a registry
+
+Today's writer prompt (`linear-write.md`) carries ~15 `#R-*` rules inline.
+Reviewer prompts (`linear-review-dim.md`) and gate parsers re-state the same
+rules in different words. Three hand-maintained descriptions of the same
+contract drift apart with every prompt iteration. The wiki-driven generator
+ADR resolves this by composing prompts from a registry at build time so the
+writer prompt, reviewer prompt, and gate parser all read from one place.
+
+The registry layer is the *universal* one — invariants and level/track
+predicates that apply across modules. Lesson-specific content (vocabulary
+domain, decolonization contrast pair, sequence steps) stays in the wiki.
+RAG payloads (chunk text, citations) stay attached to `plan.references`.
+
+## Fragment shape
+
+Every fragment is an `R-<NAME>.md` file with YAML frontmatter followed by
+markdown body. Filenames omit the `#` because the filesystem can't carry it;
+the `Rule.telemetry_id` accessor restores the `#` prefix for compatibility
+with the pipeline's existing telemetry keys (`#R-VESUM-ALL-WORDS`, etc.).
+
+```yaml
+---
+id: R-VESUM-ALL-WORDS
+description: Verify every Cyrillic word form in artifacts via mcp__sources__verify_words.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+Body markdown (rule semantics, examples, forbidden patterns). The body is
+pasted verbatim into the rendered prompt by the generator (Step 5).
+```
+
+### Required frontmatter fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Must start with `R-` (no `#` prefix). Matches the filename stem. |
+| `description` | string | One-line summary used in error messages and registry listings. |
+| `applies_to.levels` | list[str] | Subset of `{a1, a2, b1, b2, c1, c2, all}`. Use `[all]` for universal rules. |
+| `applies_to.tracks` | list[str] | Subset of `{core, seminar, all}`. |
+| `applies_to.activity_profiles` | list[str] | Free-form list; use `[all]` until Step 5 introduces profile taxonomies. |
+| `slot` | string | One of `writer.preamble`, `writer.body`, `reviewer.rubric`, `shared.contract` (see below). |
+| `depends_on` | list[str] | Other rule ids (no `#` prefix) that must appear before this one. |
+
+### Slots
+
+| Slot | Generator behavior |
+|---|---|
+| `writer.preamble` | Emitted into the *opening* of the writer prompt (charter / voice / audience framing). |
+| `writer.body` | Emitted into the writer prompt's protocol body (detailed authoring rules). |
+| `reviewer.rubric` | Emitted into the reviewer prompt as rubric criteria (deterministic-side checks composed alongside subjective dims). |
+| `shared.contract` | Emitted to **both** the writer and reviewer prompts. Use for rules where the writer is asked to do X and the reviewer is asked to verify X — single-source eliminates drift between the two surfaces. |
+
+A rule has exactly one slot. A rule that semantically applies to both
+prompts uses `shared.contract`; the generator (Step 5) is responsible for
+emitting `shared.contract` fragments into both rendered prompts.
+
+### Ordering
+
+Within a rendered prompt, the generator concatenates rules in
+topologically-sorted order over `depends_on`. Tie-break is filename
+alphabetical (= the order `load_all_rules` returns by default). The
+topological sort validates that every `depends_on` id exists in the *full*
+registry (not just the filtered subset), so removing a rule that other
+rules depend on still surfaces as `MissingDependencyError` before the
+prompt is rendered.
+
+## Loader API
+
+`scripts/build/universal_rules_registry.py` exposes:
+
+- `load_all_rules(directory=None) -> list[Rule]` — discovery + parsing.
+  Returns rules in filename-alphabetical order. Each invocation re-reads
+  the filesystem; callers that need caching wrap their own.
+- `load_applicable_rules(level, track, activity_profile, slot=None, directory=None) -> list[Rule]` —
+  filters by predicates and sorts topologically. Pass `slot=None` to load
+  every slot.
+- `get_rule(rule_id, directory=None) -> Rule` — single-rule fetch by id.
+- `Rule` dataclass with frozen fields and a `telemetry_id` property that
+  prepends `#` to match the pipeline's existing `rule_id` telemetry shape.
+
+Errors:
+
+- `MalformedFragmentError` — missing frontmatter, unknown slot, bad
+  `applies_to` shape, etc. Raised eagerly on `load_all_rules`.
+- `MissingDependencyError` — `depends_on` names a rule that does not
+  exist as a fragment.
+- `CircularDependencyError` — topological sort detected a cycle.
+
+## What is *not* in the registry
+
+Per the ADR, three categories explicitly do **not** live here:
+
+1. **Lesson substance** — sequence steps, L2 errors, vocabulary minimum,
+   decolonization contrast pairs. These live in the wiki and are inlined by
+   the generator into the rendered prompt alongside the registry.
+2. **RAG payloads** — chunk text, page citations, source attribution. These
+   are attached to `plan.references` and inlined by the generator.
+3. **Composition directives** — "include ≥1 bad-form contrast pair when
+   applicable" is a universal rule (registry); "the pair for m20 is
+   `завтрак` vs `сніданок`" is a composition junction (generator-side
+   logic, Step 5). The registry is universal; junctions are not.
+
+If a rule is candidate-for-registry but you're not sure: ask whether the
+text would be identical for m21 and m22 in the same level. If yes,
+registry. If it varies, wiki or composition.
+
+## Roadmap
+
+- **Step 4 (this scaffold):** registry + loader + tests. Generator not yet
+  wired. The legacy `linear-write.md` template still drives builds.
+- **Step 5:** `scripts/build/prompt_generator.py` consumes the registry
+  alongside the wiki manifest and plan references; emits writer prompt +
+  reviewer prompt + one Obligation Checklist. Wired into `writer_context()`
+  + `review_context()` in `linear_pipeline.py`, behind an opt-in flag.
+- **Step 6:** reviewer-side deterministic checks emitted from the same
+  registry; `wiki_coverage_gate` consumes the shared checklist. Eliminates
+  the writer/reviewer/parser drift class that produced today's m20 blocker.
+
+## How to add a new universal rule
+
+1. Pick an id `R-<NAME>` that matches an existing pipeline constant in
+   `linear_pipeline.py` (`RULE_*`) when one exists; otherwise add the
+   constant too so telemetry shows the rule id on gate failures.
+2. Create `scripts/build/universal_rules/R-<NAME>.md` with frontmatter.
+3. If the rule semantically mirrors in writer + reviewer, use
+   `slot: shared.contract`.
+4. Run the loader tests:
+   `.venv/bin/python -m pytest tests/build/test_universal_rules_registry.py`.
+5. Until Step 5 lands, also update `linear-write.md` (and `linear-review-dim.md`
+   if the rule has a reviewer surface). Step 5 will collapse the duplication.

--- a/scripts/build/universal_rules/R-ACTIVITY-COMPOSITION.md
+++ b/scripts/build/universal_rules/R-ACTIVITY-COMPOSITION.md
@@ -1,0 +1,16 @@
+---
+id: R-ACTIVITY-COMPOSITION
+description: Activities composed from layered vocab allowlist; distractors only from wiki inventory.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: [R-RENDERER-CHARTER]
+---
+
+**Activity composition (bounded, not rendered).** Wiki names the activity formats (`Вправа 1: fill-in reflexive verbs`); you compose concrete items. The same layered vocab allowlist from the V7.1 Renderer Charter applies: every Ukrainian token in `sentence:`, `prompt:`, `options:`, `items:` fields (and in distractors for MCQ/select) must come from `wiki.vocabulary_minimum ∪ plan.targets.new_vocabulary ∪ plan.targets.vocabulary_hints ∪ cumulative_learner_state.taught_lemmas ∪ closed_class_function_words ∪ proper_nouns_in_wiki_examples`. The `learner_state` vocab gate scans `activities.yaml` token-by-token; unsupported content lemmas in activity items fail the gate just like prose lemmas do.
+
+**Distractor supply (critical at A1).** Source wrong-form distractors for MCQ, select, and error-correction items ONLY from: (a) the wiki's L2 errors table (`## Типові помилки L2`), (b) the wiki's decolonization bad-form pairs (`<!-- bad -->...<!-- /bad -->` markers), or (c) the cumulative learner state. **Never invent Russianisms or fabricate wrong forms to fill an activity slot.** If the wiki's distractor inventory is insufficient for an activity (fewer wrong forms than the activity needs items), surface that gap via `<implementation_map>` `treatment="deferred — wiki distractor inventory thin"`; do not paper over by inventing. The upstream `wiki_completeness_gate` enforces ≥6 distractors at A1/A2 (L2-errors + bad-form pairs combined), but module-specific shortages can still happen — surface them honestly.
+
+**Activity item count vs INLINE/WORKBOOK split.** The `{ACTIVITY_COUNT_TARGET}` placeholder carries the per-level target; the split rule (INLINE 4-6 + WORKBOOK 6-9 at A1, etc.) is enforced by the activity-schema gate. Schema fields stay canonical per "Activity Authoring Fields" (HARD FAIL on aliases like `wrong:`/`incorrect:` instead of `error:`).

--- a/scripts/build/universal_rules/R-AUDIENCE-LANGUAGE-A1.md
+++ b/scripts/build/universal_rules/R-AUDIENCE-LANGUAGE-A1.md
@@ -1,0 +1,12 @@
+---
+id: R-AUDIENCE-LANGUAGE-A1
+description: A1/A2 explanation prose stays in English; Ukrainian only as TARGET.
+applies_to:
+  levels: [a1, a2]
+  tracks: [core]
+  activity_profiles: [all]
+slot: writer.body
+depends_on: []
+---
+
+**A1 audience language.** A1 explanation prose stays in English. Ukrainian appears only as TARGET: inline vocabulary words with English glosses, dialogue boxes, tables, conjugations, model sentences. Never use Ukrainian metalanguage TO the learner (`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`), because the learner cannot read Ukrainian explanations yet.

--- a/scripts/build/universal_rules/R-BAD-FORM-MARKER.md
+++ b/scripts/build/universal_rules/R-BAD-FORM-MARKER.md
@@ -1,0 +1,40 @@
+---
+id: R-BAD-FORM-MARKER
+description: Wrap non-VESUM teaching-contrast forms in HTML bad-form markers; decolonized framing.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: [R-VESUM-ALL-WORDS]
+---
+
+Decolonized framing is default. Ukraine has its own canon and history; Russian-imperial writers stay Russian; Holodomor is genocide; the war is a war, not a "conflict"; reject Soviet euphemisms such as "reunification" and "brotherly peoples."
+
+**Bad-form marker convention (MANDATORY everywhere).** Any Ukrainian word form that is NOT in VESUM and appears only as a teaching contrast MUST be wrapped in `<!-- bad -->...<!-- /bad -->` markers in every artifact. Do not use italics or bare prose for bad forms.
+
+```markdown
+Stick to **<canonical Ukrainian form>** (not the Russian-borrowed <!-- bad -->X<!-- /bad -->),
+and use **<native Ukrainian verb>** (not the surzhyk <!-- bad -->Y<!-- /bad -->).
+```
+
+**Positive requirement for A1-A2 vocabulary modules:** when the module covers vocabulary domains where L1-Russian-exposure learners are likely to substitute Russian borrowings (food/dining, household items, clothing, daily routines, family, body, time-of-day expressions, transportation, common verbs of action), include **AT LEAST ONE** explicit bad-form contrast pair using the marker syntax above. This is a pedagogical tool (contrast pairs accelerate L2 acquisition) AND satisfies the `llm_qg.decolonization` rubric's criterion (b) — see `scripts/build/phases/linear-review-dim.md` § `decolonization`. Pick the single most-likely L1 substitution for the module's topic from the wiki/plan/RAG content and include it concretely. One marker pair is sufficient; this isn't a quantity gate.
+
+Modules whose topic does NOT involve L1-Russian-substitutable vocabulary (e.g. pure grammar abstractions, IPA-only phonetics drill, formal-letter templates) are exempt — but for those, document the exemption inline in your `<plan_reasoning>` so the reviewer doesn't dock for absence.
+
+Apply the same convention in `module.md`, `activities.yaml` statements/items, and `vocabulary.yaml` usage lines when they name a wrong form. `type: error-correction` `sentence:` / `error:` fields are already excluded from VESUM; markers are optional there.
+
+**CONCRETE FORBIDDEN PATTERNS — HARD REJECT.** These trip `vesum_verified`, `formatting_standards`, or `russianisms_clean` unless the bad form is comment-marked:
+- `*X*, not *Y*` or `... not *Y*` — italic bad-form leak.
+- `say X, not Y`, `X, а не Y`, `instead of Y`, `замість Y` — unmarked contrast.
+- `(not Y)` / `(не Y)` — unmarked parenthetical contrast.
+- true-false `statement: "X, а не Y."` when Y is malformed or Russianism.
+
+REQUIRED: `Stick to **X** (not the Russian-borrowed <!-- bad -->Y<!-- /bad -->).`
+When in doubt, omit the bad contrast and teach only the good form.
+
+**Morpheme-bold notation.** Do not put hyphens/slashes inside bold spans: write `<verb> (**-suffix**)`, not `<verb>**-suffix**` or `**-suffix/-variant**`.
+
+**Textbook syllable-break notation.** Keep textbook syllable hyphens only when the module teaches syllabification / склади. Otherwise strip display hyphens before learner-facing prose.
+
+**Russianism floor.** `russianisms_strict` fails on any critical Russicism/calque/surzhyk finding. Check suspicious forms with `check_russian_shadow`, `search_style_guide`, `search_ua_gec_errors`, `search_heritage`, and `query_pravopys`. Never paste raw Russian forms into prose/dialogue; use a `<!-- VERIFY -->` placeholder or omit.

--- a/scripts/build/universal_rules/R-CITE-HONEST.md
+++ b/scripts/build/universal_rules/R-CITE-HONEST.md
@@ -1,0 +1,22 @@
+---
+id: R-CITE-HONEST
+description: Use real sources only; verify attribution; quotes must pass verify_quote.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+Use real sources only. Grammar/cultural claims need attributed, MCP-groundable evidence; ghost references fail `citations_resolve`. Use `mcp__sources__verify_source_attribution(source, claim)` for dictionary/style-guide/author claims and do not cite when `discusses=false`.
+
+Сибір case study (May 2026): a prior answer fabricated a Грінченко citation, an Антоненко-Давидович claim, and a fused Shevchenko line. Verify before citing; do not ship authority theatre.
+
+**Source-citation discipline** (citation honesty). Use `mcp__sources__verify_source_attribution(source, claim)` for dictionary/style-guide/source claims. If `discusses=false`, do not cite. Every grammar claim must be grounded in the Knowledge Packet or a retrieved textbook/source chunk.
+
+**Grammar claim grounding.** EVERY specific grammar claim (rules about aspect, case endings, syntax, phonetics, morphology, word formation, stress/prosody, orthography, or learner-facing meaning distinctions) MUST cite an authoritative source from the Knowledge Packet or a specific school textbook. Name the source in the text or as an HTML comment with concrete metadata: `<!-- VERIFY: source="..." grade="..." author="..." -->`. If it's a new rule not verbatim in the packet, verify it via `mcp__sources__search_text` and cite the exact grade and author.
+
+Sources in blockquotes/resources must be either in `plan_references` or grounded in a Knowledge Packet / `search_text` result that appears in writer telemetry, EXCEPT `resources.yaml` entries with `role: textbook`: those come ONLY from `plan.references`. Every textbook-role resource MUST carry the plan chunk_id in `packet_chunk_id`, `chunk_id`, or `notes`, and that chunk_id MUST appear literally in `plan.references[*].notes`. Knowledge Packet anchors and out-of-plan `search_text` results may support understanding, but they MUST NOT become textbook entries in `resources.yaml`.
+
+**Quote attribution discipline.** Every attributed Ukrainian quote must pass `mcp__sources__verify_quote(author, text)` with `matched=true` and `best_confidence >= 0.85`. Never fuse snippets from separate sources.

--- a/scripts/build/universal_rules/R-CLEAN-TABLES.md
+++ b/scripts/build/universal_rules/R-CLEAN-TABLES.md
@@ -1,0 +1,22 @@
+---
+id: R-CLEAN-TABLES
+description: Bold target Ukrainian forms only; conjugation tables need all six person/number rows.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+**Clean table formatting.** Tables: bold ONLY the target Ukrainian forms. Pronoun columns (`я`, `ти`, ...), English headers, and English glosses remain in regular weight. Conjugation tables teaching a present-tense paradigm must include the FULL set of person/number rows: **я / ти / він,вона,воно / ми / ви / вони** (six rows). Vocabulary tables stay two-column unless a third column adds essential teaching value (e.g., stress mark, IPA).
+
+**Dialogue format (gate-counted).** Ukrainian dialogue lines must be `<DialogueBox uk="..." en="...">` or `> ` blockquotes. Em-dash-only dialogue under `## Діалоги` is invisible to `l2_exposure_floor` and fails the module.
+
+Use `<DialogueBox uk="..." en="...">` to render dialogues with side-by-side translation. This satisfies Practice 2 + Practice 4 of ULP for A1 and the `l2_exposure_floor` gate. Em-dash bare lines without an `en` prop fail the gate. Every dialogue line needs an **inline English gloss** provided **within 8 tokens** of the Ukrainian text. Place longer expression notes at the **block-bottom** of the component.
+
+**Minimum UK dialogue lines (A1-A2).** For A1 and A2 modules, emit at least **15 distinct gate-countable Ukrainian dialogue surfaces** (`<DialogueBox uk="..." en="...">` entries and `> ` blockquote lines, summed). The `l2_exposure_floor` gate's floor is 14; overshoot by ≥1 for safety. Prior builds have failed at exactly 13 gate-countable lines via `too_few_uk_dialogue_lines`. Count BEFORE emitting: if you have <15, add another exchange to the dialogue section or split a long turn into two shorter ones.
+
+`шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. When you use it, add a `notes:` field to the `що` entry in `vocabulary.yaml` flagging the literary↔colloquial pair so learners know when each is appropriate (the per-item schema accepts `notes`, NOT `note` — singular fails schema validation). Do NOT add a separate top-level entry for `шо` — VESUM does not codify it and the vocab gate will reject a standalone lemma.
+
+**UK example-sentence density.** A1-m15-24 modules need >=14 gate-countable Ukrainian example surfaces across bullet-list lines and Markdown table data rows. Use bullets/tables for paradigms and trap pairs; prose-only paradigms count zero.

--- a/scripts/build/universal_rules/R-GRAMMAR-TERMS-A1.md
+++ b/scripts/build/universal_rules/R-GRAMMAR-TERMS-A1.md
@@ -1,0 +1,12 @@
+---
+id: R-GRAMMAR-TERMS-A1
+description: Use proper grammar terminology in English explanations at A1; no paraphrase.
+applies_to:
+  levels: [a1, a2]
+  tracks: [core]
+  activity_profiles: [all]
+slot: writer.body
+depends_on: []
+---
+
+**Use grammar terms at A1.** Use proper grammatical terminology in English explanations: **noun**, **verb**, **adjective**, **adverb**, **pronoun**, **reflexive**, **conjugation**. Do NOT paraphrase (`a thing`, `an action`, `a word for`, `a doing-word`, `the X-form of Y`). Adult learners benefit from real grammar terms because they transfer to future modules and outside references.

--- a/scripts/build/universal_rules/R-IMPL-MAP-COMPLETE.md
+++ b/scripts/build/universal_rules/R-IMPL-MAP-COMPLETE.md
@@ -1,0 +1,18 @@
+---
+id: R-IMPL-MAP-COMPLETE
+description: Implementation map must list every obligation_id with artifact, location, treatment.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+`<implementation_map>`: list every `obligation_id` exactly once with artifact, location, treatment. Omission causes `implementation_map_missing`. If a row cannot fit current scope, emit artifact/location `<none>` and treatment `deferred — <why>`.
+
+Emit `<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[<deferred IDs>]</implementation_map_audit>` as the first audit line.
+
+If `M < N`, fix the map before artifacts.
+
+Pre-resolved tuples come from the Implementation Map Contract: `(obligation_id, artifact, location_hint, treatment_template)`. Emit each row's required element at its `location_hint` using its `treatment_template`. Do NOT invent obligations beyond the manifest; do NOT skip rows. The deterministic `wiki_coverage_gate` verifies row-by-row; missing rows produce `fix_proposals` and the rebuild is wasted. Treatment templates that look thin → copy keys/values verbatim; do not pad. Gate diagnostics, not your prose, drive seeder fixes.

--- a/scripts/build/universal_rules/R-NO-CHILDREN-PRIMARY-QUOTES.md
+++ b/scripts/build/universal_rules/R-NO-CHILDREN-PRIMARY-QUOTES.md
@@ -1,0 +1,12 @@
+---
+id: R-NO-CHILDREN-PRIMARY-QUOTES
+description: No Grade 1-3 blockquotes in published adult A1/A2 module body.
+applies_to:
+  levels: [a1, a2]
+  tracks: [core]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: [R-CITE-HONEST, R-TEXTBOOK-30W]
+---
+
+**No children-primary blockquotes in adult A1.** No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body. Grade 1-3 RAG hits can still ground lexical choices, but do not surface as quoted material. Default: NO blockquote unless it pedagogically advances the lesson AND comes from an adult-appropriate source (Grade 7+, adult literature, Антоненко-Давидович, style guides). Adult A1 learners are not reading children's primers; do not print `<Author>, Grade 1, p.<P>` as lesson prose.

--- a/scripts/build/universal_rules/R-NO-SCAFFOLDING-LEAKS.md
+++ b/scripts/build/universal_rules/R-NO-SCAFFOLDING-LEAKS.md
@@ -1,0 +1,14 @@
+---
+id: R-NO-SCAFFOLDING-LEAKS
+description: No writer-side scaffolding (panel IDs, Krok labels, obligation names) in published module body.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+**No writer-side scaffolding leaks.** Writer-side scaffolding never appears in module body. Forbidden in published markdown: panel IDs (`P1`, `P2`, ...), Krok-N labels (`Крок 5:`, `Step 5:`), obligation names from the wiki_coverage manifest (`ban-4`, `step-5`, ...), reviewer-fix anchors, phase names, gate names. The module is a finished lesson, not a writer's worksheet.
+
+Integrate each Wiki Coverage Required item into natural lesson flow (a model sentence, usage example, conjugation row, phonetic transcription). Do NOT echo `Крок N:` labels or `[S\d+]` source markers — writer-side scaffolding.

--- a/scripts/build/universal_rules/R-PROSE-FLOOR-A1.md
+++ b/scripts/build/universal_rules/R-PROSE-FLOOR-A1.md
@@ -1,0 +1,12 @@
+---
+id: R-PROSE-FLOOR-A1
+description: Per-section prose word budget (270-330 at A1) counts prose only; structure is bonus.
+applies_to:
+  levels: [a1, a2]
+  tracks: [core]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+**Prose words only — section budget.** Per-section word budgets (270-330 for A1) count PROSE only. Callouts, dialogue boxes, table cells, bullets, comments do NOT count. Structural elements are *bonus density*, not budget — still emit ≥270 words of prose AROUND tables/callouts. Reach the prose floor BEFORE you optimize for clean structure.

--- a/scripts/build/universal_rules/R-RENDERER-CHARTER.md
+++ b/scripts/build/universal_rules/R-RENDERER-CHARTER.md
@@ -1,0 +1,23 @@
+---
+id: R-RENDERER-CHARTER
+description: Writer is a renderer, not a composer; wiki content is the lesson.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: writer.preamble
+depends_on: []
+---
+
+You are a RENDERER, not a composer. The wiki content embedded later in this prompt (§ LESSON SOURCE, § Wiki Obligations Manifest, § Wiki Coverage Required Items, § Implementation Map Contract) is the LESSON. Your job is to translate that wiki content into the four artifacts using English (A1/A2) or Ukrainian (B1+) teacher voice. You DO NOT invent vocabulary, examples, citations, dialogue lines, phonetic rules, decolonization stances, or grammar claims that are not derivable from the wiki + plan + cited RAG chunks.
+
+What you DO compose, bounded by the layered vocab allowlist (wiki vocabulary_minimum ∪ plan.targets.new_vocabulary ∪ plan.targets.vocabulary_hints ∪ cumulative_learner_state.taught_lemmas ∪ closed_class_function_words ∪ proper_nouns_in_wiki_examples ∪ bad_form_markers ∪ quoted_evidence_from_cited_RAG_chunks):
+
+1. **English glosses** for Ukrainian words (A1/A2). Prefer `mcp__sources__translate_en_uk` for canonical Balla EN-UK lookups; do not invent.
+2. **Dialogue boxes** — wiki provides example sentences; you compose 6-8 turn dialogues using ONLY allowlist lemmas. The `l2_exposure_floor` gate's 14-line A1/A2 minimum still applies; the `learner_state` vocab gate hard-fails on content lemmas outside the allowlist.
+3. **Section intros, transitions, closing summary** — bounded teacher voice the wiki doesn't carry. Subject to `#R-VOICE-META` forbidden patterns.
+4. **Activity items** — wiki names the format (`Вправа 1: fill-in reflexive verbs`); you compose concrete items using ONLY allowlist lemmas. See `#R-ACTIVITY-COMPOSITION` below.
+
+Voice rewrite, NOT translation: rewrite 3rd-person methodological Ukrainian wiki prose → 2nd-person teacher voice (English at A1/A2, Ukrainian at B1+). You may shorten, reorder for pedagogical flow, and add transitions. You may NOT add Ukrainian content the wiki did not authorize. If a section needs more Ukrainian than the wiki carries, STOP and emit `<implementation_map>` `treatment="deferred — wiki section thin"` for that row; do not invent to fill the gap.
+
+Upstream guard: the `wiki_completeness_gate` blocks the build BEFORE you run if the wiki is thin (missing methodology, <5 sequence steps at A1/A2, <3 L2 errors, <20 vocab lemmas, <6 distractors). You will not see thin wikis. If your run gets here, the wiki passed; render it faithfully.

--- a/scripts/build/universal_rules/R-SINGLE-VOICE-A1.md
+++ b/scripts/build/universal_rules/R-SINGLE-VOICE-A1.md
@@ -1,0 +1,12 @@
+---
+id: R-SINGLE-VOICE-A1
+description: One warm direct second-person teacher voice at A1; no third-person framing of learner.
+applies_to:
+  levels: [a1, a2]
+  tracks: [core]
+  activity_profiles: [all]
+slot: writer.body
+depends_on: []
+---
+
+**Single teacher voice at A1.** One teacher voice across the whole module: warm, clear, direct ("you" / "your"). No third-person framing of the learner (`the student`, `студента`, `the reader`, `учня`) and no mid-paragraph register shifts (English -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase). Good: "You use **я креслю** when you describe your own action." Bad: "the student enters an authentic space."

--- a/scripts/build/universal_rules/R-TEXTBOOK-30W.md
+++ b/scripts/build/universal_rules/R-TEXTBOOK-30W.md
@@ -1,0 +1,22 @@
+---
+id: R-TEXTBOOK-30W
+description: Chunk_id-first textbook grounding with ≥30-word verbatim blockquotes for adult sources.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: [R-CITE-HONEST]
+---
+
+**Textbook grounding.** For each `plan_references` entry, you MUST retrieve the chunk text from MCP and use THAT text as grounding — paraphrasing, topic-keyword search, or pasting from memory all fail this gate.
+
+(A) **Identify the chunk_id.** If `plan_references[*].notes` contains `chunk_id: <ID>`, copy that ID verbatim and go directly to step (B). Do NOT use `search_text` for references that already name a chunk_id; only search by author + page when notes truly lacks one. Topic-keyword searches fail this gate.
+
+(B) **Retrieve the chunk text.** Call `mcp__sources__get_chunk_context(chunk_id=<ID>)`. This step is MANDATORY — calling `search_text` alone returns a truncated snippet, not the full chunk text. The `chunk_context_for_all_refs` gate verifies these calls; if any fetchable reference is missing a `get_chunk_context` call, the gate HARD-rejects regardless of blockquote content.
+
+(C) **Surface only adult-appropriate source blockquotes.** Grade 1-3 chunks ground choices but do NOT appear as learner-facing `>` blockquotes. Adult-appropriate sources require one verbatim >=30-word Ukrainian blockquote per cited reference; no paraphrasing, translation, stitching, Russian-script text, or syllable-hyphen edits.
+
+(D) Add the exact citation line immediately after the blockquote: `*— <Author>, Grade <N>, p.<PAGE>*` (em-dash + spaces, italic).
+
+For adult-appropriate blockquotes, fewer than 30 words per blockquote, or a blockquote whose text is not literally contained in the returned chunk, makes the `published_quote_for_publishable_refs` gate HARD-reject. For Grade 1, 2, or 3 chunks, missing a learner-facing `>` blockquote is correct; the chunk still must be retrieved and used as grounding.

--- a/scripts/build/universal_rules/R-VESUM-ALL-WORDS.md
+++ b/scripts/build/universal_rules/R-VESUM-ALL-WORDS.md
@@ -1,0 +1,18 @@
+---
+id: R-VESUM-ALL-WORDS
+description: Verify every Cyrillic word form in artifacts via mcp__sources__verify_words.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+**Verify every example word in VESUM** (VESUM all-words coverage). Verify every Cyrillic word form in `module.md`, `activities.yaml`, `vocabulary.yaml`, and `resources.yaml` via `mcp__sources__verify_words`, except intentionally bad forms protected by `<!-- bad -->...<!-- /bad -->` or fields the gate excludes (`error:` / `errorWord:` in error-correction items). Selective verification is silent fabrication.
+
+**L2-trap: over-applied reflexive -ся.** Before emitting any `-ся` form, verify it. These always fail as personal reflexives unless VESUM says otherwise: `пити → *п'юся`, `читати → *читаюся`, `писати → *пишуся`.
+
+**Modern Ukrainian + heritage-defense discipline.** Default to post-2019 Pravopys forms. Never classify a word as Russianism/surzhyk/calque merely because it is archaic, historical, dialectal, or shares Proto-Slavic roots with Russian. Route uncertain forms through `mcp__sources__search_heritage` first (the кобета/кобіта pattern). If the form is authentic but non-standard, tag `[Archaism]` / `[Historism]` / `[Dialectism]` and give the modern equivalent. Unverified → omit or emit `<!-- VERIFY: heritage status for "X" unresolved -->`.
+
+Use the canonical MCP names as applicable for Tier-1 checks: `mcp__sources__check_modern_form`, `search_definitions`, `search_style_guide`, `search_grinchenko_1907`, `query_pravopys`, `search_esum`, `mcp__sources__search_heritage`, `mcp__sources__search_slovnyk_me`.

--- a/scripts/build/universal_rules/R-VOICE-META.md
+++ b/scripts/build/universal_rules/R-VOICE-META.md
@@ -1,0 +1,18 @@
+---
+id: R-VOICE-META
+description: Adult peer voice; no English meta-narration or teacherly transitions in module.md.
+applies_to:
+  levels: [all]
+  tracks: [all]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: []
+---
+
+Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`. The `engagement_floor` gate HARD-fails on phrases that describe the artifact rather than addressing the learner. Forbidden patterns (English): "Welcome to the start of our journey", "In this section we will learn", "in this module", "in this lesson", "this module covers", "this lesson covers", "we will learn", "you will learn" (in the meta sense, not a real plan), "Now that you have seen these verbs", "Let's now look at", "Before we move on", "Note that…", "Notice that…", "Observe that…", "Pay attention to…", "Remember that…", "It is important to…". Forbidden patterns (Ukrainian): "у цьому модулі", "у цьому уроці", "у цьому розділі", "у цій темі", "ми вивчимо", "ми побачимо", "далі ми…". Rule of thumb: speak TO the learner in second person about the LANGUAGE; never narrate ABOUT the module or section. Open every section with a fact, an example, a dialogue line, or a direct second-person instruction — never with a preamble about what the section will do.
+
+B1+ body text outside Tab 2 is Ukrainian only: no rescue notes, mirrored translations, parenthetical English grammar glosses, or English activity instructions. Tab 2 may carry English translations and expression notes.
+
+Activities test Ukrainian, not content recall. Pure language mechanics are fine; trivia such as "У якому році Хмельницький підписав Переяславську угоду?" is not.
+
+**Engagement floor.** Emit at least 1 content-anchored callout (`:::tip`, `:::note`, `:::caution`, `:::warning`, `[!myth-buster]`, `[!history-bite]`). It must contain a mnemonic, myth-bust, cultural note, or common-mistake reminder. Empty filler does not count. Meta-narration hits fail `engagement_floor` immediately.

--- a/scripts/build/universal_rules/README.md
+++ b/scripts/build/universal_rules/README.md
@@ -1,0 +1,11 @@
+# Universal Rules Registry
+
+Fragments keyed by `#R-*` IDs consumed by the V7.2 prompt generator.
+
+See [`docs/best-practices/universal-rules-registry.md`](../../../docs/best-practices/universal-rules-registry.md)
+for the design + how to add a new rule.
+
+Loader: [`scripts/build/universal_rules_registry.py`](../universal_rules_registry.py).
+
+**This README is documentation only — it does NOT carry frontmatter and is
+ignored by the loader (the loader globs `R-*.md`, not `*.md`).**

--- a/scripts/build/universal_rules_registry.py
+++ b/scripts/build/universal_rules_registry.py
@@ -1,0 +1,289 @@
+"""Universal rules registry — V7.2 Step 4 scaffold.
+
+Loads `R-<NAME>.md` fragments from `scripts/build/universal_rules/` and exposes
+filtering + topologically-sorted access. The Step 5 prompt generator will
+consume this to compose writer + reviewer prompts; Step 4 only ships the
+registry + loader (the legacy `scripts/build/phases/linear-write.md`
+template still drives builds during the migration).
+
+Design + roadmap: `docs/best-practices/universal-rules-registry.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+UNIVERSAL_RULES_DIR = Path(__file__).resolve().parent / "universal_rules"
+
+VALID_SLOTS = frozenset(
+    {
+        "writer.preamble",
+        "writer.body",
+        "reviewer.rubric",
+        "shared.contract",
+    }
+)
+
+VALID_LEVELS = frozenset({"a1", "a2", "b1", "b2", "c1", "c2", "all"})
+VALID_TRACKS = frozenset({"core", "seminar", "all"})
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+class RuleRegistryError(Exception):
+    """Base class for registry errors."""
+
+
+class MalformedFragmentError(RuleRegistryError):
+    """Fragment frontmatter is missing, malformed, or violates the schema."""
+
+
+class MissingDependencyError(RuleRegistryError):
+    """A `depends_on` entry names a rule id that does not exist as a fragment."""
+
+
+class CircularDependencyError(RuleRegistryError):
+    """Topological sort detected a cycle among `depends_on` edges."""
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single universal-rules registry fragment.
+
+    `id` is the bare form (`R-VESUM-ALL-WORDS`); `telemetry_id` restores the
+    leading `#` that matches the pipeline's existing `rule_id` telemetry
+    constants (e.g. `RULE_VESUM_ALL_WORDS = "#R-VESUM-ALL-WORDS"`).
+    """
+
+    id: str
+    description: str
+    levels: tuple[str, ...]
+    tracks: tuple[str, ...]
+    activity_profiles: tuple[str, ...]
+    slot: str
+    depends_on: tuple[str, ...]
+    body: str
+    source_path: Path
+
+    @property
+    def telemetry_id(self) -> str:
+        return f"#{self.id}"
+
+
+def _coerce_str_list(
+    path: Path, field: str, value: object, allowed: frozenset[str] | None
+) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise MalformedFragmentError(
+            f"{path}: applies_to.{field} must be a non-empty list, got {value!r}"
+        )
+    if any(not isinstance(v, str) for v in value):
+        raise MalformedFragmentError(
+            f"{path}: applies_to.{field} entries must all be strings"
+        )
+    if allowed is not None:
+        bad = [v for v in value if v not in allowed]
+        if bad:
+            raise MalformedFragmentError(
+                f"{path}: applies_to.{field} has unknown values {bad}; "
+                f"expected subset of {sorted(allowed)}"
+            )
+    return tuple(value)
+
+
+def _parse_fragment(path: Path) -> Rule:
+    text = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        raise MalformedFragmentError(
+            f"{path}: missing YAML frontmatter (expected '---' fenced block at top)"
+        )
+    raw_yaml, body = match.group(1), match.group(2).strip()
+    try:
+        meta = yaml.safe_load(raw_yaml) or {}
+    except yaml.YAMLError as exc:
+        raise MalformedFragmentError(
+            f"{path}: invalid YAML frontmatter: {exc}"
+        ) from exc
+    if not isinstance(meta, dict):
+        raise MalformedFragmentError(f"{path}: frontmatter must be a mapping")
+
+    required = {"id", "applies_to", "slot"}
+    missing = required - meta.keys()
+    if missing:
+        raise MalformedFragmentError(
+            f"{path}: missing required frontmatter fields: {sorted(missing)}"
+        )
+
+    rule_id = meta["id"]
+    if not isinstance(rule_id, str) or not rule_id.startswith("R-"):
+        raise MalformedFragmentError(
+            f"{path}: id must be a string starting with 'R-' (no '#' prefix), got {rule_id!r}"
+        )
+    expected_stem = rule_id
+    if path.stem != expected_stem:
+        raise MalformedFragmentError(
+            f"{path}: filename stem {path.stem!r} must match id {expected_stem!r}"
+        )
+
+    slot = meta["slot"]
+    if slot not in VALID_SLOTS:
+        raise MalformedFragmentError(
+            f"{path}: invalid slot {slot!r}; expected one of {sorted(VALID_SLOTS)}"
+        )
+
+    applies_to = meta["applies_to"]
+    if not isinstance(applies_to, dict):
+        raise MalformedFragmentError(
+            f"{path}: applies_to must be a mapping, got {type(applies_to).__name__}"
+        )
+
+    levels = _coerce_str_list(path, "levels", applies_to.get("levels", ["all"]), VALID_LEVELS)
+    tracks = _coerce_str_list(path, "tracks", applies_to.get("tracks", ["all"]), VALID_TRACKS)
+    activity_profiles = _coerce_str_list(
+        path, "activity_profiles", applies_to.get("activity_profiles", ["all"]), None
+    )
+
+    depends_on = meta.get("depends_on", []) or []
+    if not isinstance(depends_on, list) or any(not isinstance(x, str) for x in depends_on):
+        raise MalformedFragmentError(
+            f"{path}: depends_on must be a list of strings"
+        )
+
+    description = meta.get("description", "")
+    if not isinstance(description, str):
+        raise MalformedFragmentError(f"{path}: description must be a string")
+
+    return Rule(
+        id=rule_id,
+        description=description,
+        levels=levels,
+        tracks=tracks,
+        activity_profiles=activity_profiles,
+        slot=slot,
+        depends_on=tuple(depends_on),
+        body=body,
+        source_path=path,
+    )
+
+
+def load_all_rules(directory: Path | None = None) -> list[Rule]:
+    """Discover and parse every `R-*.md` fragment under `directory`.
+
+    Returns rules in filename-alphabetical order. The loader globs
+    `R-*.md` (not `*.md`) so `README.md` and any sibling docs are
+    naturally excluded.
+
+    Each invocation re-reads the filesystem; callers that need caching
+    should wrap their own.
+    """
+    base = directory if directory is not None else UNIVERSAL_RULES_DIR
+    if not base.is_dir():
+        raise RuleRegistryError(
+            f"universal rules directory does not exist: {base}"
+        )
+    rules: list[Rule] = []
+    seen_ids: dict[str, Path] = {}
+    for path in sorted(base.glob("R-*.md")):
+        rule = _parse_fragment(path)
+        if rule.id in seen_ids:
+            raise MalformedFragmentError(
+                f"duplicate rule id {rule.id!r}: {seen_ids[rule.id]} and {path}"
+            )
+        seen_ids[rule.id] = path
+        rules.append(rule)
+    return rules
+
+
+def _matches(values: tuple[str, ...], target: str) -> bool:
+    return "all" in values or target in values
+
+
+def _topological_sort(
+    rules: list[Rule], full_index: dict[str, Rule]
+) -> list[Rule]:
+    """Sort `rules` so each rule appears after its `depends_on` entries.
+
+    Validates every `depends_on` id against `full_index` (the *complete*
+    registry, not the filtered subset) — a filtered-out parent that does
+    not exist anywhere still raises `MissingDependencyError`. Tie-break is
+    input order (= filename-alphabetical from `load_all_rules`).
+    """
+    selected_ids = {r.id for r in rules}
+    for rule in rules:
+        for dep in rule.depends_on:
+            if dep not in full_index:
+                raise MissingDependencyError(
+                    f"{rule.id} depends_on {dep!r}, but no such rule fragment exists"
+                )
+    output: list[Rule] = []
+    emitted: set[str] = set()
+    remaining = list(rules)
+    progress = True
+    while remaining and progress:
+        progress = False
+        next_remaining: list[Rule] = []
+        for rule in remaining:
+            in_set_deps = [d for d in rule.depends_on if d in selected_ids]
+            if all(d in emitted for d in in_set_deps):
+                output.append(rule)
+                emitted.add(rule.id)
+                progress = True
+            else:
+                next_remaining.append(rule)
+        remaining = next_remaining
+    if remaining:
+        raise CircularDependencyError(
+            "circular dependency among rules: "
+            + ", ".join(sorted(r.id for r in remaining))
+        )
+    return output
+
+
+def load_applicable_rules(
+    level: str,
+    track: str,
+    activity_profile: str,
+    slot: str | None = None,
+    directory: Path | None = None,
+) -> list[Rule]:
+    """Return rules whose `applies_to` predicates match.
+
+    Args:
+        level: One of {a1, a2, b1, b2, c1, c2}. Rules with `levels: [all]`
+            match every level.
+        track: One of {core, seminar}. Rules with `tracks: [all]` match
+            every track.
+        activity_profile: Free-form profile string (e.g. `default`).
+            Rules with `activity_profiles: [all]` match every profile.
+        slot: Optional. If provided, only fragments whose `slot` matches
+            are returned. `None` returns every slot.
+        directory: Optional override for the registry directory (testing).
+
+    Returns:
+        Rules in topological order: every `depends_on` precedes its
+        dependents. Tie-break is filename-alphabetical.
+    """
+    all_rules = load_all_rules(directory)
+    full_index = {r.id: r for r in all_rules}
+    filtered = [
+        r
+        for r in all_rules
+        if _matches(r.levels, level)
+        and _matches(r.tracks, track)
+        and _matches(r.activity_profiles, activity_profile)
+        and (slot is None or r.slot == slot)
+    ]
+    return _topological_sort(filtered, full_index)
+
+
+def get_rule(rule_id: str, directory: Path | None = None) -> Rule:
+    """Fetch a single rule by id (`R-X` form, no `#` prefix)."""
+    for rule in load_all_rules(directory):
+        if rule.id == rule_id:
+            return rule
+    raise KeyError(f"no rule fragment with id={rule_id!r}")

--- a/tests/build/test_universal_rules_registry.py
+++ b/tests/build/test_universal_rules_registry.py
@@ -1,0 +1,384 @@
+"""Tests for the V7.2 universal-rules registry loader.
+
+Covers: real-fragment discovery + parsing, predicate filtering, topological
+ordering, malformed-fragment handling, missing/circular deps, and the
+telemetry-id contract (`#R-X`) used by `linear_pipeline.rule_id` telemetry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.build import universal_rules_registry as reg
+from scripts.build.universal_rules_registry import (
+    CircularDependencyError,
+    MalformedFragmentError,
+    MissingDependencyError,
+    RuleRegistryError,
+    get_rule,
+    load_all_rules,
+    load_applicable_rules,
+)
+
+REAL_REGISTRY = reg.UNIVERSAL_RULES_DIR
+
+
+def _write_fragment(
+    directory: Path,
+    rule_id: str,
+    *,
+    slot: str = "shared.contract",
+    levels: list[str] | None = None,
+    tracks: list[str] | None = None,
+    activity_profiles: list[str] | None = None,
+    depends_on: list[str] | None = None,
+    description: str = "Synthetic fixture rule.",
+    body: str = "Body content.",
+) -> Path:
+    """Write a well-formed fragment file under `directory` and return its path."""
+    levels = levels or ["all"]
+    tracks = tracks or ["all"]
+    activity_profiles = activity_profiles or ["all"]
+    depends_on = depends_on or []
+    path = directory / f"{rule_id}.md"
+    lines = [
+        "---",
+        f"id: {rule_id}",
+        f"description: {description}",
+        "applies_to:",
+        f"  levels: {levels}",
+        f"  tracks: {tracks}",
+        f"  activity_profiles: {activity_profiles}",
+        f"slot: {slot}",
+        f"depends_on: {depends_on}",
+        "---",
+        "",
+        body,
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Real-fragment smoke tests (locked against the shipped registry)
+# ---------------------------------------------------------------------------
+
+
+class TestRealRegistry:
+    def test_real_registry_discovers_at_least_fifteen_fragments(self) -> None:
+        rules = load_all_rules()
+        # Step 4 ships 15 fragments extracted from linear-write.md.
+        assert len(rules) >= 15, f"expected >=15 fragments, found {len(rules)}: {[r.id for r in rules]}"
+
+    def test_every_real_fragment_parses_cleanly(self) -> None:
+        rules = load_all_rules()
+        for rule in rules:
+            assert rule.id.startswith("R-")
+            assert rule.slot in reg.VALID_SLOTS
+            assert rule.body, f"{rule.id}: empty body"
+            assert rule.description, f"{rule.id}: empty description"
+
+    def test_telemetry_id_matches_pipeline_constants(self) -> None:
+        """`telemetry_id` must produce strings that match `linear_pipeline.RULE_*`."""
+        from scripts.build import linear_pipeline as lp
+
+        rules_by_id = {r.id: r for r in load_all_rules()}
+        # These pipeline constants name registry rules — verify exact match.
+        expected = {
+            lp.RULE_VOICE_META: "R-VOICE-META",
+            lp.RULE_BAD_FORM_MARKER: "R-BAD-FORM-MARKER",
+            lp.RULE_VESUM_ALL_WORDS: "R-VESUM-ALL-WORDS",
+            lp.RULE_IMPL_MAP_COMPLETE: "R-IMPL-MAP-COMPLETE",
+            lp.RULE_TEXTBOOK_30W: "R-TEXTBOOK-30W",
+            lp.RULE_CITE_HONEST: "R-CITE-HONEST",
+        }
+        for telemetry_form, bare_id in expected.items():
+            assert bare_id in rules_by_id, f"missing fragment for pipeline constant {telemetry_form}"
+            assert rules_by_id[bare_id].telemetry_id == telemetry_form
+
+    def test_real_registry_depends_on_targets_all_exist(self) -> None:
+        """Every depends_on entry must point to a real fragment."""
+        rules = load_all_rules()
+        ids = {r.id for r in rules}
+        for rule in rules:
+            for dep in rule.depends_on:
+                assert dep in ids, f"{rule.id} depends_on {dep!r} which is not present"
+
+    def test_real_registry_is_acyclic(self) -> None:
+        """Topological sort of the full real registry must complete."""
+        # `load_applicable_rules` runs the topo sort internally; if there's a
+        # cycle in the real registry, this raises CircularDependencyError.
+        rules = load_applicable_rules("a1", "core", "all")
+        assert rules, "expected at least one applicable rule at a1/core/all"
+
+
+# ---------------------------------------------------------------------------
+# Discovery + frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryAndParsing:
+    def test_load_all_rules_skips_readme_and_non_R_files(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-ALPHA")
+        (tmp_path / "README.md").write_text("# Not a fragment\n", encoding="utf-8")
+        (tmp_path / "notes.md").write_text("---\nid: bogus\n---\n", encoding="utf-8")
+        rules = load_all_rules(tmp_path)
+        assert [r.id for r in rules] == ["R-ALPHA"]
+
+    def test_load_all_rules_returns_alphabetical_order(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-ZULU")
+        _write_fragment(tmp_path, "R-ALPHA")
+        _write_fragment(tmp_path, "R-MIKE")
+        rules = load_all_rules(tmp_path)
+        assert [r.id for r in rules] == ["R-ALPHA", "R-MIKE", "R-ZULU"]
+
+    def test_missing_frontmatter_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "R-BARE.md").write_text("just a body, no frontmatter\n", encoding="utf-8")
+        with pytest.raises(MalformedFragmentError, match="frontmatter"):
+            load_all_rules(tmp_path)
+
+    def test_invalid_yaml_frontmatter_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "R-BROKEN.md").write_text(
+            "---\nid: R-BROKEN\napplies_to: : :\n---\nbody\n", encoding="utf-8"
+        )
+        with pytest.raises(MalformedFragmentError):
+            load_all_rules(tmp_path)
+
+    def test_missing_required_field_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "R-INCOMPLETE.md").write_text(
+            "---\nid: R-INCOMPLETE\nslot: shared.contract\n---\nbody\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(MalformedFragmentError, match="applies_to"):
+            load_all_rules(tmp_path)
+
+    def test_invalid_slot_raises(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-BADSLOT", slot="invalid.slot")
+        with pytest.raises(MalformedFragmentError, match="invalid slot"):
+            load_all_rules(tmp_path)
+
+    def test_filename_must_match_id(self, tmp_path: Path) -> None:
+        path = tmp_path / "R-WRONGSTEM.md"
+        path.write_text(
+            "---\nid: R-OTHER\napplies_to:\n  levels: [all]\n  tracks: [all]\n  activity_profiles: [all]\nslot: shared.contract\n---\nbody\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(MalformedFragmentError, match="filename stem"):
+            load_all_rules(tmp_path)
+
+    def test_id_must_start_with_R_dash(self, tmp_path: Path) -> None:
+        path = tmp_path / "R-BADID.md"
+        path.write_text(
+            "---\nid: '#R-WITH-HASH'\napplies_to:\n  levels: [all]\n  tracks: [all]\n  activity_profiles: [all]\nslot: shared.contract\n---\nbody\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(MalformedFragmentError, match="must be a string starting with 'R-'"):
+            load_all_rules(tmp_path)
+
+    def test_unknown_level_in_applies_to_raises(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-BADLEVEL", levels=["c3"])
+        with pytest.raises(MalformedFragmentError, match="unknown values"):
+            load_all_rules(tmp_path)
+
+    def test_empty_levels_list_raises(self, tmp_path: Path) -> None:
+        # Write directly: _write_fragment treats `levels=[]` as "use default"
+        # via `levels or ["all"]`, which would defeat the test.
+        (tmp_path / "R-NOLEVELS.md").write_text(
+            "---\nid: R-NOLEVELS\napplies_to:\n  levels: []\n  tracks: [all]\n  activity_profiles: [all]\nslot: shared.contract\n---\nbody\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(MalformedFragmentError, match="non-empty list"):
+            load_all_rules(tmp_path)
+
+    def test_duplicate_ids_raise(self, tmp_path: Path) -> None:
+        """Two fragments declaring the same id (across separate files) is malformed."""
+        _write_fragment(tmp_path, "R-A")
+        # Second file with same id but different filename — bypass _write_fragment.
+        path = tmp_path / "R-A-COPY.md"
+        path.write_text(
+            "---\nid: R-A\napplies_to:\n  levels: [all]\n  tracks: [all]\n  activity_profiles: [all]\nslot: shared.contract\n---\nbody\n",
+            encoding="utf-8",
+        )
+        # First the filename-stem check should trip for the COPY file.
+        with pytest.raises(MalformedFragmentError):
+            load_all_rules(tmp_path)
+
+    def test_directory_must_exist(self, tmp_path: Path) -> None:
+        missing = tmp_path / "no-such-dir"
+        with pytest.raises(RuleRegistryError, match="does not exist"):
+            load_all_rules(missing)
+
+    def test_telemetry_id_prepends_hash(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-XYZ")
+        rule = load_all_rules(tmp_path)[0]
+        assert rule.telemetry_id == "#R-XYZ"
+
+
+# ---------------------------------------------------------------------------
+# Filtering by level / track / activity_profile / slot
+# ---------------------------------------------------------------------------
+
+
+class TestFiltering:
+    def test_levels_all_matches_every_level(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-UNIVERSAL", levels=["all"])
+        for level in ("a1", "a2", "b1", "b2", "c1", "c2"):
+            rules = load_applicable_rules(level, "core", "all", directory=tmp_path)
+            assert [r.id for r in rules] == ["R-UNIVERSAL"], level
+
+    def test_level_filter_excludes_non_matching_levels(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-A1ONLY", levels=["a1"])
+        _write_fragment(tmp_path, "R-B1ONLY", levels=["b1"])
+        a1_rules = load_applicable_rules("a1", "core", "all", directory=tmp_path)
+        assert [r.id for r in a1_rules] == ["R-A1ONLY"]
+        b1_rules = load_applicable_rules("b1", "core", "all", directory=tmp_path)
+        assert [r.id for r in b1_rules] == ["R-B1ONLY"]
+        c1_rules = load_applicable_rules("c1", "core", "all", directory=tmp_path)
+        assert c1_rules == []
+
+    def test_audience_language_a1_does_not_apply_at_b1(self) -> None:
+        """Locks in the answer to design question #1 from the dispatch brief."""
+        # Use the real registry directly to verify the level-conditional rules
+        # are predicated as designed.
+        rules = load_applicable_rules("b1", "core", "all")
+        ids = {r.id for r in rules}
+        assert "R-AUDIENCE-LANGUAGE-A1" not in ids
+        assert "R-SINGLE-VOICE-A1" not in ids
+        assert "R-GRAMMAR-TERMS-A1" not in ids
+        assert "R-PROSE-FLOOR-A1" not in ids
+        # And the universal rules ARE present.
+        assert "R-VESUM-ALL-WORDS" in ids
+        assert "R-CITE-HONEST" in ids
+
+    def test_track_filter(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-COREONLY", tracks=["core"])
+        _write_fragment(tmp_path, "R-SEMONLY", tracks=["seminar"])
+        _write_fragment(tmp_path, "R-BOTH", tracks=["all"])
+        core_rules = load_applicable_rules("a1", "core", "all", directory=tmp_path)
+        assert {r.id for r in core_rules} == {"R-COREONLY", "R-BOTH"}
+        sem_rules = load_applicable_rules("a1", "seminar", "all", directory=tmp_path)
+        assert {r.id for r in sem_rules} == {"R-SEMONLY", "R-BOTH"}
+
+    def test_activity_profile_filter(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-DEFAULT", activity_profiles=["default"])
+        _write_fragment(tmp_path, "R-CHECKPOINT", activity_profiles=["checkpoint"])
+        _write_fragment(tmp_path, "R-ANY", activity_profiles=["all"])
+        default_rules = load_applicable_rules("a1", "core", "default", directory=tmp_path)
+        assert {r.id for r in default_rules} == {"R-DEFAULT", "R-ANY"}
+
+    def test_slot_filter(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-PRE", slot="writer.preamble")
+        _write_fragment(tmp_path, "R-BODY", slot="writer.body")
+        _write_fragment(tmp_path, "R-RUBRIC", slot="reviewer.rubric")
+        _write_fragment(tmp_path, "R-SHARED", slot="shared.contract")
+        # No slot filter — get everything.
+        all_rules = load_applicable_rules("a1", "core", "all", directory=tmp_path)
+        assert len(all_rules) == 4
+        # Slot filter narrows.
+        body_only = load_applicable_rules("a1", "core", "all", slot="writer.body", directory=tmp_path)
+        assert [r.id for r in body_only] == ["R-BODY"]
+        shared_only = load_applicable_rules(
+            "a1", "core", "all", slot="shared.contract", directory=tmp_path
+        )
+        assert [r.id for r in shared_only] == ["R-SHARED"]
+
+
+# ---------------------------------------------------------------------------
+# Topological dependency ordering
+# ---------------------------------------------------------------------------
+
+
+class TestTopologicalSort:
+    def test_simple_chain_orders_correctly(self, tmp_path: Path) -> None:
+        # A depends on B; B should come first.
+        _write_fragment(tmp_path, "R-A", depends_on=["R-B"])
+        _write_fragment(tmp_path, "R-B")
+        ordered = load_applicable_rules("a1", "core", "all", directory=tmp_path)
+        assert [r.id for r in ordered] == ["R-B", "R-A"]
+
+    def test_diamond_dependency(self, tmp_path: Path) -> None:
+        # D -> {B, C} -> A. A first, then B and C (alphabetical tie), then D.
+        _write_fragment(tmp_path, "R-A")
+        _write_fragment(tmp_path, "R-B", depends_on=["R-A"])
+        _write_fragment(tmp_path, "R-C", depends_on=["R-A"])
+        _write_fragment(tmp_path, "R-D", depends_on=["R-B", "R-C"])
+        ordered = load_applicable_rules("a1", "core", "all", directory=tmp_path)
+        assert [r.id for r in ordered] == ["R-A", "R-B", "R-C", "R-D"]
+
+    def test_circular_dependency_raises(self, tmp_path: Path) -> None:
+        # R-X -> R-Y -> R-X (cycle)
+        _write_fragment(tmp_path, "R-X", depends_on=["R-Y"])
+        _write_fragment(tmp_path, "R-Y", depends_on=["R-X"])
+        with pytest.raises(CircularDependencyError, match="circular"):
+            load_applicable_rules("a1", "core", "all", directory=tmp_path)
+
+    def test_self_dependency_raises(self, tmp_path: Path) -> None:
+        # A rule that depends_on itself is a 1-node cycle.
+        _write_fragment(tmp_path, "R-SELF", depends_on=["R-SELF"])
+        with pytest.raises(CircularDependencyError):
+            load_applicable_rules("a1", "core", "all", directory=tmp_path)
+
+    def test_missing_dependency_raises(self, tmp_path: Path) -> None:
+        _write_fragment(tmp_path, "R-NEEDS", depends_on=["R-GHOST"])
+        with pytest.raises(MissingDependencyError, match="R-GHOST"):
+            load_applicable_rules("a1", "core", "all", directory=tmp_path)
+
+    def test_filtered_out_parent_does_not_break_ordering(self, tmp_path: Path) -> None:
+        """If a dep is filtered out by predicates, the dependent still appears,
+        and the ordering for the filtered subset is consistent.
+
+        This matters because composition slots may legitimately filter a parent
+        rule out — e.g. R-ACTIVITY-COMPOSITION (shared.contract) depends on
+        R-RENDERER-CHARTER (writer.preamble). Querying shared.contract alone
+        must still return R-ACTIVITY-COMPOSITION (parent is reachable in the
+        full registry, just not in the filtered slice).
+        """
+        _write_fragment(tmp_path, "R-PARENT", slot="writer.preamble")
+        _write_fragment(
+            tmp_path, "R-CHILD", slot="shared.contract", depends_on=["R-PARENT"]
+        )
+        shared = load_applicable_rules(
+            "a1", "core", "all", slot="shared.contract", directory=tmp_path
+        )
+        assert [r.id for r in shared] == ["R-CHILD"]
+
+    def test_missing_dep_still_raises_when_dep_is_filtered_out(
+        self, tmp_path: Path
+    ) -> None:
+        """If a depends_on id does NOT exist in the full registry at all, it must
+        still raise — even when the rule passes the slot filter. The check is
+        against the *full* registry, not just the filtered subset.
+        """
+        _write_fragment(
+            tmp_path, "R-CHILD", slot="shared.contract", depends_on=["R-GHOST"]
+        )
+        with pytest.raises(MissingDependencyError, match="R-GHOST"):
+            load_applicable_rules(
+                "a1", "core", "all", slot="shared.contract", directory=tmp_path
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_rule + Rule dataclass behavior
+# ---------------------------------------------------------------------------
+
+
+class TestGetRule:
+    def test_get_rule_returns_matching_fragment(self) -> None:
+        rule = get_rule("R-VESUM-ALL-WORDS")
+        assert rule.id == "R-VESUM-ALL-WORDS"
+        assert rule.slot == "shared.contract"
+        assert "VESUM" in rule.body
+
+    def test_get_rule_missing_raises_key_error(self) -> None:
+        with pytest.raises(KeyError, match="R-DOES-NOT-EXIST"):
+            get_rule("R-DOES-NOT-EXIST")
+
+    def test_rule_dataclass_is_frozen(self) -> None:
+        import dataclasses
+
+        rule = get_rule("R-VESUM-ALL-WORDS")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            rule.id = "R-MUTATED"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Step 4 of the wiki-driven prompt generator ADR ([`docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`](https://github.com/learn-ukrainian/learn-ukrainian.github.io/blob/claude/v7.2-step4-rule-registry-scaffold-2026-05-28/docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md)). Refs #2386.

Ships the universal rules registry **scaffold only** — fragments + loader + tests + design doc. Generator wiring is Step 5 (separate PR). The existing `scripts/build/phases/linear-write.md` template still drives builds during the migration; this registry runs parallel to it.

- 15 fragments extracted from `linear-write.md` (one per `#R-*` rule) under `scripts/build/universal_rules/`
- Loader at `scripts/build/universal_rules_registry.py` with discovery, frontmatter validation, predicate filtering, topological sort
- 34 unit tests covering real-registry shape + every malformed-frontmatter mode + filtering + dependency ordering (including diamond, cycle, self-dep, missing-dep, filtered-out parent)
- Design doc at `docs/best-practices/universal-rules-registry.md`

## Verifiable claims (#M-4)

| Claim | Evidence |
|---|---|
| 15 fragments extracted | \`find scripts/build/universal_rules/ -name 'R-*.md' \| wc -l\` → \`15\` |
| Loader parses every fragment | \`load_all_rules()\` → 15 \`Rule\` objects; all parse cleanly |
| Level filter excludes A1/A2 rules from B1+ | \`test_audience_language_a1_does_not_apply_at_b1\` PASSED |
| Topological sort handles diamond + cycle + missing-dep + filtered-out parent | \`TestTopologicalSort\` (7 tests) PASSED |
| Telemetry-id contract matches \`linear_pipeline.RULE_*\` constants | \`test_telemetry_id_matches_pipeline_constants\` PASSED (6 constants verified) |
| Existing pipeline unchanged | \`pytest tests/build/ -q\` → 380 passed, 1 skipped, 2 pre-existing failures (\`test_engagement_floor_gate\` + \`test_linear_pipeline_wiki_packet\`) confirmed identical on \`origin/main\` |
| Lint clean | \`ruff check scripts tests\` → All checks passed! |
| Registry tests | \`pytest tests/build/test_universal_rules_registry.py\` → 34 passed in 0.25s |

## Design questions answered

### Q1 — Level-specific rules (\`#R-AUDIENCE-LANGUAGE-A1\` etc.)

Use the frontmatter \`applies_to.levels: [a1, a2]\` predicate. Verified by \`test_audience_language_a1_does_not_apply_at_b1\` — when querying \`level=b1\`, the four A1/A2-only rules (\`R-AUDIENCE-LANGUAGE-A1\`, \`R-SINGLE-VOICE-A1\`, \`R-GRAMMAR-TERMS-A1\`, \`R-PROSE-FLOOR-A1\`) disappear from the result; universal rules like \`R-VESUM-ALL-WORDS\` and \`R-CITE-HONEST\` stay. \`R-NO-CHILDREN-PRIMARY-QUOTES\` is also predicated \`[a1, a2]\` because the rule is specifically about Grade 1-3 textbooks not surfacing in adult primer modules at those levels; the same constraint at B1+ would be expressed differently (different grade thresholds) and should be a separate registry rule when needed.

### Q2 — Mirrored writer + reviewer rules

Use \`slot: shared.contract\`. The Step 5 generator will emit \`shared.contract\` fragments to BOTH the rendered writer prompt and the rendered reviewer prompt — single-source emission eliminates the drift class the ADR identifies as the m20 wiki_coverage_gate blocker.

Of the 15 shipped rules, 11 are \`shared.contract\` (the writer is asked to do X, the reviewer must verify X): \`R-VOICE-META\`, \`R-CITE-HONEST\`, \`R-VESUM-ALL-WORDS\`, \`R-BAD-FORM-MARKER\`, \`R-TEXTBOOK-30W\`, \`R-IMPL-MAP-COMPLETE\`, \`R-NO-CHILDREN-PRIMARY-QUOTES\`, \`R-NO-SCAFFOLDING-LEAKS\`, \`R-PROSE-FLOOR-A1\`, \`R-CLEAN-TABLES\`, \`R-ACTIVITY-COMPOSITION\`. \`R-RENDERER-CHARTER\` is \`writer.preamble\` (charter framing only). \`R-SINGLE-VOICE-A1\`, \`R-AUDIENCE-LANGUAGE-A1\`, \`R-GRAMMAR-TERMS-A1\` are \`writer.body\` (output styling that doesn't translate to a reviewer rubric criterion).

Slot taxonomy can be refined in Step 5 if the generator needs different boundaries.

### Q3 — Composition slots with lesson data (decolonization contrast pair from wiki)

Out of scope for the registry. The registry holds the **universal directive** (\"include ≥1 bad-form contrast pair when applicable for L1-Russian-substitutable domains\" in \`R-BAD-FORM-MARKER\`); the **wiki** holds the lesson-specific pair (\`завтрак\` vs \`сніданок\` for m20-routine, different pair for m21-food, etc.); the **generator composition layer** (Step 5) does the junction — inlining the wiki's pair into the directive at render time.

Documented explicitly in [`docs/best-practices/universal-rules-registry.md`](../blob/claude/v7.2-step4-rule-registry-scaffold-2026-05-28/docs/best-practices/universal-rules-registry.md) § \"What is *not* in the registry\". Heuristic: if the text would be identical for m21 and m22 in the same level → registry. If it varies per-lesson → wiki or composition.

### Q4 — Rule ordering across fragments

**Topological sort over \`depends_on\`, tie-break filename-alphabetical.** Documented in \`_topological_sort\` docstring and exercised by \`test_diamond_dependency\` (verifies A → {B, C} → D produces \`[A, B, C, D]\`, not just any valid topological order).

Edge case handled: a \`depends_on\` parent that gets filtered out by predicates (different slot, different level) does NOT block the dependent — \`test_filtered_out_parent_does_not_break_ordering\` verifies a \`shared.contract\` rule whose parent is \`writer.preamble\` still appears in the \`shared.contract\` filter. But a \`depends_on\` id that does not exist anywhere in the registry still raises \`MissingDependencyError\` — \`test_missing_dep_still_raises_when_dep_is_filtered_out\` locks this contract.

## Out of scope

- **Generator wiring (Step 5).** No code reads from the registry yet. \`linear-write.md\` remains the active writer prompt source.
- **Reviewer single-source emission (Step 6).** The shipped \`linear-review-dim.md\` continues to duplicate writer rules in its own prose. Step 6 eliminates that duplication.
- **\`linear-write.md\` modifications.** Beyond reference reading for fragment extraction, the template is untouched. Step 5 will collapse the duplication once the generator is wired.
- **Activity-profile taxonomy.** All fragments use \`activity_profiles: [all]\` until Step 5 introduces concrete profile values.

## Test plan

- [x] \`pytest tests/build/test_universal_rules_registry.py\` → 34 passed
- [x] \`ruff check scripts tests\` → clean
- [x] \`pytest tests/build/\` → 380 passed, 2 pre-existing failures unchanged from \`origin/main\`
- [x] \`find scripts/build/universal_rules/ -name 'R-*.md' \| wc -l\` → 15
- [x] Smoke-tested loader at A1/core/all (15 rules), B1/core/all (10 rules), A1/core/shared.contract (11 rules); topological order verified by eye for the real registry (R-CITE-HONEST before R-TEXTBOOK-30W before R-NO-CHILDREN-PRIMARY-QUOTES; R-VESUM-ALL-WORDS before R-BAD-FORM-MARKER; R-RENDERER-CHARTER before R-ACTIVITY-COMPOSITION)
- [x] Existing leakage sentinel \`test_writer_prompt_no_lesson_specific_leakage\` still passes (the new fragment files don't introduce cross-lesson literals — only the universal directives extracted from \`linear-write.md\`)

## Reviewer notes

- **DO NOT auto-merge.** Per dispatch brief, orchestrator reviews + merges only after design questions feel right for Step 5.
- The registry shape (slot taxonomy, applies_to keys, depends_on semantics) is what Step 5 will consume. If reviewers want different fields (e.g. \`severity\`, \`gate_name\`, separate \`reviewer_phrasing\` body), this is the PR to land that — much cheaper to change schema before fragments are referenced by generator code.
- I was conservative on \`applies_to.levels\` for level-conditional rules: when the \`linear-write.md\` source clearly named A1, I tagged \`[a1, a2]\`. Step 5 can refine when generator behavior shows specific gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)