### PR TITLE
fix(deploy): declare orchestrator-thread-bootstrap.md as preserved .agent orphan (#2439 regression)

### DIFF
--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -41,7 +41,11 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees"
 # cache/ — Monitor API client disk cache (see scripts/ai_agent_bridge/_monitor_cache.py),
 #          stores rules.body/session.body + ETag metadata so cold-start is ~780 B instead of 75 KB.
 #          Runtime-only; NOT source-tracked. rsync --delete must preserve both.
-ORPHAN_PATHS_AGENT="wake cache"
+# orchestrator-thread-bootstrap.md — replacement-thread bootstrap prompt generated into .agent/
+#          by scripts/orchestration/thread_handoff.py (#2439). Runtime-only, machine-specific
+#          (live timestamps + snapshot); NOT source-tracked. Without this entry the deploy aborts
+#          on any machine where the handoff automation has run.
+ORPHAN_PATHS_AGENT="wake cache orchestrator-thread-bootstrap.md"
 ORPHAN_PATHS_AGENTS=""
 # agents/curriculum-orchestrator.toml and agents/curriculum-writer.toml —
 # Codex agent definitions with no claude_extensions equivalent.


### PR DESCRIPTION
## Problem
`#2439` added `scripts/orchestration/thread_handoff.py`, which generates `.agent/orchestrator-thread-bootstrap.md` — a replacement-thread bootstrap prompt with live timestamps + a repo snapshot. It's a **runtime artifact** (machine-specific, not source-tracked), but it was never added to `ORPHAN_PATHS_AGENT` in `deploy_prompts.sh`.

Result: the `rsync --delete` preflight guard sees an undeclared file in the `.agent/` destination and **aborts the deploy** (`❌ Deploy aborted: undeclared orphan paths would be deleted`) on any machine where the handoff automation has run. Because `start-claude.sh` runs the deploy as `npm run claude:deploy --silent 2>/dev/null || true`, the failure is **silent** — agent/rule/skill updates simply stop reaching `.claude/`. CI never catches it (the file is gitignored, so it's absent in CI).

## Fix
Declare `orchestrator-thread-bootstrap.md` in `ORPHAN_PATHS_AGENT` alongside `wake/` and `cache/` — the existing runtime-only preserved paths — so `rsync --delete` excludes it instead of aborting.

## Verification
- Preflight now passes: `✅ All orphan paths are declared`.
- The file is **preserved**, not wiped (verified against the real orphan in the main checkout).
- Full `deploy_prompts.sh` exits 0 (`Deploy complete.`).
- `tests/test_deploy_script_idempotency.py`: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)