### PR TITLE
feat(validate): bio source-first prevention gates (#2535)

### DIFF
--- a/scripts/validate/bio_subjects.py
+++ b/scripts/validate/bio_subjects.py
@@ -1,0 +1,143 @@
+"""Subject-name helpers for deterministic BIO source-first gates."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BIO_PLANS_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans" / "bio"
+
+CYRILLIC_WORD_RE = re.compile(r"[А-Яа-яІіЇїЄєҐґ][А-Яа-яІіЇїЄєҐґ'’ʼ-]*")
+TITLE_PREFIX_RE = re.compile(r"^#{1,6}\s*")
+BIOGRAPHY_PREFIX_RE = re.compile(r"^біографія\s*:\s*", re.IGNORECASE)
+
+LEADING_TITLES = {
+    "архієпископ",
+    "гетьман",
+    "княгиня",
+    "княжна",
+    "князь",
+    "король",
+    "митрополит",
+    "патріарх",
+    "свята",
+    "святий",
+}
+
+UKRAINIAN_SUFFIXES = (
+    "ського",
+    "цького",
+    "зького",
+    "ового",
+    "євого",
+    "евої",
+    "ової",
+    "ого",
+    "ему",
+    "ому",
+    "ими",
+    "ами",
+    "ями",
+    "ах",
+    "ях",
+    "ою",
+    "ею",
+    "ий",
+    "ій",
+    "а",
+    "я",
+    "у",
+    "ю",
+    "и",
+    "і",
+)
+
+
+def subject_phrase(text: str) -> str:
+    """Return the likely person-name phrase from a plan title or wiki H1."""
+    value = TITLE_PREFIX_RE.sub("", text.strip())
+    value = BIOGRAPHY_PREFIX_RE.sub("", value).strip()
+    if ":" in value:
+        value = value.split(":", 1)[0].strip()
+    value = re.split(r"\s+[—–]\s+", value, maxsplit=1)[0].strip()
+    for sep in (" та ", " і "):
+        if sep in value:
+            value = value.split(sep, 1)[0].strip()
+            break
+    for sep in (" в ", " у "):
+        if sep in value:
+            prefix = value.split(sep, 1)[0].strip()
+            if len(CYRILLIC_WORD_RE.findall(prefix)) >= 2:
+                value = prefix
+                break
+    return value
+
+
+def cyrillic_tokens(text: str) -> list[str]:
+    """Tokenize the subject phrase, dropping leading honorific/title words."""
+    tokens = [m.group(0).casefold() for m in CYRILLIC_WORD_RE.finditer(subject_phrase(text))]
+    while tokens and tokens[0] in LEADING_TITLES:
+        tokens.pop(0)
+    return tokens
+
+
+def token_keys(token: str) -> set[str]:
+    """Return conservative stem keys for Ukrainian name-token matching."""
+    base = token.casefold().replace("’", "'").replace("ʼ", "'")
+    keys = {base}
+    for suffix in UKRAINIAN_SUFFIXES:
+        if base.endswith(suffix) and len(base) - len(suffix) >= 4:
+            keys.add(base[: -len(suffix)])
+    return keys
+
+
+def surname_keys(text: str) -> set[str]:
+    """Return comparable keys for the final token in a subject phrase."""
+    tokens = cyrillic_tokens(text)
+    if not tokens:
+        return set()
+    return token_keys(tokens[-1])
+
+
+def given_name_keys(text: str) -> set[str]:
+    """Return comparable keys for the first non-title token in a subject phrase."""
+    tokens = cyrillic_tokens(text)
+    if not tokens:
+        return set()
+    return token_keys(tokens[0])
+
+
+def shares_surname(left: str, right: str) -> bool:
+    """True when two subject phrases share a 4+ character surname key."""
+    return bool(surname_keys(left) & surname_keys(right))
+
+
+def same_person(left: str, right: str) -> bool:
+    """Conservative person match for wiki H1 checks.
+
+    Surname agreement is required. If both sides have an explicit given name,
+    the given-name keys must also agree so Mykola Kulish and Panteleimon Kulish
+    remain distinguishable.
+    """
+    if not shares_surname(left, right):
+        return False
+    left_tokens = cyrillic_tokens(left)
+    right_tokens = cyrillic_tokens(right)
+    if len(left_tokens) >= 2 and len(right_tokens) >= 2:
+        return bool(given_name_keys(left) & given_name_keys(right))
+    return True
+
+
+def load_plan_title(slug: str, *, plans_dir: Path = BIO_PLANS_DIR) -> str | None:
+    """Load a BIO plan title by slug."""
+    path = plans_dir / f"{slug}.yaml"
+    if not path.exists():
+        return None
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        return None
+    title = data.get("title")
+    return str(title).strip() if title else None

--- a/scripts/validate/check_citation_resolution.py
+++ b/scripts/validate/check_citation_resolution.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Validate that compiled wiki short citations resolve in visible source lists."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WIKI_FIGURES_DIR = PROJECT_ROOT / "wiki" / "figures"
+CITATION_RE = re.compile(r"\[S(?P<num>10|[1-9])\]")
+SOURCE_HEADING_RE = re.compile(
+    r"^#{2,6}\s*(?:джерела|список джерел|бібліографія|references|sources)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+SOURCE_MAPPING_RE = re.compile(r"(?:^|\n)\s*(?:[-*]\s*)?(?:\[(S(?:[1-9]|10))\]|(S(?:[1-9]|10))\s*[.:])\s+\S")
+
+
+@dataclass(frozen=True)
+class CitationResolutionFinding:
+    path: str
+    cited_ids: list[str]
+    reason: str
+
+
+def _relative(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def inline_citation_ids(text: str) -> list[str]:
+    return [f"S{num}" for num in sorted({int(match.group("num")) for match in CITATION_RE.finditer(text)})]
+
+
+def has_source_mapping_section(text: str) -> bool:
+    heading = SOURCE_HEADING_RE.search(text)
+    if not heading:
+        return False
+    section = text[heading.end():]
+    next_heading = re.search(r"^#{1,6}\s+\S", section, re.MULTILINE)
+    if next_heading:
+        section = section[: next_heading.start()]
+    return bool(SOURCE_MAPPING_RE.search(section))
+
+
+def check_citation_resolution_text(text: str, *, path: str = "<text>") -> CitationResolutionFinding | None:
+    cited_ids = inline_citation_ids(text)
+    if not cited_ids:
+        return None
+    if has_source_mapping_section(text):
+        return None
+    return CitationResolutionFinding(
+        path=path,
+        cited_ids=cited_ids,
+        reason="inline [S#] citations have no visible source-list mapping",
+    )
+
+
+def check_file(path: Path) -> CitationResolutionFinding | None:
+    text = path.read_text(encoding="utf-8")
+    return check_citation_resolution_text(text, path=_relative(path))
+
+
+def iter_paths(paths: list[str] | None = None) -> list[Path]:
+    if not paths:
+        return sorted(WIKI_FIGURES_DIR.glob("*.md"))
+    resolved: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_dir():
+            resolved.extend(sorted(path.glob("*.md")))
+        else:
+            resolved.append(path)
+    return resolved
+
+
+def check_paths(paths: list[Path]) -> list[CitationResolutionFinding]:
+    findings: list[CitationResolutionFinding] = []
+    for path in paths:
+        finding = check_file(path)
+        if finding:
+            findings.append(finding)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths", nargs="*", help="Explicit wiki files/directories.")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    args = parser.parse_args(argv)
+
+    paths = iter_paths(args.paths)
+    findings = check_paths(paths)
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], ensure_ascii=False, indent=2))
+    else:
+        for finding in findings:
+            print(f"{finding.path}: {finding.reason}")
+            print(f"  cited-ids: {', '.join(finding.cited_ids)}")
+        print(f"Scanned {len(paths)} wiki figure file(s) · {len(findings)} unresolved citation file(s)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate/check_discovery_integrity.py
+++ b/scripts/validate/check_discovery_integrity.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Validate BIO discovery topics against their source plan subjects.
+
+The BIO discovery files are source-first inputs for wiki compilation. A prior
+corruption copied Mykola Kulish discovery topics/objectives into unrelated
+figure files. This gate flags discovery topics whose likely surname does not
+match the corresponding immutable plan title.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import yaml
+
+try:
+    from validate.bio_subjects import PROJECT_ROOT, load_plan_title, shares_surname
+except ModuleNotFoundError:  # pragma: no cover - direct script execution
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from validate.bio_subjects import PROJECT_ROOT, load_plan_title, shares_surname
+
+
+CURRICULUM_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en"
+
+
+@dataclass(frozen=True)
+class DiscoveryFinding:
+    slug: str
+    discovery_path: str
+    topic: str
+    plan_title: str
+    reason: str
+
+
+def _relative(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def discovery_topic(data: dict) -> str:
+    """Return the primary discovery topic string."""
+    keywords = data.get("query_keywords")
+    if isinstance(keywords, list):
+        for item in keywords:
+            if isinstance(item, str) and item.strip():
+                return item.strip()
+    for key in ("topic", "title"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def check_discovery_file(
+    discovery_path: Path,
+    *,
+    plan_title: str | None = None,
+) -> DiscoveryFinding | None:
+    """Return a finding when a discovery topic names a different subject."""
+    slug = discovery_path.stem
+    data = _load_yaml(discovery_path)
+    topic = discovery_topic(data)
+    expected_title = plan_title if plan_title is not None else load_plan_title(slug)
+    if not expected_title:
+        return DiscoveryFinding(
+            slug=slug,
+            discovery_path=_relative(discovery_path),
+            topic=topic,
+            plan_title="",
+            reason="missing plan title",
+        )
+    if not topic:
+        return DiscoveryFinding(
+            slug=slug,
+            discovery_path=_relative(discovery_path),
+            topic="",
+            plan_title=expected_title,
+            reason="missing discovery topic",
+        )
+    if shares_surname(topic, expected_title):
+        return None
+    return DiscoveryFinding(
+        slug=slug,
+        discovery_path=_relative(discovery_path),
+        topic=topic,
+        plan_title=expected_title,
+        reason="discovery topic shares no 4+ character surname token with plan title",
+    )
+
+
+def iter_discovery_paths(track: str) -> list[Path]:
+    discovery_dir = CURRICULUM_DIR / track / "discovery"
+    return sorted(discovery_dir.glob("*.yaml"))
+
+
+def check_track(track: str) -> list[DiscoveryFinding]:
+    findings: list[DiscoveryFinding] = []
+    for path in iter_discovery_paths(track):
+        finding = check_discovery_file(path)
+        if finding:
+            findings.append(finding)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--track", default="bio", help="Track to scan (default: bio).")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    args = parser.parse_args(argv)
+
+    paths = iter_discovery_paths(args.track)
+    findings = check_track(args.track)
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], ensure_ascii=False, indent=2))
+    else:
+        for finding in findings:
+            print(f"{finding.discovery_path}: {finding.reason}")
+            print(f"  slug: {finding.slug}")
+            print(f"  topic: {finding.topic}")
+            print(f"  plan-title: {finding.plan_title}")
+        print(f"Scanned {len(paths)} discovery file(s) · {len(findings)} mismatch(es)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate/check_wiki_subject.py
+++ b/scripts/validate/check_wiki_subject.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate compiled BIO figure wiki H1 subjects against file slugs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+try:
+    from validate.bio_subjects import PROJECT_ROOT, load_plan_title, same_person
+except ModuleNotFoundError:  # pragma: no cover - direct script execution
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from validate.bio_subjects import PROJECT_ROOT, load_plan_title, same_person
+
+
+WIKI_FIGURES_DIR = PROJECT_ROOT / "wiki" / "figures"
+H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+WIKI_META_RE = re.compile(r"<!--\s*wiki-meta\b(?P<body>.*?)-->", re.DOTALL)
+YAML_FRONTMATTER_RE = re.compile(r"\A---\s*\n(?P<body>.*?)\n---\s*\n", re.DOTALL)
+SLUG_RE = re.compile(r"^\s*slug:\s*['\"]?(?P<slug>[^'\"\s]+)", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class WikiSubjectFinding:
+    path: str
+    file_slug: str
+    frontmatter_slug: str
+    h1: str
+    plan_title: str
+    reason: str
+
+
+def _relative(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def first_h1(text: str) -> str:
+    match = H1_RE.search(text)
+    return match.group(1).strip() if match else ""
+
+
+def frontmatter_slug(text: str) -> str:
+    for match in (YAML_FRONTMATTER_RE.search(text), WIKI_META_RE.search(text)):
+        if not match:
+            continue
+        slug_match = SLUG_RE.search(match.group("body"))
+        if slug_match:
+            return slug_match.group("slug").strip()
+    slug_match = SLUG_RE.search(text)
+    return slug_match.group("slug").strip() if slug_match else ""
+
+
+def check_wiki_file(path: Path, *, plan_title: str | None = None) -> WikiSubjectFinding | None:
+    """Return a finding when the wiki H1 names a different BIO subject."""
+    text = path.read_text(encoding="utf-8")
+    file_slug = path.stem
+    h1 = first_h1(text)
+    meta_slug = frontmatter_slug(text)
+    expected_title = plan_title if plan_title is not None else load_plan_title(file_slug)
+    if not expected_title:
+        return WikiSubjectFinding(
+            path=_relative(path),
+            file_slug=file_slug,
+            frontmatter_slug=meta_slug,
+            h1=h1,
+            plan_title="",
+            reason="missing plan title for file slug",
+        )
+    if not h1:
+        return WikiSubjectFinding(
+            path=_relative(path),
+            file_slug=file_slug,
+            frontmatter_slug=meta_slug,
+            h1="",
+            plan_title=expected_title,
+            reason="missing H1",
+        )
+    if same_person(h1, expected_title):
+        return None
+    return WikiSubjectFinding(
+        path=_relative(path),
+        file_slug=file_slug,
+        frontmatter_slug=meta_slug,
+        h1=h1,
+        plan_title=expected_title,
+        reason="H1 subject does not match file slug plan title",
+    )
+
+
+def iter_wiki_paths(paths: list[str] | None = None) -> list[Path]:
+    if not paths:
+        return sorted(WIKI_FIGURES_DIR.glob("*.md"))
+    resolved: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_dir():
+            resolved.extend(sorted(path.glob("*.md")))
+        else:
+            resolved.append(path)
+    return resolved
+
+
+def check_paths(paths: list[Path]) -> list[WikiSubjectFinding]:
+    findings: list[WikiSubjectFinding] = []
+    for path in paths:
+        finding = check_wiki_file(path)
+        if finding:
+            findings.append(finding)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths", nargs="*", help="Explicit wiki files/directories.")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    args = parser.parse_args(argv)
+
+    paths = iter_wiki_paths(args.paths)
+    findings = check_paths(paths)
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], ensure_ascii=False, indent=2))
+    else:
+        for finding in findings:
+            print(f"{finding.path}: {finding.reason}")
+            print(f"  file-slug: {finding.file_slug}")
+            print(f"  frontmatter-slug: {finding.frontmatter_slug}")
+            print(f"  h1: {finding.h1}")
+            print(f"  plan-title: {finding.plan_title}")
+        print(f"Scanned {len(paths)} wiki figure file(s) · {len(findings)} subject mismatch(es)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate/check_wiki_verify_markers.py
+++ b/scripts/validate/check_wiki_verify_markers.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Fail compiled wiki files that still contain VERIFY markers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WIKI_FIGURES_DIR = PROJECT_ROOT / "wiki" / "figures"
+VERIFY_RE = re.compile(r"<!--\s*VERIFY\b.*?-->|(?<![A-Za-z])VERIFY\s*:", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass(frozen=True)
+class VerifyMarkerFinding:
+    path: str
+    line: int
+    marker: str
+
+
+def _relative(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def find_verify_markers_text(text: str, *, path: str = "<text>") -> list[VerifyMarkerFinding]:
+    findings: list[VerifyMarkerFinding] = []
+    for match in VERIFY_RE.finditer(text):
+        marker = " ".join(match.group(0).split())
+        findings.append(
+            VerifyMarkerFinding(
+                path=path,
+                line=_line_number(text, match.start()),
+                marker=marker[:160],
+            )
+        )
+    return findings
+
+
+def check_file(path: Path) -> list[VerifyMarkerFinding]:
+    text = path.read_text(encoding="utf-8")
+    return find_verify_markers_text(text, path=_relative(path))
+
+
+def iter_paths(paths: list[str] | None = None) -> list[Path]:
+    if not paths:
+        return sorted(WIKI_FIGURES_DIR.glob("*.md"))
+    resolved: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_dir():
+            resolved.extend(sorted(path.glob("*.md")))
+        else:
+            resolved.append(path)
+    return resolved
+
+
+def check_paths(paths: list[Path]) -> list[VerifyMarkerFinding]:
+    findings: list[VerifyMarkerFinding] = []
+    for path in paths:
+        findings.extend(check_file(path))
+    return findings
+
+
+def assert_no_verify_markers(text: str, *, path: Path | str = "<text>") -> None:
+    """Raise ValueError if compiled wiki text contains a VERIFY marker."""
+    findings = find_verify_markers_text(text, path=str(path))
+    if findings:
+        first = findings[0]
+        raise ValueError(f"VERIFY marker survivor in {first.path}:{first.line}: {first.marker}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths", nargs="*", help="Explicit wiki files/directories.")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON.")
+    args = parser.parse_args(argv)
+
+    paths = iter_paths(args.paths)
+    findings = check_paths(paths)
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], ensure_ascii=False, indent=2))
+    else:
+        for finding in findings:
+            print(f"{finding.path}:{finding.line}: VERIFY marker survivor")
+            print(f"  marker: {finding.marker}")
+        print(f"Scanned {len(paths)} wiki figure file(s) · {len(findings)} VERIFY marker(s)")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate/lint_seminar_quality.py
+++ b/scripts/validate/lint_seminar_quality.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministic seminar-quality language linter for curriculum plan YAMLs.
+"""Deterministic seminar-quality language linter for seminar plans and wiki text.
 
 Seminar tracks (bio/hist/lit/istorio/oes/ruth) are *source-first* and stricter
 than core language lessons. Two language-quality defect classes recur in the
@@ -30,6 +30,7 @@ Use
     .venv/bin/python scripts/validate/lint_seminar_quality.py                 # all bio plans
     .venv/bin/python scripts/validate/lint_seminar_quality.py --track bio --json
     .venv/bin/python scripts/validate/lint_seminar_quality.py --paths curriculum/l2-uk-en/plans/bio/viktor-domontovych.yaml
+    .venv/bin/python scripts/validate/lint_seminar_quality.py --paths wiki/figures
     .venv/bin/python scripts/validate/lint_seminar_quality.py --severity high  # gate on HIGH only
 
 Exit codes
@@ -57,6 +58,7 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PLANS_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans"
+WIKI_FIGURES_DIR = PROJECT_ROOT / "wiki" / "figures"
 
 # Plan keys whose string values are identifiers / citation metadata, NOT prose.
 # We never scan these: they legitimately carry ASCII slugs, module ids, and URLs.
@@ -140,6 +142,8 @@ _ROMAN_RE = re.compile(r"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})
 
 # A whitespace token is a URL/citation if it looks like one — never script-mix-flag it.
 _URL_RE = re.compile(r"(https?://|www\.|\w+\.(?:org|com|net|ua|gov|edu)\b|wikipedia|@)", re.IGNORECASE)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_BARE_URL_RE = re.compile(r"https?://\S+|www\.\S+|\b\S+\.(?:org|com|net|ua|gov|edu)\S*", re.IGNORECASE)
 
 _HAS_CYR = re.compile(rf"[{CYRILLIC}]")
 _HAS_LAT = re.compile(rf"[{LATIN}]")
@@ -264,22 +268,115 @@ def lint_plan(path: Path) -> list[Finding]:
     return findings
 
 
+def _strip_fenced_code(text: str) -> str:
+    """Remove fenced-code bodies while preserving line numbers."""
+    cleaned: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(("```", "~~~")):
+            in_fence = not in_fence
+            cleaned.append("")
+            continue
+        cleaned.append("" if in_fence else line)
+    return "\n".join(cleaned)
+
+
+def _sanitize_text_line(line: str) -> str:
+    """Drop text-mode allowlisted spans before applying prose rules."""
+    line = _INLINE_CODE_RE.sub(" ", line)
+    return _BARE_URL_RE.sub(" ", line)
+
+
+def lint_text(path: Path) -> list[Finding]:
+    """Lint a Markdown/wiki text file with the same language-quality rules."""
+    findings: list[Finding] = []
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - surfaced as a finding
+        return [Finding(str(path), "<read>", "unreadable", "high",
+                        str(exc)[:120], "", "Text file failed to read.", "")]
+
+    try:
+        rel = str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        rel = str(path)
+
+    text = _strip_fenced_code(raw_text)
+    for line_no, raw_line in enumerate(text.splitlines(), 1):
+        value = _sanitize_text_line(raw_line)
+        if not _HAS_CYR.search(value):
+            continue
+        field = f"line {line_no}"
+        for rule in RUSSIANISMS:
+            if rule.requires_context and not any(c in value for c in rule.requires_context):
+                continue
+            m = rule.pattern.search(value)
+            if m:
+                hit = m.group(1)
+                findings.append(Finding(rel, field, rule.key, rule.severity, hit,
+                                        rule.suggestion, rule.note, _excerpt(value, hit)))
+        for token, sev, note in _scan_latin_in_cyrillic(value):
+            findings.append(Finding(rel, field, "latin_in_cyrillic", sev, token,
+                                    "pure Cyrillic / spell out in Ukrainian", note,
+                                    _excerpt(value, token)))
+    return findings
+
+
 _SEV_ORDER = {"high": 2, "advisory": 1}
+
+
+def _mode_for_path(path: Path, requested: str) -> str:
+    if requested != "auto":
+        return requested
+    return "text" if path.suffix.lower() == ".md" else "plan"
+
+
+def _iter_dir_paths(path: Path, requested: str) -> list[Path]:
+    suffixes = {".yaml"} if requested == "plan" else {".md"} if requested == "text" else {".yaml", ".md"}
+    return sorted(
+        p for p in path.rglob("*")
+        if p.is_file()
+        and p.suffix.lower() in suffixes
+        and not p.name.startswith(".")
+        and not p.name.endswith(".bak")
+        and not p.name.endswith(".sources.yaml")
+    )
 
 
 def _resolve_paths(args: argparse.Namespace) -> list[Path]:
     if args.paths:
-        return [Path(p) for p in args.paths]
+        resolved: list[Path] = []
+        for raw_path in args.paths:
+            path = Path(raw_path)
+            if path.is_dir():
+                resolved.extend(_iter_dir_paths(path, args.format))
+            else:
+                resolved.append(path)
+        return resolved
+    if args.format == "text":
+        return sorted(WIKI_FIGURES_DIR.glob("*.md"))
     track_dir = PLANS_DIR / args.track
     return sorted(p for p in track_dir.glob("*.yaml")
                   if not p.name.startswith(".") and not p.name.endswith(".bak"))
+
+
+def _summary_unit(paths: list[Path], requested: str) -> str:
+    modes = {_mode_for_path(path, requested) for path in paths}
+    if modes == {"plan"}:
+        return "plan(s)"
+    if modes == {"text"}:
+        return "text file(s)"
+    return "file(s)"
 
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--track", default="bio", help="Track under plans/ (default: bio).")
-    ap.add_argument("--paths", nargs="*", help="Explicit plan files (overrides --track).")
+    ap.add_argument("--paths", nargs="*", help="Explicit files/directories (overrides --track).")
+    ap.add_argument("--format", choices=("plan", "text", "auto"), default="auto",
+                    help="Input format: plan YAML, text Markdown, or auto by suffix (default: auto).")
     ap.add_argument("--json", action="store_true", help="Emit findings as JSON.")
     ap.add_argument("--severity", choices=("high", "advisory"), default="advisory",
                     help="Minimum severity to report and to gate exit code on (default: advisory).")
@@ -293,9 +390,8 @@ def main(argv: list[str] | None = None) -> int:
     paths = _resolve_paths(args)
     all_findings: list[Finding] = []
     for path in paths:
-        all_findings.extend(
-            f for f in lint_plan(path) if _SEV_ORDER.get(f.severity, 2) >= threshold
-        )
+        lint_fn = lint_text if _mode_for_path(path, args.format) == "text" else lint_plan
+        all_findings.extend(f for f in lint_fn(path) if _SEV_ORDER.get(f.severity, 2) >= threshold)
 
     if args.json:
         print(json.dumps([asdict(f) for f in all_findings], ensure_ascii=False, indent=2))
@@ -304,6 +400,7 @@ def main(argv: list[str] | None = None) -> int:
         # per-plan defect. Collapse those into one summary line instead of spamming
         # a line per occurrence (e.g. the «Дебат N:» activity-heading template).
         rule_counts = Counter(f.rule for f in all_findings)
+        unit = _summary_unit(paths, args.format)
         rule_files: dict[str, set[str]] = {}
         for f in all_findings:
             rule_files.setdefault(f.rule, set()).add(f.file)
@@ -325,12 +422,12 @@ def main(argv: list[str] | None = None) -> int:
                 for r in sorted(systemic, key=lambda r: -rule_counts[r]):
                     eg = sorted(rule_files[r])[0]
                     print(f"  ⚠️  [{r}] {rule_counts[r]} hits across "
-                          f"{len(rule_files[r])} plan(s) — e.g. {eg}")
+                          f"{len(rule_files[r])} {unit} — e.g. {eg}")
         n_high = sum(1 for f in all_findings if f.severity == "high")
         n_adv = len(all_findings) - n_high
         flagged = len({f.file for f in all_findings})
         print(f"\n{'─' * 60}")
-        print(f"Scanned {len(paths)} plan(s) · {flagged} flagged · "
+        print(f"Scanned {len(paths)} {unit} · {flagged} flagged · "
               f"{len(systemic)} systemic rule(s) · {n_high} high · {n_adv} advisory")
 
     return 1 if all_findings else 0

--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -75,6 +75,7 @@ def _ts() -> str:
     """Compact HH:MM:SS timestamp for log lines."""
     return datetime.now().strftime("%H:%M:%S")
 
+from validate.check_wiki_verify_markers import find_verify_markers_text
 from wiki.compiler import WRITER_CHOICES, compile_article, update_index
 from wiki.config import ALL_TRACKS, CURRICULUM_DIR, TRACK_DOMAINS, WIKI_DIR
 from wiki.enrichment import enrich_sources
@@ -371,6 +372,16 @@ def cmd_compile_one(track: str, slug: str, *, force: bool = False,
                 source_count=len(all_chunks),
             )
             print(f"    ✓ discipline in {time.monotonic() - t_stage:.1f}s", flush=True)
+            marker_findings = _verify_marker_survivors(result)
+            if marker_findings:
+                print("  ❌ VERIFY marker survivor(s) after compile:")
+                for finding in marker_findings[:5]:
+                    print(f"     - {finding.path}:{finding.line}: {finding.marker}")
+                log_event(
+                    track, slug, "verify_marker_fail",
+                    markers=len(marker_findings),
+                )
+                return False
 
             t_stage = time.monotonic()
             print("  📑 Updating index + logging event...", flush=True)
@@ -477,6 +488,15 @@ def _run_discipline_checks_and_repair(
     )
 
 
+def _verify_marker_survivors(article_path: Path):
+    """Return VERIFY marker findings for a compiled article, if any."""
+    try:
+        text = article_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return find_verify_markers_text(text, path=str(article_path))
+
+
 def _compiled_article_is_ready(track: str, slug: str) -> bool:
     """Return True when an article is fully compiled and safe to skip.
 
@@ -495,6 +515,8 @@ def _compiled_article_is_ready(track: str, slug: str) -> bool:
     try:
         article_text = article_path.read_text(encoding="utf-8")
     except OSError:
+        return False
+    if find_verify_markers_text(article_text, path=str(article_path)):
         return False
 
     registry_path = registry_path_for(article_path)

--- a/scripts/wiki/compiler.py
+++ b/scripts/wiki/compiler.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from ai_llm.claude_call import call_claude_with_fallback
 from ai_llm.codex_call import call_codex_with_fallback
 from ai_llm.fallback import CallResult, call_gemini_with_fallback, visible_sleep
+from validate.check_wiki_verify_markers import assert_no_verify_markers
 
 from .config import GEMINI_MODEL, PROMPTS_DIR, TRACK_DOMAINS, WIKI_DIR
 from .source_attribution import resolve_chunk_attribution
@@ -154,12 +155,16 @@ def compile_article(
     # Write the article
     article_path = WIKI_DIR / domain / f"{slug}.md"
     article_path.parent.mkdir(parents=True, exist_ok=True)
-    _write_article_bundle_atomic(
-        article_path,
-        article_text=response.strip() + "\n",
-        sources=sources,
-        force=force,
-    )
+    try:
+        _write_article_bundle_atomic(
+            article_path,
+            article_text=response.strip() + "\n",
+            sources=sources,
+            force=force,
+        )
+    except ValueError as exc:
+        print(f"  ❌ {exc}")
+        return None
 
     word_count = len(response.split())
     print(f"  ✅ Wrote {article_path.relative_to(WIKI_DIR)} ({word_count} words)")
@@ -495,6 +500,7 @@ def _write_article_bundle_atomic(
     force: bool = False,
 ) -> None:
     """Write article + sidecar via temp files so markdown lands last."""
+    assert_no_verify_markers(article_text, path=article_path)
     registry = _build_sources_registry(
         article_path,
         sources,

--- a/tests/test_citation_resolution_gate.py
+++ b/tests/test_citation_resolution_gate.py
@@ -1,0 +1,36 @@
+"""Tests for scripts/validate/check_citation_resolution.py."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_project_root, "scripts"))
+
+from validate.check_citation_resolution import check_citation_resolution_text
+
+
+def test_citation_resolution_flags_inline_s_markers_without_source_list():
+    text = "# Стаття\n\nТвердження з посиланням [S1] і ще одне [S2].\n"
+
+    finding = check_citation_resolution_text(text, path="wiki/figures/example.md")
+
+    assert finding is not None
+    assert finding.path == "wiki/figures/example.md"
+    assert finding.cited_ids == ["S1", "S2"]
+
+
+def test_citation_resolution_accepts_visible_source_mapping():
+    text = (
+        "# Стаття\n\n"
+        "Твердження з посиланням [S1].\n\n"
+        "## Джерела\n"
+        "- [S1] Енциклопедія Сучасної України, стаття про постать.\n"
+    )
+
+    assert check_citation_resolution_text(text) is None
+
+
+def test_citation_resolution_ignores_articles_without_s_markers():
+    assert check_citation_resolution_text("# Стаття\n\nТекст без коротких джерел.\n") is None

--- a/tests/test_discovery_integrity.py
+++ b/tests/test_discovery_integrity.py
@@ -1,0 +1,39 @@
+"""Tests for scripts/validate/check_discovery_integrity.py."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import yaml
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_project_root, "scripts"))
+
+from validate.check_discovery_integrity import check_discovery_file
+
+
+def _write_discovery(tmp_path, slug: str, topic: str):
+    path = tmp_path / f"{slug}.yaml"
+    path.write_text(
+        yaml.safe_dump({"query_keywords": [topic]}, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_discovery_integrity_flags_different_figure_topic(tmp_path):
+    path = _write_discovery(tmp_path, "anatol-petrytskyi", "Микола Куліш: Драматургія")
+
+    finding = check_discovery_file(path, plan_title="Анатоль Петрицький: Сценограф")
+
+    assert finding is not None
+    assert finding.slug == "anatol-petrytskyi"
+    assert finding.topic == "Микола Куліш: Драматургія"
+    assert finding.plan_title == "Анатоль Петрицький: Сценограф"
+
+
+def test_discovery_integrity_accepts_matching_figure_topic(tmp_path):
+    path = _write_discovery(tmp_path, "ivan-mazepa", "Іван Мазепа: Анатомія вибору")
+
+    assert check_discovery_file(path, plan_title="Іван Мазепа: Анатомія вибору") is None

--- a/tests/test_lint_seminar_quality.py
+++ b/tests/test_lint_seminar_quality.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.join(_project_root, "scripts"))
 from validate.lint_seminar_quality import (
     _scan_latin_in_cyrillic,
     lint_plan,
+    lint_text,
 )
 
 # ── Latin-in-Cyrillic: defects ───────────────────────────────────────────────
@@ -175,3 +176,32 @@ def test_clean_plan_has_no_findings(tmp_path):
         "activity_hints": [{"focus": "Дискусія про неокласицизм", "type": "debate"}],
     })
     assert findings == []
+
+
+def test_wiki_text_mode_flags_same_defect_classes(tmp_path):
+    article = tmp_path / "subject.md"
+    article.write_text(
+        "# Постать\n\n"
+        "Арест і LIT-модулі лишилися в статті.\n",
+        encoding="utf-8",
+    )
+
+    findings = {(f.rule, f.text, f.field) for f in lint_text(article)}
+
+    assert ("арест", "Арест", "line 3") in findings
+    assert ("latin_in_cyrillic", "LIT-модулі", "line 3") in findings
+
+
+def test_wiki_text_mode_allowlists_urls_code_and_legitimate_latin(tmp_path):
+    article = tmp_path / "subject.md"
+    article.write_text(
+        "# Постать\n\n"
+        "Дослідження X-променів, STEM-освіта, IEU та Ems-указ.\n"
+        "Посилання https://example.com/Арест і `LIT-модулі` не є прозою.\n"
+        "```\n"
+        "Арест і LIT-модулі всередині коду.\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+    assert lint_text(article) == []

--- a/tests/test_wiki_subject.py
+++ b/tests/test_wiki_subject.py
@@ -1,0 +1,95 @@
+"""Tests for BIO wiki subject and VERIFY-marker gates."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_project_root, "scripts"))
+
+from validate.check_wiki_subject import check_wiki_file
+from validate.check_wiki_verify_markers import find_verify_markers_text
+
+
+def _write_wiki(tmp_path, slug: str, h1: str, meta_slug: str | None = None):
+    path = tmp_path / f"{slug}.md"
+    path.write_text(
+        f"# {h1}\n\n"
+        "<!-- wiki-meta\n"
+        f"slug: {meta_slug or slug}\n"
+        "domain: figures\n"
+        "-->\n\n"
+        "## Короткий зміст\n"
+        "Текст статті.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_wiki_subject_flags_h1_for_different_figure(tmp_path):
+    path = _write_wiki(
+        tmp_path,
+        "anatol-petrytskyi",
+        "Микола Куліш: Драматургія мовного вибору",
+        meta_slug="anatol-petrytskyi",
+    )
+
+    finding = check_wiki_file(path, plan_title="Анатоль Петрицький: Сценограф")
+
+    assert finding is not None
+    assert finding.file_slug == "anatol-petrytskyi"
+    assert finding.frontmatter_slug == "anatol-petrytskyi"
+    assert "Микола Куліш" in finding.h1
+
+
+def test_wiki_subject_accepts_panteleimon_kulish_not_mykola_false_positive(tmp_path):
+    path = _write_wiki(
+        tmp_path,
+        "panteleimon-kulish",
+        "Біографія: Пантелеймон Куліш: Європеєць на хуторі",
+    )
+
+    assert check_wiki_file(path, plan_title="Пантелеймон Куліш: Європеєць на хуторі") is None
+
+
+def test_wiki_subject_accepts_h1_subtitle_without_colon(tmp_path):
+    path = _write_wiki(
+        tmp_path,
+        "volodymyr-monomakh",
+        "Біографія: Володимир Мономах — Укріплювач Русі та мислитель",
+    )
+
+    assert check_wiki_file(path, plan_title="Володимир Мономах: Укріплювач Русі") is None
+
+
+def test_wiki_subject_accepts_prepositional_h1_subtitle(tmp_path):
+    path = _write_wiki(
+        tmp_path,
+        "mykola-vasylenko",
+        "Біографія: Микола Василенко в інтелектуальному та правовому контексті епохи",
+    )
+
+    assert check_wiki_file(path, plan_title="Микола Василенко: Юрист і державник") is None
+
+
+def test_wiki_subject_distinguishes_two_kulish_figures(tmp_path):
+    path = _write_wiki(
+        tmp_path,
+        "panteleimon-kulish",
+        "Біографія: Микола Куліш: Драматург",
+    )
+
+    assert check_wiki_file(path, plan_title="Пантелеймон Куліш: Європеєць на хуторі") is not None
+
+
+def test_wiki_subject_verify_marker_gate_flags_survivor():
+    findings = find_verify_markers_text("Текст <!-- VERIFY: дата -->\nVERIFY: джерело")
+
+    assert len(findings) == 2
+    assert findings[0].line == 1
+    assert findings[1].line == 2
+
+
+def test_wiki_subject_verify_marker_gate_accepts_clean_text():
+    assert find_verify_markers_text("Текст без маркерів.") == []


### PR DESCRIPTION
## Summary
- Extends `lint_seminar_quality.py` with `--format {plan,text,auto}` plus directory-aware `--paths`; wiki figure scan found 15 flagged files, 17 high findings, 8 advisory findings.
- Adds `check_discovery_integrity.py`; BIO scan found 9 discovery topic/plan-title subject mismatches.
- Adds `check_wiki_subject.py`; BIO scan found 9 wiki H1 subject mismatches and does not flag the real `panteleimon-kulish` page.
- Adds `check_wiki_verify_markers.py`; BIO scan found 159 surviving VERIFY markers, and wiki compile readiness/post-write checks now reject marker survivors.
- Adds `check_citation_resolution.py`; BIO scan found 180 figure articles using `[S#]` citations without a visible source-list mapping.

## Validation
- `.venv/bin/python scripts/validate/lint_seminar_quality.py --paths wiki/figures`
- `.venv/bin/python scripts/validate/check_discovery_integrity.py --track bio`
- `.venv/bin/python scripts/validate/check_wiki_subject.py`
- `.venv/bin/python scripts/validate/check_wiki_verify_markers.py`
- `.venv/bin/python scripts/validate/check_citation_resolution.py`
- `.venv/bin/python -m pytest tests/ -k "seminar_quality or discovery_integrity or wiki_subject or citation"`
- `.venv/bin/ruff check scripts/validate/lint_seminar_quality.py scripts/validate/bio_subjects.py scripts/validate/check_citation_resolution.py scripts/validate/check_discovery_integrity.py scripts/validate/check_wiki_subject.py scripts/validate/check_wiki_verify_markers.py scripts/wiki/compile.py scripts/wiki/compiler.py tests/test_lint_seminar_quality.py tests/test_citation_resolution_gate.py tests/test_discovery_integrity.py tests/test_wiki_subject.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`