### PR TITLE
fix(security): fastapi 0.136.3 + starlette 1.2.1 (clears starlette CVE #120/#124)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -40,7 +40,7 @@ ecdsa==0.19.2
 einops==0.8.2
 emoji==2.15.0
 execnet==2.1.2
-fastapi==0.136.1
+fastapi==0.136.3
 filelock==3.24.3
 filetype==1.2.0
 FlagEmbedding==1.3.5
@@ -181,7 +181,7 @@ soupsieve==2.8.3
 sqlite-vec==0.1.9
 sse-starlette==3.2.0
 stanza==1.11.0
-starlette==0.50.0
+starlette==1.2.1
 stevedore==5.7.0
 surya-ocr==0.17.1
 sympy==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyyaml>=6.0
 jsonschema>=4.20
 
 # API server
-fastapi>=0.136.1
+fastapi>=0.136.3
 uvicorn>=0.34
 httpx>=0.28
 


### PR DESCRIPTION
## Why

Dependabot alerts **#120/#124** flag `starlette <= 1.0.0` (MEDIUM); the only patched line is **1.x**. Our `fastapi==0.136.1` pinned `starlette<0.51.0`, so the security fix was unreachable without a coordinated fastapi bump (greenlit).

## What

- `fastapi` 0.136.1 → **0.136.3** (`requirements.txt` floor + `requirements-lock.txt`). 0.136.3 relaxes its pin to `starlette>=0.46.0` (no upper cap).
- `starlette` 0.50.0 → **1.2.1** (`requirements-lock.txt`) — the clean-resolve target for fastapi 0.136.3, well past the patched 1.0.1.
- `sse-starlette` **unchanged** (3.2.0 already requires `starlette>=0.49.1`); `mcp` unchanged (`starlette>=0.27`).

## Compatibility evidence

Scanned every installed dist's starlette requirement — the **only** sub-1.x cap was the old fastapi 0.136.1 pin. All others are floor-only:
```
sse-starlette: starlette>=0.49.1
mcp:           starlette>=0.27
fastapi(0.136.1, being replaced): starlette<0.51.0,>=0.40.0
```
We import only `from fastapi import …` (no direct `starlette` API surface), so starlette 1.0's breaking changes don't reach our code. Behavioral verification is CI's fresh-venv `pip install -r requirements-lock.txt` + full pytest.

Closes #120, #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)