### PR TITLE
fix(a1): sync M1 site output and resource notes

### DIFF
--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/resources.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/resources.yaml
@@ -1,201 +1,197 @@
 - title: Большакова, буквар 1 клас, p. 24
   role: textbook
   chunk_id: 1-klas-bukvar-bolshakova-2018-1_s0023
-  notes: 'Plan reference: голосні/приголосні через вірші; retrieved via search_text
-    because plan notes include no literal chunk_id.'
+  notes: 'Vowel and consonant practice through short textbook verse.'
 - title: Захарійчук, буквар 1 клас (НУШ 2025), p. 13
   role: textbook
   chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0002
-  notes: 'Plan reference: [•] голосний, [–] твердий приголосний, [=] м''який приголосний;
-    resolved page context from corpus metadata.'
+  notes: 'Textbook symbols for vowel, hard consonant, and soft consonant sounds.'
 - title: Заболотний 5 клас, p. 83
   role: textbook
   chunk_id: 5-klas-ukrmova-zabolotnyi-2023_s0084
-  notes: 'Plan reference: «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо.»'
+  notes: 'Sound-letter distinction: «Звуки ми чуємо й вимовляємо, а букви бачимо
+    й пишемо.»'
 - title: Літвінова 5 клас, p. 130
   role: textbook
   chunk_id: 5-klas-ukrmova-litvinova-2022_s0135
-  notes: 'Plan reference: питання про «голосна літера» / «приголосна літера» and sound-letter
-    distinction.'
+  notes: 'Questions about vowel/consonant terminology and the sound-letter distinction.'
 - title: ULP Season 1, Episode 1 — Informal Greetings
   role: podcast
   url: https://www.ukrainianlessons.com/episode1/
-  notes: 'Plan reference: Привіт, Як справи?, response models; external search found
-    ULP Episode 1 material.'
+  notes: 'Greeting and response models: Привіт, Як справи?, and short answers.'
 - title: Anna Ohoiko — Ukrainian alphabet overview
   role: youtube
   url: https://www.youtube.com/watch?v=ksXIXj7CXwc
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: overview for the full Ukrainian alphabet.'
+  notes: 'Pronunciation video: overview for the full Ukrainian alphabet.'
 - title: Anna Ohoiko — Ukrainian alphabet pronunciation playlist
   role: youtube
   url: https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: playlist for per-letter Ukrainian pronunciation
+  notes: 'Pronunciation video: playlist for per-letter Ukrainian pronunciation
     practice.'
 - title: Anna Ohoiko — Letter А pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=hvB3VpcR3ZE
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: А.'
+  notes: 'Pronunciation video: А.'
 - title: Anna Ohoiko — Letter Б pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=V1hxBE_JbGg
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Б.'
+  notes: 'Pronunciation video: Б.'
 - title: Anna Ohoiko — Letter В pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=aFcvYfvQ2X4
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: В.'
+  notes: 'Pronunciation video: В.'
 - title: Anna Ohoiko — Letter Г pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=gVnclpSI0DU
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Г.'
+  notes: 'Pronunciation video: Г.'
 - title: Anna Ohoiko — Letter Ґ pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=gNjHqjTW9WQ
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ґ.'
+  notes: 'Pronunciation video: Ґ.'
 - title: Anna Ohoiko — Letter Д pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=g4Bh-lqzd48
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Д.'
+  notes: 'Pronunciation video: Д.'
 - title: Anna Ohoiko — Letter Е pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=KFlsroBW0dk
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Е.'
+  notes: 'Pronunciation video: Е.'
 - title: Anna Ohoiko — Letter Є pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=O0bwRyyBQSc
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Є.'
+  notes: 'Pronunciation video: Є.'
 - title: Anna Ohoiko — Letter Ж pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=dIrGVcqPwqM
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ж.'
+  notes: 'Pronunciation video: Ж.'
 - title: Anna Ohoiko — Letter З pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=BhASNxitC1A
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: З.'
+  notes: 'Pronunciation video: З.'
 - title: Anna Ohoiko — Letter И pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=W-1rCu0indE
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: И.'
+  notes: 'Pronunciation video: И.'
 - title: Anna Ohoiko — Letter І pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=Z9TH0H4ShGo
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: І.'
+  notes: 'Pronunciation video: І.'
 - title: Anna Ohoiko — Letter Ї pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=UcjdjQXhAY8
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ї.'
+  notes: 'Pronunciation video: Ї.'
 - title: Anna Ohoiko — Letter Й pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=aq0cjB90s3w
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Й.'
+  notes: 'Pronunciation video: Й.'
 - title: Anna Ohoiko — Letter К pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=J7sGEI4-xJo
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: К.'
+  notes: 'Pronunciation video: К.'
 - title: Anna Ohoiko — Letter Л pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=v6-3Xg52Buk
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Л.'
+  notes: 'Pronunciation video: Л.'
 - title: Anna Ohoiko — Letter М pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=Ez95H4ibuJo
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: М.'
+  notes: 'Pronunciation video: М.'
 - title: Anna Ohoiko — Letter Н pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=vNUfiKHPYaU
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Н.'
+  notes: 'Pronunciation video: Н.'
 - title: Anna Ohoiko — Letter О pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=gJFxRIPRZbI
   channel: Ukrainian Lessons
-  notes: 'Activity pronunciation video: О; the locked plan currently has no separate
-    О URL, but the workbook includes the stored course reference.'
+  notes: 'Pronunciation video: О.'
 - title: Anna Ohoiko — Letter П pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=JksSjjxyW5Y
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: П.'
+  notes: 'Pronunciation video: П.'
 - title: Anna Ohoiko — Letter Р pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=fMGsQ5KPQgg
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Р.'
+  notes: 'Pronunciation video: Р.'
 - title: Anna Ohoiko — Letter С pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=7UsFBgSL91E
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: С.'
+  notes: 'Pronunciation video: С.'
 - title: Anna Ohoiko — Letter Т pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=m-jcLR_gK0k
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Т.'
+  notes: 'Pronunciation video: Т.'
 - title: Anna Ohoiko — Letter У pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=VB1O6PmtYRU
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: У.'
+  notes: 'Pronunciation video: У.'
 - title: Anna Ohoiko — Letter Ф pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=haHRsFFZRQI
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ф.'
+  notes: 'Pronunciation video: Ф.'
 - title: Anna Ohoiko — Letter Х pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=vpr58zJSJKc
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Х.'
+  notes: 'Pronunciation video: Х.'
 - title: Anna Ohoiko — Letter Ц pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=u44eCjR2Oz8
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ц.'
+  notes: 'Pronunciation video: Ц.'
 - title: Anna Ohoiko — Letter Ч pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=UsJkbdsY2RA
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ч.'
+  notes: 'Pronunciation video: Ч.'
 - title: Anna Ohoiko — Letter Ш pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=1D-6MIw3OXY
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ш.'
+  notes: 'Pronunciation video: Ш.'
 - title: Anna Ohoiko — Letter Щ pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=QmBLieIuf6Q
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Щ.'
+  notes: 'Pronunciation video: Щ.'
 - title: Anna Ohoiko — Letter Ь pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=cJlal8XKBxo
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ь.'
+  notes: 'Pronunciation video: Ь.'
 - title: Anna Ohoiko — Letter Ю pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=9JdIBYCTWGw
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Ю.'
+  notes: 'Pronunciation video: Ю.'
 - title: Anna Ohoiko — Letter Я pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=yhSAf41LX8I
   channel: Ukrainian Lessons
-  notes: 'Plan pronunciation video: Я.'
+  notes: 'Pronunciation video: Я.'

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -304,7 +304,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';"""
         extra_fm_lines += "\ndraft: true"
 
     try:
-        from scripts.build.prev_next import get_prev_next_links
+        from build.prev_next import get_prev_next_links
         prev_link, next_link = get_prev_next_links(level, module_num)
         extra_fm_lines += f"\nprev: {prev_link}" if prev_link else "\nprev: false"
         extra_fm_lines += f"\nnext: {next_link}" if next_link else "\nnext: false"
@@ -543,14 +543,21 @@ def main():
             output_dir = STARLIGHT_DOCS_DIR / mod.level
             output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Find the physical file
+        # Find the physical file. Newer v7 modules use a folder layout:
+        # a1/<slug>/module.md with sibling activities/vocabulary/resources YAML.
         level_dir = CURRICULUM_DIR / lang_pair / mod.level
         md_file = level_dir / f"{mod.slug}.md"
+        module_dir = level_dir / mod.slug
 
         if not md_file.exists():
-            print(f"DEBUG: Checked path {md_file.absolute()}")
-            print(f"  \u26a0\ufe0f  Physical file not found for slug '{mod.slug}' in {mod.level}")
-            continue
+            folder_md_file = module_dir / "module.md"
+            if folder_md_file.exists():
+                md_file = folder_md_file
+            else:
+                print(f"DEBUG: Checked path {md_file.absolute()}")
+                print(f"DEBUG: Checked path {folder_md_file.absolute()}")
+                print(f"  \u26a0\ufe0f  Physical file not found for slug '{mod.slug}' in {mod.level}")
+                continue
 
         # Read and convert
         md_content = md_file.read_text(encoding='utf-8')
@@ -585,6 +592,10 @@ def main():
 
         # Load VOCABULARY
         vocab_file = level_dir / 'vocabulary' / f"{mod.slug}.yaml"
+        if not vocab_file.exists():
+            folder_vocab_file = module_dir / "vocabulary.yaml"
+            if folder_vocab_file.exists():
+                vocab_file = folder_vocab_file
 
         vocab_items = None
         if vocab_file.exists():
@@ -601,6 +612,10 @@ def main():
 
         # Load ACTIVITIES
         yaml_file = level_dir / 'activities' / f"{mod.slug}.yaml"
+        if not yaml_file.exists():
+            folder_yaml_file = module_dir / "activities.yaml"
+            if folder_yaml_file.exists():
+                yaml_file = folder_yaml_file
 
         yaml_activities = None
         if yaml_file.exists():
@@ -627,8 +642,19 @@ def main():
         module_id = f"{mod.level}-{mod.slug}"
         module_resources = all_resources.get(module_id, {})
 
+        folder_resources_file = module_dir / "resources.yaml"
+        if folder_resources_file.exists():
+            try:
+                with open(folder_resources_file, encoding='utf-8') as f:
+                    resource_data = yaml.safe_load(f)
+                if isinstance(resource_data, list | dict):
+                    module_resources = resource_data
+            except Exception as e:
+                print(f'\n❌ CRITICAL: Error parsing YAML resources for {mod.slug}: {e}')
+                sys.exit(1)
+
         # Add pronunciation videos from plan to resources
-        if plan_data and plan_data.get("pronunciation_videos"):
+        if isinstance(module_resources, dict) and plan_data and plan_data.get("pronunciation_videos"):
             pv = plan_data["pronunciation_videos"]
             yt_resources = module_resources.get("youtube", [])
             if pv.get("overview"):

--- a/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
+++ b/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
@@ -4,8 +4,6 @@ description: "33 літери, 38 звуків, Привіт!"
 sidebar:
   order: 1
   label: "01. Звуки, літери та привіт"
-pipeline: linear-phase-4
-build_status: validated
 prev: false
 next: reading-ukrainian
 ---
@@ -58,351 +56,234 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-You do not need to read Ukrainian yet. This English-led module uses Ukrainian in small chunks so you can listen, repeat, notice, and use the first phrases safely.
+**Звук — sound. Лі́тера — letter.** This first module starts with what you
+hear, then connects it to what you see on the page.
 
-By the end, you can:
+Work in this order:
 
-- say hello, goodbye, and a simple "How are you?";
-- answer with **До́бре**, **Чудо́во**, or **Норма́льно**;
-- ask and answer a name question;
-- explain the difference between a sound and a letter;
-- recognize all 33 Ukrainian letters at first-pass level;
-- know what **склад** means before the workbook asks you to count syllables;
-- avoid the first pronunciation traps: blurred **о**, confusing **и** and **і**, adding a sound after **ь**, and turning final voiced consonants into voiceless ones.
+1. hear a sound;
+2. see the letter;
+3. repeat a short word;
+4. use one greeting chunk.
 
-## Sound First, Letter Second
+You do not need long Ukrainian sentences yet. You need a few stable anchors:
+**звук**, **лі́тера**, **ма́ма**, **молоко́**, **Приві́т**, and
+**До́брий день**.
 
-Keep this rule in mind from the first minute:
+## Звук і лі́тера
 
-| You hear and say | You see and write |
+**Звук — sound.** You hear it and pronounce it.
+
+**Лі́тера — letter.** You see it and write it.
+
+Keep the two ideas separate:
+
+| Ukrainian anchor | English support |
 | --- | --- |
-| a **sound** | a **letter** |
-| **звук** - sound | **лі́тера** - letter |
+| **звук** | what your mouth says and your ear hears |
+| **лі́тера** | the written sign on the page |
+| **абе́тка** | the alphabet |
 
-A **sound** belongs to your ear and mouth. A **letter** belongs to your eyes and hand.
+Ukrainian has **33 letters** in the alphabet. In speech, Ukrainian uses more
+sounds because some letters can point to more than one sound or modify a nearby
+sound.
 
-Three numbers matter in Ukrainian:
+Three beginner clues:
 
-| Fact | Meaning |
-| --- | --- |
-| **33 letters** | the Ukrainian alphabet, or **абе́тка** |
-| **38 sounds** | what speakers actually hear and say |
-| **6 vowel sounds** | the open sounds you can sing |
+- **Я, Ю, Є, Ї** can point to a **й + vowel** sound in some positions.
+- **Ь** has no sound of its own; it softens the previous consonant.
+- **Щ** is taught here as **[шч]**.
 
-The numbers are not the same because some letters do more than one job. For example:
+### Sound or letter
 
-- **Я, Ю, Є, Ї** can point to more than one sound.
-- **Ь** is the soft sign. It has no sound of its own.
-- Many consonants can be hard or soft.
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "What do we hear and pronounce?", "options": [{"text": "лі́тера", "correct": false}, {"text": "Звук", "correct": true}, {"text": "Слово", "correct": false}], "explanation": "Звук is what we hear and pronounce."}, {"question": "What do we see in writing?", "options": [{"text": "Звук", "correct": false}, {"text": "лі́тера", "correct": true}, {"text": "Вимова", "correct": false}], "explanation": "Лі́тера is the written sign."}, {"question": "How many letters are in the Ukrainian alphabet?", "options": [{"text": "38", "correct": false}, {"text": "33", "correct": true}, {"text": "6", "correct": false}], "explanation": "The standard Ukrainian alphabet has 33 letters."}, {"question": "Why can 33 letters point to more sounds?", "options": [{"text": "Some letters have more than one job", "correct": true}, {"text": "English spelling changes Ukrainian sounds", "correct": false}, {"text": "Every letter is silent", "correct": false}], "explanation": "Some Ukrainian letters can point to more than one sound or modify a nearby sound."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "А", "correct": false}, {"text": "Ь", "correct": true}, {"text": "О", "correct": false}], "explanation": "Ь has no sound of its own."}, {"question": "Which word has three vowel sounds?", "options": [{"text": "Приві́т", "correct": false}, {"text": "молоко́", "correct": true}, {"text": "Мов", "correct": false}], "explanation": "Молоко́ has three vowel sounds, о + о + о."}]`)} />
 
-Say this rule aloud:
+## Голосні звуки
 
-**Звук = I hear it. Лі́тера = I see it.**
+**Голосни́й звук — vowel sound.** A vowel is open and easy to sing.
 
-:::tip
-Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are the course's **heartbeat** (**серцебиття**) because every Ukrainian **склад** needs a vowel sound. Short **відеоуроки** help you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
-:::
-
-### Sound or letter?
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "What is a звук?", "options": [{"text": "A sound you hear and say", "correct": true}, {"text": "A letter you see and write", "correct": false}, {"text": "A whole sentence", "correct": false}], "explanation": "A звук belongs to hearing and speaking."}, {"question": "What is a лі́тера?", "options": [{"text": "A letter you see and write", "correct": true}, {"text": "A sound you hear and say", "correct": false}, {"text": "A greeting", "correct": false}], "explanation": "A лі́тера belongs to reading and writing."}, {"question": "How many letters are in the Ukrainian alphabet?", "options": [{"text": "33", "correct": true}, {"text": "38", "correct": false}, {"text": "6", "correct": false}], "explanation": "Ukrainian has 33 letters."}, {"question": "How many basic Ukrainian vowel sounds are there?", "options": [{"text": "6", "correct": true}, {"text": "10", "correct": false}, {"text": "33", "correct": false}], "explanation": "The six basic vowel sounds are [а], [о], [у], [е], [и], [і]."}, {"question": "Does ь have its own sound?", "options": [{"text": "No", "correct": true}, {"text": "Yes", "correct": false}, {"text": "Only in Приві́т", "correct": false}], "explanation": "The soft sign ь has no sound of its own."}, {"question": "What does Приві́т mean?", "options": [{"text": "Hi", "correct": true}, {"text": "Goodbye", "correct": false}, {"text": "Milk", "correct": false}], "explanation": "Приві́т is the informal word for Hi."}]`)} />
-
-## Your First Word
-
-Your first word is:
-
-**Приві́т!** - Hi!
-
-Use **Приві́т!** with classmates, friends, family, or someone your age. Treat it as one whole chunk today.
-
-Say it slowly:
-
-**При-ві́т**
-
-Now notice the pieces:
-
-| Letter | Sound | Type |
-| --- | --- | --- |
-| **П** | [п] | consonant |
-| **р** | [р] | consonant |
-| **и** | [и] | vowel |
-| **в** | [в] | consonant |
-| **і** | [і] | vowel |
-| **т** | [т] | consonant |
-
-So **Приві́т** has two vowel sounds and four consonant sounds.
-
-## Six Vowel Sounds, Ten Letters
-
-Ukrainian has six basic vowel sounds:
+Start with six simple vowel sounds:
 
 **[а] [о] [у] [е] [и] [і]**
 
-A vowel sound is open. Your voice passes through without a block. You can hold it and sing it:
+The simple vowel letters are:
 
-- **а-а-а**
-- **о-о-о**
-- **у-у-у**
-- **і-і-і**
+**А О У Е И І**
 
-There are six vowel sounds, but ten letters that can mark vowel sounds:
+Use the beginner rule:
 
-| Simple vowel letters | Special vowel letters |
-| --- | --- |
-| **А О У Е И І** | **Я Ю Є Ї** |
-
-Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, know their job:
-
-- **Я** can sound like **[йа]** or soften a previous consonant and mark **[а]**.
-- **Ю** can sound like **[йу]** or soften a previous consonant and mark **[у]**.
-- **Є** can sound like **[йе]** or soften a previous consonant and mark **[е]**.
-- **Ї** is special: it is always **[йі]**.
-
-Three useful words:
-
-| Word | Meaning | What to notice |
-| --- | --- | --- |
-| **ма́ма** | mother | two **а** sounds |
-| **молоко́** | milk | three clean **о** sounds |
-| **Приві́т** | hi | **и** and **і** are different sounds |
-
-Important habit: Ukrainian **о** stays clean. In **молоко́**, each **о** is still **о**. Say **мо-ло-ко́**, not a blurred English-style vowel.
-
-## What Is a Склад?
-
-A **склад** is a syllable. In Ukrainian, every syllable needs a vowel sound. That is why vowels are the "heart" of a syllable.
-
-Use this simple beginner rule:
-
-**Count vowel sounds = count syllables.**
+**one vowel sound = one склад**
 
 | Word | Vowel sounds | Syllables |
 | --- | --- | --- |
-| **день** | **е** | 1 склад |
-| **ма́ма** | **а + а** | 2 склади |
-| **Приві́т** | **и + і** | 2 склади |
-| **молоко́** | **о + о + о** | 3 склади |
+| **ма́ма** | **а + а** | 2 |
+| **молоко́** | **о + о + о** | 3 |
+| **Приві́т** | **и + і** | 2 |
+| **о́ко** | **о + о** | 2 |
 
-Now the workbook can ask you about **склади** because you know the idea: find the vowel sounds first.
+Important habit: keep **о** clean. In **молоко́**, every **о** is still **о**.
+Do not blur it into an English-style reduced vowel.
 
-### Count склади
+### Кількість складів
 
-<CountSyllables client:only='react' instruction={"Count vowel sounds. Each vowel sound makes one склад."} items={JSON.parse(`[{"word": "день", "correct": 1}, {"word": "ма́ма", "correct": 2}, {"word": "Приві́т", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "та́то", "correct": 2}, {"word": "о́ко", "correct": 2}]`)} />
+<CountSyllables client:only='react' instruction={"Рахуй голосні звуки в слові."} items={JSON.parse(`[{"word": "ма́ма", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "вода́", "correct": 2}, {"word": "приві́т", "correct": 2}, {"word": "о́ко", "correct": 2}, {"word": "та́то", "correct": 2}]`)} maxCount={3} />
 
-## Consonant Sounds
+## При́голосні звуки
 
-A consonant sound uses a small block or contact in the mouth: lips, teeth, tongue, or throat.
+**При́голосний звук — consonant sound.** A consonant uses a small block or
+contact in the mouth: lips, teeth, tongue, or throat.
 
-Try four:
+Try four easy consonants:
 
-- **[м]** - close your lips and hum.
-- **[п]** - close your lips and release without humming.
-- **[т]** - touch your tongue behind your teeth.
-- **[н]** - touch your tongue and let sound pass through your nose.
-
-Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need three first clues:
-
-Vowels give a syllable its voice. Consonants build the clear **architecture** (**архітектура**) around that voice: lips, teeth, tongue, or throat make the shape.
-
-| Sign or letter | Beginner meaning |
+| Sound | Body cue |
 | --- | --- |
-| **Ь ь** | **м'який знак**; no sound of its own |
-| **Г г** | Ukrainian h-like sound |
-| **Ґ ґ** | hard **g** sound |
-| **Щ щ** | two sounds together: **[шч]** |
+| **[м]** | close your lips and hum |
+| **[п]** | close your lips and release |
+| **[т]** | touch your tongue behind the teeth |
+| **[н]** | let sound pass through the nose |
 
-Example:
+Now take **Приві́т** apart:
 
-**день** - day
-
-The final **ь** does not add a new vowel. It tells you to make **н** soft.
-
-The letters **Я, Ю, Є** are graphic **chameleons** (**хамелеони**): at the start of a word they can show **[й] + vowel**, but after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
-
-## Full Alphabet Video Pass
-
-This is your first full pass through the alphabet. The goal is not to memorize everything today. The goal is to see every letter, hear a model, and repeat once.
-
-The alphabet order is:
-
-**А Б В Г Ґ Д Е Є Ж З И І Ї Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ь Ю Я**
-
-Use the video practice below for all 33 letters. One local source record has no separate per-letter URL for **О**, so the workbook uses the local course's stored **О** video reference from the syllable materials.
-
-### Full alphabet video pass
-
-<WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "бана́н"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лимо́н"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "пес"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Full alphabet video pass" />
-
-## Stress: Наголос
-
-The little mark in **Приві́т** is the stress mark. Ukrainian stress is called **на́голос**.
-
-Stress tells you which syllable is strongest:
-
-| Word | How to say it |
+| Letter | Sound type |
 | --- | --- |
-| **Приві́т** | stress on **ві́т** |
-| **ма́ма** | stress on the first **ма́** |
-| **молоко́** | stress on **ко́** |
-| **До́брий день** | stress on **До́-** |
+| **П** | consonant |
+| **Р** | consonant |
+| **И** | vowel |
+| **В** | consonant |
+| **І** | vowel |
+| **Т** | consonant |
 
-Sometimes stress changes meaning. You do not need to use these words yet, but notice the pattern:
+So **Приві́т** has **2 vowel sounds** and **4 consonant sounds**.
 
-| Stress | Meaning |
+### Звук і літера
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "І", "right": "[і]"}, {"left": "В", "right": "[в]"}, {"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "Н", "right": "[н]"}, {"left": "Ч", "right": "[ч]"}, {"left": "Ь", "right": "softens the previous consonant"}, {"left": "Я", "right": "[йа] or softens the previous consonant"}, {"left": "Ї", "right": "[йі]"}, {"left": "Щ", "right": "[шч]"}, {"left": "Д", "right": "[д]"}]`)} />
+
+## Абетка: first video pass
+
+Use this table as a first full pass through the Ukrainian alphabet. Do not try
+to master all 33 letters in one sitting. Repeat a small group, then add more.
+
+| Лі́тера | Sound | Small word | Video |
+| --- | --- | --- | --- |
+| А | [а] | анана́с | https://www.youtube.com/watch?v=hvB3VpcR3ZE |
+| Б | [б] | банду́ра | https://www.youtube.com/watch?v=V1hxBE_JbGg |
+| В | [в] | вода́ | https://www.youtube.com/watch?v=aFcvYfvQ2X4 |
+| Г | [ɦ] | гора́ | https://www.youtube.com/watch?v=gVnclpSI0DU |
+| Ґ | [g] | ґу́дзик | https://www.youtube.com/watch?v=gNjHqjTW9WQ |
+| Д | [д] | дім | https://www.youtube.com/watch?v=g4Bh-lqzd48 |
+| Е | [е] | екра́н | https://www.youtube.com/watch?v=KFlsroBW0dk |
+| Є | [йе] | єно́т | https://www.youtube.com/watch?v=O0bwRyyBQSc |
+| Ж | [ж] | жук | https://www.youtube.com/watch?v=dIrGVcqPwqM |
+| З | [з] | зуб | https://www.youtube.com/watch?v=BhASNxitC1A |
+| И | [и] | сир | https://www.youtube.com/watch?v=W-1rCu0indE |
+| І | [і] | ім'я́ | https://www.youtube.com/watch?v=Z9TH0H4ShGo |
+| Ї | [йі] | їжа́к | https://www.youtube.com/watch?v=UcjdjQXhAY8 |
+| Й | [й] | йо́гурт | https://www.youtube.com/watch?v=aq0cjB90s3w |
+| К | [к] | кіт | https://www.youtube.com/watch?v=J7sGEI4-xJo |
+| Л | [л] | лис | https://www.youtube.com/watch?v=v6-3Xg52Buk |
+| М | [м] | ма́ма | https://www.youtube.com/watch?v=Ez95H4ibuJo |
+| Н | [н] | ніс | https://www.youtube.com/watch?v=vNUfiKHPYaU |
+| О | [о] | о́ко | https://www.youtube.com/watch?v=gJFxRIPRZbI |
+| П | [п] | піт | https://www.youtube.com/watch?v=JksSjjxyW5Y |
+| Р | [р] | рука́ | https://www.youtube.com/watch?v=fMGsQ5KPQgg |
+| С | [с] | сон | https://www.youtube.com/watch?v=7UsFBgSL91E |
+| Т | [т] | та́то | https://www.youtube.com/watch?v=m-jcLR_gK0k |
+| У | [у] | уро́к | https://www.youtube.com/watch?v=VB1O6PmtYRU |
+| Ф | [ф] | фо́то | https://www.youtube.com/watch?v=haHRsFFZRQI |
+| Х | [х] | ха́та | https://www.youtube.com/watch?v=vpr58zJSJKc |
+| Ц | [ц] | цу́кор | https://www.youtube.com/watch?v=u44eCjR2Oz8 |
+| Ч | [ч] | час | https://www.youtube.com/watch?v=UsJkbdsY2RA |
+| Ш | [ш] | шко́ла | https://www.youtube.com/watch?v=1D-6MIw3OXY |
+| Щ | [шч] | щу́ка | https://www.youtube.com/watch?v=QmBLieIuf6Q |
+| Ь | no sound | день | https://www.youtube.com/watch?v=cJlal8XKBxo |
+| Ю | [йу] | ю́шка | https://www.youtube.com/watch?v=9JdIBYCTWGw |
+| Я | [йа] | я́блуко | https://www.youtube.com/watch?v=yhSAf41LX8I |
+
+### Алфавітний повтор
+
+<WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "банду́ра"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лис"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "піт"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Алфавітний повтор" />
+
+## Приві́т: first greeting chunks
+
+Use these as whole chunks first. Grammar can wait.
+
+| Ukrainian | English support |
 | --- | --- |
-| **за́мок** | castle |
-| **замо́к** | lock |
-| **бра́ти** | brothers |
-| **брати́** | to take |
+| **Приві́т!** | Hi! |
+| **До́брий день!** | Hello / good day |
+| **До́брого ра́нку!** | Good morning |
+| **До́брий ве́чір!** | Good evening |
+| **До поба́чення!** | Goodbye |
+| **На все до́бре!** | All the best |
 
-For this course, new Ukrainian words usually show stress so you know what to say aloud.
+Now add one short exchange:
 
-## Euphony: У/В and І/Й
+<DialogueBox uk="Приві́т!" en="Hi!" />
+<DialogueBox uk="Як спра́ви?" en="How are you?" />
+<DialogueBox uk="До́бре." en="Fine." />
+<DialogueBox uk="А у тебе́?" en="And you?" />
 
-Ukrainian likes smooth sound flow. This is called **милозву́чність**. At A1, you only need to recognize two common pairs:
+Use **А у тебе́?** after **Як спра́ви?**. For a name exchange, use
+**А тебе́?**
 
-| Pair | Beginner idea |
+<DialogueBox uk="Як тебе́ зва́ти?" en="What is your name?" />
+<DialogueBox uk="Мене́ зва́ти Анна." en="My name is Anna." />
+<DialogueBox uk="А тебе́?" en="And you?" />
+
+Two ready phrases also show speaker gender:
+
+| Speaker | Phrase |
 | --- | --- |
-| **у / в** | Ukrainian may choose the smoother one for the sounds around it |
-| **і / й** | Ukrainian may choose the smoother one for the sounds around it |
+| man | **Радий тебе́ бачити.** |
+| woman | **Рада тебе́ бачити.** |
 
-You do not need to choose them alone yet. Just notice the idea: Ukrainian often avoids heavy sound piles.
+### Short dialogue
 
-## Your First Conversation
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Приві́т! ___ спра́ви?", "answer": "Як", "options": ["Як", "Що", "Де"]}, {"sentence": "До́бре. ___ у тебе́?", "answer": "А", "options": ["А", "На", "У"]}, {"sentence": "Як тебе́ зва́ти? Мене́ зва́ти Анна. ___?", "answer": "А тебе́", "options": ["А тебе́", "А у тебе́", "А тобі́"]}, {"sentence": "___ тебе́ бачити! (woman speaker)", "answer": "Рада", "options": ["Рада", "Радий", "Раді"]}, {"sentence": "___ тебе́ бачити! (man speaker)", "answer": "Радий", "options": ["Радий", "Рада", "Раді"]}]`)} />
 
-Learn these as whole phrases.
+## First-month habits
 
-| Ukrainian | English | Use |
-| --- | --- | --- |
-| **Приві́т!** | Hi! | informal |
-| **До́брий день!** | Hello! / Good day! | neutral |
-| **До́брого ра́нку!** | Good morning! | morning |
-| **До́брий ве́чір!** | Good evening! | evening |
-| **Як спра́ви?** | How are you? | friendly |
-| **До́бре.** | Fine. | simple answer |
-| **Чудо́во.** | Great. | positive answer |
-| **Норма́льно.** | Okay. | neutral answer |
-| **А у тебе́?** | And you? | after **Як спра́ви?** |
-| **Як тебе́ зва́ти?** | What is your name? | informal |
-| **Ме́не зва́ти Анна.** | My name is Anna. | name answer |
-| **А тебе́?** | And you? | after a name question |
-| **До поба́чення!** | Goodbye! | leaving |
-| **На все до́бре!** | All the best! | friendly goodbye |
+Keep this module small and clean:
 
-Read the dialogue. Then say it aloud twice: once as Anna, once as Marko.
+1. Keep **о** clear in **молоко́**.
+2. Hear the difference between **и** and **і** in **Приві́т**.
+3. Remember that **Ь** has no sound of its own.
+4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole chunks.
 
-<DialogueBox uk="А́нна: Приві́т!" en="Anna: Hi!" />
-<DialogueBox uk="Марко́: Приві́т!" en="Marko: Hi!" />
-<DialogueBox uk="А́нна: Як спра́ви?" en="Anna: How are you?" />
-<DialogueBox uk="Марко́: До́бре. А у тебе́?" en="Marko: Fine. And you?" />
-<DialogueBox uk="А́нна: Чудо́во." en="Anna: Great." />
+End with one reliable line:
 
-Now read the name exchange.
-
-<DialogueBox uk="Марко́: Як тебе́ зва́ти?" en="Marko: What is your name?" />
-<DialogueBox uk="Софія: Ме́не зва́ти Софія. А тебе́?" en="Sofia: My name is Sofia. And you?" />
-<DialogueBox uk="Марко́: Ме́не зва́ти Марко́." en="Marko: My name is Marko." />
-
-Use **А у тебе́?** after **Як спра́ви?** because you are asking about the other person's state. Use **А тебе́?** after **Як тебе́ зва́ти?** because you are asking for the other person's name.
-
-You may also hear:
-
-| Ukrainian | English | Who says it? |
-| --- | --- | --- |
-| **Радий тебе бачити.** | Glad to see you. | a male speaker |
-| **Рада тебе бачити.** | Glad to see you. | a female speaker |
-
-Do not build grammar from this yet. Just notice that Ukrainian sometimes changes a word depending on who is speaking: use **Радий тебе бачити** if the speaker is male, and **Рада тебе бачити** if the speaker is female.
-
-The word **Привіт** is useful for your first tiny sound analysis down to the details (**на гвинтики**): **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
-
-### First conversations
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "____! Як спра́ви?", "answer": "Приві́т", "options": ["Приві́т", "Молоко́", "Лі́тера"]}, {"sentence": "____. А у тебе́?", "answer": "До́бре", "options": ["До́бре", "День", "Звук"]}, {"sentence": "Як тебе́ ____?", "answer": "зва́ти", "options": ["зва́ти", "до́бре", "день"]}, {"sentence": "Ме́не ____ Анна.", "answer": "зва́ти", "options": ["зва́ти", "спра́ви", "звук"]}, {"sentence": "До ____!", "answer": "поба́чення", "options": ["поба́чення", "тебе́", "ма́ма"]}, {"sentence": "На все ____!", "answer": "до́бре", "options": ["до́бре", "лі́тера", "звук"]}]`)} />
-
-## First Pronunciation Traps
-
-Use these as safety checks:
-
-| Trap | Safer habit |
-| --- | --- |
-| Blurring **о** in **молоко́** | Keep every **о** clean: **мо-ло-ко́** |
-| Mixing **и** and **і** | In **Приві́т**, **и** and **і** are different |
-| Pronouncing **ь** as a separate sound | In **день**, **ь** only softens **н** |
-| Saying final voiced consonants as voiceless | Keep the written voiced sound; do not automatically devoice it |
-| Treating **Ї** like **І** | **Ї** is **[йі]** |
-| Mixing **Г** and **Ґ** | **Г** is h-like; **Ґ** is hard **g** |
-
-Keep Ukrainian sound categories independent. Do not use another language as the shortcut for **И**, **Е**, **О**, or **Г**. Use the Ukrainian mouth model here: **И** has its own position, unstressed **О** stays **О**, **Добрий день** is the neutral greeting, **Привіт** is the everyday informal greeting, and **Г** is the Ukrainian h-like sound.
-
-### Pronunciation safety check
-
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "In молоко́, every о stays clean.", "isTrue": true, "explanation": "Ukrainian о does not blur into а in this beginner model."}, {"statement": "The letters и and і always sound the same.", "isTrue": false, "explanation": "Приві́т contains both [и] and [і]."}, {"statement": "Ь has no sound of its own.", "isTrue": true, "explanation": "Ь softens the previous consonant."}, {"statement": "Ї is always [йі].", "isTrue": true, "explanation": "Treat Ї as [йі] at this level."}, {"statement": "Г and Ґ are the same letter.", "isTrue": false, "explanation": "Г is h-like; Ґ is hard g."}, {"statement": "Щ is [шч].", "isTrue": true, "explanation": "Щ represents two sounds together."}]`)} />
-
-## Textbook Check
-
-Before you leave the lesson tab, check that you can do these things:
-
-- Point to **Приві́т** and say "Hi."
-- Point to **До поба́чення** and say "Goodbye."
-- Answer **Як спра́ви?** with **До́бре**, **Чудо́во**, or **Норма́льно**.
-- Say whether **звук** means "sound" or "letter."
-- Say whether **лі́тера** means "sound" or "letter."
-- Explain **склад** in English.
-- Count the vowel sounds in **Приві́т**.
-- Recognize **Г**, **Ґ**, **Ї**, and **Ь** when the workbook asks for them.
-
-The workbook repeats the same ideas in different ways. It is practice for eyes, ears, and mouth.
+**Приві́т! Як тебе́ зва́ти? Мене́ зва́ти Анна. А тебе́?**
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"звук","translation":"sound","pos":"noun","example":"Це звук [а].","examples":["sound","Це звук [а]."]},{"word":"лі́тера","translation":"letter","pos":"noun","example":"Це лі́тера П.","examples":["letter","Це лі́тера П."]},{"word":"абе́тка","translation":"alphabet","pos":"noun","example":"Украї́нська абе́тка має 33 лі́тери.","examples":["alphabet","Украї́нська абе́тка має 33 лі́тери."]},{"word":"голосни́й звук","translation":"vowel sound","pos":"noun phrase","example":"[а] - голосни́й звук.","examples":["vowel sound","[а] - голосни́й звук."]},{"word":"при́голосний звук","translation":"consonant sound","pos":"noun phrase","example":"[п] - при́голосний звук.","examples":["consonant sound","[п] - при́голосний звук."]},{"word":"склад","translation":"syllable","pos":"noun","example":"У сло́ві ма́ма два склади́.","examples":["syllable","У сло́ві ма́ма два склади́."]},{"word":"на́голос","translation":"stress","pos":"noun","example":"У сло́ві Приві́т на́голос на і.","examples":["stress","У сло́ві Приві́т на́голос на і."]},{"word":"м'яки́й знак","translation":"soft sign","pos":"noun phrase","example":"Ь - м'яки́й знак.","examples":["soft sign","Ь - м'яки́й знак."]},{"word":"апо́строф","translation":"apostrophe","pos":"noun","example":"У сло́ві «ім'я́» є апо́строф.","examples":["apostrophe","У сло́ві «ім'я́» є апо́строф."]},{"word":"Приві́т","translation":"Hi","pos":"phrase","example":"Приві́т!","examples":["Hi","Приві́т!"]},{"word":"До́брий день","translation":"Hello / Good day","pos":"phrase","example":"До́брий день!","examples":["Hello / Good day","До́брий день!"]},{"word":"До́брого ра́нку","translation":"Good morning","pos":"phrase","example":"До́брого ра́нку!","examples":["Good morning","До́брого ра́нку!"]},{"word":"До́брий ве́чір","translation":"Good evening","pos":"phrase","example":"До́брий ве́чір!","examples":["Good evening","До́брий ве́чір!"]},{"word":"Як спра́ви?","translation":"How are you?","pos":"phrase","example":"Як спра́ви?","examples":["How are you?","Як спра́ви?"]},{"word":"До́бре","translation":"Fine / good","pos":"phrase","example":"До́бре.","examples":["Fine / good","До́бре."]},{"word":"Чудо́во","translation":"Great / wonderful","pos":"phrase","example":"Чудо́во.","examples":["Great / wonderful","Чудо́во."]},{"word":"Норма́льно","translation":"Okay / normal","pos":"phrase","example":"Норма́льно.","examples":["Okay / normal","Норма́льно."]},{"word":"А у тебе́?","translation":"And you? (after How are you?)","pos":"phrase","example":"До́бре. А у тебе́?","examples":["And you? (after How are you?)","До́бре. А у тебе́?"]},{"word":"Як тебе́ зва́ти?","translation":"What is your name?","pos":"phrase","example":"Як тебе́ зва́ти?","examples":["What is your name?","Як тебе́ зва́ти?"]},{"word":"Ме́не зва́ти ...","translation":"My name is ...","pos":"phrase","example":"Ме́не зва́ти Анна.","examples":["My name is ...","Ме́не зва́ти Анна."]},{"word":"А тебе́?","translation":"And you? (after a name question)","pos":"phrase","example":"Ме́не зва́ти Софія. А тебе́?","examples":["And you? (after a name question)","Ме́не зва́ти Софія. А тебе́?"]},{"word":"До поба́чення","translation":"Goodbye","pos":"phrase","example":"До поба́чення!","examples":["Goodbye","До поба́чення!"]},{"word":"На все до́бре","translation":"All the best","pos":"phrase","example":"На все до́бре!","examples":["All the best","На все до́бре!"]},{"word":"Ра́дий тебе́ ба́чити","translation":"Glad to see you (male speaker)","pos":"phrase","example":"Ра́дий тебе́ ба́чити.","examples":["Glad to see you (male speaker)","Ра́дий тебе́ ба́чити."]},{"word":"Ра́да тебе́ ба́чити","translation":"Glad to see you (female speaker)","pos":"phrase","example":"Ра́да тебе́ ба́чити.","examples":["Glad to see you (female speaker)","Ра́да тебе́ ба́чити."]},{"word":"ма́ма","translation":"mother","pos":"noun","example":"Ма́ма.","examples":["mother","Ма́ма."]},{"word":"та́то","translation":"father","pos":"noun","example":"Та́то.","examples":["father","Та́то."]},{"word":"молоко́","translation":"milk","pos":"noun","example":"Молоко́.","examples":["milk","Молоко́."]},{"word":"о́ко","translation":"eye","pos":"noun","example":"О́ко.","examples":["eye","О́ко."]},{"word":"дім","translation":"house / home","pos":"noun","example":"Дім.","examples":["house / home","Дім."]},{"word":"ніс","translation":"nose","pos":"noun","example":"Ніс.","examples":["nose","Ніс."]},{"word":"сон","translation":"sleep / dream","pos":"noun","example":"Сон.","examples":["sleep / dream","Сон."]}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"звук","translation":"sound","pos":"noun","example":"Усе починається зі звука.","examples":["sound","Усе починається зі звука."]},{"word":"лі́тера","translation":"letter","pos":"noun","example":"Лі́тера показує, як звук записати.","examples":["letter","Лі́тера показує, як звук записати."]},{"word":"абе́тка","translation":"alphabet","pos":"noun","example":"Украї́нська абе́тка має 33 лі́тери.","examples":["alphabet","Украї́нська абе́тка має 33 лі́тери."]},{"word":"голосни́й звук","translation":"vowel sound","pos":"noun phrase","example":"А — голосни́й звук.","examples":["vowel sound","А — голосни́й звук."]},{"word":"при́голосний звук","translation":"consonant sound","pos":"noun phrase","example":"П — при́голосний звук.","examples":["consonant sound","П — при́голосний звук."]},{"word":"склад","translation":"syllable","pos":"noun","example":"Ма́ма має два склади.","examples":["syllable","Ма́ма має два склади."]},{"word":"на́голос","translation":"stress","pos":"noun","example":"У слові Приві́т наголос на «ві́т».","examples":["stress","У слові Приві́т наголос на «ві́т»."]},{"word":"м'яки́й знак","translation":"soft sign","pos":"noun phrase","example":"У слові день м'яки́й знак пом'якшує [н].","examples":["soft sign","У слові день м'яки́й знак пом'якшує [н]."]},{"word":"Приві́т","translation":"hi","pos":"phrase","example":"Приві́т! Як тебе́ зва́ти?","examples":["hi","Приві́т! Як тебе́ зва́ти?"]},{"word":"До́брий день","translation":"hello","pos":"phrase","example":"До́брий день, Марко.","examples":["hello","До́брий день, Марко."]},{"word":"До́брого ра́нку","translation":"good morning","pos":"phrase","example":"До́брого ра́нку, пане Іване.","examples":["good morning","До́брого ра́нку, пане Іване."]},{"word":"До́брий ве́чір","translation":"good evening","pos":"phrase","example":"До́брий ве́чір! Ласкаво просимо.","examples":["good evening","До́брий ве́чір! Ласкаво просимо."]},{"word":"До поба́чення","translation":"goodbye","pos":"phrase","example":"До поба́чення! До зустрічі.","examples":["goodbye","До поба́чення! До зустрічі."]},{"word":"На все до́бре","translation":"all the best","pos":"phrase","example":"На все до́бре, Маріє.","examples":["all the best","На все до́бре, Маріє."]},{"word":"Як спра́ви","translation":"how are you","pos":"phrase","example":"Як спра́ви?","examples":["how are you","Як спра́ви?"]},{"word":"До́бре","translation":"fine","pos":"adverb","example":"До́бре. Дякую.","examples":["fine","До́бре. Дякую."]},{"word":"Чудо́во","translation":"great","pos":"adjective","example":"Чудо́во! Мені дуже приємно.","examples":["great","Чудо́во! Мені дуже приємно."]},{"word":"Норма́льно","translation":"okay","pos":"adverb","example":"Норма́льно. А в тебе?","examples":["okay","Норма́льно. А в тебе?"]},{"word":"А у тебе́","translation":"and you","pos":"phrase","example":"Як спра́ви? До́бре. А у тебе́?","examples":["and you","Як спра́ви? До́бре. А у тебе́?"]},{"word":"Як тебе́ зва́ти","translation":"what's your name","pos":"phrase","example":"Як тебе́ зва́ти?","examples":["what's your name","Як тебе́ зва́ти?"]},{"word":"Мене́ зва́ти","translation":"my name is","pos":"phrase","example":"Мене́ зва́ти Анна.","examples":["my name is","Мене́ зва́ти Анна."]},{"word":"А тебе́","translation":"and you","pos":"phrase","example":"Як тебе́ зва́ти? А тебе́?","examples":["and you","Як тебе́ зва́ти? А тебе́?"]},{"word":"Радий тебе́ бачити","translation":"glad to see you (masculine)","pos":"phrase","example":"Радий тебе́ бачити.","examples":["glad to see you (masculine)","Радий тебе́ бачити."]},{"word":"Рада тебе́ бачити","translation":"glad to see you (feminine)","pos":"phrase","example":"Рада тебе́ бачити.","examples":["glad to see you (feminine)","Рада тебе́ бачити."]},{"word":"ма́ма","translation":"mom/mother","pos":"noun","example":"Ма́ма.","examples":["mom/mother","Ма́ма."]},{"word":"та́то","translation":"dad","pos":"noun","example":"Та́то.","examples":["dad","Та́то."]},{"word":"молоко́","translation":"milk","pos":"noun","example":"Молоко́.","examples":["milk","Молоко́."]},{"word":"о́ко","translation":"eye","pos":"noun","example":"О́ко.","examples":["eye","О́ко."]},{"word":"дім","translation":"home","pos":"noun","example":"Дім.","examples":["home","Дім."]},{"word":"ніс","translation":"nose","pos":"noun","example":"Ніс.","examples":["nose","Ніс."]},{"word":"сон","translation":"sleep/dream","pos":"noun","example":"Сон.","examples":["sleep/dream","Сон."]},{"word":"день","translation":"day","pos":"noun","example":"Сьогодні день.","examples":["day","Сьогодні день."]},{"word":"вода́","translation":"water","pos":"noun","example":"Вода́.","examples":["water","Вода́."]}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"звук","back":"sound"},{"front":"лі́тера","back":"letter"},{"front":"абе́тка","back":"alphabet"},{"front":"голосни́й звук","back":"vowel sound"},{"front":"при́голосний звук","back":"consonant sound"},{"front":"склад","back":"syllable"},{"front":"на́голос","back":"stress"},{"front":"м'яки́й знак","back":"soft sign"},{"front":"апо́строф","back":"apostrophe"},{"front":"Приві́т","back":"Hi"},{"front":"До́брий день","back":"Hello / Good day"},{"front":"До́брого ра́нку","back":"Good morning"},{"front":"До́брий ве́чір","back":"Good evening"},{"front":"Як спра́ви?","back":"How are you?"},{"front":"До́бре","back":"Fine / good"},{"front":"Чудо́во","back":"Great / wonderful"},{"front":"Норма́льно","back":"Okay / normal"},{"front":"А у тебе́?","back":"And you? (after How are you?)"},{"front":"Як тебе́ зва́ти?","back":"What is your name?"},{"front":"Ме́не зва́ти ...","back":"My name is ..."},{"front":"А тебе́?","back":"And you? (after a name question)"},{"front":"До поба́чення","back":"Goodbye"},{"front":"На все до́бре","back":"All the best"},{"front":"Ра́дий тебе́ ба́чити","back":"Glad to see you (male speaker)"},{"front":"Ра́да тебе́ ба́чити","back":"Glad to see you (female speaker)"},{"front":"ма́ма","back":"mother"},{"front":"та́то","back":"father"},{"front":"молоко́","back":"milk"},{"front":"о́ко","back":"eye"},{"front":"дім","back":"house / home"},{"front":"ніс","back":"nose"},{"front":"сон","back":"sleep / dream"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"звук","back":"sound"},{"front":"лі́тера","back":"letter"},{"front":"абе́тка","back":"alphabet"},{"front":"голосни́й звук","back":"vowel sound"},{"front":"при́голосний звук","back":"consonant sound"},{"front":"склад","back":"syllable"},{"front":"на́голос","back":"stress"},{"front":"м'яки́й знак","back":"soft sign"},{"front":"Приві́т","back":"hi"},{"front":"До́брий день","back":"hello"},{"front":"До́брого ра́нку","back":"good morning"},{"front":"До́брий ве́чір","back":"good evening"},{"front":"До поба́чення","back":"goodbye"},{"front":"На все до́бре","back":"all the best"},{"front":"Як спра́ви","back":"how are you"},{"front":"До́бре","back":"fine"},{"front":"Чудо́во","back":"great"},{"front":"Норма́льно","back":"okay"},{"front":"А у тебе́","back":"and you"},{"front":"Як тебе́ зва́ти","back":"what's your name"},{"front":"Мене́ зва́ти","back":"my name is"},{"front":"А тебе́","back":"and you"},{"front":"Радий тебе́ бачити","back":"glad to see you (masculine)"},{"front":"Рада тебе́ бачити","back":"glad to see you (feminine)"},{"front":"ма́ма","back":"mom/mother"},{"front":"та́то","back":"dad"},{"front":"молоко́","back":"milk"},{"front":"о́ко","back":"eye"},{"front":"дім","back":"home"},{"front":"ніс","back":"nose"},{"front":"сон","back":"sleep/dream"},{"front":"день","back":"day"},{"front":"вода́","back":"water"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
 
-### Sound or letter?
+### Sound or letter
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "What is a звук?", "options": [{"text": "A sound you hear and say", "correct": true}, {"text": "A letter you see and write", "correct": false}, {"text": "A whole sentence", "correct": false}], "explanation": "A звук belongs to hearing and speaking."}, {"question": "What is a лі́тера?", "options": [{"text": "A letter you see and write", "correct": true}, {"text": "A sound you hear and say", "correct": false}, {"text": "A greeting", "correct": false}], "explanation": "A лі́тера belongs to reading and writing."}, {"question": "How many letters are in the Ukrainian alphabet?", "options": [{"text": "33", "correct": true}, {"text": "38", "correct": false}, {"text": "6", "correct": false}], "explanation": "Ukrainian has 33 letters."}, {"question": "How many basic Ukrainian vowel sounds are there?", "options": [{"text": "6", "correct": true}, {"text": "10", "correct": false}, {"text": "33", "correct": false}], "explanation": "The six basic vowel sounds are [а], [о], [у], [е], [и], [і]."}, {"question": "Does ь have its own sound?", "options": [{"text": "No", "correct": true}, {"text": "Yes", "correct": false}, {"text": "Only in Приві́т", "correct": false}], "explanation": "The soft sign ь has no sound of its own."}, {"question": "What does Приві́т mean?", "options": [{"text": "Hi", "correct": true}, {"text": "Goodbye", "correct": false}, {"text": "Milk", "correct": false}], "explanation": "Приві́т is the informal word for Hi."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "What do we hear and pronounce?", "options": [{"text": "лі́тера", "correct": false}, {"text": "Звук", "correct": true}, {"text": "Слово", "correct": false}], "explanation": "Звук is what we hear and pronounce."}, {"question": "What do we see in writing?", "options": [{"text": "Звук", "correct": false}, {"text": "лі́тера", "correct": true}, {"text": "Вимова", "correct": false}], "explanation": "Лі́тера is the written sign."}, {"question": "How many letters are in the Ukrainian alphabet?", "options": [{"text": "38", "correct": false}, {"text": "33", "correct": true}, {"text": "6", "correct": false}], "explanation": "The standard Ukrainian alphabet has 33 letters."}, {"question": "Why can 33 letters point to more sounds?", "options": [{"text": "Some letters have more than one job", "correct": true}, {"text": "English spelling changes Ukrainian sounds", "correct": false}, {"text": "Every letter is silent", "correct": false}], "explanation": "Some Ukrainian letters can point to more than one sound or modify a nearby sound."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "А", "correct": false}, {"text": "Ь", "correct": true}, {"text": "О", "correct": false}], "explanation": "Ь has no sound of its own."}, {"question": "Which word has three vowel sounds?", "options": [{"text": "Приві́т", "correct": false}, {"text": "молоко́", "correct": true}, {"text": "Мов", "correct": false}], "explanation": "Молоко́ has three vowel sounds, о + о + о."}]`)} />
 
-### Count склади
+### Кількість складів
 
-<CountSyllables client:only='react' instruction={"Count vowel sounds. Each vowel sound makes one склад."} items={JSON.parse(`[{"word": "день", "correct": 1}, {"word": "ма́ма", "correct": 2}, {"word": "Приві́т", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "та́то", "correct": 2}, {"word": "о́ко", "correct": 2}]`)} />
+<CountSyllables client:only='react' instruction={"Рахуй голосні звуки в слові."} items={JSON.parse(`[{"word": "ма́ма", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "вода́", "correct": 2}, {"word": "приві́т", "correct": 2}, {"word": "о́ко", "correct": 2}, {"word": "та́то", "correct": 2}]`)} maxCount={3} />
 
-### Full alphabet video pass
+### Звук і літера
 
-<WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "бана́н"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лимо́н"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "пес"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Full alphabet video pass" />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "І", "right": "[і]"}, {"left": "В", "right": "[в]"}, {"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "Н", "right": "[н]"}, {"left": "Ч", "right": "[ч]"}, {"left": "Ь", "right": "softens the previous consonant"}, {"left": "Я", "right": "[йа] or softens the previous consonant"}, {"left": "Ї", "right": "[йі]"}, {"left": "Щ", "right": "[шч]"}, {"left": "Д", "right": "[д]"}]`)} />
 
-### Find the useful letters
+### Алфавітний повтор
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Which letter is the hard g sound?", "options": [{"text": "Ґ", "correct": true}, {"text": "Г", "correct": false}, {"text": "Ї", "correct": false}], "explanation": "Ґ is the hard g sound; Г is the Ukrainian h-like sound."}, {"question": "Which letter is always [йі]?", "options": [{"text": "Ї", "correct": true}, {"text": "І", "correct": false}, {"text": "И", "correct": false}], "explanation": "Ї is always [йі]. І is the plain [і] vowel."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "Ь", "correct": true}, {"text": "Й", "correct": false}, {"text": "Я", "correct": false}], "explanation": "Ь is the soft sign; it changes the previous consonant."}, {"question": "Which letter is the clean [о] sound in молоко́?", "options": [{"text": "О", "correct": true}, {"text": "А", "correct": false}, {"text": "У", "correct": false}], "explanation": "Ukrainian О stays clean in молоко́."}, {"question": "In Приві́т, which two vowel letters are different?", "options": [{"text": "И and І", "correct": true}, {"text": "О and У", "correct": false}, {"text": "А and Е", "correct": false}], "explanation": "Приві́т contains both И [и] and І [і]."}]`)} />
+<WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "банду́ра"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лис"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "піт"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Алфавітний повтор" />
 
-### First conversations
+### Short dialogue
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "____! Як спра́ви?", "answer": "Приві́т", "options": ["Приві́т", "Молоко́", "Лі́тера"]}, {"sentence": "____. А у тебе́?", "answer": "До́бре", "options": ["До́бре", "День", "Звук"]}, {"sentence": "Як тебе́ ____?", "answer": "зва́ти", "options": ["зва́ти", "до́бре", "день"]}, {"sentence": "Ме́не ____ Анна.", "answer": "зва́ти", "options": ["зва́ти", "спра́ви", "звук"]}, {"sentence": "До ____!", "answer": "поба́чення", "options": ["поба́чення", "тебе́", "ма́ма"]}, {"sentence": "На все ____!", "answer": "до́бре", "options": ["до́бре", "лі́тера", "звук"]}]`)} />
-
-### Pronunciation safety check
-
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "In молоко́, every о stays clean.", "isTrue": true, "explanation": "Ukrainian о does not blur into а in this beginner model."}, {"statement": "The letters и and і always sound the same.", "isTrue": false, "explanation": "Приві́т contains both [и] and [і]."}, {"statement": "Ь has no sound of its own.", "isTrue": true, "explanation": "Ь softens the previous consonant."}, {"statement": "Ї is always [йі].", "isTrue": true, "explanation": "Treat Ї as [йі] at this level."}, {"statement": "Г and Ґ are the same letter.", "isTrue": false, "explanation": "Г is h-like; Ґ is hard g."}, {"statement": "Щ is [шч].", "isTrue": true, "explanation": "Щ represents two sounds together."}]`)} />
-
-### Vowel or consonant sound?
-
-<GroupSort client:only='react' groups={JSON.parse(`{"Vowel sounds": ["[а]", "[о]", "[у]", "[е]", "[и]", "[і]"], "Consonant sounds": ["[п]", "[р]", "[в]", "[т]", "[м]", "[н]", "[к]", "[с]"]}`)} />
-
-### See a letter, hear a sound
-
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "М", "right": "[м]"}, {"left": "Н", "right": "[н]"}, {"left": "Г", "right": "h-like [г]"}, {"left": "Ґ", "right": "hard [g]"}, {"left": "Ї", "right": "[йі]"}, {"left": "Ь", "right": "no sound"}]`)} />
-
-### Phrase meanings
-
-<Translate client:only='react' questions={JSON.parse(`[{"source": "Приві́т!", "options": [{"text": "Hi!", "correct": true}, {"text": "Goodbye!", "correct": false}, {"text": "What is your name?", "correct": false}], "explanation": "Приві́т is the informal everyday greeting."}, {"source": "До́брий день!", "options": [{"text": "Hello! / Good day!", "correct": true}, {"text": "Milk!", "correct": false}, {"text": "And you?", "correct": false}], "explanation": "До́брий день is the neutral daytime greeting."}, {"source": "Доброго ра́нку!", "options": [{"text": "Good morning!", "correct": true}, {"text": "Good evening!", "correct": false}, {"text": "My name is Anna.", "correct": false}], "explanation": "Ра́нок means morning, so Доброго ра́нку is Good morning."}, {"source": "До́брий ве́чір!", "options": [{"text": "Good evening!", "correct": true}, {"text": "Good morning!", "correct": false}, {"text": "Fine.", "correct": false}], "explanation": "Ве́чір means evening, so До́брий ве́чір is Good evening."}, {"source": "Як спра́ви?", "options": [{"text": "How are you?", "correct": true}, {"text": "Goodbye!", "correct": false}, {"text": "Letter", "correct": false}], "explanation": "Як спра́ви? asks how someone is doing."}, {"source": "До поба́чення!", "options": [{"text": "Goodbye!", "correct": true}, {"text": "Hi!", "correct": false}, {"text": "Sound", "correct": false}], "explanation": "До поба́чення is the leaving phrase Goodbye."}, {"source": "Ра́да тебе́ ба́чити.", "options": [{"text": "Glad to see you. (female speaker)", "correct": true}, {"text": "What is your name?", "correct": false}, {"text": "Good evening!", "correct": false}], "explanation": "Ра́да is the form a female speaker uses in this phrase."}]`)} />
-
-### Pronunciation traps
-
-<ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian habit." items={JSON.parse(`[{"sentence": "Do not call А, О, У голосними літерами.", "errorWord": "голосними літерами", "correctForm": "літерами, що позначають голосні звуки", "options": ["літерами, що позначають голосні звуки", "приголосними літерами"], "explanation": "Incorrect pattern: Називати літери «А», «О», «У» «голосними літерами» (vowel letters). Correct pattern: Називати їх винятково «літерами, що позначають голосні звуки» або просто говорити про «голосні звуки»."}, {"sentence": "Do not say м[а]локо for молоко.", "errorWord": "м[а]локо", "correctForm": "молоко", "options": ["молоко", "молоко́"], "explanation": "Incorrect pattern: Вимовляти ненаголошений [о] з наближенням до [а] (наприклад, казати м[а]локо замість молоко). Correct pattern: Завжди вимовляти [о] гранично чітко, без найменшого наближення до [а]: с[о́]л[о]дк[о] [S5]."}, {"sentence": "Do not add a tiny sound after день.", "errorWord": "add a tiny sound after день", "correctForm": "soften н, then stop", "options": ["soften н, then stop", "add і after нь"], "explanation": "Incorrect pattern: Намагатися артикулювати «Ь» (м'який знак) як окремий, хоч і короткий, звук (наприклад, як редуковане [і]). Correct pattern: Робити попередній приголосний звук м'яким під час вимови, не додаючи після нього жодного окремого звукового елемента (наприклад, у слові день [S11])."}, {"sentence": "Do not treat Ї as a softening letter.", "errorWord": "treat Ї as a softening letter", "correctForm": "read Ї as [йі]", "options": ["read Ї as [йі]", "read Ї as plain [і]"], "explanation": "Incorrect pattern: Сприймати літеру «Ї» як таку, що може використовуватися для пом'якшення попереднього приголосного (діючи за аналогією з «Я» чи «Ю»). Correct pattern: Неухильно читати «Ї» як повноцінні два звуки [йі], незалежно від того, в якій позиції у слові вона знаходиться [S11]."}, {"sentence": "Do not make one fixed glad phrase for every speaker.", "errorWord": "one fixed glad phrase", "correctForm": "Радий тебе бачити / Рада тебе бачити", "options": ["Радий тебе бачити / Рада тебе бачити", "Радий тебе бачити for everyone"], "explanation": "Incorrect pattern: Використовувати сталу, незмінну форму прикметника для привітання незалежно від своєї статі (наприклад, коли жінка механічно каже «Радий тебе бачити»). Correct pattern: Суворо узгоджувати прикметник із власною статтю: чоловік обов'язково каже «Радий тебе бачити», а жінка — «Рада тебе бачити» [S1], [S7]."}]`)} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Приві́т! ___ спра́ви?", "answer": "Як", "options": ["Як", "Що", "Де"]}, {"sentence": "До́бре. ___ у тебе́?", "answer": "А", "options": ["А", "На", "У"]}, {"sentence": "Як тебе́ зва́ти? Мене́ зва́ти Анна. ___?", "answer": "А тебе́", "options": ["А тебе́", "А у тебе́", "А тобі́"]}, {"sentence": "___ тебе́ бачити! (woman speaker)", "answer": "Рада", "options": ["Рада", "Радий", "Раді"]}, {"sentence": "___ тебе́ бачити! (man speaker)", "answer": "Радий", "options": ["Радий", "Рада", "Раді"]}]`)} />
 
 </TabItem>
 <TabItem label="Resources">
@@ -411,53 +292,53 @@ The workbook repeats the same ideas in different ways. It is practice for eyes, 
 
 **📚 Books:**
 - 📚 **Большакова, буквар 1 клас, p. 24**
-  голосні/приголосні через вірші; retrieved via search_text because plan notes include no literal chunk_id.
+  Vowel and consonant practice through short textbook verse.
 - 📚 **Заболотний 5 клас, p. 83**
-  «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо.»
+  Sound-letter distinction: «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо.»
 - 📚 **Захарійчук, буквар 1 клас (НУШ 2025), p. 13**
-  [•] голосний, [–] твердий приголосний, [=] м'який приголосний; resolved page context from corpus metadata.
+  Textbook symbols for vowel, hard consonant, and soft consonant sounds.
 - 📚 **Літвінова 5 клас, p. 130**
-  питання про «голосна літера» / «приголосна літера» and sound-letter distinction.
+  Questions about vowel/consonant terminology and the sound-letter distinction.
 
 **📺 Videos:**
-- 📺 [Anna Ohoiko — Letter А pronunciation](https://www.youtube.com/watch?v=hvB3VpcR3ZE) — Plan pronunciation video: А.
-- 📺 [Anna Ohoiko — Letter Б pronunciation](https://www.youtube.com/watch?v=V1hxBE_JbGg) — Plan pronunciation video: Б.
-- 📺 [Anna Ohoiko — Letter В pronunciation](https://www.youtube.com/watch?v=aFcvYfvQ2X4) — Plan pronunciation video: В.
-- 📺 [Anna Ohoiko — Letter Г pronunciation](https://www.youtube.com/watch?v=gVnclpSI0DU) — Plan pronunciation video: Г.
-- 📺 [Anna Ohoiko — Letter Д pronunciation](https://www.youtube.com/watch?v=g4Bh-lqzd48) — Plan pronunciation video: Д.
-- 📺 [Anna Ohoiko — Letter Е pronunciation](https://www.youtube.com/watch?v=KFlsroBW0dk) — Plan pronunciation video: Е.
-- 📺 [Anna Ohoiko — Letter Ж pronunciation](https://www.youtube.com/watch?v=dIrGVcqPwqM) — Plan pronunciation video: Ж.
-- 📺 [Anna Ohoiko — Letter З pronunciation](https://www.youtube.com/watch?v=BhASNxitC1A) — Plan pronunciation video: З.
-- 📺 [Anna Ohoiko — Letter И pronunciation](https://www.youtube.com/watch?v=W-1rCu0indE) — Plan pronunciation video: И.
-- 📺 [Anna Ohoiko — Letter Й pronunciation](https://www.youtube.com/watch?v=aq0cjB90s3w) — Plan pronunciation video: Й.
-- 📺 [Anna Ohoiko — Letter К pronunciation](https://www.youtube.com/watch?v=J7sGEI4-xJo) — Plan pronunciation video: К.
-- 📺 [Anna Ohoiko — Letter Л pronunciation](https://www.youtube.com/watch?v=v6-3Xg52Buk) — Plan pronunciation video: Л.
-- 📺 [Anna Ohoiko — Letter М pronunciation](https://www.youtube.com/watch?v=Ez95H4ibuJo) — Plan pronunciation video: М.
-- 📺 [Anna Ohoiko — Letter Н pronunciation](https://www.youtube.com/watch?v=vNUfiKHPYaU) — Plan pronunciation video: Н.
-- 📺 [Anna Ohoiko — Letter О pronunciation](https://www.youtube.com/watch?v=gJFxRIPRZbI) — Activity pronunciation video: О; the locked plan currently has no separate О URL, but the workbook includes the stored course reference.
-- 📺 [Anna Ohoiko — Letter П pronunciation](https://www.youtube.com/watch?v=JksSjjxyW5Y) — Plan pronunciation video: П.
-- 📺 [Anna Ohoiko — Letter Р pronunciation](https://www.youtube.com/watch?v=fMGsQ5KPQgg) — Plan pronunciation video: Р.
-- 📺 [Anna Ohoiko — Letter С pronunciation](https://www.youtube.com/watch?v=7UsFBgSL91E) — Plan pronunciation video: С.
-- 📺 [Anna Ohoiko — Letter Т pronunciation](https://www.youtube.com/watch?v=m-jcLR_gK0k) — Plan pronunciation video: Т.
-- 📺 [Anna Ohoiko — Letter У pronunciation](https://www.youtube.com/watch?v=VB1O6PmtYRU) — Plan pronunciation video: У.
-- 📺 [Anna Ohoiko — Letter Ф pronunciation](https://www.youtube.com/watch?v=haHRsFFZRQI) — Plan pronunciation video: Ф.
-- 📺 [Anna Ohoiko — Letter Х pronunciation](https://www.youtube.com/watch?v=vpr58zJSJKc) — Plan pronunciation video: Х.
-- 📺 [Anna Ohoiko — Letter Ц pronunciation](https://www.youtube.com/watch?v=u44eCjR2Oz8) — Plan pronunciation video: Ц.
-- 📺 [Anna Ohoiko — Letter Ч pronunciation](https://www.youtube.com/watch?v=UsJkbdsY2RA) — Plan pronunciation video: Ч.
-- 📺 [Anna Ohoiko — Letter Ш pronunciation](https://www.youtube.com/watch?v=1D-6MIw3OXY) — Plan pronunciation video: Ш.
-- 📺 [Anna Ohoiko — Letter Щ pronunciation](https://www.youtube.com/watch?v=QmBLieIuf6Q) — Plan pronunciation video: Щ.
-- 📺 [Anna Ohoiko — Letter Ь pronunciation](https://www.youtube.com/watch?v=cJlal8XKBxo) — Plan pronunciation video: Ь.
-- 📺 [Anna Ohoiko — Letter Ю pronunciation](https://www.youtube.com/watch?v=9JdIBYCTWGw) — Plan pronunciation video: Ю.
-- 📺 [Anna Ohoiko — Letter Я pronunciation](https://www.youtube.com/watch?v=yhSAf41LX8I) — Plan pronunciation video: Я.
-- 📺 [Anna Ohoiko — Letter Є pronunciation](https://www.youtube.com/watch?v=O0bwRyyBQSc) — Plan pronunciation video: Є.
-- 📺 [Anna Ohoiko — Letter І pronunciation](https://www.youtube.com/watch?v=Z9TH0H4ShGo) — Plan pronunciation video: І.
-- 📺 [Anna Ohoiko — Letter Ї pronunciation](https://www.youtube.com/watch?v=UcjdjQXhAY8) — Plan pronunciation video: Ї.
-- 📺 [Anna Ohoiko — Letter Ґ pronunciation](https://www.youtube.com/watch?v=gNjHqjTW9WQ) — Plan pronunciation video: Ґ.
-- 📺 [Anna Ohoiko — Ukrainian alphabet overview](https://www.youtube.com/watch?v=ksXIXj7CXwc) — Plan pronunciation video: overview for the full Ukrainian alphabet.
-- 📺 [Anna Ohoiko — Ukrainian alphabet pronunciation playlist](https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV) — Plan pronunciation video: playlist for per-letter Ukrainian pronunciation practice.
+- 📺 [Anna Ohoiko — Letter А pronunciation](https://www.youtube.com/watch?v=hvB3VpcR3ZE) — Pronunciation video: А.
+- 📺 [Anna Ohoiko — Letter Б pronunciation](https://www.youtube.com/watch?v=V1hxBE_JbGg) — Pronunciation video: Б.
+- 📺 [Anna Ohoiko — Letter В pronunciation](https://www.youtube.com/watch?v=aFcvYfvQ2X4) — Pronunciation video: В.
+- 📺 [Anna Ohoiko — Letter Г pronunciation](https://www.youtube.com/watch?v=gVnclpSI0DU) — Pronunciation video: Г.
+- 📺 [Anna Ohoiko — Letter Д pronunciation](https://www.youtube.com/watch?v=g4Bh-lqzd48) — Pronunciation video: Д.
+- 📺 [Anna Ohoiko — Letter Е pronunciation](https://www.youtube.com/watch?v=KFlsroBW0dk) — Pronunciation video: Е.
+- 📺 [Anna Ohoiko — Letter Ж pronunciation](https://www.youtube.com/watch?v=dIrGVcqPwqM) — Pronunciation video: Ж.
+- 📺 [Anna Ohoiko — Letter З pronunciation](https://www.youtube.com/watch?v=BhASNxitC1A) — Pronunciation video: З.
+- 📺 [Anna Ohoiko — Letter И pronunciation](https://www.youtube.com/watch?v=W-1rCu0indE) — Pronunciation video: И.
+- 📺 [Anna Ohoiko — Letter Й pronunciation](https://www.youtube.com/watch?v=aq0cjB90s3w) — Pronunciation video: Й.
+- 📺 [Anna Ohoiko — Letter К pronunciation](https://www.youtube.com/watch?v=J7sGEI4-xJo) — Pronunciation video: К.
+- 📺 [Anna Ohoiko — Letter Л pronunciation](https://www.youtube.com/watch?v=v6-3Xg52Buk) — Pronunciation video: Л.
+- 📺 [Anna Ohoiko — Letter М pronunciation](https://www.youtube.com/watch?v=Ez95H4ibuJo) — Pronunciation video: М.
+- 📺 [Anna Ohoiko — Letter Н pronunciation](https://www.youtube.com/watch?v=vNUfiKHPYaU) — Pronunciation video: Н.
+- 📺 [Anna Ohoiko — Letter О pronunciation](https://www.youtube.com/watch?v=gJFxRIPRZbI) — Pronunciation video: О.
+- 📺 [Anna Ohoiko — Letter П pronunciation](https://www.youtube.com/watch?v=JksSjjxyW5Y) — Pronunciation video: П.
+- 📺 [Anna Ohoiko — Letter Р pronunciation](https://www.youtube.com/watch?v=fMGsQ5KPQgg) — Pronunciation video: Р.
+- 📺 [Anna Ohoiko — Letter С pronunciation](https://www.youtube.com/watch?v=7UsFBgSL91E) — Pronunciation video: С.
+- 📺 [Anna Ohoiko — Letter Т pronunciation](https://www.youtube.com/watch?v=m-jcLR_gK0k) — Pronunciation video: Т.
+- 📺 [Anna Ohoiko — Letter У pronunciation](https://www.youtube.com/watch?v=VB1O6PmtYRU) — Pronunciation video: У.
+- 📺 [Anna Ohoiko — Letter Ф pronunciation](https://www.youtube.com/watch?v=haHRsFFZRQI) — Pronunciation video: Ф.
+- 📺 [Anna Ohoiko — Letter Х pronunciation](https://www.youtube.com/watch?v=vpr58zJSJKc) — Pronunciation video: Х.
+- 📺 [Anna Ohoiko — Letter Ц pronunciation](https://www.youtube.com/watch?v=u44eCjR2Oz8) — Pronunciation video: Ц.
+- 📺 [Anna Ohoiko — Letter Ч pronunciation](https://www.youtube.com/watch?v=UsJkbdsY2RA) — Pronunciation video: Ч.
+- 📺 [Anna Ohoiko — Letter Ш pronunciation](https://www.youtube.com/watch?v=1D-6MIw3OXY) — Pronunciation video: Ш.
+- 📺 [Anna Ohoiko — Letter Щ pronunciation](https://www.youtube.com/watch?v=QmBLieIuf6Q) — Pronunciation video: Щ.
+- 📺 [Anna Ohoiko — Letter Ь pronunciation](https://www.youtube.com/watch?v=cJlal8XKBxo) — Pronunciation video: Ь.
+- 📺 [Anna Ohoiko — Letter Ю pronunciation](https://www.youtube.com/watch?v=9JdIBYCTWGw) — Pronunciation video: Ю.
+- 📺 [Anna Ohoiko — Letter Я pronunciation](https://www.youtube.com/watch?v=yhSAf41LX8I) — Pronunciation video: Я.
+- 📺 [Anna Ohoiko — Letter Є pronunciation](https://www.youtube.com/watch?v=O0bwRyyBQSc) — Pronunciation video: Є.
+- 📺 [Anna Ohoiko — Letter І pronunciation](https://www.youtube.com/watch?v=Z9TH0H4ShGo) — Pronunciation video: І.
+- 📺 [Anna Ohoiko — Letter Ї pronunciation](https://www.youtube.com/watch?v=UcjdjQXhAY8) — Pronunciation video: Ї.
+- 📺 [Anna Ohoiko — Letter Ґ pronunciation](https://www.youtube.com/watch?v=gNjHqjTW9WQ) — Pronunciation video: Ґ.
+- 📺 [Anna Ohoiko — Ukrainian alphabet overview](https://www.youtube.com/watch?v=ksXIXj7CXwc) — Pronunciation video: overview for the full Ukrainian alphabet.
+- 📺 [Anna Ohoiko — Ukrainian alphabet pronunciation playlist](https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV) — Pronunciation video: playlist for per-letter Ukrainian pronunciation practice.
 
 **🎧 Audio:**
-- 🎧 [ULP Season 1, Episode 1 — Informal Greetings](https://www.ukrainianlessons.com/episode1/) — Привіт, Як справи?, response models; external search found ULP Episode 1 material.
+- 🎧 [ULP Season 1, Episode 1 — Informal Greetings](https://www.ukrainianlessons.com/episode1/) — Greeting and response models: Привіт, Як справи?, and short answers.
 :::
 
 </TabItem>


### PR DESCRIPTION
## Summary
- Teach `scripts/generate_mdx.py` to use folder-layout A1 modules (`<slug>/module.md` plus sibling `activities.yaml`, `vocabulary.yaml`, `resources.yaml`) so A1 M1 Starlight output no longer stays on stale flat-file content.
- Clean A1 M1 resource notes so learner-facing resources do not expose internal source/retrieval/locked-plan wording.
- Regenerate `starlight/src/content/docs/a1/sounds-letters-and-hello.mdx` from the corrected M1 source.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 1`
- YAML parse: `resources.yaml`, `activities.yaml`, `vocabulary.yaml`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/generate_mdx/core.py`
- `npx markdownlint-cli2 --no-globs starlight/src/content/docs/a1/sounds-letters-and-hello.mdx`
- `git diff --check`
- protected/generated diff grep: no matches
- rendered leak scan: no matches for internal source/locked-plan wording
- `npm run build --prefix starlight`
- Browser activity playtest on `http://127.0.0.1:4322/a1/sounds-letters-and-hello/`:
  - Lesson tab: quiz 6 correct, syllables `6 / 6`, match-up 24 matched tiles, watch-and-repeat iframe opened and navigated to `33 / 33`, fill-in 5 correct selects
  - Activities tab: same pass signals
  - console issues: none after filtering benign local/WebGL noise

X-Agent: codex/2777-m1-resource-note-qa
