### PR TITLE
fix(activities): accept item-string permutation as order correct_order

### DIFF
--- a/scripts/yaml_activities.py
+++ b/scripts/yaml_activities.py
@@ -1128,6 +1128,17 @@ class ActivityParser:
             raise ValueError("order requires non-empty items list")
         if not isinstance(correct_order, list) or not correct_order:
             raise ValueError("order requires non-empty correct_order list")
+        # Writers (e.g. codex on m20 a1/my-morning act-3) commonly express the
+        # answer as the ordered ITEM STRINGS rather than integer indices into
+        # `items`. When correct_order is an exact permutation of UNIQUE items,
+        # resolve each string to its index — unambiguous, and a natural
+        # authoring form we accept rather than HARD-fail at MDX assembly.
+        str_items = [str(item) for item in items]
+        if (all(isinstance(entry, str) for entry in correct_order)
+                and len(str_items) == len(set(str_items))
+                and len(correct_order) == len(str_items)
+                and set(correct_order) == set(str_items)):
+            correct_order = [str_items.index(entry) for entry in correct_order]
         if not all(isinstance(index, int) for index in correct_order):
             raise TypeError("order correct_order must contain integers")
         if any(index < 0 or index >= len(items) for index in correct_order):

--- a/tests/test_yaml_activities_v7_types.py
+++ b/tests/test_yaml_activities_v7_types.py
@@ -7,7 +7,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from yaml_activities import ActivityParser
+from yaml_activities import ActivityParser, OrderActivity
 
 
 def test_v7_authoring_types_parse_and_render(tmp_path):
@@ -110,6 +110,61 @@ def test_v7_authoring_types_parse_and_render(tmp_path):
         assert tag in mdx
 
     assert "ActivityPlaceholder" not in mdx
+
+
+def test_order_accepts_item_string_permutation_as_correct_order(tmp_path):
+    """Writers (codex on m20 act-3) express order answers as the ordered ITEM
+    STRINGS rather than integer indices. When correct_order is an exact
+    permutation of unique items, the parser resolves it to indices instead of
+    HARD-failing at MDX assembly with 'correct_order must contain integers'.
+    """
+    fixture = tmp_path / "order.yaml"
+    fixture.write_text(
+        """
+- id: order-strings
+  type: order
+  title: Order
+  instruction: Put the morning routine in order.
+  items:
+    - "Потім я вмиваюся."
+    - "Нарешті я йду на роботу."
+    - "Спочатку я прокидаюся."
+    - "Після цього я снідаю."
+  correct_order:
+    - "Спочатку я прокидаюся."
+    - "Потім я вмиваюся."
+    - "Після цього я снідаю."
+    - "Нарешті я йду на роботу."
+""",
+        encoding="utf-8",
+    )
+    parser = ActivityParser()
+    activities = parser.parse(fixture)
+    order_activity = activities[0]
+    assert isinstance(order_activity, OrderActivity)
+    assert order_activity.correct_order == [2, 0, 3, 1]
+    assert "<Order" in parser.to_mdx(activities)
+
+
+def test_order_still_rejects_non_permutation_strings(tmp_path):
+    """A string correct_order that is NOT an exact permutation of items must
+    still fail (no silent coercion of bogus answers)."""
+    fixture = tmp_path / "order_bad.yaml"
+    fixture.write_text(
+        """
+- id: order-bad
+  type: order
+  title: Order
+  instruction: Order them.
+  items: ["a", "b", "c"]
+  correct_order: ["a", "b", "zzz"]
+""",
+        encoding="utf-8",
+    )
+    parser = ActivityParser()
+    # parse() wraps the per-activity TypeError in a ValueError context.
+    with pytest.raises(ValueError, match="must contain integers"):
+        parser.parse(fixture)
 
 
 def test_grammar_identify_accepts_sentence_alias(tmp_path):


### PR DESCRIPTION
## Root cause
m20 a1/my-morning cleared every gate (writer, python_qg, wiki_coverage 18/18, Goodhart PASS, llm_qg terminal PASS) then HARD-failed at **MDX assembly**: `activity act-3 type='order': correct_order must contain integers`. Codex emitted `correct_order` as the ordered **item strings** (an exact permutation of `items`) rather than integer indices.

## Fix
`_parse_order` resolves a string `correct_order` to indices when it is an exact permutation of **unique** items — a natural authoring form. Non-permutation strings still reject (no silent coercion of wrong answers). Both m20 order activities resolve (`[2,0,3,1]`, `[1,2,0,3]`). +2 regression tests. Last writer-output blocker for the m20 anchor end-to-end build.