### PR TITLE
[codex] Split A1 M22-M27 activities by tab

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-time-nature/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-time-nature/activities.yaml
@@ -1,302 +1,300 @@
-- id: act-1
-  type: group-sort
-  title: A1.4 skill map
-  instruction: Sort each line by the checkpoint skill it proves.
-  groups:
-    - name: Clock time
-      items:
-        - Котра година?
-        - Зараз сьома.
-        - Зустріч о десятій.
-    - name: Calendar
-      items:
-        - У суботу.
-        - У жовтні.
-        - Влітку.
-    - name: Weather
-      items:
-        - Сьогодні тепло.
-        - Іде дощ.
-        - Надворі хмарно.
-    - name: Free-time plan
-      items:
-        - Ходімо в музей.
-        - Давай слухати музику.
-        - Я часто читаю.
-- id: act-2
-  type: match-up
-  title: Question to checkpoint answer
-  instruction: Match each question with the answer that fits a weekend plan.
-  pairs:
-    - left: Котра година?
-      right: Десята тридцять.
-    - left: О котрій зустріч?
-      right: О першій.
-    - left: Яка сьогодні погода?
-      right: Тепло і сонячно.
-    - left: Коли твій день народження?
-      right: У жовтні.
-    - left: Що ти робиш у суботу?
-      right: Граю у футбол.
-    - left: Як часто ти читаєш?
-      right: Кожен день ввечері.
-    - left: Ходімо в парк!
-      right: Добре, о котрій?
-    - left: Що ти будеш робити завтра?
-      right: Буду працювати.
-- id: act-3
-  type: fill-in
-  title: Weekend plan gaps
-  instruction: Choose the checkpoint chunk that completes the plan.
-  items:
-    - sentence: "Зустріч ___ годині."
-      answer: "о п'ятій"
-      options:
-        - "о п'ятій"
-        - "в п'ятій"
-        - "у п'ята"
-      explanation: Schedule time uses о/об plus the hour chunk.
-    - sentence: "Ми йдемо в кіно ___."
-      answer: у суботу
-      options:
-        - у суботу
-        - в суботі
-        - на суботу
-      explanation: Use у/в plus the day chunk.
-    - sentence: "Мій день народження ___."
-      answer: у січні
-      options:
-        - у січні
-        - в січень
-        - січень
-      explanation: Months answer коли? with у/в plus the month form.
-    - sentence: "Сьогодні ___ і холодно."
-      answer: іде дощ
-      options:
-        - іде дощ
-        - іде дощова
-        - дощить холод
-      explanation: Іде дощ is the safe weather chunk.
-    - sentence: "Взимку дуже ___."
-      answer: холодно
-      options:
-        - холодно
-        - спекотно
-        - тепло
-      explanation: Winter connects naturally with cold weather.
-    - sentence: "Я прокидаюся о сьомій ___."
-      answer: ранку
-      options:
-        - ранку
-        - рано
-        - вранці
-      explanation: Use ранку to clarify 7 AM after the clock time.
-- id: act-4
-  type: quiz
-  title: Build the Saturday trip
-  instruction: Choose the line that fits each part of the travel plan.
-  items:
-    - prompt: "Start with the day and destination."
-      options:
-        - text: "У суботу ми їдемо до Києва."
-          correct: true
-        - text: "На суботу ми їдемо в Київ."
-          correct: false
-        - text: "У суботі ми їдемо Київ."
-          correct: false
-      explanation: Use у суботу and до Києва.
-    - prompt: "Give the meeting time."
-      options:
-        - text: "Зустріч о десятій ранку."
-          correct: true
-        - text: "Зустріч в десять годин."
-          correct: false
-        - text: "Зустріч на десяту ранку."
-          correct: false
-      explanation: Schedule time uses о plus the time chunk.
-    - prompt: "Add the weather."
-      options:
-        - text: "Буде тепло і сонячно."
-          correct: true
-        - text: "Погода буде тепла і сонячна."
-          correct: false
-        - text: "Це є тепло і сонячно."
-          correct: false
-      explanation: Short weather chunks are enough.
-    - prompt: "Add a first action."
-      options:
-        - text: "Спочатку гуляємо в парку."
-          correct: true
-        - text: "На початку ми є гуляємо в парку."
-          correct: false
-        - text: "Перший гуляємо у парк."
-          correct: false
-      explanation: Спочатку connects the action safely.
-    - prompt: "Add a rain alternative."
-      options:
-        - text: "Якщо буде дощ, спочатку йдемо в музей."
-          correct: true
-        - text: "Якщо є дощ, спочатку ходимо до музей."
-          correct: false
-        - text: "Коли дощова, спочатку йдемо музей."
-          correct: false
-      explanation: Якщо буде дощ is the safe condition chunk.
-- id: act-5
-  type: odd-one-out
-  title: Find the unsafe checkpoint chunk
-  instruction: Choose the line that does not fit the safe A1.4 pattern.
-  items:
-    - words:
-        - "Зустріч о п'ятій."
-        - "Фільм о десятій годині."
-        - "Кава об одинадцятій."
-        - "Зустріч в п'ять годин."
-      answer: "Зустріч в п'ять годин."
-      explanation: Schedule time uses о/об.
-    - words:
-        - "Пів на восьму."
-        - "Пів на шосту."
-        - "Чверть на дванадцяту."
-        - "Пів восьмої."
-      answer: "Пів восьмої."
-      explanation: The checkpoint chunk is пів на plus the next hour.
-    - words:
-        - "Іде дощ."
-        - "Сьогодні тепло."
-        - "Надворі хмарно."
-        - "Він іде дощ."
-      answer: "Він іде дощ."
-      explanation: Weather can be an impersonal Ukrainian sentence.
-    - words:
-        - "Взимку."
-        - "Навесні."
-        - "Влітку."
-        - "Весною."
-      answer: "Весною."
-      explanation: Навесні is the safe A1 season chunk in this checkpoint.
-    - words:
-        - "Я студент."
-        - "Мені 20 років."
-        - "Він спортсмен."
-        - "Я є студент."
-      answer: "Я є студент."
-      explanation: Ukrainian normally omits the present-tense helper here.
-- id: act-6
-  type: true-false
-  title: Checkpoint readiness checks
-  instruction: Decide whether each line is ready for an A1.4 checkpoint answer.
-  items:
-    - statement: "У суботу о десятій ходімо в парк."
-      answer: true
-      explanation: Day plus time plus invitation is a complete plan.
-    - statement: "Влітку часто тепло і сонячно."
-      answer: true
-      explanation: Влітку is the safe season chunk.
-    - statement: "Я працюю з дев'ятої до п'ятої."
-      answer: true
-      explanation: This workday range is useful and safe at A1.
-    - statement: "Сьогодні холодно, тому я читаю вдома."
-      answer: true
-      explanation: Weather plus reason plus action is a good checkpoint line.
-    - statement: "Мені подобається весна."
-      answer: true
-      explanation: Мені подобається is the safe preference chunk.
-    - statement: "О першій ходімо в музей."
-      answer: true
-      explanation: The schedule chunk о першій combines naturally with an invitation.
-- id: act-7
-  type: unjumble
-  title: Rebuild integrated checkpoint lines
-  instruction: Put the words in a safe A1.4 order.
-  items:
-    - words:
-        - У
-        - суботу
-        - о
-        - десятій
-        - ходімо
-        - в
-        - парк
-      answer: У суботу о десятій ходімо в парк
-    - words:
-        - Якщо
-        - буде
-        - дощ
-        - ходімо
-        - в
-        - музей
-      answer: Якщо буде дощ ходімо в музей
-    - words:
-        - Взимку
-        - ліс
-        - холодний
-      answer: Взимку ліс холодний
-    - words:
-        - Я
-        - працюю
-        - з
-        - дев'ятої
-        - до
-        - п'ятої
-      answer: Я працюю з дев'ятої до п'ятої
-    - words:
-        - Зараз
-        - п'ять
-        - по
-        - восьмій
-      answer: Зараз п'ять по восьмій
-    - words:
-        - Я
-        - хочу
-        - вставати
-        - о
-        - шостій
-        - ранку
-      answer: Я хочу вставати о шостій ранку
-- id: act-8
-  type: fill-in
-  title: Final repair gaps
-  instruction: Choose the full repair for each unsafe checkpoint sentence.
-  items:
-    - sentence: "Season repair: ___"
-      answer: "Взимку я люблю читати книжки."
-      options:
-        - "Взимку я люблю читати книжки."
-        - "Зимою я люблю читати книжки."
-        - "На зимі я люблю читати книжки."
-      explanation: Use the adverbial season chunk взимку.
-    - sentence: "Five-past-eight repair: ___"
-      answer: "Фільм починається п'ять по восьмій."
-      options:
-        - "Фільм починається п'ять по восьмій."
-        - "Фільм починається п'ять після восьмої."
-        - "Фільм починається п'ять в восьмій."
-      explanation: Use по, not an English-style after phrase.
-    - sentence: "Ten-to-six repair: ___"
-      answer: "Автобус приїде за десять шоста."
-      options:
-        - "Автобус приїде за десять шоста."
-        - "Автобус приїде без десяти шість."
-        - "Автобус приїде до десяти шість."
-      explanation: Use за for this approaching-hour chunk.
-    - sentence: "Twenty-to-six repair: ___"
-      answer: "Урок закінчується о двадцятій хвилині на шосту."
-      options:
-        - "Урок закінчується о двадцятій хвилині на шосту."
-        - "Урок закінчується в двадцять хвилин шостої."
-        - "Урок закінчується двадцять після п'ятої."
-      explanation: Use the Ukrainian на pattern for minutes in this checkpoint.
-    - sentence: "Name and age repair: ___"
-      answer: "Мене звати Джон, і мені 20 років."
-      options:
-        - "Мене звати Джон, і мені 20 років."
-        - "Моє ім'я є Джон, і я маю 20 років."
-        - "Я є Джон, і я маю 20 років."
-      explanation: Use мене звати and мені for age.
-    - sentence: "Student line repair: ___"
-      answer: "У понеділок я студент."
-      options:
-        - "У понеділок я студент."
-        - "У понеділок я є студент."
-        - "У понеділок мене студент."
-      explanation: Ukrainian normally omits the present-tense helper in this line.
+inline:
+  - id: act-1
+    type: group-sort
+    title: A1.4 skill map
+    instruction: Sort each line by the checkpoint skill it proves.
+    groups:
+      - name: Clock time
+        items:
+          - Котра година?
+          - Зараз сьома.
+          - Зустріч о десятій.
+      - name: Calendar
+        items:
+          - У суботу.
+          - У жовтні.
+          - Влітку.
+      - name: Weather
+        items:
+          - Сьогодні тепло.
+          - Іде дощ.
+          - Надворі хмарно.
+      - name: Free-time plan
+        items:
+          - Ходімо в музей.
+          - Давай слухати музику.
+          - Я часто читаю.
+  - id: act-2
+    type: match-up
+    title: Question to checkpoint answer
+    instruction: Match each question with the answer that fits a weekend plan.
+    pairs:
+      - left: Котра година?
+        right: Десята тридцять.
+      - left: О котрій зустріч?
+        right: О першій.
+      - left: Яка сьогодні погода?
+        right: Тепло і сонячно.
+      - left: Коли твій день народження?
+        right: У жовтні.
+      - left: Що ти робиш у суботу?
+        right: Граю у футбол.
+      - left: Як часто ти читаєш?
+        right: Кожен день ввечері.
+      - left: Ходімо в парк!
+        right: Добре, о котрій?
+      - left: Що ти будеш робити завтра?
+        right: Буду працювати.
+  - id: act-3
+    type: fill-in
+    title: Weekend plan gaps
+    instruction: Choose the checkpoint chunk that completes the plan.
+    items:
+      - sentence: 'Зустріч ___ годині.'
+        answer: "о п'ятій"
+        options:
+          - "о п'ятій"
+          - "в п'ятій"
+          - "у п'ята"
+        explanation: Schedule time uses о/об plus the hour chunk.
+      - sentence: 'Ми йдемо в кіно ___.'
+        answer: у суботу
+        options:
+          - у суботу
+          - в суботі
+          - на суботу
+        explanation: Use у/в plus the day chunk.
+      - sentence: 'Мій день народження ___.'
+        answer: у січні
+        options:
+          - у січні
+          - в січень
+          - січень
+        explanation: Months answer коли? with у/в plus the month form.
+      - sentence: 'Сьогодні ___ і холодно.'
+        answer: іде дощ
+        options:
+          - іде дощ
+          - іде дощова
+          - дощить холод
+        explanation: Іде дощ is the safe weather chunk.
+      - sentence: 'Взимку дуже ___.'
+        answer: холодно
+        options:
+          - холодно
+          - спекотно
+          - тепло
+        explanation: Winter connects naturally with cold weather.
+      - sentence: 'Я прокидаюся о сьомій ___.'
+        answer: ранку
+        options:
+          - ранку
+          - рано
+          - вранці
+        explanation: Use ранку to clarify 7 AM after the clock time.
+  - id: act-4
+    type: quiz
+    title: Build the Saturday trip
+    instruction: Choose the line that fits each part of the travel plan.
+    items:
+      - prompt: 'Start with the day and destination.'
+        options:
+          - text: 'У суботу ми їдемо до Києва.'
+            correct: true
+          - text: 'На суботу ми їдемо в Київ.'
+            correct: false
+          - text: 'У суботі ми їдемо Київ.'
+            correct: false
+        explanation: Use у суботу and до Києва.
+      - prompt: 'Give the meeting time.'
+        options:
+          - text: 'Зустріч о десятій ранку.'
+            correct: true
+          - text: 'Зустріч в десять годин.'
+            correct: false
+          - text: 'Зустріч на десяту ранку.'
+            correct: false
+        explanation: Schedule time uses о plus the time chunk.
+      - prompt: 'Add the weather.'
+        options:
+          - text: 'Буде тепло і сонячно.'
+            correct: true
+          - text: 'Погода буде тепла і сонячна.'
+            correct: false
+          - text: 'Це є тепло і сонячно.'
+            correct: false
+        explanation: Short weather chunks are enough.
+      - prompt: 'Add a first action.'
+        options:
+          - text: 'Спочатку гуляємо в парку.'
+            correct: true
+          - text: 'На початку ми є гуляємо в парку.'
+            correct: false
+          - text: 'Перший гуляємо у парк.'
+            correct: false
+        explanation: Спочатку connects the action safely.
+      - prompt: 'Add a rain alternative.'
+        options:
+          - text: 'Якщо буде дощ, спочатку йдемо в музей.'
+            correct: true
+          - text: 'Якщо є дощ, спочатку ходимо до музей.'
+            correct: false
+          - text: 'Коли дощова, спочатку йдемо музей.'
+            correct: false
+        explanation: Якщо буде дощ is the safe condition chunk.
+workbook:
+  - type: odd-one-out
+    title: Find the unsafe checkpoint chunk
+    instruction: Choose the line that does not fit the safe A1.4 pattern.
+    items:
+      - words:
+          - "Зустріч о п'ятій."
+          - 'Фільм о десятій годині.'
+          - 'Кава об одинадцятій.'
+          - "Зустріч в п'ять годин."
+        answer: "Зустріч в п'ять годин."
+        explanation: Schedule time uses о/об.
+      - words:
+          - 'Пів на восьму.'
+          - 'Пів на шосту.'
+          - 'Чверть на дванадцяту.'
+          - 'Пів восьмої.'
+        answer: 'Пів восьмої.'
+        explanation: The checkpoint chunk is пів на plus the next hour.
+      - words:
+          - 'Іде дощ.'
+          - 'Сьогодні тепло.'
+          - 'Надворі хмарно.'
+          - 'Він іде дощ.'
+        answer: 'Він іде дощ.'
+        explanation: Weather can be an impersonal Ukrainian sentence.
+      - words:
+          - 'Взимку.'
+          - 'Навесні.'
+          - 'Влітку.'
+          - 'Весною.'
+        answer: 'Весною.'
+        explanation: Навесні is the safe A1 season chunk in this checkpoint.
+      - words:
+          - 'Я студент.'
+          - 'Мені 20 років.'
+          - 'Він спортсмен.'
+          - 'Я є студент.'
+        answer: 'Я є студент.'
+        explanation: Ukrainian normally omits the present-tense helper here.
+  - type: true-false
+    title: Checkpoint readiness checks
+    instruction: Decide whether each line is ready for an A1.4 checkpoint answer.
+    items:
+      - statement: 'У суботу о десятій ходімо в парк.'
+        answer: true
+        explanation: Day plus time plus invitation is a complete plan.
+      - statement: 'Влітку часто тепло і сонячно.'
+        answer: true
+        explanation: Влітку is the safe season chunk.
+      - statement: "Я працюю з дев'ятої до п'ятої."
+        answer: true
+        explanation: This workday range is useful and safe at A1.
+      - statement: 'Сьогодні холодно, тому я читаю вдома.'
+        answer: true
+        explanation: Weather plus reason plus action is a good checkpoint line.
+      - statement: 'Мені подобається весна.'
+        answer: true
+        explanation: Мені подобається is the safe preference chunk.
+      - statement: 'О першій ходімо в музей.'
+        answer: true
+        explanation: The schedule chunk о першій combines naturally with an invitation.
+  - type: unjumble
+    title: Rebuild integrated checkpoint lines
+    instruction: Put the words in a safe A1.4 order.
+    items:
+      - words:
+          - У
+          - суботу
+          - о
+          - десятій
+          - ходімо
+          - в
+          - парк
+        answer: У суботу о десятій ходімо в парк
+      - words:
+          - Якщо
+          - буде
+          - дощ
+          - ходімо
+          - в
+          - музей
+        answer: Якщо буде дощ ходімо в музей
+      - words:
+          - Взимку
+          - ліс
+          - холодний
+        answer: Взимку ліс холодний
+      - words:
+          - Я
+          - працюю
+          - з
+          - дев'ятої
+          - до
+          - п'ятої
+        answer: Я працюю з дев'ятої до п'ятої
+      - words:
+          - Зараз
+          - п'ять
+          - по
+          - восьмій
+        answer: Зараз п'ять по восьмій
+      - words:
+          - Я
+          - хочу
+          - вставати
+          - о
+          - шостій
+          - ранку
+        answer: Я хочу вставати о шостій ранку
+  - type: fill-in
+    title: Final repair gaps
+    instruction: Choose the full repair for each unsafe checkpoint sentence.
+    items:
+      - sentence: 'Season repair: ___'
+        answer: 'Взимку я люблю читати книжки.'
+        options:
+          - 'Взимку я люблю читати книжки.'
+          - 'Зимою я люблю читати книжки.'
+          - 'На зимі я люблю читати книжки.'
+        explanation: Use the adverbial season chunk взимку.
+      - sentence: 'Five-past-eight repair: ___'
+        answer: "Фільм починається п'ять по восьмій."
+        options:
+          - "Фільм починається п'ять по восьмій."
+          - "Фільм починається п'ять після восьмої."
+          - "Фільм починається п'ять в восьмій."
+        explanation: Use по, not an English-style after phrase.
+      - sentence: 'Ten-to-six repair: ___'
+        answer: 'Автобус приїде за десять шоста.'
+        options:
+          - 'Автобус приїде за десять шоста.'
+          - 'Автобус приїде без десяти шість.'
+          - 'Автобус приїде до десяти шість.'
+        explanation: Use за for this approaching-hour chunk.
+      - sentence: 'Twenty-to-six repair: ___'
+        answer: 'Урок закінчується о двадцятій хвилині на шосту.'
+        options:
+          - 'Урок закінчується о двадцятій хвилині на шосту.'
+          - 'Урок закінчується в двадцять хвилин шостої.'
+          - "Урок закінчується двадцять після п'ятої."
+        explanation: Use the Ukrainian на pattern for minutes in this checkpoint.
+      - sentence: 'Name and age repair: ___'
+        answer: 'Мене звати Джон, і мені 20 років.'
+        options:
+          - 'Мене звати Джон, і мені 20 років.'
+          - "Моє ім'я є Джон, і я маю 20 років."
+          - 'Я є Джон, і я маю 20 років.'
+        explanation: Use мене звати and мені for age.
+      - sentence: 'Student line repair: ___'
+        answer: 'У понеділок я студент.'
+        options:
+          - 'У понеділок я студент.'
+          - 'У понеділок я є студент.'
+          - 'У понеділок мене студент.'
+        explanation: Ukrainian normally omits the present-tense helper in this line.

--- a/curriculum/l2-uk-en/a1/checkpoint-time-nature/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-time-nature/module.md
@@ -153,8 +153,6 @@ and **г** as Ukrainian sounds in Ukrainian words such as **синьо-жовт�
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
 ## Діалог
 
 Read the planning dialogue. It combines time, calendar, weather, routine, and
@@ -177,8 +175,6 @@ Notice the clean everyday forms: **Добрий день**, **До побаче�
 **прізвище**, **тато**, **Мені 20 років**, **Я студент**, and
 **Він спортсмен**. Use Ukrainian zero-copula and age chunks; do not force an
 English helper into these lines.
-
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ## Підсумок
 
@@ -209,7 +205,3 @@ Write your own six-line checkpoint answer. Include:
 - one sequence word: **спочатку** or **потім**;
 - one free-time action: **гуляю**, **читаю**, **слухаю музику**;
 - one alternative: **якщо буде дощ...**.
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/days-and-months/activities.yaml
+++ b/curriculum/l2-uk-en/a1/days-and-months/activities.yaml
@@ -1,252 +1,250 @@
-- id: act-1
-  type: order
-  title: Put the week in order
-  instruction: Put the days from Monday to Sunday.
-  is_ukrainian: true
-  items:
-    - понеділок
-    - вівторок
-    - середа
-    - четвер
-    - п'ятниця
-    - субота
-    - неділя
-  correct_order: [0, 1, 2, 3, 4, 5, 6]
-- id: act-2
-  type: quiz
-  title: Clinic appointment day
-  questions:
-    - question: "У понеділок о дев'ятій можна?"
-      options:
-        - text: The receptionist offers Monday at nine.
-          correct: true
-        - text: The receptionist offers March at nine.
-          correct: false
-        - text: The receptionist offers Sunday at one.
-          correct: false
-      explanation: "У понеділок means on Monday; о дев'ятій means at nine."
-    - question: "Пацієнт каже: У понеділок я працюю. А у середу?"
-      options:
-        - text: Monday is not good; Wednesday may work.
-          correct: true
-        - text: Wednesday is not good; Sunday may work.
-          correct: false
-        - text: The patient asks about a month.
-          correct: false
-      explanation: "У середу is the Wednesday planning chunk."
-    - question: "Добре, у середу о другій."
-      options:
-        - text: The appointment is Wednesday at two.
-          correct: true
-        - text: The appointment is Friday at two.
-          correct: false
-        - text: The appointment is in February.
-          correct: false
-      explanation: "У середу + о другій combines day and time chunks."
-    - question: "Which Ukrainian greeting fits the clinic dialogue?"
-      options:
-        - text: Добрий день.
-          correct: true
-        - text: Здрастуйте.
-          correct: false
-        - text: Пока.
-          correct: false
-      explanation: "Use standard Ukrainian classroom greetings."
-- id: act-3
-  type: fill-in
-  title: Day planning chunks
-  items:
-    - sentence: "Я працюю ___."
-      answer: "у понеділок"
-      options: ["у понеділок", "on понеділок", "понеділок"]
-    - sentence: "Ми вивчаємо українську ___."
-      answer: "у вівторок"
-      options: ["у вівторок", "в вівторок", "вівторок"]
-    - sentence: "Зустріч ___."
-      answer: "у середу"
-      options: ["у середу", "середа", "на середу"]
-    - sentence: "Кава ___."
-      answer: "у четвер"
-      options: ["у четвер", "четвер", "на четвер"]
-    - sentence: "Фільм ___."
-      answer: "у п'ятницю"
-      options: ["у п'ятницю", "п'ятниця", "в п'ятниця"]
-    - sentence: "Я гуляю ___."
-      answer: "в суботу"
-      options: ["в суботу", "субота", "на субота"]
-    - sentence: "Я відпочиваю ___."
-      answer: "в неділю"
-      options: ["в неділю", "неділя", "on неділя"]
-- id: act-4
-  type: group-sort
-  title: Calendar shelves
-  instruction: Sort each word onto the right calendar shelf.
-  groups:
-    - name: Days
-      items:
-        - понеділок
-        - середа
-        - п'ятниця
-        - неділя
-    - name: Months
-      items:
-        - січень
-        - квітень
-        - липень
-        - листопад
-    - name: Seasons
-      items:
-        - зима
-        - весна
-        - літо
-        - осінь
-    - name: Nature and weather
-      items:
-        - сонце
-        - дощ
-        - сніг
-        - вітер
-- id: act-5
-  type: match-up
-  title: Month, season, memory hook
-  pairs:
-    - left: січень
-      right: зима
-    - left: березень
-      right: весна
-    - left: липень
-      right: літо
-    - left: листопад
-      right: осінь
-    - left: квітень
-      right: flowers
-    - left: липень
-      right: linden tree
-    - left: листопад
-      right: falling leaves
-    - left: березень
-      right: birch
-- id: act-6
-  type: true-false
-  title: Calendar safety checks
-  items:
-    - statement: "Ukrainian writes понеділок and січень with lowercase letters in normal sentences."
-      isTrue: true
-      explanation: "Days and months are common nouns in Ukrainian."
-    - statement: "Сьогодні є вівторок is the safest A1 sentence."
-      isTrue: false
-      explanation: "Use Сьогодні вівторок without є."
-    - statement: "Взимку, навесні, влітку, восени are useful season chunks."
-      isTrue: true
-      explanation: "These adverbs are the safe A1 forms."
-    - statement: "Я народився першого січня uses no preposition before the date."
-      isTrue: true
-      explanation: "Dates use the date chunk directly."
-    - statement: "В літо is the safe chunk for in summer."
-      isTrue: false
-      explanation: "Use влітку."
-    - statement: "У березні answers in which month."
-      isTrue: true
-      explanation: "У березні is the month chunk."
-- id: act-7
-  type: translate
-  title: Build calendar lines
-  questions:
-    - source: Today is Tuesday.
-      options:
-        - text: "Сьогодні вівторок."
-          correct: true
-        - text: "Сьогодні є вівторок."
-          correct: false
-        - text: "Сьогодні у вівторок."
-          correct: false
-      explanation: "Identify the day without є."
-    - source: I work on Monday.
-      options:
-        - text: "Я працюю у понеділок."
-          correct: true
-        - text: "Я працюю on понеділок."
-          correct: false
-        - text: "Я працюю понеділок."
-          correct: false
-      explanation: "Use у понеділок for a planned day."
-    - source: My birthday is in August.
-      options:
-        - text: "Мій день народження у серпні."
-          correct: true
-        - text: "Мій день народження в Серпень."
-          correct: false
-        - text: "Мій день народження серпень."
-          correct: false
-      explanation: "Use the month chunk у серпні and lowercase."
-    - source: In summer it is warm.
-      options:
-        - text: "Влітку тепло."
-          correct: true
-        - text: "В літо тепло."
-          correct: false
-        - text: "Літом тепло."
-          correct: false
-      explanation: "Prefer влітку."
-    - source: My birthday is on March fifteenth.
-      options:
-        - text: "Мій день народження п'ятнадцятого березня."
-          correct: true
-        - text: "Мій день народження в п'ятнадцяте березня."
-          correct: false
-        - text: "Мій день народження у березень п'ятнадцять."
-          correct: false
-      explanation: "Use the date chunk without a preposition."
-- id: act-8
-  type: error-correction
-  title: Repair calendar traps
-  instruction: Choose the safe Ukrainian calendar form.
-  items:
-    - sentence: "On понеділок я працюю."
-      error: "On понеділок"
-      answer: "У понеділок я працюю."
-      options:
-        - "У понеділок я працюю."
-        - "On понеділок я працюю."
-        - "На понеділок я працюю."
-      explanation: "Use у/в with weekday chunks, not English on."
-    - sentence: "Я народився в Перше січня."
-      error: "в Перше січня"
-      answer: "Я народився першого січня."
-      options:
-        - "Я народився першого січня."
-        - "Я народився в Перше січня."
-        - "Я народився у перший січень."
-      explanation: "Date chunks do not need в."
-    - sentence: "Вітаю з 1 вересням!"
-      error: "вересням"
-      answer: "Вітаю з 1 вересня!"
-      options:
-        - "Вітаю з 1 вересня!"
-        - "Вітаю з 1 вересням!"
-        - "Вітаю з 1 вересень!"
-      explanation: "In dates, keep the month in the date form."
-    - sentence: "Моє улюблене свято в Січень."
-      error: "в Січень"
-      answer: "Моє улюблене свято в січні."
-      options:
-        - "Моє улюблене свято в січні."
-        - "Моє улюблене свято в Січень."
-        - "Моє улюблене свято у січень."
-      explanation: "Use lowercase and the month chunk в січні."
-    - sentence: "Ми поїдемо в літо."
-      error: "в літо"
-      answer: "Ми поїдемо влітку."
-      options:
-        - "Ми поїдемо влітку."
-        - "Ми поїдемо в літо."
-        - "Ми поїдемо літо."
-      explanation: "Use the season adverb влітку."
-    - sentence: "Сьогодні є вівторок."
-      error: "є"
-      answer: "Сьогодні вівторок."
-      options:
-        - "Сьогодні вівторок."
-        - "Сьогодні є вівторок."
-        - "Сьогодні у вівторок."
-      explanation: "Do not copy English is into this line."
+inline:
+  - id: act-1
+    type: order
+    title: Put the week in order
+    instruction: Put the days from Monday to Sunday.
+    is_ukrainian: true
+    items:
+      - понеділок
+      - вівторок
+      - середа
+      - четвер
+      - п'ятниця
+      - субота
+      - неділя
+    correct_order: [0, 1, 2, 3, 4, 5, 6]
+  - id: act-2
+    type: quiz
+    title: Clinic appointment day
+    questions:
+      - question: "У понеділок о дев'ятій можна?"
+        options:
+          - text: The receptionist offers Monday at nine.
+            correct: true
+          - text: The receptionist offers March at nine.
+            correct: false
+          - text: The receptionist offers Sunday at one.
+            correct: false
+        explanation: "У понеділок means on Monday; о дев'ятій means at nine."
+      - question: 'Пацієнт каже: У понеділок я працюю. А у середу?'
+        options:
+          - text: Monday is not good; Wednesday may work.
+            correct: true
+          - text: Wednesday is not good; Sunday may work.
+            correct: false
+          - text: The patient asks about a month.
+            correct: false
+        explanation: 'У середу is the Wednesday planning chunk.'
+      - question: 'Добре, у середу о другій.'
+        options:
+          - text: The appointment is Wednesday at two.
+            correct: true
+          - text: The appointment is Friday at two.
+            correct: false
+          - text: The appointment is in February.
+            correct: false
+        explanation: 'У середу + о другій combines day and time chunks.'
+      - question: 'Which Ukrainian greeting fits the clinic dialogue?'
+        options:
+          - text: Добрий день.
+            correct: true
+          - text: Здрастуйте.
+            correct: false
+          - text: Пока.
+            correct: false
+        explanation: 'Use standard Ukrainian classroom greetings.'
+  - id: act-3
+    type: fill-in
+    title: Day planning chunks
+    items:
+      - sentence: 'Я працюю ___.'
+        answer: 'у понеділок'
+        options: ['у понеділок', 'on понеділок', 'понеділок']
+      - sentence: 'Ми вивчаємо українську ___.'
+        answer: 'у вівторок'
+        options: ['у вівторок', 'в вівторок', 'вівторок']
+      - sentence: 'Зустріч ___.'
+        answer: 'у середу'
+        options: ['у середу', 'середа', 'на середу']
+      - sentence: 'Кава ___.'
+        answer: 'у четвер'
+        options: ['у четвер', 'четвер', 'на четвер']
+      - sentence: 'Фільм ___.'
+        answer: "у п'ятницю"
+        options: ["у п'ятницю", "п'ятниця", "в п'ятниця"]
+      - sentence: 'Я гуляю ___.'
+        answer: 'в суботу'
+        options: ['в суботу', 'субота', 'на субота']
+      - sentence: 'Я відпочиваю ___.'
+        answer: 'в неділю'
+        options: ['в неділю', 'неділя', 'on неділя']
+  - id: act-4
+    type: group-sort
+    title: Calendar shelves
+    instruction: Sort each word onto the right calendar shelf.
+    groups:
+      - name: Days
+        items:
+          - понеділок
+          - середа
+          - п'ятниця
+          - неділя
+      - name: Months
+        items:
+          - січень
+          - квітень
+          - липень
+          - листопад
+      - name: Seasons
+        items:
+          - зима
+          - весна
+          - літо
+          - осінь
+      - name: Nature and weather
+        items:
+          - сонце
+          - дощ
+          - сніг
+          - вітер
+workbook:
+  - type: match-up
+    title: Month, season, memory hook
+    pairs:
+      - left: січень
+        right: зима
+      - left: березень
+        right: весна
+      - left: липень
+        right: літо
+      - left: листопад
+        right: осінь
+      - left: квітень
+        right: flowers
+      - left: липень
+        right: linden tree
+      - left: листопад
+        right: falling leaves
+      - left: березень
+        right: birch
+  - type: true-false
+    title: Calendar safety checks
+    items:
+      - statement: 'Ukrainian writes понеділок and січень with lowercase letters in normal sentences.'
+        isTrue: true
+        explanation: 'Days and months are common nouns in Ukrainian.'
+      - statement: 'Сьогодні є вівторок is the safest A1 sentence.'
+        isTrue: false
+        explanation: 'Use Сьогодні вівторок without є.'
+      - statement: 'Взимку, навесні, влітку, восени are useful season chunks.'
+        isTrue: true
+        explanation: 'These adverbs are the safe A1 forms.'
+      - statement: 'Я народився першого січня uses no preposition before the date.'
+        isTrue: true
+        explanation: 'Dates use the date chunk directly.'
+      - statement: 'В літо is the safe chunk for in summer.'
+        isTrue: false
+        explanation: 'Use влітку.'
+      - statement: 'У березні answers in which month.'
+        isTrue: true
+        explanation: 'У березні is the month chunk.'
+  - type: translate
+    title: Build calendar lines
+    questions:
+      - source: Today is Tuesday.
+        options:
+          - text: 'Сьогодні вівторок.'
+            correct: true
+          - text: 'Сьогодні є вівторок.'
+            correct: false
+          - text: 'Сьогодні у вівторок.'
+            correct: false
+        explanation: 'Identify the day without є.'
+      - source: I work on Monday.
+        options:
+          - text: 'Я працюю у понеділок.'
+            correct: true
+          - text: 'Я працюю on понеділок.'
+            correct: false
+          - text: 'Я працюю понеділок.'
+            correct: false
+        explanation: 'Use у понеділок for a planned day.'
+      - source: My birthday is in August.
+        options:
+          - text: 'Мій день народження у серпні.'
+            correct: true
+          - text: 'Мій день народження в Серпень.'
+            correct: false
+          - text: 'Мій день народження серпень.'
+            correct: false
+        explanation: 'Use the month chunk у серпні and lowercase.'
+      - source: In summer it is warm.
+        options:
+          - text: 'Влітку тепло.'
+            correct: true
+          - text: 'В літо тепло.'
+            correct: false
+          - text: 'Літом тепло.'
+            correct: false
+        explanation: 'Prefer влітку.'
+      - source: My birthday is on March fifteenth.
+        options:
+          - text: "Мій день народження п'ятнадцятого березня."
+            correct: true
+          - text: "Мій день народження в п'ятнадцяте березня."
+            correct: false
+          - text: "Мій день народження у березень п'ятнадцять."
+            correct: false
+        explanation: 'Use the date chunk without a preposition.'
+  - type: error-correction
+    title: Repair calendar traps
+    instruction: Choose the safe Ukrainian calendar form.
+    items:
+      - sentence: 'On понеділок я працюю.'
+        error: 'On понеділок'
+        answer: 'У понеділок я працюю.'
+        options:
+          - 'У понеділок я працюю.'
+          - 'On понеділок я працюю.'
+          - 'На понеділок я працюю.'
+        explanation: 'Use у/в with weekday chunks, not English on.'
+      - sentence: 'Я народився в Перше січня.'
+        error: 'в Перше січня'
+        answer: 'Я народився першого січня.'
+        options:
+          - 'Я народився першого січня.'
+          - 'Я народився в Перше січня.'
+          - 'Я народився у перший січень.'
+        explanation: 'Date chunks do not need в.'
+      - sentence: 'Вітаю з 1 вересням!'
+        error: 'вересням'
+        answer: 'Вітаю з 1 вересня!'
+        options:
+          - 'Вітаю з 1 вересня!'
+          - 'Вітаю з 1 вересням!'
+          - 'Вітаю з 1 вересень!'
+        explanation: 'In dates, keep the month in the date form.'
+      - sentence: 'Моє улюблене свято в Січень.'
+        error: 'в Січень'
+        answer: 'Моє улюблене свято в січні.'
+        options:
+          - 'Моє улюблене свято в січні.'
+          - 'Моє улюблене свято в Січень.'
+          - 'Моє улюблене свято у січень.'
+        explanation: 'Use lowercase and the month chunk в січні.'
+      - sentence: 'Ми поїдемо в літо.'
+        error: 'в літо'
+        answer: 'Ми поїдемо влітку.'
+        options:
+          - 'Ми поїдемо влітку.'
+          - 'Ми поїдемо в літо.'
+          - 'Ми поїдемо літо.'
+        explanation: 'Use the season adverb влітку.'
+      - sentence: 'Сьогодні є вівторок.'
+        error: 'є'
+        answer: 'Сьогодні вівторок.'
+        options:
+          - 'Сьогодні вівторок.'
+          - 'Сьогодні є вівторок.'
+          - 'Сьогодні у вівторок.'
+        explanation: 'Do not copy English is into this line.'

--- a/curriculum/l2-uk-en/a1/days-and-months/module.md
+++ b/curriculum/l2-uk-en/a1/days-and-months/module.md
@@ -173,10 +173,6 @@ the chunks. There is no **в** before these dates. Say **Я народився �
 After **з** in greetings, keep the month in the date form too:
 **Вітаю з 1 вересня!** The month stays **вересня**, not **вересням**.
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Підсумок
 
 Keep four calendar cards.
@@ -220,7 +216,3 @@ plan, one for a month, one for a season, and one for a birthday:
 <DialogueBox uk="Мій день народження у серпні." en="My birthday is in August." />
 <DialogueBox uk="Восени часто йде дощ." en="In autumn it often rains." />
 <DialogueBox uk="День народження двадцять другого серпня." en="The birthday is on August twenty-second." />
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/free-time/activities.yaml
+++ b/curriculum/l2-uk-en/a1/free-time/activities.yaml
@@ -1,284 +1,282 @@
-- id: act-1
-  type: true-false
-  title: Notice board invitations
-  instruction: Decide if each plan is a safe A1 invitation.
-  items:
-    - statement: "Ходімо в кіно в суботу о п'ятій."
-      answer: true
-      explanation: Invitation + place + day + time is a safe plan.
-    - statement: "Ходімо до кіно в суботу."
-      answer: false
-      explanation: Use the chunk ходімо в кіно.
-    - statement: "Давай слухати музику ввечері."
-      answer: true
-      explanation: Давай + infinitive is a friendly A1 invitation.
-    - statement: "Я ніколи працюю у неділю."
-      answer: false
-      explanation: Ніколи needs не, so say я ніколи не працюю.
-    - statement: "Якщо буде дощ, ходімо в музей."
-      answer: true
-      explanation: This combines weather and an alternative activity.
-    - statement: "Брати участь у гуртку."
-      answer: true
-      explanation: Брати участь is the safe Ukrainian chunk.
-- id: act-2
-  type: match-up
-  title: Build hobby chunks
-  instruction: Match each verb with the natural hobby chunk.
-  pairs:
-    - left: грати
-      right: у футбол
-    - left: грати
-      right: на гітарі
-    - left: слухати
-      right: музику
-    - left: дивитися
-      right: фільми
-    - left: ходити
-      right: в кіно
-    - left: ходити
-      right: в театр
-    - left: читати
-      right: книгу
-    - left: відпочивати
-      right: вдома
-- id: act-3
-  type: fill-in
-  title: Frequency and invitations
-  instruction: Choose the word or chunk that completes the sentence.
-  items:
-    - sentence: "Я ___ працюю у неділю."
-      answer: ніколи не
-      options:
-        - ніколи не
-        - ніколи
-        - завжди не
-      explanation: Ніколи needs не.
-    - sentence: "Вона грає у теніс двічі ___."
-      answer: на тиждень
-      options:
-        - на тиждень
-        - у тиждень
-        - в тиждень
-      explanation: Use раз/двічі/тричі на тиждень.
-    - sentence: "___ в кіно у суботу! — Добре!"
-      answer: Ходімо
-      options:
-        - Ходімо
-        - Ходжу
-        - Ходиш
-      explanation: Ходімо! is the invitation chunk.
-    - sentence: "Я люблю спорт, тому ___ граю у баскетбол."
-      answer: часто
-      options:
-        - часто
-        - ніколи
-        - не
-      explanation: Often fits the reason.
-    - sentence: "Я не маю часу, тому ___ читаю книги."
-      answer: рідко
-      options:
-        - рідко
-        - завжди
-        - кожен
-      explanation: Little time means rarely.
-    - sentence: "— Що ти робиш ___? — Відпочиваю."
-      answer: у вихідні
-      options:
-        - у вихідні
-        - вихідні
-        - на вихідні
-      explanation: Use у вихідні for on weekends.
-- id: act-4
-  type: quiz
-  title: Choose the safe preposition
-  instruction: Pick the phrase that keeps the activity chunk natural.
-  items:
-    - prompt: "Він грає ___ піаніно."
-      options:
-        - text: на
-          correct: true
-        - text: у
-          correct: false
-        - text: в
-          correct: false
-      explanation: Instruments use грати на.
-    - prompt: "Ми граємо ___ футбол."
-      options:
-        - text: у
-          correct: true
-        - text: на
-          correct: false
-        - text: до
-          correct: false
-      explanation: Sports use грати у/в.
-    - prompt: "Я хочу ходити ___ концерт."
-      options:
-        - text: на
-          correct: true
-        - text: в
-          correct: false
-        - text: до
-          correct: false
-      explanation: Use ходити на концерт.
-    - prompt: "Вони ходять ___ театр раз на місяць."
-      options:
-        - text: в
-          correct: true
-        - text: на
-          correct: false
-        - text: до
-          correct: false
-      explanation: Use ходити в театр.
-    - prompt: "Ми йдемо ___ кіно."
-      options:
-        - text: в
-          correct: true
-        - text: до
-          correct: false
-        - text: на
-          correct: false
-      explanation: The safe chunk is йти в кіно.
-- id: act-5
-  type: order
-  title: From weather to plan
-  instruction: Put the planning lines into a natural order.
-  is_ukrainian: true
-  items:
-    - Сьогодні субота.
-    - Оленко, що ти робиш у вихідні?
-    - Зазвичай я гуляю і читаю.
-    - Буде тепло.
-    - Давай грати у футбол о третій.
-    - Добре, а якщо буде дощ?
-    - Якщо буде дощ, ходімо в музей.
-    - Чудово!
-  correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
-- id: act-6
-  type: group-sort
-  title: Frequency shelves
-  instruction: Sort the chunks by what they answer.
-  groups:
-    - name: Always or usually
-      items:
-        - завжди
-        - зазвичай
-        - кожен день
-    - name: Sometimes or rarely
-      items:
-        - іноді
-        - інколи
-        - рідко
-    - name: Counted frequency
-      items:
-        - раз на тиждень
-        - двічі на тиждень
-        - раз на місяць
-    - name: Invitations
-      items:
-        - Ходімо в кіно!
-        - Давай грати разом!
-        - Ходімо в музей!
-- id: act-7
-  type: translate
-  title: Say a free-time plan
-  instruction: Translate into Ukrainian using the chunks from the lesson.
-  items:
-    - source: "I often listen to music."
-      options:
-        - text: "Я часто слухаю музику."
-          correct: true
-        - text: "Я слухаю до музики часто."
-          correct: false
-        - text: "Я часто слухаю до музики."
-          correct: false
-      explanation: Часто usually stands before the verb.
-    - source: "I play football twice a week."
-      options:
-        - text: "Я граю у футбол двічі на тиждень."
-          correct: true
-        - text: "Я граю футбол двічі на тиждень."
-          correct: false
-        - text: "Я граю на футбол двічі в тиждень."
-          correct: false
-      explanation: Sports use грати у/в.
-    - source: "Let's go to the cinema on Saturday at five."
-      options:
-        - text: "Ходімо в кіно в суботу о п'ятій."
-          correct: true
-        - text: "Ходімо до кіно в суботу о п'ятій."
-          correct: false
-        - text: "Ходжу в кіно в суботу о п'ятій."
-          correct: false
-      explanation: Ходімо в кіно is the clean invitation.
-    - source: "If it rains, let's go to the museum."
-      options:
-        - text: "Якщо буде дощ, ходімо в музей."
-          correct: true
-        - text: "Якщо буде дощ, ходімо до музей."
-          correct: false
-        - text: "Якщо є дощ, ходжу в музей."
-          correct: false
-      explanation: This combines weather and an alternative.
-    - source: "I never work on Sunday."
-      options:
-        - text: "Я ніколи не працюю у неділю."
-          correct: true
-        - text: "Я ніколи працюю у неділю."
-          correct: false
-        - text: "Я не ніколи працюю у неділю."
-          correct: false
-      explanation: Ніколи needs не.
-- id: act-8
-  type: error-correction
-  title: Repair hobby interference
-  instruction: Choose the Ukrainian repair for each unsafe learner sentence.
-  items:
-    - sentence: "Я граю гру (англ. I play a game)."
-      error: "граю гру"
-      answer: "Я граю в гру."
-      options:
-        - "Я граю в гру."
-        - "Я граю гру."
-        - "Я граю до гри."
-      explanation: Games use грати в/у + object.
-    - sentence: "Я слухаю до музики (англ. I listen to music)."
-      error: "до музики"
-      answer: "Я слухаю музику."
-      options:
-        - "Я слухаю музику."
-        - "Я слухаю до музики."
-        - "Я слухаю на музику."
-      explanation: Слухати takes a direct object without a preposition.
-    - sentence: "Я займаюся спорт (англ. I do sport)."
-      error: "спорт"
-      answer: "Я займаюся спортом."
-      options:
-        - "Я займаюся спортом."
-        - "Я займаюся спорт."
-        - "Я роблю спорт."
-      explanation: The safe chunk is займатися спортом.
-    - sentence: "Я дивлюся на телевізор (англ. I look at the TV)."
-      error: "на телевізор"
-      answer: "Я дивлюся телевізор."
-      options:
-        - "Я дивлюся телевізор."
-        - "Я дивлюся на телевізор."
-        - "Я слухаю телевізор."
-      explanation: For watching TV, use дивитися телевізор.
-    - sentence: "На моєму вільному часі (англ. In my free time)."
-      error: "На моєму вільному часі"
-      answer: "У мій вільний час."
-      options:
-        - "У мій вільний час."
-        - "На моєму вільному часі."
-        - "До мого вільного часу."
-      explanation: Use у/в + chunk, not на.
-    - sentence: "Ми йдемо до кіно (англ. Go to the movies)."
-      error: "до кіно"
-      answer: "Ми йдемо в кіно."
-      options:
-        - "Ми йдемо в кіно."
-        - "Ми йдемо до кіно."
-        - "Ми йдемо на кіно."
-      explanation: The safe direction chunk is в кіно.
+inline:
+  - id: act-1
+    type: true-false
+    title: Notice board invitations
+    instruction: Decide if each plan is a safe A1 invitation.
+    items:
+      - statement: "Ходімо в кіно в суботу о п'ятій."
+        answer: true
+        explanation: Invitation + place + day + time is a safe plan.
+      - statement: 'Ходімо до кіно в суботу.'
+        answer: false
+        explanation: Use the chunk ходімо в кіно.
+      - statement: 'Давай слухати музику ввечері.'
+        answer: true
+        explanation: Давай + infinitive is a friendly A1 invitation.
+      - statement: 'Я ніколи працюю у неділю.'
+        answer: false
+        explanation: Ніколи needs не, so say я ніколи не працюю.
+      - statement: 'Якщо буде дощ, ходімо в музей.'
+        answer: true
+        explanation: This combines weather and an alternative activity.
+      - statement: 'Брати участь у гуртку.'
+        answer: true
+        explanation: Брати участь is the safe Ukrainian chunk.
+  - id: act-2
+    type: match-up
+    title: Build hobby chunks
+    instruction: Match each verb with the natural hobby chunk.
+    pairs:
+      - left: грати
+        right: у футбол
+      - left: грати
+        right: на гітарі
+      - left: слухати
+        right: музику
+      - left: дивитися
+        right: фільми
+      - left: ходити
+        right: в кіно
+      - left: ходити
+        right: в театр
+      - left: читати
+        right: книгу
+      - left: відпочивати
+        right: вдома
+  - id: act-3
+    type: fill-in
+    title: Frequency and invitations
+    instruction: Choose the word or chunk that completes the sentence.
+    items:
+      - sentence: 'Я ___ працюю у неділю.'
+        answer: ніколи не
+        options:
+          - ніколи не
+          - ніколи
+          - завжди не
+        explanation: Ніколи needs не.
+      - sentence: 'Вона грає у теніс двічі ___.'
+        answer: на тиждень
+        options:
+          - на тиждень
+          - у тиждень
+          - в тиждень
+        explanation: Use раз/двічі/тричі на тиждень.
+      - sentence: '___ в кіно у суботу! — Добре!'
+        answer: Ходімо
+        options:
+          - Ходімо
+          - Ходжу
+          - Ходиш
+        explanation: Ходімо! is the invitation chunk.
+      - sentence: 'Я люблю спорт, тому ___ граю у баскетбол.'
+        answer: часто
+        options:
+          - часто
+          - ніколи
+          - не
+        explanation: Often fits the reason.
+      - sentence: 'Я не маю часу, тому ___ читаю книги.'
+        answer: рідко
+        options:
+          - рідко
+          - завжди
+          - кожен
+        explanation: Little time means rarely.
+      - sentence: '— Що ти робиш ___? — Відпочиваю.'
+        answer: у вихідні
+        options:
+          - у вихідні
+          - вихідні
+          - на вихідні
+        explanation: Use у вихідні for on weekends.
+  - id: act-4
+    type: quiz
+    title: Choose the safe preposition
+    instruction: Pick the phrase that keeps the activity chunk natural.
+    items:
+      - prompt: 'Він грає ___ піаніно.'
+        options:
+          - text: на
+            correct: true
+          - text: у
+            correct: false
+          - text: в
+            correct: false
+        explanation: Instruments use грати на.
+      - prompt: 'Ми граємо ___ футбол.'
+        options:
+          - text: у
+            correct: true
+          - text: на
+            correct: false
+          - text: до
+            correct: false
+        explanation: Sports use грати у/в.
+      - prompt: 'Я хочу ходити ___ концерт.'
+        options:
+          - text: на
+            correct: true
+          - text: в
+            correct: false
+          - text: до
+            correct: false
+        explanation: Use ходити на концерт.
+      - prompt: 'Вони ходять ___ театр раз на місяць.'
+        options:
+          - text: в
+            correct: true
+          - text: на
+            correct: false
+          - text: до
+            correct: false
+        explanation: Use ходити в театр.
+      - prompt: 'Ми йдемо ___ кіно.'
+        options:
+          - text: в
+            correct: true
+          - text: до
+            correct: false
+          - text: на
+            correct: false
+        explanation: The safe chunk is йти в кіно.
+workbook:
+  - type: order
+    title: From weather to plan
+    instruction: Put the planning lines into a natural order.
+    is_ukrainian: true
+    items:
+      - Сьогодні субота.
+      - Оленко, що ти робиш у вихідні?
+      - Зазвичай я гуляю і читаю.
+      - Буде тепло.
+      - Давай грати у футбол о третій.
+      - Добре, а якщо буде дощ?
+      - Якщо буде дощ, ходімо в музей.
+      - Чудово!
+    correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
+  - type: group-sort
+    title: Frequency shelves
+    instruction: Sort the chunks by what they answer.
+    groups:
+      - name: Always or usually
+        items:
+          - завжди
+          - зазвичай
+          - кожен день
+      - name: Sometimes or rarely
+        items:
+          - іноді
+          - інколи
+          - рідко
+      - name: Counted frequency
+        items:
+          - раз на тиждень
+          - двічі на тиждень
+          - раз на місяць
+      - name: Invitations
+        items:
+          - Ходімо в кіно!
+          - Давай грати разом!
+          - Ходімо в музей!
+  - type: translate
+    title: Say a free-time plan
+    instruction: Translate into Ukrainian using the chunks from the lesson.
+    items:
+      - source: 'I often listen to music.'
+        options:
+          - text: 'Я часто слухаю музику.'
+            correct: true
+          - text: 'Я слухаю до музики часто.'
+            correct: false
+          - text: 'Я часто слухаю до музики.'
+            correct: false
+        explanation: Часто usually stands before the verb.
+      - source: 'I play football twice a week.'
+        options:
+          - text: 'Я граю у футбол двічі на тиждень.'
+            correct: true
+          - text: 'Я граю футбол двічі на тиждень.'
+            correct: false
+          - text: 'Я граю на футбол двічі в тиждень.'
+            correct: false
+        explanation: Sports use грати у/в.
+      - source: "Let's go to the cinema on Saturday at five."
+        options:
+          - text: "Ходімо в кіно в суботу о п'ятій."
+            correct: true
+          - text: "Ходімо до кіно в суботу о п'ятій."
+            correct: false
+          - text: "Ходжу в кіно в суботу о п'ятій."
+            correct: false
+        explanation: Ходімо в кіно is the clean invitation.
+      - source: "If it rains, let's go to the museum."
+        options:
+          - text: 'Якщо буде дощ, ходімо в музей.'
+            correct: true
+          - text: 'Якщо буде дощ, ходімо до музей.'
+            correct: false
+          - text: 'Якщо є дощ, ходжу в музей.'
+            correct: false
+        explanation: This combines weather and an alternative.
+      - source: 'I never work on Sunday.'
+        options:
+          - text: 'Я ніколи не працюю у неділю.'
+            correct: true
+          - text: 'Я ніколи працюю у неділю.'
+            correct: false
+          - text: 'Я не ніколи працюю у неділю.'
+            correct: false
+        explanation: Ніколи needs не.
+  - type: error-correction
+    title: Repair hobby interference
+    instruction: Choose the Ukrainian repair for each unsafe learner sentence.
+    items:
+      - sentence: 'Я граю гру (англ. I play a game).'
+        error: 'граю гру'
+        answer: 'Я граю в гру.'
+        options:
+          - 'Я граю в гру.'
+          - 'Я граю гру.'
+          - 'Я граю до гри.'
+        explanation: Games use грати в/у + object.
+      - sentence: 'Я слухаю до музики (англ. I listen to music).'
+        error: 'до музики'
+        answer: 'Я слухаю музику.'
+        options:
+          - 'Я слухаю музику.'
+          - 'Я слухаю до музики.'
+          - 'Я слухаю на музику.'
+        explanation: Слухати takes a direct object without a preposition.
+      - sentence: 'Я займаюся спорт (англ. I do sport).'
+        error: 'спорт'
+        answer: 'Я займаюся спортом.'
+        options:
+          - 'Я займаюся спортом.'
+          - 'Я займаюся спорт.'
+          - 'Я роблю спорт.'
+        explanation: The safe chunk is займатися спортом.
+      - sentence: 'Я дивлюся на телевізор (англ. I look at the TV).'
+        error: 'на телевізор'
+        answer: 'Я дивлюся телевізор.'
+        options:
+          - 'Я дивлюся телевізор.'
+          - 'Я дивлюся на телевізор.'
+          - 'Я слухаю телевізор.'
+        explanation: For watching TV, use дивитися телевізор.
+      - sentence: 'На моєму вільному часі (англ. In my free time).'
+        error: 'На моєму вільному часі'
+        answer: 'У мій вільний час.'
+        options:
+          - 'У мій вільний час.'
+          - 'На моєму вільному часі.'
+          - 'До мого вільного часу.'
+        explanation: Use у/в + chunk, not на.
+      - sentence: 'Ми йдемо до кіно (англ. Go to the movies).'
+        error: 'до кіно'
+        answer: 'Ми йдемо в кіно.'
+        options:
+          - 'Ми йдемо в кіно.'
+          - 'Ми йдемо до кіно.'
+          - 'Ми йдемо на кіно.'
+        explanation: The safe direction chunk is в кіно.

--- a/curriculum/l2-uk-en/a1/free-time/module.md
+++ b/curriculum/l2-uk-en/a1/free-time/module.md
@@ -158,10 +158,6 @@ For a short contrast, use **а** or **але**: **Я часто читаю, а �
 a tiny integrated text, title it **Мій звичайний день** and include one free
 time line. You can also say: **Я люблю кіно, але рідко ходжу в театр.**
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Підсумок
 
 For free time, keep three patterns in your head:
@@ -201,7 +197,3 @@ Write five short lines about your free time:
 <DialogueBox uk="Я граю у футбол двічі на тиждень." en="I play football twice a week." />
 <DialogueBox uk="У суботу о п'ятій ходімо в кіно." en="On Saturday at five, let's go to the cinema." />
 <DialogueBox uk="Якщо буде дощ, ходімо в музей." en="If it rains, let's go to the museum." />
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/my-day/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-day/activities.yaml
@@ -1,307 +1,305 @@
-- id: act-1
-  type: fill-in
-  title: Parts of the day in a real diary
-  instruction: Choose the time chunk that makes the diary line natural.
-  items:
-    - sentence: "___ я прокидаюся і снідаю."
-      answer: вранці
-      options:
-        - вранці
-        - вночі
-        - після обіду
-      explanation: Morning routine starts вранці.
-    - sentence: "___ я працюю з дев'ятої до п'ятої."
-      answer: вдень
-      options:
-        - вдень
-        - вночі
-        - вранці
-      explanation: Workday action usually fits вдень.
-    - sentence: "___ я обідаю о першій."
-      answer: вдень
-      options:
-        - вдень
-        - вночі
-        - ввечері
-      explanation: Lunch belongs to the day.
-    - sentence: "___ я дивлюся фільм."
-      answer: ввечері
-      options:
-        - ввечері
-        - вранці
-        - вночі
-      explanation: Film time often fits evening.
-    - sentence: "___ я лягаю спати."
-      answer: вночі
-      options:
-        - вночі
-        - вдень
-        - вранці
-      explanation: Bedtime fits вночі.
-    - sentence: "___ я маю зробити домашнє завдання."
-      answer: після обіду
-      options:
-        - після обіду
-        - вранці
-        - пів на восьму
-      explanation: Після обіду is a useful afternoon chunk.
-- id: act-2
-  type: order
-  title: Put the diary in order
-  instruction: Put the diary lines from morning to night.
-  is_ukrainian: true
-  items:
-    - О сьомій я прокидаюся.
-    - Спочатку роблю зарядку.
-    - Потім снідаю.
-    - О дев'ятій працюю.
-    - О першій обідаю.
-    - Після обіду читаю.
-    - Ввечері дивлюся фільм.
-    - Нарешті лягаю спати.
-  correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
-- id: act-3
-  type: match-up
-  title: Routine action to useful time
-  instruction: Match each action with a likely time chunk.
-  pairs:
-    - left: прокидаюся
-      right: о сьомій
-    - left: роблю зарядку
-      right: спочатку
-    - left: снідаю
-      right: вранці
-    - left: обідаю
-      right: о першій
-    - left: читаю
-      right: після обіду
-    - left: вечеряю
-      right: ввечері
-    - left: лягаю спати
-      right: вночі
-    - left: планую читати
-      right: у середу
-- id: act-4
-  type: quiz
-  title: Planning conversation choices
-  instruction: Choose the line that keeps the plan safe and A1-sized.
-  items:
-    - prompt: "Що ти будеш робити завтра?"
-      options:
-        - text: Вранці буду працювати.
-          correct: true
-        - text: Вранці я працював учора.
-          correct: false
-        - text: Який час завтра?
-          correct: false
-      explanation: Буду працювати is a ready future chunk.
-    - prompt: "О котрій ти прокидаєшся?"
-      options:
-        - text: О сьомій.
-          correct: true
-        - text: Сім годин.
-          correct: false
-        - text: У сім годин.
-          correct: false
-      explanation: Use о + ordinal time chunk.
-    - prompt: "Хочеш гуляти ввечері?"
-      options:
-        - text: Так. Ходімо в парк!
-          correct: true
-        - text: Так. Давайте підемо в парк!
-          correct: false
-        - text: Так. Який час парк?
-          correct: false
-      explanation: Ходімо! is the safe A1 invitation chunk.
-    - prompt: "Яка сьогодні погода?"
-      options:
-        - text: Сьогодні тепло.
-          correct: true
-        - text: Сьогодні є тепло.
-          correct: false
-        - text: Погода є добре.
-          correct: false
-      explanation: Weather state chunks stay short.
-- id: act-5
-  type: group-sort
-  title: Day shelves
-  instruction: Sort each chunk onto the shelf where it belongs.
-  groups:
-    - name: Morning
-      items:
-        - вранці
-        - я прокидаюся
-        - роблю зарядку
-        - снідаю
-    - name: Day and afternoon
-      items:
-        - вдень
-        - о першій
-        - обідаю
-        - після обіду
-    - name: Evening and night
-      items:
-        - ввечері
-        - вечеряю
-        - вночі
-        - лягаю спати
-    - name: Planning chunks
-      items:
-        - я планую
-        - хочу читати
-        - маю зробити
-        - мені потрібно
-- id: act-6
-  type: unjumble
-  title: Build connected day lines
-  instruction: Put the words in a safe A1 order.
-  items:
-    - words:
-        - Вранці
-        - я
-        - прокидаюся
-      answer: Вранці я прокидаюся
-    - words:
-        - Спочатку
-        - я
-        - снідаю
-      answer: Спочатку я снідаю
-    - words:
-        - О
-        - першій
-        - я
-        - обідаю
-      answer: О першій я обідаю
-    - words:
-        - Після
-        - обіду
-        - я
-        - читаю
-      answer: Після обіду я читаю
-    - words:
-        - У
-        - середу
-        - я
-        - планую
-        - читати
-      answer: У середу я планую читати
-    - words:
-        - Нарешті
-        - я
-        - лягаю
-        - спати
-      answer: Нарешті я лягаю спати
-- id: act-7
-  type: error-correction
-  title: Repair clock and birthday traps
-  instruction: Choose the safe Ukrainian repair.
-  items:
-    - sentence: "Сім годин. (Seven o'clock)"
-      error: "Сім годин"
-      answer: "Сьома година."
-      options:
-        - "Сьома година."
-        - "Сім годин."
-        - "Сьомий година."
-      explanation: For clock time, use the feminine ordinal hour.
-    - sentence: "У шість годин. (At six o'clock)"
-      error: "У шість годин"
-      answer: "О шостій (годині)."
-      options:
-        - "О шостій (годині)."
-        - "У шість годин."
-        - "На шість година."
-      explanation: Action time uses о/об plus the time chunk.
-    - sentence: "Пів сьомої. (Half past six)"
-      error: "Пів сьомої"
-      answer: "Пів на сьому."
-      options:
-        - "Пів на сьому."
-        - "Пів сьомої."
-        - "Половина сьома."
-      explanation: Use пів на + next hour.
-    - sentence: "Без десяти шість. (Ten to six)"
-      error: "Без десяти шість"
-      answer: "За десять шоста."
-      options:
-        - "За десять шоста."
-        - "Десять до шостої."
-        - "Без десяти шість."
-      explanation: Use за or до, not без.
-    - sentence: "Моє день народження. (My birthday)"
-      error: "Моє"
-      answer: "Мій день народження."
-      options:
-        - "Мій день народження."
-        - "Моє день народження."
-        - "Моя день народження."
-      explanation: День is masculine, so use мій.
-    - sentence: "П'ять після восьми. (Five past eight)"
-      error: "після"
-      answer: "П'ять по восьмій."
-      options:
-        - "П'ять по восьмій."
-        - "П'ять хвилин на дев'яту."
-        - "П'ять після восьми."
-      explanation: Use по or на for this clock phrase, not після.
-- id: act-8
-  type: fill-in
-  title: Repair routine Ukrainian
-  instruction: Choose the safe routine word or chunk.
-  items:
-    - sentence: "Вранці я ___."
-      answer: беру душ
-      options:
-        - беру душ
-        - приймаю душ
-        - маю душ
-      explanation: Use брати душ.
-    - sentence: "Коли я хворий, я ___."
-      answer: п'ю ліки
-      options:
-        - п'ю ліки
-        - приймаю ліки
-        - беру ліки
-      explanation: Use пити ліки.
-    - sentence: "___ зараз? — Восьма."
-      answer: Котра година
-      options:
-        - Котра година
-        - Який час
-        - Скільки години
-      explanation: Use Котра година? for clock time.
-    - sentence: "___ в парк після обіду!"
-      answer: Ходімо
-      options:
-        - Ходімо
-        - Давайте підемо
-        - Пішли давайте
-      explanation: Use Ходімо! as a whole invitation chunk.
-    - sentence: "О восьмій годині я їм ___."
-      answer: сніданок
-      options:
-        - сніданок
-        - завтрак
-        - ранкову їжу
-      explanation: Use сніданок.
-    - sentence: "Мама готує дуже ___ обід."
-      answer: смачний
-      options:
-        - смачний
-        - вкусний
-        - смаковий
-      explanation: Use смачний.
-    - sentence: "Ввечері я хочу ___."
-      answer: поїсти
-      options:
-        - поїсти
-        - покушати
-        - їстися
-      explanation: Use поїсти.
-    - sentence: "О сьомій я ___ і встав."
-      answer: прокинувся
-      options:
-        - прокинувся
-        - проснувся
-        - прокидав
-      explanation: Use прокинувся as the safe recognition chunk here.
+inline:
+  - id: act-1
+    type: fill-in
+    title: Parts of the day in a real diary
+    instruction: Choose the time chunk that makes the diary line natural.
+    items:
+      - sentence: '___ я прокидаюся і снідаю.'
+        answer: вранці
+        options:
+          - вранці
+          - вночі
+          - після обіду
+        explanation: Morning routine starts вранці.
+      - sentence: "___ я працюю з дев'ятої до п'ятої."
+        answer: вдень
+        options:
+          - вдень
+          - вночі
+          - вранці
+        explanation: Workday action usually fits вдень.
+      - sentence: '___ я обідаю о першій.'
+        answer: вдень
+        options:
+          - вдень
+          - вночі
+          - ввечері
+        explanation: Lunch belongs to the day.
+      - sentence: '___ я дивлюся фільм.'
+        answer: ввечері
+        options:
+          - ввечері
+          - вранці
+          - вночі
+        explanation: Film time often fits evening.
+      - sentence: '___ я лягаю спати.'
+        answer: вночі
+        options:
+          - вночі
+          - вдень
+          - вранці
+        explanation: Bedtime fits вночі.
+      - sentence: '___ я маю зробити домашнє завдання.'
+        answer: після обіду
+        options:
+          - після обіду
+          - вранці
+          - пів на восьму
+        explanation: Після обіду is a useful afternoon chunk.
+  - id: act-2
+    type: order
+    title: Put the diary in order
+    instruction: Put the diary lines from morning to night.
+    is_ukrainian: true
+    items:
+      - О сьомій я прокидаюся.
+      - Спочатку роблю зарядку.
+      - Потім снідаю.
+      - О дев'ятій працюю.
+      - О першій обідаю.
+      - Після обіду читаю.
+      - Ввечері дивлюся фільм.
+      - Нарешті лягаю спати.
+    correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
+  - id: act-3
+    type: match-up
+    title: Routine action to useful time
+    instruction: Match each action with a likely time chunk.
+    pairs:
+      - left: прокидаюся
+        right: о сьомій
+      - left: роблю зарядку
+        right: спочатку
+      - left: снідаю
+        right: вранці
+      - left: обідаю
+        right: о першій
+      - left: читаю
+        right: після обіду
+      - left: вечеряю
+        right: ввечері
+      - left: лягаю спати
+        right: вночі
+      - left: планую читати
+        right: у середу
+  - id: act-4
+    type: quiz
+    title: Planning conversation choices
+    instruction: Choose the line that keeps the plan safe and A1-sized.
+    items:
+      - prompt: 'Що ти будеш робити завтра?'
+        options:
+          - text: Вранці буду працювати.
+            correct: true
+          - text: Вранці я працював учора.
+            correct: false
+          - text: Який час завтра?
+            correct: false
+        explanation: Буду працювати is a ready future chunk.
+      - prompt: 'О котрій ти прокидаєшся?'
+        options:
+          - text: О сьомій.
+            correct: true
+          - text: Сім годин.
+            correct: false
+          - text: У сім годин.
+            correct: false
+        explanation: Use о + ordinal time chunk.
+      - prompt: 'Хочеш гуляти ввечері?'
+        options:
+          - text: Так. Ходімо в парк!
+            correct: true
+          - text: Так. Давайте підемо в парк!
+            correct: false
+          - text: Так. Який час парк?
+            correct: false
+        explanation: Ходімо! is the safe A1 invitation chunk.
+      - prompt: 'Яка сьогодні погода?'
+        options:
+          - text: Сьогодні тепло.
+            correct: true
+          - text: Сьогодні є тепло.
+            correct: false
+          - text: Погода є добре.
+            correct: false
+        explanation: Weather state chunks stay short.
+workbook:
+  - type: group-sort
+    title: Day shelves
+    instruction: Sort each chunk onto the shelf where it belongs.
+    groups:
+      - name: Morning
+        items:
+          - вранці
+          - я прокидаюся
+          - роблю зарядку
+          - снідаю
+      - name: Day and afternoon
+        items:
+          - вдень
+          - о першій
+          - обідаю
+          - після обіду
+      - name: Evening and night
+        items:
+          - ввечері
+          - вечеряю
+          - вночі
+          - лягаю спати
+      - name: Planning chunks
+        items:
+          - я планую
+          - хочу читати
+          - маю зробити
+          - мені потрібно
+  - type: unjumble
+    title: Build connected day lines
+    instruction: Put the words in a safe A1 order.
+    items:
+      - words:
+          - Вранці
+          - я
+          - прокидаюся
+        answer: Вранці я прокидаюся
+      - words:
+          - Спочатку
+          - я
+          - снідаю
+        answer: Спочатку я снідаю
+      - words:
+          - О
+          - першій
+          - я
+          - обідаю
+        answer: О першій я обідаю
+      - words:
+          - Після
+          - обіду
+          - я
+          - читаю
+        answer: Після обіду я читаю
+      - words:
+          - У
+          - середу
+          - я
+          - планую
+          - читати
+        answer: У середу я планую читати
+      - words:
+          - Нарешті
+          - я
+          - лягаю
+          - спати
+        answer: Нарешті я лягаю спати
+  - type: error-correction
+    title: Repair clock and birthday traps
+    instruction: Choose the safe Ukrainian repair.
+    items:
+      - sentence: "Сім годин. (Seven o'clock)"
+        error: 'Сім годин'
+        answer: 'Сьома година.'
+        options:
+          - 'Сьома година.'
+          - 'Сім годин.'
+          - 'Сьомий година.'
+        explanation: For clock time, use the feminine ordinal hour.
+      - sentence: "У шість годин. (At six o'clock)"
+        error: 'У шість годин'
+        answer: 'О шостій (годині).'
+        options:
+          - 'О шостій (годині).'
+          - 'У шість годин.'
+          - 'На шість година.'
+        explanation: Action time uses о/об plus the time chunk.
+      - sentence: 'Пів сьомої. (Half past six)'
+        error: 'Пів сьомої'
+        answer: 'Пів на сьому.'
+        options:
+          - 'Пів на сьому.'
+          - 'Пів сьомої.'
+          - 'Половина сьома.'
+        explanation: Use пів на + next hour.
+      - sentence: 'Без десяти шість. (Ten to six)'
+        error: 'Без десяти шість'
+        answer: 'За десять шоста.'
+        options:
+          - 'За десять шоста.'
+          - 'Десять до шостої.'
+          - 'Без десяти шість.'
+        explanation: Use за or до, not без.
+      - sentence: 'Моє день народження. (My birthday)'
+        error: 'Моє'
+        answer: 'Мій день народження.'
+        options:
+          - 'Мій день народження.'
+          - 'Моє день народження.'
+          - 'Моя день народження.'
+        explanation: День is masculine, so use мій.
+      - sentence: "П'ять після восьми. (Five past eight)"
+        error: 'після'
+        answer: "П'ять по восьмій."
+        options:
+          - "П'ять по восьмій."
+          - "П'ять хвилин на дев'яту."
+          - "П'ять після восьми."
+        explanation: Use по or на for this clock phrase, not після.
+  - type: fill-in
+    title: Repair routine Ukrainian
+    instruction: Choose the safe routine word or chunk.
+    items:
+      - sentence: 'Вранці я ___.'
+        answer: беру душ
+        options:
+          - беру душ
+          - приймаю душ
+          - маю душ
+        explanation: Use брати душ.
+      - sentence: 'Коли я хворий, я ___.'
+        answer: п'ю ліки
+        options:
+          - п'ю ліки
+          - приймаю ліки
+          - беру ліки
+        explanation: Use пити ліки.
+      - sentence: '___ зараз? — Восьма.'
+        answer: Котра година
+        options:
+          - Котра година
+          - Який час
+          - Скільки години
+        explanation: Use Котра година? for clock time.
+      - sentence: '___ в парк після обіду!'
+        answer: Ходімо
+        options:
+          - Ходімо
+          - Давайте підемо
+          - Пішли давайте
+        explanation: Use Ходімо! as a whole invitation chunk.
+      - sentence: 'О восьмій годині я їм ___.'
+        answer: сніданок
+        options:
+          - сніданок
+          - завтрак
+          - ранкову їжу
+        explanation: Use сніданок.
+      - sentence: 'Мама готує дуже ___ обід.'
+        answer: смачний
+        options:
+          - смачний
+          - вкусний
+          - смаковий
+        explanation: Use смачний.
+      - sentence: 'Ввечері я хочу ___.'
+        answer: поїсти
+        options:
+          - поїсти
+          - покушати
+          - їстися
+        explanation: Use поїсти.
+      - sentence: 'О сьомій я ___ і встав.'
+        answer: прокинувся
+        options:
+          - прокинувся
+          - проснувся
+          - прокидав
+        explanation: Use прокинувся as the safe recognition chunk here.

--- a/curriculum/l2-uk-en/a1/my-day/module.md
+++ b/curriculum/l2-uk-en/a1/my-day/module.md
@@ -141,10 +141,6 @@ Planning uses light chunks, not a full future-tense lesson:
 The dictionary verb is **планувати**, but the useful A1 line is **я планую**.
 For duty, keep the paired chunk **маю / мені потрібно** plus an infinitive.
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Підсумок
 
 Build a day from three parts:
@@ -182,7 +178,3 @@ study, one for lunch, one for weather, one for a plan, and one for the evening:
 <DialogueBox uk="О дев'ятій я працюю." en="At nine I work." />
 <DialogueBox uk="Після обіду я планую читати." en="After lunch I plan to read." />
 <DialogueBox uk="Ввечері лягаю спати о десятій." en="In the evening I go to bed at ten." />
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/weather/activities.yaml
+++ b/curriculum/l2-uk-en/a1/weather/activities.yaml
@@ -1,260 +1,258 @@
-- id: act-1
-  type: match-up
-  title: Weather line to real-world clue
-  instruction: Match each Ukrainian weather line with the best clue.
-  pairs:
-    - left: Іде дощ.
-      right: umbrella
-    - left: Іде сніг.
-      right: winter street
-    - left: Світить сонце.
-      right: sunglasses
-    - left: Дме вітер.
-      right: moving trees
-    - left: Мінус десять.
-      right: very cold
-    - left: Плюс тридцять.
-      right: very hot
-    - left: Сьогодні хмарно.
-      right: no visible sun
-    - left: Завтра буде тепло.
-      right: good day for a walk
-- id: act-2
-  type: fill-in
-  title: Window weather chunks
-  instruction: Complete each window line with the safe weather chunk.
-  items:
-    - sentence: "Яка сьогодні погода? Сьогодні ___."
-      answer: холодно
-      options:
-        - холодно
-        - холодний
-        - я холодно
-      explanation: Weather state words do not need a subject.
-    - sentence: "Надворі ___. Сонця не видно."
-      answer: хмарно
-      options:
-        - хмарно
-        - хмара
-        - хмарний погода
-      explanation: Хмарно answers the weather question as a state.
-    - sentence: "Зараз ___ дощ."
-      answer: іде
-      options:
-        - іде
-        - є
-        - має
-      explanation: Іде дощ is the safe precipitation chunk.
-    - sentence: "Завтра ___ тепло і сонячно."
-      answer: буде
-      options:
-        - буде
-        - є
-        - має
-      explanation: Завтра буде... is the simple future weather frame.
-    - sentence: "Влітку дуже ___."
-      answer: спекотно
-      options:
-        - спекотно
-        - спекотний
-        - жар
-      explanation: Use спекотно for hot weather.
-    - sentence: "Увечері мені ___."
-      answer: холодно
-      options:
-        - холодно
-        - холодний
-        - холод
-      explanation: Мені холодно describes a person's state.
-- id: act-3
-  type: odd-one-out
-  title: Find the unsafe weather line
-  instruction: Choose the line that does not fit the safe Ukrainian pattern.
-  items:
-    - words:
-        - Сьогодні тепло.
-        - Надворі сонячно.
-        - Це є дуже сонячно.
-        - Завтра буде тепло.
-      answer: Це є дуже сонячно.
-      explanation: Do not copy English it is with це є for this weather line.
-    - words:
-        - Іде дощ.
-        - Іде сніг.
-        - Він іде дощ.
-        - Дме вітер.
-      answer: Він іде дощ.
-      explanation: Rain does not need він.
-    - words:
-        - Мені холодно.
-        - Мені вдень було холодно.
-        - Я є холодно.
-        - На вулиці холодно.
-      answer: Я є холодно.
-      explanation: Use мені for a person's state.
-    - words:
-        - опади
-        - сніг
-        - дощ
-        - осадки
-      answer: осадки
-      explanation: Use the Ukrainian weather noun опади.
-- id: act-4
-  type: group-sort
-  title: Season weather shelves
-  instruction: Sort each chunk onto the season where it first fits.
-  groups:
-    - name: ЗИМА
-      items:
-        - іде сніг
-        - мороз
-        - мінус десять
-        - холодно
-    - name: Весна
-      items:
-        - тепло
-        - світить сонце
-        - іде дощ
-        - квітень
-    - name: Літо
-      items:
-        - спекотно
-        - сонячно
-        - плюс тридцять
-        - липень
-    - name: Осінь
-      items:
-        - прохолодно
-        - хмарно
-        - часто йде дощ
-        - листопад
-- id: act-5
-  type: true-false
-  title: Weather pattern checks
-  instruction: Decide whether each statement describes the Ukrainian weather pattern safely.
-  items:
-    - statement: "Холодно, тепло, сонячно, and хмарно can answer Яка погода?"
-      correct: true
-      explanation: They are safe state words for weather.
-    - statement: "Ukrainian needs це є before every weather state."
-      correct: false
-      explanation: Say Сьогодні холодно or Надворі сонячно.
-    - statement: "Іде дощ is the safe A1 precipitation chunk."
-      correct: true
-      explanation: It is the default spoken pattern for rain.
-    - statement: "Дощ падає зараз is the best first A1 weather line."
-      correct: false
-      explanation: Learn Іде дощ first.
-    - statement: "Сніг and мороз naturally sort with ЗИМА in the first season map."
-      correct: true
-      explanation: This is the basic weather-season link.
-    - statement: "Мені подобається теплий дощ is safer than Я подобаюсь теплий дощ."
-      correct: true
-      explanation: Use Мені подобається... for likes.
-- id: act-6
-  type: translate
-  title: Build weather notes
-  instruction: Choose the safe Ukrainian weather note.
-  questions:
-    - source: Today it is cold.
-      options:
-        - text: "Сьогодні холодно."
-          correct: true
-        - text: "Сьогодні є холодно."
-          correct: false
-        - text: "Я холодно сьогодні."
-          correct: false
-      explanation: Use the state word without English-style it is.
-    - source: It is raining now.
-      options:
-        - text: "Зараз іде дощ."
-          correct: true
-        - text: "Дощ падає зараз."
-          correct: false
-        - text: "Це дощить зараз."
-          correct: false
-      explanation: Іде дощ is the target A1 chunk.
-    - source: In summer it is hot and sunny.
-      options:
-        - text: "Влітку спекотно і сонячно."
-          correct: true
-        - text: "В літо спекотний і сонячний."
-          correct: false
-        - text: "Літо є жар."
-          correct: false
-      explanation: Use the season chunk влітку and state words.
-    - source: I like spring.
-      options:
-        - text: "Мені подобається весна."
-          correct: true
-        - text: "Я подобаюсь весна."
-          correct: false
-        - text: "Я є подобається весна."
-          correct: false
-      explanation: Мені подобається... is the safe preference frame.
-    - source: I am cold in the evening.
-      options:
-        - text: "Увечері мені холодно."
-          correct: true
-        - text: "Увечері я є холодно."
-          correct: false
-        - text: "Увечері я маю холодно."
-          correct: false
-      explanation: Use мені холодно for a person's state.
-- id: act-7
-  type: order
-  title: Plan the walk after checking weather
-  instruction: Put the dialogue in a logical order.
-  is_ukrainian: true
-  items:
-    - Яка сьогодні погода?
-    - Сьогодні холодно і йде дощ.
-    - А завтра?
-    - Завтра буде тепло і сонячно.
-    - Добре! Тоді завтра гуляємо.
-  correct_order: [0, 1, 2, 3, 4]
-- id: act-8
-  type: error-correction
-  title: Repair weather calques
-  instruction: Choose the safe Ukrainian repair.
-  items:
-    - sentence: "Це є дуже сонячно."
-      error: "Це є"
-      answer: "Надворі сонячно."
-      options:
-        - "Надворі сонячно."
-        - "Це є дуже сонячно."
-        - "Сонячний є надворі."
-      explanation: Weather states can stand without це є.
-    - sentence: "Він іде дощ."
-      error: "Він"
-      answer: "Зараз іде дощ."
-      options:
-        - "Зараз іде дощ."
-        - "Він іде дощ."
-        - "Дощ має іти."
-      explanation: Rain does not take він.
-    - sentence: "Я є холодно."
-      error: "Я є"
-      answer: "Мені холодно."
-      options:
-        - "Мені холодно."
-        - "Я є холодно."
-        - "Я маю холодно."
-      explanation: Use мені for a person's state.
-    - sentence: "Сьогодні погода є добре."
-      error: "добре"
-      answer: "Сьогодні гарна погода."
-      options:
-        - "Сьогодні гарна погода."
-        - "Сьогодні погода є добре."
-        - "Сьогодні добрий погода."
-      explanation: Погода is feminine, so use гарна.
-    - sentence: "Я подобаюсь теплий дощ."
-      error: "Я подобаюсь"
-      answer: "Мені подобається теплий дощ."
-      options:
-        - "Мені подобається теплий дощ."
-        - "Я подобаюсь теплий дощ."
-        - "Я є люблю теплий дощ."
-      explanation: Use Мені подобається... for likes.
+inline:
+  - id: act-1
+    type: match-up
+    title: Weather line to real-world clue
+    instruction: Match each Ukrainian weather line with the best clue.
+    pairs:
+      - left: Іде дощ.
+        right: umbrella
+      - left: Іде сніг.
+        right: winter street
+      - left: Світить сонце.
+        right: sunglasses
+      - left: Дме вітер.
+        right: moving trees
+      - left: Мінус десять.
+        right: very cold
+      - left: Плюс тридцять.
+        right: very hot
+      - left: Сьогодні хмарно.
+        right: no visible sun
+      - left: Завтра буде тепло.
+        right: good day for a walk
+  - id: act-2
+    type: fill-in
+    title: Window weather chunks
+    instruction: Complete each window line with the safe weather chunk.
+    items:
+      - sentence: 'Яка сьогодні погода? Сьогодні ___.'
+        answer: холодно
+        options:
+          - холодно
+          - холодний
+          - я холодно
+        explanation: Weather state words do not need a subject.
+      - sentence: 'Надворі ___. Сонця не видно.'
+        answer: хмарно
+        options:
+          - хмарно
+          - хмара
+          - хмарний погода
+        explanation: Хмарно answers the weather question as a state.
+      - sentence: 'Зараз ___ дощ.'
+        answer: іде
+        options:
+          - іде
+          - є
+          - має
+        explanation: Іде дощ is the safe precipitation chunk.
+      - sentence: 'Завтра ___ тепло і сонячно.'
+        answer: буде
+        options:
+          - буде
+          - є
+          - має
+        explanation: Завтра буде... is the simple future weather frame.
+      - sentence: 'Влітку дуже ___.'
+        answer: спекотно
+        options:
+          - спекотно
+          - спекотний
+          - жар
+        explanation: Use спекотно for hot weather.
+      - sentence: 'Увечері мені ___.'
+        answer: холодно
+        options:
+          - холодно
+          - холодний
+          - холод
+        explanation: Мені холодно describes a person's state.
+  - id: act-3
+    type: odd-one-out
+    title: Find the unsafe weather line
+    instruction: Choose the line that does not fit the safe Ukrainian pattern.
+    items:
+      - words:
+          - Сьогодні тепло.
+          - Надворі сонячно.
+          - Це є дуже сонячно.
+          - Завтра буде тепло.
+        answer: Це є дуже сонячно.
+        explanation: Do not copy English it is with це є for this weather line.
+      - words:
+          - Іде дощ.
+          - Іде сніг.
+          - Він іде дощ.
+          - Дме вітер.
+        answer: Він іде дощ.
+        explanation: Rain does not need він.
+      - words:
+          - Мені холодно.
+          - Мені вдень було холодно.
+          - Я є холодно.
+          - На вулиці холодно.
+        answer: Я є холодно.
+        explanation: Use мені for a person's state.
+      - words:
+          - опади
+          - сніг
+          - дощ
+          - осадки
+        answer: осадки
+        explanation: Use the Ukrainian weather noun опади.
+  - id: act-4
+    type: group-sort
+    title: Season weather shelves
+    instruction: Sort each chunk onto the season where it first fits.
+    groups:
+      - name: ЗИМА
+        items:
+          - іде сніг
+          - мороз
+          - мінус десять
+          - холодно
+      - name: Весна
+        items:
+          - тепло
+          - світить сонце
+          - іде дощ
+          - квітень
+      - name: Літо
+        items:
+          - спекотно
+          - сонячно
+          - плюс тридцять
+          - липень
+      - name: Осінь
+        items:
+          - прохолодно
+          - хмарно
+          - часто йде дощ
+          - листопад
+workbook:
+  - type: true-false
+    title: Weather pattern checks
+    instruction: Decide whether each statement describes the Ukrainian weather pattern safely.
+    items:
+      - statement: 'Холодно, тепло, сонячно, and хмарно can answer Яка погода?'
+        correct: true
+        explanation: They are safe state words for weather.
+      - statement: 'Ukrainian needs це є before every weather state.'
+        correct: false
+        explanation: Say Сьогодні холодно or Надворі сонячно.
+      - statement: 'Іде дощ is the safe A1 precipitation chunk.'
+        correct: true
+        explanation: It is the default spoken pattern for rain.
+      - statement: 'Дощ падає зараз is the best first A1 weather line.'
+        correct: false
+        explanation: Learn Іде дощ first.
+      - statement: 'Сніг and мороз naturally sort with ЗИМА in the first season map.'
+        correct: true
+        explanation: This is the basic weather-season link.
+      - statement: 'Мені подобається теплий дощ is safer than Я подобаюсь теплий дощ.'
+        correct: true
+        explanation: Use Мені подобається... for likes.
+  - type: translate
+    title: Build weather notes
+    instruction: Choose the safe Ukrainian weather note.
+    questions:
+      - source: Today it is cold.
+        options:
+          - text: 'Сьогодні холодно.'
+            correct: true
+          - text: 'Сьогодні є холодно.'
+            correct: false
+          - text: 'Я холодно сьогодні.'
+            correct: false
+        explanation: Use the state word without English-style it is.
+      - source: It is raining now.
+        options:
+          - text: 'Зараз іде дощ.'
+            correct: true
+          - text: 'Дощ падає зараз.'
+            correct: false
+          - text: 'Це дощить зараз.'
+            correct: false
+        explanation: Іде дощ is the target A1 chunk.
+      - source: In summer it is hot and sunny.
+        options:
+          - text: 'Влітку спекотно і сонячно.'
+            correct: true
+          - text: 'В літо спекотний і сонячний.'
+            correct: false
+          - text: 'Літо є жар.'
+            correct: false
+        explanation: Use the season chunk влітку and state words.
+      - source: I like spring.
+        options:
+          - text: 'Мені подобається весна.'
+            correct: true
+          - text: 'Я подобаюсь весна.'
+            correct: false
+          - text: 'Я є подобається весна.'
+            correct: false
+        explanation: Мені подобається... is the safe preference frame.
+      - source: I am cold in the evening.
+        options:
+          - text: 'Увечері мені холодно.'
+            correct: true
+          - text: 'Увечері я є холодно.'
+            correct: false
+          - text: 'Увечері я маю холодно.'
+            correct: false
+        explanation: Use мені холодно for a person's state.
+  - type: order
+    title: Plan the walk after checking weather
+    instruction: Put the dialogue in a logical order.
+    is_ukrainian: true
+    items:
+      - Яка сьогодні погода?
+      - Сьогодні холодно і йде дощ.
+      - А завтра?
+      - Завтра буде тепло і сонячно.
+      - Добре! Тоді завтра гуляємо.
+    correct_order: [0, 1, 2, 3, 4]
+  - type: error-correction
+    title: Repair weather calques
+    instruction: Choose the safe Ukrainian repair.
+    items:
+      - sentence: 'Це є дуже сонячно.'
+        error: 'Це є'
+        answer: 'Надворі сонячно.'
+        options:
+          - 'Надворі сонячно.'
+          - 'Це є дуже сонячно.'
+          - 'Сонячний є надворі.'
+        explanation: Weather states can stand without це є.
+      - sentence: 'Він іде дощ.'
+        error: 'Він'
+        answer: 'Зараз іде дощ.'
+        options:
+          - 'Зараз іде дощ.'
+          - 'Він іде дощ.'
+          - 'Дощ має іти.'
+        explanation: Rain does not take він.
+      - sentence: 'Я є холодно.'
+        error: 'Я є'
+        answer: 'Мені холодно.'
+        options:
+          - 'Мені холодно.'
+          - 'Я є холодно.'
+          - 'Я маю холодно.'
+        explanation: Use мені for a person's state.
+      - sentence: 'Сьогодні погода є добре.'
+        error: 'добре'
+        answer: 'Сьогодні гарна погода.'
+        options:
+          - 'Сьогодні гарна погода.'
+          - 'Сьогодні погода є добре.'
+          - 'Сьогодні добрий погода.'
+        explanation: Погода is feminine, so use гарна.
+      - sentence: 'Я подобаюсь теплий дощ.'
+        error: 'Я подобаюсь'
+        answer: 'Мені подобається теплий дощ.'
+        options:
+          - 'Мені подобається теплий дощ.'
+          - 'Я подобаюсь теплий дощ.'
+          - 'Я є люблю теплий дощ.'
+        explanation: Use Мені подобається... for likes.

--- a/curriculum/l2-uk-en/a1/weather/module.md
+++ b/curriculum/l2-uk-en/a1/weather/module.md
@@ -162,10 +162,6 @@ Use the Ukrainian weather noun **опади** for precipitation. Do not use
 **осадки**. For hot weather, prefer **спекотно** and **спекотний**. You may
 hear **жарко**, but **спекотно** is the better course word.
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Підсумок
 
 Keep four weather cards.
@@ -210,7 +206,3 @@ Write your own five-line weather note:
 <DialogueBox uk="Іде дощ." en="It is raining." />
 <DialogueBox uk="Завтра буде тепло." en="Tomorrow it will be warm." />
 <DialogueBox uk="Мені подобається весна." en="I like spring." />
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/what-time/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-time/activities.yaml
@@ -1,259 +1,257 @@
-- id: act-1
-  type: quiz
-  title: Choose the clock answer
-  instruction: Choose the safe answer to "Котра година?"
-  items:
-    - prompt: "1:00"
-      options:
-        - text: Перша.
-          correct: true
-        - text: Один година.
-          correct: false
-        - text: О першій.
-          correct: false
-      explanation: "Котра година? asks for the clock label: перша."
-    - prompt: "5:00"
-      options:
-        - text: П'ята.
-          correct: true
-        - text: П'ять годин.
-          correct: false
-        - text: О п'ятій.
-          correct: false
-      explanation: "П'ята is the point on the clock; п'ять годин is duration."
-    - prompt: "8:00"
-      options:
-        - text: Восьма.
-          correct: true
-        - text: Вісім годин.
-          correct: false
-        - text: У восьмій.
-          correct: false
-      explanation: "Use the feminine ordinal form for the hour."
-    - prompt: "11:00"
-      options:
-        - text: Одинадцята.
-          correct: true
-        - text: Об одинадцятій.
-          correct: false
-        - text: Одинадцять годин.
-          correct: false
-      explanation: "Одинадцята answers what time it is now."
-- id: act-2
-  type: match-up
-  title: Digital time to Ukrainian chunk
-  instruction: Match the digital time with the Ukrainian phrase.
-  pairs:
-    - left: "2:00"
-      right: друга
-    - left: "4:00"
-      right: четверта
-    - left: "7:00"
-      right: сьома
-    - left: "10:00"
-      right: десята
-    - left: "1:30"
-      right: пів на другу
-    - left: "6:30"
-      right: пів на сьому
-    - left: "7:15"
-      right: чверть на восьму
-    - left: "7:45"
-      right: за чверть восьма
-- id: act-3
-  type: fill-in
-  title: Schedule time gaps
-  instruction: Choose the schedule chunk that completes the sentence.
-  items:
-    - sentence: "Я прокидаюся ___."
-      answer: о сьомій
-      options:
-        - о сьомій
-        - сьома
-        - у сім годин
-      explanation: "A scheduled action uses о + the schedule form."
-    - sentence: "Ми снідаємо ___."
-      answer: о восьмій
-      options:
-        - о восьмій
-        - восьма
-        - у восьму
-      explanation: "Use о восьмій for at eight."
-    - sentence: "Зустріч ___."
-      answer: о другій
-      options:
-        - о другій
-        - друга
-        - у два
-      explanation: "Meetings happen о другій."
-    - sentence: "Фільм починається ___."
-      answer: об одинадцятій
-      options:
-        - об одинадцятій
-        - о одинадцятій
-        - одинадцята
-      explanation: "Before одинадцятій, use об."
-    - sentence: "Обід ___."
-      answer: о першій дня
-      options:
-        - о першій дня
-        - перша дня
-        - у один день
-      explanation: "О першій дня means at one in the afternoon."
-    - sentence: "Вечеря ___."
-      answer: о сьомій вечора
-      options:
-        - о сьомій вечора
-        - сьома вечора
-        - у сьому вечора
-      explanation: "Use о сьомій for the scheduled action."
-- id: act-4
-  type: true-false
-  title: Full hour or duration
-  instruction: Decide whether each note is safe for this lesson.
-  items:
-    - statement: "Зараз п'ята means it is five o'clock."
-      correct: true
-      explanation: "П'ята is the clock-hour label."
-    - statement: "П'ять годин means five o'clock."
-      correct: false
-      explanation: "П'ять годин means a duration of five hours."
-    - statement: "Котра година? asks for the current time."
-      correct: true
-      explanation: "Answer with перша, друга, третя, and so on."
-    - statement: "О котрій годині? asks when an action happens."
-      correct: true
-      explanation: "Answer with о першій, о другій, о третій."
-    - statement: "Пів на восьму means 7:30."
-      correct: true
-      explanation: "The half-hour chunk looks toward the next hour."
-    - statement: "Пів восьмої is the safe A1 chunk."
-      correct: false
-      explanation: "Use пів на восьму."
-- id: act-5
-  type: group-sort
-  title: What job does the phrase do?
-  instruction: Sort each phrase by its time job.
-  groups:
-    - name: Clock answer
-      items:
-        - перша
-        - п'ята
-        - десята
-        - дванадцята
-    - name: Schedule answer
-      items:
-        - о першій
-        - о п'ятій
-        - об одинадцятій
-        - о дванадцятій
-    - name: Time of day
-      items:
-        - ранку
-        - дня
-        - вечора
-        - ночі
-- id: act-6
-  type: order
-  title: Set the meeting time
-  instruction: Put the phone exchange in a natural order.
-  items:
-    - Добрий день! Котра година?
-    - Зараз десята.
-    - О котрій ти працюєш?
-    - Я працюю о дев'ятій.
-    - Тоді зустріч о другій?
-    - Так, о другій добре.
-  correct_order:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-- id: act-7
-  type: translate
-  title: Build a safe time line
-  instruction: Choose the Ukrainian line that matches the English prompt.
-  items:
-    - source: "It is seven now."
-      options:
-        - text: Зараз сьома.
-          correct: true
-        - text: Зараз сім годин.
-          correct: false
-        - text: Зараз є сім.
-          correct: false
-      explanation: "Clock time uses the ordinal hour word."
-    - source: "I wake up at seven in the morning."
-      options:
-        - text: Я прокидаюся о сьомій ранку.
-          correct: true
-        - text: Я прокидаюся у сім годин.
-          correct: false
-        - text: Я прокидаюся сьома ранку.
-          correct: false
-      explanation: "A schedule uses о сьомій."
-    - source: "The meeting is at two."
-      options:
-        - text: Зустріч о другій.
-          correct: true
-        - text: Зустріч у дві години.
-          correct: false
-        - text: Зустріч друга.
-          correct: false
-      explanation: "Use о другій for the planned time."
-    - source: "It is half past six."
-      options:
-        - text: Пів на сьому.
-          correct: true
-        - text: Пів сьомої.
-          correct: false
-        - text: Половина після шостої.
-          correct: false
-      explanation: "The safe chunk is пів на + next hour."
-- id: act-8
-  type: error-correction
-  title: Repair time traps
-  instruction: Choose the standard Ukrainian repair.
-  items:
-    - sentence: "Зараз є п'ять годин."
-      error: "Зараз є п'ять годин."
-      answer: "Зараз п'ята (година)."
-      options:
-        - "Зараз п'ята (година)."
-        - "Зараз є п'ять годин."
-        - "Зараз о п'ятій."
-      explanation: "For clock time, use the feminine ordinal hour and no є."
-    - sentence: "Уроки починаються у вісім годин."
-      error: "у вісім годин"
-      answer: "Уроки починаються о восьмій."
-      options:
-        - "Уроки починаються о восьмій."
-        - "Уроки починаються у вісім годин."
-        - "Уроки починаються восьма."
-      explanation: "Scheduled time uses о/об, not у/в."
-    - sentence: "Чверть після сьомої."
-      error: "після"
-      answer: "Чверть на восьму. (або чверть по сьомій)"
-      options:
-        - "Чверть на восьму. (або чверть по сьомій)"
-        - "Чверть після сьомої."
-        - "Чверть без восьмої."
-      explanation: "Use на or по for the first half of the hour."
-    - sentence: "Пів восьмої."
-      error: "Пів восьмої."
-      answer: "Пів на восьму."
-      options:
-        - "Пів на восьму."
-        - "Пів восьмої."
-        - "Половина після сьомої."
-      explanation: "На is part of the half-hour chunk."
-    - sentence: "Без двадцяти три."
-      error: "Без"
-      answer: "За двадцять третя. (або двадцять до третьої)"
-      options:
-        - "За двадцять третя. (або двадцять до третьої)"
-        - "Без двадцяти три."
-        - "Після двадцяти третьої."
-      explanation: "Use за or до, not без, for time before the next hour."
+inline:
+  - id: act-1
+    type: quiz
+    title: Choose the clock answer
+    instruction: Choose the safe answer to "Котра година?"
+    items:
+      - prompt: '1:00'
+        options:
+          - text: Перша.
+            correct: true
+          - text: Один година.
+            correct: false
+          - text: О першій.
+            correct: false
+        explanation: 'Котра година? asks for the clock label: перша.'
+      - prompt: '5:00'
+        options:
+          - text: П'ята.
+            correct: true
+          - text: П'ять годин.
+            correct: false
+          - text: О п'ятій.
+            correct: false
+        explanation: "П'ята is the point on the clock; п'ять годин is duration."
+      - prompt: '8:00'
+        options:
+          - text: Восьма.
+            correct: true
+          - text: Вісім годин.
+            correct: false
+          - text: У восьмій.
+            correct: false
+        explanation: 'Use the feminine ordinal form for the hour.'
+      - prompt: '11:00'
+        options:
+          - text: Одинадцята.
+            correct: true
+          - text: Об одинадцятій.
+            correct: false
+          - text: Одинадцять годин.
+            correct: false
+        explanation: 'Одинадцята answers what time it is now.'
+  - id: act-2
+    type: match-up
+    title: Digital time to Ukrainian chunk
+    instruction: Match the digital time with the Ukrainian phrase.
+    pairs:
+      - left: '2:00'
+        right: друга
+      - left: '4:00'
+        right: четверта
+      - left: '7:00'
+        right: сьома
+      - left: '10:00'
+        right: десята
+      - left: '1:30'
+        right: пів на другу
+      - left: '6:30'
+        right: пів на сьому
+      - left: '7:15'
+        right: чверть на восьму
+      - left: '7:45'
+        right: за чверть восьма
+  - id: act-3
+    type: fill-in
+    title: Schedule time gaps
+    instruction: Choose the schedule chunk that completes the sentence.
+    items:
+      - sentence: 'Я прокидаюся ___.'
+        answer: о сьомій
+        options:
+          - о сьомій
+          - сьома
+          - у сім годин
+        explanation: 'A scheduled action uses о + the schedule form.'
+      - sentence: 'Ми снідаємо ___.'
+        answer: о восьмій
+        options:
+          - о восьмій
+          - восьма
+          - у восьму
+        explanation: 'Use о восьмій for at eight.'
+      - sentence: 'Зустріч ___.'
+        answer: о другій
+        options:
+          - о другій
+          - друга
+          - у два
+        explanation: 'Meetings happen о другій.'
+      - sentence: 'Фільм починається ___.'
+        answer: об одинадцятій
+        options:
+          - об одинадцятій
+          - о одинадцятій
+          - одинадцята
+        explanation: 'Before одинадцятій, use об.'
+      - sentence: 'Обід ___.'
+        answer: о першій дня
+        options:
+          - о першій дня
+          - перша дня
+          - у один день
+        explanation: 'О першій дня means at one in the afternoon.'
+      - sentence: 'Вечеря ___.'
+        answer: о сьомій вечора
+        options:
+          - о сьомій вечора
+          - сьома вечора
+          - у сьому вечора
+        explanation: 'Use о сьомій for the scheduled action.'
+  - id: act-4
+    type: true-false
+    title: Full hour or duration
+    instruction: Decide whether each note is safe for this lesson.
+    items:
+      - statement: "Зараз п'ята means it is five o'clock."
+        correct: true
+        explanation: "П'ята is the clock-hour label."
+      - statement: "П'ять годин means five o'clock."
+        correct: false
+        explanation: "П'ять годин means a duration of five hours."
+      - statement: 'Котра година? asks for the current time.'
+        correct: true
+        explanation: 'Answer with перша, друга, третя, and so on.'
+      - statement: 'О котрій годині? asks when an action happens.'
+        correct: true
+        explanation: 'Answer with о першій, о другій, о третій.'
+      - statement: 'Пів на восьму means 7:30.'
+        correct: true
+        explanation: 'The half-hour chunk looks toward the next hour.'
+      - statement: 'Пів восьмої is the safe A1 chunk.'
+        correct: false
+        explanation: 'Use пів на восьму.'
+workbook:
+  - type: group-sort
+    title: What job does the phrase do?
+    instruction: Sort each phrase by its time job.
+    groups:
+      - name: Clock answer
+        items:
+          - перша
+          - п'ята
+          - десята
+          - дванадцята
+      - name: Schedule answer
+        items:
+          - о першій
+          - о п'ятій
+          - об одинадцятій
+          - о дванадцятій
+      - name: Time of day
+        items:
+          - ранку
+          - дня
+          - вечора
+          - ночі
+  - type: order
+    title: Set the meeting time
+    instruction: Put the phone exchange in a natural order.
+    items:
+      - Добрий день! Котра година?
+      - Зараз десята.
+      - О котрій ти працюєш?
+      - Я працюю о дев'ятій.
+      - Тоді зустріч о другій?
+      - Так, о другій добре.
+    correct_order:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+  - type: translate
+    title: Build a safe time line
+    instruction: Choose the Ukrainian line that matches the English prompt.
+    items:
+      - source: 'It is seven now.'
+        options:
+          - text: Зараз сьома.
+            correct: true
+          - text: Зараз сім годин.
+            correct: false
+          - text: Зараз є сім.
+            correct: false
+        explanation: 'Clock time uses the ordinal hour word.'
+      - source: 'I wake up at seven in the morning.'
+        options:
+          - text: Я прокидаюся о сьомій ранку.
+            correct: true
+          - text: Я прокидаюся у сім годин.
+            correct: false
+          - text: Я прокидаюся сьома ранку.
+            correct: false
+        explanation: 'A schedule uses о сьомій.'
+      - source: 'The meeting is at two.'
+        options:
+          - text: Зустріч о другій.
+            correct: true
+          - text: Зустріч у дві години.
+            correct: false
+          - text: Зустріч друга.
+            correct: false
+        explanation: 'Use о другій for the planned time.'
+      - source: 'It is half past six.'
+        options:
+          - text: Пів на сьому.
+            correct: true
+          - text: Пів сьомої.
+            correct: false
+          - text: Половина після шостої.
+            correct: false
+        explanation: 'The safe chunk is пів на + next hour.'
+  - type: error-correction
+    title: Repair time traps
+    instruction: Choose the standard Ukrainian repair.
+    items:
+      - sentence: "Зараз є п'ять годин."
+        error: "Зараз є п'ять годин."
+        answer: "Зараз п'ята (година)."
+        options:
+          - "Зараз п'ята (година)."
+          - "Зараз є п'ять годин."
+          - "Зараз о п'ятій."
+        explanation: 'For clock time, use the feminine ordinal hour and no є.'
+      - sentence: 'Уроки починаються у вісім годин.'
+        error: 'у вісім годин'
+        answer: 'Уроки починаються о восьмій.'
+        options:
+          - 'Уроки починаються о восьмій.'
+          - 'Уроки починаються у вісім годин.'
+          - 'Уроки починаються восьма.'
+        explanation: 'Scheduled time uses о/об, not у/в.'
+      - sentence: 'Чверть після сьомої.'
+        error: 'після'
+        answer: 'Чверть на восьму. (або чверть по сьомій)'
+        options:
+          - 'Чверть на восьму. (або чверть по сьомій)'
+          - 'Чверть після сьомої.'
+          - 'Чверть без восьмої.'
+        explanation: 'Use на or по for the first half of the hour.'
+      - sentence: 'Пів восьмої.'
+        error: 'Пів восьмої.'
+        answer: 'Пів на восьму.'
+        options:
+          - 'Пів на восьму.'
+          - 'Пів восьмої.'
+          - 'Половина після сьомої.'
+        explanation: 'На is part of the half-hour chunk.'
+      - sentence: 'Без двадцяти три.'
+        error: 'Без'
+        answer: 'За двадцять третя. (або двадцять до третьої)'
+        options:
+          - 'За двадцять третя. (або двадцять до третьої)'
+          - 'Без двадцяти три.'
+          - 'Після двадцяти третьої.'
+        explanation: 'Use за or до, not без, for time before the next hour.'

--- a/curriculum/l2-uk-en/a1/what-time/module.md
+++ b/curriculum/l2-uk-en/a1/what-time/module.md
@@ -167,10 +167,6 @@ answers: **з дев'ятої до п'ятої**. A workday sentence can be simp
 **Я працюю з дев'ятої до п'ятої.** This is enough for A1. The full grammar of
 these forms comes later.
 
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
 ## Підсумок
 
 Keep three cards in your head.
@@ -219,7 +215,3 @@ and one line for a meeting:
 If you only remember one rule, remember this: **котра? -> перша, друга,
 третя** for the clock; **о котрій? -> о першій, о другій, о третій** for the
 schedule.
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->


### PR DESCRIPTION
## Summary

Splits the six A1 time/nature modules from flat V1 activity lists into V2 `inline:` and `workbook:` lists. Inline activities keep `act-1` through `act-4` and retain matching `INJECT_ACTIVITY` markers; workbook activities preserve the existing `act-5` through `act-8` content with IDs removed.

## Per-module counts

| Module | Inline | Workbook | Total |
| --- | ---: | ---: | ---: |
| what-time | 4 | 4 | 8 |
| days-and-months | 4 | 4 | 8 |
| weather | 4 | 4 | 8 |
| my-day | 4 | 4 | 8 |
| free-time | 4 | 4 | 8 |
| checkpoint-time-nature | 4 | 4 | 8 |

## Validation

- Custom parser check comparing `origin/main` vs branch totals, V2 shape, marker/id parity, and idless workbook entries: passed for all six modules.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 22 --validate` through module `27 --validate`: passed.
- Generated `starlight/src/content/docs/a1/*.mdx` files from the MDX runs were restored and are not included.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py`: 118 passed.
- `npx prettier --check` on the six changed `activities.yaml` files: passed.
- `git diff --check`: passed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`: passed.

Refs #2801