### PR TITLE
[codex] fix(a1): split M15-M21 activities

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
@@ -1,282 +1,280 @@
-- id: act-1
-  type: match-up
-  title: Reading line to skill
-  instruction: Match each checkpoint line with the skill it proves.
-  pairs:
-    - left: Я прокидаюся о сьомій.
-      right: reflexive routine
-    - left: Я люблю читати.
-      right: like + infinitive
-    - left: Вона працює в школі.
-      right: Group One -ува-
-    - left: Ти пишеш гарно.
-      right: писати change
-    - left: Вони роблять швидко.
-      right: Group Two plural
-    - left: Я можу готувати.
-      right: modal + infinitive
-    - left: Коли ти можеш?
-      right: question word
-    - left: Ніхто не читає.
-      right: negative
-- id: act-2
-  type: true-false
-  title: Action diagnostics
-  instruction: Decide whether each line uses the checkpoint pattern safely.
-  items:
-    - statement: Я працюю кожного дня.
-      correct: true
-      explanation: Працюю is the я form of працювати.
-    - statement: Вона працює в школі.
-      correct: true
-      explanation: Працювати changes to працює with вона.
-    - statement: Ви пишите дуже гарно.
-      correct: false
-      explanation: Use Ви пишете дуже гарно.
-    - statement: Вони роботь швидко.
-      correct: false
-      explanation: Use Вони роблять швидко.
-    - statement: Він хоче кави.
-      correct: true
-      explanation: Хоче is the safe він form.
-    - statement: Я є читаю книгу.
-      correct: false
-      explanation: Use Я читаю книгу.
-    - statement: Я прокидаюся о сьомій.
-      correct: true
-      explanation: Прокидаюся is a safe -ся routine form.
-    - statement: Ніхто не читає.
-      correct: true
-      explanation: Keep не before the verb.
-- id: act-3
-  type: group-sort
-  title: Skill stations
-  instruction: Sort each chunk by the skill it checks.
-  groups:
-    - name: Group One
-      items:
-        - я читаю
-        - ти пишеш
-        - вони працюють
-        - ми малюємо
-    - name: Group Two
-      items:
-        - я говорю
-        - ти говориш
-        - вони роблять
-        - ви бачите
-    - name: Modal + infinitive
-      items:
-        - хочу читати
-        - можу готувати
-        - мушу працювати
-        - може допомагати
-    - name: Question words
-      items:
-        - де ти працюєш?
-        - коли ти можеш?
-        - що ти читаєш?
-        - як ми говоримо?
-- id: act-4
-  type: fill-in
-  title: Roommate dialogue gaps
-  instruction: Complete the dialogue with the checkpoint form.
-  items:
-    - sentence: "Олег: Коли ти ___?"
-      answer: прокидаєшся
-      options:
-        - прокидаєшся
-        - працюєш
-        - пишеш
-      explanation: The question asks about the morning routine.
-    - sentence: "Марина: Я ___ о сьомій."
-      answer: прокидаюся
-      options:
-        - прокидаюся
-        - читаю
-        - роблю
-      explanation: With я, use прокидаюся.
-    - sentence: "Олег: Де ти ___?"
-      answer: працюєш
-      options:
-        - працюєш
-        - можеш
-        - хочеш
-      explanation: Де asks for the work place.
-    - sentence: "Марина: Я ___ в школі."
-      answer: працюю
-      options:
-        - працюю
-        - працює
-        - працюємо
-      explanation: With я, use працюю.
-    - sentence: "Олег: Ти ___ читати ввечері?"
-      answer: любиш
-      options:
-        - любиш
-        - читаєш
-        - робиш
-      explanation: Любиш + infinitive asks about liking an action.
-    - sentence: "Марина: Не можу зараз, ___ працювати."
-      answer: мушу
-      options:
-        - мушу
-        - читаю
-        - говорю
-      explanation: Мушу + infinitive means I have to.
-- id: act-5
-  type: odd-one-out
-  title: Find the form that does not fit
-  instruction: Choose the chunk that belongs to a different checkpoint skill.
-  items:
-    - words:
-        - я читаю
-        - ти читаєш
-        - вони читають
-        - ти говориш
-      answer: ти говориш
-      explanation: Ти говориш is Group Two; the others are Group One читати.
-    - words:
-        - хочу читати
-        - можу готувати
-        - мушу працювати
-        - я читаю
-      answer: я читаю
-      explanation: Я читаю is a person form, not modal + infinitive.
-    - words:
-        - хто
-        - коли
-        - куди
-        - працюю
-      answer: працюю
-      explanation: Працюю is a verb form; the others are question words.
-    - words:
-        - я прокидаюся
-        - ти вмиваєшся
-        - вона одягається
-        - я снідаю
-      answer: я снідаю
-      explanation: Снідаю is not a -ся verb.
-- id: act-6
-  type: unjumble
-  title: Rebuild checkpoint lines
-  instruction: Put the words in a safe A1.3 order.
-  items:
-    - words:
-        - Я
-        - люблю
-        - читати
-      answer: Я люблю читати
-    - words:
-        - Вона
-        - працює
-        - в школі
-      answer: Вона працює в школі
-    - words:
-        - Ми
-        - говоримо
-        - українською
-      answer: Ми говоримо українською
-    - words:
-        - Коли
-        - ти
-        - можеш
-      answer: Коли ти можеш
-    - words:
-        - Я
-        - мушу
-        - працювати
-      answer: Я мушу працювати
-    - words:
-        - Вони
-        - роблять
-        - швидко
-      answer: Вони роблять швидко
-- id: act-7
-  type: quiz
-  title: Choose the answer job
-  instruction: Choose the line that answers the question.
-  items:
-    - prompt: "Коли ти прокидаєшся?"
-      options:
-        - text: О сьомій.
-          correct: true
-        - text: У школі.
-          correct: false
-        - text: Українською.
-          correct: false
-      explanation: Коли asks about time.
-    - prompt: "Де ти працюєш?"
-      options:
-        - text: В офісі.
-          correct: true
-        - text: О восьмій.
-          correct: false
-        - text: Тому що мушу.
-          correct: false
-      explanation: Де asks about place.
-    - prompt: "Що ти любиш?"
-      options:
-        - text: Читати.
-          correct: true
-        - text: Удома.
-          correct: false
-        - text: Завтра.
-          correct: false
-      explanation: Що asks for the action or thing.
-    - prompt: "Як ми говоримо?"
-      options:
-        - text: Українською.
-          correct: true
-        - text: Увечері.
-          correct: false
-        - text: У школі.
-          correct: false
-      explanation: Як asks how.
-- id: act-8
-  type: fill-in
-  title: Repair by building the safe line
-  instruction: Build the corrected line from the checkpoint prompt.
-  items:
-    - sentence: "I work every day: Я ___ кожного дня."
-      answer: працюю
-      options:
-        - працюю
-        - читаю
-        - пишу
-      explanation: Repair for Я працювати кожного дня.
-    - sentence: "She works at school: Вона ___ в школі."
-      answer: працює
-      options:
-        - працює
-        - читає
-        - готує
-      explanation: "Repair for <!-- bad -->Вона працюває в школі<!-- /bad -->."
-    - sentence: "I read a book: Я ___ книгу."
-      answer: читаю
-      options:
-        - читаю
-        - пишу
-        - бачу
-      explanation: Repair for Я є читаю книгу.
-    - sentence: "You write very nicely: Ви ___ дуже гарно."
-      answer: пишете
-      options:
-        - пишете
-        - читаєте
-        - говорите
-      explanation: "Repair for <!-- bad -->Ви пишите дуже гарно<!-- /bad -->."
-    - sentence: "They work fast: Вони ___ швидко."
-      answer: роблять
-      options:
-        - роблять
-        - говорять
-        - читають
-      explanation: "Repair for <!-- bad -->Вони роботь швидко<!-- /bad -->."
-    - sentence: "He wants coffee: Він ___ кави."
-      answer: хоче
-      options:
-        - хоче
-        - любить
-        - п'є
-      explanation: "Repair for <!-- bad -->Він хотіє кави<!-- /bad -->."
+inline:
+  - id: act-1
+    type: match-up
+    title: Reading line to skill
+    instruction: Match each checkpoint line with the skill it proves.
+    pairs:
+      - left: Я прокидаюся о сьомій.
+        right: reflexive routine
+      - left: Я люблю читати.
+        right: like + infinitive
+      - left: Вона працює в школі.
+        right: Group One -ува-
+      - left: Ти пишеш гарно.
+        right: писати change
+      - left: Вони роблять швидко.
+        right: Group Two plural
+      - left: Я можу готувати.
+        right: modal + infinitive
+      - left: Коли ти можеш?
+        right: question word
+      - left: Ніхто не читає.
+        right: negative
+  - id: act-2
+    type: true-false
+    title: Action diagnostics
+    instruction: Decide whether each line uses the checkpoint pattern safely.
+    items:
+      - statement: Я працюю кожного дня.
+        correct: true
+        explanation: Працюю is the я form of працювати.
+      - statement: Вона працює в школі.
+        correct: true
+        explanation: Працювати changes to працює with вона.
+      - statement: Ви пишите дуже гарно.
+        correct: false
+        explanation: Use Ви пишете дуже гарно.
+      - statement: Вони роботь швидко.
+        correct: false
+        explanation: Use Вони роблять швидко.
+      - statement: Він хоче кави.
+        correct: true
+        explanation: Хоче is the safe він form.
+      - statement: Я є читаю книгу.
+        correct: false
+        explanation: Use Я читаю книгу.
+      - statement: Я прокидаюся о сьомій.
+        correct: true
+        explanation: Прокидаюся is a safe -ся routine form.
+      - statement: Ніхто не читає.
+        correct: true
+        explanation: Keep не before the verb.
+  - id: act-3
+    type: group-sort
+    title: Skill stations
+    instruction: Sort each chunk by the skill it checks.
+    groups:
+      - name: Group One
+        items:
+          - я читаю
+          - ти пишеш
+          - вони працюють
+          - ми малюємо
+      - name: Group Two
+        items:
+          - я говорю
+          - ти говориш
+          - вони роблять
+          - ви бачите
+      - name: Modal + infinitive
+        items:
+          - хочу читати
+          - можу готувати
+          - мушу працювати
+          - може допомагати
+      - name: Question words
+        items:
+          - де ти працюєш?
+          - коли ти можеш?
+          - що ти читаєш?
+          - як ми говоримо?
+  - id: act-4
+    type: fill-in
+    title: Roommate dialogue gaps
+    instruction: Complete the dialogue with the checkpoint form.
+    items:
+      - sentence: 'Олег: Коли ти ___?'
+        answer: прокидаєшся
+        options:
+          - прокидаєшся
+          - працюєш
+          - пишеш
+        explanation: The question asks about the morning routine.
+      - sentence: 'Марина: Я ___ о сьомій.'
+        answer: прокидаюся
+        options:
+          - прокидаюся
+          - читаю
+          - роблю
+        explanation: With я, use прокидаюся.
+      - sentence: 'Олег: Де ти ___?'
+        answer: працюєш
+        options:
+          - працюєш
+          - можеш
+          - хочеш
+        explanation: Де asks for the work place.
+      - sentence: 'Марина: Я ___ в школі.'
+        answer: працюю
+        options:
+          - працюю
+          - працює
+          - працюємо
+        explanation: With я, use працюю.
+      - sentence: 'Олег: Ти ___ читати ввечері?'
+        answer: любиш
+        options:
+          - любиш
+          - читаєш
+          - робиш
+        explanation: Любиш + infinitive asks about liking an action.
+      - sentence: 'Марина: Не можу зараз, ___ працювати.'
+        answer: мушу
+        options:
+          - мушу
+          - читаю
+          - говорю
+        explanation: Мушу + infinitive means I have to.
+workbook:
+  - type: odd-one-out
+    title: Find the form that does not fit
+    instruction: Choose the chunk that belongs to a different checkpoint skill.
+    items:
+      - words:
+          - я читаю
+          - ти читаєш
+          - вони читають
+          - ти говориш
+        answer: ти говориш
+        explanation: Ти говориш is Group Two; the others are Group One читати.
+      - words:
+          - хочу читати
+          - можу готувати
+          - мушу працювати
+          - я читаю
+        answer: я читаю
+        explanation: Я читаю is a person form, not modal + infinitive.
+      - words:
+          - хто
+          - коли
+          - куди
+          - працюю
+        answer: працюю
+        explanation: Працюю is a verb form; the others are question words.
+      - words:
+          - я прокидаюся
+          - ти вмиваєшся
+          - вона одягається
+          - я снідаю
+        answer: я снідаю
+        explanation: Снідаю is not a -ся verb.
+  - type: unjumble
+    title: Rebuild checkpoint lines
+    instruction: Put the words in a safe A1.3 order.
+    items:
+      - words:
+          - Я
+          - люблю
+          - читати
+        answer: Я люблю читати
+      - words:
+          - Вона
+          - працює
+          - в школі
+        answer: Вона працює в школі
+      - words:
+          - Ми
+          - говоримо
+          - українською
+        answer: Ми говоримо українською
+      - words:
+          - Коли
+          - ти
+          - можеш
+        answer: Коли ти можеш
+      - words:
+          - Я
+          - мушу
+          - працювати
+        answer: Я мушу працювати
+      - words:
+          - Вони
+          - роблять
+          - швидко
+        answer: Вони роблять швидко
+  - type: quiz
+    title: Choose the answer job
+    instruction: Choose the line that answers the question.
+    items:
+      - prompt: 'Коли ти прокидаєшся?'
+        options:
+          - text: О сьомій.
+            correct: true
+          - text: У школі.
+            correct: false
+          - text: Українською.
+            correct: false
+        explanation: Коли asks about time.
+      - prompt: 'Де ти працюєш?'
+        options:
+          - text: В офісі.
+            correct: true
+          - text: О восьмій.
+            correct: false
+          - text: Тому що мушу.
+            correct: false
+        explanation: Де asks about place.
+      - prompt: 'Що ти любиш?'
+        options:
+          - text: Читати.
+            correct: true
+          - text: Удома.
+            correct: false
+          - text: Завтра.
+            correct: false
+        explanation: Що asks for the action or thing.
+      - prompt: 'Як ми говоримо?'
+        options:
+          - text: Українською.
+            correct: true
+          - text: Увечері.
+            correct: false
+          - text: У школі.
+            correct: false
+        explanation: Як asks how.
+  - type: fill-in
+    title: Repair by building the safe line
+    instruction: Build the corrected line from the checkpoint prompt.
+    items:
+      - sentence: 'I work every day: Я ___ кожного дня.'
+        answer: працюю
+        options:
+          - працюю
+          - читаю
+          - пишу
+        explanation: Repair for Я працювати кожного дня.
+      - sentence: 'She works at school: Вона ___ в школі.'
+        answer: працює
+        options:
+          - працює
+          - читає
+          - готує
+        explanation: 'Repair for <!-- bad -->Вона працюває в школі<!-- /bad -->.'
+      - sentence: 'I read a book: Я ___ книгу.'
+        answer: читаю
+        options:
+          - читаю
+          - пишу
+          - бачу
+        explanation: Repair for Я є читаю книгу.
+      - sentence: 'You write very nicely: Ви ___ дуже гарно.'
+        answer: пишете
+        options:
+          - пишете
+          - читаєте
+          - говорите
+        explanation: 'Repair for <!-- bad -->Ви пишите дуже гарно<!-- /bad -->.'
+      - sentence: 'They work fast: Вони ___ швидко.'
+        answer: роблять
+        options:
+          - роблять
+          - говорять
+          - читають
+        explanation: 'Repair for <!-- bad -->Вони роботь швидко<!-- /bad -->.'
+      - sentence: 'He wants coffee: Він ___ кави.'
+        answer: хоче
+        options:
+          - хоче
+          - любить
+          - п'є
+        explanation: 'Repair for <!-- bad -->Він хотіє кави<!-- /bad -->.'

--- a/curriculum/l2-uk-en/a1/checkpoint-actions/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/module.md
@@ -138,8 +138,6 @@ Keep the common repairs close:
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Діалог
 
 Read the roommate conversation. It checks liking, two verb groups, modal verbs,
@@ -165,8 +163,6 @@ This dialogue uses clean Ukrainian greeting and farewell chunks:
 **Добрий день** and **До побачення**. Keep everyday language precise:
 **тато**, **прізвище**, **українська мова**, **Київ**, **гривня**. Those forms
 belong to earlier A1 work and stay stable here.
-
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ## Підсумок
 
@@ -197,7 +193,3 @@ and precise. **Тарас Шевченко**, **Леся Українка**, **�
 need exact dates, for example **Голодомор 1932-1933 років**. For this A1
 checkpoint, you only need to carry the principle forward: use Ukrainian forms
 and Ukrainian context clearly.
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/i-want-i-can/activities.yaml
+++ b/curriculum/l2-uk-en/a1/i-want-i-can/activities.yaml
@@ -1,282 +1,280 @@
-- id: act-1
-  type: quiz
-  title: Choose the safe modal line
-  instruction: Choose the Ukrainian line that fits each situation.
-  items:
-    - prompt: You want to read, not say that you are reading now.
-      options:
-        - text: Я хочу читати.
-          correct: true
-        - text: Я хочу читаю.
-          correct: false
-        - text: Я хотіти читати.
-          correct: false
-      explanation: After хочу, keep the second action in the -ти form.
-    - prompt: You can help someone.
-      options:
-        - text: Я можу допомогти.
-          correct: true
-        - text: Я можеш допомогти.
-          correct: false
-        - text: Я можу допомагаю.
-          correct: false
-      explanation: Я uses можу, then the infinitive допомогти.
-    - prompt: You have to work.
-      options:
-        - text: Я мушу працювати.
-          correct: true
-        - text: Я мусиш працювати.
-          correct: false
-        - text: Я мушу працюю.
-          correct: false
-      explanation: Learn я мушу plus an infinitive.
-- id: act-2
-  type: order
-  title: Build tonight's plan
-  instruction: Put the short exchange in a natural order.
-  items:
-    - Ти хочеш піти в кіно?
-    - Так, я хочу піти.
-    - Ти можеш сьогодні?
-    - На жаль, не можу.
-    - Я мушу працювати.
-    - Добре, завтра гуляємо.
-  correct_order:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-- id: act-3
-  type: fill-in
-  title: Хотіти forms
-  instruction: Choose the form of хотіти that fits the person.
-  items:
-    - sentence: Я ___ читати.
-      answer: хочу
-      options:
-        - хочу
-        - хочеш
-        - хоче
-      explanation: Я хочу.
-    - sentence: Ти ___ гуляти?
-      answer: хочеш
-      options:
-        - хочеш
-        - хочу
-        - хочемо
-      explanation: Ти хочеш.
-    - sentence: Вона ___ каву.
-      answer: хоче
-      options:
-        - хоче
-        - хочуть
-        - хочете
-      explanation: Вона хоче.
-    - sentence: Ми ___ піти.
-      answer: хочемо
-      options:
-        - хочемо
-        - хочете
-        - хочуть
-      explanation: Ми хочемо.
-    - sentence: Ви ___ каву?
-      answer: хочете
-      options:
-        - хочете
-        - хочемо
-        - хоче
-      explanation: Ви хочете.
-    - sentence: Вони ___ працювати.
-      answer: хочуть
-      options:
-        - хочуть
-        - хоче
-        - хочеш
-      explanation: Вони хочуть.
-- id: act-4
-  type: unjumble
-  title: Put the helper before the action
-  instruction: Rebuild each sentence with the helper verb before the infinitive.
-  items:
-    - words:
-        - можу
-        - Я
-        - допомогти
-      answer: Я можу допомогти
-    - words:
-        - Ти
-        - читати
-        - можеш
-      answer: Ти можеш читати
-    - words:
-        - піти
-        - Вона
-        - може
-      answer: Вона може піти
-    - words:
-        - працювати
-        - Ми
-        - можемо
-      answer: Ми можемо працювати
-    - words:
-        - можете
-        - Ви
-        - порадити
-      answer: Ви можете порадити
-    - words:
-        - гуляти
-        - Вони
-        - можуть
-      answer: Вони можуть гуляти
-- id: act-5
-  type: true-false
-  title: Modal job check
-  instruction: Decide whether each statement is safe for this lesson.
-  items:
-    - statement: After хочу, use an infinitive in Я хочу читати.
-      answer: true
-      explanation: Читати is the action word after хочу.
-    - statement: Я не можу піти is a complete safe negative.
-      answer: true
-      explanation: Не stands before можу, then the action follows.
-    - statement: Мусити always means an emergency right now.
-      answer: false
-      explanation: Мусити marks obligation; urgency comes from context.
-    - statement: In a café, Можна мені, будь ласка, каву? is a polite service chunk.
-      answer: true
-      explanation: Use this chunk before practicing blunt wants in service speech.
-- id: act-6
-  type: translate
-  title: Café politeness
-  instruction: Choose the polite Ukrainian café line.
-  items:
-    - source: Ask for coffee politely.
-      options:
-        - text: Можна мені, будь ласка, каву?
-          correct: true
-        - text: Я хочу кава.
-          correct: false
-        - text: Дай кава.
-          correct: false
-      explanation: Можна мені, будь ласка, каву? is the safe service chunk.
-    - source: Ask what the server can recommend.
-      options:
-        - text: Що можете порадити?
-          correct: true
-        - text: Що можу порадити?
-          correct: false
-        - text: Що хочеш порадити?
-          correct: false
-      explanation: Ви можете gives the polite можете.
-    - source: Accept the borshch suggestion.
-      options:
-        - text: Тоді ще борщ, будь ласка.
-          correct: true
-        - text: Тоді я хочеш борщ.
-          correct: false
-        - text: Тоді борщ хочу ти.
-          correct: false
-      explanation: Тоді ще борщ, будь ласка is a natural A1 order chunk.
-- id: act-7
-  type: match-up
-  title: Situation to line
-  instruction: Match each English situation to the Ukrainian line.
-  pairs:
-    - left: You want to go tomorrow.
-      right: Я хочу піти завтра.
-    - left: You cannot go today.
-      right: Сьогодні я не можу піти.
-    - left: You have to work.
-      right: Я мушу працювати.
-    - left: You ask what the server can recommend.
-      right: Що можете порадити?
-    - left: You ask for coffee politely.
-      right: Можна мені, будь ласка, каву?
-- id: act-8
-  type: error-correction
-  title: Repair modal-verb traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: repair-traps
-  items:
-    - sentence: Я хочу до їсти.
-      error: Я хочу до їсти.
-      answer: Я хочу їсти.
-      options:
-        - Я хочу їсти.
-        - Я хочу до їсти.
-        - Я хочу їм.
-      explanation: Ukrainian infinitives already carry the action form; do not add до.
-    - sentence: Я їсту / Я їмлю.
-      error: Я їсту / Я їмлю.
-      answer: Я їм.
-      options:
-        - Я їм.
-        - Я їсту.
-        - Я їмлю.
-      explanation: Їсти has a special ready chunk, я їм.
-    - sentence: Я хочу читаю.
-      error: Я хочу читаю.
-      answer: Я хочу читати.
-      options:
-        - Я хочу читати.
-        - Я хочу читаю.
-        - Я хотіти читати.
-      explanation: The second action stays in the infinitive.
-    - sentence: Ти хоче гуляти?
-      error: Ти хоче гуляти?
-      answer: Ти хочеш гуляти?
-      options:
-        - Ти хочеш гуляти?
-        - Ти хоче гуляти?
-        - Ти хочу гуляти?
-      explanation: Ти uses хочеш.
-    - sentence: Я могу допомогти.
-      error: Я могу допомогти.
-      answer: Я можу допомогти.
-      options:
-        - Я можу допомогти.
-        - Я могу допомогти.
-        - Я можеш допомогти.
-      explanation: Ukrainian uses можу.
-    - sentence: Я мусю працювати.
-      error: Я мусю працювати.
-      answer: Я мушу працювати.
-      options:
-        - Я мушу працювати.
-        - Я мусю працювати.
-        - Я мусиш працювати.
-      explanation: Learn я мушу as a ready chunk.
-    - sentence: Я не можу не.
-      error: Я не можу не.
-      answer: Я не можу піти.
-      options:
-        - Я не можу піти.
-        - Я не можу не.
-        - Я не може піти.
-      explanation: Finish не можу with an action.
-    - sentence: Я п'ю кава.
-      error: Я п'ю кава.
-      answer: Я п'ю каву.
-      options:
-        - Я п'ю каву.
-        - Я п'ю кава.
-        - Я п'ю кави.
-      explanation: A familiar feminine object changes кава to каву.
-    - sentence: Я хочу кава.
-      error: Я хочу кава.
-      answer: Можна мені, будь ласка, каву?
-      options:
-        - Можна мені, будь ласка, каву?
-        - Я хочу кава.
-        - Можна я кава?
-      explanation: Use the polite café chunk for service speech.
-    - sentence: Він смієтся / бореться.
-      error: Він смієтся / бореться.
-      answer: Він сміється / борешся.
-      options:
-        - Він сміється / борешся.
-        - Він смієтся / бореться.
-        - Він сміється / борешться.
-      explanation: This is recognition-only spelling and pronunciation for -ся verbs.
+inline:
+  - id: act-1
+    type: quiz
+    title: Choose the safe modal line
+    instruction: Choose the Ukrainian line that fits each situation.
+    items:
+      - prompt: You want to read, not say that you are reading now.
+        options:
+          - text: Я хочу читати.
+            correct: true
+          - text: Я хочу читаю.
+            correct: false
+          - text: Я хотіти читати.
+            correct: false
+        explanation: After хочу, keep the second action in the -ти form.
+      - prompt: You can help someone.
+        options:
+          - text: Я можу допомогти.
+            correct: true
+          - text: Я можеш допомогти.
+            correct: false
+          - text: Я можу допомагаю.
+            correct: false
+        explanation: Я uses можу, then the infinitive допомогти.
+      - prompt: You have to work.
+        options:
+          - text: Я мушу працювати.
+            correct: true
+          - text: Я мусиш працювати.
+            correct: false
+          - text: Я мушу працюю.
+            correct: false
+        explanation: Learn я мушу plus an infinitive.
+  - id: act-2
+    type: order
+    title: Build tonight's plan
+    instruction: Put the short exchange in a natural order.
+    items:
+      - Ти хочеш піти в кіно?
+      - Так, я хочу піти.
+      - Ти можеш сьогодні?
+      - На жаль, не можу.
+      - Я мушу працювати.
+      - Добре, завтра гуляємо.
+    correct_order:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+  - id: act-3
+    type: fill-in
+    title: Хотіти forms
+    instruction: Choose the form of хотіти that fits the person.
+    items:
+      - sentence: Я ___ читати.
+        answer: хочу
+        options:
+          - хочу
+          - хочеш
+          - хоче
+        explanation: Я хочу.
+      - sentence: Ти ___ гуляти?
+        answer: хочеш
+        options:
+          - хочеш
+          - хочу
+          - хочемо
+        explanation: Ти хочеш.
+      - sentence: Вона ___ каву.
+        answer: хоче
+        options:
+          - хоче
+          - хочуть
+          - хочете
+        explanation: Вона хоче.
+      - sentence: Ми ___ піти.
+        answer: хочемо
+        options:
+          - хочемо
+          - хочете
+          - хочуть
+        explanation: Ми хочемо.
+      - sentence: Ви ___ каву?
+        answer: хочете
+        options:
+          - хочете
+          - хочемо
+          - хоче
+        explanation: Ви хочете.
+      - sentence: Вони ___ працювати.
+        answer: хочуть
+        options:
+          - хочуть
+          - хоче
+          - хочеш
+        explanation: Вони хочуть.
+  - id: act-4
+    type: unjumble
+    title: Put the helper before the action
+    instruction: Rebuild each sentence with the helper verb before the infinitive.
+    items:
+      - words:
+          - можу
+          - Я
+          - допомогти
+        answer: Я можу допомогти
+      - words:
+          - Ти
+          - читати
+          - можеш
+        answer: Ти можеш читати
+      - words:
+          - піти
+          - Вона
+          - може
+        answer: Вона може піти
+      - words:
+          - працювати
+          - Ми
+          - можемо
+        answer: Ми можемо працювати
+      - words:
+          - можете
+          - Ви
+          - порадити
+        answer: Ви можете порадити
+      - words:
+          - гуляти
+          - Вони
+          - можуть
+        answer: Вони можуть гуляти
+workbook:
+  - type: true-false
+    title: Modal job check
+    instruction: Decide whether each statement is safe for this lesson.
+    items:
+      - statement: After хочу, use an infinitive in Я хочу читати.
+        answer: true
+        explanation: Читати is the action word after хочу.
+      - statement: Я не можу піти is a complete safe negative.
+        answer: true
+        explanation: Не stands before можу, then the action follows.
+      - statement: Мусити always means an emergency right now.
+        answer: false
+        explanation: Мусити marks obligation; urgency comes from context.
+      - statement: In a café, Можна мені, будь ласка, каву? is a polite service chunk.
+        answer: true
+        explanation: Use this chunk before practicing blunt wants in service speech.
+  - type: translate
+    title: Café politeness
+    instruction: Choose the polite Ukrainian café line.
+    items:
+      - source: Ask for coffee politely.
+        options:
+          - text: Можна мені, будь ласка, каву?
+            correct: true
+          - text: Я хочу кава.
+            correct: false
+          - text: Дай кава.
+            correct: false
+        explanation: Можна мені, будь ласка, каву? is the safe service chunk.
+      - source: Ask what the server can recommend.
+        options:
+          - text: Що можете порадити?
+            correct: true
+          - text: Що можу порадити?
+            correct: false
+          - text: Що хочеш порадити?
+            correct: false
+        explanation: Ви можете gives the polite можете.
+      - source: Accept the borshch suggestion.
+        options:
+          - text: Тоді ще борщ, будь ласка.
+            correct: true
+          - text: Тоді я хочеш борщ.
+            correct: false
+          - text: Тоді борщ хочу ти.
+            correct: false
+        explanation: Тоді ще борщ, будь ласка is a natural A1 order chunk.
+  - type: match-up
+    title: Situation to line
+    instruction: Match each English situation to the Ukrainian line.
+    pairs:
+      - left: You want to go tomorrow.
+        right: Я хочу піти завтра.
+      - left: You cannot go today.
+        right: Сьогодні я не можу піти.
+      - left: You have to work.
+        right: Я мушу працювати.
+      - left: You ask what the server can recommend.
+        right: Що можете порадити?
+      - left: You ask for coffee politely.
+        right: Можна мені, будь ласка, каву?
+  - type: error-correction
+    title: Repair modal-verb traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: repair-traps
+    items:
+      - sentence: Я хочу до їсти.
+        error: Я хочу до їсти.
+        answer: Я хочу їсти.
+        options:
+          - Я хочу їсти.
+          - Я хочу до їсти.
+          - Я хочу їм.
+        explanation: Ukrainian infinitives already carry the action form; do not add до.
+      - sentence: Я їсту / Я їмлю.
+        error: Я їсту / Я їмлю.
+        answer: Я їм.
+        options:
+          - Я їм.
+          - Я їсту.
+          - Я їмлю.
+        explanation: Їсти has a special ready chunk, я їм.
+      - sentence: Я хочу читаю.
+        error: Я хочу читаю.
+        answer: Я хочу читати.
+        options:
+          - Я хочу читати.
+          - Я хочу читаю.
+          - Я хотіти читати.
+        explanation: The second action stays in the infinitive.
+      - sentence: Ти хоче гуляти?
+        error: Ти хоче гуляти?
+        answer: Ти хочеш гуляти?
+        options:
+          - Ти хочеш гуляти?
+          - Ти хоче гуляти?
+          - Ти хочу гуляти?
+        explanation: Ти uses хочеш.
+      - sentence: Я могу допомогти.
+        error: Я могу допомогти.
+        answer: Я можу допомогти.
+        options:
+          - Я можу допомогти.
+          - Я могу допомогти.
+          - Я можеш допомогти.
+        explanation: Ukrainian uses можу.
+      - sentence: Я мусю працювати.
+        error: Я мусю працювати.
+        answer: Я мушу працювати.
+        options:
+          - Я мушу працювати.
+          - Я мусю працювати.
+          - Я мусиш працювати.
+        explanation: Learn я мушу as a ready chunk.
+      - sentence: Я не можу не.
+        error: Я не можу не.
+        answer: Я не можу піти.
+        options:
+          - Я не можу піти.
+          - Я не можу не.
+          - Я не може піти.
+        explanation: Finish не можу with an action.
+      - sentence: Я п'ю кава.
+        error: Я п'ю кава.
+        answer: Я п'ю каву.
+        options:
+          - Я п'ю каву.
+          - Я п'ю кава.
+          - Я п'ю кави.
+        explanation: A familiar feminine object changes кава to каву.
+      - sentence: Я хочу кава.
+        error: Я хочу кава.
+        answer: Можна мені, будь ласка, каву?
+        options:
+          - Можна мені, будь ласка, каву?
+          - Я хочу кава.
+          - Можна я кава?
+        explanation: Use the polite café chunk for service speech.
+      - sentence: Він смієтся / бореться.
+        error: Він смієтся / бореться.
+        answer: Він сміється / борешся.
+        options:
+          - Він сміється / борешся.
+          - Він смієтся / бореться.
+          - Він сміється / борешться.
+        explanation: This is recognition-only spelling and pronunciation for -ся verbs.

--- a/curriculum/l2-uk-en/a1/i-want-i-can/module.md
+++ b/curriculum/l2-uk-en/a1/i-want-i-can/module.md
@@ -163,8 +163,6 @@ recognition, not active production.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Підсумок
 
 Choose the helper by the job it does:
@@ -216,9 +214,3 @@ with **[ц':а]**. A textbook example writes **сміється** and shows
 | <!-- bad -->Я мусю працювати.<!-- /bad --> | **Я мушу працювати.** | learn **я мушу** as a ready chunk |
 | <!-- bad -->Я не можу не.<!-- /bad --> | **Я не можу піти.** | finish the sentence with an action |
 | blunt order every time | **Можна мені, будь ласка, каву?** | service speech needs a polite chunk |
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/my-morning/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-morning/activities.yaml
@@ -1,294 +1,292 @@
-- id: act-1
-  type: true-false
-  title: Hear the reflexive ending
-  instruction: Decide whether each pronunciation note is safe for this lesson.
-  items:
-    - statement: In прокидаєшся, the written -шся is pronounced like [с':а].
-      answer: true
-      explanation: Say [прокидайес':а], not each written letter separately.
-    - statement: In одягається, the written -ться is pronounced like [ц':а].
-      answer: true
-      explanation: The final sounds merge smoothly.
-    - statement: Прокидаєшся should be pronounced [прокидайешся] letter by letter.
-      answer: false
-      explanation: Do not keep a separate [ш] sound here.
-    - statement: The spelling -ся can sound like [с':а].
-      answer: true
-      explanation: This is the soft final sound to recognize.
-- id: act-2
-  type: fill-in
-  title: Add the morning ending
-  instruction: Choose the complete -ся form that fits the person.
-  items:
-    - sentence: Я ___ о сьомій.
-      answer: прокидаюся
-      options:
-        - прокидаюся
-        - прокидаєшся
-        - прокидається
-      explanation: Я uses -юся.
-    - sentence: Ти ___ рано?
-      answer: прокидаєшся
-      options:
-        - прокидаєшся
-        - прокидаюся
-        - прокидається
-      explanation: Ти uses -єшся.
-    - sentence: Вона ___ швидко.
-      answer: одягається
-      options:
-        - одягається
-        - одягаюся
-        - одягаєшся
-      explanation: Вона uses -ється.
-    - sentence: Я ___ у ванній.
-      answer: вмиваюся
-      options:
-        - вмиваюся
-        - вмиваєшся
-        - вмивається
-      explanation: Я uses -юся after the Group One stem.
-    - sentence: Ми ___ вдома.
-      answer: збираємося
-      options:
-        - збираємося
-        - збираєтеся
-        - збираються
-      explanation: Ми uses -ємося.
-    - sentence: Вони ___ о восьмій.
-      answer: прокидаються
-      options:
-        - прокидаються
-        - прокидаємося
-        - прокидаєтеся
-      explanation: Вони uses -ються.
-- id: act-3
-  type: quiz
-  title: Reflexive or regular
-  instruction: Choose the natural Ukrainian morning line.
-  items:
-    - prompt: I wash up in the morning.
-      options:
-        - text: Я вмиваюся вранці.
-          correct: true
-        - text: Я мию себе вранці.
-          correct: false
-        - text: Я вмиваю вранці.
-          correct: false
-      explanation: The routine action is Я вмиваюся.
-    - prompt: I have breakfast at home.
-      options:
-        - text: Я снідаю вдома.
-          correct: true
-        - text: Я снідаюся вдома.
-          correct: false
-        - text: Я сніданок вдома.
-          correct: false
-      explanation: Снідати is regular here; do not add -ся.
-    - prompt: I get dressed quickly.
-      options:
-        - text: Я швидко одягаюся.
-          correct: true
-        - text: Я швидко одягаю.
-          correct: false
-        - text: Я швидко одягатися.
-          correct: false
-      explanation: Use the present form одягаюся.
-    - prompt: I use a phone.
-      options:
-        - text: Я користуюся телефоном.
-          correct: true
-        - text: Я користуювася телефоном.
-          correct: false
-        - text: Я користую телефоном.
-          correct: false
-      explanation: Recognize користуватися -> користуюся.
-- id: act-4
-  type: order
-  title: Put the morning in order
-  instruction: Put the routine from first to last.
-  items:
-    - Спочатку я прокидаюся.
-    - Потім вмиваюся.
-    - Після цього одягаюся.
-    - Потім снідаю.
-    - Нарешті йду на роботу.
-  correct_order:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-- id: act-5
-  type: fill-in
-  title: Finish the roommate dialogue
-  instruction: Choose the word or phrase that completes each line.
-  items:
-    - sentence: Коли ти ___?
-      answer: прокидаєшся
-      options:
-        - прокидаєшся
-        - прокидаюся
-        - прокидається
-      explanation: The question asks ти.
-    - sentence: Я ___ о сьомій.
-      answer: прокидаюся
-      options:
-        - прокидаюся
-        - прокидаєшся
-        - прокидається
-      explanation: The answer starts with я.
-    - sentence: Що ти робиш ___?
-      answer: потім
-      options:
-        - потім
-        - сніданок
-        - рушник
-      explanation: Потім asks for the next action.
-    - sentence: Я вмиваюся і ___.
-      answer: одягаюся
-      options:
-        - одягаюся
-        - одягаєшся
-        - одягається
-      explanation: The speaker is я.
-    - sentence: Після цього я ___.
-      answer: снідаю
-      options:
-        - снідаю
-        - снідаєшся
-        - сніданок
-      explanation: Снідаю is the verb form.
-- id: act-6
-  type: group-sort
-  title: Active pattern or recognition chunk
-  instruction: Sort each form by how you should treat it today.
-  groups:
-    - name: Build with Group One + -ся
-      items:
-        - прокидаюся
-        - прокидаєшся
-        - одягається
-        - збираємося
-        - вмиваються
-    - name: Recognize as a ready chunk
-      items:
-        - дивлюся
-        - вчуся
-        - користуюся
-    - name: No -ся today
-      items:
-        - снідаю
-        - п'ю воду
-        - йду на роботу
-- id: act-7
-  type: translate
-  title: Build my morning line
-  instruction: Choose the Ukrainian line that matches the English prompt.
-  items:
-    - source: First I wake up.
-      options:
-        - text: Спочатку я прокидаюся.
-          correct: true
-        - text: Спочатку я прокидаєшся.
-          correct: false
-        - text: Спочатку я прокидатися.
-          correct: false
-      explanation: Я needs прокидаюся.
-    - source: Then I wash up.
-      options:
-        - text: Потім я вмиваюся.
-          correct: true
-        - text: Потім я мию себе.
-          correct: false
-        - text: Потім я вмиваєшся.
-          correct: false
-      explanation: Use the routine verb вмиваюся.
-    - source: After that I have breakfast.
-      options:
-        - text: Після цього я снідаю.
-          correct: true
-        - text: Після цього я снідаюся.
-          correct: false
-        - text: Після цього я сніданок.
-          correct: false
-      explanation: Снідати is regular in this routine.
-    - source: Finally I go to work.
-      options:
-        - text: Нарешті я йду на роботу.
-          correct: true
-        - text: Нарешті я йдеш на роботу.
-          correct: false
-        - text: Нарешті я йти на роботу.
-          correct: false
-      explanation: Learn я йду as the ready chunk.
-- id: act-8
-  type: error-correction
-  title: Repair morning traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: repair-traps
-  items:
-    - sentence: Я прокидаєшся.
-      error: Я прокидаєшся.
-      answer: Я прокидаюся.
-      options:
-        - Я прокидаюся.
-        - Я прокидаєшся.
-        - Я прокидається.
-      explanation: Я uses the -юся form.
-    - sentence: Він прокидаюся.
-      error: Він прокидаюся.
-      answer: Він прокидається.
-      options:
-        - Він прокидається.
-        - Він прокидаюся.
-        - Він прокидаєшся.
-      explanation: Він uses the -ється form.
-    - sentence: "Вимова: [прокидайешся]."
-      error: "[прокидайешся]"
-      answer: "[прокидайес':а]"
-      options:
-        - "[прокидайес':а]"
-        - "[прокидайешся]"
-        - "[прокидайец':а]"
-      explanation: Written -шся is pronounced [с':а].
-    - sentence: "Вимова: [одягайет'с'а]."
-      error: "[одягайет'с'а]"
-      answer: "[одягайец':а]"
-      options:
-        - "[одягайец':а]"
-        - "[одягайет'с'а]"
-        - "[одягайес':а]"
-      explanation: Written -ться is pronounced [ц':а].
-    - sentence: Я мию себе.
-      error: Я мию себе.
-      answer: Я вмиваюся.
-      options:
-        - Я вмиваюся.
-        - Я мию себе.
-        - Я вмиваю себе.
-      explanation: The natural routine verb is reflexive.
-    - sentence: Я дивюся / Я дивюсь.
-      error: Я дивюся / Я дивюсь.
-      answer: Я дивлюся.
-      options:
-        - Я дивлюся.
-        - Я дивлюся в дзеркало.
-        - Я дивлюся фільм.
-      explanation: Learn я дивлюся as a ready chunk.
-    - sentence: Я користуювася.
-      error: Я користуювася.
-      answer: Я користуюся.
-      options:
-        - Я користуюся.
-        - Я користуюся телефоном.
-        - Я використовую телефон.
-      explanation: The -ува- part drops in the present-tense form.
-    - sentence: Це мій завтрак.
-      error: завтрак
-      answer: Це мій сніданок.
-      options:
-        - Це мій сніданок.
-        - Це мій завтрак.
-        - Це моя снідати.
-      explanation: Use сніданок for breakfast.
+inline:
+  - id: act-1
+    type: true-false
+    title: Hear the reflexive ending
+    instruction: Decide whether each pronunciation note is safe for this lesson.
+    items:
+      - statement: In прокидаєшся, the written -шся is pronounced like [с':а].
+        answer: true
+        explanation: Say [прокидайес':а], not each written letter separately.
+      - statement: In одягається, the written -ться is pronounced like [ц':а].
+        answer: true
+        explanation: The final sounds merge smoothly.
+      - statement: Прокидаєшся should be pronounced [прокидайешся] letter by letter.
+        answer: false
+        explanation: Do not keep a separate [ш] sound here.
+      - statement: The spelling -ся can sound like [с':а].
+        answer: true
+        explanation: This is the soft final sound to recognize.
+  - id: act-2
+    type: fill-in
+    title: Add the morning ending
+    instruction: Choose the complete -ся form that fits the person.
+    items:
+      - sentence: Я ___ о сьомій.
+        answer: прокидаюся
+        options:
+          - прокидаюся
+          - прокидаєшся
+          - прокидається
+        explanation: Я uses -юся.
+      - sentence: Ти ___ рано?
+        answer: прокидаєшся
+        options:
+          - прокидаєшся
+          - прокидаюся
+          - прокидається
+        explanation: Ти uses -єшся.
+      - sentence: Вона ___ швидко.
+        answer: одягається
+        options:
+          - одягається
+          - одягаюся
+          - одягаєшся
+        explanation: Вона uses -ється.
+      - sentence: Я ___ у ванній.
+        answer: вмиваюся
+        options:
+          - вмиваюся
+          - вмиваєшся
+          - вмивається
+        explanation: Я uses -юся after the Group One stem.
+      - sentence: Ми ___ вдома.
+        answer: збираємося
+        options:
+          - збираємося
+          - збираєтеся
+          - збираються
+        explanation: Ми uses -ємося.
+      - sentence: Вони ___ о восьмій.
+        answer: прокидаються
+        options:
+          - прокидаються
+          - прокидаємося
+          - прокидаєтеся
+        explanation: Вони uses -ються.
+  - id: act-3
+    type: quiz
+    title: Reflexive or regular
+    instruction: Choose the natural Ukrainian morning line.
+    items:
+      - prompt: I wash up in the morning.
+        options:
+          - text: Я вмиваюся вранці.
+            correct: true
+          - text: Я мию себе вранці.
+            correct: false
+          - text: Я вмиваю вранці.
+            correct: false
+        explanation: The routine action is Я вмиваюся.
+      - prompt: I have breakfast at home.
+        options:
+          - text: Я снідаю вдома.
+            correct: true
+          - text: Я снідаюся вдома.
+            correct: false
+          - text: Я сніданок вдома.
+            correct: false
+        explanation: Снідати is regular here; do not add -ся.
+      - prompt: I get dressed quickly.
+        options:
+          - text: Я швидко одягаюся.
+            correct: true
+          - text: Я швидко одягаю.
+            correct: false
+          - text: Я швидко одягатися.
+            correct: false
+        explanation: Use the present form одягаюся.
+      - prompt: I use a phone.
+        options:
+          - text: Я користуюся телефоном.
+            correct: true
+          - text: Я користуювася телефоном.
+            correct: false
+          - text: Я користую телефоном.
+            correct: false
+        explanation: Recognize користуватися -> користуюся.
+  - id: act-4
+    type: order
+    title: Put the morning in order
+    instruction: Put the routine from first to last.
+    items:
+      - Спочатку я прокидаюся.
+      - Потім вмиваюся.
+      - Після цього одягаюся.
+      - Потім снідаю.
+      - Нарешті йду на роботу.
+    correct_order:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+workbook:
+  - type: fill-in
+    title: Finish the roommate dialogue
+    instruction: Choose the word or phrase that completes each line.
+    items:
+      - sentence: Коли ти ___?
+        answer: прокидаєшся
+        options:
+          - прокидаєшся
+          - прокидаюся
+          - прокидається
+        explanation: The question asks ти.
+      - sentence: Я ___ о сьомій.
+        answer: прокидаюся
+        options:
+          - прокидаюся
+          - прокидаєшся
+          - прокидається
+        explanation: The answer starts with я.
+      - sentence: Що ти робиш ___?
+        answer: потім
+        options:
+          - потім
+          - сніданок
+          - рушник
+        explanation: Потім asks for the next action.
+      - sentence: Я вмиваюся і ___.
+        answer: одягаюся
+        options:
+          - одягаюся
+          - одягаєшся
+          - одягається
+        explanation: The speaker is я.
+      - sentence: Після цього я ___.
+        answer: снідаю
+        options:
+          - снідаю
+          - снідаєшся
+          - сніданок
+        explanation: Снідаю is the verb form.
+  - type: group-sort
+    title: Active pattern or recognition chunk
+    instruction: Sort each form by how you should treat it today.
+    groups:
+      - name: Build with Group One + -ся
+        items:
+          - прокидаюся
+          - прокидаєшся
+          - одягається
+          - збираємося
+          - вмиваються
+      - name: Recognize as a ready chunk
+        items:
+          - дивлюся
+          - вчуся
+          - користуюся
+      - name: No -ся today
+        items:
+          - снідаю
+          - п'ю воду
+          - йду на роботу
+  - type: translate
+    title: Build my morning line
+    instruction: Choose the Ukrainian line that matches the English prompt.
+    items:
+      - source: First I wake up.
+        options:
+          - text: Спочатку я прокидаюся.
+            correct: true
+          - text: Спочатку я прокидаєшся.
+            correct: false
+          - text: Спочатку я прокидатися.
+            correct: false
+        explanation: Я needs прокидаюся.
+      - source: Then I wash up.
+        options:
+          - text: Потім я вмиваюся.
+            correct: true
+          - text: Потім я мию себе.
+            correct: false
+          - text: Потім я вмиваєшся.
+            correct: false
+        explanation: Use the routine verb вмиваюся.
+      - source: After that I have breakfast.
+        options:
+          - text: Після цього я снідаю.
+            correct: true
+          - text: Після цього я снідаюся.
+            correct: false
+          - text: Після цього я сніданок.
+            correct: false
+        explanation: Снідати is regular in this routine.
+      - source: Finally I go to work.
+        options:
+          - text: Нарешті я йду на роботу.
+            correct: true
+          - text: Нарешті я йдеш на роботу.
+            correct: false
+          - text: Нарешті я йти на роботу.
+            correct: false
+        explanation: Learn я йду as the ready chunk.
+  - type: error-correction
+    title: Repair morning traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: repair-traps
+    items:
+      - sentence: Я прокидаєшся.
+        error: Я прокидаєшся.
+        answer: Я прокидаюся.
+        options:
+          - Я прокидаюся.
+          - Я прокидаєшся.
+          - Я прокидається.
+        explanation: Я uses the -юся form.
+      - sentence: Він прокидаюся.
+        error: Він прокидаюся.
+        answer: Він прокидається.
+        options:
+          - Він прокидається.
+          - Він прокидаюся.
+          - Він прокидаєшся.
+        explanation: Він uses the -ється form.
+      - sentence: 'Вимова: [прокидайешся].'
+        error: '[прокидайешся]'
+        answer: "[прокидайес':а]"
+        options:
+          - "[прокидайес':а]"
+          - '[прокидайешся]'
+          - "[прокидайец':а]"
+        explanation: Written -шся is pronounced [с':а].
+      - sentence: "Вимова: [одягайет'с'а]."
+        error: "[одягайет'с'а]"
+        answer: "[одягайец':а]"
+        options:
+          - "[одягайец':а]"
+          - "[одягайет'с'а]"
+          - "[одягайес':а]"
+        explanation: Written -ться is pronounced [ц':а].
+      - sentence: Я мию себе.
+        error: Я мию себе.
+        answer: Я вмиваюся.
+        options:
+          - Я вмиваюся.
+          - Я мию себе.
+          - Я вмиваю себе.
+        explanation: The natural routine verb is reflexive.
+      - sentence: Я дивюся / Я дивюсь.
+        error: Я дивюся / Я дивюсь.
+        answer: Я дивлюся.
+        options:
+          - Я дивлюся.
+          - Я дивлюся в дзеркало.
+          - Я дивлюся фільм.
+        explanation: Learn я дивлюся as a ready chunk.
+      - sentence: Я користуювася.
+        error: Я користуювася.
+        answer: Я користуюся.
+        options:
+          - Я користуюся.
+          - Я користуюся телефоном.
+          - Я використовую телефон.
+        explanation: The -ува- part drops in the present-tense form.
+      - sentence: Це мій завтрак.
+        error: завтрак
+        answer: Це мій сніданок.
+        options:
+          - Це мій сніданок.
+          - Це мій завтрак.
+          - Це моя снідати.
+        explanation: Use сніданок for breakfast.

--- a/curriculum/l2-uk-en/a1/my-morning/module.md
+++ b/curriculum/l2-uk-en/a1/my-morning/module.md
@@ -140,10 +140,6 @@ the morning story useful without forcing you to invent new grammar. A good A1
 answer can be direct: **Спочатку я прокидаюся о восьмій. Потім вмиваюся. Після
 цього снідаю. Нарешті йду в університет.**
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Підсумок
 
 The active pattern is regular verb form plus **-ся**: **я прокидаюся**,
@@ -182,7 +178,3 @@ For your own A1 story, keep the order simple:
 Do not explain these endings through any other language. Ukrainian has its own
 clear pattern: choose the Ukrainian verb form, add **-ся / -сь**, and pronounce
 the final cluster smoothly.
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/questions/activities.yaml
+++ b/curriculum/l2-uk-en/a1/questions/activities.yaml
@@ -1,306 +1,304 @@
-- id: act-1
-  type: match-up
-  title: Question-word jobs
-  instruction: Match each Ukrainian question word with the job it does.
-  pairs:
-    - left: Хто?
-      right: asks for a person
-    - left: Що?
-      right: asks for a thing, topic, or action
-    - left: Де?
-      right: asks for a place
-    - left: Куди?
-      right: asks for a direction
-    - left: Коли?
-      right: asks for time
-    - left: Чому?
-      right: asks for a reason
-    - left: Як?
-      right: asks for manner or a fixed social phrase
-- id: act-2
-  type: fill-in
-  title: Interview gaps
-  instruction: Choose the question word that completes each short exchange.
-  items:
-    - sentence: ___ ти?
-      answer: Хто
-      options:
-        - Хто
-        - Що
-        - Де
-      explanation: Хто asks for a person.
-    - sentence: ___ ти вивчаєш?
-      answer: Що
-      options:
-        - Що
-        - Де
-        - Коли
-      explanation: Що asks for the topic or action.
-    - sentence: ___ ти живеш?
-      answer: Де
-      options:
-        - Де
-        - Хто
-        - Чому
-      explanation: Де asks for a place.
-    - sentence: ___ ти працюєш?
-      answer: Коли
-      options:
-        - Коли
-        - Куди
-        - Як
-      explanation: Коли asks for time.
-    - sentence: ___ ти не працюєш?
-      answer: Чому
-      options:
-        - Чому
-        - Що
-        - Хто
-      explanation: Чому asks for a reason.
-    - sentence: ___ справи?
-      answer: Як
-      options:
-        - Як
-        - Де
-        - Коли
-      explanation: Як appears in the ready phrase Як справи?
-- id: act-3
-  type: true-false
-  title: Yes/no question signals
-  instruction: Decide whether each statement is safe for this lesson.
-  items:
-    - statement: Ти говориш українською? can be a yes/no question with rising intonation.
-      answer: true
-      explanation: Ukrainian can use the same word order plus rising intonation.
-    - statement: Чи ти читаєш? is a clear written or careful-speech question marker.
-      answer: true
-      explanation: Чи is useful to recognize, but optional in active A1 speech.
-    - statement: Every Ukrainian yes/no question must begin with чи.
-      answer: false
-      explanation: Intonation is enough for many everyday yes/no questions.
-    - statement: Ти читаєш. and Ти читаєш? have the same words but different sentence force.
-      answer: true
-      explanation: The period makes a statement; the question mark and voice make a question.
-- id: act-4
-  type: group-sort
-  title: Question, answer, or negative
-  instruction: Sort each line by what it does in a conversation.
-  groups:
-    - name: Information question
-      items:
-        - Хто ти?
-        - Що ти робиш?
-        - Де книга?
-        - Коли ти працюєш?
-    - name: Short answer
-      items:
-        - Я студент.
-        - У Києві.
-        - Вранці.
-    - name: Negative sentence
-      items:
-        - Я не знаю.
-        - Він не працює.
-        - Ніхто не говорить.
-- id: act-5
-  type: unjumble
-  title: Rebuild the negative
-  instruction: Put the words in the standard Ukrainian order.
-  items:
-    - words:
-        - не
-        - Я
-        - знаю
-      answer: Я не знаю
-    - words:
-        - не
-        - Ти
-        - розумієш
-      answer: Ти не розумієш
-    - words:
-        - не
-        - хочу
-        - Я
-        - читати
-      answer: Я не хочу читати
-    - words:
-        - не
-        - можу
-        - Я
-        - піти
-      answer: Я не можу піти
-    - words:
-        - не
-        - Ніхто
-        - говорить
-      answer: Ніхто не говорить
-    - words:
-        - нічого
-        - не
-        - Я
-        - знаю
-      answer: Я нічого не знаю
-- id: act-6
-  type: translate
-  title: Build the short question
-  instruction: Choose the Ukrainian line that matches the English prompt.
-  items:
-    - source: Who are you?
-      options:
-        - text: Хто ти?
-          correct: true
-        - text: Що ти?
-          correct: false
-        - text: Де ти?
-          correct: false
-      explanation: Хто asks for a person.
-    - source: What are you studying?
-      options:
-        - text: Що ти вивчаєш?
-          correct: true
-        - text: Хто ти вивчаєш?
-          correct: false
-        - text: Коли ти вивчаєш?
-          correct: false
-      explanation: Що asks for the topic.
-    - source: Where do you live?
-      options:
-        - text: Де ти живеш?
-          correct: true
-        - text: Куди ти живеш?
-          correct: false
-        - text: Чому ти живеш?
-          correct: false
-      explanation: Де asks for location.
-    - source: I do not know.
-      options:
-        - text: Я не знаю.
-          correct: true
-        - text: Я незнаю.
-          correct: false
-        - text: Я знаю не.
-          correct: false
-      explanation: Write не separately before знаю.
-- id: act-7
-  type: order
-  title: Find the book
-  instruction: Put the home exchange in a natural order.
-  items:
-    - Де моя книга?
-    - Я не знаю.
-    - А хто знає?
-    - Мама знає.
-    - Чому мама?
-    - Тому що вона все знає!
-  correct_order:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-- id: act-8
-  type: error-correction
-  title: Repair question and negative traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: repair-traps
-  notes: |-
-    Coverage markers for seeded wiki gate only:
-    I see nobody.<br>Я бачу нікого.
-    Who is this book?<br>Хто це книжка? / Хто є ця книжка?
-    I don't believe in nothing.<br>Я не вірю в ніщо.
-    <!-- bad -->I dont know.<br>Я незнаю.<!-- /bad -->
-    Do you read?<br>Ти читаєш? (без підвищення інтонації)
-    Nowhere.<br>Неде. / Ні де.
-    How is this soup?<br>Як є цей суп? / Як цей суп?
-  items:
-    - sentence: I see nobody. Я бачу нікого.
-      error: Я бачу нікого.
-      answer: Я нікого не бачу.
-      correction: Я нікого не бачу.
-      options:
-        - Я нікого не бачу.
-        - Я бачу нікого.
-        - Я нікого бачу.
-      explanation: Ukrainian keeps не before the verb with нікого.
-    - sentence: Who is this book? Хто це книжка? / Хто є ця книжка?
-      error: Хто це книжка? / Хто є ця книжка?
-      answer: Чия це книжка?
-      correction: Чия це книжка?
-      options:
-        - Чия це книжка?
-        - Хто це книжка?
-        - Хто є ця книжка?
-      explanation: Ownership uses чия for книжка.
-    - sentence: Who is this book? Хто є ця книжка?
-      error: Хто є ця книжка?
-      answer: Чия це книжка?
-      correction: Чия це книжка?
-      options:
-        - Чия це книжка?
-        - Хто є ця книжка?
-        - Що є ця книжка?
-      explanation: Do not insert є; use the ownership question word.
-    - sentence: I don't believe in nothing. Я не вірю в ніщо.
-      error: Я не вірю в ніщо.
-      answer: Я ні в що не вірю.
-      correction: Я ні в що не вірю.
-      options:
-        - Я ні в що не вірю.
-        - Я не вірю в ніщо.
-        - Я в ніщо не вірю.
-      explanation: A preposition splits ні + що into ні в що.
-    - sentence: I dont know. The learner wrote не + знаю as one word.
-      error: не + знаю written as one word
-      answer: Я не знаю.
-      correction: Я не знаю.
-      options:
-        - Я не знаю.
-        - Я знаю не.
-        - Ні, я знаю.
-      explanation: Не is a separate word before the verb.
-    - sentence: Do you read? Ти читаєш? (without rising intonation).
-      error: Ти читаєш? (без підвищення інтонації)
-      answer: Чи ти читаєш?
-      correction: Чи ти читаєш?
-      options:
-        - Чи ти читаєш?
-        - Ти читаєш.
-        - Ти читати?
-      explanation: If intonation is not clear, чи can mark the question.
-    - sentence: Nowhere. Неде. / Ні де.
-      error: Неде. / Ні де.
-      answer: Ніде.
-      correction: Ніде.
-      options:
-        - Ніде.
-        - Неде.
-        - Ні де.
-      explanation: Ніде is one word.
-    - sentence: Nowhere. Ні де.
-      error: Ні де.
-      answer: Ніде.
-      correction: Ніде.
-      options:
-        - Ніде.
-        - Ні де.
-        - Не де.
-      explanation: Write ніде together.
-    - sentence: How is this soup? Як є цей суп? / Як цей суп?
-      error: Як є цей суп? / Як цей суп?
-      answer: Який цей суп?
-      correction: Який цей суп?
-      options:
-        - Який цей суп?
-        - Як є цей суп?
-        - Як цей суп?
-      explanation: Quality uses який.
-    - sentence: How is this soup? Як цей суп?
-      error: Як цей суп?
-      answer: Який цей суп?
-      correction: Який цей суп?
-      options:
-        - Який цей суп?
-        - Як цей суп?
-        - Що цей суп?
-      explanation: Як asks manner; який asks quality.
+inline:
+  - id: act-1
+    type: match-up
+    title: Question-word jobs
+    instruction: Match each Ukrainian question word with the job it does.
+    pairs:
+      - left: Хто?
+        right: asks for a person
+      - left: Що?
+        right: asks for a thing, topic, or action
+      - left: Де?
+        right: asks for a place
+      - left: Куди?
+        right: asks for a direction
+      - left: Коли?
+        right: asks for time
+      - left: Чому?
+        right: asks for a reason
+      - left: Як?
+        right: asks for manner or a fixed social phrase
+  - id: act-2
+    type: fill-in
+    title: Interview gaps
+    instruction: Choose the question word that completes each short exchange.
+    items:
+      - sentence: ___ ти?
+        answer: Хто
+        options:
+          - Хто
+          - Що
+          - Де
+        explanation: Хто asks for a person.
+      - sentence: ___ ти вивчаєш?
+        answer: Що
+        options:
+          - Що
+          - Де
+          - Коли
+        explanation: Що asks for the topic or action.
+      - sentence: ___ ти живеш?
+        answer: Де
+        options:
+          - Де
+          - Хто
+          - Чому
+        explanation: Де asks for a place.
+      - sentence: ___ ти працюєш?
+        answer: Коли
+        options:
+          - Коли
+          - Куди
+          - Як
+        explanation: Коли asks for time.
+      - sentence: ___ ти не працюєш?
+        answer: Чому
+        options:
+          - Чому
+          - Що
+          - Хто
+        explanation: Чому asks for a reason.
+      - sentence: ___ справи?
+        answer: Як
+        options:
+          - Як
+          - Де
+          - Коли
+        explanation: Як appears in the ready phrase Як справи?
+  - id: act-3
+    type: true-false
+    title: Yes/no question signals
+    instruction: Decide whether each statement is safe for this lesson.
+    items:
+      - statement: Ти говориш українською? can be a yes/no question with rising intonation.
+        answer: true
+        explanation: Ukrainian can use the same word order plus rising intonation.
+      - statement: Чи ти читаєш? is a clear written or careful-speech question marker.
+        answer: true
+        explanation: Чи is useful to recognize, but optional in active A1 speech.
+      - statement: Every Ukrainian yes/no question must begin with чи.
+        answer: false
+        explanation: Intonation is enough for many everyday yes/no questions.
+      - statement: Ти читаєш. and Ти читаєш? have the same words but different sentence force.
+        answer: true
+        explanation: The period makes a statement; the question mark and voice make a question.
+  - id: act-4
+    type: group-sort
+    title: Question, answer, or negative
+    instruction: Sort each line by what it does in a conversation.
+    groups:
+      - name: Information question
+        items:
+          - Хто ти?
+          - Що ти робиш?
+          - Де книга?
+          - Коли ти працюєш?
+      - name: Short answer
+        items:
+          - Я студент.
+          - У Києві.
+          - Вранці.
+      - name: Negative sentence
+        items:
+          - Я не знаю.
+          - Він не працює.
+          - Ніхто не говорить.
+workbook:
+  - type: unjumble
+    title: Rebuild the negative
+    instruction: Put the words in the standard Ukrainian order.
+    items:
+      - words:
+          - не
+          - Я
+          - знаю
+        answer: Я не знаю
+      - words:
+          - не
+          - Ти
+          - розумієш
+        answer: Ти не розумієш
+      - words:
+          - не
+          - хочу
+          - Я
+          - читати
+        answer: Я не хочу читати
+      - words:
+          - не
+          - можу
+          - Я
+          - піти
+        answer: Я не можу піти
+      - words:
+          - не
+          - Ніхто
+          - говорить
+        answer: Ніхто не говорить
+      - words:
+          - нічого
+          - не
+          - Я
+          - знаю
+        answer: Я нічого не знаю
+  - type: translate
+    title: Build the short question
+    instruction: Choose the Ukrainian line that matches the English prompt.
+    items:
+      - source: Who are you?
+        options:
+          - text: Хто ти?
+            correct: true
+          - text: Що ти?
+            correct: false
+          - text: Де ти?
+            correct: false
+        explanation: Хто asks for a person.
+      - source: What are you studying?
+        options:
+          - text: Що ти вивчаєш?
+            correct: true
+          - text: Хто ти вивчаєш?
+            correct: false
+          - text: Коли ти вивчаєш?
+            correct: false
+        explanation: Що asks for the topic.
+      - source: Where do you live?
+        options:
+          - text: Де ти живеш?
+            correct: true
+          - text: Куди ти живеш?
+            correct: false
+          - text: Чому ти живеш?
+            correct: false
+        explanation: Де asks for location.
+      - source: I do not know.
+        options:
+          - text: Я не знаю.
+            correct: true
+          - text: Я незнаю.
+            correct: false
+          - text: Я знаю не.
+            correct: false
+        explanation: Write не separately before знаю.
+  - type: order
+    title: Find the book
+    instruction: Put the home exchange in a natural order.
+    items:
+      - Де моя книга?
+      - Я не знаю.
+      - А хто знає?
+      - Мама знає.
+      - Чому мама?
+      - Тому що вона все знає!
+    correct_order:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+  - type: error-correction
+    title: Repair question and negative traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: repair-traps
+    notes: |-
+      Coverage markers for seeded wiki gate only:
+      I see nobody.<br>Я бачу нікого.
+      Who is this book?<br>Хто це книжка? / Хто є ця книжка?
+      I don't believe in nothing.<br>Я не вірю в ніщо.
+      <!-- bad -->I dont know.<br>Я незнаю.<!-- /bad -->
+      Do you read?<br>Ти читаєш? (без підвищення інтонації)
+      Nowhere.<br>Неде. / Ні де.
+      How is this soup?<br>Як є цей суп? / Як цей суп?
+    items:
+      - sentence: I see nobody. Я бачу нікого.
+        error: Я бачу нікого.
+        answer: Я нікого не бачу.
+        correction: Я нікого не бачу.
+        options:
+          - Я нікого не бачу.
+          - Я бачу нікого.
+          - Я нікого бачу.
+        explanation: Ukrainian keeps не before the verb with нікого.
+      - sentence: Who is this book? Хто це книжка? / Хто є ця книжка?
+        error: Хто це книжка? / Хто є ця книжка?
+        answer: Чия це книжка?
+        correction: Чия це книжка?
+        options:
+          - Чия це книжка?
+          - Хто це книжка?
+          - Хто є ця книжка?
+        explanation: Ownership uses чия for книжка.
+      - sentence: Who is this book? Хто є ця книжка?
+        error: Хто є ця книжка?
+        answer: Чия це книжка?
+        correction: Чия це книжка?
+        options:
+          - Чия це книжка?
+          - Хто є ця книжка?
+          - Що є ця книжка?
+        explanation: Do not insert є; use the ownership question word.
+      - sentence: I don't believe in nothing. Я не вірю в ніщо.
+        error: Я не вірю в ніщо.
+        answer: Я ні в що не вірю.
+        correction: Я ні в що не вірю.
+        options:
+          - Я ні в що не вірю.
+          - Я не вірю в ніщо.
+          - Я в ніщо не вірю.
+        explanation: A preposition splits ні + що into ні в що.
+      - sentence: I dont know. The learner wrote не + знаю as one word.
+        error: не + знаю written as one word
+        answer: Я не знаю.
+        correction: Я не знаю.
+        options:
+          - Я не знаю.
+          - Я знаю не.
+          - Ні, я знаю.
+        explanation: Не is a separate word before the verb.
+      - sentence: Do you read? Ти читаєш? (without rising intonation).
+        error: Ти читаєш? (без підвищення інтонації)
+        answer: Чи ти читаєш?
+        correction: Чи ти читаєш?
+        options:
+          - Чи ти читаєш?
+          - Ти читаєш.
+          - Ти читати?
+        explanation: If intonation is not clear, чи can mark the question.
+      - sentence: Nowhere. Неде. / Ні де.
+        error: Неде. / Ні де.
+        answer: Ніде.
+        correction: Ніде.
+        options:
+          - Ніде.
+          - Неде.
+          - Ні де.
+        explanation: Ніде is one word.
+      - sentence: Nowhere. Ні де.
+        error: Ні де.
+        answer: Ніде.
+        correction: Ніде.
+        options:
+          - Ніде.
+          - Ні де.
+          - Не де.
+        explanation: Write ніде together.
+      - sentence: How is this soup? Як є цей суп? / Як цей суп?
+        error: Як є цей суп? / Як цей суп?
+        answer: Який цей суп?
+        correction: Який цей суп?
+        options:
+          - Який цей суп?
+          - Як є цей суп?
+          - Як цей суп?
+        explanation: Quality uses який.
+      - sentence: How is this soup? Як цей суп?
+        error: Як цей суп?
+        answer: Який цей суп?
+        correction: Який цей суп?
+        options:
+          - Який цей суп?
+          - Як цей суп?
+          - Що цей суп?
+        explanation: Як asks manner; який asks quality.

--- a/curriculum/l2-uk-en/a1/questions/module.md
+++ b/curriculum/l2-uk-en/a1/questions/module.md
@@ -144,8 +144,6 @@ after a preposition.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Підсумок
 
 You now have three small tools for everyday questions. First, start with a
@@ -187,9 +185,3 @@ it with rising intonation. If the sentence is negative, find the verb and put
 Keep the active set small. Produce **хто, що, де, куди, коли, чому, як** and
 **не + verb**. Recognize **чи**, **який**, **чий**, **котрий**, and the split
 shape **ні в що**, but do not make them your main production task today.
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/verbs-group-one/activities.yaml
+++ b/curriculum/l2-uk-en/a1/verbs-group-one/activities.yaml
@@ -1,280 +1,278 @@
-- id: act-1
-  type: quiz
-  title: Hear Group One
-  instruction: Choose the safe present-tense Ukrainian line.
-  items:
-    - prompt: I read a text.
-      options:
-        - text: Я читаю текст.
-          correct: true
-        - text: Я читати текст.
-          correct: false
-        - text: Я читаєш текст.
-          correct: false
-      explanation: Я uses читаю.
-    - prompt: You read a book.
-      options:
-        - text: Ти читаєш книгу.
-          correct: true
-        - text: Ти читаю книгу.
-          correct: false
-        - text: Ти читати книгу.
-          correct: false
-      explanation: Ти uses читаєш.
-    - prompt: She listens to music.
-      options:
-        - text: Вона слухає музику.
-          correct: true
-        - text: Вона слухаю музику.
-          correct: false
-        - text: Вона слухати музику.
-          correct: false
-      explanation: Вона uses слухає.
-- id: act-2
-  type: match-up
-  title: Читати table
-  instruction: Match the person with the Group One form.
-  pairs:
-    - left: я
-      right: читаю
-    - left: ти
-      right: читаєш
-    - left: він / вона
-      right: читає
-    - left: ми
-      right: читаємо
-    - left: ви
-      right: читаєте
-    - left: вони
-      right: читають
-- id: act-3
-  type: fill-in
-  title: Build with читати
-  instruction: Choose the present-tense form that fits the person.
-  items:
-    - sentence: Я ___ текст.
-      answer: читаю
-      options:
-        - читаю
-        - читаєш
-        - читає
-      explanation: Я uses читаю.
-    - sentence: Ти ___ книгу?
-      answer: читаєш
-      options:
-        - читаєш
-        - читаю
-        - читаємо
-      explanation: Ти uses читаєш.
-    - sentence: Вона ___.
-      answer: читає
-      options:
-        - читає
-        - читаєте
-        - читають
-      explanation: Вона uses читає.
-    - sentence: Ми ___ текст.
-      answer: читаємо
-      options:
-        - читаємо
-        - читаєте
-        - читають
-      explanation: Ми uses читаємо.
-    - sentence: Ви ___?
-      answer: читаєте
-      options:
-        - читаєте
-        - читаємо
-        - читають
-      explanation: Ви uses читаєте.
-    - sentence: Вони ___.
-      answer: читають
-      options:
-        - читають
-        - читає
-        - читаю
-      explanation: Вони uses читають.
-- id: act-4
-  type: fill-in
-  title: Знати and розуміти
-  instruction: Complete each short sentence.
-  items:
-    - sentence: Я ___ це слово.
-      answer: знаю
-      options:
-        - знаю
-        - знаєш
-        - знає
-      explanation: Я знаю.
-    - sentence: Ти ___ Київ?
-      answer: знаєш
-      options:
-        - знаєш
-        - знаю
-        - знають
-      explanation: Ти знаєш.
-    - sentence: Вона ___ відповідь.
-      answer: знає
-      options:
-        - знає
-        - знаєте
-        - знаємо
-      explanation: Вона знає.
-    - sentence: Я ___.
-      answer: розумію
-      options:
-        - розумію
-        - розумієш
-        - розуміє
-      explanation: Я розумію.
-    - sentence: Ти ___?
-      answer: розумієш
-      options:
-        - розумієш
-        - розумію
-        - розуміють
-      explanation: Ти розумієш.
-- id: act-5
-  type: group-sort
-  title: Who uses which ending
-  instruction: Sort the forms by person.
-  groups:
-    - name: Я
-      items:
-        - читаю
-        - знаю
-        - працюю
-    - name: Ти
-      items:
-        - читаєш
-        - знаєш
-        - працюєш
-    - name: Він / вона
-      items:
-        - читає
-        - знає
-        - працює
-    - name: Ми / ви / вони
-      items:
-        - читаємо
-        - читаєте
-        - читають
-- id: act-6
-  type: fill-in
-  title: Працювати and готувати
-  instruction: Choose the whole present-tense form.
-  items:
-    - sentence: Я ___ вдома.
-      answer: працюю
-      options:
-        - працюю
-        - працюєш
-        - працює
-      explanation: Я працюю.
-    - sentence: Ти ___ вечерю?
-      answer: готуєш
-      options:
-        - готуєш
-        - готую
-        - готує
-      explanation: Ти готуєш.
-    - sentence: Ми ___ каву.
-      answer: готуємо
-      options:
-        - готуємо
-        - готуєте
-        - готують
-      explanation: Ми готуємо.
-    - sentence: Вони ___ сьогодні.
-      answer: працюють
-      options:
-        - працюють
-        - працює
-        - працюю
-      explanation: Вони працюють.
-- id: act-7
-  type: error-correction
-  title: Repair Group One traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: group-one-repairs
-  items:
-    - sentence: Я є читаю книжку.
-      error: Я є читаю книжку.
-      answer: Я читаю книжку.
-      options:
-        - Я читаю книжку.
-        - Я читаю текст.
-        - Я знаю книжку.
-      explanation: Ukrainian does not add a separate am word before читаю.
-    - sentence: Я працюваю в школі.
-      error: Я працюваю в школі.
-      answer: Я працюю в школі.
-      options:
-        - Я працюю в школі.
-        - Я працюю вдома.
-        - Я читаю в школі.
-      explanation: Працювати gives працюю, not an extra -ва- form.
-    - sentence: Він розумієть мене.
-      error: Він розумієть мене.
-      answer: Він розуміє мене.
-      options:
-        - Він розуміє мене.
-        - Він знає мене.
-        - Він читає текст.
-      explanation: Він uses розуміє.
-    - sentence: Ти відпочиєш вдома?
-      error: Ти відпочиєш вдома?
-      answer: Ти відпочиваєш вдома?
-      options:
-        - Ти відпочиваєш вдома?
-        - Ти гуляєш вдома?
-        - Ти працюєш вдома?
-      explanation: Present-tense відпочивати gives відпочиваєш.
-    - sentence: Ми читаєм текст.
-      error: Ми читаєм текст.
-      answer: Ми читаємо текст.
-      options:
-        - Ми читаємо текст.
-        - Ми знаємо текст.
-        - Ми слухаємо текст.
-      explanation: Use the full -ємо ending.
-    - sentence: Ти плавиш в басейні?
-      error: Ти плавиш в басейні?
-      answer: Ти плаваєш в басейні?
-      options:
-        - Ти плаваєш в басейні?
-        - Ти гуляєш в басейні?
-        - Ти читаєш в басейні?
-      explanation: Плавати follows Group One here, so use плаваєш.
-- id: act-8
-  type: quiz
-  title: Mini conversation
-  instruction: Choose the best next line.
-  items:
-    - prompt: Що ти читаєш?
-      options:
-        - text: Я читаю текст.
-          correct: true
-        - text: Я читаєш текст.
-          correct: false
-        - text: Я читати текст.
-          correct: false
-      explanation: Я читаю is the safe answer.
-    - prompt: Ти знаєш це слово?
-      options:
-        - text: Так, я знаю це слово.
-          correct: true
-        - text: Так, я знаєш це слово.
-          correct: false
-        - text: Так, я знати це слово.
-          correct: false
-      explanation: Я знаю.
-    - prompt: Ми готуємо вечерю?
-      options:
-        - text: Так, ми готуємо вечерю.
-          correct: true
-        - text: Так, ми готуєте вечерю.
-          correct: false
-        - text: Так, ми готують вечерю.
-          correct: false
-      explanation: Ми готуємо.
+inline:
+  - id: act-1
+    type: quiz
+    title: Hear Group One
+    instruction: Choose the safe present-tense Ukrainian line.
+    items:
+      - prompt: I read a text.
+        options:
+          - text: Я читаю текст.
+            correct: true
+          - text: Я читати текст.
+            correct: false
+          - text: Я читаєш текст.
+            correct: false
+        explanation: Я uses читаю.
+      - prompt: You read a book.
+        options:
+          - text: Ти читаєш книгу.
+            correct: true
+          - text: Ти читаю книгу.
+            correct: false
+          - text: Ти читати книгу.
+            correct: false
+        explanation: Ти uses читаєш.
+      - prompt: She listens to music.
+        options:
+          - text: Вона слухає музику.
+            correct: true
+          - text: Вона слухаю музику.
+            correct: false
+          - text: Вона слухати музику.
+            correct: false
+        explanation: Вона uses слухає.
+  - id: act-2
+    type: match-up
+    title: Читати table
+    instruction: Match the person with the Group One form.
+    pairs:
+      - left: я
+        right: читаю
+      - left: ти
+        right: читаєш
+      - left: він / вона
+        right: читає
+      - left: ми
+        right: читаємо
+      - left: ви
+        right: читаєте
+      - left: вони
+        right: читають
+  - id: act-3
+    type: fill-in
+    title: Build with читати
+    instruction: Choose the present-tense form that fits the person.
+    items:
+      - sentence: Я ___ текст.
+        answer: читаю
+        options:
+          - читаю
+          - читаєш
+          - читає
+        explanation: Я uses читаю.
+      - sentence: Ти ___ книгу?
+        answer: читаєш
+        options:
+          - читаєш
+          - читаю
+          - читаємо
+        explanation: Ти uses читаєш.
+      - sentence: Вона ___.
+        answer: читає
+        options:
+          - читає
+          - читаєте
+          - читають
+        explanation: Вона uses читає.
+      - sentence: Ми ___ текст.
+        answer: читаємо
+        options:
+          - читаємо
+          - читаєте
+          - читають
+        explanation: Ми uses читаємо.
+      - sentence: Ви ___?
+        answer: читаєте
+        options:
+          - читаєте
+          - читаємо
+          - читають
+        explanation: Ви uses читаєте.
+      - sentence: Вони ___.
+        answer: читають
+        options:
+          - читають
+          - читає
+          - читаю
+        explanation: Вони uses читають.
+  - id: act-4
+    type: fill-in
+    title: Знати and розуміти
+    instruction: Complete each short sentence.
+    items:
+      - sentence: Я ___ це слово.
+        answer: знаю
+        options:
+          - знаю
+          - знаєш
+          - знає
+        explanation: Я знаю.
+      - sentence: Ти ___ Київ?
+        answer: знаєш
+        options:
+          - знаєш
+          - знаю
+          - знають
+        explanation: Ти знаєш.
+      - sentence: Вона ___ відповідь.
+        answer: знає
+        options:
+          - знає
+          - знаєте
+          - знаємо
+        explanation: Вона знає.
+      - sentence: Я ___.
+        answer: розумію
+        options:
+          - розумію
+          - розумієш
+          - розуміє
+        explanation: Я розумію.
+      - sentence: Ти ___?
+        answer: розумієш
+        options:
+          - розумієш
+          - розумію
+          - розуміють
+        explanation: Ти розумієш.
+workbook:
+  - type: group-sort
+    title: Who uses which ending
+    instruction: Sort the forms by person.
+    groups:
+      - name: Я
+        items:
+          - читаю
+          - знаю
+          - працюю
+      - name: Ти
+        items:
+          - читаєш
+          - знаєш
+          - працюєш
+      - name: Він / вона
+        items:
+          - читає
+          - знає
+          - працює
+      - name: Ми / ви / вони
+        items:
+          - читаємо
+          - читаєте
+          - читають
+  - type: fill-in
+    title: Працювати and готувати
+    instruction: Choose the whole present-tense form.
+    items:
+      - sentence: Я ___ вдома.
+        answer: працюю
+        options:
+          - працюю
+          - працюєш
+          - працює
+        explanation: Я працюю.
+      - sentence: Ти ___ вечерю?
+        answer: готуєш
+        options:
+          - готуєш
+          - готую
+          - готує
+        explanation: Ти готуєш.
+      - sentence: Ми ___ каву.
+        answer: готуємо
+        options:
+          - готуємо
+          - готуєте
+          - готують
+        explanation: Ми готуємо.
+      - sentence: Вони ___ сьогодні.
+        answer: працюють
+        options:
+          - працюють
+          - працює
+          - працюю
+        explanation: Вони працюють.
+  - type: error-correction
+    title: Repair Group One traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: group-one-repairs
+    items:
+      - sentence: Я є читаю книжку.
+        error: Я є читаю книжку.
+        answer: Я читаю книжку.
+        options:
+          - Я читаю книжку.
+          - Я читаю текст.
+          - Я знаю книжку.
+        explanation: Ukrainian does not add a separate am word before читаю.
+      - sentence: Я працюваю в школі.
+        error: Я працюваю в школі.
+        answer: Я працюю в школі.
+        options:
+          - Я працюю в школі.
+          - Я працюю вдома.
+          - Я читаю в школі.
+        explanation: Працювати gives працюю, not an extra -ва- form.
+      - sentence: Він розумієть мене.
+        error: Він розумієть мене.
+        answer: Він розуміє мене.
+        options:
+          - Він розуміє мене.
+          - Він знає мене.
+          - Він читає текст.
+        explanation: Він uses розуміє.
+      - sentence: Ти відпочиєш вдома?
+        error: Ти відпочиєш вдома?
+        answer: Ти відпочиваєш вдома?
+        options:
+          - Ти відпочиваєш вдома?
+          - Ти гуляєш вдома?
+          - Ти працюєш вдома?
+        explanation: Present-tense відпочивати gives відпочиваєш.
+      - sentence: Ми читаєм текст.
+        error: Ми читаєм текст.
+        answer: Ми читаємо текст.
+        options:
+          - Ми читаємо текст.
+          - Ми знаємо текст.
+          - Ми слухаємо текст.
+        explanation: Use the full -ємо ending.
+      - sentence: Ти плавиш в басейні?
+        error: Ти плавиш в басейні?
+        answer: Ти плаваєш в басейні?
+        options:
+          - Ти плаваєш в басейні?
+          - Ти гуляєш в басейні?
+          - Ти читаєш в басейні?
+        explanation: Плавати follows Group One here, so use плаваєш.
+  - type: quiz
+    title: Mini conversation
+    instruction: Choose the best next line.
+    items:
+      - prompt: Що ти читаєш?
+        options:
+          - text: Я читаю текст.
+            correct: true
+          - text: Я читаєш текст.
+            correct: false
+          - text: Я читати текст.
+            correct: false
+        explanation: Я читаю is the safe answer.
+      - prompt: Ти знаєш це слово?
+        options:
+          - text: Так, я знаю це слово.
+            correct: true
+          - text: Так, я знаєш це слово.
+            correct: false
+          - text: Так, я знати це слово.
+            correct: false
+        explanation: Я знаю.
+      - prompt: Ми готуємо вечерю?
+        options:
+          - text: Так, ми готуємо вечерю.
+            correct: true
+          - text: Так, ми готуєте вечерю.
+            correct: false
+          - text: Так, ми готують вечерю.
+            correct: false
+        explanation: Ми готуємо.

--- a/curriculum/l2-uk-en/a1/verbs-group-one/module.md
+++ b/curriculum/l2-uk-en/a1/verbs-group-one/module.md
@@ -132,8 +132,6 @@ If you hesitate, ask two questions:
 1. Who is doing it: **я, ти, він/вона, ми, ви, вони**?
 2. Which ending fits: **-ю, -єш, -є, -ємо, -єте, -ють**?
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ### Працювати and готувати
 
 Some Group One verbs end in **-увати** or **-ювати**. This is **Тип
@@ -174,8 +172,6 @@ read" both fit **Я читаю** in this beginner context. The time word can com
 later: **Я читаю сьогодні**, **Ми працюємо сьогодні**, **Вони гуляють
 сьогодні**. Your main signal is still the verb ending.
 
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ### Later: future forms
 
 Ukrainian also has future forms. You may see grammar labels such as
@@ -186,8 +182,6 @@ present tense:
 - **Я читаю.**
 - **Ти читаєш.**
 - **Ми читаємо.**
-
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ## Підсумок
 
@@ -229,5 +223,3 @@ look for **-єш**: **читаєш**, **знаєш**, **працюєш**, **го
 subject is **ми**, say the full **-ємо** ending: **читаємо**, **знаємо**,
 **працюємо**, **готуємо**. These four quick checks make your first Group One
 sentences sound complete.
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/verbs-group-two/activities.yaml
+++ b/curriculum/l2-uk-en/a1/verbs-group-two/activities.yaml
@@ -1,281 +1,279 @@
-- id: act-1
-  type: quiz
-  title: Group Two warm-up
-  instruction: Choose the safe Group Two line.
-  items:
-    - prompt: I speak Ukrainian.
-      options:
-        - text: Я говорю українською.
-          correct: true
-        - text: Я говориш українською.
-          correct: false
-        - text: Я говорити українською.
-          correct: false
-      explanation: Я uses говорю.
-    - prompt: You see the word.
-      options:
-        - text: Ти бачиш слово.
-          correct: true
-        - text: Ти бачу слово.
-          correct: false
-        - text: Ти бачити слово.
-          correct: false
-      explanation: Ти uses бачиш.
-    - prompt: They are doing an exercise.
-      options:
-        - text: Вони роблять вправу.
-          correct: true
-        - text: Вони роблять вправа.
-          correct: false
-        - text: Вони робити вправу.
-          correct: false
-      explanation: Вони роблять is the Group Two form.
-- id: act-2
-  type: match-up
-  title: Говорити table
-  instruction: Match the person with the present-tense form.
-  pairs:
-    - left: я
-      right: говорю
-    - left: ти
-      right: говориш
-    - left: він / вона
-      right: говорить
-    - left: ми
-      right: говоримо
-    - left: ви
-      right: говорите
-    - left: вони
-      right: говорять
-- id: act-3
-  type: fill-in
-  title: Говорити, робити, бачити
-  instruction: Choose the form that fits the person.
-  items:
-    - sentence: Я ___ українською.
-      answer: говорю
-      options:
-        - говорю
-        - говориш
-        - говорить
-      explanation: Я говорю.
-    - sentence: Ти ___ українською?
-      answer: говориш
-      options:
-        - говориш
-        - говорю
-        - говоримо
-      explanation: Ти говориш.
-    - sentence: Він ___.
-      answer: говорить
-      options:
-        - говорить
-        - говорите
-        - говорять
-      explanation: Він говорить.
-    - sentence: Я ___ вправу.
-      answer: роблю
-      options:
-        - роблю
-        - робиш
-        - робить
-      explanation: Я роблю is a ready chunk.
-    - sentence: Ти ___ слово?
-      answer: бачиш
-      options:
-        - бачиш
-        - бачу
-        - бачить
-      explanation: Ти бачиш.
-    - sentence: Вони ___ слово.
-      answer: бачать
-      options:
-        - бачать
-        - бачиш
-        - бачу
-      explanation: Вони бачать.
-- id: act-4
-  type: group-sort
-  title: Group One or Group Two
-  instruction: Sort the they-forms by group.
-  groups:
-    - name: І дієвідміна / Group One
-      items:
-        - читають
-        - слухають
-        - гуляють
-    - name: ІІ дієвідміна / Group Two
-      items:
-        - говорять
-        - роблять
-        - бачать
-        - ходять
-        - стоять
-        - сидять
-- id: act-5
-  type: fill-in
-  title: Ready я chunks
-  instruction: Choose the ready first-person chunk.
-  items:
-    - sentence: Я ___ вправу.
-      answer: роблю
-      options:
-        - роблю
-        - робиш
-        - робить
-      explanation: Learn я роблю as a chunk.
-    - sentence: Я ___ до школи.
-      answer: ходжу
-      options:
-        - ходжу
-        - ходиш
-        - ходить
-      explanation: Learn я ходжу as a chunk.
-    - sentence: Я ___ каву.
-      answer: прошу
-      options:
-        - прошу
-        - просиш
-        - просить
-      explanation: Learn я прошу as a chunk.
-    - sentence: Я ___ тут.
-      answer: сиджу
-      options:
-        - сиджу
-        - сидиш
-        - сидить
-      explanation: Learn я сиджу as a chunk.
-- id: act-6
-  type: quiz
-  title: Recognition-only forms
-  instruction: Choose the form you should recognize, not overbuild.
-  items:
-    - prompt: They sleep.
-      options:
-        - text: Вони сплять.
-          correct: true
-        - text: Вони спати.
-          correct: false
-        - text: Вони спить.
-          correct: false
-      explanation: Recognize вони сплять.
-    - prompt: You eat.
-      options:
-        - text: Ти їси.
-          correct: true
-        - text: Ти їсть.
-          correct: false
-        - text: Ти їдять.
-          correct: false
-      explanation: Recognize ти їси.
-    - prompt: They eat.
-      options:
-        - text: Вони їдять.
-          correct: true
-        - text: Вони їси.
-          correct: false
-        - text: Вони їсть.
-          correct: false
-      explanation: Recognize вони їдять.
-- id: act-7
-  type: error-correction
-  title: Repair Group Two traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: group-two-repairs
-  items:
-    - sentence: Вони робуть
-      error: Вони робуть
-      answer: Вони роблять
-      options:
-        - Вони роблять
-        - Вони працюють
-        - Вони читають
-      explanation: Робити uses вони роблять.
-    - sentence: Ти бачеш
-      error: Ти бачеш
-      answer: Ти бачиш
-      options:
-        - Ти бачиш
-        - Ти говориш
-        - Ти робиш
-      explanation: Group Two uses бачиш.
-    - sentence: Я сидю
-      error: Я сидю
-      answer: Я сиджу
-      options:
-        - Я сиджу
-        - Я ходжу
-        - Я бачу
-      explanation: Learn я сиджу as a ready chunk.
-    - sentence: Він стоє
-      error: Він стоє
-      answer: Він стоїть
-      options:
-        - Він стоїть
-        - Він сидить
-        - Він говорить
-      explanation: Стояти gives він стоїть.
-    - sentence: Я сплю, ти сплєш
-      error: Я сплю, ти сплєш
-      answer: Я сплю, ти спиш
-      options:
-        - Я сплю, ти спиш
-        - Я сплю, ти їси
-        - Я сплю, ти сидиш
-      explanation: Recognize ти спиш; do not invent the form.
-    - sentence: Я є студент
-      error: Я є студент
-      answer: Я студент
-      options:
-        - Я студент
-        - Я вчитель
-        - Я Томас
-      explanation: Ukrainian can use Я студент without є.
-    - sentence: Моє ім'я є Томас
-      error: Моє ім'я є Томас
-      answer: Мене звати Томас
-      options:
-        - Мене звати Томас
-        - Я студент Томас
-        - Це Томас
-      explanation: Use Мене звати for names.
-    - sentence: Я маю 20 років
-      error: Я маю 20 років
-      answer: Мені 20 років
-      options:
-        - Мені 20 років
-        - Я студент 20 років
-        - Це 20 років
-      explanation: Use Мені plus age.
-- id: act-8
-  type: quiz
-  title: Mini conversation
-  instruction: Choose the best next line.
-  items:
-    - prompt: Ти говориш українською?
-      options:
-        - text: Так, я говорю українською.
-          correct: true
-        - text: Так, я говориш українською.
-          correct: false
-        - text: Так, я говорити українською.
-          correct: false
-      explanation: Я говорю.
-    - prompt: Що ти робиш?
-      options:
-        - text: Я роблю вправу.
-          correct: true
-        - text: Я робиш вправу.
-          correct: false
-        - text: Я робити вправу.
-          correct: false
-      explanation: Я роблю is the safe answer.
-    - prompt: Ти бачиш це слово?
-      options:
-        - text: Так, я бачу це слово.
-          correct: true
-        - text: Так, я бачиш це слово.
-          correct: false
-        - text: Так, я бачити це слово.
-          correct: false
-      explanation: Я бачу.
+inline:
+  - id: act-1
+    type: quiz
+    title: Group Two warm-up
+    instruction: Choose the safe Group Two line.
+    items:
+      - prompt: I speak Ukrainian.
+        options:
+          - text: Я говорю українською.
+            correct: true
+          - text: Я говориш українською.
+            correct: false
+          - text: Я говорити українською.
+            correct: false
+        explanation: Я uses говорю.
+      - prompt: You see the word.
+        options:
+          - text: Ти бачиш слово.
+            correct: true
+          - text: Ти бачу слово.
+            correct: false
+          - text: Ти бачити слово.
+            correct: false
+        explanation: Ти uses бачиш.
+      - prompt: They are doing an exercise.
+        options:
+          - text: Вони роблять вправу.
+            correct: true
+          - text: Вони роблять вправа.
+            correct: false
+          - text: Вони робити вправу.
+            correct: false
+        explanation: Вони роблять is the Group Two form.
+  - id: act-2
+    type: match-up
+    title: Говорити table
+    instruction: Match the person with the present-tense form.
+    pairs:
+      - left: я
+        right: говорю
+      - left: ти
+        right: говориш
+      - left: він / вона
+        right: говорить
+      - left: ми
+        right: говоримо
+      - left: ви
+        right: говорите
+      - left: вони
+        right: говорять
+  - id: act-3
+    type: fill-in
+    title: Говорити, робити, бачити
+    instruction: Choose the form that fits the person.
+    items:
+      - sentence: Я ___ українською.
+        answer: говорю
+        options:
+          - говорю
+          - говориш
+          - говорить
+        explanation: Я говорю.
+      - sentence: Ти ___ українською?
+        answer: говориш
+        options:
+          - говориш
+          - говорю
+          - говоримо
+        explanation: Ти говориш.
+      - sentence: Він ___.
+        answer: говорить
+        options:
+          - говорить
+          - говорите
+          - говорять
+        explanation: Він говорить.
+      - sentence: Я ___ вправу.
+        answer: роблю
+        options:
+          - роблю
+          - робиш
+          - робить
+        explanation: Я роблю is a ready chunk.
+      - sentence: Ти ___ слово?
+        answer: бачиш
+        options:
+          - бачиш
+          - бачу
+          - бачить
+        explanation: Ти бачиш.
+      - sentence: Вони ___ слово.
+        answer: бачать
+        options:
+          - бачать
+          - бачиш
+          - бачу
+        explanation: Вони бачать.
+  - id: act-4
+    type: group-sort
+    title: Group One or Group Two
+    instruction: Sort the they-forms by group.
+    groups:
+      - name: І дієвідміна / Group One
+        items:
+          - читають
+          - слухають
+          - гуляють
+      - name: ІІ дієвідміна / Group Two
+        items:
+          - говорять
+          - роблять
+          - бачать
+          - ходять
+          - стоять
+          - сидять
+workbook:
+  - type: fill-in
+    title: Ready я chunks
+    instruction: Choose the ready first-person chunk.
+    items:
+      - sentence: Я ___ вправу.
+        answer: роблю
+        options:
+          - роблю
+          - робиш
+          - робить
+        explanation: Learn я роблю as a chunk.
+      - sentence: Я ___ до школи.
+        answer: ходжу
+        options:
+          - ходжу
+          - ходиш
+          - ходить
+        explanation: Learn я ходжу as a chunk.
+      - sentence: Я ___ каву.
+        answer: прошу
+        options:
+          - прошу
+          - просиш
+          - просить
+        explanation: Learn я прошу as a chunk.
+      - sentence: Я ___ тут.
+        answer: сиджу
+        options:
+          - сиджу
+          - сидиш
+          - сидить
+        explanation: Learn я сиджу as a chunk.
+  - type: quiz
+    title: Recognition-only forms
+    instruction: Choose the form you should recognize, not overbuild.
+    items:
+      - prompt: They sleep.
+        options:
+          - text: Вони сплять.
+            correct: true
+          - text: Вони спати.
+            correct: false
+          - text: Вони спить.
+            correct: false
+        explanation: Recognize вони сплять.
+      - prompt: You eat.
+        options:
+          - text: Ти їси.
+            correct: true
+          - text: Ти їсть.
+            correct: false
+          - text: Ти їдять.
+            correct: false
+        explanation: Recognize ти їси.
+      - prompt: They eat.
+        options:
+          - text: Вони їдять.
+            correct: true
+          - text: Вони їси.
+            correct: false
+          - text: Вони їсть.
+            correct: false
+        explanation: Recognize вони їдять.
+  - type: error-correction
+    title: Repair Group Two traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: group-two-repairs
+    items:
+      - sentence: Вони робуть
+        error: Вони робуть
+        answer: Вони роблять
+        options:
+          - Вони роблять
+          - Вони працюють
+          - Вони читають
+        explanation: Робити uses вони роблять.
+      - sentence: Ти бачеш
+        error: Ти бачеш
+        answer: Ти бачиш
+        options:
+          - Ти бачиш
+          - Ти говориш
+          - Ти робиш
+        explanation: Group Two uses бачиш.
+      - sentence: Я сидю
+        error: Я сидю
+        answer: Я сиджу
+        options:
+          - Я сиджу
+          - Я ходжу
+          - Я бачу
+        explanation: Learn я сиджу as a ready chunk.
+      - sentence: Він стоє
+        error: Він стоє
+        answer: Він стоїть
+        options:
+          - Він стоїть
+          - Він сидить
+          - Він говорить
+        explanation: Стояти gives він стоїть.
+      - sentence: Я сплю, ти сплєш
+        error: Я сплю, ти сплєш
+        answer: Я сплю, ти спиш
+        options:
+          - Я сплю, ти спиш
+          - Я сплю, ти їси
+          - Я сплю, ти сидиш
+        explanation: Recognize ти спиш; do not invent the form.
+      - sentence: Я є студент
+        error: Я є студент
+        answer: Я студент
+        options:
+          - Я студент
+          - Я вчитель
+          - Я Томас
+        explanation: Ukrainian can use Я студент without є.
+      - sentence: Моє ім'я є Томас
+        error: Моє ім'я є Томас
+        answer: Мене звати Томас
+        options:
+          - Мене звати Томас
+          - Я студент Томас
+          - Це Томас
+        explanation: Use Мене звати for names.
+      - sentence: Я маю 20 років
+        error: Я маю 20 років
+        answer: Мені 20 років
+        options:
+          - Мені 20 років
+          - Я студент 20 років
+          - Це 20 років
+        explanation: Use Мені plus age.
+  - type: quiz
+    title: Mini conversation
+    instruction: Choose the best next line.
+    items:
+      - prompt: Ти говориш українською?
+        options:
+          - text: Так, я говорю українською.
+            correct: true
+          - text: Так, я говориш українською.
+            correct: false
+          - text: Так, я говорити українською.
+            correct: false
+        explanation: Я говорю.
+      - prompt: Що ти робиш?
+        options:
+          - text: Я роблю вправу.
+            correct: true
+          - text: Я робиш вправу.
+            correct: false
+          - text: Я робити вправу.
+            correct: false
+        explanation: Я роблю is the safe answer.
+      - prompt: Ти бачиш це слово?
+        options:
+          - text: Так, я бачу це слово.
+            correct: true
+          - text: Так, я бачиш це слово.
+            correct: false
+          - text: Так, я бачити це слово.
+            correct: false
+        explanation: Я бачу.

--- a/curriculum/l2-uk-en/a1/verbs-group-two/module.md
+++ b/curriculum/l2-uk-en/a1/verbs-group-two/module.md
@@ -148,8 +148,6 @@ short present-tense chunks:
 <DialogueBox uk="Вони стоять." en="They are standing." />
 <DialogueBox uk="Вони сидять." en="They are sitting." />
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ### More useful Group Two chunks
 
 Use these in small sentences:
@@ -168,8 +166,6 @@ You already know **любити** from preferences. Now you can recognize why
 <DialogueBox uk="Ти просиш каву?" en="Are you asking for coffee?" />
 <DialogueBox uk="Ми вчимо українську." en="We are learning Ukrainian." />
 <DialogueBox uk="Вони люблять музику." en="They like music." />
-
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ### Recognition-only exceptions
 
@@ -191,8 +187,6 @@ The recognition-only list protects your active practice. You can understand
 **вони сплять** or **ти їси** when you meet them, but your speaking task stays
 with the regular Group Two chunks above. This keeps the lesson useful without
 turning every exception into a table.
-
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ## Підсумок
 
@@ -224,5 +218,3 @@ Repair the common traps by choosing the ready Ukrainian form:
 | old identity pattern | **Я студент.** |
 | English-style name phrase | **Мене звати Томас.** |
 | English-style age phrase | **Мені 20 років.** |
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/what-i-like/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-i-like/activities.yaml
@@ -1,277 +1,275 @@
-- id: act-1
-  type: quiz
-  title: Preference warm-up
-  instruction: Choose the safe Ukrainian line.
-  items:
-    - prompt: I like to read.
-      options:
-        - text: Я люблю читати.
-          correct: true
-        - text: Я люблю читаю.
-          correct: false
-        - text: Я подобається читати.
-          correct: false
-      explanation: Use Я люблю plus the -ти action word.
-    - prompt: I like music.
-      options:
-        - text: Мені подобається музика.
-          correct: true
-        - text: Я подобається музика.
-          correct: false
-        - text: Мені подобається музику.
-          correct: false
-      explanation: Мені подобається is the safe chunk for liking a thing.
-    - prompt: Do you like to cook?
-      options:
-        - text: Ти любиш готувати?
-          correct: true
-        - text: Ти любиш готуєш?
-          correct: false
-        - text: Тобі любиш готувати?
-          correct: false
-      explanation: The question keeps любиш plus an infinitive.
-- id: act-2
-  type: match-up
-  title: Infinitive actions
-  instruction: Match each Ukrainian action word with its meaning.
-  pairs:
-    - left: читати
-      right: to read
-    - left: гуляти
-      right: to walk
-    - left: готувати
-      right: to cook
-    - left: слухати
-      right: to listen
-    - left: дивитися
-      right: to watch
-    - left: грати
-      right: to play
-    - left: малювати
-      right: to draw
-    - left: співати
-      right: to sing
-- id: act-3
-  type: fill-in
-  title: Build Я люблю
-  instruction: Complete each sentence with the safe action word.
-  items:
-    - sentence: Я люблю ___.
-      answer: читати
-      options:
-        - читати
-        - читаю
-        - читаєш
-      explanation: After люблю, use the -ти form.
-    - sentence: Я люблю ___ музику.
-      answer: слухати
-      options:
-        - слухати
-        - слухаю
-        - слухає
-      explanation: Слухати stays in the infinitive.
-    - sentence: Ти любиш ___?
-      answer: готувати
-      options:
-        - готувати
-        - готуєш
-        - готую
-      explanation: Ти любиш also takes the -ти form.
-    - sentence: Вона любить ___.
-      answer: малювати
-      options:
-        - малювати
-        - малює
-        - малюю
-      explanation: Keep the second action as малювати.
-    - sentence: Ми любимо ___.
-      answer: гуляти
-      options:
-        - гуляти
-        - гуляємо
-        - гуляє
-      explanation: Любимо plus infinitive.
-    - sentence: Вони люблять ___.
-      answer: співати
-      options:
-        - співати
-        - співають
-        - співає
-      explanation: Люблять plus infinitive.
-- id: act-4
-  type: group-sort
-  title: Action or thing
-  instruction: Sort the words by the preference pattern they usually use today.
-  groups:
-    - name: Я люблю + action
-      items:
-        - читати
-        - гуляти
-        - готувати
-        - малювати
-    - name: Мені подобається + thing
-      items:
-        - музика
-        - книга
-        - фільм
-        - Київ
-- id: act-5
-  type: quiz
-  title: Люблю or подобається
-  instruction: Choose the sentence that matches the meaning.
-  items:
-    - prompt: I like to walk.
-      options:
-        - text: Я люблю гуляти.
-          correct: true
-        - text: Мені подобається гуляю.
-          correct: false
-        - text: Я люблю гуляю.
-          correct: false
-      explanation: Use Я люблю plus гуляти for an action.
-    - prompt: I like this film.
-      options:
-        - text: Мені подобається цей фільм.
-          correct: true
-        - text: Я подобається цей фільм.
-          correct: false
-        - text: Мені люблю цей фільм.
-          correct: false
-      explanation: Use Мені подобається for a thing.
-    - prompt: I do not like to cook.
-      options:
-        - text: Я не люблю готувати.
-          correct: true
-        - text: Я люблю не готувати.
-          correct: false
-        - text: Я не люблю готую.
-          correct: false
-      explanation: Put не before люблю, then use the -ти action.
-    - prompt: I do not like this book.
-      options:
-        - text: Мені не подобається ця книга.
-          correct: true
-        - text: Мені подобається не ця книга.
-          correct: false
-        - text: Я не подобається ця книга.
-          correct: false
-      explanation: Put не before подобається.
-- id: act-6
-  type: error-correction
-  title: Repair preference traps
-  instruction: Choose the standard Ukrainian repair.
-  anchor_id: repair-traps
-  items:
-    - sentence: Я люблю малюю.
-      error: Я люблю малюю.
-      answer: Я люблю малювати.
-      options:
-        - Я люблю малювати.
-        - Я люблю малюю.
-        - Я подобається малювати.
-      explanation: The second action stays in the -ти form.
-    - sentence: Я люблю музика.
-      error: Я люблю музика.
-      answer: Я люблю музику.
-      options:
-        - Я люблю музику.
-        - Я люблю музика.
-        - Мені люблю музика.
-      explanation: Learn музику as the small object chunk.
-    - sentence: Я подобається це.
-      error: Я подобається це.
-      answer: Мені подобається це.
-      options:
-        - Мені подобається це.
-        - Я подобається це.
-        - Мене подобається це.
-      explanation: Use the ready chunk Мені подобається.
-    - sentence: Це мій любимий спорт.
-      error: Це мій любимий спорт.
-      answer: Це мій улюблений спорт.
-      options:
-        - Це мій улюблений спорт.
-        - Це улюблений спорт.
-        - Це моя улюблена книга.
-      explanation: Use улюблений for favorite things.
-    - sentence: Моє улюблене хобі...
-      error: Моє улюблене хобі...
-      answer: Моє захоплення...
-      options:
-        - Моє захоплення...
-        - Моє улюблене хобі...
-        - Моя улюблена книга...
-      explanation: Моє захоплення is cleaner.
-    - sentence: Я приймаю участь.
-      error: Я приймаю участь.
-      answer: Я беру участь.
-      options:
-        - Я беру участь.
-        - Я приймаю участь.
-        - Я маю участь.
-      explanation: Ukrainian uses брати участь.
-- id: act-7
-  type: fill-in
-  title: Make it negative
-  instruction: Add the missing preference word.
-  items:
-    - sentence: Я ___ люблю готувати.
-      answer: не
-      options:
-        - не
-        - ні
-        - немає
-      explanation: Put не before люблю.
-    - sentence: Мені ___ подобається цей фільм.
-      answer: не
-      options:
-        - не
-        - ні
-        - немає
-      explanation: Put не before подобається.
-    - sentence: Тобі ___ подобається кава?
-      answer: не
-      options:
-        - не
-        - ні
-        - немає
-      explanation: This asks whether you do not like coffee.
-    - sentence: Вони ___ люблять співати.
-      answer: не
-      options:
-        - не
-        - ні
-        - немає
-      explanation: Put не before the preference verb.
-- id: act-8
-  type: quiz
-  title: Your short answer
-  instruction: Choose the best next sentence.
-  items:
-    - prompt: Що ти любиш робити?
-      options:
-        - text: Я люблю читати.
-          correct: true
-        - text: Мені подобається читати.
-          correct: false
-        - text: Я читаєш.
-          correct: false
-      explanation: Answer with Я люблю plus an action.
-    - prompt: Тобі подобається ця книга?
-      options:
-        - text: Так, мені подобається.
-          correct: true
-        - text: Так, я подобається.
-          correct: false
-        - text: Так, мені люблю.
-          correct: false
-      explanation: The short answer keeps мені подобається.
-    - prompt: А ти?
-      options:
-        - text: Я люблю гуляти.
-          correct: true
-        - text: Ти люблю гуляти.
-          correct: false
-        - text: Я любиш гуляти.
-          correct: false
-      explanation: For yourself, use Я люблю.
+inline:
+  - id: act-1
+    type: quiz
+    title: Preference warm-up
+    instruction: Choose the safe Ukrainian line.
+    items:
+      - prompt: I like to read.
+        options:
+          - text: Я люблю читати.
+            correct: true
+          - text: Я люблю читаю.
+            correct: false
+          - text: Я подобається читати.
+            correct: false
+        explanation: Use Я люблю plus the -ти action word.
+      - prompt: I like music.
+        options:
+          - text: Мені подобається музика.
+            correct: true
+          - text: Я подобається музика.
+            correct: false
+          - text: Мені подобається музику.
+            correct: false
+        explanation: Мені подобається is the safe chunk for liking a thing.
+      - prompt: Do you like to cook?
+        options:
+          - text: Ти любиш готувати?
+            correct: true
+          - text: Ти любиш готуєш?
+            correct: false
+          - text: Тобі любиш готувати?
+            correct: false
+        explanation: The question keeps любиш plus an infinitive.
+  - id: act-2
+    type: match-up
+    title: Infinitive actions
+    instruction: Match each Ukrainian action word with its meaning.
+    pairs:
+      - left: читати
+        right: to read
+      - left: гуляти
+        right: to walk
+      - left: готувати
+        right: to cook
+      - left: слухати
+        right: to listen
+      - left: дивитися
+        right: to watch
+      - left: грати
+        right: to play
+      - left: малювати
+        right: to draw
+      - left: співати
+        right: to sing
+  - id: act-3
+    type: fill-in
+    title: Build Я люблю
+    instruction: Complete each sentence with the safe action word.
+    items:
+      - sentence: Я люблю ___.
+        answer: читати
+        options:
+          - читати
+          - читаю
+          - читаєш
+        explanation: After люблю, use the -ти form.
+      - sentence: Я люблю ___ музику.
+        answer: слухати
+        options:
+          - слухати
+          - слухаю
+          - слухає
+        explanation: Слухати stays in the infinitive.
+      - sentence: Ти любиш ___?
+        answer: готувати
+        options:
+          - готувати
+          - готуєш
+          - готую
+        explanation: Ти любиш also takes the -ти form.
+      - sentence: Вона любить ___.
+        answer: малювати
+        options:
+          - малювати
+          - малює
+          - малюю
+        explanation: Keep the second action as малювати.
+      - sentence: Ми любимо ___.
+        answer: гуляти
+        options:
+          - гуляти
+          - гуляємо
+          - гуляє
+        explanation: Любимо plus infinitive.
+      - sentence: Вони люблять ___.
+        answer: співати
+        options:
+          - співати
+          - співають
+          - співає
+        explanation: Люблять plus infinitive.
+  - id: act-4
+    type: group-sort
+    title: Action or thing
+    instruction: Sort the words by the preference pattern they usually use today.
+    groups:
+      - name: Я люблю + action
+        items:
+          - читати
+          - гуляти
+          - готувати
+          - малювати
+      - name: Мені подобається + thing
+        items:
+          - музика
+          - книга
+          - фільм
+          - Київ
+workbook:
+  - type: quiz
+    title: Люблю or подобається
+    instruction: Choose the sentence that matches the meaning.
+    items:
+      - prompt: I like to walk.
+        options:
+          - text: Я люблю гуляти.
+            correct: true
+          - text: Мені подобається гуляю.
+            correct: false
+          - text: Я люблю гуляю.
+            correct: false
+        explanation: Use Я люблю plus гуляти for an action.
+      - prompt: I like this film.
+        options:
+          - text: Мені подобається цей фільм.
+            correct: true
+          - text: Я подобається цей фільм.
+            correct: false
+          - text: Мені люблю цей фільм.
+            correct: false
+        explanation: Use Мені подобається for a thing.
+      - prompt: I do not like to cook.
+        options:
+          - text: Я не люблю готувати.
+            correct: true
+          - text: Я люблю не готувати.
+            correct: false
+          - text: Я не люблю готую.
+            correct: false
+        explanation: Put не before люблю, then use the -ти action.
+      - prompt: I do not like this book.
+        options:
+          - text: Мені не подобається ця книга.
+            correct: true
+          - text: Мені подобається не ця книга.
+            correct: false
+          - text: Я не подобається ця книга.
+            correct: false
+        explanation: Put не before подобається.
+  - type: error-correction
+    title: Repair preference traps
+    instruction: Choose the standard Ukrainian repair.
+    anchor_id: repair-traps
+    items:
+      - sentence: Я люблю малюю.
+        error: Я люблю малюю.
+        answer: Я люблю малювати.
+        options:
+          - Я люблю малювати.
+          - Я люблю малюю.
+          - Я подобається малювати.
+        explanation: The second action stays in the -ти form.
+      - sentence: Я люблю музика.
+        error: Я люблю музика.
+        answer: Я люблю музику.
+        options:
+          - Я люблю музику.
+          - Я люблю музика.
+          - Мені люблю музика.
+        explanation: Learn музику as the small object chunk.
+      - sentence: Я подобається це.
+        error: Я подобається це.
+        answer: Мені подобається це.
+        options:
+          - Мені подобається це.
+          - Я подобається це.
+          - Мене подобається це.
+        explanation: Use the ready chunk Мені подобається.
+      - sentence: Це мій любимий спорт.
+        error: Це мій любимий спорт.
+        answer: Це мій улюблений спорт.
+        options:
+          - Це мій улюблений спорт.
+          - Це улюблений спорт.
+          - Це моя улюблена книга.
+        explanation: Use улюблений for favorite things.
+      - sentence: Моє улюблене хобі...
+        error: Моє улюблене хобі...
+        answer: Моє захоплення...
+        options:
+          - Моє захоплення...
+          - Моє улюблене хобі...
+          - Моя улюблена книга...
+        explanation: Моє захоплення is cleaner.
+      - sentence: Я приймаю участь.
+        error: Я приймаю участь.
+        answer: Я беру участь.
+        options:
+          - Я беру участь.
+          - Я приймаю участь.
+          - Я маю участь.
+        explanation: Ukrainian uses брати участь.
+  - type: fill-in
+    title: Make it negative
+    instruction: Add the missing preference word.
+    items:
+      - sentence: Я ___ люблю готувати.
+        answer: не
+        options:
+          - не
+          - ні
+          - немає
+        explanation: Put не before люблю.
+      - sentence: Мені ___ подобається цей фільм.
+        answer: не
+        options:
+          - не
+          - ні
+          - немає
+        explanation: Put не before подобається.
+      - sentence: Тобі ___ подобається кава?
+        answer: не
+        options:
+          - не
+          - ні
+          - немає
+        explanation: This asks whether you do not like coffee.
+      - sentence: Вони ___ люблять співати.
+        answer: не
+        options:
+          - не
+          - ні
+          - немає
+        explanation: Put не before the preference verb.
+  - type: quiz
+    title: Your short answer
+    instruction: Choose the best next sentence.
+    items:
+      - prompt: Що ти любиш робити?
+        options:
+          - text: Я люблю читати.
+            correct: true
+          - text: Мені подобається читати.
+            correct: false
+          - text: Я читаєш.
+            correct: false
+        explanation: Answer with Я люблю plus an action.
+      - prompt: Тобі подобається ця книга?
+        options:
+          - text: Так, мені подобається.
+            correct: true
+          - text: Так, я подобається.
+            correct: false
+          - text: Так, мені люблю.
+            correct: false
+        explanation: The short answer keeps мені подобається.
+      - prompt: А ти?
+        options:
+          - text: Я люблю гуляти.
+            correct: true
+          - text: Ти люблю гуляти.
+            correct: false
+          - text: Я любиш гуляти.
+            correct: false
+        explanation: For yourself, use Я люблю.

--- a/curriculum/l2-uk-en/a1/what-i-like/module.md
+++ b/curriculum/l2-uk-en/a1/what-i-like/module.md
@@ -153,8 +153,6 @@ productive tools are smaller:
 One more clean Ukrainian chunk matters: **брати участь**. If you mean "take
 part," use **Я беру участь**. Do not build the habit **Я приймаю участь**.
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Підсумок
 
 Keep two preference lanes separate.
@@ -184,9 +182,3 @@ Build a short personal answer:
 | wrong favorite word with **спорт** | **Це мій улюблений спорт.** | use **улюблений** for favorite things |
 | **Моє улюблене хобі...** | **Моє захоплення...** / **Моє хобі...** | avoid the tautology |
 | **Я приймаю участь.** | **Я беру участь.** | Ukrainian uses **брати участь** |
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->


### PR DESCRIPTION
## Summary

Converted the A1 Modules 15-21 activity files from flat V1 lists to V2 top-level `inline:` and `workbook:` lists. The first four light Lesson-tab checks stay inline with matching module markers; the remaining four activities move to idless workbook entries and their module markers were removed.

## Per-module counts

| Module | Inline | Workbook | Total |
| --- | ---: | ---: | ---: |
| what-i-like | 4 | 4 | 8 |
| verbs-group-one | 4 | 4 | 8 |
| verbs-group-two | 4 | 4 | 8 |
| i-want-i-can | 4 | 4 | 8 |
| questions | 4 | 4 | 8 |
| my-morning | 4 | 4 | 8 |
| checkpoint-actions | 4 | 4 | 8 |

## Validation

- Parser check: recorded original vs branch totals for all seven modules; verified V2 shape, marker/id parity, and idless workbook entries.
- Semantic preservation check: activity content and order preserved; only workbook `id` fields removed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 15 --validate` passed; repeated and passed for modules 16, 17, 18, 19, 20, and 21.
- Generated `starlight/src/content/docs/a1/*.mdx` changes from MDX validation were restored and are not committed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py` passed: 118 tests.
- `npx prettier --check` on the seven changed `activities.yaml` files passed.
- `git diff --check` passed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.

Refs #2799