### PR TITLE
[codex] Make Monitor API/UI status state trustworthy

### DIFF
--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -221,7 +221,7 @@ async function loadStats() {
     safeFetch('/api/dashboard/overview'),
     safeFetch('/api/state/pipeline-versions'),
     safeFetch('/api/consultation/metrics'),
-    safeFetch('/api/state/summary'),
+    safeFetch('/api/state/summary?fresh=true'),
     safeFetch('/api/comms/batch-progress'),
     safeFetch('/api/state/weak-points?limit=1'),
     safeFetch('/api/orient'),
@@ -260,8 +260,9 @@ async function loadStats() {
   try {
     if (!summary) throw new Error('summary unavailable');
     const t = summary.totals;
+    const stale = t.audit_stale ? ` · ${t.audit_stale} stale audit` : '';
     document.getElementById('progress-stat').textContent =
-      `${v6Count} v6 · ${v5Count} v5 · ${t.research_done} research · ${t.content_done} content · ${t.audit_passing} passing`;
+      `${v6Count} v6 · ${v5Count} v5 · ${t.dossier_done ?? 0} dossiers · ${t.published_mdx ?? 0} published${stale}`;
   } catch(e) {}
 
   try {

--- a/dashboards/progress.html
+++ b/dashboards/progress.html
@@ -50,7 +50,13 @@ a:hover { text-decoration: underline; }
 .fill-content { background: var(--blue); }
 .fill-audit { background: var(--green); }
 .fill-review { background: var(--purple); }
+.fill-dossier { background: var(--orange); }
+.fill-published { background: var(--cyan); }
 .phase-count { font-size: 11px; color: var(--text2); margin-top: 2px; }
+.track-hints { min-width: 132px; max-width: 160px; font-size: 11px; color: var(--text2); line-height: 1.35; }
+.hint-warn { color: var(--yellow); }
+.hint-ok { color: var(--green); }
+.hint-stale { color: var(--red); }
 .track-chevron { color: var(--text3); font-size: 11px; transition: transform 0.2s; margin-left: 8px; }
 .track-expanded .track-chevron { transform: rotate(90deg); }
 
@@ -78,6 +84,7 @@ a:hover { text-decoration: underline; }
 .chip-content { background: #1a3055; color: var(--blue); }
 .chip-audit { background: #1a3f25; color: var(--green); }
 .chip-review { background: #2d1f5a; color: var(--purple); }
+.chip-published { background: #123f45; color: var(--cyan); }
 .chip-pass { background: var(--green); color: #000; }
 
 /* Unbuilt modules */
@@ -86,6 +93,13 @@ a:hover { text-decoration: underline; }
 .legend { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
 .legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text2); }
 .legend-dot { width: 12px; height: 12px; border-radius: 2px; }
+.freshness-banner {
+  display:flex; justify-content:space-between; gap:12px; align-items:center;
+  margin-bottom:14px; padding:10px 12px; border:1px solid var(--border);
+  background:var(--bg2); color:var(--text2); font-size:12px; border-radius:4px;
+}
+.freshness-banner strong { color:var(--text); }
+.freshness-banner .warn { color:var(--yellow); }
 
 .error-msg { color: var(--red); font-size: 13px; padding: 8px 0; }
 </style>
@@ -121,15 +135,23 @@ a:hover { text-decoration: underline; }
   <div class="stat-card"><div class="value" style="color:var(--green)" id="total-audit">—</div><div class="label">Audit Passing</div></div>
   <div class="stat-card"><div class="value" style="color:var(--purple)" id="total-reviewed">—</div><div class="label">Reviewed</div></div>
   <div class="stat-card"><div class="value" style="color:#58a6ff" id="total-final-review">—</div><div class="label">Final QA</div></div>
+  <div class="stat-card"><div class="value" style="color:var(--orange)" id="total-dossier">—</div><div class="label">Dossiers</div></div>
+  <div class="stat-card"><div class="value" style="color:var(--cyan)" id="total-published">—</div><div class="label">Published MDX</div></div>
   <div class="stat-card"><div class="value" style="color:var(--cyan)" id="total-v6">—</div><div class="label">V6 Pipeline</div></div>
   <div class="stat-card"><div class="value" style="color:var(--gray)" id="total-rebuild">—</div><div class="label">Needs Rebuild</div></div>
 </div>
 
 <div class="container">
+  <div class="freshness-banner" id="freshness-banner">
+    <span><strong>State:</strong> loading current API snapshot</span>
+    <span></span>
+  </div>
+
   <div class="legend">
     <div class="legend-item"><div class="legend-dot" style="background:var(--green)"></div> Full pass</div>
     <div class="legend-item"><div class="legend-dot" style="background:#1a3055;border:1px solid var(--blue)"></div> Content</div>
     <div class="legend-item"><div class="legend-dot" style="background:#5a3e1b;border:1px solid var(--orange)"></div> Research</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#123f45;border:1px solid var(--cyan)"></div> Published MDX</div>
     <div class="legend-item"><div class="legend-dot" style="background:var(--gray);opacity:0.4"></div> Unbuilt</div>
   </div>
 
@@ -179,6 +201,7 @@ function chipClass(mod) {
   if (isDone(phases.audit) || isDone(phases.publish) || isDone(phases.verify) || isDone(phases.validate)) return 'chip-audit';
   if (isDone(phases.write) || isDone(phases.content)) return 'chip-content';
   if (isDone(phases.research)) return 'chip-research';
+  if (mod.published_mdx) return 'chip-published';
   return 'chip-none';
 }
 
@@ -188,6 +211,7 @@ function chipLabel(mod) {
   if (isDone(phases.audit) || isDone(phases.publish) || isDone(phases.verify) || isDone(phases.validate)) return 'A';
   if (isDone(phases.write) || isDone(phases.content)) return 'C';
   if (isDone(phases.research)) return 'R';
+  if (mod.published_mdx) return 'P';
   return '·';
 }
 
@@ -197,13 +221,15 @@ function chipTitle(mod) {
   const phaseStates = Object.entries(phases)
     .map(([k, v]) => `${k}:${v.status || 'pending'}`)
     .join(' | ');
-  return `#${mod.num} ${mod.slug} [${ver}] | ${phaseStates} | audit:${mod.audit} | words:${mod.words}`;
+  const dossier = mod.dossier?.exists ? `dossier:${mod.dossier.source || 'yes'}` : 'dossier:missing';
+  const mdx = mod.published_mdx ? 'published:yes' : 'published:no';
+  return `#${mod.num} ${mod.slug} [${ver}] | ${phaseStates} | audit:${mod.audit} | words:${mod.words} | ${dossier} | ${mdx}`;
 }
 
 async function loadModulePanel(trackId, panel) {
   panel.innerHTML = '<div class="loading-msg">Loading module data...</div>';
   try {
-    const data = await fetchJson(`/api/state/pipeline/${trackId}`);
+    const data = await fetchJson(`/api/state/pipeline/${trackId}?fresh=true`);
     const mods = data.modules || [];
 
     const chips = mods.map(mod => {
@@ -223,6 +249,11 @@ async function loadModulePanel(trackId, panel) {
 function renderTrack(trackId, trackData) {
   const { total, profile, research_done, content_done, audit_passing, reviewed, final_review_done } = trackData;
   const profileColor = PROFILE_COLOR[profile] || '#8b949e';
+  const dossierDone = trackData.dossier_done || 0;
+  const published = trackData.published_mdx || 0;
+  const staleAudit = trackData.audit_stale || 0;
+  const next = nextAction(trackData);
+  const dossierLabel = trackData.is_seminar ? 'Dossier' : 'Research';
 
   return `
   <div class="track-row" id="track-${trackId}">
@@ -231,8 +262,8 @@ function renderTrack(trackId, trackData) {
       <div class="track-profile" style="color:${profileColor}">${profile}</div>
       <div class="track-phases">
         <div class="phase-col">
-          <div class="phase-label">Research</div>
-          ${progressBar(research_done, total, 'fill-research')}
+          <div class="phase-label">${dossierLabel}</div>
+          ${progressBar(trackData.is_seminar ? dossierDone : research_done, total, 'fill-dossier')}
         </div>
         <div class="phase-col">
           <div class="phase-label">Content</div>
@@ -250,6 +281,14 @@ function renderTrack(trackId, trackData) {
           <div class="phase-label">Final QA</div>
           ${progressBar(final_review_done, total, 'fill-review')}
         </div>
+        <div class="phase-col">
+          <div class="phase-label">Published</div>
+          ${progressBar(published, total, 'fill-published')}
+        </div>
+      </div>
+      <div class="track-hints">
+        <div class="${next.cls}">${next.text}</div>
+        ${staleAudit ? `<div class="hint-stale">${staleAudit} stale audit cache${staleAudit === 1 ? '' : 's'}</div>` : ''}
       </div>
       <div class="track-chevron">▶</div>
     </div>
@@ -268,14 +307,64 @@ function toggleTrack(trackId) {
   }
 }
 
+function nextAction(trackData) {
+  const total = trackData.total || 0;
+  if (trackData.is_seminar && (trackData.dossier_done || 0) < total) {
+    return { text: `Dossier gap ${trackData.dossier_done || 0}/${total}`, cls: 'hint-warn' };
+  }
+  if (!trackData.is_seminar && (trackData.research_done || 0) < total) {
+    return { text: `Research gap ${trackData.research_done || 0}/${total}`, cls: 'hint-warn' };
+  }
+  if ((trackData.generated_md || 0) < total) {
+    return { text: `Build content ${trackData.generated_md || 0}/${total}`, cls: 'hint-warn' };
+  }
+  if ((trackData.audit_stale || 0) > 0) {
+    return { text: 'Refresh audit', cls: 'hint-stale' };
+  }
+  if ((trackData.audit_passing || 0) < (trackData.generated_md || 0)) {
+    return { text: `Audit/fix ${trackData.audit_passing || 0}/${trackData.generated_md || 0}`, cls: 'hint-warn' };
+  }
+  if ((trackData.final_review_done || 0) < (trackData.audit_passing || 0)) {
+    return { text: 'Final review next', cls: 'hint-warn' };
+  }
+  return { text: 'No immediate blocker', cls: 'hint-ok' };
+}
+
+function formatTimestamp(value) {
+  if (!value) return 'unknown time';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function renderFreshness(meta) {
+  const banner = document.getElementById('freshness-banner');
+  const cache = meta?.cache || 'unknown';
+  const age = typeof meta?.age_s === 'number' ? `${Math.round(meta.age_s)}s old` : 'fresh read';
+  const ttl = typeof meta?.stale_after_s === 'number' ? `${Math.round(meta.stale_after_s)}s TTL` : 'TTL unknown';
+  const generated = formatTimestamp(meta?.generated_at);
+  const cls = cache === 'hit' ? 'warn' : '';
+  banner.innerHTML = `
+    <span><strong>State:</strong> ${escapeHtml(meta?.source || 'unknown source')} · generated ${escapeHtml(generated)}</span>
+    <span class="${cls}">${escapeHtml(cache)} · ${escapeHtml(age)} · ${escapeHtml(ttl)}</span>
+  `;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
 async function load() {
   try {
     const [res, pv] = await Promise.all([
-      fetchJson('/api/state/summary'),
-      fetchJson('/api/state/pipeline-versions').catch(() => ({})),
+      fetchJson('/api/state/summary?fresh=true'),
+      fetchJson('/api/state/pipeline-versions?fresh=true').catch(() => ({})),
     ]);
     const data = res;
     const t = data.totals;
+    renderFreshness(data.meta);
 
     document.getElementById('total-modules').textContent = t.total;
     document.getElementById('total-research').textContent = t.research_done;
@@ -283,10 +372,12 @@ async function load() {
     document.getElementById('total-audit').textContent = t.audit_passing;
     document.getElementById('total-reviewed').textContent = t.reviewed || 0;
     document.getElementById('total-final-review').textContent = t.final_review_done;
+    document.getElementById('total-dossier').textContent = t.dossier_done || 0;
+    document.getElementById('total-published').textContent = t.published_mdx || 0;
     document.getElementById('total-v6').textContent = `${pv.counts?.v6 || 0}`;
     document.getElementById('total-rebuild').textContent = `${pv.needs_rebuild || 0}`;
     document.getElementById('topbar-subtitle').textContent =
-      `Pipeline state across all tracks — ${pv.counts?.v6 || 0} v6, ${pv.needs_rebuild || 0} rebuild needed`;
+      `Pipeline state across all tracks — ${pv.counts?.v6 || 0} v6, ${t.published_mdx || 0} published, ${pv.needs_rebuild || 0} rebuild needed`;
 
     const container = document.getElementById('tracks-container');
     const trackEntries = Object.entries(data.tracks)

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -174,25 +174,54 @@ Full project snapshot — one call replaces 5 bash scripts at session start.
 curl -s http://localhost:8765/api/state/summary | python3 -m json.tool
 ```
 
+Freshness:
+- Cached for 60 seconds.
+- Pass `?fresh=true` to bypass the state-summary cache.
+- `meta.generated_at`, `meta.source`, `meta.cache`, and
+  `meta.stale_after_s` describe the snapshot. `cache: "hit"` means the
+  payload is still within the TTL; clients should still surface
+  `audit_stale` when present because that is source-artifact staleness,
+  not API-cache staleness.
+
 Returns per-track counts:
-- `total` — plan files count (source of truth)
-- `research_done` — modules with research complete across current and legacy build flows
-- `content_done` — modules with lesson content complete across current and legacy build flows
+- `total` — module catalog count from `curriculum.yaml`, falling back to
+  `plans/{track}/*.yaml` when the manifest has no module list
+- `module_source` — `curriculum.yaml` or `plans-fallback`
+- `research_done` — modules with research complete in pipeline state or
+  a discovered research/dossier file
+- `dossier_done` — discovered dossier/research files, including
+  `docs/research/{track}/{slug}.md` seminar dossiers
+- `dossier_docs` / `dossier_curriculum` — split by dossier source
+- `content_done` — modules with lesson content complete in pipeline state
+- `generated_md` — generated curriculum markdown exists on disk
+- `published_mdx` — Starlight MDX exists under
+  `starlight/src/content/docs/{track}/{slug}.mdx`
 - `audit_passing` — `status/*.json` overall == "pass"
+- `audit_stale` — status cache exists but is older than the module source
 - `final_review_done` — `review/*-final-review.md` exists
 - `prompt_reviewed` — `/prompt-review` done (`audit/*-prompt-review.md` exists)
 - `content_reviewed` — `/content-review` done (`audit/*-content-review.md` exists)
 - `profile` — "core" | "seminar" | "pro"
+- `is_seminar` — true for tracks listed in `SEMINAR_TRACK_IDS`
 
 Sample response:
 ```json
 {
   "generated_at": "2026-02-19T15:30:06Z",
+  "meta": {
+    "generated_at": "2026-02-19T15:30:06Z",
+    "source": "fs:plans+orchestration+artifacts+research",
+    "cache": "miss",
+    "stale_after_s": 60,
+    "stale": false
+  },
   "tracks": {
     "istorio": {
-      "total": 136, "profile": "seminar",
-      "research_done": 26, "content_done": 0,
-      "audit_passing": 0, "final_review_done": 0
+      "total": 136, "profile": "seminar", "is_seminar": true,
+      "module_source": "curriculum.yaml",
+      "research_done": 26, "dossier_done": 26,
+      "generated_md": 0, "published_mdx": 136,
+      "content_done": 0, "audit_passing": 0, "final_review_done": 0
     },
     "hist": {
       "total": 140, "profile": "seminar",
@@ -200,7 +229,7 @@ Sample response:
       "audit_passing": 4, "final_review_done": 4
     }
   },
-  "totals": { "total": 1778, "research_done": 400, ... }
+  "totals": { "total": 1778, "research_done": 400, "published_mdx": 220, ... }
 }
 ```
 
@@ -218,22 +247,29 @@ curl -s http://localhost:8765/api/state/pipeline/a1 | python3 -m json.tool
 Returns:
 ```json
 {
-  "num": 1, "slug": "sounds-letters-and-hello",
-  "pipeline_version": "v6",
-  "phases": {
-    "check": {"status": "complete", "ts": "2026-03-20T14:00:00Z"},
-    "research": {"status": "complete", "ts": "2026-03-20T14:01:00Z"},
-    "write": {"status": "complete", "ts": "2026-03-20T14:05:00Z"},
-    "exercises": {"status": "complete", "ts": "2026-03-20T14:08:00Z"},
-    "annotate": {"status": "complete", "ts": "2026-03-20T14:10:00Z"},
-    "enrich": {"status": "complete", "ts": "2026-03-20T14:12:00Z"},
-    "verify": {"status": "complete", "ts": "2026-03-20T14:15:00Z"},
-    "publish": {"status": "pending"}
-  },
-  "audit": "pass",
-  "words": 1500,
-  "word_target": 1200,
-  "research_score": null
+  "track": "a1",
+  "profile": "core",
+  "is_seminar": false,
+  "meta": {"source": "fs:orchestration+audit+research", "cache": "miss", "stale_after_s": 60},
+  "modules": [
+    {
+      "num": 1, "slug": "sounds-letters-and-hello",
+      "pipeline_version": "v6",
+      "phases": {
+        "check": {"status": "complete", "ts": "2026-03-20T14:00:00Z"},
+        "research": {"status": "complete", "ts": "2026-03-20T14:01:00Z"},
+        "write": {"status": "complete", "ts": "2026-03-20T14:05:00Z"},
+        "publish": {"status": "pending"}
+      },
+      "audit": "pass",
+      "words": 1500,
+      "word_target": 1200,
+      "research_score": null,
+      "generated_md": true,
+      "published_mdx": true,
+      "dossier": {"exists": false, "source": null}
+    }
+  ]
 }
 ```
 
@@ -1831,15 +1867,31 @@ revision of this endpoint was removed per reviewer BLOCKER on
 
 | Page | URL | Data source |
 |------|-----|-------------|
-| Home | `/` | `/api/dashboard/overview`, `/api/state/summary`, `/api/comms/batch-progress` |
+| Home | `/` | `/api/dashboard/overview`, `/api/state/summary?fresh=true`, `/api/comms/batch-progress` |
 | Audit Dashboard | `/audit-dashboard.html` | `/api/dashboard/overview`, `/api/dashboard/track/{id}` |
-| Progress | `/progress.html` | `/api/state/summary`, `/api/state/pipeline/{track}` |
+| Progress | `/progress.html` | `/api/state/summary?fresh=true`, `/api/state/pipeline-versions?fresh=true`, `/api/state/pipeline/{track}?fresh=true` |
 | Agent Comms | `/comms.html` | `/api/build/events/active`, `/api/build/events/recent`, `/api/comms/batch-progress`, `/api/comms/zombies`, `/api/comms/messages`, `/api/comms/stats` |
 | Quality | `/quality.html` | `/api/state/research-coverage`, `/api/state/review-coverage`, `/api/state/issues`, `/api/state/weak-points` |
 | Track Health | `/track-health.html` | `/api/state/track-health/{track}`, `/api/state/build-status`, `/api/state/enrichment-status` |
 | Curriculum | `/curriculum-dashboard.html` | `/api/dashboard/overview` |
 | Consultation | `/consultation.html` | `/api/consultation/queue`, `/api/consultation/history`, `/api/consultation/metrics` |
 | API Docs | `/docs` | FastAPI auto-generated |
+
+Dashboard consolidation status:
+- `/progress.html` is the canonical fast visual overview for current
+  track/module state. It surfaces cache freshness, dossier coverage,
+  generated/published state, stale audit warnings, and next-action hints.
+- `/audit-dashboard.html` remains because it drills into QA gate
+  breakdowns through `/api/dashboard/track/{id}`.
+- `/quality.html` remains because it is a fix queue over research,
+  reviews, issues, and weak-point endpoints rather than a status overview.
+- `/track-health.html` remains because it uses build-status and
+  enrichment endpoints that are not shown in the progress overview.
+- `/curriculum-dashboard.html` remains for plan/meta inspection. It is
+  overlapping, but deleting it would remove a distinct module-inspection
+  workflow.
+- No page is removed in this slice; the safe consolidation is to make
+  `/progress.html` trustworthy and leave the specialized pages explicit.
 
 ---
 

--- a/scripts/api/dashboard_helpers.py
+++ b/scripts/api/dashboard_helpers.py
@@ -27,7 +27,7 @@ except ImportError:
 from research_quality import assess_research_compat, find_research_path, get_rubric
 
 from .review_parsing import extract_plan_verdict, extract_review_score, extract_review_verdict
-from .state_helpers import detect_pipeline_version, read_v2_state
+from .state_helpers import detect_pipeline_version, get_plan_slugs, read_v2_state
 
 # Simple TTL cache for scan_track results
 _track_cache: dict[str, tuple[float, dict]] = {}
@@ -266,6 +266,7 @@ def compute_track_stats(modules: list, track_id: str) -> dict:
         "plan_pass": sum(1 for m in modules if m.get("plan_review_verdict") == "PASS"),
         "plan_needs_fixes": sum(1 for m in modules if m.get("plan_review_verdict") == "NEEDS FIXES"),
         "plan_fail": sum(1 for m in modules if m.get("plan_review_verdict") == "FAIL"),
+        "stale_status": sum(1 for m in modules if m.get("is_fresh") is False and m.get("status") not in {"missing", "unaudited"}),
     }
 
     rubric_name = get_rubric(track_id)
@@ -363,17 +364,20 @@ def scan_track_summary(track_id: str, track_path: str, manifest_modules: list) -
             "track_id": track_id,
             "track_path": track_path,
             "module_count": 0,
+            "is_seminar": track_id in SEMINAR_TRACK_IDS,
             "modules": [],
         }
 
+    module_entries = manifest_modules or [slug for _num, slug in get_plan_slugs(track_id)]
     modules = [
         build_module_summary(track_dir, plans_dir, track_id, parse_slug(m_entry), idx)
-        for idx, m_entry in enumerate(manifest_modules)
+        for idx, m_entry in enumerate(module_entries)
     ]
 
     return {
         "track_id": track_id,
         "track_path": track_path,
+        "is_seminar": track_id in SEMINAR_TRACK_IDS,
         "module_count": len(modules),
         "modules": modules,
     }
@@ -393,9 +397,10 @@ def scan_track(track_id: str, track_path: str, manifest_modules: list) -> dict:
             "modules": [],
         }
 
+    module_entries = manifest_modules or [slug for _num, slug in get_plan_slugs(track_id)]
     modules = [
         build_module_info(track_dir, plans_dir, track_id, parse_slug(m_entry), idx)
-        for idx, m_entry in enumerate(manifest_modules)
+        for idx, m_entry in enumerate(module_entries)
     ]
 
     return {

--- a/scripts/api/dashboard_router.py
+++ b/scripts/api/dashboard_router.py
@@ -5,6 +5,7 @@ Endpoints: overview, track detail, module deep-dive, pipeline status, activity c
 comms monitoring.
 """
 
+import asyncio
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -16,7 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from common.thresholds import REVIEW_PASS_FLOOR
 
-from .config import CURRICULUM_ROOT, LEVELS
+from .config import CURRICULUM_ROOT, LEVELS, SEMINAR_TRACK_IDS
 from .dashboard_comms import (
     collect_stuck_tasks,
     ensure_broker_cols,
@@ -38,6 +39,8 @@ from .dashboard_helpers import (
     scan_track_cached,
     scan_track_summary_cached,
 )
+from .state_coverage import compute_summary
+from .state_helpers import cache_get_with_age, cache_set, get_plan_slugs
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -50,6 +53,18 @@ except ImportError:
 from research_quality import assess_research_compat, find_research_path
 
 router = APIRouter(tags=["dashboard"])
+DASHBOARD_STATE_SUMMARY_TTL_S = 60.0
+
+
+async def _state_summary_for_dashboard() -> tuple[dict, str, float | None]:
+    """Reuse the state-summary cache so dashboard loads stay responsive."""
+    cached = cache_get_with_age("summary", ttl=DASHBOARD_STATE_SUMMARY_TTL_S)
+    if cached is not None:
+        value, age_s = cached
+        return value, "hit", age_s
+    result = await asyncio.to_thread(compute_summary)
+    cache_set("summary", result)
+    return result, "miss", 0.0
 
 
 # ==================== ENDPOINTS ====================
@@ -60,19 +75,31 @@ async def overview():
     """All tracks with module counts and pass/prose/fail stats."""
     manifest = load_manifest()
     levels = manifest.get("levels", {})
+    state_summary, cache_state, age_s = await _state_summary_for_dashboard()
+    state_tracks = state_summary.get("tracks", {})
 
     tracks = []
     totals = {"pass": 0, "content_complete": 0, "fail": 0, "unaudited": 0, "missing": 0, "shippable": 0, "total": 0}
 
     for level_cfg in LEVELS:
         track_id = level_cfg["id"]
-        track_modules = levels.get(track_id, {}).get("modules", [])
+        track_modules = levels.get(track_id, {}).get("modules", []) or [
+            slug for _num, slug in get_plan_slugs(track_id)
+        ]
         if not track_modules:
             continue
 
         track_data = scan_track_summary_cached(track_id, level_cfg["path"], track_modules)
         track_data["stats"] = compute_track_stats(track_data["modules"], track_id)
+        summary_stats = state_tracks.get(track_id, {})
         s = track_data["stats"]
+        research_total_key = "dossier_done" if summary_stats.get("is_seminar") else "research_done"
+        s["research"] = {
+            **s.get("research", {}),
+            "total": summary_stats.get(research_total_key, 0),
+            "docs": summary_stats.get("dossier_docs", 0),
+            "curriculum": summary_stats.get("dossier_curriculum", 0),
+        }
         pct = round(s["pass"] / track_data["module_count"] * 100) if track_data["module_count"] > 0 else 0
 
         track_entry = {
@@ -81,9 +108,13 @@ async def overview():
             "module_count": track_data["module_count"],
             "stats": s,
             "pct_complete": pct,
+            "profile": summary_stats.get("profile", "seminar" if track_id in SEMINAR_TRACK_IDS else "core"),
+            "is_seminar": bool(track_data.get("is_seminar") or summary_stats.get("is_seminar")),
+            "module_source": summary_stats.get("module_source"),
+            "published_mdx": summary_stats.get("published_mdx", 0),
+            "generated_md": summary_stats.get("generated_md", 0),
+            "audit_stale": summary_stats.get("audit_stale", 0),
         }
-        if track_data.get("is_seminar"):
-            track_entry["is_seminar"] = True
         tracks.append(track_entry)
 
         for key in totals:
@@ -96,6 +127,14 @@ async def overview():
         "tracks": tracks,
         "totals": totals,
         "timestamp": datetime.now(UTC).isoformat(),
+        "meta": {
+            "generated_at": state_summary.get("generated_at"),
+            "source": "fs:dashboard-summary+state-summary",
+            "cache": cache_state,
+            "stale_after_s": DASHBOARD_STATE_SUMMARY_TTL_S,
+            "stale": False,
+            **({"age_s": round(age_s, 3)} if age_s is not None else {}),
+        },
     }
 
 
@@ -108,7 +147,9 @@ async def research_overview():
     tracks = []
     for level_cfg in LEVELS:
         track_id = level_cfg["id"]
-        track_modules = levels.get(track_id, {}).get("modules", [])
+        track_modules = levels.get(track_id, {}).get("modules", []) or [
+            slug for _num, slug in get_plan_slugs(track_id)
+        ]
         if not track_modules:
             continue
 
@@ -158,9 +199,9 @@ async def track_summary(track_id: str):
     if not level_cfg:
         raise HTTPException(status_code=404, detail=f"Track {track_id} not found")
 
-    track_modules = manifest.get("levels", {}).get(track_id, {}).get("modules", [])
-    if track_modules is None:
-        track_modules = []
+    track_modules = manifest.get("levels", {}).get(track_id, {}).get("modules", []) or [
+        slug for _num, slug in get_plan_slugs(track_id)
+    ]
     return scan_track_summary_cached(track_id, level_cfg["path"], track_modules)
 
 
@@ -172,9 +213,9 @@ async def track_detail(track_id: str):
     if not level_cfg:
         raise HTTPException(status_code=404, detail=f"Track {track_id} not found")
 
-    track_modules = manifest.get("levels", {}).get(track_id, {}).get("modules", [])
-    if track_modules is None:
-        track_modules = []
+    track_modules = manifest.get("levels", {}).get(track_id, {}).get("modules", []) or [
+        slug for _num, slug in get_plan_slugs(track_id)
+    ]
     return scan_track_cached(track_id, level_cfg["path"], track_modules)
 
 

--- a/scripts/api/state_coverage.py
+++ b/scripts/api/state_coverage.py
@@ -8,21 +8,23 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
+import yaml
+
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
-from .config import CURRICULUM_ROOT, LEVELS
+from .config import CURRICULUM_ROOT, LEVELS, PROJECT_ROOT, SEMINAR_TRACK_IDS
 from .state_helpers import (
     PROFILE_MAP,
     detect_pipeline_version,
+    find_content_file,
     get_audit_status,
     get_plan_slugs,
     get_research_score,
     get_word_target_from_plan,
     is_content_done,
-    is_research_done,
     load_module_state,
     parse_phase_status_from_state,
 )
@@ -50,11 +52,14 @@ except ImportError:
 def compute_summary() -> dict:
     """Synchronous summary computation -- safe to run in asyncio.to_thread()."""
     generated_at = datetime.now(UTC).isoformat()
+    module_sources = _module_sources_by_track()
     tracks_out = {}
     totals = {
         "total": 0, "research_done": 0, "content_done": 0,
         "audit_passing": 0, "reviewed": 0, "final_review_done": 0,
         "prompt_reviewed": 0, "content_reviewed": 0,
+        "generated_md": 0, "published_mdx": 0, "dossier_done": 0,
+        "dossier_docs": 0, "dossier_curriculum": 0, "audit_stale": 0,
     }
 
     for level_cfg in LEVELS:
@@ -67,7 +72,13 @@ def compute_summary() -> dict:
         profile = PROFILE_MAP.get(track_id, "core")
         counts = _count_summary_for_track(track_dir, track_id, plan_slugs)
 
-        tracks_out[track_id] = {"total": len(plan_slugs), "profile": profile, **counts}
+        tracks_out[track_id] = {
+            "total": len(plan_slugs),
+            "profile": profile,
+            "is_seminar": track_id in SEMINAR_TRACK_IDS,
+            "module_source": module_sources.get(track_id, "plans-fallback"),
+            **counts,
+        }
 
         for key in totals:
             if key == "total":
@@ -75,27 +86,80 @@ def compute_summary() -> dict:
             elif key in counts:
                 totals[key] += counts[key]
 
-    return {"generated_at": generated_at, "tracks": tracks_out, "totals": totals}
+    return {
+        "generated_at": generated_at,
+        "tracks": tracks_out,
+        "totals": totals,
+        "sources": {
+            "module_catalog": "curriculum.yaml with plans/{track}/*.yaml fallback",
+            "build_state": "curriculum/l2-uk-en/{track}/orchestration/{slug}/state.json",
+            "generated_md": "curriculum/l2-uk-en/{track}/{slug}.md",
+            "published_mdx": "starlight/src/content/docs/{track}/{slug}.mdx",
+            "audit": "curriculum/l2-uk-en/{track}/status/{slug}.json",
+            "review": "curriculum/l2-uk-en/{track}/review/{slug}-review.md",
+            "dossier": [
+                "curriculum/l2-uk-en/{track}/research/{slug}-research.md",
+                "curriculum/l2-uk-en/{track}/research/{slug}-knowledge-packet.md",
+                "docs/research/{track}/{slug}.md",
+            ],
+        },
+    }
+
+
+def _module_sources_by_track() -> dict[str, str]:
+    """Describe which catalog source get_plan_slugs will use per track."""
+    data_path = CURRICULUM_ROOT / "curriculum.yaml"
+    try:
+        data = yaml.safe_load(data_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        data = {}
+    levels = data.get("levels", {})
+    return {
+        level_cfg["id"]: (
+            "curriculum.yaml"
+            if levels.get(level_cfg["id"], {}).get("modules", [])
+            else "plans-fallback"
+        )
+        for level_cfg in LEVELS
+    }
 
 
 def _count_summary_for_track(track_dir, track_id, plan_slugs):
     """Count research/content/audit/review stats for a single track."""
     research_done = content_done = audit_passing = 0
     reviewed = final_review_done = prompt_reviewed = content_reviewed = 0
+    generated_md = published_mdx = dossier_done = 0
+    dossier_docs = dossier_curriculum = audit_stale = 0
 
     audit_dir = track_dir / "audit"
     for _num, slug in plan_slugs:
         orch_dir = safe_join(track_dir / "orchestration", slug)
         state = load_module_state(track_id, slug, orch_dir)
 
-        if is_research_done(state, track_dir, slug):
+        research_path = find_research_path(track_dir, slug)
+        if research_path:
+            dossier_done += 1
+            research_parts = research_path.parts
+            if "docs" in research_parts and "research" in research_parts:
+                dossier_docs += 1
+            else:
+                dossier_curriculum += 1
+
+        research_phase = parse_phase_status_from_state(state, "research")
+        if research_phase.get("status") == "complete" or research_path:
             research_done += 1
         if is_content_done(state):
             content_done += 1
+        if find_content_file(track_dir, slug):
+            generated_md += 1
+        if _published_mdx_path(track_id, slug).exists():
+            published_mdx += 1
 
         audit = get_audit_status(track_dir, slug)
         if audit["status"] == "pass":
             audit_passing += 1
+        if audit["status"] == "stale":
+            audit_stale += 1
 
         if (track_dir / "review" / f"{slug}-review.md").exists():
             reviewed += 1
@@ -111,7 +175,14 @@ def _count_summary_for_track(track_dir, track_id, plan_slugs):
         "audit_passing": audit_passing, "reviewed": reviewed,
         "final_review_done": final_review_done,
         "prompt_reviewed": prompt_reviewed, "content_reviewed": content_reviewed,
+        "generated_md": generated_md, "published_mdx": published_mdx,
+        "dossier_done": dossier_done, "dossier_docs": dossier_docs,
+        "dossier_curriculum": dossier_curriculum, "audit_stale": audit_stale,
     }
+
+
+def _published_mdx_path(track_id: str, slug: str) -> Path:
+    return PROJECT_ROOT / "starlight" / "src" / "content" / "docs" / track_id / f"{slug}.mdx"
 
 
 def compute_pipeline_track(track_id: str, level_cfg: dict) -> dict:
@@ -127,6 +198,8 @@ def compute_pipeline_track(track_id: str, level_cfg: dict) -> dict:
 
         audit = get_audit_status(track_dir, slug)
         research_score = get_research_score(track_dir, slug, track_id)
+        research_path = find_research_path(track_dir, slug)
+        content_path = find_content_file(track_dir, slug)
 
         word_count = audit.get("word_count", 0)
         word_target = audit.get("word_target", 0)
@@ -147,17 +220,35 @@ def compute_pipeline_track(track_id: str, level_cfg: dict) -> dict:
             "word_count": word_count,
             "words": word_count, "word_target": word_target,
             "research_score": research_score,
+            "generated_md": bool(content_path),
+            "published_mdx": _published_mdx_path(track_id, slug).exists(),
+            "dossier": {
+                "exists": research_path is not None,
+                "source": _research_source(research_path),
+            },
             "prompt_review": (track_dir / "audit" / f"{slug}-prompt-review.md").exists(),
             "content_review": (track_dir / "audit" / f"{slug}-content-review.md").exists(),
         })
 
     return {
         "track": track_id,
+        "generated_at": datetime.now(UTC).isoformat(),
         "total": len(modules),
+        "profile": PROFILE_MAP.get(track_id, "core"),
+        "is_seminar": track_id in SEMINAR_TRACK_IDS,
         "phase_order": V6_PHASES,
         "phase_labels": {name: V6_PHASE_LABELS.get(name, name) for name in V6_PHASES},
         "modules": modules,
     }
+
+
+def _research_source(research_path: Path | None) -> str | None:
+    if research_path is None:
+        return None
+    parts = research_path.parts
+    if "docs" in parts and "research" in parts:
+        return "docs/research"
+    return "curriculum/research"
 
 
 def compute_research_coverage() -> dict:

--- a/scripts/api/state_helpers.py
+++ b/scripts/api/state_helpers.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
-from .config import CURRICULUM_ROOT, MESSAGE_DB
+from .config import CURRICULUM_ROOT, LEVELS, MESSAGE_DB, SEMINAR_TRACK_IDS
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -79,19 +79,11 @@ CURRICULUM_YAML = CURRICULUM_ROOT / "curriculum.yaml"
 PLANS_ROOT = CURRICULUM_ROOT / "plans"
 _EMPTY_YAML_VALUES = {"", "[]", "null", "Null", "NULL", "~"}
 
-# Track -> profile mapping. Professional tracks were deleted 2026-04-10
-# (STEM will eventually replace them; that work is not in this issue).
-# The entries are intentionally absent.
+# Track -> profile mapping. Keep this derived from config so newly added
+# seminar tracks do not silently render as core in state summaries.
 PROFILE_MAP = {
-    "a1": "core", "a2": "core", "b1": "core", "b2": "core",
-    "c1": "core", "c2": "core",
-    "hist": "seminar", "istorio": "seminar", "bio": "seminar",
-    "lit": "seminar", "lit-essay": "seminar", "lit-hist-fic": "seminar",
-    "lit-fantastika": "seminar", "lit-war": "seminar",
-    "lit-humor": "seminar", "lit-youth": "seminar",
-    "lit-doc": "seminar", "lit-drama": "seminar",
-    "lit-crimea": "seminar",
-    "oes": "seminar", "ruth": "seminar",
+    cfg["id"]: ("seminar" if cfg["id"] in SEMINAR_TRACK_IDS else "core")
+    for cfg in LEVELS
 }
 
 
@@ -154,6 +146,17 @@ def cache_get(key: str, ttl: float) -> object | None:
     entry = _ttl_cache.get(key)
     if entry and (time.monotonic() - entry[0]) < ttl:
         return entry[1]
+    return None
+
+
+def cache_get_with_age(key: str, ttl: float) -> tuple[object, float] | None:
+    """Return cached value and age if still within TTL, else None."""
+    entry = _ttl_cache.get(key)
+    if entry is None:
+        return None
+    age = time.monotonic() - entry[0]
+    if age < ttl:
+        return entry[1], age
     return None
 
 
@@ -384,14 +387,7 @@ def parse_phase_status_from_state(state: dict, phase_name: str) -> dict:
 
 def has_research_file(track_dir: Path, slug: str) -> bool:
     """Return True if a research file exists for this module (V5 or V6 format)."""
-    try:
-        research_dir = safe_join(track_dir, "research")
-        research_file = safe_join(research_dir, f"{slug}-research.md")
-        knowledge_packet = safe_join(research_dir, f"{slug}-knowledge-packet.md")
-    except ValueError:
-        return False
-
-    return research_file.exists() or knowledge_packet.exists()
+    return find_research_path(track_dir, slug) is not None
 
 
 def is_research_done(state: dict, track_dir: Path | None = None, slug: str | None = None) -> bool:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -61,6 +61,8 @@ from .state_coverage import (
 )
 from .state_helpers import (
     cache_get,
+    cache_get_with_age,
+    cache_invalidate,
     cache_set,
     detect_pipeline_version,
     get_audit_status,
@@ -87,6 +89,36 @@ router = APIRouter(tags=["state"])
 
 BUDGET_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "agent_budgets.yaml"
 AGENT_NAMES = ("claude", "codex", "gemini")
+STATE_SUMMARY_TTL_S = 60.0
+STATE_PIPELINE_TTL_S = 60.0
+STATE_RESEARCH_COVERAGE_TTL_S = 300.0
+STATE_RESEARCH_DETAIL_TTL_S = 120.0
+STATE_REVIEW_COVERAGE_TTL_S = 300.0
+STATE_PIPELINE_VERSIONS_TTL_S = 60.0
+
+
+def _with_state_meta(
+    result: dict[str, Any],
+    *,
+    source: str,
+    stale_after_s: float,
+    cache: str,
+    age_s: float | None = None,
+) -> dict[str, Any]:
+    """Attach freshness metadata without mutating the cached payload."""
+    payload = dict(result)
+    generated_at = str(payload.get("generated_at") or _isoformat_z(datetime.now(UTC)))
+    meta: dict[str, Any] = {
+        "generated_at": generated_at,
+        "source": source,
+        "cache": cache,
+        "stale_after_s": stale_after_s,
+        "stale": False,
+    }
+    if age_s is not None:
+        meta["age_s"] = round(age_s, 3)
+    payload["meta"] = meta
+    return payload
 
 
 def _isoformat_z(value: datetime) -> str:
@@ -418,34 +450,64 @@ async def routing_budget():
 
 
 @router.get("/summary")
-async def state_summary():
+async def state_summary(fresh: bool = Query(False)):
     """Full project snapshot. One call replaces 5 bash scripts at session start."""
-    cached = cache_get("summary", ttl=60.0)
+    if fresh:
+        cache_invalidate("summary")
+    cached = cache_get_with_age("summary", ttl=STATE_SUMMARY_TTL_S)
     if cached is not None:
-        return cached
+        value, age_s = cached
+        return _with_state_meta(
+            value,
+            source="fs:plans+orchestration+artifacts+research",
+            stale_after_s=STATE_SUMMARY_TTL_S,
+            cache="hit",
+            age_s=age_s,
+        )
     result = await asyncio.to_thread(compute_summary)
     cache_set("summary", result)
-    return result
+    return _with_state_meta(
+        result,
+        source="fs:plans+orchestration+artifacts+research",
+        stale_after_s=STATE_SUMMARY_TTL_S,
+        cache="miss",
+        age_s=0.0,
+    )
 
 
 @router.get("/pipeline/{track_id}")
-async def pipeline_track(track_id: str):
+async def pipeline_track(track_id: str, fresh: bool = Query(False)):
     """Per-module pipeline state for one track."""
     level_cfg = next((l for l in LEVELS if l["id"] == track_id), None)
     if not level_cfg:
         return JSONResponse(status_code=404, content={"error": f"Track '{track_id}' not found"})
 
     cache_key = f"pipeline_{track_id}"
-    cached = cache_get(cache_key, ttl=60.0)
+    if fresh:
+        cache_invalidate(cache_key)
+    cached = cache_get_with_age(cache_key, ttl=STATE_PIPELINE_TTL_S)
     if cached is not None:
-        return cached
+        value, age_s = cached
+        return _with_state_meta(
+            value,
+            source="fs:orchestration+audit+research",
+            stale_after_s=STATE_PIPELINE_TTL_S,
+            cache="hit",
+            age_s=age_s,
+        )
     result = await asyncio.to_thread(compute_pipeline_track, track_id, level_cfg)
     cache_set(cache_key, result)
-    return result
+    return _with_state_meta(
+        result,
+        source="fs:orchestration+audit+research",
+        stale_after_s=STATE_PIPELINE_TTL_S,
+        cache="miss",
+        age_s=0.0,
+    )
 
 
 @router.get("/pipeline-versions")
-async def pipeline_versions(track: str | None = Query(None)):
+async def pipeline_versions(track: str | None = Query(None), fresh: bool = Query(False)):
     """All modules grouped by pipeline version."""
     def _compute():
         counts = {"v6": 0, "v5": 0, "v3": 0, "unbuilt": 0}
@@ -489,12 +551,27 @@ async def pipeline_versions(track: str | None = Query(None)):
         }
 
     cache_key = f"pipeline_versions_{track or 'all'}"
-    cached = cache_get(cache_key, ttl=60.0)
+    if fresh:
+        cache_invalidate(cache_key)
+    cached = cache_get_with_age(cache_key, ttl=STATE_PIPELINE_VERSIONS_TTL_S)
     if cached is not None:
-        return cached
+        value, age_s = cached
+        return _with_state_meta(
+            value,
+            source="fs:orchestration",
+            stale_after_s=STATE_PIPELINE_VERSIONS_TTL_S,
+            cache="hit",
+            age_s=age_s,
+        )
     result = await asyncio.to_thread(_compute)
     cache_set(cache_key, result)
-    return result
+    return _with_state_meta(
+        result,
+        source="fs:orchestration",
+        stale_after_s=STATE_PIPELINE_VERSIONS_TTL_S,
+        cache="miss",
+        age_s=0.0,
+    )
 
 
 @router.get("/ready-to-build")
@@ -632,42 +709,87 @@ async def failing_modules(track: str | None = Query(None)):
 
 
 @router.get("/research-coverage")
-async def research_coverage():
+async def research_coverage(fresh: bool = Query(False)):
     """Per-track research completeness and quality."""
-    cached = cache_get("research_coverage", ttl=300.0)
+    if fresh:
+        cache_invalidate("research_coverage")
+    cached = cache_get_with_age("research_coverage", ttl=STATE_RESEARCH_COVERAGE_TTL_S)
     if cached is not None:
-        return cached
+        value, age_s = cached
+        return _with_state_meta(
+            value,
+            source="fs:research+dossiers",
+            stale_after_s=STATE_RESEARCH_COVERAGE_TTL_S,
+            cache="hit",
+            age_s=age_s,
+        )
     result = await asyncio.to_thread(compute_research_coverage)
     cache_set("research_coverage", result)
-    return result
+    return _with_state_meta(
+        result,
+        source="fs:research+dossiers",
+        stale_after_s=STATE_RESEARCH_COVERAGE_TTL_S,
+        cache="miss",
+        age_s=0.0,
+    )
 
 
 @router.get("/research/{track_id}")
-async def research_detail(track_id: str, min_score: int = 9):
+async def research_detail(track_id: str, min_score: int = 9, fresh: bool = Query(False)):
     """Per-module research quality with dimension scores, gaps, and upgrade queue."""
     level_cfg = next((l for l in LEVELS if l["id"] == track_id), None)
     if not level_cfg:
         return JSONResponse(status_code=404, content={"error": f"Track '{track_id}' not found"})
 
     cache_key = f"research_detail_{track_id}_{min_score}"
-    cached = cache_get(cache_key, ttl=120.0)
+    if fresh:
+        cache_invalidate(cache_key)
+    cached = cache_get_with_age(cache_key, ttl=STATE_RESEARCH_DETAIL_TTL_S)
     if cached is not None:
-        return cached
+        value, age_s = cached
+        return _with_state_meta(
+            value,
+            source="fs:research+dossiers",
+            stale_after_s=STATE_RESEARCH_DETAIL_TTL_S,
+            cache="hit",
+            age_s=age_s,
+        )
 
     result = await asyncio.to_thread(compute_research_detail, track_id, level_cfg, min_score)
     cache_set(cache_key, result)
-    return result
+    return _with_state_meta(
+        result,
+        source="fs:research+dossiers",
+        stale_after_s=STATE_RESEARCH_DETAIL_TTL_S,
+        cache="miss",
+        age_s=0.0,
+    )
 
 
 @router.get("/review-coverage")
-async def review_coverage():
+async def review_coverage(fresh: bool = Query(False)):
     """Per-track review and final-review coverage + quality signal."""
-    cached = cache_get("review_coverage", ttl=300.0)
+    if fresh:
+        cache_invalidate("review_coverage")
+    cached = cache_get_with_age("review_coverage", ttl=STATE_REVIEW_COVERAGE_TTL_S)
     if cached is not None:
-        return cached
+        value, age_s = cached
+        return _with_state_meta(
+            value,
+            source="fs:review+audit",
+            stale_after_s=STATE_REVIEW_COVERAGE_TTL_S,
+            cache="hit",
+            age_s=age_s,
+        )
     result = await asyncio.to_thread(compute_review_coverage)
     cache_set("review_coverage", result)
-    return result
+    return _with_state_meta(
+        result,
+        source="fs:review+audit",
+        stale_after_s=STATE_REVIEW_COVERAGE_TTL_S,
+        cache="miss",
+        age_s=0.0,
+    )
 
 
 @router.get("/build-status/{track_id}")

--- a/scripts/research/research_quality.py
+++ b/scripts/research/research_quality.py
@@ -140,6 +140,10 @@ from research.research_markdown_utils import (
     extract_section as _extract_section,
 )
 
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOCS_RESEARCH_ROOT = PROJECT_ROOT / "docs" / "research"
+_docs_research_index_cache: dict[Path, tuple[float, dict[str, Path]]] = {}
+
 # ==================== SUBSTANCE SCORING ====================
 
 # Substance thresholds by tier.
@@ -917,7 +921,8 @@ def _compute_gaps(dims: dict) -> list[str]:
 def find_research_path(track_dir: Path, slug: str) -> Path | None:
     """Find the research file path for a module.
 
-    Checks V5 format ({slug}-research.md) and V6 format ({slug}-knowledge-packet.md).
+    Checks curriculum research output first, then seminar dossier files
+    under docs/research/{track}/{slug}.md.
     """
     research_dir = track_dir / "research"
     for candidate in [
@@ -931,7 +936,38 @@ def find_research_path(track_dir: Path, slug: str) -> Path | None:
                 return rp
         except ValueError:
             pass
+
+    for candidate in [
+        f"{slug}.md",
+        f"{slug}-research.md",
+        f"{slug}-knowledge-packet.md",
+    ]:
+        rp = _docs_research_index(track_dir.name).get(candidate)
+        if rp:
+            return rp
     return None
+
+
+def _docs_research_index(track_id: str) -> dict[str, Path]:
+    """Return filename -> path index for docs/research/{track_id}."""
+    docs_research_dir = DOCS_RESEARCH_ROOT / track_id
+    if not docs_research_dir.is_dir():
+        return {}
+    try:
+        mtime = docs_research_dir.stat().st_mtime
+    except OSError:
+        return {}
+    cached = _docs_research_index_cache.get(docs_research_dir)
+    if cached and cached[0] == mtime:
+        return cached[1]
+
+    index = {
+        path.name: path
+        for path in docs_research_dir.iterdir()
+        if path.is_file() and path.suffix == ".md"
+    }
+    _docs_research_index_cache[docs_research_dir] = (mtime, index)
+    return index
 
 
 # ==================== PUBLIC API ====================

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -115,6 +115,17 @@ class TestStateSummaryEndpoint:
         assert "tracks" in data
         assert isinstance(data["tracks"], dict)
 
+    def test_has_freshness_meta_and_dossier_fields(self):
+        data = client.get("/api/state/summary?fresh=true").json()
+        meta = data["meta"]
+        assert meta["source"] == "fs:plans+orchestration+artifacts+research"
+        assert meta["cache"] == "miss"
+        assert meta["stale_after_s"] == 60.0
+        assert "dossier_done" in data["totals"]
+        assert "published_mdx" in data["totals"]
+        assert data["tracks"]["folk"]["profile"] == "seminar"
+        assert data["tracks"]["folk"]["is_seminar"] is True
+
 
 class TestPipelineVersionsEndpoint:
     """GET /api/state/pipeline-versions returns version counts."""
@@ -146,6 +157,26 @@ class TestDashboardOverviewEndpoint:
         totals = data["totals"]
         for key in ["pass", "fail", "missing", "unaudited", "total"]:
             assert key in totals
+
+    def test_track_counts_match_state_summary(self):
+        summary = client.get("/api/state/summary?fresh=true").json()
+        overview = client.get("/api/dashboard/overview").json()
+
+        overview_counts = {track["id"]: track["module_count"] for track in overview["tracks"]}
+        summary_counts = {track: stats["total"] for track, stats in summary["tracks"].items()}
+
+        assert overview_counts == summary_counts
+        assert overview_counts["lit-doc"] == summary_counts["lit-doc"]
+        assert overview_counts["lit-crimea"] == summary_counts["lit-crimea"]
+
+    def test_overview_reuses_state_summary_cache_and_track_specific_research_metric(self):
+        summary = client.get("/api/state/summary?fresh=true").json()
+        overview = client.get("/api/dashboard/overview").json()
+        tracks = {track["id"]: track for track in overview["tracks"]}
+
+        assert overview["meta"]["cache"] == "hit"
+        assert tracks["a1"]["stats"]["research"]["total"] == summary["tracks"]["a1"]["research_done"]
+        assert tracks["folk"]["stats"]["research"]["total"] == summary["tracks"]["folk"]["dossier_done"]
 
 
 # ==================== Router mounting tests ====================

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -116,6 +116,21 @@ def test_comms_page_keeps_secondary_dashboard_links():
         assert f'href="{href}"' in html
 
 
+def test_progress_page_surfaces_freshness_and_dossiers():
+    html = (DASHBOARDS / "progress.html").read_text(encoding="utf-8")
+    assert "freshness-banner" in html
+    assert "/api/state/summary?fresh=true" in html
+    assert "/api/state/pipeline-versions?fresh=true" in html
+    assert "dossier_done" in html
+    assert "published_mdx" in html
+    assert "audit_stale" in html
+    assert "nextAction" in html
+    assert "Research gap" in html
+    assert "Build content" in html
+    index_html = (DASHBOARDS / "index.html").read_text(encoding="utf-8")
+    assert "t.dossier_done ?? 0" in index_html
+
+
 def test_artifacts_page_uses_metadata_endpoint_and_filters():
     html = (DASHBOARDS / "artifacts.html").read_text(encoding="utf-8")
     assert "/api/artifacts/html" in html

--- a/tests/test_research_quality.py
+++ b/tests/test_research_quality.py
@@ -11,6 +11,7 @@ from scripts.research.research_quality import (
     _score_claim_grounding,
     _score_discovery_integration,
     _score_source_verification,
+    find_research_path,
 )
 
 
@@ -65,6 +66,39 @@ class TestParseDiscovery:
         path.write_text("- item1\n- item2\n")
         result = _parse_discovery(path)
         assert result == _make_discovery()
+
+
+class TestFindResearchPath:
+    def test_prefers_curriculum_research_file(self, tmp_path, monkeypatch):
+        import scripts.research.research_quality as research_quality
+
+        track_dir = tmp_path / "curriculum" / "l2-uk-en" / "bio"
+        research_dir = track_dir / "research"
+        docs_dir = tmp_path / "docs" / "research" / "bio"
+        research_dir.mkdir(parents=True)
+        docs_dir.mkdir(parents=True)
+        curriculum_file = research_dir / "ivan-franko-research.md"
+        docs_file = docs_dir / "ivan-franko.md"
+        curriculum_file.write_text("curriculum research", encoding="utf-8")
+        docs_file.write_text("docs dossier", encoding="utf-8")
+
+        monkeypatch.setattr(research_quality, "DOCS_RESEARCH_ROOT", tmp_path / "docs" / "research")
+
+        assert find_research_path(track_dir, "ivan-franko") == curriculum_file
+
+    def test_falls_back_to_docs_research_dossier(self, tmp_path, monkeypatch):
+        import scripts.research.research_quality as research_quality
+
+        track_dir = tmp_path / "curriculum" / "l2-uk-en" / "bio"
+        docs_dir = tmp_path / "docs" / "research" / "bio"
+        track_dir.mkdir(parents=True)
+        docs_dir.mkdir(parents=True)
+        docs_file = docs_dir / "ivan-franko.md"
+        docs_file.write_text("docs dossier", encoding="utf-8")
+
+        monkeypatch.setattr(research_quality, "DOCS_RESEARCH_ROOT", tmp_path / "docs" / "research")
+
+        assert find_research_path(track_dir, "ivan-franko") == docs_file
 
 
 # ── _score_source_verification ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #2788.

This PR makes the local Monitor API and dashboard status surfaces agree on current curriculum state after the recent A1 UX and seminar dossier work.

## Diagnosis

The stale/misleading state came from several separate drifts:

- `/api/state/summary` was cached but did not expose cache metadata, and `?fresh=true` was ignored on the state endpoint itself.
- `/api/dashboard/overview` used only `curriculum.yaml` module lists, while `/api/state/summary` fell back to `plans/{track}/*.yaml`; dashboard totals were 1,833 while state totals were 1,858.
- `PROFILE_MAP` was hard-coded and omitted `folk`, so `folk` rendered as `core` even though config treats it as a seminar track.
- Seminar dossier files under `docs/research/{track}` were invisible to the research state helpers, so BIO looked like 0 research/dossier coverage despite local dossier files.
- The progress UI rendered counts without showing cache age, source, dossier state, published MDX state, stale audit state, or next-action hints.

## State Contract

`/api/state/summary`, `/api/state/pipeline/{track}`, `/api/state/pipeline-versions`, `/api/state/research-coverage`, `/api/state/research/{track}`, and `/api/state/review-coverage` now return a backward-compatible top-level payload plus `meta`:

- `meta.generated_at`
- `meta.source`
- `meta.cache`
- `meta.stale_after_s`
- `meta.stale`
- `meta.age_s` when served from the in-process cache

`?fresh=true` now bypasses the relevant state cache.

The summary payload now also exposes explicit source/state categories:

- module catalog source: `curriculum.yaml` or `plans-fallback`
- generated markdown: `generated_md`
- published Starlight MDX: `published_mdx`
- seminar/core profile: `profile`, `is_seminar`
- dossier coverage: `dossier_done`, `dossier_docs`, `dossier_curriculum`
- stale audit cache count: `audit_stale`

Dossier discovery now checks curriculum research outputs first, then `docs/research/{track}/{slug}.md`.

## UI

`progress.html` is now the canonical fast visual overview. It shows:

- API source/cache freshness banner
- core vs seminar tracks
- dossier/research coverage
- generated content and published MDX coverage
- stale audit warnings
- next-action hints per track
- module-chip tooltips with dossier and published state

`index.html` uses fresh summary data for the progress card.

## Dashboard Route Inventory

No dashboard page was removed in this slice. Rationale is documented in `docs/MONITOR-API.md`:

- Keep `progress.html` as the consolidated trustworthy status overview.
- Keep `audit-dashboard.html` for QA gate drilldowns.
- Keep `quality.html` for research/review/weak-point fix queues.
- Keep `track-health.html` for build-status and enrichment views.
- Keep `curriculum-dashboard.html` for plan/meta inspection.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_research_quality.py tests/test_api_endpoints.py tests/test_orient_api.py tests/test_monitor_ui_contracts.py tests/test_dashboards.py -q` — 222 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check ...` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m py_compile ...` — passed
- `git diff --check` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Branch API smoke on `127.0.0.1:8767`: fresh summary ~2.55s, fresh orient ~2.60s

## Notes

Independent Gemini bridge review completed: Round 1 BLOCKING, fixes pushed, Round 2 CLEAN on f1f02baa88.
