### PR TITLE
fix(agent-runtime): cursor adapter must prefer cursor-agent over generic 'agent'

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -85,7 +85,15 @@ class CursorAdapter:
             _logger.debug("cursor adapter ignoring effort=%s (not supported by CLI)", effort)
 
         # Resolve binary. shutil.which handles PATH lookup.
-        cursor_bin = shutil.which("agent") or shutil.which("cursor-agent") or "agent"
+        # Prefer the UNAMBIGUOUS ``cursor-agent`` name. A generic ``agent`` on
+        # PATH can be a DIFFERENT tool: grok's "Grok Build TUI" installs
+        # ``~/.local/bin/agent``, whose ``-p`` means ``--single <PROMPT>`` (a
+        # value flag), so resolving ``agent`` first silently misfired EVERY
+        # cursor dispatch to grok (returncode 2: "a value is required for
+        # '--single <PROMPT>'"). Resolve ``cursor-agent`` first; fall back to a
+        # generic ``agent`` only when cursor-agent is absent (legacy cursor
+        # installs shipped as ``agent``). (#2309 bio driver, 2026-06-02)
+        cursor_bin = shutil.which("cursor-agent") or shutil.which("agent") or "cursor-agent"
 
         config = tool_config or {}
 

--- a/tests/agent_runtime/test_cursor_adapter_resume.py
+++ b/tests/agent_runtime/test_cursor_adapter_resume.py
@@ -29,6 +29,51 @@ def test_cursor_adapter_resume_first_run(adapter, tmp_path, monkeypatch):
     assert "--resume" not in plan.cmd
 
 
+def test_cursor_adapter_prefers_cursor_agent_over_generic_agent(adapter, tmp_path, monkeypatch):
+    """Regression: a generic ``agent`` binary on PATH (e.g. grok's Grok Build
+    TUI at ~/.local/bin/agent) must NOT shadow ``cursor-agent``. Resolving
+    ``agent`` first silently misfired every cursor dispatch to grok
+    (returncode 2: "a value is required for '--single <PROMPT>'")."""
+    resolved = {
+        "cursor-agent": "/Users/x/.local/bin/cursor-agent",
+        "agent": "/Users/x/.local/bin/agent",  # impostor: grok Build TUI
+    }
+    monkeypatch.setattr("shutil.which", lambda name: resolved.get(name))
+
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id="bin-resolve-1",
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[0] == "/Users/x/.local/bin/cursor-agent"
+
+
+def test_cursor_adapter_falls_back_to_agent_when_no_cursor_agent(adapter, tmp_path, monkeypatch):
+    """When ``cursor-agent`` is absent, fall back to a generic ``agent`` binary
+    (legacy cursor installs shipped under the bare ``agent`` name)."""
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/agent" if name == "agent" else None,
+    )
+
+    plan = adapter.build_invocation(
+        prompt="hi",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id="bin-resolve-2",
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[0] == "/usr/local/bin/agent"
+
+
 def test_cursor_adapter_resume_explicit_session(adapter, tmp_path, monkeypatch):
     monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
 


### PR DESCRIPTION
## Problem
grok's standalone CLI installs `~/.local/bin/agent` (\"Grok Build TUI\"), whose `-p` flag means `--single <PROMPT>` (a **value** flag). The cursor adapter resolved its binary as:

```python
cursor_bin = shutil.which("agent") or shutil.which("cursor-agent") or "agent"
```

It preferred the **generic `agent`** name — so after the grok install, **every `delegate --agent cursor` dispatch silently misfired to grok** and died instantly:

```
error: a value is required for '--single <PROMPT>' but none was supplied
```
(returncode 2, ~1s, `response_chars=0`). This killed the cursor separate-quota writer lane.

## Fix
Resolve the **unambiguous `cursor-agent`** first; fall back to a generic `agent` only when `cursor-agent` is absent (legacy cursor installs shipped as `agent`). grok is left untouched.

## Verification
- `pytest tests/agent_runtime/test_cursor_adapter_resume.py -q` → **8 passed** (6 existing + 2 new).
- `ruff check` → **All checks passed!**
- Real-PATH check (both `agent` and `cursor-agent` present): adapter now resolves `/Users/.../​.local/bin/cursor-agent`.

## Regression tests added
1. A generic `agent` on PATH no longer shadows `cursor-agent`.
2. Fallback to `agent` still works when `cursor-agent` is absent.

Found while driving bio epic #2309 (a cursor dispatch for the existing-180 audit tooling failed instantly). Shared `agent_runtime` infra → flagged for orchestrator promotion; no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)