### PR TITLE
fix(build): normalize stressed plan section headings

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7572,9 +7572,14 @@ def _section_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
         headings_by_key.setdefault(_section_heading_key(raw_heading), []).append(raw_heading)
     missing = []
     duplicate_headings = []
+    seen_keys: set[str] = set()
     for section in plan["content_outline"]:
         title = section["section"]
-        matching_headings = headings_by_key.get(_section_heading_key(title), [])
+        heading_key = _section_heading_key(title)
+        if heading_key in seen_keys:
+            continue
+        seen_keys.add(heading_key)
+        matching_headings = headings_by_key.get(heading_key, [])
         if not matching_headings:
             missing.append(title)
         elif len(matching_headings) > 1:
@@ -7638,7 +7643,8 @@ def _section_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _section_heading_key(title: Any) -> str:
-    normalized = unicodedata.normalize("NFD", str(title or "").strip())
+    title_str = str(title) if title is not None else ""
+    normalized = unicodedata.normalize("NFD", title_str.strip())
     without_stress = "".join(ch for ch in normalized if ch not in _VESUM_STRESS_MARKS)
     return re.sub(r"\s+", " ", unicodedata.normalize("NFC", without_stress)).strip()
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7537,8 +7537,25 @@ def _word_count_gate(text: str, target: int) -> dict[str, Any]:
 
 
 def _section_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
-    headings = {match.group(1).strip() for match in _HEADING_RE.finditer(text)}
-    missing = [section["section"] for section in plan["content_outline"] if section["section"] not in headings]
+    headings_by_key: dict[str, list[str]] = {}
+    for match in _HEADING_RE.finditer(text):
+        raw_heading = match.group(1).strip()
+        headings_by_key.setdefault(_section_heading_key(raw_heading), []).append(raw_heading)
+    missing = []
+    duplicate_headings = []
+    for section in plan["content_outline"]:
+        title = section["section"]
+        matching_headings = headings_by_key.get(_section_heading_key(title), [])
+        if not matching_headings:
+            missing.append(title)
+        elif len(matching_headings) > 1:
+            duplicate_headings.append(
+                {
+                    "section": title,
+                    "headings": matching_headings,
+                    "count": len(matching_headings),
+                }
+            )
     budgets = []
     for section in plan["content_outline"]:
         title = section["section"]
@@ -7584,15 +7601,30 @@ def _section_gate(text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
         # above). A future stricter mode could surface per-section under-min
         # as a separate `plan_sections_balance` advisory gate, but the build
         # halt no longer fires on it.
-        "passed": not missing,
+        "passed": not missing and not duplicate_headings,
         "missing_headings": missing,
+        "duplicate_headings": duplicate_headings,
         "word_budgets": budgets,
     }
 
 
+def _section_heading_key(title: Any) -> str:
+    normalized = unicodedata.normalize("NFD", str(title or "").strip())
+    without_stress = "".join(ch for ch in normalized if ch not in _VESUM_STRESS_MARKS)
+    return re.sub(r"\s+", " ", unicodedata.normalize("NFC", without_stress)).strip()
+
+
 def _extract_section_text(text: str, title: str) -> str:
-    match = re.search(rf"^##\s+{re.escape(title)}\s*$", text, flags=re.MULTILINE)
-    if not match:
+    title_key = _section_heading_key(title)
+    match = next(
+        (
+            heading_match
+            for heading_match in _HEADING_RE.finditer(text)
+            if _section_heading_key(heading_match.group(1)) == title_key
+        ),
+        None,
+    )
+    if match is None:
         return ""
     next_heading = re.search(r"^##\s+", text[match.end() :], flags=re.MULTILINE)
     if not next_heading:

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -4560,6 +4560,34 @@ def _render_l2_exposure_surgical_instruction(gate_report: Mapping[str, Any]) -> 
     )
 
 
+def _render_plan_sections_surgical_instruction(gate_report: Mapping[str, Any]) -> str:
+    missing_headings = [str(heading) for heading in gate_report.get("missing_headings", [])]
+    duplicate_headings = gate_report.get("duplicate_headings") or []
+    instructions = []
+
+    if missing_headings:
+        instructions.append(
+            "Missing H2 sections: "
+            f"{', '.join(missing_headings)}. Add each missing `## <section>` heading at the "
+            "appropriate plan position with the smallest amount of section content needed."
+        )
+    if duplicate_headings:
+        instructions.append(
+            "Duplicate stress-equivalent H2 sections: "
+            f"{_yaml_inline(duplicate_headings)}. For each duplicate group, keep exactly one "
+            "`##` heading for the planned section. Apply the smallest structural edit: merge "
+            "unique prose under the kept section, demote supporting duplicate blocks to `###`, "
+            "or delete an empty/redundant duplicate H2 block. Do not add a new duplicate heading."
+        )
+    if not instructions:
+        instructions.append(
+            "The plan section structure failed. Use the YAML diagnostic to add missing H2 sections "
+            "or collapse duplicate H2 sections with the smallest structural edit."
+        )
+
+    return " ".join(instructions) + " Preserve all unrelated prose byte-for-byte. Do not re-author the lesson."
+
+
 def _render_ulp_fidelity_surgical_instruction(gate_report: Mapping[str, Any]) -> str:
     failed = gate_report.get("failed_checks") or []
     return (
@@ -4585,6 +4613,7 @@ def _render_default_surgical_instruction(gate_report: Mapping[str, Any]) -> str:
 GATE_SPECIFIC_INSTRUCTION_RENDERERS: dict[str, Callable[[Mapping[str, Any]], str]] = {
     "vesum_verified": _render_vesum_surgical_instruction,
     "word_count": _render_word_count_surgical_instruction,
+    "plan_sections": _render_plan_sections_surgical_instruction,
     "engagement_floor": _render_engagement_surgical_instruction,
     "russianisms_strict": _render_russianisms_surgical_instruction,
     "l2_exposure_floor": _render_l2_exposure_surgical_instruction,

--- a/scripts/build/phases/linear-writer-correction-grok.md
+++ b/scripts/build/phases/linear-writer-correction-grok.md
@@ -26,7 +26,10 @@ will be rejected as `writer_correction_unparseable` and the module will fail.
 
 ## Hard constraint — patch-bounded
 
-Modify in place via append/insert. Never re-author or regenerate.
+Modify in place via append/insert. When the gate-specific instructions
+explicitly name a structural duplication failure, you may make the smallest
+structural edit they allow, such as demoting/deleting a duplicate heading marker
+or merging duplicate section content. Never re-author or regenerate.
 
 Forbidden phrases as instructions or strategy: "regenerate", "rewrite",
 "produce again", "start over". Do not discard the previously-passing prose.
@@ -66,7 +69,8 @@ actually made in this turn's trace.
 ## Previously-Passing Prose
 
 The following prose passed other gates before this correction. Preserve it
-verbatim except for the smallest append/insert needed for the failed gate.
+verbatim except for the smallest append/insert or explicitly permitted
+structural edit needed for the failed gate.
 Return the FULL patched module.md (the unchanged prose plus your minimal
 patch) inside the single fenced block above.
 

--- a/scripts/build/phases/linear-writer-correction.md
+++ b/scripts/build/phases/linear-writer-correction.md
@@ -26,7 +26,10 @@ will be rejected as `writer_correction_unparseable` and the module will fail.
 
 ## Hard constraint — patch-bounded
 
-Modify in place via append/insert. Never re-author or regenerate.
+Modify in place via append/insert. When the gate-specific instructions
+explicitly name a structural duplication failure, you may make the smallest
+structural edit they allow, such as demoting/deleting a duplicate heading marker
+or merging duplicate section content. Never re-author or regenerate.
 
 Forbidden phrases as instructions or strategy: "regenerate", "rewrite",
 "produce again", "start over". Do not discard the previously-passing prose.
@@ -74,7 +77,8 @@ made in this turn's trace.
 ## Previously-Passing Prose
 
 The following prose passed other gates before this correction. Preserve it
-verbatim except for the smallest append/insert needed for the failed gate.
+verbatim except for the smallest append/insert or explicitly permitted
+structural edit needed for the failed gate.
 Return the FULL patched module.md (the unchanged prose plus your minimal
 patch) inside the single fenced block above.
 

--- a/tests/test_correction_loop_surgical.py
+++ b/tests/test_correction_loop_surgical.py
@@ -36,6 +36,37 @@ def test_word_count_correction_prompt_is_append_only() -> None:
     assert "ONLY append" in prompt
 
 
+def test_plan_section_gate_matches_stressed_headings() -> None:
+    plan = {"content_outline": [{"section": "Діалоги", "words": 20}]}
+    report = linear_pipeline._section_gate(
+        "# Мій ранок\n\n## Діало́ги\n\nЛіна прокидається рано. Потім вона вмивається.\n",
+        plan,
+    )
+
+    assert report["passed"] is True
+    assert report["missing_headings"] == []
+    assert report["duplicate_headings"] == []
+    assert report["word_budgets"][0]["count"] > 0
+
+
+def test_plan_section_gate_rejects_stress_equivalent_duplicate_headings() -> None:
+    plan = {"content_outline": [{"section": "Діалоги", "words": 20}]}
+    report = linear_pipeline._section_gate(
+        "# Мій ранок\n\n"
+        "## Діало́ги\n\n"
+        "Ліна прокидається рано.\n\n"
+        "## Діалоги\n\n"
+        "Настя прокидається пізно.\n",
+        plan,
+    )
+
+    assert report["passed"] is False
+    assert report["missing_headings"] == []
+    assert report["duplicate_headings"] == [
+        {"section": "Діалоги", "headings": ["Діало́ги", "Діалоги"], "count": 2}
+    ]
+
+
 def test_unhandled_correction_gate_uses_generic_surgical_fallback() -> None:
     prompt = linear_pipeline.render_writer_correction_prompt(
         gate="textbook_grounding",

--- a/tests/test_correction_loop_surgical.py
+++ b/tests/test_correction_loop_surgical.py
@@ -67,6 +67,24 @@ def test_plan_section_gate_rejects_stress_equivalent_duplicate_headings() -> Non
     ]
 
 
+def test_plan_section_gate_deduplicates_plan_section_diagnostics() -> None:
+    plan = {
+        "content_outline": [
+            {"section": "Діалоги", "words": 20},
+            {"section": "Діало́ги", "words": 20},
+        ]
+    }
+    report = linear_pipeline._section_gate("# Мій ранок\n\n## Підсумок\n\nТекст.\n", plan)
+
+    assert report["passed"] is False
+    assert report["missing_headings"] == ["Діалоги"]
+    assert report["duplicate_headings"] == []
+
+
+def test_section_heading_key_preserves_falsy_non_none_titles() -> None:
+    assert linear_pipeline._section_heading_key(0) == "0"
+
+
 def test_plan_sections_correction_prompt_allows_duplicate_structural_edit() -> None:
     prompt = linear_pipeline.render_writer_correction_prompt(
         gate="plan_sections",

--- a/tests/test_correction_loop_surgical.py
+++ b/tests/test_correction_loop_surgical.py
@@ -67,6 +67,43 @@ def test_plan_section_gate_rejects_stress_equivalent_duplicate_headings() -> Non
     ]
 
 
+def test_plan_sections_correction_prompt_allows_duplicate_structural_edit() -> None:
+    prompt = linear_pipeline.render_writer_correction_prompt(
+        gate="plan_sections",
+        gate_report={
+            "passed": False,
+            "missing_headings": [],
+            "duplicate_headings": [
+                {"section": "Діалоги", "headings": ["Діало́ги", "Діалоги"], "count": 2}
+            ],
+        },
+        module_text="# Мій ранок\n\n## Діало́ги\n\nТекст.\n\n## Діалоги\n\nТекст.\n",
+    )
+
+    assert "Duplicate stress-equivalent H2 sections" in prompt
+    assert "keep exactly one `##` heading" in prompt
+    assert "demote supporting duplicate blocks to `###`" in prompt
+    assert "delete an empty/redundant duplicate H2 block" in prompt
+    assert "structural edit needed for the failed gate" in prompt
+    assert "No gate-specific surgical playbook exists" not in prompt
+
+
+def test_plan_sections_correction_prompt_directs_missing_heading_insert() -> None:
+    prompt = linear_pipeline.render_writer_correction_prompt(
+        gate="plan_sections",
+        gate_report={
+            "passed": False,
+            "missing_headings": ["Підсумок"],
+            "duplicate_headings": [],
+        },
+        module_text="# Мій ранок\n\n## Діалоги\n\nТекст.\n",
+    )
+
+    assert "Missing H2 sections: Підсумок" in prompt
+    assert "Add each missing `## <section>` heading" in prompt
+    assert "No gate-specific surgical playbook exists" not in prompt
+
+
 def test_unhandled_correction_gate_uses_generic_surgical_fallback() -> None:
     prompt = linear_pipeline.render_writer_correction_prompt(
         gate="textbook_grounding",


### PR DESCRIPTION
## Summary

- Normalize Ukrainian stress marks when matching generated H2 headings to planned `content_outline` sections.
- Fail the deterministic `plan_sections` gate when a planned heading appears more than once after stress normalization.
- Add focused regression coverage for stressed headings and stress-equivalent duplicates.

## Root Cause

The m20 rebuild produced stressed headings like `## Діало́ги`, while the plan requires `Діалоги`. The exact-match gate reported those sections missing, and the ADR-008 correction appended unstressed duplicate sections instead of recognizing the existing stressed headings. The build then reached MDX/LLM review with duplicated lesson sections.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_correction_loop_surgical.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_linear_pipeline_telemetry.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check --fix scripts/build/linear_pipeline.py tests/test_correction_loop_surgical.py`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Reproduced against the failed m20 artifacts: raw writer output now passes `plan_sections`; duplicated corrected/final artifacts now fail with duplicate heading diagnostics.