### PR TITLE
research(bio): Wave K Kyivan-Rus and Galicia-Volhynia dossiers

### DIFF
--- a/docs/research/bio/danylo-halytskyi.md
+++ b/docs/research/bio/danylo-halytskyi.md
@@ -1,0 +1,166 @@
+# Данило Романович (Галицький) — Research Dossier
+
+**Slug:** `danylo-halytskyi`
+**Block:** BIO (медієвальний правитель — Королівство Руське / Галицько-Волинська держава; постать, привласнена імперським наративом)
+**Tier:** 1a (державотворча постать першого ряду)
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave K)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (IEU, UINP, project textbook corpus, Грушевський)
+- [x] §2 names the imperial appropriation mechanism and the Mongol-pressure context without hagiography
+- [x] Quotes include real `verify_quote` scores: chronicle quotes `matched: false`, confidence 0.0; Hrushevsky quote `matched: true`, confidence 0.9167
+- [x] Cross-track links verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidates identified with rights caveat
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Данило Романович; in later tradition — Данило Галицький; after 1253 — **король Русі**. [T1: IEU — *Danylo Romanovych*; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0190`]
+- **Pseudonyms / aliases:** Данило Романович; Данило Галицький; король Данило; King Danylo of Rus; Danylo Romanovych. Forbidden body-text frames: "king of Russia", "Daniil Galitsky" as norm, "southwestern Russian prince."
+- **Born:** **1201**. [T1: IEU; T5: Britannica snippet used only as navigation]
+- **Died:** **1264**. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0196`; T2: `7-klas-istoria-ukr-galimov-2024_s0195`]
+- **Family / education key facts:** son of Roman Mstyslavych and Anna; brother and long-term partner of Vasylko Romanovych; father of Lev Danylovych, Shvarno Danylovych, Mstyslav Danylovych and others. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-pometun-2024_s0165`]
+
+**Source-disagreement / precision note:** The school formula "Danylo founded Lviv" needs a caveat. The opened textbook corpus ties Lviv's first written mention to **1256**, names it after Lev, and frames the foundation as Danylo's project; exact foundation chronology varies in summaries. The dossier should say "traditionally attributed to Danylo; first mention 1256; named for his son Lev" rather than inventing a precise foundation day. [T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0127`; T2: `7-klas-istoria-ukr-galimov-2024_s0199`]
+
+## 2. Механізм імперського привласнення
+
+Danylo's oppression/appropriation mechanism has two layers: **Mongol imperial pressure in his own lifetime** and **Russian-imperial appropriation of Rus after the fact**.
+
+- **Lifetime pressure:** after the Mongol conquest, Danylo had to seek recognition from Batu / the Horde, accept suzerainty in practice, and later face campaigns by Kuremsa and Burundai. Burundai's pressure forced the dismantling of key fortresses. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0196`; T2: `7-klas-istoria-ukr-hlibovska-2024_s0127`]
+- **Narrative capture:** the later Moscow-imperial *translatio imperii* folds the Kingdom of Rus into a "Russian" continuity. That erases the western Rus state line after Kyiv and makes Danylo a regional preface to Moscow instead of a ruler of **Rus / Королівство Руське**. «Синопсис Київський» (1674) is the carrier of that myth, not a decolonial authority.
+- **What gets stolen:** the title **King of Rus**, the Romanovych state, the Danylo-Vasylko partnership, the post-1240 reconstruction, and the western diplomatic orientation.
+- **Anti-hagiography:** decolonization must not turn Danylo into a flawless modern statesman. Hrushevsky's verified judgment — "син минувшого, а не чоловік будущини" — is load-bearing here: Danylo had real achievements and real limits. [T1/T4: `verify_quote(author="Грушевський")`, matched true, confidence 0.9167]
+
+## 3. Major works (державотворчі діяння)
+
+- `1205` — after Roman Mstyslavych died near Zawichost, the young Danylo and Vasylko became heirs in a long struggle against boyar factions and foreign claimants. [T1: IEU — Roman/Danylo]
+- `1238` — recovery of Halych / restoration of the Romanovych state core after decades of instability. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0126`]
+- `1239/1240` — took Kyiv shortly before the Mongol destruction, but did not establish a long stable Kyivan reign. Do not conflate Kyiv title/occupation with the later Galician-Volhynian center. [T1: IEU]
+- `1245` — **Battle of Yaroslav** on the Sian: Danylo and Vasylko defeated Hungarian-Polish forces and Galician boyar allies; this consolidated Romanovych power. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0190`; T2: `7-klas-istoria-ukr-hlibovska-2024_s0126`]
+- `1245-1246` — journey to Batu / Sarai to secure recognition under Mongol pressure; a survival move, not a triumph. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0190`]
+- `1253` — coronation at **Drohiczyn** by papal legate **Opizo** / a papal legate; title **King of Rus**. UINP's public calendar page resolves and supports the date/title frame, while school corpus gives the legate and place. [T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0127`; T5: UINP, curl 200]
+- `1254-1259` — conflict with Kuremsa, then Burundai's punitive pressure; forced dismantling of fortresses. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0196`; T2: `7-klas-istoria-ukr-hlibovska-2024_s0127`]
+- `1256 / tradition` — Lviv named for son Lev; first written mention 1256. [T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0127`; T2: `7-klas-istoria-ukr-galimov-2024_s0199`]
+- `1264` — death of Danylo; succession passed through the Romanovych family, but his son **Lev died ca. 1301**, not 1308. [T1: IEU — Lev; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0195`]
+
+## 4. Primary-source quotes
+
+**Quote 1 — Danylo before going to Batu:**
+
+> «Не дам півотчини своєї, але поїду до Батия сам!»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched: false, best_confidence 0.0**. The passage is supported by `search_text` result `7-klas-istoria-ukr-galimov-2024_s0190`. Pedagogically: show that the trip to Batu was coercive diplomacy, not voluntary loyalty.
+
+**Quote 2 — humiliation under Mongol pressure:**
+
+> «О, лихіше лиха честь татарська!»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched: false, best_confidence 0.0**; supported by `search_text` result `7-klas-istoria-ukr-galimov-2024_s0190`. Pedagogically: this line undercuts triumphalist coronation-only narratives.
+
+**Quote 3 — chronicle praise, with anti-hagiography caveat:**
+
+> «[Був] князем добрим, хоробрим і мудрим...»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched: false, best_confidence 0.0**; supported by `search_text` result `7-klas-istoria-ukr-galimov-2024_s0195`. Pair with Hrushevsky's verified critique below so the lesson does not become a saint's life.
+
+**Quote 4 — Hrushevsky's anti-hagiographic judgment:**
+
+> «син минувшого, а не чоловік будущини»
+
+Tool status: `verify_quote(author="Грушевський", ...)` returned **matched: true, best_confidence 0.9167**, with matched lines in `wave4-hrushevsky-iur-t2-3`, `wave11-hrushevsky-iur-t6`, and `wave4-hrushevsky-iur-t1`. Pedagogically: this is the dossier's strongest guard against easy hero-worship.
+
+## 5. Language register
+
+- **Register:** Galician-Volhynian chronicle style; diplomatic and military-political vocabulary; papal/Mongol terminology.
+- **CEFR readiness:** adapted narrative — B1-B2; Mongol/Latin-diplomacy discussion — C1; original chronicle language — C2.
+- **Lexicon notes:** коронація, король Русі, папський легат, півотчина, боярство, фортеця, данина, ярлик, ординська зверхність, Бурундай, Куремса. `verify_words` confirmed `коронація`, `король`, `папський`, `легат`, `фортеця`, `боярство`; `півотчина` is a source-quote term not found by VESUM and should be glossed.
+- **Stylistic features:** sharp direct speech, lament formula, praise formula, title language, and later historiographic critique.
+
+## 6. Contested points
+
+- **What's debated:** exact chronology of Lviv's founding; the practical value of the papal alliance; whether Danylo's royal title had durable institutional consequences; the balance between resistance to and accommodation of the Horde.
+- **What popular memory simplifies:** "King Danylo" can become a coronation postcard. The dossier needs Yaroslav 1245, Batu/Sarai, Burundai, and fortress dismantling in the same frame.
+- **Russian imperial attack / appropriation:** "King of Russia" is wrong for student-facing prose. The title to teach is **король Русі / King of Rus**. Do not translate Rus into modern Russia.
+- **Guard on Lev:** Danylo's son Lev belongs to the next dossier and died **ca. 1301**, not 1308; 1308 is associated with later Yurii/chronology variants, not Lev. [T1: IEU — Lev; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0195`]
+- **Anti-hagiography:** Hrushevsky's critique and the Mongol-dependence evidence must stay visible even when presenting Danylo's state-building achievements.
+
+## 7. Cross-track links
+
+> Усі шляхи під **Existing** звірені `test -e` 2026-06-03. Жодних ghost wiki paths.
+
+- **Existing BIO plan-YAML (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml` — father and state-founder.
+  - `curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml` — son and successor generation.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml` — grandson and later royal title.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/danylo-halytskyi.yaml` — direct history module.
+  - `curriculum/l2-uk-en/plans/hist/galytsko-volynska-derzhava.yaml` — state context.
+  - `curriculum/l2-uk-en/plans/hist/mongolska-navala.yaml` — Mongol conquest and pressure.
+  - `curriculum/l2-uk-en/plans/hist/kinets-halytsko-volyni.yaml` — Romanovych aftermath.
+  - `curriculum/l2-uk-en/plans/hist/rus-ta-susidy.yaml` — neighbors and diplomacy.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - `yaroslav-1245` — battle-focused source/event module.
+  - `danylo-coronation-1253` — title "King of Rus" and papal diplomacy.
+  - `burundai-fortresses` — coercion and anti-hagiography source lesson.
+
+## 8. Naming-canonical
+
+- **Slug:** `danylo-halytskyi`
+- **EN canonical:** Danylo Romanovych (King Danylo of Rus)
+- **UA canonical:** Данило Романович (Галицький)
+- **Aliases:** Данило Галицький; король Данило; король Русі; Danylo Romanovych; King Danylo of Rus.
+- **Forbidden forms:** Daniil Galitsky as norm; Daniel of Russia; King of Russia; "Russian king Daniel."
+
+## 9. Image candidates
+
+- **No lifetime portrait exists.**
+- **Best PD/CC candidates:** seals/coins associated with Romanovych rule if license-cleared; monument to King Danylo in Lviv for commemoration only; maps of Galicia-Volhynia and the Yaroslav battlefield.
+- **Context image:** Drohiczyn coronation geography or Lviv first-mention/foundation context, with a caution that later monuments are not documentary likenesses.
+- **Rights caveat:** individual image URLs and licenses must be checked in Phase 4; this dossier does not certify image rights.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Danylo Romanovych." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CA%5CDanyloRomanovych.htm. WebFetch/curl status 200. Accessed 2026-06-03.
+- *Internet Encyclopedia of Ukraine.* "Lev Danylovych." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CE%5CLevDanylovych.htm. WebFetch/curl status 200; used for the Lev death-date guard. Accessed 2026-06-03.
+
+**Tier 2 / project corpus:**
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0190` — Yaroslav 1245, Batu/Sarai, coronation context, chronicle quotes.
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0196` — 1245/1253/1254-1259/1264 chronology, Kuremsa and Burundai.
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0127` — Lviv, coronation at Drohiczyn by papal legate Opizo, Kuremsa/Burundai.
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0195` — Danylo's death, Romanovych dynasty table, Lev 1264-1301, chronicle praise.
+- `verify_quote(author="Грушевський", "син минувшого, а не чоловік будущини")` — matched true, confidence 0.9167.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. «Данило Галицький», queried via `query_wikipedia` summary 2026-06-03; used only after checking against IEU/project corpus.
+
+**Tier 5 (public-history URL, checked):**
+- Український інститут національної пам'яті. "1253 - коронація князя Данила." https://uinp.gov.ua/istorychnyy-kalendar/zhovten/7/1253-koronaciya-knyazya-danyla. WebFetch/curl status 200. Accessed 2026-06-03.
+
+**Tier 4 (historiography / appropriation):**
+- «Синопсис Київський» (1674), cited as the imperial narrative carrier to critique.
+- М. Грушевський corpus lines returned by `verify_quote`, used for anti-hagiography.
+
+**Primary-source documents accessed:** Galician-Volhynian Chronicle excerpts through project `search_text`; Hrushevsky quote verified through literary corpus.
+
+**Honest gaps:** Exact Lviv foundation chronology remains a source-disagreement point; do not state a precise foundation day. The final student close-reading version must lock chronicle wording to the selected edition.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — title kept as King of Rus, not Russia.
+- [x] No Russian-imperial transliterations in body text except forbidden-form examples.
+- [x] No Russocentric periodization.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — death and coercion stated directly.
+- [x] Modern UA place names — Галич, Львів, Дорогичин, Київ, Ярослав, Холм.
+- [N/A] Holodomor — not applicable to XIII c.
+- [N/A] Crimea/2014/2022 — not directly applicable; modern appropriation handled through Rus-to-Moscow myth.

--- a/docs/research/bio/kniaz-sviatoslav.md
+++ b/docs/research/bio/kniaz-sviatoslav.md
@@ -1,0 +1,153 @@
+# Святослав Ігорович Хоробрий — Research Dossier
+
+**Slug:** `kniaz-sviatoslav`
+**Block:** BIO (медієвальний правитель — Київська Русь; постать, привласнена імперським і військово-романтичним наративом)
+**Tier:** 1a (державотворча постать першого ряду)
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave K)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 source families cited (IEU, project textbook corpus, ПВЛ/Літопис Руський, ЕІУ linked context)
+- [x] §2 names the Rus-appropriation mechanism and the later militarized simplifications
+- [x] Primary-source / chronicle quotes are explicitly not treated as autograph speech
+- [x] `verify_quote` attempts for Hrushevsky attributions reported honestly (`matched: false`, confidence 0.0)
+- [x] Cross-track links verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidates identified with caution
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Святослав Ігорович; traditional epithets: Хоробрий, Завойовник. [T1: IEU — *Sviatoslav I Ihorovych*; T3: `query_wikipedia` summary]
+- **Pseudonyms / aliases:** Святослав Хоробрий; Святослав Завойовник; Sviatoslav I Ihorovych. Forbidden body-text forms: `Святослав Игоревич`, `Svyatoslav Igorevich`, "Russian warrior prince" as identity frame.
+- **Born:** IEU gives **942?**; Ukrainian Wikipedia and many textbooks leave the date uncertain / approximate. Treat exact birth year as provisional. [T1: IEU; T3: uk.wikipedia via `query_wikipedia`]
+- **Died:** **spring 972**, at/near the Dnipro rapids while returning from the Balkans; killed in a Pecheneg ambush led by khan **Kurya**. [T1: IEU; T2: `search_text` `5-klas-ukrlit-zabolotnyi-2022_s0143`; T2: `search_text` `7-klas-istoria-ukr-pometun-2024_s0048`]
+- **Family / education key facts:** son of Prince Ihor and Princess Olha; de jure grand prince from 945 under Olha's regency, de facto ruler from about 964; father of Yaropolk, Oleh and Volodymyr the Great. [T1: IEU; T3: uk.wikipedia summary]
+
+**Source-disagreement note:** The exact birth year is uncertain; IEU prints "942?" and Ukrainian summaries often avoid precision. Death is stable in outline (spring 972, Dnipro rapids, Kurya/Pechenegs), but the famous skull-cup detail is a **chronicle account/legendary motif**, not an independently verified artifact.
+
+## 2. Механізм імперського привласнення
+
+Святослав's oppression mechanism is not police repression but **narrative capture** from two directions: Russian-imperial appropriation of Rus rulers into a "Russian" past, and uncritical militarized romanticization that turns him into a timeless warrior icon while stripping the Kyiv-centered political context.
+
+- **Imperial carrier:** «Синопсис Київський» (1674) and the broader *translatio imperii* frame fold the Kyiv dynasty into a "Slavo-Rossian" / Moscow-serving genealogy. For Sviatoslav, this means campaigns launched from Kyiv are remembered as the prehistory of Russian expansion rather than as the foreign policy of the Kyivan state.
+- **Specific distortion:** the Khazar and Balkan campaigns are often taught as pure conquest. A decolonized dossier keeps the strategic and commercial Kyiv interests visible: control of routes, tribute relationships, Byzantine diplomacy, and the political cost of leaving Kyiv exposed to the Pechenegs. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0029`]
+- **What survived / what was distorted:** survived — chronicle passages, Byzantine references, later Ukrainian historiography. Distorted — a Moscow-centered warrior cult and low-stakes image attributions. Minor art claims, modern paintings, and popular skull-cup retellings must be marked as [UNVERIFIED] unless supported by a source actually opened in the build pass.
+
+## 3. Major works (державотворчі / військово-політичні діяння)
+
+- `945-964` — nominal rule under Olha's regency; Olha's administrative reforms form the state base on which Sviatoslav's campaigns rest. [T1: IEU — Olha / Sviatoslav]
+- `964-966` — eastern campaigns: Vyatichi, Volga Bulgars, Khazars; destruction/capture of Itil and Sarkel / Bila Vezha in the textbook and IEU tradition. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0029`]
+- `967/968` — first Balkan campaign at Byzantine prompting; capture of cities including Dorostol and Pereiaslavets on the Danube in the IEU account. [T1: IEU]
+- `968` — Pecheneg attack on Kyiv while Sviatoslav is in the Balkans; Olha and Kyiv pressure him with the critique that he seeks others' lands while neglecting his own. [T2: `search_text` `7-klas-istoria-ukr-pometun-2024_s0048`]
+- `969-971` — second Balkan campaign; confrontation with Emperor John I Tzimiskes; siege of Dorostol (23 April-22 July 971) and treaty. [T1: IEU]
+- `970` — appointment of sons as governors: Yaropolk in Kyiv, Oleh in the Derevlian land/Ovruch, Volodymyr in Novgorod. [T1: IEU; EIU context — Yaropolk/Oleh entries]
+- `spring 972` — death at the Dnipro rapids in Kurya's ambush. [T1: IEU; T2: `search_text` results above]
+
+## 4. Primary-source quotes
+
+**Quote 1 — the challenge formula attributed by the Primary Chronicle:**
+
+> «Іду на ви!»
+
+Tool status: `verify_quote(author="Літопис Руський", ...)` returned **matched: false, best_confidence 0.0**. IEU notes the Primary Chronicle's report of Sviatoslav's practice of warning enemies with this message; the OES module `pvl-sviatoslav` should verify against the selected ПВЛ edition before lesson build. Pedagogically: the line is useful only if taught as stylized chronicle speech, not a stenographic battlefield recording. [T1: IEU; Existing OES plan `pvl-sviatoslav`]
+
+**Quote 2 — chronicle death passage in textbook/corpus form:**
+
+> «У літо 972-го, коли настала весна, поплив Святослав через пороги. І напав на нього Куря, князь печенізький. Убили Святослава».
+
+Tool status: `verify_quote(author="Літопис Руський", ...)` returned **matched: false, best_confidence 0.0**. The passage is tool-backed by `search_text` result `5-klas-ukrlit-zabolotnyi-2022_s0143` and repeated in `5-klas-ukrlit-avramenko-2022_s0158`. Pedagogically: anchors the death to **spring 972** and Kurya; the skull-cup should be introduced only as a later chronicle motif, not as a verified physical fact.
+
+**Quote 3 — Hrushevsky attribution, honestly scored:**
+
+> «чистий запорожець на київському престолі» / variants in audit shorthand: «давньоруський спартанець», «перший запорожець на київськім столі».
+
+Tool status: `verify_quote(author="Грушевський", "чистий запорожець на київському престолі")` returned **matched: false, confidence 0.0**; the same for «давньоруський спартанець» and «перший запорожець...». The attribution is supported here only by `search_text` result `7-klas-istoria-ukr-pometun-2024_s0048`, which quotes a textbook's Hrushevsky excerpt. Treat as a textbook-cited historiographic label, not a corpus-verified quotation.
+
+## 5. Language register
+
+- **Register:** compressed martial chronicle style; formulas of warning, treaty oath, campaign narrative.
+- **CEFR readiness:** adapted narrative — B1-B2; discussion of source genre and Byzantine diplomacy — C1; original ПВЛ/OES — C2.
+- **Lexicon notes:** воєвода, дружина, хозари, каганат, печеніги, пороги, данина, засідка, Доростол, Цимісхій. `verify_words` confirmed `воєвода`, `хозари`, `каганат`, `печеніги`, `пороги`, `данина`; proper names like Куря and Доростол fall outside VESUM.
+- **Stylistic features:** laconic direct speech, heroic compression, treaty oath language, and later historiographic metaphor ("спартанець", "запорожець").
+
+## 6. Contested points
+
+- **What's debated:** the precise chronology of the Balkan campaigns; how much the Byzantines engineered the Pecheneg ambush; whether the "Idu na vy" formula reflects actual practice or chronicle stylization; the degree to which the Khazar campaign strengthened Kyiv versus opening the steppe corridor to new nomads.
+- **What popular memory simplifies:** Sviatoslav as pure heroic warrior. The more rigorous reading: he was a brilliant commander whose long absences created internal risk; Kyiv itself criticized him for seeking foreign lands while neglecting his own.
+- **Russian imperial / nationalist misuse:** Russian framings absorb him into an all-Russian warrior prehistory; shallow Ukrainian romanticization can also flatten him into a proto-Cossack mascot. The dossier should use the Hrushevsky label as a metaphor, not as proof that Sviatoslav was literally a Cossack before the Cossacks.
+- **Skull-cup legend:** include only as "the chronicle says Kurya made a cup from the skull"; do not cite paintings or minor popular retellings as proof. The core death fact is enough: spring 972, Dnipro rapids, Pecheneg khan Kurya.
+
+## 7. Cross-track links
+
+> Усі шляхи під **Existing** звірені `test -e` 2026-06-03.
+
+- **Existing BIO plan-YAML (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/knyahynia-olha.yaml` — mother/regent and governing contrast.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-velykii.yaml` — son and successor generation.
+  - `curriculum/l2-uk-en/plans/bio/kniaz-yaroslav-mudryi.yaml` — grandson and institutional turn.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/olha-sviatoslav.yaml` — direct historical context.
+  - `curriculum/l2-uk-en/plans/hist/khozary-i-sloviany.yaml` — Khazar campaign context.
+  - `curriculum/l2-uk-en/plans/hist/rus-ta-susidy.yaml` — Byzantium, steppe, western/eastern neighbors.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kyivska-rus.yaml` — broader Kyivan Rus synthesis.
+- **Existing OES modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/oes/pvl-sviatoslav.yaml` — close reading "Іду на ви".
+  - `curriculum/l2-uk-en/plans/oes/pvl-death-of-igor.yaml` — earlier chronicle violence and tribute context.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - `sviatoslav-balkan-campaigns` — Byzantine diplomacy and Dorostol.
+  - `kurya-chronicle-legend` — source genre lesson on death legends.
+
+## 8. Naming-canonical
+
+- **Slug:** `kniaz-sviatoslav`
+- **EN canonical:** Sviatoslav Ihorovych (Sviatoslav the Brave)
+- **UA canonical:** Святослав Ігорович Хоробрий
+- **Aliases:** Святослав Хоробрий; Святослав Завойовник; Sviatoslav I Ihorovych.
+- **Forbidden forms:** Святослав Игоревич; Svyatoslav Igorevich; "Russian Svyatoslav"; "Old Russian prince" without Kyivan Rus explanation.
+
+## 9. Image candidates
+
+- **No lifetime portrait exists.**
+- **Best PD/CC candidates:** Radziwill Chronicle miniatures of Sviatoslav; public-domain manuscript imagery; map of campaigns if rights-clear.
+- **Backup:** modern monuments/paintings only after license and claim verification; do not present them as evidence for appearance or battle details.
+- **Context image:** Dnipro rapids / Khortytsia historical map, if rights-clear, to explain the death geography.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Sviatoslav I Ihorovych." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CV%5CSviatoslavIIhorovych.htm. WebFetch/curl status 200. Accessed 2026-06-03.
+- ЕІУ contextual entries for Yaropolk Sviatoslavych, Oleh Sviatoslavych, Pechenegs/Kurya, found via `resource.history.org.ua` search snippets; used for family/death context, not as a standalone Sviatoslav biography URL.
+
+**Tier 2 / project corpus:**
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0029` — eastern campaigns, Itil/Sarkel, "Хочу на вас іти."
+- `search_text` result `7-klas-istoria-ukr-pometun-2024_s0048` — Hrushevsky/Kotliar/Polonska-Vasylenko/Pietkov classroom historiography and death correction.
+- `search_text` result `5-klas-ukrlit-zabolotnyi-2022_s0143` — chronicle death passage, spring 972, Kurya.
+- `search_text` result `5-klas-ukrlit-avramenko-2022_s0158` — parallel death passage.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. «Святослав Ігорович», queried via `query_wikipedia` summary 2026-06-03.
+
+**Tier 4 (historiography / appropriation):**
+- «Синопсис Київський» (1674), Litopys access copy: https://litopys.org.ua/synopsis/syn.htm. WebFetch opened 2026-06-03; imperial narrative evidence.
+
+**Primary-source documents accessed:** ПВЛ / Літопис Руський excerpts via project `search_text`; no autograph text by Sviatoslav.
+
+**Honest gaps:** Hrushevsky's audit-required labels did **not** verify through `verify_quote`; use them only as attributed through the textbook result unless a later pass locates the exact Hrushevsky corpus line.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Sviatoslav is a Kyivan Rus ruler, not a Russian national hero.
+- [x] No Russian-imperial transliterations in body text except forbidden forms.
+- [x] No Russocentric periodization.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — killed in ambush is stated directly.
+- [x] Modern UA place names — Київ, Дніпро, Хортиця, Овруч; Dorostol/Silistra with context.
+- [N/A] Holodomor — not applicable.
+- [N/A] Crimea/2014/2022 — not directly applicable.

--- a/docs/research/bio/kniaz-yaroslav-mudryi.md
+++ b/docs/research/bio/kniaz-yaroslav-mudryi.md
@@ -1,0 +1,148 @@
+# Ярослав-Георгій Володимирович Мудрий — Research Dossier
+
+**Slug:** `kniaz-yaroslav-mudryi`
+**Block:** BIO (медієвальний правитель — Київська Русь; постать, привласнена імперським наративом)
+**Tier:** 1a (державотворча постать першого ряду)
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave K)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ, IEU, project textbook corpus, ПВЛ tradition)
+- [x] §2 gives the Rus-appropriation mechanism, not a fabricated repression file
+- [x] Primary-source passages are chronicle/legal tradition; `verify_quote` is not treated as applicable unless scored
+- [x] Cross-track links verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidates identified with rights caveat
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ярослав-Георгій Володимирович; у традиції — Ярослав Мудрий. [T1: ЕІУ — Котляр, «Ярослав Мудрий»; T1: IEU — *Yaroslav the Wise*]
+- **Pseudonyms / aliases:** Ярослав Мудрий; Ярослав Володимирович; Ярослав-Георгій; Old Norse saga form often rendered as Jarisleif / Jarizleifr (use only in source discussion). Forbidden forms: `Yaroslav of Kiev`, `Ярослав Мудрый` as body-text norm, "Russian prince Yaroslav."
+- **Born:** **978 або перша половина 980-х рр.** [T1: ЕІУ]; IEU gives **978**. Place not securely established in the cited T1 sources. [T1: IEU]
+- **Died:** **20 лютого 1054**, Вишгород / Kyiv area; buried in Saint Sophia Cathedral in Kyiv. ЕІУ gives death in Вишгород and burial in Софія; IEU gives death date and Kyiv. [T1: ЕІУ; T1: IEU]
+- **Family / education key facts:** son of Volodymyr the Great and Rohnida of Polatsk; married Ingegerd-Iryna, daughter of Swedish king Olof Skotkonung; father of Iziaslav, Sviatoslav, Vsevolod, Ihor, Viacheslav, Anna, Yelysaveta and Anastasiia in the dynastic network. [T1: ЕІУ; T1: IEU]
+
+**Source-disagreement / correction note:** The live wiki rebuild must not flatten the **1022 / 1024 / 1026** sequence. ЕІУ says Mstyslav unsuccessfully tried for Kyiv in **1022**, then defeated Yaroslav at **Listven in 1024**, and only after the **1026** peace did the Dnipro-division duumvirate stabilize until Mstyslav's death in **1036**. Therefore "duumvirate from 1022" is wrong; write "after Listven (1024) and the Horodets/1026 settlement." [T1: ЕІУ — Ярослав Мудрий; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0077`]
+
+## 2. Механізм імперського привласнення
+
+Ярослав не має модерної "справи" НКВС чи судового переслідування. Його oppression mechanism — це **колоніальне переприсвоєння київського правового, церковного і династичного капіталу**.
+
+- **Core vehicle:** «Синопсис Київський» (1674) і пізніша імперська історіографія будують лінію Київ -> Москва як "природну" спадкоємність. Для Ярослава це означає привласнення Софії Київської, Руської Правди, династичних шлюбів і самого слова "Русь".
+- **What gets stolen:** (1) законодавча традиція — «Руська Правда»; (2) культурна програма — скрипторій/книгозбірня при Софії; (3) європейська дипломатія — шлюби дітей; (4) церковна автономна амбіція — митрополит Іларіон. [T1: ЕІУ; T1: IEU]
+- **How to teach it:** не казати "російський князь" або "давньоросійська держава"; пояснювати, що *руський* у джерелах XI ст. належить Київській Русі. `search_heritage("руський")` підтвердив українську історичну легітимність слова, а не його автоматичну російськість.
+- **What survived / what was distorted:** surviving institutions and texts — Софія, legal tradition, chronicle memory — were later rhetorically detached from Kyiv's Ukrainian continuity. The dossier should restore the Kyiv-centered frame without nationalist inflation: Yaroslav was a medieval dynast, not a modern democrat.
+
+## 3. Major works (державотворчі діяння)
+
+- `1014-1019` — rebellion against Volodymyr's tribute demand and victory over Sviatopolk in the struggle for Kyiv. [T1: ЕІУ; T1: IEU]
+- `1024-1036` — after Listven and the 1026 settlement, co-rule with Mstyslav Volodymyrovych: Kyiv/right bank for Yaroslav, Chernihiv/left bank for Mstyslav; sole rule after 1036. [T1: ЕІУ]
+- `1030` — campaign against Chud/Ests and foundation of **Юр'їв**, now Tartu, Estonia. [T1: ЕІУ; T1: IEU; T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0046`]
+- `1030-1031` — recovery of western borderlands / Cherven towns with Mstyslav in the second campaign. [T1: ЕІУ]
+- `1036` — defeat of the Pechenegs near Kyiv; construction program around Saint Sophia in the victory memory. [T1: ЕІУ; T1: IEU]
+- `1030s-1050s` — **«Руська Правда» / «Правда Ярослава»**, church statute tradition, school/library/scriptorium at Saint Sophia. [T1: ЕІУ; T1: IEU]
+- `1051` — support for Ilarion as metropolitan of Kyiv, an assertion of local church authority inside the Byzantine Christian world. [T1: IEU]
+- `1054` — **«Ярославів ряд»**: succession settlement placing Iziaslav in Kyiv/Novgorod; Sviatoslav in Chernihiv; Vsevolod in Pereiaslav/Rostov; Ihor in Volodymyr; Viacheslav in Smolensk. [T1: IEU; T1: ЕІУ — «Ряд Ярослава 1054» linked]
+
+## 4. Primary-source quotes
+
+**Quote 1 — "Yaroslav's row" / succession speech tradition (chronicle, quoted in modern translation):**
+
+> «Осе я одходжу зі світу сього. А ви, сини мої, майте межи собою любов, бо ви єсте брати, від одного отця і одної матері».
+
+Tool status: `verify_quote(author="Літопис Руський", ...)` returned **matched: false, best_confidence 0.0**. Use as ПВЛ / Літопис Руський tradition and verify in Phase 4 against the selected edition. Pedagogically: this is the cleanest primary-text doorway into the failed succession design.
+
+**Quote 2 — legal formula from the Ruska Pravda tradition:**
+
+> «Аще убьєть мужь мужа, то мьстити брату брата...»
+
+Tool status: `verify_quote(author="Руська Правда", ...)` returned **matched: false, best_confidence 0.0**. Use for OES/legal close reading only with a selected edition. Pedagogically: the line lets students see the transition from blood vengeance to regulated compensation, but it must not be overmodernized as "rule of law" in the modern sense.
+
+**Quote-verification note:** Unlike Franko/Shevchenko dossiers, Yaroslav left no literary corpus of "own works." §4 therefore uses chronicle/legal primary voices attributed to his reign, reports the failed corpus-verifier scores, and states the limitation directly.
+
+## 5. Language register
+
+- **Register:** high chronicle/legal/clerical register; Old East Slavic / Church Slavonic mixture in originals; modern Ukrainian translation for learners.
+- **CEFR readiness:** modern textbook narrative — B1-B2; legal-historical discussion — C1; original Ruska Pravda / chronicle snippets — C2 with philological support.
+- **Lexicon notes:** дуумвірат, співправитель, Руська Правда, віра (штраф), кровна помста, старійшинство, ряд, митрополит, скрипторій, книгозбірня, Юр'їв. `verify_words` confirmed `дуумвірат`, `співправитель`, `старійшинство`, `скрипторій`, `книгозбірня`.
+- **Stylistic features:** concise legal formulas, dynastic lists, ecclesiastical vocabulary, and later honorific framing ("Мудрий" is historiographic, not necessarily lifetime usage).
+
+## 6. Contested points
+
+- **What's debated:** his birth year; degree of personal authorship behind «Руська Правда»; whether "primogeniture" or a seniority/rota principle best describes the 1054 settlement; how much autonomy Kyiv's church had after Ilarion.
+- **What popular memory simplifies:** "father-in-law of Europe" can become empty prestige. The real point is diplomatic integration: his children and siblings tied Kyiv to France, Norway, Hungary, Poland, Sweden, Byzantium and the Empire. Guard: **Casimir I was Duke of Poland in Yaroslav's lifetime**, not "king" as a 1040s label. [T1: ЕІУ — Ярослав Мудрий; T1: IEU]
+- **Russian imperial attack / appropriation:** the phrase "Russian law" for «Руська Правда» is misleading in a modern national sense; teach "law of Rus / Kyivan Rus legal tradition." Likewise, Софія Київська is a Kyiv monument and Ukrainian heritage site, not an imperial trophy.
+- **Anti-hagiography:** Yaroslav imprisoned Sudislav and could be violent in power consolidation. The dossier should keep his legal/cultural achievements and coercive dynastic politics in the same frame. [T1: ЕІУ]
+
+## 7. Cross-track links
+
+> Усі шляхи під **Existing** звірені `test -e` 2026-06-03. No ghost wiki paths.
+
+- **Existing BIO plan-YAML (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-velykii.yaml` — father and predecessor.
+  - `curriculum/l2-uk-en/plans/bio/knyahynia-olha.yaml` — dynastic Christianization lineage.
+  - `curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml` — chronicle frame.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-monomakh.yaml` — later dynasty and legal/moral writing.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/yaroslav-wise.yaml` — direct history module.
+  - `curriculum/l2-uk-en/plans/hist/ruska-pravda.yaml` — legal tradition.
+  - `curriculum/l2-uk-en/plans/hist/sofiya-kyivska.yaml` — building/cultural program.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kyivska-rus.yaml` — broader synthesis.
+  - `curriculum/l2-uk-en/plans/hist/volodymyr-khreshchennia.yaml` — inherited Christianization context.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - `anna-yaroslavna` / `knyazhna-anna-yaroslavna` as figure-plan alignment check.
+  - `yaroslaviv-riad` OES close-reading module for succession language.
+
+## 8. Naming-canonical
+
+- **Slug:** `kniaz-yaroslav-mudryi`
+- **EN canonical (BGN/PCGN-style):** Yaroslav the Wise
+- **UA canonical:** Ярослав-Георгій Володимирович Мудрий
+- **Aliases:** Ярослав Мудрий; Ярослав Володимирович; Yaroslav the Wise; Jarisleif/Jarizleifr (saga context only).
+- **Forbidden forms:** Ярослав Мудрый; Yaroslav of Kiev; "Russian prince Yaroslav"; "Old Russian law" for «Руська Правда» without explanation.
+
+## 9. Image candidates
+
+- **No lifetime portrait exists**; do not use later romantic portraits as documentary likenesses.
+- **Best PD/CC candidates:** Saint Sophia Cathedral / Golden Gate images; manuscript miniatures; seal/coin imagery if license-cleared.
+- **Context image:** page/edition of «Руська Правда» or Saint Sophia graffiti tied to the 11th-century scribal environment.
+- **Rights caveat:** select individual Wikimedia/collection file pages in Phase 4; this dossier does not certify image licenses.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Котляр М. Ф. «Ярослав Мудрий, Ярослав-Георгій Володимирович» // *Енциклопедія історії України*. WebFetch opened `resource.history.org.ua` result; canonical short URL: https://www.history.org.ua/?termin=Yaroslav_M. Accessed 2026-06-03.
+- *Internet Encyclopedia of Ukraine.* "Yaroslav the Wise." https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesY%5CA%5CYaroslavtheWise. WebFetch/curl status 200. Accessed 2026-06-03.
+
+**Tier 2 / project corpus:**
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0077` — Listven 1024 / co-rule with Mstyslav / sole rule after 1036.
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0046` — Юр'їв/Tartu, Cherven towns, diplomacy.
+- ПВЛ / Літопис Руський and Ruska Pravda tradition — primary text to verify against final selected edition before lesson build.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. «Ярослав Мудрий», queried via `query_wikipedia` summary 2026-06-03; used only after checking against ЕІУ/IEU.
+
+**Tier 4 (historiography / appropriation):**
+- «Синопсис Київський» (1674), Litopys access copy: https://litopys.org.ua/synopsis/syn.htm. WebFetch opened 2026-06-03; cited as imperial narrative evidence.
+
+**Primary-source documents accessed:** ПВЛ / Літопис Руський succession speech tradition; Ruska Pravda legal formulas; no autograph text by Yaroslav survives.
+
+**Honest gaps:** The exact §4 wording must be locked to a chosen critical edition before student-facing close reading; this dossier supplies research scaffolding, not a diplomatic edition.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Kyiv/Rus context held throughout.
+- [x] No Russian-imperial transliterations in body text except forbidden forms.
+- [x] No Russocentric periodization — no "ancient Russian law" as default.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms.
+- [x] Modern UA place names — Київ, Вишгород, Чернігів, Юр'їв/Tartu.
+- [N/A] Holodomor — not applicable to XI c.
+- [N/A] Crimea/2014/2022 — not directly applicable.

--- a/docs/research/bio/lev-danylovych.md
+++ b/docs/research/bio/lev-danylovych.md
@@ -1,0 +1,152 @@
+# Лев Данилович — Research Dossier
+
+**Slug:** `lev-danylovych`
+**Block:** BIO (медієвальний правитель — Королівство Руське / Галичина; постать, привласнена імперським наративом)
+**Tier:** 1a (державотворча постать першого ряду)
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave K)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (IEU, project textbook corpus, Galician-Volhynian chronicle tradition via `search_text`)
+- [x] §2 names the imperial appropriation mechanism and does not invent a modern repression file
+- [x] Source limitation on Voishelk recorded: opened sources support Lev's killing of Voishelk, not a poison mechanism
+- [x] Primary/chronicle quote attempt reports real `verify_quote` score (`matched: false`, confidence 0.0)
+- [x] Cross-track links verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidates identified with rights caveat
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Лев Данилович; in dynastic context — Лев І Данилович. [T1: IEU — *Lev Danylovych*]
+- **Pseudonyms / aliases:** Лев І; Лев Данилович; Лев Галицький; nickname **Шалений** in school-corpus framing. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0200`]
+- **Born:** **ca. 1228**. [T1: IEU]
+- **Died:** **ca. 1301**. Guard: do not write 1308 for Lev. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0195`; T2: `7-klas-istoria-ukr-pometun-2024_s0166`]
+- **Family / education key facts:** son of King Danylo Romanovych; brother of Shvarno, Roman and Mstyslav Danylovych; husband of Constance, daughter of Hungarian king Bela IV; father of **Yurii I Lvovych**. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-pometun-2024_s0165`]
+
+**Source-disagreement / audit-guard note:** The audit warning says "poisoning of Voishelk." The opened project corpus supports the harder, documentable claim that Lev **killed** Voishelk in 1267 after Voishelk transferred Lithuania to Shvarno, but it does **not** support a poison mechanism. Therefore this dossier records: **Voishelk killing included; poison mechanism [UNVERIFIED] pending a higher-tier opened source**. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0198`; T2: `7-klas-istoria-ukr-galimov-2024_s0199`; T3: web-search Voishelk snippets]
+
+## 2. Механізм імперського привласнення
+
+Lev's appropriation mechanism is not a modern police file; it is **the same imperial recoding of Rus succession**, now applied to the Romanovych branch after Danylo.
+
+- **Imperial carrier:** «Синопсис Київський» (1674) and later imperial historiography treat Rus as a line that naturally flows to Moscow. For Lev, this erases the Galician-Volhynian/Rus western state afterlife and makes Romanovych politics a regional appendix.
+- **What gets distorted:** Lviv's role, the title and dynasty of the Kingdom of Rus, the Romanovych-Lithuanian relationship, and the transition from Danylo to Lev to **Yurii I Lvovych**.
+- **Genealogy guard:** Yurii I Lvovych was Lev's **son**, not grandson. The patronymic `Львович` is the clue, and IEU explicitly names Lev as Yurii's father. [T1: IEU — Lev; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0195`]
+- **Anti-hagiography:** decolonization cannot excuse Lev's violence. The Voishelk episode belongs in the dossier because it damaged a possible Rus-Lithuania union under Romanovych influence. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0198`]
+
+## 3. Major works (державотворчі / політичні діяння)
+
+- `1240s-1264` — ruled portions of Peremyshl / Belz before his father's death; IEU lists Prince of Peremyshl and Belz before the Galician rule. [T1: IEU]
+- `1264-ca.1301` — prince of Galicia / leading Romanovych ruler after Danylo's death, while other branches held Volhynia and adjacent lands. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-pometun-2024_s0166`]
+- `1267` — Voishelk transferred Lithuania to Shvarno; Lev, offended by the exclusion, killed Voishelk, damaging the Rus-Lithuanian union prospect. Poisoning mechanism remains [UNVERIFIED] in opened sources. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0198`; T2: `7-klas-istoria-ukr-galimov-2024_s0199`]
+- `1269` — after Shvarno's death, the Lithuanian trajectory moved away from the Romanovych line. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0199`]
+- `ca. 1272` — moved the capital to **Lviv** / made Lviv the capital of the Kingdom of Rus in the opened school-corpus framing. [T2: `search_text` `7-klas-istoria-ukr-pometun-2024_s0166`; T2: `7-klas-istoria-ukr-galimov-2024_s0199`]
+- `1270s-1290s` — active warfare and diplomacy with Poland, Hungary, Lithuania and the Horde; school corpus credits him with Lublin and part of Zakarpattia/Mukachevo, while also stressing heavy reliance on Mongol power. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0200`; T2: `7-klas-istoria-ukr-hlibovska-2024_s0130`]
+- `1356 guard` — Lviv's Magdeburg rights belong to **1356**, after Lev's reign; do not attribute them to him. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0273`; T2: `7-klas-istoria-ukr-galimov-2024_s0332`]
+
+## 4. Primary-source quotes
+
+**Quote 1 — Voishelk episode, source-backed but not poison-backed:**
+
+> «Лев Данилович... вбив Войшелка...»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", "Лев Данилович убив Войшелка")` returned **matched: false, best_confidence 0.0**. The claim is supported by `search_text` results `7-klas-istoria-ukr-galimov-2024_s0198` and `s0199`, which frame the episode as Lev killing Voishelk because power over Lithuania went to Shvarno. The poison mechanism is **not** supported by the opened corpus and must remain `[UNVERIFIED]`.
+
+**Quote 2 — nickname/assessment from school-corpus historiography:**
+
+> «...за що дістав прізвисько Шалений».
+
+Tool status: not a primary quote; supported by `search_text` result `7-klas-istoria-ukr-galimov-2024_s0200`. Use as a historiographic/classroom label, not as evidence that contemporaries uniformly used the nickname.
+
+**Quote-verification note:** Lev left no known autograph corpus. §4 therefore uses chronicle-derived/project-corpus excerpts and explicitly separates documented claims from unverified mechanism details.
+
+## 5. Language register
+
+- **Register:** Galician-Volhynian political chronicle, dynastic genealogy, frontier warfare and diplomatic vocabulary.
+- **CEFR readiness:** adapted narrative — B1-B2; source-disagreement discussion — C1; original chronicle language — C2.
+- **Lexicon notes:** столиця, отруєння, вбивство, спадкоємець, Львович, магдебурзьке право, данина, боярська рада, ординська залежність. `verify_words` confirmed `отруєння`, `магдебурзьке`, `право`, `столиця`, `спадщина`; proper names like Войшелк, Бурундай and Лев are outside normal VESUM coverage.
+- **Stylistic features:** moralized chronicle assessment, dynastic lists, territorial claims, nickname rhetoric.
+
+## 6. Contested points
+
+- **What's debated:** exact dating and scope of Lev's rule; whether to call him "king" in particular contexts; how to assess the capital move to Lviv; the detailed mechanism of Voishelk's death.
+- **What popular memory simplifies:** "founder/mover of Lviv greatness" can blur Danylo's role in founding/naming Lviv and the later 1356 Magdeburg-rights event. Lev can be tied to Lviv's capital role, not to the 1356 charter.
+- **Russian imperial attack / appropriation:** Lev's state is a Rus/Romanovych polity, not a "western Russian principality" in a modern national sense.
+- **Genealogy guard:** **Yurii I Lvovych is Lev's son**, not grandson. Do not write a skipped generation.
+- **Anti-hagiography / Voishelk:** the killing must be included; poison as a mechanism remains `[UNVERIFIED]` in this pass.
+
+## 7. Cross-track links
+
+> Усі шляхи під **Existing** звірені `test -e` 2026-06-03. Жодних ghost wiki paths.
+
+- **Existing BIO plan-YAML (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml` — father and inherited state.
+  - `curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml` — grandfather and Romanovych dynasty founder.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml` — son and successor.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/galytsko-volynska-derzhava.yaml` — state context.
+  - `curriculum/l2-uk-en/plans/hist/kinets-halytsko-volyni.yaml` — later Romanovych decline.
+  - `curriculum/l2-uk-en/plans/hist/danylo-halytskyi.yaml` — inherited Danylo context.
+  - `curriculum/l2-uk-en/plans/hist/mongolska-navala.yaml` — Horde dependence and pressure.
+- **Existing OES modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/oes/murder-blood-revenge.yaml` — source-language frame for elite violence and revenge logic.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - `voishelk-1267` — source-genre and anti-hagiography micro-module.
+  - `lviv-capital-1272` — capital shift versus later Magdeburg rights.
+
+## 8. Naming-canonical
+
+- **Slug:** `lev-danylovych`
+- **EN canonical:** Lev Danylovych
+- **UA canonical:** Лев Данилович
+- **Aliases:** Лев І Данилович; Лев Галицький; Лев Шалений; Lev Danylovych; Leo I of Galicia (navigation only).
+- **Forbidden forms:** Лев Даниилович as body-text norm; "Russian prince Lev"; treating "Leo I of Galicia" as the primary Ukrainian-course label.
+
+## 9. Image candidates
+
+- **No lifetime portrait exists.**
+- **Best PD/CC candidates:** Romanovych heraldic lion imagery; later Lviv heraldry/context maps; manuscript/chronicler imagery if license-cleared.
+- **Context image:** Lviv High Castle / medieval Lviv map only if the caption states later image/date and does not imply a lifetime portrait.
+- **Rights caveat:** individual Commons/collection pages must be checked in Phase 4; this dossier does not certify image licenses.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Lev Danylovych." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CE%5CLevDanylovych.htm. WebFetch/curl status 200. Accessed 2026-06-03.
+
+**Tier 2 / project corpus:**
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0198` — division after Danylo, Voishelk transfers Lithuania to Shvarno, Lev kills Voishelk.
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0199` — Voishelk aftermath and Lviv capital context.
+- `search_text` result `7-klas-istoria-ukr-pometun-2024_s0166` — Lev 1264-1301, capital moved to Lviv ca. 1272, territorial/diplomatic actions.
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0200` — nickname "Шалений", wars, Lublin/Zakarpattia, reliance on Mongol power.
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0130` — Lublin/Zakarpattia/Mukachevo and Horde dependence.
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0195` — dynasty table: Lev 1264-1301 and Yurii I Lvovych after him.
+- `search_text` results `7-klas-istoria-ukr-galimov-2024_s0273` and `s0332` — Lviv Magdeburg rights in 1356, post-Lev.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. «Лев Данилович», queried via `query_wikipedia` summary 2026-06-03; used only after checking against IEU/project corpus.
+
+**Tier 4 (historiography / appropriation):**
+- «Синопсис Київський» (1674), cited as the imperial narrative carrier to critique.
+
+**Primary-source documents accessed:** Galician-Volhynian Chronicle tradition through project `search_text`; no autograph text by Lev survives.
+
+**Honest gaps:** The poison mechanism in the Voishelk warning was not verified by opened sources; keep it `[UNVERIFIED]` unless a later pass opens a higher-tier source. The exact critical-edition wording of the Voishelk episode must be locked before close reading.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Lev is situated in the Romanovych / Rus / Lviv context.
+- [x] No Russian-imperial transliterations in body text except forbidden-form examples.
+- [x] No Russocentric periodization.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — killing of Voishelk stated directly.
+- [x] Modern UA place names — Львів, Галич, Перемишль, Белз, Мукачево, Люблін.
+- [N/A] Holodomor — not applicable to XIII c.
+- [N/A] Crimea/2014/2022 — not directly applicable; modern appropriation handled through Rus-to-Moscow myth.

--- a/docs/research/bio/roman-mstyslavych.md
+++ b/docs/research/bio/roman-mstyslavych.md
@@ -1,0 +1,154 @@
+# Роман Мстиславич Великий — Research Dossier
+
+**Slug:** `roman-mstyslavych`
+**Block:** BIO (медієвальний правитель — Волинь / Галичина / Київ; постать, привласнена імперським наративом)
+**Tier:** 1a (державотворча постать першого ряду)
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave K)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 source families cited (IEU, ЕІУ/web-search snippet, project textbook corpus, chronicle tradition)
+- [x] §2 names the imperial appropriation mechanism, not a fabricated modern repression file
+- [x] Primary/chronicle quotes include real `verify_quote` scores (`matched: false`, confidence 0.0) and `search_text` support where used
+- [x] Cross-track links verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidates identified with rights caveat
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Роман Мстиславич; у пізнішій традиції — Роман Великий. [T1: IEU — *Roman Mstyslavych*; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0159`]
+- **Pseudonyms / aliases:** Роман Мстиславич Великий; Роман Великий; Роман-Борис (хрещене ім'я в частині довідникової традиції); Roman Mstyslavych. Forbidden body-text frame: "Russian prince Roman" or "Galician-Volhynian as south-western Russia."
+- **Born:** між **1147 і 1152** / бл. 1152; exact year is not stable in opened sources. [T1: IEU; T3: web-search result for ЕІУ "Роман Мстиславич"]
+- **Died:** **19 червня 1205**, near **Завихост** on the Vistula, while fighting Polish forces associated with Leszek the White. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0170`]
+- **Family / education key facts:** son of Mstyslav Iziaslavych and Agnieszka, daughter of Boleslaw III Wrymouth; father of Danylo Romanovych and Vasylko Romanovych. Roman's sons inherited the Romanovych dynastic project after his death. [T1: IEU]
+
+**Source-disagreement / date-guard note:** Some school or web summaries drift toward **1173** for Roman's Volhynian accession. The guard for rebuild is **1170**: web search opened the ЕІУ entry for **Mstyslav Iziaslavych** with the death date **19.08.1170**, and Roman's Novgorod rule is consistently framed as **1168-1170** before he took the Volhynian inheritance. Do not write that his father died in 1173. [T1: ЕІУ web-search snippet — "Мстислав Ізяславич"; T1: IEU — Roman; T3/T5 navigation only: `movahistory.org.ua` search result]
+
+## 2. Механізм імперського привласнення
+
+Roman's oppression/appropriation mechanism is the same structural mechanism as for the Kyivan rulers: **Russian-imperial translatio imperii**, which absorbs Kyivan and Galician-Volhynian Rus into a later "Russian" state genealogy.
+
+- **Carrier text:** «Синопсис Київський» (1674) and later imperial historiography make the Kyivan past a preface to Moscow. For Roman, this is especially distorting because the Galician-Volhynian state was a western Rus polity with its own dynastic, military and diplomatic trajectory.
+- **What gets stolen:** the title tradition around "самодержець усієї Русі", the 1199 unification, the 1202 Kyiv intervention, and the Romanovych succession are recast as regional episodes of "Russian" history instead of a Rus/Ukrainian medieval state line. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0159`]
+- **Pedagogical counterframe:** keep the naming precise: **Русь / Королівство Руське / Галицько-Волинська держава**, not "southwestern Russia." Roman was not a modern Ukrainian nationalist, but neither was he a Russian ruler. He was a Rus dynast acting from Volhynia, Halych and Kyiv.
+- **Anti-romantic check:** the decolonial repair must not turn Roman into a clean national hero. He built power through dynastic pressure, war, coercion against rivals, and raids against Polovtsians; the dossier should teach both state-building and violence.
+
+## 3. Major works (державотворчі діяння)
+
+- `1168-1170` — князь новгородський, placed there through his father's political network; after 1170, he left Novgorod to take Volhynia. [T1: IEU; T1: ЕІУ Mstyslav Iziaslavych search snippet]
+- `1170` — inherited / took the Volodymyr-Volynskyi throne after the death of Mstyslav Iziaslavych. Guard: not 1173. [T1: IEU; T1: ЕІУ search snippet]
+- `1188` — first intervention in Halych after the death of Yaroslav Osmomysl; the final settlement took longer and depended on local boyar politics. [T1: IEU]
+- `1199` — unification of **Galicia and Volhynia** into the Galician-Volhynian polity after the death of Volodymyr Yaroslavych of Halych. [T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0159`; T2: `7-klas-istoria-ukr-hlibovska-2024_s0114`]
+- `1201-1204` — repeated intervention in Kyiv politics; school-corpus material highlights **1202** as the Kyiv-taking event, while chronology tables show short direct occupancy in early 1204 and rule through appointees. Do not conflate "taking Kyiv" with a long settled reign. [T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0159`; T4: `search_sources` Sofonovych chronology chunk]
+- `1197-1204` — campaigns against the Polovtsians and western neighbors; the chronicle tradition praises Roman as a powerful war leader. [T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0114`]
+- `1205` — death near Zawichost while fighting Leszek the White / Polish forces; his death triggered a long succession crisis for his minor sons Danylo and Vasylko. [T1: IEU; T2: `7-klas-istoria-ukr-galimov-2024_s0170`]
+
+## 4. Primary-source quotes
+
+**Quote 1 — chronicle title formula:**
+
+> «самодержець усієї Русі»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched: false, best_confidence 0.0**. The phrase is supported in this pass by project `search_text` results `7-klas-istoria-ukr-galimov-2024_s0159` and `7-klas-istoria-ukr-hlibovska-2024_s0114`. Pedagogically: use it to explain title rhetoric, not to project modern sovereignty terms backward without context.
+
+**Quote 2 — chronicle praise after Roman's death:**
+
+> «Пам'ятним самодержцем усієї Русі...»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched: false, best_confidence 0.0**. The classroom-source support is `search_text` result `7-klas-istoria-ukr-galimov-2024_s0170`, which also preserves the animal-simile praise. For lesson build, lock the final wording to a selected Galician-Volhynian Chronicle edition.
+
+**Quote 3 — proverb attributed to Roman:**
+
+> «Не почавивши бджіл, меду не наїсися».
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched: false, best_confidence 0.0**; `search_text` result `7-klas-istoria-ukr-galimov-2024_s0159` supports the attribution in a school-source context. Pedagogically useful for discussing elite violence and coercion, but not an autograph quote.
+
+## 5. Language register
+
+- **Register:** Galician-Volhynian chronicle style; princely title rhetoric; military-political narrative.
+- **CEFR readiness:** adapted narrative — B1-B2; source-genre discussion — C1; original chronicle/Old East Slavic forms — C2.
+- **Lexicon notes:** самодержець, княжий стіл, боярство, половецькі походи, спадщина, усобиці, об'єднання, Завихост. `verify_words` confirmed `самодержець`, `спадщина`, `боярство`; proper names such as Завихост are outside normal VESUM coverage.
+- **Stylistic features:** praise formula, beast similes, compressed campaign narrative, dynastic title language.
+
+## 6. Contested points
+
+- **What's debated:** exact birth year; whether Roman's second marriage was Byzantine-linked; the precise legal meaning of "самодержець"; the chronology of Kyiv control between 1201 and 1204; motives for the 1205 Polish campaign.
+- **What popular memory simplifies:** "creator of the Galician-Volhynian state" can hide the fact that unification required exploiting the Halych succession crisis and coercing local elites.
+- **Russian imperial attack / appropriation:** Russian-language summaries often normalize "Galitsko-Volynskaya Rus" inside a Russian-national timeline. The corrective is not to erase Rus, but to keep **Rусь** as a medieval Kyivan/Galician-Volhynian political-cultural term.
+- **Date guard:** his father **Mstyslav Iziaslavych died in 1170**, so Roman's move from Novgorod to Volhynia belongs to 1170, not 1173.
+- **Event-type guard:** 1199 = unification of Galicia + Volhynia; 1202 = taking Kyiv / Kyiv intervention; 1205 = death near Zawichost. Do not merge these into one generic "campaign."
+
+## 7. Cross-track links
+
+> Усі шляхи під **Existing** звірені `test -e` 2026-06-03. Жодних ghost wiki paths.
+
+- **Existing BIO plan-YAML (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml` — son and successor in the Romanovych line.
+  - `curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml` — grandson; later Galician-Volhynian continuity.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml` — later Romanovych ruler.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-monomakh.yaml` — dynastic and Kyiv political background.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/galytsko-volynska-derzhava.yaml` — direct state-formation context.
+  - `curriculum/l2-uk-en/plans/hist/danylo-halytskyi.yaml` — Romanovych inheritance after 1205.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kyivska-rus.yaml` — Rus context before western-state continuity.
+  - `curriculum/l2-uk-en/plans/hist/rus-ta-susidy.yaml` — neighbors, Polovtsians, Byzantium, Poland.
+- **Existing OES modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/oes/roman-mstyslavych.yaml` — close reading / source language anchor.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - `zawichost-1205` — event-focused module on Roman's death and Polish-Rus relations.
+  - `romanovychi-dynasty` — family tree and succession crisis after 1205.
+
+## 8. Naming-canonical
+
+- **Slug:** `roman-mstyslavych`
+- **EN canonical:** Roman Mstyslavych
+- **UA canonical:** Роман Мстиславич Великий
+- **Aliases:** Роман Мстиславич; Роман Великий; Roman Mstyslavych; Roman the Great.
+- **Forbidden forms:** Роман Мстиславич Галицкий as body-text norm; "Russian prince Roman"; "southwestern Russia" for Galicia-Volhynia.
+
+## 9. Image candidates
+
+- **No lifetime portrait exists.**
+- **Best PD/CC candidates:** Galician-Volhynian Chronicle manuscript imagery if available; maps of Galicia-Volhynia in 1199-1205; later iconographic/monumental images only with a rights and historical-distance note.
+- **Context image:** Zawichost / Vistula geography map for the death event, if rights-clear.
+- **Rights caveat:** individual Wikimedia/collection file pages must be checked in Phase 4; this dossier does not certify licenses.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Roman Mstyslavych." https://www.encyclopediaofukraine.com/display.asp?AddButton=pages%5CR%5CO%5CRomanMstyslavych.htm. WebFetch/curl status 200. Accessed 2026-06-03.
+- ЕІУ web-search result for «Роман Мстиславич» and «Мстислав Ізяславич» opened 2026-06-03; used for the 1170 father-death guard. Direct `resource.history.org.ua` URL was not curl-reachable from the worktree, so no lesson hyperlink should be exposed until rechecked.
+
+**Tier 2 / project corpus:**
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0159` — 1199 unification, 1202 Kyiv, title, Roman proverb, and the audit warning about a 1173 drift.
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0114` — 1199 unification, title, 1202 Kyiv, Polovtsian campaign context.
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0170` — 1205 death and chronicle praise.
+- `search_sources` Sofonovych chronology chunk — Kyiv-stool chronology around 1204; used only to prevent event conflation.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. «Роман Мстиславич», queried via `query_wikipedia` summary 2026-06-03; used for navigation only, never as primary.
+
+**Tier 4 (historiography / appropriation):**
+- «Синопсис Київський» (1674), used as the imperial narrative carrier to critique, not as a decolonial authority.
+
+**Primary-source documents accessed:** Galician-Volhynian Chronicle excerpts through project `search_text`; no autograph text by Roman survives.
+
+**Honest gaps:** The precise critical-edition wording of the chronicle praise must be locked before student close reading. The EIU direct URL for the Roman/Mstyslav entries did not curl-resolve from this environment; the source support is from search/open snippets and IEU.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Roman is situated in Rus / Volhynia / Halych / Kyiv, not a Russian national past.
+- [x] No Russian-imperial transliterations in body text except forbidden-form examples.
+- [x] No Russocentric periodization.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — death at Zawichost stated directly.
+- [x] Modern UA place names — Київ, Галич, Володимир, Завихост, Перемишль.
+- [N/A] Holodomor — not applicable to XII-XIII c.
+- [N/A] Crimea/2014/2022 — not directly applicable; modern appropriation is handled through the Rus-to-Moscow myth.

--- a/docs/research/bio/volodymyr-velykii.md
+++ b/docs/research/bio/volodymyr-velykii.md
@@ -1,0 +1,150 @@
+# Володимир Святославич Великий — Research Dossier
+
+**Slug:** `volodymyr-velykii`
+**Block:** BIO (медієвальний правитель — Київська Русь; постать, привласнена імперським наративом)
+**Tier:** 1a (державотворча постать першого ряду)
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — Wave K)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ, IEU, `search_text` textbook corpus, ПВЛ/Літопис Руський)
+- [x] §2 names the imperial appropriation mechanism (Синопсис 1674 / translatio imperii) instead of inventing a modern "repression" file
+- [x] Primary-source passages included with real tool status: `verify_quote` on chronicle quote returned `matched: false`, confidence 0.0; support comes from `search_text` / corpus-text retrieval
+- [x] Cross-track links verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidates identified with rights caveat
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Володимир Святославич; хрещене ім'я **Василій**; традиційні епітети — Володимир Великий, Володимир Святий. [T1: ЕІУ — Вортман, «Володимир Святославич Святий»; T1: IEU — *Volodymyr the Great*]
+- **Pseudonyms / aliases:** Володимир Великий; Володимир Святий; Володимир-Василій; князь Володимир; у фольклорі — Красне Сонечко. Заборонені імперські форми для body text: `Vladimir the Great`, `Владимир Святой`, `Saint Vladimir of Kiev` (із *Kiev*).
+- **Born:** приблизно середина X ст.; точний рік і місце не встановлені. IEU дає **ca 956**; ЕІУ обережніше: «р. н. невід.» [T1: IEU; T1: ЕІУ]
+- **Died:** **15 липня 1015**; ЕІУ подає дату без певного місця, IEU — Вишгород біля Києва. Обидва джерела погоджують рік і день смерті. [T1: ЕІУ; T1: IEU]
+- **Family / education key facts:** син Святослава Ігоровича і Малуші; онук княгині Ольги; батько Ярослава Мудрого, Мстислава Володимировича, Бориса і Гліба та інших синів. Спершу княжив у Новгороді під опікою Добрині, потім після усобиці 978/980 р. став київським князем. [T1: ЕІУ; T1: IEU]
+
+**Source-disagreement note (flagged, not smoothed):** Рік утвердження в Києві коливається між 978 і 980; IEU дає "from 980", ЕІУ прямо пише "978 або 980". Хронологія хрещення також складніша за шкільну формулу: ЕІУ посилає до теми «Хрещення Русі 987-989» і «Корсунський похід», тоді як підручникова рамка закріплює **988** як рік хрещення киян / Русі. Для wiki rebuild: у вступі можна писати "988" як навчальну дату Хрещення Русі, але в деталях слід пояснити 987-989 як комплекс подій. [T1: ЕІУ; T2: `search_text` result `7-klas-istoria-ukr-galimov-2024_s0071`]
+
+## 2. Механізм імперського привласнення
+
+Володимира не репресувала модерна спецслужба. Для постаті X-XI ст. load-bearing oppression mechanism — це **пізніше імперське привласнення київської спадщини**, яке перетворило князя, що правив у Києві за понад століття до появи Москви, на фундамент "російської" державної генеалогії.
+
+- **Текст і дата:** «**Синопсис Київський**», надрукований у Києво-Печерській лаврі **1674 р.** (із доповненнями 1678/1680), став ключовим носієм схеми "єдиного слов'яно-російського народу" і вписав київських князів у московську династично-церковну історію. Це джерело треба цитувати як **об'єкт критики**, не як деколонізаційний авторитет. [Primary/T4: `litopys.org.ua/synopsis/syn.htm`, WebFetch opened 2026-06-03; T5 navigation: Kievan Synopsis summary]
+- **Ідеологічна рамка:** *translatio imperii* — перенесення престижу і права влади з Києва на Москву: "Москва як спадкоємець Києва". У випадку Володимира це працює особливо агресивно, бо хрещення, тризуб і київський престол стають матеріалом для чужої державної легітимації.
+- **Інституційні продовження:** імперська й радянська традиції робили з Володимира "общерусского" святого і державця; сучасні московські пам'ятники та церковна риторика повторюють той самий жест — видерти князя з київського політичного простору. Педагогічний контрхід: показувати його через Київ, Русь, монети, Десятинну церкву, ПВЛ і західно-візантійську дипломатію, а не через пізню московську оптику.
+- **Що вижило / що спотворено:** вижили ПВЛ, нумізматичні джерела, археологія і західні хроніки; спотворено — лінію спадкоємності. Тризуб на монетах Володимира є прямим матеріальним містком до української державної символіки, не "спільною" прикрасою без політичного змісту. [T1: IEU — *Trident*; T2: `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0037`]
+
+## 3. Major works (державотворчі діяння)
+
+- `978/980` — утвердження в Києві після усобиці з Ярополком; завершення монополії Рюриковичів на ключові землі Русі. [T1: ЕІУ; T1: IEU]
+- `980` — язичницька реформа: пантеон із Перуном на київському пагорбі; ЕІУ фіксує також версію про спробу культу єдиного Перуна. [T1: ЕІУ]
+- `981-985` — західні й східні походи: Червенські гради, в'ятичі, радимичі, ятвяги, волзькі болгари/хозари в ширшій зовнішньополітичній програмі. [T1: ЕІУ; T1: IEU]
+- `987-989 / навчальна дата 988` — особисте хрещення, союз із Візантією, шлюб з Анною, хрещення Києва і запровадження християнства як державної релігії. [T1: ЕІУ; T1: IEU; T2: `search_text` `7-klas-istoria-ukr-galimov-2024_s0071`]
+- `кінець X ст.` — карбування **златників** і **срібляників** із княжим знаком; підручниковий корпус підтверджує написи «Володимир на столі», «Володимир, а це його срібло / золото». [T1: IEU — *Trident*; T2: `search_text` `7-klas-istoria-ukr-hlibovska-2024_s0037`]
+- `кінець X - поч. XI ст.` — Десятинна церква, перші школи, оборонні лінії проти печенігів, міста-фортеці. [T1: ЕІУ; T1: IEU]
+- `1015` — смерть і початок усобиці Володимировичів, з якої Ярослав вийде переможцем у 1019 р. [T1: ЕІУ — Ярослав Мудрий]
+
+## 4. Primary-source quotes
+
+**Quote 1 — ПВЛ / підручниковий витяг про примусову рамку хрещення киян (tool status explicit):**
+
+> «Якщо не з'явиться хто завтра на ріці — багатий, чи убогий, чи старець, чи раб, — то мені той противником буде».
+
+Tool status: `verify_quote(author="Літопис Руський", ...)` returned **matched: false, best_confidence 0.0** because the verifier is tuned for literary-author corpora, not chronicle/textbook excerpts. The passage is nevertheless tool-backed by `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0041`, which reproduces the ПВЛ excerpt. Pedagogically: this prevents hagiography; хрещення 988 was a state act with coercive force, not a purely voluntary scene.
+
+**Quote 2 — coin inscriptions, material primary text (numismatic):**
+
+> «Володимир на столі»; «Володимир, а це його срібло»; «Володимир, а це його золото».
+
+Tool status: not suitable for `verify_quote` (coin legends, not literary corpus); verified via `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0037` and corroborated by IEU *Trident* for Volodymyr's gold/silver coinage. Pedagogically: the phrase "на столі" anchors medieval political vocabulary (княжий стіл) and the trident in state practice.
+
+## 5. Language register
+
+- **Register:** літописна оповідь ПВЛ у перекладі Махновця / навчальних адаптаціях; нумізматичні формули; богословсько-політична лексика хрещення.
+- **CEFR readiness for full reading:** адаптований переказ — B1-B2; ПВЛ у сучасному перекладі — B2-C1; оригінальна давньоруська / церковнослов'янська форма — C2.
+- **Lexicon notes:** хрещення, тризуб, златник, срібляник, десятина, княжий стіл, порфірородна / багрянородна, печеніги, Змієві вали. `verify_words` confirmed the core forms `хрещення`, `тризуб`, `златник`, `срібляник`, `данина`; proper names/toponyms are outside VESUM by nature.
+- **Stylistic features:** пряма мова літопису, формула влади "на столі", християнська легітимаційна мова, контраст між агіографічним образом святого і політичним насильством державотворення.
+
+## 6. Contested points
+
+- **Що дискутує наука:** точна хронологія 987-989; місце особистого хрещення (Київ / Корсунь / комплекс подій); мотиви — віра, династичний шлюб, військова допомога Василію II, централізація влади.
+- **Що спрощує популярна пам'ять:** "язичник став святим" як психологічна казка. Досьє має тримати обидві правди: Володимир був жорстоким політиком усобиці й водночас правителем, чиї реформи дали Русі нову культурну інфраструктуру.
+- **Russian imperial attack / appropriation:** Володимир присвоюється як "общерусский" засновник. Контрфакт: його політичний центр — Київ; його символ на монетах — тризуб; його пам'ять у діаспорі прямо маркована як українська, наприклад лондонський пам'ятник 1988 р. має напис "ruler of Ukraine 980-1015" і позначку Leo Mol. [T5: London Remembers, WebFetch opened 2026-06-03]
+- **Date guard for rebuild:** не писати, що Ярослав-Мстислав дуумвірат почався 1022. ЕІУ уточнює: Мстислав осів у Чернігові після невдалої спроби 1022; поділ Руської землі по Дніпру оформився **після Лиственської битви 1024 і миру 1026**; співправління тривало до смерті Мстислава 1036. [T1: ЕІУ — Ярослав Мудрий]
+
+## 7. Cross-track links
+
+> Усі шляхи під **Existing** звірені `test -e` 2026-06-03. Жодних ghost wiki paths.
+
+- **Existing BIO plan-YAML (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/knyahynia-olha.yaml` — бабуся, попередня спроба християнізації.
+  - `curriculum/l2-uk-en/plans/bio/kniaz-yaroslav-mudryi.yaml` — син і спадкоємець політичної програми.
+  - `curriculum/l2-uk-en/plans/bio/kniaz-sviatoslav.yaml` — батько; контраст військової експансії й державної інституціоналізації.
+  - `curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml` — головна літописна рамка.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/volodymyr-khreshchennia.yaml` — основний історичний контекст хрещення.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kyivska-rus.yaml` — синтетичний модуль про Русь.
+  - `curriculum/l2-uk-en/plans/hist/kultura-kyivskoi-rusi.yaml` — культурні наслідки християнізації.
+  - `curriculum/l2-uk-en/plans/hist/sofiya-kyivska.yaml` — пізніша київська сакральна архітектура в тяглості.
+- **Existing OES modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/oes/pvl-volodymyr-choice.yaml` — close reading ПВЛ про вибір віри.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - `trident-state-symbolism` — від монет Володимира до герба УНР і України.
+  - `synopsis-1674-rus-appropriation` — спільний деколонізаційний вузол для Володимира, Ольги, Ярослава, Романовичів.
+
+## 8. Naming-canonical
+
+- **Slug:** `volodymyr-velykii`
+- **EN canonical (BGN/PCGN-style):** Volodymyr the Great
+- **UA canonical:** Володимир Святославич Великий
+- **Aliases (for `aliases:`):** Володимир Святославич; Володимир Великий; Володимир Святий; Володимир-Василій; Volodymyr the Great.
+- **Forbidden forms (Russian-imperial / Russified):** Vladimir the Great; Владимир Святой; Saint Vladimir of Kiev; "Kievan" when the local style requires Kyiv/Kyivan.
+
+## 9. Image candidates
+
+- **No lifetime portrait exists**; every image is later iconography, coinage, sculpture, or manuscript art.
+- **Best PD/CC candidates:** zlatnyk/sribnyk images showing Volodymyr and the trident; Radziwill Chronicle miniatures of baptism; Kyiv monument if rights-clear.
+- **Commemorative context:** London Saint Volodymyr statue by **Leo Mol**, erected 1988; URL verified through London Remembers, but image reuse requires separate license review. [T5: London Remembers — Saint Volodymyr]
+- **Fallback:** use a coin/trident image rather than a romanticized portrait; it directly supports the dossier's source argument.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Вортман Д. Я. «Володимир Святославич Святий» // *Енциклопедія історії України*. URL verified by WebFetch as `resource.history.org.ua` result; canonical short URL: https://www.history.org.ua/?termin=Volodymyr_Sv. Accessed 2026-06-03.
+- *Internet Encyclopedia of Ukraine.* "Volodymyr the Great." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CO%5CVolodymyrtheGreat.htm. WebFetch/curl status 200. Accessed 2026-06-03.
+- *Internet Encyclopedia of Ukraine.* "Trident." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CT%5CR%5CTrident.htm. WebFetch/curl status 200. Accessed 2026-06-03.
+
+**Tier 2 / primary text via project corpus:**
+- `search_text` result `7-klas-istoria-ukr-galimov-2024_s0071` — 988/990 baptism chronology and Byzantine marriage context.
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0037` — zlatnyky/sribnyky, trident, coin inscriptions.
+- `search_text` result `7-klas-istoria-ukr-hlibovska-2024_s0041` — ПВЛ excerpt on baptism of Kyiv.
+
+**Tier 3 (encyclopedic — navigation, cross-checked):**
+- Українська Вікіпедія. «Володимир Святославич» queried via `query_wikipedia` summary 2026-06-03; used for navigation only.
+
+**Tier 4 (historiography / appropriation):**
+- «Синопсис Київський» (1674), Litopys access copy: https://litopys.org.ua/synopsis/syn.htm. WebFetch opened 2026-06-03; used as primary evidence of imperial narrative, not as authority.
+
+**Tier 5 (general web, only for commemoration detail):**
+- London Remembers. "Saint Volodymyr." https://www.londonremembers.com/memorials/saint-volodymyr. WebFetch/curl status 200; verifies inscription, 1988 date, Leo Mol mark.
+
+**Primary-source documents accessed:** ПВЛ / Літопис Руський in textbook/corpus excerpt; coin inscriptions from Volodymyr's zlatnyky/sribnyky; «Синопсис Київський» as hostile/imperial narrative evidence.
+
+**Honest gaps:** Direct manuscript apparatus for ПВЛ was not opened in this pass; the chronicle quote is backed through project `search_text`, not `verify_quote`. Specific Commons image licenses were not selected; Phase 4 must verify individual file pages.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Володимир is anchored in Kyiv/Rus/Ukraine, not Moscow.
+- [x] No Russian-imperial transliterations in body text except the forbidden-form list.
+- [x] No Russocentric periodization — "Русь", "Київська Русь", "Київська держава"; no "ancient Russia."
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — deaths/violence stated directly.
+- [x] Modern UA place names — Київ, Вишгород, Корсунь/Херсонес with context.
+- [N/A] Holodomor — not applicable to X-XI c.
+- [N/A] Crimea/2014/2022 — not central to this figure; modern Russian aggression is relevant only as background to appropriation pedagogy.


### PR DESCRIPTION
## Summary

Adds six sourced BIO research dossiers for #2535 Wave K, covering Kyivan-Rus and Galicia-Volhynia rulers that had live wiki entries but no research dossiers.

## Per figure

- `volodymyr-velykii` — Key facts: 988/987-989 baptism frame, trident coinage on zlatnyky/sribnyky, Thietmar 400 churches/8 markets caution, London St Volodymyr statue by Leo Mol. ⚠ Resolved: no ghost wiki paths; Yaroslav-Mstislav duumvirate guarded as post-Listven 1024 / 1026 settlement, not 1022. Honest gaps: chronicle quote verifier returned no match, so support is through project `search_text`.
- `kniaz-yaroslav-mudryi` — Key facts: 1019-1054 rule, duumvirate with Mstislav until 1036, Yuriev/Tartu 1030, Ruska Pravda, Yaroslaviv riad succession, European dynastic marriages. ⚠ Resolved: Casimir I kept as Polish duke in Yaroslav's lifetime; no ghost history paths. Honest gaps: chronicle/legal quotes need selected-edition locking before close reading.
- `kniaz-sviatoslav` — Key facts: Khazar campaign, Itil/Sarkel, Balkan wars against John I Tzimiskes, death in spring 972 at Dnipro rapids by Pecheneg khan Kurya. ⚠ Resolved: skull-cup marked as chronicle account/legend; Hrushevsky labels report actual `verify_quote` failures. Honest gaps: minor art/attribution claims not asserted.
- `roman-mstyslavych` — Key facts: 1170 Volhynian succession, 1199 Galicia-Volhynia unification, 1202 Kyiv-taking, chronicle title `самодержець усієї Русі`, death 1205 near Zawichost fighting Leszek the White's forces. ⚠ Resolved: father Mstyslav Iziaslavych death guarded as 1170, not 1173. Honest gaps: EIU direct URL did not curl-resolve from worktree, so the dossier relies on IEU URL 200 plus opened search snippets for that guard.
- `danylo-halytskyi` — Key facts: Battle of Yaroslav 1245, coronation by papal legate 1253 as King of Rus, Lviv named for Lev with 1256 first-mention caveat, Kuremsa/Burundai pressure, death 1264. ⚠ Resolved: Lev death guarded as ca. 1301, not 1308; Hrushevsky quote verified true at confidence 0.9167. Honest gaps: exact Lviv foundation chronology remains caveated.
- `lev-danylovych` — Key facts: Lev ca. 1264-ca. 1301, capital move to Lviv ca. 1272, nickname `Шалений`, reliance on Horde power, Lublin/Zakarpattia/Mukachevo claims in school corpus. ⚠ Resolved: Yurii I Lvovych identified as Lev's son, not grandson; Lviv Magdeburg rights guarded as 1356 post-Lev; Voishelk killing included. Honest gaps: opened sources support killing of Voishelk, not a poison mechanism, so poison remains `[UNVERIFIED]` pending higher-tier source.

## Validation

- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py` — pass
- `git diff --check` / staged diff check — pass
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — pass

No auto-merge.
