### PR TITLE
feat(validate): seminar-quality language linter for plan YAMLs (#2535)

### DIFF
--- a/docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -67,7 +67,7 @@ in flight. Next bio work = NEXT ACTIONS #1 (landing page 180→310) + #3 (pre-re
 `scripts/wiki/sources.py::list_discovery_slugs` reconciles instead of short-circuiting; hermetic regression
 test added; wiki suite 75 passed. **Keystone NEXT ACTIONS #3 ALSO DONE — seminar-quality pre-review linter
 SHIPPED** (`scripts/validate/lint_seminar_quality.py`, branch `bio/seminar-quality-linter`, 21 tests; triage =
-4 HIGH + 1 advisory, all in the new 181–310 plans, zero false positives — see NEXT ACTIONS #3 for the list).
+4 HIGH + 2 advisory, all in the new 181–310 plans, zero false positives — see NEXT ACTIONS #3 for the list).
 NEXT ACTION on resume = (a) fix the 5 linter findings in a small DeepSeek-cross-reviewed content PR, then
 promote the linter to a BLOCKING CI gate; (b) run the Phase-4 discovery pipeline for 181..310, then the CLAUDE
 wiki writer fleet (DeepSeek cross-review). 0 dispatches in flight.** *
@@ -219,14 +219,15 @@ the merged plans; NOT deleted (#M-10 — never destroy unmerged work without the
    `validate_plan_ordering.py`). Precision-first: HIGH = gating set, advisory = review-list, **systemic rules
    collapse** to one line (the «Дебат N:» template = 540 hits / 190 plans). Run:
    `.venv/bin/python scripts/validate/lint_seminar_quality.py --track bio [--severity high] [--json]`.
-   **TRIAGE on origin/main (all VESUM/context-verified, zero false positives):** 4 HIGH + 1 advisory, ALL in the
+   **TRIAGE on origin/main (all VESUM/context-verified, zero false positives):** 4 HIGH + 2 advisory, ALL in the
    NEW 181–310 plans (original 180 clean of these classes):
    `viktor-domontovych` (bio-211) «LIT-модулі» · `myroslav-irchan` (bio-190) «L2-студентам» ·
    `antin-krushelnytskyi` (bio-191) «hindsight-осуду» · `vasyl-barvinskyi` (bio-290) «Арест»→Арешт ·
-   `kateryna-zarytska` (bio-284) prison-sense «термін»→строк (advisory). **NEXT: fix these 5 in a small
-   cross-reviewed (DeepSeek) content PR, then this linter can be promoted to a BLOCKING CI gate (currently
-   manual/pre-review only — it would redden main until the 5 are fixed).** The «Дебат» singular systemic finding
-   is a separate template/stylistic call for the orchestrator.
+   `kateryna-zarytska` (bio-284) prison-sense «термін»→строк (advisory) · `vasyl-barka` «властями»→владою/органами
+   влади (advisory). **NEXT: fix these 6 in a small cross-reviewed (DeepSeek) content PR, then this linter can be
+   promoted to a BLOCKING CI gate (currently manual/pre-review only — it would redden main until they are fixed).**
+   The «Дебат» singular systemic finding is a separate template/stylistic call for the orchestrator. (PR-2539
+   review by gemini added recall for prefixed «заарестовано» + власть-plurals — adopted after FP-verification.)
 4. **Phase 4 — WIKI ARTICLES (writer-fleet job, ~130 articles for bio-181..310, ~285K words):**
    Pipeline = `scripts/wiki/compile.py --track bio --slug <slug> --writer claude [--review]`
    (writer options are only `{gemini, claude, gpt-5.5}`; gpt-5.5=codex=PAUSED; **use `--writer claude`** —

--- a/docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -65,9 +65,12 @@ in flight. Next bio work = NEXT ACTIONS #1 (landing page 180→310) + #3 (pre-re
 **UPDATE (2026-06-01, session 3): Phase-4 PREREQUISITE DONE — wiki discovery bug fixed (branch
 `bio/fix-wiki-discovery`, this PR): `compile.py --track bio --list` now surfaces all 310 (was 180);
 `scripts/wiki/sources.py::list_discovery_slugs` reconciles instead of short-circuiting; hermetic regression
-test added; wiki suite 75 passed. NEXT ACTION on resume = run the Phase-4 discovery pipeline for 181..310,
-then the CLAUDE wiki writer fleet (DeepSeek cross-review). Remaining keystone NEXT ACTIONS #3 (seminar-quality
-pre-review linter for #2535) still open. 0 dispatches in flight.** *
+test added; wiki suite 75 passed. **Keystone NEXT ACTIONS #3 ALSO DONE — seminar-quality pre-review linter
+SHIPPED** (`scripts/validate/lint_seminar_quality.py`, branch `bio/seminar-quality-linter`, 21 tests; triage =
+4 HIGH + 1 advisory, all in the new 181–310 plans, zero false positives — see NEXT ACTIONS #3 for the list).
+NEXT ACTION on resume = (a) fix the 5 linter findings in a small DeepSeek-cross-reviewed content PR, then
+promote the linter to a BLOCKING CI gate; (b) run the Phase-4 discovery pipeline for 181..310, then the CLAUDE
+wiki writer fleet (DeepSeek cross-review). 0 dispatches in flight.** *
 
 ## ▶ CURRENT STATE (2026-06-01)
 - **SESSION 2 (later, 2026-06-01) shipped:** #2513 fully closed (9 Kulish-dup rebuilds, all DeepSeek
@@ -207,9 +210,23 @@ the merged plans; NOT deleted (#M-10 — never destroy unmerged work without the
      UA content — `LIT-модулі` (domontovych), `L2-студентам` (myroslav-irchan), `hindsight-осуду`
      (antin-krushelnytskyi). NOTE: intentional Latin (`X-променів`, `STEM`, `IEU`, `Ems`, URLs) is FINE — do
      NOT "fix" those.
-3. **Deterministic pre-review linter** (`scripts/validate/...`): russianism/calque list (арест, постум,
-   коерція, голодовка, інакомисляч, місцеві власті, термін-for-sentence) + mixed Latin-in-Cyrillic
-   (excluding URLs) + `Дебат` singular. Run BEFORE Gemini to cut review rounds and catch the defects above.
+3. **✅ Deterministic pre-review linter — SHIPPED** (`scripts/validate/lint_seminar_quality.py`, branch
+   `bio/seminar-quality-linter`, this PR; 21 hermetic tests). Covers russianism/calque list (арешт-not-арест,
+   посмертно-not-постум, коерція, голодовка, інакомисляч [person-form only — `інакомислення` is VESUM-codified,
+   NOT flagged], власті, prison-sense термін via imprisonment collocation) + Latin-in-Cyrillic (homoglyph
+   intra-word AND lazy abbreviations like LIT-/L2-/hindsight-, allowlisting X-променів/STEM/IEU/Ems/Roman
+   numerals/URLs) + `Дебат` singular. NOT a ghost-`connects_to` check (already covered by
+   `validate_plan_ordering.py`). Precision-first: HIGH = gating set, advisory = review-list, **systemic rules
+   collapse** to one line (the «Дебат N:» template = 540 hits / 190 plans). Run:
+   `.venv/bin/python scripts/validate/lint_seminar_quality.py --track bio [--severity high] [--json]`.
+   **TRIAGE on origin/main (all VESUM/context-verified, zero false positives):** 4 HIGH + 1 advisory, ALL in the
+   NEW 181–310 plans (original 180 clean of these classes):
+   `viktor-domontovych` (bio-211) «LIT-модулі» · `myroslav-irchan` (bio-190) «L2-студентам» ·
+   `antin-krushelnytskyi` (bio-191) «hindsight-осуду» · `vasyl-barvinskyi` (bio-290) «Арест»→Арешт ·
+   `kateryna-zarytska` (bio-284) prison-sense «термін»→строк (advisory). **NEXT: fix these 5 in a small
+   cross-reviewed (DeepSeek) content PR, then this linter can be promoted to a BLOCKING CI gate (currently
+   manual/pre-review only — it would redden main until the 5 are fixed).** The «Дебат» singular systemic finding
+   is a separate template/stylistic call for the orchestrator.
 4. **Phase 4 — WIKI ARTICLES (writer-fleet job, ~130 articles for bio-181..310, ~285K words):**
    Pipeline = `scripts/wiki/compile.py --track bio --slug <slug> --writer claude [--review]`
    (writer options are only `{gemini, claude, gpt-5.5}`; gpt-5.5=codex=PAUSED; **use `--writer claude`** —

--- a/scripts/validate/lint_seminar_quality.py
+++ b/scripts/validate/lint_seminar_quality.py
@@ -72,11 +72,14 @@ LATIN = "A-Za-z"
 _UK_LETTER = rf"[{CYRILLIC}'ʼ’]"  # Cyrillic + apostrophe variants
 
 
-def _boundary(stem: str, *, suffix: str = rf"{_UK_LETTER}*") -> re.Pattern[str]:
+def _boundary(stem: str, *, suffix: str = rf"{_UK_LETTER}*", prefix: str = "") -> re.Pattern[str]:
     """Whole-word Cyrillic matcher: ``stem`` not glued to another UK letter on
-    the left, optionally followed by an inflectional suffix on the right."""
+    the left, optionally preceded by ``prefix`` (e.g. ``(?:за|пере)?`` for
+    prefixed russianisms like ``заарестовано``) and followed by an inflectional
+    ``suffix`` on the right. The left-boundary lookbehind sits before the prefix,
+    so ``парестезія`` (preceded by «п», prefix not «за/пере») stays unmatched."""
     return re.compile(
-        rf"(?<!{_UK_LETTER})({stem}{suffix})(?!{_UK_LETTER})",
+        rf"(?<!{_UK_LETTER})({prefix}{stem}{suffix})(?!{_UK_LETTER})",
         re.IGNORECASE,
     )
 
@@ -95,8 +98,8 @@ class Rule:
 
 # ── Curated russianism / calque rules (high precision, proven defects) ────────
 RUSSIANISMS: tuple[Rule, ...] = (
-    Rule("арест", _boundary("арест"), "арешт / заарешт-",
-         "high", "«арест» is a Russianism; Ukrainian is «арешт» (#2528)."),
+    Rule("арест", _boundary("арест", prefix="(?:за|пере)?"), "арешт / заарешт-",
+         "high", "«арест»/«заарестовано» is a Russianism; Ukrainian is «арешт»/«заарештовано» (#2528)."),
     Rule("постум", _boundary("постум"), "посмертно / посмертний",
          "high", "«постумно/постумний» is a Latinism-via-Russian; use «посмертно» (#2528)."),
     Rule("коерція", _boundary("коерц"), "примус",
@@ -107,8 +110,9 @@ RUSSIANISMS: tuple[Rule, ...] = (
          "use «інакодумець»/«дисидент». NB «інакомислення» (abstract noun) is VESUM-codified — do NOT flag it."),
     Rule("голодовка", _boundary("голодовк"), "голодування",
          "advisory", "«голодовка» (hunger strike) is a Russianism; prefer «голодування»."),
-    Rule("власті", _boundary("власт", suffix="і"), "влада / органи влади",
-         "advisory", "«власті» (plural) is a Russianism; Ukrainian uses «влада»/«органи влади»."),
+    Rule("власті", _boundary("власт", suffix="(?:і|ей|ям|ями|ях)"), "влада / органи влади",
+         "advisory", "«власті/властей/властями» (Russian plural of «власть») is a Russianism; "
+         "Ukrainian uses «влада»/«органи влади». (Suffix-gated, so «властивість/властивий» are safe.)"),
     # Prison-sense «термін» → «строк»: ONLY in an imprisonment collocation.
     Rule("термін_строк", _boundary("термін", suffix=rf"{_UK_LETTER}*"),
          "строк (про ув'язнення)", "advisory",

--- a/scripts/validate/lint_seminar_quality.py
+++ b/scripts/validate/lint_seminar_quality.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Deterministic seminar-quality language linter for curriculum plan YAMLs.
+
+Seminar tracks (bio/hist/lit/istorio/oes/ruth) are *source-first* and stricter
+than core language lessons. Two language-quality defect classes recur in the
+plan corpus and are NOT caught by any existing validator
+(``validate_plan_config.py`` = word targets / key sets;
+``validate_plan_ordering.py`` = ``connects_to`` / ordering):
+
+1. **Russianisms / calques** — e.g. ``арест`` (→ ``арешт``), ``постумно``
+   (→ ``посмертно``), ``коерція`` (→ ``примус``), ``інакомисляч``
+   (→ ``інакодумець``), ``власті`` (→ ``влада``), prison-sense ``термін``
+   (→ ``строк``), singular ``дебат`` (→ ``дебати``). Proven defects: #2528.
+
+2. **Latin-in-Cyrillic** — homoglyph substitutions inside a single word
+   (``Cлово``, ``мистецтвoм``, ``Оспiщев``) and lazy Latin abbreviations glued
+   to Cyrillic prose (``LIT-модулі``, ``L2-студентам``, ``hindsight-осуду``).
+   Legitimate Latin (``X-променів``, ``STEM``, ``IEU``, ``Ems``, URLs) is
+   allowlisted and NOT flagged.
+
+This is a **precision-first pre-review filter**: it runs BEFORE the cross-family
+content review to cut review rounds and catch mechanical defects deterministically.
+Recall is intentionally bounded — the curated russianism list covers
+high-confidence forms only; the cross-review handles the long tail. New
+legitimate Latin tokens go in ``LATIN_ALLOWLIST``; new proven russianisms go in
+``RUSSIANISMS``.
+
+Use
+===
+    .venv/bin/python scripts/validate/lint_seminar_quality.py                 # all bio plans
+    .venv/bin/python scripts/validate/lint_seminar_quality.py --track bio --json
+    .venv/bin/python scripts/validate/lint_seminar_quality.py --paths curriculum/l2-uk-en/plans/bio/viktor-domontovych.yaml
+    .venv/bin/python scripts/validate/lint_seminar_quality.py --severity high  # gate on HIGH only
+
+Exit codes
+==========
+- 0 — no findings at or above the selected ``--severity`` (default: any).
+- 1 — at least one finding at or above the selected severity.
+
+Related
+=======
+- Issue #2535 — audit + uplift existing 1-180 plans/wikis to the seminar standard.
+- #2528 — the VESUM-verified постум/арест/Latin-homoglyph cleanup this codifies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PLANS_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans"
+
+# Plan keys whose string values are identifiers / citation metadata, NOT prose.
+# We never scan these: they legitimately carry ASCII slugs, module ids, and URLs.
+SKIP_KEYS = frozenset({
+    "slug", "module", "level", "cefr_min", "cefr_max", "track", "id",
+    "connects_to", "prerequisites", "references", "sources", "source",
+    "path", "url", "href", "link", "image", "images", "status",
+    "vocabulary_hints",  # word-level; checked by vocab validators, often bare lemmas
+})
+
+CYRILLIC = "Ѐ-ӿ"
+LATIN = "A-Za-z"
+_UK_LETTER = rf"[{CYRILLIC}'ʼ’]"  # Cyrillic + apostrophe variants
+
+
+def _boundary(stem: str, *, suffix: str = rf"{_UK_LETTER}*") -> re.Pattern[str]:
+    """Whole-word Cyrillic matcher: ``stem`` not glued to another UK letter on
+    the left, optionally followed by an inflectional suffix on the right."""
+    return re.compile(
+        rf"(?<!{_UK_LETTER})({stem}{suffix})(?!{_UK_LETTER})",
+        re.IGNORECASE,
+    )
+
+
+@dataclass(frozen=True)
+class Rule:
+    key: str
+    pattern: re.Pattern[str]
+    suggestion: str
+    severity: str  # "high" | "advisory"
+    note: str
+    # Optional: only fire when one of these context stems appears within the
+    # same string value (for context-dependent calques like prison-sense термін).
+    requires_context: tuple[str, ...] = ()
+
+
+# ── Curated russianism / calque rules (high precision, proven defects) ────────
+RUSSIANISMS: tuple[Rule, ...] = (
+    Rule("арест", _boundary("арест"), "арешт / заарешт-",
+         "high", "«арест» is a Russianism; Ukrainian is «арешт» (#2528)."),
+    Rule("постум", _boundary("постум"), "посмертно / посмертний",
+         "high", "«постумно/постумний» is a Latinism-via-Russian; use «посмертно» (#2528)."),
+    Rule("коерція", _boundary("коерц"), "примус",
+         "advisory", "«коерція» (coercion) is a calque; use «примус»."),
+    Rule("інакомисляч", _boundary("інакомисляч"), "інакодумець / дисидент",
+         "advisory",
+         "Person-form «інакомисляч(ий)» is a non-standard calque (NOT in VESUM, russian_shadow≈0.5); "
+         "use «інакодумець»/«дисидент». NB «інакомислення» (abstract noun) is VESUM-codified — do NOT flag it."),
+    Rule("голодовка", _boundary("голодовк"), "голодування",
+         "advisory", "«голодовка» (hunger strike) is a Russianism; prefer «голодування»."),
+    Rule("власті", _boundary("власт", suffix="і"), "влада / органи влади",
+         "advisory", "«власті» (plural) is a Russianism; Ukrainian uses «влада»/«органи влади»."),
+    # Prison-sense «термін» → «строк»: ONLY in an imprisonment collocation.
+    Rule("термін_строк", _boundary("термін", suffix=rf"{_UK_LETTER}*"),
+         "строк (про ув'язнення)", "advisory",
+         "Prison-sense «термін» should be «строк» (#2528); «термін» = deadline/terminology is fine.",
+         requires_context=("ув'язн", "увʼязн", "покаранн", "тюрм", "відсид", "табор", "заслан")),
+    # Singular «дебат» → pluralia tantum «дебати».
+    Rule("дебат_sing", re.compile(
+        rf"(?<!{_UK_LETTER})([Дд]ебат(?:у|ом|і)?)(?!{_UK_LETTER}|и)", ),
+         "дебати", "advisory",
+         "«дебати» is pluralia tantum in Ukrainian; singular «дебат» is a Russianism."),
+)
+
+# ── Latin-in-Cyrillic ────────────────────────────────────────────────────────
+# Legitimate Latin tokens that may appear glued to Cyrillic with a hyphen, or
+# standalone, inside Ukrainian prose. Matched case-sensitively as whole tokens.
+LATIN_ALLOWLIST = frozenset({
+    "X", "Y",                      # X-променів, осі X/Y
+    "STEM", "STEAM",
+    "IEU", "ESU", "EU", "USA", "UA", "USSR", "URSR", "OUN", "UPA", "KGB", "NKVD",
+    "Ems",                         # Ems Ukaz (proper noun)
+    "DNA", "RNA", "PhD", "MA", "BA", "CV",
+})
+# Roman numerals (XIX-столітні, XX-го, XVIII ст.) are legitimate notation.
+_ROMAN_RE = re.compile(r"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$")
+
+# A whitespace token is a URL/citation if it looks like one — never script-mix-flag it.
+_URL_RE = re.compile(r"(https?://|www\.|\w+\.(?:org|com|net|ua|gov|edu)\b|wikipedia|@)", re.IGNORECASE)
+
+_HAS_CYR = re.compile(rf"[{CYRILLIC}]")
+_HAS_LAT = re.compile(rf"[{LATIN}]")
+# A "word token": runs of letters/digits/hyphens/apostrophes (handles LIT-модулі).
+_WORD_RE = re.compile(rf"[{LATIN}{CYRILLIC}0-9'’ʼ\-]+")
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: str
+    field: str
+    rule: str
+    severity: str
+    text: str
+    suggestion: str
+    note: str
+    context: str
+
+
+def _latin_run_allowed(run: str) -> bool:
+    """Is a pure-Latin sub-token a legitimate (allowlisted) term?"""
+    bare = run.strip("-'’ʼ")
+    return (
+        not bare
+        or bare in LATIN_ALLOWLIST
+        or (len(bare) == 1 and bare.isupper())   # single-letter notation: X-, Y-
+        or bool(_ROMAN_RE.match(bare))           # roman numerals: XIX-, XVIII
+    )
+
+
+# Latin letter directly touching a Cyrillic letter (no separator) = homoglyph.
+_ADJ_MIX = re.compile(rf"[{LATIN}][{CYRILLIC}]|[{CYRILLIC}][{LATIN}]")
+
+
+def _scan_latin_in_cyrillic(value: str) -> list[tuple[str, str, str]]:
+    """Return (matched_token, severity, note) for script-mixing defects.
+
+    Two sub-patterns, distinguished by whether the scripts touch directly:
+      * **intra-word homoglyph** — a Latin letter sits *directly* next to a
+        Cyrillic letter (``Cлово``, ``мистецтвoм``, ``Оспiщев``). Always a defect;
+        the single-letter / acronym allowlist does NOT apply, because a lone
+        ``C`` glued inside a Cyrillic word is a homoglyph, not notation.
+      * **hyphen-joined Latin abbreviation** — Latin and Cyrillic meet only
+        across a hyphen (``LIT-модулі``, ``L2-студентам``, ``hindsight-осуду``);
+        flagged unless every Latin run is allowlisted notation (``X-променів``,
+        ``STEM-``, ``XIX-``).
+    URLs / citation tokens are skipped.
+    """
+    out: list[tuple[str, str, str]] = []
+    for token in _WORD_RE.findall(value):
+        if not (_HAS_CYR.search(token) and _HAS_LAT.search(token)):
+            continue
+        if _URL_RE.search(token):
+            continue
+        if _ADJ_MIX.search(token):
+            out.append((token, "high",
+                        "Latin/Cyrillic homoglyph inside one word (script mix); "
+                        "retype in pure Cyrillic (#2528)."))
+            continue
+        # Scripts meet only across hyphens: accept iff every Latin run is allowlisted.
+        latin_runs = re.findall(rf"[{LATIN}0-9]+", token)
+        if latin_runs and all(_latin_run_allowed(r) for r in latin_runs):
+            continue
+        out.append((token, "high",
+                    "Latin abbreviation glued to Cyrillic prose; spell it out in Ukrainian "
+                    "(e.g. LIT-модулі → «літературні модулі», L2 → «друга мова»)."))
+    return out
+
+
+def _iter_prose(node, *, key: str | None = None, path: str = ""):
+    """Yield (field_path, string_value) for prose-bearing leaves, skipping
+    identifier / citation keys."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k in SKIP_KEYS:
+                continue
+            yield from _iter_prose(v, key=k, path=f"{path}.{k}" if path else str(k))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _iter_prose(v, key=key, path=f"{path}[{i}]")
+    elif isinstance(node, str) and _HAS_CYR.search(node):
+        yield path, node
+
+
+def _excerpt(value: str, match: str) -> str:
+    idx = value.find(match)
+    if idx < 0:
+        return value[:80]
+    start, end = max(0, idx - 30), min(len(value), idx + len(match) + 30)
+    return ("…" if start else "") + value[start:end].replace("\n", " ") + ("…" if end < len(value) else "")
+
+
+def lint_plan(path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    try:
+        data = yaml.safe_load(path.read_text("utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - surfaced as a finding
+        return [Finding(str(path), "<yaml>", "unparseable", "high",
+                        str(exc)[:120], "", "Plan YAML failed to parse.", "")]
+    if not isinstance(data, dict):
+        return findings
+    try:
+        rel = str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        rel = str(path)
+
+    for field, value in _iter_prose(data):
+        # Russianism / calque rules.
+        for rule in RUSSIANISMS:
+            if rule.requires_context and not any(c in value for c in rule.requires_context):
+                continue
+            m = rule.pattern.search(value)
+            if m:
+                hit = m.group(1)
+                findings.append(Finding(rel, field, rule.key, rule.severity, hit,
+                                        rule.suggestion, rule.note, _excerpt(value, hit)))
+        # Latin-in-Cyrillic.
+        for token, sev, note in _scan_latin_in_cyrillic(value):
+            findings.append(Finding(rel, field, "latin_in_cyrillic", sev, token,
+                                    "pure Cyrillic / spell out in Ukrainian", note,
+                                    _excerpt(value, token)))
+    return findings
+
+
+_SEV_ORDER = {"high": 2, "advisory": 1}
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    if args.paths:
+        return [Path(p) for p in args.paths]
+    track_dir = PLANS_DIR / args.track
+    return sorted(p for p in track_dir.glob("*.yaml")
+                  if not p.name.startswith(".") and not p.name.endswith(".bak"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--track", default="bio", help="Track under plans/ (default: bio).")
+    ap.add_argument("--paths", nargs="*", help="Explicit plan files (overrides --track).")
+    ap.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    ap.add_argument("--severity", choices=("high", "advisory"), default="advisory",
+                    help="Minimum severity to report and to gate exit code on (default: advisory).")
+    ap.add_argument("--quiet", action="store_true", help="Only print the summary line.")
+    ap.add_argument("--systemic-threshold", type=int, default=20,
+                    help="A rule firing in more than this many findings is collapsed to a "
+                         "single 'systemic' summary line (default: 20).")
+    args = ap.parse_args(argv)
+
+    threshold = _SEV_ORDER[args.severity]
+    paths = _resolve_paths(args)
+    all_findings: list[Finding] = []
+    for path in paths:
+        all_findings.extend(
+            f for f in lint_plan(path) if _SEV_ORDER.get(f.severity, 2) >= threshold
+        )
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in all_findings], ensure_ascii=False, indent=2))
+    else:
+        # A rule that fires across many plans is a systemic/template issue, not a
+        # per-plan defect. Collapse those into one summary line instead of spamming
+        # a line per occurrence (e.g. the «Дебат N:» activity-heading template).
+        rule_counts = Counter(f.rule for f in all_findings)
+        rule_files: dict[str, set[str]] = {}
+        for f in all_findings:
+            rule_files.setdefault(f.rule, set()).add(f.file)
+        systemic = {r for r, c in rule_counts.items() if c > args.systemic_threshold}
+
+        by_file: dict[str, list[Finding]] = {}
+        for f in all_findings:
+            if f.rule not in systemic:
+                by_file.setdefault(f.file, []).append(f)
+        if not args.quiet:
+            for file, items in sorted(by_file.items()):
+                print(f"\n{file}")
+                for f in items:
+                    tag = "❌" if f.severity == "high" else "⚠️ "
+                    print(f"  {tag} [{f.rule}] «{f.text}» → {f.suggestion}")
+                    print(f"      {f.context}")
+            if systemic:
+                print("\nSystemic (widespread — fix the template/generator once, not per-plan):")
+                for r in sorted(systemic, key=lambda r: -rule_counts[r]):
+                    eg = sorted(rule_files[r])[0]
+                    print(f"  ⚠️  [{r}] {rule_counts[r]} hits across "
+                          f"{len(rule_files[r])} plan(s) — e.g. {eg}")
+        n_high = sum(1 for f in all_findings if f.severity == "high")
+        n_adv = len(all_findings) - n_high
+        flagged = len({f.file for f in all_findings})
+        print(f"\n{'─' * 60}")
+        print(f"Scanned {len(paths)} plan(s) · {flagged} flagged · "
+              f"{len(systemic)} systemic rule(s) · {n_high} high · {n_adv} advisory")
+
+    return 1 if all_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_lint_seminar_quality.py
+++ b/tests/test_lint_seminar_quality.py
@@ -83,6 +83,35 @@ def test_arest_russianism_flagged_high(tmp_path):
     assert ("арест", "Арест", "high") in findings
 
 
+def test_prefixed_arest_is_flagged_but_correct_form_is_not(tmp_path):
+    # Prefixed russianism «заарестовано» (not in VESUM) must be caught...
+    flagged = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Репресії",
+                             "points": ["Його було заарестовано в 1937 році"]}],
+    })
+    assert "арест" in _rules(flagged)
+    # ...while the correct «заарештовано» (with ш) and медичне «парестезія» are NOT.
+    clean = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Репресії",
+                             "points": ["Його заарештовано 1937; парестезія була симптомом"]}],
+    })
+    assert "арест" not in _rules(clean)
+
+
+def test_vlast_russian_plural_is_flagged(tmp_path):
+    flagged = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Війна",
+                             "points": ["Депортований нацистськими властями до Берліна"]}],
+    })
+    assert "власті" in _rules(flagged)
+    # Legitimate «властивість»/«властивий» and Ukrainian «владами» must NOT be flagged.
+    clean = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Стиль",
+                             "points": ["Властивий йому стиль і художня властивість образів"]}],
+    })
+    assert "власті" not in _rules(clean)
+
+
 def test_postum_russianism_flagged(tmp_path):
     findings = _lint_dict(tmp_path, {
         "content_outline": [{"section": "Спадщина",

--- a/tests/test_lint_seminar_quality.py
+++ b/tests/test_lint_seminar_quality.py
@@ -1,0 +1,148 @@
+"""Tests for the seminar-quality language linter (scripts/validate/lint_seminar_quality.py).
+
+Covers the two defect classes — Latin-in-Cyrillic and russianisms/calques — with an
+emphasis on FALSE-POSITIVE guards: legitimate Latin (X-променів, STEM, IEU, Ems, Roman
+numerals, URLs) and VESUM-codified words (інакомислення) must NOT be flagged, while the
+proven defects (LIT-модулі, L2-студентам, hindsight-осуду, арест, постумно, prison-sense
+термін) must be.
+"""
+
+import os
+import sys
+
+import pytest
+import yaml
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_project_root, "scripts"))
+
+from validate.lint_seminar_quality import (
+    _scan_latin_in_cyrillic,
+    lint_plan,
+)
+
+# ── Latin-in-Cyrillic: defects ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("token", ["LIT-модулі", "L2-студентам", "hindsight-осуду"])
+def test_latin_abbreviation_glued_to_cyrillic_is_flagged(token):
+    hits = _scan_latin_in_cyrillic(f"текст {token} текст")
+    assert hits, f"{token} should be flagged"
+    assert hits[0][1] == "high"
+
+
+@pytest.mark.parametrize("token", ["Cлово", "мистецтвoм", "Оспiщев"])
+def test_intra_word_homoglyph_is_flagged(token):
+    # These mix Latin + Cyrillic *inside* one word (homoglyph substitution).
+    hits = _scan_latin_in_cyrillic(token)
+    assert hits, f"{token} homoglyph should be flagged"
+    assert hits[0][1] == "high"
+
+
+# ── Latin-in-Cyrillic: legitimate (must NOT flag) ────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "дослідження X-променів у фізиці",
+    "осі Y та координати",
+    "STEM-освіта в школах",
+    "за даними IEU та ESU",
+    "Ems-указ 1876 року",
+    "XIX-столітні джерела",
+    "у XVIII ст. та на початку XX століття",
+    "посилання uk.wikipedia.org/wiki/Драй-Хмара на статтю",
+    "https://esu.com.ua/article про постать",
+])
+def test_legitimate_latin_is_not_flagged(text):
+    assert _scan_latin_in_cyrillic(text) == [], f"false positive on: {text}"
+
+
+# ── End-to-end plan linting via lint_plan ────────────────────────────────────
+
+def _lint_dict(tmp_path, plan: dict) -> list[tuple[str, str, str]]:
+    path = tmp_path / "subject.yaml"
+    path.write_text(yaml.dump(plan, allow_unicode=True), encoding="utf-8")
+    return [(f.rule, f.text, f.severity) for f in lint_plan(path)]
+
+
+def _rules(findings) -> set[str]:
+    return {f[0] for f in findings}
+
+
+def test_arest_russianism_flagged_high(tmp_path):
+    findings = _lint_dict(tmp_path, {
+        "title": "Тест",
+        "content_outline": [{"section": "Біографія",
+                             "points": ["Арешт стався 1948 року"]}],  # correct form
+    })
+    assert "арест" not in _rules(findings), "«арешт» (correct) must not be flagged"
+
+    findings = _lint_dict(tmp_path, {
+        "title": "Тест",
+        "content_outline": [{"section": "Біографія",
+                             "points": ["Арест 29 січня 1948 року"]}],  # russianism
+    })
+    assert ("арест", "Арест", "high") in findings
+
+
+def test_postum_russianism_flagged(tmp_path):
+    findings = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Спадщина",
+                             "points": ["Постумно реабілітований у 1960-х"]}],
+    })
+    assert "постум" in _rules(findings)
+
+
+def test_inakomyslennia_is_not_flagged_but_inakomysliach_is(tmp_path):
+    # «інакомислення» — VESUM-codified abstract noun, must NOT be flagged.
+    findings = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Контекст",
+                             "points": ["Релігійне інакомислення доби застою"]}],
+    })
+    assert "інакомисляч" not in _rules(findings)
+
+    # «інакомисляч» — non-standard person-form calque, advisory flag.
+    findings = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Контекст",
+                             "points": ["Він був інакомислячим митцем"]}],
+    })
+    assert "інакомисляч" in _rules(findings)
+
+
+def test_termin_prison_sense_needs_context(tmp_path):
+    # Prison collocation → flag.
+    flagged = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Покарання",
+                             "points": ["Відбував термін у таборі суворого режиму"]}],
+    })
+    assert "термін_строк" in _rules(flagged)
+
+    # «термін» as deadline / terminology → no imprisonment context → no flag.
+    clean = _lint_dict(tmp_path, {
+        "content_outline": [{"section": "Наука",
+                             "points": ["Запровадив новий науковий термін у мовознавстві"]}],
+    })
+    assert "термін_строк" not in _rules(clean)
+
+
+def test_identifier_and_citation_fields_are_skipped(tmp_path):
+    # connects_to / slug / references must not be scanned even if they contain
+    # Latin-Cyrillic mixes (slugs) or URLs with Cyrillic article titles.
+    findings = _lint_dict(tmp_path, {
+        "slug": "viktor-domontovych",
+        "module": "bio-201",
+        "connects_to": ["bio-mykola-zerov", "lit-neoclassicism"],
+        "references": [{"title": "Драй-Хмара", "path": "uk.wikipedia.org/wiki/Драй-Хмара"}],
+        "content_outline": [{"section": "Огляд", "points": ["Чистий український текст."]}],
+    })
+    assert findings == [], f"identifier/citation fields should be skipped, got {findings}"
+
+
+def test_clean_plan_has_no_findings(tmp_path):
+    findings = _lint_dict(tmp_path, {
+        "title": "Михайло Драй-Хмара",
+        "content_outline": [
+            {"section": "Розминка", "points": ["Поет-неокласик та перекладач."]},
+            {"section": "Репресії", "points": ["Заарештований 1935 року; помер на Колимі."]},
+        ],
+        "activity_hints": [{"focus": "Дискусія про неокласицизм", "type": "debate"}],
+    })
+    assert findings == []


### PR DESCRIPTION
## What
`scripts/validate/lint_seminar_quality.py` — a deterministic, **precision-first** pre-review linter for the #2535 seminar-standard audit. It fills the language-quality gap no existing validator covers (`validate_plan_config` = word targets/keys; `validate_plan_ordering` = `connects_to`/ordering).

### Checks
1. **Russianisms / calques** — арешт-not-`арест`, посмертно-not-`постум`, `коерція`, `голодовка`, `власті`, person-form `інакомисляч`, and prison-sense `термін`→строк (gated on an imprisonment collocation so deadline/terminology «термін» is not flagged).
2. **Latin-in-Cyrillic** — intra-word homoglyphs (`Cлово`, `мистецтвoм`, `Оспiщев`) and lazy Latin abbreviations glued to Cyrillic prose (`LIT-модулі`, `L2-студентам`, `hindsight-осуду`), while **allowlisting** legitimate Latin: `X-променів`, `STEM`, `IEU`, `Ems`, Roman numerals (`XIX-`, `XVIII`), and URLs.

Not a ghost-`connects_to` check — that is already covered by `validate_plan_ordering.py` (228/310 plans use prefixed entries; it gives 0 bio errors).

### Design
- **Precision over recall** — curated high-confidence list; cross-review handles the tail.
- **Severity**: HIGH = gating set; advisory = review-list.
- **Systemic collapse** — a rule firing across many plans (the «Дебат N:» activity-heading template: 540 hits / 190 plans) collapses to one summary line instead of spamming per-occurrence.
- Identifier/citation fields (`slug`, `module`, `connects_to`, `references`, URLs) are never scanned.

### False positives ruled out (sources MCP)
- `інакомислення` — VESUM-codified, `check_russian_shadow`=0.0 → **not flagged** (only the non-VESUM person-form `інакомисляч` is).
- `XIX` — Roman numeral → **not flagged**.

## Triage on origin/main (all VESUM/context-verified, zero false positives)
4 HIGH + 1 advisory, **all in the new 181–310 plans** (original 180 clean of these classes):

| Plan | Module | Finding |
|---|---|---|
| viktor-domontovych | bio-211 | `LIT-модулі` (high) |
| myroslav-irchan | bio-190 | `L2-студентам` (high) |
| antin-krushelnytskyi | bio-191 | `hindsight-осуду` (high) |
| vasyl-barvinskyi | bio-290 | `Арест`→Арешт (high) |
| kateryna-zarytska | bio-284 | prison-sense `термін`→строк (advisory) |

## Tests / verification
- 21 hermetic unit tests (`tests/test_lint_seminar_quality.py`) — covers each defect class + allowlist guards + identifier-field skipping. `pytest` → **21 passed**; ruff clean.
- Run: `.venv/bin/python scripts/validate/lint_seminar_quality.py --track bio [--severity high] [--json]`

## Scope
- Tooling / shared-infra (no Ukrainian *content* changes).
- **Not** wired as a blocking CI gate yet — it would redden main until the 5 findings above are fixed (next: a small DeepSeek-cross-reviewed content PR).

Refs #2535, #2309. Handoff updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)