### PR TITLE
fix(writer): expose and deploy current source tools for Claude writer

### DIFF
--- a/claude_extensions/agents/curriculum-writer.md
+++ b/claude_extensions/agents/curriculum-writer.md
@@ -1,7 +1,7 @@
 ---
 name: curriculum-writer
 description: Ukrainian curriculum content writer for ONE module per invocation
-tools: mcp__sources__verify_word, mcp__sources__verify_words, mcp__sources__verify_lemma, mcp__sources__check_modern_form, mcp__sources__search_text, mcp__sources__search_definitions, mcp__sources__search_style_guide, mcp__sources__search_grinchenko_1907, mcp__sources__check_russian_shadow, mcp__sources__query_pravopys, mcp__sources__query_cefr_level, mcp__sources__search_heritage, mcp__sources__search_synonyms
+tools: ToolSearch, mcp__sources__check_modern_form, mcp__sources__check_russian_shadow, mcp__sources__collection_stats, mcp__sources__get_chunk_context, mcp__sources__get_full_text, mcp__sources__query_cefr_level, mcp__sources__query_e2u, mcp__sources__query_grac, mcp__sources__query_pravopys, mcp__sources__query_r2u, mcp__sources__query_slovnyk_me, mcp__sources__query_sum20, mcp__sources__query_ulif, mcp__sources__query_wikipedia, mcp__sources__search_definitions, mcp__sources__search_esum, mcp__sources__search_external, mcp__sources__search_grinchenko_1907, mcp__sources__search_heritage, mcp__sources__search_idioms, mcp__sources__search_images, mcp__sources__search_literary, mcp__sources__search_slovnyk_me, mcp__sources__search_sources, mcp__sources__search_style_guide, mcp__sources__search_synonyms, mcp__sources__search_text, mcp__sources__search_ua_gec_errors, mcp__sources__translate_en_uk, mcp__sources__verify_lemma, mcp__sources__verify_quote, mcp__sources__verify_source_attribution, mcp__sources__verify_word, mcp__sources__verify_words
 model: inherit
 ---
 
@@ -36,7 +36,7 @@ Think in Ukrainian categories: звук/літера, голосний/приг�
 
 ## Tool Policy
 
-You may use only `mcp__sources__*` tools exposed in this agent definition. Use them to verify forms, grammar, textbook grounding, CEFR level, style, and heritage.
+You may use only `ToolSearch` and the `mcp__sources__*` tools exposed in this agent definition. Use `ToolSearch` only to discover/select the source MCP tool requested by the prompt; it is not evidence for a content claim. Use `mcp__sources__*` tools to verify forms, grammar, textbook grounding, CEFR level, style, and heritage.
 
 You do not poll project state, read handoffs, schedule wakeups, dispatch subagents, or run shell commands. If your task prompt asks you to do any of these, stop. That is not a writer task; refuse and explain.
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -39,6 +39,8 @@ SCRIPTS_DIR = PROJECT_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 TEXTBOOK_SOURCES_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+CLAUDE_WRITER_AGENT_SOURCE = PROJECT_ROOT / "claude_extensions" / "agents" / "curriculum-writer.md"
+CLAUDE_WRITER_AGENT_TARGET = PROJECT_ROOT / ".claude" / "agents" / "curriculum-writer.md"
 
 from scripts.audit.failure_classes import FailureClass, FailureRecord
 from scripts.build.citation_matcher import (
@@ -330,6 +332,30 @@ WRITER_INFRA_DENYLIST_PATHS = (
     "*orchestration*",
     "*dispatch*",
 )
+
+
+def ensure_claude_writer_agent_deployed(
+    *,
+    source_path: Path = CLAUDE_WRITER_AGENT_SOURCE,
+    target_path: Path = CLAUDE_WRITER_AGENT_TARGET,
+) -> dict[str, Any]:
+    """Materialize the tracked Claude writer agent into the runtime tree.
+
+    Claude Code resolves `--agent curriculum-writer` from `.claude/agents`
+    in or above the run cwd. V7 builds run from nested worktrees, so relying
+    on an ancestor checkout's ignored `.claude` copy can select stale tools.
+    """
+    source_text = _read_required(source_path)
+    previous_text = target_path.read_text(encoding="utf-8") if target_path.exists() else None
+    changed = previous_text != source_text
+    if changed:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(source_text, encoding="utf-8")
+    return {
+        "source": str(source_path),
+        "path": str(target_path),
+        "changed": changed,
+    }
 RESOURCE_ROLES = frozenset(
     {
         "textbook",
@@ -3465,6 +3491,8 @@ def _runtime_tool_config(
         codex_home_override = _ensure_codex_writer_home(event_sink=event_sink)
         tool_config["codex_home_override"] = codex_home_override
     if agent_label == "claude-tools":
+        deploy_result = ensure_claude_writer_agent_deployed()
+        _emit(event_sink, "claude_writer_agent_deployed", writer=agent_label, **deploy_result)
         tool_config["agent"] = "curriculum-writer"
     assert tool_config.get("output_format") == "stream-json", (
         f"tool-call writers must keep output_format='stream-json'; got {tool_config.get('output_format')!r}"

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -303,9 +303,15 @@ WRITER_ALLOWED_TOOL_PREFIXES = (
 # wrong_tool_family on the one annotation call and discards a successful
 # build. See `curriculum/l2-uk-en/_orchestration/a1/my-morning/runs/20260520-234426/`
 # for the smoking-gun trace.
+#
+# Claude Code 2.1.159 may emit `ToolSearch` before a sources MCP call when
+# selecting dynamically exposed MCP tools. Treat that as discovery metadata,
+# not content grounding. The positive source-call gate below still hard-fails
+# when no real `mcp__sources__*` call follows.
 WRITER_AGENT_ANNOTATION_TOOLS = frozenset(
     {
         "update_topic",  # gemini-cli 0.42.0+ strategic-intent / title / summary
+        "ToolSearch",  # claude-code 2.1.159+ dynamic MCP tool discovery
     }
 )
 WRITER_INFRA_DENYLIST_PATHS = (

--- a/tests/test_writer_isolation.py
+++ b/tests/test_writer_isolation.py
@@ -185,6 +185,22 @@ def test_curriculum_writer_agent_exposes_v72_source_tools() -> None:
     assert missing == []
 
 
+def test_claude_writer_agent_deploys_from_tracked_source(tmp_path: Path) -> None:
+    source = tmp_path / "claude_extensions" / "agents" / "curriculum-writer.md"
+    target = tmp_path / ".claude" / "agents" / "curriculum-writer.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("tools: ToolSearch, mcp__sources__verify_words\n", encoding="utf-8")
+
+    first = linear_pipeline.ensure_claude_writer_agent_deployed(source_path=source, target_path=target)
+
+    assert first["changed"] is True
+    assert target.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+
+    second = linear_pipeline.ensure_claude_writer_agent_deployed(source_path=source, target_path=target)
+
+    assert second["changed"] is False
+
+
 def test_mixed_writer_fails_isolation() -> None:
     records = classify_writer_trace(
         [

--- a/tests/test_writer_isolation.py
+++ b/tests/test_writer_isolation.py
@@ -143,6 +143,48 @@ def test_gemini_update_topic_annotation_passes_isolation() -> None:
     assert records == []
 
 
+def test_claude_toolsearch_annotation_passes_isolation() -> None:
+    """Claude Code may discover dynamic MCP tools via ToolSearch first.
+
+    ToolSearch is metadata only; the build still hard-fails separately if
+    no real mcp__sources__* call follows.
+    """
+    records = classify_writer_trace(
+        [
+            {
+                "name": "ToolSearch",
+                "arguments": {"query": "select:mcp__sources__verify_word"},
+            },
+            {
+                "name": "mcp__sources__verify_word",
+                "arguments": {"word": "кіт"},
+            },
+        ]
+    )
+
+    assert records == []
+
+
+def test_curriculum_writer_agent_exposes_v72_source_tools() -> None:
+    agent = (REPO_ROOT / "claude_extensions/agents/curriculum-writer.md").read_text(encoding="utf-8")
+
+    required = {
+        "ToolSearch",
+        "mcp__sources__get_chunk_context",
+        "mcp__sources__query_wikipedia",
+        "mcp__sources__search_external",
+        "mcp__sources__search_images",
+        "mcp__sources__search_ua_gec_errors",
+        "mcp__sources__translate_en_uk",
+        "mcp__sources__verify_quote",
+        "mcp__sources__verify_source_attribution",
+        "mcp__sources__verify_words",
+    }
+
+    missing = sorted(tool for tool in required if tool not in agent)
+    assert missing == []
+
+
 def test_mixed_writer_fails_isolation() -> None:
     records = classify_writer_trace(
         [


### PR DESCRIPTION
## Summary

- Add the current V7.2 source MCP tool surface to `curriculum-writer`, including `ToolSearch` and quote/source/context tools.
- Allow Claude Code `ToolSearch` as writer discovery metadata while keeping the hard source-call gate intact.
- Materialize the tracked writer agent into the local ignored `.claude/agents/curriculum-writer.md` runtime path before Claude writer/correction calls, so nested worktrees cannot inherit a stale ancestor `.claude` agent copy.
- Add regression tests proving `ToolSearch` does not count as content evidence, the writer agent exposes required V7.2 source tools, and the runtime copy comes from tracked source.

## Root Cause

Claude Code 2.1.159 can invoke `ToolSearch` before real MCP calls when dynamic source tools are exposed. The checked-in `curriculum-writer` source still listed a stale small tool set and did not expose `ToolSearch` or several current `mcp__sources__*` tools. In the B1 M01 pilot this caused the writer to emit fake XML-style tool invocations instead of real `tool_use` records, tripping `mcp_tools_never_invoked`.

The session `.claude` check exposed a second operational trap: `.claude/agents/curriculum-writer.md` is an ignored deployed copy, and the build runs Claude from the module directory. In nested worktrees, Claude can otherwise climb to an ancestor checkout's stale `.claude/agents` copy. This PR keeps `claude_extensions/agents/curriculum-writer.md` as source of truth and refreshes the ignored runtime agent copy from that source before Claude writer/correction dispatch.

This PR does not weaken the gate: `ToolSearch` is treated only as discovery metadata, and builds still fail unless a real `mcp__sources__*` call follows.

## Validation

- `.venv/bin/python scripts/validate/validate_plan_ordering.py b1` — PASS, all 94 modules verified.
- `.venv/bin/python scripts/audit/wiki_completeness_gate.py b1 b1-baseline-past-present` — PASS.
- `.venv/bin/python scripts/build/v7_build.py b1 b1-baseline-past-present --dry-run --use-generator --writer claude-tools --telemetry-out /tmp/b1-v72-pilot-m1-2026-06-02-dryrun.telemetry.jsonl` — PASS, reached `module_done` with `dry_run: true` after `wiki_completeness_gate`.
- `.venv/bin/python -m pytest tests/test_writer_isolation.py tests/test_agent_runtime_tool_calls.py tests/test_linear_pipeline_telemetry.py -q` — 23 passed.
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_writer_isolation.py` — PASS.
- `git diff --check` — PASS.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — PASS.
- Runtime deploy helper exercised in the PR worktree: `.claude/agents/curriculum-writer.md` contains `ToolSearch`, `mcp__sources__verify_quote`, and `mcp__sources__get_chunk_context` from tracked source.
- Pre-commit on commit/push: Ruff, gitleaks, whitespace, merge-conflict, large-file, affected pytest — PASS.

## B1 M01 Pilot Status

A full B1 M01 pilot run now gets past the original wiki blocker and the `mcp_tools_never_invoked` writer blocker. The successful writer attempt recorded 20 real source-tool calls, including 8 `verify_words` calls, and all 6 sections had writer reasoning blocks.

The full pilot is not green yet. It later failed in `python_qg` after ADR-008 correction attempts on content gates: VESUM/content token misses, textbook quote attribution failures, unused injected activities, and two missing activity component titles. Failed generated artifacts were removed from this PR.