### PR TITLE
feat(bio): religious-martyrs/UGCC-clergy dossiers — §7 verified

### DIFF
--- a/docs/research/bio/andrey-sheptytsky.md
+++ b/docs/research/bio/andrey-sheptytsky.md
@@ -1,0 +1,185 @@
+# Андрей Шептицький — Research Dossier
+
+**Slug:** `andrey-sheptytsky`
+**Block:** Religious martyrs / UGCC clergy
+**Tier:** 3
+**Issue:** #2309
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-29
+
+**Evidence rule for this dossier:** every factual bullet is keyed to the
+tool evidence ledger in §10. Direct quotations appear only where a tool
+returned the wording.
+
+## 1. Verified facts
+
+- **Full name / religious name:** Андрей Шептицький; born Roman Maria
+  Alexander Sheptytsky. [W1]
+- **Identity:** Ukrainian Greek Catholic Church primate, Metropolitan of
+  Galicia and Archbishop of Lviv in 1901-1944. [W1; U1]
+- **Born / died:** 29 July 1865, Prylbichi; 1 November 1944, Lviv. [W1; U1]
+- **Institution-building:** UGCC history material credits his leadership
+  with making the Greek-Catholic Church a broad, influential institution and
+  names the Lviv Greek-Catholic Theological Academy as a 1928 initiative. [U1]
+- **Soviet/imperial pressure context:** the dossier treats him as a UGCC
+  predecessor under occupation, not as a Soviet prison martyr; the verified
+  detention in the evidence is Russian-imperial wartime imprisonment in
+  1914-1917. [W1; U1]
+
+## 2. Oppression mechanism
+
+- **What happened:** Russian occupation forces arrested and imprisoned him
+  during the First World War; later Soviet and Russian memory politics
+  attacked the UGCC and his wartime record. [W1; U1; U3]
+- **When:** Russian wartime imprisonment is documented as 1914-1917; death is
+  documented as 1 November 1944 in Lviv. [W1; U1]
+- **Mechanism specifics:** he led the UGCC through changing regimes and
+  prepared church continuity by making Josyf Slipyj his successor in the
+  pre-1945 crisis context. [P1; U1]
+- **What survived:** institutions, pastoral letters, the Lviv Theological
+  Academy line, National Museum / cultural patronage work, and the rescue
+  memory around Jewish children and the 1942 pastoral letter `Не убий!`. [U1;
+  U2; P1]
+
+## 3. Major works / institutional legacy
+
+- `1901-1944` — Metropolitan leadership of the UGCC. [W1]
+- `1928` — Lviv Greek-Catholic Theological Academy initiative. [U1]
+- `1942` — pastoral letter `Не убий!`, treated as a key wartime primary text
+  to verify before excerpting in a lesson. [U2]
+- `2019` — Myroslav Marynovych's plan-linked book topic on Sheptytsky is a
+  cross-track bridge already present in the BIO plan ecosystem. [P3]
+
+## 4. Primary-source quotes
+
+**Quote 1 — pastoral anti-violence frame:**
+
+> Не убий!
+
+Tool status: verified as the pastoral-letter title returned by UGCC/Synod
+material. Use only after checking the full source text for lesson excerpts.
+[U2]
+
+**Quote 2 — early episcopal credo:**
+
+> для вас все посвятити
+
+Tool status: verified as a short fragment in the Synod-cited pastoral
+quotation. The full quoted sentence is not reproduced here to avoid expanding
+beyond the verified excerpt needed for the dossier. [U4]
+
+## 5. Language register
+
+- **Register:** ecclesial, pastoral, institutional, and moral-theological
+  Ukrainian. [P1; U1]
+- **CEFR readiness:** C1 for full pastoral-letter work; B2/C1 for a selected
+  biography segment with glossary. [P1]
+- **Lexicon notes:** `митрополит`, `пастир`, `беатифікація`, `екуменізм`,
+  `праведник`, `переховувати`. [P1]
+
+## 6. Contested points
+
+- **Pedagogical risk:** the plan itself flags black-and-white framings around
+  "saint/collaborator/pragmatist"; the dossier should preserve the rescue and
+  anti-violence evidence without flattening the occupation dilemmas. [P1; U2]
+- **Yad Vashem / rescue caution:** the verified Synod evidence says Yad Vashem
+  could consider recognition under stated conditions; this dossier does not
+  claim that Yad Vashem recognized him as Righteous Among the Nations. [U3]
+- **Russian/Soviet disinformation angle:** frame Soviet accusations as a
+  propaganda problem to be checked against Ukrainian and Jewish-source
+  evidence, not repeated as neutral description. [P1; U3]
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `plans/bio/andrey-sheptytsky.yaml` — dedicated BIO plan.
+  - `plans/bio/josyf-slipyj.yaml` — successor and Soviet-persecution link.
+  - `plans/bio/liubomyr-huzar.yaml` — later UGCC head and institutional-memory
+    link.
+  - `plans/bio/myroslav-marynovych.yaml` — Marynovych book/topic bridge.
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `plans/istorio/hreko-katolytska-tserkva.yaml` — source-study bridge for
+    UGCC history.
+  - `plans/istorio/holokost-v-ukraini.yaml` — Holocaust memory/source bridge.
+- **Existing LIT-DOC modules (VERIFIED present via `test -e`):**
+  - `plans/lit-doc/holocaust-testimony-ukrainian.yaml` — documentary witness
+    pairing for Holocaust memory ethics.
+- **Potential (Phase 2+) candidates surfaced by this research:**
+  - A primary-source lesson on selected pastoral letters after the full texts
+    and permissions are checked.
+
+## 8. Naming-canonical
+
+- **Slug:** `andrey-sheptytsky`
+- **UA canonical:** Андрей Шептицький
+- **EN canonical:** Andrey Sheptytsky
+- **Aliases:** Roman Maria Alexander Sheptytsky; Metropolitan Andrey; Андрей
+  (Шептицький).
+- **Forbidden forms:** Russian-shadow spellings should be confined to alias
+  checks if encountered in source metadata; do not normalize the body text
+  through Russian.
+
+## 9. Image candidates
+
+- **Best candidate:** Wikimedia / UGCC historical portrait only after license
+  verification.
+- **Context image:** Lviv St. George Cathedral or National Museum context,
+  again only after license verification.
+- **Sensitivity note:** avoid hagiographic-only visual framing; pair portrait
+  material with source-study context where possible.
+
+## 10. Sources used / tool evidence ledger
+
+**W1 — `mcp__sources.query_wikipedia`, summary/extract, query `Андрей Шептицький`:**
+raw output included `# Андрей (Шептицький)` and
+`предстоятель Української греко-католицької церкви`.
+
+**U1 — `web.open`, official UGCC history page:**
+raw output lines included `1901—1944`, `1914–1917`, and
+`Львівську греко-католицьку богословську академію (1928 р.)`.
+URL: https://ugcc.ua/church/history/metropolitan-andrey-sheptytsky/
+
+**U2 — `web.open`, official UGCC history page:**
+raw output line included `пастирське послання «Не убий!»`.
+URL: https://ugcc.ua/church/history/metropolitan-andrey-sheptytsky/
+
+**U3 — `web.open`, Synod UGCC/Yad Vashem article:**
+raw output included `може розглянути можливість визнання`.
+URL: https://synod.ugcc.ua/data/yad-vashem-poyasnyv-za-yakyh-umov-mozhe-rozglyanuty-mozhlyvist-vyznannya-mytropolyta-sheptytskogo-pravednykom-svitu-2294/
+
+**U4 — `web.open`, Synod UGCC 20-year legalization message:**
+raw output included `для вас все посвятити`.
+URL: https://synod.ugcc.ua/data/synodalne-poslannya-z-nagody-20-littya-legalizatsiy-ugkts-65-littya-z-dnya-smerti-mytropolyta-andreya-sheptytskogo-ta-25-littya-z-dnya-smerti-patriarha-yosyfa-slipogo-192/
+
+**P1 — `sed -n '1,150p' curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml`:**
+raw output included `slug: andrey-sheptytsky`,
+`title: 'Митрополит Андрей Шептицький: Пастир і рятівник'`,
+and `hist-b2-85 (Голокост в Україні)`.
+
+**P3 — `sed -n '1,170p' docs/research/bio/myroslav-marynovych.md`:**
+raw output included `Митрополит Андрей Шептицький і принцип «позитивної суми»`
+and `plans/bio/andrey-sheptytsky.yaml`.
+
+**X1 — `test -e` path verification for §7:**
+raw output included:
+
+```text
+EXISTS curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/myroslav-marynovych.yaml
+EXISTS curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml
+EXISTS curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml
+EXISTS curriculum/l2-uk-en/plans/lit-doc/holocaust-testimony-ukrainian.yaml
+```
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] No Russian-shadow spelling in body text.
+- [x] Yad Vashem recognition not fabricated.
+- [x] Soviet/Russian propaganda labels are treated as propaganda, not neutral
+      biography.
+- [x] All §7 Existing plan paths have raw `test -e` evidence.

--- a/docs/research/bio/josyf-slipyj.md
+++ b/docs/research/bio/josyf-slipyj.md
@@ -1,0 +1,194 @@
+# Йосиф Сліпий — Research Dossier
+
+**Slug:** `josyf-slipyj`
+**Block:** Religious martyrs / UGCC clergy
+**Tier:** 3
+**Issue:** #2309
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-29
+
+**Evidence rule for this dossier:** every factual bullet is keyed to the
+tool evidence ledger in §10. Direct quotations appear only where a tool
+returned the wording.
+
+## 1. Verified facts
+
+- **Full name:** Йосиф Сліпий; birth surname evidence is available in the
+  Ukrainian Wikipedia extract as Kоберницький-Дичковський. [W1]
+- **Identity:** Ukrainian church figure, bishop of the Ukrainian Greek Catholic
+  Church, Catholic cardinal, and UGCC primate / Major Archbishop. [W1; U1]
+- **Born / died:** 17 February 1892, Zazdrist; 7 September 1984, Rome. [W1]
+- **Plan role:** the BIO plan frames him as `Патріарх Йосиф Сліпий:
+  Незламний сповідник віри`, with a C1 seminar focus on 18 years in the Gulag,
+  diaspora leadership, and the patriarchate dispute. [P1]
+- **Dedup status:** no existing `docs/research/bio/josyf-slipyj.md` file was
+  present before this dossier was added. [D1]
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet authorities arrested him on 11 April 1945; an
+  official UGCC history page says a military tribunal sentenced him to eight
+  years of forced labor in Gulag camps. [U1]
+- **Duration:** official UGCC history says he spent 18 years in Soviet prisons,
+  camps, and exile. [U1]
+- **Coercion target:** official UGCC history says Bolshevik investigators tried
+  to make him embrace the Russian official church, and he refused. [U1]
+- **Underground continuity:** official UGCC history says he secretly ordained
+  Vasyl Velychkovsky as bishop on 4 February 1963, maintaining underground
+  church continuity. [U1]
+- **What survived:** the dossier should foreground imprisoned pastoral work,
+  letters to the persecuted church, Roman exile institution-building, and the
+  Ukrainian Catholic University project. [U1; P1]
+
+## 3. Major works / institutional legacy
+
+- `1929` — rector of the Lviv Theological Academy in the plan narrative. [P1]
+- `1945-1963` — Soviet imprisonment / exile period, with pastoral letters and
+  protest petitions documented by official UGCC history. [U1]
+- `1963` — Ukrainian Catholic University in Rome as an exile institution. [U1]
+- `Testament` — official UGCC material presents the Testament as a continuing
+  interpretive key for loyalty, family, school, and church memory. [U2]
+
+## 4. Primary-source quotes
+
+**Quote 1 — motto from pastoral-letter tradition:**
+
+> Великого бажайте!
+
+Tool status: verified by official UGCC material as a phrase from one of
+Slipyj's pastoral letters. [U3]
+
+**Quote 2 — reported first question after release:**
+
+> А чи стала вільною Церква?
+
+Tool status: verified in Synod UGCC material. Because the immediate primary
+document was not retrieved in this pass, treat this as a reported quote and
+not as a manuscript-verified quote. [U4]
+
+## 5. Language register
+
+- **Register:** theological, pastoral, juridical protest, and diaspora
+  institution-building language. [U1; P1]
+- **CEFR readiness:** C1 for full primary texts; B2/C1 for a narrated
+  biography lesson with a repression vocabulary scaffold. [P1]
+- **Lexicon notes:** `патріарх`, `сповідник`, `ГУЛАГ`, `заслання`,
+  `ієрарх`, `беатифікація`, `незламність`, `заповіт`. [P1]
+
+## 6. Contested points
+
+- **Vatican/patriarchate dispute:** the BIO plan explicitly asks students to
+  evaluate the patriarchate conflict rather than treat his position as simple
+  triumphalism. [P1]
+- **Soviet propaganda risk:** the plan identifies the Soviet attempt to
+  liquidate the UGCC and create a collaborator myth around Slipyj as an
+  imperial memory-politics problem. [P1]
+- **Quote caution:** use `Великого бажайте!` and the release question only with
+  their evidence status; do not invent longer Testament excerpts. [U3; U4]
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `plans/bio/josyf-slipyj.yaml` — dedicated BIO plan.
+  - `plans/bio/andrey-sheptytsky.yaml` — predecessor/successor link.
+  - `plans/bio/liubomyr-huzar.yaml` — Slipyj's diaspora and later UGCC
+    continuity link.
+  - `plans/bio/vasyl-stus.yaml` — Soviet imprisonment / witness comparison.
+  - `plans/bio/levko-lukyanenko.yaml` — Soviet prisoner-of-conscience
+    comparison.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `plans/hist/deportatsii-ukraintsiv.yaml` — Soviet coercion/deportation
+    context for western Ukrainian repression.
+  - `plans/hist/ukrainska-helsinska-hrupa.yaml` — later rights-resistance
+    comparison, not a direct Slipyj source.
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `plans/istorio/hreko-katolytska-tserkva.yaml` — source-study bridge for
+    UGCC persecution and memory.
+  - `plans/istorio/syntez-dysydentski-dzherela.yaml` — later dissident-source
+    methodology useful for Soviet accusation analysis.
+- **Potential (Phase 2+) candidates surfaced by this research:**
+  - A primary-source module on Slipyj's `Testament`, after the source text and
+    excerpt permissions are checked.
+
+## 8. Naming-canonical
+
+- **Slug:** `josyf-slipyj`
+- **UA canonical:** Йосиф Сліпий
+- **EN canonical:** Josyf Slipyj
+- **Aliases:** Yosyf Slipy; Йосип Сліпий; Йосиф (Сліпий); birth surname
+  Коберницький-Дичковський.
+- **Forbidden forms:** Russian-shadow spellings should be confined to alias
+  checks if encountered in source metadata; do not normalize the body text
+  through Russian.
+
+## 9. Image candidates
+
+- **Best candidate:** official UGCC case photographs or Wikimedia portrait
+  only after license verification.
+- **Context image:** St. Sophia in Rome or St. George Cathedral crypt only
+  after license verification.
+- **Sensitivity note:** prison/case-file images should not be used as visual
+  spectacle; prefer dignity-preserving institutional context.
+
+## 10. Sources used / tool evidence ledger
+
+**W1 — `mcp__sources.query_wikipedia`, summary/extract, query `Йосиф Сліпий`:**
+raw output included `# Йосиф (Сліпий)`,
+`єпископ Української греко-католицької церкви`, and
+`17 лютого 1892`.
+
+**U1 — `web.open`, official UGCC history page:**
+raw output lines included `April 11, 1945`, `forced labor in Gulag camps`,
+and `spent 18 years`.
+URL: https://ugcc.ua/en/church/history/patriarch-yosyf-slipy/
+
+**U2 — `web.open`, official UGCC Testament presentation:**
+raw output included `The Testament of His Beatitude Patriarch Josyf Slipyj`.
+URL: https://ugcc.ua/en/data/presentation-of-patriarch-josyf-slipyjs-testament-edition-held-in-rome-381/
+
+**U3 — `web.open`, official UGCC article on `Великого бажайте!`:**
+raw output included `вислів патріарха Йосифа Сліпого`.
+URL: https://ugcc.ua/data/velykogo-bazhayte-u-natsionalniy-filarmoniy-vidznachyly-yuviley-mytropolyta-andreya-sheptytskogo-ta-patriarha-yosyfa-slipogo-7914/
+
+**U4 — `web.open`, Synod UGCC Slipyj article:**
+raw output included `А чи стала вільною Церква?`.
+URL: https://synod.ugcc.ua/data/zarady-epyskopa-z-ukrayny-papa-rymskyy-porushyv-protokol-a-kennedi-sperechavsya-z-hrushchovym-zhyttya-yosypa-slipogo-5095/
+
+**P1 — `sed -n '1,145p' curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml`:**
+raw output included `slug: josyf-slipyj`,
+`title: 'Патріарх Йосиф Сліпий: Незламний сповідник віри'`,
+and `18 years in the Gulag`.
+
+**D1 — dedup command:**
+raw output included:
+
+```text
+MISSING docs/research/bio/josyf-slipyj.md
+```
+
+**X1 — `test -e` path verification for §7:**
+raw output included:
+
+```text
+EXISTS curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml
+EXISTS curriculum/l2-uk-en/plans/hist/deportatsii-ukraintsiv.yaml
+EXISTS curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml
+EXISTS curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml
+EXISTS curriculum/l2-uk-en/plans/istorio/syntez-dysydentski-dzherela.yaml
+```
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] Russian official-church coercion is named as Soviet/Russian state
+      pressure, not neutral church history.
+- [x] Direct quotes are limited to tool-returned wording and evidence status
+      is stated.
+- [x] No fabricated §7 paths.
+- [x] No Russian-shadow spelling in body text.

--- a/docs/research/bio/liubomyr-huzar.md
+++ b/docs/research/bio/liubomyr-huzar.md
@@ -1,0 +1,193 @@
+# Любомир Гузар — Research Dossier
+
+**Slug:** `liubomyr-huzar`
+**Block:** Religious martyrs / UGCC clergy
+**Tier:** 3
+**Issue:** #2309
+**Researcher:** Codex GPT-5.5
+**Completed:** 2026-05-29
+
+**Evidence rule for this dossier:** every factual bullet is keyed to the
+tool evidence ledger in §10. Direct quotations appear only where a tool
+returned the wording.
+
+## 1. Verified facts
+
+- **Full name:** Любомир Гузар. [W1]
+- **Identity:** Ukrainian religious figure, priest, bishop, Catholic cardinal,
+  and patriarch-primate / head of the Ukrainian Greek Catholic Church in
+  2001-2011. [W1; U1]
+- **Born / died:** 26 February 1933, Lviv; 31 May 2017, Kyiv. [W1; U1]
+- **UGCC continuity role:** he was consecrated a bishop by Patriarch Josyf
+  Slipyj in 1977 and later became Father and Head of the UGCC. [U1; U2]
+- **Dedup status:** no existing `docs/research/bio/liubomyr-huzar.md` file was
+  present before this dossier was added. [D1]
+
+## 2. Oppression / exile mechanism
+
+- **What happened:** this is an UGCC-clergy continuity dossier, not a martyr
+  dossier; verified evidence says he fled Ukraine with his parents in 1944
+  ahead of the advancing Soviet army and spent formative years in the West.
+  [U1]
+- **Return after Soviet collapse:** official UGCC archive evidence says he
+  returned to his native country when the Soviet Union collapsed in 1991 and
+  moved his monastery to Ukraine in 1993. [U1; U2]
+- **Institutional mechanism:** he helped rebuild the UGCC after legalization,
+  headed the church, and returned the major-archiepiscopal see from Lviv to
+  Kyiv in 2005. [U1; U3]
+- **What survived:** diaspora formation, Studite monastic continuity, UCU /
+  church administration, and a public moral vocabulary around dignity and
+  being human. [U1; U2; U4]
+
+## 3. Major works / institutional legacy
+
+- `1977` — bishop consecration by Patriarch Josyf Slipyj. [U1; U2]
+- `2001-2011` — headship of the UGCC. [W1; U1]
+- `2005` — return of the see of the head of the UGCC from Lviv to Kyiv. [U3]
+- `2009-2011` — audio/book sequence around `The Way to Oneself`, `The Way to
+  One's Neighbour`, and `The Way to God` in UGCC archive evidence. [U2]
+- `2017+` — memory and beatification process evidence after his death. [U5]
+
+## 4. Primary-source quotes
+
+**Quote 1 — moral program:**
+
+> Моє велике бажання - бути людиною
+
+Tool status: verified by UGCC archive material for the 2017 commemorative
+postmark. [U4]
+
+**Quote 2 — church geography:**
+
+> The Greek Catholic Church is not a Western, but an all-Ukrainian reality.
+
+Tool status: verified by official UGCC history page on the 2005 return to
+Kyiv. [U3]
+
+## 5. Language register
+
+- **Register:** pastoral-public, simple philosophical, civic-moral, and
+  ecumenical Ukrainian. [P1; U2; U4]
+- **CEFR readiness:** B2 for selected interviews / audio excerpts; C1 for
+  church-administration debates and ecumenical documents. [P1]
+- **Lexicon notes:** `блаженніший`, `моральний авторитет`, `гідність`,
+  `служіння`, `собор`, `єдність`, `смиренність`. [P1]
+
+## 6. Contested points
+
+- **Not a Soviet-prison martyr:** the verified evidence supports exile and
+  post-Soviet return, not personal Gulag imprisonment; do not retrofit a martyr
+  frame. [U1; P1]
+- **Kyiv transfer debate:** the plan asks whether transferring the UGCC seat to
+  Kyiv was historical restoration or expansion onto contested church territory;
+  teach it as a debate with church, Orthodox, and secular perspectives. [P1;
+  U3]
+- **Public authority risk:** avoid turning "moral authority" into generic
+  inspiration; connect it to specific institutional decisions and public words.
+  [U2; U4]
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `plans/bio/liubomyr-huzar.yaml` — dedicated BIO plan.
+  - `plans/bio/josyf-slipyj.yaml` — consecration / diaspora formation link.
+  - `plans/bio/andrey-sheptytsky.yaml` — dissertation and UGCC institutional
+    continuity link.
+  - `plans/bio/myroslav-marynovych.yaml` — UCU / Christian public-intellectual
+    bridge.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `plans/hist/nezalezhnist-1991.yaml` — post-Soviet return context.
+  - `plans/hist/shliakh-nezalezhnosti.yaml` — independence-era framing.
+- **Existing core / LIT diaspora modules (VERIFIED present via `test -e`):**
+  - `plans/c1/diaspora-ukrainian.yaml` — diaspora language/community bridge.
+  - `plans/c2/zovnishnia-polityka-i-diaspora.yaml` — diaspora public-life
+    extension.
+  - `plans/lit/diaspora-modern-lit.yaml` — broader exile/diaspora cultural
+    context.
+- **Potential (Phase 2+) candidates surfaced by this research:**
+  - A source-based lesson on `Бути людиною` after selecting licensed excerpts.
+
+## 8. Naming-canonical
+
+- **Slug:** `liubomyr-huzar`
+- **UA canonical:** Любомир Гузар
+- **EN canonical:** Liubomyr Huzar
+- **Aliases:** Lubomyr Husar; Любомир (Гузар); His Beatitude Lubomyr.
+- **Forbidden forms:** Russian-shadow spellings should be confined to alias
+  checks if encountered in source metadata; do not normalize the body text
+  through Russian.
+
+## 9. Image candidates
+
+- **Best candidate:** UGCC / UCU portrait only after license verification.
+- **Context image:** Patriarchal Cathedral of the Resurrection of Christ in
+  Kyiv, only after license verification.
+- **Sensitivity note:** use public-teacher / church-leader imagery rather than
+  sentimental saint-card framing.
+
+## 10. Sources used / tool evidence ledger
+
+**W1 — `mcp__sources.query_wikipedia`, summary/extract, query `Любомир Гузар`:**
+raw output included `# Любомир (Гузар)`,
+`патріарх-предстоятель Української греко-католицької церкви`, and
+`26 лютого 1933`.
+
+**U1 — `web.open`, UGCC archive obituary:**
+raw output included `February 26, 1933`, `fled from Ukraine`, and
+`ahead of the advancing Soviet army`.
+URL: https://archives.ugcc.ua/en/news/cardinal_lubomyr_husar_dies_aged_85_79609.html
+
+**U2 — `web.open`, UGCC archive article on Huzar as moral authority:**
+raw output included `ordained a bishop by Patriarch Josyf Slipyj` and
+`returned to his native land`.
+URL: https://archives.ugcc.ua/en/articles/patriarch_lubomyr_husar__a_true_moral_authority_79663.html
+
+**U3 — `web.open`, official UGCC history page on return to Kyiv:**
+raw output included `21 st of August 2005` and
+`all-Ukrainian reality`.
+URL: https://ugcc.ua/en/church/history/return-to-kyiv/
+
+**U4 — `web.open`, UGCC archive postmark item:**
+raw output included `Моє велике бажання - бути людиною`.
+URL: https://archives.ugcc.ua/news/spetspogashennya_lyubomir_guzar_19332017_moie_velike_bazhannya__buti_lyudinoyu_79632.html
+
+**U5 — `web.open`, official UGCC beatification-process item:**
+raw output included `beatification and canonization of Patriarch Lubomyr`.
+URL: https://ugcc.ua/en/data/patriarch-lubomyr-husar-may-soon-become-blessed-head-of-the-ugcc-commences-beatification-process-940/
+
+**P1 — `sed -n '1,135p' curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml`:**
+raw output included `slug: liubomyr-huzar`,
+`title: 'Любомир Гузар: Моральний авторитет нації'`,
+and `Перенесення осідку УГКЦ до Києва`.
+
+**D1 — dedup command:**
+raw output included:
+
+```text
+MISSING docs/research/bio/liubomyr-huzar.md
+```
+
+**X1 — `test -e` path verification for §7:**
+raw output included:
+
+```text
+EXISTS curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml
+EXISTS curriculum/l2-uk-en/plans/bio/myroslav-marynovych.yaml
+EXISTS curriculum/l2-uk-en/plans/hist/nezalezhnist-1991.yaml
+EXISTS curriculum/l2-uk-en/plans/hist/shliakh-nezalezhnosti.yaml
+EXISTS curriculum/l2-uk-en/plans/c1/diaspora-ukrainian.yaml
+EXISTS curriculum/l2-uk-en/plans/c2/zovnishnia-polityka-i-diaspora.yaml
+EXISTS curriculum/l2-uk-en/plans/lit/diaspora-modern-lit.yaml
+```
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] Exile / post-Soviet return is not mislabeled as Gulag martyrdom.
+- [x] Russian-shadow spellings are excluded from body text.
+- [x] Kyiv transfer is preserved as a debate, not flattened.
+- [x] All §7 Existing plan paths have raw `test -e` evidence.


### PR DESCRIPTION
## Summary

Adds three plan-backed BIO research dossiers for #2309 religious-martyrs / UGCC clergy work:

- `docs/research/bio/andrey-sheptytsky.md`
- `docs/research/bio/josyf-slipyj.md`
- `docs/research/bio/liubomyr-huzar.md`

Dedup was checked first. Direct checks before adding files returned:

```text
MISSING docs/research/bio/josyf-slipyj.md
MISSING docs/research/bio/andrey-sheptytsky.md
MISSING docs/research/bio/liubomyr-huzar.md
```

Candidate plan misses were not built:

```text
MISSING curriculum/l2-uk-en/plans/bio/klymentiy-sheptytsky.yaml
MISSING curriculum/l2-uk-en/plans/bio/klimentiy-sheptytsky.yaml
MISSING curriculum/l2-uk-en/plans/bio/mykola-charnetskyi.yaml
MISSING curriculum/l2-uk-en/plans/bio/hryhorii-khomyshyn.yaml
MISSING curriculum/l2-uk-en/plans/bio/vasyl-velychkovskyi.yaml
MISSING curriculum/l2-uk-en/plans/bio/ivan-ziatyk.yaml
MISSING curriculum/l2-uk-en/plans/bio/klymentii-sheptytskyi.yaml
MISSING curriculum/l2-uk-en/plans/bio/klementiy-sheptytsky.yaml
```

Identity checks used `mcp__sources.query_wikipedia` for each built figure.

## Figures + Section 7 path evidence

### Андрей Шептицький

`test -e` raw evidence for every Existing §7 path cited in the dossier:

```text
EXISTS curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml
EXISTS curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml
EXISTS curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
EXISTS curriculum/l2-uk-en/plans/bio/myroslav-marynovych.yaml
EXISTS curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml
EXISTS curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml
EXISTS curriculum/l2-uk-en/plans/lit-doc/holocaust-testimony-ukrainian.yaml
```

### Йосиф Сліпий

`test -e` raw evidence for every Existing §7 path cited in the dossier:

```text
EXISTS curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml
EXISTS curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml
EXISTS curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
EXISTS curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml
EXISTS curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml
EXISTS curriculum/l2-uk-en/plans/hist/deportatsii-ukraintsiv.yaml
EXISTS curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml
EXISTS curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml
EXISTS curriculum/l2-uk-en/plans/istorio/syntez-dysydentski-dzherela.yaml
```

### Любомир Гузар

`test -e` raw evidence for every Existing §7 path cited in the dossier:

```text
EXISTS curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
EXISTS curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml
EXISTS curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml
EXISTS curriculum/l2-uk-en/plans/bio/myroslav-marynovych.yaml
EXISTS curriculum/l2-uk-en/plans/hist/nezalezhnist-1991.yaml
EXISTS curriculum/l2-uk-en/plans/hist/shliakh-nezalezhnosti.yaml
EXISTS curriculum/l2-uk-en/plans/c1/diaspora-ukrainian.yaml
EXISTS curriculum/l2-uk-en/plans/c2/zovnishnia-polityka-i-diaspora.yaml
EXISTS curriculum/l2-uk-en/plans/lit/diaspora-modern-lit.yaml
```

## Validation

```text
.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/andrey-sheptytsky.md docs/research/bio/josyf-slipyj.md docs/research/bio/liubomyr-huzar.md
No fabricated Existing cross-track plan paths found.

.venv/bin/python -m pytest tests/test_lint_bio_dossier_xref.py
3 passed in 0.29s

npx markdownlint-cli2 docs/research/bio/andrey-sheptytsky.md docs/research/bio/josyf-slipyj.md docs/research/bio/liubomyr-huzar.md
Summary: 0 error(s)

.venv/bin/python scripts/audit/lint_agent_trailer.py
All 1 non-skipped commit(s) carry an X-Agent trailer.
```