### PR TITLE
fix(b2): align remaining neighbor plan links

### DIFF
--- a/curriculum/l2-uk-en/plans/b2/active-participles-past.yaml
+++ b/curriculum/l2-uk-en/plans/b2/active-participles-past.yaml
@@ -179,7 +179,7 @@ references:
   pages: §25, с. 81–82
   topic: Нормативність дієприкметникових форм
 connects_to:
-  previous: active-participles-present
+  previous: checkpoint-passive-voice
   next: participles-vs-relative-clauses
 changelog:
 - version: '1.2'

--- a/curriculum/l2-uk-en/plans/b2/active-participles-present.yaml
+++ b/curriculum/l2-uk-en/plans/b2/active-participles-present.yaml
@@ -185,8 +185,8 @@ references:
   pages: §25, с. 81–82
   topic: Обмеження вживання активних дієприкметників
 connects_to:
-  previous: passive-in-context
-  next: active-participles-past
+  previous: pobut-shchodenne
+  next: checkpoint-passive-voice
 changelog:
 - version: '1.2'
   date: '2023-10-27'

--- a/curriculum/l2-uk-en/plans/b2/b2-impersonal-passive.yaml
+++ b/curriculum/l2-uk-en/plans/b2/b2-impersonal-passive.yaml
@@ -136,7 +136,7 @@ references:
   topic: Безособові форми на -но/-то vs дієприкметники-присудки
 connects_to:
   previous: past-passive-participles
-  next: reflexive-passive
+  next: dim-zhytlo
 prerequisites:
 - past-passive-participles
 grammar:

--- a/curriculum/l2-uk-en/plans/b2/b2-one-member-sentences.yaml
+++ b/curriculum/l2-uk-en/plans/b2/b2-one-member-sentences.yaml
@@ -182,7 +182,7 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — one-member sentences
 connects_to:
-  previous: secondary-sentence-members
+  previous: sport-i-dozvillia
   next: homogeneous-members
 changelog:
 - version: '1.3'

--- a/curriculum/l2-uk-en/plans/b2/checkpoint-morphology.yaml
+++ b/curriculum/l2-uk-en/plans/b2/checkpoint-morphology.yaml
@@ -153,4 +153,4 @@ references:
 - 'State Standard 2024: B2 SS 4.1.3 (verb forms), SS 4.2 (word formation)'
 connects_to:
   previous: advanced-conjunctions-ii
-  next: advanced-case-semantics
+  next: synonymy-types-and-rows

--- a/curriculum/l2-uk-en/plans/b2/checkpoint-passive-voice.yaml
+++ b/curriculum/l2-uk-en/plans/b2/checkpoint-passive-voice.yaml
@@ -177,8 +177,8 @@ references:
   pages: SS 4.1.3.1, SS 4.2.3
   topic: Пасивний стан з дієприкметниками, видові пари в пасиві
 connects_to:
-  previous: participles-vs-relative-clauses
-  next: phrases-word-combinations
+  previous: active-participles-present
+  next: active-participles-past
 changelog:
 - version: '1.2'
   date: '2023-10-27'

--- a/curriculum/l2-uk-en/plans/b2/complex-syntax-ellipsis-parcelling.yaml
+++ b/curriculum/l2-uk-en/plans/b2/complex-syntax-ellipsis-parcelling.yaml
@@ -162,5 +162,5 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — ellipsis and parcelling
 connects_to:
-  previous: stylistic-connectors
+  previous: kupivlia-i-servisy
   next: direct-indirect-speech

--- a/curriculum/l2-uk-en/plans/b2/detached-members.yaml
+++ b/curriculum/l2-uk-en/plans/b2/detached-members.yaml
@@ -182,5 +182,5 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — detached members
 connects_to:
-  previous: parenthetical-expressions
-  next: multi-clause-sentences
+  previous: homogeneous-members
+  next: checkpoint-syntax-i

--- a/curriculum/l2-uk-en/plans/b2/idioms-somatic.yaml
+++ b/curriculum/l2-uk-en/plans/b2/idioms-somatic.yaml
@@ -172,5 +172,5 @@ references:
 - Глазова О. П. Українська мова. 11 клас (2019), §14 — Фразеологічна норма
 - 'State Standard 2024: B2 SS 4.4 — Lexicology, phraseology'
 connects_to:
-  previous: set-expressions-combined
+  previous: checkpoint-lexicology-i
   next: idioms-animals

--- a/curriculum/l2-uk-en/plans/b2/multi-clause-sentences.yaml
+++ b/curriculum/l2-uk-en/plans/b2/multi-clause-sentences.yaml
@@ -173,5 +173,5 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — complex sentences
 connects_to:
-  previous: detached-members
-  next: correlative-constructions
+  previous: parenthetical-expressions
+  next: kharchuvannia-i-kukhnia

--- a/curriculum/l2-uk-en/plans/b2/parenthetical-expressions.yaml
+++ b/curriculum/l2-uk-en/plans/b2/parenthetical-expressions.yaml
@@ -172,5 +172,5 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — parenthetical constructions
 connects_to:
-  previous: homogeneous-members
-  next: detached-members
+  previous: checkpoint-syntax-i
+  next: multi-clause-sentences

--- a/curriculum/l2-uk-en/plans/b2/participles-vs-relative-clauses.yaml
+++ b/curriculum/l2-uk-en/plans/b2/participles-vs-relative-clauses.yaml
@@ -187,7 +187,7 @@ references:
   topic: Стилістичні особливості синтаксичних конструкцій
 connects_to:
   previous: active-participles-past
-  next: checkpoint-passive-voice
+  next: zdorovya-i-medytsyna
 changelog:
 - version: '1.2'
   date: '2023-10-27'

--- a/curriculum/l2-uk-en/plans/b2/passive-in-context.yaml
+++ b/curriculum/l2-uk-en/plans/b2/passive-in-context.yaml
@@ -195,7 +195,7 @@ references:
   topic: Пасивний стан, видові пари в пасиві
 connects_to:
   previous: third-person-plural-passive
-  next: active-participles-present
+  next: pobut-shchodenne
 changelog:
 - version: '1.2'
   date: '2023-10-27'

--- a/curriculum/l2-uk-en/plans/b2/phrases-word-combinations.yaml
+++ b/curriculum/l2-uk-en/plans/b2/phrases-word-combinations.yaml
@@ -176,7 +176,7 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — phrase structure
 connects_to:
-  previous: checkpoint-passive-voice
+  previous: zdorovya-i-medytsyna
   next: predicate-types
 changelog:
 - version: '1.3'

--- a/curriculum/l2-uk-en/plans/b2/reflexive-passive.yaml
+++ b/curriculum/l2-uk-en/plans/b2/reflexive-passive.yaml
@@ -137,7 +137,7 @@ references:
   pages: §75, с. 187
   topic: Зворотний стан дієслова
 connects_to:
-  previous: b2-impersonal-passive
+  previous: dim-zhytlo
   next: third-person-plural-passive
 prerequisites:
 - b2-impersonal-passive

--- a/curriculum/l2-uk-en/plans/b2/text-analysis.yaml
+++ b/curriculum/l2-uk-en/plans/b2/text-analysis.yaml
@@ -153,5 +153,5 @@ references:
 - 'State Standard 2024: B2 SS 3 — Professional communication, text analysis'
 connects_to:
   previous: academic-writing
-  next: news-analysis-basics
+  next: news-analysis
 phase: B2.3 [Skills & Checkpoint]

--- a/curriculum/l2-uk-en/plans/b2/word-formation-place-object-names.yaml
+++ b/curriculum/l2-uk-en/plans/b2/word-formation-place-object-names.yaml
@@ -169,5 +169,5 @@ references:
 - 'State Standard 2024: B2 SS 4.2 (word formation)'
 connects_to:
   previous: word-formation-abstract-nouns
-  next: word-formation-adjective-formation
+  next: word-formation-adjective-adverbs
 phase: B2.1c [Register System & Domain Vocabulary]


### PR DESCRIPTION
## Summary
- Fixes the next B2 neighbor-link slice of stale `connects_to` metadata.
- Keeps this stacked PR at 18 changed files against `codex/b2-readiness`.
- Does not create lesson content, generated artifacts, review artifacts, backup files, or config changes.

## Stack
- Base PR: #2570 (`codex/b2-readiness`).
- Retarget this PR to `main` after #2570 merges.

## Validation
- `.venv/bin/python scripts/validate/validate_plan_ordering.py b2`
- `git diff --check codex/b2-readiness..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Forbidden-file diff grep for linter configs, `.python-version`, generated status/audit/review artifacts, and `.bak` files