### PR TITLE
fix(codex-adapter): scan local-date rollout dirs

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -34,6 +34,7 @@ import re
 import shutil
 import tempfile
 import unicodedata
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -560,16 +561,12 @@ class CodexAdapter:
         self._last_early_reap_check = now
 
         # Guard 3: mtime gate — quick stat instead of a full file scan.
-        from datetime import UTC, datetime
-
-        today = datetime.now(UTC)
-        sessions_today = (
-            Path.home() / ".codex" / "sessions" / f"{today.year:04d}" / f"{today.month:02d}" / f"{today.day:02d}"
-        )
         try:
-            if not sessions_today.exists():
-                return False
-            rollouts = list(sessions_today.glob("rollout-*.jsonl"))
+            rollouts = [
+                rollout
+                for directory in self._candidate_rollout_dirs()
+                for rollout in directory.glob("rollout-*.jsonl")
+            ]
             if not rollouts:
                 return False
             newest = max(rollouts, key=lambda p: p.stat().st_mtime)
@@ -595,12 +592,27 @@ class CodexAdapter:
     # Rollout-file recovery (post-completion hang fallback)
     # ---------------------------------------------------------------------
 
-    def _candidate_rollout_dirs(self) -> list[Path]:
-        """Return today's and yesterday's sessions dirs.
+    def _codex_home_path(self) -> Path:
+        """Return the Codex home this invocation should observe."""
+        scope = getattr(self, "_codex_home_scope", None)
+        if scope:
+            return Path(scope)
+        codex_home_env = os.environ.get("CODEX_HOME")
+        if codex_home_env:
+            return Path(codex_home_env)
+        return Path.home() / ".codex"
 
-        Yesterday is included so a call that starts at 23:59 UTC and
-        finishes at 00:01 UTC doesn't miss its own rollout when the
-        day directory rolls over. Codex 2026-04-10 audit finding.
+    def _rollout_discovery_times(self) -> tuple[datetime, datetime]:
+        """Return UTC and local clocks for Codex rollout date-dir discovery."""
+        return datetime.now(UTC), datetime.now().astimezone()
+
+    def _candidate_rollout_dirs(self) -> list[Path]:
+        """Return plausible Codex rollout session dirs.
+
+        Codex stores rollout files under the local-date session dir
+        (``sessions/YYYY/MM/DD``), while this adapter historically scanned
+        UTC-date dirs. Include +/- 1 day around both UTC and local clocks so
+        midnight-straddling runs are found in either direction.
 
         Honors the per-invocation scoped ``$CODEX_HOME`` so the V7
         writer's scoped-tempdir rollouts (materialized by
@@ -623,19 +635,22 @@ class CodexAdapter:
            the orchestrator itself exports CODEX_HOME.
         3. ``~/.codex/sessions/`` — legacy default.
         """
-        from datetime import UTC, datetime, timedelta
-
-        scope = getattr(self, "_codex_home_scope", None)
-        if scope:
-            base = Path(scope) / "sessions"
-        else:
-            codex_home_env = os.environ.get("CODEX_HOME")
-            base = Path(codex_home_env) / "sessions" if codex_home_env else Path.home() / ".codex" / "sessions"
+        base = self._codex_home_path() / "sessions"
+        utc_now, local_now = self._rollout_discovery_times()
+        dates = []
+        seen_dates = set()
+        for anchor in (utc_now, local_now):
+            for delta in (-1, 0, 1):
+                d = (anchor + timedelta(days=delta)).date()
+                if d not in seen_dates:
+                    seen_dates.add(d)
+                    dates.append(d)
         dirs: list[Path] = []
-        for delta in (0, 1):
-            d = datetime.now(UTC) - timedelta(days=delta)
+        seen_dirs: set[Path] = set()
+        for d in dates:
             candidate = base / f"{d.year:04d}" / f"{d.month:02d}" / f"{d.day:02d}"
-            if candidate.exists():
+            if candidate.exists() and candidate not in seen_dirs:
+                seen_dirs.add(candidate)
                 dirs.append(candidate)
         return dirs
 
@@ -872,18 +887,15 @@ class CodexAdapter:
             and only written at the very end on success, but kept as
             a signal for the "Codex is writing the final response" moment.
 
-        We pick the NEWEST rollout-*.jsonl inside today's sessions dir
-        and return it directly (same pattern as the Gemini adapter's
-        newest session-*.json file), so the mtime poller sees every
-        content write, not just directory-level events.
+        We include plausible session dirs around the UTC and local dates
+        so the mtime poller catches Codex startup even when UTC and local
+        dates differ.
         """
-        from datetime import UTC, datetime
-
         paths: list[Path] = []
         if plan.output_file is not None:
             paths.append(plan.output_file)
 
-        codex_home = Path.home() / ".codex"
+        codex_home = self._codex_home_path()
 
         # Secondary / fallback signals
         for rel in ("state_5.sqlite", "history.jsonl", "logs_1.sqlite"):
@@ -891,12 +903,11 @@ class CodexAdapter:
             if candidate.exists():
                 paths.append(candidate)
 
-        # Today's sessions directory (catches startup via dir mtime
-        # bump, but does NOT track subsequent content writes).
-        today = datetime.now(UTC)
-        sessions_today = codex_home / "sessions" / f"{today.year:04d}" / f"{today.month:02d}" / f"{today.day:02d}"
-        if sessions_today.exists():
-            paths.append(sessions_today)
+        # Plausible sessions directories catch startup via dir mtime bumps
+        # but do NOT track subsequent content writes.
+        for sessions_dir in self._candidate_rollout_dirs():
+            if sessions_dir not in paths:
+                paths.append(sessions_dir)
 
         # Note: we deliberately do NOT include the newest rollout-*.jsonl
         # file here. Earlier versions tried to track it for

--- a/tests/agent_runtime/test_codex_adapter.py
+++ b/tests/agent_runtime/test_codex_adapter.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
+from scripts.agent_runtime.adapters.base import InvocationPlan
 from scripts.agent_runtime.adapters.codex import CodexAdapter
 
 
@@ -42,3 +45,60 @@ def test_codex_build_invocation_honors_scoped_home(tmp_path: Path, monkeypatch) 
     )
 
     assert plan.env_overrides["CODEX_HOME"] == str(scoped_home)
+
+
+def test_codex_rollout_capture_includes_local_date_midnight_straddle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    adapter = CodexAdapter()
+    scoped_home = tmp_path / "codex-home"
+    local_rollout_dir = scoped_home / "sessions" / "2026" / "05" / "29"
+    local_rollout_dir.mkdir(parents=True)
+    rollout = local_rollout_dir / "rollout-2026-05-29T00-12-26-test.jsonl"
+    prompt = "write the lesson"
+    rollout.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "event_msg",
+                        "payload": {"type": "user_message", "message": prompt},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "function_call",
+                            "namespace": "mcp__sources__",
+                            "name": "verify_words",
+                            "arguments": json.dumps({"words": ["ранок"]}),
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output_file = tmp_path / "codex-output.txt"
+    output_file.write_text("done", encoding="utf-8")
+    utc_now = datetime(2026, 5, 28, 22, 12, tzinfo=UTC)
+    local_now = datetime(2026, 5, 29, 0, 12, tzinfo=timezone(timedelta(hours=2)))
+
+    adapter._codex_home_scope = str(scoped_home)
+    monkeypatch.setattr(adapter, "_rollout_discovery_times", lambda: (utc_now, local_now))
+    adapter._rollout_snapshot = set()
+
+    assert local_rollout_dir in adapter._candidate_rollout_dirs()
+
+    result = adapter.parse_response(
+        stdout="",
+        stderr="",
+        returncode=0,
+        output_file=output_file,
+        plan=InvocationPlan(cmd=["codex"], cwd=tmp_path, stdin_payload=prompt),
+    )
+
+    assert [call["name"] for call in result.tool_calls] == ["mcp__sources__verify_words"]


### PR DESCRIPTION
## Summary

Fixes Codex rollout discovery for the V7 `codex-tools` writer by scanning session directories around both UTC and local dates under the scoped `CODEX_HOME`. This covers the 2026-05-28T22:12Z / 2026-05-29 Budapest midnight straddle and keeps early reap + liveness polling on the same scoped-home path as post-call capture.

## Root Cause

Codex writes rollout JSONL under local-date `sessions/YYYY/MM/DD`, but the adapter looked only at UTC-date dirs in several paths. `_candidate_rollout_dirs` also needed the local-date window, and early reap / liveness needed to stop hardcoding `Path.home() / ".codex"`.

Smoking-gun rollout used for validation:

`/private/tmp/claude-501/codex-v7-writer-501/sessions/2026/05/29/rollout-2026-05-29T00-12-26-019e70a5-5dc7-7f93-a92a-0f3c1b57d932.jsonl`

Evidence from that existing rollout, without re-running Codex:

```
rollout_exists=True
candidate_dir_in_scope=True
total_sources=12
verify_words=4
names=mcp__sources__check_russian_shadow:1, mcp__sources__get_chunk_context:2, mcp__sources__query_cefr_level:2, mcp__sources__query_pravopys:1, mcp__sources__search_images:1, mcp__sources__search_style_guide:1, mcp__sources__verify_words:4
```

Raw namespace audit for the same file:

```
raw_lines_with_mcp__sources__=14
function_call_sources=12
other_namespace_mentions={'message': 1, 'user_message': 1}
function_calls=mcp__sources__check_russian_shadow:1, mcp__sources__get_chunk_context:2, mcp__sources__query_cefr_level:2, mcp__sources__query_pravopys:1, mcp__sources__search_images:1, mcp__sources__search_style_guide:1, mcp__sources__verify_words:4
```

The adapter captures the normalized callable events; the two extra raw `mcp__sources__` mentions are prompt echo/message events, not function calls.

## Sibling Sweep

Fixed in `scripts/agent_runtime/adapters/codex.py`:

- `_candidate_rollout_dirs`: scoped `CODEX_HOME`, UTC/local +/-1 day, deduped.
- `check_early_reap`: uses `_candidate_rollout_dirs()` instead of UTC `~/.codex`.
- `liveness_signal_paths`: uses scoped Codex home and candidate dirs.

Other runtime adapters check:

```
rg -n "datetime\.(now\(UTC\)|utcnow)|sessions/.*%Y|Path.home\(\).*codex" scripts/agent_runtime/adapters --glob "*.py" --glob "!codex.py" || true
```

Output: empty.

Rollout monitor note: `scripts/ai_agent_bridge/_ui_codex.py` uses a recursive `**/rollout-*{thread_id}.jsonl` search across all date dirs, so it is not affected by the UTC-vs-local date bug.

## Validation

```
.venv/bin/ruff check scripts tests
All checks passed!
```

```
.venv/bin/pytest tests/agent_runtime -q
============================== 74 passed in 9.79s ==============================
```

```
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

One-line post-fix end-to-end confirmation command for a fresh writer run:

```bash
.venv/bin/python -u scripts/build/v7_build.py a1 my-morning --writer codex-tools --use-generator --worktree; wt=$(ls -td .worktrees/builds/a1-my-morning-* | head -1); jq -e '[.[] | select((.namespace?=="mcp__sources__") or ((.name? // "")|startswith("mcp__sources__")))] | length > 0' "$wt/curriculum/l2-uk-en/a1/my-morning/writer_tool_calls.json"
```