### PR TITLE
docs(agents): codify track-driver handoff persistence (git-tracked, promoted via PR)

### DIFF
--- a/claude_extensions/agents/curriculum-track-orchestrator.md
+++ b/claude_extensions/agents/curriculum-track-orchestrator.md
@@ -36,11 +36,21 @@ initialPrompt: |
     and confirm every row is an expected `A` addition before opening the PR (`gh pr create`, no merge).
   - Transient dispatch failure (returncode 1 / no result file) → remove the worktree+branch, re-fire
     with a `-retry` task id.
-  - After each step, UPDATE your track handoff so the next track-driver session resumes cleanly.
+  - After each batch, REFRESH your handoff and include it in that batch's PR (see KEEP YOUR STATE) —
+    that is how the next track-driver session resumes cleanly.
 
-  ## KEEP YOUR STATE
-  Your handoff must always carry: current epic phase, IN-FLIGHT dispatches + their watcher ids,
-  NEXT ACTION, and the role/boundary reminders above.
+  ## KEEP YOUR STATE — git-tracked, promoted via your PR
+  Your handoff (`docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md`) is the git-tracked cross-session SSOT on
+  `main`, NOT a throwaway scratch file. Persist it like any deliverable, never as an uncommitted
+  local file:
+  - Edit it on your dispatch branch only — NEVER commit or push it onto `main` directly.
+  - BUNDLE the refreshed handoff into that batch's deliverable PR: one PR carries the new artifacts
+    AND the updated handoff. Do NOT open standalone handoff-only PRs, and do NOT churn a PR per step.
+  - The orchestrator merges that PR, so `main` always carries current driver state and any session
+    can resume from it. (If a batch produces no artifact, a handoff-only PR is fine — the point is
+    that state reaches `main` through review, not through a direct commit.)
+  It must always carry: current epic phase, IN-FLIGHT dispatches + their watcher ids, NEXT ACTION,
+  and the role/boundary reminders above.
 ---
 
 # Curriculum Track Orchestrator Agent


### PR DESCRIPTION
## Why
The track-driver handoff (`docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md`) is the cross-session resume SSOT, but the agent definition left its persistence mechanism implicit ("UPDATE your handoff" — without saying it must reach git). That invited the failure mode this thread hit: an **uncommitted local handoff**, lost on a clean checkout and ungoverned.

## What
Codify the intended model (the one #2440 already started by tracking the handoff on `main`):
- The handoff is **git-tracked on `main`** — the cross-session SSOT, not a scratch file.
- The driver edits it **on its dispatch branch only** — never a direct commit/push to `main`.
- The refreshed handoff is **bundled into that batch's deliverable PR** (one PR = new artifacts + updated state). No standalone handoff churn, no PR-per-step.
- The orchestrator merges it, so `main` always carries current driver state.

This makes the driver's "dedicated branch → PR into `main`" loop explicit for state, not just deliverables — keeping it in git without ever conflicting with the orchestrator's `main`.

## Verification
- Frontmatter still closed (delimiters lines 1 + 54) → agent still registers.
- `tests/test_deploy_script_idempotency.py`: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)