### PR TITLE
feat(a1): add M35 checkpoint places module

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-places/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/activities.yaml
@@ -1,0 +1,336 @@
+- id: act-1
+  type: match-up
+  title: Place question to answer
+  instruction: Match each question with the answer that proves the right checkpoint skill.
+  pairs:
+    - left: "Де Анна?"
+      right: "Вона в Києві."
+    - left: "Куди вона йде?"
+      right: "Вона йде в музей."
+    - left: "Звідки вона?"
+      right: "Вона з Канади."
+    - left: "Як вона їде?"
+      right: "Вона їде на метро."
+    - left: "Як дістатися?"
+      right: "Ідіть прямо і направо."
+    - left: "Де музей?"
+      right: "Музей на площі."
+    - left: "Куди їде автобус?"
+      right: "На вокзал."
+    - left: "Звідки йде студент?"
+      right: "Зі школи."
+- id: act-2
+  type: quiz
+  title: Choose the city move
+  instruction: Choose the line that fits the question.
+  items:
+    - prompt: "Де ти живеш?"
+      options:
+        - text: "Я живу в Одесі."
+          correct: true
+        - text: "Я живу в Одесу."
+          correct: false
+        - text: "Я живу з Одеси."
+          correct: false
+      explanation: "Де? with жити uses the static place chunk в Одесі."
+    - prompt: "Куди ти йдеш?"
+      options:
+        - text: "Я йду в музей."
+          correct: true
+        - text: "Я йду в музеї."
+          correct: false
+        - text: "Я йду з музею."
+          correct: false
+      explanation: "Куди? with йти uses a destination chunk."
+    - prompt: "Звідки ти?"
+      options:
+        - text: "Я з України."
+          correct: true
+        - text: "Я в Україні."
+          correct: false
+        - text: "Я в Україну."
+          correct: false
+      explanation: "Звідки? asks for source or origin."
+    - prompt: "Як ти їдеш до центру?"
+      options:
+        - text: "На метро."
+          correct: true
+        - text: "У метрою."
+          correct: false
+        - text: "З метро."
+          correct: false
+      explanation: "На метро is the safe transport chunk."
+    - prompt: "Де вокзал?"
+      options:
+        - text: "На площі, направо."
+          correct: true
+        - text: "На площу, направо."
+          correct: false
+        - text: "З площі, направо."
+          correct: false
+      explanation: "Де? asks for the static place на площі."
+    - prompt: "Куди ти їдеш завтра?"
+      options:
+        - text: "У Львів."
+          correct: true
+        - text: "У Львові."
+          correct: false
+        - text: "Зі Львова."
+          correct: false
+      explanation: "Куди? asks for the destination У Львів."
+- id: act-3
+  type: group-sort
+  title: A1.5 city shelves
+  instruction: Sort each chunk by its place function.
+  groups:
+    - name: "Де?"
+      items:
+        - "у центрі"
+        - "на площі"
+        - "в Одесі"
+        - "на роботі"
+    - name: "Куди?"
+      items:
+        - "у музей"
+        - "на вокзал"
+        - "в Україну"
+        - "на пляж"
+    - name: "Звідки?"
+      items:
+        - "з України"
+        - "зі школи"
+        - "з роботи"
+        - "з Києва"
+    - name: "Route or transport"
+      items:
+        - "на метро"
+        - "автобусом"
+        - "прямо"
+        - "направо"
+- id: act-4
+  type: fill-in
+  title: Odesa call gaps
+  instruction: Choose the chunk that completes the video call.
+  items:
+    - sentence: "Я зараз ___ Одесі."
+      answer: "в"
+      options:
+        - "в"
+        - "у"
+        - "з"
+      explanation: "Before the vowel in Одесі, в is the smoother choice."
+    - sentence: "Я ___ Дерибасівській вулиці."
+      answer: "на"
+      options:
+        - "на"
+        - "в"
+        - "з"
+      explanation: "Use на with street location: на вулиці."
+    - sentence: "Я йду ___ кафе."
+      answer: "з"
+      options:
+        - "з"
+        - "в"
+        - "на"
+      explanation: "Йду з кафе answers звідки?"
+    - sentence: "Потім я йду ___ порт."
+      answer: "у"
+      options:
+        - "у"
+        - "в"
+        - "з"
+      explanation: "Before a consonant, у порт is a smooth destination chunk."
+    - sentence: "Після порту я йду ___ пляж."
+      answer: "на"
+      options:
+        - "на"
+        - "в"
+        - "з"
+      explanation: "На пляж is the safe destination chunk."
+    - sentence: "Увечері я їду ___."
+      answer: "на вокзал"
+      options:
+        - "на вокзал"
+        - "на вокзалі"
+        - "з вокзалу"
+      explanation: "Їду asks куди?, so use на вокзал."
+- id: act-5
+  type: true-false
+  title: Ready checkpoint lines
+  instruction: Decide whether each line is ready for an A1.5 place answer.
+  items:
+    - statement: "Музей у центрі."
+      answer: true
+      explanation: "This answers де? with a static place chunk."
+    - statement: "Я йду в школу."
+      answer: true
+      explanation: "Йду asks куди?, so в школу is correct."
+    - statement: "Я в школа."
+      answer: false
+      explanation: "Static place needs в школі."
+    - statement: "Вона працює на пошті."
+      answer: true
+      explanation: "На пошті is the safe Ukrainian chunk."
+    - statement: "Я з Америки."
+      answer: true
+      explanation: "Звідки? uses the from-place form."
+    - statement: "Книга є на столі."
+      answer: false
+      explanation: "A natural A1 location line is Книга на столі."
+    - statement: "Ідіть прямо, потім направо."
+      answer: true
+      explanation: "This is a clear route instruction."
+    - statement: "Я з США."
+      answer: false
+      explanation: "Use зі США to avoid the heavy cluster."
+- id: act-6
+  type: odd-one-out
+  title: Find the route mismatch
+  instruction: Choose the line that does not fit the route pattern.
+  items:
+    - words:
+        - "у центрі"
+        - "на площі"
+        - "в Одесі"
+        - "у музей"
+      answer: "у музей"
+      explanation: "У музей answers куди?; the others answer де?"
+    - words:
+        - "у музей"
+        - "на вокзал"
+        - "в Україну"
+        - "у центрі"
+      answer: "у центрі"
+      explanation: "У центрі is static; the others are destinations."
+    - words:
+        - "з України"
+        - "з роботи"
+        - "зі школи"
+        - "на роботу"
+      answer: "на роботу"
+      explanation: "На роботу answers куди?; the others answer звідки?"
+    - words:
+        - "на метро"
+        - "автобусом"
+        - "пішки"
+        - "у школі"
+      answer: "у школі"
+      explanation: "У школі is a location, not a transport or route method."
+    - words:
+        - "Київ"
+        - "Львів"
+        - "Одеса"
+        - "Kiev"
+      answer: "Kiev"
+      explanation: "Use Kyiv in English and Київ in Ukrainian."
+    - words:
+        - "прямо"
+        - "направо"
+        - "наліво"
+        - "з України"
+      answer: "з України"
+      explanation: "З України is origin, not a route direction."
+- id: act-7
+  type: quiz
+  title: Repair checkpoint-places interference
+  instruction: Choose the natural Ukrainian repair.
+  anchor_id: repair-checkpoint-places-interference
+  items:
+    - prompt: "Repair: Я в школа."
+      options:
+        - text: "Я в школі."
+          correct: true
+        - text: "Я в школа."
+          correct: false
+        - text: "Я з школи."
+          correct: false
+      explanation: "Де? needs в/у plus the static place form."
+    - prompt: "Repair: Я іду в школі."
+      options:
+        - text: "Я іду в школу."
+          correct: true
+        - text: "Я іду в школі."
+          correct: false
+        - text: "Я іду зі школи."
+          correct: false
+      explanation: "Іду asks куди?, so use the destination chunk."
+    - prompt: "Repair: Я працюю в пошті."
+      options:
+        - text: "Я працюю на пошті."
+          correct: true
+        - text: "Я працюю в пошті."
+          correct: false
+        - text: "Я працюю до пошти."
+          correct: false
+      explanation: "The safe Ukrainian chunk is на пошті."
+    - prompt: "Repair: Книга є на столі."
+      options:
+        - text: "Книга на столі."
+          correct: true
+        - text: "Книга є на столі."
+          correct: false
+        - text: "Книга в стіл."
+          correct: false
+      explanation: "Ukrainian normally omits the present helper in this place line."
+    - prompt: "Repair: Вона живе Київ."
+      options:
+        - text: "Вона живе в Києві."
+          correct: true
+        - text: "Вона живе Київ."
+          correct: false
+        - text: "Вона живе в Київ."
+          correct: false
+      explanation: "Живе answers де? and needs в/у plus locative."
+    - prompt: "Repair: Я з Америці."
+      options:
+        - text: "Я з Америки."
+          correct: true
+        - text: "Я з Америці."
+          correct: false
+        - text: "Я в Америку."
+          correct: false
+      explanation: "Звідки? uses a from-place form, not the static place form."
+- id: act-8
+  type: unjumble
+  title: Rebuild final city lines
+  instruction: Put the words in a safe A1.5 order.
+  items:
+    - words:
+        - "Я"
+        - "в"
+        - "Києві"
+        - "у"
+        - "центрі"
+      answer: "Я в Києві у центрі"
+    - words:
+        - "Я"
+        - "йду"
+        - "в"
+        - "музей"
+      answer: "Я йду в музей"
+    - words:
+        - "Я"
+        - "з"
+        - "України"
+      answer: "Я з України"
+    - words:
+        - "Ідіть"
+        - "прямо"
+        - "потім"
+        - "направо"
+      answer: "Ідіть прямо потім направо"
+    - words:
+        - "Увечері"
+        - "я"
+        - "їду"
+        - "на"
+        - "вокзал"
+        - "на"
+        - "метро"
+      answer: "Увечері я їду на вокзал на метро"
+    - words:
+        - "Вона"
+        - "йде"
+        - "зі"
+        - "школи"
+      answer: "Вона йде зі школи"

--- a/curriculum/l2-uk-en/a1/checkpoint-places/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/module.md
@@ -1,0 +1,257 @@
+# Підсумок: Місця
+
+This checkpoint closes A1.5. It is not a new case lesson. The goal is to show
+that you can move through one Ukrainian city scene with the place tools from
+M28-M34: smooth sound links, **де?**, **куди?**, transport, directions, and
+**звідки?**
+
+By the end, you can:
+
+- choose smoother **у/в**, **і/й**, and **з/із/зі** forms in short place lines;
+- answer **де?** with a static place chunk such as **у центрі** or
+  **на площі**;
+- answer **куди?** with a destination such as **у музей**, **на вокзал**, or
+  **в Україну**;
+- use transport and route words: **автобусом**, **на метро**, **прямо**,
+  **направо**, **наліво**;
+- answer **звідки?** with **з/із/зі + from-place form**: **з України**,
+  **зі школи**, **з роботи**;
+- keep Ukrainian city names and Ukrainian grammar independent and precise.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+## Що ми знаємо?
+
+A1.5 gives you a small city map. Do not begin with a full case table. Begin
+with the question you need.
+
+| Need | Question | Safe pattern | Example |
+| --- | --- | --- | --- |
+| current place | **Де?** | **в/у/на + місцевий** | **Я в Україні. Музей на площі.** |
+| destination | **Куди?** | **в/у/на + напрямок** | **Я йду в музей. Їду на вокзал.** |
+| source or origin | **Звідки?** | **з/із/зі + from-place form** | **Я з України. Вона зі школи.** |
+| route | **Як дістатися?** | direction word | **Ідіть прямо, потім направо.** |
+| transport | **Як ти їдеш?** | vehicle chunk | **Автобусом. На метро. Пішки.** |
+
+The first checkpoint skill is static location. **Де?** asks where a person or
+thing is. Ukrainian uses a preposition and a place form together: **у школі**,
+**на роботі**, **у парку**, **в центрі**. The preposition alone is not enough.
+Say **Я в школі**, not **я в школа**. Say **Вона живе в Києві**, not
+**вона живе Київ**. For A1, learn the most useful chunks and use them in short
+sentences.
+
+The second skill is using state verbs in one place. **Жити**, **працювати**,
+**вчитися**, and **гуляти** can all answer **де?** when the action stays in one
+place: **я живу в Одесі**, **мама працює на пошті**, **ми гуляємо в парку**.
+Ukrainian often drops the English-style helper in present-tense identity and
+location lines. **Книга на столі** is enough. **Я студент** is enough.
+
+The third skill is direction. **Куди?** asks where motion is going. This is why
+**Я в школі** and **Я йду в школу** are different. The preposition can look the
+same, but the job is different: static place versus destination. Keep the
+question visible in your mind before choosing the chunk.
+
+The fourth skill is source or origin. **Звідки?** uses **з/із/зі** and a
+from-place form: **з України**, **з Києва**, **зі Львова**, **з роботи**,
+**зі школи**. This also brings back euphony. **Зі США** and **зі Львова** are
+chosen because they are easier to pronounce than a heavy consonant cluster.
+
+The fifth skill is a few stable space words. **Тут**, **там**, **туди**, and
+**звідти** can carry meaning without a new ending. At A1, treat them as ready
+words. You can say **Музей там**, **я йду туди**, and **вона йде звідти**
+without explaining subordinate clauses or advanced syntax.
+
+<!-- INJECT_ACTIVITY: act-2 -->
+
+## Читання
+
+Read the city note aloud. It combines Kyiv, transport, directions, and the
+three place questions.
+
+<DialogueBox uk="Сьогодні Анна в Києві." en="Today Anna is in Kyiv." />
+<DialogueBox uk="Вона з Канади, із Торонто, але зараз живе в Україні." en="She is from Canada, from Toronto, but now lives in Ukraine." />
+<DialogueBox uk="Анна хоче йти в музей у центрі." en="Anna wants to go to a museum in the center." />
+<DialogueBox uk="Біля метро вона питає: Де тут музей?" en="Near the metro she asks: Where is the museum here?" />
+<DialogueBox uk="Олег відповідає: Музей на площі. Їдьте на метро до центру." en="Oleh answers: The museum is on the square. Take the metro to the center." />
+<DialogueBox uk="Потім ідіть прямо і поверніть направо." en="Then go straight and turn right." />
+<DialogueBox uk="Анна їде на метро, виходить і йде направо." en="Anna takes the metro, exits, and goes right." />
+<DialogueBox uk="На площі вона бачить музей і кафе." en="On the square she sees the museum and a cafe." />
+<DialogueBox uk="Після музею Анна йде в кафе, а потім їде на вокзал." en="After the museum Anna goes to a cafe, and then goes to the station." />
+<DialogueBox uk="На вокзалі вона каже: Я їду у Львів." en="At the station she says: I am going to Lviv." />
+
+Answer in short phrases:
+
+- **Де Анна сьогодні?**
+- **Звідки вона?**
+- **Куди вона хоче йти?**
+- **Де музей?**
+- **Як Анна їде до центру?**
+- **Куди вона їде після кафе?**
+
+Notice the checkpoint rhythm. One line says where Anna is: **в Києві**. One
+line says where she is from: **з Канади, із Торонто**. One line says where she
+is going: **у музей**, later **на вокзал** and **у Львів**. These are not three
+versions of the same answer. They are three different questions.
+
+<!-- INJECT_ACTIVITY: act-3 -->
+
+## Граматика
+
+Use this checkpoint as a repair map, not as a new declension chart.
+
+### 1. Де? static place
+
+For a static place, keep the whole chunk together:
+
+<DialogueBox uk="Я в Україні." en="I am in Ukraine." />
+<DialogueBox uk="Він у Києві." en="He is in Kyiv." />
+<DialogueBox uk="Мама на роботі." en="Mom is at work." />
+<DialogueBox uk="Книга на столі." en="The book is on the table." />
+
+The most common beginner error is leaving the noun unchanged after the
+preposition. Repair it by asking **де?** first: **в школа** becomes
+**в школі**, **в Київ** becomes **в Києві**.
+
+At A1, the most useful visible pattern is simple: many **перша відміна**
+nouns change final **-а** to **-і** for a place chunk, as in **школа ->
+в школі**. Keep **в/у** or **на** with the noun. You do not need the full table
+yet. You also do not need to force **бути** into every present-tense sentence:
+**Я студент**, **Вона вдома**, and **ми в школі** are natural checkpoint
+models.
+
+### 2. State verbs in one place
+
+The same place chunk can follow state or in-place action verbs:
+
+<DialogueBox uk="Я живу в Одесі." en="I live in Odesa." />
+<DialogueBox uk="Вона працює на пошті." en="She works at the post office." />
+<DialogueBox uk="Ми вчимося в школі." en="We study at school." />
+<DialogueBox uk="Друзі гуляють у парку." en="Friends walk in the park." />
+
+Some places prefer **на** as a fixed Ukrainian habit: **на пошті**,
+**на вокзалі**, **на роботі**, **на площі**. Do not translate English
+prepositions one by one. Learn the city chunks.
+
+Start from the smallest line: **Я вдома**. Then add a verb when you need one:
+**жити в місті**, **вчитись у школі**, **працювати на заводі**, and
+**гуляти в парку**. All four still answer **де?** because the action stays in
+one place.
+
+### 3. Куди? destination
+
+Motion changes the job of the phrase:
+
+<DialogueBox uk="Я в школі." en="I am at school." />
+<DialogueBox uk="Я йду в школу." en="I am going to school." />
+<DialogueBox uk="Олена на роботі." en="Olena is at work." />
+<DialogueBox uk="Олена йде на роботу." en="Olena is going to work." />
+<DialogueBox uk="Ми в Україні." en="We are in Ukraine." />
+<DialogueBox uk="Ми їдемо в Україну." en="We are going to Ukraine." />
+
+If the verb is **іти** or **їхати**, check whether the question is **куди?**
+before using a static place form. The contrast is the point: **Де?** keeps you
+inside the place, while **куди?** sends you toward the place.
+
+### 4. Звідки? source and origin
+
+For source, use **з/із/зі** plus the from-place chunks:
+
+<DialogueBox uk="Я з України." en="I am from Ukraine." />
+<DialogueBox uk="Марко з Києва." en="Marko is from Kyiv." />
+<DialogueBox uk="Олена зі Львова." en="Olena is from Lviv." />
+<DialogueBox uk="Студент іде зі школи." en="The student is coming from school." />
+<DialogueBox uk="Тато йде з роботи." en="Dad is coming from work." />
+
+This is where euphony matters again. **Зі Львова**, **зі школи**, and
+**зі США** make the sound path easier. **З України** and **з Одеси** are light
+without an extra syllable.
+
+### 5. Тут, там, туди, звідти
+
+These words help you speak before you know many endings:
+
+<DialogueBox uk="Музей там." en="The museum is there." />
+<DialogueBox uk="Я йду туди." en="I am going there." />
+<DialogueBox uk="Вона йде звідти." en="She is coming from there." />
+
+Use them as complete A1 tools. You do not need to analyze bigger sentences
+with **де**, **куди**, and **звідки** as conjunctions yet.
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+<!-- INJECT_ACTIVITY: act-5 -->
+
+## Діалог
+
+This video call takes place during a walk in Odesa. It reviews city names,
+location, destination, origin, route language, transport, and euphony in one
+scene.
+
+<DialogueBox uk="Марія: Привіт, Лука! Я зараз в Одесі." en="Maria: Hi, Luka! I am in Odesa now." />
+<DialogueBox uk="Лука: Чудово! Де саме ти?" en="Luka: Great! Where exactly are you?" />
+<DialogueBox uk="Марія: Я на Дерибасівській вулиці." en="Maria: I am on Derybasivska Street." />
+<DialogueBox uk="Лука: Звідки ти йдеш?" en="Luka: Where are you coming from?" />
+<DialogueBox uk="Марія: Я йду з кафе. Спочатку була в центрі." en="Maria: I am coming from a cafe. First I was in the center." />
+<DialogueBox uk="Лука: Куди ти йдеш тепер?" en="Luka: Where are you going now?" />
+<DialogueBox uk="Марія: Я йду до Потьомкінських сходів, а потім у порт." en="Maria: I am going to the Potemkin Stairs, and then to the port." />
+<DialogueBox uk="Лука: Як дістатися до порту?" en="Luka: How do you get to the port?" />
+<DialogueBox uk="Марія: Іду прямо, потім направо. Можна також їхати автобусом." en="Maria: I go straight, then right. You can also go by bus." />
+<DialogueBox uk="Лука: А пляж?" en="Luka: And the beach?" />
+<DialogueBox uk="Марія: Після порту я йду на пляж. Увечері їду на вокзал." en="Maria: After the port I am going to the beach. In the evening I go to the station." />
+<DialogueBox uk="Лука: Ти з Одеси?" en="Luka: Are you from Odesa?" />
+<DialogueBox uk="Марія: Ні, я з України, з Києва, але Одеса дуже гарна." en="Maria: No, I am from Ukraine, from Kyiv, but Odesa is very beautiful." />
+
+The dialogue is longer than a single drill, but its pieces are small. You can
+answer it with a checklist:
+
+- **Де?** — **в Одесі**, **на Дерибасівській вулиці**, **в центрі**;
+- **Звідки?** — **з кафе**, **з України**, **з Києва**;
+- **Куди?** — **до Потьомкінських сходів**, **у порт**, **на пляж**,
+  **на вокзал**;
+- **Як?** — **пішки**, **автобусом**;
+- **Куди повернути?** — **прямо**, **направо**.
+
+Keep the city names Ukrainian: **Київ**, **Львів**, **Харків**, **Одеса**.
+In English use **Kyiv**, **Lviv**, **Kharkiv**, and **Odesa**. Do not use
+Russian-imperial spellings as course forms. Keep the country phrase precise:
+**в Україні**, **в Україну**, **з України**.
+
+<!-- INJECT_ACTIVITY: act-6 -->
+
+<span id="підсумок"></span>
+
+## Підсумок
+
+A1.5 is ready when you can build one connected city answer:
+
+<DialogueBox uk="Добрий день! Я з Канади, але зараз живу в Україні." en="Good afternoon! I am from Canada, but now I live in Ukraine." />
+<DialogueBox uk="Сьогодні я в Києві, у центрі." en="Today I am in Kyiv, in the center." />
+<DialogueBox uk="Я йду в музей, потім у кафе." en="I am going to a museum, then to a cafe." />
+<DialogueBox uk="До музею їду на метро." en="To the museum I go by metro." />
+<DialogueBox uk="Після метро йду прямо і направо." en="After the metro I go straight and right." />
+<DialogueBox uk="Увечері їду на вокзал, а завтра їду у Львів." en="In the evening I go to the station, and tomorrow I go to Lviv." />
+
+:::caution
+Keep the place system Ukrainian. Do not explain **у/в**, **і/й**, or
+**з/із/зі** through another language. Do not write **на Україні** for the
+country. Do not use **Kiev**, **Lvov**, **Kharkov**, or **Odessa** as course
+forms. Use **Київ**, **Львів**, **Харків**, **Одеса**, and in English
+**Kyiv**, **Lviv**, **Kharkiv**, **Odesa**.
+:::
+
+Final self-check:
+
+1. Say where you are: **Я в Україні. Я у Києві.**
+2. Say where you are going: **Я йду в музей. Я їду на вокзал.**
+3. Say where you are from: **Я з Канади, із Торонто.**
+4. Give one route command: **Ідіть прямо, потім направо.**
+5. Repair one trap: **Я в школі**, not **я в школа**.
+6. Repair another trap: **Я йду в школу**, not **я йду в школі**.
+
+Now write your own six-line place checkpoint. Include one current place, one
+destination, one source, one transport chunk, one direction word, and one
+Ukrainian city name.
+
+<!-- INJECT_ACTIVITY: act-7 -->
+
+<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/checkpoint-places/resources.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/resources.yaml
@@ -1,0 +1,30 @@
+- title: "Основні випадки чергування у-в, і-й, з, із, зі"
+  role: article
+  source_ref: "МійКлас"
+  url: https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612
+  notes: "Ukrainian-language reference page for the full euphony set reused from M28: у/в, і/й, з, із, зі."
+- title: "Ukrainian Course: Nouns in the Prepositional Case"
+  role: grammar table
+  source_ref: "ukrainiancourse.com"
+  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-prepositional-case/
+  notes: "Reference table for the static-place forms behind де? chunks; this site labels the locative case as prepositional."
+- title: "Ukrainian Course: Nouns in the Accusative Case"
+  role: grammar table
+  source_ref: "ukrainiancourse.com"
+  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-accusative-case/
+  notes: "Reference table for the direction/destination forms behind куди? chunks."
+- title: "Ukrainian Course: Nouns in the Genitive Case"
+  role: grammar table
+  source_ref: "ukrainiancourse.com"
+  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/
+  notes: "Reference table for the from-place forms behind звідки? chunks."
+- title: "Ukrainian Language: Unit 10, Page 1"
+  role: reading unit
+  source_ref: "ukrainianlanguage.uk"
+  url: https://ukrainianlanguage.uk/read/unit10/page10-1.htm
+  notes: "Beginner reading unit connected to city and place vocabulary."
+- title: "Ukrainian Language: Unit 10, Page 2"
+  role: reading unit
+  source_ref: "ukrainianlanguage.uk"
+  url: https://ukrainianlanguage.uk/read/unit10/page10-2.htm
+  notes: "Follow-up beginner city/place reading practice."

--- a/curriculum/l2-uk-en/a1/checkpoint-places/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/vocabulary.yaml
@@ -1,0 +1,156 @@
+- word: де
+  translation: where
+  pos: question word
+  example: "Де музей?"
+- word: куди
+  translation: where to
+  pos: question word
+  example: "Куди ти йдеш?"
+- word: звідки
+  translation: where from
+  pos: question word
+  example: "Звідки ти?"
+- word: у
+  translation: in; to
+  pos: preposition
+  example: "У центрі. У музей."
+- word: в
+  translation: in; to
+  pos: preposition
+  example: "В Одесі. В Україну."
+- word: на
+  translation: on; to
+  pos: preposition
+  example: "На площі. На вокзал."
+- word: з
+  translation: from
+  pos: preposition
+  example: "Я з України."
+- word: із
+  translation: from
+  pos: preposition
+  example: "Анна із Торонто."
+- word: зі
+  translation: from
+  pos: preposition
+  example: "Олена зі Львова."
+- word: центр
+  translation: center
+  pos: noun
+  example: "Музей у центрі."
+- word: площа
+  translation: square
+  pos: noun
+  example: "Музей на площі."
+- word: музей
+  translation: museum
+  pos: noun
+  example: "Я йду в музей."
+- word: кафе
+  translation: cafe
+  pos: noun
+  example: "Ми в кафе."
+- word: парк
+  translation: park
+  pos: noun
+  example: "Друзі гуляють у парку."
+- word: школа
+  translation: school
+  pos: noun
+  example: "Я в школі."
+- word: робота
+  translation: work
+  pos: noun
+  example: "Мама на роботі."
+- word: пошта
+  translation: post office
+  pos: noun
+  example: "Вона працює на пошті."
+- word: вокзал
+  translation: station
+  pos: noun
+  example: "Я їду на вокзал."
+- word: метро
+  translation: metro
+  pos: noun
+  example: "Вона їде на метро."
+- word: автобус
+  translation: bus
+  pos: noun
+  example: "Можна їхати автобусом."
+- word: пішки
+  translation: on foot
+  pos: adverb
+  example: "Я йду пішки."
+- word: прямо
+  translation: straight
+  pos: direction word
+  example: "Ідіть прямо."
+- word: направо
+  translation: right
+  pos: direction word
+  example: "Поверніть направо."
+- word: наліво
+  translation: left
+  pos: direction word
+  example: "Поверніть наліво."
+- word: тут
+  translation: here
+  pos: adverb
+  example: "Де тут музей?"
+- word: там
+  translation: there
+  pos: adverb
+  example: "Музей там."
+- word: туди
+  translation: there; to there
+  pos: adverb
+  example: "Я йду туди."
+- word: звідти
+  translation: from there
+  pos: adverb
+  example: "Вона йде звідти."
+- word: Україна
+  translation: Ukraine
+  pos: proper noun
+  example: "Я з України."
+- word: Київ
+  translation: Kyiv
+  pos: proper noun
+  example: "Сьогодні я в Києві."
+- word: Львів
+  translation: Lviv
+  pos: proper noun
+  example: "Завтра я їду у Львів."
+- word: Одеса
+  translation: Odesa
+  pos: proper noun
+  example: "Марія зараз в Одесі."
+- word: Харків
+  translation: Kharkiv
+  pos: proper noun
+  example: "Харків — велике місто."
+- word: жити
+  translation: to live
+  pos: verb
+  example: "Я живу в Україні."
+- word: працювати
+  translation: to work
+  pos: verb
+  example: "Вона працює на пошті."
+- word: вчитися
+  translation: to study
+  pos: verb
+  example: "Ми вчимося в школі."
+- word: іти
+  translation: to go on foot
+  pos: verb
+  example: "Я йду в музей."
+- word: їхати
+  translation: to go by vehicle
+  pos: verb
+  example: "Я їду на метро."
+- word: дістатися
+  translation: to get to
+  pos: verb
+  example: "Як дістатися до музею?"

--- a/starlight/src/content/docs/a1/checkpoint-places.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-places.mdx
@@ -1,0 +1,394 @@
+---
+title: "Підсумок: Місця"
+description: "Чи вмієте ви орієнтуватися в українському місті?"
+sidebar:
+  order: 35
+  label: "35. Підсумок: Місця"
+pipeline: linear-phase-4
+build_status: validated
+prev: where-from
+next: false
+---
+
+import Quiz from '@site/src/components/Quiz';
+import MatchUp from '@site/src/components/MatchUp';
+import FillIn from '@site/src/components/FillIn';
+import TrueFalse from '@site/src/components/TrueFalse';
+import Unjumble from '@site/src/components/Unjumble';
+import GroupSort from '@site/src/components/GroupSort';
+import Anagram from '@site/src/components/Anagram';
+import ErrorCorrection, { ErrorCorrectionItem } from '@site/src/components/ErrorCorrection';
+import Cloze from '@site/src/components/Cloze';
+import Select from '@site/src/components/Select';
+import Translate from '@site/src/components/Translate';
+import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
+import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import EssayResponse from '@site/src/components/EssayResponse';
+import ComparativeStudy from '@site/src/components/ComparativeStudy';
+import ReadingActivity from '@site/src/components/ReadingActivity';
+import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
+import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import SourceEvaluation from '@site/src/components/SourceEvaluation';
+import Debate from '@site/src/components/Debate';
+import EtymologyTrace from '@site/src/components/EtymologyTrace';
+import GrammarIdentify from '@site/src/components/GrammarIdentify';
+import PaleographyAnalysis from '@site/src/components/PaleographyAnalysis';
+import DialectComparison from '@site/src/components/DialectComparison';
+import TranslationCritique from '@site/src/components/TranslationCritique';
+import Transcription from '@site/src/components/Transcription';
+import Observe from '@site/src/components/Observe';
+import Order from '@site/src/components/Order';
+import CountSyllables from '@site/src/components/CountSyllables';
+import DivideWords from '@site/src/components/DivideWords';
+import OddOneOut from '@site/src/components/OddOneOut';
+import PickSyllables from '@site/src/components/PickSyllables';
+import LetterGrid from '@site/src/components/LetterGrid';
+import FlashcardDeck from '@site/src/components/FlashcardDeck';
+import VocabCard from '@site/src/components/VocabCard';
+import DialogueBox from '@site/src/components/DialogueBox';
+import HashTabSync from '@site/src/components/HashTabSync';
+import ActivityHelp from '@site/src/components/ActivityHelp';
+import YouTubeVideo from '@site/src/components/YouTubeVideo';
+import WatchAndRepeat from '@site/src/components/WatchAndRepeat';
+import Classify from '@site/src/components/Classify';
+import ImageToLetter from '@site/src/components/ImageToLetter';
+import ActivityPlaceholder from '@site/src/components/ActivityPlaceholder';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs syncKey="module-tab">
+<TabItem label="Lesson">
+
+This checkpoint closes A1.5. It is not a new case lesson. The goal is to show
+that you can move through one Ukrainian city scene with the place tools from
+M28-M34: smooth sound links, **де?**, **куди?**, transport, directions, and
+**звідки?**
+
+By the end, you can:
+
+- choose smoother **у/в**, **і/й**, and **з/із/зі** forms in short place lines;
+- answer **де?** with a static place chunk such as **у центрі** or
+  **на площі**;
+- answer **куди?** with a destination such as **у музей**, **на вокзал**, or
+  **в Україну**;
+- use transport and route words: **автобусом**, **на метро**, **прямо**,
+  **направо**, **наліво**;
+- answer **звідки?** with **з/із/зі + from-place form**: **з України**,
+  **зі школи**, **з роботи**;
+- keep Ukrainian city names and Ukrainian grammar independent and precise.
+
+### Place question to answer
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Де Анна?", "right": "Вона в Києві."}, {"left": "Куди вона йде?", "right": "Вона йде в музей."}, {"left": "Звідки вона?", "right": "Вона з Канади."}, {"left": "Як вона їде?", "right": "Вона їде на метро."}, {"left": "Як дістатися?", "right": "Ідіть прямо і направо."}, {"left": "Де музей?", "right": "Музей на площі."}, {"left": "Куди їде автобус?", "right": "На вокзал."}, {"left": "Звідки йде студент?", "right": "Зі школи."}]`)} />
+
+## Що ми знаємо?
+
+A1.5 gives you a small city map. Do not begin with a full case table. Begin
+with the question you need.
+
+| Need | Question | Safe pattern | Example |
+| --- | --- | --- | --- |
+| current place | **Де?** | **в/у/на + місцевий** | **Я в Україні. Музей на площі.** |
+| destination | **Куди?** | **в/у/на + напрямок** | **Я йду в музей. Їду на вокзал.** |
+| source or origin | **Звідки?** | **з/із/зі + from-place form** | **Я з України. Вона зі школи.** |
+| route | **Як дістатися?** | direction word | **Ідіть прямо, потім направо.** |
+| transport | **Як ти їдеш?** | vehicle chunk | **Автобусом. На метро. Пішки.** |
+
+The first checkpoint skill is static location. **Де?** asks where a person or
+thing is. Ukrainian uses a preposition and a place form together: **у школі**,
+**на роботі**, **у парку**, **в центрі**. The preposition alone is not enough.
+Say **Я в школі**, not **я в школа**. Say **Вона живе в Києві**, not
+**вона живе Київ**. For A1, learn the most useful chunks and use them in short
+sentences.
+
+The second skill is using state verbs in one place. **Жити**, **працювати**,
+**вчитися**, and **гуляти** can all answer **де?** when the action stays in one
+place: **я живу в Одесі**, **мама працює на пошті**, **ми гуляємо в парку**.
+Ukrainian often drops the English-style helper in present-tense identity and
+location lines. **Книга на столі** is enough. **Я студент** is enough.
+
+The third skill is direction. **Куди?** asks where motion is going. This is why
+**Я в школі** and **Я йду в школу** are different. The preposition can look the
+same, but the job is different: static place versus destination. Keep the
+question visible in your mind before choosing the chunk.
+
+The fourth skill is source or origin. **Звідки?** uses **з/із/зі** and a
+from-place form: **з України**, **з Києва**, **зі Львова**, **з роботи**,
+**зі школи**. This also brings back euphony. **Зі США** and **зі Львова** are
+chosen because they are easier to pronounce than a heavy consonant cluster.
+
+The fifth skill is a few stable space words. **Тут**, **там**, **туди**, and
+**звідти** can carry meaning without a new ending. At A1, treat them as ready
+words. You can say **Музей там**, **я йду туди**, and **вона йде звідти**
+without explaining subordinate clauses or advanced syntax.
+
+### Choose the city move
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Де ти живеш?", "options": [{"text": "Я живу в Одесі.", "correct": true}, {"text": "Я живу в Одесу.", "correct": false}, {"text": "Я живу з Одеси.", "correct": false}], "explanation": "Де? with жити uses the static place chunk в Одесі."}, {"question": "Куди ти йдеш?", "options": [{"text": "Я йду в музей.", "correct": true}, {"text": "Я йду в музеї.", "correct": false}, {"text": "Я йду з музею.", "correct": false}], "explanation": "Куди? with йти uses a destination chunk."}, {"question": "Звідки ти?", "options": [{"text": "Я з України.", "correct": true}, {"text": "Я в Україні.", "correct": false}, {"text": "Я в Україну.", "correct": false}], "explanation": "Звідки? asks for source or origin."}, {"question": "Як ти їдеш до центру?", "options": [{"text": "На метро.", "correct": true}, {"text": "У метрою.", "correct": false}, {"text": "З метро.", "correct": false}], "explanation": "На метро is the safe transport chunk."}, {"question": "Де вокзал?", "options": [{"text": "На площі, направо.", "correct": true}, {"text": "На площу, направо.", "correct": false}, {"text": "З площі, направо.", "correct": false}], "explanation": "Де? asks for the static place на площі."}, {"question": "Куди ти їдеш завтра?", "options": [{"text": "У Львів.", "correct": true}, {"text": "У Львові.", "correct": false}, {"text": "Зі Львова.", "correct": false}], "explanation": "Куди? asks for the destination У Львів."}]`)} />
+
+## Читання
+
+Read the city note aloud. It combines Kyiv, transport, directions, and the
+three place questions.
+
+<DialogueBox uk="Сьогодні Анна в Києві." en="Today Anna is in Kyiv." />
+<DialogueBox uk="Вона з Канади, із Торонто, але зараз живе в Україні." en="She is from Canada, from Toronto, but now lives in Ukraine." />
+<DialogueBox uk="Анна хоче йти в музей у центрі." en="Anna wants to go to a museum in the center." />
+<DialogueBox uk="Біля метро вона питає: Де тут музей?" en="Near the metro she asks: Where is the museum here?" />
+<DialogueBox uk="Олег відповідає: Музей на площі. Їдьте на метро до центру." en="Oleh answers: The museum is on the square. Take the metro to the center." />
+<DialogueBox uk="Потім ідіть прямо і поверніть направо." en="Then go straight and turn right." />
+<DialogueBox uk="Анна їде на метро, виходить і йде направо." en="Anna takes the metro, exits, and goes right." />
+<DialogueBox uk="На площі вона бачить музей і кафе." en="On the square she sees the museum and a cafe." />
+<DialogueBox uk="Після музею Анна йде в кафе, а потім їде на вокзал." en="After the museum Anna goes to a cafe, and then goes to the station." />
+<DialogueBox uk="На вокзалі вона каже: Я їду у Львів." en="At the station she says: I am going to Lviv." />
+
+Answer in short phrases:
+
+- **Де Анна сьогодні?**
+- **Звідки вона?**
+- **Куди вона хоче йти?**
+- **Де музей?**
+- **Як Анна їде до центру?**
+- **Куди вона їде після кафе?**
+
+Notice the checkpoint rhythm. One line says where Anna is: **в Києві**. One
+line says where she is from: **з Канади, із Торонто**. One line says where she
+is going: **у музей**, later **на вокзал** and **у Львів**. These are not three
+versions of the same answer. They are three different questions.
+
+### A1.5 city shelves
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Де?": ["у центрі", "на площі", "в Одесі", "на роботі"], "Куди?": ["у музей", "на вокзал", "в Україну", "на пляж"], "Звідки?": ["з України", "зі школи", "з роботи", "з Києва"], "Route or transport": ["на метро", "автобусом", "прямо", "направо"]}`)} />
+
+## Граматика
+
+Use this checkpoint as a repair map, not as a new declension chart.
+
+### 1. Де? static place
+
+For a static place, keep the whole chunk together:
+
+<DialogueBox uk="Я в Україні." en="I am in Ukraine." />
+<DialogueBox uk="Він у Києві." en="He is in Kyiv." />
+<DialogueBox uk="Мама на роботі." en="Mom is at work." />
+<DialogueBox uk="Книга на столі." en="The book is on the table." />
+
+The most common beginner error is leaving the noun unchanged after the
+preposition. Repair it by asking **де?** first: **в школа** becomes
+**в школі**, **в Київ** becomes **в Києві**.
+
+At A1, the most useful visible pattern is simple: many **перша відміна**
+nouns change final **-а** to **-і** for a place chunk, as in **школа ->
+в школі**. Keep **в/у** or **на** with the noun. You do not need the full table
+yet. You also do not need to force **бути** into every present-tense sentence:
+**Я студент**, **Вона вдома**, and **ми в школі** are natural checkpoint
+models.
+
+### 2. State verbs in one place
+
+The same place chunk can follow state or in-place action verbs:
+
+<DialogueBox uk="Я живу в Одесі." en="I live in Odesa." />
+<DialogueBox uk="Вона працює на пошті." en="She works at the post office." />
+<DialogueBox uk="Ми вчимося в школі." en="We study at school." />
+<DialogueBox uk="Друзі гуляють у парку." en="Friends walk in the park." />
+
+Some places prefer **на** as a fixed Ukrainian habit: **на пошті**,
+**на вокзалі**, **на роботі**, **на площі**. Do not translate English
+prepositions one by one. Learn the city chunks.
+
+Start from the smallest line: **Я вдома**. Then add a verb when you need one:
+**жити в місті**, **вчитись у школі**, **працювати на заводі**, and
+**гуляти в парку**. All four still answer **де?** because the action stays in
+one place.
+
+### 3. Куди? destination
+
+Motion changes the job of the phrase:
+
+<DialogueBox uk="Я в школі." en="I am at school." />
+<DialogueBox uk="Я йду в школу." en="I am going to school." />
+<DialogueBox uk="Олена на роботі." en="Olena is at work." />
+<DialogueBox uk="Олена йде на роботу." en="Olena is going to work." />
+<DialogueBox uk="Ми в Україні." en="We are in Ukraine." />
+<DialogueBox uk="Ми їдемо в Україну." en="We are going to Ukraine." />
+
+If the verb is **іти** or **їхати**, check whether the question is **куди?**
+before using a static place form. The contrast is the point: **Де?** keeps you
+inside the place, while **куди?** sends you toward the place.
+
+### 4. Звідки? source and origin
+
+For source, use **з/із/зі** plus the from-place chunks:
+
+<DialogueBox uk="Я з України." en="I am from Ukraine." />
+<DialogueBox uk="Марко з Києва." en="Marko is from Kyiv." />
+<DialogueBox uk="Олена зі Львова." en="Olena is from Lviv." />
+<DialogueBox uk="Студент іде зі школи." en="The student is coming from school." />
+<DialogueBox uk="Тато йде з роботи." en="Dad is coming from work." />
+
+This is where euphony matters again. **Зі Львова**, **зі школи**, and
+**зі США** make the sound path easier. **З України** and **з Одеси** are light
+without an extra syllable.
+
+### 5. Тут, там, туди, звідти
+
+These words help you speak before you know many endings:
+
+<DialogueBox uk="Музей там." en="The museum is there." />
+<DialogueBox uk="Я йду туди." en="I am going there." />
+<DialogueBox uk="Вона йде звідти." en="She is coming from there." />
+
+Use them as complete A1 tools. You do not need to analyze bigger sentences
+with **де**, **куди**, and **звідки** as conjunctions yet.
+
+### Odesa call gaps
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я зараз ___ Одесі.", "answer": "в", "options": ["в", "у", "з"]}, {"sentence": "Я ___ Дерибасівській вулиці.", "answer": "на", "options": ["на", "в", "з"]}, {"sentence": "Я йду ___ кафе.", "answer": "з", "options": ["з", "в", "на"]}, {"sentence": "Потім я йду ___ порт.", "answer": "у", "options": ["у", "в", "з"]}, {"sentence": "Після порту я йду ___ пляж.", "answer": "на", "options": ["на", "в", "з"]}, {"sentence": "Увечері я їду ___.", "answer": "на вокзал", "options": ["на вокзал", "на вокзалі", "з вокзалу"]}]`)} />
+
+### Ready checkpoint lines
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Музей у центрі.", "isTrue": true, "explanation": "This answers де? with a static place chunk."}, {"statement": "Я йду в школу.", "isTrue": true, "explanation": "Йду asks куди?, so в школу is correct."}, {"statement": "Я в школа.", "isTrue": false, "explanation": "Static place needs в школі."}, {"statement": "Вона працює на пошті.", "isTrue": true, "explanation": "На пошті is the safe Ukrainian chunk."}, {"statement": "Я з Америки.", "isTrue": true, "explanation": "Звідки? uses the from-place form."}, {"statement": "Книга є на столі.", "isTrue": false, "explanation": "A natural A1 location line is Книга на столі."}, {"statement": "Ідіть прямо, потім направо.", "isTrue": true, "explanation": "This is a clear route instruction."}, {"statement": "Я з США.", "isTrue": false, "explanation": "Use зі США to avoid the heavy cluster."}]`)} />
+
+## Діалог
+
+This video call takes place during a walk in Odesa. It reviews city names,
+location, destination, origin, route language, transport, and euphony in one
+scene.
+
+<DialogueBox uk="Марія: Привіт, Лука! Я зараз в Одесі." en="Maria: Hi, Luka! I am in Odesa now." />
+<DialogueBox uk="Лука: Чудово! Де саме ти?" en="Luka: Great! Where exactly are you?" />
+<DialogueBox uk="Марія: Я на Дерибасівській вулиці." en="Maria: I am on Derybasivska Street." />
+<DialogueBox uk="Лука: Звідки ти йдеш?" en="Luka: Where are you coming from?" />
+<DialogueBox uk="Марія: Я йду з кафе. Спочатку була в центрі." en="Maria: I am coming from a cafe. First I was in the center." />
+<DialogueBox uk="Лука: Куди ти йдеш тепер?" en="Luka: Where are you going now?" />
+<DialogueBox uk="Марія: Я йду до Потьомкінських сходів, а потім у порт." en="Maria: I am going to the Potemkin Stairs, and then to the port." />
+<DialogueBox uk="Лука: Як дістатися до порту?" en="Luka: How do you get to the port?" />
+<DialogueBox uk="Марія: Іду прямо, потім направо. Можна також їхати автобусом." en="Maria: I go straight, then right. You can also go by bus." />
+<DialogueBox uk="Лука: А пляж?" en="Luka: And the beach?" />
+<DialogueBox uk="Марія: Після порту я йду на пляж. Увечері їду на вокзал." en="Maria: After the port I am going to the beach. In the evening I go to the station." />
+<DialogueBox uk="Лука: Ти з Одеси?" en="Luka: Are you from Odesa?" />
+<DialogueBox uk="Марія: Ні, я з України, з Києва, але Одеса дуже гарна." en="Maria: No, I am from Ukraine, from Kyiv, but Odesa is very beautiful." />
+
+The dialogue is longer than a single drill, but its pieces are small. You can
+answer it with a checklist:
+
+- **Де?** — **в Одесі**, **на Дерибасівській вулиці**, **в центрі**;
+- **Звідки?** — **з кафе**, **з України**, **з Києва**;
+- **Куди?** — **до Потьомкінських сходів**, **у порт**, **на пляж**,
+  **на вокзал**;
+- **Як?** — **пішки**, **автобусом**;
+- **Куди повернути?** — **прямо**, **направо**.
+
+Keep the city names Ukrainian: **Київ**, **Львів**, **Харків**, **Одеса**.
+In English use **Kyiv**, **Lviv**, **Kharkiv**, and **Odesa**. Do not use
+Russian-imperial spellings as course forms. Keep the country phrase precise:
+**в Україні**, **в Україну**, **з України**.
+
+### Find the route mismatch
+
+<OddOneOut client:only='react' instruction={"Choose the line that does not fit the route pattern."} items={JSON.parse(`[{"words": ["у центрі", "на площі", "в Одесі", "у музей"], "correct": 3, "explanation": "У музей answers куди?; the others answer де?"}, {"words": ["у музей", "на вокзал", "в Україну", "у центрі"], "correct": 3, "explanation": "У центрі is static; the others are destinations."}, {"words": ["з України", "з роботи", "зі школи", "на роботу"], "correct": 3, "explanation": "На роботу answers куди?; the others answer звідки?"}, {"words": ["на метро", "автобусом", "пішки", "у школі"], "correct": 3, "explanation": "У школі is a location, not a transport or route method."}, {"words": ["Київ", "Львів", "Одеса", "Kiev"], "correct": 3, "explanation": "Use Kyiv in English and Київ in Ukrainian."}, {"words": ["прямо", "направо", "наліво", "з України"], "correct": 3, "explanation": "З України is origin, not a route direction."}]`)} />
+
+<span id="підсумок"></span>
+
+## 📋 Підсумок
+
+A1.5 is ready when you can build one connected city answer:
+
+<DialogueBox uk="Добрий день! Я з Канади, але зараз живу в Україні." en="Good afternoon! I am from Canada, but now I live in Ukraine." />
+<DialogueBox uk="Сьогодні я в Києві, у центрі." en="Today I am in Kyiv, in the center." />
+<DialogueBox uk="Я йду в музей, потім у кафе." en="I am going to a museum, then to a cafe." />
+<DialogueBox uk="До музею їду на метро." en="To the museum I go by metro." />
+<DialogueBox uk="Після метро йду прямо і направо." en="After the metro I go straight and right." />
+<DialogueBox uk="Увечері їду на вокзал, а завтра їду у Львів." en="In the evening I go to the station, and tomorrow I go to Lviv." />
+
+:::caution
+Keep the place system Ukrainian. Do not explain **у/в**, **і/й**, or
+**з/із/зі** through another language. Do not write **на Україні** for the
+country. Do not use **Kiev**, **Lvov**, **Kharkov**, or **Odessa** as course
+forms. Use **Київ**, **Львів**, **Харків**, **Одеса**, and in English
+**Kyiv**, **Lviv**, **Kharkiv**, **Odesa**.
+:::
+
+Final self-check:
+
+1. Say where you are: **Я в Україні. Я у Києві.**
+2. Say where you are going: **Я йду в музей. Я їду на вокзал.**
+3. Say where you are from: **Я з Канади, із Торонто.**
+4. Give one route command: **Ідіть прямо, потім направо.**
+5. Repair one trap: **Я в школі**, not **я в школа**.
+6. Repair another trap: **Я йду в школу**, not **я йду в школі**.
+
+Now write your own six-line place checkpoint. Include one current place, one
+destination, one source, one transport chunk, one direction word, and one
+Ukrainian city name.
+
+### Repair checkpoint-places interference
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Repair: Я в школа.", "options": [{"text": "Я в школі.", "correct": true}, {"text": "Я в школа.", "correct": false}, {"text": "Я з школи.", "correct": false}], "explanation": "Де? needs в/у plus the static place form."}, {"question": "Repair: Я іду в школі.", "options": [{"text": "Я іду в школу.", "correct": true}, {"text": "Я іду в школі.", "correct": false}, {"text": "Я іду зі школи.", "correct": false}], "explanation": "Іду asks куди?, so use the destination chunk."}, {"question": "Repair: Я працюю в пошті.", "options": [{"text": "Я працюю на пошті.", "correct": true}, {"text": "Я працюю в пошті.", "correct": false}, {"text": "Я працюю до пошти.", "correct": false}], "explanation": "The safe Ukrainian chunk is на пошті."}, {"question": "Repair: Книга є на столі.", "options": [{"text": "Книга на столі.", "correct": true}, {"text": "Книга є на столі.", "correct": false}, {"text": "Книга в стіл.", "correct": false}], "explanation": "Ukrainian normally omits the present helper in this place line."}, {"question": "Repair: Вона живе Київ.", "options": [{"text": "Вона живе в Києві.", "correct": true}, {"text": "Вона живе Київ.", "correct": false}, {"text": "Вона живе в Київ.", "correct": false}], "explanation": "Живе answers де? and needs в/у plus locative."}, {"question": "Repair: Я з Америці.", "options": [{"text": "Я з Америки.", "correct": true}, {"text": "Я з Америці.", "correct": false}, {"text": "Я в Америку.", "correct": false}], "explanation": "Звідки? uses a from-place form, not the static place form."}]`)} />
+
+### Rebuild final city lines
+
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / в / Києві / у / центрі", "answer": "Я в Києві у центрі"}, {"jumbled": "Я / йду / в / музей", "answer": "Я йду в музей"}, {"jumbled": "Я / з / України", "answer": "Я з України"}, {"jumbled": "Ідіть / прямо / потім / направо", "answer": "Ідіть прямо потім направо"}, {"jumbled": "Увечері / я / їду / на / вокзал / на / метро", "answer": "Увечері я їду на вокзал на метро"}, {"jumbled": "Вона / йде / зі / школи", "answer": "Вона йде зі школи"}]`)} />
+
+</TabItem>
+<TabItem label="Vocabulary">
+
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"де","translation":"where","pos":"question word","example":"Де музей?","examples":["where","Де музей?"]},{"word":"куди","translation":"where to","pos":"question word","example":"Куди ти йдеш?","examples":["where to","Куди ти йдеш?"]},{"word":"звідки","translation":"where from","pos":"question word","example":"Звідки ти?","examples":["where from","Звідки ти?"]},{"word":"у","translation":"in; to","pos":"preposition","example":"У центрі. У музей.","examples":["in; to","У центрі. У музей."]},{"word":"в","translation":"in; to","pos":"preposition","example":"В Одесі. В Україну.","examples":["in; to","В Одесі. В Україну."]},{"word":"на","translation":"on; to","pos":"preposition","example":"На площі. На вокзал.","examples":["on; to","На площі. На вокзал."]},{"word":"з","translation":"from","pos":"preposition","example":"Я з України.","examples":["from","Я з України."]},{"word":"із","translation":"from","pos":"preposition","example":"Анна із Торонто.","examples":["from","Анна із Торонто."]},{"word":"зі","translation":"from","pos":"preposition","example":"Олена зі Львова.","examples":["from","Олена зі Львова."]},{"word":"центр","translation":"center","pos":"noun","example":"Музей у центрі.","examples":["center","Музей у центрі."]},{"word":"площа","translation":"square","pos":"noun","example":"Музей на площі.","examples":["square","Музей на площі."]},{"word":"музей","translation":"museum","pos":"noun","example":"Я йду в музей.","examples":["museum","Я йду в музей."]},{"word":"кафе","translation":"cafe","pos":"noun","example":"Ми в кафе.","examples":["cafe","Ми в кафе."]},{"word":"парк","translation":"park","pos":"noun","example":"Друзі гуляють у парку.","examples":["park","Друзі гуляють у парку."]},{"word":"школа","translation":"school","pos":"noun","example":"Я в школі.","examples":["school","Я в школі."]},{"word":"робота","translation":"work","pos":"noun","example":"Мама на роботі.","examples":["work","Мама на роботі."]},{"word":"пошта","translation":"post office","pos":"noun","example":"Вона працює на пошті.","examples":["post office","Вона працює на пошті."]},{"word":"вокзал","translation":"station","pos":"noun","example":"Я їду на вокзал.","examples":["station","Я їду на вокзал."]},{"word":"метро","translation":"metro","pos":"noun","example":"Вона їде на метро.","examples":["metro","Вона їде на метро."]},{"word":"автобус","translation":"bus","pos":"noun","example":"Можна їхати автобусом.","examples":["bus","Можна їхати автобусом."]},{"word":"пішки","translation":"on foot","pos":"adverb","example":"Я йду пішки.","examples":["on foot","Я йду пішки."]},{"word":"прямо","translation":"straight","pos":"direction word","example":"Ідіть прямо.","examples":["straight","Ідіть прямо."]},{"word":"направо","translation":"right","pos":"direction word","example":"Поверніть направо.","examples":["right","Поверніть направо."]},{"word":"наліво","translation":"left","pos":"direction word","example":"Поверніть наліво.","examples":["left","Поверніть наліво."]},{"word":"тут","translation":"here","pos":"adverb","example":"Де тут музей?","examples":["here","Де тут музей?"]},{"word":"там","translation":"there","pos":"adverb","example":"Музей там.","examples":["there","Музей там."]},{"word":"туди","translation":"there; to there","pos":"adverb","example":"Я йду туди.","examples":["there; to there","Я йду туди."]},{"word":"звідти","translation":"from there","pos":"adverb","example":"Вона йде звідти.","examples":["from there","Вона йде звідти."]},{"word":"Україна","translation":"Ukraine","pos":"proper noun","example":"Я з України.","examples":["Ukraine","Я з України."]},{"word":"Київ","translation":"Kyiv","pos":"proper noun","example":"Сьогодні я в Києві.","examples":["Kyiv","Сьогодні я в Києві."]},{"word":"Львів","translation":"Lviv","pos":"proper noun","example":"Завтра я їду у Львів.","examples":["Lviv","Завтра я їду у Львів."]},{"word":"Одеса","translation":"Odesa","pos":"proper noun","example":"Марія зараз в Одесі.","examples":["Odesa","Марія зараз в Одесі."]},{"word":"Харків","translation":"Kharkiv","pos":"proper noun","example":"Харків — велике місто.","examples":["Kharkiv","Харків — велике місто."]},{"word":"жити","translation":"to live","pos":"verb","example":"Я живу в Україні.","examples":["to live","Я живу в Україні."]},{"word":"працювати","translation":"to work","pos":"verb","example":"Вона працює на пошті.","examples":["to work","Вона працює на пошті."]},{"word":"вчитися","translation":"to study","pos":"verb","example":"Ми вчимося в школі.","examples":["to study","Ми вчимося в школі."]},{"word":"іти","translation":"to go on foot","pos":"verb","example":"Я йду в музей.","examples":["to go on foot","Я йду в музей."]},{"word":"їхати","translation":"to go by vehicle","pos":"verb","example":"Я їду на метро.","examples":["to go by vehicle","Я їду на метро."]},{"word":"дістатися","translation":"to get to","pos":"verb","example":"Як дістатися до музею?","examples":["to get to","Як дістатися до музею?"]}]`)} title="Vocabulary" />
+
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"де","back":"where"},{"front":"куди","back":"where to"},{"front":"звідки","back":"where from"},{"front":"у","back":"in; to"},{"front":"в","back":"in; to"},{"front":"на","back":"on; to"},{"front":"з","back":"from"},{"front":"із","back":"from"},{"front":"зі","back":"from"},{"front":"центр","back":"center"},{"front":"площа","back":"square"},{"front":"музей","back":"museum"},{"front":"кафе","back":"cafe"},{"front":"парк","back":"park"},{"front":"школа","back":"school"},{"front":"робота","back":"work"},{"front":"пошта","back":"post office"},{"front":"вокзал","back":"station"},{"front":"метро","back":"metro"},{"front":"автобус","back":"bus"},{"front":"пішки","back":"on foot"},{"front":"прямо","back":"straight"},{"front":"направо","back":"right"},{"front":"наліво","back":"left"},{"front":"тут","back":"here"},{"front":"там","back":"there"},{"front":"туди","back":"there; to there"},{"front":"звідти","back":"from there"},{"front":"Україна","back":"Ukraine"},{"front":"Київ","back":"Kyiv"},{"front":"Львів","back":"Lviv"},{"front":"Одеса","back":"Odesa"},{"front":"Харків","back":"Kharkiv"},{"front":"жити","back":"to live"},{"front":"працювати","back":"to work"},{"front":"вчитися","back":"to study"},{"front":"іти","back":"to go on foot"},{"front":"їхати","back":"to go by vehicle"},{"front":"дістатися","back":"to get to"}]`)} />
+
+</TabItem>
+<TabItem label="Activities">
+
+### Place question to answer
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Де Анна?", "right": "Вона в Києві."}, {"left": "Куди вона йде?", "right": "Вона йде в музей."}, {"left": "Звідки вона?", "right": "Вона з Канади."}, {"left": "Як вона їде?", "right": "Вона їде на метро."}, {"left": "Як дістатися?", "right": "Ідіть прямо і направо."}, {"left": "Де музей?", "right": "Музей на площі."}, {"left": "Куди їде автобус?", "right": "На вокзал."}, {"left": "Звідки йде студент?", "right": "Зі школи."}]`)} />
+
+### Choose the city move
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Де ти живеш?", "options": [{"text": "Я живу в Одесі.", "correct": true}, {"text": "Я живу в Одесу.", "correct": false}, {"text": "Я живу з Одеси.", "correct": false}], "explanation": "Де? with жити uses the static place chunk в Одесі."}, {"question": "Куди ти йдеш?", "options": [{"text": "Я йду в музей.", "correct": true}, {"text": "Я йду в музеї.", "correct": false}, {"text": "Я йду з музею.", "correct": false}], "explanation": "Куди? with йти uses a destination chunk."}, {"question": "Звідки ти?", "options": [{"text": "Я з України.", "correct": true}, {"text": "Я в Україні.", "correct": false}, {"text": "Я в Україну.", "correct": false}], "explanation": "Звідки? asks for source or origin."}, {"question": "Як ти їдеш до центру?", "options": [{"text": "На метро.", "correct": true}, {"text": "У метрою.", "correct": false}, {"text": "З метро.", "correct": false}], "explanation": "На метро is the safe transport chunk."}, {"question": "Де вокзал?", "options": [{"text": "На площі, направо.", "correct": true}, {"text": "На площу, направо.", "correct": false}, {"text": "З площі, направо.", "correct": false}], "explanation": "Де? asks for the static place на площі."}, {"question": "Куди ти їдеш завтра?", "options": [{"text": "У Львів.", "correct": true}, {"text": "У Львові.", "correct": false}, {"text": "Зі Львова.", "correct": false}], "explanation": "Куди? asks for the destination У Львів."}]`)} />
+
+### A1.5 city shelves
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Де?": ["у центрі", "на площі", "в Одесі", "на роботі"], "Куди?": ["у музей", "на вокзал", "в Україну", "на пляж"], "Звідки?": ["з України", "зі школи", "з роботи", "з Києва"], "Route or transport": ["на метро", "автобусом", "прямо", "направо"]}`)} />
+
+### Odesa call gaps
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я зараз ___ Одесі.", "answer": "в", "options": ["в", "у", "з"]}, {"sentence": "Я ___ Дерибасівській вулиці.", "answer": "на", "options": ["на", "в", "з"]}, {"sentence": "Я йду ___ кафе.", "answer": "з", "options": ["з", "в", "на"]}, {"sentence": "Потім я йду ___ порт.", "answer": "у", "options": ["у", "в", "з"]}, {"sentence": "Після порту я йду ___ пляж.", "answer": "на", "options": ["на", "в", "з"]}, {"sentence": "Увечері я їду ___.", "answer": "на вокзал", "options": ["на вокзал", "на вокзалі", "з вокзалу"]}]`)} />
+
+### Ready checkpoint lines
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Музей у центрі.", "isTrue": true, "explanation": "This answers де? with a static place chunk."}, {"statement": "Я йду в школу.", "isTrue": true, "explanation": "Йду asks куди?, so в школу is correct."}, {"statement": "Я в школа.", "isTrue": false, "explanation": "Static place needs в школі."}, {"statement": "Вона працює на пошті.", "isTrue": true, "explanation": "На пошті is the safe Ukrainian chunk."}, {"statement": "Я з Америки.", "isTrue": true, "explanation": "Звідки? uses the from-place form."}, {"statement": "Книга є на столі.", "isTrue": false, "explanation": "A natural A1 location line is Книга на столі."}, {"statement": "Ідіть прямо, потім направо.", "isTrue": true, "explanation": "This is a clear route instruction."}, {"statement": "Я з США.", "isTrue": false, "explanation": "Use зі США to avoid the heavy cluster."}]`)} />
+
+### Find the route mismatch
+
+<OddOneOut client:only='react' instruction={"Choose the line that does not fit the route pattern."} items={JSON.parse(`[{"words": ["у центрі", "на площі", "в Одесі", "у музей"], "correct": 3, "explanation": "У музей answers куди?; the others answer де?"}, {"words": ["у музей", "на вокзал", "в Україну", "у центрі"], "correct": 3, "explanation": "У центрі is static; the others are destinations."}, {"words": ["з України", "з роботи", "зі школи", "на роботу"], "correct": 3, "explanation": "На роботу answers куди?; the others answer звідки?"}, {"words": ["на метро", "автобусом", "пішки", "у школі"], "correct": 3, "explanation": "У школі is a location, not a transport or route method."}, {"words": ["Київ", "Львів", "Одеса", "Kiev"], "correct": 3, "explanation": "Use Kyiv in English and Київ in Ukrainian."}, {"words": ["прямо", "направо", "наліво", "з України"], "correct": 3, "explanation": "З України is origin, not a route direction."}]`)} />
+
+### Repair checkpoint-places interference
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Repair: Я в школа.", "options": [{"text": "Я в школі.", "correct": true}, {"text": "Я в школа.", "correct": false}, {"text": "Я з школи.", "correct": false}], "explanation": "Де? needs в/у plus the static place form."}, {"question": "Repair: Я іду в школі.", "options": [{"text": "Я іду в школу.", "correct": true}, {"text": "Я іду в школі.", "correct": false}, {"text": "Я іду зі школи.", "correct": false}], "explanation": "Іду asks куди?, so use the destination chunk."}, {"question": "Repair: Я працюю в пошті.", "options": [{"text": "Я працюю на пошті.", "correct": true}, {"text": "Я працюю в пошті.", "correct": false}, {"text": "Я працюю до пошти.", "correct": false}], "explanation": "The safe Ukrainian chunk is на пошті."}, {"question": "Repair: Книга є на столі.", "options": [{"text": "Книга на столі.", "correct": true}, {"text": "Книга є на столі.", "correct": false}, {"text": "Книга в стіл.", "correct": false}], "explanation": "Ukrainian normally omits the present helper in this place line."}, {"question": "Repair: Вона живе Київ.", "options": [{"text": "Вона живе в Києві.", "correct": true}, {"text": "Вона живе Київ.", "correct": false}, {"text": "Вона живе в Київ.", "correct": false}], "explanation": "Живе answers де? and needs в/у plus locative."}, {"question": "Repair: Я з Америці.", "options": [{"text": "Я з Америки.", "correct": true}, {"text": "Я з Америці.", "correct": false}, {"text": "Я в Америку.", "correct": false}], "explanation": "Звідки? uses a from-place form, not the static place form."}]`)} />
+
+### Rebuild final city lines
+
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / в / Києві / у / центрі", "answer": "Я в Києві у центрі"}, {"jumbled": "Я / йду / в / музей", "answer": "Я йду в музей"}, {"jumbled": "Я / з / України", "answer": "Я з України"}, {"jumbled": "Ідіть / прямо / потім / направо", "answer": "Ідіть прямо потім направо"}, {"jumbled": "Увечері / я / їду / на / вокзал / на / метро", "answer": "Увечері я їду на вокзал на метро"}, {"jumbled": "Вона / йде / зі / школи", "answer": "Вона йде зі школи"}]`)} />
+
+</TabItem>
+<TabItem label="Resources">
+
+:::info[🎧 🔗 External Resources]
+
+**📝 Articles:**
+- 📄 [Основні випадки чергування у-в, і-й, з, із, зі](https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612) — Ukrainian-language reference page for the full euphony set reused from M28: у/в, і/й, з, із, зі.
+
+**🔗 Online resources:**
+- 🔗 [Ukrainian Course: Nouns in the Accusative Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-accusative-case/) — Reference table for the direction/destination forms behind куди? chunks.
+- 🔗 [Ukrainian Course: Nouns in the Genitive Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/) — Reference table for the from-place forms behind звідки? chunks.
+- 🔗 [Ukrainian Course: Nouns in the Prepositional Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-prepositional-case/) — Reference table for the static-place forms behind де? chunks; this site labels the locative case as prepositional.
+- 🔗 [Ukrainian Language: Unit 10, Page 1](https://ukrainianlanguage.uk/read/unit10/page10-1.htm) — Beginner reading unit connected to city and place vocabulary.
+- 🔗 [Ukrainian Language: Unit 10, Page 2](https://ukrainianlanguage.uk/read/unit10/page10-2.htm) — Follow-up beginner city/place reading practice.
+:::
+
+</TabItem>
+</Tabs>
+
+<HashTabSync />


### PR DESCRIPTION
Small stacked PR extracted from the closed A1 umbrella branch. Review this PR against its immediate base, not against main unless this is the runtime base PR.

Stack target:
- Base: codex/a1-stack-m34-where-from
- Head: codex/a1-stack-m35-checkpoint-places
- Commit: 607583dcfd10c8bdbbb6264932bef7403fd5aa91

Validation already run on the extracted stack:
- Per-commit hooks passed during extraction.
- Final stack: `git diff --check origin/main...HEAD` passed.
- Final stack: `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed for all 56 commits.
- Final stack: `npm --prefix starlight run build` passed after `npm --prefix starlight ci`.
- M52-M55 browser smoke passed: routes loaded with HTTP 200 and no console errors.

Review focus:
- bounded diff correctness against the base branch
- generated-artifact hygiene: no `status/*.json`, `audit/*-review.md`, or `review/*-review.md`
- plan snapshot correctness where this PR includes a required `.yaml.bak`
- merge safety for the stacked A1 sequence

Existing A1 audit and LLM audit remain evidence, but they are not a replacement for this PR-level review.