### PR TITLE
fix(vesum-gate): strip HTML comments before VESUM lookup

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7879,6 +7879,8 @@ def _strip_metalinguistic(text: str) -> str:
       is deliberately non-VESUM and would otherwise be a false positive;
       HTML comments don't render in MDX, so the learner still sees the
       bad form in plain prose for contrast.
+    - `<!-- ... -->` — remaining HTML comments such as VERIFY annotations,
+      after bad-form marker spans have already been removed.
     - `not "форма"` / `not «форма»` — prose-quoted warning examples where the
       quoted form is explicitly marked as wrong.
 
@@ -7892,6 +7894,7 @@ def _strip_metalinguistic(text: str) -> str:
     text = _PRONUNCIATION_CUE_PATTERN.sub(" ", text)
     text = _MORPHEME_FRAGMENT_RE.sub(" ", text)
     text = _AVOID_MARKER_RE.sub(" ", text)
+    text = _strip_comments(text)
     text = _WARNING_QUOTE_RE.sub(" ", text)
     text = _VESUM_ABBREVIATION_RE.sub(" ", text)
     return text

--- a/tests/test_vesum_gate_distractor_and_phonetic.py
+++ b/tests/test_vesum_gate_distractor_and_phonetic.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from scripts.build.linear_pipeline import _vesum_gate
+from scripts.build.linear_pipeline import _build_vesum_text, _vesum_gate
 
 
 def test_mc_distractor_text_not_verified() -> None:
@@ -160,3 +160,66 @@ def test_isolated_misspelling_still_caught() -> None:
     )
 
     assert "вмиваєсся" in result["missing"]
+
+
+def test_build_vesum_text_strips_bad_marker_and_verify_comment_args() -> None:
+    """Cyrillic inside bad markers and VERIFY comments is not learner prose."""
+    module_text = (
+        "the form <!-- bad -->одіватися<!-- /bad --> is not used "
+        "<!-- VERIFY: check_russian_shadow(word='одіватися') -->"
+    )
+
+    text = _build_vesum_text(module_text, [], [], [])
+
+    assert "одіватися" not in text
+
+
+def test_bad_marker_form_stays_excluded_before_comment_stripping() -> None:
+    """Bad marker ordering must remove the inner bad form before HTML comments."""
+    text = _build_vesum_text(
+        "Use одягатися, not <!-- bad -->одіватися<!-- /bad -->.",
+        [],
+        [],
+        [],
+    )
+
+    assert "одягатися" in text
+    assert "одіватися" not in text
+
+
+def test_normal_prose_cyrillic_survives_comment_stripping() -> None:
+    """Only comments and marked bad forms are stripped from VESUM text."""
+    text = _build_vesum_text(
+        "Вона одягається. <!-- VERIFY: word='одіватися' -->",
+        [],
+        [],
+        [],
+    )
+
+    assert "одягається" in text
+    assert "одіватися" not in text
+
+
+def test_vesum_gate_ignores_verify_comment_russianism_end_to_end() -> None:
+    """VERIFY comments with non-VESUM arguments must not fail the gate."""
+    module_text = (
+        "Вона одягається вранці. "
+        "<!-- VERIFY: source='vesum'; check_russian_shadow(word='одіватися') -->"
+    )
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        valid = {"вона", "вранці", "одягається"}
+        return {word: ([{"lemma": word}] if word in valid else []) for word in words}
+
+    result = _vesum_gate(
+        module_text=module_text,
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert result["passed"] is True
+    assert "одіватися" not in sent_for_verification


### PR DESCRIPTION
## Summary
- strip remaining HTML comments after bad-form marker spans in VESUM text preparation
- add regression coverage for VERIFY-comment Cyrillic args, bad-marker ordering, normal prose retention, and end-to-end gate behavior

## Validation
- `.venv/bin/python -m pytest tests/test_vesum_gate_distractor_and_phonetic.py tests/test_vesum_verified_postfix.py -q` -> `22 passed in 0.35s`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_vesum_gate_distractor_and_phonetic.py` -> `All checks passed!`
- reproduction assertion -> `reproduction assertion passed`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> `All 1 non-skipped commit(s) carry an X-Agent trailer.`