### PR TITLE
docs(folk)+manifest: Stage-0 lock — 42-topic queue, schema, rubric, archetype spec + curriculum.yaml expansion

### DIFF
--- a/curriculum/l2-uk-en/curriculum.yaml
+++ b/curriculum/l2-uk-en/curriculum.yaml
@@ -1919,30 +1919,58 @@ levels:
   folk:
     type: track
     modules:
+      # Folk track expanded 27 -> 42 (broad folk CULTURE, C1+), de-imperialized.
+      # Build order + slug renames/folds per docs/folk-epic/phase-folk-queue.md +
+      # folk-ssot-migration.md (GPT cross-check bridge #1148). Plan-file + code (FOLK_DOMAIN_MAP,
+      # module_archetypes folk-experiential) migration tracked in folk-ssot-migration.md.
+      # A · Frame / worldview / magic
+      - narodna-kultura-yak-systema
+      - narodni-viruvannia-mifolohiia-demonolohiia
+      - zamovliannia-zaklynannia-prymovky
+      # B · Calendar ritual cycle
+      - kalendarna-obriadovist-zvychai
       - koliadky-shchedrivky
       - vesnianky-hayivky
-      - rusalni-pisni
-      - kupalski-pisni
-      - obzhynkovi-pisni
+      - kupalski-rusalni-pisni
+      - zhnyvarski-obzhynkovi-pisni
+      # C · Family rite
+      - rodynna-obriadovist-zvychai
       - vesilni-pisni
       - holosinnya
+      # D · Epic / kobzar (bylyny de-weighted 9->1)
+      - dumy-nevilnytski-lytsarski
+      - dumy-sotsialno-pobutovi
+      - kobzarstvo-lirnytstvo
+      - bylyny-kyivskoho-tsyklu
+      # E · Song (historical / lyric / social / resistance / literary-origin)
+      - istorychni-pisni
+      - striletski-povstanski-pisni
+      - rodynno-pobutovi-pisni
+      - kolomyiky
+      - suspilno-pobutovi-pisni
+      - narodni-balady
+      - pisni-literaturnoho-pokhodzhennia
+      # F · Prose / paremia / child
       - charivni-kazky
       - kazky-pro-tvaryn
       - sotsialno-pobutovi-kazky
       - narodni-lehendy
       - istorychni-perekazy
-      - bylyny-kyivskoho-tsyklu
-      - bohatyri-illiya-dobrynia
-      - zastavy-bohatyrski
-      - bylyny-sotsialni
-      - pokhodzhennia-dum
-      - dumy-nevilnytski
-      - dumy-lytsarski
-      - dumy-sotsialno-pobutovi
-      - kobzarstvo-fenomen
-      - narodni-balady
-      - chumatski-burlatski-pisni
+      - narodni-opovidannia-buvalshchyny-memoraty
       - prykazky-ta-pryslivia
       - zahadky
       - narodni-anekdoty
-      - rodynna-liryka-kolomyiky
+      - dytiachyi-folklor-kolyskovi
+      # G · Drama / music / dance
+      - vertep-narodna-drama
+      - narodni-muzychni-instrumenty
+      - narodni-tantsi
+      # H · Material / everyday culture
+      - pysankarstvo
+      - narodna-vyshyvka-rushnyk-strii
+      - narodni-remesla-ta-khudozhni-promysly
+      - narodne-zhytlo-sadyba-hospodarstvo
+      - narodna-kukhnia-obriadova-yizha
+      # I · Regional / high-culture synthesis
+      - rehionalni-etnokulturni-tradytsii
+      - narodna-kultura-ta-vysoka-kultura-mistky

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -97,15 +97,29 @@ types #20-31, all source/text analysis) on a fixed 4-tab shell (Урок·Сло
   families #50-54. Serves all 8 lit sub-tracks (genre diffs = content/register at plan level).
 - **Net: 2 page archetypes + 1 shared module — NOT 13 designs.** oes/ruth/hist/istorio/bio need NO new page.
 
+### ✅ STAGE-0 FOUNDATION LOCKED (2026-06-06, branch `claude/folk-stage0-lock`, PR pending)
+NEXT-ACTION item 1 is DONE — the 4 foundation docs now exist (mirror bio's Stage-0):
+- `docs/folk-epic/phase-folk-queue.md` — **42-topic** ordered, de-imperialized queue; every GPT #1148
+  refinement applied (bylyny 9→1, pokhodzhennia-dum fold, full rename/add set); pilot marked; block
+  balance table vs GPT targets.
+- `docs/folk-epic/folk-dossier-schema.md` — the 10-section quality contract + REQUIRED multimodal-hook
+  block (image chunk_ids / named recordings / ritual sequence / motif inventory).
+- `docs/folk-epic/folk-review-rubric.md` — corpus-hammer rubric; `verify_quote` every folk text;
+  cross-family (GPT↔Claude), no DeepSeek; OPEN-PR-no-self-merge.
+- `docs/folk-epic/folk-experiential-archetype-spec.md` — 4-tab shell + families #40–45 + 3 multimodal
+  blocks + myth-box; "more prose in Урок" feedback baked in (item 2 done).
+
 ### ▶ NEXT ACTIONS ON RESUME (folk, in order)
-1. **Lock the folk foundation** (this branch is Stage-0): apply the GPT refinements → final ~41-topic
-   ordered queue doc (`docs/folk-epic/phase-folk-queue.md`) + the dossier schema + a corpus-heavy review
-   rubric + the `folk-experiential` archetype spec (activity families #40-45 + the 2 multimodal blocks, on
-   the existing 4-tab shell) as a hand-off for GPT. Mirror bio's Stage-0.
-2. **More prose** in the folk-experiential Урок design (user feedback).
-3. **First dossier — pilot `kalendarna-obriadovist-zvychai`** (GPT + Claude both picked it; best shows folk
-   as a SYSTEM). Writer = GPT now / Claude after June 8; cross-family review = the other; corpus-hammer
-   (`verify_quote` every folk text). Then dossier → grounded wiki (compile.py is dossier-grounded since #2702).
+1. **Open the Stage-0 PR** (this branch; no self-merge) bundling the 4 docs + this handoff →
+   **TRACK-UPDATE needs=merge** to orchestrator. *(In flight as of this session — see IN-FLIGHT.)*
+2. **On Stage-0 merge → dispatch the pilot dossier** `kalendarna-obriadovist-zvychai` (GPT + Claude
+   both picked it; best shows folk as a SYSTEM). Writer = **GPT now** (`delegate.py dispatch --agent
+   codex --model gpt-5.5 --worktree --base main`, brief = schema + rubric + queue row) / Claude after
+   June 8; cross-family review = the other; corpus-hammer (`verify_quote` every folk text). Gate on
+   merge because `--worktree` builds from origin/main (unmerged specs won't reach the child). Then
+   dossier → grounded wiki (`compile.py --writer {gpt-5.5|claude}`, dossier-grounded since #2702).
+3. Then the build-order first-6: `narodna-kultura-yak-systema` → pilot → `narodni-viruvannia-…` →
+   `koliadky-shchedrivky` → `rodynna-obriadovist-zvychai` → `dumy-nevilnytski-lytsarski`.
 4. Optional: design the **lit-drama** variant (≈80% assembled from folk parts) when convenient.
 
 ### 📊 CORPUS FACTS (folk is well-sourced — verified)
@@ -116,8 +130,15 @@ on народні інструменти (бандура/трембіта/цим
 despite "no YT". `compile.py --writer {gemini,claude,gpt-5.5}` (NO agy arm — would need wiring); dossier
 grounding live (#2702). Folk discovery already exists (27 files, real rag_chunks); 0 folk dossiers; 0 folk modules.
 
-### 🗂 ARTIFACTS THIS SESSION
+### 🗂 ARTIFACTS
+**Prior session (merged via #2745):**
 - `docs/poc/poc-folk-lesson-design.html` (folk-experiential archetype POC)
 - `docs/poc/poc-lit-lesson-design.html` (all-round lit archetype POC)
 - GPT folk-taxonomy cross-check = bridge msg #1148 (`ab read 1148`)
-- This handoff. **PR: OPEN (no self-merge) — folk-foundation Stage-0.**
+
+**This session (branch `claude/folk-stage0-lock`, Stage-0 lock — PR pending, NO self-merge):**
+- `docs/folk-epic/phase-folk-queue.md` (42-topic locked queue)
+- `docs/folk-epic/folk-dossier-schema.md` (10-section contract + multimodal hooks)
+- `docs/folk-epic/folk-review-rubric.md` (corpus-hammer rubric)
+- `docs/folk-epic/folk-experiential-archetype-spec.md` (module archetype spec for GPT)
+- This handoff (refreshed). **PR carries all 5 + handoff; orchestrator promotes.**

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -108,19 +108,29 @@ NEXT-ACTION item 1 is DONE — the 4 foundation docs now exist (mirror bio's Sta
   cross-family (GPT↔Claude), no DeepSeek; OPEN-PR-no-self-merge.
 - `docs/folk-epic/folk-experiential-archetype-spec.md` — 4-tab shell + families #40–45 + 3 multimodal
   blocks + myth-box; "more prose in Урок" feedback baked in (item 2 done).
+- `docs/folk-epic/folk-ssot-migration.md` — **executable** old-27→new-42 slug map (carry/rename/fold-
+  archive/new) + per-file deltas. **`curriculum.yaml` folk block UPDATED to the 42-topic order in this
+  PR** (manifest lane, CI-safe). Plan-file migration + the 2 code surfaces (`compile.py
+  FOLK_DOMAIN_MAP`, `module_archetypes.py` folk-experiential) = GPT dispatch, gated on merge.
 
 ### ▶ NEXT ACTIONS ON RESUME (folk, in order)
 1. **Open the Stage-0 PR** (this branch; no self-merge) bundling the 4 docs + this handoff →
    **TRACK-UPDATE needs=merge** to orchestrator. *(In flight as of this session — see IN-FLIGHT.)*
-2. **On Stage-0 merge → dispatch the pilot dossier** `kalendarna-obriadovist-zvychai` (GPT + Claude
-   both picked it; best shows folk as a SYSTEM). Writer = **GPT now** (`delegate.py dispatch --agent
-   codex --model gpt-5.5 --worktree --base main`, brief = schema + rubric + queue row) / Claude after
-   June 8; cross-family review = the other; corpus-hammer (`verify_quote` every folk text). Gate on
-   merge because `--worktree` builds from origin/main (unmerged specs won't reach the child). Then
-   dossier → grounded wiki (`compile.py --writer {gpt-5.5|claude}`, dossier-grounded since #2702).
-3. Then the build-order first-6: `narodna-kultura-yak-systema` → pilot → `narodni-viruvannia-…` →
+2. **On Stage-0 merge → dispatch GPT the SSOT migration** (`folk-ssot-migration.md` is the brief):
+   `git mv` 5 renames + archive 6 folded plan files → `plans/folk/_archive/`; create new plan stubs
+   (C1+, schema-valid, `status: stub`); re-key `compile.py FOLK_DOMAIN_MAP` to 42; register
+   `folk-experiential` in `module_archetypes.py` + route `track=="folk"`; regenerate discovery. One
+   worktree PR (`--agent codex --model gpt-5.5 --worktree --base main`), NO auto-merge. **#M-10: archive,
+   never delete — folded files carry real rag_chunks.** Gated on Stage-0 merge so the worktree sees the
+   updated `curriculum.yaml`.
+3. **Then dispatch the pilot dossier** `kalendarna-obriadovist-zvychai` (GPT + Claude both picked it;
+   best shows folk as a SYSTEM). Writer = **GPT now** (brief = schema + rubric + queue row) / Claude
+   after June 8; cross-family review = the other; corpus-hammer (`verify_quote` every folk text). Then
+   dossier → grounded wiki (`compile.py --writer {gpt-5.5|claude}`; needs the migrated FOLK_DOMAIN_MAP
+   entry, hence after step 2).
+4. Then the build-order first-6: `narodna-kultura-yak-systema` → pilot → `narodni-viruvannia-…` →
    `koliadky-shchedrivky` → `rodynna-obriadovist-zvychai` → `dumy-nevilnytski-lytsarski`.
-4. Optional: design the **lit-drama** variant (≈80% assembled from folk parts) when convenient.
+5. Optional: design the **lit-drama** variant (≈80% assembled from folk parts) when convenient.
 
 ### 📊 CORPUS FACTS (folk is well-sourced — verified)
 collection_stats: textbooks 25,714 · literary_texts 137,688 · sum11 127,069 · grinchenko 67,275. Verified

--- a/docs/folk-epic/folk-dossier-schema.md
+++ b/docs/folk-epic/folk-dossier-schema.md
@@ -1,0 +1,62 @@
+# Folk Dossier Schema — the quality contract (Stage-0)
+
+> The structural contract for every folk dossier at `docs/research/folk/{slug}.md`. **Genre/
+> phenomenon-shaped**, NOT bio's person-arc — a folk dossier explains a *genre, rite, or material
+> tradition*, its poetics, its verbatim exemplars, and its anti-colonial carrying-role. The dossier
+> is the **sole knowledge layer** (no YT resources), so depth is everything: it must be rich enough
+> that the grounded wiki AND GPT's experiential module can both be assembled from it without inventing
+> a single fact. Register C1+.
+
+## The 10 sections (all required)
+
+1. **Визначення та класифікація** — what the genre/phenomenon is; its place in the folk-culture
+   system; how scholars classify it; boundary cases and sub-forms.
+2. **Походження та історичний контекст** — origins, periodization, how it changed across centuries;
+   honest about contested datings and reconstruction (esp. pre-Christian / mythological layers).
+3. **Поетика / форма / техніка** — verse form, formula, melody/performance technique, materials &
+   craft technique (for material culture), symbolic vocabulary.
+4. **Класичні зразки + ВЕРБАТИМ примірники** — canonical examples WITH verbatim primary texts.
+   **Every quoted text `verify_quote`-confirmed** (the folk analogue of the bio quote-integrity gate)
+   and attributed to a named edition/collector. Record the verify_quote score inline. If a text
+   cannot be corpus-confirmed verbatim, mark it **do-not-quote / paraphrase-only** — NEVER invent or
+   "smooth" a duma line or song lyric.
+5. **Побутування / виконавство / функція** — living practice: who performed/performs it, when, in
+   what ritual or social function; regional distribution of the practice.
+6. **Збирачі та дослідники** — the collectors and scholars (Лановик, Колесса, Грушевський,
+   Грінченко, Нудьга, etc.), corpus-cited. Where scholars disagree, name the disagreement.
+7. **Культуроносна / антиколоніальна роль** — the carrying-identity-under-oppression thesis made
+   concrete for THIS genre: how it preserved language/memory/identity under imperial pressure; what
+   was banned/appropriated/russified and how the tradition survived.
+8. **Місток до високої культури** — the bridge to opera / literature / art / academic music
+   (e.g. Щедрик → Леонтович → Carol of the Bells; folk → «Запорожець за Дунаєм»; → «Лісова пісня»;
+   → Бойчук). This is what lets the eventual module be experiential, not antiquarian.
+9. **Decolonization / NPOV + source-disagreement** — honest in every direction: no Russocentric
+   framing, no romantic-nationalist over-claim (Берегиня-as-ancient-goddess type errors), no
+   flattening of regional variation. Surface contested points and source disagreements; don't smooth.
+10. **Acceptance self-check** — the writer's own pass against `folk-review-rubric.md` hard gates,
+    with the deterministic tool evidence (verify_quote scores, check_russian_shadow result,
+    query_cefr_level) quoted raw (#M-4).
+
+## + Multimodal-hook capture (REQUIRED — feeds GPT's experiential module)
+The dossier must explicitly capture, in a dedicated block, the raw material the `folk-experiential`
+archetype consumes:
+- **Image `chunk_id`s** — from SigLIP `search_images` (pysanka motifs, rushnyk patterns, instruments,
+  vertep box, regional dress). List the `chunk_id`s so the module's symbolic-decode hotspots resolve.
+- **Named recording / song references** — performer + recording/edition names for the audio block
+  (the module lets the student *hear* the sung text; the dossier names what to play).
+- **Performance / ritual descriptions** — step-by-step ritual or performance sequence (feeds the
+  Ritual-Sequencing activity family #42).
+- **Motif / formula inventory** — recurring symbols, epithets, oral-formulaic phrases (feeds
+  Symbolic-Decode #41 and Motif/Formula #44).
+
+## Grounding rule
+Where a retrieved chunk (esp. Wikipedia-only) conflicts with a corpus primary source or named
+scholarly edition, **the corpus/edition wins**; Wikipedia-only extraordinary claims are flagged, not
+asserted. This mirrors the bio "grounding > breadth" gate.
+
+## Corpus tools the writer must hit (folk-specific)
+`verify_quote` (every text), `search_literary`, `search_grinchenko_1907`, `search_heritage`,
+`search_text` (textbooks/ULP), `search_images` (SigLIP — material culture), `check_russian_shadow`,
+`query_cefr_level`, `search_idioms` (paremiology), `search_esum`/`query_sum20` (etymology where
+relevant). Folk is well-sourced (textbooks 25,714 · literary_texts 137,688 · sum11 127,069 ·
+grinchenko 67,275) — a thin dossier is a writer failure, not a corpus gap.

--- a/docs/folk-epic/folk-experiential-archetype-spec.md
+++ b/docs/folk-epic/folk-experiential-archetype-spec.md
@@ -1,0 +1,66 @@
+# `folk-experiential` Module Archetype — Spec (Stage-0 → GPT build handoff)
+
+> The module-design contract for the FOLK track. Claude designs the page (this spec + the worked POC);
+> **GPT builds modules against it** (Claude builds no modules — boundary locked 2026-06-06). Realized
+> worked example: `docs/poc/poc-folk-lesson-design.html` (koliadky/Щедрик, corpus-sourced).
+> Resolver to wire: `scripts/pipeline/module_archetypes.py`; contract:
+> `docs/architecture/module-archetype-contract.md`.
+
+## Why a new archetype
+The existing `seminar-source-analysis` archetype (activity types #20–31, all source/text analysis on
+the 4-tab shell) fits bio/hist/istorio/oes/ruth/lit. It does NOT fit folk: folk culture is **aural,
+performative, symbolic, and material** — a sung text, a ritual sequence, a pysanka motif, a danced
+form. `folk-experiential` adds the missing modalities WITHOUT changing the shell.
+
+## Shell — UNCHANGED 4-tab (`Урок · Словник · Зошит · Ресурси`)
+Same 4-tab shell as every other module. `folk-experiential` only adds new **block types** inside the
+**Урок** tab and new **activity families** inside the **Зошит** tab. No new tab, no shell fork.
+
+## Three new multimodal blocks (Урок tab)
+1. **Audio block** (`audio-block`) — lets the student *hear* the sung/performed text (the dossier's
+   §"named recording references" resolve here). Pairs the audio with the verbatim, `verify_quote`-
+   confirmed text so the learner follows the words while hearing the performance.
+2. **Symbolic-decode block** (`symbolic-decode`) — an image (SigLIP `chunk_id` from the dossier) with
+   **clickable hotspots**; each hotspot decodes a motif/symbol (pysanka sign, rushnyk pattern, vertep
+   tier). Feeds directly from the dossier's motif inventory + image chunk_ids.
+3. **High-culture bridge block** (`high-culture bridge`) — the folk→opera/lit/art line made
+   interactive (Щедрик → Леонтович → *Carol of the Bells*; folk → «Запорожець за Дунаєм» / «Лісова
+   пісня»). This is what makes the module experiential rather than antiquarian — it answers "why does
+   this folk form still matter."
+- **Decolonization myth-box** (`myth-box`) — a recurring inline callout that corrects an imperial or
+  romantic-nationalist myth (e.g. bylyny-as-Russian-epic; Берегиня-as-ancient-goddess) and, where the
+  dossier supports it, ties folk→bio (e.g. Leontovych murdered by the Cheka, 1921).
+
+## Six folk activity families (Зошит tab) — #40–#45
+These extend the global activity-type registry. Exact labels from the realized POC:
+
+| # | family | what the learner does | dossier input it consumes |
+|---|--------|-----------------------|---------------------------|
+| #40 | **Aural Genre-ID** | hear a clip → identify the genre/cycle by its aural markers | named recordings + §3 poetics |
+| #41 | **Symbolic Decoding** | decode a motif/symbol from an image or text | motif inventory + image chunk_ids |
+| #42 | **Ritual Sequencing** | order the steps of a rite/performance correctly | §5 performance/ritual sequence |
+| #43 | **Variant Comparison** | compare regional/temporal variants of one text/form | regional variation notes (§5/§9) |
+| #44 | **Motif / Formula** | spot the oral-formulaic phrase / recurring epithet | motif/formula inventory (§3) |
+| #45 | **Performance** | produce/perform — recite, sing-along, annotate a reading | verbatim exemplars (§4) |
+
+## User feedback baked in (2026-06-06)
+**MORE PROSE in the Урок body.** Activities are the in-prose interactive layer, but the expository
+prose itself must be richer — a learner reading only the Урок prose should get a full, well-written
+account of the genre, not a thin scaffold around activities. The dossier's depth (10 sections) is the
+fuel; the module's Урок must spend it.
+
+## Acceptance checklist for a `folk-experiential` module (GPT self-checks before PR)
+- [ ] 4-tab shell intact (`Урок · Словник · Зошит · Ресурси`); no tab empty (m20 #M-11 lesson).
+- [ ] ≥1 of each multimodal block present where the dossier supports it (audio / symbolic-decode /
+      high-culture bridge); every audio text and exemplar is `verify_quote`-confirmed.
+- [ ] Зошит draws from families #40–#45 (not all inline; honor the INLINE-vs-WORKBOOK activity-count
+      config), not 10 inline same-type items.
+- [ ] Урок prose is rich (user feedback), corpus-grounded, C1+ register, `check_russian_shadow` clean.
+- [ ] ≥1 decolonization myth-box; framing passes `folk-review-rubric.md` gate 7.
+- [ ] Словник + Ресурси populated (Ресурси = dossier-derived references; **no YT**).
+
+## Related designs (not part of folk MVP)
+- **all-round lit** archetype — `docs/poc/poc-lit-lesson-design.html` (serves all 8 lit sub-tracks).
+- **Shared performative/multimodal module** — lit-drama + folk + bio cultural-figures (Леонтович/
+  Квітка-Цісик/Бойчук) reuse ~80% of these blocks. Build the lit-drama variant when convenient
+  (≈80% assembled from folk parts).

--- a/docs/folk-epic/folk-review-rubric.md
+++ b/docs/folk-epic/folk-review-rubric.md
@@ -1,0 +1,54 @@
+# Folk Dossier + Wiki Review Rubric (Stage-0)
+
+The review scorecard for every folk dossier and the grounded wiki compiled from it. A dossier/wiki
+ships only when it passes **all** gates. **Reviewer = cross-family to the writer** (GPT↔Claude).
+**NO DeepSeek for folk culture** (user 2026-06-06: lacks the intrinsic Ukrainian-culture knowledge to
+catch subtle framing errors — its corpus-tool use was fine, but framing is the risk for culture).
+The reviewer MUST hammer the corpus — judging on metrics/structure alone is how a bad artifact ships
+(the m20 lesson, MEMORY #M-11).
+
+## Hard gates (deterministic — must pass; quote raw tool output, #M-4)
+1. **Quote integrity** — every verbatim folk text (duma line, song lyric, замовляння, proverb) is
+   **`verify_quote`-confirmed** (record the score) OR attributed to a named edition and marked
+   do-not-quote/paraphrase-only. NEVER an invented or altered line. This is the folk analogue of the
+   bio quote gate and is non-negotiable: a "smoothed" Маруся Богуславка line fails the gate.
+2. **No Russianisms / surzhyk** — `check_russian_shadow` clean; Ukrainian register correct; no
+   Latin-in-Cyrillic homoglyphs (except legit URLs/acronyms).
+3. **CEFR / register fit** — `query_cefr_level` consistent with C1+; readable, pedagogically useful,
+   not a raw ethnography dump.
+4. **Citation / source resolution** — every scholarly attribution (Лановик, Колесса, Грушевський,
+   Грінченко…) resolves to a real corpus chunk or a real named edition; no ghost sources, no invented
+   collector names.
+5. **Schema completeness** — all 10 sections of `folk-dossier-schema.md` present AND the multimodal-
+   hook block populated (image `chunk_id`s, named recordings, ritual sequence, motif inventory). An
+   empty multimodal block = FIX (it starves GPT's experiential module — the m20 "empty Activities
+   tab" failure mode).
+6. **Grounding > breadth** — where a Wikipedia-only chunk conflicts with a corpus primary/named
+   edition, the corpus wins; Wikipedia-only extraordinary claims flagged, not asserted.
+
+## Quality gates (cross-family review — must pass)
+7. **Decolonized NPOV (folk-specific)** — honest in every direction:
+   - **No Russocentric framing / no appropriation laundering** — esp. bylyny: name the contested
+     East-Slavic/Kyivan-inheritance problem, don't inherit the imperial frame.
+   - **No romantic-nationalist over-claim** — do NOT present Перун/Велес/Мокоша/**Берегиня** as a
+     tidy reconstructed pagan pantheon; Берегиня especially is a modern reconstruction, flag it.
+   - **No flattening** — regional variation (Гуцул/Бойко/Лемко/Полісся…) surfaced, not pan-Ukrainian-
+     smoothed; source disagreements named.
+8. **Anti-colonial role is concrete, not slogan** — §7 of the dossier ties THIS genre to specific
+   suppression/appropriation/survival facts (e.g. kobzar repression), not a generic "folklore kept
+   us alive" line. §8 high-culture bridge is real and corpus-traceable.
+9. **Poetics actually explained** — §3 demonstrates the form/technique with the verbatim exemplars,
+   not just labels them; a C1+ learner could recognize the genre from the explanation.
+
+## Reviewer's required corpus calls (the "hammer the corpus" mandate)
+`verify_quote` on EVERY folk text in the dossier · `check_russian_shadow` on the prose ·
+`query_cefr_level` · plus targeted `search_literary` / `search_grinchenko_1907` / `search_heritage` /
+`search_text` to independently confirm at least the headline claims and one disputed point. The review
+report must quote these tool outputs raw — "I checked the quotes" without the verify_quote scores is a
+rejected review (#M-4).
+
+## Verdict
+`SHIP` / `FIX-BEFORE-MERGE` (with section/line-anchored fixes) / `BLOCK`. The driver verifies every
+fix deterministically (verify_quote / check_russian_shadow / git) before applying. **Folk merge
+policy: OPEN PR, do NOT self-merge** — user/orchestrator promotes (until a folk merge-grant is
+extended; the bio grant was bio-specific).

--- a/docs/folk-epic/folk-ssot-migration.md
+++ b/docs/folk-epic/folk-ssot-migration.md
@@ -1,0 +1,97 @@
+# Folk SSOT Migration — 27 → 42 (executable spec)
+
+> The locked queue (`phase-folk-queue.md`) is a *plan*; this doc makes it **executable against the
+> source-of-truth files** so the registry stops diverging from the design (the #M-11 trap). It is the
+> brief for the migration dispatch.
+>
+> **Done in the Stage-0 PR (Claude, manifest lane, CI-safe):** `curriculum.yaml` `folk:` block updated
+> to the 42-topic ordering below.
+> **Dispatched to GPT (code + module lane, separate worktree PR, gated on Stage-0 merge):** the
+> plan-file migration + the two code surfaces + discovery re-key.
+>
+> **#M-10 / #M-26:** folded/renamed plan files carry **real rag_chunks + rich plan content** — they are
+> ARCHIVED (moved to `plans/folk/_archive/`), **never deleted**. A fold MERGES the archived content
+> into the survivor's eventual dossier; it does not discard it.
+
+## Slug map (old 27 → new 42)
+
+### Carry-forward (slug unchanged — 14)
+`koliadky-shchedrivky` · `vesnianky-hayivky` · `vesilni-pisni` · `holosinnya` · `dumy-sotsialno-pobutovi`
+· `bylyny-kyivskoho-tsyklu` (now the SOLE bylyny topic) · `narodni-balady` · `charivni-kazky` ·
+`kazky-pro-tvaryn` · `sotsialno-pobutovi-kazky` · `narodni-lehendy` · `istorychni-perekazy` ·
+`prykazky-ta-pryslivia` · `zahadky` · `narodni-anekdoty`.
+*(Note: queue prose uses `holosinnia`; the existing slug is `holosinnya` — carry the EXISTING spelling
+to avoid orphaning `holosinnya.yaml` + its rag_chunks.)*
+
+### Rename (old → new — 5; `git mv` the plan file, re-key FOLK_DOMAIN_MAP + discovery)
+| old slug | new slug | why (GPT #1148) |
+|---|---|---|
+| `kupalski-pisni` | `kupalski-rusalni-pisni` | summer cycle; **fold** `rusalni-pisni` in |
+| `obzhynkovi-pisni` | `zhnyvarski-obzhynkovi-pisni` | harvest naming |
+| `kobzarstvo-fenomen` | `kobzarstvo-lirnytstvo` | guilds/ліра/псальми/repression; **fold** `pokhodzhennia-dum` in |
+| `chumatski-burlatski-pisni` | `suspilno-pobutovi-pisni` | too narrow → full social-song set |
+| `rodynna-liryka-kolomyiky` | `rodynno-pobutovi-pisni` | was mis-scoped; **split** `kolomyiky` out as own topic |
+
+### Fold → archive (8 plan files merged into survivors)
+| folded (archive) | into survivor | note |
+|---|---|---|
+| `rusalni-pisni` | `kupalski-rusalni-pisni` | summer cycle |
+| `pokhodzhennia-dum` | `kobzarstvo-lirnytstvo` | theory, not a genre |
+| `dumy-lytsarski` | `dumy-nevilnytski-lytsarski` | merge knightly+captivity dumy (rename `dumy-nevilnytski`→`dumy-nevilnytski-lytsarski`) |
+| `bohatyri-illiya-dobrynia` | `bylyny-kyivskoho-tsyklu` | **bylyny de-weight 9→1** |
+| `bylyny-sotsialni` | `bylyny-kyivskoho-tsyklu` | bylyny de-weight |
+| `zastavy-bohatyrski` | `bylyny-kyivskoho-tsyklu` | subcycle/motif, not a peer genre |
+
+### New topics (need plan stubs — 13)
+`narodna-kultura-yak-systema` · `narodni-viruvannia-mifolohiia-demonolohiia` ·
+`zamovliannia-zaklynannia-prymovky` · `kalendarna-obriadovist-zvychai` ★(pilot) ·
+`rodynna-obriadovist-zvychai` · `istorychni-pisni` · `striletski-povstanski-pisni` · `kolomyiky` ·
+`pisni-literaturnoho-pokhodzhennia` · `narodni-opovidannia-buvalshchyny-memoraty` ·
+`dytiachyi-folklor-kolyskovi` · `vertep-narodna-drama` · `narodni-muzychni-instrumenty` ·
+`narodni-tantsi` · `pysankarstvo` · `narodna-vyshyvka-rushnyk-strii` ·
+`narodni-remesla-ta-khudozhni-promysly` · `narodne-zhytlo-sadyba-hospodarstvo` ·
+`narodna-kukhnia-obriadova-yizha` · `rehionalni-etnokulturni-tradytsii` ·
+`narodna-kultura-ta-vysoka-kultura-mistky`.
+*(13 named "net-new" beyond the renames; total new plan stubs = 21 once the rename targets that have no
+prior file are counted. GPT generates stubs at C1+, schema-valid, marked `status: stub` until built.)*
+
+## Per-file deltas
+
+### 1. `curriculum/l2-uk-en/curriculum.yaml` `folk:` block — DONE in Stage-0 PR
+Replaced the 27-slug `modules:` list with the 42-topic build-ordered list (see `phase-folk-queue.md`).
+CI-safe: no test enforces module↔plan-file existence; `compile.py` (dossier→wiki) reads discovery +
+`FOLK_DOMAIN_MAP`, not this block.
+
+### 2. `plans/folk/*.yaml` — GPT
+`git mv` the 5 renames; `git mv` the 6 folded files into `plans/folk/_archive/`; create the new plan
+stubs (C1+, schema-valid). Preserve folded files' rag_chunks for the survivor's dossier.
+
+### 3. `scripts/wiki/compile.py` `FOLK_DOMAIN_MAP` — GPT (code)
+Re-key to the 42 slugs. **Proposed** domain grouping (GPT finalizes):
+`folk/overview` (01) · `folk/belief` (02–03) · `folk/ritual` (04–10 + holosinnya) ·
+`folk/genres` (dumy×2, bylyny) · `folk/historical` (istorychni-pisni, striletski-povstanski-pisni) ·
+`folk/lyric` (rodynno-pobutovi, kolomyiky, suspilno-pobutovi, narodni-balady, pisni-lit-pokhodzhennia)
+· `folk/prose` (kazky×3, lehendy, perekazy, opovidannia-buvalshchyny) ·
+`folk/short-forms` (prykazky, zahadky, anekdoty, dytiachyi-folklor) ·
+`folk/performance` (vertep, instrumenty, tantsi) ·
+`folk/material` (pysankarstvo, vyshyvka, remesla, zhytlo, kukhnia) ·
+`folk/synthesis` (rehionalni, vysoka-kultura-mistky).
+
+### 4. `scripts/pipeline/module_archetypes.py` — GPT (code)
+Folk currently lands in `SEMINAR_TRACKS` → `resolve_module_archetype` returns `seminar-source-analysis`.
+Register the new `folk-experiential` archetype (per `folk-experiential-archetype-spec.md`: 4-tab shell,
+activity families #40–45, 3 multimodal blocks, myth-box) and route `track == "folk"` to it. Keep
+`oes/ruth/hist/istorio/bio/lit` on `seminar-source-analysis`.
+
+### 5. `scripts/pipeline/config_tables.py` — note only
+L45 persona ("Professor of Ukrainian Folklore") + L61 `"folk": "full-rebuild-lit"` skill are fine for
+the broad-culture scope. No change required now; revisit only if folk needs a dedicated skill profile.
+
+### 6. discovery files — GPT
+Re-key renamed/folded discovery slugs; regenerate from the migrated plans (`compile.py` auto-generates
+discovery from plans when absent).
+
+## Sequence
+Stage-0 PR (curriculum.yaml + this spec + the 4 design docs) merges → **dispatch GPT** for #2–#4 + #6
+(one worktree PR) → that merges → pilot dossier `kalendarna-obriadovist-zvychai` can compile to wiki
+(its `FOLK_DOMAIN_MAP` entry now exists).

--- a/docs/folk-epic/phase-folk-queue.md
+++ b/docs/folk-epic/phase-folk-queue.md
@@ -43,7 +43,7 @@ the pilot *dossier* is the calendar-rite topic because it produces concrete verb
 | 08 | `zhnyvarski-obzhynkovi-pisni` | B · Calendar | Harvest cycle. **Renamed** from `obzhynkovi-pisni` (GPT). |
 | 09 | `rodynna-obriadovist-zvychai` | C · Family rite | **NEW (GPT)** — birth/christening, wedding, funeral, housewarming as a ritual *system*. |
 | 10 | `vesilni-pisni` | C · Family rite | Wedding songs (within the family-rite arc). |
-| 11 | `holosinnia` | C · Family rite | Laments (funeral). |
+| 11 | `holosinnya` | C · Family rite | Laments (funeral). Carry-forward; existing slug spelling kept. |
 | 12 | `dumy-nevilnytski-lytsarski` | D · Epic/kobzar | Captivity + knightly dumy. |
 | 13 | `dumy-sotsialno-pobutovi` | D · Epic/kobzar | Social dumy. |
 | 14 | `kobzarstvo-lirnytstvo` | D · Epic/kobzar | **Renamed** from `kobzarstvo-fenomen` (GPT): guilds, blind performers, ліра, псальми, repression, performance context. **Folds** `pokhodzhennia-dum` (theory/history, not a genre). |

--- a/docs/folk-epic/phase-folk-queue.md
+++ b/docs/folk-epic/phase-folk-queue.md
@@ -1,0 +1,124 @@
+# Folk Track — Locked Topic Queue (Stage-0 → GPT build handoff)
+
+> **Status:** Stage-0 foundation. This is the ordered, de-imperialized folk-culture queue that
+> synthesizes the 27 existing oral-genre discovery topics + 10 user-approved broad-scope additions +
+> GPT's full taxonomy cross-check (bridge **#1148**, `ab read 1148`). **Register = C1+.**
+> Claude's deliverable boundary = research → dossier → wiki (NO modules; GPT builds modules).
+> **GPT may flex the exact count** (~42) at lock time — the load-bearing parts are the *build order*,
+> the *de-weighting of bylyny*, and the *renames/folds* below, all of which are applied here.
+
+## How this list was derived
+- **Start:** 27 existing oral-genre topics (real `rag_chunks` discovery files already on disk) + 10
+  broad-scope additions (user-approved incl. #10 `kalendarna-obriadovist-zvychai`).
+- **Then applied every GPT refinement from #1148:** de-weight bylyny 9→1, fold `pokhodzhennia-dum`
+  into kobzarstvo, add social song / magic formulas / family rites / non-fairy prose / everyday
+  material culture / literary-origin & resistance song, plus the rename set.
+- **Balance target (GPT #1148 §3):** epic/kobzar 4–5 · calendar/family ritual 7–8 · lyric/song 6–7 ·
+  prose/paremia/child ~8 · music/dance/drama 4 · material/everyday 5–6 · regional/high synthesis 2–3.
+- **Build order (GPT #1148 §4):** worldview/ritual calendar → belief/magic & family rites → song
+  genres → dumy/kobzarstvo/historical song → prose/paremia/child → drama/music/dance → material
+  culture → high-culture bridges. **Do NOT open with bylyny** (most RU-appropriated; politically
+  fragile as an opening frame).
+
+## ★ Pilot
+**`kalendarna-obriadovist-zvychai`** (#04). GPT and Claude independently converged on it: it best
+exposes folk culture as a *system* — time, ritual action, song, food, masks, belief, regional
+variation, and later literary/music reuse. (GPT's blue-sky first pick was a brand-new
+`narodna-kultura-yak-systema` systems-overview topic, which is #01 below and frames the whole track;
+the pilot *dossier* is the calendar-rite topic because it produces concrete verbatim corpus.)
+
+---
+
+## The queue (ordered; build top → bottom)
+
+| # | slug | block | notes / GPT refinement applied |
+|---|------|-------|--------------------------------|
+| 01 | `narodna-kultura-yak-systema` | A · Frame | **NEW (GPT)** — systems overview; syncretism, performance, ritual, genre, region, oral↔written boundary. The opening frame, not a genre. |
+| 02 | `narodni-viruvannia-mifolohiia-demonolohiia` | A · Worldview | мавки/русалки/домовик/упир/відьма + дохристиянські вірування. **#M-4 caution:** do NOT present Перун/Велес/Мокоша/**Берегиня** as a tidy pagan pantheon (Берегиня = modern romantic reconstruction). |
+| 03 | `zamovliannia-zaklynannia-prymovky` | A · Magic | **NEW (GPT)** — замовляння/заклинання/примовки/благословення/прокльони (Лановик «Магія і міфологія»). Folds `narodna-medytsyna-znakharstvo`. |
+| 04 | `kalendarna-obriadovist-zvychai` ★ | B · Calendar | ★ **PILOT.** Calendar-rite system (user: "super folkish"). |
+| 05 | `koliadky-shchedrivky` | B · Calendar | Winter cycle. (Щедрик → high-culture bridge to Леонтович, see #43.) |
+| 06 | `vesnianky-hayivky` | B · Calendar | Spring cycle. |
+| 07 | `kupalski-rusalni-pisni` | B · Calendar | Summer cycle. **Fold** `rusalni-pisni` into the Kupala/summer block. |
+| 08 | `zhnyvarski-obzhynkovi-pisni` | B · Calendar | Harvest cycle. **Renamed** from `obzhynkovi-pisni` (GPT). |
+| 09 | `rodynna-obriadovist-zvychai` | C · Family rite | **NEW (GPT)** — birth/christening, wedding, funeral, housewarming as a ritual *system*. |
+| 10 | `vesilni-pisni` | C · Family rite | Wedding songs (within the family-rite arc). |
+| 11 | `holosinnia` | C · Family rite | Laments (funeral). |
+| 12 | `dumy-nevilnytski-lytsarski` | D · Epic/kobzar | Captivity + knightly dumy. |
+| 13 | `dumy-sotsialno-pobutovi` | D · Epic/kobzar | Social dumy. |
+| 14 | `kobzarstvo-lirnytstvo` | D · Epic/kobzar | **Renamed** from `kobzarstvo-fenomen` (GPT): guilds, blind performers, ліра, псальми, repression, performance context. **Folds** `pokhodzhennia-dum` (theory/history, not a genre). |
+| 15 | `bylyny-kyivskoho-tsyklu` | D · Epic | **DE-WEIGHTED 9→1 (GPT).** Folds `bohatyri-illiya-dobrynia`, `bylyny-sotsialni`, `zastavy-bohatyrski`. Explicitly de-imperialize the contested East-Slavic/Kyivan inheritance framing. |
+| 16 | `istorychni-pisni` | E · Song | **NEW (GPT)** — historical SONGS, distinct from dumy and from prose perekazy (Колесса). |
+| 17 | `striletski-povstanski-pisni` | E · Song | **IN (user: "fofc they are in, fuck the occupiers").** 20th-c. resistance song tradition. |
+| 18 | `rodynno-pobutovi-pisni` | E · Song | **Renamed/re-scoped** from `rodynna-liryka-kolomyiky` (GPT: was mis-scoped). Family/everyday lyric. |
+| 19 | `kolomyiky` | E · Song | **Split out (GPT)** — kolomyika is song/dance/short-form performance, not simply family lyric. |
+| 20 | `suspilno-pobutovi-pisni` | E · Song | **Renamed** from `chumatski-burlatski-pisni` (GPT, too narrow). Adds козацькі/кріпацькі/рекрутські-солдатські/наймитські/заробітчанські-еміграційні/чумацькі/бурлацькі. |
+| 21 | `narodni-balady` | E · Song | Folk ballads. |
+| 22 | `pisni-literaturnoho-pokhodzhennia` | E · Song | **NEW (GPT)** — романси / духовні псальми; the high-culture border-zone genre (Лановик). |
+| 23 | `charivni-kazky` | F · Prose | Magic tales. |
+| 24 | `kazky-pro-tvaryn` | F · Prose | Animal tales. |
+| 25 | `sotsialno-pobutovi-kazky` | F · Prose | Social tales. **Folds** небилиці/притчі/байки/кумулятивні казки (GPT — minor tale forms). |
+| 26 | `narodni-lehendy` | F · Prose | Legends. |
+| 27 | `istorychni-perekazy` | F · Prose | Historical perekazy. |
+| 28 | `narodni-opovidannia-buvalshchyny-memoraty` | F · Prose | **Renamed** non-fairy prose block (GPT) — canonical beside legends/perekazy in Лановик. |
+| 29 | `prykazky-ta-pryslivia` | F · Paremia | Proverbs & sayings. |
+| 30 | `zahadky` | F · Paremia | Riddles. |
+| 31 | `narodni-anekdoty` | F · Paremia | Folk anecdotes. |
+| 32 | `dytiachyi-folklor-kolyskovi` | F · Child | Child folklore + lullabies. **Folds** скоромовки/лічилки/дражнилки (GPT — make explicit, no own topic). |
+| 33 | `vertep-narodna-drama` | G · Drama | **NEW** — frame шкільна драма as the learned/baroque *interface*, not simply folk drama (GPT). |
+| 34 | `narodni-muzychni-instrumenty` | G · Music | **NEW** — бандура/кобза/трембіта/цимбали. **Corpus JACKPOT** (full ULP lesson + SigLIP images). |
+| 35 | `narodni-tantsi` | G · Dance | **NEW** — гопак/метелиця/коломийка-as-dance; троїсті музики performance context. |
+| 36 | `pysankarstvo` | H · Material | **NEW** — Easter-egg art (SigLIP images, grades 2–6 corpus). |
+| 37 | `narodna-vyshyvka-rushnyk-strii` | H · Material | **Renamed** (GPT) from `narodna-vyshyvka-stryi` — include **рушник** explicitly + стрій. |
+| 38 | `narodni-remesla-ta-khudozhni-promysly` | H · Material | **Renamed** (GPT) from `narodni-promysly` — include ремесла, not only named art brands. |
+| 39 | `narodne-zhytlo-sadyba-hospodarstvo` | H · Material | **NEW (GPT)** — major material-culture gap: dwelling/homestead/husbandry. Own C1 topic since scope is true folk *culture*. |
+| 40 | `narodna-kukhnia-obriadova-yizha` | H · Material | **NEW** — борщ/кутя/коровай/паска/поминальна їжа. UNESCO + RU-flashpoint (user: "super folkish"). |
+| 41 | `rehionalni-etnokulturni-tradytsii` | I · Synthesis | **NEW (GPT)** — Гуцул/Бойко/Лемко/Полісся/Поділля/Слобожанщина/степ. **Anti-flattening** synthesis (recurring frame). |
+| 42 | `narodna-kultura-ta-vysoka-kultura-mistky` | I · Synthesis | **NEW** — folk → opera/lit/art bridges (Щедрик→Леонтович→Carol of the Bells; «Запорожець за Дунаєм»; Бойчук; «Лісова пісня»). The carrying-identity-under-oppression thesis made concrete. |
+
+**Count = 42 topics**, balanced per GPT #1148 §3:
+
+| block | topics | GPT target | ok? |
+|---|---|---|---|
+| A · Frame/worldview/magic | 01–03 (3) | — (opener + belief) | ✓ |
+| B · Calendar cycle | 04–08 (5) | (calendar+family 7–8) | ✓ |
+| C · Family rite | 09–11 (3) | ↑ combined w/ B = 8 | ✓ |
+| D · Epic/kobzar | 12–15 (4) | 4–5 | ✓ |
+| E · Song (lyric/social/historical/resistance/lit-origin) | 16–22 (7) | 6–7 | ✓ |
+| F · Prose/paremia/child | 23–32 (10) | ~8 | slightly over — GPT may fold 1–2 |
+| G · Drama/music/dance | 33–35 (3) | 4 | GPT may add troїсті-музики as 4th |
+| H · Material/everyday | 36–40 (5) | 5–6 | ✓ |
+| I · Regional/high synthesis | 41–42 (2) | 2–3 | ✓ |
+
+## What was DE-WEIGHTED / FOLDED / RENAMED (audit trail for GPT)
+- **Bylyny 9 → 1.** Folded `bohatyri-illiya-dobrynia`, `bylyny-sotsialni`, `zastavy-bohatyrski`
+  (a subcycle/motif, not a peer genre) into `bylyny-kyivskoho-tsyklu`. De-imperialized framing.
+- **`pokhodzhennia-dum`** (theory, not genre) → folded into `kobzarstvo-lirnytstvo`.
+- **Renames:** `kobzarstvo-fenomen`→`kobzarstvo-lirnytstvo`; `chumatski-burlatski-pisni`→
+  `suspilno-pobutovi-pisni`; `obzhynkovi-pisni`→`zhnyvarski-obzhynkovi-pisni`;
+  `rodynna-liryka-kolomyiky`→`rodynno-pobutovi-pisni` (+ split `kolomyiky`);
+  `narodna-vyshyvka-stryi`→`narodna-vyshyvka-rushnyk-strii`;
+  `narodni-promysly`→`narodni-remesla-ta-khudozhni-promysly`.
+- **New topics added (GPT-justified, Лановик/Колесса/Грушевський-grounded):**
+  `narodna-kultura-yak-systema`, `zamovliannia-zaklynannia-prymovky`, `rodynna-obriadovist-zvychai`,
+  `istorychni-pisni`, `striletski-povstanski-pisni`, `pisni-literaturnoho-pokhodzhennia`,
+  `narodni-opovidannia-buvalshchyny-memoraty`, `narodne-zhytlo-sadyba-hospodarstvo`,
+  `narodna-kukhnia-obriadova-yizha`, `rehionalni-etnokulturni-tradytsii`,
+  `narodna-kultura-ta-vysoka-kultura-mistky`.
+- **Folded (no own topic):** rusalni→kupalski; небилиці/притчі/байки/кумулятивні→sotsialno-pobutovi-kazky;
+  скоромовки/лічилки/дражнилки→dytiachyi-folklor; народна медицина/знахарство→zamovliannia.
+
+## Per-topic deliverable contract
+Each topic ships: **dossier** (`docs/research/folk/{slug}.md`, per `folk-dossier-schema.md`) →
+cross-family review (`folk-review-rubric.md`, corpus-hammered) → **grounded wiki**
+(`compile.py --writer {gpt-5.5|claude} --dossier docs/research/folk/{slug}.md`; dossier-grounding
+live since #2702). **No YT resources** — the dossier is the sole knowledge layer, so dossier depth
+is everything. Modules are GPT's to build against the `folk-experiential` archetype
+(`folk-experiential-archetype-spec.md`).
+
+## Build order for GPT (first 6)
+`narodna-kultura-yak-systema` → `kalendarna-obriadovist-zvychai` ★(pilot) →
+`narodni-viruvannia-mifolohiia-demonolohiia` → `koliadky-shchedrivky` →
+`rodynna-obriadovist-zvychai` → `dumy-nevilnytski-lytsarski`.
+Writer = **GPT now / Claude after June 8** (Claude content-writing benched until the June 8 reset).
+Cross-family review = the other model (GPT↔Claude; **no DeepSeek for culture**).


### PR DESCRIPTION
## Folk track — Stage-0 foundation lock + SSOT expansion

Driver-track deliverable (folk). Locks the broad-folk-culture foundation (C1+) and **updates the source of truth** so the registry stops diverging from the design. Synthesizes the 27 existing oral-genre discovery topics + 10 user-approved additions + GPT's full taxonomy cross-check (bridge #1148). **Design/manifest only** — no Ukrainian-content writing (Claude content-writing benched until June 8 reset).

### Foundation docs (`docs/folk-epic/`)
- **`phase-folk-queue.md`** — 42-topic ordered, de-imperialized queue. bylyny **9→1**, `pokhodzhennia-dum` folded, full rename/add set, block-balance vs GPT targets, pilot marked (`kalendarna-obriadovist-zvychai`).
- **`folk-dossier-schema.md`** — 10-section quality contract + REQUIRED multimodal-hook block (image `chunk_id`s / recordings / ritual sequence / motifs).
- **`folk-review-rubric.md`** — corpus-hammer rubric: `verify_quote` every text, cross-family (GPT↔Claude, **no DeepSeek for culture**), decolonized-NPOV gates.
- **`folk-experiential-archetype-spec.md`** — 4-tab shell + activity families **#40–45** + 3 multimodal blocks + myth-box; "more prose in Урок" baked in.

### SSOT expansion (the registry update)
- **`curriculum.yaml` folk block: 27 → 42** build-ordered slugs (renames/folds/additions). YAML validated — 42 modules, no dupes. CI-safe (no test enforces module↔plan-file existence; `compile.py` reads discovery + `FOLK_DOMAIN_MAP`, not this block).
- **`folk-ssot-migration.md`** — executable old-27→new-42 slug map (carry 14 / rename 5 / fold-archive 6 / new 21) + per-file deltas.

### What this PR does NOT do (gated, dispatched to GPT on merge)
The plan-file migration (`git mv` renames, **archive** 6 folded files — never delete, #M-10, they carry real rag_chunks — + new plan stubs) and the **two code surfaces** (`compile.py FOLK_DOMAIN_MAP`, `module_archetypes.py` register/route `folk-experiential`) are GPT's module/code lane → a separate worktree PR gated on this merge. Spec'd in `folk-ssot-migration.md`.

### Boundaries
- **Folk merge policy: OPEN PR, do NOT self-merge** — orchestrator/user promotes (bio grant was bio-specific).
- Touches the shared `curriculum.yaml` (folk block only) — flagging for orchestrator merge-ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)