### PR TITLE
fix(plans): allow slug and level metadata edits

### DIFF
--- a/scripts/pre_commit/check_plan_immutability.py
+++ b/scripts/pre_commit/check_plan_immutability.py
@@ -13,7 +13,7 @@ import yaml
 
 PLAN_PATH_RE = re.compile(r"^curriculum/[^/]+/plans/.+\.yaml$")
 AUTO_FIX_TAG = "[auto-fix-plan-vocab]"
-METADATA_ONLY_FIELDS = {"module", "sequence", "connects_to", "prerequisites"}
+METADATA_ONLY_FIELDS = {"module", "sequence", "slug", "level", "connects_to", "prerequisites"}
 
 
 def _run_git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:

--- a/tests/test_plan_immutability_hook.py
+++ b/tests/test_plan_immutability_hook.py
@@ -142,6 +142,8 @@ def test_metadata_only_plan_edit_without_bak_passes(tmp_path: Path):
 
     data["module"] = "a1-002"
     data["sequence"] = 2
+    data["slug"] = "test-plan-renumbered"
+    data["level"] = "A1"
     data["prerequisites"] = ["a1-001 (previous module)"]
     plan_file.write_text(
         yaml.safe_dump(data, allow_unicode=True, sort_keys=False),


### PR DESCRIPTION
## Summary
- Adds `slug` and `level` to the plan immutability hook metadata-only field allowlist.
- Keeps semantic plan edits under the existing version bump plus `.bak` requirement.
- Expands the focused hook test so metadata-only edits cover `module`, `sequence`, `slug`, `level`, and references.

## Why
B2 slug metadata backfill is currently blocked because the hook treats missing `slug:` additions as content-bearing plan edits and requires `.bak` files. Repo policy forbids backup artifacts in these metadata cleanup PRs.

## Validation
- `.venv/bin/python -m pytest tests/test_plan_immutability_hook.py`
- `.venv/bin/ruff check scripts/pre_commit/check_plan_immutability.py tests/test_plan_immutability_hook.py`
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Forbidden-file diff grep for linter configs, `.python-version`, generated status/audit/review artifacts, and `.bak` files