### PR TITLE
docs(v7.2): Step 5 dispatch brief (draft, NOT fired) + post-4.8 guidance cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,13 @@ Detailed standards in `docs/best-practices/`. Read the relevant doc before worki
 | Feature | How | When |
 | --- | --- | --- |
 | `Monitor` tool | Stream stdout events as notifications | **Build monitoring.** Agents may run V7 builds during autonomous orchestration (per user direction 2026-05-13) — always pass `--worktree`. Filter JSONL events with `grep --line-buffered '^{\"event\"'`. See below. |
-| `/effort` | Set model effort dynamically mid-session | Levels: `low` / `medium` / `high` / `xhigh` / `max`. `low`: config/typo fixes. `medium`: code fixes (default). `xhigh`: content review, plan review, module building, linguistic analysis on Opus 4.7 — Anthropic notes Opus 4.7 at `high` is weaker than prior versions, so **use `xhigh` where we previously used `high`**. `max`: reserve for deep architecture / adversarial reviews where cost is justified. |
+| `/effort` | Set model effort dynamically mid-session | Levels: `low` / `medium` / `high` / `xhigh` / `max`. `low`: config/typo fixes. `medium`: code fixes. `high`: **Opus 4.8 default** — most intelligence-sensitive work. `xhigh`: coding/agentic, content review, plan review, module building, linguistic analysis — Anthropic's explicit override for coding on 4.8. Effort matters MORE on 4.8 than prior Opus, so **sweep `medium`/`high`/`xhigh` per route** rather than defaulting to `xhigh` everywhere. `max`: deep architecture / adversarial reviews where correctness outweighs cost. |
 | Transcript search | `Ctrl+O` then `/` to search, `n`/`N` to navigate | Finding previous discussions in long sessions |
 | `--bare` flag | `claude -p "..." --bare` | Scripted calls (agent bridge) — skips hooks/LSP/plugins for speed |
 | `worktree.sparsePaths` | Configured in settings.json | Subagent worktrees exclude `node_modules/`, `data/` for speed |
 | `PostCompact` hook | Auto-runs after context compaction | Restores current task, open issues, key reminders |
 | `FileChanged` hook | Auto-runs when `curriculum/**/*.md` changes | Triggers audit on module file edits |
-| `effort: xhigh` on skills | Frontmatter in review skills | `content-review`, `plan-review`, `plan-review-seminar`, `batch-review`, `prompt-review` — forces deep analysis. Bumped from `high` → `xhigh` on 2026-04-21 after Anthropic noted Opus 4.7 at `high` underperforms prior versions. |
+| `effort: xhigh` on skills | Frontmatter in review skills | `content-review`, `plan-review`, `plan-review-seminar`, `batch-review`, `prompt-review` — forces deep analysis. Set `xhigh` 2026-04-21; retained for Opus 4.8 — Anthropic recommends `xhigh` for coding/review and a minimum of `high` for intelligence-sensitive work. |
 | `paths:` scoping on rules | Frontmatter in rule files | `ukrainian-linguistics.md` only active for curriculum/orchestration work |
 
 ### Build Monitoring (MANDATORY)

--- a/docs/dispatch-briefs/2026-05-29-v7.2-step5-prompt-generator-claude-goal.md
+++ b/docs/dispatch-briefs/2026-05-29-v7.2-step5-prompt-generator-claude-goal.md
@@ -1,0 +1,120 @@
+# Dispatch — V7.2 Step 5: `prompt_generator.py` (claude Opus 4.8 via `/goal`)
+
+**Status:** DRAFT — ready, **not fired**. Firing is an explicit user gate (Pt 14 + Pt 15 handoffs). Do not auto-fire.
+**Agent / firing:** `claude -p "/goal $(cat THIS_FILE)" --model claude-opus-4-8 --effort xhigh` (run in worktree).
+**Mode:** `danger` (worktree required — writes code + commits).
+**Task ID:** `v7.2-step5-prompt-generator-2026-05-XX`
+**Issue:** #2387 — `[V7.2 Step 5] prompt_generator.py — compose writer + reviewer prompts from registry + wiki + RAG`
+**ADR:** `docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`
+**Design doc:** `docs/best-practices/universal-rules-registry.md` (§ Roadmap → Step 5; § Loader API; § Slots).
+**Blocks:** Step 6 (#2388 reviewer single-source emission), Step 7 (#2389 m20 rebuild), Step 8 (#2390 m21+m22 pilot).
+
+## Why claude Opus 4.8 + `/goal` (firing rationale — confirm at fire time)
+
+Step 5 is judgment (generator design / composition boundary) + multi-call-site coding + tests — exactly the long-horizon agentic coding 4.8 is named for, and Anthropic explicitly pairs that class of work with `/goal`. Firing on 4.8 also measures the advertised 4.7→4.8 gain against the Step-4 (Opus 4.7) baseline on a comparable workload.
+
+**Fallback:** if Claude weekly quota is tight (per #M0 — dispatched Claude competes with the interactive seat; conditional after 2026-06-15), substitute **codex** with close orchestrator guidance. Step 5 is more mechanical than Step 4, so codex is viable; the brief is written agent-neutral except the `/goal` status-line and 4.8-prompting sections (drop those if codex).
+
+## Goal (one predicate)
+
+Build `scripts/build/prompt_generator.py` that composes the writer prompt and the per-dimension reviewer prompt from the universal-rules registry + the wiki manifest + plan references, emitting **one** Obligation Checklist consumed identically by the writer prompt, the reviewer prompt, and the `wiki_coverage_gate` parser. Wire it into `writer_context()` and `review_context()` in `linear_pipeline.py` **behind an opt-in flag**; the legacy `linear-write.md` / `linear-review-dim.md` path stays fully functional during migration.
+
+### Halt predicate (`GOAL_DONE` only when ALL hold)
+
+1. `scripts/build/prompt_generator.py` exists and exposes the API in "Required surface" §1.
+2. Opt-in flag wired (`--use-generator` on `v7_build.py`, threaded to `writer_context`/`review_context`); default OFF → legacy path byte-identical to `origin/main`.
+3. With the flag ON, the generated writer prompt and reviewer prompt render **semantically equivalent** to the legacy templates for a1/my-morning (m20) — same `#R-*` rules present, same Obligation Checklist items — modulo whitespace/formatting. A parity test asserts this.
+4. New unit tests for the generator (composition per slot, topo order, shared.contract→both prompts, Obligation Checklist single-source, opt-in flag on/off).
+5. Existing suite green: `.venv/bin/python -m pytest tests/build/ tests/test_linear_pipeline.py -q` (final line quoted raw).
+6. ruff clean on changed files.
+7. PR opened citing #2387 + ADR. **No auto-merge** — orchestrator reviews.
+
+## Required surface
+
+### 1. Generator API (`scripts/build/prompt_generator.py`)
+
+Consume the loader from `scripts/build/universal_rules_registry.py`:
+```python
+from scripts.build.universal_rules_registry import load_applicable_rules, Rule
+```
+Compose:
+- **Writer rules block** = `load_applicable_rules(level, track, activity_profile, slot="writer.preamble")` + `slot="writer.body"` + `slot="shared.contract"`, each topo-sorted; concatenate rule bodies in the order the loader returns (it already topo-sorts + filename-alphabetical tie-break). Preamble before body before contract.
+- **Reviewer rules block** = `slot="reviewer.rubric"` + `slot="shared.contract"`, topo-sorted. (`reviewer.rubric` is currently empty — all 11 `shared.contract` rules + the 3 promoted A1 rules carry the reviewer load. That's the single-source point.)
+- **One Obligation Checklist** — generated ONCE from the wiki manifest's required items (see `_render_wiki_coverage_required_items` in `linear_pipeline.py`), emitted into: (a) the writer prompt, (b) the reviewer prompt, (c) parseable by `wiki_coverage_gate` (Step 3 already parses inline tags — keep that format).
+
+Suggested signatures (implementer may refine):
+```python
+def build_writer_rules_block(level, track, activity_profile) -> str: ...
+def build_reviewer_rules_block(level, track, activity_profile) -> str: ...
+def build_obligation_checklist(wiki_manifest) -> str: ...
+```
+
+### 2. Composition boundary (do NOT put lesson substance in the generator's registry path)
+
+Per the ADR + design doc § "What is not in the registry": the generator inlines registry rules (universal) **and** wiki/RAG substance (lesson-specific) into the rendered prompt, but they come from different sources. Registry = `load_applicable_rules`. Lesson substance (sequence steps, L2 errors, vocab minimum, decolonization contrast pair) = wiki manifest / `plan.references`, already rendered by existing helpers. Keep the junction logic (e.g. "the m20 contrast pair is X") generator-side, not in the registry.
+
+### 3. Wiring (behind opt-in flag)
+
+Call sites in `scripts/build/linear_pipeline.py` (line numbers as of `742f35f7a0`):
+- `writer_context(...)` — **L2893**. Returns `dict[str, str]` of template substitution tokens. Inject the generated writer-rules block + Obligation Checklist as new tokens; the template (`linear-write.md`, loaded via `writer_prompt_path()` L1778, rendered by `render_writer_prompt()` L1790 / `render_phase_prompt`) gets a generator-fed variant **only when the flag is on**.
+- `review_context(...)` — **L3699**. Same pattern for the reviewer-rules block + the SAME Obligation Checklist.
+- Thread a `use_generator: bool = False` param from `v7_build.py` → these functions. Default OFF.
+
+**Migration safety:** with the flag OFF, `writer_context`/`review_context` must produce byte-identical output to `origin/main`. Add a regression test asserting this (snapshot the legacy dict for m20, assert unchanged).
+
+### 4. Tests
+
+- Generator composition: each slot block contains the expected rule ids; `shared.contract` rules appear in BOTH writer and reviewer blocks; topo order respected; Obligation Checklist identical between writer + reviewer + what `wiki_coverage_gate` parses.
+- Opt-in flag: OFF → legacy byte-identical; ON → generated block present, all legacy `#R-*` rules still present (parity).
+- Edge: a level with level-specific rules (a1 → the 3 promoted A1 rules present in BOTH prompts now that they're `shared.contract`; b1 → absent, per `test_audience_language_a1_does_not_apply_at_b1`).
+
+## 4.8-specific prompting tunings (load-bearing — from Anthropic's prompting guide + migration doc)
+
+1. **`--effort xhigh`** (Anthropic's explicit override for coding/agentic; NOT the API default `high`).
+2. **`thinking: {type: "adaptive"}`** — 4.8 has thinking OFF by default; omitting it silently regresses 4.7 patterns. Set explicitly if the dispatch adapter supports it (else note as a limitation).
+3. **Literal scope declarations** — 4.8 follows instructions literally, won't generalize. State scope: *"This applies to BOTH the writer prompt and the reviewer prompt"*; *"`load_applicable_rules()` returns the rules to emit — emit ALL of them into the slot, do not filter further"*; *"the Obligation Checklist is generated ONCE and reused verbatim in all three consumers."*
+4. **Tool-use bias** — 4.8 reasons before tool-calling and under-calls by default. If any Ukrainian forms are touched, prompt explicitly: *"use `mcp__sources__verify_words` for every Cyrillic form before emitting."* (Step 5 is mostly Python plumbing, so likely N/A — but state it if MCP is needed.)
+5. **Code-review recall (for the implicit Gemini/`/code-review` pass if 4.8):** add *"report every issue including low-confidence ones; a separate verification step filters."* 4.8 follows "be conservative / only high-severity" too faithfully → lower recall otherwise.
+6. **`--max-output-tokens 65536`** — start at 64k for xhigh long-horizon multi-tool work.
+7. **Subagent fan-out** — 4.8 spawns fewer by default; if fanning out across files, say so explicitly.
+
+## `/goal` status-line protocol (per `claude_extensions/rules/goal-driven-runs.md`)
+
+Every turn ends with:
+```
+GOAL_STATUS turn=N/M blocked=N/M no_progress=N/M queue_head=<token>
+```
+- Pull `N` from a real counter file (`/tmp/step5-turn.txt`), not a running tally.
+- Terminal: `GOAL_DONE reason="<predicate result>"` — e.g. `GOAL_DONE reason="generator wired; flag OFF byte-identical to main; parity+new tests green; PR #NNNN opened"`.
+- Abort: `GOAL_ABORT reason="..." last_cmd="..." last_cwd="..." last_output="..." next_action="..." queue_head=...`.
+- Async suspend (CI wait): `GOAL_WAIT signal=<watcher_id> reason="..." eta_s=...`.
+- Code changes ship via the `/goal` body's own worktree commits (this IS a coding `/goal`, not a coordination one) — but obey the evidence rule: every "tests pass / PR opened" claim carries the command + cwd + raw output line.
+
+### M cap
+
+Queue depth ≈ 10 (generator skeleton, writer composition, reviewer composition, Obligation Checklist single-source, wire writer_context, wire review_context, opt-in flag, parity test, new unit tests, existing-green) → `M = clamp(15, 10*2+5+1, 200) = 26`. Use **M=30** (one CI async wait + buffer). Verify: `.venv/bin/python -m scripts.goal_driver.size_cap --queue-depth 10 --async-waits 1`.
+
+## Verifiable claims (#M-4)
+
+| Claim | Tool (command + cwd + raw output) |
+|---|---|
+| "Generator module exists + imports" | `.venv/bin/python -c 'import scripts.build.prompt_generator as g; print([n for n in dir(g) if not n.startswith("_")])'` |
+| "Flag OFF → legacy byte-identical" | new regression test final line raw |
+| "Generated writer/reviewer prompts have parity" | new parity test final line raw |
+| "Existing build tests green" | `.venv/bin/python -m pytest tests/build/ tests/test_linear_pipeline.py -q` final line raw |
+| "Lint clean" | `.venv/bin/ruff check scripts/build/prompt_generator.py scripts/build/linear_pipeline.py` raw |
+| "PR opened" | `gh pr view --json url` raw URL |
+
+## Out of scope (do NOT do in Step 5)
+
+- **Reviewer-side deterministic checks emitted from the registry** — that's Step 6 (#2388). Step 5 emits the reviewer *rules block* + the shared Obligation Checklist; Step 6 makes `wiki_coverage_gate` consume the shared checklist and closes the parser-drift loop.
+- **Deleting the rule content from `linear-write.md`** — keep the legacy template intact during migration (flag-gated). Trimming the template (#2378) happens after the generator path is proven on m20/m21/m22.
+- **Rebuilding m20** — Step 7 (#2389), post-Step-6, as a fresh build (not `--resume`).
+
+## Done criteria
+
+- All blocking CI green (the `review / review` Gemini timeout is advisory per #M-0.5).
+- Generator composes writer + reviewer prompts from the registry; one Obligation Checklist, three consumers.
+- Opt-in flag: OFF byte-identical to main; ON parity-equivalent for m20.
+- New + existing tests green; ruff clean.
+- PR body explains: the composition boundary (registry vs wiki vs RAG), the opt-in migration plan, and how Step 6 will consume the shared checklist.

--- a/scripts/ai_llm/claude_call.py
+++ b/scripts/ai_llm/claude_call.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ai_llm.agent_runtime_call import call_agent_with_fallback
 from ai_llm.fallback import CallResult
 
-CLAUDE_MODEL_LADDER = ("claude-opus-4-8", "claude-sonnet-4-5")
+CLAUDE_MODEL_LADDER = ("claude-opus-4-8", "claude-sonnet-4-6")
 
 
 def call_claude_with_fallback(


### PR DESCRIPTION
Follow-on to #2395. Two commits.

## 1. `docs(v7.2)` — Step 5 `/goal` brief (`cf03cfcb72`)
`docs/dispatch-briefs/2026-05-29-v7.2-step5-prompt-generator-claude-goal.md` — the
dispatch brief for **#2387** (`prompt_generator.py`). **Drafted, not fired** —
firing stays an explicit user gate per the Pt 14/15 handoffs.

`/goal`-structured (status-line protocol per `goal-driven-runs.md`), grounded in
the real registry loader API and the actual `linear_pipeline.py` call sites
(`writer_context` L2893, `review_context` L3699, `writer_prompt_path` L1778). Pins
down: the halt predicate, the opt-in `--use-generator` migration path (flag OFF =
byte-identical to legacy), the single Obligation Checklist contract (writer +
reviewer + `wiki_coverage_gate`), the registry/wiki/RAG composition boundary,
4.8 prompting tunings (xhigh, adaptive thinking, literal scope, report-everything
review), and M-cap sizing (M=30). Targets **claude Opus 4.8** to measure the
4.7→4.8 gain vs the Step-4 baseline; codex fallback documented if quota is tight.

## 2. `chore(v7.2)` — post-4.8 guidance cleanup (`36ff441235`)
- **CLAUDE.md `/effort` rows:** replaced the obsolete *"Opus 4.7 at `high` is weaker
  than prior versions → use xhigh"* override with 4.8 guidance — `high` is the 4.8
  default; `xhigh` for coding/agentic; effort matters *more* on 4.8, so sweep
  `medium`/`high`/`xhigh` per route rather than defaulting to xhigh.
- **`claude_call.py`** `CLAUDE_MODEL_LADDER` fallback rung `claude-sonnet-4-5 →
  claude-sonnet-4-6` (catalog-current Sonnet). No test pins the ladder.

**Flagged, not changed:** `openai_proxy._ROUTABLE_MODELS` has a `claude-sonnet-4-7`
route (not in the catalog) and lacks `sonnet-4-6` — left as-is (no evidence of a
caller; removing risks breaking one). The "weaker than prior" text lived only in
CLAUDE.md, not MEMORY (handoff item 4g misattribution) — auto-memory `#M0` untouched.

## Verification
- ruff clean; `test_ai_llm_claude_call.py` 3/3 (the only ladder consumer).
- Brief + CLAUDE.md are docs; the 1-line `claude_call` change is ladder-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)