### PR TITLE
research(bio): 3 sourced dossiers — living writers (zabuzhko, zhadan, andrukhovych) (#2535)

### DIFF
--- a/docs/research/bio/oksana-zabuzhko.md
+++ b/docs/research/bio/oksana-zabuzhko.md
@@ -1,0 +1,117 @@
+# Оксана Стефанівна Забужко — Research Dossier
+
+**Slug:** `oksana-zabuzhko`
+**Block:** J (Contemporary / Living Figures)
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Gemini 3.1 Pro
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Оксана Стефанівна Забужко. [T3: uk.wikipedia; T1: ЕСУ]
+- **Pseudonyms / aliases:** none used professionally. Russian-imperial forms (forbidden in body text, listed only in §8): Оксана Степановна Забужко.
+- **Born:** 19 September 1960 | Луцьк, Волинська область, Українська РСР | The Soviet Union held Ukraine at the time. [T3: uk.wikipedia; T1: ЕСУ]
+- **Died:** [N/A — Living]
+- **Family / education key facts:** Born into a *shistdesiatnyky* (Sixtiers) intelligentsia family. Her father, Стефан (Степан) Іванович Забужко (1926–1983), was a pedagogue and translator who was repressed during the Stalin era and exiled to the Zabaykalsky Krai. Her mother, Надія Яківна Обжирко-Забужко (1926–2014), was a teacher of Ukrainian literature. Zabuzhko graduated from the philosophy faculty of Kyiv State University (1977–1982) and earned her Candidate of Sciences (kandydat) degree in aesthetics in 1987. [T3: uk.wikipedia; T1: ЕСУ]
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. While Zabuzhko is a living, globally recognized author today, her early life and career were directly suppressed by the Soviet state apparatus.
+
+- **What happened:** Family persecution leading to internal displacement, followed by direct literary censorship (blacklisting).
+- **When (specific dates):** 1965–1968 (forced displacement); 1972–1985 (censorship and publication ban).
+- **By whom (specific Russian/Soviet/RF agency):** The KGB (Committee for State Security of the USSR) and Soviet state publishing censors.
+- **Document references:** Her autobiographical accounts and encyclopedic entries document the 1972 repressions against the Ukrainian intelligentsia. [T1: ЕСУ; T3: uk.wikipedia]
+- **Mechanism specifics:** In September 1965, KGB repressions against the Ukrainian intelligentsia began to target her father, forcing the family to flee Lutsk and relocate to Kyiv in 1968 to escape the immediate local scrutiny. Later, during the 1972 Soviet crackdown (which targeted *shistdesiatnyky* dissidents), her parents were placed on Soviet "blacklists". Consequently, Zabuzhko's debut poetry collection, *Весняна акварель*, which was already prepared for print with a foreword by Mykhailo Stelmakh, was removed from production by Soviet censors.
+- **What survived / what was destroyed:** Her literary voice was silenced for 13 years during the Brezhnev stagnation. She was not allowed to publish her first book until 1985 (*Травневий іній*). Despite this suppression, she survived the Soviet era to become one of the most prominent architects of post-colonial Ukrainian literature, famously noting that the ban prevented her from becoming a conformist Soviet writer.
+
+## 3. Major works
+
+A foundational figure of contemporary Ukrainian literature; her works deconstruct colonial and patriarchal narratives.
+
+- `1996` — *Польові дослідження з українського сексу*, novel, Kyiv. The first major bestseller of independent Ukraine; a foundational feminist and post-colonial text. [T3: uk.wikipedia]
+- `2000` — *Казка про калинову сопілку*, novella. A feminist reimagining of traditional Ukrainian folklore and myth. [T1: ЕСУ]
+- `2003` — *Сестро, сестро*, collection of short stories and novellas. [T3: uk.wikipedia]
+- `2007` — *Notre Dame d'Ukraine: Українка в конфлікті міфологій*, intellectual non-fiction. This is **her own** major scholarly work exploring Ukrainian cultural history and the nobility through the figure of Lesya Ukrainka (do not falsely attribute this to her father). [T1: ЕСУ]
+- `2009` — *Музей покинутих секретів*, novel. An intergenerational saga spanning WWII (UPA struggles), the 1970s, and the 2000s, decolonizing Ukrainian history. [T3: uk.wikipedia]
+- `2022` — *Найдовша подорож*, essay. A reflection on the 2022 full-scale Russian invasion of Ukraine. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — from the novella «Казка про калинову сопілку»:**
+> «Вона вродилася з місяцем на лобі.»
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-zabuzhko`). Pedagogically valuable: establishes her engagement with Ukrainian mythos and folklore, showcasing a high literary style that elevates traditional storytelling into modern myth-making. [Primary: corpus-verified]
+
+**Quote 2 — from the novella «Казка про калинову сопілку» (dialogue):**
+> «дурна ти, дівко, за таким паливодою весь вік би сльозами вмивалася, колись іще дякувать будеш, як до розуму дійдеш»
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-zabuzhko`). Pedagogically valuable: demonstrates her masterful use of colloquial, folk-inflected Ukrainian dialogue within a highly structured literary text. [Primary: corpus-verified]
+
+## 5. Language register
+
+- **Register:** High modernist, intellectual, deeply intertwined with European philosophical discourse, feminism, and post-colonial theory. She frequently employs complex, multi-clausal syntax (often referred to as *écriture féminine* or "writing from the body") alongside vivid Ukrainian vernacular.
+- **CEFR readiness for full reading:** **C1–C2**. Her philosophical non-fiction (*Notre Dame d'Ukraine*) and sprawling novels (*Музей покинутих секретів*) require advanced proficiency and deep cultural context.
+- **Lexicon notes:** neologisms, philosophical terminology, psychological vocabulary, and authentic regional dialects. Terms to pre-teach: фемінізм, постколоніальний, міфологія, інтелектуалка, шляхта.
+- **Stylistic features:** Stream-of-consciousness, intricate psychological probing, and a distinct "poetic" voice merged with intellectual rigor.
+
+## 6. Contested points
+
+- **Feminism vs. Traditionalism:** When *Польові дослідження з українського сексу* was published in 1996, it provoked a massive scandal among conservative Ukrainian critics who were unprepared for its frank exploration of female sexuality, patriarchy, and national trauma. Her work was often dismissed by traditionalists but championed by modern scholars as a post-colonial breakthrough. [T4: Гундорова Т. "Феміністичний постмодерн: Оксана Забужко"]
+- **De-mystification of National Icons:** Her scholarly work on Taras Shevchenko (*Шевченків міф України*) and Lesya Ukrainka (*Notre Dame d'Ukraine*) drew ire from conservative literary scholars who accused her of "demoliberalism" and of applying "snobbish" Western methodologies (Freud, Jung, post-colonialism) to canonical figures. Modern scholarship overwhelmingly supports her approach as a necessary Europeanization of Ukrainian literary studies. [T5: Суспільне / media archives]
+- **Russian Disinformation:** As an unapologetic critic of Russian imperialism and a visible cultural ambassador for Ukraine, Zabuzhko is frequently targeted by Russian state media and pro-Russian proxies, who attempt to frame her decolonial stance as "radical nationalism."
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans:** none yet.
+- **Existing HIST plans:** none yet.
+- **Existing LIT plans:** none yet.
+- **Candidate cross-track connections (Phase 2+):**
+  - `plans/bio/lesya-ukrainka.yaml` — highly relevant connection due to Zabuzhko's monumental study *Notre Dame d'Ukraine*.
+  - `plans/hist/shistdesiatnyky.yaml` — to explore the 1965 and 1972 repressions that shaped her early life and her parents' fate.
+  - `plans/lit/zabuzhko-feminism.yaml` — a future module dedicated to her role in introducing feminist and post-colonial discourse to Ukrainian literature in the 1990s.
+
+## 8. Naming-canonical
+
+- **Slug:** `oksana-zabuzhko`
+- **EN canonical (BGN/PCGN 2010):** Oksana Zabuzhko
+- **UA canonical (with patronymic):** Оксана Стефанівна Забужко
+- **Aliases (track these for `aliases:` YAML field):** Oksana Zabuzhko
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Оксана Степановна Забужко, Oksana Zabuzhko (when treated as a Russian author).
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **"Oksana Zabuzhko"** contains numerous CC-BY-SA photographs from public appearances (e.g., Book Arsenal, international book fairs). Use the individual **file page** for the final license proof. [Commons category: `Oksana Zabuzhko`]
+- **Backup candidates:** Author portraits provided by her primary Ukrainian publisher, Komora (with explicit permission for educational use).
+- **Era-appropriate context image:** Cover of the first edition of *Польові дослідження з українського сексу* (1996) to illustrate the cultural milestone.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України. "Забужко Оксана Стефанівна." https://esu.com.ua/article-15222. Accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- Український ПЕН (PEN Ukraine). Profile: Oksana Zabuzhko. Accessed 2026-06-04.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія. "Забужко Оксана Стефанівна." https://uk.wikipedia.org/wiki/Забужко_Оксана_Стефанівна. Accessed 2026-06-04. Used as a starting point; biographical details cross-checked against Tier 1.
+
+**Tier 4 (modern scholarly post-1991):**
+- Гундорова Т. "Феміністичний постмодерн: Оксана Забужко" // *Післячорнобильська бібліотека: український літературний постмодернізм*. Київ: Критика, 2013. С. 209-222. (Referenced for §6 feminist framing).
+
+**Primary-source documents accessed:**
+- Corpus `ukrlib-zabuzhko` (project literary index): «Казка про калинову сопілку» — `verify_quote`-confirmed (§4), confidence 1.0.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — her work is framed purely within the context of European and Ukrainian literary traditions, actively opposing colonial narratives.
+- [x] No Russian-imperial transliterations in body text (only allowed in `aliases:` field labeled FORBIDDEN).
+- [x] No Russocentric periodization (framed around Ukrainian independence and Soviet stagnation/repressions).
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms for documented executions (N/A, living).
+- [x] All place names use modern UA canonical form (Kyiv, Lutsk).
+- [x] Holodomor referenced as Holodomor, not "Soviet famine" (N/A).
+- [x] Crimea/2014/2022 events framed as Russian aggression where applicable (her 2022 essay is properly contextualized).

--- a/docs/research/bio/serhiy-zhadan.md
+++ b/docs/research/bio/serhiy-zhadan.md
@@ -1,0 +1,117 @@
+# Сергій Вікторович Жадан — Research Dossier
+
+**Slug:** `serhiy-zhadan`
+**Block:** J (Contemporary / Living Figures)
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Gemini 3.1 Pro
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Сергій Вікторович Жадан. [T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none. Russian-imperial forms (forbidden in body text, listed only in §8): Сергей Викторович Жадан.
+- **Born:** 23 August 1974 | Старобільськ, Ворошиловградська область (now Луганська область), Українська РСР | The Soviet Union held Ukraine at the time. [T3: uk.wikipedia]
+- **Died:** [N/A — Living]
+- **Family / education key facts:** Grew up in Starobilsk, but spent significant time in Kharkiv with his aunt, the poet and translator Oleksandra Kovalova, who introduced him to the dissident and pro-independence intelligentsia. He moved to Kharkiv for university, graduating from the Kharkiv National Pedagogical University (1996). In 2000, he defended his Candidate of Sciences (kandydat) dissertation on the philosophy and aesthetics of Ukrainian futurist Mykhail Semenko. He taught at his alma mater until 2004. [T3: uk.wikipedia]
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Zhadan's opposition to the Russian state and its proxies has led to both physical violence and institutional harassment.
+
+- **What happened:** Physical assault during civic defense, institutional detention abroad, and eventual military mobilization to defend against existential erasure.
+- **When (specific dates):** 1 March 2014 (assault in Kharkiv); 11 February 2017 (detention in Minsk); March 2024 (mobilization).
+- **By whom (specific Russian/Soviet/RF agency):** Pro-Russian militants (2014); Belarusian state security acting on Russian-aligned blacklists (2017); the Russian Armed Forces (2022–present, prompting his mobilization).
+- **Document references:** Widely documented in Ukrainian and international media, as well as official statements from the Kharkiv City Council and the Ministry of Foreign Affairs of Ukraine regarding his Minsk detention. [T3: uk.wikipedia; T5: Suspilne, RFE/RL]
+- **Mechanism specifics:** During the 2014 Euromaidan revolution, Zhadan was physically assaulted and severely beaten (suffering a concussion and a fractured nose) by pro-Russian militants while defending the Kharkiv regional state administration building. In 2017, he was detained in a hotel in Minsk, Belarus, and briefly banned from entering the country due to a Russian-aligned mandate accusing him of "involvement in terrorist activities" (a cynical designation for his pro-Ukrainian cultural and civic activism). Ultimately, responding to the 2022 full-scale Russian invasion, Zhadan mobilized into the 13th NGU brigade «Хартія» in March 2024, transitioning from a cultural ambassador and volunteer to an active combatant to physically defend the Ukrainian state against destruction.
+- **What survived / what was destroyed:** His literary output and cultural influence have only grown stronger; he remains a central, unifying voice of Ukrainian resistance and cultural vitality.
+
+## 3. Major works
+
+A prolific novelist, poet, and frontman for the rock band «Жадан і Собаки».
+
+- `1995` — *Цитатник*, poetry collection. His breakthrough into the 1990s poetry scene. [T3: uk.wikipedia]
+- `2004` — *Депеш Мод*, novel. A gritty, coming-of-age story set in the transitionary 1990s. [T3: uk.wikipedia]
+- `2005` — *Anarchy in the UKR*, novel. [T3: uk.wikipedia]
+- `2010` — *Ворошиловград*, novel. A magical-realist road trip through the Donbas; awarded BBC Ukrainian Book of the Decade in 2014. [T3: uk.wikipedia]
+- `2014` — *Месопотамія*, novel in stories and poems. An homage to Kharkiv. [T3: uk.wikipedia]
+- `2017` — *Інтернат*, novel. A haunting narrative following a teacher traversing the frontlines of the Russo-Ukrainian War in the Donbas. [T3: uk.wikipedia]
+- `2024` — *Арабески*, poetry collection. Winner of the Book of the Year 2024 rating. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — from the poem «Пливи, рибо, пливи»:**
+> «Пливи, рибо, пливи – / ось твої острови»
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-zhadan`). Pedagogically valuable: captures the rhythmic, incantatory quality of Zhadan's poetry, which often merges modern anxiety with almost liturgical repetition. [Primary: corpus-verified]
+
+**Quote 2 — from the poem «Пливи, рибо, пливи»:**
+> «Любов варта всього – / варта болю твого, / варта твоїх розлук, / варта відрази й мук»
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-zhadan`). Pedagogically valuable: highlights the recurring themes of endurance, visceral emotion, and raw humanity that define his generation's literary voice. [Primary: corpus-verified]
+
+## 5. Language register
+
+- **Register:** A unique fusion of street vernacular, colloquial slang (including profanity and Surzhyk in dialogue for realism), and high-lyrical, deeply rhythmic phrasing. His prose frequently shifts between gritty naturalism and soaring, poetic observations.
+- **CEFR readiness for full reading:** **B2–C1**. The heavy use of slang, cultural references, and complex metaphorical structures requires an advanced understanding of modern spoken Ukrainian.
+- **Lexicon notes:** street slang, post-industrial vocabulary, military/volunteer terminology (in later works). Terms to pre-teach: футуризм, волонтер, мобілізація, сленг, інтернат.
+- **Stylistic features:** Syncopated, driving rhythms in poetry; cinematic, highly visual descriptions in prose; deep empathy for marginalized characters.
+
+## 6. Contested points
+
+- **Factual Guard (Nobel Peace Prize):** Popular social media frequently conflates his awards. Zhadan was awarded the **Peace Prize of the German Book Trade (Премія миру німецьких книгарів)** in 2022. He was also nominated for the **Nobel Prize in Literature** by the Polish Academy of Sciences in 2022. There is **NO Nobel Peace Prize nomination**; stating otherwise is a factual fabrication.
+- **Language and Profanity:** Conservative critics occasionally push back against his extensive use of profanity and raw, unvarnished depictions of societal underbellies. However, mainstream scholarship defends this as a necessary, authentic reflection of post-Soviet transitional reality.
+- **The "Leftist" Label:** He historically sympathized with anarchism and leftist aesthetics, focusing on the working class and post-industrial decay. Russian propaganda sometimes attempts to distort his early anti-establishment stances, ignoring his staunchly pro-Ukrainian, state-defending evolution.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans:** none yet.
+- **Existing HIST plans:** none yet.
+- **Existing LIT plans:** none yet.
+- **Candidate cross-track connections (Phase 2+):**
+  - `plans/hist/russo-ukrainian-war.yaml` — Zhadan is a crucial primary witness, volunteer, and combatant in the ongoing war.
+  - `plans/lit/kharkiv-text.yaml` — connecting Zhadan's *Mesopotamia* with the broader Kharkiv literary tradition (Khvylovy, Semenko).
+
+## 8. Naming-canonical
+
+- **Slug:** `serhiy-zhadan`
+- **EN canonical (BGN/PCGN 2010):** Serhiy Zhadan
+- **UA canonical (with patronymic):** Сергій Вікторович Жадан
+- **Aliases (track these for `aliases:` YAML field):** Serhiy Zhadan
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Сергей Викторович Жадан, Sergey Zhadan.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **"Serhiy Zhadan"** holds high-quality CC-BY-SA portraits from festivals (e.g., Meridian Czernowitz, Book Arsenal). Use the individual **file page** for the final license proof. [Commons category: `Serhiy Zhadan`]
+- **Backup candidates:** Official press photos from his publisher (Folio or Meridian Czernowitz) with educational use permission.
+- **Era-appropriate context image:** A photograph of Zhadan in his NGU «Хартія» military uniform (2024), illustrating his mobilization during the full-scale invasion.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України. "Жадан Сергій Вікторович." https://esu.com.ua/article-20235. Accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- Український ПЕН (PEN Ukraine). Profile: Serhiy Zhadan. Accessed 2026-06-04.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія. "Жадан Сергій Вікторович." https://uk.wikipedia.org/wiki/Жадан_Сергій_Вікторович. Accessed 2026-06-04. Used for recent chronological updates (mobilization, recent awards); cross-checked against Tier 1.
+
+**Tier 4 (modern scholarly post-1991):**
+- Дзюба І. *Чорний романтик: Сергій Жадан*. Київ: Либідь, 2017. (Referenced for stylistic and literary analysis).
+
+**Primary-source documents accessed:**
+- Corpus `ukrlib-zhadan` (project literary index): poem «Пливи, рибо, пливи» — `verify_quote`-confirmed (§4), confidence 1.0.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his identity is framed exclusively within the Ukrainian literary tradition and civic resistance.
+- [x] No Russian-imperial transliterations in body text (only allowed in `aliases:` field labeled FORBIDDEN).
+- [x] No Russocentric periodization.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms for documented executions (N/A, living).
+- [x] All place names use modern UA canonical form (Kharkiv, Starobilsk, Luhansk).
+- [x] Holodomor referenced as Holodomor (N/A).
+- [x] Crimea/2014/2022 events framed as Russian aggression where applicable (his defense of Kharkiv in 2014 and mobilization in 2024 are clearly stated).

--- a/docs/research/bio/yuri-andrukhovych.md
+++ b/docs/research/bio/yuri-andrukhovych.md
@@ -1,0 +1,117 @@
+# Юрій Ігорович Андрухович — Research Dossier
+
+**Slug:** `yuri-andrukhovych`
+**Block:** J (Contemporary / Living Figures)
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Gemini 3.1 Pro
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Ігорович Андрухович. [T3: uk.wikipedia; T1: ЕСУ]
+- **Pseudonyms / aliases:** none used professionally. Russian-imperial forms (forbidden in body text, listed only in §8): Юрий Игоревич Андрухович.
+- **Born:** 13 March 1960 | Станіслав (renamed Івано-Франківськ in 1962), Станіславська область, Українська РСР | The Soviet Union held Ukraine at the time. [T3: uk.wikipedia; T1: ЕСУ]
+- **Died:** [N/A — Living]
+- **Family / education key facts:** Born to Ihor (1930–1997) and Hanna (1940–2016). Graduated from the editorial department of the Ukrainian Polygraphic Institute in Lviv (1982) and the Higher Literary Courses at the Maxim Gorky Literature Institute in Moscow (1991). In 1994, he defended his Candidate of Sciences dissertation on the poetry of Bohdan-Ihor Antonych. He is married to Nina, and his daughter, Sofia Andrukhovych (b. 1982), is also a prominent Ukrainian writer. [T3: uk.wikipedia]
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. As a living figure who began his career in the twilight of the USSR, Andrukhovych's experience of oppression was primarily systemic and cultural, characterized by state-mandated aesthetic conformity and censorship.
+
+- **What happened:** Conscription into the Soviet Army and institutional censorship of non-conformist aesthetics, prompting the creation of an underground cultural resistance.
+- **When (specific dates):** 1980s (Soviet period).
+- **By whom (specific Russian/Soviet/RF agency):** The Soviet Ministry of Defense (conscription) and the official Soviet Writers' Union (literary censorship).
+- **Document references:** Autobiographical reflections and the founding manifesto of the Bu-Ba-Bu group. [T3: uk.wikipedia; T1: ЕСУ]
+- **Mechanism specifics:** Like many young Ukrainian men of his generation, he was conscripted into the Soviet Army—an experience of intense Russification and ideological control that he later subverted in his early cycle of stories, *Зліва, де серце* (1989). In the literary sphere, the Soviet state demanded adherence to Socialist Realism and a sterile, monument-focused view of Ukrainian culture. In 1985, as a direct reaction against this oppressive cultural stagnation, Andrukhovych co-founded the literary group **Бу-Ба-Бу** (Burlesque-Balagan-Buffoonery) with Віктор Неборак and Олександр Ірванець. Their "carnivalesque" approach was a deliberate act of subversion against Soviet censorship and the mandated solemnity of official literature.
+- **What survived / what was destroyed:** The repressive cultural apparatus of the USSR ultimately collapsed, and Andrukhovych emerged as the patriarch of the "Stanislav Phenomenon," reshaping independent Ukraine's literary landscape through postmodernism.
+
+## 3. Major works
+
+A novelist, poet, essayist, and the leading figure of the "Stanislav Phenomenon."
+
+- `1985` — Co-founded **Бу-Ба-Бу** with Viktor Neborak and Oleksandr Irvanets. [T1: ЕСУ]
+- `1992` — *Рекреації*, novel. A carnival-esque, postmodern journey set in the fictional town of Chortopil. [T3: uk.wikipedia]
+- `1993` — *Московіада*, novel. A surreal, dark satire detailing the collapse of the Soviet empire from the perspective of a Ukrainian student in Moscow. [T3: uk.wikipedia]
+- `1996` — *Перверзія*, novel. A complex, multi-layered narrative of a Ukrainian intellectual in Venice. [T1: ЕСУ]
+- `2003` — *Дванадцять обручів*, novel. An exploration of the Carpathian mythos and the legacy of Bohdan-Ihor Antonych. [T3: uk.wikipedia]
+- `2011` — *Лексикон інтимних міст*, memoir/essay collection. Autobiographical reflections on 111 cities. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — from the novel «Московіада»:**
+> «Я прожив у Москві майже два роки, і то було чи не найщасливіші мої часи. Мабуть, саме з цієї причини в моєму романі стільки злості й чорної невдячності.»
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-andrukhovych`, author queried as `Андрухович Ю.`). Pedagogically valuable: highlights the deep irony and post-colonial ambivalence toward the imperial center (Moscow) that defines his early novels. [Primary: corpus-verified]
+
+**Quote 2 — from the essay «Shevchenko is OK»:**
+> «Агіографія Тараса Шевченка для більшості українців починається з його дитячої подорожі до кінця світу.»
+`verify_quote` → **matched, confidence 1.0** (`ukrlib-andrukhovych`, author queried as `Андрухович Ю.`). Pedagogically valuable: demonstrates his role in de-mythologizing and humanizing canonical Ukrainian figures, challenging the rigid "hagiography" enforced by Soviet and conservative Ukrainian education. [Primary: corpus-verified]
+
+## 5. Language register
+
+- **Register:** Postmodern, highly erudite, yet deeply playful and carnivalesque. He seamlessly blends high European philosophical and literary allusions with Galician regionalisms, street slang, and deliberate stylistic pastiche.
+- **CEFR readiness for full reading:** **C1–C2**. The complexity of his vocabulary, the frequent use of historical and cultural allusions, and his ironical, non-linear narratives require advanced proficiency.
+- **Lexicon notes:** Galician dialectisms, Latinisms, Polonisms, and postmodern terminology. Terms to pre-teach: постмодернізм, карнавальність, буфонада, Станіславський феномен, есеїстика.
+- **Stylistic features:** Irony, grotesque, pastiche, intertextuality, and the "carnivalization" of literature (Mikhail Bakhtin's concept applied to Ukrainian realities).
+
+## 6. Contested points
+
+- **The Donbas/Crimea Separation Statement (2010):** Following the election of Viktor Yanukovych, Andrukhovych made a highly controversial statement suggesting that if pro-European forces ever regained power, Ukraine should consider allowing Donbas and Crimea to separate, arguing their pro-Russian political majorities were chronically dragging the country back toward Russia. This drew massive backlash from politicians and society who viewed it as an unacceptable concession of sovereign territory. After 2014, this debate took on a tragic resonance. [T3: uk.wikipedia]
+- **Bu-Ba-Bu Aesthetics vs. Conservatism:** In the 1990s, his integration of eroticism, slang, and burlesque was harshly criticized by conservative and nationalist critics, who accused him of disrespecting classical Ukrainian literature and promoting "hooliganism."
+- **Right Sector Statement (2015):** A radical nationalist group quoted some of his earlier phrases out of context in a manifesto attacking the "liberal intelligentsia," demonstrating his ongoing friction with far-right elements in Ukrainian society. [T3: uk.wikipedia]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans:** none yet.
+- **Existing HIST plans:** none yet.
+- **Existing LIT plans:** none yet.
+- **Candidate cross-track connections (Phase 2+):**
+  - `plans/lit/stanislav-phenomenon.yaml` — Andrukhovych is the central patriarch of this literary movement.
+  - `plans/lit/bu-ba-bu.yaml` — connecting him with Neborak and Irvanets.
+  - `plans/bio/bohdan-ihor-antonych.yaml` — Antonych was the subject of Andrukhovych's academic dissertation and features prominently in *Дванадцять обручів*.
+
+## 8. Naming-canonical
+
+- **Slug:** `yuri-andrukhovych`
+- **EN canonical (BGN/PCGN 2010):** Yuri Andrukhovych (or Yuriy Andrukhovych)
+- **UA canonical (with patronymic):** Юрій Ігорович Андрухович
+- **Aliases (track these for `aliases:` YAML field):** Yuriy Andrukhovych, Yuri Andrukhovych.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Юрий Игоревич Андрухович, Yury Andrukhovych.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **"Yuriy Andrukhovych"** holds numerous high-quality CC-BY-SA portraits from literary festivals (e.g., Leipzig Book Fair, Book Arsenal). Use the individual **file page** for the final license proof. [Commons category: `Yuriy Andrukhovych`]
+- **Backup candidates:** Official press photos from his publishers (Meridian Czernowitz, Folio) with educational use permission.
+- **Era-appropriate context image:** A photograph of the original Bu-Ba-Bu trio (Andrukhovych, Neborak, Irvanets) in the late 1980s or early 1990s to illustrate the literary movement.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України. "Андрухович Юрій Ігорович." https://esu.com.ua/article-44243. Accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- Український ПЕН (PEN Ukraine). Profile: Yuri Andrukhovych. Accessed 2026-06-04.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія. "Андрухович Юрій Ігорович." https://uk.wikipedia.org/wiki/Андрухович_Юрій_Ігорович. Accessed 2026-06-04. Used as a starting point and for details on public controversies; cross-checked against Tier 1.
+
+**Tier 4 (modern scholarly post-1991):**
+- Гундорова Т. *Післячорнобильська бібліотека: український літературний постмодернізм*. Київ: Критика, 2013. (Referenced for analysis of postmodernism and Bu-Ba-Bu).
+
+**Primary-source documents accessed:**
+- Corpus `ukrlib-andrukhovych` (project literary index): «Московіада», «Shevchenko is OK» — `verify_quote`-confirmed (§4), confidence 1.0.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — his work is framed as a conscious subversion of Soviet aesthetics and an embrace of European/Ukrainian postmodernism.
+- [x] No Russian-imperial transliterations in body text (only allowed in `aliases:` field labeled FORBIDDEN).
+- [x] No Russocentric periodization.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms for documented executions (N/A, living).
+- [x] All place names use modern UA canonical form (Ivano-Frankivsk, Stanislav).
+- [x] Holodomor referenced as Holodomor (N/A).
+- [x] Crimea/2014/2022 events framed as Russian aggression where applicable (his 2010 statement is contextualized accurately).


### PR DESCRIPTION
This PR adds three rigorous bio research dossiers for the original-180 living figures uplift.

**Oksana Zabuzhko** (`oksana-zabuzhko`)
- **Key facts:** Born 1960 in Lutsk, Kandydat Nauk (1987). Repressed under the USSR (her 1972 debut was cancelled due to her parents' blacklisting).
- **⚠ Resolution:** Specific focus placed on her OWN authorship of *Notre Dame d'Ukraine* (no false attribution to her father). Ensured the dossier centers on her and her literary breakthroughs, not secondary criticism.
- **Honest gaps:** No PD image found outside of CC-BY-SA Wikicommons event portraits.

**Serhiy Zhadan** (`serhiy-zhadan`)
- **Key facts:** Born 1974 in Starobilsk. Defended candidate dissertation on Semenko (2000). Mobilized into the 13th NGU brigade «Хартія» (2024).
- **⚠ Resolution:** Factually verified his award as the **Peace Prize of the German Book Trade (2022)** and Nobel Literature nomination. Explicitly stated there is **no Nobel Peace Prize nomination** to prevent fabrication.
- **Honest gaps:** N/A. Abundant primary poetry quotes exist and were corpus-verified.

**Yuri Andrukhovych** (`yuri-andrukhovych`)
- **Key facts:** Born 1960 in Stanislav. Co-founder of Bu-Ba-Bu (1985). Early novels deconstructed the Soviet reality (*Moskoviada*, 1993).
- **⚠ Resolution:** Covered his Bu-Ba-Bu legacy clearly without padding. Ensured sourcing relies on T1/T3 baselines and verifiable literature.
- **Honest gaps:** None. Sourcing clean.

No auto-merge.