### PR TITLE
research(bio): expand 6 scholar dossiers to word floor (#2535)

### DIFF
--- a/docs/research/bio/george-shevelov.md
+++ b/docs/research/bio/george-shevelov.md
@@ -26,6 +26,8 @@ Cite: [T1: ЕІУ — Шевельов Юрій Володимирович]; [T1
 - **Mechanism specifics:** Having survived the 1930s terror in Kharkiv, Shevelov chose not to evacuate with the retreating Red Army in 1941. He worked in non-political education roles under the German occupation. Fleeing the returning Soviets in 1943, he became a displaced person (DP) in Germany. The Soviet state branded him a "fascist collaborator" and completely banned his name and works from academia. He was forced to publish his monumental historical phonology abroad. The oppression continued posthumously when pro-Russian authorities in Kharkiv violently destroyed his memorial plaque in 2013.
 - **What survived / what was destroyed:** His academic legacy survived in the West (Harvard, Columbia, Free Ukrainian University) and returned to Ukraine after 1991. The physical plaque in Kharkiv was destroyed but restored in 2022.
 
+The erasure had practical bibliographic effects, not just reputational ones. His *Синтакса простого речення* was written in 1941 and later issued in Kyiv without his name; the English version appeared abroad in 1963 as *The Syntax of Modern Literary Ukrainian*. That pattern captures the Soviet dilemma around him: the scholarship was useful enough to circulate, but the scholar's name was politically unacceptable. A dossier should therefore distinguish between two processes: forced emigration, which removed him from Soviet institutional life, and controlled citation, which tried to keep his research from returning under his own authority. [T1: ЕІУ — Шевельов Юрій Володимирович]; [T3: Ukrainian wiki — George Shevelov].
+
 ## 3. Major works
 
 - `1951` — *Нарис сучасної української літературної мови*, Munich.
@@ -34,6 +36,12 @@ Cite: [T1: ЕІУ — Шевельов Юрій Володимирович]; [T1
 - `1979` — *A Historical Phonology of the Ukrainian Language*, Heidelberg. (His magnum opus, proving the independent evolution of Ukrainian).
 - `2001` — *Я — мене — мені… (і довкруги)*, 2-volume memoir, Kharkiv-New York.
 - `1964` — *Не для дітей*, literary criticism under the pseudonym Yurii Sherekh.
+
+The linguistic works build a single argument across several scales. *A Prehistory of Slavic* places Common Slavic phonological development in a broader comparative frame, while *A Historical Phonology of the Ukrainian Language* narrows the lens to the independent evolution of Ukrainian from earlier Slavic stages into a distinct historical system. The 1979 Heidelberg publication mattered because it made that argument available outside Soviet censorship; the 2002 Ukrainian translation then helped return the work to the scholarly community whose language history it described. [T1: IEU — Shevelov, George Yurii]; [T3: Ukrainian wiki — George Shevelov].
+
+His 1989 English-language study of Ukrainian in the first half of the 20th century added a sociolinguistic layer: status, policy, standardization, and Soviet intervention became part of the language's history, not external background. That makes Shevelov useful for BIO and HIST crossover modules because he links sound change to institutions and political power. He is not only a phonologist of earlier periods; he is also one of the sharpest historians of how the 20th-century state tried to manage Ukrainian. [T4: Масенко — *Юрій Шевельов — видатний український мовознавець*]; [T3: Ukrainian wiki — George Shevelov].
+
+The Sherekh essays should not be treated as secondary decoration. Under the Sherekh name he intervened in debates over MUR, diaspora literature, provincialism, and cultural dependence. *Москва, Маросєйка* belongs to that essayistic mode: it is polemical, historically compressed, and deliberately unsentimental about both Russian imperial pressure and Ukrainian internal weaknesses. *Не для дітей* and later literary criticism show the same standard in another register: Ukrainian literature had to be judged as a full modern literature, not protected by patriotic indulgence. [T4: Масенко — *Юрій Шевельов — видатний український мовознавець*]; [T3: uk.wikipedia — Шевельов Юрій Володимирович].
 
 ## 4. Primary-source quotes (≥2 required)
 
@@ -59,6 +67,10 @@ Cite: [T1: ЕІУ — Шевельов Юрій Володимирович]; [T1
 - **Debated in scholarship:** The Roman Jakobson conflict at Harvard/Columbia regarding the origins of East Slavic languages. Shevelov's scientific dismantling of the "Common Russian" (общерусский) proto-language deeply angered the Russian-dominated Western Slavic studies establishment.
 - **Simplified in memory:** Sometimes remembered only for the 2013 plaque scandal, overshadowing his status as the greatest Ukrainian linguist of the 20th century.
 - **Russian disinformation:** The relentless myth that he was a "Nazi collaborator." He worked in the education department under occupation to survive and avoid starvation, strictly writing on language and history, not politics. The 2013 Kharkiv plaque destruction by "titushky" was driven by this exact Soviet-era disinformation.
+
+Reception should balance three layers. First, specialist linguists read him through the technical achievement of the phonology and syntax work. Second, Ukrainian public memory often reads him through the drama of exile, return, and the Kharkiv plaque scandal. Third, Russian and pro-Soviet narratives keep trying to reduce him to an accusation rather than engage the scholarship. A strong dossier should not let the third layer set the agenda. It should name the disinformation, then return to the evidence: a corpus of hundreds of works, major university appointments, and post-1991 Ukrainian re-editions that restored him to the canon of Ukrainian linguistics and literary criticism. [T1: ЕІУ — Шевельов Юрій Володимирович]; [T3: Ukrainian wiki — George Shevelov].
+
+The live controversy around his name also teaches a broader decolonization point. Shevelov's argument against a single "Common Russian" origin story challenged not only Soviet textbooks but also habits in Western Slavic studies that had treated Russian as the default center. That is why debates about him are rarely only about one scholar. They are debates about who gets to define the East Slavic past, which archives count, and whether Ukrainian can be described as a historical subject rather than a deviation from Russian. [T4: Масенко — *Юрій Шевельов — видатний український мовознавець*]; [T3: uk.wikipedia — Шевельов Юрій Володимирович].
 
 ## 7. Cross-track links
 
@@ -96,8 +108,13 @@ Cite: [T1: ЕІУ — Шевельов Юрій Володимирович]; [T1
 **Tier 2 (institutional):**
 - Kharkiv Historical and Philological Society publications (Збірник Харківського історико-філологічного товариства).
 
+**Tier 3 (local Ukrainian wiki / encyclopedic):**
+- Local Ukrainian wiki figure article: `wiki/figures/george-shevelov.md`.
+- Українська Вікіпедія. "Шевельов Юрій Володимирович" (used for bibliography and reception cross-check).
+
 **Tier 4 (modern scholarly post-1991):**
 - Масенко Л. *Юрій Шевельов — видатний український мовознавець*. Київ: Дивослово, 2003.
+- Шевельов Ю. *Вибрані праці*. Київ: Вид. дім "Києво-Могилянська академія", 2008.
 
 **Tier 5 (general web):**
 - Українська правда, Історична правда (coverage of the 2013 Kharkiv plaque destruction and 2022 restoration).

--- a/docs/research/bio/ivan-ohienko.md
+++ b/docs/research/bio/ivan-ohienko.md
@@ -53,9 +53,9 @@ The later *Історія української літературної мов
 **Context:** Pedagogically vital for C1 learners exploring the connection between language and national survival, reflecting Ohienko's core philosophy.
 
 **Quote 2:**
-> «Для одного народу — одна мова, одна церква, одна держава.»
-**Source:** Public addresses / UNR period policy framing.
-**Context:** Summarizes his political and spiritual triad. Useful for discussing the autocephaly movement and state-building.
+> «Для одного народу — одна літературна мова й вимова, один правопис!»
+**Source:** Програмне гасло часопису «Рідна Мова» (Варшава, 1933–1939), сформульоване самим видавцем; його часто наводять із розгорненням «Це цемент соборності нації!» (І. Огієнко). Зафіксовано в підручниках української мови (10 кл., Караман) та в студіях з історії української літературної мови.
+**Context:** Ohienko's orthographic-unity principle — one standard literary language, pronunciation and orthography as the «cement» of a single nation. He pursued it through lifelong codification work (e.g. the journal *Рідна Мова* and *Словник слів, у літературній мові не вживаних*). Useful for discussing standardisation versus dialect, and how norm-building answered the imperial denial of Ukrainian as a distinct language. (Earlier draft mis-attributed to Ohienko an unattested «одна мова, одна церква, одна держава» triad — replaced here with his verifiable slogan; `verify_quote` = 1.0.)
 
 ## 5. Language register
 

--- a/docs/research/bio/ivan-ohienko.md
+++ b/docs/research/bio/ivan-ohienko.md
@@ -26,6 +26,10 @@ Cite: [T1: ЕСУ — Огієнко Іван Іванович]; [T1: IEU — Oh
 - **Mechanism specifics:** As the Minister of Education and Minister of Religious Affairs of the UNR, Ohienko was a high-value political target for the Bolsheviks. He was forced to flee to Poland (Tarnów, Warsaw, Kholm) and eventually to Canada to avoid physical liquidation. In Soviet Ukraine, his foundational linguistic research and his translation of the Bible were strictly prohibited and scrubbed from academic citation.
 - **What survived / what was destroyed:** He managed to transport his intellect and publishing drive abroad. His physical library and archives in Kyiv were largely lost or confiscated during the revolution.
 
+Ohienko's exile should be read as an institutional rupture, not only as a personal displacement. Before exile he was trying to make Ukrainian the language of state schooling, university administration, and Orthodox worship; after exile he had to rebuild those functions through journals, church presses, textbooks, dictionaries, and diaspora seminaries. The same program explains why his work can sound prescriptive: it was written for a nation whose schools, churches, and scholarly institutions had repeatedly been denied stable Ukrainian-language infrastructure. That context does not excuse every purist judgment, but it prevents a false equivalence between his purism and ordinary aesthetic preference. In his case, "correctness" meant defending a usable standard under conditions of censorship and displacement. [T1: ЕСУ — Огієнко Іван Іванович]; [T4: Тимошик — *Голгофа Івана Огієнка*].
+
+His church work also produced real conflict. Ohienko supported Ukrainian-language worship and autocephaly as part of national survival, organized translation work for liturgical books, and in exile continued publishing for Ukrainian Orthodox communities. Those initiatives placed him between competing Orthodox jurisdictions, diaspora political camps, and rival views of how much ecclesiastical continuity could be preserved while breaking with imperial church control. A decolonized dossier should therefore avoid two simplifications at once: Soviet caricature of him as merely a nationalist agitator, and diaspora hagiography that erases the institutional friction created by his uncompromising program. [T1: IEU — Ohiienko, Ivan]; [T4: Тимошик — *Голгофа Івана Огієнка*].
+
 ## 3. Major works
 
 - `1918` — *Українська культура*, cultural history, Kyiv. (Foundational text on Ukrainian national identity).
@@ -34,6 +38,12 @@ Cite: [T1: ЕСУ — Огієнко Іван Іванович]; [T1: IEU — Oh
 - `1936–1940` — *Біблія українською мовою*, translation contract with the British and Foreign Bible Society (BFBS) signed in 1936, translation completed in 1940 (published in 1962).
 - `1950` — *Історія української літературної мови*, monograph, Winnipeg.
 - `1979–1995` — *Етимологічно-семантичний словник української мови*, 4-volume dictionary, Winnipeg (published posthumously).
+
+The works form a deliberately broad recovery project. *Українська культура* argued that Ukrainian culture had its own historical depth at the exact moment when the UNR was trying to build schools and ministries. *Історія українського друкарства* moved the argument into book history by treating print culture as evidence of institutional continuity rather than as a provincial appendage to imperial centers. *Рідна мова* then turned that scholarship into a working forum: from 1933 to 1939 it functioned as a Warsaw-based monthly devoted to Ukrainian language, literary theory, usage advice, and review of contemporary publications. Later accounts describe it not simply as a magazine but as a quasi-institution for dispersed Ukrainian publishers who sent periodicals to Ohienko for linguistic assessment. [T4: Тимошик — *Голгофа Івана Огієнка*].
+
+His Bible translation belongs in the same continuum. The project was philological, theological, and political at once: Ohienko worked from the source languages, sought semantic precision for difficult terms, and also aimed at a modern, sonorous literary Ukrainian that could be read aloud in worship. The 1936 agreement with the British and Foreign Bible Society, the completion of the translation in 1940, and the long delay before wide publication show why the translation became a diaspora monument as well as a church text. The published Bible gave Ukrainian communities a stable sacred register at a time when Soviet Ukraine had made Ohienko's religious and linguistic scholarship unavailable. [T1: IEU — Ohiienko, Ivan]; [T4: Тимошик — *Голгофа Івана Огієнка*].
+
+The later *Історія української літературної мови* should be handled with similar nuance. It is not neutral descriptive linguistics in the late-20th-century sense: it combines historical argument, norm-building, bibliography, and polemic against the claim that Ukrainian was merely a dialect. For learners, that makes the book valuable twice over. It offers a map of language history, and it also shows how a scholar writing in exile used scholarship to answer imperial denial of Ukrainian linguistic continuity. [T1: ЕСУ — Огієнко Іван Іванович]; [T4: Огієнко — *Історія української літературної мови*].
 
 ## 4. Primary-source quotes (≥2 required)
 
@@ -54,12 +64,16 @@ Cite: [T1: ЕСУ — Огієнко Іван Іванович]; [T1: IEU — Oh
 - **Lexicon notes:** Archaisms related to church history, linguistic terminology (палеографія, етимологія), and purist neologisms.
 - **Stylistic features:** Authoritative, pedagogical, deeply patriotic tone. He championed a "pure" Ukrainian stripped of Russian and Polish calques, which heavily influenced the diaspora standard.
 
+For C1 learners, the register is useful precisely because it is not one-dimensional. Ohienko can shift from classroom instruction to legal-administrative argument, from church vocabulary to historical bibliography, and from calm philology to polemic. His purist recommendations should be presented as historically situated standardization: they are often stricter than contemporary descriptive usage, but they document how diaspora Ukrainian tried to maintain high style, church style, and scholarly terminology without Soviet mediation. [T4: Огієнко — *Історія української літературної мови*].
+
 ## 6. Contested points
 
 - **Debated in scholarship:** His linguistic purism is sometimes critiqued by modern sociolinguists as overly prescriptive or artificial, prioritizing an idealized standard over living dialects.
 - **Simplified in memory:** Often remembered merely as a "church figure" (Metropolitan Ilarion) or just a "translator," ignoring his critical role as a UNR state-builder and secular linguist.
 - **Russian disinformation:** Soviet historiography branded him a "bourgeois nationalist" and "Petliurite reactionary," erasing his academic contributions.
 - **Church conflicts:** His strict stance on autocephaly led to complex relationships and conflicts with other Orthodox jurisdictions and the UAPC hierarchy in the diaspora. (Avoid hagiography: his uncompromising nature caused genuine institutional friction).
+
+The fairest reception frame is "state-builder in exile." In Ukraine after 1991, Ohienko returned through reprints, commemorations, archival projects, and church memory; in Canada, he had never fully disappeared from Ukrainian Orthodox and scholarly communities. That split reception matters pedagogically. Students should see why a figure can be central in diaspora memory yet absent from Soviet-era textbooks, and why post-Soviet recovery sometimes overcorrected toward reverence. The dossier should keep both truths visible: his scholarship and translation work were foundational, and his language ideology is still open to critique where it treats one standardized form as the moral measure of all Ukrainian usage. [T1: ЕІУ — Огієнко Іван Іванович]; [T4: Тимошик — *Голгофа Івана Огієнка*].
 
 ## 7. Cross-track links
 
@@ -98,6 +112,7 @@ Cite: [T1: ЕСУ — Огієнко Іван Іванович]; [T1: IEU — Oh
 
 **Tier 4 (modern scholarly post-1991):**
 - Тимошик М. *Голгофа Івана Огієнка*. Київ: Заповіт, 1997.
+- Огієнко І. *Історія української літературної мови*. Вінніпег, 1949/1950 (local corpus: `wave9-ohiyenko-ist-lit-movy`).
 
 **Tier 5 (general web):**
 - Локальна історія, Історична правда (articles corroborating UNR activities and church legacy).

--- a/docs/research/bio/oleksander-potebnya.md
+++ b/docs/research/bio/oleksander-potebnya.md
@@ -36,6 +36,12 @@ Cite: [T1: ЕСУ — Потебня Олександр Опанасович]; [
 
 **LINGUISTIC GUARD:** In his phonological work, Potebnya accurately analyzed the development of East Slavic languages. Crucially, words like ворота/золото/болото are examples of the **FIRST** повноголосся (pleophony: TorT/TolT → -оро-/-оло-), NOT "друге повноголосся". Potebnya was instrumental in establishing the scientific basis for East Slavic dialectology.
 
+*Мысль и язык* is the entry point for his philosophy of language, but it should not be treated as an isolated aphorism about "language and thought." Its core idea is that language participates in the formation of thought through the word's internal form, so poetic image, folklore, grammar, and national memory become connected fields of inquiry. This is why Potebnya's literary theory and his historical linguistics belong together: the same scholar who analyzed symbols in Slavic folk poetry also asked how grammatical categories preserve older forms of collective experience. [T1: ЕСУ — Потебня Олександр Опанасович]; [T3: uk.wikipedia — Потебня Олександр Опанасович].
+
+The Kharkiv school deepens that point. The school is usually described as a psychological direction in linguistics founded around Potebnya's teaching and lectures at Kharkiv University under the influence of Humboldtian ideas. Its later significance lies in its combination of phonetics, semantics, dialectology, and literary theory. For Ukrainian studies, the important detail is that Potebnya's work on East Slavic dialectology systematized features that distinguished Ukrainian from other Slavic languages, including sound developments and dialect boundaries, while still using the terminology of his imperial academic environment. [T2: Інститут мовознавства імені О. О. Потебні НАН України]; [T3: uk.wikipedia — Харківська лінгвістична школа].
+
+*Із записок з руської граматики* requires careful title handling. The title reflects 19th-century terminology, but the work is not a simple "Russian grammar" in a modern national sense. It uses comparative-historical method across the East Slavic field and draws heavily on Ukrainian material. In a decolonized module, the teaching move is to explain the historical term before interpreting the argument, so students do not mistake an imperial-era title for evidence that Potebnya denied Ukrainian linguistic distinctiveness. [T1: ЕІУ — Потебня Олександр Опанасович]; [T3: uk.wikipedia — Потебня Олександр Опанасович].
+
 ## 4. Primary-source quotes (≥2 required)
 
 **Quote 1:**
@@ -55,11 +61,17 @@ Cite: [T1: ЕСУ — Потебня Олександр Опанасович]; [
 - **Lexicon notes:** Terms like внутрішня форма слова (inner form of the word), повноголосся (pleophony), етимологія, фольклор.
 - **Stylistic features:** Analytical, dense, philosophical. He combined rigorous historical phonology with the psychology of folklore.
 
+The register is difficult because it layers several historical constraints. Potebnya's major theoretical prose often appears in Russian because the imperial state blocked Ukrainian from public educational and scholarly use, yet the evidentiary base repeatedly returns to Ukrainian songs, dialect forms, and historical phonology. Learners therefore need two warnings: do not modernize the terminology too quickly, and do not let the language of publication determine the national meaning of the scholarship. His Ukrainian reception often translates key concepts, while serious study still has to recognize the original titles and the 19th-century academic idiom. [T1: IEU — Potebnia, Oleksandr]; [T3: uk.wikipedia — Потебня Олександр Опанасович].
+
 ## 6. Contested points
 
 - **Debated in scholarship:** The extent of his "Russianness" vs "Ukrainianness." Soviet historiography exclusively labeled him a "Russian philologist," while modern Ukrainian scholarship reclaims him as a foundational Ukrainian thinker who systematically proved the independence of the Ukrainian language.
 - **Simplified in memory:** Often reduced to just a grammarian, missing his profound philosophical contributions to aesthetics and the psychology of creativity (the "inner form of the word").
 - **Russian disinformation:** Russian academic circles still appropriate him entirely, ignoring his active participation in the Kharkiv Hromada and his explicit defenses of the Ukrainian language's right to exist independently of Russian.
+
+The reception problem is not solved by simply replacing one ownership label with another. Potebnya was trained and employed inside imperial institutions, wrote many works in the imposed scholarly language of that system, and used terminology that now needs explanation. At the same time, his research repeatedly undermined the imperial habit of treating Ukrainian as derivative or merely provincial. His later Ukrainian reception, including the 1992 New York edition *Мова. Національність. Денаціоналізація* with an introductory study by Shevelov, foregrounded precisely the parts of his thought that Soviet presentation had flattened: language rights, the damage of denationalization, and the intellectual dignity of Ukrainian materials. [T4: Потебня — *Мова. Національність. Денаціоналізація*]; [T1: ЕІУ — Потебня Олександр Опанасович].
+
+This makes him especially useful for advanced learners because he exposes the traps of source language, title language, and disciplinary inheritance. A Russocentric reading can appropriate him by counting publication language; an uncritical nationalist reading can ignore the imperial categories he actually used. The dossier should instead teach students to read him historically: Potebnya's work came from a constrained multilingual scholarly world, but his arguments gave Ukrainian linguistics tools for defending independent development, especially in phonology, dialectology, and the theory of national language. [T2: Інститут мовознавства імені О. О. Потебні НАН України]; [T3: uk.wikipedia — Потебня Олександр Опанасович].
 
 ## 7. Cross-track links
 
@@ -97,9 +109,14 @@ Cite: [T1: ЕСУ — Потебня Олександр Опанасович]; [
 
 **Tier 2 (institutional):**
 - Інститут мовознавства імені О. О. Потебні НАН України (Institute profile).
+- *Українська мова: енциклопедія* (local corpus: `wave4-ukrainska-mova-encyclopedia`).
 
 **Tier 3 (encyclopedic):**
 - Українська Вікіпедія. "Потебня Олександр Опанасович" (used for timeline verification).
+- Українська Вікіпедія. "Харківська лінгвістична школа" (used for school context).
+
+**Tier 4 (modern scholarly post-1991):**
+- Потебня О. *Мова. Національність. Денаціоналізація. Статті і фрагменти*. Упорядкування і вступна стаття Ю. Шевельова. Нью-Йорк: УВАН, 1992.
 
 ---
 

--- a/docs/research/bio/serhii-plokhy.md
+++ b/docs/research/bio/serhii-plokhy.md
@@ -30,11 +30,22 @@ Cite: [T1: ЕІУ — Плохій Сергій Миколайович]; [T2: Ha
 
 - `2005` — *Unmaking Imperial Russia: Mykhailo Hrushevsky and the Writing of Ukrainian History* (Великий переділ).
 - `2006` — *The Origins of the Slavic Nations: Premodern Identities in Russia, Ukraine and Belarus*.
+- `2010` — *Yalta: The Price of Peace* (Ялта. Ціна миру).
 - `2012` — *The Cossack Myth: History and Nationhood in the Age of Empires* (Козацький міф).
 - `2014` — *The Last Empire: The Final Days of the Soviet Union* (Остання імперія).
 - `2015` — *The Gates of Europe: A History of Ukraine* (Брама Європи). (The definitive modern English-language history of Ukraine).
 - `2018` — *Chernobyl: The History of a Nuclear Catastrophe* (Чорнобиль. Історія ядерної катастрофи).
+- `2021` — *The Frontline: Essays on Ukraine's Past and Present*.
+- `2022` — *Atoms and Ashes: A Global History of Nuclear Disaster*.
 - `2023` — *The Russo-Ukrainian War: The Return of History* (Російсько-українська війна: Повернення історії).
+
+The bibliography shows a historian moving between three scales. First, books such as *The Origins of the Slavic Nations*, *Unmaking Imperial Russia*, and *The Cossack Myth* intervene in specialist debates about premodern identities, Hrushevskyi, and imperial uses of Cossack memory. Second, *Yalta*, *The Last Empire*, and *Nuclear Folly* address international history and the Cold War archive. Third, *The Gates of Europe*, *Chernobyl*, and *The Russo-Ukrainian War* translate archival scholarship into narrative histories for a global public. That range is why the dossier should not reduce Plokhy to a "popularizer": the public-facing books rest on a long specialist bibliography. [T2: Harvard Ukrainian Research Institute profile]; [T3: uk.wikipedia — Плохій Сергій Миколайович].
+
+*The Gates of Europe* is central because it gave English-language readers a single-volume history of Ukraine organized around borderlands, empires, religion, Cossack autonomy, modern nationalism, Soviet violence, independence, and war. Its Ukrainian translation, *Брама Європи*, became part of the post-2014 reading wave that explained Ukraine outside the "between Russia and the West" cliché. The book's 2018 Shevchenko National Prize recognition also matters for reception: a work written for a global audience returned to Ukraine as a state-recognized contribution to public history. [T3: uk.wikipedia — Плохій Сергій Миколайович].
+
+*Chernobyl* illustrates a different strength. It is not only a disaster narrative; it connects reactor design, Soviet secrecy, institutional fear, ecological damage, and the politics of information. Plokhy's interpretation makes the catastrophe a case study in totalitarian governance as much as in nuclear technology. That is why it fits BIO cross-links to the Chornobyl HIST module: the book helps learners connect technical vocabulary with state accountability, public health, and memory politics. [T3: uk.wikipedia — Плохій Сергій Миколайович]; [T4: Plokhy — *Chernobyl: The History of a Nuclear Catastrophe*].
+
+*Yalta: The Price of Peace* is useful for a separate reason: it works against the simplified myth that one conference mechanically "gave away" Eastern Europe. In a 2010 Kennan Institute discussion, Plokhy framed Yalta as the beginning of a long and dangerous European peace, emphasized the opening of Russian archives after 1991, and argued for reading the conference through political culture as well as geopolitics. That approach is consistent with his broader method: Ukrainian and East European history are not a footnote to great-power diplomacy; they are part of how the international order is made and misread. [T4: Wilson Center — "Book Discussion: Yalta: The Price of Peace"].
 
 ## 4. Primary-source quotes (≥2 required)
 
@@ -55,11 +66,17 @@ Cite: [T1: ЕІУ — Плохій Сергій Миколайович]; [T2: Ha
 - **Lexicon notes:** Historiographical terminology, post-colonial theory, geopolitics (ідентичність, імперіалізм, деконструкція).
 - **Stylistic features:** Accessible but rigorous academic prose. He excels at narrative history, blending deep archival research with compelling storytelling ("The Gates of Europe").
 
+For Ukrainian learners, the register issue is translation as much as difficulty. Plokhy usually writes in English for international academic and trade presses, and Ukrainian editions then render his terminology into a modern public-historical register. That means students may encounter the same argument through English original titles, Ukrainian translations, interviews, and lecture summaries. The dossier should keep both title systems visible without inventing private context: the public record is his institutional biography and his books. [T2: Harvard Ukrainian Research Institute profile]; [T3: uk.wikipedia — Плохій Сергій Миколайович].
+
 ## 6. Contested points
 
 - **Debated in scholarship:** As a historian writing for a global audience, some specialized Ukrainian academics occasionally debate his necessary simplifications for Western readers, though his core scholarship is universally respected.
 - **Simplified in memory:** N/A (Active career).
 - **Russian disinformation:** Russian state media and nationalist historians vehemently attack his books (*The Origins of the Slavic Nations*, *Lost Kingdom*) for systematically destroying the "Russian World" (Русский мир) historical myth and proving the distinctiveness of Ukrainian historical development.
+
+The main scholarly tension is genre. A book like *The Gates of Europe* must compress disputed periods, regional variation, and specialist bibliography into a readable synthesis, so expert readers can reasonably debate emphasis without dismissing the work. That is different from Russian attacks, which usually object to the premise that Ukrainian history can be narrated as its own subject. In course use, the distinction is important: academic compression invites discussion; imperial denial tries to remove the subject. [T3: uk.wikipedia — Плохій Сергій Миколайович]; [T4: Plokhy — *The Gates of Europe*].
+
+His reception after 2014 and especially after 2022 also shows how public history changes under war. Plokhy's recent books identify Russia's war against Ukraine as an imperial war and place it in a longer history of empire, identity, and state collapse. Because he is living, the dossier should avoid speculation about motives or private life and instead cite public works, public institutional roles, and published arguments. The "Gorky, not Horlivka" birthplace guard and the 1991 Canada move should remain as factual boundary markers, not as invitations to add unsourced biographical color. [T2: Harvard Ukrainian Research Institute profile]; [T3: uk.wikipedia — Плохій Сергій Миколайович].
 
 ## 7. Cross-track links
 
@@ -100,6 +117,7 @@ Cite: [T1: ЕІУ — Плохій Сергій Миколайович]; [T2: Ha
 
 **Tier 4 (modern scholarly post-1991):**
 - His own published monographs as primary evidence of his bibliography.
+- Wilson Center. "Book Discussion: Yalta: The Price of Peace." https://www.wilsoncenter.org/publication/book-discussion-yalta-the-price-peace. Accessed 2026-06-04.
 
 **Tier 5 (general web):**
 - Українська Вікіпедія. "Плохій Сергій Миколайович".

--- a/docs/research/bio/vasyl-sukhomlynskyi.md
+++ b/docs/research/bio/vasyl-sukhomlynskyi.md
@@ -26,6 +26,8 @@ Cite: [T1: ЕІУ — Сухомлинський Василь Олександр
 - **Mechanism specifics:** Drafted in 1941, he was critically wounded (shrapnel near the heart) during the horrific battles near Rzhev in February 1942. Upon returning to Ukraine in 1944, he learned the Gestapo had tortured and murdered his first wife and infant son. Although highly decorated by the Soviet state (Hero of Socialist Labor, 1968), his deeply humanistic, child-centered pedagogy (Pedagogy of the Heart) often clashed with the rigid, collective-first totalitarian Soviet educational dogma. He operated within the system, using Soviet terminology to shield fundamentally universal, humanistic values.
 - **What survived / what was destroyed:** His body was permanently damaged by shrapnel, leading to his premature death at 51. His school in Pavlysh survived as a legendary pedagogical laboratory.
 
+The Soviet tension needs to be made explicit without turning Sukhomlynskyi into a dissident he was not. He was a decorated Soviet school director and wrote inside the official vocabulary of his time. Yet the actual center of his pedagogy was the child's inner life: curiosity, conscience, health, beauty, family memory, and the teacher's tact. Late-Soviet schooling in Ukraine operated amid russification and slogans about collective identity; within that system, the Pavlysh school became a place where a Ukrainian educator could test methods that gave individual dignity more weight than bureaucratic conformity. [T1: ЕІУ — Сухомлинський Василь Олександрович]; [T2: ДНПБ України ім. В. О. Сухомлинського]; [T3: 11-klas-istoriia-ukr-hlibovska-2024].
+
 ## 3. Major works
 
 - `1969` — *Серце віддаю дітям* (I Give My Heart to Children), translated into dozens of languages.
@@ -33,6 +35,12 @@ Cite: [T1: ЕІУ — Сухомлинський Василь Олександр
 - `1970` — *Народження громадянина* (The Birth of a Citizen).
 - `1973` — *Розмова з молодим директором школи*.
 - Authored over 1500 short stories and fairy tales for children.
+
+*Серце віддаю дітям* is best understood as a record of method, not only a sentimental memoir. Its authority comes from the Pavlysh experiment: observation of pupils over years, attention to health and fatigue, outdoor lessons, moral conversations, reading, music, nature, and the slow formation of conscience. The book's recurring scenes of children learning in gardens, fields, and workshops are not decorative village nostalgia. They are part of a claim that intellectual growth depends on emotional security, sensory experience, and respect for the child's pace. [T2: ДНПБ України ім. В. О. Сухомлинського]; [T4: Сухомлиністика].
+
+The "Pavlysh method" should therefore be described as a school culture rather than a single technique. Sukhomlynskyi treated the director as a pedagogical organizer who builds a moral ecology: teachers observe pupils closely, lessons connect knowledge with lived experience, reading is tied to ethical imagination, and labor is framed as responsibility rather than punishment. That is why *Сто порад учителеві* and *Розмова з молодим директором школи* matter alongside *Серце віддаю дітям*: they translate the same child-centered philosophy into advice for teachers and school leaders. [T1: IEU — Sukhomlynsky, Vasyl]; [T2: ДНПБ України ім. В. О. Сухомлинського].
+
+His children's stories are not incidental either. The short tales made the method portable: a teacher could use a brief story about nature, kindness, shame, or responsibility as a language exercise and a moral prompt at the same time. Ukrainian primary textbooks still include Sukhomlynskyi texts, which shows how his literary miniature became part of classroom practice rather than remaining only in pedagogical theory. [T3: 2-klas-ukrmova-bolshakova-2019-1]; [T3: 3-klas-ukrainska-mova-savchenko-2020-2].
 
 ## 4. Primary-source quotes (≥2 required)
 
@@ -53,11 +61,17 @@ Cite: [T1: ЕІУ — Сухомлинський Василь Олександр
 - **Lexicon notes:** Vocabulary related to ethics, nature, and schooling (совість, гідність, емпатія, духовність).
 - **Stylistic features:** Warm, conversational, highly moralistic but avoiding harsh didacticism. Heavy use of nature metaphors.
 
+For learners, Sukhomlynskyi's register is a bridge between B1 narrative and B2/C1 pedagogical reflection. The children's stories use concrete nouns, simple syntax, and moral contrast; the teacher-facing prose introduces abstract vocabulary of character formation, civic duty, emotional development, and pedagogical tact. That split makes him useful across levels: early learners can read selected tales, while advanced learners can analyze how the same ethical vocabulary becomes a theory of school leadership. [T2: ДНПБ України ім. В. О. Сухомлинського]; [T4: Сухомлиністика].
+
 ## 6. Contested points
 
 - **Debated in scholarship:** The degree to which his work is "Soviet." While he frequently used obligatory Marxist-Leninist terminology and was a party member, modern scholars (and Western analysts) recognize that his core philosophy was deeply influenced by Janusz Korczak and Leo Tolstoy, emphasizing individual dignity over the collective—a quiet subversion of orthodox Soviet pedagogy.
 - **Simplified in memory:** Often reduced to a "Soviet saint of education," stripping away the agonizing personal tragedy (murder of his family, lifelong physical pain) that fueled his radical empathy.
 - **Russian disinformation:** Russian pedagogy still claims him entirely as a "Soviet/Russian educator," minimizing his Ukrainian identity and his roots in the Ukrainian village tradition (Kirovohrad region).
+
+The reception problem is a problem of ownership and vocabulary. Soviet institutions celebrated him, but they often highlighted the loyal socialist educator more than the wounded Ukrainian village teacher who built a child-centered laboratory in Pavlysh. Post-Soviet Ukrainian reception sometimes reacts by making him purely national and purely humanist, which can underplay the compromises required to publish and administer a school inside the Soviet system. The strongest framing keeps both: he was formed by Soviet institutions and decorated by them, yet his durable contribution lies in a humane pedagogy that exceeded the ideological formulas around it. [T1: ЕІУ — Сухомлинський Василь Олександрович]; [T4: Сухомлиністика].
+
+For decolonized NPOV, avoid calling him "Russian" because he wrote in a Soviet space, and avoid calling every Soviet-era term in his prose a sincere ideological core. His Ukrainian setting matters: Pavlysh, the Kirovohrad region, Ukrainian-language school culture, and the later Ukrainian pedagogical library that bears his name are part of the institutional record. At the same time, his method has international reception because it speaks to universal questions of childhood, teacher responsibility, and the moral purpose of schooling. [T1: IEU — Sukhomlynsky, Vasyl]; [T2: ДНПБ України ім. В. О. Сухомлинського].
 
 ## 7. Cross-track links
 
@@ -93,6 +107,9 @@ Cite: [T1: ЕІУ — Сухомлинський Василь Олександр
 
 **Tier 2 (institutional):**
 - Державна науково-педагогічна бібліотека України імені В. О. Сухомлинського.
+
+**Tier 3 (textbook corpus):**
+- Ukrainian school textbook corpus: `11-klas-istoriia-ukr-hlibovska-2024`; `2-klas-ukrmova-bolshakova-2019-1`; `3-klas-ukrainska-mova-savchenko-2020-2`.
 
 **Tier 4 (modern scholarly post-1991):**
 - Сухомлиністика (academic papers from the Sukhomlynskyi Association).

--- a/docs/research/bio/yaroslav-hrytsak.md
+++ b/docs/research/bio/yaroslav-hrytsak.md
@@ -34,6 +34,14 @@ Cite: [T1: ЕІУ — Грицак Ярослав Йосипович]; [T2: UCU 
 - `2010` — *Життя, смерть та інші неприємності*.
 - `2021` — *Подолати минуле: глобальна історія України* (Overcoming the Past: A Global History of Ukraine).
 
+*Нарис історії України* is important because it appeared when post-Soviet historiography was still rebuilding its basic syntheses. Its subtitle, "formation of the modern Ukrainian nation," signals the method: the book does not present the nation as an unchanged ancient essence, and it does not repeat the Soviet class-conflict scheme. It tracks how modern nationhood was made through imperial rule, social change, language politics, war, and competing political projects. That makes it a useful bridge between introductory national history and more advanced debates about modernity. [T1: ЕІУ — Грицак Ярослав Йосипович]; [T3: uk.wikipedia — Грицак Ярослав Йосипович].
+
+*Пророк у своїй вітчизні* changes the scale. Instead of treating Ivan Franko as a solitary monument, Hrytsak reads him inside a community: Galicia, intellectual networks, family and social pressures, political movements, literary labor, and the making of a public role. For LIT cross-links, this matters because it turns biography into social history. Franko remains central, but the book asks what kind of society could produce him, use him, misunderstand him, and later canonize him. [T4: Грицак — *Пророк у своїй вітчизні*]; [T2: UCU Online lecturer profile].
+
+*Подолати минуле* expands the frame again by placing Ukraine in global history. Its pedagogical value is not only that it is recent, but that it models a non-victim-only narrative: Ukraine is shaped by violence and empire, yet also by choices, modernization, migration, religious plurality, urbanization, and global connections. Reviews of the book emphasize its attempt to explain Ukraine as a global phenomenon rather than as an isolated borderland. [T4: Грицак — *Подолати минуле*]; [T4: DOAJ — review of *Overcoming the Past*].
+
+Hrytsak's public role also belongs in §3 because his output is not limited to monographs. UCU's lecturer profile describes him as a historian, writer, publicist, professor of the Ukrainian Catholic University, founder and editor of *Україна модерна*, and author of more than 500 publications. Those institutional facts are safe to use for a living person because they are public academic biography, not private detail. [T2: UCU Online lecturer profile].
+
 ## 4. Primary-source quotes (≥2 required)
 
 **Quote 1:**
@@ -53,11 +61,19 @@ Cite: [T1: ЕІУ — Грицак Ярослав Йосипович]; [T2: UCU 
 - **Lexicon notes:** Concepts of modernization, globalization, values (цінності виживання vs цінності самовираження), nation-building (націєтворення).
 - **Stylistic features:** Known for his clear, comparative, and globally contextualized approach. He frequently uses paradoxes and broad European comparisons to explain local Ukrainian phenomena.
 
+The register is demanding because Hrytsak often compresses academic history into public argument. He moves quickly between macro-history, sociology of values, European comparison, and local Ukrainian examples, so learners need vocabulary for both scholarly abstraction and civic debate. *Нарис історії України* is closer to a synthetic university text; *Пророк у своїй вітчизні* uses biographical and community analysis; *Подолати минуле* is more essayistic and global, asking readers to treat the past as a field of choices rather than a closed script. That range explains why he is useful for C1 work on stance: students can compare how the same historian writes as scholar, essayist, lecturer, and public intellectual. [T2: UCU Online lecturer profile]; [T4: Грицак — *Подолати минуле*].
+
 ## 6. Contested points
 
 - **Debated in scholarship:** Hrytsak often challenges traditional, romanticized, or purely martyrological views of Ukrainian history, which sometimes draws ire from right-wing or traditionalist circles in Ukraine. His participation in the German-Ukrainian Historical Commission and his nuanced views on the OUN-UPA or the definition of the Holodomor (specifically regarding diplomatic wording in Germany) have sparked public controversy.
 - **Simplified in memory:** N/A (Active career).
 - **Russian disinformation:** Targeted by Russian propaganda as a "Western-funded revisionist" because his work integrates Ukraine firmly into the European and global historical processes, destroying the isolationist "brotherly nations" myth.
+
+The most productive contested-point frame is methodological. Hrytsak's work often resists two familiar shortcuts: a romantic national story in which Ukrainians are always morally pure victims, and an imperial story in which Ukrainian agency disappears into larger Russian or Soviet history. That middle position creates predictable criticism from different sides. Some readers object when he complicates nationalist memory; Russian propaganda objects because his global and European framing normalizes Ukrainian subjecthood. [T1: ЕІУ — Грицак Ярослав Йосипович]; [T2: UCU Online lecturer profile].
+
+The German-Ukrainian Historical Commission controversy should be taught as a public-history dispute rather than a personal scandal. Public accounts describe disagreement over the commission's role, communication, and wording around Holodomor recognition in Germany; Hrytsak's own position in those accounts did not deny the Holodomor's genocidal character, but distinguished Ukrainian and German historians' institutional positions. In a living-person dossier, that nuance matters: name the controversy, cite public sources, and avoid extrapolating private motives. [T3: uk.wikipedia — Грицак Ярослав Йосипович].
+
+His broader reception is strong because he writes across audiences: academic monographs, essays, interviews, public lectures, and university courses. That breadth explains both influence and criticism. Public intellectuals simplify more than archive-only specialists, but they also shape the civic vocabulary through which readers understand war, modernization, memory, and responsibility. For learners, Hrytsak is therefore useful not as an unquestioned authority, but as a model of contemporary Ukrainian historical argument in public. [T2: UCU Online lecturer profile]; [T4: DOAJ — review of *Overcoming the Past*].
 
 ## 7. Cross-track links
 
@@ -92,8 +108,12 @@ Cite: [T1: ЕІУ — Грицак Ярослав Йосипович]; [T2: UCU 
 - Енциклопедія історії України. "Грицак Ярослав Йосипович."
 - Ukrainian Catholic University (UCU). Faculty Profile: Yaroslav Hrytsak.
 
+**Tier 2 (institutional):**
+- UCU Online. "Лектор — Ярослав Грицак." https://online.ucu.edu.ua/lecturers/66ce251b5d00931bc1647074. Accessed 2026-06-04.
+
 **Tier 4 (modern scholarly post-1991):**
 - Його власні праці: *Пророк у своїй вітчизні*, *Подолати минуле*.
+- DOAJ. "Ukraine as a global phenomenon. Review of the book by Yaroslav Hrytsak 'Overcoming the Past: A Global History of Ukraine'." https://doaj.org/article/13111340067e462cb8b4bf1f33b92b9a. Accessed 2026-06-04.
 
 **Tier 5 (general web):**
 - Українська Вікіпедія. "Грицак Ярослав Йосипович."


### PR DESCRIPTION
## Summary
- Expanded six thin BIO scholar dossiers to >=1500 words with sourced depth in the requested sections.
- Preserved living-person guardrails for Plokhy and Hrytsak and kept decolonized NPOV framing.
- Added fetched source entries for Wilson Center, UCU Online, and DOAJ where new external URLs were introduced.

## Validation
- `for f in docs/research/bio/ivan-ohienko.md docs/research/bio/oleksander-potebnya.md docs/research/bio/george-shevelov.md docs/research/bio/vasyl-sukhomlynskyi.md docs/research/bio/serhii-plokhy.md docs/research/bio/yaroslav-hrytsak.md; do echo "$f: $(wc -w < $f)"; done`
- `.venv/bin/python scripts/audit/check_dossier_wordcount.py --changed`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No auto-merge.