### PR TITLE
feat(hooks): block `git branch -D/-M/-f` in main-worktree guard

### DIFF
--- a/claude_extensions/hooks/guard-branch-switch-in-main.py
+++ b/claude_extensions/hooks/guard-branch-switch-in-main.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""PreToolUse guard — block branch switches in the MAIN worktree.
+"""PreToolUse guard — block branch switches / force-deletes in the MAIN worktree.
 
 Reads the Claude Code hook payload on stdin (JSON with `tool_name` +
 `tool_input.command`) and exits with code 2 if the command would switch
-branches in the main worktree. Exit 0 in all other cases.
+branches or force-delete/force-rename a branch in the main worktree.
+Exit 0 in all other cases.
 
 Why Python and not bash? Distinguishing a literal `git checkout -b ...`
 INVOCATION from the SAME STRING appearing inside a quoted
@@ -21,13 +22,16 @@ Blocked in the MAIN worktree:
   - git switch -c <name>
   - git switch <non-main-branch>
   - git checkout <non-main-branch>          (when target is a branch, not a path)
+  - git branch -D / -M / -f <name>          (force-delete / force-rename a branch)
 
 Allowed in the MAIN worktree:
   - git checkout main / master / HEAD / HEAD~N
   - git checkout -- <path>                  (file-level discard / restore)
+  - git branch -d / -m <name>               (safe delete-if-merged / rename)
+  - git branch <name>                       (create; does not switch)
   - git status / git log / git worktree add / ...
   - non-git commands
-  - git commit -m "...body mentioning git checkout -b..."
+  - git commit -m "...body mentioning git checkout -b... / git branch -D..."
 """
 from __future__ import annotations
 
@@ -117,6 +121,31 @@ def _segments(command: str) -> list[list[str]]:
     return segments
 
 
+def _branch_force_reason(args: list[str]) -> str | None:
+    """Reason string if a `git branch` invocation force-deletes/force-renames.
+
+    Blocks only the irreversible variants in the main worktree:
+      - `git branch -D <name>`        (force delete, == --delete --force)
+      - `git branch -M <old> <new>`   (force rename/move)
+      - `git branch -f <name> <ref>`  / `--force` (force-move a ref)
+      - any combined short cluster carrying D/M/f (e.g. `-Df`)
+
+    Intentionally ALLOWED (non-destructive): `-d` (delete-if-merged),
+    `-m` (rename), plain `git branch` (list), `git branch <name>` (create).
+    Uppercase D/M and lowercase `f` are the force indicators; their
+    lowercase counterparts `d`/`m` are the safe ops, so a simple
+    character-membership test discriminates correctly.
+    """
+    for a in args:
+        if a == "--force":
+            return "git branch --force rewrites/force-deletes a branch ref in the main worktree"
+        # Single-dash short flag cluster (e.g. -D, -M, -f, -Df). Long flags
+        # (`--`) other than --force are not force ops and fall through.
+        if len(a) >= 2 and a[0] == "-" and a[1] != "-" and any(c in a[1:] for c in ("D", "M", "f")):
+            return f"git branch {a} force-deletes/force-renames a branch in the main worktree"
+    return None
+
+
 def _segment_is_dangerous(seg: list[str]) -> str | None:
     """Return a human-readable reason string if seg is a dangerous git op,
     else None."""
@@ -140,12 +169,19 @@ def _segment_is_dangerous(seg: list[str]) -> str | None:
     if i >= len(seg):
         return None
     verb = seg[i]
+    args = seg[i + 1:]
+
+    # `git branch -D/-M/-f` force-deletes or force-renames a branch ref —
+    # destructive and irreversible in the MAIN worktree. Safe variants
+    # (`-d` delete-if-merged, `-m` rename, plain list/create) are allowed.
+    if verb == "branch":
+        return _branch_force_reason(args)
+
     if verb not in SWITCH_VERBS:
         return None
 
     # Now we're on `git ... <checkout|switch> <args...>`. Decide if this
     # would switch the branch state of the current worktree.
-    args = seg[i + 1:]
 
     # File-level checkout: `git checkout -- <path>` or `git checkout
     # <treeish> -- <path>`. The presence of `--` means path-restoration,

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -1,0 +1,152 @@
+"""Unit tests for the main-worktree branch guard hook.
+
+Exercises the pure decision logic in
+``claude_extensions/hooks/guard-branch-switch-in-main.py``:
+
+  * branch switch / create detection (pre-existing behavior),
+  * the new ``git branch -D/-M/-f`` force-delete / force-rename blocking,
+  * the safe-op allow-list (``-d`` / ``-m`` / list / create), and
+  * the quote-aware tokenizer that prevents false positives on git verbs
+    quoted inside a commit message — the reason this guard is Python and
+    not a grep one-liner.
+
+The hook filename has hyphens, so it is loaded by path via importlib.
+Only module-level defs/constants run on load (``main`` is guarded by
+``__name__ == "__main__"``), so importing it has no side effects.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = REPO_ROOT / "claude_extensions" / "hooks" / "guard-branch-switch-in-main.py"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location(
+        "guard_branch_switch_in_main", HOOK_PATH
+    )
+    assert spec and spec.loader, f"could not load hook at {HOOK_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_hook()
+
+
+def _dangerous(command: str) -> str | None:
+    """Replicate the hook's per-segment scan; return the first reason or None."""
+    for seg in guard._segments(command):
+        reason = guard._segment_is_dangerous(seg)
+        if reason:
+            return reason
+    return None
+
+
+# --- Branch switches / creates (pre-existing behavior) ---------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git checkout -b feature",
+        "git switch -c feature",
+        "git switch some-branch",
+        "git checkout some-branch",
+        "git -C . checkout -b feature",
+        "sudo git checkout -b feature",
+        "git status && git checkout -b feature",
+    ],
+)
+def test_branch_switch_blocked(cmd):
+    assert _dangerous(cmd) is not None
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git checkout main",
+        "git checkout master",
+        "git checkout HEAD",
+        "git checkout -- path/to/file",
+        "git status",
+        "git log --oneline",
+        "git worktree add .worktrees/x -b x origin/main",
+        "ls -la",
+    ],
+)
+def test_safe_ops_allowed(cmd):
+    assert _dangerous(cmd) is None
+
+
+# --- Force-delete / force-rename (new behavior) ----------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git branch -D feature",
+        "git branch -M old new",
+        "git branch -f feature origin/main",
+        "git branch --force feature origin/main",
+        "git branch -d --force feature",
+        "git branch --delete --force feature",
+        "git branch -Df feature",
+        "git -C . branch -D feature",
+        "git status && git branch -D feature",
+    ],
+)
+def test_force_branch_ops_blocked(cmd):
+    reason = _dangerous(cmd)
+    assert reason is not None
+    assert "branch" in reason
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git branch -d merged-feature",  # safe delete-if-merged
+        "git branch -m old new",  # safe rename
+        "git branch feature",  # create, does not switch
+        "git branch",  # list
+        "git branch -a",  # list all
+        "git branch -r",  # list remotes
+        "git branch -v",  # verbose list
+        "git branch --list",
+        "git branch -u origin/main",  # set upstream
+    ],
+)
+def test_safe_branch_ops_allowed(cmd):
+    assert _dangerous(cmd) is None
+
+
+# --- Quote-aware: the key advantage over a grep-based hook -----------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        'git commit -m "git branch -D old"',
+        'git commit -m "revert: git checkout -b foo"',
+        "git commit -m 'force-delete via git branch -D'",
+        'git commit -m "git switch -c topic"',
+    ],
+)
+def test_quoted_git_in_commit_message_not_blocked(cmd):
+    assert _dangerous(cmd) is None
+
+
+def test_branch_force_reason_unit():
+    assert guard._branch_force_reason(["-D", "feature"]) is not None
+    assert guard._branch_force_reason(["-M", "old", "new"]) is not None
+    assert guard._branch_force_reason(["-f", "feature", "ref"]) is not None
+    assert guard._branch_force_reason(["--force", "feature", "ref"]) is not None
+    assert guard._branch_force_reason(["-d", "merged"]) is None
+    assert guard._branch_force_reason(["-m", "old", "new"]) is None
+    assert guard._branch_force_reason(["feature"]) is None
+    assert guard._branch_force_reason([]) is None


### PR DESCRIPTION
## What
Fold force-delete / force-rename blocking into the quote-aware
`claude_extensions/hooks/guard-branch-switch-in-main.py`, and delete the
fragile grep-based local hook `guard-main-worktree.sh` that was blocking
`npm run claude:deploy` as an undeclared orphan.

## Why
A local-only hook (`guard-main-worktree.sh`, gitignored, added in-session,
never in source) blocked `git reset --hard` and `git branch -D/-M/-f` in the
main worktree, but with grep that false-positives on git verbs quoted inside
commit-message bodies (e.g. `git commit -m "...git branch -D..."`) — the exact
class the Python guard was deliberately written to avoid. It also aborted
deploy. Removing it unblocked deploy; this PR re-homes the **force-delete**
protection into the tracked, quote-aware guard (per user decision: force-deletes
only — `git reset --hard origin/main` stays a valid recovery path).

## Changes
- `_branch_force_reason()`: blocks `git branch -D/-M/-f` / `--force` in the main
  worktree; allows safe `-d` (delete-if-merged), `-m` (rename), list, and
  `git branch <name>` (create, no switch).
- Quote-aware: `git commit -m "...git branch -D..."` is **not** blocked.
- New `tests/test_guard_branch_switch_in_main.py` — 38 cases: switch/create
  (existing behavior), force-op blocking, safe-op allow-list, and the
  quoted-commit-message false-positive class.

## Tests
`pytest tests/test_guard_branch_switch_in_main.py tests/test_deploy_script_idempotency.py` → 43 passed locally. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)