### PR TITLE
feat(a1): add M21 action checkpoint module

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
@@ -1,0 +1,282 @@
+- id: act-1
+  type: match-up
+  title: Reading line to skill
+  instruction: Match each checkpoint line with the skill it proves.
+  pairs:
+    - left: Я прокидаюся о сьомій.
+      right: reflexive routine
+    - left: Я люблю читати.
+      right: like + infinitive
+    - left: Вона працює в школі.
+      right: Group One -ува-
+    - left: Ти пишеш гарно.
+      right: писати change
+    - left: Вони роблять швидко.
+      right: Group Two plural
+    - left: Я можу готувати.
+      right: modal + infinitive
+    - left: Коли ти можеш?
+      right: question word
+    - left: Ніхто не читає.
+      right: negative
+- id: act-2
+  type: true-false
+  title: Action diagnostics
+  instruction: Decide whether each line uses the checkpoint pattern safely.
+  items:
+    - statement: Я працюю кожного дня.
+      correct: true
+      explanation: Працюю is the я form of працювати.
+    - statement: Вона працює в школі.
+      correct: true
+      explanation: Працювати changes to працює with вона.
+    - statement: Ви пишите дуже гарно.
+      correct: false
+      explanation: Use Ви пишете дуже гарно.
+    - statement: Вони роботь швидко.
+      correct: false
+      explanation: Use Вони роблять швидко.
+    - statement: Він хоче кави.
+      correct: true
+      explanation: Хоче is the safe він form.
+    - statement: Я є читаю книгу.
+      correct: false
+      explanation: Use Я читаю книгу.
+    - statement: Я прокидаюся о сьомій.
+      correct: true
+      explanation: Прокидаюся is a safe -ся routine form.
+    - statement: Ніхто не читає.
+      correct: true
+      explanation: Keep не before the verb.
+- id: act-3
+  type: group-sort
+  title: Skill stations
+  instruction: Sort each chunk by the skill it checks.
+  groups:
+    - name: Group One
+      items:
+        - я читаю
+        - ти пишеш
+        - вони працюють
+        - ми малюємо
+    - name: Group Two
+      items:
+        - я говорю
+        - ти говориш
+        - вони роблять
+        - ви бачите
+    - name: Modal + infinitive
+      items:
+        - хочу читати
+        - можу готувати
+        - мушу працювати
+        - може допомагати
+    - name: Question words
+      items:
+        - де ти працюєш?
+        - коли ти можеш?
+        - що ти читаєш?
+        - як ми говоримо?
+- id: act-4
+  type: fill-in
+  title: Roommate dialogue gaps
+  instruction: Complete the dialogue with the checkpoint form.
+  items:
+    - sentence: "Олег: Коли ти ___?"
+      answer: прокидаєшся
+      options:
+        - прокидаєшся
+        - працюєш
+        - пишеш
+      explanation: The question asks about the morning routine.
+    - sentence: "Марина: Я ___ о сьомій."
+      answer: прокидаюся
+      options:
+        - прокидаюся
+        - читаю
+        - роблю
+      explanation: With я, use прокидаюся.
+    - sentence: "Олег: Де ти ___?"
+      answer: працюєш
+      options:
+        - працюєш
+        - можеш
+        - хочеш
+      explanation: Де asks for the work place.
+    - sentence: "Марина: Я ___ в школі."
+      answer: працюю
+      options:
+        - працюю
+        - працює
+        - працюємо
+      explanation: With я, use працюю.
+    - sentence: "Олег: Ти ___ читати ввечері?"
+      answer: любиш
+      options:
+        - любиш
+        - читаєш
+        - робиш
+      explanation: Любиш + infinitive asks about liking an action.
+    - sentence: "Марина: Не можу зараз, ___ працювати."
+      answer: мушу
+      options:
+        - мушу
+        - читаю
+        - говорю
+      explanation: Мушу + infinitive means I have to.
+- id: act-5
+  type: odd-one-out
+  title: Find the form that does not fit
+  instruction: Choose the chunk that belongs to a different checkpoint skill.
+  items:
+    - words:
+        - я читаю
+        - ти читаєш
+        - вони читають
+        - ти говориш
+      answer: ти говориш
+      explanation: Ти говориш is Group Two; the others are Group One читати.
+    - words:
+        - хочу читати
+        - можу готувати
+        - мушу працювати
+        - я читаю
+      answer: я читаю
+      explanation: Я читаю is a person form, not modal + infinitive.
+    - words:
+        - хто
+        - коли
+        - куди
+        - працюю
+      answer: працюю
+      explanation: Працюю is a verb form; the others are question words.
+    - words:
+        - я прокидаюся
+        - ти вмиваєшся
+        - вона одягається
+        - я снідаю
+      answer: я снідаю
+      explanation: Снідаю is not a -ся verb.
+- id: act-6
+  type: unjumble
+  title: Rebuild checkpoint lines
+  instruction: Put the words in a safe A1.3 order.
+  items:
+    - words:
+        - Я
+        - люблю
+        - читати
+      answer: Я люблю читати
+    - words:
+        - Вона
+        - працює
+        - в школі
+      answer: Вона працює в школі
+    - words:
+        - Ми
+        - говоримо
+        - українською
+      answer: Ми говоримо українською
+    - words:
+        - Коли
+        - ти
+        - можеш
+      answer: Коли ти можеш
+    - words:
+        - Я
+        - мушу
+        - працювати
+      answer: Я мушу працювати
+    - words:
+        - Вони
+        - роблять
+        - швидко
+      answer: Вони роблять швидко
+- id: act-7
+  type: quiz
+  title: Choose the answer job
+  instruction: Choose the line that answers the question.
+  items:
+    - prompt: "Коли ти прокидаєшся?"
+      options:
+        - text: О сьомій.
+          correct: true
+        - text: У школі.
+          correct: false
+        - text: Українською.
+          correct: false
+      explanation: Коли asks about time.
+    - prompt: "Де ти працюєш?"
+      options:
+        - text: В офісі.
+          correct: true
+        - text: О восьмій.
+          correct: false
+        - text: Тому що мушу.
+          correct: false
+      explanation: Де asks about place.
+    - prompt: "Що ти любиш?"
+      options:
+        - text: Читати.
+          correct: true
+        - text: Удома.
+          correct: false
+        - text: Завтра.
+          correct: false
+      explanation: Що asks for the action or thing.
+    - prompt: "Як ми говоримо?"
+      options:
+        - text: Українською.
+          correct: true
+        - text: Увечері.
+          correct: false
+        - text: У школі.
+          correct: false
+      explanation: Як asks how.
+- id: act-8
+  type: fill-in
+  title: Repair by building the safe line
+  instruction: Build the corrected line from the checkpoint prompt.
+  items:
+    - sentence: "I work every day: Я ___ кожного дня."
+      answer: працюю
+      options:
+        - працюю
+        - читаю
+        - пишу
+      explanation: Repair for Я працювати кожного дня.
+    - sentence: "She works at school: Вона ___ в школі."
+      answer: працює
+      options:
+        - працює
+        - читає
+        - готує
+      explanation: "Repair for <!-- bad -->Вона працюває в школі<!-- /bad -->."
+    - sentence: "I read a book: Я ___ книгу."
+      answer: читаю
+      options:
+        - читаю
+        - пишу
+        - бачу
+      explanation: Repair for Я є читаю книгу.
+    - sentence: "You write very nicely: Ви ___ дуже гарно."
+      answer: пишете
+      options:
+        - пишете
+        - читаєте
+        - говорите
+      explanation: "Repair for <!-- bad -->Ви пишите дуже гарно<!-- /bad -->."
+    - sentence: "They work fast: Вони ___ швидко."
+      answer: роблять
+      options:
+        - роблять
+        - говорять
+        - читають
+      explanation: "Repair for <!-- bad -->Вони роботь швидко<!-- /bad -->."
+    - sentence: "He wants coffee: Він ___ кави."
+      answer: хоче
+      options:
+        - хоче
+        - любить
+        - п'є
+      explanation: "Repair for <!-- bad -->Він хотіє кави<!-- /bad -->."

--- a/curriculum/l2-uk-en/a1/checkpoint-actions/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/module.md
@@ -1,0 +1,203 @@
+# Перевірка: Дії
+
+This checkpoint closes the A1.3 action block. Nothing here is new grammar. The
+goal is to show that the pieces from Modules 15-20 can work together in one
+small life scene: what you like, what you do, what you want or can do, what you
+ask, and how you describe your morning.
+
+By the end, you can:
+
+- use **любити** with a simple action: **Я люблю читати**;
+- build Group One forms such as **я читаю**, **ти читаєш**, **вони працюють**;
+- build Group Two forms such as **я говорю**, **ти говориш**, **вони роблять**;
+- use **хочу / можу / мушу + інфінітив**;
+- ask with **хто, що, де, куди, коли, чому, як**;
+- describe a routine with **спочатку, потім, після цього, нарешті** and
+  **-ся** verbs.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+## Що ми знаємо?
+
+Think of A1.3 as a set of action cards. The dictionary card is the infinitive,
+usually ending in **-ти**: **читати**, **говорити**, **працювати**, **хотіти**.
+To find the stem for a simple practice form, first notice that the infinitive
+ending is **-ти** and can be set aside: **чита-ти**, **говори-ти**,
+**працюва-ти**. This first checkpoint habit is called finding the **основа
+інфінітива** after **відкидання закінчення -ти**. For a real sentence, choose a
+person form: **я читаю**, **ти говориш**, **вона працює**. Ukrainian does not
+need an extra helper for a normal present action.
+
+The most useful Group One card is the productive **-ува- / -юва-** pattern.
+Before the ending, **-ува- або -юва-** becomes **-у- або -ю-**:
+**працювати -> я працюю**, **малювати -> я малюю**,
+**танцювати -> вони танцюють**. Some short high-use verbs are learned as whole
+forms: **жити**, **пити**, **лити**; useful forms include **я живу**,
+**я п'ю**, **вони живуть**. For **писати**, keep the visible change:
+**пишу**, **пишеш**, **пишуть**. The plural ending **-уть / -ють** is your
+Group One signal.
+
+Group Two uses the other action signal: **ти говориш**, **ви говорите**,
+**вони роблять**. The plural ending **-ать / -ять** is the Group Two signal.
+Compare it with Group One plural forms such as **живуть** and **сіють**, then
+with recognition-only Group Two examples such as **молитися** and **чавити**.
+The forms **ти** and **ви** matter because real conversations need direct
+address: **Ти читаєш? Ви пишете?** Also recognize the school-style model
+**ти крутиш**, **ви крутите** as a direct-address pair.
+
+Modal verbs stay small and useful:
+
+| Meaning | Safe pattern |
+| --- | --- |
+| I want to read. | **Я хочу читати.** |
+| I can cook. | **Я можу готувати.** |
+| I have to work. | **Я мушу працювати.** |
+
+Use Ukrainian on its own terms. Do not explain Ukrainian forms through any
+other language. The pattern is inside Ukrainian: infinitive, person ending,
+question word, and short routine order.
+
+:::tip
+When a line feels too big, find the verb first. Ask: is it an infinitive
+ending in **-ти**, a person form like **працюю**, a modal helper like
+**можу**, or a **-ся** routine form like **вмиваюся**?
+:::
+
+<!-- INJECT_ACTIVITY: act-2 -->
+
+## Читання
+
+Read this checkpoint text aloud. It uses only A1.3 action material and familiar
+daily words.
+
+<DialogueBox uk="Я прокидаюся о сьомій." en="I wake up at seven." />
+<DialogueBox uk="Спочатку вмиваюся і чищу зуби." en="First I wash up and brush my teeth." />
+<DialogueBox uk="Потім снідаю вдома." en="Then I have breakfast at home." />
+<DialogueBox uk="Я працюю в офісі." en="I work in an office." />
+<DialogueBox uk="У перерві я читаю книгу." en="During the break I read a book." />
+<DialogueBox uk="Я люблю читати, але сьогодні мушу писати." en="I like reading, but today I have to write." />
+<DialogueBox uk="Увечері я хочу гуляти." en="In the evening I want to walk." />
+<DialogueBox uk="Моя сусідка може готувати." en="My roommate can cook." />
+<DialogueBox uk="Ми говоримо українською." en="We speak Ukrainian." />
+<DialogueBox uk="Нарешті я дивлюся фільм і відпочиваю." en="Finally I watch a film and rest." />
+
+Use the text as a diagnostic. Can you point to an infinitive? **читати**,
+**писати**, **гуляти**, and **готувати** are infinitives. Can you point to a
+Group One form? **працюю**, **читаю**, **пишуть** style forms use the Group One
+signal. Can you point to a Group Two form? **говоримо**, **роблять**, and
+**бачиш** use the Group Two signal. Can you point to **-ся**? **прокидаюся**,
+**вмиваюся**, and **дивлюся** are routine or perception chunks you already saw.
+
+Now answer these A1 questions about the text:
+
+- **Коли я прокидаюся?**
+- **Де я снідаю?**
+- **Що я люблю?**
+- **Що я мушу робити сьогодні?**
+- **Куди я хочу йти ввечері?**
+- **Як ми говоримо?**
+
+The seven question words stay active: **хто, що, де, куди, коли, чому, як**.
+For this checkpoint, short answers are enough: **о сьомій**, **вдома**,
+**читати**, **писати**, **гуляти**, **українською**.
+
+<!-- INJECT_ACTIVITY: act-3 -->
+
+## Граматика
+
+Use this review table as a repair map.
+
+| Skill | What to check | Safe A1 examples |
+| --- | --- | --- |
+| Infinitive | dictionary action ends in **-ти** | **читати**, **говорити**, **працювати** |
+| Group One | **-ю, -єш, -є, -ємо, -єте, -ють** | **я читаю**, **ти читаєш**, **вони працюють** |
+| Group One **-ува-** | **-ува- / -юва- -> -у- / -ю-** | **працювати -> працюю**, **малювати -> малюю** |
+| Short Group One | learn whole forms | **я живу**, **я п'ю**, **вони живуть** |
+| Change in **писати** | **с -> ш** in the present | **пишу**, **пишеш**, **пишуть** |
+| Group Two | **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять** | **я говорю**, **ти говориш**, **вони роблять** |
+| Direct address | **ти** and **ви** need different endings | **ти пишеш**, **ви пишете**, **ви говорите** |
+| Modal + infinitive | helper first, infinitive second | **хочу читати**, **можу готувати**, **мушу працювати** |
+| Reflexive routine | person form plus **-ся** | **я прокидаюся**, **ти вмиваєшся** |
+| Negative | **не** before the verb | **Я не працюю. Ніхто не читає.** |
+
+Do not overbuild the sentence. A correct A1 line can be very short:
+**Я працюю. Ти читаєш? Вона говорить. Ми не пишемо. Вони роблять.**
+
+### Repair traps
+
+Keep the common repairs close:
+
+| Avoid | Use | Why |
+| --- | --- | --- |
+| <!-- bad -->Я працювати кожного дня.<!-- /bad --> | **Я працюю кожного дня.** | **я** needs a person form |
+| <!-- bad -->Вона працюває в школі.<!-- /bad --> | **Вона працює в школі.** | **працювати -> працює** |
+| <!-- bad -->Я є читаю книгу.<!-- /bad --> | **Я читаю книгу.** | no extra helper for a normal action |
+| <!-- bad -->Ви пишите дуже гарно.<!-- /bad --> | **Ви пишете дуже гарно.** | **писати** is Group One here |
+| <!-- bad -->Вони роботь швидко.<!-- /bad --> | **Вони роблять швидко.** | **робити** uses Group Two plural |
+| <!-- bad -->Він хотіє кави.<!-- /bad --> | **Він хоче кави.** | learn **хоче** as the safe form |
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+<!-- INJECT_ACTIVITY: act-5 -->
+
+## Діалог
+
+Read the roommate conversation. It checks liking, two verb groups, modal verbs,
+questions, negatives, and a morning routine in one scene.
+
+<DialogueBox uk="Олег: Добрий день! Ти нова сусідка?" en="Oleh: Good afternoon! Are you the new roommate?" />
+<DialogueBox uk="Марина: Так. Мене звати Марина." en="Maryna: Yes. My name is Maryna." />
+<DialogueBox uk="Олег: Дуже приємно. Коли ти прокидаєшся?" en="Oleh: Nice to meet you. When do you wake up?" />
+<DialogueBox uk="Марина: Я прокидаюся о сьомій." en="Maryna: I wake up at seven." />
+<DialogueBox uk="Олег: Що ти робиш потім?" en="Oleh: What do you do then?" />
+<DialogueBox uk="Марина: Вмиваюся, снідаю і йду на роботу." en="Maryna: I wash up, have breakfast, and go to work." />
+<DialogueBox uk="Олег: Де ти працюєш?" en="Oleh: Where do you work?" />
+<DialogueBox uk="Марина: Я працюю в школі." en="Maryna: I work at a school." />
+<DialogueBox uk="Олег: Ти любиш читати ввечері?" en="Oleh: Do you like to read in the evening?" />
+<DialogueBox uk="Марина: Так, люблю читати і писати." en="Maryna: Yes, I like reading and writing." />
+<DialogueBox uk="Олег: Я хочу готувати сьогодні. Ти можеш допомагати?" en="Oleh: I want to cook today. Can you help?" />
+<DialogueBox uk="Марина: Не можу зараз, мушу працювати." en="Maryna: I cannot now, I have to work." />
+<DialogueBox uk="Олег: Коли ти можеш?" en="Oleh: When can you?" />
+<DialogueBox uk="Марина: Після шостої. Тоді ми готуємо і говоримо українською." en="Maryna: After six. Then we cook and speak Ukrainian." />
+<DialogueBox uk="Олег: Добре. До побачення!" en="Oleh: Good. Goodbye!" />
+
+This dialogue uses clean Ukrainian greeting and farewell chunks:
+**Добрий день** and **До побачення**. Keep everyday language precise:
+**тато**, **прізвище**, **українська мова**, **Київ**, **гривня**. Those forms
+belong to earlier A1 work and stay stable here.
+
+<!-- INJECT_ACTIVITY: act-6 -->
+
+## Підсумок
+
+You can now talk about actions in a short connected way:
+
+1. **Спочатку я прокидаюся.**
+2. **Потім я працюю / навчаюся.**
+3. **Я люблю читати.**
+4. **Я хочу гуляти, але мушу працювати.**
+5. **Де ти працюєш? Коли ти можеш?**
+6. **Увечері ми говоримо українською.**
+
+For your own checkpoint answer, write six to eight short sentences. Use one
+line for the morning, one line for work or study, one line for liking, one line
+with **хочу / можу / мушу**, one question, and one negative. A good A1 answer
+can look like this:
+
+<DialogueBox uk="Я прокидаюся о сьомій." en="I wake up at seven." />
+<DialogueBox uk="Потім працюю вдома." en="Then I work at home." />
+<DialogueBox uk="Я люблю читати." en="I like reading." />
+<DialogueBox uk="Увечері хочу гуляти." en="In the evening I want to walk." />
+<DialogueBox uk="Сьогодні не можу, мушу писати." en="Today I cannot; I have to write." />
+<DialogueBox uk="Коли ти можеш говорити?" en="When can you speak?" />
+
+When Ukrainian cultural examples appear in later reading, keep them Ukrainian
+and precise. **Тарас Шевченко**, **Леся Українка**, **Ліна Костенко**, and
+**Сергій Жадан** belong to the Ukrainian literary space. Historical references
+need exact dates, for example **Голодомор 1932-1933 років**. For this A1
+checkpoint, you only need to carry the principle forward: use Ukrainian forms
+and Ukrainian context clearly.
+
+<!-- INJECT_ACTIVITY: act-7 -->
+
+<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/checkpoint-actions/resources.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/resources.yaml
@@ -1,0 +1,25 @@
+- title: "Present Tense of Verbs: Працювати Type"
+  role: article
+  source_ref: "Добра форма 21.2"
+  url: https://opentext.ku.edu/dobraforma/chapter/21-2/
+  notes: "Review the productive Group One -ува- pattern after the checkpoint."
+- title: "Present Tense of Verbs: Other First Conjugation Verbs"
+  role: article
+  source_ref: "Добра форма 21.3"
+  url: https://opentext.ku.edu/dobraforma/chapter/21-3/
+  notes: "Review жити, пити, писати, and hard-vowel Group One forms."
+- title: "Present Tense of Verbs: Говорити and Любити Types"
+  role: article
+  source_ref: "Добра форма 22.2"
+  url: https://opentext.ku.edu/dobraforma/chapter/22-2/
+  notes: "Review Group Two endings and forms like говорити, любити, робити."
+- title: "Present Tense of -ся Verbs: First Conjugation"
+  role: article
+  source_ref: "Добра форма 23.1"
+  url: https://opentext.ku.edu/dobraforma/chapter/23-1/
+  notes: "Review the Group One + -ся routine pattern."
+- title: "Modal Verbs: Want, Must, Can"
+  role: article
+  source_ref: "Добра форма 26.1"
+  url: https://opentext.ku.edu/dobraforma/chapter/26-1-modal-verbs-want-must-can/
+  notes: "Use as a later review for хочу, мушу, можу with infinitives."

--- a/curriculum/l2-uk-en/a1/checkpoint-actions/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/vocabulary.yaml
@@ -1,0 +1,160 @@
+- lemma: дія
+  translation: action
+  pos: noun
+  usage: Це дія.
+- lemma: інфінітив
+  translation: infinitive
+  pos: noun
+  usage: Читати - це інфінітив.
+- lemma: читати
+  translation: to read
+  pos: infinitive
+  usage: Я люблю читати.
+- lemma: читаю
+  translation: I read
+  pos: verb form
+  usage: Я читаю книгу.
+- lemma: писати
+  translation: to write
+  pos: infinitive
+  usage: Мушу писати сьогодні.
+- lemma: пишу
+  translation: I write
+  pos: verb form
+  usage: Я пишу лист.
+- lemma: пишеш
+  translation: you write
+  pos: verb form
+  usage: Ти пишеш гарно.
+- lemma: працювати
+  translation: to work
+  pos: infinitive
+  usage: Я мушу працювати.
+- lemma: працюю
+  translation: I work
+  pos: verb form
+  usage: Я працюю вдома.
+- lemma: працюєш
+  translation: you work
+  pos: verb form
+  usage: Де ти працюєш?
+- lemma: працює
+  translation: he/she works
+  pos: verb form
+  usage: Вона працює в школі.
+- lemma: говорити
+  translation: to speak
+  pos: infinitive
+  usage: Можу говорити українською.
+- lemma: говорю
+  translation: I speak
+  pos: verb form
+  usage: Я говорю українською.
+- lemma: говориш
+  translation: you speak
+  pos: verb form
+  usage: Ти говориш українською.
+- lemma: говоримо
+  translation: we speak
+  pos: verb form
+  usage: Ми говоримо українською.
+- lemma: робити
+  translation: to do; to make
+  pos: infinitive
+  usage: Що ти робиш?
+- lemma: роблять
+  translation: they do; they make
+  pos: verb form
+  usage: Вони роблять швидко.
+- lemma: любити
+  translation: to like; to love
+  pos: infinitive
+  usage: Я люблю читати.
+- lemma: хочу
+  translation: I want
+  pos: modal verb form
+  usage: Я хочу гуляти.
+- lemma: можу
+  translation: I can
+  pos: modal verb form
+  usage: Я можу готувати.
+- lemma: мушу
+  translation: I have to
+  pos: modal verb form
+  usage: Я мушу працювати.
+- lemma: хотіти
+  translation: to want
+  pos: infinitive
+  usage: Він хоче кави.
+- lemma: хоче
+  translation: he/she wants
+  pos: verb form
+  usage: Він хоче кави.
+- lemma: прокидатися
+  translation: to wake up
+  pos: infinitive
+  usage: Я прокидаюся о сьомій.
+- lemma: прокидаюся
+  translation: I wake up
+  pos: reflexive verb form
+  usage: Я прокидаюся рано.
+- lemma: вмиватися
+  translation: to wash up
+  pos: infinitive
+  usage: Потім вмиваюся.
+- lemma: вмиваюся
+  translation: I wash up
+  pos: reflexive verb form
+  usage: Я вмиваюся вранці.
+- lemma: дивитися
+  translation: to watch; to look
+  pos: infinitive
+  usage: Я дивлюся фільм.
+- lemma: дивлюся
+  translation: I watch; I look
+  pos: reflexive verb form
+  usage: Нарешті я дивлюся фільм.
+- lemma: хто
+  translation: who
+  pos: question word
+  usage: Хто працює?
+- lemma: що
+  translation: what
+  pos: question word
+  usage: Що ти читаєш?
+- lemma: де
+  translation: where
+  pos: question word
+  usage: Де ти працюєш?
+- lemma: куди
+  translation: where to
+  pos: question word
+  usage: Куди ти йдеш?
+- lemma: коли
+  translation: when
+  pos: question word
+  usage: Коли ти можеш?
+- lemma: чому
+  translation: why
+  pos: question word
+  usage: Чому ти не можеш?
+- lemma: як
+  translation: how
+  pos: question word
+  usage: Як ми говоримо?
+- lemma: спочатку
+  translation: first
+  pos: sequence word
+  usage: Спочатку я прокидаюся.
+- lemma: потім
+  translation: then
+  pos: sequence word
+  usage: Потім снідаю.
+- lemma: після цього
+  translation: after that
+  pos: sequence phrase
+  usage: Після цього працюю.
+- lemma: нарешті
+  translation: finally
+  pos: sequence word
+  usage: Нарешті дивлюся фільм.

--- a/curriculum/l2-uk-en/plans/a1/checkpoint-actions.yaml.bak
+++ b/curriculum/l2-uk-en/plans/a1/checkpoint-actions.yaml.bak
@@ -2,12 +2,12 @@ module: a1-021
 level: A1
 sequence: 21
 slug: checkpoint-actions
-version: '1.2.3'
+version: '1.2.2'
 title: 'Перевірка: Дії'
 subtitle: Чи можете ви сказати, що ви робите, хочете, та ставити запитання?
 focus: review
 pedagogy: PPP
-phase: A1.3 [Дії]
+phase: А1.3 [Дії]
 word_target: 1200
 objectives:
 - Продемонструвати вміння відмінювати дієслова I та II дієвідміни

--- a/starlight/src/content/docs/a1/checkpoint-actions.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-actions.mdx
@@ -1,0 +1,337 @@
+---
+title: "Перевірка: Дії"
+description: "Чи можете ви сказати, що ви робите, хочете, та ставити запитання?"
+sidebar:
+  order: 21
+  label: "21. Перевірка: Дії"
+pipeline: linear-phase-4
+build_status: validated
+prev: my-morning
+next: false
+---
+
+import Quiz from '@site/src/components/Quiz';
+import MatchUp from '@site/src/components/MatchUp';
+import FillIn from '@site/src/components/FillIn';
+import TrueFalse from '@site/src/components/TrueFalse';
+import Unjumble from '@site/src/components/Unjumble';
+import GroupSort from '@site/src/components/GroupSort';
+import Anagram from '@site/src/components/Anagram';
+import ErrorCorrection, { ErrorCorrectionItem } from '@site/src/components/ErrorCorrection';
+import Cloze from '@site/src/components/Cloze';
+import Select from '@site/src/components/Select';
+import Translate from '@site/src/components/Translate';
+import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
+import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import EssayResponse from '@site/src/components/EssayResponse';
+import ComparativeStudy from '@site/src/components/ComparativeStudy';
+import ReadingActivity from '@site/src/components/ReadingActivity';
+import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
+import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import SourceEvaluation from '@site/src/components/SourceEvaluation';
+import Debate from '@site/src/components/Debate';
+import EtymologyTrace from '@site/src/components/EtymologyTrace';
+import GrammarIdentify from '@site/src/components/GrammarIdentify';
+import PaleographyAnalysis from '@site/src/components/PaleographyAnalysis';
+import DialectComparison from '@site/src/components/DialectComparison';
+import TranslationCritique from '@site/src/components/TranslationCritique';
+import Transcription from '@site/src/components/Transcription';
+import Observe from '@site/src/components/Observe';
+import Order from '@site/src/components/Order';
+import CountSyllables from '@site/src/components/CountSyllables';
+import DivideWords from '@site/src/components/DivideWords';
+import OddOneOut from '@site/src/components/OddOneOut';
+import PickSyllables from '@site/src/components/PickSyllables';
+import LetterGrid from '@site/src/components/LetterGrid';
+import FlashcardDeck from '@site/src/components/FlashcardDeck';
+import VocabCard from '@site/src/components/VocabCard';
+import DialogueBox from '@site/src/components/DialogueBox';
+import HashTabSync from '@site/src/components/HashTabSync';
+import ActivityHelp from '@site/src/components/ActivityHelp';
+import YouTubeVideo from '@site/src/components/YouTubeVideo';
+import WatchAndRepeat from '@site/src/components/WatchAndRepeat';
+import Classify from '@site/src/components/Classify';
+import ImageToLetter from '@site/src/components/ImageToLetter';
+import ActivityPlaceholder from '@site/src/components/ActivityPlaceholder';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs syncKey="module-tab">
+<TabItem label="Lesson">
+
+This checkpoint closes the A1.3 action block. Nothing here is new grammar. The
+goal is to show that the pieces from Modules 15-20 can work together in one
+small life scene: what you like, what you do, what you want or can do, what you
+ask, and how you describe your morning.
+
+By the end, you can:
+
+- use **любити** with a simple action: **Я люблю читати**;
+- build Group One forms such as **я читаю**, **ти читаєш**, **вони працюють**;
+- build Group Two forms such as **я говорю**, **ти говориш**, **вони роблять**;
+- use **хочу / можу / мушу + інфінітив**;
+- ask with **хто, що, де, куди, коли, чому, як**;
+- describe a routine with **спочатку, потім, після цього, нарешті** and
+  **-ся** verbs.
+
+### Reading line to skill
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Я прокидаюся о сьомій.", "right": "reflexive routine"}, {"left": "Я люблю читати.", "right": "like + infinitive"}, {"left": "Вона працює в школі.", "right": "Group One -ува-"}, {"left": "Ти пишеш гарно.", "right": "писати change"}, {"left": "Вони роблять швидко.", "right": "Group Two plural"}, {"left": "Я можу готувати.", "right": "modal + infinitive"}, {"left": "Коли ти можеш?", "right": "question word"}, {"left": "Ніхто не читає.", "right": "negative"}]`)} />
+
+## Що ми знаємо?
+
+Think of A1.3 as a set of action cards. The dictionary card is the infinitive,
+usually ending in **-ти**: **читати**, **говорити**, **працювати**, **хотіти**.
+To find the stem for a simple practice form, first notice that the infinitive
+ending is **-ти** and can be set aside: **чита-ти**, **говори-ти**,
+**працюва-ти**. This first checkpoint habit is called finding the **основа
+інфінітива** after **відкидання закінчення -ти**. For a real sentence, choose a
+person form: **я читаю**, **ти говориш**, **вона працює**. Ukrainian does not
+need an extra helper for a normal present action.
+
+The most useful Group One card is the productive **-ува- / -юва-** pattern.
+Before the ending, **-ува- або -юва-** becomes **-у- або -ю-**:
+**працювати -> я працюю**, **малювати -> я малюю**,
+**танцювати -> вони танцюють**. Some short high-use verbs are learned as whole
+forms: **жити**, **пити**, **лити**; useful forms include **я живу**,
+**я п'ю**, **вони живуть**. For **писати**, keep the visible change:
+**пишу**, **пишеш**, **пишуть**. The plural ending **-уть / -ють** is your
+Group One signal.
+
+Group Two uses the other action signal: **ти говориш**, **ви говорите**,
+**вони роблять**. The plural ending **-ать / -ять** is the Group Two signal.
+Compare it with Group One plural forms such as **живуть** and **сіють**, then
+with recognition-only Group Two examples such as **молитися** and **чавити**.
+The forms **ти** and **ви** matter because real conversations need direct
+address: **Ти читаєш? Ви пишете?** Also recognize the school-style model
+**ти крутиш**, **ви крутите** as a direct-address pair.
+
+Modal verbs stay small and useful:
+
+| Meaning | Safe pattern |
+| --- | --- |
+| I want to read. | **Я хочу читати.** |
+| I can cook. | **Я можу готувати.** |
+| I have to work. | **Я мушу працювати.** |
+
+Use Ukrainian on its own terms. Do not explain Ukrainian forms through any
+other language. The pattern is inside Ukrainian: infinitive, person ending,
+question word, and short routine order.
+
+:::tip
+When a line feels too big, find the verb first. Ask: is it an infinitive
+ending in **-ти**, a person form like **працюю**, a modal helper like
+**можу**, or a **-ся** routine form like **вмиваюся**?
+:::
+
+### Action diagnostics
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Я працюю кожного дня.", "isTrue": true, "explanation": "Працюю is the я form of працювати."}, {"statement": "Вона працює в школі.", "isTrue": true, "explanation": "Працювати changes to працює with вона."}, {"statement": "Ви пишите дуже гарно.", "isTrue": false, "explanation": "Use Ви пишете дуже гарно."}, {"statement": "Вони роботь швидко.", "isTrue": false, "explanation": "Use Вони роблять швидко."}, {"statement": "Він хоче кави.", "isTrue": true, "explanation": "Хоче is the safe він form."}, {"statement": "Я є читаю книгу.", "isTrue": false, "explanation": "Use Я читаю книгу."}, {"statement": "Я прокидаюся о сьомій.", "isTrue": true, "explanation": "Прокидаюся is a safe -ся routine form."}, {"statement": "Ніхто не читає.", "isTrue": true, "explanation": "Keep не before the verb."}]`)} />
+
+## Читання
+
+Read this checkpoint text aloud. It uses only A1.3 action material and familiar
+daily words.
+
+<DialogueBox uk="Я прокидаюся о сьомій." en="I wake up at seven." />
+<DialogueBox uk="Спочатку вмиваюся і чищу зуби." en="First I wash up and brush my teeth." />
+<DialogueBox uk="Потім снідаю вдома." en="Then I have breakfast at home." />
+<DialogueBox uk="Я працюю в офісі." en="I work in an office." />
+<DialogueBox uk="У перерві я читаю книгу." en="During the break I read a book." />
+<DialogueBox uk="Я люблю читати, але сьогодні мушу писати." en="I like reading, but today I have to write." />
+<DialogueBox uk="Увечері я хочу гуляти." en="In the evening I want to walk." />
+<DialogueBox uk="Моя сусідка може готувати." en="My roommate can cook." />
+<DialogueBox uk="Ми говоримо українською." en="We speak Ukrainian." />
+<DialogueBox uk="Нарешті я дивлюся фільм і відпочиваю." en="Finally I watch a film and rest." />
+
+Use the text as a diagnostic. Can you point to an infinitive? **читати**,
+**писати**, **гуляти**, and **готувати** are infinitives. Can you point to a
+Group One form? **працюю**, **читаю**, **пишуть** style forms use the Group One
+signal. Can you point to a Group Two form? **говоримо**, **роблять**, and
+**бачиш** use the Group Two signal. Can you point to **-ся**? **прокидаюся**,
+**вмиваюся**, and **дивлюся** are routine or perception chunks you already saw.
+
+Now answer these A1 questions about the text:
+
+- **Коли я прокидаюся?**
+- **Де я снідаю?**
+- **Що я люблю?**
+- **Що я мушу робити сьогодні?**
+- **Куди я хочу йти ввечері?**
+- **Як ми говоримо?**
+
+The seven question words stay active: **хто, що, де, куди, коли, чому, як**.
+For this checkpoint, short answers are enough: **о сьомій**, **вдома**,
+**читати**, **писати**, **гуляти**, **українською**.
+
+### Skill stations
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Group One": ["я читаю", "ти пишеш", "вони працюють", "ми малюємо"], "Group Two": ["я говорю", "ти говориш", "вони роблять", "ви бачите"], "Modal + infinitive": ["хочу читати", "можу готувати", "мушу працювати", "може допомагати"], "Question words": ["де ти працюєш?", "коли ти можеш?", "що ти читаєш?", "як ми говоримо?"]}`)} />
+
+## Граматика
+
+Use this review table as a repair map.
+
+| Skill | What to check | Safe A1 examples |
+| --- | --- | --- |
+| Infinitive | dictionary action ends in **-ти** | **читати**, **говорити**, **працювати** |
+| Group One | **-ю, -єш, -є, -ємо, -єте, -ють** | **я читаю**, **ти читаєш**, **вони працюють** |
+| Group One **-ува-** | **-ува- / -юва- -> -у- / -ю-** | **працювати -> працюю**, **малювати -> малюю** |
+| Short Group One | learn whole forms | **я живу**, **я п'ю**, **вони живуть** |
+| Change in **писати** | **с -> ш** in the present | **пишу**, **пишеш**, **пишуть** |
+| Group Two | **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять** | **я говорю**, **ти говориш**, **вони роблять** |
+| Direct address | **ти** and **ви** need different endings | **ти пишеш**, **ви пишете**, **ви говорите** |
+| Modal + infinitive | helper first, infinitive second | **хочу читати**, **можу готувати**, **мушу працювати** |
+| Reflexive routine | person form plus **-ся** | **я прокидаюся**, **ти вмиваєшся** |
+| Negative | **не** before the verb | **Я не працюю. Ніхто не читає.** |
+
+Do not overbuild the sentence. A correct A1 line can be very short:
+**Я працюю. Ти читаєш? Вона говорить. Ми не пишемо. Вони роблять.**
+
+### Repair traps
+
+Keep the common repairs close:
+
+| Avoid | Use | Why |
+| --- | --- | --- |
+| <del>Я працювати кожного дня.</del> | **Я працюю кожного дня.** | **я** needs a person form |
+| <del>Вона працюває в школі.</del> | **Вона працює в школі.** | **працювати -> працює** |
+| <del>Я є читаю книгу.</del> | **Я читаю книгу.** | no extra helper for a normal action |
+| <del>Ви пишите дуже гарно.</del> | **Ви пишете дуже гарно.** | **писати** is Group One here |
+| <del>Вони роботь швидко.</del> | **Вони роблять швидко.** | **робити** uses Group Two plural |
+| <del>Він хотіє кави.</del> | **Він хоче кави.** | learn **хоче** as the safe form |
+
+### Roommate dialogue gaps
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Олег: Коли ти ___?", "answer": "прокидаєшся", "options": ["прокидаєшся", "працюєш", "пишеш"]}, {"sentence": "Марина: Я ___ о сьомій.", "answer": "прокидаюся", "options": ["прокидаюся", "читаю", "роблю"]}, {"sentence": "Олег: Де ти ___?", "answer": "працюєш", "options": ["працюєш", "можеш", "хочеш"]}, {"sentence": "Марина: Я ___ в школі.", "answer": "працюю", "options": ["працюю", "працює", "працюємо"]}, {"sentence": "Олег: Ти ___ читати ввечері?", "answer": "любиш", "options": ["любиш", "читаєш", "робиш"]}, {"sentence": "Марина: Не можу зараз, ___ працювати.", "answer": "мушу", "options": ["мушу", "читаю", "говорю"]}]`)} />
+
+### Find the form that does not fit
+
+<OddOneOut client:only='react' instruction={"Choose the chunk that belongs to a different checkpoint skill."} items={JSON.parse(`[{"words": ["я читаю", "ти читаєш", "вони читають", "ти говориш"], "correct": 3, "explanation": "Ти говориш is Group Two; the others are Group One читати."}, {"words": ["хочу читати", "можу готувати", "мушу працювати", "я читаю"], "correct": 3, "explanation": "Я читаю is a person form, not modal + infinitive."}, {"words": ["хто", "коли", "куди", "працюю"], "correct": 3, "explanation": "Працюю is a verb form; the others are question words."}, {"words": ["я прокидаюся", "ти вмиваєшся", "вона одягається", "я снідаю"], "correct": 3, "explanation": "Снідаю is not a -ся verb."}]`)} />
+
+## Діалог
+
+Read the roommate conversation. It checks liking, two verb groups, modal verbs,
+questions, negatives, and a morning routine in one scene.
+
+<DialogueBox uk="Олег: Добрий день! Ти нова сусідка?" en="Oleh: Good afternoon! Are you the new roommate?" />
+<DialogueBox uk="Марина: Так. Мене звати Марина." en="Maryna: Yes. My name is Maryna." />
+<DialogueBox uk="Олег: Дуже приємно. Коли ти прокидаєшся?" en="Oleh: Nice to meet you. When do you wake up?" />
+<DialogueBox uk="Марина: Я прокидаюся о сьомій." en="Maryna: I wake up at seven." />
+<DialogueBox uk="Олег: Що ти робиш потім?" en="Oleh: What do you do then?" />
+<DialogueBox uk="Марина: Вмиваюся, снідаю і йду на роботу." en="Maryna: I wash up, have breakfast, and go to work." />
+<DialogueBox uk="Олег: Де ти працюєш?" en="Oleh: Where do you work?" />
+<DialogueBox uk="Марина: Я працюю в школі." en="Maryna: I work at a school." />
+<DialogueBox uk="Олег: Ти любиш читати ввечері?" en="Oleh: Do you like to read in the evening?" />
+<DialogueBox uk="Марина: Так, люблю читати і писати." en="Maryna: Yes, I like reading and writing." />
+<DialogueBox uk="Олег: Я хочу готувати сьогодні. Ти можеш допомагати?" en="Oleh: I want to cook today. Can you help?" />
+<DialogueBox uk="Марина: Не можу зараз, мушу працювати." en="Maryna: I cannot now, I have to work." />
+<DialogueBox uk="Олег: Коли ти можеш?" en="Oleh: When can you?" />
+<DialogueBox uk="Марина: Після шостої. Тоді ми готуємо і говоримо українською." en="Maryna: After six. Then we cook and speak Ukrainian." />
+<DialogueBox uk="Олег: Добре. До побачення!" en="Oleh: Good. Goodbye!" />
+
+This dialogue uses clean Ukrainian greeting and farewell chunks:
+**Добрий день** and **До побачення**. Keep everyday language precise:
+**тато**, **прізвище**, **українська мова**, **Київ**, **гривня**. Those forms
+belong to earlier A1 work and stay stable here.
+
+### Rebuild checkpoint lines
+
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / люблю / читати", "answer": "Я люблю читати"}, {"jumbled": "Вона / працює / в школі", "answer": "Вона працює в школі"}, {"jumbled": "Ми / говоримо / українською", "answer": "Ми говоримо українською"}, {"jumbled": "Коли / ти / можеш", "answer": "Коли ти можеш"}, {"jumbled": "Я / мушу / працювати", "answer": "Я мушу працювати"}, {"jumbled": "Вони / роблять / швидко", "answer": "Вони роблять швидко"}]`)} />
+
+## 📋 Підсумок
+
+You can now talk about actions in a short connected way:
+
+1. **Спочатку я прокидаюся.**
+2. **Потім я працюю / навчаюся.**
+3. **Я люблю читати.**
+4. **Я хочу гуляти, але мушу працювати.**
+5. **Де ти працюєш? Коли ти можеш?**
+6. **Увечері ми говоримо українською.**
+
+For your own checkpoint answer, write six to eight short sentences. Use one
+line for the morning, one line for work or study, one line for liking, one line
+with **хочу / можу / мушу**, one question, and one negative. A good A1 answer
+can look like this:
+
+<DialogueBox uk="Я прокидаюся о сьомій." en="I wake up at seven." />
+<DialogueBox uk="Потім працюю вдома." en="Then I work at home." />
+<DialogueBox uk="Я люблю читати." en="I like reading." />
+<DialogueBox uk="Увечері хочу гуляти." en="In the evening I want to walk." />
+<DialogueBox uk="Сьогодні не можу, мушу писати." en="Today I cannot; I have to write." />
+<DialogueBox uk="Коли ти можеш говорити?" en="When can you speak?" />
+
+When Ukrainian cultural examples appear in later reading, keep them Ukrainian
+and precise. **Тарас Шевченко**, **Леся Українка**, **Ліна Костенко**, and
+**Сергій Жадан** belong to the Ukrainian literary space. Historical references
+need exact dates, for example **Голодомор 1932-1933 років**. For this A1
+checkpoint, you only need to carry the principle forward: use Ukrainian forms
+and Ukrainian context clearly.
+
+### Choose the answer job
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Коли ти прокидаєшся?", "options": [{"text": "О сьомій.", "correct": true}, {"text": "У школі.", "correct": false}, {"text": "Українською.", "correct": false}], "explanation": "Коли asks about time."}, {"question": "Де ти працюєш?", "options": [{"text": "В офісі.", "correct": true}, {"text": "О восьмій.", "correct": false}, {"text": "Тому що мушу.", "correct": false}], "explanation": "Де asks about place."}, {"question": "Що ти любиш?", "options": [{"text": "Читати.", "correct": true}, {"text": "Удома.", "correct": false}, {"text": "Завтра.", "correct": false}], "explanation": "Що asks for the action or thing."}, {"question": "Як ми говоримо?", "options": [{"text": "Українською.", "correct": true}, {"text": "Увечері.", "correct": false}, {"text": "У школі.", "correct": false}], "explanation": "Як asks how."}]`)} />
+
+### Repair by building the safe line
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "I work every day: Я ___ кожного дня.", "answer": "працюю", "options": ["працюю", "читаю", "пишу"]}, {"sentence": "She works at school: Вона ___ в школі.", "answer": "працює", "options": ["працює", "читає", "готує"]}, {"sentence": "I read a book: Я ___ книгу.", "answer": "читаю", "options": ["читаю", "пишу", "бачу"]}, {"sentence": "You write very nicely: Ви ___ дуже гарно.", "answer": "пишете", "options": ["пишете", "читаєте", "говорите"]}, {"sentence": "They work fast: Вони ___ швидко.", "answer": "роблять", "options": ["роблять", "говорять", "читають"]}, {"sentence": "He wants coffee: Він ___ кави.", "answer": "хоче", "options": ["хоче", "любить", "п'є"]}]`)} />
+
+</TabItem>
+<TabItem label="Vocabulary">
+
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"дія","translation":"action","pos":"noun","example":"Це дія.","examples":["action","Це дія."]},{"word":"інфінітив","translation":"infinitive","pos":"noun","example":"Читати - це інфінітив.","examples":["infinitive","Читати - це інфінітив."]},{"word":"читати","translation":"to read","pos":"infinitive","example":"Я люблю читати.","examples":["to read","Я люблю читати."]},{"word":"читаю","translation":"I read","pos":"verb form","example":"Я читаю книгу.","examples":["I read","Я читаю книгу."]},{"word":"писати","translation":"to write","pos":"infinitive","example":"Мушу писати сьогодні.","examples":["to write","Мушу писати сьогодні."]},{"word":"пишу","translation":"I write","pos":"verb form","example":"Я пишу лист.","examples":["I write","Я пишу лист."]},{"word":"пишеш","translation":"you write","pos":"verb form","example":"Ти пишеш гарно.","examples":["you write","Ти пишеш гарно."]},{"word":"працювати","translation":"to work","pos":"infinitive","example":"Я мушу працювати.","examples":["to work","Я мушу працювати."]},{"word":"працюю","translation":"I work","pos":"verb form","example":"Я працюю вдома.","examples":["I work","Я працюю вдома."]},{"word":"працюєш","translation":"you work","pos":"verb form","example":"Де ти працюєш?","examples":["you work","Де ти працюєш?"]},{"word":"працює","translation":"he/she works","pos":"verb form","example":"Вона працює в школі.","examples":["he/she works","Вона працює в школі."]},{"word":"говорити","translation":"to speak","pos":"infinitive","example":"Можу говорити українською.","examples":["to speak","Можу говорити українською."]},{"word":"говорю","translation":"I speak","pos":"verb form","example":"Я говорю українською.","examples":["I speak","Я говорю українською."]},{"word":"говориш","translation":"you speak","pos":"verb form","example":"Ти говориш українською.","examples":["you speak","Ти говориш українською."]},{"word":"говоримо","translation":"we speak","pos":"verb form","example":"Ми говоримо українською.","examples":["we speak","Ми говоримо українською."]},{"word":"робити","translation":"to do; to make","pos":"infinitive","example":"Що ти робиш?","examples":["to do; to make","Що ти робиш?"]},{"word":"роблять","translation":"they do; they make","pos":"verb form","example":"Вони роблять швидко.","examples":["they do; they make","Вони роблять швидко."]},{"word":"любити","translation":"to like; to love","pos":"infinitive","example":"Я люблю читати.","examples":["to like; to love","Я люблю читати."]},{"word":"хочу","translation":"I want","pos":"modal verb form","example":"Я хочу гуляти.","examples":["I want","Я хочу гуляти."]},{"word":"можу","translation":"I can","pos":"modal verb form","example":"Я можу готувати.","examples":["I can","Я можу готувати."]},{"word":"мушу","translation":"I have to","pos":"modal verb form","example":"Я мушу працювати.","examples":["I have to","Я мушу працювати."]},{"word":"хотіти","translation":"to want","pos":"infinitive","example":"Він хоче кави.","examples":["to want","Він хоче кави."]},{"word":"хоче","translation":"he/she wants","pos":"verb form","example":"Він хоче кави.","examples":["he/she wants","Він хоче кави."]},{"word":"прокидатися","translation":"to wake up","pos":"infinitive","example":"Я прокидаюся о сьомій.","examples":["to wake up","Я прокидаюся о сьомій."]},{"word":"прокидаюся","translation":"I wake up","pos":"reflexive verb form","example":"Я прокидаюся рано.","examples":["I wake up","Я прокидаюся рано."]},{"word":"вмиватися","translation":"to wash up","pos":"infinitive","example":"Потім вмиваюся.","examples":["to wash up","Потім вмиваюся."]},{"word":"вмиваюся","translation":"I wash up","pos":"reflexive verb form","example":"Я вмиваюся вранці.","examples":["I wash up","Я вмиваюся вранці."]},{"word":"дивитися","translation":"to watch; to look","pos":"infinitive","example":"Я дивлюся фільм.","examples":["to watch; to look","Я дивлюся фільм."]},{"word":"дивлюся","translation":"I watch; I look","pos":"reflexive verb form","example":"Нарешті я дивлюся фільм.","examples":["I watch; I look","Нарешті я дивлюся фільм."]},{"word":"хто","translation":"who","pos":"question word","example":"Хто працює?","examples":["who","Хто працює?"]},{"word":"що","translation":"what","pos":"question word","example":"Що ти читаєш?","examples":["what","Що ти читаєш?"]},{"word":"де","translation":"where","pos":"question word","example":"Де ти працюєш?","examples":["where","Де ти працюєш?"]},{"word":"куди","translation":"where to","pos":"question word","example":"Куди ти йдеш?","examples":["where to","Куди ти йдеш?"]},{"word":"коли","translation":"when","pos":"question word","example":"Коли ти можеш?","examples":["when","Коли ти можеш?"]},{"word":"чому","translation":"why","pos":"question word","example":"Чому ти не можеш?","examples":["why","Чому ти не можеш?"]},{"word":"як","translation":"how","pos":"question word","example":"Як ми говоримо?","examples":["how","Як ми говоримо?"]},{"word":"спочатку","translation":"first","pos":"sequence word","example":"Спочатку я прокидаюся.","examples":["first","Спочатку я прокидаюся."]},{"word":"потім","translation":"then","pos":"sequence word","example":"Потім снідаю.","examples":["then","Потім снідаю."]},{"word":"після цього","translation":"after that","pos":"sequence phrase","example":"Після цього працюю.","examples":["after that","Після цього працюю."]},{"word":"нарешті","translation":"finally","pos":"sequence word","example":"Нарешті дивлюся фільм.","examples":["finally","Нарешті дивлюся фільм."]}]`)} title="Vocabulary" />
+
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"дія","back":"action"},{"front":"інфінітив","back":"infinitive"},{"front":"читати","back":"to read"},{"front":"читаю","back":"I read"},{"front":"писати","back":"to write"},{"front":"пишу","back":"I write"},{"front":"пишеш","back":"you write"},{"front":"працювати","back":"to work"},{"front":"працюю","back":"I work"},{"front":"працюєш","back":"you work"},{"front":"працює","back":"he/she works"},{"front":"говорити","back":"to speak"},{"front":"говорю","back":"I speak"},{"front":"говориш","back":"you speak"},{"front":"говоримо","back":"we speak"},{"front":"робити","back":"to do; to make"},{"front":"роблять","back":"they do; they make"},{"front":"любити","back":"to like; to love"},{"front":"хочу","back":"I want"},{"front":"можу","back":"I can"},{"front":"мушу","back":"I have to"},{"front":"хотіти","back":"to want"},{"front":"хоче","back":"he/she wants"},{"front":"прокидатися","back":"to wake up"},{"front":"прокидаюся","back":"I wake up"},{"front":"вмиватися","back":"to wash up"},{"front":"вмиваюся","back":"I wash up"},{"front":"дивитися","back":"to watch; to look"},{"front":"дивлюся","back":"I watch; I look"},{"front":"хто","back":"who"},{"front":"що","back":"what"},{"front":"де","back":"where"},{"front":"куди","back":"where to"},{"front":"коли","back":"when"},{"front":"чому","back":"why"},{"front":"як","back":"how"},{"front":"спочатку","back":"first"},{"front":"потім","back":"then"},{"front":"після цього","back":"after that"},{"front":"нарешті","back":"finally"}]`)} />
+
+</TabItem>
+<TabItem label="Activities">
+
+### Reading line to skill
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Я прокидаюся о сьомій.", "right": "reflexive routine"}, {"left": "Я люблю читати.", "right": "like + infinitive"}, {"left": "Вона працює в школі.", "right": "Group One -ува-"}, {"left": "Ти пишеш гарно.", "right": "писати change"}, {"left": "Вони роблять швидко.", "right": "Group Two plural"}, {"left": "Я можу готувати.", "right": "modal + infinitive"}, {"left": "Коли ти можеш?", "right": "question word"}, {"left": "Ніхто не читає.", "right": "negative"}]`)} />
+
+### Action diagnostics
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Я працюю кожного дня.", "isTrue": true, "explanation": "Працюю is the я form of працювати."}, {"statement": "Вона працює в школі.", "isTrue": true, "explanation": "Працювати changes to працює with вона."}, {"statement": "Ви пишите дуже гарно.", "isTrue": false, "explanation": "Use Ви пишете дуже гарно."}, {"statement": "Вони роботь швидко.", "isTrue": false, "explanation": "Use Вони роблять швидко."}, {"statement": "Він хоче кави.", "isTrue": true, "explanation": "Хоче is the safe він form."}, {"statement": "Я є читаю книгу.", "isTrue": false, "explanation": "Use Я читаю книгу."}, {"statement": "Я прокидаюся о сьомій.", "isTrue": true, "explanation": "Прокидаюся is a safe -ся routine form."}, {"statement": "Ніхто не читає.", "isTrue": true, "explanation": "Keep не before the verb."}]`)} />
+
+### Skill stations
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Group One": ["я читаю", "ти пишеш", "вони працюють", "ми малюємо"], "Group Two": ["я говорю", "ти говориш", "вони роблять", "ви бачите"], "Modal + infinitive": ["хочу читати", "можу готувати", "мушу працювати", "може допомагати"], "Question words": ["де ти працюєш?", "коли ти можеш?", "що ти читаєш?", "як ми говоримо?"]}`)} />
+
+### Roommate dialogue gaps
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Олег: Коли ти ___?", "answer": "прокидаєшся", "options": ["прокидаєшся", "працюєш", "пишеш"]}, {"sentence": "Марина: Я ___ о сьомій.", "answer": "прокидаюся", "options": ["прокидаюся", "читаю", "роблю"]}, {"sentence": "Олег: Де ти ___?", "answer": "працюєш", "options": ["працюєш", "можеш", "хочеш"]}, {"sentence": "Марина: Я ___ в школі.", "answer": "працюю", "options": ["працюю", "працює", "працюємо"]}, {"sentence": "Олег: Ти ___ читати ввечері?", "answer": "любиш", "options": ["любиш", "читаєш", "робиш"]}, {"sentence": "Марина: Не можу зараз, ___ працювати.", "answer": "мушу", "options": ["мушу", "читаю", "говорю"]}]`)} />
+
+### Find the form that does not fit
+
+<OddOneOut client:only='react' instruction={"Choose the chunk that belongs to a different checkpoint skill."} items={JSON.parse(`[{"words": ["я читаю", "ти читаєш", "вони читають", "ти говориш"], "correct": 3, "explanation": "Ти говориш is Group Two; the others are Group One читати."}, {"words": ["хочу читати", "можу готувати", "мушу працювати", "я читаю"], "correct": 3, "explanation": "Я читаю is a person form, not modal + infinitive."}, {"words": ["хто", "коли", "куди", "працюю"], "correct": 3, "explanation": "Працюю is a verb form; the others are question words."}, {"words": ["я прокидаюся", "ти вмиваєшся", "вона одягається", "я снідаю"], "correct": 3, "explanation": "Снідаю is not a -ся verb."}]`)} />
+
+### Rebuild checkpoint lines
+
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / люблю / читати", "answer": "Я люблю читати"}, {"jumbled": "Вона / працює / в школі", "answer": "Вона працює в школі"}, {"jumbled": "Ми / говоримо / українською", "answer": "Ми говоримо українською"}, {"jumbled": "Коли / ти / можеш", "answer": "Коли ти можеш"}, {"jumbled": "Я / мушу / працювати", "answer": "Я мушу працювати"}, {"jumbled": "Вони / роблять / швидко", "answer": "Вони роблять швидко"}]`)} />
+
+### Choose the answer job
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Коли ти прокидаєшся?", "options": [{"text": "О сьомій.", "correct": true}, {"text": "У школі.", "correct": false}, {"text": "Українською.", "correct": false}], "explanation": "Коли asks about time."}, {"question": "Де ти працюєш?", "options": [{"text": "В офісі.", "correct": true}, {"text": "О восьмій.", "correct": false}, {"text": "Тому що мушу.", "correct": false}], "explanation": "Де asks about place."}, {"question": "Що ти любиш?", "options": [{"text": "Читати.", "correct": true}, {"text": "Удома.", "correct": false}, {"text": "Завтра.", "correct": false}], "explanation": "Що asks for the action or thing."}, {"question": "Як ми говоримо?", "options": [{"text": "Українською.", "correct": true}, {"text": "Увечері.", "correct": false}, {"text": "У школі.", "correct": false}], "explanation": "Як asks how."}]`)} />
+
+### Repair by building the safe line
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "I work every day: Я ___ кожного дня.", "answer": "працюю", "options": ["працюю", "читаю", "пишу"]}, {"sentence": "She works at school: Вона ___ в школі.", "answer": "працює", "options": ["працює", "читає", "готує"]}, {"sentence": "I read a book: Я ___ книгу.", "answer": "читаю", "options": ["читаю", "пишу", "бачу"]}, {"sentence": "You write very nicely: Ви ___ дуже гарно.", "answer": "пишете", "options": ["пишете", "читаєте", "говорите"]}, {"sentence": "They work fast: Вони ___ швидко.", "answer": "роблять", "options": ["роблять", "говорять", "читають"]}, {"sentence": "He wants coffee: Він ___ кави.", "answer": "хоче", "options": ["хоче", "любить", "п'є"]}]`)} />
+
+</TabItem>
+<TabItem label="Resources">
+
+:::info[🎧 🔗 External Resources]
+
+**📝 Articles:**
+- 📄 [Modal Verbs: Want, Must, Can](https://opentext.ku.edu/dobraforma/chapter/26-1-modal-verbs-want-must-can/) — Use as a later review for хочу, мушу, можу with infinitives.
+- 📄 [Present Tense of -ся Verbs: First Conjugation](https://opentext.ku.edu/dobraforma/chapter/23-1/) — Review the Group One + -ся routine pattern.
+- 📄 [Present Tense of Verbs: Other First Conjugation Verbs](https://opentext.ku.edu/dobraforma/chapter/21-3/) — Review жити, пити, писати, and hard-vowel Group One forms.
+- 📄 [Present Tense of Verbs: Говорити and Любити Types](https://opentext.ku.edu/dobraforma/chapter/22-2/) — Review Group Two endings and forms like говорити, любити, робити.
+- 📄 [Present Tense of Verbs: Працювати Type](https://opentext.ku.edu/dobraforma/chapter/21-2/) — Review the productive Group One -ува- pattern after the checkpoint.
+:::
+
+</TabItem>
+</Tabs>
+
+<HashTabSync />


### PR DESCRIPTION
Small stacked PR extracted from the closed A1 umbrella branch. Review this PR against its immediate base, not against main unless this is the runtime base PR.

Stack target:
- Base: codex/a1-stack-m20-my-morning
- Head: codex/a1-stack-m21-checkpoint-actions
- Commit: 4f832aff39789dd454b8cd391da085865c3cec18

Validation already run on the extracted stack:
- Per-commit hooks passed during extraction.
- Final stack: `git diff --check origin/main...HEAD` passed.
- Final stack: `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed for all 56 commits.
- Final stack: `npm --prefix starlight run build` passed after `npm --prefix starlight ci`.
- M52-M55 browser smoke passed: routes loaded with HTTP 200 and no console errors.

Review focus:
- bounded diff correctness against the base branch
- generated-artifact hygiene: no `status/*.json`, `audit/*-review.md`, or `review/*-review.md`
- plan snapshot correctness where this PR includes a required `.yaml.bak`
- merge safety for the stacked A1 sequence

Existing A1 audit and LLM audit remain evidence, but they are not a replacement for this PR-level review.