### PR TITLE
research(bio): 6 sourced dossiers — Wave E 19th-c. cultural founders (#2535)

### DIFF
--- a/docs/research/bio/borys-hrinchenko.md
+++ b/docs/research/bio/borys-hrinchenko.md
@@ -1,0 +1,160 @@
+# Борис Дмитрович Грінченко — Research Dossier
+
+**Slug:** `borys-hrinchenko`
+**Block:** B (imperial-era persecuted patriot; nation-builder under censorship)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave E)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU, ЕІУ, Russian-Academy prize record; uk.wikipedia cross-checked)
+- [x] Oppression mechanism is specific (student arrest → tuberculosis; named censorship regime)
+- [x] ≥2 primary-source quotes (1 corpus `verify_quote` 1.0 + 1 corpus-attested prose; confidence reported)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Борис Дмитрович Грінченко. [T1: IEU — "Hrinchenko, Borys"; T1: ЕІУ — "Грінченко Борис Дмитрович"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **Василь Чайченко / В. Чайченко**, **П. Вартовий / Вартовий**, **Б. Вільхівський**, **Л. Яворенко**, М. Гримач, Перекотиполе, Немірич, та ін. Russified form (forbidden in body text, §8 only): Борис Дмитриевич Гринченко.
+- **Born:** 27 November (9 December) 1863 | хутір Вільховий Яр near с. Руські Тишки, Харківська губернія | the Російська імперія then held Слобожанщина. [T1: IEU — "9 December 1863… in Kharkiv county"; T3: uk.wikipedia]
+- **Died:** 23 April (**6 May**) **1910** (aged 46) | **Оспедалетті (Ospedaletti), Лігурія, Королівство Італія** | of tuberculosis; buried at the **Байкове кладовище**, Kyiv. [T1: IEU — "died 6 May 1910 in Ospedaletti, Italy" — **VERIFIED**; T3: uk.wikipedia — "6 травня 1910 року Грінченко помер в Оспедалетті, Лігурія"]
+- **Family / education key facts:** Son of an impoverished gentry family (father Дмитро Якович, a retired штабс-ротмістр). Read at five; entered the **Харківське реальне училище (1874)** but was **arrested as a student for distributing banned literature** and expelled (§2); passed external exams to qualify as a **народний учитель**, and taught for a decade in Слобожанщина and Катеринославщина (incl. 1887 at **Христина Алчевська's** village school in Олексіївка). Married Марія Загірня (Гладиліна) in 1884; their only child, daughter **Настя (Anastasia)**, died of tuberculosis in 1908 (§2). [T1: IEU; T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):** The dictionary's word-count is given variously as **~68,000** (IEU) and **70,000** (uk.wikipedia, counting headwords differently) — both refer to the same four-volume «Словарь української мови» (1907–1909); use "близько 68 000" with the variant noted. Birthplace: some sources point to a different Вільховий Яр (now within с-ще Прелесне) — a locality-name duplication, not a dispute about the man.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Hrinchenko was not executed — the empire **broke his body slowly through prison and censorship**, and the mechanism is exact.
+
+- **What happened:** Arrested and imprisoned as a teenager for spreading banned populist publications; the imprisonment seeded the **tuberculosis that killed him three decades later**. [T3: uk.wikipedia — "За поширення заборонених царським урядом видань його заарештували і кілька місяців тримали в ув'язненні… Підірване сухотою здоров'я (наслідки харківського ув'язнення)"]
+- **When (specific):** **1879**, during his studies at the Харківське реальне училище; held **several months** in Kharkiv detention, then expelled — forced to leave school and earn his living. [T3: uk.wikipedia]
+- **By whom (specific agency):** the **tsarist police / охоронка** under the imperial Ministry of the Interior, enforcing the ban on populist (народницька) literature. [T3: uk.wikipedia]
+- **Mechanism specifics — censorship as the lifelong wall.** Hrinchenko built Ukrainian schooling, lexicography, and publishing **against the Валуєвський циркуляр (1863)** and **Емський указ (1876)**, which outlawed Ukrainian-language books and teaching. His publishing house issued **~50 popular-educational books "despite severe censorship"**; his Ukrainian-language reader **«Рідне слово»** and grammar had to fight the prohibition on the Ukrainian word in schools. [T1: IEU — "published 50 popular-educational books despite severe censorship"; T3: uk.wikipedia]
+- **The family cost.** His daughter **Настя** took part in the 1905–1907 revolution, was imprisoned, contracted tuberculosis, and **died on 1 October 1908**; her infant son died soon after. These deaths, on top of his own prison-born illness, finished him: he died **eighteen months later** in Italian exile-for-treatment. [T3: uk.wikipedia]
+- **What survived / what was destroyed:** Almost everything he built survived — the dictionary, the readers, the Prosvita apparatus — but he himself was worn out at 46. The Soviet period kept his works in print while **flattening him into a harmless "народник-просвітитель,"** quietly dropping his explicit cultural nationalism (§6).
+
+## 3. Major works
+
+- `1884–1903` — poetry collections **«Пісні Василя Чайченка»** (1884), **«Під сільською стріхою»** (1886), **«Під хмарним небом»** (1893), **«Пісні та думи»** (1895), **«Хвилини»** (1903). [T3: uk.wikipedia]
+- `1884–1900` — ~50 short stories, incl. **«Каторжна»** (1888), **«Дзвоник»**, **«Без хліба»** (1884), **«Олеся»** (1890); the novellas/novels **«Сонячний промінь»** (1890), **«На розпутті»** (1892). [T1: IEU; T3: uk.wikipedia]
+- `1891` — **«Галицькі вірші»** — his polemical cycle on Galician affairs. [T3 / ЕУЛ corpus]
+- `1892–1893` — **«Листи з України Наддніпрянської»** (in «Буковина») — his programmatic statement of Ukrainian cultural independence and the famous polemic with **Драгоманов** (§4, §6). [T3: uk.wikipedia]
+- `1895–1899` — **«Етнографічні матеріали, зібрані в Чернігівській і сусідніх з нею губерніях»** (3 vols); **«Думи кобзарські»** (1897); the bibliography **«Література українського фольклору. 1777–1900»** (1901). [T3: uk.wikipedia]
+- `1896–1906` — pedagogy: **«Яка тепер народна школа на Україні»** (1896), **«Народні вчителі і вкраїнська школа»** (1906); the school readers **«Рідне слово»** and **«Українська граматика»** (with Марія Грінченко). [T1: IEU; T3: uk.wikipedia]
+- `1900–1902` — the social dilogy **«Серед темної ночі»** (1900) and **«Під тихими вербами»** (1901). [T3: uk.wikipedia]
+- `1907–1909` — the monumental **«Словарь української мови»** (4 vols; ~68,000 words), which he and Марія Загірня compiled for the Kyiv Hromada; **awarded the Russian Academy of Sciences' Костомаров (second) prize**. The foundational Ukrainian dictionary of the era; reissued 49 years later. [T1: IEU; T3: uk.wikipedia — "удостоєний Рос. АН другої премії М. Костомарова"]
+
+**Suppression note:** his explicitly nationalist «Листи з України Наддніпрянської» and «Галицькі вірші» were the parts the Soviet "народник" canon quietly downplayed.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — civic-anthem verse (1895):**
+
+> «Нас не злякають муки-кайдани: / Будемо дужчі за муки, — / Даймо ж на працю для України / Серце, і розум, і руки!»
+
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-hrinchenko`). The corpus row carries a stray metadata year (1863); the poem itself is dated **1895** in the source edition (Б. Грінченко, ПОЕЗІЇ, 1965). Pedagogically: a clean, B1-reachable statement of his "праця для України" credo. [Primary: corpus-verified]
+
+**Quote 2 — «Листи з України Наддніпрянської» (1892–93), cultural independence (the Drahomanov polemic):**
+
+> «…українська література не була, не є і не буде часткою чи наростом од московщини, а була, є і буде самостійною літературою, що в ній силкується виявити своє розумове життя український народ.»
+
+Attested in the `wave7-hrinchenko-drahomanov` corpus (Жуковський, "Національне питання в полеміці між М. Драгомановим і Б. Грінченком"), citing «Листи з України Наддніпрянської», с. 102. The sharpest primary statement of his anti-imperial cultural stance — explicitly *against* Drahomanov's view of Ukrainian letters as part of an all-Russian whole. [Primary: corpus-attested; `verify_quote` not run on this prose passage — quoted from the scholarly corpus transcription]
+
+## 5. Language register
+
+- **Register:** clear, didactic literary Ukrainian — народницька **просвітницька** prose and civic verse, deliberately accessible (he was building readers for peasants and schoolchildren). His critical/publicistic prose is more demanding.
+- **CEFR readiness for full reading:** the civic verse and children's prose at **A2–B1**; the stories at **B1–B2**; «Листи з України Наддніпрянської» and the dictionary apparatus at **C1**.
+- **Lexicon notes (pre-teach):** **лексикограф**, словник, тлумачний, **правопис**, **псевдонім**, **етнографка**/етнограф, **діалектизм**, Просвіта, граматика — all VESUM-valid (verified). His dictionary itself is a register-defining instrument: it fixed the **синонімічний відсів** of the young literary language (Русанівський).
+- **Stylistic features:** plain syntax, folk-song cadence in the verse, a moralizing-civic directness ("Серце, і розум, і руки"); as lexicographer, an unmatched ear for living folk vocabulary.
+
+## 6. Contested points
+
+- **The Hrinchenko–Drahomanov polemic (anti-hagiography core).** Their «Листи» exchange (1892–93) is a real intellectual split: Drahomanov wanted Ukrainian culture in dialogue with (and partly within) Russian culture; **Hrinchenko insisted on full cultural independence** and warned that "кожен, хто приносить хоть крихту обмоскалення в наш народ… робить йому шкоду." Modern scholarship treats this as the founding debate of Ukrainian cultural nationalism, not a quarrel to be smoothed. [T3: uk.wikipedia; corpus `wave7-hrinchenko-drahomanov`]
+- **His own self-criticism.** Late in life Hrinchenko stepped back from what he called the "хворобливий напрям" of pure national-feeling agitation, turning to more internationalist and social themes — a genuine evolution that the Soviet canon over-read into "overcoming bourgeois nationalism." Tell the evolution, refuse the Soviet gloss. [ЕУЛ corpus]
+- **What popular memory simplifies.** He is remembered mainly as "the dictionary man," eclipsing the pedagogue, the Prosvita organiser, the УДРП co-founder, and the imprisoned-as-a-teenager activist whose health that prison destroyed.
+- **Russian framing** likes the harmless "просвітитель-народник" Hrinchenko and erases the man who declared Ukrainian literature was "не… часткою… од московщини" (§4).
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — fellow nation-builder across the imperial border; Franko praised his prose.
+  - `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml` — same revival generation; his daughter Настя studied in Lviv near the Косач/Франко circle.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml` — his polemical opposite in the «Листи» debate (§4, §6).
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-kotsiubynsky.yaml` — contemporary; co-compiler of the 1903 Kulish memorial almanac «Дубове листя».
+  - `curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml` — Hrinchenko wrote an early biography of Kulish and condemned his «История воссоединения Руси».
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` — the literary-revival generation as a historical unit (his name is in it).
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the censorship his whole life's work fought.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — the Prosvita / enlightenment milieu he led in Kyiv (1906–09).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/borys-hrinchenko.yaml` — the LIT-track Hrinchenko anchor this bio should connect to.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `mariya-zahirnia` (his wife and co-lexicographer) — no plan yet.
+  - A HIST/LANG module on the «Словарь української мови» and the codification of the modern literary language — not yet built.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A Братство тарасівців (1891) "profession de foi" module bridging LIT and HIST.
+
+## 8. Naming-canonical
+
+- **Slug:** `borys-hrinchenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Borys Hrinchenko
+- **UA canonical (with patronymic):** Борис Дмитрович Грінченко
+- **Aliases to track (`aliases:` YAML field):** Borys Hrinchenko; Василь Чайченко (pseud.); П. Вартовий (pseud.); Б. Вільхівський (pseud.).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Борис Дмитриевич Гринченко; "Grinchenko" as a Russified transliteration; "Slovar malorusskogo iazyka" mis-titling of his dictionary.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Borys Hrinchenko"** — early-20th-c. photographs; he died 1910, so portraits are public domain by age. A signed 1901 photograph is held at the Lviv Franko literary-memorial museum. Use the individual **file page** for license proof. [Commons category: `Borys Hrinchenko`]
+- **Backup candidates:**
+  - НБУ 2-hryvnia jubilee coin "Борис Грінченко" (introduced 22 Nov 2013) — context image.
+  - The Kyiv monument to Hrinchenko (unveiled 22 Aug 2011) — context image (verify rights).
+  - A title page of the «Словарь української мови» (т. 1, 1907) — strong §3 illustration if a rights-clear scan is found.
+- **Context image:** a page of «Рідне слово» (his Ukrainian school reader) — illustrates the censorship-defying pedagogy of §2/§3.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Hrinchenko, Borys." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\H\R\HrinchenkoBorys.htm. Accessed 2026-06-03. (Birth 9 Dec 1863; **death 6 May 1910 Ospedaletti, Italy — verified**; pseudonyms; dictionary 1907–09; Prosvita 1906–09; Brotherhood of Taras 1891; "50 books despite severe censorship.")
+- *Енциклопедія історії України* — "Грінченко Борис Дмитрович" (UA encyclopedic baseline; life-dates and framing match).
+- Russian Academy of Sciences — the **Костомаров (second) prize** awarded to the «Словарь української мови» (documentary record of the award; cited as the prize fact, not as authority over his identity).
+
+**Tier 2 (institutional):**
+- Центральний державний архів-музей літератури і мистецтва України — particular fond **№ 15 (Б. Грінченко)**, 80 units, 1697–1910 (institutional archival holding).
+- Київський столичний університет імені Бориса Грінченка / «Грінченко онлайн» — institutional scholarship and digital corpus of his works.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Грінченко Борис Дмитрович." Accessed 2026-06-03. Verbatim source for: 1879 arrest → tuberculosis chain; daughter Настя's 1908 death; pseudonym list; work-list; **Ospedaletti death** (cross-checked against IEU).
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Жуковський А. "Національне питання в полеміці між М. Драгомановим і Б. Грінченком" — analysis of the «Листи» debate (the §4 prose quote is drawn from this corpus transcription).
+- Русанівський В. *Історія української літературної мови* — on Hrinchenko's role in fixing literary-language norms.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):** none relied upon for core claims this pass.
+
+**Primary-source documents accessed (in transcription):**
+- Corpus `ukrlib-hrinchenko` — the 1895 civic poem (§4 Quote 1), `verify_quote` confidence 1.0.
+- Corpus `wave7-hrinchenko-drahomanov` — «Листи з України Наддніпрянської» passage (§4 Quote 2), quoted via the scholarly transcription.
+
+**Honest gaps:** The §4 prose quote was taken from the Hrinchenko–Drahomanov scholarly corpus rather than `verify_quote`-confirmed against a primary edition; the dictionary head-word count carries a 68,000/70,000 source split (§1), noted not smoothed. The ЕІУ article page was not separately opened this pass (cited as the standard UA baseline alongside the directly-fetched IEU).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — told on Ukrainian terms; the empire appears as the imprisoning (1879) and censoring (Валуєвський/Емський) power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Валуєвський циркуляр / Емський указ / Братство тарасівців as markers.
+- [x] No uncritical Soviet propaganda terms — "народник/просвітитель" appears only as the *Soviet flattening* being named (§2, §6).
+- [x] No "lost his life" euphemisms — death from tuberculosis (rooted in his 1879 imprisonment) is stated plainly.
+- [x] Modern UA place names — Харків/Слобожанщина, Київ, Байкове кладовище; Ospedaletti given as the documented Italian death-place.
+- [N/A] Holodomor — не стосується (Hrinchenko died 1910).
+- [x] Russian aggression framing — the dossier names how Russian narratives prefer the harmless "просвітитель" and erase his declaration of Ukrainian literary independence (§4, §6).

--- a/docs/research/bio/marko-kropyvnytskyi.md
+++ b/docs/research/bio/marko-kropyvnytskyi.md
@@ -1,0 +1,159 @@
+# Марко Лукич Кропивницький — Research Dossier
+
+**Slug:** `marko-kropyvnytskyi`
+**Block:** B (imperial-era persecuted patriot; founder of the Ukrainian professional theatre)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave E)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU, ЕУЛ, Кропивницький museum record; uk.wikipedia cross-checked)
+- [x] Oppression mechanism is specific (Ems Ukase + named 1883 Drentteln theatre ban; repeated play bans)
+- [x] ≥2 primary-source quotes (documented from his «Автобіографія»/listy; `verify_quote` N/A — corpus lacks his texts, disclosed)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Марко Лукич Кропивницький. [T1: IEU — "Kropyvnytsky, Marko"; T1: ЕУЛ (Українська літературна енциклопедія) — "Кропивницький Марко Лукич"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none used professionally; honorific epithet **«батько українського театру»** ("father of the Ukrainian theatre"). Russified form (forbidden in body text, §8 only): Марк Лукич Кропивницкий.
+- **Born:** 10 (22) May 1840 | с. Бежбайраки (Бешбийраки), Єлисаветградський повіт, Херсонська губернія | the Російська імперія; **now с. Кропивницьке, Новоукраїнський район, Кіровоградська область** (the village was renamed for him). [T1: IEU — "22 May 1840 in Bezhbairaky"; T3: uk.wikipedia]
+- **Died:** 8 (21) April 1910 (aged 69) | **on the train (у потязі), returning from gastrol in Odesa toward his хутір Затишок** | of a **cerebral haemorrhage (крововилив у мозок)**; buried in **Харків**. [T1: IEU — "21 April 1910 en route from Mykolaiv to Kharkiv, buried in Kharkiv"; T3: uk.wikipedia — "21 квітня 1910 року раптово помер у потязі від крововиливу в мозок"]
+- **Family / education key facts:** Of the gentry Кропивницький line (герб Сас); his father Лука Іванович, an estate steward, was — in Kropyvnytskyi's own «Автобіографія» — a man of "труда мозольного" who knew poverty; his mother abandoned the family when Marko was five, leaving him a "напівсирота при живій матері." Patchy schooling (private school of Рудковський; the Бобринецька повітова школа 1853–56); an unfinished stint as a **вільний слухач** at Kyiv University's law faculty (1862, three semesters); worked as a minor court clerk before the stage. [T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):** Older diaspora references give the birth-place name and year with variants — Крип'якевич's text even prints "**1841**" and "с. Жеванівка," while the standard modern UA record (IEU, ЕУЛ, uk.wikipedia, the 2019 Verkhovna Rada resolution) fixes **1840, с. Бежбайраки (now Кропивницьке)**. Use **1840 / Бежбайраки**; the 1841/Жеванівка forms are dated errors. The death is sometimes loosely placed "en route from Mykolaiv to Kharkiv" (IEU); the detailed UA account specifies he was returning from **Odesa** gastrol and died **in the train**.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Kropyvnytskyi built the first Ukrainian professional theatre **inside a legal regime designed to make Ukrainian theatre impossible**, and the instruments are named and dated.
+
+- **What happened:** His life's work — Ukrainian-language theatre — was **banned outright, then permitted only under crippling conditions**, and his individual plays were **repeatedly censored and forbidden**. [T1: IEU; T3: uk.wikipedia; ЕУЛ corpus]
+- **When (specific):** **1876 (Ems Ukase)** caught him in Катеринослав; the ban on Ukrainian performances "тривала понад п'ять років," during which he was forced to play **"до 500 ролів на московській мові."** A **1881** circular re-permitted Ukrainian plays but forbade "влаштування спеціально малоросійського театру." After his troupe's 1882 triumph, **Kyiv governor-general Олександр Дрентельн banned Ukrainian theatre (1883) across Kyiv, Volhynia, and Podillia gubernias** (and Poltava/Chernihiv, which he also governed). [T3: uk.wikipedia]
+- **By whom (specific instruments):** the **Емський указ (1876)** of Alexander II; the **1881 circular**; the **1883 Drentteln ban**; and the **imperial censorship** that repeatedly blocked his plays. [T3: uk.wikipedia; ЕУЛ corpus]
+- **Document references / play bans (quoted, not paraphrased):** the social drama **«Глитай, або ж Павук»** "неодноразово заборонялася"; **«Замулені джерела» / «Метелик»**, **«Розгардіяш»**, **«Зерно і полова»** were **banned by the censor** and several first printed only **after his death**; «Де зерно, там і полова» was "заборон. до друку і постановки." [T1: ЕУЛ corpus — chunk fc2291b5_c3985]
+- **Mechanism specifics:** because Ukrainian theatre was illegal for years, Kropyvnytskyi survived inside Russian troupes, then exploited the 1881 opening to assemble the first professional Ukrainian troupe (§3) — only to have it driven out of the core Ukrainian governorates by Drentteln in 1883, pushing it onto the road across the empire. He felt the imperial erasure acutely (see §4 Quote 1).
+- **What survived / what was distorted:** His ~40 plays survived (many in censored variants — "поціновували понівечені цензурою варіанти"), and the **canonical texts of plays like «Титарівна» and «Конон Блискавиченко» were withheld from print for decades**; the Soviet era then re-labelled his theatre as quaint "етнографічно-побутова" folklore, muting its function as national self-defence.
+
+## 3. Major works
+
+~40 plays (most in several redactions). Selected, chronological:
+
+- `1863` — **«Микита Старостенко…»**, reworked into **«Дай серцю волю, заведе в неволю»** (3rd ed. publ. 1882) — his foundational melodrama of village life. [T1: IEU — "Dai sertsiu voliu… 1863"; T3: uk.wikipedia]
+- `1882` — **«Глитай, або ж Павук»** — social-psychological drama of the village profiteer **Бичок**, "для якого найбільша «правда» і найвища влада — гроші"; **repeatedly banned**. [T1: ЕУЛ corpus; T3: uk.wikipedia]
+- `1882` — **«Доки сонце зійде, роса очі виїсть»** and the satirical etude **«По ревізії»** (the sketch of village "bureaucracy"). [T1: ЕУЛ corpus]
+- `1889–1891` — **«Дві сім'ї»** (from the banned «Де зерно, там і полова»), **«Зайдиголова»**, **«Олеся»** (1891). [T1: ЕУЛ corpus]
+- `1900–1908` — late, more political plays: **«Супротивні течії»**, **«Конон Блискавиченко»** (1902), **«Страчена сила»** (1903), **«Розгардіяш»** (1906), **«Старі сучки й молоді парості»** (1908) — several censored or first published posthumously. [T1: ЕУЛ corpus]
+- `1907–1908` — the children's fairy-plays **«Івасик-Телесик»** and **«По щучому велінню»**, staged at the **children's theatre he founded on his хутір Затишок** — the first children's theatre in the Russian Empire with child actors. [T3: uk.wikipedia]
+- **Theatre leadership:** founded the **first Ukrainian professional troupe — the «Товариство акторів» / Театр корифеїв — in Єлисаветград, 27 October 1882**; its debut «Наталка Полтавка» launched **Марія Заньковецька** on the professional stage; he was teacher to the whole coryphaei generation (§7). [T3: uk.wikipedia]
+
+**Suppression note:** «Глитай», «Дві сім'ї», «Замулені джерела», «Розгардіяш», «Зерно і полова» were censored or banned; canonical texts of several plays were withheld from print until long after 1910.
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest corpus note (#M-4):** the project's literary index does **not** hold Kropyvnytskyi's dramatic texts, so `verify_quote` is **N/A** for them. Both quotes below are **documented** from his own «Автобіографія» and letters as transcribed in Tier-1/Tier-3 sources, with the corpus limitation disclosed.
+
+**Quote 1 — on the empire's praise that refuses to name the nation (his words on the 1874 Petersburg tour):**
+
+> «Столичні часописи похваляли мої вистави, похваляли й голоси, але ніколи ні жодного слова не сказали про те, відкіля ці таланти й голоси, хто вони Росії і хто Росія їм?»
+
+`verify_quote` → **N/A** (corpus lacks his texts); **documented** via his «Автобіографія»/listy. [T3: uk.wikipedia] Pedagogically central and *decolonial*: the founder of Ukrainian theatre naming the imperial gaze that admires the "talent" while erasing the nation it comes from — a B2 text for discussing cultural appropriation under empire.
+
+**Quote 2 — on his father, opening his «Автобіографія»:**
+
+> «…людиною „труда мозольного“ [, який] знав, що таке злидні.»
+
+`verify_quote` → **N/A** (corpus lacks his autobiography); **documented** via uk.wikipedia's quotation of his «Автобіографія». [T3: uk.wikipedia] A short register specimen of his plain, self-made-man voice and class origin. (A third documented line, from his Galician tour — «Мене тут, по сцені, вважають апостолом» — captures how the censorship-free western lands received him as a missionary of national culture.)
+
+## 5. Language register
+
+- **Register:** living village vernacular — his dramatic dialogue "іскриться від народних приповідок та прислів'їв"; mixed melodrama with folk song and dance (the etnografichno-pobutova mode), with sharper social-psychological registers in «Глитай» and the late plays.
+- **CEFR readiness for full reading:** the song-and-dance comedies at **B1**; the social dramas («Глитай», «Дай серцю волю») at **B2**; the late political plays at **B2–C1**.
+- **Lexicon notes (pre-teach):** **лихвар** (the «Глитай» theme), **мелодрама**, **корифей**, трупа, режисер, водевіль, **псевдонім**, **діалектизм** — all VESUM-valid (verified). His texts are a reservoir of **приповідки/прислів'я** for idiom work.
+- **Stylistic features:** masterful stagecraft (contemporaries called his skill "загадковим"), proverb-rich dialogue, the village-profiteer "type" (Бичок) as a social portrait; he composed his own incidental music for many plays.
+
+## 6. Contested points
+
+- **"Mere melodrama" vs serious dramatist (anti-hagiography).** Чижевський is hard on him — "загальновідомі картини соціального гніту" and crowd-pleasing "вип'ємо горілки — потанцюємо" theatre; but modern scholarship (and the censored-text record) shows his late plays reaching toward the "нова європейська естетична система" — neoromanticism, symbolism, even "драма абсурду" elements. The truth is both: a popular entertainer **and** an evolving artist whose serious texts were suppressed. [T3: uk.wikipedia — Чижевський; ЕУЛ corpus]
+- **Theatre-of-Coryphaei "merger" myth.** A persistent error claims Kropyvnytskyi's 1882 troupe "merged" with Starytsky's in 1883. In fact his **Товариство акторів was the only Ukrainian professional troupe**, and in August 1883 he simply handed its **leadership** to Starytsky (the financier), staying on as director/actor; the two later formed two troupes (April 1885) from one company. State the leadership-transfer, not a "merger." [T3: uk.wikipedia]
+- **Personal-ambition narrative.** The 1885 split is often blamed on "непогамованість особистих амбіцій"; the record shows it was largely driven by the over-grown troupe's **finances**, and the split actually *preserved* the whole acting ensemble as two professional theatres. [T3: uk.wikipedia]
+- **Russian framing** reduces his theatre to picturesque "хохлацький театр" colour — exactly the imperial gaze he himself named (§4 Quote 1).
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml` — took over the Театр корифеїв's leadership from Kropyvnytskyi (1883); co-builder of Ukrainian theatre.
+  - `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml` — coryphaeus and playwright (Тобілевич brother), trained in Kropyvnytskyi's troupe.
+  - `curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml` — debuted on the professional stage in his troupe's 1882 «Наталка Полтавка».
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — the music wing of the same theatre movement.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the Ems-Ukase regime (and the 1883 theatre ban) that defined his career (§2).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/mykhailo-starytsky.yaml` — the coryphaei-theatre LIT cluster his bio anchors alongside.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated **Театр корифеїв** HIST module (Кропивницький as founder; Заньковецька, Садовський, Саксаганський, Карпенко-Карий, Затиркевич-Карпинська) — not yet built.
+  - A bio-to-bio tie with `mykola-sadovskyi` / `panas-saksahanskyi` (Тобілевич brothers, his actors) — no plans yet.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A «Глитай, або ж Павук» module (the village-profiteer "type" + the censorship history of the play).
+
+## 8. Naming-canonical
+
+- **Slug:** `marko-kropyvnytskyi`
+- **EN canonical (BGN/PCGN-style project spelling):** Marko Kropyvnytsky
+- **UA canonical (with patronymic):** Марко Лукич Кропивницький
+- **Aliases to track (`aliases:` YAML field):** Marko Kropyvnytsky; «батько українського театру» (epithet); birth-place variants Бежбайраки / (now) Кропивницьке.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Марк Лукич Кропивницкий; "Kropivnitsky" as a Russified transliteration. (Note: the oblast capital **Кіровоград was renamed Кропивницький in 2016** — a decommunisation honour, not a Russified form.)
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Marko Kropyvnytsky"** — late-19th/early-20th-c. photographs; he died 1910, so portraits are public domain by age. Use the individual **file page** for license proof. [Commons category: `Marko Kropyvnytsky`]
+- **Backup candidates:**
+  - The **bronze bust on his grave** in Kharkiv (sculptor Федір Балавенський, 1914) — context image (verify rights).
+  - Production stills / афіші of the Театр корифеїв — context images.
+  - НБУ/Укрпошта commemorative issues for his anniversaries — verify PD/rights.
+- **Context image:** the Bergonnier-theatre memorial plaque ("10 січня 1882… перший виступ українського професійного театру") or a «Глитай, або ж Павук» playbill — strong §2/§3 illustration.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Kropyvnytsky, Marko." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\R\KropyvnytskyMarko.htm. Accessed 2026-06-03. (Birth 22 May 1840 Bezhbairaky; death 21 April 1910 en route, buried Kharkiv; first professional troupe 1882; Zankovetska/Sadovsky; «Глитай», «Дай серцю волю».)
+- *Українська літературна енциклопедія* — "Кропивницький Марко Лукич" (drama-by-drama record incl. the censorship bans; §2/§3 baseline).
+
+**Tier 2 (institutional):**
+- Меморіальний музей М. Л. Кропивницького (Кіровоград/Кропивницький; opened 1982, 100th anniversary of the Ukrainian professional theatre) — collection-based biography and holdings.
+- Кропивницький академічний обласний український музично-драматичний театр ім. М. Кропивницького — institutional memory.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Кропивницький Марко Лукич." Accessed 2026-06-03. Verbatim source for: the «Автобіографія»/listy quotes (§4); the 1876→1883 censorship chain incl. the **Дрентельн ban**; death-in-the-train detail; the troupe-leadership-transfer correction (§6). Cross-checked against IEU/ЕУЛ.
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Чижевський Д. *Історія української літератури* — the critical reading of his theatre (§6).
+- Антонович Д. — on the Kyiv/Yelysavethrad theatre milieu (§7 candidate).
+- Йосипенко М.; Пилипчук Р. — Kropyvnytskyi theatre-history scholarship (referenced as field-standard).
+
+**Tier 5 (general web — used only with T1–T4 corroboration):** none relied upon for core claims this pass.
+
+**Primary-source documents accessed (in transcription):**
+- His «Автобіографія» and letters (the 1874 Petersburg-tour reflection; the father's "труда мозольного"; the Galician "апостол" line) — quoted §4 via uk.wikipedia transcription; `verify_quote` N/A (corpus lacks his texts), disclosed.
+
+**Honest gaps:** The project literary corpus does not contain Kropyvnytskyi's plays or autobiography, so §4 rests on **documented** quotations (Tier-1/Tier-3) rather than `verify_quote` confirmation — the limitation is stated (#M-4). Older diaspora sources carry a 1840/1841 + Бежбайраки/Жеванівка variant, resolved to the standard modern form (§1). The ЕУЛ/IEU article pages are cited as the authoritative baseline; some censored-play dating relies on the ЕУЛ corpus transcription.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Kropyvnytskyi's theatre is told as the founding of a national institution; the empire appears as the banning (Ems Ukase, Drentteln) power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Емський указ / Театр корифеїв / Дрентельнова заборона as markers.
+- [x] No uncritical Soviet propaganda terms — "етнографічно-побутова"/"хохлацький театр" appear only as framings being analysed/refuted (§6).
+- [x] No "lost his life" euphemisms — death by cerebral haemorrhage on the train is stated plainly.
+- [x] Modern UA place names — Бежбайраки → Кропивницьке (Кіровоградщина), Єлисаветград, Харків; the 2016 Кіровоград→Кропивницький renaming noted as decommunisation.
+- [N/A] Holodomor — не стосується (Kropyvnytskyi died 1910).
+- [x] Russian aggression framing — the dossier foregrounds his own naming of the imperial gaze that praises "talent" while erasing the nation (§4 Quote 1, §6).

--- a/docs/research/bio/mykhailo-starytsky.md
+++ b/docs/research/bio/mykhailo-starytsky.md
@@ -1,0 +1,167 @@
+# Михайло Петрович Старицький — Research Dossier
+
+**Slug:** `mykhailo-starytsky`
+**Block:** B (imperial-era persecuted patriot; theatre & language builder under censorship)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave E)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU, ЕІУ, Шевченківська енциклопедія; uk.wikipedia cross-checked)
+- [x] Oppression mechanism is specific (Ems-Ukase-driven 1878 withdrawal; named theatre-banning circulars)
+- [x] ≥2 primary-source quotes (documented; `verify_quote` results honestly reported, incl. 0.0 corpus misses)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Петрович Старицький. [T1: IEU — "Starytsky, Mykhailo"; T1: ЕІУ — Лазанська, "Старицький Михайло Петрович", т.9, с.811; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **М. Стариченко** (used for his Andersen translations); criptonyms in Galician journals. Russified form (forbidden in body text, §8 only): Михаил Петрович Старицкий.
+- **Born:** see the **birth-date dispute below** | с. Кліщинці, Золотоніський повіт, Полтавська губернія | now Чорнобаївський район, Черкаська область; the Російська імперія then held Лівобережжя. [T3: uk.wikipedia; T1: IEU]
+- **Died:** 14 (27) April 1904 (heart disease) | Київ | Російська імперія; buried at the **Байкове кладовище**. [T1: IEU — "27 April 1904, Kyiv"; T3: uk.wikipedia]
+- **Family / education key facts:** Of a gentry (шляхетський) line; orphaned young and **raised in the household of his cousin Віталій Лисенко — father of the composer Микола Лисенко**, making Starytsky and Lysenko **relatives and lifelong artistic partners**. Studied at the Полтавська гімназія, then Kharkiv and Kyiv universities (physics-mathematics, later law; graduated Kyiv 1865); member of the **Київська (Стара) громада**. Married Софія Лисенко (1862). His daughter **Людмила Старицька-Черняхівська** became a major writer. [T3: uk.wikipedia; T1: IEU]
+
+**Source disagreement / correction note (⚠ birth-year ambiguity — flagged, NOT smoothed):** Sources split on **both the year and the month** of his birth:
+- **Modern UA scholarship + the birth-record reading** give **2 (14) November 1839**. [T3: uk.wikipedia — "2 (14) листопада 1839", citing ЕІУ т.9]
+- **IEU and the official state commemoration** give **14 December 1840**. [T1: IEU — "b 14 December 1840"; the Verkhovna Rada's 2019 resolution marks "14 грудня — 180 років з дня народження Михайла Старицького (1840–1904)"]
+
+The spread (Nov 1839 vs Dec 1840) is genuine and unresolved in the sources; the dossier records **both** so any module and the live wiki can present the ambiguity honestly rather than picking one silently. Where a single form is unavoidable, prefer **«1840»** only with the explicit note that the birth-record reading is **1839**.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Starytsky was not arrested or executed; the empire **strangled his cultural work by censorship**, and the mechanism is specific and documentary.
+
+- **What happened:** After the **Емський указ (1876)**, tsarist hostility forced him to **suspend his public/civic activity (~1878)**; the Ukrainian theatre he would later lead operated under a regime of bans and a compulsory-Russian-repertoire rule. [T1: IEU — "Owing to official tsarist hostility… after the Ems Ukase, Starytsky was forced to emigrate in 1878"; T3: uk.wikipedia — "1878 р. під тиском імперської влади Старицький припиняє активну громадську діяльність"]
+- **When (specific):** **1876 (Ems Ukase) → 1878 (withdrawal from public life) → 1881/1883** (the theatre's legal squeeze). [T1: IEU; T3: uk.wikipedia]
+- **By whom (specific instruments):** the **Емський указ** of Alexander II (1876) banning Ukrainian-language publishing, theatre, and import of books; and the **1881 circular** that permitted Ukrainian plays only under a forced pairing with a Russian piece and forbade "влаштування спеціально малоросійського театру"; then the **1883 ban by Kyiv governor-general Олександр Дрентельн** on Ukrainian theatre across Kyiv, Volhynia, Podillia, plus Poltava and Chernihiv gubernias. [T3: uk.wikipedia — corroborated in the Kropyvnytskyi record]
+- **Mechanism specifics:** several of Starytsky's plays were **held back or cut by the censor** (Чижевський notes "деякі на сцену не допустила цензура"). A chornosotenets journalist publicly branded him a "драматург-хищник" (a plagiarist-predator); Starytsky **won the libel suit**, but the episode shows the hostile climate around Ukrainian theatre. He poured the proceeds of his sold **Карлівка estate** into the troupe to keep Ukrainian theatre alive under these constraints. [T3: uk.wikipedia]
+- **What survived / what was distorted:** His plays survived and became repertoire staples, but the **Soviet period printed his historical fiction (e.g. «Розбійник Кармелюк») mostly in Russian translation first** and folded his theatre into a de-nationalised "this is folkloric entertainment" frame, muting its role as an act of cultural defence under the Ems regime.
+
+## 3. Major works
+
+- `1865 →` — civic and intimate lyric poetry: **«До України»**, **«До молоді»**, **«Швачка»**, **«Морітурі»**, **«До Шевченка»**; some became folk songs (**«Виклик» / "Ніч яка місячна…"**, set by Lysenko; **«Ох і де ти, зіронько…»**). [T3: uk.wikipedia]
+- `1872` — staged **«Чорноморці»** (Lysenko's music; Starytsky director) — among the first Ukrainian musical-theatre performances in Kyiv. [T3: uk.wikipedia]
+- `1876–1882` — verse translations: **Сербські народні думи і пісні** (1876); **«Гамлет»** of Shakespeare (1882); Andersen, Byron, Heine, Mickiewicz. [T3: uk.wikipedia]
+- `1881–1893` — social dramas **«Не судилось» / «Панське болото»** (1881), **«У темряві»** (1893), **«Талан»** (1893, on the fate of an actress — dedicated to Заньковецька). [T1: IEU; T3: uk.wikipedia]
+- `1883` — the comedy **«За двома зайцями»** (his most enduringly popular work; reworked from Нечуй-Левицький's «На Кожум'яках»). [T3: uk.wikipedia]
+- `1890` — **«Ой не ходи, Грицю, та й на вечорниці»**. [T1: IEU; T3: uk.wikipedia]
+- `1897–1899` — historical drama **«Богдан Хмельницький»** (1897) and **«Маруся Богуславка»** (1899). [T1: IEU; T3: uk.wikipedia]
+- `1894–1903` — historical prose **«Оборона Буші»** (1894), **«Перед бурею»**, **«Молодість Мазепи»**, **«Розбійник Кармелюк»** (1903). [T3: uk.wikipedia]
+- **Theatre leadership:** headed the first Ukrainian professional troupe (**Театр корифеїв**) from **August 1883** (Kropyvnytskyi had founded it Oct 1882); founded a new young-actors' troupe in 1885. [T1: IEU; T3: uk.wikipedia]
+
+**Modernised the literary language:** Starytsky deliberately coined neologisms — mocked in his day, now standard — "багато його неологізмів… здобули собі тривке місце у скарбниці української літературної мови, бо в їх творенні Старицький… йшов за духом народної мови." [T3: uk.wikipedia — Крип'якевич corpus]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest corpus note (#M-4):** the project's literary index (`ukrlib-starytsky`) does **not** hold Starytsky's lyric poetry — `verify_quote` returned **0.0** for his famous «Виклик» ("Ніч яка місячна…") and for the «Морітурі» line below. Both are nonetheless **well-documented** as his in Tier-1/Tier-3 references; they are quoted here as documented primary text with the corpus miss disclosed.
+
+**Quote 1 — from the poema «Морітурі» (his self-chosen epitaph), inscribed on his grave:**
+
+> «Нехай Україна у щасті буя, / у тім нагорода і втіха моя.»
+
+`verify_quote` → **not matched, 0.0** (corpus lacks his verse); **documented** as the inscription on his grave at the Байкове кладовище. [T3: uk.wikipedia — the 1948 grave plaque carried this line "із поеми «Morituri»"] Pedagogically: a one-line credo of self-effacing service to the nation — A2-reachable.
+
+**Quote 2 — «Виклик» (1870; the romance "Ніч яка місячна…", set to Lysenko's music):**
+
+> «Ніч яка місячна, ясная, зоряна, / видно, хоч голки збирай…»
+
+`verify_quote` → **not matched, 0.0** (corpus lacks it; the song's authorship is sometimes treated as folk, but the verse «Виклик» is attributed to Starytsky in standard references). [T3: uk.wikipedia — listed among "деякі ліричні поезії Старицького стали народними піснями"] Pedagogically: a Starytsky text that **passed into the folk-song repertoire** — a teachable example of literary verse becoming "народна пісня," with the authorship-vs-folk question flagged for honesty.
+
+## 5. Language register
+
+- **Register:** mixed — high civic-romantic lyric, fluent dramatic dialogue, and (in «За двома зайцями») comic **міщанський суржик** used satirically (Голохвостий's pretentious half-Russian speech). His historical fiction reaches for an elevated narrative register.
+- **CEFR readiness for full reading:** the songs and short lyric at **A2–B1**; the comedies at **B1–B2**; the social and historical dramas at **B2–C1**; historical prose at **C1**.
+- **Lexicon notes (pre-teach):** **корифей**, **мелодрама**, лібрето, інсценізація, **псевдонім**, неологізм, побутовий театр — all VESUM-valid (verified). Watch his deliberate **neologisms** (now standard) and the **satirical surzhyk** of Голохвостий, which must be taught as *characterisation*, not as a model.
+- **Stylistic features:** strong stage situations and characters (IEU: "видатний майстер гострих драматичних ситуацій і сильних характерів"); songcraft; a language-modernising drive that enriched the literary lexicon.
+
+## 6. Contested points
+
+- **Author-modernizer vs theatre-populist (anti-hagiography).** Чижевський criticises Starytsky for following Kropyvnytskyi's crowd-pleasing "етнографічні прикраси" — songs, dances, embroidered shirts — rather than building a didactic theatre; yet Крип'якевич credits his serious work on the literary language and his lasting neologisms. Both are true: a language reformer who also gave the box office what it wanted. [T3: uk.wikipedia — Чижевський, Крип'якевич corpora]
+- **«За двома зайцями»'s authorship layer.** It is a reworking of Нечуй-Левицький's «На Кожум'яках» — a real adaptation history that popular memory forgets. [T3: uk.wikipedia]
+- **The "драматург-хищник" libel.** The plagiarism slur (and his court victory) is a documented episode of the hostile climate around Ukrainian theatre, not evidence against him. [T3: uk.wikipedia — Чижевський/Кропивницький record]
+- **Birth-date confusion** (§1): the 1839/1840 split is a real source dispute; resist the urge to "round" it.
+- **Russian framing** likes to file Starytsky's theatre under harmless "Little-Russian colour," erasing that staging Ukrainian at all was, under the Ems Ukase, an act of resistance.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — his cousin, librettist-partner, and co-founder of Ukrainian musical theatre — the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml` — founded the Театр корифеїв (1882) that Starytsky led from 1883.
+  - `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml` — fellow coryphaeus (Тобілевич brother).
+  - `curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml` — the troupe's prima; «Талан» is dedicated to her.
+  - `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml` — the Косач–Старицький–Лисенко Kyiv circle (his daughter Людмила Старицька-Черняхівська was Lesya's close peer).
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the Ems Ukase that drove his 1878 withdrawal and walled in his theatre (§2).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/mykhailo-starytsky.yaml` — the LIT-track Starytsky anchor this bio should connect to.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated **Театр корифеїв** HIST module (founders Кропивницький/Старицький/Тобілевичі/Заньковецька) — not yet built.
+  - A bio-to-bio tie with `liudmyla-starytska-cherniakhivska` (his daughter) — no plan yet.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A «За двома зайцями» comedy module (with the Нечуй-Левицький adaptation history and the satirical-surzhyk pedagogy of §5).
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-starytsky`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykhailo Starytsky
+- **UA canonical (with patronymic):** Михайло Петрович Старицький
+- **Aliases to track (`aliases:` YAML field):** Mykhailo Starytsky; М. Стариченко (pseud.); birth-year variants 1839 / 1840.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Михаил Петрович Старицкий; "Razboinik Karmeliuk" as the canonical title (the work is Ukrainian, published in Russian first under censorship).
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Mykhailo Starytsky"** — late-19th-c. photographs; he died 1904, so portraits are public domain by age. Use the individual **file page** for license proof. [Commons category: `Mykhailo Starytsky`]
+- **Backup candidates:**
+  - Укрпошта stamp "Михайло Старицький. 1840–1904" (issued 12.11.2020) — note it uses the **1840** date (§1); verify stamp-rights/PD status.
+  - The Kyiv Starytsky museum (his last home) — context image (verify rights).
+  - A playbill/афіша of the Театр корифеїв or a «За двома зайцями» production still — context image.
+- **Context image:** a title page of his «Гамлет» translation (1882) or the «Талан» first edition — strong §3 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Starytsky, Mykhailo." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\S\T\StarytskyMykhailo.htm. Accessed 2026-06-03. (Birth **14 December 1840** [see §1 dispute]; death 27 April 1904 Kyiv; Lysenko librettos; troupe from 1883; Ems-Ukase-driven 1878 withdrawal.)
+- Лазанська Т. І. "Старицький Михайло Петрович." *Енциклопедія історії України*, т. 9. Київ: Наукова думка, 2012. С. 811.
+- *Шевченківська енциклопедія*, т. 5. Київ: Ін-т літератури ім. Т. Г. Шевченка, 2015. С. 938–939 — "Старицький Михайло Петрович."
+
+**Tier 2 (institutional):**
+- Музей Михайла Старицького (Київ) — collection-based biography and holdings.
+- Новиков А. *Український театр і драматургія…* Харків: Харківське іст.-філол. товариство, 2015 — theatre-history apparatus.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Старицький Михайло Петрович." Accessed 2026-06-03. Verbatim source for: the **1839/1840** birth split; the Lysenko-household upbringing; the 1878 withdrawal; the Дрентельн theatre ban (corroborated in the Kropyvnytskyi article); the grave inscription. Cross-checked against IEU/ЕІУ.
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Крип'якевич І. *Історія української культури* — on Starytsky's literary-language modernisation and neologisms (§3).
+- Чижевський Д. *Історія української літератури* — the critical (anti-hagiographic) reading of his theatre (§6).
+- Зеров М. "Літературна позиція М. Старицького." *Життя і Революція*, 1929 — foundational critical essay.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- "Михайло Старицький і прорвані ним канони." *Український кризовий медіа-центр*, 10.07.2023 — popular framing, corroborated by T1/T4.
+
+**Primary-source documents accessed (in transcription):**
+- The grave inscription from «Морітурі» (§4 Quote 1), via uk.wikipedia transcription; `verify_quote` = 0.0 (corpus lacks his verse), reported honestly.
+- «Виклик» / "Ніч яка місячна…" (§4 Quote 2), documented via standard references; `verify_quote` = 0.0, authorship-vs-folk question flagged.
+
+**Honest gaps:** The project literary corpus does not contain Starytsky's lyric poetry, so neither §4 quote is `verify_quote`-confirmed — both are documented via Tier-1/Tier-3 sources and the corpus misses are disclosed (#M-4). The birth date carries a real two-axis split (year *and* month), flagged not smoothed (§1). The ЕІУ/Шевченківська-енциклопедія article pages were not separately opened this pass (cited as standard UA baselines alongside the directly-fetched IEU).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Starytsky's theatre and language work are told as Ukrainian cultural defence; the empire appears as the censoring (Ems Ukase, Drentteln) power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Емський указ / Театр корифеїв / Стара громада as markers.
+- [x] No uncritical Soviet propaganda terms — "Little-Russian colour" appears only as the framing being refuted (§6).
+- [x] No "lost his life" euphemisms — N/A (died of heart disease 1904); oppression here is censorship, named precisely.
+- [x] Modern UA place names — Кліщинці (Черкащина), Київ, Байкове кладовище.
+- [N/A] Holodomor — не стосується (Starytsky died 1904).
+- [x] Russian aggression framing — the dossier names how Russian narratives reduce his theatre to harmless "колорит," erasing that staging Ukrainian under the Ems Ukase was resistance (§6).

--- a/docs/research/bio/olena-pchilka.md
+++ b/docs/research/bio/olena-pchilka.md
@@ -1,0 +1,169 @@
+# Олена Пчілка (Ольга Петрівна Косач) — Research Dossier
+
+**Slug:** `olena-pchilka`
+**Block:** B (imperial-era persecuted patriot; also persecuted by the Bolsheviks)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave E)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ, ЕУ, Огієнко; uk.wikipedia cross-checked)
+- [x] Oppression mechanism is specific (imperial language ban defied 1903/1905 + Bolshevik 1920 arrest)
+- [x] ≥2 primary-source quotes (documented from her «Автобіографія»/recorded act; `verify_quote` 0.0 disclosed)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03; bare slugs `lesya-ukrainka`/`mykhailo-drahomanov` cross-linked
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ольга Петрівна Косач (до шлюбу **Драгоманова**), pen-name **Олена Пчілка**. [T1: ЕІУ — Янишин, "Пчілка Олена", т.9, с.69; T1: ЕУ (Сарсель), "Пчілка Олена"; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **Олена Пчілка** (the canonical pen-name). Russified form (forbidden in body text, §8 only): Ольга Петровна Косач.
+- **Born:** **29 June (11 July) 1849** | Гадяч, Гадяцький повіт, Полтавська губернія | the Російська імперія. [T3: uk.wikipedia — metrical record "29 червня (11 липня) 1849"; T1: Огієнко corpus — "народилася 29.VI.1849-го року в Гадячому на Полтавщині"]
+- **Died:** **4 October 1930** | Київ | Українська СРР (СРСР); buried at the **Байкове кладовище** beside her daughter, husband, and son. [T3: uk.wikipedia; T1: Огієнко corpus — "померла 4.Х. року 1930-го"]
+- **Family / education key facts (load-bearing):** Of the **Драгоманови** Hetmanate line; **sister of Михайло Драгоманов** (`mykhailo-drahomanov`) and **mother of Леся Українка** (`lesya-ukrainka`, b. Лариса Косач 1871) — the single most important kinship axis in this dossier. Married **Петро Косач** in 1868; six children (Михайло 1869–1903, Лариса/Леся 1871–1913, Ольга, Оксана, Микола 1884–1937, Ізидора). Educated at home and at a Kyiv pension for noble girls; she **kept her own children out of the Russian state school**, teaching them Ukrainian herself (§2/§6). **Member-correspondent of the ВУАН (1925).** [T3: uk.wikipedia; T1: ЕІУ]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+- **Birth date:** the long-current popular form **"17 July 1849"** is **corrected** by the family documents and her own daughter's account, which the metrical book confirms as **29 June (11 July) 1849**. Use 29 June (O.S.) / 11 July (N.S.). [T3: uk.wikipedia — "Загальновживана версія… 17 липня. Проте ця дата суперечить документам родини Драгоманових… Метричний запис… подає дату 29 червня (11 липня)"]
+- **⚠ ВУАН year:** uk.wikipedia (twice) and the standard record give her election as **member-correspondent in 1925**; the build-brief's "**1927**" is **not** what the encyclopedic sources state. The dossier records **1925** as the sourced year and flags the 1927 figure as unconfirmed — to be checked against the ВУАН proceedings before any module asserts it. [T3: uk.wikipedia — "член-кореспондент… (1925)"; "членом-кореспондентом з 1925 року"]
+
+## 2. Oppression mechanism
+
+This is the load-bearing section, and Pchilka's case spans **two regimes**: imperial language-ban defiance, then Bolshevik arrest.
+
+**(a) Imperial censorship — and her public defiance of it.**
+- **1903, Полтава:** at the unveiling of the **Котляревський monument**, Pchilka was **the only delegate from Russian-ruled Ukraine to speak in Ukrainian**, breaking the tsarist categorical ban on public Ukrainian speech. [T3: uk.wikipedia — "Олена Пчілка єдина з представників підросійської України виступає українською мовою, порушуючи… категоричну заборону"]
+- **1905, Санкт-Петербург:** one of four Ukrainian-intelligentsia delegates who petitioned PM **Сергій Вітте** to lift the ban on Ukrainian print and schooling (the **Валуєвський циркуляр (1863)** / **Емський указ (1876)** regime) — "безрезультатно." [T3: uk.wikipedia]
+- She raised her children in Ukrainian and refused the imperial school precisely as resistance to **русифікація**. [T1: Огієнко corpus]
+
+**(b) Bolshevik persecution — arrest, 1920.**
+- **What happened:** **arrested in Гадяч** for "антибільшовицькі виступи." [T3: uk.wikipedia]
+- **When / the trigger:** **1920**, during a Shevchenko-birthday commemoration at the Гадяцька гімназія, she **draped Shevchenko's bust in a blue-and-yellow flag**; when the commissar **Крамаренко** tore it off, she led the hall in chanting **«Ганьба Крамаренкові!»** [T3: uk.wikipedia]
+- **By whom:** the Bolshevik (radianska) authorities in Гадяч. After release she fled to Могилів-Подільський (until 1924), then lived in Kyiv until her death. [T3: uk.wikipedia]
+- **What survived / what was distorted:** She survived both, but the Soviet period treated her warily — a member-correspondent of the academy who was also a documented Ukrainian nationalist; modern editions (the 2025 Volyn University 12-volume collected works) are still recovering texts, some "узагалі… втраченими." [T3: uk.wikipedia]
+
+## 3. Major works
+
+- `1876` — **«Український народний орнамент»** (23 colour plates of писанки/embroidery) — made her the first authority on Ukrainian folk ornament. [T3: uk.wikipedia]
+- `1881` — **«Українським дітям»** — her translations of Gogol, Pushkin, Lermontov for children. [T3: uk.wikipedia]
+- `1886` — **«Думки-мережанки»** — her first poetry collection. [T3: uk.wikipedia]
+- `1887, Львів` — **«Перший вінок»** — the **first Ukrainian feminist almanac**, published with **Наталія Кобринська**. [T1: ЕІУ; T3: uk.wikipedia]
+- `1887–1908` — prose: **«Товаришки»** (1887), **«Світло добра і любові»** (1888), **«За правдою»** (1889); the plays **«Сужена не огужена»** (1881), **«Світова річ»** (1908). [T3: uk.wikipedia]
+- `1906–1914` — publisher/editor of **«Рідний Край»** with the children's supplement **«Молода Україна»** (1908–1914) — a leading platform for the Ukrainian word and a school of language purity. [T1: Огієнко corpus; T3: uk.wikipedia]
+- `children's literature` — plays and verse incl. **«Весняний ранок Тарасовий»** (1914), **«Зелений гай»**, **«Кобзареві діти»** — she holds a foundational place in Ukrainian children's literature. [T3: uk.wikipedia]
+- `memoir / criticism` — **«Михайло Старицький»** (1904), **«Марко Кропивницький як артист і автор»** (1910), **«Микола Лисенко»** (1913), **«Спогади про Михайла Драгоманова»** (1926), **«Автобіографія»** (1930). [T3: uk.wikipedia]
+
+**Suppression note:** much of her corpus was scattered or lost; a full critical edition appeared only in **2025** (Волинський національний університет імені Лесі Українки).
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest corpus note (#M-4):** the project's literary index does **not** hold Pchilka's works (`verify_quote` for her «Автобіографія» line returned **0.0**). Both quotes below are **documented** from her own «Автобіографія»/recorded acts as transcribed in Tier-1/Tier-3 sources.
+
+**Quote 1 — «Автобіографія» / memoir, on the Ukrainian milieu of her childhood:**
+
+> «Українська течія — се було наше природне оточення… Щодо пісень українських… то не знаю, чи ще в якому панському домі співано їх так багато, як у нас.»
+
+`verify_quote` → **0.0** (corpus lacks her texts); **documented** via uk.wikipedia's quotation of her memoir. Pedagogically: the source of her lifelong cultural mission, in her own voice — a B1 text on family-as-nation-transmission. [Primary: documented]
+
+**Quote 2 — recorded act of defiance, Гадяч, 1920:**
+
+> «Ганьба Крамаренкові!»
+
+`verify_quote` → **N/A** (a recorded spoken cry, not a literary text); **documented** as the chant she led after the commissar tore the blue-and-yellow flag off Shevchenko's bust (§2b). [T3: uk.wikipedia] Pedagogically: a three-word primary document of civic courage at 71 under Bolshevik rule. (A third documented memoir line — her Гадяч landscape: «…я завжди думала, що се чи не найкращий на всю Полтавщину краєвид» — is a register specimen of her descriptive prose.)
+
+## 5. Language register
+
+- **Register:** cultivated, purist literary Ukrainian — she "не раз зводила бої за чистоту української мови" in «Рідний Край» and shaped her daughter Lesya's language directly (§6). Range from children's verse to ethnographic and polemical prose.
+- **CEFR readiness for full reading:** the children's verse and folk-ornament descriptions at **A2–B1**; her prose and memoir at **B2**; the «Перший вінок» feminist-programmatic and critical essays at **C1**.
+- **Lexicon notes (pre-teach):** **етнографка**, орнамент, писанка, фемінізм, видавчиня, **псевдонім**, **діалектизм** — all VESUM-valid (verified). Her texts are a source of folk-ornament and ethnographic vocabulary.
+- **Stylistic features:** ethnographic precision, didactic warmth in children's work, a combative editorial voice in journalism; a deliberate language-purity discipline she imposed on herself and her family.
+
+## 6. Contested points
+
+- **Controlling mother vs liberating educator (anti-hagiography core).** Pchilka shaped Lesya Українка's genius — chose her pen-name, kept her from the Russian school, taught her Ukrainian and several languages, and "завжди виправляла їй мову." Modern feminist scholarship (Віра Агеєва et al., *Бунтарки*) reads this same formative power as also **controlling**: she steered Lesya's publishing, career, and personal life with a strong, at times domineering, hand. Tell both: the educator who made Lesya possible **and** the mother whose control constrained her. [T1: Огієнко corpus — the editorial-control facts; T4: Агеєва, *Бунтарки* — the critical re-reading]
+- **Conflicts with contemporaries, including Franko.** Pchilka was a famously combative national-conservative figure whose polemical editorial persona brought her into tension with several contemporaries; scholarship records friction with **Іван Франко** rooted in her national-traditionalist stance versus his radical-socialist one. *(The specific Franko episodes should be cited from her «Рідний Край» polemics and the ЛНВ exchanges before a module asserts particulars; flagged here rather than fabricated — #M-4.)* [scholarly consensus; precise documents to verify]
+- **"Мати українського націоналізму."** Popular framing (and several recent titles) calls her "the mother of Ukrainian nationalism" — a real strand of her self-presentation, but one that flattens the ethnographer, the feminist-almanac editor, and the children's-literature founder. [T3: uk.wikipedia]
+- **Russian/Soviet framing** either ignores her or files her as a minor "буржуазна" relative of Lesya — erasing her own first-rank work in folklore, feminism, publishing, and her 1920 anti-Bolshevik defiance.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml` — her daughter (bare slug: `lesya-ukrainka`); the central kinship link and the heart of any module on her.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml` — her brother (bare slug: `mykhailo-drahomanov`); she wrote his «Спогади» (1926).
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — contemporary and polemical foil (§6).
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` — fellow nation-builder/publisher of the same generation.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml` — subject of her 1904 memorial essay; the Косач–Старицький–Лисенко Kyiv circle.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/drahomanov.yaml` — the Драгоманов political-thought lineage she came from.
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` — the revival generation she belongs to.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the censorship she publicly defied in 1903/1905 (§2a).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/lesia-ukrainka-intro.yaml` — the LIT cluster on her daughter, which her formative role directly feeds.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A **«Перший вінок» / Ukrainian feminism** HIST/LIT module (Пчілка + `nataliia-kobrynska`) — no plan yet.
+  - A Ukrainian-children's-literature module anchored on her — not yet built.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A «Український народний орнамент» (folk-art + writing) cross-disciplinary module.
+
+## 8. Naming-canonical
+
+- **Slug:** `olena-pchilka`
+- **EN canonical (BGN/PCGN-style project spelling):** Olena Pchilka
+- **UA canonical (with patronymic):** Ольга Петрівна Косач (Олена Пчілка); née Драгоманова
+- **Aliases to track (`aliases:` YAML field):** Olena Pchilka; Olha Kosach; Olha Drahomanova-Kosach.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Ольга Петровна Косач; "Olga Kosach/Kossach" as a Russified rendering.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Olena Pchilka"** — late-19th/early-20th-c. photographs; she died 1930, so portraits are public domain by age (author-life+70 / pre-1929 US for pre-1929 images). Use the individual **file page** for license proof. [Commons category: `Olena Pchilka`]
+- **Backup candidates:**
+  - The first monument-bust to Olena Pchilka (Луцьк, 2011, sculptor Микола Обезюк) — context image (verify rights).
+  - A family group photograph of the Косачі (with Lesya) — strong §1 illustration (verify PD).
+  - A plate from «Український народний орнамент» (1876) — context image of her ethnographic work.
+- **Context image:** a cover of «Рідний Край» / «Молода Україна» — illustrates her publishing mission (§3).
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Янишин Б. М. "Пчілка Олена." *Енциклопедія історії України*, т. 9. Київ: Наукова думка, 2012. С. 69.
+- *Енциклопедія українознавства: Словникова частина* / гол. ред. В. Кубійович. Париж; Нью-Йорк: Молоде життя — "Пчілка Олена."
+- Огієнко І. *Історія української літературної мови* (corpus `wave9-ohiyenko-ist-lit-movy`) — confirms her birth/death dates, her sisterhood with Drahomanov, her direct language-formation of Lesya, and her «Рідний Край» language battles.
+
+**Tier 2 (institutional):**
+- Волинський національний університет імені Лесі Українки — the **2025 twelve-volume collected works** of Olena Pchilka (the recovery edition).
+- ЦДІАК України — archival holdings ("До 175-річчя… ЦДІАК України, 2024").
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Олена Пчілка." Accessed 2026-06-03. Verbatim source for: the **birth-date correction** (29 June, not 17 July); the **ВУАН 1925** year; the 1903 Poltava / 1905 Witte / 1920 Гадяч episodes; the «Автобіографія» quote and the «Ганьба Крамаренкові!» act. Cross-checked against ЕІУ/Огієнко.
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Агеєва В., Борисюк І., Пашко О. та ін. *Бунтарки: нові жінки і модерна нація.* Київ, 2020 — the feminist re-reading of her maternal control over Lesya (§6).
+- Одарченко П. "Видатна діячка української культури кінця XIX — початку XX століття" — biographical scholarship.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- "Мати українського націоналізму." *Український кризовий медіа-центр*, 24.04.2024 — popular framing (§6), corroborated by T1/T3.
+- "Забута і відкрита заново: як повне зібрання творів Олени Пчілки…" *УКМЦ*, 06.06.2025 — on the 2025 recovery edition.
+
+**Primary-source documents accessed (in transcription):**
+- Her «Автобіографія» (1930) and recorded 1920 act — quoted §4 via uk.wikipedia transcription; `verify_quote` 0.0 / N/A (corpus lacks her texts), disclosed.
+
+**Honest gaps:** The project literary corpus does not contain Pchilka's works, so §4 rests on **documented** memoir/recorded quotation rather than `verify_quote` confirmation (#M-4). The **ВУАН year** is given as **1925** per the encyclopedic sources, with the brief's 1927 flagged as unconfirmed (§1). The **Franko-conflict** particulars are flagged as scholarly-consensus-but-document-pending (§6) rather than asserted with invented specifics.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Pchilka's life is told on Ukrainian terms; both the empire (language ban) and the Bolsheviks (1920 arrest) appear as oppressing powers.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Валуєвський/Емський, Котляревський-monument 1903, the 1920 Bolshevik arrest as markers (not "Civil War").
+- [x] No uncritical Soviet propaganda terms — "буржуазна" framing named only as the Soviet erasure being refuted (§6).
+- [x] No "lost his life" euphemisms — N/A (died 1930, natural causes); oppression here is censorship + arrest, named precisely.
+- [x] Holodomor — она померла 1930, напередодні; не охоплює Голодомор у тілі досьє, тож [N/A] для прямої згадки.
+- [x] Modern UA place names — Гадяч (Полтавщина), Київ, Могилів-Подільський, Байкове кладовище.
+- [x] Russian aggression framing — her 1903 Ukrainian-language defiance and 1920 blue-and-yellow-flag act are framed as anti-imperial / anti-Bolshevik resistance (§2).

--- a/docs/research/bio/panteleimon-kulish.md
+++ b/docs/research/bio/panteleimon-kulish.md
@@ -1,0 +1,184 @@
+# Пантелеймон Олександрович Куліш — Research Dossier
+
+**Slug:** `panteleimon-kulish`
+**Block:** B (imperial-era persecuted patriot; ideologically contradictory founder)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave E)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU, ЕІУ, НТШ; uk.wikipedia cross-checked)
+- [x] Oppression mechanism is specific (1847 Cyril-Methodius arrest + named censorship instruments)
+- [x] ≥2 primary-source quotes (2 corpus `verify_quote`-confirmed at 1.0, confidence reported)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied (distinguished from the playwright `mykola-kulish`)
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+> **⚠ Identity guard (load-bearing):** This is **Пантелеймон Олександрович Куліш (1819–1897)**, the 19th-c. writer/historian/translator — **NOT** the executed playwright **Микола Куліш (1892–1937)** (`mykola-kulish`). Different person, different century, different fate. Do not conflate.
+
+- **Full name (UA, canonical):** Пантелеймон Олександрович Куліш. [T1: IEU — "Kulish, Panteleimon"; T1: ЕІУ — Удод/Грузін, "Куліш Пантелеймон Олександрович", т.5, с.468; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **Панько Куліш**; **Ратай Павло** (used in the journal «Правда»); **Николай М.** (cryptonym for his Russian-language Gogol writings). Russian-imperial/Russified forms (forbidden in body text, §8 only): Пантелеймон Александрович Кулиш, "Kulish/Kuliš" in Russified renderings.
+- **Born:** 26 July (O.S.) 1819 | містечко Вороніж, Глухівський повіт, Чернігівська губернія | the Російська імперія then held Лівобережжя; now с-ще Вороніж, Шосткинський район, Сумська область. [T3: uk.wikipedia — "26 липня (7 серпня) 1819"; T1: IEU — "8 August 1819"]
+- **Died:** 2 (14) February 1897 (aged 77) | хутір Мотронівка (which he renamed **Ганнина Пустинь**) near Борзна, Чернігівська губернія | Російська імперія; now с. Оленівка, Ніжинський район, Чернігівська область. [T1: IEU — "14 February 1897, Motronivka"; T3: uk.wikipedia]
+- **Family / education key facts:** Son of Олександр Андрійович Куліш, of a Cossack-officer (старшинський) line, and Катерина, daughter of a Cossack сотник. Schooled at the Новгород-Сіверська гімназія; from the late 1830s an **auditor (вільний слухач) at Kyiv (St Volodymyr) University**, but was **never granted a diploma** — he could not document noble status and so was barred from full matriculation. [T1: IEU — "enrolled at Kyiv University in 1837 but was not permitted to finish due to his non-noble status"; T3: uk.wikipedia] Married Олександра Білозерська (the writer **Ганна Барвінок**) on 22 January 1847; **Тарас Шевченко was the boyar (best man)** at the wedding. [T3: uk.wikipedia]
+
+**Source disagreement / correction note (flagged, not smoothed):** Tier 1 sources differ by one day on the **New-Style birth date**: from O.S. **26 July 1819** uk.wikipedia computes **7 August**, while IEU gives **8 August** — a Julian→Gregorian rounding difference, not a substantive dispute (both agree on 26 July O.S., 1819). The **two «Чорна рада» originals** (a Ukrainian and a Russian text that diverge in scenes and detail — see §3) are a real philological fact, not a contradiction to resolve. The live wiki must NOT be allowed to collapse `panteleimon-kulish` into `mykola-kulish`; the two are distinct people (§8).
+
+## 2. Oppression mechanism
+
+This is the load-bearing section, and for Kulish it cuts two ways — he was both **a victim of imperial repression** and, late in life, **an apologist for the empire** (§6). Honesty in both directions is the decolonial discipline here.
+
+- **What happened:** Arrested as a member of the **Кирило-Мефодіївське братство** (Cyril and Methodius Brotherhood), interrogated, imprisoned, and exiled. [T1: IEU; T3: uk.wikipedia]
+- **When (specific):** **1847.** Travelling toward Western Europe, he was seized by the tsarist police in **Warsaw**, returned to St Petersburg, and interrogated for nearly three months in the **III відділ (Third Section)** of the Imperial Chancellery. [T1: IEU — "arrested by the tsarist police in Warsaw… two months in prison… exiled for three years to Tula"; T3: uk.wikipedia]
+- **By whom (specific agency):** the **Третій відділ Власної Е.І.В. канцелярії** (the political police of Nicholas I) and the **жандармерія**. The gendarmes could not prove formal membership but punished him anyway. [T3: uk.wikipedia — quoting the gendarmerie ruling]
+- **Document references (quoted, not paraphrased):** the III-Section ruling on Kulish, quoted in the Ukrainian record, sentenced him for
+
+  > «…самовиношував надзвичайні думки про вигадану важливість України, вмістивши навіть у надрукованих од нього творах багато двозначних місць, що могли вселяти в малоросів думки про право їх на окреме існування від імперії, — замкнути в Олексіївський равелін на чотири місяці й потім відіслати на службу в Вологду…»
+
+  [T3: uk.wikipedia — quoting the gendarmerie resolution; corroborated by the published donesennia of Count A. F. Orlov on Shevchenko, Kostomarov and Kulish, «Правда», 1893]
+
+- **Mechanism specifics:** The sentence was commuted (through his wife's petitions and influential patrons) from the Aлексіївський равелін to **two months' detention and three years' exile to Тула**, where he was **forbidden to publish** — punishment for his Russian-language «Повість про український народ» (1846). During the arrest his wife, from nervous exhaustion, bore a **stillborn child** — the couple's only pregnancy. [T1: IEU; T3: uk.wikipedia]
+- **The second, indirect mechanism — censorship of the Ukrainian word.** Kulish's lifelong project — a Ukrainian literary language, a phonetic orthography (**кулішівка**, §3), and the first Ukrainian Bible — collided with the **Валуєвський циркуляр (1863)** and the **Емський указ (1876)**, which outlawed Ukrainian-language publishing in the empire. From **1876 кулішівка itself was banned** in the Russian Empire; he had to publish abroad (Lviv, Geneva, Vienna). His own «Хуторская философия…» (1879) was banned and withdrawn from sale by the censor. [T3: uk.wikipedia — "З 1876 року кулішівку було заборонено в Російській імперії"; T1: IEU]
+- **What survived / what was destroyed:** The **manuscript of his Old Testament translation burned in the November 1885 fire at Motronivka** (Ганнина Пустинь) — the translators had to begin again from scratch (§3). His name was later inconvenient to the Soviet canon because of his "контрреволюційний"/conservative late writings, so his foundational role was muted for decades.
+
+## 3. Major works
+
+A polymath: novelist, poet, historian, ethnographer, philologist, translator, publisher. Selected, chronological:
+
+- `1846 / publ. 1857` — **«Чорна рада. Хроніка 1663 року»** — the **first Ukrainian historical novel**, on the struggle for the hetmancy after Khmelnytsky's death; exists in **two divergent originals (Ukrainian and Russian)**. Франко called it "найліпша історична повість в нашій літературі." [T1: IEU; T3: uk.wikipedia]
+- `1856–1857` — **«Записки о Южной Руси»** (2 vols) — landmark folklore-historical-ethnographic collection, printed in his new **кулішівка** orthography. [T1: IEU; T3: uk.wikipedia]
+- `late 1850s` — **кулішівка**, the **first Ukrainian phonetic alphabet** (dropping ѣ and ы, introducing ґ-marking); it underlies the modern Ukrainian orthography, served the 1860 «Кобзар» and the journal «Основа», was **banned in the empire from 1876**, and was reintroduced (modified) in Galician schools in the 1890s. [T3: uk.wikipedia; T4: Даниленко, «Пиши, як мовиш…», Мовознавство 2012]
+- `1857` — **«Граматка»**, a Ukrainian primer/reader. [T3: uk.wikipedia]
+- `1861–1862` — **«Основа»** contributions; the historical essays **«Хмельнищина»** and **«Виговщина»**; the poetry collection **«Досвітки»** (1862). [T3: uk.wikipedia]
+- `1874–1877` — **«История воссоединения Руси»** (3 vols, Russian) — his **late pro-imperial revisionist history**, which damned Cossack and peasant risings and exalted the Polish szlachta, the Polonized Ukrainian gentry, and Russian tsarism; met with dismay and anger in Ukrainian society (Глібов, **Грінченко** among the sharp critics). [T3: uk.wikipedia; T1: IEU — "a new and very critical appraisal of the Cossacks"]
+- `1882` — **«Хуторна поезія»** (incl. «О слово рідне…», §4); **«Крашанка русинам і полякам»** (1882). [T3: uk.wikipedia]
+- `1888` — **«Отпадение Малороссии от Польши»** (3 vols, Russian). [T3: uk.wikipedia]
+- `1860 → posthumous` — **the first complete Ukrainian Bible**, begun 1860, with **Іван Нечуй-Левицький** and (from 1869) the physicist-theologian **Іван Пулюй**; the New Testament appeared **1881 (NTSh, Lviv)**; the **OT manuscript burned in 1885**; Pulyuy finished it after Kulish's death; the full Bible was issued **1903** by the British & Foreign Bible Society. [T1: IEU; T2: НТШ; T3: uk.wikipedia]
+- `Shakespeare, Byron, Goethe, Schiller, Heine` — pioneering Ukrainian verse translation ("Позичена кобза", Geneva 1897, posthumous). [T3: uk.wikipedia; T4: Даниленко, «Куліш як перекладач Шекспіра», 2020]
+
+**Suppression note:** «Хуторская философия…» (1879) was banned and withdrawn; кулішівка was outlawed from 1876; the Bible could appear only abroad and only fully in 1903; the OT manuscript was lost to the 1885 fire.
+
+## 4. Primary-source quotes (≥2 required)
+
+Both quotes below were checked with `verify_quote` against the `ukrlib-kulish` corpus; the **real confidence is reported** per #M-4.
+
+**Quote 1 — «До рідного народу, подаючи йому український переклад Шекспірових творів» (the harsh self-indictment):**
+
+> «Народе без пуття, без честі і поваги, / Без правди у завітах предків диких…»
+
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-kulish`). Pedagogically central and *anti-hagiographic*: Kulish — the same man who built the orthography and the Bible — could lash his own nation in this near-self-flagellating register. It is the key to his contradictions (§6): a founder who loved the people enough to despise their failings. [Primary: corpus-verified]
+
+**Quote 2 — on the native word as sacred (the affirmative counterweight):**
+
+> «Рідне слово, божа правдо! / Як мала дитина, тебе стала промовляти / Хирна Україна.»
+
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-kulish`). The same poet who scolds the nation here consecrates its language as "божа правда." Together the two quotes hold his whole tension in two breaths. [Primary: corpus-verified]
+
+**Quote 3 (bonus) — «Хуторна поезія» (1882), the native word as a flaming sword:**
+
+> «О слово рідне! ти стоїш на чаті / Предковічних пам'яток святині, / В ясній, блискучій херувимській шаті, / Як меч огненний, в нашій Україні.»
+
+`verify_quote` → the matched line «Як меч огненний, в нашій Україні» returned from `ukrlib-kulish`; the full-quote confidence was **0.73** because of an orthographic variant (предковічних/предковікових) in my query — the corpus form above is the canonical one. [Primary: corpus-attested]
+
+## 5. Language register
+
+- **Register:** high romantic-archaizing literary Ukrainian. Kulish deliberately built a **"староруська" (Old-Ukrainian) literary register**, rich in **церковнослов'янізми** and solemn diction, deliberately purged of the burlesque (he judged Котляревський's foundation "невдалою"). [T3: uk.wikipedia; T4: Зеров, «Від Куліша до Винниченка»]
+- **CEFR readiness for full reading:** «Чорна рада» and the historical prose sit at **C1**; the «Хуторна поезія» and civic lyric at **B2–C1**; his Russian-language histories are outside the Ukrainian-reading curriculum (cite, do not assign).
+- **Lexicon notes (pre-teach):** **кулішівка**, **правопис**, **орфографія**, **псевдонім**, переклад, етнограф, фольклорист, хутір, старшина — all VESUM-valid (verified; **кулішівка** is also `check_russian_shadow`-clean, `matches_russian=false`).
+- **Stylistic features:** archaizing solemnity, biblical cadence (his translation work feeds back into his verse), canonical stanza forms (octave, Spenserian 9-line) imported into Ukrainian; the **hutir (хутір) ideal** — a Rousseauian, anti-urban "хуторянство" — as a recurring philosophical motif.
+
+## 6. Contested points
+
+- **The pro-imperial late Kulish (anti-hagiography core).** «История воссоединения Руси» (1874–77) and «Отпадение Малороссии от Польши» (1888) are **genuinely pro-tsarist and anti-Cossack** — Kulish set out "документально підтвердити ідею історичної згубності народно-визвольних рухів" and to raise the "культуротворча місія" of the Polish szlachta and Russian tsarism in Ukraine. He attacked the cult of **Хмельницький** and the Cossack risings. This must be told plainly, not buried. [T3: uk.wikipedia; T4: Ясь, «Історичне письмо пізнього П. Куліша», УІЖ 2019]
+- **Moskvophile interlude.** His 1864–1868 Warsaw service (director of spiritual affairs; translating Polish law) and his "москвофільські орієнтації" alienated former allies; per Драгоманов, after the Polish 1863 rising Kulish "пішов на службу до російської адміністрації." He later grew disillusioned, especially after the Ems Ukase. [T3: uk.wikipedia — Попович corpus]
+- **Personal contradictions.** Lifelong married to Ганна Барвінок yet with documented affairs; combative, isolating — "неймовірно складний і незручний для однобічного… трактування" (Олесь Федорук). [T3: uk.wikipedia]
+- **The "two Chorni rady".** The divergence between the Ukrainian and Russian originals is a live philological question (Даниленко, Федорук), not a flaw — evidence of his bilingual authorship strategy and censorship navigation (he showed the censor the Russian text). [T3: uk.wikipedia]
+- **Russian disinformation.** Russian framing happily quotes the late "reunification" Kulish as proof that a Ukrainian founder "really" affirmed all-Russian unity — erasing the arrested-1847, banned-from-1876, Bible-translating Kulish who built the orthography of the language Russia was trying to outlaw.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-nechuy-levytskyi.yaml` — co-translator of the first Ukrainian Bible.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — close friend; boyar at Kulish's wedding; Kulish edited and printed the 1860 «Кобзар» in кулішівка.
+  - `curriculum/l2-uk-en/plans/bio/mykola-kostomarov.yaml` — Cyril-Methodius Brotherhood co-member; co-arrested in 1847; lifelong interlocutor (and language-debate opponent).
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` — sharply condemned «История воссоединения Руси», yet co-edited the 1903 memorial almanac «Дубове листя» for Kulish.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml` — next-generation builder of the same literary language.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kyrylo-mefodiivtsi.yaml` — the Brotherhood whose 1847 destruction sent Kulish into exile (§2).
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — the censorship that outlawed his кулішівка (1876) and forced him to publish abroad.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — the brotherhood/enlightenment milieu of his early work.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/kulish-literary-legacy.yaml` — the LIT-track Kulish anchor this bio should connect to.
+  - `curriculum/l2-uk-en/plans/lit/nechuy-levytsky.yaml` — his Bible-translation collaborator's LIT cluster.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `ivan-puliui` (the physicist who completed the Bible) — no plan yet.
+  - A HIST module on the кулішівка→modern-orthography lineage — not yet built.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A «Чорна рада» first-Ukrainian-historical-novel module bridging LIT and HIST (Руїна / post-Pereiaslav succession struggle).
+
+## 8. Naming-canonical
+
+- **Slug:** `panteleimon-kulish`
+- **EN canonical (BGN/PCGN-style project spelling):** Panteleimon Kulish
+- **UA canonical (with patronymic):** Пантелеймон Олександрович Куліш
+- **Aliases to track (`aliases:` YAML field):** Panteleimon Kulish; Панько Куліш; Ратай Павло (pseud.); Николай М. (cryptonym).
+- **⚠ Disambiguation (mandatory):** NOT `mykola-kulish` (Микола Куліш, 1892–1937, the executed playwright). Any module text must keep the two strictly separate.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Пантелеймон Александрович Кулиш; "Kulish/Kuliš" used as a Russified rendering of his Ukrainian-language works.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Panteleimon Kulish"** — 19th-c. photographic and engraved portraits; he died 1897, so portraits are public domain by age (author-life+70 / pre-1929 US). Use the individual **file page** for license proof. [Commons category: `Panteleimon Kulish`]
+- **Backup candidates:**
+  - Укрпошта commemorative **markovyi arkush "200-річчя Пантелеймона Куліша"** (issued 02.08.2019) — verify stamp-rights/PD status.
+  - НБУ 2-hryvnia jubilee coin "Пантелеймон Куліш (1819–1897)" (July 2019) — context image.
+  - The Vienna memorial plaque (Skodagasse 3) marking the 1870 Bible-translation work with Pulyuy — context image (verify rights).
+- **Context image:** a title page of «Чорна рада» (1857) or a «Записки о Южной Руси» page printed in кулішівка — strong §3/§5 illustration if a rights-clear scan is found.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Kulish, Panteleimon." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages\K\U\KulishPanteleimon.htm. Accessed 2026-06-03. (Birth/death, 1847 Warsaw arrest + Tula exile, Bible with Pulyui & Nechui-Levytsky, кулішівка, anti-Cossack reappraisal.)
+- Удод О. А., Грузін Д. В. "Куліш Пантелеймон Олександрович." *Енциклопедія історії України*, т. 5 (Кон–Кю). Київ: Наукова думка, 2009. С. 468. (UA encyclopedic baseline; life-dates and framing match.)
+
+**Tier 2 (institutional):**
+- Наукове товариство ім. Шевченка (НТШ), Львів — publisher of the 1881 New Testament translation; the Куліш materials-and-studies volumes (Записки НТШ, т. 148; Збірник філологічної секції, т. 22).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Куліш Пантелеймон Олександрович." Accessed 2026-06-03. Verbatim source for: the gendarmerie ruling (§2); кулішівка ban 1876; 1885 OT-manuscript fire; «Чорна рада» two-originals; work-list. Cross-checked against IEU/ЕІУ.
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Даниленко А. *Від Біблії до Шекспіра. Пантелеймон Куліш і формування української літературної мови.* Київ: Критика, 2023 (English: Boston, MA, 2016) — the standard study of his language project.
+- Нахлік Є. *Пантелеймон Куліш: особистість, письменник, мислитель.* У 2 т. Київ, 2007.
+- Ясь О. "Історичне письмо пізнього П. Куліша…" *Український історичний журнал.* 2019. № 4. С. 61–87 — on the conservative "reunification" project (§6).
+- George Luckyj. *Panteleimon Kulish: A Sketch of His Life and Times.* NY: Columbia University Press, 1983.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- "Куліш: перший романіст, маркетолог української культури й трохи дивак." *Читомо* — popular framing, corroborated by T1/T4. Accessed 2026-06-03.
+
+**Primary-source documents accessed (in transcription):**
+- The III-Section / gendarmerie resolution on Kulish (1847), quoted §2 (via uk.wikipedia transcription; cf. the Orlov donesennia published in «Правда», 1893).
+- Corpus `ukrlib-kulish`: «До рідного народу…», the «Рідне слово, божа правдо» poem, «Хуторна поезія» (1882) — all `verify_quote`-checked (§4), confidences reported.
+
+**Honest gaps:** Kulish's own vast correspondence (Нахлік, Федорук editions) was not directly opened this pass; §4 rests on three corpus-verified verse passages. The precise N.S. birth date carries a one-day T1 split (7 vs 8 August), flagged not smoothed (§1). His most damaging late histories are in Russian and are cited as evidence of his ideology (§6), never as authority.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Kulish's life is told on Ukrainian terms; the empire appears as arresting (1847), censoring (1876), and exiling power. His own late pro-imperial writings are named as *his contradiction*, not endorsed.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Кирило-Мефодіївське братство, Валуєвський циркуляр, Емський указ as the period markers.
+- [x] No uncritical Soviet propaganda terms — none used; his conservatism is analysed, not labelled with Soviet epithets.
+- [x] No "lost his life" euphemisms — N/A (Kulish died of natural causes 1897); the oppression here is arrest/exile/censorship, named precisely.
+- [x] Modern UA place names — Вороніж (Сумщина), Мотронівка/Оленівка (Чернігівщина), Київ.
+- [N/A] Holodomor — не стосується (Kulish died 1897, decades before the Holodomor).
+- [x] Russian aggression framing — the dossier flags how Russian narratives weaponise the late "reunification" Kulish to erase the persecuted language-builder (§6).

--- a/docs/research/bio/vasyl-stefanyk.md
+++ b/docs/research/bio/vasyl-stefanyk.md
@@ -1,0 +1,170 @@
+# Василь Семенович Стефаник — Research Dossier
+
+**Slug:** `vasyl-stefanyk`
+**Block:** B (Galician patriot; documented Holodomor-era act of conscience against the Soviet regime)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave E)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU, ЕІУ, ЕУ/Шевченківська енциклопедія; uk.wikipedia cross-checked)
+- [x] Oppression mechanism is specific (Habsburg/Polish gymnasium suppression + dated arrests + the 1933 Soviet-pension refusal)
+- [x] ≥2 primary-source quotes (1 corpus `verify_quote` 1.0 + 1 documented authorial credo; confidence reported)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Василь Семенович Стефаник. [T1: IEU — "Stefanyk, Vasyl"; T1: ЕІУ — Соляр, "Стефаник Василь Семенович", т.9, с.852; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** early criptonyms «С» / no signature on his debut. Russified form (forbidden in body text, §8 only): Василий Семёнович Стефаник.
+- **Born:** 14 May 1871 | с. Русів, Снятинський повіт | **Королівство Галичини та Володимирії, Австро-Угорщина** (NOT the Russian Empire); now Снятинський район, Івано-Франківська область. [T1: IEU; T3: uk.wikipedia]
+- **Died:** 7 December 1936 (aged 65) | с. Русів | then under **Польща (Друга Річ Посполита)**; long illness in his last years. [T1: IEU; T3: uk.wikipedia]
+- **Family / education key facts:** Son of a prosperous Pokuttia peasant, Семен Стефаник. Schooled in **Polish-language gymnasia** in Коломия (**expelled 1890** for the secret «Покутська трійця» circle) and Дрогобич (where **Іван Франко** had studied); friends **Лесь Мартович** and **Марко Черемшина**. Entered the **medical faculty of the Jagiellonian University, Kraków (1892)**, but **left in 1900** without a degree, turning to literature and Radical-Party politics; mentored in Kraków by **Вацлав Морачевський**. Married Ольга Гаморак (1904; d. 1914), daughter of a UGCC priest-deputy. [T3: uk.wikipedia; T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+- **⚠ The "literary silence" was ~14 years, NOT 30.** After his 1899–1901 burst (three collections), Stefanyk **fell silent as a writer "з 1901 року… на півтора десятиліття"** and resumed in **1916** — a gap of **~14–15 years (1901→1916)**, NOT thirty. Any module must state this correctly. [T3: uk.wikipedia — "З 1901 року Стефаник як письменник на півтора десятиліття замовк"; the second period ran 1916–1933]
+- **Empire of context:** Stefanyk lived under **Austria-Hungary, then Poland — never the Russian Empire**; his "Russia-oppressed" axis is the **Soviet** one (the 1933 pension refusal, §2c), and the imperial axis is **Habsburg/Polish** suppression of the Ukrainian word and his arrests (§2a).
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Stefanyk's repression runs in three named registers.
+
+**(a) Habsburg / Polish suppression and political arrests.**
+- The **Polish-language gymnasia** he attended suppressed Ukrainian ("українська була під забороною… насаджувалися вірнопідданські погляди"); he was **expelled from the Коломия gymnasium in 1890** for the «Покутська трійця». [T3: uk.wikipedia]
+- **Arrested 1895** for political agitation among the peasantry; **arrested again in March 1915** on a false denunciation, freed through Марко Черемшина's intervention. [T3: uk.wikipedia]
+- As an Austrian-parliament deputy (посол, 1908–1918, Radical Party), he **spoke against censorship in Galicia (26 May 1908)** and defended Мирослав Січинський. [T3: uk.wikipedia]
+
+**(b) The 1914 personal catastrophe + war.** His wife Ольга died in February 1914, leaving him with three small sons; the First World War and the collapse of the Ukrainian state attempts followed. He headed the **ZUNR delegation to Kyiv (January 1919)** for the **Акт Злуки**. [T3: uk.wikipedia]
+
+**(c) ⚠ The Soviet pension refusal — a documented Holodomor-era act of conscience (VERIFIED).**
+- **What happened:** the **Soviet government granted him a personal pension in 1928** (a propaganda gesture) and feted his 60th birthday in Kharkiv in 1931. **In 1933 Stefanyk renounced the pension** on learning of the **artificially-created famine (Holodomor)** and the persecution of the Ukrainian intelligentsia. [T3: uk.wikipedia — "Стефаник у 1933 році відмовився від персональної пенсії, коли довідався про штучно створений голод і переслідування української інтелігенції" — **VERIFIED**]
+- **The follow-through:** **митрополит Андрей Шептицький** then granted him a **UGCC pension**; Stefanyk asked the cashier to pay it in **small coins**, took the heavy bag to the square, and **gave it as alms to beggars, asking them to pray «за убієнних голодом українців»** (for those murdered by the famine). [T3: uk.wikipedia]
+- **Mechanism:** this is **moral resistance to the Soviet regime at the moment of the Holodomor** — refusing the empire's money and converting the alternative into a public prayer for the famine's dead. It meets the section's specificity test: named year (1933), named instrument (the renounced 1928 Soviet pension), named act (the coin-alms for the Holodomor dead).
+- **What survived / what was distorted:** His novellas survived and were canonised, but the Soviet press reframed him as the **"селянський Бетховен" / "співець загибаючого села"** — a label **he himself explicitly rejected** (§4 Quote 2, §6) — while quietly dropping his ZUNR politics, his Radical-Party Galician record, and the **Holodomor pension refusal** itself.
+
+## 3. Major works
+
+Master of the short expressionist novella; founder of expressionism in Ukrainian literature. Selected, chronological:
+
+- `1897` — debut реалістичні новели in the Chernivtsi paper «Праця» («Виводили з села», «Лист», «Синя книжечка», «Сама-саміська» та ін., signed «С»). [T3: uk.wikipedia]
+- `1899` — **«Синя книжечка»** (Чернівці) — first collection; "став знаменитістю" (Леся Українка); contains **«Новина»** (§4) and «Катруся». [T1: IEU; T3: uk.wikipedia]
+- `1900` — **«Камінний хрест»** (Львів) — his signature novella, the parable of emigration (Іван Дідух and the stone cross); titular story of the second collection. [T1: IEU; T3: uk.wikipedia]
+- `1901` — **«Дорога»** (third collection); the lyric «Confiteor» / «Моє слово». [T3: uk.wikipedia]
+- `1905` — **«Моє слово»** (fourth collection), closing his first period. [T3: uk.wikipedia]
+- `1916–1933` (second period) — **«Марія»** (1916, dedicated to Франко), **«Діточа пригода»** (1916/17), **«Сини»**, the collection **«Вона — земля»** (1926); his late autobiographical novellas («Нитка», «Серце», «Каменярі»). [T1: IEU; T3: uk.wikipedia]
+- `letters` — his vast correspondence, which he himself rated as literature: «Моя література — в моїх листах». [T3: uk.wikipedia]
+
+**Suppression note:** his ZUNR-era politics and the 1933 Holodomor pension refusal were excised from the Soviet "селянський Бетховен" canon; some early "поезії в прозі" he destroyed himself in the 1890s.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — «Новина» (1899), the expressionist opening that made him famous:**
+
+> «У селі сталася новина, що Гриць Летючий утопив у ріці свою дівчинку. Він хотів утопити і старшу, але випросилася. Відколи Грициха вмерла, то він бідував. Не міг собі дати ради з дітьми без жінки…»
+
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-stefanyk`). The whole Stefanyk method in one paragraph: catastrophe stated flat, in покутський dialect, with the social cause (a widower's destitution) doing the moral work. A B2 anchor text for expressionism and "межова ситуація." [Primary: corpus-verified]
+
+**Quote 2 — his authorial credo, letter to «Плужанин» (1 August 1927), rejecting the "поет загибаючого села" label:**
+
+> «Я писав тому, щоби струни душі нашого селянина так кріпко настроїти і натягнути, щоби з того вийшла велика музика Бетховена. Це мені вдалося, а решта — це література.»
+
+`verify_quote` → **not matched, 0.0** (the literary corpus holds his novellas, not his letters); **documented** via his 1927 letter to «Плужанин». [T3: uk.wikipedia] The key to §6: Stefanyk himself **refused** the passive "співець загибаючого села" reading the Soviet canon imposed on him. (Two companion documented lines — «І все, що я писав, мене боліло» and «Моя література — в моїх листах» — round out his self-understanding.) [Primary: documented; corpus miss disclosed]
+
+## 5. Language register
+
+- **Register:** terse expressionist prose in the **покутський говір** (Pokuttia dialect) — "образ без рамки," extreme lexical economy, dialogue and monologue over narration, "учуднення" through dialect. His letters are confessional-lyrical.
+- **CEFR readiness for full reading:** because of the dense **dialect**, full novellas sit at **C1** (the dialect, not the length, is the barrier); short excerpts with glossary at **B2**; analytical prose about him at **B2**; the §6 reception debates at **C1**.
+- **Lexicon notes (pre-teach):** **новела**, **експресіонізм**, **покутський** (говір), **діалектизм**, межова ситуація, новеліст — all VESUM-valid (verified). Heavy **Pokuttia dialect** (надпрутський говір) requires a dedicated glossary — Кисілевський compiled a "Матеріяли для словника" of his persona-speech; do not "correct" the dialect, gloss it.
+- **Stylistic features:** catastrophic compression, free indirect dialect speech, the "стиснути… до мінімуму описовості" method, giperbola/katakhresis; he is the bridge from народницька village prose to European modernist expressionism.
+
+## 6. Contested points
+
+- **"Селянський Бетховен" / "співець загибаючого села" (anti-hagiography core).** The Soviet (and some earlier) reception fixed him as the elegist of a dying village; **Stefanyk himself rejected this** (§4 Quote 2), insisting he tuned the peasant soul toward "велика музика Бетховена," i.e. universal tragic art, not ethnographic lament. Restoring his own framing is the central interpretive task. [T3: uk.wikipedia — Коряк, *Селянський Бетховен*, 1929; and Stefanyk's own rebuttal]
+- **The 14-year silence (§1).** Its causes (the death of his mother, his father cutting him off, the meagreness of literary income, his self-destruction of unsatisfactory drafts) are debated; what is **not** debatable is its **length — ~14 years, not 30**. [T3: uk.wikipedia]
+- **The Soviet pension and its refusal.** Soviet accounts emphasise the 1928 pension and 1931 jubilee as Soviet generosity; the decisive fact they omit is the **1933 refusal over the Holodomor** (§2c). His son Семен became a Soviet figure — a family tension worth noting, not hiding. [T3: uk.wikipedia]
+- **Russian/Soviet framing** keeps the "peasant Beethoven" who accepted Soviet honours and erases the ZUNR deputy who renounced the regime's pension over the Holodomor.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — his Drohobych-gymnasium predecessor and Radical-Party leader; «Марія» (1916) is dedicated to Franko, and Stefanyk campaigned for "мужицький посол" Franko in 1897.
+  - `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml` — hailed «Синя книжечка»; met him at the 1903 Poltava Kotliarevsky unveiling.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-kotsiubynsky.yaml` — fellow modernist who welcomed his debut.
+  - `curriculum/l2-uk-en/plans/bio/olena-pchilka.yaml` and `curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml` — Naddniprianshchyna writers he met at the 1903 Poltava unveiling.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml` — the Austrian-Galician arena of his whole life, schooling, arrests, and parliamentary career (§2a).
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/stefanyk-stone-cross.yaml`, `curriculum/l2-uk-en/plans/lit/stefanyk-novellas.yaml`, `curriculum/l2-uk-en/plans/lit/stefanyk-blue-book.yaml` — the full LIT-track Stefanyk cluster this bio anchors.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST module on the **Holodomor** that uses Stefanyk's 1933 pension refusal as a Galician witness — not yet built.
+  - Bio-to-bio ties with `lesia-martovych` and `marko-cheremshyna` (the «Покутська трійця») — no plans yet.
+  - A bio tie to `andrey-sheptytsky` (who granted the UGCC pension) — dossier exists on main; plan TBD.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A «Камінний хрест» / emigration module bridging LIT and the Galician-emigration HIST theme.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-stefanyk`
+- **EN canonical (BGN/PCGN-style project spelling):** Vasyl Stefanyk
+- **UA canonical (with patronymic):** Василь Семенович Стефаник
+- **Aliases to track (`aliases:` YAML field):** Vasyl Stefanyk; «С» (early cryptonym).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Василий Семёнович Стефаник; "Stefanik" as a Russified transliteration.
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Vasyl Stefanyk"** — early-20th-c. photographs and the Іван Труш portrait (1897); he died 1936, so age-based PD applies to pre-1929 images (check each file's date for life+70 status). Use the individual **file page** for license proof. [Commons category: `Vasyl Stefanyk`]
+- **Backup candidates:**
+  - Михайло Жук / Василь Касіян portraits (1926) — verify life+70 status per artist.
+  - НБУ commemorative coin for his 150th anniversary (2021) — context image.
+  - The Русівський літературно-меморіальний музей (his house, museum from 1941) — context image (verify rights).
+- **Context image:** a title page of «Синя книжечка» (1899) or «Камінний хрест» (1900), or the Леонід Осика film «Камінний хрест» (1968) still — strong §3 illustration if rights-clear.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Stefanyk, Vasyl." (Birth 14 May 1871 Rusiv, Galicia; death 7 Dec 1936; expressionist novella; «Синя книжечка», «Камінний хрест»; Radical-Party deputy.) Accessed 2026-06-03.
+- Соляр І. Я. "Стефаник Василь Семенович." *Енциклопедія історії України*, т. 9. Київ: Наукова думка, 2012. С. 852.
+- *Шевченківська енциклопедія*, т. 5. Київ, 2015. С. 948–950 — "Стефаник Василь Семенович"; and *ЕУ (Сарсель)* "Стефаник Василь."
+
+**Tier 2 (institutional):**
+- Прикарпатський національний університет імені Василя Стефаника — the 2021 four-volume collected works (150th-anniversary edition).
+- Русівський літературно-меморіальний музей Василя Стефаника — collection-based biography.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Стефаник Василь Семенович." Accessed 2026-06-03. Verbatim source for: the **~14-year silence (1901→1916)**; the **1933 Holodomor pension refusal and coin-alms** (§2c — verified); arrests 1895/1915; the 1927 «Плужанин» credo; the 1919 ZUNR Kyiv delegation. Cross-checked against IEU/ЕІУ.
+
+**Tier 4 (modern scholarly — referenced, not all directly opened this pass):**
+- Горак Р. *Кров на чорній ріллі. Есе-біографія Василя Стефаника.* Київ: Академія, 2010.
+- Лесин В. *Василь Стефаник — майстер новели.* Київ, 1970.
+- Вавжонек М. "Василь Стефаник як представник галицьких радикалів." *Український історичний журнал*, 2014, № 5 — on his Radical-Party politics.
+- Кисілевський К. "Надпрутський говір Стефаникових персонажів" — the dialect lexicon (§5).
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- "Василь Стефаник: А прихильником Великої України я був і буду." *Український кризовий медіа-центр*, 14.05.2024 — popular framing, corroborated by T1/T3.
+
+**Primary-source documents accessed (in transcription):**
+- Corpus `ukrlib-stefanyk` — «Новина» opening (§4 Quote 1), `verify_quote` confidence **1.0**.
+- His 1927 letter to «Плужанин» (§4 Quote 2) — documented via uk.wikipedia; `verify_quote` 0.0 (corpus holds novellas, not letters), disclosed.
+
+**Honest gaps:** §4 Quote 2 is an authorial letter not held in the project corpus, so it is documented (Tier-1/Tier-3) rather than `verify_quote`-confirmed — the corpus miss is disclosed (#M-4). The artistic dialect makes full-text CEFR placement a **C1** call driven by lexis, not length (§5). The ЕІУ/Шевченківська-енциклопедія pages are cited as standard baselines alongside the directly-fetched IEU.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Stefanyk's life is told on Ukrainian/Galician terms; the Habsburg/Polish authorities appear as the language-suppressing power, and the **Soviet** regime as the one whose Holodomor he answered by renouncing its pension.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Австро-Угорщина / Королівство Галичини та Володимирії / ЗУНР / Акт Злуки as markers.
+- [x] No uncritical Soviet propaganda terms — "селянський Бетховен" / "співець загибаючого села" appear only as the labels he himself rejected (§4, §6).
+- [x] No "lost his life" euphemisms — N/A (died 1936 after long illness); his act of conscience is named precisely.
+- [x] **Holodomor referenced as Holodomor** (Голодомор / штучно створений голод), not "Soviet famine"; his 1933 pension refusal is its load-bearing witness (§2c).
+- [x] Modern UA place names — Русів (Снятинщина, Івано-Франківщина), Коломия, Дрогобич, Краків, Київ.
+- [x] Russian aggression framing — the dossier foregrounds his Soviet-pension refusal over the Holodomor and his ZUNR commitment, against the Soviet "peasant Beethoven" erasure (§6).


### PR DESCRIPTION
## Wave E — 6 sourced research dossiers for original-180 ghost-wiki figures (#2535)

19th-c. founders of modern Ukrainian literature, theatre, and scholarship. Each dossier mirrors the
10-section template + decolonization self-check, with tiered `[T1…T5]` citations, a flagged
source-disagreement note, a load-bearing §2 oppression mechanism, ≥2 primary quotes (real
`verify_quote` scores reported per #M-4), and §7 cross-track paths that all `test -e`-resolve.

**Gate:** `lint_bio_dossier_xref.py` → exit 0 (per-file and full sweep). Pre-commit §7 validator passed.

### Per figure

**`panteleimon-kulish`** — Пантелеймон Куліш (1819–1897). Top sources: IEU (T1), ЕІУ т.5 (T1), Даниленко/Нахлік (T4), uk.wikipedia (T3).
⚠ resolution: kept strictly distinct from the executed playwright `mykola-kulish` (1892–1937) — different person/century, flagged in §1 + §8. Honest about his contradictions: «История воссоединения Руси» (1874–77) attack on Khmelnytsky + the Cossack risings, and his Warsaw/moskvophile period, told plainly in §6. Bible with **Пулюй + Нечуй-Левицький** (NT 1881, full 1903); кулішівка banned 1876. Quotes: «Народе без пуття…» and «Рідне слово, божа правдо!» both `verify_quote` **1.0**. Honest gap: one-day N.S. birth split (7 vs 8 Aug), flagged.

**`borys-hrinchenko`** — Борис Грінченко (9 Dec 1863 – 6 May 1910). Top sources: IEU (T1, **Ospedaletti/Italy death verified**), ЕІУ, RAS Kostomarov-prize record, uk.wikipedia (T3).
⚠ resolution: «Словарь української мови» (1907–09, ~68k words, RAS 2nd prize); pseudonyms Чайченко/Вартовий/Вільхівський in §8; «Галицькі вірші», Prosvita (1906–09), «Рідне слово» pedagogy. §2: 1879 student arrest → the tuberculosis that killed him. Quotes: 1895 civic poem `verify_quote` **1.0** + «Листи з України Наддніпрянської» prose (corpus-attested).

**`mykhailo-starytsky`** — Михайло Старицький (1839 **or** 1840 – 1904). Top sources: IEU (T1), ЕІУ т.9, Шевченківська енц. (T1), uk.wikipedia (T3).
⚠ resolution: birth-year ambiguity NOT smoothed — uk.wiki/birth-record give **2(14) Nov 1839**, IEU + state commemoration give **14 Dec 1840** (both year AND month differ); §1 records both. «За двома зайцями», «Талан», «Богдан Хмельницький»; theatre with **Lysenko** (his cousin) & **Kropyvnytskyi** (Театр корифеїв from 1883); modernised the literary language (neologisms). Honest gap: corpus lacks his lyric poetry — both quotes documented, `verify_quote` **0.0** disclosed.

**`marko-kropyvnytskyi`** — Марко Кропивницький (1840–1910). Top sources: IEU (T1), ЕУЛ (T1), Кропивницький museum (T2), uk.wikipedia (T3).
⚠ resolution: b. **Бежбайраки** (now Кропивницьке); founded the **Театр корифеїв, 27 Oct 1882** in Єлисаветград; co-founders **Заньковецька, Садовський, Старицький, Тобілевич brothers (Карпенко-Карий/Саксаганський)**; «Глитай, або ж Павук», «Дай серцю волю…». §2: Ems Ukase + named **1883 Drentteln ban** + repeated play bans. Died on the train (cerebral haemorrhage). Non-hagiographic §6 (Чижевський's "melodrama" critique vs the censored serious late plays). Quotes documented from his «Автобіографія»/listy (incl. the 1874 imperial-erasure line), corpus N/A disclosed.

**`olena-pchilka`** — Олена Пчілка / Ольга Косач née Драгоманова (1849–1930). Top sources: ЕІУ т.9 (T1), ЕУ (T1), Огієнко (T1), Агеєва *Бунтарки* (T4), uk.wikipedia (T3).
⚠ resolution: **mother of `lesya-ukrainka`, sister of `mykhailo-drahomanov`** (cross-linked via bare slugs + verified plan paths). Honest on her **conflicts with Franko** (flagged as scholarly-consensus, specific docs pending — not fabricated) and her **controlling role over Lesya** (both the empowering and domineering sides, per *Бунтарки*). «Перший вінок» (1887). **ВУАН year: sourced as 1925** (uk.wiki ×2) — the brief's 1927 flagged as unconfirmed. §2 spans imperial language-ban defiance (1903/1905) + Bolshevik 1920 arrest. Quotes documented (Автобіографія + «Ганьба Крамаренкові!»), `verify_quote` 0.0 disclosed.

**`vasyl-stefanyk`** — Василь Стефаник (1871–1936). Top sources: IEU (T1), ЕІУ т.9, ЕУ/Шевченківська енц. (T1), uk.wikipedia (T3).
⚠ resolution: «Камінний хрест», «Новина», «Сини»; the **Holodomor-era pension refusal is REAL and verified** — renounced the 1928 Soviet pension in **1933** over the artificial famine, took Sheptytsky's UGCC pension in small coins and gave it as alms «за убієнних голодом українців». Literary silence **~14 years (1901→1916), NOT 30** — stated correctly. Galician/Austro-Hungarian context throughout (never the Russian Empire). Quotes: «Новина» opening `verify_quote` **1.0** + his 1927 «Плужанин» Beethoven credo (documented, 0.0 disclosed).

### Honest gaps (cross-cutting)
- The project literary corpus holds Kulish, Hrinchenko, Stefanyk primary texts but **not** Starytsky's lyrics, Pchilka's works, or Kropyvnytskyi's plays — quotes for those three are documented via Tier-1/Tier-3 with real `verify_quote` misses (0.0) reported, never a faked score.
- Several ЕІУ/ЕУ article pages cited as standard UA baselines alongside directly-fetched IEU/uk.wikipedia.

**No auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
