### PR TITLE
feat(ci): deterministic content-CI lane for track content (§7 + word-count)

### DIFF
--- a/.github/workflows/content-ci.yml
+++ b/.github/workflows/content-ci.yml
@@ -1,0 +1,79 @@
+name: Content CI
+
+permissions:
+  contents: read
+
+on:
+  # Advisory content gates intentionally avoid a global path filter.
+  # See ci.yml #1641/#1644: filtered required checks can wedge PRs as "expected".
+  pull_request:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      content: ${{ steps.filter.outputs.content }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4 - SHA-pinned per supply-chain hardening 2026-05-19
+        id: filter
+        with:
+          filters: |
+            content:
+              - 'docs/research/**'
+              - 'curriculum/**/*.md'
+              - 'curriculum/l2-uk-en/plans/**/*.yaml'
+              - 'plans/**/*.yaml'
+
+  section7-xref:
+    name: Content Gate (Section 7 xref)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.content == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Validate changed bio dossier Section 7 paths
+        run: |
+          git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
+          mapfile -t dossiers < <(
+            git diff --name-only --diff-filter=AM origin/main...HEAD -- docs/research/bio \
+              | grep -E '^docs/research/bio/.*\.md$' || true
+          )
+
+          if ((${#dossiers[@]} == 0)); then
+            echo "No changed bio research dossiers."
+            exit 0
+          fi
+
+          python scripts/audit/lint_bio_dossier_xref.py --paths "${dossiers[@]}"
+
+  dossier-wordcount:
+    name: Content Gate (dossier word count)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.content == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Check changed dossier word-count floor
+        run: |
+          git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
+          python scripts/audit/check_dossier_wordcount.py --changed

--- a/scripts/audit/check_dossier_wordcount.py
+++ b/scripts/audit/check_dossier_wordcount.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Check research dossier prose length against the Phase 1 template floor.
+
+The count is intentionally deterministic and local-only: remove YAML
+frontmatter, fenced code blocks, HTML comments, URLs, and common Markdown
+syntax, then count Unicode alphanumeric runs as words. Link text, heading text,
+and inline-code text remain countable because they are reader-visible prose.
+This is a template-floor guard, not a readability metric.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORD_FLOOR = 1200
+
+WORD = re.compile(r"[^\W_]+(?:[-'’][^\W_]+)*", re.UNICODE)
+FENCED_BLOCK = re.compile(r"```.*?```", re.DOTALL)
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+HTML_TAG = re.compile(r"<[^>\n]+>")
+INLINE_CODE = re.compile(r"`([^`\n]+)`")
+IMAGE = re.compile(r"!\[([^\]]*)\]\([^)]+\)")
+LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+URL = re.compile(r"https?://\S+|www\.\S+")
+
+
+@dataclass(frozen=True)
+class DossierCount:
+    path: Path
+    words: int
+
+    @property
+    def passed(self) -> bool:
+        return self.words >= WORD_FLOOR
+
+
+def _strip_yaml_frontmatter(text: str) -> str:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[index + 1 :])
+    return text
+
+
+def _strip_markdown_markup(text: str) -> str:
+    text = _strip_yaml_frontmatter(text)
+    text = FENCED_BLOCK.sub(" ", text)
+    text = HTML_COMMENT.sub(" ", text)
+    text = HTML_TAG.sub(" ", text)
+    text = INLINE_CODE.sub(r"\1", text)
+    text = IMAGE.sub(r"\1", text)
+    text = LINK.sub(r"\1", text)
+    text = URL.sub(" ", text)
+
+    cleaned_lines: list[str] = []
+    for line in text.splitlines():
+        line = re.sub(r"^\s{0,3}#{1,6}\s*", "", line)
+        line = re.sub(r"^\s{0,3}>\s?", "", line)
+        line = re.sub(r"^\s*[-*+]\s+", "", line)
+        line = re.sub(r"^\s*\d+[.)]\s+", "", line)
+        cleaned_lines.append(line)
+
+    text = "\n".join(cleaned_lines)
+    return re.sub(r"[*_~{}\[\]()|:;,.!?/\\]", " ", text)
+
+
+def count_words(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    prose = _strip_markdown_markup(text)
+    return len(WORD.findall(prose))
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _repo_relative(path: Path) -> Path | None:
+    absolute = path if path.is_absolute() else PROJECT_ROOT / path
+    try:
+        return absolute.resolve().relative_to(PROJECT_ROOT.resolve())
+    except ValueError:
+        return None
+
+
+def _is_research_dossier(path: Path) -> bool:
+    relative = _repo_relative(path)
+    if relative is None or path.suffix != ".md":
+        return False
+    return len(relative.parts) >= 3 and relative.parts[:2] == ("docs", "research")
+
+
+def _resolve_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    cwd_path = path.resolve()
+    if cwd_path.exists():
+        return cwd_path
+    return PROJECT_ROOT / path
+
+
+def changed_paths() -> list[Path]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=AM", "origin/main...HEAD"],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return [PROJECT_ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def _dedupe(paths: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for path in paths:
+        resolved = _resolve_path(path)
+        key = resolved.resolve()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(resolved)
+    return deduped
+
+
+def collect_paths(args: argparse.Namespace) -> list[Path]:
+    paths = [_resolve_path(path) for path in args.paths]
+    if args.changed:
+        paths.extend(changed_paths())
+    return [
+        path
+        for path in _dedupe(paths)
+        if _is_research_dossier(path) and path.exists() and path.is_file()
+    ]
+
+
+def print_report(counts: list[DossierCount]) -> None:
+    if not counts:
+        print("No docs/research dossier files to check.")
+        return
+
+    file_width = max(len(_display_path(item.path)) for item in counts)
+    print(f"Dossier word-count floor: {WORD_FLOOR}")
+    print(f"{'file':<{file_width}}  {'words':>5}  {'floor':>5}  status")
+    print("-" * (file_width + 25))
+    for item in counts:
+        status = "PASS" if item.passed else "FAIL"
+        print(
+            f"{_display_path(item.path):<{file_width}}  "
+            f"{item.words:>5}  {WORD_FLOOR:>5}  {status}"
+        )
+
+    failures = [item for item in counts if not item.passed]
+    if failures:
+        print()
+        print(f"{len(failures)} dossier(s) below the {WORD_FLOOR}-word floor.")
+    else:
+        print()
+        print(f"All checked dossiers meet the {WORD_FLOOR}-word floor.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check docs/research dossier word counts against the template floor.",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        type=Path,
+        default=[],
+        metavar="PATH",
+        help="One or more dossier markdown files to check.",
+    )
+    parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Check changed dossier files from git diff origin/main...HEAD.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.paths and not args.changed:
+        parser.error("provide --paths or --changed")
+
+    counts = [DossierCount(path=path, words=count_words(path)) for path in collect_paths(args)]
+    print_report(counts)
+    return 1 if any(not item.passed for item in counts) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit/check_dossier_wordcount.py
+++ b/scripts/audit/check_dossier_wordcount.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
-"""Check research dossier prose length against the Phase 1 template floor.
+"""Check research dossier total word count against the Phase 1 template floor.
 
-The count is intentionally deterministic and local-only: remove YAML
-frontmatter, fenced code blocks, HTML comments, URLs, and common Markdown
-syntax, then count Unicode alphanumeric runs as words. Link text, heading text,
-and inline-code text remain countable because they are reader-visible prose.
-This is a template-floor guard, not a readability metric.
+The count is the deterministic total whitespace-delimited word count of the
+file (``wc -w`` semantics), matching non-negotiable rule #1 ("Total word count
+>= word_target") and the dossier template's stated range (~1500 target, 1200
+floor).
+
+It is intentionally NOT prose-stripped. The template's 1200/1500/2000 figures
+are total-word figures, and the dossiers were authored against ``wc -w`` of the
+whole file (frontmatter included). Prose-stripping double-discounts them: an
+empirical sweep of the 137-dossier corpus showed a prose-only floor of 1200
+fails 51/137 dossiers including the gold-standard exemplar mykola-kostomarov
+(1147 prose / 1232 total), whereas a total-word floor of 1200 fails only the 4
+genuinely-thin dossiers (979-1017 words). This is a template-floor guard, not a
+readability metric.
 """
 
 from __future__ import annotations
 
 import argparse
-import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -19,15 +26,6 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORD_FLOOR = 1200
-
-WORD = re.compile(r"[^\W_]+(?:[-'’][^\W_]+)*", re.UNICODE)
-FENCED_BLOCK = re.compile(r"```.*?```", re.DOTALL)
-HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
-HTML_TAG = re.compile(r"<[^>\n]+>")
-INLINE_CODE = re.compile(r"`([^`\n]+)`")
-IMAGE = re.compile(r"!\[([^\]]*)\]\([^)]+\)")
-LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
-URL = re.compile(r"https?://\S+|www\.\S+")
 
 
 @dataclass(frozen=True)
@@ -40,43 +38,9 @@ class DossierCount:
         return self.words >= WORD_FLOOR
 
 
-def _strip_yaml_frontmatter(text: str) -> str:
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        return text
-
-    for index, line in enumerate(lines[1:], start=1):
-        if line.strip() == "---":
-            return "\n".join(lines[index + 1 :])
-    return text
-
-
-def _strip_markdown_markup(text: str) -> str:
-    text = _strip_yaml_frontmatter(text)
-    text = FENCED_BLOCK.sub(" ", text)
-    text = HTML_COMMENT.sub(" ", text)
-    text = HTML_TAG.sub(" ", text)
-    text = INLINE_CODE.sub(r"\1", text)
-    text = IMAGE.sub(r"\1", text)
-    text = LINK.sub(r"\1", text)
-    text = URL.sub(" ", text)
-
-    cleaned_lines: list[str] = []
-    for line in text.splitlines():
-        line = re.sub(r"^\s{0,3}#{1,6}\s*", "", line)
-        line = re.sub(r"^\s{0,3}>\s?", "", line)
-        line = re.sub(r"^\s*[-*+]\s+", "", line)
-        line = re.sub(r"^\s*\d+[.)]\s+", "", line)
-        cleaned_lines.append(line)
-
-    text = "\n".join(cleaned_lines)
-    return re.sub(r"[*_~{}\[\]()|:;,.!?/\\]", " ", text)
-
-
 def count_words(path: Path) -> int:
-    text = path.read_text(encoding="utf-8")
-    prose = _strip_markdown_markup(text)
-    return len(WORD.findall(prose))
+    """Total whitespace-delimited word count of the file (wc -w semantics)."""
+    return len(path.read_text(encoding="utf-8").split())
 
 
 def _display_path(path: Path) -> str:
@@ -175,7 +139,7 @@ def print_report(counts: list[DossierCount]) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Check docs/research dossier word counts against the template floor.",
+        description="Check docs/research dossier total word counts against the template floor.",
         epilog=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/tests/audit/test_check_dossier_wordcount.py
+++ b/tests/audit/test_check_dossier_wordcount.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit import check_dossier_wordcount
+
+
+def _write_dossier(root: Path, slug: str, word_count: int) -> Path:
+    path = root / "docs" / "research" / "bio" / f"{slug}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = " ".join(["слово"] * word_count)
+    path.write_text(
+        f"""---
+title: fixture
+---
+
+{body}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_wordcount_passes_at_template_floor(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(check_dossier_wordcount, "PROJECT_ROOT", tmp_path)
+    dossier = _write_dossier(tmp_path, "passing-fixture", 1200)
+
+    assert check_dossier_wordcount.main(["--paths", str(dossier)]) == 0
+
+    output = capsys.readouterr().out
+    assert "docs/research/bio/passing-fixture.md" in output
+    assert "1200   1200  PASS" in output
+    assert "All checked dossiers meet the 1200-word floor." in output
+
+
+def test_paths_can_be_relative_to_current_directory(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(check_dossier_wordcount, "PROJECT_ROOT", tmp_path)
+    dossier = _write_dossier(tmp_path, "cwd-relative-fixture", 1200)
+    monkeypatch.chdir(dossier.parent)
+
+    assert check_dossier_wordcount.main(["--paths", dossier.name]) == 0
+
+    output = capsys.readouterr().out
+    assert "docs/research/bio/cwd-relative-fixture.md" in output
+    assert "1200   1200  PASS" in output
+
+
+def test_wordcount_strips_html_tags_but_keeps_visible_text(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(check_dossier_wordcount, "PROJECT_ROOT", tmp_path)
+    dossier = _write_dossier(tmp_path, "html-fixture", 1199)
+    dossier.write_text(
+        dossier.read_text(encoding="utf-8") + "\n<div><kbd>слово</kbd></div>\n",
+        encoding="utf-8",
+    )
+
+    assert check_dossier_wordcount.main(["--paths", str(dossier)]) == 0
+
+    output = capsys.readouterr().out
+    assert "docs/research/bio/html-fixture.md" in output
+    assert "1200   1200  PASS" in output
+
+
+def test_changed_mode_uses_changed_research_dossiers_only(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(check_dossier_wordcount, "PROJECT_ROOT", tmp_path)
+    dossier = _write_dossier(tmp_path, "changed-fixture", 1200)
+    ignored = tmp_path / "docs" / "notes.md"
+    ignored.parent.mkdir(parents=True, exist_ok=True)
+    ignored.write_text("слово\n", encoding="utf-8")
+    monkeypatch.setattr(
+        check_dossier_wordcount,
+        "changed_paths",
+        lambda: [dossier, ignored],
+    )
+
+    assert check_dossier_wordcount.main(["--changed"]) == 0
+
+    output = capsys.readouterr().out
+    assert "docs/research/bio/changed-fixture.md" in output
+    assert "docs/notes.md" not in output
+
+
+def test_wordcount_fails_below_template_floor(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(check_dossier_wordcount, "PROJECT_ROOT", tmp_path)
+    dossier = _write_dossier(tmp_path, "failing-fixture", 1199)
+
+    assert check_dossier_wordcount.main(["--paths", str(dossier)]) == 1
+
+    output = capsys.readouterr().out
+    assert "docs/research/bio/failing-fixture.md" in output
+    assert "1199   1200  FAIL" in output
+    assert "1 dossier(s) below the 1200-word floor." in output

--- a/tests/audit/test_check_dossier_wordcount.py
+++ b/tests/audit/test_check_dossier_wordcount.py
@@ -4,11 +4,16 @@ from pathlib import Path
 
 from scripts.audit import check_dossier_wordcount
 
+# The fixture frontmatter block ("---\ntitle: fixture\n---") contributes 4
+# whitespace-delimited tokens, which the total-word count includes. Subtract
+# them from the body so the file's total word count equals `total_words`.
+_FRONTMATTER_TOKENS = 4
 
-def _write_dossier(root: Path, slug: str, word_count: int) -> Path:
+
+def _write_dossier(root: Path, slug: str, total_words: int) -> Path:
     path = root / "docs" / "research" / "bio" / f"{slug}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
-    body = " ".join(["слово"] * word_count)
+    body = " ".join(["слово"] * (total_words - _FRONTMATTER_TOKENS))
     path.write_text(
         f"""---
 title: fixture
@@ -49,21 +54,25 @@ def test_paths_can_be_relative_to_current_directory(
     assert "1200   1200  PASS" in output
 
 
-def test_wordcount_strips_html_tags_but_keeps_visible_text(
+def test_total_count_includes_markup_and_urls(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:
+    # Total-word count is wc -w semantics: markdown markup, HTML, and URLs all
+    # count as words (unlike a prose-stripping count). 1196 body words + 4
+    # frontmatter tokens = 1200 already; the extra markup tokens push it over.
     monkeypatch.setattr(check_dossier_wordcount, "PROJECT_ROOT", tmp_path)
-    dossier = _write_dossier(tmp_path, "html-fixture", 1199)
+    dossier = _write_dossier(tmp_path, "markup-fixture", 1200)
     dossier.write_text(
-        dossier.read_text(encoding="utf-8") + "\n<div><kbd>слово</kbd></div>\n",
+        dossier.read_text(encoding="utf-8")
+        + "\n[link text](https://example.org/path) <kbd>x</kbd>\n",
         encoding="utf-8",
     )
 
     assert check_dossier_wordcount.main(["--paths", str(dossier)]) == 0
 
     output = capsys.readouterr().out
-    assert "docs/research/bio/html-fixture.md" in output
-    assert "1200   1200  PASS" in output
+    # 1200 + tokens: "[link" "text](https://example.org/path)" "<kbd>x</kbd>" = 1203
+    assert "1203   1200  PASS" in output
 
 
 def test_changed_mode_uses_changed_research_dossiers_only(


### PR DESCRIPTION
## Summary

- Add advisory Content CI workflow with pinned actions and no global PR path filter.
- Reuse the existing Section 7 bio dossier xref validator for changed dossiers.
- Add deterministic dossier word-count floor gate plus focused tests.

## Validation

```text
$ .venv/bin/ruff check scripts/audit/check_dossier_wordcount.py
All checks passed!
```

```text
$ .venv/bin/python -m pytest tests/audit/test_check_dossier_wordcount.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/content-ci-lane-2026-05-30
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 5 items

tests/audit/test_check_dossier_wordcount.py .....                        [100%]

============================== 5 passed in 0.45s ===============================
```

```text
$ .venv/bin/python scripts/audit/check_dossier_wordcount.py --paths docs/research/bio/mykhailo-hrushevskyi.md
Dossier word-count floor: 1200
file                                       words  floor  status
------------------------------------------------------------------
docs/research/bio/mykhailo-hrushevskyi.md   1246   1200  PASS

All checked dossiers meet the 1200-word floor.
```

```text
$ .venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykhailo-hrushevskyi.md
No fabricated Existing cross-track plan paths found.
```

```text
$ .venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/content-ci.yml'))"
```

```text
$ zizmor --offline .github/workflows/content-ci.yml
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/content-ci.yml
No findings to report. Good job! (2 suppressed)
```