### PR TITLE
research(bio): 6 sourced dossiers — medieval/early-modern (#2535)

### DIFF
--- a/docs/research/bio/knyazhna-anna-yaroslavna.md
+++ b/docs/research/bio/knyazhna-anna-yaroslavna.md
@@ -1,0 +1,153 @@
+# Анна Ярославна, королева Франції — Research Dossier
+
+**Slug:** `knyazhna-anna-yaroslavna`
+**Block:** K (Kyivan Rus / dynastic diplomacy)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** GPT-5.5 Codex
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] Hard audit errors fixed: Sviatopolk is not Yaroslav's son; Levesque is eighteenth-century; Agatha link is hypothesis
+- [x] Direct quote discipline: signatures/documentary formulae used, no invented romantic speech
+- [x] Cross-track paths verified against plan directory
+- [x] Decolonization checklist self-applied
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Анна Ярославна; also Анна Київська, королева Франції.
+- **Pseudonyms / aliases:** Anne de Kiev, Anna of Kyiv, Anne of Rus, Anne de Ruthénie in some contexts; Anna Regina in Latin charters. Forbidden unqualified form: "Анна Русская" / "Anne of Russia" when it implies modern Russia.
+- **Born:** usually placed between the **1020s and early 1030s**, often around **1032** | Kyiv | Kyivan Rus. Exact year is uncertain.
+- **Died:** after **1075**; some reconstructions place death after 1079 or around 1080 | probably in France | exact date and burial are uncertain.
+- **Family / education key facts:** Daughter of Yaroslav the Wise and Ingegerd-Iryna of Sweden. Married King Henry I of France in **1051** and became queen consort. Mother of Philip I of France, Robert, Hugh of Vermandois and possibly Emma/other short-lived child depending on source. After Henry's death in 1060 she appears in royal charters and was connected to regency/governance during Philip's minority. Later married Raoul de Crépy/Valois, creating a church-political scandal.
+
+The core fact is dynastic diplomacy: a princess of Kyiv entered the Capetian royal house. That does not make France "Ukrainian," and it does not make Kyivan Rus "Russia." It shows that Kyiv was a major diplomatic actor in eleventh-century Europe.
+
+## 2. Oppression mechanism
+
+- **What happened:** No personal state execution or exile is documented. The load-bearing mechanism is **imperial naming appropriation** and archival mythmaking: Anna's Kyivan/Rus identity has often been absorbed into Russian-imperial language as "Anne of Russia."
+- **When:** especially from early modern and imperial historiography onward; still visible in modern French/English public labels when "de Russie/of Russia" is used lazily.
+- **By whom:** Russian imperial historiography and later Soviet/post-Soviet cultural diplomacy; also Western reference habits that equate medieval Rus with Russia.
+- **Document references:** eleventh-century French royal charters with Anna's Latin queenly signatures; modern historiography by Pierre-Charles Levesque (eighteenth century, 1736-1812; *Histoire de Russie*, 1782) as an example of later Russian-history framing that must not be misdated.
+- **Mechanism specifics:** Anna's life is used in two opposed simplified ways. Russian narratives claim her as "Russian" by treating Rus as Russia. Some Ukrainian popular retellings respond with romantic overreach, making every uncertain detail certain. A decolonized dossier says "Anna of Kyiv / Anna Yaroslavna, daughter of Yaroslav the Wise, queen of France" and then states uncertainties: birth year, death date, burial place and the exact scope of her regency.
+- **What survived / what was destroyed:** Survived: charters naming Anna as queen/mother, later monastic and French royal records, diplomatic memory. Lost or uncertain: private letters, personal voice, exact education record, burial certainty.
+
+## 3. Major works
+
+Anna's "works" are dynastic and documentary acts rather than authored literature.
+
+- `1051` — **Marriage alliance with Henry I of France**, dynastic act joining the Capetian court with Kyivan Rus.
+- `1050s` — **Queenly appearances in royal charters**, Latin documentary formulae showing her place in Capetian governance.
+- `1060` — **Transition after Henry I's death**, when Philip I was a minor and Anna appears with authority in the royal environment.
+- `1060s` — **Foundation/association with Saint-Vincent at Senlis**, a key site of her French memory. The exact level of her role should be sourced in the final lesson.
+- `1060s` — **Second marriage to Raoul de Crépy/Valois**, politically consequential and canonically controversial.
+- `posthumous` — **French and Ukrainian commemorative memory**, including Senlis monuments and modern diplomatic use of "Anna of Kyiv."
+
+## 4. Primary-source quotes (≥2 required)
+
+**Anti-fabrication note:** No first-person letter by Anna was verified in this pass. The secure primary material is documentary: charter signatures and formulae. These are not romantic speeches and should not be rewritten as them.
+
+**Primary expression 1 — Latin charter identity:**
+
+> `ANNA REGINA`
+
+This formula, "Anna the Queen," appears in the Latin documentary tradition and is the safest student-facing primary expression. It shows status without inventing interiority.
+
+**Primary expression 2 — Cyrillic/Rus-associated signature tradition:**
+
+> `Ана Ръина`
+
+This signature form is widely discussed in Ukrainian and French treatments of Anna. Use cautiously as a signature/formula, not as evidence for modern national language. Pedagogically it helps show that a Kyivan princess could appear in a French-Latin documentary setting while retaining a distinct eastern identity marker.
+
+**Primary expression 3 — what not to quote:**
+
+Do not invent lines about Anna "bringing European culture to France" or "signing when the French king could not write." Those are popular simplifications. Her documented value lies in charters, marriage diplomacy and the Capetian succession.
+
+## 5. Language register
+
+- **Register:** Latin charter/bureaucratic formulae; medieval dynastic vocabulary; modern Ukrainian expository register for learners.
+- **CEFR readiness for full reading:** adapted biography B1-B2; documentary/charter discussion C1; Latin formulas can be glossed at A2-B1 as proper-name evidence.
+- **Lexicon notes:** княжна, королева, династичний шлюб, Капетинги, регентство, грамота, підпис, Сенліс, гіпотеза, привласнення, Русь.
+- **Stylistic features:** precise hedging is part of the style. Use "ймовірно," "після 1075," "гіпотеза," and "традиційно пов'язують" rather than false certainty.
+
+## 6. Contested points
+
+- **What's debated in modern scholarship:** birth year; death date and burial; the exact scope of Anna's regency after Henry I died; the authenticity/interpretation of particular signatures; how to label her in English and French without anachronism.
+- **Hard correction 1 — Sviatopolk:** Святополк Окаянний was **Yaroslav's defeated rival**, not Yaroslav's son. He married a daughter of Bolesław I of Poland. Do not place him in a list of Yaroslav's children.
+- **Hard correction 2 — Levesque:** Pierre-Charles Levesque was an **eighteenth-century** French historian (1736-1812), a protégé of Diderot, and author of *Histoire de Russie* (1782). He was not a scholar of the second half of the seventeenth century. If his framing appears, it belongs to Enlightenment/imperial historiography, not early modern witness.
+- **Hard correction 3 — Agatha and Edward the Exile:** the Agatha -> Edward the Exile link is a **genealogical hypothesis**, not a fact. It may be mentioned only as a debated reconstruction, not as a verified diplomatic tie.
+- **What popular memory simplifies:** Anna is often turned into a civilizational trophy: "Kyiv educated France." The safer claim is narrower and stronger: Kyivan Rus had dynastic links with major European houses, and Anna held real queenly status in France.
+- **Where modern Russian disinformation attacks or appropriates:** "Anne of Russia" folds Kyivan Rus into the Russian state centuries before Muscovy's later rise. The curriculum should prefer **Anna of Kyiv** or **Anna Yaroslavna**.
+- **Other-perspective considerations:** French tradition naturally places her in Capetian history; Ukrainian tradition places her in Kyivan diplomacy; Swedish context matters through her mother Ingegerd-Iryna. None should erase the others.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was checked against the on-disk plan listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/knyazhna-anna-yaroslavna.yaml` — the BIO plan this dossier backfills.
+  - `curriculum/l2-uk-en/plans/bio/kniaz-yaroslav-mudryi.yaml` — father and dynastic context.
+  - `curriculum/l2-uk-en/plans/bio/knyahynia-olha.yaml` — earlier Kyivan female rulership memory.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-velykii.yaml` — dynastic Christianization background.
+  - `curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml` — narrative source tradition for Yaroslav's world.
+- **Existing HIST / OES plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/yaroslav-wise.yaml` — dedicated HIST module for her father's reign.
+  - `curriculum/l2-uk-en/plans/hist/sofiya-kyivska.yaml` — Kyiv sacred/political context.
+  - `curriculum/l2-uk-en/plans/hist/kultura-kyivskoi-rusi.yaml` — cultural frame.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kyivska-rus.yaml` — synthesis unit.
+  - `curriculum/l2-uk-en/plans/oes/pvl-yaroslav-wise.yaml` — PVL material on Yaroslav's reign.
+  - `curriculum/l2-uk-en/plans/oes/slovo-yaroslavna-lament.yaml` — useful contrast: another "Yaroslavna" figure in literary memory, not Anna.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST module on **Kyivan Rus dynastic marriages** across France, Norway, Hungary and Poland.
+  - A media-literacy note on "Anne de Russie" versus "Anna of Kyiv."
+- **Potential LIT additions surfaced by this research:**
+  - A short charter-reading activity using `ANNA REGINA` and a map of Capetian/Kyivan diplomacy.
+
+## 8. Naming-canonical
+
+- **Slug:** `knyazhna-anna-yaroslavna`
+- **EN canonical (BGN/PCGN-style project spelling):** Anna Yaroslavna / Anna of Kyiv
+- **UA canonical:** Анна Ярославна, королева Франції
+- **Aliases (track these for `aliases:` YAML field):** Анна Київська; Anne de Kiev; Anna of Kyiv; Anna of Rus; Anna Regina; Anne de Ruthénie.
+- **Forbidden forms:** "Анна Русская" / "Anne of Russia" as unqualified modern identity; "daughter of Sviatopolk"; "Levesque, seventeenth-century historian"; "Agatha link" as fact.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons images connected with Anna of Kyiv in Senlis, especially statue/monument photographs with CC license; final use must check file-level rights.
+- **Backup candidates:** reproductions of charter/signature images if rights clear; Saint-Vincent de Senlis context images.
+- **If no PD/CC portrait exists:** use a charter/signature or Senlis abbey context image rather than a modern fantasy portrait.
+- **Era-appropriate context image:** map of Kyivan Rus-Capetian marriage diplomacy; not a Reims Gospel image unless the lesson explicitly debunks the myth.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України / ЕСУ materials on Анна Ярославна and Yaroslav's dynasty.
+- *Internet Encyclopedia of Ukraine* entries on Yaroslav the Wise and Kyivan dynastic diplomacy.
+
+**Tier 2 (institutional):**
+- French institutional/Senlis materials on Anna's memory, charters and Saint-Vincent association, used with scholarly cross-checking.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія, "Анна Ярославна"; used for navigation only, not to settle disputed genealogy.
+
+**Tier 4 (modern scholarly post-1991 and classic scholarship):**
+- Войтович Л. dynastic tables / princely genealogy corpus surfaced through `mcp__sources.search_sources`.
+- Studies of Capetian charters and Anna's signatures.
+- Levesque, Pierre-Charles. *Histoire de Russie* (1782), cited only for historiographic context and date correction.
+
+**Primary-source documents accessed / attested:**
+- French royal charters bearing Anna's queenly formulae/signatures. No personal letter was verified; no invented speech is used.
+
+**Honest gaps:** exact birth year, death date, burial, and private voice remain uncertain. The dossier's strongest primary evidence is documentary formula, not narrative autobiography.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Uses Anna of Kyiv / Anna Yaroslavna, not "Anne of Russia" as project voice.
+- [x] Kyivan Rus not mapped onto modern Russia.
+- [x] Hard genealogy and Levesque audit corrections applied.
+- [x] No romantic invented quote.
+- [x] Uncertain dates marked as uncertain.
+- [x] French, Swedish, Polish and Ukrainian contexts kept distinct.

--- a/docs/research/bio/kostiantyn-ostrozky-elder.md
+++ b/docs/research/bio/kostiantyn-ostrozky-elder.md
@@ -1,0 +1,157 @@
+# Костянтин Іванович Острозький — Research Dossier
+
+**Slug:** `kostiantyn-ostrozky-elder`
+**Block:** K (Lithuanian-Ruthenian military/state elite; early-modern frontier)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** GPT-5.5 Codex
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] Audit correction applied: roughly 65 battles, 3 losses, about 62 victories; not the plan's erroneous 33 wins
+- [x] Orsha 1514 included; son Vasyl-Kostiantyn birth treated as ca. 1526, not 1514/1515
+- [x] Cross-track paths verified against plan directory
+- [x] Decolonization checklist self-applied
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Костянтин Іванович Острозький.
+- **Pseudonyms / aliases:** Prince Kostiantyn Ostrozky; Konstanty Ostrogski in Polish; Konstantinas Ostrogiškis in Lithuanian contexts; Костянтин Острозький Старший for disambiguation from his son Vasyl-Kostiantyn.
+- **Born:** around **1460** | Ostroh/Ruthenian princely milieu of the Grand Duchy of Lithuania | exact place/date not securely attested.
+- **Died:** **1530** | Grand Duchy of Lithuania / Ruthenian lands | buried in the Kyiv Pechersk tradition according to common accounts, with later memory tied to Kyiv and Ostroh.
+- **Family / education key facts:** Son of the Ostrozky princely house; married Tatiana Holshanska and later Oleksandra Slutskа. His son **Vasyl-Kostiantyn Ostrozky** was born around **1526**, when Kostiantyn was already past sixty; do not headline 1514/1515 for that birth. Served as Great Hetman of Lithuania, with offices including Bratslav/Vinnytsia namisnyk, Lutsk starosta, Marshal of Volhynia, Vilnius castellan and Troki voivode in standard princely genealogical summaries.
+
+The core fact is military-political: a Ruthenian Orthodox magnate commanded the army of the Grand Duchy of Lithuania and became one of the most successful anti-Muscovite commanders of his age.
+
+## 2. Oppression mechanism
+
+- **What happened:** Muscovite military captivity and later imperial erasure/minimization. He was defeated and captured at the **Battle of Vedrosha on 14 July 1500**, held in Muscovite captivity, and escaped in **1507**. Later Russian imperial memory minimized his victory at Orsha because it did not fit the myth of inevitable "gathering of Rus lands" under Moscow.
+- **When:** captivity **1500-1507**; great victory at **Orsha on 8 September 1514**; long afterlife of imperial erasure from Muscovite/Russian narratives.
+- **By whom:** Muscovite state under Ivan III/Vasilii III period for captivity and war; later Russian imperial/Soviet historiography for suppression or reframing of Orsha.
+- **Document references:** Battle and office chronology in princely genealogy and encyclopedic sources; panegyric and visual tradition around Orsha; modern scholarship on Grand Duchy of Lithuania-Ruthenian military history.
+- **Mechanism specifics:** Vedrosha was a real defeat, one of the roughly three losses in a career otherwise remembered for about sixty-two victories in around sixty-five battles. Captivity did not end his career: after escaping in 1507 he returned to command and defeated a larger Muscovite force at Orsha in 1514. The dossier must therefore avoid both hagiography and undercounting. "Never lost" is false; "33 victories" is the audit-flagged plan error; the safer figure is **approximately 65 battles, 3 losses, about 62 wins**.
+- **What survived / what was destroyed:** Survived: office records, battle memory, Orsha painting/panegyric tradition, Ostrozky dynastic memory. Damaged: public memory under Russian imperial narratives; some tomb/memorial continuity through later wars and regime changes.
+
+He should not be called a "Lithuanian prince" in a way that erases Ruthenian identity, nor a modern Ukrainian national commander in an anachronistic way. He was an Orthodox Ruthenian magnate and military leader of the Grand Duchy of Lithuania, fighting Muscovy inside the politics of the Polish-Lithuanian and Ruthenian borderlands.
+
+## 3. Major works
+
+Kostiantyn did not leave a literary corpus; his "works" are military and institutional acts.
+
+- `1497-1500` — **First tenure as Great Hetman of Lithuania**, major office in the Grand Duchy's military structure.
+- `14 July 1500` — **Battle of Vedrosha**, defeat and capture by Muscovy; crucial anti-hagiographic anchor.
+- `1507` — **Escape from Muscovite captivity**, return to Lithuanian-Ruthenian service.
+- `1507-1530` — **Second tenure as Great Hetman of Lithuania**, long command period.
+- `8 September 1514` — **Battle of Orsha**, major victory over Muscovy and central memory site.
+- `1510s-1520s` — **Defense of Volhynia, Podillia and Grand Duchy frontier zones**, part of the broader Tatar/Muscovite military environment.
+- `1526` — **Birth of Vasyl-Kostiantyn Ostrozky**, dynastic continuation; pedagogically important because father and son are often conflated.
+- `posthumous` — **Orsha panegyric/painting tradition**, a cultural memory corpus that needs verification before direct quotation.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Anti-fabrication note:** No first-person autograph quote by Kostiantyn Ivanovych was verified in this pass. The dossier therefore uses documentary/battle-memory expressions and flags the unverified panegyric line rather than claiming it.
+
+**Primary expression 1 — office title:**
+
+> «гетьман великий литовський»
+
+This office title is the safest short documentary expression to teach. It names the state office, not an ethnic identity. Pair it with "руський/рутенський православний князь" in explanation so learners do not confuse the Grand Duchy of Lithuania with modern Lithuania-only identity.
+
+**Primary expression 2 — battle-name formula:**
+
+> «Битва під Оршею»
+
+This is not a speech quote; it is the central event-name and cultural-memory phrase. It anchors the 1514 unit and can be connected to the Orsha painting and panegyric tradition after rights/source checks.
+
+**Flagged quote not used as verified:** the panegyric line often rendered in Ukrainian as **«тої волі, що у нас...»** was checked with `verify_quote(author="Невідомий", ...)` and returned **matched:false** with best confidence below threshold. Do not use it as a verified quote unless a specific published edition and page are supplied.
+
+## 5. Language register
+
+- **Register:** military-chancery and dynastic register; modern explanatory prose must handle Polish, Lithuanian, Ruthenian and Muscovite terms.
+- **CEFR readiness for full reading:** adapted biography B1-B2; office/battle historiography C1; original Latin/Polish/Ruthenian documents C2.
+- **Lexicon notes:** гетьман великий литовський, князь, воєвода, каштелян, староста, намісник, битва, полон, втеча, Орша, Ведроша, Москва/Московія, Велике князівство Литовське, руський князь.
+- **Stylistic features:** beware false-friend state names. "Lithuanian" in the office title denotes the Grand Duchy, a multiethnic polity that included Ruthenian lands and elites.
+
+## 6. Contested points
+
+- **What's debated in modern scholarship:** exact battle counts; the scale and tactical details of Orsha; how to classify Ostrozky's identity in modern national terms; the precise burial/memorial history; the relationship between Orthodox patronage and service to a Catholic-dominated political order.
+- **Audit correction — battle record:** The plan's "33 victories" is wrong for this dossier. Use **approximately 65 battles, 3 losses, about 62 wins**. Keep "approximately" because early-modern battle accounting is not a modern sports statistic.
+- **What popular memory simplifies:** Ukrainian memory can make him a proto-national anti-Russian commander; Lithuanian/Polish memory can absorb him into state service; Russian memory often minimizes Orsha. The correct frame is more interesting: a Ruthenian Orthodox prince serving the Grand Duchy of Lithuania, defending a multiethnic polity against Muscovy and steppe threats.
+- **Where modern Russian disinformation attacks or appropriates:** Orsha contradicts the imperial story that Moscow naturally gathered all Rus lands. For that reason it was often downplayed, reframed as a temporary setback or omitted from popular Russian narratives. The dossier should teach Orsha as a major Lithuanian-Ruthenian victory without turning it into simple modern nationalism.
+- **Father/son confusion:** Kostiantyn Ivanovych (elder) is not Vasyl-Kostiantyn, the founder-patron of the Ostroh Academy and Bible. The son was born around **1526**, not 1514/1515, and belongs to a separate dossier.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was checked against the on-disk plan listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-ostrozky-elder.yaml` — the BIO plan this dossier backfills.
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — son; must be disambiguated.
+  - `curriculum/l2-uk-en/plans/bio/meletii-smotrytskyi.yaml` — later Ostroh/Ruthenian learned milieu.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — later Cossack frontier world.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — sixteenth-century frontier/military comparison.
+  - `curriculum/l2-uk-en/plans/bio/petro-mohyla.yaml` — later Orthodox institutional continuation.
+  - `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml` — later Orthodox hierarchy.
+- **Existing HIST / RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — later Commonwealth frame.
+  - `curriculum/l2-uk-en/plans/hist/liublinska-uniia.yaml` — later union context for the lands his family shaped.
+  - `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml` — son-era religious politics.
+  - `curriculum/l2-uk-en/plans/hist/bratstva-i-osvita.yaml` — Ostroh legacy through education.
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — sixteenth-century military/social context.
+  - `curriculum/l2-uk-en/plans/ruth/prince-ostrozky.yaml` — Ruthenian-language Ostrozky material.
+  - `curriculum/l2-uk-en/plans/ruth/epistle-to-ostrozky.yaml` — Ostrozky reception.
+  - `curriculum/l2-uk-en/plans/ruth/herasym-smotrytsky-poems.yaml` — later Ostroh circle.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated Orsha 1514 HIST/OES module.
+  - A map activity on the Grand Duchy of Lithuania as a multiethnic polity.
+  - A source-criticism note on victory counts and military legend.
+- **Potential LIT additions surfaced by this research:**
+  - Orsha panegyric excerpt only after edition/page verification.
+
+## 8. Naming-canonical
+
+- **Slug:** `kostiantyn-ostrozky-elder`
+- **EN canonical (BGN/PCGN-style project spelling):** Kostiantyn Ostrozky the Elder
+- **UA canonical:** Костянтин Іванович Острозький
+- **Aliases (track these for `aliases:` YAML field):** Костянтин Острозький Старший; Prince Konstanty Ostrogski; Kostiantyn Ivanovych Ostrozky; Konstantinas Ostrogiškis.
+- **Forbidden forms:** "33 victories" as corrected fact; "never defeated"; "Lithuanian prince" without Ruthenian/Grand-Duchy context; confusing him with Vasyl-Kostiantyn.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portraits of Konstanty Ostrogski / Kostiantyn Ostrozky, file-level PD-old check required.
+- **Backup candidates:** public-domain reproduction of the Battle of Orsha painting; Ostroh castle/heritage images; Kyiv Pechersk memorial context if rights clear.
+- **If no PD/CC portrait exists:** use the Orsha painting as event-context image after rights verification.
+- **Era-appropriate context image:** map of Orsha campaign and Grand Duchy/Muscovy frontier.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України / ЕСУ materials on Костянтин Іванович Острозький and Оршанська битва.
+- Войтович Л. princely genealogy corpus surfaced through `mcp__sources.search_sources`, including offices and the ca. 1526 birth of Vasyl-Kostiantyn.
+
+**Tier 2 (institutional):**
+- Ukrainian/Lithuanian museum and heritage materials on Orsha and the Ostrozky family, used for image/source leads only.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія, "Костянтин Іванович Острозький"; used for navigation and cross-checking of battle/captivity chronology.
+
+**Tier 4 (modern scholarly post-1991 and classic scholarship):**
+- Modern studies of the Battle of Orsha, the Grand Duchy of Lithuania and Ruthenian princely elites.
+- Scholarship on Russian imperial memory and suppression/minimization of Orsha.
+
+**Primary-source documents accessed / attested:**
+- Office-title and battle-memory traditions; Orsha panegyric/painting tradition noted but not quoted without edition/page verification.
+
+**Honest gaps:** exact battle-count accounting varies; this dossier uses the audit-corrected approximate figure. No first-person quote was verified; the unverified panegyric line is explicitly blocked.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Muscovy named for the sixteenth-century antagonist.
+- [x] Grand Duchy of Lithuania treated as multiethnic, not modern Lithuania-only.
+- [x] Ruthenian/Orthodox identity kept visible without anachronistic nationalism.
+- [x] Plan's 33-victory error corrected.
+- [x] Father/son confusion avoided.
+- [x] No unverified panegyric quote used as verified evidence.

--- a/docs/research/bio/mykhailo-chernihivskyi.md
+++ b/docs/research/bio/mykhailo-chernihivskyi.md
@@ -1,0 +1,158 @@
+# Михайло Всеволодович Чернігівський — Research Dossier
+
+**Slug:** `mykhailo-chernihivskyi`
+**Block:** K (Kyivan/Rus principalities; Mongol-Horde martyrdom)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** GPT-5.5 Codex
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] Horde martyrdom facts anchored: 1246, boyar Fedir, refusal of ritual, Doman
+- [x] Audit warnings applied: Innocent IV appeal marked likely Danylo conflation; no "great Lithuanian prince" claim
+- [x] Relics seized/transferred by Ivan IV in 1572 included
+- [x] Cross-track paths verified against plan directory
+- [x] Decolonization checklist self-applied
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Всеволодович Чернігівський.
+- **Pseudonyms / aliases:** Михайло Чернігівський; Saint Michael of Chernihiv; Michael Vsevolodovich of Chernigov in English reference works. Forbidden as project voice: "великий литовський князь" for him; that is fringe/confused and not used.
+- **Born:** often placed around **1179** | princely milieu of the Olhovychi / Chernihiv line | Kyivan Rus successor principalities. Exact birthplace is not secure enough for a hard claim.
+- **Died:** **20 September 1246** | at Batu's Horde camp | executed after refusing ritual submission; killed with his boyar **Fedir**. The hagiographic/literary tradition names the apostate **Doman of Putyvl** as the killer.
+- **Family / education key facts:** Son of Vsevolod Sviatoslavych of the Chernihiv princely line; married Olena Romanivna according to princely genealogical sources. Ruled as Prince of Chernihiv **1224-1239** and held Kyiv in contested periods, including 1238-1239 and 1241-1243 in common reconstructions.
+
+The verified biographical center is not a long successful reign but a death narrative: a Rus prince, in the new Mongol imperial order after the destruction of Kyiv, goes to the Horde for recognition and refuses a ritual he experiences as pagan worship.
+
+## 2. Oppression mechanism
+
+- **What happened:** Imperial coercion and execution by the Mongol Horde. Mikhail and Fedir were required to pass through fire/purification and bow to Tatar idols or ancestral cult signs before Batu; they refused and were killed.
+- **When (specific date):** **20 September 1246** for the execution. The meeting with Batu belongs to the post-1240 order, after Mongol conquest and before later Galician-Volhynian diplomatic maneuvering.
+- **By whom:** Batu's Horde authorities; hagiographic tradition identifies the executioner as **Doman, a Putyvl apostate**, for Mikhail, with Fedir killed after making the same refusal.
+- **Document references:** *Житіє Михайла Чернігівського* was written before 1271 according to the literary-history source surfaced by `mcp__sources.search_literary`; the Galician-Volhynian chronicle tradition also records the Batu episode in modern Ukrainian translation.
+- **Mechanism specifics:** The mechanism was not a court case but a ritual-political demand: to receive recognition, a prince entering Horde authority had to accept symbolic submission. Mikhail's refusal turned a diplomatic visit into martyrdom. The narrative is Christian hagiography, so it uses stark moral language, but the political setting is real: after Mongol conquest, Rus princes negotiated survival under an imperial overlord.
+- **What survived / what was destroyed:** Survived: hagiographic life, chronicle notices, saint's cult, later relic traditions. Destroyed or displaced: political autonomy of Chernihiv and Kyiv under pre-Mongol terms; local memory later partly appropriated by Muscovy.
+
+**Russian-imperial afterlife:** In **1572**, Ivan IV seized/transferred the relics of Mikhail and Fedir to Moscow. This is a second appropriation mechanism: the Muscovite state absorbed the cultic capital of a Chernihiv/Kyivan-Rus martyr into its own sacred history. The dossier should state this plainly while keeping the original thirteenth-century death in the Horde context.
+
+**Audit guard:** The appeal to **Pope Innocent IV** is **UNVERIFIED / likely a conflation with Danylo Halytskyi**. Danylo's papal diplomacy is firmly documented; Mikhail's dossier must not import it. Likewise, do not say he titled himself "great Lithuanian prince."
+
+## 3. Major works
+
+Mikhail did not leave an authored literary corpus. His "works" are rulership acts and the textual afterlife around his death.
+
+- `1224-1239` — **Rule in Chernihiv**, political leadership of a major Rus principality in the pre- and early-Mongol crisis.
+- `1238-1239` — **Kyiv rule in a contested period**, important for understanding post-Monomakhovychi/Olhovychi politics.
+- `1241-1243` — **Second Kyiv-associated rule/reconstruction period** in genealogical reconstructions, after Mongol devastation.
+- `1246` — **Journey to Batu**, diplomatic mission for recognition that became martyrdom.
+- `before 1271` — *Житіє Михайла Чернігівського*, hagiographic text preserving the refusal-and-execution narrative.
+- `late medieval / early modern` — **Cult of Mikhail and Fedir**, including relic movement and Muscovite appropriation.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — refusal in the Galician-Volhynian chronicle tradition:**
+
+> «Бог нас віддав і нашу волость у ваші руки за наші гріхи й тому тобі кланяємося й віддаємо честь. Але вірі твоїх батьків і твоєму нечистому перед Богом велінню не кланяємося.»
+
+Tool status: `verify_quote(author="Галицько-Волинський літопис", ...)` returned **matched:false, best_confidence:0.0** for this modern Ukrainian translation. It is used only with a source note: the passage was surfaced by `mcp__sources.search_literary` in the Kostruba Galician-Volhynian chronicle translation (`wave6-galvol-kostruba`, chunk `adac6627_c0156`). Pedagogically, it shows the distinction between political submission to Batu and refusal of religious ritual.
+
+**Quote 2 — hagiographic motive from the Life:**
+
+> «за Христа моєго пострадати и за православную вЂру проліяти кровь свою»
+
+This wording was surfaced in `mcp__sources.search_literary` from *Історія української культури* discussion of *Житіє Михайла Чернігівського* (`wave7-istkult-t2-xiii-xvii`, chunk `484d0ffb_c0578`). It is a quoted old-language hagiographic phrase in a scholarly source, not a verified `verify_quote` hit. Pedagogically, it marks the genre: saintly confession, not neutral diplomatic minutes.
+
+**Quote 3 — Doman named in the source tradition:**
+
+The same Galician-Volhynian chronicle translation identifies the killer as **"беззаконний Доман, путивлець"**. Use this as source-language evidence for the tradition; do not turn it into a modern ethnic blame claim.
+
+## 5. Language register
+
+- **Register:** hagiographic chronicle register; Christian confession vocabulary; political vocabulary of князь, волость, ярлик and Horde submission.
+- **CEFR readiness for full reading:** adapted narrative B1-B2; source comparison C1; original old-language passages C2.
+- **Lexicon notes:** мученик, ярлик, Орда, Батий, поклонитися, ідоли, вогонь очищення, боярин, волость, реліквії, привласнення.
+- **Stylistic features:** direct speech dramatizes confession; hagiography polarizes faithful prince versus apostate killer; modern lesson prose should temper the genre without erasing it.
+
+## 6. Contested points
+
+- **What's debated in modern scholarship:** exact chronology of Mikhail's Kyiv holdings; the political purpose of his journey to Batu; the boundary between historical memory and hagiographic shaping; details of relic movement and cult.
+- **What popular memory simplifies:** The saintly death can obscure his earlier political career, including ordinary princely rivalry and the complicated collapse of Rus politics under Mongol pressure. Conversely, a purely secular account can miss why the refusal mattered to medieval authors.
+- **Where Russian imperial appropriation appears:** Moscow's 1572 seizure/transfer of relics under Ivan IV folds a Chernihiv/Rus martyr into Muscovite sacred history. Modern phrasing should keep "Chernihiv" and "Rus" visible.
+- **Audit-contested items:** The **Pope Innocent IV** item belongs to Danylo Halytskyi unless a specific source proves otherwise for Mikhail; this dossier marks it as **UNVERIFIED / likely conflation with Danylo** and does not state it as fact. The "великий литовський князь" label is not used.
+- **Other-perspective considerations:** The Horde ritual may be described in Christian sources as "idolatry"; a historical lesson should explain that this is the source's religious language and avoid caricaturing steppe political ritual.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was checked against the on-disk plan listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml` — the BIO plan this dossier backfills.
+  - `curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml` — papal/Horde diplomacy contrast; do not conflate Innocent IV.
+  - `curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml` — Galician-Volhynian predecessor context.
+  - `curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml` — later Galician-Volhynian line.
+  - `curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml` — chronicle/source-history contrast.
+- **Existing HIST / OES plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/mykhailo-chernigivskyi.yaml` — HIST counterpart with alternate transliteration.
+  - `curriculum/l2-uk-en/plans/hist/mongolska-navala.yaml` — Mongol conquest frame.
+  - `curriculum/l2-uk-en/plans/hist/galytsko-volynska-derzhava.yaml` — post-Kyiv political order.
+  - `curriculum/l2-uk-en/plans/hist/danylo-halytskyi.yaml` — Danylo contrast.
+  - `curriculum/l2-uk-en/plans/oes/battle-of-kalka.yaml` — earlier Rus-Mongol encounter.
+  - `curriculum/l2-uk-en/plans/oes/olgovychi-monomakhovychi.yaml` — dynastic conflict background.
+  - `curriculum/l2-uk-en/plans/oes/pvl-polovtsian-wars.yaml` — steppe-frontier vocabulary.
+  - `curriculum/l2-uk-en/plans/oes/fall-of-kyiv.yaml` — 1240 crisis context.
+  - `curriculum/l2-uk-en/plans/oes/hagiography-intro.yaml` — genre frame for the Life.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A source comparison activity: chronicle entry versus hagiographic Life.
+  - A HIST note on relic transfer and Muscovite sacred appropriation.
+- **Potential LIT additions surfaced by this research:**
+  - Short adapted excerpt from the Life with a vocabulary box for martyrdom language.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-chernihivskyi`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykhailo Chernihivskyi / Michael of Chernihiv
+- **UA canonical:** Михайло Всеволодович Чернігівський
+- **Aliases (track these for `aliases:` YAML field):** Михайло Чернігівський; святий Михайло Чернігівський; Michael of Chernigov; Mikhail Vsevolodovich.
+- **Forbidden forms:** "великий литовський князь"; "appealed to Innocent IV" as fact; "Danylo's papal diplomacy" imported into Mikhail's biography.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Orthodox icon images of Saint Michael of Chernihiv and boyar Fedir on Wikimedia Commons, file-level PD/CC check required.
+- **Backup candidates:** manuscript/chronicle images tied to the Galician-Volhynian tradition; images of Chernihiv churches if rights-clear.
+- **If no PD/CC portrait exists:** use a neutral iconographic image and explicitly label it as later cult image, not life portrait.
+- **Era-appropriate context image:** map of Mongol invasion routes or Kyiv/Chernihiv after 1240; avoid sensational execution art.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України / ЕСУ materials on Михайло Всеволодович Чернігівський and Mongol-period Rus.
+- Войтович Л. princely genealogy corpus surfaced through `mcp__sources.search_sources`, including death date and offices.
+
+**Tier 2 (institutional):**
+- Church-historical and museum materials on Mikhail and Fedir's cult/relics, used only with source-critical caveats.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія, "Михайло Всеволодович"; used for navigation, not for contested claims.
+
+**Tier 4 (modern scholarly post-1991 and classic scholarship):**
+- *Історія української культури*, discussion of *Житіє Михайла Чернігівського* surfaced via `mcp__sources.search_literary`.
+- Kostruba's Ukrainian rendering of the Galician-Volhynian chronicle, surfaced in the project corpus.
+- Studies of Mongol overlordship and Rus princely politics after 1240.
+
+**Primary-source documents accessed / attested:**
+- *Житіє Михайла Чернігівського* (before 1271, as discussed in scholarship).
+- Galician-Volhynian chronicle tradition in Ukrainian translation.
+
+**Honest gaps:** exact birth details and some rulership chronology remain reconstruction; the quote translations were **not** matched by `verify_quote` and are therefore cited to specific corpus search results rather than claimed as verified quote-corpus hits.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Chernihiv/Rus identity not absorbed into Moscow.
+- [x] 1572 Ivan IV relic appropriation named.
+- [x] Innocent IV conflation blocked.
+- [x] No fringe Lithuanian-prince title.
+- [x] Hagiographic language identified as genre.
+- [x] No invented direct speech beyond sourced chronicle/hagiographic passages.

--- a/docs/research/bio/nestor-litopysets.md
+++ b/docs/research/bio/nestor-litopysets.md
@@ -1,0 +1,156 @@
+# Нестор Літописець — Research Dossier
+
+**Slug:** `nestor-litopysets`
+**Block:** K (Kyivan Rus / medieval textual memory)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** GPT-5.5 Codex
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] Source-criticism sequence included: Schlözer, Stroev, Bestuzhev-Ryumin, Shakhmatov
+- [x] Nestor's traditional role separated from attested manuscript/source history
+- [x] Primary quote verified through `mcp__sources.verify_quote`
+- [x] Cross-track paths verified against the plan directory
+- [x] Decolonization checklist self-applied
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Нестор Літописець; also Нестор, чернець Києво-Печерського монастиря.
+- **Pseudonyms / aliases:** Nestor the Chronicler; Nestor Pecherskyi; Nestor of the Kyiv Caves Monastery. Forbidden Russocentric pedagogical form: treating him as a "Russian chronicler" without explaining that the text belongs to Kyivan Rus and medieval Rus, not modern Russia.
+- **Born:** probably in the **1050s** | place not securely attested | Kyivan Rus. The dossier states the birth decade as uncertainty, not as a hard archival date.
+- **Died:** after the early twelfth century redactional activity traditionally linked to him, often placed around **1114** | Kyiv Caves Monastery tradition | exact date not securely attested.
+- **Family / education key facts:** Monk of the Kyiv Caves Monastery; associated with the Pechersk learned milieu. Traditionally credited as compiler of *Повість временних літ* (PVL), but modern source criticism treats PVL as a layered compilation/redaction rather than a single-author book. More securely associated with hagiographic works on Borys and Hlib and Theodosius of the Caves.
+
+The verified minimum is modest: Nestor is a monastic author/compiler known through the Pechersk tradition and medieval manuscript transmission. The traditional attribution "Nestor wrote the Primary Chronicle" is pedagogically useful only if immediately qualified: he is the traditional compiler/name attached to a textual tradition whose surviving forms are later copies and redactions.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a personal execution/exile dossier. The load-bearing issue is **imperial appropriation and source distortion**: the Kyivan chronicle tradition was absorbed into Russian imperial narratives as the origin story of "Russian" statehood, while the layered Kyiv/Rus textual setting was flattened.
+- **When:** the distortion begins in early modern Muscovite claims to Rus inheritance, becomes scholarly/systematic under imperial historiography in the eighteenth and nineteenth centuries, and continues in Soviet and post-Soviet "common cradle" language.
+- **By whom:** Russian imperial historiography, later Soviet historiography and modern Russian state narratives. Specific scholarly milestones are not all "oppression" in a police sense; some are legitimate source criticism. The dossier distinguishes method from appropriation.
+- **Document references:** The key historiographic sequence: August Ludwig von Schlözer in the eighteenth century treated the old chronicle heavily through the idea of Nestor's text; Pavel Stroev in **1820** argued that chronicles are compilations; Konstantin Bestuzhev-Ryumin in **1868** established the compilative character of chronicles in *О составѣ русскихъ лѣтописей*; Oleksiy Shakhmatov in the **1890s** advanced textual analysis and the theory of earlier svods including the "Начальний звід."
+- **Mechanism specifics:** A decolonized lesson cannot merely replace "Russian Primary Chronicle" with "Ukrainian Primary Chronicle." The correct move is historical precision: *Повість временних літ* is a Kyivan Rus chronicle compilation preserved in manuscript traditions, later claimed by imperial centers. Nestor matters as a memory-name and monastic author, while the text demands source criticism.
+- **What survived / what was destroyed:** Survived: chronicle copies, hagiographic attributions, Pechersk memory, later scholarly reconstructions. Lost: any autograph of Nestor, the exact earliest redaction, and certainty about which passages were his own hand.
+
+## 3. Major works
+
+- `late 11th c.` — *Читання про Бориса і Гліба*, hagiographic work traditionally attributed to Nestor; important for martyr-saint narrative and early Rus sanctity.
+- `late 11th c.` — *Житіє Феодосія Печерського*, monastic biography; central to the Kyiv Caves literary tradition and to the vocabulary of ascetic authority.
+- `early 12th c.` — *Повість временних літ*, chronicle compilation traditionally associated with Nestor; surviving manuscript tradition is later and redactional.
+- `1110s` — Pechersk redactional milieu continued by later editors, including the tradition that connects Sylvester's redaction with 1116. Use this as source-history context, not as Nestor biography.
+- `post-medieval` — Kyiv Caves Patericon memory of Nestor; important for reception but not direct evidence for every detail.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Quote 1 — verified PVL incipit / program:**
+
+> «откуду есть пошла Руская земля и хто в ней почалъ пЂрвЂе княжити»
+
+Tool status: `verify_quote(author="Нестор", text="откуду есть пошла Руская земля и хто в неи почалъ пЂрвЂе княжити")` returned **matched:true, best_confidence:1.0** in `wave12-pvl-yaremenko`, with additional matches in the Laurentian tradition. Pedagogically, this is the core question of the chronicle: origin, land and rulership. Teach "Руська земля" as medieval Rus, not modern Russia.
+
+**Quote 2 — manuscript-title attribution, with source-criticism caveat:**
+
+> «ПовЂсть временныхъ лЂтъ черноризца Федосьева манастыря Печерьскаго»
+
+This wording appears in the same verified line returned by the quote tool. It matters because it gives the traditional monastic framing, but it does not settle single authorship. The lesson should pair it with the nineteenth-century discovery that chronicles are compilations.
+
+**Quote 3 — what not to do:**
+
+Do not invent a modern slogan for Nestor such as "I wrote the history of Ukraine." The surviving voice is medieval, formulaic and redactional. When adapting for learners, quote the attested incipit or summarize the source-critical problem.
+
+## 5. Language register
+
+- **Register:** medieval Church Slavonic / Old East Slavic chronicle and hagiographic register; formulaic, biblical, dynastic and monastic.
+- **CEFR readiness for full reading:** original text C2; adapted Ukrainian narrative B1-B2; source-criticism discussion C1.
+- **Lexicon notes:** літопис, звід, редакція, чернець, Києво-Печерський монастир, Руська земля, княжити, агіографія, мученики, списки, Лаврентіївський / Іпатіївський літопис.
+- **Stylistic features:** annalistic year-by-year structure, genealogical explanations, biblical causality, moralized political narrative, direct speeches shaped by literary convention.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** Whether Nestor compiled the whole PVL, a portion of it, or represents a later attribution; how to reconstruct pre-PVL svods; where to place the Pechersk and Sylvester redactions; how to interpret "Руська земля" without retrojecting modern nations.
+- **Source-criticism sequence:** Schlözer in the eighteenth century helped fix the idea of a Nestor-centered old chronicle. Stroev in **1820** pushed back by arguing that chronicles were compilations. Bestuzhev-Ryumin in **1868** gave a major demonstration of the compilative character. Shakhmatov's **1890s** textual analysis then proposed deeper layers and earlier svods, moving the question from "which man wrote it?" to "which redactions and textual families can be reconstructed?"
+- **What popular memory simplifies:** "Nestor wrote the first history of Ukraine" is a useful classroom hook but inaccurate as a final statement. "Nestor wrote the Russian Primary Chronicle" is also inaccurate because it imports a modern imperial label into a medieval Kyivan/Rus source.
+- **Where modern Russian disinformation attacks or appropriates:** The PVL is frequently used to claim that Kyiv's medieval history naturally belongs to Moscow's state story. A careful dossier refuses that transfer. It also avoids a reverse anachronism: Nestor was not a modern Ukrainian nationalist; he was a Kyivan Rus monk writing in a medieval Christian political world.
+- **Other-perspective considerations:** Church tradition venerates Nestor as a saintly chronicler; philology treats the text as layered evidence. Both perspectives can be taught, but the second must govern factual claims.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was checked against the on-disk plan listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml` — the BIO plan this dossier backfills.
+  - `curriculum/l2-uk-en/plans/bio/kniaz-yaroslav-mudryi.yaml` — Kyivan Rus state and church culture.
+  - `curriculum/l2-uk-en/plans/bio/knyahynia-olha.yaml` — PVL narrative memory and conversion cycle.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-velykii.yaml` — baptism narrative and PVL state memory.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-monomakh.yaml` — later Rus textual/political memory.
+- **Existing HIST / OES plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kultura-kyivskoi-rusi.yaml` — cultural frame for chronicle production.
+  - `curriculum/l2-uk-en/plans/hist/sofiya-kyivska.yaml` — Kyivan sacred-political landscape.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kyivska-rus.yaml` — synthesis module for Rus.
+  - `curriculum/l2-uk-en/plans/hist/yaroslav-wise.yaml` — dynastic context.
+  - `curriculum/l2-uk-en/plans/oes/pvl-intro-geography.yaml` — PVL opening geography.
+  - `curriculum/l2-uk-en/plans/oes/pvl-yaroslav-wise.yaml` — Yaroslav material in PVL.
+  - `curriculum/l2-uk-en/plans/oes/pvl-baptism-of-rus.yaml` — baptism narrative.
+  - `curriculum/l2-uk-en/plans/oes/pvl-olga-revenge.yaml` — Olga cycle.
+  - `curriculum/l2-uk-en/plans/oes/pvl-varangians.yaml` — Varangian debate.
+  - `curriculum/l2-uk-en/plans/oes/pvl-three-brothers.yaml` — Kyiv foundation narrative.
+  - `curriculum/l2-uk-en/plans/oes/pvl-lyubech-congress.yaml` — later dynastic politics.
+  - `curriculum/l2-uk-en/plans/oes/monomakh-instruction.yaml` — adjacent medieval textual unit.
+  - `curriculum/l2-uk-en/plans/oes/hagiography-intro.yaml` — genre frame for Nestor's hagiographies.
+  - `curriculum/l2-uk-en/plans/oes/pateryk-literary-form.yaml` — Pechersk reception.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A source-criticism exercise on "author, compiler, redactor."
+  - A HIST note on imperial appropriation of Kyivan Rus sources.
+- **Potential LIT additions surfaced by this research:**
+  - A side-by-side adapted reading: PVL incipit, modern Ukrainian paraphrase and map of medieval Rus.
+
+## 8. Naming-canonical
+
+- **Slug:** `nestor-litopysets`
+- **EN canonical (BGN/PCGN-style project spelling):** Nestor Litopysets / Nestor the Chronicler
+- **UA canonical:** Нестор Літописець
+- **Aliases (track these for `aliases:` YAML field):** Нестор Печерський; Нестор, чернець Києво-Печерського монастиря; Nestor of the Caves; Nestor the Chronicler.
+- **Forbidden forms:** "Russian chronicler" as an unqualified identity; "author of all of the Primary Chronicle" as settled fact; "ancient Russian history" for Kyivan Rus without explanation.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** icons of Saint Nestor the Chronicler on Wikimedia Commons or monastery/museum sources, with file-level license check.
+- **Backup candidates:** manuscript images from the Laurentian or Hypatian chronicle traditions if rights-clear; Kyiv Caves Lavra images if license permits.
+- **If no PD/CC portrait exists:** use a manuscript folio or Kyiv Caves context image rather than a modern fantasy portrait.
+- **Era-appropriate context image:** PVL manuscript opening / facsimile, map of Kyivan Rus, or Pechersk monastic context.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України / ЕСУ entries on Nestor and *Повість временних літ*; used as authoritative biographical and textual-history anchors.
+- *Історія української літератури* and Hrushevsky corpus surfaced through `mcp__sources.search_sources`; used for the source-criticism sequence.
+
+**Tier 2 (institutional):**
+- Kyiv Caves / church-historical institutional materials for veneration and iconography, used only after separating tradition from textual proof.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія entries on Нестор Літописець and *Повість временних літ*, used for navigation and cross-checking.
+
+**Tier 4 (modern scholarly post-1991 and classic philology):**
+- Шахматов О. textual studies of PVL and earlier svods.
+- Bestuzhev-Ryumin K. *О составѣ русскихъ лѣтописей* (1868), cited for the compilative-character milestone.
+- Studies of Kyivan Rus chronicle transmission and the Pechersk hagiographic tradition.
+
+**Primary-source documents accessed:**
+- *Повість временних літ* in the project corpus (`wave12-pvl-yaremenko`; Laurentian tradition matches), verified by `mcp__sources.verify_quote`.
+- Pechersk hagiographic works attributed to Nestor: *Читання про Бориса і Гліба* and *Житіє Феодосія Печерського*.
+
+**Honest gaps:** no autograph, no exact birth/death date, no definitive proof that Nestor authored every PVL section. The dossier teaches him as a traditional compiler and monastic author inside a layered textual tradition.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Kyivan Rus is not collapsed into modern Russia.
+- [x] The medieval term "Руська земля" is explained, not mistranslated.
+- [x] No invented first-person slogans.
+- [x] Imperial/Soviet appropriation named without replacing source criticism with counter-myth.
+- [x] Modern Kyiv spelling used in English context.
+- [x] Tradition and attestation are explicitly separated.

--- a/docs/research/bio/roksolana.md
+++ b/docs/research/bio/roksolana.md
@@ -1,0 +1,155 @@
+# Хасекі Хюррем-султан (Роксолана) — Research Dossier
+
+**Slug:** `roksolana`
+**Block:** K (early-modern / Ottoman court; captivity, diplomacy, literary myth)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** GPT-5.5 Codex
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2/Tier 4 sources cited, with uk.wikipedia used only as T3 navigation
+- [x] Oppression mechanism specific: Crimean-Tatar/Ottoman slave-raiding system and later gendered mythmaking separated from state martyrdom
+- [x] Quote section follows anti-fabrication rule: no invented sentimental letter text; failed `verify_quote` result recorded
+- [x] Cross-track links list only on-disk plan YAMLs as Existing
+- [x] Naming-canonical applied, including forbidden overconfident birth-name form
+- [x] Decolonization checklist self-applied
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Хасекі Хюррем-султан; in Ukrainian cultural memory, **Роксолана**. Her Ottoman court name is documented; the Ukrainian birth-name **«Настя/Анастасія Лісовська» is not documented as a contemporary fact** and must be treated as late literary/national attribution, especially through Ukrainian historical fiction.
+- **Pseudonyms / aliases:** Hürrem Sultan, Hurrem, Khurrem, Haseki Hürrem Sultan, Roxelana, Roxelane, La Rossa / Rosselane in some European traditions, Roksolana. Forbidden as asserted fact in body text: "Анастасія Гаврилівна Лісовська" unless explicitly marked as tradition/literary attribution.
+- **Born:** usually placed around **1500-1506** | probably in the Ruthenian/Ukrainian lands of the Polish-Lithuanian borderland, with Rohatyn appearing in Ukrainian tradition | documented birthplace and birth family are not securely attested.
+- **Died:** **15 April 1558** | Istanbul | Ottoman Empire | buried in the Hürrem Sultan türbe beside the Süleymaniye complex. Some popular retellings use 18 April; the dossier uses 15 April because it is the common scholarly date in modern Ottoman biographical literature.
+- **Family / education key facts:** Concubine, then legally married wife, of Sultan Suleiman I. Mother of Şehzade Mehmed, Mihrimah Sultan, Selim II, Şehzade Bayezid and Şehzade Cihangir; usually also linked to other short-lived children in Ottoman genealogical lists. She became **haseki sultan**, an unprecedentedly powerful consort role, and exercised court patronage, charitable foundation-building and diplomatic correspondence.
+
+The source record is asymmetrical. Ottoman and European documentation strongly attest her court status, children, patronage, diplomatic letters and death. Her capture story and Ukrainian origin are supported by near-contemporary European labels such as "Roksolana" and by later reports that she came from the lands of Rus, but the exact village, birth name and priest's-daughter story are **not** of the same evidentiary order. The pedagogical line is therefore: "Roksolana was almost certainly a woman from the Ruthenian/Ukrainian borderland who became Hürrem Sultan; she was not securely documented as Anastasiia Lisovska."
+
+## 2. Oppression mechanism
+
+- **What happened:** Forced displacement through the Black Sea slave-raiding and slave-market system, followed by incorporation into the Ottoman palace household. This is not a modern political arrest file; it is early-modern captivity, enslavement, conversion/renaming and court assimilation.
+- **When (specific dates):** capture is not directly dated. The plausible window is before her appearance in Suleiman's household in the 1520s; her children begin appearing in the 1520s. Her death is dated 15 April 1558. The death of Şehzade Mustafa, often folded into hostile legends about Hürrem, occurred **6 October 1553 near Ereğli** and must not be moved or generalized.
+- **By whom:** Crimean Tatar slave-raiding networks and the Ottoman imperial household market/order. The responsible mechanism is not Russian or Soviet; the later distortion mechanism is European Orientalist and patriarchal historiography, plus modern nationalist simplification.
+- **Document references:** No personal captivity file survives. The relevant documentary bodies are Ottoman palace records, waqf documents for her charitable foundations, Topkapı correspondence, and European diplomatic reports by observers such as Ogier Ghiselin de Busbecq and Venetian envoys.
+- **Mechanism specifics:** The Black Sea steppe-border slave trade made women and children from Ukrainian/Ruthenian lands vulnerable to raids, sale through Crimea and movement into Istanbul. A palace enslaved woman could gain education, proximity and power, but that power did not erase the initial coercion. Hürrem's career is therefore neither a romance of "a Ukrainian girl conquering the East" nor a simple victim biography. It shows how an enslaving imperial system could transform a captive into a dynastic actor while preserving the violence of origin.
+
+Later oppression is interpretive. European and Ottoman male writers explained an unprecedented female political presence through tropes of seduction, witchcraft and intrigue. Ukrainian memory then sometimes reversed the trope into a triumphalist national myth: "our Roksolana ruled the Ottoman Empire." Both frames flatten the record. The dossier should teach the court politics of the haseki institution, the patronage record and the limits of evidence for origin. It should also warn writers not to make her the sole cause of Mustafa's execution. Mustafa was executed near Ereğli on 6 October 1553 by order of Suleiman after a succession crisis; Hürrem and Rüstem Pasha were implicated by hostile and later narratives, but sole-cause blame is not a verified fact.
+
+- **What survived / what was destroyed:** Survived: letters attributed to Hürrem, waqf and architectural records, European diplomatic testimony, tomb and charitable complexes. Lost or never documented: birth record, pre-captivity name, family identity, a first-person account of capture.
+
+## 3. Major works
+
+- `1520s-1550s` — **Letters to Sultan Suleiman I**, Ottoman Turkish court correspondence, preserved in Topkapı-related corpora and discussed by modern Ottoman historians. They matter because they show literacy, intimacy, patronage requests and political communication, not merely harem legend.
+- `1548-1549` — **Correspondence with Sigismund II Augustus of Poland-Lithuania**, diplomatic letter exchange after the death of Sigismund I and the accession of Sigismund II. This matters for Polish-Ottoman diplomacy and for the borderland context from which "Roksolana" memory later grew.
+- `1550s` — **Diplomatic communication connected to Safavid relations**, including correspondence with women of the Safavid court reported in modern scholarship. Treat as high-court diplomacy, not as sentimental anecdote.
+- `1530s-1550s` — **Haseki Sultan Complex in Istanbul**, charitable/architectural foundation including mosque, school, hospital and soup kitchen functions in the Avret Pazarı area. It is a material primary source for her patronage.
+- `1550s` — **Jerusalem waqf / Haseki Sultan imaret**, a major charitable kitchen and foundation. It situates her beyond the palace, in imperial Islamic philanthropy.
+- `1550s` — **Charitable endowments in Mecca and Medina**, part of the sacred-geography patronage expected of the Ottoman imperial household.
+- `1558+` — **Hürrem Sultan tomb at Süleymaniye**, posthumous dynastic memorial within Suleiman's monumental complex.
+- `1980` — Павло Загребельний, *Роксолана*, historical novel. Not a primary source for the sixteenth century, but crucial for Ukrainian cultural memory and for the literary attribution of "Анастасія Лісовська."
+
+## 4. Primary-source quotes (≥2 required)
+
+**Anti-fabrication note:** This dossier does **not** quote any sentimental Ukrainian text as Hürrem's own words. A tool check for a common paraphrase returned `matched:false`, so it is not used as a quote. Her letters exist, but this pass did not open a published Ottoman-text edition with page references; therefore the dossier uses primary-source **documentary expressions** and source attestations rather than inventing polished Ukrainian translations.
+
+**Primary expression 1 — European name attestation, not her own speech:**
+
+The diplomatic label **"Roksolana/Roxelana"** is a European witness-name, linking her to the old ethnonym for Ruthenian lands. It is pedagogically useful because it explains why the Ukrainian curriculum uses `roksolana` while the Ottoman canonical name is Hürrem Sultan. Use it as an exonym, not as proof of a modern nation-state identity.
+
+**Primary expression 2 — Venetian report of origin, not her own speech:**
+
+A Venetian formulation reported in the source corpus calls her **"Sultana, ch'è di Rusi"**. This phrase is not her self-description; it is an external report that she was "of Rus." It can support a cautious Ruthenian/Ukrainian-origin discussion, but it cannot support the invented certainty "Rohatyn priest's daughter Anastasiia Lisovska."
+
+**Primary expression 3 — letters as documents, not free paraphrase:**
+
+The letters to Suleiman and Sigismund II Augustus should be summarized from a published edition or specialist translation when lesson writers use them. Do **not** modernize them into phrases such as "мій султане, моя душе" without page-level verification. The research pass explicitly tested one such Ukrainian sentimental rendering and found no match in the project quote corpus.
+
+## 5. Language register
+
+- **Register:** Ottoman court and diplomatic register, mediated into Ukrainian through historical scholarship; Ukrainian cultural memory adds high-romantic historical-fiction language.
+- **CEFR readiness for full reading:** biographical prose B1-B2; court politics and succession debate C1; original Ottoman correspondence C2 and not suitable without adaptation.
+- **Lexicon notes:** гарем, хасекі, вакф, султанат жінок, яничари, спадкоємець, дипломатичне листування, легенда, атрибуція, невільництво, Кримський ханат. Gloss **haseki** as a specific consort title, not a generic "wife."
+- **Stylistic features:** The curriculum must distinguish three registers: Ottoman administrative/pious patronage language, European diplomatic rumor language, and Ukrainian historical-novel lyricization. Mixing them produces fabrication.
+
+## 6. Contested points
+
+- **What's debated in modern scholarship:** the precise birthplace and birth name; the degree of her political influence on succession decisions; the meaning of the "Sultanate of Women" label; how much agency a formerly enslaved palace woman could exercise inside an imperial household structure.
+- **What popular memory simplifies:** Ukrainian memory often turns her into "Настя Лісовська з Рогатина" as if that were an archival fact. It is safer to say that this name is a literary/national attribution, especially reinforced by Zagrebelnyi and public memory in Rohatyn. Turkish popular memory often frames her through television melodrama, while older European memory casts her as a scheming temptress. None of these is sufficient as evidence.
+- **Where disinformation or hostile framing appears:** Russian-imperial framing tends to absorb "Ruthenian/Rus" into "Russian" identity, especially in English phrases like "Russian concubine." That is an anachronism. Conversely, a Ukrainian lesson should not overcorrect by claiming a documented modern Ukrainian passport-like identity. The decolonized NPOV form is "a woman from the Ruthenian/Ukrainian lands, remembered in Ukraine as Roksolana."
+- **Other-perspective considerations:** Ottoman/Turkish historiography centers dynasty, palace hierarchy and waqf patronage; Polish-Lithuanian context centers border diplomacy and captive-taking; Ukrainian context centers loss, survival and national memory. All three must remain visible. The execution of Mustafa on 6 October 1553 near Ereğli belongs to Ottoman succession politics and must not be presented as a Ukrainian-origin morality tale.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was checked against the on-disk plan listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/roksolana.yaml` — the BIO plan this dossier backfills.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — later Ukrainian-Ottoman-Crimean diplomacy context.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — another figure heavily mythologized in imperial and European memory.
+  - `curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml` — Ukrainian women in international cultural memory, useful for contrast.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — early-modern frontier and Ottoman/Cossack contact zone.
+- **Existing HIST / LIT-HIST-FIC plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/zahrebelny-roksolana-1.yaml` — the literary-myth module that must hedge the birth-name attribution.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/zahrebelny-roksolana-2.yaml` — continuation of the same historical-fiction treatment.
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml` — later diplomacy with the Ottoman/Crimean world.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-kultura.yaml` — steppe-frontier context for later periods.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A HIST/OES module on the **Black Sea slave trade and Crimean raids** with careful agency language.
+  - A comparative LIT module on **Roksolana in Zagrebelnyi versus Ottoman archival Hürrem**.
+  - A media-literacy note on *Muhteşem Yüzyıl* and gendered court-intrigue tropes.
+- **Potential LIT additions surfaced by this research:**
+  - A short source-criticism activity: "Which claims are documented Ottoman history, and which are Ukrainian literary memory?"
+
+## 8. Naming-canonical
+
+- **Slug:** `roksolana`
+- **EN canonical (BGN/PCGN-style project spelling):** Roksolana / Hürrem Sultan
+- **UA canonical:** Хасекі Хюррем-султан (Роксолана)
+- **Aliases (track these for `aliases:` YAML field):** Hürrem Sultan; Hurrem Sultan; Khurrem; Roxelana; Roxelane; Roksolana; La Rossa; "Настя Лісовська" and "Анастасія Лісовська" as literary/traditional aliases only.
+- **Forbidden forms:** "Анастасія Гаврилівна Лісовська" as unqualified archival fact; "Russian Roxelana" as identity claim; "Roxolana caused Mustafa's death" as simplified blame.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons portraits of Roxelana/Hürrem Sultan, especially early-modern European engravings labelled Roxelana. Use only a file page with explicit PD-old or equivalent license.
+- **Backup candidates:** photographs of the Hürrem Sultan türbe at Süleymaniye; Haseki Sultan complex images; Jerusalem Haseki Sultan imaret images if rights clear.
+- **If no PD/CC portrait exists:** use an architectural/patronage image rather than a modern television still. A waqf/building image better communicates the documented record.
+- **Era-appropriate context image:** map or image of the Black Sea slave-route context; Ottoman palace/Topkapı archive context; do not use dark stock "harem" imagery.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Internet Encyclopedia of Ukraine* / encyclopedic references on Roksolana and the Ruthenian-origin tradition; used for identity framing and cross-checking against popular claims.
+- Ottoman archival/documentary tradition: Topkapı correspondence and waqf/endowment records as discussed in modern scholarship.
+
+**Tier 2 (institutional):**
+- Turkish and Ukrainian museum/heritage materials on Hürrem Sultan's tomb, Haseki complex and Rohatyn memory, used only for material-culture leads.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія, "Роксолана" / "Хюррем Султан" article data surfaced via `mcp__sources.search_sources`; used for navigation and for the audit anchor that Mustafa was executed **6 October 1553 near Ereğli**, not as sole authority.
+
+**Tier 4 (modern scholarly post-1991):**
+- Peirce, Leslie. *The Imperial Harem: Women and Sovereignty in the Ottoman Empire.* Oxford University Press, 1993.
+- Peirce, Leslie. *Empress of the East: How a European Slave Girl Became Queen of the Ottoman Empire.* Basic Books, 2017.
+- Şahin, Kaya. *Peerless among Princes: The Life and Times of Sultan Süleyman.* Oxford University Press, 2023.
+- Ukrainian studies of Pavlo Zagrebelnyi's *Роксолана* for literary reception, not sixteenth-century fact.
+
+**Tier 5 (general web):**
+- Wikimedia Commons file pages for images only after license review.
+
+**Primary-source documents accessed / attested:**
+- Hürrem's letters to Suleiman I and Sigismund II Augustus; waqf documents for the Haseki Sultan complex and Jerusalem imaret; European diplomatic reports by Busbecq and Venetian envoys. Verbatim letter quotations were **not** used because this pass did not retrieve page-level published transcriptions.
+
+**Honest gaps:** no contemporary birth record; no verified pre-captivity name; no tool-verified Ukrainian translation of her letters in the project quote corpus. The dossier intentionally refuses the invented tidy line "Настя Лісовська from Rohatyn" as fact.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing: "Rus/Ruthenian" is not collapsed into modern Russia.
+- [x] No Russian-imperial transliterations in body text except explicitly forbidden forms in §8.
+- [x] No anachronistic modern nation-state identity claim.
+- [x] No misogynistic "schemer" frame used as explanation.
+- [x] No fabricated direct quote from letters.
+- [x] Crimean/Ottoman slavery is named without turning the dossier into nationalist romance.
+- [x] Modern Ukrainian place naming used where relevant; Ottoman names preserved for Ottoman institutions.

--- a/docs/research/bio/yuriy-nemyrych.md
+++ b/docs/research/bio/yuriy-nemyrych.md
@@ -1,0 +1,155 @@
+# Юрій Немирич — Research Dossier
+
+**Slug:** `yuriy-nemyrych`
+**Block:** K (Cossack-era statesman; Socinian thinker; Hadiach project)
+**Tier:** 1b
+**Issue:** #2535 (bio dossier uplift, original-180 ghost-wiki backfill — Wave I)
+**Researcher:** GPT-5.5 Codex
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] Audit anchors included: Raków/Socinianism, *Discursus de bello Moscovitico*, Hadiach 16.09.1658, killed 1659
+- [x] NPOV maintained: Socinian repression, Cossack state project and Ruin-era violence all named
+- [x] Cross-track paths verified against plan directory
+- [x] Decolonization checklist self-applied
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Немирич.
+- **Pseudonyms / aliases:** Jerzy Niemirycz in Polish-language scholarship; Iurii/Yurii Nemyrych; Юрій Немирич. Forbidden simplification: calling him only a "Polish magnate" or only a "Cossack patriot" without his Ruthenian noble/Socinian/Commonwealth context.
+- **Born:** **1612** | Ovruch/Kyiv-Volhynian noble milieu, commonly linked to the family estates of Cherniakhiv and the Kyiv region | Polish-Lithuanian Commonwealth.
+- **Died:** **1659** | in the anti-Vyhovsky civil-war violence of the Ruin period, traditionally near Left-Bank conflict zones | killed by opponents of the Hadiach/Vyhovsky line. Exact battlefield/local details vary in summaries and should be checked before a lesson narrows them.
+- **Family / education key facts:** Ruthenian noble of the Arian/Socinian milieu; studied at the **Raków Academy** and in several Western European centers. Author of *Discursus de bello Moscovitico* (Paris, 1632). During Hetman Ivan Vyhovsky's rule he became one of the main architects of the Union of Hadiach, signed **16 September 1658**, which proposed the Grand Duchy of Rus as a third Commonwealth member.
+
+The verified portrait is unusually complex: a European-educated Socinian noble, a Commonwealth political writer, a Cossack-state diplomat and a casualty of the failure to build a federated Ruthenian alternative to Moscow and Warsaw.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a single police persecution file. Three mechanisms matter: Socinian religious repression in the Commonwealth; Muscovite expansion after Pereiaslav; and violent internal civil conflict around the Hadiach project.
+- **When:** Socinian repression intensifies in the 1630s-1650s and culminates in the Sejm's anti-Arian/Socinian measures in **1658**. The Hadiach Union was signed **16 September 1658**. Nemyrych was killed in **1659**, during the collapse of Vyhovsky's political line.
+- **By whom:** Commonwealth Catholic/confessional authorities against Socinians; Muscovite state power as the enemy named in *Discursus de bello Moscovitico* and in Cossack diplomatic rupture; anti-Vyhovsky rebels and local forces in the Ruin violence that killed him.
+- **Document references:** *Discursus de bello Moscovitico* (Paris, 1632); the **Commission/Union of Hadiach** text dated 16 September 1658; the **Manifestation in the name of the Zaporozhian Host to foreign rulers** of October 1658, listed in the project source collection.
+- **Mechanism specifics:** Nemyrych's career sits at a hinge. As a Socinian he belonged to a confession increasingly treated as intolerable by the Commonwealth. As a Ruthenian magnate he could imagine a federated solution: the Grand Duchy of Rus inside a reformed Commonwealth. As a Vyhovsky ally he opposed Muscovite domination after the Cossack-Moscow alliance turned coercive. His death in 1659 shows the political cost: the Hadiach project lacked enough social and military consensus to survive.
+- **What survived / what was destroyed:** Survived: his Latin political treatise, Hadiach constitutional language, later historiography by Dmytro Doroshenko and Viacheslav Lypynskyi. Destroyed: the practical chance for a durable Grand Duchy of Rus in 1658-1659; much of the Socinian Ukrainian/Commonwealth milieu.
+
+## 3. Major works
+
+- `1632` — *Discursus de bello Moscovitico* (Paris), Latin political treatise on the Muscovite war; important for anti-Muscovite political thought and European education.
+- `1640s` — **Socinian patronage on Left-Bank estates**, including settlement and school/ministerial support in the Vorskla/Orel region as discussed in cultural-history scholarship.
+- `1658` — **Diplomatic role under Ivan Vyhovsky**, entry into Cossack-state high politics.
+- `16 September 1658` — **Union of Hadiach / Commission of Hadiach**, constitutional project creating the Grand Duchy of Rus; Dmytro Doroshenko identifies Nemyrych as principal author/architect.
+- `October 1658` — **Manifestation to foreign rulers in the name of the Zaporozhian Host**, explaining the rupture with Moscow; listed in the project source corpus.
+- `posthumous` — **Lypynskyi's *Україна на переломі*** and Doroshenko's histories, which made Nemyrych a key figure in conservative/federalist readings of the Cossack state.
+
+## 4. Primary-source quotes (≥2 required)
+
+**Anti-fabrication note:** The dossier uses verified document titles and constitutional language surfaced in the project source corpus. It does not invent a Ukrainian translation of Nemyrych's Latin prose.
+
+**Primary expression 1 — title of his early treatise:**
+
+> *Discursus de bello Moscovitico* (Paris, 1632)
+
+The title itself is a primary-source anchor: Nemyrych framed Muscovy as a war/political problem in a Latin European discourse. Pedagogically, it connects seventeenth-century Ukraine to Europe-wide political Latin, not to a provincial border story.
+
+**Primary expression 2 — Hadiach constitutional formula:**
+
+> «Велике Князівство Руське»
+
+This is the key political formula of the Hadiach project. Use it as a constitutional term, not as a later nationalist slogan. It captures the federal idea: the Ruthenian polity as a third member alongside Poland and Lithuania.
+
+**Primary expression 3 — source-collection title of the Manifestation:**
+
+> «Маніфестація від імені війська Запорозького до іноземних володарів, що пояснює причини розриву з Москвою»
+
+The project corpus lists this October 1658 text. It gives lesson writers a safe documentary phrase for the post-Pereiaslav rupture. Before quoting its body, use a page-level edition.
+
+## 5. Language register
+
+- **Register:** Latin humanist-political prose; Ruthenian/Commonwealth constitutional vocabulary; Cossack diplomatic register.
+- **CEFR readiness for full reading:** adapted biography B2; Hadiach political clauses C1; Latin treatise C2.
+- **Lexicon notes:** социніанин, аріянин, Раківська академія, Гадяцька унія, Велике Князівство Руське, маніфестація, федерація, Річ Посполита, Військо Запорозьке, розрив із Москвою.
+- **Stylistic features:** legal-constitutional precision, confessional vocabulary and Latin argumentation. Learners need a glossary before reading even adapted primary text.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** whether Hadiach was a realistic federal alternative or an elite project without enough Cossack/social support; how to weigh Nemyrych's Socinian identity against his later Cossack-state service; whether to call him the principal author, architect or one of several authors of Hadiach. This dossier follows Dmytro Doroshenko's strong attribution while keeping the collaborative diplomatic setting visible.
+- **What popular memory simplifies:** Nemyrych can be made into a perfect constitutional hero. That hides his noble-estate interests, Socinian minority position and the fact that many Cossacks and common people did not trust the return to a Commonwealth framework. The opposite simplification calls him a Polish aristocrat alien to Ukraine; that erases his Ruthenian political project and the Grand Duchy of Rus clause.
+- **Where modern Russian disinformation attacks or appropriates:** Moscow-centered narratives depict the 1654-1659 rupture as betrayal of "reunification." Nemyrych's documents show a different frame: Moscow as a coercive power and Hadiach as an attempted negotiated alternative. The curriculum should name "Muscovy/Moscow" for the seventeenth century and avoid projecting the modern Russian Federation backward, while also refusing the imperial "reunification" premise.
+- **Polish / Jewish / other-perspective considerations:** Polish republican tradition can read Hadiach as belated Commonwealth reform; Ukrainian Cossack memory reads it through the failure to secure autonomy and social trust; Socinian history sees Nemyrych inside a persecuted religious minority. Lessons should make room for all three.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was checked against the on-disk plan listing on 2026-06-04 and is re-validated by `scripts/audit/lint_bio_dossier_xref.py`.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — the BIO plan this dossier backfills.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — hetman under whom Hadiach was negotiated.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — predecessor whose Pereiaslav settlement set up the later rupture.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — later constitutional tradition.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml` — later Cossack-state autonomy after the Ruin.
+- **Existing HIST / ISTORIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/yurii-nemyrych.yaml` — HIST counterpart with alternate transliteration.
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml` — Cossack revolution background.
+  - `curriculum/l2-uk-en/plans/hist/khmelnychchyna-prychyny.yaml` — causes of the uprising.
+  - `curriculum/l2-uk-en/plans/hist/syntez-khmelnychchyna.yaml` — synthesis unit.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — later partition outcome after Hadiach failed.
+  - `curriculum/l2-uk-en/plans/istorio/pereiaslav-alternatyvy.yaml` — alternatives to Pereiaslav, direct conceptual tie.
+  - `curriculum/l2-uk-en/plans/istorio/pereiaslav-tsykl.yaml` — source cycle.
+  - `curriculum/l2-uk-en/plans/istorio/universaly-khmelnytkoho.yaml` — Cossack documentary register.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated Hadiach Union module with clauses, maps and stakeholders.
+  - A Socinianism-in-Ukraine explainer.
+  - A Latin political-writing mini-lesson using *Discursus* title and context.
+- **Potential LIT additions surfaced by this research:**
+  - A source-reading unit on the 1658 Manifestation to foreign rulers.
+
+## 8. Naming-canonical
+
+- **Slug:** `yuriy-nemyrych`
+- **EN canonical (BGN/PCGN-style project spelling):** Yuriy Nemyrych
+- **UA canonical:** Юрій Немирич
+- **Aliases (track these for `aliases:` YAML field):** Jerzy Niemirycz; Iurii Nemyrych; Юрій Стефанович Немирич if patronymic used in source context.
+- **Forbidden forms:** "traitor to reunification"; "Polish magnate" as sole identity; "author of Hadiach" without noting the broader commission if the lesson requires precision.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Search Wikimedia Commons / Polish-Ukrainian historical collections for Jerzy Niemirycz portraits; file-level license needed.
+- **Backup candidates:** facsimile/title page of *Discursus de bello Moscovitico* if public-domain scan exists; Hadiach treaty manuscript/printed edition image if rights clear.
+- **If no PD/CC portrait exists:** use a document image (Hadiach text or title page) rather than a generic Cossack battlefield image.
+- **Era-appropriate context image:** map of the proposed Grand Duchy of Rus inside the Commonwealth.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія історії України / ЕСУ entries on Юрій Немирич and Гадяцька угода.
+- Project source corpus entries surfaced by `mcp__sources.search_sources` and `search_literary` for Hadiach, the Manifestation and Socinian context.
+
+**Tier 2 (institutional):**
+- Scholarly/institutional editions of Cossack-era source collections listing the Hadiach Commission text and the Manifestation.
+
+**Tier 3 (encyclopedic):**
+- Українська Вікіпедія, "Юрій Немирич"; used for navigation and cross-checking of dates/works.
+
+**Tier 4 (modern scholarly post-1991 and classic scholarship):**
+- Дорошенко Д. histories of the Cossack state, cited for the principal-author/architect attribution of Hadiach.
+- Липинський В. *Україна на переломі*, legitimate interpretive source for Nemyrych's state-project significance.
+- Modern studies of Socinianism/Arianism in the Commonwealth and Ukraine.
+
+**Primary-source documents accessed / attested:**
+- Nemyrych, *Discursus de bello Moscovitico* (Paris, 1632).
+- Commission/Union of Hadiach, 16 September 1658.
+- *Маніфестація від імені війська Запорозького до іноземних володарів...*, October 1658.
+
+**Honest gaps:** exact details of the 1659 killing location should be checked in a specialist biography before narrowing. No body text from the Latin *Discursus* was quoted without an opened edition.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] Uses Muscovy/Moscow for seventeenth-century antagonist where appropriate.
+- [x] Rejects "reunification" frame as imperial premise.
+- [x] Does not erase Polish/Commonwealth or Socinian contexts.
+- [x] Does not turn Nemyrych into a hagiographic constitutional saint.
+- [x] No invented translation from Latin.
+- [x] Place and political names kept period-appropriate.


### PR DESCRIPTION
Adds six sourced bio research dossiers for epic #2309 / audit #2535:

- roksolana — Hürrem Sultan / Roksolana
- nestor-litopysets — Nestor the Chronicler
- knyazhna-anna-yaroslavna — Anna of Kyiv, Queen of France
- mykhailo-chernihivskyi — Mykhailo of Chernihiv
- yuriy-nemyrych — Yuriy Nemyrych
- kostiantyn-ostrozky-elder — Kostiantyn Ivanovych Ostrozky

Validation run:
- .venv/bin/python scripts/audit/lint_bio_dossier_xref.py
- .venv/bin/python scripts/audit/check_dossier_wordcount.py --changed
- .venv/bin/python scripts/audit/lint_agent_trailer.py

NO auto-merge.