### PR TITLE
refactor(build): extract _post_process_content from v6_build (#2747 slice 3)

### DIFF
--- a/scripts/build/content_cleanup.py
+++ b/scripts/build/content_cleanup.py
@@ -1,0 +1,158 @@
+"""Deterministic post-review content cleanup — strip LLM artifacts.
+
+Extracted from ``v6_build.py`` (#2747 slice 3) so the live post-processor
+registry (``post_processors/_migrations.py``) can run this mutator without
+importing the OBSOLETE ``v6_build`` module. The function is pure
+stdlib + ``yaml`` — no sqlite, research, or pipeline imports — so pulling
+it in is cheap (which is the whole reason ``_migrations`` resolves callables
+lazily).
+
+``v6_build`` re-imports ``post_process_content`` under its historical name
+``_post_process_content`` so its own build flow and the existing test
+monkeypatches keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+# Project curriculum root. Defined locally (matching learner_immersion.py /
+# orch_index.py) so this module has no dependency on v6_build's globals.
+# This file lives at scripts/build/, so parents[2] is the repo root.
+CURRICULUM_ROOT = Path(__file__).resolve().parents[2] / "curriculum" / "l2-uk-en"
+
+
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def post_process_content(content_path: Path) -> int:
+    """Deterministic post-processing: strip LLM artifacts."""
+    text = content_path.read_text("utf-8")
+    original_len = len(text)
+    fixes = 0
+
+    # 1. Strip duplicate summary section (LLM sometimes writes two)
+    # Keep the first "## Підсумок" or "## Summary", remove subsequent ones
+    summary_headings = list(re.finditer(
+        r"^## (?:Підсумок|Summary).*$", text, re.MULTILINE
+    ))
+    if len(summary_headings) > 1:
+        # Keep first, remove everything from second summary heading onward
+        cut_pos = summary_headings[1].start()
+        text = text[:cut_pos].rstrip() + "\n"
+        fixes += 1
+        _log("  🔧 Removed duplicate summary section")
+
+    # 2. Strip "Content notes" meta-section (LLM self-audit artifact)
+    content_notes = re.search(
+        r"\n\*\*Content notes:\*\*.*$", text, re.DOTALL
+    )
+    if content_notes:
+        text = text[:content_notes.start()].rstrip() + "\n"
+        fixes += 1
+        _log("  🔧 Removed Content notes meta-section")
+
+    # 3. Strip trailing --- separator before content notes
+    text = re.sub(r"\n---\s*$", "\n", text)
+
+    # 4. Strip ALL manual stress marks (combining acute U+0301)
+    # The writer sometimes adds them despite being told not to.
+    # The stress annotator adds correct ones later.
+    clean = text.replace("\u0301", "")
+    if clean != text:
+        stress_count = len(text) - len(clean)
+        fixes += 1
+        text = clean
+        _log(f"  🔧 Stripped {stress_count} manual stress marks")
+
+    # 5. Strip writer-generated tab markers and vocab tables
+    # .md files should contain only prose — no TAB markers (#1124)
+    if "<!-- TAB:" in text:
+        tab_pos = text.index("<!-- TAB:")
+        text = text[:tab_pos].rstrip() + "\n"
+        fixes += 1
+        _log("  🔧 Stripped writer-generated tab markers")
+
+    # 6. Strip writer-generated YouTube video embeds ONLY when plan has pronunciation_videos
+    # (publish step will add them properly). Seminar modules without pronunciation_videos
+    # may legitimately embed inline videos — don't strip those. (Gemini review #9)
+    slug = content_path.stem
+    level_dir = content_path.parent.name
+    plan_path = CURRICULUM_ROOT / "plans" / level_dir / f"{slug}.yaml"
+    has_plan_videos = False
+    if plan_path.exists():
+        try:
+            plan_data = yaml.safe_load(plan_path.read_text("utf-8"))
+            has_plan_videos = bool(plan_data.get("pronunciation_videos"))
+        except Exception:
+            pass
+    if has_plan_videos:
+        video_pattern = re.compile(r'\n*<YouTubeVideo\s[^>]*/?>\s*\n*')
+        new_text = video_pattern.sub("\n", text)
+        if new_text != text:
+            video_count = text.count("<YouTubeVideo") - new_text.count("<YouTubeVideo")
+            fixes += 1
+            text = new_text
+            _log(f"  🔧 Stripped {video_count} writer-generated YouTube embeds (ENRICH handles videos)")
+
+    # 7. Strip motivational closers — LLMs consistently produce these despite prompting
+    motivational_patterns = [
+        r"By mastering these[^.]*\.",
+        r"You have successfully[^.]*\.",
+        r"Your journey[^.]*has officially begun[^.]*\.",
+        r"You now have the (?:foundational )?tools[^.]*\.",
+        r"you have laid the groundwork[^.]*\.",
+        r"you are (?:now )?ready to[^.]*\.",
+    ]
+    for pat in motivational_patterns:
+        new_text = re.sub(pat, "", text, flags=re.IGNORECASE)
+        if new_text != text:
+            fixes += 1
+            text = new_text
+            _log(f"  🔧 Stripped motivational closer: {pat[:40]}...")
+
+    # Clean up double blank lines from stripped content
+    text = re.sub(r'\n{3,}', '\n\n', text)
+
+    # 8. Gemini style cleanup — strip empty intensifiers (deterministic, pre-review)
+    # These inflate prose without adding meaning. The write prompt bans them,
+    # but Gemini uses them anyway. Cheaper to strip here than waste review rounds.
+    _BANNED_INTENSIFIERS = [
+        "надзвичайно", "абсолютно", "буквально", "безумовно",
+        "неймовірно", "колосально", "грандіозно", "шалено",
+        "фантастично",
+    ]
+    intensifier_count = 0
+    for word in _BANNED_INTENSIFIERS:
+        # Match the word with optional trailing comma/space, case-insensitive
+        # Don't strip if it's inside a quoted source (between «»)
+        pattern = re.compile(rf"\b{word}\b\s*,?\s*", re.IGNORECASE)
+        matches = pattern.findall(text)
+        if matches and len(matches) > 2:
+                text = pattern.sub("", text)
+                intensifier_count += len(matches)
+    if intensifier_count:
+        # Fix capitalization after removal (lowercase letter after period)
+        text = re.sub(r'(\.\s+)([а-яіїєґ])', lambda m: m.group(1) + m.group(2).upper(), text)
+        fixes += 1
+        _log(f"  🔧 Stripped {intensifier_count} empty intensifiers (Gemini style cleanup)")
+
+    # 9. Strip stray single quotes from exercise DSL values
+    # LLMs sometimes produce: q: "'text'" or answer: "'word'"
+    stray_quote_pattern = re.compile(
+        r'''((?:q|answer|sentence|left|right|statement|name):\s*")'([^"]*)'("?)'''
+    )
+    new_text = stray_quote_pattern.sub(r'\1\2\3', text)
+    if new_text != text:
+        fixes += 1
+        text = new_text
+        _log("  🔧 Stripped stray quotes from exercise DSL")
+
+    if len(text) != original_len:
+        content_path.write_text(text, "utf-8")
+
+    return fixes

--- a/scripts/build/post_processors/_migrations.py
+++ b/scripts/build/post_processors/_migrations.py
@@ -37,7 +37,7 @@ def register_existing() -> None:
     # DETERMINISTIC_STRIP — strips content only, never introduces new
     # codepoints.
     register_post_processor(
-        "build.v6_build._post_process_content",
+        "build.content_cleanup.post_process_content",
         MutationClass.DETERMINISTIC_STRIP,
     )
 
@@ -58,11 +58,11 @@ def get_processor_callable(name: str):
 
         return _invoke_stress
 
-    if name == "build.v6_build._post_process_content":
+    if name == "build.content_cleanup.post_process_content":
         import tempfile
 
         def _invoke_post_process(text: str) -> str:
-            from build.v6_build import _post_process_content
+            from build.content_cleanup import post_process_content
 
             with tempfile.NamedTemporaryFile(
                 mode="w",
@@ -74,7 +74,7 @@ def get_processor_callable(name: str):
                 handle.write(text)
                 tmp_path = Path(handle.name)
             try:
-                _post_process_content(tmp_path)
+                post_process_content(tmp_path)
                 return tmp_path.read_text("utf-8")
             finally:
                 tmp_path.unlink(missing_ok=True)

--- a/scripts/build/v6_build.py
+++ b/scripts/build/v6_build.py
@@ -6233,133 +6233,14 @@ def step_exercises(content_path: Path) -> bool:
     return True
 
 
-def _post_process_content(content_path: Path) -> int:
-    """Deterministic post-processing: strip LLM artifacts."""
-    text = content_path.read_text("utf-8")
-    original_len = len(text)
-    fixes = 0
-
-    # 1. Strip duplicate summary section (LLM sometimes writes two)
-    # Keep the first "## Підсумок" or "## Summary", remove subsequent ones
-    summary_headings = list(re.finditer(
-        r"^## (?:Підсумок|Summary).*$", text, re.MULTILINE
-    ))
-    if len(summary_headings) > 1:
-        # Keep first, remove everything from second summary heading onward
-        cut_pos = summary_headings[1].start()
-        text = text[:cut_pos].rstrip() + "\n"
-        fixes += 1
-        _log("  🔧 Removed duplicate summary section")
-
-    # 2. Strip "Content notes" meta-section (LLM self-audit artifact)
-    content_notes = re.search(
-        r"\n\*\*Content notes:\*\*.*$", text, re.DOTALL
-    )
-    if content_notes:
-        text = text[:content_notes.start()].rstrip() + "\n"
-        fixes += 1
-        _log("  🔧 Removed Content notes meta-section")
-
-    # 3. Strip trailing --- separator before content notes
-    text = re.sub(r"\n---\s*$", "\n", text)
-
-    # 4. Strip ALL manual stress marks (combining acute U+0301)
-    # The writer sometimes adds them despite being told not to.
-    # The stress annotator adds correct ones later.
-    clean = text.replace("\u0301", "")
-    if clean != text:
-        stress_count = len(text) - len(clean)
-        fixes += 1
-        text = clean
-        _log(f"  🔧 Stripped {stress_count} manual stress marks")
-
-    # 5. Strip writer-generated tab markers and vocab tables
-    # .md files should contain only prose — no TAB markers (#1124)
-    if "<!-- TAB:" in text:
-        tab_pos = text.index("<!-- TAB:")
-        text = text[:tab_pos].rstrip() + "\n"
-        fixes += 1
-        _log("  🔧 Stripped writer-generated tab markers")
-
-    # 6. Strip writer-generated YouTube video embeds ONLY when plan has pronunciation_videos
-    # (publish step will add them properly). Seminar modules without pronunciation_videos
-    # may legitimately embed inline videos — don't strip those. (Gemini review #9)
-    slug = content_path.stem
-    level_dir = content_path.parent.name
-    plan_path = CURRICULUM_ROOT / "plans" / level_dir / f"{slug}.yaml"
-    has_plan_videos = False
-    if plan_path.exists():
-        try:
-            plan_data = yaml.safe_load(plan_path.read_text("utf-8"))
-            has_plan_videos = bool(plan_data.get("pronunciation_videos"))
-        except Exception:
-            pass
-    if has_plan_videos:
-        video_pattern = re.compile(r'\n*<YouTubeVideo\s[^>]*/?>\s*\n*')
-        new_text = video_pattern.sub("\n", text)
-        if new_text != text:
-            video_count = text.count("<YouTubeVideo") - new_text.count("<YouTubeVideo")
-            fixes += 1
-            text = new_text
-            _log(f"  🔧 Stripped {video_count} writer-generated YouTube embeds (ENRICH handles videos)")
-
-    # 7. Strip motivational closers — LLMs consistently produce these despite prompting
-    motivational_patterns = [
-        r"By mastering these[^.]*\.",
-        r"You have successfully[^.]*\.",
-        r"Your journey[^.]*has officially begun[^.]*\.",
-        r"You now have the (?:foundational )?tools[^.]*\.",
-        r"you have laid the groundwork[^.]*\.",
-        r"you are (?:now )?ready to[^.]*\.",
-    ]
-    for pat in motivational_patterns:
-        new_text = re.sub(pat, "", text, flags=re.IGNORECASE)
-        if new_text != text:
-            fixes += 1
-            text = new_text
-            _log(f"  🔧 Stripped motivational closer: {pat[:40]}...")
-
-    # Clean up double blank lines from stripped content
-    text = re.sub(r'\n{3,}', '\n\n', text)
-
-    # 8. Gemini style cleanup — strip empty intensifiers (deterministic, pre-review)
-    # These inflate prose without adding meaning. The write prompt bans them,
-    # but Gemini uses them anyway. Cheaper to strip here than waste review rounds.
-    _BANNED_INTENSIFIERS = [
-        "надзвичайно", "абсолютно", "буквально", "безумовно",
-        "неймовірно", "колосально", "грандіозно", "шалено",
-        "фантастично",
-    ]
-    intensifier_count = 0
-    for word in _BANNED_INTENSIFIERS:
-        # Match the word with optional trailing comma/space, case-insensitive
-        # Don't strip if it's inside a quoted source (between «»)
-        pattern = re.compile(rf"\b{word}\b\s*,?\s*", re.IGNORECASE)
-        matches = pattern.findall(text)
-        if matches and len(matches) > 2:
-                text = pattern.sub("", text)
-                intensifier_count += len(matches)
-    if intensifier_count:
-        # Fix capitalization after removal (lowercase letter after period)
-        text = re.sub(r'(\.\s+)([а-яіїєґ])', lambda m: m.group(1) + m.group(2).upper(), text)
-        fixes += 1
-        _log(f"  🔧 Stripped {intensifier_count} empty intensifiers (Gemini style cleanup)")
-
-    # 9. Strip stray single quotes from exercise DSL values
-    # LLMs sometimes produce: q: "'text'" or answer: "'word'"
-    stray_quote_pattern = re.compile(
-        r'''((?:q|answer|sentence|left|right|statement|name):\s*")'([^"]*)'("?)'''
-    )
-    new_text = stray_quote_pattern.sub(r'\1\2\3', text)
-    if new_text != text:
-        fixes += 1
-        text = new_text
-        _log("  🔧 Stripped stray quotes from exercise DSL")
-
-    if len(text) != original_len:
-        content_path.write_text(text, "utf-8")
-
-    return fixes
+# ``_post_process_content`` was extracted to a dependency-free home
+# (build/content_cleanup.py) in #2747 slice 3, so the live post-processor
+# registry no longer imports this OBSOLETE module to run it. Re-imported here
+# under its historical name so v6_build's own build flow and the existing test
+# monkeypatches (which target v6_build._post_process_content) keep working.
+from build.content_cleanup import (
+    post_process_content as _post_process_content,
+)
 
 
 def step_repair(level: str, module_num: int, slug: str) -> tuple[bool, bool]:

--- a/tests/test_post_processor_mutation_invariant.py
+++ b/tests/test_post_processor_mutation_invariant.py
@@ -144,7 +144,7 @@ def test_every_registered_processor_has_a_resolver() -> None:
 # post-review mutator; the test forces an explicit class declaration.
 _EXPECTED_REGISTRATIONS = {
     "pipeline.stress_annotator.annotate_stress",
-    "build.v6_build._post_process_content",
+    "build.content_cleanup.post_process_content",
 }
 
 


### PR DESCRIPTION
Part of #2747 (A-migration). **Slice 3.** After this, NO live (non-test) code imports `v6_build`.

## What
Move the deterministic post-review content cleanup (`_post_process_content`) out of the OBSOLETE `v6_build.py` into a dependency-free home, so the live post-processor registry (`post_processors/_migrations.py`) no longer imports `v6_build` to run it.

## Why
Per #2747's caller analysis, `_migrations.py:65` was the last V7-pipeline **hard import** of `v6_build` (`plan_patch.py` was cleared in slice 2). `alignment_manifest.py` only *soft-resolves* `v6_build` via `sys.modules` (graceful static-default fallback), so it is not a hard import. Clearing `_migrations` completes the "no live code imports v6_build" milestone.

## Changes
- **New `scripts/build/content_cleanup.py`** — `post_process_content()` (verbatim move) + local `_log` / `CURRICULUM_ROOT`. Pure stdlib + `yaml`; no sqlite/research/pipeline deps, so the lazy callable resolver pulls only this light module. Home matches slice 2's `prompt_literals.py` (`scripts/build/`, not the `post_processors/` registry package — the other registered mutator `pipeline.stress_annotator` also lives outside it).
- **`v6_build.py`** re-imports it under the historical name `_post_process_content` so v6_build's own build flow (5 internal call sites) and the existing test monkeypatches keep working unchanged. Identity preserved: `v6._post_process_content is content_cleanup.post_process_content`. v6_build shrinks ~127 lines.
- **`post_processors/_migrations.py`** — repoint the lazy import; rename the registry key `build.v6_build._post_process_content` → `build.content_cleanup.post_process_content` (key not persisted anywhere — verified).
- **`test_post_processor_mutation_invariant.py`** — update the expected-registration key.

## Tests
`pytest test_post_processor_mutation_invariant test_v6_build_events test_v6_plan_hash_drift test_plan_hash test_no_rewrite_contract test_migrations` → **all green**. Smoke verifies clean import (no circular import), re-export identity, and registry resolve+run. ruff clean.

## Remaining for full v6/v5 removal (#2747)
- Slice 4 (large): ~15 test files import `v6_build` internals — keep as renamed tested library vs retire with the build path (design call).
- Slice 5: migrate research-preseed off the `build_module_v5.py` subprocess, or keep v5 as the research builder (design call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)