### PR TITLE
[codex] Monitor API/UI route contracts and live routing page

### DIFF
--- a/dashboards/artifacts.html
+++ b/dashboards/artifacts.html
@@ -133,6 +133,7 @@ body { min-height: 100vh; }
         <a class="ops-card runtime" href="/cost.html"><strong>Cost</strong><span>Per-module, per-phase, per-model token and USD spend.</span></a>
         <a class="ops-card curriculum" href="/curriculum-dashboard.html"><strong>Curriculum Dashboard</strong><span>Track plans, module plans, word targets, outlines.</span></a>
         <a class="ops-card pipeline" href="/delegate.html"><strong>Delegate</strong><span>Delegation tasks, zombie detection, task detail modal.</span></a>
+        <a class="ops-card runtime" href="/routing.html"><strong>Agent Routing</strong><span>Live routing budget, runtime inventory, usage, and delegate outcomes.</span></a>
         <a class="ops-card curriculum" href="/image-explorer.html"><strong>Images</strong><span>Page context, bounding boxes, annotation editor, RAG search.</span></a>
         <a class="ops-card runtime" href="/orient.html"><strong>Orient</strong><span>Session snapshot: git, issues, pipeline, runtime, health.</span></a>
         <a class="ops-card pipeline" href="/progress.html"><strong>Progress</strong><span>Pipeline state across tracks from research through MDX.</span></a>

--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -3,52 +3,59 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Agent Routing &amp; Usage - ukraine-ops</title>
+<title>Agent Routing - ukraine-ops</title>
 <link rel="icon" href="data:,">
-<style>
-:root {
-  --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --border: #30363d;
-  --text: #e6edf3; --text2: #8b949e; --text3: #6e7681;
-  --green: #3fb950; --blue: #58a6ff; --red: #f85149; --yellow: #d29922;
-  --gray: #484f58; --purple: #bc8cff; --orange: #f0883e; --cyan: #39d2c0;
-}
-* { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
-a { color: var(--blue); text-decoration: none; }
-a:hover { text-decoration: underline; }
-.topbar { display: flex; align-items: center; gap: 14px; padding: 16px 24px; border-bottom: 1px solid var(--border); background: var(--bg2); }
-.topbar h1 { font-size: 22px; font-weight: 700; }
-.topbar .sub { font-size: 12px; color: var(--text2); }
-.topbar .spacer { flex: 1; }
-.container { max-width: 1200px; margin: 0 auto; padding: 24px; }
-.note { font-size: 12px; color: var(--text3); margin: 4px 0 20px; }
-.card { background: var(--bg2); border: 1px solid var(--border); border-left: 3px solid var(--blue); border-radius: 10px; padding: 18px; margin-bottom: 18px; }
-.card.green { border-left-color: var(--green); }
-.card.orange { border-left-color: var(--orange); }
-.card.purple { border-left-color: var(--purple); }
-.card h2 { font-size: 15px; font-weight: 600; margin-bottom: 12px; }
-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-th { text-align: left; padding: 8px 10px; color: var(--text3); font-size: 11px; text-transform: uppercase; border-bottom: 1px solid var(--border); }
-td { padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
-tr:last-child td { border-bottom: none; }
-.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
-.pill { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 600; }
-.pill.ok { background: rgba(63,185,80,0.15); color: var(--green); }
-.pill.warn { background: rgba(210,153,34,0.15); color: var(--yellow); }
-.pill.err { background: rgba(248,81,73,0.15); color: var(--red); }
-.pill.gray { background: rgba(72,79,88,0.2); color: var(--text2); }
-ul { margin: 6px 0 0 18px; font-size: 13px; line-height: 1.55; color: var(--text2); }
-.bar { height: 8px; border-radius: 4px; background: var(--bg3); overflow: hidden; min-width: 90px; }
-.bar > span { display: block; height: 100%; background: var(--blue); }
-</style>
 <link rel="stylesheet" href="/monitor.css">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { min-height: 100vh; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; }
+.top-bar { display:flex; align-items:center; justify-content:space-between; gap:16px; padding:16px 24px; position:sticky; top:0; z-index:10; }
+.top-left h1 { font-size:24px; margin:0; }
+.top-left span { display:block; font-size:12px; margin-top:2px; color:var(--text2); }
+.wrap { max-width:1180px; margin:0 auto; padding:28px 24px 72px; width:100%; }
+.hero { border-bottom:1.5px solid var(--text); display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; margin-bottom:24px; padding-bottom:18px; }
+.hero h2 { font-family: Charter, Georgia, serif; font-size:34px; line-height:1.1; margin:0 0 8px; }
+.hero p { color:var(--text2); font-size:15px; line-height:1.45; max-width:700px; }
+.actions { display:flex; gap:8px; align-items:center; justify-content:flex-end; }
+button { background:var(--bg2); border:1px solid var(--border); border-radius:4px; color:var(--text); cursor:pointer; font:inherit; padding:8px 12px; }
+button:hover { border-color:var(--accent); }
+.status { color:var(--text3); font-size:12px; min-width:160px; text-align:right; }
+.grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); gap:12px; margin-bottom:18px; }
+.panel { background:var(--bg2); border:1px solid var(--border); border-radius:4px; padding:16px; }
+.panel h3 { font-family: Charter, Georgia, serif; font-size:18px; margin-bottom:8px; }
+.panel .value { color:var(--accent); font-family: Charter, Georgia, serif; font-size:32px; font-weight:700; line-height:1.05; }
+.panel .sub { color:var(--text2); font-size:13px; line-height:1.45; margin-top:8px; }
+.panel.warn { border-left:3px solid var(--orange); }
+.panel.ok { border-left:3px solid var(--green); }
+.panel.info { border-left:3px solid var(--cyan); }
+table { width:100%; border-collapse:collapse; font-size:13px; }
+th { border-bottom:1px solid var(--border); color:var(--text3); font-size:11px; padding:8px 10px; text-align:left; text-transform:uppercase; }
+td { border-bottom:1px solid var(--border); padding:8px 10px; vertical-align:top; }
+tr:last-child td { border-bottom:none; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+.pill { border-radius:999px; display:inline-flex; font-size:11px; font-weight:650; padding:2px 8px; }
+.pill.cool, .pill.ok, .pill.done { background:rgba(63,185,80,.15); color:var(--green); }
+.pill.warm, .pill.hot, .pill.warn, .pill.timeout { background:rgba(210,153,34,.15); color:var(--orange); }
+.pill.near_cap, .pill.error, .pill.failed, .pill.rate_limited, .pill.zombie { background:rgba(248,81,73,.15); color:var(--red); }
+.pill.gray, .pill.unknown, .pill.spawning, .pill.running { background:rgba(72,79,88,.2); color:var(--text2); }
+.bar { background:var(--bg3); border-radius:4px; height:8px; overflow:hidden; min-width:90px; }
+.bar span { background:var(--accent); display:block; height:100%; }
+.section { margin-top:18px; }
+.section h2 { font-family: Charter, Georgia, serif; font-size:22px; margin:0 0 10px; }
+.error { color:var(--red); font-size:13px; padding:12px 0; }
+@media (max-width: 820px) {
+  .hero { grid-template-columns:1fr; }
+  .actions { justify-content:flex-start; }
+  .status { text-align:left; }
+}
+</style>
 </head>
 <body>
-<div class="topbar">
-  <h1>Agent Routing &amp; Usage</h1>
-  <span class="sub">which agent for what · subscription headroom · dispatch usage snapshot</span>
-  <span class="spacer"></span>
-  <a href="/">&larr; Home</a> &nbsp; <a href="/delegate.html">Delegate</a> &nbsp; <a href="/cost.html">Cost</a> &nbsp; <a href="/runtime.html">Runtime</a>
+<div class="top-bar">
+  <div class="top-left">
+    <h1>Agent Routing</h1>
+    <span>Live routing budget, runtime inventory, usage, and recent delegate outcomes</span>
+  </div>
   <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
     <a href="/orient.html">Orient</a>
@@ -58,59 +65,189 @@ ul { margin: 6px 0 0 18px; font-size: 13px; line-height: 1.55; color: var(--text
     <a href="/runtime.html">Runtime</a>
   </nav>
 </div>
-<div class="container">
-  <p class="note">Static snapshot, refreshed manually by the bio-driver. Live data: <a href="/delegate.html">delegate</a> (dispatch activity), <a href="/cost.html">cost</a> ($ spend), <a href="/runtime.html">runtime</a> (7-day usage). Billed quota lives in each vendor dashboard (cursor.com, Anthropic console, platform.openai.com).</p>
 
-  <div class="card green">
-    <h2>Who should do what (recommended routing)</h2>
-    <table>
-      <tr><th>Work</th><th>Primary</th><th>Backup / notes</th></tr>
-      <tr><td>Bio / seminar plan writing</td><td><b>Cursor (3&times;)</b></td><td>Codex; Claude for most sensitive. Gemini deprioritized (ghost-source history)</td></tr>
-      <tr><td>V7 module content</td><td>Cursor-tools / Claude-tools</td><td>use Cursor to spare the Claude seat</td></tr>
-      <tr><td>Wiki articles</td><td><b>Gemini</b> (unmetered)</td><td>always</td></tr>
-      <tr><td>Novel code / hard debug</td><td><b>Codex</b></td><td>Claude inline only &le;5 LOC</td></tr>
-      <tr><td>Bulk / mechanical code, fixtures, docs</td><td><b>Gemini</b> (unmetered)</td><td>&mdash;</td></tr>
-      <tr><td>Content review (cross-family)</td><td><b>DeepSeek-pro hermes</b></td><td>flaky &rarr; Codex / Claude must backstop</td></tr>
-      <tr><td>PR code review</td><td>DeepSeek-flash / Codex</td><td>off-seat</td></tr>
-      <tr><td>Search / grep</td><td>Explore subagent (haiku)</td><td>cheap</td></tr>
-      <tr><td>qwen</td><td><span class="pill err">never</span></td><td>too expensive (user 2026-05-29)</td></tr>
-    </table>
-  </div>
+<main class="wrap">
+  <section class="hero">
+    <div>
+      <h2>Dispatch routing</h2>
+      <p>Current agent budget headroom, in-flight work, runtime availability, and recent delegate outcomes.</p>
+    </div>
+    <div class="actions">
+      <button id="refresh-btn" type="button">Refresh</button>
+      <div class="status" id="refresh-status">Loading...</div>
+    </div>
+  </section>
 
-  <div class="card purple">
-    <h2>Subscription-max guidance</h2>
-    <ul>
-      <li><b>Cursor &mdash; now Pro+ (3&times;).</b> The cheapest top-quality writer; most under-realized subscription. Make it the lead bio/plan writer. (Always driver-finalize its git: it writes but doesn't commit/push.)</li>
-      <li><b>Gemini &mdash; unmetered.</b> Use freely for bulk code, fixtures, wiki, docs.</li>
-      <li><b>Codex &mdash; own weekly quota.</b> Novel impl, hard debug, adversarial review.</li>
-      <li><b>Claude seat &mdash; conserve.</b> Dispatched Claude competes with the interactive seat and sunsets after 2026-06-15 (MEMORY #M0). Reserve for sensitive content + adversarial review.</li>
-      <li><b>DeepSeek &mdash; cheap off-seat review.</b> Cross-family gate, but back it with Codex/Claude (flaky).</li>
-    </ul>
-  </div>
+  <div class="grid" id="summary-grid"></div>
 
-  <div class="card">
-    <h2>Dispatch usage snapshot &mdash; 327 tracked dispatches (batch_state, 2026-05-31)</h2>
-    <table>
-      <tr><th>Agent / model</th><th>Dispatches</th><th>Done</th><th>Signals</th><th>Share</th></tr>
-      <tr><td class="mono">codex / gpt-5.5</td><td>159</td><td>135 (85%)</td><td><span class="pill warn">16 timeouts</span> xhigh runs long</td><td><div class="bar"><span style="width:100%"></span></div></td></tr>
-      <tr><td class="mono">gemini / 3.x</td><td>74</td><td>64 (86%)</td><td><span class="pill ok">healthy</span> unmetered</td><td><div class="bar"><span style="width:47%"></span></div></td></tr>
-      <tr><td class="mono">claude / opus-4.7+4.8</td><td>30</td><td>26</td><td>mostly reviews; seat-shared</td><td><div class="bar"><span style="width:19%"></span></div></td></tr>
-      <tr><td class="mono">deepseek / v4</td><td>24</td><td>20</td><td><span class="pill warn">4 timeouts</span> flaky reviewer</td><td><div class="bar"><span style="width:15%"></span></div></td></tr>
-      <tr><td class="mono">qwen</td><td>17</td><td>11</td><td><span class="pill err">excluded</span> too expensive</td><td><div class="bar"><span style="width:11%"></span></div></td></tr>
-      <tr><td class="mono">cursor / auto</td><td>10</td><td><span class="pill err">0</span></td><td>4 rate_limited (fixed by 3&times;) · 4 needs_finalize · 2 failed</td><td><div class="bar"><span style="width:6%"></span></div></td></tr>
-      <tr><td class="mono">agy / grok</td><td>7 / 4</td><td>experimental</td><td>agy never for facts</td><td><div class="bar"><span style="width:4%"></span></div></td></tr>
-    </table>
-    <p class="note">Outcomes overall: 266 done · 25 timeout · 18 cancelled · 5 failed · 4 rate_limited. The Cursor 3&times; upgrade directly removes the rate-limited failures.</p>
-  </div>
+  <section class="section panel">
+    <h2>Budget Headroom</h2>
+    <div id="budget-table"></div>
+  </section>
 
-  <div class="card orange">
-    <h2>Live bio epic #2309 lane</h2>
-    <ul>
-      <li>bio-260&rarr;310 (51) &mdash; <span class="pill ok">built + merged</span> @ <span class="mono">f25a2c7e12</span></li>
-      <li>bio-184&rarr;259 (75) &mdash; <span class="pill warn">building</span> 3-way split: Cursor ~30 · Codex ~25 · Claude ~20 (sensitive)</li>
-      <li>Phase-3 curriculum.yaml registration &mdash; <span class="pill gray">blocked</span> until 184-259 lands (position-contiguity)</li>
-    </ul>
-  </div>
-</div>
+  <section class="section panel">
+    <h2>Runtime Agents</h2>
+    <div id="agent-table"></div>
+  </section>
+
+  <section class="section panel">
+    <h2>Recent Delegates</h2>
+    <div id="delegate-table"></div>
+  </section>
+</main>
+
+<script>
+const API_TIMEOUT_MS = 5000;
+const ENDPOINTS = {
+  routing: '/api/state/routing-budget',
+  agents: '/api/runtime/agents',
+  usage: '/api/runtime/usage?days=7',
+  delegates: '/api/delegate/tasks?limit=100'
+};
+
+async function fetchJson(path) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const res = await fetch(path, { signal: controller.signal });
+    const text = await res.text();
+    let data = {};
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      data = { detail: text };
+    }
+    if (!res.ok) throw new Error(data.detail || data.error || `HTTP ${res.status}`);
+    return data;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[ch]));
+}
+
+function pct(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? Math.max(0, Math.min(100, num)) : 0;
+}
+
+function statusPill(status) {
+  const cls = String(status || 'unknown').toLowerCase();
+  return `<span class="pill ${escapeHtml(cls)}">${escapeHtml(status || 'unknown')}</span>`;
+}
+
+function renderSummary(routing, usage, delegates) {
+  const rec = routing.recommendation || {};
+  const warnings = rec.warnings || [];
+  const active = Object.values(routing.in_flight || {}).reduce((sum, val) => sum + Number(val || 0), 0);
+  const recentTasks = delegates.tasks || [];
+  const recentDone = recentTasks.filter(task => task.status === 'done').length;
+  document.getElementById('summary-grid').innerHTML = `
+    <div class="panel ok">
+      <h3>Primary Agent</h3>
+      <div class="value">${escapeHtml(rec.primary_agent_for_code || 'unknown')}</div>
+      <div class="sub">${escapeHtml(rec.rationale || '')}</div>
+    </div>
+    <div class="panel info">
+      <h3>In Flight</h3>
+      <div class="value">${active}</div>
+      <div class="sub">${Object.entries(routing.in_flight || {}).map(([k,v]) => `${escapeHtml(k)}: ${escapeHtml(v)}`).join(' | ') || 'No active delegates'}</div>
+    </div>
+    <div class="panel ${warnings.length ? 'warn' : 'ok'}">
+      <h3>Warnings</h3>
+      <div class="value">${warnings.length}</div>
+      <div class="sub">${warnings.map(escapeHtml).join('<br>') || 'No routing warnings'}</div>
+    </div>
+    <div class="panel info">
+      <h3>7-Day Runtime Calls</h3>
+      <div class="value">${escapeHtml(usage.records_total || 0)}</div>
+      <div class="sub">${recentDone}/${recentTasks.length} recent delegate records done</div>
+    </div>
+  `;
+}
+
+function renderBudget(routing) {
+  const agents = routing.agents || {};
+  const rows = Object.entries(agents).map(([name, data]) => {
+    const burn = pct(data.burn_pct_7d);
+    const cap = data.weekly_cap_usd == null ? 'n/a' : `$${Number(data.weekly_cap_usd).toFixed(0)}`;
+    return `<tr>
+      <td class="mono">${escapeHtml(name)}</td>
+      <td>${statusPill(data.status)}</td>
+      <td>${burn.toFixed(1)}%</td>
+      <td><div class="bar"><span style="width:${burn}%"></span></div></td>
+      <td>${cap}</td>
+      <td>${escapeHtml((routing.in_flight || {})[name] ?? 0)}</td>
+    </tr>`;
+  }).join('');
+  document.getElementById('budget-table').innerHTML = `<table>
+    <tr><th>Agent</th><th>Status</th><th>7d Burn</th><th>Headroom</th><th>Weekly Cap</th><th>In Flight</th></tr>
+    ${rows || '<tr><td colspan="6">No budget data.</td></tr>'}
+  </table>`;
+}
+
+function renderAgents(agents, usage) {
+  const byAgent = usage.by_agent || {};
+  const rows = (agents.agents || []).map(agent => {
+    const stats = byAgent[agent.name] || {};
+    return `<tr>
+      <td class="mono">${escapeHtml(agent.name)}</td>
+      <td>${escapeHtml(agent.default_model || '')}</td>
+      <td>${escapeHtml(agent.binary || '')}</td>
+      <td>${escapeHtml((agent.supported_modes || []).join(', '))}</td>
+      <td>${escapeHtml(stats.total || 0)}</td>
+      <td>${escapeHtml(stats.ok || 0)}</td>
+      <td>${escapeHtml((stats.error || 0) + (stats.timeout || 0) + (stats.rate_limited || 0))}</td>
+    </tr>`;
+  }).join('');
+  document.getElementById('agent-table').innerHTML = `<table>
+    <tr><th>Agent</th><th>Default Model</th><th>Binary</th><th>Modes</th><th>7d Calls</th><th>OK</th><th>Issues</th></tr>
+    ${rows || '<tr><td colspan="7">No runtime agents found.</td></tr>'}
+  </table>`;
+}
+
+function renderDelegates(delegates) {
+  const rows = (delegates.tasks || []).slice(0, 12).map(task => `<tr>
+    <td class="mono">${escapeHtml(task.task_id)}</td>
+    <td>${escapeHtml(task.agent || '')}</td>
+    <td>${escapeHtml(task.model || '')}</td>
+    <td>${statusPill(task.status)}</td>
+    <td>${task.duration_s == null ? '' : `${Number(task.duration_s).toFixed(1)}s`}</td>
+    <td>${escapeHtml(task.started_at || '')}</td>
+  </tr>`).join('');
+  document.getElementById('delegate-table').innerHTML = `<table>
+    <tr><th>Task</th><th>Agent</th><th>Model</th><th>Status</th><th>Duration</th><th>Started</th></tr>
+    ${rows || '<tr><td colspan="6">No delegate tasks found.</td></tr>'}
+  </table>`;
+}
+
+async function loadRouting() {
+  const status = document.getElementById('refresh-status');
+  status.textContent = 'Loading...';
+  try {
+    const [routing, agents, usage, delegates] = await Promise.all([
+      fetchJson(ENDPOINTS.routing),
+      fetchJson(ENDPOINTS.agents),
+      fetchJson(ENDPOINTS.usage),
+      fetchJson(ENDPOINTS.delegates)
+    ]);
+    renderSummary(routing, usage, delegates);
+    renderBudget(routing);
+    renderAgents(agents, usage);
+    renderDelegates(delegates);
+    status.textContent = `Updated ${new Date().toLocaleTimeString()}`;
+  } catch (err) {
+    status.textContent = 'Load failed';
+    document.getElementById('summary-grid').innerHTML = `<div class="error">API unavailable: ${escapeHtml(err.message)}</div>`;
+  }
+}
+
+document.getElementById('refresh-btn').addEventListener('click', loadRouting);
+loadRouting();
+</script>
 </body>
 </html>

--- a/docs/monitor-api-ui-audit-2026-06-07.md
+++ b/docs/monitor-api-ui-audit-2026-06-07.md
@@ -1,0 +1,117 @@
+# Monitor API/UI Audit - 2026-06-07
+
+Issue: #2794
+Baseline: `2a768923d6` (`fix(monitor): make status dashboard trustworthy (#2790)`)
+
+## Scope
+
+This pass audits the local Monitor API and dashboard UI after #2790 made
+`/api/state` and the main state dashboards trustworthy. The inventory covers:
+
+- FastAPI routes mounted from `scripts/api/main.py` and `scripts/api/**`
+- Local dashboard pages in `dashboards/**`
+- Monitor API consumers in `starlight/src/**`
+- Dashboard generation and Monitor-client scripts that consume the API
+
+Route inventory was generated from the FastAPI app object, not by guessing from
+source text. Dashboard consumer inventory was checked with literal `/api/...`
+references in `dashboards/**` and `starlight/src/**`.
+
+## Current Inventory
+
+- FastAPI public HTTP routes: 175 total
+- Routes under `/api/*`: 169
+- Deprecated API routes: 6
+- WebSocket routes: 1 (`/ws/batch`)
+- Local dashboard HTML pages: 20 plus `dashboards/monitor.css` and
+  `dashboards/data/status.json`
+- Starlight Monitor API consumer: `starlight/src/components/LiveStatus.tsx`
+
+## Route Matrix
+
+| Endpoint family | Purpose | Source of truth | Cache / freshness contract | Primary consumers | Overlap / duplication | Stale or misleading risk | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/state/*` except `/api/state/reviewer-ghosts/*` | Canonical project, track, module, research, review, build, routing, manifest state | `curriculum.yaml`, `plans/**`, orchestration `state.json`, research/dossier docs, generated/published artifacts, review/audit files, cost records | Explicit per-endpoint TTLs in `state_router.py`; major endpoints return `meta.source`, `meta.cache`, `meta.stale_after_s`; `?fresh=true` on summary, pipeline, coverage, versions | `progress.html`, `track-health.html`, `quality.html`, `index.html`, Starlight `LiveStatus`, agents | Overlaps old `/api/blue/live-status`, `/api/dashboard/overview`, and some `/api/gold/*` views | Low after #2790 for summary/progress; medium for state endpoints that still omit `meta` | Keep canonical. Add a machine-readable route contract registry so every endpoint has an explicit source/freshness statement even when payload lacks `meta`. |
+| `/api/state/reviewer-ghosts/*` | Reviewer hallucination telemetry for missing-anchor `<fixes>` bundles | `curriculum/l2-uk-en/{track}/review/*-ghost-review-r*.yaml` | No route cache; per-request directory scan with optional `slug` and `since` filters | Future dashboards, agents, tests | Physically under `/api/state`, logically telemetry | Low/medium: globbing it into canonical state would misstate purpose | Keep as a distinct contract row despite the `/api/state` mount. |
+| `/api/dashboard/*` | Rich dashboard projections for audit/curriculum/comms pages | Dashboard helper scans over plans, status cache, research, review, orchestration, broker | `_track_cache` 30s, `_summary_cache` 60s, shared state-summary cache 60s for overview; most payloads do not expose meta | `audit-dashboard.html`, `curriculum-dashboard.html`, `index.html` | Overlaps `/api/state/*` for counts/progress; richer module detail remains distinct | Medium: consumers can forget these are derived projections, not canonical state | Keep for page-specific detail. Contract says `/api/state/*` is canonical for counts and freshness-sensitive state. |
+| `/api/blue/*` | Legacy Blue/final-review helper endpoints | Status cache, module files, activity YAML, review files, batch state | No route cache; `/audit?...fresh=true` runs audit script as side effect; `/live-status` is deprecated and returns deprecation headers | Agents and old docs; no active dashboard for `/live-status` | `/live-status` duplicates `/api/state/build-status`; audit/final-review overlap artifact/state endpoints | High for `/live-status`; low/medium for final-review workflow | Retain final-review helpers. Keep `/live-status` deprecated with replacement header until consumers are gone. |
+| `/api/gold/*` and `/api/agent/*` | Older team/agent module inspection views | Plans, module files, orchestration, broker/runtime files | No route cache; live filesystem/broker reads | Agent docs and older workflows | Overlaps `/api/state/module`, `/api/artifacts`, `/api/dashboard/module` | Medium: legacy names hide canonical source | Retain for compatibility. Future slice can merge into `/api/state` and `/api/artifacts` after consumer audit. |
+| `/api/artifacts/*`, `/artifacts/*`, `/files/*` | Artifact classification, ship-ready checks, HTML/report file serving | Plans, generated files, Starlight MDX, review/audit docs, docs/audit reports | No route cache; file manifests and drift checks are live reads | `artifacts.html`, agents | Complements `/api/state`; overlaps on published/stale signals | Low | Keep. Contract should flag generated/status/review files as read-only evidence and not PR artifacts. |
+| `/api/comms/channels*`, `/api/comms/inbox`, `/api/comms/agent-activity` | Canonical channel bridge and agent activity | SQLite message broker and delivery tables | No route cache; live broker reads | `channels.html`, `/api/state/manifest`, agents | Replaces legacy message/conversation endpoints | Low | Keep canonical. |
+| `/api/comms/messages`, `/api/comms/conversations`, `/api/comms/conversation/*`, `/api/comms/send`, `/api/comms/live-activity` | Legacy direct-message bridge | SQLite broker and process probes | No route cache; deprecated in OpenAPI | `comms.html`, old `ask-*` path | Duplicates channel bridge | Medium: hidden legacy UI is still linked in primary nav; routes are deprecated but alive | Retain with explicit legacy contract. Do not delete before CLI/old UI migration. |
+| `/api/comms/batch-progress`, `/api/comms/zombies`, `/api/comms/active-processes`, `/api/comms/stats`, `/api/comms/health`, `/api/comms/cleanup`, `/api/comms/acknowledge`, `/api/comms/by-module/*` | Broker/process health, batch progress, zombie cleanup, module-linked messages | SQLite broker, process table/probes, build state | No route cache; live reads/writes where method is POST | `comms.html`, `track-health.html`, agents | Some status overlaps `/api/delegate/*` and `/api/build/events/*` | Low/medium | Keep; separate from deprecated legacy message send/list routes in contracts. |
+| `/api/delegate/*` | Delegated task list, active task count, result detail | `batch_state/tasks/*.json`, process liveness, result files | No route cache; live filesystem/process reads | `delegate.html`, `index.html`, agent cold starts | Complements `/api/orient.delegate` and `/api/comms` | Low | Keep. |
+| `/api/worktrees` | Active git worktree registry | `git worktree list --porcelain`, per-worktree `git status`, and `git log -1` | No route cache; bounded subprocess timeout per git call | Agents, cold-start tooling, worktree hygiene | Complements `/api/git/hygiene` and `/api/git/cleanup` | Low; failures degrade to empty/error payload | Keep. |
+| `/api/build/events/*` | Recent and active module build events | `curriculum/l2-uk-en/**/orchestration/**/dispatch/*-meta.json` plus state files | No route cache; scan capped at 5000 meta files | `build-events.html`, `comms.html`, `index.html` | Complements delegate and comms activity | Low | Keep. |
+| `/api/runtime/*` | Agent inventory, usage, headroom, auth mode | Runtime config, usage JSONL, environment presence booleans, OAuth credential presence | No route cache; live file/env reads; auth endpoint never returns secret values | `runtime.html`, `index.html`, agents | Cost/headroom overlaps `/api/state/routing-budget` and cost API | Low | Keep. |
+| `/api/cost/*`, `/api/analytics/cost/*` | Cost summaries by project/module/phase | `batch_state/api_usage/**` cost records | No route cache; live usage reads | `cost.html`, `index.html` | Duplicate mount: `/api/analytics/cost` and `/api/cost` | Low | Keep `/api/analytics/cost` canonical for UI; retain `/api/cost` as compatibility alias. |
+| `/api/wiki/*` | Wiki compilation status, quality gates, sources inventory | Wiki progress DB/state, wiki markdown files, `data/sources.db` | Uses shared TTL cache for selected expensive aggregate reads; article detail reads file bodies | `wiki.html`, `index.html` | Complements state summary published/wiki status | Low/medium | Keep. Contract should distinguish aggregate status from article body detail. |
+| `/api/images/*`, `/api/rag/*`, `/images/*` | Textbook image explorer, annotations, RAG search, page rendering | `data/textbook_images/**`, `data/textbooks/**`, annotation JSONL, Qdrant/RAG collections | Lazy in-memory image index; PDF pool and render LRU cache; `/api/images/reload` resets index | `image-explorer.html`; `images.html` redirects there | RAG search overlaps external MCP/source tools but UI-specific | Low | Keep. Preserve `images.html` as a redirect alias, not a full page. |
+| `/api/admin/*` | Local maintenance: health, backups, disk, broker vacuum, logs, Qdrant collection checks | Qdrant snapshots/storage, broker DB, logs, data directories | No route cache; live local maintenance operations | `admin.html` | None; operational only | Medium because POST/DELETE mutates local state | Keep local-only; contract must mark mutating endpoints. |
+| `/api/consultation/*` | Template proposal queue/history/metrics | Consultation queue/history files | No route cache; live filesystem reads/writes where method is POST | `consultation.html`, `index.html` | None | Low | Keep. |
+| `/api/decisions/*`, `/api/state/governance` | Decision/ADR governance | `docs/decisions/**`, ADR docs | No route cache in decision router; governance summary is cached through orient only | Docs, agents, orient | Related but distinct: decisions are detailed, governance is aggregate | Low | Keep. |
+| `/api/issues/map` | Open issue map with categories | `gh issue list` output | No route cache in handler; `/api/orient` wraps issue collection with a 120s cache and short timeout | Agents, issue hygiene | Overlaps `/api/orient.issues` | Medium if GitHub times out; handler returns best effort | Keep. |
+| `/api/rules`, `/api/session/current`, `/api/state/manifest`, `/api/orient` | Agent cold-start coordination | Deployed rules, session-state files, git/GH/runtime/wiki/health probes | Manifest hashes rules/session; rules/session support cache semantics; orient has section TTLs and `?fresh=true` | Agents, `orient.html`, session-start tooling | Replaces direct file spelunking | Low | Keep; document as cold-start source of truth. |
+| `/api/site/*`, `/api/health`, `/api/config`, `/api/git/*`, `/api/telemetry/*`, `/api/discussions/active`, `/api/batch/*` | Site reachability, server config, git hygiene, telemetry, discussions, legacy batch state | Public site probe/GH deployments, config constants, git, transcript timing records, broker, batch_state files | Mostly no route cache; orient may cache summaries of some sections | Agents, `orient.html`, `index.html`, docs | `/api/batch/*` overlaps delegate/build/comms and is older | Low/medium | Keep. Treat `/api/batch/*` as compatibility until orchestration clients migrate. |
+| `/ws/batch` | Legacy batch heartbeat stream | API process heartbeat loop | Sends `{"type":"heartbeat"}` every 5s while connected; no persisted state or cache | Legacy live monitors | Overlaps newer polling dashboards | Low/medium because it is invisible in OpenAPI | Keep with explicit WebSocket contract until websocket consumers are audited. |
+| Static: `/{path}`, `/docs`, `/openapi.json` | Static dashboards and FastAPI generated docs | `dashboards/**`, FastAPI app | Browser/static caching only; no API freshness contract | Humans | Catch-all can hide missing dashboard files if links are stale | Medium | Keep. Dashboard page contracts must scan literal files, not only FastAPI route list. |
+
+## Page Matrix
+
+| Page | Purpose | Source of truth | Cache / freshness behavior | Consumers | Overlap / duplication | Risk | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `/` (`dashboards/index.html`) | Operations launchpad and aggregate cards | API fanout: dashboard overview, state summary, orient, runtime, delegate, wiki, cost | Client fetches live endpoints with 5s timeout; state summary called with `fresh=true` | Humans | Links to every major dashboard | Low after #2790 | Keep. |
+| `/progress.html` | Canonical visual project progress | `/api/state/summary?fresh=true`, `/api/state/pipeline-versions?fresh=true`, `/api/state/pipeline/{track}?fresh=true` | Explicit fresh requests and freshness banner | Humans | Overlaps audit/curriculum but owns current progress | Low after #2790 | Keep canonical. |
+| `/audit-dashboard.html` | QA gate and audit drill-down | `/api/dashboard/overview`, `/api/dashboard/track/*`, `/api/dashboard/module/*`, `/api/state/module/*` | Dashboard helper caches 30/60s; state module is live | Humans | Overlaps progress counts | Medium | Keep for QA details; contract says progress/state are canonical for counts. |
+| `/quality.html` | Fix queue across research/reviews/issues/weak points | `/api/state/research-coverage`, `/api/state/review-coverage`, `/api/state/issues`, `/api/state/weak-points` | State coverage TTLs where configured; weak-points 60s cache | Humans | Complements progress | Low | Keep. |
+| `/track-health.html` | One-track build/audit/enrichment/review health | `/api/state/build-status`, `/api/state/enrichment-status`, `/api/state/track-health/*`, `/api/state/module/*`, `/api/comms/by-module/*` | Build-status 15/30s caches; enrichment 120s; track-health 30s | Humans | Overlaps progress | Low | Keep. |
+| `/curriculum-dashboard.html` | Plan/meta/module inspection | `/api/dashboard/overview`, `/api/dashboard/track/*`, `/api/dashboard/module/*` | Dashboard helper caches 30/60s | Humans | Overlaps audit/progress | Medium | Keep as inspection workflow, not canonical progress. |
+| `/channels.html` | Canonical channel bridge UI | `/api/comms/channels*` | Live broker reads; client refresh/deeplink state | Humans/agents | Replaces legacy comms | Low | Keep. |
+| `/comms.html` | Legacy direct-message, zombie, batch progress UI | Deprecated legacy comms routes plus build events and broker health | Live broker/process reads | Humans if needed | Duplicates channels for chat | Medium | Explicitly retain as legacy operations page until old CLI/users migrate. |
+| `/delegate.html` | Delegated task observability | `/api/delegate/tasks*` | Live task JSON/process reads | Humans | Complements comms/build-events | Low | Keep. |
+| `/runtime.html` | Agent runtime, usage, auth/headroom | `/api/runtime/*` | Live file/env reads with 5s client timeout | Humans | Complements routing/cost | Low | Keep. |
+| `/routing.html` | Agent routing guidance | Currently static stale snapshot | Manual refresh only | Humans via index card | Duplicates runtime, delegate, cost, routing-budget | High | Refactor in this slice to live `/api/state/routing-budget` + runtime/delegate data. |
+| `/cost.html` | Cost reports | `/api/analytics/cost*` | Live cost record reads | Humans | Complements routing/runtime | Low | Keep. |
+| `/build-events.html` | Build dispatch event timeline | `/api/build/events/*` | Live capped filesystem scans | Humans | Complements comms/delegate | Low | Keep. |
+| `/wiki.html` | Wiki build/quality/source overview | `/api/wiki/*` | Wiki router caches selected aggregates | Humans | Complements state published/wiki signals | Low | Keep. |
+| `/artifacts/` and `/artifacts.html` | Artifact/report browser | `/api/artifacts/html`, static file serving | Live metadata scan | Humans | Links all ops pages | Low | Keep. |
+| `/image-explorer.html` | Textbook image/RAG annotation UI | `/api/images/*`, `/api/rag/*`, `/images/*` | Lazy image index and render LRU | Humans | None | Low | Keep. |
+| `/images.html` | Redirect alias | No API source; meta refresh to `/image-explorer.html` | Static redirect | Legacy links | Duplicate alias | Low | Retain as redirect-only alias. |
+| `/admin.html` | Local maintenance | `/api/admin/*` | Live local operations | Humans | None | Medium due to mutating POST/DELETE actions | Keep. |
+| `/consultation.html` | Template proposal queue/history | `/api/consultation/*`, `/api/config` | Live queue/history reads | Humans | None | Low | Keep. |
+| `/orient.html` | Cold-start/session snapshot | `/api/orient`, `/api/discussions/active` | Orient section TTLs; client auto-refresh | Humans/agents | Mirrors agent bootstrap | Low | Keep. |
+
+## Smallest Coherent Implementation Slice
+
+1. Add a route/page contract registry and serve it as
+   `GET /api/contracts/routes`.
+   - It should declare purpose, source of truth, freshness/cache behavior,
+     consumers, overlap, risk, and recommendation for endpoint families and
+     dashboard pages.
+   - Tests should fail if a public FastAPI HTTP route, public WebSocket route,
+     or literal dashboard page has no contract entry.
+   - Dashboard-page tests must scan `dashboards/*.html`; FastAPI's catch-all
+     route does not enumerate individual dashboard files.
+2. Refactor `dashboards/routing.html` from a stale static snapshot to a live
+   dashboard page that reads:
+   - `/api/state/routing-budget`
+   - `/api/runtime/agents`
+   - `/api/runtime/usage?days=7`
+   - `/api/delegate/tasks?limit=100`
+3. Update dashboard tests so `routing.html` is explicitly retained as a live
+   page and no longer contains the manual-refresh/static-snapshot warning.
+
+This slice is intentionally not a broad data-path rewrite. It makes contracts
+visible and testable, removes the highest-risk stale dashboard surface, and
+leaves future consolidation decisions backed by a route/page matrix.
+
+## Deferred Follow-Ups
+
+- Decide whether to remove `dashboards/images.html` after external/legacy link
+  audit. It is harmless as a redirect alias.
+- Migrate or remove legacy direct-message endpoints after old `ask-*` and
+  `comms.html` consumers are gone.
+- Consider deprecating `/api/cost/*` in favor of `/api/analytics/cost/*` once
+  no scripts depend on the shorter alias.
+- Consider folding `/api/gold/*` and `/api/agent/*` into `/api/state` and
+  `/api/artifacts` after agent consumer audit.

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -66,6 +66,7 @@ from .issues_router import router as issues_router
 from .rag_router import router as rag_router
 from .resilience import get_resilience_snapshot, resilience_middleware
 from .reviewer_ghosts_router import router as reviewer_ghosts_router
+from .route_contracts import router as contracts_router
 from .rules_router import router as rules_router
 from .runtime_router import router as runtime_router
 from .session_router import router as session_router
@@ -124,6 +125,7 @@ app.include_router(comms_router, prefix="/api/comms")
 app.include_router(consultation_router, prefix="/api/consultation")
 app.include_router(cost_router, prefix="/api/cost")
 app.include_router(cost_router, prefix="/api/analytics/cost")
+app.include_router(contracts_router, prefix="/api/contracts", tags=["contracts"])
 app.include_router(dashboard_router, prefix="/api/dashboard")
 app.include_router(decisions_router, prefix="/api/decisions", tags=["decisions"])
 app.include_router(delegate_router, prefix="/api/delegate")

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -1,0 +1,787 @@
+"""Machine-readable Monitor API and dashboard contracts.
+
+The registry is intentionally family-based: most Monitor endpoints belong to
+router families with the same source and freshness behavior. Tests verify that
+every public FastAPI route and literal dashboard HTML page matches a contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import APIRouter
+
+ContractKind = Literal["http", "websocket"]
+MatchType = Literal["exact", "prefix"]
+
+
+@dataclass(frozen=True)
+class RouteContract:
+    pattern: str
+    match: MatchType
+    kind: ContractKind
+    purpose: str
+    source_of_truth: str
+    freshness: str
+    consumers: tuple[str, ...]
+    overlap: str
+    stale_risk: str
+    recommendation: str
+    mutates: bool = False
+    replacement: str | None = None
+
+    def matches(self, path: str, kind: ContractKind) -> bool:
+        if self.kind != kind:
+            return False
+        if self.match == "exact":
+            return path == self.pattern
+        prefix = self.pattern.rstrip("/")
+        return path == prefix or path.startswith(f"{prefix}/")
+
+    @property
+    def specificity(self) -> tuple[int, int]:
+        return (1 if self.match == "exact" else 0, len(self.pattern))
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["consumers"] = list(self.consumers)
+        return data
+
+
+@dataclass(frozen=True)
+class PageContract:
+    file: str
+    url: str
+    purpose: str
+    source_of_truth: str
+    freshness: str
+    consumers: tuple[str, ...]
+    overlap: str
+    stale_risk: str
+    recommendation: str
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["consumers"] = list(self.consumers)
+        return data
+
+
+ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
+    RouteContract(
+        "/api/contracts/routes", "exact", "http",
+        "Machine-readable Monitor route and dashboard contract registry.",
+        "This module's ROUTE_CONTRACTS and PAGE_CONTRACTS declarations.",
+        "Generated per request; no route cache.",
+        ("tests", "agents", "docs"),
+        "Documents every other local Monitor endpoint.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/state/reviewer-ghosts", "prefix", "http",
+        "Reviewer hallucination telemetry for missing-anchor reviewer fixes.",
+        "curriculum/l2-uk-en/{track}/review/*-ghost-review-r*.yaml",
+        "No route cache; per-request review-directory scan with optional filters.",
+        ("agents", "future dashboards", "tests"),
+        "Mounted under /api/state but logically telemetry, not canonical module state.",
+        "medium if treated as generic /api/state progress data",
+        "keep as a distinct contract family",
+    ),
+    RouteContract(
+        "/api/state", "prefix", "http",
+        "Canonical project, track, module, research, review, build, routing, and cold-start state.",
+        "curriculum.yaml, plans, orchestration state, research/dossier docs, audit/review files, artifacts, and cost records.",
+        "State router TTLs by endpoint; major endpoints expose meta.source, meta.cache, meta.stale_after_s; selected endpoints support ?fresh=true.",
+        ("progress.html", "track-health.html", "quality.html", "index.html", "Starlight LiveStatus", "agents"),
+        "Overlaps /api/dashboard projections, /api/blue/live-status, and legacy team views.",
+        "low after #2790 for summary/progress; medium for state endpoints that do not expose meta yet",
+        "keep canonical",
+    ),
+    RouteContract(
+        "/api/dashboard", "prefix", "http",
+        "Rich dashboard projections for audit, curriculum, pipeline, and comms pages.",
+        "Dashboard helper scans over plans, status cache, research, reviews, orchestration, and broker data.",
+        "Dashboard helper caches are process-local: track detail 30s, summary 60s, overview reuses state summary 60s.",
+        ("audit-dashboard.html", "curriculum-dashboard.html", "index.html"),
+        "Overlaps /api/state counts; richer module/audit detail remains distinct.",
+        "medium if consumers treat it as canonical fresh state",
+        "keep for page-specific detail; use /api/state for freshness-sensitive counts",
+    ),
+    RouteContract(
+        "/api/blue/live-status", "exact", "http",
+        "Deprecated legacy live build status.",
+        "Filesystem scan over module files and status cache.",
+        "No route cache; returns deprecation headers and replacement guidance.",
+        ("legacy agents", "docs"),
+        "Duplicates /api/state/build-status.",
+        "high because stale consumers can bypass the canonical state contract",
+        "deprecated; migrate to /api/state/build-status",
+        replacement="/api/state/build-status",
+    ),
+    RouteContract(
+        "/api/blue", "prefix", "http",
+        "Legacy Blue/final-review helper endpoints.",
+        "Status cache, module files, activity YAML, review files, and batch state.",
+        "No route cache; /audit?...fresh=true runs audit as a side effect.",
+        ("agents", "final-review workflow"),
+        "Overlaps /api/state and /api/artifacts for some module evidence.",
+        "low for final-review helpers; medium for write-side effects",
+        "retain compatibility helpers",
+    ),
+    RouteContract(
+        "/api/gold", "prefix", "http",
+        "Legacy Gold/team module inspection endpoints.",
+        "Plans, module files, orchestration, and broker data.",
+        "No route cache; live filesystem and broker reads.",
+        ("legacy agents", "docs"),
+        "Overlaps /api/state/module, /api/artifacts, and /api/dashboard/module.",
+        "medium because canonical source is not obvious from the route name",
+        "retain until agent consumers migrate",
+    ),
+    RouteContract(
+        "/api/agent", "prefix", "http",
+        "Agent-oriented module, orchestration, prompt, runtime, and worktree snapshots.",
+        "Module files, orchestration files, runtime files, and git worktree state.",
+        "No route cache; live filesystem and git/process reads.",
+        ("agents", "docs"),
+        "Overlaps /api/state, /api/artifacts, /api/runtime, and /api/worktrees.",
+        "medium because it is a compatibility facade",
+        "retain until agent consumers migrate",
+    ),
+    RouteContract(
+        "/api/artifacts", "prefix", "http",
+        "Artifact classification, ship-ready checks, report listing, drift, and force-preview evidence.",
+        "Plans, generated curriculum files, Starlight MDX, review/audit docs, docs/audit reports.",
+        "No route cache; live filesystem reads.",
+        ("artifacts.html", "agents", "docs"),
+        "Complements /api/state published/stale signals.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/artifacts", "prefix", "http",
+        "Human artifact browser and approved documentation artifact serving.",
+        "docs, audit, and other approved artifact roots.",
+        "No route cache; serves artifacts.html for browser requests and JSON/file listings on demand.",
+        ("artifacts.html", "humans"),
+        "Shares artifact metadata with /api/artifacts/html.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/files", "prefix", "http",
+        "Approved documentation artifact serving alias.",
+        "docs, audit, and other approved artifact roots.",
+        "No route cache; live filesystem serving with extension/root allowlists.",
+        ("humans", "agents"),
+        "Alias of /artifacts file serving without the browser page default.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/comms/messages", "exact", "http",
+        "Deprecated legacy direct-message list.",
+        "SQLite message broker.",
+        "No route cache; live broker reads.",
+        ("comms.html", "legacy ask-* path"),
+        "Replaced by channel message endpoints.",
+        "medium",
+        "deprecated; migrate to /api/comms/channels/{name}/messages",
+        replacement="/api/comms/channels/{name}/messages",
+    ),
+    RouteContract(
+        "/api/comms/conversations", "exact", "http",
+        "Deprecated legacy direct-message conversation list.",
+        "SQLite message broker.",
+        "No route cache; live broker reads.",
+        ("comms.html", "legacy ask-* path"),
+        "Replaced by channel threads.",
+        "medium",
+        "deprecated; migrate to /api/comms/channels/{name}/threads/{thread_id}",
+        replacement="/api/comms/channels/{name}/threads/{thread_id}",
+    ),
+    RouteContract(
+        "/api/comms/conversation", "prefix", "http",
+        "Deprecated legacy direct-message conversation detail.",
+        "SQLite message broker.",
+        "No route cache; live broker reads.",
+        ("comms.html", "legacy ask-* path"),
+        "Replaced by channel threads.",
+        "medium",
+        "deprecated; migrate to /api/comms/channels/{name}/threads/{thread_id}",
+        replacement="/api/comms/channels/{name}/threads/{thread_id}",
+    ),
+    RouteContract(
+        "/api/comms/live-activity", "exact", "http",
+        "Deprecated legacy live activity summary.",
+        "SQLite broker and process probes.",
+        "No route cache; live broker/process reads.",
+        ("legacy docs",),
+        "Replaced by channel activity and delegate/build event endpoints.",
+        "medium",
+        "deprecated; migrate to /api/comms/agent-activity and /api/delegate/active",
+        replacement="/api/comms/agent-activity",
+    ),
+    RouteContract(
+        "/api/comms/send", "exact", "http",
+        "Deprecated legacy direct-message send endpoint.",
+        "SQLite message broker.",
+        "No route cache; POST mutates broker state.",
+        ("comms.html", "legacy ask-* path"),
+        "Replaced by channel post endpoint.",
+        "medium",
+        "deprecated; migrate to /api/comms/channels/{name}/post",
+        mutates=True,
+        replacement="/api/comms/channels/{name}/post",
+    ),
+    RouteContract(
+        "/api/comms", "prefix", "http",
+        "Canonical channel bridge plus broker/process health, batch progress, zombies, acknowledgements, and module-linked messages.",
+        "SQLite message broker, delivery tables, process probes, and build state.",
+        "No route cache; live broker/process reads. POST routes mutate broker/message state.",
+        ("channels.html", "comms.html", "track-health.html", "index.html", "agents"),
+        "Canonical channels replace legacy direct-message routes; status overlaps delegate/build events.",
+        "low/medium",
+        "keep",
+    ),
+    RouteContract(
+        "/api/delegate", "prefix", "http",
+        "Delegated task list, active task count, and task result detail.",
+        "batch_state/tasks/*.json, process liveness, and task result files.",
+        "No route cache; live filesystem/process reads.",
+        ("delegate.html", "index.html", "agents"),
+        "Complements /api/orient.delegate and /api/build/events.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/worktrees", "exact", "http",
+        "Active git worktree registry.",
+        "git worktree list --porcelain, per-worktree git status, and git log -1.",
+        "No route cache; each git subprocess has a bounded timeout.",
+        ("agents", "cold-start tooling", "worktree hygiene"),
+        "Complements /api/git/hygiene and /api/git/cleanup.",
+        "low; failures degrade to empty/error payload",
+        "keep",
+    ),
+    RouteContract(
+        "/api/build/events", "prefix", "http",
+        "Recent and active module build event timeline.",
+        "curriculum/l2-uk-en/**/orchestration/**/dispatch/*-meta.json plus module state files.",
+        "No route cache; filesystem scan capped at 5000 dispatch metadata files.",
+        ("build-events.html", "comms.html", "index.html"),
+        "Complements delegate and comms activity.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/runtime", "prefix", "http",
+        "Agent runtime inventory, usage, default-model headroom, recent calls, and auth mode.",
+        "Runtime config, usage JSONL, environment presence booleans, and OAuth credential presence.",
+        "No route cache; live file/env reads. Auth reports booleans/source names only, never secret values.",
+        ("runtime.html", "routing.html", "index.html", "agents"),
+        "Headroom and usage complement /api/state/routing-budget and cost endpoints.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/state/routing-budget", "exact", "http",
+        "Per-agent soft-cap burn and routing recommendation.",
+        "scripts/config/agent_budgets.yaml, cost records, and delegate in-flight state.",
+        "No route cache; computes from current cost records and active delegate task state.",
+        ("routing.html", "delegate.py", "agents"),
+        "Overlaps runtime usage and cost summaries but adds routing recommendation.",
+        "low",
+        "keep canonical for routing guidance",
+    ),
+    RouteContract(
+        "/api/analytics/cost", "prefix", "http",
+        "Cost summaries by project, module, and phase.",
+        "batch_state/api_usage/** cost records.",
+        "No route cache; live usage record reads.",
+        ("cost.html", "index.html", "routing.html"),
+        "Duplicate mount with /api/cost.",
+        "low",
+        "keep canonical UI path",
+    ),
+    RouteContract(
+        "/api/cost", "prefix", "http",
+        "Compatibility alias for cost summaries.",
+        "batch_state/api_usage/** cost records.",
+        "No route cache; live usage record reads.",
+        ("legacy scripts", "docs"),
+        "Alias of /api/analytics/cost.",
+        "low",
+        "retain compatibility alias",
+        replacement="/api/analytics/cost",
+    ),
+    RouteContract(
+        "/api/wiki", "prefix", "http",
+        "Wiki compilation status, quality gates, build log, article preview, and source inventory.",
+        "Wiki progress state/DB, wiki markdown files, and data/sources.db.",
+        "Selected aggregate reads use short shared TTL cache; article detail reads file bodies on demand.",
+        ("wiki.html", "index.html"),
+        "Complements /api/state published/wiki status signals.",
+        "low/medium",
+        "keep",
+    ),
+    RouteContract(
+        "/api/images", "prefix", "http",
+        "Textbook image catalog, page rendering, annotations, stats, cleanup, and reload.",
+        "data/textbook_images/**, data/textbooks/**, and annotation JSONL.",
+        "Lazy in-memory image index; PDF pool and page-render LRU cache; /reload resets the index.",
+        ("image-explorer.html",),
+        "Complements /api/rag image search.",
+        "low; mutating annotation/cleanup/reload routes are local-only",
+        "keep",
+    ),
+    RouteContract(
+        "/images", "prefix", "http",
+        "Static textbook image file serving.",
+        "data/textbook_images/** image files.",
+        "FileResponse with Cache-Control max-age=3600.",
+        ("image-explorer.html",),
+        "Static companion to /api/images metadata.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/rag", "prefix", "http",
+        "RAG text, image, and literary search plus collection stats.",
+        "Local RAG/Qdrant collections and related corpus indexes.",
+        "No Monitor route cache; search backend freshness follows collection build state.",
+        ("image-explorer.html", "agents"),
+        "Overlaps MCP/source tools but is UI-specific.",
+        "low/medium if collections are stale",
+        "keep",
+    ),
+    RouteContract(
+        "/api/admin", "prefix", "http",
+        "Local maintenance: health, backups, disk, broker vacuum, logs, and collection verification.",
+        "Qdrant snapshots/storage, broker DB, logs, data directories, and collection metadata.",
+        "No route cache; live local maintenance operations. POST/DELETE routes mutate local state.",
+        ("admin.html",),
+        "Operational-only surface.",
+        "medium because several routes mutate local state",
+        "keep local-only",
+    ),
+    RouteContract(
+        "/api/consultation", "prefix", "http",
+        "Template proposal queue, detail, approve/reject, history, and metrics.",
+        "Consultation queue/history files.",
+        "No route cache; live filesystem reads. Approve/reject POST routes mutate queue/history state.",
+        ("consultation.html", "index.html"),
+        "None.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/decisions", "prefix", "http",
+        "Decision registry listing, stale/budget/lineage views, scope lookups, and detail.",
+        "docs/decisions/**.",
+        "No route cache; live filesystem reads.",
+        ("agents", "docs"),
+        "Related to /api/state/governance aggregate.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/state/governance", "exact", "http",
+        "Governance aggregate for decisions and ADR hygiene.",
+        "docs/decisions/** and ADR docs.",
+        "No route cache in the endpoint; /api/orient may cache the governance section for 120s.",
+        ("orient.html", "agents"),
+        "Aggregate counterpart to /api/decisions detail endpoints.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/issues/map", "exact", "http",
+        "Open issue map grouped by category.",
+        "gh issue list output.",
+        "No route cache in handler; /api/orient wraps issue collection with a 120s cache and short timeout.",
+        ("agents", "issue hygiene"),
+        "Overlaps /api/orient.issues.",
+        "medium if GitHub is slow or unavailable",
+        "keep best-effort",
+    ),
+    RouteContract(
+        "/api/rules", "exact", "http",
+        "Condensed agent rule set for cold start.",
+        "Deployed rule/source markdown files.",
+        "Hash/ETag semantics when telemetry footer is disabled; otherwise generated per request.",
+        ("agents", "docs"),
+        "Replaces direct rule-file reads at cold start.",
+        "low",
+        "keep cold-start source of truth",
+    ),
+    RouteContract(
+        "/api/session/current", "exact", "http",
+        "Agent-specific current session handoff.",
+        "docs/session-state/current.md router and current.<agent>.md handoff files.",
+        "Hash/ETag semantics when telemetry footer is disabled; generated per request otherwise.",
+        ("agents", "docs"),
+        "Replaces direct session-state file spelunking.",
+        "low",
+        "keep cold-start source of truth",
+    ),
+    RouteContract(
+        "/api/orient", "exact", "http",
+        "One-shot agent and dashboard orientation snapshot.",
+        "Git, GitHub issues, pipeline state, runtime files, delegate state, broker, wiki, governance, health, and session hints.",
+        "Per-section TTLs in main.py; ?fresh=true invalidates orient cache entries.",
+        ("orient.html", "index.html", "agents"),
+        "Aggregates many other API sections.",
+        "low/medium when upstream collectors degrade",
+        "keep cold-start source of truth",
+    ),
+    RouteContract(
+        "/api/state/manifest", "exact", "http",
+        "Tiny cold-start manifest with hashes and URLs.",
+        "Rules/session hash helpers plus static endpoint metadata.",
+        "Generated per request; rules/session hashes let agents skip unchanged payloads.",
+        ("agents", "monitor client"),
+        "Index for /api/rules, /api/session/current, /api/orient, comms inbox/activity.",
+        "low",
+        "keep cold-start source of truth",
+    ),
+    RouteContract(
+        "/api/site", "prefix", "http",
+        "Public site health and deployment observability.",
+        "Public site probe and GitHub Pages deployment data.",
+        "No route cache; each request probes/queries live state with bounded subprocess/network behavior.",
+        ("agents", "docs"),
+        "Complements local build/status dashboards.",
+        "medium if network/GitHub is unavailable",
+        "keep",
+    ),
+    RouteContract(
+        "/api/git", "prefix", "http",
+        "Git hygiene and cleanup dry-run reporting.",
+        "Local git branches, worktrees, and batch_state task metadata.",
+        "No route cache; live git/filesystem reads.",
+        ("agents", "docs"),
+        "Complements /api/worktrees.",
+        "low/medium",
+        "keep read-only cleanup planning",
+    ),
+    RouteContract(
+        "/api/telemetry", "prefix", "http",
+        "Tool timing telemetry ingest and readback.",
+        "Telemetry JSON/SQLite state used by Monitor instrumentation.",
+        "No route cache; POST mutates telemetry store, GET reads current window.",
+        ("agents", "runtime tooling"),
+        "Complements optional telemetry footer.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/discussions/active", "exact", "http",
+        "Active multi-agent discussion snapshot.",
+        "Channel bridge SQLite messages and discussion state.",
+        "No route cache; live broker reads.",
+        ("orient.html", "channels.html"),
+        "Complements channel message endpoints.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/batch", "prefix", "http",
+        "Legacy batch dispatcher, active orchestration, failures, usage, checkpoints, and logs.",
+        "batch_state files and dispatcher process/log state.",
+        "No route cache; live filesystem/process reads. Dispatcher scan POST mutates dispatcher state.",
+        ("legacy scripts", "docs"),
+        "Overlaps delegate, build-events, and comms progress surfaces.",
+        "medium because it is older orchestration vocabulary",
+        "retain compatibility until clients migrate",
+    ),
+    RouteContract(
+        "/api/config", "exact", "http",
+        "Monitor config and level metadata.",
+        "scripts/api/config.py constants.",
+        "Generated per request; no route cache.",
+        ("consultation.html", "agents"),
+        "None.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/api/health", "exact", "http",
+        "API process health, uptime, timeout/saturation counters.",
+        "API process state and resilience middleware counters.",
+        "Generated per request; no route cache.",
+        ("health checks", "tests", "agents"),
+        "Related to /api/admin/health and /api/orient.health.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/ws/batch", "exact", "websocket",
+        "Legacy batch heartbeat stream.",
+        "API process heartbeat loop.",
+        "Sends {'type':'heartbeat'} every 5s while connected; no persisted state or cache.",
+        ("legacy live monitors",),
+        "Overlaps newer polling dashboards.",
+        "medium because WebSockets are not visible in OpenAPI",
+        "retain until websocket consumers are audited",
+    ),
+    RouteContract(
+        "/", "exact", "http",
+        "Dashboard root static page.",
+        "dashboards/index.html.",
+        "Static FileResponse; page fetches live API data client-side.",
+        ("humans",),
+        "Catch-all static route also serves other dashboard files.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
+        "/{path:path}", "exact", "http",
+        "Static dashboard file serving catch-all.",
+        "dashboards/**.",
+        "Static FileResponse; dashboard freshness comes from client-side API calls.",
+        ("humans",),
+        "Can hide missing page contracts unless dashboard files are scanned separately.",
+        "medium",
+        "keep; require explicit page contracts for dashboards/*.html",
+    ),
+)
+
+
+PAGE_CONTRACTS: tuple[PageContract, ...] = (
+    PageContract(
+        "index.html", "/",
+        "Operations launchpad and aggregate cards.",
+        "Fanout across dashboard, state, orient, runtime, delegate, wiki, and cost APIs.",
+        "Client fetches live endpoints with 5s timeout; state summary uses ?fresh=true.",
+        ("humans",),
+        "Links to every major dashboard.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "progress.html", "/progress.html",
+        "Canonical visual project progress.",
+        "/api/state/summary, /api/state/pipeline-versions, /api/state/pipeline/{track}.",
+        "Explicit ?fresh=true requests and freshness banner.",
+        ("humans",),
+        "Overlaps audit/curriculum but owns current progress.",
+        "low",
+        "keep canonical",
+    ),
+    PageContract(
+        "routing.html", "/routing.html",
+        "Live agent routing guidance.",
+        "/api/state/routing-budget, /api/runtime/*, /api/delegate/tasks.",
+        "Client fetches live endpoints with 5s timeout; no static usage snapshot.",
+        ("humans",),
+        "Complements runtime, delegate, cost, and routing-budget endpoints.",
+        "low after live refactor",
+        "keep live",
+    ),
+    PageContract(
+        "audit-dashboard.html", "/audit-dashboard.html",
+        "QA gate and audit drill-down.",
+        "/api/dashboard/* and /api/state/module/*.",
+        "Dashboard helper caches 30/60s; state module is live.",
+        ("humans",),
+        "Overlaps progress counts.",
+        "medium",
+        "keep for QA detail",
+    ),
+    PageContract(
+        "quality.html", "/quality.html",
+        "Research/review/issues/weak-points fix queue.",
+        "/api/state/research-coverage, /api/state/review-coverage, /api/state/issues, /api/state/weak-points.",
+        "State coverage TTLs where configured; weak-points has a 60s cache.",
+        ("humans",),
+        "Complements progress.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "track-health.html", "/track-health.html",
+        "One-track build, audit, enrichment, review, and comms health.",
+        "/api/state/build-status, /api/state/enrichment-status, /api/state/track-health, /api/state/module, /api/comms/by-module.",
+        "Build-status 15/30s caches; enrichment 120s; track-health 30s.",
+        ("humans",),
+        "Overlaps progress.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "curriculum-dashboard.html", "/curriculum-dashboard.html",
+        "Plan/meta/module inspection.",
+        "/api/dashboard/overview, /api/dashboard/track, /api/dashboard/module.",
+        "Dashboard helper caches 30/60s.",
+        ("humans",),
+        "Overlaps audit/progress.",
+        "medium",
+        "keep as inspection workflow",
+    ),
+    PageContract(
+        "channels.html", "/channels.html",
+        "Canonical channel bridge UI.",
+        "/api/comms/channels*.",
+        "Live broker reads; client preserves deeplink state.",
+        ("humans", "agents"),
+        "Replaces legacy comms chat.",
+        "low",
+        "keep canonical",
+    ),
+    PageContract(
+        "comms.html", "/comms.html",
+        "Legacy direct-message, zombie, and batch progress UI.",
+        "Deprecated legacy comms routes plus build events and broker health.",
+        "Live broker/process reads.",
+        ("humans",),
+        "Duplicates channels for chat.",
+        "medium",
+        "retain as legacy operations page until old users/CLI migrate",
+    ),
+    PageContract(
+        "delegate.html", "/delegate.html",
+        "Delegated task observability.",
+        "/api/delegate/tasks*.",
+        "Live task JSON/process reads.",
+        ("humans",),
+        "Complements comms/build-events.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "runtime.html", "/runtime.html",
+        "Agent runtime, usage, auth, and headroom.",
+        "/api/runtime/*.",
+        "Live file/env reads with 5s client timeout.",
+        ("humans",),
+        "Complements routing/cost.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "cost.html", "/cost.html",
+        "Cost reports.",
+        "/api/analytics/cost*.",
+        "Live cost record reads.",
+        ("humans",),
+        "Complements routing/runtime.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "build-events.html", "/build-events.html",
+        "Build dispatch event timeline.",
+        "/api/build/events/*.",
+        "Live capped filesystem scans.",
+        ("humans",),
+        "Complements comms/delegate.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "wiki.html", "/wiki.html",
+        "Wiki build, quality, source, and log overview.",
+        "/api/wiki/*.",
+        "Wiki router caches selected aggregates.",
+        ("humans",),
+        "Complements state published/wiki signals.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "artifacts.html", "/artifacts/",
+        "Artifact/report browser.",
+        "/api/artifacts/html and /artifacts file serving.",
+        "Live metadata scan.",
+        ("humans",),
+        "Links all ops pages.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "image-explorer.html", "/image-explorer.html",
+        "Textbook image/RAG annotation UI.",
+        "/api/images/*, /api/rag/*, /images/*.",
+        "Lazy image index and render LRU.",
+        ("humans",),
+        "None.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "images.html", "/images.html",
+        "Redirect alias to image explorer.",
+        "No API source; static meta refresh to /image-explorer.html.",
+        "Static redirect only.",
+        ("legacy links",),
+        "Duplicate alias.",
+        "low",
+        "retain redirect-only alias",
+    ),
+    PageContract(
+        "admin.html", "/admin.html",
+        "Local maintenance dashboard.",
+        "/api/admin/*.",
+        "Live local operations.",
+        ("humans",),
+        "None.",
+        "medium due to mutating POST/DELETE actions",
+        "keep local-only",
+    ),
+    PageContract(
+        "consultation.html", "/consultation.html",
+        "Template proposal queue/history dashboard.",
+        "/api/consultation/* and /api/config.",
+        "Live queue/history reads.",
+        ("humans",),
+        "None.",
+        "low",
+        "keep",
+    ),
+    PageContract(
+        "orient.html", "/orient.html",
+        "Cold-start/session orientation snapshot.",
+        "/api/orient and /api/discussions/active.",
+        "Orient section TTLs; client auto-refreshes.",
+        ("humans", "agents"),
+        "Mirrors agent bootstrap.",
+        "low",
+        "keep",
+    ),
+)
+
+router = APIRouter(tags=["contracts"])
+
+
+def contracts_for_route(path: str, kind: ContractKind = "http") -> list[RouteContract]:
+    """Return matching contracts, most specific first."""
+    return sorted(
+        (contract for contract in ROUTE_CONTRACTS if contract.matches(path, kind)),
+        key=lambda item: item.specificity,
+        reverse=True,
+    )
+
+
+def contract_for_route(path: str, kind: ContractKind = "http") -> RouteContract | None:
+    matches = contracts_for_route(path, kind)
+    return matches[0] if matches else None
+
+
+def contract_for_page(filename: str) -> PageContract | None:
+    for contract in PAGE_CONTRACTS:
+        if contract.file == filename:
+            return contract
+    return None
+
+
+@router.get("/routes")
+async def route_contracts():
+    """Public Monitor route/page contract registry."""
+    return {
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "route_contracts": [contract.to_dict() for contract in ROUTE_CONTRACTS],
+        "page_contracts": [contract.to_dict() for contract in PAGE_CONTRACTS],
+    }

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -132,6 +132,7 @@ class TestApiEndpoints:
         "/api/state/pipeline-versions",
         "/api/state/research-coverage",
         "/api/state/review-coverage",
+        "/api/state/routing-budget",
         "/api/state/summary",
         "/api/state/weak-points",
     }

--- a/tests/test_monitor_route_contracts.py
+++ b/tests/test_monitor_route_contracts.py
@@ -1,0 +1,91 @@
+"""Contract coverage tests for public Monitor routes and dashboard pages."""
+
+from pathlib import Path
+
+from fastapi.routing import APIRoute, APIWebSocketRoute
+from fastapi.testclient import TestClient
+
+from scripts.api.main import app
+from scripts.api.route_contracts import contract_for_page, contract_for_route
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARDS = ROOT / "dashboards"
+
+
+def _public_http_routes() -> list[APIRoute]:
+    return [route for route in app.routes if isinstance(route, APIRoute)]
+
+
+def _public_websocket_routes() -> list[APIWebSocketRoute]:
+    return [route for route in app.routes if isinstance(route, APIWebSocketRoute)]
+
+
+def test_every_public_http_route_has_source_and_freshness_contract():
+    missing = []
+    incomplete = []
+    for route in _public_http_routes():
+        contract = contract_for_route(route.path, "http")
+        if contract is None:
+            missing.append(route.path)
+            continue
+        if not contract.source_of_truth or not contract.freshness or not contract.recommendation:
+            incomplete.append(route.path)
+
+    assert not missing, "HTTP routes without Monitor contracts:\n" + "\n".join(sorted(missing))
+    assert not incomplete, "HTTP routes with incomplete contracts:\n" + "\n".join(sorted(incomplete))
+
+
+def test_every_public_websocket_route_has_contract():
+    missing = [
+        route.path
+        for route in _public_websocket_routes()
+        if contract_for_route(route.path, "websocket") is None
+    ]
+
+    assert not missing, "WebSocket routes without Monitor contracts:\n" + "\n".join(sorted(missing))
+
+
+def test_deprecated_routes_have_deprecation_contracts():
+    failures = []
+    for route in _public_http_routes():
+        if not getattr(route, "deprecated", False):
+            continue
+        contract = contract_for_route(route.path, "http")
+        text = " ".join(
+            [
+                contract.recommendation if contract else "",
+                contract.replacement or "" if contract else "",
+            ]
+        ).lower()
+        if "deprecated" not in text and "migrate" not in text:
+            failures.append(route.path)
+
+    assert not failures, "Deprecated routes without deprecation guidance:\n" + "\n".join(sorted(failures))
+
+
+def test_every_dashboard_html_file_has_page_contract():
+    missing = []
+    incomplete = []
+    for path in sorted(DASHBOARDS.glob("*.html")):
+        contract = contract_for_page(path.name)
+        if contract is None:
+            missing.append(path.name)
+            continue
+        if not contract.source_of_truth or not contract.freshness or not contract.recommendation:
+            incomplete.append(path.name)
+
+    assert not missing, "Dashboard pages without contracts:\n" + "\n".join(missing)
+    assert not incomplete, "Dashboard pages with incomplete contracts:\n" + "\n".join(incomplete)
+
+
+def test_contract_endpoint_exposes_route_and_page_contracts():
+    response = TestClient(app).get("/api/contracts/routes")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "generated_at" in data
+    assert data["route_contracts"]
+    assert data["page_contracts"]
+    assert any(item["pattern"] == "/api/worktrees" for item in data["route_contracts"])
+    assert any(item["pattern"] == "/ws/batch" and item["kind"] == "websocket" for item in data["route_contracts"])
+    assert any(item["file"] == "routing.html" and item["url"] == "/routing.html" for item in data["page_contracts"])

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -31,6 +31,7 @@ def test_index_page_uses_shared_parchment_monitor_design():
         "/cost.html",
         "/curriculum-dashboard.html",
         "/delegate.html",
+        "/routing.html",
         "/artifacts/",
         "/image-explorer.html",
         "/orient.html",
@@ -97,6 +98,17 @@ def test_runtime_page_keeps_primary_monitor_nav():
         assert f'href="{href}"' in html
 
 
+def test_routing_page_uses_live_monitor_sources():
+    html = (DASHBOARDS / "routing.html").read_text(encoding="utf-8")
+    assert "Static snapshot" not in html
+    assert "refreshed manually" not in html
+    assert "/api/state/routing-budget" in html
+    assert "/api/runtime/agents" in html
+    assert "/api/runtime/usage?days=7" in html
+    assert "/api/delegate/tasks?limit=100" in html
+    assert "Live routing budget" in html
+
+
 def test_shared_monitor_css_targets_unified_nav_classes():
     css = (DASHBOARDS / "monitor.css").read_text(encoding="utf-8")
     assert ".topbar .nav" not in css
@@ -154,6 +166,7 @@ def test_artifacts_page_preserves_legacy_dashboard_links():
         "/cost.html",
         "/curriculum-dashboard.html",
         "/delegate.html",
+        "/routing.html",
         "/image-explorer.html",
         "/orient.html",
         "/progress.html",

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -101,6 +101,12 @@ DASHBOARD_LOADS = {
         "/api/runtime/recent?limit=50",
         "/api/runtime/auth",
     ],
+    "routing.html": [
+        "/api/state/routing-budget",
+        "/api/runtime/agents",
+        "/api/runtime/usage?days=7",
+        "/api/delegate/tasks?limit=100",
+    ],
     "track-health.html": [
         "/api/state/build-status",
         "/api/state/enrichment-status",
@@ -157,6 +163,7 @@ BUDGETS = {
     "/api/runtime/auth": 1.5,
     "/api/runtime/recent?limit=50": 1.5,
     "/api/runtime/usage?days=7": 1.5,
+    "/api/state/routing-budget": 1.5,
     "/api/state/build-status": 1.5,
     "/api/state/enrichment-status": 1.5,
     "/api/state/issues": 1.5,


### PR DESCRIPTION
## Summary

Closes #2794.

This inventory-first slice adds a machine-readable Monitor API/dashboard contract registry and removes the highest-risk stale dashboard surface identified in the audit.

- Adds `GET /api/contracts/routes` with explicit source-of-truth, cache/freshness, consumer, overlap/risk, and recommendation metadata for public Monitor route families, the `/ws/batch` WebSocket, and dashboard pages.
- Adds contract tests that fail when a public FastAPI HTTP route, public WebSocket route, or literal `dashboards/*.html` page lacks a contract.
- Refactors `dashboards/routing.html` from a manual static snapshot to live data from `/api/state/routing-budget`, `/api/runtime/agents`, `/api/runtime/usage?days=7`, and `/api/delegate/tasks?limit=100`.
- Adds `docs/monitor-api-ui-audit-2026-06-07.md` with the route/page matrix and deferred follow-ups.

## Validation

- `.venv/bin/ruff check scripts/api/main.py scripts/api/route_contracts.py tests/test_monitor_route_contracts.py tests/test_monitor_ui_contracts.py tests/test_dashboards.py tests/test_playground_api_stability.py tests/api/test_routing_budget_endpoint.py`
- `.venv/bin/python -m py_compile scripts/api/main.py scripts/api/route_contracts.py`
- `.venv/bin/python -m pytest -q tests/test_monitor_route_contracts.py tests/test_monitor_ui_contracts.py tests/test_dashboards.py tests/test_api_endpoints.py tests/test_playground_api_stability.py tests/api/test_routing_budget_endpoint.py` (`195 passed`)
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Pre-commit and pre-push hooks passed.
- Browser verified `/routing.html` and the `/artifacts/` link against local uvicorn on port 8776.

## Independent Review

Gemini plan review initially flagged missing `/api/worktrees`, `/ws/batch`, `/api/state/reviewer-ghosts/*`, and literal dashboard-file test coverage. Those were incorporated before implementation.

Gemini implementation review on issue #2794 returned OK for contract coverage, stale dashboard risk, test adequacy, and scoped changes.