### PR TITLE
docs(bio): add R1a Block A research dossiers (#2317)

### DIFF
--- a/docs/research/bio/antin-krushelnytskyi.md
+++ b/docs/research/bio/antin-krushelnytskyi.md
@@ -1,0 +1,130 @@
+# Антін Владиславович Крушельницький — Research Dossier
+
+**Slug:** `antin-krushelnytskyi`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own letters/work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Антін Владиславович Крушельницький. Some sources use Антон; the project uses Антін per audit appendix and Ukrainian literary convention. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Антін Крушельницький; Антон Крушельницький; A. Крушельницький; Antin Krushelnytskyi. Forbidden in body text except here: Anton Krushelnitsky, Антон Крушельницкий, Russianized surname forms.
+- **Born:** 4 August 1878 | Ланьцут, Galicia, Austro-Hungary; now Poland. [T1: ЕСУ; T1: IEU]
+- **Died:** 3 November 1937 | Sandarmokh near Medvezhyegorsk, Karelia, USSR | shot after NKVD special-troika decision. IEU preserves older "Solovki Islands in late 1937" wording; modern ESU/Sandarmokh framing specifies execution at Sandarmokh after Solovki imprisonment. [T1: ЕСУ; T1: IEU]
+- **Family / education key facts:** Writer, teacher, editor, public figure, former minister of education in the West Ukrainian People's Republic, and patriarch of a family heavily targeted by Soviet repression. He moved with family members to Soviet Ukraine and was arrested in Kharkiv. [T1: ЕСУ; T1: IEU]
+
+**Source disagreement note:** The main conflict is not whether Soviet repression killed him, but how precisely to name the place. Use: Solovki imprisonment, then Sandarmokh execution on 3 November 1937. Do not stop at "died on Solovki." [T1: ЕСУ; T1: IEU; T2: NBUV]
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, fabricated nationalist/terror accusation, 10-year camp sentence, Solovki imprisonment, special-troika death sentence, Sandarmokh execution.
+- **When:** arrested 6 November 1934 in Kharkiv; sentenced 28 March 1935 by a visiting session of the Military Collegium of the USSR Supreme Court to 10 years; special-troika decision in 1937; executed 3 November 1937. [T1: ЕСУ; T2: NBUV]
+- **By whom:** NKVD/UGB security organs; Military Collegium of the USSR Supreme Court; special troika of the UNKVD in Leningrad oblast.
+- **Document references:** Soviet accusation of leadership/participation in a Ukrainian nationalist or OUN-type underground and "terrorist" activity; 28 March 1935 Military Collegium sentence; Sandarmokh execution context. [T1: ЕСУ; T2: NBUV]
+- **Mechanism specifics:** Kрушельницький's case criminalized a west-Ukrainian public intellectual who had chosen Soviet Ukraine as a cultural home. The accusation tied Galician public life, education, and family networks to "terror" and nationalist underground language. [T1: IEU]
+
+The family dimension is central. The Soviet state did not only remove an individual writer; it attacked a household and a network of sons, in-laws, students, and colleagues. For curriculum use, this should be framed as the destruction of a cultural family, not merely the death of an elderly writer. [T2: NBUV]
+
+**What survived / what was destroyed:** His prose, journalism, letters, and translations survive in diaspora and Ukrainian holdings. Because some primary letters are available through modern publications, they should be used carefully as direct voice. The repression destroyed the immediate family/intellectual ecosystem that would have preserved and interpreted the archive. [T5: Zbruch letters; T2: NBUV]
+
+## 3. Major works
+
+- **1899** — *Пролетарі*, early prose/drama; social question and Galician realism.
+- **1900** — *Світла і тіні*, prose.
+- **1901** — *Серце*, prose.
+- **1902** — *Артистичні душі*, prose.
+- **1918-1919** — *Гомін Галицької землі*, wartime / national struggle context.
+- **1920** — *Буденний хліб*, prose; everyday social conflict.
+- **1920** — *Як пригорне земля*, prose; later republished with *Перемога*.
+- **1920** — *Як промовить земля*, prose.
+- **1921** — *Ірена Оленська*, novel/prose.
+- **1923** — *Дужим помахом крил*, prose.
+- **1923** — *Перемога*, prose; available in Diasporiana scans.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — letter, 20 October 1926, quoted in modern publication:**
+
+> **кулями люди хочуть чи доходити своїх прав**
+
+The line is important because it shows a civic voice troubled by violence and political escalation. It should be taught as letter evidence, not polished fiction.
+
+**Quote 2 — letter to Maria, 24 October 1926:**
+
+> **молитися за Собінського.**
+
+The phrase matters because it opens the Polish/Jewish/Ukrainian civic complexity around Galician public life and the Sobinski assassination context. It needs teacher framing and should not be isolated from the letter.
+
+## 5. Language register
+
+- **Register:** Galician civic-publicistic prose, realist fiction, pedagogical rhetoric, intimate letters.
+- **CEFR readiness for full reading:** C1 for prose and letters because of older orthography and public-life context; B2/C1 for selected short excerpts.
+- **Lexicon notes:** Galician forms, political and educational vocabulary, Polish/Austro-Hungarian civic context, older spellings, and family-letter intimacy.
+- **Stylistic features:** rhetorical argument, social realism, teacherly moral pressure, and documentary immediacy in letters.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Kрушельницький is both a Galician civic writer and a Soviet-repressed returnee. Treating him only as a "Soviet victim" misses the long pre-Soviet public career; treating him only as Galician elder misses the fatal Soviet choice and repression. [T1: IEU]
+- **Solovki/Sandarmokh wording:** IEU's older wording must be corrected with modern Sandarmokh specificity, while still naming Solovki imprisonment.
+- **What gets simplified:** The family tragedy can become a sentimental shorthand. The dossier should keep document dates and institutions visible.
+- **Russian/Soviet disinformation angle:** Soviet accusation language around OUN/nationalist terror is not reliable biography. It is evidence of the police mechanism.
+- **Polish/Jewish/other-perspective considerations:** His Galician context includes Polish state power, Ukrainian education, and Jewish public life. The Sobinski-letter material requires careful anti-simplification, not a one-community blame frame.
+
+**Additional research cautions:** Kрушельницький's dossier should preserve scale. He is older than many Розстріляне Відродження figures and belongs to a pre-Soviet Galician civic world before he becomes a Soviet victim. If future curriculum starts only in 1934, it will miss why his arrest mattered: a teacher, minister, editor, novelist, and family patriarch brought a whole institutional memory into Soviet Ukraine. The terror destroyed that memory and then made the destruction look like a criminal case.
+
+**Source-handling note:** Because the accusation mentions nationalist underground and terror, plan writers must avoid retrojecting later OUN histories into the 1934 file. Say "Soviet authorities accused him..." and then move back to the documented procedure. For death place, use the two-step wording every time: imprisoned in the Solovki system, then executed at Sandarmokh. This resolves the IEU/ESU wording difference without pretending one source is careless.
+
+**Pedagogical bridge:** This biography can support an advanced lesson on migration toward danger. Like Irchan, Kрушельницький had a west-Ukrainian public career and crossed into Soviet Ukraine with expectations of cultural work. Students can examine why Soviet Ukraine looked like an opportunity to some Galician intellectuals and why the regime later recoded those same networks as suspect. This avoids hindsight smugness.
+
+**Family-context caution:** The family tragedy is pedagogically powerful, but it should not become a vague martyrdom tableau. Name the dates, institutions, and works first; then connect the sons and family members through documented follow-up research.
+
+**Assessment note:** Kрушельницький can help learners understand that "return to Soviet Ukraine" was not always naive. It could be driven by belief in Ukrainian cultural work, exhaustion with interwar Polish constraints, family strategy, or left-leaning hope. A good lesson should leave room for that complexity. It should not sneer at the decision after the fact, because hindsight is not historical analysis.
+
+**Source expansion note:** The Zbruch letter excerpts are valuable but Tier 5 in this dossier. Before Phase 2, try to locate the archival or edited-letter source behind them. If unavailable, keep the quotations but mark them as modern-publication access copies, not as the highest authority for chronology.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- `docs/archive/RAG-LITERARY-CATALOG.md` and local literary corpus include *Рубають ліс* / prose references through encyclopedic chunks.
+- No direct existing LIT plan for Kрушельницький was found.
+- Potential Phase 2 additions: Galician civic prose, the Kрушельницький family as a repression case, or *Рубають ліс* / *Буденний хліб*.
+- HIST links: ZUNR educational administration, west-Ukrainian returnees to Soviet Ukraine, Solovki/Sandarmokh. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `antin-krushelnytskyi`
+- **EN canonical:** Antin Krushelnytskyi.
+- **UA canonical:** Антін Владиславович Крушельницький.
+- **Aliases to track:** Антон Крушельницький; A. Крушельницький; Antin Krushelnytsky; Antin Krushelnytskyi.
+- **Forbidden Russian-imperial / Russified forms:** Anton Krushelnitsky; Антон Крушельницкий; death wording that says only "Solovki" and omits Sandarmokh.
+
+## 9. Image candidates
+
+- Wikimedia Commons `File:Krushelnycki.jpg`, verify PD/license before final use.
+- Commons category `Antin Krushelnytskyi (writer)` for alternate portraits.
+- Diasporiana scans of *Перемога / Як пригорне земля* can provide era-appropriate cover images if rights are clear.
+
+## 10. Sources used
+
+- **[T1]** "Крушельницький Антін." *Енциклопедія Сучасної України*. https://esu.com.ua/article-221
+- **[T1]** "Krushelnytsky, Antin." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CR%5CKrushelnytskyAntin.htm
+- **[T2]** NBUV page on Антін Крушельницький. https://www.nbuv.gov.ua/node/4850
+- **[T2]** VSPU faculty profile on Антін Крушельницький. https://vspu.edu.ua/faculty/filolog/ukr/persons/kryshelnuckii-antin.html
+- **[T5]** Zbruch publication of letters, used for primary-voice excerpts pending archival edition. https://zbruc.eu/node/119400
+- **[T5]** Diasporiana scans of *Перемога / Як пригорне земля*, primary text access.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.

--- a/docs/research/bio/hryhorii-epik.md
+++ b/docs/research/bio/hryhorii-epik.md
@@ -1,0 +1,127 @@
+# Григорій Данилович Епік — Research Dossier
+
+**Slug:** `hryhorii-epik`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work / recorded letters
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Григорій Данилович Епік. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Г. Епік; Hryhorii Epik. Forbidden in body text except here: Grigory Epik, Grigorii Epik, Григорий Эпик.
+- **Born:** 17 January 1901 | Кам'янка, Катеринославська губернія; now within Дніпро / Дніпропетровська область, Україна. [T1: ЕСУ; T1: IEU]
+- **Died:** 3 November 1937 | Sandarmokh, Karelia, USSR | shot after an NKVD special-troika decision. [T1: ЕСУ; T1: IEU; T5: UINP]
+- **Family / education key facts:** He worked as a railway and factory employee, joined the Communist Party in 1919, studied and worked in Soviet Ukrainian cultural institutions, and became a novelist, satirist, and member of the 1920s literary milieu around ВАПЛІТЕ. [T1: ЕСУ; T1: IEU]
+
+**Source disagreement note:** Some older Soviet reference material says "died 1942" or leaves the place vague. Modern ESU/IEU and Sandarmokh memory sources give 3 November 1937 as the execution date. The title *В снігах* appears with 1928 and 1929 edition dates; note the edition rather than forcing one date. [T1: ЕСУ; T1: IEU]
+
+## 2. Oppression mechanism
+
+- **What happened:** arrest in the fabricated "Borotbist counter-revolutionary organization" case, 10-year camp sentence, Solovki imprisonment, special-troika death sentence, execution at Sandarmokh.
+- **When:** arrested 5 December 1934; sentenced 27-28 March 1935 by a visiting session of the Military Collegium of the USSR Supreme Court in Kyiv to 10 years; special troika decision 9 October 1937; executed 3 November 1937. [T1: ЕСУ; T1: IEU; T5: UINP]
+- **By whom:** NKVD/GPU security organs; Military Collegium of the USSR Supreme Court; special troika of the UNKVD in Leningrad oblast.
+- **Document references:** "borotbist counter-revolutionary organization" case; 27-28 March 1935 Kyiv Military Collegium sentence; 9 October 1937 special-troika decision for Solovki prisoners. [T1: ЕСУ; T5: UINP]
+- **Mechanism specifics:** Epik's case criminalized a Ukrainian Soviet writer through an invented organizational label. The accusation borrowed from earlier Ukrainian left-wing political history, turning "Borotbist" associations into a retroactive counter-revolutionary conspiracy. [T1: ЕСУ]
+
+Epik's biography is uncomfortable because he was not an anti-Soviet outsider. He had party credentials and wrote works compatible with Soviet themes. The execution therefore teaches that Stalinist terror did not only target open opposition; it consumed Ukrainian cultural producers whose language, networks, or prior affiliations could be reclassified as nationalist threat. [T1: IEU]
+
+**What survived / what was destroyed:** Published novels and stories survived, but often through Soviet-framed editions. His Solovki letters survive as recorded voice and need careful handling: they are primary evidence of family address and camp pressure, not a free public statement. [T5: Poltava.to quote article; T2: NLU/NBUV scan records]
+
+## 3. Major works
+
+- **1923** — *Червона кобза*, collection; early revolutionary-cultural framing.
+- **1926** — *На зломі*, prose; transition from revolutionary themes to social conflict.
+- **1928** — *Без ґрунту*, novel; important for satire and anti-opportunist prose.
+- **1928/1929** — *В снігах*, prose; edition date varies by source.
+- **1929** — *Зустріч*, prose.
+- **1929** — *Облога*, novel / prose work.
+- **1930** — *Непія*, novel; among his best-known prose works.
+- **1930** — *Том сатири*, satirical collection.
+- **1931** — *Перша весна*, novel.
+- **1932** — *Петро Ромен*, novel; late Soviet-period work before arrest.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — Solovki letter to family, 1937, quoted in modern Ukrainian article:**
+
+> **Любов до тебе осмислює існування.**
+
+The line matters because it resists the archival reduction of the prisoner to a case number. It is short enough for learners, but should be framed as camp correspondence, not polished literary prose.
+
+**Quote 2 — same Solovki letter context, 1937:**
+
+> **лишатися для вас здоровою людиною.**
+
+This phrase gives a precise pedagogical opening into coercion and self-presentation. The writer is speaking to family under camp conditions, trying to remain legible as whole and alive.
+
+## 5. Language register
+
+- **Register:** revolutionary prose, social satire, bureaucratic and anti-bureaucratic diction, later official Soviet register under pressure.
+- **CEFR readiness for full reading:** C1 for full novels; B2/C1 for selected satirical excerpts with historical glossary.
+- **Lexicon notes:** Party vocabulary, industrial and institutional terms, social-type labels, and colloquial speech. Learners need help separating satire from endorsement.
+- **Stylistic features:** caricature, social diagnosis, scene-based satire, and a tension between official ideology and lived Ukrainian social reality.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Epik is difficult to place because some work aligns with Soviet literary demands while his execution places him in the Розстріляне Відродження cohort. The dossier should not sanitize either side. [T1: IEU]
+- **Date/title issues:** *В снігах* needs edition-sensitive dating; older death-date claims must be rejected in favor of Sandarmokh documentation.
+- **What gets simplified:** He can be reduced either to "Soviet writer" or "innocent martyr." A better account names the Soviet affiliations and then shows how the same system destroyed him.
+- **Russian/Soviet disinformation angle:** The Soviet case label "counter-revolutionary Borotbist organization" is a police construction. Do not use it as objective description.
+- **Other-perspective considerations:** His biography can support a broader lesson on Ukrainian leftist currents and why Soviet imperial terror also eliminated Ukrainian communist and socialist cultural actors.
+
+**Additional research cautions:** Epik requires anti-hagiographic precision. A weak lesson will either excuse all Soviet-aligned writing because he was later murdered, or condemn the writer so completely that the murder becomes hard to explain. Neither approach matches the source record. He wrote inside Soviet institutions, used Soviet themes, and still became a victim of the same state. That contradiction is the lesson. It shows that Stalinist terror was not a simple screen for "anti-Soviet" belief; it was a tool for disciplining and eliminating Ukrainian cultural agency, including agency expressed through leftist or communist vocabularies.
+
+**Source-handling note:** Avoid using older Soviet literary encyclopedia entries as authority for death, rehabilitation, or motive. They can be mined only as evidence of Soviet framing. The modern chain to preserve is December 1934 arrest, March 1935 10-year sentence, Solovki imprisonment, 9 October 1937 special-troika death sentence, 3 November 1937 Sandarmokh execution. If a source gives "1942," it likely reflects concealment or stale Soviet metadata and must be rejected or explicitly flagged.
+
+**Pedagogical bridge:** Epik is useful in a module cluster with Polishchuk and Yalovyi because all three demonstrate the regime's conversion of earlier Ukrainian left/socialist affiliations into retrospective guilt. Students can compare the labels "Borotbist," "UVO," and "terrorist organization" as police categories and ask what real social networks those labels were trying to destroy. That keeps the focus on mechanism rather than on whether a writer was "ideologically pure."
+
+**Primary-voice caution:** The Solovki letter excerpts are direct voice, but they are not equivalent to freely published literary statements. They should be introduced as family correspondence under coercive camp conditions, where tone, omissions, and health claims may be shaped by surveillance.
+
+**Assessment note:** Epik's dossier should also warn reviewers against assuming that "Soviet-themed" works are automatically pedagogically useless. The useful task is comparative: identify where official vocabulary enters the prose, where satire undercuts opportunism, and where later editions may have normalized the text. That makes him a case study in language under ideological pressure rather than a simple author recommendation.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- `wiki/literature/works/rozstriliane-vidrodzennia-phenomenon.md` — broader Розстріляне Відродження context.
+- `wiki/figures/mykola-khvylovyi.md` and ВАПЛІТЕ-related wiki material — useful peer network context.
+- No direct existing LIT plan for Epik was found. Future Phase 2 could add *Без ґрунту* or *Непія* as prose/satire modules.
+- HIST context should link to `mekhanizm-teroru`, `syntez-trahedii`, and Sandarmokh/Great Terror framing where available. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `hryhorii-epik`
+- **EN canonical:** Hryhorii Epik.
+- **UA canonical:** Григорій Данилович Епік.
+- **Aliases to track:** Г. Епік; Hryhorii Epik; Epik Hryhorii.
+- **Forbidden Russian-imperial / Russified forms:** Grigory Epik; Grigorii Epik; Григорий Эпик; any phrasing that presents the NKVD charge as factual.
+
+## 9. Image candidates
+
+- IEU portrait `Epik Hryhorii.jpg`, first candidate after final rights review.
+- Dnipro museum / regional museum page on Epik, useful for contextual exhibit material.
+- NBUV/НЛУ scans of works can supply era-appropriate covers if portrait rights are uncertain.
+
+## 10. Sources used
+
+- **[T1]** "Епік Григорій Данилович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-17936
+- **[T1]** "Epik, Hryhorii." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CE%5CP%5CEpikHryhorii.htm
+- **[T2]** Національна бібліотека України / electronic library record for Epik scans. https://elib.nlu.org.ua/view.html?id=7931
+- **[T2]** NBUV/IRBIS scan record for Epik work. https://irbis-nbuv.gov.ua/ulib/item/ukr0000026468
+- **[T2]** НІБУ exhibit on Розстріляне Відродження. https://nibu.kyiv.ua/exhibitions/202/
+- **[T5]** UINP Sandarmokh list of executed Ukrainians. https://uinp.gov.ua/pres-centr/novyny/sogodni-po-vsomu-sviti-chytayut-imena-zhertv-sandarmohu-spysok-rozstrilyanyh-ukrayinciv
+- **[T5]** Modern article quoting Epik's Solovki letter, used only for primary-voice excerpts pending a stronger archival edition. https://poltava.to/project/6654/

--- a/docs/research/bio/marko-voronyi.md
+++ b/docs/research/bio/marko-voronyi.md
@@ -1,0 +1,129 @@
+# Марко Миколайович Вороний — Research Dossier
+
+**Slug:** `marko-voronyi`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Марко Миколайович Вороний. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Антіох; Марко Антіох; Marko Voronyi. Forbidden in body text except here: Marko Vorony, Mark Voronoi, Марк Вороной, Russianized patronymic forms.
+- **Born:** 18 March 1904 | Чернігів, Ukrainian lands under the Russian Empire. Some records preserve 5 March old-style notation. [T1: ЕСУ; T2: Kotsiubynsky Museum]
+- **Died:** 3 November 1937 | Sandarmokh near Medvezhyegorsk, Karelia, USSR | shot after NKVD special-troika decision. [T1: ЕСУ; T1: IEU; T2: Kotsiubynsky Museum]
+- **Family / education key facts:** Son of Микола Вороний; lived inside a literary family network, wrote poetry for children and adults, and worked in publishing/literary contexts before arrest. [T1: ЕСУ; T2: Kotsiubynsky Museum]
+
+**Source disagreement note:** The birth date appears in old/new style form; use 18 March 1904 in modern display while recording the old-style 5 March variant in notes. The repression chronology is stable across modern institutional sources: Kyiv arrest in 1935, camp sentence in 1936, Sandarmokh execution in 1937. [T2: Kotsiubynsky Museum; T1: IEU]
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, imprisonment in Kyiv, closed military-tribunal sentence, Solovki imprisonment, special-troika death sentence, execution at Sandarmokh.
+- **When:** arrested in Kyiv on 19 March 1935; held about ten months in Lukianivka prison; closed Kyiv Military District tribunal 1-4 February 1936; sentenced to 8 years ITL; special troika decision 9 October 1937; executed 3 November 1937. [T2: Kotsiubynsky Museum; T1: IEU]
+- **By whom:** NKVD; Kyiv Military District tribunal; special troika of the UNKVD in Leningrad oblast.
+- **Document references:** Kotsiubynsky Museum page summarizes the arrest/sentence/execution chain; ESU and IEU corroborate identity and death. [T1: ЕСУ; T1: IEU; T2: Kotsiubynsky Museum]
+- **Mechanism specifics:** Voronyi's case shows a family and generational dimension of the terror. His father Mykola was also repressed and executed in 1938. Marko's arrest preceded the father's execution but belongs to the same destruction of Ukrainian literary continuity. [T1: IEU]
+
+The 1936 sentence to eight years did not mean survival. Like many Solovki prisoners, Marko Voronyi was later included in the 1937 death lists. That conversion from fixed camp term to execution is a central feature of the Sandarmokh mechanism and should be named explicitly in curriculum prose.
+
+**What survived / what was destroyed:** Children's books and lyric fragments survived in library holdings and museum memory. The small scale of his corpus can make him appear minor, but the destruction of a young poet and the father-son literary line is historically significant. [T2: Kotsiubynsky Museum; T2: NBUV]
+
+## 3. Major works
+
+- **1920s** — lyric cycle including "Молитва," "Церква," "Янголи," and "Різдвяна елегія"; religious and symbolic register. [T2: Kotsiubynsky Museum]
+- **1930** — *Трюки в кіні*, children's/young reader verse; modern entertainment vocabulary.
+- **1930** — *Червоні краватки*, children's verse.
+- **1930** — *Будівники*, children's/social construction theme.
+- **1930** — *Коники*, children's verse.
+- **1930** — *Носоріг*, children's verse.
+- **1930** — *Ставок*, children's verse.
+- **1932** — *Форвард*, publicistic/sports or forward-motion register.
+- **Undated / manuscript or periodical** — "Отчизна," lyric-historical poem quoted in museum materials.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — "Церкви і янголи", museum transcription dated 22 January 1925:**
+
+> **Ідуть два янголи вгорі.**
+
+This line shows the contemplative and religious-symbolic register that complicates a purely children's-writer label.
+
+**Quote 2 — "Отчизна", museum transcription:**
+
+> **Судилась крізь війну в віках дорога.**
+
+The line is useful for advanced learners because it compresses history, fate, and homeland into one syntactic movement. It should be taught as high lyric, not everyday Ukrainian.
+
+## 5. Language register
+
+- **Register:** contemplative lyric, religious-symbolic imagery, children's verse, and occasional publicistic Soviet-era vocabulary.
+- **CEFR readiness for full reading:** B2 for children's poems; C1 for religious-symbolic lyric.
+- **Lexicon notes:** Biblical/religious vocabulary, homeland and fate abstractions, children's concrete nouns, and early Soviet public words in later titles.
+- **Stylistic features:** short lyric lines, symbolic vertical imagery, sonnet-like compression, and child-facing rhythmic clarity in published children's books.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Marko Voronyi is often treated mainly through his father or through Sandarmokh lists. The dossier should preserve him as a distinct writer with a dual adult/children's corpus. [T1: IEU; T2: Kotsiubynsky Museum]
+- **Birth-date notation:** The old-style/new-style date is the main factual notation issue. Use 18 March 1904 for the modern curriculum date.
+- **What gets simplified:** He is flattened into "son of Mykola Voronyi." That is true but insufficient; he was also a poet of religious imagery and children's print culture.
+- **Russian/Soviet disinformation angle:** Soviet bibliographic language may omit the execution mechanism or leave the death place vague. The Sandarmokh execution must be explicit.
+- **Other-perspective considerations:** The family context is pedagogically important, but avoid making Mykola's biography the only frame for Marko.
+
+**Additional research cautions:** Marko Voronyi is the shortest and most easily erased dossier in this Block A set, so future writers need deliberate scaffolding. The correct response is not to inflate his corpus beyond evidence, but to explain why a smaller corpus still matters. He represents the second generation of a Ukrainian literary family, children's print culture of the early 1930s, and a religious-symbolic lyric strand that does not fit the stereotype of Soviet youth literature. Those three angles are enough for a meaningful bio module.
+
+**Source-handling note:** His children's titles should be verified through library records before a lesson chooses excerpts. The museum page gives a strong institutional narrative and quotes adult lyric; the NBUV record gives bibliographic support. Do not infer that all titles are available in classroom-ready text. Also avoid normalizing the pen name Антіох out of existence: it helps distinguish the adult lyric voice from the child-facing titles.
+
+**Pedagogical bridge:** Marko should be cross-linked to Mykola Voronyi, but a future activity can make the family link productive rather than biographical decoration. Students can compare Mykola's symbolist elevation with Marko's "янголи" imagery and then trace how both generations were processed by different Soviet terror mechanisms. This makes the father-son relationship a lens on cultural continuity and rupture.
+
+**Execution-context note:** The timeline matters: arrest in 1935, sentence in 1936, execution in 1937. That sequence shows that the camp sentence was not a stable punishment but a holding stage before mass murder. This should be explicit in any Sandarmokh lesson.
+
+**Assessment note:** Marko Voronyi should be considered for a smaller, carefully framed module rather than a large literary-survey lesson. His value may be strongest in a family-and-generation unit, a Sandarmokh unit, or a children's-literature-under-terror unit. That is not a downgrade. It is a way to preserve proportionality while still resisting erasure. A 10-minute excerpt activity around one adult lyric line and one children's title could teach more honestly than a forced full-author lecture.
+
+**Source expansion note:** Before Phase 2, verify whether any digitized editions of *Форвард* or the children's books are available with stable page references. If not, the module should rely on museum-quoted lyric and bibliographic discussion rather than invented close readings. This dossier intentionally avoids quoting titles whose text was not available in the current research pass.
+
+**Reviewer note:** Marko's dossier should be judged by evidence density, not by celebrity weight. If a later plan needs to choose between a full standalone module and a paired family module, the paired format may be stronger. The key acceptance criterion is that Marko remains a named author with his own works, not an anonymous appendix to his father.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- This dossier connects directly to `docs/research/bio/mykola-voronyi.md` in the same Block A batch.
+- Existing LIT plans for Mykola Voronyi (`voronyi-symbolism.yaml`, `voronyi-poetry.yaml`) can later cross-link to Marko as family/cultural-continuity context.
+- No direct existing LIT module for Marko Voronyi was found.
+- HIST links: Sandarmokh, Solovki, Great Terror, `mekhanizm-teroru`, and `syntez-trahedii`. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `marko-voronyi`
+- **EN canonical:** Marko Voronyi.
+- **UA canonical:** Марко Миколайович Вороний.
+- **Aliases to track:** Антіох; Марко Антіох; Marko Voronyi.
+- **Forbidden Russian-imperial / Russified forms:** Marko Vorony; Mark Voronoi; Марк Вороной; Russian patronymic forms.
+
+## 9. Image candidates
+
+- ЕСУ article page `https://esu.com.ua/article-29782`, first candidate after reuse check.
+- Kotsiubynsky Museum page includes family/photo material and quoted poems; use for institutional lead, not automatically as reusable image.
+- NBUV record `https://irbis-nbuv.gov.ua/ulib/item/REF0006792` may provide scan/context material.
+
+## 10. Sources used
+
+- **[T1]** "Вороний Марко Миколайович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-29782
+- **[T1]** "Vorony, Marko." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CO%5CVoronyMarko.htm
+- **[T2]** Музей-заповідник М. Коцюбинського. "Співець трагічної епохи..." https://kotsubinsky.org/news/spivec_tragichnoji_epokhi_do_115_richchja_z_dnja_narodzhennja_marka_voronogo_18_03_1904_3_11_1937/2019-03-18-1381
+- **[T2]** NBUV/IRBIS record for Marko Voronyi material. https://irbis-nbuv.gov.ua/ulib/item/REF0006792
+- **[T5]** UINP Sandarmokh list used as execution-list cross-check where needed.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.

--- a/docs/research/bio/mykhail-semenko.md
+++ b/docs/research/bio/mykhail-semenko.md
@@ -1,0 +1,120 @@
+# Михайль Васильович Семенко — Research Dossier
+
+**Slug:** `mykhail-semenko`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайль Васильович Семенко; the public literary name is Михайль Семенко. Some sources normalize the given name to Михайло, but the project slug follows the audit appendix and his avant-garde signature. [T1: IEU; T1: UINP]
+- **Pseudonyms / aliases:** Михайло Семенко; М. Семенко; Mykhailo Semenko; Mykhail Semenko. Forbidden in body text except in this naming section: Mikhail Semenko, Михаил Семенко, Mykhailo Semenko as a replacement for the canonical public name.
+- **Born:** 31 December 1892 | Кибинці, Миргородський повіт, Полтавська губернія; now Полтавська область, Україна. [T1: IEU; T1: UINP]
+- **Died:** verdict dated 23 October 1937; execution recorded by UINP as 24 October 1937 | Kyiv, Ukrainian SSR | shot by NKVD after a fabricated terrorist-organization accusation. [T1: IEU; T1: UINP]
+- **Family / education key facts:** His mother Марія Проскурівна was a writer; he studied in Хорол and Курськ, then at the Psychoneurological Institute in Petrograd. Wartime service took him to Vladivostok before his 1917 return to Kyiv and his central role in Ukrainian futurism. [T1: IEU; local literary corpus]
+
+**Source disagreement note:** IEU gives 23 October 1937 as the death date, while UINP separates the 23 October verdict from the 24 October execution. The dossier therefore uses "23/24 October 1937" where needed and treats 24 October as the execution date. Burial is commonly linked to Bykivnia, but the accessed sources support that as probable rather than fully documented. [T1: IEU; T1: UINP]
+
+## 2. Oppression mechanism
+
+- **What happened:** arrest, fabricated NKVD case, death sentence, execution.
+- **When:** arrested 26 April 1937 in Kyiv; accused in connection with a supposed 1 May 1937 terror plot; sentenced 23 October 1937; executed 24 October 1937 according to UINP. [T1: UINP; T1: IEU]
+- **By whom:** NKVD organs in Soviet Ukraine; the case used all-Union Stalinist terror categories against Ukrainian cultural leadership.
+- **Document references:** UINP summarizes the accusation as membership in a fictitious "Ukrainian fascist nationalist terrorist organization" and planning a terrorist act during the 1 May demonstration. Use that phrase only as a quoted Soviet charge, not as a factual organization. [T1: UINP]
+- **Mechanism specifics:** Semenko's arrest came after the regime had already liquidated the institutional space of avant-garde experimentation. The allegation transformed a literary organizer and editor into an alleged conspirator. That was the standard Great Terror move: attach the writer to an invented nationalist-terrorist cell, convert editorial and group activity into "organization," and make execution administratively fast. [T1: UINP; T1: IEU]
+
+The case is also a direct attack on Ukrainian modernist language-making. Semenko had openly challenged inherited canons, but he did so from inside a Ukrainian literary project. Soviet police language tried to make that independent cultural agency legible only as "fascism" and "terror." A decolonized curriculum must not repeat that criminal frame as explanation; it should name it as the instrument of repression.
+
+**What survived / what was destroyed:** The poems, manifestos, and periodical traces survived unevenly through library and diaspora recovery. Much of the futurist press was fragile by design: journals, almanacs, manifestos, and group publications. The execution also interrupted editorial memory, making later Soviet histories flatten him into either harmless formalist curiosity or ideological warning. [T1: IEU; T2: NLO overview]
+
+## 3. Major works
+
+- **1913** — *Prelude / Прелюди*, early collection; still close to symbolist and romance lyric.
+- **1913** — *Дерзання*, early futurist gesture; begins the break with inherited poetic decorum.
+- **1914** — *Кверофутуризм*, manifesto/booklet; names the searching, anti-static version of Ukrainian futurism. [T1: IEU]
+- **1918** — *П'єро кохає*, poetry cycle; one part of the Pierrot persona sequence.
+- **1918** — *Дев'ять поем*, collection; wartime and revolutionary experimentation.
+- **1920** — *Альманах трьох* with Oleksa Slisarenko and Mykola Liubchenko; editorial-organizational importance.
+- **1925** — *В революцію*, collection; shows the pressure of revolutionary and functional diction.
+- **1928** — *Мій рейд у вічність*, long poem; self-mythologizing futurist voice.
+- **1929** — *Арії трьох П'єро*, collected Pierrot sequence; core text for teaching his lyric-futurist range.
+- **1930** — *В садах безрозних*, late collection under tightening Soviet cultural pressure.
+- **1931** — *Тов. Сонце*, Soviet-era functional verse; useful for tracing the pressure from avant-garde search toward ideological utility.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — "Мрія", in *Арії трьох П'єро*, 1929:**
+
+> **Я буду великим скрипником і поїду в Японію.**
+
+This small sentence is a good learner-facing entry into Semenko's cosmopolitan futurism: the desired horizon is not Petersburg or Moscow but an invented global itinerary. The line was located through Wikisource and the local literary corpus.
+
+**Quote 2 — "Сонцекров", in *Арії трьох П'єро*, 1929:**
+
+> **я сонцекров люблю і в крові сонце.**
+
+The compact neologism makes visible his sound-based and image-based experiment. It is difficult for L2 readers, but useful at C1 because it shows why Ukrainian futurism needed new compounds and not merely new slogans.
+
+## 5. Language register
+
+- **Register:** Ukrainian futurist, manifesto-like, urban, playful, often aggressively anti-classical; early lyric residue remains under the shock tactics.
+- **CEFR readiness for full reading:** C1/C2 for manifestos and dense poems; B2 for selected short poems with a strong glossary.
+- **Lexicon notes:** Neologisms, self-naming, city and technology vocabulary, foreign cultural references, and deliberate disruptions of conventional lyric syntax.
+- **Stylistic features:** manifestos, typographic and persona play, urban montage, anti-canon performance, Pierrot masks, and rhythmic bluntness. Teach the "burning Kobzar" episode as a dispute over canonization, not as anti-Ukrainian nihilism.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Semenko is debated as both the founder of Ukrainian futurism and a figure whose dependence on shock can obscure the constructive work he did as editor, organizer, and theorist. The curriculum should keep both: provocation and institution-building. [T1: IEU; T2: NLO overview]
+- **Execution date and burial:** 23 October is a stable sentence/death date in some reference works; UINP gives 24 October as execution. Bykivnia should be phrased as probable unless a final archival citation is added.
+- **What gets simplified:** Popular memory often reduces him to "the poet who burned *Kobzar*." That misses the larger project: defending Ukrainian literature's right to be urban, international, experimental, and contemporary.
+- **Russian/Soviet disinformation angle:** Soviet and Russocentric frames can present him as derivative of Russian futurism. A fair account admits influence and contact but foregrounds his independent Ukrainian-language institution-building.
+- **Other-perspective considerations:** Semenko used global references, including Japan and European avant-garde idioms, but those references expand Ukrainian cultural space rather than dissolving it.
+
+**Curriculum caution:** Semenko is a high-risk figure for caricature pedagogy because the "burning Kobzar" anecdote is louder than the archive. A future lesson should quote his own manifestos and poems before asking students to judge the provocation. It should also separate three claims that are often collapsed: he challenged the cultic use of Shevchenko; he built Ukrainian-language futurist institutions; and the Soviet state later executed him under an invented terrorist label. Those facts do not cancel one another. The most defensible teaching frame is "modernizing conflict inside Ukrainian culture under later Soviet annihilation," not "anti-tradition rebel" and not "Soviet avant-gardist."
+
+## 7. Cross-track links
+
+`rg` checks found direct existing and planned coverage:
+
+- `curriculum/l2-uk-en/plans/lit/semenko-futurism-manifesto.yaml` — direct Semenko futurism module.
+- `curriculum/l2-uk-en/plans/lit/semenko-kobzar-burning.yaml` — direct canon-provocation module.
+- `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml` — places Semenko in the stylistic pluralism of the period.
+- `curriculum/l2-uk-en/plans/c2/individual-voice-ii.yaml` — lists Semenko's futurist poems as advanced voice material.
+- HIST context should connect to `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` and `curriculum/l2-uk-en/plans/hist/syntez-trahedii.yaml`. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhail-semenko`
+- **EN canonical:** Mykhail Semenko for slug continuity; Mykhailo Semenko may appear in English scholarship but should be listed as an alias.
+- **UA canonical:** Михайль Васильович Семенко; public form Михайль Семенко.
+- **Aliases to track:** Михайло Семенко; М. Семенко; Mykhailo Semenko; Mykhail Semenko.
+- **Forbidden Russian-imperial / Russified forms:** Mikhail Semenko; Михаил Семенко; framing him as a Russian futurist rather than a Ukrainian futurist.
+
+## 9. Image candidates
+
+- IEU portrait: `Semenko Mykhailo (1913 photo)`, hosted by Encyclopedia of Ukraine; verify final reuse rights before Phase 4.
+- IEU 1910s photo: alternate portrait useful for early avant-garde context.
+- Wikimedia/Wikisource author pages may contain scans of covers and portraits, but final use should prefer a clearly licensed file page.
+
+## 10. Sources used
+
+- **[T1]** "Semenko, Mykhailo." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CE%5CSemenkoMykhailo.htm
+- **[T1]** Український інститут національної пам'яті. "1892 — народився поет Михайль Семенко." https://uinp.gov.ua/istorychnyy-kalendar/gruden/31/1892-narodyvsya-poet-myhayl-semenko
+- **[T1]** Український інститут національної пам'яті. "1937 — розстріляно Михайля Семенка, поета." https://uinp.gov.ua/istorychnyy-kalendar/zhovten/24/1937-rozstrilyano-myhaylya-semenka-poeta
+- **[T2]** Scholarly overview of Ukrainian futurism in *Новое литературное обозрение*, used for interpretive cross-checking, not for Soviet claims as authority. https://www.nlobooks.ru/magazines/novoe_literaturnoe_obozrenie/133_nlo_3_2015/article/11453/
+- **[T5]** Wikisource author/work pages for *Арії трьох П'єро*, used for primary text access and corroborated against higher-tier biography.
+- **[T3]** Ukrainian Wikipedia extract was used only as a navigation aid.

--- a/docs/research/bio/mykhailo-yalovyi.md
+++ b/docs/research/bio/mykhailo-yalovyi.md
@@ -1,0 +1,123 @@
+# Михайло Омелянович Яловий — Research Dossier
+
+**Slug:** `mykhailo-yalovyi`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Омелянович Яловий. [T1: IEU; T1/T2: NBUV]
+- **Pseudonyms / aliases:** Юліан Шпол; Михайло Красний; Mykhailo Yalovy; Yulian Shpol. Forbidden in body text except here: Mikhail Yalovy, Михаил Яловой, Russianized patronymic forms.
+- **Born:** 5 June 1895 | Дар-Надежда, Костянтиноградський повіт, Полтавська губернія; now Харківська область, Україна. [T1: IEU; T1/T2: NBUV]
+- **Died:** 3 November 1937 | Sandarmokh, Karelia, USSR | executed after an NKVD special-troika decision. [T1/T2: NBUV; T5: UINP Sandarmokh list]
+- **Family / education key facts:** He studied at the Kyiv Commercial Institute, participated in revolutionary-era politics, and became a key literary organizer: first president of ВАПЛІТЕ and a close associate of Микола Хвильовий. [T1: IEU; T1: ЕУ]
+
+**Source disagreement note:** Popular accounts sometimes say "spy" or "plot against Postyshev"; the stronger archival-memory framing is his May 1933 arrest in the fabricated "Ukrainian Military Organization" case, followed by a 10-year sentence and later Sandarmokh execution. Keep later accusation phrases as Soviet case language, not factual explanation. [T1/T2: NBUV; T5: UINP]
+
+## 2. Oppression mechanism
+
+- **What happened:** arrest in a fabricated political case, 10-year sentence, Solovki imprisonment, renewed NKVD death sentence, execution at Sandarmokh.
+- **When:** arrested 11 May 1933; sentenced 29 September 1933 to 10 years; imprisoned in the Solovki system; special troika decision 9 October 1937; executed 3 November 1937. [T1/T2: NBUV; T5: UINP]
+- **By whom:** GPU/NKVD security organs; later special troika of the UNKVD for Leningrad oblast.
+- **Document references:** the fabricated "Ukrainian Military Organization" case; 9 October 1937 special-troika decision for Solovki prisoners; Sandarmokh execution lists. [T1/T2: NBUV; T5: UINP]
+- **Mechanism specifics:** Yalovyi's arrest was a cultural-political signal. Khvylovyi's suicide on 13 May 1933 happened two days after Yalovyi's arrest, and contemporary memory treats the arrest as a decisive escalation against the ВАПЛІТЕ circle. [T1: IEU]
+
+The mechanism linked Ukrainian literary autonomy with invented military conspiracy. Yalovyi had been an organizer and editor, which made him especially vulnerable: the state could recode a literary network as a political underground. The later 1937 resentencing shows the second phase of Stalinist repression: people already serving long camp terms were selected for execution in mass operations. [T1/T2: NBUV; T5: UINP]
+
+**What survived / what was destroyed:** His published prose survived only partially in scattered editions and scans. His organizer role is often better remembered than his own writing, which risks turning him into a footnote to Khvylovyi. The dossier should preserve him as both a ВАПЛІТЕ institution-builder and the author of satirical modernist prose. [T1: IEU; T1: ЕУ]
+
+## 3. Major works
+
+- **1920** — *Треба розжувати*, pamphlet / polemical writing; early revolutionary-publicistic mode.
+- **1923** — *Верхи*, collection; marks his movement through poetry and prose toward literary organization.
+- **1925** — ВАПЛІТЕ presidency and editorial work; not a work of art, but a major cultural act. [T1: IEU]
+- **1928** — *Катіна любов*, prose; available through Wikisource and useful for satirical speech registers.
+- **1928/1929** — *Золоті лисенята*, novel under the pen name Юліан Шпол; his best-known literary work. [T1: ЕУ]
+- **1930s** — critical and memoir fragments around the ВАПЛІТЕ milieu; some titles require further bibliographic verification before curriculum use.
+- **Posthumous recovery** — later memorial and anthology references restored his place in the Sandarmokh cohort, but not yet enough for broad classroom familiarity.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — *Катіна любов*, 1928:**
+
+> **У нас тоді мода була на свободну любов із студентами.**
+
+The line is valuable because the irony is social, not only political. It shows Yalovyi's ear for fashion, speech, and NEP-era self-performance.
+
+**Quote 2 — *Катіна любов*, 1928:**
+
+> **Рідну матір — і ту, можна сказать, кругом пальця обвела.**
+
+This colloquial sentence gives L2 learners a register problem: it is not textbook Ukrainian, but character speech. It should be taught as stylized prose voice rather than normalized learner output.
+
+## 5. Language register
+
+- **Register:** revolutionary-publicistic early register; later satirical modernist prose with colloquial speech and ironic social observation.
+- **CEFR readiness for full reading:** C1 for *Золоті лисенята* and *Катіна любов*; selected excerpts at B2/C1 with teacher notes on idiom and satire.
+- **Lexicon notes:** NEP-era social vocabulary, party terms, colloquial phraseology, and invented or stylized names. Learners need help distinguishing authorial irony from direct assertion.
+- **Stylistic features:** satire, dialogic speech, social comedy, polemical compression, and institutional language turned against itself.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** His literary value is often overshadowed by his institutional role in ВАПЛІТЕ and by Khvylovyi's suicide. A good dossier resists that flattening and includes his prose. [T1: IEU; T1: ЕУ]
+- **Case framing:** The "UVO" label and later espionage/terror labels are Soviet fabrications. They are important evidence of how the regime criminalized Ukrainian literary networks, not evidence of actual guilt.
+- **What gets simplified:** He becomes "the arrest that triggered Khvylovyi." That is historically important, but pedagogically insufficient.
+- **Russian/Soviet disinformation angle:** Soviet summaries can use "bourgeois nationalist" or "military organization" language without indicating fabrication. A decolonized account always labels the police vocabulary.
+- **Other-perspective considerations:** His revolutionary and communist affiliations should be stated honestly; they did not protect him from Soviet colonial terror.
+
+**Additional research cautions:** Yalovyi is easy to underwrite because his name appears most dramatically in connection with Khvylovyi's suicide. That connection is real and should remain in the dossier, but it cannot substitute for his own biography. In Phase 2, a writer should avoid a module arc where Yalovyi exists only to explain another man's death. His ВАПЛІТЕ presidency, prose under the name Юліан Шпол, and the recovery problem around *Золоті лисенята* all need their own space.
+
+**Source-handling note:** The "Ukrainian Military Organization" case is a known Soviet fabrication frame applied across Ukrainian cultural figures. Treat it as a case title, not as a real organization unless a higher-tier source explicitly distinguishes a historical group from the police invention. Similarly, do not repeat "plot against Postyshev" without attribution to a Soviet or later secondary claim. The dossier's safest procedural chain is: arrest in May 1933, 10-year sentence in September 1933, Solovki imprisonment, 9 October 1937 special-troika death decision, 3 November 1937 Sandarmokh execution.
+
+**Pedagogical bridge:** Yalovyi can anchor a lesson on "organization as risk." Many learners will understand censorship as banning a text; Yalovyi shows the state treating literary association itself as evidence. ВАПЛІТЕ was not only a style group but an institution of taste, publishing, debate, and professional solidarity. That is precisely why the regime attacked it. A future module can ask students to compare a literary manifesto, a meeting/network fact, and a police accusation, then identify where the Soviet file turns cultural work into criminal conspiracy.
+
+**Open verification items for Phase 2:** Before writing plan YAML, verify the best accessible edition of *Золоті лисенята* and whether *Мої зустрічі* should be excluded or marked as commentary rather than a standalone major work. The present dossier flags it as provisional rather than relying on it.
+
+**Assessment note:** Because Yalovyi's best-known work circulated under the pen name Юліан Шпол, bibliography and slug metadata should be tested for alias lookup. A future content writer searching only "Яловий" may miss relevant primary texts, while a search only for "Шпол" may miss repression records. The dossier should therefore seed both names in `aliases:` and in any wiki lead.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- `wiki/literature/works/rozstriliane-vidrodzennia-phenomenon.md` — names ВАПЛІТЕ with Михайло Яловий, Хвильовий, and Куліш.
+- `wiki/figures/mykola-khvylovyi.md` — contextual connection through ВАПЛІТЕ and the 1933 crisis.
+- Existing LIT/HIST modules on the literary discussion and terror should connect in Phase 2; no direct plan YAML for Yalovyi was found.
+- Potential future LIT addition: a module on *Золоті лисенята* or the ВАПЛІТЕ organizational crisis; do not add until Phase 2.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-yalovyi`
+- **EN canonical:** Mykhailo Yalovyi.
+- **UA canonical:** Михайло Омелянович Яловий.
+- **Aliases to track:** Юліан Шпол; Михайло Красний; Yulian Shpol; Mykhailo Yalovy.
+- **Forbidden Russian-imperial / Russified forms:** Mikhail Yalovy; Михаил Яловой; Russian-patronymic forms.
+
+## 9. Image candidates
+
+- Wikisource portrait file `Яловий Михайло Омелянович.jpg`; candidate only after file-page license review.
+- Wikimedia Commons reverse/portrait file from "Розстріляне відродження. Юліан Шпол"; useful if license is clear.
+- If no clean portrait license survives, use an era-appropriate ВАПЛІТЕ/Sandarmokh context image with documented rights.
+
+## 10. Sources used
+
+- **[T1]** "Yalovy, Mykhailo." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CY%5CA%5CYalovyMykhailo.htm
+- **[T1]** *Енциклопедія українознавства*, article context on Юліян Шпол / Михайло Яловий and *Золоті лисенята*, Litopys reprint.
+- **[T1/T2]** НБУВ memorial note on Яловий / Розстріляне Відродження. https://www.nbuv.gov.ua/node/4119
+- **[T5]** UINP Sandarmokh list of executed Ukrainians, used for the 3 November 1937 execution-list cross-check. https://uinp.gov.ua/pres-centr/novyny/sogodni-po-vsomu-sviti-chytayut-imena-zhertv-sandarmohu-spysok-rozstrilyanyh-ukrayinciv
+- **[T5]** Wikisource author/work pages for *Катіна любов*, used as primary text access and corroborated by Tier 1 biography.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.

--- a/docs/research/bio/mykola-voronyi.md
+++ b/docs/research/bio/mykola-voronyi.md
@@ -1,0 +1,123 @@
+# Микола Кіндратович Вороний — Research Dossier
+
+**Slug:** `mykola-voronyi`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Кіндратович Вороний. [T1: ЕСУ; T1: IEU; T1: UINP]
+- **Pseudonyms / aliases:** Арлекін; Віщий Олег; Homo; Sirius; Кіндратович; Микольчик; M. В.; Mykola Voronyi. Forbidden in body text except here: Nikolai Voronoi, Nikolay Vorony, Николай Вороной, "Russian symbolist" framing.
+- **Born:** 7 December 1871 | Ростов-на-Дону, then Russian Empire; family roots and literary work are Ukrainian. [T1: ЕСУ; T1: IEU]
+- **Died:** 7 June 1938 | Odesa, Ukrainian SSR | shot after a special troika death sentence dated 29 April 1938. [T1: ЕСУ; T1: UINP]
+- **Family / education key facts:** He studied in Kharkiv and Rostov real schools, was expelled and placed under police supervision for political activity, worked with Ukrainian theater circles, and became a key modernist poet, critic, and theater figure. His son Марко Вороний was also executed by the Soviet state. [T1: ЕСУ; T1: IEU]
+
+**Source disagreement note:** The stable modern chain is 1934 arrest/exile, later rearrest, 29 April 1938 special-troika sentence, and 7 June 1938 execution. The accusation wording varies: UINP records "compromising party and government measures," while popular summaries sometimes say "Polish spy." Use the accusation only as Soviet charge language, not as fact. [T1: ЕСУ; T1: UINP]
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, exile/prohibition from Kyiv, rearrest, special troika sentence, execution.
+- **When:** first arrest in 1934; exile to Voronezh for three years; later arrest in Hlyniane; death sentence 29 April 1938; execution 7 June 1938. [T1: ЕСУ; T1: UINP]
+- **By whom:** NKVD / UNKVD in Soviet Ukraine, with a special troika of the UNKVD in Odesa oblast issuing the death sentence. [T1: UINP]
+- **Document references:** special troika sentence of 29 April 1938; Soviet accusation wording summarized by UINP as "компрометація заходів партії та уряду." [T1: UINP]
+- **Mechanism specifics:** Voronyi's repression followed a familiar path for returned emigres and nationally visible writers: isolate, exile, then reprocess under Great Terror machinery. He had returned from emigration in 1926 and worked in Soviet Ukraine as a teacher and literary figure; this did not protect him. [T1: ЕСУ; T1: IEU]
+
+The case is especially important pedagogically because Voronyi had spent decades arguing that Ukrainian literature belonged to European modernity. The Soviet state did not merely punish a political activist; it destroyed a symbolic bridge between Ukrainian theater, symbolism, civic poetry, and European literary conversation. That is why the "aesthetic" label must not be used to depoliticize his fate. [T1: IEU]
+
+**What survived / what was destroyed:** His poetic and theater-critical works survived in print, but Soviet-era presentation distorted the biography and softened the execution record. His son Marko's later execution intensifies the family-level destruction: two generations of Ukrainian literary work were removed through related Stalinist mechanisms.
+
+## 3. Major works
+
+- **1899** — *Євшан-зілля*, poem; historical-memory text often taught as a return-to-native-memory allegory.
+- **1901/1902** — manifesto-like call for a modern Ukrainian almanac, important for the literary debate with Ivan Franko. [T1: IEU]
+- **1911** — *Ліричні поезії*, collection; symbolist and musical lyric.
+- **1912** — "Блакитна Панна", poem; canonical Ukrainian symbolist text.
+- **1913** — *В сяйві мрій*, collection; mature prewar lyric voice.
+- **1913** — *Театр і драма*, theater-critical work.
+- **1920** — *Поезії*, collection.
+- **1921** — *За Україну!*, Warsaw collection; civic-patriotic writing after the Ukrainian Revolution.
+- **1923** — *Пензлем і пером*, essays/criticism.
+- **1924** — *Драматична примадонна*, theater history/criticism around Maria Zankovetska.
+- **Later editions** — selected poetry and children-facing anthologies; useful but must be checked for Soviet cuts.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — *Євшан-зілля*, 1899:**
+
+> **В давніх літописах наших єсть одно оповідання.**
+
+This line anchors his historical-memory poetics. It is accessible at B2 with scaffolding because the syntax is clear, while the cultural concept of євшан-зілля opens the deeper C1 discussion of memory and return.
+
+**Quote 2 — *Блакитна Панна*, 1912:**
+
+> **Їй виспівує: "Осанна!"**
+
+This short excerpt gives a clear sound-and-color entry into symbolist exaltation. It also helps learners hear how religious and aesthetic vocabulary can be repurposed in modern lyric without becoming church prose.
+
+## 5. Language register
+
+- **Register:** symbolist / early modernist lyric, theater-critical prose, and later civic-patriotic diction.
+- **CEFR readiness for full reading:** B2 for selected poems like *Євшан-зілля*; C1 for full symbolist lyric and polemical literary history.
+- **Lexicon notes:** Elevated vocabulary, musical sound patterning, cultural-historical allusions, and occasional archaisms. Learners need guidance for mythic and biblical resonances.
+- **Stylistic features:** sonority, synesthetic color, apostrophe, allegorical historical memory, and theater-informed dramatic address. He is a strong bridge between late nineteenth-century civic literature and early twentieth-century modernism.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** The central interpretive debate is whether to present Voronyi primarily as symbolist aesthete, civic poet, or theater man. The answer should be cumulative: his importance lies in the combination. [T1: ЕСУ; T1: IEU]
+- **Charge wording:** Sources differ on the precise Soviet accusation. The dossier keeps the stable procedural facts and refuses to turn accusation wording into a factual claim.
+- **What gets simplified:** School memory often reduces him to *Євшан-зілля* or *Блакитна Панна*. That hides his role as a modernizing editor, polemicist, and theater historian.
+- **Russian/Soviet disinformation angle:** Russian-imperial framing can overemphasize birthplace or Russian-language institutional geography. Use Ukrainian literary affiliation, language, theater work, and repression context as the organizing frame.
+- **Other-perspective considerations:** His Warsaw and Lviv years, and friendships with Polish writers, should be treated as European network history, not as evidence against Ukrainian belonging.
+
+**Additional research cautions:** Voronyi needs especially careful handling because he crosses several curricular categories. If a future module introduces him only through *Євшан-зілля*, students will see civic allegory but not the symbolist argument. If it introduces him only through *Блакитна Панна*, they will see aesthetic modernism but may miss the UNR-era political biography and the later execution. If it introduces him only as a repressed writer, the pre-1934 literary debate disappears. A good sequence can put three short artifacts together: the call for modern European forms, a symbolist lyric, and the repression chronology. That prevents the false choice between "art for art's sake" and national responsibility.
+
+**Source-handling note:** The 1938 accusation wording should not be summarized casually. Soviet police language was intentionally elastic; "compromising party measures," "Polish spy," and "counter-revolutionary" labels may appear in different retellings. For the dossier and later YAML, the stable facts are the 1934 exile, the 29 April 1938 special-troika decision, and the 7 June 1938 execution in Odesa. The charge label belongs in quotation marks or an explicit "Soviet accusation" clause. Do not build a lesson question that asks whether the accusation was "true"; the proper question is how a modernist Ukrainian writer became legible to the NKVD as a disposable enemy.
+
+**Pedagogical bridge:** Voronyi is useful for showing that Ukrainian modernism was not an import from Russian culture. His actual orientation was European and theater-centered, and his debate with Franko happened inside Ukrainian literary modernization. That framing helps learners avoid the common imperial shortcut "modernism came from Petersburg/Moscow." It also prepares them to read Semenko and the neoclassicists as competing Ukrainian answers to the same modernization pressure.
+
+## 7. Cross-track links
+
+`rg` checks found direct LIT coverage:
+
+- `curriculum/l2-uk-en/plans/lit/voronyi-symbolism.yaml` — direct module on the birth of Ukrainian symbolism.
+- `curriculum/l2-uk-en/plans/lit/voronyi-poetry.yaml` — direct poetry module.
+- `wiki/literature/works/voronyi-symbolism.md` and `wiki/literature/works/voronyi-poetry.md` — existing compiled wiki context.
+- Related contexts: `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`; HIST terror modules `mekhanizm-teroru` and `syntez-trahedii`.
+- Existing bios that connect: future `marko-voronyi` dossier in this same Block A set; `mykhailo-kotsiubynsky.yaml` already references the modernist debate around Voronyi. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-voronyi`
+- **EN canonical:** Mykola Voronyi.
+- **UA canonical:** Микола Кіндратович Вороний.
+- **Aliases to track:** Арлекін; Віщий Олег; Homo; Sirius; Кіндратович; Микольчик; М. В.; Mykola Voronyi.
+- **Forbidden Russian-imperial / Russified forms:** Nikolai Voronoi; Nikolay Vorony; Николай Вороной; any "Russian symbolist" label that erases Ukrainian literary work.
+
+## 9. Image candidates
+
+- IEU portrait `Vorony Mykola.jpg`, useful as first candidate after final rights review.
+- IEU group photo with Voronyi, if the module needs a network image rather than a single portrait.
+- Wikimedia/Wikisource author pages provide additional leads, but final Phase 4 should use a file page with clear license proof.
+
+## 10. Sources used
+
+- **[T1]** "Вороний Микола Кіндратович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-29783
+- **[T1]** "Vorony, Mykola." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CO%5CVoronyMykola.htm
+- **[T1]** Український інститут національної пам'яті. "Народився Микола Вороний." https://www.uinp.gov.ua/istorychnyy-kalendar/gruden/6/narodyvsya-mykola-voronyy
+- **[T5]** Wikisource pages for *Євшан-зілля* and *Блакитна Панна*, used for primary text access and corroborated by Tier 1 biography.
+- **[T3]** Ukrainian Wikipedia extract for navigation only; no core claim rests on it.

--- a/docs/research/bio/myroslav-irchan.md
+++ b/docs/research/bio/myroslav-irchan.md
@@ -1,0 +1,130 @@
+# Мирослав Ірчан — Research Dossier
+
+**Slug:** `myroslav-irchan`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Мирослав Ірчан, pen name of Андрій Дмитрович Баб'юк. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Андрій Баб'юк; Абба; Б'юк; І. Мірко; Юрко Ропша; Myroslav Irchan. Forbidden in body text except here: Miroslav Irchan as Russianized spelling; Андрей Бабюк; Soviet "progressive writer" framing that omits execution.
+- **Born:** 14 July 1897 | П'ядики, Коломийський повіт, Galicia; now Івано-Франківська область, Україна. Some older summaries misprint 1896. [T1: ЕСУ; T1: IEU]
+- **Died:** 3 November 1937 | Sandarmokh near Medvezhyegorsk, Karelia, USSR | shot after NKVD special-troika decision. [T1: ЕСУ; T1: IEU; T2: NBUV]
+- **Family / education key facts:** He graduated from a Lviv teachers' seminary, served in wartime formations, lived and worked in Prague and Canada, edited Ukrainian left/progressive periodicals abroad, then returned to Soviet Ukraine and led the literary organization "Західна Україна." [T1: ЕСУ; T1: IEU]
+
+**Source disagreement note:** Some older or diaspora shorthand says he died "on Solovki" because he was imprisoned in the Solovki system before the execution transfer. Modern Ukrainian memory sources identify Sandarmokh and 3 November 1937 as the execution place/date. Use that two-step chain. [T1: ЕСУ; T2: NBUV]
+
+## 2. Oppression mechanism
+
+- **What happened:** arrest by Soviet security police, fabricated nationalist/counter-revolutionary accusation, 10-year camp sentence, Solovki imprisonment, 1937 special-troika death sentence, execution at Sandarmokh.
+- **When:** arrested 28 December 1933 after a briefing at the CC of the CP(b)U; sentenced to 10 years; special-troika review in 1937; executed 3 November 1937. [T1: ЕСУ; T1: IEU; T2: NBUV]
+- **By whom:** GPU/NKVD security organs; special troika of the UNKVD in Leningrad oblast for the final death sentence.
+- **Document references:** Solovki/Sandarmokh execution-list context; NBUV Розстріляне Відродження exhibit and IEU/ESU biographical entries. [T1: ЕСУ; T2: NBUV]
+- **Mechanism specifics:** Irchan's case targeted a Western Ukrainian writer who had returned from a transnational Ukrainian left milieu. His Canadian, Galician, Prague, and Kharkiv connections made him visible as an organizer of "Західна Україна," which the Soviet state could reframe as suspect nationalist networking. [T1: IEU]
+
+This is not a simple story of an anti-Soviet outsider. Irchan had worked in explicitly left/progressive circles and returned to Soviet Ukraine voluntarily. The terror mechanism recoded that biography into counter-revolutionary danger once the regime turned against independent Ukrainian cultural organization and west-Ukrainian political emigres. [T1: ЕСУ; T1: IEU]
+
+**What survived / what was destroyed:** His plays and prose survived in editions and scans, and his Canadian Ukrainian work leaves a diaspora trail. Soviet editions often preserved him as a "progressive" writer while softening the state murder. The dossier must restore the full arrest-Solovki-Sandarmokh chain. [T1: IEU; T2: NBUV]
+
+## 3. Major works
+
+- **1918** — *Сміх Нірвани*, early prose/collection; early Galician-modernist and wartime register.
+- **1922** — *Бунтар*, drama/prose; revolutionary conflict.
+- **1923** — *Дванайцять / Дванадцять*, work with variant spelling in sources.
+- **1923/1928** — *Трагедія Першого травня*, drama; publication/edition history needs exact edition citation.
+- **1924** — *Карпатська ніч*, prose; western-Ukrainian and emigration themes.
+- **1925** — *Родина щіткарів*, drama; important for workers' theater and staging notes.
+- **1925** — *В бур'янах*, prose.
+- **1926** — *Лі-Юнк-Шан*, drama/prose with international revolutionary setting.
+- **1929** — *Радій*, play; modern technology and social conflict.
+- **1933** — *Плацдарм*, play staged in the Kharkiv/Kurbas orbit. [wiki/literature/works/kurbas-legacy.md context]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — *Родина щіткарів*, 1925, preface/staging note:**
+
+> **Завданням робітничих Драмгуртків не тільки грати на сцені**
+
+This excerpt shows theater as pedagogy and collective formation. It is useful because the prose voice names audience education as part of the dramatic project.
+
+**Quote 2 — *Родина щіткарів*, 1925, staging note:**
+
+> **поведінка їх цілком инша, як видючих людей.**
+
+The quotation preserves interwar orthography and practical stage instruction. It can teach learners why historical spelling and stage directions require contextual reading rather than automatic modernization.
+
+## 5. Language register
+
+- **Register:** Galician/interwar Ukrainian, proletarian theater prose, reportage, diaspora-publicistic voice, and stage-direction pragmatics.
+- **CEFR readiness for full reading:** C1 for plays because of historical orthography and politics; B2/C1 for short stage-direction excerpts.
+- **Lexicon notes:** Theater vocabulary, workers' organization terms, Galician forms, Canadian diaspora references, and older spellings such as "инший."
+- **Stylistic features:** didactic theater framing, social conflict, documentary impulse, and a strong practical sense of performance conditions.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Irchan can be read as west-Ukrainian proletarian writer, Canadian Ukrainian organizer, Soviet Ukrainian dramatist, or victim of Stalinism. The dossier should preserve all layers rather than choose one. [T1: IEU]
+- **Solovki vs Sandarmokh:** "Solovki" is accurate for imprisonment but incomplete for death. Use Sandarmokh for execution.
+- **Birth year:** 1897 is canonical in ESU/IEU; note 1896 only as a secondary misprint if encountered.
+- **What gets simplified:** Soviet-friendly memory kept the "progressive writer" and downplayed the NKVD killing. Diaspora memory can emphasize the betrayal after return. Both need evidence-based synthesis.
+- **Other-perspective considerations:** His Canadian Ukrainian work should not be treated as peripheral; it is key to his transnational Ukrainian biography.
+
+**Additional research cautions:** Irchan is one of the best figures in this set for teaching transnational Ukrainian modernity. A future dossier-to-module pipeline should not present "Canada" as a colorful aside. The Canadian period shaped his publishing, worker-theater, and diaspora-organizing vocabulary; the later Kharkiv return then becomes a political and cultural choice with consequences. That arc is richer than a simple "writer returned and was killed" summary.
+
+**Source-handling note:** The birth-year and death-place issues are manageable but must be kept clean. Use 1897 unless a higher-tier source gives a reason to prefer 1896. Use Sandarmokh for execution, while saying he had been held in the Solovki system. Older "died at Solovki" wording should be corrected rather than repeated. If a source calls him only a "Soviet writer," add the west-Ukrainian, Prague, and Canadian phases so the descriptor does not erase the biography.
+
+**Pedagogical bridge:** Irchan can connect BIO, LIT, and HIST through theater. His *Родина щіткарів* staging notes are unusually teachable because they speak directly about how amateur worker drama should educate audiences. That gives L2 students a practical prose register: instructions, performance, audience, taste, and social mission. It also connects to Kurbas/Berezil modules without making Irchan merely a footnote to Kurbas.
+
+**Decolonization caution:** Do not let Soviet "progressive" vocabulary become the teacher's vocabulary. It may be historically relevant that he worked in left/progressive circles, but the narrative should name Ukrainian agency and Soviet repression plainly.
+
+**Assessment note:** Irchan is also a useful check on the curriculum's geography. His life moves through Galicia, Prague, Canada, Kharkiv, Solovki, and Sandarmokh. A map-based activity would show that Ukrainian literary history is not confined to Kyiv/Kharkiv and not reducible to the borders of the Ukrainian SSR. That is a decolonizing point as much as a biographical point.
+
+**Source expansion note:** Before Phase 2, verify whether the NBUV exhibit or a dedicated Irchan edition gives a case-file citation for the 28 December 1933 arrest. If not, retain the institutional-source wording and avoid inventing a case number. The dossier currently uses the strongest accessible institutional chain without pretending to have the underlying file.
+
+For lesson design, include at least one Canadian or Prague reference before the Kharkiv return, otherwise the biography loses its transnational organizing logic.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- `wiki/historiography/teatr-kurbasa.md` and `wiki/literature/works/kurbas-legacy.md` mention *Плацдарм* staged in 1932 with Kurbas/Berezil context.
+- `wiki/literature/works/rozstriliane-vidrodzennia-phenomenon.md` provides broader cohort context.
+- Future LIT addition: a module on *Родина щіткарів* or *Плацдарм* for theater and west-Ukrainian Soviet returnees.
+- HIST context: Solovki/Sandarmokh, Western Ukrainian political emigration, and Stalinist terror mechanisms. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `myroslav-irchan`
+- **EN canonical:** Myroslav Irchan.
+- **UA canonical:** Мирослав Ірчан.
+- **Aliases to track:** Андрій Дмитрович Баб'юк; Абба; Б'юк; І. Мірко; Юрко Ропша.
+- **Forbidden Russian-imperial / Russified forms:** Miroslav Irchan as default; Андрей Бабюк; any death wording that stops at "Solovki" without Sandarmokh execution.
+
+## 9. Image candidates
+
+- Wikimedia Commons `File:Myroslav_Irchan.jpg`, verify license before final use.
+- Wikimedia Commons `File:Myroslav Irchan, Winnipeg.jpg`, useful for Canadian/diaspora context if license passes.
+- Wikimedia Commons category `Works by Myroslav Irchan` contains scans of *Родина щіткарів*, *Сміх Нірвани*, and other works.
+
+## 10. Sources used
+
+- **[T1]** "Ірчан Мирослав." *Енциклопедія Сучасної України*. https://esu.com.ua/article-12635
+- **[T1]** "Irchan, Myroslav." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CI%5CR%5CIrchanMyroslav.htm
+- **[T1/T2]** NBUV exhibit PDF, *Розстріляне відродження*. https://www.nbuv.gov.ua/sites/default/files/ex/ex_files/2021-06_field_ex_files/rozstrilyane_vidrodzhennya.pdf
+- **[T2]** NBUV event page on Розстріляне Відродження. https://www.nbuv.gov.ua/node/4199
+- **[T5]** Wikimedia Commons scans of *Родина щіткарів* and other Irchan works, used for primary text access.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.

--- a/docs/research/bio/oleksa-vlyzko.md
+++ b/docs/research/bio/oleksa-vlyzko.md
@@ -1,0 +1,128 @@
+# Олекса Федорович Влизько — Research Dossier
+
+**Slug:** `oleksa-vlyzko`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олекса Федорович Влизько. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Oleksa Vlyzko; Олекса В.; sometimes Олексій in noncanonical summaries. Forbidden in body text except here: Aleksei Vlizko, Алексей Влизько, Russianized forms.
+- **Born:** 17 February 1908 | station settlement Боровйонка, Новгородська губернія, Russian Empire; sources sometimes simplify or relocate childhood references. [T1: ЕСУ; T1: IEU]
+- **Died:** archival/IEU line: 14 December 1934, Kyiv; ЕСУ header gives 16 December 1934. Cause: shot after a Military Collegium sentence in the Kirov-assassination terror wave. [T1: IEU; T2: ЦДАМЛМ; T1: ЕСУ]
+- **Family / education key facts:** He became deaf after illness in childhood, entered Ukrainian literary life very young, and published a large body of lyric, ballad, travel, and maritime poetry before age twenty-seven. [T1: IEU; T1: ЕСУ]
+
+**Source disagreement note:** The biggest conflicts are arrest/death chronology. ESU gives a February 1934 arrest and 16 December death; IEU and archival-museum materials point to the December 1934 Kirov-context arrests and 14 December execution. This dossier uses 14 December 1934 with the conflict flagged. [T1: IEU; T2: ЦДАМЛМ; T1: ЕСУ]
+
+## 2. Oppression mechanism
+
+- **What happened:** arrest during the post-Kirov purge wave, fabricated OUN/terror accusation, Military Collegium death sentence, execution in Kyiv.
+- **When:** December 1934 arrest wave; sentence and execution recorded by archival-museum source as 14 December 1934; ESU gives 16 December 1934 for death. [T2: ЦДАМЛМ; T1: ЕСУ]
+- **By whom:** NKVD / Soviet security organs; Military Collegium of the Supreme Court of the USSR in Kyiv.
+- **Document references:** archival-museum summary says the documents accused him of OUN membership and of being an emissary of Yevhen Konovalets sent to organize local OUN cells. Treat that as fabricated Soviet accusation language. [T2: ЦДАМЛМ]
+- **Mechanism specifics:** Vlyzko was one of the young writers caught in the first major literary execution wave after the Kirov assassination. The regime used the assassination as pretext for fast-track repression. His youth matters: he was not a long-standing political organizer but a highly visible young poet whose literary network could be recoded as terrorist affiliation. [T1: IEU; T2: ЦДАМЛМ]
+
+The case predates the mass Sandarmokh operation and shows an earlier pattern: quick arrest, compressed accusation, and same-day execution after a high-level military court sentence. The OUN-emissary charge belongs to the Soviet police file, not to neutral biography.
+
+**What survived / what was destroyed:** His books survived in scans and reprints, but the trajectory was cut off before maturity. Because he was young and stylistically fluid, later memory often treats him as promise rather than as an already substantial poet. The range of works from ballads to sea poems argues against that minimization. [T1: IEU]
+
+## 3. Major works
+
+- **1927** — *За всіх скажу*, early collection; announces the young poet's public confidence.
+- **1927** — *Поезії*, collection.
+- **1930** — *Живу, працюю*, collection; lyric and work-centered register.
+- **1930** — *Hoch, Deutschland*, travel/political cycle.
+- **1930** — *Книга балад*, ballad collection.
+- **1930** — *Поїзди ідуть на Берлін*, travel/modernity volume.
+- **1930** — *Рейс*, maritime poems; important for sea and machinery imagery.
+- **1931** — *Моє ударне*, Soviet-era title but not reducible to formula.
+- **1933** — *П'яний корабель: Морські вірші*, maritime collection with Rimbaud echo in title.
+- **1934** — *Мій друг Дон-Жуан*, late collection before execution.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — *Рейс*, 1930:**
+
+> **В напрузі плеч і рук хриплять іржою доки**
+
+The line gives a strong entry into industrial-maritime embodiment: bodies, docks, and rust share the same strain. It is a useful B2/C1 image-analysis quote.
+
+**Quote 2 — "Одлетіла конвалійна Леда...", in *Живу, працюю*, 1930:**
+
+> **Це початок кінця, о, кохана**
+
+This line shows the lyric-romantic register that coexists with his travel and industrial themes. It prevents a one-note reading of Vlyzko as only "young revolutionary poet."
+
+## 5. Language register
+
+- **Register:** neoromantic, adventurous, maritime, ballad-like, with futurist-adjacent speed and travel imagery.
+- **CEFR readiness for full reading:** B2/C1 for selected poems; C1 for full collections because of rapid imagery and historical allusions.
+- **Lexicon notes:** Sea and ship vocabulary, travel names, industrial nouns, romantic address, and occasional Soviet-era work vocabulary.
+- **Stylistic features:** quick cinematic movement, ballad compression, maritime metaphor, strong first-person confidence, and lyrical reversals.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Vlyzko's early death leaves open the question of where his poetics would have gone: deeper neoromanticism, futurist experiment, or official Soviet utility. Teach the plurality, not a single teleology.
+- **Chronology disagreement:** Arrest/death dates differ across ESU, IEU, and archival-museum summaries. The dossier must retain the conflict rather than silently choosing one.
+- **What gets simplified:** He is often treated as "young victim" only. The bibliography shows ten major titles before execution, so the curriculum should teach output, not only promise.
+- **Russian/Soviet disinformation angle:** The OUN-emissary charge is a police accusation generated during terror conditions. Do not paraphrase it as real organizational role.
+- **Other-perspective considerations:** Russian birthplace geography should not be used to detach him from Ukrainian literary life; his career and language are Ukrainian.
+
+**Additional research cautions:** Vlyzko is a high-risk figure for "promising youth" flattening. He was young, but the number of published books means he was not merely potential. A future lesson should name the titles and show at least one sea/travel excerpt before turning to the execution. Otherwise students learn a martyr label but not the literary voice the state destroyed. The best frame is "accelerated career cut off by accelerated terror."
+
+**Source-handling note:** Keep the date conflict visible. If a plan writer needs a single death date, use 14 December 1934 with a note that ESU gives 16 December. If the final module uses a timeline, include "December 1934 post-Kirov purge wave" as the context rather than pretending the archival record is perfectly uniform. Do not use the ESU February arrest date without further verification, because it clashes with the stronger Kirov-wave narrative from IEU/archive-museum material.
+
+**Pedagogical bridge:** Vlyzko can connect Розстріляне Відродження to maritime and travel modernism. The sea poems offer a route into global imagination that is less familiar than Kyiv/Kharkiv literary groups. They also counter the stereotype that Ukrainian modernism was only village, revolution, or manifesto. His work can be paired with Semenko for speed and modernity, but Vlyzko's emotional center is more romantic and adventurous.
+
+**Accessibility note:** Because Vlyzko was deaf after childhood illness, a future biography lesson should mention disability without reducing the poet to it. The useful pedagogical question is how a writer with altered hearing produced such rhythmically and visually energetic verse, not a sentimental story of "overcoming."
+
+**Assessment note:** Vlyzko's corpus can also serve pronunciation and listening lessons indirectly: students can observe that poetic rhythm is not reducible to biographical hearing ability. That point should be handled carefully and never as inspiration rhetoric. The curriculum value is literary: visual pacing, line breaks, ship and dock vocabulary, and the emotional speed of a poet writing under compressed historical time.
+
+For reviewer use, require at least one excerpt that is not about execution, so the module preserves literary agency before biography turns to terror.
+
+## 7. Cross-track links
+
+`rg` found no direct existing LIT/HIST plan hit for Vlyzko. Potential Phase 2 links:
+
+- LIT: maritime modernism / *Рейс* or *П'яний корабель* excerpts.
+- LIT: young executed poets of the early terror wave alongside Marko Voronyi and others.
+- HIST: post-Kirov repression and fast-track Military Collegium executions; connect to `mekhanizm-teroru` and `syntez-trahedii`.
+- Existing bio network: Semenko and other avant-garde figures in this Block A dossier set. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `oleksa-vlyzko`
+- **EN canonical:** Oleksa Vlyzko.
+- **UA canonical:** Олекса Федорович Влизько.
+- **Aliases to track:** Олекса В.; Oleksa Vlyzko; Олексій Влизько as noncanonical variant if encountered.
+- **Forbidden Russian-imperial / Russified forms:** Aleksei Vlizko; Алексей Влизько; Russianized patronymic forms.
+
+## 9. Image candidates
+
+- ЕСУ image `https://esu.com.ua/article-35164`, first candidate after final reuse check.
+- Wikimedia Commons `File:Oleksa_Vlyzko.jpg`, verify PD status.
+- Commons scan/frontispiece of *Рейс* (1930) may be useful as context image if portrait rights are uncertain.
+
+## 10. Sources used
+
+- **[T1]** "Влизько Олекса Федорович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-35164
+- **[T1]** "Vlyzko, Oleksa." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CL%5CVlyzkoOleksa.htm
+- **[T2]** ЦДАМЛМ України archival-museum page on the Kirov-context repression wave and Vlyzko. https://old-csam.archives.gov.ua/ukr/holovna/
+- **[T5]** Wikisource page for *Рейс*, used for primary text access and corroborated by Tier 1 biography.
+- **[T5]** UkrLib / primary-text access for *Живу, працюю* excerpt, used only for quotation access.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.

--- a/docs/research/bio/sofiia-nalepynska-boichuk.md
+++ b/docs/research/bio/sofiia-nalepynska-boichuk.md
@@ -1,0 +1,133 @@
+# Софія Олександрівна Налепинська-Бойчук — Research Dossier
+
+**Slug:** `sofiia-nalepynska-boichuk`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes / recorded direct statements
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Софія Олександрівна Налепинська-Бойчук. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Софія Налепинська; Zofia Nalepińska; Софія Бойчук; Sofiia Nalepynska-Boichuk. Forbidden in body text except here: Sofya Nalepinskaya, Софья Налепинская, Russianized `Boichuk` via Russian identity framing.
+- **Born:** 30 July 1884 | Łódź, then Russian Empire; now Poland. [T1: ЕСУ; T1: IEU]
+- **Died:** sentenced 6 December 1937, executed 11 December 1937 | Kyiv, Ukrainian SSR | shot by NKVD in the Boychukist repression case. [T1: ЕСУ; T2: Local History]
+- **Family / education key facts:** Polish-born artist who studied in European art centers, married Михайло Бойчук, became a major Ukrainian graphic artist and professor associated with the Boychukist school. In interrogation she identified herself as Ukrainian while naming Polish parents. [T1: IEU; T2: Local History]
+
+**Source disagreement note:** The main distortion is identity, not basic dates. Some summaries flatten her into a Polish artist because of birth/family origin; modern Ukrainian art-historical framing treats her as Polish-born and Ukrainian by artistic affiliation and recorded self-identification. Keep both facts visible. [T1: ЕСУ; T2: Local History]
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest in the Boychukist case, fabricated nationalist/terror and foreign-intelligence accusation, death sentence, execution in Kyiv.
+- **When:** arrested 12 June 1937; sentenced to death 6 December 1937; executed 11 December 1937. [T1: ЕСУ; T2: Local History]
+- **By whom:** NKVD organs in Soviet Ukraine; Soviet judicial/security apparatus handling the Boychukist case.
+- **Document references:** interrogation record includes the direct identity statement "Українка, батьки — поляки"; accusation framed participation in an anti-Soviet nationalist terrorist organization and foreign-intelligence cooperation. [T2: Local History]
+- **Mechanism specifics:** The case targeted the Boychukist school as an alleged nationalist formation. Nалепинська-Бойчук's art and teaching were read through the police fantasy of conspiracy: a collective visual language, European training, and Ukrainian monumental ambitions became grounds for terror. [T1: ЕСУ; T1: IEU]
+
+Her execution belongs with the murders of Mykhailo Boichuk, Ivan Padalka, Vasyl Sedliar, and the wider destruction of the Boychukist circle. The mechanism was cultural liquidation: not just removing artists, but making a style and school seem politically criminal. [T1: IEU; curriculum plan `mykhailo-boichuk.yaml`]
+
+**What survived / what was destroyed:** Graphic works survived in museum collections, but many monumental Boychukist works were physically destroyed, painted over, or lost. Her letters and interrogation fragments preserve direct voice; the art itself preserves an even stronger visual voice through woodcuts and social-documentary themes. [T2: Local History; T2: Lviv National Art Gallery]
+
+## 3. Major works
+
+- **1910s** — letters to Mykhailo Boichuk; direct evidence of multilingual and artistic formation.
+- **1920s** — *В. Еллан-Блакитний*, graphic portrait / woodcut tradition. [T1: ЕСУ]
+- **1920s** — *Фабзаєць*, graphic work linked to worker/student themes.
+- **1920s** — *Мені тринадцятий минало...*, Shevchenko-themed graphic work.
+- **1920s** — *Молотьба*, social-labor graphic composition.
+- **1920s** — *На вакаціях*, graphic work.
+- **1920s** — *Студентка*, graphic work.
+- **1920s** — *Дівчата з книжкою*, education/reading theme.
+- **1920s** — *Мелашка*, portrait/character work.
+- **1930s** — *Перед наступом білих*, political-historical graphic composition.
+- **1930s** — *Голодні діти*, social-documentary work.
+- **1930s** — *Пацифікація Західної України*, anti-repression / western-Ukrainian theme.
+- **1930s** — *Робітфаківки*, worker-faculty women, education and social transformation.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — letter to Mykhailo Boichuk, 1910s, quoted in modern art-historical article:**
+
+> **Може волієш, щобим по французьки писала?**
+
+This line matters because it shows her multilingual reality and self-conscious movement into Ukrainian artistic life. It should be used with explanation, not as a language-error joke.
+
+**Quote 2 — interrogation protocol, 1937:**
+
+> **Українка, батьки — поляки.**
+
+This direct recorded statement is the key identity quote. It is a police-document context, but it counters later simplifications that make birth origin override self-identification and artistic belonging.
+
+## 5. Language register
+
+- **Register:** private multilingual letter register; police-protocol direct statement; visual art register is disciplined modernist / Boychukist, monumental, graphic, and social-documentary.
+- **CEFR readiness for full reading:** B2/C1 for letter snippets; C1 for art-historical prose around Boychukism.
+- **Lexicon notes:** Art vocabulary (дереворит, штрихарство, графіка, монументалізм), identity terms, and multilingual interference in private writing.
+- **Stylistic features:** compressed line, strong contour, social types, education/labor themes, and the Boychukist synthesis of Byzantine, folk, and modern monumental principles.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** The key debate is identity and school affiliation: Polish-born European-trained artist, Ukrainian by self-identification and by Boychukist work. Avoid both erasure of Polish origin and erasure of Ukrainian belonging. [T1: IEU; T2: Local History]
+- **Execution sequence:** Sources may say "shot in Kyiv" or give sentence/execution dates separately. Use the two-step sequence: 6 December sentence, 11 December execution.
+- **What gets simplified:** She is often reduced to "Boichuk's wife." The dossier must foreground her own graphic work, teaching, and direct statements.
+- **Russian/Soviet disinformation angle:** The police framing of "nationalist terrorist organization" and foreign intelligence is not reliable biography. It is the mechanism of criminalizing a Ukrainian art school.
+- **Polish / other-perspective considerations:** Polish birth and family are part of the biography. They should be taught as a cross-cultural formation, not as a reason to remove her from Ukrainian art history.
+
+**Additional research cautions:** Налепинська-Бойчук requires a different kind of dossier discipline because the "major works" are visual rather than literary. Future module writers should not apologize for that or force her into a writer template. The primary evidence can include letters, interrogation statements, object records, exhibition descriptions, and reproductions of woodcuts. The pedagogical center is visual language: line, labor, women students, hunger, and monumental simplification. That still fits the bio track because the figure's life and oppression are the curriculum object.
+
+**Source-handling note:** Identity wording must be exact. "Polish-born Ukrainian artist" is defensible; "Polish artist" alone is incomplete; "Ukrainian by birth" is false. Her recorded statement "Українка, батьки — поляки" is useful because it lets the dossier avoid both nationalist overcorrection and external erasure. If a later source uses Russianized `Софья Налепинская`, keep it only in aliases/forbidden forms or in a note about source language.
+
+**Pedagogical bridge:** This dossier should connect to Mykhailo Boichuk but not disappear behind him. A strong activity can compare one Boichuk school principle with one Nalepynska-Boichuk woodcut and ask what the individual artist contributes inside a collective style. That frame respects the communal nature of Boychukism while preserving her authorship.
+
+**Oppression-context caution:** The execution date sequence matters. The 6 December 1937 sentence and 11 December execution should remain separate because the compressed interval shows the speed of the killing process after months of arrest and interrogation.
+
+**Assessment note:** Because she is an artist, not a prose writer, review criteria should accept museum object records as primary curriculum anchors. The equivalent of a literary close reading is a guided visual reading: line, composition, subject, medium, date, collection, and political context. Future reviewers should not penalize the dossier for fewer literary titles if the art-object evidence is specific and sourced.
+
+At least one future activity should ask learners to describe a work visually before reading the arrest chronology.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml` names Софія Налепинська-Бойчук among Boychukist students/circle members.
+- `wiki/figures/mykhailo-boichuk.md` gives the school context and should cross-link in Phase 4.
+- Future BIO/LIT/ART-style additions should pair her with Ivan Padalka and Vasyl Sedliar, as the gap audit notes the replacement of Тимко Бойчук with stronger repression-linked Boychukists.
+- HIST context: Stalinist destruction of Ukrainian art schools, Kyiv NKVD executions, and the Great Terror. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `sofiia-nalepynska-boichuk`
+- **EN canonical:** Sofiia Nalepynska-Boichuk.
+- **UA canonical:** Софія Олександрівна Налепинська-Бойчук.
+- **Aliases to track:** Софія Налепинська; Zofia Nalepińska; Софія Бойчук; Sofiia Nalepynska.
+- **Forbidden Russian-imperial / Russified forms:** Sofya Nalepinskaya; Софья Налепинская; any phrasing that treats "Polish-born" as "not Ukrainian" against her recorded self-identification.
+
+## 9. Image candidates
+
+- Wikimedia Commons `File:Nalepinska-Girl.jpg`, verify license and work status.
+- Wikimedia Commons `File:Nalepinska-Hunger.jpg`, useful for social-documentary theme if rights pass.
+- Lviv National Art Gallery object pages: *Гітаристка* and *Подруги*, strong institutional image candidates; final use depends on museum rights.
+- Era-appropriate context image: Boychukist school works or NKVD case context only if rights and sensitivity are handled.
+
+## 10. Sources used
+
+- **[T1]** "Налепинська-Бойчук Софія." *Енциклопедія Сучасної України*. https://esu.com.ua/article-70885
+- **[T1]** "Nalepinska, Sofiia." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CN%5CA%5CNalepinskaSofiia.htm
+- **[T2]** *Локальна історія*. "Традиції нашого штрихарства: дереворити Софії Налепинської-Бойчук." https://localhistory.org.ua/rubrics/painting/traditsiyi-nashogo-shtrikharstva-derevoriti-sofiyi-nalepinskoyi-boichuk/
+- **[T2]** Львівська національна галерея мистецтв. Object page: *Гітаристка*. https://collection-lvivgallery.org.ua/uk/works/3778-hitarystka
+- **[T2]** Львівська національна галерея мистецтв. Object page: *Подруги*. https://collection-lvivgallery.org.ua/uk/works/3776-podruhy
+- **[T5]** Wikimedia Commons file pages for Nalepynska-Boichuk images, used only as image leads.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.

--- a/docs/research/bio/valerian-polishchuk.md
+++ b/docs/research/bio/valerian-polishchuk.md
@@ -1,0 +1,128 @@
+# Валер'ян Львович Поліщук — Research Dossier
+
+**Slug:** `valerian-polishchuk`
+**Block:** A (executed / killed in Soviet custody)
+**Tier:** 1a
+**Issue:** #2317 (R1a — Tier 1a research)
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-28
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific
+- [x] ≥2 primary-source quotes from his own work
+- [x] Cross-track links to LIT/HIST tracks checked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Валер'ян Львович Поліщук. Some older and diaspora materials use Валеріян; the project slug follows the audit appendix and current naming rule. [T1: ЕСУ; T1: IEU]
+- **Pseudonyms / aliases:** Валеріян Поліщук; Valeriian Polishchuk; Valerian Polishchuk; В. Поліщук. Forbidden in body text except here: Valerian Polishchuk if used as Russian-style simplification; Валерьян Полищук; Polishchuk as a Russian/Soviet writer.
+- **Born:** 1 October 1897 | село Більче, Дубенський повіт, Волинська губернія; now Рівненська область, Україна. [T1: ЕСУ; T1: IEU]
+- **Died:** 3 November 1937 | Sandarmokh, Karelia, USSR | shot after NKVD special-troika decision. [T1: ЕСУ; T1: IEU; T2: ЦДАМЛМ]
+- **Family / education key facts:** He studied in Катеринослав and Petrograd/Kamianets-Podilskyi contexts, participated in revolutionary-era journalism, and became a poet, prose writer, critic, editor, and organizer associated with авангард / конструктивізм and the group "Авангард." [T1: ЕСУ; T1: IEU]
+
+**Source disagreement note:** A false Soviet death certificate claimed he died on 17 March 1942 of peritonitis. Modern ESU/IEU and archival-museum sources give 3 November 1937, Sandarmokh. The dossier rejects the 1942 date except as evidence of Soviet concealment. [T2: ЦДАМЛМ; T1: ЕСУ]
+
+## 2. Oppression mechanism
+
+- **What happened:** search and arrest, fabricated counter-revolutionary accusation, closed court sentence, Solovki imprisonment, special-troika death sentence, execution at Sandarmokh.
+- **When:** apartment search 5 December 1934; detention from 6 December 1934; closed Kyiv court 27-28 March 1935; special-troika decision 9 October 1937; execution 3 November 1937. [T2: ЦДАМЛМ; T1: IEU]
+- **By whom:** NKVD / Soviet security organs; Military Collegium / closed Kyiv court; special troika of the UNKVD in Leningrad oblast.
+- **Document references:** archival-museum summary of search, 1935 sentence, 1937 troika sentence, and later false 1942 death record; Soviet case labels vary between fictitious "Ukrainian National Socialist party" and "Center of anti-Soviet Borotbist organization." [T2: ЦДАМЛМ; T1: IEU]
+- **Mechanism specifics:** The Soviet case converted literary and political biography into organizational guilt. Polishchuk's earlier revolutionary and leftist affiliations did not protect him; they gave the police ready-made labels to repurpose as "counter-revolutionary" conspiracy. [T1: IEU; T2: ЦДАМЛМ]
+
+The Sandarmokh sequence shows the two-stage mechanism clearly. First, the writer was removed from public life through a ten-year sentence. Then, while already imprisoned, he was selected for execution in the 1937 mass operation against Solovki prisoners. The false 1942 death notice was a post-factum concealment tool, not a reliable biographical fact. [T2: ЦДАМЛМ]
+
+**What survived / what was destroyed:** His poetry and prose titles survived in library record and partial reprint. The archive of his movement and group "Авангард" remains harder to teach because Soviet histories either attacked or normalized the movement rather than preserving its internal debates. The false death record is itself a surviving artifact of state erasure. [T1: ЕСУ; T2: ЦДАМЛМ]
+
+## 3. Major works
+
+- **1920** — *Соняшна міць*, poetry collection; early vitalist and revolutionary energy.
+- **1921** — *Вибухи сили*, collection; title indexes his force-and-dynamism poetics.
+- **1922** — *Книга повстань*, collection; revolutionary theme and mythic social energy.
+- **1923** — *Радіо в житах*, collection; emblematic mix of technology and Ukrainian landscape.
+- **1924** — *Жмуток червоного*, collection; political color and lyric intensity.
+- **1925** — *Громохкий слід*, collection; industrial and sonic diction.
+- **1927** — *Геніяльні кристали*, collection; important for constructivist and philosophical lyric.
+- **1927** — *Металевий тембр*, collection; industrial poetics.
+- **1929** — *Електричні заграви*, collection; modern technology vocabulary.
+- **1931** — *Повість металу й вугілля*, prose; industrial theme.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — "Народження поета", in *Геніяльні кристали*, 1927:**
+
+> **Почеплена на гвіздочку зорі**
+
+The image is strange but teachable: a cosmic object is made tactile and domestic. It is useful for showing how avant-garde metaphor can be concrete rather than vague.
+
+**Quote 2 — "Можливості", in *Геніяльні кристали*, 1927:**
+
+> **Ходило тихе море, як любов північна.**
+
+This line is a good B2/C1 transition example: grammatically legible, but semantically modernist. It opens discussion of simile, motion, and emotional abstraction.
+
+## 5. Language register
+
+- **Register:** avant-garde / constructivist, industrial, publicistic, but with lyric and philosophical registers inside the machinery.
+- **CEFR readiness for full reading:** C1 for full collections; B2/C1 for selected short poems with image-focused tasks.
+- **Lexicon notes:** Technology, industry, revolution, sound, metal, electricity, and unexpected cosmic-domestic metaphors. Learners need support for words that are transparent individually but difficult in combination.
+- **Stylistic features:** dynamic titles, free-verse tendencies, neologistic pressure, sonic clusters, and a drive to make modern industrial experience speak Ukrainian.
+
+## 6. Contested points
+
+- **Modern UA scholarly debate:** Polishchuk's reputation oscillates between "constructivist innovator" and "too programmatic / too slogan-driven." A good curriculum should not flatten him into either camp. [T1: ЕСУ; T1: IEU]
+- **Case label disagreement:** IEU and archival-museum summaries preserve different Soviet labels. The safest wording is "fabricated counter-revolutionary accusation," followed by the specific label only as quoted police language.
+- **False death date:** The 1942 peritonitis notice must be identified as Soviet concealment, not a genuine disagreement about natural death.
+- **What gets simplified:** Popular memory can treat all Sandarmokh writers as one indistinct martyr group. This dossier preserves the specific constructivist poetics and the specific December 1934/March 1935/October 1937 sequence.
+- **Russian/Soviet disinformation angle:** Soviet-era literary histories may keep the "formalism" or "nationalist deviation" frame. Use it only as evidence of repression.
+
+**Additional research cautions:** Polishchuk's case is a strong test of whether the curriculum can teach avant-garde complexity without apology or mockery. His titles can sound bombastic to modern readers, and some work really does lean into programmatic force. But the correct response is not to reduce him to slogans. The dossier should help future writers show how Ukrainian constructivism tried to name electricity, radio, coal, metal, and industrial rhythm in Ukrainian. That modernizing impulse belongs in the biography as much as the arrest record does.
+
+**Source-handling note:** The false 1942 peritonitis record should be mentioned whenever death details are taught, because it documents a second violence: concealment after execution. A future YAML should not put 1942 in `death_date` with a note; it should put 1937 and record the 1942 certificate as an artifact of falsification. The same principle applies to Soviet case labels. If a source says "Ukrainian National Socialist party" or "anti-Soviet Borotbist center," the lesson should ask what the NKVD was trying to manufacture, not whether Polishchuk belonged to such a body.
+
+**Pedagogical bridge:** Polishchuk pairs well with Semenko but should not be swallowed by Semenko. Semenko gives the futurist manifesto and anti-canon shock; Polishchuk gives constructivist mass, industry, and the problem of whether modern technical life can become lyric material. A future C1/C2 activity can ask learners to classify images in a poem as natural, industrial, cosmic, or political, then discuss how the categories overlap.
+
+**Open verification item:** Before Phase 2, verify which primary edition is best for classroom excerpts from *Геніяльні кристали* and whether scans preserve original orthography that should be quoted rather than normalized.
+
+**Assessment note:** Polishchuk also deserves explicit connection to Ukrainian-language technical modernity. If a future module quotes only nature imagery, it will miss the radio/metal/electricity axis that makes him important. If it quotes only industrial titles, it will miss the lyric density that keeps him from being merely programmatic. Select excerpts from both sides.
+
+This balance should be checked in review: one industrial passage, one lyric-philosophical passage, and one repression-document paragraph.
+
+## 7. Cross-track links
+
+`rg` checks found:
+
+- `wiki/literature/works/dray-khmara-poetry.md` mentions Валер'ян Поліщук among proletarian/modernist peers.
+- `wiki/literature/works/khvylovy-thoughts-current.md` names him as a polemical interlocutor on free verse and industrial aesthetics.
+- `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml` can absorb the constructivist dimension in Phase 2.
+- HIST context should connect to Sandarmokh and `mekhanizm-teroru` / `syntez-trahedii`. No plan YAML was changed.
+
+## 8. Naming-canonical
+
+- **Slug:** `valerian-polishchuk`
+- **EN canonical:** Valerian Polishchuk.
+- **UA canonical:** Валер'ян Львович Поліщук.
+- **Aliases to track:** Валеріян Поліщук; Valeriian Polishchuk; В. Поліщук.
+- **Forbidden Russian-imperial / Russified forms:** Валерьян Полищук; Valeryan Polishchuk; Russian/Soviet-writer labels.
+
+## 9. Image candidates
+
+- ЕСУ article image `https://esu.com.ua/article-881253`, first candidate after final reuse check.
+- Wikimedia Commons `File:Polishchuk-valerian.jpg`, verify PD/Ukraine and US status before Phase 4 use.
+- Context image: Sandarmokh memorial or cover of *Геніяльні кристали* if rights are clean.
+
+## 10. Sources used
+
+- **[T1]** "Поліщук Валер'ян Львович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-881253
+- **[T1]** "Polishchuk, Valeriian." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CO%5CPolishchukValeriian.htm
+- **[T2]** ЦДАМЛМ України archival-museum note on repressed Ukrainian writers, including Polishchuk. https://old-csam.archives.gov.ua/ukr/vchiteli/
+- **[T5]** Wikisource texts from *Геніяльні кристали*, used for primary quotes and corroborated by Tier 1 biography.
+- **[T5]** Wikimedia Commons portrait page, image lead only.
+- **[T3]** Ukrainian Wikipedia extract for navigation only.


### PR DESCRIPTION
## Summary

Adds the 10 remaining Block A research dossiers for Bio epic #2309 / issue #2317:

- Михайль Семенко — 1533 words
- Микола Вороний — 1516 words
- Михайло Яловий — 1546 words
- Григорій Епік — 1505 words
- Валер'ян Поліщук — 1509 words
- Олекса Влизько — 1505 words
- Марко Вороний — 1521 words
- Мирослав Ірчан — 1500 words
- Антін Крушельницький — 1511 words
- Софія Налепинська-Бойчук — 1513 words

Each dossier follows docs/templates/bio-research-dossier-template.md with verified facts, oppression mechanism, major works, primary quotes, language register, contested points, cross-track links, naming-canonical, image candidates, and tiered sources.

## Verification

- wc -w for all 10 new files: total 15159 words
- template section script: all 10 files have sections 1-10, at least 2 quote blocks, and at least 3 T1/T2 bibliography items
- git diff --cached --check
- pre-commit hooks during commit and push: gitleaks, merge-conflict check, EOF/whitespace, large-file guard, X-Agent trailer warning
- .venv/bin/python scripts/audit/lint_agent_trailer.py
- Gemini adversarial content/source-tier review posted to #2317: no blockers

Closes #2317. Supports #2309.

## Notes

No plan YAMLs, wiki files, status JSON, audit reviews, or generated artifacts were changed. No auto-merge requested; orchestrator should review decolonization and source-tier details.