### PR TITLE
test(ci): mark leaked Stanza model tests slow — close #2691 hermetic-CI gap

### DIFF
--- a/docs/bug-autopsies/stanza-model-md5-flake.md
+++ b/docs/bug-autopsies/stanza-model-md5-flake.md
@@ -53,6 +53,34 @@ a comment in `ci.yml` explaining why the exclusion is load-bearing, and records
 this autopsy. Out of scope: vendoring/pinning the model with an integrity check
 for the `slow`/local path (follow-up).
 
+### Gap closed 2026-06-05 (`fix/stanza-slow-marker-ci-hermetic`)
+
+#2691's `slow`-marking was **incomplete** — it covered `test_stress_annotation.py`
+but missed two other model-loading test paths that stayed in the required gate:
+
+- `tests/test_post_processor_mutation_invariant.py` — its parametrized
+  `test_post_processor_stays_in_class` runs over *every* registered processor,
+  including `pipeline.stress_annotator.annotate_stress`, which loads Stanza (25
+  fixture params).
+- `tests/test_immersion_rule_ulp.py::test_ulp_fidelity_correction_reruns_stress_and_gate`
+  and `::test_linear_pipeline_stress_annotation_marks_module_and_vocabulary` —
+  both call `run_stress_annotation` / `run_ulp_fidelity_with_correction`.
+
+Because the model download is intermittently corrupt, these passed on a clean
+download and failed on a corrupt one — so the required `Test (pytest)` check
+flaked on every `requirements-lock.txt` PR (e.g. dependabot #2543/#2710 red while
+#2545/#2542/#2541 green on the same day). The fix marks exactly those model-backed
+parametrizations/tests `slow`; the surgical marker on the post-processor test
+keeps all *other* processors' invariant checks in the required gate. Verified:
+required selector now collects 0 stress_annotator params and 0 of the 2 immersion
+model tests; the `slow` subset still passes (27 passed) when run with the model.
+
+**Residual risk:** the existing prevention only guards the *selector* (`-k "not
+slow"`); it does not guarantee a newly-added model-loading test gets the `slow`
+marker. A future test that constructs the Stressifier without the marker would
+re-introduce the leak. The durable guard (a collection-time assertion that no
+required test imports/constructs the model) remains a follow-up.
+
 ## Prevention
 
 - **Required CI must be hermetic** — no live model/network downloads in the

--- a/tests/test_immersion_rule_ulp.py
+++ b/tests/test_immersion_rule_ulp.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts import config
 from scripts.audit.ulp_fidelity_gate import _UK_WORD_RE, check_ulp_fidelity
 from scripts.build import linear_pipeline, v7_build
@@ -200,6 +202,11 @@ The word **вода́** is useful in the morning because you see it in routines,
     assert "em_dash_gloss" in report["failed_checks"]
 
 
+# Loads the live Stanza Ukrainian model (run_ulp_fidelity_with_correction →
+# run_stress_annotation). Non-hermetic: the model download flakes the md5 check
+# in parallel CI. Marked `slow` so the required pytest selection
+# (`-k "not slow"`) excludes it; it still runs in the slow/nightly path.
+@pytest.mark.slow
 def test_ulp_fidelity_correction_reruns_stress_and_gate(tmp_path: Path) -> None:
     module_dir = tmp_path / "module"
     module_dir.mkdir()
@@ -268,6 +275,8 @@ Your clean morning sentence uses **я прокида́юся** before breakfast.
     assert correction["after"]["passed"] is True
 
 
+# Loads the live Stanza Ukrainian model (run_stress_annotation). See note above.
+@pytest.mark.slow
 def test_linear_pipeline_stress_annotation_marks_module_and_vocabulary(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_post_processor_mutation_invariant.py
+++ b/tests/test_post_processor_mutation_invariant.py
@@ -64,17 +64,30 @@ _ALL_FIXTURES: list[Fixture] = _POST_PROCESSOR_CORPUS + [
 ]
 
 
+# Processors that load a live ML model when invoked. Exercising them downloads
+# the Stanza Ukrainian model, which is non-hermetic and flakes Stanza's md5
+# check under parallel CI (`ValueError: md5 for .../uk/tokenize/iu.pt ...`).
+# Their parametrizations are marked `slow` so the required pytest selection
+# (`-k "not slow"`) excludes them — keeping the required gate hermetic per the
+# #2691 invariant — while every other processor's invariant check still runs.
+# They continue to run in the slow/nightly path. See
+# docs/bug-autopsies/stanza-model-md5-flake.md.
+_MODEL_BACKED_PROCESSORS = {"pipeline.stress_annotator.annotate_stress"}
+
+
 def _processor_fixture_params() -> list[pytest.param]:
     # Sort both axes so pytest-xdist test IDs are stable across workers;
     # sets/frozensets hash differently per-interpreter (#1461 lesson).
     params = []
     for processor_name in sorted(REGISTRY.keys()):
+        marks = (pytest.mark.slow,) if processor_name in _MODEL_BACKED_PROCESSORS else ()
         for fixture in sorted(_ALL_FIXTURES, key=lambda f: f.id):
             params.append(
                 pytest.param(
                     processor_name,
                     fixture,
                     id=f"{processor_name}[{fixture.id}]",
+                    marks=marks,
                 )
             )
     return params


### PR DESCRIPTION
## Problem

The required `Test (pytest)` check flaked intermittently on every PR that touches `requirements-lock.txt`. On 2026-06-04 dependabot #2543 (regex) and #2710 (starlette) went red on the Stanza `iu.pt` md5 mismatch (`ValueError: md5 for .../uk/tokenize/iu.pt is …, expected …` → 27 failed) while #2545/#2542/#2541 passed the **same day** — pure clean-vs-corrupt download dice.

## Root cause

#2691 made the required gate hermetic by marking model-backed stress tests `slow` and excluding them via `-k "not slow and not website"`. But it only covered `tests/test_stress_annotation.py` and **missed two other model-loading paths** that stayed in the required gate:

- `tests/test_post_processor_mutation_invariant.py` — `test_post_processor_stays_in_class` is parametrized over *every* registered processor, including `pipeline.stress_annotator.annotate_stress`, which loads Stanza (25 fixture params).
- `tests/test_immersion_rule_ulp.py` — `test_ulp_fidelity_correction_reruns_stress_and_gate` and `test_linear_pipeline_stress_annotation_marks_module_and_vocabulary` both call `run_stress_annotation` / `run_ulp_fidelity_with_correction`.

These download the live model in the required path → flaky md5 → flaky required check.

## Fix

Mark exactly the model-backed parametrizations/tests `slow`. The post-processor marker is **surgical** (`marks=` on only the `stress_annotator` params via `pytest.param`), so every *other* processor's mutation-class invariant still runs in required CI. Both immersion model tests get a function-level `@pytest.mark.slow`. They all continue to run in the `slow`/nightly path.

## Verification (local)

- `ruff check` — All checks passed.
- Required selector `-k "not slow and not website"` now collects **0** stress_annotator params and **0** of the 2 immersion model tests.
- Non-slow subset: **40 passed in 0.51s** (sub-second ⇒ no model load ⇒ hermetic).
- Slow subset: **27 passed in 5.84s** (the excluded tests still pass when actually run — only moved out of the required gate, not broken).
- pre-commit full-file run: **67 passed**.

## Residual risk / follow-up

Prevention today only guards the *selector*, not the *markers* — a future test that constructs the Stressifier without `slow` would re-leak. A collection-time guard asserting no required test loads the model is the durable fix (noted in the autopsy). Also recommend a dependabot.yml tweak to group `pydantic`+`pydantic-core` and cap `starlette<0.51` (separately filed) — those standalone bumps (#2540/#2710) are structurally un-mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)