### PR TITLE
fix(b2): finish tail neighbor plan links

### DIFF
--- a/curriculum/l2-uk-en/plans/b2/correlative-constructions.yaml
+++ b/curriculum/l2-uk-en/plans/b2/correlative-constructions.yaml
@@ -164,5 +164,5 @@ references:
   pages: B2, SS 4.3
   topic: Syntax — correlative constructions
 connects_to:
-  previous: multi-clause-sentences
+  previous: kharchuvannia-i-kukhnia
   next: emphasis-and-inversion

--- a/curriculum/l2-uk-en/plans/b2/secondary-sentence-members.yaml
+++ b/curriculum/l2-uk-en/plans/b2/secondary-sentence-members.yaml
@@ -184,7 +184,7 @@ references:
   topic: Syntax — secondary sentence members
 connects_to:
   previous: predicate-types
-  next: b2-one-member-sentences
+  next: sport-i-dozvillia
 changelog:
 - version: '1.3'
   date: '2026-03-31'

--- a/curriculum/l2-uk-en/plans/b2/set-expressions-combined.yaml
+++ b/curriculum/l2-uk-en/plans/b2/set-expressions-combined.yaml
@@ -148,4 +148,4 @@ references:
 - 'State Standard 2024: B2 SS 4.4 — Lexicology, phraseology'
 connects_to:
   previous: proverbs-nature-time-caution
-  next: idioms-somatic
+  next: checkpoint-lexicology-i

--- a/curriculum/l2-uk-en/plans/b2/stylistic-connectors.yaml
+++ b/curriculum/l2-uk-en/plans/b2/stylistic-connectors.yaml
@@ -169,4 +169,4 @@ references:
   topic: Syntax — text cohesion and connectors
 connects_to:
   previous: emphasis-and-inversion
-  next: complex-syntax-ellipsis-parcelling
+  next: kupivlia-i-servisy

--- a/curriculum/l2-uk-en/plans/b2/synonymy-types-and-rows.yaml
+++ b/curriculum/l2-uk-en/plans/b2/synonymy-types-and-rows.yaml
@@ -152,5 +152,5 @@ references:
   стилях'
 - 'State Standard 2024: B2 SS 4.4 — Lexicology'
 connects_to:
-  previous: pronoun-system-advanced
+  previous: checkpoint-morphology
   next: synonymy-in-registers


### PR DESCRIPTION
## Summary
- Fixes the final tail slice of B2 stale `connects_to` metadata.
- Keeps this stacked PR at 5 changed files against `codex/b2-unblock-01-neighbor-links`.
- Does not create lesson content, generated artifacts, review artifacts, backup files, or config changes.

## Stack
- Base PR: #2571 (`codex/b2-unblock-01-neighbor-links`).
- Retarget this PR after #2571 merges.

## Validation
- `.venv/bin/python scripts/validate/validate_plan_ordering.py b2`
- `git diff --check codex/b2-unblock-01-neighbor-links..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Forbidden-file diff grep for linter configs, `.python-version`, generated status/audit/review artifacts, and `.bak` files