### PR TITLE
fix(bio): canonicalize duplicate dossier slugs

### DIFF
--- a/docs/research/bio/leonid-mosendz.md
+++ b/docs/research/bio/leonid-mosendz.md
@@ -97,7 +97,7 @@ Dmytro Dontsov called him "**one of the best, if not the best, of our short-stor
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — UNR context
   - `curriculum/l2-uk-en/plans/bio/olena-teliha.yaml` — fellow вісниківство / *Вісник* circle
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `leonid-mosendz` ↔ `yurii-klen` (the Порфирій Горотак collaboration); ↔ `yevhen-malanyuk`, `yurii-darahan` (Poděbrady / Prague circle); ↔ `ivan-bahrianyi` (the Многогрішний parody).
+  - Bio-to-bio: `leonid-mosendz` ↔ `yurii-klen` (the Порфирій Горотак collaboration); ↔ `yevhen-malaniuk`, `yurii-darahan` (Poděbrady / Prague circle); ↔ `ivan-bahrianyi` (the Многогрішний parody).
   - Potential LIT addition: a `plans/lit/mosendz-prose.yaml` (file as `bio-expansion-followup`).
   - A `plans/bio/leonid-mosendz.yaml` does **not** yet exist — to be created in Phase 2.
 

--- a/docs/research/bio/natalia-livytska-kholodna.md
+++ b/docs/research/bio/natalia-livytska-kholodna.md
@@ -92,7 +92,7 @@
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — the UNR head her father succeeded; she wrote *Я бачив Симона Петлюру*
   - `curriculum/l2-uk-en/plans/bio/olena-teliha.yaml` — co-organiser with her in the «Танк» group
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `natalia-livytska-kholodna` ↔ `yevhen-malanyuk` (who loved her, dedicated poems, and named her the "Ukrainian Akhmatova"); ↔ `yurii-darahan` (Prague-school origin); ↔ `oksana-liaturynska`, `leonid-mosendz` (the émigré circle); ↔ Андрій Лівицький (her father, UNR president-in-exile — bio not yet built).
+  - Bio-to-bio: `natalia-livytska-kholodna` ↔ `yevhen-malaniuk` (who loved her, dedicated poems, and named her the "Ukrainian Akhmatova"); ↔ `yurii-darahan` (Prague-school origin); ↔ `oksana-liaturynska`, `leonid-mosendz` (the émigré circle); ↔ Андрій Лівицький (her father, UNR president-in-exile — bio not yet built).
   - Potential LIT addition: a `plans/lit/livytska-kholodna-poetry.yaml` (file as `bio-expansion-followup`).
   - A `plans/bio/natalia-livytska-kholodna.yaml` does **not** yet exist — to be created in Phase 2.
 

--- a/docs/research/bio/oksana-liaturynska.md
+++ b/docs/research/bio/oksana-liaturynska.md
@@ -97,7 +97,7 @@
   - `curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml` — Prague-émigré friend
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — she sculpted his bust
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `oksana-liaturynska` ↔ `yevhen-malanyuk` (graves face each other; close friends); ↔ `yurii-darahan` (*Княжа емаль* dedicated to his memory); ↔ `natalia-livytska-kholodna`, `leonid-mosendz` (Prague circle); ↔ Улас Самчук (her gymnasium-almanac editor; the she-wolf letter's addressee).
+  - Bio-to-bio: `oksana-liaturynska` ↔ `yevhen-malaniuk` (graves face each other; close friends); ↔ `yurii-darahan` (*Княжа емаль* dedicated to his memory); ↔ `natalia-livytska-kholodna`, `leonid-mosendz` (Prague circle); ↔ Улас Самчук (her gymnasium-almanac editor; the she-wolf letter's addressee).
   - Potential LIT addition: a `plans/lit/liaturynska-poetry.yaml` (file as `bio-expansion-followup`).
   - A `plans/bio/oksana-liaturynska.yaml` does **not** yet exist — to be created in Phase 2.
 

--- a/docs/research/bio/oleksandr-oles.md
+++ b/docs/research/bio/oleksandr-oles.md
@@ -98,7 +98,7 @@ Note: composers Микола Лисенко, Кирило Стеценко, and 
   - `curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml` — his son; direct family + ideological link
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — UNR leadership context
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `oleksandr-oles` ↔ `pavlo-tychyna` (Olesʹ authored the 1928 émigré rebuke "І ти продався їм, Тичино…"); ↔ `yevhen-malanyuk` (Празька школа milieu Olesʹ presided over in Prague); ↔ `vasyl-koroliv-staryi` (Prague émigré circle).
+  - Bio-to-bio: `oleksandr-oles` ↔ `pavlo-tychyna` (Olesʹ authored the 1928 émigré rebuke "І ти продався їм, Тичино…"); ↔ `yevhen-malaniuk` (Празька школа milieu Olesʹ presided over in Prague); ↔ `vasyl-koroliv-staryi` (Prague émigré circle).
   - A `plans/bio/oleksandr-oles.yaml` does **not** yet exist — to be created in Phase 2.
 
 ## 8. Naming-canonical

--- a/docs/research/bio/pavlo-tychyna.md
+++ b/docs/research/bio/pavlo-tychyna.md
@@ -140,7 +140,7 @@ From *Партія веде* (Pravda, 21 November 1933), the opening declaration
   - `maksym-rylskyi` (Tier 1a) — parallel capitulation arc with retained late agency
   - `mykola-bazhan` (Tier 1a) — ВАПЛІТЕ co-member, similar pattern
   - `oleksandr-oles` (Tier 1b) — author of the 1928 rebuke verse
-  - `yevhen-malanyuk` (Tier 1b) — author of the 1924 diagnosis
+  - `yevhen-malaniuk` (Tier 1b) — author of the 1924 diagnosis
 
 ## 8. Naming-canonical
 

--- a/docs/research/bio/todos-osmachka.md
+++ b/docs/research/bio/todos-osmachka.md
@@ -94,7 +94,7 @@
   - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the repression apparatus he survived
   - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — his МАРС friends (Косинка, Підмогильний, Плужник) were executed in it
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `todos-osmachka` ↔ `ivan-bahrianyi` (both МАРС; Багряний was the last friend to see Осьмачка alive and wrote the moving "Данте" letter about him); ↔ МАРС/Ланка peers Косинка / Підмогильний / Плужник (Block A); ↔ `mykola-zerov` (АСПИС); ↔ `yevhen-malanyuk` (who coined the "син села" phrase).
+  - Bio-to-bio: `todos-osmachka` ↔ `ivan-bahrianyi` (both МАРС; Багряний was the last friend to see Осьмачка alive and wrote the moving "Данте" letter about him); ↔ МАРС/Ланка peers Косинка / Підмогильний / Плужник (Block A); ↔ `mykola-zerov` (АСПИС); ↔ `yevhen-malaniuk` (who coined the "син села" phrase).
   - A `plans/bio/todos-osmachka.yaml` does **not** yet exist — to be created in Phase 2.
 
 ## 8. Naming-canonical

--- a/docs/research/bio/viktor-domontovych.md
+++ b/docs/research/bio/viktor-domontovych.md
@@ -1,6 +1,6 @@
 # Віктор Платонович Петров (В. Домонтович) — Research Dossier
 
-**Slug:** `viktor-petrov`
+**Slug:** `viktor-domontovych`
 **Block:** C.3 (émigré / postwar МУР tradition — contested émigré whose "emigration" ended in a disputed return)
 **Tier:** 1b
 **Issue:** #2318
@@ -121,8 +121,8 @@ Bio peers in scope: Mykola Zerov (his wife's first husband, executed neoclassici
 
 ## 8. Naming-canonical
 
-- **Slug:** `viktor-petrov`
-- **EN canonical (BGN/PCGN 2010):** Viktor Petrov.
+- **Slug:** `viktor-domontovych`
+- **EN canonical (curriculum / #2309 audit):** Viktor Domontovych; legal/scholarly name Viktor Petrov.
 - **UA canonical:** Петров Віктор Платонович; literary identity В. Домонтович.
 - **Aliases (track for `aliases:`):** В. Домонтович (canonical literary pseudonym); Віктор Домонтович; В. Бер (scholarly pseudonym); Віктор Петренко; Борис Веріго; Viktor Domontovych (EN); "Іванов" (alleged Soviet operational codename — record as alias-with-caveat, not as identity).
 - **Forbidden forms (Russian-imperial / Russified, flag in body text):** Виктор Платонович Петров; "Victor Petrov, Russian/Soviet writer" (Russocentric primary identification — he was a Ukrainian writer).

--- a/docs/research/bio/volodymyr-vynnychenko.md
+++ b/docs/research/bio/volodymyr-vynnychenko.md
@@ -101,7 +101,7 @@
 - **Existing BIO plans (VERIFIED present via `test -e`):**
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — the other face of the Директорія; Винниченко (civilian head) vs. Петлюра (military head)
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `volodymyr-vynnychenko` ↔ `oleksandr-oles`, `vasyl-koroliv-staryi` (first-wave émigré cohort); ↔ `yevhen-malanyuk` (the Празька школа took the UNR defeat as its founding wound).
+  - Bio-to-bio: `volodymyr-vynnychenko` ↔ `oleksandr-oles`, `vasyl-koroliv-staryi` (first-wave émigré cohort); ↔ `yevhen-malaniuk` (the Празька школа took the UNR defeat as its founding wound).
   - A `plans/bio/volodymyr-vynnychenko.yaml` does **not** yet exist — to be created in Phase 2.
 
 ## 8. Naming-canonical

--- a/docs/research/bio/yevhen-malaniuk.md
+++ b/docs/research/bio/yevhen-malaniuk.md
@@ -1,6 +1,6 @@
 # Євген Маланюк — Research Dossier
 
-**Slug:** `yevhen-malanyuk`
+**Slug:** `yevhen-malaniuk`
 **Block:** C.2 (émigré tradition — Празька школа / Prague School; UNR Army officer)
 **Tier:** 1b
 **Issue:** #2318 (R1b — Tier 1b research, Block C émigré)
@@ -97,12 +97,12 @@
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — UNR context
   - `curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml` — befriended in Poděbrady; Prague School / OUN milieu
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `yevhen-malanyuk` ↔ `yurii-darahan` (co-founded *Веселка*; Prague School origin); ↔ `oksana-liaturynska` (graves face each other; close friends); ↔ `natalia-livytska-kholodna` (his great unhappy love); ↔ `leonid-mosendz` (Poděbrady circle); ↔ `pavlo-tychyna` (the 1924 diagnosis); ↔ `yurii-klen` (whose son co-edited Klen's works with Маланюк); ↔ Олена Теліга, Юрій Липа.
-  - A `plans/bio/yevhen-malanyuk.yaml` does **not** yet exist — to be created in Phase 2.
+  - Bio-to-bio: `yevhen-malaniuk` ↔ `yurii-darahan` (co-founded *Веселка*; Prague School origin); ↔ `oksana-liaturynska` (graves face each other; close friends); ↔ `natalia-livytska-kholodna` (his great unhappy love); ↔ `leonid-mosendz` (Poděbrady circle); ↔ `pavlo-tychyna` (the 1924 diagnosis); ↔ `yurii-klen` (whose son co-edited Klen's works with Маланюк); ↔ Олена Теліга, Юрій Липа.
+  - A `plans/bio/yevhen-malaniuk.yaml` does **not** yet exist — to be created in Phase 2.
 
 ## 8. Naming-canonical
 
-- **Slug:** `yevhen-malanyuk`
+- **Slug:** `yevhen-malaniuk`
 - **EN canonical (BGN/PCGN 2010):** Yevhen Malaniuk
 - **UA canonical (with patronymic):** Євген Филимонович Маланюк
 - **Aliases (for `aliases:` field):** Маланюк Євген Филимонович; Евген Маланюк (diaspora spelling); Yevhen Malaniuk (IEU)

--- a/docs/research/bio/yurii-darahan.md
+++ b/docs/research/bio/yurii-darahan.md
@@ -93,7 +93,7 @@
 - **Existing BIO plans (VERIFIED present via `test -e`):**
   - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — UNR context
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `yurii-darahan` ↔ `yevhen-malanyuk` (co-founded *Веселка*; Yelysavethrad townsmen); ↔ `oksana-liaturynska` (her *Княжа емаль* (1941) is **dedicated to Дараган's memory**); ↔ `natalia-livytska-kholodna`, `leonid-mosendz` (the Prague circle).
+  - Bio-to-bio: `yurii-darahan` ↔ `yevhen-malaniuk` (co-founded *Веселка*; Yelysavethrad townsmen); ↔ `oksana-liaturynska` (her *Княжа емаль* (1941) is **dedicated to Дараган's memory**); ↔ `natalia-livytska-kholodna`, `leonid-mosendz` (the Prague circle).
   - Potential LIT addition: a `plans/lit/darahan-poetry.yaml` (file as `bio-expansion-followup`).
   - A `plans/bio/yurii-darahan.yaml` does **not** yet exist — to be created in Phase 2.
 

--- a/docs/research/bio/yurii-klen.md
+++ b/docs/research/bio/yurii-klen.md
@@ -92,7 +92,7 @@
   - `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml` — fellow neoclassicist, executed 1937
   - `curriculum/l2-uk-en/plans/bio/pavlo-fylypovych.yaml` — fellow neoclassicist, executed 1937
 - **Candidate cross-track connections (Phase 2+ — NOT existing files):**
-  - Bio-to-bio: `yurii-klen` ↔ `mykhailo-drai-khmara` (research dossier exists at `docs/research/bio/mykhailo-drai-khmara.md`; neoclassicist "грона п'ятірне"); ↔ Максим Рильський (the fifth survivor-by-capitulation); ↔ `leonid-mosendz` (the Горотак collaboration); ↔ `yevhen-malanyuk` (Каравели = neoclassicism + Prague School).
+  - Bio-to-bio: `yurii-klen` ↔ `mykhailo-drai-khmara` (research dossier exists at `docs/research/bio/mykhailo-drai-khmara.md`; neoclassicist "грона п'ятірне"); ↔ Максим Рильський (the fifth survivor-by-capitulation); ↔ `leonid-mosendz` (the Горотак collaboration); ↔ `yevhen-malaniuk` (Каравели = neoclassicism + Prague School).
   - A `plans/bio/yurii-klen.yaml` does **not** yet exist — to be created in Phase 2.
 
 ## 8. Naming-canonical

--- a/docs/research/bio/yurii-lavrynenko.md
+++ b/docs/research/bio/yurii-lavrynenko.md
@@ -1,6 +1,6 @@
 # Юрій Андріянович Лавріненко — Research Dossier
 
-**Slug:** `yurii-lavrinenko`
+**Slug:** `yurii-lavrynenko`
 **Block:** C.5 (émigré scholars who built Ukrainian studies in exile)
 **Tier:** 1b
 **Issue:** #2318
@@ -104,17 +104,17 @@ From his late memoir-reflections (c. 1966+):
 - **The Tychyna exemplar** (`docs/research/bio/pavlo-tychyna.md`) cites this same anthology and Lavrinenko's "покара славою" coinage — Lavrinenko is the critic who framed Tychyna's trajectory.
 - **ISTORIO diaspora cluster:** `plans/istorio/diaspora-naukovtsi.yaml`, `tsykl-kulturnykh-vidrodzhen.yaml` — diaspora scholarship and the cycle of cultural rebirths.
 - **Connected bios already in place:** `plans/bio/george-shevelov.yaml` — Shevelov personally helped Lavrinenko escape to Lviv during WWII; a direct biographical link to a fellow C.5 scholar.
-- **Potential additions (do NOT add unilaterally):** a dedicated `yurii-lavrinenko` bio module would anchor the whole Розстріляне Відродження track; file `bio-expansion-followup` if desired.
+- **Potential additions (do NOT add unilaterally):** a dedicated `yurii-lavrynenko` bio module would anchor the whole Розстріляне Відродження track; file `bio-expansion-followup` if desired.
 
 ## 8. Naming-canonical
 
-- **Slug:** `yurii-lavrinenko`
-- **EN canonical (BGN/PCGN 2010):** Yurii Lavrinenko.
+- **Slug:** `yurii-lavrynenko`
+- **EN canonical (curriculum / #2309 audit):** Yurii Lavrynenko.
 - **UA canonical (with patronymic):** Юрій Андріянович Лавріненко.
 - **Aliases (for `aliases:` field):**
   - "Юрій Лавріненко (canonical UA, ЕСУ)"
   - "Юрій Лавриненко (IEU variant spelling)"
-  - "Yurii Lavrinenko (canonical EN, BGN/PCGN 2010)"
+  - "Yurii Lavrinenko (source-spelling variant)"
   - "Юрій Дивнич (principal pen name)"
   - "Юрій Гайдар / Ю. Ясен / Д. Коларгонець / Ю. А. (further pen names / cryptonym)"
 - **Forbidden forms (flag in body text):** "Юрий Лавриненко", "Юрий Андриянович Лавриненко" (Russified).


### PR DESCRIPTION
## Summary
- Rename three BIO research dossiers to the #2309 canonical slugs: yevhen-malaniuk, yurii-lavrynenko, viktor-domontovych.
- Update internal slug fields, naming-canonical notes, and sibling §7 bio-to-bio cross-references to the renamed slugs.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

Closes #2435