### PR TITLE
fix(a1): bridge M2 syllable practice from M1

### DIFF
--- a/curriculum/l2-uk-en/a1/reading-ukrainian/module.md
+++ b/curriculum/l2-uk-en/a1/reading-ukrainian/module.md
@@ -5,6 +5,10 @@ not need long Ukrainian sentences. The goal is smaller and more useful: see a
 word, find its vowel sounds, split it into syllables, and read it without
 guessing from English spelling habits.
 
+You already practiced counting **склади** in Module 1 with the rule **one vowel
+sound = one склад**. Here we use that same skill more deliberately: not just to
+count syllables, but as the first step for reading any new Ukrainian word.
+
 By the end, you can:
 
 - count syllables by counting vowel sounds;

--- a/starlight/src/content/docs/a1/reading-ukrainian.mdx
+++ b/starlight/src/content/docs/a1/reading-ukrainian.mdx
@@ -61,6 +61,10 @@ not need long Ukrainian sentences. The goal is smaller and more useful: see a
 word, find its vowel sounds, split it into syllables, and read it without
 guessing from English spelling habits.
 
+You already practiced counting **склади** in Module 1 with the rule **one vowel
+sound = one склад**. Here we use that same skill more deliberately: not just to
+count syllables, but as the first step for reading any new Ukrainian word.
+
 By the end, you can:
 
 - count syllables by counting vowel sounds;


### PR DESCRIPTION
## Summary
- Adds an explicit M2 bridge that says learners already practiced counting склади in Module 1.
- Frames M2 as reusing that count-syllables skill as a reading strategy.
- Regenerates the matching Starlight MDX for A1 M2.

## Validation
- npx markdownlint-cli2 --no-globs curriculum/l2-uk-en/a1/reading-ukrainian/module.md starlight/src/content/docs/a1/reading-ukrainian.mdx
- YAML safe_load for A1 M2 activities/vocabulary/resources
- git diff --check
- pre-commit hooks on commit/push

## Notes
- scripts/validate/validate_yaml.py reports a pre-existing schema issue for the unchanged A1 M2 watch-and-repeat activity.
- ./services.sh build starlight could not run in the fresh dispatch worktree because Starlight node_modules/Astro are not installed there; GitHub CI should cover the build.

X-Agent: codex/2788-m2-syllable-bridge