### PR TITLE
fix(security): os.path.realpath path-injection sanitizer (retry — #2727 form not CodeQL-recognized)

### DIFF
--- a/scripts/api/session_router.py
+++ b/scripts/api/session_router.py
@@ -60,23 +60,24 @@ def _safe_project_path(rel_path: str) -> Path:
     confirm it stays inside the project root. Defense-in-depth against path
     traversal (CWE-22).
 
-    The containment guard uses a normalized-prefix check
-    (``str.startswith(root + os.sep)``) rather than ``root in
-    candidate.parents``: both reject the same escapes, but only the prefix
-    form is a sanitizer CodeQL's ``py/path-injection`` query recognizes as a
-    barrier — the ``.parents`` form left the alerts open (#2540-era scan).
-    The trailing ``os.sep`` prevents a sibling-prefix bypass (``/rootX`` is
-    not inside ``/root``); ``candidate == root`` is allowed explicitly.
+    The containment guard normalizes with ``os.path.realpath`` and checks a
+    ``startswith(root + os.sep)`` prefix. This specific ``os.path`` idiom is
+    the form CodeQL's ``py/path-injection`` query recognizes as a sanitizing
+    barrier. Earlier attempts did NOT clear the alerts: ``root in
+    candidate.parents`` (#2706) and the pathlib ``str(Path.resolve())
+    .startswith(...)`` form (#2727) are both correct at runtime but invisible
+    to the static analyzer (confirmed: the post-#2727 scan still flagged this
+    function). The trailing ``os.sep`` prevents a sibling-prefix bypass
+    (``/rootX`` is not inside ``/root``); ``candidate == root`` is allowed.
     """
-    root = PROJECT_ROOT.resolve()
-    candidate = (root / rel_path).resolve()
-    root_str = str(root)
-    if str(candidate) != root_str and not str(candidate).startswith(root_str + os.sep):
+    root = os.path.realpath(PROJECT_ROOT)
+    candidate = os.path.realpath(os.path.join(root, rel_path))
+    if candidate != root and not candidate.startswith(root + os.sep):
         raise HTTPException(
             status_code=400,
             detail="Resolved session path escapes the project root.",
         )
-    return candidate
+    return Path(candidate)
 
 
 def _read_session_file(session_path: str) -> str:


### PR DESCRIPTION
## Why a retry

#2727 replaced the `.parents` check with a pathlib `str(Path.resolve()).startswith(root + os.sep)` barrier. It's correct at runtime, but the **post-merge CodeQL scan still flagged all 3 alerts** — confirmed: scan at commit `9f6547f44` (06:34Z) flags `session_router.py:72/84/93`. CodeQL did not recognize the pathlib-string form as a sanitizer.

## Fix

Use CodeQL's **documented** `os.path` idiom (CodeQL models `os.path.realpath` for path-injection; pathlib support is weaker):

```python
root = os.path.realpath(PROJECT_ROOT)
candidate = os.path.realpath(os.path.join(root, rel_path))
if candidate != root and not candidate.startswith(root + os.sep):
    raise HTTPException(status_code=400, ...)
return Path(candidate)
```

Identical runtime behavior (escapes → 400; `candidate == root` allowed; sibling-prefix `/rootX` rejected via trailing `os.sep`).

## Verification

- `ruff` clean; `tests/test_session_router_path_safety.py` → **9 passed** (unchanged).
- **CodeQL recognition is scan-gated** — confirm on the next scan of `main` after merge. If this os.path form *also* isn't recognized, the alerts are a CodeQL limitation (the realpath-containment + `AGENT_NAME_RE` validation genuinely prevent traversal) and should be dismissed with that justification rather than chased further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)