### PR TITLE
fix(mdx): dedup inline activities and sanitize Resources notes

### DIFF
--- a/scripts/generate_mdx/converters.py
+++ b/scripts/generate_mdx/converters.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import json
 import re
 import sys
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
+from typing import Any
 
 from .dataclasses_ import (
     ComparativeStudyData,
@@ -28,25 +30,63 @@ from manifest_utils import get_module_by_slug
 from yaml_activities import Activity, ActivityParser
 
 
+def _activity_id(activity: Activity) -> str:
+    if isinstance(activity, dict):
+        return str(activity.get('id', '') or '').strip()
+    return str(getattr(activity, 'id', '') or '').strip()
+
+
+def activity_identity_key(activity: Activity) -> str:
+    """Return a stable activity key that ignores optional renderer IDs."""
+    if is_dataclass(activity):
+        payload: Any = asdict(activity)
+    elif isinstance(activity, dict):
+        payload = dict(activity)
+    elif hasattr(activity, '__dict__'):
+        payload = dict(vars(activity))
+    else:
+        payload = repr(activity)
+
+    if isinstance(payload, dict):
+        payload.pop('id', None)
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+
+
 def yaml_activities_to_jsx(
     activities: list[Activity],
     is_ukrainian_forced: bool = False,
     inline_cross_ref_ids: set[str] | None = None,
+    inline_cross_ref_positions: set[int] | None = None,
+    inline_cross_ref_fingerprints: set[str] | None = None,
 ) -> str:
-    """Convert YAML activities to JSX components using the shared ActivityParser."""
+    """Convert YAML activities to JSX components using the shared ActivityParser.
+
+    Activities already injected into the Lesson tab are omitted from the
+    workbook tab. Matching uses ID first, plus the matched list position and a
+    structural fingerprint so idless duplicates do not render in full.
+    """
     parser = ActivityParser()
-    if not inline_cross_ref_ids:
+    inline_ids = {
+        str(activity_id).strip()
+        for activity_id in (inline_cross_ref_ids or set())
+        if str(activity_id).strip()
+    }
+    inline_positions = set(inline_cross_ref_positions or set())
+    inline_fingerprints = set(inline_cross_ref_fingerprints or set())
+    if not (inline_ids or inline_positions or inline_fingerprints):
         return parser.to_mdx(activities, is_ukrainian_forced)
 
     mdx_parts = []
-    cross_ref = "_(дивіться урок)_\n\n" if is_ukrainian_forced else "_(see lesson)_\n\n"
-    for activity in activities:
+    for index, activity in enumerate(activities):
+        if (
+            index in inline_positions
+            or _activity_id(activity) in inline_ids
+            or activity_identity_key(activity) in inline_fingerprints
+        ):
+            continue
         mdx = parser._activity_to_mdx(activity, is_ukrainian_forced)
         if not mdx:
             continue
-        activity_id = str(getattr(activity, 'id', ''))
-        if activity_id in inline_cross_ref_ids:
-            mdx = re.sub(r'^(### .+?\n\n)', rf'\1{cross_ref}', mdx, count=1)
         mdx_parts.append(mdx)
     return '\n\n'.join(mdx_parts)
 

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from .converters import (
+    activity_identity_key,
     convert_bad_form_markers,
     convert_callouts,
     normalize_mdx,
@@ -160,28 +161,33 @@ def _inject_inline_activities(
     body: str,
     yaml_activities: list[Activity] | None,
     is_ukrainian_forced: bool,
-) -> tuple[str, set[str]]:
+) -> tuple[str, set[str], set[int], set[str]]:
     """Replace Tab 1 INJECT_ACTIVITY markers with matching component JSX."""
     if not yaml_activities or "INJECT_ACTIVITY" not in body:
-        return body, set()
+        return body, set(), set(), set()
 
     parser = ActivityParser()
     by_id = {
-        str(getattr(activity, 'id', '')): activity
-        for activity in yaml_activities
+        str(getattr(activity, 'id', '')): (index, activity)
+        for index, activity in enumerate(yaml_activities)
         if getattr(activity, 'id', '')
     }
     injected_ids: set[str] = set()
+    injected_positions: set[int] = set()
+    injected_fingerprints: set[str] = set()
 
     def replace_marker(match: re.Match[str]) -> str:
         activity_id = match.group(1)
-        activity = by_id.get(activity_id)
-        if activity is None:
+        matched = by_id.get(activity_id)
+        if matched is None:
             raise ValueError(f"Unresolved INJECT_ACTIVITY id: {activity_id}")
+        index, activity = matched
         injected_ids.add(activity_id)
+        injected_positions.add(index)
+        injected_fingerprints.add(activity_identity_key(activity))
         return parser._activity_to_mdx(activity, is_ukrainian_forced)
 
-    return _INJECT_ACTIVITY_RE.sub(replace_marker, body), injected_ids
+    return _INJECT_ACTIVITY_RE.sub(replace_marker, body), injected_ids, injected_positions, injected_fingerprints
 
 
 def generate_mdx(
@@ -320,7 +326,12 @@ sidebar:
     # --- TAB 1: Lesson (prose only) ---
     lesson_content = body
     lesson_content = embed_youtube_video_links(lesson_content)
-    lesson_content, injected_activity_ids = _inject_inline_activities(
+    (
+        lesson_content,
+        injected_activity_ids,
+        injected_activity_positions,
+        injected_activity_fingerprints,
+    ) = _inject_inline_activities(
         lesson_content,
         yaml_activities,
         is_ukrainian_forced,
@@ -338,19 +349,21 @@ sidebar:
 
     # --- TAB 3: Activities ---
     tab3_activities = list(yaml_activities or [])
+    no_workbook_msg = (
+        "Немає окремих вправ у робочому зошиті; дивіться вкладку «Урок»."
+        if is_ukrainian_forced
+        else "No workbook activities for this module; see the Lesson tab."
+    )
     if tab3_activities:
         activities_content = yaml_activities_to_jsx(
             tab3_activities,
             is_ukrainian_forced,
             inline_cross_ref_ids=injected_activity_ids,
+            inline_cross_ref_positions=injected_activity_positions,
+            inline_cross_ref_fingerprints=injected_activity_fingerprints,
         )
-    elif yaml_activities and injected_activity_ids:
-        no_workbook_msg = (
-            "Немає окремих вправ у робочому зошиті; дивіться вкладку «Урок»."
-            if is_ukrainian_forced
-            else "No workbook activities for this module; see the Lesson tab."
-        )
-        activities_content = f"*{no_workbook_msg}*"
+        if not activities_content.strip() and injected_activity_ids:
+            activities_content = f"*{no_workbook_msg}*"
     elif activity_plans:
         activities_content = _activity_plans_to_jsx(activity_plans)
     else:

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -273,6 +273,10 @@ _PIPELINE_METADATA_LINE_RE = re.compile(
 _PIPELINE_METADATA_FRAGMENT_RE = re.compile(
     r"\([^)]*\b(?:packet_)?chunk_id\b[^)]*\)"
     r"|\([^)]*\b(?:wiki|vesum)_query_id\b[^)]*\)"
+    r"|^\s*Plan reference;?\s*"
+    r"|\bUsed\s+(?:only\s+)?as\s+grounding[^.]*\.?"
+    r"|\bNo\s+Grade\s+\d+\s+blockquote\s+surfaced\b[^.]*\.?"
+    r"|\bsurfaced\s+in\s+module\.md\b"
     r"|\bknowledge packet anchor\s+[A-Za-z0-9_-]+\s*:?"
     r"|\b(?:packet_)?chunk_id\s*[:=]\s*[\w./:-]+"
     r"|\b(?:wiki|vesum)_query_id\s*[:=]\s*[\w./:-]+",

--- a/tests/test_assemble_mdx_v7.py
+++ b/tests/test_assemble_mdx_v7.py
@@ -127,17 +127,17 @@ references:
     lesson_tab = _tab_item(mdx, "Lesson")
     activities_tab = _tab_item(mdx, "Activities")
     assert len(_ACTIVITY_COMPONENT_RE.findall(lesson_tab)) == 2
-    assert len(_ACTIVITY_COMPONENT_RE.findall(activities_tab)) == 5
+    assert len(_ACTIVITY_COMPONENT_RE.findall(activities_tab)) == 3
     assert "<Observe" in lesson_tab
     assert "<TrueFalse" in lesson_tab
-    assert "<Observe" in activities_tab
-    assert "<TrueFalse" in activities_tab
     assert "<Order" in activities_tab
     assert "<MatchUp" in activities_tab
     assert "<FillIn" in activities_tab
-    assert "Inline observe" in activities_tab
-    assert "Inline true false" in activities_tab
-    assert activities_tab.count("*(see lesson)*") == 2
+    assert "<Observe" not in activities_tab
+    assert "<TrueFalse" not in activities_tab
+    assert "Inline observe" not in activities_tab
+    assert "Inline true false" not in activities_tab
+    assert "*(see lesson)*" not in activities_tab
     assert "INJECT_ACTIVITY" not in mdx
     assert "by Unknown" not in mdx
     assert "Караман" in mdx

--- a/tests/test_generate_mdx.py
+++ b/tests/test_generate_mdx.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from generate_mdx import (
@@ -148,7 +150,7 @@ class TestParseFrontmatter:
         assert body.strip() == "Body"
 
 
-def test_v7_tab3_inline_and_aggregate_keeps_inline_activities_with_cross_refs(tmp_path):
+def test_v7_tab3_omits_inline_activities_and_keeps_workbook_only(tmp_path):
     activities_yaml = tmp_path / "activities.yaml"
     activities_yaml.write_text(
         """
@@ -211,13 +213,134 @@ Practice there.
     assert "act-1 inline greeting" in lesson_tab
     assert "act-2 inline thanks" in lesson_tab
 
-    for activity_id in ("act-1", "act-2", "act-3", "act-4"):
-        assert activity_id in tab3
-
-    assert "### act-1 inline greeting\n\n*(see lesson)*" in tab3
-    assert "### act-2 inline thanks\n\n*(see lesson)*" in tab3
+    assert "act-1 inline greeting" not in tab3
+    assert "act-2 inline thanks" not in tab3
     assert "### act-3 workbook yes\n\n<Quiz" in tab3
     assert "### act-4 workbook no\n\n<Quiz" in tab3
+    assert "*(see lesson)*" not in tab3
+    assert tab3.count("<Quiz") == 2
+
+
+def test_v7_tab3_omits_missing_id_duplicate_of_inline_activity(tmp_path):
+    activities_yaml = tmp_path / "activities.yaml"
+    activities_yaml.write_text(
+        """
+- id: act-1
+  type: fill-in
+  title: Inline fill duplicate
+  items:
+    - sentence: Я ___ о сьомій.
+      answer: прокидаюся
+      options: [прокидаюся, снідаю]
+- type: fill-in
+  title: Inline fill duplicate
+  items:
+    - sentence: Я ___ о сьомій.
+      answer: прокидаюся
+      options: [прокидаюся, снідаю]
+- id: act-2
+  type: quiz
+  title: Workbook-only quiz
+  items:
+    - question: Choose breakfast.
+      options: [сніданок, ранок]
+      answer: сніданок
+""",
+        encoding="utf-8",
+    )
+    activities = ActivityParser().parse(activities_yaml)
+    md_content = """---
+title: Missing ID Duplicate
+subtitle: Test
+---
+# Missing ID Duplicate
+
+Practice here.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+"""
+
+    mdx = generate_mdx(md_content, 1, yaml_activities=activities, level="a1")
+    lesson_tab = mdx.split('<TabItem label="Vocabulary">')[0]
+    tab3 = mdx.split('<TabItem label="Activities">', 1)[1].split("</TabItem>", 1)[0]
+
+    assert "Inline fill duplicate" in lesson_tab
+    assert "<FillIn" in lesson_tab
+    assert "Inline fill duplicate" not in tab3
+    assert "<FillIn" not in tab3
+    assert "Workbook-only quiz" in tab3
+    assert "<Quiz" in tab3
+
+
+def test_v7_tab3_all_inline_activities_renders_workbook_empty_state(tmp_path):
+    activities_yaml = tmp_path / "activities.yaml"
+    activities_yaml.write_text(
+        """
+- id: act-1
+  type: quiz
+  title: Inline one
+  items:
+    - question: Choose hello.
+      options: [привіт, дякую]
+      answer: привіт
+- id: act-2
+  type: quiz
+  title: Inline two
+  items:
+    - question: Choose thanks.
+      options: [привіт, дякую]
+      answer: дякую
+""",
+        encoding="utf-8",
+    )
+    activities = ActivityParser().parse(activities_yaml)
+    md_content = """---
+title: All Inline
+subtitle: Test
+---
+# All Inline
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+<!-- INJECT_ACTIVITY: act-2 -->
+"""
+
+    mdx = generate_mdx(md_content, 1, yaml_activities=activities, level="a1")
+    tab3 = mdx.split('<TabItem label="Activities">', 1)[1].split("</TabItem>", 1)[0]
+
+    assert "No workbook activities for this module; see the Lesson tab." in tab3
+    assert "Inline one" not in tab3
+    assert "Inline two" not in tab3
+    assert "<Quiz" not in tab3
+    assert "*(see lesson)*" not in tab3
+
+
+def test_v7_inline_activity_missing_id_reference_fails_loudly(tmp_path):
+    activities_yaml = tmp_path / "activities.yaml"
+    activities_yaml.write_text(
+        """
+- id: act-1
+  type: quiz
+  title: Existing activity
+  items:
+    - question: Choose hello.
+      options: [привіт, дякую]
+      answer: привіт
+""",
+        encoding="utf-8",
+    )
+    activities = ActivityParser().parse(activities_yaml)
+    md_content = """---
+title: Broken Marker
+subtitle: Test
+---
+# Broken Marker
+
+<!-- INJECT_ACTIVITY: act-404 -->
+"""
+
+    with pytest.raises(ValueError, match="Unresolved INJECT_ACTIVITY id: act-404"):
+        generate_mdx(md_content, 1, yaml_activities=activities, level="a1")
 
 
 # =============================================================================

--- a/tests/test_generate_mdx_v7_resources_vocab.py
+++ b/tests/test_generate_mdx_v7_resources_vocab.py
@@ -148,3 +148,29 @@ def test_format_resources_for_mdx_strips_pipeline_metadata_from_public_text():
     assert "writer telemetry" not in mdx
     assert "wiki_query_id" not in mdx
     assert "vesum_query_id" not in mdx
+
+
+def test_format_resources_for_mdx_strips_build_speak_notes_from_public_text():
+    resources = [
+        {
+            "title": "Morning routine article",
+            "url": "https://example.com/morning",
+            "notes": (
+                "Plan reference; Used only as grounding for a simple daily plan. "
+                "No Grade 1 blockquote surfaced in module.md. "
+                "chunk_id:abc123 surfaced in module.md"
+            ),
+            "role": "article",
+        },
+    ]
+
+    for is_ukrainian_forced in (False, True):
+        mdx = format_resources_for_mdx(resources, is_ukrainian_forced=is_ukrainian_forced)
+
+        assert "[Morning routine article](https://example.com/morning)" in mdx
+        assert "> - 📄 [Morning routine article](https://example.com/morning)" in mdx
+        assert "Plan reference" not in mdx
+        assert "Used only as grounding" not in mdx
+        assert "No Grade 1 blockquote surfaced" not in mdx
+        assert "surfaced in module.md" not in mdx
+        assert "chunk_id" not in mdx


### PR DESCRIPTION
## Summary

Fixes #2424.

- Activities tab now omits activities already injected into the Lesson tab via `INJECT_ACTIVITY` markers instead of rendering duplicate full components or orphan `(see lesson)` stubs.
- Inline activity suppression matches by ID, matched list position, and structural fingerprint so missing-ID duplicates are still suppressed without changing Lesson-tab injection behavior.
- Resources rendering now strips learner-facing build-speak notes such as `Plan reference`, `Used as grounding`, `No Grade N blockquote surfaced`, `surfaced in module.md`, and `chunk_id` fragments; if notes sanitize to empty, the title/link renders alone.

## Test evidence

```text
=== 866 passed, 10 skipped, 7694 deselected, 1 xfailed, 3 warnings in 29.62s ===
All checks passed!
f8fed75c36 fix(mdx): dedup inline activities in Activities tab + sanitize Resources notes
```

## Review

- Gemini plan review completed for #2424; implementation incorporated the empty-state and invalid-marker test gaps.
- Gemini implementation review found zero blockers and no test gaps.