### PR TITLE
feat(bio): 8 Phase-1 research dossiers — batch 7 (#2309)

### DIFF
--- a/docs/research/bio/ivan-drach.md
+++ b/docs/research/bio/ivan-drach.md
@@ -1,0 +1,124 @@
+# Драч Іван Федорович — Research Dossier
+
+**Slug:** `ivan-drach`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Драч Іван Федорович.
+- **Pseudonyms / aliases:** Ivan Drach.
+- **Born:** 1936-10-17 | Теліжинці, Kyiv region, Ukrainian SSR. ESU and Ukrainian Wikipedia via `mcp__sources.query_wikipedia` agree. [S1] [S4]
+- **Died:** 2018-06-19 | Kyiv, Ukraine; buried in his native village according to ESU. [S1]
+- **Family / education key facts:** Worked as teacher and Komsomol activist after school, served in the army, studied philology at Kyiv University, worked at *Literaturna hazeta*, and completed the Higher Scriptwriting Courses in Moscow according to retrieved textbook source. [S5]
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet censorship, party criticism, pressure after contact with dissidents, and film suppression.
+- **When:** Especially 1965-1966 after the *Тіні забутих предків* protest atmosphere and the suppression/criticism of *Криниця для спраглих*.
+- **By whom:** Soviet party/censorship bodies, film-studio and Communist Party cultural administration.
+- **Document references:** Retrieved EKMAIR item identifies the Dovzhenko Studio artistic council transcript for *Криниця для спраглих* on 1966-01-29. Ukrainian Wikipedia/MCP and textbook retrieval note Central Committee criticism in 1966 and Drach's forced public repentance after dissident contacts. [S2] [S5]
+- **Mechanism specifics:** Drach was not retrieved as a prisoner. His mechanism is pressure and constraint inside official literary/cinematic institutions. The film *Криниця для спраглих*, with Drach as screenwriter and Yurii Illienko as director, was filmed in 1965, sharply criticized, and withheld from viewers until the late Soviet period. EKMAIR's cataloged transcript grounds the film-studio discussion; retrieved textbook and Wikipedia context ground the broader 1966 pressure on Drach. [S2] [S5]
+
+The dossier should not turn Drach into a clean dissident hero or a simple collaborator. The sourced frame is harder: he had early dissident contacts, was pressured into public repentance, remained a major poet and screenwriter, and later became a public figure in the national-democratic movement. [S1] [S5]
+
+- **What survived / what was destroyed:** Poetry, screenplays, and later public record survived. Some film work was delayed or shelved; the pressure damaged the public space for Ukrainian poetic cinema.
+
+## 3. Major works
+
+- `1962` — *Соняшник*, debut collection. [S1]
+- `1965` — *Протуберанці серця*, poetry. [S1]
+- `1965` — *Криниця для спраглих*, screenplay; filmed by Yurii Illienko and suppressed. [S2]
+- `1966` — *Балади буднів*, poetry. [S1]
+- `1974` — *Корінь і крона*, Shevchenko Prize collection. [S1]
+- `1976` — *Київське небо*, poetry. [S1]
+- `1981` — *Шабля і хустина*, poetry. [S1]
+- `1983` — *Духовний меч*, literary-critical essays. [S1]
+- `1985` — *Теліжинці*, poetry. [S1]
+- `1988` — *Храм сонця*, poetry. [S1]
+- `1988` — *Чорнобильська мадонна*, long poem; include after edition verification in Phase 2.
+
+## 4. Primary-source quotes
+
+> "В соняшника були руки і ноги"
+
+Source: line from Drach cited in `mcp__sources.search_literary` through Rusanivskyi's history of literary language, with work context tied to the "соняшник" image. Useful for showing animation/metaphor to B1-B2 learners. [S6]
+
+> "Кому - жом у господу"
+
+Source: Drach line cited in the literary encyclopedia chunk retrieved by `mcp__sources.search_literary` under dissonance. Use as a short stylistic example only; consult a full edition before building learner exercises. [S6]
+
+## 5. Language register
+
+- **Register:** High modernist metaphor, publicistic essay, film-poetic image, later civic rhetoric.
+- **CEFR readiness for full reading:** B2 for selected poems; C1-C2 for *Ніж у сонці* and *Чорнобильська мадонна*.
+- **Lexicon notes:** scientific metaphor (`протуберанець`), cinematic terms, biblical/civic vocabulary, neologistic compounds.
+- **Stylistic features:** Extended metaphor, syncretic imagery, ballad form, publicistic address, and sudden register shifts.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Drach's place between Sixtier experimentation, Soviet accommodation, and later national-democratic politics.
+- **What gets simplified in popular memory:** He is often reduced either to the sunflower poem or to Rukh politics. The source pack shows poetry, cinema, criticism, and public life.
+- **Where modern Russian disinformation attacks them:** Ukrainian poetic cinema is often framed as "regional Soviet color." The censorship record shows that Ukrainian folk-modernist form was politically sensitive, not merely decorative.
+- **Polish / Jewish / other-perspective considerations:** Retrieved sources did not surface a specific Polish/Jewish controversy for Drach. Source not found.
+- **Pedagogical caution:** Do not omit the forced-repentance/pressure episode, but also do not flatten the whole career into that episode.
+- **Source-balance note:** ESU is strong for works and awards but less direct on the coercive 1966 mechanism. The textbook retrieval gives the pedagogical frame for Sixtier pressure, while the eKMAIR record is important because it names a real, inspectable transcript connected to *Криниця для спраглих*. A Phase 2 module should quote from the transcript itself only after reading the full item.
+- **Risk note:** Drach's later prominence in official culture can tempt a simplified "successful Soviet poet" reading. The sourced record is more useful: innovation, pressure, compromise, return to public national politics, and an unusually broad genre range.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/drach-knife-sun.yaml`
+  - `curriculum/l2-uk-en/plans/lit/drach-ballads.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Serhii Paradzhanov, Yurii Illienko, Ivan Svitlychnyi, Viacheslav Chornovil, Sixtiers, and Ukrainian poetic cinema.
+- **Potential LIT additions surfaced by this research:**
+  - C1 module around *Криниця для спраглих* using the EKMAIR transcript and film excerpts, if rights/permissions are cleared.
+  - A contrast activity can pair a short early image from *Соняшник* with a later civic/Chornobyl passage, showing why Drach cannot be taught as a single-register poet.
+  - A media-literacy task can compare a poem, a screenplay, and a party-censorship discussion, so students see genre pressure rather than treating "Soviet literature" as one stable register or neutral category.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-drach`
+- **EN canonical (BGN/PCGN 2010):** Ivan Drach
+- **UA canonical (with patronymic):** Драч Іван Федорович
+- **Aliases (track these for `aliases:` YAML field):** Ivan Fedorovych Drach.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ivan Fedorovich Drach as Russian-style patronymic rendering (FORBIDDEN except source metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait candidates; verify individual license.
+- **Backup candidates:** ESU image; rights not established.
+- **If no PD/CC portrait exists:** Use a rights-cleared image from a public literary event or memorial.
+- **Era-appropriate context image:** Rights-cleared still/poster from *Криниця для спраглих* or *Тіні забутих предків* context.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Драч Іван Федорович" | https://esu.com.ua/article-21707 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- eKMAIR/NaUKMA repository, "\"Криниця для спраглих\". Засідання художньої ради Кіностудії імені О. Довженка 29 січня 1966 року. Стенограма" | https://ekmair.ukma.edu.ua/items/3fd967b0-ff6f-4ee6-a4bf-cf9848a3f8e7 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Драч Іван Федорович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_text`, Grade 11 Ukrainian literature textbook retrieval for Drach biography and 1966 pressure context | accessed 2026-05-30
+- `mcp__sources.search_literary`, literary encyclopedia/Rusanivskyi chunks for Drach style and quotations | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Dovzhenko Studio transcript record via eKMAIR; short poem excerpts via literary corpus. Party file/case number: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Pressure/censorship distinguished from imprisonment
+- [x] Existing paths verified
+- [x] Soviet film suppression named
+- [x] No fabricated party file ID
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/klymentii-sheptytskyi.md
+++ b/docs/research/bio/klymentii-sheptytskyi.md
@@ -1,0 +1,121 @@
+# Шептицький Климентій (Казимир Марія) — Research Dossier
+
+**Slug:** `klymentii-sheptytskyi`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Климентій Шептицький; secular name Казимир Марія Шептицький. UGCC Synod gives the baptismal name Марія Казимир and the monastic name Климентій. [S1]
+- **Pseudonyms / aliases:** Казимир Шептицький, отець Климентій, архімандрит Климентій, Klymentiy Sheptytsky, Clement Sheptytsky, Kliment Sheptytskyi.
+- **Born:** 1869-11-17 | Прилбичі, Яворівщина, Galicia, Austria-Hungary. UGCC Synod and Ukrainian Wikipedia via `mcp__sources.query_wikipedia` agree on the date and village. [S1] [S5]
+- **Died:** 1951-05-01 | Vladimir Central Prison, Russian SFSR, USSR. UGCC Synod gives 1 May 1951 and says burial occurred at night near the prison wall; Ukrainian Wikipedia gives the same death frame. [S1] [S5]
+- **Family / education key facts:** He was the younger brother of Metropolitan Andrey Sheptytskyi, studied law in Krakow, Munich, and Paris, earned a doctorate in law, served in Austrian political life, and entered the Studite monastic path in 1911-1913. [S1]
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet arrest, MGB interrogation, criminal conviction, imprisonment, and death in prison.
+- **When:** Arrested 1947-06-05 in Univ Lavra; sentenced in March 1948 to eight years; died 1951-05-01. [S1]
+- **By whom:** Soviet MGB/UMGB investigators and prison system.
+- **Document references:** A UGCC Synod article identifies the criminal case as Central Sectoral Archive of the SBU case `74978 ФП`; this dossier cites that retrieved reference and does not invent additional archive numbers. [S3]
+- **Mechanism specifics:** After the Soviet arrest of the UGCC bishops in 1945, Sheptytskyi effectively held together part of the remaining church structure, met clergy, urged them not to accept coerced transfer into Russian Orthodoxy, and sent reports on persecution to Vatican contacts. UGCC Synod reports that intercepted letters to Cardinal Tisserant and Father Korolevsky became evidence against him. [S1]
+
+The MGB charge was political even though the retrieved UGCC source records his answer that he was a monk and did not conduct political activity. He was moved from Lviv to Kyiv, then to Moscow and Vladimir. The prison chronology is unusually clear in the retrieved UGCC account, but full interrogation transcripts were not retrieved; only the case number and reported questioning are available. [S1] [S3]
+
+- **What survived / what was destroyed:** His letters and monastic instructions survived in published collections and church memory. His burial place remains unidentified in the retrieved sources; UGCC states that the grave has not been found. [S1]
+
+## 3. Major works
+
+- `1900-1907` — Austrian parliamentary and public work under his secular name, important background for the later contrast between aristocratic status and monastic obedience.
+- `1911-1913` — entry into monastic life; Studite formation.
+- `1915` — priestly ordination.
+- `1917-1926` — leadership of Studite monastic houses in Lviv and Univ.
+- `1937` — work on the Studite Typikon with Metropolitan Andrey Sheptytskyi, submitted to the Congregation for the Eastern Churches. [S1]
+- `1939` — head of the Ukrainian Catholic Institute of Church Union named for Metropolitan Rutsky; appointed Greek-Catholic exarch in Russia. [S1]
+- `1940` — message *Посліднє слово*, preparing monks for persecution; source text was not retrieved, but UGCC identifies the title and purpose. [S1]
+- `1941-1944` — participation in the Sheptytsky rescue network for Jews during the German occupation; Yad Vashem recognized him as Righteous Among the Nations. [S2]
+- `1945-1947` — letters to Vatican contacts documenting Soviet persecution; intercepted and used in the case. [S1]
+- `1881-1945` — letters to his brother Stanislav and family, published posthumously. [S6]
+
+## 4. Primary-source quotes
+
+> "З висуненими звинуваченнями я не погоджуюся."
+
+Source: answer to Soviet investigators as quoted in UGCC Synod biography. The line is useful for learners because it shows direct refusal of a criminalized Soviet frame without heroic overstatement. [S1]
+
+> "Для мене тюремна камера - це монаша келія."
+
+Source: prison saying preserved in UGCC Synod biography. It is a direct devotional register; curriculum prose should label it as recorded speech, not a stenographic court transcript. [S1]
+
+## 5. Language register
+
+- **Register:** Ecclesiastical, monastic, epistolary, and legal-bureaucratic in repression sources.
+- **CEFR readiness for full reading:** B2 for short recorded sayings; C1 for letters and monastic instructions.
+- **Lexicon notes:** `архімандрит`, `студити`, `типікон`, `екзарх`, `МГБ`, `в'язниця`, `Праведник народів світу`.
+- **Stylistic features:** Direct speech is compact and pastoral; institutional biography uses hagiographic vocabulary that should be balanced with case-file caution.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Whether Sheptytskyi should be treated primarily as Andrey Sheptytskyi's helper, as a separate Studite institutional builder, or as a prison martyr. UGCC sources explicitly warn that his contribution still needs fuller study. [S1]
+- **What gets simplified in popular memory:** He is often reduced to "the brother of Andrey" or to one rescue title. Retrieved sources show a longer record: lawyer, parliamentarian, monk, archimandrite, rescuer, and acting church leader after the 1945 arrests.
+- **Where modern Russian disinformation attacks them:** Soviet anti-Catholic framing criminalized Vatican contact and loyalty to the UGCC as anti-Soviet activity. The dossier labels that as a regime charge, not a neutral description.
+- **Polish / Jewish / other-perspective considerations:** Yad Vashem recognition is central: he and Studite collaborators helped hide Jewish children and adults. Polish aristocratic family background is also real and should not be erased into a single ethnic label.
+- **Pedagogical caution:** Do not present prison sayings as court transcripts unless the SBU file is directly consulted. Keep "recorded speech" and "archival transcript" separate.
+
+## 7. Cross-track links
+
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio link to Andrey Sheptytskyi, Yosyf Slipyi, Studite monasticism, rescue of Jews in wartime Lviv, and postwar Soviet liquidation of the UGCC.
+- **Potential LIT additions surfaced by this research:**
+  - A C1 epistolary reading from the published letters to Stanislav Sheptytskyi, if rights and text access are cleared.
+
+## 8. Naming-canonical
+
+- **Slug:** `klymentii-sheptytskyi`
+- **EN canonical (BGN/PCGN 2010):** Klymentii Sheptytskyi
+- **UA canonical (with patronymic if attested):** Шептицький Климентій; secular name Шептицький Казимир Марія.
+- **Aliases (track these for `aliases:` YAML field):** Казимир Шептицький, отець Климентій, архімандрит Климентій, Klymentiy Sheptytsky, Clement Sheptytsky, Kliment Sheptytskyi, Szeptycki.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Kliment Sheptitskii, Kazimir Sheptitsky (FORBIDDEN except archival metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category for Klymentii Sheptytskyi; verify individual file license before use.
+- **Backup candidates:** UGCC Synod portrait used in the 2020 biography page; rights not established in retrieved source.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of Univ Lavra or a Studite memorial plaque.
+- **Era-appropriate context image:** Vladimir Central Prison exterior or UGCC underground memorial image, only with explicit license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/documents/20010626_beatif_ucraina_en.html | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "У цей день, 151 рік тому, народився блаженний свящмч. Климентій Шептицький" | https://synod.ugcc.ua/data/u-tsey-den-151-rik-tomu-narodyvsya-blazhennyy-svyashchmch-klymentiy-sheptytskyy-4472/ | accessed 2026-05-30
+- Yad Vashem Collections, "Sheptytsky Clement" | https://collections.yadvashem.org/en/righteous/4017786 | accessed 2026-05-30
+- UGCC Synod, "о. Юстин Бойко: Про свідомість внутрішньоцерковної міжєпархіяльної єдності..." | https://synod.ugcc.ua/data/otets-yustyn-boyko-pro-svidomist-vnutrishnotserkovnoy-mizheparhiyalnoy-ednosti-peredvoennoy-ugkts-5787/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Климентій (Шептицький)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Radio Svoboda, "Листи братів Шептицьких. Вони вміли поєднати непоєднуване" | https://www.radiosvoboda.org/a/28405727.html | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Published case number reference `74978 ФП` via UGCC Synod; full SBU file source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet charge language labeled as accusation
+- [x] Yad Vashem recognition included without erasing Ukrainian/Polish family context
+- [x] No fabricated case-file details
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/leonid-pliushch.md
+++ b/docs/research/bio/leonid-pliushch.md
@@ -1,0 +1,124 @@
+# Плющ Леонід Іванович — Research Dossier
+
+**Slug:** `leonid-pliushch`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Плющ Леонід Іванович.
+- **Pseudonyms / aliases:** Leonid Pliushch, Leonid Plyushch, Leonid Pliouchtch.
+- **Born:** 1939-04-26 | Naryn, Kyrgyz SSR, USSR. ESU and KHPG agree; Ukrainian Wikipedia summary retrieved via `mcp__sources.query_wikipedia` also gives Naryn. [S1] [S2] [S5]
+- **Died:** 2015-06-04 | Besseges, France. ESU and KHPG agree on date and France. [S1] [S2]
+- **Family / education key facts:** Childhood illness led the family to Odesa; studied mathematics in Odesa and Kyiv; graduated from Kyiv University's mechanics-mathematics faculty in 1962; worked at the Institute of Cybernetics of the Academy of Sciences of the Ukrainian SSR until dismissal in 1968. [S1] [S2]
+
+## 2. Oppression mechanism
+
+- **What happened:** Dismissal, searches, arrest, criminal accusation under anti-Soviet agitation/propaganda, closed psychiatric ruling, punitive psychiatric confinement, forced exile/emigration.
+- **When:** Fired July 1968; joined Initiative Group in May 1969; arrested 1972-01-15; Kyiv regional court ruled him "insane" in 1973; sent to Dnipropetrovsk Special Psychiatric Hospital on 1973-07-05; expelled from the USSR in January 1976. [S1] [S2]
+- **By whom:** KGB/Soviet investigative apparatus, Kyiv regional court, Soviet punitive psychiatric system.
+- **Document references:** KHPG gives Criminal Code article `ч. I ст. 62 КК УРСР`; ESU gives the same broad accusation and court/psychiatric-hospital sequence. A full case file number was not retrieved. [S1] [S2]
+- **Mechanism specifics:** Pliushch moved from mathematical work into samvydav and rights documentation. KHPG records that he gathered information about human-rights violations in Ukraine and passed it to *Хроника текущих событий* and *Український вісник*. He signed Initiative Group letters including a 1971 appeal to the International Congress of Psychiatrists against punitive psychiatry, then became himself one of the most visible victims of that system. [S2]
+
+The psychiatric diagnosis "млявотічна шизофренія" appears in KHPG as the official diagnosis. This dossier quotes it only as a Soviet forensic-political label, not as a medical fact. The international campaign around Pliushch helped expose Soviet psychiatric abuse. [S2]
+
+- **What survived / what was destroyed:** His scientific career was broken; his memoir and later cultural criticism survived in diaspora and Ukrainian editions. Western psychiatrists found him healthy after expulsion, according to KHPG. [S2]
+
+## 3. Major works
+
+- `1966-1971` — samvydav articles on Soviet ideology, national questions, and rights violations. [S2]
+- `1971` — appeal to the 5th International Congress of Psychiatrists against punitive psychiatry. [S2]
+- `1976/1978/2002` — *На карнавалі історії* / *У карнавалі історії: Свідчення*, memoir; ESU records editions and translations. [S1]
+- `1977` — foreign representative role for the Ukrainian Helsinki Group. [S1] [S2]
+- `1986/2001` — *Екзод Тараса Шевченка. Навколо "Москалевої криниці"*, literary-critical monograph. [S2]
+- `1991` — documentary/video work *З Малоросії в Україну*, per KHPG. [S2]
+- `1993` — French book *Ukraine: A nous l'Europe!* listed by KHPG. [S2]
+- `2006` — *Його таємниця, або "Прекрасна ложа" Хвильового*, cultural/literary study listed by KHPG. [S2]
+
+## 4. Primary-source quotes
+
+> "Мушу все це запам'ятати, щоб свідчити."
+
+Source: *У карнавалі історії* passage surfaced in web retrieval. It is short enough for classroom use and captures the memoir's witness function; verify against the 2002 Fact edition before quoting in learner materials. [S4]
+
+> "свідок і учасник цього трагіфарсу"
+
+Source: Pliushch's explanation of the memoir title in retrieved online text. Use as a primary-voice lead, with edition check required in Phase 2. [S4]
+
+## 5. Language register
+
+- **Register:** Memoir, rights documentation, mathematical/intellectual prose, literary criticism.
+- **CEFR readiness for full reading:** C1 for memoir chapters; C2 for *Екзод Тараса Шевченка*.
+- **Lexicon notes:** `самвидав`, `каральна психіатрія`, `Ініціативна група`, `млявотічна шизофренія`, `закордонне представництво`, `семіотика`.
+- **Stylistic features:** Analytic self-observation, irony, political diagnosis, and literary-critical abstraction.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Pliushch began with socialist-democratic hopes and moved toward anti-communism; sources should preserve that ideological movement rather than retroactively simplifying it.
+- **What gets simplified in popular memory:** He is often remembered only as a psychiatric-abuse victim. KHPG and ESU also show a cultural mediator between Ukrainian, Moscow, Crimean Tatar, and Jewish rights networks.
+- **Where modern Russian disinformation attacks them:** Soviet psychiatric labels are the attack mechanism. Curriculum must not repeat the diagnosis as medical truth.
+- **Polish / Jewish / other-perspective considerations:** KHPG says he was a bridge to Jewish and Crimean Tatar rights movements and later worked in Ukrainian-Jewish anti-defamation contexts. [S2]
+- **Pedagogical caution:** Explain why "dissident" is useful shorthand but does not capture the full rights-network role.
+- **Source-balance note:** ESU and KHPG are mutually reinforcing for the arrest, court, psychiatric hospital, and emigration chronology. The memoir quotations are weaker because the online access copy is not a critical edition; they are included as primary-voice leads, with an explicit instruction to check the 2002 Fact edition before curriculum publication.
+- **Risk note:** The phrase "punitive psychiatry" should be anchored in the court/hospital timeline, not used as a vague metaphor. For Pliushch it means a named special psychiatric hospital, a named Soviet diagnosis, and a documented international defense campaign.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - source not found
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - source not found
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Ukrainian Helsinki Group, punitive psychiatry, Crimean Tatar rights contacts, Mykola Rudenko, Nadiia Svitlychna, Petro Hryhorenko, and Shevchenko studies.
+- **Potential LIT additions surfaced by this research:**
+  - C1/C2 excerpt from *У карнавалі історії* on witness and memory; C2 excerpt from *Екзод Тараса Шевченка*.
+  - A cross-track human-rights activity can ask learners to map how information moved between Kyiv, Moscow, Crimean Tatar, Jewish, and Western networks without treating Moscow contacts as the center of the story.
+
+## 8. Naming-canonical
+
+- **Slug:** `leonid-pliushch`
+- **EN canonical (BGN/PCGN 2010):** Leonid Pliushch
+- **UA canonical (with patronymic):** Плющ Леонід Іванович
+- **Aliases (track these for `aliases:` YAML field):** Leonid Plyushch, Leonid Pliouchtch.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Leonid Plyusch, Leonid Pliushch through Russian source-only form (FORBIDDEN except bibliography).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait candidate; verify specific license.
+- **Backup candidates:** KHPG page image; rights not established.
+- **If no PD/CC portrait exists:** Use rights-cleared cover of *У карнавалі історії* or a human-rights museum context image.
+- **Era-appropriate context image:** Dnipropetrovsk special psychiatric hospital context or samvydav image, only with explicit license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Плющ Леонід Іванович" | https://esu.com.ua/article-879739 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Харківська правозахисна група, "ПЛЮЩ ЛЕОНІД ІВАНОВИЧ" | https://museum.khpg.org/1113936077 | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Плющ Леонід Іванович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_sources`, Realna Istoriia / punitive psychiatry retrieval for Pliushch searches and samvydav accusation context | accessed 2026-05-30
+
+**Tier 5 (general web):**
+- Chytivo, "У карнавалі історії: Свідчення" | https://chtyvo.org.ua/authors/Pliusch_Leonid/U_karnavali_istorii_Svidchennia/ | accessed 2026-05-30
+- Coollib online text, "У карнавалі історії. Свідчення" | https://coollib.net/b/697342/read | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Memoir excerpts via online text; full court/medical case file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Punitive psychiatric label marked as Soviet label
+- [x] Article 62 cited from KHPG/ESU
+- [x] No fabricated case-file number
+- [x] Existing path gap declared
+- [x] Russian-imperial forms confined to naming metadata

--- a/docs/research/bio/serhii-paradzhanov.md
+++ b/docs/research/bio/serhii-paradzhanov.md
@@ -1,0 +1,123 @@
+# Параджанов Сергій Йосипович — Research Dossier
+
+**Slug:** `serhii-paradzhanov`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Параджанов Сергій Йосипович; ESU gives the birth name as Саркіс Параджанян. [S1]
+- **Pseudonyms / aliases:** Sergei Parajanov, Serhii Paradzhanov, Sarkis Parajaniants, Sarkis Paradzhanian.
+- **Born:** 1924-01-09 | Tbilisi, Georgian SSR, USSR. ESU and Ukrainian Wikipedia via `mcp__sources.query_wikipedia` agree on date and city. [S1] [S4]
+- **Died:** 1990-07-20 | Yerevan, Armenian SSR, USSR. ESU and Ukrainian Wikipedia agree. [S1] [S4]
+- **Family / education key facts:** Armenian family in Tbilisi; studied at VGIK under the Dovzhenko/Savchenko line of Soviet film education; worked for years in Kyiv and became a defining figure of Ukrainian poetic cinema. [S1] [S3]
+
+## 2. Oppression mechanism
+
+- **What happened:** Surveillance/cultural repression, arrest, criminal conviction under sexual/pornography charges used against a politically and artistically nonconforming filmmaker, imprisonment in a labor camp, and professional bans.
+- **When:** Heightened pressure in the late 1960s; arrested in Kyiv in December 1973; sentenced to five years; released in 1977 after international pressure. [S1] [S4] [S7]
+- **By whom:** Soviet security/court/camp system.
+- **Document references:** ESU and retrieved scholarly/web sources describe the 1973 arrest and imprisonment but the full court-case number was not retrieved. Source not found for stable archival ID.
+- **Mechanism specifics:** Paradzhanov's Ukrainian breakthrough, *Тіні забутих предків*, made Hutsul language and folk aesthetics central to modern cinema. Klassiki describes the film as grounded in Hutsul traditions and part of Ukrainian poetic cinema; the movement was formally radical and politically subversive. [S3]
+
+Soviet pressure used sexual-criminal charges, but retrieved sources also link the case to his nonconformist art, contacts with Ukrainian cultural circles, and perceived Ukrainian-national cultural influence. ESU is the base biographical authority; web retrievals around the Parajanov affair and Ukrainian rehabilitation confirm that Ukraine later treated the prosecution as politically motivated. [S1] [S7]
+
+- **What survived / what was destroyed:** He produced drawings, collages, and objects while imprisoned, but the camp and bans interrupted film projects and damaged decades of possible work. His film and collage legacy survived in Ukrainian, Armenian, Georgian, and international memory. [S1] [S4]
+
+## 3. Major works
+
+- `1954` — early film work after VGIK; ESU treats pre-1965 work as formative but less central. [S1]
+- `1961` — *Українська рапсодія*, film. [S4]
+- `1965` — *Тіні забутих предків*, based on Mykhailo Kotsiubynskyi, with Ivan Chendei, Yurii Illienko, Myroslav Skoryk, and Ivan Mykolaichuk. [S3]
+- `1969` — *Колір граната*, Armenian film, internationally central to his reputation. [S4]
+- `1973-1977` — prison drawings, collages, miniature works; many later held in the Yerevan museum according to retrieved Wikipedia summary. [S4]
+- `1985` — *Легенда про Сурамську фортецю*, post-release film.
+- `1988` — *Ашик-Керіб*, late film.
+- `1991` — Shevchenko National Prize posthumously, per Ukrainian Wikipedia/ESU context. [S1] [S4]
+- `2023-2024` — Ukrainian rehabilitation/national recognition reported by retrieved web sources; use only with date-specific citation. [S7]
+
+## 4. Primary-source quotes
+
+> "Я вірменин, народжений у Тбілісі"
+
+Source: Paradzhanov self-description widely retrieved in Ukrainian cultural web coverage; use as identity quote with edition/interview verification before learner publication. [S6]
+
+> "Хай живе Україна!"
+
+Source: quoted in Ukrainian history portal retrieval as from his last Ukrainian interview. Short, direct, but should be tied to the retrieved portal and verified against the interview recording in Phase 2. [S7]
+
+## 5. Language register
+
+- **Register:** Film-poetic, multilingual, visual/collage, performative interview speech.
+- **CEFR readiness for full reading:** B2 for short interviews; C1-C2 for film criticism around his work.
+- **Lexicon notes:** `поетичне кіно`, `гуцульський`, `колаж`, `монтаж`, `андеграунд`, `реабілітація`.
+- **Stylistic features:** Visual symbolism, ritualized folk detail, tableau composition, multilingual identity performance, and aphoristic self-description.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His belonging is transnational: Armenian by family, born in Georgia, artistically central to Ukrainian poetic cinema, later important to Armenian cinema. A Ukrainian bio module should avoid appropriation and state all affiliations.
+- **What gets simplified in popular memory:** He can be reduced to *Тіні забутих предків* or to the prison case. ESU and film sources show a broader body: features, scripts, collages, drawings, and performance persona.
+- **Where modern Russian disinformation attacks them:** Soviet/Russian framing can use criminal charges to erase the cultural-political nature of repression. Curriculum should name the charges but not let them define the artist's identity.
+- **Polish / Jewish / other-perspective considerations:** Retrieved sources did not surface a specific Polish or Jewish issue. Armenian, Georgian, and Ukrainian perspectives are mandatory.
+- **Pedagogical caution:** Discuss sexuality-related charges carefully: the prosecution history is part of Soviet coercion, but classroom materials should avoid sensationalism.
+- **Source-balance note:** ESU is the main authority for identity, dates, and work list. Klassiki is used for the film-language and Ukrainian poetic cinema frame, while the rehabilitation/interview web sources are leads that need direct document or recording checks before becoming curriculum text. That distinction matters because Paradzhanov is often surrounded by memorable but poorly sourced aphorisms.
+- **Risk note:** The dossier deliberately keeps "Sergei Parajanov" as an international alias while using `serhii-paradzhanov` for the Ukrainian-track slug. The figure's transnational identity should be taught as a fact, not resolved into a single ownership claim.
+
+## 7. Cross-track links
+
+- **Existing C1/cinema module (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/ukrainske-kino.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Ivan Drach, Yurii Illienko, Ivan Mykolaichuk, Mykhailo Kotsiubynskyi, Hutsul culture, Armenian cinema, and Ukrainian poetic cinema.
+- **Potential LIT additions surfaced by this research:**
+  - Pair *Тіні забутих предків* film clips with Kotsiubynskyi prose excerpts at B2-C1.
+  - A visual-literacy task can compare Hutsul cultural vocabulary in the film with the original prose setting, while noting which details come from cinema rather than Kotsiubynskyi's text.
+
+## 8. Naming-canonical
+
+- **Slug:** `serhii-paradzhanov`
+- **EN canonical (BGN/PCGN 2010):** Serhii Paradzhanov for Ukrainian track; Sergei Parajanov as international film-history alias.
+- **UA canonical (with patronymic):** Параджанов Сергій Йосипович
+- **Aliases (track these for `aliases:` YAML field):** Sergei Parajanov, Serhii Paradzhanov, Sarkis Paradzhanian, Sarkis Parajaniants.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Sergei Iosifovich Paradzhanov as default Ukrainian-track form (FORBIDDEN except bibliography/source metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category for Sergei Parajanov; verify specific image license.
+- **Backup candidates:** Sergei Parajanov Museum images; rights not established.
+- **If no PD/CC portrait exists:** Use rights-cleared still from a public-domain/licensed context or a licensed image of a Paradzhanov collage.
+- **Era-appropriate context image:** Licensed still from *Тіні забутих предків* or a Ukrainian poetic cinema poster.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Параджанов Сергій Йосипович" | https://esu.com.ua/article-887082 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Klassiki, "Shadows of Forgotten Ancestors" | https://films.klassiki.online/shadows-of-forgotten-ancestors | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Параджанов Сергій Йосипович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Iris / University of Cagliari repository, "New perspectives on the Parajanov affair..." | https://iris.unica.it/handle/11584/326731 | accessed 2026-05-30
+
+**Tier 5 (general web):**
+- Kyiv Post, "Works of Director Parajanov Sparked Revival of Ukrainian Art Traditions" | https://www.kyivpost.com/post/11534 | accessed 2026-05-30
+- PortalHistoryUA, "Сергій Параджанов" | https://portalhistoryua.com/personality/sergij-paradzhanov/ | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Short interview/self-description quotes through retrieved web sources. Full trial file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Armenian/Georgian/Ukrainian affiliations all named
+- [x] Soviet charges contextualized, not sensationalized
+- [x] Existing path verified
+- [x] No fabricated case ID
+- [x] Russian-imperial forms confined to naming metadata

--- a/docs/research/bio/teodor-romzha.md
+++ b/docs/research/bio/teodor-romzha.md
@@ -1,0 +1,120 @@
+# Ромжа Теодор Юрійович — Research Dossier
+
+**Slug:** `teodor-romzha`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ромжа Теодор Юрійович; baptismal name Юрій. UGCC Synod gives "Теодор (хресне ім'я -- Юрій) Ромжа." [S1]
+- **Pseudonyms / aliases:** Bishop Theodore Romzha, Teodor Romza, Теодор (Юрій) Ромжа.
+- **Born:** 1911-04-14 | Великий Бичків, Transcarpathia, Austria-Hungary. UGCC Synod and Vatican agree on date and village. [S1] [S2]
+- **Died:** 1947-11-01 by Moscow-time hospital record / commemorated as 1947-10-31 by local-date convention | Mukachevo hospital, Ukrainian SSR. UGCC Synod explicitly explains the 31 October / 1 November discrepancy; Vatican gives 1 November. [S1] [S2]
+- **Family / education key facts:** Ninth child in a railway-worker family; studied in Khust, then Rome; ordained priest in 1936; professor of philosophy in Uzhhorod from 1939; ordained bishop for Mukachevo in 1944. [S1] [S2]
+
+## 2. Oppression mechanism
+
+- **What happened:** Planned Soviet assassination attempt followed by poisoning in hospital.
+- **When:** Road attack 1947-10-27; poisoning/death 1947-11-01 by official Moscow-time record, locally commemorated 1947-10-31. [S1] [S2]
+- **By whom:** Soviet security/state-police apparatus; Vatican Italian biography states the poisoning was carried out by a state-security general and special agents. [S2]
+- **Document references:** Retrieved sources name the mechanism and date but do not provide a stable archival file number. Source not found for case ID.
+- **Mechanism specifics:** Romzha led the Mukachevo Greek Catholic eparchy when Soviet authorities were forcing Greek Catholics into the Russian Orthodox Church. Vatican says the Soviet authorities could not find a plausible charge, so an assassination was planned: a staged vehicle accident during a pastoral visit, followed by poisoning in the Mukachevo hospital. UGCC Synod gives a detailed local chronology and notes the death-date discrepancy caused by official Moscow time. [S1] [S2]
+
+The broader context is the Soviet destruction of the UGCC and parallel pressure on the Mukachevo eparchy. `mcp__sources.search_sources` retrieved an Encyclopedia of Ukraine / church-history passage stating that after Romzha's killing in 1947, pressure on priests intensified and the Zakarpattia union was severed in a staged 1949 process. This dossier uses that only as context, not as a substitute for the Romzha-specific sources. [S5]
+
+- **What survived / what was destroyed:** The eparchy was forced underground, but Romzha became a symbol of resistance for Mukachevo Greek Catholics and was beatified in 2001. [S1] [S2]
+
+## 3. Major works
+
+- `1936` — priestly ordination in Rome. [S1]
+- `1938-1939` — pastoral service in Berezovo and Nyzhnii Bystryi. [S1] [S2]
+- `1939` — professor of philosophy at the Uzhhorod seminary. [S2]
+- `1944` — episcopal consecration in Uzhhorod cathedral for the Mukachevo eparchy. [S1]
+- `1944-1947` — pastoral visitation under Red Army/Soviet pressure; defended Catholic communion. [S1] [S2]
+- `1947` — final pastoral trip and martyrdom after the staged attack.
+- `2001` — beatification as martyr during John Paul II's Ukraine visit. [S3]
+
+## 4. Primary-source quotes
+
+> "Полюблю Тя, Господи, кріпосте моя"
+
+Source: episcopal motto quoted by UGCC Synod from the Psalms as Romzha's chosen motto. It is a direct self-positioning phrase and a useful ecclesiastical-register anchor. [S1]
+
+> "Пора би, врешті, покінчити зі старою, дряхлою традицією"
+
+Source: letter to the Russicum rector quoted in the UGCC Synod biography, in which Romzha rejected judging a parish by income. The quote works pedagogically because it shows his social and pastoral priorities, not only martyr memory. [S1]
+
+## 5. Language register
+
+- **Register:** Ecclesiastical, pastoral, Transcarpathian church history, and Soviet repression.
+- **CEFR readiness for full reading:** B2 for motto and short letter excerpts; C1 for full church biography.
+- **Lexicon notes:** `єпископська хіротонія`, `єпархія`, `Мукачівська єпархія`, `держбезпека`, `отруєння`, `псалом`.
+- **Stylistic features:** A mix of biblical motto, pastoral correspondence, and institutional martyrology.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The death-date discrepancy is real: Vatican gives 1 November, while UGCC explains why local commemoration may use 31 October. Curriculum should give both with the reason.
+- **What gets simplified in popular memory:** The story can become only "poisoned bishop"; retrieved sources show a prior record of teaching, village service, and long pastoral travel under pressure.
+- **Where modern Russian disinformation attacks them:** Soviet narratives framed forced absorption into Russian Orthodoxy as church "reunification." This dossier uses "coercion" and "forced transfer" because retrieved church-history sources describe state-security pressure and staged processes.
+- **Polish / Jewish / other-perspective considerations:** Romzha's Transcarpathian setting was multilingual and multi-state: Hungarian, Czechoslovak, and Soviet political frames all matter. The dossier avoids flattening him into a single modern state category before source context.
+- **Pedagogical caution:** Do not hide the date discrepancy; it is a useful lesson in time zones, official records, and commemoration.
+- **Source-balance note:** Vatican is the cleanest source for the assassination mechanism in compact form; UGCC Synod is stronger for local geography, family background, motto, and the death-date explanation. The retrieved church-history context links Romzha to the wider Soviet campaign against Greek Catholics in Zakarpattia, but it should not replace the Romzha-specific Vatican/UGCC evidence.
+
+## 7. Cross-track links
+
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Mukachevo Greek Catholic eparchy, Soviet anti-religious policy in Zakarpattia, Yosyf Slipyi, and the postwar underground church.
+- **Potential LIT additions surfaced by this research:**
+  - Short B2 reading from Romzha's pastoral letter to the Russicum rector if a stable edition is retrieved.
+  - A B2/C1 comparison task can use the two dates, 31 October and 1 November 1947, to train learners to ask which clock, state archive, and commemorative community a date belongs to.
+  - Another activity can contrast a bishop's motto with a Soviet assassination narrative, showing how one life can require both religious and security-history vocabulary.
+
+## 8. Naming-canonical
+
+- **Slug:** `teodor-romzha`
+- **EN canonical (BGN/PCGN 2010):** Teodor Romzha
+- **UA canonical (with patronymic):** Ромжа Теодор Юрійович
+- **Aliases (track these for `aliases:` YAML field):** Теодор (Юрій) Ромжа, Theodore Romzha, Teodor Romza, Bishop Theodore Romzha.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Fyodor Romzha, Teodor Romzha through Russian transliteration (FORBIDDEN except archival metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait candidate; verify specific license.
+- **Backup candidates:** UGCC Synod profile image; rights not established.
+- **If no PD/CC portrait exists:** Use rights-cleared image of the Uzhhorod cathedral or Mukachevo Greek Catholic memorial.
+- **Era-appropriate context image:** Mukachevo hospital/memorial image if license-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, "Teodor Romza (1911-1947)" | https://www.vatican.va/news_services/liturgy/saints/ns_lit_doc_20010627_romza_en.html | accessed 2026-05-30
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/documents/20010626_beatif_ucraina_en.html | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "Владика Теодор Ромжа" | https://synod.ugcc.ua/data/vladyka-teodor-romzha-11713/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Теодор (Ромжа)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_sources`, Encyclopedia of Ukraine / church-history retrieval for Mukachevo eparchy and 1947-1949 Soviet coercion context | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Motto and letter excerpt via UGCC Synod. Archival assassination case file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Assassination mechanism grounded in Vatican/UGCC sources
+- [x] Date discrepancy flagged
+- [x] Soviet "reunification" framing not normalized
+- [x] Existing paths verified
+- [x] No fabricated archival ID

--- a/docs/research/bio/valentyn-moroz.md
+++ b/docs/research/bio/valentyn-moroz.md
@@ -1,0 +1,123 @@
+# Мороз Валентин Якович — Research Dossier
+
+**Slug:** `valentyn-moroz`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Мороз Валентин Якович.
+- **Pseudonyms / aliases:** Valentyn Moroz, Valentyn Yakovych Moroz.
+- **Born:** 1936-04-15 | Холонів, Volyn region, Polish Republic / now Ukraine. ESU and KHPG agree on the date and village. [S1] [S2]
+- **Died:** 2019-04-16 | Lviv, Ukraine. ESU gives date and place; Ukrainian Wikipedia via `mcp__sources.query_wikipedia` agrees. [S1] [S5]
+- **Family / education key facts:** Graduated from Lviv University in 1958; worked as teacher and then lecturer at Lutsk and Ivano-Frankivsk pedagogical institutes. [S1] [S2]
+
+## 2. Oppression mechanism
+
+- **What happened:** Two Soviet arrests, convictions under Article 62 of the Criminal Code of the Ukrainian SSR, camp imprisonment, Vladimir Prison, hunger strikes, and eventual 1979 prisoner exchange.
+- **When:** First arrest September 1965, sentence to four years; second arrest 1970-06-01 for *Репортаж із заповідника імені Берія* and essays; sentenced to six years prison, three years special-regime camps, and five years exile according to KHPG/related retrievals; exchanged in 1979. [S1] [S2] [S6]
+- **By whom:** KGB/Soviet investigative apparatus, Ukrainian SSR courts, Soviet prison/camp system.
+- **Document references:** KHPG gives `ст. 62 КК УРСР`; PNU reports declassified trial materials and interrogation protocols but this dossier did not retrieve the full archival call number. Source not found for complete case ID. [S2] [S4]
+- **Mechanism specifics:** Moroz's first imprisonment produced *Репортаж із заповідника імені Берія*, a samvydav description of camp/KGB mechanisms. ESU says after release in 1969 he wrote *Мойсей і Датан*, *Серед снігів*, and *Хроніка опору*; on 1970-06-01 he was arrested again for those writings. [S1]
+
+His second case generated a major defense reaction. ESU names signatories and defenders including Oksana Meshko, Vasyl Stus, Ivan Dziuba, Ivan Svitlychnyi, Zynovia Franko, Viacheslav Chornovil, Yevhen Sverstiuk, the Kalynetses, Nina Strokata-Karavanska, and others. [S1]
+
+- **What survived / what was destroyed:** The Soviet state tried to isolate him physically and discredit him politically. The essays survived in samvydav/diaspora publication and later Ukrainian reference sources.
+
+## 3. Major works
+
+- `1967-1969` — *Репортаж із заповідника імені Берія*, samvydav camp essay. [S1] [S2]
+- `1969-1970` — *Мойсей і Датан*, essay on national subordination. [S1]
+- `1969-1970` — *Серед снігів*, essay on moral responsibility of national elites. [S1]
+- `1969-1970` — *Хроніка опору*, essay on destruction of national cultural heritage. [S1]
+- `1975` — *Есеї, листи, документи*, diaspora collection. [S2]
+- `1978` — *Мойсей і Датан*, Smoloskyp edition. [S2]
+- `1991-1993` — teaching and public work in Lviv after return. [S2]
+- `2005/2012/2016` — *Україна у двадцятому столітті*, multi-volume historical work listed by KHPG. [S2]
+
+## 4. Primary-source quotes
+
+> "нація може жити тільки тоді"
+
+Source: *Мойсей і Датан* thesis quoted in ESU and confirmed by web retrieval. This line is strong but rhetorically radical; teaching should frame it as Moroz's position, not as course doctrine. [S1]
+
+> "перша хвиля українського відродження"
+
+Source: Moroz's description of the 1960s quoted by KHPG. It is useful for a discussion of how dissidents named their own generation. [S2]
+
+## 5. Language register
+
+- **Register:** Polemical essay, prison testimony, nationalist publicistics, later historical synthesis.
+- **CEFR readiness for full reading:** C1-C2.
+- **Lexicon notes:** `самвидав`, `заповідник`, `КДБ`, `особливо небезпечний рецидивіст`, `голодівка`, `національна еліта`.
+- **Stylistic features:** Aphoristic statements, adversarial argument, moral absolutes, and high-pressure prison testimony.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Moroz's radical nationalism and conflicts with other prisoners should be included; KHPG records criticism from fellow political prisoners in 1977. [S2]
+- **What gets simplified in popular memory:** He is often either romanticized as a pure martyr or dismissed for radicalism. A reliable module must hold both: severe Soviet persecution and real intra-dissident controversy.
+- **Where modern Russian disinformation attacks them:** Soviet and post-Soviet framing leans on "anti-Soviet agitation" and "nationalist" labels to criminalize Ukrainian self-determination. Those labels are only quoted as regime categories.
+- **Polish / Jewish / other-perspective considerations:** Some intra-prison criticism involved accusations of intolerance; do not erase this when discussing broader solidarity networks.
+- **Pedagogical caution:** His rhetoric is powerful and often polarizing. It belongs at advanced CEFR levels with historical framing, not as unsourced inspirational quotation.
+- **Source-balance note:** ESU is the strongest compact source for the sequence from the first imprisonment to the second arrest and named defenders. KHPG adds the dissident-movement context and the later controversy among prisoners. The PNU page is a lead to declassified court materials, but because the full documents were not retrieved in this pass, the dossier does not claim protocol page numbers or archival signatures.
+- **Risk note:** Moroz is a case where decolonized framing is not the same as hagiography. Soviet punishment was real and severe; so were conflicts around his radical rhetoric. A useful lesson can ask students to identify what the Soviet state punished, what other dissidents criticized, and why those are different categories of evidence.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - source not found
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - source not found
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Viacheslav Chornovil, Vasyl Stus, Ivan Dziuba, Ukrainian samvydav, Article 62 cases, Vladimir Prison, and 1979 dissident exchange.
+- **Potential LIT additions surfaced by this research:**
+  - C2 excerpt from *Репортаж із заповідника імені Берія* with heavy annotation and controversy notes.
+  - A source-literacy exercise can compare ESU's encyclopedia phrasing with KHPG's biographical narrative and a declassified-trial exhibit, once the latter is fully downloaded and cited.
+  - An advanced discussion can separate "evidence of persecution" from "agreement with the author's politics," which is essential for teaching polarizing dissident texts responsibly.
+
+## 8. Naming-canonical
+
+- **Slug:** `valentyn-moroz`
+- **EN canonical (BGN/PCGN 2010):** Valentyn Moroz
+- **UA canonical (with patronymic):** Мороз Валентин Якович
+- **Aliases (track these for `aliases:` YAML field):** Valentyn Yakovych Moroz.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Valentin Yakovlevich Moroz (FORBIDDEN except bibliography/source metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait candidate; verify individual license.
+- **Backup candidates:** KHPG page image or public memorial photos; rights not established.
+- **If no PD/CC portrait exists:** Use a rights-cleared samvydav cover or protest-campaign image.
+- **Era-appropriate context image:** Declassified court-material exhibit from PNU if rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Мороз Валентин Якович" | https://esu.com.ua/article-68906 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- Харківська правозахисна група, "МОРОЗ ВАЛЕНТИН ЯКОВИЧ" | https://museum.khpg.org/1113917542 | accessed 2026-05-30
+- Прикарпатський національний університет, "Судовий процес Валентина Мороза: розсекречені матеріали" | https://pnu.edu.ua/blog/2021/12/23/35471/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Мороз Валентин Якович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- Історична правда, "Валентин Мороз: історія України, побачена українськими очима" | https://www.istpravda.com.ua/dissidents/articles/618e5bc07568d/ | accessed 2026-05-30
+- `mcp__sources.search_sources`, modern literary retrieval on Moroz essays | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Essay quotations through ESU/KHPG; full declassified trial materials: source not found in full text.
+
+---
+
+## Decolonization self-check
+
+- [x] Article 62 regime language labeled
+- [x] Intra-dissident controversy included
+- [x] No invented case ID
+- [x] Existing path gap declared
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/yevhen-hutsalo.md
+++ b/docs/research/bio/yevhen-hutsalo.md
@@ -1,0 +1,121 @@
+# Гуцало Євген Пилипович — Research Dossier
+
+**Slug:** `yevhen-hutsalo`
+**Block:** E
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Гуцало Євген Пилипович.
+- **Pseudonyms / aliases:** Yevhen Hutsalo, Evhen Hutsalo, Eugene Hutsalo.
+- **Born:** 1937-01-14 | Старий Животів, now Новоживотів, Vinnytsia region, Ukrainian SSR. ESU gives date and place; Ukrainian Wikipedia via `mcp__sources.query_wikipedia` agrees. [S1] [S4]
+- **Died:** 1995-07-14 | Kyiv, Ukraine. ESU gives 14 July 1995; this differs from some casual web summaries that give 4 July, so the dossier follows ESU. [S1]
+- **Family / education key facts:** Graduated from Nizhyn Pedagogical Institute in 1959; worked in regional newspapers, *Literaturna Ukraina*, and the Soviet/Ukrainian Writers publishing house. [S1]
+
+## 2. Oppression mechanism
+
+- **What happened:** Indirect Soviet cultural pressure: censorship, ideological framing, and pressure to fit Ukrainian prose into Soviet literary categories.
+- **When:** 1960s-1980s, especially during the post-Thaw disciplining of Sixtiers and Ukrainian cultural production.
+- **By whom:** Soviet literary institutions, censorship systems, party-controlled publishing and criticism.
+- **Document references:** No single censorship ruling against Hutsalo was retrieved. Source not found for a personal KGB/censorship file.
+- **Mechanism specifics:** Hutsalo was not retrieved as an imprisoned dissident. His oppression mechanism is the quieter Block E form: a Ukrainian prose writer whose language, rural memory, and national-cultural attention were published inside a Soviet system that reframed such work as acceptable "Soviet" literature. A local curriculum source retrieved by `mcp__sources.search_sources` explicitly warns that Soviet references framed him as a "рад. writer," emphasized CPSU membership from 1977, and blurred national narrative into Soviet "international" language. [S5]
+
+The source-grounded way to teach him is not to claim arrest or exile. It is to show how lyrical prose, children in nature, village memory, and later anti-imperial essays made Ukrainian-language continuity visible even when the official system tried to domesticate that continuity. [S1] [S5]
+
+- **What survived / what was destroyed:** More than 200 lyrical stories and many longer prose works survived in print. What was damaged was the interpretive frame: Soviet criticism often made Ukrainian moral/ecological prose serve Soviet categories.
+
+## 3. Major works
+
+- `1961` — *Зелена радість конвалій*, poetic cycle. [S1]
+- `1962` — *Люди серед людей*, first story collection, noted by ESU for fresh emotional tone. [S1]
+- `1964` — *Яблука з осіннього саду*, stories. [S1]
+- `1966` — *Хустина шовку зеленого*, stories. [S1]
+- `1969` — *У лелечому селі*, one of the strong Ukrainian children's-story books of the period. [S1]
+- `1969` — *Подорожні*, wartime-memory prose. [S1]
+- `1971` — *Дівчата на виданні*, village moral drama. [S1]
+- `1973` — *Шкільний хліб*, postwar rural teachers. [S1]
+- `1982` — *Позичений чоловік*, comic/folkloric novel. [S1]
+- `1990s` — *Ментальність орди*, anti-imperial essay cycle; curriculum source retrieves it as part of the decolonial turn. [S5]
+
+## 4. Primary-source quotes
+
+> "Лось був старий та бувалий самець"
+
+Source: *Лось*, excerpt in Grade 5 Ukrainian literature textbook retrieved via `mcp__sources.search_text`. This short line is useful for A2-B1 learners because it introduces animal description, age, and narrative voice. [S6]
+
+> "Ми вчителі, ми не хочемо нікого обманювати"
+
+Source: *Шкільний хліб*, quoted in ESU. Pedagogically, it shows the moral plain style that lets rural teachers carry ethical pressure without slogans. [S1]
+
+## 5. Language register
+
+- **Register:** Lyrical prose, rural Ukrainian, ecological/ethical narrative, later polemical essay.
+- **CEFR readiness for full reading:** B1 for *Лось* excerpts; B2-C1 for adult prose; C1 for *Ментальність орди*.
+- **Lexicon notes:** `заповідник`, `ратиці`, `підберезник`, village household words, sensory nature vocabulary, anti-imperial essay terms.
+- **Stylistic features:** Dense nature description, moral understatement, child focalization, oral idioms, and non-urban Ukrainian phraseology.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** How to balance Hutsalo's publication within Soviet institutions and his preservation of Ukrainian rural/national language worlds.
+- **What gets simplified in popular memory:** School curricula often reduce him to *Лось*. ESU shows a much broader body: poetry, stories, novels, essays, and journalism. [S1]
+- **Where modern Russian disinformation attacks them:** The pressure is subtler than direct disinformation: imperial framing can dismiss his anti-imperial essays as "nationalist" while treating his children's prose as apolitical.
+- **Polish / Jewish / other-perspective considerations:** Retrieved sources did not surface a specific Polish or Jewish lens for Hutsalo. Source not found.
+- **Pedagogical caution:** Do not invent an arrest. Teach Soviet pressure as censorship/framing unless a personal repression file is retrieved.
+- **Source-balance note:** ESU is the authority for dates, awards, education, and the breadth of the bibliography. The retrieved school-text excerpts are not enough to define the whole career, but they are valuable because they show which Hutsalo text already lives in classroom circulation. The local curriculum retrieval is useful for the decolonization warning: it names the Soviet habit of absorbing Ukrainian prose into an all-Soviet identity frame.
+- **Risk note:** The date of death is a good example of why this dossier follows Tier 1 over casual web memory. ESU gives 14 July 1995. If a later editor sees a conflicting 4 July date, the conflict should be flagged with a retrieved source rather than silently changed.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/yevhen-hutsalo-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Hryhir Tiutiunnyk, Valerii Shevchuk, Ivan Drach, rural prose after the Thaw, and ecological ethics in children's literature.
+- **Potential LIT additions surfaced by this research:**
+  - A B1 reading around *Лось* and a C1 reading around *Ментальність орди* as two very different Hutsalo registers.
+  - A vocabulary bridge can move from concrete animal/nature words in *Лось* to abstract political vocabulary in *Ментальність орди*, making one writer useful across a wide CEFR span without pretending the registers are equally easy.
+  - A source task can ask learners why a children's-story excerpt is a primary text while a Soviet-era label such as "радянський письменник" is an interpretive frame.
+
+## 8. Naming-canonical
+
+- **Slug:** `yevhen-hutsalo`
+- **EN canonical (BGN/PCGN 2010):** Yevhen Hutsalo
+- **UA canonical (with patronymic):** Гуцало Євген Пилипович
+- **Aliases (track these for `aliases:` YAML field):** Evhen Hutsalo, Eugene Hutsalo.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Evgenii Gutsalo, Yevgeny Gutsalo (FORBIDDEN except source metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait candidate; verify license before use.
+- **Backup candidates:** ESU image; rights not established by page alone.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of Новоживотів or Nizhyn Pedagogical Institute context.
+- **Era-appropriate context image:** Cover of a rights-cleared edition of *Лось* or *Позичений чоловік*.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Гуцало Євген Пилипович" | https://esu.com.ua/article-25016 | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- `mcp__sources.search_text`, Grade 5 Ukrainian literature textbook excerpts from *Лось* | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Гуцало Євген Пилипович," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Tier 4 (modern scholarly post-1991):**
+- `mcp__sources.search_sources`, local curriculum/wiki source `wiki/literature/works/yevhen-hutsalo-shistdesiatnyky.md` | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Textbook excerpt from *Лось*; ESU quotation from *Шкільний хліб*. Personal censorship file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] No arrest invented
+- [x] ESU date used over unstable web date
+- [x] Soviet framing named as framing
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to naming metadata

--- a/docs/research/bio/zynovii-kovalyk.md
+++ b/docs/research/bio/zynovii-kovalyk.md
@@ -1,0 +1,118 @@
+# Ковалик Зиновій Григорович (Зенон) — Research Dossier
+
+**Slug:** `zynovii-kovalyk`
+**Block:** J
+**Tier:** 2
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ковалик Зиновій Григорович; religious/public church form Зенон Ковалик, ЧНІ. Ukrainian Wikipedia via `mcp__sources.query_wikipedia` indexes the article as "Зенон (Ковалик)." [S4]
+- **Pseudonyms / aliases:** о. Зенон Ковалик, Зиновій Ковалик, Zenon Kovalyk, Cenobio Kovalyk in Vatican Spanish rendering.
+- **Born:** 1903-08-18 | Івачів Горішній, Ternopil region, Galicia, Austria-Hungary. Vatican combined beatification biography and UGCC Synod anniversary report agree on the village and year; the UGCC anniversary is explicitly tied to the 120th birthday in 2023. [S1] [S2]
+- **Died:** late June 1941, reported as 1941-06-27 in UGCC commemorative sources | prison no. 2 / Brygidki or Zamartynivska prison context, Lviv | Soviet occupation. Vatican says his body was found at the end of June in a prison cell; UGCC Synod reports witness-based belief that he was killed in prison and the body was not recovered. [S1] [S3]
+- **Family / education key facts:** He entered the Redemptorists, made profession in 1926, was ordained in 1932, and worked as a preacher/missionary before Soviet arrest. [S1] [S4]
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet arrest, imprisonment, and killing during the NKVD prison massacres as Soviet forces retreated from Lviv in June 1941.
+- **When:** Arrested during the night of 1940-12-20/21 according to the Vatican biography; killed at the end of June 1941. [S1]
+- **By whom:** Soviet security authorities/NKVD prison system.
+- **Document references:** Vatican gives the prison as "Bryghidki" in Lviv. UGCC Synod reports prison no. 2 on Zamartynivska Street and notes that later Redemptorist publications gathered witness accounts and archival material. A stable Soviet case number was not retrieved. Source not found for case ID. [S1] [S3]
+- **Mechanism specifics:** The strongest retrieved chronology is the Vatican short biography: Kovalik was arrested in Lviv in December 1940, held in Brygidki, and killed as the Soviets withdrew before the German advance. UGCC Synod gives the later Ukrainian church-memory layer: witnesses said he encouraged prisoners, prayed with them, and was believed to have been crucified in the prison; the same page warns that the body was not found. [S1] [S3]
+
+The dossier therefore uses careful wording. "Killed in Soviet prison during the June 1941 massacre" is grounded. The specific crucifixion detail is attributed to witness testimony preserved in Redemptorist/UGCC memory, not stated as a forensic certainty. [S3]
+
+- **What survived / what was destroyed:** Body and grave: source says not found. Personal voice survives through a first-Liturgy prayer card and later Redemptorist books that include photos, poems, notes, and witness material. [S2] [S3]
+
+## 3. Major works
+
+- `1926` — religious profession in the Congregation of the Most Holy Redeemer. [S1]
+- `1932` — priestly ordination. [S1]
+- `1930s` — Redemptorist mission preaching; specific sermon corpus source not retrieved.
+- `1940` — last months of public ministry before arrest.
+- `1940-1941` — prison witness in Lviv; treated as a martyr record, not a literary work.
+- `2001` — beatification with the Ukrainian martyrs during John Paul II's visit to Ukraine. [S5]
+- `2021` — Redemptorist biography *Якщо така воля Божа, я радо прийму і смерть. Блаженний священномученик Зенон Ковалик, редемпторист* presented in Lviv. [S3]
+- `2023` — 120th birthday commemoration in Івачів Горішній with quotation from his first-Liturgy memorial card. [S2]
+
+## 4. Primary-source quotes
+
+> "О Ісусе! Прийми мене"
+
+Source: beginning of the prayer printed on Kovalik's memorial card for his first Divine Liturgy, quoted by UGCC Synod in the 120th-anniversary report. It is devotional and suitable for B2 learners as a short formula of offering. [S2]
+
+> "Якщо така воля Божа, я радо прийму і смерть."
+
+Source: title of the 2021 Redemptorist biography as quoted in UGCC Synod coverage. Treat as a recorded-speech title until the book itself is consulted. [S3]
+
+## 5. Language register
+
+- **Register:** Redemptorist, devotional, prison-witness, hagiographic.
+- **CEFR readiness for full reading:** B2 for short prayers; C1 for institutional martyrology.
+- **Lexicon notes:** `редемпторист`, `священномученик`, `мучеництво`, `тюрма`, `беатифікація`, `засвідчення`.
+- **Stylistic features:** Prayer-card language uses repetitive petition and sacrificial imagery. Later biographies use memory vocabulary that learners must separate from evidentiary language.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The broad fact of Soviet prison death is stable in retrieved sources; the exact method of killing relies on witness testimony and hagiographic transmission.
+- **What gets simplified in popular memory:** The crucifixion story can eclipse his Redemptorist formation, preaching, and role among prisoners. Curriculum prose should preserve both the grounded chronology and the testimony layer.
+- **Where modern Russian disinformation attacks them:** Soviet/Russian framings minimize NKVD prison massacres or recode church martyrs as political enemies. The dossier uses "Soviet security authorities" and does not repeat criminalizing labels as neutral.
+- **Polish / Jewish / other-perspective considerations:** Lviv prison massacre context includes many victim groups; this dossier only covers Kovalik and does not generalize beyond retrieved sources.
+- **Pedagogical caution:** Use "according to witness testimony" for the crucifixion detail unless a forensic or archival document is later retrieved.
+- **Source-balance note:** The Vatican entry is terse but strong for birth, arrest, prison, and death chronology. The UGCC pages add Ukrainian-language commemoration and recorded voice, but they are intentionally devotional. A Phase 2 writer should keep both: Vatican for the hard timeline, UGCC/Redemptorist material for memory, prayer, and community reception.
+
+## 7. Cross-track links
+
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ -- NOT existing files):**
+  - Bio links to Lviv prison massacres of June 1941, Redemptorist martyrs, Ivan Ziatyk, Mykola Charnetskyi, and UGCC beatification memory.
+- **Potential LIT additions surfaced by this research:**
+  - A devotional-register reading from his first-Liturgy card if a rights-cleared image or edition is obtained.
+  - A short advanced activity can ask learners to distinguish three registers in the same dossier: Vatican institutional biography, parish commemoration, and witness testimony. That supports anti-hallucination habits because the same death is not sourced with the same evidentiary strength in each register.
+
+## 8. Naming-canonical
+
+- **Slug:** `zynovii-kovalyk`
+- **EN canonical (BGN/PCGN 2010):** Zynovii Kovalyk; church/public alias Zenon Kovalyk.
+- **UA canonical (with patronymic):** Ковалик Зиновій Григорович; religious form Зенон Ковалик.
+- **Aliases (track these for `aliases:` YAML field):** Зенон (Ковалик), о. Зенон Ковалик, Zenon Kovalyk, Cenobio Kovalyk.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Zinovii Kovalyk through Russian spelling, Zenon Kovalyuk (FORBIDDEN unless archival metadata).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons or Redemptorist image candidate; individual license not verified.
+- **Backup candidates:** UGCC Synod anniversary photos from Івачів Горішній; rights not established.
+- **If no PD/CC portrait exists:** Use a rights-cleared image of the church in Івачів Горішній or a Redemptorist memorial icon.
+- **Era-appropriate context image:** Lviv prison memorial image, only with explicit license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, combined biography of Mykola Carneckyj and 24 companions, section "Cenobio Kovalyk" | https://www.vatican.va/news_services/liturgy/documents/ns_lit_doc_20010627_carneckyj_sp.html | accessed 2026-05-30
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/documents/20010626_beatif_ucraina_en.html | accessed 2026-05-30
+
+**Tier 2 (institutional):**
+- UGCC Synod, "В Івачеві Горішньому відбулося святкування 120-річчя..." | https://synod.ugcc.ua/data/v-ivachevi-gorishnomu-vidbulosya-svyatkuvannya-120-richchya-vid-dnya-narodzhennya-blazhennogo-zenona-kovalyka-12858/ | accessed 2026-05-30
+- UGCC Synod, "У Львові презентували книги про блаженних новомучеників редемптористів" | https://synod.ugcc.ua/data/u-lvovi-prezentuvaly-knygy-pro-blazhennyh-novomuchenykiv-redemptorystiv-6580/ | accessed 2026-05-30
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia, "Зенон (Ковалик)," via `mcp__sources.query_wikipedia` | accessed 2026-05-30
+
+**Primary-source documents accessed:**
+- Prayer-card quotation via UGCC Synod. Full NKVD file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] NKVD prison-killing claim grounded
+- [x] Witness-only details labeled
+- [x] No invented body recovery or grave
+- [x] Existing paths verified
+- [x] Russian-imperial forms confined to naming metadata


### PR DESCRIPTION
## Summary

Adds 8 Phase-1 Bio research dossiers for Epic #2309 batch 7, excluding Block G / politically charged military figures.

## Figures

- `klymentii-sheptytskyi` — Block J — Tier 1/2: Vatican beatification page; UGCC Synod biography; Yad Vashem Collections.
- `zynovii-kovalyk` — Block J — Tier 1/2: Vatican Ukrainian martyrs biography; UGCC Synod Redemptorist/120th-anniversary pages.
- `teodor-romzha` — Block J — Tier 1/2: Vatican Romzha biography; UGCC Synod bishop profile.
- `yevhen-hutsalo` — Block E — Tier 1/2: Encyclopedia of Modern Ukraine; retrieved Grade 5 textbook excerpt via `mcp__sources.search_text`.
- `ivan-drach` — Block E — Tier 1/2: Encyclopedia of Modern Ukraine; eKMAIR Dovzhenko Studio transcript record.
- `leonid-pliushch` — Block E — Tier 1/2: Encyclopedia of Modern Ukraine; KHPG Virtual Museum biography.
- `valentyn-moroz` — Block E — Tier 1/2: Encyclopedia of Modern Ukraine; KHPG Virtual Museum biography; PNU declassified trial-materials page.
- `serhii-paradzhanov` — Block E — Tier 1/2: Encyclopedia of Modern Ukraine; Klassiki `Shadows of Forgotten Ancestors` film page.

## Validation

- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py`
- Final line: `No fabricated Existing cross-track plan paths found.`
- `git diff --check` clean before commit.
- `scripts/audit/lint_agent_trailer.py` passed after commit.

## Source-gap notes

No selected figure is left without an adequate Tier 1/2 source pack for the core chronology. Several dossiers explicitly mark unretrieved archival case IDs or full trial files as `source not found` rather than inventing them.
