### PR TITLE
docs(pedagogy): add neutral A1/A2 standards (#2708)

### DIFF
--- a/docs/pedagogy/a1-a2-lesson-construction.md
+++ b/docs/pedagogy/a1-a2-lesson-construction.md
@@ -1,0 +1,317 @@
+# A1/A2 Lesson Construction Standard
+
+> Scope: original learn-ukrainian standards for beginner lesson construction. This
+> document may be used by planners, wiki compilers, writers, reviewers, and audit
+> agents. It does not authorize copying any commercial workbook.
+
+## Status
+
+This standard was informed by private, read-only benchmark review of strong A1
+Ukrainian-as-a-foreign-language pedagogy. Paid third-party learning materials
+may be high-quality companion resources for learners, but this curriculum stays
+independent and complementary.
+
+No proprietary workbook text, examples, exercises, dialogues, images, audio,
+page summaries, or sequence tables are stored here. The project curriculum
+sequence is governed by the Ukrainian State Standard 2024, the immutable
+`curriculum/l2-uk-en/plans/{level}/` plans, and accepted project decisions.
+Commercial benchmarks may influence *how* we scaffold a lesson; they must not
+determine *what* grammar or vocabulary appears when.
+
+## Retrofit Policy
+
+"Complete" levels are stable baselines, not frozen artifacts. If A1 or A2
+content is technically complete but fails this pedagogy standard, reopen it
+through a controlled retrofit rather than protecting weak material.
+
+Retrofit in dependency order:
+
+1. **Plans** — rewrite only when the source-of-truth scope is wrong: grammar is
+   overloaded, sequencing is mis-leveled, vocabulary recycling is absent, the
+   A1/A2 boundary is wrong, or the plan cannot support Ukrainian-first
+   scaffolding without distortion.
+2. **Wikis** — rewrite when the plan is sound but the teaching spine is weak:
+   missing sequence steps, thin examples, no visual/audio/cursive affordances,
+   no learner-error inventory, weak review cadence, or no path from recognition
+   to production.
+3. **Modules and activities** — rebuild after the plan and wiki are strong.
+   Modules are outputs; do not patch around a bad plan or thin wiki with
+   clever prose.
+
+Do not regenerate the whole level by default. Audit first, classify failures by
+plan/wiki/module layer, then rebuild the smallest coherent slice that fixes the
+pedagogical defect.
+
+## Native Teacher Principle
+
+Self-study content is not a replacement for human teaching. A1/A2 materials
+should actively encourage learners to work with native Ukrainian teachers or
+highly proficient Ukrainian instructors whenever possible.
+
+This is pedagogically necessary:
+
+- teachers hear pronunciation, stress, rhythm, and fossilized errors that static
+  content misses;
+- learners need live correction, conversation, accountability, and cultural
+  context;
+- teachers can adapt pace and explanation when a learner is stuck.
+
+It is also part of the project's Ukrainian-centered stance. Paid lessons with
+Ukrainian teachers can be a win-win: learners get better Ukrainian, and
+Ukrainian educators receive direct support during difficult conditions. Course
+content should normalize seeking teachers, conversation partners, and feedback
+loops rather than implying that a static website is enough.
+
+## Level Purpose
+
+### A1
+
+A1 is the literacy and first-contact bridge. A learner should finish A1 able to:
+
+- read printed Ukrainian confidently, with stress and pronunciation support;
+- recognize common handwritten or cursive forms without being asked to produce
+  long cursive text;
+- understand short Ukrainian prompts supported by layout, repetition, images,
+  audio, and controlled English;
+- use common everyday sentence frames in speech and short writing;
+- meet real forms early without being forced to master every paradigm at once.
+
+### A2
+
+A2 inherits the same immersion habits but moves the learner toward independent
+Ukrainian processing. A learner should finish A2 ready for B1-style immersion:
+
+- Ukrainian instructions become normal, not decorative;
+- English is limited to concise clarification, translation fields, and
+  confusion-prevention notes;
+- grammar topics synthesize earlier A1 pieces rather than restarting from
+  English explanations;
+- listening, visual inference, and short production are routine in every module.
+
+## Construction Principles
+
+### 1. Start with Ukrainian on the page
+
+Open a teaching move with a small Ukrainian artifact: a word pair, a one-line
+exchange, a picture label, a short audio prompt, or a repeated pattern. Let the
+learner infer first from position, repetition, image, audio, or typography.
+English follows only after the learner has seen the Ukrainian signal.
+
+Good pattern shapes:
+
+- Ukrainian label near an image, then a short English gloss.
+- Two or three repeated Ukrainian lines where only one form changes.
+- A listening prompt where learners mark what they hear before reading a full
+  explanation.
+- A tiny table where the visual contrast makes the grammar visible.
+
+Avoid English-first framing such as "The Ukrainian word for..." or long
+paragraphs that explain the grammar before any Ukrainian appears.
+
+### 2. Use controlled English only where it prevents confusion
+
+English at A1/A2 is a scaffold, not the lesson's default voice. Use it for:
+
+- brief glosses after Ukrainian;
+- concise grammar explanation with real terms such as noun, verb, adjective,
+  pronoun, case, aspect, stress, and conjugation;
+- answer feedback for early A1 tasks;
+- safety rails where a wrong inference would create lasting confusion.
+
+Do not use English to narrate the module, apologize for Ukrainian, or replace
+learner inference. If a concept needs more than a short English note, break the
+Ukrainian input into smaller steps.
+
+### 3. Keep the grammar load visible and narrow
+
+Each lesson should have one primary grammar job. It may include one supporting
+contrast and one recycled form, but it must not become a survey chapter.
+
+Use this load test:
+
+- Can the learner name the main pattern after the lesson?
+- Can they recognize it in fresh input?
+- Can they complete a controlled item with it?
+- Can they produce one short original response with it?
+
+If the answer is no, reduce the number of moving parts or move the secondary
+point into review.
+
+### 4. Move from recognition to production
+
+Beginner tasks should progress in this order:
+
+1. Recognition: listen, match, point, circle, sort, choose.
+2. Controlled practice: fill one slot, select an ending, match a form to a
+   context, repair a marked error.
+3. Guided production: write or say one short answer using a supplied frame.
+4. Short production: personalize one or two lines without changing the lesson's
+   grammar scope.
+
+Do not start a new A1/A2 point with open production. Do not end a lesson with
+only recognition.
+
+### 5. Recycle vocabulary deliberately
+
+New vocabulary should be useful, frequent, and needed for the lesson's task.
+Every target item should reappear in multiple modes:
+
+- once in context;
+- once in controlled practice;
+- once in listening, visual, or short production;
+- again in a later review or linked module where the learner can recognize it
+  without re-teaching.
+
+Prefer recycling from the previous few modules and from the current unit's
+theme. Do not import a commercial workbook's vocabulary order or example set.
+
+### 6. Use lawful visual context as pedagogy
+
+Images are not decoration at A1/A2. Use them when they reduce English, make a
+pattern inferable, or anchor a real Ukrainian context.
+
+Allowed visual sources:
+
+- original project graphics;
+- generated images created for this project;
+- public-domain or properly licensed images with attribution;
+- Wikimedia/Commons or archive material whose license has been checked.
+
+Forbidden visual sources:
+
+- screenshots or scans from paid workbooks;
+- copied handwriting samples from commercial resources;
+- all-rights-reserved images without permission;
+- visual choices copied to mimic a commercial page or exercise.
+
+### 7. Treat audio as a first-class scaffold
+
+Every A1/A2 lesson should include a listening path when feasible:
+
+- listen before reading;
+- listen while matching or marking;
+- repeat a short phrase;
+- check an answer by hearing the model;
+- revisit the same sound or pattern in review.
+
+Audio must be original, licensed, or lawfully linked. Public video platform
+media may be linked or embedded when appropriate, but do not download,
+transcribe, remix, or reuse the audio unless the license or explicit permission
+allows it.
+
+### 8. Support pronunciation and reading in Ukrainian script
+
+Use Ukrainian script from the start. Support reading through stress marks,
+syllable awareness, sound-letter contrasts, audio, and listen-repeat tasks.
+
+Do not use IPA, Latin-script transliteration, or English sound analogies as
+fallback pronunciation systems. The path is Ukrainian sound, Ukrainian letter,
+stress marks, audio, repetition, and recognition.
+
+### 9. Introduce cursive and handwriting as recognition before production
+
+Learners should regularly see common handwritten or cursive Ukrainian forms,
+especially in A1 literacy and early A2 review. The goal is first to recognize
+forms in real life, not to master penmanship.
+
+Acceptable progression:
+
+- match printed and cursive letters;
+- read short handwritten labels;
+- rewrite one or two known words from cursive into print;
+- later copy a short known word or personal name.
+
+Use original fonts, project-created samples, or properly licensed assets. Do
+not copy commercial handwriting samples.
+
+### 10. Manage cognitive load
+
+Beginner lessons should feel rich, not crowded. Use:
+
+- small tables with one visible contrast;
+- short audio prompts;
+- one image cluster at a time;
+- repeated pattern language;
+- enough white space for scanning;
+- review items that point back to the relevant unit or module.
+
+If a page requires the learner to track sound, case, gender, animacy, new
+vocabulary, and handwriting at once, split it.
+
+## Review Cadence
+
+A1/A2 modules need planned recycling at three distances:
+
+- same lesson: recognition returns as controlled practice;
+- near review: the form returns in the next few modules or unit boundary;
+- cumulative review: mixed items ask learners to identify what they need to
+  revisit.
+
+The review cadence must be project-native. Do not copy a commercial workbook's
+table of contents, unit grouping, review interval, or exercise sequence.
+
+## Audit Checklist
+
+Use this checklist before approving an A1/A2 lesson, wiki, prompt fragment, or
+review rubric.
+
+### IP and Source Safety
+
+- [ ] No paid-workbook text, exercises, examples, dialogues, images, audio,
+      transcripts, screenshots, extracted text, page summaries, or local file
+      paths appear in the artifact.
+- [ ] The lesson does not recreate a commercial workbook's table of contents,
+      grammar order, review cadence, exercise sequence, dialogue arc, image
+      choice, or handwriting samples.
+- [ ] Any commercial resource is cited only through a public product page or
+      ordinary bibliographic reference.
+- [ ] The curriculum sequence still follows project plans and standards.
+- [ ] If a completed lesson fails this standard, the failure is classified as
+      plan, wiki, module/activity, or review-guidance debt before rebuilding.
+
+### Ukrainian-First Scaffolding
+
+- [ ] The first learner-facing signal for each major teaching move is
+      Ukrainian, visual, or audio, not an English lecture.
+- [ ] English appears only as a controlled scaffold.
+- [ ] Ukrainian prompts are short enough for the level and supported by layout,
+      repetition, images, or audio.
+- [ ] Comprehension and recall tasks use Ukrainian stems/options where the
+      learner state supports it.
+
+### Grammar and Vocabulary Load
+
+- [ ] One primary grammar job is visible.
+- [ ] Secondary contrasts are recycled or deferred.
+- [ ] New vocabulary is necessary, frequent, and used in multiple modes.
+- [ ] Prior vocabulary is recycled without re-teaching everything.
+- [ ] Vocabulary and inflected forms pass the project's VESUM and modern-form
+      checks where those gates apply.
+- [ ] The lesson has been checked for Russianisms, surzhyk, calques, and
+      other non-standard forms under the project's linguistic authority rules.
+
+### Multimodal Support
+
+- [ ] At least one visual, audio, or typography-supported inference task exists
+      when the lesson topic allows it.
+- [ ] Visuals are original, generated, public-domain, or properly licensed.
+- [ ] Audio is original, licensed, or lawfully linked.
+- [ ] Public video platform material is link/embed only unless license or
+      permission allows reuse.
+- [ ] Cursive or handwritten recognition appears in literacy/review contexts
+      before production-heavy handwriting.
+
+### Practice Progression
+
+- [ ] The lesson moves from recognition to controlled practice.
+- [ ] The learner gets at least one short guided or original production moment.
+- [ ] Review items point learners back to what they should revisit.
+- [ ] The lesson does not overwhelm by combining too many new variables.
+
+### Teacher Support
+
+- [ ] Learner-facing guidance does not imply self-study content is enough.
+- [ ] Where appropriate, the lesson or level guidance encourages native-teacher
+      feedback, conversation practice, pronunciation correction, or tutoring.
+- [ ] Teacher recommendations are framed respectfully as support for Ukrainian
+      educators and as better pedagogy for the learner.

--- a/docs/pedagogy/commercial-source-policy.md
+++ b/docs/pedagogy/commercial-source-policy.md
@@ -1,0 +1,107 @@
+# Commercial Source Policy for Learning Materials
+
+> Scope: how agents may use paid or all-rights-reserved learning materials when
+> improving learn-ukrainian pedagogy, prompts, rubrics, or lessons.
+
+## Core Rule
+
+Paid learning materials may be used only as private, read-only benchmarks for
+abstract pedagogy. They are not source corpora for this repository.
+
+Agents may learn only high-level principles such as scaffolding style,
+cognitive load management, review design, or media support. They must not
+ingest proprietary source text into prompts, context windows, RAG, embeddings,
+source databases, generated lessons, issue comments, review artifacts, or
+preserved notes. Agents must not copy, summarize, extract, store, imitate, or
+derive learner-facing content from a commercial resource.
+
+Paid third-party workbooks and courses may be recommended as companion study
+resources in learner-facing resource lists when appropriate. They must not be
+used as source material to clone.
+
+## Allowed Uses
+
+- Use user-provided abstract observations about pedagogy, without seeing or
+  preserving proprietary source text.
+- Cite a public product page when recommending or acknowledging a resource.
+- Compare project rubrics against broad public claims such as level, audience,
+  audio support, review support, or general workbook purpose.
+- Write original policy, rubrics, and prompt guidance inspired by broad
+  pedagogy, without importing any proprietary content or sequence.
+
+## Forbidden Uses
+
+Do not put any of the following into git, docs, prompts, RAG, embeddings,
+source databases, generated lessons, issue comments, or review artifacts:
+
+- PDFs, scans, screenshots, page images, cover crops, or workbook visuals;
+- extracted text, OCR, transcripts, audio, answer keys, exercise items, or
+  dialogue lines;
+- proprietary examples, vocabulary lists, grammar charts, page-level summaries,
+  handwriting samples, or image choices;
+- local private file paths or notes that identify a user's private copy;
+- a commercial workbook's table of contents, lesson order, review cadence,
+  exercise sequence, dialogue arc, or distinctive page layout;
+- derivative exercises that preserve the same examples, order, answer pattern,
+  context, image idea, or wording with superficial substitutions.
+
+## Temporary Analysis
+
+Agents must not temporarily extract, render, OCR, transcribe, paste, or process
+paid learning materials, even outside the repository. If a user privately
+reviews a paid resource outside the repo, only abstract pedagogy observations
+may enter this project.
+
+Never add paid materials to:
+
+- `data/sources.db`;
+- `data/external_articles/`;
+- `data/references/` or any git-tracked corpus path;
+- vector stores, embeddings, or RAG indexes;
+- public docs, generated status files, audit files, or review reports.
+
+## Structural Cloning Ban
+
+Direct copying is not the only risk. Structural cloning is also forbidden.
+
+Do not recreate a commercial workbook's:
+
+- grammar order;
+- unit grouping;
+- review interval;
+- exercise-type sequence;
+- recurring character/dialogue arc;
+- image progression;
+- handwriting sample set;
+- answer-key pattern;
+- page composition.
+
+For learn-ukrainian, lesson order remains controlled by project plans, the
+Ukrainian State Standard 2024, and accepted repository decisions. Commercial
+materials may influence only abstract scaffolding principles.
+
+## Media and Public Video Rules
+
+Visuals used in lessons must be original, generated for the project,
+public-domain, or properly licensed. Record attribution where the schema
+requires it.
+
+Audio must be original, properly licensed, or linked lawfully. Public video
+platform media may be linked or embedded when appropriate, but agents must not
+download, transcribe, remix, cut, or reuse audio/video unless the license or
+explicit permission allows it.
+
+Do not use screenshots from public video platforms, paid workbooks, course
+platforms, or commercial apps unless the project has permission.
+
+## Agent Checklist
+
+- [ ] I used only public citations or private abstract analysis.
+- [ ] I did not copy or preserve any paid source material.
+- [ ] I did not add private material to git, RAG, embeddings, or source DBs.
+- [ ] I did not recreate a commercial sequence or exercise pattern.
+- [ ] I did not temporarily extract, render, OCR, transcribe, paste, or process
+      paid source material.
+- [ ] The diff contains no local private file path.
+- [ ] The work recommends paid resources respectfully as companions, not as
+      raw material for this curriculum.

--- a/scripts/build/universal_rules/R-A1-A2-MULTIMODAL-IMMERSION.md
+++ b/scripts/build/universal_rules/R-A1-A2-MULTIMODAL-IMMERSION.md
@@ -1,0 +1,55 @@
+---
+id: R-A1-A2-MULTIMODAL-IMMERSION
+description: A1/A2 lessons use context-rich Ukrainian-first scaffolding with lawful media and no commercial-workbook cloning.
+applies_to:
+  levels: [a1, a2]
+  tracks: [core]
+  activity_profiles: [all]
+slot: shared.contract
+depends_on: [R-AUDIENCE-LANGUAGE-A1, R-CITE-HONEST]
+---
+
+**A1/A2 multimodal immersion.** Beginner lessons should put more Ukrainian on
+the page without abandoning the learner. Start each major teaching move from a
+small Ukrainian artifact: a word pair, short dialogue turn, image label,
+listening prompt, repeated pattern, or compact table. Let the learner infer
+from layout, repetition, audio, image, or typography before the English scaffold
+appears.
+
+**Controlled English.** English is allowed when it prevents confusion: a brief
+gloss after Ukrainian, a short grammar note using real terms, or simple
+feedback in early A1. If a point needs a long English explanation, split the
+Ukrainian input into smaller steps instead of lecturing.
+
+**Recognition to production.** For each new A1/A2 pattern, move through:
+recognition -> controlled practice -> guided production -> one short original
+response. Do not begin with open production, and do not end with recognition
+only.
+
+**Visual, audio, and cursive support.** Use original, generated, public-domain,
+or properly licensed visuals to reduce English and make patterns inferable.
+Use original, licensed, or lawfully linked audio for listening and repeat
+practice. Expose A1/A2 learners to common handwritten or cursive Ukrainian
+forms as recognition before production; use original or licensed samples only.
+
+**Public video and media rights.** Public video platform media may be linked or
+embedded where pedagogically useful. Do not download, transcribe, remix, cut, or
+reuse hosted audio/video unless the license or explicit permission allows it.
+
+**Native-teacher loop.** Do not imply that self-study content is enough for
+learning Ukrainian. When level guidance, resource notes, or practice advice
+naturally allow it, encourage learners to seek native Ukrainian teacher
+feedback, conversation practice, pronunciation correction, or tutoring. Frame
+this as better pedagogy for the learner and respectful support for Ukrainian
+educators.
+
+**No commercial-workbook cloning.** Paid learning materials may be private
+pedagogical benchmarks only. Do not ingest their proprietary text into prompts,
+context windows, RAG, embeddings, generated lessons, issue comments, or review
+artifacts. Do not copy, summarize, quote, or derive from their examples,
+exercises, dialogues, images, handwriting samples, audio, answer keys, page
+layouts, table of contents, grammar order, review cadence, or exercise
+sequence. Lesson order remains controlled by project plans and the Ukrainian
+State Standard 2024. See
+`docs/pedagogy/a1-a2-lesson-construction.md` and
+`docs/pedagogy/commercial-source-policy.md`.


### PR DESCRIPTION
## Summary

- Adds a neutral A1/A2 lesson-construction standard for Ukrainian-first beginner scaffolding, controlled English, multimodal support, practice progression, retrofit scope, and native-teacher feedback loops.
- Adds a commercial-source policy that treats paid third-party learning materials only as private abstract pedagogy benchmarks, with no agent-side source ingestion, copying, structural cloning, RAG/indexing, or artifact preservation.
- Adds `R-A1-A2-MULTIMODAL-IMMERSION` to the universal rules registry for A1/A2 core builds.

## Scope

This closes #2708 and supports #2711. It does not start the retrofit audit, plan/wiki repair, or module rebuild work tracked separately in #2712, #2713, and #2714.

## Validation

- `npx markdownlint-cli2 --config .markdownlint.json --no-globs "docs/pedagogy/*.md"` -> 0 errors
- `.venv/bin/python -m pytest tests/build/test_universal_rules_registry.py` -> 34 passed
- `.venv/bin/python scripts/lint_prompts.py` -> clean
- `git diff --check origin/main..HEAD` -> clean
- forbidden paid-resource term search across the new docs/rule -> no matches
- pre-submit checks: no linter config or `.python-version` changes, no generated status/audit/review artifacts, no `sys.executable` in changed files, 3 files changed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> trailer present
- Gemini adversarial implementation review: initial findings resolved; final pass clean
