### PR TITLE
feat(a1): wire ULP immersion into V7 harness — UK-first rule, deterministic stress, ulp_fidelity gate

### DIFF
--- a/scripts/audit/ulp_fidelity_gate.py
+++ b/scripts/audit/ulp_fidelity_gate.py
@@ -1,0 +1,344 @@
+"""Deterministic ULP S1 fidelity gate for A1/A2 core modules.
+
+The gate checks the final post-processed ``module.md`` for Anna Ohoiko-style
+Ukrainian-first immersion: stress marks, em-dash glosses, canonical
+``DialogueBox uk/en`` turns, Ukrainian-first section openers, and the advisory
+UK:EN ratio from the shared immersion policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.config import get_immersion_policy, get_immersion_range
+
+STRESS_MARK = "\u0301"
+STRESS_COVERAGE_MIN = 0.95
+GLOSS_TOKEN_WINDOW = 8
+
+_UK_BASE_CLASS = "А-ЯҐЄІЇа-яґєії"
+_UK_LETTER_CLASS = f"{_UK_BASE_CLASS}\u0301"
+_UK_WORD_RE = re.compile(
+    rf"(?<![{_UK_LETTER_CLASS}])"
+    rf"([{_UK_BASE_CLASS}][{_UK_LETTER_CLASS}]*(?:[ʼ'][{_UK_BASE_CLASS}][{_UK_LETTER_CLASS}]*)*)"
+    rf"(?![{_UK_LETTER_CLASS}])"
+)
+_WORD_RE = re.compile(
+    r"[A-Za-zА-ЯҐЄІЇа-яґєії][A-Za-zА-ЯҐЄІЇа-яґєіїʼ'\u0301-]*"
+)
+_LATIN_RE = re.compile(r"[A-Za-z]")
+_VOWELS = set("аеиіїоуюяєАЕИІЇОУЮЯЄ")
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+_URL_RE = re.compile(r"https?://\S+")
+_JSX_BLOCK_RE = re.compile(
+    r"<[A-Z][A-Za-z0-9]*(?:[^<]|<(?![A-Z/]))*?(?:/>|</[A-Z][A-Za-z0-9]*>)",
+    re.DOTALL,
+)
+_DIALOGUEBOX_RE = re.compile(
+    r"<DialogueBox\b(?:[^<]|<(?![A-Z/]))*?(?:/>|</DialogueBox>)",
+    re.DOTALL,
+)
+_ATTR_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\"([^\"]*)\"", re.DOTALL)
+_HEADING_RE = re.compile(r"^(#{2,3})\s+(.+?)\s*$", re.MULTILINE)
+_TAB_BOUNDARY_RE = re.compile(r"<!--\s*TAB:(?:Словник|Вправи|Ресурси)\s*-->", re.IGNORECASE)
+_STRUCTURAL_LINE_RE = re.compile(r"^\s*(?:\||>|[-*+]\s|\d+\.\s|:::|```|<!--|<)")
+_LECTURE_OPENER_PATTERNS = (
+    re.compile(r"^In this (?:section|module|lesson)\b", re.IGNORECASE),
+    re.compile(r"^This (?:section|module|lesson)\b", re.IGNORECASE),
+    re.compile(r"^Your .{0,60}\bneeds?\b", re.IGNORECASE),
+    re.compile(r"^A good A[12]\b", re.IGNORECASE),
+    re.compile(r"^The student must learn\b", re.IGNORECASE),
+    re.compile(r"^To (?:build|make|tell|use|form)\b.{0,80}\byou need\b", re.IGNORECASE),
+    re.compile(r"^(?:Before|Now that)\b.{0,80}\byou\b", re.IGNORECASE),
+)
+
+
+def _strip_stress(text: str) -> str:
+    return text.replace(STRESS_MARK, "")
+
+
+def _count_syllables(word: str) -> int:
+    return sum(1 for char in _strip_stress(word) if char in _VOWELS)
+
+
+def _basic_clean(text: str) -> str:
+    text = _COMMENT_RE.sub(" ", text)
+    text = _FENCED_CODE_RE.sub(" ", text)
+    text = _INLINE_CODE_RE.sub(" ", text)
+    return _URL_RE.sub(" ", text)
+
+
+def _attr_map(block: str) -> dict[str, str]:
+    return {match.group(1): match.group(2) for match in _ATTR_RE.finditer(block)}
+
+
+def _learner_facing_text(text: str, *, include_all_jsx_strings: bool) -> str:
+    clean = _basic_clean(text)
+    jsx_values: list[str] = []
+    for block in _JSX_BLOCK_RE.findall(clean):
+        attrs = _attr_map(block)
+        if include_all_jsx_strings:
+            jsx_values.extend(attrs.values())
+        else:
+            uk = attrs.get("uk")
+            if uk:
+                jsx_values.append(uk)
+    outside_jsx = _JSX_BLOCK_RE.sub(" ", clean)
+    return "\n".join([outside_jsx, *jsx_values])
+
+
+def _stress_coverage_check(text: str) -> dict[str, Any]:
+    scan_text = _learner_facing_text(text, include_all_jsx_strings=False)
+    words = [
+        match.group(1)
+        for match in _UK_WORD_RE.finditer(scan_text)
+        if _count_syllables(match.group(1)) >= 2
+    ]
+    stressed = [word for word in words if STRESS_MARK in word]
+    pct = round(len(stressed) / len(words), 4) if words else 0.0
+    passed = bool(words) and pct >= STRESS_COVERAGE_MIN
+    return {
+        "passed": passed,
+        "multi_syllable_uk_words": len(words),
+        "stressed_multi_syllable_uk_words": len(stressed),
+        "coverage": pct,
+        "min_coverage": STRESS_COVERAGE_MIN,
+        "missing_examples": [_strip_stress(word) for word in words if STRESS_MARK not in word][:10],
+    }
+
+
+def _token_window_after(text: str, start: int, *, max_tokens: int) -> str:
+    matches = list(_WORD_RE.finditer(text[start:]))
+    if len(matches) <= max_tokens:
+        return text[start:]
+    return text[start : start + matches[max_tokens].start()]
+
+
+def _is_english_narration_line(line: str) -> bool:
+    tokens = _WORD_RE.findall(line)
+    if not tokens:
+        return False
+    if _UK_WORD_RE.search(tokens[0]):
+        return False
+    uk_count = sum(1 for token in tokens if _UK_WORD_RE.search(token))
+    latin_count = sum(1 for token in tokens if _LATIN_RE.search(token))
+    return latin_count > 0 and uk_count > 0 and latin_count >= uk_count
+
+
+def _em_dash_gloss_check(text: str) -> dict[str, Any]:
+    body = _JSX_BLOCK_RE.sub(" ", _basic_clean(text))
+    checked: list[dict[str, Any]] = []
+    violations: list[dict[str, Any]] = []
+    for line_no, raw_line in enumerate(body.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or _STRUCTURAL_LINE_RE.match(line):
+            continue
+        if not _is_english_narration_line(line):
+            continue
+        for match in _UK_WORD_RE.finditer(line):
+            word = match.group(1)
+            if _count_syllables(word) < 2:
+                continue
+            window = _token_window_after(line, match.end(1), max_tokens=GLOSS_TOKEN_WINDOW)
+            has_gloss = "—" in window and _LATIN_RE.search(window.split("—", 1)[1])
+            record = {"line": line_no, "term": word, "window": window.strip()[:120]}
+            checked.append(record)
+            if not has_gloss:
+                violations.append(record)
+    return {
+        "passed": not violations,
+        "checked_terms": len(checked),
+        "violations": violations[:10],
+        "token_window": GLOSS_TOKEN_WINDOW,
+    }
+
+
+def _tab1_text(text: str) -> str:
+    match = _TAB_BOUNDARY_RE.search(text)
+    return text[: match.start()] if match else text
+
+
+def _dialoguebox_check(text: str) -> dict[str, Any]:
+    tab1 = _tab1_text(text)
+    blocks = _DIALOGUEBOX_RE.findall(tab1)
+    canonical = 0
+    violations: list[dict[str, Any]] = []
+    for index, block in enumerate(blocks, start=1):
+        attrs = _attr_map(block)
+        uk = attrs.get("uk", "")
+        reasons: list[str] = []
+        if "uk" not in attrs:
+            reasons.append("missing_uk_attr")
+        if "en" not in attrs:
+            reasons.append("missing_en_attr")
+        if not block.strip().endswith("/>"):
+            reasons.append("not_self_closing")
+        if not uk or not _UK_WORD_RE.search(uk):
+            reasons.append("uk_attr_has_no_ukrainian")
+        if uk and _LATIN_RE.search(uk):
+            reasons.append("uk_attr_contains_english")
+        if "text" in attrs or "lines" in block:
+            reasons.append("legacy_dialogue_shape")
+        if reasons:
+            violations.append({"index": index, "reasons": reasons, "preview": block[:160]})
+        else:
+            canonical += 1
+
+    passed = canonical > 0 and not violations
+    return {
+        "passed": passed,
+        "canonical_dialoguebox_count": canonical,
+        "dialoguebox_count": len(blocks),
+        "violations": violations,
+        "reason": None if passed else "dialoguebox_uk_en_required",
+    }
+
+
+def _first_content_line_after(text: str, offset: int) -> tuple[int, str] | None:
+    suffix = text[offset:]
+    for relative_index, line in enumerate(suffix.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or _STRUCTURAL_LINE_RE.match(stripped):
+            continue
+        line_no = text[:offset].count("\n") + relative_index
+        return line_no, stripped
+    return None
+
+
+def _section_opener_check(text: str) -> dict[str, Any]:
+    tab1 = _tab1_text(_basic_clean(text))
+    violations: list[dict[str, Any]] = []
+    checked = 0
+    for match in _HEADING_RE.finditer(tab1):
+        opener = _first_content_line_after(tab1, match.end())
+        if opener is None:
+            continue
+        line_no, line = opener
+        checked += 1
+        first_tokens = _WORD_RE.findall(line)[:8]
+        first_slice = " ".join(first_tokens)
+        all_english_start = bool(first_tokens) and _LATIN_RE.search(first_slice) and not _UK_WORD_RE.search(first_slice)
+        lecture_pattern = next((pattern.pattern for pattern in _LECTURE_OPENER_PATTERNS if pattern.search(line)), None)
+        if all_english_start or lecture_pattern is not None:
+            violations.append(
+                {
+                    "heading": match.group(2).strip(),
+                    "line": line_no,
+                    "opener": line[:180],
+                    "reason": "lecture_opener" if lecture_pattern else "all_english_opener",
+                    "pattern": lecture_pattern,
+                }
+            )
+    return {
+        "passed": not violations,
+        "checked_openers": checked,
+        "violations": violations[:10],
+    }
+
+
+def _ratio_check(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    level = str(plan.get("level") or "").lower()
+    sequence = int(plan.get("sequence") or 0)
+    min_pct, max_pct = get_immersion_range(level, sequence)
+    counted_text = _learner_facing_text(text, include_all_jsx_strings=True)
+    tokens = _WORD_RE.findall(counted_text)
+    uk_tokens = [token for token in tokens if _UK_WORD_RE.search(token)]
+    pct = round((len(uk_tokens) / len(tokens) * 100), 2) if tokens else 0.0
+    return {
+        "passed": min_pct <= pct <= max_pct,
+        "pct": pct,
+        "min_pct": min_pct,
+        "max_pct": max_pct,
+        "uk_tokens": len(uk_tokens),
+        "total_tokens": len(tokens),
+        "policy": get_immersion_policy(level, sequence)["key"],
+    }
+
+
+def _applies(plan: Mapping[str, Any], profile: str | None) -> bool:
+    level = str(plan.get("level") or "").lower()
+    if level not in {"a1", "a2"}:
+        return False
+    return profile in {None, "", "core"}
+
+
+def check_ulp_fidelity(
+    module_text: str,
+    plan: Mapping[str, Any],
+    *,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic PASS/REVISE report for ULP fidelity."""
+    level = str(plan.get("level") or "").lower()
+    sequence = int(plan.get("sequence") or 0)
+    if not _applies(plan, profile):
+        return {
+            "passed": True,
+            "verdict": "SKIP",
+            "level": level,
+            "sequence": sequence,
+            "profile": profile,
+            "reason": "ulp_fidelity applies only to a1/a2 core",
+            "checks": {},
+        }
+
+    checks = {
+        "stress_coverage": _stress_coverage_check(module_text),
+        "em_dash_gloss": _em_dash_gloss_check(module_text),
+        "dialoguebox_uk_en": _dialoguebox_check(module_text),
+        "section_openers": _section_opener_check(module_text),
+        "uk_en_ratio": _ratio_check(module_text, plan),
+    }
+    failed = [name for name, check in checks.items() if check.get("passed") is not True]
+    return {
+        "passed": not failed,
+        "verdict": "PASS" if not failed else "REVISE",
+        "level": level,
+        "sequence": sequence,
+        "slug": str(plan.get("slug") or ""),
+        "profile": profile or "core",
+        "policy": get_immersion_policy(level, sequence)["key"],
+        "failed_checks": failed,
+        "checks": checks,
+    }
+
+
+def check_ulp_fidelity_paths(
+    module_path: Path,
+    plan_path: Path,
+    *,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    plan_data = yaml.safe_load(plan_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(plan_data, Mapping):
+        raise TypeError(f"plan must be a mapping: {plan_path}")
+    return check_ulp_fidelity(
+        module_path.read_text(encoding="utf-8"),
+        plan_data,
+        profile=profile,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the ULP fidelity gate.")
+    parser.add_argument("module", type=Path, help="Path to final module.md")
+    parser.add_argument("plan", type=Path, help="Path to plan YAML")
+    parser.add_argument("--profile", default=None, help="Curriculum profile, e.g. core")
+    args = parser.parse_args(argv)
+
+    report = check_ulp_fidelity_paths(args.module, args.plan, profile=args.profile)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report.get("passed") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/ulp_fidelity_gate.py
+++ b/scripts/audit/ulp_fidelity_gate.py
@@ -23,6 +23,15 @@ STRESS_MARK = "\u0301"
 STRESS_COVERAGE_MIN = 0.95
 GLOSS_TOKEN_WINDOW = 8
 
+# Terminal ULP checks are deterministic teaching *behaviours* (structural, binary):
+# a genuine ULP lesson either has stress marks, em-dash glosses, UK-only dialogue
+# boxes, and Ukrainian-first openers \u2014 or it does not. uk_en_ratio is deliberately
+# excluded: it is a continuous, context-dependent signal and is ADVISORY only, so a
+# real ULP lesson that lands a few points outside the immersion band is surfaced as
+# a warning, never false-REVISE'd. (Ratio-as-hard-gate is the mechanics-over-teaching
+# trap this whole harness fix removes \u2014 2026-05-30 ULP-harness decision.)
+_TERMINAL_CHECKS = ("stress_coverage", "em_dash_gloss", "dialoguebox_uk_en", "section_openers")
+
 _UK_BASE_CLASS = "А-ЯҐЄІЇа-яґєії"
 _UK_LETTER_CLASS = f"{_UK_BASE_CLASS}\u0301"
 _UK_WORD_RE = re.compile(
@@ -288,6 +297,8 @@ def check_ulp_fidelity(
             "sequence": sequence,
             "profile": profile,
             "reason": "ulp_fidelity applies only to a1/a2 core",
+            "failed_checks": [],
+            "warnings": [],
             "checks": {},
         }
 
@@ -298,7 +309,14 @@ def check_ulp_fidelity(
         "section_openers": _section_opener_check(module_text),
         "uk_en_ratio": _ratio_check(module_text, plan),
     }
-    failed = [name for name, check in checks.items() if check.get("passed") is not True]
+    # Only the deterministic structural checks are terminal. uk_en_ratio is
+    # advisory: it surfaces as a warning but never drives the REVISE verdict.
+    failed = [name for name in _TERMINAL_CHECKS if checks[name].get("passed") is not True]
+    warnings = [
+        name
+        for name, check in checks.items()
+        if name not in _TERMINAL_CHECKS and check.get("passed") is not True
+    ]
     return {
         "passed": not failed,
         "verdict": "PASS" if not failed else "REVISE",
@@ -308,6 +326,7 @@ def check_ulp_fidelity(
         "profile": profile or "core",
         "policy": get_immersion_policy(level, sequence)["key"],
         "failed_checks": failed,
+        "warnings": warnings,
         "checks": checks,
     }
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3873,6 +3873,38 @@ def write_writer_artifacts(module_dir: Path, artifacts: Mapping[str, str]) -> No
         emit_event("writer_negative_example_unmarkered", **fields)
 
 
+def run_stress_annotation(module_dir: Path) -> dict[str, Any]:
+    """Deterministically add Ukrainian stress marks to writer artifacts."""
+    from scripts.pipeline.stress_annotator import annotate_file
+
+    targets = ("module.md", "vocabulary.yaml")
+    counts: dict[str, int] = {}
+    for target in targets:
+        path = module_dir / target
+        _read_required(path)
+        counts[target] = annotate_file(path)
+    return {
+        "passed": True,
+        "phase": "stress_annotation",
+        "files": counts,
+        "total_added": sum(counts.values()),
+    }
+
+
+def run_ulp_fidelity_gate(
+    module_dir: Path,
+    plan_path: Path,
+    *,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Run the deterministic ULP fidelity gate on final post-stress module.md."""
+    from scripts.audit.ulp_fidelity_gate import check_ulp_fidelity
+
+    plan = plan_check(plan_path)
+    module_text = _read_required(module_dir / "module.md")
+    return check_ulp_fidelity(module_text, plan, profile=profile)
+
+
 def run_wiki_coverage_gate(
     *,
     manifest: Mapping[str, Any] | str | Path,

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -130,11 +130,14 @@ For `{DIM}` specifically:
     The module must have one teacher voice across the whole module: warm,
     clear, direct ("you" / "your"). REJECT third-person framing of the
     learner (`the student`, `студента`, `the reader`, `учня`).
-  - Mirrors `#R-AUDIENCE-LANGUAGE-A1`: REJECT Ukrainian metalanguage TO the
-    A1 learner (`Контролюй чистоту словника`, `Рішуче відкидай`,
-    `Запам'ятай...`). A1 explanation prose stays in English. Ukrainian
-    appears only as TARGET: inline vocabulary words with English glosses,
-    dialogue boxes, tables, conjugations, model sentences.
+  - Mirrors `#R-AUDIENCE-LANGUAGE-A1`: REJECT grammar-translation lectures
+    at A1/A2. The module must teach Ukrainian through Ukrainian with English
+    as a receding scaffold: Ukrainian term first, em-dash gloss after
+    (`прокидаюся — I wake up`), `<DialogueBox uk="..." en="..." />` with a
+    Ukrainian-only `uk` turn, Ukrainian-only comprehension/recall content, a
+    named persona or named characters, and no foreigner-textbook anti-patterns
+    such as transliteration tables, "X sounds like Y in English", "the student
+    must learn", or English topic-sentence openers.
 
 A dim score that re-states what a deterministic gate already enforced is a
 reviewer-protocol failure. Cite something the gate cannot see.

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -23,16 +23,16 @@ Produce exactly four artifacts: `module.md`, `activities.yaml`, `vocabulary.yaml
 
 ## V7.1 Renderer Charter — read this FIRST (#R-RENDERER-CHARTER)
 
-You are a RENDERER, not a composer. The wiki content embedded later in this prompt (§ LESSON SOURCE, § Wiki Obligations Manifest, § Wiki Coverage Required Items, § Implementation Map Contract) is the LESSON. Your job is to translate that wiki content into the four artifacts using English (A1/A2) or Ukrainian (B1+) teacher voice. You DO NOT invent vocabulary, examples, citations, dialogue lines, phonetic rules, decolonization stances, or grammar claims that are not derivable from the wiki + plan + cited RAG chunks.
+You are a RENDERER, not a composer. The wiki content embedded later in this prompt (§ LESSON SOURCE, § Wiki Obligations Manifest, § Wiki Coverage Required Items, § Implementation Map Contract) is the LESSON. Your job is to translate that wiki content into the four artifacts using Ukrainian-first ULP immersion (A1/A2) or Ukrainian teacher voice (B1+). You DO NOT invent vocabulary, examples, citations, dialogue lines, phonetic rules, decolonization stances, or grammar claims that are not derivable from the wiki + plan + cited RAG chunks.
 
 What you DO compose, bounded by the layered vocab allowlist (wiki vocabulary_minimum ∪ plan.targets.new_vocabulary ∪ plan.targets.vocabulary_hints ∪ cumulative_learner_state.taught_lemmas ∪ closed_class_function_words ∪ proper_nouns_in_wiki_examples ∪ bad_form_markers ∪ quoted_evidence_from_cited_RAG_chunks):
 
-1. **English glosses** for Ukrainian words (A1/A2). Prefer `mcp__sources__translate_en_uk` for canonical Balla EN-UK lookups; do not invent.
+1. **English scaffold glosses** for Ukrainian words (A1/A2). Use Ukrainian-first em-dash order (`прокидаюся — I wake up`). Prefer `mcp__sources__translate_en_uk` for canonical Balla EN-UK lookups; do not invent.
 2. **Dialogue boxes** — wiki provides example sentences; you compose 6-8 turn dialogues using ONLY allowlist lemmas. The `l2_exposure_floor` gate's 14-line A1/A2 minimum still applies; the `learner_state` vocab gate hard-fails on content lemmas outside the allowlist.
 3. **Section intros, transitions, closing summary** — bounded teacher voice the wiki doesn't carry. Subject to `#R-VOICE-META` forbidden patterns.
 4. **Activity items** — wiki names the format (`Вправа 1: fill-in reflexive verbs`); you compose concrete items using ONLY allowlist lemmas. See `#R-ACTIVITY-COMPOSITION` below.
 
-Voice rewrite, NOT translation: rewrite 3rd-person methodological Ukrainian wiki prose → 2nd-person teacher voice (English at A1/A2, Ukrainian at B1+). You may shorten, reorder for pedagogical flow, and add transitions. You may NOT add Ukrainian content the wiki did not authorize. If a section needs more Ukrainian than the wiki carries, STOP and emit `<implementation_map>` `treatment="deferred — wiki section thin"` for that row; do not invent to fill the gap.
+Voice rewrite, NOT translation: rewrite 3rd-person methodological Ukrainian wiki prose → 2nd-person teacher voice (Ukrainian-first with brief English support at A1/A2, Ukrainian at B1+). You may shorten, reorder for pedagogical flow, and add transitions. You may NOT add Ukrainian content the wiki did not authorize. If a section needs more Ukrainian than the wiki carries, STOP and emit `<implementation_map>` `treatment="deferred — wiki section thin"` for that row; do not invent to fill the gap.
 
 What stays load-bearing under the renderer pivot: voice rewrite quality (`#R-VOICE-META`, `#R-SINGLE-VOICE-A1`, `#R-AUDIENCE-LANGUAGE-A1`), citation honesty (`#R-CITE-HONEST`), VESUM verification (`#R-VESUM-ALL-WORDS`), the russianism/calque/surzhyk/paronym audit gates, the prose floor (`#R-PROSE-FLOOR-A1` — renderer framing does **NOT** fix word_count vs structural-density; the floor stays a HARD gate), the bad-form marker convention (`#R-BAD-FORM-MARKER`), no-scaffolding-leak (`#R-NO-SCAFFOLDING-LEAKS`), no-children-quotes (`#R-NO-CHILDREN-PRIMARY-QUOTES`), the artifact emission contract, and the dialogue count + format rules.
 
@@ -305,7 +305,15 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 **Single teacher voice at A1.** One teacher voice across the whole module: warm, clear, direct ("you" / "your"). No third-person framing of the learner (`the student`, `студента`, `the reader`, `учня`) and no mid-paragraph register shifts (English -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase). Good: "You use **я креслю** when you describe your own action." Bad: "the student enters an authentic space."
 
 <!-- rule_id: #R-AUDIENCE-LANGUAGE-A1 -->
-**A1 audience language.** A1 explanation prose stays in English. Ukrainian appears only as TARGET: inline vocabulary words with English glosses, dialogue boxes, tables, conjugations, model sentences. Never use Ukrainian metalanguage TO the learner (`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`), because the learner cannot read Ukrainian explanations yet.
+**A1/A2 audience language — ULP immersion (Anna Ohoiko S1 pattern).** Teach Ukrainian *through* Ukrainian with English as a **receding scaffold**, not through English grammar lectures. Target about 50:50 UK:EN at A1/A2 S1, per the immersion band.
+
+1. **Ukrainian-first, em-dash gloss.** Every Ukrainian term appears in Ukrainian before its English gloss, separated by an em dash: `прокидаюся — I wake up`. Never write "the word for wake up is ...".
+2. **Stress marks are deterministic.** The pipeline applies stress marks to every multi-syllable Ukrainian word after writing. Write plain Ukrainian; do not hand-stress.
+3. **Dialogues are Ukrainian-first.** Use `<DialogueBox uk="..." en="..." />`. The `uk` turn is Ukrainian-only; do not interleave English grammar inside turns.
+4. **Comprehension/recall is Ukrainian-only.** Tab 3 content stems and answer options are Ukrainian-only; English appears only in UI affordances.
+5. **Use a named first-person teacher persona or named characters.** Anchor examples in real Ukrainian places, foods, routines, and cultural context. Never write abstractly about "the student must learn...".
+6. **English is scaffold, not lecture.** Present the point in short Ukrainian first, then give a brief English support line — the Ohoiko rhythm: "don't worry if you do not catch it yet; here it is in English."
+7. **Forbidden foreigner-textbook anti-patterns:** "X sounds like Y in English", transliteration tables, English-paragraph grammar explanations with Ukrainian bolted on, "the student must learn", and English topic-sentence openers such as "Your morning story needs a few verbs" or "A good A1 story has three layers".
 
 <!-- rule_id: #R-NO-CHILDREN-PRIMARY-QUOTES -->
 **No children-primary blockquotes in adult A1.** No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body. Grade 1-3 RAG hits can still ground lexical choices, but do not surface as quoted material. Default: NO blockquote unless it pedagogically advances the lesson AND comes from an adult-appropriate source (Grade 7+, adult literature, Антоненко-Давидович, style guides). Adult A1 learners are not reading children's primers; do not print `<Author>, Grade 1, p.<P>` as lesson prose.

--- a/scripts/build/universal_rules/R-AUDIENCE-LANGUAGE-A1.md
+++ b/scripts/build/universal_rules/R-AUDIENCE-LANGUAGE-A1.md
@@ -1,6 +1,6 @@
 ---
 id: R-AUDIENCE-LANGUAGE-A1
-description: A1/A2 explanation prose stays in English; Ukrainian only as TARGET.
+description: A1/A2 Ukrainian-first ULP immersion with English as receding scaffold.
 applies_to:
   levels: [a1, a2]
   tracks: [core]
@@ -9,4 +9,30 @@ slot: shared.contract
 depends_on: []
 ---
 
-**A1 audience language.** A1 explanation prose stays in English. Ukrainian appears only as TARGET: inline vocabulary words with English glosses, dialogue boxes, tables, conjugations, model sentences. Never use Ukrainian metalanguage TO the learner (`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`), because the learner cannot read Ukrainian explanations yet.
+**A1/A2 audience language — ULP immersion (Anna Ohoiko S1 pattern).** Teach
+Ukrainian *through* Ukrainian with English as a **receding scaffold**, not
+through English grammar lectures. Target about 50:50 UK:EN at A1/A2 S1, per the
+immersion band.
+
+1. **Ukrainian-first, em-dash gloss.** Every Ukrainian term appears in Ukrainian
+   before its English gloss, separated by an em dash: `прокидаюся — I wake up`.
+   Never write "the word for wake up is ...".
+2. **Stress marks are deterministic.** The pipeline applies stress marks to
+   every multi-syllable Ukrainian word after writing. Write plain Ukrainian; do
+   not hand-stress.
+3. **Dialogues are Ukrainian-first.** Use `<DialogueBox uk="..." en="..." />`.
+   The `uk` turn is Ukrainian-only; do not interleave English grammar inside
+   turns.
+4. **Comprehension/recall is Ukrainian-only.** Tab 3 content stems and answer
+   options are Ukrainian-only; English appears only in UI affordances.
+5. **Use a named first-person teacher persona or named characters.** Anchor
+   examples in real Ukrainian places, foods, routines, and cultural context.
+   Never write abstractly about "the student must learn...".
+6. **English is scaffold, not lecture.** Present the point in short Ukrainian
+   first, then give a brief English support line — the Ohoiko rhythm: "don't
+   worry if you do not catch it yet; here it is in English."
+7. **Forbidden foreigner-textbook anti-patterns:** "X sounds like Y in English",
+   transliteration tables, English-paragraph grammar explanations with
+   Ukrainian bolted on, "the student must learn", and English topic-sentence
+   openers such as "Your morning story needs a few verbs" or "A good A1 story
+   has three layers".

--- a/scripts/build/universal_rules/R-RENDERER-CHARTER.md
+++ b/scripts/build/universal_rules/R-RENDERER-CHARTER.md
@@ -9,15 +9,15 @@ slot: writer.preamble
 depends_on: []
 ---
 
-You are a RENDERER, not a composer. The wiki content embedded later in this prompt (§ LESSON SOURCE, § Wiki Obligations Manifest, § Wiki Coverage Required Items, § Implementation Map Contract) is the LESSON. Your job is to translate that wiki content into the four artifacts using English (A1/A2) or Ukrainian (B1+) teacher voice. You DO NOT invent vocabulary, examples, citations, dialogue lines, phonetic rules, decolonization stances, or grammar claims that are not derivable from the wiki + plan + cited RAG chunks.
+You are a RENDERER, not a composer. The wiki content embedded later in this prompt (§ LESSON SOURCE, § Wiki Obligations Manifest, § Wiki Coverage Required Items, § Implementation Map Contract) is the LESSON. Your job is to translate that wiki content into the four artifacts using Ukrainian-first ULP immersion (A1/A2) or Ukrainian teacher voice (B1+). You DO NOT invent vocabulary, examples, citations, dialogue lines, phonetic rules, decolonization stances, or grammar claims that are not derivable from the wiki + plan + cited RAG chunks.
 
 What you DO compose, bounded by the layered vocab allowlist (wiki vocabulary_minimum ∪ plan.targets.new_vocabulary ∪ plan.targets.vocabulary_hints ∪ cumulative_learner_state.taught_lemmas ∪ closed_class_function_words ∪ proper_nouns_in_wiki_examples ∪ bad_form_markers ∪ quoted_evidence_from_cited_RAG_chunks):
 
-1. **English glosses** for Ukrainian words (A1/A2). Prefer `mcp__sources__translate_en_uk` for canonical Balla EN-UK lookups; do not invent.
+1. **English scaffold glosses** for Ukrainian words (A1/A2). Use Ukrainian-first em-dash order (`прокидаюся — I wake up`). Prefer `mcp__sources__translate_en_uk` for canonical Balla EN-UK lookups; do not invent.
 2. **Dialogue boxes** — wiki provides example sentences; you compose 6-8 turn dialogues using ONLY allowlist lemmas. The `l2_exposure_floor` gate's 14-line A1/A2 minimum still applies; the `learner_state` vocab gate hard-fails on content lemmas outside the allowlist.
 3. **Section intros, transitions, closing summary** — bounded teacher voice the wiki doesn't carry. Subject to `#R-VOICE-META` forbidden patterns.
 4. **Activity items** — wiki names the format (`Вправа 1: fill-in reflexive verbs`); you compose concrete items using ONLY allowlist lemmas. See `#R-ACTIVITY-COMPOSITION` below.
 
-Voice rewrite, NOT translation: rewrite 3rd-person methodological Ukrainian wiki prose → 2nd-person teacher voice (English at A1/A2, Ukrainian at B1+). You may shorten, reorder for pedagogical flow, and add transitions. You may NOT add Ukrainian content the wiki did not authorize. If a section needs more Ukrainian than the wiki carries, STOP and emit `<implementation_map>` `treatment="deferred — wiki section thin"` for that row; do not invent to fill the gap.
+Voice rewrite, NOT translation: rewrite 3rd-person methodological Ukrainian wiki prose → 2nd-person teacher voice (Ukrainian-first with brief English support at A1/A2, Ukrainian at B1+). You may shorten, reorder for pedagogical flow, and add transitions. You may NOT add Ukrainian content the wiki did not authorize. If a section needs more Ukrainian than the wiki carries, STOP and emit `<implementation_map>` `treatment="deferred — wiki section thin"` for that row; do not invent to fill the gap.
 
 Upstream guard: the `wiki_completeness_gate` blocks the build BEFORE you run if the wiki is thin (missing methodology, <5 sequence steps at A1/A2, <3 L2 errors, <20 vocab lemmas, <6 distractors). You will not see thin wikis. If your run gets here, the wiki passed; render it faithfully.

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -1059,6 +1059,17 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
             "implementation_map.json",
         )
         return all((module_dir / name).exists() for name in required)
+    if phase == "stress_annotation":
+        data = _read_json(module_dir / "stress_annotation.json")
+        return (
+            isinstance(data, Mapping)
+            and data.get("passed") is True
+            and (module_dir / "module.md").exists()
+            and (module_dir / "vocabulary.yaml").exists()
+        )
+    if phase == "ulp_fidelity_gate":
+        data = _read_json(module_dir / "ulp_fidelity_gate.json")
+        return isinstance(data, Mapping) and data.get("passed") is True
     if phase == "python_qg":
         data = _read_json(module_dir / "python_qg.json")
         if not isinstance(data, Mapping):
@@ -1333,6 +1344,75 @@ def _run(args: argparse.Namespace) -> int:
             archive=archive,
             artifact_dir=module_dir,
         )
+
+        phase = "stress_annotation"
+        _phase_started(archive, phase)
+        started_at = time.monotonic()
+        if (
+            resume_enabled
+            and not force_rerun
+            and _phase_artifact_passes(module_dir, "stress_annotation")
+        ):
+            stress_annotation = _read_json(module_dir / "stress_annotation.json")
+            tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
+        else:
+            if resume_enabled:
+                force_rerun = True
+            stress_annotation = linear_pipeline.run_stress_annotation(module_dir)
+            linear_pipeline.write_json(
+                module_dir / "stress_annotation.json",
+                stress_annotation,
+            )
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
+        if not isinstance(stress_annotation, Mapping) or stress_annotation.get("passed") is not True:
+            raise linear_pipeline.LinearPipelineError("Stress annotation failed")
+
+        phase = "ulp_fidelity_gate"
+        _phase_started(archive, phase)
+        started_at = time.monotonic()
+        if (
+            resume_enabled
+            and not force_rerun
+            and _phase_artifact_passes(module_dir, "ulp_fidelity_gate")
+        ):
+            ulp_fidelity_gate = _read_json(module_dir / "ulp_fidelity_gate.json")
+            tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
+        else:
+            if resume_enabled:
+                force_rerun = True
+            ulp_fidelity_gate = linear_pipeline.run_ulp_fidelity_gate(
+                module_dir,
+                plan_path,
+                profile=profile,
+            )
+            linear_pipeline.write_json(
+                module_dir / "ulp_fidelity_gate.json",
+                ulp_fidelity_gate,
+            )
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            artifact_dir=module_dir,
+        )
+        if not isinstance(ulp_fidelity_gate, Mapping) or ulp_fidelity_gate.get("passed") is not True:
+            failed = (
+                ulp_fidelity_gate.get("failed_checks")
+                if isinstance(ulp_fidelity_gate, Mapping)
+                else "malformed ulp_fidelity report"
+            )
+            raise linear_pipeline.LinearPipelineError(f"ULP fidelity gate failed: {failed}")
 
         phase = "python_qg"
         _phase_started(archive, phase)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -160,11 +160,11 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 5-25% Ukrainian.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: Mostly English with Ukrainian words bolded inline.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first with brief English support.\n"
                 "- UKRAINIAN CONTENT: Letters, sounds, words, and very short phrases inline.\n"
                 "- DIALOGUES & READING PRACTICE: Optional ultra-short Ukrainian sentence blocks.\n"
                 "- TABLES: Letter-sound and word-meaning tables are encouraged.\n"
-                "- STRUCTURAL RULE: English carries the explanation. Ukrainian appears in controlled chunks.\n"
+                "- STRUCTURAL RULE: Ukrainian appears first; English glosses support it briefly.\n"
                 "Ukrainian sentences max 10 words."
             ),
         },
@@ -176,11 +176,11 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 8-30% Ukrainian.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: Mostly English with Ukrainian words bolded inline.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first with brief English support.\n"
                 "- UKRAINIAN CONTENT: Words and short phrases inline: \"The word **книга** means book.\"\n"
                 "- DIALOGUES & READING PRACTICE: Short Ukrainian sentence blocks are encouraged.\n"
                 "- TABLES: Simple identity, family, or stress-pattern tables.\n"
-                "- STRUCTURAL RULE: English carries the explanation, but short Ukrainian examples should now appear regularly.\n"
+                "- STRUCTURAL RULE: Ukrainian appears first; English glosses support it briefly.\n"
                 "Ukrainian sentences max 10 words."
             ),
         },
@@ -192,10 +192,10 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 10-38% Ukrainian.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: English prose. Introduce Ukrainian grammar terms bolded with translation on first use.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first examples with brief English support.\n"
                 "- UKRAINIAN CONTENT: Words and short phrases bolded inline: \"The word **книга** (book) is feminine.\"\n"
                 "- TABLES: Vocabulary tables, word families, simple paradigm tables.\n"
-                "- STRUCTURAL RULE: Every paragraph is English. Ukrainian words/phrases appear inline bolded. "
+                "- STRUCTURAL RULE: Every section opens Ukrainian-first. Ukrainian words/phrases use em-dash glosses. "
                 "Full Ukrainian sentences (3+ words with a verb) go in tables or bulleted example lists with English gloss.\n"
                 "Ukrainian sentences max 10 words."
             ),
@@ -208,7 +208,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 15-24% Ukrainian.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: English prose — explain the grammar concept once, clearly.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first with brief English support — show the concept, then scaffold.\n"
                 "- EXAMPLES: Ukrainian sentences in bulleted lists (each line: Ukrainian — English gloss). Max 2-4 per rule.\n"
                 "- TABLES: Paradigm tables, gender sorting, vocabulary groups — all cells Ukrainian.\n"
                 "- PATTERN BOXES: Show transformations and rules: `книга → книги` (singular → plural).\n"
@@ -226,7 +226,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 15-40% Ukrainian.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: English prose — explain the grammar concept once, clearly.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first with brief English support — show the concept, then scaffold.\n"
                 "- EXAMPLES: Ukrainian sentences in bulleted lists (each line: Ukrainian — English gloss). Max 2-4 per rule.\n"
                 "- TABLES: Paradigm tables, case endings, vocabulary groups — all cells Ukrainian.\n"
                 "- PATTERN BOXES: Show transformations: `книга → книгу` (nominative → accusative).\n"
@@ -244,7 +244,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 20-40% Ukrainian. HARD GATE — the audit rejects modules outside this range.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: English prose — brief, 2-3 sentences per concept. Explain once, then show Ukrainian.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first with brief English support. Show Ukrainian before any scaffold.\n"
                 "- UKRAINIAN NARRATIVE PARAGRAPHS: REQUIRED — minimum 1 per section. "
                 "A 3-6 sentence Ukrainian paragraph demonstrating the concept in use, followed immediately by a "
                 "`> *English translation*` blockquote.\n"
@@ -265,7 +265,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 25-48% Ukrainian. HARD GATE — the audit rejects modules outside this range.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY & EXPLANATION: English prose — brief, 2-3 sentences per concept. Explain once, then show Ukrainian.\n"
+                "- THEORY & EXPLANATION: Ukrainian-first with brief English support. Show Ukrainian before any scaffold.\n"
                 "- UKRAINIAN NARRATIVE PARAGRAPHS: REQUIRED — minimum 2 per section. "
                 "A 4-8 sentence Ukrainian paragraph demonstrating the concept in use, followed immediately by a "
                 "`> *English translation*` blockquote.\n"
@@ -288,7 +288,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 20-48% Ukrainian. Bridge modules continue from late A1.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY: English prose for grammar review and metalanguage introduction.\n"
+                "- THEORY: Ukrainian-first review with brief English support for metalanguage.\n"
                 "- EXAMPLES & CONTEXT: Ukrainian — dialogues, example sentences, pattern boxes.\n"
                 "- HEADERS: Ukrainian with English in parentheses.\n"
                 "- STRUCTURAL RULE: Each sentence is 100% Ukrainian OR 100% English — never mix.\n"
@@ -306,7 +306,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 30-55% Ukrainian. HARD GATE — the audit rejects modules outside this range.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY: English prose for grammar explanations — keep short (2-3 sentences per concept, then immediately show Ukrainian examples).\n"
+                "- THEORY: Ukrainian-first examples with brief English support for grammar.\n"
                 "- EXAMPLES & CONTEXT: Ukrainian — dialogues, example sentences, cultural context.\n"
                 "- HEADERS: Ukrainian with English in parentheses.\n"
                 "- STRUCTURAL RULE: Each sentence is 100% Ukrainian OR 100% English — never mix.\n"
@@ -329,7 +329,7 @@ IMMERSION_POLICIES: dict[str, tuple[dict[str, Any], ...]] = {
             "rule": (
                 "TARGET: 40-70% Ukrainian. HARD GATE — the audit rejects modules outside this range.\n"
                 "LANGUAGE ROLES:\n"
-                "- THEORY: English prose for grammar explanations — keep these short (2-3 sentences max per concept).\n"
+                "- THEORY: Ukrainian-first examples with brief English support for grammar.\n"
                 "- EXAMPLES & CONTEXT: Ukrainian — dialogues, example sentences, cultural context.\n"
                 "- HEADERS: Ukrainian with English in parentheses.\n"
                 "- STRUCTURAL RULE: Each sentence is 100% Ukrainian OR 100% English — never mix languages within a sentence.\n"
@@ -563,11 +563,50 @@ _IMMERSION_STRUCTURAL_OVERRIDES: dict[str, dict[str, Any]] = {
 }
 
 
+_ULP_S1_IMMERSION_BAND_KEYS = frozenset(
+    {
+        "a1-m01-03",
+        "a1-m04-06",
+        "a1-m07-14",
+        "a1-m15-24",
+        "a1-m25-34",
+        "a1-m35-54",
+        "a1-m55+",
+        "a2-bridge",
+        "a2-ramp",
+        "a2-m01-20",
+    }
+)
+
+
+def _uses_ulp_s1_band(band_key: str) -> bool:
+    return band_key in _ULP_S1_IMMERSION_BAND_KEYS
+
+
+def _ulp_s1_language_roles() -> str:
+    return (
+        "TARGET: 40-55% Ukrainian. ULP S1 bilingual immersion.\n"
+        "## ULP Presentation Pattern (Anna Ohoiko S1 baseline)\n"
+        "LANGUAGE ROLES:\n"
+        "- PRIMARY POSTURE: Ukrainian-first, example-first teaching. English is a brief receding scaffold, not lecture prose.\n"
+        "- EM-DASH GLOSS: Introduce every Ukrainian term before its English gloss: `прокидаюся — I wake up`.\n"
+        "- STRESS MARKS: The pipeline applies stress marks deterministically after writing; write plain Ukrainian.\n"
+        "- DIALOGUES: Use `<DialogueBox uk=\"...\" en=\"...\" />`; each `uk` turn is Ukrainian-only.\n"
+        "- TAB 3 RECALL: Comprehension stems and content options are Ukrainian-only; English appears only in UI affordances.\n"
+        "- PERSONA: Use a named first-person teacher persona or named characters with real Ukrainian cultural anchors.\n"
+        "- FORBIDDEN: English grammar-lecture paragraphs with Ukrainian bolted on, transliteration tables, "
+        "\"X sounds like Y in English\", \"the student must learn\", and English topic-sentence openers.\n"
+        "Ukrainian sentences stay short and concrete; follow Anna Ohoiko's S1 rhythm: short Ukrainian first, then brief English support."
+    )
+
+
 def _structural_immersion_rule(band: dict[str, Any]) -> str:
     old_rule = str(band["rule"])
     language_roles = old_rule
     if old_rule.startswith("TARGET:") and "\n" in old_rule:
         language_roles = old_rule.split("\n", 1)[1]
+    if _uses_ulp_s1_band(str(band["key"])):
+        language_roles = _ulp_s1_language_roles()
     structural = (
         "STRUCTURAL TARGETS (Phase A placeholders; Phase B calibrates):\n"
         f"- At least N UK dialogue lines (band: {band['min_uk_dialogue_lines']})\n"
@@ -581,44 +620,17 @@ def _structural_immersion_rule(band: dict[str, Any]) -> str:
 
 
 def _ulp_practices_rule(track: str, module_num: int) -> str:
-    """Return the compact ULP S1 presentation baseline for early A1 prompts."""
-    if track != "a1" or module_num > 25:
-        return ""
-    return (
-        "## ULP Presentation Pattern (A1 S1 baseline)\n"
-        "Follow Anna Ohoiko's Ukrainian-first bilingual practices from "
-        "`docs/best-practices/ulp-presentation-pattern.md`:\n"
-        "Key checks: UK-first presentation; em-dash glosses; stress marks; "
-        "named persona.\n"
-        "1. EM-DASH GLOSS: every UK term in EN narration uses UK-first, "
-        "em-dash gloss order: `Приві́т! — Hi!`; never gloss-first.\n"
-        "2. SIDE-BY-SIDE BILINGUAL: narrative passages of 3+ sentences render "
-        "as a two-column MD table (UK left, EN right) or `<DialogueBox>`-style "
-        "side-by-side translation, not EN-only prose with a vocab dump.\n"
-        "3. STRESS MARKS: every multi-syllable UK term has stress marks "
-        "throughout Tab 1 prose, Tab 2 vocabulary, and Tab 3 activity prompts "
-        "(`Приві́т`, `спра́ви`, `чудо́во`).\n"
-        "4. DIALOGUE UK-ONLY: Tab 1 dialogues use pure Ukrainian named-speaker "
-        "turns first. Translation or breakdown follows after the dialogue; do "
-        "not interleave English inside the UK turn text.\n"
-        "5. UK-ONLY Q&A: Tab 3 comprehension/recall stems and answer options "
-        "are Ukrainian-only for content questions. English appears only as "
-        "secondary UI support where needed.\n"
-        "6. TRANSLATE -> WORKBOOK: EN-to-UK translation is a workbook/booster "
-        "activity in Tab 3, never Tab 1 teaching prose.\n"
-        "7. NAMED PERSONA: Tab 1 uses a named persona or named characters, with "
-        "real Ukrainian places, foods, and activities instead of generic L2 "
-        "fillers.\n"
-        "A1 violations: English-first framing, transliteration tables, inline "
-        "EN glossing inside dialogue turns, single-column EN narration with "
-        "vocab dumps, and abstract 'the student must learn' framing."
-    )
+    """Deprecated compatibility hook; ULP S1 is embedded in band roles."""
+    return ""
 
 
 def _extend_immersion_band(raw_band: dict[str, Any]) -> dict[str, Any]:
     band = dict(raw_band)
     band["advisory_pct_min"] = int(band.pop("min_pct"))
     band["advisory_pct_max"] = int(band.pop("max_pct"))
+    if _uses_ulp_s1_band(str(band["key"])):
+        band["advisory_pct_min"] = 40
+        band["advisory_pct_max"] = 55
     structural = {
         **_IMMERSION_STRUCTURAL_DEFAULTS,
         **_IMMERSION_STRUCTURAL_OVERRIDES.get(str(band["key"]), {}),
@@ -833,6 +845,7 @@ def get_immersion_rule(
     if ulp_rule:
         return f"{rule}\n\n{ulp_rule}"
     return rule
+
 
 if __name__ == "__main__":
     # Simple CLI test

--- a/scripts/pipeline/stress_annotator.py
+++ b/scripts/pipeline/stress_annotator.py
@@ -2,7 +2,8 @@
 
 Reads generated .md content, finds Ukrainian words, adds combining acute
 accent (U+0301) on the stressed vowel for words with 2+ syllables.
-Only marks first occurrence of each word form to avoid visual noise.
+Marks every multi-syllable Ukrainian word occurrence. The annotator is
+idempotent: already-stressed words are preserved and are not double-marked.
 
 Uses sentence-level processing for context-aware heteronym disambiguation.
 The Stressifier uses Stanza NLP internally — feeding full sentences allows
@@ -23,23 +24,24 @@ logger = logging.getLogger(__name__)
 
 STRESS_MARK = "\u0301"
 
-# If >5% of body words already have stress marks, the file was likely already annotated.
-# Empirically: vocab_gen.py pre-stresses ~1-2% of body words via inline examples;
-# a fully annotated file has ~15-20%. The 5% threshold sits safely between.
-_ALREADY_STRESSED_THRESHOLD = 0.05
-
 # Match Ukrainian words (2+ Cyrillic chars, may include apostrophe/soft sign/stress mark)
 # Use lookbehind/lookahead instead of \b — \b doesn't work with Cyrillic
 # Include \u0301 (combining acute accent) so already-stressed words are matched whole
+_CYRILLIC_BASE_CLASS = "А-ЯҐЄІЇа-яґєії"
+_CYRILLIC_LETTER_CLASS = f"{_CYRILLIC_BASE_CLASS}\u0301"
 _CYRILLIC_WORD_RE = re.compile(
-    r"(?<![А-ЯҐЄІЇа-яґєіїʼ'\u0301])([А-ЯҐЄІЇа-яґєіїʼ'\u0301]{2,})(?![А-ЯҐЄІЇа-яґєіїʼ'\u0301])",
+    rf"(?<![{_CYRILLIC_LETTER_CLASS}])"
+    rf"([{_CYRILLIC_BASE_CLASS}][{_CYRILLIC_LETTER_CLASS}]*(?:[ʼ'][{_CYRILLIC_BASE_CLASS}][{_CYRILLIC_LETTER_CLASS}]*)*)"
+    rf"(?![{_CYRILLIC_LETTER_CLASS}])",
     re.UNICODE,
 )
 
 # Ukrainian vowels — needed to count syllables
 _VOWELS = set("аеиіїоуюяєАЕИІЇОУЮЯЄ")
 
-# Contexts to skip: inside HTML comments, YAML frontmatter, code blocks, URLs
+# Contexts to skip: inside HTML comments, code blocks, URLs, JSX/HTML tags.
+# DialogueBox uk="..." values are annotated in a focused second pass because
+# they are learner-facing Ukrainian inside an otherwise-skipped JSX tag.
 _SKIP_PATTERNS = [
     re.compile(r"<!--.*?-->", re.DOTALL),
     re.compile(r"```.*?```", re.DOTALL),
@@ -166,6 +168,26 @@ def _build_sentence_stress_map(
     return stress_map
 
 
+_DIALOGUEBOX_UK_ATTR_RE = re.compile(
+    r"(<DialogueBox\b[^>]*\buk\s*=\s*\")(?P<uk>[^\"]*)(\")",
+    re.DOTALL,
+)
+
+
+def _annotate_dialoguebox_uk_attrs(text: str) -> tuple[str, int]:
+    """Annotate Ukrainian inside DialogueBox uk="..." props only."""
+    total = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal total
+        value = match.group("uk")
+        annotated, count = annotate_stress(value)
+        total += count
+        return f"{match.group(1)}{annotated}{match.group(3)}"
+
+    return _DIALOGUEBOX_UK_ATTR_RE.sub(replace, text), total
+
+
 def annotate_stress(text: str) -> tuple[str, int]:
     """Add stress marks to Ukrainian words in text.
 
@@ -173,9 +195,9 @@ def annotate_stress(text: str) -> tuple[str, int]:
 
     Strategy:
     - Only stress words with 2+ syllables (single-syllable = obvious)
-    - Only stress FIRST occurrence of each word form
     - Skip words inside HTML comments, code blocks, URLs, JSX tags
     - Skip words that already have stress marks
+    - Add a focused second pass for DialogueBox uk="..." values
     - Use ukrainian-word-stress library with SENTENCE context for disambiguation
     """
     skip_ranges = _build_skip_mask(text)
@@ -205,24 +227,13 @@ def annotate_stress(text: str) -> tuple[str, int]:
         if STRESS_MARK in stressed and stressed.replace(STRESS_MARK, "") == clean:
             stress_map[pos] = stressed
 
-    # First pass: find first ANNOTATABLE occurrence of each word form.
-    # Must exclude skip ranges — otherwise the first occurrence lands inside
-    # a code block/tag and all later occurrences are never annotated.
-    first_occurrences: dict[str, int] = {}
-    for i, m in enumerate(matches):
-        word = m.group(1)
-        lower = word.lower().replace(STRESS_MARK, "")
-        if lower not in first_occurrences and not _in_skip_range(m.start(), skip_ranges):
-            first_occurrences[lower] = i
-
-    # Second pass: annotate only first occurrences (reverse for safe replacement)
+    # Annotate every eligible occurrence (reverse for safe replacement).
     result = list(text)
     for i in reversed(range(len(matches))):
         m = matches[i]
         word = m.group(1)
-        lower = word.lower().replace(STRESS_MARK, "")
 
-        if first_occurrences.get(lower) != i:
+        if _in_skip_range(m.start(), skip_ranges):
             continue
 
         if _already_stressed(word):
@@ -239,7 +250,9 @@ def annotate_stress(text: str) -> tuple[str, int]:
         result[start:end] = list(stressed)
         count += 1
 
-    return "".join(result), count
+    annotated = "".join(result)
+    annotated, attr_count = _annotate_dialoguebox_uk_attrs(annotated)
+    return annotated, count + attr_count
 
 
 def annotate_file(path: Path) -> int:
@@ -251,24 +264,6 @@ def annotate_file(path: Path) -> int:
         return 0
 
     text = path.read_text("utf-8")
-
-    # Don't re-annotate if the BODY content already has significant stress marks.
-    # We exclude the Словник/vocabulary section because vocab_gen.py pre-stresses
-    # those words — counting them would falsely trigger the skip threshold.
-    # Find the earliest tab marker to isolate body content
-    body_text = text
-    first_tab_idx = len(text)
-    for tab_marker in ("<!-- TAB:Словник -->", "<!-- TAB:Ресурси -->"):
-        idx = text.find(tab_marker)
-        if idx != -1 and idx < first_tab_idx:
-            first_tab_idx = idx
-    body_text = text[:first_tab_idx]
-
-    existing = body_text.count(STRESS_MARK)
-    word_count = len(body_text.split())
-    if word_count > 0 and existing > word_count * _ALREADY_STRESSED_THRESHOLD:
-        logger.info("stress_annotator: skipping %s — body already has %d stress marks", path.name, existing)
-        return 0
 
     annotated, count = annotate_stress(text)
 

--- a/tests/test_adaptive_immersion.py
+++ b/tests/test_adaptive_immersion.py
@@ -1,8 +1,8 @@
 """Tests for A1/A2 immersion range bands (audit/config.py).
 
-Updated 2026-04-04 to match the April 3 recalibration:
-- A1: wider upper bounds (dialogue-rich content raises immersion naturally)
-- A2: 5-band graduated system (bridge, ramp, band1, band2, band3)
+Updated 2026-05-30 for the Ohoiko/ULP S1 harness:
+- A1: every core band uses 40-55% Ukrainian-first immersion
+- A2: S1 bridge/ramp/band1 use 40-55%, later A2 bands continue to ramp
 """
 
 import sys
@@ -17,39 +17,39 @@ class TestA1ImmersionRange:
     """Test get_a1_immersion_range band lookups."""
 
     def test_phonetics_band(self):
-        """M1-3: lowest immersion (phonetics, mostly English)."""
-        assert get_a1_immersion_range(1) == (5, 25)
-        assert get_a1_immersion_range(3) == (5, 25)
+        """M1-3: ULP S1 baseline."""
+        assert get_a1_immersion_range(1) == (40, 55)
+        assert get_a1_immersion_range(3) == (40, 55)
 
     def test_identity_band(self):
         """M4-6: stress, identity, family."""
-        assert get_a1_immersion_range(4) == (8, 30)
-        assert get_a1_immersion_range(6) == (8, 30)
+        assert get_a1_immersion_range(4) == (40, 55)
+        assert get_a1_immersion_range(6) == (40, 55)
 
     def test_grammar_band(self):
         """M7-14: gender, adjectives, numbers."""
-        assert get_a1_immersion_range(7) == (10, 38)
-        assert get_a1_immersion_range(14) == (10, 38)
+        assert get_a1_immersion_range(7) == (40, 55)
+        assert get_a1_immersion_range(14) == (40, 55)
 
     def test_sentence_building_band(self):
         """M15-24: verbs, questions, possessives."""
-        assert get_a1_immersion_range(15) == (15, 24)
-        assert get_a1_immersion_range(24) == (15, 24)
+        assert get_a1_immersion_range(15) == (40, 55)
+        assert get_a1_immersion_range(24) == (40, 55)
 
     def test_cases_band(self):
         """M25-34: accusative, locative, genitive."""
-        assert get_a1_immersion_range(25) == (15, 40)
-        assert get_a1_immersion_range(34) == (15, 40)
+        assert get_a1_immersion_range(25) == (40, 55)
+        assert get_a1_immersion_range(34) == (40, 55)
 
     def test_daily_life_band(self):
         """M35-54: tense, food, travel."""
-        assert get_a1_immersion_range(35) == (20, 40)
-        assert get_a1_immersion_range(54) == (20, 40)
+        assert get_a1_immersion_range(35) == (40, 55)
+        assert get_a1_immersion_range(54) == (40, 55)
 
     def test_independence_band(self):
         """M55+: practical skills."""
-        assert get_a1_immersion_range(55) == (25, 48)
-        assert get_a1_immersion_range(64) == (25, 48)
+        assert get_a1_immersion_range(55) == (40, 55)
+        assert get_a1_immersion_range(64) == (40, 55)
 
     def test_immersion_increases_monotonically(self):
         """Min immersion never decreases as module number increases."""
@@ -63,28 +63,28 @@ class TestA1ImmersionRange:
 class TestA2ImmersionRange:
     """Test get_a2_immersion_range with 5-band graduated system.
 
-    Recalibrated 2026-04-03:
-    - Bridge (M01-03): 20-48% — A1→A2 transition, overlaps with A1 finale range
-    - Ramp (M04-07): 30-55% — genitive intro, dialogues increasing
-    - Band 1 (M08-20): 40-70% — applied grammar, dialogue-rich
+    Recalibrated 2026-05-30:
+    - Bridge (M01-03): 40-55% — ULP S1 baseline
+    - Ramp (M04-07): 40-55% — ULP S1 baseline
+    - Band 1 (M08-20): 40-55% — ULP S1 baseline
     - Band 2 (M21-50): 50-80% — all cases, longer Ukrainian passages
     - Band 3 (M51-63): 65-90% — near-full immersion, B1 prep
     """
 
     def test_bridge(self):
         """M01-03: bridge from A1."""
-        assert get_a2_immersion_range(1) == (20, 48)
-        assert get_a2_immersion_range(3) == (20, 48)
+        assert get_a2_immersion_range(1) == (40, 55)
+        assert get_a2_immersion_range(3) == (40, 55)
 
     def test_ramp(self):
         """M04-07: ramp up."""
-        assert get_a2_immersion_range(4) == (30, 55)
-        assert get_a2_immersion_range(7) == (30, 55)
+        assert get_a2_immersion_range(4) == (40, 55)
+        assert get_a2_immersion_range(7) == (40, 55)
 
     def test_band1_core_grammar(self):
         """M08-20: applied grammar, dialogue-rich."""
-        assert get_a2_immersion_range(8) == (40, 70)
-        assert get_a2_immersion_range(20) == (40, 70)
+        assert get_a2_immersion_range(8) == (40, 55)
+        assert get_a2_immersion_range(20) == (40, 55)
 
     def test_band2_applied_grammar(self):
         """M21-50: all cases, longer Ukrainian passages."""

--- a/tests/test_compute_immersion_band.py
+++ b/tests/test_compute_immersion_band.py
@@ -27,7 +27,7 @@ def test_compute_immersion_band_flag_on_uses_cumulative_vocab_not_module_num(mon
 
     assert low_vocab["key"] == "a1-m01-03"
     assert high_vocab["key"] == "a1-m07-14"
-    assert low_vocab["advisory_pct_min"] != high_vocab["advisory_pct_min"]
+    assert low_vocab["rule"] != high_vocab["rule"]
 
 
 def test_immersion_accessors_preserve_backward_compat_when_flag_off(monkeypatch):

--- a/tests/test_immersion_gates.py
+++ b/tests/test_immersion_gates.py
@@ -81,8 +81,8 @@ def test_advisory_pct_always_passes() -> None:
 
     assert result["passed"] is True
     assert result["pct"] == 0.0
-    assert result["min_pct"] == 5
-    assert result["max_pct"] == 25
+    assert result["min_pct"] == 40
+    assert result["max_pct"] == 55
     assert result["policy"] == "a1-m01-03"
 
 

--- a/tests/test_immersion_rule_ulp.py
+++ b/tests/test_immersion_rule_ulp.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from scripts import config
+from scripts.audit.ulp_fidelity_gate import _UK_WORD_RE, check_ulp_fidelity
+from scripts.build import linear_pipeline, v7_build
+from scripts.pipeline.stress_annotator import STRESS_MARK
 
 ULP_KEYWORDS = (
     "em-dash",
-    "side-by-side",
+    "DialogueBox",
     "stress marks",
-    "UK-first",
-    "named persona",
+    "Ukrainian-first",
+    "named first-person teacher persona",
 )
 
 
@@ -30,11 +35,11 @@ def test_a1_m20_gets_ulp_practices() -> None:
     assert _keyword_hits(rule) >= 2
 
 
-def test_a1_late_module_does_not_get_s1_ulp_practices() -> None:
+def test_a1_late_module_gets_s1_ulp_practices() -> None:
     rule = config.get_immersion_rule("a1", 50)
 
-    assert "ULP Presentation Pattern" not in rule
-    assert _keyword_hits(rule) == 0
+    assert "ULP Presentation Pattern" in rule
+    assert _keyword_hits(rule) >= 2
 
 
 def test_c1_module_does_not_get_a1_ulp_practices() -> None:
@@ -42,3 +47,107 @@ def test_c1_module_does_not_get_a1_ulp_practices() -> None:
 
     assert "ULP Presentation Pattern" not in rule
     assert _keyword_hits(rule) == 0
+
+
+def test_ulp_word_regex_does_not_absorb_quoting_marks() -> None:
+    assert [match.group(1) for match in _UK_WORD_RE.finditer("'слово' сім'я")] == [
+        "слово",
+        "сім'я",
+    ]
+
+
+def test_ulp_fidelity_gate_passes_ukrainian_first_fixture() -> None:
+    module = """# Мій ра́нок
+
+## Ра́нок
+
+Я прокида́юся — I wake up. Мене́ зва́ти Оле́на. Я кажу́: до́брий ра́нок. English support.
+
+<DialogueBox uk="До́брий ра́нок, Оле́но." en="Good morning, Olena." />
+<DialogueBox uk="Я прокида́юся і пи́шу пові́льно." en="I wake up and write slowly." />
+
+## Ді́я
+
+Прокида́юся — I wake up. Пи́шу — I write. Чита́ю — I read. Це мій ма́лий ритм. Short support.
+"""
+
+    report = check_ulp_fidelity(
+        module,
+        {"level": "a1", "sequence": 20, "slug": "fixture"},
+        profile="core",
+    )
+
+    assert report["passed"] is True
+    assert report["verdict"] == "PASS"
+    assert report["failed_checks"] == []
+
+
+def test_ulp_fidelity_gate_revises_grammar_translation_fixture() -> None:
+    module = """# Morning verbs
+
+## Morning verbs
+
+Your morning story needs a few verbs before it can move.
+The word прокидаюся means I wake up. A reflexive verb is a verb that points back to the subject.
+
+<DialogueBox uk="Я прокидаюся and I wake up." en="I wake up." />
+"""
+
+    report = check_ulp_fidelity(
+        module,
+        {"level": "a1", "sequence": 20, "slug": "fixture"},
+        profile="core",
+    )
+
+    assert report["passed"] is False
+    assert report["verdict"] == "REVISE"
+    assert set(report["failed_checks"]) >= {
+        "stress_coverage",
+        "em_dash_gloss",
+        "dialoguebox_uk_en",
+        "section_openers",
+    }
+
+
+def test_linear_pipeline_stress_annotation_marks_module_and_vocabulary(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "module.md").write_text(
+        'Моя мама читає.\n<DialogueBox uk="Моя мама пише." en="My mother writes." />\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "vocabulary.yaml").write_text(
+        "- word: мама\n  translation: mother\n  example_uk: Моя мама читає.\n",
+        encoding="utf-8",
+    )
+
+    first = linear_pipeline.run_stress_annotation(tmp_path)
+    second = linear_pipeline.run_stress_annotation(tmp_path)
+
+    assert first["passed"] is True
+    assert first["total_added"] > 0
+    assert second["total_added"] == 0
+    assert STRESS_MARK in (tmp_path / "module.md").read_text(encoding="utf-8")
+    assert STRESS_MARK in (tmp_path / "vocabulary.yaml").read_text(encoding="utf-8")
+
+
+def test_v7_resume_artifact_passes_for_stress_and_ulp_gate(tmp_path: Path) -> None:
+    (tmp_path / "module.md").write_text("Моя мама читає.\n", encoding="utf-8")
+    (tmp_path / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    linear_pipeline.write_json(
+        tmp_path / "stress_annotation.json",
+        {"passed": True, "phase": "stress_annotation"},
+    )
+    linear_pipeline.write_json(
+        tmp_path / "ulp_fidelity_gate.json",
+        {"passed": True, "verdict": "PASS"},
+    )
+
+    assert v7_build._phase_artifact_passes(tmp_path, "stress_annotation") is True
+    assert v7_build._phase_artifact_passes(tmp_path, "ulp_fidelity_gate") is True
+
+    linear_pipeline.write_json(
+        tmp_path / "ulp_fidelity_gate.json",
+        {"passed": False, "verdict": "REVISE"},
+    )
+    assert v7_build._phase_artifact_passes(tmp_path, "ulp_fidelity_gate") is False

--- a/tests/test_immersion_rule_ulp.py
+++ b/tests/test_immersion_rule_ulp.py
@@ -109,6 +109,35 @@ The word прокидаюся means I wake up. A reflexive verb is a verb that p
     }
 
 
+def test_uk_en_ratio_is_advisory_not_terminal(monkeypatch) -> None:
+    """uk_en_ratio must never drive the REVISE verdict.
+
+    A continuous immersion-ratio band is context-dependent; hard-gating on it is
+    the mechanics-over-teaching trap the ULP harness fix removes. When every
+    structural ULP check passes but the ratio is out of band, the module must
+    still PASS, with the ratio surfaced as an advisory warning.
+    """
+    from scripts.audit import ulp_fidelity_gate as gate
+
+    structural_pass = {"passed": True}
+    monkeypatch.setattr(gate, "_stress_coverage_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_em_dash_gloss_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_dialoguebox_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_section_opener_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_ratio_check", lambda _t, _p: {"passed": False, "pct": 99.0})
+
+    report = gate.check_ulp_fidelity(
+        "irrelevant",
+        {"level": "a1", "sequence": 20, "slug": "fixture"},
+        profile="core",
+    )
+
+    assert report["verdict"] == "PASS"
+    assert report["passed"] is True
+    assert report["failed_checks"] == []
+    assert "uk_en_ratio" in report["warnings"]
+
+
 def test_linear_pipeline_stress_annotation_marks_module_and_vocabulary(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_immersion_splitter.py
+++ b/tests/test_immersion_splitter.py
@@ -183,7 +183,7 @@ def test_advisory_immersion_pct_reports_a1_m15_24_policy_cap() -> None:
     )
 
     assert result["policy"] == "a1-m15-24"
-    assert result["max_pct"] == 24
+    assert result["max_pct"] == 55
     assert result["passed"] is True
 
 
@@ -192,25 +192,12 @@ def test_my_morning_immersion_passes() -> None:
     if fixture.exists():
         text = fixture.read_text(encoding="utf-8")
     else:
-        text = """English context keeps the A1 immersion ratio bounded for learners.
-This short grammar note explains the morning routine pattern in plain English.
-Learners read the examples, notice the endings, compare the forms, and then
-practice the dialogue aloud with a partner before writing their own version.
-The surrounding English is intentionally present because early A1 modules need
-clear scaffolding and should not become full immersion lessons yet.
-Additional English teacher notes keep this compact fixture inside the stricter
-policy cap while the Ukrainian examples remain available for sentence checks.
+        text = """Я прокидаюся — I wake up. Мене звати Олена. English support.
 
-Що ти робиш потім?**
-— **Вмиваюся, одягаюся, снідаю.**
-— **А коли ти йдеш на роботу?**
-— **О восьмій
+<DialogueBox uk="Доброго ранку, Олено." en="Good morning, Olena." />
+<DialogueBox uk="Я пишу план і читаю слова." en="I write a plan and read words." />
 
-| Особа | Форма |
-|---|---|
-| я | прокидаюся |
-| ти | прокидаєшся |
-| вона | прокидається |
+Прокидаюся — I wake up. Пишу — I write. Читаю — I read. Short support.
 """
 
     result = _advisory_immersion_pct(text, PLAN)

--- a/tests/test_learner_state_v7_layout.py
+++ b/tests/test_learner_state_v7_layout.py
@@ -136,7 +136,7 @@ def test_compute_immersion_band_uses_plan_only_learner_state(tmp_path, monkeypat
         for word_index in range(1, 9)
     ]
     assert band["key"] == "a1-m04-06"
-    assert (band["advisory_pct_min"], band["advisory_pct_max"]) == (8, 30)
+    assert (band["advisory_pct_min"], band["advisory_pct_max"]) == (40, 55)
 
 
 def test_format_learner_state_contains_rule_footer_for_non_empty_state():

--- a/tests/test_reviewer_prompt_v7_register_rules.py
+++ b/tests/test_reviewer_prompt_v7_register_rules.py
@@ -19,9 +19,10 @@ REVIEWER_RULE_ANCHORS = (
     (
         "#R-AUDIENCE-LANGUAGE-A1",
         (
-            "REJECT Ukrainian metalanguage TO the A1 learner",
-            "A1 explanation prose stays in English",
-            "`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`",
+            "REJECT grammar-translation lectures",
+            "The module must teach Ukrainian through Ukrainian",
+            "`прокидаюся — I wake up`",
+            "`<DialogueBox uk=\"...\" en=\"...\" />`",
         ),
     ),
     (

--- a/tests/test_stress_annotation.py
+++ b/tests/test_stress_annotation.py
@@ -251,6 +251,14 @@ class TestURLsUntouched:
 class TestNoDuplicateStress:
     """AC: running annotator twice shouldn't double-stress."""
 
+    def test_marks_every_multi_syllable_occurrence(self):
+        text = "Мама читає. Мама пише."
+        result, count = annotate_stress(text)
+
+        assert count >= 4
+        assert result.count(STRESS_MARK) >= 4
+        assert result.replace(STRESS_MARK, "") == text
+
     def test_idempotent(self):
         text = "Моя бабуся живе у Львові."
         result1, _count1 = annotate_stress(text)
@@ -272,6 +280,22 @@ class TestNoDuplicateStress:
             assert len(positions) <= 1, (
                 f"мама should have at most 1 stress mark after re-annotation, got {len(positions)}"
             )
+
+    def test_single_syllable_and_english_untouched(self):
+        text = "Кіт тут. English morning stays English."
+        result, count = annotate_stress(text)
+
+        assert count == 0
+        assert result == text
+
+    def test_dialoguebox_uk_attr_is_annotated(self):
+        text = '<DialogueBox uk="Моя мама читає." en="My mother reads." />'
+        result, count = annotate_stress(text)
+
+        assert count > 0
+        assert 'en="My mother reads."' in result
+        assert f"ма{STRESS_MARK}ма" in result or f"чита{STRESS_MARK}є" in result
+        assert '<DialogueBox uk="' in result
 
 
 class TestPerformance:
@@ -396,17 +420,19 @@ class TestAnnotateFileSafetyCheck:
         # Body has Ukrainian words that should get stressed
         assert count > 0, "Body content should have been stress-annotated"
 
-    def test_already_stressed_body_skips(self, tmp_path):
-        """If the body itself already has >5% stress marks, skip annotation."""
+    def test_already_stressed_body_is_idempotent(self, tmp_path):
+        """A fully stressed body should not receive duplicate marks."""
         from scripts.pipeline.stress_annotator import annotate_file
 
-        # Body with lots of pre-existing stress marks (>5%)
-        stressed_body = (f"Моя{STRESS_MARK} ма{STRESS_MARK}ма працю{STRESS_MARK}є "
-                        f"в шко{STRESS_MARK}лі дуже до{STRESS_MARK}бре. ") * 30
+        stressed_body = (
+            f"Моя{STRESS_MARK} ма{STRESS_MARK}ма працю{STRESS_MARK}є "
+            f"в шко{STRESS_MARK}лі ду{STRESS_MARK}же до{STRESS_MARK}бре. "
+        ) * 30
         content = f"<!-- TAB:Урок -->\n\n{stressed_body}\n"
 
         md_file = tmp_path / "test-stressed.md"
         md_file.write_text(content, encoding="utf-8")
 
         count = annotate_file(md_file)
-        assert count == 0, "Already-stressed body should be skipped"
+        assert count == 0, "Already-stressed body should be idempotent"
+        assert md_file.read_text(encoding="utf-8") == content

--- a/tests/test_ulp_immersion_calibration.py
+++ b/tests/test_ulp_immersion_calibration.py
@@ -39,7 +39,7 @@ def test_ulp_derivation_falls_back_to_static_policy_without_learner_state(monkey
     band = config.compute_immersion_band("a1", 20)
 
     assert band["key"] == "a1-m15-24"
-    assert (band["advisory_pct_min"], band["advisory_pct_max"]) == (15, 24)
+    assert (band["advisory_pct_min"], band["advisory_pct_max"]) == (40, 55)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_writer_prompt_v7_register_rules.py
+++ b/tests/test_writer_prompt_v7_register_rules.py
@@ -19,9 +19,10 @@ WRITER_RULE_ANCHORS = (
     (
         "#R-AUDIENCE-LANGUAGE-A1",
         (
-            "A1 explanation prose stays in English",
-            "Ukrainian appears only as TARGET",
-            "`Контролюй чистоту словника`, `Рішуче відкидай`, `Запам'ятай...`",
+            "A1/A2 audience language — ULP immersion",
+            "Ukrainian-first, em-dash gloss",
+            "`прокидаюся — I wake up`",
+            "`<DialogueBox uk=\"...\" en=\"...\" />`",
         ),
     ),
     (


### PR DESCRIPTION
## Root cause

- A1/A2 writer rules instructed English explanation prose with Ukrainian only as target material.
- `compute_immersion_band` emitted early-A1 language-role text saying English carried theory/explanation.
- V7 did not call the deterministic stress annotator, so generated modules could reach gates with zero stress marks.

## Changes

1. Replaced `R-AUDIENCE-LANGUAGE-A1` and the duplicated `linear-write.md` block with Anna Ohoiko/ULP S1 Ukrainian-first immersion directives.
2. Updated A1/A2 S1 immersion policy text and advisory range to 40-55% Ukrainian, including named persona, em-dash gloss, Ukrainian-only dialogue turns, and receding English support.
3. Wired deterministic stress annotation into V7 after writer artifacts and before downstream gates for `module.md` and `vocabulary.yaml`; the annotator is idempotent and covers `DialogueBox uk` props.
4. Added `scripts/audit/ulp_fidelity_gate.py` and wired it into V7 as a hard `REVISE` gate before `python_qg`, with resume artifact plumbing.

## Validation

- `.venv/bin/python -m pytest tests/ -k "ulp or stress or immersion or audience or linear_pipeline or deploy" -q`
  `= 332 passed, 1 skipped, 8242 deselected, 10 xfailed, 3 warnings in 221.41s (0:03:41) =`
- `.venv/bin/python -m pytest tests/test_deploy_script_idempotency.py tests/test_writer_prompt_v7_register_rules.py tests/test_reviewer_prompt_v7_register_rules.py -q`
  `============================== 18 passed in 2.14s ==============================`
- `.venv/bin/ruff check <changed python files>`
  `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
  `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.`

No auto-merge.