### PR TITLE
feat(a1): add M34 where from module

### DIFF
--- a/curriculum/l2-uk-en/a1/where-from/activities.yaml
+++ b/curriculum/l2-uk-en/a1/where-from/activities.yaml
@@ -1,0 +1,273 @@
+- id: act-1
+  type: group-sort
+  title: Three place questions
+  instruction: Sort each chunk by the question it answers.
+  groups:
+    - name: "Де?"
+      items:
+        - "в Україні"
+        - "у Києві"
+        - "на роботі"
+        - "у школі"
+    - name: "Куди?"
+      items:
+        - "в Україну"
+        - "у Київ"
+        - "на роботу"
+        - "у школу"
+    - name: "Звідки?"
+      items:
+        - "з України"
+        - "з Києва"
+        - "з роботи"
+        - "зі школи"
+- id: act-2
+  type: quiz
+  title: Origin or current home
+  instruction: Choose the phrase that fits the question.
+  items:
+    - prompt: "Звідки ти?"
+      options:
+        - text: "Я з України."
+          correct: true
+        - text: "Я в Україні."
+          correct: false
+        - text: "Я в Україну."
+          correct: false
+      explanation: "Звідки? asks for origin or source: з України."
+    - prompt: "Де ти зараз живеш?"
+      options:
+        - text: "У Києві."
+          correct: true
+        - text: "У Київ."
+          correct: false
+        - text: "З Києва."
+          correct: false
+      explanation: "Де? asks for static location: у Києві."
+    - prompt: "Куди ти їдеш?"
+      options:
+        - text: "В Україну."
+          correct: true
+        - text: "В Україні."
+          correct: false
+        - text: "З України."
+          correct: false
+      explanation: "Куди? asks for destination: в Україну."
+    - prompt: "З якого міста Олена?"
+      options:
+        - text: "Вона зі Львова."
+          correct: true
+        - text: "Вона у Львові."
+          correct: false
+        - text: "Вона у Львів."
+          correct: false
+      explanation: "Origin from Lviv is зі Львова."
+    - prompt: "Звідки Марко йде?"
+      options:
+        - text: "З роботи."
+          correct: true
+        - text: "На роботу."
+          correct: false
+        - text: "На роботі."
+          correct: false
+      explanation: "Coming from work uses з роботи."
+    - prompt: "Де Анна навчається?"
+      options:
+        - text: "У школі."
+          correct: true
+        - text: "Зі школи."
+          correct: false
+        - text: "У школу."
+          correct: false
+      explanation: "A static study place answers де?"
+- id: act-3
+  type: fill-in
+  title: Student badge origins
+  instruction: Complete each badge line with the safe from-place chunk.
+  items:
+    - sentence: "Звідки ти? — Я ___."
+      answer: "з України"
+      options:
+        - "з України"
+        - "в Україну"
+        - "в Україні"
+      explanation: "Origin uses з України."
+    - sentence: "Анна ___."
+      answer: "з Канади"
+      options:
+        - "з Канади"
+        - "в Канаді"
+        - "у Канаду"
+      explanation: "Country origin uses з + from-place form."
+    - sentence: "Ми ___, а ви?"
+      answer: "з Києва"
+      options:
+        - "з Києва"
+        - "у Києві"
+        - "у Київ"
+      explanation: "Kyiv changes to з Києва."
+    - sentence: "Джон ___."
+      answer: "зі США"
+      options:
+        - "зі США"
+        - "з США"
+        - "у США"
+      explanation: "Use зі США for easier pronunciation."
+    - sentence: "Мій друг ___."
+      answer: "з Німеччини"
+      options:
+        - "з Німеччини"
+        - "у Німеччину"
+        - "в Німеччині"
+      explanation: "Звідки? uses з Німеччини."
+    - sentence: "Олена живе в Києві, але вона ___."
+      answer: "зі Львова"
+      options:
+        - "зі Львова"
+        - "у Львові"
+        - "до Львова"
+      explanation: "Origin from Lviv is зі Львова."
+- id: act-4
+  type: match-up
+  title: Base name to from-place form
+  instruction: Match each base place name with the chunk that answers Звідки?
+  pairs:
+    - left: "Україна"
+      right: "з України"
+    - left: "Канада"
+      right: "з Канади"
+    - left: "Київ"
+      right: "з Києва"
+    - left: "Львів"
+      right: "зі Львова"
+    - left: "Одеса"
+      right: "з Одеси"
+    - left: "Харків"
+      right: "з Харкова"
+    - left: "США"
+      right: "зі США"
+    - left: "школа"
+      right: "зі школи"
+- id: act-5
+  type: order
+  title: International meet-up
+  instruction: Put the introduction exchange in a natural order.
+  is_ukrainian: true
+  items:
+    - "Добрий день! Мене звати Анна."
+    - "Дуже приємно. Мене звати Марко."
+    - "Звідки ти, Анно?"
+    - "Я з Канади, із Торонто. А ти?"
+    - "Я з України, з Києва."
+    - "Чудово. Говорімо українською."
+  correct_order: [0, 1, 2, 3, 4, 5]
+- id: act-6
+  type: true-false
+  title: Toponym and identity guardrails
+  instruction: Decide whether the statement fits this lesson.
+  items:
+    - statement: "Україна, Київ, Львів, and Канада are proper names and use capital letters."
+      correct: true
+      explanation: "Country and city names are proper names."
+    - statement: "Я з Києва is the safe answer to Звідки ти?"
+      correct: true
+      explanation: "Київ changes to Києва after з."
+    - statement: "Я є з України is the natural A1 identity line."
+      correct: false
+      explanation: "Say Я з України without є."
+    - statement: "Вона львів'янка matches a woman from Lviv."
+      correct: true
+      explanation: "Use the feminine demonym."
+    - statement: "Kiev is the course English spelling for Київ."
+      correct: false
+      explanation: "Use Kyiv / Київ."
+    - statement: "Зі США is easier and safer than з США."
+      correct: true
+      explanation: "Зі avoids a hard consonant cluster."
+- id: act-7
+  type: odd-one-out
+  title: Find the from-place mismatch
+  instruction: Choose the line that does not fit the pattern.
+  items:
+    - words:
+        - "з України"
+        - "з Канади"
+        - "з Києва"
+        - "у Києві"
+      answer: "у Києві"
+      explanation: "У Києві answers де?, not звідки?"
+    - words:
+        - "в Україну"
+        - "у Київ"
+        - "на роботу"
+        - "з роботи"
+      answer: "з роботи"
+      explanation: "З роботи answers звідки?, not куди?"
+    - words:
+        - "українець"
+        - "українка"
+        - "киянин"
+        - "з України"
+      answer: "з України"
+      explanation: "The first three name people; з України names origin."
+    - words:
+        - "Kyiv"
+        - "Lviv"
+        - "Odesa"
+        - "Odessa"
+      answer: "Odessa"
+      explanation: "Use Odesa for the Ukrainian city name in English."
+- id: act-8
+  type: error-correction
+  title: Repair where-from interference
+  instruction: Choose the natural Ukrainian repair.
+  anchor_id: repair-where-from-interference
+  items:
+    - sentence: "Я з Київ."
+      error: "з Київ"
+      answer: "Я з Києва."
+      options:
+        - "Я з Києва."
+        - "Я з Київ."
+        - "Я в Києва."
+      explanation: "Звідки? uses the from-place form Києва."
+    - sentence: "Я є з України."
+      error: "є"
+      answer: "Я з України."
+      options:
+        - "Я з України."
+        - "Я є з України."
+        - "Я маю з України."
+      explanation: "Drop є in this present identity line."
+    - sentence: "Він живе в Київ."
+      error: "в Київ"
+      answer: "Він живе в Києві."
+      options:
+        - "Він живе в Києві."
+        - "Він живе в Київ."
+        - "Він живе з Києва."
+      explanation: "Живе answers де?, so use в Києві."
+    - sentence: "Вона львів'янин."
+      error: "львів'янин"
+      answer: "Вона львів'янка."
+      options:
+        - "Вона львів'янка."
+        - "Вона львів'янин."
+        - "Вона з львів'янин."
+      explanation: "Use the feminine demonym for вона."
+    - sentence: "Я з США. (Вимова: з-США)"
+      error: "з США"
+      answer: "Я зі США."
+      options:
+        - "Я зі США."
+        - "Я з США."
+        - "Я в США."
+      explanation: "Use зі before США."
+    - sentence: "Я з місто Львів."
+      error: "з місто Львів"
+      answer: "Я зі Львова. (або Я з міста Львова)"
+      options:
+        - "Я зі Львова. (або Я з міста Львова)"
+        - "Я зі Львова."
+        - "Я з місто Львів."
+      explanation: "In speech, say the city name in the from-place form."

--- a/curriculum/l2-uk-en/a1/where-from/module.md
+++ b/curriculum/l2-uk-en/a1/where-from/module.md
@@ -1,0 +1,201 @@
+# Звідки?
+
+This lesson completes your first city-place triangle. You already know how to
+say where you are: **Я в Україні**, **я у Києві**, **Олена на роботі**. You
+also know where you are going: **Я їду в Україну**, **я йду в банк**, **Олена
+йде на роботу**. Now you can answer **звідки?**: **Я з України**, **я з
+Києва**, **Олена йде з роботи**.
+
+By the end, you can:
+
+- ask **Звідки ти?**, **Звідки ви?**, and **З якого міста?**;
+- answer with **з/із/зі + родовий відмінок** as learned chunks;
+- contrast **де?**, **куди?**, and **звідки?** without mixing endings;
+- name common countries and Ukrainian cities;
+- connect origin with identity: **я з України**, **я українець/українка**,
+  **я говорю українською**.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+## Діалоги
+
+The first dialogue is an international student meeting in Kyiv. Listen for the
+question **звідки?** and the short answer **я з...**
+
+<DialogueBox uk="Марко: Добрий день! Мене звати Марко. А тебе?" en="Marko: Good afternoon! My name is Marko. And you?" />
+<DialogueBox uk="Анна: Мене звати Анна. Дуже приємно." en="Anna: My name is Anna. Nice to meet you." />
+<DialogueBox uk="Марко: Звідки ти?" en="Marko: Where are you from?" />
+<DialogueBox uk="Анна: Я з Канади, із Торонто. А ти?" en="Anna: I am from Canada, from Toronto. And you?" />
+<DialogueBox uk="Марко: Я з України, з Києва." en="Marko: I am from Ukraine, from Kyiv." />
+<DialogueBox uk="Анна: Ти говориш українською?" en="Anna: Do you speak Ukrainian?" />
+<DialogueBox uk="Марко: Так. Я українець і говорю українською." en="Marko: Yes. I am Ukrainian and I speak Ukrainian." />
+
+**Канонічні фрази ідентифікації.** Keep the first answer short. Ukrainian does
+not need **є** in the present-tense identity line: **Я з України**, not **Я є з
+України**. The phrase works as one useful block: **Звідки ти? — Я з...** Add
+the city only after the country: **Я з України, з Києва. Я з Канади, із
+Торонто.**
+
+The second dialogue is about movement away from a place.
+
+<DialogueBox uk="Оксана: Звідки ти йдеш?" en="Oksana: Where are you coming from?" />
+<DialogueBox uk="Степан: Я йду з роботи. А ти?" en="Stepan: I am coming from work. And you?" />
+<DialogueBox uk="Оксана: Я йду зі школи, а потім іду додому." en="Oksana: I am coming from school, and then I am going home." />
+<DialogueBox uk="Степан: А Олена?" en="Stepan: And Olena?" />
+<DialogueBox uk="Оксана: Вона йде з магазину. Потім їде в центр." en="Oksana: She is coming from the shop. Then she is going to the center." />
+<DialogueBox uk="Степан: Добре. До зустрічі!" en="Stepan: Good. See you!" />
+
+Use one mental map. **Де?** asks about static location. **Куди?** asks about
+the destination. **Звідки?** asks about the source or origin.
+
+| Question | Meaning | Pattern | Example |
+| --- | --- | --- | --- |
+| **Де?** | where you are | **в/у/на + місцевий** | **Я в Україні.** |
+| **Куди?** | where you go | **в/у/на + знахідний** | **Я їду в Україну.** |
+| **Звідки?** | where from | **з/із/зі + родовий** | **Я з України.** |
+
+<!-- INJECT_ACTIVITY: act-2 -->
+
+## Звідки?
+
+**Загальні назви та капіталізація власних назв.** Start with the basic
+geography words **місто**, **країна**, **вулиця**, **село**, and **столиця**.
+They are common nouns and normally begin with a lowercase letter. Specific
+names are different: **Україна**, **Київ**, **Львів**, **Харків**, **Одеса**,
+**Дніпро**, **Канада**, **Польща**, **Японія**. These are proper names, so they
+begin with a capital letter.
+
+**Родовий відмінок (Genitive Case).** For A1, learn **з/із/зі + родовий
+відмінок** as practical chunks. The grammar name is **родовий відмінок**, but
+you do not need a full A2 table yet. The visible pattern is simple: typical
+masculine place names often add **-а/-я**, while many feminine country and city
+names use **-и/-і**. You need these forms now:
+
+| Base name | From-place chunk |
+| --- | --- |
+| Україна | **з України** |
+| Канада | **з Канади** |
+| Польща | **з Польщі** |
+| Німеччина | **з Німеччини** |
+| Англія | **з Англії** |
+| Київ | **з Києва** |
+| Львів | **зі Львова** |
+| Одеса | **з Одеси** |
+| Харків | **з Харкова** |
+| робота | **з роботи** |
+| школа | **зі школи** |
+| магазин | **з магазину** |
+
+**З/із/зі and euphony.** The choice is not random. Use what is easiest to
+pronounce. **З України**, **з Канади**, and **з Одеси** are light. **Із
+Торонто** is comfortable after a consonant-heavy phrase. **Зі США**, **зі
+Львова**, and **зі школи** avoid a hard cluster. This connects directly to the
+Ukrainian **милозвучність** you practiced in M28.
+
+**Фонетичні чергування голосних у топонімах.** Some Ukrainian city names change
+inside the stem when the ending is added. Names such as **Київ**, **Львів**,
+**Харків**, and **Тернопіль** end with a closed syllable that learners notice
+quickly. The important A1 forms are **Київ -> Києва** and **Львів ->
+Львова**. The closed syllable with **і** opens and the vowel alternates: **і**
+becomes **є** in **Києва** and **о** in **Львова**. Treat this as a normal
+Ukrainian pattern, not as an exception explained through another language.
+
+<!-- INJECT_ACTIVITY: act-3 -->
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+## Країни і міста
+
+Here is a compact origin set for real introductions:
+
+| Country | From | Person |
+| --- | --- | --- |
+| **Україна** | **з України** | **українець / українка** |
+| **Канада** | **з Канади** | **канадець / канадка** |
+| **Польща** | **з Польщі** | **поляк / полька** |
+| **Німеччина** | **з Німеччини** | **німець / німкеня** |
+| **Франція** | **з Франції** | **француз / француженка** |
+| **Італія** | **з Італії** | **італієць / італійка** |
+| **Японія** | **з Японії** | **японець / японка** |
+| **США** | **зі США** | **американець / американка** |
+
+**Демоніми та ідентичність.** A demonym names a person by place. Use masculine
+and feminine forms as pairs: **українець / українка**, **киянин / киянка**,
+**львів'янин / львів'янка**, **харків'янин / харків'янка**, **одесит /
+одеситка**. Match the form to the person and keep the **чоловічий/жіночий**
+contrast visible: **Він киянин. Вона киянка. Вона львів'янка**, not **вона
+львів'янин**.
+
+You can now separate current home and origin:
+
+- **Я живу в Києві, але я зі Львова.**
+- **Вона живе в Канаді, але вона з України.**
+- **Ми зараз в Україні, але ми з Польщі.**
+- **Він живе в Одесі, але він з Харкова.**
+- **Я з Німеччини, але зараз я в Україні.**
+
+:::tip
+Ask the question first. **Де?** keeps you in the place, **куди?** sends you to
+the place, and **звідки?** brings you from the place.
+:::
+
+**Орієнтація на мапі (напрямки).** For a first map description, keep four
+adjectives: **північний**, **південний**, **західний**, **східний**. Say
+**західна Україна**, **східна Україна**, **південне місто**, **північний
+район**. This is enough to say **Львів — це місто на заході України** and
+**Харків — це місто на сході України** without adding a geography lecture.
+
+Keep the toponyms Ukrainian. In English, use **Kyiv**, **Lviv**, **Kharkiv**,
+and **Odesa**. The Russian-imperial spellings **Kiev**, **Lvov**, **Kharkov**,
+and **Odessa** are not course forms. In Ukrainian, use **Київ**, **Львів**,
+**Харків**, **Одеса**, **Дніпро**, and write them with a capital letter.
+
+<!-- INJECT_ACTIVITY: act-5 -->
+
+<!-- INJECT_ACTIVITY: act-6 -->
+
+<span id="підсумок"></span>
+
+## Підсумок
+
+Use the three-question grid as your checkpoint:
+
+| Need | Question | Safe answer |
+| --- | --- | --- |
+| current place | **Де ти?** | **Я в Україні. Я у Києві. Я на роботі.** |
+| destination | **Куди ти йдеш/їдеш?** | **В Україну. У Київ. На роботу.** |
+| origin/source | **Звідки ти? Звідки йдеш?** | **З України. З Києва. З роботи.** |
+
+Common repairs:
+
+| Learner line | Better line | Why |
+| --- | --- | --- |
+| Я з Київ. | **Я з Києва.** | **З** needs the from-place form. |
+| Я є з України. | **Я з України.** | Drop **є** in this present identity line. |
+| Він живе в Київ. | **Він живе в Києві.** | **Де?** needs the locative chunk. |
+| Вона львів'янин. | **Вона львів'янка.** | Demonyms match gender. |
+| Я з США. | **Я зі США.** | Use **зі** before this cluster. |
+| Я з місто Львів. | **Я зі Львова.** | In speech, use the city name in the from-form. |
+
+Self-check:
+
+1. Ask a new student where they are from: **Звідки ти?**
+2. Give your country and city: **Я з Канади, із Торонто.**
+3. Contrast home and origin: **Я живу в Києві, але я зі Львова.**
+4. Say a demonym pair: **українець / українка**, **киянин / киянка**.
+5. Repair one trap: **Я з Києва**, not **я з Київ**.
+
+Final introduction:
+
+**Добрий день! Мене звати Анна. Я з Канади, із Торонто. Зараз я живу в Києві
+і вчу українську. Мій друг Марко з України, з Києва. Олена живе в Києві, але
+вона зі Львова. Ми говоримо українською.**
+
+Now change only the origin pieces: **з України**, **з Канади**, **з Польщі**,
+**з Німеччини**, **зі США**, **з Києва**, **зі Львова**, **з Одеси**. If
+**де?**, **куди?**, and **звідки?** stay separate while you change names, the
+place system is ready for the checkpoint.
+
+<!-- INJECT_ACTIVITY: act-7 -->
+
+<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/where-from/resources.yaml
+++ b/curriculum/l2-uk-en/a1/where-from/resources.yaml
@@ -1,0 +1,20 @@
+- title: "ULP Season 1, Episode 4"
+  role: listening lesson
+  source_ref: "ukrainianlessons.com"
+  url: https://www.ukrainianlessons.com/episode4/
+  notes: "Reachable beginner listening lesson with Звідки ви?, countries, and origin introductions."
+- title: "Ukrainian Course: Nouns in the Genitive Case"
+  role: grammar table
+  source_ref: "ukrainiancourse.com"
+  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/
+  notes: "Reachable grammar table for the genitive forms behind з/із/зі chunks."
+- title: "Ukrainian Language: Unit 10, Page 1"
+  role: reading unit
+  source_ref: "ukrainianlanguage.uk"
+  url: https://ukrainianlanguage.uk/read/unit10/page10-1.htm
+  notes: "Reachable beginner reading page connected to city and place vocabulary."
+- title: "Ukrainian Language: Unit 10, Page 2"
+  role: reading unit
+  source_ref: "ukrainianlanguage.uk"
+  url: https://ukrainianlanguage.uk/read/unit10/page10-2.htm
+  notes: "Reachable follow-up city/place reading page for practicing place contrasts."

--- a/curriculum/l2-uk-en/a1/where-from/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/where-from/vocabulary.yaml
@@ -1,0 +1,168 @@
+- word: звідки
+  translation: where from
+  pos: adverb
+  example: "Звідки ти?"
+- word: з
+  translation: from
+  pos: preposition
+  example: "Я з України."
+- word: із
+  translation: from
+  pos: preposition
+  example: "Анна із Торонто."
+- word: зі
+  translation: from
+  pos: preposition
+  example: "Я зі Львова."
+- word: Україна
+  translation: Ukraine
+  pos: proper noun
+  example: "Я з України."
+- word: Київ
+  translation: Kyiv
+  pos: proper noun
+  example: "Марко з Києва."
+- word: Львів
+  translation: Lviv
+  pos: proper noun
+  example: "Олена зі Львова."
+- word: Одеса
+  translation: Odesa
+  pos: proper noun
+  example: "Я з Одеси."
+- word: Харків
+  translation: Kharkiv
+  pos: proper noun
+  example: "Він з Харкова."
+- word: Дніпро
+  translation: Dnipro
+  pos: proper noun
+  example: "Дніпро — велике місто."
+- word: Канада
+  translation: Canada
+  pos: proper noun
+  example: "Анна з Канади."
+- word: США
+  translation: USA
+  pos: proper noun
+  example: "Джон зі США."
+- word: Англія
+  translation: England
+  pos: proper noun
+  example: "Вони з Англії."
+- word: Німеччина
+  translation: Germany
+  pos: proper noun
+  example: "Мій друг з Німеччини."
+- word: Польща
+  translation: Poland
+  pos: proper noun
+  example: "Ми з Польщі."
+- word: Франція
+  translation: France
+  pos: proper noun
+  example: "Марі з Франції."
+- word: Італія
+  translation: Italy
+  pos: proper noun
+  example: "Лука з Італії."
+- word: Японія
+  translation: Japan
+  pos: proper noun
+  example: "Юкі з Японії."
+- word: місто
+  translation: city; town
+  pos: noun
+  example: "Київ — місто."
+- word: країна
+  translation: country
+  pos: noun
+  example: "Україна — країна."
+- word: столиця
+  translation: capital city
+  pos: noun
+  example: "Київ — столиця України."
+- word: вулиця
+  translation: street
+  pos: noun
+  example: "Вулиця Хрещатик у Києві."
+- word: площа
+  translation: square
+  pos: noun
+  example: "Соборна площа в центрі."
+- word: село
+  translation: village
+  pos: noun
+  example: "Це маленьке село."
+- word: адреса
+  translation: address
+  pos: noun
+  example: "Моя адреса в Києві."
+- word: українець
+  translation: Ukrainian man
+  pos: noun
+  example: "Він українець."
+- word: українка
+  translation: Ukrainian woman
+  pos: noun
+  example: "Вона українка."
+- word: киянин
+  translation: man from Kyiv
+  pos: noun
+  example: "Марко киянин."
+- word: киянка
+  translation: woman from Kyiv
+  pos: noun
+  example: "Оксана киянка."
+- word: львів'янин
+  translation: man from Lviv
+  pos: noun
+  example: "Тарас львів'янин."
+- word: львів'янка
+  translation: woman from Lviv
+  pos: noun
+  example: "Олена львів'янка."
+- word: харків'янин
+  translation: man from Kharkiv
+  pos: noun
+  example: "Сергій харків'янин."
+- word: харків'янка
+  translation: woman from Kharkiv
+  pos: noun
+  example: "Ірина харків'янка."
+- word: одесит
+  translation: man from Odesa
+  pos: noun
+  example: "Він одесит."
+- word: одеситка
+  translation: woman from Odesa
+  pos: noun
+  example: "Вона одеситка."
+- word: жити
+  translation: to live
+  pos: verb
+  example: "Я живу в Києві."
+- word: мандрувати
+  translation: to travel
+  pos: verb
+  example: "Ми мандруємо Україною."
+- word: північний
+  translation: northern
+  pos: adjective
+  example: "Це північний район."
+- word: південний
+  translation: southern
+  pos: adjective
+  example: "Одеса — південне місто."
+- word: західний
+  translation: western
+  pos: adjective
+  example: "Львів — західне місто."
+- word: східний
+  translation: eastern
+  pos: adjective
+  example: "Харків — східне місто."
+- word: додому
+  translation: homeward; home
+  pos: adverb
+  example: "Після школи я йду додому."

--- a/starlight/src/content/docs/a1/where-from.mdx
+++ b/starlight/src/content/docs/a1/where-from.mdx
@@ -1,0 +1,338 @@
+---
+title: "Звідки?"
+description: "Звідки ти? Я з України — походження та напрямки"
+sidebar:
+  order: 34
+  label: "34. Звідки?"
+pipeline: linear-phase-4
+build_status: validated
+prev: around-the-city
+next: false
+---
+
+import Quiz from '@site/src/components/Quiz';
+import MatchUp from '@site/src/components/MatchUp';
+import FillIn from '@site/src/components/FillIn';
+import TrueFalse from '@site/src/components/TrueFalse';
+import Unjumble from '@site/src/components/Unjumble';
+import GroupSort from '@site/src/components/GroupSort';
+import Anagram from '@site/src/components/Anagram';
+import ErrorCorrection, { ErrorCorrectionItem } from '@site/src/components/ErrorCorrection';
+import Cloze from '@site/src/components/Cloze';
+import Select from '@site/src/components/Select';
+import Translate from '@site/src/components/Translate';
+import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
+import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import EssayResponse from '@site/src/components/EssayResponse';
+import ComparativeStudy from '@site/src/components/ComparativeStudy';
+import ReadingActivity from '@site/src/components/ReadingActivity';
+import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
+import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import SourceEvaluation from '@site/src/components/SourceEvaluation';
+import Debate from '@site/src/components/Debate';
+import EtymologyTrace from '@site/src/components/EtymologyTrace';
+import GrammarIdentify from '@site/src/components/GrammarIdentify';
+import PaleographyAnalysis from '@site/src/components/PaleographyAnalysis';
+import DialectComparison from '@site/src/components/DialectComparison';
+import TranslationCritique from '@site/src/components/TranslationCritique';
+import Transcription from '@site/src/components/Transcription';
+import Observe from '@site/src/components/Observe';
+import Order from '@site/src/components/Order';
+import CountSyllables from '@site/src/components/CountSyllables';
+import DivideWords from '@site/src/components/DivideWords';
+import OddOneOut from '@site/src/components/OddOneOut';
+import PickSyllables from '@site/src/components/PickSyllables';
+import LetterGrid from '@site/src/components/LetterGrid';
+import FlashcardDeck from '@site/src/components/FlashcardDeck';
+import VocabCard from '@site/src/components/VocabCard';
+import DialogueBox from '@site/src/components/DialogueBox';
+import HashTabSync from '@site/src/components/HashTabSync';
+import ActivityHelp from '@site/src/components/ActivityHelp';
+import YouTubeVideo from '@site/src/components/YouTubeVideo';
+import WatchAndRepeat from '@site/src/components/WatchAndRepeat';
+import Classify from '@site/src/components/Classify';
+import ImageToLetter from '@site/src/components/ImageToLetter';
+import ActivityPlaceholder from '@site/src/components/ActivityPlaceholder';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs syncKey="module-tab">
+<TabItem label="Lesson">
+
+This lesson completes your first city-place triangle. You already know how to
+say where you are: **Я в Україні**, **я у Києві**, **Олена на роботі**. You
+also know where you are going: **Я їду в Україну**, **я йду в банк**, **Олена
+йде на роботу**. Now you can answer **звідки?**: **Я з України**, **я з
+Києва**, **Олена йде з роботи**.
+
+By the end, you can:
+
+- ask **Звідки ти?**, **Звідки ви?**, and **З якого міста?**;
+- answer with **з/із/зі + родовий відмінок** as learned chunks;
+- contrast **де?**, **куди?**, and **звідки?** without mixing endings;
+- name common countries and Ukrainian cities;
+- connect origin with identity: **я з України**, **я українець/українка**,
+  **я говорю українською**.
+
+### Three place questions
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Де?": ["в Україні", "у Києві", "на роботі", "у школі"], "Куди?": ["в Україну", "у Київ", "на роботу", "у школу"], "Звідки?": ["з України", "з Києва", "з роботи", "зі школи"]}`)} />
+
+## Діалоги
+
+The first dialogue is an international student meeting in Kyiv. Listen for the
+question **звідки?** and the short answer **я з...**
+
+<DialogueBox uk="Марко: Добрий день! Мене звати Марко. А тебе?" en="Marko: Good afternoon! My name is Marko. And you?" />
+<DialogueBox uk="Анна: Мене звати Анна. Дуже приємно." en="Anna: My name is Anna. Nice to meet you." />
+<DialogueBox uk="Марко: Звідки ти?" en="Marko: Where are you from?" />
+<DialogueBox uk="Анна: Я з Канади, із Торонто. А ти?" en="Anna: I am from Canada, from Toronto. And you?" />
+<DialogueBox uk="Марко: Я з України, з Києва." en="Marko: I am from Ukraine, from Kyiv." />
+<DialogueBox uk="Анна: Ти говориш українською?" en="Anna: Do you speak Ukrainian?" />
+<DialogueBox uk="Марко: Так. Я українець і говорю українською." en="Marko: Yes. I am Ukrainian and I speak Ukrainian." />
+
+**Канонічні фрази ідентифікації.** Keep the first answer short. Ukrainian does
+not need **є** in the present-tense identity line: **Я з України**, not **Я є з
+України**. The phrase works as one useful block: **Звідки ти? — Я з...** Add
+the city only after the country: **Я з України, з Києва. Я з Канади, із
+Торонто.**
+
+The second dialogue is about movement away from a place.
+
+<DialogueBox uk="Оксана: Звідки ти йдеш?" en="Oksana: Where are you coming from?" />
+<DialogueBox uk="Степан: Я йду з роботи. А ти?" en="Stepan: I am coming from work. And you?" />
+<DialogueBox uk="Оксана: Я йду зі школи, а потім іду додому." en="Oksana: I am coming from school, and then I am going home." />
+<DialogueBox uk="Степан: А Олена?" en="Stepan: And Olena?" />
+<DialogueBox uk="Оксана: Вона йде з магазину. Потім їде в центр." en="Oksana: She is coming from the shop. Then she is going to the center." />
+<DialogueBox uk="Степан: Добре. До зустрічі!" en="Stepan: Good. See you!" />
+
+Use one mental map. **Де?** asks about static location. **Куди?** asks about
+the destination. **Звідки?** asks about the source or origin.
+
+| Question | Meaning | Pattern | Example |
+| --- | --- | --- | --- |
+| **Де?** | where you are | **в/у/на + місцевий** | **Я в Україні.** |
+| **Куди?** | where you go | **в/у/на + знахідний** | **Я їду в Україну.** |
+| **Звідки?** | where from | **з/із/зі + родовий** | **Я з України.** |
+
+### Origin or current home
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Звідки ти?", "options": [{"text": "Я з України.", "correct": true}, {"text": "Я в Україні.", "correct": false}, {"text": "Я в Україну.", "correct": false}], "explanation": "Звідки? asks for origin or source: з України."}, {"question": "Де ти зараз живеш?", "options": [{"text": "У Києві.", "correct": true}, {"text": "У Київ.", "correct": false}, {"text": "З Києва.", "correct": false}], "explanation": "Де? asks for static location: у Києві."}, {"question": "Куди ти їдеш?", "options": [{"text": "В Україну.", "correct": true}, {"text": "В Україні.", "correct": false}, {"text": "З України.", "correct": false}], "explanation": "Куди? asks for destination: в Україну."}, {"question": "З якого міста Олена?", "options": [{"text": "Вона зі Львова.", "correct": true}, {"text": "Вона у Львові.", "correct": false}, {"text": "Вона у Львів.", "correct": false}], "explanation": "Origin from Lviv is зі Львова."}, {"question": "Звідки Марко йде?", "options": [{"text": "З роботи.", "correct": true}, {"text": "На роботу.", "correct": false}, {"text": "На роботі.", "correct": false}], "explanation": "Coming from work uses з роботи."}, {"question": "Де Анна навчається?", "options": [{"text": "У школі.", "correct": true}, {"text": "Зі школи.", "correct": false}, {"text": "У школу.", "correct": false}], "explanation": "A static study place answers де?"}]`)} />
+
+## Звідки?
+
+**Загальні назви та капіталізація власних назв.** Start with the basic
+geography words **місто**, **країна**, **вулиця**, **село**, and **столиця**.
+They are common nouns and normally begin with a lowercase letter. Specific
+names are different: **Україна**, **Київ**, **Львів**, **Харків**, **Одеса**,
+**Дніпро**, **Канада**, **Польща**, **Японія**. These are proper names, so they
+begin with a capital letter.
+
+**Родовий відмінок (Genitive Case).** For A1, learn **з/із/зі + родовий
+відмінок** as practical chunks. The grammar name is **родовий відмінок**, but
+you do not need a full A2 table yet. The visible pattern is simple: typical
+masculine place names often add **-а/-я**, while many feminine country and city
+names use **-и/-і**. You need these forms now:
+
+| Base name | From-place chunk |
+| --- | --- |
+| Україна | **з України** |
+| Канада | **з Канади** |
+| Польща | **з Польщі** |
+| Німеччина | **з Німеччини** |
+| Англія | **з Англії** |
+| Київ | **з Києва** |
+| Львів | **зі Львова** |
+| Одеса | **з Одеси** |
+| Харків | **з Харкова** |
+| робота | **з роботи** |
+| школа | **зі школи** |
+| магазин | **з магазину** |
+
+**З/із/зі and euphony.** The choice is not random. Use what is easiest to
+pronounce. **З України**, **з Канади**, and **з Одеси** are light. **Із
+Торонто** is comfortable after a consonant-heavy phrase. **Зі США**, **зі
+Львова**, and **зі школи** avoid a hard cluster. This connects directly to the
+Ukrainian **милозвучність** you practiced in M28.
+
+**Фонетичні чергування голосних у топонімах.** Some Ukrainian city names change
+inside the stem when the ending is added. Names such as **Київ**, **Львів**,
+**Харків**, and **Тернопіль** end with a closed syllable that learners notice
+quickly. The important A1 forms are **Київ -> Києва** and **Львів ->
+Львова**. The closed syllable with **і** opens and the vowel alternates: **і**
+becomes **є** in **Києва** and **о** in **Львова**. Treat this as a normal
+Ukrainian pattern, not as an exception explained through another language.
+
+### Student badge origins
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Звідки ти? — Я ___.", "answer": "з України", "options": ["з України", "в Україну", "в Україні"]}, {"sentence": "Анна ___.", "answer": "з Канади", "options": ["з Канади", "в Канаді", "у Канаду"]}, {"sentence": "Ми ___, а ви?", "answer": "з Києва", "options": ["з Києва", "у Києві", "у Київ"]}, {"sentence": "Джон ___.", "answer": "зі США", "options": ["зі США", "з США", "у США"]}, {"sentence": "Мій друг ___.", "answer": "з Німеччини", "options": ["з Німеччини", "у Німеччину", "в Німеччині"]}, {"sentence": "Олена живе в Києві, але вона ___.", "answer": "зі Львова", "options": ["зі Львова", "у Львові", "до Львова"]}]`)} />
+
+### Base name to from-place form
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Україна", "right": "з України"}, {"left": "Канада", "right": "з Канади"}, {"left": "Київ", "right": "з Києва"}, {"left": "Львів", "right": "зі Львова"}, {"left": "Одеса", "right": "з Одеси"}, {"left": "Харків", "right": "з Харкова"}, {"left": "США", "right": "зі США"}, {"left": "школа", "right": "зі школи"}]`)} />
+
+## Країни і міста
+
+Here is a compact origin set for real introductions:
+
+| Country | From | Person |
+| --- | --- | --- |
+| **Україна** | **з України** | **українець / українка** |
+| **Канада** | **з Канади** | **канадець / канадка** |
+| **Польща** | **з Польщі** | **поляк / полька** |
+| **Німеччина** | **з Німеччини** | **німець / німкеня** |
+| **Франція** | **з Франції** | **француз / француженка** |
+| **Італія** | **з Італії** | **італієць / італійка** |
+| **Японія** | **з Японії** | **японець / японка** |
+| **США** | **зі США** | **американець / американка** |
+
+**Демоніми та ідентичність.** A demonym names a person by place. Use masculine
+and feminine forms as pairs: **українець / українка**, **киянин / киянка**,
+**львів'янин / львів'янка**, **харків'янин / харків'янка**, **одесит /
+одеситка**. Match the form to the person and keep the **чоловічий/жіночий**
+contrast visible: **Він киянин. Вона киянка. Вона львів'янка**, not **вона
+львів'янин**.
+
+You can now separate current home and origin:
+
+- **Я живу в Києві, але я зі Львова.**
+- **Вона живе в Канаді, але вона з України.**
+- **Ми зараз в Україні, але ми з Польщі.**
+- **Він живе в Одесі, але він з Харкова.**
+- **Я з Німеччини, але зараз я в Україні.**
+
+:::tip
+Ask the question first. **Де?** keeps you in the place, **куди?** sends you to
+the place, and **звідки?** brings you from the place.
+:::
+
+**Орієнтація на мапі (напрямки).** For a first map description, keep four
+adjectives: **північний**, **південний**, **західний**, **східний**. Say
+**західна Україна**, **східна Україна**, **південне місто**, **північний
+район**. This is enough to say **Львів — це місто на заході України** and
+**Харків — це місто на сході України** without adding a geography lecture.
+
+Keep the toponyms Ukrainian. In English, use **Kyiv**, **Lviv**, **Kharkiv**,
+and **Odesa**. The Russian-imperial spellings **Kiev**, **Lvov**, **Kharkov**,
+and **Odessa** are not course forms. In Ukrainian, use **Київ**, **Львів**,
+**Харків**, **Одеса**, **Дніпро**, and write them with a capital letter.
+
+### International meet-up
+
+<Order client:only='react' items={JSON.parse(`["Добрий день! Мене звати Анна.", "Дуже приємно. Мене звати Марко.", "Звідки ти, Анно?", "Я з Канади, із Торонто. А ти?", "Я з України, з Києва.", "Чудово. Говорімо українською."]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4, 5]`)} instruction={"Put the introduction exchange in a natural order."} isUkrainian={false} />
+
+### Toponym and identity guardrails
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Україна, Київ, Львів, and Канада are proper names and use capital letters.", "isTrue": true, "explanation": "Country and city names are proper names."}, {"statement": "Я з Києва is the safe answer to Звідки ти?", "isTrue": true, "explanation": "Київ changes to Києва after з."}, {"statement": "Я є з України is the natural A1 identity line.", "isTrue": false, "explanation": "Say Я з України without є."}, {"statement": "Вона львів'янка matches a woman from Lviv.", "isTrue": true, "explanation": "Use the feminine demonym."}, {"statement": "Kiev is the course English spelling for Київ.", "isTrue": false, "explanation": "Use Kyiv / Київ."}, {"statement": "Зі США is easier and safer than з США.", "isTrue": true, "explanation": "Зі avoids a hard consonant cluster."}]`)} />
+
+<span id="підсумок"></span>
+
+## 📋 Підсумок
+
+Use the three-question grid as your checkpoint:
+
+| Need | Question | Safe answer |
+| --- | --- | --- |
+| current place | **Де ти?** | **Я в Україні. Я у Києві. Я на роботі.** |
+| destination | **Куди ти йдеш/їдеш?** | **В Україну. У Київ. На роботу.** |
+| origin/source | **Звідки ти? Звідки йдеш?** | **З України. З Києва. З роботи.** |
+
+Common repairs:
+
+| Learner line | Better line | Why |
+| --- | --- | --- |
+| Я з Київ. | **Я з Києва.** | **З** needs the from-place form. |
+| Я є з України. | **Я з України.** | Drop **є** in this present identity line. |
+| Він живе в Київ. | **Він живе в Києві.** | **Де?** needs the locative chunk. |
+| Вона львів'янин. | **Вона львів'янка.** | Demonyms match gender. |
+| Я з США. | **Я зі США.** | Use **зі** before this cluster. |
+| Я з місто Львів. | **Я зі Львова.** | In speech, use the city name in the from-form. |
+
+Self-check:
+
+1. Ask a new student where they are from: **Звідки ти?**
+2. Give your country and city: **Я з Канади, із Торонто.**
+3. Contrast home and origin: **Я живу в Києві, але я зі Львова.**
+4. Say a demonym pair: **українець / українка**, **киянин / киянка**.
+5. Repair one trap: **Я з Києва**, not **я з Київ**.
+
+Final introduction:
+
+**Добрий день! Мене звати Анна. Я з Канади, із Торонто. Зараз я живу в Києві
+і вчу українську. Мій друг Марко з України, з Києва. Олена живе в Києві, але
+вона зі Львова. Ми говоримо українською.**
+
+Now change only the origin pieces: **з України**, **з Канади**, **з Польщі**,
+**з Німеччини**, **зі США**, **з Києва**, **зі Львова**, **з Одеси**. If
+**де?**, **куди?**, and **звідки?** stay separate while you change names, the
+place system is ready for the checkpoint.
+
+### Find the from-place mismatch
+
+<OddOneOut client:only='react' instruction={"Choose the line that does not fit the pattern."} items={JSON.parse(`[{"words": ["з України", "з Канади", "з Києва", "у Києві"], "correct": 3, "explanation": "У Києві answers де?, not звідки?"}, {"words": ["в Україну", "у Київ", "на роботу", "з роботи"], "correct": 3, "explanation": "З роботи answers звідки?, not куди?"}, {"words": ["українець", "українка", "киянин", "з України"], "correct": 3, "explanation": "The first three name people; з України names origin."}, {"words": ["Kyiv", "Lviv", "Odesa", "Odessa"], "correct": 3, "explanation": "Use Odesa for the Ukrainian city name in English."}]`)} />
+
+<span id="repair-where-from-interference"></span>
+
+### Repair where-from interference
+
+<ErrorCorrection client:only='react' instruction="Choose the natural Ukrainian repair." items={JSON.parse(`[{"sentence": "Я з Київ.", "errorWord": "з Київ", "correctForm": "Я з Києва.", "options": ["Я з Києва.", "Я з Київ.", "Я в Києва."], "explanation": "Звідки? uses the from-place form Києва."}, {"sentence": "Я є з України.", "errorWord": "є", "correctForm": "Я з України.", "options": ["Я з України.", "Я є з України.", "Я маю з України."], "explanation": "Drop є in this present identity line."}, {"sentence": "Він живе в Київ.", "errorWord": "в Київ", "correctForm": "Він живе в Києві.", "options": ["Він живе в Києві.", "Він живе в Київ.", "Він живе з Києва."], "explanation": "Живе answers де?, so use в Києві."}, {"sentence": "Вона львів'янин.", "errorWord": "львів'янин", "correctForm": "Вона львів'янка.", "options": ["Вона львів'янка.", "Вона львів'янин.", "Вона з львів'янин."], "explanation": "Use the feminine demonym for вона."}, {"sentence": "Я з США. (Вимова: з-США)", "errorWord": "з США", "correctForm": "Я зі США.", "options": ["Я зі США.", "Я з США.", "Я в США."], "explanation": "Use зі before США."}, {"sentence": "Я з місто Львів.", "errorWord": "з місто Львів", "correctForm": "Я зі Львова. (або Я з міста Львова)", "options": ["Я зі Львова. (або Я з міста Львова)", "Я зі Львова.", "Я з місто Львів."], "explanation": "In speech, say the city name in the from-place form."}]`)} />
+
+</TabItem>
+<TabItem label="Vocabulary">
+
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"звідки","translation":"where from","pos":"adverb","example":"Звідки ти?","examples":["where from","Звідки ти?"]},{"word":"з","translation":"from","pos":"preposition","example":"Я з України.","examples":["from","Я з України."]},{"word":"із","translation":"from","pos":"preposition","example":"Анна із Торонто.","examples":["from","Анна із Торонто."]},{"word":"зі","translation":"from","pos":"preposition","example":"Я зі Львова.","examples":["from","Я зі Львова."]},{"word":"Україна","translation":"Ukraine","pos":"proper noun","example":"Я з України.","examples":["Ukraine","Я з України."]},{"word":"Київ","translation":"Kyiv","pos":"proper noun","example":"Марко з Києва.","examples":["Kyiv","Марко з Києва."]},{"word":"Львів","translation":"Lviv","pos":"proper noun","example":"Олена зі Львова.","examples":["Lviv","Олена зі Львова."]},{"word":"Одеса","translation":"Odesa","pos":"proper noun","example":"Я з Одеси.","examples":["Odesa","Я з Одеси."]},{"word":"Харків","translation":"Kharkiv","pos":"proper noun","example":"Він з Харкова.","examples":["Kharkiv","Він з Харкова."]},{"word":"Дніпро","translation":"Dnipro","pos":"proper noun","example":"Дніпро — велике місто.","examples":["Dnipro","Дніпро — велике місто."]},{"word":"Канада","translation":"Canada","pos":"proper noun","example":"Анна з Канади.","examples":["Canada","Анна з Канади."]},{"word":"США","translation":"USA","pos":"proper noun","example":"Джон зі США.","examples":["USA","Джон зі США."]},{"word":"Англія","translation":"England","pos":"proper noun","example":"Вони з Англії.","examples":["England","Вони з Англії."]},{"word":"Німеччина","translation":"Germany","pos":"proper noun","example":"Мій друг з Німеччини.","examples":["Germany","Мій друг з Німеччини."]},{"word":"Польща","translation":"Poland","pos":"proper noun","example":"Ми з Польщі.","examples":["Poland","Ми з Польщі."]},{"word":"Франція","translation":"France","pos":"proper noun","example":"Марі з Франції.","examples":["France","Марі з Франції."]},{"word":"Італія","translation":"Italy","pos":"proper noun","example":"Лука з Італії.","examples":["Italy","Лука з Італії."]},{"word":"Японія","translation":"Japan","pos":"proper noun","example":"Юкі з Японії.","examples":["Japan","Юкі з Японії."]},{"word":"місто","translation":"city; town","pos":"noun","example":"Київ — місто.","examples":["city; town","Київ — місто."]},{"word":"країна","translation":"country","pos":"noun","example":"Україна — країна.","examples":["country","Україна — країна."]},{"word":"столиця","translation":"capital city","pos":"noun","example":"Київ — столиця України.","examples":["capital city","Київ — столиця України."]},{"word":"вулиця","translation":"street","pos":"noun","example":"Вулиця Хрещатик у Києві.","examples":["street","Вулиця Хрещатик у Києві."]},{"word":"площа","translation":"square","pos":"noun","example":"Соборна площа в центрі.","examples":["square","Соборна площа в центрі."]},{"word":"село","translation":"village","pos":"noun","example":"Це маленьке село.","examples":["village","Це маленьке село."]},{"word":"адреса","translation":"address","pos":"noun","example":"Моя адреса в Києві.","examples":["address","Моя адреса в Києві."]},{"word":"українець","translation":"Ukrainian man","pos":"noun","example":"Він українець.","examples":["Ukrainian man","Він українець."]},{"word":"українка","translation":"Ukrainian woman","pos":"noun","example":"Вона українка.","examples":["Ukrainian woman","Вона українка."]},{"word":"киянин","translation":"man from Kyiv","pos":"noun","example":"Марко киянин.","examples":["man from Kyiv","Марко киянин."]},{"word":"киянка","translation":"woman from Kyiv","pos":"noun","example":"Оксана киянка.","examples":["woman from Kyiv","Оксана киянка."]},{"word":"львів'янин","translation":"man from Lviv","pos":"noun","example":"Тарас львів'янин.","examples":["man from Lviv","Тарас львів'янин."]},{"word":"львів'янка","translation":"woman from Lviv","pos":"noun","example":"Олена львів'янка.","examples":["woman from Lviv","Олена львів'янка."]},{"word":"харків'янин","translation":"man from Kharkiv","pos":"noun","example":"Сергій харків'янин.","examples":["man from Kharkiv","Сергій харків'янин."]},{"word":"харків'янка","translation":"woman from Kharkiv","pos":"noun","example":"Ірина харків'янка.","examples":["woman from Kharkiv","Ірина харків'янка."]},{"word":"одесит","translation":"man from Odesa","pos":"noun","example":"Він одесит.","examples":["man from Odesa","Він одесит."]},{"word":"одеситка","translation":"woman from Odesa","pos":"noun","example":"Вона одеситка.","examples":["woman from Odesa","Вона одеситка."]},{"word":"жити","translation":"to live","pos":"verb","example":"Я живу в Києві.","examples":["to live","Я живу в Києві."]},{"word":"мандрувати","translation":"to travel","pos":"verb","example":"Ми мандруємо Україною.","examples":["to travel","Ми мандруємо Україною."]},{"word":"північний","translation":"northern","pos":"adjective","example":"Це північний район.","examples":["northern","Це північний район."]},{"word":"південний","translation":"southern","pos":"adjective","example":"Одеса — південне місто.","examples":["southern","Одеса — південне місто."]},{"word":"західний","translation":"western","pos":"adjective","example":"Львів — західне місто.","examples":["western","Львів — західне місто."]},{"word":"східний","translation":"eastern","pos":"adjective","example":"Харків — східне місто.","examples":["eastern","Харків — східне місто."]},{"word":"додому","translation":"homeward; home","pos":"adverb","example":"Після школи я йду додому.","examples":["homeward; home","Після школи я йду додому."]}]`)} title="Vocabulary" />
+
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"звідки","back":"where from"},{"front":"з","back":"from"},{"front":"із","back":"from"},{"front":"зі","back":"from"},{"front":"Україна","back":"Ukraine"},{"front":"Київ","back":"Kyiv"},{"front":"Львів","back":"Lviv"},{"front":"Одеса","back":"Odesa"},{"front":"Харків","back":"Kharkiv"},{"front":"Дніпро","back":"Dnipro"},{"front":"Канада","back":"Canada"},{"front":"США","back":"USA"},{"front":"Англія","back":"England"},{"front":"Німеччина","back":"Germany"},{"front":"Польща","back":"Poland"},{"front":"Франція","back":"France"},{"front":"Італія","back":"Italy"},{"front":"Японія","back":"Japan"},{"front":"місто","back":"city; town"},{"front":"країна","back":"country"},{"front":"столиця","back":"capital city"},{"front":"вулиця","back":"street"},{"front":"площа","back":"square"},{"front":"село","back":"village"},{"front":"адреса","back":"address"},{"front":"українець","back":"Ukrainian man"},{"front":"українка","back":"Ukrainian woman"},{"front":"киянин","back":"man from Kyiv"},{"front":"киянка","back":"woman from Kyiv"},{"front":"львів'янин","back":"man from Lviv"},{"front":"львів'янка","back":"woman from Lviv"},{"front":"харків'янин","back":"man from Kharkiv"},{"front":"харків'янка","back":"woman from Kharkiv"},{"front":"одесит","back":"man from Odesa"},{"front":"одеситка","back":"woman from Odesa"},{"front":"жити","back":"to live"},{"front":"мандрувати","back":"to travel"},{"front":"північний","back":"northern"},{"front":"південний","back":"southern"},{"front":"західний","back":"western"},{"front":"східний","back":"eastern"},{"front":"додому","back":"homeward; home"}]`)} />
+
+</TabItem>
+<TabItem label="Activities">
+
+### Three place questions
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Де?": ["в Україні", "у Києві", "на роботі", "у школі"], "Куди?": ["в Україну", "у Київ", "на роботу", "у школу"], "Звідки?": ["з України", "з Києва", "з роботи", "зі школи"]}`)} />
+
+### Origin or current home
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Звідки ти?", "options": [{"text": "Я з України.", "correct": true}, {"text": "Я в Україні.", "correct": false}, {"text": "Я в Україну.", "correct": false}], "explanation": "Звідки? asks for origin or source: з України."}, {"question": "Де ти зараз живеш?", "options": [{"text": "У Києві.", "correct": true}, {"text": "У Київ.", "correct": false}, {"text": "З Києва.", "correct": false}], "explanation": "Де? asks for static location: у Києві."}, {"question": "Куди ти їдеш?", "options": [{"text": "В Україну.", "correct": true}, {"text": "В Україні.", "correct": false}, {"text": "З України.", "correct": false}], "explanation": "Куди? asks for destination: в Україну."}, {"question": "З якого міста Олена?", "options": [{"text": "Вона зі Львова.", "correct": true}, {"text": "Вона у Львові.", "correct": false}, {"text": "Вона у Львів.", "correct": false}], "explanation": "Origin from Lviv is зі Львова."}, {"question": "Звідки Марко йде?", "options": [{"text": "З роботи.", "correct": true}, {"text": "На роботу.", "correct": false}, {"text": "На роботі.", "correct": false}], "explanation": "Coming from work uses з роботи."}, {"question": "Де Анна навчається?", "options": [{"text": "У школі.", "correct": true}, {"text": "Зі школи.", "correct": false}, {"text": "У школу.", "correct": false}], "explanation": "A static study place answers де?"}]`)} />
+
+### Student badge origins
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Звідки ти? — Я ___.", "answer": "з України", "options": ["з України", "в Україну", "в Україні"]}, {"sentence": "Анна ___.", "answer": "з Канади", "options": ["з Канади", "в Канаді", "у Канаду"]}, {"sentence": "Ми ___, а ви?", "answer": "з Києва", "options": ["з Києва", "у Києві", "у Київ"]}, {"sentence": "Джон ___.", "answer": "зі США", "options": ["зі США", "з США", "у США"]}, {"sentence": "Мій друг ___.", "answer": "з Німеччини", "options": ["з Німеччини", "у Німеччину", "в Німеччині"]}, {"sentence": "Олена живе в Києві, але вона ___.", "answer": "зі Львова", "options": ["зі Львова", "у Львові", "до Львова"]}]`)} />
+
+### Base name to from-place form
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Україна", "right": "з України"}, {"left": "Канада", "right": "з Канади"}, {"left": "Київ", "right": "з Києва"}, {"left": "Львів", "right": "зі Львова"}, {"left": "Одеса", "right": "з Одеси"}, {"left": "Харків", "right": "з Харкова"}, {"left": "США", "right": "зі США"}, {"left": "школа", "right": "зі школи"}]`)} />
+
+### International meet-up
+
+<Order client:only='react' items={JSON.parse(`["Добрий день! Мене звати Анна.", "Дуже приємно. Мене звати Марко.", "Звідки ти, Анно?", "Я з Канади, із Торонто. А ти?", "Я з України, з Києва.", "Чудово. Говорімо українською."]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4, 5]`)} instruction={"Put the introduction exchange in a natural order."} isUkrainian={false} />
+
+### Toponym and identity guardrails
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Україна, Київ, Львів, and Канада are proper names and use capital letters.", "isTrue": true, "explanation": "Country and city names are proper names."}, {"statement": "Я з Києва is the safe answer to Звідки ти?", "isTrue": true, "explanation": "Київ changes to Києва after з."}, {"statement": "Я є з України is the natural A1 identity line.", "isTrue": false, "explanation": "Say Я з України without є."}, {"statement": "Вона львів'янка matches a woman from Lviv.", "isTrue": true, "explanation": "Use the feminine demonym."}, {"statement": "Kiev is the course English spelling for Київ.", "isTrue": false, "explanation": "Use Kyiv / Київ."}, {"statement": "Зі США is easier and safer than з США.", "isTrue": true, "explanation": "Зі avoids a hard consonant cluster."}]`)} />
+
+### Find the from-place mismatch
+
+<OddOneOut client:only='react' instruction={"Choose the line that does not fit the pattern."} items={JSON.parse(`[{"words": ["з України", "з Канади", "з Києва", "у Києві"], "correct": 3, "explanation": "У Києві answers де?, not звідки?"}, {"words": ["в Україну", "у Київ", "на роботу", "з роботи"], "correct": 3, "explanation": "З роботи answers звідки?, not куди?"}, {"words": ["українець", "українка", "киянин", "з України"], "correct": 3, "explanation": "The first three name people; з України names origin."}, {"words": ["Kyiv", "Lviv", "Odesa", "Odessa"], "correct": 3, "explanation": "Use Odesa for the Ukrainian city name in English."}]`)} />
+
+<span id="repair-where-from-interference"></span>
+
+### Repair where-from interference
+
+<ErrorCorrection client:only='react' instruction="Choose the natural Ukrainian repair." items={JSON.parse(`[{"sentence": "Я з Київ.", "errorWord": "з Київ", "correctForm": "Я з Києва.", "options": ["Я з Києва.", "Я з Київ.", "Я в Києва."], "explanation": "Звідки? uses the from-place form Києва."}, {"sentence": "Я є з України.", "errorWord": "є", "correctForm": "Я з України.", "options": ["Я з України.", "Я є з України.", "Я маю з України."], "explanation": "Drop є in this present identity line."}, {"sentence": "Він живе в Київ.", "errorWord": "в Київ", "correctForm": "Він живе в Києві.", "options": ["Він живе в Києві.", "Він живе в Київ.", "Він живе з Києва."], "explanation": "Живе answers де?, so use в Києві."}, {"sentence": "Вона львів'янин.", "errorWord": "львів'янин", "correctForm": "Вона львів'янка.", "options": ["Вона львів'янка.", "Вона львів'янин.", "Вона з львів'янин."], "explanation": "Use the feminine demonym for вона."}, {"sentence": "Я з США. (Вимова: з-США)", "errorWord": "з США", "correctForm": "Я зі США.", "options": ["Я зі США.", "Я з США.", "Я в США."], "explanation": "Use зі before США."}, {"sentence": "Я з місто Львів.", "errorWord": "з місто Львів", "correctForm": "Я зі Львова. (або Я з міста Львова)", "options": ["Я зі Львова. (або Я з міста Львова)", "Я зі Львова.", "Я з місто Львів."], "explanation": "In speech, say the city name in the from-place form."}]`)} />
+
+</TabItem>
+<TabItem label="Resources">
+
+:::info[🎧 🔗 External Resources]
+
+**🔗 Online resources:**
+- 🔗 [Ukrainian Course: Nouns in the Genitive Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/) — Reachable grammar table for the genitive forms behind з/із/зі chunks.
+- 🔗 [Ukrainian Language: Unit 10, Page 1](https://ukrainianlanguage.uk/read/unit10/page10-1.htm) — Reachable beginner reading page connected to city and place vocabulary.
+- 🔗 [Ukrainian Language: Unit 10, Page 2](https://ukrainianlanguage.uk/read/unit10/page10-2.htm) — Reachable follow-up city/place reading page for practicing place contrasts.
+- 🔗 [ULP Season 1, Episode 4](https://www.ukrainianlessons.com/episode4/) — Reachable beginner listening lesson with Звідки ви?, countries, and origin introductions.
+:::
+
+</TabItem>
+</Tabs>
+
+<HashTabSync />


### PR DESCRIPTION
Small stacked PR extracted from the closed A1 umbrella branch. Review this PR against its immediate base, not against main unless this is the runtime base PR.

Stack target:
- Base: codex/a1-stack-m33-around-the-city
- Head: codex/a1-stack-m34-where-from
- Commit: de0e2f6b5f7084264adf4a8ec1829acba7a585b2

Validation already run on the extracted stack:
- Per-commit hooks passed during extraction.
- Final stack: `git diff --check origin/main...HEAD` passed.
- Final stack: `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed for all 56 commits.
- Final stack: `npm --prefix starlight run build` passed after `npm --prefix starlight ci`.
- M52-M55 browser smoke passed: routes loaded with HTTP 200 and no console errors.

Review focus:
- bounded diff correctness against the base branch
- generated-artifact hygiene: no `status/*.json`, `audit/*-review.md`, or `review/*-review.md`
- plan snapshot correctness where this PR includes a required `.yaml.bak`
- merge safety for the stacked A1 sequence

Existing A1 audit and LLM audit remain evidence, but they are not a replacement for this PR-level review.