### PR TITLE
fix(security): dependency vuln sweep (curl_cffi/idna/yaml/uuid/PyPDF2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9975,13 +9975,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -113,5 +113,8 @@
   "dependencies": {
     "better-sqlite3": "^12.5.0",
     "showdown": "^2.1.0"
+  },
+  "overrides": {
+    "uuid": "11.1.1"
   }
 }

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -143,7 +143,6 @@ pymorphy3-dicts-uk==2.4.1.1.1663094765
 pymorphy3==2.0.6
 pymorphy3==2.0.6
 PyMuPDF==1.27.1
-PyPDF2==3.0.1
 pypdf==6.10.2
 pypdfium2==4.30.0
 pyproject_hooks==1.2.0

--- a/starlight/package-lock.json
+++ b/starlight/package-lock.json
@@ -3536,6 +3536,15 @@
         }
       }
     },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
+    },
     "node_modules/algoliasearch": {
       "version": "5.49.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.1.tgz",
@@ -9897,22 +9906,23 @@
       }
     },
     "node_modules/yaml-language-server": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
-      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
+      "integrity": "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
-        "prettier": "^3.5.0",
+        "ajv-i18n": "^4.2.0",
+        "prettier": "^3.8.1",
         "request-light": "^0.5.7",
         "vscode-json-languageservice": "4.1.8",
         "vscode-languageserver": "^9.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "^3.16.0",
         "vscode-uri": "^3.0.2",
-        "yaml": "2.7.1"
+        "yaml": "2.8.3"
       },
       "bin": {
         "yaml-language-server": "bin/yaml-language-server"
@@ -9925,15 +9935,18 @@
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/starlight/package.json
+++ b/starlight/package.json
@@ -37,5 +37,8 @@
     "@vitest/coverage-v8": "^4.1.7",
     "happy-dom": "^20.10.1",
     "vitest": "^4.1.7"
+  },
+  "overrides": {
+    "yaml-language-server": "1.23.0"
   }
 }


### PR DESCRIPTION
Fixes part of #2716. I shipped only the alerts that verified cleanly; `curl_cffi` and `.dagger` idna are documented as skipped.

## Baseline

```text
$ git rev-parse --abbrev-ref HEAD
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
codex/security-dep-sweep-2716
```

```text
$ git status --short
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
?? node_modules
```

## Per-alert result

| Alert | Result | Evidence |
| --- | --- | --- |
| #119 `curl_cffi` | SKIPPED | Pin was reverted because the required pip dry-run reported a resolver conflict. |
| #1 `.dagger` `idna` | SKIPPED | `uv lock --upgrade-package idna` failed because the local `.dagger/sdk` source is missing. |
| #97 Starlight `yaml` | FIXED | `yaml-language-server` overridden to `1.23.0`, nested `yaml` is `2.8.3`, `npm audit` is clean. |
| #59 root `uuid` | FIXED | Root override moves transitive `uuid` to `11.1.1`; audit no longer reports `uuid`. |
| #60/#121 `PyPDF2` | FIXED | Removed stale `PyPDF2` from `requirements-lock.txt`; scraper already imports `pypdf`. |
| #42 `showdown` | SKIPPED | It is used by legacy TypeScript markdown tooling and has no fix available. |

## Raw verification

### `curl_cffi` skipped

```text
$ .venv/bin/python -m pip install --dry-run -r requirements-lock.txt
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
Collecting curl_cffi==0.15.0 (from -r requirements-lock.txt (line 29))
ERROR: Cannot install inscriptis==2.7.0 and lxml==6.1.0 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested lxml==6.1.0
    inscriptis 2.7.0 depends on lxml<6.0.0 and >=5.4.0
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

```text
$ rg -n "curl_cffi|PyPDF2|pypdf==|pypdf" requirements.txt requirements-lock.txt scripts/rag/scrape_diasporiana.py
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
requirements-lock.txt:29:1:curl_cffi==0.14.0
requirements-lock.txt:146:1:pypdf==6.10.2
requirements-lock.txt:147:1:pypdfium2==4.30.0
scripts/rag/scrape_diasporiana.py:273:10:def _run_pypdf(pdf_path: Path) -> str | None:
scripts/rag/scrape_diasporiana.py:274:34:    if importlib.util.find_spec("pypdf") is None:
scripts/rag/scrape_diasporiana.py:276:10:    from pypdf import PdfReader
scripts/rag/scrape_diasporiana.py:297:25:        raw_text = _run_pypdf(pdf_path)
```

### idna skipped

```text
$ uv lock --upgrade-package idna
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/.dagger
Using CPython 3.14.5 interpreter at: /opt/homebrew/opt/python@3.14/bin/python3.14
error: Distribution not found at: file:///Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/.dagger/sdk
```

### Starlight yaml fixed

```text
$ npm audit
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/starlight
# npm audit report

yaml  2.0.0 - 2.8.2
Severity: moderate
yaml is vulnerable to Stack Overflow via deeply nested YAML collections - https://github.com/advisories/GHSA-48c2-rrv3-qjmp
```

```text
$ npm ls yaml yaml-language-server --package-lock-only --depth=10
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/starlight
starlight@0.0.1 /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/starlight
├─┬ @astrojs/check@0.9.9
│ └─┬ @astrojs/language-server@2.16.7
│   ├─┬ @astrojs/yaml2ts@0.2.3
│   │ └── yaml@2.8.3 deduped
│   └─┬ volar-service-yaml@0.0.70
│     └─┬ yaml-language-server@1.23.0 overridden
│       └── yaml@2.8.3
└─┬ @astrojs/react@5.0.5
  └─┬ vite@7.3.2
    └── yaml@2.8.3
```

```text
$ npm audit
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/starlight
found 0 vulnerabilities
```

```text
$ npm run build
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716/starlight
08:23:30 [build] 145 page(s) built in 8.64s
08:23:30 [build] Complete!
```

### Root uuid fixed

```text
$ npm audit
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
```

```text
$ npm ls uuid showdown --package-lock-only --depth=10
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
learn-ukrainian@1.0.0 /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
├─┬ @dagger.io/dagger@0.19.8
│ └─┬ @opentelemetry/exporter-jaeger@2.2.0
│   └─┬ jaeger-client@3.19.0
│     └── uuid@11.1.1 overridden
└── showdown@2.1.0
```

```text
$ npm audit --json | jq -r '"uuid_audit=" + ((.vulnerabilities.uuid.name // "absent")), "showdown_audit=" + ((.vulnerabilities.showdown.name // "absent")), "total=" + (.metadata.vulnerabilities.total|tostring)'
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
uuid_audit=absent
showdown_audit=showdown
total=10
```

### PyPDF2 removed

```text
$ grep -rn PyPDF2 scripts/ requirements.txt requirements-lock.txt
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
<no output; exit 1>
```

```text
$ .venv/bin/python -c "import ast; ast.parse(open('scripts/rag/scrape_diasporiana.py').read())"
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
<no output; exit 0>
```

```text
$ .venv/bin/python -c "import scripts.rag.scrape_diasporiana"
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
<no output; exit 0>
```

```text
$ .venv/bin/ruff check scripts/rag/scrape_diasporiana.py
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
All checks passed!
```

### Showdown skipped

```text
$ rg -n "showdown|require\(['\"]showdown|from ['\"]showdown|import\(['\"]showdown|new Converter|Converter\(" --glob '!node_modules/**' --glob '!starlight/node_modules/**' .
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
./package.json:94:13:    "@types/showdown": "^2.0.6",
./package.json:115:6:    "showdown": "^2.1.0"
./scripts/legacy/typescript/lib/utils/markdown.ts:10:13:import * as showdown from 'showdown';
./scripts/legacy/typescript/lib/utils/markdown.ts:179:31:export function createMarkdownConverter(options: MarkdownConverterOptions = {}): showdown.Converter {
./scripts/legacy/typescript/lib/utils/markdown.ts:195:25:  const converter = new showdown.Converter({
```

```text
$ npm audit
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
showdown  *
Severity: moderate
Showdown vulnerable to Regular Expression Denial of Service (ReDoS) in link/anchor parsing - https://github.com/advisories/GHSA-rmmh-p597-ppvv
No fix available
node_modules/showdown
```

## Hygiene checks

```text
$ git diff --check
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
<no output; exit 0>
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
Checking 1 commit(s) in origin/main..HEAD:

  accaef8196  PASS  X-Agent: codex/security-dep-sweep-2716

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

```text
$ git status --short
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
<no output; exit 0>
```

## Review note

The repo-local Gemini adversarial review command was attempted but did not return findings after repeated polling; I terminated the stuck process so no background review session remained.

```text
$ ps -axo pid,ppid,command | rg 'issue-2716-dep-sweep-review|ask-gemini Adversarial review for issue #2716' || true
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/security-dep-sweep-2716
368:70:23371 84537 /opt/homebrew/bin/bash -c ps -axo pid,ppid,command | rg 'issue-2716-dep-sweep-review|ask-gemini Adversarial review for issue #2716' || true
370:16:23373 23371 rg issue-2716-dep-sweep-review|ask-gemini Adversarial review for issue #2716
```
