### PR TITLE
ci(gemini): disable retiring advisory workflows

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,16 +1,10 @@
 name: '🔀 Gemini Dispatch'
 
+# Disabled during PR queue recovery (#2682): Gemini Code Assist / Gemini CLI
+# review is advisory, noisy across the backlog, and retiring. Keep this manual
+# trigger only so no PR, issue, or comment event can spend Gemini quota.
 on:
-  pull_request:
-    types:
-      - 'opened'
-  issues:
-    types:
-      - 'opened'
-      - 'reopened'
-  issue_comment:
-    types:
-      - 'created'
+  workflow_dispatch:
 
 defaults:
   run:
@@ -18,21 +12,10 @@ defaults:
 
 jobs:
   dispatch:
+    if: ${{ false }}
     # For PRs: only if not from a fork
     # For issues: only on open/reopen
     # For comments: only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
-    if: |-
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false
-      ) || (
-        github.event_name == 'issues' &&
-        contains(fromJSON('["opened", "reopened"]'), github.event.action)
-      ) || (
-        github.event.sender.type == 'User' &&
-        startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
-      )
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -25,6 +25,7 @@ defaults:
 
 jobs:
   invoke:
+    if: ${{ false }}
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -25,6 +25,7 @@ defaults:
 
 jobs:
   plan-execute:
+    if: ${{ false }}
     timeout-minutes: 30
     runs-on: 'ubuntu-latest'
     permissions:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -25,6 +25,7 @@ defaults:
 
 jobs:
   review:
+    if: ${{ false }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
     permissions:

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -1,20 +1,9 @@
 name: '📋 Gemini Scheduled Issue Triage'
 
+# Disabled during PR queue recovery (#2682): Gemini Code Assist / Gemini CLI
+# triage is advisory, noisy across the backlog, and retiring. Keep this manual
+# trigger only so schedules, PRs, and pushes cannot spend Gemini quota.
 on:
-  schedule:
-    - cron: '0 * * * *' # Runs every hour
-  pull_request:
-    branches:
-      - 'main'
-      - 'release/**/*'
-    paths:
-      - '.github/workflows/gemini-scheduled-triage.yml'
-  push:
-    branches:
-      - 'main'
-      - 'release/**/*'
-    paths:
-      - '.github/workflows/gemini-scheduled-triage.yml'
   workflow_dispatch:
 
 concurrency:
@@ -27,6 +16,7 @@ defaults:
 
 jobs:
   triage:
+    if: ${{ false }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
     permissions:
@@ -130,14 +120,10 @@ jobs:
           prompt: '/gemini-scheduled-triage'
 
   label:
+    if: ${{ false }}
     runs-on: 'ubuntu-latest'
     needs:
       - 'triage'
-    if: |-
-      needs.triage.outputs.available_labels != '' &&
-      needs.triage.outputs.available_labels != '[]' &&
-      needs.triage.outputs.triaged_issues != '' &&
-      needs.triage.outputs.triaged_issues != '[]'
     permissions:
       contents: 'read'
       issues: 'write'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -25,6 +25,7 @@ defaults:
 
 jobs:
   triage:
+    if: ${{ false }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
     outputs:
@@ -105,11 +106,10 @@ jobs:
           prompt: '/gemini-triage'
 
   label:
+    if: ${{ false }}
     runs-on: 'ubuntu-latest'
     needs:
       - 'triage'
-    if: |-
-      ${{ needs.triage.outputs.selected_labels != '' }}
     permissions:
       contents: 'read'
       issues: 'write'


### PR DESCRIPTION
## Summary

- Disables Gemini Code Assist / Gemini CLI advisory workflows during PR queue recovery (#2682).
- Removes automatic PR/issue/comment/schedule triggers from the entry workflows.
- Adds job-level hard-off guards to Gemini reusable jobs so manual or accidental calls cannot spend Gemini quota.
- Leaves CodeQL and deterministic gates untouched: CI/pytest, ruff, gitleaks, radon, content gates, schema validation, MDX parity, and zizmor remain active.

## Queue impact

This stops future Gemini Dispatch review/triage noise. Existing failed Gemini checks on old PR SHAs are not erased by this change; they remain advisory and should be ignored unless branch protection explicitly requires them.

## Validation

- YAML parse for all six `gemini-*.yml` files passed.
- `git diff --check` passed.
- Changed-file guard passed: only six `.github/workflows/gemini-*.yml` files changed; no linter config, Python version, generated status/audit/review artifacts, or `docs/*-STATUS.md` files.
- `sys.executable` scan over changed files produced no matches.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.

Controller issue: #2682