### PR TITLE
fix(b2): backfill plan slug metadata

### DIFF
--- a/curriculum/l2-uk-en/plans/b2/active-participles-past.yaml
+++ b/curriculum/l2-uk-en/plans/b2/active-participles-past.yaml
@@ -1,4 +1,5 @@
 module: b2-011
+slug: active-participles-past
 level: B2
 sequence: 11
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/active-participles-present.yaml
+++ b/curriculum/l2-uk-en/plans/b2/active-participles-present.yaml
@@ -1,4 +1,5 @@
 module: b2-009
+slug: active-participles-present
 level: B2
 sequence: 9
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/b2-one-member-sentences.yaml
+++ b/curriculum/l2-uk-en/plans/b2/b2-one-member-sentences.yaml
@@ -1,4 +1,5 @@
 module: b2-018
+slug: b2-one-member-sentences
 level: B2
 sequence: 18
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/checkpoint-passive-voice.yaml
+++ b/curriculum/l2-uk-en/plans/b2/checkpoint-passive-voice.yaml
@@ -1,4 +1,5 @@
 module: b2-010
+slug: checkpoint-passive-voice
 level: B2
 sequence: 10
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/homogeneous-members.yaml
+++ b/curriculum/l2-uk-en/plans/b2/homogeneous-members.yaml
@@ -1,4 +1,5 @@
 module: b2-019
+slug: homogeneous-members
 level: B2
 sequence: 19
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/lexical-stylistic-devices.yaml
+++ b/curriculum/l2-uk-en/plans/b2/lexical-stylistic-devices.yaml
@@ -1,4 +1,5 @@
 module: b2-033
+slug: lexical-stylistic-devices
 level: B2
 sequence: 33
 version: 1.2.2

--- a/curriculum/l2-uk-en/plans/b2/participles-vs-relative-clauses.yaml
+++ b/curriculum/l2-uk-en/plans/b2/participles-vs-relative-clauses.yaml
@@ -1,4 +1,5 @@
 module: b2-012
+slug: participles-vs-relative-clauses
 level: B2
 sequence: 12
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/passive-in-context.yaml
+++ b/curriculum/l2-uk-en/plans/b2/passive-in-context.yaml
@@ -1,4 +1,5 @@
 module: b2-007
+slug: passive-in-context
 level: B2
 sequence: 7
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/phrases-word-combinations.yaml
+++ b/curriculum/l2-uk-en/plans/b2/phrases-word-combinations.yaml
@@ -1,4 +1,5 @@
 module: b2-014
+slug: phrases-word-combinations
 level: B2
 sequence: 14
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/predicate-types.yaml
+++ b/curriculum/l2-uk-en/plans/b2/predicate-types.yaml
@@ -1,4 +1,5 @@
 module: b2-015
+slug: predicate-types
 level: B2
 sequence: 15
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/register-business-ukrainian.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-business-ukrainian.yaml
@@ -1,4 +1,5 @@
 module: b2-037
+slug: register-business-ukrainian
 level: B2
 sequence: 37
 version: 1.2.2

--- a/curriculum/l2-uk-en/plans/b2/register-formal-informal.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-formal-informal.yaml
@@ -1,4 +1,5 @@
 module: b2-036
+slug: register-formal-informal
 level: B2
 sequence: 36
 version: 1.2.2

--- a/curriculum/l2-uk-en/plans/b2/register-literary-ukrainian.yaml
+++ b/curriculum/l2-uk-en/plans/b2/register-literary-ukrainian.yaml
@@ -1,4 +1,5 @@
 module: b2-040
+slug: register-literary-ukrainian
 level: B2
 sequence: 40
 version: 1.2.2

--- a/curriculum/l2-uk-en/plans/b2/secondary-sentence-members.yaml
+++ b/curriculum/l2-uk-en/plans/b2/secondary-sentence-members.yaml
@@ -1,4 +1,5 @@
 module: b2-016
+slug: secondary-sentence-members
 level: B2
 sequence: 16
 version: 1.3.2

--- a/curriculum/l2-uk-en/plans/b2/syntactic-stylistic-devices.yaml
+++ b/curriculum/l2-uk-en/plans/b2/syntactic-stylistic-devices.yaml
@@ -1,4 +1,5 @@
 module: b2-034
+slug: syntactic-stylistic-devices
 level: B2
 sequence: 34
 version: 1.2.2


### PR DESCRIPTION
## Summary
- Adds missing `slug:` metadata to the 15 remaining B2 plan YAML files.
- Keeps the change metadata-only and under the repository 20-file cap.
- Does not create generated artifacts, backup files, status files, audit reviews, or config changes.

## Validation
- `.venv/bin/python scripts/validate/validate_plan_ordering.py b2`
- Per-file `.venv/bin/python scripts/validate_plan_config.py <level>/<slug> --quiet` for all changed files
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- B2 slug coverage check: missing=0, wrong=0
- Forbidden-file diff grep for linter configs, `.python-version`, generated status/audit/review artifacts, and `.bak` files

## Notes
- This depends on the merged hook-policy PR #2573, which allows non-semantic `slug`/`level` metadata corrections without `.bak` snapshots.