### PR TITLE
fix(agy): pass --model to agy CLI (1.0.5+) for deterministic headless dispatch

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -99,10 +99,12 @@ class AgyAdapter:
     ) -> InvocationPlan:
         """Build the ``agy`` print-mode invocation.
 
-        ``model`` is intentionally not mapped to a CLI flag. The active
-        model is whichever model the operator selected in the ``agy`` TUI
-        panel. ``effort`` is accepted for protocol uniformity but is a
-        no-op until agy exposes a reasoning-effort flag (follow-up #1396).
+        ``model`` is passed through to agy's ``--model`` flag (added in agy
+        1.0.5; verified against 1.0.5 — tokens like ``gemini-3.1-pro-high``).
+        When ``None`` we fall back to ``default_model``. ``effort`` is
+        accepted for protocol uniformity but is a no-op: agy encodes the
+        reasoning tier in the model id itself (the ``-high``/``-low`` suffix),
+        so there is no separate effort flag (#1396).
         """
         if mode not in self.supported_modes:
             raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
@@ -125,6 +127,7 @@ class AgyAdapter:
 
         agy_bin = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
         log_path = _build_log_path(task_id)
+        resolved_model = model or self.default_model
         # `--dangerously-skip-permissions` is unconditional: any tool-using
         # prompt (file read, shell call) triggers an interactive permission
         # prompt that would hang a headless dispatch waiting for human input.
@@ -132,11 +135,16 @@ class AgyAdapter:
         # parity, but agy has no finer-grained permission model than this
         # single flag. Callers (delegate.py/dispatch_smart.py) should force
         # mode=danger for --agent agy to avoid accidental routes around this.
+        # `--model` selects the per-invocation model (agy 1.0.5+); without it
+        # agy would use whatever the TUI last persisted, which is non-
+        # deterministic for headless dispatch.
         cmd: list[str] = [
             agy_bin,
             "-p",
             prompt,
             "--dangerously-skip-permissions",
+            "--model",
+            resolved_model,
             "--log-file",
             str(log_path),
         ]
@@ -148,7 +156,6 @@ class AgyAdapter:
         # not a per-invocation CLI flag like gemini-cli. tool_config is
         # accepted for parity but not acted on yet.
         _ = tool_config
-        _ = model
 
         return InvocationPlan(
             cmd=cmd,

--- a/tests/agent_runtime/adapters/test_agy_adapter.py
+++ b/tests/agent_runtime/adapters/test_agy_adapter.py
@@ -153,3 +153,28 @@ def test_render_writer_prompt_omits_agy_directives_for_other_writers() -> None:
 
     assert "## agy-tools writer directives" not in prompt
     assert "Do NOT issue curl-via-Bash for MCP retrieval" not in prompt
+
+
+def _build(tmp_path: Path, *, model: str | None):
+    return AgyAdapter().build_invocation(
+        prompt="hello",
+        mode="danger",
+        cwd=tmp_path,
+        model=model,
+        task_id="t-1",
+        session_id=None,
+        tool_config=None,
+    )
+
+
+def test_build_invocation_passes_explicit_model(tmp_path: Path) -> None:
+    plan = _build(tmp_path, model="gemini-3.1-pro-high")
+    # `--model <value>` must be present as adjacent argv tokens (agy 1.0.5+).
+    assert "--model" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "gemini-3.1-pro-high"
+
+
+def test_build_invocation_falls_back_to_default_model(tmp_path: Path) -> None:
+    plan = _build(tmp_path, model=None)
+    assert "--model" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--model") + 1] == AgyAdapter.default_model


### PR DESCRIPTION
## Why

agy **1.0.5** added a `--model` CLI flag, but `scripts/agent_runtime/adapters/agy.py` was written for agy **1.0.0** (no such flag) and explicitly discarded the caller's model (`_ = model`), relying on whatever model the interactive TUI last persisted. That is:
- **non-deterministic** for headless `agy -p` dispatch, and
- **unable to select Gemini 3.1 Pro (High)** — required for the agy tech-debt evaluation lane.

## What

- Resolve `model or self.default_model` and append `--model <id>` to the `agy -p` invocation.
- Update the docstring (the "model intentionally not mapped" note was stale).
- Add `build_invocation` tests: explicit-model passthrough + default fallback.

## Verification

- Token format confirmed against live agy 1.0.5: `agy --model gemini-3.1-pro-high -p "Reply READY"` → `READY` (exit 0).
- `ruff check` clean; `tests/agent_runtime/adapters/test_agy_adapter.py` → **6 passed**.

Unblocks driving agy on `gemini-3.1-pro-high` via `delegate.py --agent agy --model gemini-3.1-pro-high`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)