### PR TITLE
fix(security): CodeQL-recognized path-injection barrier in session_router (clears 3 HIGH alerts)

### DIFF
--- a/scripts/api/session_router.py
+++ b/scripts/api/session_router.py
@@ -23,6 +23,7 @@ working", not for forensic archaeology.
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 from pathlib import Path
 from typing import Literal
@@ -57,12 +58,20 @@ def _safe_project_path(rel_path: str) -> Path:
     paths are filtered for ``..``/absolute in ``_parse_agent_handoffs``. This
     is an explicit second containment barrier: resolve the candidate and
     confirm it stays inside the project root. Defense-in-depth against path
-    traversal (CWE-22) and a sanitizer the static analyzer can see — closes
-    the two ``py/path-injection`` HIGH alerts on this file.
+    traversal (CWE-22).
+
+    The containment guard uses a normalized-prefix check
+    (``str.startswith(root + os.sep)``) rather than ``root in
+    candidate.parents``: both reject the same escapes, but only the prefix
+    form is a sanitizer CodeQL's ``py/path-injection`` query recognizes as a
+    barrier — the ``.parents`` form left the alerts open (#2540-era scan).
+    The trailing ``os.sep`` prevents a sibling-prefix bypass (``/rootX`` is
+    not inside ``/root``); ``candidate == root`` is allowed explicitly.
     """
     root = PROJECT_ROOT.resolve()
     candidate = (root / rel_path).resolve()
-    if candidate != root and root not in candidate.parents:
+    root_str = str(root)
+    if str(candidate) != root_str and not str(candidate).startswith(root_str + os.sep):
         raise HTTPException(
             status_code=400,
             detail="Resolved session path escapes the project root.",

--- a/tests/test_session_router_path_safety.py
+++ b/tests/test_session_router_path_safety.py
@@ -47,3 +47,15 @@ def test_read_session_file_rejects_escape():
     with pytest.raises(HTTPException) as exc:
         _read_session_file("../../../../etc/passwd")
     assert exc.value.status_code == 400
+
+
+def test_safe_path_rejects_sibling_prefix():
+    # A sibling directory that shares PROJECT_ROOT's name as a string prefix
+    # (e.g. /…/learn-ukrainian-evil vs /…/learn-ukrainian) must be rejected.
+    # Guards the trailing-os.sep in the containment check — a plain
+    # startswith(root) without the separator would let this through.
+    root = PROJECT_ROOT.resolve()
+    sibling = f"../{root.name}-evil/secret"
+    with pytest.raises(HTTPException) as exc:
+        _safe_project_path(sibling)
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Problem

3 open **HIGH** `py/path-injection` (CWE-22) code-scanning alerts on `scripts/api/session_router.py` (lines 64/75/84, on `refs/heads/main`). #2706 added `_safe_project_path()` and routed `_read_session_file` through it, but guarded containment with `root not in candidate.parents`. That **prevents traversal at runtime**, but is **not a sanitizer CodeQL recognizes** — so the taint from `?agent=` → filesystem read still flows past it statically, and the alerts never closed.

## Fix

Replace the `.parents` check with the documented normalized-prefix barrier:

```python
root_str = str(root)
if str(candidate) != root_str and not str(candidate).startswith(root_str + os.sep):
    raise HTTPException(status_code=400, ...)
```

- Same rejections as before (escapes → 400; `candidate == root` allowed).
- `str.startswith()` on a resolved path **is** in CodeQL's `py/path-injection` sanitizer set → the 3 alerts auto-close on the next scan of `main`.
- Trailing `os.sep` prevents a sibling-prefix bypass (`/…/learn-ukrainian-evil` is not inside `/…/learn-ukrainian`).

## Verification

- `ruff check` clean.
- `tests/test_session_router_path_safety.py`: **9 passed** — existing escape/in-root/root-itself cases + a new `test_safe_path_rejects_sibling_prefix` locking in the `os.sep`.

Defense-in-depth unchanged: `AGENT_NAME_RE` + `..`/absolute filtering upstream still apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)