### PR TITLE
feat(bio): 5 Phase-1 research dossiers — batch 9 tail (#2309)

### DIFF
--- a/docs/research/bio/ivan-ziatyk.md
+++ b/docs/research/bio/ivan-ziatyk.md
@@ -1,0 +1,129 @@
+# Зятик Іван — Research Dossier
+
+**Slug:** `ivan-ziatyk`
+**Block:** J
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Зятик Іван. Patronymic in retrieved official sources: source not found.
+- **Pseudonyms / aliases:** о. Іван Зятик; Blessed Ivan Ziatyk; Ivan Ziatyk; Іван Зятик, ЧНІ.
+- **Born:** 1899-12-26 | Одрехово near Сянок, now Poland | Austria-Hungary / Galicia. UGCC Synod article states the date through the 121st anniversary in 2020 and names the village.
+- **Died:** 1952-05-17 | prison hospital of Ozerlag / Озерний лагер no. 7, Bratsk area, Irkutsk oblast, RSFSR | Soviet forced-labor camp system. UGCC Synod gives this death date and describes the prison-hospital death.
+- **Family / education key facts:** Ukrainian Greek Catholic priest and Redemptorist. Professor of dogmatic theology and Scripture in the Redemptorist seminary at Holosko from 1937; monastery superior roles during 1941-1946; took over vicar/protohegumen responsibilities after Йосиф де Вохт's deportation. Sources: UGCC Synod and Vatican beatification list.
+
+## 2. Oppression mechanism
+
+- **What happened:** Monastic confinement under surveillance, arrest, interrogations/torture, Soviet sentence, transfer to Ozerlag, death after beatings and illness.
+- **When:** Redemptorists gathered/constrained at Holosko in spring 1946; moved to Univ on 1948-10-17; Зятик arrested 1950-01-05; warrant issued 1950-01-20; final sentence 1951-11-21; died 1952-05-17.
+- **By whom:** Soviet MGB/KGB security environment and МВД camp system. UGCC Synod's testimony uses "кагебісти" for interrogators; formal 1950 warrant was from the Ministry of State Security administration.
+- **Document references:** UGCC Synod cites the charge under Articles 20-54-1'a and 54-10 part 2 of the Criminal Code of the Ukrainian SSR: "сприяння учасникам антирадянської націоналістичної організації та антирадянська агітація." Exact archival case number: source not found.
+- **Mechanism specifics:** After the Soviet attack on the UGCC hierarchy, Redemptorists were concentrated in one monastery under special supervision. The Synod article says security agents checked the monks several times a week and pressured them to abandon their vocation. After the Belgian superior Йосиф де Вохт was deported, Зятик became a senior Redemptorist leader and a vicarial figure, making him a target. He was arrested in January 1950, interrogated and tortured, and sentenced in Kyiv in November 1951 to ten years. His assigned camp was Ozerlag no. 7 near Bratsk.
+
+UGCC Synod reports eyewitness testimony that he refused to sign conversion to Orthodoxy, even when threatened with harm to relatives. The same account says he was beaten, doused with water, left in Siberian frost, and died from the consequences; it also reports Soviet medical wording of myocarditis, arteriosclerosis, cirrhosis, pleuritis, and cachexia. Teach the Soviet medical formula as part of the file record, not as an exoneration of violence.
+
+- **What survived / what was destroyed:** His direct writings are not prominent in retrieved sources; his witness survived through Redemptorist memory, UGCC beatification process, and Vatican recognition. Soviet records reduced religious fidelity to anti-Soviet "agitation."
+
+## 3. Major works
+
+- `1935` — entry into the Redemptorist novitiate, per UGCC Synod.
+- `1936` — assignment to the Stanislaviv monastery of Mother of Perpetual Help.
+- `1937` — professor of dogmatic theology and Scripture at the Redemptorist seminary in Holosko.
+- `1941-1944` — temporary superior of the Ternopil monastery of the Dormition.
+- `1944-1946` — superior of the Zboiska monastery of Mother of Perpetual Help, where the Redemptorist gymnasium-juvenate operated.
+- `1948` — receives vicar/protohegumen authority after Йосиф де Вохт's deportation, per UGCC Synod.
+- `1950-1952` — imprisonment and martyrdom.
+- `2001` — beatified by Pope John Paul II in Lviv, per UGCC Synod and Vatican.
+
+## 4. Primary-source quotes
+
+> "Ні! Цього я не зроблю."
+
+Source: testimony of Ярослав Юрчак in the UGCC Synod article, recounting Зятик's refusal to sign acceptance of Orthodoxy under pressure. This is recorded speech in a witness account, not a signed text; use with attribution.
+
+> "Божа воля."
+
+Source: same witness account in the UGCC Synod article, after security officers threatened relatives. Pedagogically, this is useful only with context; do not turn it into sentimental hagiography detached from coercion.
+
+No longer written Ukrainian text by Зятик himself was retrieved in this pass. Phase 2 should search Redemptorist archives for letters, sermons, or seminary notes.
+
+## 5. Language register
+
+- **Register:** Ecclesiastical, witness testimony, Soviet legal-bureaucratic.
+- **CEFR readiness for full reading:** B2 for adapted biography; C1 for official church prose and Soviet charge language.
+- **Lexicon notes:** `редемпторист`, `єромонах`, `протоігумен`, `УГКЦ`, `вікарій`, `антирадянська агітація`, `Озерлаг`, `беатифікація`.
+- **Stylistic features:** The main teaching challenge is code-switching between church vocabulary and repressive legal vocabulary.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Exact reconstruction of interrogation/camp violence; how much weight to give witness testimony versus Soviet medical paperwork; how to recover his intellectual life, not only martyrdom.
+- **What gets simplified in popular memory:** "Redemptorist martyr" can erase his teaching and administrative responsibilities. He was a professor and superior before becoming a victim.
+- **Where modern Russian disinformation attacks them:** Soviet categories such as "anti-Soviet nationalist organization" criminalized religious leadership and Ukrainian church continuity. Do not repeat these as neutral descriptors.
+- **Other-perspective considerations:** His birthplace is now in Poland, near Sanok. Use current geography accurately and avoid implying modern border identities back onto 1899 without explanation.
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml`
+  - `curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/povoienne-vidbudova.yaml`
+  - `curriculum/l2-uk-en/plans/hist/tomos.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/kulturna-rezystentsiia.yaml`
+- **Existing B2 modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/b2/religion-in-ukraine.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Миколай Чарнецький, Зиновій Ковалик, Йосиф Сліпий, and Redemptorist martyr network.
+  - Grammar/reading module on Soviet legal articles versus church witness testimony.
+- **Potential LIT additions surfaced by this research:**
+  - None until primary letters/sermons are retrieved.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-ziatyk`
+- **EN canonical (BGN/PCGN 2010):** Ivan Ziatyk
+- **UA canonical:** Зятик Іван
+- **Aliases (track these for `aliases:` YAML field):** о. Іван Зятик; Blessed Ivan Ziatyk; Ivan Ziatyk, C.Ss.R.; Іван Зятик, ЧНІ
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ivan Zyatyk if sourced through Russian; Иван Зятык / Иван Зятик (FORBIDDEN except archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** UGCC Synod article portrait | https://synod.ugcc.ua/data/26-grudnya-mynae-121-rik-vid-dnya-narodzhennya-svyashchennomuchenyka-ivana-zyatyka-4837/ | rights unclear.
+- **Backup candidates:** Vatican/UGCC beatification icon or Redemptorist materials, rights to verify.
+- **If no PD/CC portrait exists:** use text card or rights-cleared icon only after permission.
+- **Era-appropriate context image:** Redemptorist monastery / Holosko or Univ context image if public domain or institutional permission exists.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/saints/20010626_beatif_ucraina_en.html | accessed 2026-05-30.
+- Vatican, John Paul II, Homily at Divine Liturgy with Beatifications, Lviv, 2001-06-27 | https://www.vatican.va/content/john-paul-ii/en/homilies/2001/documents/hf_jp-ii_hom_20010627_ucraina-beat.html | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Синод Єпископів УГКЦ, "26 грудня минає 121 рік від дня народження священномученика Івана Зятика" | https://synod.ugcc.ua/data/26-grudnya-mynae-121-rik-vid-dnya-narodzhennya-svyashchennomuchenyka-ivana-zyatyka-4837/ | accessed 2026-05-30.
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia search via `mcp__sources.query_wikipedia` returned no article in cache; no T3 fact used without T1/T2 corroboration.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grade 11 history textbook retrievals via `mcp__sources.search_text` on liquidation of the UGCC and religious dissidence | accessed 2026-05-30.
+
+**Primary-source documents accessed:**
+- Witness direct-speech account in UGCC Synod article.
+- Exact Soviet archival case number: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet charges quoted as charges, not fact
+- [x] No fabricated case number
+- [x] Border/geography handled explicitly
+- [x] Russian-imperial transliterations confined to aliases
+- [x] Existing paths verified

--- a/docs/research/bio/mykyta-budka.md
+++ b/docs/research/bio/mykyta-budka.md
@@ -1,0 +1,131 @@
+# Будка Микита Михайлович — Research Dossier
+
+**Slug:** `mykyta-budka`
+**Block:** J
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Будка Микита Михайлович. ESU article title uses "Никита"; this dossier uses modern Ukrainian "Микита" while recording the ESU form as an alias.
+- **Pseudonyms / aliases:** Никита Будка; Nykyta Budka; Mykyta Budka; Nikita Budka; Nicetas Budka.
+- **Born:** 1877-06-07 | Добромірка, нині Тернопільська область | Kingdom of Galicia and Lodomeria, Austria-Hungary. ESU and UGCC Synod agree.
+- **Died:** ESU gives 1949-10-01 | Караганда, Kazakh SSR. UGCC Synod gives 1949-10-01 in one paragraph and also cites Kazakhstan confirmation of death on 1949-09-28. The discrepancy must be flagged in Phase 2 rather than silently harmonized.
+- **Family / education key facts:** Brother of Дмитро Будка, per ESU. Studied law in Lviv, theology in Lviv and Innsbruck, and was ordained by Metropolitan Andrey Sheptytsky in 1905. Appointed in 1912 as first Ukrainian Catholic bishop in Canada; returned to Europe in 1927/1928. Sources: ESU, UGCC Synod, Vatican beatification list, IEU/MCP context.
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest, NKVD investigation, prison, sentence to forced labor, deportation to Karaganda/KarLag, death in custody.
+- **When:** Arrested 1945-04-11 in Lviv; sentenced in 1946 to eight years; died 1949-09-28 or 1949-10-01 in/near Karaganda.
+- **By whom:** NKVD during the Soviet liquidation campaign against the Ukrainian Greek Catholic Church.
+- **Document references:** ESU states he was arrested by NKVD in Lviv on 1945-04-11 and sentenced in 1946 to eight years of hard labor. UGCC Synod states he was accused of teaching in an underground seminary, serving memorial prayers for victims of Bolshevik terror in 1939, and agitating for separation of Ukraine from the USSR. Exact case file number: source not found.
+- **Mechanism specifics:** The retrieved textbook sources frame the broader campaign: Soviet authorities arrested the higher Greek Catholic hierarchy in April 1945, created an NKVD-controlled "ініціативна група," and staged the noncanonical 1946 Lviv council to force the UGCC into the Russian Orthodox Church. Будка was part of the arrested episcopal leadership. UGCC Synod describes torture, humiliation, hunger, an eight-year sentence, transfer to KarLag near Karaganda, and heavy physical labor. ESU corroborates arrest, sentence, Kazakhstan exile, and 2001 beatification.
+
+The dossier must avoid two distortions: first, treating his Canadian work as only diaspora church administration; second, treating his death as a vague "camp hardship." The retrieved sources identify a state attack on the UGCC hierarchy, detention by NKVD, forced-labor camp, and death before the end of the sentence.
+
+- **What survived / what was destroyed:** His Canadian institutional legacy survived in parishes, schools, bursae, publications, and commemoration. His grave location remains uncertain in UGCC reporting; the body/remains were not recovered in a normal public burial.
+
+## 3. Major works
+
+- `1907` — Galician branch of the St. Raphael emigrant-aid society, organizational work for emigrants, per ESU.
+- `1910-1912` — founder/editor of *Емігрант*, monthly for Ukrainian emigrants, per ESU.
+- `1912` — consecration as first Ukrainian Catholic bishop in Canada; mission base in Winnipeg, per ESU/UGCC Synod/Vatican.
+- `1913` — Sobor of Ukrainian Catholic priests in Canada, per ESU.
+- `1910s` — pastoral letters to Canadian Ukrainians; one 1914 letter became controversial in wartime Canada, per Encyclopedia of Ukraine/web retrieval.
+- `1910s-1920s` — parish, church, school, orphanage, bursary, and press-building in Canada, per ESU and UGCC Synod.
+- `1928-1945` — auxiliary/vicar and church administrator roles in Lviv; work around Zarvanytsia restoration, per ESU.
+- `2001` — beatified as one of Mykola Charnetskyi and 24 companion martyrs, per Vatican.
+
+## 4. Primary-source quotes
+
+> "old Fatherland"
+
+Source: Encyclopedia of Ukraine summary of his 1914 pastoral letter says he called reservists to defend the "old Fatherland" of Austria-Hungary. This English quotation is a red-flag teaching item: it shows why the letter became politically dangerous in Canada, but Phase 2 should retrieve the Ukrainian original before classroom use.
+
+> "source not found"
+
+A second verified first-person Ukrainian quote from Будка's own writing was not retrieved in the available T1/T2/web pass. The UGCC Synod article quotes *Душпастир* praising him and reports accusations against him, but that is not Будка's own recorded speech.
+
+For pedagogy, use his biography first as institutional action rather than slogan: building churches/schools in Canada, then refusing Soviet separation from Rome.
+
+## 5. Language register
+
+- **Register:** Ecclesiastical, pastoral, institutional, legal-repressive.
+- **CEFR readiness for full reading:** B2 for adapted biography; C1 for pastoral-letter excerpts and church history.
+- **Lexicon notes:** `єпископ`, `УГКЦ`, `еміграція`, `пастирський лист`, `рукоположення`, `каторжна праця`, `Карлаг`, `беатифікація`, `мученик`.
+- **Stylistic features:** Church titles and historical jurisdictions are dense; lesson writers should pre-teach ecclesiastical hierarchy before using primary texts.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** His 1914 Canadian pastoral letter and its political consequences; exact death date in camp records; balance between diaspora leadership and martyrdom in a short bio.
+- **What gets simplified in popular memory:** "First bishop in Canada" can overshadow the later NKVD martyrdom. Conversely, "martyr" can flatten the difficult Canadian wartime controversy.
+- **Where modern Russian disinformation attacks them:** Soviet propaganda framed the UGCC hierarchy as anti-Soviet/nationalist and used forced "reunion" language for the 1946 liquidation. The dossier treats those phrases as Soviet coercive vocabulary.
+- **Polish / Canadian / other-perspective considerations:** In Canada, the 1914 letter sits inside wartime internment, loyalty suspicion, and immigrant vulnerability. Teach this as a Canadian state and imperial-war context, not as a simple personal error story.
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml`
+  - `curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml`
+  - `curriculum/l2-uk-en/plans/hist/povoienne-vidbudova.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Existing B2 modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/b2/religion-in-ukraine.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Йосиф Сліпий, Андрей Шептицький, Миколай Чарнецький, Григорій Хомишин.
+  - Canada diaspora module on migration, church infrastructure, and wartime internment.
+- **Potential LIT additions surfaced by this research:**
+  - None until Ukrainian primary pastoral-letter excerpts are retrieved.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykyta-budka`
+- **EN canonical (BGN/PCGN 2010):** Mykyta Budka
+- **UA canonical (with patronymic):** Будка Микита Михайлович
+- **Aliases (track these for `aliases:` YAML field):** Будка Никита; Nykyta Budka; Nikita Budka; Nicetas Budka
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Никита Будка as default body form; Nikita Budka as default body form (allowed only in source titles/metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Vatican/UGCC beatification portraits or Ukrainian Catholic eparchy image; license must be verified before reuse.
+- **Backup candidates:** ESU article portrait | https://esu.com.ua/article-36541 | rights require verification; UGCC Synod image | https://synod.ugcc.ua/data/vladyka-nykyta-budka-3395/ | rights unclear.
+- **If no PD/CC portrait exists:** use a rights-cleared icon-style image only if ecclesiastical licensing is explicit; otherwise use text-only card.
+- **Era-appropriate context image:** Winnipeg Ukrainian Catholic church / early diaspora parish image if public domain.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Будка Никита" | https://esu.com.ua/article-36541 | accessed 2026-05-30.
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/saints/20010626_beatif_ucraina_en.html | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Синод Єпископів УГКЦ, "Владика Никита Будка" | https://synod.ugcc.ua/data/vladyka-nykyta-budka-3395/ | accessed 2026-05-30.
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Никита (Будка)" via `mcp__sources.query_wikipedia` | accessed 2026-05-30.
+- Encyclopedia of Ukraine, "Budka, Nykyta" | accessed via web search result | accessed 2026-05-30.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grade 11 history textbook retrievals via `mcp__sources.search_text` on ліквідація УГКЦ, NKVD-controlled "ініціативна група," and catacomb church | accessed 2026-05-30.
+
+**Primary-source documents accessed:**
+- Exact NKVD case number: source not found.
+- Ukrainian original of 1914 pastoral letter: source not found in this pass.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet "возз'єднання" frame treated as coercive
+- [x] Death-date discrepancy flagged
+- [x] No fabricated case number
+- [x] Russian-imperial transliterations confined to aliases
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms

--- a/docs/research/bio/petro-verhun.md
+++ b/docs/research/bio/petro-verhun.md
@@ -1,0 +1,137 @@
+# Вергун Петро Іванович — Research Dossier
+
+**Slug:** `petro-verhun`
+**Block:** J
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Вергун Петро Іванович.
+- **Pseudonyms / aliases:** о. Петро Вергун; Blessed Petro Verhun; Petro Verhun; Петро Вергун.
+- **Born:** 1890-11-18 | Городок, нині Львівська область | Kingdom of Galicia and Lodomeria, Austria-Hungary. ESU and UGCC Synod agree.
+- **Died:** 1957-02-07 | Ангарське, Красноярський край / ESU gives "с-ще Ангарське Краснодар. краю, РФ" but UGCC Synod states Ангарське Красноярського краю and burial on the Angara River. This geographic discrepancy is flagged; Angara context supports Krasnoyarsk/Angara, not Krasnodar.
+- **Family / education key facts:** UGCC priest, doctor of philosophy, Ukrainian Galician Army veteran, pastor for Ukrainian Catholics in Berlin, later Apostolic Visitor in Germany. Ordained by Metropolitan Andrey Sheptytsky in October 1927. Sources: ESU, UGCC Synod, Vatican.
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrest by Soviet security after the capture of Berlin, deportation to the USSR, prison/GULAG sentence, forced labor, post-release exile, death in exile.
+- **When:** UGCC Synod says arrested 1945-06-21; ESU says 1945-06-22. In 1946 he was sentenced in Kyiv to eight years. Released from forced labor 1952-06-22; in exile from 1953; died 1957-02-07.
+- **By whom:** NKVD / Soviet security organs and Soviet courts/camp system.
+- **Document references:** ESU documents arrest by NKVD, eight-year sentence, and Siberian imprisonment until 1955. UGCC Synod gives the 1946 Kyiv sentence to eight years in GULAG prisons. Exact case number: source not found.
+- **Mechanism specifics:** Вергун's danger to Soviet authorities lay in transnational church infrastructure. He remained in Berlin as pastor and Apostolic Visitor for Ukrainian Catholics in Germany. UGCC Synod preserves his refusal to leave Berlin while Ukrainian faithful remained there. After Soviet forces captured Berlin, he was arrested and deported. The sentence and camp/exile path severed the Ukrainian Catholic diaspora leadership line from its Berlin base.
+
+His death should be described as the end of a repressive sequence, not an isolated illness. The retrieved sources support arrest, conviction, forced labor, release, exile, surgery in 1954, and death in 1957. In 2004, UGCC sources report his relics were returned to Ukraine and transferred to the cathedral in Stryi.
+
+- **What survived / what was destroyed:** His pastoral texts, historical works on Eastern church questions, and memory in the Ukrainian Catholic community in Germany survived. Soviet repression destroyed his Berlin ministry and kept him from normal pastoral life after release.
+
+## 3. Major works
+
+- `1909` — volunteer in the Austrian army, per ESU.
+- `1919-1920` — service in the Ukrainian Galician Army, per ESU.
+- `1926` — graduation from the Ukrainian Free University in Prague, per ESU.
+- `1927` — seminary completion and priestly ordination by Andrey Sheptytsky.
+- `1927` — begins ministry in Berlin.
+- `1929` — pastor of Ukrainian Catholics in Berlin.
+- `1937` — receives dignity of prelate, per ESU.
+- `1940` — priest for Ukrainian Catholics in Berlin; later Apostolic Visitor in Germany, per ESU.
+- `1940s` — *Послання Апостольського Візитатора до українців-католиків візантійсько-слов'янського обряду у Великонімеччині*, listed by ESU.
+- `1940s` — *Geschichte der Union im Ostslawischen Raum*, historical study listed by ESU.
+- `1940s` — *Die Orientalischen Riten und Kirchlichen Gemeinschaften*, church-history study listed by ESU.
+- `2001` — beatified by Pope John Paul II in Lviv, per Vatican.
+- `2004` — relics returned to Ukraine and transferred to Stryi cathedral, per UGCC Synod.
+
+## 4. Primary-source quotes
+
+> "Поки хоча б один українець в Берліні, я залишуся тут."
+
+Source: UGCC Synod, "27 червня Українська Греко-Католицька Церква вшановує пам'ять новомучеників," reporting Вергун's statement when he refused to move his seat to Munich. This is the key pastoral-responsibility quote.
+
+> "Вони є прикладом, на який слід споглядати..."
+
+Source: Pope Francis's 2019 words to UGCC representatives, quoted in the UGCC Synod Berlin academy report about Вергун. This is not Вергун's own speech, so it must not count as a primary quote from him; it can support legacy framing only.
+
+A second verified direct quote from Вергун's own writings was not retrieved. ESU lists his pastoral message and historical studies, so Phase 2 should seek the text of the *Послання Апостольського Візитатора* before classroom writing.
+
+## 5. Language register
+
+- **Register:** Ecclesiastical, diaspora-administrative, historical-theological, Soviet legal-repressive.
+- **CEFR readiness for full reading:** B2 for adapted biography; C1-C2 for his German-language church-history studies and pastoral documents.
+- **Lexicon notes:** `апостольський візитатор`, `візантійсько-слов'янський обряд`, `прелат`, `УГА`, `ГУЛАГ`, `заслання`, `беатифікація`.
+- **Stylistic features:** His source base crosses Ukrainian and German. Lesson writers should not use Russian mediation for German/UGCC terms.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Exact arrest date, precise Soviet custody route, and the ESU/UGCC discrepancy around "Краснодарський" versus "Красноярський" краи. The Angara River burial context points to the Siberian Angara geography, so the dossier flags rather than normalizes the mismatch.
+- **What gets simplified in popular memory:** "Priest-martyr" can erase his prewar intellectual and diaspora-administrative profile. He was also a scholar of church union and an organizer for Ukrainians in Germany.
+- **Where modern Russian disinformation attacks them:** Soviet security categories treated independent Ukrainian Catholic pastoral care as political disloyalty. Do not translate the case into "foreign collaboration" without naming Soviet coercion and occupation.
+- **Other-perspective considerations:** Berlin context requires attention to Ukrainian displaced persons, wartime Germany, and postwar Soviet reach into Central Europe. Avoid a simple east/west morality tale; focus on pastoral duty to a vulnerable diaspora community.
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml`
+  - `curriculum/l2-uk-en/plans/bio/josyf-slipyj.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml`
+  - `curriculum/l2-uk-en/plans/hist/povoienne-vidbudova.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/hreko-katolytska-tserkva.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`
+- **Existing B2 modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/b2/religion-in-ukraine.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Андрей Шептицький, Йосиф Сліпий, Омелян Ковч, Миколай Чарнецький.
+  - Diaspora/religion module on Ukrainian Catholics in Germany.
+- **Potential LIT additions surfaced by this research:**
+  - If the pastoral message is retrieved, use an excerpt for C1 church/diaspora rhetoric.
+
+## 8. Naming-canonical
+
+- **Slug:** `petro-verhun`
+- **EN canonical (BGN/PCGN 2010):** Petro Verhun
+- **UA canonical (with patronymic):** Вергун Петро Іванович
+- **Aliases (track these for `aliases:` YAML field):** о. Петро Вергун; Blessed Petro Verhun; Petro Werhun in some German/Latin-script contexts
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Пётр Вергун; Pyotr Vergun; Petr Vergun as default body form (FORBIDDEN except archival metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** UGCC Synod image on the 27 June new martyrs page | https://synod.ugcc.ua/data/27-chervnya-ukraynska-greko-katolytska-tserkva-vshanovue-pamyat-novomuchenykiv-istoriy-svyatosti-9451/ | rights unclear.
+- **Backup candidates:** ESU article image if present | https://esu.com.ua/article-33516 | rights require verification; Berlin academy UGCC article images | rights unclear.
+- **If no PD/CC portrait exists:** use text card or request UGCC/eparchy permission for beatification portrait.
+- **Era-appropriate context image:** Ukrainian Catholic church/community in Berlin, or Stryi cathedral relics image, only if license allows.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Вергун Петро" | https://esu.com.ua/article-33516 | accessed 2026-05-30.
+- Vatican, "Beatifications during the Pastoral Visit of His Holiness John Paul II in Ukraine" | https://www.vatican.va/news_services/liturgy/saints/20010626_beatif_ucraina_en.html | accessed 2026-05-30.
+- Vatican, John Paul II, Homily at Divine Liturgy with Beatifications, Lviv, 2001-06-27 | https://www.vatican.va/content/john-paul-ii/en/homilies/2001/documents/hf_jp-ii_hom_20010627_ucraina-beat.html | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Синод Єпископів УГКЦ, "27 червня Українська Греко-Католицька Церква вшановує пам'ять новомучеників" | https://synod.ugcc.ua/data/27-chervnya-ukraynska-greko-katolytska-tserkva-vshanovue-pamyat-novomuchenykiv-istoriy-svyatosti-9451/ | accessed 2026-05-30.
+- Синод Єпископів УГКЦ, "У Берліні відбулася урочиста Академія..." | https://synod.ugcc.ua/data/u-berlini-vidbulasya-urochysta-akademiya-z-nagody-80-littya-intronizatsiy-blazhennogo-petra-verguna-apostolskym-vizytatorom-v-nimechchyni-7279/ | accessed 2026-05-30.
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Петро (Вергун)" via `mcp__sources.query_wikipedia` | accessed 2026-05-30.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grade 11 history textbook retrievals via `mcp__sources.search_text` on Soviet liquidation of the UGCC and religious dissidence | accessed 2026-05-30.
+
+**Primary-source documents accessed:**
+- Вергун's direct statement reported by UGCC Synod.
+- Text of *Послання Апостольського Візитатора*: source not found in this pass.
+- Exact NKVD/GULAG case number: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] Soviet repression named specifically
+- [x] Geography discrepancy flagged
+- [x] No fabricated case number
+- [x] Russian-imperial transliterations confined to aliases
+- [x] Existing paths verified

--- a/docs/research/bio/veniamin-kushnir.md
+++ b/docs/research/bio/veniamin-kushnir.md
@@ -1,0 +1,140 @@
+# Кушнір Веніамін Володимирович — Research Dossier
+
+**Slug:** `veniamin-kushnir`
+**Block:** E
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Кушнір Веніамін Володимирович.
+- **Pseudonyms / aliases:** Веніамін Кушнір; Veniamin Kushnir; Benjamin/Veniamyn Kushnir in occasional English-facing references.
+- **Born:** 1926-01-07 | с. Купин, Кам'янець-Подільський повіт / нині Городоцький район Хмельницької області | Ukrainian SSR, USSR. ESU gives Купин; UARTLIB gives Рудка, Хмельницька область. This place-name discrepancy is flagged for Phase 2 verification.
+- **Died:** 1992-06-19 | Київ | independent Ukraine. ESU and Ukrainian Wikipedia search result agree.
+- **Family / education key facts:** Painter, not poet in retrieved Tier 1/2 sources. Graduated from the Lviv Institute of Applied and Decorative Art in 1953; teachers included Йосип Бокшай, Іван Гуторов, and Роман Сельський. Worked at the Dnipropetrovsk Art School in 1953-1955 and moved to Kyiv in 1956. Sources: ESU, UARTLIB, Ukrainian Wikipedia search via MCP.
+
+## 2. Oppression mechanism
+
+- **What happened:** Ideological harassment, surveillance pressure, professional marginalization, and narrowing of exhibition/public activity.
+- **When:** Early 1960s activity in the Club of Creative Youth; 1970s harassment and persecution by authorities, per ESU; broader closure of "Сучасник" after the 1963 ideological campaign, per textbook retrieval.
+- **By whom:** Soviet party-ideological authorities and the KGB security environment. Personal case number: source not found.
+- **Document references:** ESU says he distributed and reproduced самвидав and in the 1970s suffered "цькування і переслідування з боку влади." It does not provide a file number. The grade 11 textbook source describes the state closure of "Сучасник" and other шістдесятники cells after ideological attacks. Exact KGB file: source not found.
+- **Mechanism specifics:** Кушнір's load-bearing oppression mechanism is cultural and professional rather than a retrieved prison biography. ESU identifies him as a participant in the rights movement, organizer of the Club of Creative Youth "Сучасник," head of the artists' section, and distributor/copier of самвидав. UARTLIB corroborates him as an active шістдесятник artist and says the repressive wave of the next decade forced him into long isolation. Grade 11 textbook retrieval supplies the broader mechanism: free artistic activity outside socialist realism was treated as dangerous; clubs were closed; those who did not abandon civic positions entered the machinery of repression.
+
+This dossier therefore avoids the false precision of a missing criminal case. The specific claim that can be taught is: his art and civic labor were pushed away from public cultural space by the Soviet system because he belonged to the шістдесятники network and helped circulate forbidden texts.
+
+- **What survived / what was destroyed:** His paintings, posthumous exhibitions, and the memory work of family/institutions survived. What was damaged was his public presence during life, especially in the 1970s, and access to a full institutional art career.
+
+## 3. Major works
+
+- `1953` — *Б. Хмельницький із військом*, painting, listed by ESU.
+- `1953` — *Універсали Б. Хмельницького*, painting, listed by ESU.
+- `1957` — *З поля*, painting.
+- `1960` — *Плотогони*, painting; one of the large Kyiv-period canvases also noted by UARTLIB.
+- `1961` — *Трембітарі*, painting.
+- `1961` — *Червоні маки*, painting.
+- `1963` — *Дума про О. Довбуша*, painting.
+- `1964` — *Кобза*, painting.
+- `1968` — *Апостол Правди*, painting; title signals Shevchenko-centered civic memory.
+- `1968` — *Та не однаково мені...*, painting; Shevchenko allusion.
+- `1972` — *Зустріч на чужині (Леся Українка)*, painting.
+- `1975` — *Скорботна мати*, painting.
+- `1979` — *Скерцо. Зґвалтована Україна*, painting; explicitly political title in ESU list.
+- `1980` — *Трембіти сумують*, painting.
+- `1991` — *Автопортрет зі свічкою*, painting.
+
+## 4. Primary-source quotes
+
+Direct recorded speech by Кушнір in Tier 1/2 retrieved sources: source not found. ESU, UARTLIB, KPI, Boryviter search, MCP search, and the NAS PDF on шістдесятники supplied biography, work titles, and institutional context, but not two verified first-person statements.
+
+Primary artefact text that can still serve curriculum planning:
+
+> "Та не однаково мені..."
+
+Source: artwork title, ESU list of major works, 1968. The title quotes Shevchenko's civic lexicon and is useful for connecting painting to literature.
+
+> "Скерцо. Зґвалтована Україна"
+
+Source: artwork title, ESU list of major works, 1979. This is not recorded speech, but it is primary title evidence for how national injury enters his visual language.
+
+Phase 2 should search archival exhibition catalogues and the 2017 album *Веніамін Кушнір* for verified first-person quotes before lesson writing.
+
+## 5. Language register
+
+- **Register:** Visual-symbolic, civic, folk-historical; biographical prose around him is art-historical and rights-movement language.
+- **CEFR readiness for full reading:** B1-B2 for adapted biography; B2-C1 for art-critical readings.
+- **Lexicon notes:** `живописець`, `шістдесятник`, `самвидав`, `правозахисний рух`, `цькування`, `переслідування`, `монументально-декоративне мистецтво`, `пейзаж`, `натюрморт`.
+- **Stylistic features:** Paintings use historical, maternal, landscape, and Shevchenko-coded titles. For L2 learners, titles can be introduced before dense art criticism.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The exact geography of birth in public sources; how visible to make his самвидав work compared with his painting; how to place him among better-known шістдесятники artists without reducing him to a supporting name.
+- **What gets simplified in popular memory:** The prompt label "poet" is not supported by retrieved ESU/UARTLIB/MCP sources. He should be taught as a painter, teacher, and rights-movement participant.
+- **Where modern Russian disinformation attacks them:** The common Soviet move was to frame Ukrainian cultural autonomy and non-socialist-realist aesthetics as nationalism or formalism. Use that as context, not as neutral vocabulary.
+- **Other-perspective considerations:** His art draws on Ukrainian historical and folk motifs. Avoid treating folk sources as decorative ethnicity only; in the шістдесятники context, they also functioned as resistance to Russified Soviet cultural uniformity.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/kulturna-rezystentsiia.yaml`
+- **Existing C1 modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/yevhen-hutsalo-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio links to Алла Горська, Віктор Зарецький, Галина Севрук, Опанас Заливаха, Іван Світличний.
+  - Visual-art task on Shevchenko quotations in painting titles: *Та не однаково мені...*.
+- **Potential LIT additions surfaced by this research:**
+  - Pair his Shevchenko-titled works with a B2/C1 lesson on civic quotation in visual culture.
+
+## 8. Naming-canonical
+
+- **Slug:** `veniamin-kushnir`
+- **EN canonical (BGN/PCGN 2010):** Veniamin Kushnir
+- **UA canonical (with patronymic):** Кушнір Веніамін Володимирович
+- **Aliases (track these for `aliases:` YAML field):** Веніамін Кушнір; Veniamyn Kushnir; Benjamin Kushnir
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Veniamin Kushnir as a Russian-language default context; Вениамин Кушнир (FORBIDDEN except archival/Russian-source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ESU portrait at https://esu.com.ua/article-52533 | rights require verification before reuse.
+- **Backup candidates:** UARTLIB artist page image | https://uartlib.org/ukrayinski-hudozhniki/kushnir-veniamin/ | rights unclear; KPI exhibition page for "Стежками України" | https://kpi.ua/640-13 | rights unclear.
+- **If no PD/CC portrait exists:** use a rights-cleared image from a museum catalogue or request permission from estate/institution; otherwise use a text-only bio card.
+- **Era-appropriate context image:** Club of Creative Youth group photo or Museum of Sixtiers context image, only with verified license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Кушнір Веніамін Володимирович" | https://esu.com.ua/article-52533 | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Бібліотека українського мистецтва, "Кушнір Веніамін" | https://uartlib.org/ukrayinski-hudozhniki/kushnir-veniamin/ | accessed 2026-05-30.
+- КПІ ім. Ігоря Сікорського, "Мальовничими стежками України" | https://kpi.ua/640-13 | accessed 2026-05-30.
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia search for "Кушнір Веніамін Володимирович" via `mcp__sources.query_wikipedia` | accessed 2026-05-30.
+
+**Tier 4 (modern scholarly post-1991):**
+- NAS PDF retrieval mentioning Кушнір and the KTYM artists' section | https://files.nas.gov.ua/PublicMessages/Documents/0/2021/08/210826111923150-6270.pdf | accessed 2026-05-30.
+- Grade 11 history textbook retrievals via `mcp__sources.search_text` on Клуб творчої молоді and шістдесятники | accessed 2026-05-30.
+
+**Tier 5 (general web):**
+- Boryviter biography page located by web search but not used for unsupported facts where T1/T2 sufficed.
+
+**Primary-source documents accessed:**
+- ESU-listed artwork titles. First-person primary quotes: source not found in retrieved sources.
+
+---
+
+## Decolonization self-check
+
+- [x] Prompt role mismatch corrected rather than repeated
+- [x] No fabricated arrest/case number
+- [x] Soviet labels treated as repression vocabulary, not neutral fact
+- [x] Existing paths verified
+- [x] Russian-imperial transliterations confined to forbidden aliases

--- a/docs/research/bio/viktor-zaretskyi.md
+++ b/docs/research/bio/viktor-zaretskyi.md
@@ -1,0 +1,136 @@
+# Зарецький Віктор Іванович — Research Dossier
+
+**Slug:** `viktor-zaretskyi`
+**Block:** E
+**Tier:** 1
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Зарецький Віктор Іванович.
+- **Pseudonyms / aliases:** Viktor Zaretskyi; Viktor Zaretsky; Віктор Зарецький.
+- **Born:** 1925-02-08 | Білопілля, нині Сумська область | Ukrainian SSR, USSR. ESU and UINP agree on date and place.
+- **Died:** 1990-08-23 | Київ | Ukrainian SSR, USSR. ESU gives this date and city; Ukrainian Wikipedia via MCP gives the same endpoint.
+- **Family / education key facts:** Husband of Алла Горська, later Майя Григор'єва; father of Олексій Зарецький. Graduated from the Kyiv Art Institute in 1953 in Serhii Hryhoriev's workshop. Member of the Union of Artists of Ukraine from 1956. Sources: ESU, UINP, Ukrainian Wikipedia via `mcp__sources.query_wikipedia`.
+
+## 2. Oppression mechanism
+
+- **What happened:** Political and professional pressure, surveillance environment, and post-1965 dissident solidarity pressure rather than a documented arrest.
+- **When:** 1963 closure/pressure on the Club of Creative Youth; 1965 first wave of arrests of Ukrainian dissidents and the "Лист 139-ти"; 1970 killing of Алла Горська and ensuing intimidation context.
+- **By whom:** Soviet party-ideological bodies and KGB security environment. Exact personal KGB case file number for Зарецький: source not found in retrieved sources.
+- **Document references:** UINP states that Зарецький and Горська signed the "Лист 139-ти" condemning the first arrests of dissidents. ESU identifies him as head of the Club of Creative Youth "Сучасник" from 1963 and as a leader of the шістдесятники. A file identifier for surveillance or interrogation: source not found.
+- **Mechanism specifics:** Зарецький's repression story should not be inflated into imprisonment. Retrieved sources support a different mechanism: the regime narrowed public space for artists who used Ukrainian cultural memory, non-socialist-realist forms, and civic solidarity. Grade 11 textbook retrieval says "Сучасник" held exhibitions outside socialist realism, that authorities saw free шістдесятник creativity as a threat, and that the clubs were closed after the 1963 ideological attack. UINP then places Зарецький and Горська inside that civic network and names his signature under the 1965 protest letter.
+
+The killing of Алла Горська in 1970 belongs to a related but separately documented case. This dossier cites it as context for Зарецький's biography and for cross-links, not as a proven personal criminal case against him. The safest pedagogical frame is "artist under Soviet ideological pressure and dissident-network intimidation," not "arrested dissident."
+
+- **What survived / what was destroyed:** His large body of painting, graphics, pedagogical writing, and the studio lineage survived. The official Soviet art system marginalized the civic context of the work; post-1991 publications and exhibitions restored the шістдесятник frame.
+
+## 3. Major works
+
+- `1955` — *Шахтарі. Зміна*, painting, early industrial-social subject listed by ESU.
+- `1960` — *Вибирання льону (Ланкова П. Сироватко)*, painting; source for later letter about the "льонпункт" visual revelation.
+- `1966` — *Вишневий вітер*, painting, listed by ESU.
+- `1971` — *В. Стус*, portrait; important for the artist's later Стус iconography.
+- `1975` — *Косівський гончар*, painting; folk-craft subject.
+- `1977` — *Білий пароплав*, painting, listed by ESU.
+- `1981` — *Наталка*, painting.
+- `1982` — *Вечірнє катання*, painting.
+- `1986-1988` — pedagogical system *Роздуми біля полотна*, developed in his studio, per ESU.
+- `1988` — *Дерево (Витоки мистецтва)*, painting, listed by ESU.
+- `1989` — *Золотий череп. Дзвони Чорнобиля*, painting.
+- `1990` — *Орач (В. Стус)*, painting, listed by ESU.
+
+## 4. Primary-source quotes
+
+> "Від академічної школи ніколи не відмовлявся."
+
+Source: Віктор Зарецький, quoted in *Пошуки коріння. Листи, нариси, спогади, статті* (ННДІУ, 2009), p. 246 in the PDF text. This keeps the learner from misreading his modernism as a rejection of craft discipline.
+
+> "Для мене у творчості головне — шал емоцій, пристрасть."
+
+Source: same published interview passage in *Пошуки коріння*, p. 246. Pedagogically, this is a short entry into his late decorative style without relying on the reductive label "Ukrainian Klimt."
+
+> "Стус справив на мене величезне враження."
+
+Source: Зарецький interview quoted in *Пошуки коріння*, p. 253. This anchors the Стус portraits in a direct artistic memory rather than a generic dissident-symbol reading.
+
+## 5. Language register
+
+- **Register:** Visual-art discourse, memoir, studio pedagogy, civic-intellectual language.
+- **CEFR readiness for full reading:** B2 for adapted biography and artwork captions; C1 for essays/interviews in *Пошуки коріння*.
+- **Lexicon notes:** `шістдесятник`, `соціалістичний реалізм`, `монументальне мистецтво`, `сецесія`, `орнаментика`, `самвидав`, `Лист 139-ти`.
+- **Stylistic features:** In art lessons, emphasize concrete visual vocabulary: color, line, ornament, portrait, memory, studio. Avoid overloading learners with art-historical period labels before B2.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** How far to treat Зарецький as a dissident versus a civic-minded artist in a dissident milieu; how to describe the late "Klimt" / Secession influence without erasing Ukrainian folk sources; how to read the Krasnodon period without accepting Soviet memorial framing.
+- **What gets simplified in popular memory:** He is often reduced to "Alla Horska's husband" or "Ukrainian Klimt." Both are useful hooks but poor endpoints. ESU presents him as a painter, graphic artist, teacher, head of "Сучасник," studio founder, and posthumous Shevchenko Prize laureate.
+- **Where modern Russian disinformation attacks them:** The usual Soviet/Russian line is not a single current smear but a frame: nonconforming Ukrainian art is dismissed as formalism or nationalism. Use the textbook context on the 1963 ideological attack to show this mechanism.
+- **Other-perspective considerations:** Краснодон/Молодогвардійці references require care because Soviet memory politics around Donbas were heavily curated. Do not let that one commission define the artist's whole trajectory.
+
+## 7. Cross-track links
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/alla-horska.yaml`
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/pislya-stalina-shistdesiatnyky.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/kulturna-rezystentsiia.yaml`
+- **Existing C1 modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/yevhen-hutsalo-shistdesiatnyky.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio-to-bio links to Алла Горська, Опанас Заливаха, Василь Стус, Іван Світличний, and Лесь Танюк.
+  - Visual-art activity on portrait as memory: *В. Стус* and *Орач (В. Стус)*.
+- **Potential LIT additions surfaced by this research:**
+  - Paired excerpt from Зарецький's studio reflections with a шістдесятники literature module on Стус or Світличний.
+
+## 8. Naming-canonical
+
+- **Slug:** `viktor-zaretskyi`
+- **EN canonical (BGN/PCGN 2010):** Viktor Zaretskyi
+- **UA canonical (with patronymic):** Зарецький Віктор Іванович
+- **Aliases (track these for `aliases:` YAML field):** Viktor Zaretsky; Viktor Zaretskyi; Віктор Зарецький
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Viktor Zaretskii; Victor Zaretsky as default body form; Виктор Зарецкий (FORBIDDEN except archival/Russian-source metadata)
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ESU article portrait | https://esu.com.ua/article-15529 | rights require verification before reuse.
+- **Backup candidates:** UINP historical-calendar portrait, credited to art-nostalgie.com.ua, rights unclear; Horska-Zaretskyi foundation images, rights unclear; Wikimedia/WikiArt reproductions only after license check.
+- **If no PD/CC portrait exists:** use a rights-cleared exhibition poster or verified photo from a museum/foundation permission workflow.
+- **Era-appropriate context image:** Photo of the Club of Creative Youth milieu or a rights-cleared image of *Орач (В. Стус)* if reproduction rights are cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України, "Зарецький Віктор Іванович" | https://esu.com.ua/article-15529 | accessed 2026-05-30.
+- Український інститут національної пам'яті, "1925 — народився Віктор Зарецький, художник" | https://uinp.gov.ua/istorychnyy-kalendar/lyutyy/8/1925-narodyvsya-viktor-zareckyy | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Horska-Zaretskyi foundation, "Віктор Зарецький" | https://horska-zaretskyi.com/viktor-zaretskyi/ | accessed 2026-05-30.
+- ННДІУ, *Віктор Зарецький. Пошуки коріння. Листи, нариси, спогади, статті* | https://ndiu.knu.ua/images/elektr_bibl/zareck1.pdf | accessed 2026-05-30.
+
+**Tier 3 (encyclopedic):**
+- Ukrainian Wikipedia "Зарецький Віктор Іванович" via `mcp__sources.query_wikipedia` | accessed 2026-05-30.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grade 11 history textbook retrievals via `mcp__sources.search_text` on Клуб творчої молоді "Сучасник" and шістдесятники, especially Hlibovska 2024 pp. 94-95 and Gisem 2024 pp. 78-80 | accessed 2026-05-30.
+
+**Primary-source documents accessed:**
+- Зарецький's letters/interview passages in *Пошуки коріння*.
+- Exact KGB case file or personal surveillance file: source not found.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing
+- [x] Soviet "formalism" labels treated as repression vocabulary, not fact
+- [x] No fabricated arrest/case number
+- [x] Russian-imperial transliterations confined to forbidden aliases
+- [x] Existing paths verified
+- [x] Place names use Ukrainian canonical forms


### PR DESCRIPTION
## Summary

Adds five Phase-1 BIO research dossiers for Epic #2309 batch 9 final non-G tail:

- `viktor-zaretskyi` — Віктор Зарецький
- `veniamin-kushnir` — Веніамін Кушнір
- `mykyta-budka` — Микита Будка
- `ivan-ziatyk` — Іван Зятик
- `petro-verhun` — Петро Вергун

## Tier 1/2 sources used

- Віктор Зарецький: ЕСУ; Український інститут національної пам'яті; Horska-Zaretskyi foundation; ННДІУ PDF `Пошуки коріння`.
- Веніамін Кушнір: ЕСУ; Бібліотека українського мистецтва; КПІ exhibition page; NAS PDF context.
- Микита Будка: ЕСУ; Синод Єпископів УГКЦ; Vatican 2001 beatification list.
- Іван Зятик: Синод Єпископів УГКЦ; Vatican 2001 beatification list; John Paul II 2001 beatification homily.
- Петро Вергун: ЕСУ; Синод Єпископів УГКЦ; Vatican 2001 beatification list; John Paul II 2001 beatification homily.

## Validation

Raw validator final line:

`No fabricated Existing cross-track plan paths found.`

Additional checks:

- `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.
- Pre-commit/pre-push hooks passed.

## Source gaps declared in dossiers

- Кушнір: retrieved sources identify him as a painter, not a poet; no verified first-person quotes found.
- Будка: second first-person quote and exact NKVD case number not found.
- Вергун: second first-person quote and exact NKVD/GULAG case number not found.