### PR TITLE
fix(monitor): remove stale pipeline UI labels

### DIFF
--- a/dashboards/comms.html
+++ b/dashboards/comms.html
@@ -314,15 +314,15 @@ function closeDetail() {
   document.getElementById('detail-panel').classList.remove('open');
 }
 
-// Parse task_id to extract track, slug, phase
+// Parse task_id to extract track, slug, phase.
 function parseTaskId(taskId) {
   if (!taskId) return null;
-  // v5-body-injury-dual-pA -> track from state, slug=body-injury-dual, phase=A
-  const m = taskId.match(/^v5-(.+?)-(p[A-Z].*)$/);
-  if (m) return { slug: m[1], phaseKey: m[2] };
-  // yw-some-slug-p0 -> old format
-  const m2 = taskId.match(/^yw-(.+?)-(p\d.*)$/);
-  if (m2) return { slug: m2[1], phaseKey: m2[2] };
+  const modern = taskId.match(/^build:([^:]+):(.+?):(.+)$/);
+  if (modern) return { track: modern[1], slug: modern[2], phaseKey: modern[3] };
+  const legacy = taskId.match(/^v5-(.+?)-(p[A-Z].*)$/);
+  if (legacy) return { slug: legacy[1], phaseKey: legacy[2] };
+  const oldQueue = taskId.match(/^yw-(.+?)-(p\d.*)$/);
+  if (oldQueue) return { slug: oldQueue[1], phaseKey: oldQueue[2] };
   return null;
 }
 
@@ -564,9 +564,13 @@ async function loadLiveActivity() {
         const slug = escapeHtmlAttribute(c.slug || '');
         const type = escapeHtmlAttribute(c.type || '');
         const sizeKb = escapeHtmlAttribute(c.size_kb ?? '');
-        const taskId = escapeHtmlAttribute(`v5-${c.slug || ''}-pA`);
         return `
-          <div class="feed-item completion conversation-row" data-task-id="${taskId}">
+          <div class="feed-item completion build-row"
+               data-build-track="${track}"
+               data-build-slug="${slug}"
+               data-build-phase="${type}"
+               data-build-status="completed"
+               data-task-id="">
             <div class="fi-top">
               <span class="fi-track">${track}</span>
               <span class="fi-age">${timeAgo(c.seconds_ago)} ago</span>
@@ -582,10 +586,12 @@ async function loadLiveActivity() {
     const dispatches = (recentData.events || []).slice(0, DISPATCH_LIMIT).map(e => {
       const ts = e.ts ? new Date(e.ts).getTime() : now;
       return {
-        task_id: `${e.level || ''}-${e.slug || ''}-${e.phase || 'event'}`,
+        task_id: e.task_id || '',
         from: e.agent || 'pipeline',
         to: e.level || '',
         type: e.ok ? 'success' : 'error',
+        slug: e.slug || '',
+        phase: e.phase || '',
         preview: `${e.phase || 'phase'} ${e.ok ? 'ok' : 'failed'}${e.duration_s != null ? ` (${e.duration_s}s)` : ''}`,
         seconds_ago: Math.max(0, Math.round((now - ts) / 1000)),
       };
@@ -596,9 +602,9 @@ async function loadLiveActivity() {
       dispEl.innerHTML = '<div class="empty-feed">No recent messages</div>';
     } else {
       dispEl.innerHTML = dispatches.map(d => {
-        // Extract slug from task_id (v5-some-slug-pA -> some-slug)
-        const slug = (d.task_id || '').replace(/^v5-/, '').replace(/-p[A-Z].*$/, '') || d.task_id;
-        const phase = (d.task_id || '').match(/-p([A-Z][^-]*)/) ? (d.task_id.match(/-p([A-Z][^-]*)/)[1]) : '';
+        const parsed = parseTaskId(d.task_id || '');
+        const slug = parsed?.slug || d.slug || d.task_id || 'build event';
+        const phase = parsed?.phaseKey || d.phase || '';
         const isFinished = (d.preview || '').includes('finished');
         const isError = d.type === 'error' || (d.preview || '').includes('Error');
         const borderClass = isError ? 'style="border-left-color:var(--red)"' : isFinished ? 'style="border-left-color:var(--green)"' : '';
@@ -609,8 +615,8 @@ async function loadLiveActivity() {
               <span>${d.from} &rarr; ${d.to}</span>
               <span class="fi-age">${timeAgo(d.seconds_ago)} ago</span>
             </div>
-            <div class="fi-slug">${slug}${phase ? ' <span class="fi-phase ' + phaseClass('Phase ' + phase) + '">' + phase + '</span>' : ''}</div>
-            <div class="fi-detail">${(d.preview || '').substring(0, 100)}</div>
+            <div class="fi-slug">${escapeHtmlAttribute(slug)}${phase ? ' <span class="fi-phase ' + phaseClass('Phase ' + phase) + '">' + escapeHtmlAttribute(phase) + '</span>' : ''}</div>
+            <div class="fi-detail">${escapeHtmlAttribute((d.preview || '').substring(0, 100))}</div>
           </div>
         `;
       }).join('');
@@ -908,7 +914,7 @@ async function refreshHealthOnly() {
 }
 
 document.getElementById('feed-building').addEventListener('click', onBuildRowClick);
-document.getElementById('feed-completions').addEventListener('click', onConversationRowClick);
+document.getElementById('feed-completions').addEventListener('click', onBuildRowClick);
 document.getElementById('feed-dispatches').addEventListener('click', onConversationRowClick);
 document.getElementById('zombie-list').addEventListener('click', onConversationRowClick);
 document.getElementById('msg-tbody').addEventListener('click', onConversationRowClick);

--- a/dashboards/cost.html
+++ b/dashboards/cost.html
@@ -98,7 +98,7 @@ th { color: var(--text2); font-size: 11px; text-transform: uppercase; }
       <div id="top-modules" class="empty">Loading...</div>
     </div>
     <div class="card">
-      <div class="row" style="justify-content:space-between"><h2>Warnings</h2><span class="muted">Legacy gaps and prompt bloat</span></div>
+      <div class="row" style="justify-content:space-between"><h2>Warnings</h2><span class="muted">Cost gaps and prompt bloat</span></div>
       <div id="warnings" class="empty">Loading...</div>
     </div>
   </section>

--- a/dashboards/curriculum-dashboard.html
+++ b/dashboards/curriculum-dashboard.html
@@ -58,8 +58,9 @@ a:hover { text-decoration: underline; }
 .module-table .rq-score.stub { color: var(--red); }
 .module-table .rq-coverage { color: var(--text3); font-size: 11px; }
 .module-table .ver-label { font-size: 10px; font-weight: 600; padding: 1px 4px; border-radius: 3px; }
-.module-table .ver-v6 { background: rgba(63,185,80,0.15); color: var(--green); }
-.module-table .ver-unbuilt { background: rgba(72,79,88,0.2); color: var(--text3); }
+.module-table .ver-current { background: rgba(63,185,80,0.15); color: var(--green); }
+.module-table .ver-backlog { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.module-table .ver-pending { background: rgba(72,79,88,0.2); color: var(--text3); }
 
 /* Unbuilt modules */
 .obsolete { opacity: 0.4; }
@@ -154,6 +155,25 @@ function pctColor(pct) {
   return 'rgba(72,79,88,0.3)';
 }
 
+function pipelineLabel(version) {
+  if (version === 'v6') return 'current';
+  if (version === 'v5' || version === 'v3') return 'legacy';
+  if (version === 'unbuilt' || !version) return 'pending';
+  return 'unknown';
+}
+
+function pipelineClass(version) {
+  const label = pipelineLabel(version);
+  if (label === 'current') return 'ver-current';
+  if (label === 'legacy') return 'ver-backlog';
+  return 'ver-pending';
+}
+
+function needsBuildRefresh(module) {
+  if (typeof module.needs_rebuild === 'boolean') return module.needs_rebuild;
+  return pipelineLabel(module.pipeline_version) !== 'current';
+}
+
 async function fetchOverview() {
   overviewData = await fetchJson(`${API}/overview`);
   renderTreemap(overviewData.tracks);
@@ -235,14 +255,14 @@ async function loadTrackDetail(trackId) {
       ${researchStat}
     </div>
     <table class="module-table">
-      <thead><tr><th>#</th><th>Module</th><th>Ver</th><th>Status</th><th>Words</th><th>Research</th><th>QA</th></tr></thead>
+      <thead><tr><th>#</th><th>Module</th><th>Build</th><th>Status</th><th>Words</th><th>Research</th><th>QA</th></tr></thead>
       <tbody>
         ${data.modules.map(m => {
           const cls = m.status === 'content-complete' ? 'content-complete' : m.status;
           const ver = m.pipeline_version || 'unbuilt';
-          const isV6 = ver === 'v6';
-          const obsolete = isV6 ? '' : ' obsolete';
-          const verCls = isV6 ? 'ver-v6' : 'ver-unbuilt';
+          const obsolete = needsBuildRefresh(m) ? ' obsolete' : '';
+          const verCls = pipelineClass(ver);
+          const verLabel = pipelineLabel(ver);
           const wordPct = m.word_target > 0 ? Math.min(m.word_count / m.word_target * 100, 100) : 0;
           const r = m.research || {};
           let rCol;
@@ -260,7 +280,7 @@ async function loadTrackDetail(trackId) {
             <tr class="${obsolete}" onclick="loadModuleDetail('${trackId}','${m.slug}')">
               <td>${m.num}</td>
               <td>${m.slug}</td>
-              <td><span class="ver-label ${verCls}">${ver}</span></td>
+              <td><span class="ver-label ${verCls}">${verLabel}</span></td>
               <td><span class="status-dot ${cls}"></span> ${m.status}</td>
               <td>${m.word_count.toLocaleString()}/${m.word_target.toLocaleString()} <span class="word-mini" style="width:${wordPct}%"></span></td>
               ${rCol}
@@ -402,12 +422,12 @@ async function loadModuleDetail(trackId, slug) {
         ? `<div class="detail-card"><h3>Claude QA</h3><div class="meta-row"><span class="label">Status</span><span style="color:var(--yellow)">⏳ Pending — run with --final-review</span></div></div>`
         : '');
 
-  const pipelineVer = m.pipeline_version || 'unknown';
-  const verColor = pipelineVer === 'v6' ? 'var(--green)' : 'var(--text3)';
+  const pipelineVer = pipelineLabel(m.pipeline_version);
+  const verColor = pipelineVer === 'current' ? 'var(--green)' : 'var(--text3)';
 
   panel.innerHTML = `
     <h2 style="font-size:16px;margin-bottom:4px;">${slug}</h2>
-    <div style="color:var(--text2);font-size:12px;margin-bottom:16px;">${trackId} &middot; <span style="color:${verColor};font-weight:600">${pipelineVer}</span></div>
+    <div style="color:var(--text2);font-size:12px;margin-bottom:16px;">${trackId} &middot; <span style="color:${verColor};font-weight:600">${pipelineVer} build state</span></div>
     ${qaHtml}
     ${researchHtml}
     ${planHtml}

--- a/dashboards/delegate.html
+++ b/dashboards/delegate.html
@@ -263,7 +263,7 @@ async function loadTasks() {
     document.getElementById('active-content').innerHTML = '<div class="empty">Unable to load tasks</div>';
     document.getElementById('completed-content').innerHTML = '<div class="empty">Unable to load tasks</div>';
   }
-  document.getElementById('last-refresh').textContent = `Updated ${new Date().toLocaleTimeString()} · manual refresh only`;
+  document.getElementById('last-refresh').textContent = `Updated ${new Date().toLocaleTimeString()} · refresh on demand`;
 }
 
 loadTasks();

--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -118,13 +118,13 @@ body { min-height: 100vh; font-family: -apple-system, BlinkMacSystemFont, 'Segoe
   <a class="card" href="/delegate.html" style="border-left: 3px solid var(--yellow);">
     <div class="icon">&#129309;</div>
     <h2>Delegate</h2>
-    <p>Delegation task list with zombie detection, manual refresh, and full task detail modal.</p>
+    <p>Delegation task list with zombie detection, active counts, and full task detail modal.</p>
     <div class="card-stat" id="card-stat-delegate"></div>
   </a>
   <a class="card" href="/routing.html" style="border-left: 3px solid var(--blue);">
     <div class="icon">&#129518;</div>
     <h2>Agent Routing</h2>
-    <p>Which agent for what, subscription headroom, and a dispatch-usage snapshot. Maximize the paid subscriptions.</p>
+    <p>Which agent for what, subscription headroom, and live dispatch usage. Maximize the paid subscriptions.</p>
     <div class="card-stat">routing &amp; usage</div>
   </a>
   <a class="card" href="/artifacts/" style="border-left: 3px solid var(--accent);">
@@ -148,7 +148,7 @@ body { min-height: 100vh; font-family: -apple-system, BlinkMacSystemFont, 'Segoe
   <a class="card progress" href="/progress.html">
     <div class="icon">&#9654;</div>
     <h2>Progress</h2>
-    <p>Pipeline state across all tracks. Research → Content → Validate → Review → MDX.</p>
+    <p>Build state across all tracks. Research, content, validation, review, published MDX.</p>
     <div class="card-stat" id="progress-stat"></div>
   </a>
   <a class="card quality" href="/quality.html">
@@ -215,11 +215,23 @@ function setStat(id, text) {
   if (el) el.textContent = text || '';
 }
 
+function buildStateSummary(pv) {
+  const state = pv?.build_state || {};
+  const current = pv?.current_builds ?? state.current ?? pv?.counts?.v6 ?? 0;
+  const backlog = pv?.rebuild_backlog ?? state.backlog ?? pv?.needs_rebuild ?? 0;
+  return {
+    current,
+    backlog,
+    builtPct: pv?.pct_built || 0,
+  };
+}
+
 async function loadStats() {
-  let v6Count = 0, v5Count = 0, builtPct = 0, pendingConsultations = 0;
+  let buildState = { current: 0, backlog: 0, builtPct: 0 };
+  let pendingConsultations = 0;
   const [data, pv, cMetrics, summary, comms, weakPoints, orient, runtimeAgents, delegate, buildEvents, wiki, cost] = await Promise.all([
     safeFetch('/api/dashboard/overview'),
-    safeFetch('/api/state/pipeline-versions'),
+    safeFetch('/api/state/pipeline-versions?fresh=true'),
     safeFetch('/api/consultation/metrics'),
     safeFetch('/api/state/summary?fresh=true'),
     safeFetch('/api/comms/batch-progress'),
@@ -235,17 +247,16 @@ async function loadStats() {
   try {
     if (!data || !pv) throw new Error('overview unavailable');
     const t = data.totals;
-    v6Count = pv.counts?.v6 || 0;
-    v5Count = pv.counts?.v5 || 0;
-    builtPct = pv.pct_built || 0;
+    buildState = buildStateSummary(pv);
     pendingConsultations = cMetrics?.pending_queue || 0;
 
     document.getElementById('stats-row').innerHTML = `
       <div class="stat"><div class="value">${t.total}</div><div class="label">Modules</div></div>
       <div class="stat"><div class="value" style="color:var(--green)">${t.pass}</div><div class="label">Passing</div></div>
       <div class="stat"><div class="value" style="color:var(--blue)">${t.content_complete}</div><div class="label">Prose Only</div></div>
-      <div class="stat"><div class="value" style="color:var(--cyan)">${v6Count} v6 / ${v5Count} v5</div><div class="label">Pipeline</div></div>
-      <div class="stat"><div class="value" style="color:var(--purple)">${builtPct}%</div><div class="label">Built</div></div>
+      <div class="stat"><div class="value" style="color:var(--cyan)">${buildState.current}</div><div class="label">Current Builds</div></div>
+      <div class="stat"><div class="value" style="color:var(--orange)">${buildState.backlog}</div><div class="label">Rebuild Backlog</div></div>
+      <div class="stat"><div class="value" style="color:var(--purple)">${buildState.builtPct}%</div><div class="label">Built</div></div>
     `;
 
     document.getElementById('audit-stat').textContent = `${t.pass} passing / ${t.total} total`;
@@ -262,7 +273,7 @@ async function loadStats() {
     const t = summary.totals;
     const stale = t.audit_stale ? ` · ${t.audit_stale} stale audit` : '';
     document.getElementById('progress-stat').textContent =
-      `${v6Count} v6 · ${v5Count} v5 · ${t.dossier_done ?? 0} dossiers · ${t.published_mdx ?? 0} published${stale}`;
+      `${buildState.current} current · ${buildState.backlog} backlog · ${t.dossier_done ?? 0} dossiers · ${t.published_mdx ?? 0} published${stale}`;
   } catch(e) {}
 
   try {

--- a/dashboards/orient.html
+++ b/dashboards/orient.html
@@ -457,7 +457,7 @@ async function loadOrient() {
   } catch (error) {
     setPageBanner(`API unavailable: ${error.message}`);
     document.getElementById('refresh-status').textContent = 'Auto-refresh stopped after API failure';
-    document.getElementById('generated-at').textContent = 'Waiting for manual refresh';
+    document.getElementById('generated-at').textContent = 'Waiting for refresh';
     refreshHalted = true;
     stopRefresh();
     console.error('[orient] refresh failed', error);

--- a/dashboards/progress.html
+++ b/dashboards/progress.html
@@ -87,7 +87,7 @@ a:hover { text-decoration: underline; }
 .chip-published { background: #123f45; color: var(--cyan); }
 .chip-pass { background: var(--green); color: #000; }
 
-/* Unbuilt modules */
+/* Modules outside the current build state */
 .obsolete { opacity: 0.4; }
 
 .legend { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
@@ -110,7 +110,7 @@ a:hover { text-decoration: underline; }
 
 <div class="topbar">
   <h1>&#9654; Progress</h1>
-  <div style="font-size:12px;color:var(--text3);" id="topbar-subtitle">Pipeline state across all tracks</div>
+  <div style="font-size:12px;color:var(--text3);" id="topbar-subtitle">Build state across all tracks</div>
   <div class="spacer"></div>
   <nav class="monitor-nav" aria-label="Monitor sections">
     <a href="/">Home</a>
@@ -137,8 +137,8 @@ a:hover { text-decoration: underline; }
   <div class="stat-card"><div class="value" style="color:#58a6ff" id="total-final-review">—</div><div class="label">Final QA</div></div>
   <div class="stat-card"><div class="value" style="color:var(--orange)" id="total-dossier">—</div><div class="label">Dossiers</div></div>
   <div class="stat-card"><div class="value" style="color:var(--cyan)" id="total-published">—</div><div class="label">Published MDX</div></div>
-  <div class="stat-card"><div class="value" style="color:var(--cyan)" id="total-v6">—</div><div class="label">V6 Pipeline</div></div>
-  <div class="stat-card"><div class="value" style="color:var(--gray)" id="total-rebuild">—</div><div class="label">Needs Rebuild</div></div>
+  <div class="stat-card"><div class="value" style="color:var(--cyan)" id="total-current-builds">—</div><div class="label">Current Builds</div></div>
+  <div class="stat-card"><div class="value" style="color:var(--gray)" id="total-rebuild">—</div><div class="label">Rebuild Backlog</div></div>
 </div>
 
 <div class="container">
@@ -152,15 +152,11 @@ a:hover { text-decoration: underline; }
     <div class="legend-item"><div class="legend-dot" style="background:#1a3055;border:1px solid var(--blue)"></div> Content</div>
     <div class="legend-item"><div class="legend-dot" style="background:#5a3e1b;border:1px solid var(--orange)"></div> Research</div>
     <div class="legend-item"><div class="legend-dot" style="background:#123f45;border:1px solid var(--cyan)"></div> Published MDX</div>
-    <div class="legend-item"><div class="legend-dot" style="background:var(--gray);opacity:0.4"></div> Unbuilt</div>
-  </div>
-
-  <div style="font-size:12px;color:var(--text2);margin-bottom:16px;">
-    Click a track row to expand per-module phase chips. Hover a chip to see details.
+    <div class="legend-item"><div class="legend-dot" style="background:var(--gray);opacity:0.4"></div> Pending build state</div>
   </div>
 
   <div id="tracks-container">
-    <div class="loading-msg">Loading pipeline state...</div>
+    <div class="loading-msg">Loading build state...</div>
   </div>
 </div>
 
@@ -195,6 +191,26 @@ function isDone(phase) {
   return phase && phase.status === 'complete';
 }
 
+function buildStateSummary(pv) {
+  const state = pv?.build_state || {};
+  return {
+    current: pv?.current_builds ?? state.current ?? pv?.counts?.v6 ?? 0,
+    backlog: pv?.rebuild_backlog ?? state.backlog ?? pv?.needs_rebuild ?? 0,
+  };
+}
+
+function pipelineLabel(version) {
+  if (version === 'v6') return 'current build state';
+  if (version === 'v5' || version === 'v3') return 'legacy build state';
+  if (version === 'unbuilt' || !version) return 'pending build state';
+  return 'unknown build state';
+}
+
+function moduleNeedsRefresh(mod) {
+  if (typeof mod.needs_rebuild === 'boolean') return mod.needs_rebuild;
+  return pipelineLabel(mod.pipeline_version) !== 'current build state';
+}
+
 function chipClass(mod) {
   const phases = mod.phases || {};
   if (mod.audit === 'pass') return 'chip-pass';
@@ -217,13 +233,13 @@ function chipLabel(mod) {
 
 function chipTitle(mod) {
   const phases = mod.phases || {};
-  const ver = mod.pipeline_version || 'unknown';
+  const buildState = pipelineLabel(mod.pipeline_version);
   const phaseStates = Object.entries(phases)
     .map(([k, v]) => `${k}:${v.status || 'pending'}`)
     .join(' | ');
   const dossier = mod.dossier?.exists ? `dossier:${mod.dossier.source || 'yes'}` : 'dossier:missing';
   const mdx = mod.published_mdx ? 'published:yes' : 'published:no';
-  return `#${mod.num} ${mod.slug} [${ver}] | ${phaseStates} | audit:${mod.audit} | words:${mod.words} | ${dossier} | ${mdx}`;
+  return `#${mod.num} ${mod.slug} [${buildState}] | ${phaseStates} | audit:${mod.audit} | words:${mod.words} | ${dossier} | ${mdx}`;
 }
 
 async function loadModulePanel(trackId, panel) {
@@ -236,7 +252,7 @@ async function loadModulePanel(trackId, panel) {
       const cls = chipClass(mod);
       const label = chipLabel(mod);
       const title = chipTitle(mod);
-      const obsolete = mod.pipeline_version === 'v6' ? '' : ' obsolete';
+      const obsolete = moduleNeedsRefresh(mod) ? ' obsolete' : '';
       return `<div class="module-chip ${cls}${obsolete}" data-tip="${title}">${label}</div>`;
     }).join('');
 
@@ -374,10 +390,11 @@ async function load() {
     document.getElementById('total-final-review').textContent = t.final_review_done;
     document.getElementById('total-dossier').textContent = t.dossier_done || 0;
     document.getElementById('total-published').textContent = t.published_mdx || 0;
-    document.getElementById('total-v6').textContent = `${pv.counts?.v6 || 0}`;
-    document.getElementById('total-rebuild').textContent = `${pv.needs_rebuild || 0}`;
+    const buildState = buildStateSummary(pv);
+    document.getElementById('total-current-builds').textContent = `${buildState.current}`;
+    document.getElementById('total-rebuild').textContent = `${buildState.backlog}`;
     document.getElementById('topbar-subtitle').textContent =
-      `Pipeline state across all tracks — ${pv.counts?.v6 || 0} v6, ${t.published_mdx || 0} published, ${pv.needs_rebuild || 0} rebuild needed`;
+      `Build state across all tracks — ${buildState.current} current, ${t.published_mdx || 0} published, ${buildState.backlog} in backlog`;
 
     const container = document.getElementById('tracks-container');
     const trackEntries = Object.entries(data.tracks)

--- a/dashboards/track-health.html
+++ b/dashboards/track-health.html
@@ -175,7 +175,7 @@ a:hover { text-decoration: underline; }
 </div>
 
 <script>
-const TRACKS = ['a1','a2','b1','b2','b2-pro','c1','c1-pro','c2','b2-hist','c1-hist','c1-bio','lit','oes','ruth'];
+let trackIds = [];
 let currentTrack = null;
 let overviewData = null;
 
@@ -192,6 +192,30 @@ async function fetchJson(url, options) {
 }
 
 function pct(v, t) { return t > 0 ? Math.round(v / t * 100) : 0; }
+
+function orderedTrackIds(summaryTracks, ...trackMaps) {
+  const ids = new Set(Object.keys(summaryTracks || {}));
+  for (const trackMap of trackMaps) {
+    for (const id of Object.keys(trackMap || {})) ids.add(id);
+  }
+  return Array.from(ids).filter(Boolean);
+}
+
+function buildStateSummary(pv) {
+  const state = pv?.build_state || {};
+  return {
+    current: pv?.current_builds ?? state.current ?? pv?.counts?.v6 ?? 0,
+    currentPct: pv?.pct_current ?? pv?.pct_v6 ?? 0,
+    backlog: pv?.rebuild_backlog ?? state.backlog ?? pv?.needs_rebuild ?? 0,
+  };
+}
+
+function pipelineLabel(version) {
+  if (version === 'v6') return 'current build state';
+  if (version === 'v5' || version === 'v3') return 'legacy build state';
+  if (version === 'unbuilt' || !version) return 'pending build state';
+  return 'unknown build state';
+}
 
 function barColor(pct) {
   if (pct >= 90) return 'var(--green)';
@@ -214,14 +238,18 @@ async function loadOverview() {
   const el = document.getElementById('overview-container');
   el.innerHTML = '<div class="loading">Loading all tracks...</div>';
   try {
-    const [buildRes, enrichRes] = await Promise.all([
+    const [buildRes, enrichRes, summaryRes] = await Promise.all([
       fetchJson('/api/state/build-status'),
       fetchJson('/api/state/enrichment-status'),
+      fetchJson('/api/state/summary?fresh=true').catch(() => ({ tracks: {} })),
     ]);
     overviewData = { build: buildRes.tracks, enrich: enrichRes.tracks };
+    trackIds = orderedTrackIds(summaryRes.tracks, buildRes.tracks, enrichRes.tracks);
+    if (currentTrack && !trackIds.includes(currentTrack)) currentTrack = null;
+    renderTrackSelector();
 
     let rows = '';
-    for (const tid of TRACKS) {
+    for (const tid of trackIds) {
       const b = buildRes.tracks[tid];
       const e = enrichRes.tracks[tid];
       if (!b && !e) continue;
@@ -264,7 +292,7 @@ async function loadOverview() {
 
 function renderTrackSelector() {
   const el = document.getElementById('track-selector');
-  el.innerHTML = TRACKS.map(t => {
+  el.innerHTML = trackIds.map(t => {
     const active = t === currentTrack ? ' active' : '';
     return `<button class="track-btn${active}" onclick="selectTrack('${t}')">${t}</button>`;
   }).join('');
@@ -285,8 +313,7 @@ async function selectTrack(trackId) {
 
     const h = health;
     const bs = buildStatus;
-    const v6Pct = pv.pct_v6 || 0;
-    const v6Count = pv.counts?.v6 || 0;
+    const buildState = buildStateSummary(pv);
 
     // Health cards
     let cards = '';
@@ -294,7 +321,7 @@ async function selectTrack(trackId) {
     const ship = h.shippable || {count: 0, pct: 0};
     cards += healthCard('Shippable', `${ship.pct}%`, `${ship.count}/${h.total} ready to deploy`, ship.pct);
     cards += healthCard('Audit Passing', `${h.audit.pct}%`, `${h.audit.passing} pass, ${h.audit.failing} fail`, h.audit.pct, 'var(--cyan)');
-    cards += healthCard('V6 Pipeline', `${v6Pct}%`, `${v6Count}/${h.total} modules on v6`, v6Pct, 'var(--gray)');
+    cards += healthCard('Current Builds', `${buildState.currentPct}%`, `${buildState.current}/${h.total} current, ${buildState.backlog} backlog`, buildState.currentPct, 'var(--gray)');
     cards += healthCard('Word Quality', h.words.avg_ratio, 'avg words vs target', null, 'var(--cyan)');
     cards += `<div class="health-card eta-card">
       <div class="label">ETA (remaining)</div>
@@ -383,17 +410,16 @@ function startAutoRefresh() {
 }
 
 // Init
-renderTrackSelector();
 loadOverview();
 startAutoRefresh();
 
 // Auto-select first track with activity
 setTimeout(async () => {
   if (!overviewData) return;
-  const active = TRACKS.find(t => {
+  const active = trackIds.find(t => {
     const b = overviewData.build[t];
     return b && (b.done > 0 || b.building > 0);
-  });
+  }) || trackIds[0];
   if (active) selectTrack(active);
 }, 1500);
 
@@ -503,7 +529,7 @@ function renderInspector(mod, extraComms) {
     ['Track', mod.track || '—'],
     ['Module #', mod.num || '—'],
     ['Slug', mod.slug || '—'],
-    ['Pipeline', mod.pipeline_version || 'unknown'],
+    ['Build State', pipelineLabel(mod.pipeline_version)],
     ['Words', wordCount ? `${wordCount}` : '—'],
     ['Word Target', wordTarget ? `${wordTarget}` : '—'],
     ['Audit', auditStatus],
@@ -514,7 +540,7 @@ function renderInspector(mod, extraComms) {
   ];
   const infoHtml = info.map(([k, v]) => {
     let style = '';
-    if (k === 'Pipeline') style = v === 'v6' ? 'color:var(--green);font-weight:600' : 'color:var(--text3)';
+    if (k === 'Build State') style = v === 'current build state' ? 'color:var(--green);font-weight:600' : 'color:var(--text3)';
     if (k === 'Audit') style = v === 'pass' ? 'color:var(--green)' : v === 'fail' ? 'color:var(--red)' : '';
     if (k === 'Review') style = reviewData.score >= 8.0 ? 'color:var(--green)' : reviewData.score != null ? 'color:var(--yellow)' : '';
     if (k === 'Shippable') style = v === 'YES' ? 'color:var(--green);font-weight:700' : 'color:var(--red);font-weight:700';
@@ -623,7 +649,7 @@ function renderInspector(mod, extraComms) {
 
   inspectorBody.innerHTML = `
     <div class="insp-section">
-      <div class="insp-section-title">Pipeline Phases <span style="font-size:10px;color:${mod.pipeline_version === 'v6' ? 'var(--green)' : 'var(--text3)'};font-weight:400">(${mod.pipeline_version || 'unknown'})</span></div>
+      <div class="insp-section-title">Build Phases <span style="font-size:10px;color:${pipelineLabel(mod.pipeline_version) === 'current build state' ? 'var(--green)' : 'var(--text3)'};font-weight:400">(${pipelineLabel(mod.pipeline_version)})</span></div>
       <div class="phase-timeline">${timeline}</div>
     </div>
     <div class="insp-section">

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -537,13 +537,28 @@ async def pipeline_versions(track: str | None = Query(None), fresh: bool = Query
             per_track[track_id] = track_counts
 
         total = sum(counts.values())
-        built = counts["v6"] + counts["v5"]
+        current_builds = counts["v6"]
+        legacy_builds = counts["v5"] + counts["v3"]
+        unbuilt_modules = counts["unbuilt"]
+        rebuild_backlog = legacy_builds + unbuilt_modules
+        built = current_builds + counts["v5"]
         return {
             "total": total, "counts": counts,
             "pct_v6": round(counts["v6"] / total * 100) if total else 0,
             "pct_v5": round(counts["v5"] / total * 100) if total else 0,
+            "pct_current": round(current_builds / total * 100) if total else 0,
             "pct_built": round(built / total * 100) if total else 0,
-            "needs_rebuild": counts["v5"] + counts["v3"] + counts["unbuilt"],
+            "current_builds": current_builds,
+            "legacy_builds": legacy_builds,
+            "unbuilt_modules": unbuilt_modules,
+            "rebuild_backlog": rebuild_backlog,
+            "build_state": {
+                "current": current_builds,
+                "legacy": legacy_builds,
+                "unbuilt": unbuilt_modules,
+                "backlog": rebuild_backlog,
+            },
+            "needs_rebuild": rebuild_backlog,
             "per_track": per_track,
             "v6_modules": by_version["v6"],
             "v5_modules": by_version["v5"],

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -138,6 +138,23 @@ class TestPipelineVersionsEndpoint:
         data = client.get("/api/state/pipeline-versions").json()
         assert "counts" in data
 
+    def test_exposes_neutral_build_state_summary(self):
+        data = client.get("/api/state/pipeline-versions?fresh=true").json()
+        counts = data["counts"]
+
+        assert data["current_builds"] == counts["v6"]
+        assert data["legacy_builds"] == counts["v5"] + counts["v3"]
+        assert data["unbuilt_modules"] == counts["unbuilt"]
+        assert data["rebuild_backlog"] == counts["v5"] + counts["v3"] + counts["unbuilt"]
+        assert data["needs_rebuild"] == data["rebuild_backlog"]
+        assert data["build_state"] == {
+            "current": data["current_builds"],
+            "legacy": data["legacy_builds"],
+            "unbuilt": data["unbuilt_modules"],
+            "backlog": data["rebuild_backlog"],
+        }
+        assert "pct_current" in data
+
 
 class TestDashboardOverviewEndpoint:
     """GET /api/dashboard/overview returns tracks."""

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -143,6 +143,59 @@ def test_progress_page_surfaces_freshness_and_dossiers():
     assert "t.dossier_done ?? 0" in index_html
 
 
+def test_monitor_dashboards_hide_legacy_pipeline_version_labels():
+    dashboard_text = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in [
+            DASHBOARDS / "index.html",
+            DASHBOARDS / "progress.html",
+            DASHBOARDS / "track-health.html",
+            DASHBOARDS / "curriculum-dashboard.html",
+            DASHBOARDS / "comms.html",
+            DASHBOARDS / "delegate.html",
+            DASHBOARDS / "orient.html",
+            DASHBOARDS / "cost.html",
+        ]
+    }
+    stale_strings = [
+        "V6 Pipeline",
+        " v6",
+        " v5",
+        "v5-${",
+        "modules on v6",
+        "manual refresh only",
+        "dispatch-usage snapshot",
+        "Legacy gaps",
+        "Pipeline state across all tracks",
+        "Waiting for manual refresh",
+        "<th>Ver</th>",
+    ]
+
+    for page, html in dashboard_text.items():
+        for stale_string in stale_strings:
+            assert stale_string not in html, f"{page} exposes stale Monitor UI copy: {stale_string!r}"
+
+    assert "Current Builds" in dashboard_text["index.html"]
+    assert "Rebuild Backlog" in dashboard_text["progress.html"]
+    assert "Build State" in dashboard_text["track-health.html"]
+    assert "<th>Build</th>" in dashboard_text["curriculum-dashboard.html"]
+
+
+def test_track_health_uses_live_track_inventory():
+    html = (DASHBOARDS / "track-health.html").read_text(encoding="utf-8")
+    assert "const TRACKS =" not in html
+    assert "/api/state/summary?fresh=true" in html
+    assert "orderedTrackIds" in html
+
+
+def test_comms_recent_completions_open_build_detail_without_fake_task_ids():
+    html = (DASHBOARDS / "comms.html").read_text(encoding="utf-8")
+    assert 'class="feed-item completion build-row"' in html
+    assert 'data-build-status="completed"' in html
+    assert "feed-completions').addEventListener('click', onBuildRowClick)" in html
+    assert "v5-${" not in html
+
+
 def test_artifacts_page_uses_metadata_endpoint_and_filters():
     html = (DASHBOARDS / "artifacts.html").read_text(encoding="utf-8")
     assert "/api/artifacts/html" in html


### PR DESCRIPTION
Closes #2802.

## Summary
- add neutral build-state fields to /api/state/pipeline-versions while preserving version-key compatibility
- replace browser-facing v5/v6 dashboard labels with current/backlog/build-state wording
- derive Track Health track buttons from live API state instead of the old hard-coded track list
- keep Comms completion rows clickable via the build-detail modal without fake task IDs

## Validation
- .venv/bin/python -m pytest -q tests/test_monitor_ui_contracts.py tests/test_dashboards.py tests/test_monitor_route_contracts.py tests/test_playground_api_stability.py tests/test_api_endpoints.py tests/test_api_state.py tests/test_monitor_cache.py tests/test_api_router_split.py tests/test_module_dashboard.py
- .venv/bin/ruff check scripts/api/state_router.py tests/test_api_endpoints.py tests/test_monitor_ui_contracts.py
- .venv/bin/python -m py_compile scripts/api/state_router.py
- git diff --check origin/main..HEAD
- .venv/bin/python scripts/audit/lint_agent_trailer.py
- Browser QA on desktop and mobile for /, /progress.html, /track-health.html, /curriculum-dashboard.html, and /comms.html
- Local Gemini review via ai_agent_bridge: first review found the Comms completion click regression; fixed and re-reviewed as SAFE TO MERGE

No generated status/audit/review artifacts included.