### PR TITLE
fix(b2): repair readiness plan reference drift

### DIFF
--- a/curriculum/l2-uk-en/plans/b2/academic-writing.yaml
+++ b/curriculum/l2-uk-en/plans/b2/academic-writing.yaml
@@ -156,6 +156,6 @@ references:
 - Ворон А. А. Українська мова. 11 клас (2019) — Академічне красномовство
 - 'State Standard 2024: B2 SS 3 — Professional communication themes'
 connects_to:
-  previous: professional-reports-advanced
+  previous: professional-reports
   next: text-analysis
 phase: B2.3 [Skills & Checkpoint]

--- a/curriculum/l2-uk-en/plans/b2/advanced-conjunctions-i.yaml
+++ b/curriculum/l2-uk-en/plans/b2/advanced-conjunctions-i.yaml
@@ -152,6 +152,6 @@ references:
 - 'Глазова, 11 клас (2019): §1-10 — Морфологічна норма'
 - 'State Standard 2024: B2 SS 4.1.3 (verb forms)'
 connects_to:
-  previous: word-formation-adverbs-integration
+  previous: word-formation-adjective-adverbs
   next: advanced-conjunctions-ii
 phase: B2.2 [Phraseology & Synonymy]

--- a/curriculum/l2-uk-en/plans/b2/aspect-nuances-secondary-imperfectivization.yaml
+++ b/curriculum/l2-uk-en/plans/b2/aspect-nuances-secondary-imperfectivization.yaml
@@ -172,5 +172,5 @@ references:
 - 'Авраменко, 11 клас (2019): §15-20 — Морфологічна норма'
 - 'State Standard 2024: B2 SS 4.1.3 (verb forms)'
 connects_to:
-  previous: checkpoint-domain
+  previous: checkpoint-cases-morphology
   next: aspect-nuances-imperative-infinitive

--- a/curriculum/l2-uk-en/plans/b2/b2-final-exam.yaml
+++ b/curriculum/l2-uk-en/plans/b2/b2-final-exam.yaml
@@ -156,6 +156,6 @@ references:
 - Глазова О. П. Українська мова. 11 клас (2019) — Тематична лексика для ЗНО
 - 'State Standard 2024: B2 — Full level assessment criteria'
 connects_to:
-  previous: b2-pidsumkovyy-ohlyad
+  previous: religion-in-ukraine
   next:
 phase: B2.4 [Communication Skills]

--- a/curriculum/l2-uk-en/plans/b2/direct-indirect-speech.yaml
+++ b/curriculum/l2-uk-en/plans/b2/direct-indirect-speech.yaml
@@ -163,4 +163,4 @@ references:
   topic: Syntax — direct and indirect speech
 connects_to:
   previous: complex-syntax-ellipsis-parcelling
-  next: checkpoint-syntax
+  next: checkpoint-syntax-ii

--- a/curriculum/l2-uk-en/plans/b2/discussion-debate.yaml
+++ b/curriculum/l2-uk-en/plans/b2/discussion-debate.yaml
@@ -147,6 +147,6 @@ references:
 - Ворон А. А. Українська мова. 11 клас (2019) — Академічне красномовство
 - 'State Standard 2024: B2 SS 3 — Professional communication, debate skills'
 connects_to:
-  previous: presentation-skills-advanced
+  previous: presentation-skills
   next: checkpoint-communication
 phase: B2.4 [Communication Skills]

--- a/curriculum/l2-uk-en/plans/b2/economics-business-vocabulary.yaml
+++ b/curriculum/l2-uk-en/plans/b2/economics-business-vocabulary.yaml
@@ -174,4 +174,4 @@ references:
 - 'State Standard 2024: B2 SS 3 (Thematic areas: суспільство, право, економіка)'
 connects_to:
   previous: law-justice-vocabulary
-  next: checkpoint-domain
+  next: genitive-advanced

--- a/curriculum/l2-uk-en/plans/b2/neologisms-borrowings.yaml
+++ b/curriculum/l2-uk-en/plans/b2/neologisms-borrowings.yaml
@@ -152,4 +152,4 @@ references:
 - 'State Standard 2024: B2 SS 4.4 — Lexicology, neologisms'
 connects_to:
   previous: idioms-nature
-  next: checkpoint-lexicology
+  next: checkpoint-lexicology-ii

--- a/curriculum/l2-uk-en/plans/b2/phonetic-stylistic-devices.yaml
+++ b/curriculum/l2-uk-en/plans/b2/phonetic-stylistic-devices.yaml
@@ -165,5 +165,5 @@ references:
   pages: SS 4.4
   topic: Стилістика (B2)
 connects_to:
-  previous: checkpoint-syntax
+  previous: checkpoint-syntax-ii
   next: lexical-stylistic-devices

--- a/curriculum/l2-uk-en/plans/b2/politics-government-vocabulary.yaml
+++ b/curriculum/l2-uk-en/plans/b2/politics-government-vocabulary.yaml
@@ -175,5 +175,5 @@ references:
 - 'Авраменко, 11 клас (2019): Лексикологія — терміни, професіоналізми, запозичення'
 - 'State Standard 2024: B2 SS 3 (Thematic areas: суспільство, право, економіка)'
 connects_to:
-  previous: checkpoint-register
+  previous: register-practice-cross-register-rewriting
   next: law-justice-vocabulary

--- a/curriculum/l2-uk-en/plans/b2/professional-email-advanced.yaml
+++ b/curriculum/l2-uk-en/plans/b2/professional-email-advanced.yaml
@@ -163,5 +163,5 @@ references:
 - 'State Standard 2024: B2 SS 3 — Professional communication themes'
 connects_to:
   previous: professional-email-basics
-  next: professional-reports-basics
+  next: professional-reports
 phase: B2.4 [Communication Skills]

--- a/curriculum/l2-uk-en/plans/b2/professional-email-basics.yaml
+++ b/curriculum/l2-uk-en/plans/b2/professional-email-basics.yaml
@@ -150,6 +150,6 @@ references:
   мовлення
 - 'State Standard 2024: B2 SS 3 — Professional communication themes'
 connects_to:
-  previous: checkpoint-lexicology
+  previous: checkpoint-lexicology-ii
   next: professional-email-advanced
 phase: B2.4 [Communication Skills]

--- a/curriculum/l2-uk-en/plans/b2/pronoun-system-advanced.yaml
+++ b/curriculum/l2-uk-en/plans/b2/pronoun-system-advanced.yaml
@@ -123,5 +123,5 @@ references:
 - title: Авраменко Grade 10, p. 45-50
   notes: Стилістика займенників та морфологічна норма.
 connects_to:
-- b2-057 (advanced-case-semantics)
-- b2-059 (some-other-grammar-module)
+- b2-051 (advanced-case-semantics)
+- b2-053 (checkpoint-cases-morphology)

--- a/curriculum/l2-uk-en/plans/b2/register-business-ukrainian.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-business-ukrainian.yaml
@@ -177,5 +177,5 @@ references:
   topic: Стилістика (B2)
 connects_to:
   previous: register-formal-informal
-  next: register-academic-technical
+  next: register-formal-written
 phase: B2.1b [Participles & Register Intro]

--- a/curriculum/l2-uk-en/plans/b2/register-formal-informal.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-formal-informal.yaml
@@ -171,6 +171,6 @@ references:
   pages: SS 4.4
   topic: Стилістика (B2)
 connects_to:
-  previous: register-introduction
+  previous: mistsia-i-oriientyry
   next: register-business-ukrainian
 phase: B2.1b [Participles & Register Intro]

--- a/curriculum/l2-uk-en/plans/b2/register-literary-ukrainian.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-literary-ukrainian.yaml
@@ -171,6 +171,6 @@ references:
   pages: SS 4.4
   topic: Стилістика (B2)
 connects_to:
-  previous: register-official-legal
-  next: register-media-journalistic
+  previous: tradytsii-i-zvychai
+  next: register-public-discourse
 phase: B2.1b [Participles & Register Intro]

--- a/curriculum/l2-uk-en/plans/b2/register-practice-cross-register-rewriting.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-practice-cross-register-rewriting.yaml
@@ -181,5 +181,5 @@ references:
   pages: SS 4.4
   topic: Стилістика (B2)
 connects_to:
-  previous: register-religious-ukrainian
-  next: checkpoint-register
+  previous: checkpoint-register-domain
+  next: politics-government-vocabulary

--- a/curriculum/l2-uk-en/plans/b2/religion-in-ukraine.yaml
+++ b/curriculum/l2-uk-en/plans/b2/religion-in-ukraine.yaml
@@ -152,5 +152,5 @@ references:
 - 'State Standard 2024: B2 SS 3 — Thematic areas: суспільство, культура'
 connects_to:
   previous: modern-diaspora
-  next: capstone-research
+  next: b2-final-exam
 phase: B2.3 [Skills & Checkpoint]

--- a/curriculum/l2-uk-en/plans/b2/syntactic-stylistic-devices.yaml
+++ b/curriculum/l2-uk-en/plans/b2/syntactic-stylistic-devices.yaml
@@ -172,4 +172,4 @@ references:
   topic: Стилістика (B2)
 connects_to:
   previous: lexical-stylistic-devices
-  next: register-introduction
+  next: mistsia-i-oriientyry


### PR DESCRIPTION
## Summary
- Corrects stale B2 `connects_to` references in the pronoun and merged-plan metadata slice.
- Keeps the PR under the repository cap at 19 changed files.
- Does not create lesson content, generated artifacts, status files, audit reviews, or backup files.

## Validation
- `.venv/bin/python scripts/validate/validate_plan_ordering.py b2`
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Forbidden-file diff grep for linter configs, `.python-version`, generated status/audit/review artifacts, and `.bak` files

## Follow-up
- Next PR should handle the remaining B2 neighbor-link drift as a separate under-20-file slice.
- `slug:` metadata remains blocked by the plan immutability hook policy, so it needs a separate policy PR before slug backfill.