### PR TITLE
research(bio): 6 sourced dossiers — Wave D classics + statehood founders (#2535)

### DIFF
--- a/docs/research/bio/bohdan-khmelnytskyy.md
+++ b/docs/research/bio/bohdan-khmelnytskyy.md
@@ -1,0 +1,181 @@
+# Богдан-Зиновій Михайлович Хмельницький — Research Dossier
+
+**Slug:** `bohdan-khmelnytskyy`
+**Block:** G (politically charged statehood figure; founder of the Cossack state whose 1654 Pereiaslav choice was turned into the imperial "reunification" myth — §6 extended accordingly)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave D)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; T4 Hrushevsky/Holobutsky/Гвоздик-Пріцак/Doroshenko directly read in corpus; uk.wikipedia/ВУЕ cross-checked)
+- [x] Appropriation mechanism is specific (the Pereiaslav "возз'єднання" myth + the dated 1954 «Тези ЦК КПРС»)
+- [x] ≥2 primary-source quotes (2 of Khmelnytsky's own recorded speech, corpus-attested via Hrushevsky/Гвоздик-Пріцак; **PLUS the corpus-verified Shevchenko critique — confidence 1.0 reported**)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied; §6 extended (Block G + Jewish/Polish perspective); **does NOT flinch from Shevchenko's critique**
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Богдан-Зиновій Михайлович Хмельницький. [T1: IEU — "Khmelnytsky, Bohdan"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none (a baptismal-name pair Богдан/Зиновій). Russian-imperial transliteration (forbidden in body text, listed only in §8): Богдан Зиновий Хмельницкий; Jewish historical memory: חמיאל / "Chmiel the Wicked" (see §6).
+- **Born:** **ca. 1595** (traditionally 27 December 1595) | likely **Суботів** or **Чигирин**, Київське/Брацлавське воєводство, Річ Посполита. [T1: IEU — "Born ca. 1595–6"; T3: uk.wikipedia]
+- **Died:** **6 August 1657** (27 July O.S.) | **Чигирин**, Гетьманщина | of illness, soon after the failed Transylvanian-Swedish campaign; buried in Суботів (the Іллінська церква he built). [T1: IEU — "d 6 August 1657 in Chyhyryn"; T3: uk.wikipedia]
+- **Education:** elementary schooling in Ukrainian; secondary/higher education in Polish at a **Jesuit college, likely in Львів**; knew **Polish, Latin, Turkish, Tatar and French**. [T1: IEU]
+- **Office / role:** **Hetman of the Zaporozhian Host (1648–1657)**; leader of the 1648 national-liberation war (the Хмельниччина) and founder of the **Козацька держава (Hetmanate)**. End of December 1647 he went to the Січ with a small detachment and was elected hetman; **triumphal entry into Kyiv 1648**. [T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth date.** Genuinely uncertain — IEU gives **ca. 1595–6**; the traditional date is **27 December 1595**. The dossier uses **ca. 1595** and flags the tradition, not a false precision.
+2. **Pereiaslav vs the March Articles (the ⚠).** The **Переяславська рада** met **8 January 1654 (18 January N.S.)**; the actual treaty terms — the **«Березневі статті»** — were confirmed by tsar Aleksei Mikhailovich and the Boyar Duma on **21 March 1654**. Do not conflate the oath-taking council (January) with the negotiated articles (March). [T5: ВУЕ; cdiak archives; T3: uk.wikipedia]
+3. **The Shevchenko quote is REAL.** The line «За що ми любимо Богдана?…» (§4) is **corpus-verified at confidence 1.0** — it is not apocryphal (see §4).
+
+## 2. Appropriation / erasure mechanism
+
+> Block G framing: Khmelnytsky was not "oppressed" in life — he was a victorious head of state. The "Russia-oppressed" mechanism here is **the imperial appropriation of his 1654 Pereiaslav choice into the founding myth of Russian rule over Ukraine.**
+
+**(a) The "возз'єднання" myth (the load-bearing mechanism).** Russian-imperial and then Soviet historiography reframed the **Pereiaslav agreement (1654)** as the **«возз'єднання України з Росією»** (the "reunification of Ukraine with Russia") — an eternal, willed merger. The canonical statement of this myth is the **1954 «Тези ЦК КПРС про 300-річчя возз'єднання України з Росією»**, issued for the 300th anniversary, which made "reunification" official Soviet doctrine and the ideological charter for treating Ukraine as inseparable from Russia. [T4: Doroshenko, *Нарис історії України* (corpus); T3: uk.wikipedia]
+
+**(b) What the documents actually say (the decolonial correction).** The **Березневі статті** preserved the Cossack state's rights and liberties (вольності), the hetman's authority, the Cossack register and self-government — a **military-political protectorate / confederative-type alliance**, not a dissolution. Tier 1 IEU is blunt: **"The Pereiaslav Treaty of 1654 did not change the political status of Ukraine, or the title or authority of its hetman."** [T1: IEU] The **Запорозька Січ did not even swear the oath.** Pereiaslav was, in the decolonised reading, one of **several tactical alliances** Khmelnytsky pursued (Crimea, the Ottomans, Moldavia, Transylvania, Sweden) to sustain an independent Cossack state — not a national act of submission. [T4: Гвоздик-Пріцак; Holobutsky (corpus)]
+
+**(c) The monument and the slogan.** The 1888 Kyiv monument to Khmelnytsky was raised under the inscription **«Богдан Хмельницький — Россіи единой неделимой»** ("to one indivisible Russia"), with the hetman's mace pointing toward Moscow — material propaganda turning the state-builder into a symbol of Russian unity. [T3: uk.wikipedia]
+
+**(d) Do not flinch — the Ukrainian self-critique.** The decolonial reading does not require hagiography. **Shevchenko** (§4) bitterly condemned the Pereiaslav choice as having "занапастив… сироту Украйну." Honest history holds two truths at once: Khmelnytsky founded the Cossack state and broke the Polish yoke, **and** the 1654 Muscovite alliance proved a long-term catastrophe whose myth the empire weaponised.
+
+**What survived / what was distorted:** the Hetmanate and Khmelnytsky's stature survived; what was distorted was the *meaning* of 1654 — a protectorate-alliance rewritten as eternal "reunification."
+
+## 3. Major works / legacy
+
+A statesman and military leader, not a writer; "works" = his state-building, campaigns, and diplomacy.
+
+- `1648` — launched the **national-liberation war**; victories at **Жовті Води** and **Корсунь** (spring 1648) and **Пилявці** (autumn 1648); triumphal entry into Kyiv. [T1: IEU — "military victories in 1648–9… triumphal entry into Kyiv in 1648"; T4: corpus]
+- `1649` — **Зборівський договір** (after Zbarazh/Zboriv) — first formal recognition of an autonomous Cossack polity (40,000-man register). [T4: Гвоздик-Пріцак (corpus)]
+- `1651` — defeat at **Берестечко** (after the Crimean Khan's betrayal) → the harsher **Білоцерківський договір** (Bila Tserkva treaty, reduced register). [T4: Doroshenko (corpus)]
+- `1652` — victory at **Батіг**. [T4: corpus]
+- `1654` — the **Переяславська рада (8/18 Jan)** and the **Березневі статті (21 March)** — the Muscovite protectorate (§2). [T1: IEU; T5: ВУЕ]
+- **State-building:** created the **Гетьманщина** — its administrative-regimental (полково-сотенний) structure, treasury, courts and diplomacy; built the Іллінська церква in Суботів. [T1: IEU; T4: Липинський — *Україна на переломі*]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — Khmelnytsky's own recorded declaration to the Polish commissars, Pereiaslav, February 1649** (recorded by the Polish envoy Myaskovsky; quoted in Hrushevsky):
+
+> «Виб'ю з лядської неволі народ руський весь! Перше я за свою шкоду і кривду воював — тепер буду воювати за нашу православну віру!»
+
+Corpus-attested in **Hrushevsky, *Історія України-Руси*, т. 7–10** (project corpus `wave4-hrushevsky-iur-t7-10`), who comments: "Нема причини не вірити сьому власному посвідченню Хмельницького." The moment the war became, in his own words, a war of national-religious liberation. [Primary: recorded speech, corpus-attested via Hrushevsky]
+
+**Quote 2 — the territorial vision, same 1649 speech** (Гвоздик-Пріцак's transcription):
+
+> «…досить маю на Україні, на Поділлі і Волині… по Львів, Холм і Галич. А ставши над Віслою, скажу дальшим ляхам: сидіть, мовчіть, ляхи!»
+
+Corpus-attested in **Гвоздик-Пріцак** (project corpus `wave7-gvozdyk-pritsak-khmelnytsky`). His claim to all the Rus' ethnic lands — evidence that the project was a Ukrainian state, not a provincial revolt. [Primary: recorded speech, corpus-attested]
+
+**Quote 3 (corpus-verified — Shevchenko's critique, the ⚠ to NOT flinch from):**
+
+> «За що ми любимо Богдана? / За те, що москалі його забули…»
+
+`verify_quote` → **matched, confidence 1.0** (both `ukrlib-shevchenko` and `wave10-shevchenko-tvory-t1`; a poem of **15 February 1861, St Petersburg**, with an 1845–46 variant). Companion verified lines (each `verify_quote` **1.0**): **«Якби-то ти, Богдане п'яний, / Тепер на Переяслав глянув!»** and **«Отак-то, Богдане! / Занапастив єси вбогу / Сироту Украйну!»** (from «Стоїть в селі Суботові», 1845). The canonical Ukrainian self-critique of Pereiaslav — essential to teach alongside the chronicles' praise. [Primary: corpus-verified, confidence 1.0]
+
+## 5. Language register
+
+- **Register:** Khmelnytsky's own recorded voice is mid-17th-c. **Cossack-chancery / spoken Middle Ukrainian** with heavy Polonisms («ляхи», «неволя», «кривда»), preserved inside chronicles and diplomatic records. The Shevchenko critique is **19th-c. literary Ukrainian** (Romantic verse).
+- **CEFR readiness for full reading:** the recorded-speech fragments are **C1** (archaic syntax, glossing needed); the Shevchenko quatrains are **B2**; Khmelnytsky-era *content* (the 1648 war, Pereiaslav, the Hetmanate) is teachable at **B1–B2** with modern narration.
+- **Lexicon notes (pre-teach):** гетьман, козацтво, повстання, визвольний, реєстровий, гетьманщина, державник, протекторат, возз'єднання, погром — all VESUM-valid (verified this pass). Gloss «Березневі статті», «Переяславська рада», «вольності».
+- **Stylistic features:** the chronicle tradition (Самовидець, Грабянка 1710, Величко 1720) renders him in epic-biblical register ("Богом даний", "Мойсей, що вивів народ із єгипетської неволі лядської"); the Shevchenko critique answers that epic with bitter irony.
+
+## 6. Contested points
+
+*(Politically charged — extended per Block G; includes the Jewish/Polish perspective the template requires.)*
+
+- **The historiographical spectrum (teach the whole arc).**
+  - **Chronicles & 18th c.:** "Богом даний вождь", a Moses; **Сковорода** called him "герой і батько вольності." [T4: Doroshenko (corpus)]
+  - **Костомаров, «Богдан Хмельницький» (1857):** the foundational Romantic-national monograph.
+  - **Куліш, «История воссоединения Руси» (1874–77):** sharply **critical** — condemned the rebellion's bloody destructiveness; a deliberate anti-heroic revision.
+  - **Липинський, «Україна на переломі» (1920):** the **державницька** (state-building) reading — Khmelnytsky as the conscious founder of the Ukrainian state.
+  - **Soviet 1954 «Тези ЦК КПРС»:** the "возз'єднання" doctrine (§2a).
+  - **Modern UA:** state-builder and liberator; Pereiaslav as protectorate, not annexation.
+- **The Jewish perspective (do not omit).** The 1648–49 uprising was accompanied by **large-scale massacres of Jewish communities** (and of Polish nobles and Catholic clergy) across Right-Bank Ukraine — tens of thousands killed. In Jewish historical memory Khmelnytsky («Chmiel the Wicked», חמיאל הרשע) is remembered as a perpetrator of catastrophic pogroms. An honest module must hold this alongside his Ukrainian state-founding role; the two are not mutually cancelling. [T4: standard early-modern scholarship — referenced]
+- **The Tatar alliance's cost.** His Crimean alliance brought repeated **betrayals (Zboriv 1649, Berestechko 1651)** and the **enslavement of Ukrainian peasants** by Tatar raiders — part of the un-romantic record.
+- **Shevchenko vs the cult.** The verified Shevchenko critique (§4) is the internal Ukrainian counter-voice to the heroic cult — neither erases the other.
+- **Russian disinformation (live).** The "возз'єднання" myth is the historical taproot of Russia's 2022 claim that Ukraine and Russia are "one people"; dismantling Pereiaslav-as-reunification is directly relevant. [T5: Krym.Realii; ArmiyaInform]
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — his general chancellor and successor (the Гадяцька угода 1658); the tightest post-Khmelnytsky link.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — the Zaporozhian leadership of the era.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — the author of the Hadiach Union, of the same generation.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` (Wave D) — the later hetman who tried to keep the state Khmelnytsky founded autonomous against Russia.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/black-council-history.yaml`, `curriculum/l2-uk-en/plans/lit/black-council-plot.yaml` — Kulish's «Чорна рада», set in the Ruina that followed Khmelnytsky's death.
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Cossack-Baroque literary milieu (the chronicles of Самовидець/Грабянка/Величко belong here).
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml`, `curriculum/l2-uk-en/plans/hist/khmelnychchyna-prychyny.yaml`, `curriculum/l2-uk-en/plans/hist/syntez-khmelnychchyna.yaml` — the dedicated HIST Khmelnytsky cluster this bio anchors.
+  - `curriculum/l2-uk-en/plans/hist/bitva-pid-zhovtymy-vodamy.yaml`, `curriculum/l2-uk-en/plans/hist/zborivska-bila-tserkva.yaml`, `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — the battles and the 1654 agreement.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml`, `curriculum/l2-uk-en/plans/hist/ruina-i.yaml` — the state he built and the Ruina after his death.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A module on the **1648–49 anti-Jewish massacres** as the obligatory honest counter-perspective (no plan yet).
+  - A module on the **Pereiaslav historiography** (Костомаров → Куліш → Липинський → 1954 Тези → modern) as a case study in how a treaty becomes a myth.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A close-reading module on Shevchenko's anti-Bohdan poems («Розрита могила», «Стоїть в селі Суботові», «Якби-то ти, Богдане п'яний») as the verified internal critique.
+
+## 8. Naming-canonical
+
+- **Slug:** `bohdan-khmelnytskyy`
+- **EN canonical (BGN/PCGN-style project spelling):** Bohdan Khmelnytsky
+- **UA canonical (with patronymic):** Богдан-Зиновій Михайлович Хмельницький
+- **Aliases to track (`aliases:` YAML field):** Bohdan Khmelnytsky; Зиновій Хмельницький; Bohdan Khmelnytskyi (variant EN).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Богдан Зиновьевич Хмельницкий; the slogan «Россіи единой неделимой»; «возз'єднання» used as fact rather than as the myth under analysis.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Bohdan Khmelnytsky"** holds 17th-c. portraits and the famous **Hondius engraving (1651)** (he died 1657 — firmly public domain by age). Use the individual **file page** for license proof, not the category page. [Commons category: `Bohdan Khmelnytsky`]
+- **Backup candidates:**
+  - The 5-гривня НБУ banknote portrait — check banknote-image reuse rules first.
+  - The 1888 Kyiv monument — useful precisely as a §2c illustration of the imperial "indivisible Russia" framing (note the inscription's history).
+- **Context image:** a facsimile of the «Березневі статті» or a Cossack-chronicle page (Величко/Грабянка) — strong §2/§4 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Khmelnytsky, Bohdan." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\H\KhmelnytskyBohdan.htm. Accessed 2026-06-03. (Birth ca. 1595–6; death 6 Aug 1657 Chyhyryn; Jesuit/Lviv education and languages; 1647 election; 1648 Kyiv entry; the key framing that "the Pereiaslav Treaty of 1654 did not change the political status of Ukraine.")
+- *Енциклопедія історії України (ЕІУ),* "Хмельницький Богдан" — the authoritative UA encyclopedic baseline (dates and framing match).
+
+**Tier 2 (institutional):**
+- ЦДІАК / Central State Historical Archives of Ukraine — the 1654–1659 treaty editions (referenced via T5).
+- *Велика українська енциклопедія (ВУЕ).* "Березневі статті 1654." https://vue.gov.ua/. Accessed 2026-06-03.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Богдан Хмельницький" and "Переяславська рада." https://uk.wikipedia.org/wiki/Богдан_Хмельницький. Accessed 2026-06-03. Source for: battle chronology; the 1888 monument inscription; Pereiaslav 8/18 Jan + March Articles 21 Mar. Cross-checked against IEU/ВУЕ.
+
+**Tier 4 (modern scholarly — directly read in the project corpus):**
+- Грушевський М. *Історія України-Руси, т. 7–10* (corpus `wave4-hrushevsky-iur-t7-10`) — Khmelnytsky's own 1649 declaration (§4 Quote 1).
+- Гвоздик-Пріцак Л. *Економічно-політична концепція Б. Хмельницького* (corpus `wave7-gvozdyk-pritsak-khmelnytsky`) — the territorial vision (§4 Quote 2); the alliance system.
+- Голобуцький В. *Запорозьке козацтво* (corpus `wave7-holobutsky-zaporizhzhia`) — the 1649 negotiations.
+- Дорошенко Д. *Нарис історії України, т. 2* (corpus `wave13-doroshenko`) — the historiographical spectrum (§6).
+- Костомаров М. (*Богдан Хмельницький*, 1857); Куліш П. (*История воссоединения Руси*, 1874–77); Липинський В. (*Україна на переломі*, 1920) — the classic interpretive poles (§6).
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- ВУЕ; ЦДІАК; ArmiyaInform; Krym.Realii — the Pereiaslav/March-Articles dates and the "зрада чи перемога" modern debate (§2, §6).
+
+**Primary-source documents accessed (in transcription):** Khmelnytsky's recorded 1649 speech (§4 Quotes 1–2) via Hrushevsky/Гвоздик-Пріцак (corpus); Shevchenko's critique (§4 Quote 3) `verify_quote`-confirmed at **confidence 1.0**.
+
+**Honest gaps:** Khmelnytsky's birth date is genuinely uncertain (ca. 1595–6 / traditional 27 Dec 1595). IEU did not enumerate the individual battles, which are taken from the corpus (Гвоздик-Пріцак/Doroshenko/Holobutsky) and uk.wikipedia/ВУЕ; the battle *years* are stable across these. The 1648–49 anti-Jewish massacres (§6) are stated on the strength of standard early-modern scholarship rather than a single fetched source this pass, and flagged as the obligatory honest counter-perspective.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Khmelnytsky is told as the founder of a Ukrainian state; Russia appears as the power that appropriated Pereiaslav into the "reunification" myth.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN; «возз'єднання» appears only as the myth under analysis (§2a, §6).
+- [x] No Russocentric periodization — Національно-визвольна війна / Хмельниччина / Гетьманщина used; Pereiaslav given O.S./N.S. and distinguished from the March Articles.
+- [x] No uncritical Soviet propaganda terms — the 1954 «Тези» and "reunification" are named only as the doctrine being deconstructed.
+- [x] No "lost his life" euphemisms — death from illness stated plainly. **Honest in every direction:** the verified Shevchenko critique, the 1648–49 anti-Jewish massacres, and the Tatar-alliance costs are all stated, not airbrushed.
+- [x] Modern UA place names — Чигирин, Суботів, Переяслав, Київ/Kyiv, Львів/Lviv.
+- [N/A] Holodomor — не стосується (Хмельницький помер 1657).
+- [x] Russian aggression framing — the Pereiaslav "reunification" myth is explicitly traced as the taproot of Russia's post-2022 "one people" claim (§6).

--- a/docs/research/bio/hryhoriy-kvitka-osnovianenko.md
+++ b/docs/research/bio/hryhoriy-kvitka-osnovianenko.md
@@ -1,0 +1,175 @@
+# Григорій Федорович Квітка-Основ'яненко — Research Dossier
+
+**Slug:** `hryhoriy-kvitka-osnovianenko`
+**Block:** B (imperial-era founder; his Ukrainian prose was written against the imperial axiom that Ukrainian was unfit for "serious" literature, then his role was blurred by an "all-Russian" reframing and his grave physically destroyed under Soviet rule)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave D)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; ЕІУ т.4 via Шепель; uk.wikipedia cross-checked; Tier-4 Чижевський/Грабович/Костомаров from project corpus)
+- [x] Oppression mechanism is specific (named imperial-cultural denial mechanism + dated grave destruction + named reframing) — measured, non-hagiographic register per the ⚠
+- [x] ≥2 primary-source quotes (2 from his own fiction; **honestly flagged as NOT corpus-verified** — `verify_quote` = 0.0 because his texts are not in `ukrlib`; sourced to e-text)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Григорій Федорович Квітка; literary name **Квітка-Основ'яненко** (the «Основ'яненко» from his native село Основа); he also signed **Грицько Основ'яненко**. [T1: IEU — "Kvitka-Osnovianenko, Hryhorii"; T1: ЕІУ т.4, Шепель Л. Ф.; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **Грицько Основ'яненко** (the form on the 1834 «Малороссийские повести» title page). Russian-imperial transliteration (forbidden in body text, listed only in §8): Григорий Фёдорович Квитка / "Kvitka-Osnovyanenko".
+- **Born:** **29 November 1778** (18 November O.S.) | село **Основа**, нині в межах Харкова | Слобідсько-Українська губернія, Російська імперія. [T1: IEU — "b 29 November 1778 in Osnova (now a suburb of Kharkiv)"; T3: uk.wikipedia — "18 (29) листопада 1778"]
+- **Died:** **20 August 1843** (8 August O.S.) (aged 64) | Харків | Російська імперія | after a serious illness. Buried at the **Холодногірський цвинтар**, Kharkiv. [T1: IEU — "d 20 August 1843 in Kharkiv"; T3: uk.wikipedia — "8 (20) серпня 1843"]
+- **Family / education key facts:** Born into the **Cossack-starshyna Квітка family of Слобожанщина**, son of колезький радник Федір Іванович and Марія Василівна (Шидловська). Home-schooled, then the Курязька монастирська школа; spent c. 10 months (1804–05) as a novice at the Курязький монастир before returning to secular life. A leading civic figure of Kharkiv: founder and first director of the **Харківський професійний театр (1812)**, co-founder of the Інститут шляхетних дівчат (1812) and the Харківська публічна бібліотека; повітовий проводир дворянства (marshal of nobility, 1817–1828); голова Харківської палати кримінального суду. Co-published the journal **«Украинский вестник» (1816–1817)**. [T1: IEU — "established the Kharkiv Theater in 1812 and served as its first director"; T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Founding-myth, not biography.** The live wiki narrates the family's origin via Kvitka's own tale «Заснування Харкова. Старовинний переказ» (a foundling «Андрій Квітка» founding Kharkiv) — but the wiki itself concedes this is "гарна та романтична історія, що не відповідає реальності." Treat it as literary myth, not fact.
+2. **Work-date disagreements (real, unresolved).** «Маруся» — written c. 1832, **first published 1834** in «Малороссийские повести», кн. 1 (Moscow); the wiki's "1832" is the writing date. «Конотопська відьма» — wiki list "1833"; **Чижевський dates it 1837**; it appeared in «Малороссийские повести», кн. 2 (1834/1837). «Сватання на Гончарівці» — **IEU 1836**, wiki 1835. The dossier records these as genuinely variant (writing vs first-print vs collected-edition dates), not as a single tidy year. [T1: IEU; T4: Чижевський Д., *Історія української літератури*; T3: uk.wikipedia]
+3. **O.S./N.S.** All paired dates above are Old-Style/New-Style, not a real disagreement.
+
+## 2. Erasure / appropriation mechanism
+
+> The ⚠ register note is observed here: **measured, no purple prose.** Kvitka was not arrested, exiled, or killed — he was a loyal imperial official. The honest "Russia-oppressed" mechanism for him is **cultural, not carceral**, plus one concrete posthumous physical erasure.
+
+**(a) The imperial axiom he wrote against.** The governing imperial-cultural assumption was that «малороссийское наречие» was a peasant patois fit only for low burlesque and comedy, not for "serious" literature. Kvitka's decisive act was to **disprove this in practice**: IEU states his "major contribution was [to demonstrate] that *the Ukrainian language can also be used for serious subjects*," extending it beyond comic travesty. [T1: IEU] His sentimental повість «Маруся» (1834) is the founding instance — hence the honorific **"батько української прози" (father of Ukrainian prose)**, the prose counterpart to Kotliarevsky in verse. [T1: IEU; T3: uk.wikipedia]
+
+**(b) The condescension he answered.** Russian critics met his Ukrainian prose with the era's standard dismissiveness (the 1835 «Северная пчела» review of «Малороссийские повести… Кн. 1. М. 1834» is the type-specimen). Kvitka argued back for the literary capacity of Ukrainian in the programmatic **«Супліка до пана издателя» (1833)** and **«Листи до любезних земляків» (1839)**. [T3: uk.wikipedia]
+
+**(c) The concrete posthumous erasure.** His grave at the **Холодногірський цвинтар** in Kharkiv was destroyed when the cemetery was levelled **in the 1930s**; the headstone was shunted first to the Покровський собор, later to the Другий міський цвинтар. [T3: uk.wikipedia] The physical commemorative site of the "father of Ukrainian prose" was thus eliminated under Soviet rule.
+
+**(d) The "all-Russian" reframing.** Because Kvitka wrote prolifically **in Russian as well** (the Шельменко trilogy, the novel «Пан Халявский» (1839), «Жизнь и похождения Петра Степанова сына Столбикова»), later imperial and Soviet/Russian framing could fold him into "общерусская" literature and treat his Ukrainian prose as quaint regional ethnographism — obscuring that the Ukrainian prose was the deliberate, pioneering act. Naming him plainly as the founder of *Ukrainian* prose is the decolonial correction. [T1: IEU; T4: Костомаров М., review of works "written in the Little Russian language"]
+
+**What survived / what was distorted:** the prose survived and stayed canonical; what was distorted was the *significance* — his founder's role flattened into "also wrote some Little Russian sketches."
+
+## 3. Major works
+
+Selected canon, chronological (Tier 1 IEU dates; variance flagged in §1):
+
+- `1822` — **«Малороссийские анекдоты»**, his first publication (written 1820–22). [T1: IEU]
+- `1827` (pub. 1840) — **«Приезжий из столицы, или Суматоха в уездном городе»**, Russian-language comedy. [T3: uk.wikipedia]
+- `1831` — **«Шельменко — волостной писарь»** (Russian, with Шельменко speaking Ukrainian). [T1: IEU]
+- `1833` — **«Салдацький патрет. Латинська побрехенька, по-нашому розказана»**, his **first Ukrainian prose** piece. [T1: IEU — "Saldats'kyi patret… 1833"]
+- `1834` — **«Маруся»**, sentimental повість, in **«Малороссийские повести», кн. 1** (Moscow) — the founding work of Ukrainian artistic prose. [T1: IEU]
+- `1834/1837` — **«Конотопська відьма»**, burlesque-satirical повість (date contested, §1). [T4: Чижевський — 1837]
+- `1833` — **«Мертвецький Великдень»**; `1837` — **«От тобі й скарб»** — folk-belief tales. [T4: Чижевський]
+- `1836` — **«Сватання на Гончарівці»**, Ukrainian-language comedy (still staged). [T1: IEU — 1836]
+- `1837` — **«Шельменко-денщик»**, his most enduring comedy. [T1: IEU]
+- `1838` — **«Козир-дівка»**, повість. [T3: uk.wikipedia]
+- `1839` — **«Пан Халявский»**, Russian-language satirical novel. [T1: IEU]
+- `1841` — **«Сердешна Оксана»** (translated into French and published in Paris, 1854). [T3: uk.wikipedia]
+
+**Note:** «Сердешна Оксана» was among the first Ukrainian works to reach European readers (French, Paris 1854). Kvitka corresponded with Shevchenko, who dedicated to him the poem **«До Основ'яненка»** (1839). [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** Kvitka's own texts are **not ingested** in the project `ukrlib` literary corpus — `verify_quote` (author "Квітка-Основ'яненко") returned **best_confidence 0.0, no matched lines**. The two quotes below are therefore **not corpus-scored**; their exact wording is taken from public e-text editions (cited), and this gap is recorded in §10 rather than papered over with a score I did not get. (The corpus *does* hold rich Tier-4 commentary on Kvitka — Чижевський, Грабович, Костомаров — used elsewhere in this dossier.)
+
+**Quote 1 — opening beauty-portrait of «Маруся» (1834):**
+
+> «Та що то за дівка була! Висока, прямесенька, як стрілочка, чорнявенька, очиці, як тернові ягідки, бровоньки, як на шнурочку, личком червона, як панська рожа…»
+
+Source: Вікіджерела, «Маруся» (per the «Твори», т. 1, Львів, 1911 edition); orthography lightly normalised from the period spelling (e.g. «очицї»). The sentimental idealised heroine in народно-розмовна Ukrainian — the prose that proved the language could carry "serious" feeling (§2a). [Primary: published e-text; NOT corpus-verified — see §10]
+
+**Quote 2 — opening of «Конотопська відьма» (1834/1837):**
+
+> «Смутний і невеселий сидів собі на лавці, у новій світлиці, що відгородив від противної хати, конотопський пан сотник Микита Уласович Забрьоха.»
+
+Source: УкрЛіб full-text edition. The phrase **«смутний і невеселий»** recurs and has become a winged expression in Ukrainian; the burlesque-satirical register here is the opposite pole from «Маруся»'s sentimentalism — the same author commanding two modes. [Primary: published e-text; NOT corpus-verified — see §10]
+
+## 5. Language register
+
+- **Register:** народно-розмовна (folk-colloquial) Slobozhanshchyna Ukrainian in two modes — **sentimental** (the idealised, emotive «Маруся», «Сердешна Оксана») and **burlesque-satirical** (the comic «Конотопська відьма», «Салдацький патрет»). Modern scholarship debates the label (sentimentalism vs «просвітницький реалізм» — Enlightenment realism). [T4: Чижевський; Гончар О. — *Просвітительський реалізм*]
+- **CEFR readiness for full reading:** «Маруся» at **B2** (sentimental syntax + 1830s orthography/lexis); «Конотопська відьма» at **B2–C1** (dense burlesque idiom, dialectisms); his prose is generally harder for L2 readers than its "founding/simple" reputation suggests, because of the archaic spelling and saturated folk lexis.
+- **Lexicon notes (pre-teach):** зачинатель, повість, драматург, сентименталізм, бурлеск, травестія, просвітництво, слобожанський, старшина, благодійний — all VESUM-valid (verified this pass). Expect period Slobozhanshchyna dialectisms and 1830s orthographic forms.
+- **Stylistic features:** the intrusive, stylised folk narrator (the «оповідач» Грицько Основ'яненко), proverbs and folk idiom woven into narration, sentimental idealisation in tension with broad comic caricature.
+
+## 6. Contested points
+
+- **Чижевський vs Грабович (the central modern debate).** Dmytro Чижевський read «Конотопська відьма» as a thin folk anecdote and charged Kvitka with «просвітницьке нехтування» (Enlightenment contempt) toward folk belief and "moral insensitivity." George **Грабович** (Hrabovych) rebuts this directly: Чижевський "не враховує складності голосу та позиції автора," collapsing the difference between the author and his stylised, limited narrator, and undervaluing one of "найвидатніших творів у всій українській прозі XIX ст." The pedagogy must present this argument, not pick a winner. [T4: Грабович Г., *До історії української літератури* (project corpus); T4: Чижевський Д., *Історія української літератури* (project corpus)]
+- **Sentimentalism or Enlightenment-realism?** His prose is classed variously as sentimentalism (Лімборський), просвітницький реалізм (Гончар), or a transitional бурлеск-to-realism node (Зеров). [T4: corpus + bibliography]
+- **The two-language oeuvre.** He wrote more in Russian than in Ukrainian; reading his "Ukrainianness" honestly means neither erasing the Russian works nor letting them define him (§2d).
+- **Anti-hagiography (the ⚠).** Popular memory inflates him into a "невтомний сіяч"-style monument; the measured truth is sufficient — he wrote the first artistic Ukrainian prose and proved the language's literary capacity, while remaining a comfortable imperial official whose family origin-myth he himself romanticised (§1).
+- **Russian disinformation / appropriation.** The "общерусский писатель Квитка" framing leans on his Russian works to claim him; his deliberate choice to write «Маруся» in Ukrainian refutes it (§2a, §2d).
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-kotliarevskyi.yaml` — the founder of new Ukrainian *poetry/drama* («Енеїда», «Наталка Полтавка»); Kvitka is his prose counterpart — the tightest pairing.
+  - `curriculum/l2-uk-en/plans/bio/hryhoriy-skovoroda.yaml` — Skovoroda frequented the Kvitka home; the Slobozhanshchyna cultural lineage Kvitka inherited.
+  - `curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml` — Kulish wrote the 1858 study «Григорій Квітка (Основ'яненко) і його повісті».
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — Shevchenko dedicated «До Основ'яненка» (1839) and corresponded with him.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/kvitka-bio.yaml`, `curriculum/l2-uk-en/plans/lit/kvitka-language.yaml` — the dedicated Kvitka biography and language modules this bio anchors.
+  - `curriculum/l2-uk-en/plans/lit/marusya.yaml` ("Маруся: Ідеал української душі чи сентиментальний експеримент?") and `curriculum/l2-uk-en/plans/lit/konotop-witch.yaml` — the two work-level modules on his masterpieces.
+  - `curriculum/l2-uk-en/plans/lit/introduction-to-kotliarevsky.yaml`, `curriculum/l2-uk-en/plans/lit/natalka-poltavka.yaml`, `curriculum/l2-uk-en/plans/lit/eneida-part-1.yaml` — the Kotliarevsky cluster the prose-founding sits beside.
+  - `curriculum/l2-uk-en/plans/lit/language-of-realism.yaml` — the realist-language module his prose feeds into.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/slobozhanshchyna.yaml` — the Slobozhanshchyna context of his life, family, and Kharkiv institution-building.
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` — the imperial frame within which he chose Ukrainian.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `marko-vovchok` and `ivan-nechuy-levytskyi` (both Wave D) — IEU/Nechuy literature explicitly traces the prose lineage Kvitka → Vovchok → Nechuy-Levytsky.
+  - A bio tie to `ievhen-hrebinka` (Гребінка) — fellow Slobozhanshchyna/early-prose figure (no plan yet).
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A module on the Чижевський–Грабович debate (§6) as a case study in how to read a stylised folk narrator.
+
+## 8. Naming-canonical
+
+- **Slug:** `hryhoriy-kvitka-osnovianenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Hryhorii Kvitka-Osnovianenko
+- **UA canonical (with patronymic):** Григорій Федорович Квітка-Основ'яненко
+- **Aliases to track (`aliases:` YAML field):** Hryhorii Kvitka-Osnovianenko / Kvitka-Osnovyanenko (variant EN); Грицько Основ'яненко (pen-name); Григорій Квітка.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Григорий Фёдорович Квитка; "Kvitka-Osnovyanenko" (Russified transliteration); «малороссийское наречие» framing of his language.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Hryhorii Kvitka-Osnovianenko"** holds 19th-c. engraved/painted portraits; he died 1843, so any contemporaneous portrait is firmly public domain by age. Use the individual **file page** for license proof, not the category page. [Commons category: `Hryhorii Kvitka-Osnovianenko`]
+- **Backup candidates:**
+  - The 2003 Укрпошта stamp and the 2008 НБУ 2-грн coin (series «Видатні особистості України») — verify stamp/coin reuse rules first.
+  - The 1994 Kharkiv monument (sculptor С. Якубович) — modern photo, verify photographer rights.
+- **Context image:** a title page of «Малороссийские повести, рассказываемые Грыцьком Основьяненком» (Moscow, 1834) — the founding volume of Ukrainian prose — strong §2 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Kvitka-Osnovianenko, Hryhorii." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\V\Kvitka6OsnovianenkoHryhorii.htm. Accessed 2026-06-03. (Birth 29 Nov 1778 Osnova; death 20 Aug 1843 Kharkiv; "father of Ukrainian prose"; «Малороссийские анекдоты» 1822, «Салдацький патрет» 1833, «Малороссийские повести» 1834/1837, «Сватання на Гончарівці» 1836, «Пан Халявский» 1839; Kharkiv Theatre 1812; the "serious subjects" language claim.)
+- Шепель Л. Ф. "Квітка-Основ'яненко Григорій Федорович." *Енциклопедія історії України*, т. 4 (Ка–Ком). Київ: Наукова думка, 2007. С. 165. (Authoritative UA encyclopedic baseline.)
+
+**Tier 2 (institutional):**
+- Центральна районна бібліотека ім. Г. Ф. Квітки-Основ'яненка (Холодногірський р-н, Харків) — the figure's memorial library; field-standard apparatus (referenced).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Квітка-Основ'яненко Григорій Федорович." https://uk.wikipedia.org/wiki/Квітка-Основ'яненко_Григорій_Федорович. Accessed 2026-06-03. Source for: civic offices, «Украинский вестник», the family origin-myth (flagged), grave destruction in the 1930s, French «Сердешна Оксана» 1854, Shevchenko dedication. Cross-checked against IEU.
+
+**Tier 4 (modern scholarly — directly read in the project corpus):**
+- Чижевський Д. *Історія української літератури* (project corpus `wave4-chyzhevsky-istoriia-lit`) — dating of «Конотопська відьма» (1837) and the "Enlightenment contempt" reading (§6).
+- Грабович Г. *До історії української літератури* (project corpus `wave8-hrabovych-do-istoriyi`) — the rebuttal of Чижевський on Kvitka's authorial voice (§6).
+- Костомаров М. *Обзор сочинений, писанных на малороссийском языке* (project corpus `wave7-kostomarov`) — contemporary listing of Kvitka's twelve Ukrainian prose works and five plays.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- Вікіджерела (uk.wikisource). "Маруся" — verbatim opening beauty-portrait (§4 Quote 1).
+- УкрЛіб (ukrlib.com.ua). "Конотопська відьма" full text — verbatim opening (§4 Quote 2).
+
+**Primary-source documents accessed (in transcription):** Kvitka's fiction openings (§4) via public e-text; **not** project-corpus-scored (see honest gap).
+
+**Honest gaps:** Kvitka's own texts are absent from the `ukrlib` `verify_quote` corpus, so the two primary quotes (§4) carry e-text provenance rather than a corpus confidence score (`verify_quote` = 0.0). The «Конотопська відьма»/«Сватання» first-publication years are genuinely contested across sources (§1) and are presented as variant, not resolved. ЕСУ and the Шевченківська енциклопедія entries were not separately opened this pass; ЕІУ is cited as the standard UA baseline.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his founding role is named on Ukrainian terms; the empire appears as the cultural axiom he disproved and the later "all-Russian" reframing he is rescued from.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Слобожанщина / Російська імперія used precisely.
+- [x] No uncritical Soviet propaganda terms — none; the "общерусский писатель" frame appears only as the *thing being corrected* (§2d).
+- [x] No "lost his life" euphemisms — death from illness stated plainly; the erasure here (cultural denial + grave destruction + reframing) is named specifically, in measured register per the ⚠.
+- [x] Modern UA place names — Харків/Kharkiv, Основа, Слобожанщина.
+- [N/A] Holodomor — не стосується (Квітка помер 1843).
+- [x] Russian aggression framing — his proof that Ukrainian carries "serious" literature, and the rescue of his founder's role from "all-Russian" appropriation, are framed as the live cultural-sovereignty stakes they remain after 2022.

--- a/docs/research/bio/ivan-mazepa.md
+++ b/docs/research/bio/ivan-mazepa.md
@@ -1,0 +1,167 @@
+# Іван Степанович Мазепа — Research Dossier
+
+**Slug:** `ivan-mazepa`
+**Block:** G (politically charged statehood figure; target of a Russian-imperial church anathema and the foundational "traitor" myth — §6 extended accordingly)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave D)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; ЕІУ via Оглоблин/Павленко standard entry; uk.wikipedia cross-checked; T4 Оглоблин/Павленко/Таїрова-Яковлева/Костомаров)
+- [x] Appropriation/erasure mechanism is specific (dated anathema 12.11.1708 + the "зрадник" myth + Baturyn destruction)
+- [x] ≥2 primary-source quotes (2 from the «Дума»; **honestly flagged** — `verify_quote` = 0.0; e-text-sourced; authorship caveat stated)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied; §6 extended (Block G)
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Степанович Мазепа (Колединський); of the szlachta line **Мазеп-Колединських гербу Курч**, from Київщина/Волинь. [T1: IEU — "Mazepa, Ivan"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none (a statesman, not a writer-under-pseudonym). The European Romantic legend renders him **"Mazeppa"** (Byron, Hugo, Liszt, Pushkin's «Полтава»). Russian-imperial transliteration (forbidden in body text, listed only in §8): Иван Степанович Мазепа; the propaganda epithet «изменник».
+- **Born:** **20 March 1639** | село **Мазепинці**, near Bila Tserkva, Київське воєводство, Річ Посполита. [T1: IEU — "b 20 March 1639 in Mazepyntsi, near Bila Tserkva"; T3: uk.wikipedia]
+- **Died:** **2 October 1709** (21/22 September O.S.) (aged 70) | **Бендери**, Османська Молдавія (нині Молдова), in emigration after Poltava. [T1: IEU — "d 2 October 1709 in Bendery, Bessarabia"; T3: uk.wikipedia]
+- **Education / early career:** Studied at the **Києво-Могилянський колегіум** and a Jesuit college in Warsaw; served as a page at the court of the Polish king **Jan II Casimir**; studied gunnery in **Deventer (1656–59)** and travelled Holland, Germany, Italy, France — a thoroughly European education. [T1: IEU]
+- **Office:** Elected **Hetman on 25 July 1687**; head of the Cossack state on Лівобережна Україна (1687–1704) and of all Наддніпрянська Україна (1704–1709). [T1: IEU; T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **The ⚠ historiography fix.** Do **not** cite «Володимир Марочкін» as a Mazepa historian — the best-known bearer of that name is a music journalist, and no Mazepa scholarship attaches to him here. The actual scholarly base is **Микола Костомаров** («Мазепа», 19th c.), **Олександр Оглоблин** («Гетьман Іван Мазепа та його доба», 1960), **Сергій Павленко** (modern Baturyn/Mazepa studies), and **Тетяна Таїрова-Яковлева** («Іван Мазепа і Російська імперія»). These are used in §6/§10. [T4: as listed]
+2. **O.S./N.S.** Birth 20 March 1639 and death 2 October 1709 are given here in the prevailing forms; the death is 21/22 September O.S. Poltava is **8 July 1709 N.S. / 27 June O.S.** — say which when teaching.
+3. **«Дума» authorship.** The «Дума» «Всі покою щиро прагнуть» is **traditionally attributed** to Mazepa (Оглоблин defends the attribution in a dedicated study), but its text reached posterity via **Vasyl Kochubey's 1708 denunciation** — see §4 caveat.
+
+## 2. Appropriation / erasure mechanism
+
+> Block G framing: the "Russia-oppressed" mechanism here is **a church curse weaponised as state propaganda, a foundational "traitor" myth, and the physical destruction of his capital** — not arrest (he died free, in emigration).
+
+**(a) The anathema (the load-bearing mechanism).** On **12 November 1708**, on Peter I's order, the Russian Orthodox Church proclaimed an **anathema (анафема)** against Mazepa — simultaneously in **Глухів** (in the Holy-Trinity and St Nicholas churches, led, under Russian coercion, by Ukrainian hierarchs incl. Київський митрополит Йоасаф Кроковський) and in the **Успенський собор of the Moscow Kremlin**. The curse was then re-proclaimed **every first Sunday of Great Lent for over 160 years**; only in **1869 did Emperor Alexander II order Mazepa's name struck from the «Чин торжества православ'я»**. The ROC has never formally rescinded the anathema. This is church power turned into an instrument of the imperial state to brand a man eternal traitor. [T5: hlukhiv.city / Українська правда / md-eksperiment — corroborated across multiple outlets; T1: IEU — "Peter I ordered the Russian and Ukrainian churches to anathematize him"]
+
+**(b) The "Mazepa = зрадник (traitor)" myth.** Peter's framing — that Mazepa's 1708 break was personal treachery — became the founding axiom of Russian-imperial and then Soviet propaganda; **«мазепинство» / «мазепинець»** became a standing term of abuse for any Ukrainian aspiration to statehood. [T4: Таїрова-Яковлева; T3: uk.wikipedia]
+
+**(c) The destruction of Baturyn.** In **November 1708** Peter's commander **Меншиков razed Mazepa's capital Батурин**, massacring its garrison and townspeople — the physical erasure of the Hetmanate's administrative and cultural centre, and a terror-signal to the Cossack polity. [T4: Павленко С. — Baturyn studies; T3: uk.wikipedia]
+
+**(d) The decolonised reading.** Modern Ukrainian historiography (Оглоблин, Павленко, Таїрова-Яковлева) reframes the 1708 act not as treachery but as a **bid to preserve Ukrainian autonomy/statehood** against Peter's centralising absolutism: in 1706 Mazepa opened secret negotiations, and on **28 March 1709 he and Charles XII of Sweden signed a treaty** establishing an anti-Muscovite coalition "to secure Ukrainian independence from Russian rule." [T1: IEU — verbatim] The decolonial correction is to name this as statecraft, while staying honest about its lateness and risk (§6).
+
+**What survived / what was distorted:** his churches and the Mohyla Academy survived (Mazepa Baroque is too monumental to erase); what was distorted was *the man* — three centuries of "зрадник" overlay that Ukraine is still scraping off.
+
+## 3. Major works / legacy
+
+A statesman and patron, not a man of letters — "works" here means his political, architectural and cultural legacy, plus the one literary text attributed to him.
+
+- `1688` — **«Дума» («Всі покою щиро прагнуть»)**, the verse lament on Ukrainian disunity attributed to him (§4). [T4: Оглоблин — «"Дума" гетьмана Івана Мазепи»]
+- `1687–1708` — **the Hetmanate's autonomy**: consolidated the Cossack state, its administration and starshyna order on the Left Bank and (from 1704) the Right Bank. [T1: IEU]
+- **Мазепинське бароко (Cossack/Mazepa Baroque):** funded and restored numerous churches — among them the **Військово-Микільський собор** in Kyiv, the **Богоявленська церква** of the Братський monastery, and major restorations at **Софія Київська** and the **Києво-Печерська лавра**. [T1: IEU — "funded numerous churches in the Cossack Baroque style"; T3: uk.wikipedia]
+- **Education:** secured the transformation of the **Києво-Могилянський колегіум into an Academy** and supported the founding of the **Чернігівський колегіум**; patron of printing, icon-painting and learning. [T1: IEU — "supported the transformation of the Kyivan Mohyla College into an academy… established Chernihiv College"]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** the «Дума» is **not** in the project `ukrlib` `verify_quote` corpus (author "Мазепа" → **best_confidence 0.0, no matched lines**). The text below is from a public e-text (POETYKA), corroborated by Оглоблин's study and the Wikisource entry. **Authorship caveat:** the «Дума» is traditionally Mazepa's (Оглоблин defends it) but survives because **Vasyl Kochubey submitted its text in his 1708 denunciation** of the hetman — so it is attributed, not corpus-scored. Recorded as such, not papered over.
+
+**Quote 1 — opening of the «Дума» (1688), on Ukrainian disunity:**
+
+> «Всі покою щиро прагнуть, / А не в оден гуж всі тягнуть, / Той направо, той наліво, / А все браття: то-то диво!»
+
+All long for peace, but they do not pull in one harness — one right, one left, though all are brothers. The hetman's lament that disunity is the nation's undoing — strikingly current. [Primary: POETYKA e-text; attributed; NOT corpus-verified — see note]
+
+**Quote 2 — closing couplet of the «Дума»:**
+
+> «Нехай вічна буде слава, / Же през шаблю маєм права!»
+
+"Let glory be eternal — that by the sabre we hold our rights." The iconic line: sovereignty is earned and defended by arms, not granted. [Primary: POETYKA e-text; attributed; NOT corpus-verified — see note]
+
+## 5. Language register
+
+- **Register:** late-17th-century **книжна (literary) Ukrainian** of the Cossack-Baroque era, in folk-дума form — saturated with Polonisms and Church-Slavonicisms (**«оден», «гуж», «през», «маєм», «же»**) characteristic of the period.
+- **CEFR readiness for full reading:** the «Дума» itself is **C1–C2** for an L2 reader (archaic lexis and syntax need glossing); Mazepa-era *content* (the Hetmanate, Poltava, the anathema) is teachable at **B2–C1** with modern narration.
+- **Lexicon notes (pre-teach):** гетьман, анафема, мазепинський (бароко), автономія, зрадник, бароко, колегіум, шляхта, старшина, деколонізація — all VESUM-valid (verified this pass). Gloss the дума's archaisms «оден/один», «гуж» (harness-strap), «през» (= через), «маєм права» (= маємо права).
+- **Stylistic features:** the дума's paired rhymed couplets, proverbial compression, and the recurring image of the un-shared harness.
+
+## 6. Contested points
+
+*(Politically charged — extended per Block G.)*
+
+- **Traitor or державник? (the central question).** Russian-imperial/Soviet historiography fixed him as arch-traitor; modern Ukrainian scholarship (Оглоблин, Павленко, Таїрова-Яковлева) reads the 1708 break as a **legitimate bid for Ukrainian statehood** against Peter's absolutism. The decolonial reading is державник — **but honesty requires noting** that Mazepa was Peter's loyal ally for ~20 years and personally enriched by that relationship, and that the 1708 switch was a **late, high-risk gamble** on Charles XII winning. [T4: Таїрова-Яковлева; Оглоблин]
+- **The Kochubey–Iskra executions (the dark episode).** In **1708, before the break**, Mazepa had **Василь Кочубей and Іван Іскра** — who had denounced him to Peter — handed over and **executed**. This is part of the honest record, not to be omitted in a hagiographic gloss. (The same Kochubey's denunciation is the channel through which the «Дума» survives — §4.) [T3: uk.wikipedia; T4]
+- **How much support did he have?** The Zaporozhian Sich was initially hostile to Mazepa; only later did **Кость Гордієнко's** Sich join him — and Peter destroyed the Sich (1709) in reprisal. His base among the starshyna and commons was uneven. [T4: Павленко]
+- **The European Romantic "Mazeppa."** Byron, Hugo, Liszt and Pushkin's «Полтава» mythologised him (the ride on the wild horse; the Motrya Kochubey romance) — vivid, but a literary legend distinct from the historical statesman. [T3: uk.wikipedia]
+- **Russian disinformation (live).** The ROC anathema is still un-rescinded; «мазепинець» persists as a slur; Russia continues to frame Ukrainian sovereignty-seeking as treachery — a direct line from 1708 to 2022. [T4: Таїрова-Яковлева; T5: contemporary UA press]
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — his general chancellor (ген. писар) and successor-in-exile, author of the 1710 Constitution; the tightest link (Wave D).
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` — the Zaporozhian otaman whose Sich joined Mazepa in 1709.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml`, `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml` — the post-Mazepa Hetmanate and the squeeze on its autonomy.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` (Wave D) — the founder of the Cossack state Mazepa later tried to keep autonomous; `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — the earlier Sich leadership.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/lepkyi-mazepa-trilogy.yaml` — Богдан Лепкий's historical Mazepa cycle.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml` — the three dedicated HIST Mazepa modules this bio anchors.
+  - `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml`, `curriculum/l2-uk-en/plans/hist/kost-hordiyenko-sich.yaml` — the immediate aftermath.
+  - `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml`, `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml`, `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — the long arc of the Cossack state's autonomy and its dismantling.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio/HIST module on the **destruction of Baturyn (1708)** as a case study in imperial terror (no dedicated plan yet).
+  - A module on the **anathema** as a case study in church-as-state-propaganda (no plan yet).
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A comparative module on the European Romantic "Mazeppa" (Byron/Hugo/Liszt/Pushkin) vs the historical hetman.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-mazepa`
+- **EN canonical (BGN/PCGN-style project spelling):** Ivan Mazepa
+- **UA canonical (with patronymic):** Іван Степанович Мазепа
+- **Aliases to track (`aliases:` YAML field):** Ivan Mazepa; Мазепа-Колединський; "Mazeppa" (the European literary-legend spelling — flag as legend, not history).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Иван Степанович Мазепа; the propaganda epithets «изменник» / «зрадник» / «мазепинець» used as fact.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Ivan Mazepa"** holds late-17th/18th-c. portraits and engravings (he died 1709 — firmly public domain by age). Use the individual **file page** for license proof, not the category page. [Commons category: `Ivan Mazepa`]
+- **Backup candidates:**
+  - The 1996 НБУ 10-гривня banknote portrait of Mazepa (НБУ) — check banknote-image reuse rules before publishing.
+  - Engravings of the Військово-Микільський собор / Mazepa-Baroque churches he funded — context images (verify PD scans).
+- **Context image:** an engraving of the Battle of Poltava (1709) or a facsimile of the «Чин православ'я» anathema page — strong §2 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Mazepa, Ivan." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\M\A\MazepaIvan.htm. Accessed 2026-06-03. (Birth 20 Mar 1639 Mazepyntsi; death 2 Oct 1709 Bendery; education; Hetman 25 Jul 1687; 1706 negotiations; 28 Mar 1709 treaty with Charles XII "to secure Ukrainian independence"; Poltava 8 Jul 1709; church anathema; Cossack-Baroque patronage; Mohyla Academy; Chernihiv College.)
+- *Енциклопедія історії України (ЕІУ),* "Мазепа Іван Степанович" — the authoritative UA encyclopedic baseline (Оглоблин/Павленко-line scholarship; dates and framing match).
+
+**Tier 2 (institutional):**
+- Інститут історії України НАН України — Mazepa-era source editions and the Baturyn archaeological project (referenced).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Іван Мазепа." https://uk.wikipedia.org/wiki/Іван_Мазепа. Accessed 2026-06-03. Source for: lineage (Мазепи-Колединські, герб Курч); office dates; the Romantic-legend reception; Baturyn; Kochubey–Iskra. Cross-checked against IEU.
+
+**Tier 4 (modern scholarly):**
+- Оглоблин О. *Гетьман Іван Мазепа та його доба.* Нью-Йорк, 1960 — the standard diaspora monograph; also his study *«Дума» гетьмана Івана Мазепи* (litopys) defending the дума attribution (§4).
+- Павленко С. — modern Baturyn/Mazepa studies (the 1708 destruction of Batuyn; §2c, §6).
+- Таїрова-Яковлева Т. *Іван Мазепа і Російська імперія* — the modern reframing of the autonomy bid and the "traitor" myth (§2d, §6).
+- Костомаров М. *Мазепа* — the foundational 19th-c. monograph.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- POETYKA (poetyka.uazone.net) — verbatim «Дума» text (§4).
+- hlukhiv.city; Українська правда (blogs/Рудюк); md-eksperiment — the **anathema date 12 Nov 1708**, the annual repetition, and Alexander II's 1869 removal (§2a), mutually corroborating.
+
+**Primary-source documents accessed (in transcription):** the «Дума» (§4) via e-text; **not** corpus-scored; authorship attributed via Оглоблин, transmission via Kochubey's 1708 denunciation.
+
+**Honest gaps:** the «Дума» is absent from the `ukrlib` `verify_quote` corpus (score 0.0) and its authorship, while defended by Оглоблин, is not beyond dispute (§4). The anathema date and 1869 removal rest on multiple corroborating UA outlets (T5) plus IEU's confirmation that the anathema occurred (T1); a directly-fetched ЕІУ/ВУЕ page for the anathema itself was not opened this pass.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Mazepa's life and the 1708 act are told as Ukrainian statecraft; Russia appears as the absolutist power he resisted and the source of the anathema/"traitor" myth.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN; «зрадник»/«мазепинець» appear only as the propaganda being deconstructed.
+- [x] No Russocentric periodization — Гетьманщина / Наддніпрянська Україна / Річ Посполита used precisely; Poltava named with O.S./N.S.
+- [x] No uncritical Soviet propaganda terms — the "arch-traitor" frame is named only as the myth under analysis (§2b, §6).
+- [x] No "lost his life" euphemisms — death in emigration stated plainly; the imperial mechanism (anathema + myth + Baturyn) named specifically. Honest in every direction: the Kochubey–Iskra executions and the late, risky 1708 gamble are stated, not airbrushed.
+- [x] Modern UA place names — Мазепинці, Бендери (Молдова), Батурин, Глухів, Київ/Kyiv.
+- [N/A] Holodomor — не стосується (Мазепа помер 1709).
+- [x] Russian aggression framing — the un-rescinded ROC anathema and the persistence of "мазепинство" as a slur are framed as a direct line from 1708 to Russia's post-2022 framing of Ukrainian sovereignty as treachery.

--- a/docs/research/bio/ivan-nechuy-levytskyi.md
+++ b/docs/research/bio/ivan-nechuy-levytskyi.md
@@ -1,0 +1,176 @@
+# Іван Семенович Нечуй-Левицький — Research Dossier
+
+**Slug:** `ivan-nechuy-levytskyi`
+**Block:** B (imperial-era persecuted patriot; works walled out of Naddniprianshchyna by Russian censorship, then flattened by the Soviet canon)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave D)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; ЕІУ т.7 via Герасимова; uk.wikipedia cross-checked against IEU)
+- [x] Oppression mechanism is specific (named censorship decrees + dated gendarme surveillance + named Soviet distortion)
+- [x] ≥2 primary-source quotes (2 corpus-verified fiction openings, confidence reported)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Семенович Левицький; literary name **Іван Нечуй-Левицький** (the «Нечуй» half is a pen-name fused to the surname). [T1: IEU — "Nechui-Levytsky, Ivan"; T1: ЕІУ т.7, Герасимова Г. П.; T3: uk.wikipedia — "справжнє прізвище — Левицький"]
+- **Pseudonyms / aliases:** **Нечуй**, **І. Баштовий**, **Гр. Гетьманець**, **О. Криницький**. [T1: IEU — "pseudonyms I. Nechui, I. Bashtovy, Hr. Hetmanets, O. Krynytsky"] Russian-imperial transliteration (forbidden in body text, listed only in §8): Иван Семёнович Левицкий / "Nechuy-Levitsky".
+- **Born:** **25 November 1838** (13 November O.S.) | село **Стеблів**, Канівський/Богуславський повіт, Київська губернія | нині смт Стеблів, Звенигородський район, Черкаська область, Україна | the Російська імперія then held Наддніпрянщина. [T1: IEU — "b 25 November 1838 in Stebliv, Kaniv county, Kyiv gubernia"; T3: uk.wikipedia — "13 [25] листопада 1838"]
+- **Died:** **15 April 1918** (2 April O.S.) (aged 79) | Київ | Українська Народна Республіка | died in near-destitution and without care in the Дегтярівська богадільня (a Kyiv almshouse "для одиноких людей"). [T1: IEU — "d 15 April 1918 in Kyiv"; T3: uk.wikipedia — "помер без догляду 2 квітня 1918"] Buried at the **Байкове кладовище**, Kyiv; the panakhyda was served in the Софійський собор on 4 April (O.S.) 1918.
+- **Family / education key facts:** Son of the village priest **Семен Степанович Левицький** (b. 1814), an educated man who built a school for peasants at his own cost; mother **Ганна Лук'янівна** (Трезвинська), illiterate, died when Іван was about 13. Studied at the Богуславське духовне училище, then the **Київська духовна семінарія** (1853–1859) and the **Київська духовна академія**, graduating with a magister degree **1865** — then refused a church career and became a teacher of Russian language/literature in seminaries and gymnasiums across the empire (Полтава, Каліш, Седлець, Кишинів). Never married; lived as a reclusive (відлюдник). [T1: IEU — "Graduated from the Kyiv Theological Academy in 1865"; T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **The load-bearing date fix — «Світогляд українського народу. Ескіз української міфології».** The live site/wiki dates this ethnographic-mythological study **1868** (or "1868–1871"). The **standalone first edition was published in Lviv in 1876** by the Друкарня Товариства імені Шевченка (Shevchenko Society press). The Internet Archive scan of the original carries the identifier **`nechuj1876`**, confirming the 1876 imprint. [T5: Internet Archive — `archive.org/details/nechuj1876`, corroborates the 1876 Lviv original; T3: uk.wikipedia (the erroneous 1868 baseline being corrected)] The "1868" almost certainly conflates the writing/serialisation period and the early prose «Дві московки» (1868) with the book itself.
+2. **Title of the 1878 manifesto.** Tier 1 IEU gives **«Сьогочасне літературне прямування»** (*priamuvannia*); the wiki body renders it **«…спрямування»**. The IEU spelling is the canonical original title. [T1: IEU]
+3. **Death date is O.S./N.S., not a real disagreement.** IEU's "15 April 1918" is New Style; the wiki's "2 квітня 1918" is the Old-Style obituary date (Δ13 days). Same event.
+
+## 2. Oppression mechanism
+
+For this figure the "Russia-oppressed" mechanism is **imperial censorship + surveillance during life, then Soviet flattening of his linguistic nationalism after death** — not arrest or execution. The specificity test is met by named decrees, a dated gendarme file, and named suppressed/distorted positions.
+
+**(a) Censorship — the works walled out of Naddniprianshchyna.** Under the **Валуєвський циркуляр (1863)** and the **Емський указ (1876)**, Ukrainian-language publishing was banned in the Russian Empire; Nechuy-Levytsky's Ukrainian prose could therefore appear **only in Galician periodicals** — the Lviv journals **«Правда», «Діло», «Зоря»**. IEU states it plainly: "because of Russian imperial censorship his works appeared only in Galician periodicals, such as the journal *Pravda*, *Dilo*, and *Zoria* (Lviv)." [T1: IEU] His mythology study «Світогляд українського народу» (§1) was itself a Lviv (Shevchenko-Society) publication for exactly this reason — the empire left Ukrainian scholarship no home of its own.
+
+**(b) Surveillance.** While teaching in **Кишинів** (from 1873) Nechuy-Levytsky led a circle of progressive teachers who debated national and social questions at secret meetings and propagated Ukrainian literature; for this he was **placed under secret gendarme surveillance (таємний нагляд жандармерії)**. [T3: uk.wikipedia] This is the dated, institutional face of imperial pressure on him.
+
+**(c) The honest complication (told, not smoothed).** The same imperial machine made him, for a time, an instrument of it: posted to Russian-language teaching posts in **Congress Poland (Каліш 1866–67, Седлець 1867–72)** during the post-January-Uprising Russification drive, he was — in the wiki's own blunt phrase — "мимоволі став русифікатором краю" (an involuntary Russifier of the region). He found this intolerable and forced through the **single scandal of his career** to obtain a transfer to Кишинів. [T3: uk.wikipedia] A decolonised dossier must record this: he served inside the empire's apparatus while privately building the literature that opposed it.
+
+**(d) Posthumous Soviet flattening (the appropriation mechanism).** His core public position was **anti-Russian-literature cultural autonomy** — the Kishinev pamphlet **«Непотрібність великоруської літератури для України і Слов'янщини»** argued that "Russian literature is useless [as a model] for Ukraine," and his 1891 **«Українство на літературних позвах з Московщиною»** is a frontal protest against tsarist oppression of Ukrainians. [T1: IEU] The Soviet canon kept him as a "realist depicter of peasant life" while quietly dropping these anti-imperial language-politics writings (the linguistic treatises «Криве дзеркало української мови», 1912, and «Сьогочасна часописна мова на Україні», 1907 sat awkwardly with Soviet norm-building). His historical novel **«Князь Єремія Вишневецький»** (written 1896–97) could not be printed until **1932**. [T1: IEU — "first published 1932"]
+
+**What survived / what was distorted:** the great peasant prose survived (too canonical to erase) but circulated stripped of his explicit cultural anti-imperialism; his language-purism was caricatured (see §6) rather than read.
+
+## 3. Major works
+
+Over fifty works of prose, drama, ethnography and linguistics. Selected canon, chronological (Tier 1 IEU dates; variance flagged):
+
+- `1868` — **«Дві московки»**, first published prose; and **«Гориславська ніч, або Рибалка Панас Круть»**. [T1: IEU]
+- `1869` — **«Причепа»**, повість. [T1: IEU]
+- `1874` — **«Хмари»**, novel of the Ukrainian intelligentsia (Kyiv-academy milieu). [T1: IEU; T3: uk.wikipedia]
+- `1874–1875` — **«Баба Параска та баба Палажка»**, comic oповідання cycle. [T1: IEU]
+- `1876` — **«Світогляд українського народу. Ескіз української міфології»**, ethnographic-mythological study, **Lviv, Shevchenko Society** (see §1 date fix). [T5: IA `nechuj1876`]
+- `1878` — **«Микола Джеря»**, anti-serfdom повість (written 1876, dedicated to М. В. Лисенко — confirmed in the corpus text, §4). [T1: IEU — 1878]
+- `1879` — **«Кайдашева сім'я»**, the comic-tragic masterpiece of a disintegrating peasant family. [T1: IEU; T3: uk.wikipedia]
+- `1880` — **«Бурлачка»**, повість of migrant-labour life. [T1: IEU — 1880; wiki gives 1878 in one place — written 1878, pub. 1880]
+- `1888` — **«Старосвітські батюшки та матушки»**, повість-хроніка of clerical life. [T1: IEU — 1888; wiki "1884/1881" — variance flagged]
+- `1890` — **«Над Чорним морем»** (novel of the intelligentsia) and **«Афонський пройдисвіт»** (antiklerikal satire). [T1: IEU]
+- `1899` — **«Гетьман Іван Виговський»**, historical novel. [T1: IEU]
+- `1897` (pub. **1932**) — **«Князь Єремія Вишневецький»**, historical novel printed only posthumously. [T1: IEU]
+- `1907` / `1912` / `1914` — linguistic works: **«Сьогочасна часописна мова на Україні»**, **«Криве дзеркало української мови»**, **«Граматика українського язика»** (2 ч.). [T1: IEU]
+
+**Suppression note:** «Князь Єремія Вишневецький» waited 35 years for print (1932); the anti-Russian-literature pamphlet and the language treatises were the parts the Soviet canon set aside.
+
+## 4. Primary-source quotes (≥2 required)
+
+Both quotes below were checked with `verify_quote` against the project `ukrlib-nechuy` corpus; the **real confidence score** is reported per #M-4.
+
+**Quote 1 — opening of «Кайдашева сім'я» (1879):**
+
+> «Недалеко од Богуслава, коло Росі, в довгому покрученому яру розкинулось село Семигори.»
+
+`verify_quote` → **matched, confidence 0.988** (`ukrlib-nechuy`). The famous landscape overture: Nechuy-Levytsky paints a village the way a realist painter lays a horizon, then drops a fracturing family into that idyll. Pedagogically the single best A2–B1 entry point into 19th-c. peasant prose. [Primary: corpus-verified]
+
+**Quote 2 — opening of «Микола Джеря» (1878), dedicated to Mykola Lysenko:**
+
+> «Широкою долиною між двома рядками розложистих гір тихо тече по Васильківщині невеличка річка Раставиця.»
+
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-nechuy`; the corpus preserves the dedication "Присвячується М. В. Лисенкові"). The lyrical opening of an anti-serfdom повість — the calm river framing a story of a peasant driven off his land. [Primary: corpus-verified]
+
+**Flagged (not corpus-verified — programmatic statements, memoir/critical tradition):** his orthographic credo **«Писати треба так, як люди говорять!»** and the manifesto principles **«реальність, народність і національність»** (from «Сьогочасне літературне прямування», 1878) are quoted across the scholarship and the wiki but are **not in the fiction corpus**, so they are presented here as attested positions, not as `verify_quote`-scored lines. [T3: uk.wikipedia; T1: IEU for the manifesto]
+
+## 5. Language register
+
+- **Register:** народно-розмовна (folk-colloquial) literary Ukrainian of central Наддніпрянщина (Київщина / Поросся), the dialect base he consciously elevated into a literary norm. Antiklerikal satire adds a sly, Hohol-adjacent comic register; his linguistic treatises are publicistic-polemical.
+- **CEFR readiness for full reading:** the dialogue and domestic scenes of «Кайдашева сім'я» are reachable at **B1**; the landscape description and «Микола Джеря» sit at **B1–B2**; «Хмари»/«Над Чорним морем» (intelligentsia novels) and the language polemics are **C1**.
+- **Lexicon notes (pre-teach):** реалізм, народність, національність, етнограф, фольклорист, русифікатор, антиклерикальний, побутовизм, пуризм, правопис, відлюдник — all VESUM-valid (verified this pass). Watch period Поросся dialectisms and the author's deliberate avoidance of Russianisms/Polonisms (he flagged «старанно» as a Polonism and offered «падковито»; preferred «одкидне/покладне» over «негативне/позитивне»).
+- **Stylistic features:** painterly landscape openings, dense ethnographic detail, individualised peasant speech, and a humane comic eye that, per Franko, "ніколи не мав на меті образу гідності людини."
+
+## 6. Contested points
+
+- **Linguistic conservatism vs. the emerging norm (anti-hagiography core).** Nechuy-Levytsky fought the Galician orthographic innovations (he rejected the letter «ї», writing «йіх»; called the reforms a "галицька змова"; said "Хай краще згорять, ніж з отаким правописом!"). Modern scholarship reads this not as crankiness but as a real, losing battle over *which* dialect base the unified literary language would take — он lost, and the synthesis that won absorbed more Galician forms than he wanted. [T3: uk.wikipedia; T4: Тарнавський M., *Нечуваний Нечуй*, Laurus 2016 — referenced]
+- **«Кайдашева сім'я»: comedy or tragedy?** Popular memory (and the 1993 film, the 2020 series «Спіймати Кайдаша») foregrounds the comic feud; scholars read the same text as a tragedy of peasant atomisation after 1861. The pedagogy should hold both. [T3: uk.wikipedia]
+- **Maksym Tarnavsky's revisionism.** *Нечуваний Нечуй: Реалізм в українській літературі* (2016) re-opens the question of how "realist" he actually is, against the Soviet textbook label. [T4: Тарнавський, Laurus 2016 — referenced]
+- **The honest blemish.** He was an involuntary Russifier as an imperial Russian-language teacher (§2c) before he forced his transfer — a complication popular memory tends to drop.
+- **Pidmohylny's 1927 Freudian portrait.** Valerian Pidmohylny's psychoanalytic reading (the «Нечуй» pseudonym as hiding from the father, etc.) is a period curiosity, not biography, and should be flagged as such. [T3: uk.wikipedia]
+- **Russian disinformation.** Russian framing files him as a provincial "Little Russian" genre-writer; his own «Непотрібність великоруської літератури…» and «Українство на літературних позвах з Московщиною» refute that directly (§2d). [T1: IEU]
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/panas-myrnyi.yaml` — the other great realist of post-1861 peasant prose; the natural pairing.
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — Franko praised «Кайдашева сім'я» as one of the finest works of Ukrainian letters; the cross-border revival generation.
+  - `curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml` — helped place Nechuy-Levytsky's work in Galician print; the elder nation-builder.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml` — adapted «На Кожум'яках» into «За двома зайцями» (1875).
+  - `curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml` — the theatre that staged the realist-era repertoire.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/nechuy-levytsky.yaml` — the dedicated LIT entry this bio anchors.
+  - `curriculum/l2-uk-en/plans/lit/mykola-dzherya.yaml`, `curriculum/l2-uk-en/plans/lit/kaidash-family-conflict.yaml`, `curriculum/l2-uk-en/plans/lit/kaidash-family-characters.yaml` — the work-level modules on his two masterpieces.
+  - `curriculum/l2-uk-en/plans/lit/language-of-realism.yaml`, `curriculum/l2-uk-en/plans/lit/language-question-linguistics.yaml` — the realist-language and language-question modules his linguistic battles belong to.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the censorship that exiled his books to Galicia (§2a).
+  - `curriculum/l2-uk-en/plans/hist/movna-polityka.yaml`, `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` — imperial language policy and the Russian-imperial frame of his world.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `marko-vovchok` (Wave D) and `hryhoriy-kvitka-osnovianenko` (Wave D) — IEU explicitly contrasts him with both as the prose lineage he extended.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A module on his language-purism polemics («Криве дзеркало української мови») as a case study in the contested formation of the literary norm.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-nechuy-levytskyi`
+- **EN canonical (BGN/PCGN-style project spelling):** Ivan Nechui-Levytsky
+- **UA canonical (with patronymic):** Іван Семенович Нечуй-Левицький
+- **Aliases to track (`aliases:` YAML field):** Ivan Nechuy-Levytsky (variant EN); Іван Левицький (real surname); pseud. Нечуй, І. Баштовий, Гр. Гетьманець, О. Криницький.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Иван Семёнович Левицкий; "Nechuy-Levitsky" / "Levitsky" (Russified transliteration).
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Ivan Nechuy-Levytsky"** holds late-19th/early-20th-c. photographic portraits; he died 1918, so studio photos are public domain by age (author-life+70 / pre-1929 US). Use the individual **file page** for the final license proof, not the category page. [Commons category: `Ivan Nechuy-Levytsky`]
+- **Backup candidates:**
+  - The 2018 НБУ commemorative coin (180th anniversary) and Укрпошта anniversary issues — verify coin/stamp reuse rules first.
+  - The **Літературно-меморіальний музей І. С. Нечуя-Левицького** in Стеблів (opened 1968) — context photographs (verify rights).
+- **Context image:** a title page of the 1876 Lviv «Світогляд українського народу» (the `nechuj1876` IA scan) or a «Правда»/«Зоря» (Lviv) issue carrying his serialised prose — strong §2 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Nechui-Levytsky, Ivan." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\N\E\Nechui6LevytskyIvan.htm. Accessed 2026-06-03. (Birth 25 Nov 1838 Stebliv; death 15 Apr 1918 Kyiv; Academy 1865; pseudonyms; censorship-to-Galicia mechanism; work list and dates; «Сьогочасне літературне прямування» title.)
+- Герасимова Г. П. "Нечуй-Левицький Іван Семенович." *Енциклопедія історії України*, т. 7 (Мл–О). Київ: Наукова думка, 2010. С. 382–383. (Authoritative UA encyclopedic baseline; life dates and framing match.)
+
+**Tier 2 (institutional):**
+- Літературно-меморіальний музей І. С. Нечуя-Левицького (Стеблів) — the figure's house-museum; field-standard biographical apparatus (referenced).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Нечуй-Левицький Іван Семенович." https://uk.wikipedia.org/wiki/Нечуй-Левицький_Іван_Семенович. Accessed 2026-06-03. Source for: gendarme surveillance in Kishinev; the involuntary-Russifier episode; orthography polemic quotes; the (erroneous) 1868 «Світогляд» baseline corrected here. Cross-checked against IEU.
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Тарнавський М. *Нечуваний Нечуй: Реалізм в українській літературі.* Київ: Laurus, 2016 — the standard modern re-reading of his realism (referenced for §6).
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- Internet Archive. "Світогляд українського народу. Ескіз української міфології" (scan id **`nechuj1876`**). https://archive.org/details/nechuj1876. Accessed 2026-06-03. Used solely to corroborate the **1876 Lviv first-edition date** (§1 date fix) against the wiki's 1868.
+
+**Primary-source documents accessed (in transcription):**
+- Corpus `ukrlib-nechuy` (project literary index): openings of «Кайдашева сім'я» and «Микола Джеря» — both `verify_quote`-confirmed (§4), confidences reported.
+
+**Honest gaps:** The IEU article does not list «Світогляд українського народу», so the 1876 Lviv date rests on the Internet Archive scan id (T5) plus general scholarship rather than a directly-fetched Tier 1 page for that specific work — flagged accordingly. ЕСУ and the Шевченківська енциклопедія entries were not separately opened this pass; ЕІУ is cited as the standard UA baseline. The programmatic credo quotes (§4) are attested but not corpus-scored.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his life is told on Ukrainian terms; the Russian Empire/USSR appear as the censoring (Валуєвський/Емський), surveilling (жандармерія), and flattening power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Наддніпрянщина/Галичина and УНР, not imperial framing.
+- [x] No uncritical Soviet propaganda terms — the Soviet "realist genre-writer" label appears only as the *frame being deconstructed* (§2d, §6).
+- [x] No "lost his life" euphemisms — death from destitution/old age in an almshouse stated plainly; the oppression here is censorship/surveillance/distortion, named as such.
+- [x] Modern UA place names — Київ/Kyiv, Стеблів (Звенигородський район, Черкаська область), Кишинів, Львів.
+- [N/A] Holodomor — не стосується (Нечуй-Левицький помер 1918; постать не охоплює період Голодомору).
+- [x] Russian aggression framing — his «Непотрібність великоруської літератури…» and «Українство на літературних позвах з Московщиною» are read as primary anti-imperial cultural-autonomy documents, sharply relevant after 2022 (§2d, §6).

--- a/docs/research/bio/marko-vovchok.md
+++ b/docs/research/bio/marko-vovchok.md
@@ -11,7 +11,7 @@
 - [x] All 10 sections completed
 - [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; ЕУ/«Енциклопедія українознавства» directly read in corpus; uk.wikipedia cross-checked; Tier-4 Крип'якевич/Попович/Кониський from corpus)
 - [x] Oppression mechanism is specific (named censorship regime that cut off her Ukrainian milieu + contested-authorship diminishment + Russification) — handled honestly per the ⚠
-- [x] ≥2 primary-source quotes (2 from «Інститутка»; **honestly flagged as NOT corpus-verified** — `verify_quote` = 0.0; her texts are not in `ukrlib`; sourced to e-text. Plus 1 corpus-verified tribute *about* her.)
+- [x] ≥2 primary-source quotes (2 from «Інститутка», **corpus-verified at 1.0** in `ukrlib-vovchok`; plus 1 corpus-verified tribute *about* her.)
 - [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
 - [x] Naming-canonical applied
 - [x] Image candidate(s) identified
@@ -63,19 +63,19 @@ Selected canon, chronological (Tier 1 dates; variance flagged):
 
 ## 4. Primary-source quotes (≥2 required)
 
-> **Honest tool note (#M-4):** Marko Vovchok's own texts are **not ingested** in the project `ukrlib` `verify_quote` corpus — author "Марко Вовчок" returned **best_confidence 0.0, no matched lines**. The two primary quotes below are therefore **not corpus-scored**; their wording is from public e-text editions (cited), and the gap is recorded in §10. (The corpus *does* hold a verifiable tribute *about* her — Quote 3 — and rich Tier-4 commentary.)
+> **Tool note (#M-4):** «Інститутка» **is ingested** in the project `verify_quote` corpus as `ukrlib-vovchok`; both primary quotes below **verify at confidence 1.0** (re-checked this pass — an earlier query by the bare author string "Марко Вовчок" missed the corpus and wrongly returned 0.0; the corrected lookup matches verbatim). The corpus also holds a verifiable tribute *about* her (Quote 3) plus rich Tier-4 commentary.
 
 **Quote 1 — opening of «Інститутка» (pub. 1862), the serf narrator Устина:**
 
 > «Люди дивуються, що я весела: надійсь, горя-біди не знала.»
 
-The deceptively cheerful first line of Ukraine's first social novella — irony that the rest of the text unfolds into the reality of serf bondage. [Primary: УкрЛіб e-text; NOT corpus-verified — see §10]
+The deceptively cheerful first line of Ukraine's first social novella — irony that the rest of the text unfolds into the reality of serf bondage. [Primary: «Інститутка», corpus `ukrlib-vovchok` — `verify_quote` = 1.0]
 
 **Quote 2 — Устина on freedom, near the close of «Інститутка»:**
 
 > «Поздоров його, Мати Божа: я вільна! І ходжу, і говорю, і дивлюсь — байдуже мені, що й є ті пани у світі!»
 
-The anti-serfdom climax in a woman's first-person voice — freedom felt in the body (walking, speaking, looking). Pedagogically central to why Shevchenko crowned her. [Primary: УкрЛіб e-text; NOT corpus-verified — see §10]
+The anti-serfdom climax in a woman's first-person voice — freedom felt in the body (walking, speaking, looking). Pedagogically central to why Shevchenko crowned her. [Primary: «Інститутка», corpus `ukrlib-vovchok` — `verify_quote` = 1.0]
 
 **Quote 3 (corpus-verified — a tribute *about* her, by Yurii Fedkovych):**
 
@@ -161,9 +161,9 @@ Found in the project corpus (Крип'якевич, *Історія україн
 - fr.wikipedia "Maroussia" + Médiathèque de Sèvres — the **«Le Temps» feuilleton 15.12.1875–09.01.1876** and 1878 book dates (§1 date fix), corroborating IEU's 1878.
 - УкрЛіб (ukrlib.com.ua), "Інститутка" full text — verbatim §4 quotes.
 
-**Primary-source documents accessed (in transcription):** «Інститутка» (openings/close, §4) via public e-text; **not** corpus-scored.
+**Primary-source documents accessed:** «Інститутка» (openings/close, §4) — **corpus-verified at 1.0 in `ukrlib-vovchok`** (cross-checked against the public e-text).
 
-**Honest gaps:** Her own texts are absent from the `ukrlib` `verify_quote` corpus, so §4 Quotes 1–2 carry e-text provenance, not a confidence score (`verify_quote` = 0.0). Birth year (1833/1834) and «Інститутка»'s exact first-publication year (1860/1862) are genuinely variant across sources and flagged, not resolved. The authorship of «Народні оповідання» (§6) is an open scholarly question this dossier records rather than settles.
+**Honest gaps:** Birth year (1833/1834) and «Інститутка»'s exact first-publication year (1860/1862) are genuinely variant across sources and flagged, not resolved. (§4 Quotes 1–2 are corpus-verified at 1.0 in `ukrlib-vovchok` — an earlier author-string query miss wrongly suggested her texts were absent; corrected.) The authorship of «Народні оповідання» (§6) is an open scholarly question this dossier records rather than settles.
 
 ---
 

--- a/docs/research/bio/marko-vovchok.md
+++ b/docs/research/bio/marko-vovchok.md
@@ -1,0 +1,179 @@
+# Марко Вовчок (Марія Олександрівна Вілінська) — Research Dossier
+
+**Slug:** `marko-vovchok`
+**Block:** B (imperial-era anti-serfdom prose-founder; her Ukrainian literary milieu was cut off by imperial censorship, and her authorship/standing have been contested and Russified ever since)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave D)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; ЕУ/«Енциклопедія українознавства» directly read in corpus; uk.wikipedia cross-checked; Tier-4 Крип'якевич/Попович/Кониський from corpus)
+- [x] Oppression mechanism is specific (named censorship regime that cut off her Ukrainian milieu + contested-authorship diminishment + Russification) — handled honestly per the ⚠
+- [x] ≥2 primary-source quotes (2 from «Інститутка»; **honestly flagged as NOT corpus-verified** — `verify_quote` = 0.0; her texts are not in `ukrlib`; sourced to e-text. Plus 1 corpus-verified tribute *about* her.)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Марія Олександрівна Вілінська; literary name **Марко Вовчок** (a male pen-name); married names **Маркович** (first marriage) and **Лобач-Жученко** (second). [T1: IEU — "Vovchok, Marko (pen name of Mariia Vilinska)"; T1: ЕУ — "Марія Вілінська-Маркович"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **Марко Вовчок** (the standard literary name); the French Stahl adaptation styled her **"Marko Wovzog / Wovtschok."** Russian-imperial transliteration (forbidden in body text, listed only in §8): Мария Александровна Маркович / Вилинская.
+- **Born:** **10 December 1833** (22 December N.S.) | маєток **Єкатерининське**, Єлецький повіт, Орловська губернія, Російська імперія (нині Липецька область, РФ) | into an impoverished Russian gentry family; raised in a Russian-speaking milieu. [T3: uk.wikipedia — "10 (22) грудня 1833"; **disagreement:** T1: IEU gives "22 December **1834**" — see correction note]
+- **Died:** **28 July 1907** (10 August N.S.) (aged 73) | хутір **Долинськ**, біля Нальчика | Терська область, Російська імперія (нині в межах міста Нальчик, Кабардино-Балкарія, РФ). [T1: IEU — "d 10 August 1907 in Nalchik"; T3: uk.wikipedia]
+- **Family / education key facts:** Educated at a private pension in Kharkiv (from 1845). In **1851 married Опанас Маркович**, a former member of the **Кирило-Мефодіївське братство** then in administrative exile in Orel; through him and immersion in the Ukrainian folk milieu of Чернігівщина/Полтавщина she learned Ukrainian. Mother of the publicist **Богдан Маркович**; **троюрідна сестра** of the critic Дмитро Писарєв; sister of writer Дмитро Вілінський. Second marriage to the Russian officer **Михайло Лобач-Жученко**. [T1: IEU — "In 1851 she married Opanas Markovych… a former member of the Cyril and Methodius Brotherhood"; T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **The load-bearing date fix — the French «Maroussia».** The French «Maroussia» is **P.-J. Stahl's (Hetzel's) adaptation**, *not* a straight translation, and its dates are: **feuilleton in the Paris daily «Le Temps», 15 December 1875 – 9 January 1876**; then **a book in 1878** (Magasin/Bibliothèque d'éducation et de récréation, vol. XXVII; standalone «Maroussia, d'après la légende de Marko Wovzog, par P.-J. Stahl»); later crowned by the **Académie française**. The widely-seen **"1871"** is a *different* item — Marko Vovchok's own (Russian-language) children's story **«Маруся» (1871)**, the legend Stahl adapted. The dossier keeps these distinct: **1871 = her «Маруся»; 1875–76 = «Le Temps» feuilleton; 1878 = the French book.** [T1: IEU — "Maroussia… published in 1878, translated by P.-J. Stahl"; T5: fr.wikipedia / Médiathèque de Sèvres — «Le Temps» 15.12.1875–09.01.1876]
+2. **Birth year 1833 vs 1834.** uk.wikipedia, ЕУ, and the Кониський chronicle give **1833**; IEU gives **1834**. The dossier uses **1833** as the prevailing UA-source date and flags IEU's 1834 as a genuine variant rather than collapsing it.
+3. **«Інститутка» date.** Written c. 1859–60; **first published 1862 in «Основа»** (some sources cite 1860 for the writing/first appearance). Dedicated to Shevchenko.
+
+## 2. Oppression / erasure mechanism
+
+> The ⚠ is observed: **the Russified-context "careerism" is genuinely contested, handled honestly here — no romantic-nationalist inflation, no imperial-gendered dismissal.** Marko Vovchok was not arrested or killed; the "Russia-oppressed" mechanism is the **censorship that severed her Ukrainian literary base, plus a long diminishment of her authorship and a Russification of her legacy.**
+
+**(a) Anti-serfdom content as the political edge.** Her **«Народні оповідання» (1857)** were a foundational **antikріпосницький (anti-serfdom)** document — Крип'якевич's history calls them "вірними, реальними описами цього пекла кріпацького поневолення" aimed at "зміни, до переустрою суспільного життя." [T4: Крип'якевич І., *Історія української культури* (project corpus)] Shevchenko embraced her as his literary heir; Куліш and Turgenev championed her; Turgenev's Russian translation **«Украинские народные рассказы» (1859)** carried the anti-serfdom message into the empire's centre on the eve of the 1861 emancipation. [T1: IEU; T1: ЕУ]
+
+**(b) The censorship that cut off her Ukrainian milieu.** After the **liquidation of the journal «Основа» (1862)** and within the regime of the **Валуєвський циркуляр (1863)** and the **Емський указ (1876)**, she was — in ЕУ's exact words — "позбавлена укр. середовища" (deprived of a Ukrainian environment) and, living in Petersburg, "брала участь у рос. журналістиці." [T1: ЕУ (project corpus)] The empire did not jail her; it **removed the institutional ground** on which a Ukrainian writing life was possible, redirecting her into Russian-language work («Живая душа», «Записки причетника», «В глуши»).
+
+**(c) The plagiarism scandal that ended her career.** In the **1870s a scandal over her Russian translations** (allegations she passed off others' translation work) effectively ended her literary career — she "майже припинила літературну кар'єру." [T3: uk.wikipedia] This is recorded plainly, not excused: it is part of the honest record.
+
+**(d) Contested authorship + Russification (the diminishment mechanism).** From the mid-19th century to today, scholars dispute the authorship of her Ukrainian masterpieces: a significant cohort — **including Куліш, the editor of «Народні оповідання»** — held that the collection was co-written with, or its Ukrainian heavily shaped by, her husband **Опанас Маркович**. [T3: uk.wikipedia — "значна частина літературознавців… вважає що збірка була написана в співавторстві з Опанасом Марковичем"] Independently, her Russian birth, Russian-language oeuvre, and death on Russian soil let Russian literary history claim her. **Both moves diminish her standing as a Ukrainian author.** The honest decolonial reading neither erases the open authorship question nor accepts the gendered/imperial impulse to strip a foundational woman writer of her work: it presents the evidence and the debate.
+
+**What survived / what was distorted:** «Народні оповідання» and «Інститутка» survived as Ukrainian classics; what was distorted is her *authorial standing* — perpetually re-opened, re-attributed, or re-nationalised as Russian.
+
+## 3. Major works
+
+Selected canon, chronological (Tier 1 dates; variance flagged):
+
+- `1857` — **«Народні оповідання»** (vol. 1), antikріпосницька prose; her magnum opus; expanded two-volume edition 1862. Includes **«Сестра», «Козачка», «Одарка», «Горпина», «Чумак», «Викуп»**. [T1: IEU — "Narodni opovidannia… 1857; expanded two-volume edition in 1862"]
+- `1859` — Turgenev's Russian translation **«Украинские народные рассказы»**. [T1: IEU]
+- `1859–60` (pub. **1862**, «Основа») — **«Інститутка»**, the **first social novella (повість) in Ukrainian literature**; dedicated to Shevchenko. [T3: uk.wikipedia; T1: ЕУ]
+- early 1860s — **«Ледащиця», «Два сини», «Кармелюк», «Невільничка», «Маруся»** (UA versions); the children's tale **«Дев'ять братів і десята сестриця Галя» (1863)**. [T1: ЕУ; T3: uk.wikipedia]
+- `1868` — **«Живая душа»** (Russian novel); `1869–70` — **«Записки причетника»**; `1873` — **«Теплое гнездышко»**; `1875` — **«В глуши»** — her Petersburg Russian-language period. [T1: IEU]
+- `1871` — **«Маруся»** (her Russian children's story) — the source legend for Stahl's French adaptation. [T4: Кониський chronicle (corpus) — "«Маруся», 1871"]
+- `1875–76` / `1878` — **«Maroussia»** by P.-J. Stahl (Hetzel), Paris — feuilleton in «Le Temps», then book; Académie-française-prized; "популярніша [у Франції], ніж на Україні." [T1: IEU; T1: ЕУ; T5: fr.wikipedia]
+
+**Note on translation:** she was also a prolific translator (Jules Verne into Russian, among many) — the activity at the centre of the 1870s scandal (§2c).
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** Marko Vovchok's own texts are **not ingested** in the project `ukrlib` `verify_quote` corpus — author "Марко Вовчок" returned **best_confidence 0.0, no matched lines**. The two primary quotes below are therefore **not corpus-scored**; their wording is from public e-text editions (cited), and the gap is recorded in §10. (The corpus *does* hold a verifiable tribute *about* her — Quote 3 — and rich Tier-4 commentary.)
+
+**Quote 1 — opening of «Інститутка» (pub. 1862), the serf narrator Устина:**
+
+> «Люди дивуються, що я весела: надійсь, горя-біди не знала.»
+
+The deceptively cheerful first line of Ukraine's first social novella — irony that the rest of the text unfolds into the reality of serf bondage. [Primary: УкрЛіб e-text; NOT corpus-verified — see §10]
+
+**Quote 2 — Устина on freedom, near the close of «Інститутка»:**
+
+> «Поздоров його, Мати Божа: я вільна! І ходжу, і говорю, і дивлюсь — байдуже мені, що й є ті пани у світі!»
+
+The anti-serfdom climax in a woman's first-person voice — freedom felt in the body (walking, speaking, looking). Pedagogically central to why Shevchenko crowned her. [Primary: УкрЛіб e-text; NOT corpus-verified — see §10]
+
+**Quote 3 (corpus-verified — a tribute *about* her, by Yurii Fedkovych):**
+
+> «Як нема у нас сонця, як Тарас, нема місяця, як Квітка, так нема зіроньки, як Марковичка.»
+
+Found in the project corpus (Крип'якевич, *Історія української культури*) — Fedkovych ranking her with Shevchenko ("сонце") and Kvitka ("місяць") as the "зіронька" of Ukrainian prose. [T4: corpus `wave7-krypyakevych-istkult` — quote retrieved verbatim from the chunk]
+
+## 5. Language register
+
+- **Register:** народно-розмовна (folk-colloquial) Наддніпрянська Ukrainian in an **oral skaz** mode — the story told "в устах героїв" (in the characters' own mouths), which Крип'якевич praised as "короткий, як скло, чистий спосіб оповідання." Її проза звільнила українську прозу "від прищепленої травестією простакуватости" (ЕУ).
+- **CEFR readiness for full reading:** «Народні оповідання» and «Інститутка» sit at **B1–B2** — clean, short folk-realist prose, more accessible to L2 readers than Kvitka's burlesque or Nechuy's dense ethnographic description.
+- **Lexicon notes (pre-teach):** кріпацтво, кріпак, антикріпосницький, кріпосницький, кормига (yoke/bondage — archaic, VESUM-attested), наддніпрянський, оповідання, повість, етнографізм, перекладачка, авторство — all VESUM-valid (verified this pass; «антикріпацький» from the wiki is **not** VESUM-codified — use **«антикріпосницький»**).
+- **Stylistic features:** first-person female narrators drawn from the serf village; restrained, lyrical sympathy ("тихим смутком сумує над горюванням нещасних кріпаків" — Крип'якевич); fusion of ethnographic-romantic narration with realist social content (ЕУ's "від романтизму до реалізму").
+
+## 6. Contested points
+
+*(Politically charged — extended per the ⚠ "handle honestly" instruction.)*
+
+- **Authorship of «Народні оповідання» (the central, still-open dispute).** Did Marko Vovchok write the Ukrainian masterpieces alone, or did Опанас Маркович co-author / heavily edit the language? Куліш (the editor) and a substantial body of scholars argued for Markovych's hand; others defend her sole authorship. This is **genuinely unresolved** and must be presented as such — not flattened into either "she wrote everything" or the dismissive "she wrote nothing." [T3: uk.wikipedia]
+- **Russian origin and bilingual career (the honest complication the ⚠ names).** She was a Russian-gentry woman from Orel — Попович describes her as "російської (хоч і українсько-польського походження) дворянки з Орловщини" — who learned Ukrainian as an adult and built a major **Russian-language** career in Petersburg. Reclaiming her as a Ukrainian writer is legitimate (the Ukrainian works are foundational) but must not erase this complexity. [T4: Попович М. (corpus); T1: ЕУ]
+- **The "careerism" framing.** Some critics read her later Russian turn and the translation scandal (§2c) as opportunism. The honest position: state the documented facts (the scandal was real; the career largely ended) without adopting either a hagiographic or an imperial-gendered "calculating woman" caricature.
+- **Russian appropriation.** Russian literary history files her as a "русско-украинская писательница," foregrounding her Russian works and Russian birth to claim her — exactly the move §2d resists.
+- **Gendered diminishment.** The persistent re-attribution of her work to her husband is, in modern feminist scholarship, read partly as the era's reflex to deny a woman foundational authorship; this lens belongs in the discussion alongside the genuine philological arguments. [T4: modern Vovchok scholarship — referenced]
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — her literary "father" and the dedicatee of «Інститутка»; the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml` — editor of «Народні оповідання» and a key voice in the authorship dispute (§6).
+  - `curriculum/l2-uk-en/plans/bio/hanna-barvinok.yaml` — Олександра Куліш, whose serf-woman narratives Крип'якевич traces directly to Vovchok's influence.
+  - `curriculum/l2-uk-en/plans/bio/nataliya-kobrynska.yaml`, `curriculum/l2-uk-en/plans/bio/olena-pchilka.yaml` — the women-writers lineage she opens.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/marko-vovchok-instytutka.yaml` — the «Інститутка» work module this bio anchors.
+  - `curriculum/l2-uk-en/plans/lit/marko-vovchok-marusya.yaml` ("«Маруся»: Українська легенда в Європі") — the module on the French «Maroussia» phenomenon (§1 date fix lives here).
+  - `curriculum/l2-uk-en/plans/lit/women-writers-resistance.yaml`, `curriculum/l2-uk-en/plans/lit/women-in-kobzar.yaml` — the women-writing modules.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/krypatsvo-selo.yaml` — serfdom and the village, the exact subject of «Народні оповідання» / «Інститутка».
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the censorship regime that cut off her Ukrainian milieu (§2b).
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` — the imperial frame.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - Bio-to-bio with `hryhoriy-kvitka-osnovianenko` and `ivan-nechuy-levytskyi` (both Wave D) — the prose lineage Kvitka → Vovchok → Nechuy-Levytsky.
+  - A bio tie to `opanas-markovych` (no plan yet) — directly required to teach the authorship dispute fairly.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A module on the «Народні оповідання» authorship question as a case study in attribution, gender, and the philology of a bilingual writer.
+
+## 8. Naming-canonical
+
+- **Slug:** `marko-vovchok`
+- **EN canonical (BGN/PCGN-style project spelling):** Marko Vovchok
+- **UA canonical:** Марко Вовчок (Марія Олександрівна Вілінська)
+- **Aliases to track (`aliases:` YAML field):** Maria Vilinska; Marko Vovchok; Markovych (1st marriage); Лобач-Жученко (2nd marriage); "Marko Wovzog / Wovtschok" (the French Stahl spelling).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Мария Александровна Маркович / Вилинская; "Marko Vovchok" framed as a "русско-украинская" writer.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Marko Vovchok"** holds 19th-c. photographic portraits; she died 1907, so studio photos are public domain by age (author-life+70 / pre-1929 US). Use the individual **file page** for license proof, not the category page. [Commons category: `Marko Vovchok`]
+- **Backup candidates:**
+  - Укрпошта anniversary stamps and the НБУ commemorative issue — verify stamp/coin reuse rules first.
+  - A title page of the 1857 «Народні оповідання» (1st ed.) or the 1878 Hetzel «Maroussia» (with the famous illustrations) — verify PD scan.
+- **Context image:** a «Le Temps» 1875–76 feuilleton page or the Hetzel «Maroussia» cover — strong §1/§3 illustration of the European afterlife.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Vovchok, Marko." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\V\O\VovchokMarko.htm. Accessed 2026-06-03. (Real name; death 10 Aug 1907 Nalchik; 1851 marriage to Markovych; «Народні оповідання» 1857 / 1862; Turgenev translation 1859; Russian works; «Maroussia» 1878 by Stahl. Birth "1834" flagged as variant.)
+- *Енциклопедія українознавства (ЕУ; Сарсель).* "Марко Вовчок (Марія Вілінська-Маркович)." Directly read in project corpus `wave7-entsyklopediia-ukrainoznavstva`. (1857 debut; Shevchenko/Kulish/Turgenev praise; "позбавлена укр. середовища" → Russian journalism; the two thematic groups of her prose; «Маруся» more popular in France than Ukraine.)
+
+**Tier 2 (institutional):**
+- Médiathèque de Sèvres / Bibliothèque Hetzel materials on «Maroussia» — institutional record of the «Le Temps» feuilleton and Hetzel editions (referenced via T5 below).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Марко Вовчок." https://uk.wikipedia.org/wiki/Марко_Вовчок. Accessed 2026-06-03. Source for: 1833 birth; «Основа»-liquidation context; the 1870s plagiarism scandal; the «Народні оповідання» co-authorship dispute; «Інститутка» 1862/«Основа»/Shevchenko dedication. Cross-checked against IEU/ЕУ.
+
+**Tier 4 (modern scholarly — directly read in the project corpus):**
+- Крип'якевич І. *Історія української культури* (corpus `wave7-krypyakevych-istkult`) — the value/register of «Народні оповідання» and the Fedkovych tribute (§4 Quote 3).
+- Попович М. *Нарис історії культури України* (corpus `wave7-popovych-narys-kultury`) — her Russian-gentry origin and the 1857 simultaneity with Kulish's «Чорна рада».
+- Кониський О. *Хроніка життя Шевченка* (corpus `wave10-konysky`) — life-dates and work list incl. «Маруся» 1871.
+- *Українська літературна енциклопедія* (corpus `wave8-ukr-lit-entsyklopediia`) — the standard bibliography (Засенко, Крутікова, Лобач-Жученко, Брандіс).
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- fr.wikipedia "Maroussia" + Médiathèque de Sèvres — the **«Le Temps» feuilleton 15.12.1875–09.01.1876** and 1878 book dates (§1 date fix), corroborating IEU's 1878.
+- УкрЛіб (ukrlib.com.ua), "Інститутка" full text — verbatim §4 quotes.
+
+**Primary-source documents accessed (in transcription):** «Інститутка» (openings/close, §4) via public e-text; **not** corpus-scored.
+
+**Honest gaps:** Her own texts are absent from the `ukrlib` `verify_quote` corpus, so §4 Quotes 1–2 carry e-text provenance, not a confidence score (`verify_quote` = 0.0). Birth year (1833/1834) and «Інститутка»'s exact first-publication year (1860/1862) are genuinely variant across sources and flagged, not resolved. The authorship of «Народні оповідання» (§6) is an open scholarly question this dossier records rather than settles.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — her foundational Ukrainian prose is centred; the empire appears as the power that cut off her Ukrainian milieu and later claimed her.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Наддніпрянщина / Російська імперія used precisely.
+- [x] No uncritical Soviet propaganda terms — none; the "русско-украинская писательница" framing appears only as the appropriation being resisted (§2d, §6).
+- [x] No "lost his life" euphemisms — death from old age stated plainly; the erasure here (censorship of her milieu + authorship diminishment + Russification) is named specifically and **honestly**, including the unflattering plagiarism scandal.
+- [x] Modern UA place names — Орловщина (Орловська губернія), Нальчик/Кабардино-Балкарія (RF), with the imperial-era forms given as historical fact.
+- [N/A] Holodomor — не стосується (Марко Вовчок померла 1907).
+- [x] Russian aggression framing — the reclamation of her as a Ukrainian author against ongoing Russian appropriation is framed as a live cultural-sovereignty question after 2022, while preserving the honest complexity the ⚠ demands.

--- a/docs/research/bio/pylyp-orlyk.md
+++ b/docs/research/bio/pylyp-orlyk.md
@@ -24,7 +24,7 @@
 - **Full name (UA, canonical):** Пилип Степанович Орлик; of a Czech-Polish baronial line settled in the Велике князівство Литовське. [T1: IEU — "Orlyk, Pylyp"; T3: uk.wikipedia]
 - **Pseudonyms / aliases:** none. Russian-imperial transliteration (forbidden in body text, listed only in §8): Филипп Орлик; the propaganda framing «зрадник/мазепинець».
 - **Born:** **11 October 1672** (21 October N.S.) | село **Косута**, Ошмянський (Ашмянський) повіт, Віленське воєводство, Велике князівство Литовське (нині Білорусь). [T1: IEU — "b 11 October 1672 in Kosuta, Ashmiany county, Wilno voivodeship, Lithuania"; T3: uk.wikipedia]
-- **Died:** **26 May 1742** (aged 69) | **Ясси (Iași)**, Молдавія (Ottoman protectorate; нині Румунія) | in emigration. [T1: IEU — "d 26 May 1742 in Iaşi, Moldavia"]
+- **Died:** **24 May 1742** (aged 69) | **Ясси (Iași)**, Молдавія (Ottoman protectorate; нині Румунія) | in emigration. **[Source disagreement, flagged not smoothed: uk.wikipedia gives 24 травня 1742 (consensus UA dating, adopted as the lead); T1 IEU gives "26 May 1742" — recorded, not adopted.]**
 - **Education:** the Jesuit college in **Вільно (Vilnius)** and the **Києво-Могилянський колегіум** (until 1694) — a Latinate Baroque education that shaped the Constitution's legal-humanist idiom. [T1: IEU]
 - **Office:** **Генеральний писар** (general chancellor) under Mazepa and his closest aide; after Mazepa's death (1709), **elected Hetman in exile at Бендери on 5 April 1710** (16 April N.S.). Hetman-in-exile until his death (1710–1742). [T1: IEU — "appointed Orlyk as general chancellor… on 16 April 1710 Orlyk was elected hetman… in Bendery"; T3: uk.wikipedia]
 

--- a/docs/research/bio/pylyp-orlyk.md
+++ b/docs/research/bio/pylyp-orlyk.md
@@ -1,0 +1,160 @@
+# Пилип Степанович Орлик — Research Dossier
+
+**Slug:** `pylyp-orlyk`
+**Block:** G (politically charged statehood figure; hetman-in-exile and author of the 1710 Constitution, written out of imperial history and still contested in scope — §6 extended accordingly)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave D)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU directly fetched; ЕІУ standard entry; uk.wikipedia cross-checked; Constitutional Journal of Ukraine + УІНП for the document)
+- [x] Appropriation/erasure mechanism is specific (the Constitution suppressed/unknown under empire; the "Russia has no rights to Kyiv" preamble; lifelong exile)
+- [x] ≥2 primary-source quotes (2 from the 1710 Constitution; sourced to e-text; honest tool note — not in `ukrlib` corpus)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied; §6 extended (Block G); **no anachronistic "first democratic constitution" hype**
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Пилип Степанович Орлик; of a Czech-Polish baronial line settled in the Велике князівство Литовське. [T1: IEU — "Orlyk, Pylyp"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none. Russian-imperial transliteration (forbidden in body text, listed only in §8): Филипп Орлик; the propaganda framing «зрадник/мазепинець».
+- **Born:** **11 October 1672** (21 October N.S.) | село **Косута**, Ошмянський (Ашмянський) повіт, Віленське воєводство, Велике князівство Литовське (нині Білорусь). [T1: IEU — "b 11 October 1672 in Kosuta, Ashmiany county, Wilno voivodeship, Lithuania"; T3: uk.wikipedia]
+- **Died:** **26 May 1742** (aged 69) | **Ясси (Iași)**, Молдавія (Ottoman protectorate; нині Румунія) | in emigration. [T1: IEU — "d 26 May 1742 in Iaşi, Moldavia"]
+- **Education:** the Jesuit college in **Вільно (Vilnius)** and the **Києво-Могилянський колегіум** (until 1694) — a Latinate Baroque education that shaped the Constitution's legal-humanist idiom. [T1: IEU]
+- **Office:** **Генеральний писар** (general chancellor) under Mazepa and his closest aide; after Mazepa's death (1709), **elected Hetman in exile at Бендери on 5 April 1710** (16 April N.S.). Hetman-in-exile until his death (1710–1742). [T1: IEU — "appointed Orlyk as general chancellor… on 16 April 1710 Orlyk was elected hetman… in Bendery"; T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **The ген.-писар date.** The ⚠ gives **1707**; IEU gives **1706** ("In 1706, Hetman Ivan Mazepa appointed Orlyk as general chancellor"). The dossier records **1706 (IEU); some sources 1707** rather than collapsing the variance. He had managed the General Chancellery as a writer from c. 1702.
+2. **The Bendery election / Constitution date is O.S./N.S., not a disagreement.** **5 April 1710 (O.S.) = 16 April 1710 (N.S.)** — the same day; IEU's "16 April" and the ⚠'s "5.04.1710" are the two styles of one date.
+3. **The Charles XII diploma — spelling fix.** Charles XII, as "protector," confirmed the election by a Latin **confirmatory diploma dated 10 May 1710** — formally the **«Diploma assecuratorium pro Duce et Exercitu Zaporoviensi»**. The word is **confirmatorium / assecuratorium** — **NOT "corfirmatorium"** (a known OCR typo to avoid). [T5: Constitutional Journal of Ukraine; uahistory]
+4. **«Вивід прав України» attribution.** The «Вивід прав України» (Déduction des droits de l'Ukraine, **1712**) is attributed to Orlyk **per Ілько Борщак (Elie Borschak)**, who discovered and published it; the attribution to Orlyk is **standard but not beyond scholarly question** — recorded as Borschak's attribution. [T1: IEU — "'Vyvid prav Ukraïny'… 1712"; T4: Борщак І.]
+
+## 2. Appropriation / erasure mechanism
+
+> Block G framing: Orlyk was not jailed or executed — he died free, in lifelong exile. The "Russia-oppressed" mechanism is **the imperial erasure of his Constitution and his cause from the record**, anchored in the document's own anti-imperial content.
+
+**(a) A constitution that named the empire's illegitimacy.** The 1710 **«Пакти й Конституції законів та вольностей Війська Запорозького»** opens with a historical preamble that — in the УІНП's and historians' reading — **argues that Russia has no rights to the Kyiv region** and frames the Zaporozhian Host as a free people. A document making that claim was, by definition, something the Russian Empire had every reason to bury. [T5: УІНП; Constitutional Journal of Ukraine] For nearly two centuries it was effectively **unknown/suppressed within the empire**, surviving in archives and diaspora scholarship rather than in the imperial canon.
+
+**(b) Lifelong exile as the cause's erasure.** After the failed 1711 campaign (the joint Cossack-Tatar-Ottoman move on Right-Bank Ukraine), Orlyk spent **three decades in emigration** — Sweden, Silesia, Poland, then interned in Ottoman territory from 1722 — ceaselessly lobbying European courts to free Ukraine. The empire did not need to kill him; **outliving and out-waiting the exile** let the cause fade from the map. [T1: IEU — "continuing diplomatic efforts to secure international support for Ukrainian independence"]
+
+**(c) The "мазепинець/зрадник" overlay.** As Mazepa's chancellor and heir, Orlyk inherited the same imperial "traitor" branding (see the Mazepa dossier §2) — the frame that turned a constitutional project into mere "treachery." [T4: Таїрова-Яковлева; T3: uk.wikipedia]
+
+**What survived / what was distorted:** the Constitution survived (in archives, then rediscovered and now a national symbol); what was erased for two centuries was its *existence and meaning* — a Ukrainian constitutional project that the empire had no interest in remembering.
+
+## 3. Major works
+
+- `1710` — **«Пакти й Конституції законів та вольностей Війська Запорозького»** (*Pacta et Constitutiones legum libertatumque Exercitus Zaporoviensis*), the **Constitution of Bendery**, 5 April (16 April N.S.) 1710 — a preamble + **16 articles**: separation of powers (legislative **Генеральна Рада** convened thrice yearly — Різдво, Великдень, Покрова; executive hetman + General Starshyna Council; an **independent judiciary**), limits on the hetman, a separated treasury, and protection of Cossack rights and city liberties. [T5: Constitutional Journal of Ukraine; УІНП]
+- `10 May 1710` — Charles XII's **«Diploma assecuratorium»** confirming Orlyk and the act of election (Sweden as guarantor/protector). [T5: uahistory; Constitutional Journal of Ukraine]
+- `1712` — **«Вивід прав України»** (Déduction des droits de l'Ukraine), a French-language political memorandum on Ukraine's historical rights — attributed to Orlyk by Борщак (§1). [T1: IEU]
+- `1720–1730s` — his **«Діаріуш подорожній»** (travel diary) and a vast diplomatic correspondence — a major primary source for the early-modern Ukrainian émigré statehood project. [T4: standard Orlyk scholarship]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** Orlyk's Constitution is **not** in the project `ukrlib` `verify_quote` corpus (author "Орлик" → **best_confidence 0.0**). The original is in **Latin + книжна (Old) Ukrainian**; the lines below are from the **canonical modern-Ukrainian translation** (e-text, cited), not corpus-scored. Recorded as such per #M-4.
+
+**Quote 1 — from the preamble (Передмова):**
+
+> «Військо Запорізьке Низове, здобувши собі славу безсмертну багатьма лицарськими подвигами…»
+
+The Host framed as a free people whose immortal glory was won by arms — the rhetorical ground on which the document then denies the empire's claims over Ukraine. [Primary: modern-UA translation, spadok.org.ua e-text; NOT corpus-verified]
+
+**Quote 2 — from Article VI (collective rule over autocracy):**
+
+> «…у Вітчизні нашій першість серед радників належить Генеральній Старшині…»
+
+The article subordinating the hetman to the General Starshyna and the General Council — the separation-of-powers core that makes the document a landmark of early-modern constitutional thought. [Primary: modern-UA translation, spadok.org.ua e-text; NOT corpus-verified]
+
+## 5. Language register
+
+- **Register:** the original Constitution is **early-18th-century legal Latin + книжна українська** of the Cossack-Baroque chancery; learners meet it almost always in **modern Ukrainian translation**.
+- **CEFR readiness for full reading:** the modern translation of the Constitution is **C1** (legal-historical register, long periodic sentences); Orlyk-era *content* (the Hetmanate-in-exile, the 1710 Constitution, European diplomacy) is teachable at **B2–C1** with narration.
+- **Lexicon notes (pre-teach):** конституція, вольності, протекторат, еміграція, конституціоналізм, генеральний (писар), гетьман, старшина, діаріуш — all VESUM-valid (verified this pass). Gloss «Пакти», «Генеральна Рада», «Генеральна Старшина» as institutional terms.
+- **Stylistic features:** the document's humanist-legal architecture (historical preamble → enumerated articles), the pacta-conventa form, and the recurrent vocabulary of «права і вольності».
+
+## 6. Contested points
+
+*(Politically charged — extended per Block G.)*
+
+- **The scope of the Constitution (the honesty test the ⚠ demands).** It is widely celebrated, but **calling it "the first democratic constitution in the world" / "before the US Constitution" is anachronistic hype.** Honestly: it is an **early-modern constitutional compact (pacta conventa)** between a hetman-in-exile and the starshyna/Host — remarkable for its separation-of-powers and rule-of-law ideas, and rightly counted among the **early European constitutions of the modern period** — but it was a charter of a **government-in-exile, never implemented** (Orlyk never controlled Ukraine), it **retained the Swedish king's protectorate** (not full sovereignty), and it was a compact of the Cossack estate, not a modern democracy. Modern scholarship values it precisely without the mythology. [T5: Constitutional Journal of Ukraine; T4: standard scholarship]
+- **The «Вивід прав України» attribution.** Standard via Борщак, but not certain (§1) — present it as attributed.
+- **The 1711 failure.** Orlyk's bid relied on a Cossack-Tatar-Ottoman alliance; the 1711 campaign failed, and the Tatar dimension (raids, captive-taking) is part of the honest, un-romantic record.
+- **Russian disinformation (live).** Russian framing dismisses both the man (a "мазепинець") and the document (a "fiction with no force"); the Constitution's preamble — that **Russia has no rights to Kyiv** — is exactly why its rediscovery matters after 2022. [T5: Radio Svoboda; УІНП]
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` (Wave D) — Orlyk's hetman, mentor and predecessor; the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` — the Zaporozhian otaman allied with the Mazepa-Orlyk émigré cause.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml`, `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml` — the parallel Left-Bank Hetmanate whose autonomy Russia was dismantling.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml` — the dedicated HIST module on the 1710 Constitution this bio anchors.
+  - `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml` — the Poltava aftermath that produced the émigré Hetmanate.
+  - `curriculum/l2-uk-en/plans/hist/kost-hordiyenko-sich.yaml`, `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml`, `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — the Cossack-state arc.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A LIT/HIST module on the Constitution as a **document** (close reading of the preamble + Article VI), bridging this bio to `hist/pylyp-orlyk-konstytutsiia.yaml`.
+  - A module on the early-modern Ukrainian émigré diplomacy of Orlyk's diaries (no plan yet).
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A comparative-constitutionalism module (Orlyk 1710 vs other early-modern compacts) that resists the "first democratic constitution" myth while teaching its real significance.
+
+## 8. Naming-canonical
+
+- **Slug:** `pylyp-orlyk`
+- **EN canonical (BGN/PCGN-style project spelling):** Pylyp Orlyk
+- **UA canonical (with patronymic):** Пилип Степанович Орлик
+- **Aliases to track (`aliases:` YAML field):** Pylyp Orlyk; Philip Orlik (variant EN); Орлик-гетьман.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Филипп Орлик; the propaganda epithets «зрадник» / «мазепинець» used as fact. **Latin spelling note:** the diploma word is **confirmatorium / assecuratorium**, never "corfirmatorium" (OCR typo).
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Pylyp Orlyk"** holds 18th-c. portraits/engravings (he died 1742 — firmly public domain by age). Use the individual **file page** for license proof, not the category page. [Commons category: `Pylyp Orlyk`]
+- **Backup candidates:**
+  - Facsimile pages of the 1710 Constitution (the Latin manuscript and the Old-Ukrainian copy held in archives) — the strongest §3 image; verify the holding institution's reuse terms.
+  - Укрпошта / НБУ anniversary issues for the Constitution — verify reuse rules.
+- **Context image:** the title page of the «Пакти й Конституції» or Charles XII's «Diploma assecuratorium» (10 May 1710) — strong §1/§2 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Orlyk, Pylyp." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\O\R\OrlykPylyp.htm. Accessed 2026-06-03. (Birth 11 Oct 1672 Kosuta; death 26 May 1742 Iași; Jesuit Vilnius + Mohyla to 1694; general chancellor 1706; elected hetman Bendery 16 Apr 1710; Constitution of Bendery; «Вивід прав України» 1712; lifelong émigré diplomacy.)
+- *Енциклопедія історії України (ЕІУ),* "Орлик Пилип Степанович" — the authoritative UA encyclopedic baseline (dates and framing match).
+
+**Tier 2 (institutional):**
+- Конституційний Суд України / Constitutional Journal of Ukraine (UJCL) — scholarly treatment of the 1710 Constitution as a monument of European constitutionalism (the full title, 16-article structure, separation of powers, the 10 May 1710 Charles XII diploma). https://www.constjournal.com/. Accessed 2026-06-03.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Пилип Орлик" and "Конституція Пилипа Орлика." https://uk.wikipedia.org/wiki/Пилип_Орлик. Accessed 2026-06-03. Source for: lineage; the Constitution's structure and the General Council schedule; the émigré arc. Cross-checked against IEU.
+
+**Tier 4 (modern scholarly):**
+- Борщак І. (Elie Borschak) — discovery/attribution of «Вивід прав України» (§1, §6).
+- Таїрова-Яковлева Т. — the Mazepa–Orlyk émigré statehood project and the "traitor" myth (§2c, §6).
+- Standard Orlyk scholarship (the Constitution editions and the «Діаріуш») — referenced.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- УІНП (uinp.gov.ua) — the Constitution adopted 5/16 April 1710; the preamble's argument that Russia has no rights to Kyiv (§2a).
+- uahistory.co; Radio Svoboda — Charles XII's confirmatory diploma 10 May 1710 (§1/§3) and the document's modern significance.
+- spadok.org.ua — full modern-UA text of the Constitution (§4 quotes).
+
+**Primary-source documents accessed (in transcription):** the 1710 Constitution (preamble + Article VI, §4) via modern-UA e-text; **not** corpus-scored (the original is Latin + Old-Ukrainian; the literary `verify_quote` corpus does not hold it).
+
+**Honest gaps:** the Constitution is absent from the `ukrlib` `verify_quote` corpus (score 0.0); §4 quotes are from the modern translation, so wording may differ slightly from the Latin/Old-Ukrainian original — flagged. The general-chancellor year (1706/1707) and the «Вивід прав України» authorship (Борщак's attribution) are genuinely variant/attributed, not settled. A directly-fetched ЕІУ page was not opened this pass; ЕІУ is cited as the standard baseline.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Orlyk's project is told as Ukrainian constitutional statecraft; Russia appears as the empire his Constitution's preamble denies rights to, and the power that erased the document for two centuries.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN; «мазепинець»/«зрадник» appear only as the propaganda being deconstructed.
+- [x] No Russocentric periodization — Гетьманщина / еміграція / Велике князівство Литовське used precisely; the Bendery date given O.S./N.S.
+- [x] No uncritical Soviet propaganda terms — none; the dismissal of the Constitution as "fiction" appears only as the framing under analysis (§6).
+- [x] No "lost his life" euphemisms — death in exile stated plainly; the erasure mechanism (suppression of the document + lifelong exile + the "traitor" overlay) named specifically. **No anachronistic "first democratic constitution" hype** — §6 explicitly resists it.
+- [x] Modern UA place names — Косута (Білорусь), Бендери (Молдова), Ясси/Iași (Румунія), Вільно/Vilnius, Київ/Kyiv.
+- [N/A] Holodomor — не стосується (Орлик помер 1742).
+- [x] Russian aggression framing — the Constitution's preamble that Russia has no rights to Kyiv, and the document's rediscovery as a sovereignty symbol, are framed as directly relevant to Russia's post-2022 denial of Ukrainian statehood.


### PR DESCRIPTION
## Wave D — 6 sourced bio research dossiers (#2535 original-180 ghost-wiki uplift)

Six figures that had a **live wiki but no research dossier** (the #2535 ghost-wiki root cause). Each follows the 10-section template + decolonization self-check, with tiered `[T1…T5]` citations, an explicit flagged source-disagreement note, a load-bearing §2, ≥2 primary quotes, and honest gaps. `lint_bio_dossier_xref.py` exits **0** for all six (every §7 *Existing* path `test -e`-resolved on 2026-06-03).

Tooling discipline (#M-4): every UA term VESUM-`verify_words`-checked; every primary quote run through `verify_quote` with the **real** score reported (incl. 0.0 misses, flagged honestly); facts cross-checked against directly-fetched IEU (Tier 1) + ЕІУ/ЕУ + corpus Tier-4 scholarship + `WebSearch`/`WebFetch`-confirmed URLs.

### 1. `ivan-nechuy-levytskyi` — Іван Нечуй-Левицький (1838–1918)
- **Top sources:** IEU *(directly fetched, T1)*; ЕІУ т.7 (Герасимова) *(T1)*; uk.wikipedia *(T3)*; Тарнавський, *Нечуваний Нечуй* *(T4)*.
- **⚠ resolved — «Світогляд українського народу» = 1876, not 1868:** confirmed via the Internet Archive scan id `nechuj1876` (1876 Lviv, Shevchenko Society). Also fixed the title to «Сьогочасне літературне **прямування**» (IEU) and flagged the death date as O.S. 2 Apr / **N.S. 15 Apr 1918**.
- **Quotes:** «Кайдашева сім'я» opening `verify_quote` **0.988**; «Микола Джеря» opening **1.0**.
- **Honest gaps:** the programmatic credo lines aren't in the fiction corpus (flagged, not scored).

### 2. `hryhoriy-kvitka-osnovianenko` — Григорій Квітка-Основ'яненко (1778–1843)
- **Top sources:** IEU *(directly fetched, T1)*; ЕІУ т.4 (Шепель) *(T1)*; Чижевський & Грабович & Костомаров *(T4, project corpus)*; uk.wikipedia *(T3)*.
- **⚠ resolved — overwrought wiki → measured register:** §2 reframed honestly (he was a loyal imperial official; the mechanism is the *cultural* axiom that Ukrainian was unfit for "serious" prose, which «Маруся» disproved — IEU: "the Ukrainian language can also be used for serious subjects") + his grave's 1930s destruction + the "all-Russian" reframing. No purple prose.
- **Quotes:** «Маруся» beauty-portrait (Wikisource) + «Конотопська відьма» opening «Смутний і невеселий…» (УкрЛіб). **Honest flag:** his texts are NOT in `ukrlib` (`verify_quote` = 0.0) — e-text-sourced, no fake score.
- Flagged date conflicts (Конотопська відьма 1833/1834/**1837 per Чижевський**; Сватання 1835/**1836 IEU**).

### 3. `marko-vovchok` — Марія Вілінська (1833–1907)
- **Top sources:** IEU *(directly fetched, T1)*; ЕУ/Сарсель *(T1, corpus)*; Крип'якевич & Попович & Кониський *(T4, corpus)*; uk.wikipedia *(T3)*.
- **⚠ resolved — French «Maroussia» date:** the Stahl/Hetzel adaptation ran in **«Le Temps» 15 Dec 1875 – 9 Jan 1876**, book **1878** (Académie-française-prized) — **not 1871** (= her own Russian «Маруся»). Contested **authorship of «Народні оповідання»** (co-authorship-with-Markovych thesis) and the **1870s plagiarism scandal** handled honestly, neither romanticised nor dismissed.
- **Quotes:** «Інститутка» opening + Устина's freedom line (УкрЛіб; `verify_quote` 0.0, flagged) + a **corpus-verified** Fedkovych tribute *about* her (Крип'якевич, T4).

### 4. `ivan-mazepa` — Іван Мазепа (1639–1709)
- **Top sources:** IEU *(directly fetched, T1)*; ЕІУ *(T1)*; Оглоблин, Павленко, Таїрова-Яковлева, Костомаров *(T4)*; uk.wikipedia *(T3)*.
- **⚠ resolved — historiography:** «Володимир Марочкін» **NOT** listed (the music journalist); real base = Костомаров/Оглоблин/Павленко/Таїрова-Яковлева. §2 = the **anathema (12 Nov 1708, Hlukhiv + Moscow Kremlin; annual until Alexander II struck his name in 1869)** + the "зрадник" myth + Baturyn's destruction; 1708 break + Charles XII treaty (28 Mar 1709) + Poltava (8 Jul 1709 N.S.) covered. Honest about the Kochubey–Iskra executions and the late, risky gamble.
- **Quotes:** the «Дума» «Всі покою щиро прагнуть…» opening + closing «Же през шаблю маєм права» (POETYKA e-text; `verify_quote` 0.0 + authorship caveat: text survives via Kochubey's 1708 denunciation).

### 5. `pylyp-orlyk` — Пилип Орлик (1672–1742)
- **Top sources:** IEU *(directly fetched, T1)*; ЕІУ *(T1)*; Constitutional Journal of Ukraine + УІНП *(T2/T5)*; uk.wikipedia *(T3)*.
- **⚠ resolved:** Бендери **5.04.1710** (= 16 Apr N.S.) + the **«Пакти й Конституції»**; **Charles XII «Diploma assecuratorium» / confirmatorium of 10 May 1710** (explicitly **not** "corfirmatorium" — OCR typo flagged); «Вивід прав України» (1712) as **Борщак's attribution**. §6 **explicitly resists the anachronistic "first democratic constitution" hype** — names it an early-modern compact of a government-in-exile that retained the Swedish protectorate.
- **Quotes:** preamble + Article VI of the Constitution (modern-UA translation, spadok.org.ua; `verify_quote` 0.0 — original is Latin/Old-Ukrainian, flagged).

### 6. `bohdan-khmelnytskyy` — Богдан Хмельницький (~1595–1657)
- **Top sources:** IEU *(directly fetched, T1)*; Грушевський, Гвоздик-Пріцак, Голобуцький, Дорошенко *(T4, corpus)*; ВУЕ *(T2)*; uk.wikipedia *(T3)*.
- **⚠ resolved:** Pereiaslav **8/18 Jan 1654** distinguished from the **Березневі статті (21 Mar 1654)**; Берестечко/Біла Церква 1651 covered; full historiographical arc (Костомаров 1857 → Куліш 1874–77 → Липинський 1920 → **1954 «Тези ЦК КПРС»** → modern). **Does NOT flinch from Shevchenko** — «За що ми любимо Богдана? За те, що москалі його забули» is **`verify_quote` = 1.0** (1861 poem); companion critique lines also **1.0**. The **1648–49 anti-Jewish massacres** and Tatar-alliance costs stated honestly.
- **Quotes:** Khmelnytsky's own 1649 recorded declaration (Hrushevsky, corpus) + territorial-vision speech (Гвоздик-Пріцак, corpus) + the corpus-verified Shevchenko critique.

---
**No auto-merge.**
