### PR TITLE
fix(a1): split M5 lesson and workbook activities

### DIFF
--- a/curriculum/l2-uk-en/a1/who-am-i/module.md
+++ b/curriculum/l2-uk-en/a1/who-am-i/module.md
@@ -270,6 +270,6 @@ Before the workbook, cover the English side and say the Ukrainian aloud:
 | Where are you from? informal | **Звідки ти?** |
 | I am from Canada. | **Я з Канади.** |
 
-Use the workbook to make the pieces automatic: register choice, name chunks,
-**це** questions, pronouns, profession pairs, dialogue fill-ins, safer
-Ukrainian sentence choices, native-form choices, and vocabulary recognition.
+Use the workbook for extra practice: profession pairs, dialogue fill-ins,
+safer Ukrainian sentence choices, native-form choices, and vocabulary
+recognition.

--- a/starlight/src/content/docs/a1/who-am-i.mdx
+++ b/starlight/src/content/docs/a1/who-am-i.mdx
@@ -4,8 +4,6 @@ description: "Мене звати... — ваша перша справжня р
 sidebar:
   order: 5
   label: "05. Хто я?"
-pipeline: linear-phase-4
-build_status: validated
 prev: stress-and-melody
 next: my-family
 ---
@@ -336,9 +334,9 @@ Before the workbook, cover the English side and say the Ukrainian aloud:
 | Where are you from? informal | **Звідки ти?** |
 | I am from Canada. | **Я з Канади.** |
 
-Use the workbook to make the pieces automatic: register choice, name chunks,
-**це** questions, pronouns, profession pairs, dialogue fill-ins, safer
-Ukrainian sentence choices, native-form choices, and vocabulary recognition.
+Use the workbook for extra practice: profession pairs, dialogue fill-ins,
+safer Ukrainian sentence choices, native-form choices, and vocabulary
+recognition.
 
 </TabItem>
 <TabItem label="Vocabulary">
@@ -349,22 +347,6 @@ Ukrainian sentence choices, native-form choices, and vocabulary recognition.
 
 </TabItem>
 <TabItem label="Activities">
-
-### Formal or informal?
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "You meet a classmate your age.", "options": [{"text": "Як тебе звати?", "correct": true}, {"text": "Як вас звати?", "correct": false}], "explanation": "Use тебе with one familiar peer."}, {"question": "You meet an unknown adult at orientation.", "options": [{"text": "Як вас звати?", "correct": true}, {"text": "Як тебе звати?", "correct": false}], "explanation": "Use вас with one unknown adult or in a formal setting."}, {"question": "A peer asks your name. You answer and return the question.", "options": [{"text": "Мене звати Олена. А тебе?", "correct": true}, {"text": "Мене звати Олена. А вас?", "correct": false}], "explanation": "The peer situation stays informal."}, {"question": "An instructor asks your name. You answer and return the question.", "options": [{"text": "Мене звати Петро. А вас?", "correct": true}, {"text": "Мене звати Петро. А тебе?", "correct": false}], "explanation": "The instructor situation stays formal."}]`)} />
-
-### Build the name chunk
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "___ звати Марко.", "answer": "Мене", "options": ["Мене", "Ти", "Це"]}, {"sentence": "Як ___ звати?", "answer": "тебе", "options": ["тебе", "я", "він"]}, {"sentence": "Як ___ звати?", "answer": "вас", "options": ["вас", "вона", "ми"]}, {"sentence": "Дуже ___!", "answer": "приємно", "options": ["приємно", "студент", "звідки"]}, {"sentence": "Мене звати Олена. А ___?", "answer": "тебе", "options": ["тебе", "Київ", "це"]}]`)} />
-
-### This is / Who is this?
-
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Це Андрій.", "right": "This is Andrii."}, {"left": "Це Оксана.", "right": "This is Oksana."}, {"left": "Хто це?", "right": "Who is this?"}, {"left": "Що це?", "right": "What is this?"}, {"left": "Це кава.", "right": "This is coffee."}]`)} />
-
-### Pronoun choice
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "I", "options": [{"text": "я", "correct": true}, {"text": "ти", "correct": false}, {"text": "вони", "correct": false}], "explanation": "Я is the speaker."}, {"question": "you, one friend", "options": [{"text": "ти", "correct": true}, {"text": "ви", "correct": false}, {"text": "він", "correct": false}], "explanation": "Ти is one informal you."}, {"question": "you, one unknown adult", "options": [{"text": "ви", "correct": true}, {"text": "ти", "correct": false}, {"text": "вона", "correct": false}], "explanation": "Ви is formal for one person and also plural."}, {"question": "she", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "я", "correct": false}], "explanation": "Вона points to a woman or girl."}]`)} />
 
 <span id="fix-common-l2-traps"></span>
 


### PR DESCRIPTION
## Summary
- updates A1 M5 source wording so the workbook is framed as extra practice, not repeated inline lesson practice
- regenerates `starlight/src/content/docs/a1/who-am-i.mdx` so the Activities tab omits inline Lesson-tab activities and keeps workbook-only extras

## Validation
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 5`
- `.venv/bin/python -m pytest tests/test_generate_mdx.py -q` — 81 passed
- `.venv/bin/python -m pytest tests/test_yaml_activities.py tests/test_activity_schema_gate.py -q` — 35 passed
- `npm run build:starlight` — passed
- `git diff --check` — passed
- deterministic M5 tab split check — passed
- `.venv/bin/pre-commit run --files curriculum/l2-uk-en/a1/who-am-i/module.md starlight/src/content/docs/a1/who-am-i.mdx` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Notes
- `.venv/bin/pre-commit run --all-files` is not clean on current repo state due unrelated pre-existing YAML/docs/BIO hook failures and auto-fixable EOF/whitespace drift outside this PR; those auto-fixes were reverted and are not included.
- The standalone `scripts/validate/validate_yaml.py` currently rejects this lesson's pre-existing error-correction activity via the schema-validator path, while the activity parser, schema gate tests, MDX generation, and Starlight build pass. This PR does not change `activities.yaml`.