### PR TITLE
docs(folk): Stage-0 foundation — driver handoff + folk-experiential & all-round-lit design POCs

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -1,0 +1,123 @@
+# Folk Track — Claude Driver Handoff (MY OWN — not the orchestrator's)
+
+> **Scope/boundaries (user 2026-06-06):** User redirected Claude from the bio epic to **re-research +
+> rebuild the FOLK track first** ("leave bio resting, test the system with folk"). Codex/GPT is the
+> orchestrator. Claude does NOT touch `docs/session-state/current.md`. This is Claude's OWN git-tracked
+> tracking doc so a fresh Claude folk session resumes without the orchestrator's handoff. Launch with
+> `claude --agent curriculum-track-orchestrator`. **Bio rests** (310/310 dossiers safe on main, its
+> handoff intact at `docs/bio-epic/CLAUDE-DRIVER-HANDOFF.md`, 0 bio dispatches in flight).
+>
+> **🚧 GIT DISCIPLINE:** scope git to folk paths (`curriculum/l2-uk-en/plans/folk`,
+> `curriculum/l2-uk-en/folk`, `docs/research/folk`, `docs/folk-epic`, `docs/poc`,
+> `starlight/src/content/docs/folk`, `wiki/folk`). Never a tree-wide `git status`/main op. If a non-folk
+> file surfaces (esp. `docs/session-state/*`), SKIP SILENTLY.
+>
+> **⚖ MERGE POLICY:** the bio merge-grant was bio-specific. For FOLK, **OPEN PRs, do NOT self-merge** —
+> user/orchestrator promotes (until the user extends a folk grant).
+
+## ▶▶▶ SESSION HANDOFF (2026-06-06, FOLK SCOPE + TAXONOMY + DESIGN ARCHETYPES) — RESUME HERE
+
+### ✅ DECISIONS LOCKED THIS SESSION (all user-confirmed)
+1. **Track = FOLK, broad scope.** Not oral-folklore-only — **broad folk CULTURE** (oral genres + music +
+   dance + material/visual culture + ritual customs). User rationale: without it you can't understand the
+   uniqueness of e.g. the opera «Запорожець за Дунаєм».
+2. **Register = C1+.** (Folk currently registered as C1 in curriculum.yaml.)
+3. **Claude's deliverable boundary = research → dossier → wiki. NO modules.** GPT builds the modules +
+   "final experience" and is trending to orchestrator. Claude designs the pages; GPT builds against them.
+4. **Writers/reviewers for Ukrainian CULTURE = Claude + GPT only. NO DeepSeek** (user: deepseek lacks the
+   intrinsic Ukrainian-culture knowledge to catch subtle framing errors; its corpus-tool use was fine but
+   that's not the risk for culture). Cross-family pair = GPT↔Claude.
+5. **⛔ Claude BENCHED for content WRITING until June 8 morning reset** (user, quota). Design/analysis/
+   orchestration by Claude is fine; only Ukrainian-content WRITING is benched. Sequencing works out: the
+   gap-audit + design need no writer; first dossier starts when Claude returns (or GPT writes earlier).
+6. **Reviewer MUST hammer the corpus** — `verify_quote` on every folk text (duma/song lyrics must be exact,
+   the folk analogue of the bio quote-integrity gate), + search_literary / search_grinchenko_1907 /
+   search_heritage / check_russian_shadow / query_cefr_level.
+7. **No YT resources for folk** — the dossier is the SOLE knowledge layer, so dossier depth is everything.
+
+### 📋 FOLK TAXONOMY — 27 existing + 10 broad-scope additions (GPT-cross-checked, bridge msg #1148)
+**Existing 27** (oral genres): bohatyri-illiya-dobrynia, bylyny-kyivskoho-tsyklu, bylyny-sotsialni,
+zastavy-bohatyrski, dumy-{lytsarski,nevilnytski,sotsialno-pobutovi}, pokhodzhennia-dum, kobzarstvo-fenomen,
+koliadky-shchedrivky, vesnianky-hayivky, kupalski-pisni, rusalni-pisni, obzhynkovi-pisni, vesilni-pisni,
+holosinnya, chumatski-burlatski-pisni, narodni-balady, rodynna-liryka-kolomyiky, charivni-kazky,
+kazky-pro-tvaryn, sotsialno-pobutovi-kazky, narodni-lehendy, istorychni-perekazy, prykazky-ta-pryslivia,
+zahadky, narodni-anekdoty.
+
+**10 broad-scope additions (user-approved, incl. #10):**
+1. `narodni-viruvannia-mifolohiia-demonolohiia` (мавки/русалки/домовик/упир/відьма + дохристиянські вірування)
+2. `istorychni-pisni` (historical SONGS — distinct from dumy & from prose perekazy)
+3. `vertep-narodna-drama` 4. `dytiachyi-folklor-kolyskovi`
+5. `narodni-muzychni-instrumenty` (бандура/кобза/трембіта/цимбали; corpus JACKPOT)
+6. `narodni-tantsi` 7. `pysankarstvo` 8. `narodna-vyshyvka-rushnyk-strii`
+9. `narodni-remesla-ta-khudozhni-promysly` 10. `kalendarna-obriadovist-zvychai` ✅ KEEP (user: "super folkish")
+
+**GPT cross-check refinements to APPLY when locking the queue (msg #1148):**
+- **DE-WEIGHT bylyny 4→1** (de-imperialize; bylyny are the most RU-appropriated genre; do NOT open with them).
+  Fold bohatyri/social/zastavy into one; fold `pokhodzhennia-dum` into kobzarstvo.
+- **Resistance songs `striletski-povstanski-pisni` = IN** (user: "fofc they are in, fuck the occupiers").
+- Add `pisni-literaturnoho-pokhodzhennia` (романси/духовні псальми — the high-culture bridge genre).
+- Add `rodynna-obriadovist-zvychai` (family-RITE system) + `rehionalni-etnokulturni-tradytsii`
+  (Гуцул/Бойко/Лемко/Полісся — anti-flattening) + `narodna-kukhnia` (борщ/кутя/коровай — UNESCO, RU-flashpoint).
+- Add opening **`narodna-kultura-yak-systema`** (systems overview) — GPT's recommended frame.
+- Rename: kobzarstvo→`kobzarstvo-lirnytstvo`; chumatski→`suspilno-pobutovi-pisni`; obzhynkovi→`zhnyvarski-obzhynkovi`.
+- **#M-4 caution:** do NOT present Перун/Велес/**Берегиня** as a tidy pagan pantheon (Берегиня = modern romantic
+  reconstruction). Bake into the belief dossier.
+- **Net ≈ 41 topics**, rebalanced (epic 9→5). GPT's pilot pick = `kalendarna-obriadovist-zvychai` (#10) — converges with Claude.
+
+### 📐 FOLK DOSSIER SCHEMA (the quality contract — genre/phenomenon-shaped, NOT bio's person arc)
+1. Визначення та класифікація · 2. Походження та історичний контекст · 3. Поетика/форма/техніка ·
+4. **Класичні зразки + ВЕРБАТИМ примірники (every quote `verify_quote`-confirmed)** ·
+5. Побутування/виконавство/функція · 6. Збирачі та дослідники (corpus-cited) ·
+7. **Культуроносна/антиколоніальна роль** (the carrying-identity-under-oppression thesis) ·
+8. **Місток до високої культури** (opera/lit/art bridge) · 9. Decolonization/NPOV + source-disagreement ·
+10. Acceptance self-check. **+ multimodal-hook capture**: image `chunk_id`s (SigLIP search_images),
+named recording/song refs, performance/ritual descriptions — so the eventual module can be experiential.
+
+### 🎨 DESIGN ARCHETYPES (Claude's design lane — POCs built this session, in `docs/poc/`)
+**Finding:** there is NO realized seminar module POC (0 built across all 7 seminar tracks). The POC design
+(`docs/poc/poc-lesson-design.html`) has core + a generic `seminar-source-analysis` archetype (12 activity
+types #20-31, all source/text analysis) on a fixed 4-tab shell (Урок·Словник·Зошит·Ресурси). Resolver:
+`scripts/pipeline/module_archetypes.py`; contract: `docs/architecture/module-archetype-contract.md`.
+
+**Coverage verdict (evidence-grounded):**
+| Tracks | Archetype |
+|---|---|
+| bio · hist · istorio · **oes** · **ruth** · lit (+ 7 lit sub-tracks) | `seminar-source-analysis` ✅ (oes/ruth = its NATIVE philology use case: transcription/paleography/etymology/dialect) |
+| **folk** | 🆕 `folk-experiential` — **built**: `docs/poc/poc-folk-lesson-design.html` |
+| **lit (all 8 sub-tracks)** | one all-round page — **built**: `docs/poc/poc-lit-lesson-design.html` |
+| **lit-drama** + **folk** + **bio cultural-figures** (Леонтович/Квітка-Цісик/Бойчук) | **shared performative/multimodal module** (audio + dramatic-reading + image-decode) |
+
+- **folk-experiential POC** (worked example koliadky/Щедрик, corpus-sourced): NEW components = audio block
+  (hear the sung text), symbolic-decode (clickable hotspots), high-culture bridge (Щедрик→Леонтович→Carol of
+  the Bells), folk activity families #40-45 (aural genre-ID, symbolic decode, ritual sequencing, variant
+  compare, motif/formula, performance). Decolonization myth-box ties folk→bio (Leontovych murdered by Cheka 1921).
+  **User feedback: WANT MORE PROSE in the Урок body** (activities are the in-prose layer; expository prose must be richer).
+- **all-round lit POC** (worked example Леся «Лісова пісня»): close-reading annotation, prosody/scansion,
+  narrative-structure map, + the SHARED dramatic-performance module (covers lit-drama), myth-box, lit
+  families #50-54. Serves all 8 lit sub-tracks (genre diffs = content/register at plan level).
+- **Net: 2 page archetypes + 1 shared module — NOT 13 designs.** oes/ruth/hist/istorio/bio need NO new page.
+
+### ▶ NEXT ACTIONS ON RESUME (folk, in order)
+1. **Lock the folk foundation** (this branch is Stage-0): apply the GPT refinements → final ~41-topic
+   ordered queue doc (`docs/folk-epic/phase-folk-queue.md`) + the dossier schema + a corpus-heavy review
+   rubric + the `folk-experiential` archetype spec (activity families #40-45 + the 2 multimodal blocks, on
+   the existing 4-tab shell) as a hand-off for GPT. Mirror bio's Stage-0.
+2. **More prose** in the folk-experiential Урок design (user feedback).
+3. **First dossier — pilot `kalendarna-obriadovist-zvychai`** (GPT + Claude both picked it; best shows folk
+   as a SYSTEM). Writer = GPT now / Claude after June 8; cross-family review = the other; corpus-hammer
+   (`verify_quote` every folk text). Then dossier → grounded wiki (compile.py is dossier-grounded since #2702).
+4. Optional: design the **lit-drama** variant (≈80% assembled from folk parts) when convenient.
+
+### 📊 CORPUS FACTS (folk is well-sourced — verified)
+collection_stats: textbooks 25,714 · literary_texts 137,688 · sum11 127,069 · grinchenko 67,275. Verified
+verbatim primary folk texts retrievable: Маруся Богуславка (duma), Щедрик, «Лісова пісня», full ULP lesson
+on народні інструменти (бандура/трембіта/цимбали), писанка/вишивка in grades 2-6, троїсті музики + вертеп +
+козацьке бароко in history textbooks. **SigLIP `search_images` exists** → material-culture topics get visuals
+despite "no YT". `compile.py --writer {gemini,claude,gpt-5.5}` (NO agy arm — would need wiring); dossier
+grounding live (#2702). Folk discovery already exists (27 files, real rag_chunks); 0 folk dossiers; 0 folk modules.
+
+### 🗂 ARTIFACTS THIS SESSION
+- `docs/poc/poc-folk-lesson-design.html` (folk-experiential archetype POC)
+- `docs/poc/poc-lit-lesson-design.html` (all-round lit archetype POC)
+- GPT folk-taxonomy cross-check = bridge msg #1148 (`ab read 1148`)
+- This handoff. **PR: OPEN (no self-merge) — folk-foundation Stage-0.**

--- a/docs/poc/poc-folk-lesson-design.html
+++ b/docs/poc/poc-folk-lesson-design.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>POC: Folk-Experiential Lesson Design — learn-ukrainian</title>
+<!--
+  FOLK-EXPERIENTIAL archetype POC (Claude, bio/folk driver).
+  Worked example: koliadky-shchedrivky (Щедрівки) — fully corpus-sourced.
+  Reuses the poc-lesson-design.html design system; ADDS the folk-only surfaces:
+    1. Audio block (hear the sung text — folk is oral)
+    2. Symbolic-decode block (read a visual/material code — image hotspots)
+    3. High-culture bridge box (folk -> opera/film/art)
+    4. Folk activity families #40-#45 (aural genre-ID, symbolic decode,
+       ritual sequencing, variant comparison, motif/formula, performance)
+  Source-analysis families (#20-31) stay available; this layer is ADDITIVE.
+-->
+<style>
+  :root {
+    --blue:#0057B8; --yellow:#FFD700; --blue-light:#E8F0FE; --yellow-light:#FFF9E0;
+    --green:#2E7D32; --green-light:#E8F5E9; --red:#C62828; --red-light:#FFEBEE;
+    --purple:#6A1B9A; --purple-light:#F3E5F5; --orange:#E65100; --orange-light:#FFF3E0;
+    --teal:#00695C; --teal-light:#E0F2F1; --brown:#5D4037; --brown-light:#EFEBE9;
+    --folk:#A4133C; --folk-2:#C9621A; --folk-light:#FBE9EC;
+    --gray-50:#FAFAFA; --gray-100:#F5F5F5; --gray-200:#EEEEEE; --gray-300:#E0E0E0;
+    --gray-600:#757575; --gray-800:#424242; --gray-900:#212121;
+    --radius:12px; --shadow:0 2px 8px rgba(0,0,0,0.08); --shadow-lg:0 4px 16px rgba(0,0,0,0.12);
+  }
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;color:var(--gray-900);background:var(--gray-50);line-height:1.7;}
+
+  .module-switch{background:var(--gray-900);color:white;padding:10px 24px;display:flex;align-items:center;gap:16px;font-size:13px;position:sticky;top:0;z-index:100;}
+  .module-switch .poc-label{margin-left:auto;color:var(--yellow);font-weight:600;letter-spacing:0.5px;}
+  .module-switch .arch{background:var(--folk);padding:3px 10px;border-radius:5px;color:white;font-weight:700;}
+
+  .header{padding:24px 0;border-bottom:4px solid var(--yellow);background:linear-gradient(135deg,var(--folk),var(--folk-2));color:white;}
+  .header-inner{max-width:840px;margin:0 auto;padding:0 24px;}
+  .level-badge{display:inline-block;background:var(--yellow);color:var(--gray-900);font-weight:700;font-size:12px;padding:2px 10px;border-radius:4px;margin-bottom:8px;}
+  .header h1{font-size:26px;font-weight:700;margin-bottom:4px;}
+  .header .subtitle{opacity:0.9;font-size:14px;}
+
+  .tabs-container{max-width:840px;margin:0 auto;padding:0 24px;}
+  .tabs{display:flex;border-bottom:2px solid var(--gray-200);margin-top:20px;overflow-x:auto;}
+  .tab{padding:11px 20px;font-size:14px;font-weight:600;color:var(--gray-600);background:none;border:none;cursor:pointer;border-bottom:3px solid transparent;margin-bottom:-2px;white-space:nowrap;transition:all .2s;}
+  .tab:hover{color:var(--folk);}
+  .tab.active{color:var(--folk);border-bottom-color:var(--folk);}
+  .tab-content{display:none;padding:28px 0 60px;}
+  .tab-content.active{display:block;}
+  .content-area{max-width:840px;margin:0 auto;padding:0 24px;}
+
+  h2{font-size:20px;color:var(--folk);margin:28px 0 14px;padding-bottom:6px;border-bottom:2px solid var(--yellow);}
+  h2:first-child{margin-top:0;}
+  h3{font-size:17px;margin:20px 0 10px;color:var(--gray-800);}
+  p{margin-bottom:14px;font-size:15px;}
+  .new-tag{display:inline-block;background:var(--folk);color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;vertical-align:middle;letter-spacing:.5px;margin-left:8px;}
+
+  /* ---- NEW #1: Audio block (folk is oral — you HEAR the text) ---- */
+  .audio-block{background:#1c1230;color:#fff;border-radius:var(--radius);padding:18px 20px;margin:22px 0;box-shadow:var(--shadow-lg);}
+  .audio-head{display:flex;align-items:center;gap:12px;margin-bottom:14px;}
+  .audio-play{width:46px;height:46px;border-radius:50%;background:var(--yellow);color:#1c1230;border:none;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex:0 0 auto;}
+  .audio-meta{font-size:13px;opacity:.85;}
+  .audio-meta strong{display:block;font-size:15px;opacity:1;}
+  .waveform{display:flex;align-items:flex-end;gap:3px;height:34px;margin:10px 0 14px;}
+  .waveform span{flex:1;background:linear-gradient(var(--yellow),var(--folk-2));border-radius:2px;opacity:.55;animation:wv 1.1s ease-in-out infinite;}
+  @keyframes wv{0%,100%{height:20%}50%{height:100%}}
+  .synced-lyric{background:rgba(255,255,255,.07);border-left:3px solid var(--yellow);border-radius:8px;padding:12px 16px;font-style:italic;line-height:1.9;font-size:15px;}
+  .synced-lyric .lit{background:rgba(255,215,0,.28);border-radius:3px;padding:0 2px;}
+
+  /* primary source / myth (reused from seminar design system) */
+  .source-box{background:var(--purple-light);border:2px solid var(--purple);border-radius:var(--radius);padding:18px 22px;margin:22px 0;}
+  .source-box-header{font-weight:700;color:var(--purple);margin-bottom:8px;font-size:15px;}
+  .source-box blockquote{font-style:italic;border-left:3px solid var(--purple);padding-left:14px;margin:10px 0;color:var(--gray-800);white-space:pre-line;}
+  .source-box .source-cite{font-size:13px;color:var(--gray-600);text-align:right;}
+  .myth-box{background:var(--red-light);border:2px solid var(--red);border-radius:var(--radius);padding:18px 22px;margin:22px 0;}
+  .myth-box-header{display:flex;align-items:center;gap:10px;font-weight:700;font-size:16px;margin-bottom:10px;color:var(--red);}
+  .myth-box .myth-claim{background:rgba(198,40,40,.08);padding:10px 14px;border-radius:8px;margin:8px 0;font-style:italic;border-left:3px solid var(--red);}
+  .myth-box .myth-truth{background:var(--green-light);padding:10px 14px;border-radius:8px;margin:8px 0;border-left:3px solid var(--green);}
+
+  /* ---- NEW #2: Symbolic-decode block (read a visual/material code) ---- */
+  .decode-block{margin:22px 0;}
+  .decode-stage{position:relative;background:linear-gradient(135deg,#2a1a3a,#4a148c);border-radius:var(--radius);min-height:240px;display:flex;align-items:center;justify-content:center;color:#fff;overflow:hidden;box-shadow:var(--shadow);}
+  .decode-scene{font-size:13px;opacity:.5;text-align:center;padding:20px;}
+  .hotspot{position:absolute;width:26px;height:26px;border-radius:50%;background:var(--yellow);color:#1c1230;font-weight:700;border:2px solid #fff;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:13px;box-shadow:0 0 0 6px rgba(255,215,0,.25);transition:transform .15s;}
+  .hotspot:hover{transform:scale(1.18);}
+  .decode-info{margin-top:12px;background:var(--folk-light);border:1px solid var(--folk);border-radius:8px;padding:12px 16px;font-size:14px;min-height:48px;}
+  .decode-info .ds-sym{font-weight:700;color:var(--folk);}
+
+  /* ---- NEW #3: High-culture bridge ---- */
+  .bridge-box{background:var(--teal-light);border:2px solid var(--teal);border-radius:var(--radius);padding:18px 22px;margin:22px 0;}
+  .bridge-head{display:flex;align-items:center;gap:10px;font-weight:700;color:var(--teal);font-size:16px;margin-bottom:10px;}
+  .bridge-flow{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:14px;}
+  .bridge-node{background:#fff;border:1px solid var(--teal);border-radius:8px;padding:6px 12px;font-weight:600;}
+  .bridge-arrow{color:var(--teal);font-weight:700;}
+
+  /* ritual timeline */
+  .ritual-timeline{counter-reset:rt;margin:14px 0;}
+  .rt-step{position:relative;padding:10px 14px 10px 44px;background:#fff;border:1px solid var(--gray-200);border-radius:8px;margin-bottom:8px;font-size:14px;}
+  .rt-step::before{counter-increment:rt;content:counter(rt);position:absolute;left:10px;top:9px;width:24px;height:24px;background:var(--folk);color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;}
+
+  /* exercise wrapper + badges (reused) */
+  .exercise{background:#fff;border-radius:var(--radius);border:2px solid var(--gray-200);padding:22px;margin:22px 0;box-shadow:var(--shadow);}
+  .exercise-header{display:flex;align-items:center;gap:10px;margin-bottom:12px;flex-wrap:wrap;}
+  .exercise-badge{font-size:11px;font-weight:700;padding:3px 9px;border-radius:10px;color:#fff;letter-spacing:.3px;}
+  .exercise-title{font-weight:700;font-size:15px;}
+  .exercise-num{margin-left:auto;color:var(--gray-300);font-weight:700;font-size:13px;}
+  .exercise-instruction{font-size:14px;color:var(--gray-600);margin-bottom:12px;}
+  .badge-aural{background:var(--folk);} .badge-decode{background:var(--purple);}
+  .badge-ritual{background:var(--orange);} .badge-variant{background:var(--teal);}
+  .badge-motif{background:var(--blue);} .badge-perform{background:var(--green);}
+  .opt{padding:11px 14px;border:1.5px solid var(--gray-200);border-radius:8px;margin:7px 0;cursor:pointer;font-size:14px;transition:all .15s;}
+  .opt:hover{border-color:var(--folk);background:var(--folk-light);}
+  .opt.right{border-color:var(--green);background:var(--green-light);}
+  .opt.wrong{border-color:var(--red);background:var(--red-light);}
+  .match-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+  .match-grid .opt{margin:0;text-align:center;}
+  table.cmp{width:100%;border-collapse:collapse;font-size:14px;margin-top:6px;}
+  table.cmp th{text-align:left;padding:7px 10px;background:var(--folk-light);}
+  table.cmp td{padding:6px 8px;border-bottom:1px solid var(--gray-200);}
+  table.cmp input{width:100%;border:1px solid var(--gray-300);border-radius:6px;padding:6px 8px;font-size:13px;}
+  .ta{width:100%;min-height:80px;border:1px solid var(--gray-300);border-radius:8px;padding:10px 12px;font-size:14px;font-family:inherit;margin-top:8px;}
+  .mt-passage{background:var(--gray-100);border-radius:8px;padding:12px 16px;font-style:italic;line-height:1.9;}
+  .mt-passage .formula{background:var(--yellow-light);border-bottom:2px solid var(--yellow);cursor:pointer;}
+  .rec-btn{display:inline-flex;align-items:center;gap:8px;background:var(--folk);color:#fff;border:none;padding:10px 18px;border-radius:24px;font-size:14px;cursor:pointer;font-weight:600;}
+  .vocab-table{width:100%;border-collapse:collapse;font-size:14px;}
+  .vocab-table th{text-align:left;padding:8px 10px;background:var(--folk-light);}
+  .vocab-table td{padding:8px 10px;border-bottom:1px solid var(--gray-200);}
+  .note{background:var(--blue-light);border-left:3px solid var(--blue);border-radius:8px;padding:12px 16px;margin:16px 0;font-size:14px;}
+  .res-item{display:flex;gap:12px;align-items:flex-start;background:#fff;border:1px solid var(--gray-200);border-radius:8px;padding:12px 14px;margin-bottom:10px;}
+  .res-icon{width:34px;height:34px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:16px;flex:0 0 auto;}
+</style>
+</head>
+<body>
+
+<div class="module-switch">
+  <span class="arch">FOLK-EXPERIENTIAL</span>
+  <label>archetype proposal — additive to seminar-source-analysis</label>
+  <span class="poc-label">POC · learn-ukrainian</span>
+</div>
+
+<div class="header">
+  <div class="header-inner">
+    <span class="level-badge">C1 · ФОЛЬКЛОР</span>
+    <h1>Колядки та щедрівки</h1>
+    <div class="subtitle">Carols &amp; Shchedrivky — the winter-cycle ritual song</div>
+  </div>
+</div>
+
+<div class="tabs-container">
+  <div class="tabs">
+    <button class="tab active" data-tab="urok">Урок</button>
+    <button class="tab" data-tab="slovnyk">Словник</button>
+    <button class="tab" data-tab="zoshyt">Зошит</button>
+    <button class="tab" data-tab="resursy">Ресурси</button>
+  </div>
+</div>
+
+<div class="content-area">
+
+  <!-- ================= УРОК ================= -->
+  <div id="urok" class="tab-content active">
+    <h2>Що таке щедрівка</h2>
+    <p>Щедрівки — старовинні обрядові <strong>величальні пісні</strong> зимового циклу, які виконують у Щедрий вечір (напередодні Нового року за юліанським календарем). Їхня мета — «ублагати духів неба й землі сприяти в господарстві наступного року». Це не просто пісня, а <strong>дія</strong>: гурт обходить двори, славить господаря, отримує дари.</p>
+
+    <!-- NEW #1: audio -->
+    <div class="audio-block">
+      <div class="audio-head">
+        <button class="audio-play" onclick="this.textContent=this.textContent==='▶'?'⏸':'▶';document.getElementById('wf').style.animationPlayState='running'">&#x25B6;</button>
+        <div class="audio-meta"><strong>«Щедрик» — народна щедрівка</strong>обробка М. Леонтовича · слухай і стеж за текстом</div>
+      </div>
+      <div class="waveform" id="wf">
+        <span style="animation-delay:0s"></span><span style="animation-delay:.1s"></span><span style="animation-delay:.2s"></span><span style="animation-delay:.05s"></span><span style="animation-delay:.3s"></span><span style="animation-delay:.15s"></span><span style="animation-delay:.25s"></span><span style="animation-delay:.08s"></span><span style="animation-delay:.18s"></span><span style="animation-delay:.28s"></span><span style="animation-delay:.12s"></span><span style="animation-delay:.22s"></span><span style="animation-delay:.04s"></span><span style="animation-delay:.16s"></span><span style="animation-delay:.26s"></span>
+      </div>
+      <div class="synced-lyric"><span class="lit">Щедрик, щедрик, щедрівочка,</span> / Прилетіла ластівочка. / Стала собі щебетати, / Господаря викликати…</div>
+      <p style="font-size:12px;opacity:.6;margin:8px 0 0">POC: audio src wired from corpus recording at build; text is verify_quote-confirmed in the dossier.</p>
+    </div>
+
+    <div class="source-box">
+      <div class="source-box-header">Першоджерело: щедрівка «Щедрик»</div>
+      <blockquote>Щедрик, щедрик, щедрівочка,
+Прилетіла ластівочка.
+Стала собі щебетати,
+Господаря викликати:
+— Вийди, вийди, господарю,
+Подивися на кошару.
+Там овечки покотились,
+А ягнички народились…</blockquote>
+      <div class="source-cite">— укр. народна щедрівка (6-klas-ukrlit-avramenko-2023; 6-klas-ukrlit-zabolotnyi-2023) · verify_quote → dossier</div>
+    </div>
+
+    <!-- NEW #2: symbolic decode -->
+    <h3>Символи щедрівки <span class="new-tag">DECODE</span></h3>
+    <p>Натисни на позначки — щедрівка закодована давнім світоглядом, а не просто описує село.</p>
+    <div class="decode-block">
+      <div class="decode-stage">
+        <div class="decode-scene">[ілюстрація щедрування: господар, кошара, ластівка — image from corpus SigLIP search at build ]</div>
+        <div class="hotspot" style="top:30%;left:22%" onclick="decode('ластівка','Прилітає навесні — а щедрівку співають узимку. Чому? Бо праукраїнський Новий рік святкували 20 березня (весняне рівнодення). Ластівка приносила звістку про новий рік — образ пережив зміну календаря.')">1</div>
+        <div class="hotspot" style="top:58%;left:64%" onclick="decode('кошара','Овечки «покотились», ягнички «народились» — магія примноження. Величальна пісня не описує, а програмує достаток на новий рік.')">2</div>
+        <div class="hotspot" style="top:40%;left:46%" onclick="decode('Маланка і Василь','Обовʼязкові персонажі дійства: Маланка (за пізнішою фольклорною традицією — дочка богині Лади) і Василь (місяць). Обряд, а не концерт.')">3</div>
+      </div>
+      <div class="decode-info" id="dinfo">Натисни позначку, щоб прочитати символ…</div>
+    </div>
+
+    <!-- NEW #3: myth box (decolonization + oppression thesis + bio bridge) -->
+    <div class="myth-box">
+      <div class="myth-box-header">&#x2694; Руйнуємо міф</div>
+      <div class="myth-claim">«Carol of the Bells» — американська (або «російська») різдвяна класика.</div>
+      <div class="myth-truth"><strong>Насправді:</strong> це українська щедрівка «Щедрик» в обробці <strong>Миколи Леонтовича</strong> (1916; світова премʼєра — хор О. Кошиця, 1922, Нью-Йорк). Англійський текст «Carol of the Bells» написали лише 1936 р. Леонтовича <strong>вбив агент ЧК у 1921 році</strong> — композитор світового хіта загинув від рук тієї ж імперії, яка згодом привласнювала його музику. <em>(Звʼязок із треком «bio»: Леонтович.)</em></div>
+    </div>
+
+    <!-- NEW: high-culture bridge -->
+    <div class="bridge-box">
+      <div class="bridge-head">&#x1F3BC; Місток до високої культури</div>
+      <div class="bridge-flow">
+        <span class="bridge-node">народна щедрівка</span><span class="bridge-arrow">&#x2192;</span>
+        <span class="bridge-node">Леонтович «Щедрик» (1916)</span><span class="bridge-arrow">&#x2192;</span>
+        <span class="bridge-node">«Carol of the Bells»</span><span class="bridge-arrow">&#x2192;</span>
+        <span class="bridge-node">«Home Alone», «Harry Potter»</span>
+      </div>
+      <p style="margin:12px 0 0;font-size:14px">Так фольклор живить високу культуру — рівно те, чому опера «Запорожець за Дунаєм» нечитувана без народної основи.</p>
+    </div>
+  </div>
+
+  <!-- ================= СЛОВНИК ================= -->
+  <div id="slovnyk" class="tab-content">
+    <h2>Словник</h2>
+    <table class="vocab-table">
+      <tr><th>Слово</th><th>Значення</th><th>Приклад</th></tr>
+      <tr><td><strong>щедрівка</strong></td><td>shchedrivka (New-Year well-wishing song)</td><td>співати щедрівки</td></tr>
+      <tr><td><strong>величальна</strong></td><td>laudatory, glorifying (song)</td><td>величальна обрядова пісня</td></tr>
+      <tr><td><strong>кошара</strong></td><td>sheepfold</td><td>подивися на кошару</td></tr>
+      <tr><td><strong>обряд</strong></td><td>rite, ritual</td><td>обрядова пісня</td></tr>
+      <tr><td><strong>гурт</strong></td><td>group (of carolers)</td><td>гурт щедрувальників</td></tr>
+      <tr><td><strong>дійство</strong></td><td>ritual performance, enactment</td><td>святкове дійство</td></tr>
+    </table>
+    <div class="note"><strong>Жива мовна традиція:</strong> у колядках уживають вітання в <em>називному</em> відмінку — «Добрий вечір тобі, <u>пане господарю</u>!» (не «Доброго вечора»). Фольклор зберігає давню граматичну форму. <span style="color:var(--gray-600)">(heritage-defense flagged via search_heritage.)</span></div>
+  </div>
+
+  <!-- ================= ЗОШИТ ================= -->
+  <div id="zoshyt" class="tab-content">
+    <h2>Зошит <span class="new-tag">FOLK ACTIVITY FAMILIES #40–45</span></h2>
+    <p style="color:var(--gray-600);font-size:14px">Folk-specific families. The source-analysis families (#20–31) remain available; these are the ones folk needs that bio/hist/lit don't.</p>
+
+    <!-- #40 Aural Genre-ID -->
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-aural">Aural Genre-ID</span><span class="exercise-title">Упізнай жанр на слух</span><span class="exercise-num">#40</span></div>
+      <div class="exercise-instruction">&#x25B6; Прослухай фрагмент. До якого жанру зимового циклу він належить?</div>
+      <div class="opt" onclick="pick(this,false)">Веснянка (весняний цикл)</div>
+      <div class="opt" onclick="pick(this,true)">Щедрівка (величальна, новорічна — рефрен, заклик до господаря)</div>
+      <div class="opt" onclick="pick(this,false)">Голосіння (похоронний жанр)</div>
+    </div>
+
+    <!-- #41 Symbolic Decoding -->
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-decode">Symbolic Decode</span><span class="exercise-title">Розкодуй символ</span><span class="exercise-num">#41</span></div>
+      <div class="exercise-instruction">Зʼєднай образ зі значенням.</div>
+      <div class="match-grid">
+        <div class="opt">ластівка</div><div class="opt" onclick="pick(this,true)">звістка про прадавній весняний Новий рік</div>
+        <div class="opt">овечки «покотились»</div><div class="opt" onclick="pick(this,true)">магія примноження достатку</div>
+      </div>
+    </div>
+
+    <!-- #42 Ritual Sequencing -->
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-ritual">Ritual Sequencing</span><span class="exercise-title">Віднови послідовність обряду</span><span class="exercise-num">#42</span></div>
+      <div class="exercise-instruction">Перетягни етапи Щедрого вечора у правильному порядку (POC: drag-order at build).</div>
+      <div class="ritual-timeline">
+        <div class="rt-step">Гурт збирається, обирає Маланку й Василя</div>
+        <div class="rt-step">Обхід дворів, спів щедрівок під вікнами</div>
+        <div class="rt-step">Величання господаря, побажання достатку</div>
+        <div class="rt-step">Господар обдаровує щедрувальників</div>
+      </div>
+    </div>
+
+    <!-- #43 Variant Comparison -->
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-variant">Variant Compare</span><span class="exercise-title">Порівняй регіональні варіанти</span><span class="exercise-num">#43</span></div>
+      <div class="exercise-instruction">Дві версії щедрівки з різних регіонів. Заповни таблицю.</div>
+      <table class="cmp">
+        <tr><th>Ознака</th><th>Наддніпрянський</th><th>Карпатський</th></tr>
+        <tr><td>Образ-рефрен</td><td><input placeholder="…"></td><td><input placeholder="…"></td></tr>
+        <tr><td>Персонажі дійства</td><td><input placeholder="…"></td><td><input placeholder="…"></td></tr>
+      </table>
+    </div>
+
+    <!-- #44 Motif / Formula -->
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-motif">Motif / Formula</span><span class="exercise-title">Знайди обрядову формулу</span><span class="exercise-num">#44</span></div>
+      <div class="exercise-instruction">Клацни сталу величальну/етикетну формулу в тексті.</div>
+      <div class="mt-passage">«<span class="formula" onclick="pick(this,true)">Добрий вечір тобі, пане господарю</span>! Застеляйте столи, та все килимами. Та кладіть калачі з ярої пшениці…»</div>
+    </div>
+
+    <!-- #45 Performance -->
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-perform">Performance</span><span class="exercise-title">Заспівай / продекламуй</span><span class="exercise-num">#45</span></div>
+      <div class="exercise-instruction">Фольклор живе у виконанні. Прослухай зразок, повтори рефрен, запиши себе.</div>
+      <button class="rec-btn">&#x25CF; Записати виконання</button>
+      <p style="font-size:12px;color:var(--gray-600);margin-top:8px">POC: mic capture + self-review at build; optional auto-feedback on rhythm.</p>
+    </div>
+  </div>
+
+  <!-- ================= РЕСУРСИ ================= -->
+  <div id="resursy" class="tab-content">
+    <h2>Ресурси</h2>
+    <div class="res-item"><div class="res-icon" style="background:var(--folk-light);color:var(--folk)">&#9834;</div><div><strong>Аудіо:</strong> «Щедрик» (хорова обробка М. Леонтовича) + польова щедрівка — corpus recordings.</div></div>
+    <div class="res-item"><div class="res-icon" style="background:var(--purple-light);color:var(--purple)">&#9638;</div><div><strong>Зображення:</strong> щедрування, вертеп, зірка — SigLIP image search over the textbook corpus.</div></div>
+    <div class="res-item"><div class="res-icon" style="background:var(--blue-light);color:var(--blue)">&#9635;</div><div><strong>Джерела:</strong> 6-klas-ukrlit-avramenko-2023; 6-klas-ukrlit-zabolotnyi-2023; 6-klas-ukrmova-litvinova-2023 (corpus, tier 1).</div></div>
+    <div class="res-item"><div class="res-icon" style="background:var(--teal-light);color:var(--teal)">&#8644;</div><div><strong>Перехресно:</strong> bio → Микола Леонтович; folk → «Маланка», «вертеп».</div></div>
+  </div>
+
+</div>
+
+<script>
+  document.querySelectorAll('.tab').forEach(function(t){
+    t.onclick=function(){
+      document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active');});
+      document.querySelectorAll('.tab-content').forEach(function(x){x.classList.remove('active');});
+      t.classList.add('active');
+      document.getElementById(t.dataset.tab).classList.add('active');
+    };
+  });
+  function decode(sym,txt){
+    var el=document.getElementById('dinfo');
+    el.textContent='';
+    var b=document.createElement('span'); b.className='ds-sym'; b.textContent=sym+': ';
+    el.appendChild(b); el.appendChild(document.createTextNode(txt));
+  }
+  function pick(el,ok){el.classList.remove('right','wrong');el.classList.add(ok?'right':'wrong');}
+</script>
+</body>
+</html>

--- a/docs/poc/poc-lit-lesson-design.html
+++ b/docs/poc/poc-lit-lesson-design.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>POC: Literature Lesson Design (all-round) — learn-ukrainian</title>
+<!--
+  ALL-ROUND LIT archetype POC (Claude, design lane).
+  Serves the WHOLE lit family: lit, lit-essay, lit-war, lit-hist-fic, lit-youth,
+  lit-fantastika, lit-humor, lit-drama (435 plans).
+  Worked example: Леся Українка «Лісова пісня» (драма-феєрія) — corpus-sourced.
+  Reuses the seminar/folk design system. Components:
+    - Close-reading annotation (click a line -> literary device/meaning)   [NEW lit]
+    - Prosody / scansion (stress + meter marking)                           [NEW lit]
+    - Narrative-structure map (пролог + 3 дії, season-coded)                [NEW lit]
+    - Dramatic / performance block (audio of staging + role)   [SHARED with folk]
+    - myth-box (decolonization) + source-box + essay            [reused seminar]
+  Source-analysis families (#20-31) stay available; lit families #50-54 added.
+-->
+<style>
+  :root{
+    --blue:#0057B8;--yellow:#FFD700;--blue-light:#E8F0FE;--yellow-light:#FFF9E0;
+    --green:#2E7D32;--green-light:#E8F5E9;--red:#C62828;--red-light:#FFEBEE;
+    --purple:#6A1B9A;--purple-light:#F3E5F5;--orange:#E65100;--orange-light:#FFF3E0;
+    --teal:#00695C;--teal-light:#E0F2F1;--brown:#5D4037;--brown-light:#EFEBE9;
+    --lit:#1B4332;--lit-2:#40916C;--lit-light:#E7F1EC;
+    --gray-50:#FAFAFA;--gray-100:#F5F5F5;--gray-200:#EEEEEE;--gray-300:#E0E0E0;
+    --gray-600:#757575;--gray-800:#424242;--gray-900:#212121;
+    --radius:12px;--shadow:0 2px 8px rgba(0,0,0,0.08);--shadow-lg:0 4px 16px rgba(0,0,0,0.12);
+  }
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;color:var(--gray-900);background:var(--gray-50);line-height:1.7;}
+  .module-switch{background:var(--gray-900);color:#fff;padding:10px 24px;display:flex;align-items:center;gap:16px;font-size:13px;position:sticky;top:0;z-index:100;}
+  .module-switch .poc-label{margin-left:auto;color:var(--yellow);font-weight:600;letter-spacing:.5px;}
+  .module-switch .arch{background:var(--lit-2);padding:3px 10px;border-radius:5px;color:#fff;font-weight:700;}
+  .header{padding:24px 0;border-bottom:4px solid var(--yellow);background:linear-gradient(135deg,var(--lit),var(--lit-2));color:#fff;}
+  .header-inner{max-width:840px;margin:0 auto;padding:0 24px;}
+  .level-badge{display:inline-block;background:var(--yellow);color:var(--gray-900);font-weight:700;font-size:12px;padding:2px 10px;border-radius:4px;margin-bottom:8px;}
+  .header h1{font-size:26px;font-weight:700;margin-bottom:4px;}
+  .header .subtitle{opacity:.9;font-size:14px;}
+  .tabs-container{max-width:840px;margin:0 auto;padding:0 24px;}
+  .tabs{display:flex;border-bottom:2px solid var(--gray-200);margin-top:20px;overflow-x:auto;}
+  .tab{padding:11px 20px;font-size:14px;font-weight:600;color:var(--gray-600);background:none;border:none;cursor:pointer;border-bottom:3px solid transparent;margin-bottom:-2px;white-space:nowrap;transition:all .2s;}
+  .tab:hover{color:var(--lit-2);}
+  .tab.active{color:var(--lit);border-bottom-color:var(--lit);}
+  .tab-content{display:none;padding:28px 0 60px;}
+  .tab-content.active{display:block;}
+  .content-area{max-width:840px;margin:0 auto;padding:0 24px;}
+  h2{font-size:20px;color:var(--lit);margin:28px 0 14px;padding-bottom:6px;border-bottom:2px solid var(--yellow);}
+  h2:first-child{margin-top:0;}
+  h3{font-size:17px;margin:20px 0 10px;color:var(--gray-800);}
+  p{margin-bottom:14px;font-size:15px;}
+  .new-tag{display:inline-block;background:var(--lit-2);color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;vertical-align:middle;letter-spacing:.5px;margin-left:8px;}
+  .shared-tag{display:inline-block;background:var(--orange);color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;vertical-align:middle;letter-spacing:.5px;margin-left:8px;}
+
+  /* NEW lit: close-reading annotation */
+  .cr-block{margin:22px 0;}
+  .cr-text{background:#fff;border:2px solid var(--lit-light);border-left:4px solid var(--lit);border-radius:var(--radius);padding:18px 22px;font-size:16px;line-height:2.1;box-shadow:var(--shadow);}
+  .cr-text .anno{background:var(--lit-light);border-bottom:2px dotted var(--lit-2);cursor:pointer;padding:0 2px;border-radius:3px;}
+  .cr-text .anno:hover{background:var(--yellow-light);}
+  .cr-info{margin-top:12px;background:var(--lit-light);border:1px solid var(--lit-2);border-radius:8px;padding:12px 16px;font-size:14px;min-height:48px;}
+  .cr-info .cr-dev{font-weight:700;color:var(--lit);}
+
+  /* NEW lit: prosody / scansion */
+  .scan{background:#1a2e23;color:#fff;border-radius:var(--radius);padding:18px 20px;margin:22px 0;box-shadow:var(--shadow-lg);}
+  .scan-line{font-size:20px;letter-spacing:.5px;line-height:2.6;}
+  .syl{display:inline-block;position:relative;padding:0 1px;}
+  .syl .mark{position:absolute;top:-16px;left:50%;transform:translateX(-50%);font-size:13px;color:var(--yellow);}
+  .syl.str{font-weight:700;}
+  .scan-key{font-size:12px;opacity:.7;margin-top:14px;}
+
+  /* NEW lit: narrative-structure map */
+  .nstruct{display:flex;gap:8px;margin:18px 0;flex-wrap:wrap;}
+  .ns-node{flex:1;min-width:150px;background:#fff;border:1px solid var(--gray-200);border-top:4px solid var(--lit-2);border-radius:10px;padding:12px 14px;box-shadow:var(--shadow);}
+  .ns-node .ns-act{font-weight:700;color:var(--lit);font-size:13px;}
+  .ns-node .ns-season{font-size:12px;color:var(--orange);font-weight:600;margin:2px 0 6px;}
+  .ns-node .ns-beat{font-size:13px;color:var(--gray-800);}
+
+  /* SHARED (folk): audio / dramatic performance */
+  .audio-block{background:#1c1230;color:#fff;border-radius:var(--radius);padding:18px 20px;margin:22px 0;box-shadow:var(--shadow-lg);}
+  .audio-head{display:flex;align-items:center;gap:12px;margin-bottom:14px;}
+  .audio-play{width:46px;height:46px;border-radius:50%;background:var(--yellow);color:#1c1230;border:none;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex:0 0 auto;}
+  .audio-meta{font-size:13px;opacity:.85;}.audio-meta strong{display:block;font-size:15px;opacity:1;}
+  .role-line{background:rgba(255,255,255,.07);border-left:3px solid var(--yellow);border-radius:8px;padding:12px 16px;font-size:15px;line-height:1.9;margin-top:6px;}
+  .role-line .who{color:var(--yellow);font-weight:700;}
+  .role-line .stage{font-style:italic;opacity:.7;font-size:13px;}
+
+  /* reused seminar */
+  .source-box{background:var(--purple-light);border:2px solid var(--purple);border-radius:var(--radius);padding:18px 22px;margin:22px 0;}
+  .source-box-header{font-weight:700;color:var(--purple);margin-bottom:8px;font-size:15px;}
+  .source-box blockquote{font-style:italic;border-left:3px solid var(--purple);padding-left:14px;margin:10px 0;color:var(--gray-800);white-space:pre-line;}
+  .source-box .source-cite{font-size:13px;color:var(--gray-600);text-align:right;}
+  .myth-box{background:var(--red-light);border:2px solid var(--red);border-radius:var(--radius);padding:18px 22px;margin:22px 0;}
+  .myth-box-header{display:flex;align-items:center;gap:10px;font-weight:700;font-size:16px;margin-bottom:10px;color:var(--red);}
+  .myth-box .myth-claim{background:rgba(198,40,40,.08);padding:10px 14px;border-radius:8px;margin:8px 0;font-style:italic;border-left:3px solid var(--red);}
+  .myth-box .myth-truth{background:var(--green-light);padding:10px 14px;border-radius:8px;margin:8px 0;border-left:3px solid var(--green);}
+  .bridge-box{background:var(--teal-light);border:2px solid var(--teal);border-radius:var(--radius);padding:16px 20px;margin:22px 0;font-size:14px;}
+  .bridge-box b{color:var(--teal);}
+
+  .exercise{background:#fff;border-radius:var(--radius);border:2px solid var(--gray-200);padding:22px;margin:22px 0;box-shadow:var(--shadow);}
+  .exercise-header{display:flex;align-items:center;gap:10px;margin-bottom:12px;flex-wrap:wrap;}
+  .exercise-badge{font-size:11px;font-weight:700;padding:3px 9px;border-radius:10px;color:#fff;letter-spacing:.3px;}
+  .exercise-title{font-weight:700;font-size:15px;}
+  .exercise-num{margin-left:auto;color:var(--gray-300);font-weight:700;font-size:13px;}
+  .exercise-instruction{font-size:14px;color:var(--gray-600);margin-bottom:12px;}
+  .badge-close{background:var(--lit);}.badge-prosody{background:var(--purple);}.badge-theme{background:var(--teal);}
+  .badge-nstruct{background:var(--blue);}.badge-drama{background:var(--orange);}.badge-essay{background:var(--brown);}
+  .opt{padding:11px 14px;border:1.5px solid var(--gray-200);border-radius:8px;margin:7px 0;cursor:pointer;font-size:14px;transition:all .15s;}
+  .opt:hover{border-color:var(--lit-2);background:var(--lit-light);}
+  .opt.right{border-color:var(--green);background:var(--green-light);}.opt.wrong{border-color:var(--red);background:var(--red-light);}
+  .ta{width:100%;min-height:90px;border:1px solid var(--gray-300);border-radius:8px;padding:10px 12px;font-size:14px;font-family:inherit;margin-top:8px;}
+  .essay-rubric{display:grid;gap:6px;margin-top:10px;}
+  .rubric-item{font-size:13px;background:var(--gray-100);border-radius:6px;padding:6px 10px;}
+  .rubric-item b{color:var(--lit);}
+  .vocab-table{width:100%;border-collapse:collapse;font-size:14px;}
+  .vocab-table th{text-align:left;padding:8px 10px;background:var(--lit-light);}
+  .vocab-table td{padding:8px 10px;border-bottom:1px solid var(--gray-200);}
+  .res-item{display:flex;gap:12px;align-items:flex-start;background:#fff;border:1px solid var(--gray-200);border-radius:8px;padding:12px 14px;margin-bottom:10px;}
+  .res-icon{width:34px;height:34px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:16px;flex:0 0 auto;}
+  .serves{background:var(--lit-light);border-radius:10px;padding:12px 16px;margin:16px 0;font-size:13px;color:var(--gray-800);}
+  .serves b{color:var(--lit);}
+</style>
+</head>
+<body>
+
+<div class="module-switch">
+  <span class="arch">ALL-ROUND LIT</span>
+  <label>one page for the whole lit family (8 sub-tracks · 435 plans)</label>
+  <span class="poc-label">POC · learn-ukrainian</span>
+</div>
+
+<div class="header">
+  <div class="header-inner">
+    <span class="level-badge">C1+ · ЛІТЕРАТУРА</span>
+    <h1>Леся Українка — «Лісова пісня»</h1>
+    <div class="subtitle">Drama-feeria · neoromanticism — verse drama on a folk-mythological base</div>
+  </div>
+</div>
+
+<div class="tabs-container">
+  <div class="tabs">
+    <button class="tab active" data-tab="urok">Урок</button>
+    <button class="tab" data-tab="slovnyk">Словник</button>
+    <button class="tab" data-tab="zoshyt">Зошит</button>
+    <button class="tab" data-tab="resursy">Ресурси</button>
+  </div>
+</div>
+
+<div class="content-area">
+
+  <!-- ===================== УРОК ===================== -->
+  <div id="urok" class="tab-content active">
+    <div class="serves">This one page serves every lit sub-track. <b>Close-reading + prosody + narrative-structure</b> cover lit / essay / war / hist-fic / youth / fantastika / humor; the <b>dramatic-performance block</b> (shared with folk) covers <b>lit-drama</b>. Genre differences are content/register, set in the plan.</div>
+
+    <h2>Жанр і задум</h2>
+    <p>«Лісова пісня» (1911) — <strong>драма-феєрія</strong> Лесі Українки, вершина українського неоромантизму. Драма побудована на <strong>народній демонології</strong> (Мавка, Лісовик, Перелесник), а її конфлікт — між духовною красою і приземленим практицизмом — піднесено до символічного узагальнення.</p>
+
+    <!-- NEW lit: close-reading -->
+    <h3>Пильне читання <span class="new-tag">CLOSE-READING</span></h3>
+    <p>Натисни підкреслені місця — текст працює через троп і підтекст, а не буквально.</p>
+    <div class="cr-block">
+      <div class="cr-text">«У тебе <span class="anno" onclick="cr('Епітетний контраст','«голос чистий» (слух) проти «очі непрозорі» (зір) — синестезійний контраст, що відразу викриває роздвоєну натуру Лукаша: дар є, але душа «непрозора».')">голос чистий, як струмок, / а очі — непрозорі</span>. … Не зневажай <span class="anno" onclick="cr('Метафора-засторога','«душі своєї цвіту» — цвіт як метафора духовного потенціалу; Мавчине застереження стане пророчим, бо Лукаш «не зміг своїм життям до себе дорівнятись».')">душі своєї цвіту</span>, / бо з нього виросло кохання наше!»</div>
+      <div class="cr-info" id="crinfo">Натисни підкреслене місце, щоб прочитати аналіз…</div>
+    </div>
+
+    <div class="source-box">
+      <div class="source-box-header">Першоджерело: «Лісова пісня», дія I</div>
+      <blockquote>Не зневажай душі своєї цвіту,
+бо з нього виросло кохання наше!</blockquote>
+      <div class="source-cite">— Леся Українка, «Лісова пісня» (10-klas-ukrlit-borzenko) · verify_quote → dossier</div>
+    </div>
+
+    <!-- NEW lit: prosody / scansion -->
+    <h3>Версифікація <span class="new-tag">PROSODY</span></h3>
+    <p>Вірш драми — переважно <strong>п’ятистопний ямб</strong>. Познач наголоси, щоб почути ритм:</p>
+    <div class="scan">
+      <div class="scan-line">
+        <span class="syl">Не</span> <span class="syl str"><span class="mark">´</span>зне</span><span class="syl">ва</span><span class="syl str"><span class="mark">´</span>жай</span> <span class="syl">ду</span><span class="syl str"><span class="mark">´</span>ші</span> <span class="syl">сво</span><span class="syl str"><span class="mark">´</span>є</span><span class="syl">ї</span> <span class="syl str"><span class="mark">´</span>цві</span><span class="syl">ту</span>
+      </div>
+      <div class="scan-key">´ = наголошений склад · ямб = ◡ —́ (нена­голошений + наголошений)</div>
+    </div>
+
+    <!-- NEW lit: narrative structure -->
+    <h3>Композиція <span class="new-tag">STRUCTURE</span></h3>
+    <p>Пролог + три дії, прив’язані до пір року — природа дзеркалить душевні зміни:</p>
+    <div class="nstruct">
+      <div class="ns-node"><div class="ns-act">Пролог</div><div class="ns-season">поза часом</div><div class="ns-beat">Світ міфічних істот; умовний, символічний ключ.</div></div>
+      <div class="ns-node"><div class="ns-act">Дія I</div><div class="ns-season">весна</div><div class="ns-beat">Зародження кохання Мавки й Лукаша; гармонія людини і природи.</div></div>
+      <div class="ns-node"><div class="ns-act">Дія II</div><div class="ns-season">пізнє літо</div><div class="ns-beat">Конфлікт мрії та буденності; зрада.</div></div>
+      <div class="ns-node"><div class="ns-act">Дія III</div><div class="ns-season">пізня осінь</div><div class="ns-beat">Непоправна втрата; запізніле прозріння.</div></div>
+    </div>
+
+    <!-- SHARED (folk): dramatic performance — covers lit-drama -->
+    <h3>Драматичне виконання <span class="shared-tag">SHARED · folk-drama module</span></h3>
+    <div class="audio-block">
+      <div class="audio-head">
+        <button class="audio-play" onclick="this.textContent=this.textContent==='▶'?'⏸':'▶'">&#x25B6;</button>
+        <div class="audio-meta"><strong>Фінальний монолог Мавки</strong>сценічний запис · стеж за роллю та ремаркою</div>
+      </div>
+      <div class="role-line"><span class="who">МАВКА:</span> «…ти душу дав мені, як гострий ніж / дає вербовій тихій гілці голос». <span class="stage">(голос промовляє вже в чарівній грі сопілки)</span></div>
+      <p style="font-size:12px;opacity:.6;margin:10px 0 0">POC: staging audio + role/ремарка at build; для lit-drama додається завдання «читання за ролями».</p>
+    </div>
+
+    <!-- decolonization -->
+    <div class="myth-box">
+      <div class="myth-box-header">&#x2694; Руйнуємо міф</div>
+      <div class="myth-claim">Леся Українка — «хвора поетеса», авторка кількох патріотичних віршів.</div>
+      <div class="myth-truth"><strong>Насправді:</strong> модерністка світового рівня — неоромантична драматургиня, перекладачка, критикиня; «Лісова пісня» — філософська драма про свободу духу. Радянський канон звужував її до «Contra spem spero» й образу страждання, щоб приховати її антиімперський модернізм і феміністичну думку.</div>
+    </div>
+
+    <div class="bridge-box"><b>Перехресні зв’язки:</b> folk → народна демонологія (Мавка, Лісовик, Перелесник); bio → М. Драй-Хмара (його оцінка: «трагедія високої душі, що заблудилась серед болота буденного життя»).</div>
+  </div>
+
+  <!-- ===================== СЛОВНИК ===================== -->
+  <div id="slovnyk" class="tab-content">
+    <h2>Словник</h2>
+    <table class="vocab-table">
+      <tr><th>Слово / термін</th><th>Значення</th><th>Приклад</th></tr>
+      <tr><td><strong>драма-феєрія</strong></td><td>drama-feeria (fairy/verse drama)</td><td>жанр «Лісової пісні»</td></tr>
+      <tr><td><strong>неоромантизм</strong></td><td>neoromanticism</td><td>вершина укр. неоромантизму</td></tr>
+      <tr><td><strong>ремарка</strong></td><td>stage direction</td><td>розгорнуті ремарки</td></tr>
+      <tr><td><strong>підтекст</strong></td><td>subtext</td><td>роль підтексту в образі Мавки</td></tr>
+      <tr><td><strong>символ</strong></td><td>symbol</td><td>Мавка як складний символ</td></tr>
+      <tr><td><strong>метаморфоза</strong></td><td>metamorphosis</td><td>перетворення на вербу</td></tr>
+    </table>
+  </div>
+
+  <!-- ===================== ЗОШИТ ===================== -->
+  <div id="zoshyt" class="tab-content">
+    <h2>Зошит <span class="new-tag">LIT FAMILIES #50–54</span></h2>
+    <p style="color:var(--gray-600);font-size:14px">Literary families added to the source-analysis set (#20–31 remain available — авторський задум, есе, порівняння, критика перекладу).</p>
+
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-close">Close-reading</span><span class="exercise-title">Назви троп</span><span class="exercise-num">#50</span></div>
+      <div class="exercise-instruction">«голос чистий, як струмок, а очі — непрозорі». Який прийом несе характеристику Лукаша?</div>
+      <div class="opt" onclick="pick(this,false)">Гіпербола</div>
+      <div class="opt" onclick="pick(this,true)">Контрастний епітет / синестезія (чистий голос ↔ непрозорі очі)</div>
+      <div class="opt" onclick="pick(this,false)">Метонімія</div>
+    </div>
+
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-prosody">Prosody</span><span class="exercise-title">Визнач розмір</span><span class="exercise-num">#51</span></div>
+      <div class="exercise-instruction">Познач наголоси у рядку (POC: click-to-mark at build) і визнач віршовий розмір.</div>
+      <div class="opt" onclick="pick(this,true)">Ямб (◡ —́)</div>
+      <div class="opt" onclick="pick(this,false)">Хорей (—́ ◡)</div>
+      <div class="opt" onclick="pick(this,false)">Дактиль (—́ ◡ ◡)</div>
+    </div>
+
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-theme">Theme-trace</span><span class="exercise-title">Простеж мотив</span><span class="exercise-num">#52</span></div>
+      <div class="exercise-instruction">Простеж мотив «сопілки/голосу» крізь три дії — як він змінює значення від кохання до втрати?</div>
+      <textarea class="ta" placeholder="Дія I … Дія II … Дія III …"></textarea>
+    </div>
+
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-nstruct">Structure</span><span class="exercise-title">Зістав композицію та пори року</span><span class="exercise-num">#53</span></div>
+      <div class="exercise-instruction">З’єднай дію з її сезоном і драматичною функцією (POC: drag-match at build).</div>
+      <div class="opt" onclick="pick(this,true)">Дія I — весна — зародження кохання</div>
+      <div class="opt" onclick="pick(this,true)">Дія III — пізня осінь — втрата і прозріння</div>
+    </div>
+
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-drama">Dramatic reading</span><span class="exercise-title">Читання за ролями</span><span class="exercise-num">#54 · shared</span></div>
+      <div class="exercise-instruction">Озвуч монолог Мавки з потрібною інтонацією; запиши й порівняй зі сценічним записом.</div>
+      <button class="audio-play" style="background:var(--orange);color:#fff;width:auto;height:auto;padding:9px 18px;border-radius:22px;font-size:14px;font-weight:600">&#x25CF; Записати читання</button>
+    </div>
+
+    <div class="exercise">
+      <div class="exercise-header"><span class="exercise-badge badge-essay">Essay</span><span class="exercise-title">Есе</span><span class="exercise-num">#21 · reused</span></div>
+      <div class="exercise-instruction">«Чи є фінал «Лісової пісні» поразкою чи перемогою духу?» Аргументуй, спираючись на текст. 250–400 слів.</div>
+      <textarea class="ta" placeholder="Напишіть есе українською мовою…"></textarea>
+      <div class="essay-rubric">
+        <div class="rubric-item"><b>Текстова опора:</b> щонайменше дві цитати з твору</div>
+        <div class="rubric-item"><b>Аргументація:</b> чітка теза + розвиток</div>
+        <div class="rubric-item"><b>Мова:</b> академічний стиль українською</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===================== РЕСУРСИ ===================== -->
+  <div id="resursy" class="tab-content">
+    <h2>Ресурси</h2>
+    <div class="res-item"><div class="res-icon" style="background:var(--lit-light);color:var(--lit)">&#128214;</div><div><strong>Текст:</strong> «Лісова пісня» (повний текст, дія I–III) — corpus literary_texts.</div></div>
+    <div class="res-item"><div class="res-icon" style="background:#1c1230;color:var(--yellow)">&#9834;</div><div><strong>Сценічний запис:</strong> фінальний монолог Мавки — для lit-drama (shared performance module).</div></div>
+    <div class="res-item"><div class="res-icon" style="background:var(--blue-light);color:var(--blue)">&#9635;</div><div><strong>Джерела:</strong> 10-klas-ukrlit-borzenko-2018-prof; листи Лесі Українки до матері й сестри (авторський задум).</div></div>
+    <div class="res-item"><div class="res-icon" style="background:var(--teal-light);color:var(--teal)">&#8644;</div><div><strong>Перехресно:</strong> folk → народна демонологія; bio → М. Драй-Хмара.</div></div>
+  </div>
+
+</div>
+
+<script>
+  document.querySelectorAll('.tab').forEach(function(t){
+    t.onclick=function(){
+      document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active');});
+      document.querySelectorAll('.tab-content').forEach(function(x){x.classList.remove('active');});
+      t.classList.add('active');
+      document.getElementById(t.dataset.tab).classList.add('active');
+    };
+  });
+  function cr(dev,txt){
+    var el=document.getElementById('crinfo'); el.textContent='';
+    var b=document.createElement('span'); b.className='cr-dev'; b.textContent=dev+': ';
+    el.appendChild(b); el.appendChild(document.createTextNode(txt));
+  }
+  function pick(el,ok){el.classList.remove('right','wrong');el.classList.add(ok?'right':'wrong');}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Folk track re-research/rebuild — Stage-0 foundation

User redirected the Claude driver from bio to **re-research + rebuild the FOLK track first** (2026-06-06). Bio rests (310/310 dossiers safe; its handoff intact). This PR carries the durable state + design artifacts from the kickoff session. **OPEN — do not self-merge** (folk has no merge-grant yet; user/orchestrator promotes).

### What's in it
- **`docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md`** — resumable driver SSOT: locked scope (broad folk culture, C1+, research→dossier→wiki only — GPT builds modules; Claude+GPT writers, **no DeepSeek for Ukrainian culture**), the **~41-topic taxonomy** with GPT cross-check refinements (bylyny 4→1 de-imperialized, resistance songs IN, +literary-origin/family-rite/regional/cuisine/systems-overview), the genre-shaped **folk dossier schema**, corpus facts, and next actions.
- **`docs/poc/poc-folk-lesson-design.html`** — the **`folk-experiential`** archetype (audio block, symbolic-decode hotspots, high-culture bridge, folk activity families #40-45) on the existing 4-tab shell. Worked example: Щедрик (corpus-sourced).
- **`docs/poc/poc-lit-lesson-design.html`** — one **all-round lit page** for the whole lit family (8 sub-tracks / 435 plans): close-reading + prosody + narrative-structure + the **shared dramatic module** that covers lit-drama. Worked example: «Лісова пісня».

### Design verdict (architecture)
There is **no realized seminar module POC** (0 built across all 7 seminar tracks). Coverage maps to **2 page archetypes + 1 shared module — not 13 designs**:
- `seminar-source-analysis` → bio · hist · istorio · **oes · ruth** · lit (oes/ruth are its native philology use case)
- `folk-experiential` → folk
- shared performative/multimodal module → folk + lit-drama + bio cultural-figures

### Notes
- POCs are design drafts (folk Урок needs **more expository prose** per user feedback — tracked in the handoff).
- GPT folk-taxonomy cross-check = bridge msg #1148.
- Docs/HTML only; pre-commit clean (gitleaks passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)