### PR TITLE
feat(a1): add M24 weather module

### DIFF
--- a/curriculum/l2-uk-en/a1/weather/activities.yaml
+++ b/curriculum/l2-uk-en/a1/weather/activities.yaml
@@ -1,0 +1,260 @@
+- id: act-1
+  type: match-up
+  title: Weather line to real-world clue
+  instruction: Match each Ukrainian weather line with the best clue.
+  pairs:
+    - left: Іде дощ.
+      right: umbrella
+    - left: Іде сніг.
+      right: winter street
+    - left: Світить сонце.
+      right: sunglasses
+    - left: Дме вітер.
+      right: moving trees
+    - left: Мінус десять.
+      right: very cold
+    - left: Плюс тридцять.
+      right: very hot
+    - left: Сьогодні хмарно.
+      right: no visible sun
+    - left: Завтра буде тепло.
+      right: good day for a walk
+- id: act-2
+  type: fill-in
+  title: Window weather chunks
+  instruction: Complete each window line with the safe weather chunk.
+  items:
+    - sentence: "Яка сьогодні погода? Сьогодні ___."
+      answer: холодно
+      options:
+        - холодно
+        - холодний
+        - я холодно
+      explanation: Weather state words do not need a subject.
+    - sentence: "Надворі ___. Сонця не видно."
+      answer: хмарно
+      options:
+        - хмарно
+        - хмара
+        - хмарний погода
+      explanation: Хмарно answers the weather question as a state.
+    - sentence: "Зараз ___ дощ."
+      answer: іде
+      options:
+        - іде
+        - є
+        - має
+      explanation: Іде дощ is the safe precipitation chunk.
+    - sentence: "Завтра ___ тепло і сонячно."
+      answer: буде
+      options:
+        - буде
+        - є
+        - має
+      explanation: Завтра буде... is the simple future weather frame.
+    - sentence: "Влітку дуже ___."
+      answer: спекотно
+      options:
+        - спекотно
+        - спекотний
+        - жар
+      explanation: Use спекотно for hot weather.
+    - sentence: "Увечері мені ___."
+      answer: холодно
+      options:
+        - холодно
+        - холодний
+        - холод
+      explanation: Мені холодно describes a person's state.
+- id: act-3
+  type: odd-one-out
+  title: Find the unsafe weather line
+  instruction: Choose the line that does not fit the safe Ukrainian pattern.
+  items:
+    - words:
+        - Сьогодні тепло.
+        - Надворі сонячно.
+        - Це є дуже сонячно.
+        - Завтра буде тепло.
+      answer: Це є дуже сонячно.
+      explanation: Do not copy English it is with це є for this weather line.
+    - words:
+        - Іде дощ.
+        - Іде сніг.
+        - Він іде дощ.
+        - Дме вітер.
+      answer: Він іде дощ.
+      explanation: Rain does not need він.
+    - words:
+        - Мені холодно.
+        - Мені вдень було холодно.
+        - Я є холодно.
+        - На вулиці холодно.
+      answer: Я є холодно.
+      explanation: Use мені for a person's state.
+    - words:
+        - опади
+        - сніг
+        - дощ
+        - осадки
+      answer: осадки
+      explanation: Use the Ukrainian weather noun опади.
+- id: act-4
+  type: group-sort
+  title: Season weather shelves
+  instruction: Sort each chunk onto the season where it first fits.
+  groups:
+    - name: ЗИМА
+      items:
+        - іде сніг
+        - мороз
+        - мінус десять
+        - холодно
+    - name: Весна
+      items:
+        - тепло
+        - світить сонце
+        - іде дощ
+        - квітень
+    - name: Літо
+      items:
+        - спекотно
+        - сонячно
+        - плюс тридцять
+        - липень
+    - name: Осінь
+      items:
+        - прохолодно
+        - хмарно
+        - часто йде дощ
+        - листопад
+- id: act-5
+  type: true-false
+  title: Weather pattern checks
+  instruction: Decide whether each statement describes the Ukrainian weather pattern safely.
+  items:
+    - statement: "Холодно, тепло, сонячно, and хмарно can answer Яка погода?"
+      correct: true
+      explanation: They are safe state words for weather.
+    - statement: "Ukrainian needs це є before every weather state."
+      correct: false
+      explanation: Say Сьогодні холодно or Надворі сонячно.
+    - statement: "Іде дощ is the safe A1 precipitation chunk."
+      correct: true
+      explanation: It is the default spoken pattern for rain.
+    - statement: "Дощ падає зараз is the best first A1 weather line."
+      correct: false
+      explanation: Learn Іде дощ first.
+    - statement: "Сніг and мороз naturally sort with ЗИМА in the first season map."
+      correct: true
+      explanation: This is the basic weather-season link.
+    - statement: "Мені подобається теплий дощ is safer than Я подобаюсь теплий дощ."
+      correct: true
+      explanation: Use Мені подобається... for likes.
+- id: act-6
+  type: translate
+  title: Build weather notes
+  instruction: Choose the safe Ukrainian weather note.
+  questions:
+    - source: Today it is cold.
+      options:
+        - text: "Сьогодні холодно."
+          correct: true
+        - text: "Сьогодні є холодно."
+          correct: false
+        - text: "Я холодно сьогодні."
+          correct: false
+      explanation: Use the state word without English-style it is.
+    - source: It is raining now.
+      options:
+        - text: "Зараз іде дощ."
+          correct: true
+        - text: "Дощ падає зараз."
+          correct: false
+        - text: "Це дощить зараз."
+          correct: false
+      explanation: Іде дощ is the target A1 chunk.
+    - source: In summer it is hot and sunny.
+      options:
+        - text: "Влітку спекотно і сонячно."
+          correct: true
+        - text: "В літо спекотний і сонячний."
+          correct: false
+        - text: "Літо є жар."
+          correct: false
+      explanation: Use the season chunk влітку and state words.
+    - source: I like spring.
+      options:
+        - text: "Мені подобається весна."
+          correct: true
+        - text: "Я подобаюсь весна."
+          correct: false
+        - text: "Я є подобається весна."
+          correct: false
+      explanation: Мені подобається... is the safe preference frame.
+    - source: I am cold in the evening.
+      options:
+        - text: "Увечері мені холодно."
+          correct: true
+        - text: "Увечері я є холодно."
+          correct: false
+        - text: "Увечері я маю холодно."
+          correct: false
+      explanation: Use мені холодно for a person's state.
+- id: act-7
+  type: order
+  title: Plan the walk after checking weather
+  instruction: Put the dialogue in a logical order.
+  is_ukrainian: true
+  items:
+    - Яка сьогодні погода?
+    - Сьогодні холодно і йде дощ.
+    - А завтра?
+    - Завтра буде тепло і сонячно.
+    - Добре! Тоді завтра гуляємо.
+  correct_order: [0, 1, 2, 3, 4]
+- id: act-8
+  type: error-correction
+  title: Repair weather calques
+  instruction: Choose the safe Ukrainian repair.
+  items:
+    - sentence: "Це є дуже сонячно."
+      error: "Це є"
+      answer: "Надворі сонячно."
+      options:
+        - "Надворі сонячно."
+        - "Це є дуже сонячно."
+        - "Сонячний є надворі."
+      explanation: Weather states can stand without це є.
+    - sentence: "Він іде дощ."
+      error: "Він"
+      answer: "Зараз іде дощ."
+      options:
+        - "Зараз іде дощ."
+        - "Він іде дощ."
+        - "Дощ має іти."
+      explanation: Rain does not take він.
+    - sentence: "Я є холодно."
+      error: "Я є"
+      answer: "Мені холодно."
+      options:
+        - "Мені холодно."
+        - "Я є холодно."
+        - "Я маю холодно."
+      explanation: Use мені for a person's state.
+    - sentence: "Сьогодні погода є добре."
+      error: "добре"
+      answer: "Сьогодні гарна погода."
+      options:
+        - "Сьогодні гарна погода."
+        - "Сьогодні погода є добре."
+        - "Сьогодні добрий погода."
+      explanation: Погода is feminine, so use гарна.
+    - sentence: "Я подобаюсь теплий дощ."
+      error: "Я подобаюсь"
+      answer: "Мені подобається теплий дощ."
+      options:
+        - "Мені подобається теплий дощ."
+        - "Я подобаюсь теплий дощ."
+        - "Я є люблю теплий дощ."
+      explanation: Use Мені подобається... for likes.

--- a/curriculum/l2-uk-en/a1/weather/module.md
+++ b/curriculum/l2-uk-en/a1/weather/module.md
@@ -1,0 +1,216 @@
+# Погода
+
+This lesson gives you a small Ukrainian weather toolkit. The main habit is
+simple: for weather, Ukrainian often describes the state directly. You do not
+need an English-style "it" at the front.
+
+By the end, you can:
+
+- ask and answer **Яка погода?** and **Як погода?**;
+- describe the day with **тепло, холодно, сонячно, хмарно**;
+- say **іде дощ**, **іде сніг**, **дме вітер**, and **світить сонце**;
+- connect weather with **зима, весна, літо, осінь**;
+- say what kind of season you like with **Мені подобається...**;
+- repair unsafe lines such as **Це є дуже сонячно**, **Він іде дощ**,
+  **Я є холодно**, **осадки**, and **Я подобаюсь теплий дощ**.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+## Діалоги
+
+The first scene is at the window. Two friends are deciding whether to go for a
+walk.
+
+<DialogueBox uk="Іванко: Яка сьогодні погода?" en="Ivanko: What is the weather like today?" />
+<DialogueBox uk="Галя: Сьогодні холодно і йде дощ." en="Halia: Today it is cold and it is raining." />
+<DialogueBox uk="Іванко: А завтра?" en="Ivanko: And tomorrow?" />
+<DialogueBox uk="Галя: Завтра буде тепло і сонячно." en="Halia: Tomorrow it will be warm and sunny." />
+<DialogueBox uk="Іванко: Добре! Тоді завтра гуляємо." en="Ivanko: Good! Then tomorrow we will walk." />
+
+The useful answer is short: **Сьогодні холодно. Іде дощ.** Ukrainian does not
+need **це є** for this kind of weather line. Say **Надворі сонячно**, not
+**Це є дуже сонячно**. Say **Зараз іде дощ**, not **Він іде дощ**.
+
+The second scene connects weather to seasons and likes.
+
+<DialogueBox uk="Галя: Яка пора року тобі подобається?" en="Halia: Which season do you like?" />
+<DialogueBox uk="Іванко: Мені подобається літо." en="Ivanko: I like summer." />
+<DialogueBox uk="Галя: Чому?" en="Halia: Why?" />
+<DialogueBox uk="Іванко: Тому що влітку тепло і сонячно. А тобі?" en="Ivanko: Because in summer it is warm and sunny. And you?" />
+<DialogueBox uk="Галя: Мені подобається осінь. Восени красиво, але часто йде дощ." en="Halia: I like autumn. In autumn it is beautiful, but it often rains." />
+
+For likes, keep the same chunk you learned before: **Мені подобається...**
+Do not build the English order word by word. **Мені подобається теплий дощ** is
+safe. **Я подобаюсь теплий дощ** is not.
+
+<!-- INJECT_ACTIVITY: act-2 -->
+
+## Яка погода?
+
+Start with one question and one small answer.
+
+| Question | Safe A1 answer |
+| --- | --- |
+| **Яка погода?** | **Сьогодні тепло.** |
+| **Як погода?** | **Надворі хмарно.** |
+| **Яка сьогодні погода?** | **Сьогодні холодно і йде дощ.** |
+
+The first weather words are state words:
+
+| Ukrainian | Meaning | Use it like this |
+| --- | --- | --- |
+| **тепло** | warm | **Сьогодні тепло.** |
+| **холодно** | cold | **Надворі холодно.** |
+| **сонячно** | sunny | **Завтра буде сонячно.** |
+| **хмарно** | cloudy | **Сьогодні хмарно.** |
+| **спекотно** | hot | **Влітку спекотно.** |
+| **прохолодно** | cool | **Увечері прохолодно.** |
+
+These are impersonal weather chunks. They describe the state; they do not need
+a subject. English says "it is cold." Ukrainian can simply say **холодно**. If
+you want a place, add **надворі** or **на вулиці**: **Надворі холодно. На
+вулиці тепло.**
+
+The school-grammar idea behind this is simple:
+
+> Безособові речення найчастіше передають явища природи, фізичний і психічний стан людини, значення можливості чи бажаності якоїсь дії. НАПРИКЛАД: 1. А ввечері на вулиці дощить. 2. Мені вдень було холодно. 3. Треба вранці замовити таксі. Іноді односкладні безособові речення виступають синтаксичними синонімами до двоскладних.
+
+*— Заболотний Grade 8, p.126*
+
+You do not need to analyze the whole quote today. The A1 idea is this:
+weather states can be complete Ukrainian sentences without an English-style
+subject.
+
+For rain and snow, use the old independent Ukrainian pattern **іде + weather
+word**. It is not a translation from Russian or another neighboring language.
+It is the normal pattern to learn first:
+
+The Ukrainian pattern is **іде + [опади]**. In learner words, that means
+**іде дощ** and **іде сніг**.
+
+| Weather event | Safe chunk |
+| --- | --- |
+| rain | **іде дощ** |
+| snow | **іде сніг** |
+| wind | **дме вітер** |
+| sun | **світить сонце** |
+
+You can also recognize **дощить**, especially in **Надворі дощить**, but your
+default A1 line is **Іде дощ.** Do not say **Дощ падає зараз** or **Це дощить
+зараз** when you need the basic spoken weather line.
+
+Use opposites to build quick weather meaning: **сонячно - хмарно** and
+**тепло - холодно**. Add one more careful pair: **гарна погода** and
+**погана погода**. Here **погода** is a feminine noun, so the adjective changes:
+**гарна погода**, not **добре погода**. You can also say **Надворі добре**.
+
+For a person, use **мені** with the state word:
+
+<DialogueBox uk="Мені холодно." en="I am cold." />
+<DialogueBox uk="Мені вдень було холодно." en="I was cold during the day." />
+
+This is a ready chunk. Do not say **Я є холодно** or **Я маю холодно**.
+
+<!-- INJECT_ACTIVITY: act-3 -->
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+## Погода і пори року
+
+Weather becomes useful when you connect it with the calendar from the last
+lesson.
+
+| Season | Weather chunks |
+| --- | --- |
+| **зима** | **Взимку холодно. Іде сніг. Мороз.** |
+| **весна** | **Навесні тепло. Світить сонце. Іде дощ.** |
+| **літо** | **Влітку спекотно. Сонячно.** |
+| **осінь** | **Восени прохолодно. Хмарно. Часто йде дощ.** |
+
+If a card says **сніг** or **мороз**, it naturally belongs with **ЗИМА**. If a
+card says **спекотно** or **плюс тридцять**, it naturally belongs with
+**літо**. The same weather phrase can change by place, but these first links
+give you a safe starting point.
+
+You can add temperature very simply:
+
+<DialogueBox uk="Сьогодні плюс двадцять градусів." en="Today it is plus twenty degrees." />
+<DialogueBox uk="Сьогодні мінус десять." en="Today it is minus ten." />
+<DialogueBox uk="Плюс двадцять - тепло." en="Plus twenty is warm." />
+<DialogueBox uk="Мінус десять - холодно." en="Minus ten is cold." />
+
+Three short nature lines are useful for recognition: **Сонце світить. Дощ іде.
+Сніг падає.** In your own speaking, prefer the everyday chunks **світить
+сонце**, **іде дощ**, and **іде сніг**.
+
+Ukrainian nature vocabulary is rich. At A1, you only need to recognize a small
+synonym row for bad winter weather: **завірюха, віхола, сніговій**. These words
+are not required for your own sentences today, but they show why Ukrainian
+weather vocabulary should be learned on its own terms. Avoid Russian-imperial
+teaching habits that present Ukrainian as a secondary language or as a
+фонетичним чи лексичним варіантом російської. Do not use Russian phonetic
+analogies for Ukrainian sounds. Learn **х** in **хмарно** and **г** in
+**гарний** as Ukrainian sounds. Do not replace this row with a Russian
+winter-storm label.
+
+Категорично заборонено спиратися на фонетичні аналогії з російською
+мовою. When you explain the letter **х** in **хмарно** or **г** in
+**гарний**, не можна посилатися на звучання в російській мові. These are
+independent Ukrainian sounds.
+
+Use the Ukrainian weather noun **опади** for precipitation. Do not use
+**осадки**. For hot weather, prefer **спекотно** and **спекотний**. You may
+hear **жарко**, but **спекотно** is the better course word.
+
+<!-- INJECT_ACTIVITY: act-5 -->
+
+<!-- INJECT_ACTIVITY: act-6 -->
+
+## Підсумок
+
+Keep four weather cards.
+
+First: ask and answer the weather question.
+
+<DialogueBox uk="Яка сьогодні погода?" en="What is the weather like today?" />
+<DialogueBox uk="Сьогодні прохолодно і хмарно." en="Today it is cool and cloudy." />
+
+Second: use the precipitation chunks.
+
+<DialogueBox uk="Зараз іде дощ." en="It is raining now." />
+<DialogueBox uk="Завтра буде сніг." en="Tomorrow there will be snow." />
+<DialogueBox uk="Взимку іде сніг." en="In winter it snows." />
+
+Third: connect weather to a season.
+
+<DialogueBox uk="Влітку спекотно і сонячно." en="In summer it is hot and sunny." />
+<DialogueBox uk="Восени часто йде дощ." en="In autumn it often rains." />
+<DialogueBox uk="Навесні тепло." en="In spring it is warm." />
+
+Fourth: say a simple preference.
+
+<DialogueBox uk="Що тобі подобається більше? Спекотне літо чи студена зима?" en="What do you like more? A hot summer or a cold winter?" />
+<DialogueBox uk="Мені подобається спекотне літо." en="I like a hot summer." />
+<DialogueBox uk="Мені подобається студена зима, але мені холодно ввечері." en="I like a cold winter, but I am cold in the evening." />
+
+:::caution
+Keep the weather system Ukrainian. Do not compare Ukrainian words with Russian
+words, do not use **осадки**, and do not explain **іде дощ** as a borrowed
+pattern. Конструкція **іде дощ** is a **незалежний давній український
+структурний патерн**, not **переклад з російської чи іншої
+сусідньої мови**. Build your weather speech from Ukrainian chunks:
+**Надворі сонячно**, **Іде дощ**, **Мені холодно**, **Мені подобається теплий
+дощ**.
+:::
+
+Write your own five-line weather note:
+
+<DialogueBox uk="Сьогодні холодно." en="Today it is cold." />
+<DialogueBox uk="Надворі хмарно." en="Outside it is cloudy." />
+<DialogueBox uk="Іде дощ." en="It is raining." />
+<DialogueBox uk="Завтра буде тепло." en="Tomorrow it will be warm." />
+<DialogueBox uk="Мені подобається весна." en="I like spring." />
+
+<!-- INJECT_ACTIVITY: act-7 -->
+
+<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/weather/resources.yaml
+++ b/curriculum/l2-uk-en/a1/weather/resources.yaml
@@ -1,0 +1,10 @@
+- title: "Weather in Ukrainian"
+  role: article
+  source_ref: "Ukrainian Lessons"
+  url: https://www.ukrainianlessons.com/weather-vocabulary/
+  notes: "Learner-safe weather vocabulary list with common Ukrainian weather phrases."
+- title: "Dative Pronouns and Подобатися"
+  role: article
+  source_ref: "Добра форма 15.1"
+  url: https://opentext.ku.edu/dobraforma/chapter/15-1/
+  notes: "Follow-up grammar reference for chunks such as Мені подобається and dative state patterns."

--- a/curriculum/l2-uk-en/a1/weather/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/weather/vocabulary.yaml
@@ -1,0 +1,168 @@
+- word: погода
+  translation: weather
+  pos: noun
+  example: "Яка сьогодні погода?"
+- word: тепло
+  translation: warm
+  pos: adverb
+  example: "Сьогодні тепло."
+- word: холодно
+  translation: cold
+  pos: adverb
+  example: "Надворі холодно."
+- word: сонячно
+  translation: sunny
+  pos: adverb
+  example: "Завтра буде сонячно."
+- word: хмарно
+  translation: cloudy
+  pos: adverb
+  example: "Сьогодні хмарно."
+- word: спекотно
+  translation: hot
+  pos: adverb
+  example: "Влітку спекотно."
+- word: прохолодно
+  translation: cool
+  pos: adverb
+  example: "Увечері прохолодно."
+- word: дощ
+  translation: rain
+  pos: noun
+  example: "Іде дощ."
+- word: сніг
+  translation: snow
+  pos: noun
+  example: "Іде сніг."
+- word: сонце
+  translation: sun
+  pos: noun
+  example: "Світить сонце."
+- word: вітер
+  translation: wind
+  pos: noun
+  example: "Дме вітер."
+- word: мороз
+  translation: frost; freezing cold
+  pos: noun
+  example: "Взимку мороз."
+- word: опади
+  translation: precipitation
+  pos: noun
+  example: "Дощ і сніг - це опади."
+- word: іде дощ
+  translation: it is raining
+  pos: weather chunk
+  example: "Зараз іде дощ."
+- word: іде сніг
+  translation: it is snowing
+  pos: weather chunk
+  example: "Взимку іде сніг."
+- word: дме вітер
+  translation: the wind is blowing
+  pos: weather chunk
+  example: "Сьогодні дме вітер."
+- word: світить сонце
+  translation: the sun is shining
+  pos: weather chunk
+  example: "Світить сонце."
+- word: надворі
+  translation: outside; outdoors
+  pos: adverb
+  example: "Надворі тепло."
+- word: на вулиці
+  translation: outside; in the street
+  pos: phrase
+  example: "На вулиці холодно."
+- word: сьогодні
+  translation: today
+  pos: adverb
+  example: "Сьогодні хмарно."
+- word: завтра
+  translation: tomorrow
+  pos: adverb
+  example: "Завтра буде тепло."
+- word: вчора
+  translation: yesterday
+  pos: adverb
+  example: "Вчора було холодно."
+- word: градус
+  translation: degree
+  pos: noun
+  example: "Плюс двадцять градусів."
+- word: плюс
+  translation: plus
+  pos: temperature word
+  example: "Сьогодні плюс двадцять."
+- word: мінус
+  translation: minus
+  pos: temperature word
+  example: "Сьогодні мінус десять."
+- word: гарний
+  translation: good; beautiful
+  pos: adjective
+  example: "Сьогодні гарна погода."
+- word: поганий
+  translation: bad
+  pos: adjective
+  example: "Сьогодні погана погода."
+- word: теплий
+  translation: warm
+  pos: adjective
+  example: "Мені подобається теплий дощ."
+- word: холодний
+  translation: cold
+  pos: adjective
+  example: "Холодний день."
+- word: зима
+  translation: winter
+  pos: noun
+  example: "Взимку холодно."
+- word: весна
+  translation: spring
+  pos: noun
+  example: "Навесні тепло."
+- word: літо
+  translation: summer
+  pos: noun
+  example: "Влітку спекотно."
+- word: осінь
+  translation: autumn; fall
+  pos: noun
+  example: "Восени часто йде дощ."
+- word: взимку
+  translation: in winter
+  pos: adverb
+  example: "Взимку іде сніг."
+- word: навесні
+  translation: in spring
+  pos: adverb
+  example: "Навесні світить сонце."
+- word: влітку
+  translation: in summer
+  pos: adverb
+  example: "Влітку тепло."
+- word: восени
+  translation: in autumn
+  pos: adverb
+  example: "Восени хмарно."
+- word: Мені холодно.
+  translation: I am cold.
+  pos: state chunk
+  example: "Увечері мені холодно."
+- word: Мені подобається...
+  translation: I like...
+  pos: preference chunk
+  example: "Мені подобається весна."
+- word: завірюха
+  translation: snowstorm
+  pos: passive noun
+  example: "Завірюха - зимове слово."
+- word: віхола
+  translation: snowstorm; blizzard
+  pos: passive noun
+  example: "Віхола - зимове слово."
+- word: сніговій
+  translation: snowstorm
+  pos: passive noun
+  example: "Сніговій - зимове слово."

--- a/starlight/src/content/docs/a1/weather.mdx
+++ b/starlight/src/content/docs/a1/weather.mdx
@@ -1,0 +1,347 @@
+---
+title: "Погода"
+description: "Сьогодні холодно — розмовляємо про погоду"
+sidebar:
+  order: 24
+  label: "24. Погода"
+pipeline: linear-phase-4
+build_status: validated
+prev: days-and-months
+next: false
+---
+
+import Quiz from '@site/src/components/Quiz';
+import MatchUp from '@site/src/components/MatchUp';
+import FillIn from '@site/src/components/FillIn';
+import TrueFalse from '@site/src/components/TrueFalse';
+import Unjumble from '@site/src/components/Unjumble';
+import GroupSort from '@site/src/components/GroupSort';
+import Anagram from '@site/src/components/Anagram';
+import ErrorCorrection, { ErrorCorrectionItem } from '@site/src/components/ErrorCorrection';
+import Cloze from '@site/src/components/Cloze';
+import Select from '@site/src/components/Select';
+import Translate from '@site/src/components/Translate';
+import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
+import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import EssayResponse from '@site/src/components/EssayResponse';
+import ComparativeStudy from '@site/src/components/ComparativeStudy';
+import ReadingActivity from '@site/src/components/ReadingActivity';
+import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
+import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import SourceEvaluation from '@site/src/components/SourceEvaluation';
+import Debate from '@site/src/components/Debate';
+import EtymologyTrace from '@site/src/components/EtymologyTrace';
+import GrammarIdentify from '@site/src/components/GrammarIdentify';
+import PaleographyAnalysis from '@site/src/components/PaleographyAnalysis';
+import DialectComparison from '@site/src/components/DialectComparison';
+import TranslationCritique from '@site/src/components/TranslationCritique';
+import Transcription from '@site/src/components/Transcription';
+import Observe from '@site/src/components/Observe';
+import Order from '@site/src/components/Order';
+import CountSyllables from '@site/src/components/CountSyllables';
+import DivideWords from '@site/src/components/DivideWords';
+import OddOneOut from '@site/src/components/OddOneOut';
+import PickSyllables from '@site/src/components/PickSyllables';
+import LetterGrid from '@site/src/components/LetterGrid';
+import FlashcardDeck from '@site/src/components/FlashcardDeck';
+import VocabCard from '@site/src/components/VocabCard';
+import DialogueBox from '@site/src/components/DialogueBox';
+import HashTabSync from '@site/src/components/HashTabSync';
+import ActivityHelp from '@site/src/components/ActivityHelp';
+import YouTubeVideo from '@site/src/components/YouTubeVideo';
+import WatchAndRepeat from '@site/src/components/WatchAndRepeat';
+import Classify from '@site/src/components/Classify';
+import ImageToLetter from '@site/src/components/ImageToLetter';
+import ActivityPlaceholder from '@site/src/components/ActivityPlaceholder';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs syncKey="module-tab">
+<TabItem label="Lesson">
+
+This lesson gives you a small Ukrainian weather toolkit. The main habit is
+simple: for weather, Ukrainian often describes the state directly. You do not
+need an English-style "it" at the front.
+
+By the end, you can:
+
+- ask and answer **Яка погода?** and **Як погода?**;
+- describe the day with **тепло, холодно, сонячно, хмарно**;
+- say **іде дощ**, **іде сніг**, **дме вітер**, and **світить сонце**;
+- connect weather with **зима, весна, літо, осінь**;
+- say what kind of season you like with **Мені подобається...**;
+- repair unsafe lines such as **Це є дуже сонячно**, **Він іде дощ**,
+  **Я є холодно**, **осадки**, and **Я подобаюсь теплий дощ**.
+
+### Weather line to real-world clue
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Іде дощ.", "right": "umbrella"}, {"left": "Іде сніг.", "right": "winter street"}, {"left": "Світить сонце.", "right": "sunglasses"}, {"left": "Дме вітер.", "right": "moving trees"}, {"left": "Мінус десять.", "right": "very cold"}, {"left": "Плюс тридцять.", "right": "very hot"}, {"left": "Сьогодні хмарно.", "right": "no visible sun"}, {"left": "Завтра буде тепло.", "right": "good day for a walk"}]`)} />
+
+## Діалоги
+
+The first scene is at the window. Two friends are deciding whether to go for a
+walk.
+
+<DialogueBox uk="Іванко: Яка сьогодні погода?" en="Ivanko: What is the weather like today?" />
+<DialogueBox uk="Галя: Сьогодні холодно і йде дощ." en="Halia: Today it is cold and it is raining." />
+<DialogueBox uk="Іванко: А завтра?" en="Ivanko: And tomorrow?" />
+<DialogueBox uk="Галя: Завтра буде тепло і сонячно." en="Halia: Tomorrow it will be warm and sunny." />
+<DialogueBox uk="Іванко: Добре! Тоді завтра гуляємо." en="Ivanko: Good! Then tomorrow we will walk." />
+
+The useful answer is short: **Сьогодні холодно. Іде дощ.** Ukrainian does not
+need **це є** for this kind of weather line. Say **Надворі сонячно**, not
+**Це є дуже сонячно**. Say **Зараз іде дощ**, not **Він іде дощ**.
+
+The second scene connects weather to seasons and likes.
+
+<DialogueBox uk="Галя: Яка пора року тобі подобається?" en="Halia: Which season do you like?" />
+<DialogueBox uk="Іванко: Мені подобається літо." en="Ivanko: I like summer." />
+<DialogueBox uk="Галя: Чому?" en="Halia: Why?" />
+<DialogueBox uk="Іванко: Тому що влітку тепло і сонячно. А тобі?" en="Ivanko: Because in summer it is warm and sunny. And you?" />
+<DialogueBox uk="Галя: Мені подобається осінь. Восени красиво, але часто йде дощ." en="Halia: I like autumn. In autumn it is beautiful, but it often rains." />
+
+For likes, keep the same chunk you learned before: **Мені подобається...**
+Do not build the English order word by word. **Мені подобається теплий дощ** is
+safe. **Я подобаюсь теплий дощ** is not.
+
+### Window weather chunks
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Яка сьогодні погода? Сьогодні ___.", "answer": "холодно", "options": ["холодно", "холодний", "я холодно"]}, {"sentence": "Надворі ___. Сонця не видно.", "answer": "хмарно", "options": ["хмарно", "хмара", "хмарний погода"]}, {"sentence": "Зараз ___ дощ.", "answer": "іде", "options": ["іде", "є", "має"]}, {"sentence": "Завтра ___ тепло і сонячно.", "answer": "буде", "options": ["буде", "є", "має"]}, {"sentence": "Влітку дуже ___.", "answer": "спекотно", "options": ["спекотно", "спекотний", "жар"]}, {"sentence": "Увечері мені ___.", "answer": "холодно", "options": ["холодно", "холодний", "холод"]}]`)} />
+
+## Яка погода?
+
+Start with one question and one small answer.
+
+| Question | Safe A1 answer |
+| --- | --- |
+| **Яка погода?** | **Сьогодні тепло.** |
+| **Як погода?** | **Надворі хмарно.** |
+| **Яка сьогодні погода?** | **Сьогодні холодно і йде дощ.** |
+
+The first weather words are state words:
+
+| Ukrainian | Meaning | Use it like this |
+| --- | --- | --- |
+| **тепло** | warm | **Сьогодні тепло.** |
+| **холодно** | cold | **Надворі холодно.** |
+| **сонячно** | sunny | **Завтра буде сонячно.** |
+| **хмарно** | cloudy | **Сьогодні хмарно.** |
+| **спекотно** | hot | **Влітку спекотно.** |
+| **прохолодно** | cool | **Увечері прохолодно.** |
+
+These are impersonal weather chunks. They describe the state; they do not need
+a subject. English says "it is cold." Ukrainian can simply say **холодно**. If
+you want a place, add **надворі** or **на вулиці**: **Надворі холодно. На
+вулиці тепло.**
+
+The school-grammar idea behind this is simple:
+
+> Безособові речення найчастіше передають явища природи, фізичний і психічний стан людини, значення можливості чи бажаності якоїсь дії. НАПРИКЛАД: 1. А ввечері на вулиці дощить. 2. Мені вдень було холодно. 3. Треба вранці замовити таксі. Іноді односкладні безособові речення виступають синтаксичними синонімами до двоскладних.
+
+*— Заболотний Grade 8, p.126*
+
+You do not need to analyze the whole quote today. The A1 idea is this:
+weather states can be complete Ukrainian sentences without an English-style
+subject.
+
+For rain and snow, use the old independent Ukrainian pattern **іде + weather
+word**. It is not a translation from Russian or another neighboring language.
+It is the normal pattern to learn first:
+
+The Ukrainian pattern is **іде + [опади]**. In learner words, that means
+**іде дощ** and **іде сніг**.
+
+| Weather event | Safe chunk |
+| --- | --- |
+| rain | **іде дощ** |
+| snow | **іде сніг** |
+| wind | **дме вітер** |
+| sun | **світить сонце** |
+
+You can also recognize **дощить**, especially in **Надворі дощить**, but your
+default A1 line is **Іде дощ.** Do not say **Дощ падає зараз** or **Це дощить
+зараз** when you need the basic spoken weather line.
+
+Use opposites to build quick weather meaning: **сонячно - хмарно** and
+**тепло - холодно**. Add one more careful pair: **гарна погода** and
+**погана погода**. Here **погода** is a feminine noun, so the adjective changes:
+**гарна погода**, not **добре погода**. You can also say **Надворі добре**.
+
+For a person, use **мені** with the state word:
+
+<DialogueBox uk="Мені холодно." en="I am cold." />
+<DialogueBox uk="Мені вдень було холодно." en="I was cold during the day." />
+
+This is a ready chunk. Do not say **Я є холодно** or **Я маю холодно**.
+
+### Find the unsafe weather line
+
+<OddOneOut client:only='react' instruction={"Choose the line that does not fit the safe Ukrainian pattern."} items={JSON.parse(`[{"words": ["Сьогодні тепло.", "Надворі сонячно.", "Це є дуже сонячно.", "Завтра буде тепло."], "correct": 2, "explanation": "Do not copy English it is with це є for this weather line."}, {"words": ["Іде дощ.", "Іде сніг.", "Він іде дощ.", "Дме вітер."], "correct": 2, "explanation": "Rain does not need він."}, {"words": ["Мені холодно.", "Мені вдень було холодно.", "Я є холодно.", "На вулиці холодно."], "correct": 2, "explanation": "Use мені for a person's state."}, {"words": ["опади", "сніг", "дощ", "осадки"], "correct": 3, "explanation": "Use the Ukrainian weather noun опади."}]`)} />
+
+### Season weather shelves
+
+<GroupSort client:only='react' groups={JSON.parse(`{"ЗИМА": ["іде сніг", "мороз", "мінус десять", "холодно"], "Весна": ["тепло", "світить сонце", "іде дощ", "квітень"], "Літо": ["спекотно", "сонячно", "плюс тридцять", "липень"], "Осінь": ["прохолодно", "хмарно", "часто йде дощ", "листопад"]}`)} />
+
+## Погода і пори року
+
+Weather becomes useful when you connect it with the calendar from the last
+lesson.
+
+| Season | Weather chunks |
+| --- | --- |
+| **зима** | **Взимку холодно. Іде сніг. Мороз.** |
+| **весна** | **Навесні тепло. Світить сонце. Іде дощ.** |
+| **літо** | **Влітку спекотно. Сонячно.** |
+| **осінь** | **Восени прохолодно. Хмарно. Часто йде дощ.** |
+
+If a card says **сніг** or **мороз**, it naturally belongs with **ЗИМА**. If a
+card says **спекотно** or **плюс тридцять**, it naturally belongs with
+**літо**. The same weather phrase can change by place, but these first links
+give you a safe starting point.
+
+You can add temperature very simply:
+
+<DialogueBox uk="Сьогодні плюс двадцять градусів." en="Today it is plus twenty degrees." />
+<DialogueBox uk="Сьогодні мінус десять." en="Today it is minus ten." />
+<DialogueBox uk="Плюс двадцять - тепло." en="Plus twenty is warm." />
+<DialogueBox uk="Мінус десять - холодно." en="Minus ten is cold." />
+
+Three short nature lines are useful for recognition: **Сонце світить. Дощ іде.
+Сніг падає.** In your own speaking, prefer the everyday chunks **світить
+сонце**, **іде дощ**, and **іде сніг**.
+
+Ukrainian nature vocabulary is rich. At A1, you only need to recognize a small
+synonym row for bad winter weather: **завірюха, віхола, сніговій**. These words
+are not required for your own sentences today, but they show why Ukrainian
+weather vocabulary should be learned on its own terms. Avoid Russian-imperial
+teaching habits that present Ukrainian as a secondary language or as a
+фонетичним чи лексичним варіантом російської. Do not use Russian phonetic
+analogies for Ukrainian sounds. Learn **х** in **хмарно** and **г** in
+**гарний** as Ukrainian sounds. Do not replace this row with a Russian
+winter-storm label.
+
+Категорично заборонено спиратися на фонетичні аналогії з російською
+мовою. When you explain the letter **х** in **хмарно** or **г** in
+**гарний**, не можна посилатися на звучання в російській мові. These are
+independent Ukrainian sounds.
+
+Use the Ukrainian weather noun **опади** for precipitation. Do not use
+**осадки**. For hot weather, prefer **спекотно** and **спекотний**. You may
+hear **жарко**, but **спекотно** is the better course word.
+
+### Weather pattern checks
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Холодно, тепло, сонячно, and хмарно can answer Яка погода?", "isTrue": true, "explanation": "They are safe state words for weather."}, {"statement": "Ukrainian needs це є before every weather state.", "isTrue": false, "explanation": "Say Сьогодні холодно or Надворі сонячно."}, {"statement": "Іде дощ is the safe A1 precipitation chunk.", "isTrue": true, "explanation": "It is the default spoken pattern for rain."}, {"statement": "Дощ падає зараз is the best first A1 weather line.", "isTrue": false, "explanation": "Learn Іде дощ first."}, {"statement": "Сніг and мороз naturally sort with ЗИМА in the first season map.", "isTrue": true, "explanation": "This is the basic weather-season link."}, {"statement": "Мені подобається теплий дощ is safer than Я подобаюсь теплий дощ.", "isTrue": true, "explanation": "Use Мені подобається... for likes."}]`)} />
+
+### Build weather notes
+
+<Translate client:only='react' questions={JSON.parse(`[]`)} />
+
+## 📋 Підсумок
+
+Keep four weather cards.
+
+First: ask and answer the weather question.
+
+<DialogueBox uk="Яка сьогодні погода?" en="What is the weather like today?" />
+<DialogueBox uk="Сьогодні прохолодно і хмарно." en="Today it is cool and cloudy." />
+
+Second: use the precipitation chunks.
+
+<DialogueBox uk="Зараз іде дощ." en="It is raining now." />
+<DialogueBox uk="Завтра буде сніг." en="Tomorrow there will be snow." />
+<DialogueBox uk="Взимку іде сніг." en="In winter it snows." />
+
+Third: connect weather to a season.
+
+<DialogueBox uk="Влітку спекотно і сонячно." en="In summer it is hot and sunny." />
+<DialogueBox uk="Восени часто йде дощ." en="In autumn it often rains." />
+<DialogueBox uk="Навесні тепло." en="In spring it is warm." />
+
+Fourth: say a simple preference.
+
+<DialogueBox uk="Що тобі подобається більше? Спекотне літо чи студена зима?" en="What do you like more? A hot summer or a cold winter?" />
+<DialogueBox uk="Мені подобається спекотне літо." en="I like a hot summer." />
+<DialogueBox uk="Мені подобається студена зима, але мені холодно ввечері." en="I like a cold winter, but I am cold in the evening." />
+
+:::caution
+Keep the weather system Ukrainian. Do not compare Ukrainian words with Russian
+words, do not use **осадки**, and do not explain **іде дощ** as a borrowed
+pattern. Конструкція **іде дощ** is a **незалежний давній український
+структурний патерн**, not **переклад з російської чи іншої
+сусідньої мови**. Build your weather speech from Ukrainian chunks:
+**Надворі сонячно**, **Іде дощ**, **Мені холодно**, **Мені подобається теплий
+дощ**.
+:::
+
+Write your own five-line weather note:
+
+<DialogueBox uk="Сьогодні холодно." en="Today it is cold." />
+<DialogueBox uk="Надворі хмарно." en="Outside it is cloudy." />
+<DialogueBox uk="Іде дощ." en="It is raining." />
+<DialogueBox uk="Завтра буде тепло." en="Tomorrow it will be warm." />
+<DialogueBox uk="Мені подобається весна." en="I like spring." />
+
+### Plan the walk after checking weather
+
+<Order client:only='react' items={JSON.parse(`["Яка сьогодні погода?", "Сьогодні холодно і йде дощ.", "А завтра?", "Завтра буде тепло і сонячно.", "Добре! Тоді завтра гуляємо."]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4]`)} instruction={"Put the dialogue in a logical order."} isUkrainian={false} />
+
+### Repair weather calques
+
+<ErrorCorrection client:only='react' instruction="Choose the safe Ukrainian repair." items={JSON.parse(`[{"sentence": "Це є дуже сонячно.", "errorWord": "Це є", "correctForm": "Надворі сонячно.", "options": ["Надворі сонячно.", "Це є дуже сонячно.", "Сонячний є надворі."], "explanation": "Weather states can stand without це є."}, {"sentence": "Він іде дощ.", "errorWord": "Він", "correctForm": "Зараз іде дощ.", "options": ["Зараз іде дощ.", "Він іде дощ.", "Дощ має іти."], "explanation": "Rain does not take він."}, {"sentence": "Я є холодно.", "errorWord": "Я є", "correctForm": "Мені холодно.", "options": ["Мені холодно.", "Я є холодно.", "Я маю холодно."], "explanation": "Use мені for a person's state."}, {"sentence": "Сьогодні погода є добре.", "errorWord": "добре", "correctForm": "Сьогодні гарна погода.", "options": ["Сьогодні гарна погода.", "Сьогодні погода є добре.", "Сьогодні добрий погода."], "explanation": "Погода is feminine, so use гарна."}, {"sentence": "Я подобаюсь теплий дощ.", "errorWord": "Я подобаюсь", "correctForm": "Мені подобається теплий дощ.", "options": ["Мені подобається теплий дощ.", "Я подобаюсь теплий дощ.", "Я є люблю теплий дощ."], "explanation": "Use Мені подобається... for likes."}]`)} />
+
+</TabItem>
+<TabItem label="Vocabulary">
+
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"погода","translation":"weather","pos":"noun","example":"Яка сьогодні погода?","examples":["weather","Яка сьогодні погода?"]},{"word":"тепло","translation":"warm","pos":"adverb","example":"Сьогодні тепло.","examples":["warm","Сьогодні тепло."]},{"word":"холодно","translation":"cold","pos":"adverb","example":"Надворі холодно.","examples":["cold","Надворі холодно."]},{"word":"сонячно","translation":"sunny","pos":"adverb","example":"Завтра буде сонячно.","examples":["sunny","Завтра буде сонячно."]},{"word":"хмарно","translation":"cloudy","pos":"adverb","example":"Сьогодні хмарно.","examples":["cloudy","Сьогодні хмарно."]},{"word":"спекотно","translation":"hot","pos":"adverb","example":"Влітку спекотно.","examples":["hot","Влітку спекотно."]},{"word":"прохолодно","translation":"cool","pos":"adverb","example":"Увечері прохолодно.","examples":["cool","Увечері прохолодно."]},{"word":"дощ","translation":"rain","pos":"noun","example":"Іде дощ.","examples":["rain","Іде дощ."]},{"word":"сніг","translation":"snow","pos":"noun","example":"Іде сніг.","examples":["snow","Іде сніг."]},{"word":"сонце","translation":"sun","pos":"noun","example":"Світить сонце.","examples":["sun","Світить сонце."]},{"word":"вітер","translation":"wind","pos":"noun","example":"Дме вітер.","examples":["wind","Дме вітер."]},{"word":"мороз","translation":"frost; freezing cold","pos":"noun","example":"Взимку мороз.","examples":["frost; freezing cold","Взимку мороз."]},{"word":"опади","translation":"precipitation","pos":"noun","example":"Дощ і сніг - це опади.","examples":["precipitation","Дощ і сніг - це опади."]},{"word":"іде дощ","translation":"it is raining","pos":"weather chunk","example":"Зараз іде дощ.","examples":["it is raining","Зараз іде дощ."]},{"word":"іде сніг","translation":"it is snowing","pos":"weather chunk","example":"Взимку іде сніг.","examples":["it is snowing","Взимку іде сніг."]},{"word":"дме вітер","translation":"the wind is blowing","pos":"weather chunk","example":"Сьогодні дме вітер.","examples":["the wind is blowing","Сьогодні дме вітер."]},{"word":"світить сонце","translation":"the sun is shining","pos":"weather chunk","example":"Світить сонце.","examples":["the sun is shining","Світить сонце."]},{"word":"надворі","translation":"outside; outdoors","pos":"adverb","example":"Надворі тепло.","examples":["outside; outdoors","Надворі тепло."]},{"word":"на вулиці","translation":"outside; in the street","pos":"phrase","example":"На вулиці холодно.","examples":["outside; in the street","На вулиці холодно."]},{"word":"сьогодні","translation":"today","pos":"adverb","example":"Сьогодні хмарно.","examples":["today","Сьогодні хмарно."]},{"word":"завтра","translation":"tomorrow","pos":"adverb","example":"Завтра буде тепло.","examples":["tomorrow","Завтра буде тепло."]},{"word":"вчора","translation":"yesterday","pos":"adverb","example":"Вчора було холодно.","examples":["yesterday","Вчора було холодно."]},{"word":"градус","translation":"degree","pos":"noun","example":"Плюс двадцять градусів.","examples":["degree","Плюс двадцять градусів."]},{"word":"плюс","translation":"plus","pos":"temperature word","example":"Сьогодні плюс двадцять.","examples":["plus","Сьогодні плюс двадцять."]},{"word":"мінус","translation":"minus","pos":"temperature word","example":"Сьогодні мінус десять.","examples":["minus","Сьогодні мінус десять."]},{"word":"гарний","translation":"good; beautiful","pos":"adjective","example":"Сьогодні гарна погода.","examples":["good; beautiful","Сьогодні гарна погода."]},{"word":"поганий","translation":"bad","pos":"adjective","example":"Сьогодні погана погода.","examples":["bad","Сьогодні погана погода."]},{"word":"теплий","translation":"warm","pos":"adjective","example":"Мені подобається теплий дощ.","examples":["warm","Мені подобається теплий дощ."]},{"word":"холодний","translation":"cold","pos":"adjective","example":"Холодний день.","examples":["cold","Холодний день."]},{"word":"зима","translation":"winter","pos":"noun","example":"Взимку холодно.","examples":["winter","Взимку холодно."]},{"word":"весна","translation":"spring","pos":"noun","example":"Навесні тепло.","examples":["spring","Навесні тепло."]},{"word":"літо","translation":"summer","pos":"noun","example":"Влітку спекотно.","examples":["summer","Влітку спекотно."]},{"word":"осінь","translation":"autumn; fall","pos":"noun","example":"Восени часто йде дощ.","examples":["autumn; fall","Восени часто йде дощ."]},{"word":"взимку","translation":"in winter","pos":"adverb","example":"Взимку іде сніг.","examples":["in winter","Взимку іде сніг."]},{"word":"навесні","translation":"in spring","pos":"adverb","example":"Навесні світить сонце.","examples":["in spring","Навесні світить сонце."]},{"word":"влітку","translation":"in summer","pos":"adverb","example":"Влітку тепло.","examples":["in summer","Влітку тепло."]},{"word":"восени","translation":"in autumn","pos":"adverb","example":"Восени хмарно.","examples":["in autumn","Восени хмарно."]},{"word":"Мені холодно.","translation":"I am cold.","pos":"state chunk","example":"Увечері мені холодно.","examples":["I am cold.","Увечері мені холодно."]},{"word":"Мені подобається...","translation":"I like...","pos":"preference chunk","example":"Мені подобається весна.","examples":["I like...","Мені подобається весна."]},{"word":"завірюха","translation":"snowstorm","pos":"passive noun","example":"Завірюха - зимове слово.","examples":["snowstorm","Завірюха - зимове слово."]},{"word":"віхола","translation":"snowstorm; blizzard","pos":"passive noun","example":"Віхола - зимове слово.","examples":["snowstorm; blizzard","Віхола - зимове слово."]},{"word":"сніговій","translation":"snowstorm","pos":"passive noun","example":"Сніговій - зимове слово.","examples":["snowstorm","Сніговій - зимове слово."]}]`)} title="Vocabulary" />
+
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"погода","back":"weather"},{"front":"тепло","back":"warm"},{"front":"холодно","back":"cold"},{"front":"сонячно","back":"sunny"},{"front":"хмарно","back":"cloudy"},{"front":"спекотно","back":"hot"},{"front":"прохолодно","back":"cool"},{"front":"дощ","back":"rain"},{"front":"сніг","back":"snow"},{"front":"сонце","back":"sun"},{"front":"вітер","back":"wind"},{"front":"мороз","back":"frost; freezing cold"},{"front":"опади","back":"precipitation"},{"front":"іде дощ","back":"it is raining"},{"front":"іде сніг","back":"it is snowing"},{"front":"дме вітер","back":"the wind is blowing"},{"front":"світить сонце","back":"the sun is shining"},{"front":"надворі","back":"outside; outdoors"},{"front":"на вулиці","back":"outside; in the street"},{"front":"сьогодні","back":"today"},{"front":"завтра","back":"tomorrow"},{"front":"вчора","back":"yesterday"},{"front":"градус","back":"degree"},{"front":"плюс","back":"plus"},{"front":"мінус","back":"minus"},{"front":"гарний","back":"good; beautiful"},{"front":"поганий","back":"bad"},{"front":"теплий","back":"warm"},{"front":"холодний","back":"cold"},{"front":"зима","back":"winter"},{"front":"весна","back":"spring"},{"front":"літо","back":"summer"},{"front":"осінь","back":"autumn; fall"},{"front":"взимку","back":"in winter"},{"front":"навесні","back":"in spring"},{"front":"влітку","back":"in summer"},{"front":"восени","back":"in autumn"},{"front":"Мені холодно.","back":"I am cold."},{"front":"Мені подобається...","back":"I like..."},{"front":"завірюха","back":"snowstorm"},{"front":"віхола","back":"snowstorm; blizzard"},{"front":"сніговій","back":"snowstorm"}]`)} />
+
+</TabItem>
+<TabItem label="Activities">
+
+### Weather line to real-world clue
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Іде дощ.", "right": "umbrella"}, {"left": "Іде сніг.", "right": "winter street"}, {"left": "Світить сонце.", "right": "sunglasses"}, {"left": "Дме вітер.", "right": "moving trees"}, {"left": "Мінус десять.", "right": "very cold"}, {"left": "Плюс тридцять.", "right": "very hot"}, {"left": "Сьогодні хмарно.", "right": "no visible sun"}, {"left": "Завтра буде тепло.", "right": "good day for a walk"}]`)} />
+
+### Window weather chunks
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Яка сьогодні погода? Сьогодні ___.", "answer": "холодно", "options": ["холодно", "холодний", "я холодно"]}, {"sentence": "Надворі ___. Сонця не видно.", "answer": "хмарно", "options": ["хмарно", "хмара", "хмарний погода"]}, {"sentence": "Зараз ___ дощ.", "answer": "іде", "options": ["іде", "є", "має"]}, {"sentence": "Завтра ___ тепло і сонячно.", "answer": "буде", "options": ["буде", "є", "має"]}, {"sentence": "Влітку дуже ___.", "answer": "спекотно", "options": ["спекотно", "спекотний", "жар"]}, {"sentence": "Увечері мені ___.", "answer": "холодно", "options": ["холодно", "холодний", "холод"]}]`)} />
+
+### Find the unsafe weather line
+
+<OddOneOut client:only='react' instruction={"Choose the line that does not fit the safe Ukrainian pattern."} items={JSON.parse(`[{"words": ["Сьогодні тепло.", "Надворі сонячно.", "Це є дуже сонячно.", "Завтра буде тепло."], "correct": 2, "explanation": "Do not copy English it is with це є for this weather line."}, {"words": ["Іде дощ.", "Іде сніг.", "Він іде дощ.", "Дме вітер."], "correct": 2, "explanation": "Rain does not need він."}, {"words": ["Мені холодно.", "Мені вдень було холодно.", "Я є холодно.", "На вулиці холодно."], "correct": 2, "explanation": "Use мені for a person's state."}, {"words": ["опади", "сніг", "дощ", "осадки"], "correct": 3, "explanation": "Use the Ukrainian weather noun опади."}]`)} />
+
+### Season weather shelves
+
+<GroupSort client:only='react' groups={JSON.parse(`{"ЗИМА": ["іде сніг", "мороз", "мінус десять", "холодно"], "Весна": ["тепло", "світить сонце", "іде дощ", "квітень"], "Літо": ["спекотно", "сонячно", "плюс тридцять", "липень"], "Осінь": ["прохолодно", "хмарно", "часто йде дощ", "листопад"]}`)} />
+
+### Weather pattern checks
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Холодно, тепло, сонячно, and хмарно can answer Яка погода?", "isTrue": true, "explanation": "They are safe state words for weather."}, {"statement": "Ukrainian needs це є before every weather state.", "isTrue": false, "explanation": "Say Сьогодні холодно or Надворі сонячно."}, {"statement": "Іде дощ is the safe A1 precipitation chunk.", "isTrue": true, "explanation": "It is the default spoken pattern for rain."}, {"statement": "Дощ падає зараз is the best first A1 weather line.", "isTrue": false, "explanation": "Learn Іде дощ first."}, {"statement": "Сніг and мороз naturally sort with ЗИМА in the first season map.", "isTrue": true, "explanation": "This is the basic weather-season link."}, {"statement": "Мені подобається теплий дощ is safer than Я подобаюсь теплий дощ.", "isTrue": true, "explanation": "Use Мені подобається... for likes."}]`)} />
+
+### Build weather notes
+
+<Translate client:only='react' questions={JSON.parse(`[]`)} />
+
+### Plan the walk after checking weather
+
+<Order client:only='react' items={JSON.parse(`["Яка сьогодні погода?", "Сьогодні холодно і йде дощ.", "А завтра?", "Завтра буде тепло і сонячно.", "Добре! Тоді завтра гуляємо."]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4]`)} instruction={"Put the dialogue in a logical order."} isUkrainian={false} />
+
+### Repair weather calques
+
+<ErrorCorrection client:only='react' instruction="Choose the safe Ukrainian repair." items={JSON.parse(`[{"sentence": "Це є дуже сонячно.", "errorWord": "Це є", "correctForm": "Надворі сонячно.", "options": ["Надворі сонячно.", "Це є дуже сонячно.", "Сонячний є надворі."], "explanation": "Weather states can stand without це є."}, {"sentence": "Він іде дощ.", "errorWord": "Він", "correctForm": "Зараз іде дощ.", "options": ["Зараз іде дощ.", "Він іде дощ.", "Дощ має іти."], "explanation": "Rain does not take він."}, {"sentence": "Я є холодно.", "errorWord": "Я є", "correctForm": "Мені холодно.", "options": ["Мені холодно.", "Я є холодно.", "Я маю холодно."], "explanation": "Use мені for a person's state."}, {"sentence": "Сьогодні погода є добре.", "errorWord": "добре", "correctForm": "Сьогодні гарна погода.", "options": ["Сьогодні гарна погода.", "Сьогодні погода є добре.", "Сьогодні добрий погода."], "explanation": "Погода is feminine, so use гарна."}, {"sentence": "Я подобаюсь теплий дощ.", "errorWord": "Я подобаюсь", "correctForm": "Мені подобається теплий дощ.", "options": ["Мені подобається теплий дощ.", "Я подобаюсь теплий дощ.", "Я є люблю теплий дощ."], "explanation": "Use Мені подобається... for likes."}]`)} />
+
+</TabItem>
+<TabItem label="Resources">
+
+:::info[🎧 🔗 External Resources]
+
+**📝 Articles:**
+- 📄 [Dative Pronouns and Подобатися](https://opentext.ku.edu/dobraforma/chapter/15-1/) — Follow-up grammar reference for chunks such as Мені подобається and dative state patterns.
+- 📄 [Weather in Ukrainian](https://www.ukrainianlessons.com/weather-vocabulary/) — Learner-safe weather vocabulary list with common Ukrainian weather phrases.
+:::
+
+</TabItem>
+</Tabs>
+
+<HashTabSync />


### PR DESCRIPTION
Small stacked PR extracted from the closed A1 umbrella branch. Review this PR against its immediate base, not against main unless this is the runtime base PR.

Stack target:
- Base: codex/a1-stack-m23-days-and-months
- Head: codex/a1-stack-m24-weather
- Commit: 5e71e7ea5342d65c8785cc69f0fe4fcc737f587c

Validation already run on the extracted stack:
- Per-commit hooks passed during extraction.
- Final stack: `git diff --check origin/main...HEAD` passed.
- Final stack: `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed for all 56 commits.
- Final stack: `npm --prefix starlight run build` passed after `npm --prefix starlight ci`.
- M52-M55 browser smoke passed: routes loaded with HTTP 200 and no console errors.

Review focus:
- bounded diff correctness against the base branch
- generated-artifact hygiene: no `status/*.json`, `audit/*-review.md`, or `review/*-review.md`
- plan snapshot correctness where this PR includes a required `.yaml.bak`
- merge safety for the stacked A1 sequence

Existing A1 audit and LLM audit remain evidence, but they are not a replacement for this PR-level review.