### PR TITLE
fix(audit): find_dead_code excludes .worktrees/ + archive/ (#1863 Phase 2)

### DIFF
--- a/scripts/audit/find_dead_code.py
+++ b/scripts/audit/find_dead_code.py
@@ -3,6 +3,38 @@ import datetime
 import subprocess
 from pathlib import Path
 
+# Directory NAMES never walked by the filesystem scanners (categories A/B/F).
+# Critically includes `.worktrees`: live dispatch worktrees are full repo
+# copies, so scanning them multiplies every hit by the number of active
+# worktrees (observed 2026-06-06: 11 worktrees → 77% of the report was
+# `.worktrees/` noise). `archive` is the Phase-4 holding pen for already-
+# triaged deletions — re-reporting it as "dead code" is pure noise. The other
+# names are virtualenvs / vendored deps / VCS internals.
+EXCLUDE_DIR_NAMES = (
+    ".venv",
+    "embed-venv",
+    "node_modules",
+    "site-packages",
+    ".git",
+    ".worktrees",
+    "archive",
+)
+
+
+def _is_excluded(path: Path) -> bool:
+    """True if any path component is an excluded directory name."""
+    return any(part in EXCLUDE_DIR_NAMES for part in path.parts)
+
+
+def _ugrep_exclude_flags() -> list[str]:
+    """`--exclude-dir=<name>` flags for every excluded directory."""
+    return [f"--exclude-dir={name}" for name in EXCLUDE_DIR_NAMES]
+
+
+def _vulture_exclude_glob() -> str:
+    """Comma-joined `*/<name>/*` globs for vulture's --exclude."""
+    return ",".join(f"*/{name}/*" for name in EXCLUDE_DIR_NAMES)
+
 
 def run_cmd(cmd, cwd=None):
     try:
@@ -16,7 +48,7 @@ def category_a(root: Path):
     hits = []
     try:
         for p in root.rglob("*.py"):
-            if ".venv" in p.parts or "node_modules" in p.parts or ".git" in p.parts:
+            if _is_excluded(p):
                 continue
             try:
                 content = p.read_text(encoding="utf-8")
@@ -28,9 +60,7 @@ def category_a(root: Path):
                         "-rlw",
                         stem,
                         str(root),
-                        "--exclude-dir=.git",
-                        "--exclude-dir=node_modules",
-                        "--exclude-dir=.venv",
+                        *_ugrep_exclude_flags(),
                     ]
                     res = run_cmd(cmd)
                     if res and res.stdout.strip():
@@ -60,7 +90,7 @@ def category_b(root: Path):
             "--min-confidence",
             "80",
             "--exclude",
-            "*/.venv/*,*/embed-venv/*,*/node_modules/*,*/site-packages/*",
+            _vulture_exclude_glob(),
         ]
     )
     if not res:
@@ -143,8 +173,7 @@ def category_f(root: Path):
     for d in root.rglob("orchestration"):
         if (
             d.is_dir()
-            and ".venv" not in d.parts
-            and "node_modules" not in d.parts
+            and not _is_excluded(d)
             and not (d / "status.json").exists()
             and not (d.parent / "status.json").exists()
         ):
@@ -235,7 +264,10 @@ def main():
 
     categories = {
         "A Marked-obsolete code (M)": (category_a, "Grep for OBSOLETE banners; check live callers via ugrep."),
-        "B Dead Python (L)": (category_b, "vulture --min-confidence 80 (excludes .venv/embed-venv/node_modules/site-packages)."),
+        "B Dead Python (L)": (
+            category_b,
+            "vulture --min-confidence 80 (excludes .venv/embed-venv/node_modules/site-packages/.git/.worktrees/archive).",
+        ),
         "C Stale docs (L)": (category_c, "ugrep v6_build|pipeline_v5 in docs/ excluding specific subdirs."),
         "D Generated artifacts that escaped (L)": (
             category_d,

--- a/tests/audit/test_find_dead_code.py
+++ b/tests/audit/test_find_dead_code.py
@@ -1,4 +1,15 @@
-from scripts.audit.find_dead_code import category_a, category_b, category_c, category_d, category_g, main
+from pathlib import Path
+
+from scripts.audit.find_dead_code import (
+    _is_excluded,
+    category_a,
+    category_b,
+    category_c,
+    category_d,
+    category_f,
+    category_g,
+    main,
+)
 
 
 def test_category_a(tmp_path):
@@ -107,3 +118,41 @@ def test_smoke_main(tmp_path, monkeypatch):
     ]
     for c in categories:
         assert c in content
+
+
+def test_is_excluded():
+    # .worktrees (live dispatch worktrees = full repo copies) and archive
+    # (Phase-4 holding pen) must be excluded; normal source paths must not.
+    assert _is_excluded(Path("/repo/.worktrees/dispatch/x/scripts/foo.py"))
+    assert _is_excluded(Path("/repo/archive/2026-06-06-cleanup-1/old.py"))
+    assert _is_excluded(Path("/repo/.venv/lib/python/site-packages/x.py"))
+    assert _is_excluded(Path("/repo/node_modules/pkg/index.js"))
+    assert not _is_excluded(Path("/repo/scripts/build/v7_build.py"))
+
+
+def test_category_a_excludes_worktrees(tmp_path):
+    # An OBSOLETE module in the live tree is flagged; an identical one inside
+    # .worktrees/ (a full repo copy) must NOT be — else every hit is counted
+    # once per active worktree (the 2026-06-06 77%-pollution bug).
+    (tmp_path / "live.py").write_text("OBSOLETE\ndef foo(): pass", encoding="utf-8")
+    wt = tmp_path / ".worktrees" / "dispatch" / "x"
+    wt.mkdir(parents=True)
+    (wt / "copy.py").write_text("OBSOLETE\ndef foo(): pass", encoding="utf-8")
+
+    hits = category_a(tmp_path)
+
+    assert any("live.py" in h for h in hits)
+    assert not any(".worktrees" in h for h in hits)
+
+
+def test_category_f_excludes_worktrees(tmp_path):
+    # An orphaned orchestration dir in the live tree is a candidate; one inside
+    # .worktrees/ must NOT be (484 of the polluted F hits were worktree copies).
+    (tmp_path / "mod" / "orchestration").mkdir(parents=True)
+    wt_orch = tmp_path / ".worktrees" / "dispatch" / "x" / "mod" / "orchestration"
+    wt_orch.mkdir(parents=True)
+
+    hits = category_f(tmp_path)
+
+    assert any("mod/orchestration" in h and ".worktrees" not in h for h in hits)
+    assert not any(".worktrees" in h for h in hits)


### PR DESCRIPTION
## What

`scripts/audit/find_dead_code.py` (the #1863 Phase 1 inventory tool, merged in #2741) walked `.worktrees/` — **11 live dispatch worktrees, each a full repo copy** — so every hit was counted once per worktree.

**Impact (measured 2026-06-06):** 77% of the report (2460/3202 hits) was `.worktrees/` noise; scan took 6m16s. This blocked #1863 Phase 2 (triage → file 10 sub-issues): triaging off polluted data would propagate the noise into 10 issues.

## Root cause

The three root-level filesystem scanners each carried their own ad-hoc exclude list, all missing `.worktrees`:
- `category_a` — `root.rglob("*.py")` + ugrep caller check
- `category_b` — vulture `--exclude` glob
- `category_f` — `root.rglob("orchestration")`

Categories C/D/E/G/H/I/J already scope to a subdir (`docs/`, `scripts/`, …) or use `git ls-files` (tracked-only; `.worktrees` is gitignored), so they needed no change.

## Fix

Centralized exclusion into one `EXCLUDE_DIR_NAMES` constant + `_is_excluded()` / `_ugrep_exclude_flags()` / `_vulture_exclude_glob()` helpers, applied consistently across A/B/F. Kills the scattered-per-category exclusion bug class. Also added `archive` (the Phase-4 deletion holding pen — re-reporting already-triaged deletions as "dead code" is noise).

## Result (clean re-run)

| Metric | Before | After |
|---|---|---|
| Total hits | 3187 | **712** |
| `.worktrees/` walk hits | 2460 | **0** |
| Category B (vulture) | 2124 | 153 |
| Category F | 484 | 20 |
| Runtime | 6m16s | **1m03s** (6×) |

## Tests

3 regression tests added (`_is_excluded` helper + category A/F worktree-exclusion). `tests/audit/` green: **471 passed, 17 skipped**. ruff clean.

Unblocks #1863 Phase 2 triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)