### PR TITLE
[codex] Split A1 M9-M14 activities

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-my-world/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-my-world/activities.yaml
@@ -1,311 +1,309 @@
-- id: act-1
-  type: quiz
-  title: Checkpoint warm-up
-  instruction: Choose the safe Ukrainian line.
-  items:
-    - prompt: My name is John.
-      options:
-        - text: Мене звати Джон.
-          correct: true
-        - text: Моє ім'я є Джон.
-          correct: false
-        - text: Я є Джон.
-          correct: false
-      explanation: Use Мене звати... for a name.
-    - prompt: I am a student.
-      options:
-        - text: Я студент.
-          correct: true
-        - text: Я є студент.
-          correct: false
-        - text: Мене студент.
-          correct: false
-      explanation: Present identity normally drops є.
-    - prompt: My book is on the table.
-      options:
-        - text: Моя книга на столі.
-          correct: true
-        - text: Мій книга на столі.
-          correct: false
-        - text: Моє книга на столі.
-          correct: false
-      explanation: Книга is feminine, so use моя.
-    - prompt: I have glasses.
-      options:
-        - text: У мене є окуляри.
-          correct: true
-        - text: Вона має один окуляри.
-          correct: false
-        - text: У мене є один окуляри.
-          correct: false
-      explanation: Окуляри is plural-only.
-- id: act-2
-  type: match-up
-  title: Gender and control words
-  instruction: Match each noun with the control word.
-  pairs:
-    - left: стіл
-      right: він
-    - left: книга
-      right: вона
-    - left: вікно
-      right: воно
-    - left: кімната
-      right: вона
-    - left: місто
-      right: воно
-    - left: книги
-      right: вони
-    - left: окуляри
-      right: вони
-    - left: телефон
-      right: він
-- id: act-3
-  type: fill-in
-  title: Marketplace dialogue
-  instruction: Complete the checkpoint dialogue.
-  items:
-    - sentence: ___ вишиванка біла.
-      answer: Ця
-      options:
-        - Ця
-        - Цей
-        - Це
-      explanation: Вишиванка is feminine in this context.
-    - sentence: ___ глечик старий.
-      answer: Той
-      options:
-        - Той
-        - Та
-        - Те
-      explanation: Глечик is masculine.
-    - sentence: ___ намисто гарне.
-      answer: Це
-      options:
-        - Це
-        - Ця
-        - Цей
-      explanation: Намисто is neuter.
-    - sentence: ___ писанки червоні.
-      answer: Ці
-      options:
-        - Ці
-        - Ця
-        - Це
-      explanation: Писанки is plural.
-    - sentence: Скільки ___ це намисто?
-      answer: коштує
-      options:
-        - коштує
-        - звати
-        - років
-      explanation: Скільки коштує...? asks a price.
-    - sentence: Сто ___.
-      answer: гривень
-      options:
-        - гривень
-        - роки
-        - ім'я
-      explanation: Сто гривень is the price chunk.
-- id: act-4
-  type: group-sort
-  title: Review categories
-  instruction: Sort the words by checkpoint category.
-  groups:
-    - name: Objects
-      items:
-        - стіл
-        - книга
-        - вікно
-        - лампа
-    - name: Colors
-      items:
-        - червоний
-        - синій
-        - білий
-        - жовтий
-    - name: Numbers and prices
-      items:
-        - три
-        - двадцять
-        - сто
-        - гривень
-- id: act-5
-  type: quiz
-  title: Singular, plural, and description
-  instruction: Choose the sentence that matches the noun.
-  items:
-    - prompt: стіл
-      options:
-        - text: Мій стіл великий.
-          correct: true
-        - text: Моя стіл велика.
-          correct: false
-        - text: Моє стіл велике.
-          correct: false
-      explanation: Стіл is masculine.
-    - prompt: кімната
-      options:
-        - text: Моя кімната чиста.
-          correct: true
-        - text: Мій кімната чистий.
-          correct: false
-        - text: Моє кімната чисте.
-          correct: false
-      explanation: Кімната is feminine.
-    - prompt: вікно
-      options:
-        - text: Моє вікно чисте.
-          correct: true
-        - text: Моя вікно чиста.
-          correct: false
-        - text: Мій вікно чистий.
-          correct: false
-      explanation: Вікно is neuter.
-    - prompt: книги
-      options:
-        - text: Мої книги нові.
-          correct: true
-        - text: Моя книги нова.
-          correct: false
-        - text: Мій книги новий.
-          correct: false
-      explanation: Книги is plural.
-- id: act-6
-  type: quiz
-  title: Repair checkpoint traps
-  instruction: Choose the corrected Ukrainian sentence.
-  items:
-    - prompt: Я є студент.
-      options:
-        - text: Я студент.
-          correct: true
-        - text: Я є студент.
-          correct: false
-        - text: Мене студент.
-          correct: false
-      explanation: Present identity normally drops є.
-    - prompt: Моє ім'я є Джон.
-      options:
-        - text: Мене звати Джон.
-          correct: true
-        - text: Моє ім'я є Джон.
-          correct: false
-        - text: Я звати Джон.
-          correct: false
-      explanation: Use the name chunk Мене звати...
-    - prompt: Мій книга на столі.
-      options:
-        - text: Моя книга на столі.
-          correct: true
-        - text: Мій книга на столі.
-          correct: false
-        - text: Моє книга на столі.
-          correct: false
-      explanation: Книга is feminine.
-    - prompt: Вона має один окуляри.
-      options:
-        - text: Вона має окуляри. (або У неї є окуляри.)
-          correct: true
-        - text: Вона має один окуляри.
-          correct: false
-        - text: Вона має одна окуляри.
-          correct: false
-      explanation: Окуляри is plural-only.
-    - prompt: Я бачу великий кімнату.
-      options:
-        - text: Я бачу велику кімнату.
-          correct: true
-        - text: Я бачу великий кімнату.
-          correct: false
-        - text: Я бачу велике кімнату.
-          correct: false
-      explanation: Treat велику кімнату as a safe object chunk.
-    - prompt: Мені 20 роки.
-      options:
-        - text: Мені 20 років.
-          correct: true
-        - text: Мені 20 роки.
-          correct: false
-        - text: Я маю 20 роки.
-          correct: false
-      explanation: Age uses Мені ... років.
-- id: act-7
-  type: fill-in
-  title: Write your checkpoint text
-  instruction: Complete a short personal description.
-  items:
-    - sentence: Мене ___ Анна.
-      answer: звати
-      options:
-        - звати
-        - ім'я
-        - є
-      explanation: Мене звати... is the name chunk.
-    - sentence: Це ___ кімната.
-      answer: моя
-      options:
-        - моя
-        - мій
-        - моє
-      explanation: Кімната is feminine.
-    - sentence: Мій стіл ___.
-      answer: великий
-      options:
-        - великий
-        - велика
-        - велике
-      explanation: Стіл is masculine.
-    - sentence: Моє вікно ___.
-      answer: чисте
-      options:
-        - чисте
-        - чиста
-        - чистий
-      explanation: Вікно is neuter.
-    - sentence: Ці книги ___.
-      answer: нові
-      options:
-        - нові
-        - нова
-        - новий
-      explanation: Книги is plural.
-    - sentence: Мені 20 ___.
-      answer: років
-      options:
-        - років
-        - роки
-        - рік
-      explanation: Use the learned age chunk.
-- id: act-8
-  type: quiz
-  title: Ukrainian cultural frame
-  instruction: Choose the learner-safe course form.
-  items:
-    - prompt: The national flag colors
-      options:
-        - text: синьо-жовтий прапор
-          correct: true
-        - text: жовто-синій порядок
-          correct: false
-        - text: синій знак
-          correct: false
-      explanation: Use синьо-жовтий прапор for the Ukrainian flag.
-    - prompt: The capital in English-facing text
-      options:
-        - text: Kyiv
-          correct: true
-        - text: Kiyiv
-          correct: false
-        - text: Kyjiv
-          correct: false
-      explanation: Kyiv is the Ukrainian form in English.
-    - prompt: The Ukrainian currency
-      options:
-        - text: гривня
-          correct: true
-        - text: крамниця
-          correct: false
-        - text: прізвище
-          correct: false
-      explanation: Гривня is the Ukrainian currency.
+inline:
+  - id: act-1
+    type: quiz
+    title: Checkpoint warm-up
+    instruction: Choose the safe Ukrainian line.
+    items:
+      - prompt: My name is John.
+        options:
+          - text: Мене звати Джон.
+            correct: true
+          - text: Моє ім'я є Джон.
+            correct: false
+          - text: Я є Джон.
+            correct: false
+        explanation: Use Мене звати... for a name.
+      - prompt: I am a student.
+        options:
+          - text: Я студент.
+            correct: true
+          - text: Я є студент.
+            correct: false
+          - text: Мене студент.
+            correct: false
+        explanation: Present identity normally drops є.
+      - prompt: My book is on the table.
+        options:
+          - text: Моя книга на столі.
+            correct: true
+          - text: Мій книга на столі.
+            correct: false
+          - text: Моє книга на столі.
+            correct: false
+        explanation: Книга is feminine, so use моя.
+      - prompt: I have glasses.
+        options:
+          - text: У мене є окуляри.
+            correct: true
+          - text: Вона має один окуляри.
+            correct: false
+          - text: У мене є один окуляри.
+            correct: false
+        explanation: Окуляри is plural-only.
+  - id: act-2
+    type: match-up
+    title: Gender and control words
+    instruction: Match each noun with the control word.
+    pairs:
+      - left: стіл
+        right: він
+      - left: книга
+        right: вона
+      - left: вікно
+        right: воно
+      - left: кімната
+        right: вона
+      - left: місто
+        right: воно
+      - left: книги
+        right: вони
+      - left: окуляри
+        right: вони
+      - left: телефон
+        right: він
+  - id: act-3
+    type: fill-in
+    title: Marketplace dialogue
+    instruction: Complete the checkpoint dialogue.
+    items:
+      - sentence: ___ вишиванка біла.
+        answer: Ця
+        options:
+          - Ця
+          - Цей
+          - Це
+        explanation: Вишиванка is feminine in this context.
+      - sentence: ___ глечик старий.
+        answer: Той
+        options:
+          - Той
+          - Та
+          - Те
+        explanation: Глечик is masculine.
+      - sentence: ___ намисто гарне.
+        answer: Це
+        options:
+          - Це
+          - Ця
+          - Цей
+        explanation: Намисто is neuter.
+      - sentence: ___ писанки червоні.
+        answer: Ці
+        options:
+          - Ці
+          - Ця
+          - Це
+        explanation: Писанки is plural.
+      - sentence: Скільки ___ це намисто?
+        answer: коштує
+        options:
+          - коштує
+          - звати
+          - років
+        explanation: Скільки коштує...? asks a price.
+      - sentence: Сто ___.
+        answer: гривень
+        options:
+          - гривень
+          - роки
+          - ім'я
+        explanation: Сто гривень is the price chunk.
+  - id: act-4
+    type: group-sort
+    title: Review categories
+    instruction: Sort the words by checkpoint category.
+    groups:
+      - name: Objects
+        items:
+          - стіл
+          - книга
+          - вікно
+          - лампа
+      - name: Colors
+        items:
+          - червоний
+          - синій
+          - білий
+          - жовтий
+      - name: Numbers and prices
+        items:
+          - три
+          - двадцять
+          - сто
+          - гривень
+workbook:
+  - type: quiz
+    title: Singular, plural, and description
+    instruction: Choose the sentence that matches the noun.
+    items:
+      - prompt: стіл
+        options:
+          - text: Мій стіл великий.
+            correct: true
+          - text: Моя стіл велика.
+            correct: false
+          - text: Моє стіл велике.
+            correct: false
+        explanation: Стіл is masculine.
+      - prompt: кімната
+        options:
+          - text: Моя кімната чиста.
+            correct: true
+          - text: Мій кімната чистий.
+            correct: false
+          - text: Моє кімната чисте.
+            correct: false
+        explanation: Кімната is feminine.
+      - prompt: вікно
+        options:
+          - text: Моє вікно чисте.
+            correct: true
+          - text: Моя вікно чиста.
+            correct: false
+          - text: Мій вікно чистий.
+            correct: false
+        explanation: Вікно is neuter.
+      - prompt: книги
+        options:
+          - text: Мої книги нові.
+            correct: true
+          - text: Моя книги нова.
+            correct: false
+          - text: Мій книги новий.
+            correct: false
+        explanation: Книги is plural.
+  - type: quiz
+    title: Repair checkpoint traps
+    instruction: Choose the corrected Ukrainian sentence.
+    items:
+      - prompt: Я є студент.
+        options:
+          - text: Я студент.
+            correct: true
+          - text: Я є студент.
+            correct: false
+          - text: Мене студент.
+            correct: false
+        explanation: Present identity normally drops є.
+      - prompt: Моє ім'я є Джон.
+        options:
+          - text: Мене звати Джон.
+            correct: true
+          - text: Моє ім'я є Джон.
+            correct: false
+          - text: Я звати Джон.
+            correct: false
+        explanation: Use the name chunk Мене звати...
+      - prompt: Мій книга на столі.
+        options:
+          - text: Моя книга на столі.
+            correct: true
+          - text: Мій книга на столі.
+            correct: false
+          - text: Моє книга на столі.
+            correct: false
+        explanation: Книга is feminine.
+      - prompt: Вона має один окуляри.
+        options:
+          - text: Вона має окуляри. (або У неї є окуляри.)
+            correct: true
+          - text: Вона має один окуляри.
+            correct: false
+          - text: Вона має одна окуляри.
+            correct: false
+        explanation: Окуляри is plural-only.
+      - prompt: Я бачу великий кімнату.
+        options:
+          - text: Я бачу велику кімнату.
+            correct: true
+          - text: Я бачу великий кімнату.
+            correct: false
+          - text: Я бачу велике кімнату.
+            correct: false
+        explanation: Treat велику кімнату as a safe object chunk.
+      - prompt: Мені 20 роки.
+        options:
+          - text: Мені 20 років.
+            correct: true
+          - text: Мені 20 роки.
+            correct: false
+          - text: Я маю 20 роки.
+            correct: false
+        explanation: Age uses Мені ... років.
+  - type: fill-in
+    title: Write your checkpoint text
+    instruction: Complete a short personal description.
+    items:
+      - sentence: Мене ___ Анна.
+        answer: звати
+        options:
+          - звати
+          - ім'я
+          - є
+        explanation: Мене звати... is the name chunk.
+      - sentence: Це ___ кімната.
+        answer: моя
+        options:
+          - моя
+          - мій
+          - моє
+        explanation: Кімната is feminine.
+      - sentence: Мій стіл ___.
+        answer: великий
+        options:
+          - великий
+          - велика
+          - велике
+        explanation: Стіл is masculine.
+      - sentence: Моє вікно ___.
+        answer: чисте
+        options:
+          - чисте
+          - чиста
+          - чистий
+        explanation: Вікно is neuter.
+      - sentence: Ці книги ___.
+        answer: нові
+        options:
+          - нові
+          - нова
+          - новий
+        explanation: Книги is plural.
+      - sentence: Мені 20 ___.
+        answer: років
+        options:
+          - років
+          - роки
+          - рік
+        explanation: Use the learned age chunk.
+  - type: quiz
+    title: Ukrainian cultural frame
+    instruction: Choose the learner-safe course form.
+    items:
+      - prompt: The national flag colors
+        options:
+          - text: синьо-жовтий прапор
+            correct: true
+          - text: жовто-синій порядок
+            correct: false
+          - text: синій знак
+            correct: false
+        explanation: Use синьо-жовтий прапор for the Ukrainian flag.
+      - prompt: The capital in English-facing text
+        options:
+          - text: Kyiv
+            correct: true
+          - text: Kiyiv
+            correct: false
+          - text: Kyjiv
+            correct: false
+        explanation: Kyiv is the Ukrainian form in English.
+      - prompt: The Ukrainian currency
+        options:
+          - text: гривня
+            correct: true
+          - text: крамниця
+            correct: false
+          - text: прізвище
+            correct: false
+        explanation: Гривня is the Ukrainian currency.

--- a/curriculum/l2-uk-en/a1/checkpoint-my-world/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-my-world/module.md
@@ -165,8 +165,6 @@ agreement (**біла**, **синя**, **старий**, **маленькі**), 
 (**ця**, **той**, **ці**, **це**), prices (**сто гривень**), and plural forms
 (**писанки маленькі**).
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Підсумок
 
 Make your own 6-10 sentence checkpoint text. Keep it personal and small. This
@@ -216,9 +214,3 @@ Historical and cultural facts stay precise when they appear later:
 the Holodomor is **1932-1933**, and Ukrainian literature examples belong to
 the Ukrainian canon. Do not present Russian-imperial figures as Ukrainian
 authors.
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/colors/activities.yaml
+++ b/curriculum/l2-uk-en/a1/colors/activities.yaml
@@ -1,454 +1,450 @@
-- id: act-1
-  type: quiz
-  title: Ask about color
-  instruction: Choose the natural question or short answer.
-  items:
-    - prompt: You point to a pencil and ask its color.
-      options:
-        - text: Якого кольору олівець?
-          correct: true
-        - text: Який колір є олівець?
-          correct: false
-        - text: Якого кольору є олівець?
-          correct: false
-      explanation: Learn Якого кольору...? as one question chunk without є.
-    - prompt: Якого кольору светр?
-      options:
-        - text: Синій.
-          correct: true
-        - text: Синя.
-          correct: false
-        - text: Синє.
-          correct: false
-      explanation: Светр is masculine, so the short answer is синій.
-    - prompt: Якого кольору ручка?
-      options:
-        - text: Червона.
-          correct: true
-        - text: Червоний.
-          correct: false
-        - text: Червоне.
-          correct: false
-      explanation: Ручка is feminine.
-    - prompt: Якого кольору вікно?
-      options:
-        - text: Біле.
-          correct: true
-        - text: Білий.
-          correct: false
-        - text: Біла.
-          correct: false
-      explanation: Вікно is neuter.
-    - prompt: Якого кольору соняшники?
-      options:
-        - text: Жовті.
-          correct: true
-        - text: Жовта.
-          correct: false
-        - text: Жовте.
-          correct: false
-      explanation: Соняшники is plural.
-    - prompt: Якого кольору прапор України?
-      options:
-        - text: Синьо-жовтий.
-          correct: true
-        - text: Блакитно-жовтий.
-          correct: false
-        - text: Сіро-жовтий.
-          correct: false
-      explanation: The standard chunk is синьо-жовтий прапор.
-- id: act-2
-  type: fill-in
-  title: Color endings
-  instruction: Choose the ending or form that matches the noun.
-  items:
-    - sentence: червон__ олівець
-      answer: ий
-      options:
-        - ий
-        - а
-        - е
-      explanation: Олівець is masculine, so use червоний.
-    - sentence: червон__ ручка
-      answer: а
-      options:
-        - а
-        - ий
-        - е
-      explanation: Ручка is feminine.
-    - sentence: червон__ яблуко
-      answer: е
-      options:
-        - е
-        - а
-        - ий
-      explanation: Яблуко is neuter.
-    - sentence: біл__ светр
-      answer: ий
-      options:
-        - ий
-        - а
-        - е
-      explanation: Светр is masculine.
-    - sentence: біл__ сорочка
-      answer: а
-      options:
-        - а
-        - ий
-        - е
-      explanation: Сорочка is feminine.
-    - sentence: сір__ пальто
-      answer: е
-      options:
-        - е
-        - ий
-        - а
-      explanation: Пальто is neuter here.
-    - sentence: зелен__ зошит
-      answer: ий
-      options:
-        - ий
-        - а
-        - е
-      explanation: Зошит is masculine.
-    - sentence: рожев__ листівка
-      answer: а
-      options:
-        - а
-        - е
-        - ий
-      explanation: Листівка is feminine.
-    - sentence: син__ книга
-      answer: я
-      options:
-        - я
-        - ій
-        - є
-      explanation: Синій is soft; with книга say синя.
-    - sentence: син__ вікно
-      answer: є
-      options:
-        - є
-        - ій
-        - я
-      explanation: With вікно say синє.
-- id: act-3
-  type: group-sort
-  title: Hard or soft color
-  instruction: Sort the color chunks by adjective pattern.
-  groups:
-    - label: Hard pattern -ий/-а/-е
-      items:
-        - червоний олівець
-        - жовта стрічка
-        - зелене яблуко
-        - білий светр
-        - чорна сукня
-        - сіре пальто
-        - коричневі черевики
-        - помаранчевий олівець
-    - label: Soft pattern -ій/-я/-є
-      items:
-        - синій светр
-        - синя ручка
-        - синє море
-        - сині речі
-- id: act-4
-  type: quiz
-  title: Синій or блакитний
-  instruction: Choose the better A1 color chunk.
-  items:
-    - prompt: A clear sky
-      options:
-        - text: блакитне небо
-          correct: true
-        - text: синьо-жовте небо
-          correct: false
-        - text: коричневе небо
-          correct: false
-      explanation: For a clear sky, use блакитне небо.
-    - prompt: The Ukrainian flag
-      options:
-        - text: синьо-жовтий прапор
-          correct: true
-        - text: блакитно-жовтий прапор
-          correct: false
-        - text: голубо-жовтий прапор
-          correct: false
-      explanation: The standard phrase is синьо-жовтий прапор.
-    - prompt: A dark blue sweater
-      options:
-        - text: синій светр
-          correct: true
-        - text: блакитна светр
-          correct: false
-        - text: синє светр
-          correct: false
-      explanation: Светр is masculine; синій also signals deep blue.
-    - prompt: A light-blue postcard
-      options:
-        - text: блакитна листівка
-          correct: true
-        - text: синій листівка
-          correct: false
-        - text: блакитне листівка
-          correct: false
-      explanation: Листівка is feminine.
-    - prompt: Deep water
-      options:
-        - text: синє море
-          correct: true
-        - text: блакитний море
-          correct: false
-        - text: синя море
-          correct: false
-      explanation: Море is neuter; синє море is a stable chunk.
-    - prompt: A notebook that is dark green
-      options:
-        - text: темно-зелений зошит
-          correct: true
-        - text: темна-зелена зошит
-          correct: false
-        - text: зелено-темний зошит
-          correct: false
-      explanation: Treat темно-зелений as one compound color chunk.
-- id: act-5
-  type: match-up
-  title: Appearance chunks
-  instruction: Match each Ukrainian chunk with its natural context.
-  pairs:
-    - left: карі очі
-      right: brown eyes
-    - left: русяве волосся
-      right: fair or light-brown hair
-    - left: сиве волосся
-      right: grey hair
-    - left: руде волосся
-      right: red hair
-    - left: блакитне небо
-      right: light-blue sky
-    - left: синьо-жовтий прапор
-      right: Ukrainian flag colors
-- id: act-6
-  type: error-correction
-  title: Repair color traps
-  instruction: Choose the standard Ukrainian correction.
-  items:
-    - sentence: Сукня є червона.
-      error: Сукня є червона.
-      answer: Сукня червона.
-      options:
-        - Сукня червона.
-        - Сукня червоний.
-        - Сукня є червоний.
-      explanation: In this present-tense frame, Ukrainian normally omits є.
-    - sentence: Якого кольору є светр?
-      error: Якого кольору є светр?
-      answer: Якого кольору светр?
-      options:
-        - Якого кольору светр?
-        - Яка кольору светр?
-        - Якого кольору є светр?
-      explanation: Keep Якого кольору...? as one chunk without є.
-    - sentence: Блакитно-жовтий прапор.
-      error: Блакитно-жовтий прапор.
-      answer: Синьо-жовтий прапор.
-      options:
-        - Синьо-жовтий прапор.
-        - Блакитно-жовтий прапор.
-        - Жовто-блакитний прапор.
-      explanation: The standard chunk for Ukraine's flag is синьо-жовтий прапор.
-    - sentence: У мене є синій настрій.
-      error: У мене є синій настрій.
-      answer: Мені сумно. / У мене поганий настрій.
-      options:
-        - Мені сумно. / У мене поганий настрій.
-        - У мене є синій настрій.
-        - Я синій сьогодні.
-      explanation: Do not copy the English color idiom. Use a Ukrainian mood phrase.
-    - sentence: Вона має червоне волосся.
-      error: Вона має червоне волосся.
-      answer: У неї руде волосся.
-      options:
-        - У неї руде волосся.
-        - Вона має червоне волосся.
-        - У неї червоний волосся.
-      explanation: For red hair, use руде волосся; for possession, use У неї...
-    - sentence: ЧорнИй, білИй (з наголосом на закінченні)
-      error: ЧорнИй, білИй (з наголосом на закінченні)
-      answer: ЧОрний, бІлий
-      options:
-        - ЧОрний, бІлий
-        - ЧорнИй, білИй
-        - чорний, білий
-      explanation: In these common color words, stress is on the root.
-- id: act-7
-  type: fill-in
-  title: Room and clothes colors
-  instruction: Complete each practical sentence.
-  items:
-    - sentence: Моя кімната ___.
-      answer: біла
-      options:
-        - біла
-        - білий
-        - біле
-      explanation: Кімната is feminine.
-    - sentence: Стіл ___.
-      answer: коричневий
-      options:
-        - коричневий
-        - коричнева
-        - коричневе
-      explanation: Стіл is masculine.
-    - sentence: Пальто ___.
-      answer: сіре
-      options:
-        - сіре
-        - сірий
-        - сіра
-      explanation: Пальто is neuter here.
-    - sentence: У мене ___ светр.
-      answer: синій
-      options:
-        - синій
-        - синя
-        - синє
-      explanation: Светр is masculine.
-    - sentence: У неї ___ очі.
-      answer: карі
-      options:
-        - карі
-        - коричневі
-        - каре
-      explanation: Use the fixed appearance chunk карі очі.
-    - sentence: У нього ___ волосся.
-      answer: русяве
-      options:
-        - русяве
-        - русявий
-        - русий
-      explanation: Волосся is neuter; learn русяве волосся as a chunk.
-    - sentence: У бабусі ___ волосся.
-      answer: сиве
-      options:
-        - сиве
-        - сива
-        - сивий
-      explanation: Learn сиве волосся as a chunk.
-    - sentence: Це ___ небо.
-      answer: блакитне
-      options:
-        - блакитне
-        - блакитний
-        - блакитна
-      explanation: Небо is neuter.
-- id: act-8
-  type: translate
-  title: Choose the Ukrainian line
-  instruction: Choose the Ukrainian sentence that matches the English cue.
-  items:
-    - source: The dress is red.
-      options:
-        - text: Сукня червона.
-          correct: true
-        - text: Сукня є червона.
-          correct: false
-        - text: Сукня червоний.
-          correct: false
-      explanation: No є is needed, and сукня is feminine.
-    - source: I have a blue sweater.
-      options:
-        - text: У мене синій светр.
-          correct: true
-        - text: У мене синя светр.
-          correct: false
-        - text: У мене є блакитно светр.
-          correct: false
-      explanation: Светр is masculine; синій is the soft color form.
-    - source: The sky is light blue.
-      options:
-        - text: Небо блакитне.
-          correct: true
-        - text: Небо блакитний.
-          correct: false
-        - text: Небо синя.
-          correct: false
-      explanation: Небо is neuter, and блакитний means light blue.
-    - source: She has brown eyes.
-      options:
-        - text: У неї карі очі.
-          correct: true
-        - text: Вона має коричневі очі.
-          correct: false
-        - text: У неї коричневе очі.
-          correct: false
-      explanation: Use the fixed chunk карі очі.
-    - source: He has grey hair.
-      options:
-        - text: У нього сиве волосся.
-          correct: true
-        - text: У нього сіре волосся.
-          correct: false
-        - text: Він має сивий волосся.
-          correct: false
-      explanation: Use сиве волосся and the У нього... frame.
-    - source: The flag is blue and yellow.
-      options:
-        - text: Прапор синьо-жовтий.
-          correct: true
-        - text: Прапор блакитно-жовтий.
-          correct: false
-        - text: Прапор синій і жовта.
-          correct: false
-      explanation: Keep синьо-жовтий as the fixed flag color chunk.
-- id: act-9
-  type: true-false
-  title: Color checkpoint
-  instruction: Decide if the statement is right.
-  items:
-    - statement: Якого кольору светр?
-      answer: true
-      explanation: This is the standard color question chunk.
-    - statement: Якого кольору є светр?
-      answer: false
-      explanation: Do not insert є into this question.
-    - statement: Ручка синя.
-      answer: true
-      explanation: Ручка is feminine, and синій becomes синя.
-    - statement: Вікно синій.
-      answer: false
-      explanation: Вікно is neuter; say Вікно синє.
-    - statement: Синій and блакитний are both active A1 words here.
-      answer: true
-      explanation: Синій is dark/deep blue; блакитний is light/sky blue.
-    - statement: Голубий is a production target here.
-      answer: false
-      explanation: It is passive recognition only here.
-    - statement: У неї карі очі.
-      answer: true
-      explanation: Карі очі is a natural fixed chunk.
-    - statement: "The Ukrainian flag chunk is синьо-жовтий прапор."
-      answer: true
-      explanation: Keep this exact phrase.
-- id: act-10
-  type: match-up
-  title: Color chunks
-  instruction: Match each color chunk with the object or image it best fits.
-  pairs:
-    - left: червоний олівець
-      right: red pencil
-    - left: червона ручка
-      right: red pen
-    - left: червоне яблуко
-      right: red apple
-    - left: блакитне небо
-      right: light-blue sky
-    - left: синє море
-      right: deep-blue sea
-    - left: чорна сукня
-      right: black dress
-    - left: білий светр
-      right: white sweater
-    - left: коричневі черевики
-      right: brown shoes
+inline:
+  - id: act-1
+    type: quiz
+    title: Ask about color
+    instruction: Choose the natural question or short answer.
+    items:
+      - prompt: You point to a pencil and ask its color.
+        options:
+          - text: Якого кольору олівець?
+            correct: true
+          - text: Який колір є олівець?
+            correct: false
+          - text: Якого кольору є олівець?
+            correct: false
+        explanation: Learn Якого кольору...? as one question chunk without є.
+      - prompt: Якого кольору светр?
+        options:
+          - text: Синій.
+            correct: true
+          - text: Синя.
+            correct: false
+          - text: Синє.
+            correct: false
+        explanation: Светр is masculine, so the short answer is синій.
+      - prompt: Якого кольору ручка?
+        options:
+          - text: Червона.
+            correct: true
+          - text: Червоний.
+            correct: false
+          - text: Червоне.
+            correct: false
+        explanation: Ручка is feminine.
+      - prompt: Якого кольору вікно?
+        options:
+          - text: Біле.
+            correct: true
+          - text: Білий.
+            correct: false
+          - text: Біла.
+            correct: false
+        explanation: Вікно is neuter.
+      - prompt: Якого кольору соняшники?
+        options:
+          - text: Жовті.
+            correct: true
+          - text: Жовта.
+            correct: false
+          - text: Жовте.
+            correct: false
+        explanation: Соняшники is plural.
+      - prompt: Якого кольору прапор України?
+        options:
+          - text: Синьо-жовтий.
+            correct: true
+          - text: Блакитно-жовтий.
+            correct: false
+          - text: Сіро-жовтий.
+            correct: false
+        explanation: The standard chunk is синьо-жовтий прапор.
+  - id: act-2
+    type: fill-in
+    title: Color endings
+    instruction: Choose the ending or form that matches the noun.
+    items:
+      - sentence: червон__ олівець
+        answer: ий
+        options:
+          - ий
+          - а
+          - е
+        explanation: Олівець is masculine, so use червоний.
+      - sentence: червон__ ручка
+        answer: а
+        options:
+          - а
+          - ий
+          - е
+        explanation: Ручка is feminine.
+      - sentence: червон__ яблуко
+        answer: е
+        options:
+          - е
+          - а
+          - ий
+        explanation: Яблуко is neuter.
+      - sentence: біл__ светр
+        answer: ий
+        options:
+          - ий
+          - а
+          - е
+        explanation: Светр is masculine.
+      - sentence: біл__ сорочка
+        answer: а
+        options:
+          - а
+          - ий
+          - е
+        explanation: Сорочка is feminine.
+      - sentence: сір__ пальто
+        answer: е
+        options:
+          - е
+          - ий
+          - а
+        explanation: Пальто is neuter here.
+      - sentence: зелен__ зошит
+        answer: ий
+        options:
+          - ий
+          - а
+          - е
+        explanation: Зошит is masculine.
+      - sentence: рожев__ листівка
+        answer: а
+        options:
+          - а
+          - е
+          - ий
+        explanation: Листівка is feminine.
+      - sentence: син__ книга
+        answer: я
+        options:
+          - я
+          - ій
+          - є
+        explanation: Синій is soft; with книга say синя.
+      - sentence: син__ вікно
+        answer: є
+        options:
+          - є
+          - ій
+          - я
+        explanation: With вікно say синє.
+  - id: act-3
+    type: group-sort
+    title: Hard or soft color
+    instruction: Sort the color chunks by adjective pattern.
+    groups:
+      - label: Hard pattern -ий/-а/-е
+        items:
+          - червоний олівець
+          - жовта стрічка
+          - зелене яблуко
+          - білий светр
+          - чорна сукня
+          - сіре пальто
+          - коричневі черевики
+          - помаранчевий олівець
+      - label: Soft pattern -ій/-я/-є
+        items:
+          - синій светр
+          - синя ручка
+          - синє море
+          - сині речі
+  - id: act-4
+    type: quiz
+    title: Синій or блакитний
+    instruction: Choose the better A1 color chunk.
+    items:
+      - prompt: A clear sky
+        options:
+          - text: блакитне небо
+            correct: true
+          - text: синьо-жовте небо
+            correct: false
+          - text: коричневе небо
+            correct: false
+        explanation: For a clear sky, use блакитне небо.
+      - prompt: The Ukrainian flag
+        options:
+          - text: синьо-жовтий прапор
+            correct: true
+          - text: блакитно-жовтий прапор
+            correct: false
+          - text: голубо-жовтий прапор
+            correct: false
+        explanation: The standard phrase is синьо-жовтий прапор.
+      - prompt: A dark blue sweater
+        options:
+          - text: синій светр
+            correct: true
+          - text: блакитна светр
+            correct: false
+          - text: синє светр
+            correct: false
+        explanation: Светр is masculine; синій also signals deep blue.
+      - prompt: A light-blue postcard
+        options:
+          - text: блакитна листівка
+            correct: true
+          - text: синій листівка
+            correct: false
+          - text: блакитне листівка
+            correct: false
+        explanation: Листівка is feminine.
+      - prompt: Deep water
+        options:
+          - text: синє море
+            correct: true
+          - text: блакитний море
+            correct: false
+          - text: синя море
+            correct: false
+        explanation: Море is neuter; синє море is a stable chunk.
+      - prompt: A notebook that is dark green
+        options:
+          - text: темно-зелений зошит
+            correct: true
+          - text: темна-зелена зошит
+            correct: false
+          - text: зелено-темний зошит
+            correct: false
+        explanation: Treat темно-зелений as one compound color chunk.
+workbook:
+  - type: match-up
+    title: Appearance chunks
+    instruction: Match each Ukrainian chunk with its natural context.
+    pairs:
+      - left: карі очі
+        right: brown eyes
+      - left: русяве волосся
+        right: fair or light-brown hair
+      - left: сиве волосся
+        right: grey hair
+      - left: руде волосся
+        right: red hair
+      - left: блакитне небо
+        right: light-blue sky
+      - left: синьо-жовтий прапор
+        right: Ukrainian flag colors
+  - type: error-correction
+    title: Repair color traps
+    instruction: Choose the standard Ukrainian correction.
+    items:
+      - sentence: Сукня є червона.
+        error: Сукня є червона.
+        answer: Сукня червона.
+        options:
+          - Сукня червона.
+          - Сукня червоний.
+          - Сукня є червоний.
+        explanation: In this present-tense frame, Ukrainian normally omits є.
+      - sentence: Якого кольору є светр?
+        error: Якого кольору є светр?
+        answer: Якого кольору светр?
+        options:
+          - Якого кольору светр?
+          - Яка кольору светр?
+          - Якого кольору є светр?
+        explanation: Keep Якого кольору...? as one chunk without є.
+      - sentence: Блакитно-жовтий прапор.
+        error: Блакитно-жовтий прапор.
+        answer: Синьо-жовтий прапор.
+        options:
+          - Синьо-жовтий прапор.
+          - Блакитно-жовтий прапор.
+          - Жовто-блакитний прапор.
+        explanation: The standard chunk for Ukraine's flag is синьо-жовтий прапор.
+      - sentence: У мене є синій настрій.
+        error: У мене є синій настрій.
+        answer: Мені сумно. / У мене поганий настрій.
+        options:
+          - Мені сумно. / У мене поганий настрій.
+          - У мене є синій настрій.
+          - Я синій сьогодні.
+        explanation: Do not copy the English color idiom. Use a Ukrainian mood phrase.
+      - sentence: Вона має червоне волосся.
+        error: Вона має червоне волосся.
+        answer: У неї руде волосся.
+        options:
+          - У неї руде волосся.
+          - Вона має червоне волосся.
+          - У неї червоний волосся.
+        explanation: For red hair, use руде волосся; for possession, use У неї...
+      - sentence: ЧорнИй, білИй (з наголосом на закінченні)
+        error: ЧорнИй, білИй (з наголосом на закінченні)
+        answer: ЧОрний, бІлий
+        options:
+          - ЧОрний, бІлий
+          - ЧорнИй, білИй
+          - чорний, білий
+        explanation: In these common color words, stress is on the root.
+  - type: fill-in
+    title: Room and clothes colors
+    instruction: Complete each practical sentence.
+    items:
+      - sentence: Моя кімната ___.
+        answer: біла
+        options:
+          - біла
+          - білий
+          - біле
+        explanation: Кімната is feminine.
+      - sentence: Стіл ___.
+        answer: коричневий
+        options:
+          - коричневий
+          - коричнева
+          - коричневе
+        explanation: Стіл is masculine.
+      - sentence: Пальто ___.
+        answer: сіре
+        options:
+          - сіре
+          - сірий
+          - сіра
+        explanation: Пальто is neuter here.
+      - sentence: У мене ___ светр.
+        answer: синій
+        options:
+          - синій
+          - синя
+          - синє
+        explanation: Светр is masculine.
+      - sentence: У неї ___ очі.
+        answer: карі
+        options:
+          - карі
+          - коричневі
+          - каре
+        explanation: Use the fixed appearance chunk карі очі.
+      - sentence: У нього ___ волосся.
+        answer: русяве
+        options:
+          - русяве
+          - русявий
+          - русий
+        explanation: Волосся is neuter; learn русяве волосся as a chunk.
+      - sentence: У бабусі ___ волосся.
+        answer: сиве
+        options:
+          - сиве
+          - сива
+          - сивий
+        explanation: Learn сиве волосся as a chunk.
+      - sentence: Це ___ небо.
+        answer: блакитне
+        options:
+          - блакитне
+          - блакитний
+          - блакитна
+        explanation: Небо is neuter.
+  - type: translate
+    title: Choose the Ukrainian line
+    instruction: Choose the Ukrainian sentence that matches the English cue.
+    items:
+      - source: The dress is red.
+        options:
+          - text: Сукня червона.
+            correct: true
+          - text: Сукня є червона.
+            correct: false
+          - text: Сукня червоний.
+            correct: false
+        explanation: No є is needed, and сукня is feminine.
+      - source: I have a blue sweater.
+        options:
+          - text: У мене синій светр.
+            correct: true
+          - text: У мене синя светр.
+            correct: false
+          - text: У мене є блакитно светр.
+            correct: false
+        explanation: Светр is masculine; синій is the soft color form.
+      - source: The sky is light blue.
+        options:
+          - text: Небо блакитне.
+            correct: true
+          - text: Небо блакитний.
+            correct: false
+          - text: Небо синя.
+            correct: false
+        explanation: Небо is neuter, and блакитний means light blue.
+      - source: She has brown eyes.
+        options:
+          - text: У неї карі очі.
+            correct: true
+          - text: Вона має коричневі очі.
+            correct: false
+          - text: У неї коричневе очі.
+            correct: false
+        explanation: Use the fixed chunk карі очі.
+      - source: He has grey hair.
+        options:
+          - text: У нього сиве волосся.
+            correct: true
+          - text: У нього сіре волосся.
+            correct: false
+          - text: Він має сивий волосся.
+            correct: false
+        explanation: Use сиве волосся and the У нього... frame.
+      - source: The flag is blue and yellow.
+        options:
+          - text: Прапор синьо-жовтий.
+            correct: true
+          - text: Прапор блакитно-жовтий.
+            correct: false
+          - text: Прапор синій і жовта.
+            correct: false
+        explanation: Keep синьо-жовтий as the fixed flag color chunk.
+  - type: true-false
+    title: Color checkpoint
+    instruction: Decide if the statement is right.
+    items:
+      - statement: Якого кольору светр?
+        answer: true
+        explanation: This is the standard color question chunk.
+      - statement: Якого кольору є светр?
+        answer: false
+        explanation: Do not insert є into this question.
+      - statement: Ручка синя.
+        answer: true
+        explanation: Ручка is feminine, and синій becomes синя.
+      - statement: Вікно синій.
+        answer: false
+        explanation: Вікно is neuter; say Вікно синє.
+      - statement: Синій and блакитний are both active A1 words here.
+        answer: true
+        explanation: Синій is dark/deep blue; блакитний is light/sky blue.
+      - statement: Голубий is a production target here.
+        answer: false
+        explanation: It is passive recognition only here.
+      - statement: У неї карі очі.
+        answer: true
+        explanation: Карі очі is a natural fixed chunk.
+      - statement: 'The Ukrainian flag chunk is синьо-жовтий прапор.'
+        answer: true
+        explanation: Keep this exact phrase.
+  - type: match-up
+    title: Color chunks
+    instruction: Match each color chunk with the object or image it best fits.
+    pairs:
+      - left: червоний олівець
+        right: red pencil
+      - left: червона ручка
+        right: red pen
+      - left: червоне яблуко
+        right: red apple
+      - left: блакитне небо
+        right: light-blue sky
+      - left: синє море
+        right: deep-blue sea
+      - left: чорна сукня
+        right: black dress
+      - left: білий светр
+        right: white sweater
+      - left: коричневі черевики
+        right: brown shoes

--- a/curriculum/l2-uk-en/a1/colors/module.md
+++ b/curriculum/l2-uk-en/a1/colors/module.md
@@ -189,8 +189,6 @@ Practice the contrast with one question: **Якого кольору небо?**
 clear, bright sky, answer **блакитне**. If you point to deep water, answer
 **синє**.
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Зовнішність
 
 People are not always described by the same simple palette you use for objects.
@@ -217,8 +215,6 @@ Say:
 
 Do not copy English color idioms word for word. If you mean "I feel blue,"
 say **Мені сумно** or **У мене поганий настрій**.
-
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ## Підсумок
 
@@ -262,11 +258,3 @@ add counting; for now, one noun plus one color is the goal.
 End with one small spoken chain: **Якого кольору? Білий, біла, біле. Чорний,
 чорна, чорне. Синій, синя, синє.** Then choose one real object and say one
 sentence about it.
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->
-
-<!-- INJECT_ACTIVITY: act-9 -->
-
-<!-- INJECT_ACTIVITY: act-10 -->

--- a/curriculum/l2-uk-en/a1/how-many/activities.yaml
+++ b/curriculum/l2-uk-en/a1/how-many/activities.yaml
@@ -1,470 +1,466 @@
-- id: act-1
-  type: quiz
-  title: Count 0-10
-  instruction: Choose the correct Ukrainian number or chunk.
-  items:
-    - prompt: 0
-      options:
-        - text: нуль
-          correct: true
-        - text: о
-          correct: false
-        - text: один
-          correct: false
-      explanation: Phone numbers use нуль, not English "oh."
-    - prompt: one pencil
-      options:
-        - text: один олівець
-          correct: true
-        - text: одна олівець
-          correct: false
-        - text: одне олівець
-          correct: false
-      explanation: Олівець is masculine.
-    - prompt: one pen
-      options:
-        - text: одна ручка
-          correct: true
-        - text: один ручка
-          correct: false
-        - text: одне ручка
-          correct: false
-      explanation: Ручка is feminine.
-    - prompt: one pastry
-      options:
-        - text: одне тістечко
-          correct: true
-        - text: один тістечко
-          correct: false
-        - text: одна тістечко
-          correct: false
-      explanation: Тістечко is neuter.
-    - prompt: two pencils
-      options:
-        - text: два олівці
-          correct: true
-        - text: дві олівці
-          correct: false
-        - text: два олівець
-          correct: false
-      explanation: Use два with masculine plural chunks.
-    - prompt: two pens
-      options:
-        - text: дві ручки
-          correct: true
-        - text: два ручки
-          correct: false
-        - text: дві ручка
-          correct: false
-      explanation: Use дві with feminine plural chunks.
-- id: act-2
-  type: fill-in
-  title: Write the number
-  instruction: Choose the Ukrainian written form.
-  items:
-    - sentence: 5 = ___
-      answer: п'ять
-      options:
-        - п'ять
-        - пять
-        - пьять
-      explanation: П'ять has an apostrophe.
-    - sentence: 6 = ___
-      answer: шість
-      options:
-        - шість
-        - шесть
-        - шисть
-      explanation: Use the Ukrainian form шість.
-    - sentence: 7 = ___
-      answer: сім
-      options:
-        - сім
-        - сєм
-        - семь
-      explanation: Use сім.
-    - sentence: 15 = ___
-      answer: п'ятнадцять
-      options:
-        - п'ятнадцять
-        - пятьнадцять
-        - п'ятьнадцять
-      explanation: П'ятнадцять keeps the apostrophe and the -надцять pattern.
-    - sentence: 17 = ___
-      answer: сімнадцять
-      options:
-        - сімнадцять
-        - сємнадцять
-        - семнадцять
-      explanation: Use сімнадцять.
-    - sentence: 18 = ___
-      answer: вісімнадцять
-      options:
-        - вісімнадцять
-        - вісемнадцять
-        - вісімнацять
-      explanation: Keep the full -надцять ending.
-    - sentence: 20 = ___
-      answer: двадцять
-      options:
-        - двадцять
-        - дванадцять
-        - двадцать
-      explanation: Двадцять is twenty.
-    - sentence: 47 = ___
-      answer: сорок сім
-      options:
-        - сорок сім
-        - чотиридесят сім
-        - сорок семь
-      explanation: Forty is сорок; seven is сім.
-    - sentence: 50 = ___
-      answer: п'ятдесят
-      options:
-        - п'ятдесят
-        - п'ятьдесять
-        - пятьдесят
-      explanation: Use п'ятдесят, without an extra soft sign.
-    - sentence: 90 = ___
-      answer: дев'яносто
-      options:
-        - дев'яносто
-        - дев'ятдесят
-        - дев'яносят
-      explanation: Ninety is дев'яносто.
-- id: act-3
-  type: match-up
-  title: Prices
-  instruction: Match the price with the Ukrainian phrase.
-  pairs:
-    - left: 1 UAH
-      right: одна гривня
-    - left: 2 UAH
-      right: дві гривні
-    - left: 4 UAH
-      right: чотири гривні
-    - left: 5 UAH
-      right: п'ять гривень
-    - left: 50 UAH
-      right: п'ятдесят гривень
-    - left: 150 UAH
-      right: сто п'ятдесят гривень
-    - left: 200 UAH
-      right: двісті гривень
-    - left: 1000 UAH
-      right: тисяча гривень
-- id: act-4
-  type: fill-in
-  title: Age chunks
-  instruction: Choose рік, роки, or років.
-  items:
-    - sentence: Мені двадцять один ___.
-      answer: рік
-      options:
-        - рік
-        - роки
-        - років
-      explanation: Numbers ending in 1 use рік, except 11.
-    - sentence: Моїй сестрі двадцять чотири ___.
-      answer: роки
-      options:
-        - роки
-        - рік
-        - років
-      explanation: Numbers ending in 2-4 use роки, except 12-14.
-    - sentence: Мені двадцять п'ять ___.
-      answer: років
-      options:
-        - років
-        - рік
-        - роки
-      explanation: Numbers ending in 5+ use років.
-    - sentence: Їй вісімнадцять ___.
-      answer: років
-      options:
-        - років
-        - роки
-        - рік
-      explanation: Teens use років.
-    - sentence: Бабусі вісімдесят ___.
-      answer: років
-      options:
-        - років
-        - роки
-        - рік
-      explanation: Eighty uses років.
-    - sentence: Скільки тобі ___?
-      answer: років
-      options:
-        - років
-        - год
-        - рік
-      explanation: Ask Скільки тобі років?
-- id: act-5
-  type: quiz
-  title: Phone number groups
-  instruction: Choose the line that reads the number naturally.
-  items:
-    - prompt: 097
-      options:
-        - text: нуль дев'яносто сім
-          correct: true
-        - text: о дев'яносто сім
-          correct: false
-        - text: нуль дев'ятдесят сім
-          correct: false
-      explanation: Say нуль; 90 is дев'яносто.
-    - prompt: 45
-      options:
-        - text: сорок п'ять
-          correct: true
-        - text: чотиридесят п'ять
-          correct: false
-        - text: сорок пять
-          correct: false
-      explanation: 45 is сорок п'ять.
-    - prompt: 67
-      options:
-        - text: шістдесят сім
-          correct: true
-        - text: шістьдесять сім
-          correct: false
-        - text: шістдесят семь
-          correct: false
-      explanation: Use шістдесят сім.
-    - prompt: 321
-      options:
-        - text: три два один
-          correct: true
-        - text: триста двадцять один
-          correct: false
-        - text: три дві один
-          correct: false
-      explanation: Phone numbers may be read digit by digit in a group.
-    - prompt: 050
-      options:
-        - text: нуль п'ятдесят
-          correct: true
-        - text: о п'ятдесят
-          correct: false
-        - text: нуль п'ятьдесять
-          correct: false
-      explanation: Say нуль and п'ятдесят.
-- id: act-6
-  type: group-sort
-  title: 1 / 2-4 / 5+ chunks
-  instruction: Sort each noun chunk by the number pattern.
-  groups:
-    - label: 1
-      items:
-        - одна гривня
-        - один рік
-        - один олівець
-        - одне тістечко
-    - label: 2-4
-      items:
-        - дві гривні
-        - три роки
-        - чотири зошити
-        - дві ручки
-    - label: 5+
-      items:
-        - п'ять гривень
-        - двадцять років
-        - десять зошитів
-        - шість студентів
-- id: act-7
-  type: error-correction
-  title: Repair number traps
-  instruction: Choose the standard Ukrainian correction.
-  items:
-    - sentence: п'ять столи / п'ять студентів (якщо вжито як Називний множини)
-      error: п'ять столи
-      answer: п'ять столів / п'ять студентів
-      options:
-        - п'ять столів / п'ять студентів
-        - п'ять столи / п'ять студенти
-        - п'ять стола / п'ять студент
-      explanation: With 5+, use the memorized chunk п'ять столів.
-    - sentence: Який час? / Що час?
-      error: Який час? / Що час?
-      answer: Котра година? / О котрій годині?
-      options:
-        - Котра година? / О котрій годині?
-        - Який час? / Що час?
-        - Скільки час?
-      explanation: For time, use the fixed formula Котра година?
-    - sentence: Я маю 20 років / Я є 20 років
-      error: Я маю 20 років / Я є 20 років
-      answer: Мені 20 років
-      options:
-        - Мені 20 років
-        - Я маю 20 років
-        - Я є 20 років
-      explanation: Age uses the chunk Мені ... років.
-    - sentence: перше січень / сьоме травень
-      error: перше січень / сьоме травень
-      answer: перше січня / сьоме травня
-      options:
-        - перше січня / сьоме травня
-        - перше січень / сьоме травень
-        - один січня / сім травня
-      explanation: Learn dates as fixed chunks for now.
-    - sentence: п'ятьдесять / шістьдесять
-      error: п'ятьдесять / шістьдесять
-      answer: п'ятдесят / шістдесят
-      options:
-        - п'ятдесят / шістдесят
-        - п'ятьдесять / шістьдесять
-        - п'ятдесять / шістьдесят
-      explanation: Use п'ятдесят and шістдесят.
-    - sentence: один тисяча / один мільйон
-      error: один тисяча / один мільйон
-      answer: тисяча / мільйон
-      options:
-        - тисяча / мільйон
-        - один тисяча / один мільйон
-        - одне тисяча / одне мільйон
-      explanation: Use тисяча and мільйон as standalone chunks.
-- id: act-8
-  type: fill-in
-  title: Numeral spell-check
-  instruction: Choose the standard form.
-  items:
-    - sentence: У мене ___ книг.
-      answer: п'ять
-      options:
-        - п'ять
-        - пять
-        - пьять
-      explanation: П'ять has an apostrophe.
-    - sentence: У нашій групі ___ студентів.
-      answer: шість
-      options:
-        - шість
-        - шесть
-        - шисть
-      explanation: Use шість.
-    - sentence: На поличці ___ книжок.
-      answer: сім
-      options:
-        - сім
-        - сєм
-        - семь
-      explanation: Use сім.
-    - sentence: На картці ___ гривень.
-      answer: сімнадцять
-      options:
-        - сімнадцять
-        - сємнадцять
-        - семнадцять
-      explanation: Use сімнадцять.
-    - sentence: Мамі ___ років.
-      answer: п'ятдесят
-      options:
-        - п'ятдесят
-        - пятдесят
-        - пятьдесят
-      explanation: Use п'ятдесят.
-    - sentence: Дідусеві ___ років.
-      answer: дев'яносто
-      options:
-        - дев'яносто
-        - дев'ятдесят
-        - дев'яносят
-      explanation: Use дев'яносто.
-    - sentence: Зараз ___.
-      answer: пів на шосту
-      options:
-        - пів на шосту
-        - пол-шостого
-        - половина шостого
-      explanation: Use the Ukrainian time chunk пів на шосту.
-- id: act-9
-  type: translate
-  title: Choose the Ukrainian line
-  instruction: Choose the Ukrainian sentence that matches the English cue.
-  items:
-    - source: How much does the cake cost?
-      options:
-        - text: Скільки коштує торт?
-          correct: true
-        - text: Скільки є торт?
-          correct: false
-        - text: Який коштує торт?
-          correct: false
-      explanation: Use Скільки коштує...?
-    - source: Two hundred hryvnias.
-      options:
-        - text: Двісті гривень.
-          correct: true
-        - text: Два сто гривні.
-          correct: false
-        - text: Двісті гривні.
-          correct: false
-      explanation: Use двісті гривень.
-    - source: I am twenty-five years old.
-      options:
-        - text: Мені двадцять п'ять років.
-          correct: true
-        - text: Я маю двадцять п'ять років.
-          correct: false
-        - text: Я є двадцять п'ять років.
-          correct: false
-      explanation: Use Мені ... років.
-    - source: She is eighteen.
-      options:
-        - text: Їй вісімнадцять.
-          correct: true
-        - text: Вона має вісімнадцять.
-          correct: false
-        - text: Її вісімнадцять.
-          correct: false
-      explanation: Use Їй for the age chunk.
-    - source: My phone number is zero ninety-seven...
-      options:
-        - text: Мій номер телефону — нуль дев'яносто сім...
-          correct: true
-        - text: Мій номер телефону — о дев'яносто сім...
-          correct: false
-        - text: Мій номер телефону — нуль дев'ятдесят сім...
-          correct: false
-      explanation: Say нуль and дев'яносто.
-    - source: 250 hryvnias.
-      options:
-        - text: Двісті п'ятдесят гривень.
-          correct: true
-        - text: Двасто п'ятьдесять гривень.
-          correct: false
-        - text: Двісті п'ятдесят гривні.
-          correct: false
-      explanation: Use двісті п'ятдесят гривень.
-- id: act-10
-  type: true-false
-  title: Quick number checkpoint
-  instruction: Decide if the statement is right.
-  items:
-    - statement: П'ять зошитів.
-      answer: true
-      explanation: This is the safe 5+ chunk.
-    - statement: П'ять столи.
-      answer: false
-      explanation: Say п'ять столів.
-    - statement: Мені двадцять один рік.
-      answer: true
-      explanation: Numbers ending in 1 use рік, except 11.
-    - statement: Мені двадцять чотири роки.
-      answer: true
-      explanation: Numbers ending in 2-4 use роки, except 12-14.
-    - statement: Я маю двадцять років.
-      answer: false
-      explanation: Use Мені двадцять років.
-    - statement: Нуль дев'яносто сім.
-      answer: true
-      explanation: This is a natural phone-number group.
-    - statement: П'ятдесят гривень.
-      answer: true
-      explanation: П'ятдесят is the standard form for 50.
-    - statement: Один тисяча гривень.
-      answer: false
-      explanation: Use тисяча гривень.
+inline:
+  - id: act-1
+    type: quiz
+    title: Count 0-10
+    instruction: Choose the correct Ukrainian number or chunk.
+    items:
+      - prompt: 0
+        options:
+          - text: нуль
+            correct: true
+          - text: о
+            correct: false
+          - text: один
+            correct: false
+        explanation: Phone numbers use нуль, not English "oh."
+      - prompt: one pencil
+        options:
+          - text: один олівець
+            correct: true
+          - text: одна олівець
+            correct: false
+          - text: одне олівець
+            correct: false
+        explanation: Олівець is masculine.
+      - prompt: one pen
+        options:
+          - text: одна ручка
+            correct: true
+          - text: один ручка
+            correct: false
+          - text: одне ручка
+            correct: false
+        explanation: Ручка is feminine.
+      - prompt: one pastry
+        options:
+          - text: одне тістечко
+            correct: true
+          - text: один тістечко
+            correct: false
+          - text: одна тістечко
+            correct: false
+        explanation: Тістечко is neuter.
+      - prompt: two pencils
+        options:
+          - text: два олівці
+            correct: true
+          - text: дві олівці
+            correct: false
+          - text: два олівець
+            correct: false
+        explanation: Use два with masculine plural chunks.
+      - prompt: two pens
+        options:
+          - text: дві ручки
+            correct: true
+          - text: два ручки
+            correct: false
+          - text: дві ручка
+            correct: false
+        explanation: Use дві with feminine plural chunks.
+  - id: act-3
+    type: match-up
+    title: Prices
+    instruction: Match the price with the Ukrainian phrase.
+    pairs:
+      - left: 1 UAH
+        right: одна гривня
+      - left: 2 UAH
+        right: дві гривні
+      - left: 4 UAH
+        right: чотири гривні
+      - left: 5 UAH
+        right: п'ять гривень
+      - left: 50 UAH
+        right: п'ятдесят гривень
+      - left: 150 UAH
+        right: сто п'ятдесят гривень
+      - left: 200 UAH
+        right: двісті гривень
+      - left: 1000 UAH
+        right: тисяча гривень
+  - id: act-4
+    type: fill-in
+    title: Age chunks
+    instruction: Choose рік, роки, or років.
+    items:
+      - sentence: Мені двадцять один ___.
+        answer: рік
+        options:
+          - рік
+          - роки
+          - років
+        explanation: Numbers ending in 1 use рік, except 11.
+      - sentence: Моїй сестрі двадцять чотири ___.
+        answer: роки
+        options:
+          - роки
+          - рік
+          - років
+        explanation: Numbers ending in 2-4 use роки, except 12-14.
+      - sentence: Мені двадцять п'ять ___.
+        answer: років
+        options:
+          - років
+          - рік
+          - роки
+        explanation: Numbers ending in 5+ use років.
+      - sentence: Їй вісімнадцять ___.
+        answer: років
+        options:
+          - років
+          - роки
+          - рік
+        explanation: Teens use років.
+      - sentence: Бабусі вісімдесят ___.
+        answer: років
+        options:
+          - років
+          - роки
+          - рік
+        explanation: Eighty uses років.
+      - sentence: Скільки тобі ___?
+        answer: років
+        options:
+          - років
+          - год
+          - рік
+        explanation: Ask Скільки тобі років?
+  - id: act-5
+    type: quiz
+    title: Phone number groups
+    instruction: Choose the line that reads the number naturally.
+    items:
+      - prompt: 097
+        options:
+          - text: нуль дев'яносто сім
+            correct: true
+          - text: о дев'яносто сім
+            correct: false
+          - text: нуль дев'ятдесят сім
+            correct: false
+        explanation: Say нуль; 90 is дев'яносто.
+      - prompt: 45
+        options:
+          - text: сорок п'ять
+            correct: true
+          - text: чотиридесят п'ять
+            correct: false
+          - text: сорок пять
+            correct: false
+        explanation: 45 is сорок п'ять.
+      - prompt: 67
+        options:
+          - text: шістдесят сім
+            correct: true
+          - text: шістьдесять сім
+            correct: false
+          - text: шістдесят семь
+            correct: false
+        explanation: Use шістдесят сім.
+      - prompt: 321
+        options:
+          - text: три два один
+            correct: true
+          - text: триста двадцять один
+            correct: false
+          - text: три дві один
+            correct: false
+        explanation: Phone numbers may be read digit by digit in a group.
+      - prompt: 050
+        options:
+          - text: нуль п'ятдесят
+            correct: true
+          - text: о п'ятдесят
+            correct: false
+          - text: нуль п'ятьдесять
+            correct: false
+        explanation: Say нуль and п'ятдесят.
+workbook:
+  - type: fill-in
+    title: Write the number
+    instruction: Choose the Ukrainian written form.
+    items:
+      - sentence: 5 = ___
+        answer: п'ять
+        options:
+          - п'ять
+          - пять
+          - пьять
+        explanation: П'ять has an apostrophe.
+      - sentence: 6 = ___
+        answer: шість
+        options:
+          - шість
+          - шесть
+          - шисть
+        explanation: Use the Ukrainian form шість.
+      - sentence: 7 = ___
+        answer: сім
+        options:
+          - сім
+          - сєм
+          - семь
+        explanation: Use сім.
+      - sentence: 15 = ___
+        answer: п'ятнадцять
+        options:
+          - п'ятнадцять
+          - пятьнадцять
+          - п'ятьнадцять
+        explanation: П'ятнадцять keeps the apostrophe and the -надцять pattern.
+      - sentence: 17 = ___
+        answer: сімнадцять
+        options:
+          - сімнадцять
+          - сємнадцять
+          - семнадцять
+        explanation: Use сімнадцять.
+      - sentence: 18 = ___
+        answer: вісімнадцять
+        options:
+          - вісімнадцять
+          - вісемнадцять
+          - вісімнацять
+        explanation: Keep the full -надцять ending.
+      - sentence: 20 = ___
+        answer: двадцять
+        options:
+          - двадцять
+          - дванадцять
+          - двадцать
+        explanation: Двадцять is twenty.
+      - sentence: 47 = ___
+        answer: сорок сім
+        options:
+          - сорок сім
+          - чотиридесят сім
+          - сорок семь
+        explanation: Forty is сорок; seven is сім.
+      - sentence: 50 = ___
+        answer: п'ятдесят
+        options:
+          - п'ятдесят
+          - п'ятьдесять
+          - пятьдесят
+        explanation: Use п'ятдесят, without an extra soft sign.
+      - sentence: 90 = ___
+        answer: дев'яносто
+        options:
+          - дев'яносто
+          - дев'ятдесят
+          - дев'яносят
+        explanation: Ninety is дев'яносто.
+  - type: group-sort
+    title: 1 / 2-4 / 5+ chunks
+    instruction: Sort each noun chunk by the number pattern.
+    groups:
+      - label: 1
+        items:
+          - одна гривня
+          - один рік
+          - один олівець
+          - одне тістечко
+      - label: 2-4
+        items:
+          - дві гривні
+          - три роки
+          - чотири зошити
+          - дві ручки
+      - label: 5+
+        items:
+          - п'ять гривень
+          - двадцять років
+          - десять зошитів
+          - шість студентів
+  - type: error-correction
+    title: Repair number traps
+    instruction: Choose the standard Ukrainian correction.
+    items:
+      - sentence: п'ять столи / п'ять студентів (якщо вжито як Називний множини)
+        error: п'ять столи
+        answer: п'ять столів / п'ять студентів
+        options:
+          - п'ять столів / п'ять студентів
+          - п'ять столи / п'ять студенти
+          - п'ять стола / п'ять студент
+        explanation: With 5+, use the memorized chunk п'ять столів.
+      - sentence: Який час? / Що час?
+        error: Який час? / Що час?
+        answer: Котра година? / О котрій годині?
+        options:
+          - Котра година? / О котрій годині?
+          - Який час? / Що час?
+          - Скільки час?
+        explanation: For time, use the fixed formula Котра година?
+      - sentence: Я маю 20 років / Я є 20 років
+        error: Я маю 20 років / Я є 20 років
+        answer: Мені 20 років
+        options:
+          - Мені 20 років
+          - Я маю 20 років
+          - Я є 20 років
+        explanation: Age uses the chunk Мені ... років.
+      - sentence: перше січень / сьоме травень
+        error: перше січень / сьоме травень
+        answer: перше січня / сьоме травня
+        options:
+          - перше січня / сьоме травня
+          - перше січень / сьоме травень
+          - один січня / сім травня
+        explanation: Learn dates as fixed chunks for now.
+      - sentence: п'ятьдесять / шістьдесять
+        error: п'ятьдесять / шістьдесять
+        answer: п'ятдесят / шістдесят
+        options:
+          - п'ятдесят / шістдесят
+          - п'ятьдесять / шістьдесять
+          - п'ятдесять / шістьдесят
+        explanation: Use п'ятдесят and шістдесят.
+      - sentence: один тисяча / один мільйон
+        error: один тисяча / один мільйон
+        answer: тисяча / мільйон
+        options:
+          - тисяча / мільйон
+          - один тисяча / один мільйон
+          - одне тисяча / одне мільйон
+        explanation: Use тисяча and мільйон as standalone chunks.
+  - type: fill-in
+    title: Numeral spell-check
+    instruction: Choose the standard form.
+    items:
+      - sentence: У мене ___ книг.
+        answer: п'ять
+        options:
+          - п'ять
+          - пять
+          - пьять
+        explanation: П'ять has an apostrophe.
+      - sentence: У нашій групі ___ студентів.
+        answer: шість
+        options:
+          - шість
+          - шесть
+          - шисть
+        explanation: Use шість.
+      - sentence: На поличці ___ книжок.
+        answer: сім
+        options:
+          - сім
+          - сєм
+          - семь
+        explanation: Use сім.
+      - sentence: На картці ___ гривень.
+        answer: сімнадцять
+        options:
+          - сімнадцять
+          - сємнадцять
+          - семнадцять
+        explanation: Use сімнадцять.
+      - sentence: Мамі ___ років.
+        answer: п'ятдесят
+        options:
+          - п'ятдесят
+          - пятдесят
+          - пятьдесят
+        explanation: Use п'ятдесят.
+      - sentence: Дідусеві ___ років.
+        answer: дев'яносто
+        options:
+          - дев'яносто
+          - дев'ятдесят
+          - дев'яносят
+        explanation: Use дев'яносто.
+      - sentence: Зараз ___.
+        answer: пів на шосту
+        options:
+          - пів на шосту
+          - пол-шостого
+          - половина шостого
+        explanation: Use the Ukrainian time chunk пів на шосту.
+  - type: translate
+    title: Choose the Ukrainian line
+    instruction: Choose the Ukrainian sentence that matches the English cue.
+    items:
+      - source: How much does the cake cost?
+        options:
+          - text: Скільки коштує торт?
+            correct: true
+          - text: Скільки є торт?
+            correct: false
+          - text: Який коштує торт?
+            correct: false
+        explanation: Use Скільки коштує...?
+      - source: Two hundred hryvnias.
+        options:
+          - text: Двісті гривень.
+            correct: true
+          - text: Два сто гривні.
+            correct: false
+          - text: Двісті гривні.
+            correct: false
+        explanation: Use двісті гривень.
+      - source: I am twenty-five years old.
+        options:
+          - text: Мені двадцять п'ять років.
+            correct: true
+          - text: Я маю двадцять п'ять років.
+            correct: false
+          - text: Я є двадцять п'ять років.
+            correct: false
+        explanation: Use Мені ... років.
+      - source: She is eighteen.
+        options:
+          - text: Їй вісімнадцять.
+            correct: true
+          - text: Вона має вісімнадцять.
+            correct: false
+          - text: Її вісімнадцять.
+            correct: false
+        explanation: Use Їй for the age chunk.
+      - source: My phone number is zero ninety-seven...
+        options:
+          - text: Мій номер телефону — нуль дев'яносто сім...
+            correct: true
+          - text: Мій номер телефону — о дев'яносто сім...
+            correct: false
+          - text: Мій номер телефону — нуль дев'ятдесят сім...
+            correct: false
+        explanation: Say нуль and дев'яносто.
+      - source: 250 hryvnias.
+        options:
+          - text: Двісті п'ятдесят гривень.
+            correct: true
+          - text: Двасто п'ятьдесять гривень.
+            correct: false
+          - text: Двісті п'ятдесят гривні.
+            correct: false
+        explanation: Use двісті п'ятдесят гривень.
+  - type: true-false
+    title: Quick number checkpoint
+    instruction: Decide if the statement is right.
+    items:
+      - statement: П'ять зошитів.
+        answer: true
+        explanation: This is the safe 5+ chunk.
+      - statement: П'ять столи.
+        answer: false
+        explanation: Say п'ять столів.
+      - statement: Мені двадцять один рік.
+        answer: true
+        explanation: Numbers ending in 1 use рік, except 11.
+      - statement: Мені двадцять чотири роки.
+        answer: true
+        explanation: Numbers ending in 2-4 use роки, except 12-14.
+      - statement: Я маю двадцять років.
+        answer: false
+        explanation: Use Мені двадцять років.
+      - statement: Нуль дев'яносто сім.
+        answer: true
+        explanation: This is a natural phone-number group.
+      - statement: П'ятдесят гривень.
+        answer: true
+        explanation: П'ятдесят is the standard form for 50.
+      - statement: Один тисяча гривень.
+        answer: false
+        explanation: Use тисяча гривень.

--- a/curriculum/l2-uk-en/a1/how-many/module.md
+++ b/curriculum/l2-uk-en/a1/how-many/module.md
@@ -59,8 +59,6 @@ When you hear a price, first catch the number, then catch the money word.
 to translate every ending while someone is speaking.
 :::
 
-<!-- INJECT_ACTIVITY: act-2 -->
-
 ## Числа 1-20
 
 Learn **нуль** first. In phone numbers, the first digit is **нуль**, not the
@@ -242,8 +240,6 @@ number (**п'ятдесят шість**). The practical goal is clarity. Speak 
 pause between groups, and repeat the number back before you trust that you
 wrote it correctly.
 
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Number Traps
 
 Keep these repairs automatic:
@@ -274,8 +270,6 @@ produce them yet.
 One more trap is the money word itself. Use **гривня**, **гривні**,
 **гривень** for Ukrainian money. Keep other currencies out of these A1 price
 drills unless a later lesson gives you a specific travel context.
-
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ## Підсумок
 
@@ -309,9 +303,3 @@ A strong final routine has four lines:
 Say those lines until the chunks feel boring. That is the point: numbers should
 become quick enough that you can use them while buying bread, writing a phone
 number, or answering a simple personal question.
-
-<!-- INJECT_ACTIVITY: act-8 -->
-
-<!-- INJECT_ACTIVITY: act-9 -->
-
-<!-- INJECT_ACTIVITY: act-10 -->

--- a/curriculum/l2-uk-en/a1/many-things/activities.yaml
+++ b/curriculum/l2-uk-en/a1/many-things/activities.yaml
@@ -1,344 +1,342 @@
-- id: act-1
-  type: quiz
-  title: One thing, many things
-  instruction: Choose the plural chunk.
-  items:
-    - prompt: стіл
-      options:
-        - text: столи
-          correct: true
-        - text: стіла
-          correct: false
-        - text: стілів
-          correct: false
-      explanation: Learn the pair стіл - столи.
-    - prompt: книга
-      options:
-        - text: книги
-          correct: true
-        - text: книгі
-          correct: false
-        - text: книга
-          correct: false
-      explanation: Книга becomes книги.
-    - prompt: вікно
-      options:
-        - text: вікна
-          correct: true
-        - text: вікни
-          correct: false
-        - text: вікні
-          correct: false
-      explanation: Many neuter nouns ending in -о use -а.
-    - prompt: стілець
-      options:
-        - text: стільці
-          correct: true
-        - text: стілеці
-          correct: false
-        - text: стільця
-          correct: false
-      explanation: Learn стілець - стільці as its own pair.
-    - prompt: крісло
-      options:
-        - text: крісла
-          correct: true
-        - text: крісли
-          correct: false
-        - text: кріслі
-          correct: false
-      explanation: Крісло becomes крісла.
-    - prompt: ручка
-      options:
-        - text: ручки
-          correct: true
-        - text: ручкі
-          correct: false
-        - text: ручка
-          correct: false
-      explanation: Ручка becomes ручки.
-- id: act-2
-  type: match-up
-  title: Singular and plural pairs
-  instruction: Match one thing with many things.
-  pairs:
-    - left: стіл
-      right: столи
-    - left: книга
-      right: книги
-    - left: вікно
-      right: вікна
-    - left: стілець
-      right: стільці
-    - left: телефон
-      right: телефони
-    - left: зошит
-      right: зошити
-    - left: лампа
-      right: лампи
-    - left: дзеркало
-      right: дзеркала
-- id: act-3
-  type: fill-in
-  title: Plural adjective ending
-  instruction: Choose the ending that makes the adjective plural.
-  items:
-    - sentence: нов__ книги
-      answer: і
-      options:
-        - і
-        - а
-        - ий
-      explanation: Plural adjectives use -і.
-    - sentence: велик__ столи
-      answer: і
-      options:
-        - і
-        - ий
-        - е
-      explanation: Великий becomes великі.
-    - sentence: чист__ вікна
-      answer: і
-      options:
-        - і
-        - е
-        - а
-      explanation: Чисте becomes чисті.
-    - sentence: син__ зошити
-      answer: і
-      options:
-        - і
-        - я
-        - є
-      explanation: Синій becomes сині.
-    - sentence: літн__ дні
-      answer: і
-      options:
-        - і
-        - ій
-        - я
-      explanation: Літній becomes літні.
-    - sentence: осінн__ ранки
-      answer: і
-      options:
-        - і
-        - я
-        - є
-      explanation: Осінній becomes осінні.
-    - sentence: червон__ ручки
-      answer: і
-      options:
-        - і
-        - а
-        - ий
-      explanation: Червона becomes червоні.
-    - sentence: жовт__ лампи
-      answer: і
-      options:
-        - і
-        - а
-        - е
-      explanation: Жовта becomes жовті.
-- id: act-4
-  type: group-sort
-  title: Singular, ordinary plural, special number
-  instruction: Sort each chunk by what it shows.
-  groups:
-    - label: One thing
-      items:
-        - стіл
-        - книга
-        - вікно
-        - стілець
-    - label: Ordinary plural
-      items:
-        - столи
-        - книги
-        - вікна
-        - стільці
-    - label: Special number chunk
-      items:
-        - п'ять зошитів
-        - десять учнів
-        - сто гривень
-        - двоє дверей
-- id: act-5
-  type: quiz
-  title: Ці, ті, мої, які
-  instruction: Choose the plural helper.
-  items:
-    - prompt: These tables are big.
-      options:
-        - text: Ці столи великі.
-          correct: true
-        - text: Цей столи великі.
-          correct: false
-        - text: Ця столи великі.
-          correct: false
-      explanation: Use ці with plural nouns near you.
-    - prompt: Those chairs are old.
-      options:
-        - text: Ті стільці старі.
-          correct: true
-        - text: Той стільці старі.
-          correct: false
-        - text: Та стільці старі.
-          correct: false
-      explanation: Use ті for plural nouns farther away.
-    - prompt: My notebooks are blue.
-      options:
-        - text: Мої зошити сині.
-          correct: true
-        - text: Мій зошити сині.
-          correct: false
-        - text: Моя зошити сині.
-          correct: false
-      explanation: The plural form of my is мої.
-    - prompt: Which pens?
-      options:
-        - text: Які ручки?
-          correct: true
-        - text: Яка ручки?
-          correct: false
-        - text: Який ручки?
-          correct: false
-      explanation: The plural question word is які.
-    - prompt: These books are new.
-      options:
-        - text: Ці книги нові.
-          correct: true
-        - text: Це книги нове.
-          correct: false
-        - text: Ця книги нова.
-          correct: false
-      explanation: Use plural ці and plural нові.
-- id: act-6
-  type: match-up
-  title: People chunks
-  instruction: Match the English prompt with the Ukrainian chunk.
-  pairs:
-    - left: we
-      right: ми
-    - left: you, plural or formal
-      right: ви
-    - left: for us
-      right: для нас
-    - left: for you
-      right: для вас
-    - left: we need
-      right: нам треба
-    - left: you need
-      right: вам треба
-    - left: with us
-      right: з нами
-    - left: with you
-      right: з вами
-- id: act-7
-  type: fill-in
-  title: Number chunks
-  instruction: Choose the noun chunk after the number.
-  items:
-    - sentence: два ___
-      answer: зошити
-      options:
-        - зошити
-        - зошитів
-        - зошит
-      explanation: With 2, use the ordinary plural chunk два зошити.
-    - sentence: три ___
-      answer: книги
-      options:
-        - книги
-        - книг
-        - книга
-      explanation: Три книги is the A1-safe phrase.
-    - sentence: чотири ___
-      answer: смартфони
-      options:
-        - смартфони
-        - смартфонів
-        - смартфон
-      explanation: Чотири uses the ordinary plural form here.
-    - sentence: п'ять ___
-      answer: зошитів
-      options:
-        - зошитів
-        - зошити
-        - зошит
-      explanation: Treat п'ять зошитів as a later 5+ chunk.
-    - sentence: десять ___
-      answer: учнів
-      options:
-        - учнів
-        - учні
-        - учень
-      explanation: Treat десять учнів as a later 5+ chunk.
-    - sentence: сто ___
-      answer: гривень
-      options:
-        - гривень
-        - гривні
-        - гривня
-      explanation: Сто гривень is the price chunk from the numbers module.
-- id: act-8
-  type: error-correction
-  title: Repair plural traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: repair-traps
-  items:
-    - sentence: великий м'ячі
-      error: великий м'ячі
-      answer: великі м'ячі
-      options:
-        - великі м'ячі
-        - великий м'ячі
-        - велика м'ячі
-      explanation: Plural adjectives use -і.
-    - sentence: синія шарфи
-      error: синія шарфи
-      answer: сині шарфи
-      options:
-        - сині шарфи
-        - синія шарфи
-        - синій шарфи
-      explanation: The plural color form is сині.
-    - sentence: два зошитів / два смартфонів
-      error: два зошитів / два смартфонів
-      answer: два зошити / чотири смартфони
-      options:
-        - два зошити / чотири смартфони
-        - два зошитів / два смартфонів
-        - два зошита / чотири смартфона
-      explanation: Two, three, and four use the ordinary plural form here.
-    - sentence: п'ять зошити / десять учні
-      error: п'ять зошити / десять учні
-      answer: п'ять зошитів / десять учнів
-      options:
-        - п'ять зошитів / десять учнів
-        - п'ять зошити / десять учні
-        - п'ять зошита / десять учня
-      explanation: Keep the 5+ chunk п'ять зошитів.
-    - sentence: один двері / два двері
-      error: один двері / два двері
-      answer: одні двері / двоє дверей
-      options:
-        - одні двері / двоє дверей
-        - один двері / два двері
-        - одна двері / дві двері
-      explanation: Двері is plural-only in everyday use.
-    - sentence: молоді / дітвори
-      error: молоді / дітвори
-      answer: молодь / дітвора
-      options:
-        - молодь / дітвора
-        - молоді / дітвори
-        - молодя / дітвори
-      explanation: Молодь is a singular collective word.
-    - sentence: для ми / з ми
-      error: для ми / з ми
-      answer: для нас / з нами
-      options:
-        - для нас / з нами
-        - для ми / з ми
-        - для нам / з нас
-      explanation: "Use the pronoun chunks: для нас, з нами."
+inline:
+  - id: act-1
+    type: quiz
+    title: One thing, many things
+    instruction: Choose the plural chunk.
+    items:
+      - prompt: стіл
+        options:
+          - text: столи
+            correct: true
+          - text: стіла
+            correct: false
+          - text: стілів
+            correct: false
+        explanation: Learn the pair стіл - столи.
+      - prompt: книга
+        options:
+          - text: книги
+            correct: true
+          - text: книгі
+            correct: false
+          - text: книга
+            correct: false
+        explanation: Книга becomes книги.
+      - prompt: вікно
+        options:
+          - text: вікна
+            correct: true
+          - text: вікни
+            correct: false
+          - text: вікні
+            correct: false
+        explanation: Many neuter nouns ending in -о use -а.
+      - prompt: стілець
+        options:
+          - text: стільці
+            correct: true
+          - text: стілеці
+            correct: false
+          - text: стільця
+            correct: false
+        explanation: Learn стілець - стільці as its own pair.
+      - prompt: крісло
+        options:
+          - text: крісла
+            correct: true
+          - text: крісли
+            correct: false
+          - text: кріслі
+            correct: false
+        explanation: Крісло becomes крісла.
+      - prompt: ручка
+        options:
+          - text: ручки
+            correct: true
+          - text: ручкі
+            correct: false
+          - text: ручка
+            correct: false
+        explanation: Ручка becomes ручки.
+  - id: act-2
+    type: match-up
+    title: Singular and plural pairs
+    instruction: Match one thing with many things.
+    pairs:
+      - left: стіл
+        right: столи
+      - left: книга
+        right: книги
+      - left: вікно
+        right: вікна
+      - left: стілець
+        right: стільці
+      - left: телефон
+        right: телефони
+      - left: зошит
+        right: зошити
+      - left: лампа
+        right: лампи
+      - left: дзеркало
+        right: дзеркала
+  - id: act-3
+    type: fill-in
+    title: Plural adjective ending
+    instruction: Choose the ending that makes the adjective plural.
+    items:
+      - sentence: нов__ книги
+        answer: і
+        options:
+          - і
+          - а
+          - ий
+        explanation: Plural adjectives use -і.
+      - sentence: велик__ столи
+        answer: і
+        options:
+          - і
+          - ий
+          - е
+        explanation: Великий becomes великі.
+      - sentence: чист__ вікна
+        answer: і
+        options:
+          - і
+          - е
+          - а
+        explanation: Чисте becomes чисті.
+      - sentence: син__ зошити
+        answer: і
+        options:
+          - і
+          - я
+          - є
+        explanation: Синій becomes сині.
+      - sentence: літн__ дні
+        answer: і
+        options:
+          - і
+          - ій
+          - я
+        explanation: Літній becomes літні.
+      - sentence: осінн__ ранки
+        answer: і
+        options:
+          - і
+          - я
+          - є
+        explanation: Осінній becomes осінні.
+      - sentence: червон__ ручки
+        answer: і
+        options:
+          - і
+          - а
+          - ий
+        explanation: Червона becomes червоні.
+      - sentence: жовт__ лампи
+        answer: і
+        options:
+          - і
+          - а
+          - е
+        explanation: Жовта becomes жовті.
+  - id: act-5
+    type: quiz
+    title: Ці, ті, мої, які
+    instruction: Choose the plural helper.
+    items:
+      - prompt: These tables are big.
+        options:
+          - text: Ці столи великі.
+            correct: true
+          - text: Цей столи великі.
+            correct: false
+          - text: Ця столи великі.
+            correct: false
+        explanation: Use ці with plural nouns near you.
+      - prompt: Those chairs are old.
+        options:
+          - text: Ті стільці старі.
+            correct: true
+          - text: Той стільці старі.
+            correct: false
+          - text: Та стільці старі.
+            correct: false
+        explanation: Use ті for plural nouns farther away.
+      - prompt: My notebooks are blue.
+        options:
+          - text: Мої зошити сині.
+            correct: true
+          - text: Мій зошити сині.
+            correct: false
+          - text: Моя зошити сині.
+            correct: false
+        explanation: The plural form of my is мої.
+      - prompt: Which pens?
+        options:
+          - text: Які ручки?
+            correct: true
+          - text: Яка ручки?
+            correct: false
+          - text: Який ручки?
+            correct: false
+        explanation: The plural question word is які.
+      - prompt: These books are new.
+        options:
+          - text: Ці книги нові.
+            correct: true
+          - text: Це книги нове.
+            correct: false
+          - text: Ця книги нова.
+            correct: false
+        explanation: Use plural ці and plural нові.
+workbook:
+  - type: group-sort
+    title: Singular, ordinary plural, special number
+    instruction: Sort each chunk by what it shows.
+    groups:
+      - label: One thing
+        items:
+          - стіл
+          - книга
+          - вікно
+          - стілець
+      - label: Ordinary plural
+        items:
+          - столи
+          - книги
+          - вікна
+          - стільці
+      - label: Special number chunk
+        items:
+          - п'ять зошитів
+          - десять учнів
+          - сто гривень
+          - двоє дверей
+  - type: match-up
+    title: People chunks
+    instruction: Match the English prompt with the Ukrainian chunk.
+    pairs:
+      - left: we
+        right: ми
+      - left: you, plural or formal
+        right: ви
+      - left: for us
+        right: для нас
+      - left: for you
+        right: для вас
+      - left: we need
+        right: нам треба
+      - left: you need
+        right: вам треба
+      - left: with us
+        right: з нами
+      - left: with you
+        right: з вами
+  - type: fill-in
+    title: Number chunks
+    instruction: Choose the noun chunk after the number.
+    items:
+      - sentence: два ___
+        answer: зошити
+        options:
+          - зошити
+          - зошитів
+          - зошит
+        explanation: With 2, use the ordinary plural chunk два зошити.
+      - sentence: три ___
+        answer: книги
+        options:
+          - книги
+          - книг
+          - книга
+        explanation: Три книги is the A1-safe phrase.
+      - sentence: чотири ___
+        answer: смартфони
+        options:
+          - смартфони
+          - смартфонів
+          - смартфон
+        explanation: Чотири uses the ordinary plural form here.
+      - sentence: п'ять ___
+        answer: зошитів
+        options:
+          - зошитів
+          - зошити
+          - зошит
+        explanation: Treat п'ять зошитів as a later 5+ chunk.
+      - sentence: десять ___
+        answer: учнів
+        options:
+          - учнів
+          - учні
+          - учень
+        explanation: Treat десять учнів as a later 5+ chunk.
+      - sentence: сто ___
+        answer: гривень
+        options:
+          - гривень
+          - гривні
+          - гривня
+        explanation: Сто гривень is the price chunk from the numbers module.
+  - type: error-correction
+    title: Repair plural traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: repair-traps
+    items:
+      - sentence: великий м'ячі
+        error: великий м'ячі
+        answer: великі м'ячі
+        options:
+          - великі м'ячі
+          - великий м'ячі
+          - велика м'ячі
+        explanation: Plural adjectives use -і.
+      - sentence: синія шарфи
+        error: синія шарфи
+        answer: сині шарфи
+        options:
+          - сині шарфи
+          - синія шарфи
+          - синій шарфи
+        explanation: The plural color form is сині.
+      - sentence: два зошитів / два смартфонів
+        error: два зошитів / два смартфонів
+        answer: два зошити / чотири смартфони
+        options:
+          - два зошити / чотири смартфони
+          - два зошитів / два смартфонів
+          - два зошита / чотири смартфона
+        explanation: Two, three, and four use the ordinary plural form here.
+      - sentence: п'ять зошити / десять учні
+        error: п'ять зошити / десять учні
+        answer: п'ять зошитів / десять учнів
+        options:
+          - п'ять зошитів / десять учнів
+          - п'ять зошити / десять учні
+          - п'ять зошита / десять учня
+        explanation: Keep the 5+ chunk п'ять зошитів.
+      - sentence: один двері / два двері
+        error: один двері / два двері
+        answer: одні двері / двоє дверей
+        options:
+          - одні двері / двоє дверей
+          - один двері / два двері
+          - одна двері / дві двері
+        explanation: Двері is plural-only in everyday use.
+      - sentence: молоді / дітвори
+        error: молоді / дітвори
+        answer: молодь / дітвора
+        options:
+          - молодь / дітвора
+          - молоді / дітвори
+          - молодя / дітвори
+        explanation: Молодь is a singular collective word.
+      - sentence: для ми / з ми
+        error: для ми / з ми
+        answer: для нас / з нами
+        options:
+          - для нас / з нами
+          - для ми / з ми
+          - для нам / з нас
+        explanation: 'Use the pronoun chunks: для нас, з нами.'

--- a/curriculum/l2-uk-en/a1/many-things/module.md
+++ b/curriculum/l2-uk-en/a1/many-things/module.md
@@ -192,8 +192,6 @@ Then add pointing words from the last module:
 - **Ті стільці старі.**
 - **Мої ручки сині.**
 
-<!-- INJECT_ACTIVITY: act-4 -->
-
 ### With numbers
 
 You already met the number pattern in prices and ages. Here it helps with
@@ -257,8 +255,6 @@ Third, combine plural helpers:
 - **мої сині зошити**
 - **які червоні ручки?**
 
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ### Repair traps
 
 Use these repairs when English tries to keep Ukrainian too simple:
@@ -273,10 +269,6 @@ Use these repairs when English tries to keep Ukrainian too simple:
 | **молоді** for the group | **молодь** | The group word stays singular |
 | **для ми** | **для нас** | Pronouns change in chunks |
 | **з ми** | **з нами** | After **з**, use **нами** |
-
-<!-- INJECT_ACTIVITY: act-8 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Mini room check
 

--- a/curriculum/l2-uk-en/a1/this-and-that/activities.yaml
+++ b/curriculum/l2-uk-en/a1/this-and-that/activities.yaml
@@ -1,337 +1,335 @@
-- id: act-1
-  type: quiz
-  title: Це as a whole sentence
-  instruction: Choose the natural Ukrainian sentence.
-  items:
-    - prompt: This is a table.
-      options:
-        - text: Це стіл.
-          correct: true
-        - text: Це є стіл.
-          correct: false
-        - text: Цей є стіл.
-          correct: false
-      explanation: Present-tense Ukrainian normally drops є in this sentence.
-    - prompt: Who is this?
-      options:
-        - text: Хто це?
-          correct: true
-        - text: Хто цей?
-          correct: false
-        - text: Хто той?
-          correct: false
-      explanation: Use the fixed question Хто це?
-    - prompt: What is this?
-      options:
-        - text: Що це?
-          correct: true
-        - text: Що ця?
-          correct: false
-        - text: Що той?
-          correct: false
-      explanation: Що це? is the safe first question.
-    - prompt: This is my backpack.
-      options:
-        - text: Це мій рюкзак.
-          correct: true
-        - text: Цей є мій рюкзак.
-          correct: false
-        - text: Це є мій рюкзак.
-          correct: false
-      explanation: Keep Це мій рюкзак as one chunk.
-- id: act-2
-  type: match-up
-  title: Noun gender and pointing word
-  instruction: Match the noun with the near pointing phrase.
-  pairs:
-    - left: стіл
-      right: цей стіл
-    - left: книга
-      right: ця книга
-    - left: вікно
-      right: це вікно
-    - left: радіо
-      right: це радіо
-    - left: ручки
-      right: ці ручки
-    - left: телефони
-      right: ці телефони
-- id: act-3
-  type: fill-in
-  title: Цей, ця, це, ці
-  instruction: Choose the near pointing word.
-  items:
-    - sentence: ___ стіл новий.
-      answer: Цей
-      options:
-        - Цей
-        - Ця
-        - Це
-      explanation: Стіл is masculine, so use цей.
-    - sentence: ___ книга цікава.
-      answer: Ця
-      options:
-        - Ця
-        - Цей
-        - Це
-      explanation: Книга is feminine, so use ця.
-    - sentence: ___ вікно велике.
-      answer: Це
-      options:
-        - Це
-        - Цей
-        - Ця
-      explanation: Вікно is neuter, so use це.
-    - sentence: ___ ручки сині.
-      answer: Ці
-      options:
-        - Ці
-        - Цей
-        - Ця
-      explanation: Ручки is plural, so use ці.
-    - sentence: ___ телефон чорний.
-      answer: Цей
-      options:
-        - Цей
-        - Ця
-        - Ці
-      explanation: Телефон is masculine.
-    - sentence: ___ сумка червона.
-      answer: Ця
-      options:
-        - Ця
-        - Це
-        - Цей
-      explanation: Сумка is feminine.
-- id: act-4
-  type: match-up
-  title: Near and far
-  instruction: Match each near phrase with the far phrase.
-  pairs:
-    - left: цей стіл
-      right: той стіл
-    - left: ця книга
-      right: та книга
-    - left: це вікно
-      right: те вікно
-    - left: ці ручки
-      right: ті ручки
-    - left: цей телефон
-      right: той телефон
-    - left: ця сумка
-      right: та сумка
-- id: act-5
-  type: quiz
-  title: Clear choices with чи
-  instruction: Choose the clear question or answer.
-  items:
-    - prompt: Which table, this one or that one?
-      options:
-        - text: Який стіл — цей чи той?
-          correct: true
-        - text: Яка стіл — ця чи та?
-          correct: false
-        - text: Яке стіл — це чи те?
-          correct: false
-      explanation: Стіл is masculine, so use який, цей, той.
-    - prompt: Which bag, this red one or that blue one?
-      options:
-        - text: Яка сумка — ця червона чи та синя?
-          correct: true
-        - text: Який сумка — цей червоний чи той синій?
-          correct: false
-        - text: Яке сумка — це червоне чи те синє?
-          correct: false
-      explanation: Сумка is feminine, so use яка, ця, та.
-    - prompt: Which window, this big one or that small one?
-      options:
-        - text: Яке вікно — це велике чи те маленьке?
-          correct: true
-        - text: Яка вікно — ця велика чи та маленька?
-          correct: false
-        - text: Який вікно — цей великий чи той маленький?
-          correct: false
-      explanation: Вікно is neuter, so use яке, це, те.
-    - prompt: Make the list clearer.
-      options:
-        - text: У кімнаті є та книга і ручка.
-          correct: true
-        - text: У кімнаті є та книга та ручка.
-          correct: false
-        - text: У кімнаті є ця книга ця ручка.
-          correct: false
-      explanation: Use і for the list when та already means that.
-- id: act-6
-  type: fill-in
-  title: Useful chunks
-  instruction: Choose the safe A1 chunk.
-  items:
-    - sentence: Я хочу ___ книгу.
-      answer: цю
-      options:
-        - цю
-        - цей
-        - це
-      explanation: Treat цю книгу as a buying chunk for now.
-    - sentence: Я хочу ___ олівець.
-      answer: цей
-      options:
-        - цей
-        - цю
-        - ці
-      explanation: Олівець is masculine; this A1 chunk stays simple.
-    - sentence: ___ книга цікава.
-      answer: Ця
-      options:
-        - Ця
-        - Це
-        - Цей
-      explanation: Before a feminine noun, use ця.
-    - sentence: ___ мій стіл.
-      answer: Це
-      options:
-        - Це
-        - Цей є
-        - Той є
-      explanation: Це мій стіл is the natural sentence.
-    - sentence: Мене ___ Марк.
-      answer: звати
-      options:
-        - звати
-        - ім'я є
-        - є ім'я
-      explanation: Use Мене звати + name.
-    - sentence: ___ 20 років.
-      answer: Мені
-      options:
-        - Мені
-        - Я маю
-        - Я є
-      explanation: Age uses the Мені ... років chunk.
-- id: act-7
-  type: quiz
-  title: Repair the trap
-  instruction: Choose the repaired sentence.
-  # wiki err-1: ❌ «Цей є мій стіл» -> ✅ «Це мій стіл»
-  # wiki err-2: ❌ «Я маю 20 років » -> ✅ «Мені 20 років»
-  # wiki err-3: ❌ «Моє ім'я є Марк » -> ✅ «Мене звати Марк»
-  # wiki err-4: ❌ «Я бачу теє хлопця» -> ✅ «Я бачу того хлопця»
-  # wiki err-5: ❌ «Я розмовляв з його» -> ✅ «Я розмовляв з ним»
-  # wiki err-6: ❌ «У тому́» -> ✅ «У то́му»
-  # wiki err-7: ❌ «Це цікавий книга» -> ✅ «Ця книга цікава»
-  items:
-    - prompt: "Fix the sentence: Цей є мій стіл."
-      options:
-        - text: Це мій стіл.
-          correct: true
-        - text: Цей є мій стіл.
-          correct: false
-        - text: Це є мій стіл.
-          correct: false
-      explanation: Use universal це and drop є.
-    - prompt: "Fix the sentence: Це цікавий книга."
-      options:
-        - text: Ця книга цікава.
-          correct: true
-        - text: Це цікавий книга.
-          correct: false
-        - text: Цей книга цікавий.
-          correct: false
-      explanation: Книга is feminine, so use ця and feminine цікава.
-    - prompt: "Fix the sentence: Я маю 20 років."
-      options:
-        - text: Мені 20 років.
-          correct: true
-        - text: Я маю 20 років.
-          correct: false
-        - text: Я є 20 років.
-          correct: false
-      explanation: Use the age chunk from the numbers module.
-    - prompt: "Fix the sentence: Моє ім'я є Марк."
-      options:
-        - text: Мене звати Марк.
-          correct: true
-        - text: Моє ім'я є Марк.
-          correct: false
-        - text: Я ім'я Марк.
-          correct: false
-      explanation: Use Мене звати + name.
-    - prompt: Choose the everyday A1-safe sentence.
-      options:
-        - text: Я бачу того хлопця.
-          correct: true
-        - text: Я бачу теє хлопця.
-          correct: false
-        - text: Я бачу той хлопця.
-          correct: false
-      explanation: Теє is poetic/passive recognition, not everyday A1 speech.
-    - prompt: Choose the later-grammar preview chunk.
-      options:
-        - text: Я розмовляю з ним.
-          correct: true
-        - text: Я розмовляю з його.
-          correct: false
-        - text: Я розмовляю з він.
-          correct: false
-      explanation: After з, the safe chunk is з ним.
-- id: act-8
-  type: error-correction
-  title: Manifest repair rows
-  instruction: Read the learner trap and choose the repaired Ukrainian chunk.
-  items:
-    - sentence: Цей є мій стіл
-      error: "❌ «Цей є мій стіл»"
-      answer: "✅ «Це мій стіл»"
-      options:
-        - "✅ «Це мій стіл»"
-        - "Це є мій стіл"
-        - "Цей мій стіл"
-      explanation: Use universal це and drop є.
-    - sentence: Я маю 20 років
-      error: "❌ «Я маю 20 років »"
-      answer: "✅ «Мені 20 років»"
-      options:
-        - "✅ «Мені 20 років»"
-        - "Я є 20 років"
-        - "Мій вік 20"
-      explanation: Age uses Мені ... років.
-    - sentence: Моє ім'я є Марк
-      error: "❌ «Моє ім'я є Марк »"
-      answer: "✅ «Мене звати Марк»"
-      options:
-        - "✅ «Мене звати Марк»"
-        - "Я ім'я Марк"
-        - "Моє ім'я Марк"
-      explanation: Names use Мене звати + name.
-    - sentence: Я бачу теє хлопця
-      error: "❌ «Я бачу теє хлопця»"
-      answer: "✅ «Я бачу того хлопця»"
-      options:
-        - "✅ «Я бачу того хлопця»"
-        - "Я бачу той хлопця"
-        - "Я бачу те хлопця"
-      explanation: Теє is poetic/passive recognition, not the everyday chunk.
-    - sentence: Я розмовляв з його
-      error: "❌ «Я розмовляв з його»"
-      answer: "✅ «Я розмовляв з ним»"
-      options:
-        - "✅ «Я розмовляв з ним»"
-        - "Я розмовляв з він"
-        - "Я розмовляв його"
-      explanation: After з, recognize the safe chunk з ним.
-    - sentence: У тому́
-      error: "❌ «У тому́»"
-      answer: "✅ «У то́му»"
-      options:
-        - "✅ «У то́му»"
-        - "У цей"
-        - "На тому"
-      explanation: This stress point is a later preview, not active A1 production.
-    - sentence: Це цікавий книга
-      error: "❌ «Це цікавий книга»"
-      answer: "✅ «Ця книга цікава»"
-      options:
-        - "✅ «Ця книга цікава»"
-        - "Цей книга цікавий"
-        - "Це цікава книга"
-      explanation: Before a feminine noun, use ця.
+inline:
+  - id: act-1
+    type: quiz
+    title: Це as a whole sentence
+    instruction: Choose the natural Ukrainian sentence.
+    items:
+      - prompt: This is a table.
+        options:
+          - text: Це стіл.
+            correct: true
+          - text: Це є стіл.
+            correct: false
+          - text: Цей є стіл.
+            correct: false
+        explanation: Present-tense Ukrainian normally drops є in this sentence.
+      - prompt: Who is this?
+        options:
+          - text: Хто це?
+            correct: true
+          - text: Хто цей?
+            correct: false
+          - text: Хто той?
+            correct: false
+        explanation: Use the fixed question Хто це?
+      - prompt: What is this?
+        options:
+          - text: Що це?
+            correct: true
+          - text: Що ця?
+            correct: false
+          - text: Що той?
+            correct: false
+        explanation: Що це? is the safe first question.
+      - prompt: This is my backpack.
+        options:
+          - text: Це мій рюкзак.
+            correct: true
+          - text: Цей є мій рюкзак.
+            correct: false
+          - text: Це є мій рюкзак.
+            correct: false
+        explanation: Keep Це мій рюкзак as one chunk.
+  - id: act-2
+    type: match-up
+    title: Noun gender and pointing word
+    instruction: Match the noun with the near pointing phrase.
+    pairs:
+      - left: стіл
+        right: цей стіл
+      - left: книга
+        right: ця книга
+      - left: вікно
+        right: це вікно
+      - left: радіо
+        right: це радіо
+      - left: ручки
+        right: ці ручки
+      - left: телефони
+        right: ці телефони
+  - id: act-3
+    type: fill-in
+    title: Цей, ця, це, ці
+    instruction: Choose the near pointing word.
+    items:
+      - sentence: ___ стіл новий.
+        answer: Цей
+        options:
+          - Цей
+          - Ця
+          - Це
+        explanation: Стіл is masculine, so use цей.
+      - sentence: ___ книга цікава.
+        answer: Ця
+        options:
+          - Ця
+          - Цей
+          - Це
+        explanation: Книга is feminine, so use ця.
+      - sentence: ___ вікно велике.
+        answer: Це
+        options:
+          - Це
+          - Цей
+          - Ця
+        explanation: Вікно is neuter, so use це.
+      - sentence: ___ ручки сині.
+        answer: Ці
+        options:
+          - Ці
+          - Цей
+          - Ця
+        explanation: Ручки is plural, so use ці.
+      - sentence: ___ телефон чорний.
+        answer: Цей
+        options:
+          - Цей
+          - Ця
+          - Ці
+        explanation: Телефон is masculine.
+      - sentence: ___ сумка червона.
+        answer: Ця
+        options:
+          - Ця
+          - Це
+          - Цей
+        explanation: Сумка is feminine.
+  - id: act-4
+    type: match-up
+    title: Near and far
+    instruction: Match each near phrase with the far phrase.
+    pairs:
+      - left: цей стіл
+        right: той стіл
+      - left: ця книга
+        right: та книга
+      - left: це вікно
+        right: те вікно
+      - left: ці ручки
+        right: ті ручки
+      - left: цей телефон
+        right: той телефон
+      - left: ця сумка
+        right: та сумка
+workbook:
+  - type: quiz
+    title: Clear choices with чи
+    instruction: Choose the clear question or answer.
+    items:
+      - prompt: Which table, this one or that one?
+        options:
+          - text: Який стіл — цей чи той?
+            correct: true
+          - text: Яка стіл — ця чи та?
+            correct: false
+          - text: Яке стіл — це чи те?
+            correct: false
+        explanation: Стіл is masculine, so use який, цей, той.
+      - prompt: Which bag, this red one or that blue one?
+        options:
+          - text: Яка сумка — ця червона чи та синя?
+            correct: true
+          - text: Який сумка — цей червоний чи той синій?
+            correct: false
+          - text: Яке сумка — це червоне чи те синє?
+            correct: false
+        explanation: Сумка is feminine, so use яка, ця, та.
+      - prompt: Which window, this big one or that small one?
+        options:
+          - text: Яке вікно — це велике чи те маленьке?
+            correct: true
+          - text: Яка вікно — ця велика чи та маленька?
+            correct: false
+          - text: Який вікно — цей великий чи той маленький?
+            correct: false
+        explanation: Вікно is neuter, so use яке, це, те.
+      - prompt: Make the list clearer.
+        options:
+          - text: У кімнаті є та книга і ручка.
+            correct: true
+          - text: У кімнаті є та книга та ручка.
+            correct: false
+          - text: У кімнаті є ця книга ця ручка.
+            correct: false
+        explanation: Use і for the list when та already means that.
+  - type: fill-in
+    title: Useful chunks
+    instruction: Choose the safe A1 chunk.
+    items:
+      - sentence: Я хочу ___ книгу.
+        answer: цю
+        options:
+          - цю
+          - цей
+          - це
+        explanation: Treat цю книгу as a buying chunk for now.
+      - sentence: Я хочу ___ олівець.
+        answer: цей
+        options:
+          - цей
+          - цю
+          - ці
+        explanation: Олівець is masculine; this A1 chunk stays simple.
+      - sentence: ___ книга цікава.
+        answer: Ця
+        options:
+          - Ця
+          - Це
+          - Цей
+        explanation: Before a feminine noun, use ця.
+      - sentence: ___ мій стіл.
+        answer: Це
+        options:
+          - Це
+          - Цей є
+          - Той є
+        explanation: Це мій стіл is the natural sentence.
+      - sentence: Мене ___ Марк.
+        answer: звати
+        options:
+          - звати
+          - ім'я є
+          - є ім'я
+        explanation: Use Мене звати + name.
+      - sentence: ___ 20 років.
+        answer: Мені
+        options:
+          - Мені
+          - Я маю
+          - Я є
+        explanation: Age uses the Мені ... років chunk.
+  - type: quiz
+    title: Repair the trap
+    instruction: Choose the repaired sentence.
+    # wiki err-1: ❌ «Цей є мій стіл» -> ✅ «Це мій стіл»
+    # wiki err-2: ❌ «Я маю 20 років » -> ✅ «Мені 20 років»
+    # wiki err-3: ❌ «Моє ім'я є Марк » -> ✅ «Мене звати Марк»
+    # wiki err-4: ❌ «Я бачу теє хлопця» -> ✅ «Я бачу того хлопця»
+    # wiki err-5: ❌ «Я розмовляв з його» -> ✅ «Я розмовляв з ним»
+    # wiki err-6: ❌ «У тому́» -> ✅ «У то́му»
+    # wiki err-7: ❌ «Це цікавий книга» -> ✅ «Ця книга цікава»
+    items:
+      - prompt: 'Fix the sentence: Цей є мій стіл.'
+        options:
+          - text: Це мій стіл.
+            correct: true
+          - text: Цей є мій стіл.
+            correct: false
+          - text: Це є мій стіл.
+            correct: false
+        explanation: Use universal це and drop є.
+      - prompt: 'Fix the sentence: Це цікавий книга.'
+        options:
+          - text: Ця книга цікава.
+            correct: true
+          - text: Це цікавий книга.
+            correct: false
+          - text: Цей книга цікавий.
+            correct: false
+        explanation: Книга is feminine, so use ця and feminine цікава.
+      - prompt: 'Fix the sentence: Я маю 20 років.'
+        options:
+          - text: Мені 20 років.
+            correct: true
+          - text: Я маю 20 років.
+            correct: false
+          - text: Я є 20 років.
+            correct: false
+        explanation: Use the age chunk from the numbers module.
+      - prompt: "Fix the sentence: Моє ім'я є Марк."
+        options:
+          - text: Мене звати Марк.
+            correct: true
+          - text: Моє ім'я є Марк.
+            correct: false
+          - text: Я ім'я Марк.
+            correct: false
+        explanation: Use Мене звати + name.
+      - prompt: Choose the everyday A1-safe sentence.
+        options:
+          - text: Я бачу того хлопця.
+            correct: true
+          - text: Я бачу теє хлопця.
+            correct: false
+          - text: Я бачу той хлопця.
+            correct: false
+        explanation: Теє is poetic/passive recognition, not everyday A1 speech.
+      - prompt: Choose the later-grammar preview chunk.
+        options:
+          - text: Я розмовляю з ним.
+            correct: true
+          - text: Я розмовляю з його.
+            correct: false
+          - text: Я розмовляю з він.
+            correct: false
+        explanation: After з, the safe chunk is з ним.
+  - type: error-correction
+    title: Manifest repair rows
+    instruction: Read the learner trap and choose the repaired Ukrainian chunk.
+    items:
+      - sentence: Цей є мій стіл
+        error: '❌ «Цей є мій стіл»'
+        answer: '✅ «Це мій стіл»'
+        options:
+          - '✅ «Це мій стіл»'
+          - 'Це є мій стіл'
+          - 'Цей мій стіл'
+        explanation: Use universal це and drop є.
+      - sentence: Я маю 20 років
+        error: '❌ «Я маю 20 років »'
+        answer: '✅ «Мені 20 років»'
+        options:
+          - '✅ «Мені 20 років»'
+          - 'Я є 20 років'
+          - 'Мій вік 20'
+        explanation: Age uses Мені ... років.
+      - sentence: Моє ім'я є Марк
+        error: "❌ «Моє ім'я є Марк »"
+        answer: '✅ «Мене звати Марк»'
+        options:
+          - '✅ «Мене звати Марк»'
+          - "Я ім'я Марк"
+          - "Моє ім'я Марк"
+        explanation: Names use Мене звати + name.
+      - sentence: Я бачу теє хлопця
+        error: '❌ «Я бачу теє хлопця»'
+        answer: '✅ «Я бачу того хлопця»'
+        options:
+          - '✅ «Я бачу того хлопця»'
+          - 'Я бачу той хлопця'
+          - 'Я бачу те хлопця'
+        explanation: Теє is poetic/passive recognition, not the everyday chunk.
+      - sentence: Я розмовляв з його
+        error: '❌ «Я розмовляв з його»'
+        answer: '✅ «Я розмовляв з ним»'
+        options:
+          - '✅ «Я розмовляв з ним»'
+          - 'Я розмовляв з він'
+          - 'Я розмовляв його'
+        explanation: After з, recognize the safe chunk з ним.
+      - sentence: У тому́
+        error: '❌ «У тому́»'
+        answer: '✅ «У то́му»'
+        options:
+          - '✅ «У то́му»'
+          - 'У цей'
+          - 'На тому'
+        explanation: This stress point is a later preview, not active A1 production.
+      - sentence: Це цікавий книга
+        error: '❌ «Це цікавий книга»'
+        answer: '✅ «Ця книга цікава»'
+        options:
+          - '✅ «Ця книга цікава»'
+          - 'Цей книга цікавий'
+          - 'Це цікава книга'
+        explanation: Before a feminine noun, use ця.

--- a/curriculum/l2-uk-en/a1/this-and-that/module.md
+++ b/curriculum/l2-uk-en/a1/this-and-that/module.md
@@ -165,8 +165,6 @@ Use **ті** for plural things farther away: **ті ручки**, **ті тел�
 "these," and **ті** means "those." Keep the question small:
 **Які ручки — ці чи ті?**
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Підсумок
 
 Most of this module stays in the nominative:
@@ -196,8 +194,6 @@ You may also see old or emphatic forms:
 Use **цей / ця / це / той / та / те** actively. Treat the other forms as
 recognition items for reading, songs, or later lessons.
 
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ### Repair traps
 
 Keep these repairs close:
@@ -217,10 +213,6 @@ habit now. **Мене звати** comes from your introduction module, and
 After prepositions, Ukrainian pronouns often change in a way English does not:
 **з ним**, **у нього**, **у неї**. That is later material. For today, simply
 recognize **Я розмовляю з ним** as the safe chunk, not **з його**.
-
-<!-- INJECT_ACTIVITY: act-8 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Mini world check
 

--- a/curriculum/l2-uk-en/a1/what-is-it-like/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-is-it-like/activities.yaml
@@ -1,480 +1,476 @@
-- id: act-1
-  type: quiz
-  title: Which question word?
-  instruction: Choose the question word that fits the noun.
-  items:
-    - prompt: стіл
-      options:
-        - text: Який?
-          correct: true
-        - text: Яка?
-          correct: false
-        - text: Яке?
-          correct: false
-      explanation: Стіл is masculine, so ask Який?
-    - prompt: книга
-      options:
-        - text: Яка?
-          correct: true
-        - text: Який?
-          correct: false
-        - text: Яке?
-          correct: false
-      explanation: Книга is feminine, so ask Яка?
-    - prompt: фото
-      options:
-        - text: Яке?
-          correct: true
-        - text: Яка?
-          correct: false
-        - text: Який?
-          correct: false
-      explanation: Фото is neuter in this lesson, so ask Яке?
-    - prompt: кімната
-      options:
-        - text: Яка?
-          correct: true
-        - text: Який?
-          correct: false
-        - text: Які?
-          correct: false
-      explanation: Кімната is feminine.
-    - prompt: книги
-      options:
-        - text: Які?
-          correct: true
-        - text: Яке?
-          correct: false
-        - text: Який?
-          correct: false
-      explanation: Книги is plural, so ask Які?
-    - prompt: вікно
-      options:
-        - text: Яке?
-          correct: true
-        - text: Який?
-          correct: false
-        - text: Яка?
-          correct: false
-      explanation: Вікно is neuter.
-- id: act-2
-  type: fill-in
-  title: Finish the adjective
-  instruction: Choose the adjective ending that matches the noun.
-  items:
-    - sentence: велик__ стіл
-      answer: ий
-      options:
-        - ий
-        - а
-        - е
-      explanation: Стіл is masculine, so use великий.
-    - sentence: нов__ книга
-      answer: а
-      options:
-        - а
-        - ий
-        - е
-      explanation: Книга is feminine, so use нова.
-    - sentence: чист__ вікно
-      answer: е
-      options:
-        - е
-        - ий
-        - а
-      explanation: Вікно is neuter, so use чисте.
-    - sentence: стар__ фото
-      answer: е
-      options:
-        - е
-        - а
-        - ий
-      explanation: Фото is neuter in this lesson.
-    - sentence: дорог__ телефон
-      answer: ий
-      options:
-        - ий
-        - а
-        - е
-      explanation: Телефон is masculine.
-    - sentence: дешев__ листівка
-      answer: а
-      options:
-        - а
-        - е
-        - ий
-      explanation: Листівка is feminine.
-    - sentence: гарн__ кімната
-      answer: а
-      options:
-        - а
-        - ий
-        - е
-      explanation: Кімната is feminine.
-    - sentence: брудн__ дзеркало
-      answer: е
-      options:
-        - е
-        - а
-        - ий
-      explanation: Дзеркало is neuter.
-    - sentence: світл__ плакат
-      answer: ий
-      options:
-        - ий
-        - е
-        - а
-      explanation: Плакат is masculine.
-    - sentence: нов__ книги
-      answer: і
-      options:
-        - і
-        - а
-        - е
-      explanation: Plural A1 chunks use нові.
-- id: act-3
-  type: group-sort
-  title: Sort the chunks
-  instruction: Sort each adjective-noun chunk by the question it answers.
-  groups:
-    - label: Який?
-      items:
-        - великий стіл
-        - новий телефон
-        - старий атлас
-        - дорогий плакат
-    - label: Яка?
-      items:
-        - нова книга
-        - гарна листівка
-        - чиста кімната
-        - дешева ручка
-    - label: Яке?
-      items:
-        - старе фото
-        - чисте вікно
-        - велике ліжко
-        - брудне дзеркало
-    - label: Які?
-      items:
-        - нові книги
-        - гарні речі
-        - старі фото
-        - дешеві листівки
-- id: act-4
-  type: match-up
-  title: Match opposites
-  instruction: Match each adjective with its opposite.
-  pairs:
-    - left: великий
-      right: маленький
-    - left: новий
-      right: старий
-    - left: гарний
-      right: поганий
-    - left: чистий
-      right: брудний
-    - left: дорогий
-      right: дешевий
-    - left: світлий
-      right: темний
-- id: act-5
-  type: quiz
-  title: Sentence frame
-  instruction: Choose the natural A1 sentence.
-  items:
-    - prompt: The book is new.
-      options:
-        - text: Книга нова.
-          correct: true
-        - text: Книга є нова.
-          correct: false
-        - text: Книга новий.
-          correct: false
-      explanation: Ukrainian usually leaves out є in this present-tense frame.
-    - prompt: The table is clean.
-      options:
-        - text: Стіл чистий.
-          correct: true
-        - text: Стіл чиста.
-          correct: false
-        - text: Стіл є чистий.
-          correct: false
-      explanation: Стіл is masculine, and the no-є frame is natural.
-    - prompt: The window is big.
-      options:
-        - text: Вікно велике.
-          correct: true
-        - text: Вікно великий.
-          correct: false
-        - text: Вікно велика.
-          correct: false
-      explanation: Вікно is neuter.
-    - prompt: A nice postcard
-      options:
-        - text: гарна листівка
-          correct: true
-        - text: гарний листівка
-          correct: false
-        - text: гарне листівка
-          correct: false
-      explanation: Листівка is feminine.
-    - prompt: A useful atlas
-      options:
-        - text: корисний атлас
-          correct: true
-        - text: корисна атлас
-          correct: false
-        - text: корисне атлас
-          correct: false
-      explanation: Атлас is masculine.
-    - prompt: Interesting things
-      options:
-        - text: цікаві речі
-          correct: true
-        - text: цікава речі
-          correct: false
-        - text: цікаве речі
-          correct: false
-      explanation: Plural chunks use цікаві.
-- id: act-6
-  type: fill-in
-  title: Describe the room
-  instruction: Complete the short room lines.
-  items:
-    - sentence: Моя кімната ___ і світла.
-      answer: маленька
-      options:
-        - маленька
-        - маленький
-        - маленьке
-      explanation: Кімната is feminine.
-    - sentence: Стіл ___ і чистий.
-      answer: новий
-      options:
-        - новий
-        - нова
-        - нове
-      explanation: Стіл is masculine.
-    - sentence: Ліжко старе, ___ зручне.
-      answer: але
-      options:
-        - але
-        - який
-        - яка
-      explanation: Але adds a contrast.
-    - sentence: Вікно ___ і чисте.
-      answer: велике
-      options:
-        - велике
-        - великий
-        - велика
-      explanation: Вікно is neuter.
-    - sentence: Книга дорога, ___ листівка дешева.
-      answer: а
-      options:
-        - а
-        - і
-        - яке
-      explanation: А contrasts two things.
-    - sentence: У мене є ___ стіл і стара лампа.
-      answer: новий
-      options:
-        - новий
-        - нова
-        - нове
-      explanation: Стіл is masculine.
-- id: act-7
-  type: error-correction
-  title: Repair adjective agreement
-  instruction: Fix the adjective or sentence frame.
-  items:
-    - sentence: Він є добрий студент.
-      error: Він є добрий студент.
-      answer: Він добрий студент.
-      options:
-        - Він добрий студент.
-        - Він добра студент.
-        - Він є добра студент.
-      explanation: In this present-tense frame, Ukrainian normally omits є.
-    - sentence: Це гарна хлопець.
-      error: Це гарна хлопець.
-      answer: Це гарний хлопець.
-      options:
-        - Це гарний хлопець.
-        - Це гарне хлопець.
-        - Це гарна хлопець.
-      explanation: Хлопець is masculine.
-    - sentence: Який твоє ім'я?
-      error: Який твоє ім'я?
-      answer: "Яке твоє ім'я? (або: Як тебе звати?)"
-      options:
-        - "Яке твоє ім'я? (або: Як тебе звати?)"
-        - Яка твоє ім'я?
-        - Який твоє ім'я?
-      explanation: Ім'я is neuter; in real introductions, use Як тебе звати?
-    - sentence: Вона читає цікавий книжку.
-      error: Вона читає цікавий книжку.
-      answer: Вона читає цікаву книжку.
-      options:
-        - Вона читає цікаву книжку.
-        - Вона читає цікавий книжку.
-        - Вона читає цікаве книжку.
-      explanation: This is an object form; notice that adjective and noun move together.
-    - sentence: Моя мамалига смачний.
-      error: Моя мамалига смачний.
-      answer: Моя мамалига смачна.
-      options:
-        - Моя мамалига смачна.
-        - Моя мамалига смачний.
-        - Моя мамалига смачне.
-      explanation: Мамалига is feminine, so use смачна.
-    - sentence: Це мій синій ручка.
-      error: Це мій синій ручка.
-      answer: Це моя синя ручка.
-      options:
-        - Це моя синя ручка.
-        - Це мій синій ручка.
-        - Це моє синє ручка.
-      explanation: Ручка is feminine, and синій is a soft-stem adjective.
-- id: act-8
-  type: fill-in
-  title: Adjective trap repair
-  instruction: Choose the standard Ukrainian adjective.
-  items:
-    - sentence: Цей суп дуже ___.
-      answer: смачний
-      options:
-        - смачний
-        - вкусний
-      explanation: Use смачний for tasty.
-    - sentence: У мене є ___ олівець.
-      answer: жовтий
-      options:
-        - жовтий
-        - жолтий
-      explanation: Use жовтий.
-    - sentence: У сусідки ___ кіт.
-      answer: чорний
-      options:
-        - чорний
-        - черний
-      explanation: Use чорний.
-    - sentence: Прапор ___, а не білий.
-      answer: червоний
-      options:
-        - червоний
-        - красний
-      explanation: Use червоний for red in ordinary modern Ukrainian.
-    - sentence: Це ___ фільм.
-      answer: поганий
-      options:
-        - поганий
-        - плохий
-      explanation: Use поганий.
-    - sentence: Це ___ відповідь на запитання.
-      answer: правильна
-      options:
-        - правильна
-        - вірна
-      explanation: Use правильна відповідь for a correct answer.
-    - sentence: Дай мені, будь ласка, ___ олівець.
-      answer: будь-який
-      options:
-        - будь-який
-        - любий
-      explanation: Use the standard Ukrainian form for any.
-    - sentence: Сергій — ___ хлопчик.
-      answer: розумний
-      options:
-        - розумний
-        - умний
-      explanation: Use розумний.
-    - sentence: Тарас — ___ учень.
-      answer: лінивий
-      options:
-        - лінивий
-        - ленивий
-      explanation: Use лінивий.
-- id: act-9
-  type: translate
-  title: Choose the Ukrainian line
-  instruction: Choose the Ukrainian sentence that matches the English cue.
-  items:
-    - source: My room is small but nice.
-      options:
-        - text: Моя кімната маленька, але гарна.
-          correct: true
-        - text: Мій кімната маленький, але гарний.
-          correct: false
-        - text: Моє кімната маленьке, але гарне.
-          correct: false
-      explanation: Кімната is feminine.
-    - source: The table is new and clean.
-      options:
-        - text: Стіл новий і чистий.
-          correct: true
-        - text: Стіл нова і чиста.
-          correct: false
-        - text: Стіл нове і чисте.
-          correct: false
-      explanation: Стіл is masculine.
-    - source: The photo is old.
-      options:
-        - text: Фото старе.
-          correct: true
-        - text: Фото стара.
-          correct: false
-        - text: Фото старий.
-          correct: false
-      explanation: Фото is neuter in this lesson.
-    - source: A cheap postcard
-      options:
-        - text: дешева листівка
-          correct: true
-        - text: дешевий листівка
-          correct: false
-        - text: дешеве листівка
-          correct: false
-      explanation: Листівка is feminine.
-    - source: Good afternoon.
-      options:
-        - text: Добрий день.
-          correct: true
-        - text: Добра день.
-          correct: false
-        - text: Добре день.
-          correct: false
-      explanation: День is masculine, so the greeting is Добрий день.
-    - source: The books are interesting.
-      options:
-        - text: Книги цікаві.
-          correct: true
-        - text: Книги цікава.
-          correct: false
-        - text: Книги цікаве.
-          correct: false
-      explanation: Plural chunks use цікаві.
-- id: act-10
-  type: true-false
-  title: Quick checkpoint
-  instruction: Decide if the statement is right.
-  items:
-    - statement: Стіл новий.
-      answer: true
-      explanation: Стіл is masculine, so новий is correct.
-    - statement: Книга нове.
-      answer: false
-      explanation: Книга is feminine; say Книга нова.
-    - statement: Вікно чисте.
-      answer: true
-      explanation: Вікно is neuter.
-    - statement: Який кімната?
-      answer: false
-      explanation: Кімната is feminine; ask Яка кімната?
-    - statement: Кімната маленька, але гарна.
-      answer: true
-      explanation: Both adjectives agree with кімната.
-    - statement: "В українській можна описати річ без є: Книга цікава."
-      answer: true
-      explanation: This no-є present-tense frame is normal.
+inline:
+  - id: act-1
+    type: quiz
+    title: Which question word?
+    instruction: Choose the question word that fits the noun.
+    items:
+      - prompt: стіл
+        options:
+          - text: Який?
+            correct: true
+          - text: Яка?
+            correct: false
+          - text: Яке?
+            correct: false
+        explanation: Стіл is masculine, so ask Який?
+      - prompt: книга
+        options:
+          - text: Яка?
+            correct: true
+          - text: Який?
+            correct: false
+          - text: Яке?
+            correct: false
+        explanation: Книга is feminine, so ask Яка?
+      - prompt: фото
+        options:
+          - text: Яке?
+            correct: true
+          - text: Яка?
+            correct: false
+          - text: Який?
+            correct: false
+        explanation: Фото is neuter in this lesson, so ask Яке?
+      - prompt: кімната
+        options:
+          - text: Яка?
+            correct: true
+          - text: Який?
+            correct: false
+          - text: Які?
+            correct: false
+        explanation: Кімната is feminine.
+      - prompt: книги
+        options:
+          - text: Які?
+            correct: true
+          - text: Яке?
+            correct: false
+          - text: Який?
+            correct: false
+        explanation: Книги is plural, so ask Які?
+      - prompt: вікно
+        options:
+          - text: Яке?
+            correct: true
+          - text: Який?
+            correct: false
+          - text: Яка?
+            correct: false
+        explanation: Вікно is neuter.
+  - id: act-2
+    type: fill-in
+    title: Finish the adjective
+    instruction: Choose the adjective ending that matches the noun.
+    items:
+      - sentence: велик__ стіл
+        answer: ий
+        options:
+          - ий
+          - а
+          - е
+        explanation: Стіл is masculine, so use великий.
+      - sentence: нов__ книга
+        answer: а
+        options:
+          - а
+          - ий
+          - е
+        explanation: Книга is feminine, so use нова.
+      - sentence: чист__ вікно
+        answer: е
+        options:
+          - е
+          - ий
+          - а
+        explanation: Вікно is neuter, so use чисте.
+      - sentence: стар__ фото
+        answer: е
+        options:
+          - е
+          - а
+          - ий
+        explanation: Фото is neuter in this lesson.
+      - sentence: дорог__ телефон
+        answer: ий
+        options:
+          - ий
+          - а
+          - е
+        explanation: Телефон is masculine.
+      - sentence: дешев__ листівка
+        answer: а
+        options:
+          - а
+          - е
+          - ий
+        explanation: Листівка is feminine.
+      - sentence: гарн__ кімната
+        answer: а
+        options:
+          - а
+          - ий
+          - е
+        explanation: Кімната is feminine.
+      - sentence: брудн__ дзеркало
+        answer: е
+        options:
+          - е
+          - а
+          - ий
+        explanation: Дзеркало is neuter.
+      - sentence: світл__ плакат
+        answer: ий
+        options:
+          - ий
+          - е
+          - а
+        explanation: Плакат is masculine.
+      - sentence: нов__ книги
+        answer: і
+        options:
+          - і
+          - а
+          - е
+        explanation: Plural A1 chunks use нові.
+  - id: act-3
+    type: group-sort
+    title: Sort the chunks
+    instruction: Sort each adjective-noun chunk by the question it answers.
+    groups:
+      - label: Який?
+        items:
+          - великий стіл
+          - новий телефон
+          - старий атлас
+          - дорогий плакат
+      - label: Яка?
+        items:
+          - нова книга
+          - гарна листівка
+          - чиста кімната
+          - дешева ручка
+      - label: Яке?
+        items:
+          - старе фото
+          - чисте вікно
+          - велике ліжко
+          - брудне дзеркало
+      - label: Які?
+        items:
+          - нові книги
+          - гарні речі
+          - старі фото
+          - дешеві листівки
+  - id: act-4
+    type: match-up
+    title: Match opposites
+    instruction: Match each adjective with its opposite.
+    pairs:
+      - left: великий
+        right: маленький
+      - left: новий
+        right: старий
+      - left: гарний
+        right: поганий
+      - left: чистий
+        right: брудний
+      - left: дорогий
+        right: дешевий
+      - left: світлий
+        right: темний
+workbook:
+  - type: quiz
+    title: Sentence frame
+    instruction: Choose the natural A1 sentence.
+    items:
+      - prompt: The book is new.
+        options:
+          - text: Книга нова.
+            correct: true
+          - text: Книга є нова.
+            correct: false
+          - text: Книга новий.
+            correct: false
+        explanation: Ukrainian usually leaves out є in this present-tense frame.
+      - prompt: The table is clean.
+        options:
+          - text: Стіл чистий.
+            correct: true
+          - text: Стіл чиста.
+            correct: false
+          - text: Стіл є чистий.
+            correct: false
+        explanation: Стіл is masculine, and the no-є frame is natural.
+      - prompt: The window is big.
+        options:
+          - text: Вікно велике.
+            correct: true
+          - text: Вікно великий.
+            correct: false
+          - text: Вікно велика.
+            correct: false
+        explanation: Вікно is neuter.
+      - prompt: A nice postcard
+        options:
+          - text: гарна листівка
+            correct: true
+          - text: гарний листівка
+            correct: false
+          - text: гарне листівка
+            correct: false
+        explanation: Листівка is feminine.
+      - prompt: A useful atlas
+        options:
+          - text: корисний атлас
+            correct: true
+          - text: корисна атлас
+            correct: false
+          - text: корисне атлас
+            correct: false
+        explanation: Атлас is masculine.
+      - prompt: Interesting things
+        options:
+          - text: цікаві речі
+            correct: true
+          - text: цікава речі
+            correct: false
+          - text: цікаве речі
+            correct: false
+        explanation: Plural chunks use цікаві.
+  - type: fill-in
+    title: Describe the room
+    instruction: Complete the short room lines.
+    items:
+      - sentence: Моя кімната ___ і світла.
+        answer: маленька
+        options:
+          - маленька
+          - маленький
+          - маленьке
+        explanation: Кімната is feminine.
+      - sentence: Стіл ___ і чистий.
+        answer: новий
+        options:
+          - новий
+          - нова
+          - нове
+        explanation: Стіл is masculine.
+      - sentence: Ліжко старе, ___ зручне.
+        answer: але
+        options:
+          - але
+          - який
+          - яка
+        explanation: Але adds a contrast.
+      - sentence: Вікно ___ і чисте.
+        answer: велике
+        options:
+          - велике
+          - великий
+          - велика
+        explanation: Вікно is neuter.
+      - sentence: Книга дорога, ___ листівка дешева.
+        answer: а
+        options:
+          - а
+          - і
+          - яке
+        explanation: А contrasts two things.
+      - sentence: У мене є ___ стіл і стара лампа.
+        answer: новий
+        options:
+          - новий
+          - нова
+          - нове
+        explanation: Стіл is masculine.
+  - type: error-correction
+    title: Repair adjective agreement
+    instruction: Fix the adjective or sentence frame.
+    items:
+      - sentence: Він є добрий студент.
+        error: Він є добрий студент.
+        answer: Він добрий студент.
+        options:
+          - Він добрий студент.
+          - Він добра студент.
+          - Він є добра студент.
+        explanation: In this present-tense frame, Ukrainian normally omits є.
+      - sentence: Це гарна хлопець.
+        error: Це гарна хлопець.
+        answer: Це гарний хлопець.
+        options:
+          - Це гарний хлопець.
+          - Це гарне хлопець.
+          - Це гарна хлопець.
+        explanation: Хлопець is masculine.
+      - sentence: Який твоє ім'я?
+        error: Який твоє ім'я?
+        answer: "Яке твоє ім'я? (або: Як тебе звати?)"
+        options:
+          - "Яке твоє ім'я? (або: Як тебе звати?)"
+          - Яка твоє ім'я?
+          - Який твоє ім'я?
+        explanation: Ім'я is neuter; in real introductions, use Як тебе звати?
+      - sentence: Вона читає цікавий книжку.
+        error: Вона читає цікавий книжку.
+        answer: Вона читає цікаву книжку.
+        options:
+          - Вона читає цікаву книжку.
+          - Вона читає цікавий книжку.
+          - Вона читає цікаве книжку.
+        explanation: This is an object form; notice that adjective and noun move together.
+      - sentence: Моя мамалига смачний.
+        error: Моя мамалига смачний.
+        answer: Моя мамалига смачна.
+        options:
+          - Моя мамалига смачна.
+          - Моя мамалига смачний.
+          - Моя мамалига смачне.
+        explanation: Мамалига is feminine, so use смачна.
+      - sentence: Це мій синій ручка.
+        error: Це мій синій ручка.
+        answer: Це моя синя ручка.
+        options:
+          - Це моя синя ручка.
+          - Це мій синій ручка.
+          - Це моє синє ручка.
+        explanation: Ручка is feminine, and синій is a soft-stem adjective.
+  - type: fill-in
+    title: Adjective trap repair
+    instruction: Choose the standard Ukrainian adjective.
+    items:
+      - sentence: Цей суп дуже ___.
+        answer: смачний
+        options:
+          - смачний
+          - вкусний
+        explanation: Use смачний for tasty.
+      - sentence: У мене є ___ олівець.
+        answer: жовтий
+        options:
+          - жовтий
+          - жолтий
+        explanation: Use жовтий.
+      - sentence: У сусідки ___ кіт.
+        answer: чорний
+        options:
+          - чорний
+          - черний
+        explanation: Use чорний.
+      - sentence: Прапор ___, а не білий.
+        answer: червоний
+        options:
+          - червоний
+          - красний
+        explanation: Use червоний for red in ordinary modern Ukrainian.
+      - sentence: Це ___ фільм.
+        answer: поганий
+        options:
+          - поганий
+          - плохий
+        explanation: Use поганий.
+      - sentence: Це ___ відповідь на запитання.
+        answer: правильна
+        options:
+          - правильна
+          - вірна
+        explanation: Use правильна відповідь for a correct answer.
+      - sentence: Дай мені, будь ласка, ___ олівець.
+        answer: будь-який
+        options:
+          - будь-який
+          - любий
+        explanation: Use the standard Ukrainian form for any.
+      - sentence: Сергій — ___ хлопчик.
+        answer: розумний
+        options:
+          - розумний
+          - умний
+        explanation: Use розумний.
+      - sentence: Тарас — ___ учень.
+        answer: лінивий
+        options:
+          - лінивий
+          - ленивий
+        explanation: Use лінивий.
+  - type: translate
+    title: Choose the Ukrainian line
+    instruction: Choose the Ukrainian sentence that matches the English cue.
+    items:
+      - source: My room is small but nice.
+        options:
+          - text: Моя кімната маленька, але гарна.
+            correct: true
+          - text: Мій кімната маленький, але гарний.
+            correct: false
+          - text: Моє кімната маленьке, але гарне.
+            correct: false
+        explanation: Кімната is feminine.
+      - source: The table is new and clean.
+        options:
+          - text: Стіл новий і чистий.
+            correct: true
+          - text: Стіл нова і чиста.
+            correct: false
+          - text: Стіл нове і чисте.
+            correct: false
+        explanation: Стіл is masculine.
+      - source: The photo is old.
+        options:
+          - text: Фото старе.
+            correct: true
+          - text: Фото стара.
+            correct: false
+          - text: Фото старий.
+            correct: false
+        explanation: Фото is neuter in this lesson.
+      - source: A cheap postcard
+        options:
+          - text: дешева листівка
+            correct: true
+          - text: дешевий листівка
+            correct: false
+          - text: дешеве листівка
+            correct: false
+        explanation: Листівка is feminine.
+      - source: Good afternoon.
+        options:
+          - text: Добрий день.
+            correct: true
+          - text: Добра день.
+            correct: false
+          - text: Добре день.
+            correct: false
+        explanation: День is masculine, so the greeting is Добрий день.
+      - source: The books are interesting.
+        options:
+          - text: Книги цікаві.
+            correct: true
+          - text: Книги цікава.
+            correct: false
+          - text: Книги цікаве.
+            correct: false
+        explanation: Plural chunks use цікаві.
+  - type: true-false
+    title: Quick checkpoint
+    instruction: Decide if the statement is right.
+    items:
+      - statement: Стіл новий.
+        answer: true
+        explanation: Стіл is masculine, so новий is correct.
+      - statement: Книга нове.
+        answer: false
+        explanation: Книга is feminine; say Книга нова.
+      - statement: Вікно чисте.
+        answer: true
+        explanation: Вікно is neuter.
+      - statement: Який кімната?
+        answer: false
+        explanation: Кімната is feminine; ask Яка кімната?
+      - statement: Кімната маленька, але гарна.
+        answer: true
+        explanation: Both adjectives agree with кімната.
+      - statement: 'В українській можна описати річ без є: Книга цікава.'
+        answer: true
+        explanation: This no-є present-tense frame is normal.

--- a/curriculum/l2-uk-en/a1/what-is-it-like/module.md
+++ b/curriculum/l2-uk-en/a1/what-is-it-like/module.md
@@ -179,8 +179,6 @@ Cover the English and answer aloud:
 - **Який стіл?** — **Новий і чистий.**
 - **Яке ліжко?** — **Старе, але зручне.**
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ### Watch the traps
 
 Adjectives are a common interference zone. Keep Ukrainian on its own terms.
@@ -202,8 +200,6 @@ words. Use the clean Ukrainian pair.
 One more sentence-frame trap: present-tense Ukrainian often has no visible
 "to be." Use **Він добрий студент**, not **Він є добрий студент**. Use
 **Книга нова**, not an English-shaped sentence.
-
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ## Підсумок
 
@@ -242,11 +238,3 @@ chunks.
 Workbook practice will make the pattern automatic: choose the right question
 word, finish the adjective ending, match opposites, describe a room, and repair
 the adjective traps.
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->
-
-<!-- INJECT_ACTIVITY: act-9 -->
-
-<!-- INJECT_ACTIVITY: act-10 -->


### PR DESCRIPTION
## Summary

Splits the next A1 #2795 slice from flat V1 activity lists into V2 `inline:` and `workbook:` lists for modules M9-M14.

Per-module counts:

| Module | Inline | Workbook | Total preserved |
| --- | ---: | ---: | ---: |
| what-is-it-like | 4 | 6 | 10 |
| colors | 4 | 6 | 10 |
| how-many | 4 | 6 | 10 |
| this-and-that | 4 | 4 | 8 |
| many-things | 4 | 4 | 8 |
| checkpoint-my-world | 4 | 4 | 8 |

Tradeoff: the three 8-activity modules remain at 4 workbook activities because this slice preserves existing total counts and does not add duplicate activities just to reach the workbook target range.

## Validation

- Parser/count check against `origin/main`: verified V2 shape, original vs branch total counts, marker/id parity, and idless workbook entries for all six modules.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 N --validate` for N = 9, 10, 11, 12, 13, 14.
- Restored generated `starlight/src/content/docs/a1/*.mdx` outputs after MDX validation; no generated files are committed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py` passed: 118 tests.
- `npx prettier --check` passed on the six changed `activities.yaml` files.
- `git diff --check` passed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.

Refs #2795