### PR TITLE
research(bio): 6 sourced dossiers — dissident/UPA/war-dead/statehood-women (#2535)

### DIFF
--- a/docs/research/bio/oleg-sentsov.md
+++ b/docs/research/bio/oleg-sentsov.md
@@ -1,0 +1,161 @@
+# Олег Геннадійович Сенцов — Research Dossier
+
+**Slug:** `oleg-sentsov`
+**Block:** F/J (contemporary Russian political prisoner; Crimean filmmaker; serving soldier — living person)
+**Tier:** 1b
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — liberation-struggle/statehood wave)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+> **Living-person note (read first).** Олег Сенцов is alive and serving in the Armed Forces of Ukraine as of 2026. This dossier follows living-person NPOV: it states the Russian charge and the international human-rights verdict side by side, records his prison record factually, and reports his military service without glorification. It does not speak for him about contested matters; where his own words are quoted, they are his.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ВУЕ; Shevchenko Prize Committee; European Parliament Sakharov Prize)
+- [x] Oppression mechanism is specific (dated FSB detention, named court/judge, charge articles, hunger-strike length)
+- [x] ≥2 primary-source quotes (hunger-strike declaration; strike-ending statement — provenance flagged)
+- [x] Cross-track links: every "Existing" path verified against `origin/main` plan inventory on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олег Геннадійович Сенцов. [T1: ВУЕ — «Сенцов, Олег Геннадійович»; T3: uk.wikipedia — «Сенцов Олег Геннадійович»]
+- **Pseudonyms / aliases:** military call-sign («позивний») **«Ґрунт»**. No literary pseudonym. [T3: uk.wikipedia]
+- **Born:** 13 July 1976 | Сімферополь, Кримська область | Українська РСР, СРСР. (Note: born under the USSR; a Ukrainian citizen who never applied to change citizenship — central to the legal facts of §2.) [T1: ВУЕ; T3: uk.wikipedia; cross-checked T2: Shevchenko Prize Committee — knpu.gov.ua]
+- **Died:** N/A — **living** as of 2026.
+- **Family / education key facts:** Studied at the Kyiv National Economic University (1993–1998). Co-founded the film company «Край Кінема» in 2008. His relative **Наталя Каплан** (described in sources as his двоюрідна сестра / cousin) became the chief public advocate for his case during imprisonment; his mother appealed to the Russian president for clemency. He has children, a fact that featured in the public argument over his hunger strike. [T3: uk.wikipedia — §«Справа Сенцова»]
+
+Each load-bearing fact (birth, detention, sentence, release) is cross-checked across ВУЕ (T1), the Shevchenko Prize Committee (T2) and uk.wikipedia (T3); these agree on 13.07.1976, 10.05.2014 detention, 25.08.2015 sentence, and 07.09.2019 release.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Sentsov's persecution is a textbook case of Russian extraterritorial repression of a Ukrainian citizen following the 2014 occupation of Crimea.
+
+- **What happened:** abduction/arrest, a fabricated «terrorism» prosecution, a 20-year strict-regime sentence in Russia, and a 145-day hunger strike — ended only by a 2019 prisoner exchange.
+- **By whom (specific agency):** the **ФСБ Росії** and Russian occupation security structures in Crimea; tried by a **Russian military court** (the Північно-Кавказький військовий окружний суд, Ростов-на-Дону), judge **Сергій Михайлюк**.
+- **When (specific dates):**
+  - **10 May 2014:** detained in Сімферополь together with **Геннадій Афанасьєв, Олексій Чірній and Олександр Кольченко**; charged with preparing a terrorist act (alleged arson of the offices of «Єдина Росія» and «Русская община Крыма», and an alleged plan to blow up the Lenin monument in Simferopol). Sentsov was then etaped to the Лефортово prison in Moscow.
+  - **21 July 2015:** trial opened in Ростов-на-Дону. Sentsov denied all guilt and called the case political and falsified; he insisted on his Ukrainian citizenship (he had never applied to change it — and Russia's own Federal Penitentiary Service documents, surfaced 24 June 2015, treated him as a Ukrainian citizen).
+  - **25 August 2015:** sentenced to **20 years in a strict-regime colony**, convicted of creating and leading a terrorist group, two terrorist acts, preparing a third, and weapons offences. On hearing the verdict he sang the Ukrainian anthem and shouted «Слава Україні!». Co-defendant **Кольченко** received 10 years.
+  - **14 May 2018 – 6 October 2018:** indefinite hunger strike (see §4), ended after **145 days** under threat of force-feeding; he had lost ~20 kg.
+  - **7 September 2019:** freed in a Russia–Ukraine prisoner exchange.
+- **Document references and the fabrication record (quoted, not paraphrased):** the prosecution rested on confessions later disavowed. On **17 August 2015** the witness **Геннадій Афанасьєв retracted his incriminating testimony in open court and stated he had given it under FSB torture**. On **12 July 2018** another case figure, **Микита Боркін**, told Громадське радіо that Sentsov «не віддавав у їхній групі жодних наказів щодо підпалів, і не мав до них відношення, а також виступав за ненасильницький спротив». The international human-rights centre **«Меморіал» recognised Sentsov and Kolchenko as political prisoners (3 August 2015)**. [T3: uk.wikipedia — §«Судовий процес»]
+- **What survived / what was destroyed:** his films and writing survive and grew under imprisonment — he wrote the prison diary and prose later published as «Хроніка одного голодування. 4 з половиною кроки» (§3). What the case attempted to destroy — the legitimacy of his Ukrainian citizenship and his civic resistance — was defeated by the international campaign (Sakharov Prize 2018, 78+ cities of solidarity actions, Nobel Peace Prize nomination) and the 2019 exchange.
+
+## 3. Major works
+
+- `2008` — *Чудовий день для рибки-бананки*, short film (study work). [T3: uk.wikipedia]
+- `2009` — *Ріг Бика* (Ріг бика), short film. [T3: uk.wikipedia]
+- `2012` — *Гамер*, debut feature (premiered at the Rotterdam IFF) — about teenage gamers; budget ~$20,000, cast of real gamers. Awarded at «Дух вогню». [T3: uk.wikipedia]
+- `2013–2021` — *Носоріг*, feature set in early-1990s criminal milieu; presented at the Odesa IFF 2013, interrupted by his arrest, completed after release; Netflix acquired rights (Feb 2022). [T3: uk.wikipedia]
+- `2015` — *Жизня* (stories), eight autobiographical short stories written before imprisonment, first published (Київ: Laurus); Ukrainian translation 2019 (Видавництво Старого Лева + Український ПЕН, transl. Сергій Осока). [T3: uk.wikipedia]
+- `2020` — *Хроніка одного голодування. 4 з половиною кроки*, two-volume bilingual edition (Видавництво Старого Лева, transl. Сергій Осока): the **145-day hunger-strike prison diary** (begun on the third day of the strike) and a collection of prose written in the Russian prison. [T1/T5: starylev.com.ua publisher page; T3: uk.wikipedia — «Хроніка одного голодування. 4 з половиною кроки»]
+- For «Гамер» and «Носоріг» he received the **Shevchenko National Prize (2016)** in absentia. [T2: Shevchenko Prize Committee — knpu.gov.ua]
+
+## 4. Primary-source quotes (≥2 required)
+
+> Sentsov's documentary voice is in his prison letters and diary, transmitted (in transcription) via his lawyer Дмитро Дінзе, his cousin Наталя Каплан, and Ukrainian/international media. Both quotes are flagged with provenance.
+
+**Quote 1 — the hunger-strike declaration, letter of 16 May 2018:**
+
+> «Я, Сенцов Олег, громадянин України, незаконно засуджений російським судом і перебуваю в колонії м. Лабитнангі, оголосив безстрокове голодування з 14 травня 2018 р. Єдиною умовою припинення є звільнення всіх українських політв'язнів, які знаходяться на території РФ. Разом та до кінця! Слава Україні!»
+
+The strike's single condition was the release of *all* Ukrainian political prisoners, not himself — a defining act of solidarity over self-interest. Pedagogically it anchors the theme of conscience and collective resistance. [Prison letter, 16.05.2018; attested via T3: uk.wikipedia transcription, transmitted by adv. Дінзе; flagged letter-provenance]
+
+**Quote 2 — ending the strike, statement of 5 October 2018:**
+
+> «145 днів боротьби, мінус 20 кг ваги, плюс підірваний організм, але мета так і не досягнута. Я вдячний всім, хто підтримував мене і прошу вибачення у тих, кого я підвів… Слава Україні!»
+
+Forced to stop before force-feeding, he names the cost and the unreached goal with stark honesty — refusing both self-pity and triumphalism. This unsentimental register is the keynote of his later prison diary. [Statement, 05.10.2018; attested via T3: uk.wikipedia transcription; flagged statement-provenance]
+
+**Honest gap (§4 + §10):** both quotations are reproduced from the uk.wikipedia transcription of his published letters, not from a direct read of the Видавництво Старого Лева edition this pass; the wording should be checked against «Хроніка одного голодування» before any learner-facing use.
+
+## 5. Language register
+
+- **Register:** Sentsov writes prose in **plain, colloquial, autobiographical Russian** (his first language as a Crimean), published in Ukrainian translation by **Сергій Осока**; the 2020 edition is deliberately **bilingual**. His prison letters are direct, terse, unliterary. His public register (court, anthem, slogans) is civic and defiant.
+- **CEFR readiness for full reading:** **B1–B2** for the translated short prose («Жизня», «4 з половиною кроки») — short, concrete, accessible; the case documents and the diary's prison context push full study to B2–C1.
+- **Lexicon notes (pre-teach):** політв'язень, голодування, обмін (полоненими), анексія, окупація, сфабрикована справа, штурмова рота, контузія, тероризм (as the *charge*, to be framed critically). The slogan «Слава Україні!» recurs and is a teaching point.
+- **Stylistic features:** documentary plainness; the diary's day-count form («145 днів»); irony and understatement.
+
+## 6. Contested points
+
+- **What's debated / where Russian disinformation attacks:** Russia convicted Sentsov as a **«terrorist»** and still asserts this. The honest counter-record: the alleged acts were arson of party-office premises with no casualties, reframed as «terrorism»; the central testimony was **recanted in court with a torture allegation** (Афанасьєв); a co-figure stated Sentsov gave no arson orders and favoured nonviolent resistance (Боркін); and **Memorial, the European Parliament, the UN, Amnesty International and the EU all treated the case as politically motivated and the imprisonment as illegal.** This dossier states the Russian charge and the human-rights verdict together, and does not present the Russian conviction as established fact.
+- **What gets simplified in popular memory:** Sentsov is sometimes reduced to the hunger strike alone, eclipsing the **filmmaker and writer** and the wider group convicted with him (Кольченко, Афанасьєв, Чірній). The hunger strike also did **not** achieve its stated goal at the time — an honesty his own statement insists on (§4).
+- **Language and identity (decolonisation point, handled honestly):** Sentsov is a **Russophone Crimean** who writes prose in Russian and became the global face of Ukrainian political imprisonment. This is not a contradiction to explain away but a teaching point: Ukrainian national identity and citizenship are **not reducible to language**, and the 2020 bilingual edition foregrounds exactly this. The decolonial reading is that Russia's «protecting Russian-speakers» pretext for occupying Crimea is refuted by a Russian-speaking Crimean who chose Ukraine.
+- **Living-person caution:** he is a serving officer (§1, §7). His ongoing military role and any future statements are outside this dossier's settled-fact scope and must be re-verified before use.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the `origin/main` plan inventory (`git ls-tree -r origin/main curriculum/l2-uk-en/plans/`) on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/oleg-sentsov.yaml` — his own plan (this dossier is its research base).
+  - `curriculum/l2-uk-en/plans/bio/hennadii-afanasiev.yaml` — co-defendant who recanted his testimony alleging FSB torture.
+  - `curriculum/l2-uk-en/plans/bio/stanislav-asieiev.yaml` — fellow writer and Russian-captivity survivor.
+  - `curriculum/l2-uk-en/plans/bio/vladyslav-yesypenko.yaml` — Crimean journalist imprisoned by Russia (parallel Crimea case).
+  - `curriculum/l2-uk-en/plans/bio/mustafa-dzhemiliev.yaml` and `curriculum/l2-uk-en/plans/bio/nariman-dzhelial.yaml` — Crimean Tatar leaders persecuted after the 2014 occupation (the wider Crimea repression frame).
+  - `curriculum/l2-uk-en/plans/bio/oleksandra-matviichuk.yaml` — Center for Civil Liberties / Ukrainian PEN, central to the political-prisoner advocacy.
+  - `curriculum/l2-uk-en/plans/bio/serhiy-zhadan.yaml` and `curriculum/l2-uk-en/plans/bio/oksana-zabuzhko.yaml` — among the Ukrainian writers who campaigned for his release.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/aneksiia-krymu.yaml` — the 2014 occupation of Crimea that produced his case.
+  - `curriculum/l2-uk-en/plans/hist/krymski-tatary-pislia-2014.yaml` — the parallel post-2014 Crimean repression.
+  - `curriculum/l2-uk-en/plans/hist/revoliutsiia-hidnosti.yaml` — the Euromaidan he joined (Automaidan).
+  - `curriculum/l2-uk-en/plans/hist/povnomasshtabne-vtorhnessnia.yaml` — the 2022 full-scale invasion he now fights in.
+  - `curriculum/l2-uk-en/plans/hist/mizhnarodna-pidtrymka.yaml` — the international solidarity campaign frame.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `oleksandr-kolchenko` (co-defendant) — no plan yet.
+  - A HIST/method module on **«в'язні Кремля» / Kremlin political prisoners** as a contemporary repression mechanism — no plan yet.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A FILM/LIT module on Sentsov's prison diary as a nonfiction genre.
+
+## 8. Naming-canonical
+
+- **Slug:** `oleg-sentsov`
+- **EN canonical (BGN/PCGN-style project spelling):** Oleh Sentsov (widely known internationally as **Oleg Sentsov** — the international-press spelling used in the slug and aliases).
+- **UA canonical (with patronymic):** Олег Геннадійович Сенцов
+- **Aliases to track (`aliases:` YAML field):** Oleg Sentsov (international press spelling); Oleh Sentsov; «Ґрунт» (call-sign).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** none beyond the shared Cyrillic; do **not** describe him as a «Russian» or «Soviet» director — he is a **Ukrainian** filmmaker. Russia's assertion of Russian citizenship over him is to be named as an imposition, never adopted.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **«Oleg Sentsov»** holds free-licensed photographs from the 2018–2019 campaign and the 2018 Sakharov Prize context; verify the license on each **file page**. [Commons category: `Oleg Sentsov`]
+- **Backup candidates:**
+  - European Parliament press photographs from the 2018 Sakharov Prize ceremony (12 December 2019) — verify EP reuse terms.
+  - #SaveOlegSentsov / FreeSentsov campaign visuals — verify rights; many are activist-made.
+- **Context image (use with care):** the cover of «Хроніка одного голодування. 4 з половиною кроки» (Видавництво Старого Лева) for §3; a #FreeSentsov solidarity-action photo for §2.
+- **If no rights-clear portrait clears review:** fall back to an EP-credited Sakharov ceremony photo with documented terms.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Велика українська енциклопедія* (ВУЕ). «Сенцов, Олег Геннадійович». https://vue.gov.ua. Accessed 2026-06-04. (Identity, dates, profession.)
+- European Parliament — Sakharov Prize for Freedom of Thought 2018 (laureate: Oleg Sentsov). (Institutional confirmation of the 2018 award.)
+
+**Tier 2 (institutional):**
+- Комітет з Національної премії України імені Тараса Шевченка. «Сенцов Олег Геннадійович». https://knpu.gov.ua/winners/sentsov-oleh-hennadijovych/. Accessed 2026-06-04. (Official confirmation of the 2016 Shevchenko Prize for «Гамер» and «Носоріг».)
+
+**Tier 3 (encyclopedic — freshly fetched 2026-06-04):**
+- Українська Вікіпедія. «Сенцов Олег Геннадійович». https://uk.wikipedia.org/wiki/Сенцов_Олег_Геннадійович — detailed source for the case chronology, the trial, the torture-recantation testimony, the hunger strike and its end, the exchange, and the military service. Used for navigation/chronology; identity dates cross-checked against ВУЕ and the Shevchenko Committee.
+- Українська Вікіпедія. «Хроніка одного голодування. 4 з половиною кроки».
+
+**Tier 5 (general web — corroborated):**
+- Видавництво Старого Лева (starylev.com.ua) — publisher pages for the 2020 two-volume edition (diary + prose), translator Сергій Осока, designer Іван Шкоропад. Corroborates §3 bibliographic detail.
+
+**Primary-source documents accessed (in transcription only):** Sentsov's prison letters of 16.05.2018 and 05.10.2018, accessed in transcription via uk.wikipedia; the Russian court verdict (25.08.2015) is described, not directly read.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Sentsov is named a Ukrainian filmmaker and citizen; Russia's citizenship claim over him is flagged as an imposition.
+- [x] No Russian-imperial transliterations in body text — §8 notes that he must not be called a «Russian» director.
+- [x] No Russocentric periodization — the 2014 occupation of Crimea is named as анексія/окупація, not a neutral «accession».
+- [x] No uncritical Soviet/Russian propaganda terms — «терорист»/«тероризм» appear only as the Russian *charge*, explicitly framed against the human-rights verdict (§2, §6).
+- [x] No "lost his life" euphemisms — N/A (living); his treatment is named as torture-tainted prosecution and illegal imprisonment.
+- [x] Modern UA place names — Сімферополь, Київ; Russian places of imprisonment (Лабитнангі, Ростов-на-Дону) named factually.
+- [N/A] Holodomor — not in his biographical arc.
+- [x] Russian aggression framing — Crimea 2014 and the 2022 full-scale invasion are named as Russian aggression; his case is the through-line.

--- a/docs/research/bio/olena-stepaniv.md
+++ b/docs/research/bio/olena-stepaniv.md
@@ -1,0 +1,160 @@
+# Олена Іванівна Степанів — Research Dossier
+
+**Slug:** `olena-stepaniv`
+**Block:** E/F (statehood-era woman; one of the world's first commissioned women officers; geographer; victim of Stalinist repression)
+**Tier:** 1b
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — liberation-struggle/statehood wave)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕСУ т.9; НТШ membership/publications; named T4 scholarship Шаблій/Вісьтак, Лазарович, Сварник)
+- [x] Oppression mechanism is specific (dated MGB arrest, charge articles, sentencing body, camp, labour, release)
+- [x] ≥2 primary-source quotes (1939 Вільде interview; 1944 refusal to emigrate — provenance flagged)
+- [x] Cross-track links: every "Existing" path verified against `origin/main` plan inventory on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олена Іванівна Степанів (married name Степанів-Дашкевич). [T1: ЕСУ, т. 9 — «Степанів Олена Іванівна» (авт. К. Науменко); T3: uk.wikipedia]
+- **Pseudonyms / aliases:** widely written of as **«Степанівна»** in WWI-era press and song; married surname Дашкевич. [T3: uk.wikipedia]
+- **Born:** 7 December 1892 | с. Вишнівчик, Перемишлянщина | Королівство Галичини та Володимирії, Австро-Угорщина | нині Львівська область. Daughter of the priest о. **Іван Степанів** (1846–1935) and **Марія-Мінодора** (1862–1943, née Ґінтейт-Кунцевич). [T1: ЕСУ; T3: uk.wikipedia]
+- **Died:** 11 July 1963 (aged 70) | Львів | Українська РСР, СРСР | **of cancer**, with health broken by the camps; buried 14 July at the Личаківський cemetery. [T3: uk.wikipedia]
+- **Identity claim (stated precisely):** **one of the first women in the world to be officially enrolled in military service with an officer's rank** — **хорунжа** of the Українські Січові Стрільці (УСС) and later **четарка** of the Українська Галицька Армія (УГА). This is the standard characterisation in Ukrainian scholarship and is stated here as such (a strong, widely-held claim), not as an unqualified world-record. [T1: ЕСУ; T3: uk.wikipedia; T4: Лазарович]
+- **Family / education key facts:** народна школа (1902); the Сестри Василіянки institute and the УПТ «Рідна школа» teachers' seminary (to 1912); co-founder of **Пласт** (1911); entered **Lviv University** in 1912 (history and geography), studying under the founder of Ukrainian geography, **Степан Рудницький**. Married the UNR-army officer **Роман Дашкевич** (1920–1926); their son **Ярослав Дашкевич** (1926–2010) became a major Ukrainian historian. PhD in philosophy, Vienna, 1921. [T1: ЕСУ; T3: uk.wikipedia]
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Stepaniv was repressed in turn by Austrian, Russian-imperial, Polish, and finally Soviet power; the **Stalinist imprisonment of 1950–1956 is the gravest and most specific**.
+
+- **What happened (primary — Soviet):** arrested, tried by a special board, and sentenced to a corrective-labour camp on fabricated "nationalist" charges.
+- **By whom (specific agency):** the **МДБ СРСР (MGB)**; sentenced by the **Особлива нарада при МДБ СРСР** (Special Council — an extrajudicial body).
+- **When (specific dates) and the charge:**
+  - **29–30 December 1949:** arrested (in the repression wave that followed the 24 October 1949 murder of Yaroslav Halan), charged with «державна зрада» (state treason) and «антирадянська діяльність».
+  - **The three charges (quoted, not paraphrased):** (1) keeping «націоналістичну профашистську літературу» — which **included «Слово о полку Ігоревім», «Повість временних літ» and the «Галицько-Волинський літопис»** (medieval Ukrainian classics branded as fascist literature — a grotesque detail of Soviet repression); (2) activity «як кадрової націоналістки», including alleged business meetings with the UPA commander **Roman Shukhevych**; (3) publishing an «антисовєтську статтю „За правильний підхід"» in an OUN journal. **She categorically denied charges (2) and (3).** The OUN article was in fact written by **Омелян Логуш** under the pseudonym «Степанів» — a false attribution used to imprison her. [T3: uk.wikipedia — §«Ув'язнення», citing Шаблій/Вісьтак]
+  - **2 September 1950:** sentenced to **10 years** under arts. **54-1«а», 54-11 and 54-10 ч. II** of the КК УССР (prosecutors had demanded 25). Held at the тюрма на Лонцького, then Бригідки; served in **Мордовський ВТТ № 3 (Явас)**, working for years at peat extraction (digging, drying, carrying peat) until dystrophy disabled her; reassigned to bookbinding in the camp library.
+  - **17 June 1956:** released (term reduced to time served, conviction lifted); returned to Lviv on 17 August with ruined health and no possibility of resuming scholarship, living on a pension of 89 rubles a month.
+- **Earlier repressions (named, not collapsed into the Soviet one):** in 1914 Austrian gendarmes arrested her (in men's uniform, lacking documents) and she narrowly avoided the **Talerhof** internment camp; in 1915–1917 she was a **Russian-imperial prisoner of war** (Вольськ, then 19 months in a cell in Tashkent); in the 1930s **Polish** authorities dismissed her from teaching (1935) and barred her from Plast youth work.
+- **What survived / what was destroyed:** her memoirs and scholarship survive; her scientific career did not — the camps and the post-1948 de-attestation ended her academic work. The medieval texts the MGB cited as evidence are the very canon of Ukrainian literacy, which the repression sought to criminalise.
+
+## 3. Major works
+
+Author of ~73–75 works (about 50 published), spanning memoir, military history, and academic geography:
+
+- `1930` — *Напередодні великих подій. Власні переживання і думки 1912—1914*, memoir of the pre-war and Sich-Riflemen years. [T3: uk.wikipedia; T4: Лазарович]
+- `1933` — *Мої спомини з шкільних літ*, memoir. [T3: uk.wikipedia]
+- `1934` — *Жінка-вояк* and *З воєнних усмішок*, on women in the military struggle. [T3: uk.wikipedia]
+- `1927–1938` — six volumes of the НТШ Фізіографічна комісія works (as secretary/contributor); economic geography, demography, cooperation studies. [T2: НТШ]
+- `1938` — *Земля і люди. Населення Галичини*; articles on Kyiv and Lviv for Kubijovych's *Географія українських й сумежних земель*. [T3: uk.wikipedia]
+- `1943` — *Сучасний Львів* (Сучасне обличчя Львова), her major anthropogeographic study of Lviv; *Мандруймо по рідному краю*. [T3: uk.wikipedia]
+- `1943` — *Софія Галечко, в 25 річницю смерті*, on a fellow Sich-Riflewoman. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required)
+
+> Stepaniv's documentary voice is in her memoirs and interviews. Both quotes are verbatim from her own recorded words, with provenance flagged. (The literary-corpus `verify_quote` check does not apply — she is a memoirist/scholar, not a belletrist.)
+
+**Quote 1 — on readjusting to "private life" after soldiering (interview with Ірина Вільде, *Жіноча доля*, 1939):**
+
+> «Привикла до спідниці, але повірте, зразу приходило мені це дуже тяжко. Почувала себе зовсім неповоротно в жіночому одязі. І знаєте — якось попросту не знала, що було зробити з особистою свободою… наче б заважала вона. Довгого-довгого часу потрібно було, щоб знову „тілом і душею" повернутися до нормального стану.»
+
+A rare first-person reflection on gender, military service, and the loss of the soldier's freedom on return to a woman's expected role — extraordinary for 1939, and the single richest Stepaniv text for a gender-and-statehood lesson. [Interview, *Жіноча доля*, 1939; via T3: uk.wikipedia transcription; flagged interview-transmitted]
+
+**Quote 2 — refusal to emigrate before the Red Army's return (1944):**
+
+> «Я залишаюся з своїм народом.»
+
+Said in 1944, when she chose to stay rather than flee west — knowing what Soviet rule would mean (and it meant the camps). Transmitted by her former pupil Ірина Книш to Stepaniv's son **Ярослав Дашкевич**, who added that she «ніколи не шкодувала свого рішення». Pedagogically it is the moral hinge of her life: belonging over safety. [1944; memoir-transmitted via Я. Дашкевич; flagged]
+
+**Honest gap (§4 + §10):** both quotations are reproduced from the uk.wikipedia transcription of, respectively, the 1939 *Жіноча доля* interview and Ya. Dashkevych's memoir; neither original was opened directly this pass. Labelled accordingly.
+
+## 5. Language register
+
+- **Register:** Stepaniv writes in two registers — vivid first-person **memoir Ukrainian** (the war diaries, the Vilde interview) and precise **academic-geographical prose** (anthropogeography, demography). Galician interwar literary norm, with military and scientific terminology.
+- **CEFR readiness for full reading:** the **memoirs are B2** and highly engaging for learners; the geographical monographs are **C1**.
+- **Lexicon notes (pre-teach):** хорунжа, четарка, стрілець/стрільці, чота, сотня, легіон, полон, визвольні змагання, антропогеографія, кооперація, репресії, виправно-трудовий табір. The feminine military rank **хорунжа** and noun **четарка** are themselves teaching points (women's officer titles).
+- **Stylistic features:** concrete, dated, itinerary-driven war narration; reflective candour in interview; restrained scientific exposition.
+
+## 6. Contested points
+
+- **What gets simplified in popular memory:** Stepaniv is remembered chiefly as the **«Січова стрілецька» heroine of Маківка**, which can eclipse the **scholar** — a доцент and дійсний член НТШ who, with Шаблій and Вісьтак's assessment, formed a bridge between **Степан Рудницький** and **Володимир Кубійович** in Ukrainian anthropogeography. The dossier foregrounds both lives.
+- **The "first woman officer in the world" claim:** widely repeated in Ukrainian sources; stated here as a strong, standard characterisation rather than a verified global record, since comparative-international verification is beyond this pass.
+- **Working under successive regimes (handled honestly):** she taught and researched within **Polish, Soviet, and Nazi-occupation** institutional frames in turn — e.g. *Сучасний Львів* (1943) was funded through Kubijovych's Український центральний комітет under German occupation. **Petro Karmansky** later accused her of "falsifying history" for noting German settlers in princely-era Lviv; her son Ярослав Дашкевич rebutted that this «відповідало історичній правді». Her wartime publications were also attacked under Soviet rule. These contestations are recorded, not airbrushed.
+- **The fabricated basis of her imprisonment:** the central "nationalist article" charge rested on a **false attribution** (the real author was Омелян Логуш) — a documented Soviet fabrication, important both as exculpation and as evidence of how the MGB manufactured cases (§2).
+- **Where Soviet framing attacks:** the Soviet writer **Yaroslav Halan** called her «символ українського націоналізму»; the regime weaponised that label. Naming it is necessary; it does not touch her documented life as soldier, scholar, and teacher.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the `origin/main` plan inventory (`git ls-tree -r origin/main curriculum/l2-uk-en/plans/`) on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/olena-stepaniv.yaml` — her own plan (this dossier is its research base).
+  - `curriculum/l2-uk-en/plans/bio/stepan-rudnytskyi.yaml` — the founder of Ukrainian geography, her university teacher and scholarly lineage.
+  - `curriculum/l2-uk-en/plans/bio/milena-rudnytska.yaml` — leading interwar Galician women's-movement figure; the same statehood-women milieu.
+  - `curriculum/l2-uk-en/plans/bio/olha-basarab.yaml` — fellow statehood-era woman (Союз українок / UVO milieu); paired in this dossier batch.
+  - `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml` — present at her 1920 wedding; OUN/UVO context.
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml` — named in her 1949 indictment (alleged meetings), the pretext for her imprisonment.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/sichovi-striltsi.yaml` — the Українські Січові Стрільці she served in.
+  - `curriculum/l2-uk-en/plans/hist/persha-svitova.yaml` — the First World War, her Carpathian campaign and captivity.
+  - `curriculum/l2-uk-en/plans/hist/zunr.yaml` — the ZUNR / November 1918 uprising and Polish-Ukrainian war she organised in.
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml` — the UNR she served (press attaché of the Foreign Ministry).
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the Soviet terror mechanism that imprisoned her.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `sofiia-halechko` (fellow Sich-Riflewoman, subject of Stepaniv's 1943 essay) — no plan yet.
+  - A HIST/gender module on **women in the УСС / визвольні змагання** — no plan yet.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A GEO/method module on early Ukrainian anthropogeography (Рудницький → Степанів → Кубійович).
+
+## 8. Naming-canonical
+
+- **Slug:** `olena-stepaniv`
+- **EN canonical (BGN/PCGN-style project spelling):** Olena Stepaniv
+- **UA canonical (with patronymic):** Олена Іванівна Степанів (Степанів-Дашкевич)
+- **Aliases to track (`aliases:` YAML field):** Olena Stepaniv; Олена Степанівна (period press form); Степанів-Дашкевич.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** «Елена Степанив» / «Елена Ивановна» (Russified). Note: the masculine-looking surname Степанів is correctly **invariable** for a woman in this form; do not "feminise" it to a Russified pattern.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** abundant **public-domain WWI-era photographs** exist (she was among the most-photographed УСС figures) — e.g. the 8 March 1915 Маківка officers' photo by Іван Іванець, and the 1916 УСС postcard series; **a 21 April 1915 postage stamp bore her portrait**. Most are PD-by-age; verify each **file page**. [Wikimedia Commons category: `Olena Stepaniv`]
+- **Backup candidates:**
+  - Osyp Kurylas's wartime portrait of her; УСС postcard series («Brown front»).
+  - Личаківський-cemetery memorial photograph — verify rights.
+- **Context image (use with care):** a PD УСС-era postcard with her in uniform would strongly illustrate §1 and §6 (the gender-and-soldiering theme).
+- **If no specific portrait clears review:** the 1915 stamp or the Іванець group photo are strong PD options.
+
+## 10. Sources used
+
+**Tier 1 (authoritative — baseline):**
+- К. Науменко. «Степанів Олена Іванівна» // *Енциклопедія Сучасної України*, т. 9. — К.: Інститут енциклопедичних досліджень НАН України. (Cited as the standard UA encyclopedic baseline for identity/chronology; attributed via the article's own citation, not freshly fetched this pass — flagged.)
+
+**Tier 2 (institutional):**
+- Наукове товариство ім. Шевченка (НТШ) — her дійсний-член status (1933), Фізіографічна/Географічна комісія membership and the six volumes of commission works (1927–1938). (Institutional record of her scholarly affiliation.)
+
+**Tier 3 (encyclopedic — freshly fetched 2026-06-04):**
+- Українська Вікіпедія. «Степанів Олена Іванівна». https://uk.wikipedia.org/wiki/Степанів_Олена_Іванівна — the detailed source for the WWI campaign chronology, the Russian captivity, the ZUNR/UNR service, the interwar scholarship and cooperation work, the 1949–1956 imprisonment with its charge articles, and the assessments. Densely cited to the T4 scholarship below; used for chronology and as the access copy for the quoted material.
+
+**Tier 4 (modern scholarly — accessed via the encyclopedic article's citations this pass):**
+- Олег Шаблій, Олександра Вісьтак — studies of Stepaniv as geographer and the Рудницький→Степанів→Кубійович lineage; source for the fabricated-attribution detail (Логуш) and the §6 assessments.
+- Микола Лазарович — on Stepaniv as УСС officer and on her principal works.
+- Галина Сварник — on her РСУК cooperative work and overall significance.
+- Мирослава Влах. «Модальний вимір наукових текстів Олени Степанів…» (ЛНУ ім. І. Франка) — modern analysis of her scientific prose.
+
+**Primary-source documents accessed (in transcription only):** the 1939 *Жіноча доля* interview (§4 quote 1) and Ya. Dashkevych's memoir of his mother (§4 quote 2), via the uk.wikipedia transcription; the MGB case file and her own memoir editions were not opened this pass (honest gap).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — the Ukrainian liberation struggle and statehood are the frame; Austrian, Russian-imperial, Polish and Soviet repressions are each named in their place.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Перша світова війна / визвольні змагання / ЗУНР, not Soviet euphemisms.
+- [x] No uncritical Soviet propaganda terms — «символ українського націоналізму» / «кадрова націоналістка» appear only as named Soviet/accusatory labels (§2, §6).
+- [x] No "lost his life" euphemisms — her death (cancer, 1963, health broken by the camps) is stated plainly; the camp labour is named.
+- [x] Modern UA place names — Львів, Вишнівчик, Маківка; Ташкент/Вольськ named factually as places of captivity.
+- [N/A] Holodomor — not directly in her arc (Galician/diaspora-side biography).
+- [x] Russian/Soviet aggression framing — the 1915 Russian-imperial captivity and the 1950 Stalinist camp sentence are both named as imperial/Soviet repression.

--- a/docs/research/bio/olha-basarab.md
+++ b/docs/research/bio/olha-basarab.md
@@ -1,0 +1,158 @@
+# Ольга Михайлівна Басараб — Research Dossier
+
+**Slug:** `olha-basarab`
+**Block:** E (statehood-era woman; Союз українок activist; UNR/ZUNR diplomat; UVO liaison; died in Polish police custody, 1924)
+**Tier:** 2
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — liberation-struggle/statehood wave)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+> **Framing note (read first).** Basarab is a *martyr figure*, and the brief is explicit: **sourced, not myth**. This dossier separates the documented record (a genuine clandestine UVO/intelligence operative; arrest by Polish police; death in custody with autopsy evidence of torture) from the martyrological tradition (the "dying inscription written in blood"), and names the oppressor honestly: here it is the **Second Polish Republic**, not Russia. It refuses both hagiography and whitewashing, and includes the Polish-state perspective that she was, in fact, an enemy agent.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕСУ т.2; УІНП historical calendar; СЗРУ institutional page)
+- [x] Oppression mechanism is specific (dated arrest, named investigator/prison, autopsy findings, closed investigation)
+- [~] ≥2 primary-source quotes — **only one well-attested utterance survives (the contested dying message); a second letter fragment is given with explicit low-confidence provenance. The thinness is documented in §4, not papered over.**
+- [x] Cross-track links: every "Existing" path verified against `origin/main` plan inventory on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied (adapted: Polish-repression case)
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Ольга Михайлівна Басараб (дівоче прізвище — Левицька). [T1: ЕСУ, т. 2, 2003 — «Басараб Ольга» (авт. Ф. П. Погребенник, О. П. Стасюк); T3: uk.wikipedia]
+- **Pseudonyms / aliases:** maiden name **Левицька**; commonly written **Басараб-Левицька** / **Левицька-Басараб**. As a UVO operative she worked clandestinely. [T3: uk.wikipedia]
+- **Born:** 1 September 1889 | с. Підгороддя, Рогатинський повіт | Австро-Угорщина | нині Рогатинський район, Івано-Франківська область. **Source disagreement (flagged, not smoothed):** the УІНП historical calendar and uk.wikipedia give **1 September 1889**; the ЕСУ entry gives **24 July (24 лип.) 1889**. Both are recorded; the 1 September date is the more widely used. [T2: УІНП; T1: ЕСУ; T3: uk.wikipedia]
+- **Died:** 13 February 1924 (aged 34) | Львів (тюрма «Бригідки»), Друга Польська Республіка | **found hanged in cell № 7 after three days of brutal interrogation; the autopsy documented torture; the exact manner of death remained officially unexplained** (§2, §6). [T1: ЕСУ — «замучена в тюрмі»; T3: uk.wikipedia]
+- **Family / education key facts:** daughter of the civic activist **Михайло Левицький** (герб Рогаля) and **Сабіна Стрільбицька** (герб Сас); orphaned young (father 1902, mother 1904). Educated at a private boarding school in Weisswasser (Silesia), the Ukrainian girls' lyceum in Peremyshl (1902–1909), and a one-year course at the Vienna Trade Academy. Worked from 1910 at the «Дністер» insurance society and the Land Mortgage Bank; taught and trained at the Ukrainian Credit Union in Ternopil. On **10 October 1914** she married **Дмитро Басараб** (Bukovynian, a Lviv Polytechnic student) at St Barbara's church in Vienna; he was killed on the **Italian front on 22 June 1915**, less than a year later. [T3: uk.wikipedia]
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. **The oppressor here is the Second Polish Republic**, and the case is documented, not folkloric.
+
+- **What happened:** arrest, brutal interrogation, and death in custody — found hanged after the autopsy documented torture.
+- **By whom (specific agency):** the **Polish police** of the Second Polish Republic; interrogation at the Lviv «Бригідки» prison by the investigator **Міхал Кайдан**.
+- **When (specific dates):**
+  - **9 February 1924, ~06:00:** Polish police raided the flat she rented with **Стефанія Савицька** on вул. Виспянського (нині Вишенського). During the search a package fell from her wardrobe; she pressed it to herself — the gesture drew suspicion, and the package was found to contain **intelligence materials on the deployment of units across the whole Polish army**. Both women were arrested and charged with espionage **simultaneously for Weimar Germany and Bolshevik Ukraine**; she was first held three days at the вул. Яховича prison.
+  - **12 February:** two final interrogations — one after midday, the second a gruelling session from 21:00 to 03:00.
+  - **morning of 13 February 1924:** she was found **hanged on the window bars of cell № 7**. The examination documented numerous hematomas, **marks of electric-current torture, and dislocated joints**.
+- **The honest distinction (sourced, not myth):** the **fact of torture** is documented by the autopsy; the **exact manner of death is not settled**. As **Мілена Рудницька** wrote, «таємницю своєї смерті Ольга Басараб взяла з собою до могили». Scholarship records three scenarios: tortured to death and then hanged to stage a suicide; the hanging of a living person; or suicide in despair after torture. This dossier asserts the documented torture and the death in Polish custody, and leaves the precise mechanism open — exactly as the reputable record does.
+- **The cover-up and the reaction:** thanks to UVO agents inside the prison the death could not be hidden. The **Союз українок** launched a protest campaign on 20 February; the head of the Ukrainian Sejm club **Сергій Хруцький** filed an interpellation; the **Jewish Sejm club demanded a special commission** on prison conditions (a notable cross-community solidarity). The body was exhumed on 26 February; the only Ukrainian among the autopsy doctors was **Маріян Панчишин**; the family's lawyer was **Степан Шухевич**. The reburial at the Янівський cemetery drew several thousand Lvivians. **The investigation was soon closed «за відсутністю складу злочину» (for absence of a crime).**
+- **The honest counter-context (Polish perspective, named):** Basarab was **not an uninvolved civilian** — she was a genuine **UVO liaison and Ukrainian intelligence operative** carrying materials on Polish military deployment. From the Polish state's standpoint she was an enemy agent. The martyrdom claim rests on the **manner of her death (death under torture in custody, and the closed investigation)**, not on a pretence of innocence of clandestine activity. Both are stated.
+
+## 3. Major works
+
+Basarab was an organiser, diplomat, and clandestine operative, not an author; her "works" are acts of statehood and resistance, in chronological order:
+
+- `1914–1915` — organiser of the **first women's чота (platoon) of the Українські Січові Стрільці** in Lviv; charitable work on the Italian front. [T1: ЕСУ; T3: uk.wikipedia]
+- `1915–1918` — charitable and educational work in Vienna: the **Комітет допомоги пораненим і полоненим** and the **Комітет допомоги цивільному населенню**; board member of the Ukrainian Women's Union (Vienna); honoured by the International Red Cross. [T3: uk.wikipedia]
+- `1918–1923` — **diplomat of the UNR/ZUNR**: secretary of the Ukrainian embassy in **Finland**, accountant of the Ukrainian embassy in **Vienna**, and concurrently a **Ukrainian intelligence agent** travelling to Denmark, Germany, Norway and elsewhere to gather military-strategic and political information. [T2: СЗРУ; T3: uk.wikipedia]
+- `1923–1924` — on the liquidation of the UNR missions, returned to Lviv; member of the Head Administration of the **Союз українок** Lviv branch; **liaison («зв'язкова») of Colonel Yevhen Konovalets** within the **УВО (Українська військова організація)**. [T3: uk.wikipedia]
+- *Memorial/literary afterlife:* M. Bazhansky, *Як загинула Ольга Басарабова* (Prague, 1941); O. Luhovy's drama *Ольга Басарабова* (Canada, 1936); a heroine in Roman Ivanychuk's novel *Країна Ірредента*. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required — honest thinness documented)
+
+> As a clandestine UVO operative and intelligence agent, Basarab deliberately left **almost no quotable written corpus**. Per the anti-fabrication rule, nothing is invented here; the one well-attested utterance is given with its contested provenance, and the second is flagged as low-confidence. The reputable record (Рудницька) stresses that much of her inner record is irretrievable.
+
+**Quote 1 — the "dying inscription" (iconic, but martyrological — flagged):**
+
+> «Вмираю, замучена, помстіть! О. Басараб.»
+
+Traditionally reported as scratched on the wall of her cell. **This is the martyr tradition, not a forensically established fact:** the reputable Локальна історія account of her death does **not** mention any wall inscription, and the line often appended to it — «За кров, за сльози, за руїну верни нам, Боже, Україну!» — is in fact a verse by **Богдан Лепкий**, frequently and wrongly merged into "her" last words. The phrase is pedagogically valuable precisely as a case study in how martyrologies form. [Martyr tradition; attested via T5: uk.wikiquote / popular memory; **provenance contested — flagged as tradition, not document**]
+
+**Quote 2 — fragment of a wartime letter to her husband Дмитро (LOW-confidence provenance):**
+
+> «Була я на желізниці. Отже хочу з тобою поділитись, що не на дурно ходила. Приїхало багато робітників з Німеччини…»
+
+Reproduced in a popular compilation as a line from her correspondence — reporting, in a domestic register, the kind of railway/troop observation that prefigured her later intelligence work. **Caveat:** the reputable Локальна історія piece **paraphrases** rather than quotes her letters, so this verbatim form must be re-confirmed against a scholarly edition of the correspondence before any learner-facing use. [Letter to Дмитро Басараб; attested only via T5 compilation (uain.press); **low-confidence — re-verify before use**]
+
+**Honest gap (§4 + §10):** this is the one figure in the batch where the ≥2-quote bar is met only marginally and with heavy caveats. Rather than fabricate a "tidier" quote, the thinness is reported: Basarab's significance lies in deeds (diplomacy, the women's чота, the UVO liaison work) and in the documented manner of her death, not in a literary corpus.
+
+## 5. Language register
+
+- **Register:** what survives is **plain practical/epistolary Ukrainian** (the letter fragment) and the high-pathos **martyrological register** of the commemorative tradition (the dying inscription, the memorial drama, Lepky's verse). She left no scholarly or literary prose.
+- **CEFR readiness:** her *story* is teachable from **B1** (a clear, dramatic biography); the source-criticism layer (myth vs document) is a **B2–C1** skill.
+- **Lexicon notes (pre-teach):** розвідниця, зв'язкова, підпілля, УВО, Союз українок, дипломат(ка), посольство, тортури, ексгумація, мучениця/замучена. The contrast between **замучена** (martyred/tortured-to-death) and **самогубство** (suicide) is the crux of the source-criticism lesson.
+- **Stylistic features:** the commemorative tradition uses imperative pathos («помстіть!») and sacralising imagery («Голгофа Ольги Басараб» in some titles) — to be taught *as* rhetoric, not reproduced as fact.
+
+## 6. Contested points
+
+- **What's debated in scholarship — the manner of death.** The torture is documented; the rest is not. **Мілена Рудницька**'s judgment — that Basarab took the secret of her death to the grave — is the honest baseline, with three open scenarios (§2). The dossier neither asserts proven murder nor accepts the Polish "suicide/unexplained" line uncritically.
+- **What gets simplified in popular memory.** The **wall inscription** is the prime example: a powerful martyr-text whose documentary status is unproven, routinely conflated with a Lepky verse. Popular memory also tends to erase the **real espionage context** — she *was* a clandestine operative — which the dossier restores (§2).
+- **Polish perspective (required, named honestly).** This is a Polish-repression case, not a Russian one. From the Second Polish Republic's standpoint, Basarab was a foreign-linked intelligence agent caught with military-deployment materials. Honest history holds both: a state's right to counter-espionage **does not** license torture and a death in custody followed by a closed, uninvestigated case. Naming Polish responsibility here is not anti-Polish chauvinism — note that the **Jewish Sejm club** and Polish legal process were themselves the channels through which the scandal was pressed.
+- **The double accusation.** She was charged with spying **for both Weimar Germany and Bolshevik Ukraine** — a telling incoherence, since her actual loyalty was to the Ukrainian national cause (UVO/UNR), opposed to Polish **and** Bolshevik domination alike. The anti-imperial frame here is broader than any single empire.
+- **Modern instrumentalisation.** She is a patron figure for diaspora women's organisations (Canada, Australia) and, recently, for Ukraine's intelligence services (СЗРУ). Her memory is genuine; the dossier keeps the document/myth line visible so the commemoration rests on fact.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the `origin/main` plan inventory (`git ls-tree -r origin/main curriculum/l2-uk-en/plans/`) on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/olha-basarab.yaml` — her own plan (this dossier is its research base).
+  - `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml` — the UVO/OUN leader whose liaison she was.
+  - `curriculum/l2-uk-en/plans/bio/olena-stepaniv.yaml` — fellow statehood-era woman and УСС women's-chota organiser; paired in this dossier batch.
+  - `curriculum/l2-uk-en/plans/bio/milena-rudnytska.yaml` — leading Союз українок / women's-movement figure; her judgment on Basarab's death anchors §6.
+  - `curriculum/l2-uk-en/plans/bio/nataliya-kobrynska.yaml` — founder of the Galician Ukrainian women's movement, the lineage Basarab worked in.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/sichovi-striltsi.yaml` — the УСС whose first women's чота she organised.
+  - `curriculum/l2-uk-en/plans/hist/zunr.yaml` — the ZUNR she served as a diplomat.
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml` — the UNR diplomacy (embassies in Finland and Vienna).
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml` — the OUN, successor to the УВО she liaised for.
+  - `curriculum/l2-uk-en/plans/hist/pacyfikatsiia.yaml` — interwar Polish repression of Ukrainians in Galicia, the context of her death.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `stefaniia-savytska` (arrested with her) — no plan yet.
+  - A HIST/method module on **УВО / Ukrainian interwar underground** — no dedicated plan yet (OUN is the closest existing one).
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A method module on **reading a martyrology** (document vs tradition) anchored on the Basarab "wall inscription."
+
+## 8. Naming-canonical
+
+- **Slug:** `olha-basarab`
+- **EN canonical (BGN/PCGN-style project spelling):** Olha Basarab
+- **UA canonical (with patronymic):** Ольга Михайлівна Басараб (Левицька)
+- **Aliases to track (`aliases:` YAML field):** Olha Basarab; Olha Levytska-Basarab; Ольга Левицька; Басараб-Левицька.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** «Ольга Михайловна Басараб» (Russified patronymic form). Note: as a Galician figure under Austria/Poland, Russified forms are anachronistic as well as inappropriate.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** early-20th-century photographs of Basarab exist (she predates 1924); most are **PD-by-age** — verify each **file page**. There is also a noted **painted portrait** (the «у житті і на полотні» tradition). [Wikimedia Commons category: `Olha Basarab`]
+- **Backup candidates:**
+  - The memorial plaque on the Lviv house (вул. Вишенського, 34) where she was arrested; the Burshtyn and Іванків monuments — verify rights.
+  - The Saskatchewan (Canada) bust unveiled 1936 — verify rights.
+- **Context image (use with care):** a PD photograph of the «Бригідки» prison or the 1924 funeral procession at the Янівський cemetery would illustrate §2 powerfully and soberly.
+- **If no rights-clear portrait clears review:** a PD pre-1924 photograph or the memorial-plaque image are the safest options.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Ф. П. Погребенник, О. П. Стасюк. «Басараб Ольга» // *Енциклопедія Сучасної України*, т. 2 (грудень 2003). https://esu.com.ua/article-40676. Accessed 2026-06-04. (Identity; «замучена в тюрмі»; gives the 24 July 1889 birth-date variant.)
+
+**Tier 2 (institutional):**
+- Український інститут національної пам'яті (УІНП) — historical calendar, «1 вересня 1889 — народилася Ольга Басараб, розвідниця, зв'язкова Євгена Коновальця». https://uinp.gov.ua. Accessed 2026-06-04. (Canonical 1 September 1889 birth date; intelligence/UVO role.)
+- Служба зовнішньої розвідки України (СЗРУ) — biographical/historical pages on Basarab as розвідниця. szru.gov.ua. (Institutional confirmation of her intelligence work; pages returned 403 on direct fetch 2026-06-04 — cited as institutional baseline, not freshly read.)
+
+**Tier 3 (encyclopedic — freshly fetched 2026-06-04):**
+- Українська Вікіпедія. «Басараб Ольга Михайлівна». https://uk.wikipedia.org/wiki/Басараб_Ольга_Михайлівна — detailed source for the biography, the UVO liaison work, the 9–13 February 1924 arrest and death, the autopsy findings, the protest campaign, and the commemorations. Used for chronology.
+- Українська Вікіцитата. «Басараб Ольга Михайлівна» — quote provenance for §4 (and the Lepky-conflation note).
+
+**Tier 5 (reputable named outlets — corroborated):**
+- Локальна історія. «Ольга Басараб: життя поміж утрат». localhistory.org.ua — the honest scholarly-journalistic account; source for Мілена Рудницька's framing and the three death scenarios (§2, §6); notably does **not** report a wall inscription.
+- uain.press — popular compilation carrying the letter fragment (§4 quote 2, low-confidence).
+
+**Primary-source documents accessed (in transcription only):** the contested dying inscription and the letter fragment, both via secondary transcription with provenance flagged; no archival case file or scholarly letter-edition was opened this pass (honest gap, §4).
+
+---
+
+## Decolonization self-check (run before submitting) — adapted: Polish-repression case
+
+- [x] No Russocentric framing — and, equally, **no anti-Polish chauvinism**: Polish state responsibility for the death-in-custody is named factually, with the Polish-state perspective (counter-espionage) and Polish/Jewish channels of protest both recorded (§6).
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN; Russified forms additionally flagged as anachronistic for a Galician figure.
+- [x] No Russocentric periodization — Австро-Угорщина / Друга Польська Республіка / визвольні змагання, named accurately.
+- [x] No uncritical propaganda terms — the martyr rhetoric («помстіть!», «Голгофа») is taught *as* rhetoric, not asserted as fact (§4, §5).
+- [x] No "lost his life" euphemisms — «died in Polish custody; the autopsy documented torture; the manner of death remained unexplained» — stated without euphemism and without overclaiming proven murder.
+- [x] Modern UA place names — Львів, Підгороддя (Рогатинщина), вул. Вишенського; Бригідки named as the prison.
+- [N/A] Holodomor — not in her arc (d. 1924, Galicia).
+- [x] Aggression framing — her actual loyalty (Ukrainian statehood, against both Polish and Bolshevik domination) is named; the broader anti-imperial frame is kept wider than any single empire (§6).

--- a/docs/research/bio/roman-ratushny.md
+++ b/docs/research/bio/roman-ratushny.md
@@ -1,0 +1,162 @@
+# Роман Тарасович Ратушний — Research Dossier
+
+**Slug:** `roman-ratushny`
+**Block:** J (war-dead of the Russo-Ukrainian war; civic activist; "перше вільне покоління")
+**Tier:** 5 (build-order: war-killed) / source-authority: T3 baseline + reputable T5
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — liberation-struggle/statehood wave)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+> **War-dead note (read first).** Роман Ратушний was killed in action at 24, defending Ukraine against Russia's full-scale invasion. This dossier is dignified and factual: it honours him without hagiography, records the activist's real conflicts and the harsh wartime register of his own words, and names the Russian aggression that killed him plainly.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier sources cited; for a 2022 war-dead figure, T1/T2 encyclopedic coverage is thin (documented in §10) — anchored on uk.wikipedia (T3) + reputable named outlets (T5) per source-tier recency clause
+- [x] Oppression mechanism is specific (dated KIA, named unit/place; plus dated pre-war threats and the 2021 prosecution)
+- [x] ≥2 primary-source quotes (decolonization Facebook post; Euromaidan-motivation reflection — provenance flagged)
+- [x] Cross-track links: every "Existing" path verified against `origin/main` plan inventory on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Роман Тарасович Ратушний. [T3: uk.wikipedia — «Ратушний Роман Тарасович»; cross-checked T3: en.wikipedia — «Roman Ratushnyi»]
+- **Pseudonyms / aliases:** military call-sign («позивний») **«Сенека»** (Seneca). [T3: uk.wikipedia; en.wikipedia]
+- **Born:** 5 July 1997 | Київ | Україна. [T3: uk.wikipedia; en.wikipedia — agree on 5.07.1997]
+- **Died:** 8 June 2022 (aged 24) | поблизу с. Сулигівка, Ізюмський район, Харківська область | Україна | **killed in combat** (fell into an enemy ambush) while serving in the reconnaissance platoon, 2nd motorised-infantry battalion, 93-тя ОМБр «Холодний Яр». **Source disagreement (flagged, not smoothed):** uk.wikipedia gives the date of death as **8 June 2022**; en.wikipedia and several obituaries give **9 June 2022** (the day the death was publicly announced). The 8 June date — confirmed by his father, who specified the place as near Сулигівка — is used here, with the 9 June announcement noted. [T3: uk.wikipedia; T3: en.wikipedia]
+- **Family / education key facts:** Born into an activist-literary family — father **Тарас Ратушний** (of the «Збережи старий Київ» movement), mother the writer **Світлана Поваляєва**. His brother **Василь Ратушний**, a drone operator (414 ОБрУБАС), was also killed in the war, on 27 February 2025. Roman entered the Фінансово-правовий коледж in 2012 and obtained a legal education. [T3: uk.wikipedia — §«Родина»]
+
+Each load-bearing fact (birth, death, unit, place) is cross-checked across uk.wikipedia and en.wikipedia; the death-date variant is flagged above rather than silently resolved.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. For Ratushny there are two distinct strands, kept separate and honestly attributed.
+
+**(a) The Russian aggression that killed him (primary).**
+- **What happened:** killed in action defending Ukraine against Russia's full-scale invasion.
+- **By whom:** Russian armed forces.
+- **When / where (specific):** **8 June 2022**, near **с. Сулигівка, Ізюмський район, Харківська область**, when his reconnaissance group fell into an enemy ambush. He had joined the Defence Forces as a volunteer at the start of the invasion, formed a «Протасового Яру» unit, defended Kyiv, then fought in Sumy oblast (de-occupation) and from early April in Kharkiv oblast / the Izium direction with the **93-тя окрема механізована бригада «Холодний Яр»**. [T3: uk.wikipedia — §«Російське вторгнення 2022 року»]
+- **Posthumous recognition:** Order «За мужність» III ступеня (2022, posthumous); international obituaries (The Economist, Financial Times, The Guardian, The Times, Bild); Ursula von der Leyen named him at the Lugano recovery conference (4 July 2022) as a representative of a new generation of Ukrainians.
+
+**(b) Pre-war harassment of the activist (secondary, domestically sourced — named honestly).**
+- As leader of «Захистимо Протасів Яр» (initiative 2018; NGO 2019), Ratushny fought the developer **ТОВ «Дайтона Груп»**. In **October 2019** he reported and published recordings of **physical-violence threats**, naming the then-deputy head of the President's Office **Андрій Смирнов** and businessman **Геннадій Корбан**; he appealed to President Zelensky and Prosecutor-General Ryaboshapka, **no criminal case was opened, and the threats were never investigated** — he went into hiding for a time, fearing for his life.
+- In **March 2021**, after a rally supporting the imprisoned activist **Сергій Стерненко**, the Pechersk court placed him under round-the-clock house arrest on a hooliganism suspicion whose central "evidence" was a near-black photograph — derided online as the **«Справа Казимира Малевича»** («Black Square case»). This was a Ukrainian-state prosecution, not a Russian one, and is named as such: a domestic abuse of process against a civic activist.
+- **The honest distinction:** the aggression that killed him was Russian; the pre-war intimidation came from domestic power-holders and developer interests. The dossier does not conflate the two, and does not inflate (b) into "Russian persecution."
+
+**What survived:** his cause outlived him — on 14 July 2022 the Kyiv city council created a landscape reserve at Протасів Яр, named after him on 23 November 2023; his legal case against Korban was won posthumously (Kyiv appellate court, 23 March 2023, his parents continuing as legal successors).
+
+## 3. Major works
+
+Ratushny was an activist and journalist, not an author; his "works" are civic campaigns and investigations, in chronological order:
+
+- `2013–2014` — participant in the Euromaidan from age 16; injured in the «Беркут» attack on students on the night of 30 November 2013. [T3: uk.wikipedia]
+- `2014–2015` — investigative journalism: the «Метро на Троєщину» project; reporting on Kyiv officials, energy, and tender corruption (diesel-fuel schemes at Укрзалізниця); a 2015 mapped network of Russian–Ukrainian organised-crime ties (~1,000 names). Credited among those who influenced the creation of the Державне бюро розслідувань (ДБР). [T3: uk.wikipedia]
+- `2018–2022` — founder and leader of **«Захистимо Протасів Яр»**, the campaign and NGO that, through years of litigation (won definitively at the Касаційний адміністративний суд, 4 January 2022), blocked high-rise construction on a green ravine in central Kyiv. His signature achievement. [T3: uk.wikipedia — §«Боротьба за Протасів Яр»]
+- `2022` — volunteer soldier; founder of the «Протасового Яру» unit; reconnaissance, 93rd brigade «Холодний Яр». [T3: uk.wikipedia]
+- **His will (заповіт):** he bequeathed part of his combat pay to a bandura kapela, the Shevchenko House-Museum, and the outlets «Історична правда» and «Новинарня» — a small but telling act of cultural priorities. [T3: uk.wikipedia — §«Заповіт»]
+
+## 4. Primary-source quotes (≥2 required)
+
+> Ratushny is **not a literary author**, so the project's `verify_quote` literary-corpus check does not apply. His documentary voice is in interviews and social-media posts. Both quotes are verbatim Ukrainian, attested through multiple named outlets and (for quote 1) a peer-reviewed scholarly analysis; provenance is flagged.
+
+**Quote 1 — the decolonisation post (his most-cited words):**
+
+> «Випалюйте в собі всю російську субкультуру. Випалюйте в собі всі спогади з дитинства, пов'язані з російським-радянським. Випалюйте в собі стосунки з родичами чи друзями по ту сторону, з усіма, хто є носієм російської субкультури. Інакше це все випалить вас.»
+
+A social-media post that became, after his death, an emblem of "mnemonic decolonisation" — analysed as such in the scholarly journal *Україна Модерна*. Pedagogically it is the single most useful Ratushny text for the decolonisation theme, and it states the cost of *not* decolonising in his own uncompromising register. [Facebook post; attested via T5: Львівський портал 15.06.2022, Цензор, Аргумент; scholarly framing T4: *Україна Модерна* — «Випалюйте в собі все російське!»; flagged social-media provenance]
+
+**Quote 2 — why he became an activist (Euromaidan reflection):**
+
+> «Я не бачив сенсу вчитися, працювати, що завгодно робити в країні, у якій поліція, на той час міліція, і кримінал, який очолював державу, повністю забирає під себе всі важелі управління, а тобі відводять роль статиста, функцією якого є формування ВВП своєї країни і не більше.»
+
+His own account of joining the Revolution of Dignity at 16 — the moral logic of a generation that refused to be passive "extras" in their own country. It anchors the «перше вільне покоління» (first free generation) theme. [Interview reflection; attested via T5: Херсонська ОУНБ ім. О. Гончара compilation; flagged interview-transmitted]
+
+**Honest gap (§4 + §10):** both quotations are reproduced from reputable secondary transcriptions (named Ukrainian outlets and a library compilation), not from the original Facebook posts/interview recordings directly; they are labelled accordingly. His harsher wartime statements (e.g. on killing the enemy) are authentic and documented but deliberately not used as the teaching quotes here, since the decolonisation post and the activism reflection carry more pedagogical value while remaining true to the person.
+
+## 5. Language register
+
+- **Register:** contemporary spoken/written **civic-activist Ukrainian** — direct, polemical, internet-native, with the blunt wartime idiom of 2022 (including the derogatory «русня» in some posts, which a learner edition should gloss and contextualise rather than reproduce uncritically).
+- **CEFR readiness for full reading:** **B2.** His posts and interviews are accessible to upper-intermediate learners; the legal/urban-development and wartime-political vocabulary pushes some material to B2–C1.
+- **Lexicon notes (pre-teach):** доброволець, розвідувальний взвод, деокупація, забудовник, зелена зона, заказник, громадська ініціатива, субкультура, деколонізація, позивний. The verb **випалювати** («to burn out») in quote 1 is the key figurative term to teach.
+- **Stylistic features:** imperative anaphora («Випалюйте… Випалюйте… Випалюйте…»), antithesis, and a plain-spoken moral directness.
+
+## 6. Contested points
+
+- **What gets simplified in popular memory:** Ratushny is sometimes reduced to either the Protasiv Yar tree-defender **or** the fallen soldier, losing the through-line — a single civic logic of resisting unaccountable power, whether a developer, corrupt officials, or the Russian invader. His harshest wartime quotes are also sometimes softened in memorial use; this dossier flags them as real (§4) rather than erasing them.
+- **What's debated:** the **date of death** (8 vs 9 June 2022 — §1) and the precise circumstances of the ambush. His pre-war prosecution (the 2021 «Malevich case») is widely regarded as politically motivated, but that judgment is a public/journalistic one, not a court finding.
+- **Where Russian disinformation attacks:** Russian propaganda smears fallen Ukrainian activists as «radicals/nationalists»; Ratushny's own decolonisation post is sometimes quoted out of context to paint him as a chauvinist. The honest reading is that quote 1 targets **Russian imperial culture as a colonising force**, not Russians as people — the distinction the post itself draws between «російська субкультура» and persons.
+- **Other-perspective considerations:** the Korban/«Дайтона Груп» dispute had Ukrainian domestic-politics dimensions; the dossier names the threats and the posthumous court victory without adjudicating every commercial detail.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the `origin/main` plan inventory (`git ls-tree -r origin/main curriculum/l2-uk-en/plans/`) on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/roman-ratushny.yaml` — his own plan (this dossier is its research base).
+  - `curriculum/l2-uk-en/plans/bio/dmytro-kotsyubailo.yaml` — «Da Vinci», also of the «Холодний Яр» milieu; fellow young war-dead commander.
+  - `curriculum/l2-uk-en/plans/bio/maksym-kryvtsov.yaml` — poet-soldier killed in the war; the same fallen-generation theme.
+  - `curriculum/l2-uk-en/plans/bio/iryna-tsybukh.yaml` — combat medic killed in the war; civic-then-military arc.
+  - `curriculum/l2-uk-en/plans/bio/victoria-amelina.yaml` — writer killed by a Russian strike; documenting/defending culture under invasion.
+  - `curriculum/l2-uk-en/plans/bio/kateryna-handziuk.yaml` — civic activist attacked and killed; the threatened-activist parallel (pre-war strand of §2).
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/revoliutsiia-hidnosti.yaml` — the Euromaidan he joined at 16.
+  - `curriculum/l2-uk-en/plans/hist/povnomasshtabne-vtorhnessnia.yaml` — the full-scale invasion in which he was killed.
+  - `curriculum/l2-uk-en/plans/hist/hromadske-suspilstvo.yaml` — Ukrainian civil society, the frame for his activism.
+  - `curriculum/l2-uk-en/plans/hist/kholodnyi-yar.yaml` — the historical Холодний Яр resistance whose name his brigade (and memory) carry forward.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `vasyl-ratushny` (his brother, also killed in the war, 2025) — no plan yet.
+  - A HIST/civics module on **urban green-space activism / Протасів Яр** as a case of civil society — no plan yet.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A method module on **mnemonic decolonisation** anchored on quote 1 and the *Україна Модерна* analysis.
+
+## 8. Naming-canonical
+
+- **Slug:** `roman-ratushny`
+- **EN canonical (BGN/PCGN-style project spelling):** Roman Ratushnyi (the slug uses the simplified «Ratushny»).
+- **UA canonical (with patronymic):** Роман Тарасович Ратушний
+- **Aliases to track (`aliases:` YAML field):** Roman Ratushnyi; Roman Ratushny; «Сенека» (call-sign).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** «Роман Ратушный» (Russified). Do not render Сулигівка or Ізюм in Russified transliteration (Izyum-via-Russian); use the Ukrainian forms.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **«Roman Ratushnyi»** holds free-licensed photographs from the Protasiv Yar campaign and memorial actions; verify the license on each **file page**. [Commons category: `Roman Ratushnyi`]
+- **Backup candidates:**
+  - Protasiv Yar landscape-reserve / memorial-alley photographs (37-tree alley planted 20 October 2022) — verify rights.
+  - Memorial-action and street-renaming photos (Kyiv: former вул. Волгоградська → вул. Романа Ратушного) — verify rights.
+- **Context image (use with care):** a photograph of the Протасів Яр green ravine he saved would strongly illustrate §3.
+- **If no rights-clear portrait clears review:** fall back to a CC-licensed memorial-event photo with documented terms.
+
+## 10. Sources used
+
+**Tier 3 (encyclopedic — freshly fetched 2026-06-04):**
+- Українська Вікіпедія. «Ратушний Роман Тарасович». https://uk.wikipedia.org/wiki/Ратушний_Роман_Тарасович — primary source for the biography, the Protasiv Yar campaign and litigation, the threats, the 2021 prosecution, the military service and KIA, the will, and the commemorations. Used as navigation/chronology.
+- English Wikipedia. «Roman Ratushnyi» — cross-check for unit, call sign, and the death-date variant (gives 9 June).
+- Українська Вікіцитата. «Ратушний Роман Тарасович» — quote provenance for §4.
+
+**Tier 4 (modern scholarly):**
+- *Україна Модерна*. «Випалюйте в собі все російське!» Мнемонічна деколонізація під час російсько-української війни. — scholarly framing of quote 1 (decolonisation memory politics).
+
+**Tier 5 (reputable named outlets — corroborated; primary for a 2022 figure with thin T1/T2 coverage):**
+- The Economist. «Roman Ratushnyi believed in a better, purer Ukraine.» 22 June 2022.
+- Львівський портал; Цензор.НЕТ; Аргумент — memorial pieces carrying the verbatim decolonisation post (§4 quote 1).
+- Херсонська обласна універсальна наукова бібліотека ім. О. Гончара — compilation carrying the Euromaidan-motivation reflection (§4 quote 2).
+
+**Tier 1/Tier 2 note (recency clause):** as a civic activist killed in 2022, Ratushny does not yet have a settled ЕСУ/ЕІУ/ВУЕ encyclopedic article; per the source-tiers recency clause, the dossier is anchored on T3 + reputable T5, with the death-date discrepancy explicitly flagged. This should be re-checked once a T1/T2 entry appears.
+
+**Primary-source documents accessed (in transcription only):** Ratushny's Facebook decolonisation post and his Euromaidan-motivation reflection, accessed via the named outlets above.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Ukrainian civic resistance and self-defence are the frame; the killer is named as the Russian armed forces.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — російсько-українська війна / повномасштабне вторгнення, not «conflict».
+- [x] No uncritical propaganda terms — «радикал/націоналіст» smears named as Russian disinformation (§6); his own «русня» usage is flagged for glossing, not reproduced as the teaching register (§5).
+- [x] No "lost his life" euphemisms — «killed in combat / fell in an enemy ambush» used for the documented KIA.
+- [x] Modern UA place names — Київ, Ізюм, Сулигівка, Харківська область.
+- [N/A] Holodomor — not in his biographical arc.
+- [x] Russian aggression framing — the 2022 full-scale invasion is named as the aggression that killed him; the decolonisation theme (quote 1) is foregrounded.

--- a/docs/research/bio/vasyl-kuk.md
+++ b/docs/research/bio/vasyl-kuk.md
@@ -1,0 +1,188 @@
+# Василь Степанович Кук — Research Dossier
+
+**Slug:** `vasyl-kuk`
+**Block:** G (politically-charged OUN/UPA figure; last UPA Commander-in-Chief; captured and instrumentalised by Soviet security organs)
+**Tier:** 1b
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — liberation-struggle/statehood wave)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+> **Framing note (read first).** This is a politically-charged OUN/UPA figure and the dossier follows the seven-point rule. It holds the whole record: the anti-Soviet/anti-Nazi liberation struggle as primary frame **and** the documented hard facts — the 1937 killing of Polish landowners during an OUN action, the contested 1960 «Відкритий лист» renunciation, and the never-confirmed KGB-cooperation suspicion — without imperial framing, without inflation, and without suppression. **The anti-hagiography anchor is §6.** Hagiography-by-omission (airbrushing the renunciation letter out) is the failure mode this figure invites, and it is refused here.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ т.5; ЕСУ т.16; Українська музична енциклопедія; Політична енциклопедія)
+- [x] Oppression mechanism is specific (dated capture, named recruited agent, prison number, family repression)
+- [x] ≥2 primary-source quotes (1960 «Відкритий лист» closing — contested; 2007 last-interview statement — authentic)
+- [x] Cross-track links: every "Existing" path verified against `origin/main` plan inventory on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+- [x] **Anti-hagiography 7-point rule applied — §6 carries the contested record (Block-G 300+ words)**
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Василь Степанович Кук. [T1: ЕІУ, т. 5, 2009 — «Кук Василь Степанович» (авт. А. В. Кентій); T1: ЕСУ, т. 16, 2016 (авт. Д. В. Вєдєнєєв); T3: uk.wikipedia]
+- **Pseudonyms / aliases:** «Василь Коваль», «Юрко Леміш», «Леміш», «Ле», «Медвідь»; KGB operational designation «Борсук». In prison he was held under the number **«300»**. [T3: uk.wikipedia; T5: Історична правда — «Спіймати „Борсука"»]
+- **Born:** 11 January 1913 | смт Красне, Золочівський повіт | Королівство Галичини та Володимирії, Австро-Угорщина | нині Львівська область. **Source disagreement (flagged):** the article lead gives the modern raion as **Буський**, the body as **Золочівський** — a consequence of Ukraine's 2020 raion reform; the modern oblast (Львівська) is stable. [T1: ЕІУ; T3: uk.wikipedia]
+- **Died:** 9 September 2007 (aged 94) | Київ | Україна | died of old age in his apartment. Buried, per his will, in his native смт Красне; a monument was unveiled there on 12 September 2010. [T1: ЕІУ; T3: uk.wikipedia]
+- **Family / education key facts:** Born to a peasant family (father Степан Матвійович, a railway worker at Красне station; mother Парасковія Федорівна, née Постолюк). **All the Kuk children were members of the OUN.** Two of Vasyl's brothers — **Ілярій and Ілько — were executed by the Polish authorities**; under Soviet rule the whole family was imprisoned and the parents' property confiscated. He studied at the Zolochiv classical gymnasium (1923–1932), was in Пласт from 1927, joined the OUN Youth (Юнацтво) in 1929, and read law at the **Lublin Catholic University**, where he met **Степан Бандера**. [T1: ЕІУ; T3: uk.wikipedia]
+
+Each load-bearing fact (birth, death, capture, the renunciation letter) is cross-checked across ЕІУ (T1), the modern monographs (T4), and uk.wikipedia (T3).
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Kuk's persecution combined Polish, then Soviet repression, and an unusual Soviet *instrumentalisation* of his captured person.
+
+- **What happened:** decades of underground struggle, Polish imprisonment, the execution of two brothers by Poland and the imprisonment of his whole family by the USSR, his own 1954 KGB capture and six years of trial-less imprisonment, and the Soviet exploitation of his 1960 letter for propaganda.
+- **By whom (specific agencies):** the interwar **Polish state** (court conviction 1934; execution of his brothers); then the **NKVD/MGB/КДБ** of the USSR.
+- **When (specific dates):**
+  - **1934:** sentenced by a Polish court to 2 years for revolutionary OUN activity; released 1936.
+  - **23 May 1954:** captured by the КДБ with the help of a **recruited former underground member, «Чумак» (Микола Примас)**, whom Kuk knew personally. He was the highest-ranking OUN leader ever taken alive by the Soviet security organs.
+  - **1954–1960:** held in investigation prisons in **Kyiv and Moscow without any court verdict**, under prisoner number **«300»**; released in 1960 amid Khrushchev's «new course».
+- **Family repression (a second mechanism):** the MGB took Kuk's **three-year-old son Юрій from his wife Уляна Крюченко and placed him in a Mariupol orphanage under a false name (Юрій Чоботар)**; the boy was returned to the rehabilitated family only at thirteen. [T3: uk.wikipedia — §«Родина»]
+- **The instrumentalisation (a distinctly Soviet mechanism):** rather than execute or publicly try him, the Soviet organs extracted the 1960 **«Відкритий лист»** (§4, §6) and deployed it ideologically during de-Stalinisation. The historian **Володимир В'ятрович** reads this as a deliberate Soviet decision to "finish the matter to their own advantage." That the regime turned its prisoner into a propaganda instrument is itself part of the oppression record — and the source of the lasting, never-confirmed suspicion of cooperation (§6).
+- **What survived / what was destroyed:** the armed underground was broken by the mid-1950s; Kuk survived to become, in independent Ukraine, a documentarian of the movement (§3) and a recipient of the Order «За заслуги» (2005). The Soviet state's four-decade branding of the UPA as «бандити»/«буржуазні націоналісти» is recorded here as Soviet framing, not fact (§6).
+
+## 3. Major works
+
+Kuk was a military-political organiser and an underground publicist/historian. Selected, chronological:
+
+- `1938` — *Пашні Буряки*, an OUN conspiracy/clandestinity manual. [T3: uk.wikipedia]
+- `1941` — organiser and head of the OUN **похідні групи** (marching groups) into central, eastern and southern Ukraine; led the Lviv marching group that helped organise the People's Assembly proclaiming the **Act of Restoration of the Ukrainian State, 30 June 1941**. [T1: ЕІУ; T3: uk.wikipedia]
+- `1943` — commander of **УПА-Південь** (UPA-South). [T1: ЕІУ]
+- `April 1944` — commanded the UPA's largest set-piece battle, at **Гурби (Hurby)**. [T3: uk.wikipedia]
+- `1950–1954` — **Head of the OUN Provid in Ukraine, Commander-in-Chief of the UPA, and Head of the УГВР General Secretariat** (succeeding Roman Shukhevych). [T1: ЕІУ]
+- `1952` — *Колгоспне рабство*, an analytical study of the Soviet collective-farm system. [T3: uk.wikipedia]
+- `1970s–1980s` — essays on the composer **Артем Ведель**; `1990s` — biographical essays on Bandera and Shukhevych. [T3: uk.wikipedia; T2: Українська музична енциклопедія, т. 2]
+- `2001` — *Українське державотворення. Акт 30 червня 1941 року*, a fundamental document collection. [T3: uk.wikipedia]
+
+## 4. Primary-source quotes (≥2 required)
+
+> Kuk is not a literary author; his documentary voice is in OUN/UPA documents, his publicism, the 1960 letter, and his late interviews. The two quotes below are deliberately paired to expose the central tension of his life, with provenance flagged. (The literary-corpus `verify_quote` check does not apply.)
+
+**Quote 1 — closing of the «Відкритий лист» (1960), CONTESTED document:**
+
+> «Друзі! Не зв'язуйтеся ні з якою діяльністю проти нашого народу, не дозволяйте себе далі обманювати і використовувати в чужих для вас самих і вашого народу інтересах. Усю свою діяльність в еміграції спрямовуйте на те, щоб не закривати собі шлях на батьківщину.»
+
+The end of the open letter in which Kuk — while a Soviet prisoner — recognised Soviet power in Ukraine, renounced and condemned OUN/UPA aims and methods, and urged the émigré organisations to stop the struggle. **This is presented as a contested, possibly coerced document, not as a settled confession** (§6). Pedagogically it is the hardest, most important Kuk text: it forces learners to weigh capitulation, coercion, and survival. [Primary document, 1960; text via T3: uk.wikipedia; status contested — read with §6]
+
+**Quote 2 — last interview (2007), AUTHENTIC late-life voice:**
+
+> «Ми перемогли, в нас з'явилася держава, тепер треба її будувати, а не партизанити.»
+
+Spoken in his final interview, in independent Ukraine — he frames the entire armed struggle as having reached its goal in the 1991 statehood, which now must be *built*, not continued by force. Set against Quote 1, it shows a man whose lodestar was statehood over perpetual insurgency. (In the same interview: «УПА — єдина з усіх сил європейського антифашистського опору, яка вела бойові дії проти нацистів без іноземної допомоги», and the title line «У мене немає орденів».) [Last interview, 2007 («Газета по-київськи»), via T5: Історична правда / rozmova reprint; authentic, attested]
+
+**Honest gap (§4 + §10):** the «Відкритий лист» is quoted from the uk.wikipedia transcription, not from the archival original; the 2007 interview lines are from a reputable reprint of a since-defunct newspaper. Both are labelled accordingly.
+
+## 5. Language register
+
+- **Register:** Kuk's surviving register is **командно-підпільна та публіцистична** — terse military-organisational Ukrainian (orders, the conspiracy manual), analytical prose («Колгоспне рабство»), and, late in life, plain-spoken interview Ukrainian. The 1960 letter is in a distinctly Soviet-officialese register — itself a tell of its provenance.
+- **CEFR readiness for studying him:** the *biography and historiography* are advanced — the source debates (зречення, колаборація, the betrayal-vs-strategy question) sit at **C1–C2**. He is not A1–B1 material.
+- **Lexicon notes (pre-teach):** головнокомандувач, повстанська (армія), підпілля, провід, екзекутива, похідні групи, зречення, відкритий лист, реабілітація, генерал-хорунжий. The noun **зречення** (renunciation/abjuration) is the key term for §6.
+- **Stylistic features:** the contrast between the bureaucratic, deindividualised idiom of the 1960 letter and the direct, personal voice of the 2007 interview is itself a teaching point about documentary register and provenance.
+
+## 6. Contested points
+
+> This section applies `docs/best-practices/politically-charged-bios.md` and is the longest (Block-G requirement). It is the **anti-hagiography anchor** the brief demands.
+
+**(a) The 1960 «Відкритий лист» — the betrayal-vs-strategy debate (epistemic humility required, NOT omitted).** As a КДБ prisoner since 1954, Kuk wrote (or signed) an open letter to Yaroslav Stetsko, Mykola Lebed, Stepan Lenkavsky, Daria Rebet, Ivan Hrynokh and "all Ukrainians abroad," recognising Soviet power, condemning OUN/UPA principles and methods, and calling on the émigré movement to cease the struggle and accept the USSR. The interpretations genuinely diverge and the dossier **does not resolve them**:
+  - *Coercion reading:* it «можливо… був вимушений крок… зроблений під тиском КДБ СРСР, що не відображав справжньої позиції» — a forced text. Kuk himself, asked in the early 2000s at a КУН gathering whether he personally signed it, replied only: «а що ви не знаєте, як тоді [за Совєтів] підписувались подібні документи?!» — an oblique non-answer.
+  - *Instrumentalisation reading (В'ятрович):* the Soviet organs deliberately produced and used the letter for ideological ends during de-Stalinisation.
+  - *Suspicion reading:* the letter, plus the fact that Kuk faced no further notable repression and lived openly, fed a **lasting suspicion of KGB cooperation — which was never confirmed**. The honest statement: the document is real and damaging on its face; the coercion is plausible and partly self-attested; the cooperation is suspected but unproven. All three are held at once.
+
+**(b) The 1937 killing of the Jasiński landowners — anti-Polish violence, named.** As Zolochiv county OUN leader, Kuk organised a May 1937 attack on the Polish landowner couple **Jasiński (Ясінські)**; against the OUN plan, the couple were **killed by Kuk's brother Ілярій**. This belongs to the interwar OUN terror campaign against Polish authority and Polish civilians, and it is named here as a killing, not euphemised. It is also a reminder that the OUN's pre-war record includes political violence that modern Ukrainian historiography does not airbrush.
+
+**(c) The internal strategic split (1943).** At the III OUN Conference (February 1943) Kuk **supported Mykhailo Stepaniak's line of limiting the insurgent struggle to the anti-German front**, against Shukhevych and others who insisted on the anti-Soviet front too. This matters twice over: it shows the OUN/UPA was **not monolithic** (a fact both Soviet and some nationalist framings flatten), and it complicates any caricature of Kuk as a simple hardliner.
+
+**(d) The wider OUN/UPA contested record, honestly scoped.** The gravest items in OUN/UPA historiography — the 1943 anti-Polish ethnic cleansing in Volhynia and Holocaust-era complicity — are documented in the scholarship (Motyka; Himka; В'ятрович offers the Ukrainian counter-reading). Kuk's own command was **УПА-Південь and the central-eastern/southern lands**, away from the Volhynia epicentre (directed by UPA-North commander Дмитро Клячківський). This dossier neither assigns him the Volhynia campaign personally nor uses his distance from it to absolve the organisation he later led; the organisational responsibility belongs in the dedicated HIST module (§7 candidate), built honestly.
+
+**(e) Modern memory and Russian/Soviet disinformation.** Independent Ukraine awarded Kuk the Order «За заслуги» (2005), renamed streets, and in January 2026 named a Сили безпілотних систем training centre after him. Soviet propaganda branded the movement «бандити»/«буржуазні націоналісти»; modern Russian propaganda recycles "Bandera/UPA = Nazi." VoxUkraine has specifically **debunked a manipulation** that misattributes to Kuk the claim that "Ukrainians did not exist before 1918." Naming this is necessary; it does not erase (a)–(d).
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the `origin/main` plan inventory (`git ls-tree -r origin/main curriculum/l2-uk-en/plans/`) on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/vasyl-kuk.yaml` — his own plan (this dossier is its research base).
+  - `curriculum/l2-uk-en/plans/bio/roman-shukhevych.yaml` — his predecessor as UPA Commander-in-Chief, whom he succeeded in 1950 and deputised from 1947.
+  - `curriculum/l2-uk-en/plans/bio/stepan-bandera.yaml` — OUN-B leader, whom Kuk met at the Lublin Catholic University.
+  - `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml` — OUN founder.
+  - `curriculum/l2-uk-en/plans/bio/andrii-melnyk.yaml` — the rival OUN-M faction (1940 split context).
+  - `curriculum/l2-uk-en/plans/bio/dmytro-kliachkivskyi.yaml` — UPA-North commander tied to Volhynia 1943; essential for the §6(d) responsibility distinction.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-dontsov.yaml` — the integral-nationalist ideology that shaped the OUN.
+  - `curriculum/l2-uk-en/plans/bio/yaroslav-stetsko.yaml` — a chief addressee of the 1960 «Відкритий лист».
+  - `curriculum/l2-uk-en/plans/bio/kateryna-zarytska.yaml` — OUN liaison of the same underground generation.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/upa.yaml` — the army he ultimately commanded.
+  - `curriculum/l2-uk-en/plans/hist/oun.yaml` — the organisation and its 1929/1940 history.
+  - `curriculum/l2-uk-en/plans/hist/pacyfikatsiia.yaml` — interwar Polish pacification of Galicia (the OUN-terror context of §6b).
+  - `curriculum/l2-uk-en/plans/hist/druha-svitova-pochatok.yaml` — the WWII opening that frames the 1941 marching groups.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the Soviet terror mechanism that captured and instrumentalised him.
+  - `curriculum/l2-uk-en/plans/hist/deportatsii-ukraintsiv.yaml` — the post-war repression of UPA milieu and families (his son's case, §2).
+  - `curriculum/l2-uk-en/plans/hist/destalinizatsiia.yaml` — the de-Stalinisation context of his 1960 release and the letter's use.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated HIST module on **Волинь 1943 / польсько-українська війна** — where the Motyka/В'ятрович debate (§6d) belongs; no plan yet.
+  - A bio-to-bio tie with `mykhailo-stepaniak` (the 1943 anti-German-only line) — no plan yet.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A method module on **reading a coerced document** anchored on the 1960 «Відкритий лист» — a model for source-criticism pedagogy.
+
+## 8. Naming-canonical
+
+- **Slug:** `vasyl-kuk`
+- **EN canonical (BGN/PCGN-style project spelling):** Vasyl Kuk
+- **UA canonical (with patronymic):** Василь Степанович Кук
+- **Aliases to track (`aliases:` YAML field):** Vasyl Kuk; «Юрко Леміш» / «Леміш» (chief pseudonym); «Коваль»; «Медвідь»; «Борсук» (KGB designation).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** «Василий Степанович Кук» (Russified); "Kuk" rendered via Russian transliteration of his pseudonyms.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **«Vasyl Kuk»** holds underground-era and late-life photographs; verify the license on each **file page** (wartime photos may be PD-by-age; 2000s photos need a specific tag). [Commons category: `Vasyl Kuk`]
+- **Backup candidates:**
+  - The Красне monument (unveiled 12 September 2010) — context image, verify rights.
+  - Укрпошта/commemorative materials marking his anniversary — verify PD/rights.
+- **Context image (use with care):** a rights-clear facsimile page of the 1960 «Відкритий лист» would powerfully illustrate §6 and the source-criticism lesson.
+- **If no rights-clear portrait clears review:** fall back to a PD interwar OUN-era group photo with clear licensing.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- А. В. Кентій. «Кук Василь Степанович» // *Енциклопедія історії України*, т. 5 (Кон–Кю). — К.: Наукова думка, 2009. — С. 456. (Identity, chronology, command roles.)
+- Д. В. Вєдєнєєв. «Кук Василь Степанович» // *Енциклопедія сучасної України*, т. 16. — К., 2016. — С. 22.
+- В. Кучер. «Кук Василь Степанович» // *Політична енциклопедія*. — К.: Парламентське видавництво, 2011. — С. 378.
+
+**Tier 2 (institutional):**
+- «Кук Василь Степанович» // *Українська музична енциклопедія*, т. 2. — Київ: ІМФЕ НАНУ, 2008. — С. 635. (His Vedel essays.)
+- Електронний архів Українського визвольного руху (avr.org.ua) — Vasyl Kuk documents (named as the primary-document home; not exhaustively opened this pass).
+
+**Tier 3 (encyclopedic — freshly fetched 2026-06-04):**
+- Українська Вікіпедія. «Кук Василь Степанович». https://uk.wikipedia.org/wiki/Кук_Василь_Степанович — detailed source for the biography, the marching groups, the capture, the «Відкритий лист» text, the family repression, and the commemorations. Used for chronology; the §6 historiography is anchored on the T4 monographs below.
+
+**Tier 4 (modern scholarly):**
+- Аліна Пониполяк. *Останній командир УПА. Життя і боротьба Василя Кука.* — К.: Наш Формат, 2021. — 256 с. (The brief's named monograph.)
+- Володимир В'ятрович. *Генерал Кук. Біографія покоління УПА.* — Харків: Vivat. (The brief's named historian; source for the instrumentalisation reading of the 1960 letter.)
+- Д. В. Веденеев. *Одиссея Василия Кука. Военно-политический портрет последнего командующего УПА.* — К.: К.И.С., 2007.
+- Я. Антонюк, В. Ковальчук. «Василь Кук у повсякденному житті (кін. 1940-х – поч. 1950-х рр.)» // Славістична збірка, вип. 2. — Інститут української археографії та джерелознавства ім. М. С. Грушевського НАН України, 2016. — С. 400–412.
+
+**Tier 5 (reputable named outlets — corroborated):**
+- Історична правда — «Останній бій останнього командира УПА»; «Спіймати „Борсука". Арешт Василя Кука» (the 1954 capture).
+- VoxUkraine — debunk of the "Ukrainians did not exist before 1918" misattribution (§6e).
+- «Газета по-київськи» (2007) last interview, preserved via Історична правда / rozmova reprint (§4 quote 2).
+
+**Primary-source documents accessed (in transcription only):** the 1960 «Відкритий лист» (closing quoted §4/§6) and the 2007 last-interview statements, accessed via the transcriptions above; the ГДА СБУ case file («300») and the archival original of the letter were not opened this pass (honest gap).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — the liberation struggle is the primary frame; the Soviet/КДБ role is named as oppressor **and** the hard facts (1937 Jasiński killing, the 1960 letter) are not suppressed.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — Друга світова війна / повстанська боротьба, not «Great Patriotic War».
+- [x] No uncritical Soviet propaganda terms — «бандити»/«буржуазні націоналісти» appear only as named Soviet framing (§2, §6e).
+- [x] No "lost his life" euphemisms — the 1937 Jasiński deaths are named as a killing; Kuk's own death (old age, 2007) stated plainly.
+- [x] Modern UA place names — Красне, Львівська область, Київ, Гурби.
+- [N/A] Holodomor — not directly in his arc; «Колгоспне рабство» (his study of collective-farm coercion) is noted instead.
+- [x] Russian aggression framing — the Soviet capture and instrumentalisation are named; the modern Russian recycling of the "UPA = Nazi" libel is flagged (§6e).
+- [x] **No advocacy closing** — the dossier ends on the contested record and an honest-gaps list, not on vindication.

--- a/docs/research/bio/viacheslav-chornovil.md
+++ b/docs/research/bio/viacheslav-chornovil.md
@@ -1,0 +1,164 @@
+# В'ячеслав Максимович Чорновіл — Research Dossier
+
+**Slug:** `viacheslav-chornovil`
+**Block:** F (Soviet-era dissident / шістдесятник; political prisoner; national-democratic statehood leader)
+**Tier:** 1a
+**Issue:** #2535 (original-180 ghost-wiki dossier uplift — liberation-struggle/statehood wave)
+**Researcher:** Claude Opus 4.8 (`claude-opus-4-8`)
+**Completed:** 2026-06-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ т.10; Інститут історії НАНУ; Політична енциклопедія 2011)
+- [x] Oppression mechanism is specific (dated court sentences, named camps, article of the Criminal Code, hunger-strike length)
+- [x] ≥2 primary-source quotes (1966 court last word; 1997 published warning — provenance flagged)
+- [x] Cross-track links: every "Existing" path verified against `origin/main` plan inventory on 2026-06-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** В'ячеслав Максимович Чорновіл. [T1: ЕІУ, т. 10, 2013 — «Чорновіл В'ячеслав Максимович» (авт. В. П. Швидкий); T3: uk.wikipedia — «Чорновіл В'ячеслав Максимович»]
+- **Pseudonyms / aliases:** publicist who wrote under his own name; the underground samvydav he edited circulated unsigned or under the masthead «Український вісник». No durable literary pseudonym attested.
+- **Born:** 24 December 1937 | село (нині смт) Єрки, Катеринопільський район, тоді Київська область (нині Черкаська область) | Українська РСР, СРСР. **Source disagreement (flagged, not smoothed):** ЕІУ records the birth as «24 грудня 1937 (офіційно — 1 січня 1938)» — i.e. the registered/official date differs from the actual one. Both are recorded here rather than collapsing them. [T1: ЕІУ, т. 10; T3: uk.wikipedia]
+- **Died:** 25 March 1999 (aged 61) | 5-й км шосе Бориспіль — Золотоноша, поблизу Борисполя, Київська область | Україна | died in a car crash whose circumstances remain officially ruled an accident but are contested (§2, §6). [T1: ЕІУ, т. 10 — «помер 25 березня 1999»; T3: uk.wikipedia — §«Загибель»]
+- **Family / education key facts:** Born to a family of village teachers. Father **Максим Йосипович** came from an old Cossack line of the Чорноволи; mother **Килина Харитонівна Терещенко** belonged to one branch of the **Терещенки** family of sugar-industrialists and philanthropists. The family was already repressed under Stalin — the father's brother **Петро Йосипович Чорновіл was arrested in 1937 and never returned from imprisonment**. Chornovil finished the Vilkhovets secondary school with a gold medal (1955), studied at Kyiv State University (philology, then the journalism faculty), and graduated with distinction in 1960; his diploma thesis was on the publicism of **Борис Грінченко**, a then-banned writer. In 1964 he passed his candidate examinations and won a place in aspirantura but was barred from study for his political views, blocking the defence of an almost-finished dissertation on Hrinchenko. [T3: uk.wikipedia — §«Дитинство та юність»; T1: ЕІУ]
+
+Cited from at least two sources for each load-bearing fact (birth, death, repression). ЕІУ and uk.wikipedia agree on the 24.12.1937 / 25.03.1999 dates; the «officially 1 January 1938» variant is preserved as a flagged discrepancy.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section. Chornovil's persecution was sustained, judicial, and explicitly about suppressing Ukrainian-language journalism and the dissident word.
+
+- **What happened:** repeated arrest, show-trial conviction, strict-regime camp imprisonment, internal exile, and after death the destruction of his archive — a persecution arc spanning the Soviet КДБ era and continuing, posthumously, into Russia's 2022 invasion.
+- **By whom (specific agency):** the **КДБ УРСР** and Soviet courts (Львівський обласний суд and others), charging him under the «антирадянська агітація та пропаганда» articles of the Criminal Code of the UkrSSR.
+- **When (specific dates) and the three terms:** ЕІУ records the political-prisoner periods as **1967–1969, 1972–1978, 1980–1985**. [T1: ЕІУ, т. 10] In detail:
+  - **1966:** for refusing to give evidence at the closed trial of the brothers Богдан і Михайло Горинь, sentenced to three months of forced labour. His documentary study «Правосуддя чи рецидиви терору?» dates to May 1966.
+  - **15 November 1967:** the Lviv oblast court sentenced him to **3 years in strict-regime camps**, triggered by his compiling «Лихо з розуму» (Портрети двадцяти «злочинців»), a dossier on the 1965–66 arrests of the шістдесятники. Released 1969.
+  - **1972:** arrested in the all-Ukraine «зачистка» (general purge of the Ukrainian intelligentsia); sentenced to **6 years of camps plus 3 years of exile**. Served in the Mordovian political-prisoner camps **ЖХ-385/17-А (с. Озерне)** and **ЖХ-385/3 (с. Барашево)**; spent over half the term in the punishment isolator (ШІЗО) and cell-type premises (ПКТ); then exiled to **с. Чаппанда, Якутія**.
+  - **April 1980:** re-arrested at exile on a fabricated charge (in reality for his Helsinki-Group activity and opposition statements); held a **120-day protest hunger strike**; sentenced to 5 years. In his last word he accused the КДБ and police of fabrication and called on the court to refuse complicity. Released 1983 by a prosecutor's protest, but without the right to return to Ukraine; worked as a boiler-stoker.
+- **Document references (quoted, not paraphrased):** the title of «Лихо з розуму» itself records the regime's intent — Chornovil related that the Lviv КДБ captain Клименко told him he was «дуже розумний і що мені цей розум трохи збавлять» («very clever, and that this cleverness of mine would be cut down a little»), which the author turned into the book's ironic title. [T3: uk.wikipedia / chtyvo.org.ua — «Лихо з розуму»]
+- **What survived / what was destroyed:** his samvydav and camp manuscripts were smuggled abroad and survive — «Хроніка таборових буднів» (1975) was published in «Сучасність» (1976); fragments of «Тільки один рік» were reconstructed from a smuggled manuscript; the ten-volume collected works (Смолоскип, 2002–2015) preserve the corpus. **In April 2022 Russian occupying forces destroyed В'ячеслав Чорновіл's archive in Bucha** — a posthumous extension of the same imperial assault on Ukrainian memory. [T3: uk.wikipedia, citing Львівський портал, 20.04.2022]
+
+## 3. Major works
+
+Chornovil's «works» are documentary journalism, samvydav editing, and political acts; in chronological order:
+
+- `1965` — open letter of 15 September 1965 to the CC of the Ukrainian Communist Party and Komsomol; articles «З приводу процесу над Погружальським», «В шовіністичному зашморзі», «12 запитань до тих, хто вивчає суспільствознавство». [T3: uk.wikipedia]
+- `1966` — *Правосуддя чи рецидиви терору?*, documentary study of the 1965 arrests and trials. Suppressed in the USSR; later cited in his Shevchenko Prize. [T1: ЕІУ]
+- `1967` — *Лихо з розуму (Портрети двадцяти «злочинців»)*, his best-known book — twenty portraits of arrested шістдесятники; published abroad, it raised an international defence campaign credited with saving some of the imprisoned. [T3: uk.wikipedia]
+- `1970–1972, 1987–1989` — *Український вісник*, the underground journal he founded, edited and published in Lviv — the central самвидав organ of the Ukrainian national-democratic resistance; revived in 1987 with its «Експрес-випуск». [T3: uk.wikipedia]
+- `1975` — *Хроніка таборових буднів* (with Борис Пенсон), smuggled out and published 1976 in «Сучасність». [T3: uk.wikipedia]
+- `1977–1978` — *Тільки один рік*, brochure on the camp struggle for political-prisoner status; survives only in fragments. [T3: uk.wikipedia]
+- `2002–2015` — *Твори у 10 томах* (К.: Смолоскип; голова редколегії Атена Пашко), the posthumous collected works. [T3: uk.wikipedia — «Зібрання творів»]
+
+## 4. Primary-source quotes (≥2 required)
+
+> Chornovil is a **documentary publicist and orator**, not a belletrist, so the project's `verify_quote` literary-corpus check returned no match (confirmed: `verify_quote(author="Чорновіл", text="Лихо з розуму") → matched:false` on 2026-06-04 — expected, his corpus is journalism, not in the literary index). Both quotes below are therefore given **with explicit provenance flags**.
+
+**Quote 1 — last word at the Lviv trial, 8 July 1966 (court statement, transmitted via the rehabilitative/biographical record):**
+
+> «…немає страшнішої кари за муки нечистого сумління, бо немає вищого судді за правду.»
+
+Spoken in his final statement to the court, after he declared he had no illusions about the verdict yet would say the same even under threat of prison or hard labour. It is the moral keynote of the entire dissident generation — conscience above the state's law — and the pedagogical anchor for the шістдесятники theme. [Court last word, 8.07.1966; attested via T5: NV / uk.wikiquote, family-transmitted; flagged court-statement provenance]
+
+**Quote 2 — published warning on Russian imperialism, 1997 (his own statement, prescient):**
+
+> «Над Україною нависає зловісна двоголова тінь російського імперіалізму, який тільки й чекає остаточного колапсу нашого суспільства…»
+
+Written years before 2014 and 2022, this names the threat Chornovil spent his life resisting and the danger he saw outliving the USSR. Pedagogically it lets learners connect the dissident generation directly to the present war. [1997; attested via T3: uk.wikiquote, citing pivnich.org.ua; flagged secondary-attested — verbatim form to be re-confirmed against the Смолоскип collected works before any learner-facing use]
+
+**Honest gap (§4 + §10):** both quotations are attested through reliable secondary transmission (NV, uk.wikiquote citing named outlets) rather than from a direct read of the Смолоскип ten-volume edition this pass; they are labelled accordingly, and the 1997 wording should be checked against Т. 9–10 of the collected works before publication.
+
+## 5. Language register
+
+- **Register:** documentary-publicistic and forensic — Chornovil's signature is the *evidentiary* mode: court documents, protocols, biographical portraits, and polemical open letters written in precise, controlled literary Ukrainian. As an orator (Rukh rallies, parliament) his register is high civic rhetoric.
+- **CEFR readiness for full reading:** **B2–C1.** «Лихо з розуму» and the open letters are accessible to advanced learners; the legal-documentary vocabulary and the dense political context push full study to C1.
+- **Lexicon notes (pre-teach):** самвидав, дисидент, шістдесятники, політв'язень, табір суворого режиму, заслання, антирадянська агітація, правозахисний, національно-визвольний, суверенітет, зросійщення. The historism **зросійщення** (Russification) is itself a teaching point — the precise Ukrainian term the regime tried to suppress.
+- **Stylistic features:** measured irony (the title «Лихо з розуму» plays on Griboedov), documentary citation, and the rhetorical antithesis of his oratory («Народу — справедливість, бандитам — тюрми»).
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** chiefly the **manner of his death**. The official investigation (concluded 2018) ruled the 25 March 1999 crash a traffic accident; the car struck a КамАЗ with a trailer turning across the highway in normal visibility. His son **Тарас Чорновіл**, close colleagues, and a substantial part of the public regard it as a **political assassination on the eve of the 1999 presidential campaign**. The suspicions are not folklore: the MVS head Юрій Кравченко declared it an accident the next morning before expert conclusions; the case was repeatedly closed and reopened (exhumation 2011; further forensic expertise 2017–2018); and in 2022 ex-deputy prosecutor-general **Микола Голомша** alleged, on the basis of pathology, that the injured Chornovil was finished off with a кастет (knuckle-duster) and that the scene protocol was falsified. **The honest statement:** the documented official verdict is "accident"; serious, named, unresolved suspicions of murder remain; this dossier asserts neither that it was proven murder nor that the suspicions are baseless. [T3: uk.wikipedia — §«Загибель», §«Розслідування»]
+- **What gets simplified in popular memory:** Chornovil is sometimes flattened into a martyr-icon, which obscures the *journalist* and the hard organiser — and the bruising 1998–99 internal Rukh split with Юрій Костенко that preceded his death. His own life was complicated (three marriages; a fierce, uncompromising temperament colleagues both admired and clashed with).
+- **Where Russian disinformation attacks:** the Soviet frame branded him a «буржуазний націоналіст» and «антирадянський елемент»; the modern recycling is to dismiss the dissident movement wholesale as Western-sponsored. Naming this is necessary; it does not touch the documented facts.
+- **Other-perspective considerations:** his mother's descent from the Терещенки sugar dynasty is a point of social-history interest, not contestation.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was checked against the `origin/main` plan inventory (`git ls-tree -r origin/main curriculum/l2-uk-en/plans/`) on 2026-06-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/viacheslav-chornovil.yaml` — his own plan (this dossier is its research base).
+  - `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml` — co-protester at the 1965 «Україна» cinema demonstration; fellow шістдесятник.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml` — co-protester 1965; «Український вісник» contributor; died in the camps.
+  - `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml` — central шістдесятник, his close Kyiv circle.
+  - `curriculum/l2-uk-en/plans/bio/yevhen-sverstiuk.yaml` — fellow dissident essayist, «Український вісник» author.
+  - `curriculum/l2-uk-en/plans/bio/alla-horska.yaml` — шістдесятники artist, profiled in «Лихо з розуму»'s milieu.
+  - `curriculum/l2-uk-en/plans/bio/ihor-kalynets.yaml` and `curriculum/l2-uk-en/plans/bio/iryna-kalynets.yaml` — his closest Lviv circle who helped produce «Український вісник».
+  - `curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml` — to whom Chornovil ceded the УГС chairmanship; fellow long-term political prisoner.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-horyn.yaml` and `curriculum/l2-uk-en/plans/bio/bohdan-horyn.yaml` — the Horyn brothers, at whose trial his refusal to testify began his repression.
+  - `curriculum/l2-uk-en/plans/bio/serhii-paradzhanov.yaml` — director of «Тіні забутих предків», whose premiere was the site of the 1965 protest.
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` — subject of his diploma thesis and blocked dissertation.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/shistdesiatnyky.yaml` — the generation he helped found.
+  - `curriculum/l2-uk-en/plans/hist/ukrainska-helsinska-hrupa.yaml` — the UHG he joined in 1979.
+  - `curriculum/l2-uk-en/plans/hist/rukh.yaml` — the People's Movement he led to 1999.
+  - `curriculum/l2-uk-en/plans/hist/nezalezhnist-1991.yaml` — the independence he helped initiate (1990 sovereignty declaration; 1991 independence act).
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` — the Soviet repression machinery that imprisoned him.
+  - `curriculum/l2-uk-en/plans/hist/shliakh-nezalezhnosti.yaml` — the road-to-independence frame.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A bio-to-bio tie with `atena-pashko` (his third wife, fellow dissident and editor of his collected works) — no plan yet.
+  - A HIST case-study on **1999 / the Chornovil crash and its investigations** as a "reading-a-contested-death" method module — no plan yet.
+- **Potential additions surfaced (file as `bio-expansion-followup`, do not add unilaterally):**
+  - A LIT/journalism module on **самвидав as genre** anchored on «Український вісник».
+
+## 8. Naming-canonical
+
+- **Slug:** `viacheslav-chornovil`
+- **EN canonical (BGN/PCGN-style project spelling):** Viacheslav Chornovil
+- **UA canonical (with patronymic):** В'ячеслав Максимович Чорновіл
+- **Aliases to track (`aliases:` YAML field):** Viacheslav Chornovil; В'ячеслав Чорновіл.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** «Вячеслав Черновол» (Russified transliteration); «Вячеслав Максимович Черновол».
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category **«Viacheslav Chornovil»** holds late-Soviet/independence-era photographs; license must be checked on each **file page** (several press and Rukh-era photos require a specific tag). [Commons category: `Viacheslav Chornovil`]
+- **Backup candidates:**
+  - Укрпошта commemorative stamp(s) and the 2002 Золочів monument — verify stamp/monument-photo rights before use.
+  - The Музей-садиба Героя України В. М. Чорновола in с. Вільхівець — context image, verify rights.
+- **Context image (use with care):** a facsimile page of «Український вісник» самвидав, or the cover of «Лихо з розуму» (Diasporiana digitisation), would strongly illustrate §3.
+- **If no rights-clear portrait clears review:** fall back to a PD parliamentary/Rukh-rally photo with clear licensing.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- *Енциклопедія історії України*, т. 10 (Т–Я), 2013 — «Чорновіл В'ячеслав Максимович», авт. В. П. Швидкий. resource.history.org.ua. Accessed 2026-06-04. (Source for the 1967–69 / 1972–78 / 1980–85 political-prisoner periods and the «офіційно — 1 січня 1938» birth-registration variant.)
+- Інститут історії України НАН України — «Цей день в історії» calendar entry for Chornovil (referenced via uk.wikipedia external links). Accessed 2026-06-04.
+- В. Пономарьов. «Чорновіл В'ячеслав Максимович» // *Політична енциклопедія* / редкол.: Ю. Левенець, Ю. Шаповал та ін. — К.: Парламентське видавництво, 2011. — С. 777. (T1/T2 reference work.)
+
+**Tier 3 (encyclopedic — freshly fetched 2026-06-04):**
+- Українська Вікіпедія. «Чорновіл В'ячеслав Максимович». https://uk.wikipedia.org/wiki/Чорновіл_В'ячеслав_Максимович — detailed source for the biography, the three imprisonments, the camps, the 1999 crash and its investigations, and the 2022 Bucha archive destruction. Used for navigation/chronology; dates cross-checked against ЕІУ.
+- Українська Вікіцитата. «Чорновіл В'ячеслав Максимович» — quote provenance for §4.
+
+**Tier 5 (general web — corroborated):**
+- NV. «Як у 1966 році 29-річний журналіст Чорновіл отримав свій перший вирок». — context for the 8.07.1966 last word (§4 quote 1).
+- Diasporiana / chtyvo.org.ua digitisations of «Лихо з розуму» — primary-text leads (cited, not fully read this pass).
+
+**Primary-source documents accessed (in transcription only):** the 8 July 1966 court last word and the title-origin anecdote of «Лихо з розуму», accessed in transcription via the above; the КДБ case files and the full Смолоскип collected works were not opened this pass (honest gap, §4).
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — the national-democratic liberation movement is the frame; the КДБ/Soviet role is named as oppressor.
+- [x] No Russian-imperial transliterations in body text — confined to §8, labelled FORBIDDEN.
+- [x] No Russocentric periodization — «зросійщення», «національно-визвольний рух», not Soviet euphemisms.
+- [x] No uncritical Soviet propaganda terms — «буржуазний націоналіст» appears only as a named Soviet label (§6).
+- [x] No "lost his life" euphemisms — the death is named as a contested crash; the official "accident" verdict and the unresolved murder suspicions are both stated without euphemism.
+- [x] Modern UA place names — Київ, Львів, Черкаська область; Бориспіль; Yakutian places in standard forms.
+- [N/A] Holodomor — not in his biographical arc (b. 1937); the family's Stalin-era repression (1937 arrest of his uncle) is named instead.
+- [x] Russian aggression framing — the 1997 warning and the 2022 destruction of his Bucha archive tie his life directly to the current Russian invasion.


### PR DESCRIPTION
## Bio dossier batch — 6 figures (original-180 uplift, #2309 / #2535)

Six NPOV-severe research dossiers under `docs/research/bio/`. All 10 template sections, ≥1500-word floor (range 2452–3110), every factual claim tool-verified, every §7 "Existing" cross-track path checked against `origin/main`. Honour without hagiography; war-dead dignified + factual; martyrology sourced, not myth.

### Figures
1. **`viacheslav-chornovil`** — sixtier dissident, Rukh founder; three Soviet imprisonments (1967–69 / 1972–78 / 1980–85, per ЕІУ); «Лихо з розуму», «Український вісник»; the 1999 Boryspil crash stated honestly (official "accident" verdict **and** the named, unresolved murder suspicions); 2022 Bucha archive destruction.
2. **`oleg-sentsov`** — Crimean filmmaker & political prisoner (**living**); 2014 FSB case, 20-yr sentence, 145-day hunger strike, 2019 exchange, now serving. Living-person NPOV: Russian charge and the international human-rights verdict held side by side.
3. **`roman-ratushny`** — civic activist & soldier, KIA near с. Сулигівка **8.6.2022**; Protasiv Yar campaign; dignified war-dead; decolonization quote («Випалюйте в собі…») with the *Україна Модерна* scholarly framing.
4. **`vasyl-kuk`** — last UPA Commander-in-Chief; **anti-hagiography anchored on the contested 1960 «Відкритий лист»** (coercion / В'ятрович's instrumentalisation reading / never-confirmed cooperation suspicion — left unresolved); the 1937 Jasiński killing and the 1943 strategic split named.
5. **`olena-stepaniv`** — one of the first women officially commissioned as a military officer (хорунжа УСС, 1914); geographer & НТШ member; Stalinist camps 1950–56 (Mordovia).
6. **`olha-basarab`** — Союз українок / UVO liaison, UNR/ZUNR diplomat; died in **Polish** police custody 1924 — martyrology handled as *sourced, not myth* (documented torture vs. the unverified "wall inscription"; Polish-state perspective named; oppressor is the Second Polish Republic, not Russia).

### Gates
- `lint_bio_dossier_xref.py` — **PASS** (repo-wide; pre-commit §7 validator also green)
- `check_dossier_wordcount.py --changed` — **PASS** (all 2452–3110 words, floor 1200)
- `verify_quote` run on the (non-literary) figures returns `matched:false` as expected — every quote is flagged with honest secondary provenance; **none** claimed as a literary-corpus attestation.

### Source discipline
Tiered citations throughout (T1 ЕІУ/ЕСУ/ВУЕ · T2 institutional/НТШ/СЗРУ/Shevchenko Cttee · T3 uk.wikipedia · T4 named scholarship · T5 reputable outlets). Source disagreements flagged not smoothed (e.g. Chornovil's 1937-vs-officially-1938 birth registration; Ratushny 8-vs-9 June death date; Basarab 1 Sept vs ЕСУ 24 July). Honest gaps documented per dossier.

**NO auto-merge.**