### PR TITLE
fix(a1): split M6 lesson and workbook activities

### DIFF
--- a/curriculum/l2-uk-en/a1/my-family/module.md
+++ b/curriculum/l2-uk-en/a1/my-family/module.md
@@ -220,6 +220,5 @@ Use native Ukrainian family words in the workbook: **дружина** for wife,
 **одружений** for married. Do not turn these into a Russian comparison lesson;
 just choose the Ukrainian word.
 
-Workbook practice will make the pieces automatic: family vocabulary, **У мене
-є** questions, possessive forms, dialogue blanks, required L2 traps, native
-family-word choices, and quick vocabulary recognition.
+Use the workbook for extra practice: safer Ukrainian family sentences, native
+family-word choices, photo-dialogue blanks, and quick vocabulary recognition.

--- a/starlight/src/content/docs/a1/my-family.mdx
+++ b/starlight/src/content/docs/a1/my-family.mdx
@@ -4,8 +4,6 @@ description: "У мене є брат — показуємо фотографі�
 sidebar:
   order: 6
   label: "06. Моя сім'я"
-pipeline: linear-phase-4
-build_status: validated
 prev: who-am-i
 next: checkpoint-first-contact
 ---
@@ -286,9 +284,8 @@ Use native Ukrainian family words in the workbook: **дружина** for wife,
 **одружений** for married. Do not turn these into a Russian comparison lesson;
 just choose the Ukrainian word.
 
-Workbook practice will make the pieces automatic: family vocabulary, **У мене
-є** questions, possessive forms, dialogue blanks, required L2 traps, native
-family-word choices, and quick vocabulary recognition.
+Use the workbook for extra practice: safer Ukrainian family sentences, native
+family-word choices, photo-dialogue blanks, and quick vocabulary recognition.
 
 </TabItem>
 <TabItem label="Vocabulary">
@@ -299,22 +296,6 @@ family-word choices, and quick vocabulary recognition.
 
 </TabItem>
 <TabItem label="Activities">
-
-### Family photo questions
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "You ask one peer whether they have a brother.", "options": [{"text": "У тебе є брат?", "correct": true}, {"text": "У мене є брат?", "correct": false}, {"text": "Це брат?", "correct": false}], "explanation": "У тебе є...? asks one familiar person whether they have someone."}, {"question": "You answer yes and say you have one sister.", "options": [{"text": "Так, у мене є одна сестра.", "correct": true}, {"text": "Так, у тебе є одна сестра.", "correct": false}, {"text": "Так, це одна сестра.", "correct": false}], "explanation": "У мене є... answers for yourself."}, {"question": "You answer no with the safe A1 answer.", "options": [{"text": "Ні.", "correct": true}, {"text": "У мене немає брат.", "correct": false}, {"text": "Ні є брат.", "correct": false}], "explanation": "Keep the negative answer simple at A1."}, {"question": "You ask what his name is.", "options": [{"text": "Як його звати?", "correct": true}, {"text": "Як її звати?", "correct": false}, {"text": "Що його звати?", "correct": false}], "explanation": "Його fits a brother, dad, son, or grandfather."}, {"question": "You identify your mom in a photo.", "options": [{"text": "Це моя мама.", "correct": true}, {"text": "Це мій мама.", "correct": false}, {"text": "Це моє мама.", "correct": false}], "explanation": "Мама is feminine, so use моя."}, {"question": "You identify your parents.", "options": [{"text": "Це мої батьки.", "correct": true}, {"text": "Це мій батьки.", "correct": false}, {"text": "Це моя батьки.", "correct": false}], "explanation": "Батьки is plural, so use мої."}]`)} />
-
-### Family words
-
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "mother", "right": "мама"}, {"left": "father", "right": "тато"}, {"left": "brother", "right": "брат"}, {"left": "sister", "right": "сестра"}, {"left": "grandmother", "right": "бабуся"}, {"left": "grandfather", "right": "дідусь"}, {"left": "parents", "right": "батьки"}, {"left": "relatives", "right": "родичі"}]`)} />
-
-### Build the I-have chunk
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "___ мене є брат.", "answer": "У", "options": ["У", "Це", "Хто"]}, {"sentence": "У ___ є сестра.", "answer": "мене", "options": ["мене", "мій", "це"]}, {"sentence": "У ___ є брат?", "answer": "тебе", "options": ["тебе", "мене", "він"]}, {"sentence": "У ___ є діти?", "answer": "вас", "options": ["вас", "твій", "вона"]}, {"sentence": "У мене є ___ брат.", "answer": "один", "options": ["один", "одна", "дві"]}, {"sentence": "У мене є ___ сестра.", "answer": "одна", "options": ["одна", "один", "два"]}, {"sentence": "У мене є ___ брати.", "answer": "два", "options": ["два", "дві", "одна"]}, {"sentence": "У мене є ___ сестри.", "answer": "дві", "options": ["дві", "два", "один"]}]`)} />
-
-### My or your?
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ___ брат.", "answer": "мій", "options": ["мій", "моя", "моє", "мої"]}, {"sentence": "Це ___ мама.", "answer": "моя", "options": ["моя", "мій", "моє", "мої"]}, {"sentence": "Це ___ місто.", "answer": "моє", "options": ["моє", "мій", "моя", "мої"]}, {"sentence": "Це ___ батьки.", "answer": "мої", "options": ["мої", "мій", "моя", "моє"]}, {"sentence": "Це ___ тато?", "answer": "твій", "options": ["твій", "твоя", "твоє", "твої"]}, {"sentence": "Це ___ сестра?", "answer": "твоя", "options": ["твоя", "твій", "твоє", "твої"]}, {"sentence": "Це ___ прізвище?", "answer": "твоє", "options": ["твоє", "твій", "твоя", "твої"]}, {"sentence": "Це ___ родичі?", "answer": "твої", "options": ["твої", "твій", "твоя", "твоє"]}]`)} />
 
 ### Choose the Ukrainian family sentence
 


### PR DESCRIPTION
## Summary
- updates A1 M6 source wording so the workbook is framed as extra practice, not repeated inline lesson practice
- regenerates `starlight/src/content/docs/a1/my-family.mdx` so the Activities tab omits inline Lesson-tab activities and keeps workbook-only extras

## Validation
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 6`
- `.venv/bin/python -m pytest tests/test_generate_mdx.py -q` — 81 passed
- `.venv/bin/python -m pytest tests/test_yaml_activities.py tests/test_activity_schema_gate.py -q` — 35 passed
- `npm run build:starlight` — passed
- `git diff --check` — passed
- deterministic M6 tab split check — passed
- `.venv/bin/pre-commit run --files curriculum/l2-uk-en/a1/my-family/module.md starlight/src/content/docs/a1/my-family.mdx` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Notes
- Full all-files pre-commit is not used for this narrow PR because current repo state has unrelated pre-existing all-files hook failures outside this diff; targeted pre-commit on changed files passes.