### PR TITLE
research(bio): 6 sourced dossiers — early-modern church/Cossack founders (#2535)

### DIFF
--- a/docs/research/bio/iov-boretskyi.md
+++ b/docs/research/bio/iov-boretskyi.md
@@ -1,0 +1,180 @@
+# Йов (Іван Матвійович) Борецький — Research Dossier
+
+**Slug:** `iov-boretskyi`
+**Block:** K (early-modern church-restorer; posthumous imperial appropriation/erasure of the hierarchy he rebuilt)
+**Tier:** 1b
+**Issue:** #2535 (ghost-wiki dossier backfill — early-modern church/Cossack founders)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ/Сас; Когут; Літвинов; Філософська думка в Україні/Стратій; Острозька академія encyclopedia)
+- [x] Oppression mechanism is specific — the Commonwealth's outlawing of the 1620 hierarchy + the posthumous 1686 Muscovite capture + Soviet weaponising of his 1624 Moscow overture
+- [x] ≥2 primary-source quotes (Протестація 1621; Луцьк school statute; О воспитаніи чад) — attestation honestly reported (verify_quote = no match in the ukrlib corpus; cited from documented publications)
+- [x] Cross-track links: every "Existing" path verified against the on-disk plan listing (2026-06-04) and re-checked by `lint_bio_dossier_xref.py`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Йов Борецький; secular name Іван Матвійович Борецький (monastic name **Йов** from December 1619). [T1: ЕІУ — Борецький Іов (Сас П. М.); T3: uk.wikipedia; T1: Філософська думка в Україні: Біобібліографічний словник]
+- **Pseudonyms / aliases:** none used in print. Polish/Russified forms (forbidden in body text, listed only in §8): Jan Borecki, Иов Борецкий, Iov Boretsky (Russified).
+- **Born:** **≈1560** | містечко Бірча, Руське воєводство, Річ Посполита (now Bircza, Підкарпатське воєводство, Poland — a historically Ukrainian/руський settlement) | of the petty gentry house Борецьких гербу Голобок. [T3: uk.wikipedia; T1: Літвинов — "народився на Львівщині"]
+- **Died:** 2 March 1631 (O.S.) / **12 March 1631** (N.S.) | Київ, Річ Посполита | buried by his will at the **Михайлівський Золотоверхий монастир**, then the metropolitan's residence. [T3: uk.wikipedia — "2 (12) березня 1631"]
+- **Family / education key facts:** Son of the petty noble Матвій Борецький. Probably schooled at the **Острозька академія**, then Kraków University; from **1604** the first Latin teacher, then rector (1604–1605), of the **Львівська братська школа**; from 1610/1611 a priest in Kyiv (Воскресенська church on Podil) in Єлисей Плетенецький's learned Lavra circle; **first rector of the Київська братська школа (1615–1618)**. Married Никифора Чеховичівна; both took monastic vows in December 1619. **Mentor of Petro Mohyla.** [T3: uk.wikipedia; T1: Острозька академія encyclopedia (Пасічник)]
+
+**Source note (flagged):** birth is given only as **≈1560**; the **place** is Бірча per uk.wikipedia, "Львівщина" per Літвинов — same Galician-руський milieu. His secular name appears as **Іван** (UA) and is Polonised as **Jan** in the Polski Słownik Biograficzny (Chodynicki) — the latter a translation artefact, not a second person.
+
+## 2. Oppression mechanism
+
+For Boretsky the repression runs in two directions, and the dossier names both honestly. The **contemporary** mechanism is the Polish-Lithuanian Commonwealth's outlawing and persecution of the Orthodox hierarchy he restored; the **posthumous appropriation/erasure** is twofold — Moscow's later capture of his very see, and Soviet historiography's weaponising of his 1624 Moscow overture into a "reunification" myth.
+
+- **What happened:** (a) 1620–1632 — the restored Orthodox hierarchy was **illegal under Commonwealth law**; Boretsky and the new bishops were branded as Ottoman/Moscow agents and could not freely exercise office; the Uniate side blamed the 1620 consecrations for the 1623 killing of the Uniate archbishop Йосафат Кунцевич. (b) Posthumously — the **Київська митрополія** he re-founded was subordinated to the **Moscow Patriarchate in 1686**, erasing its Constantinople/Jerusalem-patriarchal autonomy. (c) Soviet historiography (the РЕІУ, a forbidden source listed even in uk.wikipedia's bibliography) cherry-picked his 1624 appeal to Moscow to manufacture a "вікове прагнення до возз'єднання з Росією."
+- **When (specific):** the hierarchy was restored under Cossack protection in **1620**; the Commonwealth only legalised an Orthodox metropolitan in the **1632 «Статті для заспокоєння руського народу»** — *after* Boretsky's death (1631). The Muscovite capture of the see is **1686**.
+- **By whom:** the **Річ Посполита** (royal/Catholic-Uniate establishment) contemporaneously; the **Moscow Patriarchate** and later **Soviet historiography** posthumously.
+- **Document / mechanism references:** the Filosofska-dumka biobibliography frames the Moscow overture precisely as a **defensive response to Polish persecution**, not a Russophile programme:
+
+  > «…у відповідь на утиски і порушення прав з боку польського уряду висловлюється ідея про політ. союз з Моск. державою.»
+
+  [T1: Філософська думка в Україні: Біобібліографічний словник (Стратій Я.), via corpus `wave8-fdm-biobibliohrafichnyi`]
+
+- **Mechanism specifics:** under the cover of Hetman **Петро Сагайдачний** and the Запорозьке військо, Patriarch **Феофан III of Jerusalem** secretly consecrated a new Orthodox episcopate in **1620**, with Boretsky as **Митрополит Київський, Галицький і всієї Русі** — an act the Commonwealth treated as criminal. Boretsky spent his metropolitanate (1620–1631) defending a hierarchy Warsaw would not recognise (the «Протестація» 1621, «Юстифікація» 1622), earning the title **"козацький митрополит."** Когут documents the structural fact: "**1620 р. під козацьким протекторатом відновилася православна ієрархія, а все Запорозьке військо увійшло до складу Київського православного братства**." [T1: Когут З., corpus `wave7-kohut-tsentralizm`]
+- **What survived / what was erased:** the hierarchy survived (Mohyla legalised and crowned it after 1632), but the **autonomy** Boretsky fought for was the very thing Moscow erased in 1686. The honest counter-reading of his Moscow overture (§6) restores him as a persecuted churchman seeking any protector against Warsaw — not the proto-reunificationist of Soviet myth.
+
+## 3. Major works
+
+A polemicist, translator and educator; several attributions are probable rather than certain (flagged). [T1: ЕІУ; T1: Філософська думка/Стратій; T3: uk.wikipedia]
+
+- `≈1605–1606` — **«Пересторога»** (probable authorship, per Возняк/Стратій) — one of the major monuments of Ukrainian polemical literature, anti-Catholic/anti-Uniate, indicting the Commonwealth's colonisation and the absence of "шкіл посполитих" (народних). [T1: Філософська думка/Стратій; T3: uk.wikipedia]
+- `1606` — **«Діалог про православну віру»** (Острог). [T3: uk.wikipedia]
+- `1609` — **«О воспитаніи чад»** (probable) — a pedagogical tract placing learning above all. [T3: uk.wikipedia]
+- `1619` — co-translated/edited the **«Анфологіон»** (Лаврська друкарня), the menaion supplemented with services and short lives of Rus' saints. [T3: uk.wikipedia]
+- `1620` — restored, with Sahaidachny and Patriarch Феофан, the **Ukrainian Orthodox hierarchy**; became its first metropolitan (1620–1631). [T1: Когут; T3: uk.wikipedia]
+- `1621` — **«Протестація»** (with Ісая Копинський and Йосиф Курцевич) — the manifesto defending the restored hierarchy and the Ukrainians' right to their land and faith, exalting the Cossacks as heirs of "старої Руси." [T1: ЕІУ; T3: uk.wikipedia]
+- `1622` — **«Юстифікація»** — the second memorial in defence of the hierarchy. [T3: uk.wikipedia]
+- `1628` — **«Аполлія апології Мелетія Смотрицького»** (Київ), the refutation of Smotrytsky's Uniate «Апологія»; and **«Лімонар»**, a translation of the Sinai patericon. [T3: uk.wikipedia]
+
+**Note on the intervening metropolitan:** Boretsky was *not* directly succeeded by Mohyla. After his death (1631) the see passed to **Ісая Копинський (metropolitan 1631–1633)** — his Протестація co-author — before Mohyla took the cathedra in **1633**. Копинський then contested Mohyla's election for years (see the Mohyla dossier §1). This succession Боре́цький → Копинський → Могила must not be elided. [T3: uk.wikipedia — Просвітницька діяльність; cross-ref `petro-mohyla` dossier]
+
+## 4. Primary-source quotes (≥2 required)
+
+These are Boretsky's documented words from his тексти and the school statute he ratified. **Attestation note (honest):** `verify_quote(author="Борецький")` returned **no match (confidence 0.0)** — the early-modern church-polemic corpus is not in the project's ukrlib *belletristic* author index; the quotes are therefore cited from their documented critical publications, not claimed as ukrlib-corpus hits.
+
+**Quote 1 — «Протестація» (1621), the rights-to-the-land claim:**
+
+> «Ми громадяни своєї землі, добре і чесно в домах шляхетних уроджені, в ній осідок і оселі свої маємо… і взяли ми лише те, що нам предки наші заповідали.»
+
+A foundational early-modern statement of Ukrainian autochthony and ancestral right — the political nerve of the whole hierarchy-restoration project. [Primary: «Протестація» 1621, publ. in *Пам'ятки братських шкіл на Україні*, Київ, 1988; quoted via T3: uk.wikipedia / Грушевський, *Історія України-Руси*, т. 6]
+
+**Quote 2 — the Луцьк brotherhood-school statute Boretsky ratified, on educational equality:**
+
+> «Багатії над убогими в школі нічим вищі не мають бути, лише самою наукою.»
+
+The thesis that "the rich are no higher in school than the poor — only by learning" became a guiding principle of the братські школи; pure pedagogical egalitarianism for a B1–B2 classroom. [Primary: Луцька school statute; quoted via T3: uk.wikipedia]
+
+**Quote 3 — «О воспитаніи чад» (1609), learning as the source of all good:**
+
+> «…з неї [науки], як з жродла, все добре походить, і през ню чоловік чоловіком ся находить.»
+
+"From it [learning], as from a wellspring, all good flows, and through it a person becomes a person" — early-modern *ruska мова* (жродло = джерело, през = через) preserving authentic period lexis. [Primary: «О воспитаніи чад» 1609; quoted via T3: uk.wikipedia]
+
+## 5. Language register
+
+- **Register:** learned ecclesiastical *ruska/prosta мова* (early-modern literary Ukrainian) for the polemics and statutes, Church Slavonic for liturgy, Latin/Greek for scholarship. His prose carries period forms — **жродло** (=джерело), **през** (=через), **посполитий** (=загальнонародний) — that must be preserved, not modernised.
+- **CEFR readiness for full reading:** the primary texts are **C1–C2** (archaic morphology, Polish-Latin loans); biographical prose is **B1–B2**; the §2/§6 Moscow-overture debate is **C1**.
+- **Lexicon notes (pre-teach):** митрополит, ієрархія, братство, ігумен, ректор, полеміст, протестація, шляхтич, міщанин, відновлення, вестернізація — **all 10 verified present in VESUM** (2026-06-04). Note **протестація** and **вестернізація** are authentic modern Ukrainian nouns (not anachronisms) used to describe his programme.
+- **Stylistic features:** civic-republican appeals (the autochthony claim), aphoristic egalitarianism (the school statute), and the аккумулятивна Baroque catalogue (the Cossacks as "лицарі Христа" / heirs of old Rus').
+
+## 6. Contested points
+
+- **The 1624 Moscow overture — the load-bearing decolonial nuance.** Boretsky did appeal to the Muscovite government (1624) for protection and even floated the annexation of Україна-Русь to the Muscovite state; the Tsar declined (Muscovy was too weak after its recent war with Poland). Soviet historiography seized on this to cast him as a proto-"reunifier." The honest reading, documented by Стратій, is that the overture was **a defensive response to relentless Commonwealth persecution** of the outlawed Orthodox hierarchy — a churchman seeking any external protector against Warsaw, not a Russophile. Present the **fact** plainly and the **Soviet "reunification" gloss** as the distortion it is. [T1: Філософська думка/Стратій; T3: uk.wikipedia]
+- **Authorship attributions.** «Пересторога» and «О воспитаніи чад» are **probable**, not certain, attributions (Возняк, Стратій); do not state them as settled.
+- **The Cossack-metropolitan synthesis.** Boretsky's exaltation of the Cossacks as heirs of "старої Руси" is sometimes read anachronistically as proto-nationalism; modern scholarship (Когут, Сас) reads it as a specifically 17th-c. confessional-estate alliance, not a modern national one.
+- **What gets simplified in popular memory:** the smooth "Boretsky → Mohyla" handoff erases **Ісая Копинський (1631–1633)** and the bitter succession dispute (§3). And his canonisation (UPC-KP, 2008) is recent and jurisdiction-specific — not a universal Orthodox glorification.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the on-disk plan directory listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml` — the BIO plan this dossier backfills (#2535 ghost-wiki gap).
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — the hetman whose Cossack protectorate made the 1620 restoration possible; the tightest link.
+  - `curriculum/l2-uk-en/plans/bio/petro-mohyla.yaml` — his protégé, to whom he entrusted the schools on his deathbed.
+  - `curriculum/l2-uk-en/plans/bio/meletii-smotrytskyi.yaml` — his fellow 1620 consecrand (archbishop of Polotsk), later opponent whose «Апологія» Boretsky refuted.
+  - `curriculum/l2-uk-en/plans/bio/sylvestr-kosiv.yaml` — his pupil and chronicler ("Сильвестр Косів писав про нього…").
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — the Ostroh academy milieu that probably formed him.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml` — the 17th-c. Orthodox struggle he led.
+  - `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml` — the 1596 Union that abolished the hierarchy he restored in 1620.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — the brotherhood-school movement he ran.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — the Cossack power that protected the hierarchy.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — the Commonwealth that outlawed it.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Ukrainian Baroque polemical-literary culture «Пересторога»/«Протестація» belong to.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A BIO plan for **Ісая Копинський** (the intervening metropolitan 1631–1633) — not yet built; needed to make the succession honest.
+  - A HIST unit on the **1620 secret restoration of the Orthodox hierarchy** as a Cossack-church act of state.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A primary-text module on **«Пересторога»** as a monument of Ukrainian polemical literature (§3).
+
+## 8. Naming-canonical
+
+- **Slug:** `iov-boretskyi`
+- **EN canonical (BGN/PCGN-style):** Iov Boretskyi
+- **UA canonical (with patronymic):** Іван Матвійович Борецький, чернече ім'я Йов
+- **Aliases to track (`aliases:` YAML field):** Job Boretsky (EN variant of the monastic name); Ivan Boretskyi (secular name); "козацький митрополит" (epithet).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Иов Борецкий; Iov Boretsky (Russified transliteration); Jan Borecki (Polonised); any framing of his 1624 Moscow overture as proof of a "natural striving for reunion with Russia."
+
+## 9. Image candidates
+
+- **Best PD portrait:** there is no securely contemporary portrait; a **19th-/20th-c. engraved or icon image of Metropolitan Йов Борецький** (PD by age) on Wikimedia Commons category **"Iov Boretsky"** — verify the individual file page. [Commons category: `Iov Boretsky`]
+- **Backup candidates:**
+  - The **Михайлівський Золотоверхий монастир** (his residence and burial place) — era/context architecture image, PD by age / freely licensed modern photo.
+  - A title page of the **«Анфологіон» (Київ, 1619)** he co-edited.
+- **Context image:** a page of the **«Протестація» (1621)** or the 1620-hierarchy-restoration scene — strong §2 illustration if a rights-clear scan is found.
+- **If no rights-clear portrait clears review:** fall back to the Михайлівський Золотоверхий cathedral or the «Анфологіон» 1619 title page.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Сас П. М. "Борецький Іов." *Енциклопедія історії України*, т. 1 (А–В). Київ: Наук. думка, 2003. С. 341. (cited via uk.wikipedia bibliography + resource.history.org.ua).
+- Когут З. *Російський централізм і українська автономія* — on the 1620 Cossack-protectorate restoration (corpus `wave7-kohut-tsentralizm`).
+- Літвинов В. (ред.) *Ренесансний гуманізм в Україні* — biographical entry on Боре́цький (corpus `wave7-lytvynov-renesans-humanizm`).
+- Стратій Я. "Борецький Іван (Йов)." *Філософська думка в Україні: Біобібліографічний словник.* Київ, 2002. С. 28–29 (corpus `wave8-fdm-biobibliohrafichnyi`).
+- Пасічник І. "Борецький Іван (Іов)." *Острозька академія: історія та сучасність…: енциклопедичне видання.* Острог, 2019. С. 131–141 (cited via uk.wikipedia).
+
+**Tier 2 (institutional / classic):**
+- *Києво-Могилянська академія в іменах, XVII–XVIII ст.: енциклопедія.* Київ: КМ Академія, 2001. С. 80–81.
+- Голубєв С. *Киевский митрополит Петр Могила и его сподвижники*, т. 1. Київ, 1883 (classic archival study).
+- Грушевський М. *Історія української літератури*, т. 6. Київ, 1995.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Йов (Борецький)." Dates, offices, works and the Moscow-overture framing cross-checked against ЕІУ and Філософська думка. Accessed 2026-06-04.
+
+**Tier 4 (modern scholarly — referenced):**
+- Ісаєвич Я. *Братства та їх роль в розвитку української культури XVI–XVIII ст.* Київ, 1966.
+- Мицько І. *Острозька слов'яно-греко-латинська академія.* Київ, 1990.
+
+**Primary-source documents accessed (in transcription, via T1/T3):**
+- **«Протестація» (1621)** — quoted §4 (publ. *Пам'ятки братських шкіл на Україні*, 1988).
+- **Луцька school statute; «О воспитаніи чад» (1609)** — quoted §4 (via uk.wikipedia / Грушевський).
+
+**Honest gaps:** the **IEU** English entry did not load this pass (404 on the expected URL); ЕІУ (Сас) is cited from the printed encyclopedia and uk.wikipedia's bibliography instead. `verify_quote` returned **no match** for Боре́цький (the church-polemic corpus is outside the ukrlib belletristic index) — reported honestly in §4. **Birth year (~1560)** and the authorship of **«Пересторога»/«О воспитаніи чад»** are genuinely uncertain (§6) and presented as open.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Kyiv/Lviv are the centres; Moscow appears as a declined protector (1624) and the later (1686) annexing power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Річ Посполита / Берестейська унія / Запорозьке військо used precisely; "reunification" named only as the Soviet myth.
+- [x] No uncritical Soviet terms — the РЕІУ "возз'єднання" frame is named as forbidden-source distortion, not endorsed.
+- [x] No "lost his life" euphemism — N/A (death 1631 natural); the repression is the Commonwealth's outlawing + posthumous appropriation, named precisely.
+- [x] Modern UA place names — Київ, Львів, Острог, Бірча, Луцьк used throughout.
+- [N/A] Holodomor — out of period (17th c.).
+- [N/A] Crimea/2014/2022 — not applicable to this figure's record; not forced.
+- [x] Truth in every direction — his 1624 Moscow overture is stated as documented fact, with the Soviet "reunification" gloss exposed as distortion, not suppressed.

--- a/docs/research/bio/kostiantyn-vasyl-ostrozky.md
+++ b/docs/research/bio/kostiantyn-vasyl-ostrozky.md
@@ -1,0 +1,171 @@
+# Костянтин-Василь (Василь-Костянтин) Острозький — Research Dossier
+
+**Slug:** `kostiantyn-vasyl-ostrozky`
+**Block:** K (early-modern magnate-patron; imperial appropriation of the Ostroh cultural revival + the dynastic-religious loss)
+**Tier:** 1b
+**Issue:** #2535 (ghost-wiki dossier backfill — early-modern church/Cossack founders)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU; ЕІУ/Ворончук; Огієнко; ЕУ; Шевельов)
+- [x] Oppression mechanism is specific — the Moscow 1663 reprint → 1751 Synodal-Bible appropriation of the Ostroh Bible + the Polish-Catholic dynastic erasure (Janusz's conversion)
+- [x] ≥2 primary-source expressions (his authored preface to the Ostroh Bible 1581; his anti-Union epistle in the Острозька «Книжиця» 1598; his recorded union-conditions) — verbatim-folio gap honestly flagged
+- [x] **Disambiguation honoured:** this is **Василь-Костянтин** (the patron, 1526/27–1608), NOT his father **Костянтин Іванович Острозький** (the elder, Orsha victor, d. 1530)
+- [x] Cross-track links: every "Existing" path verified against the on-disk plan listing (2026-06-04) and re-checked by `lint_bio_dossier_xref.py`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Василь-Костянтин Острозький (also rendered Костянтин-Василь; baptismal Василь, later styled by his father's name Костянтин). Old-Ukrainian: Костεньтин Ѡстрозский; Latin: Constantinus Dux in Ostrog. [T1: IEU — Ostrozky, Kostiantyn (Vasyl); T1: ЕІУ — Острозький Василь-Костянтин Костянтинович (Ворончук І.); T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none. Polish/Russified forms (forbidden in body text, listed only in §8): Konstanty Wasyl Ostrogski (Polish), Константин Константинович Острожский (Russified).
+- **Born:** **≈2 February 1526** (some sources 1527; Kempa "ok. 1524/1525") | Дубно, Волинь (raised in Туров) | younger son of the elder Острозький. [T1: IEU — "1526 or 1527"; T3: uk.wikipedia — "бл. 2 лютого 1526"]
+- **Died:** between **23 and 29 February 1608** | місто Острог, Волинь, Річ Посполита | buried 27 April 1608 in the crypt of the Богоявленська (Epiphany) церква, Ostroh. [T3: uk.wikipedia; T1: IEU — "23 February 1608"]
+- **Family / education key facts:** Son of **Костянтин Іванович Острозький** (the elder, the great hetman; d. 1530) and Олександра Слуцька. The richest magnate of the Commonwealth — at his height "80 містечок, 40 замків і 2760 сіл." **Воєвода київський for 49 years (1559–1608)**, senator (1569), signed the **Люблінська унія (1569)**; a candidate for the Polish throne (1573–74, blocked as "вождь схизматиків") and floated for the Muscovite throne (1598). Married Софія Тарновська (1553); among his children, **Януш (Janusz)** — the dynastic hinge of §2/§6. [T1: IEU; T3: uk.wikipedia]
+
+**Disambiguation note (load-bearing):** do NOT conflate him with his **father, Костянтин Іванович Острозький** (the elder, ~1460–1530, great hetman of Lithuania, victor of Orsha 1514) — a separate figure with his own plan slug `kostiantyn-ostrozky-elder`. This dossier is the **patron son**, Василь-Костянтин (1526/27–1608).
+
+## 2. Oppression mechanism
+
+For a magnate-patron the repression is **appropriation and dynastic erasure**: the Ostroh cultural revival he funded — above all the **Ostroh Bible (1581)** — was absorbed into the *Russian* Orthodox canon, while the Orthodox Ostrozky dynasty he built was dissolved into the Polish-Catholic aristocracy through his own son's conversion.
+
+- **What happened:** (a) the **Ostroh Bible** (a Ukrainian scholarly monument) was reprinted in **Moscow (1663)** and became the textual base of the Russian **Синодальна (Єлизаветинська) Біблія 1751/1756** — *the* canonical Bible of the Russian Orthodox Church — and the whole Ostroh achievement was reframed as "common Russian" heritage; (b) the **Orthodox Ostrozky line ended**: his heir **Януш converted to Roman Catholicism**, the dynasty Polonised-Catholicised, and the Ostroh Academy decayed after the prince's death.
+- **When (specific):** the appropriation runs **1663 → 1751**; the dynastic break is Janusz's conversion (in Vienna, **1568–1573**) and the line's extinction in the early 17th c.
+- **By whom:** the **Moscow Patriarchate / Russian Synodal Church** (textual appropriation; the БРЭ today still files him under Russian history — *evidence of the frame, not authority*, per the source-tier special rule); and the **Polish-Catholic Counter-Reformation** (dynastic denationalisation).
+- **Document / mechanism references (quoted, not paraphrased):** Огієнко names the appropriation directly — the Ostroh Bible was a *Ukrainian* achievement Moscow itself could not have produced:
+
+  > «…сама історія вибрала український народ, як найкультурніший на той час серед усіх православних слов'ян, на цю велику працю — видання повної друкованої Біблії… Культурний розвиток в Москві був тоді такий низький, що там наукове, добре видання Біблії постати не могло.»
+
+  And the appropriation route is documentary: "**З уніфікованим правописом Острозька Біблія була передрукована 1663 року в Москві… стала основою Синодальної (Єлисаветинської) Біблії 1751 і 1756 рр.**" [T2: Огієнко, corpus `wave7-ohiyenko-tserka`; T3: uk.wikipedia — Острозька Біблія]
+- **Mechanism specifics:** Острозький built, with his own fortune, the **Острозька академія** (~1576), the **Острозька друкарня** (he brought the persecuted printer **Іван Федоров** in 1575), and the learned **Ostroh circle** (Герасим Смотрицький as rector, Христофор Філалет, the future patriarch Кирило Лукаріс, Дем'ян Наливайко). Грушевський called this "**перше національне відродження України**." The empire took the fruit (the Bible) and erased the tree (a *Ukrainian* national revival became "общерусское просвещение"); the Polish-Catholic machine took the dynasty.
+- **What survived / what was erased:** the **Ostroh Bible survived** — too monumental to lose — but reattributed; the **Orthodox Ostrozky dynasty did not survive** as Orthodox. The 2008 UPC-KP canonisation of the prince as **благовірний** is part of the modern reclamation of an erased patron.
+
+## 3. Major works (patronage achievements)
+
+His "works" are the institutions and books he commissioned. [T1: IEU; T1: ЕУ; T3: uk.wikipedia; T1: Шевельов]
+
+- `1572` — founded a school at **Турів**; `1577` — at **Володимир**. [T1: IEU]
+- `1575` — invited the persecuted printer **Іван Федоров** to set up the **Острозька друкарня** (~1577). [T3: uk.wikipedia]
+- `1576` — founded the **Острозька академія** — the first East-Slavic school to teach Latin, Greek and Church Slavonic in parallel; the model later borrowed by the Lviv, Lutsk and other brotherhood schools. [T1: IEU; T3: uk.wikipedia]
+- `1578` — the **«Буквар»** (Ostroh primer) and the Greek-Slavonic **«Кграматыка»** from the Ostroh press. [T1: Шевельов]
+- `1581` — the **Острозька Біблія** — the **first complete printed Bible in Church Slavonic** (628 folios, ~1500–2000 copies), established by the Ostroh scholars against Greek and Hebrew sources; it carries a **передмова від імені Костянтина Острозького**. [T1: ЕІУ — Острозька Біблія (Ісаєвич); T3: uk.wikipedia]
+- `1587–1599` — the Ostroh polemical school: Герасим Смотрицький's **«Ключ царства небесного»** (1587), Христофор Філалет's **«Апокрисис»** (1597), and the **Острозька «Книжиця»** (1598), an anti-Union anthology containing **a poslannia of К. Острозький himself**, alongside М. Пігас and Іван Вишенський. [T1: Шевельов, corpus `wave9-shevelov-fonolohiia`]
+
+**Appropriation note:** the **Ostroh Bible** was reprinted in Москва 1663 and made the base of the Russian Synodal Bible 1751 (§2) — the single clearest case of imperial appropriation of a Ukrainian cultural monument.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Attestation note (honest):** Острозький's verbatim autograph folios (the Bible preface; his 1595 circular letter; the 1598 «Книжиця» epistle) were **not opened directly** this pass, and `verify_quote` is **not applicable** (he is outside the ukrlib belletristic index). §4 therefore rests on his **authored documents and his recorded position**, clearly labelled — the gold-exemplar pattern for figures whose primary texts are thin/Church-Slavonic.
+
+**Primary expression 1 — his authored preface to the Ostroh Bible (1581):**
+
+The 1581 Bible carries, by documentary record, a **«передмова від імені Костянтина Острозького»** — the prince's own dedicatory foreword framing the complete Scripture as a bulwark of the Orthodox faith for the Slavs; the book's own colophon names it "**Библіа, сиріч книги Ветхаго и Новаго Завіта, по язику словенску**," published "**заходами князя Костянтина Острозького**." This authored preface is his primary documentary voice; the verbatim folio is flagged as un-opened this pass. [T1: uk.wikipedia / ЕІУ — Острозька Біблія: "містить… передмову від імені Костянтина Острозького"]
+
+**Primary expression 2 — his recorded conception of church union (his stated position):**
+
+> Острозький wanted union as «об'єднання Сх. і Зах. Церков **із збереженням грецького обряду та всіх прав старої київської митрополії**» — and **only «за згодою патріярха на вселенському соборі»** (by a patriarch's consent at an ecumenical council), NOT a secret clerical deal.
+
+This is the documented record of *his* condition — the principled stance from which he denounced the secret 1596 Берестейський собор. [T1: ЕУ, corpus `wave7-entsyklopediia-ukrainoznavstva`; presented as recorded position, not verbatim autograph]
+
+**Primary work referenced:** his anti-Union **poslannia in the Острозька «Книжиця» (1598)** — documented (Шевельов) as an authored text in his own voice; verbatim not retrieved this pass (§10).
+
+## 5. Language register
+
+- **Register:** the Ostroh circle's high Baroque polyglossia — **Church Slavonic** (the Bible), the learned **prosta/ruska мова** of the polemics, and Latin/Greek/Polish for scholarship. Острозький's own register (correspondence, senate speeches) was the chancery Ruthenian-and-Latin of a Commonwealth magnate. Огієнко notes the Ostroh correctors even modernised obscure Church-Slavonic forms toward the living language — an early move of the literary norm.
+- **CEFR readiness for full reading:** the Ostroh Bible / polemics are **C2** (Church Slavonic); biographical prose is **B2**; the §2/§6 appropriation-and-dynasty debate is **C1**.
+- **Lexicon notes (pre-teach):** князь, магнат, меценат, воєвода, сенатор, друкарня, академія, схизматик, благовірний — **all verified present in VESUM** (2026-06-04). Note **схизматик** ("schismatic") is the *Catholic-Commonwealth* label hung on the Orthodox prince — to be used only in quotation marks as their term. (Caveat: **православ'я** returned no VESUM hit on the typographic apostrophe — a real word, not an error.)
+- **Stylistic features:** the rhetoric of *foundation* (prefaces, dedications, charters), confessional polemic (the «Книжиця»), and the magnate's senate oratory.
+
+## 6. Contested points
+
+- **The Ostroh Bible's appropriation (the core distortion).** Russian/Soviet narratives treat the Ostroh Bible and the Synodal Bible derived from it as "Russian Orthodox" heritage; the documentary chain (Москва 1663 → Синодальна 1751) is real, but the **origin is Ukrainian** — Грушевський's "перше національне відродження України." Present the appropriation route as fact and the "общерусское" framing as the distortion. [T2: Огієнко; T1: Грушевський]
+- **Union: founder or opponent?** Острозький **initiated** union talks (with Possevino, 1583; he funded Потій's Rome trip) **and then fiercely opposed** the secret 1596 Брест union — because it bypassed the ecumenical-council process he demanded. This is not inconsistency but a coherent conditional position; popular memory simplifies him into a pure anti-Uniate. [T1: ЕУ; T3: uk.wikipedia]
+- **The dynastic loss (Janusz).** His heir **Януш** (baptised Іван) converted to Roman Catholicism (Vienna, 1568–73) and was "the last man of the great Ostrozky dynasty"; the Orthodox magnate house the prince built dissolved into the Polish-Catholic elite — the denationalisation Огієнко named writ large in one family. [T3: uk.wikipedia — Януш Острозький]
+- **Relation to the Cossacks / Наливайко.** Острозький crushed the Косинський rising (П'ятка, 1593) and opposed **Северин Наливайко's** 1594–96 uprising, yet (per Маєвський) sheltered people tied to it — a magnate's ambivalence, not simple hostility (link to the Наливайко dossier). [T3: uk.wikipedia]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the on-disk plan directory listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — the BIO plan this dossier backfills (#2535 ghost-wiki gap).
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-ostrozky-elder.yaml` — his **father**, the elder (the disambiguation pair; do not conflate).
+  - `curriculum/l2-uk-en/plans/bio/meletii-smotrytskyi.yaml` — Meletii, son of his Academy's first rector Герасим Смотрицький, and his protégé.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — the Cossack leader he opposed (1594–96); whose brother Дем'ян was in his Ostroh circle.
+  - `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml` — the future metropolitan probably formed in the Ostroh milieu.
+  - `curriculum/l2-uk-en/plans/bio/petro-mohyla.yaml` — the later Kyiv institution-builder whose project answers Ostroh.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml` — the 1596 Union he initiated talks for and then opposed.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — the brotherhood-school movement his Ostroh model seeded.
+  - `curriculum/l2-uk-en/plans/hist/liublinska-uniia.yaml` — the 1569 Union he signed as Rus' leader.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — the Commonwealth he was the richest magnate of.
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — the 1590s Cossack risings (Косинський, Наливайко) he confronted.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Ukrainian Baroque polemical literature the Ostroh circle launched.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST/LANG unit on the **Ostroh Bible (1581)** and its appropriation route to the Russian Synodal Bible (§2).
+  - A BIO plan for **Герасим Смотрицький** (his Academy's first rector) — not yet built.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A primary-text module on the **Острозька «Книжиця» (1598)** anti-Union anthology (§3).
+
+## 8. Naming-canonical
+
+- **Slug:** `kostiantyn-vasyl-ostrozky`
+- **EN canonical (BGN/PCGN-style):** Kostiantyn-Vasyl Ostrozky (also Vasyl-Kostiantyn Ostrozky)
+- **UA canonical (with patronymic):** Василь-Костянтин Костянтинович Острозький
+- **Aliases to track (`aliases:` YAML field):** Vasyl-Kostiantyn Ostrozky; Constantine of Ostroh; "некоронований король Русі" (epithet); baptismal name Василь.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Константин Константинович Острожский; Konstanty Wasyl Ostrogski (Polonised, for `aliases` only); any framing of the Ostroh Bible/Academy as "Russian" heritage; and the **conflation with his father Костянтин Іванович Острозький (the elder)**.
+
+## 9. Image candidates
+
+- **Best PD portrait:** the well-known **portrait of Prince Vasyl-Kostiantyn Ostrozky** (16th–17th c. type, many PD reproductions) on Wikimedia Commons category **"Kostiantyn Vasyl Ostrozky"** — verify the individual file page. [Commons category: `Kostiantyn Vasyl Ostrozky`]
+- **Backup candidates:**
+  - The **title page / coat-of-arms folio of the Острозька Біблія (1581)** (the prince's герб is printed on the title verso) — a rights-clear primary image and a perfect §2/§3 illustration.
+  - The **Острозький замок** / Богоявленська церква (his residence and burial place) — era/context architecture.
+- **Context image:** a folio of the Ostroh Bible (Church-Slavonic двома шпальтами) for the §2 appropriation discussion.
+- **If no rights-clear portrait clears review:** fall back to the Ostroh Bible 1581 title page or the Ostroh castle.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Ostrozky, Kostiantyn (Vasyl)." encyclopediaofukraine.com. Accessed 2026-06-04.
+- Ворончук І. "Острозький Василь-Костянтин Костянтинович." *Енциклопедія історії України*, т. 7. Київ: Наук. думка, 2010. С. 690–691.
+- Ісаєвич Я. "Острозька Біблія." *Енциклопедія історії України*, т. 7. Київ, 2010. С. 685.
+- *Енциклопедія українознавства* (Берестейська унія; the Ostroh Academy and Bible) — corpus `wave7-entsyklopediia-ukrainoznavstva`.
+- Шевельов Ю. *Історична фонологія української мови* (the Ostroh polemical corpus, the «Книжиця» 1598) — corpus `wave9-shevelov-fonolohiia`.
+
+**Tier 2 (institutional / classic):**
+- Огієнко І. (Митрополит Іларіон). *Українська Церква* — on the Ostroh Bible as a Ukrainian achievement and its Moscow appropriation (corpus `wave7-ohiyenko-tserka`).
+- Грушевський М. *Історія України-Руси*, т. 6, с. 479–487 — the "перше національне відродження України" framing.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Костянтин Василь Острозький" and "Острозька Біблія" and "Януш Острозький." Dates, the founding of the Academy/press, the Bible's appropriation route, and Janusz's conversion cross-checked against IEU, ЕІУ and ЕУ. Accessed 2026-06-04.
+
+**Tier 4 (modern scholarly — referenced):**
+- Kempa T. *Konstanty Wasyl Ostrogski… Wojewoda kijowski i marszałek Ziemi Wołyńskiej.* Toruń, 1997; *Akademia i Drukarnia Ostrogska.* 2006.
+- Кралюк П. М. *Острозька Біблія в контексті української та європейської культур.* Острог, 2006.
+
+**Primary-source documents accessed (in transcription, via T1/T3):**
+- **Острозька Біблія (1581)** — title/colophon and the documented "передмова від імені Костянтина Острозького" (§4); the Moscow-1663 → Synodal-1751 appropriation route (§2).
+- **Острозька «Книжиця» (1598)** — his anti-Union poslannia referenced (§3/§4).
+
+**Honest gaps:** Острозький's **verbatim autograph folios** (the Bible preface; the 1595 circular letter; the 1598 epistle) were not opened directly this pass — §4 rests on his **authored documents and recorded position**, clearly labelled. `verify_quote` is **not applicable** (no ukrlib belletristic entry). The **birth year (1526 vs 1527, even ~1524/25)** is genuinely source-variant (§1).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Ostroh is "перше національне відродження України"; Moscow appears as the later appropriator of the Bible.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Річ Посполита / Берестейська унія / Острозька академія used precisely; "общерусское" named only as the appropriating frame.
+- [x] No uncritical imperial terms — "схизматик" used only as the Commonwealth's quoted label; the БРЭ frame named as forbidden-source distortion.
+- [x] No "lost his life" euphemism — N/A (death 1608 natural); the repression is cultural appropriation + dynastic erasure, named precisely.
+- [x] Modern UA place names — Острог, Дубно, Туров, Володимир, Київ used throughout.
+- [N/A] Holodomor — out of period (16th–17th c.).
+- [N/A] Crimea/2014/2022 — not applicable to this figure's record; not forced.
+- [x] Disambiguation honoured — kept distinct from his father, Костянтин Іванович Острозький (the elder).

--- a/docs/research/bio/meletii-smotrytskyi.md
+++ b/docs/research/bio/meletii-smotrytskyi.md
@@ -1,0 +1,175 @@
+# Мелетій (Максим Герасимович) Смотрицький — Research Dossier
+
+**Slug:** `meletii-smotrytskyi`
+**Block:** K (early-modern philologist; posthumous imperial appropriation of his grammar)
+**Tier:** 1b
+**Issue:** #2535 (ghost-wiki dossier backfill — early-modern church/Cossack founders)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU; Українська мова: енциклопедія/Німчук; Історія української культури/Крип'якевич; Огієнко)
+- [x] Oppression mechanism is specific — the appropriation of the 1619 grammar into "Russian" linguistics + the 1628 Kyiv anathema, with documentary anchors
+- [x] ≥2 primary-source quotes (the Тренос 1610 lament + its catalogue of apostate houses, both retrieved from the literary corpus)
+- [x] Cross-track links: every "Existing" path verified against the on-disk plan listing (2026-06-04) and re-checked by `lint_bio_dossier_xref.py`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Мелетій Смотрицький (secular name Максим Герасимович Смотрицький; monastic name Мелетій from 1618). [T1: IEU — Smotrytsky, Meletii; T1: Українська мова: енциклопедія — Смотрицький Мелетій; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** **Теофіл Ортолог** (Theophil Orthologus) — the pen-name on «Тренос» (1610). Russified forms (forbidden in body text, listed only in §8): Мелетий Смотрицкий, Meletij Smotrickij.
+- **Born:** **1577** (exact day unknown) | містечко Смотрич, Поділля (now Кам'янець-Подільський район, Хмельницька область, Україна) | son of the руський (Ukrainian) Orthodox gentry. [T1: IEU — "1577 in Smotrych, Podilia"; T3: uk.wikipedia]
+- **Died:** 17 December 1633 (O.S.) / **27 December 1633** (N.S.) | село Дермань (now Здолбунівський район, Рівненська область, Україна) | as archimandrite of the Дерманський монастир; buried there. [T1: IEU — "27 December 1633 at the Derman Monastery, Volhynia"; T3: uk.wikipedia]
+- **Family / education key facts:** Son of **Герасим Смотрицький**, the writer-polemicist and **first rector of the Острозька академія**, co-editor of the Ostroh Bible (1581). Educated at the Острозька школа, then the Jesuit Віленська академія (1594–1600, under the patronage of Prince Костянтин-Василь Острозький), then Protestant German universities (Wrocław, Leipzig, Wittenberg, Nuremberg) as tutor to the young Prince Соломирецький; probably took a doctorate in medicine abroad. [T1: IEU; T3: uk.wikipedia — Життєпис]
+
+**Source note (flagged):** the **birthplace** is given variously as Смотрич, Кам'янець, or Острог; the two UA Tier-1 traditions settle on **Смотрич**, the family seat. The **birth year 1577** is stable across IEU, the Polish Słownik Biograficzny (Frick: "ok. 1577"), and uk.wikipedia.
+
+## 2. Oppression mechanism
+
+For a philologist the load-bearing repression is **appropriation and erasure**: the Ukrainian (руський) scholar's grammar was absorbed into the history of *Russian* linguistics, its author re-labelled, while in his own lifetime he was crushed between the Polish-Jesuit Counter-Reformation and a hardening Orthodox establishment that publicly anathematised him.
+
+- **What happened:** (a) posthumous — his «Граматика» (1619) became the standard grammar across Ukraine, Belarus **and Russia**, and Russian/Soviet historiography claimed it (and its author) as a foundation of *Russian* grammar; (b) in his lifetime — the Orthodox Church publicly cursed and physically destroyed his «Апологія» (1628), forcing a recantation.
+- **When (specific):** the grammar appeared at **Єв'є (Vievis) in 1619**; it remained "**до середини XVIII ст. … єдиним підручником з граматики в школах України, Росії та Білорусі**" [T1: Історія української культури, `wave7-istkult`]. The Kyiv anathema is dated **14/24 August 1628** (during the liturgy at the Києво-Печерська лавра). [T3: uk.wikipedia]
+- **By whom:** the **Russian Empire's linguistic-historiographic apparatus** (later codified in Soviet and Russian reference works such as the Большая российская энциклопедія, which files him under Russian linguistics — *evidence of the appropriating frame, not an authority*, per the source-tier special rule); and, contemporaneously, the assembled Orthodox episcopate at the 1628 Kyiv synod.
+- **Document / mechanism references:** Огієнко documents the upstream machine — the Jesuit-school engine that denationalised the Orthodox elite (the world Smotrytsky was formed in and reacted against):
+
+  > «Своїм звичаєм єзуїти головний удар направили на вищу українську й білоруську інтелігенцію… При допомозі своїх дуже добрих шкіл вони денаціоналізували, а потім навернули на католицтво більшість вищої православної інтелігенції… всі, хто тільки кидав тоді православну віру, той не тільки переходив на католицтво, але й зраджував своїй нації…»
+
+  [T2: Огієнко І. *Українська Церква*, via corpus `wave7-ohiyenko-tserka`]
+
+- **Mechanism specifics:** the **«Грамматіки Славенскія правилноє Сvнтаґма» (Єв'є, 1619)** codified Church Slavonic so authoritatively that Moscow adopted it as its own school grammar; through later anonymised/expanded Moscow redactions it shaped the Russian grammatical tradition, and the author's руський (Ukrainian) identity was quietly written out. The same erasure logic ran through Soviet linguistics, which folded him into a generic "восточнославянское" frame. The counter-evidence is the Ukrainian academic record: НАН's facsimile-and-study edition (Німчук, 1979) and the *Українська мова: енциклопедія* entry restore him as a **Ukrainian** linguist whose rules "**зберігають чинність і в сучасній українській літературній мові**" (he fixed the letter **ґ**, the use of **й**, and much of modern UA punctuation). [T1: Українська мова: енциклопедія; T1: Німчук, `wave9-skhidnoslov-hramatyky`]
+- **What survived / what was erased:** the grammar survived (indispensable), but stripped of nation; the man's own arc — Orthodox polemicist turned Uniate — was then weaponised by every side. **Truth in both directions:** he was neither a Russian grammarian nor a simple traitor; he was a Ukrainian Baroque intellectual ground between Rome, Warsaw and a defensive Orthodoxy, whose linguistic achievement an empire later took and renamed.
+
+## 3. Major works
+
+[T1: IEU; T1: Українська мова: енциклопедія; T1: Історія української культури; T3: uk.wikipedia]
+
+- `1610` — **«Θρῆνος / Тренос, тобто Плач єдиної святої вселенської апостольської Східної Церкви»** (Wilno), under the pseudonym Теофіл Ортолог — the great Baroque polemic mourning the Orthodox elite's defection to Rome; Orthodox readers "**полишали дітям як дорогу спадщину, веліли класти з собою в могилу**" (Крип'якевич). Written in Polish; answered by the Jesuit Petro Skarga. [T1: Історія української культури, `wave7-krypyakevych-istkult`]
+- `1616` — translation into staroukrainian of the **«Євангеліє учительноє… Калиста»** (the Harvard HLEUL *Jevanhelije učytelnoje*). [T3: uk.wikipedia; T2: HURI/HLEUL vol. II]
+- `≈1615–1618` — taught Church Slavonic and Latin at the **Київська братська школа**, among its first rectors, where he largely composed the grammar. [T1: Історія української культури]
+- `1618` — monastic profession at the Vilnius Holy-Spirit (Святодухівський) monastery; took the name **Мелетій**; co-wrote the **«Буквар языка славенска»** (Єв'є, 1618). [T3: uk.wikipedia]
+- `1619` — **«Грамматіки Славе́нския пра́вилное Сѵ́нтагма»** (Єв'є / Vievis), his masterwork — the systematising grammar of Church Slavonic; the standard textbook for ~130 years across Ukraine, Belarus and Russia, translated into Latin, read in Bulgaria, Serbia, Croatia, Romania. [T1: Українська мова: енциклопедія; T1: Історія української культури]
+- `1620` — consecrated **православний архієпископ полоцький, єпископ вітебський і мстиславський** by Patriarch **Феофан III (Theophanes)**. [T1: IEU; T3: uk.wikipedia]
+- `1620–1622` — the Vilnius-period polemics **«Verificatia niewinności»** (1620), **«Oborona Verificaciey»** (1621). [T1: IEU]
+- `1628` — **«Апологія» (Apologia peregrinatiey)** (Львів), defending the Union — condemned and torn up at the **Kyiv synod, August 1628**; he publicly recanted under duress. [T1: IEU; T3: uk.wikipedia]
+- `1629` — **«Exethesis»** (Львів), his last great polemic, now openly for church union under Rome. [T3: uk.wikipedia]
+
+**Suppression / appropriation note:** the grammar was reprinted and rewritten in Moscow and absorbed into Russian grammatical history (§2); the «Апологія» was physically destroyed by the Orthodox synod of 1628.
+
+## 4. Primary-source quotes (≥2 required)
+
+Both passages are from **«Тренос» (1610)**, his most influential work; the original is Polish, and these are the canonical **Ukrainian renderings** (translated from the Polish, **not** through Russian) preserved in Ukrainian scholarship — flagged as translations per the source rules.
+
+**Quote 1 — the lament of Mother (Eastern) Church, the Тренос's emotional core:**
+
+> «Горе мені бідній, горе нещасливій, пограбованій, позбавленій усіх моїх маєтків, обдертій із шат моїх на прилюдну ганьбу мого тіла… Колись гарна й багата — я зогиджена і вбога! Колись була королевою, любленою всім світом, тепер усі гордять мною і знущаються… Родила я діти й виховала, а вони виреклись мене та приложили руку до мого упадку.»
+
+This personification of the Church as a despoiled woman is the specimen of Ukrainian Baroque rhetoric — and the reason the book was buried with its readers. [T1: Крип'якевич, *Історія української культури*, via corpus `wave7-krypyakevych-istkult`]
+
+**Quote 2 — the roll-call of руські noble houses that abandoned Orthodoxy (the Тренос's documentary spine):**
+
+> «…оплакує перехід на католицтво таких православних "руських" родин: княжат Острозьких, Слуцьких, Заславських, Збаразьких, Вишневецьких, Сангушків, Чорторийських… Ходкевичі, Глібовичі, Кишки, Сапіги… Тишкевичі… Гулевичі… Потії й інші…»
+
+A primary-source map of the denationalisation of the 17th-c. Ukrainian-Belarusian aristocracy — exactly the mechanism Огієнко names in §2. [T1: Тренос, л. 15, via Огієнко, corpus `wave7-ohiyenko-tserka`; cross-ref Грушевський, *Історія України-Руси*, т. 6, с. 598]
+
+**Linguistic primary artefact (his own terminology):** in the 1619 grammar Smotrytsky fixed the Church-Slavonic metalanguage — **имя, глаголъ, падежъ, число, родъ** etc. These are **historically correct Church-Slavonic grammatical terms** and must **not** be "corrected": e.g. **глаголъ** is his term for the verb (modern UA **дієслово**) and **падежъ** his term for case (modern UA **відмінок**). See §5 for the tool evidence on why these only *look* like Russianisms today.
+
+## 5. Language register
+
+- **Register:** learned Baroque, multilingual — **Polish** for the great polemics (Тренос, Verificatia), **Church Slavonic** for the grammar and liturgy, **prosta/ruska мова** (early-modern literary Ukrainian) for sermons and translations (the Євангеліє учительноє, the Лямент for Леонтій Карпович). "**Мелетій Смотрицький використовував для написання своїх творів староукраїнську мову**." [T3: uk.wikipedia]
+- **CEFR readiness for full reading:** the primary texts are **C2** (archaic morphology, Church-Slavonic and Polish); biographical prose is **B2**; the §2/§6 appropriation debate is **C1**.
+- **Lexicon notes (pre-teach) + the падеж/глагол guard:** граматика, мовознавець, полеміст, архієпископ, унія, уніат, синтагма — **all verified present in VESUM** (2026-06-04). The grammatical metalanguage needs careful handling: Smotrytsky's **падежъ** and **глаголъ** are the correct 1619 Church-Slavonic terms; their **modern UA** equivalents are **відмінок** and **дієслово** (both VESUM-verified). The tool `check_russian_shadow` flags modern **падеж** as Russian-matching (`matches_russian=true`, confidence **1.0**) — precisely because, *today*, падеж is a Russianism for відмінок; yet **глагол** returns `matches_russian=false` (treated as an archaic/Church-Slavonic form). **Pedagogical rule:** in the historical 1619 context these terms are authentic and stay as written; only in *modern* Ukrainian prose would падеж be a Russianism to correct. Do not retroject the modern norm onto his grammar.
+- **Stylistic features:** prosopopoeia (the weeping Church), accumulative catalogues (the noble houses), antithesis (колись королева — тепер удова), and the scholastic apparatus of the grammar (definition → paradigm → rule).
+
+## 6. Contested points
+
+- **The conversion — apostasy or tragic synthesis?** Smotrytsky died a **Uniate** (Greek Catholic) after a lifetime as the foremost Orthodox polemicist. UA scholarship is genuinely split: some (older Orthodox, and Soviet) frame him as a renegade; modern medievalists (Frick; Кралюк; Яковенко) read him as a sincere seeker of church unity disillusioned by the decay he saw on his 1624–25 Eastern journey. The dossier presents the conversion as **fact**, the motive as **contested**. [T1: IEU; T4: Кралюк 2007; T4: Яковенко 1993]
+- **Authorship vs nation of the grammar.** Russian/Soviet linguistics treats the 1619 grammar as a monument of "Russian/East-Slavic" learning; Ukrainian linguistics (Німчук) insists on its **Ukrainian** authorship and its living imprint on modern Ukrainian orthography. This is the §2 appropriation debate. [T1: Українська мова: енциклопедія; T1: Німчук 1982]
+- **Russian disinformation / framing.** The Большая российская энциклопедія entry (Барабаш, Неменський) and Russian Wikipedia file him as a figure of Russian culture — a forbidden authority here, cited only as **evidence of the appropriating frame** (source-tier special rule).
+- **What gets simplified in popular memory:** "father of Slavonic grammar" flattens that he wrote a grammar of **Church Slavonic**, not of vernacular Ukrainian; and the pen-name **Теофіл Ортолог** is often forgotten, obscuring how dangerous the Тренос was to publish under one's own name.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the on-disk plan directory listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/meletii-smotrytskyi.yaml` — the BIO plan this dossier backfills (#2535 ghost-wiki gap).
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — his patron and the founder of the Ostroh milieu his father led.
+  - `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml` — the metropolitan who answered the «Апологія» (his «Апологія» refutation) and met him in 1627.
+  - `curriculum/l2-uk-en/plans/bio/petro-mohyla.yaml` — fellow Kyiv-circle figure he met in 1627; the institution-builder whose Collegium absorbed the grammar.
+  - `curriculum/l2-uk-en/plans/bio/ivan-ohienko.yaml` — the linguist-churchman who both edited Ukrainian church history and worked the same orthographic terrain.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml` — the 1596 Union of Brest that defined his entire polemical and personal arc.
+  - `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml` — the 17th-c. Orthodox-church struggle he was a protagonist of.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — the brotherhood-school movement that produced his grammar.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — the Commonwealth confessional politics he navigated.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Ukrainian Baroque literary culture the Тренос helped open.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A BIO plan for **Герасим Смотрицький** (his father, first Ostroh rector) — not yet built.
+  - A LANG/LIT module on the **1619 grammar** as the root of modern Ukrainian orthographic rules (the **ґ**, the **й**) — strong §5 material.
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A primary-text reading of the **Тренос** lament as a specimen of Ukrainian Baroque prosopopoeia (§4).
+
+## 8. Naming-canonical
+
+- **Slug:** `meletii-smotrytskyi`
+- **EN canonical (BGN/PCGN-style):** Meletii Smotrytskyi
+- **UA canonical (with patronymic):** Максим Герасимович Смотрицький, чернече ім'я Мелетій
+- **Aliases to track (`aliases:` YAML field):** Теофіл Ортолог / Theophil Orthologus (pseudonym); Maksym Smotrytskyi (secular name); Meletij Smotryc'kyj (HLEUL transliteration).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Мелетий Смотрицкий; Meletij Smotrickij; any framing of him as a "Russian" grammarian or figure of "Russian culture."
+
+## 9. Image candidates
+
+- **Best PD portrait:** the title page of the **«Граматика» (Єв'є, 1619)** — the cleanest, rights-clear primary image (scans on **Polona.pl**, public-domain by age). Use the Polona file page for licence proof. [Polona.pl — Смотрицький стародруки]
+- **Backup candidates:**
+  - A 19th-/early-20th-c. engraved portrait of Smotrytsky as archbishop (PD by age; verify the file).
+  - The title page of the **«Тренос»** (Wilno, 1610) — strong §3/§4 illustration.
+- **Context image:** a page of the grammar showing the paradigms / his terminology (имя, глаголъ, падежъ) — a §5 illustration of the metalanguage discussion.
+- **If no rights-clear portrait clears review:** fall back to the 1619 grammar title page (the portrait situation for 17th-c. figures is thin).
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Smotrytsky, Meletii." encyclopediaofukraine.com (…SmotrytskyMeletii.htm). Accessed 2026-06-04.
+- *Українська мова: енциклопедія* (Німчук В. В., "Смотрицький Мелетій"). НАН України, Ін-т мовознавства ім. О. О. Потебні. Київ: Укр. енцикл. ім. М. П. Бажана, 2004. (retrieved from corpus `wave4-ukrainska-mova-encyclopedia`).
+- *Історія української культури*, т. 2 (Крип'якевич І. та колектив) — on the Тренос and the grammar's reach. (retrieved from corpus `wave7-krypyakevych-istkult`, `wave7-istkult-t2-xiii-xvii`).
+- *Східнослов'янські граматики XVI–XVII ст.* (Німчук В. В. та ін.). Київ: Наук. думка, 1982 (retrieved from corpus `wave9-skhidnoslov-hramatyky`).
+- Сас П. "Смотрицький Мелетій." *Енциклопедія історії України*, т. 9. Київ: Наук. думка, 2012. С. 676–677 (cited via uk.wikipedia bibliography).
+
+**Tier 2 (institutional / classic):**
+- Огієнко І. (Митрополит Іларіон). *Українська Церква* — on the Jesuit denationalisation engine and the Тренос catalogue (corpus `wave7-ohiyenko-tserka`).
+- Harvard Library of Early Ukrainian Literature (HLEUL), *Collected Works of Meletij Smotryc'kyj*, vol. I (intro D. A. Frick) & vol. II (the Jevanhelije učytelnoje). Cambridge, Mass., 1987.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Мелетій Смотрицький." Dates, works, conversion arc cross-checked against IEU and the Українська мова encyclopedia. Accessed 2026-06-04.
+
+**Tier 4 (modern scholarly — referenced):**
+- Кралюк П. М. *Мелетій Смотрицький і українське духовно-культурне відродження…* Острог, 2007.
+- Яковенко Н. "Мелетій Смотрицький." *Історія України в особах: IX–XVIII ст.* Київ, 1993.
+- Frick D. A. "Smotrycki Maksym…" *Polski Słownik Biograficzny*, т. XXXIX/3. 1999. С. 356–362.
+
+**Primary-source documents accessed (in transcription, via T1/T2 corpus):**
+- **«Тренос» (Wilno, 1610)** — quoted §4 (Крип'якевич; Огієнко/Грушевський).
+- **«Грамматіки Славенскія правилноє Сѵнтагма» (Єв'є, 1619)** — its metalanguage discussed §4/§5 (Німчук facsimile-study, 1979).
+
+**Honest gaps:** the **Тренос** quotes are Ukrainian translations of the Polish original (clearly labelled); the autograph/first-print folios were not opened directly this pass. The **exact day of birth** in 1577 is unrecorded. The **motive** for his 1627 conversion is genuinely contested (§6) and presented as open.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — the grammar is told as a Ukrainian achievement; Russia appears as the later appropriating frame.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Річ Посполита / Берестейська унія / Московське царство used precisely.
+- [x] No uncritical imperial terms — the БРЭ "Russian-culture" framing is named only as the appropriating narrative, not endorsed.
+- [x] No "lost his life" euphemism — N/A (death 1633 natural); repression is appropriation + the 1628 anathema, named precisely.
+- [x] Modern UA place names — Смотрич, Острог, Вільно, Єв'є (Vievis), Дермань, Полоцьк used with modern raion/oblast forms.
+- [N/A] Holodomor — out of period (17th c.).
+- [N/A] Crimea/2014/2022 — not applicable to this figure's record; not forced.
+- [x] Truth in every direction — his conversion to the Union is stated plainly, neither hagiographised nor condemned; the падеж/глагол historical terms are protected from anachronistic "correction."

--- a/docs/research/bio/petro-mohyla.md
+++ b/docs/research/bio/petro-mohyla.md
@@ -1,0 +1,174 @@
+# Петро Симеонович Могила — Research Dossier
+
+**Slug:** `petro-mohyla`
+**Block:** K (early-modern institution-builder; posthumous imperial appropriation/erasure)
+**Tier:** 1b
+**Issue:** #2535 (ghost-wiki dossier backfill — early-modern church/Cossack founders)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU; Шевченківська енциклопедія; Історія української культури НАН; Огієнко)
+- [x] Oppression mechanism is specific — names the 1686 subordination, the Synodal book-censorship, the ROC "local saint" downgrade, with documentary anchors
+- [x] ≥2 primary-source quotes (1646 Требник preface + the ruska-mova betrothal ordo, both retrieved from the literary corpus via Огієнко)
+- [x] Cross-track links: every "Existing" path verified against the on-disk plan listing (2026-06-04) and re-checked by `lint_bio_dossier_xref.py`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Петро Симеонович Могила (Romanian: Petru Movilă). [T1: IEU — Mohyla, Petro; T1: Шевченківська енциклопедія — Могила Петро Симеонович; T3: uk.wikipedia — Петро Могила]
+- **Pseudonyms / aliases:** none. Russified/Latinised forms (forbidden in body text, listed only in §8): Пётр Могила, Pyotr Mogila, Petrus Mohila.
+- **Born:** 21 December 1596 (O.S.) / **31 December 1596** (commonly cited N.S.) | місто Сучава (Suceava), Молдавське князівство (now Romania) | of the Moldavian princely-boyar Movilă (Могила) house. [T1: Шевченківська енциклопедія — "31.XII 1596"; T3: uk.wikipedia — "21 (31) грудня 1596"; **source disagreement, flagged §1 note**]
+- **Died:** 1 January 1647 (O.S.) / **11 January 1647** (N.S.), aged 50 | Київ, Річ Посполита | natural causes; buried by his own will in the Велика (Успенська) церква Києво-Печерської лаври. [T1: Шевченківська енциклопедія — "11.I 1647"; T1: IEU — "11 January 1647"; T3: uk.wikipedia]
+- **Family / education key facts:** Son of Симеон Могила, hospodar (господар) of Wallachia and Moldavia, and the Transylvanian princess Маргарет (Margareta). After his father's death (1607) and the loss of the family's Moldavian-Wallachian holdings (1612), the family fled to the Ukrainian lands of the Річ Посполита, sheltered by kin (Потоцькі, Корецькі, Вишневецькі). Schooled at the Львівська братська школа, then the Замойська академія and universities in the Netherlands and Paris; fluent in Ukrainian, Greek, Latin, Polish and Romanian. Fought as a Polish-army officer at Цецора (1620) and **Хотин (1621)** before taking monastic vows in the Києво-Печерський монастир (1625). [T1: IEU; T3: uk.wikipedia]
+
+**Source disagreement note (flagged, not smoothed):** the **birth year** is firmly **1596**, not 1595 (the latter is a recurring error). The two UA Tier-1 sources (Шевченківська енциклопедія, ЕІУ-tradition) give **31 December 1596**; IEU gives "**January 10, 1597**" — a different Julian→Gregorian recalculation of the same late-December-1596 birth, not a second year. This dossier anchors **1596** per the audit guard and the two concordant UA sources. The **day of episcopal consecration** in Lviv in 1633 also varies by source (see §1/§3): royal confirmation **12 March 1633** is firm; IEU places the Lviv consecration in **May 1633**, uk.wikipedia near the **end of June 1633** — recorded as a day-level variance, the year (1633) is not in doubt.
+
+## 2. Oppression mechanism
+
+For an early-modern institution-builder the repression is **posthumous appropriation and erasure**: Mohyla died (1647) a free metropolitan under Constantinople, but the Muscovite/Russian-imperial state then captured his institutions, absorbed his works into a "Russian Orthodox" narrative, and physically suppressed the distinct Kyivan-Mohylian liturgical tradition he had codified.
+
+- **What happened:** institutional capture + liturgical erasure + narrative absorption of his legacy by the Moscow Patriarchate and the Russian Empire.
+- **When (specific):** the decisive break is **1686** — within a generation of his death — when the Київська православна митрополія (Mohyla's see, held by him 1633–1647 as **екзарх Константинопольського патріарха**) was subordinated to the Moscow Patriarchate. The suppression of the distinct Kyivan service-books followed across the late 17th–18th centuries. [T3: uk.wikipedia — exarch status; context: HIST plan `pravoslavna-tserkva-17`]
+- **By whom (specific body):** the **Московський патріархат** and, from the 18th century, the **Russian imperial Святійший Синод**, which placed the Kyiv and Chernihiv presses under Moscow censorship and forbade printing anything diverging from "great-Russian" editions.
+- **Document / mechanism references (quoted, not paraphrased):** the church historian Іван Огієнко (Митрополит Іларіон) documents the concrete mechanism — Moscow's forcible replacement of Ukrainian service-books, the very books Mohyla had standardised:
+
+  > «Приєднавши Українську Церкву до своєї, московський уряд силою заборонив нам уживати власні Богослужбові книжки, накинувши нам книжки московські… про наш власний український Требник, наприклад 1646 р., що його видав митрополит Київський Петро Могила, ми зовсім забули…»
+
+  [T2: Огієнко І. *Українська Церква* — retrieved from the literary corpus, `wave7-ohiyenko-tserka`]
+
+- **Mechanism specifics (1–3 ¶):** Mohyla had built three things the empire could not tolerate as *Ukrainian*: an autonomous **Київська митрополія** under Constantinople; a Western-standard **колегія** (later академія) that out-taught Muscovy; and a corpus of **Kyivan service-books** (the «Требник» 1646, «Служебник», the catechism) in their own redaction. After 1686 the empire kept all three but stripped their Ukrainian authorship — drawing Mohylian graduates (Стефан Яворський, Феофан Прокопович, Інокентій Ґізель's milieu) into Muscovy to *build the Russian* church and school while imperial historiography reframed this as native "Russian enlightenment." Mohyla's catechism «Православне сповідання віри», approved at the 1642 Яссы synod, was reprinted in **Москва 1696** and absorbed as *the* Orthodox confession — appropriation by adoption.
+- **What survived / what was erased:** the works survived (too useful to destroy) but were **detached from author and nation** — the Kyivan Требник tradition was driven out of use in Ukrainian parishes and replaced by Moscow editions (Огієнко, above). A late, telling coda: when Mohyla was canonised in **1996**, every Ukrainian Orthodox jurisdiction glorified him as a full saint, while the **Russian Orthodox Church recognised him only as a "місцевошанований" (locally-venerated) saint** — a deliberate downgrade of a metropolitan whose intellect it had spent three centuries absorbing. [T3: uk.wikipedia — Канонізація]
+
+## 3. Major works
+
+Roughly **20 works** of theology, liturgy, polemics and pedagogy; below are the load-bearing ones, chronological. [T1: IEU; T1: Історія української культури, `wave7-istkult`; T3: uk.wikipedia]
+
+- `1627` — installed **архімандрит Києво-Печерської лаври** (royal confirmation 29 Nov 1627), at age 30 — the platform for everything after. [T3: uk.wikipedia]
+- `1628` — **«Агапита діакона главизни поучительни»** and a **«Тріодь цвітная»**, his translations from Greek printed at the Lavra press. [T3: uk.wikipedia]
+- `1629` — **«Леітургіаріон» / «Служебник»**, a service-book corrected against Greek sources with his own dogmatic and rubrical commentary — "протягом двохсот років не втрачав свого значення." [T3: uk.wikipedia]
+- `1631` — founds the **Лаврська школа**; **1632** merges it with the Київська братська школа to form the **Києво-Могилянська колегія** — "eventually the largest centre of scholarship and education in Eastern Europe" (IEU). Branches at Вінниця, Гоща and Крем'янець follow. [T1: IEU; T3: uk.wikipedia; HIST plan `bratstva-i-osvita`]
+- `1632` — **«Крест Христа Спасителя»**, his attributed sermon, Kyiv. [T1: Історія української культури — "талановито написаної проповіді «Крест Хреста Спасителя» (Київ, 1632)"]
+- `1633` — confirmed by King Władysław IV (12 March) and consecrated **Митрополит Київський, Галицький і всієї Русі**, екзарх Константинопольського патріарха (1633–1647). [T1: IEU; T3: uk.wikipedia]
+- `1640` — **«Православне сповідання віри»** (Orthodoxa Confessio Fidei), the first systematic Orthodox catechism, drafted by the Mohylian circle under his direction; ratified at the **1642 synod in Яссы**. [T1: IEU; T1: Історія української культури]
+- `1644` — **«Λίθος / Камінь»** (under the pseudonym Eusebius Pimin), the great polemical reply to Касіян Сакович's *Perspektywa*. [T3: uk.wikipedia]
+- `1646` — **«Требник» (Евхологіон)**, the "Требник Петра Могили" — his masterwork of liturgical codification, used across Ukraine and later imposed-upon and reprinted by the Russian church. [T1: IEU; T2: Огієнко]
+
+**Suppression note:** the distinct Mohylian service-books were driven out of Ukrainian use and replaced by Moscow editions (§2); the full catechism was first printed abroad (Greek/Latin/Polish) and only reprinted in Москва 1696 after his death.
+
+## 4. Primary-source quotes (≥2 required)
+
+Both quotes are Mohyla's own codifying voice from the **«Требник» 1646**, retrieved from the project literary corpus (`wave7-ohiyenko-tserka`, Огієнко's *Українська Церква*, which quotes the Требник directly).
+
+**Quote 1 — the preface to the Требник 1646, Mohyla diagnosing liturgical disunity:**
+
+> «На око те побачиш, — каже він, — Чительнику Освященний, коли поглянеш до Виленських та Острізьких Требників, де в таїнстві Шлюбу або в Відправі Вінчання шлюбних слів, в яких згода молодих (а це є форма таїнства) виявляється, не положено…»
+
+Pedagogically valuable: the founder-as-editor, justifying standardisation by appeal to evidence ("на око побачиш") — a Baroque scholarly habit, and a window on why his Требник mattered. [T2: Огієнко — Требник 1646 preface, via literary corpus]
+
+**Quote 2 — the betrothal ordo Mohyla codified, in the *ruska* (Ukrainian) language of the rite:**
+
+> «Маеш [Имк] неотменный и статечный умысл заручити собе теперь тую [Имк], которую тут перед собою видишь, в стан малженский, а гды тому час будет, поняти ей собе за малжонку?»
+
+Огієнко flags the rubric itself — the priest asks "руским (цебто українським) языком" — i.e. the Mohylian rite put the binding question in the people's Ukrainian, not Church Slavonic. A concrete artefact of 17th-c. liturgical Ukrainian for learners. [T2: Огієнко — Требник 1646 marriage ordo, via literary corpus]
+
+**Note on register:** these are early-modern *ruska мова* / Church-Slavonic-inflected texts (малженство, статечний, гды). They are quoted as historical primary text and must **not** be "modernised" — the archaic forms are the evidence.
+
+## 5. Language register
+
+- **Register:** high ecclesiastical Baroque — Church Slavonic for scripture/liturgy, *prosta/ruska мова* (early-modern literary Ukrainian) for prefaces, sermons and the binding rubrics, plus Polish and Latin for scholarship. Mohyla's own policy, per uk.wikipedia: старозавітні тексти — церковнослов'янською; проповіді й панегірики — українською; наукові праці — слов'янськими/латиною.
+- **CEFR readiness for full reading:** the primary texts are **C2** (archaic morphology, Church-Slavonic lexis); biographical prose about him is **B2**; the §2/§6 appropriation debate is **C1**.
+- **Lexicon notes (pre-teach):** митрополит, архімандрит, екзарх, колегія, требник, служебник, сповідання (віри), катехізис, господар (=ruler/hospodar, false-friend for "master"), боярський, полемічний, обмосковлення, дерусифікація — **all 12 verified present in VESUM** (2026-06-04 batch). Note the historical compound **обмосковлення** is authentic Ukrainian, **not** a Russianism (`check_russian_shadow`: `matches_russian=false`, confidence 0.0).
+- **Stylistic features:** Baroque scholastic apparatus (numbered rubrics, dogmatic glosses appended to ordines), evidentiary appeals ("на око побачиш"), bilingual question-and-answer catechetics.
+
+## 6. Contested points
+
+- **"Catholic/Jesuit borrowing" — reform or Latinisation?** Mohyla rebuilt Orthodox education and theology *за католицькими, єзуїтськими взірцями* (Jesuit-college model, scholastic method). UA scholarship debates whether this was a confident modernisation that saved Orthodoxy or a partial Latinisation of it; uk.wikipedia records contemporaries split between seeing him as "щирий поборник єдности православ'я" and "рукою королівської влади." Treat as a live, legitimate debate, not a verdict. [T3: uk.wikipedia — Дипломатична діяльність]
+- **Ethnic origin vs national belonging.** Mohyla was **of Moldavian (Romanian) princely stock** yet became "батько руської (української) теології." Popular memory sometimes flattens this either into "a Romanian" or into "a Russian church father." Both erase the actual fact: a Moldavian-born builder of *Ukrainian* (руської) church and learning within the Річ Посполита. [T1: IEU; T3: uk.wikipedia]
+- **Russian-imperial appropriation (the core distortion).** Imperial and Soviet narratives folded Mohyla, his Collegium and his catechism into a "common Russian Orthodox / all-Russian enlightenment" story, obscuring that Kyiv *taught Moscow*, not the reverse. Огієнко's whole project is the counter-documentation (§2, §4). The ROC's 1996 "local saint" downgrade is the same logic in miniature. [T2: Огієнко; T3: uk.wikipedia]
+- **What gets simplified in popular memory:** "founder of the first Ukrainian university" compresses a messy institutional history (Лаврська + братська schools merged 1632; "академія" status formalised later) into a clean origin myth. The **1596 vs 1597** birth-date and **1595** error also recur in popular texts (§1).
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the on-disk plan directory listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/petro-mohyla.yaml` — the HIST treatment of the same figure; tightest link.
+  - `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml` — the 17th-c. Orthodox-church context his whole career sits in.
+  - `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml` — the 1596 Union of Brest that defined the confessional battlefield he inherited.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — the brotherhood-school movement his Collegium grew out of and superseded.
+  - `curriculum/l2-uk-en/plans/hist/khotynska-viyna.yaml` — the 1621 Khotyn war he fought in before ordination.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — the Commonwealth polity that framed Orthodox legality.
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/petro-mohyla.yaml` — the BIO plan this dossier backfills (the #2535 ghost-wiki gap).
+  - `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml` — his mentor (see §1), the metropolitan whose library he inherited.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — the hetman who restored the Orthodox hierarchy (1620) Mohyla later led.
+  - `curriculum/l2-uk-en/plans/bio/ivan-ohienko.yaml` — the 20th-c. church historian whose documentation of the Mohyla Требник's suppression is my §2/§4 spine.
+  - `curriculum/l2-uk-en/plans/bio/sylvestr-kosiv.yaml` — his successor-once-removed and Collegium rector.
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — the prior magnate-builder of Orthodox learning (Ostroh) Mohyla's Kyiv project answers.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Kyivan-Mohylian Baroque literary culture his Collegium incubated.
+  - `curriculum/l2-uk-en/plans/lit/skovoroda-baroque-philosophy.yaml` — the Mohyla-Academy intellectual lineage running to Сковорода.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST unit on the **1686 subordination of the Kyiv Metropolitanate to Moscow** as the institutional hinge of §2 (relates to the existing `tomos` plan on autocephaly).
+  - A BIO↔BIO arc Острозький → Борецький → Могила → Косів as the "Orthodox-revival relay."
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A primary-text module on the **Требник 1646** marriage ordo as a specimen of 17th-c. liturgical Ukrainian (§4).
+
+## 8. Naming-canonical
+
+- **Slug:** `petro-mohyla`
+- **EN canonical (BGN/PCGN-style):** Petro Mohyla
+- **UA canonical (with patronymic):** Петро Симеонович Могила
+- **Aliases to track (`aliases:` YAML field):** Petru Movilă (Romanian); Petro Movila; "Mohyla College / Kyiv-Mohyla Academy" (institutional eponym).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Пётр Могила; Pyotr Mogila; "Peter Mohila/Mogila"; any framing of him as a "Russian Orthodox" church father.
+
+## 9. Image candidates
+
+- **Best PD portrait:** the 17th-c. **portrait of Petro Mohyla** (anonymous, Kyiv), long held at the Kyiv-Mohyla Academy / Lavra — out of copyright by age; Wikimedia Commons category **"Petro Mohyla"** holds it. Use the individual **file page** for licence proof, not the category page. [Commons category: `Petro Mohyla`]
+- **Backup candidates:**
+  - The **Спас на Берестові** church (restored by Mohyla) fresco/portrait area — era-context architecture image, PD by age.
+  - Укрпошта / NBU commemoratives for the Kyiv-Mohyla Academy anniversaries (check stamp/coin rights before use).
+- **Context image:** a title page of the **«Требник» 1646** (Lavra print) — a strong §2/§4 illustration if a rights-clear scan is found.
+- **If no rights-clear portrait clears review:** fall back to the PD Требник 1646 title page or the Києво-Могилянська академия building.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine*. "Mohyla, Petro." encyclopediaofukraine.com (display.asp…MohylaPetro.htm). Accessed 2026-06-04.
+- *Шевченківська енциклопедія*, т. 4 (М—Па). "Могила Петро Симеонович" (31.XII 1596 — 11.I 1647). Київ: Ін-т літератури ім. Т. Г. Шевченка НАН України, 2013. С. 283–284. (retrieved from corpus `wave10-shevchenkivsky-slovnyk`).
+- *Історія української культури*, т. 2 (XIII–XVII ст.). НАН України. (retrieved from corpus `wave7-istkult-t2-xiii-xvii`) — on the Mohylian circle and «Крест Христа Спасителя» (Київ, 1632).
+
+**Tier 2 (institutional / classic church-history):**
+- Огієнко І. (Митрополит Іларіон). *Українська Церква* — on the 1646 Требник, its forcible Muscovite replacement, and the marriage ordo (retrieved from corpus `wave7-ohiyenko-tserka`).
+- Ісаєвич Я. *Українське книговидання* — on the Lviv/Lavra printing disputes around the Требник (retrieved from corpus `wave8-isaievych-knyhovydannia`).
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Петро Могила." Dates, offices, works and the canonisation downgrade cross-checked against IEU and Шевченківська енциклопедія. Accessed 2026-06-04.
+
+**Tier 4 (modern scholarly — referenced via T1/T2):**
+- Жуковський А. *Петро Могила й питання єдности церков.* Київ, 1997 (cited within Історія української культури).
+
+**Primary-source documents accessed (in transcription, via T2 corpus):**
+- **«Требник» Петра Могили (Київ, 1646)** — preface and marriage ordo, quoted §4 via Огієнко.
+- **«Православне сповідання віри» (1640; synod of Яссы 1642; Москва 1696)** — referenced §2/§3.
+
+**Honest gaps:** the autograph/first-print folios of the Требник and the catechism were not opened directly this pass — §4 rests on Огієнко's verbatim transcription (clearly labelled). The exact **day** of the 1633 Lviv consecration and the precise N.S. **birth day** remain source-variant (§1) and are presented as open, not resolved.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Kyiv is the centre; Moscow appears only as the later appropriating/erasing power.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — used Річ Посполита / Берестейська унія / Московський патріархат, not imperial shorthand.
+- [x] No uncritical Soviet/imperial terms — "all-Russian enlightenment" appears only named as the appropriating narrative, not endorsed.
+- [x] No "lost his life" euphemism — N/A (death was natural, 1647); the repression is posthumous appropriation, named precisely.
+- [x] Modern UA place names — Київ/Kyiv, Сучава, Львів, Крем'янець used throughout.
+- [N/A] Holodomor — out of period (17th c.); no occasion to reference it.
+- [N/A] Crimea/2014/2022 — not applicable to this figure's documented record; not forced.

--- a/docs/research/bio/severyn-nalyvaiko.md
+++ b/docs/research/bio/severyn-nalyvaiko.md
@@ -1,0 +1,173 @@
+# Северин (Семерій) Наливайко — Research Dossier
+
+**Slug:** `severyn-nalyvaiko`
+**Block:** K (early-modern Cossack leader; executed by the Commonwealth, his memory later appropriated/legend-clad)
+**Tier:** 1b
+**Issue:** #2535 (ghost-wiki dossier backfill — early-modern church/Cossack founders)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (IEU; Шевченківська енциклопедія; Грушевський; Леп'явко; Сас; Яворницький)
+- [x] Oppression mechanism is specific — the Commonwealth execution (Warsaw, 11 April 1597, beheaded + quartered) **distinguished from** the martyr-legend (Franko's debunking), plus the later Russian/Soviet appropriation
+- [x] ≥2 primary-source quotes (two verbatim passages from his letters to King Sigismund III) — attestation honestly reported (verify_quote = no match in the ukrlib corpus)
+- [x] **Fact-vs-legend guard honoured:** documented death = **beheading + quartering**, NOT the "copper bull / red-hot iron horse" legend
+- [x] Cross-track links: every "Existing" path verified against the on-disk plan listing (2026-06-04) and re-checked by `lint_bio_dossier_xref.py`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Северин Наливайко — though his **own letters are signed «Семерій»**, which historians take as his real name (other recorded variants: Селівей Павло, Семен, Шимон). [T1: IEU — Nalyvaiko, Severyn; T1: Шевченківська енциклопедія — Наливайко Семерій (Северин); T3: uk.wikipedia]
+- **Pseudonyms / aliases:** the family-legend surname **Острозький-Санґушко** (a princely-descent claim, see §6). Russified forms (forbidden in body text, listed only in §8): Северин Наливайко → Семён/Семерий Наливайко (Russified), Nalivaiko.
+- **Born:** **≈1560** (first half of the 1560s) | містечко **Гусятин** (now Тернопільська область, Україна) — some sources Острог or Кам'янець | of a **boyar-remnant** family; his father a furrier (кушнір). [T1: IEU — "circa 1560 in Husiatyn"; T4: Леп'явко; T3: uk.wikipedia]
+- **Died:** 11 April 1597 (O.S.) / **21 April 1597** (N.S.) | Варшава, Річ Посполита | **publicly beheaded, then his body quartered** (четвертований). [T1: IEU — "21 April 1597… beheaded, quartered, and put on public display"; T3: uk.wikipedia — "11 (21) квітня 1597… відрубали голову. Потім тіло четвертували"]
+- **Family / education key facts:** Elder brother **Дем'ян Наливайко** — priest of Prince Kostiantyn-Vasyl Ostrozky's house church and a teacher at the **Острозька академія** (the tie to the Ostrozky milieu); another brother a shoemaker in Ostroh; a sister, Олена. Severyn served as **сотник of Ostrozky's надвірна хоругва** (private-army company) and helped crush the Косинський rising (Пʼятка, 1593) before turning rebel. [T3: uk.wikipedia — Родина; T1: IEU]
+
+**Source note (flagged):** the **real first name** is contested — «Семерій» (his signature) vs the popular «Северин»; the **birthplace** (Гусятин / Острог / Кам'янець) and **birth year** (~1560, vs a descendant-document claim of Острог, April 1554) are genuinely uncertain (§6). The **princely "Острозький-Санґушко" parentage** is a family legend with non-matching dates — not established fact.
+
+## 2. Oppression mechanism
+
+Naliваyko is the one figure here who was **physically executed** — and **truth in every direction matters**: the executioner was the **Polish-Lithuanian Commonwealth**, not Russia. The *imperial appropriation/erasure* then came later and from the other side: Russian-Romantic and Soviet historiography captured his memory, and a lurid **martyr-legend displaced the documented facts** of his death.
+
+- **What happened (documented):** betrayed and besieged at **Солониця** (1596), handed over to the Commonwealth by mutinying Cossacks, tortured for months, and on **11 April 1597 beheaded in the centre of Warsaw before a great crowd; his body was then quartered**. [T1: IEU; T3: uk.wikipedia]
+- **When (specific):** the Солониця siege began **25–26 May 1596**; Naliваyko was handed over by **early July 1596** (IEU: "7 July 1596"); the last interrogation was **9 April 1597**; the execution **11 April 1597**. [T1: IEU; T3: uk.wikipedia]
+- **By whom:** the **Річ Посполита** (Polish Crown) — the field hetman **Станіслав Жолкевський** ran the campaign; the sentence was carried out in Warsaw. The **later** appropriation/erasure is **Russian-imperial Romanticism** (Ryleev's poem «Наливайко») and **Soviet historiography** (the УРЕ, a forbidden source, flattening him into anti-feudal "class struggle").
+- **Document / mechanism references — the fact-vs-legend guard (load-bearing):** the popular tale that Naliваyko was roasted in a **«мідяний бик»** (copper bull) or on a **red-hot iron horse with a glowing iron crown** is a **legend**, not the record. **Іван Франко** identified its source:
+
+  > Франко вважав, що це лише адаптація римо-католицьким священиком Йончинським давньої легенди про тирана **Фаларіса**, який, за переказами, карав ворогів, спалюючи їх у мідному бику.
+
+  The documented death is **beheading and quartering** (§1). [T3: uk.wikipedia — У літописах і художній літературі; Franko's attribution]
+- **Mechanism specifics:** Naliваyko led the **1594–1596 peasant-Cossack uprising** across Поділля, Волинь, Київщина and Belarus — the first mass anti-Commonwealth rising and a template for the great 17th-c. Cossack wars. His **1596 political project** (per Сас) proposed a Cossack-held borderland from the Dniester to the Dnipro guarding against Tatars, Turks **and Muscovites**, with himself as sole official hetman — a state-building vision the Commonwealth answered with the axe, and which later mythology obscured.
+- **What survived / what was erased:** the **man was killed and his project erased**; his **memory survived but distorted** — first into the martyr-legend (copper bull), then into Russian-Romantic and Soviet class-struggle frames. The honest recovery (Леп'явко, Сас) restores the **documented** Naliваyko: a borderland Cossack commander with a concrete political plan, executed by Warsaw in 1597.
+
+## 3. Major works (acts and documents)
+
+A military-political leader, not an author; his "works" are his campaigns, his **letters to the king**, and his 1596 project. [T1: IEU; T4: Леп'явко; T4: Сас]
+
+- `1594` — organised a ~2,500-strong Cossack detachment on the Bratslav frontier; anti-Tatar/Turkish campaigns into **Молдова/Волощина** (took Tiahyn/Tighina, raided Bilhorod, Kiliа). [T3: uk.wikipedia]
+- `autumn 1594` — the **Bratslav rising** against the szlachta; burned the Bratslav land-records (актові книги) — the conflict's opening. [T3: uk.wikipedia]
+- `1595` — joined the anti-Ottoman Holy-League operations (Moldavia, Hungary under Archduke Maximilian); the **Волинь/Білорусь contributions campaign** (Луцьк, Слуцьк, Бобруйськ, Могилів). [T3: uk.wikipedia]
+- `late 1595` — his **first known letter from a Ukrainian Cossack to a Commonwealth king** (to Sigismund III), explaining his actions and proposing the reform of the Cossacks. [T3: uk.wikipedia]
+- `1596` — the **політичний проект** (Сас): a Cossack autonomous borderland Dniester–Dnipro, with Naliваyko as sole hetman. [T4: Сас 1994]
+- `May–July 1596` — the **Солониця** siege and the end of the uprising. [T1: IEU]
+
+## 4. Primary-source quotes (≥2 required)
+
+Two **verbatim passages from Naliваyko's own letters to King Sigismund III** (the earliest surviving letters of a Ukrainian Cossack to a Commonwealth king). **Attestation note (honest):** `verify_quote(author="Наливайко")` returned **no match (confidence 0.0)** — his chancery letters are outside the ukrlib *belletristic* index; the quotes are cited from their documented publication ("Листи Наливайка до короля Сигізмунда III"), not claimed as ukrlib-corpus hits.
+
+**Quote 1 — the personal-grievance motive (avenging his father against Kalynovsky):**
+
+> «П. Каліновский моєму батьку без усякої причини ребра поломав, і таким чином батька мого зігнав зі світа, а я за сю велику кривду, не будучи свідомим правних способів і не маючи коштів і накладів, потрібних для процесу, як чоловік бідний, признаюсь до того — постановив був над ним помститися способом худопахольським.»
+
+A rare first-person window on motive — a poor man denied legal redress choosing "способом худопахольським" (a commoner's way) of revenge; it complicates the later "defender of Orthodoxy" halo (§6). [Primary: Naliваyko's letter to Sigismund III; via T3: uk.wikipedia]
+
+**Quote 2 — his chivalric self-image (sparing Khodkevych's children):**
+
+> «Ми як люди рицарські над невинними мститися не хочемо, це нам, людям рицарським, не годиться.»
+
+Naliваyko held captive the children of the voivode Khodkevych yet harmed none — "we, as knightly people, will not avenge ourselves on the innocent." The язык of козацьке рицарство (Cossack knighthood) in his own voice. [Primary: Naliваyko's letter; via T3: uk.wikipedia]
+
+**Contemporaries' recorded impression (corroboration, not his own voice):** a Danzig trade-resident who saw him on the way to execution: "**З вигляду гарний чоловік, сильний і стрункий, з вихованим і одвертим обличчям**"; the Polish chronicler Bielski: "**Була то особа красна, муж, яких небагато.**" [T3: uk.wikipedia]
+
+## 5. Language register
+
+- **Register:** the **chancery ruska мова** of a late-16th-c. Cossack commander — his letters mix Ukrainian, Polish administrative formulae and Cossack-knightly idiom (рицарські люди, способом худопахольським). Not literary; documentary and rhetorical.
+- **CEFR readiness for full reading:** the letters are **C1–C2** (archaic morphology, Polonisms); biographical/uprising narrative is **B1–B2**; the §2/§6 fact-vs-legend and appropriation analysis is **C1**.
+- **Lexicon notes (pre-teach):** козацький, ватажок, повстання, сотник, гетьман, надвірний (=household/private, of the хоругва), кварцяний (=the Crown's standing "quartz" army), мученик, четвертувати (=to quarter, the documented manner of his body's display) — **all 9 verified present in VESUM** (2026-06-04). The verb **четвертувати** is the precise documented term; **мідяний бик** (copper bull) is the legend's term, used only in quotation.
+- **Stylistic features:** the petition rhetoric of his royal letters (grievance → justification → proposal), and the Cossack-knightly ethos (рицарство) that later folk думи amplified into martyrdom.
+
+## 6. Contested points
+
+- **Fact vs martyr-legend (the core guard).** Documented: **beheaded and quartered**, Warsaw, 11 April 1597. Legend (from later Cossack chronicles): roasted in a **copper bull** / on a red-hot iron horse with an iron crown. **Франко** traced the legend to a Catholic priest's reuse of the **Phalaris** myth. Always lead with the documented death; present the copper bull as legend. [T3: uk.wikipedia; Franko]
+- **"Defender of Orthodoxy" — later projection.** From the **Літопис Граб'янки** onward Naliваyko wears an Orthodox-martyr halo (he did sack the Uniate Терлецький's estates, possibly at Ostrozky's prompting). But **Грушевський** cautions: "**принципіальні релігійно-національні мотиви в русі властиво ще не грали ніякої замітної ролі**." The 1594–96 rising was social-political-frontier first; the confessional reading is retrospective. [T1: Грушевський; T3: uk.wikipedia]
+- **Russian/Soviet appropriation.** Russian Romanticism (Ryleev's «Наливайко», 1825) and Soviet historiography (УРЕ — a forbidden source) recast him as an anti-feudal/class hero or a "friendship-of-peoples" precursor; both flatten the documented frontier-Cossack politician. Name these as framings, not facts. [source-tier special rule]
+- **Identity puzzles.** His **real name** (Семерій vs Северин), **birthplace** (Гусятин/Острог/Кам'янець), **birth year** (~1560 vs 1554), and the **princely "Острозький-Санґушко" descent** are all genuinely unsettled; the **Ціолковський-descent** family legend is unsourced. Do not present any as established. [T3: uk.wikipedia]
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the on-disk plan directory listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — the BIO plan this dossier backfills (#2535 ghost-wiki gap).
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — his patron, whose private army he led and whose brother-circle (Дем'ян) tied him to Ostroh.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — the great Cossack revolution his 1594–96 rising prefigured.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — the next-generation hetman who institutionalised what Naliваyko's rising opened.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — the earlier Cossack origin-figure (the Sich) in the same arc.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — Shevchenko mythologised "Кравчина"/Наливайко in «Тарасова ніч».
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — Franko, who debunked the copper-bull legend (§2/§6).
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — the 16th-c. Cossack risings; his is the central case.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml` — the origins of the Cossacks his rising politicised.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml` — the Sich whose низовці he allied with (Лобода, Шаула).
+  - `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — the Cossack host he co-led.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — the Commonwealth that executed him.
+  - `curriculum/l2-uk-en/plans/hist/krymske-khanstvo.yaml` — the Tatar threat his early campaigns answered.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Cossack-Baroque literary memory (chronicles, думи) that built his image.
+  - `curriculum/l2-uk-en/plans/lit/kostenko-marusia-churai-1.yaml` — Костенко invokes Наливайко in «Маруся Чурай».
+  - `curriculum/l2-uk-en/plans/lit/haidamaky.yaml` — the later Cossack-rebellion literary theme his memory feeds.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST unit on the **Солониця 1596** siege as the rising's end and the betrayal motif.
+  - A LIT module contrasting the **documented execution** with the **думи / Ryleev** legend (a fact-vs-myth literacy lesson).
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A primary-text module on **Naliваyko's letters to Sigismund III** as the earliest Cossack royal correspondence (§4).
+
+## 8. Naming-canonical
+
+- **Slug:** `severyn-nalyvaiko`
+- **EN canonical (BGN/PCGN-style):** Severyn Nalyvaiko
+- **UA canonical:** Северин (Семерій) Наливайко
+- **Aliases to track (`aliases:` YAML field):** Семерій Наливайко (his signed name); Селівей Павло; "Кравчина" (Shevchenko's name for him); the legendary "Острозький-Санґушко."
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Семён Наливайко / Nalivaiko (Russified); any framing of him primarily as an anti-feudal "class hero" or a "friendship-of-peoples" precursor; and the **"copper bull" execution legend stated as fact**.
+
+## 9. Image candidates
+
+- **Best PD portrait:** there is **no contemporary likeness**; the standard images are later artistic reconstructions (19th–20th c.) — use a PD reconstruction from Wikimedia Commons category **"Severyn Nalyvaiko"** and **label it a reconstruction**, not a portrait. [Commons category: `Severyn Nalyvaiko`]
+- **Backup candidates:**
+  - The **NBU silver coin «Северин Наливайко»** (series «Герої козацької доби», 20 ₴) and the 2011 Укрпошта stamp (Лобода + Наливайко) — era/commemorative images (check rights).
+  - The **пам'ятник у Гусятині** (his presumed birthplace) — modern, freely-licensed photo.
+- **Context image:** a map of the **1594–96 uprising** or the Солониця siege — strong §2/§3 illustration.
+- **If no rights-clear image clears review:** fall back to the NBU coin or the uprising map; **do not** use a copper-bull illustration except explicitly captioned as the *legend* (§6).
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine.* "Nalyvaiko, Severyn." encyclopediaofukraine.com. Accessed 2026-06-04.
+- *Шевченківська енциклопедія*, т. 4. "Наливайко Семерій (Северин)." Київ: Ін-т літератури ім. Т. Г. Шевченка НАН України, 2013. С. 429.
+- Грушевський М. *Історія України-Руси* — on the not-yet-confessional character of the 1594–96 rising.
+
+**Tier 2 / Tier 4 (institutional / modern scholarly):**
+- Леп'явко С. "Северин Наливайко." *Володарі гетьманської булави: Історичні портрети.* Київ: Варта, 1994. С. 53–85; and "Семерій Наливайко," in *Історія України в особах: Литовсько-Польська доба*, Київ, 1997.
+- Сас П. М. "Політичний проект Северина Наливайка 1596 р." Київ; Черкаси, 1994.
+- Антонович М. *Студії з часів Наливайка.* Прага, 1941.
+- Яворницький Д. *Історія запорізьких козаків*, т. 2. Київ: Наук. думка, 1990.
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Северин Наливайко." Dates, the Солониця siege, the execution, the Franko legend-attribution, and the family ties cross-checked against IEU, the Шевченківська енциклопедія and Леп'явко. Accessed 2026-06-04.
+
+**Polish reference (cross-check, labelled):**
+- Majewski W. "Nalewajko (Nalywajko) Semen (Seweryn?)." *Polski Słownik Biograficzny*, т. XXII/3. 1977. С. 489–492.
+
+**Primary-source documents accessed (in transcription, via T3):**
+- **Naliваyko's letters to King Sigismund III** — quoted §4 ("Листи Наливайка до короля Сигізмунда III").
+
+**Honest gaps:** `verify_quote` returned **no match** for Наливайко (his letters are outside the ukrlib belletristic index) — reported honestly in §4. His **real name, birthplace, birth year and parentage** are genuinely unsettled (§6) and presented as open. No contemporary **portrait** exists (§9).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — the rising is told on Ukrainian/Cossack terms; Russian/Soviet readings appear only as later framings.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Річ Посполита / козацьке повстання / Запорожжя used precisely; "class struggle" / "friendship of peoples" named only as the Soviet frame.
+- [x] No uncritical Soviet terms — the УРЕ class-reductive reading is named as forbidden-source distortion, not endorsed.
+- [x] No "lost his life" euphemism — the documented **execution** (beheading + quartering, 11 April 1597) is named precisely; the copper-bull tale is labelled legend.
+- [x] Modern UA place names — Гусятин, Острог, Солониця (Лубни), Варшава used throughout.
+- [x] Truth in every direction — the **executioner was the Commonwealth, not Russia**; the **Russian/Soviet appropriation of his memory** is named separately and honestly.
+- [N/A] Holodomor — out of period (16th c.).
+- [N/A] Crimea/2014/2022 — not applicable to this figure's record; not forced.

--- a/docs/research/bio/sylvestr-kosiv.md
+++ b/docs/research/bio/sylvestr-kosiv.md
@@ -1,0 +1,175 @@
+# Сильвестр (Стефан Адамович) Косів — Research Dossier
+
+**Slug:** `sylvestr-kosiv`
+**Block:** K (early-modern church-resister to the 1654 Moscow subordination; the "forgotten metropolitan")
+**Tier:** 1b
+**Issue:** #2535 (ghost-wiki dossier backfill — early-modern church/Cossack founders)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕУ-НТШ; ЕІУ/Хижняк; Дорошенко; Когут; Грушевський; ЕУ; Дзюба-Павленко)
+- [x] Oppression mechanism is specific — the 1654 forced oath, the 1685/86 canonical capture, and the "reunification"-myth erasure that made him "the forgotten metropolitan"
+- [x] ≥2 primary-source quotes (Kosiv's recorded 1654 refusals + Buturlin's 16 Jan 1654 address as the documentary anchor)
+- [x] **Citation guard honoured:** the Muscovite envoy in Kyiv, January 1654, was **Василь (Васильович) Бутурлін**, NOT "Андрій Бутурлін"
+- [x] Cross-track links: every "Existing" path verified against the on-disk plan listing (2026-06-04) and re-checked by `lint_bio_dossier_xref.py`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Сильвестр Косів; secular name Стефан Адамович Косів (also Косов, Коссов; monastic name **Сильвестр**). [T1: ЕІУ — Косов (Косів) Стефан-Адам (Хижняк З.); T1: ЕУ-НТШ, Словникова частина; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** none. Russified/Polonised forms (forbidden in body text, listed only in §8): Сильвестр Коссов (Russified Косов), Sylwester Kossów (Polish).
+- **Born:** **≈1600** | шляхетський маєток Жировиці, Вітебське воєводство, Велике князівство Литовське (now Жыровічы / Žyrovichy, Belarus) | of руський (Ruthenian) Orthodox gentry. [T3: uk.wikipedia; T1: ЕІУ/Хижняк]
+- **Died:** 13 April 1657 (O.S.) / **23 April 1657** (N.S.) | Київ, Гетьманщина | as metropolitan. [T3: uk.wikipedia — "13 (23) квітня 1657"]
+- **Family / education key facts:** Educated at Вільно, Люблін and Замостя; taught at the **Львівська братська школа**; from **1631** a teacher and **prefect of the Києво-Могилянський колегіум**, a core member of the **Могилянський гурток** and co-architect of Mohyla's reforms; from **1635** bishop of Mstislav, Orsha and Mahiliou. Pupil and close associate of **Петро Могила**. [T3: uk.wikipedia; T1: Грушевський, *Історія української літератури*, т. 7]
+
+**Source note (flagged):** the **birth year (~1600)** is approximate across all sources (ЕУ-НТШ records "р. н. невід."); the **surname** appears as Косів / Косов / Коссов — modern Ukrainian normalises to **Косів** (the Russified **Коссов** is to be avoided in body text).
+
+## 2. Oppression mechanism
+
+Kosiv is the early-modern figure on whom the **Russian appropriation/erasure mechanism is sharpest**: as the serving head of the Ukrainian Orthodox Church in 1654, he **opposed** the Pereiaslav subordination to Muscovy and **refused the oath to the tsar** — and was therefore written out of the Soviet/Russian "возз'єднання" (reunification) myth, surviving in modern memory literally as **«забутий митрополит»** (the forgotten metropolitan).
+
+- **What happened:** Moscow (a) **coerced** Kosiv's oath via troops; (b) over 1654–1685 progressively captured the Kyiv metropolitanate canonically; (c) the imperial/Soviet **Pereiaslav-as-joyful-reunification narrative erased** the documented opposition of the Ukrainian Church's own head.
+- **When (specific):** the Muscovite embassy under boyar **Василь Бутурлін** reached Kyiv on **16 January 1654**; Kosiv and his bishops, citing their bond to the Patriarch of Constantinople, **refused to swear**; Moscow then forced the oath "за допомогою стрільців, що прибули до Києва." The full canonical capture came in **1685/1686** (after his death), when Moscow obtained the Constantinople patriarch's pressured consent to transfer the Ukrainian Church to the Moscow Patriarchate. [T3: uk.wikipedia; T1: ЕУ — "1654 р. митр. Сильвестр Косів і частина духівництва відмовилися скласти присягу Москві… Лише 1685 р. Москва здобула згоду царгородського патріярха…"; T1: Дорошенко]
+- **By whom:** the **Московське царство** (tsar Алексій Михайлович; envoy boyar Василь Бутурлін; later Patriarch Йоаким) contemporaneously, and **Soviet/Russian historiography** posthumously (the "reunification" myth).
+- **Document references (quoted, not paraphrased):** the primary record of the appropriation moment is Buturlin's address in Kyiv, **16 January 1654**, already deploying the tsar's new title over "**Малыя Россія**," preserved by Грушевський:
+
+  > «Божіею милостію великій государь, царь и в. князь Алексій Михайлович всеа Русіи самодержецъ … васъ, преосвященнаго Селивестра, митрополита кіевского, галицкого и **всеа Малыя Россія** … велілъ спросить о вашемъ о спасенном пребываніи…»
+
+  Грушевський then records Kosiv's quiet counter-move: he kept titling the tsar by the **old** style **"самодержця всея Руси"** — "**і тим чином засвідчує свою непричетність до проголошення його 'государем всея Великія і Малыя Руси', що сталось перед тим в Переяславі**." [T1: Грушевський, *Вибрані статті*, corpus `wave7-hrushevsky-vybrani-statti`]
+
+- **Mechanism specifics:** Kosiv went further than titulature — he refused to send his Kyiv clergy, gentry and servants to swear, calling them "free people"; he protested to the Sejm against the agreement with the tsar and even appealed to the Polish king Jan Kazimierz to free Kyiv "from the Moscow people." Дорошенко frames the whole arc: the Ukrainian Church's Constantinople dependence "**після унії з Москвою 1654 р. служила для неї заборолом проти московських зазіхань**," and Kosiv "**дуже нерадо погодився на присягу московському цареві**." [T1: Дорошенко, *Нарис історії України*, т. 2, corpus `wave13-doroshenko-narys-istoriyi-ukrayiny-t2`]
+- **What survived / what was erased:** the Church limped on in resistance (his successors Діонісій Балабан, Йосиф Нелюбович-Тукальський were openly anti-Moscow) until the 1686 capture; but **Kosiv himself was erased from the official Pereiaslav story**, because a metropolitan who refused the oath contradicts the reunification myth. The recovery of his memory — Горовий's 2014 «Забутий митрополит Сильвестр Косов», the «Останній екзарх» journalism — is itself the counter-decolonisation.
+
+## 3. Major works
+
+A theologian, educator and polemicist of the Mohyla circle; the major works are **1635**, in Polish. [T3: uk.wikipedia; T1: Дзюба-Павленко, *Літопис культури*; T1: Грушевський]
+
+- `1635` — **«Patericon»** (Київ, Polish) — a humanist reworking of the **Києво-Печерський патерик**, polemicising with Catholics and Protestants to defend the sanctity of the Cave ascetics; "користувався великою популярністю," later used by Димитрій Туптало for his **Четьї-Мінеї**. [T1: Дзюба-Павленко, corpus `wave7-dzyuba-pavlenko-litopys-kultury`]
+- `1635` — **«Exegesis»** (Київ) — a defence of the Orthodox (Mohyla) schools, written exactly when the Catholic/Polish side attacked the Kyiv and Vinnytsia colleges and the 1635 Sejm capped their teaching "не вище діалектики і логіки." [T1: Грушевський, т. 7; T3: uk.wikipedia]
+- `1637` — **«Дидаскалія»** (a teaching on the seven sacraments), much reprinted. [T3: uk.wikipedia]
+- `1647` — elected **Митрополит Київський, Галицький і всієї Русі, екзарх Вселенського (Царгородського) патріарха** (1647–1657). [T1: Когут; T3: uk.wikipedia]
+- `грудень 1648` — solemnly greeted **Богдан Хмельницький** on his triumphal entry into Kyiv. [T3: uk.wikipedia]
+- `1652` — **«О хиротоніи»** (on ordination). [T3: uk.wikipedia]
+
+**Note on the Mohyla circle:** Grushevsky lists Kosiv among the «могилянського атенею» graduates alongside Інокентій Ґізель, Лазар Баранович and the «пiонери української культури на московськім ґрунті» Епіфаній Славинецький and Арсеній Сатановський — the very scholars Moscow later drew north (1649) to build its own learning (the appropriation in §2, seen from the supply side). [T1: Грушевський, т. 7, corpus `wave4-hrushevsky-iur-t7-10`]
+
+## 4. Primary-source quotes (≥2 required)
+
+Kosiv's load-bearing "voice" is his **recorded acts and speech of January 1654**, the moment that defines him. **Attestation note (honest):** `verify_quote` is **not applicable** — Kosiv is a 17th-c. church figure outside the ukrlib *belletristic* author index; the quotes below are cited from their documented critical editions (Грушевський; the historical record), not claimed as ukrlib-corpus hits.
+
+**Quote 1 — recorded refusal to coerce his people into the oath (Kyiv, January 1654):**
+
+> «…вони люди вільні, і він не буде їх примушувати присягати цареві.»
+
+Kosiv declined to march his Kyiv clergy, gentry and servants to swear to the tsar, calling them **free people** — a precise act of refusal at the founding moment of the Muscovite claim. [Primary: recorded in the 1654 record; via T1: Грушевський / Дорошенко tradition; T5: Radio Svoboda — "Митрополит Сильвестр Косів — противник Переяславської Ради," corroborated by T1]
+
+**Quote 2 — recorded titular non-recognition of the tsar's new "Великої і Малої Русі" claim:**
+
+> Kosiv addressed Aleksei Mikhailovich only by the **old** style — **«самодержця всея Руси»** — pointedly *not* the new Pereiaslav title "государ всея Великія і Малыя Руси," "**і тим чином засвідчує свою непричетність до проголошення його**" of that title.
+
+A subtle, fully documented act of constitutional resistance through titulature — exactly the kind of evidence the reunification myth had to erase. [Primary: Kosiv's 1654 addresses, recorded and analysed in T1: Грушевський, *Вибрані статті*]
+
+**Authored-work note:** his **«Patericon» (1635)** is his enduring authored monument; its argument (defending the Cave saints against Catholic/Protestant polemic) is documented by Дзюба-Павленко (§3), though no verbatim line was retrieved this pass — flagged in §10.
+
+## 5. Language register
+
+- **Register:** learned Baroque — **Polish** for the great works (Patericon, Exegesis), Church Slavonic for liturgy, and the chancery **ruska мова** of his metropolitan addresses; Latin/Greek for scholarship. The 1654 record preserves the period chancery-Slavonic of the tsar's titulature (государь, самодержецъ, престол).
+- **CEFR readiness for full reading:** the primary texts (Polish/Church-Slavonic) are **C2**; biographical prose is **B1–B2**; the §2/§6 Pereiaslav-erasure debate is **C1**.
+- **Lexicon notes (pre-teach):** митрополит, екзарх, митрополія, префект, присяга, самодержець, **самостійник** (=independence-defender — his modern epithet "митрополит-самостійник") — **verified present in VESUM** (2026-06-04). The work-titles **«Патерикон», «Дидаскалія»** and the term **хиротонія/хіротонія** are church-Greek borrowings used as titles, not modern lemmas (VESUM returns no entry — handle as proper titles, not vocabulary).
+- **Stylistic features:** humanist hagiographic apologetics (the Patericon), school-defence polemic (Exegesis), and the diplomatic precision of his 1654 titulature — a rhetoric of *what you refuse to say*.
+
+## 6. Contested points
+
+- **The Pereiaslav erasure (the core distortion).** Soviet and Russian historiography canonised **Переяславська рада 1654** as a joyful "возз'єднання"; the documented fact that the **head of the Ukrainian Church refused the oath** and resisted Moscow's claim is the inconvenient datum that myth erased. Modern Ukrainian scholarship and journalism restore Kosiv precisely as the **противник Переяславської Ради** / митрополит-самостійник. [T1: ЕУ; T5: Radio Svoboda; T4: Горовий 2014]
+- **How far did his resistance go?** Sources agree he refused the oath, protested to the Sejm, and appealed to the Polish king; the *depth* of his pro-Commonwealth lean is debated — uk.wikipedia stresses he was "**також проти беззастережної угоди з Річчю Посполитою**," i.e. a defender of Church **independence**, not a simple Polish partisan. Present the autonomy stance as primary, the Polish appeal as a tactical move.
+- **The "forgotten" framing.** Calling him "the forgotten metropolitan" is itself a 21st-c. recovery move; useful, but note that he was *forgotten by the imperial narrative*, not by all scholarship (Грушевський, Дорошenko, the ЕУ all kept him).
+- **What gets simplified in popular memory:** Kosiv is often collapsed into "Mohyla's successor," eliding that he was a **major author** (the Patericon) in his own right and the church-statesman of the Хмельниччина.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the on-disk plan directory listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/sylvestr-kosiv.yaml` — the BIO plan this dossier backfills (#2535 ghost-wiki gap).
+  - `curriculum/l2-uk-en/plans/bio/petro-mohyla.yaml` — his teacher and the founder of the Collegium he prefected.
+  - `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml` — the earlier metropolitan whom Kosiv chronicled as a pupil.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — the hetman he greeted in 1648 and whose Pereiaslav choice he resisted in 1654.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — Khmelnytsky's successor whose Hadiach turn (1658) shared Kosiv's anti-Moscow concern.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — the 1654 agreement he opposed; the tightest link.
+  - `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml` — the 17th-c. Church-autonomy struggle he embodied.
+  - `curriculum/l2-uk-en/plans/hist/tomos.yaml` — the autocephaly arc whose 1686 negation his resistance prefigures.
+  - `curriculum/l2-uk-en/plans/hist/khmelnychchyna-prychyny.yaml` — the Khmelnytsky era his metropolitanate spanned.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — the Cossack state within which he was a church-statesman.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — the Kyiv-Mohylian Baroque letters his Patericon belongs to.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST unit on the **1686 Moscow annexation of the Kyiv Metropolitanate** as the completion of what Kosiv resisted (relates to `tomos`).
+  - A BIO arc Могила → Косів → Балабан → Тукальський as the "metropolitans of resistance."
+- **Potential LIT additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A primary-text module on the **«Patericon» (1635)** as Baroque hagiographic apologetics (§3).
+
+## 8. Naming-canonical
+
+- **Slug:** `sylvestr-kosiv`
+- **EN canonical (BGN/PCGN-style):** Sylvestr Kosiv
+- **UA canonical (with patronymic):** Стефан Адамович Косів, чернече ім'я Сильвестр
+- **Aliases to track (`aliases:` YAML field):** Sylvester Kosov / Kossov (EN variants); Stefan Kosiv (secular name); "забутий митрополит" / "митрополит-самостійник" (epithets); the 1654 envoy is **Василь Бутурлін** (track to prevent the "Андрій Бутурлін" error).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Сильвестр Коссов (Russified); Sylwester Kossów (Polonised); and the **error form "Андрій Бутурлін"** for the 1654 envoy (the envoy was **Василь Васильович Бутурлін**); any framing of 1654 as a willing "возз'єднання."
+
+## 9. Image candidates
+
+- **Best PD portrait:** no secure contemporary likeness survives; a **19th-/20th-c. engraved portrait of Metropolitan Сильвестр Косів** (PD by age) — verify the individual Wikimedia Commons file page. [Commons category: `Sylvester Kosov`]
+- **Backup candidates:**
+  - A title page of the **«Patericon» (Київ, 1635)** — the cleanest rights-clear primary image.
+  - The **Софійський собор** (St Sophia, Kyiv), where he served the prayer-service on 16 January 1654 — era/context image.
+- **Context image:** a facsimile of the 1654 Buturlin embassy record or the St Sophia interior — strong §2 illustration if rights-clear.
+- **If no rights-clear portrait clears review:** fall back to the «Patericon» 1635 title page or St Sophia.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Хижняк З. І. "Косов (Косів) Стефан-Адам." Інститут історії України НАН України / ЕІУ-tradition, 2008 (cited via uk.wikipedia).
+- *Енциклопедія українознавства: Словникова частина* (НТШ; гол. ред. В. Кубійович). Париж–Нью-Йорк: Молоде життя. Кн. 2, с. 2807 — гасло "Косів Сильвестер."
+- Дорошенко Д. *Нарис історії України*, т. 2 — on the Constantinople dependence as a shield and Kosiv's reluctant oath (corpus `wave13-doroshenko-narys-istoriyi-ukrayiny-t2`).
+- Когут З. *Російський централізм і українська автономія* — on the autonomous Kyiv metropolitanate and Kosiv as Mohyla's successor (corpus `wave7-kohut-tsentralizm`).
+- Грушевський М. *Вибрані статті* (the Buturlin address + Kosiv's titulature) and *Історія української літератури*, т. 7 (the Mohyla circle) — corpus `wave7-hrushevsky-vybrani-statti`, `wave4-hrushevsky-iur-t7-10`.
+- *Енциклопедія українознавства* (Церква в козацькій державі) — on the 1654 oath-refusal and the 1685 capture (corpus `wave7-entsyklopediia-ukrainoznavstva`).
+- Дзюба О., Павленко Г. *Літопис культури* — on the «Patericon» (1635) (corpus `wave7-dzyuba-pavlenko-litopys-kultury`).
+
+**Tier 2 (institutional):**
+- *Філософський енциклопедичний словник* (Ін-т філософії ім. Г. Сковороди НАН України). Київ: Абрис, 2002 — гасло "Косів, Сильвестр."
+
+**Tier 3 (encyclopedic — navigation, cross-checked against T1):**
+- Українська Вікіпедія. "Сильвестр Косів." Dates, offices, works and the 1654 oath-refusal cross-checked against ЕІУ, ЕУ and Грушевський. Accessed 2026-06-04.
+
+**Tier 4 / Tier 5 (modern, with T1 corroboration):**
+- Горовий А. *Забутий митрополит Сильвестр Косов.* Київ: Наш час, 2014 (T4).
+- "Митрополит Сильвестр Косів — противник Переяславської Ради." *Радіо Свобода* (T5; corroborated by T1 Грушевський/ЕУ).
+- "Останній екзарх: загадка бунтівного митрополита." *Mind.ua*, 7.12.2018 (T5; corroborated).
+
+**Primary-source documents accessed (in transcription, via T1):**
+- **Buturlin's Kyiv address, 16 January 1654** — quoted §2/§4 (via Грушевський).
+- **«Patericon» (1635); «Exegesis» (1635)** — referenced §3/§4.
+
+**Honest gaps:** the **IEU** entry did not load this pass (404); ЕІУ (Хижняк) and ЕУ-НТШ are cited instead. No **verbatim line** from the Patericon/Exegesis was retrieved — §4 rests on Kosiv's **recorded acts and speech** of January 1654 (clearly labelled), which the template permits. `verify_quote` is **not applicable** (no ukrlib belletristic entry). **Birth year (~1600)** is approximate across all sources.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Kyiv is the first-throne city; Moscow appears as the coercing/annexing power of 1654–1686.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Переяславська угода / Гетьманщина / Царгородський патріарх used precisely; "возз'єднання" named only as the myth.
+- [x] No uncritical Soviet terms — "reunification" appears only as the distortion Kosiv's record refutes.
+- [x] No "lost his life" euphemism — N/A (death 1657 natural); the repression is the forced oath + canonical capture + memory-erasure, named precisely.
+- [x] Modern UA place names — Київ, Львів, Жировиці, Мстислав used; the envoy correctly named **Василь Бутурлін**.
+- [N/A] Holodomor — out of period (17th c.).
+- [N/A] Crimea/2014/2022 — not applicable to this figure's record; not forced.
+- [x] Citation guard honoured — the 1654 envoy is **Василь (Васильович) Бутурлін**, not "Андрій Бутурлін."


### PR DESCRIPTION
Backfills the missing **#2535** research dossiers for six early-modern figures that have a **live wiki/plan but no research dossier** (the ghost-wiki root cause). Each is a 10-section + self-check dossier mirroring the `mykola-leontovych` / `ivan-franko` gold exemplars, tool-backed per **#M-4** (IEU / ЕІУ / Шевченківська енциклопедія / ЕУ / Огієнко / Грушевський / Дорошенко / Когут + the literary corpus via `mcp__sources`, plus `verify_words`, `check_russian_shadow`, `verify_quote`). §2 documents the **imperial appropriation/erasure mechanism** each faced; documented fact is kept distinct from legend; truth is told in every direction.

## Per-figure one-liners
- **`petro-mohyla`** — Петро Симеонович Могила (b. **31 Dec 1596**, not 1595; metropolitan 1633; «Требник» 1646; Києво-Могилянський колегіум). §2 = posthumous Muscovite capture (1686), the Москва-1696 catechism appropriation, and the forced replacement of the Kyivan service-books (Огієнко). Two primary quotes from the 1646 Требник.
- **`meletii-smotrytskyi`** — Мелетій (Максим Герасимович) Смотрицький (b. ≈1577, son of Герасим, 1st Ostroh rector; «Граматика» 1619, Єв'є; abp of Polotsk 1620; later the Uniate church). §2 = the grammar appropriated into "Russian" linguistics. The Church-Slavonic terms **падеж/глагол** kept as historically correct (with `check_russian_shadow` evidence — not "fixed"). Тренос 1610 quotes.
- **`iov-boretskyi`** — Йов (Іван) Борецький (metropolitan 1620, consecrated by Patriarch **Феофан, Oct 1620**; «Протестація» 1621). Intervening metropolitan **Ісая Копинський (1631–1633)** before Mohyla is kept explicit. The 1624 Moscow overture told as a defensive response to Polish persecution, not Soviet "reunification."
- **`sylvestr-kosiv`** — Сильвестр (Стефан) Косів (metropolitan 1647–1657; «Патерикон» 1635). **Citation guard honoured:** the Jan 1654 Muscovite envoy was **Василь Бутурлін**, not "Андрій." §2 = his refusal of the 1654 oath, erased by the Pereiaslav "reunification" myth (Грушевський's primary record).
- **`kostiantyn-vasyl-ostrozky`** — Василь-Костянтин Острозький (**1526/27–1608**; Острозька академія 1576; Острозька Біблія 1581). Kept distinct from his father (the elder). §2 = the Ostroh Bible → Москва 1663 → Синодальна Біблія 1751 appropriation, plus son **Януш's** Catholic conversion (the dynastic loss).
- **`severyn-nalyvaiko`** — Северин (Семерій) Наливайко (повстання **1594–1596**; Солониця; executed **Warsaw, 11 April 1597**). **Fact-vs-legend guard:** documented death = beheading + quartering, NOT the "copper bull" legend (Franko's Phalaris debunking). Executioner = the Commonwealth; the Russian/Soviet appropriation of his memory named separately. Two verbatim letter-quotes.

## Gates
- `lint_bio_dossier_xref.py` → **exit 0** on all 6 and on the full sweep (§7 "Existing" paths verified against the on-disk plan listing).
- Pre-commit (gitleaks, §7 validator, trailers) passed.
- ~2590–2840 words each (above the ~1500 target, matching the gold exemplars).

No auto-merge.