### PR TITLE
feat(handoff): add agent-specific thread routers

### DIFF
--- a/.codex/hooks/session-setup.sh
+++ b/.codex/hooks/session-setup.sh
@@ -216,6 +216,7 @@ fi
 # This is the zero-touch rehydrate: current.md keeps a stable Latest-Brief
 # marker so the hook can inject a compact pointer instead of dumping the index.
 HANDOFF_FILE="$PROJECT_DIR/docs/session-state/current.md"
+HANDOFF_AGENT="${SESSION_HANDOFF_AGENT:-claude}"
 HANDOFF_CONTEXT=""
 HANDOFF_WARNINGS=""
 
@@ -225,7 +226,7 @@ build_handoff_pointer() {
 PREVIOUS-SESSION HANDOFF — read this brief first, then orient via Monitor API.
 
 Brief: $brief_path
-Read with: Read tool. The brief is ~4KB, YAML frontmatter + bullet body.
+Read with: Read tool. The target is the current agent handoff or a compact brief.
 Cold-start protocol: claude_extensions/rules/workflow.md § "Two-tier handoffs"
 
 ---
@@ -253,9 +254,18 @@ EOF
 }
 
 if [ -f "$HANDOFF_FILE" ]; then
+  AGENT_HANDOFF=$(sed -n "s/^[[:space:]]*-[[:space:]]*${HANDOFF_AGENT}:[[:space:]]*//p" "$HANDOFF_FILE" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//')
+  if [ -n "$AGENT_HANDOFF" ]; then
+    if [ -f "$PROJECT_DIR/$AGENT_HANDOFF" ]; then
+      HANDOFF_CONTEXT=$(build_handoff_pointer "$AGENT_HANDOFF")
+    else
+      HANDOFF_WARNINGS="WARN: Agent-Handoff for $HANDOFF_AGENT pointed to $AGENT_HANDOFF but file missing on disk."
+    fi
+  fi
+
   MARKER_BRIEF=$(grep -m1 '^Latest-Brief:' "$HANDOFF_FILE" 2>/dev/null | sed 's/^Latest-Brief:[[:space:]]*//; s/[[:space:]]*$//')
 
-  if [ -n "$MARKER_BRIEF" ]; then
+  if [ -z "$HANDOFF_CONTEXT" ] && [ -n "$MARKER_BRIEF" ]; then
     if [ -f "$PROJECT_DIR/$MARKER_BRIEF" ]; then
       HANDOFF_CONTEXT=$(build_handoff_pointer "$MARKER_BRIEF")
     else

--- a/claude_extensions/agents/curriculum-orchestrator.md
+++ b/claude_extensions/agents/curriculum-orchestrator.md
@@ -10,13 +10,13 @@ initialPrompt: |
   2. Orient via Monitor API, not files:
      - `curl -s --max-time 2 http://localhost:8765/api/state/manifest`
      - `curl -s --max-time 2 'http://localhost:8765/api/rules?format=markdown'` only if rules hash changed
-     - `curl -s --max-time 2 http://localhost:8765/api/session/current` only if session hash changed
+     - `curl -s --max-time 2 'http://localhost:8765/api/session/current?agent=orchestrator'` only if session hash changed
      - `curl -s --max-time 2 http://localhost:8765/api/orient`
      - `curl -s --max-time 2 'http://localhost:8765/api/comms/inbox?agent=claude'`
-  3. Read the latest handoff linked by the top row of `docs/session-state/current.md`.
+  3. Read `docs/session-state/current.orchestrator.md` for the detailed handoff; `current.md` is only the router.
   4. Check `docs/decisions/pending/`; pending decisions block only their declared Scope.
   5. Then begin work. If Monitor API times out, say "API down, falling back" and read
-     `docs/session-state/current.md` -> latest handoff -> `memory/MEMORY.md` -> `CLAUDE.md`.
+     `docs/session-state/current.md` router -> matching `current.<agent>.md` -> `memory/MEMORY.md` -> `CLAUDE.md`.
 
   Standalone session = main orchestrator. Drive the queue without asking when the next
   action is obvious.

--- a/claude_extensions/hooks/session-setup.sh
+++ b/claude_extensions/hooks/session-setup.sh
@@ -216,6 +216,7 @@ fi
 # This is the zero-touch rehydrate: current.md keeps a stable Latest-Brief
 # marker so the hook can inject a compact pointer instead of dumping the index.
 HANDOFF_FILE="$PROJECT_DIR/docs/session-state/current.md"
+HANDOFF_AGENT="${SESSION_HANDOFF_AGENT:-claude}"
 HANDOFF_CONTEXT=""
 HANDOFF_WARNINGS=""
 
@@ -225,7 +226,7 @@ build_handoff_pointer() {
 PREVIOUS-SESSION HANDOFF — read this brief first, then orient via Monitor API.
 
 Brief: $brief_path
-Read with: Read tool. The brief is ~4KB, YAML frontmatter + bullet body.
+Read with: Read tool. The target is the current agent handoff or a compact brief.
 Cold-start protocol: claude_extensions/rules/workflow.md § "Two-tier handoffs"
 
 ---
@@ -253,9 +254,18 @@ EOF
 }
 
 if [ -f "$HANDOFF_FILE" ]; then
+  AGENT_HANDOFF=$(sed -n "s/^[[:space:]]*-[[:space:]]*${HANDOFF_AGENT}:[[:space:]]*//p" "$HANDOFF_FILE" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//')
+  if [ -n "$AGENT_HANDOFF" ]; then
+    if [ -f "$PROJECT_DIR/$AGENT_HANDOFF" ]; then
+      HANDOFF_CONTEXT=$(build_handoff_pointer "$AGENT_HANDOFF")
+    else
+      HANDOFF_WARNINGS="WARN: Agent-Handoff for $HANDOFF_AGENT pointed to $AGENT_HANDOFF but file missing on disk."
+    fi
+  fi
+
   MARKER_BRIEF=$(grep -m1 '^Latest-Brief:' "$HANDOFF_FILE" 2>/dev/null | sed 's/^Latest-Brief:[[:space:]]*//; s/[[:space:]]*$//')
 
-  if [ -n "$MARKER_BRIEF" ]; then
+  if [ -z "$HANDOFF_CONTEXT" ] && [ -n "$MARKER_BRIEF" ]; then
     if [ -f "$PROJECT_DIR/$MARKER_BRIEF" ]; then
       HANDOFF_CONTEXT=$(build_handoff_pointer "$MARKER_BRIEF")
     else

--- a/claude_extensions/rules/workflow.md
+++ b/claude_extensions/rules/workflow.md
@@ -19,7 +19,7 @@ Shell equivalent:
 ```bash
 curl -s http://localhost:8765/api/state/manifest         # ~1 KB index
 curl -s http://localhost:8765/api/rules?format=markdown  # only if hash changed
-curl -s http://localhost:8765/api/session/current        # only if hash changed
+curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'  # only if hash changed
 curl -s http://localhost:8765/api/orient                 # always-fresh, has meta
 curl -s 'http://localhost:8765/api/comms/inbox?agent=claude'  # unread messages
 ```
@@ -45,7 +45,21 @@ Every new session handoff ships as a **PAIR**:
 - **`docs/session-state/<date>-<slug>-brief.md`** (~2-5KB) — machine-readable, cold-start entry point. YAML frontmatter + bullet-list body. Agents read THIS.
 - **`docs/session-state/<date>-<slug>.html`** (~20-40KB) — rich human-readable. Narrative, tables, KPIs, callouts. Humans read THIS. Agents only open it if the brief flags something they need narrative for.
 
-**Cold-start rule:** after the Monitor API bootstrap above, locate the top row of `current.md` § "Latest handoff" and read its **Brief** link. Do NOT read the `.html` unless the brief is missing (older rows pre-split) or the brief tells you to.
+**Cold-start rule:** after the Monitor API bootstrap above, use the agent-specific
+session endpoint when you know your role:
+
+```bash
+curl -s 'http://localhost:8765/api/session/current?agent=claude'
+curl -s 'http://localhost:8765/api/session/current?agent=codex'
+curl -s 'http://localhost:8765/api/session/current?agent=gemini'
+curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'
+```
+
+`docs/session-state/current.md` is now a small compatibility router. It keeps
+`Latest-Brief: docs/session-state/current.orchestrator.md` for legacy hooks and
+an `Agent-Handoff:` mapping for `current.<agent>.md`. Read the router only to
+discover paths; detailed state belongs in the agent-specific file. Do NOT read
+the `.html` unless the agent-specific handoff points you there.
 
 ### Brief frontmatter schema (required fields)
 
@@ -90,7 +104,12 @@ Reserve all narrative, anecdotes, KPIs, and rich rationale for the `.html` compa
 
 Brief and HTML are authored together in the same orchestrator turn. Never ship one without the other for sessions going forward.
 
-Every update to `docs/session-state/current.md` MUST also update the top-level `Latest-Brief: docs/session-state/<date>-<slug>-brief.md` marker to the new brief path. The SessionStart hook parses this marker before falling back to table regex; table-format drift would silently reintroduce the old cold-start budget tax.
+Every orchestrator router update to `docs/session-state/current.md` MUST keep
+the top-level `Latest-Brief:` marker and the `Agent-Handoff:` mapping parseable.
+Non-orchestrator agents update only `docs/session-state/current.<agent>.md`
+unless a task explicitly authorizes a router update. The SessionStart hook
+parses `Latest-Brief:` before falling back to table regex; marker drift would
+silently reintroduce the old cold-start budget tax.
 
 ### Backfill policy
 

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -65,7 +65,7 @@ curl -s http://localhost:8765/api/state/manifest
 
 # 2. Only fetch components whose hash changed since last session.
 curl -s http://localhost:8765/api/rules?format=markdown     # ~1.3 KB
-curl -s http://localhost:8765/api/session/current           # ~1-3 KB
+curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'  # ~1-3 KB
 
 # 3. Always-fresh: git, pipeline, runtime, wiki, health, hints — with meta.
 curl -s http://localhost:8765/api/orient
@@ -690,7 +690,7 @@ curl -s http://localhost:8765/api/state/manifest
 
 # 2. Core context. Only fetch if manifest hash differs from local cache.
 curl -s http://localhost:8765/api/rules?format=markdown
-curl -s http://localhost:8765/api/session/current
+curl -s 'http://localhost:8765/api/session/current?agent=claude'
 
 # 3. Fresh project state.
 curl -s http://localhost:8765/api/orient
@@ -1329,7 +1329,7 @@ hashes against its local cache and only refetches what changed.
 {
   "generated_at": "2026-04-17T10:15:00Z",
   "rules":   {"hash": "abc...", "url": "/api/rules?format=markdown"},
-  "session": {"hash": "def...", "url": "/api/session/current?format=markdown"},
+  "session": {"hash": "def...", "url": "/api/session/current?agent=orchestrator&format=markdown"},
   "orient":  {"url": "/api/orient", "fresh_param": "?fresh=true"},
   "inbox":   {"url_template": "/api/comms/inbox?agent={name}"}
 }
@@ -1360,12 +1360,16 @@ to `.claude/rules/` still gets correct content.
   an SDK needs to reconcile the hash against its on-disk cache. With
   telemetry enabled, the response also includes top-level `_telemetry`.
 
-### `GET /api/session/current?format={markdown,json}`
+### `GET /api/session/current?agent={name}&format={markdown,json}`
 
-`docs/session-state/current.md` plus a short list of recent handoff
-filenames (newest first). Kept intentionally small — the endpoint
-answers "what do I need to know RIGHT NOW to keep working", not
-"give me the full history".
+Agent-specific session handoff plus a short list of recent handoff
+filenames (newest first). The default agent is `orchestrator`; use
+`agent=codex`, `agent=claude`, or `agent=gemini` to read that agent's
+`docs/session-state/current.<agent>.md`. Pass `agent=router` only when
+you need the small compatibility router at `docs/session-state/current.md`.
+
+Kept intentionally small — the endpoint answers "what do I need to know RIGHT
+NOW to keep working", not "give me the full history".
 
 With telemetry enabled, `format=markdown` appends the context footer and
 `format=json` adds top-level `_telemetry`.

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -51,6 +51,26 @@ All substantive discussion happens on GitHub where it is persistent and searchab
 
 **Never put full reviews or code in broker messages.** Post on GitHub, then ping with "review posted on #559."
 
+### Thread handoff ownership
+
+`docs/session-state/current.md` is a compatibility router, not a shared scratch
+handoff. It keeps `Latest-Brief: docs/session-state/current.orchestrator.md`
+plus an `Agent-Handoff:` mapping.
+
+Each agent owns one detailed handoff file:
+
+| Agent | Handoff |
+|---|---|
+| orchestrator | `docs/session-state/current.orchestrator.md` |
+| codex | `docs/session-state/current.codex.md` |
+| claude | `docs/session-state/current.claude.md` |
+| gemini | `docs/session-state/current.gemini.md` |
+
+Use `/api/session/current?agent=<name>` or read the matching
+`current.<agent>.md` directly. Only the orchestrator updates the router by
+default; other agents update it only when the task explicitly asks for a router
+change.
+
 ### Runtime layer — single source of truth for agent CLI calls
 
 As of #1184 (April 2026), all three agents (Claude, Gemini, Codex) are
@@ -272,7 +292,7 @@ curl -s http://localhost:8765/api/state/manifest
 
 # 2. Only fetch components whose hash changed since last session.
 curl -s http://localhost:8765/api/rules?format=markdown
-curl -s http://localhost:8765/api/session/current
+curl -s 'http://localhost:8765/api/session/current?agent=claude'
 
 # 3. Always-fresh: git state, pipeline, runtime, wiki, health, hints.
 curl -s http://localhost:8765/api/orient

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -1,7 +1,7 @@
 # Codex Thread Handoff Runbook
 
-This runbook covers overnight orchestrator rollover when a Codex heartbeat
-thread approaches the auto-compaction zone.
+This runbook covers replacement-thread rollover when a Codex, Claude, Gemini,
+or orchestrator heartbeat thread approaches the auto-compaction zone.
 
 ## Verified Capabilities
 
@@ -28,12 +28,22 @@ Verified locally on 2026-05-30:
 ## Architecture
 
 The handoff system uses a local thread lease plus a generated bootstrap
-prompt:
+prompt, scoped by agent name:
 
-- Lease state: `.agent/orchestrator-thread-lease.json` (gitignored)
-- Bootstrap prompt: `.agent/orchestrator-thread-bootstrap.md` (gitignored)
-- Optional tracked handoff update: `docs/session-state/current.md`
+- Lease state: `.agent/<agent>-thread-lease.json` (gitignored)
+- Bootstrap prompt: `.agent/<agent>-thread-bootstrap.md` (gitignored)
+- Tracked agent handoff: `docs/session-state/current.<agent>.md`
+- Compatibility router: `docs/session-state/current.md`
 - Script: `scripts/orchestration/thread_handoff.py`
+
+Agent names are lower-case slugs matching `[a-z][a-z0-9-]*`. The standard
+agents are `orchestrator`, `codex`, `claude`, and `gemini`; additional agents
+can use the same naming rule.
+
+`docs/session-state/current.md` is intentionally small. It is a router with a
+stable `Latest-Brief: docs/session-state/current.orchestrator.md` marker for
+legacy cold-start hooks plus an `Agent-Handoff:` mapping for each agent. Do not
+put detailed state in the router.
 
 The lease records:
 
@@ -48,13 +58,14 @@ The cleanup guard is false after `prepare`. It becomes true only after
 `confirm-started --new-thread-id ...` succeeds. This keeps the old heartbeat
 alive if the replacement thread was not actually started.
 
-## Standard Rollover
+## Standard Orchestrator Rollover
 
 Run this from the repo root when the heartbeat thread enters the rollover
 zone:
 
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --agent orchestrator \
   --write-current \
   --context-percent 86
 ```
@@ -63,6 +74,7 @@ If the active thread id or automation id is known, include them:
 
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --agent orchestrator \
   --write-current \
   --active-thread-id <current-thread-id> \
   --active-automation-id <old-heartbeat-automation-id> \
@@ -73,7 +85,8 @@ This writes:
 
 - `.agent/orchestrator-thread-lease.json`
 - `.agent/orchestrator-thread-bootstrap.md`
-- `docs/session-state/current.md` only when `--write-current` is present
+- `docs/session-state/current.orchestrator.md`
+- `docs/session-state/current.md` router only when `--write-current` is present
 
 The generated prompt is the exact replacement-thread bootstrap. If the Codex
 app `create_thread` tool is available to the current agent, use it with that
@@ -84,6 +97,7 @@ After the replacement thread is visibly running, confirm it:
 
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
+  --agent orchestrator \
   --new-thread-id <replacement-thread-id>
 ```
 
@@ -91,12 +105,40 @@ Only if the output shows `"old_automation_ready_to_delete": true` may the old
 heartbeat automation be deleted or paused through the Codex app
 `automation_update` tool.
 
+## Non-Orchestrator Agent Rollover
+
+Agents other than the orchestrator write only their own handoff by default:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --agent codex \
+  --context-percent 86
+```
+
+That writes `.agent/codex-thread-lease.json`,
+`.agent/codex-thread-bootstrap.md`, and
+`docs/session-state/current.codex.md`. It does not modify
+`docs/session-state/current.md` and does not touch
+`docs/session-state/current.orchestrator.md`.
+
+Only pass `--write-current` for a non-orchestrator agent when the task
+explicitly authorizes a router update. The router must stay tiny and must keep
+`Latest-Brief:` plus the `Agent-Handoff:` mapping.
+
+Confirm the replacement with the same agent name:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
+  --agent codex \
+  --new-thread-id <replacement-thread-id>
+```
+
 ## Safety Checks
 
 Check the lease at any time:
 
 ```bash
-.venv/bin/python scripts/orchestration/thread_handoff.py check
+.venv/bin/python scripts/orchestration/thread_handoff.py check --agent orchestrator
 ```
 
 Warnings mean the old heartbeat automation should stay active. Common
@@ -115,6 +157,7 @@ discard the corrupt lease and start a new one, run:
 
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --agent orchestrator \
   --force-reset-state \
   --write-current \
   --context-percent 86
@@ -123,7 +166,7 @@ discard the corrupt lease and start a new one, run:
 Dry-run without writing files:
 
 ```bash
-.venv/bin/python scripts/orchestration/thread_handoff.py prepare --dry-run
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --dry-run
 ```
 
 Audit local Codex metadata:
@@ -143,7 +186,9 @@ Include live Monitor API state in the audit:
 At 75 percent context, run `prepare --dry-run` to verify the packet renders.
 
 At 82 percent context or higher, run `prepare --write-current` and start the
-replacement thread. Keep the old heartbeat active until `confirm-started`
+replacement thread for the orchestrator. Other agents run `prepare --agent
+<name>` without `--write-current` unless explicitly asked to update the shared
+router. Keep the old heartbeat active until `confirm-started --agent <name>`
 records the replacement thread id.
 
 At 90 percent context or higher, stop non-handoff work. The current thread

--- a/docs/session-state/current.claude.md
+++ b/docs/session-state/current.claude.md
@@ -1,0 +1,13 @@
+# Current - Claude Thread Handoff
+
+> No Claude-specific replacement-thread handoff has been prepared yet.
+> Generate one with:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent claude
+```
+
+Claude agents should read `docs/session-state/current.md` for the router, then
+this file for Claude-specific continuation state. Do not update
+`docs/session-state/current.md` unless the task explicitly authorizes a router
+update.

--- a/docs/session-state/current.codex.md
+++ b/docs/session-state/current.codex.md
@@ -1,0 +1,13 @@
+# Current - Codex Thread Handoff
+
+> No Codex-specific replacement-thread handoff has been prepared yet.
+> Generate one with:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex
+```
+
+Codex agents should read `docs/session-state/current.md` for the router, then
+this file for Codex-specific continuation state. Do not update
+`docs/session-state/current.md` unless the task explicitly authorizes a router
+update.

--- a/docs/session-state/current.gemini.md
+++ b/docs/session-state/current.gemini.md
@@ -1,0 +1,13 @@
+# Current - Gemini Thread Handoff
+
+> No Gemini-specific replacement-thread handoff has been prepared yet.
+> Generate one with:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent gemini
+```
+
+Gemini agents should read `docs/session-state/current.md` for the router, then
+this file for Gemini-specific continuation state. Do not update
+`docs/session-state/current.md` unless the task explicitly authorizes a router
+update.

--- a/docs/session-state/current.md
+++ b/docs/session-state/current.md
@@ -1,137 +1,16 @@
-# Current - Codex orchestrator handoff (2026-05-30T20:35Z)
+# Current Session Router
 
-Latest-Brief: docs/session-state/current.md
+Latest-Brief: docs/session-state/current.orchestrator.md
 
-> Handoff-only update. Treat `origin/main` and this file as authoritative.
+Agent-Handoff:
+- orchestrator: docs/session-state/current.orchestrator.md
+- codex: docs/session-state/current.codex.md
+- claude: docs/session-state/current.claude.md
+- gemini: docs/session-state/current.gemini.md
 
-## Thread / Role
+Default-Agent: orchestrator
+Generated-At: 2026-05-30T20:35:00Z
 
-- Main orchestrator thread is the **Orchestrator watchdog replacement**:
-  `019e7836-06ef-7973-a630-07824922dfe5`.
-- User explicitly corrected direction:
-  - BIO is Claude-owned.
-  - Codex drives orchestration, GitHub issue memory, PR queue, and A1 golden
-    learner journey.
-  - Use agents/compute, but keep ownership boundaries clear.
-- Context is near auto-compact; continue in a fresh thread.
-
-## Git State
-
-- Repo: `/Users/krisztiankoos/projects/learn-ukrainian`
-- Branch: `main`
-- HEAD before this handoff update: `2490db006e`
-- Upstream: `origin/main`
-- Modified file before handoff commit: `docs/session-state/current.md`
-- Active delegates after closing the explorer: none known.
-
-Recent commits before this handoff:
-
-- `2490db006e` `docs(session-state): record issue triage board`
-- `90235bc878` `docs(session-state): avoid stale BIO handoff head`
-- `3ac4e7e7db` `docs(session-state): record BIO Phase 2 unblock`
-- `2379c38d4c` `feat(bio): add Phase 2 plan for Mykhailo Drai-Khmara (#2456)`
-
-## Critical Next Order
-
-Do **not** jump straight into A1 implementation while PRs are waiting.
-
-First clear the PR queue:
-
-1. **#2459** `docs(bio): refresh Claude driver handoff — Phase-2 division + session lessons`
-   - Branch: `docs/bio-handoff-update-2026-05-30`
-   - Status at last check: `UNSTABLE` only because Gemini `review / review`
-     was still in progress. Other checks were green.
-   - BIO handoff/docs PR, Claude-owned lane. Inspect review result, merge if
-     clean or route feedback to Claude.
-2. **#2450** `feat(handoff): add agent-specific thread routers`
-   - Branch: `codex/agent-thread-handoffs-2026-05-30`
-   - This is operationally important: thread-handoff task becomes real on
-     `main` only after #2450 lands.
-   - It was previously `DIRTY`/`UNKNOWN` after main moved. Rebase/update,
-     verify, and merge before relying on agent-specific handoff behavior.
-3. **#2447** draft `fix(build): normalize stressed plan section headings`
-   - Branch: `codex/m20-plan-section-heading-gate`
-   - A1 support/blocker PR, not the product strategy itself.
-   - Review/undraft/merge only if still sound after current main.
-
-Only after those PRs are handled should Codex proceed into the A1 epic.
-
-## Correct A1 Direction
-
-Do not treat m20/m21/m22 as the strategy. They are support/validation issues
-from the old V7.2 path.
-
-The user’s product direction is:
-
-- Start A1 from the beginning.
-- Build the learner experience as the product spine.
-- First slice is A1 M1-M7 safe onboarding / first contact.
-- Fix pipeline/gates only when they block producing excellent learner content.
-
-Read-only explorer found A1 M1-M7 sequence:
-
-1. `sounds-letters-and-hello` — `Звуки, літери та привіт`
-2. `reading-ukrainian` — `Читаємо українською`
-3. `special-signs` — `Особливі знаки`
-4. `stress-and-melody` — `Наголос і мелодика`
-5. `who-am-i` — `Хто я?`
-6. `my-family` — `Моя сім'я`
-7. `checkpoint-first-contact` — `Підсумок: Перший контакт`
-
-Explorer also found:
-
-- Sequence source: `curriculum/l2-uk-en/curriculum.yaml`
-- Each M1-M7 has plan YAML and discovery YAML.
-- No populated content bundle was found for M1-M7.
-- Only populated A1 lesson bundle found was `curriculum/l2-uk-en/a1/my-morning/`.
-
-## Issue Board State
-
-Issue triage already completed:
-
-- 71 open issues.
-- 0 missing `lane:*`.
-- 0 missing `state:*`.
-- BIO issues labeled Claude-owned.
-- A1 golden path labeled Codex-owned.
-- No issues closed.
-
-Active board after PR queue:
-
-- A1/Codex: #2389, #2390, #2418, #2419, #2380, plus #2447 PR if not merged.
-- Orchestration/Codex: #2450/#2448, #2368, #2126.
-- BIO/Claude: #2309, #2451, plus #2459 PR if not merged.
-
-Proposed archive candidates only, do not close without review:
-
-- #2351 likely superseded by #2418.
-- #1969 likely superseded by #2418.
-- #2132 likely stale promote-protocol result thread.
-
-## Restart Commands
-
-```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
-git status --short
-git log --oneline -8 --decorate --no-merges
-gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20
-gh issue list --state open --label state:now --limit 100 --json number,title,labels,url
-curl -sS http://127.0.0.1:8765/api/delegate/active
-```
-
-For A1 M1-M7 inventory:
-
-```bash
-sed -n '1,220p' curriculum/l2-uk-en/curriculum.yaml
-find curriculum/l2-uk-en/a1 -maxdepth 2 -type f | sort
-sed -n '1,80p' curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml
-```
-
-## Guardrails
-
-- Keep main checkout read-only except handoff updates.
-- Use `.worktrees/dispatch/<agent>/<task>/` for implementation.
-- Do not edit generated status/audit/review artifacts, linter configs, or
-  `.python-version`.
-- Every commit must carry an `X-Agent` trailer.
-- Do not delete/pause old automation unless the user explicitly instructs it.
+This file is a small compatibility router. Detailed thread state lives in
+`docs/session-state/current.<agent>.md`; agents should update only their own
+handoff file unless the task explicitly authorizes a router update.

--- a/docs/session-state/current.orchestrator.md
+++ b/docs/session-state/current.orchestrator.md
@@ -1,0 +1,137 @@
+# Current - Codex orchestrator handoff (2026-05-30T20:35Z)
+
+Latest-Brief: docs/session-state/current.orchestrator.md
+
+> Handoff-only update. Treat `origin/main` and this file as authoritative.
+
+## Thread / Role
+
+- Main orchestrator thread is the **Orchestrator watchdog replacement**:
+  `019e7836-06ef-7973-a630-07824922dfe5`.
+- User explicitly corrected direction:
+  - BIO is Claude-owned.
+  - Codex drives orchestration, GitHub issue memory, PR queue, and A1 golden
+    learner journey.
+  - Use agents/compute, but keep ownership boundaries clear.
+- Context is near auto-compact; continue in a fresh thread.
+
+## Git State
+
+- Repo: `/Users/krisztiankoos/projects/learn-ukrainian`
+- Branch: `main`
+- HEAD before this handoff update: `2490db006e`
+- Upstream: `origin/main`
+- Modified file before handoff commit: `docs/session-state/current.md`
+- Active delegates after closing the explorer: none known.
+
+Recent commits before this handoff:
+
+- `2490db006e` `docs(session-state): record issue triage board`
+- `90235bc878` `docs(session-state): avoid stale BIO handoff head`
+- `3ac4e7e7db` `docs(session-state): record BIO Phase 2 unblock`
+- `2379c38d4c` `feat(bio): add Phase 2 plan for Mykhailo Drai-Khmara (#2456)`
+
+## Critical Next Order
+
+Do **not** jump straight into A1 implementation while PRs are waiting.
+
+First clear the PR queue:
+
+1. **#2459** `docs(bio): refresh Claude driver handoff — Phase-2 division + session lessons`
+   - Branch: `docs/bio-handoff-update-2026-05-30`
+   - Status at last check: `UNSTABLE` only because Gemini `review / review`
+     was still in progress. Other checks were green.
+   - BIO handoff/docs PR, Claude-owned lane. Inspect review result, merge if
+     clean or route feedback to Claude.
+2. **#2450** `feat(handoff): add agent-specific thread routers`
+   - Branch: `codex/agent-thread-handoffs-2026-05-30`
+   - This is operationally important: thread-handoff task becomes real on
+     `main` only after #2450 lands.
+   - It was previously `DIRTY`/`UNKNOWN` after main moved. Rebase/update,
+     verify, and merge before relying on agent-specific handoff behavior.
+3. **#2447** draft `fix(build): normalize stressed plan section headings`
+   - Branch: `codex/m20-plan-section-heading-gate`
+   - A1 support/blocker PR, not the product strategy itself.
+   - Review/undraft/merge only if still sound after current main.
+
+Only after those PRs are handled should Codex proceed into the A1 epic.
+
+## Correct A1 Direction
+
+Do not treat m20/m21/m22 as the strategy. They are support/validation issues
+from the old V7.2 path.
+
+The user's product direction is:
+
+- Start A1 from the beginning.
+- Build the learner experience as the product spine.
+- First slice is A1 M1-M7 safe onboarding / first contact.
+- Fix pipeline/gates only when they block producing excellent learner content.
+
+Read-only explorer found A1 M1-M7 sequence:
+
+1. `sounds-letters-and-hello` — `Звуки, літери та привіт`
+2. `reading-ukrainian` — `Читаємо українською`
+3. `special-signs` — `Особливі знаки`
+4. `stress-and-melody` — `Наголос і мелодика`
+5. `who-am-i` — `Хто я?`
+6. `my-family` — `Моя сім'я`
+7. `checkpoint-first-contact` — `Підсумок: Перший контакт`
+
+Explorer also found:
+
+- Sequence source: `curriculum/l2-uk-en/curriculum.yaml`
+- Each M1-M7 has plan YAML and discovery YAML.
+- No populated content bundle was found for M1-M7.
+- Only populated A1 lesson bundle found was `curriculum/l2-uk-en/a1/my-morning/`.
+
+## Issue Board State
+
+Issue triage already completed:
+
+- 71 open issues.
+- 0 missing `lane:*`.
+- 0 missing `state:*`.
+- BIO issues labeled Claude-owned.
+- A1 golden path labeled Codex-owned.
+- No issues closed.
+
+Active board after PR queue:
+
+- A1/Codex: #2389, #2390, #2418, #2419, #2380, plus #2447 PR if not merged.
+- Orchestration/Codex: #2450/#2448, #2368, #2126.
+- BIO/Claude: #2309, #2451, plus #2459 PR if not merged.
+
+Proposed archive candidates only, do not close without review:
+
+- #2351 likely superseded by #2418.
+- #1969 likely superseded by #2418.
+- #2132 likely stale promote-protocol result thread.
+
+## Restart Commands
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git status --short
+git log --oneline -8 --decorate --no-merges
+gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20
+gh issue list --state open --label state:now --limit 100 --json number,title,labels,url
+curl -sS http://127.0.0.1:8765/api/delegate/active
+```
+
+For A1 M1-M7 inventory:
+
+```bash
+sed -n '1,220p' curriculum/l2-uk-en/curriculum.yaml
+find curriculum/l2-uk-en/a1 -maxdepth 2 -type f | sort
+sed -n '1,80p' curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml
+```
+
+## Guardrails
+
+- Keep main checkout read-only except handoff updates.
+- Use `.worktrees/dispatch/<agent>/<task>/` for implementation.
+- Do not edit generated status/audit/review artifacts, linter configs, or
+  `.python-version`.
+- Every commit must carry an `X-Agent` trailer.
+- Do not delete/pause old automation unless the user explicitly instructs it.

--- a/scripts/ai_agent_bridge/monitor_client.py
+++ b/scripts/ai_agent_bridge/monitor_client.py
@@ -126,7 +126,7 @@ class MonitorClient:
             key="session",
             manifest_key="session",
             manifest=manifest,
-            default_url="/api/session/current?format=markdown",
+            default_url="/api/session/current?agent=orchestrator&format=markdown",
         )
 
     # -- internal shared path --------------------------------------

--- a/scripts/api/session_router.py
+++ b/scripts/api/session_router.py
@@ -3,7 +3,8 @@
 Mounted at /api/session in main.py.
 
 Endpoints:
-    GET /api/session/current              Markdown summary of current session
+    GET /api/session/current              Markdown summary of orchestrator session
+    GET /api/session/current?agent=codex  Markdown summary of Codex session
     GET /api/session/current?format=json  {hash, bytes, sections, markdown}
 
 Why this exists (GH #1309): every agent cold-start was reading
@@ -13,15 +14,16 @@ into one endpoint lets agents check a single hash on
 ``/api/state/manifest`` and only refetch when something changed.
 
 The payload is kept lean on purpose — if an agent needs the full
-session state, the current.md file path is advertised in the JSON
-response so the agent can fall back to a direct read. The endpoint is
-designed for "what do I need to know RIGHT NOW to start working", not
-for forensic archaeology.
+session state, the selected current.<agent>.md file path is advertised
+in the JSON response so the agent can fall back to a direct read. The
+endpoint is designed for "what do I need to know RIGHT NOW to start
+working", not for forensic archaeology.
 """
 
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -38,7 +40,9 @@ from .telemetry.response import (
 
 router = APIRouter(tags=["session"])
 
-SESSION_CURRENT_PATH = "docs/session-state/current.md"
+SESSION_ROUTER_PATH = "docs/session-state/current.md"
+DEFAULT_SESSION_AGENT = "orchestrator"
+AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 
 # How many recent handoff files to include in the consolidated summary.
 # Small on purpose — the manifest is the jump table; this endpoint is
@@ -46,13 +50,13 @@ SESSION_CURRENT_PATH = "docs/session-state/current.md"
 _RECENT_HANDOFFS_N = 3
 
 
-def _read_current_session() -> str:
-    path = PROJECT_ROOT / SESSION_CURRENT_PATH
+def _read_session_file(session_path: str) -> str:
+    path = PROJECT_ROOT / session_path
     if not path.is_file():
         raise HTTPException(
             status_code=404,
             detail=(
-                f"Session state file not found at {SESSION_CURRENT_PATH}. "
+                f"Session state file not found at {session_path}. "
                 "Create it with the current task's context."
             ),
         )
@@ -61,8 +65,67 @@ def _read_current_session() -> str:
     except OSError as exc:
         raise HTTPException(
             status_code=500,
-            detail=f"Could not read {SESSION_CURRENT_PATH}: {exc}",
+            detail=f"Could not read {session_path}: {exc}",
         ) from exc
+
+
+def _normalize_agent(agent: str | None) -> str:
+    normalized = (agent or DEFAULT_SESSION_AGENT).strip().lower()
+    if normalized == "router":
+        return normalized
+    if not AGENT_NAME_RE.fullmatch(normalized):
+        raise HTTPException(
+            status_code=400,
+            detail="agent names must match [a-z][a-z0-9-]*",
+        )
+    return normalized
+
+
+def _parse_agent_handoffs(router_markdown: str) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    in_mapping = False
+    for raw_line in router_markdown.splitlines():
+        line = raw_line.strip()
+        if line == "Agent-Handoff:":
+            in_mapping = True
+            continue
+        if not in_mapping:
+            continue
+        if not line:
+            break
+        if line.startswith("- "):
+            line = line[2:].strip()
+        if ":" not in line:
+            continue
+        agent, path = [part.strip() for part in line.split(":", 1)]
+        if not AGENT_NAME_RE.fullmatch(agent):
+            continue
+        rel_path = Path(path)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            continue
+        mapping[agent] = rel_path.as_posix()
+    return mapping
+
+
+def _resolve_session_path(agent: str) -> str:
+    if agent == "router":
+        return SESSION_ROUTER_PATH
+
+    router_path = PROJECT_ROOT / SESSION_ROUTER_PATH
+    agent_default = f"docs/session-state/current.{agent}.md"
+    if not router_path.is_file():
+        return agent_default
+
+    router_markdown = router_path.read_text(encoding="utf-8", errors="replace")
+    handoffs = _parse_agent_handoffs(router_markdown)
+    if agent in handoffs:
+        return handoffs[agent]
+
+    # Backward compatibility for older current.md files that still contained
+    # the detailed orchestrator handoff rather than an Agent-Handoff router.
+    if agent == DEFAULT_SESSION_AGENT and not handoffs:
+        return SESSION_ROUTER_PATH
+    return agent_default
 
 
 def _recent_handoff_paths() -> list[str]:
@@ -80,15 +143,21 @@ def _recent_handoff_paths() -> list[str]:
     candidates: list[Path] = []
     for pattern in ("*.md", "*.html"):
         candidates.extend(session_dir.glob(pattern))
-    all_handoffs = sorted(p for p in candidates if p.name != "current.md")
+    all_handoffs = sorted(
+        p
+        for p in candidates
+        if p.name != "current.md" and not (p.name.startswith("current.") and p.suffix == ".md")
+    )
     latest = all_handoffs[-_RECENT_HANDOFFS_N:] if all_handoffs else []
     latest.reverse()  # newest first
     return [str(p.relative_to(PROJECT_ROOT)) for p in latest]
 
 
-def _assemble_session() -> tuple[str, dict, str]:
+def _assemble_session(agent: str = DEFAULT_SESSION_AGENT) -> tuple[str, dict, str]:
     """Return (markdown, sections_dict, sha256_hex) for the session view."""
-    current_md = _read_current_session().rstrip() + "\n"
+    normalized_agent = _normalize_agent(agent)
+    current_path = _resolve_session_path(normalized_agent)
+    current_md = _read_session_file(current_path).rstrip() + "\n"
     handoffs = _recent_handoff_paths()
 
     if handoffs:
@@ -107,7 +176,9 @@ def _assemble_session() -> tuple[str, dict, str]:
 
     digest = hashlib.sha256(markdown.encode("utf-8")).hexdigest()
     sections = {
-        "current": SESSION_CURRENT_PATH,
+        "agent": normalized_agent,
+        "current": current_path,
+        "router": SESSION_ROUTER_PATH,
         "recent_handoffs": handoffs,
     }
     return markdown, sections, digest
@@ -116,6 +187,10 @@ def _assemble_session() -> tuple[str, dict, str]:
 @router.get("/current")
 def session_current(
     request: Request,
+    agent: str = Query(
+        DEFAULT_SESSION_AGENT,
+        description="Agent-specific handoff to serve; use 'router' for docs/session-state/current.md.",
+    ),
     format: Literal["markdown", "json"] = Query(
         "markdown",
         description="'markdown' returns text/markdown; 'json' wraps with hash + section map.",
@@ -127,7 +202,7 @@ def session_current(
     ``304 Not Modified`` with no body, so an SDK with a valid local
     cache pays only the TCP round-trip.
     """
-    markdown, sections, digest = _assemble_session()
+    markdown, sections, digest = _assemble_session(agent)
     etag = f'"{digest}"'
 
     if not telemetry_footer_enabled() and _matches_etag(request.headers.get("If-None-Match"), digest):
@@ -161,10 +236,10 @@ def _cache_headers(etag: str, digest: str) -> dict[str, str]:
     return headers
 
 
-def session_hash() -> str:
+def session_hash(agent: str = DEFAULT_SESSION_AGENT) -> str:
     """Hash-only helper for ``/api/state/manifest``. Returns empty on error."""
     try:
-        _, _, digest = _assemble_session()
+        _, _, digest = _assemble_session(agent)
     except HTTPException:
         return ""
     return digest

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -1029,7 +1029,7 @@ async def manifest():
         {
           "generated_at": "2026-04-17T10:15:00Z",
           "rules":   {"hash": "...", "url": "/api/rules?format=markdown"},
-          "session": {"hash": "...", "url": "/api/session/current?format=markdown"},
+          "session": {"hash": "...", "url": "/api/session/current?agent=orchestrator&format=markdown"},
           "orient":  {"url": "/api/orient"},
           "inbox":   {"url_template": "/api/comms/inbox?agent={name}"}
         }
@@ -1062,7 +1062,7 @@ async def manifest():
         },
         "session": {
             "hash": session_hash(),
-            "url": "/api/session/current?format=markdown",
+            "url": "/api/session/current?agent=orchestrator&format=markdown",
             "format": "markdown",
             "note": "Current.md + recent session-state handoff filenames.",
         },

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -77,7 +77,26 @@ assert_not_contains "$output" "HEAD BODY SHOULD NOT APPEAR" "marker hit"
 assert_not_contains "$output" "WARN:" "marker hit"
 marker_bytes="$(printf '%s' "$output" | wc -c | tr -d ' ')"
 
-# 2. Table regex fallback.
+# 2. Agent-Handoff mapping wins over the compatibility Latest-Brief marker.
+setup_fixture "$fixture_root"
+mkdir -p "$fixture_root/docs/session-state"
+printf 'orchestrator body\n' > "$fixture_root/docs/session-state/current.orchestrator.md"
+printf 'claude body\n' > "$fixture_root/docs/session-state/current.claude.md"
+cat > "$fixture_root/docs/session-state/current.md" <<'EOF'
+# Current Session Router
+
+Latest-Brief: docs/session-state/current.orchestrator.md
+
+Agent-Handoff:
+- orchestrator: docs/session-state/current.orchestrator.md
+- claude: docs/session-state/current.claude.md
+EOF
+output="$(run_hook "$fixture_root")"
+assert_contains "$output" "Brief: docs/session-state/current.claude.md" "agent handoff"
+assert_not_contains "$output" "Brief: docs/session-state/current.orchestrator.md" "agent handoff"
+assert_not_contains "$output" "WARN:" "agent handoff"
+
+# 3. Table regex fallback.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/foo"
 printf 'brief body\n' > "$fixture_root/foo/bar-brief.md"
@@ -96,7 +115,7 @@ assert_contains "$output" "WARN: Latest-Brief marker missing in current.md" "tab
 assert_not_contains "$output" "TABLE FALLBACK BODY SHOULD NOT APPEAR" "table fallback"
 fallback_warn_count=$((fallback_warn_count + $(count_warns "$output")))
 
-# 3. Brief missing.
+# 4. Brief missing.
 setup_fixture "$fixture_root"
 cat > "$fixture_root/docs/session-state/current.md" <<'EOF'
 # Current
@@ -110,7 +129,7 @@ assert_contains "$output" "WARN: Latest-Brief pointed to foo/missing-brief.md bu
 assert_contains "$output" "MISSING MARKER FALLBACK BODY" "missing brief"
 fallback_warn_count=$((fallback_warn_count + $(count_warns "$output")))
 
-# 4. No handoff table at all.
+# 5. No handoff table at all.
 setup_fixture "$fixture_root"
 cat > "$fixture_root/docs/session-state/current.md" <<'EOF'
 # Current

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -41,11 +41,12 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees"
 # cache/ — Monitor API client disk cache (see scripts/ai_agent_bridge/_monitor_cache.py),
 #          stores rules.body/session.body + ETag metadata so cold-start is ~780 B instead of 75 KB.
 #          Runtime-only; NOT source-tracked. rsync --delete must preserve both.
-# orchestrator-thread-bootstrap.md — replacement-thread bootstrap prompt generated into .agent/
-#          by scripts/orchestration/thread_handoff.py (#2439). Runtime-only, machine-specific
-#          (live timestamps + snapshot); NOT source-tracked. Without this entry the deploy aborts
-#          on any machine where the handoff automation has run.
-ORPHAN_PATHS_AGENT="wake cache orchestrator-thread-bootstrap.md"
+# *-thread-bootstrap.md / *-thread-lease.json — replacement-thread handoff
+#          files generated into .agent/ by scripts/orchestration/thread_handoff.py.
+#          Runtime-only, machine-specific (live timestamps + snapshot); NOT
+#          source-tracked. Without these entries the deploy aborts on any
+#          machine where the handoff automation has run.
+ORPHAN_PATHS_AGENT="wake cache *-thread-bootstrap.md *-thread-lease.json"
 ORPHAN_PATHS_AGENTS=""
 # agents/curriculum-orchestrator.toml and agents/curriculum-writer.toml —
 # Codex agent definitions with no claude_extensions equivalent.
@@ -101,7 +102,7 @@ check_orphans() {
         local matched=false
         for d in $declared; do
             # Match if orphan is exactly d or starts with d (for directories)
-            if [[ "$orphan" == "$d" || "$orphan" == "$d"* || "$orphan/" == "$d" ]]; then
+            if [[ "$orphan" == "$d" || "$orphan" == $d || "$orphan" == "$d"* || "$orphan/" == "$d" ]]; then
                 matched=true
                 break
             fi

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Prepare and guard Codex orchestrator thread handoffs.
+"""Prepare and guard agent-specific thread handoffs.
 
 The Codex app can expose thread and automation tools to an agent, but a local
 repo script cannot assume those app-only tools exist. This helper gathers the
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import urllib.error
@@ -25,9 +26,10 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 DEFAULT_MONITOR_BASE_URL = "http://127.0.0.1:8765"
-DEFAULT_STATE_PATH = Path(".agent/orchestrator-thread-lease.json")
-DEFAULT_BOOTSTRAP_PATH = Path(".agent/orchestrator-thread-bootstrap.md")
-DEFAULT_CURRENT_PATH = Path("docs/session-state/current.md")
+DEFAULT_AGENT = "orchestrator"
+DEFAULT_ROUTER_AGENTS = ("orchestrator", "codex", "claude", "gemini")
+AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+DEFAULT_ROUTER_PATH = Path("docs/session-state/current.md")
 DEFAULT_STALE_HOURS = 12
 DEFAULT_CONTEXT_THRESHOLD = 82.0
 
@@ -41,6 +43,41 @@ class CommandResult:
 
 def repo_root_from_file() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def normalize_agent_name(value: str | None) -> str:
+    agent = (value or DEFAULT_AGENT).strip().lower()
+    if not AGENT_NAME_RE.fullmatch(agent):
+        raise ValueError(
+            "agent names must match [a-z][a-z0-9-]* so handoff paths cannot escape the repo"
+        )
+    return agent
+
+
+def argparse_agent_name(value: str) -> str:
+    try:
+        return normalize_agent_name(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def default_state_path(agent: str) -> Path:
+    return Path(f".agent/{agent}-thread-lease.json")
+
+
+def default_bootstrap_path(agent: str) -> Path:
+    return Path(f".agent/{agent}-thread-bootstrap.md")
+
+
+def default_handoff_path(agent: str) -> Path:
+    return Path(f"docs/session-state/current.{agent}.md")
+
+
+def router_agents(selected_agent: str) -> list[str]:
+    agents = list(DEFAULT_ROUTER_AGENTS)
+    if selected_agent not in agents:
+        agents.append(selected_agent)
+    return agents
 
 
 def utc_now() -> datetime:
@@ -65,9 +102,9 @@ def parse_iso_datetime(value: str | None) -> datetime | None:
 
 def rel(path: Path, root: Path) -> str:
     try:
-        return str(path.resolve().relative_to(root.resolve()))
+        return path.resolve().relative_to(root.resolve()).as_posix()
     except ValueError:
-        return str(path)
+        return path.as_posix()
 
 
 def run_command(
@@ -290,6 +327,7 @@ def generation_id(prefix: str, now: datetime) -> str:
 def prepare_state(
     state: dict[str, Any],
     *,
+    agent: str = DEFAULT_AGENT,
     now: datetime,
     active_thread_id: str | None,
     active_automation_id: str | None,
@@ -299,10 +337,11 @@ def prepare_state(
 ) -> dict[str, Any]:
     prepared = dict(state)
     prepared["schema_version"] = SCHEMA_VERSION
+    prepared["agent"] = agent
 
     active = dict(prepared.get("active") or {})
     if not active.get("generation"):
-        active["generation"] = generation_id("orchestrator", now)
+        active["generation"] = generation_id(agent, now)
         active["started_at"] = isoformat_z(now)
     if active_thread_id:
         active["thread_id"] = active_thread_id
@@ -316,15 +355,15 @@ def prepare_state(
     replacement = dict(prepared.get("replacement") or {})
     if force_new_replacement or replacement.get("status") not in {"pending_start", "started"}:
         replacement = {
-            "generation": generation_id("orchestrator-next", now),
+            "generation": generation_id(f"{agent}-next", now),
             "status": "pending_start",
             "prepared_at": isoformat_z(now),
             "thread_id": None,
-            "bootstrap_prompt_path": str(bootstrap_path),
+            "bootstrap_prompt_path": bootstrap_path.as_posix(),
         }
     else:
         replacement["prepared_at"] = isoformat_z(now)
-        replacement["bootstrap_prompt_path"] = str(bootstrap_path)
+        replacement["bootstrap_prompt_path"] = bootstrap_path.as_posix()
     prepared["replacement"] = replacement
 
     cleanup = dict(prepared.get("cleanup") or {})
@@ -454,6 +493,9 @@ def render_bootstrap_prompt(
     snapshot: dict[str, Any],
     state: dict[str, Any],
     *,
+    agent: str = DEFAULT_AGENT,
+    router_path: Path = DEFAULT_ROUTER_PATH,
+    handoff_path: Path | None = None,
     context_threshold: float,
 ) -> str:
     git = snapshot["git"]
@@ -461,20 +503,27 @@ def render_bootstrap_prompt(
     github = snapshot["github"]
     active = state.get("active") or {}
     replacement = state.get("replacement") or {}
-    prompt_path = replacement.get("bootstrap_prompt_path") or str(DEFAULT_BOOTSTRAP_PATH)
+    prompt_path = replacement.get("bootstrap_prompt_path") or default_bootstrap_path(agent).as_posix()
+    handoff_path = handoff_path or default_handoff_path(agent)
+    router_text = router_path.as_posix()
+    handoff_text = handoff_path.as_posix()
     active_generation = active.get("generation") or "unknown"
     replacement_generation = replacement.get("generation") or "unknown"
     context_percent = (state.get("last_handoff") or {}).get("context_percent")
+    agent_label = "Codex orchestrator" if agent == "orchestrator" else agent
 
     return "\n".join([
         f"Work locally in {git.get('repo_root')}.",
         "",
-        "You are the replacement Codex orchestrator thread.",
+        f"You are the replacement {agent_label} thread.",
         f"Replacement generation: {replacement_generation}",
         f"Previous active generation: {active_generation}",
+        f"Agent handoff: {handoff_text}",
+        f"Global router: {router_text}",
         "",
         "Read first:",
-        "- docs/session-state/current.md",
+        f"- {router_text}",
+        f"- {handoff_text}",
         "- AGENTS.md",
         "- docs/best-practices/agent-cooperation.md",
         "- docs/best-practices/codex-thread-handoff.md",
@@ -497,7 +546,7 @@ def render_bootstrap_prompt(
         "",
         "After the replacement thread is actually running, confirm it from the repo root:",
         "```bash",
-        ".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --new-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --new-thread-id <replacement-thread-id>",
         "```",
         "",
         "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
@@ -515,6 +564,7 @@ def render_current_markdown(
     snapshot: dict[str, Any],
     state: dict[str, Any],
     *,
+    agent: str = DEFAULT_AGENT,
     context_threshold: float,
 ) -> str:
     git = snapshot["git"]
@@ -524,13 +574,15 @@ def render_current_markdown(
     replacement = state.get("replacement") or {}
     cleanup = state.get("cleanup") or {}
     handoff = state.get("last_handoff") or {}
-    prompt_path = replacement.get("bootstrap_prompt_path") or str(DEFAULT_BOOTSTRAP_PATH)
+    prompt_path = replacement.get("bootstrap_prompt_path") or default_bootstrap_path(agent).as_posix()
+    title_agent = "Orchestrator" if agent == "orchestrator" else agent.title()
 
     lines = [
-        f"# Current - Codex thread handoff ({snapshot['generated_at']})",
+        f"# Current - {title_agent} thread handoff ({snapshot['generated_at']})",
         "",
         "> Generated by `scripts/orchestration/thread_handoff.py prepare`.",
         "> This is a rollover handoff, not proof that the replacement thread started.",
+        f"> Agent: `{agent}`.",
         "",
         "## Thread Lease",
         "",
@@ -604,12 +656,41 @@ def render_current_markdown(
         "After the new thread is actually running, run:",
         "",
         "```bash",
-        ".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --new-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --new-thread-id <replacement-thread-id>",
         "```",
         "",
         "Do not delete the old heartbeat automation before this confirmation.",
         "",
     ]
+    return "\n".join(lines)
+
+
+def render_router_markdown(
+    *,
+    generated_at: str,
+    default_agent: str,
+    agents: list[str],
+) -> str:
+    default_handoff = default_handoff_path(default_agent).as_posix()
+    lines = [
+        "# Current Session Router",
+        "",
+        f"Latest-Brief: {default_handoff}",
+        "",
+        "Agent-Handoff:",
+    ]
+    for agent in agents:
+        lines.append(f"- {agent}: {default_handoff_path(agent).as_posix()}")
+    lines.extend([
+        "",
+        f"Default-Agent: {default_agent}",
+        f"Generated-At: {generated_at}",
+        "",
+        "This file is a small compatibility router. Detailed thread state lives in",
+        "`docs/session-state/current.<agent>.md`; agents should update only their own",
+        "handoff file unless the task explicitly authorizes a router update.",
+        "",
+    ])
     return "\n".join(lines)
 
 
@@ -702,9 +783,15 @@ def check_state(
 def cmd_prepare(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     now = utc_now()
-    state_path = repo_root / args.state_file
-    bootstrap_path = repo_root / args.bootstrap_file
-    current_path = repo_root / args.current_file
+    agent = normalize_agent_name(args.agent)
+    state_file = args.state_file or default_state_path(agent)
+    bootstrap_file = args.bootstrap_file or default_bootstrap_path(agent)
+    handoff_file = args.handoff_file or default_handoff_path(agent)
+    router_file = args.current_file or DEFAULT_ROUTER_PATH
+    state_path = repo_root / state_file
+    bootstrap_path = repo_root / bootstrap_file
+    handoff_path = repo_root / handoff_file
+    router_path = repo_root / router_file
 
     state = load_state(state_path)
     state_error = state_error_payload(state, state_path, repo_root)
@@ -718,23 +805,45 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         }
     prepared_state = prepare_state(
         state,
+        agent=agent,
         now=now,
         active_thread_id=args.active_thread_id,
         active_automation_id=args.active_automation_id,
-        bootstrap_path=Path(args.bootstrap_file),
+        bootstrap_path=Path(bootstrap_file),
         context_percent=args.context_percent,
         force_new_replacement=args.force_new_replacement,
     )
     snapshot = gather_snapshot(repo_root, args.monitor_base_url)
-    prompt = render_bootstrap_prompt(snapshot, prepared_state, context_threshold=args.context_threshold)
-    current_md = render_current_markdown(snapshot, prepared_state, context_threshold=args.context_threshold)
+    prompt = render_bootstrap_prompt(
+        snapshot,
+        prepared_state,
+        agent=agent,
+        router_path=Path(router_file),
+        handoff_path=Path(handoff_file),
+        context_threshold=args.context_threshold,
+    )
+    handoff_md = render_current_markdown(
+        snapshot,
+        prepared_state,
+        agent=agent,
+        context_threshold=args.context_threshold,
+    )
+    router_md = render_router_markdown(
+        generated_at=snapshot["generated_at"],
+        default_agent=DEFAULT_AGENT,
+        agents=router_agents(agent),
+    )
 
     if args.dry_run:
         output = {
             "dry_run": True,
-            "state_file": str(state_path),
-            "bootstrap_file": str(bootstrap_path),
-            "current_file": str(current_path),
+            "agent": agent,
+            "state_file": state_path.as_posix(),
+            "bootstrap_file": bootstrap_path.as_posix(),
+            "handoff_file": handoff_path.as_posix(),
+            "router_file": router_path.as_posix(),
+            "current_file": router_path.as_posix(),
+            "would_write_router": bool(args.write_current),
             "old_automation_ready_to_delete": False,
             "bootstrap_prompt": prompt,
         }
@@ -743,17 +852,22 @@ def cmd_prepare(args: argparse.Namespace) -> int:
 
     bootstrap_path.parent.mkdir(parents=True, exist_ok=True)
     bootstrap_path.write_text(prompt, encoding="utf-8")
+    handoff_path.parent.mkdir(parents=True, exist_ok=True)
+    handoff_path.write_text(handoff_md, encoding="utf-8")
     write_json_atomic(state_path, prepared_state)
-    wrote_current = False
+    wrote_router = False
     if args.write_current:
-        current_path.parent.mkdir(parents=True, exist_ok=True)
-        current_path.write_text(current_md, encoding="utf-8")
-        wrote_current = True
+        router_path.parent.mkdir(parents=True, exist_ok=True)
+        router_path.write_text(router_md, encoding="utf-8")
+        wrote_router = True
 
     output = {
+        "agent": agent,
         "state_file": rel(state_path, repo_root),
         "bootstrap_file": rel(bootstrap_path, repo_root),
-        "current_file": rel(current_path, repo_root) if wrote_current else None,
+        "handoff_file": rel(handoff_path, repo_root),
+        "router_file": rel(router_path, repo_root) if wrote_router else None,
+        "current_file": rel(router_path, repo_root) if wrote_router else None,
         "replacement_status": prepared_state["replacement"]["status"],
         "old_automation_ready_to_delete": prepared_state["cleanup"]["old_automation_ready_to_delete"],
     }
@@ -763,7 +877,8 @@ def cmd_prepare(args: argparse.Namespace) -> int:
 
 def cmd_confirm_started(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
-    state_path = repo_root / args.state_file
+    agent = normalize_agent_name(args.agent)
+    state_path = repo_root / (args.state_file or default_state_path(agent))
     state = load_state(state_path)
     state_error = state_error_payload(state, state_path, repo_root)
     if state_error:
@@ -782,6 +897,7 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
         return 2
     write_json_atomic(state_path, confirmed)
     print(json.dumps({
+        "agent": agent,
         "state_file": rel(state_path, repo_root),
         "replacement_status": confirmed["replacement"]["status"],
         "replacement_thread_id": confirmed["replacement"]["thread_id"],
@@ -792,7 +908,8 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
 
 def cmd_check(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
-    state_path = repo_root / args.state_file
+    agent = normalize_agent_name(args.agent)
+    state_path = repo_root / (args.state_file or default_state_path(agent))
     state = load_state(state_path)
     facts, warnings = check_state(
         state,
@@ -801,7 +918,7 @@ def cmd_check(args: argparse.Namespace) -> int:
         context_percent=args.context_percent,
         context_threshold=args.context_threshold,
     )
-    payload = {"facts": facts, "warnings": warnings, "state_file": rel(state_path, repo_root)}
+    payload = {"agent": agent, "facts": facts, "warnings": warnings, "state_file": rel(state_path, repo_root)}
     print(json.dumps(payload, indent=2))
     return 2 if warnings else 0
 
@@ -821,9 +938,11 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     prepare = subparsers.add_parser("prepare", help="Prepare a rollover handoff and bootstrap prompt.")
-    prepare.add_argument("--state-file", type=Path, default=DEFAULT_STATE_PATH)
-    prepare.add_argument("--bootstrap-file", type=Path, default=DEFAULT_BOOTSTRAP_PATH)
-    prepare.add_argument("--current-file", type=Path, default=DEFAULT_CURRENT_PATH)
+    prepare.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    prepare.add_argument("--state-file", type=Path)
+    prepare.add_argument("--bootstrap-file", type=Path)
+    prepare.add_argument("--handoff-file", type=Path, help="Override docs/session-state/current.<agent>.md.")
+    prepare.add_argument("--current-file", type=Path, help="Override the shared docs/session-state/current.md router.")
     prepare.add_argument("--active-thread-id")
     prepare.add_argument("--active-automation-id")
     prepare.add_argument("--context-percent", type=float)
@@ -834,19 +953,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Discard an unreadable lease state file and start a new lease.",
     )
-    prepare.add_argument("--write-current", action="store_true", help="Also overwrite docs/session-state/current.md.")
+    prepare.add_argument("--write-current", action="store_true", help="Also overwrite the shared current.md router.")
     prepare.add_argument("--dry-run", action="store_true", help="Print the generated packet without writing files.")
     prepare.set_defaults(func=cmd_prepare)
 
-    confirm = subparsers.add_parser("confirm-started", help="Confirm that the replacement Codex thread is running.")
-    confirm.add_argument("--state-file", type=Path, default=DEFAULT_STATE_PATH)
+    confirm = subparsers.add_parser("confirm-started", help="Confirm that the replacement agent thread is running.")
+    confirm.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    confirm.add_argument("--state-file", type=Path)
     confirm.add_argument("--new-thread-id", required=True)
     confirm.add_argument("--new-automation-id")
     confirm.add_argument("--confirmed-by", default=os.environ.get("USER", "operator"))
     confirm.set_defaults(func=cmd_confirm_started)
 
     check = subparsers.add_parser("check", help="Detect stale or unsafe handoff state.")
-    check.add_argument("--state-file", type=Path, default=DEFAULT_STATE_PATH)
+    check.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    check.add_argument("--state-file", type=Path)
     check.add_argument("--stale-hours", type=float, default=DEFAULT_STALE_HOURS)
     check.add_argument("--context-percent", type=float)
     check.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -108,7 +108,9 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
 
     assert "You are the replacement Codex orchestrator thread." in prompt
-    assert "confirm-started --new-thread-id <replacement-thread-id>" in prompt
+    assert "docs/session-state/current.md" in prompt
+    assert "docs/session-state/current.orchestrator.md" in prompt
+    assert "confirm-started --agent orchestrator --new-thread-id <replacement-thread-id>" in prompt
     assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
     assert "Context estimate: 90.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
 
@@ -133,7 +135,156 @@ def test_render_current_markdown_includes_required_handoff_sections(tmp_path: Pa
     assert "## Open PRs" in rendered
     assert "## Delegated Tasks" in rendered
     assert "## Next Commands" in rendered
-    assert "docs/session-state/current.md" in rendered
+    assert "confirm-started --agent orchestrator --new-thread-id <replacement-thread-id>" in rendered
+
+
+def test_render_router_markdown_contains_parseable_markers():
+    rendered = th.render_router_markdown(
+        generated_at="2026-05-30T08:00:00Z",
+        default_agent="orchestrator",
+        agents=["orchestrator", "codex", "claude", "gemini"],
+    )
+
+    assert "Latest-Brief: docs/session-state/current.orchestrator.md" in rendered
+    assert "Agent-Handoff:" in rendered
+    assert "- codex: docs/session-state/current.codex.md" in rendered
+    assert len(rendered.encode("utf-8")) < 1200
+
+
+def test_default_agent_paths_are_agent_specific():
+    assert th.default_state_path("claude") == Path(".agent/claude-thread-lease.json")
+    assert th.default_bootstrap_path("claude") == Path(".agent/claude-thread-bootstrap.md")
+    assert th.default_handoff_path("claude") == Path("docs/session-state/current.claude.md")
+
+
+def test_prepare_orchestrator_writes_router_and_agent_handoff(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main([
+        "--repo-root",
+        str(tmp_path),
+        "prepare",
+        "--agent",
+        "orchestrator",
+        "--write-current",
+        "--context-percent",
+        "86",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["agent"] == "orchestrator"
+    assert payload["state_file"] == ".agent/orchestrator-thread-lease.json"
+    assert payload["bootstrap_file"] == ".agent/orchestrator-thread-bootstrap.md"
+    assert payload["handoff_file"] == "docs/session-state/current.orchestrator.md"
+    assert payload["router_file"] == "docs/session-state/current.md"
+    assert "Latest-Brief: docs/session-state/current.orchestrator.md" in (
+        tmp_path / "docs/session-state/current.md"
+    ).read_text(encoding="utf-8")
+    assert "## Thread Lease" in (
+        tmp_path / "docs/session-state/current.orchestrator.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_prepare_non_orchestrator_does_not_clobber_router_or_orchestrator_handoff(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+):
+    session_dir = tmp_path / "docs/session-state"
+    session_dir.mkdir(parents=True)
+    router_path = session_dir / "current.md"
+    orchestrator_path = session_dir / "current.orchestrator.md"
+    router_path.write_text("router stays\n", encoding="utf-8")
+    orchestrator_path.write_text("orchestrator stays\n", encoding="utf-8")
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main([
+        "--repo-root",
+        str(tmp_path),
+        "prepare",
+        "--agent",
+        "claude",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["agent"] == "claude"
+    assert payload["router_file"] is None
+    assert router_path.read_text(encoding="utf-8") == "router stays\n"
+    assert orchestrator_path.read_text(encoding="utf-8") == "orchestrator stays\n"
+    assert (session_dir / "current.claude.md").is_file()
+    assert (tmp_path / ".agent/claude-thread-lease.json").is_file()
+    assert (tmp_path / ".agent/claude-thread-bootstrap.md").is_file()
+
+
+def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    agent_dir = tmp_path / ".agent"
+    agent_dir.mkdir()
+    th.write_json_atomic(
+        agent_dir / "orchestrator-thread-lease.json",
+        th.prepare_state(
+            {},
+            agent="orchestrator",
+            now=now,
+            active_thread_id="old-orchestrator",
+            active_automation_id=None,
+            bootstrap_path=Path(".agent/orchestrator-thread-bootstrap.md"),
+            context_percent=None,
+            force_new_replacement=False,
+        ),
+    )
+    th.write_json_atomic(
+        agent_dir / "claude-thread-lease.json",
+        th.prepare_state(
+            {},
+            agent="claude",
+            now=now,
+            active_thread_id="old-claude",
+            active_automation_id=None,
+            bootstrap_path=Path(".agent/claude-thread-bootstrap.md"),
+            context_percent=None,
+            force_new_replacement=False,
+        ),
+    )
+
+    rc = th.main([
+        "--repo-root",
+        str(tmp_path),
+        "confirm-started",
+        "--agent",
+        "claude",
+        "--new-thread-id",
+        "new-claude",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["agent"] == "claude"
+    assert payload["state_file"] == ".agent/claude-thread-lease.json"
+    claude_state = json.loads((agent_dir / "claude-thread-lease.json").read_text(encoding="utf-8"))
+    orchestrator_state = json.loads((agent_dir / "orchestrator-thread-lease.json").read_text(encoding="utf-8"))
+    assert claude_state["replacement"]["thread_id"] == "new-claude"
+    assert claude_state["cleanup"]["old_automation_ready_to_delete"] is True
+    assert orchestrator_state["cleanup"]["old_automation_ready_to_delete"] is False
+
+
+def test_confirm_started_missing_agent_prepare_is_safe(tmp_path: Path, capsys):
+    rc = th.main([
+        "--repo-root",
+        str(tmp_path),
+        "confirm-started",
+        "--agent",
+        "gemini",
+        "--new-thread-id",
+        "new-gemini",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "run prepare first" in payload["error"]
+    assert not (tmp_path / ".agent/gemini-thread-lease.json").exists()
 
 
 def test_check_state_flags_pending_and_stale_replacement():

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -93,7 +93,18 @@ def session_fixture(tmp_path, monkeypatch):
     session_dir = project_root / "docs" / "session-state"
     session_dir.mkdir(parents=True)
     (session_dir / "current.md").write_text(
+        "# Current Session Router\n\n"
+        "Latest-Brief: docs/session-state/current.orchestrator.md\n\n"
+        "Agent-Handoff:\n"
+        "- orchestrator: docs/session-state/current.orchestrator.md\n"
+        "- codex: docs/session-state/current.codex.md\n",
+        encoding="utf-8",
+    )
+    (session_dir / "current.orchestrator.md").write_text(
         "# Current task\n\nWorking on #1309.\n", encoding="utf-8"
+    )
+    (session_dir / "current.codex.md").write_text(
+        "# Codex task\n\nCodex-specific handoff.\n", encoding="utf-8"
     )
     (session_dir / "2026-04-01-old.md").write_text("old handoff\n", encoding="utf-8")
     (session_dir / "2026-04-17-newest.md").write_text("new handoff\n", encoding="utf-8")
@@ -109,18 +120,41 @@ def test_session_current_markdown(session_fixture):
     # Recent handoffs block appended after the current.md body.
     assert "Recent session-state files" in resp.text
     assert "2026-04-17-newest.md" in resp.text
-    # Older handoffs listed too but not current.md itself.
-    assert "current.md" not in resp.text.split("Recent session-state")[1]
+    # Older handoffs listed too but not current router or agent handoff files.
+    recent_block = resp.text.split("Recent session-state")[1]
+    assert "current.md" not in recent_block
+    assert "current.orchestrator.md" not in recent_block
 
 
 def test_session_current_json(session_fixture):
     resp = client.get("/api/session/current?format=json")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["sections"]["current"] == "docs/session-state/current.md"
+    assert body["sections"]["agent"] == "orchestrator"
+    assert body["sections"]["current"] == "docs/session-state/current.orchestrator.md"
+    assert body["sections"]["router"] == "docs/session-state/current.md"
     assert body["sections"]["recent_handoffs"][0].endswith("2026-04-17-newest.md")
     assert body["hash"]
     assert body["bytes"] == len(body["markdown"].encode("utf-8"))
+
+
+def test_session_current_agent_query(session_fixture):
+    resp = client.get("/api/session/current?agent=codex")
+    assert resp.status_code == 200
+    assert "Codex-specific handoff." in resp.text
+    assert "Working on #1309." not in resp.text
+
+
+def test_session_current_router_query(session_fixture):
+    resp = client.get("/api/session/current?agent=router")
+    assert resp.status_code == 200
+    assert "Agent-Handoff:" in resp.text
+    assert "Codex-specific handoff." not in resp.text
+
+
+def test_session_current_rejects_invalid_agent(session_fixture):
+    resp = client.get("/api/session/current?agent=../bad")
+    assert resp.status_code == 400
 
 
 def test_session_current_404_without_current_md(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Split detailed thread handoffs into docs/session-state/current.<agent>.md files while keeping docs/session-state/current.md as a tiny router with Latest-Brief and Agent-Handoff mappings.
- Add --agent-aware lease, bootstrap, prepare/check/confirm paths in scripts/orchestration/thread_handoff.py.
- Teach /api/session/current to serve agent-specific handoffs via ?agent=, and update Claude startup/onboarding docs for the new routing model.
- Preserve per-agent .agent/*-thread-bootstrap.md and .agent/*-thread-lease.json files during prompt deploys.

Closes #2448.

## Validation

- .venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py tests/test_manifest_api.py tests/test_monitor_client_sdk.py -q
- .venv/bin/ruff check scripts/orchestration/thread_handoff.py scripts/api/session_router.py scripts/api/state_router.py scripts/ai_agent_bridge/monitor_client.py tests/orchestration/test_thread_handoff.py tests/test_manifest_api.py
- bash scripts/audit/test_session_setup_hook.sh
- bash tests/test_deploy_prompts_orphan_guard.sh
- git diff --check HEAD~1..HEAD
- .venv/bin/python scripts/audit/lint_agent_trailer.py
- Dry runs: thread_handoff.py prepare --agent claude --dry-run and prepare --agent orchestrator --write-current --dry-run
- Gemini plan and implementation reviews posted on #2448; implementation verdict: APPROVE