### PR TITLE
refactor(build): extract phase constants from v6_build (#2747 step 1)

### DIFF
--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -696,7 +696,7 @@ async def orient(fresh: bool = False):
 async def get_config():
     # Import pipeline phase config — single source of truth
     try:
-        from scripts.build.v6_build import PHASE_LABELS, PHASES
+        from scripts.build.phase_constants import PHASE_LABELS, PHASES
         pipeline_info = {"phases": PHASES, "phase_labels": PHASE_LABELS}
     except ImportError:
         pipeline_info = {}

--- a/scripts/api/state_build.py
+++ b/scripts/api/state_build.py
@@ -27,7 +27,7 @@ from .state_helpers import (
 )
 
 try:
-    from scripts.build.v6_build import PHASES as V6_PHASE_ORDER
+    from scripts.build.phase_constants import PHASES as V6_PHASE_ORDER
 except ImportError:
     V6_PHASE_ORDER = [
         "check", "research", "skeleton", "pre-verify", "write",

--- a/scripts/api/state_coverage.py
+++ b/scripts/api/state_coverage.py
@@ -35,8 +35,8 @@ from .review_parsing import count_review_issues, extract_plan_verdict, extract_r
 
 # Import canonical phase list from pipeline
 try:
-    from scripts.build.v6_build import PHASE_LABELS as V6_PHASE_LABELS
-    from scripts.build.v6_build import PHASES as V6_PHASES
+    from scripts.build.phase_constants import PHASE_LABELS as V6_PHASE_LABELS
+    from scripts.build.phase_constants import PHASES as V6_PHASES
 except ImportError:
     V6_PHASES = [
         "check", "research", "skeleton", "pre-verify", "write",

--- a/scripts/api/state_helpers.py
+++ b/scripts/api/state_helpers.py
@@ -47,8 +47,8 @@ _content_file_index_cache: dict[Path, tuple[float, dict[str, Path]]] = {}
 # than an empty list — an empty phase list silently breaks coverage
 # endpoints.
 try:
-    from build.v6_build import PHASE_LABELS as _V6_PHASE_LABELS
-    from build.v6_build import PHASES as _V6_PHASES
+    from build.phase_constants import PHASE_LABELS as _V6_PHASE_LABELS
+    from build.phase_constants import PHASES as _V6_PHASES
 except ImportError:
     _V6_PHASES = [
         "check", "research", "skeleton", "pre-verify", "write",

--- a/scripts/api/state_issues.py
+++ b/scripts/api/state_issues.py
@@ -25,7 +25,7 @@ from .state_helpers import (
 )
 
 try:
-    from scripts.build.v6_build import PHASES as V6_PHASES
+    from scripts.build.phase_constants import PHASES as V6_PHASES
 except ImportError:
     V6_PHASES = [
         "check", "research", "skeleton", "pre-verify", "write",

--- a/scripts/build/phase_constants.py
+++ b/scripts/build/phase_constants.py
@@ -1,0 +1,49 @@
+"""Canonical V6 pipeline phase order + human-friendly labels.
+
+Extracted from ``scripts/build/v6_build.py`` (#2747 / #1863) so that
+out-of-process consumers — chiefly the Monitor API's ``state_*`` modules —
+can read the phase list and labels WITHOUT importing the 12K-line, OBSOLETE
+``v6_build`` build entrypoint. ``v6_build`` re-imports these names for its own
+internal use and for back-compat with its test suite, so the data has exactly
+one source of truth here.
+
+Pure data only — this module must never import build/runtime code (keeping it
+dependency-free is what lets the API import it cheaply).
+"""
+
+# All phases in pipeline order (used by --resume and by API state reconciliation).
+# ``PHASES`` is the stable public alias; ``ALL_PHASES`` is the underlying list.
+# They are the same object on purpose — keep them in sync (free, identical list).
+ALL_PHASES: list[str] = [
+    "check", "research", "skeleton", "pre-verify", "write", "honesty-annotate",
+    "exercises", "activities", "repair", "activity-pre-validate", "verify-exercises", "annotate",
+    "vocab", "enrich", "verify", "review", "review-style", "stress", "publish", "audit",
+]
+PHASES = ALL_PHASES
+
+# Human-friendly labels for the v6 phases. Keys match ``PHASES`` exactly; any
+# phase without an explicit label falls back to its kebab-case id via
+# ``PHASE_LABELS.get(name, name)``.
+PHASE_LABELS: dict[str, str] = {
+    "check": "Plan check",
+    "research": "Research",
+    "skeleton": "Skeleton",
+    "pre-verify": "Pre-verify",
+    "write": "Write content",
+    "honesty-annotate": "Honesty annotate",
+    "exercises": "Exercises",
+    "activities": "Activities",
+    "repair": "Repair",
+    "activity-pre-validate": "Activity pre-validation",
+    "verify-exercises": "Verify exercises",
+    "annotate": "Annotate",
+    "vocab": "Vocabulary",
+    "vocab-check": "Vocabulary coverage check",
+    "enrich": "Enrich",
+    "verify": "Verify content",
+    "review": "Review",
+    "review-style": "Style review",
+    "stress": "Stress marks",
+    "publish": "Publish MDX",
+    "audit": "Audit",
+}

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -1359,21 +1359,14 @@ def _normalize_v6_phase_status(result: object, *, phase: str) -> V6_PHASE_STATUS
     raise V6StateError(f"Invalid result for phase {phase}: {result!r}")
 
 
-# All phases in pipeline order (used by --resume).
-#
-# Also exported as ``PHASES`` for out-of-process consumers that need the
-# canonical v6 phase list — specifically the monitor API's state_helpers
-# module, which used to import from the retired pipeline_v5 module. Do
-# NOT delete either alias — ``_ALL_PHASES`` is referenced locally by the
-# many resume/state helpers throughout this file, while ``PHASES`` is the
-# stable public name. They must stay in sync (which is free — they're
-# the same list object).
-_ALL_PHASES = [
-    "check", "research", "skeleton", "pre-verify", "write", "honesty-annotate",
-    "exercises", "activities", "repair", "activity-pre-validate", "verify-exercises", "annotate",
-    "vocab", "enrich", "verify", "review", "review-style", "stress", "publish", "audit",
-]
-PHASES = _ALL_PHASES
+# Phase order + labels now live in ``scripts/build/phase_constants.py`` so the
+# Monitor API (state_* modules) can read them WITHOUT importing this 12K-line,
+# OBSOLETE build entrypoint (#2747 / #1863). Re-imported here for this file's
+# internal resume/state helpers and for back-compat with its test suite.
+# ``_ALL_PHASES`` is the internal alias; ``PHASES``/``PHASE_LABELS`` are public.
+from build.phase_constants import ALL_PHASES as _ALL_PHASES
+from build.phase_constants import PHASE_LABELS, PHASES
+
 _PHASE_SATISFIED_STATUSES = {"complete", "skipped"}
 _PLAN_HASH_STALE_PHASES = tuple(phase for phase in PLAN_HASH_PHASES if phase in {
     "skeleton",
@@ -1396,33 +1389,7 @@ _PLAN_HASH_ABORT_MESSAGE = (
     "Plan changed since last write — re-run from skeleton to rebuild with updated plan"
 )
 
-# Human-friendly labels for the v6 phases. Exposed alongside ``PHASES``
-# for API consumers that want to render a phase name in a UI. Keys match
-# ``PHASES`` exactly; any phase without an explicit label falls back to
-# its kebab-case id via ``PHASE_LABELS.get(name, name)``.
-PHASE_LABELS: dict[str, str] = {
-    "check": "Plan check",
-    "research": "Research",
-    "skeleton": "Skeleton",
-    "pre-verify": "Pre-verify",
-    "write": "Write content",
-    "honesty-annotate": "Honesty annotate",
-    "exercises": "Exercises",
-    "activities": "Activities",
-    "repair": "Repair",
-    "activity-pre-validate": "Activity pre-validation",
-    "verify-exercises": "Verify exercises",
-    "annotate": "Annotate",
-    "vocab": "Vocabulary",
-    "vocab-check": "Vocabulary coverage check",
-    "enrich": "Enrich",
-    "verify": "Verify content",
-    "review": "Review",
-    "review-style": "Style review",
-    "stress": "Stress marks",
-    "publish": "Publish MDX",
-    "audit": "Audit",
-}
+# (PHASE_LABELS is imported above from build.phase_constants.)
 
 
 def _phase_names_with_status(

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -70,7 +70,7 @@ class TestConfigEndpoint:
         assert "pipeline" in data
 
     def test_uses_v6_pipeline_constants(self):
-        from scripts.build.v6_build import PHASE_LABELS, PHASES
+        from scripts.build.phase_constants import PHASE_LABELS, PHASES
 
         data = client.get("/api/config").json()
         assert data["pipeline"]["phases"] == PHASES

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -604,7 +604,7 @@ class TestComputePipelineTrack:
 
     def test_v6_phase_order_and_labels(self):
         from scripts.api.state_coverage import compute_pipeline_track
-        from scripts.build.v6_build import PHASE_LABELS, PHASES
+        from scripts.build.phase_constants import PHASE_LABELS, PHASES
 
         level_cfg = {"id": "a1", "path": "l2-uk-en/a1"}
         plan_slugs = [(1, "test-slug")]


### PR DESCRIPTION
## What
First concrete step on **#2747 (A)**. The Monitor API (`state_build`/`state_helpers`/`state_issues`/`state_coverage`/`main`) imported `PHASES`/`PHASE_LABELS` from `scripts/build/v6_build.py` — pulling the **12,299-line OBSOLETE build entrypoint** into the API process just to read a phase list. That coupling is a big part of what makes `v6_build` un-removable.

This moves the two pure-data constants to a new dependency-free module `scripts/build/phase_constants.py`. `v6_build` re-imports them, so its internal resume/state helpers and its **entire test suite are unaffected** — object identity is preserved (`PHASES is v6_build.PHASES is phase_constants.PHASES`). The 5 live API modules + 2 API tests now import from the new module.

## Why this slice
The A migration is large (v6_build is a living 12K-line module with ~15 test files depending on internals + a research-preseed coupling). This is the **lowest-risk, highest-value first cut**: an architecturally-wrong dependency (a *monitoring* API importing a *build* module) is removed, with zero behavior change.

## Remaining for #2747 (kept open)
- Extract `_strip_prompt_control_tags` / `_format_prompt_literal_block` (imported by the V7 `plan_patch` phase) + `_post_process_content` (post-processor migration).
- Migrate the research-preseed pipeline off `build_module_v5.py`.
- Only then can `v6_build`/v5 be removed.

## Verification
- `ruff` clean; import-identity smoke; **343 tests pass** across `tests/test_api_*`, `tests/api/`, `test_v6_build_events`, `test_manifest_api`, `test_orient_api`, `test_api_state`.
- Scope: exactly 9 files (+67/−51), no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)