### PR TITLE
fix(b1): clean up landing page order

### DIFF
--- a/scripts/audit/check_mdx_source_parity.py
+++ b/scripts/audit/check_mdx_source_parity.py
@@ -85,6 +85,9 @@ def check_parity(mdx_files: list[Path], changed_files: set[Path], base: str | No
         level = parts[0]
         slug = rel_path.stem
 
+        if len(parts) == 2 and slug == "index":
+            continue
+
         if level in legacy_levels:
             continue
 
@@ -165,9 +168,11 @@ def main(argv: list[str] | None = None) -> int:
             if len(parts) < 2:
                 continue
             level = parts[0]
+            slug = rel_path.stem
+            if len(parts) == 2 and slug == "index":
+                continue
             if level in legacy_levels:
                 continue
-            slug = rel_path.stem
             expected_source_dir = SOURCE_DIR / level / slug
             if not expected_source_dir.exists():
                 violations.append((mdx_path, f"Missing source directory: {expected_source_dir}"))

--- a/scripts/generate_landing_pages.py
+++ b/scripts/generate_landing_pages.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections import OrderedDict
 from pathlib import Path
 
 import yaml
@@ -30,13 +31,29 @@ TRACK_CONFIG = {
     "c2": {"title": "C2 — Mastery", "uk_title": "Досконало", "uk_sub": "Mastery", "color": "#212121", "word_target": 5000},
 }
 
+B1_UNIT_RANGES = [
+    (1, 10, "M01-M10 · Aspect foundations"),
+    (11, 21, "M11-M21 · Sound changes and noun patterns"),
+    (22, 33, "M22-M33 · Verb systems"),
+    (34, 43, "M34-M43 · Motion and spatial language"),
+    (44, 51, "M44-M51 · Comparison and word formation"),
+    (52, 64, "M52-M64 · Cases, prepositions, and sentence parts"),
+    (65, 74, "M65-M74 · Participles, gerunds, and media"),
+    (75, 84, "M75-M84 · Complex syntax"),
+    (85, 94, "M85-M94 · Register, narrative, and B1 review"),
+]
+
 
 def get_module_status(level: str, slug: str) -> str:
-    """Check if module is built and passing audit."""
+    """Check if module is deployed and, when available, passing audit."""
     status_path = CURRICULUM_ROOT / level / "status" / f"{slug}.json"
-    content_path = CURRICULUM_ROOT / level / f"{slug}.md"
+    content_paths = [
+        CURRICULUM_ROOT / level / f"{slug}.md",
+        CURRICULUM_ROOT / level / slug / "module.md",
+        STARLIGHT_DOCS / level / f"{slug}.mdx",
+    ]
 
-    if not content_path.exists():
+    if not any(path.exists() for path in content_paths):
         return "locked"
 
     if status_path.exists():
@@ -49,6 +66,17 @@ def get_module_status(level: str, slug: str) -> str:
             pass
 
     return "active"  # Content exists but not passing
+
+
+def get_unit_name(level: str, module_num: int, plan: dict) -> str:
+    """Return the learner-facing unit label for a module."""
+    if level == "b1":
+        for start, end, label in B1_UNIT_RANGES:
+            if start <= module_num <= end:
+                return label
+
+    phase = plan.get("phase", "")
+    return phase if phase else f"{level.upper()} Modules"
 
 
 def get_plan_data(level: str, slug: str) -> dict:
@@ -86,18 +114,16 @@ def generate_landing_page(level: str) -> str:
         "word_target": 4000,
     })
 
-    # Group modules by phase — consolidate (same phase may appear at multiple positions)
-    from collections import OrderedDict
+    # Group modules by learner-facing unit while preserving curriculum.yaml order.
     phase_items: OrderedDict[str, list[str]] = OrderedDict()
     done_count = 0
+    active_count = 0
 
     for i, slug in enumerate(modules, 1):
         plan = get_plan_data(level, slug)
         title = plan.get("title", slug.replace("-", " ").title())
         subtitle = plan.get("subtitle", "")
-        phase = plan.get("phase", "")
-
-        unit_name = phase if phase else f"{level.upper()} Modules"
+        unit_name = get_unit_name(level, i, plan)
 
         if unit_name not in phase_items:
             phase_items[unit_name] = []
@@ -105,6 +131,8 @@ def generate_landing_page(level: str) -> str:
         status = get_module_status(level, slug)
         if status == "done":
             done_count += 1
+        elif status == "active":
+            active_count += 1
 
         sub_escaped = escape_js_string(subtitle[:80])
         title_escaped = escape_js_string(title)
@@ -129,7 +157,24 @@ def generate_landing_page(level: str) -> str:
 
     modules_js = "\n".join(modules_js_lines)
 
-    description = f"{config.get('uk_sub', '')} — {len(modules)} modules"
+    planned_count = len(modules) - done_count - active_count
+    if level == "b1":
+        subtitle = f"{active_count} learner page available · {done_count} reviewed · {len(modules)}-module plan"
+        progress_title = "Build status"
+        progress_description = f"{active_count} available · {done_count} reviewed · {planned_count} planned"
+        description = f"B1 landing — {len(modules)} modules in curriculum order"
+    else:
+        subtitle = f"{config.get('uk_sub', '')} — {done_count}/{len(modules)} modules complete"
+        progress_title = ""
+        progress_description = ""
+        description = f"{config.get('uk_sub', '')} — {len(modules)} modules"
+
+    progress_props = ""
+    if progress_title:
+        progress_props = (
+            f'\n  progressTitle="{escape_js_string(progress_title)}"'
+            f'\n  progressDescription="{escape_js_string(progress_description)}"'
+        )
 
     mdx = f"""---
 title: "{config['title']}"
@@ -143,7 +188,7 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="{level.upper()}"
   title="{config['uk_title']}"
-  subtitle="{config.get('uk_sub', '')} — {done_count}/{len(modules)} modules complete"
+  subtitle="{escape_js_string(subtitle)}"{progress_props}
   moduleCount={{{len(modules)}}}
   wordTarget={{{config['word_target']}}}
   color="{config['color']}"

--- a/scripts/generate_landing_pages.py
+++ b/scripts/generate_landing_pages.py
@@ -44,6 +44,17 @@ B1_UNIT_RANGES = [
 ]
 
 
+def truncate_card_subtitle(text: str, limit: int = 96) -> str:
+    """Trim generated card subtitles without cutting through a word."""
+    if len(text) <= limit:
+        return text
+
+    shortened = text[:limit].rstrip()
+    if " " in shortened:
+        shortened = shortened.rsplit(" ", 1)[0]
+    return shortened
+
+
 def get_module_status(level: str, slug: str) -> str:
     """Check if module is deployed and, when available, passing audit."""
     status_path = CURRICULUM_ROOT / level / "status" / f"{slug}.json"
@@ -134,7 +145,7 @@ def generate_landing_page(level: str) -> str:
         elif status == "active":
             active_count += 1
 
-        sub_escaped = escape_js_string(subtitle[:80])
+        sub_escaped = escape_js_string(truncate_card_subtitle(subtitle))
         title_escaped = escape_js_string(title)
 
         phase_items[unit_name].append(
@@ -159,7 +170,8 @@ def generate_landing_page(level: str) -> str:
 
     planned_count = len(modules) - done_count - active_count
     if level == "b1":
-        subtitle = f"{active_count} learner page available · {done_count} reviewed · {len(modules)}-module plan"
+        page_label = "page" if active_count == 1 else "pages"
+        subtitle = f"{active_count} learner {page_label} available · {done_count} reviewed · {len(modules)}-module plan"
         progress_title = "Build status"
         progress_description = f"{active_count} available · {done_count} reviewed · {planned_count} planned"
         description = f"B1 landing — {len(modules)} modules in curriculum order"

--- a/starlight/src/components/LevelLanding.module.css
+++ b/starlight/src/components/LevelLanding.module.css
@@ -30,6 +30,7 @@
 }
 
 .heroTitle {
+  color: white;
   font-size: 1.75rem;
   font-weight: 700;
   margin: 0 0 0.3rem 0;

--- a/starlight/src/components/LevelLanding.tsx
+++ b/starlight/src/components/LevelLanding.tsx
@@ -142,8 +142,8 @@ export default function LevelLanding(props: LevelLandingProps): ReactNode {
   const moduleCount = totalModules || unitGroups.reduce((acc, g) => acc + g.items.length, 0);
   const pct = moduleCount > 0 ? Math.round((doneCount / moduleCount) * 100) : 0;
   const darkerColor = adjustColor(color, -40);
-  const progressTitle = props.progressTitle || 'Your Progress';
-  const progressDescription = props.progressDescription || `${doneCount} of ${moduleCount} completed (${pct}%)`;
+  const progressTitle = props.progressTitle ?? 'Your Progress';
+  const progressDescription = props.progressDescription ?? `${doneCount} of ${moduleCount} completed (${pct}%)`;
 
   return (
     <div className={styles.container}>

--- a/starlight/src/components/LevelLanding.tsx
+++ b/starlight/src/components/LevelLanding.tsx
@@ -37,6 +37,8 @@ type LevelLandingProps = {
   totalPlanned?: number; // backwards compat
   hours?: number;
   color?: string;
+  progressTitle?: string;
+  progressDescription?: string;
   modules: UnitGroup[] | OldModuleItem[];
 };
 
@@ -140,6 +142,8 @@ export default function LevelLanding(props: LevelLandingProps): ReactNode {
   const moduleCount = totalModules || unitGroups.reduce((acc, g) => acc + g.items.length, 0);
   const pct = moduleCount > 0 ? Math.round((doneCount / moduleCount) * 100) : 0;
   const darkerColor = adjustColor(color, -40);
+  const progressTitle = props.progressTitle || 'Your Progress';
+  const progressDescription = props.progressDescription || `${doneCount} of ${moduleCount} completed (${pct}%)`;
 
   return (
     <div className={styles.container}>
@@ -158,8 +162,8 @@ export default function LevelLanding(props: LevelLandingProps): ReactNode {
       {/* Progress */}
       <div className={styles.progressSection}>
         <div className={styles.progressHeader}>
-          <h3>Your Progress</h3>
-          <span>{doneCount} of {moduleCount} completed ({pct}%)</span>
+          <h3>{progressTitle}</h3>
+          <span>{progressDescription}</span>
         </div>
         <div className={styles.progressBar}>
           <div className={styles.progressFill} style={{ width: `${pct}%`, background: color }} />

--- a/starlight/src/content/docs/b1/index.mdx
+++ b/starlight/src/content/docs/b1/index.mdx
@@ -42,7 +42,7 @@ import LevelLanding from '@site/src/components/LevelLanding';
         { num: 15, slug: "simplification-consonants", title: "Спрощення приголосних", sub: "Щастя — щасливий: коли приголосний випадає", status: "locked" },
         { num: 16, slug: "noun-subclasses-masculine", title: "Іменники на -ар, -яр, -ин", sub: "Пекар, школяр, киянин — хто вони і як їх відмінювати", status: "locked" },
         { num: 17, slug: "noun-subclasses-hissing", title: "Іменники на ж, ч, ш, щ", sub: "Мішана група II відміни — від сторожа до товариша", status: "locked" },
-        { num: 18, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті ї", status: "locked" },
+        { num: 18, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті їжі", status: "locked" },
         { num: 19, slug: "noun-subclasses-feminine", title: "Жіночий рід (нульове закінчення)", sub: "III відміна — від любові до подорожі", status: "locked" },
         { num: 20, slug: "pluralia-tantum", title: "Іменники у множині", sub: "Двері, окуляри, Карпати — слова без однини", status: "locked" },
         { num: 21, slug: "checkpoint-morphophonemics", title: "Контрольна робота 1", sub: "Базовий рівень та морфонеміка — перевірка модулі №1–12", status: "locked" },

--- a/starlight/src/content/docs/b1/index.mdx
+++ b/starlight/src/content/docs/b1/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "B1 — Intermediate"
-description: "Intermediate — 94 modules"
+description: "B1 landing — 94 modules in curriculum order"
 template: splash
 ---
 
@@ -9,259 +9,151 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="B1"
-  title="Жива мова"
-  subtitle="Intermediate — 1/94 modules complete"
+  title="Крок вперед"
+  subtitle="1 learner page available · 0 reviewed · 94-module plan"
+  progressTitle="Build status"
+  progressDescription="1 available · 0 reviewed · 93 planned"
   moduleCount={94}
   wordTarget={4000}
-  color="#E65100"
+  color="#6A1B9A"
   modules={[
     {
-      unit: "B1.0 [Основи та опанування виду]",
+      unit: "M01-M10 · Aspect foundations",
       items: [
         { num: 1, slug: "b1-baseline-past-present", title: "Минуле і теперішнє", sub: "Повторення дієслівних часів з повним зануренням в українську", status: "locked" },
-        { num: 10, slug: "work-and-career", title: "Робота і кар'єра", sub: "Професійна лексика, працевлаштування та розповідь про досвід", status: "locked" },
-        { num: 12, slug: "checkpoint-aspect", title: "Контрольна робота: вид дієслова", sub: "Діагностична перевірка аспектного вибору в усіх контекстах модулі №1–11", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.0 [Baselines & Aspect Mastery]",
-      items: [
         { num: 2, slug: "b1-baseline-future-aspect", title: "Майбутній час і вид дієслова", sub: "Три форми майбутнього часу та видові пари", status: "locked" },
         { num: 3, slug: "people-and-relationships", title: "Людина і стосунки", sub: "Зовнішність, характер, родина та знайомство", status: "locked" },
-        { num: 6, slug: "aspect-in-narration", title: "Вид у розповіді", sub: "Тло і передній план — як аспект створює наратив", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.0 [Базові концепції та опанування виду]",
-      items: [
         { num: 4, slug: "aspect-past-tense", title: "Вид у минулому часі", sub: "Одного разу vs щодня — як вид змінює значення минулого", status: "locked" },
-        { num: 9, slug: "aspect-in-negation", title: "Вид і заперечення", sub: "Не робив vs ще не зробив — заперечення факту чи очікування", status: "locked" },
-        { num: 8, slug: "aspect-in-imperatives", title: "Вид у наказовому способі", sub: "Відкрий! vs Не відкривай! — чому заперечення змінює вид", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.0 [Основи та майстерність виду]",
-      items: [
         { num: 5, slug: "aspect-future-tense", title: "Вид у майбутньому часі", sub: "Три способи сказати 'я буду' — і чому їх саме три", status: "locked" },
-        { num: 11, slug: "aspect-in-conditionals", title: "Вид в умовних реченнях", sub: "Якщо зробиш проти якби робив — реальність і вид", status: "locked" },
+        { num: 6, slug: "aspect-in-narration", title: "Вид у розповіді", sub: "Тло і передній план — як аспект створює наратив", status: "locked" },
+        { num: 7, slug: "daily-life-and-routines", title: "Щоденне життя", sub: "Розпорядок дня, побут та повсякденне спілкування", status: "locked" },
+        { num: 8, slug: "aspect-in-negation", title: "Вид і заперечення", sub: "Не робив vs ще не зробив — заперечення факту чи очікування", status: "locked" },
+        { num: 9, slug: "work-and-career", title: "Робота і кар'єра", sub: "Професійна лексика, працевлаштування та розповідь про досвід", status: "locked" },
+        { num: 10, slug: "checkpoint-aspect", title: "Контрольна робота: вид дієслова", sub: "Діагностична перевірка аспектного вибору в усіх контекстах модулі №1–11", status: "locked" },
       ]
     },
     {
-      unit: "B1.2 [Дієслова]",
+      unit: "M11-M21 · Sound changes and noun patterns",
       items: [
-        { num: 7, slug: "daily-life-and-routines", title: "Щоденне життя", sub: "Розпорядок дня, побут та повсякденне спілкування", status: "locked" },
-        { num: 25, slug: "conditionals-unreal", title: "Умовний спосіб (нереальний)", sub: "Якби-речення та контрфактичні умовні конструкції", status: "locked" },
+        { num: 11, slug: "alternation-vowels", title: "Чергування голосних", sub: "Коли о та е стають і — і коли зникають зовсім", status: "locked" },
+        { num: 12, slug: "alternation-consonants-nouns", title: "Чергування приголосних (іменники)", sub: "Друг — друже — друзі: як змінюються приголосні в іменниках", status: "locked" },
+        { num: 13, slug: "alternation-consonants-verbs", title: "Чергування приголосних (дієслова)", sub: "Сидіти — сиджу, плакати — плачу: приголосні в дієсловах", status: "locked" },
+        { num: 14, slug: "health-at-the-doctor", title: "Здоров'я і медицина", sub: "У лікаря — від скарг до рецепта", status: "locked" },
+        { num: 15, slug: "simplification-consonants", title: "Спрощення приголосних", sub: "Щастя — щасливий: коли приголосний випадає", status: "locked" },
+        { num: 16, slug: "noun-subclasses-masculine", title: "Іменники на -ар, -яр, -ин", sub: "Пекар, школяр, киянин — хто вони і як їх відмінювати", status: "locked" },
+        { num: 17, slug: "noun-subclasses-hissing", title: "Іменники на ж, ч, ш, щ", sub: "Мішана група II відміни — від сторожа до товариша", status: "locked" },
+        { num: 18, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті ї", status: "locked" },
+        { num: 19, slug: "noun-subclasses-feminine", title: "Жіночий рід (нульове закінчення)", sub: "III відміна — від любові до подорожі", status: "locked" },
+        { num: 20, slug: "pluralia-tantum", title: "Іменники у множині", sub: "Двері, окуляри, Карпати — слова без однини", status: "locked" },
+        { num: 21, slug: "checkpoint-morphophonemics", title: "Контрольна робота 1", sub: "Базовий рівень та морфонеміка — перевірка модулі №1–12", status: "locked" },
+      ]
+    },
+    {
+      unit: "M22-M33 · Verb systems",
+      items: [
+        { num: 22, slug: "conditionals-real", title: "Умовний спосіб (реальний)", sub: "Якщо-речення та реальні умовні конструкції", status: "locked" },
+        { num: 23, slug: "conditionals-unreal", title: "Умовний спосіб (нереальний)", sub: "Якби-речення та контрфактичні умовні конструкції", status: "locked" },
+        { num: 24, slug: "aspect-in-conditionals", title: "Вид в умовних реченнях", sub: "Якщо зробиш проти якби робив — реальність і вид", status: "locked" },
+        { num: 25, slug: "shopping-and-services", title: "Покупки і послуги", sub: "На ринку, в магазині, на пошті — порівняння і словотвір у дії", status: "locked" },
         { num: 26, slug: "imperative-nuances", title: "Наказовий спосіб (деталі)", sub: "Хай/нехай, ввічливі форми та вид дієслова в наказі", status: "locked" },
+        { num: 27, slug: "aspect-in-imperatives", title: "Вид у наказовому способі", sub: "Відкрий! vs Не відкривай! — чому заперечення змінює вид", status: "locked" },
         { num: 28, slug: "reflexive-verbs-nuances", title: "Зворотні дієслова", sub: "Нюанси -ся/-сь: взаємність, стан, пасивність", status: "locked" },
+        { num: 29, slug: "housing-and-renting", title: "Житло і оренда", sub: "Пошук квартири, оренда, комунальні послуги — відмінки в дії", status: "locked" },
+        { num: 30, slug: "passive-voice-intro", title: "Пасивний стан (вступ)", sub: "Пасивні конструкції через зворотні дієслова та форми на -но/-то", status: "locked" },
+        { num: 31, slug: "verbal-nouns", title: "Віддієслівні іменники", sub: "Читання, бачення, відкриття — як дієслова стають іменниками", status: "locked" },
+        { num: 32, slug: "verb-formation-suffixes", title: "Творення дієслів", sub: "Префікси, суфікси та способи дієслівного словотворення", status: "locked" },
         { num: 33, slug: "checkpoint-verbs", title: "Контрольна робота 2", sub: "Дієслівна фаза — перевірка модулі №18–25", status: "locked" },
       ]
     },
     {
-      unit: "B1.1 [Морфонологія]",
-      items: [
-        { num: 13, slug: "alternation-vowels", title: "Чергування голосних", sub: "Коли о та е стають і — і коли зникають зовсім", status: "locked" },
-        { num: 14, slug: "alternation-consonants-nouns", title: "Чергування приголосних (іменники)", sub: "Друг — друже — друзі: як змінюються приголосні в іменниках", status: "locked" },
-        { num: 15, slug: "alternation-consonants-verbs", title: "Чергування приголосних (дієслова)", sub: "Сидіти — сиджу, плакати — плачу: приголосні в дієсловах", status: "locked" },
-        { num: 16, slug: "health-at-the-doctor", title: "Здоров'я і медицина", sub: "У лікаря — від скарг до рецепта", status: "locked" },
-        { num: 17, slug: "simplification-consonants", title: "Спрощення приголосних", sub: "Щастя — щасливий: коли приголосний випадає", status: "locked" },
-        { num: 20, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті їжі", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.1 [Морфофонеміка]",
-      items: [
-        { num: 18, slug: "noun-subclasses-masculine", title: "Іменники на -ар, -яр, -ин", sub: "Пекар, школяр, киянин — хто вони і як їх відмінювати", status: "locked" },
-        { num: 19, slug: "noun-subclasses-hissing", title: "Іменники на ж, ч, ш, щ", sub: "Мішана група II відміни — від сторожа до товариша", status: "locked" },
-        { num: 21, slug: "noun-subclasses-feminine", title: "Жіночий рід (нульове закінчення)", sub: "III відміна — від любові до подорожі", status: "locked" },
-        { num: 22, slug: "pluralia-tantum", title: "Іменники у множині", sub: "Двері, окуляри, Карпати — слова без однини", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.1 [Морфонеміка]",
-      items: [
-        { num: 23, slug: "checkpoint-morphophonemics", title: "Контрольна робота 1", sub: "Базовий рівень та морфонеміка — перевірка модулі №1–12", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.2 [Система дієслів]",
-      items: [
-        { num: 24, slug: "conditionals-real", title: "Умовний спосіб (реальний)", sub: "Якщо-речення та реальні умовні конструкції", status: "locked" },
-        { num: 31, slug: "housing-and-renting", title: "Житло і оренда", sub: "Пошук квартири, оренда, комунальні послуги — відмінки в дії", status: "locked" },
-        { num: 29, slug: "passive-voice-intro", title: "Пасивний стан (вступ)", sub: "Пасивні конструкції через зворотні дієслова та форми на -но/-то", status: "locked" },
-        { num: 30, slug: "verbal-nouns", title: "Віддієслівні іменники", sub: "Читання, бачення, відкриття — як дієслова стають іменниками", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.2 [Система дієслова]",
-      items: [
-        { num: 27, slug: "shopping-and-services", title: "Покупки і послуги", sub: "На ринку, в магазині, на пошті — порівняння і словотвір у дії", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.2 [Verbs]",
-      items: [
-        { num: 32, slug: "verb-formation-suffixes", title: "Творення дієслів", sub: "Префікси, суфікси та способи дієслівного словотворення", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.3 [Дієслова руху]",
+      unit: "M34-M43 · Motion and spatial language",
       items: [
         { num: 34, slug: "prepositions-spatial-review", title: "Просторові прийменники", sub: "Біля, серед, навпроти, між — просторові відношення перед вивченням дієслів руху", status: "locked" },
+        { num: 35, slug: "motion-base-review", title: "Рух: іти, їхати, бігти", sub: "Базові пари дієслів руху — односпрямовані та різноспрямовані", status: "locked" },
+        { num: 36, slug: "motion-prefixes-arrival", title: "Прийти, доїхати", sub: "Префікси при- (прибуття) та до- (досягнення мети) з дієсловами руху", status: "locked" },
+        { num: 37, slug: "traveling-ukraine", title: "Подорож Україною", sub: "Подорожні розповіді — транспорт, маршрути, пам'ятки", status: "locked" },
+        { num: 38, slug: "motion-prefixes-departure", title: "Піти, від'їхати", sub: "Префікси пі-/по- (вирушання) та від- (віддалення) з дієсловами руху", status: "locked" },
+        { num: 39, slug: "motion-prefixes-in-out", title: "Зайти, вийти", sub: "Префікси за- (входження/забігання) та ви- (вихід) з дієсловами руху", status: "locked" },
+        { num: 40, slug: "motion-prefixes-transit", title: "Перейти, проїхати", sub: "Префікси пере- (перетинання) та про- (проїжджання повз) з дієсловами руху", status: "locked" },
+        { num: 41, slug: "motion-flight-swim", title: "Летіти, пливти", sub: "Дієслова руху в повітрі та на воді — з усіма префіксами", status: "locked" },
+        { num: 42, slug: "figurative-motion", title: "Час іде, дощ іде", sub: "Переносне вживання дієслів руху в українській мові", status: "locked" },
         { num: 43, slug: "checkpoint-motion", title: "Контрольна робота 3", sub: "Перевірка знань: просторові прийменники, дієслова руху, префікси, подорожі", status: "locked" },
       ]
     },
     {
-      unit: "B1.3 [Всесвіт дієслів руху]",
+      unit: "M44-M51 · Comparison and word formation",
       items: [
-        { num: 35, slug: "motion-base-review", title: "Рух: іти, їхати, бігти", sub: "Базові пари дієслів руху — односпрямовані та різноспрямовані", status: "locked" },
-        { num: 36, slug: "motion-prefixes-arrival", title: "Прийти, доїхати", sub: "Префікси при- (прибуття) та до- (досягнення мети) з дієсловами руху", status: "locked" },
-        { num: 39, slug: "traveling-ukraine", title: "Подорож Україною", sub: "Подорожні розповіді — транспорт, маршрути, пам'ятки", status: "locked" },
-        { num: 37, slug: "motion-prefixes-departure", title: "Піти, від'їхати", sub: "Префікси пі-/по- (вирушання) та від- (віддалення) з дієсловами руху", status: "locked" },
-        { num: 38, slug: "motion-prefixes-in-out", title: "Зайти, вийти", sub: "Префікси за- (входження/забігання) та ви- (вихід) з дієсловами руху", status: "locked" },
-        { num: 41, slug: "motion-flight-swim", title: "Летіти, пливти", sub: "Дієслова руху в повітрі та на воді — з усіма префіксами", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.3 [Світ дієслів руху]",
-      items: [
-        { num: 40, slug: "motion-prefixes-transit", title: "Перейти, проїхати", sub: "Префікси пере- (перетинання) та про- (проїжджання повз) з дієсловами руху", status: "locked" },
-        { num: 42, slug: "figurative-motion", title: "Час іде, дощ іде", sub: "Переносне вживання дієслів руху в українській мові", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.4 [Порівняння та словотворення]",
-      items: [
-        { num: 44, slug: "adjectives-comparative", title: "Вищий ступінь прикметників", sub: "Проста та складена форми вищого ступеня порівняння", status: "done" },
+        { num: 44, slug: "adjectives-comparative", title: "Вищий ступінь прикметників", sub: "Проста та складена форми вищого ступеня порівняння", status: "active" },
         { num: 45, slug: "adjectives-superlative", title: "Найвищий ступінь прикметників", sub: "Проста та складена форми найвищого ступеня порівняння", status: "locked" },
         { num: 46, slug: "adverbs-comparison-formation", title: "Ступені порівняння та творення прислівників", sub: "Як прислівники утворюються і порівнюються в українській мові", status: "locked" },
         { num: 47, slug: "nature-and-environment", title: "Природа і довкілля", sub: "Погода, рослини, тварини, екологія — природа українською", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.4 [Ступені порівняння та словотвір]",
-      items: [
         { num: 48, slug: "word-formation-adjectives", title: "Творення прикметників", sub: "Як утворюються прикметники від іменників, дієслів і прикметників", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.4 [Comparison & Word Formation]",
-      items: [
         { num: 49, slug: "possessive-adjectives", title: "Присвійні прикметники", sub: "Батьків дім, материна мова, Шевченкова поезія — творення і вживання", status: "locked" },
         { num: 50, slug: "word-formation-nouns", title: "Творення назв осіб і місць", sub: "Суфікси для назв людей за діяльністю та назв приміщень і місць", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.4 [Порівняння та словотвір]",
-      items: [
         { num: 51, slug: "checkpoint-comparison", title: "Контрольна робота 4", sub: "Перевірка знань: ступені порівняння, словотвір, покупки і послуги", status: "locked" },
       ]
     },
     {
-      unit: "B1.7 [Складний синтаксис]",
+      unit: "M52-M64 · Cases, prepositions, and sentence parts",
       items: [
-        { num: 81, slug: "homogeneous-members", title: "Однорідні члени речення", sub: "Пунктуація, сполучники та узагальнювальне слово", status: "locked" },
-        { num: 74, slug: "complex-subordinate-object", title: "З'ясувальні речення", sub: "Підрядні речення з що, щоб, чи, хто, куди", status: "locked" },
-        { num: 75, slug: "complex-subordinate-relative", title: "Означальні речення", sub: "Підрядні з який/яка/яке у різних відмінках", status: "locked" },
-        { num: 76, slug: "complex-subordinate-time", title: "Часові речення", sub: "Одночасність і різночасність: коли, поки, доки, щойно", status: "locked" },
-        { num: 77, slug: "complex-subordinate-reason", title: "Речення причини", sub: "Чому? Бо, тому що, через те що, оскільки", status: "locked" },
-        { num: 78, slug: "complex-subordinate-condition", title: "Речення умови", sub: "Якщо, коли (=якщо), як: реальні умови у складному реченні", status: "locked" },
-        { num: 79, slug: "complex-subordinate-purpose", title: "Речення мети", sub: "Для чого? Щоб, для того щоб, аби", status: "locked" },
-        { num: 80, slug: "complex-subordinate-concess", title: "Речення допусту", sub: "Хоча, дарма що, незважаючи на те що", status: "locked" },
-        { num: 82, slug: "reported-speech", title: "Пряма і непряма мова", sub: "Передача чужого мовлення: пряма мова, непряма мова, діалог", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.5 [Нюанси відмінків та прийменники]",
-      items: [
-        { num: 52, slug: "genitive-nuances", title: "Родовий відмінок (деталі)", sub: "Розширені значення родового: частина від цілого, бажання, заперечення, дати", status: "locked" },
-        { num: 53, slug: "dative-nuances", title: "Давальний відмінок (деталі)", sub: "Суб'єкт стану, вік, потреба — розширені значення давального", status: "locked" },
+        { num: 52, slug: "homogeneous-members", title: "Однорідні члени речення", sub: "Пунктуація, сполучники та узагальнювальне слово", status: "locked" },
+        { num: 53, slug: "genitive-nuances", title: "Родовий відмінок (деталі)", sub: "Розширені значення родового: частина від цілого, бажання, заперечення, дати", status: "locked" },
+        { num: 54, slug: "dative-nuances", title: "Давальний відмінок (деталі)", sub: "Суб'єкт стану, вік, потреба — розширені значення давального", status: "locked" },
         { num: 55, slug: "education-and-university", title: "Освіта і навчання", sub: "Академічна лексика, дисципліни та дієприкметники в науковому стилі", status: "locked" },
-        { num: 54, slug: "instrumental-nuances", title: "Орудний відмінок (деталі)", sub: "Характеристика, професія, шлях, сумісність — розширені значення орудного", status: "locked" },
-        { num: 56, slug: "vocative-formal", title: "Кличний відмінок (офіційний)", sub: "Звертання у формальному, діловому та офіційному контексті", status: "locked" },
-        { num: 57, slug: "prepositions-temporal", title: "Часові прийменники", sub: "Через, за, на, перед, після, до — точне вираження часу", status: "locked" },
+        { num: 56, slug: "instrumental-nuances", title: "Орудний відмінок (деталі)", sub: "Характеристика, професія, шлях, сумісність — розширені значення орудного", status: "locked" },
+        { num: 57, slug: "vocative-formal", title: "Кличний відмінок (офіційний)", sub: "Звертання у формальному, діловому та офіційному контексті", status: "locked" },
+        { num: 58, slug: "prepositions-temporal", title: "Часові прийменники", sub: "Через, за, на, перед, після, до — точне вираження часу", status: "locked" },
         { num: 59, slug: "places-and-locations", title: "Місця і розташування", sub: "Географічна лексика, описи міст і країн, відмінки для місця та походження", status: "locked" },
-        { num: 58, slug: "prepositions-cause-purpose", title: "Причина і мета", sub: "Прийменники і конструкції для вираження причини та мети", status: "locked" },
-        { num: 60, slug: "cases-with-ordinal-numerals", title: "Порядкові числівники і відмінки", sub: "Відмінювання порядкових числівників, дати, час, поверхи", status: "locked" },
-        { num: 61, slug: "cases-with-quantity-expressions", title: "Кількісні вирази", sub: "Узгодження числівників з іменниками та неозначено-кількісні слова", status: "locked" },
-        { num: 63, slug: "checkpoint-cases", title: "Контрольна робота 5", sub: "Перевірка знань: розширені відмінки, прийменники, числівники, займенники, житло", status: "locked" },
+        { num: 60, slug: "prepositions-cause-purpose", title: "Причина і мета", sub: "Прийменники і конструкції для вираження причини та мети", status: "locked" },
+        { num: 61, slug: "cases-with-ordinal-numerals", title: "Порядкові числівники і відмінки", sub: "Відмінювання порядкових числівників, дати, час, поверхи", status: "locked" },
+        { num: 62, slug: "cases-with-quantity-expressions", title: "Кількісні вирази", sub: "Узгодження числівників з іменниками та неозначено-кількісні слова", status: "locked" },
+        { num: 63, slug: "advanced-pronouns", title: "Займенники (деталі)", sub: "Питально-відносні, зворотний себе, неозначені та заперечні займенники", status: "locked" },
+        { num: 64, slug: "checkpoint-cases", title: "Контрольна робота 5", sub: "Перевірка знань: розширені відмінки, прийменники, числівники, займенники, житло", status: "locked" },
       ]
     },
     {
-      unit: "B1.5 [Нюанси відмінків і прийменники]",
+      unit: "M65-M74 · Participles, gerunds, and media",
       items: [
-        { num: 62, slug: "advanced-pronouns", title: "Займенники (деталі)", sub: "Питально-відносні, зворотний себе, неозначені та заперечні займенники", status: "locked" },
+        { num: 65, slug: "participles-active", title: "Активні дієприкметники", sub: "Ознака за дією, яку виконує сам предмет", status: "locked" },
+        { num: 66, slug: "participles-passive", title: "Пасивні дієприкметники", sub: "Ознака за дією, якої зазнає предмет", status: "locked" },
+        { num: 67, slug: "participle-phrases", title: "Дієприкметниковий зворот", sub: "Дієприкметник із залежними словами та правила відокремлення", status: "locked" },
+        { num: 68, slug: "leisure-culture-festivals", title: "Дозвілля, культура і свята", sub: "Вільний час, мистецтво, традиції та святкування", status: "locked" },
+        { num: 69, slug: "short-form-adjectives", title: "Короткі прикметники (зелен, потрібен)", sub: "Повні та короткі форми якісних прикметників", status: "locked" },
+        { num: 70, slug: "gerunds-imperfective", title: "Дієприслівники недоконаного виду", sub: "Додаткова дія, одночасна з основною: читаючи, слухаючи", status: "locked" },
+        { num: 71, slug: "gerunds-perfective", title: "Дієприслівники доконаного виду", sub: "Попередня дія: прочитавши, дізнавшись, повернувшись", status: "locked" },
+        { num: 72, slug: "gerund-phrases", title: "Дієприслівниковий зворот", sub: "Дієприслівник із залежними словами: відокремлення та стилістика", status: "locked" },
+        { num: 73, slug: "society-and-media", title: "Суспільство і медіа", sub: "Новини, ЗМІ, суспільне життя — розуміємо та обговорюємо", status: "locked" },
+        { num: 74, slug: "checkpoint-participles", title: "Контрольна робота 6", sub: "Перевірка знань: дієприкметники, короткі прикметники, дієприслівники, освіта", status: "locked" },
       ]
     },
     {
-      unit: "B1.6 [Дієприкметники та дієприслівники]",
+      unit: "M75-M84 · Complex syntax",
       items: [
-        { num: 64, slug: "participles-active", title: "Активні дієприкметники", sub: "Ознака за дією, яку виконує сам предмет", status: "locked" },
-        { num: 66, slug: "participle-phrases", title: "Дієприкметниковий зворот", sub: "Дієприкметник із залежними словами та правила відокремлення", status: "locked" },
-        { num: 67, slug: "leisure-culture-festivals", title: "Дозвілля, культура і свята", sub: "Вільний час, мистецтво, традиції та святкування", status: "locked" },
-        { num: 69, slug: "gerunds-imperfective", title: "Дієприслівники недоконаного виду", sub: "Додаткова дія, одночасна з основною: читаючи, слухаючи", status: "locked" },
-        { num: 70, slug: "gerunds-perfective", title: "Дієприслівники доконаного виду", sub: "Попередня дія: прочитавши, дізнавшись, повернувшись", status: "locked" },
-        { num: 59, slug: "gerund-phrases", title: "Дієприслівниковий зворот", sub: "Дієприслівник із залежними словами: відокремлення та стилістика", status: "locked" },
-        { num: 71, slug: "society-and-media", title: "Суспільство і медіа", sub: "Новини, ЗМІ, суспільне життя — розуміємо та обговорюємо", status: "locked" },
-        { num: 72, slug: "checkpoint-participles", title: "Контрольна робота 6", sub: "Перевірка знань: дієприкметники, короткі прикметники, дієприслівники, освіта", status: "locked" },
+        { num: 75, slug: "complex-compound", title: "Складносурядне речення", sub: "Єднальні, протиставні та розділові сполучники", status: "locked" },
+        { num: 76, slug: "complex-subordinate-object", title: "З'ясувальні речення", sub: "Підрядні речення з що, щоб, чи, хто, куди", status: "locked" },
+        { num: 77, slug: "complex-subordinate-relative", title: "Означальні речення", sub: "Підрядні з який/яка/яке у різних відмінках", status: "locked" },
+        { num: 78, slug: "complex-subordinate-time", title: "Часові речення", sub: "Одночасність і різночасність: коли, поки, доки, щойно", status: "locked" },
+        { num: 79, slug: "complex-subordinate-reason", title: "Речення причини", sub: "Чому? Бо, тому що, через те що, оскільки", status: "locked" },
+        { num: 80, slug: "complex-subordinate-condition", title: "Речення умови", sub: "Якщо, коли (=якщо), як: реальні умови у складному реченні", status: "locked" },
+        { num: 81, slug: "complex-subordinate-purpose", title: "Речення мети", sub: "Для чого? Щоб, для того щоб, аби", status: "locked" },
+        { num: 82, slug: "complex-subordinate-concess", title: "Речення допусту", sub: "Хоча, дарма що, незважаючи на те що", status: "locked" },
+        { num: 83, slug: "reported-speech", title: "Пряма і непряма мова", sub: "Передача чужого мовлення: пряма мова, непряма мова, діалог", status: "locked" },
+        { num: 84, slug: "checkpoint-syntax", title: "Контрольна робота 7", sub: "Перевірка знань: складні речення, пряма і непряма мова, дозвілля і культура", status: "locked" },
       ]
     },
     {
-      unit: "B1.6 [Participles & Gerunds]",
+      unit: "M85-M94 · Register, narrative, and B1 review",
       items: [
-        { num: 65, slug: "participles-passive", title: "Пасивні дієприкметники", sub: "Ознака за дією, якої зазнає предмет", status: "locked" },
-        { num: 68, slug: "short-form-adjectives", title: "Короткі прикметники (зелен, потрібен)", sub: "Повні та короткі форми якісних прикметників", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.7 [Синтаксис складного речення]",
-      items: [
-        { num: 73, slug: "complex-compound", title: "Складносурядне речення", sub: "Єднальні, протиставні та розділові сполучники", status: "locked" },
-        { num: 83, slug: "checkpoint-syntax", title: "Контрольна робота 7", sub: "Перевірка знань: складні речення, пряма і непряма мова, дозвілля і культура", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.8 [Текст і регістр]",
-      items: [
-        { num: 84, slug: "text-register-formal", title: "Офіційний стиль", sub: "Офіційно-діловий стиль мовлення: документи, заяви, ділове листування", status: "locked" },
-        { num: 85, slug: "text-register-informal", title: "Розмовний стиль", sub: "Розмовне мовлення: побутова мова, діалоги, емоційна лексика", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.8 [Text & Register]",
-      items: [
-        { num: 86, slug: "text-compression", title: "Абревіатури та скорочення", sub: "Складноскорочені слова, абревіатури, графічні скорочення", status: "locked" },
-        { num: 87, slug: "reading-literature", title: "Читання художніх текстів", sub: "Художній стиль мовлення — від уривків до розуміння літератури", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.8 [Текст та регістр]",
-      items: [
-        { num: 88, slug: "introductory-words", title: "Вставні слова та Однорідні члени речення", sub: "Мабуть, можливо, здається, на жаль — слова, що виражають ставлення мовця", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.8 [Текст і стиль]",
-      items: [
-        { num: 89, slug: "checkpoint-text-register", title: "Контрольна робота 8", sub: "Перевірка знань: стилі мовлення, заперечення, вставні слова, природа, читання", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.9 [Синтез та випуск]",
-      items: [
-        { num: 90, slug: "narrative-mastery", title: "Мистецтво розповіді", sub: "Поєднання часів, видів, рухових дієслів і дієприкметників у текстах", status: "locked" },
-        { num: 93, slug: "practice-exam", title: "Пробний екзамен B1", sub: "Інтегрований екзамен: читання, аудіювання, письмо, говоріння", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.9 [Синтез і випуск]",
-      items: [
-        { num: 91, slug: "debate-and-opinion", title: "Аргументація", sub: "Теза, аргументи, дискусія — переконуємо українською", status: "locked" },
-      ]
-    },
-    {
-      unit: "B1.9 [Синтез та завершення]",
-      items: [
-        { num: 92, slug: "comprehensive-b1-review", title: "Загальне повторення B1", sub: "Від фонетики до аргументації — повний огляд граматики B1", status: "locked" },
+        { num: 85, slug: "text-register-formal", title: "Офіційний стиль", sub: "Офіційно-діловий стиль мовлення: документи, заяви, ділове листування", status: "locked" },
+        { num: 86, slug: "text-register-informal", title: "Розмовний стиль", sub: "Розмовне мовлення: побутова мова, діалоги, емоційна лексика", status: "locked" },
+        { num: 87, slug: "text-compression", title: "Абревіатури та скорочення", sub: "Складноскорочені слова, абревіатури, графічні скорочення", status: "locked" },
+        { num: 88, slug: "reading-literature", title: "Читання художніх текстів", sub: "Художній стиль мовлення — від уривків до розуміння літератури", status: "locked" },
+        { num: 89, slug: "introductory-words", title: "Вставні слова та Однорідні члени речення", sub: "Мабуть, можливо, здається, на жаль — слова, що виражають ставлення мовця", status: "locked" },
+        { num: 90, slug: "checkpoint-text-register", title: "Контрольна робота 8", sub: "Перевірка знань: стилі мовлення, заперечення, вставні слова, природа, читання", status: "locked" },
+        { num: 91, slug: "narrative-mastery", title: "Мистецтво розповіді", sub: "Поєднання часів, видів, рухових дієслів і дієприкметників у текстах", status: "locked" },
+        { num: 92, slug: "debate-and-opinion", title: "Аргументація", sub: "Теза, аргументи, дискусія — переконуємо українською", status: "locked" },
+        { num: 93, slug: "comprehensive-b1-review", title: "Загальне повторення B1", sub: "Від фонетики до аргументації — повний огляд граматики B1", status: "locked" },
+        { num: 94, slug: "practice-exam", title: "Пробний екзамен B1", sub: "Інтегрований екзамен: читання, аудіювання, письмо, говоріння", status: "locked" },
       ]
     },
   ]}

--- a/tests/audit/test_check_mdx_source_parity.py
+++ b/tests/audit/test_check_mdx_source_parity.py
@@ -31,6 +31,15 @@ def test_check_parity_mdx_only(mock_legacy_levels, mock_subprocess):
     assert len(violations) == 1
     assert "MDX file changed but no source files changed" in violations[0][1]
 
+def test_check_parity_level_landing_page(mock_legacy_levels, mock_subprocess):
+    # Level landing pages are generated indexes, not lesson MDX artifacts.
+    mdx_files = [MDX_DIR / "b1" / "index.mdx"]
+    changed_files = {MDX_DIR / "b1" / "index.mdx"}
+    mock_subprocess.return_value = "1 file changed\n" # Not whitespace-only
+
+    violations = check_parity(mdx_files, changed_files)
+    assert len(violations) == 0
+
 def test_check_parity_mdx_and_source(mock_legacy_levels, mock_subprocess):
     # MDX + source diff (pass)
     mdx_files = [MDX_DIR / "a1" / "01-hello.mdx"]


### PR DESCRIPTION
## Summary

- Regenerates the B1 landing page in exact `curriculum.yaml` order, M01-M94.
- Replaces raw/stale plan `phase` groupings with nine canonical B1 unit headings.
- Makes B1 landing status truthful: 1 learner page available, 0 reviewed, 93 planned.
- Keeps only M44 (`adjectives-comparative`) linked because it is the only deployed B1 learner page.
- Narrows the MDX source-parity hook so generated level landing pages (`<level>/index.mdx`) are not treated as lesson MDX; lesson MDX parity remains enforced.

## Stack

Stacked on #2536 / `codex/b1-source-order-cleanup-2026-06-01`.

Fixes #2531.

## Validation

- `.venv/bin/python scripts/generate_landing_pages.py --track b1`
- Generated B1 MDX check: 94 modules, exact 1-94 order, 9 units, statuses `done=0 active=1 locked=93`
- `.venv/bin/python -m py_compile scripts/generate_landing_pages.py`
- `.venv/bin/python -m pytest tests/audit/test_check_mdx_source_parity.py`
- `git diff --check`
- Forbidden-file diff check for `.python-version`, `.yamllint`, `.markdownlint.json`, `status/*.json`, `audit/*-review.md`, `review/*-review.md`
- `npm run build:starlight` (37,986 pages built)
- Built static page served from `starlight/dist` and inspected in the in-app browser at `/b1/`: exact 94-card order, 9 canonical units, truthful build status, M44 link present

## Notes

A desktop-width Playwright check was not run because the local Playwright browser binary is not installed in this worktree. The in-app browser was at narrow/mobile width; the full Starlight build and static page inspection passed.
