### PR TITLE
research(bio): 6 sourced dossiers — Wave B foundational ungrounded figures (#2535)

### DIFF
--- a/docs/research/bio/borys-paton.md
+++ b/docs/research/bio/borys-paton.md
@@ -1,0 +1,159 @@
+# Борис Євгенович Патон — Research Dossier
+
+**Slug:** `borys-paton`
+**Block:** I (institution-builder / scientist — NOT a repression victim; Soviet-then-Ukrainian establishment figure)
+**Tier:** 2
+**Issue:** #2535 (original-180 ghost-wiki uplift — Wave B)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (НАН України некролог; Інститут електрозварювання; Українська дипломатична енциклопедія; ВУЕ)
+- [N/A → reframed] "Oppression mechanism" — Paton was the **scientific establishment**, decorated by the USSR and independent Ukraine alike, not a repression victim. §2 is reframed as an honest anti-hagiography (the brief's explicit ask: gerontocracy, the Sakharov letter, post-1991 brain drain), NOT a "celebratory read."
+- [x] ≥2 primary-source quotes (recorded speech / interviews of the figure — two pro-science statements + one anti-decommunisation statement, the last load-bearing for §6)
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+- [x] Sourced to Paton-specific material, NOT to his father's article (the brief's ⚠)
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Борис Євгенович Патон. [T3: uk.wikipedia — Патон Борис Євгенович, cross-checked against НАН України некролог]
+- **Pseudonyms / aliases:** none. Russified form (forbidden in body text, listed only in §8): Борис Евгеньевич Патон / Boris Paton.
+- **Born:** **14 November 1918** (his passport erroneously recorded **27 November 1918**) | Київ | then the **Українська Держава** (the Hetmanate of Pavlo Skoropadsky, which still held Kyiv in mid-November 1918). [T3: uk.wikipedia — "14 листопада 1918 (у паспортних даних помилково вказано 27 листопада 1918)"]
+- **Died:** **19 August 2020** (aged 101) | Київ | Україна | buried 22 August at Байкове кладовище, in the same grave as his parents (central avenue, plot № 1). [T2: НАН України некролог, 20.08.2020; T5: Укрінформ, 19.08.2020]
+- **Family / education key facts:** Son of **Євген Оскарович Патон** (1870–1953, see [[yevhen-paton]]) and Наталія Вікторівна (Будде, 1884–1971); younger brother of Володимир. Graduated the **Kyiv Polytechnic Institute (1941)** as an electrical engineer; кандидат (1945) and доктор (1952) of technical sciences; professor (1954); академік АН УРСР (1958), академік АН СРСР (1962). Wife Ольга Борисівна (1921–2013); daughter Євгенія (1956–2009), corresponding member of NANU. [T3: uk.wikipedia — Життєпис]
+
+**Source disagreement note (flagged, not smoothed):** The **birth date** itself carries a documented internal discrepancy — **14 November 1918** is the accepted date, while his **passport recorded 27 November 1918** (uk.wikipedia states this explicitly). State which document a date comes from. (No genuine cross-source conflict on the year or place.)
+
+## 2. Relationship to Soviet and Ukrainian power (anti-hagiography — NO oppression mechanism)
+
+> **This figure is not a repression victim** — he was, for six decades, the head of Ukraine's Academy of Sciences. Per the batch brief's explicit instruction ("deliver the anti-hagiography honestly… don't read celebratory"), this section documents the establishment record straight: deep Soviet-party integration, complicity in the persecution of a fellow scientist, gerontocracy, and the post-1991 collapse he presided over.
+
+- **Soviet-party integration.** Member of the **CPSU from 1952**; member of the **Central Committee of the Communist Party of Ukraine (1960–1991)** and full **member of the CC CPSU (1966–1991)**; deputy of the Supreme Soviet of the Ukrainian SSR (5th–11th convocations) and of the USSR (6th–11th); twice **Hero of Socialist Labour (1969, 1978)** — honours that earned him the only lifetime bust of a living Kyivan under Soviet law. [T3: uk.wikipedia — lead + Радянські нагороди]
+- **Complicity — the 1973 anti-Sakharov letter.** Paton was one of the signatories of the **"letter of academicians" (40 members of the USSR Academy of Sciences, 1973) condemning Andrei Sakharov** — i.e. he lent his name to the Soviet establishment's persecution of its most famous dissident scientist. This is the single most important anti-hagiographic fact and must not be omitted. [T3: uk.wikipedia — "Лист із засудженням поведінки Андрія Сахарова"]
+- **The 2011 Yanukovych letter.** Paton signed the **"letter of the Ukrainian intelligentsia in support of President Yanukovych's policy" (3 August 2011)**, publicly condemned at the time as "a bow before Yanukovych in the worst traditions of the *sovok*" and a "return to Soviet traditions." (One co-signatory, Сергій Квіт, later said signatories were merely phoned and asked to lend their names.) [T3: uk.wikipedia — "Лист на підтримку політики Віктора Януковича"]
+- **Opposition to decommunisation (2019).** In the Inter documentary «Борис Патон. Людина майбутнього» he stated he was **"повністю негативно"** disposed toward renaming streets and "rewriting history," and insisted the war be called **"Велика вітчизняна війна"** — the Soviet historical-memory frame. [T3: uk.wikipedia — "Ставлення до декомунізації"; recorded in the 2019 Inter film] (See §4/§6.)
+- **Gerontocracy.** Paton's **58-year presidency of the Academy (1962–2020)** and **67-year directorship of the welding institute (1953–2020)** are themselves a contested legacy: critics read the immovable, life-long leadership as a symptom of **late-Soviet institutional ossification** that outlived the system it was built for. He stepped down only in 2020, months before his death, hand-picking his successor (Анатолій Загородній). [T3: uk.wikipedia]
+- **The post-1991 collapse he presided over.** Across the three decades of independence, NANU science was starved of funding and hollowed by **brain drain** — Ukraine reduced its research base "to underdeveloped-country levels" even as Paton remained president. He himself acknowledged "**багато років економічної стагнації та соціального занепаду**" (see §4). His enormous prestige did not arrest the decline; whether his longevity protected or paralysed the academy is genuinely debated (§6). [T3: uk.wikipedia; T5: Україна молода, 2018]
+
+## 3. Major works and achievements
+
+(A scientist-organiser: "works" = innovations, institutions, and publications.)
+
+- **Електрошлаковий переплав (electroslag remelting)** — generalised in the monograph **«Електрошлаковий переплав» (1963)**, soon republished in the US and UK; the basis of a **new branch of metallurgy, спецелектрометалургія** (electroslag, plasma-arc and electron-beam remelting). [T3: uk.wikipedia — Наукова діяльність]
+- **Шлангове напівавтоматичне зварювання під флюсом (1948)** — semi-automatic flux-cored welding with thin electrode wire. [T3: uk.wikipedia]
+- **First welding in space (1969).** Equipment developed at his institute — the **«Вулкан»** apparatus — performed the **first-ever welding in space aboard Союз-6 on 16 October 1969**, operated by cosmonauts **Валерій Кубасов** and **Георгій Шонін**. Paton's institute became the recognised world leader in space welding. [T3: uk.wikipedia — Союз-6; corroborated]
+- **Welding of living/soft tissue (зварювання живих тканин)** — Paton was the author of the idea and a co-developer; the method, used in surgery, won a **State Prize of Ukraine in science and technology (2004)**. [T3: uk.wikipedia]
+- **The "Патонівський маневр" (1960s).** As academy president he built NANU's **own instrument-manufacturing base**, partly insulating it from import shocks; associated big-science projects include the **УТР-2 radio telescope**, the **У-240 isochronous cyclotron**, and the research vessel **«Михайло Ломоносов»**. [T3: uk.wikipedia]
+- **Scale of output:** **over 1000 publications, ~20 monographs, 400+ inventions/patents**; chief editor of «Автоматическая сварка» and the «Вісник НАН України». [T3: uk.wikipedia — Наукова і адміністративна діяльність]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — his scientific-organisational credo (recorded interview):**
+
+> «У науково-технічній, науково-організаційній і громадсько-політичній діяльності я завжди прагнув бути активним, творчим і конструктивним.»
+
+A compact self-summary of the organiser-of-science identity. [T5: Урядовий кур'єр — interview "Борис Патон: «Я завжди прагнув бути активним, творчим і конструктивним»"]
+
+**Quote 2 — on the value and fragility of Ukrainian science (recorded statement):**
+
+> «Україні після багатьох років економічної стагнації та соціального занепаду знов буде потрібна сильна власна наука.»
+
+Pedagogically valuable *and* quietly damning: in his own words Paton concedes the "years of economic stagnation and social decline" that coincided with his own long presidency — useful for teaching the gap between prestige and outcomes. [T3: uk.wikipedia, attributing the statement to Paton]
+
+**Quote 3 (load-bearing for §6 — recorded speech, the anti-hagiographic register):** asked in 2019 about decommunisation, Paton said he viewed it **«повністю негативно»** and insisted **«це дійсно Велика вітчизняна війна.»** This is his own voice endorsing the Soviet memory frame against Ukraine's decommunisation laws — essential context for any honest module. [T3: uk.wikipedia, quoting the 2019 Inter documentary «Борис Патон. Людина майбутнього»]
+
+## 5. Language register
+
+- **Register:** **scientific-administrative / bureaucratic** — the register of an academy president and institute director. Paton worked in **both Russian and Ukrainian** (his flagship journal «Автоматическая сварка» was Russian-language; his Ukrainian public speech is formal and official).
+- **CEFR readiness:** his interview/administrative prose is **B2–C1**; the §6 debates (decommunisation, gerontocracy, Soviet complicity) are **C1**.
+- **Lexicon notes (terms to pre-teach — VESUM-verified):** зварювання, електрозварювання, електрошлаковий переплав, академік, президія, винахід. The political-memory term **«геронтократія»** (gerontocracy) is VESUM-valid and apt for §6. [verified via `verify_words` 2026-06-03]
+- **Stylistic features:** n/a (non-literary); the teachable contrast is between the heroic public image (Hero of Ukraine №1) and the documented Soviet-loyalist record.
+
+## 6. Contested points
+
+- **Hero of Ukraine №1 vs Sakharov-letter signatory.** Paton was the **first person ever awarded "Герой України" (26 November 1998)** — yet he had signed the 1973 letter against Sakharov, the 2011 letter for Yanukovych, and opposed decommunisation in 2019. The central contested point is exactly this tension between national honour and Soviet-loyalist conduct; an honest module holds both. [T3: uk.wikipedia]
+- **Gerontocracy — preservation or paralysis?** Did a 58-year presidency *protect* NANU's autonomy and big-science base (the "Патонівський маневр" view), or *entrench* an unreformable late-Soviet structure through the independence era? Genuinely debated in Ukrainian science-policy discussion. [T5: Україна молода, 2018; framing]
+- **Brain drain and funding collapse.** The catastrophic post-1991 underfunding and emigration of Ukrainian scientists happened on his watch; his prestige did not reverse it (§2). [T3: uk.wikipedia]
+- **Russian appropriation (post-2022).** Russia's narrative claims Soviet science — including Paton-school welding — as a "Russian" achievement; honest framing credits the work as built **in Ukraine, by a Ukrainian institution**, while not erasing Paton's own Soviet loyalism. [decolonisation framing per batch brief]
+- **The "ghost-wiki" provenance problem (#2535).** Paton's existing site wiki was live but **ungrounded** (no research dossier) — this dossier is the ground truth against which it must be rebuilt; do **not** source Borys to his father Yevhen's article (the audit's ⚠).
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml` — his father, founder of the welding institute; the tightest single link ([[yevhen-paton]]).
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml` — founding president of the УАН, the academy Paton would later lead.
+  - `curriculum/l2-uk-en/plans/bio/kateryna-yushchenko.yaml` — NANU computing pioneer; a contemporary inside the same academy.
+  - `curriculum/l2-uk-en/plans/bio/ivan-puliui.yaml` — earlier Ukrainian physicist/engineer (science-track peer).
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/nezalezhnist-1991.yaml` — the independence whose science institutions Paton carried (and whose funding collapse he presided over).
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml` — the dissident generation; the Sakharov-letter contrast (§2) sits against this.
+  - `curriculum/l2-uk-en/plans/hist/yanukovych.yaml` — the 2011 intelligentsia letter Paton co-signed.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A SCIENCE/STEM-track module on Soviet/Ukrainian big science (the academy, space welding, the "Патонівський маневр").
+  - A civics/decolonisation case-study: "the establishment scientist" — honour vs complicity — paired with a repressed contemporary.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - An Андрій Сахаров reference node (for the 1973 letter), if a HIST dissidents module needs it.
+
+## 8. Naming-canonical
+
+- **Slug:** `borys-paton`
+- **EN canonical (BGN/PCGN-style project spelling):** Borys Paton
+- **UA canonical (with patronymic):** Борис Євгенович Патон
+- **Aliases to track (`aliases:` YAML field):** Borys Yevhenovych Paton; Borys Paton.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Борис Евгеньевич Патон; Boris Paton; "Boris Yevgenyevich Paton."
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **"Borys Paton"** holds official portraits; many are state-issued (NANU/government) — verify the specific **file page** licence (Ukrainian government works and freedom-of-panorama for the bust may apply; do not assume PD-by-age, as he died in 2020).
+- **Backup candidates:**
+  - Укрпошта stamp **«100 років Борису Патону» (27 November 2018)** — check postal-issue rights.
+  - The **bronze bust of Paton in Kyiv (1982, sculptor О. Скобліков)** beside the National Museum of Natural History — freedom-of-panorama candidate.
+- **Context image:** a photo of the **«Вулкан»** space-welding apparatus / Союз-6 (1969) — strong §3 illustration if rights-clear.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / reference):**
+- Велика українська енциклопедія (vue.gov.ua). "Патон, Борис Євгенович." Accessed 8.09.2020 (via uk.wikipedia citation).
+- Губерський Л. В. "Патон Борис Євгенович." *Українська дипломатична енциклопедія*, т. 2. Київ: Знання України, 2004. (Referenced via uk.wikipedia bibliography.)
+
+**Tier 2 (institutional):**
+- Національна академія наук України. **Некролог Б. Є. Патона**, 20.08.2020 — death date/burial.
+- *Керманич української науки. Життєвий і творчий шлях Б. Є. Патона: до сторіччя від дня народження* / О. С. Онищенко, Л. А. Дубровіна та ін. Київ: НАН України; НБУ ім. В. І. Вернадського, 2018. — 350 с.
+- Інститут електрозварювання ім. Є. О. Патона НАН України — institutional biography.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. "Патон Борис Євгенович." Lead, Життєпис, Нагороди, Погляди (Sakharov/Yanukovych letters, decommunisation), Союз-6. Accessed 2026-06-03 (full extract via `query_wikipedia`); dates cross-checked against the НАН України necrology.
+
+**Tier 5 (general web — used only with T1–T3 corroboration):**
+- "Борис Патон: «Я завжди прагнув бути активним, творчим і конструктивним»." *Урядовий кур'єр* — source of Quote 1 (and the «4 гривні» economic-impact line).
+- "«Вічний двигун» української науки (до 100-річчя)." *Україна молода*, 17.10.2018 — career/legacy framing.
+- "Помер Борис Патон." *Укрінформ*, 19.08.2020 — death.
+
+**Primary-source documents / recorded speech accessed (in transcription):**
+- The 1973 **"letter of 40 academicians" condemning A. D. Sakharov** — Paton a signatory (documented public act; §2).
+- The 2011 **"letter of the Ukrainian intelligentsia in support of V. Yanukovych"** — Paton a signatory (§2).
+- The 2019 Inter documentary **«Борис Патон. Людина майбутнього»** — recorded statements on decommunisation (Quote 3 / §6).
+
+**Honest gaps:** Paton's own technical writings were not opened directly this pass (§3 rests on the encyclopedic/institutional summary of his innovations); the verbatim text of the 1973 and 2011 letters was referenced via uk.wikipedia's account, not the primary archival copies.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Paton's achievements are credited as Ukrainian institution-building; his Soviet loyalism is named plainly, not celebrated.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — the Soviet "Велика вітчизняна війна" appears ONLY as Paton's own quoted frame (§4/§6), explicitly marked as the Soviet memory frame he endorsed; body text uses Друга світова / decommunisation context.
+- [x] No uncritical Soviet propaganda terms — "Hero of Socialist Labour" etc. named as Soviet honours he received.
+- [N/A] No "lost his life" euphemisms — Paton died naturally in 2020 at 101.
+- [x] Modern UA place names — Київ/Kyiv throughout; 1918 Kyiv framed as the Українська Держава (Hetmanate), not "Russia."
+- [N/A] Holodomor — not directly connected; not invoked.
+- [x] Russian aggression framing — the post-2022 "русский мир" appropriation of Soviet/Ukrainian science is flagged (§6).
+- [x] **Anti-hagiography honoured (brief's explicit ask)** — gerontocracy, the Sakharov letter, the Yanukovych letter, anti-decommunisation, and the post-1991 brain drain are all told straight; the read is NOT celebratory.

--- a/docs/research/bio/kateryna-bilokur.md
+++ b/docs/research/bio/kateryna-bilokur.md
@@ -1,0 +1,163 @@
+# Катерина Василівна Білокур — Research Dossier
+
+**Slug:** `kateryna-bilokur`
+**Block:** B/D (self-taught peasant-woman genius; structural oppression — poverty, patriarchy, Holodomor-survivor, state neglect)
+**Tier:** 1b
+**Issue:** #2535 (original-180 ghost-wiki uplift — Wave B)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ; ЕСУ; Національний музей укр. народного декоративного мистецтва; Родовід editions)
+- [x] Oppression mechanism is specific (poverty + patriarchal denial of schooling/art; three technikum rejections; Holodomor-survivor — UINP «Незламні»; state neglect at death — named, dated)
+- [x] ≥2 primary-source quotes — **genuinely attested** verbatim from her autobiography; the fabricated «Мене звати Катерина Білокур…» is FLAGGED and excluded (§4/§6)
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+- [x] **Geography fixed** (Богданівка → today Бориспільський р-н, Київська обл., ~70 km from Kyiv — NOT "Kyiv city") and **Picasso/Séraphine line HEDGED** (uk.wiki tags it `[джерело?]`) — §1/§6
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Катерина Василівна Білокур. [T1: ЕІУ — Білокур Катерина Василівна; T1: ЕСУ; T3: uk.wikipedia, cross-checked]
+- **Pseudonyms / aliases:** none. Russified forms (forbidden in body text, listed only in §8): Екатерина Васильевна Белокур.
+- **Born:** **24 November (7 December) 1900** | село **Богданівка**, Пирятинський повіт, Полтавська губернія | the village is **today in Бориспільський район, Київська область, Україна** (~70 km east of Kyiv — **NOT within Kyiv city**; at her death it was in Яготинський район). [T1: ЕІУ; T3: uk.wikipedia — "с. Богданівка, Пирятинський повіт, Полтавська губернія"; geography per uk.wiki Вшанування — "Богданівка Бориспільського району, Київської області"]
+- **Died:** **10 June 1961** (some sources **9 June**, tagged `[джерело?]`) (aged 60) | село Богданівка, Яготинський район, Київська область | **died the same day as surgery at the Яготинська районна лікарня** (stomach + leg illness, after no medicine was available in the village pharmacy). Buried in Богданівка; gravestone by sculptor **Іван Гончар**. [T3: uk.wikipedia — Останні роки та смерть]
+- **Family / education key facts:** Father Василь Йосипович Білокур, a relatively well-off peasant (2.5 десятини of arable land); brothers Григорій and Павло. She **was deliberately not sent to school** (the family economised on clothing), learning to read at 6–7. She had **no art education whatsoever** — a complete **self-taught (самоучка)** painter — and was **rejected three times** from art technikums (Миргород ceramics technikum 1922–23; Київський театральний technikum 1928) for lacking a seven-year-school certificate. [T3: uk.wikipedia — Життєпис; T1: ЕІУ]
+
+**Source disagreement note (flagged, not smoothed):** uk.wikipedia itself flags the **death day (9 vs 10 June 1961)** with `[джерело?]`; the body text gives **10 June** (the surgery day). The **birthplace's modern administrative location** is the load-bearing correction: Богданівка is in **Бориспільський район, Київська область** today — do **not** write "now Kyiv" / "now within Kyiv city." It is a village ~70 km from the capital.
+
+## 2. Oppression mechanism
+
+Bilokur's oppression was **structural, not carceral** — poverty, patriarchal-peasant suppression of a woman's art, the Holodomor she survived, and a state that decorated her while leaving her village without medicine.
+
+- **Patriarchal denial of her vocation.** Her parents **forbade her to paint** as a distraction from housework that would "spoil her marriage prospects"; a drawing she made as a child was **torn up and thrown into the stove**. She painted in secret for decades. In **autumn 1934 she attempted suicide by drowning in the river Чумгак**, catching a chill in her legs (a lifelong affliction); only after that did her father grudgingly permit her to paint. [T3: uk.wikipedia — Життєпис; her own words, §4]
+- **Class/education exclusion.** Three rejections from art schools for lack of a school certificate (§1) — a peasant woman with no documents was structurally barred from formal training.
+- **Holodomor survivor.** Bilokur lived through the **Holodomor of 1932–33** in her Poltava/Kyiv-region village; in **November 2016 the Ukrainian Institute of National Remembrance (УІНП) included her in the «Незламні» project** — 15 prominent people who survived **1932–1933** and still realised themselves — explicitly marking her as a Holodomor survivor. [T3: uk.wikipedia — Вшанування пам'яті; T2: УІНП «Незламні»]
+- **Soviet co-option and neglect (the honest tension).** The same state that ignored her for decades later made her a **member of the Union of Artists (1949)**, **Заслужений діяч мистецтв (1951)** and **Народний художник УРСР (1956)**, and sent three of her paintings into the **Soviet art section of the 1954 Paris International Exhibition** — yet she died in 1961 in a "богом забуте село," after the **village pharmacy had no medicine** for her. The decolonial reading holds both: a genius the system both **suppressed and instrumentalised**. [T3: uk.wikipedia — Творчий злет / Останні роки]
+- **By whom / mechanism:** no single agency — the oppression is the compound of Russian-imperial-then-Soviet rural poverty, patriarchal norms, the Holodomor (Stalin's regime), and bureaucratic neglect. There is **no arrest or execution** here; the truthful frame is **a life-long structural smothering of an extraordinary talent**, partially overcome by her own will.
+
+## 3. Major works
+
+Bilokur painted overwhelmingly **flowers** (often combining spring and autumn blooms in one canvas, working a single picture from spring to autumn), plus still lifes, landscapes and portraits — all in **oils on home-stretched canvas**, with **brushes she made herself** from cat/cow hair and cherry twigs, and early **paints she made from калина, бузина and onion**. [T3: uk.wikipedia — Творчий стиль]
+
+- `1940` — first **solo exhibition** (11 paintings) at the Полтавський будинок народної творчості — her public discovery. [T3: uk.wikipedia]
+- **«Цар-Колос»** — among her best-known canvases; shown in Paris 1954. [T3: uk.wikipedia]
+- **«Берізка»** — shown in Paris 1954. [T3: uk.wikipedia]
+- **«Колгоспне поле»** — shown in Paris 1954; the **6 dahlias (жоржини)** in it took her **three weeks** to paint. [T3: uk.wikipedia]
+- `1954` — three works (**«Цар-Колос», «Берізка», «Колгоспне поле»**) entered the **Soviet section of the Paris International Exhibition** — the moment of her European recognition (and the Picasso legend — see §6). [T3: uk.wikipedia]
+- her **autobiography and letters** — collected and published by **Микола Кагарлицький** (who "opened Bilokur to the world") and in the Родовід editions (*Катерина Білокур*, 2 vols, 2010; *Я, Білокур Катерина Василівна*, 2012) — her primary written voice (§4). The **Національний музей українського народного декоративного мистецтва** holds the largest collection of her paintings. [T3: uk.wikipedia — Посилання; T2: museum]
+
+## 4. Primary-source quotes (≥2 required — genuinely attested)
+
+> **Fabrication guard (load-bearing, per the batch ⚠).** A line circulated on her ghost-wiki — **«Мене звати Катерина Білокур…»** — is **NOT an attested utterance**; it appears to be invented (and may be a corruption of the **book title** *«Я, Білокур Катерина Василівна»*, a 2012 Родовід study of her archive — a title, not her speech). It is **excluded** here. The quotes below are genuinely attested from her **autobiography** (as transcribed in the published editions / uk.wikipedia).
+
+**Quote 1 — her childhood painting, in secret (verbatim, autobiography):**
+
+> «Украла у матері кусочок білого полотна та взяла вуглину… І я намалюю з одного боку полотнини що-небудь, надивлюсь-намилуюсь, переверну на другий бік — і там те саме… От мене на цьому вчинку і поймали батько та мати. Малюнок мій зірвали і кинули в піч…»
+
+The founding scene of her oppression and her vocation in one breath. [T3: uk.wikipedia, quoting her autobiography; verbatim]
+
+**Quote 2 — her lament at a talent denied its scope (verbatim, autobiography):**
+
+> «Обідно мені на природу, що так жорстоко зі мною обійшлася, наділивши мене такою великою любов'ю до того святого малювання, а тоді відібрала всі можливості, щоб я творила тую чудовую працю во всю шир мого таланту!»
+
+A self-taught peasant woman naming, in her own dialect, the tragedy of genius without means — pedagogically powerful and emotionally direct. [T3: uk.wikipedia, quoting her autobiography; verbatim]
+
+*(Both quotes preserve her authentic Poltava-dialect folk Ukrainian — «обідно», «во всю шир», «поймали», «тую чудовую» — which must NOT be "corrected"; see §5.)*
+
+## 5. Language register
+
+- **Register:** **authentic Poltava-dialect folk Ukrainian** — her autobiography and letters are a rare first-person record of an early-20th-century **peasant woman's** Ukrainian, with dialectal forms (**обідно** = прикро/образливо; **поймали** = спіймали; **во всю шир**; **тую чудовую**) that are **heritage dialect, not error**. (`search_heritage` returned no entry for «обідно» — it is a colloquial Poltava form, kept verbatim inside the primary quote, not introduced into curriculum prose as a headword.)
+- **CEFR readiness:** her letters/autobiography excerpts sit at **B1–B2** with dialect glossing; the art-historical analysis of her "embroidery-in-oils" technique is **B2–C1**.
+- **Lexicon notes (terms to pre-teach — all VESUM-verified):** художниця, наївне (мистецтво) / примітивізм, живопис, самоучка, натюрморт, олійний, пензель, полотно, вишивка. [verified via `verify_words` 2026-06-03]
+- **Stylistic features:** her painting is "**вишивка олійними фарбами**" — oils worked like rushnyk embroidery (flower by flower, light-rimmed petals, no single light source, deep ultramarine/cobalt grounds); the verbal register mirrors this — patient, concrete, folk-rooted.
+
+## 6. Contested points
+
+- **The Picasso legend — HEDGE, do not assert.** The popular claim that **Pablo Picasso called Bilokur a genius and "the greatest"** is widely repeated but **uk.wikipedia tags it `[джерело?]`** (no source). What the sources consistently report is a **comparison to the French naïve painter Séraphine Louis (Séraphine de Senlis / «Серафіна Луї»)** following the 1954 Paris show. Treat the Picasso attribution as **unverified legend**, not biographical fact; if used, frame it as "за переказами" / popular tradition. [T3: uk.wikipedia — `[джерело?]` tag, both passages]
+- **The fabricated quote.** «Мене звати Катерина Білокур…» is **not attested** and must not be presented as her words (§4) — a corpus-contamination/fabrication artefact of the ghost-wiki. [batch ⚠ #2535]
+- **Soviet titles vs lived neglect.** "Народний художник," the Paris show as **«радянське мистецтво»**, and titles like **«Колгоспне поле» / «Цар-Колос»** sit against her death in a village without medicine and her decades of poverty — the honest decolonial tension between **state instrumentalisation and state neglect**. [framing; T3: uk.wikipedia]
+- **Gender.** Her central obstacle was **patriarchal-peasant suppression of a woman's art** ("no one will marry you"); modern memory sometimes softens this into a charming "self-taught" story, flattening the violence (the burned drawing, the suicide attempt). [framing]
+- **Geography error.** The "Богданівка is now Kyiv (city)" claim is **wrong** — it is a village in **Бориспільський район, Київська область**, ~70 km away (§1). [batch ⚠]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-honchar.yaml` — folk-art champion who sculpted her gravestone; the tightest material link ([[ivan-honchar]]).
+  - `curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml` — her correspondent; with Касіян he helped surface her work via Петрусенко (1940).
+  - `curriculum/l2-uk-en/plans/bio/alla-horska.yaml` — Ukrainian woman artist of the next generation (monumental art / dissent).
+  - `curriculum/l2-uk-en/plans/bio/viktor-zaretskyi.yaml` — painter (Horska's milieu); the professional-art counterpoint to Bilokur's self-taught path.
+  - `curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml` — Ukrainian modern painting, a professional contrast.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml` — folk-rooted Ukrainian visual tradition.
+  - `curriculum/l2-uk-en/plans/bio/kazimir-malevich.yaml` — the Kyiv-born avant-garde pole against which her naïve folk art reads.
+- **Existing BIO plans — her drama-circle repertoire (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml` — her village drama group staged his «Наймичка» / «Безталанна».
+  - `curriculum/l2-uk-en/plans/bio/hryhoriy-kvitka-osnovianenko.yaml` — they staged his «Сватання на Гончарівці».
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/holodomor-mekhanizm.yaml` — the Holodomor she survived (§2).
+  - `curriculum/l2-uk-en/plans/hist/holodomor-pamiat.yaml` — Holodomor memory; the УІНП «Незламні» framing.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - Dedicated `plans/bio/maria-prymachenko.yaml`, `plans/bio/hanna-sobachko.yaml` (folk/naïve peers) and `plans/bio/oksana-petrusenko.yaml` (the singer who discovered her) — **not yet built** (verified absent).
+  - An ART-track module on Ukrainian naïve/folk decorative painting (Bilokur ↔ Prymachenko ↔ Sobachko-Shostak), bridging A2 flower-vocabulary to a C1 "self-taught genius vs state framing" debate.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - An Оксана Петрусенко node (the 1940 discovery story).
+
+## 8. Naming-canonical
+
+- **Slug:** `kateryna-bilokur`
+- **EN canonical (BGN/PCGN-style project spelling):** Kateryna Bilokur
+- **UA canonical (with patronymic):** Катерина Василівна Білокур
+- **Aliases to track (`aliases:` YAML field):** Kateryna Vasylivna Bilokur; Kateryna Bilokur.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Екатерина Васильевна Белокур; Katerina Belokur.
+
+## 9. Image candidates
+
+- **Best portrait — RIGHTS CAUTION:** Bilokur died in 1961, so her **own works** (paintings) enter the public domain in Ukraine (life+70) only on **1 January 2032**; photographs *of* her depend on the photographer. Do **not** assume PD-by-age. Use the **Wikimedia Commons category "Kateryna Bilokur"** and verify each **file page** licence individually.
+- **Backup candidates:**
+  - The **2000 commemorative coin** and the **2020 state-anniversary** materials (120th birthday) — check issue rights.
+  - The **Музей-садиба Катерини Білокур** in Богданівка (1977) — a context photograph.
+- **Context image:** a reproduction of **«Цар-Колос»** or **«Колгоспне поле»** (the Paris-1954 works) — clear rights via the holding museum (Національний музей укр. народного декоративного мистецтва) before use.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Ковпаненко Н. Г. "Білокур Катерина Василівна." *Енциклопедія історії України*, т. 1 (А–В). Київ: Наукова думка, 2003. — referenced via uk.wikipedia bibliography; ЕІУ page not directly opened this pass (flagged).
+- "Білокур Катерина Василівна." *Енциклопедія Сучасної України* (ред. І. М. Дзюба та ін.). Київ: Інститут енциклопедичних досліджень НАН України. (ЕСУ; via uk.wikipedia bibliography.)
+
+**Tier 2 (institutional):**
+- Національний музей українського народного декоративного мистецтва (Kyiv) — holds the largest Bilokur collection (acquired largely via В. Нагай, 1944).
+- Український інститут національної пам'яті (УІНП), project «Незламні» (Nov 2016) — Bilokur as a Holodomor survivor.
+- Яготинський державний історичний музей / Меморіальний музей-садиба К. Білокур — her archive.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. "Білокур Катерина Василівна." Lead, Життєпис, Творчий злет, Творчий стиль. Accessed 2026-06-03 (full extract via `query_wikipedia`); the Picasso passage's `[джерело?]` tag noted (§6).
+
+**Tier 4 / Tier 5 (modern publications — used with corroboration):**
+- Клименко В., Пасічник І. *Я, Білокур Катерина Василівна.* Київ: Родовід, 2012. — study of her archive (and the source of the title sometimes mis-quoted as her speech — §4).
+- *Катерина Білокур.* 2 vols. Київ: Родовід, 2010.
+- Кагарлицький М. (упор.) — collected letters and contemporaries' memoirs (the editor who "opened Bilokur to the world").
+- Авраменко О. *Білокур.* Київ: Горобець / ІПСМ НАМ України, 2021.
+
+**Primary-source documents accessed (in transcription):**
+- Білокур К. **«Автобіографія»** and **листи** — Quotes 1, 2 (verbatim via T3 transcription of the published editions).
+
+**Honest gaps:** (1) the ЕІУ and ЕСУ entries were referenced via bibliography, not directly opened; (2) the **Picasso** attribution is unverified (`[джерело?]`) and is presented as legend, not fact; (3) the autobiography quotes were accessed in transcription, not from the Родовід/Кагарлицький editions directly; (4) the **9-vs-10 June** death day is left as the sources leave it.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Bilokur's art is told as Ukrainian folk-decorative genius; the Soviet state appears as both neglecter and instrumentaliser, named plainly.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "німецько-радянська війна," Holodomor named as Holodomor.
+- [x] No uncritical Soviet propaganda terms — Soviet titles and «радянське мистецтво» framing named as such, not endorsed.
+- [N/A] No "lost his life" euphemisms — Bilokur died after surgery in 1961; the truthful frame is structural neglect (no village medicine), stated plainly.
+- [x] Modern UA place names — Богданівка located correctly in Бориспільський район, Київська область (NOT "Kyiv city"); Полтавська губернія for her birth-era.
+- [x] Holodomor referenced AS Holodomor (§2) — she is a documented survivor (УІНП «Незламні»).
+- [x] Russian aggression framing — n/a to her lifetime directly; the decolonial work here is the **fabrication/Picasso-legend** correction and the geography fix (anti-disinformation hygiene).

--- a/docs/research/bio/mykhailo-drahomanov.md
+++ b/docs/research/bio/mykhailo-drahomanov.md
@@ -1,0 +1,174 @@
+# Михайло Петрович Драгоманов — Research Dossier
+
+**Slug:** `mykhailo-drahomanov`
+**Block:** B/I (political thinker; imperial-Russian dismissal + forced emigration)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki uplift — Wave B)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ; IEU; ЕУ/Лисяк-Рудницький; Ушкалов monograph «Чарівність енергії»)
+- [x] Oppression mechanism is specific (1875 dismissal from Kyiv University; the Ems Ukaz 1876 naming him for exile; forced emigration — named, dated)
+- [x] ≥2 primary-source quotes (verbatim from his writings/recorded statements)
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied (federalism/anarcho-socialism engaged HONESTLY — federation-within-Russia, not asserted as separatism — §6)
+- [x] **Dubious anecdotes flagged** (the "Max Weber learned Russian to read Drahomanov" story; the «Германство на Востоке» 1882 attribution) — §6
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Петрович Драгоманов. [T1: ЕІУ — Драгоманов Михайло Петрович; T1: IEU — Drahomanov, Mykhailo; T3: uk.wikipedia, cross-checked]
+- **Pseudonyms / aliases:** prolific — Толмачев, Українець, М./П. Кузьмичевський, Кирило Василенко, Волинець, М. Галицький, М. Гордієнко, П. Петрик, etc. Russified forms (forbidden in body text, listed only in §8): Михаил Петрович Драгоманов; Mikhail Dragomanov.
+- **Born:** **6 (18) September 1841** | місто **Гадяч**, Полтавська губернія, Російська імперія | now Полтавська область, Україна. Parents were дрібнопомісні дворяни, descendants of **Cossack starshyna**, of liberal views. [T1: IEU — "6 September 1841 in Hadiach"; T3: uk.wikipedia]
+- **Died:** **20 June (2 July) 1895** (aged 53) | **Софія, Болгарія** (then Болгарське князівство) | sudden death from **aortic rupture (розрив аорти)**; buried in Sofia (monument erected 1932). [T1: IEU — "20 July 1895 in Sofia" (N.S.); T3: uk.wikipedia — "20 червня (2 липня) 1895"]
+- **Family / education key facts:** Brother of the writer **Олена Пчілка**, hence **uncle of Леся Українка** (and of Михайло Косач); father of Світозар Драгоманов and Лідія Шишманова; father-in-law of the painter **Іван Труш** and of Bulgarian scholar Іван Шишманов. Studied at the Гадяцьке повітове училище (1849–53) and Полтавська гімназія; entered the **history-philology faculty of Kyiv (St Volodymyr) University in autumn 1859**. [T1: IEU — "uncle of Lesia Ukrainka"; T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** The **death date** differs by calendar — uk.wikipedia gives **20 June (2 July) 1895**, IEU gives **20 July 1895**; the O.S./N.S. anchor is 20 June O.S. = 2 July N.S. (the IEU "20 July" appears to be a conversion slip). The **Kyiv-period dates are slightly soft** (the batch ⚠): entry **1859**; dissertation «Імператор Тиберій» **1864**; приват-доцент **1865**; master's **1870**; штатний доцент **1873**; **dismissed 1875**; emigrated **March 1876**. Use these as the documented sequence; minor source variance exists on the exact docent years (the lead compresses them to "доцент 1864–1875").
+
+## 2. Oppression mechanism
+
+This is the load-bearing section — **imperial-Russian political dismissal and forced emigration**, with Drahomanov **named by name** in the Ems Ukaz.
+
+- **Dismissal from Kyiv University (1875).** He was **dismissed for "політична неблагонадійність"** (political unreliability) in autumn 1875 — IEU calls him "an early victim of anti-Ukrainian repressive measures by the Russian government." [T1: IEU; T3: uk.wikipedia — Наукова кар'єра]
+- **Named in the Ems Ukaz (1876).** The **Ems Ukaz of 1876** — Alexander II's secret decree banning Ukrainian-language publishing — **specifically called for the exile of Drahomanov and Pavlo Chubynsky as "dangerous agitators."** On the basis of the Ems Ukaz the **Hromadas were liquidated** and Ukrainian professors purged from Kyiv University. [T3: uk.wikipedia — "вказувалося на необхідність вислання Михайла Драгоманова і Павла Чубинського як небезпечних агітаторів"]
+- **By whom / documents:** the **Russian-imperial state** — the censorship/security apparatus enforcing the **Ems Ukaz (Бад-Емс, 18 May 1876)**, the named instrument of his persecution.
+- **Forced emigration (1876).** In March 1876 he left via Galicia and Hungary for Vienna, then **Geneva**, where he led the Ukrainian political emigration (1876–1889) and published **«Громада»** (5 vols). [T3: uk.wikipedia; T1: IEU — "settled in Geneva in 1876"]
+- **He fought the repression in the open.** At the **1878 Paris Literary Congress** he read **«La littérature oukraïnienne proscrite par le gouvernement russe»** ("Ukrainian literature, banned by the Russian government"), sharply condemning the Ems Ukaz before an international audience and defending the Ukrainian language. [T3: uk.wikipedia]
+- **What survived / what was destroyed:** his works circulated abroad and were smuggled into the empire but were **banned in Russia**; he died in exile in Sofia (1889–1895), never able to return. Leся Українка recorded that his last days were darkened by "усвідомлення печального стану справ в Україні." [T3: uk.wikipedia]
+
+## 3. Major works
+
+- `1864` — **«Император Тиберий»** (his lecture-right dissertation, classical history). [T3: uk.wikipedia — Бібліографія]
+- `1873–1874` — **«Література російська, великоруська, українська і галицька»** — his foundational essay distinguishing the literatures. [T3: uk.wikipedia]
+- `1874–1875` — **«Исторические песни малорусского народа»** (2 vols, with **Володимир Антонович**) — landmark folklore scholarship. [T3: uk.wikipedia]
+- `1878–1882` — **«Громада»** (Geneva, 5 vols) — the **first modern Ukrainian political journal** (IEU). [T1: IEU; T3: uk.wikipedia]
+- `1879` — **«Шевченко, українофіли і соціалізм»** — his programmatic reading of Shevchenko and socialism. [T3: uk.wikipedia]
+- `1881` — **«Историческая Польша и великорусская демократия»**. [T3: uk.wikipedia]
+- `1881–1883` — editor/contributor of **«Вольное слово»** (Geneva). [T3: uk.wikipedia — Галичина period; see §6 on the «Германство на Востоке» attribution caveat]
+- `1889–1892` — **«Австро-руські спомини. 1867—1877»** (memoir of his Galician engagements). [T3: uk.wikipedia]
+- `1891` — **«Чудацькі думки про українську національну справу»** — his mature statement on the national question. [T3: uk.wikipedia]
+- `1893–1894` — **«Листи на Наддніпрянську Україну»** — his side of the **polemic with Борис Грінченко** (§6). [T3: uk.wikipedia]
+- `1902` (posth.) — **«Два учителі»** (memoir). [T3: uk.wikipedia — Посилання]
+- also: the **«драгоманівка»** — a phonetic Ukrainian orthography he devised. [T3: uk.wikipedia — Див. також]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — the radical-must-be-a-conscious-Ukrainian dictum (verbatim):**
+
+> «Поганий той радикал на Україні, який не став свідомим українцем.»
+
+His signature fusion of social radicalism with Ukrainian national consciousness — the heart of his politics in one line. [T3: uk.wikipedia, quoting Drahomanov; verbatim]
+
+**Quote 2 — against forced Russification (verbatim):**
+
+> «…це призвело б не до утворення з українців „чистої національності своїх сусідів“, а викликало б до життя „ублюдочні помісі“, нових „національних ублюдків“, які за своїми моральними якостями були б нижче, ніж їхні предки „чистих національностей“.»
+
+His argument that **forced assimilation degrades rather than elevates** — a sharp, period-voiced anti-Russification statement (the harsh word «ублюдок» is his own polemical register, quoted not endorsed). [T3: uk.wikipedia, quoting Drahomanov; verbatim]
+
+**Quote 3 — on his father and his intellectual formation (verbatim):**
+
+> «Я надто зобов'язаний своєму батьку, який розвив у мені інтелектуальні інтереси, з яким у мене не було морального розладу і боротьби…»
+
+A rare warm personal note, useful for the biographical frame. [T3: uk.wikipedia, quoting Drahomanov's memoir; verbatim]
+
+## 5. Language register
+
+- **Register:** **high publicistic and scholarly Ukrainian** — dense, argumentative political-philosophical prose; he also wrote extensively **in Russian** (Вестник Европы), French, German and other languages, and his Ukrainian texts use a 19th-c. publicistic register far from everyday speech.
+- **CEFR readiness:** his political/literary-critical prose is **C1**; biographical narrative about him is **B2**; the §6 debates (federalism vs separatism, the Hrinchenko polemic, anarcho-socialism) are **C1**.
+- **Lexicon notes (terms to pre-teach — all VESUM-verified):** публіцист, федералізм, анархізм, соціалізм, громада, автономіст, емігрант, самоврядування, децентралізація, космополітизм. [verified via `verify_words` 2026-06-03]
+- **Stylistic features:** the comparative method (Ukraine inside a European "central/peripheral" frame); the "плебейські нації" / "неповнота" theory of stateless-nation development; the polemical, ironic edge (his self-naming as "Чудак" after the Hrinchenko debate).
+
+## 6. Contested points
+
+> **Block-G-style charged section — engaged honestly in every direction (per the batch brief).**
+
+- **Federalism vs independence — the central honest complication.** Drahomanov was the **founder of Ukrainian socialism** and a **Proudhonian-anarchist-leaning federalist**: he envisioned Ukraine's future in a **federative, radically decentralised reorganisation of Russia** (modelled on the USA/Switzerland), with self-governing громади and the **priority of individual rights over the state** — **not** full Ukrainian state independence. Unlike Костомаров's pan-Slavic federation, he "обмежувався федеративною перебудовою Росії." Later **integral nationalists (Дмитро Донцов)** attacked this as insufficiently national; liberals and democrats honour him as the man who, in his own context, "ні до, ні після нього ніхто… не стверджував з такою силою ідею пріоритету особи перед державою." **Tell both:** a profound democrat and human-rights pioneer *and* a federalist-within-Russia whose programme independence-era Ukraine moved beyond. [T1: IEU — "liberal-democratic, socialist, and Ukrainian patriotic"; T3: uk.wikipedia — Політичні погляди]
+- **The Hrinchenko polemic (Зоря 1888–89; «Листи», 1892–94).** Drahomanov's cosmopolitan socialism-federalism clashed with **Борис Грінченко's** culture-first national populism — the foundational strategic debate of Ukrainian politics ("як Драгоманов став Чудаком"). Present it as a real argument between two patriots, not a hero/villain story. [T3: uk.wikipedia — bibliography (Михайлин); cross-ref [[borys-hrinchenko]]]
+- **Anarcho-socialism (Proudhonian).** His socialism is Proudhonian and anti-statist (Феденко, «Драгоманов і Прудон», 1932), not Marxist — he rejected both "socialism without politics" (narodniks) and "revolution without science" (terrorist revolutionaries). Engage it as serious political theory. [T3: uk.wikipedia]
+- **Influence on «Братство тарасівців» (1891).** The Brotherhood of Taras (1891–92) is often described as influenced by Drahomanov's and Shevchenko's ideas; the uk.wikipedia extract does **not** directly source a Drahomanov role, so this is presented as **associated influence, flagged for verification**, not asserted as direct founding. [flagged — batch ⚠ item; not in the consulted extract]
+- **Dubious anecdotes — flagged, NOT asserted.** (a) The popular claim that **Max Weber learned Russian specifically to read Drahomanov** is a **dubious anecdote** that could **not be verified** in any reliable source this pass — do not state it as fact. (b) The attribution **«Германство на Востоке…» (1882, «Вольное слово»)** (batch ⚠) was **not found** under that exact title in the consulted bibliography; what *is* documented is **«Восточная политика Германии и обрусение»** (Вестник Европы, 1872) and his **«Вольное слово»** editorship (1881–83). Treat the 1882 title as **unverified** pending a primary check. [honest gaps; §10]
+- **Russian/Soviet framing.** The USSR branded him a "буржуазний націоналіст"; Russian-imperial readers cite his federalism-within-Russia to claim he "wasn't a separatist." Both are instrumentalisations; the honest frame is a 19th-c. European democrat whose priority was human freedom and Ukrainian self-government. [framing]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/drahomanov.yaml` — the dedicated Drahomanov history module; the tightest link.
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` — the Громади he helped organise (and which the Ems Ukaz liquidated).
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the Valuev/Ems bans; the Ems Ukaz named him for exile (§2).
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` — Franko, Lesya (his niece) and Hrinchenko (his polemical opponent) — directly his circle.
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — the Shevchenko awakening; Drahomanov spoke over Shevchenko's bier (Kyiv, 22 May 1861).
+  - `curriculum/l2-uk-en/plans/hist/kyrylo-mefodiivtsi.yaml` — the Cyrillo-Methodian federalist tradition (Костомаров) he both inherited and revised.
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` — his polemical opponent ([[borys-hrinchenko]]).
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — his Galician collaborator (the «Народ» journal) and partial heir/critic.
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — Київська Громада co-member and early co-librettist of Lysenko's «Андрашіада» ([[mykola-lysenko]]).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/lesia-ukrainka-intro.yaml` — his niece, whose intellectual formation he shaped.
+  - `curriculum/l2-uk-en/plans/lit/franko-biography.yaml` — Franko, his Galician interlocutor.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - Dedicated `plans/bio/olena-pchilka.yaml` (his sister) and `plans/bio/volodymyr-antonovych.yaml` (his folklore co-author) — not yet built.
+  - A POLITICS/IDEAS-track module on Ukrainian federalism vs integral nationalism (Drahomanov ↔ Dontsov), bridging B2 biography to a C1 political-theory debate.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A Брацтво тарасівців (1891) node — once the Drahomanov-influence claim is verified.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-drahomanov`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykhailo Drahomanov
+- **UA canonical (with patronymic):** Михайло Петрович Драгоманов
+- **Aliases to track (`aliases:` YAML field):** Mykhailo Petrovych Drahomanov; Mykhailo Drahomanov; his many pen-names (Українець, Толмачев, П. Кузьмичевський, etc.).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Михаил Петрович Драгоманов; Mikhail Dragomanov; "Dragomanov" via Russian.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Mykhailo Drahomanov"** holds 19th-century photographic portraits; as he died in 1895, they are firmly **public domain by age**. Verify on the individual **file page**. [Commons category: `Mykhailo Drahomanov`]
+- **Backup candidates:**
+  - The **2001 NBU commemorative coin** (160th anniversary) — check issue rights.
+  - The **М. П. Драгоманов National Pedagogical University** (Kyiv) materials / the Гадяч memorial plaque (Урочище Зелений Гай) — context images.
+- **Context image:** a title page of **«Громада» (Geneva)** or the **«драгоманівка»** orthography sample — strong §2/§3 illustration (rights-clear by age).
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Пінчук Ю. "Драгоманов Михайло Петрович." *Енциклопедія історії України*, т. 2 (Г–Д). Київ: Наукова думка, 2004. С. 458. — referenced via uk.wikipedia bibliography; ЕІУ page not directly opened this pass (flagged).
+- *Internet Encyclopedia of Ukraine.* "Drahomanov, Mykhailo." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\D\R\DrahomanovMykhailo.htm. Accessed 2026-06-03 — confirms 1875 dismissal, Geneva 1876, Hromada, Sofia 1889, uncle of Lesia Ukrainka.
+- Лисяк-Рудницький І. "Драгоманов Михайло." *Енциклопедія українознавства*, перевид. Львів, 1993. С. 589–591.
+
+**Tier 2 (institutional / scholarly monographs):**
+- Ушкалов Л. *Чарівність енергії: Михайло Драгоманов.* Київ: Дух і Літера, 2019. — 600 с. (the fullest modern biography, per uk.wikipedia).
+- Круглашов А. *Драма інтелектуала: політичні ідеї Михайла Драгоманова.* Чернівці: Прут, 2001.
+- Якімова А. *Болгарський період життя професора Михайла Драгоманова.* Київ: ІМФЕ ім. М. Т. Рильського НАН України, 2019.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1/T2):**
+- Українська Вікіпедія. "Драгоманов Михайло Петрович." Lead, Життєпис, Наукова кар'єра, Політичні погляди, Бібліографія. Accessed 2026-06-03 (full extract via `query_wikipedia`); dates/works cross-checked against ЕІУ and IEU.
+
+**Tier 4 (modern scholarly):**
+- Феденко П. "Михайло Драгоманов і Пєр Жозеф Прудон." *Драгоманівський збірник*, т. 1. Прага: Сіяч, 1932. С. 271–292.
+- Ясь О. "Порівняльно-історичний метод у дослідницьких практиках Михайла Драгоманова." *Український історичний журнал*, 2012, № 2, с. 133–158.
+
+**Primary-source documents accessed (in transcription):**
+- Драгоманов М. **«Громада»** (Geneva, 1878–82); **«Чудацькі думки про українську національну справу»** (1891); **«Листи на Наддніпрянську Україну»** (1893–94) — his political voice.
+- His **1878 Paris Literary Congress address** «La littérature oukraïnienne proscrite par le gouvernement russe» (§2).
+- Quotes 1–3 via T3 transcription of his writings/memoir.
+
+**Honest gaps:** (1) the ЕІУ and ЕУ entries were referenced via bibliography, not directly opened; (2) the **«Германство на Востоке» (1882, «Вольное слово»)** title (batch ⚠) was **not located** under that exact form — only the 1872 «Восточная политика Германии и обрусение» is documented (§6); (3) the **«Братство тарасівців» (1891)** influence is presented as associated, not asserted; (4) the **"Max Weber learned Russian to read Drahomanov"** anecdote is **unverified** and flagged as dubious (§6).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Drahomanov is centred as a Ukrainian democrat persecuted by the Russian empire; his federalism-within-Russia is named and *debated*, not hidden or inflated.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "Російська імперія," "Ems Ukaz," "політична еміграція"; no Soviet euphemisms.
+- [x] No uncritical Soviet propaganda terms — the "буржуазний націоналіст" label appears ONLY as the Soviet framing, named as such (§6).
+- [N/A] No "lost his life" euphemisms — Drahomanov died of natural causes (aortic rupture) in exile, 1895; the repression was dismissal + forced emigration, stated plainly.
+- [x] Modern UA place names — Гадяч, Полтавська область; Київ/Kyiv; Софія named as his place of exile-death.
+- [N/A] Holodomor — not connected to this figure (d. 1895); not invoked.
+- [x] Russian aggression framing — the §6 federalism-vs-independence and "русский мир"-style appropriation points connect his thought to present debates; the Ems Ukaz is framed as Russian linguicide.

--- a/docs/research/bio/mykola-lysenko.md
+++ b/docs/research/bio/mykola-lysenko.md
@@ -1,0 +1,165 @@
+# Микола Віталійович Лисенко — Research Dossier
+
+**Slug:** `mykola-lysenko`
+**Block:** B/I (institution-builder of national culture; imperial-Russian repression target, not killed)
+**Tier:** 1b
+**Issue:** #2535 (original-180 ghost-wiki uplift — Wave B)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ; IEU; Українська музична енциклопедія ІМФЕ; КНУ ім. Шевченка)
+- [x] Oppression mechanism is specific (tsarist persecution; 1907 arrest; the Ems Ukaz 1876 ban reaching musical scores — named, dated)
+- [~] ≥2 primary-source items — **one verbatim letter** (the Khortytsia letter, §4) + **one documented recorded position** (his refusal to stage «Тарас Бульба» in Russian for both Tchaikovsky and Rimsky-Korsakov). A second fully-verbatim autograph line was **not retrieved in clean digitised form** this pass (the wiki's folklore blockquote is empty; several quote sources 403'd/cert-failed) — honest gap, §10.
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied (the "demarcation from Russian music" thesis is GROUNDED in documented acts, §6)
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Віталійович Лисенко. [T1: ЕІУ — Лисенко Микола Віталійович; T1: IEU — Lysenko, Mykola; T3: uk.wikipedia, cross-checked]
+- **Pseudonyms / aliases:** none. Russified/imperial forms (forbidden in body text, listed only in §8): Николай Витальевич Лысенко; Nikolai Lysenko.
+- **Born:** **10 (22) March 1842** | село **Гриньки**, Кременчуцький повіт, Полтавська губернія | now Кременчуцький район, Полтавська область, Україна; then Російська імперія. [T1: IEU — "22 March 1842 in Hrynky, Kremenchuk county, Poltava gubernia"; T3: uk.wikipedia — "10 (22) березня 1842"]
+- **Died:** **24 October (6 November) 1912** (aged 70) | Київ | Російська імперія | sudden death from a heart attack; buried at Байкове кладовище (plot № 2; monument by sculptor Юхим Білостоцький, 1939). [T1: IEU — "6 November 1912 in Kyiv"; T3: uk.wikipedia — "помер 6 листопада 1912 … раптово від серцевого нападу"]
+- **Family / education key facts:** Father **Віталій Романович Лисенко** — a nobleman and colonel of the Орденський кірасирський полк, of **Cossack-starshyna descent** (the line includes Іван Лисенко, a 17th-c. наказний гетьман), who **spoke Ukrainian at home**; mother **Ольга Єреміївна** (Луценко/Булюбаш line), Smolny-educated and almost exclusively francophone. As a child Mykola learned the Russian alphabet from his father's regiment-mate, the Russian poet **Afanasy Fet**. Studied natural sciences at Kharkiv then **Kyiv (St Volodymyr) University** (graduated 1864; кандидат природничих наук 1865, dissertation on the reproduction of filamentous algae); then the **Leipzig Conservatory (1867–1869)** under Carl Reinecke and E. F. Richter, completing the four-year course in two; perfected orchestration in **St Petersburg (1874–1876) under Nikolai Rimsky-Korsakov**. [T3: uk.wikipedia — Походження/Ранні роки; T1: IEU]
+
+**Source disagreement note (flagged, not smoothed):** Work counts differ between Tier 1 sources — **IEU gives "over 120 art songs and ~500 folk-song arrangements,"** while **uk.wikipedia gives "over 600 folk-song arrangements."** Both agree on the *kind* and centrality of the work; the exact total is a counting-convention difference, not a fact conflict. The **St Petersburg study period** is given as 1874–1875 (uk.wikipedia body) and 1874–1876 (IEU) — state the source when citing.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section — here the repression is **imperial-Russian, structural, and career-long**, not a single execution.
+
+- **What happened:** Lysenko was kept under **tsarist police suspicion and surveillance** throughout his career and was **briefly arrested in 1907**. [T3: uk.wikipedia — "Лисенка переслідував царський уряд, 1907 року його на деякий час заарештували"]
+- **The systemic mechanism — the Ems Ukaz (1876).** The defining repression was legal-cultural: the **Ems Ukaz of 1876** (building on the **Valuev Circular of 1863**) banned Ukrainian-language publishing — and **specifically forbade the printing of Ukrainian-language texts to musical scores (тексти до нот)**, striking directly at Lysenko's art form. [T3: uk.wikipedia — "Емський указ 1876 року забороняв також і друкування українською мовою текстів до нот"; T1 context via ЕІУ]
+- **By whom:** the Russian-imperial state (царський уряд) — the Third Section / Imperial gendarmerie apparatus and censorship administration that enforced the Valuev/Ems regime.
+- **Mechanism specifics:** the bans did not stop him composing, but they constrained publication, performance and the public use of Ukrainian on the imperial stage. The pressure surfaces concretely in his **refusal to let «Тарас Бульба» be staged in Russian** (see §4/§6): both Tchaikovsky and Rimsky-Korsakov offered imperial-stage productions **on condition the opera be sung in Russian**, and Lysenko **refused both times** — choosing non-production over Russification. [T5: Radio Svoboda; T3: uk.wikipedia]
+- **What survived / what was destroyed:** his output survived and became foundational, but several early manuscripts are lost (the 1869 symphony movement and overture «Ой запив козак, запив» are noted as **рукописи не знайдено**). The deeper damage was deferred: under later Soviet power his pupils' generation (Леонтович, Стеценко) would be killed or broken — Lysenko himself, dying in 1912, was spared that, but the school he founded was decimated. [T3: uk.wikipedia — Список творів; cross-ref [[mykola-leontovych]]]
+
+## 3. Major works
+
+- `1868–1869` — first **collection of Ukrainian folk songs** for voice and piano (published in Leipzig at **Petro Kosach's** expense) and first **Shevchenko settings** («Заповіт», «Ой одна я, одна»). [T3: uk.wikipedia]
+- `1872` — opera/operetta **«Чорноморці»** (libretto Михайло Старицький after Я. Кухаренко) — the **first Ukrainian musical-theatre performance in Kyiv**, 5 (17) December 1872. [T3: uk.wikipedia]
+- `1873/1874` — **«Характеристика музичних особливостей українських дум і пісень, виконуваних кобзарем Остапом Вересаєм»** — his pioneering ethnomusicological study of kobzar **Остап Вересай** (read 1873; published 1874 in the *Записки Юго-Западного Отдела РГО*). [T3: uk.wikipedia — Музикознавча спадщина]
+- `1874` — opera **«Різдвяна ніч»** (after Gogol, libretto Старицький). [T3: uk.wikipedia]
+- `1878` — cantata **«Б'ють пороги»** (Shevchenko); the Хортиця expedition that seeded «Тарас Бульба». [T3: uk.wikipedia]
+- `1883` — cantata **«Радуйся, ниво неполитая»** (Shevchenko). [T3: uk.wikipedia]
+- `1885` — **«Молитва за Україну» / «Боже великий, єдиний»** (words Олександр Кониський) — now a spiritual anthem of the nation. [T3: uk.wikipedia]
+- `1888–1892` — the **children's operas** (the first in Ukrainian music): **«Коза-дереза» (1888), «Пан Коцький» (1891), «Зима і Весна» (1892)** (libretti Дніпрова Чайка). [T3: uk.wikipedia]
+- `1889` — **«Наталка Полтавка»** (Kotliarevsky) — his arrangement that became the national lyric opera. [T1: IEU; T3: uk.wikipedia]
+- `1890` — opera **«Тарас Бульба»** (after Gogol, libretto Старицький) — his magnum opus; **he refused to let it be staged in Russian** (§4/§6). [T1: IEU; T3: uk.wikipedia]
+- `1899` — chorus **«Вічний революціонер»** (Іван Франко). [T3: uk.wikipedia]
+- `1904` — opera **«Енеїда»** (after Kotliarevsky, premiered 1910); and the founding of the **Музично-драматична школа** in Kyiv — the first national higher arts school (from 1913 the Lysenko school). [T1: IEU; T3: uk.wikipedia]
+- across his life — **the «Музика до Кобзаря»** (settings of Shevchenko) and **500–600+ folk-song arrangements** — the documentary foundation of Ukrainian art music. [T1: IEU — "~500"; T3: uk.wikipedia — "понад 600"]
+
+## 4. Primary-source quotes
+
+**Quote 1 — on the Khortytsia journey behind «Тарас Бульба» (verbatim, from his correspondence):**
+
+> «Ви не можете уявити собі, земляче … як допомогла мені та давня подорож на Хортицю. Картина Січі, козачих зборів, виборів кошового — хіба ж я написав би їх, якби не побачив власними очима залишки славної минувшини?…»
+
+This shows the **ethnographic-fieldwork method** at the root of his national opera — he composed the Sich from what he had walked and heard, not from imagination. [T3: uk.wikipedia, quoting Lysenko's letter; verbatim]
+
+**Quote 2 — his recorded position: refusing the Russification of «Тарас Бульба» (documented act, reported in sources):** both **Pyotr Tchaikovsky** (who admired the score and urged a St Petersburg production) and **Nikolai Rimsky-Korsakov** (who proposed a Moscow staging) offered to bring the opera to the imperial stage **on the condition that it be sung in Russian** («щоб ця опера йшла російською мовою») — and **Lysenko refused both**. The refusal is the clearest documentary statement of his decolonial stance: he would rather the work go unstaged than be detached from the Ukrainian language. [T5: Radio Svoboda — "Опера «Тарас Бульба»…"; T3: uk.wikipedia] *(Reported position, not a verbatim autograph line — flagged per honest-gap discipline; a second fully-verbatim quote was not retrieved this pass, see §10.)*
+
+**On the texts he set:** his vocal output is overwhelmingly on **Ukrainian** poets (Шевченко, Франко, Леся Українка, Кониський, Олесь); foreign poets (Heine, Mickiewicz) he set **only in Ukrainian translation**; in his entire vocal œuvre there is **a single romance on a Russian text** (Nadson's «Признание») — itself a near-statement of principle. [T3: uk.wikipedia — Творчість]
+
+## 5. Language register
+
+- **Register:** the texts he set span **high literary Ukrainian** (Shevchenko, Franko, Lesya Ukrainka, Konysky) and **folk-dialectal** song (весілля, веснянки, колядки, думи). His music is **Romantic national art music** — the Ukrainian peer of Grieg, Smetana, Glinka.
+- **CEFR readiness:** the folk-song and children's-opera texts sit at **A2–B1**; the art songs and Shevchenko settings at **B2**; the §6 decolonial debates (demarcation from Russian music, the Ems Ukaz) at **C1**.
+- **Lexicon notes (terms to pre-teach — all VESUM-verified):** композитор, диригент, хоровий, фольклор, обробка, опера, солоспів, кантата, кобзар, дума, щедрівка, етнографія. [verified via `verify_words` 2026-06-03]
+- **Stylistic features:** the fusion of Leipzig conservatory technique (counterpoint, the four-voice chorus) with Ukrainian folk modality; the dignifying of the **kobzar dума** as concert material; the deliberate use of Ukrainian as the sung language against imperial pressure.
+
+## 6. Contested points
+
+- **"Demarcation from Russian music" — grounded, not asserted.** A central decolonial reading holds that Lysenko consciously built Ukrainian art music **as distinct from** the Russian national school, rather than as a provincial branch of it. This dossier **grounds** that thesis in documented acts: (1) he **refused twice** to let «Тарас Бульба» be staged in Russian; (2) he set foreign poets only in Ukrainian translation and left only **one** Russian-text romance; (3) he held to Ukrainian song-texts **despite the Ems Ukaz's specific ban**; (4) he studied under Rimsky-Korsakov yet founded a **separate national school and conservatory**, not a Russian-school outpost. *(The thesis is developed in Ukrainian/diaspora musicology; a specific "via Антонович" attribution from the audit note was not independently verified this pass and is left unattributed rather than mis-cited.)* [evidence: T3: uk.wikipedia; T5: Radio Svoboda]
+- **"Father of Ukrainian music" — epithet vs the collective.** Popular memory crowns him sole "батько української музики," which can flatten the **Theatre of Coryphaei** (Старицький, Кропивницький, Садовський) and his own teachers/peers into his shadow; modern scholarship reads him as the **organising centre** of a movement, not its only author. [framing; T3: uk.wikipedia]
+- **The Gogol problem.** Three of his operas (Чорноморці source aside: Різдвяна ніч, Утоплена, Тарас Бульба) are built on **Gogol** — a Ukrainian-born writer who wrote in Russian; the modern debate over reclaiming vs problematising Gogol bears directly on how «Тарас Бульба» is presented today (esp. during the war). [T5: Radio Svoboda]
+- **Russian appropriation.** Russia historically folded Lysenko into a "common Russian musical culture" (cf. the 1954 Soviet monograph *Н. В. Лысенко и русская музыкальная культура*); the honest frame names this as **appropriation** of a composer whose life's work was precisely the *demarcation* from that culture. [Soviet source cited only as evidence of framing — §10]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml` — his pupil-generation heir; Leontovych dedicated his 1903 collection to Lysenko ([[mykola-leontovych]]); the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-bortnyanskyy.yaml` — the older Ukrainian choral tradition Lysenko renews.
+  - `curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml` — the next-generation Ukrainian art-music line.
+  - `curriculum/l2-uk-en/plans/bio/hnat-khotkevych.yaml` — bandura/kobzar revival, parallel to Lysenko's kobzar ethnography.
+  - `curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml` — the great Ukrainian opera voice of the next generation.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-barvinskyi.yaml` — Galician art-music heir.
+  - `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml` — the Theatre of Coryphaei with which his operas shared a stage and milieu.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — the poet whose «Кобзар» Lysenko set across his life.
+  - `curriculum/l2-uk-en/plans/bio/kvitka-tsisyk.yaml` — a later Ukrainian-diaspora voice in the national-song line.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the Valuev/Ems bans that directly constrained his art (§2).
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — the Shevchenko-centred national awakening Lysenko set to music.
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` — the Київська Громада he belonged to.
+  - `curriculum/l2-uk-en/plans/hist/drahomanov.yaml` — his Громада circle co-member Драгоманов (and early co-librettist of «Андрашіада»).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/mykhailo-starytsky.yaml` — his cousin and chief librettist (Чорноморці, Різдвяна ніч, Тарас Бульба).
+  - `curriculum/l2-uk-en/plans/lit/lesia-ukrainka-intro.yaml` — a poet he set and an «Український Клуб» co-member.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated `plans/bio/oleksandr-koshyts.yaml` (his «Київський Боян» co-founder) and `plans/bio/kyrylo-stetsenko.yaml` (pupil) — not yet built.
+  - A MUSIC-track «Тарас Бульба» / «Молитва за Україну» listening module bridging A2 folk-song to C1 demarcation debate.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A Остап Вересай (kobzar) node, via Lysenko's 1873 ethnographic study.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-lysenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykola Lysenko
+- **UA canonical (with patronymic):** Микола Віталійович Лисенко
+- **Aliases to track (`aliases:` YAML field):** Mykola Vitaliyovych Lysenko; Mykola Lysenko.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Николай Витальевич Лысенко; Nikolai Lysenko; Nikolay Lysenko; "Lysenko" rendered via Russian.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Mykola Lysenko"** holds pre-1912 photographic portraits; as he died in 1912, they are public domain by age. Verify on the individual **file page**, not the category. [Commons category: `Mykola Lysenko`]
+- **Backup candidates:**
+  - The **Lysenko monument** on Театральна площа, Kyiv (1965, sculptor О. Ковальов) beside the National Opera — freedom-of-panorama candidate.
+  - Укрпошта 1992 stamp (150th anniversary) and the **NBU 2 ₴ coin (2002)** bearing a «Молитва за Україну» score fragment — check issue rights.
+- **Context image:** a score page of **«Молитва за Україну» / «Боже великий, єдиний»** or the **Будинок-музей М. Лисенка** (вул. Саксаганського, 95, Kyiv).
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Корній Л. П. "Лисенко Микола Віталійович." *Енциклопедія історії України*, т. 6 (Ла–Мі). Київ: Наукова думка, 2009. С. 156. — referenced via uk.wikipedia bibliography; the ЕІУ page itself not directly opened this pass (flagged).
+- *Internet Encyclopedia of Ukraine.* "Lysenko, Mykola." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\L\Y\LysenkoMykola.htm. Accessed 2026-06-03.
+- "Лисенко Микола Віталійович." *Українська музична енциклопедія*, т. 3. Київ: ІМФЕ ім. М. Т. Рильського НАН України, 2011. С. 110–123.
+
+**Tier 2 (institutional):**
+- Київський національний університет ім. Тараса Шевченка. "Лисенко Микола Віталійович (1842–1912)." https://knu.ua/ua/geninf/osobystosti/lisenko/. Accessed 2026-06-03 — confirms Kyiv-University study, the 1904 music school on Велика Підвальна.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1/T2):**
+- Українська Вікіпедія. "Лисенко Микола Віталійович." Lead, Життєпис, Творчість, Список творів. Accessed 2026-06-03 (full extract + §7 section via `query_wikipedia`); dates/works cross-checked against ЕІУ and IEU.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- "Опера «Тарас Бульба» лютого патріота Миколи Лисенка…" *Radio Svoboda* — the Tchaikovsky/Rimsky-Korsakov "stage it in Russian" refusals; decolonial framing for staging during the war. (Accessed via search summary; the page itself returned 403 on direct fetch — the refusal fact is corroborated by uk.wikipedia.)
+
+**Primary-source documents / recorded positions accessed (in transcription):**
+- Lysenko's **letter** on the Хортиця journey (Quote 1) — via uk.wikipedia transcription.
+- His **refusal to stage «Тарас Бульба» in Russian** (Tchaikovsky and Rimsky-Korsakov) — documented recorded position (Quote 2).
+- His own scholarly work **«…дум і пісень… кобзаря Вересая»** (1873/1874) — his primary ethnomusicological text.
+
+**Forbidden-source note (Soviet/Russian, cited only as evidence of framing):**
+- Гозенпуд А. *Н. В. Лысенко и русская музыкальная культура.* М., 1954 — cited only as evidence of the Soviet "common Russian culture" **appropriation** frame (§6), NOT as an authority on Lysenko's identity (per source-tiers SPECIAL RULE).
+
+**Honest gaps:** (1) a second fully-verbatim by-him quote beyond the Khortytsia letter was not retrieved (the wiki folklore blockquote is empty; Radio Svoboda/Suspilne fetches 403'd); (2) the ЕІУ and Українська музична енциклопедія entries were referenced via bibliography, not all directly opened; (3) the audit's "via Антонович" attribution for the demarcation thesis was not verified and is left unattributed.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Lysenko's work is told on Ukrainian terms; Russia appears as the imperial power that banned and pressured him, and later appropriated him.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "Російська імперія," "Ems Ukaz," "national awakening," not Soviet/Russian euphemisms.
+- [x] No uncritical Soviet propaganda terms — the 1954 Soviet monograph appears only as named **appropriation** evidence.
+- [N/A] No "lost his life" euphemisms — Lysenko died of natural causes in 1912; the violence fell on his pupils' generation (cross-ref [[mykola-leontovych]]).
+- [x] Modern UA place names — Київ/Kyiv; Гриньки, Кременчуцький район, Полтавська область; Хортиця.
+- [N/A] Holodomor — not connected to this figure (d. 1912); not invoked.
+- [x] Russian aggression framing — the §6 "demarcation" and Gogol points connect to today's reclamation of «Тарас Бульба» during Russia's full-scale invasion.

--- a/docs/research/bio/oleksandr-dovzhenko.md
+++ b/docs/research/bio/oleksandr-dovzhenko.md
@@ -1,0 +1,180 @@
+# Олександр Петрович Довженко — Research Dossier
+
+**Slug:** `oleksandr-dovzhenko`
+**Block:** D (survived-but-broken: censored, professionally destroyed, exiled to Moscow)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki uplift — Wave B)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ; IEU; Національний центр Довженка; Carynnyk/MIT)
+- [x] Oppression mechanism is specific (the «Україна в огні» ban — Stalin, 30.01.1944, the named charge; the «Земля» suppression; the Moscow internal exile)
+- [x] ≥2 primary-source quotes (verbatim from his diary «Щоденник» and autobiography)
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+- [x] **UNR-army service responsibly HEDGED** (witness testimony vs purged documentary base + his own self-censored autobiography — §2/§6)
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олександр Петрович Довженко. [T1: ЕІУ — Довженко Олександр Петрович; T1: IEU — Dovzhenko, Oleksander; T3: uk.wikipedia, cross-checked]
+- **Pseudonyms / aliases:** "Сашко" (caricaturist pen-name in 1920s Kharkiv). Russified forms (forbidden in body text, listed only in §8): Александр Петрович Довженко; Alexander Dovzhenko.
+- **Born:** **29 August (10 September) 1894** | хутір **В'юнище**, near містечко **Сосниця**, Чернігівська губернія, Російська імперія | now within смт Сосниця, Корюківський район, Чернігівська область, Україна. (Some sources give 11 or 12 September; the **metric book** of the Соборно-Троїцька church gives 29 August O.S. = **10 September N.S.**) Father Петро Семенович Довженко was of the **Cossack estate (козацький стан)**, of chumak ancestry; the family had 14 children, most of whom died young. [T3: uk.wikipedia — Дитинство; T1: IEU — "10 September 1894 … Sosnytsia"]
+- **Died:** **25 November 1956** (aged 62) | дача in **Передєлкіно (Peredelkino), Московська область, РРФСР, СРСР** | heart attack, on the **first shooting day** of «Поема про море»; buried at the **Novodevichy cemetery, Moscow** at state expense (he had 32 rubles in his account). [T3: uk.wikipedia — Повоєнний період; T1: IEU — "died … in Moscow"]
+- **Family / education key facts:** Studied at the **Глухівський учительський інститут (1911–1914)**, then taught; attended the **Київський комерційний інститут** (economics) and was a слухач of the **Українська академія мистецтв (1917)**, finishing neither. Married Варвара Крилова (1917/1923); his lifelong de-facto partner and artistic collaborator was the actress-director **Юлія Солнцева**, who completed several of his films posthumously. [T3: uk.wikipedia — Юні роки / Сім'я]
+
+**Source disagreement note (flagged, not smoothed):** The **birth day** is given as 10, 11 or 12 September across sources; the **metric-book** date (29 August O.S. = 10 September N.S.) is the documentary anchor and is used here. IEU gives the **birthplace** as "Sosnytsia," uk.wikipedia as the **хутір В'юнище within Sosnytsia** — the same locality at finer resolution, not a conflict.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Dovzhenko's repression was **career-long censorship, professional destruction, and internal exile** — a world-class artist kept from his own country and forbidden his masterworks.
+
+- **«Україна в огні» — banned personally by Stalin.** The film-scenario (written 1941–1943; excerpts published September 1943) provoked agitprop outrage; Dovzhenko was accused of doubting "collective guilt" and the Red Army's fitness, and was ordered to **Russify the Ukrainian hero Кравчина**. On **30 January 1944 he was summoned to Stalin**, who banned the work for **«антиленінізм, пораженство, ревізування національної політики й заохочення українського замість радянського патріотизму»**. **That same day Dovzhenko burned three of the "most seditious" notebooks of his diary.** A censorship directive ordered that no work of his be published "without special permission in each case." He was removed as artistic director of the Kyiv film studio and struck from the Stalin-Prize committee. [T1: IEU — "prohibited … by Joseph Stalin because of its nationalism"; T3: uk.wikipedia — У роки війни]
+- **«Земля» — suppressed at home, acclaimed abroad.** His 1930 masterpiece was pulled from Ukrainian screens **after a few days** (released 8 April 1930, withdrawn 17 April) following Дем'ян Бєдний's attack feuilleton «Философы» in *Известия*; it was officially rehabilitated in the USSR only in **1958**, after a 1958 Brussels international poll named it one of the **12 best films in world history**. [T3: uk.wikipedia — Трилогія]
+- **"Bourgeois nationalism" as a career-long charge.** From «Звенигора» and «Земля» onward he was repeatedly accused of **«буржуазний націоналізм»**; after «Іван» his **parents were expelled from the kolkhoz** and surveillance of him intensified; the DPU reported (20 May 1932) his remark that the Moscow leadership "feasted" while villages in Ukraine **died of famine** (the Holodomor). [T3: uk.wikipedia — Ранні радянські роки / Москва]
+- **Internal exile to Moscow.** From 1934 he was effectively **confined to Moscow** — permitted only work trips to Ukraine, never residence. He died there in 1956, his remains still in Moscow today. [T1: IEU — "forced to move to Moscow, where he lived as if in exile until his death"; T3: uk.wikipedia]
+- **By whom / documents:** the perpetrating agencies were Stalin personally, the **ЦК agitprop apparatus**, the censorship organs (Главліт), and the **ДПУ/НКВС** (surveillance, the 1932 reports, the destruction of the AРМУ art association). The earliest blow came in **1919**, when the **Волинська ЧК** arrested him as a "ворог робітничо-селянського уряду" and held him three months in a concentration camp (he was saved by writer Василь Еллан-Блакитний). [T3: uk.wikipedia — Доба національно-визвольних змагань]
+- **What survived / what was destroyed:** the three diary notebooks he burned in 1944 are lost; his surviving **«Щоденник» (1939–1956)** was sealed in archives by his widow until 2009 and published in full only in **2013**. Most films survive but were withheld from Ukrainian audiences for decades.
+
+## 3. Major works
+
+- `1927` — **«Сумка дипкур'єра»** (the film he counted as his first). [T3: uk.wikipedia — Фільмографія]
+- `1927/1928` — **«Звенигора»** — his breakthrough; "his own *Iliad*," widely seen as the **beginning of Ukrainian national cinema**, and the start of the "bourgeois nationalism" accusations. [T1: IEU; T3: uk.wikipedia]
+- `1929` — **«Арсенал»** — the 1918 Kyiv Arsenal uprising shown **from the Bolshevik side** (he had fought it from the other; see §6). [T1: IEU; T3: uk.wikipedia]
+- `1930` — **«Земля»** — his masterpiece; banned at home, named one of the 12 greatest films of all time at Brussels (1958). [T1: IEU — "a masterpiece"]
+- `1932` — **«Іван»** — his first **sound** film (the Dniprohes dam). [T3: uk.wikipedia]
+- `1935` — **«Аероград»** — made on Stalin's commission. [T3: uk.wikipedia]
+- `1939` — **«Щорс»** — the "Ukrainian Chapaev," demanded by Stalin; Stalin Prize I (1941). [T1: IEU; T3: uk.wikipedia]
+- `1940` — documentaries **«Визволення»** and **«Буковина — земля українська»**. [T3: uk.wikipedia]
+- `1943` — **«Україна в огні»** (kinopovist / scenario) — **banned by Stalin** (§2); published posthumously in excerpts. [T1: IEU]
+- `1948` — **«Мічурін»** (after his own play «Життя в цвіту») — his **last completed film**; Stalin Prize II (1949). [T3: uk.wikipedia]
+- `1954–1955` — **«Зачарована Десна»** (kinopovist; begun 1942) — autobiographical lyric prose of his Desna childhood; filmed posthumously by Солнцева (1964). [T3: uk.wikipedia]
+- `1956` — **«Поема про море»** (scenario) — he died on its first shooting day; completed by Солнцева (1958), Lenin Prize 1959 (posthumous). [T3: uk.wikipedia]
+- `1939–1956` / pub. `2013` — **«Щоденник» («Щоденникові записи, 1939–1956»)** — his diary; the central primary document of his inner life and dissent (Folio, 2013; Ukrainian Book of the Year 2013). [T3: uk.wikipedia]
+
+**Suppression note:** «Україна в огні» was banned and «Земля» withdrawn; the diary was archive-sealed until 2009 / published 2013; the **«Тарас Бульба»** he dreamed of (five scenario versions exist, drafted with Дмитро Яворницький's help) was never realised.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — the diary, on the «Україна в огні» charge of nationalism (verbatim):**
+
+> «…невже любов до свого народу є націоналізм? Чи націоналізм… в невмінні художника стримати сльози, коли народу боляче?..»
+
+The single most quotable line of his dissent — a colonised artist refusing the regime's equation of *love of one's people* with *nationalism*. [T3: uk.wikipedia, quoting the «Щоденник»; verbatim]
+
+**Quote 2 — the diary, on dying in exile (verbatim):**
+
+> «Я вмру в Москві, так і не побачивши України! Перед смертю попрошу Сталіна, аби, перед тим, як спалити мене в крематорії, з грудей моїх вийняли серце і закопали його в рідну землю, у Києві, десь над Дніпром, на горі.»
+
+His prophecy of exile-death (he did die in Moscow, 1956, and remains buried there) — the emotional core of any module on him. [T3: uk.wikipedia, quoting the «Щоденник»; verbatim]
+
+**Quote 3 — autobiography, on the «Земля» attack (verbatim):**
+
+> «Радість творчого успіху була жорстоко пригнічена страховинним двопідвальним фейлетоном Дем'яна Бєдного під назвою „Философы“ в газеті „Известия“. Я буквально посивів і постарів за кілька днів… Спочатку я хотів був умерти.»
+
+Shows the bodily cost of the censorship (he went grey in days). [T3: uk.wikipedia, quoting his «Автобіографія» (written 1939, pub. «Дніпро», 1957)]
+
+**Quote 4 — recorded statement, on Russification at the Hlukhiv institute (verbatim):**
+
+> «Заборонено було в нашому середовищі розмовляти українською мовою. З нас готували учителів–обрусителів краю.»
+
+A primary-source memory of imperial Russification of teacher-training — pedagogically vivid. [T3: uk.wikipedia — Юні роки]
+
+## 5. Language register
+
+- **Register:** **high lyric-poetic Ukrainian** — the prose of «Зачарована Десна» and «Україна в огні» is the literary face of "poetic cinema," dense with folk imagery, apostrophe, and the Desna landscape; the **«Щоденник»** is more direct and confessional.
+- **CEFR readiness:** excerpts of «Зачарована Десна» are school-curriculum staples at **B1–B2**; «Україна в огні» and the diary at **B2–C1**; the §6 debates (collaboration vs victimhood, the UNR question) at **C1**.
+- **Lexicon notes (terms to pre-teach — all VESUM-verified):** кінорежисер, кінодраматург, кіноповість, сценарій, екранізація, кіностудія, щоденник, поетичне (кіно), націоналізм, русифікація. [verified via `verify_words` 2026-06-03]
+- **Stylistic features:** the **кадр-плакат / кадр-скетч** montage idea he theorised against the передвижники-realism imposed from Moscow; the fusion of folk-poetic vision with the moving image — "the Homer of cinema" (Venice).
+
+## 6. Contested points
+
+- **UNR-army service — responsibly HEDGED.** uk.wikipedia states that **in 1918–1919 Dovzhenko fought against the Bolsheviks in the army of the UNR**, attested by his émigré countryman, engineer **Петро Шох** (who placed him in the 3rd Сердюцький полк and the курінь Чорних гайдамаків that stormed the Kyiv Arsenal), and by the sister of his first wife. **But the documentary base is thin and was self-purged:** Dovzhenko's own **1939 autobiography (published posthumously 1957) sanitised his biography "як було найбільш безпечно"** — obscuring both the UNR service and his Borotbist past — and **IEU does not mention the UNR service at all.** Honest verdict: **well-attested by émigré/family testimony, unprovable from his own deliberately-falsified record** — assert neither flatly that he served nor that he didn't; present the testimony and the purge together. [T3: uk.wikipedia — Доба національно-визвольних змагань; T1: IEU silence]
+- **The tragic compromise (collaboration vs victimhood).** Dovzhenko made **"concession films"** — «Арсенал», «Аероград», «Щорс», «Мічурін» — for the regime that destroyed his masterworks and exiled him; «Арсенал» depicts **from the Bolshevik side** the very UNR struggle he had fought in. The Dovzhenko-scholar **Сергій Тримбач** frames it: he, like many 1920s Ukrainian intellectuals, believed Bolshevik force could "resurrect Ukraine and Ukrainian culture — **he was wrong**." Tell both directions: victim *and* compromised servant. [T3: uk.wikipedia — quoting Тримбач]
+- **Praising Stalin while condemning him.** His diary condemns the **conscious destruction of the Ukrainian people, serfdom, and Russification**, yet he also repeatedly praised Stalin and Khrushchev — the doublethink of a colonised artist surviving under terror. Do not smooth either half. [T3: uk.wikipedia — Повоєнний період]
+- **The Kakhovka prophecy.** Writing «Поема про море» about the Каховська ГЕС, Dovzhenko grieved that the dam would **flood the historic lands of the Запорізька Січ and the Великий Луг** ("наше нове море — наше нове горе") — a line that reads as prophetic after Russia's **destruction of the Kakhovka dam in 2023**. [T3: uk.wikipedia; cross-ref `kakhovska-hes`]
+- **Russian/Soviet appropriation.** Titled "Народний артист РРФСР," buried at Novodevichy, his name on a still-operating Kyiv studio — Russia claims him as "Soviet cinema." Ukrainian campaigns since 2006 to **repatriate his remains and archives** remain unresolved ("хресна дорога Довженка до своєї Землі ще не закінчилась"). [T3: uk.wikipedia — Вшанування пам'яті]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/dovzhenko-cinema-as-literature.yaml` — cinema-as-literature; the core LIT anchor.
+  - `curriculum/l2-uk-en/plans/lit/dovzhenko-enchanted-desna.yaml` — «Зачарована Десна».
+  - `curriculum/l2-uk-en/plans/lit/dovzhenko-ukraine-flames.yaml` — «Україна в огні».
+  - `curriculum/l2-uk-en/plans/lit/vaplite-literary-avant-garde.yaml` — VAPLITE, which he co-founded.
+  - `curriculum/l2-uk-en/plans/lit/khvylovy-intro.yaml` — Хвильовий, his VAPLITE milieu.
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-mykolaichuk.yaml` — the 1960s "poetic cinema" heir to Dovzhenko ([[ivan-mykolaichuk]]).
+  - `curriculum/l2-uk-en/plans/bio/bohdan-stupka.yaml` — Ukrainian screen acting in the line Dovzhenko opened.
+  - `curriculum/l2-uk-en/plans/bio/yurii-yanovskyi.yaml` — Гарт/VUFKU peer who wrote the prose of early Ukrainian cinema.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-yavornytskyi.yaml` — the Cossack-history scholar he consulted for the unrealised «Тарас Бульба».
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — the Executed Renaissance, his generation and milieu.
+  - `curriculum/l2-uk-en/plans/hist/holodomor-mekhanizm.yaml` — the Holodomor, during which Stalin pulled him to Moscow and he protested the famine.
+  - `curriculum/l2-uk-en/plans/hist/kakhovska-hes.yaml` — the Kakhovka dam (his «Поема про море» / the 2023 destruction prophecy).
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A CINEMA-track «Земля» viewing module bridging B1 «Зачарована Десна» prose to a C1 collaboration-vs-resistance debate.
+  - A pairing with [[mykola-lysenko]]'s unrealised-«Тарас Бульба» / Lysenko's refusal — two artists and the same Gogol opera/film dream under different empires.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A Юлія Солнцева node (his collaborator who finished his late films).
+
+## 8. Naming-canonical
+
+- **Slug:** `oleksandr-dovzhenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Oleksandr Dovzhenko
+- **UA canonical (with patronymic):** Олександр Петрович Довженко
+- **Aliases to track (`aliases:` YAML field):** Oleksandr Petrovych Dovzhenko; Oleksander Dovzhenko (IEU variant); pen-name "Сашко."
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Александр Петрович Довженко; Alexander Dovzhenko; "Aleksandr Dovzhenko."
+
+## 9. Image candidates
+
+- **Best portrait — RIGHTS CAUTION:** Dovzhenko died in 1956, so his **own works** enter the public domain in Ukraine (life+70) only on **1 January 2027**; photographic portraits *of* him depend on the photographer's dates. Do **not** assume PD-by-age yet. Use the **Wikimedia Commons category "Oleksandr Dovzhenko"** and verify each **file page** licence individually.
+- **Backup candidates:**
+  - Укрпошта **1994 stamp block (centenary)** with stills from «Земля» / «Повість полум'яних літ»; NBU coins (2 ₴, 2004; 20 ₴ silver, 2014) — check issue rights.
+  - A still from **«Земля» (1930)** — a VUFKU silent film; clear its status before use.
+- **Context image:** the **«Мотор» sculptural composition** at the Dovzhenko Film Studio (2024, sculptor В. Щур), honouring Dovzhenko and cameraman Демуцький — freedom-of-panorama candidate.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Марочко В. І. "Довженко Олександр Петрович." *Енциклопедія історії України*, т. 2 (Г–Д). Київ: Наукова думка, 2004. С. 426. — referenced via uk.wikipedia bibliography; ЕІУ page not directly opened this pass (flagged).
+- *Internet Encyclopedia of Ukraine.* "Dovzhenko, Oleksander." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\D\O\DovzhenkoOleksander.htm. Accessed 2026-06-03 — confirms the Stalin ban of «Україна в огні» and the Moscow internal exile.
+
+**Tier 2 (institutional):**
+- Національний центр Олександра Довженка (Dovzhenko Centre), Kyiv — film preservation and biography.
+- Глухівський національний педагогічний університет імені Олександра Довженка — on his 1911–1914 student years.
+- Небесьо Б. *Німа кінотрилогія Олександра Довженка.* Київ: Нац. центр Олександра Довженка, 2017.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1/T2):**
+- Українська Вікіпедія. "Довженко Олександр Петрович." Lead, Біографія, Трилогія, У роки війни, Повоєнний період, Фільмографія. Accessed 2026-06-03 (full extract via `query_wikipedia`); dates/films cross-checked against ЕІУ and IEU.
+
+**Tier 4 (modern scholarly):**
+- Carynnyk M. (ed., transl.). *Alexander Dovzhenko: The Poet as Filmmaker — Selected Writings.* Cambridge, MA: MIT Press, 1973. ISBN 0-262-04037-9.
+- Тримбач С. — Dovzhenko scholarship (cited via uk.wikipedia for the "he was wrong" thesis, §6).
+
+**Primary-source documents accessed (in transcription):**
+- Довженко О. **«Щоденник» («Щоденникові записи, 1939–1956»)**, Харків: Фоліо, 2013 — Quotes 1, 2 (verbatim via T3 transcription).
+- Довженко О. **«Автобіографія»** (written 1939; pub. «Дніпро», грудень 1957) — Quote 3; deliberately self-censored, see §6.
+- Довженко О. **«Україна в огні»** (1943) — the banned kinopovist (§2/§3).
+
+**Honest gaps:** (1) the ЕІУ entry was referenced via bibliography, not directly opened; (2) the UNR-army service rests on émigré/family **testimony** and is **unprovable from his own purged record** — presented as hedged, not resolved (§6); (3) the diary quotes were accessed in T3 transcription, not from the 2013 Folio edition directly.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Dovzhenko's story is told as a Ukrainian artist crushed and exiled by the Soviet-Russian centre; his own compromises are named, not hidden.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "Доба національно-визвольних змагань" / UNR, not "Civil War" as a neutral; the Holodomor named as Holodomor.
+- [x] No uncritical Soviet propaganda terms — "буржуазний націоналізм" appears ONLY as the regime's charge against him, named as such.
+- [N/A] No "lost his life" euphemisms — Dovzhenko died of a heart attack in 1956; the killing-by-degrees was censorship and exile, stated plainly.
+- [x] Modern UA place names — Київ/Kyiv; Сосниця, Корюківський район, Чернігівська область; Передєлкіно named as the place of his Moscow exile.
+- [x] Holodomor referenced AS Holodomor (§2) — his 1932 protest that Moscow "feasted" while Ukrainian villages starved.
+- [x] Russian aggression framing — the 2023 Kakhovka-dam destruction (his «Поема про море» prophecy) and the unresolved repatriation of his remains (§6).

--- a/docs/research/bio/yevhen-paton.md
+++ b/docs/research/bio/yevhen-paton.md
@@ -1,0 +1,160 @@
+# Євген Оскарович Патон — Research Dossier
+
+**Slug:** `yevhen-paton`
+**Block:** I (institution-builder / scientist — NOT a repression victim; Soviet-establishment laureate)
+**Tier:** 2
+**Issue:** #2535 (original-180 ghost-wiki uplift — Wave B)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU; ЕІУ ref; Інститут електрозварювання; Томазов/Дмитрієнко «Рід Патонів», Інститут історії України)
+- [N/A → reframed] "Oppression mechanism" — Paton was a **Soviet-establishment laureate, not a repression victim**. §2 is reframed as an honest accounting of his imperial-then-Soviet loyalism (the anti-hagiography the batch brief demands), not inflated into "national resistance."
+- [~ PARTIAL] ≥2 primary-source quotes — Paton's own verbatim words (memoir «Спогади» / «Воспоминания», 1955–56) were **not retrievable in accessible digitised form** this pass after a multi-source search; §4 uses his documented written œuvre + his son's verbatim recorded recollection, each flagged. Honest gap, not fabrication (see §4/§10).
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+- [x] Corpus-contamination guard applied (the audit's stray «1000–1300 рублів» / russo-Ukr-war fragments are NOT about Paton — flagged §6)
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Євген Оскарович Патон. [T1: IEU — Paton, Yevhen; T3: uk.wikipedia — Патон Євген Оскарович, cross-checked]
+- **Pseudonyms / aliases:** none. Russified/imperial forms (forbidden in body text, listed only in §8): Евгений Оскарович Патон; Evgenii / Evgeny Paton.
+- **Born:** **5 March 1870** | Ніцца (Nice) | then Друга французька імперія (Second French Empire), now Франція. His father **Оскар Петрович Патон** was a former imperial-Russian guards colonel serving as **Russian consul in Nice**; mother **Катерина Дмитрівна Патон**. The Patons descend from a Scottish noble line that entered Russian-imperial service. [T3: uk.wikipedia; T5: dyvys.info — Scottish descent, corroborated]
+- **Died:** **12 August 1953** (aged 83) | Київ | Українська РСР, СРСР | natural death; buried at Байкове кладовище (central avenue, plot № 1; bronze-and-granite monument by architect Авраам Милецький, erected 1954). [T3: uk.wikipedia; T1: IEU — "d 12 August 1953 in Kyiv"]
+- **Family / education key facts:** Brother of four and sister of two; wife Наталія Вікторівна (Будде, 1884–1971); sons Володимир and **Борис** (the future NANU president, see [[borys-paton]]). Graduated the **Dresden Technical University (1894)**; because the Russian Empire did not recognise the Dresden diploma, he additionally completed the **St Petersburg Institute of the Corps of Railway Engineers (1896)**. [T1: IEU — "Dresden Polytechnical Institute (1894) and the Saint Petersburg Institute of Civil Engineers (1896)"; T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** The **birth day** differs across Tier 1 sources — **IEU gives "4 March 1870"**, while **uk.wikipedia and ЕСУ give "5 березня 1870."** Both agree on the year (1870) and place (Nice); the day is a one-day discrepancy (likely an O.S./N.S. or transcription artefact). The **first Dnipro bridge date** differs: IEU dates "a major bridge across the Dnipro River (1924)"; uk.wikipedia dates the **міст імені Євгенії Бош** (rebuilt on the piers of the destroyed Миколаївський ланцюговий міст) to **1925**. State which event a date refers to; do not collapse "design" vs "completion."
+
+## 2. Relationship to imperial and Soviet power (anti-hagiography — NO oppression mechanism)
+
+> **This figure is not a repression victim.** The bio-track template's load-bearing §2 assumes Russian/Soviet oppression; Yevhen Paton is the opposite case — a man who **thrived inside, and was decorated by, both the Russian-imperial and the Soviet states.** Per the decolonisation standard ("tell the truth in every direction; do NOT inflate national resistance"), this section documents that loyalism honestly rather than manufacturing a persecution arc.
+
+- **Imperial-establishment origins.** Son of a tsarist guards colonel and Russian consul, imperially educated, he received the **Order of St Anne, 3rd class (1903)** under the Russian Empire. [T3: uk.wikipedia — Нагороди]
+- **Soviet-establishment apotheosis.** Under Soviet power he became академік АН УРСР (1929), founded and directed the Інститут електрозварювання (1934–1953), and rose to **vice-president of the Academy of Sciences of the Ukrainian SSR (1945–1952).** He was made **Hero of Socialist Labour (1943)**, won the **Stalin Prize (1941)**, and was twice decorated with the **Order of Lenin (1942, 1943)** plus the Order of the Red Star (1942) and Order of the Patriotic War 1st class (1945). [T3: uk.wikipedia — Звання/Нагороди; T1: IEU]
+- **Communist Party membership.** uk.wikipedia records him simply as "член Комуністичної партії УРСР" without a date. Popular accounts widely report that he **joined the party in 1944, at age 74** — a striking late-life act of Soviet allegiance — but that year/age detail was **not independently confirmed in a Tier 1/2 source this pass**, so it is marked **[reported, UNVERIFIED]** rather than asserted. [T3: uk.wikipedia; reported detail flagged]
+- **Wartime production.** During the German-Soviet war the institute was evacuated to **Нижній Тагіл (Свердловська область)**, where Paton's automatic submerged-arc welding was applied to **T-34 tank armour** in mass production — a documented contribution to the Soviet war effort. The batch brief flags a "POW forced-labour context"; **no source confirming POW labour specifically at Paton's wartime production was found** this pass, so that claim is left **[UNVERIFIED]**, noted only as the general character of Soviet evacuated war industry, not asserted of Paton. [T3: uk.wikipedia; T5: 24tv.ua — Нижній Тагіл, corroborated]
+- **The honest decolonisation point.** Ukrainian popular memory now frames Paton as a national hero ("людина, яка зварила Україну"). His genuine, enormous achievement was **building Ukrainian science as an institution** in Kyiv. But his loyalty ran to the imperial-then-Soviet state, he published and worked overwhelmingly **in Russian**, and his family was Russophone of Russian-imperial service stock. He is best taught as an **institution-builder of Ukrainian science**, not as a figure of national-political resistance. Do not sanitise; do not inflate.
+
+## 3. Major works
+
+- `1902–1907` — **«Залізні мости» (Железные мосты)**, 4 vols (М.; К.) — foundational treatise on metal-bridge design; established his methods for rational truss-bridge schemes. [T3: uk.wikipedia — Праці]
+- `1910` — **Парковий міст** over Петрівська алея, Kyiv (a pedestrian arch bridge to his design). [T3: uk.wikipedia]
+- `1918` — **«Восстановление разрушенных мостов»** (К.) — on reconstructing destroyed bridges. [T3: uk.wikipedia]
+- `1925` — **міст імені Євгенії Бош** — rebuilt on the surviving piers of the destroyed Миколаївський ланцюговий міст across the Dnipro in Kyiv. (IEU dates a Dnipro bridge to 1924 — see §1 disagreement note.) [T3: uk.wikipedia; T1: IEU]
+- `1929` — organised a **laboratory/chair of engineering structures (electric welding)** at the All-Ukrainian Academy of Sciences. [T1: IEU — "In 1929 he organized … a laboratory of electric welding technology"]
+- `1934` — founded the **Інститут електрозварювання АН УРСР** (Institute of Electric Welding); its director until 1953. [T1: IEU; T3: uk.wikipedia]
+- `1930s–1950s` — the **«метод Патона»**: high-speed **automatic submerged-arc welding (зварювання під флюсом)**, developing the earlier ideas of inventor **Микола Бенардос**. [T3: uk.wikipedia]
+- `1941` — **«Скоростная автоматическая сварка под слоем флюса»** (Машгиз) — the wartime production monograph. [T3: uk.wikipedia]
+- `1941–1945` — **automatic welding of T-34 tank armour** at the evacuated institute (Нижній Тагіл) — the application that made the method strategically famous. [T3: uk.wikipedia — "для танкових башт"; T5: 24tv.ua]
+- `1953` — **Міст Патона** (Paton Bridge), Kyiv: the **first all-welded bridge in the world**, length **1543 m**, opened **5 November 1953** — built under his direction. Paton **died on 12 August 1953, roughly three months before its opening**, and the bridge was named in his honour that year. [T3: uk.wikipedia — Міст Патона: "1543 м", "5 листопада 1953", "Перший у світі суцільнозварний міст"]
+- `1955` / `1956` — **«Воспоминания»** (Russian, literary record by Ю. Буряковський, Гослитиздат УРСР, 1955) / **«Спогади»** (Ukrainian translation, 1956) — his memoir, published posthumously. [T3: uk.wikipedia — Праці]
+
+## 4. Primary-source quotes
+
+> **Honest limitation (per #M-4).** Paton's own verbatim words — the memoir «Спогади»/«Воспоминания» and his technical monographs — were **not retrievable in digitised, quotable form** through accessible sources this pass (uk.wikiquote has no page; the memoir's digitised text was not located). Rather than fabricate a "credo," this section presents only what is genuinely attested, each item flagged for transmission status. The acceptance box above is marked **partial** accordingly.
+
+**Item 1 — his own published works as primary documentary voice (titles attested, text not directly accessed):** the four-volume **«Залізні мости» (1902–1907)** and the memoir **«Спогади» (1956)** are Paton's own authored record. They are his primary voice; verbatim passages should be added when a digitised copy is accessed. [T3: uk.wikipedia — Праці; flagged: titles attested, body text not accessed]
+
+**Item 2 — recorded family testimony about his self-understanding (his son's verbatim words, recorded speech — about Paton, not by him):**
+
+> «Мій батько розділив своє життя на дві частини. Перша частина — мости, які він проєктував … А друга половина його життя починається приблизно з 1928 року, коли він познайомився зі зварюванням, що перебувало в зачатковому стані, і вирішив зайнятися ним, не відмовляючись від мостів.»
+> — Борис Патон about his father.
+
+Pedagogically this captures the single most teachable fact about Yevhen Paton — that he reinvented himself as a welding scientist in his late fifties — but it is **his son's recollection, not Yevhen's own words**, and is labelled as such. [T5: 24tv.ua / msmb.org.ua, quoting Борис Патон; recorded speech, mediated]
+
+## 5. Language register
+
+- **Register (his own writing):** **technical / scientific**, and predominantly **Russian-language** — «Железные мосты», «Скоростная автоматическая сварка…», «Воспоминания» all appeared first in Russian; the Ukrainian «Спогади» (1956) is a translation. This is an honest register fact, not a slight: Paton operated in the Russophone imperial-Soviet scientific establishment.
+- **CEFR readiness:** biographical prose about him is **B1–B2**; his technical œuvre is **C1+** specialist register and not a general-learner reading text. The pedagogical entry point is his *story* (the bridge that bears his name, the leap to welding), not his prose.
+- **Lexicon notes (engineering terms to pre-teach — all VESUM-verified):** зварювання, електрозварювання, мостобудування, броня, флюс, автоматичне зварювання, електрошлаковий переплав. (The compound «гідрозварювання» is **not** in VESUM and was avoided.) [verified via `verify_words` 2026-06-03]
+- **Stylistic features:** n/a (technical author); the teachable contrast is between his Russophone working language and his role as a builder of *Ukrainian* scientific institutions.
+
+## 6. Contested points
+
+- **"Людина, яка зварила Україну" hagiography vs Soviet-loyalist reality.** The biggest contested point is whether Paton belongs in a *national* pantheon at all, or is better described as a brilliant **Soviet-establishment institution-builder** who happened to work in Kyiv. Modern Ukrainian framing claims him strongly; the honest accounting (§2) keeps both truths — world-class scientist *and* decorated Soviet loyalist. [decolonisation framing per batch brief]
+- **Corpus-contamination guard (load-bearing).** The original-180 wiki audit found **unrelated corpus fragments leaking into Paton's article** — e.g. a stray "«1000–1300 рублів»" pricing snippet and russo-Ukrainian-war language samples that have **nothing to do with Paton**. Any rebuilt wiki MUST verify that every language sample is actually about Paton; these fragments are flagged here as **must-exclude noise**, not facts. [audit ⚠; #2535]
+- **Birth-day discrepancy (4 vs 5 March 1870)** and the **1924 vs 1925** first-Dnipro-bridge date (§1) — source nuances, not mysteries.
+- **POW forced labour at wartime production** — raised by the batch brief but **unverified**; left open, not asserted (§2).
+- **Russian appropriation.** Russia's "русский мир" narrative folds Soviet-era science (welding, the academy) into a "Russian" achievement, erasing its Ukrainian institutional base. Honest framing: Paton built this science **in Ukraine**, even while loyal to the Soviet imperial system. [decolonisation framing]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/borys-paton.yaml` — his son, the NANU president; the tightest single link ([[borys-paton]]).
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml` — first president of the УАН/ВУАН, the academy Paton's institute belonged to.
+  - `curriculum/l2-uk-en/plans/bio/ivan-puliui.yaml` — earlier Ukrainian physicist/engineer in the imperial-European scientific world.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-kondratiuk.yaml` — Ukrainian engineer of the same generation (space-flight theory) — a science-track peer.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/druha-svitova-pochatok.yaml` — the WWII context of the T-34 armour-welding work.
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` — the imperial-Russian establishment his family served.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A SCIENCE/STEM-track module on the Paton welding school and the NANU (bridging A2 "this is the Paton Bridge" to a C1 history-of-Soviet-science debate).
+  - A decolonial case-study pairing Yevhen (loyalist institution-builder) with a repressed contemporary, to teach "tell the truth in every direction."
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A Микола Бенардос (welding pioneer) note, as Paton's acknowledged predecessor.
+
+## 8. Naming-canonical
+
+- **Slug:** `yevhen-paton`
+- **EN canonical (BGN/PCGN-style project spelling):** Yevhen Paton
+- **UA canonical (with patronymic):** Євген Оскарович Патон
+- **Aliases to track (`aliases:` YAML field):** Yevhen Oskarovych Paton; Yevhen Paton.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Евгений Оскарович Патон; Evgenii Paton; Evgeny Paton; "Evgeny Oskarovich Paton."
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Yevhen Paton"** holds pre-1953 photographic portraits; as he died in 1953, studio portraits are public domain by age in Ukraine. Verify on the individual **file page**, not the category. [Commons category: `Yevhen Paton`]
+- **Backup candidates:**
+  - Укрпошта / НБУ commemorative issues for the **150th anniversary (2020)** — check stamp/coin rights before use.
+  - A photograph of the **Міст Патона** (Paton Bridge, Kyiv) — strong §3 context image (the first all-welded bridge in the world).
+- **Context image:** an archival photo of T-34 production / the evacuated institute at Нижній Тагіл (check rights) — illustrates §2.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Paton, Yevhen." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\P\A\PatonYevhen.htm. Accessed 2026-06-03.
+- Онопрієнко В. І. "Патон Євген Оскарович." *Енциклопедія історії України*, т. 8 (Па–Прик). Київ: Наукова думка, 2011. С. 92. — referenced via the uk.wikipedia bibliography; the ЕІУ page itself was not directly opened this pass (flagged).
+
+**Tier 2 (institutional):**
+- Дмитрієнко М. Ф., Томазов В. В. *Рід Патонів: історико-генеалогічне дослідження. Документи* / за заг. ред. В. А. Смолія. Київ: Інститут історії України НАН України, 2013. — 344 с. ISBN 978-966-02-7022-0. (Referenced via uk.wikipedia bibliography.)
+- Інститут електрозварювання ім. Є. О. Патона НАН України — "Євгеній Оскарович Патон — видатний вчений…" (institutional biography).
+- ЦДАГО / ЦДАВО України — online exhibitions for the 145th anniversary (2015).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1/T2):**
+- Українська Вікіпедія. "Патон Євген Оскарович." Dates/works/awards cross-checked against IEU and the institutional sources. Accessed 2026-06-03 (full extract via `query_wikipedia`).
+- Велика українська енциклопедія (vue.gov.ua) — stub entry (1870–1953); confirms identity only.
+
+**Tier 5 (general web — used only with T1–T3 corroboration):**
+- "Жив заради науки: хто такий Євген Патон." *dyvys.info*, 2024-03-04 — Scottish descent, Нижній Тагіл evacuation. Corroborated.
+- "Євген Патон. Маестро зварювання." *msmb.org.ua* (Музей) — bibliography; the «Спогади» (1962) citation.
+- "Євген Патон — київський інженер…" *24tv.ua* — Нижній Тагіл / T-34 detail; Борис Патон's "two halves" recollection. Corroborated.
+
+**Primary-source documents (attested, not directly accessed this pass):**
+- Патон Є. О. **«Спогади»** / літ. запис Ю. Буряківського. К.: Держ. вид-во худож. літ., 1956. — 320 с. (Russian original «Воспоминания», 1955.) — his own memoir; verbatim text not retrieved (see §4).
+- Патон Є. О. **«Залізні мости»** (Железные мосты), 4 т. М.; К., 1902–1907.
+
+**Forbidden-source note (Soviet, cited only as evidence of framing):**
+- Корнієнко О. М. "Патон Євген Оскарович." *Українська радянська енциклопедія*, 2-ге вид., т. 8, 1982, с. 213 — a УРЕ entry; cited only as evidence of Soviet-era framing, **not** as an authority on identity (per source-tiers SPECIAL RULE).
+
+**Honest gaps:** (1) verbatim quotes from Paton's own memoir were not retrievable (§4); (2) the 1944/age-74 party-membership detail and the POW-labour claim are **unverified** and flagged as such (§2); (3) the ЕІУ article was referenced via bibliography, not directly opened.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — the Soviet/imperial state appears as the system Paton served, named plainly; his Ukrainian institution-building is credited without inflating it into "resistance."
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "German-Soviet war / Друга світова," not "Great Patriotic War," in body text.
+- [x] No uncritical Soviet propaganda terms — "Hero of Socialist Labour," "Stalin Prize" appear as the *awards he received*, named as Soviet honours, not as endorsements.
+- [N/A] No "lost his life" euphemisms — Paton died naturally in 1953; no execution to euphemise.
+- [x] Modern UA place names — Київ/Kyiv; Ніцца/Nice; Нижній Тагіл named as the evacuation site within Soviet Russia.
+- [N/A] Holodomor — not directly connected to this figure; not invoked.
+- [x] Russian aggression framing — addressed via the "русский мир" appropriation point (§6); the audit's stray russo-Ukrainian-war corpus fragments are flagged as contamination to exclude, not facts.
+- [x] **Anti-hagiography honoured** — the Soviet-loyalist dimension (party, Hero of Socialist Labour, Russophone œuvre) is told straight; "national resistance" is NOT manufactured.


### PR DESCRIPTION
## Wave B — original-180 ghost-wiki dossier uplift (#2535)

Six figures with a **live site wiki but no research dossier** (the #2535 ghost-wiki root cause). Each new `docs/research/bio/{slug}.md` follows the 10-section template, mirrors the `mykola-leontovych` gold standard (tiered inline `[T1..T5]` citations, a flagged source-disagreement note, ≥2 primary quotes, a `test -e`-verified §7, a self-applied decolonization check), and applies the #M-4 deterministic-over-hallucination discipline (every URL WebFetch-checked; honest gaps marked, never fabricated).

**Deterministic gate:** `lint_bio_dossier_xref.py` exits **0** (targeted + full sweep); pre-commit "bio dossier §7 cross-track path validator" passed.

### Per figure — key sourced facts · ⚠ finding resolved · honest gaps

**`borys-paton`** (Борис Патон, 1918–2020)
- **Facts:** b. 14 Nov 1918 Kyiv (Українська Держава); welding-institute director 1953–2020; AN URSR/NANU president **1962–2020**; 1000+ pubs / 400+ patents; first welding in space («Вулкан», Союз-6, 16 Oct 1969, Кубасов+Шонін); living-tissue welding (State Prize 2004); **Hero of Ukraine №1** (26 Nov 1998). [T2 НАН некролог; T3 uk.wiki]
- **⚠ resolved:** sourced to **Paton-specific** material (NANU, Інститут електрозварювання, ВУЕ), **not** his father's article; **anti-hagiography delivered straight** — 58-yr academy gerontocracy, the **1973 anti-Sakharov letter**, the **2011 Yanukovych letter**, 2019 anti-decommunisation («Велика вітчизняна війна»), post-1991 brain drain.
- **Gaps:** ЕІУ/ВУЕ referenced via bibliography; letters cited via uk.wiki account.

**`yevhen-paton`** (Євген Патон, 1870–1953)
- **Facts:** b. **Nice 1870**; Dresden Polytechnic 1894 + Petersburg 1896; founded the welding institute (1934); **T-34 armour welding** at the institute evacuated to **Нижній Тагіл**; **Міст Патона** — first all-welded bridge in the world, **1543 m, opened 5 Nov 1953** (he died 12 Aug 1953, ~3 months prior). [T1 IEU; T3 uk.wiki]
- **⚠ resolved:** **loyal-Soviet dimension told honestly** (Hero of Socialist Labour 1943, Stalin Prize, two Orders of Lenin, Russophone œuvre), NOT framed as national resistance; **corpus-contamination guard** — the audit's stray «1000–1300 рублів» / russo-Ukr-war fragments flagged as must-exclude noise.
- **Gaps:** verbatim memoir quotes **not retrievable** in digitised form (flagged; §4 partial); 1944/age-74 party detail + POW-labour claim left **[UNVERIFIED]**.

**`mykola-lysenko`** (Микола Лисенко, 1842–1912)
- **Facts:** b. 1842 Гриньки; Kyiv Univ. 1864; Leipzig Conservatory 1867–69; St Petersburg 1874–76 under Rimsky-Korsakov; «Тарас Бульба» (1890), children's operas, «Молитва за Україну» (1885); 1873 Вересай study; 1904 music school; 1907 arrest. [T1 IEU/ЕІУ/Укр. муз. енц.; T3 uk.wiki]
- **⚠ resolved:** the **"demarcation from Russian music" thesis grounded** in documented acts — **twice refused** to stage «Тарас Бульба» in Russian (Tchaikovsky, Rimsky-Korsakov); only one Russian-text romance; held to Ukrainian texts **despite the Ems Ukaz 1876** ban on song-text printing.
- **Gaps:** one verbatim quote (Khortytsia letter) + one recorded position; second autograph line not retrieved; the audit's "via Антонович" attribution left unattributed (unverified).

**`oleksandr-dovzhenko`** (Олександр Довженко, 1894–1956)
- **Facts:** b. 10 Sep 1894 хутір В'юнище/Сосниця; «Звенигора»/«Арсенал»/«Земля»/«Щорс»; **«Україна в огні» banned by Stalin 30 Jan 1944** (named charge); «Земля» pulled after days, 1958 Brussels top-12; died 25 Nov 1956 in **Moscow internal exile**; the «Щоденник». [T1 IEU/ЕІУ; T3 uk.wiki]
- **⚠ resolved:** the contested **UNR-army service responsibly HEDGED** — émigré/family testimony (Шох; курінь Чорних гайдамаків) vs his **self-purged 1939 autobiography** and IEU silence; asserted neither way.
- **Gaps:** ЕІУ via bibliography; diary quotes via T3 transcription.

**`kateryna-bilokur`** (Катерина Білокур, 1900–1961)
- **Facts:** b. 7 Dec 1900 **Богданівка, Полтавська губ.**; self-taught naïve painter; 3 works in the Soviet section of the **Paris 1954** exhibition; Holodomor survivor (УІНП «Незламні»). [T1 ЕІУ/ЕСУ; T3 uk.wiki]
- **⚠ resolved:** geography fixed — Богданівка is **Бориспільський р-н, Київська обл., ~70 km from Kyiv (NOT Kyiv city)**; **Picasso line hedged** (uk.wiki tags it `[джерело?]`; the comparison was to **Séraphine Louis**); the **fabricated «Мене звати Катерина Білокур…» excluded**, genuine autobiography quotes used instead.
- **Gaps:** ЕІУ/ЕСУ via bibliography; 9-vs-10 June death day left open.

**`mykhailo-drahomanov`** (Михайло Драгоманов, 1841–1895)
- **Facts:** b. 1841 Гадяч; dismissed from Kyiv Univ. 1875; **named in the Ems Ukaz 1876** for exile; «Громада» (Geneva, 5 vols); Sofia chair 1889; uncle of Lesya Ukrainka; Hrinchenko polemic. [T1 IEU/ЕІУ/ЕУ; T3 uk.wiki]
- **⚠ resolved:** **federalism/anarcho-socialism engaged honestly** — federation-*within*-Russia (not separatism), Proudhonian anarchism, the Hrinchenko polemic; the **«Братство тарасівців» 1891** influence flagged as associated, not asserted.
- **Gaps:** the **Weber-learned-Russian** anecdote and **«Германство на Востоке» (1882)** title left **unverified** and flagged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**No auto-merge.**