### PR TITLE
fix(stress): serialize Stanza model download to fix flaky pytest CI red

### DIFF
--- a/scripts/pipeline/stress_annotator.py
+++ b/scripts/pipeline/stress_annotator.py
@@ -16,8 +16,11 @@ Issue: #981, #1019
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
 import re
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -54,13 +57,68 @@ _SKIP_PATTERNS = [
 _stressifier = None
 
 
+def _stanza_download_lock_path() -> Path:
+    """Path to the inter-process lock guarding first-time Stanza model setup.
+
+    Keyed to the shared Stanza resources directory (``STANZA_RESOURCES_DIR``
+    or ``~/stanza_resources``) so that every process that downloads into that
+    directory contends on the same lock. Falls back to the system temp dir if
+    the resources directory cannot be created.
+    """
+    base = os.environ.get("STANZA_RESOURCES_DIR") or os.path.join(
+        os.path.expanduser("~"), "stanza_resources"
+    )
+    if not base.startswith("~"):
+        try:
+            Path(base).mkdir(parents=True, exist_ok=True)
+            return Path(base) / ".uk-model-download.lock"
+        except OSError:
+            pass
+    return Path(tempfile.gettempdir()) / "stanza-uk-model-download.lock"
+
+
+@contextlib.contextmanager
+def _model_download_lock():
+    """Serialize first-time Stressifier construction across processes.
+
+    The Stressifier constructor lazily downloads the Stanza Ukrainian model
+    into a shared resources directory. When several processes start cold at
+    once — ``pytest -n auto`` workers, or concurrent V7 builds — they each
+    write the same model file simultaneously, corrupting it and tripping
+    Stanza's md5 check (``ValueError: md5 for .../uk/tokenize/iu.pt is ...,
+    expected ...``) — a flaky ``Test (pytest)`` failure on the whole
+    stress_annotator mutation class plus the ULP stress tests. Holding an
+    inter-process file lock around construction makes the download/load
+    atomic, so only the first process downloads and the rest load the
+    verified file from disk.
+    """
+    try:
+        from filelock import FileLock, Timeout
+    except ImportError:
+        # filelock is a pinned dependency, but never let its absence turn a
+        # working stress pass into a hard failure — degrade to unlocked.
+        yield
+        return
+
+    lock = FileLock(str(_stanza_download_lock_path()), timeout=900)
+    try:
+        with lock:
+            yield
+    except Timeout:
+        # Extremely unlikely (a model download takes seconds). Proceed
+        # unlocked rather than introducing a new failure mode.
+        logger.warning("stress_annotator: timed out acquiring model download lock; proceeding unlocked")
+        yield
+
+
 def _get_stressifier():
     """Lazy load the Stressifier (loads Stanza model on first call)."""
     global _stressifier
     if _stressifier is None:
         from ukrainian_word_stress import Stressifier, StressSymbol
 
-        _stressifier = Stressifier(stress_symbol=StressSymbol.CombiningAcuteAccent)
+        with _model_download_lock():
+            _stressifier = Stressifier(stress_symbol=StressSymbol.CombiningAcuteAccent)
     return _stressifier
 
 

--- a/tests/test_stress_annotation.py
+++ b/tests/test_stress_annotation.py
@@ -10,7 +10,12 @@ Validates post-processing stress annotation:
 
 from __future__ import annotations
 
+import contextlib
+import subprocess
+import sys
 import time
+import types
+from pathlib import Path
 
 from scripts.pipeline.stress_annotator import (
     STRESS_MARK,
@@ -436,3 +441,92 @@ class TestAnnotateFileSafetyCheck:
         count = annotate_file(md_file)
         assert count == 0, "Already-stressed body should be idempotent"
         assert md_file.read_text(encoding="utf-8") == content
+
+
+# ---------------------------------------------------------------------------
+# Stanza model-download concurrency guard (CI flake regression)
+#
+# The Stressifier constructor lazily downloads the Stanza UK model into a
+# shared resources dir. Under `pytest -n auto` (and concurrent V7 builds),
+# multiple processes raced to write the same file, corrupting it and tripping
+# Stanza's md5 check — failing the whole stress_annotator mutation class plus
+# the ULP stress tests. `_get_stressifier` now serializes construction with an
+# inter-process file lock. These tests pin that contract without touching the
+# network or loading the real model.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Each worker increments a shared counter via a non-atomic read-modify-write
+# inside the download lock. With the lock, the final value equals the worker
+# count; without it, the deliberate sleep window guarantees lost updates.
+_LOCK_COUNTER_SNIPPET = """\
+import os, sys, time
+sys.path.insert(0, {repo_root!r})
+os.environ["STANZA_RESOURCES_DIR"] = {resources_dir!r}
+from scripts.pipeline.stress_annotator import _model_download_lock
+counter = {counter!r}
+with _model_download_lock():
+    value = int(open(counter).read())
+    time.sleep(0.05)
+    open(counter, "w").write(str(value + 1))
+"""
+
+
+class TestModelDownloadLock:
+    """The lazy Stressifier load must be concurrency-safe across processes."""
+
+    def test_lock_path_keyed_to_stanza_resources_dir(self, tmp_path, monkeypatch):
+        from scripts.pipeline import stress_annotator as sa
+
+        monkeypatch.setenv("STANZA_RESOURCES_DIR", str(tmp_path))
+        assert sa._stanza_download_lock_path() == tmp_path / ".uk-model-download.lock"
+
+    def test_get_stressifier_constructs_inside_download_lock(self, monkeypatch):
+        """Construction must happen *inside* the lock, never before/after it."""
+        from scripts.pipeline import stress_annotator as sa
+
+        events: list[str] = []
+
+        @contextlib.contextmanager
+        def fake_lock():
+            events.append("lock-enter")
+            try:
+                yield
+            finally:
+                events.append("lock-exit")
+
+        class FakeStressifier:
+            def __init__(self, *args, **kwargs):
+                events.append("construct")
+
+        fake_module = types.SimpleNamespace(
+            Stressifier=FakeStressifier,
+            StressSymbol=types.SimpleNamespace(CombiningAcuteAccent="́"),
+        )
+        monkeypatch.setitem(sys.modules, "ukrainian_word_stress", fake_module)
+        monkeypatch.setattr(sa, "_model_download_lock", fake_lock)
+        monkeypatch.setattr(sa, "_stressifier", None)
+
+        sa._get_stressifier()
+
+        assert events == ["lock-enter", "construct", "lock-exit"]
+
+    def test_model_download_lock_serializes_across_processes(self, tmp_path):
+        """Concurrent cold starts must not interleave (the #1448-style race)."""
+        counter = tmp_path / "counter.txt"
+        counter.write_text("0", encoding="utf-8")
+
+        snippet = _LOCK_COUNTER_SNIPPET.format(
+            repo_root=str(REPO_ROOT),
+            resources_dir=str(tmp_path),
+            counter=str(counter),
+        )
+
+        worker_count = 5
+        python = REPO_ROOT / ".venv/bin/python"
+        procs = [subprocess.Popen([str(python), "-c", snippet]) for _ in range(worker_count)]
+        for proc in procs:
+            assert proc.wait(timeout=120) == 0, "lock worker subprocess failed"
+
+        # No lost updates → every worker's increment landed.
+        assert counter.read_text(encoding="utf-8") == str(worker_count)


### PR DESCRIPTION
## Problem

The full `Test (pytest)` suite on `main` was intermittently **RED**, blocking every Python PR. The failing tests:

- `tests/test_immersion_rule_ulp.py::test_ulp_fidelity_correction_reruns_stress_and_gate`
- `tests/test_immersion_rule_ulp.py::test_linear_pipeline_stress_annotation_marks_module_and_vocabulary`
- the **entire** `tests/test_post_processor_mutation_invariant.py::test_post_processor_stays_in_class[pipeline.stress_annotator.annotate_stress[*]]` parametrized class

## Root cause (not a code-logic regression — a concurrency race)

Ground truth from the actual CI logs (run `26852586859`, on commit `d6599133e7`):

```
ValueError: md5 for /home/runner/stanza_resources/uk/tokenize/iu.pt is
240005175d130c9c919e07b9e4082715, expected c4dda85fe08fae542f710445284e44ca
```

`stress_annotator._get_stressifier()` lazily constructs a `ukrainian_word_stress.Stressifier`, whose constructor builds a `stanza.Pipeline` that **downloads the Stanza Ukrainian model** into the shared `~/stanza_resources` dir on first use. CI runs `pytest -n auto`, so multiple xdist **worker processes** hit their first stress test at the same time and **race to write the same model file**, corrupting it → Stanza's md5 check raises → `annotate_stress` crashes on *every* input (even `empty_text`/`plain_ascii_prose`), which:

- crashes the whole `annotate_stress` mutation-invariant class, and
- breaks the two ULP tests that assert real stress annotation (`total_added > 0`, `passed is True`).

This is **flaky, not a clean regression**: the very next push (`2bc5bf548c`, run `26936754895`) downloaded the model cleanly and the same tests **PASSED**. There is no single "regressing commit" — the race surfaces non-deterministically depending on worker download timing. (The mutation class was parametrized into ~28 fixtures back in `8723c0b639`, which multiplied the cold-start call sites and raised the odds of the race triggering.)

## Fix

Wrap first-time `Stressifier` construction in an **inter-process `filelock`** keyed to the shared resources dir (`STANZA_RESOURCES_DIR` / `~/stanza_resources`). Only the first process downloads; the rest block, then load the verified file from disk. No concurrent writes → no corruption.

- Also protects **concurrent V7 builds**, which share the same `~/stanza_resources`.
- `filelock==3.24.3` is already pinned in `requirements-lock.txt` (what CI installs with `--no-deps`) and pulled transitively in dev — no requirements/lock change needed.
- Degrades to unlocked if `filelock` is ever absent or acquisition times out, so it can never introduce a *new* failure mode.

## Tests

New `TestModelDownloadLock` in `tests/test_stress_annotation.py`:
- lock path is keyed to `STANZA_RESOURCES_DIR`,
- construction happens **inside** the lock (ordering guard),
- a cross-process subprocess race **loses updates without the lock** (verified: counter ended at `1/5`) but **stays consistent with it** (`5/5`).

## Proof

```
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/claude/fix-ulp-stress
$ .venv/bin/ruff check scripts/pipeline/stress_annotator.py tests/test_stress_annotation.py
All checks passed!

$ .venv/bin/python -m pytest tests/test_immersion_rule_ulp.py tests/test_post_processor_mutation_invariant.py tests/test_stress_annotation.py -q
collected 102 items
tests/test_immersion_rule_ulp.py ..............                          [ 13%]
tests/test_post_processor_mutation_invariant.py ........................ [ 37%]
.............................                                            [ 65%]
tests/test_stress_annotation.py ...................................      [100%]
============================= 102 passed in 8.80s ==============================
```

Full CI-equivalent suite (`pytest -n auto` + CI ignore/deselect list) after the fix: **0 stress/ulp/post_processor failures**. The 13 remaining failures (`test_git_cleanup_router`, `test_monitor_api_telemetry`, `test_writer_prompt_render_size`) are pre-existing **local-environment-only** failures (real git subprocesses, localhost monitor service, local data) — identical set before and after this change, and green on CI (the `2bc5bf548c` push run was SUCCESS).

NOTE: shared build-pipeline infra (non-bio). **Do not auto-merge** — orchestrator/next session reconciles.
