### PR TITLE
research(bio): 6 sourced dossiers — Wave C repressed/dissident literary (#2535)

### DIFF
--- a/docs/research/bio/ivan-dziuba.md
+++ b/docs/research/bio/ivan-dziuba.md
@@ -1,0 +1,172 @@
+# Іван Михайлович Дзюба — Research Dossier
+
+**Slug:** `ivan-dziuba`
+**Block:** A (persecuted dissident-critic; arrested 1972, recanted under duress, rehabilitated; Hero of Ukraine)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave C)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ Желєзняк T1; his memoirs «На трьох континентах» T2; Частакова monograph T4; + the primary treatise in the corpus)
+- [x] Oppression mechanism is specific (commission 15.02.1972; arrest 13.01.1972; 1973 sentence 5+5 years; recantation under TB/КГБ duress)
+- [x] ≥2 primary-source quotes — two corpus-verified treatise passages (conf 1.0) + his 1965 recorded stage speech
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+> **⚠ HONEST COMPLEXITY (load-bearing):** Dziuba **recanted under duress in 1973** (open tuberculosis + a year of КГБ interrogation; he would not have survived a camp winter). He never repudiated the substance of «Інтернаціоналізм чи русифікація?» and returned to the front rank of Ukrainian intellectual life — Hero of Ukraine, Minister of Culture, academician. §2 and §6 engage the recantation without excusing or condemning.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Михайлович Дзюба. [T1: ЕІУ — Желєзняк, т. 2, с. 378; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none. Russified imperial form (forbidden in body text; §8 only): Иван Михайлович Дзюба, Ivan Dzyuba.
+- **Born:** 26 July 1931 | село **Миколаївка**, Ольгинський район (**нині Волноваський район**), Донецька область (тоді Сталінська обл.) | Українська РСР. [T3: uk.wikipedia — "с. Миколаївка, Ольгинський район, нині Волноваський район, Донецька область"; T1: ЕІУ]
+- **Died:** **22 February 2022** (aged 90) | Київ, Україна | buried 24 February, Байкове кладовище (ділянка № 47а). [T3: uk.wikipedia]
+- **Family / education key facts:** son of peasants Михайло Іванович Дзюба (1909–1943, **killed at the front**) and Ольга Никифорівна (1912–1981). In **1932 the family fled the Holodomor** to Новотроїцьке, then to Оленівські Кар'єри (now Докучаєвськ). Studied **Russian philology at the Донецький педагогічний інститут** (a Stalin-stipend student), then the aspirantura of the **Інститут літератури ім. Т. Г. Шевченка**. A central member of the Київ **Клуб творчої молоді** (with Світличний, Горська, Симоненко, Костенко, Драч, Танюк, Сверстюк). [T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** the **district name** shifted (Ольгинський → нині Волноваський район) — same village, modern form used. His **Hero of Ukraine** award is **26 July 2001** (some short notices give other years — the дата is 2001). His birthplace's oblast was "Сталінська" in 1931 administrative terms and is **Донецька область** today; use the modern form.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section.
+
+- **What happened:** repeated political firings → forced professional isolation → the condemnation of his treatise → expulsion from the Writers' Union → arrest, trial, prison/exile sentence → a **duress recantation** → years of menial labour and publication ban → (after 1991) full rehabilitation. [T3: uk.wikipedia; T1: ЕІУ]
+- **When (specific dates):** fired from «Вітчизна» **1962** and «Молодь» **1965**; treatise written **1965**, sent to the leadership **1965–66**; expelled from the Спілка письменників **1972**; **arrested 13 January 1972**; condemnation commission report **15 February 1972**; sentenced **1973**; pardoned/recanted **late 1973**. [T3: uk.wikipedia]
+- **By whom (specific agency):** the **КГБ УРСР** (surveillance, interrogation), the **ЦК КПУ** (the 7 Feb 1972 commission), the **Київський обласний суд** (1973 sentence), and the **Спілка письменників України** (1972 expulsion). [T3: uk.wikipedia]
+- **Document references (quoted, not paraphrased):**
+  - On **4 September 1965**, at the Параджанов «Тіні забутих предків» premiere in the «Україна» cinema, Dziuba took the stage and said: "**У нас велике свято. Але й велике горе. В Україні почалися арешти творчої молоді,**" then named the arrested (Світличний, Караванський, the Горинь brothers, Гель) over a siren switched on to drown him out; В'ячеслав Чорновіл shouted "Хто протестує проти політичних арештів — встаньте!" [T3: uk.wikipedia]
+  - On **15 February 1972** the ЦК КПУ commission (chair **А. Д. Скаба**, incl. **М. З. Шамота**) ruled that «Інтернаціоналізм чи русифікація?» was "**від початку й до кінця пасквілем на радянську дійсність, на національну політику КПРС…**" — the document that turned the treatise into a criminal charge. [T3: uk.wikipedia]
+- **Mechanism specifics:** for three years after 1965 he was confined to proof-reading the «Український біологічний журнал» — a deliberate isolation from literature. In **1965** he wrote **«Інтернаціоналізм чи русифікація?»** and **personally mailed it** to first secretary **Петро Шелест**, head of the УРСР government **Володимир Щербицький**, the CC in Moscow, and «Новый мир» editor Tvardovsky — inviting open debate. **Arrested 13 January 1972** at the home of Іван Світличний; in **1973** sentenced to **5 years' imprisonment + 5 years' exile**. [T3: uk.wikipedia]
+- **The recantation (engaged honestly):** in КГБ remand, with **open tuberculosis** (contracted at 19) and a year of interrogation, Dziuba petitioned the Presidium of the Supreme Soviet for **pardon** and made a partial **"покаяння."** Researchers note this was a survival decision — "інакше він просто не пережив би найближчу зиму в таборі." He did **not** disown the treatise's argument. After the "pardon" the aircraft designer **Олег Антонов** found him proof-reading work at the Kyiv aviation plant, where he worked **8 years**, long unable to publish. [T3: uk.wikipedia]
+- **What survived / what was destroyed:** the treatise survived — it was already abroad (London, 1968) and in samvydav; it was finally printed in Ukraine in «Вітчизна» (1990). Dziuba's reputation survived the recantation: he became a **co-founder of Народний Рух України (1989)**, **Minister of Culture (1992–94)**, academician, and **Hero of Ukraine (2001)**. [T3: uk.wikipedia]
+
+## 3. Major works
+
+- `1965 (London 1968; Вітчизна 1990)` — **«Інтернаціоналізм чи русифікація?»** — the landmark samvydav treatise dismantling Soviet russification from inside Marxist-Leninist doctrine. [Primary in corpus `wave7-dzyuba-internatsionalizm`; verify_quote-confirmed §4]
+- `criticism (1960s–)` — literary-critical essays that won him the **О. Білецький Prize (1987)** and the **Shevchenko Prize (1991)**. [T3: uk.wikipedia]
+- `2001` — **«Україна перед Сфінксом майбутнього»** (НаУКМА inaugural lecture). [T3: uk.wikipedia]
+- `2005` — **«Микола Хвильовий: "Азіятський ренесанс" і "психологічна Европа"»** — his study of a Wave-C peer (see cross-links). [T3: uk.wikipedia]
+- `2008` — **«Тарас Шевченко. Життя і творчість»** (Києво-Могилянська академія) — Книжка року 2008. [T3: uk.wikipedia]
+- `2009` — editor of the 10-volume **«Україна. Антологія пам'яток державотворення X–XX ст.»**. [T3: uk.wikipedia]
+- `2015` — **«Донецька рана України»** (Інститут історії України) — his analysis of how Soviet/post-Soviet manipulation of the Donbas prepared the 2014 occupation. [T3: uk.wikipedia]
+- `editorial` — co-chair of the **«Енциклопедія Сучасної України»**; co-author of the **Шевченківська енциклопедія** (State Prize 2017); chief editor of **«Сучасність»** in the 1990s. [T3: uk.wikipedia]
+
+**Suppression note:** «Інтернаціоналізм чи русифікація?» was unpublishable in the USSR for 25 years and became a criminal charge against its author; it appeared in Ukraine only in 1990.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — the core thesis of «Інтернаціоналізм чи русифікація?» (1965).** `verify_quote` against the corpus (`wave7-dzyuba-internatsionalizm`) returned **matched=true, confidence 1.0**:
+
+> «Ідея асиміляції націй, ідея про майбутнє безнаціональне суспільство — це не ідея наукового комунізму, а того "комунізму", який Маркс і Енгельс називали казармовим.»
+
+Dziuba's method in one line: turn the regime's own canon (Marx/Engels/Lenin) against its russification policy. [Primary: І. Дзюба, «Інтернаціоналізм чи русифікація?»; verify_quote conf. 1.0, work `wave7-dzyuba-internatsionalizm`]
+
+**Quote 2 — the cover letter to the Party leadership (the open-debate gambit).** `verify_quote` returned **matched=true, confidence 1.0**:
+
+> «…бо йдеться про долю цілих націй. Ось про це я й хочу говорити докладніше. З цією метою додаю до листа підготовлений мною матеріал на цю тему ("Інтернаціоналізм чи русифікація?").»
+
+The astonishing premise — a citizen mailing a dissident treatise *to Shelest and Shcherbytsky themselves*, demanding the policy "виправиться." [Primary: cover letter to П. Шелест / В. Щербицький, 1965; verify_quote conf. 1.0, work `wave7-dzyuba-internatsionalizm`]
+
+**Quote 2b — the demand for free debate (corpus-attested, partial match).** The treatise's answer to coercion: `verify_quote` surfaced the verbatim line at conf 0.76 —
+
+> «…[я можу] протиставити одне: свободу — свободу публічного і чесного обговорення [національного питання].»
+
+[Primary: same work; verify_quote partial conf. 0.76 — reported honestly, the matched line is the real text]
+
+**Quote 3 — his 1965 stage statement (recorded speech, labelled):**
+
+> «У нас велике свято. Але й велике горе. В Україні почалися арешти творчої молоді.»
+
+The public act that opened the шістдесятники's open confrontation with the regime. [T3: uk.wikipedia — recorded; not corpus-verified verbatim]
+
+## 5. Language register
+
+- **Register:** scholarly-publicistic — rigorous, citation-dense argument (party resolutions, Lenin, Marx/Engels) deployed *against* the regime; later, a supple literary-critical and essayistic prose.
+- **CEFR readiness for full reading:** **C1–C2** — the treatise is sustained political-theoretical argument; his Shevchenko and Khvylovyi criticism is also C1. Short framed excerpts can be staged at **B2** with heavy scaffolding.
+- **Lexicon notes:** Marxist-Leninist and national-question terminology (асиміляція, русифікація, інтернаціоналізм, національне питання, державотворення); his late writing adds cultural-history vocabulary (Донеччина, ідентичність, маніпуляція).
+- **Stylistic features:** the immanent-critique method (beat the system with its own texts); measured, lawyerly tone; the moral force of restraint.
+
+## 6. Contested points
+
+- **The recantation (mandatory, handled honestly).** Dziuba's 1973 "покаяння" is the hardest fact in his life. Extracted under **medical duress (open TB) and a year of КГБ interrogation**, it was — on the scholarly consensus — a survival act, not a betrayal of the idea; he never disowned the treatise's substance. The uncompromising dissident ethic (e.g. **Vasyl Stus's** refusal of any concession) judged recantation harshly; most historians contextualise Dziuba's. The dossier names the fact, the duress, **and** the tension — without smoothing or excusing. [T3: uk.wikipedia; T4: Частакова]
+- **Communist positions — tactic or conviction?** He wrote *as* a Marxist-Leninist; whether this was sincere belief, a tactical frame, or both at the time is debated. His later evolution (Rukh, independence) is clear. [Primary: the treatise]
+- **Bilingualism nuance.** His late "Ми — двомовні, а нас за це називають націоналістами" is a complex, sometimes-contested position on Ukrainian bilingualism — to be presented in full, not clipped.
+- **Where Russian aggression continues:** «Донецька рана України» (2015) directly analyses the manipulation that fed the **2014 occupation of the Donbas** (his own homeland); contemporary Russian narrative denies both the russification he documented and the occupation he diagnosed. Named here as such.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml`, `curriculum/l2-uk-en/plans/bio/alla-horska.yaml`, `curriculum/l2-uk-en/plans/bio/yevhen-sverstiuk.yaml`, `curriculum/l2-uk-en/plans/bio/bohdan-horyn.yaml` — the Клуб творчої молоді / шістдесятники core (Світличний's home was his place of arrest).
+  - `curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml`, `curriculum/l2-uk-en/plans/bio/lina-kostenko.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-drach.yaml` — fellow шістдесятники of the same circle.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml` — stood beside him in the 1965 protest; the moral counter-case on recantation (§6).
+  - `curriculum/l2-uk-en/plans/bio/serhii-paradzhanov.yaml` — whose premiere was the stage for the 1965 protest.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`, `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml` — his generation and the russification fight at the heart of his treatise.
+  - `curriculum/l2-uk-en/plans/hist/rukh.yaml`, `curriculum/l2-uk-en/plans/hist/nezalezhnist-1991.yaml` — the movement he co-founded and the independence he helped build.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the КГБ machinery that arrested him.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/dziuba-internationalism.yaml`, `curriculum/l2-uk-en/plans/lit/dziuba-literature.yaml` — the dedicated Dziuba LIT pair.
+  - `curriculum/l2-uk-en/plans/lit/shestydesiatnyky-as-phenomenon.yaml`, `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml` — the generational frame and samvydav system that carried his treatise.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST/CIVIC module on **«Інтернаціоналізм чи русифікація?»** as a primary text on russification.
+  - A module on **«Донецька рана України»** as a 2014/2022 pre-history.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A node on **the ethics of recantation** under totalitarianism (Dziuba ↔ Stus as paired case study).
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-dziuba`
+- **EN canonical (BGN/PCGN-style project spelling):** Ivan Dziuba
+- **UA canonical (with patronymic):** Іван Михайлович Дзюба
+- **Aliases to track (`aliases:` YAML field):** Ivan Dziuba; treatise title EN "Internationalism or Russification?".
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Иван Дзюба; Ivan Dzyuba (Russified transliteration).
+
+## 9. Image candidates
+
+- **Best portrait (note: recent figure — PD-by-age does NOT apply):** Dziuba died in **2022**, so most photographs are **in copyright**. Use a **CC-BY / CC-BY-SA** licensed press or Wikimedia portrait, or seek permission; do not assume public domain. [check Wikimedia Commons `Ivan Dziuba` file-page licenses individually]
+- **Backup candidates:** stills from the 2023 documentary **«Іван і Марта»** (rights-cleared only); his Байкове кладовище grave (ділянка № 47а); a samvydav/«Вітчизна» 1990 page of «Інтернаціоналізм чи русифікація?».
+- **Context image:** a facsimile of the treatise's first London 1968 edition cover — strong §3 illustration if rights-clear.
+- **If no rights-clear portrait clears review:** use the treatise title-page / an official state-award ceremony photo released under a compatible licence.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Желєзняк М. Г. "Дзюба Іван Михайлович." *Енциклопедія історії України*, т. 2 (Г–Д). Київ: Наукова думка, 2004. С. 378. (cited via article apparatus.)
+- *Шевченківські лауреати. 1962–2001: Енциклопедичний довідник.* Київ, 2001. С. 136–138.
+
+**Tier 2 (institutional / primary-adjacent):**
+- Дзюба І. *На трьох континентах.* Київ: Кліо, 2013 — his own memoirs.
+- Дзюба І. *Донецька рана України: Історико-культурологічні есеї.* Київ: Інститут історії України НАН України, 2015.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Дзюба Іван Михайлович." Birth/death, the 1965 protest, the treatise's recipients, arrest, recantation, ministerial and award record cross-checked against ЕІУ. Accessed 2026-06-03.
+
+**Tier 4 (modern scholarly — referenced):**
+- Частакова Н. *Іван Дзюба: Дух і творчість.* Київ: Університетське видавництво ПУЛЬСАРИ, 2016.
+- Юрій Шаповал, «Досвітній вогонь» // Дзеркало тижня, 2005 — on the treatise's history.
+
+**Primary-source documents accessed (via the corpus):**
+- І. Дзюба, **«Інтернаціоналізм чи русифікація?»** (London, 1968) — accessed directly via the literary corpus (`wave7-dzyuba-internatsionalizm`), verify_quote-confirmed conf. 1.0 (§4), incl. the cover letter to Шелест/Щербицький.
+- The 7 Feb 1972 ЦК КПУ commission decision (chair Скаба) declaring the treatise a "пасквіль" (via T3).
+
+**Honest gaps:** the ЕІУ entry is cited via apparatus (page number), not opened page-by-page this pass; opened sources are uk.wikipedia (T3) and the primary treatise in the corpus. The exact wording and extent of the **1973 recantation** is sensitive and variously reported — the dossier states the fact and the duress, not a verbatim text. Image licensing is genuinely constrained (recent death; copyright, not PD).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his anti-russification analysis is told on its own terms; the empire appears as the assimilating power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "шістдесятники," "самвидав," "русифікація," "державотворення" used precisely.
+- [x] No uncritical Soviet propaganda terms — "пасквіль," "ідеологічні помилки," "антирадянський" appear only quoted as the regime's own charges, named as such.
+- [x] No "lost his life" euphemism — N/A (he died in 2022 at 90); his persecution and the duress recantation are named plainly, not softened.
+- [x] Modern UA place names — Миколаївка (Волноваський район, Донецька область), Докучаєвськ, Київ/Kyiv.
+- [x] Holodomor referenced as **Holodomor** (his family fled it in 1932), never "Soviet famine."
+- [x] Russian aggression framing — «Донецька рана України» is set against the **2014 occupation of the Donbas** and today's russification denial (§6).

--- a/docs/research/bio/les-kurbas.md
+++ b/docs/research/bio/les-kurbas.md
@@ -1,0 +1,176 @@
+# Лесь Курбас (Олександр-Зенон Степанович Курбас) — Research Dossier
+
+**Slug:** `les-kurbas`
+**Block:** A (executed by NKVD; death-date falsified by the state — Розстріляне відродження)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave C)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU T1; ЕІУ Герасимова T1; ЕСУ Корнієнко T1; ULE & Шевченківський словник in corpus)
+- [x] Oppression mechanism is specific (arrest 25.12.1933; 5-year sentence 9.04.1934; трійка 9.10.1937; shot 3.11.1937 Сандармох; case № 3168)
+- [x] ≥2 primary-source quotes — Kurbas's own theatre aphorisms (labelled Wikiquote/recollection) + the ЕУ-attested programme of the "thinking theatre"
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Лесь Курбас — Олександр-Зенон Степанович Курбас. [T1: IEU — "Kurbas, Les"; T1: ULE (corpus) — "[Олександр-Зенон Степанович]"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** "Лесь" is the lifelong familiar form of Олександр. Russified imperial forms (forbidden in body text; §8 only): Александр Курбас, Aleksandr Kurbas.
+- **Born:** 25 February 1887 | місто Самбір, Самбірський повіт, Королівство Галичини та Володимирії, **Австро-Угорщина** | now Самбірський район, Львівська область, Україна. [T1: IEU — "b 25 February 1887 in Sambir, Galicia"; T1: ULE (corpus); T3: uk.wikipedia]
+- **Died:** **3 November 1937** (aged 50) | урочище Сандармох, Медвеж'єгорський район, Карельська АРСР, РРФСР | **shot by the NKVD** in the Соловецький-etap mass executions. [T1: IEU — "d 3 November 1937 in Sandarmokh"; T1: ULE (corpus) — "3.XI 1937"; T3: uk.wikipedia]
+- **Family / education key facts:** Born into a Galician acting family — father Степан Курбас and mother Ванда (stage name **Яновичі**). Народний артист УРСР (1925). Studied at the Тернопільська гімназія, **Львівський університет (1908–10)** — where he fought for the university's Ukrainianisation — then transferred to the **Віденський університет** (philosophy/Slavistics, 1907–08, 1911) in protest at Polonisation, and completed the drama school of the Vienna Conservatory. [T1: ULE (corpus); T3: uk.wikipedia]
+
+**Source disagreement note — THE central falsification (flagged, not smoothed):** Kurbas's **death date is split across the corpus along exactly the political fault-line the state engineered.** The post-Soviet **Українська літературна енциклопедія** (corpus `wave8-ukr-lit-entsyklopediia`) gives the **true date "3.XI 1937"**; but the Soviet-era **Шевченківський словник** (corpus `wave10-shevchenkivsky-slovnyk`) prints **"25.II 1887 — 15.Х 1942"**, and М. Попович's *Нарис історії культури* carries **"1942"** too. The "1942" is a **deliberate NKVD fabrication** (see §2/§6) — and the fakes do not even agree with each other (15 **October** 1942 in the dictionary vs 15 **November** 1942 on the widow's 1961 certificate), which is itself the fingerprint of forgery. Use **3 November 1937**; name the 1942 date as falsification whenever it appears.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section.
+
+- **What happened:** professional destruction (Oct 1933) → arrest → fabricated terrorism conviction → GULAG (Білбалтканал → Solovki → Anzer) → execution → **state falsification of the death**. [T1: IEU; T3: uk.wikipedia]
+- **When (specific dates):** dismissed from Березіль **5 October 1933**; **arrested 25 December 1933**; sentenced **9 April 1934** (5 years); трійка death sentence **9 October 1937**; **shot 3 November 1937**; fake death certificate issued **16 May 1961** (claiming death 15 Nov 1942). [T3: uk.wikipedia]
+- **By whom (specific agency):** the **Колегія Наркомосу УСРР** (dismissal), the **НКВС/ДПУ** (arrest, interrogation, case № 3168), the **Харківський суд** (1934 sentence), and the **особлива трійка УНКВД Ленінградської області** (the 9 Oct 1937 death list). [T3: uk.wikipedia]
+- **Document references (quoted, not paraphrased):**
+  - The **5 October 1933** Наркомос protocol dismissing him states he held "**позицію українського націоналіста**" and that Березіль "не зміг зайняти відповідне місце в створенні українського радянського мистецтва"; only four actors defended him — Іван Мар'яненко, **Йосип Гірняк**, Борис Балабан, Роман Черкашин. [T3: uk.wikipedia]
+  - He was charged with membership of the counter-revolutionary terrorist "**Українська військова організація**" (УВО) and an alleged plot to murder **Павло Постишев**, second secretary of the ЦК КП(б)У; after months of "допити" he signed on 10 March 1934 that he was "контрреволюціонером." The case is **Справа № 3168** (published by Шудря/Лабінський). [T3: uk.wikipedia; T4: Шудря, Лабінський «Трагедійна доля митця. Справа № 3168»]
+- **Mechanism specifics:** sentenced 9 April 1934 to **5 years**; sent to the **Біломорсько-Балтійський канал** construction near Медвежа Гора, where he still staged plays for the вільнонаймані. In **1936** transferred to the **Соловецький табір особливого призначення** (СЛОН) — there he built a theatre and staged Погодін's «Аристократи» and Shaw's «Учень диявола» — then to **Анзер island**, staging Pushkin's «Маленькі трагедії». On **9 October 1937** the Leningrad-oblast трійка condemned 1825 Solovki prisoners to death in a single list; Kurbas was shot at **Сандармох on 3 November 1937**, in the same Соловецький-etap as **Микола Куліш, Валер'ян Підмогильний, Григорій Епік**. [T3: uk.wikipedia]
+- **What survived / what was destroyed:** the regime then **falsified the death** — the Rivne paper «Волинь» (March 1942) spread that he was alive "перевізником на річці коло Мурману," and on **16 May 1961** the state handed his widow **Валентина Чистякова** a certificate claiming he died of "крововиливу в мозок" on **15 November 1942**. The truth surfaced only after archive declassification. **Rehabilitated:** the Військовий трибунал Північного військового округу closed the case **31 January 1957**. His Berezil legacy survived in his collaborators and writings; he has **no grave** — a 1993 пам'ятник-пантеон in Kharkiv holds soil brought from Соловки. [T3: uk.wikipedia]
+
+## 3. Major works
+
+A director and theorist, not chiefly a writer of texts; his "works" are landmark **productions** plus theoretical **publicism**.
+
+- `1915–16` — founded **«Тернопільські театральні вечори»**, the first stationary professional Ukrainian theatre. [T1: ULE (corpus)]
+- `1917–19` — founded the **Молодий театр** (Kyiv), opening with Винниченко's «Чорна Пантера і Білий Ведмідь»; «Шевченківська вистава» and «Цар Едіп» (1918–19). [T1: Попович (corpus)]
+- `1920` — **«Гайдамаки»** after Shevchenko — his epochal staging (music К. Стеценко), which toured Ukraine and beyond for decades. [T1: Шевченківський словник (corpus)]
+- `1922–1933` — founder and head of **«Березіль»** (Kyiv, then Kharkiv): «Жовтень» (1922), «Газ» Kaiser (1923), **«Джиммі Хіггінс»** after Sinclair (1923), «Макбет» (1924), «Золоте черево» Crommelynck (1926), and the **Куліш cycle — «Народний Малахій» (1928), «Мина Мазайло» (1929), «Маклена Ґраса» (1933)** — the summit of Ukrainian modernist theatre. [T3: uk.wikipedia]
+- `1924–25` — film director (ВУФКУ, Одеса): «Вендетта», «Макдональд», «Арсенальці». [T3: uk.wikipedia]
+- `theory/publicism` — **«Шляхи Березоля»** (1927); the journals «Театральні вісті», **«Барикади театру»** (1923–24), «Радянський театр»; collected posthumously as **«Березіль: Із творчої спадщини»** (1988) and **«Філософія театру»** (Основи, 2001); director's diary «Набринілі болем акорди». [T1: ULE (corpus); T3: uk.wikipedia]
+
+**Suppression note:** Berezil was liquidated as Kurbas's theatre in 1933 (renamed in 1935 to the Харків. укр. драм. театр ім. Т. Г. Шевченка); his name and method were unmentionable for decades, and his theoretical legacy was reassembled only from the late 1980s.
+
+## 4. Primary-source quotes (≥2 required)
+
+> Note on method: Kurbas's writings are not in the project's verify_quote literary corpus (it is poetry/prose-centric); the corpus instead **paraphrases his programme**, and his aphorisms survive via the documentary editions and Wikiquote. Sources and verify-status are stated honestly.
+
+**Quote 1 — the actor against the "trained ape" (on theatre as creation, not imitation):**
+
+> «Створити те, чого немає в дійсності, кинути людям фантазію, ідеальне, неіснуюче, але прекрасне — тільки в цьому може бути різниця актора від гарно вишколеної мавпи.»
+
+The core of his anti-naturalist credo: theatre **creates**, it does not copy life. [T5: uk.wikiquote — sourced; not corpus-verified verbatim]
+
+**Quote 2 — on why Soviet critics rejected the Куліш plays (the "national content"):**
+
+> «І коли частина глядачів на Україні не розуміє цього змісту, то це тому, що воно є суто національним.»
+
+Said of «Народний Малахій» / «Мина Мазайло» — Kurbas naming the national substance the regime would punish. [T5: uk.wikiquote — sourced]
+
+**Quote 2b — the programme of the "thinking theatre," attested in the corpus.** The Енциклопедія українознавства (corpus `wave7-entsyklopediia-ukrainoznavstva`) records his governing principle verbatim as a paraphrase:
+
+> «театр не відтворює життя, а своїми, властивими йому засобами впливає на життя» — звідси у Курбаса «гасло активного, думаючого театру»; «"Березіль" ішов через афект до думки.»
+
+This is the cleanest corpus-anchored statement of his method (синтетичний театр, перетворення). [T1: ЕУ (corpus) — paraphrase of Kurbas's own programme]
+
+**Quote 3 (recollection — clearly labelled) — on communism and human nature:**
+
+> «Комунізм несумісний з природою людини, як вогонь з водою.»
+
+Transmitted by Лесь Танюк (Radio Svoboda) as Kurbas's late conviction — powerful but **recollected, possibly polished**; flagged as second-hand, not a settled text. [T5: Радіо Свобода — Танюк, via uk.wikiquote]
+
+## 5. Language register
+
+- **Register:** theatrical-theoretical **publicism** — dense, conceptual, coining a vocabulary (перетворення, синтетичний театр, "розумний арлекін," "думаючий театр"). His was a director's intellectual prose, formed by Vienna philosophy and Galician-literary culture.
+- **CEFR readiness for full reading:** his theoretical texts are **C1–C2**; but his *productions* are largely visual, so excerpts (a «Гайдамаки» description, a Berezil photo) work from **B1** with support.
+- **Lexicon notes:** theatre terminology to pre-teach — режисура, вистава, перетворення, експресіонізм, конструктивізм, синтетичний, агітпроп; the Galician/Austrian biographical layer (Королівство Галичини та Володимирії) needs a historical gloss.
+- **Stylistic features:** montage and rhythm as dramaturgy; "через афект до думки" (through affect to thought) — the deliberate contrast with German expressionism (corpus §6).
+
+## 6. Contested points
+
+- **The falsified death-date (centerpiece).** The "1942 / brain-haemorrhage" story is a documented **state forgery**; that two official Soviet artefacts give two *different* fake dates (15.X.1942; 15.XI.1942) is proof of fabrication, and that a reference dictionary printed the fake into "scholarship" shows how deep the erasure ran. Always correct to **3 November 1937, executed**. [corpus: ULE vs Шевченківський словник; T3: uk.wikipedia]
+- **Avant-garde communist or national modernist?** Kurbas was Народний артист УРСР and worked inside Soviet theatre, yet was destroyed as a "український націоналіст." Whether his late "комунізм несумісний з природою людини" marks a real break or a recollection shaped by hindsight is debated. [T5: Танюк]
+- **Simplified in memory:** flattened into "the founder of Berezil" or a single martyrdom, losing the theorist (перетворення) and the Galician-Viennese formation.
+- **Where Russian/Soviet disinformation attacks:** the fabricated UVO/Postyshev-plot charge; the fake 1942 death; and the broader erasure of Сандармох — where, since Russia's seizure of the narrative, the memorial itself has been contested and damaged. Named here as falsification. [T3: uk.wikipedia]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-kulish.yaml` — his playwright; their collaboration and shared execution at Сандармох are the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/mykola-khvylovyi.yaml` — the ВАПЛІТЕ-era intellectual milieu Berezil moved in.
+  - `curriculum/l2-uk-en/plans/bio/hnat-khotkevych.yaml` — in whose theatre the young Kurbas first worked; later also executed (1938).
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-vynnychenko.yaml` — the Молодий театр opened with his «Чорна Пантера».
+  - `curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml` — stage-design world of the 1920s Ukrainian theatre.
+  - `curriculum/l2-uk-en/plans/bio/maik-yohansen.yaml`, `curriculum/l2-uk-en/plans/bio/heo-shkurupii.yaml`, `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml` — «Барикади театру» contributors and 1920s Kharkiv/Kyiv peers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — the generation; his death is one of its definitive losses.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the трійка / Solovki machinery that killed him.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/sandarmokh-tragedy-erasure.yaml` — the execution ground and its erasure — directly his fate.
+  - `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`, `curriculum/l2-uk-en/plans/lit/vaplite-literary-avant-garde.yaml` — the generational and avant-garde frame.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated THEATRE module on **«Березіль»** and the concept of **перетворення** (none exists yet).
+  - A BIO node for **Йосип Гірняк** / **Микола Садовський** (no plan files yet — confirmed absent on 2026-06-03).
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A module on the **falsified-death mechanism** as a category of Soviet erasure (Kurbas + the «1942» artefacts as case study).
+
+## 8. Naming-canonical
+
+- **Slug:** `les-kurbas`
+- **EN canonical (BGN/PCGN-style project spelling):** Les Kurbas
+- **UA canonical (with patronymic):** Лесь Курбас — Олександр-Зенон Степанович Курбас
+- **Aliases to track (`aliases:` YAML field):** Les Kurbas; Oleksandr Kurbas; family stage-name Яновичі (parents).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Александр Курбас; Aleksandr Kurbas; "Lesy Kurbas" mis-transliteration. **The falsified death-year 1942 must never be presented as fact.**
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Les Kurbas"** holds 1910s–1930s photographic portraits; he died in 1937, so pre-1937 photographs are public domain by age in Ukraine and the US. Confirm on the individual **file page**. [Commons category: `Les Kurbas`]
+- **Backup candidates:** a Berezil production still (e.g. «Гайдамаки» 1920, «Народний Малахій» 1928); the Мистецький музей Леся Курбаса in Самбір.
+- **Context image:** the **Сандармох** memorial, or a facsimile page of Справа № 3168 — strong §2 illustrations if rights-clear.
+- **If no rights-clear portrait clears review:** fall back to the NBU 2007 commemorative coin (120th anniversary) or a PD «Барикади театру» journal cover.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Kurbas, Les." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\U\KurbasLes.htm — birth/death (3 Nov 1937), arrest, Berezil, Solovki execution. Accessed 2026-06-03 (opened and verified).
+- Герасимова Г. П. "Курбас Лесь." *Енциклопедія історії України*, т. 5 (Кон–Кю). Київ: Наукова думка, 2009. С. 514. (cited via article apparatus.)
+- Корнієнко Н. М. "Курбас Лесь." *Енциклопедія Сучасної України.* Київ: Інститут енциклопедичних досліджень НАН України. (ЕСУ article; cited via apparatus.)
+- *Українська літературна енциклопедія* (corpus `wave8-ukr-lit-entsyklopediia`) — gives the **correct 3.XI 1937**; and *Енциклопедія українознавства* (corpus) — the "thinking theatre" programme.
+
+**Tier 2 / Tier 4 (institutional / modern scholarly):**
+- Єрмакова Н. *Березільська культура: історія, досвід.* Київ: Фенікс, 2012.
+- Корнієнко Н. *Лесь Курбас: репетиція майбутнього.* Київ: Либідь, 2007.
+- Макарик І. *Перетворення Шекспіра. Лесь Курбас, український модернізм…* Київ: Ніка-Центр, 2010.
+- Шудря М., Лабінський М. «Трагедійна доля митця. Справа № 3168» // Україна, 1991, № 11–13 — the NKVD case file.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Лесь Курбас." Dates/arrest/execution and the falsified-1942 documents cross-checked against IEU and ULE. Accessed 2026-06-03.
+
+**Tier 5 (general web — used only with corroboration):**
+- uk.wikiquote.org, "Лесь Курбас" — source of Quotes 1–3 (labelled).
+- Радіо Свобода — Лесь Танюк, «Курбас: комунізм несумісний з природою людини» (the recollected Quote 3).
+
+**Primary-source documents accessed (in transcription / via scholarship):**
+- **Справа № 3168** (НКВС/ДПУ) and the 9 October 1937 трійка death list (via Шудря/Лабінський; IEU).
+- The **16 May 1961 death certificate** issued to Валентина Чистякова (the falsification document, claiming death 15 Nov 1942).
+
+**Honest gaps:** Kurbas's theoretical texts are not in the verify_quote corpus, so §4 rests on documentary editions / Wikiquote (labelled) plus the corpus's ЕУ paraphrase. The brief's "«97» (1930)" is **not** in Kurbas's Berezil repertoire — «97» was Микола Куліш's play staged by Гнат Юра at the Franko theatre; Kurbas's Куліш productions were «Народний Малахій» (1928), «Мина Мазайло» (1929) and «Маклена Ґраса» (1933) — corrected here per the verified production list.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his Galician-Viennese formation and Ukrainian modernist project are central; the empire appears as executioner and forger.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "Українська революція" used; "Громадянська війна" appears only inside reported corpus/biography, not as my frame.
+- [x] No uncritical Soviet propaganda terms — "український націоналіст" / "контрреволюціонер" appear only quoted as the regime's own charges, named as fabrication.
+- [x] No "lost his life" euphemism — "shot by the NKVD at Сандармох" stated plainly; the falsified "natural death" is named as forgery.
+- [x] Modern UA place names — Самбір (Львівська область), Харків/Kharkiv; Сандармох named as the execution ground.
+- [N/A] Holodomor — not directly part of his biography (executed 1937; he was already imprisoned during 1932–33); not forced into the text.
+- [x] Russian aggression framing — the contemporary contestation/damage of the Сандармох memorial under Russian narrative control is noted (§6).

--- a/docs/research/bio/mykola-khvylovyi.md
+++ b/docs/research/bio/mykola-khvylovyi.md
@@ -1,0 +1,169 @@
+# Микола Хвильовий (Микола Григорович Фітільов) — Research Dossier
+
+**Slug:** `mykola-khvylovyi`
+**Block:** A (driven to suicide by Soviet persecution — Розстріляне відродження)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave C)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU T1; Костюк/Смолоскип 5-volume T2; Мельників critical edition + ГДА СБУ formulary file)
+- [x] Oppression mechanism is specific (Stalin's 26.04.1926 letter; НКВС справа-формуляр С-183; suicide 13.05.1933, house «Слово»)
+- [x] ≥2 primary-source quotes — two verify_quote-confirmed pamphlet passages (1.0 and 0.84) + the transmitted suicide-note opening (labelled)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Хвильовий — pen name of **Микола Григорович Фітільов**. [T1: IEU — "born Mykola Fitilev"; T3: uk.wikipedia — "справжнє ім'я — Фітільов Микола Григорович"]
+- **Pseudonyms / aliases:** Хвильовий (his permanent literary name); also signed **Юлія Уманець, Стефан Кароль, Дядько Микола**. Russified imperial forms (forbidden in body text; listed only in §8): Николай Хвылёвый, Nikolai/Nikolay Khvylovy. [T3: uk.wikipedia]
+- **Born:** 13 December 1893 (1 December O.S.) | селище Тростянець, Охтирський повіт, Харківська губернія | now Сумська область, Україна; the Російська імперія held the region. [T3: uk.wikipedia — "1 [13] грудня 1893"; T1: IEU gives **14 December 1893** — a one-day divergence, flagged below]
+- **Died:** 13 May 1933 (aged 39) | Харків, будинок письменників «Слово», квартира № 9 | Українська СРР | **suicide by gunshot to the temple** (driven to it by the onset of mass terror — see §2). [T1: IEU — "committed suicide… 13 May 1933 in Kharkiv"; T3: uk.wikipedia — "покінчив життя самогубством… пострілом у скроню"]
+- **Family / education key facts:** Son of teacher **Григорій Олексійович Фітільов** (of дворянський origin, Russophone, by Хвильовий's own account a heavy drinker) and teacher **Єлисавета Іванівна Тарасенко**. Studied at the Охтирська and Богодухівська чоловічі гімназії, expelled from both for involvement in Ukrainian revolutionary / socialist circles. Worked as an itinerant labourer across the Donbas and southern Ukraine; from 1916 a soldier in the First World War. Joined the **КП(б)У in April 1919** and led a partisan detachment of "вільних козаків" in late 1918 fighting гетьманців, Germans, and the **Army of the УНР** — a convinced Bolshevik whose later destruction by the regime he served is the core of his tragedy. [T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** IEU dates his birth to **14 December 1893** (New Style) while Ukrainian sources give **1 (13) December 1893** — i.e. 1 December Old Style = 13 December New Style; the one-day difference is a transliteration/calendar artefact, not two different events. His **real surname** is spelled both **Фітільов** and **Фітільов / Фітилів** in editions; the canonical literary identity is uncontested: *Хвильовий*. The **exact wording of the two suicide notes** differs across publications because the originals were confiscated by the міліція in 1933 and circulated only from memory/reconstruction until the late 1980s (see §4).
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Хвильовий was not shot or sentenced; he was **driven to suicide** ("доведений до самогубства") by a sustained machinery of political persecution, then **erased** for half a century. This is a documented mode of Soviet repression, not a private tragedy.
+
+- **What happened:** ideological persecution → forced public recantations → surveillance and professional isolation → and, at the onset of the mass terror, suicide as protest. [T1: IEU — "every opportunity to live, write, and fight for his ideas was blocked"; T3: uk.wikipedia]
+- **When (specific dates):** Stalin's intervention **26 April 1926**; secret-police formulary file opened **1927**; renunciation of «Геть від Москви!» **January 1928** (from Vienna); suicide **13 May 1933**.
+- **By whom (specific agencies):** the **ЦК ВКП(б) and Й. Сталін personally**, the **КП(б)У** leadership (Л. Каганович, А. Хвиля, В. Чубар, Г. Петровський as the public attack chorus), and the **НКВС/ДПУ УСРР** (surveillance). [T3: uk.wikipedia]
+- **Document references (quoted, not paraphrased):**
+  - **Stalin's letter «Тов. Кагановичу та іншим членам ПБ ЦК ВКП(б)У» of 26 April 1926** named Хвильовий's writings as evidence of spreading anti-Russian sentiment in Ukraine — the signal that turned a literary debate into a political hunt. [T3: uk.wikipedia — "У листі… від 26 квітня 1926 року Й. Сталін вказав на виступи Хвильового як прояви поширення антиросійських настроїв в Україні"]
+  - **НКВС/ДПУ УСРР справа-формуляр С-183 (1927)** — the standing surveillance dossier opened on him. [T3: uk.wikipedia — "1927 року працівники НКВС УСРР заводять справу-формуляр С-183"; Primary: ГДА СБУ formulary file]
+- **Mechanism specifics:** Хвильовий launched the **Літературна дискусія 1925–1928** with the 1925 article «Про "сатану в бочці"…» and the pamphlet cycles «Камо грядеши?» (1925), «Думки проти течії» (1926), «Апологети писаризму» (1926) and the polemic «Україна чи Малоросія?» (suppressed in his lifetime), demanding that Ukrainian culture stop imitating Moscow and orient on a "психологічну Європу." Branded the ideologist of "хвильовізм" — one of three labelled "national-deviations" alongside "шумськізм" and "волобуєвщина" — he was forced into humiliating public recantations in 1926–1928 to save **ВАПЛІТЕ** from dissolution, and from Vienna in January 1928 publicly renounced his own slogan «Геть від Москви!» in a letter to the newspaper «Комуніст». [T1: IEU — "renouncing his slogan 'Away from Moscow'"; T3: uk.wikipedia]
+- **The trigger:** in spring 1933 he travelled the Полтавщина villages with Аркадій Любченко and saw the **Holodomor** at first hand, returning "фізично й морально розбитим." On the night of 12–13 May 1933 his friend **Михайло Яловий** was arrested. On 13 May, in his flat in the «Слово» building, before friends including **Микола Куліш** and Олесь Досвітній, Хвильовий shot himself — Куліш was first to the sound. [T3: uk.wikipedia — "Самогубство Миколи Хвильового"]
+- **What survived / what was destroyed:** the night before, Хвильовий destroyed an unfinished novel (probably «Комсомольці»). The two suicide notes were read by friends, then **confiscated by the міліція**; his stepdaughter Любов Уманцева first heard the true text of her note only in the late 1980s. His name and works were **banned until the final years of the USSR**. The suicide detonated the mass arrests that emptied the «Слово» building — the symbolic end of the **Розстріляне відродження**.
+
+## 3. Major works
+
+- `1921` — поетична збірка **«Молодість»**; поема **«В електричний вік»** — early romantic-impressionist verse. [T3: uk.wikipedia]
+- `1922` — **«Досвітні симфонії»** (вірші). [T3: uk.wikipedia]
+- `1923` — **«Сині етюди»** (новели, оповідання, етюди) — the breakthrough prose book; academician Олександр Білецький called him "основоположником справжньої нової української прози." [T3: uk.wikipedia]
+- `1924` — новела **«Я (Романтика)»** — a Cheka officer who shoots his own mother in the name of the Revolution; the central text of the humanism-vs-fanaticism conflict. [T3: uk.wikipedia]
+- `1925` — pamphlet cycle **«Камо грядеши?»** (Книгоспілка); article «Про "сатану в бочці"…» that opened the Літературна дискусія. [T3: uk.wikipedia; verify_quote-confirmed, §4]
+- `1926` — pamphlet cycles **«Думки проти течії»** and **«Апологети писаризму»**; the powerhouse повість **«Санаторійна зона»**. [T3: uk.wikipedia]
+- `1927` — роман **«Вальдшнепи»** (part 1 published; part 2 suppressed/lost after the assault on it). [T3: uk.wikipedia]
+- `(written 1926, unpublished in his lifetime)` — **«Україна чи Малоросія?»** — the most pointed polemic; first printed only 1993 (Смолоскип). [T3: uk.wikipedia]
+- `1928–1931` — editor and founder of the journals **«Літературний ярмарок»** and **«Пролітфронт»**. [T1: IEU; T3: uk.wikipedia]
+- `1931–1933` — the "period of heroic endurance": late "party-line" attempts (**«Мисливські оповідання…»**, **«Майбутні шахтарі»**, **«З лабораторії»**) written under near-total isolation. [T3: uk.wikipedia]
+
+**Suppression note:** «Україна чи Малоросія?» went unpublished for ~67 years; «Вальдшнепи» part 2 was destroyed/lost; the entire œuvre was banned until the late 1980s; the first full critical edition (**Повне зібрання у 5 томах**, упор. Ростислав Мельників) appeared only **2018–2023**.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — the peroration of «Камо грядеши?» (1925).** `verify_quote` against the literary corpus (`ukrlib-khvylovy`) returned **matched=true, confidence 1.0**:
+
+> «Ми відкидаємо малоросійщину, просвітянщину та іншу безперспективну вузькість і кличемо до невідомих обріїв прекрасного азіатського ренесансу… Кажіть же, юнаки й юнки: — Камо грядеши?»
+
+Pedagogically central: the programmatic break with "малоросійщина" (provincial colonial self-image) and the call to a Ukrainian-led "азіатський ренесанс." [Primary: М. Хвильовий, «Камо грядеши?», 1925; verify_quote conf. 1.0, work `ukrlib-khvylovy`]
+
+**Quote 2 — on what "Європа" meant (the «психологічна Європа» argument).** `verify_quote` returned **matched=true, confidence 0.84**:
+
+> «…під "Європою" ми мали на увазі не тільки технічні досягнення, але й — головне — психологічну категорію, певний тип культурного фактора в історичному процесі, певний революційний метод.»
+
+This is the sentence behind the slogan «Дайош психологічну Європу» / «Геть від Москви!»: Хвильовий argues for Europe as an *orientation and method*, not a geography — useful for teaching that his "anti-Moscow" stance was cultural decolonisation, which the regime deliberately re-read as political treason. [Primary: М. Хвильовий, polemical cycle; verify_quote conf. 0.84, work `ukrlib-khvylovy`]
+
+**Quote 3 (transmitted document — labelled) — the suicide note to fellow writers, 13 May 1933.** The original was confiscated; the text below is the widely transmitted opening, **not** corpus-verifiable (a note is not a published literary work):
+
+> «Арешт Ялового — це розстріл цілої генерації… За що? За те, що ми були найщирішими комуністами?»
+
+The note famously ends "Хай живе комунізм. Хай живе соціалістичне будівництво. Хай живе комуністична партія." That a man hunted to death by the Party closed his life with "Long live the Communist Party" is the unsmoothed tragedy of national-communism (see §6) — do not edit it out. [T3: uk.wikipedia — «Самогубство Миколи Хвильового»; full text public only after late-1980s rehabilitation]
+
+## 5. Language register
+
+- **Register:** high modernist. Early prose is **ornamental** ("орнаментальна проза") — impressionistic, rhythmic, alliterative, lyric, with weak plot and strong leitmotif/symbol. The pamphlets are blazing **polemical publicism**: irony, sarcasm, rhetorical apostrophe, neologism.
+- **CEFR readiness for full reading:** the modernist prose and pamphlets are **C1–C2** (dense allusion, irony, period political lexicon); analytical biography about him is **B2**; the §6 debates (національ-комунізм, деколонізація) are **C1**.
+- **Lexicon notes:** period-political compounds — *малоросійщина, просвітянщина, хвильовізм, азіатський ренесанс, націонал-комунізм, українізація*; watch the deliberate calque-baiting and the 1920s Харків literary slang. VESUM confirms *памфлет, самогубство, розстріляне (→ розстріляний), відродження, українізація, націонал-комунізм, псевдонім, репресії, реабілітований*; **Голодомор** is a proper-noun term absent from the VESUM morphological table and should be glossed, never softened to "Soviet famine."
+- **Stylistic features:** musicalised, ritmised prose; binary montage of the dreamed vs the real (novellas «Синій листопад», «Арабески»); the unreliable revolutionary narrator.
+
+## 6. Contested points
+
+- **National-communism — sincerity vs tactic.** Was Хвильовий a genuine communist who believed Ukrainian culture could flourish *within* the Revolution, or was Soviet loyalty a shield for a national project? His own recantations and the "Хай живе комуністична партія" close make this irreducibly complex; modern UA scholarship (Олег Ільницький: "Хвильовий-комуніст — це не Каганович") reads him as a national-communist destroyed by the empire he served, not as a closet separatist. [T3/T5: Читомо — Ільницький]
+- **What «Геть від Москви!» actually demanded.** Хвильовий insisted he sought cultural, not political/economic, separation from Soviet Russia; the regime collapsed that distinction on purpose. The debate over how far he went is live. [T3: uk.wikipedia]
+- **Simplified in popular memory:** he is flattened into a one-line slogan ("Геть від Москви!") that strips the «психологічна Європа» argument and his communism; or sentimentalised purely as a martyr, erasing the partisan commander who fought the УНР Army.
+- **Where Russian disinformation attacks:** the Soviet line branded "хвильовізм" as bourgeois-nationalist and even "fascist" (the 1934 «Більшовик України» tied Скрипник to "українських фашистів Шумського-Хвильового"); contemporary Russian framing minimises or erases the Розстріляне відродження wholesale to deny that Moscow physically destroyed a Ukrainian cultural generation. Both are named here as regime framing, not fact. [T3: uk.wikipedia]
+- **Dontsov's verdict (contested reading):** Дмитро Донцов held that "навіть якщо Хвильовий сам натиснув на спуск револьвера, зброю в його руку вклала Москва" — rhetorically powerful, but a nationalist appropriation of a communist; flagged as interpretation. [T3: uk.wikipedia]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-kulish.yaml` — closest ally; the playwright was in Хвильовий's flat at the suicide and led ВАПЛІТЕ with him.
+  - `curriculum/l2-uk-en/plans/bio/les-kurbas.yaml` — Березіль director, fellow ВАПЛІТЕ-orbit modernist, shot Сандармох 1937.
+  - `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml` — leader of the неокласики who sided with Хвильовий in the discussion.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml` — the survivor-who-broke counter-case of the same generation.
+  - `curriculum/l2-uk-en/plans/bio/yurii-yanovskyi.yaml`, `curriculum/l2-uk-en/plans/bio/maik-yohansen.yaml`, `curriculum/l2-uk-en/plans/bio/heo-shkurupii.yaml`, `curriculum/l2-uk-en/plans/bio/hryhorii-kosynka.yaml` — ВАПЛІТЕ / 1920s Харків peers, most later liquidated.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — the phenomenon his death closes.
+  - `curriculum/l2-uk-en/plans/hist/holodomor-mekhanizm.yaml` — the famine he witnessed weeks before his suicide.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the terror apparatus.
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml` — the українізація / russification fight at the centre of his polemics.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/khvylovy-intro.yaml`, `curriculum/l2-uk-en/plans/lit/khvylovy-i-am-romance.yaml`, `curriculum/l2-uk-en/plans/lit/khvylovy-pamphlets.yaml`, `curriculum/l2-uk-en/plans/lit/khvylovy-woodsnipes.yaml` — the dedicated Хвильовий LIT cluster (intro, «Я (Романтика)», pamphlets, «Вальдшнепи»).
+  - `curriculum/l2-uk-en/plans/lit/vaplite-literary-avant-garde.yaml` — ВАПЛІТЕ as movement.
+  - `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`, `curriculum/l2-uk-en/plans/lit/sandarmokh-tragedy-erasure.yaml` — generational frame and the killing-field where his peers ended.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST module on the **«Слово» building** as a microcosm of the liquidation of the 1920s literary elite.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A focused module on the **Літературна дискусія 1925–1928** as a decolonial debate.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-khvylovyi`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykola Khvylovyi
+- **UA canonical:** Микола Хвильовий (real name Микола Григорович Фітільов)
+- **Aliases to track (`aliases:` YAML field):** Mykola Khvylovy (variant EN); Юлія Уманець; Стефан Кароль; Дядько Микола; surname variants Фітільов / Фітилів.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Николай Хвылёвый; Nikolai/Nikolay Khvylovy; "Khvylevyi" Russified transliteration.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Mykola Khvylovy"** holds 1920s photographic portraits; the subject died in 1933 and the photos predate that, so they are public domain by age in Ukraine and the US (pre-1929 / author-life+70). Confirm on the individual **file page**, not the category. [Commons category: `Mykola Khvylovy`]
+- **Backup candidates:** a photograph of the **будинок «Слово»** in Харків (the site of his suicide and of the mass arrests); a scan of a 1920s «Сині етюди» / «Камо грядеши?» title page.
+- **Context image:** a facsimile page of the suppressed «Україна чи Малоросія?» (first printed 1993) — a strong §2/§3 illustration if a rights-clear scan is found.
+- **If no rights-clear portrait clears review:** fall back to the PD title-page of a 1920s edition.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Khvylovy, Mykola." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\H\KhvylovyMykola.htm — confirms birth/death, real surname Fitilev, suicide, the renounced "Away from Moscow" slogan. Accessed 2026-06-03 (page opened and verified).
+
+**Tier 2 (institutional):**
+- Хвильовий М. *Твори. У 5-ти томах* / заг. ред. Г. Костюка. Нью-Йорк; Балтімор; Торонто: Українське видавництво «Смолоскип» ім. В. Симоненка, 1978–1986 — the foundational diaspora scholarly edition that preserved the suppressed texts.
+- **ГДА СБУ** — Галузевий державний архів СБУ: НКВС/ДПУ УСРР **справа-формуляр С-183** (surveillance dossier opened 1927). Cited as primary documentation, not interpretation.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Микола Хвильовий" and "Самогубство Миколи Хвильового." Dates/works/death cross-checked against IEU. Accessed 2026-06-03.
+
+**Tier 4 (modern scholarly — referenced):**
+- Хвильовий М. *Повне зібрання у 5 томах* / упоряд., ред., прим. Р. Мельникова. 2018–2023 — the first full critical edition (передмови В. Агеєвої, Ю. Безхутрого, В. Зенгви, Р. Мельникова).
+- Олег Ільницький. «Хвильовий-комуніст — це не Каганович» // Читомо (interview/essay on the national-communist reading). [T5 outlet, named author; used for §6 framing only]
+
+**Primary-source documents accessed (in transcription):**
+- The two suicide notes of 13 May 1933 (to fellow writers; to stepdaughter Любов Уманцева) — confiscated 1933, public only after late-1980s rehabilitation; opening lines cited via T3.
+- Stalin's letter «Тов. Кагановичу та іншим членам ПБ ЦК ВКП(б)У», 26 April 1926 (cited via T3; the political signal that opened the campaign).
+- М. Хвильовий, pamphlet «Камо грядеши?» (1925) and the «психологічна Європа» polemic — accessed directly through the literary corpus (`ukrlib-khvylovy`) and verify_quote-confirmed (§4).
+
+**Honest gaps:** the ЕСУ and ЕІУ entries on Хвильовий exist but were not directly opened in this pass — IEU (T1) is the opened encyclopedic anchor, cross-checked against the very detailed Ukrainian Wikipedia. The exact wording of the suicide notes is **transmission-dependent** (originals confiscated) and is presented as such, not as a settled text. The fate of «Вальдшнепи» part 2 and the «Комсомольці» manuscript is genuinely unknown.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his own decolonial argument («психологічна Європа», «Геть від Москви!») is told on its own terms; Moscow appears as the persecuting power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Українська революція / Розстріляне відродження; named "громадянська війна" only inside reported biography, not as my own frame.
+- [x] No uncritical Soviet propaganda terms — "буржуазний націоналізм" / "фашисти" appear only quoted as the regime's own falsification, named as such.
+- [x] No "lost his life" euphemism — the suicide is named plainly and framed as state-driven ("доведення до самогубства"); his murdered peers are "shot," not "perished."
+- [x] Modern UA place names — Харків/Kharkiv, Тростянець (Сумська область), Полтавщина.
+- [x] Holodomor referenced as **Holodomor** (the famine he witnessed in spring 1933), never "Soviet famine."
+- [N/A] Crimea/2014/2022 — not applicable to a figure who died in 1933; the contemporary tie is Russia's ongoing erasure of the Розстріляне відродження (§6), noted there.

--- a/docs/research/bio/mykola-kulish.md
+++ b/docs/research/bio/mykola-kulish.md
@@ -1,0 +1,172 @@
+# Микола Гурович Куліш — Research Dossier
+
+**Slug:** `mykola-kulish`
+**Block:** A (executed by NKVD — Розстріляне відродження)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave C)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+> **⚠ DISAMBIGUATION (load-bearing):** This dossier is the **modernist playwright Микола Гурович Куліш (1892–1937)**, shot at Сандармох. He is **NOT** Пантелеймон Олександрович Куліш (1819–1897), the 19th-century writer/ethnographer/Bible-translator (separate dossier/slug `panteleimon-kulish`). No content from Panteleimon's biography belongs here. The cohort-collapse bug that once duplicated Kulish material is explicitly avoided.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU T1; ЕІУ Герасимова T1; Русанівський & Попович scholarly histories held in the corpus)
+- [x] Oppression mechanism is specific (arrest Dec 1934; «Справа боротьбистів» March 1935; shot 3.11.1937 Сандармох per трійка постанова 9.10.1937)
+- [x] ≥2 primary-source quotes — «Мина Мазайло» (T1-sourced) + «Народний Малахій» (T1-sourced) + «Патетична соната» (labelled)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied (with Panteleimon disambiguation)
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Гурович Куліш. [T1: IEU — "Kulish, Mykola"; T1: ЕІУ — Герасимова, т. 5, с. 466; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** wrote his earliest schoolboy satire in rukopysni журнали; no lasting pen-name. Russified imperial form (forbidden in body text; §8 only): Николай Гурьевич Кулиш.
+- **Born:** 18 December 1892 | село Чаплинка, Дніпровський повіт, Таврійська губернія | now Херсонська область, Україна; the Російська імперія held Таврія. [T1: IEU — "b 18 December 1892 in Chaplynka, Tavriia gubernia"; T3: uk.wikipedia]
+- **Died:** 3 November 1937 (aged 44) | урочище Сандармох, Медвеж'єгорський район, Карельська АРСР, РРФСР | **shot by the NKVD** in the «Соловецький етап» of 1111 prisoners. [T1: IEU — "d 3 November 1937 in Sandarmokh, Karelia"; T3: uk.wikipedia]
+- **Family / education key facts:** Born to a poor family in Чаплинка; a local teacher (Володимир Губенко) and the Чаплинка intelligentsia raised ~100 крб so the gifted boy could study. Studied in Олешки (училище, then прогімназія), where he began writing and met lifelong friend Іван Дніпровський. Mobilised August 1914, made an officer (підпоручик, 224-й піхотний Юхновський полк), wounded/shell-shocked at the front. In the Українська революція he chaired the Олешки рада (1918) and in July 1919 **formed and commanded the Дніпровський селянський полк of the Red Army**, defending Херсон and Миколаїв against Denikin's forces; compiled the first Ukrainian adult primer **«Первинка»**. [T3: uk.wikipedia; T1: Попович — "у роки Громадянської війни командував полком червоних"]
+
+**Source disagreement note (flagged, not smoothed):** A striking contamination — М. Попович's *Нарис історії культури України* prints Kulish's dates as **"(1882 — 1942 рр.)"**, both wrong: the "1942" echoes the **falsified Soviet death-date** notoriously imposed on his collaborator Лесь Курбас (see `les-kurbas`), here bleeding into a respected cultural history. The canonical dates **18 Dec 1892 – 3 Nov 1937** are fixed by IEU (T1), ЕІУ (T1, Герасимова), and uk.wikipedia (T3). This is exactly why the source-tier policy forbids finishing at a single source.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section.
+
+- **What happened:** professional destruction (1933–34) → arrest → show-trial conviction → Solovki isolation → execution. [T3: uk.wikipedia; T1: IEU]
+- **When (specific dates):** denounced at the **Перший всесоюзний з'їзд радянських письменників (17 Aug – 1 Sep 1934)**; **arrested December 1934**; sentenced **March 1935**; trійка death sentence **9 October 1937**; shot **3 November 1937**. [T3: uk.wikipedia]
+- **By whom (specific agency):** the **НКВС УСРР** (arrest and case), the **виїзна Військова колегія Верховного суду СРСР** (1935 sentence), and the **особлива трійка НКВС по Ленінградській області** (the 9 Oct 1937 death sentence executed at Сандармох). [T3: uk.wikipedia]
+- **Document references (quoted, not paraphrased):**
+  - On **19 August 1934** at the writers' congress, **І. Кулик** branded Kulish a dramatist "більшість п'єс якого є відверто націоналістичними і ворожими нам," tying the indictment to Курбас's Березіль. [T3: uk.wikipedia]
+  - The 1935 case is the **«Контрреволюційної боротьбистської організації» справа 1935** (the "Borotbist terrorist centre"), studied by Ю. Шаповал; Kulish was sentenced "до 10 років Соловецьких таборів" alongside **Г. Епік, Є. Плужник, В. Підмогильний, О. Ковінька**. [T1: IEU — "tried as a member of a fictitious 'all-Ukrainian terrorist center of Borotbists'"; T4: Шаповал; T3: uk.wikipedia]
+- **Mechanism specifics:** arrested in **December 1934 on the eve of Іван Дніпровський's funeral** and charged with belonging to a nationalist terrorist organisation linked to the **ОУН**. Held in strict isolation on Соловки. On the **20th anniversary of the October Revolution**, the regime executed the «Соловецький етап» — 1111 prisoners — in the forest at **Сандармох**, Kulish among them, **together with Лесь Курбас, Валер'ян Підмогильний, Григорій Епік**. [T1: IEU; T3: uk.wikipedia]
+- **What survived / what was destroyed:** his **first play «На рыбной ловле»** and his **last play «Такі»** were **seized at his arrest and are lost**. For decades the regime hid the killing behind the myth that the Соловецький етап had been **drowned by barge in the White Sea** — disproved only in **1997**, when the Karelian «Меморіал» located the real execution ground at Сандармох. **Rehabilitated 4 August 1956** "за відсутністю складу злочину." [T3: uk.wikipedia]
+
+## 3. Major works
+
+Roughly **15 plays in 1923–1934**; the founder of modern Ukrainian drama. [T3: uk.wikipedia]
+
+- `1924` — **«97»**, his breakthrough — the 1921–22 Херсонщина famine on stage; staged at the Franko theatre and then with Березіль. [T3: uk.wikipedia]
+- `1925` — **«Комуна в степах»**; the symbolist-tinged comedy **«Отак загинув Гуска»** (from his 1913 «На рыбной ловле»). [T3: uk.wikipedia]
+- `1926` — the expressionist farce **«Хулій Хурина»**; the satire on party careerists **«Зона»**. [T3: uk.wikipedia]
+- `1927` — **«Народний Малахій»** (staged by Курбас 1928) — the tragicomic "Don Quixote" of "негайної реформи людини"; a peak. [T1: Попович; T3: uk.wikipedia]
+- `1929` — **«Мина Мазайло»** — the great comedy of українізація, surname-changing, and linguistic self-colonisation; **«Патетична соната»** — three forces (communist, White-guard, national-patriotic) in 1917–18, fusing experimental drama with the вертеп tradition. [T1: Русанівський; T3: uk.wikipedia]
+- `1933` — **«Маклена Граса»** (rejected by public and authorities alike); **«Прощай, село»** (reissued 1934 as **«Поворот Марка»**); **«Вічний бунт»**. [T3: uk.wikipedia]
+
+**Suppression note:** «На рыбной ловле» and «Такі» were confiscated and lost; most plays were unstageable/unprintable for decades; the first posthumous edition appeared abroad (УВАН, Нью-Йорк, 1955) before any in Soviet Ukraine.
+
+## 4. Primary-source quotes (≥2 required)
+
+> Note on method: Kulish's play texts are **not** in the project's verify_quote literary corpus (a search on author "Микола Куліш" returned matched=false). The lines below are nonetheless **attested inside the corpus through Tier-1 scholarship** (Русанівський's history of the literary language; Попович's cultural history) and Wikiquote; each is sourced, and the verify-status is stated honestly.
+
+**Quote 1 — «Мина Мазайло» (1929), Мокій defending the Ukrainian word.** Quoted in В. Русанівський's *Історія української літературної мови* (corpus `wave9-rusanivsky-ist-lit-movy`):
+
+> «Мокій: — Або кажуть — думка бринить. Це треба так розуміти: тільки-тільки береться, вона ще неясна — бринить… (Рина:) Ти знаєш, як по-українському кажуть: "ночью при звьоздах не спітся"? — … — Зорію. Правда, прекрасно звучить?»
+
+This is the play's beating heart: the beauty and specificity of Ukrainian set against the Russifier's contempt — pedagogically perfect for the українізація theme. [T1-scholarly: Русанівський, in corpus; the play line itself]
+
+**Quote 2 — «Народний Малахій» (1927), the mania of remaking the human being.** М. Попович's *Нарис історії культури України* (corpus `wave7-popovych-narys-kultury`) frames the hero by his own obsession — "негайної реформи людини"; the play's refrain is:
+
+> «Бо головне ж тепер — реформа людини…»
+
+Малахій Стаканчик's doomed "голуба реформа" of humanity is the tragicomic indictment of utopian violence. [T1-scholarly: Попович, in corpus; line via Wikiquote — sourced, not corpus-verified verbatim]
+
+**Quote 3 (labelled, Wikiquote-sourced) — «Патетична соната» (1929):**
+
+> «Українче, спізнай самого себе!» … «Хочемо, щоб нація наша чужих чобіт не чистила. Пора! Вільними стати пора!»
+
+The line that the play could not say openly except through езопівська мова — and that helped get him killed. [T5: uk.wikiquote — sourced; not corpus-verified verbatim]
+
+## 5. Language register
+
+- **Register:** modernist **experimental drama** — expressionism, grotesque, tragicomedy, the вертеп frame, and deliberate **surzhyk/російзм satire** (Kulish puts "проізношеніє," "безобразіє," "етого не может быть" in his characters' mouths *as characterisation* of the Russified petite-bourgeoisie — these are the play's targets, not the author's register). Лавріненко: "Микола Куліш був творцем модерної драми українського революційного відродження." [T1: Русанівський, in corpus]
+- **CEFR readiness for full reading:** **C1–C2** (irony, period politics, code-switching). «Мина Мазайло» is doubly demanding because its very subject is language politics; excerpts can be staged at **B2** with heavy glossing.
+- **Lexicon notes:** 1920s political lexicon (українізація, ВАПЛІТЕ, боротьбист); the *intentional* росіянізми are teaching specimens of what the play satirises — flag, don't "correct" them.
+- **Stylistic features:** montage, choral/musical structure (Патетична соната literally built on Beethoven), the holy-fool protagonist, езопівська мова to evade censorship.
+
+## 6. Contested points
+
+- **The namesake trap (must be guarded).** Popular search and even some catalogues collapse Микола Куліш into **Пантелеймон Куліш**; they are different centuries and different men. Naming discipline is part of the pedagogy here.
+- **«Народний Малахій» — satire of the revolution or of its betrayal?** Read as езопівська мова (the corpus's ULE entry lists it among canonical Aesopian texts), it cuts at utopian violence itself; Soviet critics read hostility, modern critics read tragedy. [T1: ULE, in corpus]
+- **Communist who broke.** Kulish commanded a Red regiment and believed in the Revolution, then — after witnessing the **1933 Holodomor on the Херсонщина** — began to "розчаровуватися у революційних ідеях." The arc from Red officer to executed "nationalist" is the unsmoothed complexity. [T3: uk.wikipedia]
+- **Where Russian/Soviet disinformation attacks:** the 1934 label "буржуазно-націоналістичний драматург" and the fabricated "Borotbist terrorist centre"; and the decades-long **White-Sea-drowning myth** that hid the Сандармох executions until 1997. Both named here as regime falsification. [T3: uk.wikipedia]
+- **The date contamination (§1):** the "1882–1942" misprint shows how the falsified-Kurbas chronology seeped even into scholarship.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/les-kurbas.yaml` — the Березіль director who staged «Народний Малахій», «Мина Мазайло», «Маклена Граса» and died beside him at Сандармох; the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/mykola-khvylovyi.yaml` — ВАПЛІТЕ co-leader; Kulish was in his flat at the 1933 suicide and succeeded him as ВАПЛІТЕ president.
+  - `curriculum/l2-uk-en/plans/bio/valerian-pidmohylnyi.yaml`, `curriculum/l2-uk-en/plans/bio/hryhorii-epik.yaml`, `curriculum/l2-uk-en/plans/bio/yevhen-pluzhnyk.yaml` — co-defendants in the 1935 «боротьбисти» case; Підмогильний and Епік were shot with him at Сандармох.
+  - `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml`, `curriculum/l2-uk-en/plans/bio/yurii-yanovskyi.yaml`, `curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml`, `curriculum/l2-uk-en/plans/bio/maik-yohansen.yaml`, `curriculum/l2-uk-en/plans/bio/ostap-vyshnia.yaml` — the Харків literary circle of the 1920s.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — the generation he belongs to.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the trійка/Військова колегія machinery that killed him.
+  - `curriculum/l2-uk-en/plans/hist/holodomor-mekhanizm.yaml` — the 1933 famine he witnessed on the Херсонщина.
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml` — the українізація politics dramatised in «Мина Мазайло».
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/vaplite-literary-avant-garde.yaml` — ВАПЛІТЕ, which he led.
+  - `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`, `curriculum/l2-uk-en/plans/lit/sandarmokh-tragedy-erasure.yaml` — the generational frame and the killing-ground where he died.
+  - *(Deliberately NOT linked: `lit/kulish-literary-legacy.yaml` — that module is **Panteleimon** Kulish, a different figure.)*
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated LIT cluster on **«Мина Мазайло»** and **«Народний Малахій»** as set-text drama (none exists yet).
+  - A theatre-history module on **«Березіль»** linking Kulish ↔ Kurbas.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A focused module on the **«Патетична соната»** as a censored masterpiece (banned after a brief Moscow run).
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-kulish`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykola Kulish
+- **UA canonical (with patronymic):** Микола Гурович Куліш
+- **Aliases to track (`aliases:` YAML field):** Mykola Kulish (playwright); Mykola Hurovych Kulish.
+- **CRITICAL disambiguation (NOT aliases — different person):** Пантелеймон Куліш / Panteleimon Kulish (1819–1897) is a separate figure (slug `panteleimon-kulish`). Never merge.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Николай Гурьевич Кулиш; "Nikolai Kulish."
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Mykola Kulish"** (the playwright) holds 1920s–30s portraits; he died in 1937, so pre-1937 photographs are public domain by age in Ukraine and the US. Confirm on the individual **file page**, and make sure the file is the **playwright**, not Panteleimon. [Commons category: `Mykola Kulish`]
+- **Backup candidates:** a Березіль production still of «Народний Малахій» or «Мина Мазайло» (1928–29); the Херсонський музично-драматичний театр ім. М. Куліша façade.
+- **Context image:** the **Сандармох** memorial (the execution ground), or a 1934 congress photograph — strong §2 illustrations if rights-clear.
+- **If no rights-clear portrait clears review:** fall back to a PD title-page of a 1920s «97» or «Мина Мазайло» edition.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Kulish, Mykola." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\U\KulishMykola.htm — birth/death, arrest, Borotbist show-trial, Solovki, Sandarmokh. Accessed 2026-06-03 (opened and verified).
+- Герасимова Г. П. "Куліш Микола Гурович." *Енциклопедія історії України*, т. 5 (Кон–Кю). Київ: Наукова думка, 2009. С. 466. (cited via the article's джерела; ЕІУ т. 5).
+- Русанівський В. *Історія української літературної мови* — held in the corpus (`wave9-rusanivsky-ist-lit-movy`); source of the «Мина Мазайло» Мокій passage and the Лавріненко characterisation.
+- Попович М. *Нарис історії культури України* — held in the corpus (`wave7-popovych-narys-kultury`); the «Народний Малахій» / «реформа людини» framing (and the flagged 1882–1942 date error).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Куліш Микола Гурович." Dates/works/arrest/execution cross-checked against IEU and ЕІУ. Accessed 2026-06-03.
+
+**Tier 4 (modern scholarly — referenced):**
+- Кузякіна Н. *Микола Куліш* — the foundational monograph (cited via T3 links).
+- Шаповал Ю. «"Контрреволюційної боротьбистської організації" справа 1935» — on the case that convicted him.
+
+**Tier 5 (general web — used only with corroboration):**
+- uk.wikiquote.org, "Микола Куліш" — source of the «Патетична соната» lines (labelled; not corpus-verified verbatim).
+
+**Primary-source documents accessed (in transcription / via scholarship):**
+- The **«Контрреволюційної боротьбистської організації» справа 1935** (Військова колегія Верховного суду; трійка постанова 9 Oct 1937) — cited via Шаповал / IEU.
+- The Карельський «Меморіал» 1997 identification of the Сандармох execution site (refuting the White-Sea myth).
+
+**Honest gaps:** Kulish's plays are not in the verify_quote corpus, so §4 rests on Tier-1 scholarship quoting the lines plus Wikiquote, all labelled. The ЕІУ entry is cited from the article apparatus, not opened page-by-page this pass (IEU is the opened encyclopedic anchor). The texts of «На рыбной ловле» and «Такі» are **lost** (confiscated 1934).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his drama and language-politics are told on Ukrainian terms; the empire appears as executioner.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "Українська революція" used; "Громадянська війна" appears only inside reported biography/Попович, not as my frame.
+- [x] No uncritical Soviet propaganda terms — "буржуазно-націоналістичний" appears only quoted as the regime's own label, named as falsification.
+- [x] No "lost his life" euphemism — "shot by the NKVD at Сандармох" stated plainly.
+- [x] Modern UA place names — Чаплинка/Олешки (Херсонська область), Харків/Kharkiv; Сандармох named as the execution site.
+- [x] Holodomor referenced as **Holodomor** (the 1933 famine he witnessed), never "Soviet famine."
+- [N/A] Crimea/2014/2022 — not applicable to a figure executed in 1937; the live tie is Russia's erasure of Сандармох and the Розстріляне відродження (§6).

--- a/docs/research/bio/vasyl-stus.md
+++ b/docs/research/bio/vasyl-stus.md
@@ -1,0 +1,159 @@
+# Василь Семенович Стус — Research Dossier
+
+**Slug:** `vasyl-stus`
+**Block:** A (killed in the GULAG — шістдесятник / dissident; Ukrainian Helsinki Group)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave C)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU T1; НАН Інститут літератури 4-vol edition T1/T2; Кіпіані KGB-archive book; Хейфец co-prisoner memoir)
+- [x] Oppression mechanism is specific (arrests 12.01.1972 & May 1980; camps named: Mordovia → Magadan exile → Perm-36 ВС-389/36-1; died 4.09.1985)
+- [x] ≥2 primary-source quotes — the corpus-verified programmatic poem (conf 1.0) + his recorded statement on the verdict
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+> **⚠ GEOGRAPHY CORRECTION (load-bearing):** Stus was **NOT held in Siberia.** First term (1972–77): **Mordovian camps** (Дубравлаг), then **exile in Magadan oblast / Kolyma** (gold mines, 1977–79). Second term (1980–85): **camp ВС-389/36-1 — "Perm-36" — at Кучино in the Урал (Perm krai)**, where he died on **4 September 1985**. Reburied in **Kyiv, 19 November 1989**. Any "Siberia" framing is an error.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Василь Семенович Стус. [T1: IEU — "Stus, Vasyl"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** псевдо **Василь Петрик**. Russified imperial form (forbidden in body text; §8 only): Василий Семёнович Стус, Vasili Stus.
+- **Born:** **6 January 1938** | село Рахнівка, Гайсинський район, Вінницька область | Українська РСР, СРСР. [T3: uk.wikipedia — "6 січня 1938"; T1: IEU gives **8 January 1938** — a date divergence, flagged below]
+- **Died:** 4 September 1985 (night of 3–4 Sept, aged 47) | **табір ВС-389/36-1 ("Перм-36"), біля села Кучино, Чусовський район, Пермський край, РРФСР** | killed by the GULAG regime during an indefinite dry hunger-strike (official cause "зупинка серця"; co-prisoners allege deliberate killing — see §2). [T1: IEU — "d 4 September 1985 in… camp no. 389/36-1, Perm oblast"; T3: uk.wikipedia]
+- **Family / education key facts:** Fourth child of peasants Семен Дем'янович and Ірина Яківна; in 1939–40 the family moved to **Сталіно (now Донецьк)** to escape forced collectivisation. Graduated the історико-філологічний факультет of the **Сталінський (Донецький) педагогічний інститут** (1959, honours); two years' army service **on the Урал**. Entered the aspirantura of the **Інститут літератури ім. Т. Шевченка АН УРСР** (Kyiv); expelled after his 1965 protest. Married **Валентина Попелюх** (1965); son **Дмитро Стус** (b. 1966), the scholar of his father's work. [T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** Stus's **birth date** is given as **6 January 1938** by Ukrainian sources (and is the celebrated date) but as **8 January 1938** by IEU — a two-day divergence, not two events. The **cause of death** is genuinely contested (official "cardiac arrest" vs hypothermia vs deliberate killing by carcer bunk-blow per Василь Овсієнко) and is presented as open in §2/§6.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section.
+
+- **What happened:** dissident protest → expulsion → two arrests → two camp terms (Mordovia, then Perm-36) with exile between → death on hunger-strike in the carcer. [T1: IEU; T3: uk.wikipedia]
+- **When (specific dates):** protest **4 September 1965**; expelled from the aspirantura 1965; **first arrest 12 January 1972** → 5 years camp + 3 years exile (Sept 1972); **second arrest May 1980** → 10 years hard labour + 5 years exile (Sept 1980); **died 4 September 1985**. [T3: uk.wikipedia]
+- **By whom (specific agency):** the **КДБ УРСР** (surveillance from 1965, both cases), the **Київський обласний суд** (1972 and 1980 sentences), and the **GULAG camp administration** of Дубравлаг (Mordovia) and ВС-389/36 (Perm). [T3: uk.wikipedia]
+- **Document references (quoted, not paraphrased):**
+  - On **4 September 1965**, at the Kyiv premiere of Параджанов's «Тіні забутих предків» in the «Україна» cinema, Stus — with **Іван Дзюба, В'ячеслав Чорновіл, Юрій Бадзьо** — called on the audience to condemn the arrests of the Ukrainian intelligentsia: "the first public political protest against the mass repressions in the postwar USSR." [T3: uk.wikipedia]
+  - The 1972 case rested on a КДБ-commissioned "review" of his samvydav collections by **Арсен Каспрук**, who branded «Зимові дерева» the poetics of "декадансу, ідейного занепаду" and "шкідлива всім своїм ідейним спрямуванням." Stus answered (see §4 Quote 2) that "на руках цього доктора філології — моя кров." [T3: uk.wikipedia]
+- **Mechanism specifics:** the **first term (1972–77)** was served in the **Mordovian camps**; most camp verse was confiscated and destroyed, a little reaching freedom in letters to his wife. Then **exile (1977–79) in селище Імені Матросова, Magadan oblast**, working the **gold mines of Kolyma**. Returning to Kyiv in autumn 1979 he joined the **Українська Гельсінська група**; **rearrested in May 1980**, declared an "особливо небезпечний рецидивіст," and tried with the assigned lawyer **Віктор Медведчук, who conceded his client's guilt** — a notorious betrayal later condemned by legal analysis. From November 1980 he was held in **camp ВС-389/36-1 (Perm-36) at Кучино**; family visits were forbidden after spring 1981. The guards destroyed the ~300-poem collection **«Птах душі»**. On **28 August 1985** he was thrown into the карцер for leaning his elbow on the bunk; he declared an **indefinite dry hunger-strike** and **died in the night of 4 September 1985**. [T3: uk.wikipedia; T1: IEU]
+- **What survived / what was destroyed:** «Птах душі» (~300 poems) and much camp verse were **destroyed**; «Палімпсести» survived only because it circulated as several different "списки" smuggled out — a deliberate echo of the chronicle/palimpsest tradition. Stus was **reburied in Kyiv on 19 November 1989** (Байкове кладовище) beside camp-mates **Юрій Литвин** and **Олекса Тихий**; over **30,000 mourners** attended. **Posthumously rehabilitated 1990**; Shevchenko Prize 1991; **Hero of Ukraine 2005**. [T1: IEU; T3: uk.wikipedia]
+
+## 3. Major works
+
+- `1965` — **«Круговерть»** — first collection, rejected by the publisher. [T3: uk.wikipedia]
+- `1970` — **«Зимові дерева»** — circulated in самвидав and printed abroad (Brussels/London). [T3: uk.wikipedia]
+- `1971` — **«Веселий цвинтар»** — the satirically bleak collection the КДБ used against him. [T3: uk.wikipedia]
+- `1972` — **«Час творчості / Dichtenszeit»** — written in the КДБ remand prison; a dated prison "diary in verse." [T3: uk.wikipedia]
+- `1971–1977 (pub. 1986)` — **«Палімпсести»** — his masterwork, existing in several smuggled redactions; contains the prayer-meditations. [T3: uk.wikipedia]
+- `translations` — Goethe, **Rilke** («Сонети до Орфея», «Дуїнські елегії»), Celan, Lorca, Rimbaud, Kipling, Ungaretti — a major contribution; his early ~100 Goethe/Rilke translations were **confiscated and lost**. [T3: uk.wikipedia]
+- `essays` — **«Феномен доби»** (on Tychyna's "poetic death," 1970–71); **«Зникоме розцвітання»** (on Свідзінський). [T3: uk.wikipedia]
+- `posthumous` — НАН Інститут літератури **Твори у 4 т., 6 кн.** (Львів, 1994–99, ред. Д. Стус, М. Коцюбинська); **«Дорога болю»** (1990, Shevchenko Prize). [T3: uk.wikipedia]
+
+**Suppression note:** his work was banned and partly destroyed in his lifetime; «Палімпсести» appeared only in 1986; the scholarly Twory came after independence.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — the programmatic poem, his life-credo.** `verify_quote` against the corpus (`ukrlib-stus`) returned **matched=true, confidence 1.0** for both the opening and the «Народе мій» turn (they are one poem):
+
+> «Як добре те, що смерті не боюсь я / і не питаю, чи тяжкий мій хрест… / що жив-любив і не набрався скверни, / ненависті, прокльону, каяття. / Народе мій, до тебе я ще верну…»
+
+The whole ethic of Stus in nine lines: fearlessness before death, refusal of hatred and recantation, and the vow of return to his people — pedagogically the single best entry point. [Primary: В. Стус, «Як добре те, що смерті не боюсь я»; verify_quote conf. 1.0, work `ukrlib-stus`]
+
+**Quote 2 — his recorded answer to the verdict (recorded statement, labelled).** On the КДБ "reviewer" Каспрук and the investigators:
+
+> «На руках цього доктора філології — моя кров, як і на руках слідчих Логінова, Мезері, Пархоменка, судді, прокурора і адвоката-прокурора, накиненого силоміць… Вони такі самі душогуби, як слідчі і судді.»
+
+This lets learners hear Stus naming the *intellectual* complicity of the regime's literary servants — central to «Феномен доби» and his whole moral stance. [T3: uk.wikipedia — his commentary on the 1972 verdict; recorded statement, not corpus-verified verbatim]
+
+## 5. Language register
+
+- **Register:** high modernist / **hermetic** lyric — fusing Ukrainian folk stylisation with Goethe, Rilke and the existentialists (Camus). Prayer-meditation forms appear after the first arrest; verlibre dominates the lost late work.
+- **CEFR readiness for full reading:** **C1–C2** — the neologisms and archaisms are demanding; a few accessible programmatic poems («Як добре те…», «Господи, гніву пречистого…») can be staged at **B2** with glossing.
+- **Lexicon notes:** authorial neologisms (**всевікна, всенезустріч, стобагаття, стогори, сторозтриклятий, стосиній**); dialect/archaic lexis (антоновий огонь, комонь = кінь, парсуна, щовб, чезнути); biblical phraseology (Глас Господній; край Господніх Брам). VESUM will reject the deliberate новотвори — these are the poetics, not errors, and must be glossed, never "corrected."
+- **Stylistic features:** "розривні" lines with enjambment, dense assonance/alliteration, the palimpsest principle (multiple co-existing redactions) — itself a teaching point about samvydav transmission.
+
+## 6. Contested points
+
+- **Cause of death — genuinely open.** Official "cardiac arrest"; widely held hypothermia/exhaustion on dry hunger-strike; co-prisoner **Василь Овсієнко** raises possible deliberate killing by carcer bunk-blow. The firm core (died 4 Sept 1985 in the Perm-36 carcer, on hunger-strike, killed by the regime) stands; the exact mechanism is contested. [T3: uk.wikipedia; T2/T5: Хейфец; Плющ «Вбивство поета В. Стуса»]
+- **The Medvedchuk question.** That his court-appointed lawyer **Віктор Медведчук** conceded guilt is documented; the debate is over whether anything could have changed the (party-decided) outcome — Medvedchuk's self-exculpation is itself contested by 2016 legal analysis. [T3: uk.wikipedia]
+- **Simplified in memory:** reduced to "martyr" or "Nobel nominee 1985," losing the hermetic poet and translator; or claimed for one political camp when his stance was moral before it was factional.
+- **Where Russian aggression continues:** occupying forces **destroyed the Stus memorial plaque at Donetsk University in 2015** and his sister's home near Donetsk airport in 2014; Donetsk National University, renamed for Stus, relocated to Vinnytsia. The erasure is ongoing, not historical. [T3: uk.wikipedia]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml`, `curriculum/l2-uk-en/plans/bio/yevhen-sverstiuk.yaml` — шістдесятники co-protesters and friends (Dziuba stood beside him in 1965).
+  - `curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml` — the шістдесятник generation's earlier martyr.
+  - `curriculum/l2-uk-en/plans/bio/alla-horska.yaml` — Клуб творчої молоді circle; murdered 1970.
+  - `curriculum/l2-uk-en/plans/bio/ihor-kalynets.yaml`, `curriculum/l2-uk-en/plans/bio/iryna-kalynets.yaml`, `curriculum/l2-uk-en/plans/bio/mykola-rudenko.yaml`, `curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml` — Ukrainian Helsinki Group co-members.
+  - `curriculum/l2-uk-en/plans/bio/yurii-lytvyn.yaml`, `curriculum/l2-uk-en/plans/bio/oleksa-tykhyi.yaml` — died in the same ВС-389/36 camp and were reburied with him in Kyiv (1989).
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml`, `curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml` — his two movements.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml`, `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml`, `curriculum/l2-uk-en/plans/hist/rukh.yaml` — repression machinery, language politics, and the movement that won his reburial.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/stus-palimpsests.yaml`, `curriculum/l2-uk-en/plans/lit/stus-letters-to-son.yaml`, `curriculum/l2-uk-en/plans/lit/stus-moral-imperative.yaml`, `curriculum/l2-uk-en/plans/lit/stus-vertical-of-spirit.yaml` — the dedicated Stus LIT cluster.
+  - `curriculum/l2-uk-en/plans/lit/kyiv-school-of-poetry.yaml`, `curriculum/l2-uk-en/plans/lit/shestydesiatnyky-as-phenomenon.yaml`, `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml` — poetic context and the samvydav system that carried «Палімпсести».
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A module on **Perm-36 / the Dissident memorial** as a site of memory.
+  - A translation-studies module on **Stus as translator of Rilke/Goethe**.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A node pairing Stus with **Юрій Литвин** and **Олекса Тихий** (the 1989 triple reburial).
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-stus`
+- **EN canonical (BGN/PCGN-style project spelling):** Vasyl Stus
+- **UA canonical (with patronymic):** Василь Семенович Стус
+- **Aliases to track (`aliases:` YAML field):** Vasyl Stus; псевдо Василь Петрик.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Василий Семёнович Стус; Vasili/Vasily Stus; "Wassyl Stus" mis-transliteration. **Do not write "Siberia" for his imprisonment** (Mordovia / Magadan-Kolyma / Perm-Урал).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **"Vasyl Stus"** holds 1960s–80s photographs and the КДБ case-file mugshots (now declassified via the СБУ archive / Кіпіані's «Справа Василя Стуса»); check each **file page** for license (some are СБУ-archive public-domain releases). [Commons category: `Vasyl Stus`]
+- **Backup candidates:** the 1989 reburial procession (Байкове кладовище); the Perm-36 camp (now a museum); his Donetsk University barelief (destroyed 2015 — a powerful "erasure" image via archival photo).
+- **Context image:** a samvydav page of «Палімпсести», or a КДБ Справа cover from the Кіпіані collection — strong §2 illustration if rights-clear.
+- **If no rights-clear portrait clears review:** fall back to a PD «Зимові дерева» (Brussels, 1970) cover.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Stus, Vasyl." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\S\T\StusVasyl.htm — birth/death, Perm-36 (camp 389/36-1), Helsinki Group, reburial. Accessed 2026-06-03 (opened and verified).
+- Стус В. *Твори: у 4 т., 6 кн.* / НАН України, Інститут літератури ім. Т. Г. Шевченка; ред. Д. Стус, М. Коцюбинська. Львів: Просвіта, 1994–1999 — the institutional scholarly edition.
+
+**Tier 2 (institutional / primary-adjacent):**
+- Хейфец М. *Українські силюети.* Сучасність, 1984 — co-prisoner memoir of Stus.
+- Плющ Л. «Вбивство поета В. Стуса» // *В. Стус в житті, творчості, спогадах…* Балтимор; Торонто: Смолоскип, 1987.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Стус Василь Семенович." Dates/camps/death/reburial cross-checked against IEU. Accessed 2026-06-03.
+
+**Tier 4 (modern scholarly — referenced):**
+- Дмитро Стус. *Василь Стус: життя як творчість.* Київ: Факт, 2004.
+- Вахтанг Кіпіані. *Справа Василя Стуса. Збірка документів з архіву колишнього КДБ УРСР.* Vivat, 2019 — the КДБ case files.
+
+**Primary-source documents accessed (in transcription / via scholarship):**
+- The 1972 and 1980 Київський обласний суд sentences and the КДБ "review" by А. Каспрук (via T3/Кіпіані).
+- В. Стус, «Як добре те, що смерті не боюсь я» — accessed directly via the literary corpus (`ukrlib-stus`), verify_quote-confirmed conf. 1.0 (§4).
+
+**Honest gaps:** IEU is the opened encyclopedic anchor; the ЕСУ/ЕІУ entries exist but were not opened this pass. The **cause of death** is left open (three competing accounts). Quote 2 is a recorded statement via T3, not a corpus-verified literary text. Stus's lost works («Птах душі», early Goethe/Rilke translations) are gone — noted, not reconstructed.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Stus's defence of Ukrainian culture and his moral resistance are central; the empire appears as jailer.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "шістдесятники," "Українська Гельсінська група," "самвидав," "GULAG" used precisely.
+- [x] No uncritical Soviet propaganda terms — "антирадянська агітація," "особливо небезпечний рецидивіст" appear only quoted as the regime's own charges, named as such.
+- [x] No "lost his life" euphemism — "killed by the GULAG regime" / "died on hunger-strike in the carcer" stated plainly.
+- [x] Modern UA place names — Рахнівка (Вінницька область), Донецьк (not "Сталіно" except as the historical name), Київ/Kyiv; camps named precisely (Mordovia / Magadan-Kolyma / Perm-36), **never "Siberia."**
+- [N/A] Holodomor — not directly his biography; his family fled collectivisation to Донецьк (noted), but the famine is not forced into the text.
+- [x] Russian aggression framing — the 2014/2015 destruction of his Donetsk memorial and his sister's home, and Donetsk University's displacement, are named as Russian aggression (§6).

--- a/docs/research/bio/vasyl-symonenko.md
+++ b/docs/research/bio/vasyl-symonenko.md
@@ -1,0 +1,166 @@
+# Василь Андрійович Симоненко — Research Dossier
+
+**Slug:** `vasyl-symonenko`
+**Block:** A (persecuted шістдесятник; died at 28 under surveillance after a militia beating)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave C)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ Герасимова T1; Шевченківська енциклопедія T1; ЕУ T1; Тарнашинська Інститут-літератури нарис T2; Shankovsky/U. Alberta T2)
+- [x] Oppression mechanism is specific (Bykivnia memorandum 1962; militia beating summer 1962; censorship distortions; posthumous erasure-by-canonisation)
+- [x] ≥2 primary-source quotes — THREE corpus-verified poems (conf 1.0 / 0.81)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+> **⚠ ANTI-FABRICATION (load-bearing):** There is **NO work titled «Казки для сина Лесика».** Symonenko wrote **three** verse fairy tales: **«Цар Плаксій і Лоскотон», «Подорож у країну Навпаки», «Казка про Дурила».** (His son was **Олесь** — the spurious title likely garbles "Олесь"/"Лесик." Do not invent it.) Verified below against uk.wikipedia + ЕІУ.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Василь Андрійович Симоненко. [T1: ЕІУ — Герасимова, т. 9, с. 559; T1: Шевченківська енциклопедія, т. 5, с. 759–760; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none persistent. Russified imperial form (forbidden in body text; §8 only): Василий Андреевич Симоненко.
+- **Born:** 8 January 1935 | село **Біївці**, Лубенський район, тоді Харківська (нині **Полтавська**) область | над річкою Удай, на Лубенщині. [T3: uk.wikipedia — "с. Біївці… на Лубенщині Полтавської області"; T1: ЕІУ]
+- **Died:** night of **13–14 December 1963** (aged 28) | Черкаси, Українська РСР | **kidney cancer (рак нирок)** — following the 1962 militia beating (causation contested, see §2/§6). [T3: uk.wikipedia — "Помер у ніч проти 14 грудня 1963 року в 28-річному віці"]
+- **Family / education key facts:** raised in Біївці; finished school in Тарандинці with a gold medal (1952), then the **journalism faculty of Київський університет** (grad. 1957) — classmates Юрій Мушкетик, Микола Сом, Валерій Шевчук, Борис Олійник. Worked on the Черкаси papers «Черкаська правда», «Молодь Черкащини», «Робітнича газета». Wife Люся; son **Олесь**. [T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** the **death date** is given as **13 December** in the article lead but the body specifies the **night against 14 December 1963** — i.e. he died overnight 13→14 Dec; both refer to one event. His birthplace's **oblast** is "тодішня Харківська" in 1935 administrative terms but is **Полтавська область (Лубенщина)** today — use the modern form. He is consistently described as **28** at death ("прожив неповних 29 років").
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Symonenko was never formally tried or imprisoned; the mechanism was **surveillance + physical violence + censorship + posthumous erasure-by-distortion** — and a death at 28 whose link to the beating the regime made impossible to prove.
+
+- **What happened:** placed under КДБ surveillance after a civic act of memory; beaten by militia; his poems censored or suppressed; after death, canonised in distorted "loyal" form while his samvydav was silenced. [T3: uk.wikipedia; T1: ЕУ]
+- **When (specific dates):** Bykivnia memorandum **1962**; militia beating **summer 1962**; death **December 1963**; the 1965 Shevchenko-Prize nomination blocked; samvydav published abroad **1965**. [T3: uk.wikipedia]
+- **By whom (specific agency):** the **КДБ УРСР** (surveillance), the **transport міліція** at station «Ім. Тараса Шевченка» (Сміла) (the beating), Soviet **censorship/Головліт** (the textual distortions), and party critics (М. Шамота) in the posthumous revision. [T3: uk.wikipedia]
+- **Document references (quoted, not paraphrased):**
+  - In **1962**, with **Алла Горська** and **Лесь Танюк**, Symonenko located NKVD mass-execution sites at the Лук'янівське and Васильківське cemeteries and at **Биківня**, and the group sent a **Меморандум to the Kyiv city council** demanding the sites be opened and turned into "національні місця скорботи та пам'яті." Танюк's diary records the group seeing children at Биківня using a **skull with a bullet-hole as a football**. "Такого зухвальства система простити не змогла — за Симоненком встановлюється нагляд." [T3: uk.wikipedia]
+  - The censorship is documented at the level of single lines: the printed «Любове грізна! Світла моя муко! / Комуністична радосте моя!» was the censor's rewrite of Symonenko's actual «**Любове світла! Чорна моя муко! / І радосте безрадісна моя!**» [T3: uk.wikipedia]
+- **Mechanism specifics:** in **summer 1962** the militia at the railway station beat him brutally; "different unconfirmed versions" hold it was a КДБ provocation. From spring 1963 his health collapsed (kidneys); he was diagnosed with kidney cancer and died in December 1963 at 28. His samvydav verse — already circulating and "поклали початок українському рухові опору 1960–1970-х років" — was published abroad in **«Сучасність»** (1965) and the collection **«Берег чекань»** (1965/1973) together with his diary **«Окрайці думок»**. [T3: uk.wikipedia]
+- **What survived / what was destroyed:** Soviet criticism first tried to neutralise him by **total silence**, then (after 1972, via М. Шамота) by **revising him as incompatible with "партійність"** — while the censored, "safe" poems were canonised. The fate of much of his literary estate is "невідома." His true voice survived through **samvydav and the diaspora** (the Смолоскип publishing house took his name). Shevchenko Prize awarded **only in 1995**, 30 years late. [T3: uk.wikipedia]
+
+## 3. Major works
+
+- `1962` — **«Тиша і грім»** — the only poetry collection published in his lifetime. [T3: uk.wikipedia]
+- `1963` — verse fairy tale **«Цар Плаксій та Лоскотон»** — the only fairy tale printed while he lived. [T3: uk.wikipedia]
+- `verse fairy tales (the real three)` — **«Цар Плаксій і Лоскотон», «Подорож у країну Навпаки» (pub. 1964), «Казка про Дурила»** — children's verse with sharp political allegory. **(NOT «Казки для сина Лесика» — that title does not exist.)** [T3: uk.wikipedia — Твори / Віршовані казки]
+- `1964 (posthumous)` — **«Земне тяжіння»** (поезії). [T3: uk.wikipedia]
+- `1965 (posthumous)` — **«Вино з троянд»** (новели); abroad: **«Берег чекань»** + diary **«Окрайці думок»**. [T3: uk.wikipedia]
+- `1981 (posthumous)` — **«Лебеді материнства»** (книга). [T3: uk.wikipedia]
+- `signature samvydav poems` — **«Задивляюсь у твої зіниці», «Лебеді материнства», «Ти знаєш, що ти — людина?», «Гей, нові Колумби й Магеллани», «Курдському братові», «Некролог кукурудзяному качанові», «Брама»** — the civic/anti-imperial core. [T3: uk.wikipedia]
+
+**Suppression note:** most of his important verse was unprintable in the USSR and circulated as samvydav; the printed canon was the censored remainder.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — «Лебеді материнства» (the homeland one cannot choose).** `verify_quote` against the corpus (`ukrlib-symonenko`) returned **matched=true, confidence 1.0**:
+
+> «Можна все на світі вибирати, сину, / Вибрати не можна тільки Батьківщину.»
+
+The most quoted couplet in modern Ukrainian poetry — a lullaby that became a national credo. Accessible enough for B1 learners. [Primary: В. Симоненко, «Лебеді материнства»; verify_quote conf. 1.0, work `ukrlib-symonenko`]
+
+**Quote 2 — «Гей, нові Колумби й Магеллани» (the people that cannot be cancelled).** `verify_quote` returned **matched=true, confidence 1.0**:
+
+> «Народ мій є! Народ мій завжди буде! / Ніхто не перекреслить мій народ!»
+
+The anti-imperial defiance the regime feared — a direct answer to erasure. [Primary: В. Симоненко; verify_quote conf. 1.0, work `ukrlib-symonenko`]
+
+**Quote 3 — «Задивляюсь у твої зіниці» (love of the homeland).** `verify_quote` returned **matched=true, confidence 1.0** (opening) / 0.81 (next line):
+
+> «Задивляюсь у твої зіниці / голубі й тривожні, ніби рань…»
+
+The opening of his great address to Ukraine — pedagogically gentle, lexically B1. [Primary: В. Симоненко, «Задивляюсь у твої зіниці»; verify_quote conf. 1.0/0.81, work `ukrlib-symonenko`]
+
+## 5. Language register
+
+- **Register:** civic-lyric, **Shevchenko-rooted** and song-like — Symonenko himself said "Є в мені щось від діда Тараса і прадіда Сковороди." Many poems became folk-style songs; the diction is direct, oral, emotionally plain.
+- **CEFR readiness for full reading:** the **most accessible** of the Wave-C figures — «Лебеді материнства», «Ти знаєш, що ти — людина?» sit at **B1** (already school-program texts); the verse fairy tales reach **A2–B1**; the sharper satire and the diary are **B2**.
+- **Lexicon notes:** mostly common modern Ukrainian; civic abstractions (Батьківщина, народ, гідність) and a few folk/diminutive forms; useful for teaching emotional register and rhetoric of address ("сину," "брате").
+- **Stylistic features:** apostrophe/address, anaphora, the rhetorical exclamation ("Народ мій є!"), the lullaby-and-manifesto fusion; the censorship case (§2) is itself a teachable contrast of two textual variants.
+
+## 6. Contested points
+
+- **The non-existent fairy tale (anti-fabrication).** Catalogues and AI sometimes invent «Казки для сина Лесика»; the real titles are «Цар Плаксій і Лоскотон», «Подорож у країну Навпаки», «Казка про Дурила». His son was **Олесь**. Naming discipline matters.
+- **Cause of death — contested.** Official: kidney cancer. Widely believed: the **summer-1962 militia beating** precipitated the fatal illness, possibly a КДБ provocation — **unproven**. The firm core (beaten 1962; under surveillance; dead at 28 in 1963) stands; the **causal link beating→death is not documented**, and should not be asserted as fact. [T3: uk.wikipedia; T5: «Полтавщина» interview]
+- **Myth vs man.** Іван Андрусяк's «Міф про Василя Симоненка» warns against the sentimental/heroic flattening; modern scholarship reads a more complex Soviet-formed poet who broke toward dissent.
+- **Where Russian great-power chauvinism is the target:** «Курдському братові» is an anti-imperial allegory (the Kurd as stand-in for the colonised Ukrainian); contemporary Russian narrative erases exactly this reading. Named here as the poem's design.
+- **Erasure-by-canonisation:** the Soviet move to print the "loyal" Symonenko while silencing the samvydav is a distinct repression mode — control the dead poet's image.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/alla-horska.yaml` — with him and Танюк at the 1962 Bykivnia discovery; murdered 1970.
+  - `curriculum/l2-uk-en/plans/bio/lina-kostenko.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-drach.yaml`, `curriculum/l2-uk-en/plans/bio/mykola-vinhranovskyi.yaml` — the Клуб творчої молоді poets of his generation.
+  - `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml`, `curriculum/l2-uk-en/plans/bio/yevhen-sverstiuk.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml` — the samvydav critics who defended his true legacy.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml` — who called him "найбільшого шістдесятника із шістдесятників."
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml` — his generation/movement.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the mass graves (Bykivnia) he forced into the open.
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml` — the language/national question central to his civic verse.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/symonenko-knights.yaml`, `curriculum/l2-uk-en/plans/lit/symonenko-truth.yaml` — the dedicated Symonenko LIT pair.
+  - `curriculum/l2-uk-en/plans/lit/shestydesiatnyky-as-phenomenon.yaml`, `curriculum/l2-uk-en/plans/lit/kyiv-school-of-poetry.yaml`, `curriculum/l2-uk-en/plans/lit/samvydav-underground-publishing.yaml` — generational frame and the samvydav system that carried him.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST module on **Биківня** as a site of memory (Symonenko's memorandum as origin point).
+  - A children's-literature module on his **verse fairy tales** (the real three).
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A node on the **censorship-variants** of his poems as a textual-criticism teaching case.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-symonenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Vasyl Symonenko
+- **UA canonical (with patronymic):** Василь Андрійович Симоненко
+- **Aliases to track (`aliases:` YAML field):** Vasyl Symonenko.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Василий Симоненко; Vasili Symonenko. **The invented title «Казки для сина Лесика» must never be attributed to him.**
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **"Vasyl Symonenko"** holds 1950s–60s photographs; he died in 1963, so pre-1963 photos are public domain by age in Ukraine and the US. Confirm on the individual **file page**. [Commons category: `Vasyl Symonenko`]
+- **Backup candidates:** the **Біївці house-museum** (his birthplace); the Черкаси monument (2010); the NBU 2008 2-грн coin; the 2015 commemorative stamp.
+- **Context image:** a samvydav/«Берег чекань» (1965) page, or a Биківня memorial photo — strong §2 illustration if rights-clear.
+- **If no rights-clear portrait clears review:** fall back to the PD «Тиша і грім» (1962) cover.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Герасимова Г. П. "Симоненко Василь Андрійович." *Енциклопедія історії України*, т. 9 (Прил–С). Київ: Наукова думка, 2012. С. 559. (cited via article apparatus.)
+- "Симоненко Василь Андрійович." *Шевченківська енциклопедія*, т. 5 (Пе–С). Київ: Інститут літератури ім. Т. Г. Шевченка, 2015. С. 759–760. (gol. red. М. Г. Жулинський.)
+- *Енциклопедія українознавства: Словникова частина* / гол. ред. В. Кубійович. Париж; Нью-Йорк: Молоде життя — entry "Симоненко."
+
+**Tier 2 (institutional):**
+- Тарнашинська Л. *Василь Симоненко: «Україно, ти моя молитва…»: біобібліогр. нарис.* Київ: Нац. парлам. б-ка України; Інститут літератури ім. Т. Г. Шевченка НАН України, 2007. (Шістдесятництво: профілі на тлі покоління, вип. 11.)
+- Shankovsky I. *Vasyl' Symonenko and his Background.* Edmonton: University of Alberta, 1966.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Симоненко Василь Андрійович." Dates/works/the three fairy tales/the Bykivnia memorandum cross-checked against ЕІУ and Шевченківська енциклопедія. Accessed 2026-06-03.
+
+**Tier 5 (general web — used only with corroboration):**
+- Іван Андрусяк, «Міф про Василя Симоненка» // УНІАН-Культура, 2011 — for §6 anti-hagiography.
+- «Полтавщина» interview (Едуард Кухаренко) — on the contested causation of his death (labelled, unverified).
+
+**Primary-source documents accessed (in transcription / via the corpus):**
+- В. Симоненко, «Лебеді материнства», «Гей, нові Колумби й Магеллани», «Задивляюсь у твої зіниці» — accessed directly via the literary corpus (`ukrlib-symonenko`), verify_quote-confirmed conf. 1.0 (§4).
+- The 1962 **Меморандум** to the Kyiv city council on the mass-grave sites (via T3/Танюк's diary).
+
+**Honest gaps:** the encyclopedic Tier-1 entries are cited via apparatus (page numbers), not opened page-by-page this pass; the opened sources are uk.wikipedia (T3) and the corpus. The **causation of his death** is left open (kidney cancer; the beating's role unproven). The full fate of his literary estate is "невідома."
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his civic and anti-imperial verse is told on Ukrainian terms; the empire appears as censor and aggressor.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — "шістдесятники," "самвидав," "український рух опору" used precisely.
+- [x] No uncritical Soviet propaganda terms — "партійність" appears only quoted as the regime's criterion, named as distortion.
+- [x] No "lost his life" euphemism — death named plainly (kidney cancer), with the beating and surveillance set out and the causation left honestly open.
+- [x] Modern UA place names — Біївці (Полтавська область / Лубенщина), Черкаси, Київ/Kyiv; Биківня named as an NKVD mass-grave site.
+- [x] Holodomor — not central, but the **Bykivnia** Stalinist mass graves he exposed are named as such (НКВС executions), not "repressions" in the abstract.
+- [x] Russian aggression framing — his «Курдському братові» is read as an anti-imperial allegory that today's Russian narrative erases (§6).


### PR DESCRIPTION
## Wave C — 6 sourced bio research dossiers (#2535 original-180 ghost-wiki uplift)

Six figures that had a live wiki but **no research dossier** (the #2535 ghost-wiki root cause). Each dossier mirrors `docs/templates/bio-research-dossier-template.md` (10 sections + decolonization self-check), uses tiered `[T1…/T5]` citations, carries a flagged "source disagreement" note, a load-bearing §2 oppression mechanism, and ≥2 primary quotes. Every quote score reported is the **real** `verify_quote` score (#M-4). Every §7 "Existing" path was `test -e`-verified; the `lint_bio_dossier_xref.py` validator passes (exit 0).

### Per figure — key sourced facts · ⚠ resolution · honest gaps

**1. `mykola-khvylovyi` — Микола Хвильовий (Фітільов), 1893–1933**
- Sourced: suicide 13.05.1933 in the «Слово» building; Stalin's letter to Kaganovich **26.04.1926**; НКВС справа-формуляр **С-183 (1927)**; «Сині етюди» (1923); ВАПЛІТЕ; «Геть від Москви!» / «психологічна Європа». Top sources: **IEU (T1, opened)**, uk.wikipedia (T3), Костюк/Смолоскип 5-vol ed. (T2), Мельників critical ed. (T4).
- ⚠ All establish-points covered; «Камо грядеши?» peroration **verify_quote 1.0** and the «психологічна Європа» passage **0.84** (corpus `ukrlib-khvylovy`); suicide-note opening confirmed via T3 (note confiscated 1933, public only post-1980s).
- Honest gap: ЕСУ/ЕІУ exist but not opened this pass; suicide-note wording is transmission-dependent.

**2. `mykola-kulish` — Микола Гурович Куліш (playwright), 1892–1937**
- Sourced: «97» (1924), «Народний Малахій» (1927), «Мина Мазайло» (1929); commanded the **Дніпровський селянський полк** (Red Army, 1919); Berezil/Kurbas; arrested Dec 1934; «боротьбисти» case 1935 → Solovki; **shot 3.11.1937 Сандармох**. Top sources: **IEU (T1, opened)**, ЕІУ Герасимова т.5 с.466 (T1), Русанівський & Попович histories (in corpus), uk.wikipedia (T3).
- ⚠ **Panteleimon-conflation explicitly blocked** (disambiguation banner + §6/§8; `lit/kulish-literary-legacy.yaml` confirmed = Panteleimon and deliberately NOT linked). Bonus catch: Попович misprints his dates "(1882–1942)" — flagged as falsified-Kurbas-date contamination.
- Honest gap: his plays are not in the verify_quote corpus, so §4 quotes are Tier-1-scholarship-attested + Wikiquote (labelled); «На рыбной ловле» & «Такі» are lost.

**3. `les-kurbas` — Лесь Курбас, 1887–1937**
- Sourced: b.1887 Самбір (actor family); Молодий театр + Березіль; arrest 25.12.1933 (УВО/Postyshev fabrication, Справа № 3168); 5-year sentence 1934; Solovki/Anzer; **shot 3.11.1937 Сандармох**. Top sources: **IEU (T1, opened)**, ЕІУ Герасимова т.5 с.514 (T1), ЕСУ Корнієнко (T1), ULE & Шевченківський словник (in corpus).
- ⚠ **Falsified death-date documented from the corpus itself**: Soviet-era Шевченківський словник gives "15.Х 1942" and Попович "1942" (and the widow's 1961 certificate "15.XI 1942"), while post-Soviet ULE gives the true **3.XI 1937** — the inconsistent fakes are the fingerprint of forgery. Also corrected the brief's "«97» (1930)": not in Kurbas's Berezil repertoire (that was Гнат Юра's Franko staging).
- Honest gap: his theory texts aren't in the verify_quote corpus; §4 uses documentary-edition/Wikiquote aphorisms (labelled) + the ЕУ-attested "думаючий театр" programme.

**4. `vasyl-stus` — Василь Стус, 1938–1985**
- Sourced: 1965 «Україна»-cinema protest; arrests 12.01.1972 & May 1980; Helsinki Group; «Палімпсести»; **died 4.09.1985** on dry hunger-strike in the Perm-36 carcer; reburied Kyiv 19.11.1989 with Литвин & Тихий. Top sources: **IEU (T1, opened)**, НАН Інститут літератури 4-vol ed. (T1/T2), Кіпіані KGB-archive book (T4), uk.wikipedia (T3).
- ⚠ **Geography fixed**: Mordovian camps (1972–77) → Magadan/Kolyma **exile** (1977–79) → **Perm-36 (ВС-389/36-1), Урал** (1980–85) — **never Siberia** (IEU explicitly "not Mordovia" for the death camp). Programmatic poem **verify_quote 1.0** (`ukrlib-stus`).
- Honest gap: cause of death left genuinely open (cardiac arrest / hypothermia / carcer-bunk killing per Овсієнко).

**5. `vasyl-symonenko` — Василь Симоненко, 1935–1963**
- Sourced: b. **Біївці, Лубенщина (Полтавщина)**; Клуб творчої молоді; 1962 **Bykivnia mass-grave memorandum**; **beaten by militia summer 1962** (Сміла station); died at 28 (kidney cancer). Top sources: ЕІУ Герасимова т.9 с.559 (T1), Шевченківська енциклопедія т.5 (T1), ЕУ (T1), Тарнашинська нарис (T2), Shankovsky/U.Alberta (T2).
- ⚠ **«Казки для сина Лесика» does not exist** — confirmed the real three («Цар Плаксій і Лоскотон», «Подорож у країну Навпаки», «Казка про Дурила»); his son was **Олесь** (source of the garble). THREE poems **verify_quote 1.0** (`ukrlib-symonenko`): «Лебеді материнства», «Народ мій є!», «Задивляюсь у твої зіниці».
- Honest gap: causation of death (beating→cancer) is widely believed but **not documented** — stated as open.

**6. `ivan-dziuba` — Іван Дзюба, 1931–2022**
- Sourced: b. **Миколаївка, Волноваський р-н**; «Інтернаціоналізм чи русифікація?» (1965), **mailed personally to Шелест & Щербицький** 1965–66; arrest 13.01.1972; 1973 sentence; Minister of Culture **1992–94**; **Hero of Ukraine 2001**; **died 22.02.2022** (age 90). Top sources: ЕІУ Желєзняк т.2 с.378 (T1), his memoirs «На трьох континентах» (T2), Частакова monograph (T4), the **treatise itself in the corpus** (`wave7-dzyuba-internatsionalizm`, **verify_quote 1.0**).
- ⚠ **Recantation engaged honestly** (§2/§6): the 1973 "покаяння" was extracted under open-TB medical duress + a year of КГБ interrogation; he never disowned the treatise's substance; the Stus-vs-Dziuba tension on recantation is named, not smoothed.
- Honest gap: ЕІУ cited via apparatus (not opened this pass); exact recantation wording is sensitive/variously reported; image licensing constrained (2022 death → copyright, not PD).

### Gates
- `lint_bio_dossier_xref.py` → **exit 0** (all 6 + full sweep).
- Pre-commit (incl. "bio dossier §7 cross-track path validator") → **Passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**No auto-merge.**
