### PR TITLE
fix(a1): preserve M1 nav while updating phrasing

### DIFF
--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
@@ -203,7 +203,7 @@
 - id: act-5
   type: fill-in
   title: Short dialogue
-  instruction: Choose the chunk that completes the first dialogue.
+  instruction: Choose the phrase that completes the first dialogue.
   items:
   - sentence: Приві́т! ___ спра́ви?
     answer: Як

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
@@ -8,7 +8,7 @@ Work in this order:
 1. hear a sound;
 2. see the letter;
 3. repeat a short word;
-4. use one greeting chunk.
+4. use one greeting phrase.
 
 You do not need long Ukrainian sentences yet. You need a few stable anchors:
 **звук**, **лі́тера**, **ма́ма**, **молоко́**, **Приві́т**, and
@@ -140,9 +140,9 @@ to master all 33 letters in one sitting. Repeat a small group, then add more.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-## Приві́т: first greeting chunks
+## Приві́т: first greeting phrases
 
-Use these as whole chunks first. Grammar can wait.
+Use these as whole phrases first. Grammar can wait.
 
 | Ukrainian | English support |
 | --- | --- |
@@ -183,7 +183,7 @@ Keep this module small and clean:
 1. Keep **о** clear in **молоко́**.
 2. Hear the difference between **и** and **і** in **Приві́т**.
 3. Remember that **Ь** has no sound of its own.
-4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole chunks.
+4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole phrases.
 
 End with one reliable line:
 

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -33,6 +33,8 @@ from .utils import CURRICULUM_DIR, PROJECT_ROOT, SCRIPT_DIR, STARLIGHT_DOCS_DIR,
 # Ensure scripts/ is on sys.path for sibling imports
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from manifest_utils import CORE_LEVELS, TRACKS, Module, get_modules_for_level
 from slug_utils import to_bare_slug

--- a/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
+++ b/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
@@ -64,7 +64,7 @@ Work in this order:
 1. hear a sound;
 2. see the letter;
 3. repeat a short word;
-4. use one greeting chunk.
+4. use one greeting phrase.
 
 You do not need long Ukrainian sentences yet. You need a few stable anchors:
 **звук**, **лі́тера**, **ма́ма**, **молоко́**, **Приві́т**, and
@@ -204,9 +204,9 @@ to master all 33 letters in one sitting. Repeat a small group, then add more.
 
 <WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "банду́ра"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лис"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "піт"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Алфавітний повтор" />
 
-## Приві́т: first greeting chunks
+## Приві́т: first greeting phrases
 
-Use these as whole chunks first. Grammar can wait.
+Use these as whole phrases first. Grammar can wait.
 
 | Ukrainian | English support |
 | --- | --- |
@@ -249,7 +249,7 @@ Keep this module small and clean:
 1. Keep **о** clear in **молоко́**.
 2. Hear the difference between **и** and **і** in **Приві́т**.
 3. Remember that **Ь** has no sound of its own.
-4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole chunks.
+4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole phrases.
 
 End with one reliable line:
 


### PR DESCRIPTION
## Summary
- Replace learner-facing "chunk/chunks" wording in A1 M1 greetings with "phrase/phrases".
- Update the source module, activity instruction, and regenerated Starlight MDX.
- Preserve A1 M1 `prev`/`next` frontmatter by making the generator CLI path include the repo root before importing navigation helpers.
- Leave internal `chunk_id` resource keys untouched.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 1`
- YAML parse for `curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/generate_mdx/core.py`
- `npx markdownlint-cli2 --no-globs starlight/src/content/docs/a1/sounds-letters-and-hello.mdx`
- `git diff --check`
- learner-facing chunk scan: no matches outside internal `chunk_id` keys
- pre-commit PASS
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

X-Agent: codex/2778-m1-greeting-phrasing
