### PR TITLE
feat(bio): 10 Phase-1 research dossiers — Block G (#2309)

### DIFF
--- a/docs/research/bio/andrii-melnyk.md
+++ b/docs/research/bio/andrii-melnyk.md
@@ -1,0 +1,113 @@
+# Андрій Атанасович Мельник — Research Dossier
+
+**Slug:** `andrii-melnyk`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Андрій Атанасович Мельник.
+- **Pseudonyms / aliases:** Євген; English canonical: Andrii Melnyk.
+- **Born:** 12 December 1890 | Volia Yakubova, Drohobych area, Galicia | Austria-Hungary. [T1: ЕСУ — Мельник Андрій Атанасович] [T1: IEU — Melnyk, Andrii]
+- **Died:** 1 November 1964 | Clervaux, Grand Duchy of Luxembourg; buried in Luxembourg. ЕСУ gives Clervaux and burial in Luxembourg; IEU confirms the date and exile death. [T1: ЕСУ] [T1: IEU]
+- **Family / education key facts:** Studied at the Stryi gymnasium and the Higher Agricultural School in Vienna; volunteered for the Ukrainian Sich Riflemen; became a colonel of the UNR Army; worked with Metropolitan Andrei Sheptytsky after Polish imprisonment; elected OUN leader after Yevhen Konovalets's assassination. [T1: ЕСУ] [T1: IEU]
+
+No OS/NS discrepancy was found for the vital dates. The common place-name issue is older Polish/German spellings of Volia Yakubova and Luxembourg localities; use Ukrainian canonical forms in body prose.
+
+## 2. Oppression mechanism
+
+- **What happened:** Russian imperial wartime captivity; Polish imprisonment for UVO activity; Nazi arrest and Sachsenhausen imprisonment; exile under Soviet threat.
+- **When:** Russian captivity during the First World War; Polish imprisonment in the 1920s, with release in 1928; Nazi arrest at the beginning of 1944 and release late that year. [T1: ЕСУ] [T2: Ukrainian 10th-grade textbook RAG]
+- **By whom:** Russian imperial military authorities; Polish state; German security authorities; Soviet services as hostile postwar opponents, though no direct Soviet arrest file was retrieved.
+- **Document references:** No Soviet or Polish case-file number retrieved in this pass. ЕСУ and IEU provide the core chronology; textbook RAG corroborates Sachsenhausen.
+
+Melnyk's oppression is multi-regime. He was a Ukrainian officer of the independence struggle, then an underground UVO/OUN actor under Polish rule, then a factional OUN leader under Nazi occupation and in exile. The Nazi imprisonment matters because it prevents a flat "German puppet" label, but his movement still tried to use Germany's attack on the USSR to open space for Ukrainian statehood.
+
+## 3. Major works
+
+- `1930s-1960s` — historical articles on the Ukrainian independence struggle; noted by IEU but requiring page-verified bibliography.
+- `1941-1944` — memoranda and political correspondence of the OUN-M milieu, including appeals against German policy in Ukraine; use source editions in Phase 2.
+- `Postwar` — PUN/OUN-M addresses and organizational documents; political prose rather than literary writing.
+
+Melnyk is a military-political dossier, not a literature dossier. Works should be treated as institutional documents.
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Будіть віру в прийдешнє..." Source: Ukrainian 10th-grade history textbook excerpt quoting Melnyk. This short imperative shows the didactic tone of OUN-M public speech. [T2: textbook RAG]
+- "Українську самостійну державу" appears in the same quoted textbook passage as the aim of faith and struggle. Use only with the textbook citation until a primary edition is retrieved. [T2: textbook RAG]
+
+Source gap: a scanned page-stable Melnyk edition was not retrieved. Do not add longer quotes from unsourced commemorative websites.
+
+## 5. Language register
+
+- **Register:** military-political, disciplined, exhortative.
+- **CEFR readiness for full reading:** C1 for authentic political documents; B2 for excerpts.
+- **Lexicon notes:** `Провід`, `державність`, `обов'язок`, `віра`, `самостійність`, older nationalist institutional vocabulary.
+- **Stylistic features:** direct address, officerly moral vocabulary, less populist and more hierarchical than Banderaite prose.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Melnyk headed the older OUN line after Konovalets. IEU's OUN entry stresses the Rome 1939 assembly, the title `vozhd`, and the generational split with Bandera's younger, more radical western-Ukrainian activists. That authoritarian leadership model must be recorded. [T1: IEU — Organization of Ukrainian Nationalists]
+- **What gets simplified in popular memory:** Melnyk is sometimes reduced to "the moderate one" because OUN-M is contrasted with OUN-B. That is too simple. OUN-M was still an integral-nationalist, authoritarian movement and sought geopolitical openings from Axis warfare. Conversely, projecting all OUN-B/UPA decisions onto Melnyk obscures the real split and later rivalry.
+- **Where modern Russian disinformation attacks him:** Russian narratives frequently avoid distinctions among OUN-M, OUN-B, UVO, UPA, and UNR veterans, turning all Ukrainian independence actors into one "fascist" category. This erases Melnyk's service in the UNR Army, his post-Konovalets factional role, and his Nazi imprisonment.
+- **Polish / Jewish / other-perspective considerations:** Polish perspectives matter because Melnyk's early underground milieu operated under the Polish state and used political violence; Jewish perspectives matter because OUN ideological environments, even outside OUN-B, contained authoritarian and exclusionary assumptions. For Melnyk specifically, the dossier should not attribute Kliachkivskyi's Volhynia command role to him, but it should place OUN-M within the broader right-wing nationalist field that modern scholarship studies critically.
+- **NPOV-decolonized framing:** Melnyk should be framed as an anti-imperial Ukrainian officer and OUN-M leader who faced Russian, Polish, and Nazi coercion, while also representing an authoritarian nationalist tradition. The balanced curriculum question is not "hero or collaborator"; it is how Ukrainian statehood projects operated in a violent imperial borderland while carrying their own exclusionary politics.
+- **Specific classroom caution:** Melnyk's biography is useful for teaching factional precision. A lesson should not say "the OUN did X" when the event belongs specifically to OUN-B, UPA-North, OUN-M, UVO, or a German-controlled auxiliary structure. At the same time, factional precision is not an excuse to make OUN-M ideologically harmless. The Rome 1939 leadership language and the movement's hierarchical imagination are part of the evidence base.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml`
+  - `curriculum/l2-uk-en/plans/bio/dmytro-dontsov.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/polskyi-pohliad.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - BIO plan for Melnyk; comparison activity on OUN-M versus OUN-B.
+
+## 8. Naming-canonical
+
+- **Slug:** `andrii-melnyk`
+- **EN canonical (BGN/PCGN 2010):** Andrii Melnyk
+- **UA canonical:** Андрій Атанасович Мельник
+- **Aliases:** Євген; Andrii Melnyk; Andriy Melnyk as search alias.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Andrei Melnik; Andrey Melnik; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons image of Andrii Melnyk, license to verify.
+- **Backup candidates:** ЕСУ portrait; IEU image if permission is documented.
+- **Era-appropriate context image:** Ukrainian Sich Riflemen/UNR Army public-domain image for context, not as a substitute portrait.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Мельник Андрій Атанасович." <https://esu.com.ua/article-66256> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Melnyk, Andrii." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CM%5CE%5CMelnykAndrii.htm>.
+- Internet Encyclopedia of Ukraine. "Organization of Ukrainian Nationalists." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CO%5CR%5COrganizationofUkrainianNationalists.htm>.
+
+**Tier 2 (institutional):**
+- Ukrainian 10th-grade history textbook RAG excerpts on Melnyk and OUN.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grzegorz Rossolinski-Liebe, *Stepan Bandera*.
+- Per Anders Rudling, "The OUN, the UPA and the Holocaust."
+- John-Paul Himka, *Ukrainian Nationalists and the Holocaust*.
+
+**Primary-source documents accessed:**
+- No Melnyk case-file ID retrieved; primary quotations limited to textbook-cited excerpts pending Phase 2 scan check.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] OUN-M and OUN-B distinguished.
+- [x] Russian-imperial spellings confined to §8.
+- [x] Nazi imprisonment and authoritarian nationalism both named.
+- [x] No Soviet encyclopedia framing used.
+- [x] No invented case file or quote.

--- a/docs/research/bio/avhustyn-voloshyn.md
+++ b/docs/research/bio/avhustyn-voloshyn.md
@@ -12,7 +12,7 @@
 - **Full name (UA, canonical):** Августин Іванович Волошин.
 - **Pseudonyms / aliases:** о. Августин Волошин; Monsignor Avhustyn Voloshyn; English canonical: Avhustyn Voloshyn.
 - **Born:** 17 March 1874 | Kelechyn, Transcarpathia | Austria-Hungary. [T1: ЕСУ — Волошин Августин Іванович] [T1: IEU — Voloshyn, Avhustyn]
-- **Died:** July 1945 | Moscow, USSR | died after Soviet arrest and imprisonment. IEU gives 19 July 1945 in Moscow; Ukrainian textbook RAG says Soviet counterintelligence arrested him on 1 May 1945 and transported him to a Soviet prison where he died; some Ukrainian memorial sources give 11 July, so the dossier flags 19 July as IEU/ESU-preferred pending archival check. [T1: IEU] [T2: textbook RAG]
+- **Died:** July 1945 | Moscow, USSR | died after Soviet arrest and imprisonment. IEU gives 19 July 1945 in Moscow; Ukrainian textbook RAG says Soviet counterintelligence arrested him on 1 May 1945 and transported him to a Soviet prison where he died; some Ukrainian memorial sources give 11 July, so the dossier flags 19 July as IEU/ЕСУ-preferred pending archival check. [T1: IEU] [T2: textbook RAG]
 - **Family / education key facts:** Greek Catholic priest, teacher, pedagogue, publisher, head of the autonomous Carpatho-Ukrainian government, and president of Carpatho-Ukraine declared in Khust on 15 March 1939. [T1: ЕСУ] [T1: IEU]
 
 ## 2. Oppression mechanism

--- a/docs/research/bio/avhustyn-voloshyn.md
+++ b/docs/research/bio/avhustyn-voloshyn.md
@@ -1,0 +1,113 @@
+# Августин Іванович Волошин — Research Dossier
+
+**Slug:** `avhustyn-voloshyn`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Августин Іванович Волошин.
+- **Pseudonyms / aliases:** о. Августин Волошин; Monsignor Avhustyn Voloshyn; English canonical: Avhustyn Voloshyn.
+- **Born:** 17 March 1874 | Kelechyn, Transcarpathia | Austria-Hungary. [T1: ЕСУ — Волошин Августин Іванович] [T1: IEU — Voloshyn, Avhustyn]
+- **Died:** July 1945 | Moscow, USSR | died after Soviet arrest and imprisonment. IEU gives 19 July 1945 in Moscow; Ukrainian textbook RAG says Soviet counterintelligence arrested him on 1 May 1945 and transported him to a Soviet prison where he died; some Ukrainian memorial sources give 11 July, so the dossier flags 19 July as IEU/ESU-preferred pending archival check. [T1: IEU] [T2: textbook RAG]
+- **Family / education key facts:** Greek Catholic priest, teacher, pedagogue, publisher, head of the autonomous Carpatho-Ukrainian government, and president of Carpatho-Ukraine declared in Khust on 15 March 1939. [T1: ЕСУ] [T1: IEU]
+
+## 2. Oppression mechanism
+
+- **What happened:** Arrested by Soviet counterintelligence in Prague and transported to Moscow, where he died in Soviet custody.
+- **When:** Arrest on 1 May 1945; death in July 1945, with 19 July used by IEU and several references.
+- **By whom:** Soviet counterintelligence/SMERSH-era security apparatus.
+- **Document references:** Full interrogation/custody file ID not retrieved. The textbook RAG states the arrest and Soviet imprisonment; IEU and ЕСУ provide vital dates and Moscow death.
+
+Voloshyn's oppression was direct Soviet state violence against the president of a short-lived Ukrainian polity. He was an elderly priest-educator in Prague when Soviet forces arrived, not an armed underground commander. This is why the mechanism should be framed as Soviet removal of a Ukrainian statehood symbol from Central Europe after the Second World War. [T1: IEU] [T2: textbook RAG]
+
+Hungarian occupation and the collapse of Czechoslovakia are also essential context. Carpatho-Ukraine was declared as Nazi Germany dismantled Czechoslovakia and Hungary invaded. That context does not make Voloshyn a German puppet; nor does it make the one-day state free from authoritarian emergency politics.
+
+## 3. Major works
+
+- `1904` — *Азбука*, school textbook.
+- `1907` — *Практична граматика малоруської мови*, Hungarian-language grammar defending the living popular language and Ukrainian linguistic unity. [T1: ЕСУ]
+- `1919` — *Наука о числах для 1 и 2 классов народных школ*, mathematics textbook.
+- `1920` — *Педагогічна психологія*, pedagogical work.
+- `1920` — *Педагогіка і дидактика*, teacher-training work.
+- `1923` — *Исторія педагогики для учительських семинарій*, education history.
+- `1931` — *Коротка історія педагогіки для учительських семінарій*, textbook.
+- `1935` — *Логіка*, *Методика народно-шкільного навчання*, *Фізика й хемія*, school works.
+- `1942` — *Про шкільне право будучої української держави*, state-building education text.
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Головною умовою культурного поступу ... є свобода культурної праці." Source: local RAG excerpt from Волошин, *Вибрані твори*. Useful for presenting education and culture as public freedom. [T2: local RAG, `wiki/mastery/c2/teaching-ukrainian-i.md`]
+- "Письменник своїми шляхетними думками... виховує свій нарід." Source: same local RAG excerpt. Useful for pedagogy because Voloshyn links literature, ethics, and national education. [T2: local RAG]
+
+Phase 2 should verify page numbers in the printed *Вибрані твори* edition before using the quotes in learner-facing materials.
+
+## 5. Language register
+
+- **Register:** pedagogical, clerical-public, early 20th-century Transcarpathian Ukrainian.
+- **CEFR readiness for full reading:** B2-C1 depending on orthography; A2/B1 only through adapted excerpts.
+- **Lexicon notes:** older school terms, Transcarpathian/Church vocabulary, historical spellings in titles.
+- **Stylistic features:** normative argument, teacherly clarity, moral vocabulary, nation-building through education.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The core debate is how to frame Carpatho-Ukraine in March 1939. Ukrainian scholarship treats it as a serious act of Ukrainian state-building in Transcarpathia, rooted in local institutions and an elected Soim. Critical scholarship also notes the impossible geopolitical setting: Czechoslovakia was collapsing, Germany was manipulating the region, Hungary invaded, and local emergency politics narrowed pluralism. [T1: ЕСУ] [T1: IEU] [T4: Vehesh/Vidnianskyi bibliography]
+- **What gets simplified in popular memory:** Ukrainian memory often presents Voloshyn as a saintly president-priest and Soviet martyr. That is not false in outline, but it risks flattening the messy 1938-39 politics, the role of Carpathian Sich, and minority/Rusyn-Hungarian tensions.
+- **Where modern Russian disinformation attacks him:** Russian and pro-imperial narratives sometimes portray Carpatho-Ukraine as an artificial German-backed project to deny Transcarpathian Ukrainian agency. The decolonized response is to show local institutions, education work, Ukrainian language activism, and the Soviet arrest after 1945. It is not to ignore the region's plural identities or German-Hungarian pressure.
+- **Polish / Jewish / other-perspective considerations:** Jewish and Hungarian communities in Transcarpathia were profoundly affected by the Hungarian occupation and the wider Holocaust context. Voloshyn's own dossier should not absorb all regional wartime history, but a module connected to him should not present Carpatho-Ukraine as ethnically simple.
+- **NPOV-decolonized framing:** Voloshyn is a Ukrainian priest, educator, and president of Carpatho-Ukraine who died in Soviet custody. He should be taught as a statehood figure and as a pedagogue, while the curriculum also names the emergency politics and regional minority complexities of 1938-39.
+- **Regional identity caution:** Older sources may use "Ruthenian," "Rusyn," "Carpatho-Ruthenian," or "Ukrainian" differently. The dossier should not retroactively erase local naming debates, but it should also avoid Russian-imperial claims that Transcarpathian identity was naturally anti-Ukrainian. Voloshyn's education and language work is evidence for a Ukrainian orientation within a plural region.
+- **Date caution:** Preserve the July 1945 death-date discrepancy in notes until an archival custody record is checked.
+- **Pedagogy caution:** His textbooks make him more than a one-day president; include the educator arc.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/karpatska-ukraina.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/zakarpattia-tysiacholittia.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Voloshyn; education-history reading on his school textbooks; source analysis on Soviet arrest narratives.
+
+## 8. Naming-canonical
+
+- **Slug:** `avhustyn-voloshyn`
+- **EN canonical (BGN/PCGN 2010):** Avhustyn Voloshyn
+- **UA canonical:** Августин Іванович Волошин
+- **Aliases:** о. Августин Волошин; Monsignor Avhustyn Voloshyn; Augustin Voloshyn as search alias.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Avgustin Voloshin; Augustin Ivanovich Voloshin; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait of Avhustyn Voloshyn; verify license.
+- **Backup candidates:** ЕСУ page image; NBU/educational memorial page images if rights allow.
+- **Era-appropriate context image:** Khust/Carpatho-Ukraine Soim image or map, rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Волошин Августин Іванович." <https://esu.com.ua/article-27856> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Voloshyn, Avhustyn." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CO%5CVoloshynAvhustyn.htm>.
+
+**Tier 2 (institutional):**
+- Ukrainian 10th-grade history textbook RAG excerpt on Voloshyn's arrest and Soviet prison death.
+- Vernadsky National Library / pedagogical bibliography page on Voloshyn's 150th anniversary and works.
+
+**Tier 4 (modern scholarly post-1991):**
+- Mykola Vehesh and Stepan Vidnianskyi, *Августин Волошин і Карпатська Україна* / related Institute of History scholarship.
+
+**Primary-source documents accessed:**
+- Local RAG quotes from *Вибрані твори*; no Soviet custody file ID retrieved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Soviet arrest/death named directly.
+- [x] Carpatho-Ukraine framed as Ukrainian statehood without erasing geopolitics.
+- [x] Minority/regional complexity acknowledged.
+- [x] No Russian-imperial spellings in body prose.
+- [x] Date discrepancy flagged.

--- a/docs/research/bio/dmytro-kliachkivskyi.md
+++ b/docs/research/bio/dmytro-kliachkivskyi.md
@@ -12,7 +12,7 @@
 - **Full name (UA, canonical):** Дмитро-Роман Семенович Клячківський.
 - **Pseudonyms / aliases:** Клим Савур, Охрім, Білаш; English canonical: Dmytro Kliachkivskyi.
 - **Born:** 4 November 1911 | Zbarazh area, Galicia | Austria-Hungary. ЕСУ and IEU/Savur identify him as the UPA commander known as Klym Savur; use ЕСУ for the full Ukrainian name. [T1: ЕСУ — Клячківський Дмитро-Роман Семенович] [T1: IEU — Savur, Klym]
-- **Died:** 12 February 1945 | near Orzhiv/Klevan area, Rivne region | killed in an NKVD/NKDB operation. [T1: ЕСУ] [T4: Patryliak/Motyka references]
+- **Died:** 12 February 1945 | near Orzhiv/Klevan area, Rivne region | killed in an NKVD/NKGB operation. [T1: ЕСУ] [T4: Patryliak/Motyka references]
 - **Family / education key facts:** Educated in Ukrainian schools in Galicia; joined OUN; became one of the principal OUN-B/UPA commanders in Volhynia and Polissia; remembered as commander of UPA-North. [T1: ЕСУ] [T1: IEU]
 
 No OS/NS discrepancy was found for the death date. The contested point is not the date but command responsibility for anti-Polish violence in Volhynia.
@@ -21,7 +21,7 @@ No OS/NS discrepancy was found for the death date. The contested point is not th
 
 - **What happened:** Soviet security pursuit and killing in the forest near Orzhiv after the return of Soviet power to western Ukraine.
 - **When:** 10-12 February 1945 operation window; death on 12 February 1945.
-- **By whom:** NKVD internal troops and NKDB operative group, according to Ukrainian historical summaries of the Orzhiv operation.
+- **By whom:** NKVD internal troops and NKGB operative group, according to Ukrainian historical summaries of the Orzhiv operation.
 - **Document references:** This pass did not retrieve the full archival file. Secondary summaries refer to Soviet operational records and later Ukrainian scholarly discussion of the Orzhiv operation. Mark the precise fond/opys/sprava as source not found.
 
 Kliachkivskyi's death was a Soviet counterinsurgency killing, not an ordinary battlefield casualty. The mechanism belongs in the dossier because Soviet and later Russian accounts framed UPA as "banditry" while hiding the colonial counterinsurgency context. At the same time, the Soviet source category is dangerous: operational reports can document time, unit, and coercive method, but cannot be treated as authoritative on Ukrainian motives or legitimacy. [T1: ЕСУ] [T2: source-tier policy]
@@ -109,7 +109,7 @@ One disputed order attributed to him concerning Poles is discussed in Motyka thr
 
 ## Decolonization self-check (run before submitting)
 
-- [x] Soviet counterinsurgency named as NKVD/NKDB, not neutralized.
+- [x] Soviet counterinsurgency named as NKVD/NKGB, not neutralized.
 - [x] Volhynia controversy centered and attributed.
 - [x] Polish civilian perspective explicitly included.
 - [x] No Russian-imperial spellings in body prose.

--- a/docs/research/bio/dmytro-kliachkivskyi.md
+++ b/docs/research/bio/dmytro-kliachkivskyi.md
@@ -1,0 +1,116 @@
+# Дмитро-Роман Семенович Клячківський — Research Dossier
+
+**Slug:** `dmytro-kliachkivskyi`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дмитро-Роман Семенович Клячківський.
+- **Pseudonyms / aliases:** Клим Савур, Охрім, Білаш; English canonical: Dmytro Kliachkivskyi.
+- **Born:** 4 November 1911 | Zbarazh area, Galicia | Austria-Hungary. ЕСУ and IEU/Savur identify him as the UPA commander known as Klym Savur; use ЕСУ for the full Ukrainian name. [T1: ЕСУ — Клячківський Дмитро-Роман Семенович] [T1: IEU — Savur, Klym]
+- **Died:** 12 February 1945 | near Orzhiv/Klevan area, Rivne region | killed in an NKVD/NKDB operation. [T1: ЕСУ] [T4: Patryliak/Motyka references]
+- **Family / education key facts:** Educated in Ukrainian schools in Galicia; joined OUN; became one of the principal OUN-B/UPA commanders in Volhynia and Polissia; remembered as commander of UPA-North. [T1: ЕСУ] [T1: IEU]
+
+No OS/NS discrepancy was found for the death date. The contested point is not the date but command responsibility for anti-Polish violence in Volhynia.
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet security pursuit and killing in the forest near Orzhiv after the return of Soviet power to western Ukraine.
+- **When:** 10-12 February 1945 operation window; death on 12 February 1945.
+- **By whom:** NKVD internal troops and NKDB operative group, according to Ukrainian historical summaries of the Orzhiv operation.
+- **Document references:** This pass did not retrieve the full archival file. Secondary summaries refer to Soviet operational records and later Ukrainian scholarly discussion of the Orzhiv operation. Mark the precise fond/opys/sprava as source not found.
+
+Kliachkivskyi's death was a Soviet counterinsurgency killing, not an ordinary battlefield casualty. The mechanism belongs in the dossier because Soviet and later Russian accounts framed UPA as "banditry" while hiding the colonial counterinsurgency context. At the same time, the Soviet source category is dangerous: operational reports can document time, unit, and coercive method, but cannot be treated as authoritative on Ukrainian motives or legitimacy. [T1: ЕСУ] [T2: source-tier policy]
+
+## 3. Major works
+
+- `1942-1945` — UPA-North orders and reports attributed to Клим Савур; no page-verified source edition retrieved in this pass.
+- `1943` — command correspondence around Volhynia operations; use only through document editions or scholarship with archival references.
+- `Posthumous` — entries in *Літопис УПА* and Ukrainian security-archive publications; Phase 2 should retrieve stable pages before quotation.
+
+Kliachkivskyi is not a literary figure. His curriculum value is in command documents and how to read contested orders.
+
+## 4. Primary-source quotes (>=2 required)
+
+Source not found for two page-verified direct quotations from Kliachkivskyi's own writings in retrieved Tier 1/Tier 2 sources. Do not manufacture commands from later polemical websites. Phase 2 should check *Літопис УПА* volumes and HDA SBU document editions before adding quotations.
+
+One disputed order attributed to him concerning Poles is discussed in Motyka through testimony of Yurii Stelmashchuk, but this dossier does not quote it as Kliachkivskyi's own written order because the source chain is contested and requires archival-page verification. [T4: Motyka]
+
+## 5. Language register
+
+- **Register:** underground military-administrative.
+- **CEFR readiness for full reading:** C1-C2 for authentic orders; B2 for excerpts with glossing.
+- **Lexicon notes:** `сотня`, `курінь`, `терен`, `провід`, `боївка`, `внутрішні війська`, security-service abbreviations.
+- **Stylistic features:** compressed commands, euphemistic operational vocabulary, chain-of-command references.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Kliachkivskyi is one of the most sensitive UPA figures because mainstream Polish and Western scholarship often places him near the center of UPA-North decision-making during the 1943 Volhynia massacres. Motyka argues that the decision for large-scale anti-Polish action in western Volhynia was tied to Kliachkivskyi's command position; Snyder treats the violence as ethnic cleansing in a German-Soviet imperial war zone. Ukrainian scholarship debates command chains, local initiative, Soviet/Nazi manipulation, and the relationship between OUN-B orders and village-level violence. [T4: Motyka] [T4: Snyder]
+- **What gets simplified in popular memory:** Some Ukrainian commemorations present him only as an anti-Soviet commander killed by the NKVD. That is incomplete. Some Polish or Russian narratives present him only as a perpetrator, erasing the Soviet counterinsurgency and the fact that UPA also fought Soviet and German forces. The dossier must keep both dimensions visible.
+- **Where modern Russian disinformation attacks him:** Russian disinformation uses Volhynia to delegitimize all Ukrainian resistance and even present contemporary Ukraine as inherently genocidal. That is propaganda. The response cannot be denial; it must be source-based acknowledgment of civilian killings and command-responsibility debates, with clear separation from current Russian war narratives.
+- **Polish / Jewish / other-perspective considerations:** Polish civilian suffering is central, not optional. The curriculum should use Polish scholarship and survivor-centered material in the Volhynia modules. Jewish perspectives enter through OUN/UPA militia histories and the wider German occupation context, though Kliachkivskyi's most direct dossier controversy is Polish-Ukrainian violence.
+- **NPOV-decolonized framing:** Kliachkivskyi should be taught as an anti-Soviet UPA commander killed by Soviet security forces and as a commander tied by serious scholarship to mass violence against Polish civilians. Neither identity cancels the other.
+- **Evidence caution:** The dossier should separate three evidentiary levels: verified UPA-North command role; scholarly attribution of responsibility for Volhynia decisions; and specific alleged written orders, which require page-stable archival publication before quotation. This prevents both denialist evasions and overconfident claims built on weak source chains.
+- **Language caution:** Avoid the Soviet label "bandit" except as a quoted regime category. Use "UPA commander," "underground," and "Soviet counterinsurgency" for neutral prose.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/volyn-pamiat-i-travma.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/volyn-i-pamiat.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/polskyi-pohliad.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml`
+  - `curriculum/l2-uk-en/plans/bio/vasyl-kuk.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Kliachkivskyi; document-analysis activity comparing operational reports, Polish testimony, and Ukrainian underground sources.
+
+## 8. Naming-canonical
+
+- **Slug:** `dmytro-kliachkivskyi`
+- **EN canonical (BGN/PCGN 2010):** Dmytro Kliachkivskyi
+- **UA canonical:** Дмитро-Роман Семенович Клячківський
+- **Aliases:** Клим Савур; Охрім; Білаш; Klym Savur.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Dmitry Klyachkivsky; Klim Savur as Russian-only spelling; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons photo "Dmytro Klyachkivsky UPA.jpg"; verify source and license.
+- **Backup candidates:** ЕСУ PDF image; UPA archive image if rights are clear.
+- **Era-appropriate context image:** Map of Volhynia/UPA-North area, preferably from a rights-cleared educational source.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ PDF. "Клячківський Дмитро-Роман Семенович." <https://esu.com.ua/pdf/file/8656.pdf> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Savur, Klym." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CA%5CSavurKlym.htm>.
+
+**Tier 2 (institutional):**
+- HDA SBU / Ukrainian source-edition leads noted but not page-retrieved; archival ID remains source not found.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grzegorz Motyka, *From the Volhynian Massacre to Operation Vistula*.
+- Timothy Snyder, "The Causes of Ukrainian-Polish Ethnic Cleansing 1943."
+- Ivan Patryliak, studies on OUN/UPA military activity and the Orzhiv operation.
+- Per Anders Rudling, "The OUN, the UPA and the Holocaust."
+
+**Primary-source documents accessed:**
+- No page-stable Kliachkivskyi primary order retrieved in this pass.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Soviet counterinsurgency named as NKVD/NKDB, not neutralized.
+- [x] Volhynia controversy centered and attributed.
+- [x] Polish civilian perspective explicitly included.
+- [x] No Russian-imperial spellings in body prose.
+- [x] No invented primary quotes or file IDs.

--- a/docs/research/bio/kateryna-zarytska.md
+++ b/docs/research/bio/kateryna-zarytska.md
@@ -1,0 +1,116 @@
+# Катерина Миронівна Зарицька — Research Dossier
+
+**Slug:** `kateryna-zarytska`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Катерина Миронівна Зарицька.
+- **Pseudonyms / aliases:** Монета and other underground names require source-edition verification; English canonical: Kateryna Zarytska.
+- **Born:** 5 November 1914 | Kolomyia, Galicia | Austria-Hungary. IEU gives 5 November 1914; ЕСУ confirms the biographical entry and family context. [T1: IEU — Zarytska, Kateryna] [T1: ЕСУ — Зарицька Катерина Миронівна]
+- **Died:** 29 August 1986 | Lviv, Ukrainian SSR | after decades of imprisonment and restricted residence. [T1: IEU] [T1: ЕСУ]
+- **Family / education key facts:** Daughter of mathematician Myron Zarytskyi; student at Lviv Polytechnic; wife of Mykhailo Soroka and mother of Bohdan Soroka; OUN underground organizer; head of the Ukrainian Red Cross within the UPA underground. [T1: IEU] [T1: ЕСУ]
+
+No OS/NS discrepancy found. The birth date occasionally appears as 3 November in general web sources; IEU's 5 November is used here and the discrepancy should be checked before Phase 2 YAML.
+
+## 2. Oppression mechanism
+
+- **What happened:** Polish arrest and imprisonment; Soviet arrest in 1940; MGB arrest in 1947 and 25-year sentence; imprisonment in Russian prisons and Mordovian camps.
+- **When:** Polish arrest 8 November 1934; Soviet arrest 1940; MGB arrest 1947; imprisonment to 1968 with release/residence constraints until 1972. [T1: ЕСУ] [T1: IEU]
+- **By whom:** Polish authorities; Soviet NKVD/MGB; Soviet camp/prison administration.
+- **Document references:** No case-file fond/opys/sprava retrieved. IEU provides prisons: Verkhnouralsk, Vladimir, and Mordovia. [T1: IEU]
+
+Zarytska's oppression is specific and long. Polish authorities prosecuted her for OUN involvement around the Pieracki assassination case. Soviet authorities imprisoned her as an OUN member in 1940, then the MGB arrested her again in 1947 and imposed a 25-year sentence. IEU says she served time in Russian prisons and Mordovian camps and lived in Ternopil oblast after release. [T1: IEU]
+
+The prison geography matters. Verkhnouralsk, Vladimir, and Mordovia place her punishment inside the Soviet/Russian carceral system rather than in an abstract "postwar hardship." A learner-facing biography should name that geography because it connects western Ukrainian underground history with the wider Soviet prison network used against Ukrainian political prisoners.
+
+## 3. Major works
+
+- `1946` — *Науковість діалектичного матеріалізму*, underground critique of Soviet ideology. [T1: ЕСУ]
+- `1946` — *Найбільш демократичні вибори*, political text on Soviet electoral claims. [T1: ЕСУ]
+- `1946` — *Большевики і національне питання*, underground political analysis. [T1: ЕСУ]
+- `1946` — *Шляхи російського імперіалізму*, anti-imperial analysis. [T1: ЕСУ]
+- `1946` — *Чи большевики ведуть до комунізму*, underground critique. [T1: ЕСУ]
+- `1947` — editorial work for an underground journal listed by ЕСУ; title/page details require Phase 2 verification.
+
+## 4. Primary-source quotes (>=2 required)
+
+Source not found for two page-verified direct quotations from Zarytska's own underground works in retrieved Tier 1/Tier 2 sources. The titles above are source-verified through ЕСУ, but titles are not a substitute for quoted passages.
+
+Phase 2 should retrieve a printed or archival edition of her essays before learner-facing quotations. This is especially important because underground anti-Soviet texts often circulate in excerpted form without page control.
+
+## 5. Language register
+
+- **Register:** underground political analysis; organizational and humanitarian vocabulary.
+- **CEFR readiness for full reading:** C1; B2 for selected excerpts.
+- **Lexicon notes:** `діалектичний матеріалізм`, `російський імперіалізм`, `національне питання`, `Український Червоний Хрест`, camp vocabulary.
+- **Stylistic features:** polemical critique, ideological analysis, practical underground register.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Zarytska is often presented through the humanitarian work of the Ukrainian Red Cross. That role was real, but it existed inside the OUN/UPA underground. A serious dossier should neither masculinize the story by treating her only as a courier for male commanders nor sanitize the movement by isolating humanitarian care from the armed network. [T1: IEU] [T1: ЕСУ]
+- **What gets simplified in popular memory:** Commemoration tends to emphasize endurance, motherhood, and imprisonment. Those are important, but her own writings listed by ЕСУ show a political intellectual who wrote against Soviet ideology and Russian imperialism. She was not merely a victim or helper.
+- **Where modern Russian disinformation attacks her:** Russian narratives present women in the OUN/UPA underground as "bandit accomplices" or erase them completely. The decolonized correction is to name her agency, her Ukrainian Red Cross work, and her Soviet imprisonment. The anti-hagiographic correction is to keep her within the contested OUN/UPA context.
+- **Polish / Jewish / other-perspective considerations:** Her 1934 Polish prosecution connects her to OUN political violence in interwar Poland, though she is not a Volhynia commander. Jewish/Holocaust perspectives matter as part of the wider OUN/UPA field, but no source retrieved in this pass ties her personally to anti-Jewish violence. Do not imply guilt by association; do not erase organizational context.
+- **NPOV-decolonized framing:** Zarytska should be taught as a Ukrainian underground organizer, writer, humanitarian-network leader, and long-term Soviet political prisoner. The controversy is how to place humanitarian service within an armed nationalist underground whose wider record is contested.
+- **Gender-history caution:** Do not reduce her to family roles even though her father, husband, and son are historically significant. Her own political writing and leadership of the underground medical/humanitarian network are independent reasons for inclusion. At the same time, the family network helps explain why Soviet repression targeted households and kinship structures, not only individual commanders.
+- **Terminology caution:** "Ukrainian Red Cross" in this context means the underground UPA-linked structure, not the international neutral organization.
+- **Source caution:** Her underground essays need page control before quotation because titles alone can overstate what the recovered text actually argues.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/volyn-pamiat-i-travma.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml`
+  - `curriculum/l2-uk-en/plans/bio/vasyl-kuk.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Zarytska; women in the underground; Ukrainian Red Cross under UPA.
+
+## 8. Naming-canonical
+
+- **Slug:** `kateryna-zarytska`
+- **EN canonical (BGN/PCGN 2010):** Kateryna Zarytska
+- **UA canonical:** Катерина Миронівна Зарицька
+- **Aliases:** Kateryna Zarytska; Kateryna Zarycka as library-search alias; daughter of Myron Zarytskyi.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Ekaterina Zaritskaya; Katerina Zaritskaia; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ЕСУ portrait; verify reuse rights.
+- **Backup candidates:** IEU page image if available; NBU/archival portrait if rights allow.
+- **Era-appropriate context image:** Ukrainian Red Cross underground document or camp-prison context image, rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Зарицька Катерина Миронівна." <https://esu.com.ua/article-15538> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Zarytska, Kateryna." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CZ%5CA%5CZarytskaKateryna.htm>.
+
+**Tier 2 (institutional):**
+- NBU Ukrainika / memorial leads for Zarytska; use only after page verification.
+
+**Tier 4 (modern scholarly post-1991):**
+- Scholarship on women in OUN/UPA and Ukrainian Red Cross; Phase 2 should add page-stable monographs/articles.
+- General OUN/UPA controversy sources: Himka, Rudling, Motyka for context, not individualized accusation.
+
+**Primary-source documents accessed:**
+- No page-stable prison file or quotation retrieved in this pass.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Soviet prison mechanism specific.
+- [x] Women's agency foregrounded without sanitizing OUN/UPA context.
+- [x] No guilt-by-association beyond sourced claims.
+- [x] Russian-imperial forms confined to §8.
+- [x] Quote and file gaps documented.

--- a/docs/research/bio/lev-rebet.md
+++ b/docs/research/bio/lev-rebet.md
@@ -1,0 +1,113 @@
+# Лев Романович Ребет — Research Dossier
+
+**Slug:** `lev-rebet`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Лев Романович Ребет.
+- **Pseudonyms / aliases:** no stable underground pseudonym retrieved; English canonical: Lev Rebet.
+- **Born:** 3 March 1912 | Stryi, Galicia | Austria-Hungary. [T1: IEU — Rebet, Lev]
+- **Died:** 12 October 1957 | Munich, Federal Republic of Germany | assassinated by Soviet agent Bohdan Stashynsky with a poison device. [T1: IEU] [T2: ICJ Bulletin no. 15]
+- **Family / education key facts:** Lawyer, journalist, OUN activist, member of the 1941 Ukrainian State Administration, later exile scholar and publicist; associated after the war with the more pluralist OUN-zakordon / OUN abroad milieu rather than Bandera's command line. [T1: IEU] [T2: ICJ Bulletin no. 15]
+
+No OS/NS discrepancy was found. Some secondary web pages give inaccurate birth dates; IEU and the Stashynsky-trial record should control.
+
+## 2. Oppression mechanism
+
+- **What happened:** Nazi imprisonment and later Soviet KGB assassination in exile.
+- **When:** Nazi imprisonment followed the 1941 proclamation context; KGB killing on 12 October 1957.
+- **By whom:** German occupation/security authorities; Soviet KGB through Bohdan Stashynsky.
+- **Document references:** The Stashynsky trial summarized in ICJ Bulletin no. 15 is the retrieved legal source for the assassination; no KGB file ID retrieved.
+
+Rebet's assassination is one of the clearest Cold War examples of Soviet extraterritorial murder of Ukrainian political opponents. The ICJ bulletin states that Stashynsky killed Rebet in 1957 and Bandera in 1959 with a specialized poison device after receiving Soviet orders. This is a Tier 2 legal-institutional source and should be preferred over popular retellings. [T2: ICJ Bulletin no. 15]
+
+The murder also shows why a dossier should not use public fame as a proxy for Soviet threat perception. Rebet is less internationally famous than Bandera, but the trial record indicates that Soviet handlers treated his exile journalism and ideological work as dangerous. For curriculum purposes, that makes him a useful bridge between political biography, KGB methods, and the history of Ukrainian diaspora institutions after 1945.
+
+## 3. Major works
+
+- `1940s-1950s` — articles in *Suchasna Ukraina*, *Chas*, and *Ukrainska Trybuna*; the Stashynsky trial record says Soviet handlers viewed these as ideological, not merely journalistic. [T2: ICJ Bulletin no. 15]
+- `1950s` — *Держава і нація*, political theory; page-stable edition not retrieved.
+- `1950s` — *Теорія нації*, political/sociological work; page-stable edition not retrieved.
+- `Posthumous` — collected works and studies of democratic nationalism in the OUN-z milieu.
+
+## 4. Primary-source quotes (>=2 required)
+
+Source not found for two page-verified direct quotations from Rebet's own works in retrieved Tier 1/Tier 2 sources. The dossier therefore identifies works but does not quote inspirational passages from unsourced websites.
+
+The ICJ trial summary records the Soviet rationale that Rebet was targeted as an ideological writer in exile. That is not Rebet's own voice, but it is a primary legal clue to why the KGB selected him. [T2: ICJ Bulletin no. 15]
+
+## 5. Language register
+
+- **Register:** analytical political theory, diaspora journalism.
+- **CEFR readiness for full reading:** C1-C2.
+- **Lexicon notes:** `нація`, `держава`, `демократичний націоналізм`, exile political vocabulary.
+- **Stylistic features:** argument-driven prose, sociological abstraction, less sloganized than OUN-B mobilizational texts.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Rebet complicates the easy OUN story. He belonged to the OUN milieu and the 1941 state-administration circle, so his early record must remain in the same contested field as Bandera and Stetsko. Yet after the war he became associated with a more democratic and anti-totalitarian nationalist current, and Soviet services identified him as an influential exile theorist. [T1: IEU] [T2: ICJ Bulletin no. 15]
+- **What gets simplified in popular memory:** Rebet is often remembered only as "the other KGB assassination before Bandera." That underplays his intellectual role and his split from Bandera-line authoritarianism. Conversely, some nationalist memory uses his later democratic profile to soften the earlier OUN context too quickly.
+- **Where modern Russian disinformation attacks him:** Russian narratives fold Rebet into a generic "fascist emigre" category to justify Soviet violence. The decolonized correction is to name the KGB assassination as state murder, while still placing his early OUN affiliation in the documented wartime controversy.
+- **Polish / Jewish / other-perspective considerations:** Rebet was part of the 1941 OUN-B environment; Jewish/Holocaust scholarship on OUN attitudes and Lviv 1941 is relevant background. He is not the central Volhynia command figure, so Polish civilian-harm debates should be referenced through OUN/UPA context rather than falsely individualized.
+- **NPOV-decolonized framing:** Rebet should be taught as a Ukrainian nationalist intellectual murdered by the KGB and as an OUN-linked actor whose later democratic-nationalist writing does not erase the contested 1941 context.
+- **Factional caution:** Rebet's later position outside Bandera's narrow command line is historically important. It should be used to explain ideological diversity and splits inside the nationalist exile world, not to create a purified "good nationalist" category. Learners should see that democratic language, anti-Soviet persecution, and early OUN entanglement can coexist in one biography.
+- **Assassination-framing caution:** Do not let the KGB murder become the whole story. It should anchor the oppression mechanism, but Rebet's inclusion depends also on his political writing, his editorship, and the fact that Soviet services treated Ukrainian exile analysis as a threat. That makes him different from a purely commemorative martyr profile.
+- **Source caution:** Because many Rebet summaries circulate through Bandera-focused narratives, Phase 2 should privilege IEU, trial documents, and page-verified Rebet editions over derivative web biographies.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml`
+  - `curriculum/l2-uk-en/plans/bio/dmytro-dontsov.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Rebet; comparative reading on KGB assassinations of Rebet and Bandera.
+
+## 8. Naming-canonical
+
+- **Slug:** `lev-rebet`
+- **EN canonical (BGN/PCGN 2010):** Lev Rebet
+- **UA canonical:** Лев Романович Ребет
+- **Aliases:** Lev Rebet; Лев Ребет.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Lev Romanovich Rebet; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons / diaspora portrait of Lev Rebet, license to verify.
+- **Backup candidates:** IEU article image if rights allow; Ukrainian diaspora archive images.
+- **Era-appropriate context image:** ICJ/Stashynsky trial document excerpt or Munich memorial context, rights-cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine. "Rebet, Lev." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRebetLev.htm>.
+
+**Tier 2 (institutional):**
+- International Commission of Jurists. *Bulletin*, no. 15 (1963), Stashynsky trial summary. <https://www.icj.org/wp-content/uploads/2013/07/ICJ-Bulletin-15-1963-eng.pdf>.
+
+**Tier 4 (modern scholarly post-1991):**
+- John-Paul Himka, *Ukrainian Nationalists and the Holocaust*.
+- Karel Berkhoff and Marco Carynnyk, article on OUN and Stetsko's 1941 autobiography.
+- Studies of OUN-z and Ukrainian democratic nationalism; Phase 2 should add page-stable Rebet editions.
+
+**Primary-source documents accessed:**
+- ICJ trial summary; no page-stable Rebet work retrieved for quotation.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] KGB assassination named directly.
+- [x] Early OUN context not erased.
+- [x] Later democratic-nationalist profile distinguished from hagiography.
+- [x] Russian-imperial forms confined to §8.
+- [x] Quote gap documented.

--- a/docs/research/bio/nil-khasevych.md
+++ b/docs/research/bio/nil-khasevych.md
@@ -1,0 +1,117 @@
+# Ніл Антонович Хасевич — Research Dossier
+
+**Slug:** `nil-khasevych`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ніл Антонович Хасевич.
+- **Pseudonyms / aliases:** Бей-Зот, 333, Левко, Рибалка, Старий, Джміль, КВ-37, З-14, 85-10. [T1: ЕСУ — Хасевич Ніл]
+- **Born:** 25 November 1905 | Diuksyn, Volhynia | Russian Empire. ЕСУ and IEU confirm the date and Volhynian locality. [T1: ЕСУ] [T1: IEU — Khasevych, Nil]
+- **Died:** 4 March 1952 | near Sukhivtsi, Rivne region | killed in a Soviet MGB operation. ЕСУ states he died in combat with an operational group of the USSR Ministry of State Security. [T1: ЕСУ]
+- **Family / education key facts:** Ukrainian graphic artist, woodcut specialist, public-political underground participant; lost a leg in youth, studied art in Warsaw, became known for ex libris and later UPA underground graphics. [T1: ЕСУ] [T1: IEU]
+
+No OS/NS discrepancy found. The precise operational document for the 1952 MGB action was not retrieved.
+
+## 2. Oppression mechanism
+
+- **What happened:** Hunted and killed by Soviet MGB forces because of his role in the UPA underground and the circulation of anti-Soviet graphics.
+- **When:** 4 March 1952.
+- **By whom:** Ministry of State Security of the USSR (MGB) operational group.
+- **Document references:** ЕСУ provides the MGB killing mechanism; no fond/opys/sprava retrieved in this pass. [T1: ЕСУ]
+
+Khasevych's case shows Soviet fear of images. He was not just a hidden artist; he made visual propaganda, awards, seals, bofony, and woodcuts for the underground. ЕСУ notes more than 150 insurgent-themed woodcuts and UPA military-award designs. Soviet security targeted the visual infrastructure of resistance because prints could cross borders and make repression visible. [T1: ЕСУ]
+
+His disability should be handled with the same care as his politics. The loss of a leg is biographically relevant because it shaped how he fought and worked, but it should not become sentimental shorthand. The stronger pedagogical point is that a disabled artist built a technical visual language that Soviet security considered operationally dangerous.
+
+## 3. Major works
+
+- `1937` — prize-winning woodcuts at an international wood-engraving exhibition in Warsaw. [T1: ЕСУ]
+- `1939` — *Книжкові знаки Ніла Хасевича*, album, Warsaw. [T1: ЕСУ]
+- `1939` — *Екслібрис Ніла Хасевича*, album, Philadelphia. [T1: ЕСУ]
+- `1940s` — underground graphics for OUN/UPA publications, including satirical journals and leaflets. [T2: textbook RAG]
+- `1948` — selected UPA award designs and bofony; exact dates need archival verification.
+- `1949` — woodcut "20 років боротьби ОУН," noted in textbook RAG.
+- `Posthumous` — albums of Khasevych's graphics, often used in UPA memory work.
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Я не можу битися зброєю..." Source: Ukrainian 11th-grade history textbook RAG quoting Khasevych. The line presents the tool-of-art-as-weapon self-understanding. [T2: textbook RAG]
+- "Я хочу, щоб світ знав..." Source: same textbook RAG quote. Useful for teaching visual testimony and international communication. [T2: textbook RAG]
+
+Phase 2 should verify the original letter or memoir source behind the textbook quotation before using the full quote in learner-facing material.
+
+## 5. Language register
+
+- **Register:** visual-political rather than literary; captions and slogans are concise, mobilizational, and graphic.
+- **CEFR readiness for full reading:** B1-B2 for captions; C1 for art-historical essays about him.
+- **Lexicon notes:** `дереворит`, `екслібрис`, `бофон`, `відзнака`, `підпілля`, `різець`.
+- **Stylistic features:** stark contrast, emblematic composition, compressed slogans, martyrological imagery.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Khasevych is less politically charged than Bandera or Kliachkivskyi, but his art is embedded in UPA propaganda. Art historians rightly study his technical skill, disability, training, and graphic innovation; historians must also name that he designed visual material for an armed underground whose political record is contested. [T1: ЕСУ] [T1: IEU]
+- **What gets simplified in popular memory:** Ukrainian memory often presents him as the heroic artist who fought with a chisel. That is a powerful and sourced self-image, but it should not turn his work into neutral art detached from OUN/UPA messaging. Conversely, dismissing the art as mere "bandit propaganda" repeats Soviet framing and erases a sophisticated Ukrainian graphic tradition.
+- **Where modern Russian disinformation attacks him:** Soviet/Russian narratives reduce UPA cultural production to criminal agitation. The decolonized correction is to analyze the prints as art, political communication, and anti-Soviet testimony. The anti-hagiographic correction is to ask what the images omit: Polish civilian suffering, Jewish catastrophe, and coercion inside wartime underground politics.
+- **Polish / Jewish / other-perspective considerations:** Khasevych's known role is visual production, not command of violence. Still, any UPA visual-culture module should be paired with Volhynia and Holocaust modules so learners do not encounter the iconography without the civilian-harm context.
+- **NPOV-decolonized framing:** Teach Khasevych as a major Ukrainian graphic artist killed by MGB forces and as an UPA propagandist. Both labels are necessary.
+- **Visual-source caution:** His woodcuts can be read at three levels: formal graphic design, underground communication, and political myth-making. A balanced lesson should ask what the print wants viewers to feel, what Soviet violence it documents, and what parts of the wartime record remain outside the image frame.
+- **Accessibility caution:** Because Khasevych's biography includes disability and visual art, future learner materials should avoid pity language. The stronger framing is agency: a disabled Ukrainian artist used reproducible graphic media to fight Soviet erasure and to build underground institutions.
+- **Museum caution:** If using a woodcut as an image asset, caption it as political print culture, not decorative illustration.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+- **Existing LIT-WAR modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-war/upa-underground-literature.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/volyn-pamiat-i-travma.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Khasevych; visual-literacy lesson on UPA woodcuts and Soviet anti-underground imagery.
+
+## 8. Naming-canonical
+
+- **Slug:** `nil-khasevych`
+- **EN canonical (BGN/PCGN 2010):** Nil Khasevych
+- **UA canonical:** Ніл Антонович Хасевич
+- **Aliases:** Бей-Зот; 333; Левко; Рибалка; Старий; Джміль; КВ-37; З-14; 85-10.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Nil Khasevich; Nikolai Khasevich; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ЕСУ image / Wikimedia Commons portrait of Nil Khasevych; verify license.
+- **Backup candidates:** scanned albums of ex libris and woodcuts if public-domain or permission-cleared.
+- **Era-appropriate context image:** One rights-cleared woodcut, ideally with source-edition metadata and caption explaining propaganda context.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Хасевич Ніл." <https://esu.com.ua/article-884470> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Khasevych, Nil." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CH%5CKhasevychNil.htm>.
+
+**Tier 2 (institutional):**
+- Ukrainian 10th/11th-grade history textbook RAG excerpts on Khasevych, underground printing, and the quoted chisel statement.
+
+**Tier 4 (modern scholarly post-1991):**
+- Studies on UPA visual culture and underground print networks; Phase 2 should add page-stable art-history sources.
+- General OUN/UPA context scholarship: Motyka, Himka, Rudling, Snyder.
+
+**Primary-source documents accessed:**
+- Textbook-cited Khasevych quote; no MGB operation file ID retrieved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] MGB killing named directly.
+- [x] Art quality and propaganda function both named.
+- [x] OUN/UPA controversy connected without false individualized charges.
+- [x] Russian-imperial forms confined to §8.
+- [x] Image-rights caution included.

--- a/docs/research/bio/petro-fedun-poltava.md
+++ b/docs/research/bio/petro-fedun-poltava.md
@@ -1,0 +1,119 @@
+# Петро Миколайович Федун «Полтава» — Research Dossier
+
+**Slug:** `petro-fedun-poltava`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Петро Миколайович Федун.
+- **Pseudonyms / aliases:** Полтава, Север, Волянський; English canonical: Petro Fedun-Poltava.
+- **Born:** 24 February 1919 | Shnyriv, Brody area, Galicia | Second Polish Republic region after 1918; source gives the modern Ukrainian locality. [T1: ЕСУ — Федун Петро Миколайович]
+- **Died:** 23 December 1951 | western Ukraine, underground bunker during MGB operation | killed in Soviet security operation. [T1: ЕСУ]
+- **Family / education key facts:** OUN/UPA ideologue, publicist, member of the underground leadership, linked to the Ukrainian Supreme Liberation Council milieu; authored programmatic anti-Soviet and nationalist texts. [T1: ЕСУ]
+
+No OS/NS discrepancy found. The exact death-place operational file and unit details require archival verification before Phase 2.
+
+## 2. Oppression mechanism
+
+- **What happened:** Hunted and killed by Soviet state security during counterinsurgency against the OUN/UPA underground.
+- **When:** 23 December 1951.
+- **By whom:** MGB / Soviet state-security operational forces.
+- **Document references:** ЕСУ supplies the death date and underground role; no stable MGB fond/opys/sprava retrieved in this pass.
+
+Fedun's oppression mechanism was Soviet counterinsurgency against an underground political writer. This matters because he was not only a fighter with a weapon; he was a producer of ideological texts the Soviet regime treated as dangerous. But the dossier should not treat Soviet persecution as proof that all of his ideas were democratic or all OUN/UPA conduct was justified. [T1: ЕСУ]
+
+For Phase 2, the missing archival task is concrete: identify the MGB operation report for 23 December 1951 and the source edition for his collected writings. Until then, the dossier should say "killed by Soviet state security" and cite ЕСУ, but should not invent the unit, bunker coordinates, or last words.
+
+## 3. Major works
+
+- `1943` — early underground political texts listed by ЕСУ; details require page verification.
+- `1945` — *Колоніяльна господарська політика большевицьких імперіялістів в Україні*, anti-colonial economic critique. [T1: ЕСУ]
+- `1946` — *Елементи революційності українського націоналізму*, ideological work. [T1: ЕСУ]
+- `1946` — *Концепція Самостійної України і основна тенденція ідейно-політичного розвитку сучасного світу*, programmatic text. [T1: ЕСУ]
+- `1947` — *Передпосилки поширення нашого руху в умовах большевицького СССР*, strategy text. [T1: ЕСУ]
+- `1947` — *Шлях активної, збройної боротьби проти окупантів — єдиноправильний шлях до національного визволення*, UPA anniversary text. [T1: ЕСУ]
+- `1948` — *Хто такі бандерівці і за що вони борються*, public explanation of the movement. [T1: ЕСУ]
+- `1940s` — *Ідея Української Самостійної Соборної Держави*, core ideological formula listed by ЕСУ. [T1: ЕСУ]
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Хто такі бандерівці і за що вони борються." Source: title of Fedun's 1948 work listed by ЕСУ. It is included because the title defines his public-facing explanatory project. [T1: ЕСУ]
+- "Колоніяльна господарська політика большевицьких імперіялістів в Україні." Source: title of Fedun's 1945 work listed by ЕСУ. It is useful as a compact anti-imperial economic frame. [T1: ЕСУ]
+
+Source gap: titles are source-verified but not sufficient for rich quotation. A page-stable edition of Fedun's collected works was not retrieved; do not add unsourced excerpts.
+
+## 5. Language register
+
+- **Register:** underground ideological-political, anti-colonial, programmatic.
+- **CEFR readiness for full reading:** C1-C2; B2 with glossary for short excerpts.
+- **Lexicon notes:** `колоніяльна`, `большевицькі імперіялісти`, `самостійна соборна держава`, `революційність`, older diaspora/underground orthography.
+- **Stylistic features:** abstract argument, programmatic title structure, ideological binaries, social-economic critique.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Fedun is often cited as evidence that the late-war and postwar OUN/UPA underground shifted toward anti-imperial, social, and sometimes democratic language. That shift is real enough to study through his works. It must not be used to erase the earlier integral-nationalist and authoritarian OUN inheritance or civilian-harm record in the broader movement. [T1: ЕСУ] [T4: OUN/UPA scholarship]
+- **What gets simplified in popular memory:** Supportive memory presents him as the sophisticated theorist who proves UPA fought for national and social liberation. Critical memory can flatten him into a propagandist for an armed underground. Both simplifications miss the pedagogical value: his works show how the underground explained itself after direct contact with Soviet Ukraine, German occupation, and mass war.
+- **Where modern Russian disinformation attacks him:** Russian narratives treat the term "Banderites" as proof of fascism and ignore Fedun's explicit anti-imperial and anti-Soviet-colonial vocabulary. However, Ukrainian responses should not simply adopt Fedun's self-description as neutral truth. His own texts are primary sources for what the movement claimed about itself, not final adjudications of what it did.
+- **Polish / Jewish / other-perspective considerations:** Fedun was not the Volhynia field commander, but his explanatory texts belong to the same OUN-B/UPA tradition whose record includes Polish civilian killings and Holocaust-adjacent controversies. Learners should read his programmatic language alongside modules that include Polish and Jewish perspectives.
+- **NPOV-decolonized framing:** Teach Fedun as an important underground intellectual killed by Soviet security forces and as a source for OUN/UPA self-representation. Make clear that self-representation is not the same as independent historical judgment.
+- **Textual caution:** Fedun's titles use anti-colonial terms that are pedagogically valuable in a decolonized curriculum. They should be compared with independent scholarship, not treated as a neutral narrator's voice. That comparison lets learners see how underground actors named Soviet domination while also asking what their program did or did not say about non-Ukrainian civilians.
+- **Alias caution:** "Полтава" is a nom de guerre, not a birthplace claim. Keep the slug hyphenated to avoid collision with writers or place-based entries.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+- **Existing LIT-WAR modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-war/upa-underground-literature.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/volyn-pamiat-i-travma.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml`
+  - `curriculum/l2-uk-en/plans/bio/vasyl-kuk.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Fedun-Poltava; source-reading lesson on underground self-description versus external scholarship.
+
+## 8. Naming-canonical
+
+- **Slug:** `petro-fedun-poltava`
+- **EN canonical (BGN/PCGN 2010):** Petro Fedun-Poltava
+- **UA canonical:** Петро Миколайович Федун «Полтава»
+- **Aliases:** Петро Полтава; Полтава; Север; Волянський; Petro Poltava.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Pyotr Fedun; Petr Fedun; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** ЕСУ image or Wikimedia Commons portrait if license verified.
+- **Backup candidates:** UPA archive image; underground publication facsimile if rights allow.
+- **Era-appropriate context image:** Title page of *Хто такі бандерівці...* from a rights-cleared source edition.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Федун Петро Миколайович." <https://esu.com.ua/article-886281> | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Local archive/RAG note on UPA underground literature and Fedun's works.
+
+**Tier 4 (modern scholarly post-1991):**
+- Studies on OUN/UPA ideological change after 1943, including Patryliak and diaspora/CIUS scholarship.
+- Himka, Rudling, Motyka, and Snyder for broader movement controversies.
+
+**Primary-source documents accessed:**
+- Work titles from ЕСУ; no page-stable text quotations or MGB case-file ID retrieved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Soviet MGB killing named.
+- [x] Fedun's anti-imperial language presented as primary self-description, not proof by itself.
+- [x] Broader OUN/UPA controversies retained.
+- [x] Russian-imperial forms confined to §8.
+- [x] No invented direct quotes.

--- a/docs/research/bio/stepan-bandera.md
+++ b/docs/research/bio/stepan-bandera.md
@@ -1,0 +1,124 @@
+# Степан Андрійович Бандера — Research Dossier
+
+**Slug:** `stepan-bandera`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Степан Андрійович Бандера.
+- **Pseudonyms / aliases:** Баба, Лис, Сірий; English canonical: Stepan Bandera.
+- **Born:** 1 January 1909 | Staryi Uhryniv, Kalush area, Galicia | Austria-Hungary. ЕСУ and the Internet Encyclopedia of Ukraine (IEU) agree on the date and locality. [T1: ЕСУ — Бандера Степан Андрійович] [T1: IEU — Bandera, Stepan]
+- **Died:** 15 October 1959 | Munich, Federal Republic of Germany | assassinated by KGB agent Bohdan Stashynsky with poison. ЕСУ gives Munich and the date; the Stashynsky trial record summarized in the International Commission of Jurists bulletin names Rebet and Bandera as KGB assassinations by the same agent. [T1: ЕСУ] [T2: ICJ Bulletin no. 15]
+- **Family / education key facts:** Son of Greek Catholic priest Andrii Bandera; educated at the Stryi Ukrainian gymnasium; studied agronomy at Lviv Polytechnic; joined UVO in 1927 and OUN in 1929; became western-Ukrainian OUN regional leader in 1933. [T1: ЕСУ] [T1: IEU]
+
+Sources do not create an Old Style/New Style calendar problem for his dates; the date disagreement to flag is not birth/death but public memory after 1991, especially the status of the 2010 Hero of Ukraine decree and its later legal challenge.
+
+## 2. Oppression mechanism
+
+- **What happened:** Polish imprisonment; Nazi arrest and Sachsenhausen imprisonment; Soviet KGB assassination in exile.
+- **When:** Polish sentence in 1936 after the Warsaw/Lviv OUN trials; German arrest after the 30 June 1941 proclamation, followed by Sachsenhausen confinement; killing on 15 October 1959.
+- **By whom:** Polish courts/police; German security authorities; Soviet KGB through Bohdan Stashynsky.
+- **Document references:** The dossier did not retrieve a Bandera NKVD/KGB case-file fond number. The KGB assassination is documented through the West German Stashynsky proceedings summarized by the International Commission of Jurists. [T2: ICJ Bulletin no. 15, 1963]
+
+The Polish state prosecuted Bandera for OUN-directed political violence, including the assassination of Polish interior minister Bronislaw Pieracki. ЕСУ explicitly says he redirected OUN combat work from robberies toward individual terror against Polish-administration representatives and persons treated as Soviet sympathizers; that fact is included to prevent sanitizing the interwar record. [T1: ЕСУ]
+
+After OUN-B proclaimed restoration of Ukrainian statehood in Lviv on 30 June 1941, German authorities refused to recognize the act. Ukrainian school-source excerpts and IEU agree that Bandera and Yaroslav Stetsko were arrested and interned in Sachsenhausen. This was oppression by a Nazi regime, not evidence that the OUN-B project was democratic or free of collaboration attempts. [T1: IEU] [T2: Ukrainian 10th-grade history textbook RAG]
+
+The Soviet mechanism was assassination abroad. Bohdan Stashynsky testified after defecting that he killed Lev Rebet in 1957 and Bandera in 1959 on KGB orders, using a poison-spray device. That mechanism matters pedagogically because Russian narratives often present Bandera only as a criminal label while erasing that the Soviet state carried out extraterritorial murder against a Ukrainian nationalist opponent. [T2: ICJ Bulletin no. 15]
+
+## 3. Major works
+
+- `1940s-1950s` — *Перспективи української революції*, essays and political writings; diaspora edition, published posthumously and used by OUN-B circles.
+- `1950` — "Слово до українських націоналістів-революціонерів за кордоном"; exile political address.
+- `1950s` — articles in *Визвольний шлях* and OUN-B publications; important for ideological register, but page-verified article list still needs Phase 2 checking.
+
+Bandera was primarily an underground organizer and factional leader, not a literary author. The curriculum should treat his writings as political documents, not as belles-lettres.
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Ні на що не здадуться навіть найкращі нагоди..." Source: Ukrainian 10th-grade history textbook excerpt quoting Bandera. The sentence is useful for teaching revolutionary voluntarism, but the full publication source and page should be verified before learner-facing use. [T2: textbook RAG]
+- "Українська самостійна соборна держава" recurs as the OUN-B end-state formula in Banderaite documents and in ЕСУ's summary of his ideology. Treat this as a programmatic phrase rather than a personal aphorism. [T1: ЕСУ]
+
+Source gap: a page-stable scanned edition of Bandera's own essays was not retrieved in this pass. Do not add longer direct quotations until a primary edition is checked.
+
+## 5. Language register
+
+- **Register:** ideological, declarative, conspiratorial-political.
+- **CEFR readiness for full reading:** C1-C2 for authentic essays; B2 only in excerpted, glossed form.
+- **Lexicon notes:** abstract nouns in `-ість`, ideological compounds, interwar nationalist terminology, terms such as `провід`, `революція`, `самостійність`, `соборність`.
+- **Stylistic features:** slogans, antithesis, imperative framing, little narrative scaffolding.
+
+## 6. Contested points
+
+- **What's debated in modern scholarship:** Bandera's personal agency during 1941-44 is narrower than the symbolic role attached to his name. He was imprisoned by Germany for much of the period, so claims that he personally commanded every UPA action are not supportable. At the same time, OUN-B was his faction; its cadres, ideology, and organizational decisions cannot be detached from his leadership line. Rossolinski-Liebe, Himka, Berkhoff/Carynnyk, Rudling, Snyder, and Motyka are appropriate scholarship to use for the fascist/integral-nationalist, Holocaust, and Polish-Ukrainian violence debates.
+- **What gets simplified in popular memory:** Ukrainian memory often compresses him into a symbol of anti-Soviet defiance. That symbol intensified after Russia's 2014 and 2022 aggression; Rating Group's April-May 2022 survey found strongly improved public attitudes toward Bandera compared with 2012. That polling is relevant to memory politics, not proof that interwar OUN ideology became democratic retrospectively. [T2: Rating Group 2022]
+- **Where modern Russian disinformation attacks him:** Russian state narratives use "Bandera" and "Banderite" as elastic slurs for any Ukrainian statehood position, including liberal and Jewish Ukrainians who have no OUN connection. The dossier must call that propaganda out, while also refusing the counter-error of presenting the OUN-B record as clean.
+- **Polish / Jewish / other-perspective considerations:** The Volhynia and Eastern Galicia killings of Polish civilians in 1943-44, and the involvement of OUN-linked networks and militias in anti-Jewish violence during the German occupation, are legitimate historical debates. They are not invented by Russian propaganda. Motyka and Snyder emphasize ethnic-cleansing dynamics against Poles; Himka, Berkhoff/Carynnyk, and Rudling emphasize OUN antisemitism, militia participation, and Holocaust-adjacent violence. The dossier should distinguish: Soviet/KGB murder of Bandera is documented oppression; OUN-B's ideology and wartime civilian-harm record remain serious contested history.
+- **Memory/legal issue:** President Viktor Yushchenko's decree no. 46/2010 awarded Bandera the Hero of Ukraine title, but courts later invalidated the award on citizenship grounds. This should be presented as a memory-politics flashpoint, not as evidence for or against his wartime conduct. [T2: President of Ukraine decree no. 46/2010]
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/volyn-pamiat-i-travma.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/polskyi-pohliad.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml`
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml`
+  - `curriculum/l2-uk-en/plans/bio/dmytro-dontsov.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bandera-specific BIO plan; memory-politics lesson on the 2010 decree and post-2022 polling.
+
+## 8. Naming-canonical
+
+- **Slug:** `stepan-bandera`
+- **EN canonical (BGN/PCGN 2010):** Stepan Bandera
+- **UA canonical:** Степан Андрійович Бандера
+- **Aliases:** Stepan Bandera; Степан Бандера; Баба; Лис; Сірий.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Stepan Andreevich Bandera; Stiepan Bandera; Bandera as a generic ethnic slur.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait of Stepan Bandera; verify exact license before Phase 4 use.
+- **Backup candidates:** ЕСУ portrait page image; IEU article image if rights allow.
+- **Era-appropriate context image:** President of Ukraine decree no. 46/2010 facsimile or a public-domain OUN trial/context image, only if rights are clear.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Бандера Степан Андрійович." <https://esu.com.ua/article-40247> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Bandera, Stepan." <https://www.encyclopediaofukraine.com/display.asp?linkPath=pages%5CB%5CA%5CBanderaStepan.htm> | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- International Commission of Jurists. *Bulletin*, no. 15 (1963), Stashynsky trial summary. <https://www.icj.org/wp-content/uploads/2013/07/ICJ-Bulletin-15-1963-eng.pdf>.
+- President of Ukraine. Decree no. 46/2010, "Про присвоєння С. Бандері звання Герой України." <https://zakon.rada.gov.ua/laws/show/46/2010>.
+- Rating Group. "The Tenth National Survey: Ideological Markers of the War," May 2022. <https://ratinggroup.ua/>.
+
+**Tier 4 (modern scholarly post-1991):**
+- Grzegorz Rossolinski-Liebe, *Stepan Bandera: The Life and Afterlife of a Ukrainian Nationalist*.
+- John-Paul Himka, *Ukrainian Nationalists and the Holocaust*.
+- Karel Berkhoff and Marco Carynnyk, "The Organization of Ukrainian Nationalists and Its Attitude toward Germans and Jews."
+- Grzegorz Motyka, *From the Volhynian Massacre to Operation Vistula*.
+- Timothy Snyder, "The Causes of Ukrainian-Polish Ethnic Cleansing 1943."
+
+**Primary-source documents accessed:**
+- ICJ Stashynsky trial summary; presidential decree no. 46/2010. No KGB archival fond number retrieved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing.
+- [x] Russian-imperial transliterations appear only in forbidden-form field.
+- [x] Ukrainian Revolution / Ukrainian statehood frame used where relevant.
+- [x] Soviet propaganda labels not used as authority.
+- [x] KGB assassination named directly.
+- [x] Place names use modern UA canonical forms in prose.
+- [x] Holocaust and Volhynia controversies acknowledged without Russian-propaganda framing.

--- a/docs/research/bio/yaroslav-stetsko.md
+++ b/docs/research/bio/yaroslav-stetsko.md
@@ -91,7 +91,7 @@ Source gap: a page-verified scanned edition of Stetsko's own works was not retri
 
 **Tier 1 (authoritative):**
 - ЕСУ. "Стецько Ярослав Семенович." <https://esu.com.ua/article-884618> | accessed 2026-05-30.
-- Internet Encyclopedia of Ukraine. "Stetsko, Yaroslav." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesSTStetskoYaroslav.htm> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Stetsko, Yaroslav." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CT%5CStetskoYaroslav.htm> | accessed 2026-05-30.
 
 **Tier 2 (institutional):**
 - Ukrainian 10th-grade history textbook RAG excerpts on the 30 June 1941 proclamation and German arrests.

--- a/docs/research/bio/yaroslav-stetsko.md
+++ b/docs/research/bio/yaroslav-stetsko.md
@@ -1,0 +1,115 @@
+# Ярослав Семенович Стецько — Research Dossier
+
+**Slug:** `yaroslav-stetsko`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ярослав Семенович Стецько.
+- **Pseudonyms / aliases:** З. Карбович, Є. Орловський, С. Осинський, Б. Озерський, Я. Підлісецький; English canonical: Yaroslav Stetsko.
+- **Born:** 19 January 1912 | Ternopil, Galicia | Austria-Hungary. [T1: ЕСУ — Стецько Ярослав Семенович] [T1: IEU — Stetsko, Yaroslav]
+- **Died:** 5 July 1986 | Munich, Federal Republic of Germany. [T1: ЕСУ] [T1: IEU]
+- **Family / education key facts:** Studied law and philosophy in Krakow and Lviv; joined Ukrainian Nationalist Youth, UVO, and OUN; by 1932 held ideological responsibilities in OUN; husband of Slava Stetsko. [T1: IEU] [T1: ЕСУ]
+
+No OS/NS discrepancy was found for his birth/death dates. The main source discrepancy is interpretive: diaspora and institutional encyclopedias foreground anti-Soviet activism and Nazi imprisonment, while Holocaust scholarship foregrounds antisemitic texts and the 1941 collaboration attempt.
+
+## 2. Oppression mechanism
+
+- **What happened:** Polish arrests and imprisonment; Nazi arrest after the 30 June 1941 proclamation and imprisonment in Sachsenhausen; long-term Soviet/KGB hostile targeting in exile through propaganda and anti-OUN operations.
+- **When:** Polish authorities sentenced him in 1936 and he was amnestied in 1937; German arrest followed July-September 1941, with Sachsenhausen confinement until 1944; postwar Soviet targeting continued through the Cold War.
+- **By whom:** Polish courts/police; German security authorities; Soviet state security and propaganda organs.
+- **Document references:** No Soviet case-file ID for Stetsko was retrieved. Nazi imprisonment is covered by IEU and Ukrainian textbook RAG. Polish imprisonment is covered by IEU. [T1: IEU] [T2: textbook RAG]
+
+Stetsko's oppression record is real but cannot be used as a shortcut to absolution. Polish imprisonment resulted from OUN underground activity. Nazi arrest resulted from the German refusal to accept OUN-B's unilateral restoration of Ukrainian statehood in Lviv. Soviet hostility came from his postwar role in OUN-B and the Anti-Bolshevik Bloc of Nations, but this pass did not retrieve a stable KGB archival file for a specific operation against him. [T1: ЕСУ] [T1: IEU]
+
+## 3. Major works
+
+- `1938` — *Без національної революції немає соціяльної*, political brochure; shows the social-revolutionary language of OUN-B ideology.
+- `1939` — *Націоналізм і демократія*, ideological essay; important for the democracy-versus-authoritarianism controversy.
+- `1953` — *Сучасний стан в СССР і його політика*, Cold War anti-Soviet analysis.
+- `1954` — *Основні завваги до змісту нашої визвольної концепції*, programmatic text.
+- `1954` — *Ідейно-політичний резистанс організованого українського підпілля*, underground-memory text.
+- `1955` — *Міжнароднє становище і українська справа*, geopolitical pamphlet.
+- `1959` — *Бунт проти матеріялізму*, ideological text.
+- `1987` — *Українська визвольна концепція*, collected works, Munich, posthumous.
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Без національної революції немає соціяльної." Source: title of Stetsko's 1938 brochure listed by ЕСУ. It is a title, not a full passage, but it is a concise statement of the politics he wanted readers to hear. [T1: ЕСУ]
+- "Націоналізм і демократія." Source: title of his 1939 essay listed by ЕСУ. Pedagogically useful because the phrase opens the debate over whether his later democratic language overcame earlier authoritarian commitments. [T1: ЕСУ]
+
+Source gap: a page-verified scanned edition of Stetsko's own works was not retrieved, so this dossier does not add unsourced inspirational quotations. The 1941 antisemitic autobiography is discussed through Berkhoff/Carynnyk and Himka rather than quoted at length.
+
+## 5. Language register
+
+- **Register:** high ideological-polemical, diaspora political prose.
+- **CEFR readiness for full reading:** C1-C2; B2 in short, heavily glossed excerpts.
+- **Lexicon notes:** `визвольна концепція`, `резистанс`, `матеріялізм`, `соціяльна`, OUN-era orthography, diaspora spellings.
+- **Stylistic features:** binaries, abstract nouns, revolutionary teleology, geopolitical framing.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Stetsko is central to the 30 June 1941 Act and the short-lived Ukrainian State Administration. The act was a declaration of Ukrainian statehood under catastrophic conditions at the opening of the German-Soviet war; it was not recognized by Germany, and Stetsko was arrested. That anti-imperial fact must be taught. But the text's pledge to cooperate with Nazi Germany, and Stetsko's own 1939-41 antisemitic writings, are also documented and cannot be minimized. [T1: IEU] [T4: Berkhoff/Carynnyk] [T4: Himka]
+- **What gets simplified in popular memory:** Commemorative accounts often move quickly from "proclaimed independence" to "Nazi prisoner." That sequence is true but incomplete: before arrest, OUN-B attempted a state project that imagined tactical cooperation with the German invasion, and Stetsko's ideological writing included anti-Jewish claims that mainstream Holocaust scholarship treats as serious evidence.
+- **Where modern Russian disinformation attacks him:** Russian narratives collapse the whole Ukrainian statehood tradition into "Nazi collaboration" by using Stetsko as a symbol. That is propagandistic because it erases German repression of OUN-B, Soviet occupation, and the broader Ukrainian anti-imperial struggle. It becomes credible only when Ukrainian memory work hides the antisemitic and authoritarian record.
+- **Polish / Jewish / other-perspective considerations:** Jewish perspectives are essential here. Berkhoff and Carynnyk's Harvard Ukrainian Studies article on Stetsko's 1941 autobiography and Himka's Holocaust work should frame any learner-facing claim about antisemitism. Polish perspectives matter indirectly through OUN interwar violence and wartime memory, though Stetsko is less directly a Volhynia command figure than Kliachkivskyi or Shukhevych.
+- **NPOV-decolonized framing:** The dossier should say: Stetsko was an anti-Soviet Ukrainian nationalist who suffered Polish and Nazi imprisonment and opposed Soviet imperial rule; he was also an OUN-B ideologue whose 1941 project and antisemitic writings belong in any honest account. Neither "freedom fighter, full stop" nor "Nazi puppet, full stop" is acceptable.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml`
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/holokost-v-ukraini.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/polskyi-pohliad.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-dontsov.yaml`
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Stetsko; source-analysis activity on the 30 June 1941 proclamation.
+
+## 8. Naming-canonical
+
+- **Slug:** `yaroslav-stetsko`
+- **EN canonical (BGN/PCGN 2010):** Yaroslav Stetsko
+- **UA canonical:** Ярослав Семенович Стецько
+- **Aliases:** З. Карбович; Є. Орловський; С. Осинський; Б. Озерський; Я. Підлісецький.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Yaroslav Stetsko as "Jaroslav Stecko" without Ukrainian context; Iaroslav Stetsko only when quoting a source title; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait of Yaroslav Stetsko; verify license and source chain before Phase 4.
+- **Backup candidates:** ЕСУ page image; OUN archive photograph if rights are clear.
+- **Era-appropriate context image:** Facsimile of the 30 June 1941 proclamation from a Ukrainian source edition, if rights allow.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- ЕСУ. "Стецько Ярослав Семенович." <https://esu.com.ua/article-884618> | accessed 2026-05-30.
+- Internet Encyclopedia of Ukraine. "Stetsko, Yaroslav." <https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesSTStetskoYaroslav.htm> | accessed 2026-05-30.
+
+**Tier 2 (institutional):**
+- Ukrainian 10th-grade history textbook RAG excerpts on the 30 June 1941 proclamation and German arrests.
+
+**Tier 4 (modern scholarly post-1991):**
+- Karel Berkhoff and Marco Carynnyk, "The Organization of Ukrainian Nationalists and Its Attitude toward Germans and Jews: Iaroslav Stets'ko's 1941 Zhyttiepys," *Harvard Ukrainian Studies* 23.
+- John-Paul Himka, *Ukrainian Nationalists and the Holocaust*.
+- Grzegorz Rossolinski-Liebe, *Stepan Bandera: The Life and Afterlife of a Ukrainian Nationalist*.
+
+**Primary-source documents accessed:**
+- No Soviet case-file ID retrieved. Stetsko's works are identified from ЕСУ; page-verified scans still needed for direct quotations.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Ukrainian statehood struggle framed without Russian imperial vocabulary.
+- [x] Nazi-collaboration controversy acknowledged directly.
+- [x] Antisemitic-source problem attributed to scholarship, not hidden.
+- [x] No forbidden Russian transliterations in body prose.
+- [x] Source gaps named instead of filled.

--- a/docs/research/bio/yurii-tiutiunnyk.md
+++ b/docs/research/bio/yurii-tiutiunnyk.md
@@ -1,0 +1,113 @@
+# Юрій Йосипович Тютюнник — Research Dossier
+
+**Slug:** `yurii-tiutiunnyk`
+**Block:** G
+**Tier:** 4
+**Issue:** #2309
+**Researcher:** Codex GPT-5
+**Completed:** 2026-05-30
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Йосипович Тютюнник.
+- **Pseudonyms / aliases:** Юрко Тютюнник; English canonical: Yurii Tiutiunnyk.
+- **Born:** 20 April 1891 | Budyshche, Zvenyhorodka county area, central Ukraine | Russian Empire. IEU and UINP-derived materials agree on 1891 and Budyshche/Budyshcha; use modern Cherkasy-region framing in prose. [T1: IEU — Tiutiunnyk, Yurii] [T2: UINP materials on the Winter Campaign]
+- **Died:** 20 October 1930 | Moscow, USSR | executed by Soviet security organs. UINP materials state that chekists shot him in Moscow; IEU confirms the execution. [T1: IEU] [T2: UINP]
+- **Family / education key facts:** Ukrainian military leader of the Revolution period; served in formations that shifted through the revolutionary war, then joined the UNR Army; became a general-khorunzhyi and a key organizer of insurgent operations, including the Second Winter Campaign. [T1: IEU] [T2: UINP]
+
+Disambiguation: this is the UNR Army general Юрій Йосипович Тютюнник, not the writer Григір Тютюнник already represented at `docs/research/bio/hryhir-tiutiunnyk.md`.
+
+## 2. Oppression mechanism
+
+- **What happened:** GPU/OGPU deception, forced return/collaboration under Soviet control, later arrest and execution.
+- **When:** Lured into Soviet-controlled Ukraine in 1923; executed on 20 October 1930.
+- **By whom:** Soviet Cheka/GPU/OGPU security organs.
+- **Document references:** This pass did not retrieve the archival criminal-case ID. UINP materials state the 1923 deception and the 1930 shooting in Moscow. [T2: UINP] [T1: IEU]
+
+Tiutiunnyk's case is a classic Soviet counterinsurgency pattern: lure a prominent exile/insurgent leader, use him in propaganda and controlled cultural work, then destroy him once useful. UINP materials note that he appeared in the propaganda film *P.K.P.* (*Pilsudskyi kupyv Petliuru*) playing himself, a fact that must be framed as coerced Soviet exploitation rather than free political conversion unless a source proves otherwise.
+
+## 3. Major works
+
+- `1920` — operational writing connected to the First Winter Campaign and UNR insurgent planning; source-edition retrieval needed.
+- `1923-1929` — memoir and film-related texts produced under Soviet control; use with caution because the coercive setting matters.
+- `1926` — involvement in the film *P.K.P.*; propaganda artifact, pedagogically useful for media-literacy comparison.
+- `Posthumous` — memoirs and document editions on the Winter Campaigns; use UINP/NAN source editions in Phase 2.
+
+## 4. Primary-source quotes (>=2 required)
+
+- "Пілсудський купив Петлюру." Source: title of the Soviet propaganda film in which Tiutiunnyk was made to appear as himself. It is not his free statement; it is a coercive artifact useful for propaganda analysis. [T2: UINP]
+- Source not found for two reliable page-stable quotations from Tiutiunnyk's own memoirs in this pass. Phase 2 should retrieve a source edition before using his voice directly.
+
+The lack of direct quotes is intentional: Soviet-produced material around Tiutiunnyk is polluted by coercion, and the curriculum should not convert it into his authentic position without documentary control.
+
+## 5. Language register
+
+- **Register:** military memoir, operational-political, revolutionary-period prose.
+- **CEFR readiness for full reading:** C1; B2 for short excerpts about campaigns.
+- **Lexicon notes:** `отаман`, `повстанський штаб`, `генерал-хорунжий`, `чекісти`, `Зимовий похід`, `Армія УНР`.
+- **Stylistic features:** campaign chronology, military rank vocabulary, compressed revolutionary context.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Tiutiunnyk's post-1923 Soviet period is the difficult point. He was a UNR general and insurgent organizer, but Soviet services lured him back, used him in propaganda, and eventually executed him. A lazy heroic narrative ignores the propaganda collaboration; a lazy Soviet/Russian narrative treats that coerced period as proof that the UNR cause was false. The dossier should frame the 1923-30 period as Soviet coercive management unless a specific document proves voluntary ideological conversion.
+- **What gets simplified in popular memory:** He is sometimes remembered only through the Winter Campaigns and anti-Bolshevik struggle. The film *P.K.P.* and the final Moscow execution complicate that arc and are precisely why he is pedagogically valuable.
+- **Where modern Russian disinformation attacks him:** Russian/Soviet narratives historically used captured Ukrainian leaders to portray the UNR as foreign-manipulated and doomed. The film title itself is a propaganda claim that Petliura was bought by Poland. That should be analyzed as Soviet messaging, not repeated as fact.
+- **Polish / Jewish / other-perspective considerations:** Polish context matters because the UNR-Polish alliance and the Second Winter Campaign are tied to interwar border politics. The dossier should not import OUN/UPA controversies onto Tiutiunnyk; his track is the Ukrainian Revolution, UNR exile, and Soviet security deception.
+- **NPOV-decolonized framing:** Tiutiunnyk should be taught as a Ukrainian revolutionary military leader destroyed by Soviet security organs, with a frank account of his coerced Soviet-period public role. That is more rigorous than either martyr-only memory or Soviet "renegade" framing.
+- **Source-method caution:** Tiutiunnyk is a good dossier for teaching why Soviet-produced autobiography, film, and confession-like materials require context. A student can compare a UNR operational source, a Soviet film artifact, and a later UINP or ЕІУ summary, then ask who controlled the conditions under which each text was made. That makes the Soviet oppression mechanism visible without pretending that every late text bearing his name is equally authentic.
+- **Disambiguation caution:** Do not attach literary expectations from the later writers Hryhir or Hryhorii Tiutiunnyk to this figure. The shared surname is pedagogically risky because learners may already know the prose writer; the UNR general belongs to the military-political track and to Soviet security history, not to the 1960s literary canon.
+
+## 7. Cross-track links
+
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`
+  - `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml`
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`
+- **Existing ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/1918-1920-viina-i-soiuz.yaml`
+- **Existing LIT-WAR modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-war/unr-war-literature.yaml`
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml`
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - Bio plan for Yurii Tiutiunnyk; media-literacy lesson on Soviet propaganda film.
+
+## 8. Naming-canonical
+
+- **Slug:** `yurii-tiutiunnyk`
+- **EN canonical (BGN/PCGN 2010):** Yurii Tiutiunnyk
+- **UA canonical:** Юрій Йосипович Тютюнник
+- **Aliases:** Юрко Тютюнник; Yurii Tiutiunnyk; Yurko Tiutiunnyk.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Yuri Tyutyunnik; Yuriy Tyutyunnyk; Russian patronymic spellings.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons/UNR-era portrait of Yurii Tiutiunnyk; verify publication date and license.
+- **Backup candidates:** IEU article image if rights are clear; UINP educational poster image with permission.
+- **Era-appropriate context image:** Winter Campaign map or UNR Army photo, rights permitting.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Internet Encyclopedia of Ukraine. "Tiutiunnyk, Yurii." <https://www.encyclopediaofukraine.com/display.asp?linkPath=pages%5CT%5CI%5CTiutiunnykYurii.htm>.
+- ЕІУ entry lead: "ТЮТЮННИК ЮРІЙ ЙОСИПОВИЧ," Institute of History of Ukraine search result.
+
+**Tier 2 (institutional):**
+- Ukrainian Institute of National Remembrance materials on the Winter Campaigns and Yurii Tiutiunnyk.
+
+**Tier 4 (modern scholarly post-1991):**
+- Studies of the Ukrainian Revolution, UNR Army, and Soviet security operations; Phase 2 should add page-stable monographs.
+
+**Primary-source documents accessed:**
+- No OGPU case-file ID retrieved; no page-stable memoir quotation retrieved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Ukrainian Revolution frame used.
+- [x] Soviet propaganda artifact labeled as propaganda.
+- [x] Disambiguation from Hryhir Tiutiunnyk explicit.
+- [x] No Russian-imperial transliterations in body prose.
+- [x] No invented archival ID.


### PR DESCRIPTION
## Summary

Adds the ten requested Phase 1 bio research dossiers for Epic #2309 Block G + Khasevych:

- `stepan-bandera`
- `yaroslav-stetsko`
- `andrii-melnyk`
- `dmytro-kliachkivskyi`
- `yurii-tiutiunnyk`
- `avhustyn-voloshyn`
- `lev-rebet`
- `kateryna-zarytska`
- `petro-fedun-poltava`
- `nil-khasevych`

Each dossier has all ten template sections, explicit §6 controversy framing, naming-canonical warnings, image candidates, and §7 Existing paths checked against real plan files.

## Per-figure Tier 1/2 sources

- Stepan Bandera: ЕСУ `Бандера Степан Андрійович`; Internet Encyclopedia of Ukraine `Bandera, Stepan`; ICJ Bulletin no. 15 for Stashynsky/KGB assassination; President of Ukraine decree no. 46/2010; Rating Group 2022 for memory-politics context.
- Yaroslav Stetsko: ЕСУ `Стецько Ярослав Семенович`; IEU `Stetsko, Yaroslav`; Ukrainian textbook RAG for 30 June 1941/Nazi arrest context.
- Andrii Melnyk: ЕСУ `Мельник Андрій Атанасович`; IEU `Melnyk, Andrii`; IEU `Organization of Ukrainian Nationalists`; Ukrainian textbook RAG.
- Dmytro Kliachkivskyi: ЕСУ PDF `Клячківський Дмитро-Роман Семенович`; IEU `Savur, Klym`.
- Yurii Tiutiunnyk: IEU `Tiutiunnyk, Yurii`; ЕІУ lead for `ТЮТЮННИК ЮРІЙ ЙОСИПОВИЧ`; UINP Winter Campaign materials.
- Avhustyn Voloshyn: ЕСУ `Волошин Августин Іванович`; IEU `Voloshyn, Avhustyn`; Ukrainian textbook RAG; NBU/pedagogical bibliography leads.
- Lev Rebet: IEU `Rebet, Lev`; ICJ Bulletin no. 15 for Stashynsky/KGB assassination.
- Kateryna Zarytska: ЕСУ `Зарицька Катерина Миронівна`; IEU `Zarytska, Kateryna`; NBU Ukrainika lead.
- Petro Fedun-Poltava: ЕСУ `Федун Петро Миколайович`; local UPA underground-literature RAG lead.
- Nil Khasevych: ЕСУ `Хасевич Ніл`; IEU `Khasevych, Nil`; Ukrainian textbook RAG for underground-printing and quote context.

## §6 controversy framing approach

The dossiers use NPOV-but-decolonized framing: Russian/Soviet/Nazi/Polish coercion is named specifically, but oppression does not erase ideological or civilian-harm controversies. For OUN/UPA figures, §6 separates Russian disinformation distortions from legitimate scholarship on authoritarian/integral nationalism, the 30 June 1941 proclamation, Holocaust-adjacent violence, Volhynia/Eastern Galicia, and post-1991 memory politics. Polish and Jewish perspectives are explicitly included where relevant, without projecting command responsibility onto figures where sources do not support it.

## Validator

Raw final line:

```text
No fabricated Existing cross-track plan paths found.
```

## Explicit source gaps / contested claims not asserted

No contested claim was filled by inference. The following were marked as source gaps or scoped cautiously in the dossiers:

- Exact NKVD/NKDB/MGB/KGB archival fond/opys/sprava IDs were not retrieved for Stetsko, Melnyk, Kliachkivskyi, Tiutiunnyk, Voloshyn, Rebet, Zarytska, Fedun, or Khasevych; where legal/institutional evidence exists, it is cited instead (for example ICJ on Rebet/Bandera).
- Page-stable direct quotations were not retrieved for Kliachkivskyi, Rebet, Zarytska, and several Fedun/Stetsko primary texts; the dossiers say `source not found` rather than inventing quotes.
- Kliachkivskyi command responsibility for Volhynia is attributed to mainstream scholarship and kept distinct from unverified written-order quotations.
- Tiutiunnyk's Soviet-period film/public role is framed as Soviet coercive exploitation unless a future source proves voluntary ideological conversion.
- Voloshyn's July 1945 death-date discrepancy is flagged pending archival custody-file verification.

## Checks

- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths <10 dossiers>`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --cached --check`
- pre-commit hooks during commit and push
