### PR TITLE
feat(v7): single-source reviewer obligations

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -140,6 +140,7 @@ _WORKBOOK_AGGREGATE_LOCATION_RE = re.compile(
     + r")\b",
     re.IGNORECASE,
 )
+OBLIGATION_CHECKLIST_SCHEMA_VERSION = 1
 
 
 def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
@@ -251,6 +252,68 @@ def parse_implementation_map(text: str) -> dict[str, dict[str, str]]:
     return entries
 
 
+def build_obligation_checklist_object(
+    manifest: Mapping[str, Any] | str | Path,
+    *,
+    seeded_map: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the structured checklist shared by prompts and the gate.
+
+    The generated prompt path emits this object as rendered text, then passes
+    the same object into ``check_wiki_coverage``. Sequence-step item extraction
+    happens here once; the gate consumes the stored ``required_items`` instead
+    of re-deriving them when the checklist is supplied.
+    """
+    manifest_data = _load_manifest(manifest)
+    seeded_index = _seeded_obligation_index(seeded_map)
+    obligations: list[dict[str, Any]] = []
+    for obligation in validate_obligations(manifest_data):
+        obligation_id = str(obligation.get("id") or "")
+        enriched = _enrich_obligation_from_seeded_map(
+            obligation,
+            seeded_index.get(obligation_id),
+        )
+        if str(enriched.get("type") or "") == "sequence_step":
+            claim = str(enriched.get("required_claim") or enriched.get("heading") or "")
+            normalized_claim = _normalize_required_claim(claim)
+            enriched["normalized_claim"] = normalized_claim
+            enriched["required_items"] = _extract_required_items(normalized_claim)
+        obligations.append(enriched)
+
+    vocab_minimum = [
+        str(item.get("lemma") or "")
+        for item in manifest_data.get("wiki_vocabulary_minimum", [])
+        if isinstance(item, Mapping) and item.get("lemma")
+    ]
+    return {
+        "schema_version": OBLIGATION_CHECKLIST_SCHEMA_VERSION,
+        "slug": str(manifest_data.get("slug") or ""),
+        "wiki_path": str(manifest_data.get("wiki_path") or ""),
+        "vocabulary_minimum": vocab_minimum,
+        "obligations": obligations,
+    }
+
+
+def obligations_from_checklist(checklist: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return gate-ready obligations from a structured checklist object."""
+    if checklist.get("schema_version") != OBLIGATION_CHECKLIST_SCHEMA_VERSION:
+        raise ValueError("obligation checklist schema_version must be 1")
+    raw_obligations = checklist.get("obligations")
+    if not isinstance(raw_obligations, Sequence) or isinstance(raw_obligations, (str, bytes)):
+        raise ValueError("obligation checklist obligations must be a list")
+    obligations: list[dict[str, Any]] = []
+    for index, item in enumerate(raw_obligations, start=1):
+        if not isinstance(item, Mapping):
+            raise ValueError(f"obligation checklist obligations[{index}] must be an object")
+        obligation = dict(item)
+        if not str(obligation.get("id") or ""):
+            raise ValueError(f"obligation checklist obligations[{index}] missing id")
+        if not str(obligation.get("type") or ""):
+            raise ValueError(f"obligation checklist obligations[{index}] missing type")
+        obligations.append(obligation)
+    return obligations
+
+
 def validate_obligations(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Flatten manifest obligations in deterministic manifest order."""
     obligations: list[dict[str, Any]] = []
@@ -277,6 +340,7 @@ def check_wiki_coverage(
     resources_yaml: str = "",
     level: str | None = None,
     seeded_map: Mapping[str, Any] | None = None,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compare manifest obligations to claimed artifact evidence."""
     map_entries = (
@@ -294,7 +358,12 @@ def check_wiki_coverage(
     obligation_results: list[dict[str, Any]] = []
     seeded_index = _seeded_obligation_index(seeded_map)
 
-    for obligation in validate_obligations(manifest):
+    obligations = (
+        obligations_from_checklist(obligation_checklist)
+        if obligation_checklist is not None
+        else validate_obligations(manifest)
+    )
+    for obligation in obligations:
         obligation_id = str(obligation.get("id") or "")
         obligation = _enrich_obligation_from_seeded_map(
             obligation,
@@ -379,6 +448,7 @@ def check_wiki_coverage_paths(
     module_dir: Path,
     level: str | None = None,
     seeded_map: Mapping[str, Any] | None = None,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     manifest_data = _load_manifest(manifest)
     implementation_map_path = module_dir / "implementation_map.json"
@@ -395,6 +465,7 @@ def check_wiki_coverage_paths(
         resources_yaml=_read_optional(module_dir / "resources.yaml"),
         level=level,
         seeded_map=seeded_map,
+        obligation_checklist=obligation_checklist,
     )
 
 
@@ -864,8 +935,23 @@ def _check_obligation_text(obligation: Mapping[str, Any], target_text: str, arti
 
     if obligation_type == "sequence_step":
         claim = str(obligation.get("required_claim") or obligation.get("heading") or "")
-        normalized_claim = _normalize_required_claim(claim)
-        items = _extract_required_items(normalized_claim)
+        raw_items = obligation.get("required_items")
+        if isinstance(raw_items, Mapping):
+            items = {
+                "vocabulary": [
+                    str(item)
+                    for item in raw_items.get("vocabulary", [])
+                    if isinstance(item, str)
+                ],
+                "examples": [
+                    str(item)
+                    for item in raw_items.get("examples", [])
+                    if isinstance(item, str)
+                ],
+            }
+        else:
+            normalized_claim = _normalize_required_claim(claim)
+            items = _extract_required_items(normalized_claim)
 
         # If we have extracted items, use item-level coverage.
         if items["vocabulary"] or items["examples"]:

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1077,8 +1077,26 @@ def _manifest_mapping(wiki_manifest: str | Mapping[str, Any]) -> dict[str, Any] 
     return dict(manifest)
 
 
-def _render_wiki_coverage_required_items(wiki_manifest: str | Mapping[str, Any]) -> str:
+def build_wiki_coverage_obligation_checklist(
+    wiki_manifest: str | Mapping[str, Any],
+    *,
+    seeded_map: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the structured checklist shared by generated prompts and gate."""
+    from scripts.audit.wiki_coverage_gate import build_obligation_checklist_object
+
+    return build_obligation_checklist_object(wiki_manifest, seeded_map=seeded_map)
+
+
+def _render_wiki_coverage_required_items(
+    wiki_manifest: str | Mapping[str, Any],
+    *,
+    obligation_checklist: Mapping[str, Any] | None = None,
+) -> str:
     """Render a breakdown of required items for the writer prompt."""
+    if obligation_checklist is not None:
+        return _render_structured_wiki_coverage_required_items(obligation_checklist)
+
     if isinstance(wiki_manifest, str):
         try:
             manifest = json.loads(wiki_manifest)
@@ -1141,6 +1159,86 @@ def _render_wiki_coverage_required_items(wiki_manifest: str | Mapping[str, Any])
         lines.append(f"- Pedagogical goal: {why}")
         if str(item.get("treatment")) == "contrast_pair":
              lines.append("- Required location: activities.yaml `error-correction` activity, entry with `sentence`, `error`, `correction` fields")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def _render_structured_wiki_coverage_required_items(
+    obligation_checklist: Mapping[str, Any],
+) -> str:
+    """Render the generator checklist object used by the gate."""
+    from scripts.audit.wiki_coverage_gate import obligations_from_checklist
+
+    lines = [
+        "**Coverage rule**: every listed item MUST appear at least once in `module.md` PROSE (model sentence, definition, or paragraph). A vocab table entry alone is NOT coverage. Structural elements (tables, dialogue boxes) count for vocabulary but NOT for wiki_coverage obligations.",
+        "",
+    ]
+    vocab_items = [
+        str(item)
+        for item in obligation_checklist.get("vocabulary_minimum", [])
+        if str(item).strip()
+    ]
+    if vocab_items:
+        lines.append("### wiki_vocabulary_minimum")
+        lines.append("- Lemmas: " + ", ".join(vocab_items))
+        lines.append("")
+
+    for item in obligations_from_checklist(obligation_checklist):
+        oid = str(item.get("id") or "")
+        obligation_type = str(item.get("type") or "")
+        if obligation_type == "sequence_step":
+            lines.append(f"### {oid} (sequence step)")
+            extracted = item.get("required_items")
+            if isinstance(extracted, Mapping):
+                vocabulary = [
+                    str(value)
+                    for value in extracted.get("vocabulary", [])
+                    if str(value).strip()
+                ]
+                examples = [
+                    str(value)
+                    for value in extracted.get("examples", [])
+                    if str(value).strip()
+                ]
+                if vocabulary:
+                    lines.append(f"- Vocabulary to introduce: {', '.join(vocabulary)}")
+                if examples:
+                    lines.append(f"- Required examples: {', '.join(f'«{e}»' for e in examples)}")
+            goal = str(item.get("normalized_claim") or item.get("required_claim") or item.get("heading") or "")
+            if goal:
+                lines.append(f"- Pedagogical goal: {goal}")
+        elif obligation_type == "l2_error":
+            incorrect = str(item.get("incorrect") or "")
+            correct = str(item.get("correct") or "")
+            why = str(item.get("why") or "")
+            if not (incorrect or correct):
+                continue
+            lines.append(f"### {oid} (L2 error contrast)")
+            lines.append(f"- Required contrast: incorrect `{incorrect}` vs correct `{correct}`")
+            if why:
+                lines.append(f"- Pedagogical goal: {why}")
+            if str(item.get("treatment")) == "contrast_pair":
+                lines.append("- Required location: activities.yaml `error-correction` activity, entry with `sentence`, `error`, `correction` fields")
+        elif obligation_type == "phonetic_rule":
+            written = str(item.get("written") or "")
+            spoken = str(item.get("spoken") or "")
+            if not (written or spoken):
+                continue
+            lines.append(f"### {oid} (phonetic rule)")
+            lines.append(f"- Required mapping: written `{written}` -> spoken `{spoken}`")
+            if item.get("examples"):
+                lines.append(f"- Required examples: {json.dumps(item.get('examples'), ensure_ascii=False)}")
+        elif obligation_type == "decolonization_ban":
+            rule = str(item.get("rule") or "")
+            if not rule:
+                continue
+            lines.append(f"### {oid} (decolonization ban)")
+            if item.get("subtype"):
+                lines.append(f"- Subtype: {item['subtype']}")
+            lines.append(f"- Required rule: {rule}")
+        else:
+            lines.append(f"### {oid} ({obligation_type})")
         lines.append("")
 
     return "\n".join(lines).strip()
@@ -1810,6 +1908,7 @@ def render_writer_prompt(
     implementation_map: Mapping[str, Any] | None = None,
     writer: str = "claude-tools",
     use_generator: bool = False,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> str:
     template_path = generated_writer_prompt_path() if use_generator else writer_prompt_path(writer)
     return render_phase_prompt(
@@ -1822,6 +1921,7 @@ def render_writer_prompt(
             implementation_map=implementation_map,
             writer=writer,
             use_generator=use_generator,
+            obligation_checklist=obligation_checklist,
         ),
     )
 
@@ -2934,19 +3034,22 @@ def writer_context(
     implementation_map: Mapping[str, Any] | None = None,
     writer: str | None = None,
     use_generator: bool = False,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     level = str(plan["level"])
     sequence = int(plan["sequence"])
     learner_state = build_learner_state(level.lower(), sequence)
     activity_config = _activity_config(level, sequence, str(plan["slug"]))
     if wiki_manifest is None:
-        wiki_manifest_data = build_wiki_manifest_data(level=level.lower(), slug=str(plan["slug"]), plan=plan)
-        wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest_data)
-        required_items_text = _render_wiki_coverage_required_items(wiki_manifest_data)
+        manifest_for_checklist = build_wiki_manifest_data(level=level.lower(), slug=str(plan["slug"]), plan=plan)
+        wiki_manifest_text = _render_prompt_wiki_manifest(manifest_for_checklist)
+        required_items_text = _render_wiki_coverage_required_items(manifest_for_checklist)
     elif isinstance(wiki_manifest, str):
+        manifest_for_checklist = wiki_manifest
         wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest)
         required_items_text = _render_wiki_coverage_required_items(wiki_manifest)
     else:
+        manifest_for_checklist = wiki_manifest
         wiki_manifest_text = _render_prompt_wiki_manifest(wiki_manifest)
         required_items_text = _render_wiki_coverage_required_items(wiki_manifest)
 
@@ -2988,13 +3091,29 @@ def writer_context(
         # computed required_items_text so the writer prompt, reviewer prompt, and
         # wiki_coverage_gate all read one rendering. Keyed behind the flag so the
         # legacy return above stays byte-identical with the flag OFF.
-        from scripts.build.prompt_generator import build_writer_rules_block, track_for_level
+        from scripts.build.prompt_generator import (
+            build_obligation_checklist,
+            build_obligation_checklist_object,
+            build_writer_rules_block,
+            track_for_level,
+        )
 
         rules_block = build_writer_rules_block(level.lower(), track_for_level(level))
         # Resolve any build-time tokens the rule bodies carry (e.g.
         # {ACTIVITY_COUNT_TARGET}) against the context computed above.
         context["GENERATED_WRITER_RULES"] = _inline_prompt_tokens(rules_block, context)
-        context["OBLIGATION_CHECKLIST"] = required_items_text
+        checklist = (
+            dict(obligation_checklist)
+            if obligation_checklist is not None
+            else build_obligation_checklist_object(
+                manifest_for_checklist,
+                seeded_map=implementation_map,
+            )
+        )
+        context["OBLIGATION_CHECKLIST"] = build_obligation_checklist(
+            manifest_for_checklist,
+            obligation_checklist=checklist,
+        )
     return context
 
 
@@ -3710,6 +3829,7 @@ def run_wiki_coverage_gate(
     writer_output: str,
     module_dir: Path,
     level: str | None = None,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     from scripts.audit.wiki_coverage_gate import check_wiki_coverage_paths
 
@@ -3718,6 +3838,7 @@ def run_wiki_coverage_gate(
         implementation_map=writer_output,
         module_dir=module_dir,
         level=level,
+        obligation_checklist=obligation_checklist,
     )
     if result.get("passed") is False:
         proposals = list(result.get("fix_proposals") or [])
@@ -3756,6 +3877,7 @@ def review_context(
     implementation_map: Mapping[str, Any] | None = None,
     *,
     use_generator: bool = False,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     """Build context for one independent per-dimension LLM QG prompt."""
     if dim not in QG_DIMS:
@@ -3772,7 +3894,7 @@ def review_context(
         manifest_for_checklist = wiki_manifest
 
     if implementation_map is None:
-        manifest_for_map = _manifest_mapping(wiki_manifest) if wiki_manifest is not None else wiki_manifest_data
+        manifest_for_map = _manifest_mapping(manifest_for_checklist)
         if manifest_for_map is None:
             impl_map_contract = "(no implementation_map provided and wiki_manifest was not parseable)"
         else:
@@ -3808,6 +3930,7 @@ def review_context(
         # with the flag OFF.
         from scripts.build.prompt_generator import (
             build_obligation_checklist,
+            build_obligation_checklist_object,
             build_reviewer_rules_block,
             track_for_level,
         )
@@ -3818,7 +3941,18 @@ def review_context(
         # context plus the level's activity config so none survive into the prompt.
         token_map = {**context, **_activity_config(level, sequence, str(plan["slug"]))}
         context["GENERATED_REVIEWER_RULES"] = _inline_prompt_tokens(rules_block, token_map)
-        context["OBLIGATION_CHECKLIST"] = build_obligation_checklist(manifest_for_checklist)
+        checklist = (
+            dict(obligation_checklist)
+            if obligation_checklist is not None
+            else build_obligation_checklist_object(
+                manifest_for_checklist,
+                seeded_map=implementation_map,
+            )
+        )
+        context["OBLIGATION_CHECKLIST"] = build_obligation_checklist(
+            manifest_for_checklist,
+            obligation_checklist=checklist,
+        )
     return context
 
 
@@ -3831,6 +3965,7 @@ def render_review_prompt(
     implementation_map: Mapping[str, Any] | None = None,
     *,
     use_generator: bool = False,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> str:
     template_path = (
         generated_review_prompt_path()
@@ -3847,6 +3982,7 @@ def render_review_prompt(
             wiki_manifest,
             implementation_map,
             use_generator=use_generator,
+            obligation_checklist=obligation_checklist,
         ),
     )
 
@@ -4764,6 +4900,7 @@ def run_wiki_coverage_with_corrections(
     narrow_corrector: Callable[..., str] | None = None,
     invoker: Callable[..., Any] | None = None,
     event_sink: Callable[..., None] | None = None,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run wiki_coverage_gate with batched and narrow correction loops.
 
@@ -4782,6 +4919,7 @@ def run_wiki_coverage_with_corrections(
             writer_output=writer_output,
             module_dir=module_dir,
             level=level,
+            obligation_checklist=obligation_checklist,
         )
 
     result = _run_gate()

--- a/scripts/build/prompt_generator.py
+++ b/scripts/build/prompt_generator.py
@@ -34,7 +34,7 @@ in the registry"):
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from scripts.build.universal_rules_registry import load_applicable_rules
 
@@ -135,7 +135,23 @@ def build_reviewer_rules_block(
     return _compose_slots(level, track, activity_profile, REVIEWER_SLOT_ORDER)
 
 
-def build_obligation_checklist(wiki_manifest: str | Mapping[str, object]) -> str:
+def build_obligation_checklist_object(
+    wiki_manifest: str | Mapping[str, object],
+    *,
+    seeded_map: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the structured checklist object used by prompt and gate consumers."""
+    from scripts.build.linear_pipeline import build_wiki_coverage_obligation_checklist
+
+    return build_wiki_coverage_obligation_checklist(wiki_manifest, seeded_map=seeded_map)
+
+
+def build_obligation_checklist(
+    wiki_manifest: str | Mapping[str, object],
+    *,
+    obligation_checklist: Mapping[str, Any] | None = None,
+    seeded_map: Mapping[str, Any] | None = None,
+) -> str:
     """Render the ONE Obligation Checklist from the wiki manifest's required items.
 
     Single source across all three consumers:
@@ -153,4 +169,10 @@ def build_obligation_checklist(wiki_manifest: str | Mapping[str, object]) -> str
     """
     from scripts.build.linear_pipeline import _render_wiki_coverage_required_items
 
-    return _render_wiki_coverage_required_items(wiki_manifest)
+    checklist = obligation_checklist
+    if checklist is None:
+        checklist = build_obligation_checklist_object(wiki_manifest, seeded_map=seeded_map)
+    return _render_wiki_coverage_required_items(
+        wiki_manifest,
+        obligation_checklist=checklist,
+    )

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -657,6 +657,7 @@ def _writer_prompt(
     implementation_map: Mapping[str, Any],
     writer: str,
     use_generator: bool = False,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> str:
     return linear_pipeline.render_writer_prompt(
         plan=plan,
@@ -666,6 +667,7 @@ def _writer_prompt(
         implementation_map=implementation_map,
         writer=writer,
         use_generator=use_generator,
+        obligation_checklist=obligation_checklist,
     )
 
 
@@ -728,6 +730,7 @@ def _run_llm_qg(
     implementation_map: Mapping[str, Any] | None = None,
     stdout_silence_timeout: int | None = None,
     use_generator: bool = False,
+    obligation_checklist: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     from scripts.agent_runtime.runner import invoke
 
@@ -750,6 +753,7 @@ def _run_llm_qg(
             wiki_manifest,
             implementation_map,
             use_generator=use_generator,
+            obligation_checklist=obligation_checklist,
         )
         (module_dir / f"llm-qg-{dim}-prompt.md").write_text(prompt, encoding="utf-8")
         result = invoke(
@@ -1233,6 +1237,7 @@ def _run(args: argparse.Namespace) -> int:
         started_at = time.monotonic()
         module_dir.mkdir(parents=True, exist_ok=True)
         impl_map_path = module_dir / "implementation_map.json"
+        obligation_checklist: Mapping[str, Any] | None = None
         if (
             resume_enabled
             and not force_rerun
@@ -1246,12 +1251,22 @@ def _run(args: argparse.Namespace) -> int:
             else:
                 impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
                 write_implementation_map(impl_map, impl_map_path)
+            if use_generator:
+                obligation_checklist = linear_pipeline.build_wiki_coverage_obligation_checklist(
+                    wiki_manifest_data,
+                    seeded_map=impl_map,
+                )
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
             if resume_enabled:
                 force_rerun = True
             impl_map = seed_implementation_map(wiki_manifest_data, plan=plan)
             write_implementation_map(impl_map, impl_map_path)
+            if use_generator:
+                obligation_checklist = linear_pipeline.build_wiki_coverage_obligation_checklist(
+                    wiki_manifest_data,
+                    seeded_map=impl_map,
+                )
             tracker.emit(
                 "implementation_map_seeded",
                 slug=slug,
@@ -1266,6 +1281,7 @@ def _run(args: argparse.Namespace) -> int:
                 implementation_map=impl_map,
                 writer=writer,
                 use_generator=use_generator,
+                obligation_checklist=obligation_checklist,
             )
             # gemini-tools must load .gemini/settings.json from repo root;
             # module_dir cwd would leave its MCP catalog empty. See
@@ -1366,6 +1382,7 @@ def _run(args: argparse.Namespace) -> int:
                 module_dir=module_dir,
                 level=level,
                 event_sink=tracker.emit,
+                obligation_checklist=obligation_checklist,
             )
             linear_pipeline.write_json(
                 module_dir / "wiki_coverage_gate.json", wiki_coverage_gate
@@ -1468,6 +1485,7 @@ def _run(args: argparse.Namespace) -> int:
                 implementation_map=impl_map,
                 stdout_silence_timeout=args.writer_timeout,
                 use_generator=use_generator,
+                obligation_checklist=obligation_checklist,
             )
             linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)
         aggregate = llm_qg["aggregate"]

--- a/tests/audit/test_wiki_coverage_gate.py
+++ b/tests/audit/test_wiki_coverage_gate.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from scripts.audit.wiki_coverage_gate import check_wiki_coverage, parse_implementation_map
+from scripts.audit.wiki_coverage_gate import (
+    build_obligation_checklist_object,
+    check_wiki_coverage,
+    parse_implementation_map,
+)
 from scripts.build.phases.implementation_map import seed_implementation_map
 
 FIXTURES_DIR = Path(__file__).with_name("fixtures")
@@ -129,6 +133,49 @@ def test_decolonization_ban_legacy_manifest_without_subtype_field() -> None:
     assert result["status"] == "FAIL"
     assert result["reason"] == "ban_substance_missing"
     assert "subtype" not in result
+
+
+def test_gate_default_path_preserves_legacy_manifest_output() -> None:
+    """Flag-OFF callers do not receive the generator checklist path."""
+    manifest = _ban_manifest(BAN_1_RULE)
+    kwargs = {
+        "manifest": manifest,
+        "implementation_map": _claim(),
+        "module_md": "This module avoids the prohibited framing.",
+        "activities_yaml": "[]",
+    }
+
+    assert check_wiki_coverage(**kwargs) == check_wiki_coverage(
+        **kwargs,
+        obligation_checklist=None,
+    )
+
+
+def test_gate_uses_supplied_obligation_checklist_instead_of_reflattening_manifest() -> None:
+    manifest = _sequence_step_manifest()
+    extra_step = dict(manifest["sequence_steps"][0])
+    extra_step["id"] = "step-6"
+    extra_step["required_claim"] = "Introduce the extra phrase «пізніше»."
+    manifest["sequence_steps"].append(extra_step)
+    checklist = build_obligation_checklist_object(manifest)
+    checklist["obligations"] = checklist["obligations"][:1]
+
+    report = check_wiki_coverage(
+        manifest=manifest,
+        obligation_checklist=checklist,
+        implementation_map={
+            "step-5": {
+                "artifact": "module.md",
+                "location": "whole file",
+                "treatment": "first checklist obligation only",
+            }
+        },
+        module_md="The prose includes вода, зарядка, сніданок, раненько, завжди, ніколи.",
+        activities_yaml="[]",
+    )
+
+    assert report["total"] == 1
+    assert [item["obligation_id"] for item in report["obligations"]] == ["step-5"]
 
 
 # Regression tests for two bugs that masked the build #6 a1/my-morning gate

--- a/tests/build/test_prompt_generator.py
+++ b/tests/build/test_prompt_generator.py
@@ -50,6 +50,12 @@ def _emission_order(text: str) -> list[str]:
     return MARKER_COMMENT_RE.findall(text)
 
 
+def _inserted_obligation_checklist(prompt: str) -> str:
+    start = prompt.index("**Coverage rule**:")
+    end = prompt.index("\n\n## Implementation Map Contract", start)
+    return prompt[start:end].strip()
+
+
 @pytest.fixture(scope="module")
 def m20():
     """Real a1/my-morning plan + manifest + implementation map fixtures."""
@@ -168,17 +174,34 @@ def test_a1_only_rules_absent_at_b1():
 
 
 def test_obligation_checklist_is_single_source(m20):
-    checklist = pg.build_obligation_checklist(m20["wiki_manifest"])
+    checklist_obj = pg.build_obligation_checklist_object(
+        m20["wiki_manifest"],
+        seeded_map=m20["implementation_map"],
+    )
+    checklist = pg.build_obligation_checklist(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
     assert checklist, "expected a non-empty checklist for m20"
-    # Same renderer the writer prompt already used for WIKI_COVERAGE_REQUIRED_ITEMS.
-    assert checklist == lp._render_wiki_coverage_required_items(m20["wiki_manifest"])
+    # Same renderer object the writer prompt, reviewer prompt, and gate consume.
+    assert checklist == lp._render_wiki_coverage_required_items(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
 
 
 def test_obligation_checklist_derived_from_wiki_coverage_gate_extraction(m20):
     """The checklist's required vocab must be the gate's extracted required items."""
     from scripts.audit.wiki_coverage_gate import _extract_required_items, _normalize_required_claim
 
-    checklist = pg.build_obligation_checklist(m20["wiki_manifest"])
+    checklist_obj = pg.build_obligation_checklist_object(
+        m20["wiki_manifest"],
+        seeded_map=m20["implementation_map"],
+    )
+    checklist = pg.build_obligation_checklist(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
     required_examples: set[str] = set()
     for item in m20["wiki_manifest"].get("sequence_steps", []):
         claim = str(item.get("required_claim") or item.get("heading") or "")
@@ -193,7 +216,14 @@ def test_obligation_checklist_derived_from_wiki_coverage_gate_extraction(m20):
 
 
 def test_obligation_checklist_identical_in_writer_and_reviewer_prompts(m20):
-    checklist = pg.build_obligation_checklist(m20["wiki_manifest"])
+    checklist_obj = pg.build_obligation_checklist_object(
+        m20["wiki_manifest"],
+        seeded_map=m20["implementation_map"],
+    )
+    checklist = pg.build_obligation_checklist(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
     writer_prompt = lp.render_writer_prompt(
         plan=m20["plan"],
         plan_content=m20["plan_content"],
@@ -202,6 +232,7 @@ def test_obligation_checklist_identical_in_writer_and_reviewer_prompts(m20):
         implementation_map=m20["implementation_map"],
         writer="claude-tools",
         use_generator=True,
+        obligation_checklist=checklist_obj,
     )
     reviewer_prompt = lp.render_review_prompt(
         m20["plan"],
@@ -211,9 +242,10 @@ def test_obligation_checklist_identical_in_writer_and_reviewer_prompts(m20):
         m20["wiki_manifest"],
         m20["implementation_map"],
         use_generator=True,
+        obligation_checklist=checklist_obj,
     )
-    assert checklist in writer_prompt
-    assert checklist in reviewer_prompt
+    assert _inserted_obligation_checklist(writer_prompt) == checklist
+    assert _inserted_obligation_checklist(reviewer_prompt) == checklist
 
 
 # --------------------------------------------------------------------------- #
@@ -286,15 +318,37 @@ def test_writer_prompt_off_byte_identical_to_legacy_template(m20):
 
 
 def test_writer_context_on_adds_generator_keys(m20):
+    checklist_obj = pg.build_obligation_checklist_object(
+        m20["wiki_manifest"],
+        seeded_map=m20["implementation_map"],
+    )
     ctx = lp.writer_context(
         m20["plan"], m20["plan_content"], "KP", m20["wiki_manifest"],
         implementation_map=m20["implementation_map"], writer="claude-tools",
-        use_generator=True,
+        use_generator=True, obligation_checklist=checklist_obj,
     )
     assert "#R-VESUM-ALL-WORDS" in ctx["GENERATED_WRITER_RULES"]
-    assert ctx["OBLIGATION_CHECKLIST"] == ctx["WIKI_COVERAGE_REQUIRED_ITEMS"]
+    assert ctx["OBLIGATION_CHECKLIST"] == pg.build_obligation_checklist(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
     # Build-time tokens inside rule bodies are resolved before injection.
     assert "{ACTIVITY_COUNT_TARGET}" not in ctx["GENERATED_WRITER_RULES"]
+
+
+def test_writer_context_on_without_manifest_builds_checklist(m20):
+    ctx = lp.writer_context(
+        m20["plan"],
+        m20["plan_content"],
+        "KP",
+        wiki_manifest=None,
+        implementation_map=m20["implementation_map"],
+        writer="claude-tools",
+        use_generator=True,
+    )
+
+    assert "OBLIGATION_CHECKLIST" in ctx
+    assert "### step-" in ctx["OBLIGATION_CHECKLIST"]
 
 
 def test_generated_writer_prompt_parity_with_legacy(m20):
@@ -334,14 +388,51 @@ def test_generated_reviewer_prompt_parity_with_legacy(m20):
 
 def test_obligation_checklist_single_source_across_three_consumers(m20):
     """writer prompt == reviewer prompt == build_obligation_checklist text."""
-    checklist = pg.build_obligation_checklist(m20["wiki_manifest"])
+    checklist_obj = pg.build_obligation_checklist_object(
+        m20["wiki_manifest"],
+        seeded_map=m20["implementation_map"],
+    )
+    checklist = pg.build_obligation_checklist(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
     writer_ctx = lp.writer_context(
         m20["plan"], m20["plan_content"], "KP", m20["wiki_manifest"],
         implementation_map=m20["implementation_map"], writer="claude-tools", use_generator=True,
+        obligation_checklist=checklist_obj,
     )
     review_ctx = lp.review_context(
         m20["plan"], m20["plan_content"], "X", "pedagogical",
         m20["wiki_manifest"], m20["implementation_map"], use_generator=True,
+        obligation_checklist=checklist_obj,
     )
     assert checklist == writer_ctx["OBLIGATION_CHECKLIST"]
     assert checklist == review_ctx["OBLIGATION_CHECKLIST"]
+
+
+def test_gate_consumes_obligation_checklist_one_to_one(m20):
+    """wiki_coverage_gate sees the same obligations the renderer emitted."""
+    from scripts.audit.wiki_coverage_gate import obligations_from_checklist
+
+    checklist_obj = pg.build_obligation_checklist_object(
+        m20["wiki_manifest"],
+        seeded_map=m20["implementation_map"],
+    )
+    rendered = pg.build_obligation_checklist(
+        m20["wiki_manifest"],
+        obligation_checklist=checklist_obj,
+    )
+    gate_obligations = obligations_from_checklist(checklist_obj)
+    gate_ids = [str(item["id"]) for item in gate_obligations]
+    rendered_ids = [
+        match
+        for match in re.findall(r"^### (\S+) \(", rendered, flags=re.MULTILINE)
+        if match != "wiki_vocabulary_minimum"
+    ]
+
+    assert len(gate_obligations) == len(m20["implementation_map"]["entries"])
+    assert rendered_ids == gate_ids
+    assert len(rendered_ids) == len(set(rendered_ids)), "no orphan/duplicate rendered obligations"
+    for item in gate_obligations:
+        if item["type"] == "sequence_step":
+            assert item["normalized_claim"] in rendered


### PR DESCRIPTION
## Summary

Closes #2388.

Builds on Step 5 (`12735cfabb`) by closing the single-source loop for generated prompts and `wiki_coverage_gate`:

- adds a structured Obligation Checklist object built once from the wiki manifest + seeded implementation map
- renders that object into both generated writer and reviewer prompts under `--use-generator`
- passes the same object into `wiki_coverage_gate` / correction retries so the gate validates the exact obligation set the writer saw
- keeps the legacy flag-OFF path on manifest-derived gate behavior and legacy `WIKI_COVERAGE_REQUIRED_ITEMS`

ADR: `docs/decisions/pending/2026-05-28-wiki-driven-prompt-generator.md`
Design: `docs/best-practices/universal-rules-registry.md`

## Validation

- Checklist byte-identical acceptance:
  - `cwd=/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/v7.2-step6-reviewer-single-source-2026-05-28`
  - command: `.venv/bin/python -m pytest tests/build/test_prompt_generator.py::test_obligation_checklist_identical_in_writer_and_reviewer_prompts -q`
  - raw final line: `============================== 1 passed in 0.90s ===============================`
- Gate parses 1:1 acceptance:
  - command: `.venv/bin/python -m pytest tests/build/test_prompt_generator.py::test_gate_consumes_obligation_checklist_one_to_one -q`
  - raw final line: `============================== 1 passed in 0.24s ===============================`
- Flag-OFF/gate regression:
  - command: `.venv/bin/python -m pytest tests/build/test_prompt_generator.py tests/audit/test_wiki_coverage_gate.py::test_gate_default_path_preserves_legacy_manifest_output tests/audit/test_wiki_coverage_gate.py::test_gate_uses_supplied_obligation_checklist_instead_of_reflattening_manifest -q`
  - raw final line: `============================== 22 passed in 5.59s ==============================`
- Ruff:
  - command: `.venv/bin/ruff check scripts/audit/wiki_coverage_gate.py scripts/build/linear_pipeline.py scripts/build/prompt_generator.py scripts/build/v7_build.py tests/build/test_prompt_generator.py tests/audit/test_wiki_coverage_gate.py`
  - raw final line: `All checks passed!`
- Full required suite:
  - command: `.venv/bin/python -m pytest tests/build/ tests/audit/ -q`
  - raw final line: `================== 2 failed, 843 passed, 25 skipped in 15.52s ==================`
  - the two failures reproduce with this patch stashed: `tests/build/test_engagement_floor_gate.py::test_engagement_fails_when_one_callout_below_minimum` and `tests/build/test_linear_pipeline_wiki_packet.py::test_build_knowledge_packet_reads_wiki_and_sources`
- Agent trailer audit:
  - command: `.venv/bin/python scripts/audit/lint_agent_trailer.py`
  - raw final line: `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.`

## Review Notes

Local pre-commit review ran via the repo `local-code-review` workflow:

- Gemini reviewed the working-tree diff and found one scoping cleanup, now resolved via `manifest_for_checklist`.
- Codex challenge marked that finding stale/resolved and suggested the added `wiki_manifest=None` generator guard.
