### PR TITLE
research(bio): 6 sourced dossiers — composers/Cossack-founders/orientalist (#2535)

### DIFF
--- a/docs/research/bio/ahatanhel-krymskyi.md
+++ b/docs/research/bio/ahatanhel-krymskyi.md
@@ -1,0 +1,126 @@
+# Агатангел Кримський — Research Dossier
+
+**Slug:** `ahatanhel-krymskyi`
+**Block:** G
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Codex GPT-5
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Агатангел Юхимович Кримський.
+- **Pseudonyms / aliases:** А. Хванько, Хванько Кримський, Ївхимець, Панько Рогач, Мирза-Джафар; forbidden body forms: Agafangel Krymskii, Krymsky, Крымский Агафангел Ефимович.
+- **Born:** 15 January 1871 | Володимир-Волинський, now Володимир, Волинська область | Russian Empire, Volhynian губернія. ESU gives 03(15).01.1871; EIU gives 15(03).01.1871.
+- **Died:** 25 January 1942 | Кустанай, Kazakhstan | USSR | death in prison exile after NKVD arrest; NАН biography cautions that the exact day is uncertain and likely before or by 25 January 1942.
+- **Family / education key facts:** ESU and EIU identify his father as Юхим Кримський from a Belarusian-Crimean Tatar line and his mother as Аделаїда Сидорович of Polish-Lithuanian background. He studied at the Острозька прогімназія, the 2nd Kyiv gymnasium, Колегія Павла Ґалаґана, the Lazarev Institute of Oriental Languages, and Moscow University. At age eighteen he knew eight languages; ESU says he later learned more than fifty more, while the local Ukrainian-language encyclopedia chunk says he freely used nearly sixty languages. This dossier therefore uses "майже 60" / "about sixty" and does not overstate "60+" as a verified count.
+
+The core dates are corroborated by ESU, EIU, and NАН України. His role is likewise stable: orientalist, linguist, literary historian, writer, translator, one of the founding academicians of the Ukrainian Academy of Sciences in 1918, and an institutional builder of Ukrainian Arabistics, Turkology, Iranian studies, and Ukrainian historical linguistics.
+
+## 2. Oppression mechanism
+
+- **What happened:** professional removal, surveillance, arrest, deportation, death in prison.
+- **When:** 1930 removal from academic posts after the Soviet campaign around the SVU show trial; summer 1941 arrest; death registered around 25 January 1942.
+- **By whom:** Soviet security and party-state institutions; arrest by NKVD.
+- **Document references:** The plan warning names "Справа-формуляр № 245", but this file number was not verified in the sources used here. Do not assert it in curriculum text unless an archival catalogue page or case file is retrieved.
+- **Mechanism specifics:** NАН states that after the SVU purge Kримський was dismissed from all posts and left without work for three years. In 1941, after Germany's invasion of the USSR, Soviet security organs arrested him as a Ukrainian "nationalist" intellectual and transported him to Кустанай. The local Ukrainian wiki corpus records that the case was closed in 1957 "for absence of a crime" and that rehabilitation followed in 1960; NАН and ESU both frame his death as a consequence of imprisonment rather than a normal academic death.
+- **What survived / what was destroyed:** His printed scholarship survived in multiple domains, but the human infrastructure of his school was broken. The loss was not only one scholar; it was the interruption of a Ukrainian institutional line in Oriental studies and historical linguistics.
+
+This is a classic case of Soviet academic decapitation. Kримський was not punished for a single publication. The target was a multilingual founder of Ukrainian scholarly autonomy who could connect Ukrainian studies with Arabic, Persian, Turkish, Semitic, Crimean Tatar, and Slavic fields without routing that knowledge through Russian imperial categories.
+
+## 3. Major works
+
+- `1895` — *Повістки й ескізи з українського життя*, prose collection, Коломия/Львів. Early modernist psychological prose.
+- `1898` — "Филология и погодинская гипотеза", scholarly polemic in *Киевская старина*. A direct challenge to the Pogodin-Sobolevsky theory about Kyiv and the Ukrainian language.
+- `1901` — *Пальмове гілля*, poetry and translations, Львів. One of the main Ukrainian vehicles for Oriental poetic motifs.
+- `1905` — *Андрій Лаговський*, novel, first incomplete publication; full text published in Kyiv in 1972. A landmark of Ukrainian psychological and intellectual prose.
+- `1906` — *Бейрутські оповідання*, prose published in *Нова громада*. Draws on his 1896-1898 Levant stay.
+- `1907-1908` — *Украинская грамматика*, two volumes. Important in the defense and description of Ukrainian as an independent language.
+- `1922` — *Українська мова, звідкіля вона взялася і як розвивалася*, linguistic-historical study.
+- `1924` — *Історія Туреччини* and *Хафіз та його пісні*. Mature work in Turkology and Persian literary history.
+- `1925` — *Перський театр, звідки він узявсь і як розвивавсь*. Study in Iranian cultural history.
+- `1927` — *Історія Туреччини та її письменства*. Major late synthesis.
+- `1930` — *Студії з Криму* material and related Crimean Tatar studies, as cited by ESU. Important for a decolonized understanding of Crimea before and after Russian imperial annexation.
+
+## 4. Primary-source quotes (>=2 required)
+
+Kримський's direct literary quotations in the project corpus did not verify cleanly under `mcp__sources.verify_quote` in the earlier checks, so the following are deliberately marked as page-cited, non-corpus excerpts rather than corpus-verified quotations.
+
+- "поет Лаговський, як усі поети, скидався трохи на Еолову арфу" (не в корпусі проєкту; за виданням А. Ю. Кримський, *Твори: у 5 т.*, т. 2, Київ: Наукова думка, 1972, с. 111; page cited in Людмила Скорина, 2022). Pedagogically, this short image lets learners see how Kримський makes a learned allusion serve psychological self-description.
+- "Почутлива людина на льодову висульку скидається" (не в корпусі проєкту; за виданням А. Ю. Кримський, *Твори: у 5 т.*, т. 2, 1972, с. 272; page cited in Скорина, 2022). This is useful for advanced learners because it combines everyday metaphor with reflective, modernist characterization.
+
+Do not use the attractive but unverified slogans "Я зроду-віку українофіл" or any altered Ohienko-style triad. They were not verified for this dossier. The point for writers is exactly that Kримський's voice is available, but it must be edition-locked before being quoted.
+
+## 5. Language register
+
+- **Register:** mixed high scholarly, literary modernist, Orientalist philological, and psychological prose.
+- **CEFR readiness for full reading:** C1 for prose excerpts; C2 for scholarly articles and linguistic polemics.
+- **Lexicon notes:** learners will meet Arabic, Persian, Turkish, Semitic, philological, and theological vocabulary; older spellings; and intellectual-prose sentence structures. The prose also uses intertextual multilingualism.
+- **Stylistic features:** dense learned allusion, irony, psychological introspection, and code-switching across literary traditions.
+
+Kримський is not a good early-level reading author if the goal is fluency. He is excellent for C1/C2 lessons about Ukrainian as a language of world scholarship. A short, annotated excerpt from *Андрій Лаговський* can support modernist prose work, while the linguistic polemics belong in advanced lessons about language history and imperial denial.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** the exact number of languages he actively commanded; the balance between his Orientalist scholarship and his literary modernism; the role of sexuality, illness, and self-fashioning in readings of *Андрій Лаговський*; and the archival detail of his Soviet security case.
+- **What gets simplified in popular memory:** he is often reduced to "polyglot who knew sixty languages" or "founder of Oriental studies." Both are true-ish but flatten the more important question: how he used multilingual scholarship to defend Ukrainian cultural autonomy.
+- **Where Russian imperial/Soviet framing attacks him:** the older imperial frame absorbs him into "Russian Oriental studies" because he worked and studied in Moscow and published some Russian-language scholarship. Soviet framing later recoded his Ukrainian commitments as nationalist danger. Both frames should be rejected without pretending that his institutional life was simple or purely Kyiv-based.
+- **Other-perspective considerations:** his Crimean Tatar ancestry matters, but it should not be turned into token identity. He wrote within Ukrainian scholarship and also studied Crimean Tatar history and literature. For Crimea-related lessons, his work can help learners see a Ukrainian scholarly tradition that takes Crimean Tatar culture seriously before the 1944 deportation and before the 2014 Russian occupation.
+
+The safest pedagogical framing is anti-hagiographic: Kримський was a towering scholar, but also a figure of complicated imperial education, multilingual publication, and personal modernist tensions. That complexity is not a weakness; it is why he belongs in a serious curriculum.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None verified for this dossier.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — Soviet destruction of Ukrainian cultural and scholarly elites.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/omelian-pritsak.yaml` — Ukrainian Oriental studies and historical scholarship.
+  - `curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml` — source bio plan exists on origin/main; this dossier is research support, not the lesson itself.
+  - Ukrainian language-history module on the Pogodin-Sobolevsky controversy; `zasnuvannia-uan` was checked and did not resolve as an existing HIST plan path in this worktree.
+- **Potential LIT additions surfaced by this research:**
+  - Annotated C1 excerpt from *Андрій Лаговський* focused on modernist introspection and multilingual allusion.
+
+## 8. Naming-canonical
+
+- **Slug:** `ahatanhel-krymskyi`
+- **EN canonical (BGN/PCGN 2010):** Ahatanhel Krymskyi.
+- **UA canonical (with patronymic if attested):** Агатангел Юхимович Кримський.
+- **Aliases (track these for `aliases:` YAML field):** А. Хванько; Хванько Кримський; Ївхимець; Панько Рогач; Мирза-Джафар; Ağatanğel Efim Qırımlı.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Agafangel Krymskii; Krymsky; Крымский Агафангел Ефимович; Агатангел Крымский.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait of Ahatanhel Krymskyi, public-domain/old photograph category; verify license before final image packaging.
+- **Backup candidates:** NАН України profile image; ESU article image; NBU "Україніка" collection images, subject to institutional reuse terms.
+- **Era-appropriate context image:** NBU electronic collection for Кримський's library and manuscripts; useful for scholarship-focused UI rather than a repression-focused page.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- О. Пріцак, "Кримський Агатангел Юхимович," *Енциклопедія Сучасної України*, https://esu.com.ua/article-1082, accessed 2026-06-04.
+- О. Ясь, "Кримський Агатангел Юхимович," *Енциклопедія історії України*, https://www.history.org.ua/?termin=Krimskii_A, accessed 2026-06-04.
+- *Українська мова: енциклопедія* local corpus chunk `modern_literary:1af78606_c0010`, used for the cautious "майже 60 мовами" wording.
+
+**Tier 2 (institutional):**
+- НАН України profile, "Кримський Агатангел Юхимович," https://www.old.nas.gov.ua/UA/PersonalSite/Pages/Biography.aspx?PersonID=0000006818, accessed 2026-06-04.
+- НБУ "Україніка" electronic collection, "Кримський Агатангел Юхимович," https://irbis-nbuv.gov.ua/ulib/col/col0000017523, accessed 2026-06-04.
+
+**Tier 3 (encyclopedic):**
+- Project Ukrainian wiki corpus, `ukrainian_wiki:ahatanhel-krymskyi:p1-1` and `p20-20`, used only after T1/T2 corroboration.
+
+**Tier 4 (modern scholarly post-1991):**
+- Людмила Скорина, "Параметри інтертекстуального поля роману Агатангела Кримського «Андрій Лаговський»," 2022, https://doi.org/10.28925/2412-2475.2022.20.9.
+- Соломія Павличко, *Націоналізм, сексуальність, орієнталізм: складний світ Агатангела Кримського*, Київ: Основи, 2000.
+
+**Primary-source documents accessed:**
+- A. Ю. Кримський, *Твори: у 5 т.*, т. 2, Київ: Наукова думка, 1972, cited for non-corpus literary excerpts through page-specific scholarly references.
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] No Russian-imperial transliterations in body text except labeled forbidden forms.
+- [x] Soviet accusations are described as accusations, not as neutral facts.
+- [x] The unverified "Справа-формуляр № 245" number is flagged, not asserted.
+- [x] Language count is cautious: "майже 60" / "more than fifty after age eighteen," not inflated.

--- a/docs/research/bio/borys-liatoshynskyi.md
+++ b/docs/research/bio/borys-liatoshynskyi.md
@@ -1,0 +1,130 @@
+# Борис Лятошинський — Research Dossier
+
+**Slug:** `borys-liatoshynskyi`
+**Block:** D
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Codex GPT-5
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Борис Миколайович Лятошинський.
+- **Pseudonyms / aliases:** Borys Liatoshynskyi; Borys Liatoshynsky; Boris Lyatoshinsky; forbidden body forms: Boris Lyatoshinskiy as default English, Борис Лятошинский.
+- **Born:** 22 December 1894 Old Style / 3 January 1895 New Style | Житомир | Russian Empire.
+- **Died:** 15 April 1968 | Kyiv | Ukrainian SSR, USSR.
+- **Family / education key facts:** ESU identifies him as a composer, conductor, public music figure, and pedagogue. He graduated from the law faculty of Kyiv University in 1918 and from the Kyiv Conservatory in 1919 in Reinhold Gliere's composition class. IEU corroborates the Zhytomyr birth, Kyiv death, Kyiv Conservatory training, and later teaching career.
+
+The central fact for the curriculum is that Liatoshynskyi was not merely "a Soviet Ukrainian composer." He was one of the main figures who made Ukrainian music symphonic, modernist, and technically European while living under a state that demanded ideological legibility and socialist-realist obedience.
+
+## 2. Oppression mechanism
+
+- **What happened:** ideological persecution, censorship, ban/pressure on works, public accusations of "formalism" and "bourgeois pacifism," forced revision of compositions.
+- **When:** 1930s pressure after the 1932 Soviet reorganization of artistic unions; 1948 formalism campaign after the Muradeli resolution; 1951 criticism of the Third Symphony after its first performance; later revision work around the finale.
+- **By whom:** Soviet party-state cultural bodies, Union of Soviet Composers / Union of Composers of Ukraine structures, and official press criticism aligned with Central Committee decrees.
+- **Document references:** 1948 anti-formalism campaign; 15 October 1951 chamber-symphonic section review; 18-26 October 1951 VI plenum stenogram of the Union of Soviet Composers of Ukraine, both cited in Fareniuk 2024 from ЦДАМЛМ fonds.
+- **Mechanism specifics:** ESU states that Liatoshynskyi's high civic and ethical position in the campaigns against "formalism" in 1948 and 1951 had major public significance. IEU notes harsh party criticism and official bans, including Symphony No. 2. Fareniuk's 2024 study shows that the first edition of Symphony No. 3 should be divided into versions 1.0, 1.1, and 1.2 because rehearsal advice and ideological criticism caused multiple edits before performance.
+- **What survived / what was destroyed:** The works survived, but not always in their first form. The Third Symphony's original, unpressured version remains a textological problem; Fareniuk warns that the familiar "first edition" is already version 1.2 and not the untouched 1.0.
+
+This mechanism is cultural coercion rather than prison. The state did not need to shoot Liatoshynskyi to damage his artistic freedom. It used institutions, meetings, labels, and performance access. The dossier should therefore avoid a crude dissident narrative. He held official posts and received Soviet awards, yet those facts do not cancel the pressure; they show the compromised environment in which major Ukrainian art survived.
+
+## 3. Major works
+
+- `1914` — *Юнацький квартет*, string quartet. Early evidence of chamber-music ambition.
+- `1918-1919` — Symphony No. 1, orchestral. Opening of his symphonic line.
+- `1922` — Piano Trio No. 1 and String Quartet No. 2. Part of the 1920s modernist search.
+- `1923 / 1929` — *Золотий обруч*, opera after Ivan Franko's *Захар Беркут*. ESU treats it as a milestone of Ukrainian opera.
+- `1927` — Overture on Four Ukrainian Folk Themes. A key synthesis of folk source and modern orchestration.
+- `1935-1936` — Symphony No. 2. Later criticized and restricted; important for the formalism context.
+- `1937-1938` — *Щорс*, opera. Pedagogically useful as a compromised Soviet commission rather than a free nationalist work.
+- `1942` — *Український квінтет*, chamber ensemble. The plan anchor says 1945, but ESU lists 1942; use ESU as the stronger source and flag the mismatch in downstream lesson writing.
+- `1943` — String Quartet No. 4.
+- `1951-1954` — Symphony No. 3, with the epigraph "Мир переможе війну." Central oppression-mechanism work.
+- `1953` — *Слов'янський концерт*, piano and orchestra.
+- `1955` — *Ґражина*, symphonic ballad; *Ромео і Джульєта*, suite.
+- `1963` — Symphony No. 4.
+- `1965-1966` — Symphony No. 5 "Слов'янська."
+
+## 4. Primary-source quotes (>=2 required)
+
+The project quote verifier did not match Liatoshynskyi's best-known personal sentence. Therefore the wording below is page-cited and explicitly marked as non-corpus evidence.
+
+- "Як композитор я вже мертвий і коли воскресну — не знаю" (не в корпусі проєкту; quoted in Н. Набокова, *Науковий вісник НМАУ*, вип. 114, 2016, с. 331, from one of Liatoshynskyi's letters; the article's bibliography points to *Борис Лятошинський. Епістолярна спадщина*, т. 1, 2002). Pedagogically, this is a high-impact line for explaining how cultural repression feels from inside a composer's working life.
+- "Мир переможе війну" (не в корпусі проєкту; epigraph to the first version of Symphony No. 3, discussed in Fareniuk 2024 and related scholarship on the first edition). This should be taught as a score/program epigraph, not as a casual slogan. It matters because Soviet critics treated the antiwar tragic concept as ideologically suspect.
+
+Secondary historiography also preserves Dmitро Антонович's assessment that Liatoshynskyi was "найрадикальніше модерний," but that is not Liatoshynskyi's own voice. Use it in interpretation, not in the primary-quote slot.
+
+## 5. Language register
+
+- **Register:** musical modernist, high analytical, often non-verbal; when using letters, intimate professional register.
+- **CEFR readiness for full reading:** B2 for a short biographical lesson; C1/C2 for criticism, letters, and score commentary.
+- **Lexicon notes:** симфонізм, формалізм, соціалістичний реалізм, інструментація, експресіонізм, алеаторика, додекафонія, сонористика, редакція партитури.
+- **Stylistic features:** the teaching challenge is translating musical facts into language tasks. Pair short Ukrainian prose about works with listening prompts rather than long theoretical paragraphs at B1/B2.
+
+Liatoshynskyi belongs in curriculum where learners can handle abstract cultural vocabulary and Soviet institutional terminology. A B2 lesson can cover "composer under pressure"; C1 can compare ESU, IEU, and Fareniuk's textological account of the Third Symphony.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** how to reconstruct and perform the Third Symphony's first edition; how to name versions 1.0, 1.1, and 1.2; how to balance his official Soviet positions with his resistance to aesthetic dictates; and how much emphasis to give to Gliere versus Ukrainian and European-modernist sources.
+- **What gets simplified in popular memory:** he is sometimes called simply "father of Ukrainian symphonism" or "composer persecuted for formalism." Both are useful entry points but can hide the institutional complexity: he chaired bodies, taught generations, accepted commissions, and still faced coercion.
+- **Where Russian/Soviet framing attacks them:** Soviet criticism used "formalism" and "bourgeois pacifism" to delegitimize work that did not sound ideologically triumphant. Later Russian framing often re-centers his training under Gliere or treats Ukrainian modernism as a provincial branch of Russian/Soviet music.
+- **Other-perspective considerations:** Polish and broader Slavic topics appear in his works, especially later suites and symphonic poems. This is not evidence against Ukrainian identity; it is part of his European horizon.
+
+The anti-hagiographic point is essential. Liatoshynskyi was not outside the Soviet system; he was an artist trying to preserve difficult modern music from inside a system that rewarded obedience and punished ambiguity.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None verified for this dossier.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — broader context of Soviet cultural repression.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — lineage from national music separation to modern symphonism.
+  - `curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml` — Soviet violence and Ukrainian music.
+  - `curriculum/l2-uk-en/plans/bio/maksym-berezovskyy.yaml` — Ukrainian classical-composer canon.
+  - `curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml` — source bio plan exists on origin/main.
+- **Potential LIT additions surfaced by this research:**
+  - C1 reading/listening lesson on "Мир переможе війну" and the politics of musical endings.
+
+## 8. Naming-canonical
+
+- **Slug:** `borys-liatoshynskyi`
+- **EN canonical (BGN/PCGN 2010):** Borys Liatoshynskyi.
+- **UA canonical (with patronymic if attested):** Борис Миколайович Лятошинський.
+- **Aliases (track these for `aliases:` YAML field):** Borys Liatoshynsky; Boris Lyatoshinsky; Борис Лятошинський.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Boris Lyatoshinskiy; Борис Лятошинский.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons, `Borys_Lyatoshynsky_(composer).png`, marked PD-old/expired; verify final license before packaging.
+- **Backup candidates:** Wikimedia Commons portrait `Borys_Mykolayovych_Lyatoshynsky.jpg`; IEU multimedia images if reuse terms allow.
+- **Era-appropriate context image:** Manuscript or program material for Symphony No. 3 from ЦДАМЛМ fonds would be ideal, but rights must be checked.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- "Лятошинський Борис Миколайович," *Енциклопедія Сучасної України*, https://esu.com.ua/article-60072, accessed 2026-06-04.
+- "Liatoshynsky, Borys," *Internet Encyclopedia of Ukraine*, https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesLILiatoshynskyBorys, accessed 2026-06-04.
+- *Енциклопедія українознавства* local corpus chunks `feaa5fa7_c2254` and `feaa5fa7_c2255`.
+
+**Tier 2 (institutional):**
+- ЦДАМЛМ фонд references as cited in Fareniuk 2024: Ф. 181, Ф. 661, stenograms and protocols around the Third Symphony.
+
+**Tier 3 (encyclopedic):**
+- Project Ukrainian wiki corpus, `ukrainian_wiki:borys-liatoshynskyi:p20-21`, used only with T1/T4 corroboration.
+
+**Tier 4 (modern scholarly post-1991):**
+- Гліб Фаренюк, "Перша редакція Третьої симфонії Бориса Лятошинського: шлях до прем'єри," *Українська музика*, 2(49), 2024, https://journals.lnma.lviv.ua/index.php/ukrmuzyka/article/view/804.
+- Н. Набокова, "Золоті сторінки української музики..." *Науковий вісник НМАУ*, вип. 114, 2016.
+- М. Копиця, ed., *Борис Лятошинський. Епістолярна спадщина*, т. 1, Київ: НМАУ, 2002.
+
+**Primary-source documents accessed:**
+- Liatoshynskyi letter excerpt and Symphony No. 3 epigraph through page-cited scholarly publications; not matched by project quote corpus.
+
+## Decolonization self-check
+
+- [x] No Russocentric framing of Ukrainian symphonism.
+- [x] Gliere is included as a teacher without making him the explanation for Liatoshynskyi's Ukrainian modernism.
+- [x] Soviet awards and official posts are included without erasing coercion.
+- [x] "Український квінтет" date mismatch is flagged: plan says 1945, ESU lists 1942.
+- [x] The Third Symphony is described with Fareniuk's version caution.

--- a/docs/research/bio/dmytro-bortnyanskyy.md
+++ b/docs/research/bio/dmytro-bortnyanskyy.md
@@ -1,0 +1,127 @@
+# Дмитро Бортнянський — Research Dossier
+
+**Slug:** `dmytro-bortnyanskyy`
+**Block:** B
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Codex GPT-5
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дмитро Степанович Бортнянський.
+- **Pseudonyms / aliases:** Dmytro Bortniansky; Dmytro Bortnyanskyy; Bortniansky; Бортнянський Дмитро; forbidden body forms: Dmitry Bortnyansky as default identity, Дмитрий Бортнянский.
+- **Born:** 1751 | Глухів | Hetmanate / Russian Empire borderland administration after imperial encroachment; exact day not secured in the T1 sources used.
+- **Died:** 28 September 1825 Old Style / 10 October 1825 New Style | Saint Petersburg | Russian Empire.
+- **Family / education key facts:** EIU identifies him as born in Глухів in the family of a townsman who was later a Cossack of the Ніжинський полк. He studied at the Глухівська співацька школа, entered the imperial court chapel in Saint Petersburg in 1758, studied with Baldassare Galuppi, spent 1769-1779 in Italy, and became director of the court choir in 1796.
+
+The essential verified frame is "Ukrainian classical composer formed in the Глухів musical system, absorbed into the imperial court, later claimed by Russian imperial culture." IEU explicitly says the court choir he directed was composed mostly of Ukrainians, and that his choral works combined Ukrainian choral traditions with late eighteenth-century European music.
+
+## 2. Oppression mechanism
+
+- **What happened:** imperial extraction and later cultural appropriation rather than documented personal imprisonment or execution.
+- **When:** 1758 removal into the Saint Petersburg court chapel; 1769-1779 Italian training under imperial auspices; 1796 directorship of the court choir; 1882 Moscow publication of sacred works in an edition associated with Peter Tchaikovsky; later Russian/Soviet canonization as "Russian" court music.
+- **By whom:** Russian imperial court institutions and later imperial/Soviet cultural historiography.
+- **Document references:** EIU article "Бортнянський Дмитро Степанович" and IEU "Bortniansky, Dmytro"; ESU "Бортнянськознавство" documents Ukrainian musicological recovery and the earlier neglect of church music.
+- **Mechanism specifics:** Bortnyanskyy was not "silenced" like a twentieth-century victim. His music circulated widely, but under an imperial label that blurred where the musicians, training, and melodic background came from. The court chapel functioned as a pipeline from Ukrainian musical schooling to the imperial capital. The later canon often treated service in Saint Petersburg as proof of Russian identity rather than as evidence of imperial concentration of Ukrainian talent.
+- **What survived / what was destroyed:** The sacred concertos and operas survived unevenly, but the Ukrainian context was repeatedly thinned. ESU's "Бортнянськознавство" is important because it shows how Ukrainian scholars, especially after the late nineteenth century and again after the mid-twentieth century, had to recover the Ukrainian dimension of his reception.
+
+This dossier should not invent a persecution story. The decolonizing task is more precise: name the extraction and appropriation mechanism, then restore Bortnyanskyy to the history of Ukrainian and European classicism without pretending he lived in a modern nation-state context.
+
+## 3. Major works
+
+- `1777` — *Creonte / Креонт*, Italian opera, staged in Venice according to EIU/IEU.
+- `1778` — *Alcide / Алкід*, Italian opera, Venice.
+- `1779` — *Quinto Fabio / Квінт Фабій*, Italian opera, Modena.
+- `1786` — *Le faucon / Сокіл*, French opera. A court-stage work from the post-Italy period.
+- `1786` — *La fête du seigneur / Свято сеньйора*, French opera.
+- `1787` — *Le fils rival / Син-суперник*, French opera.
+- `1790` — Concerto-Symphony in B-flat major. IEU notes it was long considered the first symphonic work composed in the Russian Empire until earlier work by Maksym Berezovskyi was identified.
+- `1790s-1820s` — 35 four-part choral concertos. Central to his sacred choral legacy.
+- `1790s-1820s` — 10 double-chorus concertos. Important for the large-scale a cappella tradition.
+- `1790s-1820s` — 14 panegyric hymns and liturgical works for three and four voices and double choruses.
+- `1882` — first major ten-volume edition of sacred choral works, edited by Tchaikovsky in Moscow; significant as publication history, not as authorship.
+
+## 4. Primary-source quotes (>=2 required)
+
+No authenticated Ukrainian authorial speech by Bortnyanskyy was found in the project quote corpus. `mcp__sources.verify_quote` returned false for the common incipit "Коль славен наш Господь в Сионе"; additionally, the text is by Mikhail Kheraskov, not by Bortnyanskyy. Therefore the excerpts below are marked as score/work incipits, not as words authored by him.
+
+- "Коль славен наш Господь в Сионе" (не в корпусі проєкту; score incipit associated with Bortnyanskyy's setting; text not by Bortnyanskyy). This can be used only to introduce how his music traveled through imperial religious and civic contexts.
+- "Не отвержи мене во время старости" (не в корпусі проєкту; traditional liturgical text set in the sacred-concerto repertory). This is useful for teaching the boundary between a composer's musical authorship and the borrowed sacred text.
+
+For interpretation, use Dmitро Антонович's and ESU/IEU's assessments of his role, but do not turn those secondary statements into "quotes from Bortnyanskyy." The responsible lesson move is to say that his primary voice is chiefly musical and score-based.
+
+## 5. Language register
+
+- **Register:** eighteenth-century sacred, court, and classical musical register; textual language often Church Slavonic, Italian, French, Latin, or German depending on genre.
+- **CEFR readiness for full reading:** B2 for a prose biography; C1/C2 for scholarly discussion of church music; language excerpts themselves are not modern conversational Ukrainian.
+- **Lexicon notes:** капела, хоровий концерт, фугато, літургія, а cappella, класицизм, мелос, придворна капела, Глухівська співацька школа.
+- **Stylistic features:** the key "style" is musical rather than lexical: choral balance, sacred concerto form, fugue finales, and Ukrainian melodic influence within European classicism.
+
+For L2 learners, Bortnyanskyy works best as a cultural-history lesson, not a reading-comprehension author. The Ukrainian prose around him can be modern and accessible; the primary materials require teacher framing.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** how to weigh his Ukrainian formation against his imperial court career; the degree and form of Ukrainian folk-melodic influence in sacred works; and how to edit, perform, and contextualize the large sacred corpus today.
+- **What gets simplified in popular memory:** he is sometimes called a "Russian Mozart" or simply an imperial court composer. Both phrasings obscure the Глухів school and Ukrainian choral tradition. The dossier should not repeat "Russian Mozart" except as an example of appropriation.
+- **Bologna/Mozart legend:** do not state that Bortnyanskyy "beat Mozart" on a Bologna academy golden board. The Bologna/Martini/Mozart anecdote belongs to the Berezovskyi legend cluster and is contested even there. The local plan warning is correct: for Bortnyanskyy, the solid T1 facts are Galuppi, Italy, operas, and court chapel.
+- **Where Russian imperial framing attacks them:** Russian imperial histories treat Saint Petersburg employment and Moscow publication as identity proof. A decolonized account treats those facts as evidence of imperial centralization.
+- **Other-perspective considerations:** His Italian and French operas are not ornamental details; they show that Ukrainian musicians were moving through European classicism even when imperial institutions controlled careers.
+
+The anti-hagiographic line is that Bortnyanskyy did benefit from imperial structures. The decolonized line is that those structures were built in part by taking Ukrainian-trained musicians and renaming their output through the court.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None verified for this dossier.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml` — Глухів, Hetmanate cultural institutions, and early modern elite culture context.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/maksym-berezovskyy.yaml` — compare Ukrainian classical composers and the Bologna legend problem.
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — later national music framing.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-bortnyanskyy.yaml` — source bio plan exists on origin/main.
+- **Potential LIT additions surfaced by this research:**
+  - C1 culture note on "musical authorship vs text authorship" using sacred-concerto incipits.
+
+## 8. Naming-canonical
+
+- **Slug:** `dmytro-bortnyanskyy`
+- **EN canonical (BGN/PCGN 2010):** Dmytro Bortnianskyi / Dmytro Bortnyanskyy. The project slug uses `bortnyanskyy`; keep it stable.
+- **UA canonical (with patronymic if attested):** Дмитро Степанович Бортнянський.
+- **Aliases (track these for `aliases:` YAML field):** Dmytro Bortniansky; Bortniansky; Дмитро Бортнянський; Дмитро Степанович Бортнянський.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Dmitry Bortnyansky; Dmitrii Bortnianskii; Дмитрий Бортнянский as default label.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portrait by M. Belsky, 1788, public-domain old artwork: `File:Бортнянский_(1788).jpg`.
+- **Backup candidates:** Wikimedia Commons signature image; IEU portrait if reuse terms allow.
+- **Era-appropriate context image:** Score PDF or title page of a public-domain Bortnyanskyy sacred work; use only after license review.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Г. Герасимова, "Бортнянський Дмитро Степанович," *Енциклопедія історії України*, https://www.history.org.ua/?termin=Bortnianskyj_D, accessed 2026-06-04.
+- "Bortniansky, Dmytro," *Internet Encyclopedia of Ukraine*, https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesBOBortnianskyDmytro, accessed 2026-06-04.
+- "Бортнянськознавство," *Енциклопедія Сучасної України*, https://esu.com.ua/article-37370, accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- Глухівська співацька школа and court chapel links as referenced by EIU/IEU.
+
+**Tier 3 (encyclopedic):**
+- Project Ukrainian wiki corpus, `ukrainian_wiki:dmytro-bortnyanskyy:p1-1`, used only with T1 corroboration.
+
+**Tier 4 (modern scholarly post-1991):**
+- В. Іванов, *Дмитро Бортнянський*, Київ, 1980, cited by ESU as a detailed monograph.
+- Н. Герасимова-Персидська and other musicological works listed in ESU "Бортнянськознавство."
+- Дмитро Антонович, *Українська культура*, local corpus chunk `2971c499_c0670`, used for interpretive context.
+
+**Primary-source documents accessed:**
+- Public-domain score/title evidence for incipits only; no verified direct authorial speech found in the project corpus.
+
+## Decolonization self-check
+
+- [x] Does not call him a Russian composer.
+- [x] Does not state the Bologna/Mozart legend as fact.
+- [x] Separates musical authorship from borrowed sacred text.
+- [x] Names imperial extraction and later appropriation without inventing a prison/execution story.
+- [x] Uses Глухів and Ukrainian choral tradition as the starting context.

--- a/docs/research/bio/dmytro-vyshnevetsky.md
+++ b/docs/research/bio/dmytro-vyshnevetsky.md
@@ -1,0 +1,139 @@
+# Дмитро Вишневецький — Research Dossier
+
+**Slug:** `dmytro-vyshnevetsky`
+**Block:** B
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Codex GPT-5
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дмитро Іванович Вишневецький.
+- **Pseudonyms / aliases:** Байда; Дмитро "Байда" Вишневецький; Dmytro Vyshnevetsky; Wiśniowiecki; forbidden body forms: Dmitry Vishnevetsky as default, Дмитрий Вишневецкий.
+- **Born:** exact date unknown; IEU says after 1516 | probably Volhynian princely milieu | Grand Duchy of Lithuania / Ruthenian princely context.
+- **Died:** 1563; IEU gives 29 October 1563 in Istanbul; EIU gives 1563. The execution took place after capture during the Moldavian campaign.
+- **Family / education key facts:** EIU identifies him as from the princely Вишневецькі family, son of Іван Михайлович Вишневецький and Анастасія Олізаровичівна, related through the Ostrozky line. In the 1540s-1550s he held the Cherkasy and Kaniv starostva and worked with Cossack forces on the steppe frontier.
+
+The dossier must separate the historical military-political figure from the folk-song hero Байда. The two are connected in reception, but they are not identical evidence streams.
+
+## 2. Oppression mechanism
+
+- **What happened:** military defeat, captivity, refusal to enter Ottoman service, execution.
+- **When:** 1563, after a Moldavian campaign with Albert Laski.
+- **By whom:** Ottoman authorities in Istanbul after transfer from Moldavian captivity.
+- **Document references:** EIU "Вишневецький Дмитро Іванович"; IEU "Vyshnevetsky, Dmytro"; chronicle tradition in Bielski/Paprocki as cited by Hrushevsky and Holobutskyi.
+- **Mechanism specifics:** EIU states that after defeat in Moldavia Вишневецький was wounded, captured, brought to Istanbul, refused to enter Turkish service, and was executed with the nobleman Piasecki. Hrushevsky records that the death quickly entered legendary forms, including the hook execution motif. This means the physical execution is historical, but many details of the hook scene are chronicle/legendary elaboration.
+- **What survived / what was destroyed:** No body of personal writings survives for curriculum use. What survived is a political-military trace in chronicles, state correspondence, historiography, and the folk-song cycle about Байда.
+
+This is not Russian/Soviet oppression. The decolonizing issue is historiographical: avoid later imperial or nationalist simplifications, and avoid turning the folk song into a police report.
+
+## 3. Major works
+
+This figure did not leave "works" in the literary sense. The major curriculum anchors are actions and reception texts.
+
+- `1545` — first known source mentions according to EIU.
+- `1540s-1550s` — service as Cherkasy and Kaniv starosta; organization of border defense and Cossack support.
+- `1553` — trip to Ottoman lands connected with freeing a relative and frontier diplomacy.
+- `1554-1556` — appointment/guard role around Khortytsia and construction of a stronghold on Mala Khortytsia.
+- `1556` — campaigns against Ottoman and Crimean Tatar fortresses, including Ochakiv and Islam-Kermen in EIU.
+- `1557` — defense against Devlet Giray's campaign and withdrawal from Khortytsia.
+- `1557-1561` — service to Muscovy and continued anti-Ottoman / anti-Tatar campaigns; this should be taught as tactical service, not identity change.
+- `1562` — attempt to persuade Ivan IV to continue anti-Ottoman struggle; return to Sigismund II Augustus after failure.
+- `1563` — Moldavian campaign, capture, execution in Istanbul.
+- `post-1563` — folk song *Пісня про Байду* and later historical-literary reception, including Hrushevsky's essay "Байда-Вишневецький в поезії і історії."
+
+## 4. Primary-source quotes (>=2 required)
+
+No reliable direct speech by the historical Вишневецький was found. The quotations below are therefore reception/legend evidence, not personal utterance, and should be used only in a legend-vs-history section.
+
+- "В Царгородї на риночку / Ой пє Байда мед-горілочку" (verified through `mcp__sources.verify_quote(author="Грушевський М.", ...)`, confidence 1.0, in Hrushevsky's quotation of the folk song; project corpus chunk `5794da94_c0119`). This line is valuable because it shows the folk song's deliberately non-documentary opening.
+- "слабкі і далекі звязки" (verified by the Cossack-founders subagent with `mcp__sources.verify_quote`, author "Грушевський М.", confidence 1.0, chunk `5794da94_c0817`). Hrushevsky uses this to caution that the song and the historical prince are connected at a distance, not in a simple one-to-one biography.
+
+Chronicle excerpt "скинуті з башти на гаки" is usable only if cited to *Kronika Marcina Bielskiego*, t. 2, p. 1149, through Holobutskyi's discussion. Do not present it as a quote from Вишневецький.
+
+## 5. Language register
+
+- **Register:** historical-political prose for the biography; folk-historical song for Байда reception; early modern chronicle register for death accounts.
+- **CEFR readiness for full reading:** B1/B2 for adapted biography; C1 for Hrushevsky or Holobutskyi historiography; C1 for unadapted folk-song variants with archaic/dialect forms.
+- **Lexicon notes:** староста, Січ, острів Мала Хортиця, Кримське ханство, Османська імперія, Молдова, ясир, дума, історична пісня.
+- **Stylistic features:** the folk song uses formulaic repetition, heroic defiance, and comic-heroic opening; historiography uses cautious modality and source comparison.
+
+For learners, the best task is a two-column reading: "what we know from sources" versus "what the Байда song does poetically."
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** whether the Mala Khortytsia fort should be called the first Sich; how directly the folk Байда can be identified with Вишневецький; and how to evaluate his service to Muscovy as tactical frontier politics rather than later national betrayal or allegiance.
+- **What gets simplified in popular memory:** he is often called "founder of the Zaporizhian Sich" without qualification. EIU says historiography contains that view; Holobutskyi cautions against making him the sole founder of the Sich. A better wording is "one of the key organizers of early Zaporizhian Cossack military structures."
+- **Where Russian imperial framing attacks them:** Russian-imperial and Soviet narratives may overemphasize his service to Moscow, making Muscovy the center of anti-Ottoman action. Ukrainian historiography should keep the Lithuanian-Ruthenian, Polish-Lithuanian, Cossack, Crimean, Ottoman, Moldavian, and Muscovite fields in view.
+- **Other-perspective considerations:** Ottoman, Moldavian, Polish-Lithuanian, and Crimean Tatar perspectives matter. He was not only a Ukrainian hero fighting "the Turks"; he was a frontier nobleman using shifting alliances in a violent border world. Modern lessons should avoid anti-Tatar or anti-Muslim essentializing language.
+
+Balanced historiography: Hrushevsky emphasizes the legendary transformation of the death story; Holobutskyi resists treating Вишневецький as the sole founder; Дзира pushes back against overly separating Байда and Вишневецький; Lemercier-Quelquejay is relevant for Ottoman-source terminology and frontier context. The curriculum should teach this as a historiography problem, not a single heroic paragraph.
+
+For production, the safest sentence is: "Вишневецький був одним із ключових організаторів раннього запорозького козацтва, а народна пісня про Байду стала головним образом його посмертної пам'яті." This keeps both truths visible. It neither denies the folk connection nor turns the folk song's hook scene, comic marketplace opening, or heroic replies into a stenographic account of 1563.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None verified for this dossier.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/dmytro-vyshnevetskyi.yaml` — existing HIST plan uses the `-i` spelling.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml` — origins of Cossackdom.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml` — Zaporizhian Sich as institution.
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — sixteenth-century Cossack frontier context.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — Ruthenian princely elite context.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — later Cossack revolt and memory.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — source bio plan exists on origin/main.
+- **Potential LIT additions surfaced by this research:**
+  - A B2/C1 lesson on *Пісня про Байду* as historical-song reception, explicitly not a documentary biography.
+
+## 8. Naming-canonical
+
+- **Slug:** `dmytro-vyshnevetsky`
+- **EN canonical (BGN/PCGN 2010):** Dmytro Vyshnevetskyi. Project slug omits final `i`; keep slug stable.
+- **UA canonical (with patronymic if attested):** Дмитро Іванович Вишневецький.
+- **Aliases (track these for `aliases:` YAML field):** Байда; Дмитро Байда; Dmytro Baida Vyshnevetsky; Wiśniowiecki.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Dmitry Vishnevetsky; Дмитрий Вишневецкий.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons / National Museum of the History of Ukraine, eighteenth-century portrait of Dmytro "Baida" Vyshnevetsky, PD-old/PD-Art; verify final license.
+- **Backup candidates:** Commons category `Dmytro Vyshnevetsky` monuments and reproductions.
+- **Era-appropriate context image:** Mala Khortytsia / Baida Island context map or public-domain image, if rights are clear.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Ю. Мицик, "Вишневецький Дмитро Іванович," *Енциклопедія історії України*, https://www.history.org.ua/?termin=Vyshnevetskyj_D, accessed 2026-06-04.
+- Arkadii Zhukovsky, "Vyshnevetsky, Dmytro," *Internet Encyclopedia of Ukraine*, https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesVYVyshnevetskyDmytro, accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- National Museum of the History of Ukraine portrait via Wikimedia Commons metadata.
+
+**Tier 3 (encyclopedic):**
+- Project textbook corpus chunks `textbook_sections:3989` and `textbook_sections:4268`, used only with T1/T4 corroboration.
+
+**Tier 4 (modern scholarly post-1991 / classic scholarly):**
+- М. Грушевський, "Байда-Вишневецький в поезії і історії," available at Litopys and in project corpus.
+- В. Голобуцький, *Запорозьке козацтво*, Kyiv, 1994 PDF through history.org.ua.
+- Я. Дзира, discussion cited by Holobutskyi, *Україна: наука і культура*, 1991, вип. 25.
+- Chantal Lemercier-Quelquejay, Ottoman-source scholarship as cited in Holobutskyi; original bibliographic follow-up still needed before direct quotation.
+
+**Primary-source documents accessed:**
+- Folk-song and chronicle material through Hrushevsky/Holobutskyi; no direct personal writing by Вишневецький found.
+
+## Decolonization self-check
+
+- [x] Legend and history are separated.
+- [x] Moscow service is contextualized without making Muscovy the center.
+- [x] No anti-Tatar or anti-Muslim essentializing frame.
+- [x] The "first Sich founder" claim is qualified.
+- [x] No Russian-state sources used.
+
+## Acceptance self-check
+
+- [x] No direct personal quotes fabricated; reception quotes are labeled as reception.
+- [x] Existing cross-track paths use only verified files.
+- [x] Birth date is not invented.
+- [x] The Baida folk-song material is explicitly pedagogical, not documentary.

--- a/docs/research/bio/hnat-khotkevych.md
+++ b/docs/research/bio/hnat-khotkevych.md
@@ -1,0 +1,132 @@
+# Гнат Хоткевич — Research Dossier
+
+**Slug:** `hnat-khotkevych`
+**Block:** G
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Codex GPT-5
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Гнат Мартинович Хоткевич.
+- **Pseudonyms / aliases:** Гнат Галайда; Hnat Khotkevych; Ignat Khotkevich; forbidden body forms: Игнат Хоткевич, Хоткевич Игнат Мартынович.
+- **Born:** Kharkiv | date disputed. EIU gives 31(19) December 1877 and IEU gives 12 January 1878 New Style; the Kharkiv State Archive page cites a student-file birth certificate copy, ф. 770, оп. 2, спр. 2097, арк. 2, giving 19 December 1876. The safest curriculum wording is "born in Kharkiv; older encyclopedias give 1877/1878, while archival evidence gives 19 December 1876."
+- **Died:** 8 October 1938 | Kharkiv NKVD internal prison | Ukrainian SSR, USSR | executed by Soviet security bodies. EIU contains an internal date defect: its lead gives 08.10.1938, while one body line says 8 September 1938. AVR/Texty and the archive-document set support 8 October 1938 after a 29 September 1938 troika sentence.
+- **Family / education key facts:** EIU identifies him as the son of a cook and a domestic worker, educated at the Kharkiv Technological Institute, and trained professionally as a railway engineer. He became a writer, actor, director, bandurist, composer, ethnographer, art historian, and public cultural organizer.
+
+Khotkevych's dossier must not flatten him into only "writer" or only "bandurist." His importance lies in the combination: literature, theatre, bandura pedagogy, ethnography, and Ukrainian cultural infrastructure in Kharkiv, Galicia, Hutsulshchyna, and Soviet Ukraine before Stalinist destruction.
+
+## 2. Oppression mechanism
+
+- **What happened:** imperial surveillance/exile, Soviet professional destruction, arrest, coerced accusations, execution, posthumous rehabilitation.
+- **When:** 1899 temporary exclusion from the Kharkiv Technological Institute; 1905-1906 exile/emigration after revolutionary activity; 1915 police exile to Belgorod/Voronezh; early 1930s dismissal and publication/performance restrictions; arrest on 21 February 1938; special troika sentence on 29 September 1938; execution on 8 October 1938; rehabilitation on 11 May 1956.
+- **By whom:** Russian imperial police/gendarmerie in the earlier period; NKVD / UNKVD for Kharkiv oblast in 1938.
+- **Document references:** AVR/CDVR/Texty collection of the repressive case; Kharkiv archive student-file materials; EIU article by Кізченко; local corpus repression chunks `c5e05b63_c0002` and related evidence.
+- **Mechanism specifics:** The 1938 accusation framed Khotkevych as a member of an anti-Soviet Ukrainian nationalist terrorist organization and as tied to German intelligence. The available rehabilitation context treats those charges as fabricated/coerced. He was sentenced by a special troika, not by a transparent court process. His earlier career had already been damaged: works were banned, employment and ration access were threatened, and the bandura class and performance network were curtailed.
+- **What survived / what was destroyed:** His published works, some music, and bandura pedagogy survived, but the Kharkiv bandura school and the broader cultural infrastructure around kobzar/bandura practice were violently interrupted. Family members also faced Soviet repression in the wider Хоткевич family story.
+
+This is an execution dossier. Do not use euphemisms such as "lost his life." Khotkevych was shot by the Soviet security apparatus.
+
+## 3. Major works
+
+- `1897` — "Грузинка," short story in *Зоря*. Start of literary publication.
+- `1902` — *Поезії в прозі*, prose poems.
+- `1905-1906` — *Лихоліття*, drama, tied to revolutionary experience.
+- `1909` — *Підручник гри на бандурі*, early bandura manual; later expanded/republished around 1930.
+- `1909` — *Довбуш*, drama / Hutsul theatre repertoire anchor.
+- `1910` — *Гуцульський рік*, ethnographic drama.
+- `1911` — *Камінна душа*, romantic Hutsul/opryshky prose; core literary work for excerpting.
+- `1914` — *Гірські акварелі*, prose collection.
+- `1924` — *Народний і середньовічний театр у Галичині*, scholarly/art-historical work.
+- `1926` — *О полку Ігоревім*, drama.
+- `1928` — *Авірон*, prose.
+- `1928-1931` — *Твори* in eight volumes, later curtailed by Soviet suppression.
+- `1930` — *Музичні інструменти українського народу*, musicological/ethnographic study.
+- `1930` — *Підручник гри на бандурі*, later edition; essential to the Kharkiv bandura-school story.
+- `1929` and after — *Богдан Хмельницький*, tetralogy project; historical prose/drama anchor.
+
+## 4. Primary-source quotes (>=2 required)
+
+Both quotations below were verified with `mcp__sources.verify_quote(author="Хоткевич Г.", ...)`.
+
+- "То такі були люде, що не боєлиси фестунків." Source: *Камінна душа*, project corpus `ukrlib-khotkevych`, chunk `06704c7b_c0038`; verifier confidence 1.0. This quote is pedagogically valuable because it puts Hutsul dialect and oral memory into one short line.
+- ""Купало", велике древнє свято єднання, свято плодородності, достатку, очищення й радості." Source: Khotkevych prose in project corpus `ukrlib-khotkevych`, chunk `8a6de40c_c0081`; verifier confidence 0.9885. It is useful for teaching ethnographic register and ritual vocabulary without turning the lesson into folklore trivia.
+
+Potential letter quotation "Як мені далі жити?..." matched in the corpus via a biographical note quoting letters, but it should be page-locked to an epistolary edition before use as a primary letter in production materials.
+
+## 5. Language register
+
+- **Register:** mixed literary, folk-dialect, ethnographic, theatrical, and technical/music-pedagogical.
+- **CEFR readiness for full reading:** B2 for short annotated prose; C1 for *Камінна душа* without heavy glossing; C1/C2 for bandura manuals and ethnographic scholarship.
+- **Lexicon notes:** Hutsul dialect forms in *Камінна душа*; bandura terminology; theatre and ethnography vocabulary; Soviet bureaucratic language in repression documents.
+- **Stylistic features:** oral storytelling, dialect dialogue, ethnographic precision, dramatic scene-building, and a strong contrast between lyrical prose and technical cultural instruction.
+
+Khotkevych is one of the best figures for showing that Ukrainian literature is not a single Kyiv/Poltava standard register. Learners should meet him with glosses and audio or performance context where possible.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** exact birth date; how to weigh his literary work against his bandura and theatre work; how to reconstruct the Kharkiv bandura school after Soviet interruption; and how to use case-file materials without repeating NKVD accusations as facts.
+- **What gets simplified in popular memory:** he is often remembered as "bandurist executed in 1938" or "author of *Камінна душа*." The fuller figure is an infrastructure-builder who joined pedagogy, performance, instrument technique, and prose.
+- **Where Russian/Soviet framing attacks them:** the 1938 accusation vocabulary turns cultural Ukrainian work into "nationalist terrorism" and "espionage." This dossier treats that as the mechanism of repression, not as evidence of guilt.
+- **Other-perspective considerations:** Hutsul material requires care: do not exoticize Hutsul speech as quaint. Khotkevych worked with living communities and theatre practice; the dialect is literary material and ethnographic evidence, not decoration.
+
+The source disagreement on birth date should be explicitly preserved in downstream YAML or article text. The older encyclopedia date is widespread, but the Kharkiv archive's student-file evidence is stronger for a corrected note.
+
+Another practical caution for writers: do not make the bandura story merely nostalgic. Soviet repression targeted a living pedagogy and performance network. Khotkevych's manuals, classes, and Poltava chapel work are evidence of modern cultural institution-building, not a museum-like return to the past. This matters because Russian and Soviet narratives often tolerated "folk color" while attacking autonomous Ukrainian cultural organization.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None verified for this dossier. A possible *Камінна душа* LIT module was checked and is absent.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/rozstriliane-vidrodzennia.yaml` — execution and Soviet destruction of Ukrainian cultural elites.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — music networks and performance culture.
+  - `curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml` — Ukrainian music and Soviet violence.
+  - `curriculum/l2-uk-en/plans/bio/hnat-khotkevych.yaml` — source bio plan exists on origin/main.
+- **Potential LIT additions surfaced by this research:**
+  - B2/C1 excerpt lesson from *Камінна душа* with Hutsul dialect glossing.
+  - Culture note on Kharkiv bandura school and Soviet suppression of kobzar/bandura practice.
+
+## 8. Naming-canonical
+
+- **Slug:** `hnat-khotkevych`
+- **EN canonical (BGN/PCGN 2010):** Hnat Khotkevych.
+- **UA canonical (with patronymic if attested):** Гнат Мартинович Хоткевич.
+- **Aliases (track these for `aliases:` YAML field):** Гнат Галайда; Hnat Khotkevych; Ignat Khotkevich.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Игнат Хоткевич; Хоткевич Игнат Мартынович.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Hnat Khotkevych.jpg`, early twentieth-century portrait, marked PD-Ukraine/old; verify final rights before packaging.
+- **Backup candidates:** Kharkiv State Archive student-file photograph, ф. 770, оп. 2, спр. 2097, арк. 1; archive page states CC BY 4.0 unless otherwise noted. AVR case scans can serve as document images, not portraits.
+- **Era-appropriate context image:** AVR/CDVR case-file scans from `https://avr.org.ua/?idUpCat=2667`, if license and sensitivity review pass.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- В. Кізченко, "Хоткевич Гнат Мартинович," *Енциклопедія історії України*, https://www.history.org.ua/?termin=Khotkevych_H, accessed 2026-06-04.
+- "Khotkevych, Hnat," *Internet Encyclopedia of Ukraine*, https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesKHKhotkevychHnat, accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- Державний архів Харківської області, student-file birth evidence, https://archives.kh.gov.ua/?page_id=27449, accessed 2026-06-04.
+- AVR/CDVR/Texty case-file collection notice, https://texty.org.ua/fragments/104706/banduryst-teroryst-dokumenty-zi-spravy-represovanoho-muzykanta-gnata-hotkevycha-dostupni-onlajn/, accessed 2026-06-04.
+
+**Tier 3 (encyclopedic):**
+- Project literary corpus `ukrlib-khotkevych`, chunks `06704c7b_c0038`, `8a6de40c_c0081`, `7f3e293a_c0000`, and `c5e05b63_c0002`.
+
+**Tier 4 (modern scholarly post-1991):**
+- Віктор Мішалов and bandura-studies references listed in ESU entries on later bandurists; used for follow-up direction only.
+
+**Primary-source documents accessed:**
+- NKVD/rehabilitation case scans through AVR/CDVR collection, as summarized by Texty.
+- Kharkiv State Archive birth/student-file record cited above.
+
+## Decolonization self-check
+
+- [x] Execution named directly.
+- [x] NKVD accusations are not repeated as facts.
+- [x] Birth-date disagreement is preserved instead of silently resolved.
+- [x] Hutsul dialect is treated as a serious literary register.
+- [x] No Russian-state sources used.

--- a/docs/research/bio/kost-hordiyenko.md
+++ b/docs/research/bio/kost-hordiyenko.md
@@ -1,0 +1,140 @@
+# Кость Гордієнко — Research Dossier
+
+**Slug:** `kost-hordiyenko`
+**Block:** B
+**Tier:** 1a
+**Issue:** #2535
+**Researcher:** Codex GPT-5
+**Completed:** 2026-06-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Кость Гордієнко; also Костянтин Гордієнко.
+- **Pseudonyms / aliases:** Kost Hordiienko; Kost Hordiyenko; Кость Гордієнко-Головко in some traditions; forbidden body forms: Костя Гордиенко, Kost Gordienko as default.
+- **Born:** unknown date | Poltava region according to EIU/IEU; origin traditions vary and should not be over-specified without source.
+- **Died:** 4 May 1733 Old Style / 15 May 1733 New Style if converted | Кам'янська Січ, near present-day Respublikanets, Beryslav raion, Kherson oblast | Russian/Ottoman-Crimean frontier context after the Mazepa-Orlyk exile period. EIU gives 04.05.1733.
+- **Family / education key facts:** EIU and IEU say he studied at the Kyiv-Mohyla College/Academy and joined the Zaporozhian Cossacks. He was a Cossack of the Платнирівський курінь and was repeatedly elected koshovyi otaman.
+
+This dossier replaces the bad Russian-state source listed in the plan. That source must not be cited or tagged primary.
+
+## 2. Oppression mechanism
+
+- **What happened:** not a personal execution; Russian imperial retaliation against Zaporizhian autonomy and communities after the Mazepa-Hordiyenko-Charles XII alliance.
+- **When:** March/April 1709 alliance with Mazepa and Charles XII; 25 May 1709 destruction of Chortomlyk Sich; 1711 destruction of Kamyanka Sich in the wider anti-Orlyk campaign; later Oleshky/Kamyanka exile politics.
+- **By whom:** Russian imperial military and state power under Peter I and commanders acting after Poltava.
+- **Document references:** EIU "Гордієнко Кость"; IEU "Hordiienko, Kost"; IEU "Chortomlyk Sich"; Chukhlib's EIU article on the 1710 Pacta; Yavornytskyi material preserved on Litopys.
+- **Mechanism specifics:** Hordiyenko opposed Moscow's encroachment on Zaporozhian rights even when he was personally at odds with Mazepa. In 1709 he joined Mazepa and Charles XII with thousands of Zaporozhians and sought a political-military arrangement against Russian domination. Russian punishment fell on the Sich community: Chortomlyk Sich was destroyed, Zaporozhian spaces were militarily pressured, and the post-Poltava Cossack exile had to operate through Bendery, Oleshky, and Kamyanka contexts.
+- **What survived / what was destroyed:** Hordiyenko's grave at Kamyanka survived as a memory site. The Chortomlyk community and autonomous Zaporozhian political space were violently disrupted. The 1710 Pacta survived in several versions and remains a key constitutional text of the exile polity.
+
+This is a political autonomy dossier. Do not invent a martyrdom death. Hordiyenko died at Kamyanka Sich; the oppression mechanism is collective retaliation and imperial destruction of Zaporozhian autonomy.
+
+## 3. Major works
+
+Hordiyenko was not a literary author. His curriculum anchors are political acts, letters, and constitutional participation.
+
+- `1702-1713` — repeated terms as koshovyi otaman of the Zaporozhian Sich; EIU summarizes the range as 1702-1713 and 1728.
+- `1702` — letter to Peter I defending Zaporozhian rights on the Samara and against Kamianyi Zaton encroachment, as described in local corpus and scholarship.
+- `1705` — boundary and fortress-rights conflicts with Russian authorities; relevant to the Mezheva Commission context.
+- `March/April 1709` — joined Mazepa and Charles XII with roughly 8,000 Zaporozhians; IEU gives treaty at Velyki Budyshcha on 8 April 1709.
+- `June 1709` — after Poltava, helped Charles XII and Mazepa's forces cross near Perevolochna and withdraw toward Bendery.
+- `1710` — participant in the Bendery political settlement around Pylyp Orlyk and the Pacta/Constitution; phrase as participant/signatory/approval role, not sole author.
+- `1711` — took part in Orlyk's campaign toward Right-Bank Ukraine.
+- `1712-1713` — Oleshky settlement and complicated break/realignment with Orlyk, according to IEU/EIU.
+- `1728` — late return/renewed otaman role in some EIU/IEU formulations.
+- `1733` — death at Kamyanka Sich; grave memory.
+
+## 4. Primary-source quotes (>=2 required)
+
+Hordiyenko is represented through letters and constitutional documents rather than a literary corpus. The two excerpts below are not in the project quote corpus and should be cited by edition/page in production.
+
+- "злість здавна на Вітчизну, матір нашу" (не в корпусі проєкту; за виданням Д. Яворницький, *Історія запорізьких козаків*, т. 3, Львів, 1992, с. 258, as reproduced on Litopys). This line is useful for teaching political vocabulary around "Вітчизна" before modern nation-state language.
+- "віддалившись від царя московського" (не в корпусі проєкту; same Yavornytskyi/Litopys source, p. 258). This gives a compact, sourceable expression of the political break with Moscow without importing modern slogans.
+
+For the 1710 Pacta, the title phrase "прав і вольностей Війська Запорозького" is safe as a document title, not a personal quote. It should be used to frame Hordiyenko's constitutional context.
+
+## 5. Language register
+
+- **Register:** early modern political, military, legal, and diplomatic register.
+- **CEFR readiness for full reading:** B2 for adapted biography; C1/C2 for Yavornytskyi, Pacta excerpts, and early modern political language.
+- **Lexicon notes:** кошовий отаман, Військо Запорозьке Низове, протекторат, права і вольності, Січ, Бендери, Олешківська Січ, Кам'янська Січ, Чортомлицька Січ.
+- **Stylistic features:** formal political appeals, collective rights language, oath/treaty vocabulary, and place-heavy military geography.
+
+Hordiyenko can support B2 lessons on "choice under pressure" and C1 lessons on the political vocabulary of rights, autonomy, and imperial domination.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** exact birth origin; number and dates of otaman terms; how to describe his role in the 1710 Pacta; and how to balance his anti-Moscow position with his tactical moves under Ottoman/Crimean protection.
+- **What gets simplified in popular memory:** he is sometimes reduced to "Mazepa's ally." That misses his earlier opposition to Mazepa when the hetman was loyal to Moscow. His 1709 choice was not personal loyalty to Mazepa; it was a Zaporozhian rights calculation.
+- **Where Russian disinformation attacks them:** Russian-state narratives frame Mazepa, Hordiyenko, and Charles XII through "treason" vocabulary. This dossier rejects that frame and uses Ukrainian/scholarly sources. The plan's Russian-state source is deliberately dropped.
+- **Other-perspective considerations:** Swedish, Ottoman, Crimean Tatar, Polish, and Right-Bank Ukrainian contexts matter. Do not write as if the only meaningful axis was Kyiv/Moscow. Also avoid pretending the post-Poltava exile environment was simple liberation politics; it involved dependency, failed campaigns, and hard choices.
+
+The balanced formulation: Hordiyenko was a defender of Zaporozhian autonomy and rights, not a modern democratic nationalist in a twentieth-century sense. He operated in early eighteenth-century treaty, oath, and military-protectorate language.
+
+One more caution is needed for lesson writers: his break with Moscow should not be taught as a sudden personal conversion. The sources show a longer conflict over forts, land, and the rights of the Lower Zaporozhian Host. That long conflict explains why an otaman who had opposed Mazepa while Mazepa was loyal to Peter I could later cooperate with Mazepa after the political situation changed.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - None verified for this dossier.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/kost-hordiyenko-sich.yaml` — existing HIST module directly tied to this figure.
+  - `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml` — 1710 Pacta and Orlyk context.
+  - `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml` — Mazepa-era context.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — Cossack polity context.
+  - `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — later autonomy-loss arc.
+- **Candidate cross-track connections (to create/verify in Phase 2+ — NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — alliance and post-Poltava exile.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — Bendery council, Pacta, exile polity.
+  - `curriculum/l2-uk-en/plans/bio/petro-kalnyshevskyy.yaml` — later Zaporizhian autonomy and imperial suppression.
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` — source bio plan exists on origin/main.
+- **Potential LIT additions surfaced by this research:**
+  - C1 source-reading mini-unit on Zaporozhian rights language using Hordiyenko letters and the Pacta title/preamble.
+
+## 8. Naming-canonical
+
+- **Slug:** `kost-hordiyenko`
+- **EN canonical (BGN/PCGN 2010):** Kost Hordiienko. Project slug uses `hordiyenko`; keep slug stable.
+- **UA canonical (with patronymic if attested):** Кость Гордієнко; Костянтин Гордієнко.
+- **Aliases (track these for `aliases:` YAML field):** Kost Hordiienko; Kost Hordiyenko; Кость Гордієнко-Головко.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Kost Gordienko; Костя Гордиенко; Константин Гордиенко as default.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** no secure free portrait identified for the early eighteenth-century otaman.
+- **Backup candidates:** Wikimedia Commons grave image, `Могила Костя Гордієнко.jpg`, CC BY-SA 4.0; Commons category "Grave of Kost Hordiienko."
+- **Era-appropriate context image:** Kamyanka Sich / grave context image is preferable to a speculative portrait. Avoid images of the twentieth-century writer Kost Hordiienko; that is a different person.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- В. Станіславський, "Гордієнко Кость," *Енциклопедія історії України*, https://www.history.org.ua/?termin=Gordienko_K, accessed 2026-06-04.
+- "Hordiienko, Kost," *Internet Encyclopedia of Ukraine*, https://www.encyclopediaofukraine.com/display.asp?linkpath=pagesHOHordiienkoKost, accessed 2026-06-04.
+- Т. Чухліб, "Пакти та конституції законів і вольностей Війська Запорозького 1710," *Енциклопедія історії України*, https://www.history.org.ua/?termin=Pakty_i_Konstytutsiia_prav_i_volnostej_Vijska_Zaporozkoho_1710, accessed 2026-06-04.
+
+**Tier 2 (institutional):**
+- Litopys reproduction of Hordiyenko/Yavornytskyi source text, https://litopys.org.ua/suspil/sus156.htm, accessed 2026-06-04.
+
+**Tier 3 (encyclopedic):**
+- Project Ukrainian wiki corpus `ukrainian_wiki:kost-hordiyenko:p1-1`, used only with T1 corroboration.
+
+**Tier 4 (modern scholarly post-1991):**
+- Т. Чухліб, *Донеччина та Луганщина — козацькі землі України*, Інститут історії України НАН України, 2014, https://history.org.ua/LiberUA/978-966-02-7397-9/978-966-02-7397-9.pdf.
+- Д. Яворницький, *Історія запорізьких козаків*, т. 3, Львів, 1992.
+
+**Primary-source documents accessed:**
+- Hordiyenko letter excerpts via Yavornytskyi/Litopys; 1710 Pacta title and context via EIU and Wikisource corpus.
+
+## Decolonization self-check
+
+- [x] Russian-state source from the plan is dropped.
+- [x] No "treason" frame.
+- [x] Death is not falsely made into martyrdom.
+- [x] Orlyk Constitution role is phrased as participant/signatory/context, not sole authorship.
+- [x] Image warning prevents confusion with the twentieth-century writer.
+
+## Acceptance self-check
+
+- [x] The bad Russian-state source is absent from sources used.
+- [x] Existing cross-track paths resolve locally.
+- [x] Collective retaliation is distinguished from personal execution.
+- [x] Early modern rights language is preserved without presentist overclaiming.


### PR DESCRIPTION
Adds six sourced bio research dossiers:

- ahatanhel-krymskyi
- borys-liatoshynskyi
- dmytro-bortnyanskyy
- hnat-khotkevych
- dmytro-vyshnevetsky
- kost-hordiyenko

NO auto-merge.