### PR TITLE
ci(dependabot): ignore constrained transitive bumps (pydantic-core, starlette>=0.51)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,20 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    # Block constrained transitive bumps that requirements-lock.txt (a flat,
+    # fully-pinned lock) lets Dependabot propose past their parent's pin,
+    # producing structurally un-mergeable PRs. See issue #2716.
+    ignore:
+      # pydantic-core is pinned EXACTLY by pydantic (pydantic==2.12.5 requires
+      # pydantic-core==2.41.5). A standalone bump fails deterministically at
+      # import: `SystemError: ... pydantic-core ... incompatible ... requires
+      # 2.41.5`. It must move only via a pydantic bump (which recomputes the
+      # lock and brings a matching pydantic-core). Closed PR: #2540.
+      - dependency-name: "pydantic-core"
+      # starlette is capped by fastapi (fastapi==0.136.1 requires
+      # starlette<0.51.0); starlette 1.x makes the lock unresolvable by pip.
+      # Allow 0.50.x patches but block >=0.51 until a fastapi bump loosens the
+      # cap — REMOVE this entry when fastapi supports starlette 1.x. Closed
+      # PR: #2710.
+      - dependency-name: "starlette"
+        versions: [">=0.51.0"]


### PR DESCRIPTION
## Why

`requirements-lock.txt` is a flat, fully-pinned lock, so Dependabot proposes standalone bumps of version-constrained transitive packages — structurally un-mergeable PRs that burn a CI cycle + a triage each time the package releases. Seen this cycle:

- **#2540** `pydantic-core 2.41.5→2.47.0` — `pydantic==2.12.5` requires `pydantic-core==2.41.5` (exact). Deterministic `SystemError: ...incompatible...requires 2.41.5` at import.
- **#2710** `starlette 0.50.0→1.0.1` — `fastapi==0.136.1` requires `starlette<0.51.0`; lockfile unresolvable by normal pip.

## What

Add `ignore` to the pip ecosystem:
- `pydantic-core` — ignored entirely; it moves only when `pydantic` bumps (the pydantic PR recomputes the lock and brings a matching `pydantic-core`). Transitive updates inside a pydantic PR are unaffected by the ignore.
- `starlette` — ignore `>=0.51.0` only; `0.50.x` patch bumps still flow. **Remove this entry when a fastapi bump loosens the `<0.51` cap** (commented inline).

Grouping was considered and rejected: a group still proposes an incompatible standalone bump when the parent has no concurrent update.

## Verification

`yaml.safe_load` parses; pip ignore block = `pydantic-core` (all) + `starlette [">=0.51.0"]`. yamllint pre-commit passed.

Closes #2716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)