### PR TITLE
feat(bio): 8 Phase-1 research dossiers — batch 6 (#2309)

### DIFF
--- a/docs/research/bio/hryhorii-khomyshyn.md
+++ b/docs/research/bio/hryhorii-khomyshyn.md
@@ -1,0 +1,125 @@
+# Хомишин Григорій Лукич — Research Dossier
+
+**Slug:** `hryhorii-khomyshyn`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Хомишин Григорій Лукич; church form Григорій (Хомишин).
+- **Pseudonyms / aliases:** Hryhorii Khomyshyn, Hryhorij Chomyshyn, Hryhory Khomyshyn, Bishop Gregory Khomyshyn.
+- **Born:** 1867-03-25 | Гадинківці, Ternopil district in UGCC/Vatican wording | Austria-Hungary. Sources: UGCC bishop profile; Vatican Ukrainian Greek Catholic martyr biography page.
+- **Died:** UGCC gives 1945-12-28 | Lukianivska prison hospital, Kyiv | Ukrainian SSR. Vatican biography page gives 1947-01-17 in Kyiv's NKVD prison. This dossier follows the more detailed UGCC archival account for the local date/place, while preserving the Vatican discrepancy.
+- **Family / education key facts:** UGCC says he came from a middle-peasant family, completed the Ternopil gymnasium in 1888, studied theology in Lviv, and defended a doctorate after studies in Vienna in 1899. Vatican confirms further theological education in Vienna from 1894 to 1899 and episcopal ordination in 1904.
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet arrests, NKVD/NKGB investigation, long interrogations, fabricated political accusations, transfer to Kyiv, death in prison hospital.
+- **When:** Vatican and UGCC agree on a first arrest in 1939. UGCC gives second arrest on 1945-04-15 and states most other UGCC bishops were arrested on 1945-04-11. The UGCC archival article cites arrest warrant/order materials from 1945-03-26 and an arrest/search order no. 634 issued on 1945-04-11.
+- **By whom:** NKVD/NKGB Soviet security organs; UGCC identifies the 4th section of the 2nd Directorate of the NKGB of the Ukrainian SSR and names state-security officers including Captain Dubok and Captain Khodin in the published archival summary.
+- **Document references:** UGCC bishop profile states the last seven months are described in criminal case no. `35826`, volume 1, held in the Archive of the Security Service of Ukraine in Kyiv. It records 36 interrogation protocols, the last on 1945-09-11. The 1945 charge used articles 54-1a and 54-11 of the Criminal Code of the Ukrainian SSR; Soviet accusation language is quoted only as accusation.
+- **Mechanism specifics:** UGCC's archival article states that on 1945-05-10 Khomyshyn was charged with anti-Soviet agitation, slandering Soviet power, being an "agent of the Vatican," and trying to separate Ukrainians from the Russian people. The same source notes that the criminal language was written in the investigator's idiom, not Khomyshyn's own. On 1945-12-21, as his health deteriorated, he was moved from the inner NKVD prison to Lukianivska prison hospital, where UGCC says he died on 1945-12-28.
+- **What survived / what was destroyed:** His episcopal institutions were attacked, but UGCC preserves his pastoral letters, memoirs, press initiatives, case-file summary, and public memory through beatification. The exact physical fate of all manuscripts and diocesan papers: source not found.
+
+## 3. Major works
+
+- `1893` — priestly ordination by Bishop Yulian Sas-Kuilovskyi, per UGCC.
+- `1899` — doctorate after Vienna studies, per UGCC.
+- `1902-1904` — rector of the Lviv seminary, appointed by Metropolitan Andrey Sheptytsky, per Vatican/UGCC.
+- `1904` — bishop of Stanislaviv, episcopal consecration in Saint George Cathedral, per UGCC/Vatican.
+- `1907` — opening/support of Stanislaviv seminary, per UGCC.
+- `1925/1931` — Ukrainian Catholic Organization, later Ukrainian National Renewal, civic-religious organizing per UGCC.
+- `1926` — *Нова Зоря*, Catholic press initiative, per UGCC.
+- `1927` — *Правда*, Catholic press initiative, per UGCC.
+- `1931` — "Відозва ... про пресу," press address quoted by UGCC.
+- `1932` — *Українська проблема*, pastoral letter / publicistic treatise, available through Zbruc and Chytomo-style access copies.
+- `1934` — "Вісник Станиславівської єпархії" statements on press and religious reading, per UGCC.
+- `1935` — society *Скала*, religious/civic association against communism, per UGCC.
+
+## 4. Primary-source quotes
+
+> "вона фактично має владу над людським мисленням"
+
+Source: Khomyshyn's 1931 address on the press, quoted by UGCC bishop profile. It gives learners a concise way into his media ethics and explains why newspapers became part of his pastoral program.
+
+> "коли впровадимо Боже царство в наші душі"
+
+Source: *Українська проблєма* (1932), reprinted by Zbruc as an access copy. The line is useful because it shows his political argument was built from moral-theological categories, not from secular party language alone.
+
+## 5. Language register
+
+- **Register:** Pastoral-publicistic, ecclesiastical, moral-political.
+- **CEFR readiness for full reading:** C1-C2 for full pastoral letters; B2 for short adapted excerpts.
+- **Lexicon notes:** `єпископ`, `єпархія`, `пастирський лист`, `католицька акція`, `антирадянська агітація`, `НКДБ`, `Лук'янівська тюрма`.
+- **Stylistic features:** Formal church prose, moral antithesis, political diagnosis, and older Galician orthography in source reprints.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His church politics, Latinization/Byzantinism positions, Ukrainian-Polish orientation, and criticism of radical nationalism are debated. Recent scholarly articles on Ukrainian-Polish cultural and church relations treat him as a complex borderland figure rather than a simple hagiographic symbol.
+- **What gets simplified in popular memory:** He can be flattened into "martyr bishop." UGCC sources show four decades of diocesan building, seminary work, press strategy, finance, schools, monastic institutions, and lay organizations before the prison death.
+- **Where modern Russian disinformation attacks them:** Soviet case language called him an "agent of the Vatican" and accused him of separating Ukrainians from Russians. This dossier treats that as Soviet criminalizing vocabulary, not reliable interpretation.
+- **Polish / Jewish / other-perspective considerations:** Polish-Ukrainian relations are central because his interwar public program worked inside the Second Polish Republic and was contested by Ukrainian movements. The dossier should not sanitize those disputes, but it must keep the Soviet prison-death mechanism distinct from interwar political disagreements.
+- **Pedagogical caution:** The Vatican date conflicts with the detailed UGCC archival chronology. Curriculum prose should state the discrepancy and use the case-file-backed UGCC date unless a newer Vatican correction or archival edition is retrieved.
+
+## 7. Cross-track links
+
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Andrey Sheptytskyi, Yosyf Slipyi, Ivan Liatyshevskyi, Ukrainian Catholic press, and the Stanislaviv eparchy.
+- **Potential LIT additions surfaced by this research:**
+  - A C1/C2 excerpt module from *Українська проблема* focused on moral authority, media, and political language.
+
+## 8. Naming-canonical
+
+- **Slug:** `hryhorii-khomyshyn`
+- **EN canonical (BGN/PCGN 2010):** Hryhorii Khomyshyn
+- **UA canonical (with patronymic):** Хомишин Григорій Лукич
+- **Aliases (track these for `aliases:` YAML field):** Григорій (Хомишин), Hryhorij Chomyshyn, Hryhory Khomyshyn, Bishop Gregory Khomyshyn
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Grigorii Khomishin, Grigory Khomishin (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** UGCC bishop profile portrait; rights not established in retrieved page.
+- **Backup candidates:** Wikimedia Commons portrait candidates; verify file-level license before use.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of Stanislaviv/Ioano-Frankivsk cathedral context or Lukianivska prison context.
+- **Era-appropriate context image:** *Нова Зоря* or *Українська проблема* title page, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, Ukrainian Greek Catholic martyr biography page | https://www.vatican.va/news_services/liturgy/documents/ns_lit_doc_20010627_carneckyj_en.html | accessed 2026-05-30
+- UGCC Synod, "Владика Григорій Хомишин" | https://synod.ugcc.ua/data/vladyka-grygoriy-homyshyn-19207/ | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "Матеріали архіву колишнього КДБ про ув'язнення владики Григорія Хомишина" | https://synod.ugcc.ua/data/materialy-arhivu-kolyshnogo-kdb-pro-uvyaznennya-vladyky-grygoriya-homyshyna-4850/ | accessed 2026-05-30
+- UGCC Synod, "Сьогодні минає 80-та річниця..." | https://synod.ugcc.ua/data/sogodni-mynae-80-ta-richnytsya-vidhodu-do-vichnosti-epyskopa-grygoriya-homyshyna-18689/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Григорій (Хомишин)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Ivan Andrukhiv, "Єпископ Григорій Хомишин: на перехресті українсько-польських культурних та церковних взаємин..." | https://ukr-inst.lviv.ua/index.php/ukraina-polshcha/article/view/321 | accessed 2026-05-30
+- Volodymyr Moroz, article on *Українська проблема* in UCU repository | https://er.ucu.edu.ua/items/37d576b9-c01c-44cd-a23f-5768866c23c8 | accessed 2026-05-30
+
+**Tier 5 (general web):**
+- Zbruc, "Українська проблєма" access copy | https://zbruc.eu/node/36187 | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Criminal case no. `35826`, volume 1, Archive of the Security Service of Ukraine in Kyiv, as summarized and quoted by UGCC/Oleh Yehreshii.
+- Khomyshyn, *Українська проблєма* (1932), Zbruc access copy.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet accusation language labeled
+- [x] Vatican/UGCC death-date discrepancy flagged
+- [x] Case number included only from retrieved UGCC archival summary
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/hryhorii-khomyshyn.md
+++ b/docs/research/bio/hryhorii-khomyshyn.md
@@ -87,7 +87,7 @@ Source: *Українська проблєма* (1932), reprinted by Zbruc as an
 
 - **Best PD/CC portrait:** UGCC bishop profile portrait; rights not established in retrieved page.
 - **Backup candidates:** Wikimedia Commons portrait candidates; verify file-level license before use.
-- **If no PD/CC portrait exists:** Use a rights-cleared image of Stanislaviv/Ioano-Frankivsk cathedral context or Lukianivska prison context.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of Stanislaviv/Ivano-Frankivsk cathedral context or Lukianivska prison context.
 - **Era-appropriate context image:** *Нова Зоря* or *Українська проблема* title page, if rights-cleared.
 
 ## 10. Sources used

--- a/docs/research/bio/ivan-padalka.md
+++ b/docs/research/bio/ivan-padalka.md
@@ -1,0 +1,125 @@
+# Падалка Іван Іванович — Research Dossier
+
+**Slug:** `ivan-padalka`
+**Block:** I
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Падалка Іван Іванович.
+- **Pseudonyms / aliases:** Ivan Padalka; no stable artistic pseudonym found in retrieved Tier 1/Tier 2 sources.
+- **Born:** IEU gives 1894-10-27 in Zhornoklovy, Zolotonosha county, Poltava gubernia. Kherson Museum of the Book gives 1894-11-15 in Zhornoklovy, modern Cherkasy region. This dossier flags the date discrepancy.
+- **Died:** 1937-07-13 | Kyiv | Ukrainian SSR | executed by Soviet authorities. IEU gives date/place; *Реабілітовані історією. Харківська область*, book 2, gives the same execution date and Kyiv.
+- **Family / education key facts:** Kherson Museum says he was born into a large farming family, studied first in parish and ministerial schools, then at the Myrhorod Applied Arts School under Opanas Slastion. IEU confirms study at Myrhorod, Kyiv Art School, and the Ukrainian State Academy of Arts under Mykhailo Boichuk and Vasyl Krychevskyi.
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest, fabricated political charge, death sentence, execution, confiscation/destruction of works and archive, family reprisals.
+- **When:** Kherson Museum gives arrest on 1936-09-29. IEU gives September 1936. *Реабілітовані історією. Харківська область*, book 2, states that the first of the Boichukists arrested in September 1936 was Ivan Padalka and that he was sentenced and shot on 1937-07-13.
+- **By whom:** NKVD; Military Collegium of the Supreme Court of the USSR.
+- **Document references:** *Реабілітовані історією. Харківська область*, book 2, cites HDA SBU Kharkiv, file `014860`, sheets 6, 20, 220, 221, 222, in the chapter on the Boichukists. The same volume's rehabilitated-persons register states that Padalka was accused under articles 54-8 and 54-11 of the Criminal Code of the Ukrainian SSR as a member of a "national-fascist Ukrainian organization"; this is Soviet accusation language, not accepted description.
+- **Mechanism specifics:** IEU gives the broad sequence: arrest by NKVD in September 1936, later execution, and posthumous rehabilitation in 1958. The rehabilitation volume adds the court body and date: the Military Collegium sentenced him to the highest measure of punishment on 1937-07-13, and he was shot the same day in Kyiv. Kherson Museum adds that his paintings were confiscated and his personal archive destroyed, and that his wife Mariia Pasko was later arrested and sent to Kolyma. The retrieved sources therefore support a precise Stalinist terror case, not a vague "persecution" label.
+- **What survived / what was destroyed:** IEU lists paintings, prints, book illustrations, and murals; Kherson Museum states that paintings were confiscated and the personal archive destroyed. IEU notes destroyed Lutsk barracks murals and the Chervonozavodskyi theater fresco context.
+
+## 3. Major works
+
+- `1919` — Lutsk barracks murals in Kyiv, collective mural project under Boichuk, destroyed in 1922 per IEU.
+- `1919` — illustrations for *Барвінок* with Tymofii Boichuk, children's book/journal work, listed by IEU and Kherson Museum.
+- `1926` — *Apple*, print, listed by IEU.
+- `1927` — *Attack of the Red Cavalry*, painting, listed by IEU.
+- `1927` — *Photographer in the Village*, genre painting, listed by IEU.
+- `1928` — DniproHES series, prints, listed by IEU.
+- `1928` — illustrations to *Слово о полку Ігоревім*, book graphics, listed by IEU.
+- `1928` — cover for *Мистецтво Слобожанщини*, book design, pictured by IEU.
+- `1933` — illustrations for Denis Diderot's *Вибрані твори*, listed by Kherson Museum.
+- `1933-1935` — *Rest* fresco in Kharkiv Chervonozavodskyi Ukrainian Drama Theater, collective mural work, listed by IEU.
+- `1934` — illustration for Quevedo's *Історія життя пройдисвіта*, listed by Kherson Museum.
+
+## 4. Primary-source quotes
+
+> "АРМУ не є організація якогось одного напряму майстрів"
+
+Source: Padalka in *Червоний шлях* (1926, no. 2), quoted in *Реабілітовані історією. Харківська область*, book 2. The line matters because it shows Padalka defending a plural, organized Ukrainian art field before Socialist Realist control hardened.
+
+> "На жаль, я був поганим учнем Бойчука"
+
+Source: 1929 interview quoted by Lyuk Media from the "Universalnyi zhurnal" auto-interview tradition. This is Tier 5 as an access copy; it is used only as a direct-voice lead. It helps learners avoid reducing him to an obedient Boichuk imitator.
+
+## 5. Language register
+
+- **Register:** Art-critical, workshop-pedagogical, modernist-publicistic.
+- **CEFR readiness for full reading:** B2 for short interview excerpts; C1 for art-critical prose.
+- **Lexicon notes:** `бойчукізм`, `монументальне мистецтво`, `графіка`, `дереворит`, `фреска`, `АРМУ`, `формалізм` as Soviet attack vocabulary.
+- **Stylistic features:** Short polemical statements, institutional art terminology, and modernist vocabulary that benefits from visual support.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His exact birth date and the degree of independence from Boichuk's method. IEU gives one date; Ukrainian museum-memory pages give another.
+- **What gets simplified in popular memory:** He is often remembered only as "one of the Boichukists." IEU and Kherson Museum show a broader profile: teacher, printmaker, illustrator, muralist, and book designer.
+- **Where modern Russian disinformation attacks them:** The Soviet accusation of a "national-fascist Ukrainian organization" is attack language in the criminal case; the dossier labels it as such.
+- **Polish / Jewish / other-perspective considerations:** His art moved through Ukrainian modernist networks and European exhibitions. No specific Polish/Jewish contested point was found in retrieved sources.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/rozstriliane-kontekst.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-rozstriliane.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Mykhailo Boichuk, Vasyl Sedliar, Sofiia Nalepynska-Boichuk, Oksana Pavlenko, and Opanas Slastion.
+- **Potential LIT additions surfaced by this research:**
+  - A B2 visual-reading activity using Padalka's *Слово о полку Ігоревім* illustrations.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-padalka`
+- **EN canonical (BGN/PCGN 2010):** Ivan Padalka
+- **UA canonical (with patronymic):** Падалка Іван Іванович
+- **Aliases (track these for `aliases:` YAML field):** Ivan Padalka, Ivan Ivanovych Padalka
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ivan Ivanovich Padalka (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** IEU group photograph of Mykhailo Boichuk and students including Ivan Padalka; rights need page-level confirmation before publication.
+- **Backup candidates:** Wikimedia Commons images of Padalka illustrations, including *Слово о полку Ігоревім* page; verify license before use.
+- **If no PD/CC portrait exists:** Use a rights-cleared reproduction of a book illustration.
+- **Era-appropriate context image:** HDA SBU / rehabilitation-volume citation page for the Boichukists, if permission allows.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine, "Padalka, Ivan" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesP%5CA%5CPadalkaIvan | accessed 2026-05-30
+- *Реабілітовані історією. Харківська область*, book 2 | https://www.reabit.org.ua/files/store/Kharkiv_2.pdf | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Kherson Regional Universal Scientific Library, Museum of the Book, "Український художник Іван Падалка" | https://museum.lib.kherson.ua/ukrainskiy-hudozhnik-ivan-padalka.htm | accessed 2026-05-30
+- National Library for Children, Padalka page | https://chl.kiev.ua/Default.aspx?id=11408 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Падалка Іван Іванович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Liudmyla Sokoliuk, "Бойчукіст Іван Падалка," cited in Kherson Museum source and in *Реабілітовані історією*.
+
+**Tier 5 (general web):**
+- Lyuk Media, "Про життя розстріляного бойчукіста Івана Падалки" | https://lyuk.media/city/ivan-padalka/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Padalka article/interview excerpts quoted in *Реабілітовані історією* and Lyuk Media access copy.
+- HDA SBU Kharkiv case citation `014860`, sheets 6, 20, 220, 221, 222, as cited in *Реабілітовані історією*.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet accusation language labeled as accusation
+- [x] Birth-date discrepancy flagged
+- [x] NKVD/court mechanism specific
+- [x] No case number invented beyond retrieved HDA SBU citation
+- [x] Existing paths verified

--- a/docs/research/bio/mykola-charnetskyi.md
+++ b/docs/research/bio/mykola-charnetskyi.md
@@ -1,0 +1,121 @@
+# Чарнецький Миколай Олександрович — Research Dossier
+
+**Slug:** `mykola-charnetskyi`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Чарнецький Миколай Олександрович; church form Миколай (Чарнецький), ЧНІ.
+- **Pseudonyms / aliases:** Mykola Charnetskyi, Mykola Carneckyj, Mykola Čarneckyj, Bishop Mykola Charnetsky.
+- **Born:** 1884-12-14 | Семаківці, Horodenka district / Stanislaviv region | Austria-Hungary. Vatican biography and UGCC bishop profile agree on date and village; regional wording differs.
+- **Died:** 1959-04-02 | Lviv | Ukrainian SSR. Vatican and UGCC agree on date.
+- **Family / education key facts:** UGCC says he was the eldest child in a large peasant family. Vatican says he studied in Rome, received a doctorate in dogmatic theology, became professor and spiritual director at the Stanislaviv seminary, and entered the Redemptorist novitiate in 1919.
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, imprisonment, interrogation/torture, conviction as an "agent of the Vatican," forced-labor camps, release as terminally ill.
+- **When:** Vatican says he was arrested by the NKVD on 1945-04-11 and sentenced to six years of forced labor in Siberia. A UGCC profile page gives 1944-04-11 in its short note, while another UGCC/Redemptorist narrative and Vatican use 1945. This dossier flags the discrepancy and follows the Vatican date for the core chronology.
+- **By whom:** NKVD; Soviet court/camp system.
+- **Document references:** UGCC and Redemptorist parish biography report the accusation "agent of the Vatican" and a ten-year strict-regime sentence after Kyiv imprisonment. A stable archival case number was not retrieved. Source not found for file ID.
+- **Mechanism specifics:** Vatican's biography establishes the official beatification biography: in 1926 Pope Pius XI appointed him Apostolic Visitor to Greek Catholics in Volhynia and Polissia; he was ordained bishop in Rome in 1931; during the Soviet assault on the UGCC he was arrested by the NKVD. UGCC sources expand the suffering narrative: prison on Lontskoho Street, transfer to Kyiv, a trial after about a year, and a ten-year sentence as an "agent of the Vatican." Because sources disagree on sentence length and arrest date, the dossier records both rather than forcing a false harmonization.
+- **What survived / what was destroyed:** His institutional mission in Volhynia and Polissia was broken; his reputation as confessor/martyr survived through underground UGCC memory and the beatification process completed in 2001.
+
+## 3. Major works
+
+- `1909` — priestly ordination, pastoral service, per Vatican and UGCC.
+- `1910s` — professor and spiritual director at Stanislaviv seminary, formation work, per Vatican.
+- `1919` — entry into Redemptorist novitiate in Zboiska near Lviv, per Vatican.
+- `1926` — Apostolic Visitor for Greek Catholics in Volhynia and Polissia, per Vatican.
+- `1931` — episcopal consecration in Rome, per Vatican and UGCC.
+- `1939-1945` — service during Soviet and wartime disruption, UGCC pastoral context.
+- `1945-1956` — prison and camp witness; not an authored work, but a central confessor record in UGCC memory.
+- `1956-1959` — post-release secret pastoral presence in Lviv, per UGCC/Redemptorist narrative.
+- `2001` — beatification as martyr by Pope John Paul II during the Ukraine visit, per Vatican/UGCC.
+
+## 4. Primary-source quotes
+
+> "ми є в Божих руках"
+
+Source: recorded classroom remark preserved in Redemptorist/UGCC biography, said during an air raid when seminarians were afraid. It is a direct pastoral register useful for learner discussion of faith language under danger.
+
+> "Набожністю до Найсвятішого Серця"
+
+Source: answer attributed to Charnetskyi on how he formed seminarians, preserved on the Charnetskyi church biography page. This is a parish access copy, so it should be treated as a direct-voice lead rather than a critical edition.
+
+## 5. Language register
+
+- **Register:** Pastoral, monastic, ecclesiastical.
+- **CEFR readiness for full reading:** B2 for short quotes; C1 for full hagiographic or theological biography.
+- **Lexicon notes:** `редемпторист`, `єпископська хіротонія`, `апостольський візитатор`, `екзарх`, `мученик`, `табір примусової праці`.
+- **Stylistic features:** Hagiographic memory, pastoral exhortation, and institutional Catholic terminology. Learners need help separating devotional register from historical claims.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Arrest date and sentence length differ between Vatican and UGCC summaries. The dossier flags 1945 vs 1944/1945 wording and six-year vs ten-year sentence reporting.
+- **What gets simplified in popular memory:** He is often remembered only as a miracle-working martyr. Vatican and UGCC sources show his prior seminary, Redemptorist, and Volhynia/Polissia mission work.
+- **Where modern Russian disinformation attacks them:** Soviet anti-Catholic framing used "agent of the Vatican" as criminalizing language. The dossier quotes it only as accusation.
+- **Polish / Jewish / other-perspective considerations:** His Volhynia and Polissia mission sat in a multi-confessional borderland. Retrieved sources did not provide enough detail for a separate Polish or Jewish perspective section.
+- **Pedagogical caution:** Devotional biographies sometimes smooth chronology in service of witness. Curriculum prose should preserve the Vatican/UGCC date and sentence discrepancies rather than forcing a single neat timeline.
+- **Source-balance note:** The Vatican page is the strongest compact external authority for life dates and beatification context, while the UGCC and Redemptorist pages provide Ukrainian-language detail and recorded speech. Claims about interrogation hours, camp transfers, and sentence wording should stay tied to those institutional biographies unless a Soviet case file is later retrieved.
+
+## 7. Cross-track links
+
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Andrey Sheptytskyi, Yosyf Slipyi, Vasyl Velychkovskyi, Volhynia mission history, and the 2001 beatifications.
+- **Potential LIT additions surfaced by this research:**
+  - No literary-text module surfaced; potential C1 reading could use memoir/testimony excerpts if a critical edition is retrieved.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-charnetskyi`
+- **EN canonical (BGN/PCGN 2010):** Mykola Charnetskyi
+- **UA canonical (with patronymic):** Чарнецький Миколай Олександрович
+- **Aliases (track these for `aliases:` YAML field):** Миколай (Чарнецький), Mykola Carneckyj, Mykola Čarneckyj, Bishop Mykola Charnetsky
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Nikolai Charnetskii, Nikolay Charnetsky (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** UGCC bishop profile portrait; rights not established in retrieved source.
+- **Backup candidates:** Wikimedia Commons tomb image `File:Tomb_of_Mykolai_Charnetskyi_(01).jpg` | CC BY-SA 3.0 per Commons page; verify before publication.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of his tomb or a Redemptorist church memorial.
+- **Era-appropriate context image:** Lontskoho prison museum image for Soviet religious persecution, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, "Mykola Carneckyj (1884-1959)" | https://www.vatican.va/news_services/liturgy/documents/ns_lit_doc_20010627_carneckyj_en.html | accessed 2026-05-30
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/saints/20010626_beatif_ucraina_en.html | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "Владика Миколай Чарнецький" | https://synod.ugcc.ua/data/vladyka-mykolay-charnetskyy-11728/ | accessed 2026-05-30
+- UGCC Synod, "Чудо стається не просто так..." | https://synod.ugcc.ua/data/chudo-staetsya-ne-prosto-tak-shcho-varto-znaty-pro-vladyku-mykolaya-charnetskogo-7627/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Миколай (Чарнецький)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- *Науковий вісник ІФБУ "Добрий Пастир"* article excerpts surfaced in search; used only as lead, not core citation.
+
+**Tier 5 (general web):**
+- Parish biography, "Миколай Чарнецький" | https://charnetskyj.org.ua/mykolaj-charnetskyj/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Recorded sayings preserved in UGCC/Redemptorist biographies. Archival trial file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet accusation language labeled
+- [x] Arrest-date discrepancy flagged
+- [x] No case file invented
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/vasyl-krychevskyi.md
+++ b/docs/research/bio/vasyl-krychevskyi.md
@@ -1,0 +1,126 @@
+# Кричевський Василь Григорович — Research Dossier
+
+**Slug:** `vasyl-krychevskyi`
+**Block:** I
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Кричевський Василь Григорович.
+- **Pseudonyms / aliases:** Vasyl H. Krychevsky, Vasyl Krychevsky, Wasyl Kryczewski; no stable literary pseudonym found in retrieved sources.
+- **Born:** ESU gives 1872-12-29 Old Style / 1873-01-10 New Style, with another variant 1872-12-31 / 1873-01-12 | Ворожба, Лебединський повіт, Харківська губернія | Russian Empire. IEU uses 1873-01-12. This dossier preserves the discrepancy.
+- **Died:** 1952-11-15 | Caracas, Venezuela | reburied 1975 in Bound Brook, New Jersey, United States. Sources: ESU "Кричевський Василь Григорович"; IEU "Krychevsky, Vasyl H."
+- **Family / education key facts:** Brother of Fedir Krychevskyi; father of Vasyl and Mykola Krychevskyi and Halyna Krychevska-Linde; grandfather of Kateryna Krychevska-Rosandich. ESU says he graduated from the Kharkiv Technical Railway School in 1889, audited lectures at Kharkiv University, and trained in art largely through practice with Kharkiv architects and artists.
+
+## 2. Oppression mechanism
+
+- **What happened:** Indirect political-cultural displacement and emigration; no retrieved source documents an arrest, indictment, prison sentence, or numbered Soviet case file against him.
+- **When:** ESU states that from 1944 he lived in emigration in Austria and France, and from 1948 in Venezuela. Earlier Soviet institutional life is documented: professor and founder-level figure in Ukrainian art education from 1917, VUAN art and archeological committee membership in the 1920s, and honored status in 1940. Formal coercive document: source not found.
+- **By whom:** For a precise state-agency act against Krychevskyi personally, source not found. The documented mechanism is the political impossibility of remaining in Soviet Ukraine after a career attached to the UNR's visual statehood, Ukrainian architectural modernism, and nationally marked pedagogy.
+- **Document references:** Arrest file, court case number, rehabilitation notice, or NKVD/MGB file: source not found in retrieved sources.
+- **Mechanism specifics:** ESU and IEU ground the verified biographical arc: Krychevskyi designed the Great and Small State Coats of Arms of the Ukrainian People's Republic, seals, banknotes, and other state graphics in 1918; he also helped define a Ukrainian architectural modern vocabulary through the Poltava Zemstvo building and later museum and book-design work. ESU documents his move into emigration in 1944 and his postwar life outside Ukraine. The dossier therefore treats him as an indirectly displaced cultural-statehood figure, not as a documented prisoner. Claims that he was formally prosecuted, sentenced, or rehabilitated are not made here because no retrieved Tier 1/Tier 2 source supported them.
+- **What survived / what was destroyed:** ESU lists a large surviving corpus in museums in Kyiv, Lviv, Poltava, Odesa, Kharkiv, Lebedyn, Kaniv, New York, and Canada. Some architectural and exhibition projects were physically altered or lost, but a source-verified destruction dossier against his works was not found.
+
+## 3. Major works
+
+- `1902` — Ukrainian house for the 12th Archeological Congress in Kharkiv, exhibition architecture, an early public statement of vernacular form.
+- `1903-1908` — Poltava Provincial Zemstvo building, architecture, identified by ESU as the beginning of Ukrainian architectural style in modern public architecture.
+- `1904` — People's House in Lokhvytsia, architecture, listed by ESU.
+- `1909` — Mykhailo Hrushevskyi house, facade and vestibule design in Kyiv, listed by ESU.
+- `1911` — Design for Hrushevskyi's *Ілюстрована історія України*, book art, listed by ESU.
+- `1914` — "Розуміння українського стилю," article in *Сяйво*, primary theoretical text cited by ESU and a KNUBA conference PDF.
+- `1918` — Great and Small State Coats of Arms, seals, and two-hryvnia credit note of the UNR, state graphic design, listed by ESU.
+- `1923` — Ukrainian pavilion at the All-Union Agricultural Exhibition in Moscow, architecture, listed by ESU.
+- `1925` — village club-reading room for the Paris International Exhibition, architecture, listed by ESU.
+- `1928` — reconstruction of the Taras Shevchenko House-Museum in Kyiv, museum design, listed by ESU.
+- `1934-1937` — Taras Shevchenko memorial museum near the grave in Kaniv, architecture with P. Kostyrko, listed by ESU.
+- `1926-1939` — art direction and design for films including *Тарас Шевченко*, *Тарас Трясило*, *Звенигора*, *Назар Стодоля*, and *Сорочинський ярмарок*, listed by ESU.
+
+## 4. Primary-source quotes
+
+> "Стиль barocco перейшов до нас на початку 17-го ст."
+
+Source: Vasyl Krychevskyi, "Розуміння українського стилю" (1914), quoted in KNUBA collection *Архітектура та будівництво: відновлення України. Наука, технологія, практика* (2023), which cites *Василь Григорович Кричевський: хрестоматія*, vol. 1, 2016. This quote helps learners see that Krychevskyi treated style as historical transmission, not decorative folklore.
+
+> "Ми — піонери українського стилю"
+
+Source: inscription attributed to Krychevskyi on the Poltava Zemstvo foundation board, reported by Stepanecka hromada and Poltava cultural pages. It is a short primary inscription, not a later scholarly paraphrase; the exact archival plate citation was not found.
+
+## 5. Language register
+
+- **Register:** Art-historical, architectural-theoretical, institutional.
+- **CEFR readiness for full reading:** C1 for original essays; B2 for adapted museum captions and object descriptions.
+- **Lexicon notes:** `архітектурний модерн`, `орнамент`, `бароко`, `герб`, `печатка`, `земство`, `павільйон`, `експозиція`.
+- **Stylistic features:** Technical vocabulary, historical comparisons, and object-based argumentation. The register is useful for advanced learners studying culture, design, and state symbolism.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His exact birth date is inconsistent across ESU and IEU. The scope of his role as "founder" of Ukrainian architectural modernism can be taught as a major claim grounded in ESU, while leaving room for broader collective context.
+- **What gets simplified in popular memory:** He is often reduced to "the trident designer." ESU shows a much wider career: architecture, cinema, book design, pedagogy, museum work, painting, and ethnographic collecting.
+- **Where modern Russian disinformation attacks them:** Direct attack material retrieved for Krychevskyi: source not found. The vulnerable framing risk is Soviet-style erasure of UNR visual statehood and Ukrainian style as merely regional decoration.
+- **Polish / Jewish / other-perspective considerations:** His work moved through imperial Kharkiv, Kyiv, Paris, Prague, and Venezuelan exile networks. Lessons should avoid making Ukrainian style seem isolated from European modernism.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/unr-vybory.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Fedir Krychevskyi, Heorhii Narbut, Mykhailo Boichuk, Mykhailo Hrushevskyi, and Oleksandr Dovzhenko.
+- **Potential LIT additions surfaced by this research:**
+  - A B2/C1 visual-culture module on state symbols of the Ukrainian Revolution.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-krychevskyi`
+- **EN canonical (BGN/PCGN 2010):** Vasyl Krychevskyi
+- **UA canonical (with patronymic):** Кричевський Василь Григорович
+- **Aliases (track these for `aliases:` YAML field):** Vasyl H. Krychevsky, Vasyl Krychevsky, Wasyl Kryczewski
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Vasilii Krichevskii, Vasily Krichevsky (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Кричевський Василь.jpg` | public-domain claim on Commons page; verify file metadata before publication.
+- **Backup candidates:** ESU portrait on article page; IEU images of works and portrait, rights require checking.
+- **If no PD/CC portrait exists:** Use an image of the Poltava Zemstvo building with a clear CC license.
+- **Era-appropriate context image:** UNR trident design or two-hryvnia credit note, if public-domain metadata is confirmed.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія Сучасної України*, "Кричевський Василь Григорович" | https://esu.com.ua/article-1645 | accessed 2026-05-30
+- Internet Encyclopedia of Ukraine, "Krychevsky, Vasyl H." | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CR%5CKrychevskyVasylH.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Museum Fund of Ukraine, "Кричевський Василь Григорович" | https://museum.mcsc.gov.ua/authors/krichevskiy-vasil-grigorovich-6872 | accessed 2026-05-30
+- KNUBA, *Архітектура та будівництво: відновлення України. Наука, технологія, практика* | https://library.knuba.edu.ua/books/zbirniki/01/2023/66_2023.pdf | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Кричевський Василь Григорович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- *Василь Григорович Кричевський: хрестоматія*, vol. 1, Kharkiv: Savchuk, 2016, cited through KNUBA PDF.
+
+**Tier 5 (general web):**
+- Stepanecka hromada anniversary page for the Poltava Zemstvo inscription | https://stepanecka-gromada.gov.ua/news/1673437660/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Krychevskyi, "Розуміння українського стилю" (1914), excerpt cited through KNUBA/Savchuk chrestomathy.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing
+- [x] No unverified arrest or case file invented
+- [x] Birth-date discrepancy flagged
+- [x] UNR state-symbol work named directly
+- [x] Russian-imperial transliterations confined to naming metadata
+- [x] Existing paths verified

--- a/docs/research/bio/vasyl-lypkivskyi.md
+++ b/docs/research/bio/vasyl-lypkivskyi.md
@@ -1,0 +1,123 @@
+# Липківський Василь Костянтинович — Research Dossier
+
+**Slug:** `vasyl-lypkivskyi`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Липківський Василь Костянтинович; as church hierarch, митрополит Василь.
+- **Pseudonyms / aliases:** Vasyl Lypkivskyi, Metropolitan Vasyl, Василь (Липківський).
+- **Born:** 1864-03-19 | Попудня, modern Cherkasy region | Russian Empire. Source: UINP birth calendar page.
+- **Died:** 1937-11-27 | Kyiv | Ukrainian SSR | executed by NKVD after special-troika sentence. Source: UINP death calendar page.
+- **Family / education key facts:** UINP says he came from an old priestly family, studied at the Uman religious school, Kyiv Theological Seminary, and Kyiv Theological Academy, and received a candidate of theology degree. He was ordained in 1891 and later became a leader of Ukrainian church autocephaly.
+
+## 2. Oppression mechanism
+
+- **What happened:** Surveillance, dismissal, arrests, removal from office under state pressure, liquidation of the UAOC, final arrest, NKVD troika death sentence, execution.
+- **When:** UINP states he was dismissed from teaching in 1905 for liberal views and "Ukrainophilism" and kept under police surveillance. It records two Soviet arrests before the 1927 church council, a three-month imprisonment before that council, the 1927 forced removal from metropolitan service, UAOC liquidation in 1929, final arrest on 1937-10-22, sentence about a month later, and execution on 1937-11-27.
+- **By whom:** Russian imperial police surveillance; Soviet special services; NKVD special troika at the Kyiv administration.
+- **Document references:** UINP gives the special-troika body and charge phrase "anti-Soviet agitation on a large scale." Archival case number: source not found.
+- **Mechanism specifics:** UINP frames Lypkivskyi as creator and first metropolitan of the revived 1921 Ukrainian Autocephalous Orthodox Church. His oppression was tied to the church's Ukrainian-language liturgy, claim to autocephaly, and refusal to remain under Moscow church authority. In 1927, state pressure forced the council to remove him from metropolitan service. In 1929 the Soviet state labeled the UAOC part of an anti-Soviet underground and liquidated it. His final arrest in October 1937 ended with a special-troika death sentence and execution in Kyiv; UINP says he was probably buried in Bykivnia, while a memorial cross stands at Lukianivka.
+- **What survived / what was destroyed:** UINP says his *History of the Ukrainian Orthodox Church* survived because it was passed to the West. The institutional UAOC structure was broken by the Soviet liquidation campaign, but its memory was revived with the 1990 UAOC restoration and 1997 canonization.
+
+## 3. Major works
+
+- `1891` — priestly ordination and parish/school work, pastoral institution-building.
+- `1905` — public conflict with imperial church-school authorities, leading to dismissal and surveillance per UINP.
+- `1917` — cofounder-level work in the Brotherhood of the Resurrection of Christ and the autocephaly movement.
+- `1919` — first Ukrainian-language liturgy in Kyiv's Mykilska cathedral, pastoral-liturgical milestone per UINP.
+- `1919` — rector of Saint Sophia Cathedral, Kyiv, per UINP UNR figure page.
+- `1921` — first metropolitan of Kyiv and all Ukraine of the UAOC after the October 1921 council at Saint Sophia.
+- `1920s` — translations of theological and liturgical texts into Ukrainian, per UINP.
+- `1930` — memoir and analytical writing on the "conciliar liquidation" of the UAOC, quoted by UINP.
+- `1930s` — *Історія Української Православної Церкви*, manuscript preserved in the West per UINP.
+
+## 4. Primary-source quotes
+
+> "Не нову церкву для нашого народу ми утворюємо"
+
+Source: sermon quoted on UINP birth page. The line matters because it frames autocephaly as restoration of a native church, not invention of a sect.
+
+> "ми мусимо вискочити з-під московської церковної влади"
+
+Source: memoir quotation on UINP "Люди Свободи" page. This is a direct anti-imperial ecclesiastical formulation and should be taught with the 1686 Moscow-patriarchate context.
+
+## 5. Language register
+
+- **Register:** Sermonic, polemical, ecclesiastical-publicistic.
+- **CEFR readiness for full reading:** C1 for sermons and memoirs; B2 for adapted excerpts.
+- **Lexicon notes:** `автокефалія`, `митрополит`, `собор`, `богослужіння`, `московський патріярх`, `церковна влада`, `антирадянська агітація`.
+- **Stylistic features:** Biblical appeals, rhetorical questions, church-canonical vocabulary, and emotionally direct anti-imperial framing.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Canonical legitimacy and procedures of the 1921 UAOC consecrations are church-history debates. The dossier states only what UINP documents: the council proclaimed autocephaly and elected him metropolitan.
+- **What gets simplified in popular memory:** He is sometimes reduced to martyrdom. UINP shows decades of pedagogy, translation, parish organizing, and church governance before the 1937 execution.
+- **Where modern Russian disinformation attacks them:** Russian church-imperial framing often presents Ukrainian autocephaly as illegitimate separatism. The dossier grounds the claim in Ukrainian institutional sources and avoids accepting Moscow's categories.
+- **Polish / Jewish / other-perspective considerations:** Not central in retrieved sources. The key "other perspective" is intra-Orthodox canonical disagreement, which should be handled without erasing Soviet coercion.
+- **Pedagogical caution:** The UINP pages give enough specificity for a repression arc, including arrest date, troika body, charge phrase, and execution date. They do not give a case number, so lesson materials should not simulate an archival dossier citation.
+- **Source-balance note:** The retrieved source set is institutionally Ukrainian but not a critical edition of his papers. Treat sermon quotations as access excerpts until manuscript or printed-edition citations are added.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/tomos.yaml`
+  - `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Volodymyr Chekhivskyi, Agatangel Krymskyi, UAOC 1921 council, and Bykivnia memory.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 church-publicistic excerpt module from Lypkivskyi's sermons.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-lypkivskyi`
+- **EN canonical (BGN/PCGN 2010):** Vasyl Lypkivskyi
+- **UA canonical (with patronymic):** Липківський Василь Костянтинович
+- **Aliases (track these for `aliases:` YAML field):** Василь (Липківський), Metropolitan Vasyl, Vasyl Lypkivsky
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Vasilii Lipkovskii, Vasily Lipkovsky (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Vasyl_Lypkivskiy_01.jpg` | public-domain claim on Commons page; verify before publication.
+- **Backup candidates:** UINP article images from artefact.org.ua / lypkivskyivasyl.in.ua; rights require confirmation.
+- **If no PD/CC portrait exists:** Use a rights-cleared photograph of Saint Sophia Cathedral with captioned church-history context.
+- **Era-appropriate context image:** Bykivnia or Lukianivka memorial cross image, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Ukrainian Institute of National Memory, "1864 – народився Василь Липківський..." | https://uinp.gov.ua/istorychnyy-kalendar/berezen/19/1864-narodyvsya-vasyl-lypkivskyy-tvorec-i-pershyy-mytropolyt-uapc | accessed 2026-05-30
+- Ukrainian Institute of National Memory, "1937 - розстріляно митрополита УАПЦ Василя Липківського" | https://uinp.gov.ua/istorychnyy-kalendar/lystopad/27/1937-rozstrilyano-mytropolyta-uapc-vasylya-lypkivskogo | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UINP UNR figure page, "Липківський Василь" | https://unr.uinp.gov.ua/figures/lipkivskiy-vasil | accessed 2026-05-30
+- UINP, "Люди Свободи" | https://old.uinp.gov.ua/page/lyudi-svobodi | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Василь (Липківський)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Source not found in retrieved set beyond UINP institutional synthesis.
+
+**Tier 5 (general web):**
+- Patriarchia sermon access page for Lypkivskyi sermon tradition | https://patriarchia.org.ua/news/propovid-na-nedilyu-shostu-po-trijczi-mytropolyt-lypkivskyj-pro-proshhennya-grihiv/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Lypkivskyi sermon and memoir excerpts quoted by UINP. Archival case number: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Russian church-imperial framing rejected
+- [x] NKVD troika and charge specified
+- [x] No archival file number invented
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/vasyl-sedliar.md
+++ b/docs/research/bio/vasyl-sedliar.md
@@ -10,7 +10,7 @@
 ## 1. Verified facts
 
 - **Full name (UA, canonical):** Седляр Василь Теофанович.
-- **Pseudonyms / aliases:** Vasyl Sedliar, Vasyl Sedljar, Vasyl Sedliar; no stable pseudonym found in retrieved sources.
+- **Pseudonyms / aliases:** Vasyl Sedliar, Vasyl Sedljar; no stable pseudonym found in retrieved sources.
 - **Born:** IEU gives 1899-04-12 in Zhorzhivka, Poltava gubernia. Some modern memorial sources use Khrystivka/Shyshaky-area wording; the retrieved Tier 1 source used here is IEU.
 - **Died:** 1937-07-13 | Kyiv | Ukrainian SSR | executed after NKVD arrest and Soviet charges. Source: IEU "Sedliar, Vasyl."
 - **Family / education key facts:** IEU says he studied at the Kyiv Art School from 1915 to 1919 and at the Ukrainian State Academy of Arts from 1919 to 1922 under Mykhailo Boichuk. He later directed the Mezhyhiria Ceramics Tekhnikum and taught at the Kyiv State Art Institute.

--- a/docs/research/bio/vasyl-sedliar.md
+++ b/docs/research/bio/vasyl-sedliar.md
@@ -1,0 +1,124 @@
+# Седляр Василь Теофанович — Research Dossier
+
+**Slug:** `vasyl-sedliar`
+**Block:** I
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Седляр Василь Теофанович.
+- **Pseudonyms / aliases:** Vasyl Sedliar, Vasyl Sedljar, Vasyl Sedliar; no stable pseudonym found in retrieved sources.
+- **Born:** IEU gives 1899-04-12 in Zhorzhivka, Poltava gubernia. Some modern memorial sources use Khrystivka/Shyshaky-area wording; the retrieved Tier 1 source used here is IEU.
+- **Died:** 1937-07-13 | Kyiv | Ukrainian SSR | executed after NKVD arrest and Soviet charges. Source: IEU "Sedliar, Vasyl."
+- **Family / education key facts:** IEU says he studied at the Kyiv Art School from 1915 to 1919 and at the Ukrainian State Academy of Arts from 1919 to 1922 under Mykhailo Boichuk. He later directed the Mezhyhiria Ceramics Tekhnikum and taught at the Kyiv State Art Institute.
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest, accusation of terrorist activity, execution, destruction/banning of works.
+- **When:** IEU gives arrest on 1936-11-26 and execution on 1937-07-13. The same entry says he was executed with Mykhailo Boichuk and Ivan Padalka.
+- **By whom:** NKVD; the precise court body for Sedliar in retrieved sources is not as fully documented as Padalka's. Court file number: source not found.
+- **Document references:** IEU gives the arrest date, charge category, execution, destruction of works, and 1958 rehabilitation. A stable archival file ID for Sedliar's own case was not retrieved.
+- **Mechanism specifics:** IEU documents a clear Stalinist terror arc: the pressure on Sedliar increased in the mid-1930s, including attacks on the "Europe" series and Boichukist art as formalist or ideologically suspect. The 1931 *Kobzar* with seventy-five Sedliar illustrations was published before the terror peak; after his execution the edition was banned and destroyed. IEU states that most of his creative works, including thousands of paintings, were destroyed by the NKVD. The mechanism therefore combined physical murder with cultural erasure of a visual school.
+- **What survived / what was destroyed:** Surviving works include portraits, *In a Liknep School*, *An Execution in Mezhyhiria*, and some *Kobzar* illustrations. IEU explicitly records destroyed frescoes, destroyed majority of works, and the destroyed/banned *Kobzar* edition.
+
+## 3. Major works
+
+- `1919` — Lutsk barracks murals in Kyiv, collective mural project under Boichuk, destroyed in 1922 per IEU.
+- `1924` — Kyiv Institute of Plastic Arts auditorium murals, collective frescoes, destroyed in 1934 per IEU.
+- `1924` — Mezhyhiria Ceramics Tekhnikum murals, collective mural work, listed by IEU.
+- `1924-1925` — *In a Liknep School*, painting, listed by IEU.
+- `1926` — *Portrait of Oksana Pavlenko*, painting, pictured/listed by IEU.
+- `1926-1927` — "Europe" series after travel with Boichuk, criticized by Communist Party critics per IEU.
+- `1927` — *An Execution in Mezhyhiria*, painting, listed by IEU.
+- `1931` — *Kobzar* with 75 illustrations, book art, later banned and destroyed per IEU.
+- `1931` — *Beside the Tractor*, painting, pictured by IEU.
+- `1933-1935` — Chervonozavodskyi Ukrainian Drama Theater frescoes, collective mural work, later destroyed per IEU.
+- `1934` — "Занепад сучасного буржуазного мистецтва на Заході," art-critical essay, cited by Serhii Bilokin.
+
+## 4. Primary-source quotes
+
+> "Ця виучка ... ніколи не перешкоджала виявлятися їхнім особливостям"
+
+Source: Vasyl Sedliar as quoted on UA View's Boichuk project page, discussing the Boichuk workshop method. This quote is useful because it frames Boichukism as disciplined formation rather than mechanical copying.
+
+> "почуття релігійне, найплодотворніше джерело їх натхнення"
+
+Source: Sedliar, "Занепад сучасного буржуазного мистецтва на Заході," *Образотворче мистецтво* (1934), quoted by Serhii Bilokin with page references. It matters pedagogically because Sedliar's language shows how a Soviet-era art article could still preserve premodern sacred-art vocabulary that later became dangerous.
+
+## 5. Language register
+
+- **Register:** Art-critical, pedagogical, modernist-theoretical.
+- **CEFR readiness for full reading:** C1 for original criticism; B2 for selected captions and short excerpts.
+- **Lexicon notes:** `фреска`, `темпера`, `Кобзар`, `бойчукізм`, `монументальне мистецтво`, `лікнеп`, `формалізм`, `терористична діяльність` as Soviet accusation language.
+- **Stylistic features:** Dense art-historical comparisons, workshop terminology, and politically charged Soviet-era labels that need careful framing.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The exact location wording of his birthplace, the size of the destroyed corpus, and how to describe Boichukism as school, method, or style.
+- **What gets simplified in popular memory:** He is often reduced to "the other Boichukist executed with Boichuk." IEU shows him as director, teacher, critic, illustrator, and a major *Kobzar* artist.
+- **Where modern Russian disinformation attacks them:** Soviet accusation language and later anti-formalist rhetoric framed Boichukists as dangerous nationalist formalists. The dossier treats that language as evidence of repression.
+- **Polish / Jewish / other-perspective considerations:** The "Europe" travel series and Bauhaus/Western factory visits show a transnational art-education context. Lessons should avoid implying a closed Ukrainian-only stylistic genealogy.
+- **Pedagogical caution:** The retrieved sources are strong for arrest, execution, destroyed works, and rehabilitation, but weak for the exact legal file. Curriculum prose should therefore say "charged with terrorist activity" per IEU and avoid inventing a courtroom narrative until an archival citation is retrieved.
+- **Source-balance note:** IEU is the grounding source for the repression facts; UA View and Bilokin are used for workshop voice and interpretive texture, not to override IEU chronology.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/rozstriliane-kontekst.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-rozstriliane.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Mykhailo Boichuk, Ivan Padalka, Sofiia Nalepynska-Boichuk, Oksana Pavlenko, and Taras Shevchenko as illustrated author.
+- **Potential LIT additions surfaced by this research:**
+  - A visual-reading lesson on the 1931 illustrated *Kobzar* and Soviet image censorship.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-sedliar`
+- **EN canonical (BGN/PCGN 2010):** Vasyl Sedliar
+- **UA canonical (with patronymic):** Седляр Василь Теофанович
+- **Aliases (track these for `aliases:` YAML field):** Vasyl Sedliar, Vasyl Sedljar
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Vasilii Sedliar, Vasily Sedlyar (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `File:Юродивий Василь Седляр.jpg` | Commons page lists CC BY-SA 4.0; verify before publication.
+- **Backup candidates:** IEU images of Sedliar portraits and works; rights require confirmation.
+- **If no PD/CC portrait exists:** Use a rights-cleared reproduction of the *Kobzar* cover or a surviving painting.
+- **Era-appropriate context image:** Destroyed Chervonozavodskyi theater fresco documentation, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine, "Sedliar, Vasyl" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CE%5CSedliarVasyl.htm | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UA View / Museum of Contemporary Art NGO, Boichuk project page | https://uaview.ui.org.ua/ua/artist/Boichuk-Mykhaylo | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Седляр Василь Теофанович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Serhii Bilokin, "У Парижі" | https://www.s-bilokin.name/Culture/Bojchuk/Paris.html | accessed 2026-05-30
+
+**Tier 5 (general web):**
+- Ukrainian memorial article on Sedliar's anniversary | https://ukrpohliad.org/national-memory/do-127-richchya-mytczya-z-kogorty-rozstrilyanogo-vidrodzhennya-vasylya-sedlyara.html | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Sedliar excerpts from *Образотворче мистецтво* (1934), quoted with page citations by Serhii Bilokin.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet accusation language labeled
+- [x] No archival case number invented
+- [x] Destroyed works documented through IEU
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/vasyl-velychkovskyi.md
+++ b/docs/research/bio/vasyl-velychkovskyi.md
@@ -1,0 +1,122 @@
+# Величковський Василь Володимирович — Research Dossier
+
+**Slug:** `vasyl-velychkovskyi`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Величковський Василь Володимирович; church form Василь (Величковський), ЧНІ.
+- **Pseudonyms / aliases:** Vasyl Velychkovskyi, Vasyl Velychkovskyj, Basil Velychkovsky, Bishop Vasyl.
+- **Born:** 1903-06-01 | Stanislaviv, now Ivano-Frankivsk | Austria-Hungary. Sources: UGCC bishop profile and UGCC birth page.
+- **Died:** 1973-06-30 | Winnipeg, Canada | after Soviet imprisonment and deportation. Sources: UGCC bishop profile; Vatican beatification list.
+- **Family / education key facts:** UGCC says he was born into a priestly family, studied in Chortkiv-area schools and the Basilian Institute of Saint Josaphat, completed gymnasium in Horodenka, and entered the Greek Catholic seminary in Lviv in 1920. Vatican confirms seminary entry, Redemptorist vows in 1925, and priestly ordination on 1925-10-09.
+
+## 2. Oppression mechanism
+
+- **What happened:** NKVD arrest, pressure to accept Orthodoxy, death sentence commuted to ten years in Vorkuta camps, underground episcopal work, second arrest, strict-regime imprisonment, deportation from the USSR.
+- **When:** UGCC says NKVD arrested him on 1945-08-07 in the monastery; Vatican says he was arrested in 1945 and taken to Kyiv. UGCC gives second arrest in January 1969 after searches on 1968-10-18; sentence to three years; release/deportation on 1972-01-27.
+- **By whom:** NKVD for the first arrest; later Soviet security and court system for the second prosecution.
+- **Document references:** UGCC states the first sentence was death for "active anti-Soviet propaganda," later commuted to ten years in Vorkuta. For the second case, UGCC says the trial charged him with "anti-Soviet propaganda" and listening to Vatican religious broadcasts. Stable archival case number: source not found.
+- **Mechanism specifics:** The first case sought to break Greek Catholic resistance by pressuring clergy to accept Orthodoxy. Velychkovskyi refused, was sentenced to death, and then sent to camps. After release in 1955 he returned to Lviv and served the underground UGCC. In 1963, Yosyf Slipyi consecrated him bishop in a Moscow apartment and appointed him a locum tenens for the Church in Ukraine. The second prosecution targeted his underground church leadership and his religious booklet on the Mother of Perpetual Help; UGCC preserves his own explanation that the authorities punished his work as priest and bishop.
+- **What survived / what was destroyed:** His underground ordinations and episcopal continuity survived through the catacomb UGCC, including Bishop Volodymyr Sterniuk. The physical toll of prison survived in trauma and illness; UGCC biography says he died in Canada within a year of deportation.
+
+## 3. Major works
+
+- `1925` — Redemptorist vows and priestly ordination, beginning of missionary work.
+- `1942` — hegumen of the Ternopil monastery, per Vatican.
+- `1945-1955` — Vorkuta camp witness after commuted death sentence, per UGCC/Vatican.
+- `1955-1969` — underground pastoral work in Lviv, private liturgies, seminary formation, and spiritual direction, per UGCC.
+- `1963` — episcopal consecration by Yosyf Slipyi in Moscow, per UGCC.
+- `1963-1969` — locum tenens leadership of the clandestine UGCC in Ukraine, per UGCC/Vatican.
+- `1960s` — booklet *Історія чудотворної ікони Матері Божої Неустанної Помочі*, named by UGCC as the text used against him in the second trial.
+- `1964` — episcopal consecration of Volodymyr Sterniuk, per UGCC.
+- `1972` — deportation from the USSR after second prison term, per UGCC.
+- `2001` — beatification in the group of Ukrainian Greek Catholic martyrs, per Vatican.
+
+## 4. Primary-source quotes
+
+> "Несподівано скоро проминуло мені моїх десять літ кари"
+
+Source: Velychkovskyi memoir quotation on the UGCC bishop profile. It gives a direct prison-return voice without romanticizing the camp term.
+
+> "Я завжди був щасливий, повний радости"
+
+Source: UGCC vocation article quoting his recollection of religious calling. It gives learners pastoral-memoir language and shows how he narrated vocation under later persecution.
+
+## 5. Language register
+
+- **Register:** Pastoral memoir, underground ecclesiastical, devotional.
+- **CEFR readiness for full reading:** B2 for short memoir quotes; C1 for full theological or hagiographic prose.
+- **Lexicon notes:** `редемпторист`, `Воркута`, `місцеблюститель`, `катакомбна Церква`, `антисовєтська пропаганда`, `депортація`.
+- **Stylistic features:** Personal testimony, spiritual vocabulary, and Soviet legal accusation language that must be marked as accusation.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The detailed legal record of both cases needs archival retrieval; the retrieved UGCC/Vatican sources provide chronology but not case numbers.
+- **What gets simplified in popular memory:** He is often remembered only as a martyr in Canada/Winnipeg shrine contexts. UGCC sources show a much longer underground leadership role in Lviv.
+- **Where modern Russian disinformation attacks them:** Soviet framing criminalized religious texts and contact with Vatican broadcasts as anti-Soviet propaganda. This dossier quotes that framing only as prosecution language.
+- **Polish / Jewish / other-perspective considerations:** Not central in retrieved sources. The broader issue is Catholic-Orthodox coercion under Soviet occupation; do not recast it as voluntary "reunion."
+- **Pedagogical caution:** The second prosecution is especially useful for showing that repression did not end with Stalin's death. The UGCC source gives a 1969 trial and 1972 deportation, so avoid compressing his biography into only the 1945 arrest.
+
+## 7. Cross-track links
+
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Yosyf Slipyi, Volodymyr Sterniuk, Mykola Charnetskyi, and underground seminary networks.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 testimony excerpt sequence from prison memoirs if a critical edition is retrieved.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-velychkovskyi`
+- **EN canonical (BGN/PCGN 2010):** Vasyl Velychkovskyi
+- **UA canonical (with patronymic):** Величковський Василь Володимирович
+- **Aliases (track these for `aliases:` YAML field):** Василь (Величковський), Vasyl Velychkovskyj, Basil Velychkovsky
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Vasilii Velichkovskii, Vasily Velichkovsky (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** UGCC bishop profile image; rights not established in retrieved source.
+- **Backup candidates:** Wikimedia Commons image of Vasyl Velychkovskyi and Mykola Charnetskyi church icon/photo; file-level license source not verified.
+- **If no PD/CC portrait exists:** Use a rights-cleared photo of the Winnipeg shrine or a memorial plaque.
+- **Era-appropriate context image:** Lviv underground apartment/museum image if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/saints/20010626_beatif_ucraina_en.html | accessed 2026-05-30
+- Vatican companion biographies page for Ukrainian Greek Catholic servants of God | https://www.vatican.va/news_services/liturgy/documents/ns_lit_doc_20010627_carneckyj_en.html | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "Владика Василь Величковський" | https://synod.ugcc.ua/data/vladyka-vasyl-velychkovskyy-11715/ | accessed 2026-05-30
+- UGCC Synod, "1 червня 1903 року народився..." | https://synod.ugcc.ua/data/1-chervnya-1903-roku-narodyvsya-svyashchmch-vasyliy-velychkovskyy-9231/ | accessed 2026-05-30
+- UGCC Synod, Marian/vocation articles on Velychkovskyi | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Василь (Величковський)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Source not found in retrieved set beyond institutional UGCC/Vatican synthesis.
+
+**Tier 5 (general web):**
+- Wikimedia Commons image lead; license not verified enough for final publication | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Velychkovskyi memoir/recollection excerpts quoted by UGCC. Archival case numbers for 1945 and 1969 prosecutions: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet accusation language labeled
+- [x] First and second prosecutions separated
+- [x] No case file invented
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/yosafat-kotsylovskyi.md
+++ b/docs/research/bio/yosafat-kotsylovskyi.md
@@ -1,0 +1,125 @@
+# Коциловський Йосафат Йосиф — Research Dossier
+
+**Slug:** `yosafat-kotsylovskyi`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Коциловський Йосафат Йосиф; born Йосиф Коциловський, monastic name Йосафат.
+- **Pseudonyms / aliases:** Josaphat Kotsylovsky, Josaphat Kocylovskyj, Йосафат (Коциловський).
+- **Born:** 1876-03-03 | Пакошівка near Sanok, Lemko region | Austria-Hungary. Sources: UGCC bishop profile and Vatican biography list.
+- **Died:** 1947-11-17 | Soviet camp hospital "Chapaev" near Kyiv / Kyiv prison in Vatican wording | Ukrainian SSR / USSR. UGCC gives the camp hospital detail; Vatican says Kyiv prison. This dossier flags the place wording difference.
+- **Family / education key facts:** UGCC says his father Petro was active in Galician public life and his mother Kateryna Kosar-Kotsylovska came from a Greek Catholic priestly family. UGCC records legal studies in Lviv, officer-reserve training in Vienna, and theological studies in Rome, where he received doctorates in philosophy and theology.
+
+## 2. Oppression mechanism
+
+- **What happened:** Pressure by Soviet and Polish communist authorities, arrests, transfer to NKVD, forced removal east, imprisonment, death in Soviet custody.
+- **When:** UGCC says Polish police arrested him on 1945-09-21; he was held in Rzeszow until January 1946; on 1946-01-16 Polish security handed him and several priests to the NKVD in Rzeszow. UGCC also notes a renewed arrest/removal in 1946 after he refused to leave his see voluntarily. Vatican summarizes: first arrest in September 1945, release, second arrest in 1946, handover again to the Soviet Union, death on 1947-11-17.
+- **By whom:** Polish security/police under communist authority; NKVD; Soviet prison/camp system.
+- **Document references:** UGCC gives dates and institutional sequence but no case number. Courtroom docket, Soviet camp file, or NKVD case number: source not found.
+- **Mechanism specifics:** UGCC describes Kotsylovskyi as defending priests' duty to remain with their parishes during forced population transfers and as refusing to accept removal from his episcopal see except by Rome. The arrest sequence shows cross-border coercion: Polish authorities detained him, transferred him to the NKVD, and Soviet authorities tried to force church subordination. UGCC reports NKVD pressure to recognize the Moscow Patriarch's authority. His handwritten loyalty statement anticipated arrest and exile, asking that his fidelity be communicated to the Pope.
+- **What survived / what was destroyed:** The Przemysl diocesan institutional network was violently disrupted; his seminary and press work remain documented in UGCC history. His relics and memory survived through UGCC veneration and the 2001 beatification.
+
+## 3. Major works
+
+- `1907` — priestly ordination after Roman theological studies, per UGCC/Vatican.
+- `1911` — entry into Basilian novitiate; monastic name Йосафат, per UGCC.
+- `1914-1916` — organization/leadership of an emigration seminary in Kromeriz, per UGCC.
+- `1917` — episcopal consecration and enthronement in Przemysl, per UGCC/Vatican.
+- `1917` — first pastoral letter invoking Saint Josaphat, quoted by UGCC.
+- `1918` — participation in the Ukrainian National Council of the Western Ukrainian People's Republic, per UGCC.
+- `1921` — blessing/opening of the Greek Catholic seminary in Przemysl, per UGCC.
+- `1928` — diocesan periodical *Бескид*, later *Український Бескид*, under diocesan press activity per UGCC.
+- `1931` — Diocesan Institute of Catholic Action, per UGCC.
+- `1918-1937` — canonical visitations across parishes, per UGCC.
+- `1945-1946` — loyalty statement before expected arrest, quoted by UGCC.
+
+## 4. Primary-source quotes
+
+> "Рим мене призначив тут єпископом"
+
+Source: Kotsylovskyi's reply to police, quoted by UGCC bishop profile. It is pedagogically useful because it condenses ecclesial authority, coercion, and conscience into one sentence.
+
+> "складаю у його стіп вияв моєї вірності"
+
+Source: handwritten loyalty statement quoted by UGCC bishop profile; the UGCC page has an internal papal-name typo in one place, while the death-page context points to Pius XII. This quote should be taught with the source discrepancy note.
+
+## 5. Language register
+
+- **Register:** Ecclesiastical, pastoral, institutional, diplomatic.
+- **CEFR readiness for full reading:** C1 for pastoral letters and institutional biography; B2 for selected quotes.
+- **Lexicon notes:** `єпархія`, `василіянин`, `хіротонія`, `Апостольський престол`, `канонічні візитації`, `депортація`, `НКВД`.
+- **Stylistic features:** Formal ecclesiastical syntax, loyalty formulas, and borderland institutional vocabulary.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Exact death-place wording differs: UGCC specifies the Chapaev camp hospital near Kyiv; Vatican gives Kyiv prison. The dossier preserves both.
+- **What gets simplified in popular memory:** He is sometimes remembered only as a martyr. UGCC sources show educator, seminary builder, diocesan press organizer, and defender of parish continuity.
+- **Where modern Russian disinformation attacks them:** Soviet coercion sought to force recognition of Moscow church authority; do not recast that pressure as free ecclesial transfer.
+- **Polish / Jewish / other-perspective considerations:** UGCC notes he sheltered Jews in episcopal/cathedral spaces and refused German pressure to issue collaborationist messaging. Polish-Ukrainian conflict and postwar population transfer are part of the context; lessons should not erase Polish security's role in the arrest sequence.
+- **Pedagogical caution:** The arrest chain crosses Polish and Soviet institutions. To avoid a flattened "Soviets arrested him" summary, curriculum prose should keep the 1945 Polish police arrest, the Rzeszow detention, and the 1946 NKVD transfer distinct.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/tomos.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Hryhorii Lakota, Andrey Sheptytskyi, ZUNR church history, Przemysl seminary, and postwar deportations.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 reading on pastoral letters in borderland crisis if a full text is retrieved.
+
+## 8. Naming-canonical
+
+- **Slug:** `yosafat-kotsylovskyi`
+- **EN canonical (BGN/PCGN 2010):** Yosafat Kotsylovskyi
+- **UA canonical (with patronymic):** Коциловський Йосафат Йосиф
+- **Aliases (track these for `aliases:` YAML field):** Йосиф Коциловський, Йосафат (Коциловський), Josaphat Kotsylovsky, Josaphat Kocylovskyj
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Iosafat Kotsilovskii, Iosif Kotsilovskii (FORBIDDEN except as archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** UGCC bishop profile portrait; rights not established in retrieved source.
+- **Backup candidates:** Wikimedia Commons, `File:The_relics_of_the_blessed_of_Josaphat_Kotsylovsky.JPG`; file-level license not verified in retrieved page.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of the Przemysl cathedral/seminary context.
+- **Era-appropriate context image:** Diocesan press masthead *Український Бескид*, if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, Ukrainian beatification companion biographies page | https://www.vatican.va/news_services/liturgy/documents/ns_lit_doc_20010627_carneckyj_en.html | accessed 2026-05-30
+- Vatican, "Beatifications during the Pastoral Visit..." | https://www.vatican.va/news_services/liturgy/saints/20010626_beatif_ucraina_en.html | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "Владика Йосафат Коциловський" | https://synod.ugcc.ua/data/vladyka-yosafat-kotsylovskyy-11192/ | accessed 2026-05-30
+- UGCC Synod, birth page | https://synod.ugcc.ua/data/u-tsey-den-144-roky-tomu-narodyvsya-epyskop-yosafat-kotsylovskyy-2540/ | accessed 2026-05-30
+- UGCC Synod, death anniversary page | https://synod.ugcc.ua/data/75-rokiv-tomu-vidiyshov-do-vichnosti-blazhennyy-svyashchennomuchenyk-yosafat-kotsylovskyy-10672/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Йосафат (Коциловський)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Source not found in retrieved set beyond UGCC/Vatican institutional synthesis.
+
+**Tier 5 (general web):**
+- Wikimedia Commons image lead; license not verified enough for final publication | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Kotsylovskyi pastoral-letter and handwritten-statement excerpts quoted by UGCC. Trial/camp file number: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Polish security and NKVD sequence named
+- [x] Death-place discrepancy flagged
+- [x] No case number invented
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata


### PR DESCRIPTION
## Summary

Adds 8 Phase-1 Bio research dossiers for Epic #2309, batch 6 NON-Block-G. Nil Khasevych was intentionally excluded after the audit mechanism table marked him `(G)`, despite the canonical slug appendix row being Block I.

## Figures + blocks + Tier-1/2 sources

- `vasyl-krychevskyi` — Block I — T1: ESU "Кричевський Василь Григорович"; IEU "Krychevsky, Vasyl H.". T2: Museum Fund of Ukraine; KNUBA 2023 PDF citing the Savchuk chrestomathy.
- `ivan-padalka` — Block I — T1: IEU "Padalka, Ivan"; *Реабілітовані історією. Харківська область*, book 2. T2: Kherson Regional Library Museum of the Book; National Library for Children.
- `vasyl-sedliar` — Block I — T1: IEU "Sedliar, Vasyl". T2: UA View / Boichuk project; source gaps are declared where a case-file number was not retrieved.
- `hryhorii-khomyshyn` — Block J — T1/T2: Vatican Ukrainian martyr biography page; UGCC Synod bishop profile; UGCC archival article on case no. 35826.
- `vasyl-lypkivskyi` — Block J — T1/T2: UINP birth and execution calendar pages; UINP UNR figure page; UINP "Люди Свободи".
- `mykola-charnetskyi` — Block J — T1: Vatican biography / beatification pages. T2: UGCC Synod bishop profile and suffering/beatification article.
- `vasyl-velychkovskyi` — Block J — T1: Vatican beatification pages. T2: UGCC Synod bishop profile, birth page, and UGCC Marian/vocation articles.
- `yosafat-kotsylovskyi` — Block J — T1: Vatican biography / beatification pages. T2: UGCC Synod bishop, birth, and death pages.

## Validation

Raw validator final line:

```text
No fabricated Existing cross-track plan paths found.
```

Other checks:

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
PASS: X-Agent: codex/bio-batch6-nonG-2026-05-30
```

## Source-gap notes

- Krychevskyi has strong ESU/IEU grounding for life/work/emigration, but no retrieved formal persecution case file; the dossier labels the oppression mechanism as indirect displacement and says `source not found` for arrest/case data.
- Several religious-martyr dossiers have institutional Vatican/UGCC/UINP sourcing but no retrieved Soviet archival case number; those gaps are declared in the dossiers instead of invented.