### PR TITLE
fix(dashboards): conform routing.html to monitor-shell contract — unblocks main pytest

### DIFF
--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -41,6 +41,7 @@ ul { margin: 6px 0 0 18px; font-size: 13px; line-height: 1.55; color: var(--text
 .bar { height: 8px; border-radius: 4px; background: var(--bg3); overflow: hidden; min-width: 90px; }
 .bar > span { display: block; height: 100%; background: var(--blue); }
 </style>
+<link rel="stylesheet" href="/monitor.css">
 </head>
 <body>
 <div class="topbar">
@@ -48,6 +49,14 @@ ul { margin: 6px 0 0 18px; font-size: 13px; line-height: 1.55; color: var(--text
   <span class="sub">which agent for what · subscription headroom · dispatch usage snapshot</span>
   <span class="spacer"></span>
   <a href="/">&larr; Home</a> &nbsp; <a href="/delegate.html">Delegate</a> &nbsp; <a href="/cost.html">Cost</a> &nbsp; <a href="/runtime.html">Runtime</a>
+  <nav class="monitor-nav" aria-label="Monitor sections">
+    <a href="/">Home</a>
+    <a href="/orient.html">Orient</a>
+    <a href="/channels.html">Channels</a>
+    <a href="/comms.html">Comms</a>
+    <a href="/artifacts/">Artifacts</a>
+    <a href="/runtime.html">Runtime</a>
+  </nav>
 </div>
 <div class="container">
   <p class="note">Static snapshot, refreshed manually by the bio-driver. Live data: <a href="/delegate.html">delegate</a> (dispatch activity), <a href="/cost.html">cost</a> ($ spend), <a href="/runtime.html">runtime</a> (7-day usage). Billed quota lives in each vendor dashboard (cursor.com, Anthropic console, platform.openai.com).</p>


### PR DESCRIPTION
**Main pytest is RED**, blocking all PRs. Root cause: `dashboards/routing.html` (added by #2481, a `docs(bio)` driver dashboard) never conformed to the monitor-shell contract — it lacks `<link rel="stylesheet" href="/monitor.css">` and `class="monitor-nav"`, so `tests/test_monitor_ui_contracts.py::test_all_playground_pages_use_single_monitor_shell` (which globs all `dashboards/*.html`) fails.

**Fix (contract-conformance only, no data change):**
- Add `<link rel="stylesheet" href="/monitor.css">` after the inline `<style>` (the test requires it to follow the last `</style>` when `#0d1117` is inlined).
- Add a `<nav class="monitor-nav">` with the 6 `PRIMARY_NAV_HREFS` (/, /orient.html, /channels.html, /comms.html, /artifacts/, /runtime.html), mirroring `cost.html`.

**Verified locally:** `pytest tests/test_monitor_ui_contracts.py → 13 passed`.

Flagging for orchestrator awareness — this is a monitor-infra file, but it's a bio-driver artifact (#2481) breaking main CI and blocking bio PRs #2527/#2528, so fixing it to unblock the repo. The dashboard's *data* (routing table) is stale/divergent from the current bio handoff but I left it untouched — separate concern.