### PR TITLE
research(bio): add living-writer dossiers for Vynnychuk and Shkliar

### DIFF
--- a/docs/research/bio/vasyl-shkliar.md
+++ b/docs/research/bio/vasyl-shkliar.md
@@ -1,0 +1,159 @@
+# Василь Миколайович Шкляр — Research Dossier
+
+**Slug:** `vasyl-shkliar`
+**Block:** K (living contemporary novelist; public anti-imperial memory work, not a personal martyr biography)
+**Tier:** 3
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — living writers)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 institutional sources cited where available (Rada decree, Shevchenko Committee copy, history.org.ua/Thompson PDF); Wikipedia kept Tier 3 only
+- [x] Oppression mechanism is specific and modest: this is subject-matter memory suppression plus a documented 2011 award refusal/postponement, not an invented personal repression case
+- [x] >=2 primary/recorded-speech quotes included; `verify_quote` scores reported honestly as corpus-unmatched
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Василь Миколайович Шкляр. [T3: uk.wikipedia; T5/T2-ish publisher page]
+- **Pseudonyms / aliases:** The accessible sources in this pass use his real name. Forbidden/Russified forms for body text: Василий Николаевич Шкляр; Vasiliy Shklyar when copied from Russian-language metadata.
+- **Born:** 10 June 1951 | село Ганжалівка, then Лисянський район, Черкаська область | Ukrainian SSR, USSR. [T3: uk.wikipedia; publisher page]
+- **Died:** N/A — living person as of this dossier date.
+- **Education / career key facts:** Studied philology at Kyiv University, spent part of his studies at Yerevan University studying Armenian language/literature, and graduated from Kyiv University in 1973. He worked as a journalist and became known as a novelist and translator. [T3: uk.wikipedia]
+
+**Source note:** No Tier 1 ЕСУ/IEU-style biographical entry was located for Shkliar in this pass. Birth and education should therefore remain double-checked in Phase 2 if a higher-tier biographical source is found. This dossier does not add family/private-life detail.
+
+## 2. Oppression mechanism
+
+This dossier should **not** manufacture a Soviet prison/repression biography for a living writer. The load-bearing mechanism is instead twofold:
+
+**(a) Suppressed historical memory inside the novels.** **«Залишенець. Чорний ворон»** centers on the Kholodnyi Yar insurgent milieu and the armed resistance to Bolshevik/Soviet power in the early 1920s. The political charge of the work comes from restoring a memory tradition Soviet historiography framed through "banditry" or erased from public legitimacy. Use **Холодний Яр**, **повстанці**, **залишенець**, and **антиколоніальна пам'ять** carefully; do not flatten the novel into simple nationalist pageantry.
+
+**(b) Documented 2011 award conflict.** Radio Svoboda reported on 10 February 2011 that the Shevchenko Prize committee awarded the literature prize to Shkliar for **«Залишенець» («Чорний Ворон»)**. On 4 March 2011, Ukrainian Week published Shkliar's statement asking the president to postpone his award until Dmytro Tabachnyk was no longer in power; the statement says he could not accept the prize while Tabachnyk remained in office. The official Presidential Decree No. 275/2011 of 4 March 2011, as published by the Verkhovna Rada database and by the Shevchenko Committee site, lists the 2011 laureates but **does not list Shkliar**. Radio Svoboda then reported that he received the "people's Shevchenko Prize" in Kholodnyi Yar in April 2011. [T5: Radio Svoboda; T5: Ukrainian Week; T2: Rada; T2: KNPU]
+
+**What survived / what was distorted:** The work was not destroyed; it circulated widely. The risk is interpretive distortion: Soviet/Russian frames can dismiss the Kholodnyi Yar material as extremist or regional myth, while uncritical celebration can ignore the novel's contested politics and reception. The curriculum should name the controversy and keep the documentary sequence exact.
+
+## 3. Major works
+
+- `1976/1977` — **«Шовкова нитка»** / **«Перший сніг»**, early prose/children's and adult work in the late Soviet period. [T3: uk.wikipedia]
+- `1979` — **«Де твій Остап, Соломіє?»**, short prose collection. [T3: uk.wikipedia]
+- `1982` — **«Живиця»**, prose collection. [T3: uk.wikipedia]
+- `1986` — **«Праліс: Тінь сови»**, early novel. [T3: uk.wikipedia]
+- `1989` — **«Ностальгія»**, novel. [T3: uk.wikipedia]
+- `1999` — **«Ключ»**, novel; major post-Soviet breakthrough in popular readership. [T3: uk.wikipedia]
+- `2001` — **«Елементал»**, novel drawing on Caucasus/war-zone experience as mediated in the author's public biography. [T3: uk.wikipedia]
+- `2003` — **«Кров кажана»**, novel. [T3: uk.wikipedia]
+- `2009` — **«Залишенець. Чорний ворон»**, historical novel about Kholodnyi Yar insurgency; the core text for BIO/LIT/HIST integration. [T3: uk.wikipedia; T5: Radio Svoboda]
+- `2014` — **«Маруся»**, historical novel. [T3: uk.wikipedia]
+- `2015` — **«Чорне сонце»**, prose connected in reception with war-era Ukrainian military themes. [T3: uk.wikipedia]
+- `2017` — **«Троща»**, historical novel. [T3: uk.wikipedia]
+- `2019` — **«Характерник»**, historical novel. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (>=2 required)
+
+The local literary corpus did **not** match the chosen recorded-speech passages under `ukrlib-shkliar`; the real scores are reported rather than inflated.
+
+**Quote 1 — 2011 statement on the Shevchenko Prize:**
+
+> «поки при владі є Дмитро Табачник, я не зможу прийняти премію»
+
+`verify_quote(author="ukrlib-shkliar")` -> **matched: false, best_confidence: 0.0**. Source context: Shkliar's statement as published by Ukrainian Week on 4 March 2011. Pedagogically useful because it fixes the distinction between committee recognition, presidential-decree omission, and his own request to postpone/decline acceptance under Tabachnyk. [T5: Ukrainian Week]
+
+**Quote 2 — recorded speech on Kholodnyi Yar symbolism:**
+
+> «Центр боротьби за Україну знову переміщується до Холодного Яру»
+
+`verify_quote(author="ukrlib-shkliar")` -> **matched: false, best_confidence: 0.0**. Source context: Radio Svoboda interview/report before the April 2011 people's-prize event in Kholodnyi Yar. Pedagogically useful because it shows how Shkliar frames place as living political memory, not merely setting. [T5: Radio Svoboda]
+
+**Quote red flag:** `verify_quote(author="ukrlib-shkliar", text="Воля України або смерть")` returned **matched: false, best_confidence: 0.0**. That phrase is better treated as a Kholodnyi Yar motto/history phrase, not as a verified Shkliar-authored quotation unless a specific edition/page is checked.
+
+## 5. Language register
+
+- **Register:** popular historical prose, publicistic interviews, nationalist memory vocabulary, and action-driven narrative.
+- **CEFR readiness for full reading:** **B2/C1** for guided excerpts; **C1** for full novels because learners need historical/political scaffolding and vocabulary for insurgency, Soviet institutions, and regional memory.
+- **Lexicon notes:** VESUM check found `залишенець`, `холодноярці`, `холодноярський`, `повстанці`, `спротив`, `бестселер`, `белетристика`, `документальність`, `популяризація`, `антиколоніальний`, and `постколоніальний`. The form `холоднояровці` did **not** verify; prefer `холодноярці` or phrase through `повстанці Холодного Яру`. `check_russian_shadow` returned `matches_russian: false` for `залишенець` and `бестселер` at threshold 0.7.
+- **Stylistic features:** high-contrast moral conflict, reconstruction of suppressed insurgent memory, folk-heroic diction, and thriller pacing. Counterbalance with source work so the lesson does not become hagiography.
+
+## 6. Contested points
+
+- **Award wording.** A common simplification says Shkliar "won and refused the Shevchenko Prize." The documented sequence is more precise: the committee selected him for **«Залишенець» («Чорний Ворон»)**; he publicly asked to postpone acceptance while Tabachnyk was in power; Presidential Decree No. 275/2011 did not include him; supporters organized a people's prize in Kholodnyi Yar. Teach the sequence, not a slogan.
+- **Politics and reception.** The novel's recovery of Kholodnyi Yar memory is important for de-Sovietizing historical imagination, but the writer's public politics and reception have been contested. Keep claims sourced and avoid presenting popularity as literary consensus.
+- **"Father of the Ukrainian bestseller" trope.** This phrase appears in popular/publisher materials. It is not a neutral scholarly fact unless backed by sales data. In curriculum copy, prefer "popular historical novelist" or "widely read novelist" only when tied to a source.
+- **Ewa Thompson attribution.** If the module uses a postcolonial frame, correctly attribute it to **Ewa M. Thompson** and her book **_Imperial Knowledge: Russian Literature and Colonialism_** (Ukrainian translation: **«Трубадури імперії: Російська література і колоніалізм»**, Kyiv: Osnovy, 2006). This is a theoretical frame for Russian imperial literary discourse, not a direct source about Shkliar's biography. [T2/T4: history.org.ua PDF of the Ukrainian translation]
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-04. Candidate links are bare slugs/topics only and are not asserted as files.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/vasyl-shkliar.yaml` — biographical anchor.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/shklyar-black-raven-1.yaml`
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/shklyar-black-raven-2.yaml`
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/shklyar-marusia.yaml`
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `kholodnyi-yar-memory` — historical memory and Soviet erasure.
+  - `shevchenko-prize-2011` — public-award conflict and cultural politics.
+  - `ewa-thompson-imperial-knowledge` — theory frame for Russian imperial discourse, not a Shkliar biography source.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-shkliar`
+- **EN canonical (project spelling):** Vasyl Shkliar
+- **UA canonical (with patronymic):** Василь Миколайович Шкляр
+- **Aliases (track for `aliases:` YAML field):** Vasyl Shkliar; Vasyl Shklyar (common alternate transliteration in catalogs).
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Василий Николаевич Шкляр; Vasiliy Shklyar.
+
+## 9. Image candidates
+
+- **Best portrait candidate:** Wikimedia Commons category/page for Vasyl Shkliar, if an individual file has a compatible license. He is living, so do not assume public domain.
+- **Backup candidates:** publisher/BookForum/event photographs only if the individual file has explicit CC or permission.
+- **Context image:** Kholodnyi Yar landscape/monument photographs may be easier to clear under Commons licensing than an author portrait; verify location and license before use.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- No ЕСУ/IEU-style Tier 1 biographical entry located in this pass. This is an honest gap for Phase 2 verification.
+
+**Tier 2 (institutional / official):**
+- Верховна Рада України, legislation database. "Про присудження Національної премії України імені Тараса Шевченка: Указ Президента України від 04.03.2011 № 275/2011." https://zakon.rada.gov.ua/go/275/2011. Accessed 2026-06-04. Official decree text; Shkliar is not listed.
+- Комітет з Національної премії України імені Тараса Шевченка. "Указ Президента України від 4 березня 2011р. № 275..." https://knpu.gov.ua/ukazy-prezydenta-ukrainy/ukaz-prezydenta-ukrainy-vid-4-bereznia-2011r-275-pro-prysudzhennia-natsionalnoi-premii-ukrainy-imeni-tarasa-shevchenka/. Accessed 2026-06-04. Official committee copy of the same decree sequence.
+- history.org.ua digital library PDF. Ева М. Томпсон. **«Трубадури імперії: Російська література і колоніалізм»**. Kyiv: Osnovy, 2006. https://history.org.ua/LiberUA/966-500-265-1/966-500-265-1.pdf. Accessed 2026-06-04. Used only for correct Ewa Thompson attribution and decolonial framing.
+
+**Tier 3 (encyclopedic — tertiary, not primary):**
+- Українська Вікіпедія. "Шкляр Василь Миколайович." https://uk.wikipedia.org/wiki/Шкляр_Василь_Миколайович. Accessed through `query_wikipedia` on 2026-06-04. Used for life/work chronology and checked against external sources where possible.
+
+**Tier 5 (general web / interviews / publisher):**
+- Видавництво "Ярославів Вал." "Шкляр Василь." https://yar-val.com.ua/shkliar-vasyl/. Accessed 2026-06-04. Used for birth/date/place cross-check; publisher source, not neutral scholarship.
+- Radio Svoboda. "Шевченківську премію з літератури отримав Василь Шкляр — повідомлення." https://www.radiosvoboda.org/a/2305299.html. Accessed 2026-06-04. Committee-award report.
+- Український тиждень. "Шкляр відмовився від Шевченківської премії. Через Табачника." https://tyzhden.ua/shkliar-vidmovyvsia-vid-shevchenkivskoi-premii-cherez-tabachnyka/. Accessed 2026-06-04. Published text of statement/refusal-postponement.
+- Radio Svoboda. "За «Чорного Ворона» — народну Шевченківську премію." https://www.radiosvoboda.org/a/4745759.html. Accessed 2026-06-04. People's-prize/Kholodnyi Yar report and recorded speech.
+
+**Primary-source/corpus checks:**
+- `verify_quote(author="ukrlib-shkliar", text="поки при владі є Дмитро Табачник, я не зможу прийняти премію")` -> matched false, best_confidence 0.0.
+- `verify_quote(author="ukrlib-shkliar", text="Центр боротьби за Україну знову переміщується до Холодного Яру")` -> matched false, best_confidence 0.0.
+- `verify_quote(author="ukrlib-shkliar", text="Воля України або смерть")` -> matched false, best_confidence 0.0.
+- `verify_words` and `check_russian_shadow` results recorded in §5.
+
+**Honest gaps:** No Tier 1 biographical encyclopedia entry was located. No direct primary manuscript/archive source for **«Залишенець. Чорний ворон»** was available in the local corpus, so quotes are recorded speech, not novel text. Do not add private-life facts.
+
+**URL verification:** Every external URL listed in §10 returned HTTP 200 after redirects via `curl -L` on 2026-06-04.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Kholodnyi Yar is treated as Ukrainian memory, not Soviet "banditry."
+- [x] No Russian-imperial transliterations in body text except the explicitly forbidden list in §8.
+- [x] No Russocentric periodization — early 1920s resistance is named through Ukrainian insurgent memory, not Russian Civil War shorthand.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — living person.
+- [x] Place names use modern UA canonical forms with historical administrative context where needed.
+- [N/A] Holodomor.
+- [x] Russian/Soviet imperial framing is named where relevant; no unsupported 2014/2022 claims added.

--- a/docs/research/bio/yuriy-vynnychuk.md
+++ b/docs/research/bio/yuriy-vynnychuk.md
@@ -1,0 +1,161 @@
+# Юрій Павлович Винничук — Research Dossier
+
+**Slug:** `yuriy-vynnychuk`
+**Block:** K (living contemporary writer; Soviet-era pressure and post-Soviet cultural controversy, not a martyr biography)
+**Tier:** 3
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — living writers)
+**Researcher:** GPT-5.5 (Codex)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 institutional sources cited where available (ЕСУ, EBRD/BBC award note, Wilson Center event record); Wikipedia kept Tier 3 only
+- [x] Oppression mechanism is specific and modest: KDB interest/search in 1974, later KDB attention in 1978; no invented arrest, case file, or imprisonment
+- [x] >=2 primary/recorded-speech quotes included; `verify_quote` scores reported honestly as corpus-unmatched
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Павлович Винничук. [T1: ЕСУ; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** Юрко Винничук (publication form); Юзьо Обсерватор (journalistic persona). Forbidden/Russified forms for body text: Юрий Павлович Винничук; Yuri Vinnichuk when copied from Russian-language metadata.
+- **Born:** 18 March 1952 | **Станіслав, now Івано-Франківськ** | Ukrainian SSR, USSR. [T1: ЕСУ; T3: uk.wikipedia]
+- **Died:** N/A — living person as of this dossier date.
+- **Education / early work:** Graduated from the Ivano-Frankivsk Pedagogical Institute in 1973; worked for a time as an artist-designer and in journalism; later became a writer, journalist, editor, translator, and anthologist. [T1: ЕСУ; T3: uk.wikipedia]
+
+**Hard correction note:** Do **not** write a "Lviv childhood" premise. The verified birth place is **Станіслав/Ivano-Frankivsk**, and the verified education path is the Ivano-Frankivsk Pedagogical Institute. In a 2009 recorded interview, Vynnychuk says he finished the institute in 1973, worked at **«Прикарпатська правда»**, and after a 4 April 1974 KGB search fled to Lviv. [T5: Detector Media interview; T3: uk.wikipedia]
+
+## 2. Oppression mechanism
+
+This is a **living-writer dossier**, so the section should not inflate the record into martyrdom. The documented mechanism is **Soviet security pressure and publishability constraints**, not arrest, exile, or imprisonment.
+
+**What happened:** Vynnychuk's early manuscripts and non-socialist-realist writing drew KGB/KDB interest. The best accessible source in this pass is his own recorded account: after someone reported that he had old books and wrote texts far from socialist realism, KGB officers searched his home on **4 April 1974**; he describes the search as lasting 12 hours and says he then left for Lviv. Ukrainian Wikipedia repeats the same date and adds that the search was meant to find anti-Soviet writing. [T5: Detector Media interview; T3: uk.wikipedia]
+
+**By whom:** Soviet KGB/KDB structures. The dossier did **not** locate an archival case number, warrant, or personnel file; do not invent one.
+
+**Later pressure:** The Ukrainian Wikipedia article states that in 1978 Vynnychuk wrote the poem **«Арканум»** and the story **«Ги-ги-ги»**, which again attracted KGB attention because of anti-Soviet satire. Treat this as a tertiary-source claim unless a future researcher finds a primary archival record or a stable author interview specifically on the 1978 episode. [T3: uk.wikipedia]
+
+**What survived / what was distorted:** The relevant survival story is not destroyed manuscripts but **delayed public circulation**: much of the prose associated with Vynnychuk's black humor, mystification, erotic grotesque, and old-Lviv urban memory enters print only around the late Soviet collapse and post-1991 market. This makes him useful pedagogically as a case of how late Soviet censorship and post-Soviet publishing conditions shaped genre, not as a case of carceral repression.
+
+## 3. Major works
+
+- `1989` — **«Огненний змій»**, anthology of 19th-c. Ukrainian fantasy, editor/anthologist role. [T1: ЕСУ]
+- `1990` — **«Спалах»**, fantastic prose collection; includes the early **«Місце для дракона»** material. [T1: ЕСУ; T3: uk.wikipedia]
+- `1990/2002` — **«Місце для дракона»**, philosophical children's/YA tale; strong candidate for accessible B2/C1 discussion. [T1: ЕСУ]
+- `1991/1992` — **«Діви ночі»**, crime/erotic urban prose; first journal publication then book publication. [T3: uk.wikipedia]
+- `1992` — **«Ласкаво просимо в Щуроград»**, anti-utopian Soviet-reality satire. [T3: uk.wikipedia]
+- `1999` — **«Легенди Львова»**, urban-legend/cultural-memory collection; important but should not be mistaken for childhood autobiography. [T1: ЕСУ]
+- `2003` — **«Мальва Ланда»**, novel. [T1: ЕСУ]
+- `2005` — **«Весняні ігри в осінніх садах»**, novel; listed by EBRD/BBC as the 2005 BBC Ukrainian Book of the Year winner. [T2: EBRD/BBC award note]
+- `2012` — **«Танґо смерті»**, novel; named BBC Ukrainian Book of the Year 2012 by BBC Ukrainian/EBRD; Wilson Center later hosted him in a Contemporary Ukrainian Literature event around the English translation. [T2: EBRD; T2: Wilson Center]
+- `2015` — **«Аптекар»**, historical-adventure novel set in early modern Lviv; useful for language/register work but requires high-context scaffolding. [T5: Rozmova interview; T3: uk.wikipedia]
+
+## 4. Primary-source quotes (>=2 required)
+
+The local literary corpus did **not** match the chosen recorded-speech passages under `ukrlib-vynnychuk`; the real scores are reported rather than upgraded.
+
+**Quote 1 — recorded speech on national mythmaking:**
+
+> «Кожна нація творить свої міфи»
+
+`verify_quote(author="ukrlib-vynnychuk")` -> **matched: false, best_confidence: 0.0**. Source context: interview title and topic in Detector Media, 2009. Pedagogically useful because Vynnychuk's mystifications and old-Lviv prose need to be taught as invented/curated cultural memory, not as transparent documentary history. [T5: Detector Media]
+
+**Quote 2 — recorded speech on censorship pressure and the move to Lviv:**
+
+> «Після того, як 4 квітня 1974 р. у мене зробили обшук... я втік до Львова»
+
+`verify_quote(author="ukrlib-vynnychuk")` was run on a shorter related passage and returned **matched: false, best_confidence: 0.0**. Source context: Detector Media interview, where he links the search to KGB interest in old books and non-socialist-realist writing. Pedagogically useful because it corrects the false "Lviv childhood" storyline and anchors Lviv as an adult relocation after Soviet pressure. [T5: Detector Media]
+
+**Quote 3 — recorded craft stance, optional teaching hook:**
+
+> «Реалізм у літературі — це часто страшенно нудно»
+
+`verify_quote(author="ukrlib-vynnychuk")` was not corpus-matched in this pass; treat it as recorded interview/public-title evidence, not corpus-verified literary text. It helps explain why the dossier should foreground grotesque, fantasy, parody, and urban legend instead of forcing a realist-prose template. [T5: Rozmova interview archive]
+
+## 5. Language register
+
+- **Register:** urban Galician/Ukrainian literary prose with black humor, parody, erotic grotesque, fantasy, old-Lviv cultural lexicon, and deliberate mystification.
+- **CEFR readiness for full reading:** **B2/C1** for selected excerpts from **«Місце для дракона»** or urban legends; **C1/C2** for **«Танґо смерті»**, **«Аптекар»**, and heavily intertextual satirical prose.
+- **Lexicon notes:** VESUM check found `містифікація`, `постмодернізм`, `андеграунд`, `пастиш`, `інтертекстуальність`, `фантасмагорія`, `гротеск`, `бурлеск`, `краєзнавство`, and `антологія`. `check_russian_shadow` returned `matches_russian: false` for `містифікація` and `пастиш` at threshold 0.7.
+- **Stylistic features:** genre-mixing, mock-archival posture, unreliable documentary voice, burlesque shifts between comic and tragic registers, and Lviv urban micro-history.
+
+## 6. Contested points
+
+- **Birthplace and Lviv identity.** Vynnychuk is strongly associated with Lviv as a writer and anthologist, but source-backed biography begins in **Станіслав/Ivano-Frankivsk** and only moves to Lviv in 1974. Any module that begins "Lviv boyhood" is factually wrong.
+- **Mystification vs fabrication.** His literary hoaxes are part of the art and should be taught as authored postmodern play, not accidentally repeated as historical evidence. This matters because one of his invented "old texts" entered reference circulation before being exposed as a hoax.
+- **Erotic/black-humor controversies.** Treat controversies through sourced public texts only. Do not add private-life speculation, moralizing, or unsourced claims about intent.
+- **Decolonial use.** His work can be read against Soviet realism and against Russian cultural prestige, but he should not be reduced to "anti-Russian writer." The better frame is the recovery and invention of Ukrainian urban genre spaces that Soviet cultural policy had narrowed.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-06-04. Candidate links are bare slugs/topics only and are not asserted as files.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/yuriy-vynnychuk.yaml` — the bio plan this dossier should correct, especially birthplace/Lviv timing.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-fantastika/vynnychuk-tango-death.yaml`
+  - `curriculum/l2-uk-en/plans/lit-fantastika/vynnychuk-night-maiden.yaml`
+  - `curriculum/l2-uk-en/plans/lit-youth/vynnychuk-lviv-tales.yaml`
+  - `curriculum/l2-uk-en/plans/lit-humor/vynnychuk-hoaxes.yaml`
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `postmodern-mystification` — teach literary hoax as method, not as archive.
+  - `lviv-urban-memory` — compare Vynnychuk's curated Lviv with historical Lviv modules.
+  - `late-soviet-censorship-humor` — connect black humor to publishability under late Soviet constraints.
+
+## 8. Naming-canonical
+
+- **Slug:** `yuriy-vynnychuk`
+- **EN canonical (project spelling):** Yuriy Vynnychuk
+- **UA canonical (with patronymic):** Юрій Павлович Винничук
+- **Aliases (track for `aliases:` YAML field):** Юрко Винничук; Юзьо Обсерватор; Yuriy Vynnychuk; Yuri Vynnychuk.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Юрий Павлович Винничук; Yuri Vinnichuk.
+
+## 9. Image candidates
+
+- **Best portrait candidate:** Wikimedia Commons category/page for Yuriy Vynnychuk. Because he is living, verify the individual file license before reuse; do not assume public domain.
+- **Backup candidates:** event photographs from Wilson Center/Kennan Institute pages if license permits; publisher or festival headshots only with explicit CC/license permission.
+- **Context image:** book cover/title page for **«Танґо смерті»** or **«Легенди Львова»** may be fair-use-like in some contexts but should not be used as open educational art unless rights are cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України. "Винничук Юрій Павлович." https://esu.com.ua/article-34039. Accessed 2026-06-04. Birth in Станіслав, date, education, early work, genre characterization, selected bibliography.
+
+**Tier 2 (institutional / award):**
+- EBRD Press Office. "BBC Book prize winners in partnership with EBRD Cultural Programme." https://www.ebrd.com/home/news-and-events/news/2012/bbc-book-prize-winners-in-partnership-with-ebrd-cultural-programme.html. Accessed 2026-06-04. BBC Book 2012 for **«Танґо смерті»** and past-winner note for **«Весняні ігри в осінніх садах»**.
+- Wilson Center / Kennan Institute. "Tango of Death." https://www.wilsoncenter.org/event/tango-death. Accessed 2026-06-04. Event record for Vynnychuk and **The Tango of Death**, including BBC 2012 award note.
+
+**Tier 3 (encyclopedic — tertiary, not primary):**
+- Українська Вікіпедія. "Винничук Юрій Павлович." https://uk.wikipedia.org/wiki/Винничук_Юрій_Павлович. Accessed through `query_wikipedia` on 2026-06-04. Used for cross-checking life/work chronology; not treated as primary.
+
+**Tier 5 (general web / interviews):**
+- Detector Media. "Юрій Винничук: «Кожна нація творить свої міфи»." https://detector.media/withoutsection/article/43711/2009-02-10-yuriy-vynnychuk-kozhna-natsiya-tvoryt-svoi-mify/. Accessed 2026-06-04. Recorded interview; used for 1974 search/move account and quote.
+- Rozmova interview archive. "Юрій Винничук: Реалізм у літературі — це часто страшенно нудно." https://rozmova.wordpress.com/2015/10/08/urij-vynnychuk/. Accessed 2026-06-04. Used only as interview evidence/craft hook.
+- Radio Svoboda. "Порнографія чи еротика: хто стане цензором творчості Юрія Винничука?" https://www.radiosvoboda.org/a/24460860.html. Accessed 2026-06-04. Background on public controversy; not used for private claims.
+
+**Primary-source/corpus checks:**
+- `verify_quote(author="ukrlib-vynnychuk", text="Кожна нація творить свої міфи")` -> matched false, best_confidence 0.0.
+- `verify_quote(author="ukrlib-vynnychuk", text="Поезія належить молодості")` -> matched false, best_confidence 0.0.
+- `search_literary("Винничук Танґо смерті")` returned no Vynnychuk primary text match in the local corpus.
+- `verify_words` and `check_russian_shadow` results recorded in §5.
+
+**Honest gaps:** No KGB/KDB archival file number was located in this pass. ЕСУ is current only through its 2005 entry, so later works/awards are cross-checked against award/institutional or tertiary sources. Living-person private details are intentionally omitted.
+
+**URL verification:** Every external URL listed in §10 returned HTTP 200 after redirects via `curl -L` on 2026-06-04.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Soviet/KGB pressure is named, but the biography stays Ukrainian and local.
+- [x] No Russian-imperial transliterations in body text except the explicitly forbidden list in §8.
+- [x] No Russocentric periodization — late Soviet and post-1991 contexts are named directly.
+- [x] No uncritical Soviet propaganda terms.
+- [x] No "lost his life" euphemisms — living person.
+- [x] Place names use modern UA canonical forms with historical Станіслав explained.
+- [N/A] Holodomor.
+- [x] Russian aggression framing not central to this dossier; no false 2014/2022 claims added.


### PR DESCRIPTION
## Summary

Adds two sourced BIO research dossiers for living writers under `docs/research/bio/`:

- `yuriy-vynnychuk`
- `vasyl-shkliar`

## Per-figure notes

### yuriy-vynnychuk

Key facts: Юрій Павлович Винничук, born 18 March 1952 in Станіслав (now Івано-Франківськ), writer/journalist/editor; major works covered include «Діви ночі», «Танґо смерті», «Аптекар», «Місце для дракона», and «Легенди Львова».

⚠ resolution: The dossier explicitly corrects the false "Lviv childhood" premise. It records Ivano-Frankivsk education, the 1974 KGB/KDB search account, and the move to Lviv only in 1974.

Honest gaps: No KGB/KDB archival file number was located; later post-2005 work/award facts rely on award/institutional or tertiary sources because the ЕСУ entry is from 2005. Local `verify_quote` did not match the recorded-speech passages; real score reported as 0.0.

### vasyl-shkliar

Key facts: Василь Миколайович Шкляр, born 10 June 1951 in Ганжалівка, Черкащина; novelist associated with «Залишенець. Чорний Ворон», «Маруся», «Ключ», and other popular historical prose.

⚠ resolution: The dossier keeps the 2011 Shevchenko Prize sequence exact: committee recognition/report, Shkliar's public request to postpone/decline acceptance while Tabachnyk was in office, omission from Presidential Decree No. 275/2011, and the later people's prize in Kholodnyi Yar. It also correctly attributes Ewa M. Thompson's «Трубадури імперії: Російська література і колоніалізм» as the Ukrainian translation/framing of _Imperial Knowledge_ rather than a Shkliar-specific source.

Honest gaps: No Tier 1 biographical encyclopedia entry was located in this pass; birth/education are sourced to Wikipedia plus publisher/general sources and flagged for Phase 2 higher-tier verification. Local `verify_quote` did not match the recorded-speech passages; real score reported as 0.0.

## Validation

- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py` exits 0.
- All external URLs cited in the dossiers returned HTTP 200 after redirects via `curl -L`.
- Only the two requested dossier files are included in the commit.

No auto-merge.