### PR TITLE
fix(bio): add missing reference title to Drai-Khmara plan

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/mykhailo-drai-khmara.yaml.bak
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-drai-khmara.yaml.bak
@@ -133,14 +133,13 @@ references:
   type: reference
 - author: Михайло Драй-Хмара
   note: Єдина прижиттєва збірка поезій.
-  title: Проростень
   type: primary
   work: Проростень
 sequence: 183
 slug: mykhailo-drai-khmara
 subtitle: The Neoclassicist Poet and Scholar Consumed by the Terror
 title: 'Михайло Драй-Хмара: Ґроно п''ятірне та доля неокласика'
-version: '4.1'
+version: '4.0'
 vocabulary_hints:
 - definition: молодий пагін рослини; у назві збірки Драй-Хмари — метафора проростання нової поетичної мови
   pos: ч.


### PR DESCRIPTION
## Problem
Full GitHub pytest fails on `main` (CI blocker noted by Codex while clearing the PR queue, e.g. #2450):

```
tests/curriculum/test_seminar_plan_refs_titles.py::test_all_seminar_plans_pass_validate_plan
-> Reference validation failed for curriculum/l2-uk-en/plans/bio/mykhailo-drai-khmara.yaml:
   Every plan reference must include a title
```

## Root cause
The primary reference in `curriculum/l2-uk-en/plans/bio/mykhailo-drai-khmara.yaml` had `work: Проростень` but no `title`. This plan merged via #2456 **after** the seminar-ref-title backfill PR, so the backfill never touched it.

## Fix (minimal, BIO-owned)
- Added `title: Проростень` to the primary reference — derived per `backfill_seminar_ref_titles.derive_title` rule #1 (`work` → title verbatim), the exact rule the test/validator enforce.
- Bumped plan `version` 4.0 → 4.1 and committed the `.bak` snapshot, as required by the plan-immutability gate (non-negotiable §7).
- Scope limited to that YAML + its required `.bak`. No code/test/other-plan changes.

## Verification
```
$ .venv/bin/python -m pytest tests/curriculum/test_seminar_plan_refs_titles.py -q
2 passed in 6.35s
```
(Failed before the fix on exactly this plan; passes after.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)