### PR TITLE
fix(ci): keep Stanza model checks out of required pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,36 +350,6 @@ jobs:
           .venv/bin/python -m pip install --no-deps -r requirements-lock.txt
           .venv/bin/python -m pip install multiprocess==0.70.18 huggingface-hub==0.36.0
 
-      - name: Prewarm Stanza resources
-        if: needs.changes.outputs.code == 'true'
-        run: |
-          stanza_resources_dir="$RUNNER_TEMP/stanza_resources"
-          echo "STANZA_RESOURCES_DIR=$stanza_resources_dir" >> "$GITHUB_ENV"
-          rm -rf "$stanza_resources_dir"
-          mkdir -p "$stanza_resources_dir"
-          STANZA_RESOURCES_DIR="$stanza_resources_dir" .venv/bin/python - <<'PY'
-          import os
-          import shutil
-
-          from ukrainian_word_stress import Stressifier, StressSymbol
-
-          resources_dir = os.environ["STANZA_RESOURCES_DIR"]
-
-          for attempt in range(2):
-              try:
-                  stressifier = Stressifier(
-                      stress_symbol=StressSymbol.CombiningAcuteAccent
-                  )
-                  stressifier("Моя мама читає.")
-                  break
-              except ValueError as exc:
-                  if "md5 for " not in str(exc) or attempt == 1:
-                      raise
-                  print(f"Stanza prewarm hit corrupt model cache, retrying: {exc}")
-                  shutil.rmtree(resources_dir, ignore_errors=True)
-                  os.makedirs(resources_dir, exist_ok=True)
-          PY
-
       - name: Run tests
         if: needs.changes.outputs.code == 'true' && !cancelled() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (github.event_name != 'push' || github.ref != 'refs/heads/main')
         run: |

--- a/tests/test_stress_annotation.py
+++ b/tests/test_stress_annotation.py
@@ -17,6 +17,8 @@ import time
 import types
 from pathlib import Path
 
+import pytest
+
 from scripts.pipeline.stress_annotator import (
     STRESS_MARK,
     _build_skip_mask,
@@ -128,6 +130,7 @@ class TestInSkipRange:
 # Integration tests for annotate_stress
 # ---------------------------------------------------------------------------
 
+@pytest.mark.slow
 class TestApostropheWords:
     """AC: apostrophe words (сім'я, м'ясо) stressed correctly."""
 
@@ -167,6 +170,7 @@ class TestApostropheWords:
             )
 
 
+@pytest.mark.slow
 class TestProperNouns:
     """AC: proper nouns not double-stressed."""
 
@@ -201,6 +205,7 @@ class TestProperNouns:
             assert len(positions) <= 1
 
 
+@pytest.mark.slow
 class TestCodeBlocksUntouched:
     """AC: words inside code blocks should not get stress marks."""
 
@@ -228,6 +233,7 @@ class TestCodeBlocksUntouched:
         )
 
 
+@pytest.mark.slow
 class TestURLsUntouched:
     """AC: URLs should not get stress marks."""
 
@@ -253,6 +259,7 @@ class TestURLsUntouched:
         assert "</div>" in result
 
 
+@pytest.mark.slow
 class TestNoDuplicateStress:
     """AC: running annotator twice shouldn't double-stress."""
 
@@ -303,6 +310,7 @@ class TestNoDuplicateStress:
         assert '<DialogueBox uk="' in result
 
 
+@pytest.mark.slow
 class TestPerformance:
     """AC: annotating a 1500-word module takes <5 seconds."""
 
@@ -338,6 +346,7 @@ class TestPerformance:
         assert count > 0, "Should have stressed at least some words"
 
 
+@pytest.mark.slow
 class TestHeteronyms:
     """AC: heteronyms handled by Stanza context.
 
@@ -373,6 +382,7 @@ class TestHeteronyms:
             assert isinstance(result, str)
 
 
+@pytest.mark.slow
 class TestRealModuleContent:
     """Test with content from actual A1 module files."""
 
@@ -400,6 +410,7 @@ class TestRealModuleContent:
 # annotate_file — safety check fix (#1052)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.slow
 class TestAnnotateFileSafetyCheck:
     """The 2% safety check should only count stress marks in the body,
     not in Словник/Ресурси tabs that are pre-stressed by vocab_gen.py."""
@@ -455,6 +466,19 @@ class TestAnnotateFileSafetyCheck:
 # network or loading the real model.
 # ---------------------------------------------------------------------------
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _venv_python() -> Path:
+    """Return the local or parent workspace venv Python for subprocess tests."""
+    local = REPO_ROOT / ".venv/bin/python"
+    if local.exists():
+        return local
+    for parent in REPO_ROOT.parents:
+        candidate = parent / ".venv/bin/python"
+        if candidate.exists():
+            return candidate
+    return local
+
 
 # Each worker increments a shared counter via a non-atomic read-modify-write
 # inside the download lock. With the lock, the final value equals the worker
@@ -523,7 +547,7 @@ class TestModelDownloadLock:
         )
 
         worker_count = 5
-        python = REPO_ROOT / ".venv/bin/python"
+        python = _venv_python()
         procs = [subprocess.Popen([str(python), "-c", snippet]) for _ in range(worker_count)]
         for proc in procs:
             assert proc.wait(timeout=120) == 0, "lock worker subprocess failed"

--- a/tests/test_stress_heteronyms.py
+++ b/tests/test_stress_heteronyms.py
@@ -14,6 +14,8 @@ from ukrainian_word_stress import Stressifier, StressSymbol
 
 STRESS = "\u0301"  # combining acute accent
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture(scope="module")
 def stressifier():

--- a/tests/test_stress_verification.py
+++ b/tests/test_stress_verification.py
@@ -60,6 +60,7 @@ class TestExtractStressedWords:
         assert words[0][1] == 2  # line 2
 
 
+@pytest.mark.slow
 class TestVerifyStressMarks:
     """Integration tests — require ukrainian-word-stress + Stanza model."""
 


### PR DESCRIPTION
## Summary
- remove the unconditional Stanza prewarm step from required CI
- mark real Stanza-backed stress integration tests as slow so the existing required pytest gate excludes live model downloads
- keep deterministic stress helper and model-download lock tests in required pytest
- make the lock subprocess test use the worktree venv when present and the parent workspace venv in local worktrees, without sys.executable

## Incident
Default branch run 26958186902 failed on main commit 39f31a7672cce04e5b6b5966bdad9c16443ce891 because Stanza fetched a Ukrainian model payload whose md5 did not match the expected tokenizer hash. That made branch protection depend on a live model download from Hugging Face.

## Verification
- PyYAML parsed .github/workflows/ci.yml
- git diff --check
- ruff check tests/test_stress_annotation.py tests/test_stress_heteronyms.py tests/test_stress_verification.py
- pytest tests/test_stress_annotation.py::TestModelDownloadLock -q
- pytest tests/test_stress_annotation.py tests/test_stress_heteronyms.py tests/test_stress_verification.py -k "not slow and not website" -q
- pre-commit affected-file pytest: 59 passed, 1 skipped, 10 xfailed
- lint_agent_trailer.py

Controller: #2682