### PR TITLE
research(bio): salvage 2 dossiers (petliura, kostenko) from limit-interrupted waves (#2535)

### DIFF
--- a/docs/research/bio/lina-kostenko.md
+++ b/docs/research/bio/lina-kostenko.md
@@ -1,0 +1,175 @@
+# Ліна Василівна Костенко — Research Dossier
+
+**Slug:** `lina-kostenko`
+**Block:** J (living / modern writers — Soviet-era censorship survivor)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 — Wave J)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ, ЕСУ, IEU)
+- [x] Oppression mechanism is specific (named ideologue, dated CPU directives, blacklist author, document trail)
+- [x] ≥2 primary-source quotes (verified in `ukrlib-kostenko`, scores reported)
+- [x] Cross-track links: every "Existing" path verified with `test -e` 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified — **living-person rights caveat flagged**
+- [x] Decolonization checklist self-applied
+- [x] **Living person**: sourced facts only; mixed reception of «Записки…» and the silence-vs-escape debate presented, not smoothed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ліна Василівна Костенко. [T1: ЕІУ — Костенко Ліна Василівна (І. Дзюба, т. 5, с. 222); T1: ЕСУ — Костенко Ліна Василівна; T1: IEU — Kostenko, Lina]
+- **Pseudonyms / aliases:** none. Russified/Russian-imperial forms (forbidden in body text, listed only in §8): Лина Васильевна Костенко.
+- **Born:** 19 March 1930 | місто **Ржищів**, Київська округа, Українська СРР | now Ржищів, Київська область, Україна. **Alive** (turned 96 in March 2026). [T1: IEU — "19 March 1930 in Rzhyshchiv, Kyiv oblast"; T3: uk.wikipedia — "19 березня 1930, Ржищів"]
+- **Family / education key facts:** Daughter of teachers Василь Григорович and Зінаїда Юхимівна Костенки; the family moved to Kyiv in 1936 and lived on the Труханів острів workers' settlement (school burned with the settlement in 1943). Studied at the Київський педагогічний інститут, then graduated from the **Московський літературний інститут ім. Горького in 1956**. First marriage to Polish writer **Єжи-Ян Пахльовський** — daughter **Оксана Пахльовська** (b. 18 Sep 1956, writer/culturologist, professor of Ukrainian at Rome's «La Sapienza»). Second marriage to film scholar **Василь Цвіркунов** (head of the Dovzhenko Film Studio in the 1960s) — son Василь (b. 1969, programmer in California). [T1: IEU — "graduated from the Gorky Institute of Literature in Moscow in 1956"; T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** The **suppression year of «Зоряний інтеграл»** differs across Tier 1/Tier 3: IEU dates the suppression to **1962** ("ideologically harmful and a departure from socialist realism"); Ukrainian Wikipedia dates the withdrawal of the typeset book to **1963** ("у 1963 році зняли з друку"). The events are the same act of censorship; the year is given here as **1962/1963** rather than collapsed. Likewise **«Берестечко»** carries a long composition span — IEU gives it as begun **1966**, the book published only **1999** — do not conflate composition with publication.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Kostenko was **not arrested or imprisoned** (unlike camp-bound peers Стус, Світличний); her oppression was the documented Soviet machinery of **ideological denunciation, censorship and blacklist** — professional silencing of a writer who would not recant. The template's specificity rules apply equally to indirect oppression.
+
+- **What happened:** systematic removal from print, public denunciation by name from the CPU Central Committee podium, and inclusion on a secret ideological blacklist — a ~16-year exclusion from original publication in Ukraine.
+- **When (specific dates):**
+  - From **1961** she is attacked for «аполітичність»; the film after her screenplay «Дорогою вітрів» is pulled from production. [T3: uk.wikipedia]
+  - **8 April 1963** — at an ideological conference the CPU Central Committee secretary for ideology **Андрій Скаба** declared that "формалістичні викрутаси зі словом" appear in "деякі твори молодих поетів Миколи Вінграновського, Івана Драча, Л. Костенко" — naming her was "сигнал до погрому покоління шістдесятників." [T3: uk.wikipedia, citing the conference record]
+  - **1962/1963** — the typeset collection **«Зоряний інтеграл»** is suppressed; **«Княжа гора»** is later pulled from the press (1972). [T1: IEU; T3: uk.wikipedia]
+  - **1973** — she is placed on the **"чорні списки"** compiled by the CPU CC secretary for ideology **Валентин Маланчук**. Only after Malanchuk's removal does **«Над берегами вічної ріки»** appear in **1977** — her first new collection in Ukraine since 1961. [T3: uk.wikipedia; corroborated T1: IEU — "remained unpublished in Ukraine until 1977"]
+- **By whom (named agency / officials):** the **ЦК КПУ** ideological apparatus — secretaries for ideology **Андрій Скаба** (1963 denunciation) and **Валентин Маланчук** (1973 blacklist); enforced through Голов­літ censorship and the Спілка письменників України. This is Party-administrative repression, not the security organs, and is named as such.
+- **Document references (named, not paraphrased):** the 8 April 1963 ideological-conference statement by Скаба (quoted above); the Malanchuk **«чорні списки»** of 1973; the special **Постанова Президії СПУ** that finally released «Маруся Чурай» (written ~1973, it "пролежав без руху шість років" before its 1979 printing). [T3: uk.wikipedia; T1: ЕІУ]
+- **Mechanism specifics:** Through the late 1960s Kostenko also took **public stands** that deepened her blacklisting: she signed the 1965 protest against the arrests of the intelligentsia, attended the Lviv trials of Михайло Осадчий and Мирослава Зваричевська, threw flowers to the **Horyn brothers** at their trial, and signed the 1968 **«лист-протест 139»** to Brezhnev, Kosygin and Pidhorny demanding an end to illegal political trials; she also wrote in defence of **В'ячеслав Чорновіл**. After this "ім'я Ліни Костенко радянська преса довгі роки не згадувала" — she "працювала в шухляду" (wrote "into the drawer"). [T3: uk.wikipedia]
+- **What survived / what was destroyed:** nothing was physically destroyed, but a decade-plus of her work circulated only abroad (Czechoslovak journals, Polish papers) and in **самвидав**; «Зоряний інтеграл» never appeared as planned. The mechanism is **silencing-without-martyrdom**: deny the page, not the life — which is itself the core of the §6 debate.
+
+## 3. Major works
+
+- `1957` — **«Проміння землі»**, debut poetry collection. [T3: uk.wikipedia]
+- `1958` — **«Вітрила»**, poetry. [T3]
+- `1961` — **«Мандрівки серця»**, poetry — "засвідчила творчу зрілість," her last book for 16 years. [T3]
+- `1963` — **«Зоряний інтеграл»**, poetry — **suppressed/never issued** (набір "розсипано"). [T1: IEU; T3]
+- `1972` — **«Княжа гора»**, poetry — **pulled by censorship**, unpublished. [T3]
+- `1977` — **«Над берегами вічної ріки»**, poetry — the breakthrough back into print. [T1: IEU; T3]
+- `1979` — **«Маруся Чурай»**, **історичний роман у віршах** (Радянський письменник) — a semi-legendary Poltava songwriter against the Cossack–Polish war; **Shevchenko Prize 1987**. The signature work. [T1: IEU; T3]
+- `1980` — **«Неповторність»**, poetry (co-cited for the 1987 Shevchenko Prize). [T1: IEU]
+- `1987` — **«Сад нетанучих скульптур»**, poetry — **Antonovych Prize 1989**. [T3]
+- `1987` — **«Бузиновий цар»**, poetry for children. [T3]
+- `1999` — **«Берестечко»**, роман у віршах (composed from 1966) — the 1651 battle as national reckoning. [T1: IEU; T3]
+- `1999` — **«Гуманітарна аура нації, або Дефект головного дзеркала»**, inaugural lecture at НаУКМА — programmatic essay on cultural self-image. [T3]
+- `2010` — **«Записки українського самашедшого»**, her **first prose novel** — a 2000s panorama in a male diarist's voice; a 2011 bestseller and a **critically divisive** book (see §6). [T3]
+- `2011` — **«Річка Геракліта»**, **«Мадонна перехресть»**; `2026` — **«Вітер з Марса»**, new poems. [T3]
+
+## 4. Primary-source quotes (≥2 required)
+
+All quotes verified against the **`ukrlib-kostenko`** corpus via `verify_quote` (scores reported, not asserted).
+
+**Quote 1 — ars poetica / moral credo, from the sonnet «Життя іде і все без коректур…»:**
+
+> «Життя іде і все без коректур, / і як напишеш, так уже і буде. / Але не бійся прикрого рядка. / … / Не бійся правди, хоч яка гірка…»
+
+`verify_quote` matched the opening line at **confidence 0.9833** (work `ukrlib-kostenko`; source attribution: Поезія, "Наукова думка", Київ, 1998). Pedagogically central: the irreversibility-of-the-written-word as an ethic of honesty — the exact stance that cost her 16 years of print silence (§2). [Primary: ukrlib-kostenko; verify_quote 0.9833]
+
+**Quote 2 — chosen fate over comfort, the line most often read as her biography in one sentence:**
+
+> «Я вибрала Долю собі сама.»
+
+`verify_quote` matched at **confidence 0.9634** (work `ukrlib-kostenko`). Useful for framing the silence-as-choice debate (§6): she casts the withdrawal as election, not victimhood. [Primary: ukrlib-kostenko; verify_quote 0.9634]
+
+**Quote 3 — the cyclical resilience aphorism (supporting):**
+
+> «І все на світі треба пережити, / і кожен фініш — це, по суті, старт.»
+
+`verify_quote` matched the first line at **confidence 0.9846** (`ukrlib-kostenko`). [Primary: ukrlib-kostenko; verify_quote 0.9846]
+
+**Recorded-speech specimen (not from a literary work — register sample, §5):** declining the title Hero of Ukraine, she answered **«Політичної біжутерії не ношу!»** ("I don't wear political costume jewellery"). This is reported speech in the press, not a verse line, and is labelled as such. [T3: uk.wikipedia]
+
+## 5. Language register
+
+- **Register:** high modernist–**neoclassical** lyric — clear, aphoristic, syntactically transparent diction in the line of Зеров/Рильський rather than baroque density. Her hallmark is the epigrammatic closing couplet (Quotes 1–3). Historical verse (Маруся Чурай, Берестечко) layers in 17th-c. Cossack-era lexis and toponymy.
+- **CEFR readiness for full reading:** shorter lyric **B1–B2**; the novels-in-verse «Маруся Чурай» / «Берестечко» **B2–C1** (period vocabulary, historical reference); the «Гуманітарна аура нації» essay **C1**.
+- **Lexicon notes:** standard literary Ukrainian with comparatively few dialectisms — one of the more L2-accessible major poets. Terms a module should pre-teach are mostly **meta-vocabulary about her era**: шістдесятники / шістдесятниця, дисидентка, самвидав, цензура, відлига, аполітичність, роман у віршах — all VESUM-verified present (10/10 batch, 2026-06-03).
+- **Stylistic features:** epigram and antithesis; the sustained historical monologue in the verse-novels; controlled, "cold-clear" imagery. The pedagogical entry point is a single short sonnet (Quote 1) before any verse-novel excerpt.
+
+## 6. Contested points
+
+- **«Записки українського самашедшого» (2010) — genuinely mixed reception (required balance).** The novel was a commercial phenomenon (official print run ~80,000 by June 2011) and was praised as a panoramic diagnosis of 2000s Ukraine and of a "цунамі брехні" / Russian information war. But it drew substantial criticism: that it reads as **publicistic monologue/rant** rather than crafted fiction; that the male-diarist voice is a thin mask for the author's op-ed; and that some passages carry **xenophobic/homophobic** notes. The Jan–Feb 2011 promotional tour was abruptly **cut short on 9 February 2011** after, in the publisher's words, "провокативні інсинуації деяких львівських письменників, журналістів та діячів театру." The book is therefore a live critical argument, not a settled triumph. [T3: uk.wikipedia; T5: Український тиждень, 08.06.2011]
+- **Silence — resistance or escape?** Modern scholarship (Іван Дзюба, monograph «Є поети для епох», 2012) frames her long withdrawal as principled dissidence. A counter-reading notes she avoided the camps that broke Стус and Світличний and asks whether "writing into the drawer" was also self-protective retreat. Her own line «Я вибрала Долю собі сама» (Quote 2) is claimed by both readings. Presented here as an **open debate**, not resolved. [T4: Дзюба 2012; T3]
+- **Refusal of state honours.** Declining Hero of Ukraine («Політичної біжутерії не ношу!») is read by admirers as integrity and by sceptics as performance; both readings are in circulation. [T3]
+- **Russian disinformation.** As a living symbol of Ukrainian cultural sovereignty (Légion d'honneur 2022; honorary citizen of Kyiv 2024), she is a target of Russian narrative attacks; «Записки…» itself anticipates and names that information war. [T3; T5]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/kostenko-poetry.yaml` — her lyric corpus; the tightest link.
+  - `curriculum/l2-uk-en/plans/lit/kostenko-marusia-churai-1.yaml` and `curriculum/l2-uk-en/plans/lit/kostenko-marusia-churai-2.yaml` — the verse-novel, two-part study.
+  - `curriculum/l2-uk-en/plans/lit/kostenko-garden-of-unthawed-sculptures.yaml` — «Сад нетанучих скульптур».
+  - `curriculum/l2-uk-en/plans/lit/shestydesiatnyky-as-phenomenon.yaml` — her literary generation.
+- **Existing BIO plans (VERIFIED present) — her шістдесятники cohort:**
+  - `curriculum/l2-uk-en/plans/bio/ivan-drach.yaml` — co-denounced with her by Скаба in 1963; her ally in defending the arrested.
+  - `curriculum/l2-uk-en/plans/bio/mykola-vinhranovskyi.yaml` — co-denounced in the same 1963 statement.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml`, `curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml` — the camp-bound wing of the generation (the §6 contrast).
+  - `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml` — author of the major monograph on her («Є поети для епох»).
+  - `curriculum/l2-uk-en/plans/bio/dmytro-pavlychko.yaml` — шістдесятник peer.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml` — the dissident-generation context of §2.
+  - `curriculum/l2-uk-en/plans/hist/chornobyl.yaml` — she scripted «Чорнобиль. Тризна» (1993) and led literary expeditions into the exclusion zone.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - Оксана Пахльовська (her daughter; diaspora-theory scholar) — no `plans/bio/oksana-pakhlovska.yaml` yet.
+  - В'ячеслав Чорновіл (whom she publicly defended) — candidate bio.
+  - A LIT module on «Берестечко» as national-defeat reckoning — not yet built.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A «Записки українського самашедшого» reception-debate seminar bridging B2 lyric and C1 critical-reception analysis.
+
+## 8. Naming-canonical
+
+- **Slug:** `lina-kostenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Lina Kostenko
+- **UA canonical (with patronymic):** Ліна Василівна Костенко
+- **Aliases to track (`aliases:` YAML field):** Lina Kostenko; Lina Vasylivna Kostenko.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Лина Костенко; Лина Васильевна Костенко; "Kostenko, Lina" Russified transliterations of the patronymic (Vasilyevna).
+
+## 9. Image candidates
+
+- **Living-person rights caveat (load-bearing):** Kostenko is alive, so **no portrait is public-domain by age**. Any photo needs an explicit free licence — do **not** assume Wikimedia Commons presence equals reuse rights.
+- **Best free-licence candidate:** search Wikimedia Commons category **"Lina Kostenko"** for images released **CC BY / CC BY-SA** (e.g. event photos uploaded by Ukrainian institutions); verify the **individual file page** licence, not the category.
+- **Backup candidates:** a CC-licensed press photo from a state ceremony (e.g. the 2022 Légion d'honneur award, or 2024 honorary-citizen-of-Kyiv events) — confirm licence at source.
+- **If no free-licence portrait clears review:** fall back to a rights-cleared cover scan of «Маруся Чурай» or the minor planet 290127 Лінакостенко context image; flag for the image-rights reviewer.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Дзюба І. М. "Костенко Ліна Василівна." *Енциклопедія історії України*, т. 5 (Кон–Кю). Київ: Наукова думка, 2009. С. 222. ISBN 978-966-00-0855-4.
+- Дзюба І. М. "Костенко Ліна Василівна." *Енциклопедія Сучасної України*. Київ: Інститут енциклопедичних досліджень НАН України, 2001–2025.
+- "Kostenko, Lina." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKostenkoLina.htm. Accessed 2026-06-03 (WebFetch-confirmed: birth date, 1962 suppression, "unpublished until 1977", Marusia Churai 1979, Shevchenko Prize 1987).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Костенко Ліна Василівна." Dates/works/blacklist cross-checked against ЕІУ, ЕСУ, IEU. Accessed 2026-06-03.
+
+**Tier 4 (modern scholarly):**
+- Дзюба І. *Є поети для епох* (монографія про Ліну Костенко). Київ: Либідь, 2012.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- "Ліна Костенко про цунамі брехні…" *Український тиждень*, 08.06.2011 — reception/themes of «Записки…». (Cited via T3 reference list; treat as interview color, corroborated by T3.)
+
+**Primary-source documents accessed (in transcription):**
+- The 8 April 1963 ideological-conference statement by А. Скаба and the 1973 Malanchuk «чорні списки», via the documented record summarised in T3 (uk.wikipedia), cross-checked against IEU's independent "unpublished until 1977".
+- Her own verse via the **`ukrlib-kostenko`** corpus (Quotes 1–3, `verify_quote` 0.98/0.96/0.98).
+
+**Honest gaps:** ЕСУ and ЕІУ were accessed through the named author/volume/page citation and the IEU English parallel (WebFetch-confirmed), not via a separately fetched ЕСУ article URL (ЕСУ's article-NNNN slug was not resolved this pass). The two famous lines «Страшні слова, коли вони мовчать» and «Поезія — це завжди неповторність» are **not** in the `ukrlib-kostenko` corpus chunks (verify_quote 0.0) and are therefore **not** quoted as verified here, despite being widely attributed to her — an honest-gap call per the anti-fabrication rule.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — her story is told on Ukrainian terms; Soviet power appears only as the silencing apparatus.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used «відлига» / шістдесятники, not Soviet-era euphemism.
+- [x] No uncritical Soviet propaganda terms — "формалістичні викрутаси," "аполітичність" appear only quoted as the regime's own denunciation, named as such.
+- [x] No "lost his life" euphemisms — N/A (figure alive); used "censorship / blacklist / silenced" for the documented repression.
+- [x] Modern UA place names — Київ/Kyiv, Ржищів, Київська область.
+- [N/A] Holodomor — не стосується цієї постаті (нар. 1930; у тілі досьє не фігурує).
+- [x] Russian aggression framing — «Записки…» and her post-2022 honours are set against Russia's information war / full-scale invasion (§6).

--- a/docs/research/bio/symon-petliura.md
+++ b/docs/research/bio/symon-petliura.md
@@ -1,0 +1,178 @@
+# Симон Васильович Петлюра — Research Dossier
+
+**Slug:** `symon-petliura`
+**Block:** G (politically charged — liberation-struggle statesman; assassinated in emigration)
+**Tier:** 1a
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU [T1]; Hunczak, Либідь 1993 [T2]; Abramson, HURI 1999 [T2])
+- [x] Oppression mechanism is specific (date, killer, agency-attribution, trial dates, verdict)
+- [x] ≥2 primary-source quotes (from Петлюра. Статті, листи, документи)
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+- [x] §6 ≥300 words (Block G requirement) — the 1919–20 pogrom question is presented in BOTH directions
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Си́мон Васи́льович Петлю́ра (name at birth recorded as Семе́н Васильович). [T1: IEU — Petliura, Symon; T3: uk.wikipedia — Петлюра Симон Васильович]
+- **Pseudonyms / aliases:** literary/political pen-names including **В. Марченко**, **В. Салевський**, **Симон Орлик**, **О. Ряст**. Russian-imperial forms (forbidden in body text, listed only in §8): Симон Васильевич Петлюра, Simon/Symon Petlyura (Petlura).
+- **Born:** **10 (22 н. ст.) травня 1879** | передмістя **Полтави** (вул. Загородня, нині вул. Капітана Володимира Кісельова) | Російська імперія. Third son in a Poltava міщани family of the Cossack Петлюра line; mother from the old Poltava Марченко line. [T1: IEU — "b 10 May 1879 in Poltava"; T3: uk.wikipedia — "народився в передмісті Полтави"]
+- **Died:** **25 травня 1926** (aged 47) | **Париж**, ріг вул. Расін і бульвару Сен-Мішель | Французька Республіка | **застрелений сімома пострілами** Шоломом (Самуїлом) Шварцбардом; buried at cimetière du Montparnasse, ділянка №11. [T1: IEU — "d 25 May 1926 in Paris (assassinated)"; T3: uk.wikipedia — Вбивство Симона Петлюри]
+- **Family / education key facts:** Studied at the **Полтавська духовна семінарія**, expelled in 1901 for nationalist/political activity; joined the Революційна українська партія (РУП), later УСДРП. Worked as a teacher, journalist and editor (Львів, Київ, later Москва) before 1917. Married Olha Bilska; daughter Lesia (d. 1941). [T1: IEU; T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** The **degree of Petliura's command responsibility for the 1919–20 pogroms** is the single genuinely contested point of his biography and is treated at length in §6 — it is a live scholarly debate (Hunczak/Abramson vs Gilley vs Gergel's statistics), not a settled fact in either direction. The **scale of Jewish deaths** is itself a range, not a number: sources give **35,000–50,000** killed in pogroms across UNR-controlled territory in 1919–20, attributed across many armed actors (see §2/§6). His **given name** appears in records as both Семен (at birth) and the canonical **Симон**.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Petliura is a **liberation-struggle leader assassinated in emigration**, and — separately — the target of a seven-decade Soviet disinformation campaign. Both must be stated precisely.
+
+- **What happened:** Targeted assassination. On **25 травня 1926**, ≈2 p.m., as Petliura paused at a bookshop window on the corner of rue Racine and boulevard Saint-Michel in Paris, **Шолом (Самуїл) Шварцбард** fired **seven** revolver shots into him and then waited beside the body for the police. Petliura was rushed to a clinic on boulevard Saint-Germain but could not be saved. [T3: uk.wikipedia — Вбивство; T1: IEU]
+- **When (specific):** the killing **25 May 1926**; the trial of Schwartzbard opened **18 October 1927** and, **eight days later (≈26 October 1927)**, the Cour d'assises de la Seine **acquitted** him **by eight jurors to four**. [T3: uk.wikipedia — "18 жовтня 1927 року Шварцбард постав перед судом… Через вісім днів… вісьмома голосами проти чотирьох був виправданий"]
+- **By whom (attribution):** The killing is widely attributed by Ukrainian and Western researchers to a **Soviet (ОДПУ/ГПУ) operation** for which the pogrom-vengeance motive served as cover. The attribution rests on: (a) the activity in Paris from 1925 of **Михайло Володін**, named as a GPU agent who cultivated Schwartzbard (per the trial-time statement of Elia Dobkovsky and the study of **А. Яковлів, «Паризька трагедія»**); (b) the 1954 US Congress testimony of KGB defector **Petro Deriabin**. This attribution is **probable and well-argued but not archivally closed** — it is presented here as the dominant scholarly reading, not as proven beyond dispute. [T3: uk.wikipedia — Вбивство, Процес Шварцбарда]
+- **Document references (the trial record):** At the 1927 process the prosecution "**не висунули жодних переконливих доказів особистої причетності Петлюри до погромів чи організації погромів**," and the defence introduced **понад 200 документів** showing the UNR government's attempts to halt pogroms — documents the court declined to weigh. [T3: uk.wikipedia — Процес Шварцбарда]
+- **The documented anti-pogrom record (load-bearing for §6):** Petliura's government issued punitive measures against pogromists — e.g. отаман **Іван Семесенко**, responsible for the Proskuriv massacre (February 1919), was arrested in May 1919 and **shot in spring 1920**; the UNR allocated 20 million hryvni to victims' families; Petliura issued army orders condemning pogroms, the best-known being **Наказ Військам УНР ч. 131 (26 серпня 1919, Кам'янець-Подільський)**, and an **address to the population of 18 березня 1921** (in emigration) deploring the pogroms. [T3: uk.wikipedia — Єврейські погроми…; T2: Hunczak — Симон Петлюра та євреї]
+- **The second oppression — Soviet erasure and inversion:** For decades the USSR weaponised the pogrom charge to brand the entire Ukrainian liberation movement "петлюрівщина" / "буржуазно-націоналістична" banditry, making "Petliura" a Soviet synonym for Ukrainian nationalism-as-criminality. Lenin personally tracked Petliura's emigration activity as a threat. The assassination removed the most prominent émigré leader of the movement; the trial's acquittal then supplied a durable propaganda frame. [T3: uk.wikipedia — Вбивство]
+- **What survived / what was destroyed:** Petliura's published articles, letters and documents survive (collected as **«Статті, листи, документи»**, multiple volumes); the UNR state-in-exile (ДЦ УНР) he led continued in emigration until 1992, when it formally transferred its mandate to independent Ukraine.
+
+## 3. Major works
+
+Petliura was a working **publicist and editor** before he was a statesman; his "works" are political journalism, editorial leadership, and state/army documents.
+
+- `1900s` — co-founder/editor of РУП and Ukrainian social-democratic journalism; editor of **«Слово»** (organ of УСДРП). [T1: IEU]
+- `1906–1908` — editorial work in Київ; co-edited **«Україна»** and **«Рада»** circles. [T3: uk.wikipedia]
+- `1912–1917` — editor of the influential Moscow-based Ukrainian monthly **«Украинская жизнь»** (Russian-language journal advocating Ukrainian cultural-political rights). [T1: IEU]
+- `1917` — Генеральний секретар військових справ of the Центральна Рада; organiser of the Ukrainian army. [T1: IEU]
+- `1918–1919` — leader of the anti-Hetman uprising; from **11 лютого 1919** **Голова Директорії УНР** and **Головний отаман** of the army; **одноосібний правитель** ДЦ УНР from 12 листопада 1920. [T3: uk.wikipedia]
+- `21–24 квітня 1920` — the **Варшавська угода** (Петлюра–Пілсудський): a political-military alliance with the Second Polish Republic against Bolshevik Russia, by which the UNR recognised the Zbruch/Western-Volhynia line as the border (controversially ceding Galicia/Western Volhynia claims) in exchange for joint operations; the joint offensive took **Київ on 7 травня 1920** before the June retreat. [T1: IEU — "Signed in April 1920… capturing Kyiv on May 7, 1920"]
+- `1924–1926` — émigré editor; founded the weekly **«Тризуб»** (Paris, 1925), the central organ of the UNR exile. [T3: uk.wikipedia]
+- `posthumous` — **«Симон Петлюра. Статті, листи, документи»** (several volumes, UVAN/diaspora editions) — the standard corpus of his writing. [Primary]
+
+## 4. Primary-source quotes (≥2 required)
+
+Petliura's documentary voice is political-publicistic. The literary corpus (`verify_quote`) does **not** index his publicism — a `verify_quote(author="Петлюра")` returned `matched:false, confidence 0.0`, which reflects corpus coverage, not absence of the texts. The quotes below are drawn from the standard edition **«Статті, листи, документи»** as catalogued on Вікіцитати, with one widely-misattributed line flagged as such.
+
+**Quote 1 — statehood above party (his core political creed):**
+
+> «Справа здобуття української державності — це справа нації української, а не якогось класу чи партії.»
+
+Pedagogically central: it states the supra-party, national-unity premise of the UNR project — useful for contrasting Petliura's nation-first framing with the class-first framing of his Bolshevik opponents. [T5: Вікіцитати — citing Петлюра С., «Статті, листи, документи»; corroborated as his settled position by T1: IEU]
+
+**Quote 2 — the cost of national liberation:**
+
+> «Шлях звільнення кожної нації густо кропиться кров'ю.»
+
+A sober (not triumphal) line on the price of independence; pairs well with the tragedy of his own death and the UNR's defeat. [T5: Вікіцитати — Петлюра С.]
+
+**Flagged misattribution (anti-fabrication discipline):** the line often hung on Petliura — *«Нам не так страшні московські воші, як страшні українські гниди»* — is **unverified in serious sources** (Вікіцитати itself flags it). Do **not** put it in a learner's mouth as authentic Petliura. Likewise the hostile *«Шкода жидів, але жидівські погроми підтримують дисціпліну в армії…»* is a **second-hand attribution** (relayed by Hrushevsky/Zhukivsky to minister Revutsky), not a documented Petliura statement — treated in §6.
+
+**Documented anti-pogrom texts (referenced, not quoted verbatim here):** Наказ Військам УНР **ч. 131 (26.08.1919)** and the **address of 18.03.1921** are real, dated documents condemning pogroms; their exact verbatim wording was **not** captured in this research pass from a Tier 1/2 transcription, so they are described (with date + source) rather than quoted to avoid fabricating text. [T2: Hunczak — Симон Петлюра та євреї, Либідь 1993; T3: uk.wikipedia]
+
+## 5. Language register
+
+- **Register:** early-20th-century **publicistic / political-rhetorical** Ukrainian — editorial prose, manifestos, army orders. Clear, oratorical, periodic; some period bureaucratic-military lexis.
+- **CEFR readiness for full reading:** **C1** for his publicism (abstract political vocabulary: державність, нація, отаманщина, погром, автономія); the **biographical narrative** about him sits at **B2**; the §6 historiographic debate is **C1–C2**.
+- **Lexicon notes (pre-teach):** Головний отаман, Директорія, отаманщина, погром, еміграція, державний центр, антигетьманське повстання, виправдання (acquittal). VESUM-verified standard forms: отаман, погром, еміграція, виправдати, антигетьманський, повстання (all FOUND). Proper/derived forms not in VESUM common-word dictionary (Директорія, Холодноярська) are glossed as proper nouns, not errors.
+- **Stylistic features:** appeals to **нація** over class/party; martial-civic register; the recurrent figure of the lonely state-builder under siege.
+
+## 6. Contested points (Block G — extended)
+
+**The pogrom question — presented in BOTH directions, not smoothed.** Between 1919 and 1920, on territory nominally under UNR control, pogroms killed an estimated **35,000–50,000 Jews**. Jewish statistician **Nahum Gergel**'s much-cited count attributes **≈40 %** of pogroms to units of the UNR army, **25 %** to independent warlord bands, **17 %** to Denikin's Whites, **9 %** to the Red Army, **4 %** to Hryhoriiv's forces, and **3 %** to the Polish army. [T4: Gergel, *YIVO Annual* 6 (1951)] This is the indictment side, and it must be stated plainly: **UNR-aligned units committed mass murder of Jews**, most infamously at **Proskuriv (Iziaslav)** under otaman **Семесенко** (February 1919).
+
+The defence side is equally documented. Historian **Тарас Гунчак (Taras Hunczak)** — whose *Симон Петлюра та євреї* (Либідь, 1993) is the foundational study — and historian **Henry Abramson** (*A Prayer for the Government: Ukrainians and Jews in Revolutionary Times*, HURI/Harvard, 1999) show that **Petliura did not initiate or order pogroms**, held documented **pro-Jewish political views**, governed with a **Ministry for Jewish Affairs** and Jewish ministers (Margolin, Revutsky), issued **orders against pogroms** (наказ ч. 131, 26.08.1919), and had pogromists like Семесенко **executed**. IEU states the scholarly consensus directly: *"Petliura's own personal convictions render such responsibility highly unlikely, and all the documentary evidence indicates that he consistently made efforts to stem pogrom activity by UNR troops."* [T1: IEU]
+
+The honest crux is **command responsibility**, and serious scholars **disagree**. After 1918 Petliura **progressively lost control** of army units and especially of semi-independent otamans — so "армія Петлюри" is, as the Ukrainian historiography itself notes, an **imprecise** label that conflates loyal regulars with bands beyond his command. Yet historian **Christopher Gilley** argues the Directory was **de jure** consistent in condemning and sentencing pogromists but **de facto** inconsistent in enforcing those sentences — a real charge of weak command rather than of incitement. [T4: Gilley, *Українська атаманщина*] The contested hostile quote (*"жидівські погроми підтримують дисціпліну в армії"*), relayed second-hand by Hrushevsky and Zhukivsky to Revutsky, is **disputed and uncorroborated** and cannot bear the weight of an intent claim. The pedagogically correct framing: **Petliura was not a pogromist and worked against pogroms, AND command responsibility for atrocities by units flying his flag remains a genuine, unresolved scholarly debate.** Do not resolve it for the learner in either direction.
+
+**The assassination and trial as disinformation engine.** Subtelny's observation — that for many Russified contemporaries it was *"easier to blame Petliura and the Ukrainians than Denikin and his Russian generals"* — describes the mechanism by which the worst pogroms (Fastiv, by Denikin's Whites) were rhetorically displaced onto Petliura. The 1927 acquittal, and the founding of LICRA out of the trial, hardened a frame in which "Petliura" stands for antisemitism — a frame the USSR then weaponised for seventy years. **Russian/Soviet disinformation** to flag: "петлюрівщина" as a synonym for banditry; the suppression of the OGPU-operation evidence; the modern recycling of the pogrom charge to delegitimise Ukrainian statehood wholesale.
+
+**What popular memory simplifies:** the Warsaw alliance — celebrated by some as realpolitik, condemned by others (especially West-Ukrainian/ZUNR memory) as **selling out Galicia** to Piłsudski — is flattened in both directions and deserves its real ambivalence.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — the figure's own plan (this dossier backfills its research base).
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-vynnychenko.yaml` — first head of the Directory; Petliura's rival and predecessor (the Vynnychenko↔Petliura split is core to §6).
+  - `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml` — Sich Riflemen commander under the UNR; later OUN founder (Wave I sibling).
+  - `curriculum/l2-uk-en/plans/bio/petro-bolbochan.yaml` — UNR colonel executed 1919 amid the Petliura-era command conflicts (Wave I sibling).
+  - `curriculum/l2-uk-en/plans/bio/mykola-mikhnovskyi.yaml` — the prior generation's statehood ideologue (Wave I sibling).
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` — Central Rada head; the §6 second-hand quote passes through Hrushevsky.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml` — the dedicated HIST treatment of Petliura in the revolution.
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml` — the Directory he led.
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml` — where his military-secretary career began.
+  - `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml` — the Bolshevik–Ukrainian war he fought.
+  - `curriculum/l2-uk-en/plans/hist/zunr.yaml` — the ZUNR partner whose Galicia claim the Warsaw alliance overrode.
+  - `curriculum/l2-uk-en/plans/hist/kholodnyi-yar.yaml` — the loyal-to-UNR insurgency that fought on after his retreat.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/vynnychenko-honesty.yaml` — Vynnychenko's literary voice, the cultural-political counterweight to Petliura.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST module on the **1919–20 pogroms** as a standalone unit (the Gergel/Hunczak/Gilley debate) — not yet built; would carry the §6 NPOV load.
+  - A BIO link to **Юзеф Пілсудський** (Warsaw alliance partner) — no plan exists.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A Jewish-Ukrainian relations LIT/HIST strand anchored on Abramson's *A Prayer for the Government*.
+
+## 8. Naming-canonical
+
+- **Slug:** `symon-petliura`
+- **EN canonical (BGN/PCGN-style project spelling):** Symon Petliura
+- **UA canonical (with patronymic):** Симон Васильович Петлюра
+- **Aliases to track (`aliases:` YAML field):** Symon Petlura; pen-names В. Марченко, В. Салевський, Симон Орлик, О. Ряст.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Симон Васильевич Петлюра; Simon Petlyura; "Petlura" as a pejorative synonym for pogromism ("петлюрівщина" used as a slur).
+
+## 9. Image candidates
+
+- **Best PD portrait:** Wikimedia Commons category **"Symon Petliura"** holds pre-1926 photographic portraits (UNR-era official photos and the famous Head-of-Directory portrait); the subject died in 1926 and the photos predate that, so they are public domain by age in Ukraine and the US. Use the individual **file page** for final license proof. [Commons category: `Symon Petliura`]
+- **Backup candidates:**
+  - The 2004 Укрпошта commemorative postage stamp (referenced in the uk.wiki article) — check stamp-rights/PD status.
+  - The **посмертна маска** (death mask) photograph — strong, sober §2 illustration if a rights-clear scan exists.
+- **Context image:** a page of **«Тризуб»** (Paris, 1925–) masthead, or the 1927 Paris trial press coverage ("Écho de Paris", "Paris-Midi") — illustrates the disinformation/trial dimension.
+- **If no rights-clear portrait clears review:** fall back to the PD «Тризуб» masthead or the Montparnasse grave photograph.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Petliura, Symon." encyclopediaofukraine.com. Accessed 2026-06-03. (Directly opened — birth/death dates, roles, Warsaw alliance, pogrom-responsibility consensus statement.)
+
+**Tier 2 (institutional / foundational scholarship — referenced via bibliography, not all directly opened this pass):**
+- Гунчак Т. (Taras Hunczak). *Симон Петлюра та євреї.* Київ: Либідь, 1993. — the foundational study of Petliura and the pogrom question. (Surfaced via the uk.wiki pogroms-article bibliography; cited for its documented thesis, not directly opened.)
+- Abramson, Henry. *A Prayer for the Government: Ukrainians and Jews in Revolutionary Times, 1917–1920.* Cambridge, MA: Harvard Ukrainian Research Institute (HURI), 1999.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Петлюра Симон Васильович"; "Єврейські погроми під час Української революції"; "Вбивство Симона Петлюри." Dates/trial/quotes cross-checked against IEU. Accessed 2026-06-03 via `mcp__sources__query_wikipedia`.
+
+**Tier 4 (modern scholarly — referenced):**
+- Gergel, Nahum. "The Pogroms in the Ukraine in 1918–21." *YIVO Annual of Jewish Science* 6 (1951). — the 40%/25%/17%/9%/4%/3% attribution statistics.
+- Gilley, Christopher. *Українська атаманщина: націоналізм та ідеологія в просторі насильства* (Russian ed., 2014). — the de jure / de facto command-enforcement critique.
+- Субтельний О. (Orest Subtelny). *Україна: історія.* — the "easier to blame Petliura than Denikin" framing.
+
+**Tier 5 (general web — used only with T1–T4 corroboration):**
+- Вікіцитати. "Симон Петлюра." — source of Quotes 1–2 (cited to «Статті, листи, документи») and the misattribution flag. Accessed 2026-06-03.
+
+**Primary-source documents referenced:**
+- Петлюра С. *Статті, листи, документи* (UVAN/diaspora multi-volume edition) — the corpus of his writing (quotes via Вікіцитати catalogue).
+- Наказ Військам УНР ч. 131 (26.08.1919); звернення до населення України (18.03.1921) — dated anti-pogrom documents (referenced via Hunczak / uk.wiki; verbatim text NOT captured this pass).
+- 1927 Cour d'assises de la Seine trial record (Schwartzbard) — 200+ defence documents; acquittal 8–4. (Via uk.wiki summary.)
+
+**Honest gaps:** ЕІУ (Інститут історії України) and ЕСУ entries on Petliura exist but were **not directly opened** this pass; the core dates/roles rest on IEU [T1] cross-checked against uk.wiki [T3]. The **verbatim text** of наказ ч. 131 and the 18.03.1921 appeal was not captured from a Tier 1/2 transcription and is therefore described, not quoted. The **OGPU-operation** attribution of the assassination is the dominant but not archivally-closed reading. The **command-responsibility** question (§6) is presented as genuinely unresolved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — told on Ukrainian terms; Russia/USSR appears as oppressor and as disinformation source.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — **Українська революція (1917–1921)** and **більшовицько-українська війна**, not "Civil War."
+- [x] No uncritical Soviet propaganda terms — "петлюрівщина" / "буржуазно-націоналістичний" appear only named **as** Soviet framing, never in the project's own voice.
+- [x] No "lost his life" euphemism — **assassinated / застрелений** for the documented killing; the **pogrom victims' murders named as murders**, not smoothed.
+- [x] Modern UA place names — Київ/Kyiv, Полтава, Кам'янець-Подільський, Проскурів (noting modern Хмельницький).
+- [N/A] Holodomor — не стосується (Петлюра вбитий 1926, до Голодомору).
+- [x] Russian aggression framing — the modern recycling of the pogrom charge to delegitimise Ukrainian statehood is named as disinformation (§6).


### PR DESCRIPTION
Two fully-completed dossiers rescued after the **5-hour Claude limit** cut waves I/J at returncode 1 (each writer finished its first dossier before the cut). Remaining figures are being re-dispatched via **codex** (separate quota).

- **symon-petliura** — Симон Петлюра (1879–1926), Head of UNR Directory. NPOV on the 1919–20 pogroms (Hunchak: did not initiate/order; command-responsibility debate presented both ways); 1926 Paris assassination + 1927 Schwartzbard acquittal trial included. Decolonization self-check complete; the modern recycling of the pogrom charge named as disinformation.
- **lina-kostenko** — Ліна Костенко (b. 1930), Шістдесятники poet. ~15-yr publication ban; «Маруся Чурай» (Shevchenko Prize 1987); living-person NPOV with the mixed reception of «Записки українського самашедшого».

Both: 10-section template + decolonization self-check; `lint_bio_dossier_xref.py` exit 0; merge-base diff = exactly 2 `A` additions. Pending DeepSeek cross-family review (claude writer → DeepSeek reviewer).

No auto-merge.