### PR TITLE
docs(agents): define track orchestrator protocol

### DIFF
--- a/claude_extensions/agents/curriculum-orchestrator.md
+++ b/claude_extensions/agents/curriculum-orchestrator.md
@@ -20,6 +20,8 @@ initialPrompt: |
 
   Standalone session = main orchestrator. Drive the queue without asking when the next
   action is obvious.
+  Promoted track orchestrators own their tracks. Treat their PRs/delegates as awareness-only
+  unless they ask for main review, merge, a Decision Card, or bounded Codex help.
 ---
 
 # Curriculum Orchestrator Agent
@@ -70,10 +72,36 @@ Bad pedagogy creates durable learner errors. Strong modules beat many mediocre m
 - `.claude/`, `.codex/`, and `.agent/` are deploy targets. Source is `claude_extensions/`.
 
 ## Agent Roster
-- Wiki/content writer: Gemini, always. `scripts/wiki/compile.py` defaults to Gemini.
+- Main orchestrator: Codex for repo-wide queue, A1, tooling, infra, tech debt,
+  GitHub issues, integration, and final merge judgment.
+- Promoted track orchestrators: own their assigned tracks end-to-end. The BIO
+  track is currently Claude/BIO-orchestrator owned; do not duplicate BIO triage
+  unless the track orchestrator asks.
+- Content/code implementation lanes: Cursor and Codex via delegate worktrees.
+- Review lanes: Claude `review-deep`, DeepSeek via Hermes delegate, Codex
+  integration review. Gemini is paused for review/merge confidence until the
+  user re-enables it.
+- Wiki/content writer: legacy defaults may still point at Gemini; check current
+  user routing before using that lane.
 - Ukrainian linguistic verification: inline Claude via `mcp__sources__*`.
 - UI work via Desktop: `codex-desktop` or `claude-desktop`; Desktop needs explicit polling.
 - Bridge: `scripts/ai_agent_bridge/__main__.py` (`ab`) for multi-agent discussions and one-shot asks.
+
+## Track Orchestrator Protocol
+- Track orchestrator source of truth: its track handoff, e.g.
+  `docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md`.
+- Main orchestrator source of truth: `docs/session-state/current.md` router plus
+  `docs/session-state/current.orchestrator.md`.
+- Track pings use:
+  `TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight>
+  owner=<agent> needs=<main-review|merge|codex-help|decision|none>
+  summary=<one sentence>`.
+- Main replies use:
+  `MAIN-ACK track=<track> action=<merge-queued|needs-fix|codex-dispatched|noted>
+  scope=<what main will do> boundary=<what remains track-owned>`.
+- Main interrupts track work only for repo-wide safety: generated artifacts,
+  linter/Python-version changes, merge conflicts, failing required CI,
+  cross-track architecture conflicts, or user direction changes.
 
 ## Operational Rules
 - Quality-gate numbers live in `scripts/config.py` and `scripts/audit/config.py`.

--- a/claude_extensions/agents/curriculum-track-orchestrator.md
+++ b/claude_extensions/agents/curriculum-track-orchestrator.md
@@ -16,6 +16,9 @@ initialPrompt: |
     your PRs. `git fetch` is read-only and OK. (Creating PRs for anything — tooling, docs, agents —
     is encouraged; the orchestrator promotes them.)
   - Do not start work in other tracks or general orchestration unless your handoff/task says so.
+  - Communicate with the main orchestrator through durable state, not private chat memory:
+    update your track handoff, open PRs with explicit status/blockers, and use bridge/channel
+    messages only as short pings pointing to those durable records.
 
   ## YOUR COLD-START (do this BEFORE anything else)
   1. Read your TRACK HANDOFF — the single source of truth for your state, boundaries, and dispatch loop.
@@ -51,6 +54,16 @@ initialPrompt: |
     that state reaches `main` through review, not through a direct commit.)
   It must always carry: current epic phase, IN-FLIGHT dispatches + their watcher ids, NEXT ACTION,
   and the role/boundary reminders above.
+
+  ## COMMUNICATE WITH MAIN ORCHESTRATOR
+  Use this ping format when main needs to know something:
+  `TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight>
+  owner=<agent> needs=<main-review|merge|codex-help|decision|none> summary=<one sentence>`.
+
+  Use `needs=codex-help` only for a bounded request with file scope and expected output. Otherwise,
+  keep driving the track yourself. Main may reply with:
+  `MAIN-ACK track=<track> action=<merge-queued|needs-fix|codex-dispatched|noted>
+  scope=<what main will do> boundary=<what remains track-owned>`.
 ---
 
 # Curriculum Track Orchestrator Agent

--- a/docs/agent-channels/shared/context.md
+++ b/docs/agent-channels/shared/context.md
@@ -9,8 +9,8 @@ API snapshot per-post — do NOT put that here.
 
 **learn-ukrainian** — an open-source Ukrainian language curriculum for
 English speakers (A1→C2 core + seminar tracks: HIST, BIO, LIT, OES,
-RUTH, ISTORIO, and literary sub-tracks). Built by Claude + Gemini with
-adversarial review between agents.
+RUTH, ISTORIO, and literary sub-tracks). Built by a multi-agent team with
+explicit ownership boundaries and adversarial review between agents.
 
 - Repo: `learn-ukrainian` (all paths in this file are relative to the repo root)
 - License: CC BY-SA 4.0 for content, MIT for build tooling
@@ -19,9 +19,40 @@ adversarial review between agents.
 
 ## Agents & roles
 
-- **Claude** — architecture, code, pipeline, integration, synthesis
-- **Gemini (3.1-pro-preview)** — content writer, code reviewer, adversarial critic
-- **Codex** — code investigations, root-cause analysis, bug hunts. **Reserved — do not delegate coding to Codex on ticket #1190.**
+- **Codex** — main orchestrator for repo-wide queue, GitHub issue memory, A1,
+  tooling, infra, tech debt, integration, and final merge judgment.
+- **Claude** — architecture, sensitive reasoning, deep review, and promoted
+  track orchestration when assigned. BIO is currently Claude/BIO-orchestrator
+  owned.
+- **Cursor** — implementation/content rebuild lane through delegate/bridge.
+- **DeepSeek** — cheap code/content review and deterministic triage through
+  Hermes-backed delegate.
+- **Gemini** — paused for review/merge confidence until the user re-enables it.
+  Do not treat failed/canceled Gemini review checks as decisive on their own.
+
+## Track orchestrators
+
+A promoted track orchestrator owns one curriculum track/epic end-to-end. The
+main orchestrator observes that track, merges when safe, and handles repo-wide
+risks, but does not duplicate or override track-local triage.
+
+Current promoted track boundary:
+
+- **BIO** — owned by the Claude BIO orchestrator. Codex should not triage, fix,
+  merge, or route BIO PRs/content unless Claude explicitly asks for help.
+
+Communication protocol:
+
+- Track source of truth: the track handoff file, e.g.
+  `docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md`.
+- Main source of truth: `docs/session-state/current.md` router plus
+  `docs/session-state/current.orchestrator.md`.
+- Bridge/channel messages are short pings that point to a PR, issue, or handoff
+  section; durable details live in Git-tracked docs or GitHub.
+- Track update format:
+  `TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight> owner=<agent> needs=<main-review|merge|codex-help|decision|none> summary=<one sentence>`.
+- Main response format:
+  `MAIN-ACK track=<track> action=<merge-queued|needs-fix|codex-dispatched|noted> scope=<what main will do> boundary=<what remains track-owned>`.
 
 ## Non-negotiable rules (every agent, every post)
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -1,7 +1,8 @@
 # Agent Cooperation Best Practices
 
-> **Scope:** How Claude, Gemini, and Codex work together without degrading each other's output quality.
-> Full protocol: `docs/CLAUDE-GEMINI-COOPERATION.md`
+> **Scope:** How Claude, Codex, Cursor, DeepSeek, and track orchestrators work
+> together without degrading each other's output quality.
+> Historical protocol archive: `docs/archive/CLAUDE-GEMINI-COOPERATION.md`
 > Review evidence contract: [`docs/review-protocol.md`](../review-protocol.md)
 >
 > **Runtime layer:** All agent CLI invocations route through `scripts/agent_runtime/`.
@@ -14,8 +15,13 @@
 | Team | Agent | Role |
 |------|-------|------|
 | 💙 **Синя команда** (Blue) | Claude | Architect, reviewer, quality gate |
-| 💛 **Жовта команда** (Gold) | Gemini | Content builder, implementer |
-| 🟢 **Зелена команда** (Green) | Codex | Adversarial reviewer, bug finder, code improver |
+| 💛 **Жовта команда** (Gold) | Cursor / track writers | Content builder, implementer |
+| 🟢 **Зелена команда** (Green) | Codex | Main orchestrator, adversarial reviewer, bug finder, code improver |
+| ⚙️ **Review lane** | DeepSeek | Cheap code/content review and deterministic triage |
+
+Gemini is currently paused for review/merge confidence until the user re-enables
+that lane. Historical Gemini instructions in this document describe old bridge
+behavior; prefer Claude, Codex, Cursor, and DeepSeek for new orchestration work.
 
 **Both teams are adversarial by design.** The purpose is quality through finding mistakes, not agreement. An approved module means both teams couldn't find serious problems — not that both teams were polite.
 
@@ -50,6 +56,64 @@ All substantive discussion happens on GitHub where it is persistent and searchab
 | **Broker messages** | Short notifications pointing to GitHub | <200 chars |
 
 **Never put full reviews or code in broker messages.** Post on GitHub, then ping with "review posted on #559."
+
+### Track orchestrator promotion
+
+A **track orchestrator** is an agent promoted to own one curriculum track or
+epic end-to-end, such as BIO. Once promoted, that orchestrator owns the track's
+content queue, dispatches, handoff, and PR preparation. The main orchestrator
+does not micromanage that track.
+
+| Scope | Main orchestrator owns | Track orchestrator owns |
+|---|---|---|
+| Branch policy | `main`, merge sequencing, release safety | Dispatch worktrees and PR branches only |
+| State | `docs/session-state/current.orchestrator.md` and router | Track handoff, e.g. `docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md` |
+| Work selection | Repo-wide priorities, A1 spine, tooling, infra, tech debt, issues | Track backlog, batches, reviews, content quality |
+| Agent dispatch | Cross-track/tooling agents | Track-local writers/reviewers, including headless Codex |
+| Merge authority | Final reconcile and merge decision | Open PRs and route track feedback, never merge |
+
+**Boundary rule:** if a track orchestrator exists, the main orchestrator treats
+that track's PRs and delegates as awareness-only unless the track orchestrator
+asks for help. This keeps one owner per workstream and prevents duplicate
+triage.
+
+### Track ↔ main communication protocol
+
+Track orchestrators and the main orchestrator communicate through durable,
+low-noise surfaces:
+
+1. **Track handoff is the track source of truth.** The track orchestrator keeps
+   a track handoff current on its PR branches and bundles handoff updates with
+   the batch PR whenever possible.
+2. **GitHub PRs carry deliverables.** Track orchestrators open PRs with clear
+   scope, validation, active dispatch ids, and blockers. The main orchestrator
+   reads the PR instead of scraping private chat context.
+3. **Bridge messages are pings, not payloads.** Use `ab p` / channel posts only
+   to point to the PR, issue, or handoff section that changed.
+4. **Main only interrupts for repo-wide risk.** Examples: generated artifacts in
+   diff, `.python-version`/linter config changes, merge conflicts, failing
+   required CI, cross-track architectural conflicts, or user direction changes.
+5. **Track asks for help explicitly.** If the track needs Codex, it dispatches
+   or requests a bounded Codex task with a file scope, expected output, and
+   ownership boundary.
+6. **Decisions use Decision Cards.** Cross-track or user-visible choices go to a
+   Decision Card with scope; local track implementation choices stay in the
+   track handoff/PR.
+
+Recommended ping format:
+
+```text
+TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight>
+owner=<agent> needs=<main-review|merge|codex-help|decision|none>
+summary=<one sentence, link to handoff/PR for details>
+```
+
+Recommended main response format:
+
+```text
+MAIN-ACK track=<track> action=<merge-queued|needs-fix|codex-dispatched|noted>
+scope=<what main will do> boundary=<what remains track-owned>
+```
 
 ### Thread handoff ownership
 

--- a/docs/session-state/current.orchestrator.md
+++ b/docs/session-state/current.orchestrator.md
@@ -1,112 +1,136 @@
-# Current - Codex orchestrator handoff (2026-05-30T20:35Z)
+# Current - Codex orchestrator handoff (2026-05-31T08:15Z)
 
 Latest-Brief: docs/session-state/current.orchestrator.md
 
 > Handoff-only update. Treat `origin/main` and this file as authoritative.
 
-## Thread / Role
+## Role / Direction
 
-- Main orchestrator thread is the **Orchestrator watchdog replacement**:
-  `019e7836-06ef-7973-a630-07824922dfe5`.
-- User explicitly corrected direction:
-  - BIO is Claude-owned.
-  - Codex drives orchestration, GitHub issue memory, PR queue, and A1 golden
-    learner journey.
-  - Use agents/compute, but keep ownership boundaries clear.
-- Context is near auto-compact; continue in a fresh thread.
+- Codex is the orchestrator and sidekick for GitHub issue memory, agent bridge
+  awareness, A1 golden learner journey, tooling, infra, and tech debt.
+- BIO track is fully owned by the BIO orchestrator (Claude). Do not interfere
+  with BIO PRs/content/delegates unless Claude explicitly asks Codex for help.
+- When a track orchestrator is promoted, let that orchestrator run the track.
+  They can call headless Codex when needed; Codex main stays organized around
+  repo-wide orchestration and non-BIO work.
+- Use the strong-agent mix actively for bounded work:
+  - Codex: orchestration, integration, code changes, final merge judgment.
+  - Claude: BIO ownership, deep PR/path review via `review-deep`, sensitive
+    reasoning.
+  - Cursor: implementation/content rebuild work through delegate/bridge.
+  - DeepSeek: cheap code/content review and deterministic triage via delegate.
+- Stop using Gemini for reviews until the user says otherwise. Gemini review
+  checks are currently unreliable/noisy and should not provide merge confidence.
+- Do not delete or pause old automation unless explicitly instructed.
 
 ## Git State
 
 - Repo: `/Users/krisztiankoos/projects/learn-ukrainian`
-- Branch: `main`
-- HEAD before this handoff update: `2490db006e`
-- Upstream: `origin/main`
-- Modified file before handoff commit: `docs/session-state/current.md`
-- Active delegates after closing the explorer: none known.
+- Main checkout branch: `main`
+- Current authoritative remote head at handoff:
+  `836526d165 feat(api): surface bridge activity for orchestrators`
+- Main checkout has unrelated dirty user/Claude files; do not revert:
+  - `docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md`
+  - `scripts/deploy_prompts.sh`
+  - `docs/bio-epic/phase2-word-target-defects-2026-05-31.txt`
+  - `docs/session-state/2026-05-30-pr2460-bak-fix-inflight.md`
 
-Recent commits before this handoff:
+## Completed Since Prior Handoff
 
-- `2490db006e` `docs(session-state): record issue triage board`
-- `90235bc878` `docs(session-state): avoid stale BIO handoff head`
-- `3ac4e7e7db` `docs(session-state): record BIO Phase 2 unblock`
-- `2379c38d4c` `feat(bio): add Phase 2 plan for Mykhailo Drai-Khmara (#2456)`
+- #2459 merged: BIO Claude driver handoff refresh.
+- #2450 merged: agent-specific thread handoff routers. `docs/session-state/current.md`
+  is now a router; detailed state lives in `current.<agent>.md`.
+- #2447 merged: stressed plan section heading gate.
+- #2478 merged: `GET /api/comms/agent-activity` read-only bridge activity
+  endpoint plus manifest discovery. Local API at `127.0.0.1:8765` was still
+  serving the old process when checked, so restart it before expecting the new
+  endpoint locally.
 
-## Critical Next Order
+Note: #2478 deterministic CI passed and local Gemini diff review had no
+findings, but the user has since corrected policy: do not use Gemini for review
+confidence going forward.
 
-Do **not** jump straight into A1 implementation while PRs are waiting.
+## Active Delegates
 
-First clear the PR queue:
+Check with:
 
-1. **#2459** `docs(bio): refresh Claude driver handoff — Phase-2 division + session lessons`
-   - Branch: `docs/bio-handoff-update-2026-05-30`
-   - Status at last check: `UNSTABLE` only because Gemini `review / review`
-     was still in progress. Other checks were green.
-   - BIO handoff/docs PR, Claude-owned lane. Inspect review result, merge if
-     clean or route feedback to Claude.
-2. **#2450** `feat(handoff): add agent-specific thread routers`
-   - Branch: `codex/agent-thread-handoffs-2026-05-30`
-   - This is operationally important: thread-handoff task becomes real on
-     `main` only after #2450 lands.
-   - It was previously `DIRTY`/`UNKNOWN` after main moved. Rebase/update,
-     verify, and merge before relying on agent-specific handoff behavior.
-3. **#2447** draft `fix(build): normalize stressed plan section headings`
-   - Branch: `codex/m20-plan-section-heading-gate`
-   - A1 support/blocker PR, not the product strategy itself.
-   - Review/undraft/merge only if still sound after current main.
+```bash
+curl -sS http://127.0.0.1:8765/api/delegate/active
+```
 
-Only after those PRs are handled should Codex proceed into the A1 epic.
+Active at handoff time:
 
-## Correct A1 Direction
+- `review-2477-20260531080952` - Claude Opus review-deep for BIO PR #2477.
+- `bio-rebuild-blockI1` - Cursor, running before this handoff.
+- `bio-rebuild-blockG7` - Cursor, running before this handoff.
+- `review-pr2476-plan-ci` - DeepSeek v4 flash read-only triage for BIO PR
+  #2476. Dispatched before the BIO boundary correction; let Claude decide
+  whether to use or ignore the result.
+- `review-pr2474-plan-ci` - DeepSeek v4 flash read-only triage for BIO PR
+  #2474. Dispatched before the BIO boundary correction; let Claude decide
+  whether to use or ignore the result.
 
-Do not treat m20/m21/m22 as the strategy. They are support/validation issues
-from the old V7.2 path.
+Do not assume the bridge `status` command is authoritative for delegates; use
+`/api/delegate/active` and task logs/state.
 
-The user's product direction is:
+## BIO Boundary
+
+Open BIO PRs remain, but they are Claude/BIO-orchestrator owned. Codex should
+not triage, fix, merge, or route BIO content PRs unless Claude asks. Awareness:
+
+- #2477 deterministic checks clean; Gemini review canceled; Claude review
+  running.
+- #2476 has real `Curriculum Plans` failure:
+  `hryhorii-khomyshyn` content outline sum 4000 under word target 5200.
+- #2474 has real `Curriculum Plans` failure:
+  `danylo-shcherbakivskyi` word target under config, plan 3400 vs config 5000.
+- #2473 and #2471 have real `Curriculum Plans` failures and active Cursor BIO
+  rebuild delegates.
+- #2475, #2472, #2470, #2469, #2468 appeared deterministic-clean except
+  Gemini review failure/cancellation at last check.
+
+Let Claude/BIO orchestrator handle these.
+
+## Agent Bridge Routes
+
+Use these instead of Gemini:
+
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-deep <PR-or-path> --effort high
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-claude "<prompt>" --task-id <id> --review
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-cursor - --task-id <id>
+.venv/bin/python scripts/delegate.py dispatch --agent deepseek --model deepseek-v4-flash --mode read-only --task-id <id> --prompt '<prompt>'
+```
+
+DeepSeek is wired through Hermes:
+
+- `deepseek-v4-flash`: cheap code/PR review and CI triage.
+- `deepseek-v4-pro`: content review / VESUM-heavy lanes.
+
+Cursor has broker/delegate support but no PR-comment auto-posting wrapper.
+Claude `review-deep` is the explicit PR/path review wrapper.
+
+## A1 Direction
+
+Codex focus now: A1, tooling, infra, tech debt, and GitHub issues.
+
+Do not treat m20/m21/m22 as product strategy. They are support/validation
+items. Product direction:
 
 - Start A1 from the beginning.
 - Build the learner experience as the product spine.
 - First slice is A1 M1-M7 safe onboarding / first contact.
-- Fix pipeline/gates only when they block producing excellent learner content.
+- Fix pipeline/gates only when they block excellent learner content.
 
-Read-only explorer found A1 M1-M7 sequence:
+A1 M1-M7 sequence:
 
-1. `sounds-letters-and-hello` — `Звуки, літери та привіт`
-2. `reading-ukrainian` — `Читаємо українською`
-3. `special-signs` — `Особливі знаки`
-4. `stress-and-melody` — `Наголос і мелодика`
-5. `who-am-i` — `Хто я?`
-6. `my-family` — `Моя сім'я`
-7. `checkpoint-first-contact` — `Підсумок: Перший контакт`
-
-Explorer also found:
-
-- Sequence source: `curriculum/l2-uk-en/curriculum.yaml`
-- Each M1-M7 has plan YAML and discovery YAML.
-- No populated content bundle was found for M1-M7.
-- Only populated A1 lesson bundle found was `curriculum/l2-uk-en/a1/my-morning/`.
-
-## Issue Board State
-
-Issue triage already completed:
-
-- 71 open issues.
-- 0 missing `lane:*`.
-- 0 missing `state:*`.
-- BIO issues labeled Claude-owned.
-- A1 golden path labeled Codex-owned.
-- No issues closed.
-
-Active board after PR queue:
-
-- A1/Codex: #2389, #2390, #2418, #2419, #2380, plus #2447 PR if not merged.
-- Orchestration/Codex: #2450/#2448, #2368, #2126.
-- BIO/Claude: #2309, #2451, plus #2459 PR if not merged.
-
-Proposed archive candidates only, do not close without review:
-
-- #2351 likely superseded by #2418.
-- #1969 likely superseded by #2418.
-- #2132 likely stale promote-protocol result thread.
+1. `sounds-letters-and-hello`
+2. `reading-ukrainian`
+3. `special-signs`
+4. `stress-and-melody`
+5. `who-am-i`
+6. `my-family`
+7. `checkpoint-first-contact`
 
 ## Restart Commands
 
@@ -114,24 +138,15 @@ Proposed archive candidates only, do not close without review:
 cd /Users/krisztiankoos/projects/learn-ukrainian
 git status --short
 git log --oneline -8 --decorate --no-merges
-gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20
-gh issue list --state open --label state:now --limit 100 --json number,title,labels,url
 curl -sS http://127.0.0.1:8765/api/delegate/active
-```
-
-For A1 M1-M7 inventory:
-
-```bash
-sed -n '1,220p' curriculum/l2-uk-en/curriculum.yaml
-find curriculum/l2-uk-en/a1 -maxdepth 2 -type f | sort
-sed -n '1,80p' curriculum/l2-uk-en/plans/a1/sounds-letters-and-hello.yaml
+gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20
 ```
 
 ## Guardrails
 
-- Keep main checkout read-only except handoff updates.
 - Use `.worktrees/dispatch/<agent>/<task>/` for implementation.
 - Do not edit generated status/audit/review artifacts, linter configs, or
   `.python-version`.
 - Every commit must carry an `X-Agent` trailer.
-- Do not delete/pause old automation unless the user explicitly instructs it.
+- Use `.venv/bin/python`, not `sys.executable` or system Python.
+- Do not revert unrelated dirty files in the main checkout.


### PR DESCRIPTION
## Summary
- document promoted track orchestrator ownership boundaries and main-orchestrator communication protocol
- update shared channel context with current agent lanes: Codex, Claude, Cursor, DeepSeek, and paused Gemini review confidence
- add TRACK-UPDATE / MAIN-ACK protocol to the main and track orchestrator prompts
- refresh current orchestrator handoff with the latest A1/BIO boundary state

## Validation
- git diff --check
- pre-commit hooks on commit and push
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py