### PR TITLE
cleanup(C): update operational docs V6→V7 (#2749)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1737,7 +1737,7 @@ Worktree classification:
 
 ### Force-preview — `GET /api/artifacts/{track}/{slug}/force-preview`
 
-Exact list of files `v6_build.py {track} {num} --force` would delete,
+Exact list of files `v7_build.py {track} {slug} --worktree --force` would delete,
 classified by category. **Never** deletes anything.
 
 ```json
@@ -1842,7 +1842,7 @@ revision of this endpoint was removed per reviewer BLOCKER on
 
 ## Build Event Stream (#1180)
 
-`scripts/build/v6_build.py` now emits monitor-friendly JSON lines to `stdout` alongside the existing human-readable logs. Each event is exactly one line, includes `event` and `ts`, and is flushed immediately with `print(..., flush=True)`.
+`scripts/build/v7_build.py` now emits monitor-friendly JSON lines to `stdout` alongside the existing human-readable logs. Each event is exactly one line, includes `event` and `ts`, and is flushed immediately with `print(..., flush=True)`.
 
 Example stream:
 
@@ -1862,7 +1862,7 @@ Conceptual Claude Code `Monitor` usage:
 
 ```text
 Monitor
-  command: .venv/bin/python scripts/build/v6_build.py a2 1 --resume
+  command: .venv/bin/python scripts/build/v7_build.py a2 m01-bridge --worktree --resume
   stream: stdout
   parse: JSONL lines whose objects contain "event"
   ignore: human-readable log lines that are not JSON

--- a/docs/RUNBOOK-BUILD.md
+++ b/docs/RUNBOOK-BUILD.md
@@ -46,34 +46,22 @@ Core levels (A1-C2) are 100% compiled. If any are missing:
 ### Single Module
 
 ```bash
-# Module numbers are 1-indexed, matching order in curriculum.yaml
-.venv/bin/python scripts/build/v6_build.py a1 1
+# Modules use the slug from curriculum.yaml
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree
 ```
 
 ### Batch (Range)
 
-```bash
-# A1: 55 modules (1-55)
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55
-
-# A2: 69 modules (1-69)
-.venv/bin/python scripts/build/v6_build.py a2 1 --range 69
-
-# B1: 94 modules (1-94)
-.venv/bin/python scripts/build/v6_build.py b1 1 --range 94
-
-# B2: 93 modules (1-93)
-.venv/bin/python scripts/build/v6_build.py b2 1 --range 93
-```
+V7 is single-module per invocation (no `--range`). To run a batch, use standard shell loops or CI orchestration over the module list.
 
 ### Writer / Reviewer
 
 ```bash
 # Default: gemini-tools writes, cross-agent reviews
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree
 
 # Explicit Gemini writes + Gemini reviews (current setup)
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55 \
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree \
   --writer gemini-tools --reviewer gemini-tools
 ```
 
@@ -81,16 +69,16 @@ Core levels (A1-C2) are 100% compiled. If any are missing:
 
 ```bash
 # Auto (default): preserve current environment behavior
-.venv/bin/python scripts/build/v6_build.py a1 1 --writer gemini-tools
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --writer gemini-tools
 
 # Subscription / OAuth: strip GEMINI_API_KEY and GOOGLE_API_KEY for this run
 GEMINI_AUTH_MODE=subscription \
-  .venv/bin/python scripts/build/v6_build.py a1 1 --writer gemini-tools
+  .venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --writer gemini-tools
 
 # API key: preserve key env vars explicitly
 GEMINI_AUTH_MODE=api \
   GEMINI_API_KEY=... \
-  .venv/bin/python scripts/build/v6_build.py a1 1 --writer gemini-tools
+  .venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --writer gemini-tools
 ```
 
 `GEMINI_AUTH_MODE=subscription|api|auto` only affects Gemini CLI launches.
@@ -99,21 +87,21 @@ Claude and Codex paths ignore it.
 ### Resume (continue from where it stopped)
 
 ```bash
-# Resume all incomplete modules in range — skips completed phases
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55 --resume
+# Resume an incomplete module — skips completed phases
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --resume
 
 # Resume from a specific step (e.g., after first pass stops at review)
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55 --step publish --resume
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --step publish --resume
 ```
 
 ### Specific Steps Only
 
 ```bash
-# Run only audit+heal+publish for modules that stopped at stress/review
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55 --step publish --resume
+# Run only audit+heal+publish for a module that stopped at stress/review
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --step publish --resume
 
 # Run only review pass
-.venv/bin/python scripts/build/v6_build.py a1 1 --range 55 --step review --resume
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --step review --resume
 ```
 
 ---

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -2,7 +2,7 @@
 
 Current operational reference for repo-local scripts and agent workflows.
 
-- Main build entry point: `.venv/bin/python scripts/build/v6_build.py {level} {num}`
+- Main build entry point: `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree`
 - Validation pipeline after content exists: `npm run audit`, `npm run pipeline`, `npm run generate:json`
 - This document intentionally omits retired pipelines and legacy script paths
 
@@ -342,7 +342,7 @@ Additional audit guardrails:
 
 ### Build pipeline entry point
 
-`.venv/bin/python scripts/build/v6_build.py {level} {num}` is the single end-to-end build entry point. It drives the write -> enrich -> review -> audit -> publish chain.
+`.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree` is the single end-to-end build entry point. It drives the write -> enrich -> review -> audit -> publish chain.
 
 ### Agent runtime
 
@@ -371,25 +371,22 @@ Use two entry points depending on the job:
 
 | Need | Entry point |
 |---|---|
-| Full module build | `.venv/bin/python scripts/build/v6_build.py {level} {num}` |
+| Full module build | `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree` |
 | Validate existing content | `npm run audit`, `npm run pipeline`, `npm run generate:json` |
 
-### `scripts/build/v6_build.py`
+### `scripts/build/v7_build.py`
 
 Single end-to-end build entry point.
 
 ```bash
 # Single module
-.venv/bin/python scripts/build/v6_build.py a1 5
-
-# Range
-.venv/bin/python scripts/build/v6_build.py a1 7 --range 14
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree
 
 # Resume from prior state
-.venv/bin/python scripts/build/v6_build.py hist 12 --resume
+.venv/bin/python scripts/build/v7_build.py hist m12-kyivan-rus --worktree --resume
 
 # Run a specific step only
-.venv/bin/python scripts/build/v6_build.py b1 9 --step review
+.venv/bin/python scripts/build/v7_build.py b1 m09-travel --worktree --step review
 ```
 
 Useful flags:
@@ -401,11 +398,11 @@ Useful flags:
 
 #### Build monitoring with Claude Code `Monitor` tool
 
-v6_build.py emits JSONL events on stdout (`module_start`, `phase_done`, `review_score`, `module_done`, `module_failed`, `batch_done`). Use the Claude Code `Monitor` tool to stream these as notifications:
+v7_build.py emits JSONL events on stdout (`module_start`, `phase_done`, `review_score`, `module_done`, `module_failed`, `batch_done`). Use the Claude Code `Monitor` tool to stream these as notifications:
 
 ```
 Monitor(
-    command=".venv/bin/python -u scripts/build/v6_build.py a1 1 --range 55 --resume 2>&1 | grep --line-buffered '^{\"event\"'",
+    command=".venv/bin/python -u scripts/build/v7_build.py a1 m01-alphabet --worktree --resume 2>&1 | grep --line-buffered '^{\"event\"'",
     description="A1 build events",
     persistent=True,
     timeout_ms=3600000
@@ -437,7 +434,7 @@ npm run pipeline l2-uk-en a1 5
 npm run generate:json l2-uk-en a1 5
 ```
 
-`pipeline.py` is the technical validation pipeline. It is not the same thing as the end-to-end build orchestrator in `scripts/build/v6_build.py`.
+`pipeline.py` is the technical validation pipeline. It is not the same thing as the end-to-end build orchestrator in `scripts/build/v7_build.py`.
 
 ---
 
@@ -489,7 +486,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 
 | Script | Purpose | Command |
 |---|---|---|
-| `scripts/build/v6_build.py` | End-to-end module build | `.venv/bin/python scripts/build/v6_build.py a1 5` |
+| `scripts/build/v7_build.py` | End-to-end module build | `.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree` |
 | `scripts/audit_level.py` | Audit a level, module, or range | `npm run audit -- b1 1-10` |
 | `scripts/audit_module.py` | Audit a single module file | `.venv/bin/python scripts/audit_module.py <file>` |
 | `scripts/pipeline.py` | Technical validation pipeline | `npm run pipeline l2-uk-en a1 5` |
@@ -895,7 +892,7 @@ ab channel tail reviews --thread THREAD_ID
 ab channel new mytopic --include shared --agents claude,gemini,codex
 
 # Post — short form (one recipient)
-ab p reviews gemini "Review the v6 heal-loop changes in scripts/build/v6_build.py"
+ab p reviews gemini "Review the heal-loop changes in scripts/build/linear_pipeline.py"
 
 # Post — long form (multi-recipient, threading)
 ab post reviews "Adversarial review of #1299 docs patch" --to gemini,codex --parent MSG_ID
@@ -994,7 +991,7 @@ Use `delegate.py status-or-fail <task-id>` before reporting async task state fro
 
 Two event surfaces, split by agent:
 
-- **Claude Code** has a built-in `Monitor` tool that streams stdout events as notifications with ~zero context cost. Use it to watch `v6_build.py` JSONL events, `ab channel watch --event-stream`, or any long-running command. Invoke the tool directly — do **not** wrap it in a shell poll loop.
+- **Claude Code** has a built-in `Monitor` tool that streams stdout events as notifications with ~zero context cost. Use it to watch `v7_build.py` JSONL events, `ab channel watch --event-stream`, or any long-running command. Invoke the tool directly — do **not** wrap it in a shell poll loop.
 - **Gemini / Codex** (headless) do not have `Monitor`. Poll the Monitor API via `curl` when they need to check state.
 
 State queries (all agents):
@@ -1074,7 +1071,7 @@ ab converse "Let's plan the A1/1 build" --task-id a1-1-planning \
 | Build one module | `/module {level} {num}` |
 | Full seminar rebuild | `/full-rebuild {track} {slug}` |
 | Full core rebuild | `/full-rebuild-core {level} {num}` |
-| Full v6 build via script | `.venv/bin/python scripts/build/v6_build.py {level} {num}` |
+| Full v7 build via script | `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree` |
 | Audit a module or range | `npm run audit -- {level} {num|range}` |
 | Run technical validation | `npm run pipeline l2-uk-en {level} {num}` |
 | Generate app JSON | `npm run generate:json l2-uk-en {level} {num}` |

--- a/docs/agent-channels/pipeline/context.md
+++ b/docs/agent-channels/pipeline/context.md
@@ -1,8 +1,8 @@
-# pipeline — v6 build, audit, dispatch
+# pipeline — v7 build, audit, dispatch
 
-This channel is for conversations about the V6 module build pipeline
+This channel is for conversations about the V7 module build pipeline
 and its supporting infrastructure. If you're posting here, you're
-discussing `scripts/build/v6_build.py`, `scripts/build/quick_verify.py`,
+discussing `scripts/build/v7_build.py`, `scripts/build/quick_verify.py`,
 `scripts/audit/**`, `scripts/build/dispatch.py`, the agent_runtime
 adapter, or anything else that touches how a module goes from plan →
 prose → audit → review → publish.
@@ -29,7 +29,7 @@ check → research → skeleton → write → activities → enrich → verify �
 
 | File | What |
 |---|---|
-| `scripts/build/v6_build.py` | 6000-line god object — main pipeline orchestrator |
+| `scripts/build/v7_build.py` | CLI entry point for linear_pipeline execution |
 | `scripts/build/quick_verify.py` | Post-write structural checks |
 | `scripts/build/phases/v6-write.md` | Write-phase prompt template |
 | `scripts/build/dispatch.py` | Agent invocation (Gemini/Claude tools mode) |
@@ -47,7 +47,7 @@ check → research → skeleton → write → activities → enrich → verify �
 ## Common commands
 
 ```bash
-.venv/bin/python scripts/build/v6_build.py a1 3               # build module 3 of A1
-.venv/bin/python scripts/build/v6_build.py b1 N --slug X --step write --resume  # re-run write
+.venv/bin/python scripts/build/v7_build.py a1 m03-slug --worktree               # build module 3 of A1
+.venv/bin/python scripts/build/v7_build.py b1 mX-slug --worktree --step write --resume  # re-run write
 .venv/bin/python -m pytest tests/test_quick_verify.py         # unit tests
 ```

--- a/docs/architecture/system-topology.md
+++ b/docs/architecture/system-topology.md
@@ -30,7 +30,7 @@ graph TB
     end
 
     subgraph Pipeline["scripts/build/ — v6 pipeline"]
-        V6[v6_build.py<br/>17 phases]
+        V7[v7_build.py<br/>linear_pipeline.py]
         DispatchAgent[dispatch_agent]
         SessionAnalysis[session_analysis.py]
     end
@@ -107,7 +107,7 @@ graph TB
     RuntimeR --> Usage
     DelegateR --> TaskState
 
-    V6 --> Starlight
+    V7 --> Starlight
     Starlight --> MDX
 
     Gemini -.->|MCP| RAGServer
@@ -117,10 +117,10 @@ graph TB
 
 ## Data flows
 
-### Building a module (v6 pipeline)
+### Building a module (v7 pipeline)
 
 ```
-user → v6_build.py {level} {num}
+user → v7_build.py {level} {slug} --worktree
   → loads plans/{level}/{slug}.yaml
   → loads wiki/{domain}/{slug}.md (knowledge packet)
   → dispatch_agent() per phase
@@ -180,7 +180,7 @@ user → compile.py --track hist --slug kyivan-rus
 
 | Path | Purpose |
 |------|---------|
-| `scripts/build/v6_build.py` | The one pipeline entry point |
+| `scripts/build/v7_build.py` | The one pipeline entry point |
 | `scripts/agent_runtime/runner.py` | The one LLM dispatch function |
 | `scripts/api/main.py` | The one API server |
 | `scripts/wiki/compile.py` | The one wiki compiler |

--- a/docs/best-practices/code-quality.md
+++ b/docs/best-practices/code-quality.md
@@ -10,12 +10,12 @@
 
 ```bash
 # ✅ Correct
-.venv/bin/python scripts/build/v6_build.py a1 1
+.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a1/sounds-letters-and-hello.md
 
 # ❌ Wrong
-python3 scripts/build/v6_build.py a1 1   # missing deps
-python scripts/build/v6_build.py a1 1    # wrong version
+python3 scripts/build/v7_build.py a1 m01-alphabet --worktree   # missing deps
+python scripts/build/v7_build.py a1 m01-alphabet --worktree    # wrong version
 ```
 
 **Why:** The venv uses pyenv Python 3.12.8 compiled with `--enable-loadable-sqlite-extensions` for sqlite-vec. Homebrew Python will silently fail on vector search.
@@ -31,7 +31,9 @@ rm -rf .venv && ~/.pyenv/versions/3.12.8/bin/python -m venv .venv
 
 | Script | Use for | Status |
 |--------|---------|--------|
-| `scripts/build/v6_build.py` | All new builds (17-phase pipeline) | **Current (V6)** |
+| `scripts/build/v7_build.py` | V7 pipeline orchestrator (CLI entry point) | **Current (V7)** |
+| `scripts/build/linear_pipeline.py` | V7 linear execution engine | **Current (V7)** |
+| `scripts/build/v6_build.py` | Legacy v6 pipeline | **RETIRED** |
 | `scripts/build/dispatch.py` | Agent subprocess dispatch (Claude/Gemini/Codex) | **Current** |
 | `scripts/build/enrich.py` | Deterministic post-write enrichment | **Current** |
 | `scripts/build/activity_repair.py` | Deterministic activity fixer (#1185) | **Current** |
@@ -40,7 +42,7 @@ rm -rf .venv && ~/.pyenv/versions/3.12.8/bin/python -m venv .venv
 | `scripts/build/build_module_v5.py` (+ stub at scripts/build_module_v5.py) | Legacy v5 entrypoint | **RETIRED** — do not use |
 | `scripts/build/pipeline_v5.py` (+ stub at scripts/pipeline_v5.py) | Legacy v5 phases | **RETIRED** — do not use |
 
-Always use V6. The v5 files remain only so old session state files can still
+Always use V7. The legacy files remain only so old session state files can still
 be loaded for forensic analysis — no new code should import them.
 
 ---
@@ -157,7 +159,7 @@ Strings containing colons followed by content must be single-quoted:
 
 ## Logging Conventions
 
-Use the `_log()` helper from `scripts/build/v6_build.py` — it writes to stdout
+Use the `_log()` helper from `scripts/build/linear_pipeline.py` — it writes to stdout
 and to the module's orchestration state.json phase log. Pipeline modules should
 import it or define a thin proxy; ad-hoc scripts can use stdlib `print()` but
 must prefix messages with a two-space indent + phase tag to stay grep-able.

--- a/docs/lesson-schema-design.md
+++ b/docs/lesson-schema-design.md
@@ -435,7 +435,7 @@ PLACEHOLDERS = {
 
 # Downstream-substituted tokens (.format(**ctx) sites). NOT Phase-0
 # concerns; this list exists only so the typo guard knows to skip
-# them. Keep in sync with v6_build.py / linear_pipeline.py.
+# them. Keep in sync with linear_pipeline.py.
 DOWNSTREAM_TOKENS = frozenset({
     "LEVEL", "MODULE_NUM", "TOPIC_TITLE", "PHASE", "WORD_TARGET",
     "WORD_CEILING", "SUMMARY_HEADING", "IMMERSION_RULE",
@@ -520,8 +520,8 @@ caller — typically `Path(...).read_text()` — replaces with
   even though the typo guard runs first.
 - **Downstream-token registry is explicit, not inferred.** The
   generator can't statically know what `.format(**ctx)` keys
-  v6_build.py uses — they're hardcoded in `DOWNSTREAM_TOKENS` and
-  drift with v6_build.py changes. This is acceptable maintenance
+  linear_pipeline.py uses — they're hardcoded in `DOWNSTREAM_TOKENS` and
+  drift with linear_pipeline.py changes. This is acceptable maintenance
   overhead because the registry change is one-line per new token,
   caught by the typo guard if forgotten.
 


### PR DESCRIPTION
Update operational docs from retired v6_build.py to current v7_build.py and linear_pipeline.py.