### PR TITLE
feat(a1): add M13 many things module

### DIFF
--- a/curriculum/l2-uk-en/a1/many-things/activities.yaml
+++ b/curriculum/l2-uk-en/a1/many-things/activities.yaml
@@ -1,0 +1,344 @@
+- id: act-1
+  type: quiz
+  title: One thing, many things
+  instruction: Choose the plural chunk.
+  items:
+    - prompt: стіл
+      options:
+        - text: столи
+          correct: true
+        - text: стіла
+          correct: false
+        - text: стілів
+          correct: false
+      explanation: Learn the pair стіл - столи.
+    - prompt: книга
+      options:
+        - text: книги
+          correct: true
+        - text: книгі
+          correct: false
+        - text: книга
+          correct: false
+      explanation: Книга becomes книги.
+    - prompt: вікно
+      options:
+        - text: вікна
+          correct: true
+        - text: вікни
+          correct: false
+        - text: вікні
+          correct: false
+      explanation: Many neuter nouns ending in -о use -а.
+    - prompt: стілець
+      options:
+        - text: стільці
+          correct: true
+        - text: стілеці
+          correct: false
+        - text: стільця
+          correct: false
+      explanation: Learn стілець - стільці as its own pair.
+    - prompt: крісло
+      options:
+        - text: крісла
+          correct: true
+        - text: крісли
+          correct: false
+        - text: кріслі
+          correct: false
+      explanation: Крісло becomes крісла.
+    - prompt: ручка
+      options:
+        - text: ручки
+          correct: true
+        - text: ручкі
+          correct: false
+        - text: ручка
+          correct: false
+      explanation: Ручка becomes ручки.
+- id: act-2
+  type: match-up
+  title: Singular and plural pairs
+  instruction: Match one thing with many things.
+  pairs:
+    - left: стіл
+      right: столи
+    - left: книга
+      right: книги
+    - left: вікно
+      right: вікна
+    - left: стілець
+      right: стільці
+    - left: телефон
+      right: телефони
+    - left: зошит
+      right: зошити
+    - left: лампа
+      right: лампи
+    - left: дзеркало
+      right: дзеркала
+- id: act-3
+  type: fill-in
+  title: Plural adjective ending
+  instruction: Choose the ending that makes the adjective plural.
+  items:
+    - sentence: нов__ книги
+      answer: і
+      options:
+        - і
+        - а
+        - ий
+      explanation: Plural adjectives use -і.
+    - sentence: велик__ столи
+      answer: і
+      options:
+        - і
+        - ий
+        - е
+      explanation: Великий becomes великі.
+    - sentence: чист__ вікна
+      answer: і
+      options:
+        - і
+        - е
+        - а
+      explanation: Чисте becomes чисті.
+    - sentence: син__ зошити
+      answer: і
+      options:
+        - і
+        - я
+        - є
+      explanation: Синій becomes сині.
+    - sentence: літн__ дні
+      answer: і
+      options:
+        - і
+        - ій
+        - я
+      explanation: Літній becomes літні.
+    - sentence: осінн__ ранки
+      answer: і
+      options:
+        - і
+        - я
+        - є
+      explanation: Осінній becomes осінні.
+    - sentence: червон__ ручки
+      answer: і
+      options:
+        - і
+        - а
+        - ий
+      explanation: Червона becomes червоні.
+    - sentence: жовт__ лампи
+      answer: і
+      options:
+        - і
+        - а
+        - е
+      explanation: Жовта becomes жовті.
+- id: act-4
+  type: group-sort
+  title: Singular, ordinary plural, special number
+  instruction: Sort each chunk by what it shows.
+  groups:
+    - label: One thing
+      items:
+        - стіл
+        - книга
+        - вікно
+        - стілець
+    - label: Ordinary plural
+      items:
+        - столи
+        - книги
+        - вікна
+        - стільці
+    - label: Special number chunk
+      items:
+        - п'ять зошитів
+        - десять учнів
+        - сто гривень
+        - двоє дверей
+- id: act-5
+  type: quiz
+  title: Ці, ті, мої, які
+  instruction: Choose the plural helper.
+  items:
+    - prompt: These tables are big.
+      options:
+        - text: Ці столи великі.
+          correct: true
+        - text: Цей столи великі.
+          correct: false
+        - text: Ця столи великі.
+          correct: false
+      explanation: Use ці with plural nouns near you.
+    - prompt: Those chairs are old.
+      options:
+        - text: Ті стільці старі.
+          correct: true
+        - text: Той стільці старі.
+          correct: false
+        - text: Та стільці старі.
+          correct: false
+      explanation: Use ті for plural nouns farther away.
+    - prompt: My notebooks are blue.
+      options:
+        - text: Мої зошити сині.
+          correct: true
+        - text: Мій зошити сині.
+          correct: false
+        - text: Моя зошити сині.
+          correct: false
+      explanation: The plural form of my is мої.
+    - prompt: Which pens?
+      options:
+        - text: Які ручки?
+          correct: true
+        - text: Яка ручки?
+          correct: false
+        - text: Який ручки?
+          correct: false
+      explanation: The plural question word is які.
+    - prompt: These books are new.
+      options:
+        - text: Ці книги нові.
+          correct: true
+        - text: Це книги нове.
+          correct: false
+        - text: Ця книги нова.
+          correct: false
+      explanation: Use plural ці and plural нові.
+- id: act-6
+  type: match-up
+  title: People chunks
+  instruction: Match the English prompt with the Ukrainian chunk.
+  pairs:
+    - left: we
+      right: ми
+    - left: you, plural or formal
+      right: ви
+    - left: for us
+      right: для нас
+    - left: for you
+      right: для вас
+    - left: we need
+      right: нам треба
+    - left: you need
+      right: вам треба
+    - left: with us
+      right: з нами
+    - left: with you
+      right: з вами
+- id: act-7
+  type: fill-in
+  title: Number chunks
+  instruction: Choose the noun chunk after the number.
+  items:
+    - sentence: два ___
+      answer: зошити
+      options:
+        - зошити
+        - зошитів
+        - зошит
+      explanation: With 2, use the ordinary plural chunk два зошити.
+    - sentence: три ___
+      answer: книги
+      options:
+        - книги
+        - книг
+        - книга
+      explanation: Три книги is the A1-safe phrase.
+    - sentence: чотири ___
+      answer: смартфони
+      options:
+        - смартфони
+        - смартфонів
+        - смартфон
+      explanation: Чотири uses the ordinary plural form here.
+    - sentence: п'ять ___
+      answer: зошитів
+      options:
+        - зошитів
+        - зошити
+        - зошит
+      explanation: Treat п'ять зошитів as a later 5+ chunk.
+    - sentence: десять ___
+      answer: учнів
+      options:
+        - учнів
+        - учні
+        - учень
+      explanation: Treat десять учнів as a later 5+ chunk.
+    - sentence: сто ___
+      answer: гривень
+      options:
+        - гривень
+        - гривні
+        - гривня
+      explanation: Сто гривень is the price chunk from the numbers module.
+- id: act-8
+  type: error-correction
+  title: Repair plural traps
+  instruction: Choose the standard Ukrainian repair.
+  anchor_id: repair-traps
+  items:
+    - sentence: великий м'ячі
+      error: великий м'ячі
+      answer: великі м'ячі
+      options:
+        - великі м'ячі
+        - великий м'ячі
+        - велика м'ячі
+      explanation: Plural adjectives use -і.
+    - sentence: синія шарфи
+      error: синія шарфи
+      answer: сині шарфи
+      options:
+        - сині шарфи
+        - синія шарфи
+        - синій шарфи
+      explanation: The plural color form is сині.
+    - sentence: два зошитів / два смартфонів
+      error: два зошитів / два смартфонів
+      answer: два зошити / чотири смартфони
+      options:
+        - два зошити / чотири смартфони
+        - два зошитів / два смартфонів
+        - два зошита / чотири смартфона
+      explanation: Two, three, and four use the ordinary plural form here.
+    - sentence: п'ять зошити / десять учні
+      error: п'ять зошити / десять учні
+      answer: п'ять зошитів / десять учнів
+      options:
+        - п'ять зошитів / десять учнів
+        - п'ять зошити / десять учні
+        - п'ять зошита / десять учня
+      explanation: Keep the 5+ chunk п'ять зошитів.
+    - sentence: один двері / два двері
+      error: один двері / два двері
+      answer: одні двері / двоє дверей
+      options:
+        - одні двері / двоє дверей
+        - один двері / два двері
+        - одна двері / дві двері
+      explanation: Двері is plural-only in everyday use.
+    - sentence: молоді / дітвори
+      error: молоді / дітвори
+      answer: молодь / дітвора
+      options:
+        - молодь / дітвора
+        - молоді / дітвори
+        - молодя / дітвори
+      explanation: Молодь is a singular collective word.
+    - sentence: для ми / з ми
+      error: для ми / з ми
+      answer: для нас / з нами
+      options:
+        - для нас / з нами
+        - для ми / з ми
+        - для нам / з нас
+      explanation: "Use the pronoun chunks: для нас, з нами."

--- a/curriculum/l2-uk-en/a1/many-things/module.md
+++ b/curriculum/l2-uk-en/a1/many-things/module.md
@@ -1,0 +1,300 @@
+# Many Things
+
+Ukrainian does not add one universal ending for "more than one." You learn a
+few useful plural shapes, then keep each new noun together with its plural
+form: **стіл - столи**, **книга - книги**, **вікно - вікна**. The good news is
+that adjectives become simpler in the plural: **великий / велика / велике**
+all become **великі**.
+
+By the end, you can:
+
+- turn familiar classroom nouns into safe plural chunks;
+- choose **ці / ті / мої / які** with plural nouns;
+- describe groups with plural adjectives and colors;
+- use **два, три, чотири** with ordinary plural noun forms;
+- recognize plural-only words such as **гроші**, **двері**, and **окуляри**
+  without trying to force them into singular.
+
+<!--
+Wiki coverage obligations:
+step-1: Include plural people pronoun chunks ми/ви and recognition chunks нас/вас/нам/вам/нами/вами in simple invitations.
+step-2: Teach Називний відмінок множини noun patterns -и/-і and -а/-я with зошити, учні, гривні.
+step-3: Present plural-only words (гроші, двері, окуляри, радощі, сани, ворота) and singular-only collective words (молодь, дітвора, птаство, листя) as recognition, not active counting.
+step-4: Teach plural adjectives from тверда група examples by contrasting однина with plural: які? and -і for all genders: великі, сині.
+step-5: Show soft-base adjectives such as синій -> сині, літній -> літні, осінній -> осінні.
+step-6: State 2/3/4 + nominative plural: два зошити, три книги, чотири смартфони; два селянина is a later/passive exception, not active A1.
+step-7: Preview 5+ as later genitive plural chunks: п'ять зошитів, десять учнів.
+err-1: Wrong великий м'ячі -> correct великі м'ячі, because plural adjectives use -і.
+err-2: Wrong nonstandard blue-scarf plural -> correct сині шарфи, because plural removes gender endings and uses які? сині.
+err-3: Wrong два зошитів / два смартфонів -> correct два зошити / чотири смартфони for 2, 3, 4.
+err-4: Wrong п'ять зошити / десять учні -> correct п'ять зошитів / десять учнів as a later 5+ chunk.
+err-5: Wrong один двері / два двері -> correct одні двері / двоє дверей for plural-only nouns.
+err-6: Wrong молоді / дітвори -> correct молодь / дітвора as singular-only collective nouns.
+err-7: Wrong для ми / з ми -> correct для нас / з нами.
+ban-1: Teach Ukrainian plural grammar on its own terms; do not use Russian as a bridge.
+ban-2: For два, три, чотири, state the Ukrainian pattern directly: два зошити, три смартфони, чотири відсотки.
+ban-3: Do not phrase Ukrainian rules as exceptions to another language.
+ban-4: Keep двоє, троє, четверо as Ukrainian collective-number recognition chunks for plural-only nouns.
+-->
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+## Діалоги
+
+The classroom is getting ready for a Ukrainian lesson. Several things are on
+the tables, so the first job is simple: name one thing, then name many.
+
+<DialogueBox uk="Марко: Що тут є?" en="Marko: What is here?" />
+<DialogueBox uk="Оля: Тут столи, стільці і вікна." en="Olia: There are tables, chairs, and windows here." />
+<DialogueBox uk="Марко: Які столи?" en="Marko: What are the tables like?" />
+<DialogueBox uk="Оля: Столи великі й нові." en="Olia: The tables are big and new." />
+<DialogueBox uk="Марко: А стільці?" en="Marko: And the chairs?" />
+<DialogueBox uk="Оля: Стільці старі, але чисті." en="Olia: The chairs are old, but clean." />
+<DialogueBox uk="Марко: А ці вікна?" en="Marko: And these windows?" />
+<DialogueBox uk="Оля: Ці вікна чисті й великі." en="Olia: These windows are clean and big." />
+
+At a small shop, plural forms appear because you want more than one item:
+
+<DialogueBox uk="Покупець: У вас є ручки?" en="Customer: Do you have pens?" />
+<DialogueBox uk="Продавець: Так. Які ручки - червоні чи сині?" en="Seller: Yes. Which pens - red or blue?" />
+<DialogueBox uk="Покупець: Сині. І ще зошити." en="Customer: Blue ones. And notebooks too." />
+<DialogueBox uk="Продавець: Скільки?" en="Seller: How many?" />
+<DialogueBox uk="Покупець: Три зошити і дві ручки." en="Customer: Three notebooks and two pens." />
+<DialogueBox uk="Продавець: Добре. Для вас є нові сині ручки." en="Seller: Good. For you there are new blue pens." />
+<DialogueBox uk="Покупець: Дякую. Нам треба саме ці." en="Customer: Thank you. We need exactly these." />
+
+Notice four small plural helpers:
+
+| Helper | Meaning | Example |
+| --- | --- | --- |
+| **ці** | these | **ці ручки**, **ці столи** |
+| **ті** | those | **ті книги**, **ті стільці** |
+| **мої** | my, plural | **мої зошити**, **мої книги** |
+| **які** | which / what kind, plural | **Які ручки?** |
+
+Plural can also mean people. This is another way to talk about **багато**:
+more than one person is acting together. Keep these as useful chunks for
+invitations and classroom teamwork:
+
+- **ми** = we, **ви** = you plural / formal you
+- **для нас** = for us, **для вас** = for you
+- **нам треба** = we need, **вам треба** = you need
+- **з нами** = with us, **з вами** = with you
+
+You do not need a pronoun table today. Just recognize the chunks when people
+are acting together: **Ми тут. Нам треба три зошити. Ідіть з нами.**
+
+:::tip
+When a noun is plural, the old gender question becomes quiet. You no longer
+need **мій / моя / моє** or **який / яка / яке**. Use the plural forms:
+**мої** and **які**.
+:::
+
+<!-- INJECT_ACTIVITY: act-2 -->
+
+## Один → багато
+
+Start with the nouns you already know. Learn the plural as part of the word,
+not as a guess.
+
+| One | Many | Pattern to notice |
+| --- | --- | --- |
+| **стіл** | **столи** | masculine, often **-и** |
+| **зошит** | **зошити** | masculine, often **-и** |
+| **телефон** | **телефони** | masculine, often **-и** |
+| **стілець** | **стільці** | masculine, **-ець** often changes |
+| **книга** | **книги** | feminine, often **-и** |
+| **ручка** | **ручки** | feminine, often **-и** |
+| **сумка** | **сумки** | feminine, often **-и** |
+| **вікно** | **вікна** | neuter **-о** becomes **-а** |
+| **крісло** | **крісла** | neuter **-о** becomes **-а** |
+| **дзеркало** | **дзеркала** | neuter **-о** becomes **-а** |
+
+This is the nominative plural pattern, **називний відмінок множини**, in its
+safest A1 shape. You will meet the same shape in people and money words such
+as **учні** and **гривні**.
+
+This is enough for A1:
+
+- many masculine and feminine nouns use **-и** or **-і**;
+- many neuter nouns ending in **-о** use **-а**;
+- a few words, such as **стілець - стільці**, need their own memory hook.
+
+Do not turn the list into a rule machine. Say the pair aloud and keep the pair
+together: **стіл - столи**, **книга - книги**, **вікно - вікна**. If a new
+word matters, learn both forms at the same time.
+
+Some words already look plural and do not have a simple everyday singular:
+**гроші**, **двері**, **окуляри**, **сани**, **ворота**, **радощі**. Treat
+them as whole words first. You can say **ці двері** and **мої окуляри**.
+Later you will learn special counting phrases such as **одні двері** and
+**двоє дверей**; Ukrainian also has collective number words such as **двоє**,
+**троє**, and **четверо** for later work with plural-only nouns. Keep that
+Ukrainian feature; do not replace it with a flattened counting shortcut.
+
+Some collective words usually stay singular: **молодь**, **дітвора**,
+**птаство**, **листя**. At A1, just recognize that they name a group while
+behaving like singular words. Do not force a plural ending onto them.
+
+<!-- INJECT_ACTIVITY: act-3 -->
+
+## Прикметники у множині
+
+Plural adjectives are friendlier than singular adjectives. In singular, you
+had to match gender:
+
+| Masculine | Feminine | Neuter |
+| --- | --- | --- |
+| **великий стіл** | **велика книга** | **велике вікно** |
+| **новий зошит** | **нова сумка** | **нове крісло** |
+| **синій шарф** | **синя ручка** | **синє вікно** |
+
+In the plural, use **які?** and the adjective ending **-і**. A textbook may
+call the regular hard-adjective path **тверда група**, but your A1 habit is
+simpler: move from **однина** to plural and use **-і**.
+
+| Many things | Description |
+| --- | --- |
+| **столи** | **великі столи** |
+| **книги** | **нові книги** |
+| **вікна** | **чисті вікна** |
+| **ручки** | **сині ручки** |
+| **зошити** | **корисні зошити** |
+
+The noun can come from any gender in the singular. The plural adjective still
+uses **-і**:
+
+- **великий стіл -> великі столи**
+- **нова книга -> нові книги**
+- **чисте вікно -> чисті вікна**
+- **синій шарф -> сині шарфи**
+- **літній день -> літні дні**
+- **осінній ранок -> осінні ранки**
+
+This protects you from a common English-speaker habit. English keeps the
+adjective unchanged: big table, big tables. Ukrainian changes the adjective:
+**великий стіл**, but **великі столи**. If your noun is plural, your adjective
+is plural too.
+
+Use colors the same way:
+
+- **червоні ручки**
+- **сині зошити**
+- **білі стіни**
+- **чорні стільці**
+- **жовті лампи**
+
+Then add pointing words from the last module:
+
+- **Ці столи великі.**
+- **Ці книги нові.**
+- **Ті вікна чисті.**
+- **Ті стільці старі.**
+- **Мої ручки сині.**
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+### With numbers
+
+You already met the number pattern in prices and ages. Here it helps with
+classroom objects.
+
+For **два, три, чотири**, use the ordinary plural form you are learning:
+
+| Number chunk | Safe A1 phrase |
+| --- | --- |
+| **два** | **два зошити**, **два столи** |
+| **три** | **три книги**, **три ручки** |
+| **чотири** | **чотири смартфони**, **чотири стільці** |
+
+For **п'ять** and higher, you will often see a different later chunk:
+**п'ять зошитів**, **десять учнів**, **сто гривень**. Do not build the full
+case system today. Just keep the useful phrases as phrases.
+
+Some later human nouns have special shapes, for example **два селянина**.
+That exception is not active A1 work; skip it unless a later lesson asks for
+it.
+
+The practical classroom line is:
+
+**Нам треба три зошити і дві ручки.** = We need three notebooks and two pens.
+
+That one sentence ties the module together: a plural people chunk (**нам**),
+numbers (**три**, **дві**), plural nouns (**зошити**, **ручки**), and no extra
+grammar table.
+
+<!-- INJECT_ACTIVITY: act-5 -->
+
+## Підсумок
+
+Keep the module in three short habits.
+
+Learn Ukrainian plural grammar directly. Do not use Russian as a bridge,
+standard, or comparison point; do not frame Ukrainian rules as exceptions to
+Russian. The Ukrainian pattern is enough on its own: **два зошити**,
+**три книги**, **чотири смартфони**.
+
+First, learn noun pairs:
+
+- **стіл - столи**
+- **стілець - стільці**
+- **книга - книги**
+- **ручка - ручки**
+- **вікно - вікна**
+- **крісло - крісла**
+
+Second, use one plural adjective ending:
+
+- **великий / велика / велике -> великі**
+- **новий / нова / нове -> нові**
+- **синій / синя / синє -> сині**
+- **чистий / чиста / чисте -> чисті**
+
+Third, combine plural helpers:
+
+- **ці великі столи**
+- **ті старі стільці**
+- **мої сині зошити**
+- **які червоні ручки?**
+
+<!-- INJECT_ACTIVITY: act-6 -->
+
+### Repair traps
+
+Use these repairs when English tries to keep Ukrainian too simple:
+
+| Avoid | Use | Why |
+| --- | --- | --- |
+| **великий м'ячі** | **великі м'ячі** | Plural adjective: **-і** |
+| copying a singular **-я** ending into plural | **сині шарфи** | The plural form is **сині** |
+| **два зошитів** | **два зошити** | **2, 3, 4** use the ordinary plural form here |
+| **п'ять зошити** | **п'ять зошитів** | Treat **5+** as a later memorized chunk |
+| **один двері** | **одні двері** | **двері** is plural-only |
+| **молоді** for the group | **молодь** | The group word stays singular |
+| **для ми** | **для нас** | Pronouns change in chunks |
+| **з ми** | **з нами** | After **з**, use **нами** |
+
+<!-- INJECT_ACTIVITY: act-8 -->
+
+<!-- INJECT_ACTIVITY: act-7 -->
+
+### Mini room check
+
+Look around your desk or room. Make six tiny plural sentences:
+
+- **Це столи.**
+- **Ці столи великі.**
+- **Ті стільці старі.**
+- **Мої зошити сині.**
+- **Ці книги нові.**
+- **Три ручки тут.**
+
+Now ask three plural questions:
+
+- **Які столи?**
+- **Які ручки - червоні чи сині?**
+- **Ці книги чи ті книги?**
+
+Keep the Ukrainian pattern direct. The plural noun changes, the adjective uses
+**-і**, and **ці / ті / мої / які** do the plural work for pointing, owning,
+and asking.

--- a/curriculum/l2-uk-en/a1/many-things/resources.yaml
+++ b/curriculum/l2-uk-en/a1/many-things/resources.yaml
@@ -1,0 +1,15 @@
+- title: "Plural of Ukrainian Nouns - Special Forms"
+  role: article
+  source_ref: "Plural of Ukrainian Nouns — Special Forms"
+  url: https://www.ukrainianlessons.com/plural-of-ukrainian-nouns-special-forms/
+  notes: "Learner-safe follow-up on plural noun patterns and special plural forms; use after this A1 lesson."
+- title: "FMU 1-46 - Grammar Point: Plural of Nouns in Ukrainian"
+  role: podcast
+  source_ref: "FMU 1-46 | Grammar Point: Plural of Nouns in Ukrainian"
+  url: https://www.ukrainianlessons.com/fmu46/
+  notes: "Short audio-supported grammar review for noun plurals."
+- title: "ULP Season 2, Episode 42 - Plural Nouns in Ukrainian"
+  role: podcast
+  source_ref: "ULP 2-42 | Plural Nouns in Ukrainian"
+  url: https://www.ukrainianlessons.com/episode42/
+  notes: "Optional later listening with more plural noun practice beyond the core A1 classroom set."

--- a/curriculum/l2-uk-en/a1/many-things/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/many-things/vocabulary.yaml
@@ -1,0 +1,204 @@
+- lemma: стіл
+  translation: table, singular
+  pos: noun
+  usage: Це стіл.
+- lemma: столи
+  translation: tables
+  pos: noun
+  usage: Столи великі.
+- lemma: стілець
+  translation: chair, singular
+  pos: noun
+  usage: Це стілець.
+- lemma: стільці
+  translation: chairs
+  pos: noun
+  usage: Стільці старі.
+- lemma: книга
+  translation: book, singular
+  pos: noun
+  usage: Ця книга нова.
+- lemma: книги
+  translation: books
+  pos: noun
+  usage: Книги нові.
+- lemma: вікно
+  translation: window, singular
+  pos: noun
+  usage: Це вікно.
+- lemma: вікна
+  translation: windows
+  pos: noun
+  usage: Вікна чисті.
+- lemma: зошит
+  translation: notebook, singular
+  pos: noun
+  usage: Це мій зошит.
+- lemma: зошити
+  translation: notebooks
+  pos: noun
+  usage: Три зошити тут.
+- lemma: ручка
+  translation: pen, singular
+  pos: noun
+  usage: Це ручка.
+- lemma: ручки
+  translation: pens
+  pos: noun
+  usage: Ці ручки сині.
+- lemma: сумка
+  translation: bag, singular
+  pos: noun
+  usage: Ця сумка червона.
+- lemma: сумки
+  translation: bags
+  pos: noun
+  usage: Сумки чорні.
+- lemma: лампа
+  translation: lamp, singular
+  pos: noun
+  usage: Лампа біла.
+- lemma: лампи
+  translation: lamps
+  pos: noun
+  usage: Лампи жовті.
+- lemma: крісло
+  translation: armchair, singular
+  pos: noun
+  usage: Це крісло.
+- lemma: крісла
+  translation: armchairs
+  pos: noun
+  usage: Крісла чисті.
+- lemma: дзеркало
+  translation: mirror, singular
+  pos: noun
+  usage: Дзеркало нове.
+- lemma: дзеркала
+  translation: mirrors
+  pos: noun
+  usage: Дзеркала чисті.
+- lemma: річ
+  translation: thing
+  pos: noun
+  usage: Це моя річ.
+- lemma: речі
+  translation: things
+  pos: noun
+  usage: Це мої речі.
+- lemma: ці
+  translation: these
+  pos: pronoun
+  usage: Ці столи великі.
+- lemma: ті
+  translation: those
+  pos: pronoun
+  usage: Ті стільці старі.
+- lemma: мої
+  translation: my, plural
+  pos: pronoun
+  usage: Мої зошити сині.
+- lemma: які
+  translation: which; what kind, plural
+  pos: pronoun
+  usage: Які ручки?
+- lemma: ми
+  translation: we
+  pos: pronoun
+  usage: Ми тут.
+- lemma: ви
+  translation: you, plural or formal
+  pos: pronoun
+  usage: Ви тут?
+- lemma: нас
+  translation: us
+  pos: pronoun
+  usage: Для нас.
+- lemma: вас
+  translation: you, plural/formal object
+  pos: pronoun
+  usage: Для вас.
+- lemma: нам
+  translation: to us
+  pos: pronoun
+  usage: Нам треба три зошити.
+- lemma: вам
+  translation: to you
+  pos: pronoun
+  usage: Вам треба ручки.
+- lemma: нами
+  translation: with us
+  pos: pronoun
+  usage: З нами.
+- lemma: вами
+  translation: with you
+  pos: pronoun
+  usage: З вами.
+- lemma: гроші
+  translation: money, plural-only
+  pos: noun
+  usage: Це гроші.
+- lemma: двері
+  translation: door; doors, plural-only form
+  pos: noun
+  usage: Ці двері старі.
+- lemma: окуляри
+  translation: glasses, plural-only
+  pos: noun
+  usage: Мої окуляри тут.
+- lemma: молодь
+  translation: youth, collective singular
+  pos: noun
+  usage: Молодь тут.
+- lemma: дітвора
+  translation: children as a group, collective singular
+  pos: noun
+  usage: Дітвора там.
+- lemma: птаство
+  translation: birds as a group, collective singular
+  pos: noun
+  usage: Птаство тут.
+- lemma: великий
+  translation: big, masculine
+  pos: adjective
+  usage: Великий стіл.
+- lemma: великі
+  translation: big, plural
+  pos: adjective
+  usage: Великі столи.
+- lemma: нові
+  translation: new, plural
+  pos: adjective
+  usage: Нові книги.
+- lemma: чисті
+  translation: clean, plural
+  pos: adjective
+  usage: Чисті вікна.
+- lemma: сині
+  translation: blue, plural
+  pos: adjective
+  usage: Сині зошити.
+- lemma: осінні
+  translation: autumn, plural adjective
+  pos: adjective
+  usage: Осінні ранки.
+- lemma: два зошити
+  translation: two notebooks
+  pos: phrase
+  usage: Два зошити тут.
+- lemma: три книги
+  translation: three books
+  pos: phrase
+  usage: Три книги тут.
+- lemma: чотири смартфони
+  translation: four smartphones
+  pos: phrase
+  usage: Чотири смартфони тут.
+- lemma: п'ять зошитів
+  translation: five notebooks, later 5+ chunk
+  pos: phrase
+  usage: П'ять зошитів is a recognition chunk here.
+- lemma: двоє дверей
+  translation: two doors, collective-number chunk
+  pos: phrase
+  usage: Двоє дверей is passive recognition here.

--- a/starlight/src/content/docs/a1/many-things.mdx
+++ b/starlight/src/content/docs/a1/many-things.mdx
@@ -1,0 +1,417 @@
+---
+title: "Багато речей"
+description: "Столи, книги, вікна — від однини до множини"
+sidebar:
+  order: 13
+  label: "13. Багато речей"
+pipeline: linear-phase-4
+build_status: validated
+prev: this-and-that
+next: checkpoint-my-world
+---
+
+import Quiz from '@site/src/components/Quiz';
+import MatchUp from '@site/src/components/MatchUp';
+import FillIn from '@site/src/components/FillIn';
+import TrueFalse from '@site/src/components/TrueFalse';
+import Unjumble from '@site/src/components/Unjumble';
+import GroupSort from '@site/src/components/GroupSort';
+import Anagram from '@site/src/components/Anagram';
+import ErrorCorrection, { ErrorCorrectionItem } from '@site/src/components/ErrorCorrection';
+import Cloze from '@site/src/components/Cloze';
+import Select from '@site/src/components/Select';
+import Translate from '@site/src/components/Translate';
+import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
+import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import EssayResponse from '@site/src/components/EssayResponse';
+import ComparativeStudy from '@site/src/components/ComparativeStudy';
+import ReadingActivity from '@site/src/components/ReadingActivity';
+import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
+import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import SourceEvaluation from '@site/src/components/SourceEvaluation';
+import Debate from '@site/src/components/Debate';
+import EtymologyTrace from '@site/src/components/EtymologyTrace';
+import GrammarIdentify from '@site/src/components/GrammarIdentify';
+import PaleographyAnalysis from '@site/src/components/PaleographyAnalysis';
+import DialectComparison from '@site/src/components/DialectComparison';
+import TranslationCritique from '@site/src/components/TranslationCritique';
+import Transcription from '@site/src/components/Transcription';
+import Observe from '@site/src/components/Observe';
+import Order from '@site/src/components/Order';
+import CountSyllables from '@site/src/components/CountSyllables';
+import DivideWords from '@site/src/components/DivideWords';
+import OddOneOut from '@site/src/components/OddOneOut';
+import PickSyllables from '@site/src/components/PickSyllables';
+import LetterGrid from '@site/src/components/LetterGrid';
+import FlashcardDeck from '@site/src/components/FlashcardDeck';
+import VocabCard from '@site/src/components/VocabCard';
+import DialogueBox from '@site/src/components/DialogueBox';
+import HashTabSync from '@site/src/components/HashTabSync';
+import ActivityHelp from '@site/src/components/ActivityHelp';
+import YouTubeVideo from '@site/src/components/YouTubeVideo';
+import WatchAndRepeat from '@site/src/components/WatchAndRepeat';
+import Classify from '@site/src/components/Classify';
+import ImageToLetter from '@site/src/components/ImageToLetter';
+import ActivityPlaceholder from '@site/src/components/ActivityPlaceholder';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs syncKey="module-tab">
+<TabItem label="Lesson">
+
+Ukrainian does not add one universal ending for "more than one." You learn a
+few useful plural shapes, then keep each new noun together with its plural
+form: **стіл - столи**, **книга - книги**, **вікно - вікна**. The good news is
+that adjectives become simpler in the plural: **великий / велика / велике**
+all become **великі**.
+
+By the end, you can:
+
+- turn familiar classroom nouns into safe plural chunks;
+- choose **ці / ті / мої / які** with plural nouns;
+- describe groups with plural adjectives and colors;
+- use **два, три, чотири** with ordinary plural noun forms;
+- recognize plural-only words such as **гроші**, **двері**, and **окуляри**
+  without trying to force them into singular.
+
+
+### One thing, many things
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "стіл", "options": [{"text": "столи", "correct": true}, {"text": "стіла", "correct": false}, {"text": "стілів", "correct": false}], "explanation": "Learn the pair стіл - столи."}, {"question": "книга", "options": [{"text": "книги", "correct": true}, {"text": "книгі", "correct": false}, {"text": "книга", "correct": false}], "explanation": "Книга becomes книги."}, {"question": "вікно", "options": [{"text": "вікна", "correct": true}, {"text": "вікни", "correct": false}, {"text": "вікні", "correct": false}], "explanation": "Many neuter nouns ending in -о use -а."}, {"question": "стілець", "options": [{"text": "стільці", "correct": true}, {"text": "стілеці", "correct": false}, {"text": "стільця", "correct": false}], "explanation": "Learn стілець - стільці as its own pair."}, {"question": "крісло", "options": [{"text": "крісла", "correct": true}, {"text": "крісли", "correct": false}, {"text": "кріслі", "correct": false}], "explanation": "Крісло becomes крісла."}, {"question": "ручка", "options": [{"text": "ручки", "correct": true}, {"text": "ручкі", "correct": false}, {"text": "ручка", "correct": false}], "explanation": "Ручка becomes ручки."}]`)} />
+
+## Діалоги
+
+The classroom is getting ready for a Ukrainian lesson. Several things are on
+the tables, so the first job is simple: name one thing, then name many.
+
+<DialogueBox uk="Марко: Що тут є?" en="Marko: What is here?" />
+<DialogueBox uk="Оля: Тут столи, стільці і вікна." en="Olia: There are tables, chairs, and windows here." />
+<DialogueBox uk="Марко: Які столи?" en="Marko: What are the tables like?" />
+<DialogueBox uk="Оля: Столи великі й нові." en="Olia: The tables are big and new." />
+<DialogueBox uk="Марко: А стільці?" en="Marko: And the chairs?" />
+<DialogueBox uk="Оля: Стільці старі, але чисті." en="Olia: The chairs are old, but clean." />
+<DialogueBox uk="Марко: А ці вікна?" en="Marko: And these windows?" />
+<DialogueBox uk="Оля: Ці вікна чисті й великі." en="Olia: These windows are clean and big." />
+
+At a small shop, plural forms appear because you want more than one item:
+
+<DialogueBox uk="Покупець: У вас є ручки?" en="Customer: Do you have pens?" />
+<DialogueBox uk="Продавець: Так. Які ручки - червоні чи сині?" en="Seller: Yes. Which pens - red or blue?" />
+<DialogueBox uk="Покупець: Сині. І ще зошити." en="Customer: Blue ones. And notebooks too." />
+<DialogueBox uk="Продавець: Скільки?" en="Seller: How many?" />
+<DialogueBox uk="Покупець: Три зошити і дві ручки." en="Customer: Three notebooks and two pens." />
+<DialogueBox uk="Продавець: Добре. Для вас є нові сині ручки." en="Seller: Good. For you there are new blue pens." />
+<DialogueBox uk="Покупець: Дякую. Нам треба саме ці." en="Customer: Thank you. We need exactly these." />
+
+Notice four small plural helpers:
+
+| Helper | Meaning | Example |
+| --- | --- | --- |
+| **ці** | these | **ці ручки**, **ці столи** |
+| **ті** | those | **ті книги**, **ті стільці** |
+| **мої** | my, plural | **мої зошити**, **мої книги** |
+| **які** | which / what kind, plural | **Які ручки?** |
+
+Plural can also mean people. This is another way to talk about **багато**:
+more than one person is acting together. Keep these as useful chunks for
+invitations and classroom teamwork:
+
+- **ми** = we, **ви** = you plural / formal you
+- **для нас** = for us, **для вас** = for you
+- **нам треба** = we need, **вам треба** = you need
+- **з нами** = with us, **з вами** = with you
+
+You do not need a pronoun table today. Just recognize the chunks when people
+are acting together: **Ми тут. Нам треба три зошити. Ідіть з нами.**
+
+:::tip
+When a noun is plural, the old gender question becomes quiet. You no longer
+need **мій / моя / моє** or **який / яка / яке**. Use the plural forms:
+**мої** and **які**.
+:::
+
+### Singular and plural pairs
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "стіл", "right": "столи"}, {"left": "книга", "right": "книги"}, {"left": "вікно", "right": "вікна"}, {"left": "стілець", "right": "стільці"}, {"left": "телефон", "right": "телефони"}, {"left": "зошит", "right": "зошити"}, {"left": "лампа", "right": "лампи"}, {"left": "дзеркало", "right": "дзеркала"}]`)} />
+
+## Один → багато
+
+Start with the nouns you already know. Learn the plural as part of the word,
+not as a guess.
+
+| One | Many | Pattern to notice |
+| --- | --- | --- |
+| **стіл** | **столи** | masculine, often **-и** |
+| **зошит** | **зошити** | masculine, often **-и** |
+| **телефон** | **телефони** | masculine, often **-и** |
+| **стілець** | **стільці** | masculine, **-ець** often changes |
+| **книга** | **книги** | feminine, often **-и** |
+| **ручка** | **ручки** | feminine, often **-и** |
+| **сумка** | **сумки** | feminine, often **-и** |
+| **вікно** | **вікна** | neuter **-о** becomes **-а** |
+| **крісло** | **крісла** | neuter **-о** becomes **-а** |
+| **дзеркало** | **дзеркала** | neuter **-о** becomes **-а** |
+
+This is the nominative plural pattern, **називний відмінок множини**, in its
+safest A1 shape. You will meet the same shape in people and money words such
+as **учні** and **гривні**.
+
+This is enough for A1:
+
+- many masculine and feminine nouns use **-и** or **-і**;
+- many neuter nouns ending in **-о** use **-а**;
+- a few words, such as **стілець - стільці**, need their own memory hook.
+
+Do not turn the list into a rule machine. Say the pair aloud and keep the pair
+together: **стіл - столи**, **книга - книги**, **вікно - вікна**. If a new
+word matters, learn both forms at the same time.
+
+Some words already look plural and do not have a simple everyday singular:
+**гроші**, **двері**, **окуляри**, **сани**, **ворота**, **радощі**. Treat
+them as whole words first. You can say **ці двері** and **мої окуляри**.
+Later you will learn special counting phrases such as **одні двері** and
+**двоє дверей**; Ukrainian also has collective number words such as **двоє**,
+**троє**, and **четверо** for later work with plural-only nouns. Keep that
+Ukrainian feature; do not replace it with a flattened counting shortcut.
+
+Some collective words usually stay singular: **молодь**, **дітвора**,
+**птаство**, **листя**. At A1, just recognize that they name a group while
+behaving like singular words. Do not force a plural ending onto them.
+
+### Plural adjective ending
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "нов__ книги", "answer": "і", "options": ["і", "а", "ий"]}, {"sentence": "велик__ столи", "answer": "і", "options": ["і", "ий", "е"]}, {"sentence": "чист__ вікна", "answer": "і", "options": ["і", "е", "а"]}, {"sentence": "син__ зошити", "answer": "і", "options": ["і", "я", "є"]}, {"sentence": "літн__ дні", "answer": "і", "options": ["і", "ій", "я"]}, {"sentence": "осінн__ ранки", "answer": "і", "options": ["і", "я", "є"]}, {"sentence": "червон__ ручки", "answer": "і", "options": ["і", "а", "ий"]}, {"sentence": "жовт__ лампи", "answer": "і", "options": ["і", "а", "е"]}]`)} />
+
+## Прикметники у множині
+
+Plural adjectives are friendlier than singular adjectives. In singular, you
+had to match gender:
+
+| Masculine | Feminine | Neuter |
+| --- | --- | --- |
+| **великий стіл** | **велика книга** | **велике вікно** |
+| **новий зошит** | **нова сумка** | **нове крісло** |
+| **синій шарф** | **синя ручка** | **синє вікно** |
+
+In the plural, use **які?** and the adjective ending **-і**. A textbook may
+call the regular hard-adjective path **тверда група**, but your A1 habit is
+simpler: move from **однина** to plural and use **-і**.
+
+| Many things | Description |
+| --- | --- |
+| **столи** | **великі столи** |
+| **книги** | **нові книги** |
+| **вікна** | **чисті вікна** |
+| **ручки** | **сині ручки** |
+| **зошити** | **корисні зошити** |
+
+The noun can come from any gender in the singular. The plural adjective still
+uses **-і**:
+
+- **великий стіл -> великі столи**
+- **нова книга -> нові книги**
+- **чисте вікно -> чисті вікна**
+- **синій шарф -> сині шарфи**
+- **літній день -> літні дні**
+- **осінній ранок -> осінні ранки**
+
+This protects you from a common English-speaker habit. English keeps the
+adjective unchanged: big table, big tables. Ukrainian changes the adjective:
+**великий стіл**, but **великі столи**. If your noun is plural, your adjective
+is plural too.
+
+Use colors the same way:
+
+- **червоні ручки**
+- **сині зошити**
+- **білі стіни**
+- **чорні стільці**
+- **жовті лампи**
+
+Then add pointing words from the last module:
+
+- **Ці столи великі.**
+- **Ці книги нові.**
+- **Ті вікна чисті.**
+- **Ті стільці старі.**
+- **Мої ручки сині.**
+
+### Singular, ordinary plural, special number
+
+<GroupSort client:only='react' groups={JSON.parse(`{"One thing": ["стіл", "книга", "вікно", "стілець"], "Ordinary plural": ["столи", "книги", "вікна", "стільці"], "Special number chunk": ["п'ять зошитів", "десять учнів", "сто гривень", "двоє дверей"]}`)} />
+
+### With numbers
+
+You already met the number pattern in prices and ages. Here it helps with
+classroom objects.
+
+For **два, три, чотири**, use the ordinary plural form you are learning:
+
+| Number chunk | Safe A1 phrase |
+| --- | --- |
+| **два** | **два зошити**, **два столи** |
+| **три** | **три книги**, **три ручки** |
+| **чотири** | **чотири смартфони**, **чотири стільці** |
+
+For **п'ять** and higher, you will often see a different later chunk:
+**п'ять зошитів**, **десять учнів**, **сто гривень**. Do not build the full
+case system today. Just keep the useful phrases as phrases.
+
+Some later human nouns have special shapes, for example **два селянина**.
+That exception is not active A1 work; skip it unless a later lesson asks for
+it.
+
+The practical classroom line is:
+
+**Нам треба три зошити і дві ручки.** = We need three notebooks and two pens.
+
+That one sentence ties the module together: a plural people chunk (**нам**),
+numbers (**три**, **дві**), plural nouns (**зошити**, **ручки**), and no extra
+grammar table.
+
+### Ці, ті, мої, які
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "These tables are big.", "options": [{"text": "Ці столи великі.", "correct": true}, {"text": "Цей столи великі.", "correct": false}, {"text": "Ця столи великі.", "correct": false}], "explanation": "Use ці with plural nouns near you."}, {"question": "Those chairs are old.", "options": [{"text": "Ті стільці старі.", "correct": true}, {"text": "Той стільці старі.", "correct": false}, {"text": "Та стільці старі.", "correct": false}], "explanation": "Use ті for plural nouns farther away."}, {"question": "My notebooks are blue.", "options": [{"text": "Мої зошити сині.", "correct": true}, {"text": "Мій зошити сині.", "correct": false}, {"text": "Моя зошити сині.", "correct": false}], "explanation": "The plural form of my is мої."}, {"question": "Which pens?", "options": [{"text": "Які ручки?", "correct": true}, {"text": "Яка ручки?", "correct": false}, {"text": "Який ручки?", "correct": false}], "explanation": "The plural question word is які."}, {"question": "These books are new.", "options": [{"text": "Ці книги нові.", "correct": true}, {"text": "Це книги нове.", "correct": false}, {"text": "Ця книги нова.", "correct": false}], "explanation": "Use plural ці and plural нові."}]`)} />
+
+## 📋 Підсумок
+
+Keep the module in three short habits.
+
+Learn Ukrainian plural grammar directly. Do not use Russian as a bridge,
+standard, or comparison point; do not frame Ukrainian rules as exceptions to
+Russian. The Ukrainian pattern is enough on its own: **два зошити**,
+**три книги**, **чотири смартфони**.
+
+First, learn noun pairs:
+
+- **стіл - столи**
+- **стілець - стільці**
+- **книга - книги**
+- **ручка - ручки**
+- **вікно - вікна**
+- **крісло - крісла**
+
+Second, use one plural adjective ending:
+
+- **великий / велика / велике -> великі**
+- **новий / нова / нове -> нові**
+- **синій / синя / синє -> сині**
+- **чистий / чиста / чисте -> чисті**
+
+Third, combine plural helpers:
+
+- **ці великі столи**
+- **ті старі стільці**
+- **мої сині зошити**
+- **які червоні ручки?**
+
+### People chunks
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "we", "right": "ми"}, {"left": "you, plural or formal", "right": "ви"}, {"left": "for us", "right": "для нас"}, {"left": "for you", "right": "для вас"}, {"left": "we need", "right": "нам треба"}, {"left": "you need", "right": "вам треба"}, {"left": "with us", "right": "з нами"}, {"left": "with you", "right": "з вами"}]`)} />
+
+### Repair traps
+
+Use these repairs when English tries to keep Ukrainian too simple:
+
+| Avoid | Use | Why |
+| --- | --- | --- |
+| **великий м'ячі** | **великі м'ячі** | Plural adjective: **-і** |
+| copying a singular **-я** ending into plural | **сині шарфи** | The plural form is **сині** |
+| **два зошитів** | **два зошити** | **2, 3, 4** use the ordinary plural form here |
+| **п'ять зошити** | **п'ять зошитів** | Treat **5+** as a later memorized chunk |
+| **один двері** | **одні двері** | **двері** is plural-only |
+| **молоді** for the group | **молодь** | The group word stays singular |
+| **для ми** | **для нас** | Pronouns change in chunks |
+| **з ми** | **з нами** | After **з**, use **нами** |
+
+<span id="repair-traps"></span>
+
+### Repair plural traps
+
+<ErrorCorrection client:only='react' instruction="Choose the standard Ukrainian repair." items={JSON.parse(`[{"sentence": "великий м'ячі", "errorWord": "великий м'ячі", "correctForm": "великі м'ячі", "options": ["великі м'ячі", "великий м'ячі", "велика м'ячі"], "explanation": "Plural adjectives use -і."}, {"sentence": "синія шарфи", "errorWord": "синія шарфи", "correctForm": "сині шарфи", "options": ["сині шарфи", "синія шарфи", "синій шарфи"], "explanation": "The plural color form is сині."}, {"sentence": "два зошитів / два смартфонів", "errorWord": "два зошитів / два смартфонів", "correctForm": "два зошити / чотири смартфони", "options": ["два зошити / чотири смартфони", "два зошитів / два смартфонів", "два зошита / чотири смартфона"], "explanation": "Two, three, and four use the ordinary plural form here."}, {"sentence": "п'ять зошити / десять учні", "errorWord": "п'ять зошити / десять учні", "correctForm": "п'ять зошитів / десять учнів", "options": ["п'ять зошитів / десять учнів", "п'ять зошити / десять учні", "п'ять зошита / десять учня"], "explanation": "Keep the 5+ chunk п'ять зошитів."}, {"sentence": "один двері / два двері", "errorWord": "один двері / два двері", "correctForm": "одні двері / двоє дверей", "options": ["одні двері / двоє дверей", "один двері / два двері", "одна двері / дві двері"], "explanation": "Двері is plural-only in everyday use."}, {"sentence": "молоді / дітвори", "errorWord": "молоді / дітвори", "correctForm": "молодь / дітвора", "options": ["молодь / дітвора", "молоді / дітвори", "молодя / дітвори"], "explanation": "Молодь is a singular collective word."}, {"sentence": "для ми / з ми", "errorWord": "для ми / з ми", "correctForm": "для нас / з нами", "options": ["для нас / з нами", "для ми / з ми", "для нам / з нас"], "explanation": "Use the pronoun chunks: для нас, з нами."}]`)} />
+
+### Number chunks
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "два ___", "answer": "зошити", "options": ["зошити", "зошитів", "зошит"]}, {"sentence": "три ___", "answer": "книги", "options": ["книги", "книг", "книга"]}, {"sentence": "чотири ___", "answer": "смартфони", "options": ["смартфони", "смартфонів", "смартфон"]}, {"sentence": "п'ять ___", "answer": "зошитів", "options": ["зошитів", "зошити", "зошит"]}, {"sentence": "десять ___", "answer": "учнів", "options": ["учнів", "учні", "учень"]}, {"sentence": "сто ___", "answer": "гривень", "options": ["гривень", "гривні", "гривня"]}]`)} />
+
+### Mini room check
+
+Look around your desk or room. Make six tiny plural sentences:
+
+- **Це столи.**
+- **Ці столи великі.**
+- **Ті стільці старі.**
+- **Мої зошити сині.**
+- **Ці книги нові.**
+- **Три ручки тут.**
+
+Now ask three plural questions:
+
+- **Які столи?**
+- **Які ручки - червоні чи сині?**
+- **Ці книги чи ті книги?**
+
+Keep the Ukrainian pattern direct. The plural noun changes, the adjective uses
+**-і**, and **ці / ті / мої / які** do the plural work for pointing, owning,
+and asking.
+
+</TabItem>
+<TabItem label="Vocabulary">
+
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"стіл","translation":"table, singular","pos":"noun","example":"Це стіл.","examples":["table, singular","Це стіл."]},{"word":"столи","translation":"tables","pos":"noun","example":"Столи великі.","examples":["tables","Столи великі."]},{"word":"стілець","translation":"chair, singular","pos":"noun","example":"Це стілець.","examples":["chair, singular","Це стілець."]},{"word":"стільці","translation":"chairs","pos":"noun","example":"Стільці старі.","examples":["chairs","Стільці старі."]},{"word":"книга","translation":"book, singular","pos":"noun","example":"Ця книга нова.","examples":["book, singular","Ця книга нова."]},{"word":"книги","translation":"books","pos":"noun","example":"Книги нові.","examples":["books","Книги нові."]},{"word":"вікно","translation":"window, singular","pos":"noun","example":"Це вікно.","examples":["window, singular","Це вікно."]},{"word":"вікна","translation":"windows","pos":"noun","example":"Вікна чисті.","examples":["windows","Вікна чисті."]},{"word":"зошит","translation":"notebook, singular","pos":"noun","example":"Це мій зошит.","examples":["notebook, singular","Це мій зошит."]},{"word":"зошити","translation":"notebooks","pos":"noun","example":"Три зошити тут.","examples":["notebooks","Три зошити тут."]},{"word":"ручка","translation":"pen, singular","pos":"noun","example":"Це ручка.","examples":["pen, singular","Це ручка."]},{"word":"ручки","translation":"pens","pos":"noun","example":"Ці ручки сині.","examples":["pens","Ці ручки сині."]},{"word":"сумка","translation":"bag, singular","pos":"noun","example":"Ця сумка червона.","examples":["bag, singular","Ця сумка червона."]},{"word":"сумки","translation":"bags","pos":"noun","example":"Сумки чорні.","examples":["bags","Сумки чорні."]},{"word":"лампа","translation":"lamp, singular","pos":"noun","example":"Лампа біла.","examples":["lamp, singular","Лампа біла."]},{"word":"лампи","translation":"lamps","pos":"noun","example":"Лампи жовті.","examples":["lamps","Лампи жовті."]},{"word":"крісло","translation":"armchair, singular","pos":"noun","example":"Це крісло.","examples":["armchair, singular","Це крісло."]},{"word":"крісла","translation":"armchairs","pos":"noun","example":"Крісла чисті.","examples":["armchairs","Крісла чисті."]},{"word":"дзеркало","translation":"mirror, singular","pos":"noun","example":"Дзеркало нове.","examples":["mirror, singular","Дзеркало нове."]},{"word":"дзеркала","translation":"mirrors","pos":"noun","example":"Дзеркала чисті.","examples":["mirrors","Дзеркала чисті."]},{"word":"річ","translation":"thing","pos":"noun","example":"Це моя річ.","examples":["thing","Це моя річ."]},{"word":"речі","translation":"things","pos":"noun","example":"Це мої речі.","examples":["things","Це мої речі."]},{"word":"ці","translation":"these","pos":"pronoun","example":"Ці столи великі.","examples":["these","Ці столи великі."]},{"word":"ті","translation":"those","pos":"pronoun","example":"Ті стільці старі.","examples":["those","Ті стільці старі."]},{"word":"мої","translation":"my, plural","pos":"pronoun","example":"Мої зошити сині.","examples":["my, plural","Мої зошити сині."]},{"word":"які","translation":"which; what kind, plural","pos":"pronoun","example":"Які ручки?","examples":["which; what kind, plural","Які ручки?"]},{"word":"ми","translation":"we","pos":"pronoun","example":"Ми тут.","examples":["we","Ми тут."]},{"word":"ви","translation":"you, plural or formal","pos":"pronoun","example":"Ви тут?","examples":["you, plural or formal","Ви тут?"]},{"word":"нас","translation":"us","pos":"pronoun","example":"Для нас.","examples":["us","Для нас."]},{"word":"вас","translation":"you, plural/formal object","pos":"pronoun","example":"Для вас.","examples":["you, plural/formal object","Для вас."]},{"word":"нам","translation":"to us","pos":"pronoun","example":"Нам треба три зошити.","examples":["to us","Нам треба три зошити."]},{"word":"вам","translation":"to you","pos":"pronoun","example":"Вам треба ручки.","examples":["to you","Вам треба ручки."]},{"word":"нами","translation":"with us","pos":"pronoun","example":"З нами.","examples":["with us","З нами."]},{"word":"вами","translation":"with you","pos":"pronoun","example":"З вами.","examples":["with you","З вами."]},{"word":"гроші","translation":"money, plural-only","pos":"noun","example":"Це гроші.","examples":["money, plural-only","Це гроші."]},{"word":"двері","translation":"door; doors, plural-only form","pos":"noun","example":"Ці двері старі.","examples":["door; doors, plural-only form","Ці двері старі."]},{"word":"окуляри","translation":"glasses, plural-only","pos":"noun","example":"Мої окуляри тут.","examples":["glasses, plural-only","Мої окуляри тут."]},{"word":"молодь","translation":"youth, collective singular","pos":"noun","example":"Молодь тут.","examples":["youth, collective singular","Молодь тут."]},{"word":"дітвора","translation":"children as a group, collective singular","pos":"noun","example":"Дітвора там.","examples":["children as a group, collective singular","Дітвора там."]},{"word":"птаство","translation":"birds as a group, collective singular","pos":"noun","example":"Птаство тут.","examples":["birds as a group, collective singular","Птаство тут."]},{"word":"великий","translation":"big, masculine","pos":"adjective","example":"Великий стіл.","examples":["big, masculine","Великий стіл."]},{"word":"великі","translation":"big, plural","pos":"adjective","example":"Великі столи.","examples":["big, plural","Великі столи."]},{"word":"нові","translation":"new, plural","pos":"adjective","example":"Нові книги.","examples":["new, plural","Нові книги."]},{"word":"чисті","translation":"clean, plural","pos":"adjective","example":"Чисті вікна.","examples":["clean, plural","Чисті вікна."]},{"word":"сині","translation":"blue, plural","pos":"adjective","example":"Сині зошити.","examples":["blue, plural","Сині зошити."]},{"word":"осінні","translation":"autumn, plural adjective","pos":"adjective","example":"Осінні ранки.","examples":["autumn, plural adjective","Осінні ранки."]},{"word":"два зошити","translation":"two notebooks","pos":"phrase","example":"Два зошити тут.","examples":["two notebooks","Два зошити тут."]},{"word":"три книги","translation":"three books","pos":"phrase","example":"Три книги тут.","examples":["three books","Три книги тут."]},{"word":"чотири смартфони","translation":"four smartphones","pos":"phrase","example":"Чотири смартфони тут.","examples":["four smartphones","Чотири смартфони тут."]},{"word":"п'ять зошитів","translation":"five notebooks, later 5+ chunk","pos":"phrase","example":"П'ять зошитів is a recognition chunk here.","examples":["five notebooks, later 5+ chunk","П'ять зошитів is a recognition chunk here."]},{"word":"двоє дверей","translation":"two doors, collective-number chunk","pos":"phrase","example":"Двоє дверей is passive recognition here.","examples":["two doors, collective-number chunk","Двоє дверей is passive recognition here."]}]`)} title="Vocabulary" />
+
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"стіл","back":"table, singular"},{"front":"столи","back":"tables"},{"front":"стілець","back":"chair, singular"},{"front":"стільці","back":"chairs"},{"front":"книга","back":"book, singular"},{"front":"книги","back":"books"},{"front":"вікно","back":"window, singular"},{"front":"вікна","back":"windows"},{"front":"зошит","back":"notebook, singular"},{"front":"зошити","back":"notebooks"},{"front":"ручка","back":"pen, singular"},{"front":"ручки","back":"pens"},{"front":"сумка","back":"bag, singular"},{"front":"сумки","back":"bags"},{"front":"лампа","back":"lamp, singular"},{"front":"лампи","back":"lamps"},{"front":"крісло","back":"armchair, singular"},{"front":"крісла","back":"armchairs"},{"front":"дзеркало","back":"mirror, singular"},{"front":"дзеркала","back":"mirrors"},{"front":"річ","back":"thing"},{"front":"речі","back":"things"},{"front":"ці","back":"these"},{"front":"ті","back":"those"},{"front":"мої","back":"my, plural"},{"front":"які","back":"which; what kind, plural"},{"front":"ми","back":"we"},{"front":"ви","back":"you, plural or formal"},{"front":"нас","back":"us"},{"front":"вас","back":"you, plural/formal object"},{"front":"нам","back":"to us"},{"front":"вам","back":"to you"},{"front":"нами","back":"with us"},{"front":"вами","back":"with you"},{"front":"гроші","back":"money, plural-only"},{"front":"двері","back":"door; doors, plural-only form"},{"front":"окуляри","back":"glasses, plural-only"},{"front":"молодь","back":"youth, collective singular"},{"front":"дітвора","back":"children as a group, collective singular"},{"front":"птаство","back":"birds as a group, collective singular"},{"front":"великий","back":"big, masculine"},{"front":"великі","back":"big, plural"},{"front":"нові","back":"new, plural"},{"front":"чисті","back":"clean, plural"},{"front":"сині","back":"blue, plural"},{"front":"осінні","back":"autumn, plural adjective"},{"front":"два зошити","back":"two notebooks"},{"front":"три книги","back":"three books"},{"front":"чотири смартфони","back":"four smartphones"},{"front":"п'ять зошитів","back":"five notebooks, later 5+ chunk"},{"front":"двоє дверей","back":"two doors, collective-number chunk"}]`)} />
+
+</TabItem>
+<TabItem label="Activities">
+
+### One thing, many things
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "стіл", "options": [{"text": "столи", "correct": true}, {"text": "стіла", "correct": false}, {"text": "стілів", "correct": false}], "explanation": "Learn the pair стіл - столи."}, {"question": "книга", "options": [{"text": "книги", "correct": true}, {"text": "книгі", "correct": false}, {"text": "книга", "correct": false}], "explanation": "Книга becomes книги."}, {"question": "вікно", "options": [{"text": "вікна", "correct": true}, {"text": "вікни", "correct": false}, {"text": "вікні", "correct": false}], "explanation": "Many neuter nouns ending in -о use -а."}, {"question": "стілець", "options": [{"text": "стільці", "correct": true}, {"text": "стілеці", "correct": false}, {"text": "стільця", "correct": false}], "explanation": "Learn стілець - стільці as its own pair."}, {"question": "крісло", "options": [{"text": "крісла", "correct": true}, {"text": "крісли", "correct": false}, {"text": "кріслі", "correct": false}], "explanation": "Крісло becomes крісла."}, {"question": "ручка", "options": [{"text": "ручки", "correct": true}, {"text": "ручкі", "correct": false}, {"text": "ручка", "correct": false}], "explanation": "Ручка becomes ручки."}]`)} />
+
+### Singular and plural pairs
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "стіл", "right": "столи"}, {"left": "книга", "right": "книги"}, {"left": "вікно", "right": "вікна"}, {"left": "стілець", "right": "стільці"}, {"left": "телефон", "right": "телефони"}, {"left": "зошит", "right": "зошити"}, {"left": "лампа", "right": "лампи"}, {"left": "дзеркало", "right": "дзеркала"}]`)} />
+
+### Plural adjective ending
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "нов__ книги", "answer": "і", "options": ["і", "а", "ий"]}, {"sentence": "велик__ столи", "answer": "і", "options": ["і", "ий", "е"]}, {"sentence": "чист__ вікна", "answer": "і", "options": ["і", "е", "а"]}, {"sentence": "син__ зошити", "answer": "і", "options": ["і", "я", "є"]}, {"sentence": "літн__ дні", "answer": "і", "options": ["і", "ій", "я"]}, {"sentence": "осінн__ ранки", "answer": "і", "options": ["і", "я", "є"]}, {"sentence": "червон__ ручки", "answer": "і", "options": ["і", "а", "ий"]}, {"sentence": "жовт__ лампи", "answer": "і", "options": ["і", "а", "е"]}]`)} />
+
+### Singular, ordinary plural, special number
+
+<GroupSort client:only='react' groups={JSON.parse(`{"One thing": ["стіл", "книга", "вікно", "стілець"], "Ordinary plural": ["столи", "книги", "вікна", "стільці"], "Special number chunk": ["п'ять зошитів", "десять учнів", "сто гривень", "двоє дверей"]}`)} />
+
+### Ці, ті, мої, які
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "These tables are big.", "options": [{"text": "Ці столи великі.", "correct": true}, {"text": "Цей столи великі.", "correct": false}, {"text": "Ця столи великі.", "correct": false}], "explanation": "Use ці with plural nouns near you."}, {"question": "Those chairs are old.", "options": [{"text": "Ті стільці старі.", "correct": true}, {"text": "Той стільці старі.", "correct": false}, {"text": "Та стільці старі.", "correct": false}], "explanation": "Use ті for plural nouns farther away."}, {"question": "My notebooks are blue.", "options": [{"text": "Мої зошити сині.", "correct": true}, {"text": "Мій зошити сині.", "correct": false}, {"text": "Моя зошити сині.", "correct": false}], "explanation": "The plural form of my is мої."}, {"question": "Which pens?", "options": [{"text": "Які ручки?", "correct": true}, {"text": "Яка ручки?", "correct": false}, {"text": "Який ручки?", "correct": false}], "explanation": "The plural question word is які."}, {"question": "These books are new.", "options": [{"text": "Ці книги нові.", "correct": true}, {"text": "Це книги нове.", "correct": false}, {"text": "Ця книги нова.", "correct": false}], "explanation": "Use plural ці and plural нові."}]`)} />
+
+### People chunks
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "we", "right": "ми"}, {"left": "you, plural or formal", "right": "ви"}, {"left": "for us", "right": "для нас"}, {"left": "for you", "right": "для вас"}, {"left": "we need", "right": "нам треба"}, {"left": "you need", "right": "вам треба"}, {"left": "with us", "right": "з нами"}, {"left": "with you", "right": "з вами"}]`)} />
+
+### Number chunks
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "два ___", "answer": "зошити", "options": ["зошити", "зошитів", "зошит"]}, {"sentence": "три ___", "answer": "книги", "options": ["книги", "книг", "книга"]}, {"sentence": "чотири ___", "answer": "смартфони", "options": ["смартфони", "смартфонів", "смартфон"]}, {"sentence": "п'ять ___", "answer": "зошитів", "options": ["зошитів", "зошити", "зошит"]}, {"sentence": "десять ___", "answer": "учнів", "options": ["учнів", "учні", "учень"]}, {"sentence": "сто ___", "answer": "гривень", "options": ["гривень", "гривні", "гривня"]}]`)} />
+
+<span id="repair-traps"></span>
+
+### Repair plural traps
+
+<ErrorCorrection client:only='react' instruction="Choose the standard Ukrainian repair." items={JSON.parse(`[{"sentence": "великий м'ячі", "errorWord": "великий м'ячі", "correctForm": "великі м'ячі", "options": ["великі м'ячі", "великий м'ячі", "велика м'ячі"], "explanation": "Plural adjectives use -і."}, {"sentence": "синія шарфи", "errorWord": "синія шарфи", "correctForm": "сині шарфи", "options": ["сині шарфи", "синія шарфи", "синій шарфи"], "explanation": "The plural color form is сині."}, {"sentence": "два зошитів / два смартфонів", "errorWord": "два зошитів / два смартфонів", "correctForm": "два зошити / чотири смартфони", "options": ["два зошити / чотири смартфони", "два зошитів / два смартфонів", "два зошита / чотири смартфона"], "explanation": "Two, three, and four use the ordinary plural form here."}, {"sentence": "п'ять зошити / десять учні", "errorWord": "п'ять зошити / десять учні", "correctForm": "п'ять зошитів / десять учнів", "options": ["п'ять зошитів / десять учнів", "п'ять зошити / десять учні", "п'ять зошита / десять учня"], "explanation": "Keep the 5+ chunk п'ять зошитів."}, {"sentence": "один двері / два двері", "errorWord": "один двері / два двері", "correctForm": "одні двері / двоє дверей", "options": ["одні двері / двоє дверей", "один двері / два двері", "одна двері / дві двері"], "explanation": "Двері is plural-only in everyday use."}, {"sentence": "молоді / дітвори", "errorWord": "молоді / дітвори", "correctForm": "молодь / дітвора", "options": ["молодь / дітвора", "молоді / дітвори", "молодя / дітвори"], "explanation": "Молодь is a singular collective word."}, {"sentence": "для ми / з ми", "errorWord": "для ми / з ми", "correctForm": "для нас / з нами", "options": ["для нас / з нами", "для ми / з ми", "для нам / з нас"], "explanation": "Use the pronoun chunks: для нас, з нами."}]`)} />
+
+</TabItem>
+<TabItem label="Resources">
+
+:::info[🎧 🔗 External Resources]
+
+**📝 Articles:**
+- 📄 [Plural of Ukrainian Nouns - Special Forms](https://www.ukrainianlessons.com/plural-of-ukrainian-nouns-special-forms/) — Learner-safe follow-up on plural noun patterns and special plural forms; use after this A1 lesson.
+
+**🎧 Audio:**
+- 🎧 [FMU 1-46 - Grammar Point: Plural of Nouns in Ukrainian](https://www.ukrainianlessons.com/fmu46/) — Short audio-supported grammar review for noun plurals.
+- 🎧 [ULP Season 2, Episode 42 - Plural Nouns in Ukrainian](https://www.ukrainianlessons.com/episode42/) — Optional later listening with more plural noun practice beyond the core A1 classroom set.
+:::
+
+</TabItem>
+</Tabs>
+
+<HashTabSync />


### PR DESCRIPTION
Small stacked PR extracted from the closed A1 umbrella branch. Review this PR against its immediate base, not against main unless this is the runtime base PR.

Stack target:
- Base: codex/a1-stack-m12-this-and-that
- Head: codex/a1-stack-m13-many-things
- Commit: 06f76959772620ed0bf10387f31c8d03bd9c6d95

Validation already run on the extracted stack:
- Per-commit hooks passed during extraction.
- Final stack: `git diff --check origin/main...HEAD` passed.
- Final stack: `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed for all 56 commits.
- Final stack: `npm --prefix starlight run build` passed after `npm --prefix starlight ci`.
- M52-M55 browser smoke passed: routes loaded with HTTP 200 and no console errors.

Review focus:
- bounded diff correctness against the base branch
- generated-artifact hygiene: no `status/*.json`, `audit/*-review.md`, or `review/*-review.md`
- plan snapshot correctness where this PR includes a required `.yaml.bak`
- merge safety for the stacked A1 sequence

Existing A1 audit and LLM audit remain evidence, but they are not a replacement for this PR-level review.