### PR TITLE
feat(orchestration): add Codex thread handoff guard

### DIFF
--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -1,0 +1,151 @@
+# Codex Thread Handoff Runbook
+
+This runbook covers overnight orchestrator rollover when a Codex heartbeat
+thread approaches the auto-compaction zone.
+
+## Verified Capabilities
+
+Verified locally on 2026-05-30:
+
+- Codex app tools are exposed in this environment for `create_thread`,
+  `list_threads`, `read_thread`, `send_message_to_thread`,
+  `set_thread_title`, `set_thread_pinned`, `set_thread_archived`, and
+  `automation_update`.
+- Those app tools are not callable from a repo-local Python subprocess.
+  Local automation must therefore generate state, prompts, and guardrails
+  without depending on them.
+- `$CODEX_HOME/state_5.sqlite` contains a `threads` table plus related
+  `thread_dynamic_tools` and job tables. `$CODEX_HOME/session_index.jsonl`
+  is a compact local thread index.
+- `$CODEX_HOME/automations/` existed but had no `automation.toml` files in
+  this audit, only `.run-jitter-salt`.
+- `scripts/ai_agent_bridge/_ui_codex.py` already supports sending messages
+  to an existing Codex UI thread with `codex exec resume`; it does not create
+  a new app thread.
+- Monitor state for orchestration is available through `/api/orient`,
+  `/api/delegate/active`, `/api/delegate/tasks`, and `/api/worktrees`.
+
+## Architecture
+
+The handoff system uses a local thread lease plus a generated bootstrap
+prompt:
+
+- Lease state: `.agent/orchestrator-thread-lease.json` (gitignored)
+- Bootstrap prompt: `.agent/orchestrator-thread-bootstrap.md` (gitignored)
+- Optional tracked handoff update: `docs/session-state/current.md`
+- Script: `scripts/orchestration/thread_handoff.py`
+
+The lease records:
+
+- active orchestrator generation and thread id, when known
+- active heartbeat automation id, when known
+- replacement generation
+- replacement status: `pending_start` or `started`
+- bootstrap prompt path
+- cleanup guard: `old_automation_ready_to_delete`
+
+The cleanup guard is false after `prepare`. It becomes true only after
+`confirm-started --new-thread-id ...` succeeds. This keeps the old heartbeat
+alive if the replacement thread was not actually started.
+
+## Standard Rollover
+
+Run this from the repo root when the heartbeat thread enters the rollover
+zone:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --write-current \
+  --context-percent 86
+```
+
+If the active thread id or automation id is known, include them:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --write-current \
+  --active-thread-id <current-thread-id> \
+  --active-automation-id <old-heartbeat-automation-id> \
+  --context-percent 86
+```
+
+This writes:
+
+- `.agent/orchestrator-thread-lease.json`
+- `.agent/orchestrator-thread-bootstrap.md`
+- `docs/session-state/current.md` only when `--write-current` is present
+
+The generated prompt is the exact replacement-thread bootstrap. If the Codex
+app `create_thread` tool is available to the current agent, use it with that
+prompt. If it is not available, create one new Codex UI thread manually and
+paste the generated prompt. That is the only unavoidable UI action.
+
+After the replacement thread is visibly running, confirm it:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
+  --new-thread-id <replacement-thread-id>
+```
+
+Only if the output shows `"old_automation_ready_to_delete": true` may the old
+heartbeat automation be deleted or paused through the Codex app
+`automation_update` tool.
+
+## Safety Checks
+
+Check the lease at any time:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py check
+```
+
+Warnings mean the old heartbeat automation should stay active. Common
+warnings:
+
+- replacement is still `pending_start`
+- pending replacement is stale
+- active generation has not been seen recently
+- context estimate is at or above the threshold
+- cleanup says ready but no replacement thread id is recorded
+- lease state file is unreadable or corrupt
+
+`prepare` and `confirm-started` refuse to overwrite an unreadable lease file.
+Inspect or restore the file first. If the operator intentionally wants to
+discard the corrupt lease and start a new one, run:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --force-reset-state \
+  --write-current \
+  --context-percent 86
+```
+
+Dry-run without writing files:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare --dry-run
+```
+
+Audit local Codex metadata:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py audit
+```
+
+Include live Monitor API state in the audit:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py audit --include-monitor
+```
+
+## Heartbeat Behavior
+
+At 75 percent context, run `prepare --dry-run` to verify the packet renders.
+
+At 82 percent context or higher, run `prepare --write-current` and start the
+replacement thread. Keep the old heartbeat active until `confirm-started`
+records the replacement thread id.
+
+At 90 percent context or higher, stop non-handoff work. The current thread
+should only write the handoff packet, start or prompt for the replacement
+thread, and preserve the old automation until confirmation.

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python
+"""Prepare and guard Codex orchestrator thread handoffs.
+
+The Codex app can expose thread and automation tools to an agent, but a local
+repo script cannot assume those app-only tools exist. This helper gathers the
+durable local state, writes a handoff packet, generates the replacement-thread
+bootstrap prompt, and records a lease that prevents old automation cleanup
+until the replacement thread is explicitly confirmed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import urllib.error
+import urllib.request
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_MONITOR_BASE_URL = "http://127.0.0.1:8765"
+DEFAULT_STATE_PATH = Path(".agent/orchestrator-thread-lease.json")
+DEFAULT_BOOTSTRAP_PATH = Path(".agent/orchestrator-thread-bootstrap.md")
+DEFAULT_CURRENT_PATH = Path("docs/session-state/current.md")
+DEFAULT_STALE_HOURS = 12
+DEFAULT_CONTEXT_THRESHOLD = 82.0
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def repo_root_from_file() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def isoformat_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def rel(path: Path, root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def run_command(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout_s: int = 10,
+) -> CommandResult:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return CommandResult(returncode=127, stdout="", stderr=str(exc))
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        return CommandResult(
+            returncode=124,
+            stdout=str(stdout).strip(),
+            stderr=(str(stderr).strip() or f"timeout after {timeout_s}s"),
+        )
+    return CommandResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout.strip(),
+        stderr=completed.stderr.strip(),
+    )
+
+
+def git_output(repo_root: Path, *args: str, timeout_s: int = 10) -> str:
+    result = run_command(["git", *args], cwd=repo_root, timeout_s=timeout_s)
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def http_get_json(base_url: str, path: str, timeout_s: float = 3.0) -> dict[str, Any]:
+    url = base_url.rstrip("/") + path
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+        return {"_error": f"{type(exc).__name__}: {exc}"}
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as exc:
+        return {"_error": f"JSONDecodeError: {exc}"}
+    return data if isinstance(data, dict) else {"value": data}
+
+
+def gh_json(repo_root: Path, args: list[str], timeout_s: int = 15) -> Any:
+    result = run_command(["gh", *args], cwd=repo_root, timeout_s=timeout_s)
+    if result.returncode != 0:
+        return {"_error": result.stderr or result.stdout or "gh command failed"}
+    try:
+        return json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return {"_error": f"JSONDecodeError: {exc}"}
+
+
+def parse_git_log(raw: str) -> list[dict[str, str]]:
+    commits: list[dict[str, str]] = []
+    for line in raw.splitlines():
+        parts = line.split("\t", 1)
+        if not parts or not parts[0]:
+            continue
+        commits.append({
+            "sha": parts[0],
+            "subject": parts[1] if len(parts) > 1 else "",
+        })
+    return commits
+
+
+def parse_status(raw: str) -> list[dict[str, str]]:
+    files: list[dict[str, str]] = []
+    for line in raw.splitlines():
+        if not line:
+            continue
+        files.append({
+            "status": line[:2].strip() or line[:2],
+            "path": line[3:] if len(line) > 3 else "",
+        })
+    return files
+
+
+def parse_ahead_behind(raw: str, upstream: str) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    parts = raw.split()
+    if len(parts) < 2:
+        return {"upstream": upstream, "parse_error": f"unexpected rev-list output: {raw!r}"}
+    try:
+        behind = int(parts[0])
+        ahead = int(parts[1])
+    except ValueError:
+        return {"upstream": upstream, "parse_error": f"non-integer rev-list output: {raw!r}"}
+    return {"ahead": ahead, "behind": behind, "upstream": upstream}
+
+
+def gather_git_state(repo_root: Path) -> dict[str, Any]:
+    branch = git_output(repo_root, "branch", "--show-current") or "DETACHED"
+    head = git_output(repo_root, "rev-parse", "--short=10", "HEAD")
+    full_head = git_output(repo_root, "rev-parse", "HEAD")
+    upstream = git_output(repo_root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+    ahead_behind = None
+    if upstream:
+        counts = git_output(repo_root, "rev-list", "--left-right", "--count", f"{upstream}...HEAD")
+        ahead_behind = parse_ahead_behind(counts, upstream)
+
+    return {
+        "repo_root": str(repo_root),
+        "branch": branch,
+        "head": head,
+        "full_head": full_head,
+        "ahead_behind": ahead_behind,
+        "last_commits": parse_git_log(
+            git_output(repo_root, "log", "-5", "--pretty=format:%h%x09%s")
+        ),
+        "modified_files": parse_status(git_output(repo_root, "status", "--short")),
+    }
+
+
+def gather_monitor_state(base_url: str) -> dict[str, Any]:
+    return {
+        "base_url": base_url.rstrip("/"),
+        "orient": http_get_json(base_url, "/api/orient?fresh=true"),
+        "active_delegates": http_get_json(base_url, "/api/delegate/active"),
+        "completed_delegates": http_get_json(base_url, "/api/delegate/tasks?status=done&limit=5"),
+        "worktrees": http_get_json(base_url, "/api/worktrees"),
+    }
+
+
+def gather_github_state(repo_root: Path) -> dict[str, Any]:
+    return {
+        "open_prs": gh_json(repo_root, [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision",
+            "--limit",
+            "20",
+        ]),
+        "open_issues": gh_json(repo_root, [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,url,updatedAt,labels",
+            "--limit",
+            "10",
+        ]),
+    }
+
+
+def gather_snapshot(repo_root: Path, base_url: str) -> dict[str, Any]:
+    return {
+        "generated_at": isoformat_z(utc_now()),
+        "git": gather_git_state(repo_root),
+        "monitor": gather_monitor_state(base_url),
+        "github": gather_github_state(repo_root),
+    }
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "state_error": f"unreadable state file: {path}: {type(exc).__name__}: {exc}",
+        }
+    if not isinstance(data, dict):
+        return {"schema_version": SCHEMA_VERSION, "state_error": f"state file is not a JSON object: {path}"}
+    data.setdefault("schema_version", SCHEMA_VERSION)
+    return data
+
+
+def state_error_payload(state: dict[str, Any], state_path: Path, repo_root: Path) -> dict[str, Any] | None:
+    error = state.get("state_error")
+    if not error:
+        return None
+    return {
+        "error": str(error),
+        "state_file": rel(state_path, repo_root),
+        "hint": "Inspect the file, restore it, or rerun prepare with --force-reset-state to start a new lease.",
+    }
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def active_thread_id_from_env() -> str | None:
+    return os.environ.get("CODEX_THREAD_ID") or os.environ.get("CODEX_SESSION_ID")
+
+
+def generation_id(prefix: str, now: datetime) -> str:
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    return f"{prefix}-{stamp}"
+
+
+def prepare_state(
+    state: dict[str, Any],
+    *,
+    now: datetime,
+    active_thread_id: str | None,
+    active_automation_id: str | None,
+    bootstrap_path: Path,
+    context_percent: float | None,
+    force_new_replacement: bool,
+) -> dict[str, Any]:
+    prepared = dict(state)
+    prepared["schema_version"] = SCHEMA_VERSION
+
+    active = dict(prepared.get("active") or {})
+    if not active.get("generation"):
+        active["generation"] = generation_id("orchestrator", now)
+        active["started_at"] = isoformat_z(now)
+    if active_thread_id:
+        active["thread_id"] = active_thread_id
+    elif active_thread_id_from_env() and not active.get("thread_id"):
+        active["thread_id"] = active_thread_id_from_env()
+    if active_automation_id:
+        active["automation_id"] = active_automation_id
+    active["last_seen_at"] = isoformat_z(now)
+    prepared["active"] = active
+
+    replacement = dict(prepared.get("replacement") or {})
+    if force_new_replacement or replacement.get("status") not in {"pending_start", "started"}:
+        replacement = {
+            "generation": generation_id("orchestrator-next", now),
+            "status": "pending_start",
+            "prepared_at": isoformat_z(now),
+            "thread_id": None,
+            "bootstrap_prompt_path": str(bootstrap_path),
+        }
+    else:
+        replacement["prepared_at"] = isoformat_z(now)
+        replacement["bootstrap_prompt_path"] = str(bootstrap_path)
+    prepared["replacement"] = replacement
+
+    cleanup = dict(prepared.get("cleanup") or {})
+    cleanup["old_automation_ready_to_delete"] = False
+    cleanup["reason"] = "replacement thread has not been explicitly confirmed"
+    prepared["cleanup"] = cleanup
+
+    prepared["last_handoff"] = {
+        "prepared_at": isoformat_z(now),
+        "context_percent": context_percent,
+    }
+    return prepared
+
+
+def confirm_started(
+    state: dict[str, Any],
+    *,
+    new_thread_id: str,
+    new_automation_id: str | None,
+    confirmed_by: str,
+    now: datetime,
+) -> dict[str, Any]:
+    if not new_thread_id.strip():
+        raise ValueError("--new-thread-id is required")
+    if not state.get("replacement"):
+        raise ValueError("no pending replacement exists; run prepare first")
+
+    confirmed = dict(state)
+    replacement = dict(confirmed["replacement"])
+    replacement["status"] = "started"
+    replacement["thread_id"] = new_thread_id.strip()
+    replacement["confirmed_at"] = isoformat_z(now)
+    if new_automation_id:
+        replacement["automation_id"] = new_automation_id
+    confirmed["replacement"] = replacement
+
+    cleanup = dict(confirmed.get("cleanup") or {})
+    cleanup["old_automation_ready_to_delete"] = True
+    cleanup["confirmed_by"] = confirmed_by
+    cleanup["confirmed_at"] = isoformat_z(now)
+    cleanup["reason"] = "replacement thread start confirmed by operator command"
+    confirmed["cleanup"] = cleanup
+    confirmed["updated_at"] = isoformat_z(now)
+    return confirmed
+
+
+def format_table(rows: list[list[str]], headers: list[str]) -> str:
+    if not rows:
+        return "_None._"
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, value in enumerate(row):
+            widths[idx] = max(widths[idx], len(value))
+    header_line = "| " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers)) + " |"
+    sep_line = "| " + " | ".join("-" * widths[idx] for idx in range(len(headers))) + " |"
+    row_lines = [
+        "| " + " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)) + " |"
+        for row in rows
+    ]
+    return "\n".join([header_line, sep_line, *row_lines])
+
+
+def summarize_prs(open_prs: Any) -> str:
+    if isinstance(open_prs, dict) and open_prs.get("_error"):
+        return f"_Unavailable: {open_prs['_error']}_"
+    rows = []
+    for pr in open_prs if isinstance(open_prs, list) else []:
+        rows.append([
+            f"#{pr.get('number')}",
+            str(pr.get("headRefName") or ""),
+            str(pr.get("mergeStateStatus") or ""),
+            "yes" if pr.get("isDraft") else "no",
+            str(pr.get("title") or ""),
+        ])
+    return format_table(rows, ["PR", "Branch", "Merge", "Draft", "Title"])
+
+
+def summarize_issues(open_issues: Any) -> str:
+    if isinstance(open_issues, dict) and open_issues.get("_error"):
+        return f"_Unavailable: {open_issues['_error']}_"
+    rows = []
+    for issue in open_issues if isinstance(open_issues, list) else []:
+        rows.append([
+            f"#{issue.get('number')}",
+            str(issue.get("updatedAt") or ""),
+            str(issue.get("title") or ""),
+        ])
+    return format_table(rows, ["Issue", "Updated", "Title"])
+
+
+def summarize_tasks(tasks_payload: Any) -> str:
+    if not isinstance(tasks_payload, dict):
+        return "_Unavailable._"
+    if tasks_payload.get("_error"):
+        return f"_Unavailable: {tasks_payload['_error']}_"
+    rows = []
+    for task in tasks_payload.get("tasks") or []:
+        rows.append([
+            str(task.get("task_id") or ""),
+            str(task.get("agent") or ""),
+            str(task.get("status") or ""),
+            str(task.get("age_s") or task.get("duration_s") or ""),
+        ])
+    return format_table(rows, ["Task", "Agent", "Status", "Age/Duration"])
+
+
+def summarize_modified_files(files: list[dict[str, str]]) -> str:
+    if not files:
+        return "_None._"
+    rows = [[item.get("status", ""), item.get("path", "")] for item in files]
+    return format_table(rows, ["Status", "Path"])
+
+
+def summarize_commits(commits: list[dict[str, str]]) -> str:
+    rows = [[item.get("sha", ""), item.get("subject", "")] for item in commits]
+    return format_table(rows, ["SHA", "Subject"])
+
+
+def context_line(context_percent: float | None, threshold: float) -> str:
+    if context_percent is None:
+        return "Context percent was not supplied; use --context-percent from a statusline or manual estimate."
+    state = "ROLL OVER NOW" if context_percent >= threshold else "below rollover threshold"
+    return f"Context estimate: {context_percent:.1f}% ({state}; threshold {threshold:.1f}%)."
+
+
+def render_bootstrap_prompt(
+    snapshot: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    context_threshold: float,
+) -> str:
+    git = snapshot["git"]
+    monitor = snapshot["monitor"]
+    github = snapshot["github"]
+    active = state.get("active") or {}
+    replacement = state.get("replacement") or {}
+    prompt_path = replacement.get("bootstrap_prompt_path") or str(DEFAULT_BOOTSTRAP_PATH)
+    active_generation = active.get("generation") or "unknown"
+    replacement_generation = replacement.get("generation") or "unknown"
+    context_percent = (state.get("last_handoff") or {}).get("context_percent")
+
+    return "\n".join([
+        f"Work locally in {git.get('repo_root')}.",
+        "",
+        "You are the replacement Codex orchestrator thread.",
+        f"Replacement generation: {replacement_generation}",
+        f"Previous active generation: {active_generation}",
+        "",
+        "Read first:",
+        "- docs/session-state/current.md",
+        "- AGENTS.md",
+        "- docs/best-practices/agent-cooperation.md",
+        "- docs/best-practices/codex-thread-handoff.md",
+        "",
+        "Rules:",
+        "- Continue from the handoff exactly; do not restart from scratch.",
+        "- Keep the main checkout read-only except handoff updates.",
+        "- Use dispatch worktrees for implementation work: .worktrees/dispatch/<agent>/<task>/.",
+        "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",
+        "- Do not delete or migrate the old heartbeat automation until the confirm-started command below has succeeded.",
+        "",
+        "Start by orienting from the local monitor and PR state:",
+        "```bash",
+        "cd " + str(git.get("repo_root")),
+        "curl -sS http://127.0.0.1:8765/api/orient",
+        "curl -sS http://127.0.0.1:8765/api/delegate/active",
+        "curl -sS http://127.0.0.1:8765/api/worktrees",
+        "gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20",
+        "```",
+        "",
+        "After the replacement thread is actually running, confirm it from the repo root:",
+        "```bash",
+        ".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --new-thread-id <replacement-thread-id>",
+        "```",
+        "",
+        "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
+        "",
+        "Current snapshot:",
+        f"- Branch: {git.get('branch')} @ {git.get('head')}",
+        f"- {context_line(float(context_percent) if context_percent is not None else None, context_threshold)}",
+        f"- Active delegates: {(monitor.get('active_delegates') or {}).get('total', 'unknown') if isinstance(monitor.get('active_delegates'), dict) else 'unknown'}",
+        f"- Open PRs: {len(github.get('open_prs')) if isinstance(github.get('open_prs'), list) else 'unknown'}",
+        f"- Bootstrap prompt source: {prompt_path}",
+    ]) + "\n"
+
+
+def render_current_markdown(
+    snapshot: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    context_threshold: float,
+) -> str:
+    git = snapshot["git"]
+    monitor = snapshot["monitor"]
+    github = snapshot["github"]
+    active = state.get("active") or {}
+    replacement = state.get("replacement") or {}
+    cleanup = state.get("cleanup") or {}
+    handoff = state.get("last_handoff") or {}
+    prompt_path = replacement.get("bootstrap_prompt_path") or str(DEFAULT_BOOTSTRAP_PATH)
+
+    lines = [
+        f"# Current - Codex thread handoff ({snapshot['generated_at']})",
+        "",
+        "> Generated by `scripts/orchestration/thread_handoff.py prepare`.",
+        "> This is a rollover handoff, not proof that the replacement thread started.",
+        "",
+        "## Thread Lease",
+        "",
+        f"- Active generation: `{active.get('generation', 'unknown')}`",
+        f"- Active thread id: `{active.get('thread_id', 'unknown')}`",
+        f"- Active automation id: `{active.get('automation_id', 'unknown')}`",
+        f"- Replacement generation: `{replacement.get('generation', 'unknown')}`",
+        f"- Replacement status: `{replacement.get('status', 'unknown')}`",
+        f"- Replacement thread id: `{replacement.get('thread_id') or 'not-confirmed'}`",
+        f"- Old automation ready to delete: `{cleanup.get('old_automation_ready_to_delete', False)}`",
+        f"- Bootstrap prompt: `{prompt_path}`",
+        "",
+        "## Context Budget",
+        "",
+        context_line(
+            float(handoff["context_percent"]) if handoff.get("context_percent") is not None else None,
+            context_threshold,
+        ),
+        "",
+        "## Git State",
+        "",
+        f"- Repo: `{git.get('repo_root')}`",
+        f"- Branch: `{git.get('branch')}`",
+        f"- HEAD: `{git.get('head')}` (`{git.get('full_head')}`)",
+        f"- Upstream: `{(git.get('ahead_behind') or {}).get('upstream', 'none')}`",
+        f"- Ahead/behind: `{git.get('ahead_behind')}`",
+        "",
+        "### Last 5 Commits",
+        "",
+        summarize_commits(git.get("last_commits") or []),
+        "",
+        "### Modified Files",
+        "",
+        summarize_modified_files(git.get("modified_files") or []),
+        "",
+        "## Open PRs",
+        "",
+        summarize_prs(github.get("open_prs")),
+        "",
+        "## Open Issues",
+        "",
+        summarize_issues(github.get("open_issues")),
+        "",
+        "## Delegated Tasks",
+        "",
+        "### Active",
+        "",
+        summarize_tasks(monitor.get("active_delegates")),
+        "",
+        "### Recently Completed",
+        "",
+        summarize_tasks(monitor.get("completed_delegates")),
+        "",
+        "## Worktrees",
+        "",
+        f"- Count: `{(monitor.get('worktrees') or {}).get('count', 'unknown') if isinstance(monitor.get('worktrees'), dict) else 'unknown'}`",
+        "",
+        "## Next Commands",
+        "",
+        "```bash",
+        "cd " + str(git.get("repo_root")),
+        "curl -sS http://127.0.0.1:8765/api/orient",
+        "curl -sS http://127.0.0.1:8765/api/delegate/active",
+        "curl -sS http://127.0.0.1:8765/api/worktrees",
+        "gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20",
+        "```",
+        "",
+        "## Replacement Bootstrap Prompt",
+        "",
+        "Paste the generated bootstrap prompt into the new Codex thread, or use the Codex app `create_thread` tool when available.",
+        "After the new thread is actually running, run:",
+        "",
+        "```bash",
+        ".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --new-thread-id <replacement-thread-id>",
+        "```",
+        "",
+        "Do not delete the old heartbeat automation before this confirmation.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def inspect_codex_home(codex_home: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "codex_home": str(codex_home),
+        "exists": codex_home.exists(),
+        "session_index": str(codex_home / "session_index.jsonl"),
+        "automations_dir": str(codex_home / "automations"),
+    }
+    automations_dir = codex_home / "automations"
+    if automations_dir.exists():
+        result["automation_toml_files"] = [
+            str(path)
+            for path in sorted(automations_dir.glob("**/automation.toml"))
+        ]
+    else:
+        result["automation_toml_files"] = []
+
+    state_dbs = sorted(codex_home.glob("state_*.sqlite"), key=lambda p: p.stat().st_mtime, reverse=True)
+    result["state_databases"] = [str(path) for path in state_dbs[:3]]
+    if state_dbs:
+        db_path = state_dbs[0]
+        try:
+            with closing(sqlite3.connect(db_path)) as conn:
+                tables = [
+                    row[0]
+                    for row in conn.execute("select name from sqlite_master where type='table' order by name")
+                ]
+                result["latest_state_db"] = str(db_path)
+                result["tables"] = tables
+                if "threads" in tables:
+                    result["thread_count"] = conn.execute("select count(*) from threads").fetchone()[0]
+                    result["recent_threads"] = [
+                        {"id": row[0], "title": row[1], "cwd": row[2], "archived": bool(row[3])}
+                        for row in conn.execute(
+                            "select id, title, cwd, archived from threads order by updated_at desc limit 5"
+                        )
+                    ]
+        except sqlite3.Error as exc:
+            result["sqlite_error"] = f"{type(exc).__name__}: {exc}"
+
+    codex_help = run_command(["codex", "exec", "resume", "--help"], cwd=Path.cwd(), timeout_s=5)
+    result["codex_exec_resume_available"] = codex_help.returncode == 0
+    if codex_help.returncode != 0:
+        result["codex_exec_resume_error"] = codex_help.stderr or codex_help.stdout
+    return result
+
+
+def check_state(
+    state: dict[str, Any],
+    *,
+    now: datetime,
+    stale_after: timedelta,
+    context_percent: float | None,
+    context_threshold: float,
+) -> tuple[list[str], list[str]]:
+    warnings: list[str] = []
+    facts: list[str] = []
+    active = state.get("active") or {}
+    replacement = state.get("replacement") or {}
+    cleanup = state.get("cleanup") or {}
+
+    if state.get("state_error"):
+        warnings.append(str(state["state_error"]))
+
+    facts.append(f"active_generation={active.get('generation', 'unknown')}")
+    facts.append(f"replacement_status={replacement.get('status', 'none')}")
+    facts.append(f"old_automation_ready_to_delete={cleanup.get('old_automation_ready_to_delete', False)}")
+
+    active_seen = parse_iso_datetime(active.get("last_seen_at") or active.get("started_at"))
+    if active_seen and now - active_seen > stale_after:
+        warnings.append(f"active generation last seen {now - active_seen} ago")
+
+    prepared_at = parse_iso_datetime(replacement.get("prepared_at"))
+    if replacement.get("status") == "pending_start":
+        warnings.append("replacement thread is pending_start; old automation must stay active")
+        if prepared_at and now - prepared_at > stale_after:
+            warnings.append(f"replacement has been pending for {now - prepared_at}")
+
+    if cleanup.get("old_automation_ready_to_delete") and not replacement.get("thread_id"):
+        warnings.append("cleanup says ready, but replacement thread_id is missing")
+
+    if context_percent is not None and context_percent >= context_threshold:
+        warnings.append(f"context estimate {context_percent:.1f}% is at/above threshold {context_threshold:.1f}%")
+
+    return facts, warnings
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    now = utc_now()
+    state_path = repo_root / args.state_file
+    bootstrap_path = repo_root / args.bootstrap_file
+    current_path = repo_root / args.current_file
+
+    state = load_state(state_path)
+    state_error = state_error_payload(state, state_path, repo_root)
+    if state_error and not args.force_reset_state:
+        print(json.dumps(state_error, indent=2))
+        return 2
+    if state_error and args.force_reset_state:
+        state = {
+            "schema_version": SCHEMA_VERSION,
+            "reset_from_error": state_error["error"],
+        }
+    prepared_state = prepare_state(
+        state,
+        now=now,
+        active_thread_id=args.active_thread_id,
+        active_automation_id=args.active_automation_id,
+        bootstrap_path=Path(args.bootstrap_file),
+        context_percent=args.context_percent,
+        force_new_replacement=args.force_new_replacement,
+    )
+    snapshot = gather_snapshot(repo_root, args.monitor_base_url)
+    prompt = render_bootstrap_prompt(snapshot, prepared_state, context_threshold=args.context_threshold)
+    current_md = render_current_markdown(snapshot, prepared_state, context_threshold=args.context_threshold)
+
+    if args.dry_run:
+        output = {
+            "dry_run": True,
+            "state_file": str(state_path),
+            "bootstrap_file": str(bootstrap_path),
+            "current_file": str(current_path),
+            "old_automation_ready_to_delete": False,
+            "bootstrap_prompt": prompt,
+        }
+        print(json.dumps(output, indent=2))
+        return 0
+
+    bootstrap_path.parent.mkdir(parents=True, exist_ok=True)
+    bootstrap_path.write_text(prompt, encoding="utf-8")
+    write_json_atomic(state_path, prepared_state)
+    wrote_current = False
+    if args.write_current:
+        current_path.parent.mkdir(parents=True, exist_ok=True)
+        current_path.write_text(current_md, encoding="utf-8")
+        wrote_current = True
+
+    output = {
+        "state_file": rel(state_path, repo_root),
+        "bootstrap_file": rel(bootstrap_path, repo_root),
+        "current_file": rel(current_path, repo_root) if wrote_current else None,
+        "replacement_status": prepared_state["replacement"]["status"],
+        "old_automation_ready_to_delete": prepared_state["cleanup"]["old_automation_ready_to_delete"],
+    }
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+def cmd_confirm_started(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    state_path = repo_root / args.state_file
+    state = load_state(state_path)
+    state_error = state_error_payload(state, state_path, repo_root)
+    if state_error:
+        print(json.dumps(state_error, indent=2))
+        return 2
+    try:
+        confirmed = confirm_started(
+            state,
+            new_thread_id=args.new_thread_id,
+            new_automation_id=args.new_automation_id,
+            confirmed_by=args.confirmed_by,
+            now=utc_now(),
+        )
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
+    write_json_atomic(state_path, confirmed)
+    print(json.dumps({
+        "state_file": rel(state_path, repo_root),
+        "replacement_status": confirmed["replacement"]["status"],
+        "replacement_thread_id": confirmed["replacement"]["thread_id"],
+        "old_automation_ready_to_delete": confirmed["cleanup"]["old_automation_ready_to_delete"],
+    }, indent=2))
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    state_path = repo_root / args.state_file
+    state = load_state(state_path)
+    facts, warnings = check_state(
+        state,
+        now=utc_now(),
+        stale_after=timedelta(hours=args.stale_hours),
+        context_percent=args.context_percent,
+        context_threshold=args.context_threshold,
+    )
+    payload = {"facts": facts, "warnings": warnings, "state_file": rel(state_path, repo_root)}
+    print(json.dumps(payload, indent=2))
+    return 2 if warnings else 0
+
+
+def cmd_audit(args: argparse.Namespace) -> int:
+    codex_home = Path(args.codex_home).expanduser().resolve()
+    audit = inspect_codex_home(codex_home)
+    audit["monitor"] = gather_monitor_state(args.monitor_base_url) if args.include_monitor else "skipped"
+    print(json.dumps(audit, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_file())
+    parser.add_argument("--monitor-base-url", default=os.environ.get("MONITOR_API_BASE_URL", DEFAULT_MONITOR_BASE_URL))
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare", help="Prepare a rollover handoff and bootstrap prompt.")
+    prepare.add_argument("--state-file", type=Path, default=DEFAULT_STATE_PATH)
+    prepare.add_argument("--bootstrap-file", type=Path, default=DEFAULT_BOOTSTRAP_PATH)
+    prepare.add_argument("--current-file", type=Path, default=DEFAULT_CURRENT_PATH)
+    prepare.add_argument("--active-thread-id")
+    prepare.add_argument("--active-automation-id")
+    prepare.add_argument("--context-percent", type=float)
+    prepare.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)
+    prepare.add_argument("--force-new-replacement", action="store_true")
+    prepare.add_argument(
+        "--force-reset-state",
+        action="store_true",
+        help="Discard an unreadable lease state file and start a new lease.",
+    )
+    prepare.add_argument("--write-current", action="store_true", help="Also overwrite docs/session-state/current.md.")
+    prepare.add_argument("--dry-run", action="store_true", help="Print the generated packet without writing files.")
+    prepare.set_defaults(func=cmd_prepare)
+
+    confirm = subparsers.add_parser("confirm-started", help="Confirm that the replacement Codex thread is running.")
+    confirm.add_argument("--state-file", type=Path, default=DEFAULT_STATE_PATH)
+    confirm.add_argument("--new-thread-id", required=True)
+    confirm.add_argument("--new-automation-id")
+    confirm.add_argument("--confirmed-by", default=os.environ.get("USER", "operator"))
+    confirm.set_defaults(func=cmd_confirm_started)
+
+    check = subparsers.add_parser("check", help="Detect stale or unsafe handoff state.")
+    check.add_argument("--state-file", type=Path, default=DEFAULT_STATE_PATH)
+    check.add_argument("--stale-hours", type=float, default=DEFAULT_STALE_HOURS)
+    check.add_argument("--context-percent", type=float)
+    check.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)
+    check.set_defaults(func=cmd_check)
+
+    audit = subparsers.add_parser("audit", help="Inspect local Codex thread/automation metadata.")
+    audit.add_argument("--codex-home", default=os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
+    audit.add_argument("--include-monitor", action="store_true")
+    audit.set_defaults(func=cmd_audit)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import thread_handoff as th
+
+
+def sample_snapshot(tmp_path: Path) -> dict:
+    return {
+        "generated_at": "2026-05-30T08:00:00Z",
+        "git": {
+            "repo_root": str(tmp_path),
+            "branch": "main",
+            "head": "abc123def0",
+            "full_head": "abc123def0456789",
+            "ahead_behind": {"ahead": 1, "behind": 0, "upstream": "origin/main"},
+            "last_commits": [
+                {"sha": "abc123def0", "subject": "docs(session): handoff"},
+                {"sha": "1111111111", "subject": "feat(api): monitor"},
+            ],
+            "modified_files": [
+                {"status": "M", "path": "docs/session-state/current.md"},
+            ],
+        },
+        "monitor": {
+            "base_url": "http://127.0.0.1:8765",
+            "orient": {"git": {"head": "abc123def0"}},
+            "active_delegates": {"total": 0, "tasks": []},
+            "completed_delegates": {
+                "total": 1,
+                "tasks": [{"task_id": "codex/example", "agent": "codex", "status": "done", "duration_s": 42}],
+            },
+            "worktrees": {"count": 2, "worktrees": []},
+        },
+        "github": {
+            "open_prs": [
+                {
+                    "number": 12,
+                    "title": "feat: example",
+                    "headRefName": "codex/example",
+                    "mergeStateStatus": "CLEAN",
+                    "isDraft": False,
+                }
+            ],
+            "open_issues": [
+                {"number": 34, "title": "Need handoff", "updatedAt": "2026-05-30T07:00:00Z"},
+            ],
+        },
+    }
+
+
+def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = th.prepare_state(
+        {},
+        now=now,
+        active_thread_id="old-thread",
+        active_automation_id="old-auto",
+        bootstrap_path=Path(".agent/bootstrap.md"),
+        context_percent=86.0,
+        force_new_replacement=False,
+    )
+
+    assert state["active"]["thread_id"] == "old-thread"
+    assert state["active"]["automation_id"] == "old-auto"
+    assert state["replacement"]["status"] == "pending_start"
+    assert state["cleanup"]["old_automation_ready_to_delete"] is False
+
+    confirmed = th.confirm_started(
+        state,
+        new_thread_id="new-thread",
+        new_automation_id=None,
+        confirmed_by="tester",
+        now=now + timedelta(minutes=2),
+    )
+    assert confirmed["replacement"]["status"] == "started"
+    assert confirmed["replacement"]["thread_id"] == "new-thread"
+    assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
+
+
+def test_confirm_started_rejects_missing_pending_replacement():
+    with pytest.raises(ValueError, match="run prepare first"):
+        th.confirm_started(
+            {},
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+        )
+
+
+def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = th.prepare_state(
+        {},
+        now=now,
+        active_thread_id="old-thread",
+        active_automation_id="old-auto",
+        bootstrap_path=Path(".agent/bootstrap.md"),
+        context_percent=90.0,
+        force_new_replacement=False,
+    )
+    prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
+
+    assert "You are the replacement Codex orchestrator thread." in prompt
+    assert "confirm-started --new-thread-id <replacement-thread-id>" in prompt
+    assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
+    assert "Context estimate: 90.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
+
+
+def test_render_current_markdown_includes_required_handoff_sections(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = th.prepare_state(
+        {},
+        now=now,
+        active_thread_id="old-thread",
+        active_automation_id=None,
+        bootstrap_path=Path(".agent/bootstrap.md"),
+        context_percent=None,
+        force_new_replacement=False,
+    )
+    rendered = th.render_current_markdown(sample_snapshot(tmp_path), state, context_threshold=82.0)
+
+    assert "## Thread Lease" in rendered
+    assert "## Git State" in rendered
+    assert "### Last 5 Commits" in rendered
+    assert "### Modified Files" in rendered
+    assert "## Open PRs" in rendered
+    assert "## Delegated Tasks" in rendered
+    assert "## Next Commands" in rendered
+    assert "docs/session-state/current.md" in rendered
+
+
+def test_check_state_flags_pending_and_stale_replacement():
+    prepared_at = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = {
+        "active": {"generation": "orchestrator-1", "last_seen_at": th.isoformat_z(prepared_at)},
+        "replacement": {"status": "pending_start", "prepared_at": th.isoformat_z(prepared_at)},
+        "cleanup": {"old_automation_ready_to_delete": False},
+    }
+
+    facts, warnings = th.check_state(
+        state,
+        now=prepared_at + timedelta(hours=13),
+        stale_after=timedelta(hours=12),
+        context_percent=83.0,
+        context_threshold=82.0,
+    )
+
+    assert "active_generation=orchestrator-1" in facts
+    assert any("pending_start" in warning for warning in warnings)
+    assert any("context estimate 83.0%" in warning for warning in warnings)
+    assert any("replacement has been pending" in warning for warning in warnings)
+
+
+def test_check_state_flags_corrupted_state_file():
+    facts, warnings = th.check_state(
+        {"schema_version": th.SCHEMA_VERSION, "state_error": "unreadable state file: bad json"},
+        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+        stale_after=timedelta(hours=12),
+        context_percent=None,
+        context_threshold=82.0,
+    )
+
+    assert "replacement_status=none" in facts
+    assert warnings == ["unreadable state file: bad json"]
+
+
+def test_prepare_refuses_to_overwrite_corrupted_state_file(tmp_path: Path, capsys, monkeypatch):
+    state_file = Path(".agent/orchestrator-thread-lease.json")
+    state_path = tmp_path / state_file
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main([
+        "--repo-root",
+        str(tmp_path),
+        "prepare",
+        "--state-file",
+        str(state_file),
+        "--bootstrap-file",
+        ".agent/bootstrap.md",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "unreadable state file" in payload["error"]
+    assert state_path.read_text(encoding="utf-8") == "{not-json"
+    assert not (tmp_path / ".agent/bootstrap.md").exists()
+
+
+def test_parse_ahead_behind_reports_malformed_output():
+    parsed = th.parse_ahead_behind("not-a-count", "origin/main")
+
+    assert parsed == {
+        "upstream": "origin/main",
+        "parse_error": "unexpected rev-list output: 'not-a-count'",
+    }
+
+
+def test_inspect_codex_home_reports_thread_metadata(tmp_path: Path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    db = codex_home / "state_1.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "create table threads (id text, title text, cwd text, archived integer, updated_at integer)"
+        )
+        conn.execute(
+            "insert into threads values ('thread-1', 'Example', '/tmp/repo', 0, 100)"
+        )
+
+    audit = th.inspect_codex_home(codex_home)
+
+    assert audit["latest_state_db"] == str(db)
+    assert audit["thread_count"] == 1
+    assert audit["recent_threads"][0]["id"] == "thread-1"
+    assert audit["automation_toml_files"] == []


### PR DESCRIPTION
## Summary

Closes #2438.

Adds a local Codex thread-handoff system for overnight orchestrator rollovers:

- `scripts/orchestration/thread_handoff.py` gathers monitor/git/GitHub state, writes a guarded local lease, generates a replacement bootstrap prompt, can update `docs/session-state/current.md`, and refuses old-heartbeat cleanup until `confirm-started` records the replacement thread id.
- `docs/best-practices/codex-thread-handoff.md` documents the verified app-tool/local-metadata audit and the shortest safe operator workflow.
- `tests/orchestration/test_thread_handoff.py` covers the core state machine, stale pending detection, prompt/current rendering, and local Codex metadata audit.

## Validation

- Gemini adversarial implementation review on #2438: no blocking findings.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/orchestration/thread_handoff.py tests/orchestration/test_thread_handoff.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/orchestration/thread_handoff.py prepare --dry-run --context-percent 86`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/orchestration/thread_handoff.py audit`
- `npx markdownlint-cli2 docs/best-practices/codex-thread-handoff.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
