### PR TITLE
fix(agy): drop --model flag (1.0.5 downgrades to CCPA) — revert #2731

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -99,12 +99,19 @@ class AgyAdapter:
     ) -> InvocationPlan:
         """Build the ``agy`` print-mode invocation.
 
-        ``model`` is passed through to agy's ``--model`` flag (added in agy
-        1.0.5; verified against 1.0.5 — tokens like ``gemini-3.1-pro-high``).
-        When ``None`` we fall back to ``default_model``. ``effort`` is
-        accepted for protocol uniformity but is a no-op: agy encodes the
-        reasoning tier in the model id itself (the ``-high``/``-low`` suffix),
-        so there is no separate effort flag (#1396).
+        ``model`` is intentionally NOT mapped to agy's ``--model`` flag. On agy
+        1.0.5 the flag's resolver does not recognise the runtime model ids:
+        BOTH ``gemini-3.1-pro-high`` and the ``"Gemini 3.1 Pro (High)"`` label
+        log ``Model ID ... not in local config, defaulting to CCPA`` and
+        DOWNGRADE off the operator's selection (verified 2026-06-05 via the agy
+        log). Headless ``agy -p`` with no ``--model`` correctly uses the model
+        persisted in ``~/.gemini/antigravity-cli/settings.json`` — the
+        TUI-selected model, which agy propagates to the backend
+        (``Propagating selected model override ... label="Gemini 3.1 Pro
+        (High)"``). So model selection for agy dispatch is an OPERATOR setting
+        (pick the model in the agy TUI), not a per-invocation flag. ``effort``
+        is a no-op for the same reason (#1396). #2731 (which passed ``--model``)
+        was reverted here because it forced the CCPA downgrade.
         """
         if mode not in self.supported_modes:
             raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
@@ -127,7 +134,6 @@ class AgyAdapter:
 
         agy_bin = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
         log_path = _build_log_path(task_id)
-        resolved_model = model or self.default_model
         # `--dangerously-skip-permissions` is unconditional: any tool-using
         # prompt (file read, shell call) triggers an interactive permission
         # prompt that would hang a headless dispatch waiting for human input.
@@ -135,16 +141,13 @@ class AgyAdapter:
         # parity, but agy has no finer-grained permission model than this
         # single flag. Callers (delegate.py/dispatch_smart.py) should force
         # mode=danger for --agent agy to avoid accidental routes around this.
-        # `--model` selects the per-invocation model (agy 1.0.5+); without it
-        # agy would use whatever the TUI last persisted, which is non-
-        # deterministic for headless dispatch.
+        # NOTE: no `--model` — see the docstring. Passing it downgrades to
+        # CCPA; the model is the operator's agy-TUI-persisted selection.
         cmd: list[str] = [
             agy_bin,
             "-p",
             prompt,
             "--dangerously-skip-permissions",
-            "--model",
-            resolved_model,
             "--log-file",
             str(log_path),
         ]
@@ -156,6 +159,7 @@ class AgyAdapter:
         # not a per-invocation CLI flag like gemini-cli. tool_config is
         # accepted for parity but not acted on yet.
         _ = tool_config
+        _ = model
 
         return InvocationPlan(
             cmd=cmd,

--- a/tests/agent_runtime/adapters/test_agy_adapter.py
+++ b/tests/agent_runtime/adapters/test_agy_adapter.py
@@ -167,14 +167,10 @@ def _build(tmp_path: Path, *, model: str | None):
     )
 
 
-def test_build_invocation_passes_explicit_model(tmp_path: Path) -> None:
-    plan = _build(tmp_path, model="gemini-3.1-pro-high")
-    # `--model <value>` must be present as adjacent argv tokens (agy 1.0.5+).
-    assert "--model" in plan.cmd
-    assert plan.cmd[plan.cmd.index("--model") + 1] == "gemini-3.1-pro-high"
-
-
-def test_build_invocation_falls_back_to_default_model(tmp_path: Path) -> None:
-    plan = _build(tmp_path, model=None)
-    assert "--model" in plan.cmd
-    assert plan.cmd[plan.cmd.index("--model") + 1] == AgyAdapter.default_model
+def test_build_invocation_does_not_pass_model_flag(tmp_path: Path) -> None:
+    # agy 1.0.5's --model resolver does not recognise the runtime model ids
+    # and downgrades to CCPA; model is the operator's agy-TUI-persisted
+    # selection, so the adapter must NOT pass --model. (Reverts #2731.)
+    for model in ("gemini-3.1-pro-high", "Gemini 3.1 Pro (High)", None):
+        plan = _build(tmp_path, model=model)
+        assert "--model" not in plan.cmd, f"--model leaked for model={model!r}"


### PR DESCRIPTION
## Why (corrects my own #2731)

#2731 wired the agy adapter to pass `--model`. Live verification on agy 1.0.5 (2026-06-05) shows that's **wrong** — the CLI `--model` resolver doesn't recognise our model ids:

```
$ agy --model "gemini-3.1-pro-high" -p ...   →  Model ID gemini-3.1-pro-high not in local config, defaulting to CCPA
$ agy --model "Gemini 3.1 Pro (High)" -p ... →  Model ID Gemini 3.1 Pro (High) not in local config, defaulting to CCPA
```

Both **downgrade** off the operator's selection. The **no-`--model`** run instead logs:
```
model_config_manager: Propagating selected model override to backend: label="Gemini 3.1 Pro (High)"
```
i.e. headless `agy -p` correctly uses the model persisted by the agy TUI in `~/.gemini/antigravity-cli/settings.json`. So **agy model selection is an operator setting** (choose it in the TUI), not a per-invocation flag — and #2731 actively broke it (every dispatch forced CCPA).

Headless auth itself is fine: `ChainedAuth: authenticated via keyring` after `agy login`.

## What

- Revert the adapter to **not** pass `--model`; ignore the runtime model arg (`_ = model`). Documented inline + in the docstring.
- Tests now assert `--model` is absent (token / label / None).

## Verification
- `ruff` clean; `tests/agent_runtime/adapters/test_agy_adapter.py` → **5 passed**.

Follow-up: #2675 (`codex/agy-mcp-fix`) passes `--model` as the display name — same CCPA flaw — so its model-flag part should be dropped too (its MCP-config/docs value is separate). Operating procedure for the agy bakeoff: set Gemini 3.1 Pro (High) in the agy TUI; dispatch headless with no `--model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)