### PR TITLE
feat(bio): 8 Phase-1 research dossiers (#2309)

### DIFF
--- a/docs/research/bio/bohdan-horyn.md
+++ b/docs/research/bio/bohdan-horyn.md
@@ -1,0 +1,125 @@
+# Горинь Богдан Миколайович — Research Dossier
+
+**Slug:** `bohdan-horyn`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Горинь Богдан Миколайович.
+- **Pseudonyms / aliases:** Bohdan Horyn; Богдан Горинь.
+- **Born:** 1936-02-10 | Kniselo, now Lviv oblast | Second Polish Republic. Sources: ESU "Горинь Богдан Миколайович"; KHPG biography; UINP calendar article.
+- **Died:** Not applicable as of sources retrieved; ESU and 2026 *Україна Молода* article treat him as living. If this changes after 2026-05-30, source not found in this research batch.
+- **Family / education key facts:** Brother of Mykhailo and Mykola Horyn; graduated from Lviv University in 1959; worked at the Lviv House of Folk Art, taught, then was a researcher at the Lviv Museum of Ukrainian Art. ESU and KHPG corroborate these facts.
+
+## 2. Oppression mechanism
+
+- **What happened:** Family deportation attempt, arrest in the first post-thaw wave, imprisonment in Mordovia, post-release professional blocking and publication ban.
+- **When:** On 1944-12-25, UINP and KHPG state that NKVD personnel moved his pregnant mother and two sons toward Khodoriv for deportation to Siberia, but the family escaped. In 1965, he was arrested in the first wave against Ukrainian intellectuals. ESU says he was sentenced to 3 years imprisonment for "anti-Soviet activity"; UINP says he served in camp No. 11 at Yavas in the Mordovian ASSR. He avoided arrest in the January 1972 wave, according to UINP.
+- **By whom:** NKVD in the 1944 family deportation attempt; KGB / Soviet court in the 1965 case.
+- **Document references:** ESU records the 1965 conviction as "за антирад. діяльність"; KHPG biography identifies him as a shistdesiatnyk, samvydav organizer, and rights/national-democratic movement figure. UINP names the camp and later publication consequences.
+- **Mechanism specifics:** The first arrest wave targeted the Lviv shistdesiatnyky network that organized lectures, contacts with Kyiv writers, and samvydav. ESU states that Horyn was deputy president of Lviv's Creative Youth Club "Пролісок," organized and distributed samvydav, and was imprisoned in Mordovia. UINP adds that in Yavas he met Levko Lukyanenko, Opanas Zalyvakha, Ivan Hel, Ivan Kandyba, Mykhailo Soroka, and members of the Ukrainian Workers' and Peasants' Union. After release he could not return to regular intellectual work and cycled through manual jobs; UINP states that even while employed at the Lviv Art Gallery, none of his art-history articles was allowed to appear.
+- **What survived / what was destroyed:** His professional trajectory was interrupted, but he became a founder of the Ukrainian Helsinki Union, co-author of its program document "Декларація принципів," organizer of the 1989 Rukh founding congress, MP in 1990-1998, and later author of major documentary and art-history books. ESU and UINP both list post-1987 civic roles; UINP records the 2019 Shevchenko Prize for *Святослав Гординський на тлі доби*.
+
+## 3. Major works
+
+- `1960s` — literary and art criticism before imprisonment, noted by ESU.
+- `1968` — materials collected with Ivan Kandyba about the Ukrainian Workers' and Peasants' Union published in Munich as *Українські юристи під судом КГБ*, per UINP.
+- `1987` — editorial work with the revived *Український вісник*, per UINP.
+- `1988` — co-founder of the Ukrainian Helsinki Union and co-author of "Декларація принципів," per ESU and UINP.
+- `1994` — *Опанас Заливаха. Вибір шляху*, listed by ESU/UINP.
+- `2006-2010` — *Не тільки про себе*, three-volume documentary novel-collage, described by publisher listings and UINP.
+- `2010s` — *Любов і творчість Софії Караффи-Корбут*, art-history/literary study, per UINP.
+- `2019` — *Святослав Гординський на тлі доби*, Shevchenko Prize-winning study, per UINP and 2026 *Україна Молода*.
+- `2024` — *Під ковпаком окупантів*, noted in 2026 *Україна Молода* article.
+
+## 4. Primary-source quotes
+
+> "Ніколи до тої сатанинської влади не мав..."
+
+Source: Bohdan Horyn's 2026 public remarks quoted in *Україна Молода* on his 90th anniversary. The line is a primary oral-history source on his view of Stalinist/Soviet power.
+
+> "творити, боротися і силою духу переборювати труднощі"
+
+Source: same *Україна Молода* account of Horyn's speech, reflecting on the Shevchenko evening organized in a camp. It is useful as a concise statement of camp-era cultural resistance.
+
+## 5. Language register
+
+- **Register:** Memoir-documentary, publicistic, art-historical, parliamentary-political.
+- **CEFR readiness for full reading:** B2 for interview/speech excerpts; C1 for documentary prose and art criticism.
+- **Lexicon notes:** Teach `самвидав`, `мистецтвознавець`, `концтабір`, `політв'язень`, `Декларація принципів`, `Українська Гельсінська спілка`.
+- **Stylistic features:** Evidence-heavy recollection, archive-based collage, rhetorical moral judgment, and art-historical description.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His later documentary self-writing blurs memoir, archive, and political testimony; that is a strength if taught with source criticism, not as unmediated memory.
+- **What gets simplified in popular memory:** "Brother of Mykhailo Horyn" misses his independent role as art historian, samvydav organizer, UHS founder, Rukh organizer, and post-Soviet documentary author.
+- **Where modern Russian disinformation attacks them:** Soviet framing of "anti-Soviet activity" hides cultural organization, samvydav, and rights work. This dossier quotes such labels only as indictment language.
+- **Other-perspective considerations:** Family history includes OUN and UPA connections, but this non-Block-G dossier does not narrate military history. Its focus is documented civic/cultural resistance and post-1965 repression.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml`
+  - `curriculum/l2-uk-en/plans/hist/rukh.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/kulturna-rezystentsiia.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-dysydentski-dzherela.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Mykhailo Horyn, Opanas Zalyvakha, Ivan Hel, Ivan Kandyba, Viacheslav Chornovil, and Levko Lukyanenko.
+- **Potential LIT additions surfaced by this research:**
+  - A documentary-prose module on *Не тільки про себе* as memory/archival collage, after rights review.
+
+## 8. Naming-canonical
+
+- **Slug:** `bohdan-horyn`
+- **EN canonical (BGN/PCGN 2010):** Bohdan Horyn
+- **UA canonical (with patronymic):** Горинь Богдан Миколайович
+- **Aliases (track these for `aliases:` YAML field):** Bohdan Horyn', Bogdan Horyn
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Bogdan Goryn, Bogdan Gorin (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ESU entry photo for "Горинь Богдан Миколайович"; verify reuse terms.
+- **Backup candidates:** UINP article images; *Україна Молода* 2026 event photos by Taras Zdorovylo require permission.
+- **If no PD/CC portrait exists:** Use no portrait until permission from the Museum of the Sixtiers or family/archive.
+- **Era-appropriate context image:** Rights-cleared image of the Lviv Art Gallery-era Opanas Zalyvakha exhibition or *Український вісник* cover.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Горинь Богдан Миколайович" | https://esu.com.ua/article-31257 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- KHPG Virtual Museum, "Горинь Богдан Миколайович" | https://museum.khpg.org/1113894082 | accessed 2026-05-30
+- Ukrainian Institute of National Memory, "1936 - народився Богдан Горинь, дисидент" | https://uinp.gov.ua/istorychnyy-kalendar/lyutyy/10/1936-narodyvsya-bogdan-goryn-dysydent | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Богдан Горинь" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- *Україна Молода*, "Будитель нації..." | https://umoloda.kyiv.ua/number/4000/164/193397/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- *Україна Молода* transcript-style excerpts of Bohdan Horyn's 90th-anniversary public remarks.
+- KHPG biography with repression chronology.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No Russian-imperial transliterations in body text
+- [x] OUN/UPA-adjacent family context not expanded into Block G military narrative
+- [x] Soviet legal labels quoted only as prosecution language
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms
+- [x] Holodomor not central here
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/hryhir-tiutiunnyk.md
+++ b/docs/research/bio/hryhir-tiutiunnyk.md
@@ -1,0 +1,127 @@
+# Тютюнник Григір Михайлович — Research Dossier
+
+**Slug:** `hryhir-tiutiunnyk`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Тютюнник Григір Михайлович; civil given-name form Григорій.
+- **Pseudonyms / aliases:** Hryhir Tiutiunnyk; Hryhorii Tiutiunnyk; Григір Тютюнник.
+- **Born:** 1931-12-05 | Shylivka, Zinkiv raion, Poltava oblast | Ukrainian SSR. Sources: IEU "Tiutiunnyk, Hryhir"; Ukrainian Wikipedia via MCP; `mcp__sources.search_text` Grade 11 textbook results.
+- **Died:** 1980-03-06 in Kyiv according to Ukrainian Wikipedia and school-textbook sources; IEU gives 1980-03-07. This dossier flags the discrepancy rather than silently resolving it. The event is described as suicide in IEU and Ukrainian Wikipedia; the exact overnight timing likely explains the one-day difference.
+- **Family / education key facts:** Son of Mykhailo Tiutiunnyk and Hanna Syvokin; father arrested during the Great Terror in the night of 1937-11-29/30 and posthumously rehabilitated in 1958, per Ukrainian Wikipedia and textbook excerpts retrieved by MCP. Younger brother of writer Hryhorii Tiutiunnyk. Graduated from Kharkiv University in 1962, per IEU and Ukrainian Wikipedia.
+
+## 2. Oppression mechanism
+
+- **What happened:** Family repression, censorship and hostile official criticism, non-publication of works during life, psychological pressure; no sourced arrest of Hryhir Tiutiunnyk himself was found.
+- **When:** Father's arrest in 1937; writer's censorship/criticism intensified through the 1970s. IEU states that Soviet critics were hostile because his prose diverged from socialist realism and that in response to the critics' hostility he committed suicide. Ukrainian Wikipedia states that works were printed reluctantly, criticized harshly, and some were not published in his lifetime. `mcp__sources.search_literary` textbook result says *Три зозулі з поклоном* was written in 1976 and not printed during the author's lifetime.
+- **By whom:** NKVD for the father's arrest; Soviet literary censorship/official criticism for the writer's professional pressure. Specific KGB file or court case for Hryhir himself: source not found.
+- **Document references:** Source not found for a named KGB case against Hryhir Tiutiunnyk. IEU and textbook sources support censorship/criticism but do not give a file number.
+- **Mechanism specifics:** His prose centered rural trauma, moral injury, orphaned childhood, hunger, and loneliness without conforming to Soviet triumphalist formulas. IEU explicitly states that he did not conform to socialist realism and that critics were ill-disposed to his work. Textbook sources retrieved through MCP show that *Три зозулі з поклоном* was withheld during his lifetime and framed as a work of "love supreme" rather than Soviet heroic plot. The father-arrest trauma was not background decoration: school-textbook excerpts preserve his own recollection that his father was arrested when he turned forty.
+- **What survived / what was destroyed:** The posthumous two-volume *Твори* (1985) and Shevchenko Prize recognition in 1989 restored his place in the canon. IEU notes posthumous recognition during democratization; Ukrainian Wikipedia lists posthumously published works and later editions.
+
+## 3. Major works
+
+- `1961` — "В сумерки," first publication in Russian; Ukrainian Wikipedia states he later switched to Ukrainian.
+- `1966` — *Зав'язь*, first short-story collection, per IEU and textbook sources.
+- `1969` — *Деревій*, short-story collection and title story recognized in a 1968 competition, per IEU and Ukrainian Wikipedia.
+- `1969` — *Облога*, novella, per IEU.
+- `1970` — *Ласочка*, children's stories, per Ukrainian Wikipedia.
+- `1972` — *Батьківські пороги*, collection, per IEU.
+- `1973` — *Степова казка*, children's book, per Ukrainian Wikipedia.
+- `1975` — *Крайнебо*, collection, per IEU.
+- `1976` — *Климко*, novella; Lesia Ukrainka Prize recognition in 1980, per Ukrainian Wikipedia.
+- `1976` — "Три зозулі з поклоном," novella; textbook source says not printed during his lifetime.
+- `1978` — *Коріння*, collection, per Ukrainian Wikipedia and textbook sources.
+- `1979` — *Вогник далеко в степу*, novella, per Ukrainian Wikipedia.
+- `1981` — *Вибрані твори*, posthumous edition.
+- `1985` — *Твори*, two volumes; IEU says it marked posthumous recognition.
+
+## 4. Primary-source quotes
+
+> "Ніколи не працював над темою."
+
+Source: Grade 7/11 textbook corpus result via `mcp__sources.search_text`, quoting Tiutiunnyk's craft statement that he worked on feelings rather than topics. It is excellent for learners because it shifts literary analysis from plot labels to emotional precision.
+
+> "Любові всевишній присвячується."
+
+Source: dedication to "Три зозулі з поклоном," retrieved in `mcp__sources.search_literary` Grade 11 Borzenko result. It frames the novella outside Soviet ideological categories.
+
+## 5. Language register
+
+- **Register:** Rural psychological realism, compressed novella prose, colloquial-lyrical narration.
+- **CEFR readiness for full reading:** B2 for guided short stories; C1 for full stylistic analysis.
+- **Lexicon notes:** Rural speech, emotional understatement, kinship vocabulary, hunger/war childhood terms, and moral-ethical lexicon such as `милосердя`, `самовідданість`, `доброта`.
+- **Stylistic features:** Exact detail, dialogue-driven characterization, silence, restrained tragedy, and folk-inflected idiom without folklore decoration.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** How directly to connect his suicide to censorship and official hostility. IEU supports the link to hostile criticism; claims of a specific KGB campaign against him were not retrieved and should not be asserted without evidence.
+- **What gets simplified in popular memory:** He is often reduced to a "sad rural prose writer." The sources show a highly disciplined modern short-prose artist, translator, children's writer, and shistdesiatnyky-era prose innovator.
+- **Where modern Russian disinformation attacks them:** The Soviet simplification would read his refusal of socialist-realist optimism as pessimism or lack of ideological clarity. The retrieved sources support teaching it as moral realism.
+- **Other-perspective considerations:** His father's Great Terror arrest and his own Russian-to-Ukrainian language shift make his biography a strong decolonization case without needing to invent direct imprisonment.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/tiutiunnyk-novella-mastery.yaml`
+  - `curriculum/l2-uk-en/plans/lit/tiutiunnyk-three-cuckoos.yaml`
+  - `curriculum/l2-uk-en/plans/lit/yevhen-hutsalo-shistdesiatnyky.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Hryhorii Tiutiunnyk, Yevhen Hutsalo, Valerii Shevchuk, and Oles Honchar.
+- **Potential LIT additions surfaced by this research:**
+  - A source-study activity comparing the 1980-03-06 / 1980-03-07 death-date discrepancy.
+
+## 8. Naming-canonical
+
+- **Slug:** `hryhir-tiutiunnyk`
+- **EN canonical (BGN/PCGN 2010):** Hryhir Tiutiunnyk
+- **UA canonical (with patronymic):** Тютюнник Григір Михайлович
+- **Aliases (track these for `aliases:` YAML field):** Григорій Тютюнник, Hryhorii Tiutiunnyk, Hryhir Tyutyunnyk
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Grigor Tyutyunnik, Grigor Tiutiunnik (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** IEU image "Hryhir Tiutiunnyk"; verify license before reuse.
+- **Backup candidates:** Wikimedia Commons or Central State Archive-Museum of Literature and Art materials; verify rights.
+- **If no PD/CC portrait exists:** Use no portrait until rights are confirmed.
+- **Era-appropriate context image:** Rights-cleared image of Shylivka/Poltava rural landscape only if not falsely presented as a specific biographical site.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine, "Tiutiunnyk, Hryhir" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CT%5CI%5CTiutiunnykHryhir.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Ukrainian textbook corpus via `mcp__sources.search_text` and `mcp__sources.search_literary`, including Grade 11 Avramenko/Borzenko chunks on Tiutiunnyk | accessed 2026-05-30
+- Ukrainian Bibliography for Children, "Тютюнник Григір (Григорій) Михайлович" | https://uhb.chl.kiev.ua/autors/338-hryhir-hryhorii-mykhailovych-tiutiunnyk | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Тютюнник Григір Михайлович" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Oleksii Nezhyvyi, Tiutiunnyk textual/source-study bibliography from Ukrainian Wikipedia references; not directly accessed.
+
+**Primary-source documents accessed:**
+- Textbook-corpus excerpts quoting Tiutiunnyk's craft statements and *Три зозулі з поклоном* dedication.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No fabricated KGB case; direct KGB persecution marked source not found
+- [x] No Russian-imperial transliterations in body text
+- [x] Date discrepancy flagged
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms
+- [x] Holodomor not central except broader rural trauma context
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/ihor-kalynets.md
+++ b/docs/research/bio/ihor-kalynets.md
@@ -1,0 +1,127 @@
+# Калинець Ігор Миронович — Research Dossier
+
+**Slug:** `ihor-kalynets`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Калинець Ігор Миронович.
+- **Pseudonyms / aliases:** Ihor Kalynets; Ihor Kalynec; Ігор Калинець.
+- **Born:** 1939-07-09 | Khodoriv, now Stryi raion, Lviv oblast | then Polish-ruled western Ukraine. Sources: ESU "Калинець Ігор Миронович"; IEU "Kalynets, Ihor"; KHPG biography.
+- **Died:** 2025-06-28 | Lviv | Ukraine. Sources: ESU updated article; KHPG memorial article "In Memory of Ihor Kalynets"; `mcp__sources.search_sources` Ukrainian-wiki corpus result "Ігор Калинець: Поезія як вчинок".
+- **Family / education key facts:** Husband of Iryna Kalynets; graduated from Lviv University; worked in the Lviv Oblast Archive until his 1972 arrest. ESU and KHPG corroborate education and employment; IEU gives the English-language scholarly baseline.
+
+Because Kalynets died after many older reference works were written, date-sensitive claims here use ESU and the KHPG 2025 memorial rather than older IEU text alone.
+
+## 2. Oppression mechanism
+
+- **What happened:** Publication suppression, KGB surveillance, arrest, sentence to camps and exile, blacklisting.
+- **When:** KHPG states that the type for his first planned collection *Екскурсії* was broken up for "ideological reasons" in 1963. From 1965, Ihor and Iryna were under KGB surveillance. Iryna was arrested in January 1972; Ihor was arrested 1972-08-11. ESU and KHPG both give the sentence: 6 years in strict-regime camps and 3 years of exile.
+- **By whom:** KGB / КДБ; Soviet court under Article 62 part 1 of the Criminal Code of the UkrSSR.
+- **Document references:** KHPG names Article 62 part 1, "anti-Soviet agitation and propaganda"; ESU gives the same accusation. KHPG records that the court used a KGB-ordered literary expert analysis of five Kalynets collections.
+- **Mechanism specifics:** The state treated poetic publication abroad as criminal evidence. IEU states that he was imprisoned because his poetry had appeared in the West; KHPG specifies that prosecutors cited foreign publication, dedication to Valentyn Moroz, contacts with "unreliable" people and foreigners, and literary expert reports commissioned by the KGB. He served first in Perm camp No. 35 near Vsekhsvyatska, then in camp No. 36 at Kuchino, took part in camp-resistance statements, letters, hunger strikes, and camp chronicles. Exile was in Chita oblast, where KHPG says he and Iryna worked in collective-farm conditions.
+- **What survived / what was destroyed:** The poems survived through samvydav and western editions: *Поезії з України* (Brussels, 1970), *Підсумовуючи мовчання* (Munich, 1971), and *Коронування опудала* (New York, 1972). ESU and IEU state that his collected poetic corpus was later divided into *Пробуджена муза* and *Невольнича муза*. His "muse" was largely silenced after release, but he became an editor of *Євшан-зілля* and later wrote for children.
+
+## 3. Major works
+
+- `1963` — *Екскурсії*, planned first collection; KHPG says the typeset was broken up for ideological reasons.
+- `1966` — *Вогонь Купала*, poetry collection, Kyiv; ESU and IEU state that it was withdrawn/confiscated after publication.
+- `1970` — *Поезії з України*, Brussels; western edition, later reissued as *Відчинення вертепу*.
+- `1971` — *Підсумовуючи мовчання*, Munich; dedicated to Valentyn Moroz according to KHPG.
+- `1972` — *Коронування опудала*, New York; western publication cited by ESU and IEU.
+- `1972` — *Молімось зорям дальнім*, prose written during imprisonment in Lviv jail; IEU states it appeared in *Suchasnist* in 1994.
+- `1991` — *Пробуджена муза* and *Невольнича муза*, collected poetry volumes; IEU and the MCP Ukrainian-wiki corpus identify the division.
+- `1992` — *Тринадцять аналогій*, Shevchenko Prize recognition per ESU.
+- `1998` — *Дурні казки*, children's book, noted by IEU.
+
+## 4. Primary-source quotes
+
+> "Моя поезія до арешту - це суцільна присвята..."
+
+Source: Ihor Kalynets interview excerpt retrieved via `mcp__sources.search_sources`, linked to *Дивослово* / later interview material in the Ukrainian-wiki corpus "Ігор Калинець: Поезія як вчинок." This is a compact self-definition of the pre-arrest poems as national dedication rather than private ornament.
+
+> "Січень 22, День Злуки і Свободи України."
+
+Source: Volodymyr Marmus recollection in KHPG "In Memory of Ihor Kalynets," recounting Kalynets's camp gathering on 22 January. It matters pedagogically because it turns a calendar date into a covert prison ritual.
+
+## 5. Language register
+
+- **Register:** Neo-baroque, imagistic, culturally allusive lyric; later children's prose and civic speech.
+- **CEFR readiness for full reading:** C1 for lyric cycles; B1-B2 for selected children's texts.
+- **Lexicon notes:** High density of ritual, Christian, baroque, folklore, and Antonych-derived imagery; teach `самвидав`, `заслання`, `табір`, `невольнича`, `вертеп`, `алюзія`.
+- **Stylistic features:** Cyclical architecture, mythic time, calendrical motifs, dense metaphor, and indirect political coding.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** How to stage Kalynets for learners: as a dissident first, as a difficult neo-baroque poet first, or as the rare figure in whom the two cannot be separated.
+- **What gets simplified in popular memory:** "Poet-political prisoner" is true but too thin. ESU and IEU show a long formal evolution: archive worker, samvydav poet, camp resister, editor of uncensored *Євшан-зілля*, children's writer, and civic moral authority.
+- **Where modern Russian disinformation attacks them:** Soviet-style framing criminalized western publication and Ukrainian cultural memory as "anti-Soviet activity." Dossier language treats that as prosecution terminology, not fact.
+- **Other-perspective considerations:** His work is rooted in western Ukrainian memory but became a national and diaspora text through Brussels, Munich, New York, Warsaw, Baltimore, Toronto, and Lviv publication channels.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/kalynets-dissident-poetry.yaml`
+  - `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Iryna Kalynets, Ivan Svitlychnyi, Vasyl Stus, Valentyn Moroz, and the Chortkiv flag-raising group.
+- **Potential LIT additions surfaced by this research:**
+  - A scaffolded close-reading of *Відчинення вертепу* with copyright-safe short excerpts.
+
+## 8. Naming-canonical
+
+- **Slug:** `ihor-kalynets`
+- **EN canonical (BGN/PCGN 2010):** Ihor Kalynets
+- **UA canonical (with patronymic):** Калинець Ігор Миронович
+- **Aliases (track these for `aliases:` YAML field):** Ihor Kalynec, Igor Kalynets, Ігор Калинець
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Igor Kalinets, Igor Kalinec (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** IEU images "Ihor Kalynets" and "Ihor and Iryna Kalynets"; verify license before reuse.
+- **Backup candidates:** KHPG memorial portrait; Lviv funeral photos are recent and require rights clearance.
+- **If no PD/CC portrait exists:** Use a rights-cleared cover image from a post-1991 edition only after permission.
+- **Era-appropriate context image:** A rights-cleared photo of Perm-36/Kuchino memorial context or a *Євшан-зілля* cover.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Калинець Ігор Миронович" | https://esu.com.ua/article-10472 | accessed 2026-05-30
+- Internet Encyclopedia of Ukraine, "Kalynets, Ihor" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CA%5CKalynetsIhor.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- KHPG Virtual Museum, "Калинець Ігор Миронович" | https://museum.khpg.org/1113911396 | accessed 2026-05-30
+- KHPG, "In Memory of Ihor Kalynets" | https://museum.khpg.org/en/1628665441 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Ігор Калинець" via `mcp__sources.query_wikipedia` and `mcp__sources.search_sources` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Petro Shkrabiuk, *Попід золоті ворота*; Mykola Ilnytskyi, *Ключем метафори відімкнені вуста* (bibliographic references from IEU; not directly accessed).
+
+**Primary-source documents accessed:**
+- KHPG biography reproducing charges under Article 62 and camp details.
+- KHPG memorial recollection by Volodymyr Marmus.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] Russian/Soviet accusation labels treated as prosecution language
+- [x] No Russian-imperial transliterations in body text
+- [x] Existing paths verified
+- [x] No unsupported claim about 2025 death without current sources
+- [x] Place names use Ukrainian canonical forms
+- [x] Holodomor not central here
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/iryna-kalynets.md
+++ b/docs/research/bio/iryna-kalynets.md
@@ -1,0 +1,128 @@
+# Калинець Ірина Онуфріївна (Стасів-Калинець) — Research Dossier
+
+**Slug:** `iryna-kalynets`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Калинець Ірина Онуфріївна; birth surname and dissident-archive form: Стасів-Калинець Ірина Онуфріївна.
+- **Pseudonyms / aliases:** Iryna Kalynets; Iryna Stasiv-Kalynets; Ірина Стасів-Калинець.
+- **Born:** 1940-12-06 | Lviv | Ukrainian SSR under Soviet occupation after the 1939 annexation. Sources: ESU "Калинець Ірина Онуфріївна"; KHPG "Стасів-Калинець Ірина Онуфріївна"; Ukrainian Wikipedia summary via MCP.
+- **Died:** 2012-07-31 | Lviv | Ukraine. Sources: ESU; KHPG; Ukrainian Wikipedia summary via MCP.
+- **Family / education key facts:** Wife of Ihor Kalynets; mother of Zvenyslava Kalynets; graduated from Lviv University in 1964; worked as teacher, methodologist, librarian, and later professor at Lviv University. ESU gives the post-1991 education roles; KHPG gives the dissident-era work path and family separation caused by imprisonment.
+
+## 2. Oppression mechanism
+
+- **What happened:** Dismissal, KGB surveillance, arrest, interrogations involving pupils, conviction under Article 62, strict-regime camp, exile, family separation.
+- **When:** Dismissed in 1970; signed protests in 1970 and December 1971; arrested in Lviv on 1972-01-12; tried in July 1972; sentence was 6 years strict-regime camps plus 3 years exile. ESU and KHPG corroborate the sentence; KHPG provides the arrest and trial context.
+- **By whom:** KGB / КДБ of the Ukrainian SSR; Soviet court applying Article 62 part 1 of the Criminal Code of the UkrSSR.
+- **Document references:** KHPG states that she and Stefania Shabatura were tried under Article 62 part 1, "anti-Soviet agitation and propaganda." KHPG also records that the investigation called her pupils as witnesses.
+- **Mechanism specifics:** KHPG states that only two or three of roughly one hundred pupils gave testimony against her, alleging that she read poems dedicated to Viacheslav Chornovil, gave students Valentyn Moroz works, and spoke about an independent Ukraine. The investigators failed to prove participation in the Chornovil group or in the uncensored *Український вісник*, but the court convicted her anyway. She served in the women's Mordovian political zone ЖХ-385/3-4 at Barashevo, with Stefania Shabatura, Nadiia Svitlychna, and others, and took part in collective letters, hunger strikes, Easter-observance protests, and appeals to the UN and human-rights bodies. Exile was in Chita oblast.
+- **What survived / what was destroyed:** Her manuscripts survived across prison and exile in partial/post-Soviet publication. ESU lists manuscript collections *Лісовий Никифор*, *Дорога вигнання*, *Оранта*, *Крізь камінь*, *Тирсою в полі*, and *Остання з плакальниць*, with later inclusion in *Поезії* (New York, 1991) and *Шлюб із полином* (Lviv, 1995). The family was forced into nine years of separation from daughter Zvenyslava.
+
+## 3. Major works
+
+- `1959` — "Дика троянда," debut poem in *Жовтень*, per ESU.
+- `1965` — *Лісовий Никифор*, manuscript poetry collection, per ESU.
+- `1968-1971` — *Дорога вигнання*, manuscript cycle, per ESU.
+- `1969-1970` — *Оранта*, manuscript poetry collection, per ESU.
+- `1972-1979` — *Крізь камінь*, prison/exile-period poetry, per ESU.
+- `1973-1979` — *Тирсою в полі*, prison/exile-period poetry, per ESU.
+- `1974-1979` — *Остання з плакальниць*, prison/exile-period poetry, per ESU.
+- `1991` — *Поезії*, New York collection, per ESU.
+- `1995` — *Шлюб із полином*, Lviv collection, per ESU.
+- `1993-2002` — children's prose and cultural studies including *Лелека і Чорна Хмара*, *Пімбо-Бімбо*, and studies of Kyivan Rus' Christian culture, per ESU and UkrLib biography.
+- `1987-1989` — co-founder/editor of *Євшан-зілля* with Ihor Kalynets, per ESU.
+
+## 4. Primary-source quotes
+
+> "У школі обпльовувалося найсвятіше..."
+
+Source: Iryna Stasiv-Kalynets recollection quoted in KHPG biography and expanded in the 2008 KHPG interview recorded by Vasyl Ovsiienko. It is a precise learner-facing statement about double consciousness under Soviet schooling.
+
+> "Так, я ходила."
+
+Source: KHPG interview, where she recalls answering a teacher who demanded to know whether pupils had gone to church. The line matters because it compresses religious, family, and national dissent into an ordinary school moment.
+
+## 5. Language register
+
+- **Register:** Lyric-sacral, historical-cultural essay, pedagogical public speech.
+- **CEFR readiness for full reading:** C1 for poetry and cultural studies; B2 for selected autobiographical interview excerpts.
+- **Lexicon notes:** Learners need `політв'язень`, `заслання`, `самвидав`, `Українська греко-католицька церква`, `Оранта`, `вигнання`, `правозахисний`.
+- **Stylistic features:** Religious imagery, lament/trenos forms, historical layering from Kyivan Rus' to dissident modernity, and direct testimony in interviews.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The balance between her literary work, children's writing, scholarship, and political/education reform roles after 1990. ESU's entry shows that the post-release life is not an appendix but a second major phase.
+- **What gets simplified in popular memory:** "Wife of Ihor Kalynets" is a misleading shortcut. ESU and KHPG document an independent writer, organizer, political prisoner, MP, educational reformer, and professor.
+- **Where modern Russian disinformation attacks them:** Soviet accusations treated classroom Ukrainian history, independent Ukraine, and religious observance as criminal. The dossier quotes those accusations only as evidence of repression.
+- **Other-perspective considerations:** Her family memory includes UGCC persecution and relatives linked to OUN. This dossier avoids turning that background into a Block G military narrative; the subject here is her documented cultural and human-rights resistance.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/kalynets-dissident-poetry.yaml`
+  - `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml`
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/kulturna-rezystentsiia.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Ihor Kalynets, Stefania Shabatura, Nadiia Svitlychna, Viacheslav Chornovil, Valentyn Moroz, and Nina Strokata.
+- **Potential LIT additions surfaced by this research:**
+  - A women political-prisoners unit pairing Kalynets, Shabatura, Svitlychna, and Strokata through verified KHPG testimony.
+
+## 8. Naming-canonical
+
+- **Slug:** `iryna-kalynets`
+- **EN canonical (BGN/PCGN 2010):** Iryna Kalynets
+- **UA canonical (with patronymic):** Калинець Ірина Онуфріївна
+- **Aliases (track these for `aliases:` YAML field):** Ірина Стасів-Калинець, Iryna Stasiv-Kalynets, Iryna Stasiv
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Irina Kalinets, Irina Stasiv-Kalinets (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ESU entry image for "Калинець Ірина Онуфріївна"; rights must be checked before reuse.
+- **Backup candidates:** KHPG Virtual Museum portrait; IEU image of Ihor and Iryna Kalynets; verify license.
+- **If no PD/CC portrait exists:** Use no portrait in Phase 2 and request rights from a museum/archive.
+- **Era-appropriate context image:** Rights-cleared image of Mordovian women's political-camp memorial context or *Євшан-зілля* cover.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Калинець Ірина Онуфріївна" | https://esu.com.ua/article-10473 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- KHPG Virtual Museum, "Стасів-Калинець Ірина Онуфріївна" | https://museum.khpg.org/1113999256 | accessed 2026-05-30
+- Vasyl Ovsiienko, "Калинець-Стасів Ірина. Інтерв'ю" | https://museum.khpg.org/1383774632 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Ірина Калинець" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- ESU bibliography for her literary and cultural studies; direct scholarly monographs not accessed.
+
+**Primary-source documents accessed:**
+- KHPG interview recorded 2008-06-26 by Vasyl Ovsiienko.
+- KHPG biography reproducing Article 62 case details and camp actions.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No Russian-imperial transliterations in body text
+- [x] No conflation of family OUN background with this non-Block-G dossier
+- [x] Soviet legal accusations quoted only as repression evidence
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms
+- [x] Holodomor not central here
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/ivan-svitlychnyi.md
+++ b/docs/research/bio/ivan-svitlychnyi.md
@@ -1,0 +1,126 @@
+# Світличний Іван Олексійович — Research Dossier
+
+**Slug:** `ivan-svitlychnyi`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Світличний Іван Олексійович.
+- **Pseudonyms / aliases:** Ivan Svitlychny; Ivan Svitlychnyi; Іван Світличний.
+- **Born:** 1929-09-20 | Половинкине, тоді Луганська округа / нині Луганська область | Українська СРР. Sources: IEU "Svitlychny, Ivan"; KHPG "Світличний Іван Олексійович"; НБУВ anniversary note.
+- **Died:** 1992-10-25 | Kyiv | independent Ukraine. Sources: IEU; KHPG; Radio Svoboda "Країна Інкогніта: Іван Світличний".
+- **Family / education key facts:** Brother of dissident Nadiia Svitlychna; graduated from Kharkiv University philology in 1952; worked in literary studies and lexicography before political dismissal. IEU lists his work at *Radianske literaturoznavstvo*, the Institute of Literature, and the dictionary department of the Institute of Linguistics; KHPG and НБУВ corroborate the literary-critic, poet, translator, and human-rights profile.
+
+The sources agree on the core dates. KHPG gives the richest account of the apartment on Umanska Street as a hub of shistdesiatnyky networking and samvydav; IEU gives the compact scholarly baseline.
+
+## 2. Oppression mechanism
+
+- **What happened:** Political surveillance, dismissal, two arrests, imprisonment, internal exile, health destruction.
+- **When:** Fired and first arrested in 1965; released after about eight months. Second arrest occurred in the January 1972 crackdown, with search on 1972-01-12 and later trial on 1973-04-27 to 1973-04-29. Sentence: 7 years strict-regime camps plus 5 years internal exile.
+- **By whom:** KGB / КДБ of the Ukrainian SSR; Kyiv regional court; Soviet camp administration in Perm camps ВС-389/35 and ВС-389/36.
+- **Document references:** KHPG identifies the "Справа Добоша" as the formal pretext; KHPG states the charge under Article 62 part 1 of the Criminal Code of the UkrSSR, "anti-Soviet agitation and propaganda." IEU states the charge as contributing to and distributing samvydav.
+- **Mechanism specifics:** KHPG records that the 1972 search removed Ukrainian and Russian samvydav, books, a typewriter, a radio receiver, and magnetic tapes with recordings of Vasyl Symonenko, Vasyl Stus, and others. The state attempted to recast cultural circulation as a foreign-linked conspiracy after the arrest of Belgian citizen Yaroslav Dobosh. IEU reports that Svitlychnyi was sentenced on 1972-era samvydav activity; KHPG gives the court dates and the exact sentence. In the camps he joined collective protest actions and hunger strikes; KHPG records a 56-day hunger strike and punishment in SHIZO/PKT. In January 1978, KHPG says he contracted Botkin's disease through an unclean syringe in the zone hospital; on 1978-05-07 he was sent into exile to Ust-Kan in the Gorno-Altai region, arriving 1978-06-27.
+- **What survived / what was destroyed:** IEU and Radio Svoboda both state that he returned to Kyiv severely disabled after strokes suffered in exile. KHPG quotes Leonida Svitlychna's judgment that, physically, he died in 1992, but as a creative person he was destroyed by the August 1981 stroke in Altai. His poetry and criticism survived through post-Soviet publication, especially *Серце для куль і для рим* (1991).
+
+## 3. Major works
+
+- `1950s-1960s` — literary-critical articles in *Вітчизна*, *Радянське літературознавство*, and *Дніпро*; IEU notes that these began appearing while he was still a student.
+- `1960s` — criticism of socialist-realist simplification and support for shistdesiatnyky writing, including Ivan Dziuba, Vasyl Stus, and the Kyiv-Lviv network; KHPG identifies him as a moral authority of the movement.
+- `1960s-1970s` — translations from Czech, Slovak, French, and *Слово о полку Ігоревім*; IEU lists Nezval, Halas, Mahen, Hanzlik, Rufus, La Fontaine, Beranger, and Baudelaire.
+- `1970s` — camp and exile poetry; IEU states that some appeared in the West before Soviet-era rehabilitation.
+- `1991` — *Серце для куль і для рим*, poetry collection; IEU and Radio Svoboda identify it as his late-life collection.
+- `1994` — *У мене - тільки слово*; cited by Wikiquote's source notes for individual poems.
+- `2008` — *З живучого племені Дон Кіхотів* (with Nadiia Svitlychna), source collection cited by Wikiquote and later scholarship.
+
+## 4. Primary-source quotes
+
+> "Я - теж Вітчизна."
+
+Source: Ivan Svitlychnyi poem excerpt, cited in Wikiquote from *З живучого племені Дон Кіхотів* / *У мене - тільки слово*. This compact line is useful for B2-C1 learners because it turns patriotism from slogan into ethical responsibility.
+
+> "Серце - мішень для куль і для рим."
+
+Source: Ivan Svitlychnyi line cited in Wikiquote and echoed by the 1991 collection title *Серце для куль і для рим*. It gives a direct bridge between poetic form and political violence: rhyme and bullets aim at the same heart.
+
+## 5. Language register
+
+- **Register:** Compressed lyric, aphoristic public speech, learned literary criticism.
+- **CEFR readiness for full reading:** C1 for criticism; B2-C1 for selected poems.
+- **Lexicon notes:** Learners should know `самвидав`, `заслання`, `шістдесятники`, `русифікація`, `правозахисник`; VESUM verification found these forms and did not find the Russianism `русофікація`.
+- **Stylistic features:** Dense antithesis, ethical aphorism, prison lyric understatement, and intertextual references to Ukrainian and European poetry.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** How to weigh Svitlychnyi's role as poet against his larger role as organizer, critic, reader, and private cultural institution. IEU and KHPG both stress that his influence exceeded his published corpus.
+- **What gets simplified in popular memory:** He is sometimes remembered only as "доброокий" or as a victim of the 1972 arrests. KHPG and Radio Svoboda show a more precise role: bridge between Kyiv and Lviv, distributor of samvydav, translator, and camp-resistance participant.
+- **Where modern Russian disinformation attacks them:** The usual Soviet label, "anti-Soviet nationalist activity," should be quoted only as prosecution language. The evidence retrieved shows literary circulation, recordings, and samvydav, not violence.
+- **Other-perspective considerations:** He connected eastern Ukrainian origins, Kyiv literary circles, and Lviv dissident networks; this counters the false regional split often imposed on Ukrainian cultural history.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-essay/svitlychny-prison-lyrics.yaml`
+  - `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-dysydentski-dzherela.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Nadiia Svitlychna, Ivan Dziuba, Yevhen Sverstiuk, Vasyl Stus, Ihor Kalynets, and the Horyn brothers.
+- **Potential LIT additions surfaced by this research:**
+  - A short C1 text pack on Svitlychnyi as translator, using only verified poems and rights-cleared excerpts.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-svitlychnyi`
+- **EN canonical (BGN/PCGN 2010):** Ivan Svitlychnyi
+- **UA canonical (with patronymic):** Світличний Іван Олексійович
+- **Aliases (track these for `aliases:` YAML field):** Ivan Svitlychny, Ivan Svitlychnyj, Ivan Svitlychnyĭ, Іван Світличний
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ivan Svetlichny, Ivan Svetlichnyi (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** IEU image "Ivan Svitlychny (arrest photo)" and shistdesiatnyky group photos on IEU; license must be checked before reuse.
+- **Backup candidates:** KHPG Virtual Museum portrait; НБУВ anniversary page imagery if rights allow.
+- **If no PD/CC portrait exists:** Use a rights-cleared scan of a book cover only as a fallback and only after legal review.
+- **Era-appropriate context image:** A verified photo of the Kyiv Club of Creative Youth or a rights-cleared samvydav/typewriter image.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія українознавства* / Internet Encyclopedia of Ukraine, "Svitlychny, Ivan" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CV%5CSvitlychnyIvan.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Борис Захаров, "Світличний Іван Олексійович," Дисидентський рух в Україні / KHPG Virtual Museum | https://museum-old.khpg.org/1113995279 | accessed 2026-05-30
+- НБУВ, "Народився Іван Світличний..." | https://www.nbuv.gov.ua/node/4288 | accessed 2026-05-30
+- Radio Svoboda, "Країна Інкогніта: Іван Світличний" | https://www.radiosvoboda.org/a/941323.html | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikiquote, "Світличний Іван Олексійович" | accessed 2026-05-30
+- Ukrainian Wikipedia, "Світличний Іван Олексійович" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Roman Mokryk, *Бунт проти імперії* (cited by Wikiquote source notes; not directly accessed).
+
+**Primary-source documents accessed:**
+- KHPG biography's reproduced court/prosecution details for Article 62 and the Dobosh case.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No Russian-imperial transliterations in body text
+- [x] No Russocentric periodization
+- [x] Soviet labels quoted only as prosecution language
+- [x] No euphemism for state-caused health destruction
+- [x] Place names use modern UA canonical forms where applicable
+- [x] Holodomor not central here
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/mykhailo-horyn.md
+++ b/docs/research/bio/mykhailo-horyn.md
@@ -1,0 +1,125 @@
+# Горинь Михайло Миколайович — Research Dossier
+
+**Slug:** `mykhailo-horyn`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Горинь Михайло Миколайович.
+- **Pseudonyms / aliases:** Mykhailo Horyn; Mikhail Horyn in older English-language indexing.
+- **Born:** 1930-06-17 | Kniselo, now Lviv oblast | Second Polish Republic. Sources: ESU "Горинь Михайло Миколайович"; KHPG biography; UINP calendar article.
+- **Died:** 2013-01-13 | Lviv | Ukraine. Sources: ESU; KHPG; Suspilne biography.
+- **Family / education key facts:** Brother of Bohdan and Mykola Horyn; husband of Olha Horyn; father of Oksana Horyn. Graduated from Lviv University in 1954; worked as teacher, school director/inspector, then industrial psychologist at the Lviv forklift plant. ESU and KHPG corroborate education and early work; Suspilne summarizes the same path.
+
+## 2. Oppression mechanism
+
+- **What happened:** Attempted family deportation, university punishment, repeated arrest and imprisonment, prohibition from professional work, fabricated second case, severe health damage in camps.
+- **When:** December 1944 deportation attempt with his mother, according to KHPG and Suspilne. Arrested in 1965; convicted in 1966 to 6 years strict-regime camps. In 1967, while in Mordovia, sentenced to 3 years in Vladimir prison for "propaganda" and spreading samvydav among prisoners, per ESU. Re-arrested 1981-12-03 (UINP); convicted in 1982 to 10 years camps and 5 years exile; released in 1987 because of grave health deterioration; rehabilitated in 1990.
+- **By whom:** NKVD in the 1944 deportation attempt; KGB / КДБ in the dissident cases; Soviet courts; camp administrations in Mordovia, Vladimir prison, and Kuchino.
+- **Document references:** ESU records the 1966 and 1982 sentences; UINP specifies the 1981 arrest and KGB-planted false documents; Suspilne names the planted document allegedly from the Ukrainian Helsinki Group and the text called "Соціальні дослідження механізму русифікації на Україні."
+- **Mechanism specifics:** The first post-thaw case targeted the Lviv shistdesiatnyky network and samvydav circulation. ESU states that Horyn organized dissemination of political literature published abroad and samvydav production. Suspilne and UINP state that the 1981-1982 case lacked evidence and relied on planted materials meant to show continued "anti-Soviet activity." Horyn protested with a hunger strike; Suspilne states that on the tenth day he suffered a heart attack but still received 10 years in special/strict regime plus 5 years exile. UINP records his placement in Kuchino, where several Ukrainian political prisoners died in 1981-1985.
+- **What survived / what was destroyed:** His health was damaged by imprisonment, but he survived to organize the Ukrainian Helsinki Union, the Working Group for the Defense of Ukrainian Political Prisoners, the 1990 Chain of Unity, and parliamentary independence work. Suspilne states that he participated in the 1991 proclamation of independence as a deputy of the first convocation.
+
+## 3. Major works
+
+- `1960s` — methodological and labor-psychology articles and teacher materials, noted by ESU and Suspilne.
+- `1970s` — illegal *Бюлетень* of the Ukrainian Helsinki Group, which ESU says he issued in the late 1970s.
+- `1978` — UHG document quoted by Suspilne about party officials and state-security organs watching people who took paper rights seriously.
+- `1987` — role in reviving *Український вісник*, per ESU and Suspilne.
+- `1988` — co-author/organizer around the Ukrainian Helsinki Union declaration and Working Group for Defense of Ukrainian Political Prisoners, per Suspilne and UINP.
+- `1991-1994` — parliamentary work in sovereignty and diaspora-related commissions, per ESU and Suspilne.
+- `1994` — *Національно-визвольний рух в Україні*, listed by ESU.
+- `1995` — article "Чечня - мірило морального здоров'я Західної демократії," listed by ESU.
+
+## 4. Primary-source quotes
+
+> "Я піду в другому ешелоні."
+
+Source: Suspilne biography, recounting Horyn's written response when Mykola Rudenko and Oleksa Tykhy proposed open Helsinki participation. It helps learners see strategic sequencing, not passivity.
+
+> "А тому, що вмирають тільки українці."
+
+Source: Horyn's recollection quoted in Suspilne, about speaking to Kuchino camp chief Dolmatov after the deaths of Tykhy, Lytvyn, Marchenko, and Stus. The line is a direct witness statement about the ethnic-political pattern of camp deaths.
+
+## 5. Language register
+
+- **Register:** Publicistic, organizational, rights-document, oral-testimony.
+- **CEFR readiness for full reading:** B2 for interview excerpts; C1 for political documents.
+- **Lexicon notes:** Teach `самвидав`, `політв'язень`, `правозахисник`, `особливо небезпечний рецидивіст`, `ланцюг Злуки`, `реабілітація`.
+- **Stylistic features:** Strategic understatement, legal-document vocabulary, memoir detail, and post-1987 mass-movement rhetoric.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Horyn's relation to open Helsinki activism: Suspilne's "second echelon" episode shows a deliberate tactical delay rather than lack of commitment.
+- **What gets simplified in popular memory:** He is often reduced to "Rukh-era politician." ESU, KHPG, UINP, and Suspilne show earlier teacher, psychologist, samvydav organizer, prisoner, and international political-prisoner advocate roles.
+- **Where modern Russian disinformation attacks them:** The Soviet prosecution language of "especially dangerous state criminal" and "anti-Soviet activity" should be treated as a fabricated security frame. Retrieved sources describe planted materials and human-rights activity.
+- **Other-perspective considerations:** His family history includes OUN/UPA repression context, but this dossier stays outside Block G and focuses on documented civic, samvydav, and human-rights work.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml`
+  - `curriculum/l2-uk-en/plans/hist/rukh.yaml`
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/memorandum-uhh.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-dysydentski-dzherela.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Bohdan Horyn, Viacheslav Chornovil, Levko Lukyanenko, Oleksa Tykhy, Mykola Rudenko, and Vasyl Stus.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 documentary-reading activity on planted evidence and Soviet legal labels in the 1981-1982 Horyn case.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-horyn`
+- **EN canonical (BGN/PCGN 2010):** Mykhailo Horyn
+- **UA canonical (with patronymic):** Горинь Михайло Миколайович
+- **Aliases (track these for `aliases:` YAML field):** Mikhail Horyn, Mykhailo Horyn'
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Mikhail Goryn, Mikhail Gorin (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ESU entry photo for "Горинь Михайло Миколайович"; verify reuse terms.
+- **Backup candidates:** Suspilne article photos marked public domain where explicitly stated; KHPG Virtual Museum image; verify each license.
+- **If no PD/CC portrait exists:** Use a rights-cleared photo from parliamentary archives or no portrait until permission.
+- **Era-appropriate context image:** Rights-cleared photo of former political prisoners in 1988 or the Chain of Unity.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Горинь Михайло Миколайович" | https://esu.com.ua/article-31261 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- KHPG Virtual Museum, "Горинь Михайло Миколайович" | https://museum.khpg.org/1113893629 | accessed 2026-05-30
+- Ukrainian Institute of National Memory, "1930 - народився Михайло Горинь, дисидент, правозахисник" | https://uinp.gov.ua/istorychnyy-kalendar/cherven/17/1930-narodyvsya-myhaylo-goryn-dysydent-pravozahysnyk | accessed 2026-05-30
+- Suspilne Culture, "У таборі вмирають тільки українці" | https://suspilne.media/culture/507421-u-tabori-vmiraut-tilki-ukrainci-biografia-ukrainskogo-disidenta-mihajla-gorina/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Михайло Горинь" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Zaporizhzhia Historical Review article on Horyn's 1961-1965 activity, search result consulted but not used for unsourced details.
+
+**Primary-source documents accessed:**
+- KHPG interview material with Horyn; Suspilne-quoted Horyn recollections and 1978 UHG document excerpt.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No Russian-imperial transliterations in body text
+- [x] Block G-adjacent family context not treated as military biography
+- [x] Soviet legal labels quoted only as prosecution language
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms
+- [x] Holodomor not central here
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/mykhailo-hrushevskyi.md
+++ b/docs/research/bio/mykhailo-hrushevskyi.md
@@ -1,0 +1,125 @@
+# Грушевський Михайло Сергійович — Research Dossier
+
+**Slug:** `mykhailo-hrushevskyi`
+**Block:** C
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Грушевський Михайло Сергійович.
+- **Pseudonyms / aliases:** М. Заволока, Михайло Заволока, М. Сергієнко, Хлопець, per ESU.
+- **Born:** 1866-09-17 Old Style / 1866-09-29 New Style | Kholm, now Chelm, Poland | Russian Empire. Sources: ESU "Грушевський Михайло Сергійович"; IEU "Hrushevsky, Mykhailo"; existing plan `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`.
+- **Died:** ESU gives 1934-11-24 | Kislovodsk, Stavropol krai, RSFSR, buried at Baikove Cemetery in Kyiv. IEU gives 1934-11-25. This dossier flags the one-day discrepancy. Sources agree on Kislovodsk and burial in Kyiv.
+- **Family / education key facts:** Son of Serhii Hrushevskyi; brother of Oleksandr and Hanna; husband of Mariia; father of Kateryna. Graduated from Tiflis gymnasium and the historical-philological faculty of Kyiv University; studied under Volodymyr Antonovych. ESU and IEU corroborate these details.
+
+## 2. Oppression mechanism
+
+- **What happened:** Russian imperial arrest and exile in 1914; Soviet destruction of institutions, surveillance, 1931 GPU/OGPU arrest, forced residence in Moscow, repression of students and family/school.
+- **When:** ESU says he was arrested by the gendarmerie in Kyiv on 1914-11-28 and exiled to Simbirsk, then Kazan and Moscow. IEU describes fall 1914 arrest, two-month Kyiv imprisonment, and exile to Simbirsk, Kazan, then Moscow under police surveillance. In the Soviet period, ESU states that from autumn 1929 his historical institutions were destroyed; NDKIU was closed in September 1930; he moved to Moscow on 1931-03-07; GPU arrested him on 1931-03-23 and moved him to OGPU detention in Kharkiv; he was released on 1931-04-04. IEU states that in March 1931 he was arrested and forced to live in Moscow under surveillance.
+- **By whom:** Russian imperial gendarmerie; GPU/OGPU; Soviet party and academy apparatus.
+- **Document references:** ESU names the fictitious "Український національний центр" accusation and states he was charged with leading a counterrevolutionary organization. IEU also identifies the frame-up as the fictitious Ukrainian National Center. Specific archival file number: source not found in retrieved sources.
+- **Mechanism specifics:** In 1914, imperial authorities accused him of Austrophilism and connection to the Ukrainian Sich Riflemen, removing him from Kyiv and academic leadership. In the 1920s he returned to Soviet Ukraine under the Ukrainization opening and rebuilt historical scholarship at VUAN. ESU details his commissions, journal *Україна*, and historical school. Beginning in 1929, Soviet authorities liquidated those institutions, attacked his historical scheme as nationalist, arrested many coworkers and students, and forced him into semi-captivity in Moscow. ESU says he withdrew earlier statements after release and denied participation in counterrevolutionary activity.
+- **What survived / what was destroyed:** His institutional school in Soviet Ukraine was largely destroyed by 1934, per IEU. His historical scheme survived in diaspora and later Ukrainian scholarship; IEU notes that open discussion in Soviet Ukraine was taboo until the late 1980s and changed dramatically in post-Soviet Ukraine.
+
+## 3. Major works
+
+- `1891` — *Очерк истории Киевской земли от смерти Ярослава до конца XIV века*, based on award-winning student work, per IEU/ESU.
+- `1894` — *Барское староство. Исторические очерки*, master's dissertation, per ESU/IEU.
+- `1898-1937` — *Історія України-Руси*, 10-volume synthesis to 1658; IEU calls it the first major synthesis of Ukrainian history ever written.
+- `1904` — "Звичайна схема 'руської' історії і справа раціонального укладу історії Східнього Слов'янства," anti-imperial historiographic essay, per IEU and MCP literary corpus.
+- `1904/1906/1911` — *Очерк истории украинского народа*, general overview, per IEU.
+- `1911` — *Ілюстрована історія України*, popular history, per IEU.
+- `1917` — *Вільна Україна*, political-publicistic collection, per IEU.
+- `1918` — *На порозі нової України: гадки і мрії*, per IEU.
+- `1921` — *Початки громадянства. Генетична соціологія*, per ESU/IEU.
+- `1923-1927` — *Історія української літератури*, multi-volume literary history, per IEU.
+- `1924-1930` — editor of *Україна*, all-Ukrainian journal of Ukrainian studies, per ESU/IEU.
+
+## 4. Primary-source quotes
+
+> "головна вага повинна бути перенесена з історії держави на історію народу"
+
+Source: Hrushevskyi, "Звичайна схема 'руської' історії..." (1904), retrieved via `mcp__sources.search_literary` from `wave7-hrushevsky-vybrani-statti`. This is the core method statement for moving Ukrainian history away from imperial dynastic state history.
+
+> "общерусскої історії не було й не може бути"
+
+Source: same 1904 essay as quoted in the MCP source corpus. It directly challenges the imperial "common Russian" historical frame and is essential for decolonized historiography lessons.
+
+## 5. Language register
+
+- **Register:** Scholarly-historiographic, publicistic, political-theoretical.
+- **CEFR readiness for full reading:** C1-C2 for original essays; B2-C1 for adapted excerpts.
+- **Lexicon notes:** `історіографія`, `державність`, `народність`, `схема`, `автономія`, `федерація`, `Центральна Рада`, `ВУАН`, `репресії`.
+- **Stylistic features:** Long analytic periods, polemical precision, old orthographic forms in pre-1917 and diaspora editions, and dense institutional vocabulary.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His political federalism, role in Central Rada state-building, and 1924 return to Soviet Ukraine. The existing bio plan frames these as core debate questions: compromise, tragic mistake, or attempt to save scholarship.
+- **What gets simplified in popular memory:** "First president of Ukraine" is imprecise. The existing plan warns that he was head of the Central Rada, not president in the modern executive sense.
+- **Where modern Russian disinformation attacks them:** IEU records Soviet labels such as "nationalist historian" and "enemy of Soviet rule." These are cited as Soviet attack language, not accepted descriptors.
+- **Polish / Jewish / other-perspective considerations:** Hrushevskyi's work challenged both Russian imperial and Polish-dominated regional frames. Lessons should avoid turning Ukrainian historiography into a mirror-image imperial claim; his method centered the historical people, social process, and territorial continuity.
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/hrushevskyi.yaml`
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-essay/hrushevsky-essayist.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/halychyna-natsionalnyi-rukh.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Kateryna Hrushevska, Mariia Voiakovska-Hrushevska, Volodymyr Antonovych, Yevhen Chykalenko, Viacheslav Lypynskyi, and Nataliia Polonska-Vasylenko.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 source module contrasting Hrushevskyi's 1904 "Звичайна схема" with imperial and Soviet historiographic labels.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-hrushevskyi`
+- **EN canonical (BGN/PCGN 2010):** Mykhailo Hrushevskyi
+- **UA canonical (with patronymic):** Грушевський Михайло Сергійович
+- **Aliases (track these for `aliases:` YAML field):** Mykhailo Hrushevsky, Mykhailo Hrushevs'kyi, М. Заволока, Михайло Заволока, М. Сергієнко, Хлопець
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Mikhail Grushevsky, Mikhail Grushevskii (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** IEU images of Hrushevskyi, including 1895, 1906, 1926, 1929, and Central Rada context photos; verify rights and source metadata.
+- **Backup candidates:** Wikimedia Commons Hrushevskyi portraits; state museum images from the Mykhailo Hrushevskyi Historical-Memorial Museum in Kyiv, rights permitting.
+- **If no PD/CC portrait exists:** Use a public-domain pre-1934 portrait from Commons after license verification.
+- **Era-appropriate context image:** Central Rada photograph or NTSh/Lviv scholarly context image, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Грушевський Михайло Сергійович" | https://esu.com.ua/article-32114 | accessed 2026-05-30
+- Internet Encyclopedia of Ukraine, "Hrushevsky, Mykhailo" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CR%5CHrushevskyMykhailo.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Existing curriculum plan `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` | accessed 2026-05-30
+- Hrushevsky portal / Institute of History search result for encyclopedia linkage | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Михайло Грушевський" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_literary` results for Hrushevskyi's "Звичайна схема" in `wave7-hrushevsky-vybrani-statti` and related corpora | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Hrushevskyi, "Звичайна схема 'руської' історії й справа раціонального укладу історії Східнього Слов'янства" (1904), via MCP literary corpus.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No uncritical Soviet labels
+- [x] "President" myth corrected
+- [x] Date discrepancy flagged
+- [x] Russian-imperial transliterations confined to forbidden aliases
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms
+- [x] Crimea/2014/2022 not applicable

--- a/docs/research/bio/oles-honchar.md
+++ b/docs/research/bio/oles-honchar.md
@@ -1,0 +1,133 @@
+# Гончар Олесь (Олександр) Терентійович — Research Dossier
+
+**Slug:** `oles-honchar`
+**Block:** D
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Гончар Олесь; civil name Олександр Терентійович Гончар.
+- **Pseudonyms / aliases:** Oles Honchar; Oleksandr Honchar.
+- **Born:** 1918-04-03 | Sukhe, now Poltava oblast | Ukrainian State / revolutionary-era Ukraine. Sources: ESU "Гончар Олесь"; IEU "Honchar, Oles"; existing plan `curriculum/l2-uk-en/plans/bio/oles-honchar.yaml`.
+- **Died:** 1995-07-14 | Kyiv | Ukraine. Sources: ESU and IEU.
+- **Family / education key facts:** Studied journalism in Kharkiv, then Kharkiv University before the war; graduated from Dnipropetrovsk University in 1946; Second World War veteran, wounded twice, and held in a concentration camp at Kholodna Hora in Kharkiv, per ESU. Headed the Writers' Union of Ukraine from 1959 to 1971, per ESU and IEU.
+
+## 2. Oppression mechanism
+
+- **What happened:** Censorship and official campaign against *Собор* rather than imprisonment; earlier works also operated under Soviet ideological pressure.
+- **When:** *Собор* was published in 1968. ESU states it was officially condemned and removed from the literary process for 20 years. IEU states that *Sobor* was officially censured and removed from circulation. The existing bio plan frames the same period as a key paradox: Stalin Prize winner to author of a banned novel.
+- **By whom:** Soviet party-literary apparatus and official criticism; exact Central Committee document or resolution title not found in the retrieved sources for this dossier.
+- **Document references:** ESU and IEU supply the suppression fact but not a named archival document. Therefore: source not found for a specific order number, meeting protocol, or censorship file.
+- **Mechanism specifics:** ESU explains the ideological reason: the old cathedral in the novel became a symbol of historical memory, patriotism, and spirituality incompatible with Soviet ideology. The novel's anti-consumerist, anti-destruction, and national-memory content made it dangerous even though Honchar was an official writer with major Soviet awards. The punishment was professional-literary containment, not Gulag: official condemnation, removal from circulation, and two decades of exclusion from normal literary discussion.
+- **What survived / what was destroyed:** *Собор* survived through reader memory, samvydav-style circulation, and later republication. Honchar's public authority also survived enough for him to support Ukrainian language and culture during perestroika and independence-era transition, as ESU notes.
+
+This is an indirect-oppression dossier: unlike Block E prisoners, Honchar was not sentenced under Article 62 in the sources retrieved. The documented harm is the state's ability to make a major novel disappear from normal publication, criticism, and classroom circulation.
+
+## 3. Major works
+
+- `1938-1941` — early novellas and *Стокозове поле*, where ESU says there was a mention of the Holodomor of 1933.
+- `1946-1948` — *Прапороносці*, trilogy; ESU and IEU identify it as the work that brought postwar prominence and Stalin Prizes.
+- `1947` — *Земля гуде*, novella.
+- `1952` — *Таврія*, novel.
+- `1957` — *Перекоп*, novel.
+- `1960` — *Людина і зброя*, novel; ESU notes Shevchenko Prize in 1962.
+- `1963` — *Тронка*, novel; ESU notes Lenin Prize in 1964.
+- `1968` — *Собор*, novel; censured/removed from circulation, per ESU and IEU.
+- `1970` — *Циклон*, novel.
+- `1973` — *Бригантина*, novella.
+- `1976` — *Берег любові*, novel.
+- `1980` — *Твоя зоря*, novel; ESU notes USSR State Prize in 1982.
+- `1987` — *Далекі вогнища*, novella; ESU says it reflects the Holodomor theme.
+- `1991` — *Чим живемо*, publicistic/literary-critical collection.
+
+## 4. Primary-source quotes
+
+> "Собори душ своїх бережіть, друзі..."
+
+Source: *Собор* (1968), verified through `mcp__sources.verify_quote` and `mcp__sources.search_literary` against `ukrlib-honchar`. This line is the novel's teachable ethical formula: historical architecture becomes inner moral architecture.
+
+> "Мова - це всі глибинні пласти..."
+
+Source: Honchar diary/publicistic quote as reproduced by Vogue UA from *Щоденники*. The wording is used here only as a short excerpt; it anchors Honchar's later cultural defense of language.
+
+## 5. Language register
+
+- **Register:** High literary prose, lyrical-social realism, publicistic diary voice.
+- **CEFR readiness for full reading:** C1 for *Собор* and diaries; B2 for guided excerpts.
+- **Lexicon notes:** `собор`, `пам'ять`, `духовність`, `споживацтво`, `соцреалізм`, `цензура`, `Голодомор`.
+- **Stylistic features:** Symbolic object (cathedral), romanticized moral speech, ecological and heritage vocabulary, and a tension between official Soviet forms and Ukrainian ethical subtext.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Honchar's compromises: early Stalin-Prize success and official posts versus later cultural resistance through *Собор*, public authority, and defense of language. The existing bio plan explicitly frames this as "system vs conscience."
+- **What gets simplified in popular memory:** He is alternately flattened into "official Soviet classic" or "hidden dissident." ESU and IEU both support a more difficult path: official writer whose 1968 novel crossed ideological limits.
+- **Where modern Russian disinformation attacks them:** Soviet discourse treated Ukrainian heritage defense and local memory as suspect nationalism. This dossier does not reuse "bourgeois nationalist" labels except as historical accusation.
+- **Other-perspective considerations:** His war writing used Red Army frames; decolonized pedagogy should distinguish lived wartime experience from later Soviet mythologization of "Great Patriotic War" narratives.
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/oles-honchar.yaml`
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/honchar-cathedral.yaml`
+  - `curriculum/l2-uk-en/plans/lit/honchar-banners.yaml`
+  - `curriculum/l2-uk-en/plans/lit-essay/sverstiuk-cathedral.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Yevhen Sverstiuk, Ivan Dziuba, Vasyl Stus, and writers whose Soviet-era compromises need anti-hagiographic treatment.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 comparison of ESU's *Собор* summary with Sverstiuk's essay module.
+
+## 8. Naming-canonical
+
+- **Slug:** `oles-honchar`
+- **EN canonical (BGN/PCGN 2010):** Oles Honchar
+- **UA canonical (with patronymic):** Гончар Олесь (Олександр) Терентійович
+- **Aliases (track these for `aliases:` YAML field):** Oleksandr Honchar, Oles' Honchar, Олесь Гончар
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Oles Gonchar, Aleksandr Gonchar (FORBIDDEN except as archival/Soviet metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** IEU "Image - Oles Honchar"; verify license and donor terms.
+- **Backup candidates:** Wikimedia Commons Honchar portraits; ESU article image; permissions required.
+- **If no PD/CC portrait exists:** Use no portrait until rights are verified; avoid recent copyrighted press portraits.
+- **Era-appropriate context image:** Rights-cleared image of a Ukrainian cathedral/industrial-steppe setting only if tied to *Собор* pedagogy and not misleadingly presented as the novel's cathedral.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Гончар Олесь" | https://esu.com.ua/article-30828 | accessed 2026-05-30
+- Internet Encyclopedia of Ukraine, "Honchar, Oles" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CO%5CHoncharOles.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Existing curriculum plan `curriculum/l2-uk-en/plans/bio/oles-honchar.yaml` | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Олесь Гончар" via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Vogue UA, quote selection from Honchar diaries | accessed 2026-05-30
+- `mcp__sources.search_literary` textbook/literary corpus results for *Собор* and Honchar reception | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- `mcp__sources.verify_quote`, exact *Собор* quote match in `ukrlib-honchar`.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing
+- [x] No Soviet "Great Patriotic War" periodization as neutral voice
+- [x] No Russian-imperial transliterations in body text
+- [x] Specific censorship document not invented; marked "source not found"
+- [x] Existing paths verified
+- [x] Holodomor named as Holodomor where relevant
+- [x] Place names use Ukrainian canonical forms
+- [x] Crimea/2014/2022 not applicable


### PR DESCRIPTION
## Summary

Adds Phase-1 research dossiers for eight non-Block-G figures:
- ivan-svitlychnyi
- ihor-kalynets
- iryna-kalynets
- mykhailo-horyn
- bohdan-horyn
- oles-honchar
- hryhir-tiutiunnyk
- mykhailo-hrushevskyi

## Tier-1/2 sources used

- ivan-svitlychnyi: Encyclopedia of Ukraine / Internet Encyclopedia of Ukraine; KHPG Virtual Museum of the Dissident Movement.
- ihor-kalynets: Encyclopedia of Modern Ukraine; Encyclopedia of Ukraine / Internet Encyclopedia of Ukraine; KHPG Virtual Museum of the Dissident Movement.
- iryna-kalynets: Encyclopedia of Modern Ukraine; KHPG Virtual Museum of the Dissident Movement.
- mykhailo-horyn: Encyclopedia of Modern Ukraine; KHPG Virtual Museum of the Dissident Movement; Ukrainian Institute of National Memory.
- bohdan-horyn: Encyclopedia of Modern Ukraine; KHPG Virtual Museum of the Dissident Movement; Ukrainian Institute of National Memory.
- oles-honchar: Encyclopedia of Modern Ukraine; Encyclopedia of Ukraine / Internet Encyclopedia of Ukraine; existing BIO source plan.
- hryhir-tiutiunnyk: Encyclopedia of Ukraine / Internet Encyclopedia of Ukraine; Ukrainian textbook/literary corpus sources retrieved via source tools.
- mykhailo-hrushevskyi: Encyclopedia of Modern Ukraine; Encyclopedia of Ukraine / Internet Encyclopedia of Ukraine; existing BIO source plan.

## Validation

No fabricated Existing cross-track plan paths found.

## Source limitations declared in dossiers

- hryhir-tiutiunnyk: direct KGB case/persecution source not found; dossier uses sourced family repression, censorship/publication constraints, and flags death-date discrepancy.
- oles-honchar: specific Central Committee censorship order/file source not found; dossier treats Sobor-era pressure as sourced cultural/institutional repression, not Article 62 imprisonment.
- mykhailo-hrushevskyi: specific archival file number source not found; dossier flags death-date discrepancy between ESU and IEU.
