### PR TITLE
feat(bio): 8 Phase-1 research dossiers — batch 3 (#2309)

### DIFF
--- a/docs/research/bio/ivan-karpenko-karyi.md
+++ b/docs/research/bio/ivan-karpenko-karyi.md
@@ -1,0 +1,130 @@
+# Карпенко-Карий Іван — Research Dossier
+
+**Slug:** `ivan-karpenko-karyi`
+**Block:** B
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Карпенко-Карий Іван; birth name Тобілевич Іван Карпович.
+- **Pseudonyms / aliases:** Іван Карпенко-Карий, І. Карпенко-Карий, Ivan Karpenko-Karyi, Ivan Tobilevych.
+- **Born:** 1845-09-17 Old Style / 1845-09-29 New Style | Арсенівка, near Yelysavethrad | Kherson gubernia, Russian Empire. Sources: Енциклопедія історії України, "Карпенко-Карий Іван"; ЕСУ, "Карпенко-Карий Іван."
+- **Died:** 1907-09-02 Old Style / 1907-09-15 New Style | Berlin | German Empire. Sources: EIU and ESU agree on date pair and Berlin.
+- **Family / education key facts:** Member of the Tobilevych theatre family; brother of Mykola Sadovskyi, Panas Saksahanskyi, and Mariia Sadovska-Barilotti. Worked in civil service before becoming a central dramatist and actor of the Ukrainian theatre of coryphaei.
+
+## 2. Oppression mechanism
+
+- **What happened:** Removed from service, placed under surveillance, exiled administratively, and restricted from public theatre work.
+- **When:** 1883 removal from service; three-year exile to Novocherkassk beginning in the 1880s; later covert surveillance until 1895, per EIU/ESU.
+- **By whom:** Russian imperial administration and police.
+- **Document references:** EIU/ESU identify the police-supervision mechanism but do not give an archival case number. Specific file ID: source not found.
+- **Mechanism specifics:** EIU and ESU state that in 1883 Tobilevych was dismissed from service for links with Ukrainian revolutionary circles and for helping provide passports to revolutionaries. He was then sent to Novocherkassk for three years under public police supervision. ESU adds that public supervision later became covert surveillance and continued into the 1890s.
+
+The repression interrupted a career at the exact intersection of theatre, Ukrainian public culture, and anti-imperial associational life. The name "Карпенко-Карий" also marks a professional rebirth: the dramatist wrote and performed under stage conditions shaped by imperial restrictions on Ukrainian-language theatre and by direct police supervision of his person.
+
+This dossier treats police surveillance as a sourced biographical fact because both EIU and ESU give the service dismissal, Novocherkassk exile, and later covert supervision. It does not add a charge sheet, trial name, or decree number because none appeared in the retrieved sources. Phase 2 should look for archival theatre-police records before any lesson claims a specific case file.
+
+- **What survived / what was destroyed:** The plays survived and became canonical. A specific police case citation was not retrieved; the dossier therefore records the mechanism from EIU/ESU without inventing document numbers.
+
+## 3. Major works
+
+- `1884/1897` — *Чабан* / *Бурлака*, drama, listed by EIU/ESU.
+- `1884` — *Бондарівна*, drama, listed by EIU.
+- `1885/1887` — *Безталанна*, drama, listed by EIU/ESU.
+- `1885/1887` — *Наймичка*, drama, listed by EIU/ESU.
+- `1886/1891` — *Мартин Боруля*, comedy, published in an NTSh edition available on Wikisource; core social-satirical work.
+- `1890/1891` — *Сто тисяч*, comedy, listed by EIU/ESU; canonical critique of money and status.
+- `1893/1897` — *Паливода XVIII століття*, historical drama, listed by EIU.
+- `1899/1900` — *Сава Чалий*, historical tragedy, listed by EIU/ESU.
+- `1900/1902` — *Хазяїн*, comedy, listed by EIU/ESU; peak critique of capitalist accumulation.
+- `1903/1905` — *Суєта*, comedy, listed by EIU.
+- `1904/1905` — *Житейське море*, comedy, listed by EIU.
+
+## 4. Primary-source quotes
+
+> "Виходить: я — не бидло"
+
+Source: *Мартин Боруля* (Lviv: NTSh, 1921), act I, Wikisource. The line makes class aspiration and insult vocabulary teachable in a short, memorable form.
+
+> "Тисяча рублів згоріла"
+
+Source: *Мартин Боруля* (1921), Wikisource page scan. The fragment anchors the comic collapse of status fantasy without requiring learners to read the full act at first encounter.
+
+## 5. Language register
+
+- **Register:** Realist stage dialogue, colloquial-satirical, with legal/status vocabulary.
+- **CEFR readiness for full reading:** B2 for selected scenes; C1 for full plays because of idiom, class register, and historical bureaucracy.
+- **Lexicon notes:** `дворянство`, `чин`, `бидло`, `служба`, `хазяїн`, `оренда`, `гроші`, `папери`; learners need historical notes on rank, estate, and rural capitalism.
+- **Stylistic features:** Fast repartee, comic repetition, mixed high/low diction, precise social idiolects, and stage irony built on what characters misunderstand about their own status.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Balance between Karpenko-Karyi as realist social critic and as national theatre-builder. EIU and ESU both place him inside theatre history and literary history.
+- **What gets simplified in popular memory:** *Мартин Боруля* is often taught as a single joke about false nobility. The repression record and theatre restrictions show why status, documents, and language on stage were politically charged.
+- **Where modern Russian disinformation attacks them:** No specific modern campaign was retrieved. The risk is imperial normalization of Ukrainian theatre as provincial entertainment rather than a surveilled national public sphere.
+- **Polish / Jewish / other-perspective considerations:** Plays involving estates, markets, and money should be taught with social-class context rather than ethnic shorthand.
+- **Pedagogical risk:** Do not teach the comic dialogue as "simple village speech." The retrieved works operate through precise estate, bureaucratic, and financial vocabulary; flattening that register erases the satire.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-drama/karpenko-karyi-theatre.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/ukrainian-drama-origins.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Mykola Sadovskyi, Panas Saksahanskyi, Marko Kropyvnytskyi, and Mariia Zankovetska.
+  - A HIST/LIT module on the Ems-era theatre restrictions and the Ukrainian theatre of coryphaei.
+- **Potential LIT additions surfaced by this research:**
+  - A B2 scene-based lesson on legal/status vocabulary in *Мартин Боруля*.
+  - A C1 comparison of *Сто тисяч* and *Хазяїн* as money/status satire, using only passages whose editions are verified in Phase 2.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-karpenko-karyi`
+- **EN canonical (BGN/PCGN 2010):** Ivan Karpenko-Karyi
+- **UA canonical (with patronymic if needed):** Карпенко-Карий Іван; Тобілевич Іван Карпович
+- **Aliases (track these for `aliases:` YAML field):** Іван Тобілевич, Ivan Tobilevych, Ivan Karpenko-Kary, I. Karpenko-Karyi
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ivan Karpenko-Kary, Ivan Tobilevich, Ivan Karpovich Tobilevich (FORBIDDEN except as source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Карпенко-Карий.jpg` | public-domain marking on Commons | https://commons.wikimedia.org/wiki/File:%D0%9A%D0%B0%D1%80%D0%BF%D0%B5%D0%BD%D0%BA%D0%BE-%D0%9A%D0%B0%D1%80%D0%B8%D0%B9.jpg
+- **Backup candidates:** `File:Карпенко-Карий І.jpg` on Commons; theatre-family group photographs if license-cleared.
+- **If no PD/CC portrait exists:** Use a public-domain pre-1907 portrait after checking Commons metadata.
+- **Era-appropriate context image:** A theatre of coryphaei group photograph or programme, rights permitting.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України, "Карпенко-Карий Іван" | https://www.history.org.ua/?termin=Karpenko_Kary | accessed 2026-05-30
+- Енциклопедія Сучасної України, "Карпенко-Карий Іван" | https://esu.com.ua/article-10051 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Wikisource, *Мартин Боруля* (1921) | https://uk.wikisource.org/wiki/Мартин_Боруля_(1921) | accessed 2026-05-30
+- Wikisource page scan, *Тобілевич Іван. Мартин Боруля* | https://uk.wikisource.org/wiki/Сторінка:Тобілевич_Іван._Мартин_Боруля_(Львів,_1921).djvu/48 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Іван Карпенко-Карий," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- No additional modern scholarly monograph was retrieved for this dossier; source gap recorded.
+
+**Tier 5 (general web):**
+- English Wikipedia, "Ivan Karpenko-Karyi," used only for cross-checking English naming and never as the sole source for dates or repression | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Karpenko-Karyi, *Мартин Боруля* (1921 NTSh edition), via Wikisource.
+
+---
+
+## Decolonization self-check
+
+- [x] Imperial police mechanism named specifically
+- [x] Theatre treated as national public culture, not provincial entertainment
+- [x] Case-file gap declared
+- [x] Existing plan paths verified
+- [x] Forbidden transliterations confined to metadata

--- a/docs/research/bio/ivan-manzhura.md
+++ b/docs/research/bio/ivan-manzhura.md
@@ -1,0 +1,128 @@
+# Манжура Іван Іванович — Research Dossier
+
+**Slug:** `ivan-manzhura`
+**Block:** B
+**Tier:** 3
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Манжура Іван Іванович.
+- **Pseudonyms / aliases:** Іван Калічка; Ivan Manzhura; Ivan Ivanovych Manzhura.
+- **Born:** 1851-10-20 Old Style / 1851-11-01 New Style | Харків | Russian Empire. Sources: `mcp__sources.search_sources` result from *Українська літературна енциклопедія*, Dnipro library biography, and UkrLit biographical pages.
+- **Died:** 1893-05-03 Old Style / 1893-05-15 New Style | Катеринослав, now Дніпро | Russian Empire. The Ukrainian Literary Encyclopedia result and the retrieved source pack agree on the date/place pair.
+- **Family / education key facts:** The Ukrainian Literary Encyclopedia entry states that he was orphaned early, raised in the family of an aunt married to Oleksandr Potebnia, accepted to Kharkiv gymnasium at state expense, expelled from the sixth class, and in 1871 expelled from the Kharkiv Veterinary Institute as politically unreliable.
+
+## 2. Oppression mechanism
+
+- **What happened:** Educational exclusion and political unreliability labeling; later poverty and marginal publication conditions.
+- **When:** Exact expulsion dates were not retrieved. Biographical sources state that he was expelled from the Kharkiv gymnasium for insubordination and from the Kharkiv Veterinary Institute as `неблагонадійний`.
+- **By whom:** Kharkiv gymnasium authorities and Kharkiv Veterinary Institute administration under the Russian Empire; broader imperial censorship context for Ukrainian-language publications.
+- **Document references:** No expulsion decree, police file, or censorship file number was retrieved. Document reference: source not found.
+- **Mechanism specifics:** The retrieved UkrLit and Dnipro library biographies present a consistent pattern: Manzhura's education was interrupted by institutional discipline and political unreliability, after which he lived precariously while gathering folklore, writing poetry, and publishing in limited venues. This is not equivalent to a documented prison/exile case, so the dossier treats it as indirect institutional persecution rather than physical repression.
+
+The source pack also notes censorship and title instability around *Степові думи та співи*, including variant reference forms and heavy posthumous publication. Because no specific censorship order was retrieved, the safe claim is that imperial institutions narrowed his education and publication conditions; the exact legal file remains unsourced.
+
+- **What survived / what was destroyed:** Poems, tales, and ethnographic work survived in published and posthumous forms. Institutional expulsion documents and exact censorship files were not retrieved.
+
+The archival gap is significant. A future pass should check library catalogues, ESU updates, and regional archival guides before adding any police-file detail. Until then, the dossier deliberately avoids stronger claims such as arrest, formal exile, or a numbered censorship decision.
+
+## 3. Major works
+
+- `1889` — *Степові думи та співи*, poetry collection, source pack via UkrLit and modern text pages.
+- Undated / collected — "До Музи," lyric poem in *Степові думи та співи*, text retrieved through md-eksperiment.
+- Undated / collected — "Дума," lyric poem in *Степові думи та співи*, text retrieved through md-eksperiment.
+- Undated — "Босяцька пісня," poem, listed by UkrLit.
+- Undated — "На пасіці," poem, listed by UkrLit.
+- Undated — "Розкіш-доля," poem, listed by UkrLit.
+- Undated — "Ой чом мені молодому," poem, listed by UkrLit.
+- Undated — "На добрій ниві," poem, listed by UkrLit.
+- Undated — "Билиця," narrative work, listed by UkrLit.
+- Undated — "Нечесна," narrative work, listed by UkrLit.
+- Undated — "Бурлакова могила" and "Бурлака," works listed by UkrLit.
+- Undated — *Трьомсин-богатир* and *Іван Голик*, tale/folkloric narrative works, listed by UkrLit.
+
+## 4. Primary-source quotes
+
+> "Годі бо, Музонько"
+
+Source: Manzhura, "До Музи," in *Степові думи та співи* (1889), text retrieved through md-eksperiment. The phrase is a compact example of his folk-poetic apostrophe and diminutive register.
+
+> "На серці ж сум"
+
+Source: Manzhura, "Дума," in *Степові думи та співи* (1889), text retrieved through md-eksperiment. This line gives learners an accessible entry to emotional vocabulary in a folk-song cadence.
+
+## 5. Language register
+
+- **Register:** Folk-poetic and ethnographic, with southeastern dialect features; lyric, satirical, and narrative modes.
+- **CEFR readiness for full reading:** B2 for selected lyrics; C1 for full historical/dialect reading because of dialectal forms and older poetic conventions.
+- **Lexicon notes:** `дума`, `муза`, `недоля`, `бурлака`, `пасіка`, `степ`, `говірка`; learners should distinguish dialectal signal from error.
+- **Stylistic features:** Diminutives, apostrophe, folk-song rhythm, ethnographic vocabulary, and alternation between plain speech and stylized song.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The retrieved source pack identifies title variation: *Степові думи та співи* versus reversed or variant title order in some references. It also flags posthumous-publication complexity.
+- **What gets simplified in popular memory:** Manzhura is often reduced to a regional folklorist. The source pack shows a broader profile: poet, folklorist, ethnographer, journalist, lexicographer, translator, and collector.
+- **Where modern Russian disinformation attacks them:** No specific modern disinformation campaign was retrieved. The risk is imperial marginalization: treating southeastern Ukrainian dialect and steppe folklore as ethnographic raw material rather than Ukrainian literature.
+- **Polish / Jewish / other-perspective considerations:** The retrieved sources did not surface a specific issue. Source not found.
+- **Learner framing:** Because dialect features are central to the retrieved scholarship, exercises should mark them as regional evidence, not as "incorrect" forms.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - A B2/C1 LIT module on steppe folklore, southeastern dialect features, and Ukrainian poetic register.
+  - A BIO link to ethnographers and folklorists whose work preserved regional speech under imperial constraints.
+- **Potential LIT additions surfaced by this research:**
+  - A short dialect-awareness lesson using "До Музи" with normalized vocabulary notes.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-manzhura`
+- **EN canonical (BGN/PCGN 2010):** Ivan Manzhura
+- **UA canonical (with patronymic):** Манжура Іван Іванович
+- **Aliases (track these for `aliases:` YAML field):** Іван Калічка, Ivan Ivanovych Manzhura
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ivan Manzhura as Russian-source metadata only if accompanied by Ukrainian canonical name; Ivan Manzhura Ivanovich (FORBIDDEN except as source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Манжура Іван Іванович.jpg` | public-domain/PDM marking on Commons | https://commons.wikimedia.org/wiki/File:%D0%9C%D0%B0%D0%BD%D0%B6%D1%83%D1%80%D0%B0_%D0%86%D0%B2%D0%B0%D0%BD_%D0%86%D0%B2%D0%B0%D0%BD%D0%BE%D0%B2%D0%B8%D1%87.jpg
+- **Backup candidates:** Commons category `Category:Ivan Ivanovich Manzhura`; Dnipro library images if rights-cleared.
+- **If no PD/CC portrait exists:** Use the Commons portrait after checking license metadata.
+- **Era-appropriate context image:** Title page of *Степові думи та співи*, if a rights-cleared scan is located.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- `mcp__sources.search_sources`, *Українська літературна енциклопедія* (1988-1995), "Манжура Іван Іванович" in `wave8-ukr-lit-entsyklopediia` | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Dnipro library biography, "Іван Манжура" | https://library.dp.ua/?id=518 | accessed 2026-05-30
+- Wikimedia Commons category and portrait metadata for Ivan Manzhura | https://commons.wikimedia.org/wiki/Category:Ivan_Ivanovich_Manzhura | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Манжура Іван Іванович," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+- UkrLit biographical and reference pages on Manzhura | https://ukrlit.net/info/dovidnik/204.html | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- md-eksperiment, "Південно-східні говіркові риси у збірці поезій Івана Манжури 'Степові думи та співи'" | https://md-eksperiment.org/post/20180907-pivdenno-shidni-govirkovi-risi-u-zbirci-poezij | accessed 2026-05-30
+- md-eksperiment, "Характер ліричного героя..." | https://md-eksperiment.org/post/20180907-harakter-lirichnogo-geroya-v-poeziyi-i-manzhuri | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Manzhura, "До Музи" | https://md-eksperiment.org/post/20180826-do-muzi | accessed 2026-05-30
+- Manzhura, "Дума" | https://md-eksperiment.org/post/20180826-duma | accessed 2026-05-30
+
+---
+
+## Decolonization self-check
+
+- [x] Archival source gap declared instead of hidden
+- [x] Indirect institutional persecution not inflated into an arrest case
+- [x] Dialect features treated as Ukrainian register, not deficiency
+- [x] No fabricated cross-track paths
+- [x] Source gaps marked explicitly

--- a/docs/research/bio/leonid-hlibov.md
+++ b/docs/research/bio/leonid-hlibov.md
@@ -1,0 +1,130 @@
+# Глібов Леонід Іванович — Research Dossier
+
+**Slug:** `leonid-hlibov`
+**Block:** B
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Глібов Леонід Іванович.
+- **Pseudonyms / aliases:** Дідусь Кенир, Леонід Глібов, Leonid Hlibov, Leonid Glibov.
+- **Born:** 1827-02-21 Old Style / 1827-03-05 New Style | Веселий Поділ, Полтавщина | Russian Empire. Sources: `mcp__sources.search_sources` result from *Українська літературна енциклопедія*, literary encyclopedia entry retrieved through slovnyk.me, Commons file metadata, and Ukrainian Wikipedia via `mcp__sources.query_wikipedia`.
+- **Died:** 1893-10-29 Old Style / 1893-11-10 New Style | Чернігів | Russian Empire. The Ukrainian Literary Encyclopedia result and Commons metadata agree on the date/place pair.
+- **Family / education key facts:** Poet, fabulist, journalist, teacher, editor, and public figure. The Ukrainian Literary Encyclopedia result states that he taught geography in Chernihiv gymnasium, edited *Черниговский листок* from 1861, and was removed in 1863 after publication of politically suspect materials and alleged links to `Земля і воля`.
+
+## 2. Oppression mechanism
+
+- **What happened:** Censorship pressure, removal from editorial/teaching positions, police surveillance, and forced relocation.
+- **When:** 1863 closure/suppression context for *Черниговский листок* and removal from posts; broader 1863 Valuev Circular censorship context.
+- **By whom:** Russian imperial censorship and police-administrative authorities.
+- **Document references:** Valuev Circular of 1863 is the named imperial censorship document for the broader Ukrainian-language context. A specific file ordering Hlibov's dismissal or surveillance was not retrieved. File ID: source not found.
+- **Mechanism specifics:** The retrieved literary encyclopedia entry and Kherson library page connect Hlibov's 1863 troubles to publication of politically suspect materials, alleged links to `Земля і воля`, and the policing of *Черниговский листок*. The source pack also notes police surveillance and a forced move to Nizhyn. Because the exact police order was not retrieved, this dossier states the mechanism as censorship and professional punishment, not as a sourced arrest.
+
+The Valuev Circular matters as the same-year imperial framework for Ukrainian-language restriction. Hlibov's fables and lyric poems did not simply circulate in a neutral literary marketplace; they circulated under conditions where Ukrainian print, schools, and public speech were being administratively narrowed.
+
+- **What survived / what was destroyed:** The fables and the song-poem "Журба" survived and entered school culture. Specific newspaper police files and the complete administrative record of dismissal were not retrieved.
+
+For YAML and lesson drafting, mark the repression mechanism as `censorship / professional punishment / surveillance`. Do not convert it into a prison or exile claim unless a future source retrieves a specific order. The retrieved source pack supports dismissal, surveillance, and publication pressure, but not a numbered case file.
+
+## 3. Major works
+
+- `1859` — "Журба" / "Стоїть гора високая," lyric poem/song text, source pack via md-eksperiment and UkrLib.
+- `1861-1863` — *Черниговский листок*, newspaper edited by Hlibov, source pack.
+- Undated / collected — "Вовк та Ягня," fable, listed in literary reference sources.
+- Undated / collected — "Вовк і Кіт," fable, listed in the source pack.
+- Undated / collected — "Вовк і Вівчарі," fable, listed in the source pack.
+- Undated / collected — "Ведмідь-пасічник," fable, listed in the source pack.
+- Undated / collected — "Громада," fable, listed in the source pack.
+- Undated / collected — "Муха і Бджола" / "Бджола і Мухи," fable, listed in the source pack.
+- Undated / collected — "Вечір," lyric poem, listed in the source pack.
+- Undated / collected — "Скажіть мені правду, добрі люди," song/poem, listed in the source pack.
+- Undated / collected — "Летить голуб понад морем," song/poem, listed in the source pack.
+
+## 4. Primary-source quotes
+
+> "До тебе, люба річенько"
+
+Source: Hlibov, "Журба" (1859), md-eksperiment/UkrLib text. The short phrase demonstrates the lyric folk-song cadence and diminutive address.
+
+> "Я рідну Україну"
+
+Source: Hlibov, "Бджола і Мухи" / "Муха й Бджола," text retrieved in the source pack. This fragment is a clear entry point for patriotic vocabulary in an allegorical fable.
+
+## 5. Language register
+
+- **Register:** Fable-allegorical and folk-lyric; accessible colloquial syntax with moral compression.
+- **CEFR readiness for full reading:** B1-B2 for selected fables and "Журба"; B2 for a broader fable set with historical vocabulary notes.
+- **Lexicon notes:** `байка`, `річенька`, `чужина`, `бджола`, `муха`, `громада`, `вовк`, `ягня`; diminutives often carry lyric tenderness or satirical bite.
+- **Stylistic features:** Ezopic allegory, compact moral endings, dialogic animal figures, folk-song cadence, and plain syntax that hides political pressure.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Work titles and dating drift across sources, especially "Журба" as poem/song and "Муха й Бджола" versus "Бджола і Мухи."
+- **What gets simplified in popular memory:** Hlibov is often remembered only as a children's fabulist. The newspaper and censorship context show a public intellectual working under imperial pressure.
+- **Where modern Russian disinformation attacks them:** No specific modern campaign was retrieved. The relevant risk is treating him as a harmless provincial fabulist while removing the Ukrainian print/censorship context.
+- **Polish / Jewish / other-perspective considerations:** No specific issue was retrieved. Source not found.
+- **Register caution:** Children's-accessible language does not mean politically empty language. The allegorical fable form is precisely why a censorship-era reading matters.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/leonid-hlibov.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - A B1/B2 fable module connecting Hlibov with later children's literature and allegory.
+  - A HIST/LIT bridge on the Valuev Circular's effect on newspapers, schools, and Ukrainian public language.
+- **Potential LIT additions surfaced by this research:**
+  - An allegory lesson using one fable with explicit censorship-era context.
+  - A paired reading of "Журба" and one fable to separate lyric folk-song register from allegorical moral register.
+
+## 8. Naming-canonical
+
+- **Slug:** `leonid-hlibov`
+- **EN canonical (BGN/PCGN 2010):** Leonid Hlibov
+- **UA canonical (with patronymic):** Глібов Леонід Іванович
+- **Aliases (track these for `aliases:` YAML field):** Дідусь Кенир, Leonid Glibov, Leonid Hlibiv
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Leonid Glebov, Leonid Ivanovich Glebov (FORBIDDEN except as source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Глібов Л.jpg` | public-domain marking on Commons | https://commons.wikimedia.org/wiki/File:%D0%93%D0%BB%D1%96%D0%B1%D0%BE%D0%B2_%D0%9B.jpg
+- **Backup candidates:** Commons category `Category:Leonid Hlibov`; institutional images from Chernihiv collections if rights-cleared.
+- **If no PD/CC portrait exists:** Use Commons portrait after checking license metadata.
+- **Era-appropriate context image:** *Черниговский листок* issue image, if a rights-cleared scan is located.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- `mcp__sources.search_sources`, *Українська літературна енциклопедія* (1988-1995), "Глібов Леонід Іванович" in `wave8-ukr-lit-entsyklopediia` | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Kherson regional library biography, "Леонід Глібов" | https://lib.kherson.ua/leonid-glibov.htm | accessed 2026-05-30
+- Wikimedia Commons category and portrait metadata for Leonid Hlibov | https://commons.wikimedia.org/wiki/Category:Leonid_Hlibov | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Literary encyclopedia entry via slovnyk.me, "ГЛІБОВ Леонід Іванович" | https://slovnyk.me/dict/literary_encyclopedia/%D0%93%D0%9B%D0%86%D0%91%D0%9E%D0%92_%D0%9B%D0%B5%D0%BE%D0%BD%D1%96%D0%B4_%D0%86%D0%B2%D0%B0%D0%BD%D0%BE%D0%B2%D0%B8%D1%87 | accessed 2026-05-30
+- Ukrainian Wikipedia, "Глібов Леонід Іванович," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Ukrainian literature reference page, "Леонід Глібов (1827-1893)" | https://ukrlit.net/info/history_xix/22.html | accessed 2026-05-30
+
+**Tier 5 (general web):**
+- Wikipedia-on-IPFS mirror entry for *Черниговский листок*, used only as a newspaper-context lead and not as an authority for biographical dates | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Hlibov, "Журба" | https://md-eksperiment.org/post/20140428-leonid-glibov-zhurba | accessed 2026-05-30
+- Hlibov, "Бджола і Мухи" | https://virshi.com.ua/leonid-glibov-bdzhola-muhy/ | accessed 2026-05-30
+
+---
+
+## Decolonization self-check
+
+- [x] Censorship and surveillance named without inventing an arrest
+- [x] Archival source gap declared
+- [x] Existing paths verified
+- [x] Newspaper source title preserved as historical title
+- [x] Ukrainian canonical name used throughout

--- a/docs/research/bio/mykhailo-kravchuk.md
+++ b/docs/research/bio/mykhailo-kravchuk.md
@@ -1,0 +1,128 @@
+# Кравчук Михайло Пилипович — Research Dossier
+
+**Slug:** `mykhailo-kravchuk`
+**Block:** H
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Кравчук Михайло Пилипович.
+- **Pseudonyms / aliases:** Mykhailo Kravchuk, M. Kravchuk, Michel Krawtchouk in some international mathematical citation contexts.
+- **Born:** NAS and Internet Encyclopedia of Ukraine normalize birth as 1892-10-12 | Човниця, Луцький повіт, Волинь | Russian Empire. KPI presents 1892-09-27, so the date discrepancy is flagged.
+- **Died:** 1942-03-09 | near Magadan / Kolyma camp system | USSR. Sources: Internet Encyclopedia of Ukraine, NAS biography, KPI memorial page, and KHPG archival note.
+- **Family / education key facts:** Mathematician, professor at Kyiv Polytechnic Institute, academician of the All-Ukrainian Academy of Sciences, and author of work that gave his name to Kravchuk polynomials. Sources: IEU, NAS, ESU.
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, fabricated political charges, long prison sentence, forced labor transfer, death in the Kolyma camp system.
+- **When:** 1938-02-21 arrest; 1938-09-23 sentence to 20 years in prison plus five years loss of rights; 1942-03-09 death.
+- **By whom:** NKVD of the Ukrainian SSR and Soviet prison/camp administration.
+- **Document references:** NBUV and KHPG source pack identify the arrest and sentence chronology. The indictment transcript cited in the source pack uses accusations of "bourgeois nationalism" and espionage; exact archival case number was not retrieved. Case ID: source not found.
+- **Mechanism specifics:** NBUV, KHPG, IEU, and NAS sources converge on the core sequence: Kravchuk was arrested in February 1938, sentenced in September 1938 to a twenty-year term, moved through Soviet prisons and transit points, and died in the Kolyma/Magadan camp region in March 1942. The charges belong to Stalinist political fabrication; this dossier mentions the Soviet accusation language only as accusation language, not as description.
+
+The academic loss was also institutional. ESU and IEU list a substantial mathematical bibliography, while the repression cut off his school and removed a leading Ukrainian-language mathematical scholar from public scientific life.
+
+- **What survived / what was destroyed:** Mathematical works, textbooks, and the named polynomial tradition survived. The retrieved sources did not supply a complete NKVD case file ID; that gap is declared.
+
+Downstream text should avoid the vague phrase "died in exile." The retrieved sources support a more specific statement: he died after NKVD arrest, sentencing, transport through the Soviet prison system, and confinement in the Kolyma/Magadan camp region. The exact camp medical/death document was not retrieved.
+
+## 3. Major works
+
+- `1919` — *Геометрія: Курс лекцій в Укр. нар. університеті*, lecture course, listed by ESU.
+- `1924` — *Про квадратичні форми та лінійні перетворення*, mathematical work, listed by ESU.
+- `1929` — *Алгебричні студії над аналітичними функціями*, mathematical work, listed by ESU.
+- `1929` — *Sur une généralisation des polynômes d'Hermite*, article associated with Kravchuk polynomial work, listed by ESU/IEU.
+- `1932` — *Вступ до вищої математики*, coauthored textbook, listed by ESU.
+- `1932` — *Застосування способу моментів до розв'язання лінійних диференціальних та інтегральних рівнянь*, monograph, Commons scan.
+- `1933` — *Елементи теорії визначників*, coauthored textbook, listed by ESU.
+- `1934` — *Диференціальні рівняння та їх застосування в природознавстві й техніці*, coauthored textbook, listed by ESU.
+- `1935` — *Sur quelques inégalités dans le problème des moments*, article, listed by ESU.
+
+## 4. Primary-source quotes
+
+> "звільнитися від схеми"
+
+Source: Kravchuk, *Застосування способу моментів до розв'язання лінійних диференціальних та інтегральних рівнянь* (Kyiv, 1932), Commons PDF scan. The fragment shows technical prose aimed at method, not slogan.
+
+> "на власних розвідках"
+
+Source: same 1932 monograph, Commons PDF scan. Pedagogically, this illustrates Ukrainian academic register in mathematics and the vocabulary of independent research.
+
+## 5. Language register
+
+- **Register:** Technical academic Ukrainian, proof-oriented mathematical prose.
+- **CEFR readiness for full reading:** C2 for mathematical monographs; B2-C1 for short biographical excerpts and glossary work.
+- **Lexicon notes:** `рівняння`, `моменти`, `многочлен`, `перетворення`, `визначник`, `диференціальний`, `інтегральний`; terms may be valuable for STEM Ukrainian modules.
+- **Stylistic features:** Dense nominal phrases, theorem/proof sequencing, Ukrainian technical terminology, and occasional French international scholarly framing in titles.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Birth date normalization. NAS and IEU give 12 October 1892, while KPI gives 27 September 1892. This likely reflects calendar conversion or source tradition, but the dossier does not resolve beyond retrieved evidence.
+- **What gets simplified in popular memory:** The slogan "Україна і математика" circulates widely, but this dossier used retrieved primary monograph fragments instead of relying on an unattributed aphorism.
+- **Where modern Russian disinformation attacks them:** No specific modern disinformation campaign was retrieved. The Soviet accusation of "bourgeois nationalism" is recorded only as repressive charge language.
+- **Polish / Jewish / other-perspective considerations:** No specific issue was retrieved. Source not found.
+- **STEM pedagogy note:** His dossier can support Ukrainian-for-science vocabulary without reducing him to a victim biography; the retrieved bibliography gives enough mathematical anchors for terminology work.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - A STEM Ukrainian module on mathematical terminology using Kravchuk's 1932 monograph.
+  - A HIST/BIO connection to Stalinist repression of Ukrainian scientists and VUAN/Kyiv academic institutions.
+- **Potential LIT additions surfaced by this research:**
+  - Not a LIT addition; better handled as H-track science biography and terminology.
+  - If adapted for language courses, use short prefaces or definitions from the 1932 monograph rather than asking learners to parse proofs.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-kravchuk`
+- **EN canonical (BGN/PCGN 2010):** Mykhailo Kravchuk
+- **UA canonical (with patronymic):** Кравчук Михайло Пилипович
+- **Aliases (track these for `aliases:` YAML field):** M. Kravchuk, Michel Krawtchouk, Mykhaylo Kravchuk
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Mikhail Kravchuk, Mikhail Krawtchouk (FORBIDDEN except as source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:M.Kravchuk.jpg` | public-domain marking on Commons | https://commons.wikimedia.org/wiki/File:M.Kravchuk.jpg
+- **Backup candidates:** `File:Михайло_Кравчук.png` on Commons; NAS/KPI memorial images if reuse rights are explicit.
+- **If no PD/CC portrait exists:** Use a Commons portrait after checking Ukraine/U.S. public-domain status.
+- **Era-appropriate context image:** Commons PDF scan of the 1932 monograph; use only if page-image reuse is rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine, "Kravchuk, Mykhailo" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CR%5CKravchukMykhailo.htm | accessed 2026-05-30
+- NAS biography page for Mykhailo Kravchuk | https://www.old.nas.gov.ua/UA/PersonalSite/Pages/Biography.aspx?PersonID=0000006684 | accessed 2026-05-30
+- Енциклопедія Сучасної України, "Кравчук Михайло Пилипович" | https://esu.com.ua/article-2611 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- NBUV profile/note on Kravchuk | https://www.nbuv.gov.ua/node/4345 | accessed 2026-05-30
+- KPI memorial page | https://kpi.ua/kravchuk_mykhaylo | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Кравчук Михайло Пилипович," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- KHPG archive note | https://archive.khpg.org/1071235755 | accessed 2026-05-30
+
+**Tier 5 (general web):**
+- Realna Istoriia video transcript indexed in the sources corpus, used only as a pointer to accusation wording and not as the sole source for chronology | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Kravchuk, *Застосування способу моментів до розв'язання лінійних диференціальних та інтегральних рівнянь* (1932), Commons PDF scan | accessed 2026-05-30
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet accusation language marked as accusation, not fact
+- [x] Birth-date discrepancy flagged
+- [x] NKVD file number gap declared
+- [x] No fabricated curriculum paths
+- [x] Scientific Ukrainian register centered

--- a/docs/research/bio/mykola-kostomarov.md
+++ b/docs/research/bio/mykola-kostomarov.md
@@ -1,0 +1,128 @@
+# Костомаров Микола Іванович — Research Dossier
+
+**Slug:** `mykola-kostomarov`
+**Block:** B
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Костомаров Микола Іванович.
+- **Pseudonyms / aliases:** Єремія Галка, Иван Богучаров, Mykola Kostomarov; EIU and Wikisource sources also preserve Russian-language publication contexts.
+- **Born:** 1817-05-16 or 1817-05-17 New Style | Юрасівка, Острогозький повіт, Воронезька губернія | Russian Empire. EIU flags the 16/17 May discrepancy; this dossier does not silently resolve it.
+- **Died:** 1885-04-07 Old Style / 1885-04-19 New Style | Saint Petersburg | Russian Empire. Sources: EIU "Костомаров Микола Іванович"; Ukrainian Wikipedia via `mcp__sources.query_wikipedia`.
+- **Family / education key facts:** Educated at Kharkiv University. Worked as a historian, writer, folklorist, and public thinker. His Ukrainian program is tied in EIU and MCP literary results to the Кирило-Мефодіївське братство.
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest, fortress imprisonment, exile, publishing/teaching restriction.
+- **When:** March 1847 arrest after discovery of the Кирило-Мефодіївське братство; imprisonment in the Peter and Paul Fortress; exile to Saratov after the investigation.
+- **By whom:** Russian imperial authorities, including the political-police apparatus around the Brotherhood investigation.
+- **Document references:** EIU identifies the case as the Кирило-Мефодіївське братство investigation. A specific archival file number was not retrieved. Court or file ID: source not found.
+- **Mechanism specifics:** EIU states that Kostomarov was arrested in 1847 for participation in the Brotherhood, held for about a year in the Peter and Paul Fortress, and then exiled to Saratov. The same source describes restrictions on scholarly work and publishing after the exile sentence. The MCP literary result from Енциклопедія українознавства identifies the Brotherhood's program: a free Ukrainian republic in a federation of Slavic peoples, centered in Kyiv, with universal suffrage, freedom of conscience, native-language education, and abolition of serfdom.
+
+The repression was directed at a political-cultural program, not a single literary text. Kostomarov's *Книги битія українського народу* gave the Brotherhood a biblical-prophetic idiom, while the imperial response treated Ukrainian political imagination as a security threat.
+
+For curriculum use, the important distinction is between source-attested repression and later myth. The retrieved EIU entry supports the arrest, fortress imprisonment, Saratov exile, and restrictions. It does not support invented details such as a named courtroom verdict or a numbered archival file, so those are excluded until a primary case citation is retrieved.
+
+- **What survived / what was destroyed:** The Brotherhood was broken organizationally. Kostomarov's historical and literary writings survived, including later editions of *Книги битія українського народу* and the 1861 essay *Дві руські народності*.
+
+## 3. Major works
+
+- `1838` — *Сава Чалий*, drama, listed by EIU.
+- `1839` — *Українські балади*, poetic collection under the Єремія Галка name, listed by EIU.
+- `1841` — *Переяславська ніч*, drama, listed by EIU.
+- `1844` — *Об историческом значении русской народной поэзии*, scholarly work, listed by EIU.
+- `1846` — *Книги битія українського народу*, political-religious manifesto, preserved in later editions and Wikisource.
+- `1847` — *Слов'янська міфологія*, scholarly work, listed by EIU.
+- `1859` — *Богдан Хмельницький*, historical monograph, listed by EIU.
+- `1861` — *Дві руські народності*, essay contrasting Ukrainian and Russian historical-political cultures, available via Wikisource.
+- `1879-1880` — *Руїна*, historical study, listed by EIU.
+- `1882` — *Мазепа*, historical study, listed by EIU.
+- `1884` — *Мазепинці*, historical study, listed by EIU.
+
+## 4. Primary-source quotes
+
+> "Не хочем царя, хочемо бути вільні і рівні"
+
+Source: *Книги битія українського народу*, 1921 Lviv edition on Wikisource. Pedagogically, this is a concise entry point into the Brotherhood's anti-autocratic vocabulary.
+
+> "Хто хоче бути першим, повинен бути всім слугою"
+
+Source: *Книги битія українського народу*, 1921 Lviv edition on Wikisource. The line matters because the manifesto translates political equality into biblical ethical syntax.
+
+## 5. Language register
+
+- **Register:** Biblical-prophetic political prose; scholarly-historical prose in later works.
+- **CEFR readiness for full reading:** C1 for *Книги битія* because of archaizing syntax and dense allusion; C1-C2 for *Дві руські народності* in original form.
+- **Lexicon notes:** `братство`, `слов'янський`, `воля`, `рівність`, `республіка`, `народність`, `кріпацтво`; learners need a note that nineteenth-century `руський` and `руський/російський` usages require historical framing.
+- **Stylistic features:** Scriptural parallelism, moral antithesis, national-historical typology, and long argumentative periods.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The exact authorship and textual shaping of *Книги битія українського народу* is sometimes discussed alongside Taras Shevchenko's influence, but the retrieved EIU and Wikisource materials credit Kostomarov as author.
+- **What gets simplified in popular memory:** The Brotherhood is often reduced to a romantic literary circle. The retrieved encyclopedia result shows a concrete political program: native-language education, abolition of serfdom, and republican/federal visions.
+- **Where modern Russian disinformation attacks them:** Imperial and Soviet narratives commonly flatten the distinction between Ukrainian and Russian historical development. *Дві руські народності* is a direct primary text for resisting that erasure.
+- **Polish / Jewish / other-perspective considerations:** Brotherhood federalism imagined a Slavic order centered in Kyiv; lessons should avoid presenting that program as modern liberal pluralism without context.
+- **Date and source discipline:** Because EIU itself gives a variant birth date, downstream YAML should preserve a `date_note` rather than forcing a single unqualified date.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-essay/kostomarov-two-rus-nationalities.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/kyrylo-mefodiivtsi.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/knyhy-butiia-shevchenko.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Taras Shevchenko, Panteleimon Kulish, Mykola Hulak, and Vasyl Bilozerskyi.
+  - A HIST/LIT bridge on the Brotherhood investigation as an imperial censorship and policing case.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 excerpt sequence comparing *Книги битія* with *Дві руські народності*.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-kostomarov`
+- **EN canonical (BGN/PCGN 2010):** Mykola Kostomarov
+- **UA canonical (with patronymic):** Костомаров Микола Іванович
+- **Aliases (track these for `aliases:` YAML field):** Єремія Галка, Ieremiia Halka, Ivan Bogucharov, Mykola Kostomariv
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Nikolai Kostomarov, Nikolay Kostomarov, Nikolai Ivanovich Kostomarov (FORBIDDEN except as archival/source-title metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Library of Congress portrait on Commons, `File:Nikola i Ivanovich Kostomarov, head-and-shoulders portrait, facing front LCCN99615560.jpg` | CC0/Public Domain Dedication | https://commons.wikimedia.org/wiki/File:Nikola_i_Ivanovich_Kostomarov,_head-and-shoulders_portrait,_facing_front_LCCN99615560.jpg
+- **Backup candidates:** Other public-domain nineteenth-century portraits on Commons after license verification.
+- **If no PD/CC portrait exists:** Use the LOC/Commons image and note historical source metadata.
+- **Era-appropriate context image:** Кирило-Мефодіївське братство document facsimile, if a rights-cleared institutional image is available.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України, "Костомаров Микола Іванович" | https://www.history.org.ua/?termin=Kostomarov_M | accessed 2026-05-30
+- `mcp__sources.search_literary`, Енциклопедія українознавства result on Кирило-Мефодіївське братство and *Книги битія українського народу* | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Wikisource, *Книги битія українського народу* | https://uk.wikisource.org/wiki/Книги_битія_українського_народу | accessed 2026-05-30
+- Wikisource, *Дві руські народності* | https://uk.wikisource.org/wiki/Дві_руські_народності | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Костомаров Микола Іванович," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_literary` Chyzhevsky result discussing *Книги битія українського народу* | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Kostomarov, *Книги битія українського народу*, 1921 Lviv edition via Wikisource.
+- Kostomarov, *Дві руські народності*, via Wikisource.
+
+---
+
+## Decolonization self-check
+
+- [x] Brotherhood political program named without imperial euphemism
+- [x] Birth-date discrepancy flagged
+- [x] Police-file gap declared instead of invented
+- [x] Existing paths verified
+- [x] Russian transliterations confined to naming metadata

--- a/docs/research/bio/panas-myrnyi.md
+++ b/docs/research/bio/panas-myrnyi.md
@@ -1,0 +1,128 @@
+# Мирний Панас — Research Dossier
+
+**Slug:** `panas-myrnyi`
+**Block:** B
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Панас Мирний; birth name Рудченко Панас Якович.
+- **Pseudonyms / aliases:** Панас Мирний, П. Мирний, Panas Myrnyi, Panas Myrny.
+- **Born:** 1849-05-13 | Миргород, Полтавщина | Russian Empire. Sources: UINP historical calendar entry; NBUV anniversary note; Ukrainian literary biography pages retrieved by the source pack.
+- **Died:** 1920-01-28 | Полтава | Ukraine under wartime revolutionary/Soviet transition. Sources: UINP, NBUV, UkrLit biography.
+- **Family / education key facts:** Brother of Ivan Bilyk, coauthor of *Хіба ревуть воли, як ясла повні?* Worked for decades in the imperial civil-service bureaucracy while publishing Ukrainian literature under a pseudonym; this double life is noted in UINP and literary-biographical sources.
+
+## 2. Oppression mechanism
+
+- **What happened:** Indirect imperial censorship and Ukrainian-language suppression, not a retrieved personal arrest case.
+- **When:** 1876-05-18 Old Style / 1876-05-30 New Style Ems Ukaz; continuing publication restrictions in the late 1870s and 1880s.
+- **By whom:** Russian imperial state under Alexander II; imperial censorship administration.
+- **Document references:** Ems Ukaz of 1876. A personal police case number against Panas Myrnyi was not retrieved. Specific personal file ID: source not found.
+- **Mechanism specifics:** UINP's Ems Ukaz calendar entry identifies the 1876 decree as a ban on printing and importing Ukrainian-language books, as well as Ukrainian-language public performance and readings. The Panas Myrnyi source pack connects this censorship environment to the delayed and displaced publication of Ukrainian prose: *Хіба ревуть воли, як ясла повні?*, written with Ivan Bilyk in the 1870s, was first published outside the Russian Empire's normal Ukrainian-language print channel, in Geneva in 1880, because imperial censorship blocked publication.
+
+Myrnyi's case therefore belongs to the "deterministic over hallucination" category of indirect oppression. The retrieved sources do not prove a direct personal arrest, exile, or trial. They do prove a named state document and a publication mechanism: Ukrainian prose had to move through pseudonyms, Galicia/foreign printing, or delayed editions under imperial language policy.
+
+- **What survived / what was destroyed:** The major novels survived; publication chronology was distorted by censorship. A personal surveillance dossier was not retrieved.
+
+For downstream bio YAML, the oppression field should therefore say `censorship / publication displacement`, not `arrested` or `exiled`. The sourced state document is the Ems Ukaz; the unsourced item is a personal police case.
+
+## 3. Major works
+
+- `1872` — *Лихий попутав*, prose, listed by UkrLit and Myslene Drevo biography.
+- `1874` — *П'яниця*, prose, listed in the source pack.
+- `1875` — *Лихі люди*, prose, listed by UkrLit; publication was shaped by censorship.
+- `1872-1875 / 1880` — *Хіба ревуть воли, як ясла повні?*, novel with Ivan Bilyk; written in the 1870s and first published in Geneva in 1880, per NBUV/UkrLit/Myslene Drevo sources.
+- `1883` — *Повія*, novel, listed by UkrLit and NBUV.
+- `1883` — *Лимерівна*, drama, listed by UkrLit.
+- `1884` — *Перемудрив*, drama/prose work, listed by the source pack.
+- `1885` — *Морозенко*, prose, listed by UkrLit.
+- `1887` — *Лови*, prose, listed by UkrLit.
+- `1901` — "Про мову," publicistic note, available via Myslene Drevo.
+
+## 4. Primary-source quotes
+
+> "Найбільше і найдорожче добро"
+
+Source: Panas Myrnyi, "Про мову" (February 1901), Myslene Drevo. The fragment is a concise entry into his language ideology without overquoting the essay.
+
+> "Хоч би ти, соловейку"
+
+Source: Panas Myrnyi, *Дума про військо Ігореве*, Myslene Drevo. The line is useful pedagogically because it shows his work with older epic material through Ukrainian poetic diction.
+
+## 5. Language register
+
+- **Register:** Realist prose grounded in living speech; publicistic when writing about language; epic-poetic in the *Слово о полку Ігоревім* retelling.
+- **CEFR readiness for full reading:** B2 for selected publicistic excerpts; C1 for *Хіба ревуть воли* and *Повія* because of dialect, idiom, social vocabulary, and long realist syntax.
+- **Lexicon notes:** `ясла`, `воли`, `громада`, `чиновник`, `повія`, `правда`, `кривда`, `мова`; learners need notes on nineteenth-century rural legal and social terms.
+- **Stylistic features:** Extended psychological narration, idiomatic dialogue, proverb-like titles, and narrator movement between social panorama and intimate interiority.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Composition versus publication chronology, especially for works delayed by censorship. The source pack specifically flagged the publication gap around *Хіба ревуть воли* and other texts.
+- **What gets simplified in popular memory:** Myrnyi is often taught as only a realist novelist. The language essay and censorship history show that his prose also belongs to the Ukrainian-language rights history of the Russian Empire.
+- **Where modern Russian disinformation attacks them:** No specific modern disinformation campaign was retrieved. The predictable distortion is to treat the Ems restrictions as neutral "publication policy" rather than a named imperial prohibition on Ukrainian.
+- **Polish / Jewish / other-perspective considerations:** The retrieved sources did not surface a specific Polish or Jewish perspective issue for this dossier. Source not found.
+- **Coauthorship note:** Lessons on *Хіба ревуть воли* should name Ivan Bilyk when discussing the novel's composition, because the retrieved sources identify the collaboration.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/panas-myrny-intro.yaml`
+  - `curriculum/l2-uk-en/plans/lit/khiba-revut-voly-1.yaml`
+  - `curriculum/l2-uk-en/plans/lit/khiba-revut-voly-2.yaml`
+  - `curriculum/l2-uk-en/plans/lit/khiba-revut-voly-style.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Ivan Bilyk, Mykhailo Drahomanov, and Ukrainian Geneva publishing.
+  - A C1 module on censorship-delayed publication chronology.
+- **Potential LIT additions surfaced by this research:**
+  - A short B2 prose/publicistic lesson from "Про мову" paired with the existing Ems Ukaz history plan.
+
+## 8. Naming-canonical
+
+- **Slug:** `panas-myrnyi`
+- **EN canonical (BGN/PCGN 2010):** Panas Myrnyi
+- **UA canonical (with patronymic if needed):** Мирний Панас; Рудченко Панас Якович
+- **Aliases (track these for `aliases:` YAML field):** Панас Мирний, П. Мирний, Panas Myrny, Panas Rudchenko
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Afanasii Rudchenko, Afanasy Rudchenko, Panas Mirny (FORBIDDEN except as source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Myrnyi.jpg` | public-domain marking on Commons | https://commons.wikimedia.org/wiki/File:Myrnyi.jpg
+- **Backup candidates:** NBUV anniversary images, if rights-cleared; museum portraits with explicit reuse permissions.
+- **If no PD/CC portrait exists:** Use the Commons portrait after license verification.
+- **Era-appropriate context image:** Cover or title-page image for the Geneva 1880 edition of *Хіба ревуть воли*, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- UINP historical calendar, "1849, 13 травня - народився Панас Мирний" | https://www.uinp.gov.ua/istorychnyy-kalendar/traven/13/1849-narodyvsya-panas-myrnyy-pysmennyk-dramaturg | accessed 2026-05-30
+- UINP historical calendar, "1876, 30 травня - Емський указ" | https://www.uinp.gov.ua/istorychnyy-kalendar/traven/30/1876-emskyy-ukaz | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- NBUV, "Панас Мирний (1849-1920). До 175-річчя..." | https://www.nbuv.gov.ua/node/6526 | accessed 2026-05-30
+- Myslene Drevo, "Панас Мирний" | https://www.myslenedrevo.com.ua/uk/Lit/M/MyrnyP.html | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Панас Мирний," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Myslene Drevo study page on censorship obstacles around Panas Myrnyi | https://www.myslenedrevo.com.ua/uk/Lit/M/MyrnyP/Studiji/Syvachenko/4.html | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Panas Myrnyi, "Про мову" | https://www.myslenedrevo.com.ua/uk/Lit/M/MyrnyP/OtherWorks/ProMovu.html | accessed 2026-05-30
+- Panas Myrnyi, *Дума про військо Ігореве* | https://www.myslenedrevo.com.ua/uk/Lit/M/MyrnyP/Transl/DumaProVijskoIgoreve.html | accessed 2026-05-30
+
+---
+
+## Decolonization self-check
+
+- [x] Indirect censorship named as such; no false arrest invented
+- [x] Ems Ukaz cited as a specific imperial document
+- [x] Existing curriculum paths verified
+- [x] Russian-imperial naming excluded from body text
+- [x] Publication gaps treated as censorship evidence, not author delay

--- a/docs/research/bio/pavlo-hrabovskyi.md
+++ b/docs/research/bio/pavlo-hrabovskyi.md
@@ -1,0 +1,120 @@
+# Грабовський Павло Арсенович — Research Dossier
+
+**Slug:** `pavlo-hrabovskyi`
+**Block:** B
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Грабовський Павло Арсенович.
+- **Pseudonyms / aliases:** Павло Граб, П. Граб, Граб, П. Арсенич, Хмара, per ESU and EIU biographical entries.
+- **Born:** 1864-08-30 Old Style / 1864-09-11 New Style | село Пушкарне, now Грабовське, Сумська область | Russian Empire. Sources: Енциклопедія історії України, "Грабовський Павло Арсенович"; ЕСУ, "Грабовський Павло Арсенович."
+- **Died:** 1902-11-29 Old Style / 1902-12-12 New Style | Тобольськ | Russian Empire. The same two encyclopedia entries give the Julian/Gregorian pair and Tobolsk endpoint.
+- **Family / education key facts:** Born into the family of a village psalmist. Studied at Okhtyrka bursa and, from 1879, at Kharkiv Theological Seminary. EIU and ESU both connect the seminary years to his entry into Narodnik circles.
+
+## 2. Oppression mechanism
+
+- **What happened:** Expelled, placed under police supervision, imprisoned, and exiled repeatedly by the Russian imperial state.
+- **When:** 1882 seminary expulsion and police supervision; 1886 arrest; 1888 administrative exile to Siberia; 1889 re-arrest after the Yakutsk protest; 1890s prison and settlement sequence through Irkutsk, Viliuisk, Yakutsk, and Tobolsk.
+- **By whom:** Russian imperial police, prison administration, and exile administration.
+- **Document references:** EIU and ESU identify the charges and exile sequence but do not provide an archival case number. Specific court or police file ID: source not found.
+- **Mechanism specifics:** ESU states that in 1882 Hrabovskyi was expelled from Kharkiv Theological Seminary for links to the Narodnik group "Чорний переділ" and sent to Pushkarne under police supervision. EIU and ESU then describe the 1886 arrest for revolutionary agitation, ties to the same circle, and dissemination of forbidden literature. In 1888 he was sent to Balagansk district in Irkutsk gubernia for a five-year exile term.
+
+In 1889 Hrabovskyi signed the protest "Російському урядові" after the repression of political exiles in Yakutsk. ESU records that he was arrested again, spent about three and a half years in Irkutsk prison, then was moved to Viliuisk, Yakutsk, and finally Tobolsk, where he died in 1902. This is not a vague "difficult life" story: the state mechanism was administrative exile backed by prison confinement.
+
+- **What survived / what was destroyed:** His poetry, translations, and correspondence survived through publications from Galicia and later collected editions. Personal archival police file identifiers were not retrieved for this dossier.
+
+## 3. Major works
+
+- `1894` — *Пролїсок*, poetry collection, Lviv. Includes the textile-labor poem "Швачка"; source: Wikisource scan and EIU/ESU bibliography.
+- `1894` — *Твори Івана Сурика*, translation/editing work, identified in the EIU/ESU source chain.
+- `1895` — *З чужого поля*, translated poetry collection, Lviv. The Wikisource scan preserves the 1895 publication.
+- `1896` — *З Півночі*, poetry, exile-period collection, listed by EIU/ESU.
+- `1897` — *Доля*, poetry, listed by EIU/ESU.
+- `1898` — *Кобза*, poetry, listed by EIU/ESU.
+- `1898` — *Песни України*, translation-oriented publication, listed by EIU.
+- Undated / periodical circulation — "До України," "До Русі-України," "Я не співець чудовної природи...", and "Уперед," civic poems associated with the prison-exile corpus in EIU/ESU summaries.
+
+## 4. Primary-source quotes
+
+> "Рученьки терпнуть, злипають ся віченьки"
+
+Source: Hrabovskyi, "Швачка," in *Пролїсок* (Lviv, 1894), Wikisource. The line is useful for learners because it compresses social critique into diminutive forms and physical detail.
+
+> "Не тобі молюсь я, боже"
+
+Source: Hrabovskyi, *З чужого поля* (1895), Wikisource page scan. This short opening shows the anti-hypocrisy register of his civic poetry without requiring a full advanced reading.
+
+## 5. Language register
+
+- **Register:** Civic-poetic, social-accusatory, anti-aestheticist, with lyric and publicistic overlap.
+- **CEFR readiness for full reading:** B2-C1 for selected poems; C1 for full collections because of older orthography, exile vocabulary, and political allusion.
+- **Lexicon notes:** `заслання`, `народ`, `неволя`, `боротьба`, `швачка`, `каторга`, `жертва`, `правда`; older spellings from Galician publications should be normalized only in learner notes, not silently modernized.
+- **Stylistic features:** Direct apostrophe, imperative civic address, social-detail imagery, and high-frequency diminutives that are not sentimental but accusatory.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The relative weight of Hrabovskyi as poet, translator, and political exile. EIU and ESU foreground both the literary corpus and the revolutionary/exile biography; a course should not reduce him to a martyr footnote.
+- **What gets simplified in popular memory:** His Siberian exile is often remembered as a single continuous punishment. The retrieved sources show a sequence of expulsion, surveillance, imprisonment, administrative exile, re-arrest, and forced settlement.
+- **Where modern Russian disinformation attacks them:** No specific modern disinformation campaign was retrieved. The relevant risk is older imperial framing that treats him as merely a "Russian Narodnik" figure while erasing the Ukrainian-language literary project.
+- **Polish / Jewish / other-perspective considerations:** Galicia mattered as a publication space because the Russian Empire's Ukrainian-language restrictions made imperial publication difficult. This is a publication-ecology point, not a claim that Galicia authored the work.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - A B2/C1 LIT module on Hrabovskyi's exile poetry beside civic poems by Lesia Ukrainka and Ivan Franko.
+  - A HIST/BIO link to Russian imperial administrative exile as a mechanism used against Ukrainian writers.
+- **Potential LIT additions surfaced by this research:**
+  - An excerpt lesson around "Швачка" for social vocabulary and diminutive morphology in non-sentimental usage.
+
+## 8. Naming-canonical
+
+- **Slug:** `pavlo-hrabovskyi`
+- **EN canonical (BGN/PCGN 2010):** Pavlo Hrabovskyi
+- **UA canonical (with patronymic):** Грабовський Павло Арсенович
+- **Aliases (track these for `aliases:` YAML field):** Павло Граб, П. Граб, Граб, П. Арсенич, Хмара, Pavlo Hrabovsky
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Pavel Grabovsky, Pavel Grabovskii (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Pavlo Hrabovsky.jpg` | public-domain marking on the file page | https://commons.wikimedia.org/wiki/File:Pavlo_Hrabovsky.jpg
+- **Backup candidates:** EIU/ESU portraits if rights metadata is explicit; later memorial photographs only if a rights-cleared institutional source is found.
+- **If no PD/CC portrait exists:** Use a public-domain pre-1902 portrait from Commons after verifying the license.
+- **Era-appropriate context image:** A map of Siberian exile routes or Tobolsk context image, rights permitting.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України, "Грабовський Павло Арсенович" | https://www.history.org.ua/?termin=Grabovsky_P | accessed 2026-05-30
+- Енциклопедія Сучасної України, "Грабовський Павло Арсенович" | https://esu.com.ua/article-26782 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Wikisource, *Пролїсок/Швачка* | https://uk.wikisource.org/wiki/Пролїсок/Швачка | accessed 2026-05-30
+- Wikisource page scan, *Павло Грабовський. З чужого поля* (1895) | https://uk.wikisource.org/wiki/Сторінка:Павло_Грабовський._З_чужого_поля_(1895).djvu/29 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Грабовський Павло Арсенович," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_sources` result from `wave8-ukr-lit-entsyklopediia`, "Грабовський Павло Арсенович" | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Hrabovskyi, "Швачка," in *Пролїсок* (1894), via Wikisource.
+- Hrabovskyi, *З чужого поля* (1895), via Wikisource scan.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing
+- [x] Russian-imperial agency named directly
+- [x] Police-file number gap declared instead of invented
+- [x] Existing paths verified by absence/search, not assumed
+- [x] Ukrainian canonical naming used

--- a/docs/research/bio/stepan-rudnytskyi.md
+++ b/docs/research/bio/stepan-rudnytskyi.md
@@ -1,0 +1,129 @@
+# Рудницький Степан Львович — Research Dossier
+
+**Slug:** `stepan-rudnytskyi`
+**Block:** H
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Рудницький Степан Львович.
+- **Pseudonyms / aliases:** Stepan Rudnytskyi, Stepan Rudnytsky, S. Rudnytskyi.
+- **Born:** 1877-12-03 | Перемишль | Austria-Hungary. Sources: Internet Encyclopedia of Ukraine; UINP historical calendar; Commons portrait metadata.
+- **Died:** 1937-11-03 | Sandarmokh, Karelia | USSR. Sources: UINP and Kherson library biography; Ukrainian Wikipedia via `mcp__sources.query_wikipedia` also flags the correction from earlier Solovky-death claims.
+- **Family / education key facts:** Geographer, cartographer, ethnographer, academician of VUAN, and founder figure for Ukrainian physical, political, and military geography. Sources: IEU, UINP, Ukrainian Wikipedia summary.
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, fabricated counterrevolutionary/espionage charges, camp sentence, special troika death sentence, execution.
+- **When:** 1933-03-23 arrest; 1933-09-23 sentence to five years; October 1937 special troika death sentence; 1937-11-03 execution.
+- **By whom:** NKVD and the special NKVD troika of Leningrad Oblast; Soviet camp administration.
+- **Document references:** UINP and the Kherson library page identify the accusation as membership in the alleged "Українська Військова Організація" and espionage. A specific archival case number was not retrieved. File ID: source not found.
+- **Mechanism specifics:** UINP states that Rudnytskyi was arrested in 1933 and charged without evidence with participation in a counterrevolutionary organization and espionage. The Kherson library source pack gives the sentence and camp path: Svirlag and the White Sea-Baltic camp before the 1937 troika decision. Both sources give 3 November 1937 as the execution date at Sandarmokh.
+
+This repression destroyed a geographer whose work explicitly treated Ukraine as a political-geographical subject. The retrieved `mcp__sources.search_sources` result from *Українська державність у XX столітті* preserves citations to Rudnytskyi's 1923 work *Українська справа зі становища політичної географії*, where Moscow is framed as politically and economically incompatible with Ukrainian independence.
+
+- **What survived / what was destroyed:** Major geographical works, maps, and reprints survived. The institutional school in Soviet Ukraine was broken by Stalinist repression. Exact NKVD case ID was not retrieved.
+
+The dossier keeps the older Solovky version only as a contested-point warning. Current lessons should use Sandarmokh and the 1937-11-03 execution date unless a cited primary archive requires more nuance.
+
+## 3. Major works
+
+- `1905` — *Нинїшна ґеоґрафія*, listed in Commons/IEU source pack.
+- `1908` — *Начерк географічної термінології*, terminology work, listed in the source pack.
+- `1910` — *Коротка ґеоґрафія України*, part 1, listed by IEU/UINP/source pack.
+- `1914` — *Коротка ґеоґрафія України*, part 2, listed by IEU/source pack.
+- `1916` — *Україна край і нарід*, geographic-political work, listed in IEU/source pack.
+- `1917` — *Україна наш рідний край*, school/pedagogical geography, cited by Kherson library.
+- `1919` — *Початкова ґеоґрафія для народніх шкіл*, listed in source pack.
+- `1921` — *Україна — наш рідний край*, edition/scanned work on Commons.
+- `1923` — *Огляд національної території України*, listed by IEU/source pack.
+- `1923` — *Українська справа зі становища політичної географії*, cited in `mcp__sources.search_sources` result from *Українська державність у XX столітті*.
+- `1924/1926` — *Основи землезнання України*, volumes 1-2, listed by IEU/source pack.
+- `1925/1927` — *Основи морфольоґії й ґеольоґії Підкарпатської Руси й Закарпаття взагалі*, listed by IEU/source pack.
+
+## 4. Primary-source quotes
+
+> "земля, де живемо, зветься Україна"
+
+Source: Rudnytskyi, *Коротка географія України*, quoted by Kherson library biography. This is a simple, powerful geography sentence for A2/B1 learners after adaptation.
+
+> "любов рідного краю"
+
+Source: Rudnytskyi, *Коротка географія України*, quoted by Kherson library biography. It links affective patriotism to geographic knowledge, a useful pedagogical frame.
+
+## 5. Language register
+
+- **Register:** Didactic geography, political geography, terminology-building academic prose.
+- **CEFR readiness for full reading:** B2 for selected school-geography sentences; C1-C2 for political-geography essays and terminology-heavy work.
+- **Lexicon notes:** `географія`, `територія`, `край`, `нарід`, `землезнання`, `морфологія`, `геологія`, `державність`; older orthography such as `ґеоґрафія` should be explained.
+- **Stylistic features:** Pedagogical definitions, spatial classification, national-territorial argument, and terminology creation.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Death-place metadata. Ukrainian Wikipedia and the source pack note that older accounts placed his death at Solovky or used uncertain dates; post-1997 Sandarmokh research corrected the execution site and date to 1937-11-03.
+- **What gets simplified in popular memory:** He is sometimes remembered only as a geographer. The retrieved sources show cartography, terminology, political geography, and statehood argument as inseparable.
+- **Where modern Russian disinformation attacks them:** Soviet charges of "counterrevolutionary" organization and espionage are repressive accusations, not facts. Modern lessons must not reproduce them unmarked.
+- **Polish / Jewish / other-perspective considerations:** Born in Austrian-ruled Перемишль and worked across Habsburg and Soviet contexts; learners should avoid projecting later borders backward.
+- **Map-reading caution:** His territorial maps should be taught as political geography from their publication context, not as timeless ethnic-boundary diagrams.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - None found for this slug in the current plans tree.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - A HIST/GEO module on Ukrainian political geography and maps of national territory.
+  - A BIO link to VUAN scholars repressed in the 1930s.
+  - A C1 terminology module on `географія`, `землезнання`, `територія`, and statehood vocabulary.
+- **Potential LIT additions surfaced by this research:**
+  - Not primarily LIT; consider an interdisciplinary source-reading lesson from *Україна наш рідний край*.
+
+## 8. Naming-canonical
+
+- **Slug:** `stepan-rudnytskyi`
+- **EN canonical (BGN/PCGN 2010):** Stepan Rudnytskyi
+- **UA canonical (with patronymic):** Рудницький Степан Львович
+- **Aliases (track these for `aliases:` YAML field):** Stepan Rudnytsky, S. Rudnytskyi, Степан Рудницький
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Stepan Rudnitsky, Stepan Lvovich Rudnitsky (FORBIDDEN except as source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Рудницкий, Степан Львович.jpg` | public-domain marking on Commons | https://commons.wikimedia.org/wiki/File:%D0%A0%D1%83%D0%B4%D0%BD%D0%B8%D1%86%D0%BA%D0%B8%D0%B9%2C_%D0%A1%D1%82%D0%B5%D0%BF%D0%B0%D0%BD_%D0%9B%D1%8C%D0%B2%D0%BE%D0%B2%D0%B8%D1%87.jpg
+- **Backup candidates:** Commons map file `Оглядова карта українських земель, 1915.jpg`; Commons 1921 scan of *Україна — наш рідний край*.
+- **If no PD/CC portrait exists:** Use the Commons portrait after checking public-domain status.
+- **Era-appropriate context image:** Rudnytskyi map of Ukrainian lands, if the Commons public-domain metadata is valid.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine, "Rudnytsky, Stepan" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CU%5CRudnytskyStepan.htm | accessed 2026-05-30
+- UINP historical calendar, "Народився Степан Рудницький" | https://uinp.gov.ua/istorychnyy-kalendar/gruden/3/narodyvsya-stepan-rudnyckyy | accessed 2026-05-30
+- `mcp__sources.search_sources`, *Українська державність у XX столітті* result citing Rudnytskyi's *Українська справа зі становища політичної географії* | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Kherson regional library, "Степан Рудницький" | https://lib.kherson.ua/stepan-rudnitskiy.htm | accessed 2026-05-30
+- Commons scan, *Україна — наш рідний край* (1921) | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Рудницький Степан Львович," retrieved via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- RVV reprint page for *Україна наш рідний край* (2025) | https://rvv.com.ua/product/ukrayina-nash-ridnyj-kraj-stepan-rudnyczqqkyj-2025/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Rudnytskyi, *Україна — наш рідний край* (1921), Commons scan.
+- Rudnytskyi, *Українська справа зі становища політичної географії* (1923), cited through `mcp__sources.search_sources` result.
+
+---
+
+## Decolonization self-check
+
+- [x] Execution named directly, not euphemized
+- [x] Soviet accusation language marked as allegation
+- [x] Sandarmokh/Solovky discrepancy flagged
+- [x] No fabricated existing paths
+- [x] Ukrainian territorial-geography frame preserved


### PR DESCRIPTION
## Summary

Adds 8 NON-Block-G Phase 1 bio research dossiers for Epic #2309, batch 3. Selection prioritized missing Block B and H figures after excluding PR #2427 in-flight figures and all Block G figures.

## Figures and source tiers

- `pavlo-hrabovskyi` — Block B — Tier 1: Енциклопедія історії України, Енциклопедія Сучасної України; Tier 2: Wikisource scans of `Пролїсок` / `З чужого поля`.
- `mykola-kostomarov` — Block B — Tier 1: Енциклопедія історії України, MCP Енциклопедія українознавства result; Tier 2: Wikisource `Книги битія українського народу`, `Дві руські народності`.
- `ivan-karpenko-karyi` — Block B — Tier 1: Енциклопедія історії України, Енциклопедія Сучасної України; Tier 2: Wikisource `Мартин Боруля` NTSh edition.
- `panas-myrnyi` — Block B — Tier 1: UINP Panas Myrnyi calendar entry, UINP Ems Ukaz calendar entry; Tier 2: NBUV anniversary note, Myslene Drevo primary texts.
- `ivan-manzhura` — Block B — Tier 1: MCP `Українська літературна енциклопедія` result; Tier 2: Dnipro library biography, Commons metadata.
- `leonid-hlibov` — Block B — Tier 1: MCP `Українська літературна енциклопедія` result; Tier 2: Kherson library biography, Commons metadata.
- `mykhailo-kravchuk` — Block H — Tier 1: Internet Encyclopedia of Ukraine, NAS biography, Енциклопедія Сучасної України; Tier 2: NBUV profile, KPI memorial page.
- `stepan-rudnytskyi` — Block H — Tier 1: Internet Encyclopedia of Ukraine, UINP calendar entry, MCP `Українська державність у XX столітті` result; Tier 2: Kherson library biography, Commons scan.

## Validation

- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py`
- Raw final line: `No fabricated Existing cross-track plan paths found.`
- `git diff --cached --check` passed before commit.
- Commit trailer validated with `.venv/bin/python scripts/audit/lint_agent_trailer.py`.

## Source gaps declared in dossiers

- No specific police/court/NKVD archival file IDs were retrieved for the dossiers that mention repression mechanisms; each relevant dossier says `source not found` rather than inventing file numbers.
- Manzhura and Hlibov now use Ukrainian Literary Encyclopedia corpus entries, but still lack retrieved archival expulsion/dismissal file IDs.
