### PR TITLE
fix(agent-runtime): pass agy model flag

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -38,6 +38,37 @@ No other subprocess building anywhere else in the codebase. If you find
 yourself writing `subprocess.Popen([..., "claude", ...])` — stop. Use
 `runner.invoke()`.
 
+## Agy setup for sources MCP
+
+`delegate.py dispatch --agent agy --model "Gemini 3.1 Pro (High)"` now
+passes the model display name through to `agy --model`. If `model=None`,
+the adapter omits `--model` and leaves Antigravity on its configured
+default.
+
+Agy does not take MCP servers as a per-invocation CLI flag. Configure
+`sources` in `~/.gemini/antigravity-cli/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "sources": {
+      "httpUrl": "http://127.0.0.1:8766/mcp"
+    }
+  }
+}
+```
+
+As of `agy` 1.0.5, that `httpUrl` streamable-HTTP config can invoke
+`sources` tools directly, so no stdio bridge is required. Verify the
+server is alive before dispatching a dossier writer:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8766/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"p","version":"1"}}}'
+```
+
 ## Add a new agent in 20 lines
 
 1. Copy `scripts/agent_runtime/adapters/_template.py` to `adapters/youragent.py`.

--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -7,30 +7,28 @@ seminar-track writer ADR at
 `docs/decisions/pending/2026-05-20-seminar-track-writer-assignment.md`
 adds it as candidate D pending empirical testing.
 
-Known behavioral facts as of agy 1.0.0 (verified locally 2026-05-20):
+Known behavioral facts as of agy 1.0.5 (verified locally 2026-06-04):
 
 - Headless prompt mode is ``agy -p "<prompt>"``. Stdin prompts are ignored.
 - Resume/new conversation is ``--conversation=<uuid>``.
+- When the caller provides ``model``, the adapter passes it through as
+  ``--model "<display name>"``. Passing ``None`` leaves agy on its own
+  default / configured model.
 - Write-capable modes use ``--dangerously-skip-permissions``. Read-only
   hangs on interactive permission prompts; callers must force
   ``mode="danger"`` for headless dispatch (mirrors the codex protection).
 - Print-mode stdout is the final answer only. Tool-call telemetry is stored
   in Antigravity's per-conversation JSONL transcript, located via a unique
   ``--log-file`` path for each invocation.
-- ``agy`` model selection is controlled by the interactive TUI and persists
-  across ``agy -p`` invocations; there is no CLI model flag. The runtime
-  records the caller-passed ``model`` in the JSONL audit row for
-  provenance only.
 - ``agy plugin`` only exposes ``import gemini|claude``, ``install``,
   ``enable``, ``disable``. There is no plugin-marketplace browse surface,
-  and ``import gemini`` is a no-op in a default install. The adapter
-  accepts ``tool_config["mcp_server_names"]`` for API parity with
-  ``GeminiAdapter`` but does not act on it today; wire ``agy plugin
-  enable <name>`` once concrete MCP servers are available.
+  and ``import gemini`` is a no-op in a default install.
 
 MCP plugin enablement is managed by agy's local configuration rather than a
 per-invocation CLI flag. The adapter accepts tool_config for API parity but
-does not mutate agy's MCP setup.
+does not mutate agy's MCP setup. The ``sources`` MCP works with Antigravity's
+``httpUrl`` streamable-HTTP config at
+``~/.gemini/antigravity-cli/mcp_config.json``.
 
 Differences from the kubedojo source:
 
@@ -99,10 +97,10 @@ class AgyAdapter:
     ) -> InvocationPlan:
         """Build the ``agy`` print-mode invocation.
 
-        ``model`` is intentionally not mapped to a CLI flag. The active
-        model is whichever model the operator selected in the ``agy`` TUI
-        panel. ``effort`` is accepted for protocol uniformity but is a
-        no-op until agy exposes a reasoning-effort flag (follow-up #1396).
+        ``model`` is mapped to ``agy --model`` when provided. ``None`` leaves
+        agy on its configured/default model. ``effort`` is accepted for
+        protocol uniformity but is a no-op until agy exposes a
+        reasoning-effort flag (follow-up #1396).
         """
         if mode not in self.supported_modes:
             raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
@@ -140,6 +138,8 @@ class AgyAdapter:
             "--log-file",
             str(log_path),
         ]
+        if model:
+            cmd.extend(["--model", model])
 
         if session_id:
             cmd.append(f"--conversation={session_id}")
@@ -148,7 +148,6 @@ class AgyAdapter:
         # not a per-invocation CLI flag like gemini-cli. tool_config is
         # accepted for parity but not acted on yet.
         _ = tool_config
-        _ = model
 
         return InvocationPlan(
             cmd=cmd,

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -238,13 +238,10 @@ def build_mcp_tool_config(
         )
 
     if canonical_agent == "agy":
-        # agy 1.0.0 has no per-invocation MCP flag (Phase 2 follow-up).
-        # We mirror the Gemini path's diagnostics shape so the upstream
-        # `_runtime_tool_config` validator does not fail-fast at dispatch
-        # time; the lack of MCP wiring then surfaces at runtime as
-        # MCP_TOOLS_NEVER_INVOKED, which is the precise + intended signal
-        # for the seminar-writer bakeoff. The adapter itself ignores
-        # `mcp_server_names`; we pass it through for parity / debuggability.
+        # agy reads MCP servers from ~/.gemini/antigravity-cli/mcp_config.json
+        # rather than from per-invocation flags. Mirror the Gemini diagnostics
+        # shape so dispatch can record the requested sources while the adapter
+        # leaves Antigravity's local MCP setup untouched.
         if not mcp_servers:
             return None, _basic_diagnostics(
                 mcp_config_path=resolved_config_path,

--- a/tests/agent_runtime/adapters/test_agy_adapter.py
+++ b/tests/agent_runtime/adapters/test_agy_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from scripts.agent_runtime.adapters import agy as agy_module
 from scripts.agent_runtime.adapters.agy import AgyAdapter
 from scripts.agent_runtime.adapters.base import InvocationPlan
 from scripts.build import linear_pipeline
@@ -39,6 +40,43 @@ def _write_transcript(app_data: Path) -> None:
         (FIXTURES / "verify_words_transcript.jsonl").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+
+
+def test_build_invocation_passes_model_flag(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(agy_module.shutil, "which", lambda name: "/bin/agy")
+
+    plan = AgyAdapter().build_invocation(
+        prompt="Reply with AGY_OK",
+        mode="danger",
+        cwd=tmp_path,
+        model="Gemini 3.1 Pro (High)",
+        task_id="agy-model-test",
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[:3] == ["/bin/agy", "-p", "Reply with AGY_OK"]
+    model_index = plan.cmd.index("--model")
+    assert plan.cmd[model_index + 1] == "Gemini 3.1 Pro (High)"
+
+
+def test_build_invocation_omits_model_flag_when_model_is_none(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(agy_module.shutil, "which", lambda name: "/bin/agy")
+
+    plan = AgyAdapter().build_invocation(
+        prompt="Reply with AGY_OK",
+        mode="danger",
+        cwd=tmp_path,
+        model=None,
+        task_id="agy-model-test",
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[:3] == ["/bin/agy", "-p", "Reply with AGY_OK"]
+    assert "--model" not in plan.cmd
 
 
 def test_parse_response_extracts_mcp_calls_from_real_agy_transcript(


### PR DESCRIPTION
## Summary

- Pass caller-provided agy models through as `agy --model <display name>`.
- Update the agy adapter docs/tests for agy 1.0.5 model-flag behavior.
- Document the working `sources` MCP setup in `docs/agent-runtime-guide.md`.
- Keep MCP setup external to the adapter: agy reads `~/.gemini/antigravity-cli/mcp_config.json`.

## Reproduction and MCP proof

Bug 1 reproduced: agy works without MCP configured.

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: timeout 60 agy -p "Reply with exactly AGY_OK" --model "Gemini 3.1 Pro (High)" --dangerously-skip-permissions
output:
AGY_OK
```

The `sources` streamable-HTTP server is alive.

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: curl -sS -X POST http://127.0.0.1:8766/mcp -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"p","version":"1"}}}'
output:
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"sources","version":"1.26.0"}}}
```

Bug 2 did not reproduce on agy 1.0.5 with the diagnosed `httpUrl` config. With:

```json
{
  "mcpServers": {
    "sources": {
      "httpUrl": "http://127.0.0.1:8766/mcp"
    }
  }
}
```

agy calls `sources.verify_word` successfully:

~~~text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: timeout 180 agy -p "Call the sources MCP tool verify_word for the Ukrainian word привіт and paste the raw JSON result." --model "Gemini 3.1 Pro (High)" --dangerously-skip-permissions
output:
Here is the result from the `verify_word` MCP tool for the word "привіт":

```
'привіт' — 2 match(es) in VESUM:

- **lemma**: привіт  |  **pos**: noun  |  **tags**: `noun:inanim:m:v_naz`  |  **is_archaic**: False
- **lemma**: привіт  |  **pos**: noun  |  **tags**: `noun:inanim:m:v_zna`  |  **is_archaic**: False
```

*(Note: The MCP server returns a formatted Markdown string rather than a raw JSON array, so the above is the direct output received from the tool).*
~~~

Direct JSON-RPC `tools/call` proof for the same server/tool:

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: curl -sS -X POST http://127.0.0.1:8766/mcp -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"verify_word","arguments":{"word":"привіт"}}}'
output:
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"'привіт' — 2 match(es) in VESUM:\n\n- **lemma**: привіт  |  **pos**: noun  |  **tags**: `noun:inanim:m:v_naz`  |  **is_archaic**: False\n- **lemma**: привіт  |  **pos**: noun  |  **tags**: `noun:inanim:m:v_zna`  |  **is_archaic**: False"}],"isError":false}}
```

Delegate smoke also invoked the tool:

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: .venv/bin/python scripts/delegate.py dispatch --agent agy --task-id agy-mcp-smoke-20260604-0911 --model "Gemini 3.1 Pro (High)" --mode danger --worktree --base main --prompt-file tmp/agy_verify_word_PROMPT.md --hard-timeout 300 --silence-timeout 120 --initial-response-timeout 60
output:
dispatch telemetry for agy could not resolve effort: no explicit override or readable default; recording 'unknown'
dispatch telemetry for agy could not resolve cli_version: version probe failed; recording 'unknown'
🌲 dispatch agy-mcp-smoke-20260604-0911: branch=agy/mcp-smoke-20260604-0911 base_sha=d18d6d459f71632d4787bb0bd3fdad503fb874c8 path=/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix/.worktrees/dispatch/agy/mcp-smoke-20260604-0911 layout=dispatch
agy-mcp-smoke-20260604-0911
```

~~~text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: cat batch_state/tasks/agy-mcp-smoke-20260604-0911.result
output:
Here is the raw result from the `verify_word` tool:

```
'привіт' — 2 match(es) in VESUM:

- **lemma**: привіт  |  **pos**: noun  |  **tags**: `noun:inanim:m:v_naz`  |  **is_archaic**: False
- **lemma**: привіт  |  **pos**: noun  |  **tags**: `noun:inanim:m:v_zna`  |  **is_archaic**: False
```

TOOL_CALLED_VERIFY_WORD
~~~

## Validation

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: .venv/bin/ruff check scripts/agent_runtime/adapters/agy.py scripts/agent_runtime/tool_config.py tests/agent_runtime/adapters/test_agy_adapter.py
output:
All checks passed!
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-mcp-fix
command: .venv/bin/python -m pytest tests/agent_runtime/adapters/test_agy_adapter.py
output:
6 passed in 0.98s
```

No auto-merge.
