### PR TITLE
fix(wiki-coverage): extract only real required lemmas

### DIFF
--- a/scripts/audit/wiki_coverage_gate.py
+++ b/scripts/audit/wiki_coverage_gate.py
@@ -1180,25 +1180,93 @@ def _normalize_required_claim(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+_REQUIRED_VOCAB_STOPWORDS = {
+    "а",
+    "або",
+    "але",
+    "він",
+    "вона",
+    "вони",
+    "воно",
+    "ви",
+    "і",
+    "й",
+    "ми",
+    "напр",
+    "наприклад",
+    "сь",
+    "ся",
+    "та",
+    "ти",
+    "тобто",
+    "тощо",
+    "чи",
+    "я",
+    "зокрема",
+    "-сь",
+    "-ся",
+}
+
+_REQUIRED_VOCAB_SURROUNDING = " \t\r\n,;:.\"'`*_«»"
+
+
+def _clean_required_vocab_candidate(token: str) -> str:
+    return re.sub(r"\s+", " ", token.strip(_REQUIRED_VOCAB_SURROUNDING)).strip()
+
+
+def _is_required_vocab_noise(token: str) -> bool:
+    normalized = token.casefold().strip(_REQUIRED_VOCAB_SURROUNDING)
+    return (
+        not normalized
+        or normalized in _REQUIRED_VOCAB_STOPWORDS
+        or len(normalized) == 1
+        or not re.search(r"[А-Яа-яІіЇїЄєҐґ]", normalized)
+    )
+
+
+def _required_vocab_items_from_parenthetical_token(token: str) -> list[str]:
+    token = _clean_required_vocab_candidate(token)
+    if _is_required_vocab_noise(token):
+        return []
+
+    words = token.split()
+    if len(words) > 2:
+        first_word = _clean_required_vocab_candidate(words[0])
+        # Some source claims write an infinitive lemma with a short descriptive
+        # complement. Keep only the lemma; drop the descriptive phrase itself.
+        if (
+            "«" not in token
+            and "»" not in token
+            and "—" not in token
+            and "-" not in token
+            and re.search(r"(?:ти|тися|тись)$", first_word.casefold())
+            and not _is_required_vocab_noise(first_word)
+        ):
+            return [first_word]
+        return []
+
+    return [token]
+
+
 def _extract_required_items(claim_text: str) -> dict[str, list[str]]:
     """Extract item-level requirements (vocabulary, examples) from a claim."""
     vocabulary: list[str] = []
-    # Vocabulary: find Ukrainian words inside parentheses.
+    # Vocabulary: find plausible Ukrainian lemmas inside parentheses.
     for match in re.findall(r"\(([^()]+)\)", claim_text):
         for token in match.split(","):
-            token = token.strip().strip(" \t\r\n,;:.\"\'")
-            if token and re.search(r"[А-Яа-яІіЇїЄєҐґ]", token):
-                vocabulary.append(token)
+            vocabulary.extend(_required_vocab_items_from_parenthetical_token(token))
 
     examples: list[str] = []
 
     def _add_item(val: str):
-        val = val.strip()
+        val = _clean_required_vocab_candidate(val)
         if not val or not re.search(r"[А-Яа-яІіЇїЄєҐґ]", val):
             return
         # If it's a single word, it might be vocabulary.
         if len(val.split()) > 1:
             examples.append(val)
+        elif _is_required_vocab_noise(val):
+            return
         else:
             vocabulary.append(val)
 

--- a/tests/test_extract_required_items_noise.py
+++ b/tests/test_extract_required_items_noise.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from scripts.audit.wiki_coverage_gate import _extract_required_items
+
+
+def test_extract_required_items_drops_discourse_marker_from_parenthetical_vocab() -> None:
+    claim = "Teach first conjugation endings (наприклад, читати) [S8]."
+
+    items = _extract_required_items(claim)
+
+    assert items["vocabulary"] == ["читати"]
+    assert "наприклад" not in items["vocabulary"]
+
+
+def test_extract_required_items_drops_phrase_particle_and_single_letter_noise() -> None:
+    claim = (
+        "Teach дивитися reflexives "
+        "(наприклад, дивитися в дзеркало під час ранкових зборів); "
+        "поява вставного «л» — дивлюся."
+    )
+
+    items = _extract_required_items(claim)
+
+    assert "дивитися" in items["vocabulary"]
+    assert "наприклад" not in items["vocabulary"]
+    assert "дивитися в дзеркало під час ранкових зборів" not in items["vocabulary"]
+    assert "л" not in items["vocabulary"]
+
+
+def test_extract_required_items_keeps_legit_one_word_parenthetical_lemma() -> None:
+    claim = "Introduce the morning routine verb (прокидатися) before examples."
+
+    items = _extract_required_items(claim)
+
+    assert items["vocabulary"] == ["прокидатися"]


### PR DESCRIPTION
## Summary
- Filter sequence-step parenthetical vocabulary extraction to drop discourse markers, pronouns, particles, single letters, and long descriptive phrases.
- Preserve real lemma obligations, including leading infinitive lemmas when claims include a descriptive complement.
- Add m20 regression coverage for наприклад/phrase/л over-extraction.

## Validation
- `.venv/bin/python -m pytest tests/test_extract_required_items_noise.py tests/test_wiki_coverage_gate.py -q`
- `.venv/bin/ruff check scripts/audit/wiki_coverage_gate.py tests/test_extract_required_items_noise.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No auto-merge.