### PR TITLE
fix(a1): split M2 lesson and workbook activities

### DIFF
--- a/curriculum/l2-uk-en/a1/reading-ukrainian/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/reading-ukrainian/vocabulary.yaml
@@ -103,6 +103,6 @@
   pos: adverb
   usage: Так.
 - lemma: ні
-  translation: no
+  translation: "no"
   pos: particle
   usage: Ні.

--- a/starlight/src/content/docs/a1/reading-ukrainian.mdx
+++ b/starlight/src/content/docs/a1/reading-ukrainian.mdx
@@ -4,8 +4,6 @@ description: "Від літер до слів та речень"
 sidebar:
   order: 2
   label: "02. Читаємо українською"
-pipeline: linear-phase-4
-build_status: validated
 prev: sounds-letters-and-hello
 next: special-signs
 ---
@@ -299,26 +297,6 @@ routine every time: vowel sounds first, syllables second, smooth reading third.
 
 </TabItem>
 <TabItem label="Activities">
-
-### Count vowel sounds
-
-<CountSyllables client:only='react' instruction={"Count the vowel sounds. Each vowel sound makes one склад."} items={JSON.parse(`[{"word": "день", "correct": 1}, {"word": "ма́ма", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "ву́лиця", "correct": 3}, {"word": "бібліоте́ка", "correct": 5}, {"word": "Украї́на", "correct": 4}]`)} />
-
-### Vowel letter jobs
-
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "А", "right": "clean [а]"}, {"left": "О", "right": "clean [о]"}, {"left": "И", "right": "clean [и]"}, {"left": "І", "right": "clean [і]"}, {"left": "Я at word start", "right": "[йа]"}, {"left": "Ї", "right": "always [йі]"}]`)} />
-
-### Split into склади́
-
-<DivideWords client:only='react' instruction={"Divide each word into syllables."} items={JSON.parse(`[{"word": "мама", "answer": "ма ма"}, {"word": "молоко", "answer": "мо ло ко"}, {"word": "вулиця", "answer": "ву ли ця"}, {"word": "столиця", "answer": "сто ли ця"}, {"word": "людина", "answer": "лю ди на"}, {"word": "бібліотека", "answer": "бі блі о те ка"}]`)} />
-
-### Reading traps
-
-<ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian reading habit." items={JSON.parse(`[{"sentence": "Do not read молоко as м[а]локо.", "errorWord": "м[а]локо", "correctForm": "молоко", "options": ["молоко", "blurred о"], "explanation": "Ukrainian о stays clean; read молоко with three open beats."}, {"sentence": "Do not read дж as two broken sounds.", "errorWord": "two broken sounds", "correctForm": "one joined sound", "options": ["one joined sound", "д plus ж"], "explanation": "ДЖ marks one joined reading unit in words such as джерело."}, {"sentence": "Do not read Ї as plain І.", "errorWord": "plain І", "correctForm": "[йі]", "options": ["[йі]", "[і]"], "explanation": "Ї is always [йі]."}, {"sentence": "Do not add a vowel after день.", "errorWord": "add a vowel", "correctForm": "soften н and stop", "options": ["soften н and stop", "add і after нь"], "explanation": "Ь has no sound of its own; it softens the previous consonant."}]`)} />
-
-### Textbook check
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "What is a склад?", "options": [{"text": "a syllable", "correct": true}, {"text": "a letter", "correct": false}, {"text": "a greeting", "correct": false}], "explanation": "A склад is a syllable."}, {"question": "How many syllables are in молоко?", "options": [{"text": "3", "correct": true}, {"text": "2", "correct": false}, {"text": "1", "correct": false}], "explanation": "молоко has three vowel sounds and three syllables."}, {"question": "Which letter is always [йі]?", "options": [{"text": "Ї", "correct": true}, {"text": "І", "correct": false}, {"text": "И", "correct": false}], "explanation": "Ї is always [йі]."}]`)} />
 
 ### One, two, or three syllables?
 


### PR DESCRIPTION
## Summary
- Regenerate A1 M2 so inline Lesson-tab activities no longer duplicate in the Activities tab.
- Keep the Activities tab focused on extra practice: syllable grouping, reading facts, word meaning checks, and vowel repeat practice.
- Quote the M2 vocabulary translation for \ні\ so YAML parsing preserves the learner-facing \no\ value during regeneration.

## Validation
- .venv/bin/python scripts/generate_mdx.py l2-uk-en a1 2
- .venv/bin/yamllint curriculum/l2-uk-en/a1/reading-ukrainian/vocabulary.yaml (exit 0; existing document-start warning)
- .venv/bin/python -m pytest tests/test_yaml_activities.py -q
- .venv/bin/python -m pytest tests/test_generate_mdx.py -q
- npm run build:starlight
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py
- Deterministic MDX check: Activities tab excludes Count vowel sounds, Vowel letter jobs, Split into склади́, Reading traps, Textbook check; includes One/two/three syllables, Reading facts, Reading words, Vowel reading pass

## Scope Guard
- No generated status/audit/review artifacts.
- No changes to .python-version, .yamllint, or .markdownlint.json.
- Activities YAML source is unchanged; this uses the #2780 renderer behavior for V1 activity lists with inline injection markers.