### PR TITLE
fix(security): bump curl_cffi 0.14.0→0.15.0 (clears HIGH alert #119)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -26,7 +26,7 @@ colorama==0.4.6
 coloredlogs==15.0.1
 coverage==7.14.0
 cryptography==47.0.0
-curl_cffi==0.14.0
+curl_cffi==0.15.0
 datasets==4.8.5
 DAWG-Python==0.7.2
 DAWG2-Python==0.9.0


### PR DESCRIPTION
## Summary
Targeted lock-only bump clearing **dependabot alert #119** (curl_cffi HIGH CVE, #2732 Part 1).

## Why a 1-line edit, not a full re-lock
- CI installs the lock with **`--no-deps`** (`.github/workflows/ci.yml:373`) → a clean full resolve is **not** required for correctness.
- `curl_cffi` is **purely transitive** (no `import curl_cffi` in `scripts/`/`tests/`; not a top-level requirement).
- curl_cffi 0.15.0's runtime deps are **already satisfied** by the current lock:
  - `cffi>=2.0.0` → `cffi==2.0.0` ✓
  - `certifi>=2024.2.2` → `certifi==2026.2.25` ✓
  - `rich` (new in 0.15.0) → `rich==14.3.3` ✓
- Dependabot couldn't auto-open this: its full-resolve step chokes on **unrelated** pre-existing lock conflicts.

## Deferred (NOT this PR) — tracked in #2732
The lock is not clean-resolvable due to pre-existing rot (#1634-class):
- `inscriptis 2.7.0` vs `lxml 6.1.0`
- `pillow 12.2.0` vs `marker-pdf 1.10.2` (needs `Pillow<11.0.0`)

Verified the isolated set `inscriptis 2.7.1 + lxml 6.0.4 + curl_cffi 0.15.0` resolves, but a clean **full** resolve additionally needs the pillow/marker-pdf conflict fixed — out of scope here.

## Verification
The PR's own `--no-deps` CI (`Test (pytest)`) is the authoritative gate — identical to the 8 dependabot bumps merged earlier today.

Refs #2732 · closes dependabot alert #119