### PR TITLE
fix(v7): correct ULP fidelity failures before abort

### DIFF
--- a/scripts/audit/ulp_fidelity_gate.py
+++ b/scripts/audit/ulp_fidelity_gate.py
@@ -24,13 +24,11 @@ STRESS_COVERAGE_MIN = 0.95
 GLOSS_TOKEN_WINDOW = 8
 
 # Terminal ULP checks are deterministic teaching *behaviours* (structural, binary):
-# a genuine ULP lesson either has stress marks, em-dash glosses, UK-only dialogue
-# boxes, and Ukrainian-first openers \u2014 or it does not. uk_en_ratio is deliberately
-# excluded: it is a continuous, context-dependent signal and is ADVISORY only, so a
-# real ULP lesson that lands a few points outside the immersion band is surfaced as
-# a warning, never false-REVISE'd. (Ratio-as-hard-gate is the mechanics-over-teaching
-# trap this whole harness fix removes \u2014 2026-05-30 ULP-harness decision.)
-_TERMINAL_CHECKS = ("stress_coverage", "em_dash_gloss", "dialoguebox_uk_en", "section_openers")
+# a genuine ULP lesson either has Ukrainian-first mixed lines, UK-only dialogue
+# boxes, and Ukrainian-first openers \u2014 or it does not. Continuous/coverage signals
+# are ADVISORY so mechanically useful but incomplete detectors do not false-REVISE
+# otherwise teachable output.
+_TERMINAL_CHECKS = ("em_dash_gloss", "dialoguebox_uk_en", "section_openers")
 
 _UK_BASE_CLASS = "А-ЯҐЄІЇа-яґєії"
 _UK_LETTER_CLASS = f"{_UK_BASE_CLASS}\u0301"
@@ -45,9 +43,11 @@ _WORD_RE = re.compile(
 _LATIN_RE = re.compile(r"[A-Za-z]")
 _VOWELS = set("аеиіїоуюяєАЕИІЇОУЮЯЄ")
 _COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_BAD_MARKER_RE = re.compile(r"<!--\s*bad\s*-->.*?<!--\s*/bad\s*-->", re.DOTALL | re.IGNORECASE)
 _FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`]+`")
 _URL_RE = re.compile(r"https?://\S+")
+_PRONUNCIATION_LINE_RE = re.compile(r"\b(?:spoken|sounds?)\b.*\[[^\]]+\]", re.IGNORECASE)
 _JSX_BLOCK_RE = re.compile(
     r"<[A-Z][A-Za-z0-9]*(?:[^<]|<(?![A-Z/]))*?(?:/>|</[A-Z][A-Za-z0-9]*>)",
     re.DOTALL,
@@ -80,6 +80,7 @@ def _count_syllables(word: str) -> int:
 
 
 def _basic_clean(text: str) -> str:
+    text = _BAD_MARKER_RE.sub(" ", text)
     text = _COMMENT_RE.sub(" ", text)
     text = _FENCED_CODE_RE.sub(" ", text)
     text = _INLINE_CODE_RE.sub(" ", text)
@@ -143,6 +144,17 @@ def _is_english_narration_line(line: str) -> bool:
     return latin_count > 0 and uk_count > 0 and latin_count >= uk_count
 
 
+def _line_has_em_dash_gloss(line: str) -> bool:
+    for match in _UK_WORD_RE.finditer(line):
+        window = _token_window_after(line, match.end(1), max_tokens=GLOSS_TOKEN_WINDOW)
+        if "—" not in window:
+            continue
+        post_dash = window.split("—", 1)[1]
+        if _LATIN_RE.search(post_dash):
+            return True
+    return False
+
+
 def _em_dash_gloss_check(text: str) -> dict[str, Any]:
     body = _JSX_BLOCK_RE.sub(" ", _basic_clean(text))
     checked: list[dict[str, Any]] = []
@@ -153,19 +165,24 @@ def _em_dash_gloss_check(text: str) -> dict[str, Any]:
             continue
         if not _is_english_narration_line(line):
             continue
-        for match in _UK_WORD_RE.finditer(line):
-            word = match.group(1)
-            if _count_syllables(word) < 2:
-                continue
-            window = _token_window_after(line, match.end(1), max_tokens=GLOSS_TOKEN_WINDOW)
-            has_gloss = "—" in window and _LATIN_RE.search(window.split("—", 1)[1])
-            record = {"line": line_no, "term": word, "window": window.strip()[:120]}
-            checked.append(record)
-            if not has_gloss:
-                violations.append(record)
+        if _PRONUNCIATION_LINE_RE.search(line):
+            continue
+        terms = [
+            match.group(1)
+            for match in _UK_WORD_RE.finditer(line)
+            if _count_syllables(match.group(1)) >= 2
+        ]
+        if not terms:
+            continue
+        has_gloss = _line_has_em_dash_gloss(line)
+        record = {"line": line_no, "terms": terms[:8], "preview": line[:180]}
+        checked.append(record)
+        if not has_gloss:
+            violations.append(record)
     return {
         "passed": not violations,
-        "checked_terms": len(checked),
+        "checked_lines": len(checked),
+        "checked_terms": sum(len(record["terms"]) for record in checked),
         "violations": violations[:10],
         "token_window": GLOSS_TOKEN_WINDOW,
     }

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3905,6 +3905,51 @@ def run_ulp_fidelity_gate(
     return check_ulp_fidelity(module_text, plan, profile=profile)
 
 
+def run_ulp_fidelity_with_correction(
+    module_dir: Path,
+    plan_path: Path,
+    *,
+    profile: str | None = None,
+    writer: str = "claude-tools",
+    writer_corrector: Callable[[CorrectionContext], str | Mapping[str, str] | None] | None = None,
+    invoker: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Run ULP fidelity and apply one ADR-008 writer correction when needed."""
+    report = run_ulp_fidelity_gate(module_dir, plan_path, profile=profile)
+    if report.get("passed") is True:
+        return report
+
+    correction_payload = _apply_writer_correction(
+        "ulp_fidelity",
+        report,
+        qg_report={"gates": {"ulp_fidelity": report}},
+        module_dir=module_dir,
+        plan_path=plan_path,
+        writer_corrector=writer_corrector,
+        writer=writer,
+        invoker=invoker,
+    )
+    artifact: dict[str, Any] = {
+        "round": 1,
+        "before": report,
+        "correction": correction_payload,
+    }
+
+    if correction_payload and correction_payload.get("applied") in {
+        "module_patch",
+        "strict_json_artifacts",
+        "writer_artifacts_mapping",
+    }:
+        stress_annotation = run_stress_annotation(module_dir)
+        write_json(module_dir / "stress_annotation.json", stress_annotation)
+        artifact["stress_annotation"] = stress_annotation
+        report = run_ulp_fidelity_gate(module_dir, plan_path, profile=profile)
+        artifact["after"] = report
+
+    write_json(module_dir / "ulp_fidelity_correction_r1.json", artifact)
+    return report
+
+
 def run_wiki_coverage_gate(
     *,
     manifest: Mapping[str, Any] | str | Path,
@@ -4515,6 +4560,20 @@ def _render_l2_exposure_surgical_instruction(gate_report: Mapping[str, Any]) -> 
     )
 
 
+def _render_ulp_fidelity_surgical_instruction(gate_report: Mapping[str, Any]) -> str:
+    failed = gate_report.get("failed_checks") or []
+    return (
+        f"ULP fidelity failed checks: {_yaml_inline(failed)}. "
+        "Patch only `module.md`. Preserve the existing lesson structure, activities, "
+        "vocabulary, citations, and already-good Ukrainian dialogue. Fix terminal ULP "
+        "issues surgically: make every section opener begin with a Ukrainian-first "
+        "example or dialogue chunk followed by an em-dash English gloss; for mixed "
+        "English scaffold lines that introduce Ukrainian terms, use `український термін "
+        "— English gloss` in the same line. Do not add hand stress marks as a goal; the "
+        "pipeline re-runs deterministic stress annotation after your patch."
+    )
+
+
 def _render_default_surgical_instruction(gate_report: Mapping[str, Any]) -> str:
     return (
         "No gate-specific surgical playbook exists for this gate. Fix only the failed gate "
@@ -4529,6 +4588,7 @@ GATE_SPECIFIC_INSTRUCTION_RENDERERS: dict[str, Callable[[Mapping[str, Any]], str
     "engagement_floor": _render_engagement_surgical_instruction,
     "russianisms_strict": _render_russianisms_surgical_instruction,
     "l2_exposure_floor": _render_l2_exposure_surgical_instruction,
+    "ulp_fidelity": _render_ulp_fidelity_surgical_instruction,
 }
 
 

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -1388,10 +1388,11 @@ def _run(args: argparse.Namespace) -> int:
         else:
             if resume_enabled:
                 force_rerun = True
-            ulp_fidelity_gate = linear_pipeline.run_ulp_fidelity_gate(
+            ulp_fidelity_gate = linear_pipeline.run_ulp_fidelity_with_correction(
                 module_dir,
                 plan_path,
                 profile=profile,
+                writer=writer,
             )
             linear_pipeline.write_json(
                 module_dir / "ulp_fidelity_gate.json",

--- a/tests/test_immersion_rule_ulp.py
+++ b/tests/test_immersion_rule_ulp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from scripts import config
@@ -102,11 +103,11 @@ The word прокидаюся means I wake up. A reflexive verb is a verb that p
     assert report["passed"] is False
     assert report["verdict"] == "REVISE"
     assert set(report["failed_checks"]) >= {
-        "stress_coverage",
         "em_dash_gloss",
         "dialoguebox_uk_en",
         "section_openers",
     }
+    assert "stress_coverage" in report["warnings"]
 
 
 def test_uk_en_ratio_is_advisory_not_terminal(monkeypatch) -> None:
@@ -136,6 +137,135 @@ def test_uk_en_ratio_is_advisory_not_terminal(monkeypatch) -> None:
     assert report["passed"] is True
     assert report["failed_checks"] == []
     assert "uk_en_ratio" in report["warnings"]
+
+
+def test_stress_coverage_is_advisory_not_terminal(monkeypatch) -> None:
+    from scripts.audit import ulp_fidelity_gate as gate
+
+    structural_pass = {"passed": True}
+    monkeypatch.setattr(gate, "_stress_coverage_check", lambda _t: {"passed": False, "coverage": 0.9})
+    monkeypatch.setattr(gate, "_em_dash_gloss_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_dialoguebox_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_section_opener_check", lambda _t: dict(structural_pass))
+    monkeypatch.setattr(gate, "_ratio_check", lambda _t, _p: dict(structural_pass))
+
+    report = gate.check_ulp_fidelity(
+        "irrelevant",
+        {"level": "a1", "sequence": 20, "slug": "fixture"},
+        profile="core",
+    )
+
+    assert report["verdict"] == "PASS"
+    assert report["passed"] is True
+    assert report["failed_checks"] == []
+    assert "stress_coverage" in report["warnings"]
+
+
+def test_em_dash_gate_is_line_level_for_real_scaffold() -> None:
+    module = """# Мій ра́нок
+
+## Мій ра́нок
+
+**Вода́ — water** can stand after **по́тім**: **По́тім вода́**. **Ру́ханка — light exercise** is a short morning item.
+Written **-шся** is spoken **[с':а]**: **прокида́єшся** -> **[прокидайес':а]**.
+
+<DialogueBox uk="Я прокида́юся." en="I wake up." />
+"""
+
+    report = check_ulp_fidelity(
+        module,
+        {"level": "a1", "sequence": 20, "slug": "fixture"},
+        profile="core",
+    )
+
+    assert "em_dash_gloss" not in report["failed_checks"]
+
+
+def test_em_dash_gate_rejects_distant_punctuation_dash() -> None:
+    module = """# Мій ра́нок
+
+## Мій ра́нок
+
+The word **вода́** is useful in the morning because you see it in routines, and this sentence uses a normal aside after many words — not a glossary pair.
+
+<DialogueBox uk="Я п'ю воду́." en="I drink water." />
+"""
+
+    report = check_ulp_fidelity(
+        module,
+        {"level": "a1", "sequence": 20, "slug": "fixture"},
+        profile="core",
+    )
+
+    assert "em_dash_gloss" in report["failed_checks"]
+
+
+def test_ulp_fidelity_correction_reruns_stress_and_gate(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(
+        "\n".join(
+            [
+                "level: a1",
+                "sequence: 20",
+                "slug: fixture",
+                "module: 20",
+                "title: Fixture",
+                "subtitle: ULP fixture",
+                "word_target: 300",
+                "content_outline:",
+                "  - section: opener",
+                "    words: 300",
+                "    points:",
+                "      - fixture",
+                "references:",
+                "  - title: Fixture",
+                "    notes: synthetic test plan",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (module_dir / "module.md").write_text(
+        """# Мій ра́нок
+
+## Підсумок
+
+Your clean morning sentence uses **я прокида́юся** before breakfast.
+
+<DialogueBox uk="Я прокида́юся." en="I wake up." />
+""",
+        encoding="utf-8",
+    )
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+
+    corrected = """```module.md
+# Мій ра́нок
+
+## Підсумок
+
+**Я прокида́юся ра́но** — I wake up early. This is the clean morning model.
+
+<DialogueBox uk="Я прокида́юся ра́но." en="I wake up early." />
+```"""
+
+    def corrector(_context: linear_pipeline.CorrectionContext) -> str:
+        return corrected
+
+    report = linear_pipeline.run_ulp_fidelity_with_correction(
+        module_dir,
+        plan_path,
+        profile="core",
+        writer="codex-tools",
+        writer_corrector=corrector,
+    )
+
+    assert report["passed"] is True
+    assert (module_dir / "stress_annotation.json").exists()
+    correction = json.loads((module_dir / "ulp_fidelity_correction_r1.json").read_text(encoding="utf-8"))
+    assert correction["correction"]["applied"] == "module_patch"
+    assert correction["after"]["passed"] is True
 
 
 def test_linear_pipeline_stress_annotation_marks_module_and_vocabulary(


### PR DESCRIPTION
## Summary
- make ULP stress coverage advisory so incomplete deterministic stress data does not hard-fail otherwise usable output
- reduce em-dash gloss false positives by evaluating mixed scaffold lines, ignoring bad-marker spans and pronunciation lines
- add one ADR-008 writer correction pass for ULP fidelity before the V7 build aborts, then rerun stress annotation and the gate

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_immersion_rule_ulp.py tests/test_stress_annotation.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/ulp_fidelity_gate.py scripts/build/linear_pipeline.py scripts/build/v7_build.py tests/test_immersion_rule_ulp.py
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py