### PR TITLE
fix(pipeline): sanitize impl-map render and gate scaffolding leaks

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -1157,7 +1157,20 @@ def _strip_step_prefix(text: str) -> str:
 
 def _strip_source_markers(text: str) -> str:
     """Strip inline source-reference markers like [S7] or [S1, S3]."""
-    return re.sub(r"\[[SС]\d+(?:,\s*[SС]\d+)*\]", "", text).strip()
+    return re.sub(r"\[[SС]\d+(?:\s*,\s*[SС]\d+)*\]", "", text).strip()
+
+
+_WRITER_SCAFFOLDING_STEP_LABEL_RE = re.compile(
+    r"(?:Крок|Step|Урок)\s+\d+\s*:\s*",
+    re.IGNORECASE,
+)
+
+
+def strip_writer_scaffolding(text: str) -> str:
+    """Strip wiki-manifest scaffolding that must not be copyable into prose."""
+    text = _WRITER_SCAFFOLDING_STEP_LABEL_RE.sub("", text)
+    text = _strip_source_markers(text)
+    return re.sub(r"\s+", " ", text).strip()
 
 
 def _normalize_required_claim(text: str) -> str:
@@ -1227,7 +1240,7 @@ def _marker_candidates(text: str) -> list[str]:
     raw_parts = re.split(r"\s*/\s*|\s+або\s+|\s+чи\s+", cleaned)
     parts = []
     for part in raw_parts:
-        part = re.sub(r"\[[SС]\d+\]", "", part)
+        part = re.sub(r"\[[SС]\d+(?:\s*,\s*[SС]\d+)*\]", "", part)
         part = re.sub(r"[`*_]", "", part).strip(" .;:,")
         if part:
             parts.append(part)

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8270,8 +8270,15 @@ def _formatting_standards_gate(text: str) -> dict[str, Any]:
 
 
 _SCAFFOLDING_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+# Gate flags only the UKRAINIAN step labels (Крок/Урок) — the observed leak class
+# is Ukrainian wiki-manifest scaffolding. English "Step N:" is intentionally NOT
+# flagged here: it can appear in legitimate English pedagogical prose (e.g. a
+# how-to sequence), and the source-marker check below already catches the
+# unambiguous `[SN]` signature that accompanies a real leak. (The writer-prompt
+# sanitizer still strips English "Step N:" defensively; this is the published-
+# prose detector, where a false positive blocks a real build.)
 _SCAFFOLDING_STEP_LABEL_RE = re.compile(
-    r"(?:Крок|Step|Урок)\s+\d+\s*:",
+    r"(?:Крок|Урок)\s+\d+\s*:",
     re.IGNORECASE,
 )
 _SCAFFOLDING_SOURCE_MARKER_RE = re.compile(

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -152,6 +152,7 @@ PYTHON_QG_GATE_ORDER = (
     "vocab_count",
     "plan_sections",
     "formatting_standards",
+    "scaffolding_leak",
     "vesum_verified",
     "citations_resolve",
     "textbook_grounding",
@@ -362,6 +363,7 @@ RULE_VOICE_META = "#R-VOICE-META"
 RULE_BAD_FORM_MARKER = "#R-BAD-FORM-MARKER"
 RULE_VESUM_ALL_WORDS = "#R-VESUM-ALL-WORDS"
 RULE_IMPL_MAP_COMPLETE = "#R-IMPL-MAP-COMPLETE"
+RULE_NO_SCAFFOLDING_LEAKS = "#R-NO-SCAFFOLDING-LEAKS"
 RULE_TEXTBOOK_30W = "#R-TEXTBOOK-30W"
 RULE_CITE_HONEST = "#R-CITE-HONEST"
 CORRECTION_PREVIEW_CHARS = 200
@@ -2014,6 +2016,8 @@ def _writer_rule_ids_for_gate_failure(
 ) -> list[str]:
     if gate == "engagement_floor":
         return [RULE_VOICE_META] if report.get("meta_narration_hits") else []
+    if gate == "scaffolding_leak":
+        return [RULE_NO_SCAFFOLDING_LEAKS]
     if gate == "vesum_verified":
         return [RULE_VESUM_ALL_WORDS, RULE_BAD_FORM_MARKER]
     if gate in {"russianisms_strict", "russianisms_clean", "surzhyk_clean", "calques_clean", "paronym_clean"}:
@@ -2033,6 +2037,10 @@ def _writer_rule_evidence_for_gate(
         hits = report.get("meta_narration_hits")
         if isinstance(hits, list):
             return ", ".join(str(hit) for hit in hits[:3])
+    if gate == "scaffolding_leak":
+        offending = report.get("offending")
+        if isinstance(offending, list):
+            return "; ".join(str(item) for item in offending[:3])
     if gate == "vesum_verified":
         missing = report.get("missing")
         if isinstance(missing, list):
@@ -6480,6 +6488,7 @@ def run_python_qg(
     record("word_count", _word_count_gate(module_text, int(plan["word_target"])))
     record("plan_sections", _section_gate(module_text, plan))
     record("formatting_standards", _formatting_standards_gate(module_text))
+    record("scaffolding_leak", _scaffolding_leak_gate(module_text))
     record(
         "vesum_verified",
         _vesum_gate(
@@ -8258,6 +8267,52 @@ def _formatting_standards_gate(text: str) -> dict[str, Any]:
         "malformed_callouts": malformed_callouts,
         "missing_mandatory_callouts": missing_mandatory,
     }
+
+
+_SCAFFOLDING_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_SCAFFOLDING_STEP_LABEL_RE = re.compile(
+    r"(?:Крок|Step|Урок)\s+\d+\s*:",
+    re.IGNORECASE,
+)
+_SCAFFOLDING_SOURCE_MARKER_RE = re.compile(
+    r"\[[SС]\d+(?:\s*,\s*[SС]\d+)*\]"
+)
+
+
+def _line_preserving_blank(match: re.Match[str]) -> str:
+    return "\n" * match.group(0).count("\n")
+
+
+def _strip_scaffolding_scan_exclusions(text: str) -> str:
+    text = _SCAFFOLDING_COMMENT_RE.sub(_line_preserving_blank, text)
+    lines: list[str] = []
+    in_fence = False
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            lines.append("\n" if line.endswith("\n") else "")
+            is_just_backticks = not stripped.rstrip().strip("`")
+            single_line_fence = (
+                not is_just_backticks and stripped.rstrip().endswith("```")
+            )
+            if not single_line_fence:
+                in_fence = not in_fence
+            continue
+        if in_fence:
+            lines.append("\n" if line.endswith("\n") else "")
+            continue
+        lines.append(line)
+    return "".join(lines)
+
+
+def _scaffolding_leak_gate(text: str) -> dict[str, Any]:
+    """Fail when writer-only wiki scaffolding leaks into published prose."""
+    scan_text = _strip_scaffolding_scan_exclusions(text)
+    offending = []
+    for line_no, line in enumerate(scan_text.splitlines(), start=1):
+        if _SCAFFOLDING_STEP_LABEL_RE.search(line) or _SCAFFOLDING_SOURCE_MARKER_RE.search(line):
+            offending.append({"line": line_no, "text": line.strip()})
+    return {"passed": not offending, "offending": offending}
 
 
 def _normalize_citation_ref(value: Any) -> str:

--- a/scripts/build/phases/implementation_map.py
+++ b/scripts/build/phases/implementation_map.py
@@ -9,6 +9,8 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal, NotRequired, TypedDict
 
+from scripts.audit.wiki_coverage_gate import strip_writer_scaffolding
+
 ObligationType = Literal[
     "sequence_step",
     "l2_error",
@@ -433,7 +435,7 @@ def render_for_writer_prompt(payload: dict[str, Any]) -> str:
                 f"- obligation_id: {entry['obligation_id']}  "
                 f"(obligation_type: {entry['obligation_type']})",
                 f"  artifact: {entry['artifact']}",
-                f"  location_hint: {entry['location_hint']}",
+                f"  location_hint: {strip_writer_scaffolding(entry['location_hint'])}",
             ]
         )
         if entry.get("subtype"):
@@ -451,6 +453,7 @@ def render_for_writer_prompt(payload: dict[str, Any]) -> str:
             if key == "activity_stub" and isinstance(value, Mapping):
                 _stub_drop = {"manifest", "obligation_id", "location_hint"}
                 value = {k: v for k, v in value.items() if k not in _stub_drop}
+            value = _sanitize_writer_prompt_render_value(value)
             rows.append(f"    {key}: {_render_template_value(value)}")
     body = "\n".join(rows)
     header = (
@@ -460,6 +463,19 @@ def render_for_writer_prompt(payload: dict[str, Any]) -> str:
         "`treatment_template` as the structural blueprint."
     )
     return f"{header}\n\n{body}\n"
+
+
+def _sanitize_writer_prompt_render_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return strip_writer_scaffolding(value)
+    if isinstance(value, Mapping):
+        return {
+            key: _sanitize_writer_prompt_render_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [_sanitize_writer_prompt_render_value(item) for item in value]
+    return value
 
 
 def _render_template_value(value: Any) -> str:

--- a/tests/test_scaffolding_leak_gate.py
+++ b/tests/test_scaffolding_leak_gate.py
@@ -67,6 +67,20 @@ def test_scaffolding_leak_gate_passes_on_clean_a1_prose() -> None:
     assert result == {"passed": True, "offending": []}
 
 
+def test_scaffolding_leak_gate_allows_english_step_instructions() -> None:
+    # English "Step N:" can be legitimate published pedagogical prose; only the
+    # Ukrainian Крок/Урок labels and the [SN] source-marker signature indicate a
+    # real wiki-scaffolding leak. (Deepseek review #2412 finding 2a.)
+    text = (
+        "## How to form the present tense\n\n"
+        "Step 1: find the verb stem. Step 2: add the personal ending.\n"
+    )
+
+    result = _scaffolding_leak_gate(text)
+
+    assert result == {"passed": True, "offending": []}
+
+
 def test_scaffolding_leak_gate_is_ordered_but_not_auto_corrected() -> None:
     assert PYTHON_QG_GATE_ORDER.index("formatting_standards") < PYTHON_QG_GATE_ORDER.index(
         "scaffolding_leak"

--- a/tests/test_scaffolding_leak_gate.py
+++ b/tests/test_scaffolding_leak_gate.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from scripts.build.linear_pipeline import (
+    PYTHON_QG_GATE_ORDER,
+    WRITER_CORRECTION_GATES,
+    _scaffolding_leak_gate,
+)
+
+
+def test_scaffolding_leak_gate_fails_on_step_labels_and_source_markers() -> None:
+    text = (
+        "## Дієслова на -ся\n\n"
+        "A reflexive verb adds -ся. Крок 2: use прокидатися [S3, S6].\n"
+    )
+
+    result = _scaffolding_leak_gate(text)
+
+    assert result["passed"] is False
+    assert result["offending"] == [
+        {
+            "line": 3,
+            "text": "A reflexive verb adds -ся. Крок 2: use прокидатися [S3, S6].",
+        }
+    ]
+
+
+def test_scaffolding_leak_gate_ignores_comments_and_fenced_code() -> None:
+    text = """## Notes
+
+<!-- VERIFY: source="wiki step-1 [S3]" Крок 2: -->
+
+```md
+Крок 2: use прокидатися [S3, S6]
+```
+
+Чистий текст без службових міток.
+"""
+
+    result = _scaffolding_leak_gate(text)
+
+    assert result == {"passed": True, "offending": []}
+
+
+def test_scaffolding_leak_gate_does_not_blind_after_single_line_backticks() -> None:
+    text = """## Notes
+
+```print("hello")```
+
+Крок 3: leaked prose [S4]
+"""
+
+    result = _scaffolding_leak_gate(text)
+
+    assert result["passed"] is False
+    assert result["offending"] == [{"line": 5, "text": "Крок 3: leaked prose [S4]"}]
+
+
+def test_scaffolding_leak_gate_passes_on_clean_a1_prose() -> None:
+    text = (
+        "## Мій ранок\n\n"
+        "Я прокидаюся о сьомій. Потім умиваюся і одягаюся.\n"
+        "Ти прокидаєшся рано? Я дивлюся в дзеркало.\n"
+    )
+
+    result = _scaffolding_leak_gate(text)
+
+    assert result == {"passed": True, "offending": []}
+
+
+def test_scaffolding_leak_gate_is_ordered_but_not_auto_corrected() -> None:
+    assert PYTHON_QG_GATE_ORDER.index("formatting_standards") < PYTHON_QG_GATE_ORDER.index(
+        "scaffolding_leak"
+    )
+    assert "scaffolding_leak" not in WRITER_CORRECTION_GATES

--- a/tests/test_writer_prompt_scaffolding_sanitizer.py
+++ b/tests/test_writer_prompt_scaffolding_sanitizer.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import copy
+
+from scripts.build.phases.implementation_map import render_for_writer_prompt
+
+
+def _payload_with_scaffolding() -> dict:
+    return {
+        "schema_version": 1,
+        "slug": "my-morning",
+        "wiki_path": "wiki/pedagogy/a1/my-morning.md",
+        "manifest_obligation_count": 1,
+        "entries": [
+            {
+                "obligation_id": "step-1",
+                "obligation_type": "sequence_step",
+                "artifact": "module.md",
+                "location_hint": "Крок 4: §Дієслова на -ся [S7]",
+                "treatment_template": {
+                    "shape": "prose explanation",
+                    "required_claim": "Крок 1: Ознайомлення... [S8] ... [S6, S8]",
+                    "nested": {
+                        "instruction": "Step 2: use прокидатися [S3]",
+                        "summary": "A reflexive verb adds -ся. Крок 5: practice дивитися [S7]",
+                        "spaced_marker": "Use умиватися [S1 , S2]",
+                        "items": ["Урок 3: reinforce одягатися [С4]"],
+                    },
+                },
+                "manifest_payload": {"id": "step-1"},
+            }
+        ],
+    }
+
+
+def test_render_for_writer_prompt_strips_scaffolding_without_mutating_payload() -> None:
+    payload = _payload_with_scaffolding()
+    original = copy.deepcopy(payload)
+
+    rendered = render_for_writer_prompt(payload)
+
+    assert payload == original
+    assert "Крок 1:" not in rendered
+    assert "Крок 4:" not in rendered
+    assert "Крок 5:" not in rendered
+    assert "Step 2:" not in rendered
+    assert "Урок 3:" not in rendered
+    assert "[S8]" not in rendered
+    assert "[S6, S8]" not in rendered
+    assert "[S7]" not in rendered
+    assert "[S3]" not in rendered
+    assert "[S1 , S2]" not in rendered
+    assert "[С4]" not in rendered
+    assert "Ознайомлення" in rendered
+    assert "A reflexive verb adds -ся. practice дивитися" in rendered
+    assert "§Дієслова на -ся" in rendered


### PR DESCRIPTION
## Root cause

m20 reached `module_done`, but the writer prompt exposed implementation-map scaffolding as copyable prose. `render_for_writer_prompt` rendered `treatment_template` values and `location_hint` directly, so `Крок N:` labels and `[SN]` source markers from the wiki manifest leaked into `module.md`. The only deterministic protection was advisory prompt text, so the leak class depended on noisy LLM naturalness review.

## Fixes

1. Sanitize only the writer-visible implementation-map render:
   - add `strip_writer_scaffolding()` for unanchored `Крок|Step|Урок N:` labels and `[S/СN]` source markers
   - apply it recursively to rendered `treatment_template` string values and to `location_hint`
   - preserve the seeded implementation-map payload unchanged for wiki coverage fallback

2. Add a hard deterministic `scaffolding_leak` gate:
   - scans `module.md` prose for step labels and source markers
   - masks MDX/HTML comments and fenced code blocks first
   - reports offending `{line, text}` rows
   - is included in deterministic gate aggregation and intentionally excluded from writer auto-correction

Gemini adversarial review r1 found two scanner/regex edge cases; both were fixed. Follow-up review reported the final staged diff CLEAN.

## Verification

```text
.venv/bin/python -m pytest tests/test_writer_prompt_scaffolding_sanitizer.py tests/test_scaffolding_leak_gate.py -q
============================== 6 passed in 0.26s ===============================
```

```text
.venv/bin/python -m pytest tests/test_writer_prompt_*.py tests/test_linear_pipeline_wiki_coverage.py tests/audit/test_wiki_coverage_gate.py -q
======================== 66 passed in 64.79s (0:01:04) =========================
```

```text
.venv/bin/ruff check scripts/build/phases/implementation_map.py scripts/build/linear_pipeline.py scripts/audit/wiki_coverage_gate.py tests/test_writer_prompt_scaffolding_sanitizer.py tests/test_scaffolding_leak_gate.py
All checks passed!
```

```text
synthetic render grep -cE '(Крок|Step|Урок)...|\[[SС]N...]'
0
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
